### PR TITLE
feat: shift signup visibility for coordinators and admins

### DIFF
--- a/docs/features/26-shift-signup-visibility.md
+++ b/docs/features/26-shift-signup-visibility.md
@@ -8,7 +8,7 @@ Coordinators and admins managing shifts cannot currently see who has signed up f
 
 Signup names/avatars use existing per-page auth checks — no new authorization logic needed:
 
-- **Browse page (`/Shifts`):** Uses the existing `isPrivileged` variable in `ShiftsController` — true for Admin, NoInfoAdmin, VolunteerCoordinator, or any department coordinator (`GetCoordinatorDepartmentIdsAsync().Count > 0`).
+- **Browse page (`/Shifts`):** Uses the existing `isPrivileged` variable in `ShiftsController` — true for Admin, NoInfoAdmin, or any department coordinator (`GetCoordinatorDepartmentIdsAsync().Count > 0`).
 - **Admin page (`/Teams/{slug}/Shifts`):** Uses the existing `CanApproveAsync` helper in `ShiftAdminController` — true for Admin, NoInfoAdmin, VolunteerCoordinator, or coordinator of that specific team.
 
 Regular volunteers see only fill counts (existing behavior, unchanged).

--- a/src/Humans.Application/Interfaces/IShiftManagementService.cs
+++ b/src/Humans.Application/Interfaces/IShiftManagementService.cs
@@ -150,7 +150,7 @@ public interface IShiftManagementService
     /// </summary>
     Task<IReadOnlyList<UrgentShift>> GetBrowseShiftsAsync(
         Guid eventSettingsId, Guid? departmentId = null, LocalDate? date = null,
-        bool includeAdminOnly = false);
+        bool includeAdminOnly = false, bool includeSignups = false);
 
     /// <summary>
     /// Calculates the urgency score for a single shift.
@@ -186,7 +186,8 @@ public record UrgentShift(
     double UrgencyScore,
     int ConfirmedCount,
     int RemainingSlots,
-    string DepartmentName);
+    string DepartmentName,
+    IReadOnlyList<(Guid UserId, string DisplayName, SignupStatus Status, bool HasProfilePicture)> Signups);
 
 /// <summary>
 /// Per-day staffing data for build/strike visualization.

--- a/src/Humans.Infrastructure/Services/ShiftManagementService.cs
+++ b/src/Humans.Infrastructure/Services/ShiftManagementService.cs
@@ -488,11 +488,23 @@ public class ShiftManagementService : IShiftManagementService
             .FirstOrDefaultAsync(e => e.Id == eventSettingsId);
         if (es == null) return [];
 
-        var query = _dbContext.Shifts
-            .Include(s => s.Rota).ThenInclude(r => r.Team)
-            .Include(s => s.Rota).ThenInclude(r => r.EventSettings)
-            .Include(s => s.ShiftSignups).ThenInclude(ss => ss.User)
-            .Where(s => s.Rota.EventSettingsId == eventSettingsId);
+        IQueryable<Shift> query;
+        if (includeSignups)
+        {
+            query = _dbContext.Shifts
+                .Include(s => s.Rota).ThenInclude(r => r.Team)
+                .Include(s => s.Rota).ThenInclude(r => r.EventSettings)
+                .Include(s => s.ShiftSignups).ThenInclude(ss => ss.User);
+        }
+        else
+        {
+            query = _dbContext.Shifts
+                .Include(s => s.Rota).ThenInclude(r => r.Team)
+                .Include(s => s.Rota).ThenInclude(r => r.EventSettings)
+                .Include(s => s.ShiftSignups);
+        }
+
+        query = query.Where(s => s.Rota.EventSettingsId == eventSettingsId);
 
         if (!includeAdminOnly)
             query = query.Where(s => !s.AdminOnly);
@@ -517,9 +529,9 @@ public class ShiftManagementService : IShiftManagementService
                 var signups = includeSignups
                     ? s.ShiftSignups
                         .Where(ss => ss.Status is SignupStatus.Confirmed or SignupStatus.Pending)
