### PR TITLE
feat: fix coordinator visibility and sync reconciliation (#152)

### DIFF
--- a/src/Humans.Application/DTOs/SyncReport.cs
+++ b/src/Humans.Application/DTOs/SyncReport.cs
@@ -1,17 +1,33 @@
 namespace Humans.Application.DTOs;
 
 /// <summary>
+/// A person affected by a sync step, with enough info to render a link.
+/// </summary>
+public record SyncAffectedUser(Guid UserId, string DisplayName);
+
+/// <summary>
+/// A single change within a sync step.
+/// </summary>
+public record SyncChange(string Action, SyncAffectedUser User, string Detail);
+
+/// <summary>
 /// Result of a single sync step (e.g., "Volunteers", "Coordinators").
 /// </summary>
 public record SyncStepResult(string StepName)
 {
-    public List<string> Added { get; } = [];
-    public List<string> Removed { get; } = [];
-    public List<string> Fixed { get; } = [];
-    public List<string> Skipped { get; } = [];
+    public List<SyncChange> Changes { get; } = [];
 
-    public int TotalChanges => Added.Count + Removed.Count + Fixed.Count;
-    public bool HasChanges => TotalChanges > 0;
+    public int TotalChanges => Changes.Count;
+    public bool HasChanges => Changes.Count > 0;
+
+    public void Added(Guid userId, string displayName, string? detail = null) =>
+        Changes.Add(new SyncChange("Added", new SyncAffectedUser(userId, displayName), detail ?? ""));
+
+    public void Removed(Guid userId, string displayName, string? detail = null) =>
+        Changes.Add(new SyncChange("Removed", new SyncAffectedUser(userId, displayName), detail ?? ""));
+
+    public void Fixed(Guid userId, string displayName, string detail) =>
+        Changes.Add(new SyncChange("Fixed", new SyncAffectedUser(userId, displayName), detail));
 }
 
 /// <summary>
@@ -21,8 +37,6 @@ public class SyncReport
 {
     public List<SyncStepResult> Steps { get; } = [];
 
-    public int TotalAdded => Steps.Sum(s => s.Added.Count);
-    public int TotalRemoved => Steps.Sum(s => s.Removed.Count);
-    public int TotalFixed => Steps.Sum(s => s.Fixed.Count);
+    public int TotalChanges => Steps.Sum(s => s.TotalChanges);
     public bool HasChanges => Steps.Any(s => s.HasChanges);
 }

--- a/src/Humans.Application/DTOs/SyncReport.cs
+++ b/src/Humans.Application/DTOs/SyncReport.cs
@@ -1,0 +1,28 @@
+namespace Humans.Application.DTOs;
+
+/// <summary>
+/// Result of a single sync step (e.g., "Volunteers", "Coordinators").
+/// </summary>
+public record SyncStepResult(string StepName)
+{
+    public List<string> Added { get; } = [];
+    public List<string> Removed { get; } = [];
+    public List<string> Fixed { get; } = [];
+    public List<string> Skipped { get; } = [];
+
+    public int TotalChanges => Added.Count + Removed.Count + Fixed.Count;
+    public bool HasChanges => TotalChanges > 0;
+}
+
+/// <summary>
+/// Aggregate result of a full system team sync run.
+/// </summary>
+public class SyncReport
+{
+    public List<SyncStepResult> Steps { get; } = [];
+
+    public int TotalAdded => Steps.Sum(s => s.Added.Count);
+    public int TotalRemoved => Steps.Sum(s => s.Removed.Count);
+    public int TotalFixed => Steps.Sum(s => s.Fixed.Count);
+    public bool HasChanges => Steps.Any(s => s.HasChanges);
+}

--- a/src/Humans.Application/DTOs/SyncReport.cs
+++ b/src/Humans.Application/DTOs/SyncReport.cs
@@ -15,7 +15,7 @@ public record SyncChange(string Action, SyncAffectedUser User, string Detail);
 /// </summary>
 public record SyncStepResult(string StepName)
 {
-    public List<SyncChange> Changes { get; } = [];
+    public List<SyncChange> Changes { get; init; } = [];
 
     public int TotalChanges => Changes.Count;
     public bool HasChanges => Changes.Count > 0;
@@ -35,7 +35,7 @@ public record SyncStepResult(string StepName)
 /// </summary>
 public class SyncReport
 {
-    public List<SyncStepResult> Steps { get; } = [];
+    public List<SyncStepResult> Steps { get; init; } = [];
 
     public int TotalChanges => Steps.Sum(s => s.TotalChanges);
     public bool HasChanges => Steps.Any(s => s.HasChanges);

--- a/src/Humans.Application/Interfaces/ISystemTeamSync.cs
+++ b/src/Humans.Application/Interfaces/ISystemTeamSync.cs
@@ -10,6 +10,6 @@ public interface ISystemTeamSync
     Task SyncCoordinatorsMembershipForUserAsync(Guid userId, CancellationToken cancellationToken = default);
     Task SyncColaboradorsMembershipForUserAsync(Guid userId, CancellationToken cancellationToken = default);
     Task SyncAsociadosMembershipForUserAsync(Guid userId, CancellationToken cancellationToken = default);
-    Task SyncBoardTeamAsync(CancellationToken cancellationToken = default);
+    Task SyncBoardTeamAsync(Application.DTOs.SyncReport? report = null, CancellationToken cancellationToken = default);
     Task SyncBarrioLeadsMembershipForUserAsync(Guid userId, CancellationToken cancellationToken = default);
 }

--- a/src/Humans.Infrastructure/Jobs/SystemTeamSyncJob.cs
+++ b/src/Humans.Infrastructure/Jobs/SystemTeamSyncJob.cs
@@ -7,6 +7,7 @@ using Humans.Application.Interfaces;
 using Humans.Domain.Constants;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
+using Humans.Application.DTOs;
 using Humans.Infrastructure.Data;
 using Humans.Infrastructure.Services;
 
@@ -50,23 +51,25 @@ public class SystemTeamSyncJob : ISystemTeamSync
     }
 
     /// <summary>
-    /// Executes the system team sync job.
+    /// Executes the system team sync job and returns a report of what changed.
     /// </summary>
-    public async Task ExecuteAsync(CancellationToken cancellationToken = default)
+    public async Task<SyncReport> ExecuteAsync(CancellationToken cancellationToken = default)
     {
         _logger.LogInformation("Starting system team sync at {Time}", _clock.GetCurrentInstant());
+        var report = new SyncReport();
 
         try
         {
             // These run sequentially because they share the same DbContext instance,
             // which is not thread-safe. Parallelizing with Task.WhenAll would require
             // IServiceScopeFactory to create separate DbContext instances per task.
-            await SyncVolunteersTeamAsync(cancellationToken);
-            await SyncCoordinatorsTeamAsync(cancellationToken);
-            await SyncBoardTeamAsync(cancellationToken);
-            await SyncAsociadosTeamAsync(cancellationToken);
-            await SyncColaboradorsTeamAsync(cancellationToken);
-            await SyncBarrioLeadsTeamAsync(cancellationToken);
+            await SyncVolunteersTeamAsync(report, cancellationToken);
+            await ReconcileCoordinatorRolesAsync(report, cancellationToken);
+            await SyncCoordinatorsTeamAsync(report, cancellationToken);
+            await SyncBoardTeamAsync(report, cancellationToken);
+            await SyncAsociadosTeamAsync(report, cancellationToken);
+            await SyncColaboradorsTeamAsync(report, cancellationToken);
+            await SyncBarrioLeadsTeamAsync(report, cancellationToken);
 
             _metrics.RecordJobRun("system_team_sync", "success");
             _logger.LogInformation("Completed system team sync");
@@ -77,15 +80,90 @@ public class SystemTeamSyncJob : ISystemTeamSync
             _logger.LogError(ex, "Error during system team sync");
             throw;
         }
+
+        return report;
+    }
+
+    /// <summary>
+    /// Reconciles TeamMember.Role with IsManagement role assignments.
+    /// Members assigned to an IsManagement role definition should have Role = Coordinator.
+    /// Members not assigned to any IsManagement role should have Role = Member.
+    /// </summary>
+    public async Task ReconcileCoordinatorRolesAsync(SyncReport? report = null, CancellationToken cancellationToken = default)
+    {
+        _logger.LogDebug("Reconciling coordinator roles with IsManagement assignments");
+        var step = new SyncStepResult("Coordinator Role Reconciliation");
+
+        // Find all active team members who are assigned to an IsManagement role but have Role = Member
+        var shouldBeCoordinator = await _dbContext.TeamMembers
+            .Include(tm => tm.User)
+            .Include(tm => tm.RoleAssignments)
+                .ThenInclude(ra => ra.TeamRoleDefinition)
+            .Where(tm =>
+                tm.LeftAt == null &&
+                tm.Role == TeamMemberRole.Member &&
+                tm.RoleAssignments.Any(ra => ra.TeamRoleDefinition.IsManagement))
+            .ToListAsync(cancellationToken);
+
+        foreach (var member in shouldBeCoordinator)
+        {
+            member.Role = TeamMemberRole.Coordinator;
+            var teamName = await _dbContext.Teams
+                .Where(t => t.Id == member.TeamId)
+                .Select(t => t.Name)
+                .FirstOrDefaultAsync(cancellationToken) ?? "Unknown";
+
+            step.Fixed.Add($"{member.User.DisplayName} promoted to Coordinator on {teamName}");
+
+            _logger.LogInformation(
+                "Reconciled {UserName} to Coordinator on team {TeamId} (had IsManagement role assignment)",
+                member.User.DisplayName, member.TeamId);
+        }
+
+        // Find all active team members who have Role = Coordinator but no IsManagement role assignment
+        var shouldBeMember = await _dbContext.TeamMembers
+            .Include(tm => tm.User)
+            .Include(tm => tm.RoleAssignments)
+                .ThenInclude(ra => ra.TeamRoleDefinition)
+            .Where(tm =>
+                tm.LeftAt == null &&
+                tm.Role == TeamMemberRole.Coordinator &&
+                tm.Team.SystemTeamType == SystemTeamType.None &&
+                !tm.RoleAssignments.Any(ra => ra.TeamRoleDefinition.IsManagement))
+            .ToListAsync(cancellationToken);
+
+        foreach (var member in shouldBeMember)
+        {
+            member.Role = TeamMemberRole.Member;
+            var teamName = await _dbContext.Teams
+                .Where(t => t.Id == member.TeamId)
+                .Select(t => t.Name)
+                .FirstOrDefaultAsync(cancellationToken) ?? "Unknown";
+
+            step.Fixed.Add($"{member.User.DisplayName} demoted to Member on {teamName} (no IsManagement role)");
+
+            _logger.LogInformation(
+                "Reconciled {UserName} to Member on team {TeamId} (no IsManagement role assignment)",
+                member.User.DisplayName, member.TeamId);
+        }
+
+        if (shouldBeCoordinator.Count > 0 || shouldBeMember.Count > 0)
+        {
+            await _dbContext.SaveChangesAsync(cancellationToken);
+            _cache.Remove(CacheKeys.ActiveTeams);
+        }
+
+        report?.Steps.Add(step);
     }
 
     /// <summary>
     /// Syncs the Volunteers team membership based on document compliance.
     /// Members: All users with all required documents signed.
     /// </summary>
-    public async Task SyncVolunteersTeamAsync(CancellationToken cancellationToken = default)
+    public async Task SyncVolunteersTeamAsync(SyncReport? report = null, CancellationToken cancellationToken = default)
     {
         _logger.LogDebug("Syncing Volunteers team");
+        var step = new SyncStepResult("Volunteers");
 
         var team = await GetSystemTeamAsync(SystemTeamType.Volunteers, cancellationToken);
         if (team == null)
@@ -105,16 +183,18 @@ public class SystemTeamSyncJob : ISystemTeamSync
         var partition = await _membershipCalculator.PartitionUsersAsync(allApprovedIds, cancellationToken);
         var eligibleUserIds = partition.Active.ToList();
 
-        await SyncTeamMembershipAsync(team, eligibleUserIds, cancellationToken);
+        await SyncTeamMembershipAsync(team, eligibleUserIds, cancellationToken, step: step);
+        report?.Steps.Add(step);
     }
 
     /// <summary>
     /// Syncs the Coordinators team membership based on Coordinator roles.
     /// Members: All users who are Coordinator of any team.
     /// </summary>
-    public async Task SyncCoordinatorsTeamAsync(CancellationToken cancellationToken = default)
+    public async Task SyncCoordinatorsTeamAsync(SyncReport? report = null, CancellationToken cancellationToken = default)
     {
         _logger.LogDebug("Syncing Coordinators team");
+        var step = new SyncStepResult("Coordinators");
 
         var team = await GetSystemTeamAsync(SystemTeamType.Coordinators, cancellationToken);
         if (team == null)
@@ -138,16 +218,18 @@ public class SystemTeamSyncJob : ISystemTeamSync
         var eligibleSet = await _membershipCalculator.GetUsersWithAllRequiredConsentsForTeamAsync(
             leadUserIds, SystemTeamIds.Coordinators, cancellationToken);
 
-        await SyncTeamMembershipAsync(team, eligibleSet.ToList(), cancellationToken);
+        await SyncTeamMembershipAsync(team, eligibleSet.ToList(), cancellationToken, step: step);
+        report?.Steps.Add(step);
     }
 
     /// <summary>
     /// Syncs the Board team membership based on RoleAssignment.
     /// Members: All users with active "Board" RoleAssignment.
     /// </summary>
-    public async Task SyncBoardTeamAsync(CancellationToken cancellationToken = default)
+    public async Task SyncBoardTeamAsync(SyncReport? report = null, CancellationToken cancellationToken = default)
     {
         _logger.LogDebug("Syncing Board team");
+        var step = new SyncStepResult("Board");
 
         var team = await GetSystemTeamAsync(SystemTeamType.Board, cancellationToken);
         if (team == null)
@@ -173,27 +255,29 @@ public class SystemTeamSyncJob : ISystemTeamSync
         var eligibleSet = await _membershipCalculator.GetUsersWithAllRequiredConsentsForTeamAsync(
             boardMemberIds, SystemTeamIds.Board, cancellationToken);
 
-        await SyncTeamMembershipAsync(team, eligibleSet.ToList(), cancellationToken);
+        await SyncTeamMembershipAsync(team, eligibleSet.ToList(), cancellationToken, step: step);
+        report?.Steps.Add(step);
     }
 
     /// <summary>
     /// Syncs the Asociados team membership based on approved applications.
     /// Members: All users with an approved Asociado application.
     /// </summary>
-    public Task SyncAsociadosTeamAsync(CancellationToken cancellationToken = default) =>
-        SyncTierTeamAsync(MembershipTier.Asociado, SystemTeamType.Asociados, SystemTeamIds.Asociados, cancellationToken);
+    public Task SyncAsociadosTeamAsync(SyncReport? report = null, CancellationToken cancellationToken = default) =>
+        SyncTierTeamAsync(MembershipTier.Asociado, SystemTeamType.Asociados, SystemTeamIds.Asociados, report, cancellationToken);
 
     /// <summary>
     /// Syncs the Colaboradors team membership based on approved Colaborador applications.
     /// Members: All users with an approved Colaborador application who are also in the Volunteers team.
     /// </summary>
-    public Task SyncColaboradorsTeamAsync(CancellationToken cancellationToken = default) =>
-        SyncTierTeamAsync(MembershipTier.Colaborador, SystemTeamType.Colaboradors, SystemTeamIds.Colaboradors, cancellationToken);
+    public Task SyncColaboradorsTeamAsync(SyncReport? report = null, CancellationToken cancellationToken = default) =>
+        SyncTierTeamAsync(MembershipTier.Colaborador, SystemTeamType.Colaboradors, SystemTeamIds.Colaboradors, report, cancellationToken);
 
     private async Task SyncTierTeamAsync(MembershipTier tier, SystemTeamType teamType, Guid teamId,
-        CancellationToken cancellationToken)
+        SyncReport? report, CancellationToken cancellationToken)
     {
         _logger.LogDebug("Syncing {TeamType} team", teamType);
+        var step = new SyncStepResult(teamType.ToString());
 
         var team = await GetSystemTeamAsync(teamType, cancellationToken);
         if (team == null)
@@ -264,7 +348,8 @@ public class SystemTeamSyncJob : ISystemTeamSync
             await _dbContext.SaveChangesAsync(cancellationToken);
         }
 
