### PR TITLE
feat: feedback triage workflow (#147)

### DIFF
--- a/docs/features/27-feedback-system.md
+++ b/docs/features/27-feedback-system.md
@@ -94,6 +94,15 @@ Key fields: Id, UserId, Category (enum→string), Description, PageUrl, UserAgen
 | `PATCH /api/feedback/{id}/github-issue` | FeedbackApiController | SetGitHubIssue |
 | `POST /api/feedback/{id}/respond` | FeedbackApiController | SendResponse |
 
+## Claude Code Triage Integration (#147)
+
+The feedback API enables a Claude Code workflow for processing feedback during dev sessions:
+
+- **`/whats` integration:** When `HUMANS_API_URL` and `HUMANS_API_KEY` env vars are set, `/whats` checks for pending feedback and surfaces the count in its status output. Humans-project-specific; other projects skip this step.
+- **`/triage` skill:** Interactive triage of pending reports — for each report, choose to respond, create a GitHub issue (on `nobodies-collective/Humans`), mark won't fix, or skip. Issues are linked back to the feedback report via the API.
+- **Environment setup:** `FEEDBACK_API_KEY` env var on the server, `HUMANS_API_KEY`/`HUMANS_API_URL` in `.claude/settings.local.json` (gitignored).
+- **Admin visibility:** `FEEDBACK_API_KEY` status shown on `/Admin/Configuration` diagnostics page.
+
 ## Related Features
 
 - Email outbox (`EmailOutboxMessage`) — used for response emails

--- a/docs/superpowers/plans/2026-03-19-feedback-triage-workflow.md
+++ b/docs/superpowers/plans/2026-03-19-feedback-triage-workflow.md
@@ -1,0 +1,333 @@
+# Feedback Triage Workflow Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enable Claude Code to surface pending feedback in `/whats` and triage it interactively via `/triage`.
+
+**Architecture:** Three changes — one C# code addition (Admin config page), two skill files (modify `/whats`, create `/triage`). The API already exists; this is purely workflow integration.
+
+**Tech Stack:** ASP.NET Core (C#), Claude Code skills (markdown), curl for API calls
+
+**Spec:** `docs/superpowers/specs/2026-03-19-feedback-triage-workflow-design.md`
+
+---
+
+### Task 1: Add FEEDBACK_API_KEY to Admin Configuration page
+
+**Files:**
+- Modify: `src/Humans.Web/Controllers/AdminController.cs:183` (after line 183, before `return View`)
+
+- [ ] **Step 1: Create feature branch**
+
+```bash
+git checkout -b feature/147-feedback-triage
+```
+
+- [ ] **Step 2: Add the env var check to AdminController.Configuration()**
+
+In `src/Humans.Web/Controllers/AdminController.cs`, insert after line 183 (the closing `});` of the Ticket Vendor block) and before line 185 (`return View`):
+
+```csharp
+        // Feedback API key is from env var
+        var feedbackApiKey = Environment.GetEnvironmentVariable("FEEDBACK_API_KEY");
+        items.Add(new ConfigurationItemViewModel
+        {
+            Section = "Feedback API",
+            Key = "FEEDBACK_API_KEY (env)",
+            IsSet = !string.IsNullOrEmpty(feedbackApiKey),
+            Preview = !string.IsNullOrEmpty(feedbackApiKey) ? feedbackApiKey[..Math.Min(3, feedbackApiKey.Length)] + "..." : "(not set)",
+            IsRequired = false,
+        });
+```
+
+This follows the exact pattern of lines 174-183 (Ticket Vendor API key).
+
+- [ ] **Step 3: Build to verify no compilation errors**
+
+Run: `dotnet build Humans.slnx`
+Expected: Build succeeded
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Humans.Web/Controllers/AdminController.cs
+git commit -m "feat: add FEEDBACK_API_KEY to admin configuration page (#147)"
+```
+
+---
+
+### Task 2: Update /whats skill to surface pending feedback
+
+**Files:**
+- Modify: `~/.claude/skills/whats/SKILL.md`
+
+- [ ] **Step 1: Add feedback check to /whats tiered gathering table**
+
+In the `### 1b: Tiered gathering` section, add a new row to the source table:
+
+| Source | `next` | default | `blocked` | `new` | `full` |
+|--------|--------|---------|-----------|-------|--------|
+| Feedback API | — | yes | — | — | yes |
+
+- [ ] **Step 2: Add feedback fetch instructions after Step 1c**
+
+Add a new section `### 1d: Feedback check` after `### 1c: Batch GitHub data`:
+
+```markdown
+### 1d: Feedback check
+
+When the feedback API check is applicable (see tiered gathering), fetch pending feedback in parallel with other sources:
+
+\`\`\`bash
+curl -sf -H "X-Api-Key: $HUMANS_API_KEY" "$HUMANS_API_URL/api/feedback?status=Open" 2>/dev/null
+\`\`\`
+
+If `HUMANS_API_URL` or `HUMANS_API_KEY` are not set, skip silently (no error). If the curl fails (server down, bad key), skip silently.
+
+Count the number of Open reports from the JSON array response.
+```
+
+- [ ] **Step 3: Add feedback to output sections**
+
+In `### Default (no modifier)`, add after the Status line:
+```markdown
+- If feedback API returned results, append to status: ", X pending feedback reports"
+- If any Open feedback exists, add a recommendation: "Run `/triage` to process N pending feedback reports — community-reported issues should get fast turnaround"
+```
+
+In `### full`, add to the Status section:
+```markdown
+- Include pending feedback count in status line
+- List each pending report briefly (category, first line of description, date)
+```
+
+- [ ] **Step 4: Commit (outside repo — this is a user skill file, no git)**
+
+No commit needed — skill files live in `~/.claude/skills/`, outside the repo.
+
+---
+
+### Task 3: Create /triage skill
+
+**Files:**
+- Create: `~/.claude/skills/triage/SKILL.md`
+
+- [ ] **Step 1: Create the skill directory**
+
+```bash
+mkdir -p ~/.claude/skills/triage
+```
+
+- [ ] **Step 2: Write the skill file**
+
+Create `~/.claude/skills/triage/SKILL.md` with this content:
+
+````markdown
+---
+name: triage
+description: "Triage pending feedback from the Humans app — respond to reporters, create GitHub issues, update status. Use when /whats shows pending feedback or when you want to process community reports."
+argument-hint: "[qa] [all]"
+---
+
+# Feedback Triage
+
+Interactive triage of pending feedback from the Humans app via its API.
+
+## Arguments
+
+- *(none)* — triage Open reports from production
+- `qa` — triage from QA instance (`$HUMANS_QA_API_URL`) instead of production
+- `all` — include Acknowledged reports (for re-triage / follow-up)
+
+## Prerequisites
+
+Requires env vars (set in `.claude/settings.local.json`):
+- `HUMANS_API_URL` — production base URL
+- `HUMANS_QA_API_URL` — QA base URL
+- `HUMANS_API_KEY` — API key (same for both environments)
+
+If any required var is missing, tell the user and stop.
+
+## Step 1: Fetch pending feedback
+
+Determine base URL:
+- If `qa` argument: use `$HUMANS_QA_API_URL`
+- Otherwise: use `$HUMANS_API_URL`
+
+Fetch Open reports:
+```bash
+curl -sf -H "X-Api-Key: $HUMANS_API_KEY" "$BASE_URL/api/feedback?status=Open"
+```
+
+If `all` argument, also fetch Acknowledged and merge:
+```bash
+curl -sf -H "X-Api-Key: $HUMANS_API_KEY" "$BASE_URL/api/feedback?status=Acknowledged"
+```
+
+Parse the JSON array. If empty → "No pending feedback." → done.
+
+Store results. Sort by CreatedAt ascending (oldest first).
+
+## Step 2: Triage each report
+
+For each report, display:
+```
+### Feedback #{index} — {Category}
+**Description:** {Description}
+**Page:** {PageUrl}
+**Submitted:** {CreatedAt}
+**Reporter:** {ReporterName}
+**Status:** {Status}
+```
+
+If the report has a screenshot URL, note it: "Screenshot available at {BASE_URL}{ScreenshotUrl}"
+
+Then present the action menu via `AskUserQuestion`:
+
+| Option | Label | Description |
+|--------|-------|-------------|
+| 1 | Respond & Resolve | Send a response to the reporter and mark as Resolved |
+| 2 | Create Issue | Create a GitHub issue and link it back |
+| 3 | Create Issue + Respond | Create issue, then send response mentioning issue number |
+| 4 | Won't Fix | Mark as Won't Fix (optionally with a response) |
+| 5 | Skip | Move to next report |
+
+### Action: Respond & Resolve
+
+1. Draft a response message based on the feedback content. Present it to the user for review/edit via `AskUserQuestion` with a text input option.
+2. Send the response:
+   ```bash
+   curl -sf -X POST -H "X-Api-Key: $HUMANS_API_KEY" -H "Content-Type: application/json" \
+     -d '{"message": "<response text>"}' \
+     "$BASE_URL/api/feedback/{id}/respond"
+   ```
+3. Update status to Resolved:
+   ```bash
+   curl -sf -X PATCH -H "X-Api-Key: $HUMANS_API_KEY" -H "Content-Type: application/json" \
+     -d '{"status": "Resolved"}' \
+     "$BASE_URL/api/feedback/{id}/status"
+   ```
+
+### Action: Create Issue
+
+1. Compose the issue title — summarize the description in one short sentence.
+2. Create the GitHub issue:
+   ```bash
+   gh issue create --repo nobodies-collective/Humans \
+     --title "<title>" \
+     --label "<bug|enhancement|question>" \
+     --body "$(cat <<'EOF'
+   **Reported via in-app feedback**
+
+   > {Description}
+
+   - **Category:** {Category}
+   - **Page:** {PageUrl}
+   - **Reported:** {CreatedAt}
+   EOF
+   )"
+   ```
+3. Extract the issue number from the output.
+4. Link it back to the feedback report:
+   ```bash
+   curl -sf -X PATCH -H "X-Api-Key: $HUMANS_API_KEY" -H "Content-Type: application/json" \
+     -d '{"issueNumber": <number>}' \
+     "$BASE_URL/api/feedback/{id}/github-issue"
+   ```
+5. Update status to Acknowledged:
+   ```bash
+   curl -sf -X PATCH -H "X-Api-Key: $HUMANS_API_KEY" -H "Content-Type: application/json" \
+     -d '{"status": "Acknowledged"}' \
+     "$BASE_URL/api/feedback/{id}/status"
+   ```
+
+### Action: Create Issue + Respond
+
+1. Do "Create Issue" steps above.
+2. Draft a response referencing the issue number, e.g.: "Thanks for reporting this! We've logged it as #<number> and will look into it."
+3. Present to user for review/edit.
+4. Send the response via the respond endpoint.
+5. Status stays Acknowledged (not Resolved — issue is still open).
+
+### Action: Won't Fix
+
+1. Optionally draft a brief explanation response. Ask user if they want to send it.
+2. If yes, send via respond endpoint.
+3. Update status to WontFix:
+   ```bash
+   curl -sf -X PATCH -H "X-Api-Key: $HUMANS_API_KEY" -H "Content-Type: application/json" \
+     -d '{"status": "WontFix"}' \
+     "$BASE_URL/api/feedback/{id}/status"
+   ```
+
+### Action: Skip
+
+Move to next report. No API calls.
+
+## Step 3: Summary
+
+After all reports are processed, print:
+
+```
+Triage complete: X reports processed
+- Issues created: Y
+- Responses sent: Z
+- Won't Fix: W
+- Skipped: S
+```
+
+If any issues were created, list them: `#number: title`
+````
+
+- [ ] **Step 3: Test that the skill loads**
+
+Verify the skill appears in the skill list — the user can check by looking at the available skills in their next session (or by running `/triage` to see if it triggers).
+
+- [ ] **Step 4: No commit needed**
+
+Skill files live in `~/.claude/skills/`, outside the repo.
+
+---
+
+### Task 4: Update feature spec and commit
+
+**Files:**
+- Modify: `docs/features/27-feedback-system.md`
+
+- [ ] **Step 1: Add triage workflow section to feature spec**
+
+Append a section to `docs/features/27-feedback-system.md` documenting the triage workflow:
+- Claude Code integration via API
+- `/whats` surfaces pending feedback count
+- `/triage` skill for interactive processing
+- Environment setup requirements (FEEDBACK_API_KEY, Claude Code env vars)
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/features/27-feedback-system.md docs/superpowers/specs/2026-03-19-feedback-triage-workflow-design.md docs/superpowers/plans/2026-03-19-feedback-triage-workflow.md
+git commit -m "docs: add feedback triage workflow spec and plan (#147)"
+```
+
+---
+
+### Task 5: Push and create PR
+
+- [ ] **Step 1: Verify build passes**
+
+Run: `dotnet build Humans.slnx`
+Expected: Build succeeded
+
+- [ ] **Step 2: Run format check**
+
+Run: `dotnet format Humans.slnx --verify-no-changes`
+Expected: No formatting issues
+
+- [ ] **Step 3: Push and create PR**
+
+```bash
+git push -u origin feature/147-feedback-triage
+gh pr create --repo peterdrier/Humans --base main \
+  --title "feat: feedback triage workflow (#147)" \
+  --body "..."
+```

--- a/docs/superpowers/specs/2026-03-19-feedback-triage-workflow-design.md
+++ b/docs/superpowers/specs/2026-03-19-feedback-triage-workflow-design.md
@@ -1,0 +1,157 @@
+# Feedback Triage Workflow — Design Spec
+
+**Issue:** #147 — Add feedback-to-issue triage workflow via API
+**Date:** 2026-03-19
+**Supersedes:** #142 (bug reporting link — covered by feedback widget + this workflow)
+
+## Context
+
+The in-app feedback system (#141) is live. Humans submit bug reports, feature requests, and questions via a widget on every page. Reports are stored in the database and accessible through both an admin web UI (`/Admin/Feedback`) and a JSON API (`/api/feedback`).
+
+The API already supports all CRUD operations needed for triage:
+
+| Endpoint | Purpose |
+|----------|---------|
+| `GET /api/feedback?status=Open` | List pending reports |
+| `GET /api/feedback/{id}` | Get single report |
+| `PATCH /api/feedback/{id}/status` | Update status |
+| `PATCH /api/feedback/{id}/notes` | Set admin notes |
+| `PATCH /api/feedback/{id}/github-issue` | Link GH issue number |
+| `POST /api/feedback/{id}/respond` | Send email response to reporter |
+
+Authentication: `X-Api-Key` header against `FEEDBACK_API_KEY` env var.
+
+**Gap:** No workflow ties these endpoints together. Feedback accumulates without being acted on. The goal is a Claude Code workflow where pending feedback surfaces during dev sessions and can be triaged interactively.
+
+## Deliverables
+
+### 1. `/whats` skill integration
+
+Add a feedback check to the `/whats` skill's Step 1 (parallel gathering).
+
+**When:** All modes except `next` (too slow for single-line output).
+
+**How:**
+```bash
+curl -sf -H "X-Api-Key: $HUMANS_API_KEY" "$HUMANS_API_URL/api/feedback?status=Open"
+```
+
+**In output:**
+- Status line: "X pending feedback reports" alongside open issue/blocked counts
+- If any Open feedback exists, add to recommendations: "Run `/triage` to process N pending feedback reports"
+- Feedback count is informational only — `/whats` does not triage, it surfaces
+
+**Env vars** (stored in `.claude/settings.local.json`, gitignored):
+- `HUMANS_API_URL` — defaults to production (`https://humans.nobodies.team`)
+- `HUMANS_QA_API_URL` — QA instance (`https://humans.n.burn.camp`)
+- `HUMANS_API_KEY` — shared API key for both environments
+
+### 2. `/triage` skill (new)
+
+Interactive skill that processes pending feedback one at a time.
+
+**Trigger:** User runs `/triage` (or recommended by `/whats` when feedback is pending).
+
+**Arguments:**
+- *(none)* — triage Open reports from production
+- `qa` — triage from QA instance instead
+- `all` — include Acknowledged reports (re-triage)
+
+**Flow:**
+
+1. **Fetch** `GET /api/feedback?status=Open` (for `all` mode: two requests — one for Open, one for Acknowledged — merged client-side, since the API accepts only a single status filter)
+2. **If empty** — "No pending feedback." — done
+3. **For each report**, display:
+   - Category badge (Bug / Feature Request / Question)
+   - Description (full text)
+   - Page URL where submitted
+   - Submission date
+   - Reporter name (from API response)
+4. **Action menu** via `AskUserQuestion`:
+
+| Action | Steps |
+|--------|-------|
+| **Respond & Resolve** | User writes message → `POST /respond` → `PATCH /status` to Resolved |
+| **Create Issue** | `gh issue create --repo nobodies-collective/Humans` → `PATCH /github-issue` → `PATCH /status` to Acknowledged |
+| **Create Issue + Respond** | Create issue, then send response mentioning issue number, then Acknowledged |
+| **Won't Fix** | Optional response → `PATCH /status` to WontFix |
+| **Skip** | Move to next report |
+
+5. **Summary** — "Triaged X reports: Y issues created, Z responses sent, W skipped"
+
+**Issue creation details:**
+- Title: AI summary of first sentence of description, or user-provided
+- Body template:
+  ```markdown
+  **Reported via in-app feedback**
+
+  > {description}
+
+  - **Category:** {category}
+  - **Page:** {pageUrl}
+  - **Reported:** {createdAt}
+  ```
+- Labels: `bug` for Bug, `enhancement` for FeatureRequest, `question` for Question
+- After creation: link issue number back to feedback report via `PATCH /github-issue`
+
+**Response drafting:**
+- For each response action, Claude drafts a message based on the feedback content and action taken
+- User reviews/edits via `AskUserQuestion` text input before sending
+- Example draft for issue creation: "Thanks for reporting this! We've logged it as #{number} and will look into it."
+
+### 3. Admin/Configuration page — add Feedback API key
+
+Add `FEEDBACK_API_KEY` to the Admin/Configuration diagnostics page so admins can verify it's set on production.
+
+**Change:** In `AdminController.Configuration()`, add an env var check after the existing Ticket Vendor pattern:
+
+```csharp
+var feedbackApiKey = Environment.GetEnvironmentVariable("FEEDBACK_API_KEY");
+items.Add(new ConfigurationItemViewModel
+{
+    Section = "Feedback API",
+    Key = "FEEDBACK_API_KEY (env)",
+    IsSet = !string.IsNullOrEmpty(feedbackApiKey),
+    Preview = !string.IsNullOrEmpty(feedbackApiKey)
+        ? feedbackApiKey[..Math.Min(3, feedbackApiKey.Length)] + "..."
+        : "(not set)",
+    IsRequired = false,
+});
+```
+
+This follows the exact pattern used for `TICKET_VENDOR_API_KEY` at line 175-183.
+
+## Environment Setup
+
+### Server side
+- `FEEDBACK_API_KEY` env var set in Coolify for QA and production deployments
+- Same key value used for both (simplifies Claude Code config)
+
+### Claude Code side
+`.claude/settings.local.json` (gitignored):
+```json
+{
+  "env": {
+    "HUMANS_API_URL": "https://humans.nobodies.team",
+    "HUMANS_QA_API_URL": "https://humans.n.burn.camp",
+    "HUMANS_API_KEY": "<key>"
+  }
+}
+```
+
+## YAGNI — Not included
+
+- **Webhook notifications** — no push notifications when feedback arrives; polling via `/whats` is sufficient
+- **Batch triage** — no bulk actions; at ~500 users, volume is low enough for one-at-a-time
+- **Priority scoring** — no automatic prioritization of feedback; human judgment during triage
+- **Feedback history for reporters** — reporters don't see their past submissions (beyond email responses)
+- **Auto-categorization** — no AI classification of feedback category; reporters choose
+
+## Files to create/modify
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `~/.claude/skills/triage/SKILL.md` | Create | New triage skill |
+| `~/.claude/skills/whats/SKILL.md` | Modify | Add feedback check to Step 1 |
+| `src/Humans.Web/Controllers/AdminController.cs` | Modify | Add FEEDBACK_API_KEY to config page |
+| `docs/features/27-feedback-system.md` | Update | Document triage workflow integration |

--- a/src/Humans.Web/Controllers/AdminController.cs
+++ b/src/Humans.Web/Controllers/AdminController.cs
@@ -138,13 +138,13 @@ public class AdminController : HumansControllerBase
             ("Email", "Email:Password", true),
             ("Email", "Email:FromAddress", true),
             ("Email", "Email:BaseUrl", true),
-            ("Google Workspace", "GoogleWorkspace:ServiceAccountKeyPath", false),
-            ("Google Workspace", "GoogleWorkspace:ServiceAccountKeyJson", false),
-            ("Google Workspace", "GoogleWorkspace:Domain", false),
             ("GitHub", "GitHub:Owner", true),
             ("GitHub", "GitHub:Repository", true),
             ("GitHub", "GitHub:AccessToken", true),
             ("Google Maps", "GoogleMaps:ApiKey", true),
+            ("Google Workspace", "GoogleWorkspace:ServiceAccountKeyPath", false),
+            ("Google Workspace", "GoogleWorkspace:ServiceAccountKeyJson", false),
+            ("Google Workspace", "GoogleWorkspace:Domain", false),
             ("OpenTelemetry", "OpenTelemetry:OtlpEndpoint", false),
             ("Ticket Vendor", "TicketVendor:EventId", false),
             ("Ticket Vendor", "TicketVendor:Provider", false),
@@ -171,7 +171,19 @@ public class AdminController : HumansControllerBase
             };
         }).ToList();
 
