### PR TITLE
fix: Frank's UX feedback batch + Magick.NET 14.11.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: Build and Test
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, qa ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, qa ]
 
 env:
   DOTNET_VERSION: '10.0.x'

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -51,7 +51,7 @@
     <PackageVersion Include="Serilog.Sinks.Debug" Version="3.0.0" />
     <PackageVersion Include="Serilog.Sinks.OpenTelemetry" Version="4.2.0" />
     <!-- Image Processing -->
-    <PackageVersion Include="Magick.NET-Q8-AnyCPU" Version="14.10.4" />
+    <PackageVersion Include="Magick.NET-Q8-AnyCPU" Version="14.11.0" />
     <!-- Localization -->
     <PackageVersion Include="Microsoft.Extensions.Localization" Version="10.0.3" />
     <!-- Data Protection -->

--- a/src/Humans.Application/Interfaces/IShiftManagementService.cs
+++ b/src/Humans.Application/Interfaces/IShiftManagementService.cs
@@ -160,7 +160,7 @@ public interface IShiftManagementService
     // === Staffing & Summary ===
 
     /// <summary>
-    /// Gets per-day staffing data for build/strike periods.
+    /// Gets per-day staffing data for all periods (set-up, event, strike).
     /// </summary>
     Task<IReadOnlyList<DailyStaffingData>> GetStaffingDataAsync(
         Guid eventSettingsId, Guid? departmentId = null);
@@ -189,7 +189,7 @@ public record UrgentShift(
     string DepartmentName);
 
 /// <summary>
-/// Per-day staffing data for build/strike visualization.
+/// Per-day staffing data for set-up/event/strike visualization.
 /// </summary>
 public record DailyStaffingData(
     int DayOffset,

--- a/src/Humans.Infrastructure/Services/ShiftManagementService.cs
+++ b/src/Humans.Infrastructure/Services/ShiftManagementService.cs
@@ -287,9 +287,17 @@ public class ShiftManagementService : IShiftManagementService
                 throw new InvalidOperationException($"Day offset {dayOffset} is outside the strike period ({es.EventEndOffset + 1} to {es.StrikeEndOffset})");
         }
 
+        // Skip days that already have shifts (additive mode)
+        var existingDayOffsets = await _dbContext.Shifts
+            .Where(s => s.RotaId == rotaId)
+            .Select(s => s.DayOffset)
+            .Distinct()
+            .ToListAsync();
+        var existingSet = existingDayOffsets.ToHashSet();
+
         var now = _clock.GetCurrentInstant();
 