-        await SyncTeamMembershipAsync(team, eligibleUserIds, cancellationToken);
+        await SyncTeamMembershipAsync(team, eligibleUserIds, cancellationToken, step: step);
+        report?.Steps.Add(step);
     }
 
     /// <summary>
@@ -369,9 +454,10 @@ public class SystemTeamSyncJob : ISystemTeamSync
     /// Syncs the Barrio Leads team membership based on active CampLead assignments.
     /// Members: All users who are active leads of any camp.
     /// </summary>
-    public async Task SyncBarrioLeadsTeamAsync(CancellationToken cancellationToken = default)
+    public async Task SyncBarrioLeadsTeamAsync(SyncReport? report = null, CancellationToken cancellationToken = default)
     {
         _logger.LogDebug("Syncing Barrio Leads team");
+        var step = new SyncStepResult("Barrio Leads");
 
         var team = await GetSystemTeamAsync(SystemTeamType.BarrioLeads, cancellationToken);
         if (team == null)
@@ -387,7 +473,8 @@ public class SystemTeamSyncJob : ISystemTeamSync
             .Distinct()
             .ToListAsync(cancellationToken);
 
-        await SyncTeamMembershipAsync(team, eligibleUserIds, cancellationToken);
+        await SyncTeamMembershipAsync(team, eligibleUserIds, cancellationToken, step: step);
+        report?.Steps.Add(step);
     }
 
     /// <summary>