-                        .Select(ss => (ss.UserId, ss.User.DisplayName, ss.Status,
-                            HasProfilePicture: ss.User.ProfilePictureUrl != null))
-                        .OrderBy(ss => ss.Status)
+                        .Select(ss => (ss.UserId, DisplayName: ss.User?.DisplayName ?? "", ss.Status,
+                            HasProfilePicture: ss.User?.ProfilePictureUrl != null))
+                        .OrderBy(ss => ss.Status == SignupStatus.Confirmed ? 0 : 1)
                         .ThenBy(ss => ss.DisplayName, StringComparer.OrdinalIgnoreCase)
                         .ToList()
                     : [];

--- a/src/Humans.Infrastructure/Services/ShiftManagementService.cs
+++ b/src/Humans.Infrastructure/Services/ShiftManagementService.cs
@@ -468,7 +468,7 @@ public class ShiftManagementService : IShiftManagementService
                 var confirmedCount = s.ShiftSignups.Count(d => d.Status == SignupStatus.Confirmed);
                 var score = CalculateScore(s, confirmedCount);
                 var remaining = Math.Max(0, s.MaxVolunteers - confirmedCount);
-                return new UrgentShift(s, score, confirmedCount, remaining, s.Rota.Team.Name);
+                return new UrgentShift(s, score, confirmedCount, remaining, s.Rota.Team.Name, []);
             })
             .Where(u => u.UrgencyScore > 0)
             .OrderByDescending(u => u.UrgencyScore)
@@ -482,7 +482,7 @@ public class ShiftManagementService : IShiftManagementService
 
     public async Task<IReadOnlyList<UrgentShift>> GetBrowseShiftsAsync(
         Guid eventSettingsId, Guid? departmentId = null, LocalDate? date = null,
-        bool includeAdminOnly = false)
+        bool includeAdminOnly = false, bool includeSignups = false)
     {
         var es = await _dbContext.EventSettings.AsNoTracking()
             .FirstOrDefaultAsync(e => e.Id == eventSettingsId);
@@ -491,7 +491,7 @@ public class ShiftManagementService : IShiftManagementService
         var query = _dbContext.Shifts
             .Include(s => s.Rota).ThenInclude(r => r.Team)
             .Include(s => s.Rota).ThenInclude(r => r.EventSettings)
-            .Include(s => s.ShiftSignups)
+            .Include(s => s.ShiftSignups).ThenInclude(ss => ss.User)
             .Where(s => s.Rota.EventSettingsId == eventSettingsId);
 
         if (!includeAdminOnly)
@@ -514,7 +514,16 @@ public class ShiftManagementService : IShiftManagementService
                 var confirmedCount = s.ShiftSignups.Count(d => d.Status == SignupStatus.Confirmed);
                 var score = CalculateScore(s, confirmedCount);
                 var remaining = Math.Max(0, s.MaxVolunteers - confirmedCount);
-                return new UrgentShift(s, score, confirmedCount, remaining, s.Rota.Team.Name);
+                var signups = includeSignups
+                    ? s.ShiftSignups
+                        .Where(ss => ss.Status is SignupStatus.Confirmed or SignupStatus.Pending)
+                        .Select(ss => (ss.UserId, ss.User.DisplayName, ss.Status,
+                            HasProfilePicture: ss.User.ProfilePictureUrl != null))
+                        .OrderBy(ss => ss.Status)
+                        .ThenBy(ss => ss.DisplayName, StringComparer.OrdinalIgnoreCase)
+                        .ToList()
+                    : [];
+                return new UrgentShift(s, score, confirmedCount, remaining, s.Rota.Team.Name, signups);
             })
             .OrderByDescending(u => u.UrgencyScore)
             .ToList();

--- a/src/Humans.Web/Controllers/ShiftsController.cs
+++ b/src/Humans.Web/Controllers/ShiftsController.cs
@@ -132,12 +132,9 @@ public class ShiftsController : Controller
         }
         else
         {
-            var allShifts = await _shiftMgmt.GetBrowseShiftsAsync(es.Id,
-                includeAdminOnly: isPrivileged, includeSignups: false);
-            allDepartments = allShifts
-                .Select(u => new DepartmentOption { TeamId = u.Shift!.Rota.TeamId, Name = u.DepartmentName ?? "Unknown" })
-                .DistinctBy(d => d.TeamId)
-                .OrderBy(d => d.Name, StringComparer.Ordinal)
+            var depts = await _shiftMgmt.GetDepartmentsWithRotasAsync(es.Id);
+            allDepartments = depts
+                .Select(d => new DepartmentOption { TeamId = d.TeamId, Name = d.TeamName })
                 .ToList();
         }
 