-        foreach (var (dayOffset, staffing) in dailyStaffing.OrderBy(d => d.Key))
+        foreach (var (dayOffset, staffing) in dailyStaffing.Where(d => !existingSet.Contains(d.Key)).OrderBy(d => d.Key))
         {
             var shift = new Shift
             {
@@ -545,9 +553,10 @@ public class ShiftManagementService : IShiftManagementService
 
         var tz = DateTimeZoneProviders.Tzdb[es.TimeZoneId];
 
-        // Build period: [BuildStartOffset..-1] and Strike period: [EventEndOffset+1..StrikeEndOffset]
+        // All periods: Build [BuildStartOffset..-1], Event [0..EventEndOffset], Strike [EventEndOffset+1..StrikeEndOffset]
         var dayOffsets = new List<int>();
         for (var d = es.BuildStartOffset; d < 0; d++) dayOffsets.Add(d);
+        for (var d = 0; d <= es.EventEndOffset; d++) dayOffsets.Add(d);
         for (var d = es.EventEndOffset + 1; d <= es.StrikeEndOffset; d++) dayOffsets.Add(d);
 
         if (dayOffsets.Count == 0) return [];
@@ -569,7 +578,7 @@ public class ShiftManagementService : IShiftManagementService
             var dayDate = es.GateOpeningDate.PlusDays(dayOffset);
             var dayStart = dayDate.AtStartOfDayInZone(tz).ToInstant();
             var dayEnd = dayDate.PlusDays(1).AtStartOfDayInZone(tz).ToInstant();
-            var period = dayOffset < 0 ? "Build" : "Strike";
+            var period = dayOffset < 0 ? "Set-up" : dayOffset <= es.EventEndOffset ? "Event" : "Strike";
             var dateLabel = dayDate.DayOfWeek.ToString()[..3] + " " + dayDate.ToString("MMM d", null);
 
             var overlapping = shifts.Where(s =>

--- a/src/Humans.Web/Controllers/CampController.cs
+++ b/src/Humans.Web/Controllers/CampController.cs
@@ -373,7 +373,7 @@ public class CampController : Controller
                         LeadId = l.Id,
                         UserId = l.UserId,
                         DisplayName = l.User.DisplayName,
-                        }).ToList();
+                    }).ToList();
                 model.Images = camp.Images.OrderBy(i => i.SortOrder)
                     .Select(i => new CampImageViewModel
                     {

--- a/src/Humans.Web/Controllers/ShiftAdminController.cs
+++ b/src/Humans.Web/Controllers/ShiftAdminController.cs
@@ -148,7 +148,7 @@ public class ShiftAdminController : Controller
 
         await _shiftMgmt.CreateRotaAsync(rota);
         TempData["SuccessMessage"] = $"Rota '{model.Name}' created.";
-        return RedirectToAction(nameof(Index), new { slug });
+        return Redirect(Url.Action(nameof(Index), new { slug }) + "#rota-" + rota.Id.ToString("N"));
     }
 
     [HttpPost("Rotas/{rotaId}")]

--- a/src/Humans.Web/Resources/SharedResource.de.resx
+++ b/src/Humans.Web/Resources/SharedResource.de.resx
@@ -54,7 +54,7 @@
   <data name="Nav_Home" xml:space="preserve"><value>Startseite</value></data>
   <data name="Nav_MyProfile" xml:space="preserve"><value>Mein Profil</value></data>
   <data name="Nav_Teams" xml:space="preserve"><value>Teams</value></data>
-  <data name="Nav_Shifts" xml:space="preserve"><value>Shifts</value></data>
+  <data name="Nav_Shifts" xml:space="preserve"><value>Volunteer</value></data>
   <data name="Nav_Roster" xml:space="preserve"><value>Roster</value></data>
   <data name="Nav_Consents" xml:space="preserve"><value>Vereinbarungen</value></data>
   <data name="Nav_Governance" xml:space="preserve"><value>Governance</value></data>

--- a/src/Humans.Web/Resources/SharedResource.es.resx
+++ b/src/Humans.Web/Resources/SharedResource.es.resx
@@ -54,7 +54,7 @@
   <data name="Nav_Home" xml:space="preserve"><value>Inicio</value></data>
   <data name="Nav_MyProfile" xml:space="preserve"><value>Mi perfil</value></data>
   <data name="Nav_Teams" xml:space="preserve"><value>Equipos</value></data>
-  <data name="Nav_Shifts" xml:space="preserve"><value>Shifts</value></data>
+  <data name="Nav_Shifts" xml:space="preserve"><value>Volunteer</value></data>
   <data name="Nav_Roster" xml:space="preserve"><value>Roster</value></data>
   <data name="Nav_Consents" xml:space="preserve"><value>Acuerdos</value></data>
   <data name="Nav_Governance" xml:space="preserve"><value>Gobernanza</value></data>

--- a/src/Humans.Web/Resources/SharedResource.fr.resx
+++ b/src/Humans.Web/Resources/SharedResource.fr.resx
@@ -54,7 +54,7 @@
   <data name="Nav_Home" xml:space="preserve"><value>Accueil</value></data>
   <data name="Nav_MyProfile" xml:space="preserve"><value>Mon profil</value></data>
   <data name="Nav_Teams" xml:space="preserve"><value>&#xC9;quipes</value></data>
-  <data name="Nav_Shifts" xml:space="preserve"><value>Shifts</value></data>
+  <data name="Nav_Shifts" xml:space="preserve"><value>Volunteer</value></data>
   <data name="Nav_Roster" xml:space="preserve"><value>Roster</value></data>
   <data name="Nav_Consents" xml:space="preserve"><value>Accords</value></data>
   <data name="Nav_Governance" xml:space="preserve"><value>Gouvernance</value></data>

--- a/src/Humans.Web/Resources/SharedResource.it.resx
+++ b/src/Humans.Web/Resources/SharedResource.it.resx
@@ -54,7 +54,7 @@
   <data name="Nav_Home" xml:space="preserve"><value>Home</value></data>
   <data name="Nav_MyProfile" xml:space="preserve"><value>Il mio Profilo</value></data>
   <data name="Nav_Teams" xml:space="preserve"><value>Team</value></data>
-  <data name="Nav_Shifts" xml:space="preserve"><value>Shifts</value></data>
+  <data name="Nav_Shifts" xml:space="preserve"><value>Volunteer</value></data>
   <data name="Nav_Roster" xml:space="preserve"><value>Roster</value></data>
   <data name="Nav_Consents" xml:space="preserve"><value>Accordi</value></data>
   <data name="Nav_Governance" xml:space="preserve"><value>Governance</value></data>

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -54,7 +54,7 @@
   <data name="Nav_Home" xml:space="preserve"><value>Home</value></data>
   <data name="Nav_MyProfile" xml:space="preserve"><value>My Profile</value></data>
   <data name="Nav_Teams" xml:space="preserve"><value>Teams</value></data>
-  <data name="Nav_Shifts" xml:space="preserve"><value>Shifts</value></data>
+  <data name="Nav_Shifts" xml:space="preserve"><value>Volunteer</value></data>
   <data name="Nav_Roster" xml:space="preserve"><value>Roster</value></data>
   <data name="Nav_Consents" xml:space="preserve"><value>Agreements</value></data>
   <data name="Nav_Governance" xml:space="preserve"><value>Governance</value></data>

--- a/src/Humans.Web/Views/Home/About.cshtml
+++ b/src/Humans.Web/Views/Home/About.cshtml
@@ -321,7 +321,7 @@
                 <tr>
                     <td>Image Processing</td>
                     <td><a href="https://www.nuget.org/packages/Magick.NET-Q8-AnyCPU" target="_blank">Magick.NET-Q8-AnyCPU</a></td>
-                    <td>14.10.4</td>
+                    <td>14.11.0</td>
                     <td>Apache-2.0</td>
                 </tr>
 

--- a/src/Humans.Web/Views/Shared/_StaffingChart.cshtml
+++ b/src/Humans.Web/Views/Shared/_StaffingChart.cshtml
@@ -1,27 +1,39 @@
 @using Humans.Application.Interfaces
 @model (List<DailyStaffingData> Data, string ChartId)
 
-@if (Model.Data.Count > 0)
-{
-    <div class="card mb-4">
-        <div class="card-header"><h6 class="mb-0">Build / Strike Staffing</h6></div>
-        <div class="card-body">
-            <canvas id="@Model.ChartId" height="100"></canvas>
-        </div>
-    </div>
+@{
+    var periods = Model.Data.GroupBy(d => d.Period).OrderBy(g => g.Key switch { "Set-up" => 0, "Event" => 1, "Strike" => 2, _ => 3 }).ToList();
+}
 
+@if (periods.Count > 0)
+{
     <script>
     if (typeof Chart === 'undefined') {
         var s = document.createElement('script');
         s.src = 'https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js';
-        s.onload = function() { window['render_@(Model.ChartId)'](); };
+        s.onload = function() {
+            @foreach (var group in periods)
+            {
+                <text>window['render_@(Model.ChartId)_@(group.Key.Replace("-", ""))']();</text>
+            }
+        };
         document.head.appendChild(s);
     } else {
-        document.addEventListener('DOMContentLoaded', function() { window['render_@(Model.ChartId)'](); });
+        document.addEventListener('DOMContentLoaded', function() {
+            @foreach (var group in periods)
+            {
+                <text>window['render_@(Model.ChartId)_@(group.Key.Replace("-", ""))']();</text>
+            }
+        });
     }
 
-    window['render_@(Model.ChartId)'] = function() {
-        var data = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.Data, new System.Text.Json.JsonSerializerOptions { PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase }));
+    @foreach (var group in periods)
+    {
+        var chartKey = Model.ChartId + "_" + group.Key.Replace("-", "");
+        var jsonOpts = new System.Text.Json.JsonSerializerOptions { PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase };
+        <text>
+    window['render_@(chartKey)'] = function() {
+        var data = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(group.ToList(), jsonOpts));
         var labels = data.map(function(d) { return d.dateLabel; });
         var confirmed = data.map(function(d) { return d.confirmedCount; });
         var remaining = data.map(function(d) { return Math.max(0, d.totalSlots - d.confirmedCount); });
@@ -34,7 +46,7 @@
             return '#dc3545';
         });
 
-        new Chart(document.getElementById('@Model.ChartId'), {
+        new Chart(document.getElementById('@chartKey'), {
             type: 'bar',
             data: {
                 labels: labels,
@@ -56,5 +68,22 @@
             }
         });
     };
+        </text>
+    }
     </script>
+
+    @foreach (var group in periods)
+    {
+        var chartKey = Model.ChartId + "_" + group.Key.Replace("-", "");
+        var totalSlots = group.Sum(d => d.TotalSlots);
+        if (totalSlots > 0)
+        {
+            <div class="card mb-4">
+                <div class="card-header"><h6 class="mb-0">@group.Key Staffing</h6></div>
+                <div class="card-body">
+                    <canvas id="@chartKey" height="100"></canvas>
+                </div>
+            </div>
+        }
+    }
 }