@@ -419,7 +506,7 @@ public class SystemTeamSyncJob : ISystemTeamSync
     }
 
     private async Task SyncTeamMembershipAsync(Team team, List<Guid> eligibleUserIds,
-        CancellationToken cancellationToken, Guid? singleUserSync = null)
+        CancellationToken cancellationToken, Guid? singleUserSync = null, SyncStepResult? step = null)
     {
         var currentMemberIds = team.Members
             .Where(m => m.LeftAt == null)
@@ -462,6 +549,7 @@ public class SystemTeamSyncJob : ISystemTeamSync
             _dbContext.TeamMembers.Add(member);
 
             var userName = userNames.GetValueOrDefault(userId, userId.ToString());
+            step?.Added.Add(userName);
             await _auditLogService.LogAsync(
                 AuditAction.TeamMemberAdded, nameof(Team), team.Id,
                 $"{userName} added to {team.Name} by system sync",
@@ -486,6 +574,7 @@ public class SystemTeamSyncJob : ISystemTeamSync
                 member.LeftAt = now;
 
                 var userName = userNames.GetValueOrDefault(userId, userId.ToString());
+                step?.Removed.Add(userName);
                 await _auditLogService.LogAsync(
                     AuditAction.TeamMemberRemoved, nameof(Team), team.Id,
                     $"{userName} removed from {team.Name} by system sync",

--- a/src/Humans.Infrastructure/Jobs/SystemTeamSyncJob.cs
+++ b/src/Humans.Infrastructure/Jobs/SystemTeamSyncJob.cs
@@ -113,7 +113,7 @@ public class SystemTeamSyncJob : ISystemTeamSync
                 .Select(t => t.Name)
                 .FirstOrDefaultAsync(cancellationToken) ?? "Unknown";
 
-            step.Fixed.Add($"{member.User.DisplayName} promoted to Coordinator on {teamName}");
+            step.Fixed(member.UserId, member.User.DisplayName, $"Promoted to Coordinator on {teamName}");
 
             _logger.LogInformation(
                 "Reconciled {UserName} to Coordinator on team {TeamId} (had IsManagement role assignment)",
@@ -140,7 +140,7 @@ public class SystemTeamSyncJob : ISystemTeamSync
                 .Select(t => t.Name)
                 .FirstOrDefaultAsync(cancellationToken) ?? "Unknown";
 
-            step.Fixed.Add($"{member.User.DisplayName} demoted to Member on {teamName} (no IsManagement role)");
+            step.Fixed(member.UserId, member.User.DisplayName, $"Demoted to Member on {teamName} (no IsManagement role)");
 
             _logger.LogInformation(
                 "Reconciled {UserName} to Member on team {TeamId} (no IsManagement role assignment)",
@@ -549,7 +549,7 @@ public class SystemTeamSyncJob : ISystemTeamSync
             _dbContext.TeamMembers.Add(member);
 
             var userName = userNames.GetValueOrDefault(userId, userId.ToString());
-            step?.Added.Add(userName);
+            step?.Added(userId, userName);
             await _auditLogService.LogAsync(
                 AuditAction.TeamMemberAdded, nameof(Team), team.Id,
                 $"{userName} added to {team.Name} by system sync",
@@ -574,7 +574,7 @@ public class SystemTeamSyncJob : ISystemTeamSync
                 member.LeftAt = now;
 
                 var userName = userNames.GetValueOrDefault(userId, userId.ToString());
-                step?.Removed.Add(userName);
+                step?.Removed(userId, userName);
                 await _auditLogService.LogAsync(
                     AuditAction.TeamMemberRemoved, nameof(Team), team.Id,
                     $"{userName} removed from {team.Name} by system sync",

--- a/src/Humans.Infrastructure/Jobs/SystemTeamSyncJob.cs
+++ b/src/Humans.Infrastructure/Jobs/SystemTeamSyncJob.cs
@@ -169,6 +169,7 @@ public class SystemTeamSyncJob : ISystemTeamSync
         if (team == null)
         {
             _logger.LogWarning("Volunteers system team not found");
+            report?.Steps.Add(step);
             return;
         }
 
@@ -200,6 +201,7 @@ public class SystemTeamSyncJob : ISystemTeamSync
         if (team == null)
         {
             _logger.LogWarning("Coordinators system team not found");
+            report?.Steps.Add(step);
             return;
         }
 
@@ -235,6 +237,7 @@ public class SystemTeamSyncJob : ISystemTeamSync
         if (team == null)
         {
             _logger.LogWarning("Board system team not found");
+            report?.Steps.Add(step);
             return;
         }
 
@@ -283,6 +286,7 @@ public class SystemTeamSyncJob : ISystemTeamSync
         if (team == null)
         {
             _logger.LogWarning("{TeamType} system team not found", teamType);
+            report?.Steps.Add(step);
             return;
         }
 
@@ -463,6 +467,7 @@ public class SystemTeamSyncJob : ISystemTeamSync
         if (team == null)
         {
             _logger.LogWarning("Barrio Leads system team not found");
+            report?.Steps.Add(step);
             return;
         }
 

--- a/src/Humans.Infrastructure/Services/TeamService.cs
+++ b/src/Humans.Infrastructure/Services/TeamService.cs
@@ -780,8 +780,31 @@ public partial class TeamService : ITeamService
         CancellationToken cancellationToken = default)
     {
         var cached = await GetCachedTeamsAsync(cancellationToken);
-        return cached.TryGetValue(teamId, out var team) &&
-               team.Members.Any(m => m.UserId == userId && m.Role == TeamMemberRole.Coordinator);
+        if (!cached.TryGetValue(teamId, out var team))
+            return false;
+
+        // Check direct coordinator role on this team
+        if (team.Members.Any(m => m.UserId == userId && m.Role == TeamMemberRole.Coordinator))
+            return true;
+
+        // Check IsManagement role assignment (source of truth — handles cases where
+        // TeamMember.Role hasn't been reconciled yet)
+        var hasManagementRole = await _dbContext.Set<TeamRoleAssignment>()
+            .AsNoTracking()
+            .AnyAsync(ra =>
+                ra.TeamMember.TeamId == teamId &&
+                ra.TeamMember.UserId == userId &&
+                ra.TeamMember.LeftAt == null &&
+                ra.TeamRoleDefinition.IsManagement,
+                cancellationToken);
+        if (hasManagementRole)
+            return true;
+
+        // Check if user is coordinator of the parent team (department coordinators manage child teams)
+        if (team.ParentTeamId.HasValue)
+            return await IsUserCoordinatorOfTeamAsync(team.ParentTeamId.Value, userId, cancellationToken);
+
+        return false;
     }
 
     public async Task<bool> IsUserAdminAsync(Guid userId, CancellationToken cancellationToken = default)

--- a/src/Humans.Web/Controllers/AdminController.cs
+++ b/src/Humans.Web/Controllers/AdminController.cs
@@ -106,32 +106,34 @@ public class AdminController : HumansControllerBase
         try
         {
             var report = await systemTeamSyncJob.ExecuteAsync();
-
-            if (!report.HasChanges)
-            {
-                SetSuccess("System teams synced — no changes needed.");
-            }
-            else
-            {
-                var parts = new List<string>();
-                foreach (var step in report.Steps.Where(s => s.HasChanges))
-                {
-                    var changes = new List<string>();
-                    if (step.Added.Count > 0) changes.Add($"+{step.Added.Count} added");
-                    if (step.Removed.Count > 0) changes.Add($"-{step.Removed.Count} removed");
-                    if (step.Fixed.Count > 0) changes.Add($"{step.Fixed.Count} fixed");
-                    parts.Add($"{step.StepName}: {string.Join(", ", changes)}");
-                }
-                SetSuccess($"System teams synced. {string.Join(". ", parts)}.");
-            }
+            TempData["SyncReport"] = System.Text.Json.JsonSerializer.Serialize(report);
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to sync system teams");
             SetError($"Sync failed: {ex.Message}");
+            return RedirectToAction(nameof(Index));
         }
 
-        return RedirectToAction(nameof(Index));
+        return RedirectToAction(nameof(SyncResults));
+    }
+
+    [HttpGet("SyncResults")]
+    public IActionResult SyncResults()
+    {
+        SyncReport? report = null;
+        if (TempData["SyncReport"] is string json)
+        {
+            report = System.Text.Json.JsonSerializer.Deserialize<SyncReport>(json);
+        }
+
+        if (report == null)
+        {
+            SetInfo("No sync results to display. Run a sync first.");
+            return RedirectToAction(nameof(Index));
+        }
+
+        return View(report);
     }
 
     [HttpGet("Logs")]

--- a/src/Humans.Web/Controllers/AdminController.cs
+++ b/src/Humans.Web/Controllers/AdminController.cs
@@ -105,8 +105,25 @@ public class AdminController : HumansControllerBase
     {
         try
         {
-            await systemTeamSyncJob.ExecuteAsync();
-            SetSuccess("System teams synced successfully.");
+            var report = await systemTeamSyncJob.ExecuteAsync();
+
+            if (!report.HasChanges)
+            {
+                SetSuccess("System teams synced — no changes needed.");
+            }
+            else
+            {
+                var parts = new List<string>();
+                foreach (var step in report.Steps.Where(s => s.HasChanges))
+                {
+                    var changes = new List<string>();
+                    if (step.Added.Count > 0) changes.Add($"+{step.Added.Count} added");
+                    if (step.Removed.Count > 0) changes.Add($"-{step.Removed.Count} removed");
+                    if (step.Fixed.Count > 0) changes.Add($"{step.Fixed.Count} fixed");
+                    parts.Add($"{step.StepName}: {string.Join(", ", changes)}");
+                }
+                SetSuccess($"System teams synced. {string.Join(". ", parts)}.");
+            }
         }
         catch (Exception ex)
         {

--- a/src/Humans.Web/Views/Admin/SyncResults.cshtml
+++ b/src/Humans.Web/Views/Admin/SyncResults.cshtml
@@ -1,0 +1,78 @@
+@model Humans.Application.DTOs.SyncReport
+@{
+    ViewData["Title"] = "System Team Sync Results";
+}
+
+<div class="container-fluid px-4">
+    <div class="d-flex justify-content-between align-items-center mt-4 mb-3">
+        <h1>Sync Results</h1>
+        <a asp-action="Index" class="btn btn-outline-secondary btn-sm">
+            <i class="fa-solid fa-arrow-left me-1"></i>Back to Admin
+        </a>
+    </div>
+
+    @if (!Model.HasChanges)
+    {
+        <div class="alert alert-success">
+            <i class="fa-solid fa-check-circle me-1"></i>All @Model.Steps.Count steps completed — no changes needed.
+        </div>
+    }
+    else
+    {
+        <div class="alert alert-info">
+            <i class="fa-solid fa-arrows-rotate me-1"></i>Sync completed with @Model.TotalChanges change(s) across @Model.Steps.Count steps.
+        </div>
+    }
+
+    @foreach (var step in Model.Steps)
+    {
+        <div class="card mb-3">
+            <div class="card-header d-flex justify-content-between align-items-center">
+                <strong>@step.StepName</strong>
+                @if (step.HasChanges)
+                {
+                    <span class="badge bg-warning text-dark">@step.TotalChanges change(s)</span>
+                }
+                else
+                {
+                    <span class="badge bg-success">No changes</span>
+                }
+            </div>
+            @if (step.HasChanges)
+            {
+                <div class="card-body p-0">
+                    <table class="table table-sm mb-0">
+                        <thead>
+                            <tr>
+                                <th style="width: 100px">Action</th>
+                                <th>Human</th>
+                                <th>Detail</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach (var change in step.Changes)
+                            {
+                                var badgeClass = change.Action switch
+                                {
+                                    "Added" => "bg-success",
+                                    "Removed" => "bg-danger",
+                                    "Fixed" => "bg-info",
+                                    _ => "bg-secondary"
+                                };
+                                <tr>
+                                    <td><span class="badge @badgeClass">@change.Action</span></td>
+                                    <td>
+                                        <a asp-controller="Human" asp-action="Detail" asp-route-id="@change.User.UserId">
+                                            @change.User.DisplayName
+                                        </a>
+                                    </td>
+                                    <td class="text-muted">@change.Detail</td>
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
+                </div>
+            }
+        </div>
+    }
+</div>


### PR DESCRIPTION
## Summary
- **IsUserCoordinatorOfTeamAsync** now checks `IsManagement` role assignments as source of truth, not just denormalized `TeamMember.Role`
- **Department coordinators** inherit management access to child teams via parent team check
- **New sync step** `ReconcileCoordinatorRolesAsync` fixes `TeamMember.Role` drift from `IsManagement` role assignments (promotes/demotes as needed)
- **Sync reporting** — `ExecuteAsync` returns `SyncReport` with per-step details; admin sync button shows summary of changes

Closes #152

## Test plan
- [ ] Log in as Doreen (or a coordinator with an IsManagement role) — verify Team Management tab is visible
- [ ] Run Admin > Sync System Teams — verify it shows what changed (e.g., "Coordinator Role Reconciliation: 1 fixed")
- [ ] After sync, verify Doreen's `TeamMember.Role` is now `Coordinator` in the DB
- [ ] Check a department coordinator can see management tab on child team pages
- [ ] Verify Hangfire hourly sync still works (returns report, no errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)