--- a/src/Humans.Web/Controllers/ShiftsController.cs
+++ b/src/Humans.Web/Controllers/ShiftsController.cs
@@ -70,7 +70,8 @@ public class ShiftsController : Controller
 
         // Build the browse view — show all active shifts, hide AdminOnly from regular volunteers
         var urgentShifts = await _shiftMgmt.GetBrowseShiftsAsync(
-            es.Id, departmentId: departmentId, date: filterDate, includeAdminOnly: isPrivileged);
+            es.Id, departmentId: departmentId, date: filterDate,
+            includeAdminOnly: isPrivileged, includeSignups: isPrivileged);
 
         // Group by department → rota → shift
         var departments = urgentShifts
@@ -102,7 +103,12 @@ public class ShiftsController : Controller
                                             AbsoluteEnd = end,
                                             Period = period,
                                             ConfirmedCount = u.ConfirmedCount,
-                                            RemainingSlots = u.RemainingSlots
+                                            RemainingSlots = u.RemainingSlots,
+                                            Signups = u.Signups
+                                                .Select(s => new ShiftSignupInfo(
+                                                    s.UserId, s.DisplayName, s.Status,
+                                                    s.HasProfilePicture ? $"/Human/{s.UserId}/Picture" : null))
+                                                .ToList()
                                         };
                                     })
                                     .OrderBy(s => s.AbsoluteStart)
@@ -126,7 +132,8 @@ public class ShiftsController : Controller
         }
         else
         {
-            var allShifts = await _shiftMgmt.GetBrowseShiftsAsync(es.Id, includeAdminOnly: isPrivileged);
+            var allShifts = await _shiftMgmt.GetBrowseShiftsAsync(es.Id,
+                includeAdminOnly: isPrivileged, includeSignups: false);
             allDepartments = allShifts
                 .Select(u => new DepartmentOption { TeamId = u.Shift!.Rota.TeamId, Name = u.DepartmentName ?? "Unknown" })
                 .DistinctBy(d => d.TeamId)
@@ -143,7 +150,8 @@ public class ShiftsController : Controller
             UserSignupShiftIds = userSignupShiftIds,
             UserSignupStatuses = userSignupStatuses,
             Departments = departments,
-            AllDepartments = allDepartments
+            AllDepartments = allDepartments,
+            ShowSignups = isPrivileged
         };
 
         return View(model);

--- a/src/Humans.Web/Models/ShiftViewModels.cs
+++ b/src/Humans.Web/Models/ShiftViewModels.cs
@@ -129,6 +129,7 @@ public class ShiftBrowseViewModel
     public bool ShowFullShifts { get; set; }
     public HashSet<Guid> UserSignupShiftIds { get; set; } = [];
     public Dictionary<Guid, SignupStatus> UserSignupStatuses { get; set; } = new();
+    public bool ShowSignups { get; set; }
 }
 
 public class DepartmentOption
@@ -151,6 +152,8 @@ public class RotaShiftGroup
     public List<ShiftDisplayItem> Shifts { get; set; } = [];
 }
 
+public record ShiftSignupInfo(Guid UserId, string DisplayName, SignupStatus Status, string? ProfilePictureUrl);
+
 public class ShiftDisplayItem
 {
     public Shift Shift { get; set; } = null!;
@@ -159,6 +162,7 @@ public class ShiftDisplayItem
     public ShiftPeriod Period { get; set; }
     public int ConfirmedCount { get; set; }
     public int RemainingSlots { get; set; }
+    public IReadOnlyList<ShiftSignupInfo> Signups { get; set; } = [];
 }
 
 // === Mine ===

--- a/src/Humans.Web/Resources/SharedResource.de.resx
+++ b/src/Humans.Web/Resources/SharedResource.de.resx
@@ -1141,5 +1141,7 @@
   <data name="Camp_SwissCampLabel" xml:space="preserve"><value>Wurde dieses Camp jemals "Swiss Camp" genannt?</value></data>
   <data name="Camp_InfoTitle" xml:space="preserve"><value>Barrio-Info</value></data>
   <data name="Camp_NameLabel" xml:space="preserve"><value>Barrio-Name</value></data>