--- a/src/Humans.Web/Views/ShiftAdmin/Index.cshtml
+++ b/src/Humans.Web/Views/ShiftAdmin/Index.cshtml
@@ -83,13 +83,13 @@
     @* Rotas *@
     @foreach (var rota in Model.Rotas)
     {
-        <div class="card mb-3">
+        <div class="card mb-3" id="rota-@rota.Id.ToString("N")">
             <div class="card-header d-flex justify-content-between align-items-center">
                 <div>
                     <h5 class="mb-0 d-inline">@rota.Name</h5>
                     <span class="badge bg-secondary ms-2">@rota.Priority</span>
                     <span class="badge bg-info ms-1">@rota.Policy</span>
-                    <span class="badge bg-secondary ms-1">@rota.Period</span>
+                    <span class="badge bg-secondary ms-1">@(rota.Period == RotaPeriod.Build ? "Set-up" : rota.Period.ToString())</span>
                     @if (!string.IsNullOrEmpty(rota.PracticalInfo))
                     {
                         <div class="text-muted small mt-1">@rota.PracticalInfo</div>
@@ -144,7 +144,7 @@
                                 <div class="col-md-2">
                                     <label class="form-label">Period</label>
                                     <select name="Period" class="form-select">
-                                        <option value="Build" selected="@(rota.Period == RotaPeriod.Build)">Build</option>
+                                        <option value="Build" selected="@(rota.Period == RotaPeriod.Build)">Set-up</option>
                                         <option value="Event" selected="@(rota.Period == RotaPeriod.Event)">Event</option>
                                         <option value="Strike" selected="@(rota.Period == RotaPeriod.Strike)">Strike</option>
                                     </select>
@@ -192,7 +192,7 @@
                                             @{
                                                 var shiftLabel = shift.IsAllDay
                                                     ? "All day"
-                                                    : $"{shift.StartTime}–{shift.StartTime.PlusMinutes((int)shift.Duration.TotalMinutes)}";
+                                                    : $"{shift.StartTime.ToString("HH:mm", null)}–{shift.StartTime.PlusMinutes((int)shift.Duration.TotalMinutes).ToString("HH:mm", null)}";
                                             }
                                             @shiftLabel
                                             @if (shift.AdminOnly) { <span class="badge bg-dark">Admin Only</span> }
@@ -210,15 +210,15 @@
                                             };
                                             var phaseLabel = phase switch
                                             {
-                                                ShiftPeriod.Build => "Build",
-                                                ShiftPeriod.Event => "Burn",
+                                                ShiftPeriod.Build => "Set-up",
+                                                ShiftPeriod.Event => "Event",
                                                 ShiftPeriod.Strike => "Strike",
                                                 _ => ""
                                             };
                                         }
                                         <td><span class="badge @phaseBadge me-1">@phaseLabel</span>@shiftDateLabel</td>