-        // Ticket vendor API key is from env var, not configuration
+        // Env var keys (inserted in alphabetical order by section)
+        var feedbackApiKey = Environment.GetEnvironmentVariable("FEEDBACK_API_KEY");
+        items.Insert(
+            items.FindIndex(i => string.Equals(i.Section, "GitHub", StringComparison.Ordinal)),
+            new ConfigurationItemViewModel
+            {
+                Section = "Feedback API",
+                Key = "FEEDBACK_API_KEY (env)",
+                IsSet = !string.IsNullOrEmpty(feedbackApiKey),
+                Preview = !string.IsNullOrEmpty(feedbackApiKey) ? feedbackApiKey[..Math.Min(3, feedbackApiKey.Length)] + "..." : "(not set)",
+                IsRequired = false,
+            });
+
         var apiKey = Environment.GetEnvironmentVariable("TICKET_VENDOR_API_KEY");
         items.Add(new ConfigurationItemViewModel
         {
@@ -179,17 +191,6 @@ public class AdminController : HumansControllerBase
             Key = "TICKET_VENDOR_API_KEY (env)",
             IsSet = !string.IsNullOrEmpty(apiKey),
             Preview = !string.IsNullOrEmpty(apiKey) ? apiKey[..Math.Min(3, apiKey.Length)] + "..." : "(not set)",
-            IsRequired = false,
-        });
-
-        // Feedback API key is from env var
-        var feedbackApiKey = Environment.GetEnvironmentVariable("FEEDBACK_API_KEY");
-        items.Add(new ConfigurationItemViewModel
-        {
-            Section = "Feedback API",
-            Key = "FEEDBACK_API_KEY (env)",
-            IsSet = !string.IsNullOrEmpty(feedbackApiKey),
-            Preview = !string.IsNullOrEmpty(feedbackApiKey) ? feedbackApiKey[..Math.Min(3, feedbackApiKey.Length)] + "..." : "(not set)",
             IsRequired = false,
         });
 

