### PR TITLE
feat: add in-app feedback system with admin triage and API

### DIFF
--- a/.claude/DATA_MODEL.md
+++ b/.claude/DATA_MODEL.md
@@ -4,7 +4,7 @@
 
 - [Key Entities](#key-entities) | [Relationships](#relationships) | [User Entity](#user-entity) | [Profile Entity](#profile-entity)
 - [Application Entity](#application-entity) | [BoardVote Entity](#boardvote-entity) | [EmailOutboxMessage Entity](#emailoutboxmessage-entity)
-- [Campaign](#campaign-entity) | [CampaignCode](#campaigncode-entity) | [CampaignGrant](#campaigngrant-entity) | [SystemSetting](#systemsetting-entity)
+- [Campaign](#campaign-entity) | [CampaignCode](#campaigncode-entity) | [CampaignGrant](#campaigngrant-entity) | [SystemSetting](#systemsetting-entity) | [FeedbackReport](#feedbackreport-entity)
 - [Enums](#enums): MembershipTier, ConsentCheckStatus, VoteChoice, ApplicationStatus, SystemTeamType, AuditAction, RotaPeriod, RolePeriod
 - [Constants](#constants) | [ContactField Entity](#contactfield-entity) | [Term Lifecycle](#term-lifecycle) | [Camp Enums](#camp-enums)
 
@@ -50,6 +50,7 @@
 | ShiftSignup | Links User to Shift with state machine (Pending/Confirmed/Refused/Bailed/Cancelled/NoShow), optional SignupBlockId for range signups |
 | GeneralAvailability | Per-user per-event day availability (AvailableDayOffsets stored as jsonb) |
 | VolunteerEventProfile | Per-event volunteer profile with skills, dietary, medical data |
+| FeedbackReport | In-app feedback from users (bug reports, feature requests, questions) with screenshot support |
 
 ## Relationships
 
@@ -288,6 +289,33 @@ Key/value store for runtime configuration flags. Currently used for:
 | Key | string | Primary key |
 | Value | string | Setting value |
 
+## FeedbackReport Entity
+
+In-app feedback submitted by authenticated users. Admins triage via the admin UI; Claude Code can manage via the REST API (`/api/feedback`).
+
+| Property | Type | Purpose |
+|----------|------|---------|
+| Id | Guid | Primary key |
+| UserId | Guid | FK → User (reporter) |
+| Category | FeedbackCategory | Bug, FeatureRequest, Question |
+| Description | string | Feedback text (max 5000) |
+| PageUrl | string | URL where feedback was submitted |
+| UserAgent | string? | Browser user agent string |
+| ScreenshotFileName | string? | Original filename |
+| ScreenshotStoragePath | string? | Relative path under wwwroot/uploads/feedback/ |
+| ScreenshotContentType | string? | MIME type (image/jpeg, image/png, image/webp) |
+| Status | FeedbackStatus | Open, Acknowledged, Resolved, WontFix |
+| AdminNotes | string? | Internal notes (max 5000) |
+| GitHubIssueNumber | int? | Linked GitHub issue |
+| AdminResponseSentAt | Instant? | When last response email was sent |
+| CreatedAt | Instant | Submission timestamp |
+| UpdatedAt | Instant | Last modification |
+| ResolvedAt | Instant? | When resolved/won't-fix |
+| ResolvedByUserId | Guid? | FK → User (resolver, SetNull on delete) |
+
+**Table:** `feedback_reports`
+**Indexes:** Status, CreatedAt, UserId
+
 ## Enums
 
 ### MembershipTier
@@ -357,6 +385,24 @@ Includes onboarding redesign actions:
 - `TierApplicationRejected` — Board rejected a tier application
 - `TierDowngraded` — Admin downgraded a member's tier
 - `MembershipsRevokedOnDeletionRequest` — GDPR deletion revoked memberships
+- `FeedbackResponseSent` — Admin sent an email response to a feedback report
+
+### FeedbackCategory
+
+| Value | Description |
+|-------|-------------|
+| Bug | Bug report |
+| FeatureRequest | Feature request |
+| Question | General question |
+
+### FeedbackStatus
+
+| Value | Description |
+|-------|-------------|
+| Open | New, unreviewed |
+| Acknowledged | Admin has seen it |
+| Resolved | Fixed or addressed |
+| WontFix | Will not be addressed |
 
 ### RotaPeriod
 

--- a/docs/features/27-feedback-system.md
+++ b/docs/features/27-feedback-system.md
@@ -1,0 +1,101 @@
+# 27 — Feedback System
+
+## Business Context
+
+Humans need a way to report bugs, request features, and ask questions directly from the app. Admins need a triage dashboard to manage feedback, and Claude Code needs API access to query and manage reports programmatically.
+
+## User Stories
+
+### US-27.1: Submit Feedback
+
+**As** an authenticated human, **I want** to submit feedback from any page, **so that** I can report issues without leaving my current workflow.
+
+**Acceptance Criteria:**
+- Floating feedback button visible on all pages (authenticated users only)
+- Modal form with category (Bug/Feature Request/Question), description, and optional screenshot
+- Page URL and user agent captured automatically
+- Success/error feedback via TempData toast
+- Screenshot upload limited to JPEG/PNG/WebP, max 10MB
+
+### US-27.2: Admin Triage
+
+**As** an Admin, **I want** to view and manage all feedback reports, **so that** I can triage and respond to user issues.
+
+**Acceptance Criteria:**
+- List view at `/Admin/Feedback` with status/category filtering
+- Detail view with full description, screenshot, reporter link, timestamps
+- Update status (Open/Acknowledged/Resolved/Won't Fix)
+- Admin notes (internal, not visible to reporter)
+- Link GitHub issue number
+- Send email response to reporter (via outbox)
+- Accessible from Admin tools page
+
+### US-27.3: API Access
+
+**As** Claude Code (or another external tool), **I want** to query and manage feedback via a REST API, **so that** I can integrate feedback into automated workflows.
+
+**Acceptance Criteria:**
+- `GET /api/feedback` — list with optional status/category/limit filters
+- `GET /api/feedback/{id}` — single report detail
+- `PATCH /api/feedback/{id}/status` — update status
+- `PATCH /api/feedback/{id}/notes` — update admin notes
+- `PATCH /api/feedback/{id}/github-issue` — link GitHub issue
+- `POST /api/feedback/{id}/respond` — send email response
+- All endpoints require `X-Api-Key` header (configured via `FEEDBACK_API_KEY` env var)
+- 503 if API key not configured, 401 if key invalid
+
+### US-27.4: Email Response
+
+**As** an Admin, **I want** to send a response to the feedback reporter via email, **so that** they know their feedback was heard and addressed.
+
+**Acceptance Criteria:**
+- Email sent via outbox pattern (not inline)
+- Localized in reporter's preferred language (en/es/de/fr/it)
+- Includes original description as blockquote
+- `AdminResponseSentAt` timestamp updated
+- Audit log entry created (`FeedbackResponseSent`)
+
+## Data Model
+
+See `.claude/DATA_MODEL.md` — `FeedbackReport` entity.
+
+**Table:** `feedback_reports`
+
+Key fields: Id, UserId, Category (enum→string), Description, PageUrl, UserAgent, Screenshot* (FileName/StoragePath/ContentType), Status (enum→string), AdminNotes, GitHubIssueNumber, AdminResponseSentAt, CreatedAt, UpdatedAt, ResolvedAt, ResolvedByUserId.
+
+**Screenshot storage:** `wwwroot/uploads/feedback/{reportId}/{guid}.{ext}`
+
+## Authorization Matrix
+
+| Endpoint | Auth |
+|----------|------|
+| `POST /Feedback/Submit` | `[Authorize]` (any authenticated user) |
+| `GET /Admin/Feedback` | `[Authorize(Roles = "Admin")]` |
+| `GET /Admin/Feedback/{id}` | `[Authorize(Roles = "Admin")]` |
+| `POST /Admin/Feedback/{id}/*` | `[Authorize(Roles = "Admin")]` |
+| `GET /api/feedback` | API key (`X-Api-Key` header) |
+| `* /api/feedback/*` | API key (`X-Api-Key` header) |
+
+## URL Routes
+
+| Route | Controller | Action |
+|-------|-----------|--------|
+| `POST /Feedback/Submit` | FeedbackController | Submit |
+| `GET /Admin/Feedback` | AdminFeedbackController | Index |
+| `GET /Admin/Feedback/{id}` | AdminFeedbackController | Detail |
+| `POST /Admin/Feedback/{id}/Status` | AdminFeedbackController | UpdateStatus |
+| `POST /Admin/Feedback/{id}/Notes` | AdminFeedbackController | UpdateNotes |
+| `POST /Admin/Feedback/{id}/GitHubIssue` | AdminFeedbackController | SetGitHubIssue |
+| `POST /Admin/Feedback/{id}/Respond` | AdminFeedbackController | SendResponse |
+| `GET /api/feedback` | FeedbackApiController | List |
+| `GET /api/feedback/{id}` | FeedbackApiController | Get |
+| `PATCH /api/feedback/{id}/status` | FeedbackApiController | UpdateStatus |
+| `PATCH /api/feedback/{id}/notes` | FeedbackApiController | UpdateNotes |
+| `PATCH /api/feedback/{id}/github-issue` | FeedbackApiController | SetGitHubIssue |
+| `POST /api/feedback/{id}/respond` | FeedbackApiController | SendResponse |
+
+## Related Features
+
+- Email outbox (`EmailOutboxMessage`) — used for response emails
+- Audit log (`AuditLogEntry`) — tracks response sends
+- Admin tools dashboard — nav link to feedback list

--- a/docs/superpowers/specs/2026-03-18-feedback-system-design.md
+++ b/docs/superpowers/specs/2026-03-18-feedback-system-design.md
@@ -1,0 +1,212 @@
+# In-App Feedback System Design
+
+**Issue:** #141
+**Date:** 2026-03-18
+**Status:** Approved
+
+## Overview
+
+An in-app feedback system allowing authenticated humans to report bugs, request features, and ask questions. Includes an admin triage UI, email responses to reporters, and a JSON API with API key auth for Claude Code integration.
+
+## Data Model
+
+### FeedbackReport Entity
+
+```
+FeedbackReport
+├── Id: Guid
+├── UserId: Guid (FK → User)
+├── Category: FeedbackCategory (enum)
+├── Description: string (5000)
+├── PageUrl: string (2000) — auto-captured current URL
+├── UserAgent: string? (1000) — auto-captured browser info
+├── ScreenshotFileName: string? (256) — original filename
+├── ScreenshotStoragePath: string? (512) — relative path: uploads/feedback/{reportId}/{guid}.ext
+├── ScreenshotContentType: string? (64)
+├── Status: FeedbackStatus (enum)
+├── AdminNotes: string? (5000) — internal notes
+├── GitHubIssueNumber: int? — linked GitHub issue
+├── AdminResponseSentAt: Instant? — last email response timestamp
+├── CreatedAt: Instant
+├── UpdatedAt: Instant — last status/notes change
+├── ResolvedAt: Instant?
+├── ResolvedByUserId: Guid? (FK → User)
+└── Navigation: User, ResolvedByUser
+```
+
+Note: The report `Id` is generated before `SaveChangesAsync` so it can be used in the screenshot storage path (`uploads/feedback/{reportId}/{guid}.ext`).
+
+### Enums
+
+```
+FeedbackCategory:
+  Bug
+  FeatureRequest
+  Question
+
+FeedbackStatus:
+  Open
+  Acknowledged
+  Resolved
+  WontFix
+```
+
+### Storage
+
+- Screenshot files stored on disk at `wwwroot/uploads/feedback/{reportId}/{guid}.ext`
+- Served via standard static file middleware (same pattern as camp images)
+- Allowed types: JPEG, PNG, WebP. Max 10MB.
+- Metadata (filename, path, content type) stored in the entity
+- If a screenshot file is missing on disk, the image tag gracefully degrades (broken image); no special handling needed
+
+## Status Workflow
+
+```
+Open → Acknowledged → Resolved
+                   → WontFix
+```
+
+- New submissions start as `Open`
+- `Acknowledged` = admin has seen it
+- `Resolved` / `WontFix` = terminal states, sets `ResolvedAt` and `ResolvedByUserId`
+- Reopening a resolved report: clears `ResolvedAt` and `ResolvedByUserId`, sets status back to `Open`
+- All status changes update `UpdatedAt`
+
+## UI: Feedback Widget
+
+### Floating Button
+- Fixed-position button in bottom-right corner of every page
+- Only visible to authenticated users (`User.Identity.IsAuthenticated`)
+- Implemented as `FeedbackWidgetViewComponent` invoked in `_Layout.cshtml`
+- Clicking opens a Bootstrap modal
+
+### Footer Link
+- "Feedback" link in the site footer, opens the same modal
+
+### Modal Form
+- Category dropdown (Bug / Feature Request / Question)
+- Description textarea (required, max 5000 chars)
+- File upload input (optional, JPEG/PNG/WebP, max 10MB)
+- Hidden fields auto-populated by JS: current page URL (`window.location.href`), user agent (`navigator.userAgent`)
+- Submit POSTs to `POST /Feedback/Submit`
+- Redirects back to the referring page with TempData success message
+- Full i18n across all 5 locales (en/es/de/fr/it)
+
+## UI: Admin Pages
+
+**Authorization:** Admin role only.
+
+### List Page (`GET /Admin/Feedback`)
+- Table of all feedback reports, newest first
+- Columns: status badge, category badge, description snippet (truncated), reporter name, page URL, date
+- Filter bar: status (Open / Acknowledged / Resolved / Won't Fix / All), category
+- Click row to open detail
+
+### Detail Page (`GET /Admin/Feedback/{id}`)
+- Full description text
+- Screenshot display (if uploaded)
+- Page URL (clickable), user agent, reporter profile link
+- Status dropdown to change status
+- Admin notes textarea (saved on the report)
+- GitHub issue number field (optional, renders as clickable link to `https://github.com/nobodies-collective/Humans/issues/{number}`)
+- "Send Response" section: textarea to compose email to reporter, sends via email outbox
+- Timestamps: submitted, last updated, last response sent
+
+**No localization** on admin pages per coding rules.
+
+## API: Claude Code Integration
+
+### Authentication
+
+New `ApiKeyAuthFilter` — an `IAuthorizationFilter` that checks the `X-Api-Key` header against a configured key. Returns 401 on missing/invalid key. This is new infrastructure (no existing inbound API key pattern in the codebase). The key value is stored in environment variable `FEEDBACK_API_KEY` and loaded via a settings object at DI registration time (same config pattern as TicketTailor, though that's outbound auth).
+
+### Endpoints
+
+| Method | Route | Description |
+|--------|-------|-------------|
+| GET | `/api/feedback` | List reports. Query params: `status`, `category`, `limit` (default 50) |
+| GET | `/api/feedback/{id}` | Single report detail |
+| PATCH | `/api/feedback/{id}/status` | Update status. Body: `{ "status": "Resolved" }` |
+| PATCH | `/api/feedback/{id}/notes` | Update admin notes. Body: `{ "notes": "..." }` |
+| PATCH | `/api/feedback/{id}/github-issue` | Set GitHub issue number. Body: `{ "issueNumber": 141 }` |
+| POST | `/api/feedback/{id}/respond` | Send email to reporter. Body: `{ "message": "..." }` |
+
+### Response Format
+JSON. Report objects include: id, reporter display name, description, category, status, page URL, user agent, admin notes, GitHub issue number, screenshot URL (relative path), timestamps.
+
+No create/delete via API. Submissions come through the web UI only. Reports are never deleted.
+
+## Email Response
+
+- Requires new methods on `IEmailService` (`SendFeedbackResponseAsync`) and `IEmailRenderer` (`RenderFeedbackResponse`) with implementations in `OutboxEmailService` and `EmailRenderer`
+- Localized to reporter's preferred language
+- Subject: "Update on your feedback" (localized)
+- Body: greeting, original description quoted, admin's response message
+- `AdminResponseSentAt` updated on each send
+- Multiple responses allowed over time
+- One-way communication — no reply-to
+
+## Service Layer
+
+### IFeedbackService
+- `SubmitFeedbackAsync(userId, category, description, pageUrl, userAgent, screenshot?)` — creates report (generates Id first), stores screenshot to disk
+- `GetFeedbackByIdAsync(id)` — single report with navigation properties
+- `GetFeedbackListAsync(status?, category?, limit)` — filtered list
+- `UpdateStatusAsync(id, status, actorUserId)` — change status, set/clear resolved fields, update `UpdatedAt`
+- `UpdateAdminNotesAsync(id, notes)` — save admin notes, update `UpdatedAt`
+- `SetGitHubIssueNumberAsync(id, issueNumber)` — link to GitHub issue
+- `SendResponseAsync(id, message, actorUserId)` — compose and queue email response via `IEmailService`
+
+### Audit Logging
+- `AuditAction.FeedbackResponseSent` — logged when email response is sent
+
+## Authorization
+
+| Action | Who |
+|--------|-----|
+| Submit feedback | Any active member (authenticated + ActiveMember claim) |
+| View/manage feedback (admin UI) | Admin only |
+| API access | Valid API key |
+
+Note: `FeedbackController` requires the `ActiveMember` claim (default behavior via `MembershipRequiredFilter`). Users still onboarding cannot submit feedback. The `FeedbackApiController` must be added to `MembershipRequiredFilter.ExemptControllers` since it uses API key auth instead of cookie auth.
+
+## Files Created/Modified
+
+### New Files
+- `src/Humans.Domain/Entities/FeedbackReport.cs`
+- `src/Humans.Domain/Enums/FeedbackCategory.cs`
+- `src/Humans.Domain/Enums/FeedbackStatus.cs`
+- `src/Humans.Infrastructure/Data/Configurations/FeedbackReportConfiguration.cs`
+- `src/Humans.Infrastructure/Services/FeedbackService.cs`
+- `src/Humans.Application/Interfaces/IFeedbackService.cs`
+- `src/Humans.Web/Controllers/FeedbackController.cs` (submission)
+- `src/Humans.Web/Controllers/AdminFeedbackController.cs` (admin UI)
+- `src/Humans.Web/Controllers/FeedbackApiController.cs` (JSON API)
+- `src/Humans.Web/Filters/ApiKeyAuthFilter.cs`
+- `src/Humans.Web/ViewComponents/FeedbackWidgetViewComponent.cs`
+- `src/Humans.Web/Views/Shared/Components/FeedbackWidget/Default.cshtml`
+- `src/Humans.Web/Views/AdminFeedback/Index.cshtml`
+- `src/Humans.Web/Views/AdminFeedback/Detail.cshtml`
+- `src/Humans.Web/Models/FeedbackViewModels.cs`
+- EF migration
+
+### Modified Files
+- `src/Humans.Domain/Enums/AuditAction.cs` — add `FeedbackResponseSent`
+- `src/Humans.Application/Interfaces/IEmailService.cs` — add `SendFeedbackResponseAsync`
+- `src/Humans.Application/Interfaces/IEmailRenderer.cs` — add `RenderFeedbackResponse`
+- `src/Humans.Infrastructure/Services/OutboxEmailService.cs` — implement `SendFeedbackResponseAsync`
+- `src/Humans.Infrastructure/Services/EmailRenderer.cs` — implement `RenderFeedbackResponse`
+- `src/Humans.Web/Views/Shared/_Layout.cshtml` — invoke FeedbackWidgetViewComponent, add footer link
+- `src/Humans.Web/Resources/SharedResource.resx` (+ es/de/fr/it) — widget labels, category names, email template
+- `src/Humans.Web/Extensions/InfrastructureServiceCollectionExtensions.cs` — register services, API key config
+- `src/Humans.Web/Authorization/MembershipRequiredFilter.cs` — add `FeedbackApiController` to exempt list
+- `.claude/DATA_MODEL.md` — add FeedbackReport entity
+- `docs/features/` — new feature spec
+
+## What This Doesn't Do (YAGNI)
+
+- No automated GitHub webhook integration (manual response flow)
+- No user-facing "my feedback history" page
+- No admin notification on new submission
+- No rich text or markdown in feedback descriptions
+- No feedback voting or prioritization

--- a/src/Humans.Application/Humans.Application.csproj
+++ b/src/Humans.Application/Humans.Application.csproj
@@ -5,6 +5,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="NodaTime" />
   </ItemGroup>
 

--- a/src/Humans.Application/Interfaces/IEmailRenderer.cs
+++ b/src/Humans.Application/Interfaces/IEmailRenderer.cs
@@ -86,6 +86,11 @@ public interface IEmailRenderer
     EmailContent RenderBoardDailyDigest(string boardMemberName, string date, IReadOnlyList<BoardDigestTierGroup> tierGroups, BoardDigestOutstandingCounts? outstandingCounts = null, string? culture = null);
 
     /// <summary>
+    /// Feedback response notification.
+    /// </summary>
+    EmailContent RenderFeedbackResponse(string userName, string originalDescription, string responseMessage, string? culture = null);
+
+    /// <summary>
     /// Facilitated message between volunteers.
     /// </summary>
     EmailContent RenderFacilitatedMessage(

--- a/src/Humans.Application/Interfaces/IEmailService.cs
+++ b/src/Humans.Application/Interfaces/IEmailService.cs
@@ -229,6 +229,14 @@ public interface IEmailService
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Sends a feedback response notification to the reporter.
+    /// </summary>
+    Task SendFeedbackResponseAsync(
+        string userEmail, string userName, string originalDescription,
+        string responseMessage, string? culture = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Sends a facilitated message from one volunteer to another.
     /// </summary>
     Task SendFacilitatedMessageAsync(

--- a/src/Humans.Application/Interfaces/IFeedbackService.cs
+++ b/src/Humans.Application/Interfaces/IFeedbackService.cs
@@ -1,0 +1,34 @@
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using Microsoft.AspNetCore.Http;
+
+namespace Humans.Application.Interfaces;
+
+public interface IFeedbackService
+{
+    Task<FeedbackReport> SubmitFeedbackAsync(
+        Guid userId, FeedbackCategory category, string description,
+        string pageUrl, string? userAgent, IFormFile? screenshot,
+        CancellationToken cancellationToken = default);
+
+    Task<FeedbackReport?> GetFeedbackByIdAsync(
+        Guid id, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<FeedbackReport>> GetFeedbackListAsync(
+        FeedbackStatus? status = null, FeedbackCategory? category = null,
+        int limit = 50, CancellationToken cancellationToken = default);
+
+    Task UpdateStatusAsync(
+        Guid id, FeedbackStatus status, Guid actorUserId,
+        CancellationToken cancellationToken = default);
+
+    Task UpdateAdminNotesAsync(
+        Guid id, string? notes, CancellationToken cancellationToken = default);
+
+    Task SetGitHubIssueNumberAsync(
+        Guid id, int? issueNumber, CancellationToken cancellationToken = default);
+
+    Task SendResponseAsync(
+        Guid id, string message, Guid actorUserId,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Humans.Application/Interfaces/IFeedbackService.cs
+++ b/src/Humans.Application/Interfaces/IFeedbackService.cs
@@ -19,7 +19,7 @@ public interface IFeedbackService
         int limit = 50, CancellationToken cancellationToken = default);
 
     Task UpdateStatusAsync(
-        Guid id, FeedbackStatus status, Guid actorUserId,
+        Guid id, FeedbackStatus status, Guid? actorUserId,
         CancellationToken cancellationToken = default);
 
     Task UpdateAdminNotesAsync(
@@ -29,6 +29,6 @@ public interface IFeedbackService
         Guid id, int? issueNumber, CancellationToken cancellationToken = default);
 
     Task SendResponseAsync(
-        Guid id, string message, Guid actorUserId,
+        Guid id, string message, Guid? actorUserId,
         CancellationToken cancellationToken = default);
 }

--- a/src/Humans.Domain/Entities/FeedbackReport.cs
+++ b/src/Humans.Domain/Entities/FeedbackReport.cs
@@ -1,0 +1,33 @@
+using NodaTime;
+using Humans.Domain.Enums;
+
+namespace Humans.Domain.Entities;
+
+public class FeedbackReport
+{
+    public Guid Id { get; init; }
+
+    public Guid UserId { get; init; }
+    public User User { get; set; } = null!;
+
+    public FeedbackCategory Category { get; set; }
+    public string Description { get; set; } = string.Empty;
+    public string PageUrl { get; set; } = string.Empty;
+    public string? UserAgent { get; set; }
+
+    public string? ScreenshotFileName { get; set; }
+    public string? ScreenshotStoragePath { get; set; }
+    public string? ScreenshotContentType { get; set; }
+
+    public FeedbackStatus Status { get; set; } = FeedbackStatus.Open;
+    public string? AdminNotes { get; set; }
+    public int? GitHubIssueNumber { get; set; }
+    public Instant? AdminResponseSentAt { get; set; }
+
+    public Instant CreatedAt { get; init; }
+    public Instant UpdatedAt { get; set; }
+    public Instant? ResolvedAt { get; set; }
+
+    public Guid? ResolvedByUserId { get; set; }
+    public User? ResolvedByUser { get; set; }
+}

--- a/src/Humans.Domain/Enums/AuditAction.cs
+++ b/src/Humans.Domain/Enums/AuditAction.cs
@@ -58,4 +58,5 @@ public enum AuditAction
     ShiftSignupNoShow,
     ShiftSignupCancelled,
     TeamPageContentUpdated,
+    FeedbackResponseSent,
 }

--- a/src/Humans.Domain/Enums/AuditAction.cs
+++ b/src/Humans.Domain/Enums/AuditAction.cs
@@ -59,4 +59,5 @@ public enum AuditAction
     ShiftSignupCancelled,
     TeamPageContentUpdated,
     FeedbackResponseSent,
+    FeedbackStatusChanged,
 }

--- a/src/Humans.Domain/Enums/FeedbackCategory.cs
+++ b/src/Humans.Domain/Enums/FeedbackCategory.cs
@@ -1,0 +1,8 @@
+namespace Humans.Domain.Enums;
+
+public enum FeedbackCategory
+{
+    Bug,
+    FeatureRequest,
+    Question
+}

--- a/src/Humans.Domain/Enums/FeedbackStatus.cs
+++ b/src/Humans.Domain/Enums/FeedbackStatus.cs
@@ -1,0 +1,9 @@
+namespace Humans.Domain.Enums;
+
+public enum FeedbackStatus
+{
+    Open,
+    Acknowledged,
+    Resolved,
+    WontFix
+}

--- a/src/Humans.Infrastructure/Data/Configurations/FeedbackReportConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/FeedbackReportConfiguration.cs
@@ -1,0 +1,65 @@
+using Humans.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Humans.Infrastructure.Data.Configurations;
+
+public class FeedbackReportConfiguration : IEntityTypeConfiguration<FeedbackReport>
+{
+    public void Configure(EntityTypeBuilder<FeedbackReport> builder)
+    {
+        builder.ToTable("feedback_reports");
+
+        builder.HasKey(f => f.Id);
+
+        builder.Property(f => f.Category)
+            .HasConversion<string>()
+            .HasMaxLength(50)
+            .IsRequired();
+
+        builder.Property(f => f.Description)
+            .HasMaxLength(5000)
+            .IsRequired();
+
+        builder.Property(f => f.PageUrl)
+            .HasMaxLength(2000)
+            .IsRequired();
+
+        builder.Property(f => f.UserAgent)
+            .HasMaxLength(1000);
+
+        builder.Property(f => f.ScreenshotFileName)
+            .HasMaxLength(256);
+
+        builder.Property(f => f.ScreenshotStoragePath)
+            .HasMaxLength(512);
+
+        builder.Property(f => f.ScreenshotContentType)
+            .HasMaxLength(64);
+
+        builder.Property(f => f.Status)
+            .HasConversion<string>()
+            .HasMaxLength(50)
+            .IsRequired();
+
+        builder.Property(f => f.AdminNotes)
+            .HasMaxLength(5000);
+
+        builder.Property(f => f.CreatedAt).IsRequired();
+        builder.Property(f => f.UpdatedAt).IsRequired();
+
+        builder.HasOne(f => f.User)
+            .WithMany()
+            .HasForeignKey(f => f.UserId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasOne(f => f.ResolvedByUser)
+            .WithMany()
+            .HasForeignKey(f => f.ResolvedByUserId)
+            .OnDelete(DeleteBehavior.SetNull);
+
+        builder.HasIndex(f => f.Status);
+        builder.HasIndex(f => f.CreatedAt);
+        builder.HasIndex(f => f.UserId);
+    }
+}

--- a/src/Humans.Infrastructure/Data/HumansDbContext.cs
+++ b/src/Humans.Infrastructure/Data/HumansDbContext.cs
@@ -60,6 +60,7 @@ public class HumansDbContext : IdentityDbContext<User, IdentityRole<Guid>, Guid>
     public DbSet<ShiftSignup> ShiftSignups => Set<ShiftSignup>();
     public DbSet<VolunteerEventProfile> VolunteerEventProfiles => Set<VolunteerEventProfile>();
     public DbSet<GeneralAvailability> GeneralAvailability => Set<GeneralAvailability>();
+    public DbSet<FeedbackReport> FeedbackReports => Set<FeedbackReport>();
 
     protected override void OnModelCreating(ModelBuilder builder)
     {

--- a/src/Humans.Infrastructure/Migrations/20260318173147_AddFeedbackReports.Designer.cs
+++ b/src/Humans.Infrastructure/Migrations/20260318173147_AddFeedbackReports.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Humans.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Humans.Infrastructure.Migrations
 {
     [DbContext(typeof(HumansDbContext))]
-    partial class HumansDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260318173147_AddFeedbackReports")]
+    partial class AddFeedbackReports
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Humans.Infrastructure/Migrations/20260318173147_AddFeedbackReports.cs
+++ b/src/Humans.Infrastructure/Migrations/20260318173147_AddFeedbackReports.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NodaTime;
+
+#nullable disable
+
+namespace Humans.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddFeedbackReports : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "feedback_reports",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    UserId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Category = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    Description = table.Column<string>(type: "character varying(5000)", maxLength: 5000, nullable: false),
+                    PageUrl = table.Column<string>(type: "character varying(2000)", maxLength: 2000, nullable: false),
+                    UserAgent = table.Column<string>(type: "character varying(1000)", maxLength: 1000, nullable: true),
+                    ScreenshotFileName = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    ScreenshotStoragePath = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: true),
+                    ScreenshotContentType = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: true),
+                    Status = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    AdminNotes = table.Column<string>(type: "character varying(5000)", maxLength: 5000, nullable: true),
+                    GitHubIssueNumber = table.Column<int>(type: "integer", nullable: true),
+                    AdminResponseSentAt = table.Column<Instant>(type: "timestamp with time zone", nullable: true),
+                    CreatedAt = table.Column<Instant>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<Instant>(type: "timestamp with time zone", nullable: false),
+                    ResolvedAt = table.Column<Instant>(type: "timestamp with time zone", nullable: true),
+                    ResolvedByUserId = table.Column<Guid>(type: "uuid", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_feedback_reports", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_feedback_reports_users_ResolvedByUserId",
+                        column: x => x.ResolvedByUserId,
+                        principalTable: "users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                    table.ForeignKey(
+                        name: "FK_feedback_reports_users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_feedback_reports_CreatedAt",
+                table: "feedback_reports",
+                column: "CreatedAt");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_feedback_reports_ResolvedByUserId",
+                table: "feedback_reports",
+                column: "ResolvedByUserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_feedback_reports_Status",
+                table: "feedback_reports",
+                column: "Status");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_feedback_reports_UserId",
+                table: "feedback_reports",
+                column: "UserId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "feedback_reports");
+        }
+    }
+}

--- a/src/Humans.Infrastructure/Services/EmailRenderer.cs
+++ b/src/Humans.Infrastructure/Services/EmailRenderer.cs
@@ -322,6 +322,21 @@ public class EmailRenderer : IEmailRenderer
         return $"<h3>{HtmlEncode(header)}</h3>\n<ul>\n{string.Join("\n", items)}\n</ul>\n<hr/>";
     }
 
+    public EmailContent RenderFeedbackResponse(string userName, string originalDescription, string responseMessage, string? culture = null)
+    {
+        using (WithCulture(culture))
+        {
+            var subject = _localizer["Email_FeedbackResponse_Subject"].Value;
+            var body = string.Format(
+                CultureInfo.CurrentCulture,
+                _localizer["Email_FeedbackResponse_Body"].Value,
+                HtmlEncode(userName),
+                HtmlEncode(originalDescription),
+                HtmlEncode(responseMessage));
+            return new EmailContent(subject, body);
+        }
+    }
+
     public EmailContent RenderFacilitatedMessage(
         string recipientName,
         string senderName,

--- a/src/Humans.Infrastructure/Services/FeedbackService.cs
+++ b/src/Humans.Infrastructure/Services/FeedbackService.cs
@@ -1,0 +1,215 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using NodaTime;
+using Humans.Application.Interfaces;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using Humans.Infrastructure.Data;
+
+namespace Humans.Infrastructure.Services;
+
+public class FeedbackService : IFeedbackService
+{
+    private readonly HumansDbContext _dbContext;
+    private readonly IEmailService _emailService;
+    private readonly IAuditLogService _auditLogService;
+    private readonly IClock _clock;
+    private readonly IHostEnvironment _env;
+    private readonly ILogger<FeedbackService> _logger;
+
+    private static readonly HashSet<string> AllowedContentTypes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "image/jpeg", "image/png", "image/webp"
+    };
+
+    private const long MaxScreenshotBytes = 10 * 1024 * 1024; // 10MB
+
+    public FeedbackService(
+        HumansDbContext dbContext,
+        IEmailService emailService,
+        IAuditLogService auditLogService,
+        IClock clock,
+        IHostEnvironment env,
+        ILogger<FeedbackService> logger)
+    {
+        _dbContext = dbContext;
+        _emailService = emailService;
+        _auditLogService = auditLogService;
+        _clock = clock;
+        _env = env;
+        _logger = logger;
+    }
+
+    public async Task<FeedbackReport> SubmitFeedbackAsync(
+        Guid userId, FeedbackCategory category, string description,
+        string pageUrl, string? userAgent, IFormFile? screenshot,
+        CancellationToken cancellationToken = default)
+    {
+        var now = _clock.GetCurrentInstant();
+        var reportId = Guid.NewGuid();
+
+        var report = new FeedbackReport
+        {
+            Id = reportId,
+            UserId = userId,
+            Category = category,
+            Description = description,
+            PageUrl = pageUrl,
+            UserAgent = userAgent,
+            Status = FeedbackStatus.Open,
+            CreatedAt = now,
+            UpdatedAt = now
+        };
+
+        // Handle screenshot upload
+        if (screenshot is { Length: > 0 })
+        {
+            if (screenshot.Length > MaxScreenshotBytes)
+                throw new InvalidOperationException("Screenshot must be under 10MB.");
+
+            if (!AllowedContentTypes.Contains(screenshot.ContentType))
+                throw new InvalidOperationException("Screenshot must be JPEG, PNG, or WebP.");
+
+            var ext = screenshot.ContentType switch
+            {
+                "image/jpeg" => ".jpg",
+                "image/png" => ".png",
+                "image/webp" => ".webp",
+                _ => ".bin"
+            };
+
+            var fileName = $"{Guid.NewGuid()}{ext}";
+            var relativePath = Path.Combine("uploads", "feedback", reportId.ToString(), fileName);
+            var absolutePath = Path.Combine(_env.ContentRootPath, "wwwroot", relativePath);
+
+            Directory.CreateDirectory(Path.GetDirectoryName(absolutePath)!);
+
+            await using var stream = new FileStream(absolutePath, FileMode.Create);
+            await screenshot.CopyToAsync(stream, cancellationToken);
+
+            report.ScreenshotFileName = screenshot.FileName;
+            report.ScreenshotStoragePath = relativePath.Replace('\\', '/');
+            report.ScreenshotContentType = screenshot.ContentType;
+        }
+
+        _dbContext.FeedbackReports.Add(report);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        _logger.LogInformation("Feedback {ReportId} submitted by {UserId}: {Category}", reportId, userId, category);
+
+        return report;
+    }
+
+    public async Task<FeedbackReport?> GetFeedbackByIdAsync(
+        Guid id, CancellationToken cancellationToken = default)
+    {
+        return await _dbContext.FeedbackReports
+            .Include(f => f.User)
+            .Include(f => f.ResolvedByUser)
+            .FirstOrDefaultAsync(f => f.Id == id, cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<FeedbackReport>> GetFeedbackListAsync(
+        FeedbackStatus? status = null, FeedbackCategory? category = null,
+        int limit = 50, CancellationToken cancellationToken = default)
+    {
+        var query = _dbContext.FeedbackReports
+            .Include(f => f.User)
+            .AsQueryable();
+
+        if (status.HasValue)
+            query = query.Where(f => f.Status == status.Value);
+
+        if (category.HasValue)
+            query = query.Where(f => f.Category == category.Value);
+
+        return await query
+            .OrderByDescending(f => f.CreatedAt)
+            .Take(limit)
+            .AsNoTracking()
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task UpdateStatusAsync(
+        Guid id, FeedbackStatus status, Guid actorUserId,
+        CancellationToken cancellationToken = default)
+    {
+        var report = await _dbContext.FeedbackReports.FindAsync(new object[] { id }, cancellationToken)
+            ?? throw new InvalidOperationException($"Feedback report {id} not found");
+
+        var now = _clock.GetCurrentInstant();
+        report.Status = status;
+        report.UpdatedAt = now;
+
+        if (status is FeedbackStatus.Resolved or FeedbackStatus.WontFix)
+        {
+            report.ResolvedAt = now;
+            report.ResolvedByUserId = actorUserId;
+        }
+        else
+        {
+            // Reopening — clear resolved fields
+            report.ResolvedAt = null;
+            report.ResolvedByUserId = null;
+        }
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        _logger.LogInformation("Feedback {ReportId} status changed to {Status} by {ActorId}", id, status, actorUserId);
+    }
+
+    public async Task UpdateAdminNotesAsync(
+        Guid id, string? notes, CancellationToken cancellationToken = default)
+    {
+        var report = await _dbContext.FeedbackReports.FindAsync(new object[] { id }, cancellationToken)
+            ?? throw new InvalidOperationException($"Feedback report {id} not found");
+
+        report.AdminNotes = notes;
+        report.UpdatedAt = _clock.GetCurrentInstant();
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task SetGitHubIssueNumberAsync(
+        Guid id, int? issueNumber, CancellationToken cancellationToken = default)
+    {
+        var report = await _dbContext.FeedbackReports.FindAsync(new object[] { id }, cancellationToken)
+            ?? throw new InvalidOperationException($"Feedback report {id} not found");
+
+        report.GitHubIssueNumber = issueNumber;
+        report.UpdatedAt = _clock.GetCurrentInstant();
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task SendResponseAsync(
+        Guid id, string message, Guid actorUserId,
+        CancellationToken cancellationToken = default)
+    {
+        var report = await _dbContext.FeedbackReports
+            .Include(f => f.User)
+            .FirstOrDefaultAsync(f => f.Id == id, cancellationToken)
+            ?? throw new InvalidOperationException($"Feedback report {id} not found");
+
+        var user = report.User;
+
+        await _emailService.SendFeedbackResponseAsync(
+            user.Email!, user.DisplayName,
+            report.Description, message,
+            user.PreferredLanguage, cancellationToken);
+
+        report.AdminResponseSentAt = _clock.GetCurrentInstant();
+        report.UpdatedAt = report.AdminResponseSentAt.Value;
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        var actor = await _dbContext.Users.FindAsync(new object[] { actorUserId }, cancellationToken);
+        await _auditLogService.LogAsync(
+            AuditAction.FeedbackResponseSent, nameof(FeedbackReport), id,
+            $"Response sent to {user.DisplayName} for feedback {id}",
+            actorUserId, actor?.DisplayName ?? actorUserId.ToString());
+
+        _logger.LogInformation("Feedback response sent for {ReportId} by {ActorId}", id, actorUserId);
+    }
+}

--- a/src/Humans.Infrastructure/Services/FeedbackService.cs
+++ b/src/Humans.Infrastructure/Services/FeedbackService.cs
@@ -77,7 +77,7 @@ public class FeedbackService : IFeedbackService
                 "image/jpeg" => ".jpg",
                 "image/png" => ".png",
                 "image/webp" => ".webp",
-                _ => ".bin"
+                _ => throw new InvalidOperationException($"Unexpected content type: {screenshot.ContentType}")
             };
 
             var fileName = $"{Guid.NewGuid()}{ext}";
@@ -133,7 +133,7 @@ public class FeedbackService : IFeedbackService
     }
 
     public async Task UpdateStatusAsync(
-        Guid id, FeedbackStatus status, Guid actorUserId,
+        Guid id, FeedbackStatus status, Guid? actorUserId,
         CancellationToken cancellationToken = default)
     {
         var report = await _dbContext.FeedbackReports.FindAsync(new object[] { id }, cancellationToken)
@@ -156,6 +156,18 @@ public class FeedbackService : IFeedbackService
         }
 
         await _dbContext.SaveChangesAsync(cancellationToken);
+
+        string actorName = "API";
+        if (actorUserId.HasValue)
+        {
+            var actor = await _dbContext.Users.FindAsync(new object[] { actorUserId.Value }, cancellationToken);
+            actorName = actor?.DisplayName ?? actorUserId.Value.ToString();
+        }
+
+        await _auditLogService.LogAsync(
+            AuditAction.FeedbackStatusChanged, nameof(FeedbackReport), id,
+            $"Feedback {id} status changed to {status}",
+            actorUserId ?? Guid.Empty, actorName);
 
         _logger.LogInformation("Feedback {ReportId} status changed to {Status} by {ActorId}", id, status, actorUserId);
     }
@@ -185,7 +197,7 @@ public class FeedbackService : IFeedbackService
     }
 
     public async Task SendResponseAsync(
-        Guid id, string message, Guid actorUserId,
+        Guid id, string message, Guid? actorUserId,
         CancellationToken cancellationToken = default)
     {
         var report = await _dbContext.FeedbackReports
@@ -204,11 +216,17 @@ public class FeedbackService : IFeedbackService
         report.UpdatedAt = report.AdminResponseSentAt.Value;
         await _dbContext.SaveChangesAsync(cancellationToken);
 
-        var actor = await _dbContext.Users.FindAsync(new object[] { actorUserId }, cancellationToken);
+        string actorName = "API";
+        if (actorUserId.HasValue)
+        {
+            var actor = await _dbContext.Users.FindAsync(new object[] { actorUserId.Value }, cancellationToken);
+            actorName = actor?.DisplayName ?? actorUserId.Value.ToString();
+        }
+
         await _auditLogService.LogAsync(
             AuditAction.FeedbackResponseSent, nameof(FeedbackReport), id,
             $"Response sent to {user.DisplayName} for feedback {id}",
-            actorUserId, actor?.DisplayName ?? actorUserId.ToString());
+            actorUserId ?? Guid.Empty, actorName);
 
         _logger.LogInformation("Feedback response sent for {ReportId} by {ActorId}", id, actorUserId);
     }

--- a/src/Humans.Infrastructure/Services/OutboxEmailService.cs
+++ b/src/Humans.Infrastructure/Services/OutboxEmailService.cs
@@ -229,6 +229,16 @@ public class OutboxEmailService : IEmailService
     }
 
     /// <inheritdoc />
+    public async Task SendFeedbackResponseAsync(
+        string userEmail, string userName, string originalDescription,
+        string responseMessage, string? culture = null,
+        CancellationToken cancellationToken = default)
+    {
+        var content = _renderer.RenderFeedbackResponse(userName, originalDescription, responseMessage, culture);
+        await EnqueueAsync(userEmail, userName, content, "feedback_response", cancellationToken);
+    }
+
+    /// <inheritdoc />
     public async Task SendFacilitatedMessageAsync(
         string recipientEmail,
         string recipientName,

--- a/src/Humans.Infrastructure/Services/SmtpEmailService.cs
+++ b/src/Humans.Infrastructure/Services/SmtpEmailService.cs
@@ -228,6 +228,16 @@ public class SmtpEmailService : IEmailService
     }
 
     /// <inheritdoc />
+    public async Task SendFeedbackResponseAsync(
+        string userEmail, string userName, string originalDescription,
+        string responseMessage, string? culture = null,
+        CancellationToken cancellationToken = default)
+    {
+        var content = _renderer.RenderFeedbackResponse(userName, originalDescription, responseMessage, culture);
+        await SendEmailAsync(userEmail, content.Subject, content.HtmlBody, null, cancellationToken);
+        _metrics.RecordEmailSent("feedback_response");
+    }
+
     public async Task SendFacilitatedMessageAsync(
         string recipientEmail,
         string recipientName,

--- a/src/Humans.Infrastructure/Services/StubEmailService.cs
+++ b/src/Humans.Infrastructure/Services/StubEmailService.cs
@@ -205,6 +205,17 @@ public class StubEmailService : IEmailService
         return Task.CompletedTask;
     }
 
+    public Task SendFeedbackResponseAsync(
+        string userEmail, string userName, string originalDescription,
+        string responseMessage, string? culture = null,
+        CancellationToken cancellationToken = default)
+    {
+        _logger.LogInformation(
+            "[STUB] Would send feedback response to {Email} ({UserName}) [Culture: {Culture}]",
+            userEmail, userName, culture);
+        return Task.CompletedTask;
+    }
+
     public Task SendFacilitatedMessageAsync(
         string recipientEmail,
         string recipientName,

--- a/src/Humans.Web/Authorization/MembershipRequiredFilter.cs
+++ b/src/Humans.Web/Authorization/MembershipRequiredFilter.cs
@@ -27,6 +27,7 @@ public class MembershipRequiredFilter : IAsyncActionFilter
         "Camp",             // Public camps pages ([AllowAnonymous])
         "CampAdmin",        // Has its own Roles = "CampAdmin,Admin" gate
         "CampApi",          // Public API ([AllowAnonymous])
+        "Feedback",         // Feedback submission — accessible to all authenticated users
         "FeedbackApi",      // API key auth, no membership required
     };
 

--- a/src/Humans.Web/Authorization/MembershipRequiredFilter.cs
+++ b/src/Humans.Web/Authorization/MembershipRequiredFilter.cs
@@ -27,6 +27,7 @@ public class MembershipRequiredFilter : IAsyncActionFilter
         "Camp",             // Public camps pages ([AllowAnonymous])
         "CampAdmin",        // Has its own Roles = "CampAdmin,Admin" gate
         "CampApi",          // Public API ([AllowAnonymous])
+        "FeedbackApi",      // API key auth, no membership required
     };
 
     public Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)

--- a/src/Humans.Web/Controllers/AdminFeedbackController.cs
+++ b/src/Humans.Web/Controllers/AdminFeedbackController.cs
@@ -1,0 +1,132 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Humans.Application.Interfaces;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using Humans.Web.Models;
+
+namespace Humans.Web.Controllers;
+
+[Authorize(Roles = "Admin")]
+[Route("Admin/Feedback")]
+public class AdminFeedbackController : Controller
+{
+    private readonly IFeedbackService _feedbackService;
+    private readonly UserManager<User> _userManager;
+    private readonly ILogger<AdminFeedbackController> _logger;
+
+    public AdminFeedbackController(
+        IFeedbackService feedbackService,
+        UserManager<User> userManager,
+        ILogger<AdminFeedbackController> logger)
+    {
+        _feedbackService = feedbackService;
+        _userManager = userManager;
+        _logger = logger;
+    }
+
+    [HttpGet("")]
+    public async Task<IActionResult> Index(FeedbackStatus? status, FeedbackCategory? category)
+    {
+        var reports = await _feedbackService.GetFeedbackListAsync(status, category);
+
+        var viewModel = new FeedbackListViewModel
+        {
+            StatusFilter = status,
+            CategoryFilter = category,
+            Reports = reports.Select(r => new FeedbackListItemViewModel
+            {
+                Id = r.Id,
+                Category = r.Category,
+                Status = r.Status,
+                Description = r.Description.Length > 100 ? r.Description[..100] + "..." : r.Description,
+                ReporterName = r.User.DisplayName,
+                ReporterUserId = r.UserId,
+                PageUrl = r.PageUrl,
+                CreatedAt = r.CreatedAt.ToDateTimeUtc(),
+                HasScreenshot = r.ScreenshotStoragePath != null
+            }).ToList()
+        };
+
+        return View(viewModel);
+    }
+
+    [HttpGet("{id}")]
+    public async Task<IActionResult> Detail(Guid id)
+    {
+        var report = await _feedbackService.GetFeedbackByIdAsync(id);
+        if (report == null)
+            return NotFound();
+
+        var viewModel = new FeedbackDetailViewModel
+        {
+            Id = report.Id,
+            Category = report.Category,
+            Status = report.Status,
+            Description = report.Description,
+            PageUrl = report.PageUrl,
+            UserAgent = report.UserAgent,
+            ScreenshotUrl = report.ScreenshotStoragePath != null ? $"/{report.ScreenshotStoragePath}" : null,
+            ReporterName = report.User.DisplayName,
+            ReporterUserId = report.UserId,
+            AdminNotes = report.AdminNotes,
+            GitHubIssueNumber = report.GitHubIssueNumber,
+            CreatedAt = report.CreatedAt.ToDateTimeUtc(),
+            UpdatedAt = report.UpdatedAt.ToDateTimeUtc(),
+            AdminResponseSentAt = report.AdminResponseSentAt?.ToDateTimeUtc(),
+            ResolvedAt = report.ResolvedAt?.ToDateTimeUtc(),
+            ResolvedByName = report.ResolvedByUser?.DisplayName
+        };
+
+        return View(viewModel);
+    }
+
+    [HttpPost("{id}/Status")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> UpdateStatus(Guid id, UpdateFeedbackStatusModel model)
+    {
+        var user = await _userManager.GetUserAsync(User);
+        if (user == null) return NotFound();
+
+        await _feedbackService.UpdateStatusAsync(id, model.Status, user.Id);
+        TempData["SuccessMessage"] = "Status updated.";
+        return RedirectToAction(nameof(Detail), new { id });
+    }
+
+    [HttpPost("{id}/Notes")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> UpdateNotes(Guid id, UpdateFeedbackNotesModel model)
+    {
+        await _feedbackService.UpdateAdminNotesAsync(id, model.Notes);
+        TempData["SuccessMessage"] = "Notes saved.";
+        return RedirectToAction(nameof(Detail), new { id });
+    }
+
+    [HttpPost("{id}/GitHubIssue")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> SetGitHubIssue(Guid id, SetGitHubIssueModel model)
+    {
+        await _feedbackService.SetGitHubIssueNumberAsync(id, model.IssueNumber);
+        TempData["SuccessMessage"] = "GitHub issue linked.";
+        return RedirectToAction(nameof(Detail), new { id });
+    }
+
+    [HttpPost("{id}/Respond")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> SendResponse(Guid id, SendFeedbackResponseModel model)
+    {
+        if (!ModelState.IsValid)
+        {
+            TempData["ErrorMessage"] = "Response message is required.";
+            return RedirectToAction(nameof(Detail), new { id });
+        }
+
+        var user = await _userManager.GetUserAsync(User);
+        if (user == null) return NotFound();
+
+        await _feedbackService.SendResponseAsync(id, model.Message, user.Id);
+        TempData["SuccessMessage"] = "Response sent.";
+        return RedirectToAction(nameof(Detail), new { id });
+    }
+}

--- a/src/Humans.Web/Controllers/FeedbackApiController.cs
+++ b/src/Humans.Web/Controllers/FeedbackApiController.cs
@@ -1,0 +1,110 @@
+using Microsoft.AspNetCore.Mvc;
+using Humans.Application.Interfaces;
+using Humans.Domain.Enums;
+using Humans.Web.Filters;
+using Humans.Web.Models;
+
+namespace Humans.Web.Controllers;
+
+[ApiController]
+[Route("api/feedback")]
+[ServiceFilter(typeof(ApiKeyAuthFilter))]
+public class FeedbackApiController : ControllerBase
+{
+    private readonly IFeedbackService _feedbackService;
+
+    public FeedbackApiController(IFeedbackService feedbackService)
+    {
+        _feedbackService = feedbackService;
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> List(
+        [FromQuery] FeedbackStatus? status,
+        [FromQuery] FeedbackCategory? category,
+        [FromQuery] int limit = 50)
+    {
+        var reports = await _feedbackService.GetFeedbackListAsync(status, category, limit);
+
+        var result = reports.Select(r => new
+        {
+            r.Id,
+            Category = r.Category.ToString(),
+            Status = r.Status.ToString(),
+            r.Description,
+            r.PageUrl,
+            r.UserAgent,
+            ReporterName = r.User.DisplayName,
+            ReporterUserId = r.UserId,
+            r.AdminNotes,
+            r.GitHubIssueNumber,
+            ScreenshotUrl = r.ScreenshotStoragePath != null ? $"/{r.ScreenshotStoragePath}" : null,
+            CreatedAt = r.CreatedAt.ToDateTimeUtc(),
+            UpdatedAt = r.UpdatedAt.ToDateTimeUtc(),
+            AdminResponseSentAt = r.AdminResponseSentAt?.ToDateTimeUtc(),
+            ResolvedAt = r.ResolvedAt?.ToDateTimeUtc(),
+            ResolvedByName = r.ResolvedByUser?.DisplayName
+        });
+
+        return Ok(result);
+    }
+
+    [HttpGet("{id}")]
+    public async Task<IActionResult> Get(Guid id)
+    {
+        var r = await _feedbackService.GetFeedbackByIdAsync(id);
+        if (r == null) return NotFound();
+
+        return Ok(new
+        {
+            r.Id,
+            Category = r.Category.ToString(),
+            Status = r.Status.ToString(),
+            r.Description,
+            r.PageUrl,
+            r.UserAgent,
+            ReporterName = r.User.DisplayName,
+            ReporterUserId = r.UserId,
+            r.AdminNotes,
+            r.GitHubIssueNumber,
+            ScreenshotUrl = r.ScreenshotStoragePath != null ? $"/{r.ScreenshotStoragePath}" : null,
+            CreatedAt = r.CreatedAt.ToDateTimeUtc(),
+            UpdatedAt = r.UpdatedAt.ToDateTimeUtc(),
+            AdminResponseSentAt = r.AdminResponseSentAt?.ToDateTimeUtc(),
+            ResolvedAt = r.ResolvedAt?.ToDateTimeUtc(),
+            ResolvedByName = r.ResolvedByUser?.DisplayName
+        });
+    }
+
+    [HttpPatch("{id}/status")]
+    public async Task<IActionResult> UpdateStatus(Guid id, [FromBody] UpdateFeedbackStatusModel model)
+    {
+        // API has no user context — use empty GUID as actor
+        await _feedbackService.UpdateStatusAsync(id, model.Status, Guid.Empty);
+        return Ok(new { success = true });
+    }
+
+    [HttpPatch("{id}/notes")]
+    public async Task<IActionResult> UpdateNotes(Guid id, [FromBody] UpdateFeedbackNotesModel model)
+    {
+        await _feedbackService.UpdateAdminNotesAsync(id, model.Notes);
+        return Ok(new { success = true });
+    }
+
+    [HttpPatch("{id}/github-issue")]
+    public async Task<IActionResult> SetGitHubIssue(Guid id, [FromBody] SetGitHubIssueModel model)
+    {
+        await _feedbackService.SetGitHubIssueNumberAsync(id, model.IssueNumber);
+        return Ok(new { success = true });
+    }
+
+    [HttpPost("{id}/respond")]
+    public async Task<IActionResult> SendResponse(Guid id, [FromBody] SendFeedbackResponseModel model)
+    {
+        if (!ModelState.IsValid)
+            return BadRequest(ModelState);
+
+        await _feedbackService.SendResponseAsync(id, model.Message, Guid.Empty);
+        return Ok(new { success = true });
+    }
+}

--- a/src/Humans.Web/Controllers/FeedbackApiController.cs
+++ b/src/Humans.Web/Controllers/FeedbackApiController.cs
@@ -79,8 +79,8 @@ public class FeedbackApiController : ControllerBase
     [HttpPatch("{id}/status")]
     public async Task<IActionResult> UpdateStatus(Guid id, [FromBody] UpdateFeedbackStatusModel model)
     {
-        // API has no user context — use empty GUID as actor
-        await _feedbackService.UpdateStatusAsync(id, model.Status, Guid.Empty);
+        // API has no user context — pass null actor
+        await _feedbackService.UpdateStatusAsync(id, model.Status, null);
         return Ok(new { success = true });
     }
 
@@ -104,7 +104,7 @@ public class FeedbackApiController : ControllerBase
         if (!ModelState.IsValid)
             return BadRequest(ModelState);
 
-        await _feedbackService.SendResponseAsync(id, model.Message, Guid.Empty);
+        await _feedbackService.SendResponseAsync(id, model.Message, null);
         return Ok(new { success = true });
     }
 }

--- a/src/Humans.Web/Controllers/FeedbackController.cs
+++ b/src/Humans.Web/Controllers/FeedbackController.cs
@@ -40,7 +40,7 @@ public class FeedbackController : Controller
         if (!ModelState.IsValid)
         {
             TempData["ErrorMessage"] = _localizer["Feedback_Error"].Value;
-            return Redirect(model.PageUrl ?? "/");
+            return LocalRedirect(Url.IsLocalUrl(model.PageUrl) ? model.PageUrl : "/");
         }
 
         try
@@ -57,6 +57,6 @@ public class FeedbackController : Controller
             TempData["ErrorMessage"] = _localizer["Feedback_Error"].Value;
         }
 
-        return Redirect(model.PageUrl ?? "/");
+        return LocalRedirect(Url.IsLocalUrl(model.PageUrl) ? model.PageUrl : "/");
     }
 }

--- a/src/Humans.Web/Controllers/FeedbackController.cs
+++ b/src/Humans.Web/Controllers/FeedbackController.cs
@@ -1,0 +1,62 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Localization;
+using Humans.Application.Interfaces;
+using Humans.Domain.Entities;
+using Humans.Web.Models;
+
+namespace Humans.Web.Controllers;
+
+[Authorize]
+[Route("Feedback")]
+public class FeedbackController : Controller
+{
+    private readonly IFeedbackService _feedbackService;
+    private readonly UserManager<User> _userManager;
+    private readonly IStringLocalizer<SharedResource> _localizer;
+    private readonly ILogger<FeedbackController> _logger;
+
+    public FeedbackController(
+        IFeedbackService feedbackService,
+        UserManager<User> userManager,
+        IStringLocalizer<SharedResource> localizer,
+        ILogger<FeedbackController> logger)
+    {
+        _feedbackService = feedbackService;
+        _userManager = userManager;
+        _localizer = localizer;
+        _logger = logger;
+    }
+
+    [HttpPost("Submit")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Submit(SubmitFeedbackViewModel model)
+    {
+        var user = await _userManager.GetUserAsync(User);
+        if (user == null)
+            return NotFound();
+
+        if (!ModelState.IsValid)
+        {
+            TempData["ErrorMessage"] = _localizer["Feedback_Error"].Value;
+            return Redirect(model.PageUrl ?? "/");
+        }
+
+        try
+        {
+            await _feedbackService.SubmitFeedbackAsync(
+                user.Id, model.Category, model.Description,
+                model.PageUrl, model.UserAgent, model.Screenshot);
+
+            TempData["SuccessMessage"] = _localizer["Feedback_Submitted"].Value;
+        }
+        catch (InvalidOperationException ex)
+        {
+            _logger.LogWarning(ex, "Feedback submission failed for user {UserId}", user.Id);
+            TempData["ErrorMessage"] = _localizer["Feedback_Error"].Value;
+        }
+
+        return Redirect(model.PageUrl ?? "/");
+    }
+}

--- a/src/Humans.Web/Extensions/InfrastructureServiceCollectionExtensions.cs
+++ b/src/Humans.Web/Extensions/InfrastructureServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@ using Humans.Application.Interfaces;
 using Humans.Infrastructure.Configuration;
 using Humans.Infrastructure.Jobs;
 using Humans.Infrastructure.Services;
+using Humans.Web.Filters;
 
 namespace Humans.Web.Extensions;
 
@@ -97,6 +98,13 @@ public static class InfrastructureServiceCollectionExtensions
         services.AddScoped<IShiftManagementService, ShiftManagementService>();
         services.AddScoped<IShiftSignupService, ShiftSignupService>();
         services.AddScoped<IGeneralAvailabilityService, GeneralAvailabilityService>();
+
+        // Feedback API key
+        services.Configure<FeedbackApiSettings>(opts =>
+        {
+            opts.ApiKey = Environment.GetEnvironmentVariable("FEEDBACK_API_KEY") ?? string.Empty;
+        });
+        services.AddScoped<ApiKeyAuthFilter>();
 
         // Ticket vendor integration
         services.Configure<TicketVendorSettings>(opts =>

--- a/src/Humans.Web/Extensions/InfrastructureServiceCollectionExtensions.cs
+++ b/src/Humans.Web/Extensions/InfrastructureServiceCollectionExtensions.cs
@@ -75,6 +75,7 @@ public static class InfrastructureServiceCollectionExtensions
         services.AddScoped<IMembershipCalculator, MembershipCalculator>();
         services.AddScoped<IRoleAssignmentService, RoleAssignmentService>();
         services.AddScoped<IAuditLogService, AuditLogService>();
+        services.AddScoped<IFeedbackService, FeedbackService>();
         services.AddScoped<IApplicationDecisionService, ApplicationDecisionService>();
         services.AddScoped<IOnboardingService, OnboardingService>();
         services.AddScoped<IConsentService, ConsentService>();

--- a/src/Humans.Web/Filters/ApiKeyAuthFilter.cs
+++ b/src/Humans.Web/Filters/ApiKeyAuthFilter.cs
@@ -1,0 +1,37 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.Options;
+
+namespace Humans.Web.Filters;
+
+public class FeedbackApiSettings
+{
+    public const string SectionName = "FeedbackApi";
+    public string ApiKey { get; set; } = string.Empty;
+}
+
+public class ApiKeyAuthFilter : IAuthorizationFilter
+{
+    private const string ApiKeyHeaderName = "X-Api-Key";
+    private readonly string _apiKey;
+
+    public ApiKeyAuthFilter(IOptions<FeedbackApiSettings> settings)
+    {
+        _apiKey = settings.Value.ApiKey;
+    }
+
+    public void OnAuthorization(AuthorizationFilterContext context)
+    {
+        if (string.IsNullOrEmpty(_apiKey))
+        {
+            context.Result = new StatusCodeResult(503); // Not configured
+            return;
+        }
+
+        if (!context.HttpContext.Request.Headers.TryGetValue(ApiKeyHeaderName, out var providedKey)
+            || !string.Equals(providedKey, _apiKey, StringComparison.Ordinal))
+        {
+            context.Result = new UnauthorizedResult(); // 401
+        }
+    }
+}

--- a/src/Humans.Web/Models/FeedbackViewModels.cs
+++ b/src/Humans.Web/Models/FeedbackViewModels.cs
@@ -12,7 +12,10 @@ public class SubmitFeedbackViewModel
     [StringLength(5000)]
     public string Description { get; set; } = string.Empty;
 
+    [StringLength(2000)]
     public string PageUrl { get; set; } = string.Empty;
+
+    [StringLength(1000)]
     public string? UserAgent { get; set; }
 
     public IFormFile? Screenshot { get; set; }

--- a/src/Humans.Web/Models/FeedbackViewModels.cs
+++ b/src/Humans.Web/Models/FeedbackViewModels.cs
@@ -1,0 +1,83 @@
+using System.ComponentModel.DataAnnotations;
+using Humans.Domain.Enums;
+
+namespace Humans.Web.Models;
+
+public class SubmitFeedbackViewModel
+{
+    [Required]
+    public FeedbackCategory Category { get; set; }
+
+    [Required]
+    [StringLength(5000)]
+    public string Description { get; set; } = string.Empty;
+
+    public string PageUrl { get; set; } = string.Empty;
+    public string? UserAgent { get; set; }
+
+    public IFormFile? Screenshot { get; set; }
+}
+
+public class FeedbackListViewModel
+{
+    public List<FeedbackListItemViewModel> Reports { get; set; } = [];
+    public FeedbackStatus? StatusFilter { get; set; }
+    public FeedbackCategory? CategoryFilter { get; set; }
+}
+
+public class FeedbackListItemViewModel
+{
+    public Guid Id { get; set; }
+    public FeedbackCategory Category { get; set; }
+    public FeedbackStatus Status { get; set; }
+    public string Description { get; set; } = string.Empty;
+    public string ReporterName { get; set; } = string.Empty;
+    public Guid ReporterUserId { get; set; }
+    public string PageUrl { get; set; } = string.Empty;
+    public DateTime CreatedAt { get; set; }
+    public bool HasScreenshot { get; set; }
+}
+
+public class FeedbackDetailViewModel
+{
+    public Guid Id { get; set; }
+    public FeedbackCategory Category { get; set; }
+    public FeedbackStatus Status { get; set; }
+    public string Description { get; set; } = string.Empty;
+    public string PageUrl { get; set; } = string.Empty;
+    public string? UserAgent { get; set; }
+    public string? ScreenshotUrl { get; set; }
+    public string ReporterName { get; set; } = string.Empty;
+    public Guid ReporterUserId { get; set; }
+    public string? AdminNotes { get; set; }
+    public int? GitHubIssueNumber { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+    public DateTime? AdminResponseSentAt { get; set; }
+    public DateTime? ResolvedAt { get; set; }
+    public string? ResolvedByName { get; set; }
+}
+
+public class UpdateFeedbackStatusModel
+{
+    [Required]
+    public FeedbackStatus Status { get; set; }
+}
+
+public class UpdateFeedbackNotesModel
+{
+    [StringLength(5000)]
+    public string? Notes { get; set; }
+}
+
+public class SetGitHubIssueModel
+{
+    public int? IssueNumber { get; set; }
+}
+
+public class SendFeedbackResponseModel
+{
+    [Required]
+    [StringLength(5000)]
+    public string Message { get; set; } = string.Empty;
+}

--- a/src/Humans.Web/Resources/SharedResource.de.resx
+++ b/src/Humans.Web/Resources/SharedResource.de.resx
@@ -1144,4 +1144,15 @@
   <data name="Shifts_SignedUp" xml:space="preserve"><value>Angemeldet</value></data>
   <data name="Shifts_Pending" xml:space="preserve"><value>(ausstehend)</value></data>
 
+  <!-- Feedback Email -->
+  <data name="Email_FeedbackResponse_Subject" xml:space="preserve"><value>Update zu deinem Feedback</value></data>
+  <data name="Email_FeedbackResponse_Body" xml:space="preserve"><value>&lt;h2&gt;Update zu deinem Feedback&lt;/h2&gt;
+&lt;p&gt;Hallo {0},&lt;/p&gt;
+&lt;p&gt;Wir haben dein Feedback geprüft:&lt;/p&gt;
+&lt;blockquote style="border-left: 3px solid #ccc; padding-left: 12px; color: #666;"&gt;{1}&lt;/blockquote&gt;
+&lt;p&gt;&lt;strong&gt;Unsere Antwort:&lt;/strong&gt;&lt;/p&gt;
+&lt;p&gt;{2}&lt;/p&gt;
+&lt;p&gt;Danke, dass du uns hilfst, besser zu werden!&lt;/p&gt;
+&lt;p&gt;Das Humans Team&lt;/p&gt;</value><comment>{0} = user name, {1} = original description, {2} = response message</comment></data>
+
 </root>

--- a/src/Humans.Web/Resources/SharedResource.de.resx
+++ b/src/Humans.Web/Resources/SharedResource.de.resx
@@ -1155,4 +1155,20 @@
 &lt;p&gt;Danke, dass du uns hilfst, besser zu werden!&lt;/p&gt;
 &lt;p&gt;Das Humans Team&lt;/p&gt;</value><comment>{0} = user name, {1} = original description, {2} = response message</comment></data>
 
+  <!-- Feedback Widget -->
+  <data name="Feedback_Button" xml:space="preserve"><value>Feedback</value></data>
+  <data name="Feedback_Title" xml:space="preserve"><value>Feedback senden</value></data>
+  <data name="Feedback_Category" xml:space="preserve"><value>Kategorie</value></data>
+  <data name="Feedback_Category_Bug" xml:space="preserve"><value>Fehlerbericht</value></data>
+  <data name="Feedback_Category_FeatureRequest" xml:space="preserve"><value>Funktionsanfrage</value></data>
+  <data name="Feedback_Category_Question" xml:space="preserve"><value>Frage</value></data>
+  <data name="Feedback_Description" xml:space="preserve"><value>Beschreibung</value></data>
+  <data name="Feedback_DescriptionPlaceholder" xml:space="preserve"><value>Erzähl uns, was passiert ist oder was du dir wünschst...</value></data>
+  <data name="Feedback_Screenshot" xml:space="preserve"><value>Screenshot (optional)</value></data>
+  <data name="Feedback_ScreenshotHelp" xml:space="preserve"><value>JPEG, PNG oder WebP. Max. 10MB.</value></data>
+  <data name="Feedback_Cancel" xml:space="preserve"><value>Abbrechen</value></data>
+  <data name="Feedback_Submit" xml:space="preserve"><value>Senden</value></data>
+  <data name="Feedback_Submitted" xml:space="preserve"><value>Danke! Dein Feedback wurde gesendet.</value></data>
+  <data name="Feedback_Error" xml:space="preserve"><value>Beim Senden deines Feedbacks ist ein Fehler aufgetreten. Bitte versuche es erneut.</value></data>
+
 </root>

--- a/src/Humans.Web/Resources/SharedResource.es.resx
+++ b/src/Humans.Web/Resources/SharedResource.es.resx
@@ -1164,4 +1164,15 @@
   <data name="Shifts_SignedUp" xml:space="preserve"><value>Apuntados</value></data>
   <data name="Shifts_Pending" xml:space="preserve"><value>(pendiente)</value></data>
 
+  <!-- Feedback Email -->
+  <data name="Email_FeedbackResponse_Subject" xml:space="preserve"><value>Actualización sobre tu feedback</value></data>
+  <data name="Email_FeedbackResponse_Body" xml:space="preserve"><value>&lt;h2&gt;Actualización sobre tu Feedback&lt;/h2&gt;
+&lt;p&gt;Hola {0},&lt;/p&gt;
+&lt;p&gt;Hemos revisado tu feedback:&lt;/p&gt;
+&lt;blockquote style="border-left: 3px solid #ccc; padding-left: 12px; color: #666;"&gt;{1}&lt;/blockquote&gt;
+&lt;p&gt;&lt;strong&gt;Nuestra respuesta:&lt;/strong&gt;&lt;/p&gt;
+&lt;p&gt;{2}&lt;/p&gt;
+&lt;p&gt;¡Gracias por ayudarnos a mejorar!&lt;/p&gt;
+&lt;p&gt;El equipo de Humans&lt;/p&gt;</value><comment>{0} = user name, {1} = original description, {2} = response message</comment></data>
+
 </root>

--- a/src/Humans.Web/Resources/SharedResource.es.resx
+++ b/src/Humans.Web/Resources/SharedResource.es.resx
@@ -1175,4 +1175,20 @@
 &lt;p&gt;¡Gracias por ayudarnos a mejorar!&lt;/p&gt;
 &lt;p&gt;El equipo de Humans&lt;/p&gt;</value><comment>{0} = user name, {1} = original description, {2} = response message</comment></data>
 
+  <!-- Feedback Widget -->
+  <data name="Feedback_Button" xml:space="preserve"><value>Feedback</value></data>
+  <data name="Feedback_Title" xml:space="preserve"><value>Enviar Feedback</value></data>
+  <data name="Feedback_Category" xml:space="preserve"><value>Categoría</value></data>
+  <data name="Feedback_Category_Bug" xml:space="preserve"><value>Reporte de error</value></data>
+  <data name="Feedback_Category_FeatureRequest" xml:space="preserve"><value>Solicitud de función</value></data>
+  <data name="Feedback_Category_Question" xml:space="preserve"><value>Pregunta</value></data>
+  <data name="Feedback_Description" xml:space="preserve"><value>Descripción</value></data>
+  <data name="Feedback_DescriptionPlaceholder" xml:space="preserve"><value>Cuéntanos qué pasó o qué te gustaría ver...</value></data>
+  <data name="Feedback_Screenshot" xml:space="preserve"><value>Captura de pantalla (opcional)</value></data>
+  <data name="Feedback_ScreenshotHelp" xml:space="preserve"><value>JPEG, PNG o WebP. Máximo 10MB.</value></data>
+  <data name="Feedback_Cancel" xml:space="preserve"><value>Cancelar</value></data>
+  <data name="Feedback_Submit" xml:space="preserve"><value>Enviar</value></data>
+  <data name="Feedback_Submitted" xml:space="preserve"><value>¡Gracias! Tu feedback ha sido enviado.</value></data>
+  <data name="Feedback_Error" xml:space="preserve"><value>Algo salió mal al enviar tu feedback. Por favor, inténtalo de nuevo.</value></data>
+
 </root>

--- a/src/Humans.Web/Resources/SharedResource.fr.resx
+++ b/src/Humans.Web/Resources/SharedResource.fr.resx
@@ -1144,4 +1144,15 @@
   <data name="Shifts_SignedUp" xml:space="preserve"><value>Inscrits</value></data>
   <data name="Shifts_Pending" xml:space="preserve"><value>(en attente)</value></data>
 
+  <!-- Feedback Email -->
+  <data name="Email_FeedbackResponse_Subject" xml:space="preserve"><value>Mise à jour de votre feedback</value></data>
+  <data name="Email_FeedbackResponse_Body" xml:space="preserve"><value>&lt;h2&gt;Mise à jour de votre Feedback&lt;/h2&gt;
+&lt;p&gt;Bonjour {0},&lt;/p&gt;
+&lt;p&gt;Nous avons examiné votre feedback :&lt;/p&gt;
+&lt;blockquote style="border-left: 3px solid #ccc; padding-left: 12px; color: #666;"&gt;{1}&lt;/blockquote&gt;
+&lt;p&gt;&lt;strong&gt;Notre réponse :&lt;/strong&gt;&lt;/p&gt;
+&lt;p&gt;{2}&lt;/p&gt;
+&lt;p&gt;Merci de nous aider à nous améliorer !&lt;/p&gt;
+&lt;p&gt;L'équipe Humans&lt;/p&gt;</value><comment>{0} = user name, {1} = original description, {2} = response message</comment></data>
+
 </root>

--- a/src/Humans.Web/Resources/SharedResource.fr.resx
+++ b/src/Humans.Web/Resources/SharedResource.fr.resx
@@ -1155,4 +1155,20 @@
 &lt;p&gt;Merci de nous aider à nous améliorer !&lt;/p&gt;
 &lt;p&gt;L'équipe Humans&lt;/p&gt;</value><comment>{0} = user name, {1} = original description, {2} = response message</comment></data>
 
+  <!-- Feedback Widget -->
+  <data name="Feedback_Button" xml:space="preserve"><value>Feedback</value></data>
+  <data name="Feedback_Title" xml:space="preserve"><value>Envoyer un Feedback</value></data>
+  <data name="Feedback_Category" xml:space="preserve"><value>Catégorie</value></data>
+  <data name="Feedback_Category_Bug" xml:space="preserve"><value>Rapport de bug</value></data>
+  <data name="Feedback_Category_FeatureRequest" xml:space="preserve"><value>Demande de fonctionnalité</value></data>
+  <data name="Feedback_Category_Question" xml:space="preserve"><value>Question</value></data>
+  <data name="Feedback_Description" xml:space="preserve"><value>Description</value></data>
+  <data name="Feedback_DescriptionPlaceholder" xml:space="preserve"><value>Dites-nous ce qui s'est passé ou ce que vous aimeriez voir...</value></data>
+  <data name="Feedback_Screenshot" xml:space="preserve"><value>Capture d'écran (facultatif)</value></data>
+  <data name="Feedback_ScreenshotHelp" xml:space="preserve"><value>JPEG, PNG ou WebP. Max 10 Mo.</value></data>
+  <data name="Feedback_Cancel" xml:space="preserve"><value>Annuler</value></data>
+  <data name="Feedback_Submit" xml:space="preserve"><value>Envoyer</value></data>
+  <data name="Feedback_Submitted" xml:space="preserve"><value>Merci ! Votre feedback a été envoyé.</value></data>
+  <data name="Feedback_Error" xml:space="preserve"><value>Une erreur est survenue lors de l'envoi de votre feedback. Veuillez réessayer.</value></data>
+
 </root>

--- a/src/Humans.Web/Resources/SharedResource.it.resx
+++ b/src/Humans.Web/Resources/SharedResource.it.resx
@@ -1155,4 +1155,20 @@
 &lt;p&gt;Grazie per aiutarci a migliorare!&lt;/p&gt;
 &lt;p&gt;Il team Humans&lt;/p&gt;</value><comment>{0} = user name, {1} = original description, {2} = response message</comment></data>
 
+  <!-- Feedback Widget -->
+  <data name="Feedback_Button" xml:space="preserve"><value>Feedback</value></data>
+  <data name="Feedback_Title" xml:space="preserve"><value>Invia Feedback</value></data>
+  <data name="Feedback_Category" xml:space="preserve"><value>Categoria</value></data>
+  <data name="Feedback_Category_Bug" xml:space="preserve"><value>Segnalazione bug</value></data>
+  <data name="Feedback_Category_FeatureRequest" xml:space="preserve"><value>Richiesta funzionalità</value></data>
+  <data name="Feedback_Category_Question" xml:space="preserve"><value>Domanda</value></data>
+  <data name="Feedback_Description" xml:space="preserve"><value>Descrizione</value></data>
+  <data name="Feedback_DescriptionPlaceholder" xml:space="preserve"><value>Raccontaci cosa è successo o cosa vorresti vedere...</value></data>
+  <data name="Feedback_Screenshot" xml:space="preserve"><value>Screenshot (opzionale)</value></data>
+  <data name="Feedback_ScreenshotHelp" xml:space="preserve"><value>JPEG, PNG o WebP. Max 10MB.</value></data>
+  <data name="Feedback_Cancel" xml:space="preserve"><value>Annulla</value></data>
+  <data name="Feedback_Submit" xml:space="preserve"><value>Invia</value></data>
+  <data name="Feedback_Submitted" xml:space="preserve"><value>Grazie! Il tuo feedback è stato inviato.</value></data>
+  <data name="Feedback_Error" xml:space="preserve"><value>Qualcosa è andato storto nell'invio del tuo feedback. Riprova.</value></data>
+
 </root>

--- a/src/Humans.Web/Resources/SharedResource.it.resx
+++ b/src/Humans.Web/Resources/SharedResource.it.resx
@@ -1144,4 +1144,15 @@
   <data name="Shifts_SignedUp" xml:space="preserve"><value>Iscritti</value></data>
   <data name="Shifts_Pending" xml:space="preserve"><value>(in attesa)</value></data>
 
+  <!-- Feedback Email -->
+  <data name="Email_FeedbackResponse_Subject" xml:space="preserve"><value>Aggiornamento sul tuo feedback</value></data>
+  <data name="Email_FeedbackResponse_Body" xml:space="preserve"><value>&lt;h2&gt;Aggiornamento sul tuo Feedback&lt;/h2&gt;
+&lt;p&gt;Ciao {0},&lt;/p&gt;
+&lt;p&gt;Abbiamo esaminato il tuo feedback:&lt;/p&gt;
+&lt;blockquote style="border-left: 3px solid #ccc; padding-left: 12px; color: #666;"&gt;{1}&lt;/blockquote&gt;
+&lt;p&gt;&lt;strong&gt;La nostra risposta:&lt;/strong&gt;&lt;/p&gt;
+&lt;p&gt;{2}&lt;/p&gt;
+&lt;p&gt;Grazie per aiutarci a migliorare!&lt;/p&gt;
+&lt;p&gt;Il team Humans&lt;/p&gt;</value><comment>{0} = user name, {1} = original description, {2} = response message</comment></data>
+
 </root>

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -1160,4 +1160,15 @@
   <data name="Shifts_SignedUp" xml:space="preserve"><value>Signed Up</value></data>
   <data name="Shifts_Pending" xml:space="preserve"><value>(pending)</value></data>
 
+  <!-- Feedback Email -->
+  <data name="Email_FeedbackResponse_Subject" xml:space="preserve"><value>Update on your feedback</value></data>
+  <data name="Email_FeedbackResponse_Body" xml:space="preserve"><value>&lt;h2&gt;Update on Your Feedback&lt;/h2&gt;
+&lt;p&gt;Dear {0},&lt;/p&gt;
+&lt;p&gt;We've reviewed your feedback:&lt;/p&gt;
+&lt;blockquote style="border-left: 3px solid #ccc; padding-left: 12px; color: #666;"&gt;{1}&lt;/blockquote&gt;
+&lt;p&gt;&lt;strong&gt;Our response:&lt;/strong&gt;&lt;/p&gt;
+&lt;p&gt;{2}&lt;/p&gt;
+&lt;p&gt;Thank you for helping us improve!&lt;/p&gt;
+&lt;p&gt;The Humans Team&lt;/p&gt;</value><comment>{0} = user name, {1} = original description, {2} = response message</comment></data>
+
 </root>

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -1171,4 +1171,20 @@
 &lt;p&gt;Thank you for helping us improve!&lt;/p&gt;
 &lt;p&gt;The Humans Team&lt;/p&gt;</value><comment>{0} = user name, {1} = original description, {2} = response message</comment></data>
 
+  <!-- Feedback Widget -->
+  <data name="Feedback_Button" xml:space="preserve"><value>Feedback</value></data>
+  <data name="Feedback_Title" xml:space="preserve"><value>Send Feedback</value></data>
+  <data name="Feedback_Category" xml:space="preserve"><value>Category</value></data>
+  <data name="Feedback_Category_Bug" xml:space="preserve"><value>Bug Report</value></data>
+  <data name="Feedback_Category_FeatureRequest" xml:space="preserve"><value>Feature Request</value></data>
+  <data name="Feedback_Category_Question" xml:space="preserve"><value>Question</value></data>
+  <data name="Feedback_Description" xml:space="preserve"><value>Description</value></data>
+  <data name="Feedback_DescriptionPlaceholder" xml:space="preserve"><value>Tell us what happened or what you'd like to see...</value></data>
+  <data name="Feedback_Screenshot" xml:space="preserve"><value>Screenshot (optional)</value></data>
+  <data name="Feedback_ScreenshotHelp" xml:space="preserve"><value>JPEG, PNG, or WebP. Max 10MB.</value></data>
+  <data name="Feedback_Cancel" xml:space="preserve"><value>Cancel</value></data>
+  <data name="Feedback_Submit" xml:space="preserve"><value>Send</value></data>
+  <data name="Feedback_Submitted" xml:space="preserve"><value>Thank you! Your feedback has been submitted.</value></data>
+  <data name="Feedback_Error" xml:space="preserve"><value>Something went wrong submitting your feedback. Please try again.</value></data>
+
 </root>

--- a/src/Humans.Web/ViewComponents/FeedbackWidgetViewComponent.cs
+++ b/src/Humans.Web/ViewComponents/FeedbackWidgetViewComponent.cs
@@ -1,0 +1,14 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace Humans.Web.ViewComponents;
+
+public class FeedbackWidgetViewComponent : ViewComponent
+{
+    public IViewComponentResult Invoke()
+    {
+        if (UserClaimsPrincipal?.Identity?.IsAuthenticated != true)
+            return Content(string.Empty);
+
+        return View();
+    }
+}

--- a/src/Humans.Web/Views/Admin/Index.cshtml
+++ b/src/Humans.Web/Views/Admin/Index.cshtml
@@ -38,6 +38,9 @@
                 <a asp-action="Logs" class="list-group-item list-group-item-action">
                     <i class="fa-solid fa-triangle-exclamation me-2"></i>Application Logs
                 </a>
+                <a asp-controller="AdminFeedback" asp-action="Index" class="list-group-item list-group-item-action">
+                    <i class="fa-solid fa-comment-dots me-2"></i>Feedback
+                </a>
             </div>
         </div>
 

--- a/src/Humans.Web/Views/AdminFeedback/Detail.cshtml
+++ b/src/Humans.Web/Views/AdminFeedback/Detail.cshtml
@@ -110,7 +110,7 @@
                     <button type="submit" class="btn btn-sm btn-primary">Link</button>
                     @if (Model.GitHubIssueNumber.HasValue)
                     {
-                        <a href="https://github.com/peterdrier/Humans/issues/@Model.GitHubIssueNumber" target="_blank" class="btn btn-sm btn-outline-secondary">
+                        <a href="https://github.com/nobodies-collective/Humans/issues/@Model.GitHubIssueNumber" target="_blank" class="btn btn-sm btn-outline-secondary">
                             <i class="fa-brands fa-github me-1"></i>#@Model.GitHubIssueNumber
                         </a>
                     }
@@ -125,7 +125,7 @@
                 <form asp-action="SendResponse" asp-route-id="@Model.Id" method="post">
                     @Html.AntiForgeryToken()
                     <textarea name="Message" class="form-control mb-2" rows="4" maxlength="5000" required placeholder="Type your response to the reporter... This will be sent via email."></textarea>
-                    <button type="submit" class="btn btn-sm btn-primary" onclick="return confirm('Send this response to @Model.ReporterName via email?')">
+                    <button type="submit" class="btn btn-sm btn-primary" data-confirm="Send this response to @Model.ReporterName via email?">
                         <i class="fa-solid fa-paper-plane me-1"></i>Send Response
                     </button>
                     @if (Model.AdminResponseSentAt.HasValue)
@@ -168,3 +168,15 @@
         </div>
     </div>
 </div>
+
+@section Scripts {
+    <script>
+        document.querySelectorAll('[data-confirm]').forEach(function (btn) {
+            btn.addEventListener('click', function (e) {
+                if (!confirm(btn.dataset.confirm)) {
+                    e.preventDefault();
+                }
+            });
+        });
+    </script>
+}

--- a/src/Humans.Web/Views/AdminFeedback/Detail.cshtml
+++ b/src/Humans.Web/Views/AdminFeedback/Detail.cshtml
@@ -60,7 +60,15 @@
                 }
 
                 <div class="mt-3 small text-muted">
-                    <strong>Page:</strong> <a href="@Model.PageUrl" target="_blank">@Model.PageUrl</a>
+                    <strong>Page:</strong>
+                    @if (Uri.TryCreate(Model.PageUrl, UriKind.Absolute, out var pageUri) && (pageUri.Scheme == "http" || pageUri.Scheme == "https"))
+                    {
+                        <a href="@Model.PageUrl" target="_blank">@Model.PageUrl</a>
+                    }
+                    else
+                    {
+                        @Model.PageUrl
+                    }
                 </div>
                 @if (!string.IsNullOrEmpty(Model.UserAgent))
                 {

--- a/src/Humans.Web/Views/AdminFeedback/Detail.cshtml
+++ b/src/Humans.Web/Views/AdminFeedback/Detail.cshtml
@@ -1,0 +1,170 @@
+@model Humans.Web.Models.FeedbackDetailViewModel
+@using Humans.Domain.Enums
+@{
+    ViewData["Title"] = $"Feedback #{Model.Id.ToString()[..8]}";
+}
+
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a asp-action="Index">Feedback</a></li>
+        <li class="breadcrumb-item active">@Model.Id.ToString()[..8]</li>
+    </ol>
+</nav>
+
+<vc:temp-data-alerts />
+
+<div class="row">
+    <!-- Main content -->
+    <div class="col-lg-8">
+        <!-- Report card -->
+        <div class="card mb-4">
+            <div class="card-header d-flex justify-content-between align-items-center">
+                <span>
+                    @{
+                        var catBadge = Model.Category switch
+                        {
+                            FeedbackCategory.Bug => "bg-danger",
+                            FeedbackCategory.FeatureRequest => "bg-primary",
+                            FeedbackCategory.Question => "bg-info text-dark",
+                            _ => "bg-secondary"
+                        };
+                        var statusBadge = Model.Status switch
+                        {
+                            FeedbackStatus.Open => "bg-warning text-dark",
+                            FeedbackStatus.Acknowledged => "bg-info text-dark",
+                            FeedbackStatus.Resolved => "bg-success",
+                            FeedbackStatus.WontFix => "bg-secondary",
+                            _ => "bg-secondary"
+                        };
+                    }
+                    <span class="badge @catBadge me-1">@Model.Category</span>
+                    <span class="badge @statusBadge">@Model.Status</span>
+                </span>
+                <span class="text-muted small">
+                    by <a asp-controller="Human" asp-action="View" asp-route-id="@Model.ReporterUserId">@Model.ReporterName</a>
+                </span>
+            </div>
+            <div class="card-body">
+                <p class="card-text" style="white-space: pre-wrap;">@Model.Description</p>
+
+                @if (Model.ScreenshotUrl != null)
+                {
+                    <div class="mt-3">
+                        <strong>Screenshot:</strong>
+                        <div class="mt-2">
+                            <a href="@Model.ScreenshotUrl" target="_blank">
+                                <img src="@Model.ScreenshotUrl" class="img-fluid border rounded" style="max-height: 400px;" alt="Feedback screenshot" />
+                            </a>
+                        </div>
+                    </div>
+                }
+
+                <div class="mt-3 small text-muted">
+                    <strong>Page:</strong> <a href="@Model.PageUrl" target="_blank">@Model.PageUrl</a>
+                </div>
+                @if (!string.IsNullOrEmpty(Model.UserAgent))
+                {
+                    <div class="small text-muted">
+                        <strong>User Agent:</strong> @Model.UserAgent
+                    </div>
+                }
+            </div>
+        </div>
+
+        <!-- Status form -->
+        <div class="card mb-4">
+            <div class="card-header">Status</div>
+            <div class="card-body">
+                <form asp-action="UpdateStatus" asp-route-id="@Model.Id" method="post" class="d-flex gap-2 align-items-center">
+                    @Html.AntiForgeryToken()
+                    <select name="Status" class="form-select form-select-sm" style="width: auto;">
+                        @foreach (var s in Enum.GetValues<FeedbackStatus>())
+                        {
+                            <option value="@s" selected="@(Model.Status == s)">@s</option>
+                        }
+                    </select>
+                    <button type="submit" class="btn btn-sm btn-primary">Save</button>
+                </form>
+            </div>
+        </div>
+
+        <!-- Admin notes form -->
+        <div class="card mb-4">
+            <div class="card-header">Admin Notes</div>
+            <div class="card-body">
+                <form asp-action="UpdateNotes" asp-route-id="@Model.Id" method="post">
+                    @Html.AntiForgeryToken()
+                    <textarea name="Notes" class="form-control mb-2" rows="3" maxlength="5000" placeholder="Internal notes (not visible to the reporter)">@Model.AdminNotes</textarea>
+                    <button type="submit" class="btn btn-sm btn-primary">Save Notes</button>
+                </form>
+            </div>
+        </div>
+
+        <!-- GitHub issue form -->
+        <div class="card mb-4">
+            <div class="card-header">GitHub Issue</div>
+            <div class="card-body">
+                <form asp-action="SetGitHubIssue" asp-route-id="@Model.Id" method="post" class="d-flex gap-2 align-items-center">
+                    @Html.AntiForgeryToken()
+                    <input type="number" name="IssueNumber" class="form-control form-control-sm" style="width: 120px;" value="@Model.GitHubIssueNumber" placeholder="#" />
+                    <button type="submit" class="btn btn-sm btn-primary">Link</button>
+                    @if (Model.GitHubIssueNumber.HasValue)
+                    {
+                        <a href="https://github.com/peterdrier/Humans/issues/@Model.GitHubIssueNumber" target="_blank" class="btn btn-sm btn-outline-secondary">
+                            <i class="fa-brands fa-github me-1"></i>#@Model.GitHubIssueNumber
+                        </a>
+                    }
+                </form>
+            </div>
+        </div>
+
+        <!-- Send response form -->
+        <div class="card mb-4">
+            <div class="card-header">Send Response to Reporter</div>
+            <div class="card-body">
+                <form asp-action="SendResponse" asp-route-id="@Model.Id" method="post">
+                    @Html.AntiForgeryToken()
+                    <textarea name="Message" class="form-control mb-2" rows="4" maxlength="5000" required placeholder="Type your response to the reporter... This will be sent via email."></textarea>
+                    <button type="submit" class="btn btn-sm btn-primary" onclick="return confirm('Send this response to @Model.ReporterName via email?')">
+                        <i class="fa-solid fa-paper-plane me-1"></i>Send Response
+                    </button>
+                    @if (Model.AdminResponseSentAt.HasValue)
+                    {
+                        <span class="text-muted small ms-2">Last response sent: @Model.AdminResponseSentAt.Value.ToString("yyyy-MM-dd HH:mm")</span>
+                    }
+                </form>
+            </div>
+        </div>
+    </div>
+
+    <!-- Sidebar -->
+    <div class="col-lg-4">
+        <div class="card">
+            <div class="card-header">Timestamps</div>
+            <div class="card-body small">
+                <dl class="row mb-0">
+                    <dt class="col-5">Submitted</dt>
+                    <dd class="col-7">@Model.CreatedAt.ToString("yyyy-MM-dd HH:mm")</dd>
+
+                    <dt class="col-5">Last Updated</dt>
+                    <dd class="col-7">@Model.UpdatedAt.ToString("yyyy-MM-dd HH:mm")</dd>
+
+                    @if (Model.AdminResponseSentAt.HasValue)
+                    {
+                        <dt class="col-5">Response Sent</dt>
+                        <dd class="col-7">@Model.AdminResponseSentAt.Value.ToString("yyyy-MM-dd HH:mm")</dd>
+                    }
+
+                    @if (Model.ResolvedAt.HasValue)
+                    {
+                        <dt class="col-5">Resolved</dt>
+                        <dd class="col-7">@Model.ResolvedAt.Value.ToString("yyyy-MM-dd HH:mm")</dd>
+
+                        <dt class="col-5">Resolved By</dt>
+                        <dd class="col-7">@(Model.ResolvedByName ?? "—")</dd>
+                    }
+                </dl>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/Humans.Web/Views/AdminFeedback/Index.cshtml
+++ b/src/Humans.Web/Views/AdminFeedback/Index.cshtml
@@ -59,7 +59,7 @@ else
             <tbody>
                 @foreach (var r in Model.Reports)
                 {
-                    <tr class="@(r.Status == FeedbackStatus.Resolved || r.Status == FeedbackStatus.WontFix ? "table-light text-muted" : "")" style="cursor: pointer;" onclick="window.location='@Url.Action("Detail", new { id = r.Id })'">
+                    <tr class="@(r.Status == FeedbackStatus.Resolved || r.Status == FeedbackStatus.WontFix ? "table-light text-muted" : "")" style="cursor: pointer;" data-detail-url="@Url.Action("Detail", new { id = r.Id })">
                         <td>
                             @{
                                 var statusBadge = r.Status switch
@@ -87,7 +87,7 @@ else
                         </td>
                         <td class="text-truncate" style="max-width: 300px;">@r.Description</td>
                         <td>
-                            <a asp-controller="Human" asp-action="View" asp-route-id="@r.ReporterUserId" onclick="event.stopPropagation();">@r.ReporterName</a>
+                            <a asp-controller="Human" asp-action="View" asp-route-id="@r.ReporterUserId" class="js-stop-propagation">@r.ReporterName</a>
                         </td>
                         <td class="text-truncate small text-muted" style="max-width: 200px;">@r.PageUrl</td>
                         <td class="text-center">
@@ -102,4 +102,19 @@ else
             </tbody>
         </table>
     </div>
+
+    @section Scripts {
+        <script>
+            document.querySelectorAll('tr[data-detail-url]').forEach(function (row) {
+                row.addEventListener('click', function () {
+                    window.location = row.dataset.detailUrl;
+                });
+            });
+            document.querySelectorAll('.js-stop-propagation').forEach(function (el) {
+                el.addEventListener('click', function (e) {
+                    e.stopPropagation();
+                });
+            });
+        </script>
+    }
 }

--- a/src/Humans.Web/Views/AdminFeedback/Index.cshtml
+++ b/src/Humans.Web/Views/AdminFeedback/Index.cshtml
@@ -1,0 +1,105 @@
+@model Humans.Web.Models.FeedbackListViewModel
+@using Humans.Domain.Enums
+@{
+    ViewData["Title"] = "Feedback";
+}
+
+<h1><i class="fa-solid fa-comment-dots me-2"></i>Feedback</h1>
+
+<vc:temp-data-alerts />
+
+<!-- Filter bar -->
+<form method="get" class="row g-2 mb-4">
+    <div class="col-auto">
+        <select name="status" class="form-select form-select-sm">
+            <option value="">All Statuses</option>
+            @foreach (var s in Enum.GetValues<FeedbackStatus>())
+            {
+                <option value="@s" selected="@(Model.StatusFilter == s)">@s</option>
+            }
+        </select>
+    </div>
+    <div class="col-auto">
+        <select name="category" class="form-select form-select-sm">
+            <option value="">All Categories</option>
+            @foreach (var c in Enum.GetValues<FeedbackCategory>())
+            {
+                <option value="@c" selected="@(Model.CategoryFilter == c)">@c</option>
+            }
+        </select>
+    </div>
+    <div class="col-auto">
+        <button type="submit" class="btn btn-sm btn-outline-primary">Filter</button>
+        @if (Model.StatusFilter.HasValue || Model.CategoryFilter.HasValue)
+        {
+            <a asp-action="Index" class="btn btn-sm btn-outline-secondary ms-1">Clear</a>
+        }
+    </div>
+</form>
+
+@if (Model.Reports.Count == 0)
+{
+    <div class="alert alert-info">No feedback reports found.</div>
+}
+else
+{
+    <div class="table-responsive">
+        <table class="table table-hover align-middle">
+            <thead>
+                <tr>
+                    <th>Status</th>
+                    <th>Category</th>
+                    <th>Description</th>
+                    <th>Reporter</th>
+                    <th>Page</th>
+                    <th class="text-center"><i class="fa-solid fa-camera" title="Screenshot"></i></th>
+                    <th>Date</th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach (var r in Model.Reports)
+                {
+                    <tr class="@(r.Status == FeedbackStatus.Resolved || r.Status == FeedbackStatus.WontFix ? "table-light text-muted" : "")" style="cursor: pointer;" onclick="window.location='@Url.Action("Detail", new { id = r.Id })'">
+                        <td>
+                            @{
+                                var statusBadge = r.Status switch
+                                {
+                                    FeedbackStatus.Open => "bg-warning text-dark",
+                                    FeedbackStatus.Acknowledged => "bg-info text-dark",
+                                    FeedbackStatus.Resolved => "bg-success",
+                                    FeedbackStatus.WontFix => "bg-secondary",
+                                    _ => "bg-secondary"
+                                };
+                            }
+                            <span class="badge @statusBadge">@r.Status</span>
+                        </td>
+                        <td>
+                            @{
+                                var catBadge = r.Category switch
+                                {
+                                    FeedbackCategory.Bug => "bg-danger",
+                                    FeedbackCategory.FeatureRequest => "bg-primary",
+                                    FeedbackCategory.Question => "bg-info text-dark",
+                                    _ => "bg-secondary"
+                                };
+                            }
+                            <span class="badge @catBadge">@r.Category</span>
+                        </td>
+                        <td class="text-truncate" style="max-width: 300px;">@r.Description</td>
+                        <td>
+                            <a asp-controller="Human" asp-action="View" asp-route-id="@r.ReporterUserId" onclick="event.stopPropagation();">@r.ReporterName</a>
+                        </td>
+                        <td class="text-truncate small text-muted" style="max-width: 200px;">@r.PageUrl</td>
+                        <td class="text-center">
+                            @if (r.HasScreenshot)
+                            {
+                                <i class="fa-solid fa-image text-success"></i>
+                            }
+                        </td>
+                        <td class="small text-nowrap">@r.CreatedAt.ToString("yyyy-MM-dd HH:mm")</td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+    </div>
+}

--- a/src/Humans.Web/Views/Shared/Components/FeedbackWidget/Default.cshtml
+++ b/src/Humans.Web/Views/Shared/Components/FeedbackWidget/Default.cshtml
@@ -1,0 +1,57 @@
+@using Humans.Domain.Enums
+
+<!-- Floating feedback button -->
+<button type="button" class="btn btn-primary rounded-circle shadow position-fixed"
+        style="bottom: 24px; right: 24px; width: 56px; height: 56px; z-index: 1050;"
+        data-bs-toggle="modal" data-bs-target="#feedbackModal"
+        title="@Localizer["Feedback_Button"]">
+    <i class="fa-solid fa-comment-dots fa-lg"></i>
+</button>
+
+<!-- Feedback modal -->
+<div class="modal fade" id="feedbackModal" tabindex="-1" aria-labelledby="feedbackModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <form asp-controller="Feedback" asp-action="Submit" method="post" enctype="multipart/form-data">
+                @Html.AntiForgeryToken()
+                <div class="modal-header">
+                    <h5 class="modal-title" id="feedbackModalLabel">@Localizer["Feedback_Title"]</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <div class="mb-3">
+                        <label class="form-label">@Localizer["Feedback_Category"]</label>
+                        <select name="Category" class="form-select" required>
+                            <option value="Bug">@Localizer["Feedback_Category_Bug"]</option>
+                            <option value="FeatureRequest">@Localizer["Feedback_Category_FeatureRequest"]</option>
+                            <option value="Question">@Localizer["Feedback_Category_Question"]</option>
+                        </select>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">@Localizer["Feedback_Description"]</label>
+                        <textarea name="Description" class="form-control" rows="5" required maxlength="5000"
+                                  placeholder="@Localizer["Feedback_DescriptionPlaceholder"]"></textarea>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">@Localizer["Feedback_Screenshot"]</label>
+                        <input type="file" name="Screenshot" class="form-control" accept="image/jpeg,image/png,image/webp" />
+                        <div class="form-text">@Localizer["Feedback_ScreenshotHelp"]</div>
+                    </div>
+                    <input type="hidden" name="PageUrl" id="feedbackPageUrl" />
+                    <input type="hidden" name="UserAgent" id="feedbackUserAgent" />
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">@Localizer["Feedback_Cancel"]</button>
+                    <button type="submit" class="btn btn-primary">@Localizer["Feedback_Submit"]</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+<script>
+    document.getElementById('feedbackModal').addEventListener('show.bs.modal', function () {
+        document.getElementById('feedbackPageUrl').value = window.location.href;
+        document.getElementById('feedbackUserAgent').value = navigator.userAgent;
+    });
+</script>

--- a/src/Humans.Web/Views/Shared/_Layout.cshtml
+++ b/src/Humans.Web/Views/Shared/_Layout.cshtml
@@ -124,6 +124,7 @@
             <div class="d-flex gap-3">
                 <a asp-controller="Home" asp-action="About" class="text-muted small">About</a>
                 <a asp-controller="Home" asp-action="Privacy" class="text-muted small">@Localizer["Nav_Privacy"]</a>
+                <a href="#" class="text-muted small" data-bs-toggle="modal" data-bs-target="#feedbackModal">@Localizer["Feedback_Button"]</a>
             </div>
             @{
                 var assembly = System.Reflection.Assembly.GetEntryAssembly()!;
@@ -162,5 +163,6 @@
             crossorigin="anonymous"></script>
     <script src="~/js/site.js"></script>
     @await RenderSectionAsync("Scripts", required: false)
+    @await Component.InvokeAsync("FeedbackWidget")
 </body>
 </html>

--- a/src/Humans.Web/Views/Shared/_Layout.cshtml
+++ b/src/Humans.Web/Views/Shared/_Layout.cshtml
@@ -124,7 +124,10 @@
             <div class="d-flex gap-3">
                 <a asp-controller="Home" asp-action="About" class="text-muted small">About</a>
                 <a asp-controller="Home" asp-action="Privacy" class="text-muted small">@Localizer["Nav_Privacy"]</a>
-                <a href="#" class="text-muted small" data-bs-toggle="modal" data-bs-target="#feedbackModal">@Localizer["Feedback_Button"]</a>
+                @if (User.Identity?.IsAuthenticated == true)
+                {
+                    <a href="#" class="text-muted small" data-bs-toggle="modal" data-bs-target="#feedbackModal">@Localizer["Feedback_Button"]</a>
+                }
             </div>
             @{
                 var assembly = System.Reflection.Assembly.GetEntryAssembly()!;

--- a/tests/Humans.Application.Tests/Services/FeedbackServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/FeedbackServiceTests.cs
@@ -1,0 +1,145 @@
+using AwesomeAssertions;
+using Humans.Application.Interfaces;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using Humans.Infrastructure.Data;
+using Humans.Infrastructure.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using NodaTime;
+using NodaTime.Testing;
+using NSubstitute;
+using Xunit;
+
+namespace Humans.Application.Tests.Services;
+
+public class FeedbackServiceTests : IDisposable
+{
+    private readonly HumansDbContext _dbContext;
+    private readonly FakeClock _clock;
+    private readonly IEmailService _emailService;
+    private readonly IAuditLogService _auditLog;
+    private readonly FeedbackService _service;
+
+    public FeedbackServiceTests()
+    {
+        var options = new DbContextOptionsBuilder<HumansDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        _dbContext = new HumansDbContext(options);
+        _clock = new FakeClock(Instant.FromUtc(2026, 3, 18, 12, 0));
+        _emailService = Substitute.For<IEmailService>();
+        _auditLog = Substitute.For<IAuditLogService>();
+        var env = Substitute.For<IHostEnvironment>();
+        env.ContentRootPath.Returns(Path.GetTempPath());
+
+        _service = new FeedbackService(
+            _dbContext, _emailService, _auditLog, _clock, env,
+            NullLogger<FeedbackService>.Instance);
+    }
+
+    public void Dispose()
+    {
+        _dbContext.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public async Task SubmitFeedbackAsync_CreatesReport()
+    {
+        var userId = Guid.NewGuid();
+        _dbContext.Users.Add(new User { Id = userId, DisplayName = "Test", Email = "t@t.com" });
+        await _dbContext.SaveChangesAsync();
+
+        var report = await _service.SubmitFeedbackAsync(
+            userId, FeedbackCategory.Bug, "Something broke",
+            "/Teams/test", "Mozilla/5.0", null);
+
+        report.Id.Should().NotBeEmpty();
+        report.Category.Should().Be(FeedbackCategory.Bug);
+        report.Status.Should().Be(FeedbackStatus.Open);
+        report.Description.Should().Be("Something broke");
+        report.PageUrl.Should().Be("/Teams/test");
+    }
+
+    [Fact]
+    public async Task UpdateStatusAsync_SetsResolvedFields_WhenTerminal()
+    {
+        var report = await CreateTestReport();
+
+        await _service.UpdateStatusAsync(report.Id, FeedbackStatus.Resolved, Guid.NewGuid());
+
+        var updated = await _dbContext.FeedbackReports.FindAsync(report.Id);
+        updated!.Status.Should().Be(FeedbackStatus.Resolved);
+        updated.ResolvedAt.Should().NotBeNull();
+        updated.ResolvedByUserId.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task UpdateStatusAsync_ClearsResolvedFields_WhenReopened()
+    {
+        var actorId = Guid.NewGuid();
+        var report = await CreateTestReport();
+        await _service.UpdateStatusAsync(report.Id, FeedbackStatus.Resolved, actorId);
+        await _service.UpdateStatusAsync(report.Id, FeedbackStatus.Open, actorId);
+
+        var updated = await _dbContext.FeedbackReports.FindAsync(report.Id);
+        updated!.Status.Should().Be(FeedbackStatus.Open);
+        updated.ResolvedAt.Should().BeNull();
+        updated.ResolvedByUserId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetFeedbackListAsync_FiltersByStatus()
+    {
+        await CreateTestReport(FeedbackStatus.Open);
+        await CreateTestReport(FeedbackStatus.Open);
+        await CreateTestReport(FeedbackStatus.Resolved);
+
+        var results = await _service.GetFeedbackListAsync(status: FeedbackStatus.Open);
+
+        results.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task SendResponseAsync_EnqueuesEmail_AndUpdatesTimestamp()
+    {
+        var userId = Guid.NewGuid();
+        _dbContext.Users.Add(new User { Id = userId, DisplayName = "Reporter", Email = "reporter@test.com" });
+        await _dbContext.SaveChangesAsync();
+
+        var report = await _service.SubmitFeedbackAsync(
+            userId, FeedbackCategory.Bug, "Bug desc", "/page", null, null);
+
+        var actorId = Guid.NewGuid();
+        _dbContext.Users.Add(new User { Id = actorId, DisplayName = "Admin", Email = "admin@test.com" });
+        await _dbContext.SaveChangesAsync();
+
+        await _service.SendResponseAsync(report.Id, "Fixed it!", actorId);
+
+        await _emailService.Received(1).SendFeedbackResponseAsync(
+            "reporter@test.com", "Reporter", "Bug desc", "Fixed it!",
+            Arg.Any<string?>(), Arg.Any<CancellationToken>());
+
+        var updated = await _dbContext.FeedbackReports.FindAsync(report.Id);
+        updated!.AdminResponseSentAt.Should().NotBeNull();
+    }
+
+    private async Task<FeedbackReport> CreateTestReport(FeedbackStatus status = FeedbackStatus.Open)
+    {
+        var userId = Guid.NewGuid();
+        _dbContext.Users.Add(new User { Id = userId, DisplayName = "Test", Email = $"{userId}@test.com" });
+        await _dbContext.SaveChangesAsync();
+
+        var report = await _service.SubmitFeedbackAsync(
+            userId, FeedbackCategory.Bug, "Test bug", "/test", null, null);
+
+        if (status != FeedbackStatus.Open)
+        {
+            await _service.UpdateStatusAsync(report.Id, status, Guid.NewGuid());
+        }
+
+        return report;
+    }
+}

--- a/todos.md
+++ b/todos.md
@@ -23,6 +23,9 @@ Send reminders to humans who signed up but never completed profile/consent, auto
 #### #137: Public team pages with editable markdown content, CTAs, and member roster
 Public-facing team pages with editable markdown, calls-to-action, and visible member roster. Label: none.
 
+#### #141: Add in-app feedback system for bug reports and feature requests
+Feedback widget on every page (post-login) capturing bug reports / feature requests with automatic URL/browser context and optional screenshot. Admin triage page with status workflow, email responses to reporters, and Claude Code queryable data for dev workflow.
+
 #### #138: Add Catalan (ca) translation
 New `SharedResource.ca.resx` with all ~805 keys, register `"ca"` culture in `Program.cs`, language selector, and Catalan email templates.
 


### PR DESCRIPTION
Closes nobodies-collective/Humans#141

## Summary

- **Feedback widget**: Floating button + modal on all pages for authenticated users to submit bug reports, feature requests, and questions with optional screenshot upload
- **Admin triage UI**: `/Admin/Feedback` list and detail views with status management, admin notes, GitHub issue linking, and email response to reporters
- **REST API**: `/api/feedback` endpoints with API key auth (`X-Api-Key` header) for external tool integration (e.g., Claude Code)
- **Service layer**: `FeedbackService` with screenshot upload (JPEG/PNG/WebP, 10MB max), email response via outbox pattern, audit logging
- **Localization**: All user-facing strings in en/es/de/fr/it
- **Data layer**: `FeedbackReport` entity, EF configuration, PostgreSQL migration with indexes
- **Tests**: 5 unit tests covering submission, status transitions, filtering, and email response
- **Code review fixes**: CSP-compliant views (no inline handlers), open redirect prevention, FK-safe nullable actor IDs, PageUrl XSS sanitization, membership gate exemption for feedback submission

## Test plan

- [ ] Run migration on QA database
- [ ] Submit feedback as authenticated user (bug, feature request, question)
- [ ] Submit feedback with screenshot upload
- [ ] Verify floating button and footer link only visible when authenticated
- [ ] Verify onboarding users (not yet active members) can submit feedback
- [ ] Admin: view feedback list with status/category filters
- [ ] Admin: update status, add notes, link GitHub issue
- [ ] Admin: send email response to reporter
- [ ] API: test all endpoints with valid/invalid/missing API key
- [ ] Verify CSP — no console errors on admin feedback pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)