-                                        <td>@shift.StartTime</td>
-                                        <td>@(shift.Duration.TotalHours)h</td>
+                                        <td>@shift.StartTime.ToString("HH:mm", null)</td>
+                                        <td>@(shift.IsAllDay ? "Full day" : $"{shift.Duration.TotalHours}h")</td>
                                         @{
                                             var confirmed = shift.ShiftSignups.Count(d => d.Status == SignupStatus.Confirmed);
                                             var understaffed = confirmed < shift.MinVolunteers;
@@ -379,16 +379,18 @@
                     <p class="text-muted">No shifts yet.</p>
                 }
 
-                @* Staffing Grid for Build/Strike rotas without shifts *@
-                @if (Model.CanManageShifts && rota.Period != RotaPeriod.Event && rota.Shifts.Count == 0)
+                @* Staffing Grid for Build/Strike rotas *@
+                @if (Model.CanManageShifts && rota.Period != RotaPeriod.Event)
                 {
                     var periodRange = rota.Period == RotaPeriod.Build
                         ? (Start: Model.EventSettings.BuildStartOffset, End: -1)
                         : (Start: Model.EventSettings.EventEndOffset + 1, End: Model.EventSettings.StrikeEndOffset);
+                    var existingDayOffsets = rota.Shifts.Select(s => s.DayOffset).Distinct().ToHashSet();
 
-                    <div class="mt-3 border-top pt-3 staffing-grid-container" data-rota-id="@rota.Id">
-                        <h6>Configure Staffing</h6>
-                        <p class="text-muted small">Pick your date range, then set min/max humans per day.</p>
+                    <div class="mt-3 border-top pt-3 staffing-grid-container" data-rota-id="@rota.Id"
+                         data-existing-days="@System.Text.Json.JsonSerializer.Serialize(existingDayOffsets)">
+                        <h6>@(rota.Shifts.Count > 0 ? "Add More Days" : "Configure Staffing")</h6>
+                        <p class="text-muted small">Pick your date range, then set min/max humans per day. Days that already have shifts are excluded.</p>
 
                         @* Step 1: Date range picker *@
                         <div class="staffing-step1 row g-2 align-items-end mb-3">
@@ -588,7 +590,7 @@
                         <div class="col-md-2">
                             <label class="form-label">Period</label>
                             <select name="Period" class="form-select">
-                                <option value="Build">Build</option>
+                                <option value="Build">Set-up</option>
                                 <option value="Event" selected>Event</option>
                                 <option value="Strike">Strike</option>
                             </select>
@@ -670,13 +672,15 @@
         var step2 = container.querySelector('.staffing-step2');
         var tbody = container.querySelector('.staffing-tbody');
         var allDays = JSON.parse(container.querySelector('.staffing-days-data').textContent);
+        var existingDays = JSON.parse(container.dataset.existingDays || '[]');
 
         showBtn.addEventListener('click', function() {
             var startOffset = parseInt(startSelect.value);
             var endOffset = parseInt(endSelect.value);
             if (startOffset > endOffset) { alert('Start must be before end.'); return; }
 
-            var days = allDays.filter(function(d) { return d.offset >= startOffset && d.offset <= endOffset; });
+            var days = allDays.filter(function(d) { return d.offset >= startOffset && d.offset <= endOffset && existingDays.indexOf(d.offset) === -1; });
+            if (days.length === 0) { alert('All days in this range already have shifts.'); return; }
             tbody.innerHTML = '';
             days.forEach(function(day, i) {
                 var tr = document.createElement('tr');
@@ -696,12 +700,33 @@
                     var val = this.value;
                     manuallyEdited[idx + '-' + (isMin ? 'min' : 'max')] = true;
 
+                    // Min/Cap sync: when min exceeds cap on this row, bump cap
+                    if (isMin) {
+                        var row = this.closest('tr');
+                        var maxInput = row.querySelector('.staffing-max');
+                        if (parseInt(val) > parseInt(maxInput.value)) {
+                            maxInput.value = val;
+                            manuallyEdited[idx + '-max'] = true;
+                        }
+                    }
+
                     // Fill down to subsequent rows not manually edited
                     var rows = tbody.querySelectorAll(isMin ? '.staffing-min' : '.staffing-max');
                     for (var j = idx + 1; j < rows.length; j++) {
                         var key = j + '-' + (isMin ? 'min' : 'max');
                         if (!manuallyEdited[key]) {
                             rows[j].value = val;
+                        }
+                    }
+
+                    // After cascade-fill min, also sync cap on filled rows
+                    if (isMin) {
+                        var maxRows = tbody.querySelectorAll('.staffing-max');
+                        var minRows = tbody.querySelectorAll('.staffing-min');
+                        for (var j = idx + 1; j < minRows.length; j++) {
+                            if (parseInt(minRows[j].value) > parseInt(maxRows[j].value)) {
+                                maxRows[j].value = minRows[j].value;
+                            }
                         }
                     }
                 });
@@ -738,5 +763,31 @@
             });
         });
     });