+  <data name="Shifts_SignedUp" xml:space="preserve"><value>Angemeldet</value></data>
+  <data name="Shifts_Pending" xml:space="preserve"><value>(ausstehend)</value></data>
 
 </root>

--- a/src/Humans.Web/Resources/SharedResource.es.resx
+++ b/src/Humans.Web/Resources/SharedResource.es.resx
@@ -1161,5 +1161,7 @@
   <data name="Camp_SwissCampLabel" xml:space="preserve"><value>¿Este camp se ha llamado alguna vez "Swiss Camp"?</value></data>
   <data name="Camp_InfoTitle" xml:space="preserve"><value>Información del Barrio</value></data>
   <data name="Camp_NameLabel" xml:space="preserve"><value>Nombre del Barrio</value></data>
+  <data name="Shifts_SignedUp" xml:space="preserve"><value>Apuntados</value></data>
+  <data name="Shifts_Pending" xml:space="preserve"><value>(pendiente)</value></data>
 
 </root>

--- a/src/Humans.Web/Resources/SharedResource.fr.resx
+++ b/src/Humans.Web/Resources/SharedResource.fr.resx
@@ -1141,5 +1141,7 @@
   <data name="Camp_SwissCampLabel" xml:space="preserve"><value>Ce camp a-t-il déjà été appelé "Swiss Camp" ?</value></data>
   <data name="Camp_InfoTitle" xml:space="preserve"><value>Info du Barrio</value></data>
   <data name="Camp_NameLabel" xml:space="preserve"><value>Nom du Barrio</value></data>
+  <data name="Shifts_SignedUp" xml:space="preserve"><value>Inscrits</value></data>
+  <data name="Shifts_Pending" xml:space="preserve"><value>(en attente)</value></data>
 
 </root>

--- a/src/Humans.Web/Resources/SharedResource.it.resx
+++ b/src/Humans.Web/Resources/SharedResource.it.resx
@@ -1141,5 +1141,7 @@
   <data name="Camp_SwissCampLabel" xml:space="preserve"><value>Questo camp è mai stato chiamato "Swiss Camp"?</value></data>
   <data name="Camp_InfoTitle" xml:space="preserve"><value>Info del Barrio</value></data>
   <data name="Camp_NameLabel" xml:space="preserve"><value>Nome del Barrio</value></data>
+  <data name="Shifts_SignedUp" xml:space="preserve"><value>Iscritti</value></data>
+  <data name="Shifts_Pending" xml:space="preserve"><value>(in attesa)</value></data>
 
 </root>

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -1157,5 +1157,7 @@
   <data name="Camp_SwissCampLabel" xml:space="preserve"><value>Has this camp ever been called "Swiss Camp"</value></data>
   <data name="Camp_InfoTitle" xml:space="preserve"><value>Barrio Info</value></data>
   <data name="Camp_NameLabel" xml:space="preserve"><value>Barrio Name</value></data>
+  <data name="Shifts_SignedUp" xml:space="preserve"><value>Signed Up</value></data>
+  <data name="Shifts_Pending" xml:space="preserve"><value>(pending)</value></data>
 
 </root>

--- a/src/Humans.Web/Views/ShiftAdmin/Index.cshtml
+++ b/src/Humans.Web/Views/ShiftAdmin/Index.cshtml
@@ -235,7 +235,7 @@
                                         {
                                             var activeSignups = shift.ShiftSignups
                                                 .Where(ss => ss.Status is SignupStatus.Confirmed or SignupStatus.Pending)
-                                                .OrderBy(ss => ss.Status).ThenBy(ss => ss.User.DisplayName, StringComparer.OrdinalIgnoreCase)
+                                                .OrderBy(ss => ss.Status == SignupStatus.Confirmed ? 0 : 1).ThenBy(ss => ss.User?.DisplayName, StringComparer.OrdinalIgnoreCase)
                                                 .ToList();
                                             <td class="small">
                                                 @if (rota.Period == RotaPeriod.Event)
@@ -245,7 +245,7 @@
                                                         var ss = activeSignups[i];
                                                         if (i > 0) { <text>, </text> }
                                                         <a asp-controller="Human" asp-action="View" asp-route-id="@ss.UserId"
-                                                           class="text-decoration-none @(ss.Status == SignupStatus.Pending ? "text-muted fst-italic" : "")">@ss.User.DisplayName</a>@if (ss.Status == SignupStatus.Pending)
+                                                           class="text-decoration-none @(ss.Status == SignupStatus.Pending ? "text-muted fst-italic" : "")">@ss.User?.DisplayName</a>@if (ss.Status == SignupStatus.Pending)
                                                         {<small class="text-muted"> @Localizer["Shifts_Pending"]</small>}
                                                     }
                                                 }