--- a/src/Humans.Web/Controllers/AdminController.cs
+++ b/src/Humans.Web/Controllers/AdminController.cs
@@ -182,6 +182,17 @@ public class AdminController : HumansControllerBase
             IsRequired = false,
         });
 
+        // Feedback API key is from env var
+        var feedbackApiKey = Environment.GetEnvironmentVariable("FEEDBACK_API_KEY");
+        items.Add(new ConfigurationItemViewModel
+        {
+            Section = "Feedback API",
+            Key = "FEEDBACK_API_KEY (env)",
+            IsSet = !string.IsNullOrEmpty(feedbackApiKey),
+            Preview = !string.IsNullOrEmpty(feedbackApiKey) ? feedbackApiKey[..Math.Min(3, feedbackApiKey.Length)] + "..." : "(not set)",
+            IsRequired = false,
+        });
+
         return View(new AdminConfigurationViewModel { Items = items });
     }
 


### PR DESCRIPTION
## Summary
- Add `FEEDBACK_API_KEY` to Admin Configuration diagnostics page (follows existing Ticket Vendor pattern)
- Add spec and plan docs for the feedback triage workflow
- Update feedback system feature doc with triage integration section

The companion skill files (`/whats` integration and new `/triage` skill) live in `~/.claude/skills/` outside the repo.

## Test plan
- [ ] Verify `/Admin/Configuration` shows "Feedback API" section with key status
- [ ] Verify `FEEDBACK_API_KEY` env var is set in QA Coolify
- [ ] Test `/triage qa` against QA instance (submit test feedback first)
- [ ] Test `/whats` shows pending feedback count in Humans project

🤖 Generated with [Claude Code](https://claude.com/claude-code)