+    // Min/Cap sync: when min exceeds cap, bump cap to match
+    function syncMinCap(minInput, maxInput) {
+        minInput.addEventListener('input', function() {
+            var minVal = parseInt(this.value) || 0;
+            var maxVal = parseInt(maxInput.value) || 0;
+            if (minVal > maxVal) {
+                maxInput.value = minVal;
+                maxInput.dispatchEvent(new Event('input', { bubbles: true }));
+            }
+        });
+    }
+
+    // Apply to all Add Shift and Edit Shift forms
+    document.querySelectorAll('form').forEach(function(form) {
+        var minInput = form.querySelector('input[name="MinVolunteers"]');
+        var maxInput = form.querySelector('input[name="MaxVolunteers"]');
+        if (minInput && maxInput) syncMinCap(minInput, maxInput);
+    });
+
+    // Scroll to fragment on page load (for newly created rotas)
+    if (window.location.hash) {
+        var target = document.querySelector(window.location.hash);
+        if (target) {
+            setTimeout(function() { target.scrollIntoView({ behavior: 'smooth', block: 'start' }); }, 100);
+        }
+    }
 })();
 </script>

--- a/src/Humans.Web/Views/ShiftDashboard/Index.cshtml
+++ b/src/Humans.Web/Views/ShiftDashboard/Index.cshtml
@@ -84,8 +84,8 @@
                         };
                         var periodLabel = period switch
                         {
-                            ShiftPeriod.Build => "Build",
-                            ShiftPeriod.Event => "Burn",
+                            ShiftPeriod.Build => "Set-up",
+                            ShiftPeriod.Event => "Event",
                             ShiftPeriod.Strike => "Strike",
                             _ => ""
                         };