@@ -255,11 +255,11 @@
                                                         @foreach (var ss in activeSignups)
                                                         {
                                                             <a asp-controller="Human" asp-action="View" asp-route-id="@ss.UserId"
-                                                               title="@ss.User.DisplayName@(ss.Status == SignupStatus.Pending ? $" ({Localizer["Shifts_Pending"]})" : "")"
+                                                               title="@(ss.User?.DisplayName)@(ss.Status == SignupStatus.Pending ? $" ({Localizer["Shifts_Pending"]})" : "")"
                                                                class="@(ss.Status == SignupStatus.Pending ? "opacity-50" : "")"
                                                                style="@(ss.Status == SignupStatus.Pending ? "border: 1px dashed #6c757d; border-radius: 50%;" : "")">
-                                                                <vc:user-avatar profile-picture-url="@(ss.User.ProfilePictureUrl != null ? $"/Human/{ss.UserId}/Picture" : null)"
-                                                                                display-name="@ss.User.DisplayName"
+                                                                <vc:user-avatar profile-picture-url="@(ss.User?.ProfilePictureUrl != null ? $"/Human/{ss.UserId}/Picture" : null)"
+                                                                                display-name="@(ss.User?.DisplayName)"
                                                                                 size="26" />
                                                             </a>
                                                         }

--- a/src/Humans.Web/Views/ShiftAdmin/Index.cshtml
+++ b/src/Humans.Web/Views/ShiftAdmin/Index.cshtml
@@ -173,6 +173,10 @@
                                     <th>Start</th>
                                     <th>Hours</th>
                                     <th>Filled</th>
+                                    @if (Model.CanApproveSignups)
+                                    {
+                                        <th>@Localizer["Shifts_SignedUp"]</th>
+                                    }
                                     <th></th>
                                 </tr>
                             </thead>
@@ -227,6 +231,42 @@
                                             <span class="@(understaffed ? "text-danger fw-bold" : "")">@confirmed</span>
                                             <small class="text-muted">/ @shift.MinVolunteers–@shift.MaxVolunteers</small>
                                         </td>