--- a/src/Humans.Web/Views/Shifts/Index.cshtml
+++ b/src/Humans.Web/Views/Shifts/Index.cshtml
@@ -24,8 +24,8 @@
     {
         return shift.GetShiftPeriod(es) switch
         {
-            ShiftPeriod.Build => "Build",
-            ShiftPeriod.Event => "Burn",
+            ShiftPeriod.Build => "Set-up",
+            ShiftPeriod.Event => "Event",
             ShiftPeriod.Strike => "Strike",
             _ => ""
         };
@@ -115,7 +115,7 @@
                             {
                                 <span class="badge bg-warning text-dark ms-1">Important</span>
                             }
-                            <span class="badge @(rotaGroup.Rota.Period == RotaPeriod.Build ? "bg-info" : rotaGroup.Rota.Period == RotaPeriod.Strike ? "bg-secondary" : "bg-success") ms-1">@rotaGroup.Rota.Period</span>
+                            <span class="badge @(rotaGroup.Rota.Period == RotaPeriod.Build ? "bg-info" : rotaGroup.Rota.Period == RotaPeriod.Strike ? "bg-secondary" : "bg-success") ms-1">@(rotaGroup.Rota.Period == RotaPeriod.Build ? "Set-up" : rotaGroup.Rota.Period.ToString())</span>
                         </h6>
                         @if (!string.IsNullOrEmpty(rotaGroup.Rota.PracticalInfo))
                         {
@@ -127,6 +127,34 @@
                             @* Build/Strike: show date range with per-day fill rates and range signup *@
                             var allDayShifts = rotaGroup.Shifts.Where(s => s.Shift.IsAllDay).OrderBy(s => s.Shift.DayOffset).ToList();
                             var availableShifts = allDayShifts.Where(s => s.RemainingSlots > 0 && !Model.UserSignupShiftIds.Contains(s.Shift.Id)).ToList();
+                            @if (availableShifts.Count > 0)
+                            {
+                                <form asp-action="SignUpRange" method="post" class="row g-2 align-items-end mb-3">
+                                    @Html.AntiForgeryToken()
+                                    <input type="hidden" name="rotaId" value="@rotaGroup.Rota.Id" />
+                                    <div class="col-auto">
+                                        <label class="form-label form-label-sm">Start</label>
+                                        <select name="startDayOffset" class="form-select form-select-sm">
+                                            @foreach (var s in availableShifts)
+                                            {
+                                                <option value="@s.Shift.DayOffset">@FormatDate(es, s.Shift.DayOffset)</option>
+                                            }
+                                        </select>
+                                    </div>
+                                    <div class="col-auto">
+                                        <label class="form-label form-label-sm">End</label>
+                                        <select name="endDayOffset" class="form-select form-select-sm">
+                                            @foreach (var s in availableShifts)
+                                            {
+                                                <option value="@s.Shift.DayOffset" selected="@(s == availableShifts.Last())">@FormatDate(es, s.Shift.DayOffset)</option>
+                                            }
+                                        </select>
+                                    </div>
+                                    <div class="col-auto">
+                                        <button type="submit" class="btn btn-sm btn-success">Sign Up for Range</button>
+                                    </div>
+                                </form>
+                            }
                             <div class="table-responsive">
                                 <table class="table table-sm">
                                     <thead>
@@ -162,34 +190,6 @@
                                     </tbody>
                                 </table>
                             </div>
-                            @if (availableShifts.Count > 0)
-                            {
-                                <form asp-action="SignUpRange" method="post" class="row g-2 align-items-end mb-3">
-                                    @Html.AntiForgeryToken()
-                                    <input type="hidden" name="rotaId" value="@rotaGroup.Rota.Id" />
-                                    <div class="col-auto">
-                                        <label class="form-label form-label-sm">Start</label>
-                                        <select name="startDayOffset" class="form-select form-select-sm">
-                                            @foreach (var s in availableShifts)
-                                            {
-                                                <option value="@s.Shift.DayOffset">@FormatDate(es, s.Shift.DayOffset)</option>
-                                            }
-                                        </select>
-                                    </div>
-                                    <div class="col-auto">
-                                        <label class="form-label form-label-sm">End</label>
-                                        <select name="endDayOffset" class="form-select form-select-sm">
-                                            @foreach (var s in availableShifts)
-                                            {
-                                                <option value="@s.Shift.DayOffset" selected="@(s == availableShifts.Last())">@FormatDate(es, s.Shift.DayOffset)</option>
-                                            }
-                                        </select>
-                                    </div>
-                                    <div class="col-auto">
-                                        <button type="submit" class="btn btn-sm btn-success">Sign Up for Range</button>
-                                    </div>
-                                </form>
-                            }
                         }
                         else
                         {
@@ -214,11 +214,11 @@
                                             var isFull = item.RemainingSlots <= 0;
                                             var understaffed = item.ConfirmedCount < shift.MinVolunteers;
                                             <tr class="@(isFull ? "table-secondary" : "")">
-                                                <td>@(shift.IsAllDay ? "All day" : $"{shift.StartTime}–{shift.StartTime.PlusMinutes((int)shift.Duration.TotalMinutes)}")</td>
+                                                <td>@(shift.IsAllDay ? "All day" : $"{shift.StartTime.ToString("HH:mm", null)}–{shift.StartTime.PlusMinutes((int)shift.Duration.TotalMinutes).ToString("HH:mm", null)}")</td>
                                                 <td><span class="badge @GetPhaseBadge(shift, es)">@GetPhase(shift, es)</span></td>
                                                 <td>@FormatDate(es, shift.DayOffset)</td>
                                                 <td>@FormatTime(item.AbsoluteStart, tz)</td>
-                                                <td>@(shift.Duration.TotalHours)h</td>
+                                                <td>@(shift.IsAllDay ? "Full day" : $"{shift.Duration.TotalHours}h")</td>
                                                 <td>
                                                     <span class="@(understaffed ? "text-danger fw-bold" : "")">@item.ConfirmedCount</span>
                                                     <small class="text-muted">/ @shift.MinVolunteers–@shift.MaxVolunteers</small>

--- a/src/Humans.Web/Views/Shifts/Mine.cshtml
+++ b/src/Humans.Web/Views/Shifts/Mine.cshtml
@@ -25,8 +25,8 @@
         var period = shift.GetShiftPeriod(es);
         return period switch
         {
-            ShiftPeriod.Build => "Build",
-            ShiftPeriod.Event => "Burn",
+            ShiftPeriod.Build => "Set-up",
+            ShiftPeriod.Event => "Event",
             ShiftPeriod.Strike => "Strike",
             _ => ""
         };

--- a/src/Humans.Web/Views/Team/Roster.cshtml
+++ b/src/Humans.Web/Views/Team/Roster.cshtml
@@ -49,7 +49,7 @@
         <ul class="dropdown-menu">
             <li><a class="dropdown-item" href="@Url.Action("Roster", new { priority = Model.PriorityFilter, status = Model.StatusFilter })">All</a></li>
             <li><a class="dropdown-item" href="@Url.Action("Roster", new { priority = Model.PriorityFilter, status = Model.StatusFilter, period = "YearRound" })">Year-round</a></li>
-            <li><a class="dropdown-item" href="@Url.Action("Roster", new { priority = Model.PriorityFilter, status = Model.StatusFilter, period = "Build" })">Build</a></li>
+            <li><a class="dropdown-item" href="@Url.Action("Roster", new { priority = Model.PriorityFilter, status = Model.StatusFilter, period = "Build" })">Set-up</a></li>
             <li><a class="dropdown-item" href="@Url.Action("Roster", new { priority = Model.PriorityFilter, status = Model.StatusFilter, period = "Event" })">Event</a></li>
             <li><a class="dropdown-item" href="@Url.Action("Roster", new { priority = Model.PriorityFilter, status = Model.StatusFilter, period = "Strike" })">Strike</a></li>
         </ul>
@@ -102,7 +102,7 @@ else
                             "Strike" => "bg-secondary",
                             _ => "bg-light text-dark"
                         };
-                        var periodLabel = slot.Period == "YearRound" ? "Year-round" : slot.Period;
+                        var periodLabel = slot.Period switch { "YearRound" => "Year-round", "Build" => "Set-up", _ => slot.Period };
                     }
                     <td><span class="badge @periodBadge">@periodLabel</span></td>
                     <td>@slot.SlotNumber</td>

--- a/src/Humans.Web/Views/TeamAdmin/Roles.cshtml
+++ b/src/Humans.Web/Views/TeamAdmin/Roles.cshtml
@@ -72,7 +72,7 @@
                             <label class="form-label">Period</label>
                             <select name="Period" class="form-select">
                                 <option value="YearRound" selected="@(role.Period == RolePeriod.YearRound)">Year-round</option>
-                                <option value="Build" selected="@(role.Period == RolePeriod.Build)">Build</option>
+                                <option value="Build" selected="@(role.Period == RolePeriod.Build)">Set-up</option>
                                 <option value="Event" selected="@(role.Period == RolePeriod.Event)">Event</option>
                                 <option value="Strike" selected="@(role.Period == RolePeriod.Strike)">Strike</option>
                             </select>
@@ -221,7 +221,7 @@ else
                     <label class="form-label">Period</label>
                     <select name="Period" class="form-select">
                         <option value="YearRound" selected>Year-round</option>
-                        <option value="Build">Build</option>
+                        <option value="Build">Set-up</option>
                         <option value="Event">Event</option>
                         <option value="Strike">Strike</option>
                     </select>

--- a/tests/Humans.Integration.Tests/AnonymousAccessTests.cs
+++ b/tests/Humans.Integration.Tests/AnonymousAccessTests.cs
@@ -33,9 +33,16 @@ public class AnonymousAccessTests : IntegrationTestBase
         response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