+                                        @if (Model.CanApproveSignups)
+                                        {
+                                            var activeSignups = shift.ShiftSignups
+                                                .Where(ss => ss.Status is SignupStatus.Confirmed or SignupStatus.Pending)
+                                                .OrderBy(ss => ss.Status).ThenBy(ss => ss.User.DisplayName, StringComparer.OrdinalIgnoreCase)
+                                                .ToList();
+                                            <td class="small">
+                                                @if (rota.Period == RotaPeriod.Event)
+                                                {
+                                                    @for (var i = 0; i < activeSignups.Count; i++)
+                                                    {
+                                                        var ss = activeSignups[i];
+                                                        if (i > 0) { <text>, </text> }
+                                                        <a asp-controller="Human" asp-action="View" asp-route-id="@ss.UserId"
+                                                           class="text-decoration-none @(ss.Status == SignupStatus.Pending ? "text-muted fst-italic" : "")">@ss.User.DisplayName</a>@if (ss.Status == SignupStatus.Pending)
+                                                        {<small class="text-muted"> @Localizer["Shifts_Pending"]</small>}
+                                                    }
+                                                }
+                                                else
+                                                {
+                                                    <div class="d-flex flex-wrap gap-1">
+                                                        @foreach (var ss in activeSignups)
+                                                        {
+                                                            <a asp-controller="Human" asp-action="View" asp-route-id="@ss.UserId"
+                                                               title="@ss.User.DisplayName@(ss.Status == SignupStatus.Pending ? $" ({Localizer["Shifts_Pending"]})" : "")"
+                                                               class="@(ss.Status == SignupStatus.Pending ? "opacity-50" : "")"
+                                                               style="@(ss.Status == SignupStatus.Pending ? "border: 1px dashed #6c757d; border-radius: 50%;" : "")">
+                                                                <vc:user-avatar profile-picture-url="@(ss.User.ProfilePictureUrl != null ? $"/Human/{ss.UserId}/Picture" : null)"
+                                                                                display-name="@ss.User.DisplayName"
+                                                                                size="26" />
+                                                            </a>
+                                                        }
+                                                    </div>
+                                                }
+                                            </td>
+                                        }
                                         <td>
                                             @if (Model.CanManageShifts)
                                             {
@@ -252,7 +292,7 @@
                                     @if (Model.CanManageShifts)
                                     {
                                         <tr class="collapse" id="edit-shift-@shift.Id.ToString("N")">
-                                            <td colspan="6">
+                                            <td colspan="@(Model.CanApproveSignups ? 7 : 6)">
                                                 <form asp-action="EditShift" asp-route-slug="@Model.Department.Slug" asp-route-shiftId="@shift.Id" method="post">
                                                     @Html.AntiForgeryToken()
                                                     <div class="row g-2 align-items-end">
@@ -301,7 +341,7 @@
                                     {
                                         var signupsCollapseId = "signups-" + shift.Id.ToString("N");
                                         <tr>
-                                            <td colspan="6">
+                                            <td colspan="@(Model.CanApproveSignups ? 7 : 6)">
                                                 <button class="btn btn-sm btn-outline-info" type="button"
                                                         data-bs-toggle="collapse" data-bs-target="#@signupsCollapseId">
                                                     Signups (@shiftSignups.Count)
@@ -309,7 +349,7 @@
                                             </td>
                                         </tr>
                                         <tr class="collapse" id="@signupsCollapseId">
-                                            <td colspan="6">
+                                            <td colspan="@(Model.CanApproveSignups ? 7 : 6)">
                                                 <div class="p-2">
                                                     @foreach (var signup in shiftSignups)
                                                     {
@@ -357,7 +397,7 @@
                                     {
                                         var voluntellCollapseId = "dept-voluntell-" + shift.Id.ToString("N");
                                         <tr class="collapse" id="@voluntellCollapseId">
-                                            <td colspan="6">
+                                            <td colspan="@(Model.CanApproveSignups ? 7 : 6)">
                                                 <div class="p-3 bg-light">
                                                     <div class="input-group mb-2" style="max-width: 400px;">
                                                         <input type="text" class="form-control dept-voluntell-search"

--- a/src/Humans.Web/Views/Shifts/Index.cshtml
+++ b/src/Humans.Web/Views/Shifts/Index.cshtml
@@ -204,6 +204,10 @@
                                             <th>Time</th>
                                             <th>Duration</th>
                                             <th>Filled</th>
+                                            @if (Model.ShowSignups)
+                                            {
+                                                <th>@Localizer["Shifts_SignedUp"]</th>
+                                            }
                                             <th></th>
                                         </tr>
                                     </thead>
@@ -227,6 +231,19 @@
                                                         <span class="badge bg-warning text-dark">Needs help</span>
                                                     }
                                                 </td>
+                                                @if (Model.ShowSignups)
+                                                {
+                                                    <td class="small">
+                                                        @for (var i = 0; i < item.Signups.Count; i++)
+                                                        {
+                                                            var signup = item.Signups[i];
+                                                            if (i > 0) { <text>, </text> }
+                                                            <a asp-controller="Human" asp-action="View" asp-route-id="@signup.UserId"
+                                                               class="text-decoration-none @(signup.Status == SignupStatus.Pending ? "text-muted fst-italic" : "")">@signup.DisplayName</a>@if (signup.Status == SignupStatus.Pending)
+                                                            {<small class="text-muted"> @Localizer["Shifts_Pending"]</small>}
+                                                        }
+                                                    </td>
+                                                }
                                                 <td>
                                                     @if (Model.UserSignupShiftIds.Contains(shift.Id))
                                                     {

--- a/src/Humans.Web/Views/Shifts/Index.cshtml
+++ b/src/Humans.Web/Views/Shifts/Index.cshtml
@@ -130,7 +130,7 @@
                             <div class="table-responsive">
                                 <table class="table table-sm">
                                     <thead>
-                                        <tr><th>Date</th><th>Filled</th><th>Status</th></tr>
+                                        <tr><th>Date</th><th>Filled</th><th>Status</th>@if (Model.ShowSignups) {<th>@Localizer["Shifts_SignedUp"]</th>}</tr>
                                     </thead>
                                     <tbody>
                                         @foreach (var item in allDayShifts)
@@ -157,6 +157,24 @@
                                                         <span class="badge bg-warning text-dark">Needs help</span>
                                                     }
                                                 </td>
+                                                @if (Model.ShowSignups)
+                                                {
+                                                    <td>
+                                                        <div class="d-flex flex-wrap gap-1">
+                                                            @foreach (var signup in item.Signups)
+                                                            {
+                                                                <a asp-controller="Human" asp-action="View" asp-route-id="@signup.UserId"
+                                                                   title="@signup.DisplayName@(signup.Status == SignupStatus.Pending ? $" ({Localizer["Shifts_Pending"]})" : "")"
+                                                                   class="@(signup.Status == SignupStatus.Pending ? "opacity-50" : "")"
+                                                                   style="@(signup.Status == SignupStatus.Pending ? "border: 1px dashed #6c757d; border-radius: 50%;" : "")">
+                                                                    <vc:user-avatar profile-picture-url="@signup.ProfilePictureUrl"
+                                                                                    display-name="@signup.DisplayName"
+                                                                                    size="26" />
+                                                                </a>
+                                                            }
+                                                        </div>
+                                                    </td>
+                                                }
                                             </tr>
                                         }
                                     </tbody>

--- a/tests/Humans.Application.Tests/Services/ShiftManagementServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/ShiftManagementServiceTests.cs
@@ -176,8 +176,128 @@ public class ShiftManagementServiceTests : IDisposable
     }
 
     // ============================================================
+    // GetBrowseShiftsAsync — includeSignups
+    // ============================================================
+
+    [Fact]
+    public async Task GetBrowseShifts_IncludeSignups_ReturnsConfirmedAndPendingOnly()
+    {
+        // Arrange
+        var (es, rota) = SeedRotaScenario(RotaPeriod.Event);
+        var shift = SeedShift(rota, dayOffset: 1);
+        var confirmedUser = SeedUser("Alice");
+        var pendingUser = SeedUser("Bob");
+        var bailedUser = SeedUser("Charlie");
+
+        SeedSignup(shift, confirmedUser, SignupStatus.Confirmed);
+        SeedSignup(shift, pendingUser, SignupStatus.Pending);
+        SeedSignup(shift, bailedUser, SignupStatus.Bailed);
+        await _dbContext.SaveChangesAsync();
+
+        // Act
+        var results = await _service.GetBrowseShiftsAsync(es.Id, includeSignups: true);
+
+        // Assert: only Confirmed and Pending signups returned
+        results.Should().HaveCount(1);
+        var signups = results[0].Signups;
+        signups.Should().HaveCount(2);
+        signups.Select(s => s.DisplayName).Should().BeEquivalentTo(["Alice", "Bob"]);
+    }
+
+    [Fact]
+    public async Task GetBrowseShifts_IncludeSignups_ConfirmedBeforePending()
+    {
+        // Arrange
+        var (es, rota) = SeedRotaScenario(RotaPeriod.Event);
+        var shift = SeedShift(rota, dayOffset: 1);
+        var confirmedUser = SeedUser("Zara");
+        var pendingUser = SeedUser("Alice");
+
+        SeedSignup(shift, confirmedUser, SignupStatus.Confirmed);
+        SeedSignup(shift, pendingUser, SignupStatus.Pending);
+        await _dbContext.SaveChangesAsync();
+
+        // Act
+        var results = await _service.GetBrowseShiftsAsync(es.Id, includeSignups: true);
+
+        // Assert: Confirmed (Zara) first, then Pending (Alice), regardless of name order
+        var signups = results[0].Signups;
+        signups.Should().HaveCount(2);
+        signups[0].DisplayName.Should().Be("Zara");
+        signups[0].Status.Should().Be(SignupStatus.Confirmed);
+        signups[1].DisplayName.Should().Be("Alice");
+        signups[1].Status.Should().Be(SignupStatus.Pending);
+    }
+
+    [Fact]
+    public async Task GetBrowseShifts_WithoutIncludeSignups_ReturnsEmptySignups()
+    {
+        // Arrange
+        var (es, rota) = SeedRotaScenario(RotaPeriod.Event);
+        var shift = SeedShift(rota, dayOffset: 1);
+        var user = SeedUser("Alice");
+        SeedSignup(shift, user, SignupStatus.Confirmed);
+        await _dbContext.SaveChangesAsync();
+
+        // Act
+        var results = await _service.GetBrowseShiftsAsync(es.Id, includeSignups: false);
+
+        // Assert: signups list is empty even though shift has signups
+        results.Should().HaveCount(1);
+        results[0].Signups.Should().BeEmpty();
+    }
+
+    // ============================================================
     // Helpers
     // ============================================================
+
+    private User SeedUser(string displayName)
+    {
+        var user = new User
+        {
+            Id = Guid.NewGuid(),
+            DisplayName = displayName,
+            UserName = $"{displayName.ToLowerInvariant()}@test.com",
+            Email = $"{displayName.ToLowerInvariant()}@test.com",
+            NormalizedEmail = $"{displayName.ToUpperInvariant()}@TEST.COM",
+            NormalizedUserName = $"{displayName.ToUpperInvariant()}@TEST.COM",
+            CreatedAt = TestNow
+        };
+        _dbContext.Users.Add(user);
+        return user;
+    }
+
+    private Shift SeedShift(Rota rota, int dayOffset)
+    {
+        var shift = new Shift
+        {
+            Id = Guid.NewGuid(),
+            RotaId = rota.Id,
+            DayOffset = dayOffset,
+            StartTime = new LocalTime(8, 0),
+            Duration = Duration.FromHours(4),
+            MinVolunteers = 2,
+            MaxVolunteers = 5,
+            CreatedAt = TestNow,
+            UpdatedAt = TestNow
+        };
+        _dbContext.Shifts.Add(shift);
+        return shift;
+    }
+
+    private void SeedSignup(Shift shift, User user, SignupStatus status)
+    {
+        var signup = new ShiftSignup
+        {
+            Id = Guid.NewGuid(),
+            ShiftId = shift.Id,
+            UserId = user.Id,
+            Status = status,
+            CreatedAt = TestNow,
+            UpdatedAt = TestNow
+        };
+        _dbContext.ShiftSignups.Add(signup);
+    }
 
     private (EventSettings es, Rota rota) SeedRotaScenario(RotaPeriod period)
     {


### PR DESCRIPTION
## Summary
- Coordinators and admins can now see who signed up for each shift inline
- Event shifts show comma-separated name links; Build/Strike shifts show avatar thumbnails
- Confirmed signups shown first, pending shown in muted/italic with "(pending)" label
- Data only fetched and rendered for privileged users — regular volunteers see no change
- Localized in all 5 languages (en, es, de, fr, it)

## Files changed
- **Data layer:** `ShiftSignupInfo` DTO, `UrgentShift` record extended with `Signups`, `GetBrowseShiftsAsync` gains `includeSignups` parameter
- **Controller:** Maps signup data to view models, uses `GetDepartmentsWithRotasAsync` for efficient dropdown
- **Views:** Conditional "Signed Up" column on `/Shifts` (browse) and `/Teams/{slug}/Shifts` (admin)
- **Localization:** `Shifts_SignedUp` and `Shifts_Pending` keys in all 5 `.resx` files
- **Tests:** 3 new tests for signup filtering, ordering, and conditional inclusion

## Test plan
- [ ] As Admin: browse `/Shifts` — "Signed Up" column visible for Event and Build/Strike shifts
- [ ] Event shifts: comma-separated names, confirmed normal weight, pending italic with "(pending)"
- [ ] Build/Strike shifts: avatar thumbnails, confirmed full opacity, pending semi-transparent
- [ ] As Admin: browse `/Teams/{slug}/Shifts` — same signup visibility on admin page
- [ ] As regular volunteer: browse `/Shifts` — no "Signed Up" column visible
- [ ] Verify name links go to `/Human/{userId}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)