+    [Fact]
+    public async Task TeamsPage_IsAccessibleAnonymously()
+    {
+        var response = await Client.GetAsync("/Teams");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
     [Theory]
     [InlineData("/Profile")]
-    [InlineData("/Teams")]
     [InlineData("/Admin")]
     [InlineData("/Consent")]
     public async Task ProtectedEndpoint_RedirectsToLogin_WhenAnonymous(string path)

--- a/tests/Humans.Integration.Tests/Infrastructure/HumansWebApplicationFactory.cs
+++ b/tests/Humans.Integration.Tests/Infrastructure/HumansWebApplicationFactory.cs
@@ -32,9 +32,9 @@ public class HumansWebApplicationFactory : WebApplicationFactory<Program>, IAsyn
                 ["Email:SmtpHost"] = "localhost",
                 ["Email:FromAddress"] = "test@example.com",
                 ["Email:BaseUrl"] = "https://localhost",
-                ["GitHub:Owner"] = "test-owner",
-                ["GitHub:Repository"] = "test-repo",
-                ["GitHub:AccessToken"] = "test-token",
+                ["GitHub:Owner"] = "",
+                ["GitHub:Repository"] = "",
+                ["GitHub:AccessToken"] = "",
                 ["GoogleMaps:ApiKey"] = "test-api-key",
             });
         });
@@ -47,6 +47,7 @@ public class HumansWebApplicationFactory : WebApplicationFactory<Program>, IAsyn
             if (emailDescriptor != null)
                 services.Remove(emailDescriptor);
             services.AddScoped(_ => Substitute.For<IEmailService>());
+
         });
     }
 


### PR DESCRIPTION
## Summary
- **Min/cap sync**: auto-update cap when min exceeds it (all shift forms + staffing grid)
- **Nav bar**: rename "Shifts" → "Volunteer" (all locales)
- **Phase tags**: Build→Set-up, Burn→Event across all views and dropdowns
- **Time format**: remove seconds from time display (HH:mm)
- **Full day**: show "Full day" instead of "24h" for all-day shifts
- **Scroll to rota**: auto-scroll to newly created rota after creation
- **3 histograms**: split staffing chart into Set-up, Event, Strike
- **Staffing grid always**: show for build/strike rotas even with existing shifts (additive only)
- **Signup form on top**: move Sign Up for Range above shifts table on browse page
- **Magick.NET 14.11.0**: resolves NU1902 vulnerability (GHSA-gc62-2v5p-qpmp)
- **& in team names**: investigated — no code bug found, all Razor encoding is correct. Needs QA verification with actual data.

## Test plan
- [ ] Create a rota, verify page scrolls to it
- [ ] On the staffing grid, increase min above cap — cap should auto-update
- [ ] Verify nav bar says "Volunteer" not "Shifts"
- [ ] Verify all phase badges say "Set-up" / "Event" / "Strike" (not Build/Burn)
- [ ] Verify shift times show HH:mm without seconds
- [ ] Verify all-day shifts show "Full day" not "24h"
- [ ] Check staffing charts render 3 separate charts (Set-up, Event, Strike)
- [ ] On a build rota with existing shifts, verify "Add More Days" grid appears
- [ ] On browse page, verify Sign Up for Range form is above the shifts table
- [ ] Create a team with & in the name (e.g., "W&R zone"), verify it displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)