### PR TITLE
feat: camp contact privacy — hide email, facilitated messaging, multiple links (#146)

### DIFF
--- a/.github/workflows/preview-db.yml
+++ b/.github/workflows/preview-db.yml
@@ -14,8 +14,7 @@ jobs:
           PR_ID=${{ github.event.pull_request.number }}
           DB_NAME="humans_pr_${PR_ID}"
 
-          # Terminate connections and drop if exists (handles re-deploys on push)
-          docker exec humans-db psql -U humans -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '${DB_NAME}' AND pid <> pg_backend_pid();" || true
+          # Drop if exists (handles re-deploys on push)
           docker exec humans-db psql -U humans -c "DROP DATABASE IF EXISTS ${DB_NAME};"
 
           # Create empty database then restore from QA
@@ -34,7 +33,6 @@ jobs:
     steps:
       - name: Drop preview database
         run: |
-          docker exec humans-db psql -U humans -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = 'humans_pr_${{ github.event.pull_request.number }}' AND pid <> pg_backend_pid();" || true
           docker exec humans-db psql -U humans -c "DROP DATABASE IF EXISTS humans_pr_${{ github.event.pull_request.number }};"
 
       - name: Remove preview uploads

--- a/docs/features/20-camps.md
+++ b/docs/features/20-camps.md
@@ -24,9 +24,10 @@ Nobodies Collective organizes camping areas ("barrios") at Nowhere and related e
 **So that** I can learn about its community and decide whether to join
 
 **Acceptance Criteria:**
-- Shows camp name, contact info, description, images
+- Shows camp name, links (with platform icons), description, images
+- Contact email is hidden — replaced with facilitated "Contact this camp" button (login required)
 - Displays current season data (vibes, kids policy, performance space, etc.)
-- Shows leads with display names
+- Shows leads with display names (authenticated users only)
 - Shows historical names if any
 - Leads and admins see edit link
 
@@ -128,8 +129,8 @@ Camp
 ├── Slug: string [unique, URL-friendly]
 ├── ContactEmail: string
 ├── ContactPhone: string
-├── WebOrSocialUrl: string?
-├── ContactMethod: string
+├── WebOrSocialUrl: string? (legacy, read-only fallback — cleared when Links is populated)
+├── Links: List<CampLink>? (jsonb — multiple URLs with auto-detected platform)
 ├── IsSwissCamp: bool
 ├── TimesAtNowhere: int
 ├── CreatedByUserId: Guid (FK → User)

--- a/src/Humans.Application/Interfaces/ICampService.cs
+++ b/src/Humans.Application/Interfaces/ICampService.cs
@@ -1,5 +1,6 @@
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
+using Humans.Domain.ValueObjects;
 using NodaTime;
 
 namespace Humans.Application.Interfaces;
@@ -13,7 +14,7 @@ public interface ICampService
         string contactEmail,
         string contactPhone,
         string? webOrSocialUrl,
-        string contactMethod,
+        List<CampLink>? links,
         bool isSwissCamp,
         int timesAtNowhere,
         CampSeasonData seasonData,
@@ -39,7 +40,7 @@ public interface ICampService
     Task ReactivateSeasonAsync(Guid seasonId, CancellationToken cancellationToken = default);
     // Camp updates
     Task UpdateCampAsync(Guid campId, string contactEmail, string contactPhone,
-        string? webOrSocialUrl, string contactMethod, bool isSwissCamp, int timesAtNowhere,
+        string? webOrSocialUrl, List<CampLink>? links, bool isSwissCamp, int timesAtNowhere,
         CancellationToken cancellationToken = default);
     Task DeleteCampAsync(Guid campId, CancellationToken cancellationToken = default);
 

--- a/src/Humans.Domain/Entities/Camp.cs
+++ b/src/Humans.Domain/Entities/Camp.cs
@@ -1,3 +1,4 @@
+using Humans.Domain.ValueObjects;
 using NodaTime;
 
 namespace Humans.Domain.Entities;
@@ -9,7 +10,7 @@ public class Camp
     public string ContactEmail { get; set; } = string.Empty;
     public string ContactPhone { get; set; } = string.Empty;
     public string? WebOrSocialUrl { get; set; }
-    public string ContactMethod { get; set; } = string.Empty;
+    public List<CampLink>? Links { get; set; }
     public bool IsSwissCamp { get; set; }
     public int TimesAtNowhere { get; set; }
 

--- a/src/Humans.Domain/Helpers/PlatformDetector.cs
+++ b/src/Humans.Domain/Helpers/PlatformDetector.cs
@@ -1,0 +1,46 @@
+namespace Humans.Domain.Helpers;
+
+public static class PlatformDetector
+{
+    public record PlatformInfo(string Name, string IconClass);
+
+    private static readonly Dictionary<string, PlatformInfo> KnownPlatforms = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["instagram.com"] = new("Instagram", "fa-brands fa-instagram"),
+        ["facebook.com"] = new("Facebook", "fa-brands fa-facebook"),
+        ["x.com"] = new("X", "fa-brands fa-x-twitter"),
+        ["twitter.com"] = new("X", "fa-brands fa-x-twitter"),
+        ["tiktok.com"] = new("TikTok", "fa-brands fa-tiktok"),
+        ["discord.gg"] = new("Discord", "fa-brands fa-discord"),
+        ["discord.com"] = new("Discord", "fa-brands fa-discord"),
+        ["youtube.com"] = new("YouTube", "fa-brands fa-youtube"),
+        ["linkedin.com"] = new("LinkedIn", "fa-brands fa-linkedin"),
+    };
+
+    public static PlatformInfo Detect(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url) || !Uri.TryCreate(url, UriKind.Absolute, out var uri))
+            return new PlatformInfo(string.Empty, "fa-solid fa-link");
+
+        var host = uri.Host.ToLowerInvariant();
+        if (host.StartsWith("www.", StringComparison.Ordinal))
+            host = host[4..];
+
+        if (KnownPlatforms.TryGetValue(host, out var platform))
+            return platform;
+
+        return new PlatformInfo(host, "fa-solid fa-link");
+    }
+
+    public static bool IsSocialMedia(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url) || !Uri.TryCreate(url, UriKind.Absolute, out var uri))
+            return false;
+
+        var host = uri.Host.ToLowerInvariant();
+        if (host.StartsWith("www.", StringComparison.Ordinal))
+            host = host[4..];
+
+        return KnownPlatforms.ContainsKey(host);
+    }
+}

--- a/src/Humans.Domain/ValueObjects/CampLink.cs
+++ b/src/Humans.Domain/ValueObjects/CampLink.cs
@@ -1,0 +1,7 @@
+namespace Humans.Domain.ValueObjects;
+
+public class CampLink
+{
+    public string Url { get; set; } = string.Empty;
+    public string? Platform { get; set; }
+}

--- a/src/Humans.Infrastructure/Data/Configurations/CampConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/CampConfiguration.cs
@@ -25,7 +25,7 @@ public class CampConfiguration : IEntityTypeConfiguration<Camp>
                 v => JsonSerializer.Serialize(v, JsonOptions),
                 v => JsonSerializer.Deserialize<List<CampLink>>(v, JsonOptions) ?? new(),
                 new ValueComparer<List<CampLink>>(
-                    (a, b) => a != null && b != null && JsonSerializer.Serialize(a, JsonOptions) == JsonSerializer.Serialize(b, JsonOptions),
+                    (a, b) => a == null ? b == null : b != null && JsonSerializer.Serialize(a, JsonOptions) == JsonSerializer.Serialize(b, JsonOptions),
                     v => string.GetHashCode(JsonSerializer.Serialize(v, JsonOptions), StringComparison.Ordinal),
                     v => JsonSerializer.Deserialize<List<CampLink>>(JsonSerializer.Serialize(v, JsonOptions), JsonOptions)!));
 

--- a/src/Humans.Infrastructure/Data/Configurations/CampConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/CampConfiguration.cs
@@ -1,11 +1,16 @@
+using System.Text.Json;
 using Humans.Domain.Entities;
+using Humans.Domain.ValueObjects;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace Humans.Infrastructure.Data.Configurations;
 
 public class CampConfiguration : IEntityTypeConfiguration<Camp>
 {
+    private static readonly JsonSerializerOptions JsonOptions = new();
+
     public void Configure(EntityTypeBuilder<Camp> builder)
     {
         builder.ToTable("camps");
@@ -14,7 +19,15 @@ public class CampConfiguration : IEntityTypeConfiguration<Camp>
         builder.Property(b => b.ContactEmail).HasMaxLength(256).IsRequired();
         builder.Property(b => b.ContactPhone).HasMaxLength(64).IsRequired();
         builder.Property(b => b.WebOrSocialUrl).HasMaxLength(512);
-        builder.Property(b => b.ContactMethod).HasMaxLength(512).IsRequired();
+
+        builder.Property(b => b.Links).HasColumnType("jsonb")
+            .HasConversion(
+                v => JsonSerializer.Serialize(v, JsonOptions),
+                v => JsonSerializer.Deserialize<List<CampLink>>(v, JsonOptions) ?? new(),
+                new ValueComparer<List<CampLink>>(
+                    (a, b) => a != null && b != null && JsonSerializer.Serialize(a, JsonOptions) == JsonSerializer.Serialize(b, JsonOptions),
+                    v => string.GetHashCode(JsonSerializer.Serialize(v, JsonOptions), StringComparison.Ordinal),
+                    v => JsonSerializer.Deserialize<List<CampLink>>(JsonSerializer.Serialize(v, JsonOptions), JsonOptions)!));
 
         builder.HasIndex(b => b.Slug).IsUnique();
 

--- a/src/Humans.Infrastructure/Migrations/20260319191455_AddCampLinksRemoveContactMethod.Designer.cs
+++ b/src/Humans.Infrastructure/Migrations/20260319191455_AddCampLinksRemoveContactMethod.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Humans.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Humans.Infrastructure.Migrations
 {
     [DbContext(typeof(HumansDbContext))]
-    partial class HumansDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260319191455_AddCampLinksRemoveContactMethod")]
+    partial class AddCampLinksRemoveContactMethod
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Humans.Infrastructure/Migrations/20260319191455_AddCampLinksRemoveContactMethod.cs
+++ b/src/Humans.Infrastructure/Migrations/20260319191455_AddCampLinksRemoveContactMethod.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Humans.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCampLinksRemoveContactMethod : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ContactMethod",
+                table: "camps");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Links",
+                table: "camps",
+                type: "jsonb",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Links",
+                table: "camps");
+
+            migrationBuilder.AddColumn<string>(
+                name: "ContactMethod",
+                table: "camps",
+                type: "character varying(512)",
+                maxLength: 512,
+                nullable: false,
+                defaultValue: "");
+        }
+    }
+}

--- a/src/Humans.Infrastructure/Services/CampService.cs
+++ b/src/Humans.Infrastructure/Services/CampService.cs
@@ -1,6 +1,7 @@
 using Humans.Application.Interfaces;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
+using Humans.Domain.ValueObjects;
 using Humans.Infrastructure.Data;
 using Humans.Infrastructure.Helpers;
 using Microsoft.EntityFrameworkCore;
@@ -44,7 +45,7 @@ public class CampService : ICampService
 
     public async Task<Camp> CreateCampAsync(
         Guid createdByUserId, string name, string contactEmail, string contactPhone,
-        string? webOrSocialUrl, string contactMethod, bool isSwissCamp, int timesAtNowhere,
+        string? webOrSocialUrl, List<CampLink>? links, bool isSwissCamp, int timesAtNowhere,
         CampSeasonData seasonData, List<string>? historicalNames, int year,
         CancellationToken cancellationToken = default)
     {
@@ -69,7 +70,7 @@ public class CampService : ICampService
             ContactEmail = contactEmail,
             ContactPhone = contactPhone,
             WebOrSocialUrl = webOrSocialUrl,
-            ContactMethod = contactMethod,
+            Links = links,
             IsSwissCamp = isSwissCamp,
             TimesAtNowhere = timesAtNowhere,
             CreatedByUserId = createdByUserId,
@@ -421,7 +422,7 @@ public class CampService : ICampService
     // ==========================================================================
 
     public async Task UpdateCampAsync(Guid campId, string contactEmail, string contactPhone,
-        string? webOrSocialUrl, string contactMethod, bool isSwissCamp, int timesAtNowhere,
+        string? webOrSocialUrl, List<CampLink>? links, bool isSwissCamp, int timesAtNowhere,
         CancellationToken cancellationToken = default)
     {
         var camp = await _dbContext.Camps.FindAsync([campId], cancellationToken)
@@ -430,7 +431,9 @@ public class CampService : ICampService
         camp.ContactEmail = contactEmail;
         camp.ContactPhone = contactPhone;
         camp.WebOrSocialUrl = webOrSocialUrl;
-        camp.ContactMethod = contactMethod;
+        camp.Links = links;
+        if (links is { Count: > 0 })
+            camp.WebOrSocialUrl = null;
         camp.IsSwissCamp = isSwissCamp;
         camp.TimesAtNowhere = timesAtNowhere;
         camp.UpdatedAt = _clock.GetCurrentInstant();

--- a/src/Humans.Infrastructure/Services/CampService.cs
+++ b/src/Humans.Infrastructure/Services/CampService.cs
@@ -69,7 +69,7 @@ public class CampService : ICampService
             Slug = slug,
             ContactEmail = contactEmail,
             ContactPhone = contactPhone,
-            WebOrSocialUrl = webOrSocialUrl,
+            WebOrSocialUrl = links is { Count: > 0 } ? null : webOrSocialUrl,
             Links = links,
             IsSwissCamp = isSwissCamp,
             TimesAtNowhere = timesAtNowhere,

--- a/src/Humans.Web/Controllers/CampApiController.cs
+++ b/src/Humans.Web/Controllers/CampApiController.cs
@@ -43,7 +43,7 @@ public class CampApiController : ControllerBase
                 b.TimesAtNowhere,
                 b.IsSwissCamp,
                 b.ContactEmail,
-                b.ContactMethod,
+                b.Links,
                 b.WebOrSocialUrl
             };
         }).OrderBy(b => b.Name, StringComparer.OrdinalIgnoreCase).ToList();

--- a/src/Humans.Web/Controllers/CampApiController.cs
+++ b/src/Humans.Web/Controllers/CampApiController.cs
@@ -42,7 +42,6 @@ public class CampApiController : ControllerBase
                 Status = (season?.Status ?? CampSeasonStatus.Pending).ToString(),
                 b.TimesAtNowhere,
                 b.IsSwissCamp,
-                b.ContactEmail,
                 b.Links,
                 b.WebOrSocialUrl
             };

--- a/src/Humans.Web/Controllers/CampController.cs
+++ b/src/Humans.Web/Controllers/CampController.cs
@@ -4,10 +4,12 @@ using Microsoft.AspNetCore.Mvc;
 using Humans.Application.Interfaces;
 using Humans.Domain.Constants;
 using Humans.Domain.Entities;
+using System.Text.RegularExpressions;
 using Humans.Domain.Enums;
 using Humans.Domain.Helpers;
 using Humans.Domain.ValueObjects;
 using Humans.Web.Models;
+using Microsoft.Extensions.Caching.Memory;
 using Humans.Web.Authorization;
 using Microsoft.Extensions.Localization;
 using NodaTime;
@@ -22,19 +24,28 @@ public class CampController : HumansControllerBase
     private readonly IClock _clock;
     private readonly ILogger<CampController> _logger;
     private readonly IStringLocalizer<SharedResource> _localizer;
+    private readonly IEmailService _emailService;
+    private readonly IAuditLogService _auditLogService;
+    private readonly IMemoryCache _cache;
 
     public CampController(
         ICampService campService,
         UserManager<User> userManager,
         IClock clock,
         ILogger<CampController> logger,
-        IStringLocalizer<SharedResource> localizer)
+        IStringLocalizer<SharedResource> localizer,
+        IEmailService emailService,
+        IAuditLogService auditLogService,
+        IMemoryCache cache)
         : base(userManager)
     {
         _campService = campService;
         _clock = clock;
         _logger = logger;
         _localizer = localizer;
+        _emailService = emailService;
+        _auditLogService = auditLogService;
+        _cache = cache;
     }
 
     // ======================================================================
@@ -220,6 +231,89 @@ public class CampController : HumansControllerBase
         };
 
         return View(nameof(Details), viewModel);
+    }
+
+    // ======================================================================
+    // Facilitated Contact
+    // ======================================================================
+
+    [Authorize]
+    [HttpGet("{slug}/Contact")]
+    public async Task<IActionResult> Contact(string slug)
+    {
+        var camp = await _campService.GetCampBySlugAsync(slug);
+        if (camp == null) return NotFound();
+
+        var season = camp.Seasons.OrderByDescending(s => s.Year).FirstOrDefault();
+        var model = new CampContactViewModel
+        {
+            CampSlug = slug,
+            CampName = season?.Name ?? slug
+        };
+        return View(model);
+    }
+
+    [Authorize]
+    [HttpPost("{slug}/Contact")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Contact(string slug, CampContactViewModel model)
+    {
+        var camp = await _campService.GetCampBySlugAsync(slug);
+        if (camp == null) return NotFound();
+
+        var currentUser = await GetCurrentUserAsync();
+        if (currentUser == null) return Unauthorized();
+
+        // Rate limit: one message per camp per user per 10 minutes
+        var rateLimitKey = $"camp-contact:{currentUser.Id}:{camp.Id}";
+        if (_cache.TryGetValue(rateLimitKey, out _))
+        {
+            SetError(_localizer["Camp_Contact_RateLimited"].Value);
+            return RedirectToAction(nameof(Details), new { slug });
+        }
+
+        if (!ModelState.IsValid)
+        {
+            model.CampSlug = slug;
+            var season = camp.Seasons.OrderByDescending(s => s.Year).FirstOrDefault();
+            model.CampName = season?.Name ?? slug;
+            return View(model);
+        }
+
+        try
+        {
+            var cleanMessage = Regex.Replace(
+                model.Message, "<[^>]+>", "", RegexOptions.None, TimeSpan.FromSeconds(1));
+
+            var season2 = camp.Seasons.OrderByDescending(s => s.Year).FirstOrDefault();
+            var campDisplayName = season2?.Name ?? slug;
+            var senderEmail = currentUser.GetEffectiveEmail() ?? currentUser.Email!;
+
+            await _emailService.SendFacilitatedMessageAsync(
+                camp.ContactEmail,
+                campDisplayName,
+                currentUser.DisplayName,
+                cleanMessage,
+                model.IncludeContactInfo,
+                senderEmail);
+
+            await _auditLogService.LogAsync(
+                AuditAction.FacilitatedMessageSent,
+                nameof(Camp), camp.Id,
+                $"Message sent to camp '{campDisplayName}' (contact info shared: {(model.IncludeContactInfo ? "yes" : "no")})",
+                currentUser.Id, currentUser.DisplayName);
+
+            _cache.Set(rateLimitKey, true, TimeSpan.FromMinutes(10));
+
+            SetSuccess(string.Format(_localizer["Camp_Contact_Success"].Value, campDisplayName));
+            return RedirectToAction(nameof(Details), new { slug });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to send facilitated message to camp {Slug}", slug);
+            SetError(_localizer["Common_Error"].Value);
+            return RedirectToAction(nameof(Details), new { slug });
+        }
     }
 
     // ======================================================================

--- a/src/Humans.Web/Controllers/CampController.cs
+++ b/src/Humans.Web/Controllers/CampController.cs
@@ -372,7 +372,7 @@ public class CampController : HumansControllerBase
             var campLinks = model.Links
                 .Where(u => !string.IsNullOrWhiteSpace(u)
                     && Uri.TryCreate(u.Trim(), UriKind.Absolute, out var parsed)
-                    && (string.Equals(parsed.Scheme, "http", StringComparison.Ordinal) || string.Equals(parsed.Scheme, "https", StringComparison.Ordinal)))
+                    && (string.Equals(parsed.Scheme, Uri.UriSchemeHttp, StringComparison.Ordinal) || string.Equals(parsed.Scheme, Uri.UriSchemeHttps, StringComparison.Ordinal)))
                 .Select(u => new CampLink { Url = u.Trim(), Platform = PlatformDetector.Detect(u.Trim()).Name })
                 .ToList();
 
@@ -487,7 +487,7 @@ public class CampController : HumansControllerBase
             var updateLinks = model.Links
                 .Where(u => !string.IsNullOrWhiteSpace(u)
                     && Uri.TryCreate(u.Trim(), UriKind.Absolute, out var parsed)
-                    && (string.Equals(parsed.Scheme, "http", StringComparison.Ordinal) || string.Equals(parsed.Scheme, "https", StringComparison.Ordinal)))
+                    && (string.Equals(parsed.Scheme, Uri.UriSchemeHttp, StringComparison.Ordinal) || string.Equals(parsed.Scheme, Uri.UriSchemeHttps, StringComparison.Ordinal)))
                 .Select(u => new CampLink { Url = u.Trim(), Platform = PlatformDetector.Detect(u.Trim()).Name })
                 .ToList();
 

--- a/src/Humans.Web/Controllers/CampController.cs
+++ b/src/Humans.Web/Controllers/CampController.cs
@@ -370,7 +370,9 @@ public class CampController : HumansControllerBase
                     .ToList();
 
             var campLinks = model.Links
-                .Where(u => !string.IsNullOrWhiteSpace(u))
+                .Where(u => !string.IsNullOrWhiteSpace(u)
+                    && Uri.TryCreate(u.Trim(), UriKind.Absolute, out var parsed)
+                    && (string.Equals(parsed.Scheme, "http", StringComparison.Ordinal) || string.Equals(parsed.Scheme, "https", StringComparison.Ordinal)))
                 .Select(u => new CampLink { Url = u.Trim(), Platform = PlatformDetector.Detect(u.Trim()).Name })
                 .ToList();
 
@@ -379,7 +381,7 @@ public class CampController : HumansControllerBase
                 model.Name,
                 model.ContactEmail,
                 model.ContactPhone,
-                model.WebOrSocialUrl,
+                null, // WebOrSocialUrl legacy — new registrations/edits use Links
                 campLinks.Count > 0 ? campLinks : null,
                 model.IsSwissCamp,
                 model.TimesAtNowhere,
@@ -483,7 +485,9 @@ public class CampController : HumansControllerBase
         try
         {
             var updateLinks = model.Links
-                .Where(u => !string.IsNullOrWhiteSpace(u))
+                .Where(u => !string.IsNullOrWhiteSpace(u)
+                    && Uri.TryCreate(u.Trim(), UriKind.Absolute, out var parsed)
+                    && (string.Equals(parsed.Scheme, "http", StringComparison.Ordinal) || string.Equals(parsed.Scheme, "https", StringComparison.Ordinal)))
                 .Select(u => new CampLink { Url = u.Trim(), Platform = PlatformDetector.Detect(u.Trim()).Name })
                 .ToList();
 
@@ -491,7 +495,7 @@ public class CampController : HumansControllerBase
                 camp.Id,
                 model.ContactEmail,
                 model.ContactPhone,
-                model.WebOrSocialUrl,
+                null, // WebOrSocialUrl legacy — new registrations/edits use Links
                 updateLinks.Count > 0 ? updateLinks : null,
                 model.IsSwissCamp,
                 model.TimesAtNowhere);
@@ -843,7 +847,6 @@ public class CampController : HumansControllerBase
             Name = season.Name,
             ContactEmail = camp.ContactEmail,
             ContactPhone = camp.ContactPhone,
-            WebOrSocialUrl = camp.WebOrSocialUrl,
             Links = (camp.Links is { Count: > 0 } ? camp.Links.Select(l => l.Url).ToList() : camp.WebOrSocialUrl != null ? new List<string> { camp.WebOrSocialUrl } : new List<string>()),
             IsSwissCamp = camp.IsSwissCamp,
             TimesAtNowhere = camp.TimesAtNowhere,

--- a/src/Humans.Web/Controllers/CampController.cs
+++ b/src/Humans.Web/Controllers/CampController.cs
@@ -5,6 +5,8 @@ using Humans.Application.Interfaces;
 using Humans.Domain.Constants;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
+using Humans.Domain.Helpers;
+using Humans.Domain.ValueObjects;
 using Humans.Web.Models;
 using Humans.Web.Authorization;
 using Microsoft.Extensions.Localization;
@@ -151,9 +153,7 @@ public class CampController : HumansControllerBase
             Id = camp.Id,
             Slug = camp.Slug,
             Name = currentSeason?.Name ?? camp.Slug,
-            ContactEmail = camp.ContactEmail,
-            ContactMethod = camp.ContactMethod,
-            WebOrSocialUrl = camp.WebOrSocialUrl,
+            Links = (camp.Links is { Count: > 0 } ? camp.Links : camp.WebOrSocialUrl != null ? new List<CampLink> { new() { Url = camp.WebOrSocialUrl } } : new List<CampLink>()),
             IsSwissCamp = camp.IsSwissCamp,
             TimesAtNowhere = camp.TimesAtNowhere,
             HistoricalNames = camp.HistoricalNames.Select(h => h.Name).ToList(),
@@ -201,9 +201,7 @@ public class CampController : HumansControllerBase
             Id = camp.Id,
             Slug = camp.Slug,
             Name = season.Name,
-            ContactEmail = camp.ContactEmail,
-            ContactMethod = camp.ContactMethod,
-            WebOrSocialUrl = camp.WebOrSocialUrl,
+            Links = (camp.Links is { Count: > 0 } ? camp.Links : camp.WebOrSocialUrl != null ? new List<CampLink> { new() { Url = camp.WebOrSocialUrl } } : new List<CampLink>()),
             IsSwissCamp = camp.IsSwissCamp,
             TimesAtNowhere = camp.TimesAtNowhere,
             HistoricalNames = camp.HistoricalNames.Select(h => h.Name).ToList(),
@@ -277,13 +275,18 @@ public class CampController : HumansControllerBase
                     .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
                     .ToList();
 
+            var campLinks = model.Links
+                .Where(u => !string.IsNullOrWhiteSpace(u))
+                .Select(u => new CampLink { Url = u.Trim(), Platform = PlatformDetector.Detect(u.Trim()).Name })
+                .ToList();
+
             var camp = await _campService.CreateCampAsync(
                 user.Id,
                 model.Name,
                 model.ContactEmail,
                 model.ContactPhone,
                 model.WebOrSocialUrl,
-                model.ContactMethod,
+                campLinks.Count > 0 ? campLinks : null,
                 model.IsSwissCamp,
                 model.TimesAtNowhere,
                 MapToSeasonData(model),
@@ -385,12 +388,17 @@ public class CampController : HumansControllerBase
 
         try
         {
+            var updateLinks = model.Links
+                .Where(u => !string.IsNullOrWhiteSpace(u))
+                .Select(u => new CampLink { Url = u.Trim(), Platform = PlatformDetector.Detect(u.Trim()).Name })
+                .ToList();
+
             await _campService.UpdateCampAsync(
                 camp.Id,
                 model.ContactEmail,
                 model.ContactPhone,
                 model.WebOrSocialUrl,
-                model.ContactMethod,
+                updateLinks.Count > 0 ? updateLinks : null,
                 model.IsSwissCamp,
                 model.TimesAtNowhere);
 
@@ -742,7 +750,7 @@ public class CampController : HumansControllerBase
             ContactEmail = camp.ContactEmail,
             ContactPhone = camp.ContactPhone,
             WebOrSocialUrl = camp.WebOrSocialUrl,
-            ContactMethod = camp.ContactMethod,
+            Links = (camp.Links is { Count: > 0 } ? camp.Links.Select(l => l.Url).ToList() : camp.WebOrSocialUrl != null ? new List<string> { camp.WebOrSocialUrl } : new List<string>()),
             IsSwissCamp = camp.IsSwissCamp,
             TimesAtNowhere = camp.TimesAtNowhere,
             BlurbLong = season.BlurbLong,

--- a/src/Humans.Web/Models/CampViewModels.cs
+++ b/src/Humans.Web/Models/CampViewModels.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using Humans.Domain.Enums;
+using Humans.Domain.ValueObjects;
 
 namespace Humans.Web.Models;
 
@@ -42,9 +43,7 @@ public class CampDetailViewModel
     public Guid Id { get; set; }
     public string Slug { get; set; } = string.Empty;
     public string Name { get; set; } = string.Empty;
-    public string ContactEmail { get; set; } = string.Empty;
-    public string ContactMethod { get; set; } = string.Empty;
-    public string? WebOrSocialUrl { get; set; }
+    public List<CampLink> Links { get; set; } = new();
     public bool IsSwissCamp { get; set; }
     public int TimesAtNowhere { get; set; }
     public List<string> HistoricalNames { get; set; } = new();
@@ -95,7 +94,7 @@ public class CampRegisterViewModel
     public string ContactEmail { get; set; } = string.Empty;
     public string ContactPhone { get; set; } = string.Empty;
     public string? WebOrSocialUrl { get; set; }
-    public string ContactMethod { get; set; } = string.Empty;
+    public List<string> Links { get; set; } = new();
     public bool IsSwissCamp { get; set; }
     public int TimesAtNowhere { get; set; }
     public string? HistoricalNames { get; set; }

--- a/src/Humans.Web/Models/CampViewModels.cs
+++ b/src/Humans.Web/Models/CampViewModels.cs
@@ -136,6 +136,19 @@ public class CampImageViewModel
     public int SortOrder { get; set; }
 }
 
+// Contact form
+public class CampContactViewModel
+{
+    public string CampSlug { get; set; } = string.Empty;
+    public string CampName { get; set; } = string.Empty;
+
+    [Required]
+    [StringLength(2000, MinimumLength = 1)]
+    public string Message { get; set; } = string.Empty;
+
+    public bool IncludeContactInfo { get; set; } = true;
+}
+
 // Admin dashboard
 public class CampAdminViewModel
 {

--- a/src/Humans.Web/Models/CampViewModels.cs
+++ b/src/Humans.Web/Models/CampViewModels.cs
@@ -93,7 +93,6 @@ public class CampRegisterViewModel
     public string Name { get; set; } = string.Empty;
     public string ContactEmail { get; set; } = string.Empty;
     public string ContactPhone { get; set; } = string.Empty;
-    public string? WebOrSocialUrl { get; set; }
     public List<string> Links { get; set; } = new();
     public bool IsSwissCamp { get; set; }
     public int TimesAtNowhere { get; set; }

--- a/src/Humans.Web/Resources/SharedResource.de.resx
+++ b/src/Humans.Web/Resources/SharedResource.de.resx
@@ -46,6 +46,7 @@
   <data name="Common_Back" xml:space="preserve"><value>Zurück</value></data>
   <data name="Common_Submit" xml:space="preserve"><value>Absenden</value></data>
   <data name="Common_NotProvided" xml:space="preserve"><value>Nicht angegeben</value></data>
+  <data name="Common_Error" xml:space="preserve"><value>Etwas ist schiefgelaufen. Bitte versuche es später erneut.</value></data>
 
   <!-- ======================== -->
   <!-- Navigation (_Layout)     -->

--- a/src/Humans.Web/Resources/SharedResource.de.resx
+++ b/src/Humans.Web/Resources/SharedResource.de.resx
@@ -1142,6 +1142,23 @@
   <data name="Camp_SwissCampLabel" xml:space="preserve"><value>Wurde dieses Camp jemals "Swiss Camp" genannt?</value></data>
   <data name="Camp_InfoTitle" xml:space="preserve"><value>Barrio-Info</value></data>
   <data name="Camp_NameLabel" xml:space="preserve"><value>Barrio-Name</value></data>
+  <data name="Camp_ContactButton" xml:space="preserve"><value>Dieses Barrio kontaktieren</value></data>
+  <data name="Camp_ContactLoginHint" xml:space="preserve"><value>Anmeldung erforderlich · Deine E-Mail bleibt privat</value></data>
+  <data name="Camp_Contact_Title" xml:space="preserve"><value>Kontakt {0}</value></data>
+  <data name="Camp_Contact_Heading" xml:space="preserve"><value>Kontakt {0}</value></data>
+  <data name="Camp_Contact_Breadcrumb" xml:space="preserve"><value>Kontakt</value></data>
+  <data name="Camp_Contact_MessageLabel" xml:space="preserve"><value>Deine Nachricht</value></data>
+  <data name="Camp_Contact_PlainTextOnly" xml:space="preserve"><value>Nur Text. Maximal 2000 Zeichen.</value></data>
+  <data name="Camp_Contact_IncludeContactInfo" xml:space="preserve"><value>Meine Kontaktdaten einschließen</value></data>
+  <data name="Camp_Contact_IncludeContactInfoHelp" xml:space="preserve"><value>Deine E-Mail wird als Antwortadresse hinzugefügt, damit sie dir direkt antworten können</value></data>
+  <data name="Camp_Contact_Send" xml:space="preserve"><value>Senden</value></data>
+  <data name="Camp_Contact_Success" xml:space="preserve"><value>Deine Nachricht wurde an {0} gesendet.</value></data>
+  <data name="Camp_Contact_RateLimited" xml:space="preserve"><value>Du hast dieses Barrio kürzlich kontaktiert. Bitte warte einige Minuten.</value></data>
+  <data name="Camp_Links_Header" xml:space="preserve"><value>Links &amp; Kontakt</value></data>
+  <data name="Camp_Edit_Links" xml:space="preserve"><value>Links</value></data>
+  <data name="Camp_Edit_AddLink" xml:space="preserve"><value>Link hinzufügen</value></data>
+  <data name="Camp_Edit_RemoveLink" xml:space="preserve"><value>Entfernen</value></data>
+  <data name="Camp_Edit_WebsiteNudge" xml:space="preserve"><value>Wir empfehlen, eine Website für dein Barrio hinzuzufügen.</value></data>
   <data name="Shifts_SignedUp" xml:space="preserve"><value>Angemeldet</value></data>
   <data name="Shifts_Pending" xml:space="preserve"><value>(ausstehend)</value></data>
 

--- a/src/Humans.Web/Resources/SharedResource.es.resx
+++ b/src/Humans.Web/Resources/SharedResource.es.resx
@@ -46,6 +46,7 @@
   <data name="Common_Back" xml:space="preserve"><value>Volver</value></data>
   <data name="Common_Submit" xml:space="preserve"><value>Enviar</value></data>
   <data name="Common_NotProvided" xml:space="preserve"><value>No proporcionado</value></data>
+  <data name="Common_Error" xml:space="preserve"><value>Algo salió mal. Por favor, inténtalo de nuevo más tarde.</value></data>
 
   <!-- ======================== -->
   <!-- Navigation (_Layout)     -->

--- a/src/Humans.Web/Resources/SharedResource.es.resx
+++ b/src/Humans.Web/Resources/SharedResource.es.resx
@@ -1162,6 +1162,23 @@
   <data name="Camp_SwissCampLabel" xml:space="preserve"><value>¿Este camp se ha llamado alguna vez "Swiss Camp"?</value></data>
   <data name="Camp_InfoTitle" xml:space="preserve"><value>Información del Barrio</value></data>
   <data name="Camp_NameLabel" xml:space="preserve"><value>Nombre del Barrio</value></data>
+  <data name="Camp_ContactButton" xml:space="preserve"><value>Contactar este barrio</value></data>
+  <data name="Camp_ContactLoginHint" xml:space="preserve"><value>Requiere iniciar sesión · Tu email se mantiene privado</value></data>
+  <data name="Camp_Contact_Title" xml:space="preserve"><value>Contactar {0}</value></data>
+  <data name="Camp_Contact_Heading" xml:space="preserve"><value>Contactar {0}</value></data>
+  <data name="Camp_Contact_Breadcrumb" xml:space="preserve"><value>Contacto</value></data>
+  <data name="Camp_Contact_MessageLabel" xml:space="preserve"><value>Tu mensaje</value></data>
+  <data name="Camp_Contact_PlainTextOnly" xml:space="preserve"><value>Solo texto plano. Máximo 2000 caracteres.</value></data>
+  <data name="Camp_Contact_IncludeContactInfo" xml:space="preserve"><value>Incluir mi información de contacto</value></data>
+  <data name="Camp_Contact_IncludeContactInfoHelp" xml:space="preserve"><value>Tu email se añadirá como respuesta para que puedan responderte directamente</value></data>
+  <data name="Camp_Contact_Send" xml:space="preserve"><value>Enviar</value></data>
+  <data name="Camp_Contact_Success" xml:space="preserve"><value>Tu mensaje se ha enviado a {0}.</value></data>
+  <data name="Camp_Contact_RateLimited" xml:space="preserve"><value>Ya has contactado este barrio recientemente. Espera unos minutos antes de enviar otro mensaje.</value></data>
+  <data name="Camp_Links_Header" xml:space="preserve"><value>Enlaces y Contacto</value></data>
+  <data name="Camp_Edit_Links" xml:space="preserve"><value>Enlaces</value></data>
+  <data name="Camp_Edit_AddLink" xml:space="preserve"><value>Añadir enlace</value></data>
+  <data name="Camp_Edit_RemoveLink" xml:space="preserve"><value>Eliminar</value></data>
+  <data name="Camp_Edit_WebsiteNudge" xml:space="preserve"><value>Recomendamos encarecidamente añadir una web para tu barrio para que los visitantes puedan conocerte mejor.</value></data>
   <data name="Shifts_SignedUp" xml:space="preserve"><value>Apuntados</value></data>
   <data name="Shifts_Pending" xml:space="preserve"><value>(pendiente)</value></data>
 

--- a/src/Humans.Web/Resources/SharedResource.fr.resx
+++ b/src/Humans.Web/Resources/SharedResource.fr.resx
@@ -1142,6 +1142,23 @@
   <data name="Camp_SwissCampLabel" xml:space="preserve"><value>Ce camp a-t-il déjà été appelé "Swiss Camp" ?</value></data>
   <data name="Camp_InfoTitle" xml:space="preserve"><value>Info du Barrio</value></data>
   <data name="Camp_NameLabel" xml:space="preserve"><value>Nom du Barrio</value></data>
+  <data name="Camp_ContactButton" xml:space="preserve"><value>Contacter ce barrio</value></data>
+  <data name="Camp_ContactLoginHint" xml:space="preserve"><value>Connexion requise · Votre email reste privé</value></data>
+  <data name="Camp_Contact_Title" xml:space="preserve"><value>Contacter {0}</value></data>
+  <data name="Camp_Contact_Heading" xml:space="preserve"><value>Contacter {0}</value></data>
+  <data name="Camp_Contact_Breadcrumb" xml:space="preserve"><value>Contact</value></data>
+  <data name="Camp_Contact_MessageLabel" xml:space="preserve"><value>Votre message</value></data>
+  <data name="Camp_Contact_PlainTextOnly" xml:space="preserve"><value>Texte brut uniquement. Maximum 2000 caractères.</value></data>
+  <data name="Camp_Contact_IncludeContactInfo" xml:space="preserve"><value>Inclure mes coordonnées</value></data>
+  <data name="Camp_Contact_IncludeContactInfoHelp" xml:space="preserve"><value>Votre email sera ajouté en réponse pour qu'ils puissent vous répondre directement</value></data>
+  <data name="Camp_Contact_Send" xml:space="preserve"><value>Envoyer</value></data>
+  <data name="Camp_Contact_Success" xml:space="preserve"><value>Votre message a été envoyé à {0}.</value></data>
+  <data name="Camp_Contact_RateLimited" xml:space="preserve"><value>Vous avez déjà contacté ce barrio récemment. Veuillez patienter quelques minutes.</value></data>
+  <data name="Camp_Links_Header" xml:space="preserve"><value>Liens &amp; Contact</value></data>
+  <data name="Camp_Edit_Links" xml:space="preserve"><value>Liens</value></data>
+  <data name="Camp_Edit_AddLink" xml:space="preserve"><value>Ajouter un lien</value></data>
+  <data name="Camp_Edit_RemoveLink" xml:space="preserve"><value>Supprimer</value></data>
+  <data name="Camp_Edit_WebsiteNudge" xml:space="preserve"><value>Nous recommandons fortement d'ajouter un site web pour votre barrio.</value></data>
   <data name="Shifts_SignedUp" xml:space="preserve"><value>Inscrits</value></data>
   <data name="Shifts_Pending" xml:space="preserve"><value>(en attente)</value></data>
 

--- a/src/Humans.Web/Resources/SharedResource.fr.resx
+++ b/src/Humans.Web/Resources/SharedResource.fr.resx
@@ -46,6 +46,7 @@
   <data name="Common_Back" xml:space="preserve"><value>Retour</value></data>
   <data name="Common_Submit" xml:space="preserve"><value>Envoyer</value></data>
   <data name="Common_NotProvided" xml:space="preserve"><value>Non renseign&#xE9;</value></data>
+  <data name="Common_Error" xml:space="preserve"><value>Une erreur est survenue. Veuillez réessayer plus tard.</value></data>
 
   <!-- ======================== -->
   <!-- Navigation (_Layout)     -->

--- a/src/Humans.Web/Resources/SharedResource.it.resx
+++ b/src/Humans.Web/Resources/SharedResource.it.resx
@@ -1142,6 +1142,23 @@
   <data name="Camp_SwissCampLabel" xml:space="preserve"><value>Questo camp è mai stato chiamato "Swiss Camp"?</value></data>
   <data name="Camp_InfoTitle" xml:space="preserve"><value>Info del Barrio</value></data>
   <data name="Camp_NameLabel" xml:space="preserve"><value>Nome del Barrio</value></data>
+  <data name="Camp_ContactButton" xml:space="preserve"><value>Contatta questo barrio</value></data>
+  <data name="Camp_ContactLoginHint" xml:space="preserve"><value>Accesso richiesto · La tua email resta privata</value></data>
+  <data name="Camp_Contact_Title" xml:space="preserve"><value>Contatta {0}</value></data>
+  <data name="Camp_Contact_Heading" xml:space="preserve"><value>Contatta {0}</value></data>
+  <data name="Camp_Contact_Breadcrumb" xml:space="preserve"><value>Contatto</value></data>
+  <data name="Camp_Contact_MessageLabel" xml:space="preserve"><value>Il tuo messaggio</value></data>
+  <data name="Camp_Contact_PlainTextOnly" xml:space="preserve"><value>Solo testo. Massimo 2000 caratteri.</value></data>
+  <data name="Camp_Contact_IncludeContactInfo" xml:space="preserve"><value>Includi le mie informazioni di contatto</value></data>
+  <data name="Camp_Contact_IncludeContactInfoHelp" xml:space="preserve"><value>La tua email sarà aggiunta come risposta per permettere una risposta diretta</value></data>
+  <data name="Camp_Contact_Send" xml:space="preserve"><value>Invia</value></data>
+  <data name="Camp_Contact_Success" xml:space="preserve"><value>Il tuo messaggio è stato inviato a {0}.</value></data>
+  <data name="Camp_Contact_RateLimited" xml:space="preserve"><value>Hai già contattato questo barrio di recente. Attendi qualche minuto.</value></data>
+  <data name="Camp_Links_Header" xml:space="preserve"><value>Link &amp; Contatto</value></data>
+  <data name="Camp_Edit_Links" xml:space="preserve"><value>Link</value></data>
+  <data name="Camp_Edit_AddLink" xml:space="preserve"><value>Aggiungi link</value></data>
+  <data name="Camp_Edit_RemoveLink" xml:space="preserve"><value>Rimuovi</value></data>
+  <data name="Camp_Edit_WebsiteNudge" xml:space="preserve"><value>Ti consigliamo vivamente di aggiungere un sito web per il tuo barrio.</value></data>
   <data name="Shifts_SignedUp" xml:space="preserve"><value>Iscritti</value></data>
   <data name="Shifts_Pending" xml:space="preserve"><value>(in attesa)</value></data>
 

--- a/src/Humans.Web/Resources/SharedResource.it.resx
+++ b/src/Humans.Web/Resources/SharedResource.it.resx
@@ -46,6 +46,7 @@
   <data name="Common_Back" xml:space="preserve"><value>Indietro</value></data>
   <data name="Common_Submit" xml:space="preserve"><value>Invia</value></data>
   <data name="Common_NotProvided" xml:space="preserve"><value>Non fornito</value></data>
+  <data name="Common_Error" xml:space="preserve"><value>Qualcosa è andato storto. Riprova più tardi.</value></data>
 
   <!-- ======================== -->
   <!-- Navigation (_Layout)     -->

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -46,6 +46,7 @@
   <data name="Common_Back" xml:space="preserve"><value>Back</value></data>
   <data name="Common_Submit" xml:space="preserve"><value>Submit</value></data>
   <data name="Common_NotProvided" xml:space="preserve"><value>Not provided</value></data>
+  <data name="Common_Error" xml:space="preserve"><value>Something went wrong. Please try again later.</value></data>
 
   <!-- ======================== -->
   <!-- Navigation (_Layout)     -->

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -1158,6 +1158,23 @@
   <data name="Camp_SwissCampLabel" xml:space="preserve"><value>Has this camp ever been called "Swiss Camp"</value></data>
   <data name="Camp_InfoTitle" xml:space="preserve"><value>Barrio Info</value></data>
   <data name="Camp_NameLabel" xml:space="preserve"><value>Barrio Name</value></data>
+  <data name="Camp_ContactButton" xml:space="preserve"><value>Contact this barrio</value></data>
+  <data name="Camp_ContactLoginHint" xml:space="preserve"><value>Login required · Your email stays private</value></data>
+  <data name="Camp_Contact_Title" xml:space="preserve"><value>Contact {0}</value><comment>{0} = camp name</comment></data>
+  <data name="Camp_Contact_Heading" xml:space="preserve"><value>Contact {0}</value><comment>{0} = camp name</comment></data>
+  <data name="Camp_Contact_Breadcrumb" xml:space="preserve"><value>Contact</value></data>
+  <data name="Camp_Contact_MessageLabel" xml:space="preserve"><value>Your message</value></data>
+  <data name="Camp_Contact_PlainTextOnly" xml:space="preserve"><value>Plain text only. Maximum 2000 characters.</value></data>
+  <data name="Camp_Contact_IncludeContactInfo" xml:space="preserve"><value>Include my contact info</value></data>
+  <data name="Camp_Contact_IncludeContactInfoHelp" xml:space="preserve"><value>Your email will be added as reply-to so they can respond directly</value></data>
+  <data name="Camp_Contact_Send" xml:space="preserve"><value>Send</value></data>
+  <data name="Camp_Contact_Success" xml:space="preserve"><value>Your message has been sent to {0}.</value><comment>{0} = camp name</comment></data>
+  <data name="Camp_Contact_RateLimited" xml:space="preserve"><value>You've already contacted this barrio recently. Please wait a few minutes before sending another message.</value></data>
+  <data name="Camp_Links_Header" xml:space="preserve"><value>Links &amp; Contact</value></data>
+  <data name="Camp_Edit_Links" xml:space="preserve"><value>Links</value></data>
+  <data name="Camp_Edit_AddLink" xml:space="preserve"><value>Add link</value></data>
+  <data name="Camp_Edit_RemoveLink" xml:space="preserve"><value>Remove</value></data>
+  <data name="Camp_Edit_WebsiteNudge" xml:space="preserve"><value>We strongly recommend adding a website for your barrio so visitors can learn more about you.</value></data>
   <data name="Shifts_SignedUp" xml:space="preserve"><value>Signed Up</value></data>
   <data name="Shifts_Pending" xml:space="preserve"><value>(pending)</value></data>
 

--- a/src/Humans.Web/Views/Camp/Contact.cshtml
+++ b/src/Humans.Web/Views/Camp/Contact.cshtml
@@ -1,0 +1,46 @@
+@model Humans.Web.Models.CampContactViewModel
+@{
+    ViewData["Title"] = string.Format(Localizer["Camp_Contact_Title"].Value, Model.CampName);
+}
+
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a asp-controller="Camp" asp-action="Index">@Localizer["Camps_Title"]</a></li>
+        <li class="breadcrumb-item"><a asp-controller="Camp" asp-action="Details" asp-route-slug="@Model.CampSlug">@Model.CampName</a></li>
+        <li class="breadcrumb-item active" aria-current="page">@Localizer["Camp_Contact_Breadcrumb"]</li>
+    </ol>
+</nav>
+
+<h1>@string.Format(Localizer["Camp_Contact_Heading"].Value, Model.CampName)</h1>
+
+<vc:temp-data-alerts />
+
+<div class="card">
+    <div class="card-body">
+        <form asp-action="Contact" asp-route-slug="@Model.CampSlug" method="post">
+            @Html.AntiForgeryToken()
+            <input type="hidden" asp-for="CampSlug" />
+            <input type="hidden" asp-for="CampName" />
+
+            <div asp-validation-summary="ModelOnly" class="alert alert-danger"></div>
+
+            <div class="mb-3">
+                <label asp-for="Message" class="form-label">@Localizer["Camp_Contact_MessageLabel"]</label>
+                <textarea asp-for="Message" class="form-control" rows="8" maxlength="2000"></textarea>
+                <span asp-validation-for="Message" class="text-danger"></span>
+                <div class="form-text">@Localizer["Camp_Contact_PlainTextOnly"]</div>
+            </div>
+
+            <div class="mb-3 form-check">
+                <input asp-for="IncludeContactInfo" class="form-check-input" type="checkbox" />
+                <label asp-for="IncludeContactInfo" class="form-check-label">@Localizer["Camp_Contact_IncludeContactInfo"]</label>
+                <div class="form-text">@Localizer["Camp_Contact_IncludeContactInfoHelp"]</div>
+            </div>
+
+            <div class="d-flex gap-2">
+                <button type="submit" class="btn btn-primary">@Localizer["Camp_Contact_Send"]</button>
+                <a asp-action="Details" asp-route-slug="@Model.CampSlug" class="btn btn-outline-secondary">@Localizer["Common_Cancel"]</a>
+            </div>
+        </form>
+    </div>
+</div>

--- a/src/Humans.Web/Views/Camp/Details.cshtml
+++ b/src/Humans.Web/Views/Camp/Details.cshtml
@@ -277,7 +277,7 @@
                     @foreach (var lead in Model.Leads)
                     {
                         <li class="list-group-item">
-                            <a asp-controller="Human" asp-action="Detail" asp-route-id="@lead.UserId">@lead.DisplayName</a>
+                            <a asp-controller="Human" asp-action="View" asp-route-id="@lead.UserId">@lead.DisplayName</a>
                         </li>
                     }
                 </ul>

--- a/src/Humans.Web/Views/Camp/Details.cshtml
+++ b/src/Humans.Web/Views/Camp/Details.cshtml
@@ -219,23 +219,33 @@
     </div>
 
     <div class="col-md-4">
-        @* Contact info *@
+        @* Links & Contact *@
         <div class="card mb-4">
             <div class="card-header">
-                <i class="fa-solid fa-address-book me-1"></i> Contact
+                <i class="fa-solid fa-link me-1"></i> @Localizer["Camp_Links_Header"]
             </div>
             <div class="card-body">
-                <dl class="mb-0">
-                    <dt>Email</dt>
-                    <dd><a href="mailto:@Model.ContactEmail">@Model.ContactEmail</a></dd>
-                    <dt>Preferred Contact</dt>
-                    <dd>@Model.ContactMethod</dd>
-                    @if (!string.IsNullOrEmpty(Model.WebOrSocialUrl))
-                    {
-                        <dt>Web / Social</dt>
-                        <dd><a href="@Model.WebOrSocialUrl" target="_blank" rel="noopener noreferrer">@Model.WebOrSocialUrl</a></dd>
-                    }
-                </dl>
+                @if (Model.Links.Count > 0)
+                {
+                    <div class="mb-3">
+                        @foreach (var link in Model.Links)
+                        {
+                            var platform = Humans.Domain.Helpers.PlatformDetector.Detect(link.Url);
+                            <div class="mb-2">
+                                <a href="@link.Url" target="_blank" rel="noopener noreferrer">
+                                    <i class="@platform.IconClass me-1"></i> @platform.Name
+                                </a>
+                            </div>
+                        }
+                    </div>
+                }
+                <hr />
+                <a asp-action="Contact" asp-route-slug="@Model.Slug" class="btn btn-primary w-100">
+                    <i class="fa-solid fa-envelope me-1"></i> @Localizer["Camp_ContactButton"]
+                </a>
+                <div class="text-center mt-1">
+                    <small class="text-muted">@Localizer["Camp_ContactLoginHint"]</small>
+                </div>
             </div>
         </div>
 

--- a/src/Humans.Web/Views/Camp/Details.cshtml
+++ b/src/Humans.Web/Views/Camp/Details.cshtml
@@ -240,12 +240,18 @@
                     </div>
                 }
                 <hr />
-                <a asp-action="Contact" asp-route-slug="@Model.Slug" class="btn btn-primary w-100">
-                    <i class="fa-solid fa-envelope me-1"></i> @Localizer["Camp_ContactButton"]
-                </a>
-                <div class="text-center mt-1">
-                    <small class="text-muted">@Localizer["Camp_ContactLoginHint"]</small>
-                </div>
+                @if (User.Identity?.IsAuthenticated == true)
+                {
+                    <a asp-action="Contact" asp-route-slug="@Model.Slug" class="btn btn-primary w-100">
+                        <i class="fa-solid fa-envelope me-1"></i> @Localizer["Camp_ContactButton"]
+                    </a>
+                }
+                else
+                {
+                    <div class="text-center text-muted">
+                        <i class="fa-solid fa-envelope me-1"></i> @Localizer["Camp_ContactLoginHint"]
+                    </div>
+                }
             </div>
         </div>
 

--- a/src/Humans.Web/Views/Camp/Edit.cshtml
+++ b/src/Humans.Web/Views/Camp/Edit.cshtml
@@ -353,3 +353,23 @@
         </div>
     </div>
 </div>
+
+@section Scripts {
+    <script>
+        document.getElementById('add-link')?.addEventListener('click', function() {
+            const container = document.getElementById('links-container');
+            if (container.querySelectorAll('.link-entry').length >= 10) return;
+            const div = document.createElement('div');
+            div.className = 'input-group mb-2 link-entry';
+            div.innerHTML = '<input type="url" name="Links" class="form-control" placeholder="https://" />' +
+                '<button type="button" class="btn btn-outline-danger remove-link"><i class="fa-solid fa-times"></i></button>';
+            container.appendChild(div);
+        });
+
+        document.addEventListener('click', function(e) {
+            if (e.target.closest('.remove-link')) {
+                e.target.closest('.link-entry').remove();
+            }
+        });
+    </script>
+}

--- a/src/Humans.Web/Views/Camp/Edit.cshtml
+++ b/src/Humans.Web/Views/Camp/Edit.cshtml
@@ -355,21 +355,5 @@
 </div>
 
 @section Scripts {
-    <script>
-        document.getElementById('add-link')?.addEventListener('click', function() {
-            const container = document.getElementById('links-container');
-            if (container.querySelectorAll('.link-entry').length >= 10) return;
-            const div = document.createElement('div');
-            div.className = 'input-group mb-2 link-entry';
-            div.innerHTML = '<input type="url" name="Links" class="form-control" placeholder="https://" />' +
-                '<button type="button" class="btn btn-outline-danger remove-link"><i class="fa-solid fa-times"></i></button>';
-            container.appendChild(div);
-        });
-
-        document.addEventListener('click', function(e) {
-            if (e.target.closest('.remove-link')) {
-                e.target.closest('.link-entry').remove();
-            }
-        });
-    </script>
+    <partial name="_LinksEditorScripts" />
 }

--- a/src/Humans.Web/Views/Camp/Edit.cshtml
+++ b/src/Humans.Web/Views/Camp/Edit.cshtml
@@ -53,13 +53,34 @@
                             <label asp-for="ContactPhone" class="form-label">Contact Phone</label>
                             <input asp-for="ContactPhone" class="form-control" type="tel" pattern="\+[\d\s\-()]{6,20}" placeholder="+34 612 345 678" />
                         </div>
-                        <div class="col-md-6">
-                            <label asp-for="ContactMethod" class="form-label">Preferred Contact Method</label>
-                            <input asp-for="ContactMethod" class="form-control" required />
-                        </div>
-                        <div class="col-md-6">
-                            <label asp-for="WebOrSocialUrl" class="form-label">Website or Social Media</label>
-                            <input asp-for="WebOrSocialUrl" class="form-control" type="url" placeholder="https://" />
+                        <div class="col-12">
+                            <label class="form-label">@Localizer["Camp_Edit_Links"]</label>
+                            <div id="links-container">
+                                @if (Model.Links != null)
+                                {
+                                    for (var i = 0; i < Model.Links.Count; i++)
+                                    {
+                                        <div class="input-group mb-2 link-entry">
+                                            <input type="url" name="Links" class="form-control" value="@Model.Links[i]" placeholder="https://" />
+                                            <button type="button" class="btn btn-outline-danger remove-link">
+                                                <i class="fa-solid fa-times"></i>
+                                            </button>
+                                        </div>
+                                    }
+                                }
+                            </div>
+                            <button type="button" class="btn btn-outline-secondary btn-sm" id="add-link">
+                                <i class="fa-solid fa-plus me-1"></i> @Localizer["Camp_Edit_AddLink"]
+                            </button>
+                            @{
+                                var hasWebsite = Model.Links?.Any(u => !string.IsNullOrEmpty(u) && !Humans.Domain.Helpers.PlatformDetector.IsSocialMedia(u)) ?? false;
+                            }
+                            @if (!hasWebsite)
+                            {
+                                <div class="alert alert-warning mt-2 mb-0">
+                                    <i class="fa-solid fa-triangle-exclamation me-1"></i> @Localizer["Camp_Edit_WebsiteNudge"]
+                                </div>
+                            }
                         </div>
                         <div class="col-md-3">
                             <label asp-for="TimesAtNowhere" class="form-label">Times Participating</label>

--- a/src/Humans.Web/Views/Camp/Register.cshtml
+++ b/src/Humans.Web/Views/Camp/Register.cshtml
@@ -219,3 +219,23 @@
         </button>
     </div>
 </form>
+
+@section Scripts {
+    <script>
+        document.getElementById('add-link')?.addEventListener('click', function() {
+            const container = document.getElementById('links-container');
+            if (container.querySelectorAll('.link-entry').length >= 10) return;
+            const div = document.createElement('div');
+            div.className = 'input-group mb-2 link-entry';
+            div.innerHTML = '<input type="url" name="Links" class="form-control" placeholder="https://" />' +
+                '<button type="button" class="btn btn-outline-danger remove-link"><i class="fa-solid fa-times"></i></button>';
+            container.appendChild(div);
+        });
+
+        document.addEventListener('click', function(e) {
+            if (e.target.closest('.remove-link')) {
+                e.target.closest('.link-entry').remove();
+            }
+        });
+    </script>
+}

--- a/src/Humans.Web/Views/Camp/Register.cshtml
+++ b/src/Humans.Web/Views/Camp/Register.cshtml
@@ -221,21 +221,5 @@
 </form>
 
 @section Scripts {
-    <script>
-        document.getElementById('add-link')?.addEventListener('click', function() {
-            const container = document.getElementById('links-container');
-            if (container.querySelectorAll('.link-entry').length >= 10) return;
-            const div = document.createElement('div');
-            div.className = 'input-group mb-2 link-entry';
-            div.innerHTML = '<input type="url" name="Links" class="form-control" placeholder="https://" />' +
-                '<button type="button" class="btn btn-outline-danger remove-link"><i class="fa-solid fa-times"></i></button>';
-            container.appendChild(div);
-        });
-
-        document.addEventListener('click', function(e) {
-            if (e.target.closest('.remove-link')) {
-                e.target.closest('.link-entry').remove();
-            }
-        });
-    </script>
+    <partial name="_LinksEditorScripts" />
 }

--- a/src/Humans.Web/Views/Camp/Register.cshtml
+++ b/src/Humans.Web/Views/Camp/Register.cshtml
@@ -36,13 +36,19 @@
                     <label asp-for="ContactPhone" class="form-label">Contact Phone</label>
                     <input asp-for="ContactPhone" class="form-control" type="tel" pattern="\+[\d\s\-()]{6,20}" placeholder="+34 612 345 678" />
                 </div>
-                <div class="col-md-6">
-                    <label asp-for="ContactMethod" class="form-label">Preferred Contact Method</label>
-                    <input asp-for="ContactMethod" class="form-control" placeholder="e.g. Email, WhatsApp, Signal" required />
-                </div>
-                <div class="col-md-6">
-                    <label asp-for="WebOrSocialUrl" class="form-label">Website or Social Media</label>
-                    <input asp-for="WebOrSocialUrl" class="form-control" type="url" placeholder="https://" />
+                <div class="col-12">
+                    <label class="form-label">@Localizer["Camp_Edit_Links"]</label>
+                    <div id="links-container">
+                        <div class="input-group mb-2 link-entry">
+                            <input type="url" name="Links" class="form-control" placeholder="https://" />
+                            <button type="button" class="btn btn-outline-danger remove-link">
+                                <i class="fa-solid fa-times"></i>
+                            </button>
+                        </div>
+                    </div>
+                    <button type="button" class="btn btn-outline-secondary btn-sm" id="add-link">
+                        <i class="fa-solid fa-plus me-1"></i> @Localizer["Camp_Edit_AddLink"]
+                    </button>
                 </div>
                 <div class="col-md-3">
                     <label asp-for="TimesAtNowhere" class="form-label">Times Participating</label>

--- a/src/Humans.Web/Views/Camp/_LinksEditorScripts.cshtml
+++ b/src/Humans.Web/Views/Camp/_LinksEditorScripts.cshtml
@@ -1,0 +1,17 @@
+<script>
+    document.getElementById('add-link')?.addEventListener('click', function() {
+        const container = document.getElementById('links-container');
+        if (container.querySelectorAll('.link-entry').length >= 10) return;
+        const div = document.createElement('div');
+        div.className = 'input-group mb-2 link-entry';
+        div.innerHTML = '<input type="url" name="Links" class="form-control" placeholder="https://" />' +
+            '<button type="button" class="btn btn-outline-danger remove-link"><i class="fa-solid fa-times"></i></button>';
+        container.appendChild(div);
+    });
+
+    document.addEventListener('click', function(e) {
+        if (e.target.closest('.remove-link')) {
+            e.target.closest('.link-entry').remove();
+        }
+    });
+</script>

--- a/tests/Humans.Application.Tests/Helpers/PlatformDetectorTests.cs
+++ b/tests/Humans.Application.Tests/Helpers/PlatformDetectorTests.cs
@@ -1,0 +1,47 @@
+using AwesomeAssertions;
+using Humans.Domain.Helpers;
+using Xunit;
+
+namespace Humans.Application.Tests.Helpers;
+
+public class PlatformDetectorTests
+{
+    [Theory]
+    [InlineData("https://www.instagram.com/campvibes", "Instagram", "fa-brands fa-instagram")]
+    [InlineData("https://facebook.com/campvibes", "Facebook", "fa-brands fa-facebook")]
+    [InlineData("https://x.com/campvibes", "X", "fa-brands fa-x-twitter")]
+    [InlineData("https://twitter.com/campvibes", "X", "fa-brands fa-x-twitter")]
+    [InlineData("https://tiktok.com/@campvibes", "TikTok", "fa-brands fa-tiktok")]
+    [InlineData("https://discord.gg/abc123", "Discord", "fa-brands fa-discord")]
+    [InlineData("https://discord.com/invite/abc", "Discord", "fa-brands fa-discord")]
+    [InlineData("https://youtube.com/c/campvibes", "YouTube", "fa-brands fa-youtube")]
+    [InlineData("https://linkedin.com/company/campvibes", "LinkedIn", "fa-brands fa-linkedin")]
+    [InlineData("https://campvibes.com", "campvibes.com", "fa-solid fa-link")]
+    [InlineData("https://www.campvibes.org/about", "campvibes.org", "fa-solid fa-link")]
+    public void Detect_ReturnsCorrectPlatform(string url, string expectedName, string expectedIcon)
+    {
+        var result = PlatformDetector.Detect(url);
+        result.Name.Should().Be(expectedName);
+        result.IconClass.Should().Be(expectedIcon);
+    }
+
+    [Theory]
+    [InlineData("https://campvibes.com", false)]
+    [InlineData("https://instagram.com/campvibes", true)]
+    [InlineData("https://facebook.com/campvibes", true)]
+    [InlineData("https://mycampsite.org", false)]
+    public void IsSocialMedia_IdentifiesCorrectly(string url, bool expected)
+    {
+        PlatformDetector.IsSocialMedia(url).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("not-a-url")]
+    public void Detect_InvalidUrl_ReturnsFallback(string url)
+    {
+        var result = PlatformDetector.Detect(url);
+        result.Name.Should().BeEmpty();
+        result.IconClass.Should().Be("fa-solid fa-link");
+    }
+}

--- a/tests/Humans.Application.Tests/Services/CampServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/CampServiceTests.cs
@@ -57,7 +57,7 @@ public class CampServiceTests : IDisposable
 
         var camp = await _service.CreateCampAsync(
             userId, "Camp Funhouse", "camp@fun.com", "+34612345678",
-            "https://instagram.com/funhouse", "DM us on Instagram",
+            "https://instagram.com/funhouse", null,
             isSwissCamp: false, timesAtNowhere: 0,
             MakeSeasonData(), historicalNames: null, year: 2026);
 
@@ -86,7 +86,7 @@ public class CampServiceTests : IDisposable
 
         var act = () => _service.CreateCampAsync(
             userId, "Register", "camp@test.com", "+34600000000",
-            null, "email", false, 0, MakeSeasonData(), null, 2026);
+            null, null, false, 0, MakeSeasonData(), null, 2026);
 
         await act.Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("*reserved*");
@@ -318,7 +318,7 @@ public class CampServiceTests : IDisposable
     {
         return await _service.CreateCampAsync(
             Guid.NewGuid(), "Test Camp", "test@camp.com", "+34600000000",
-            null, "email us", false, 1, MakeSeasonData(), null, 2026);
+            null, null, false, 1, MakeSeasonData(), null, 2026);
     }
 
     private async Task SeedSettingsAsync()


### PR DESCRIPTION
## Summary

- **Hide camp email from public** — contact info no longer shown on detail pages
- **Facilitated contact form** — "Contact this camp" button sends message via email without exposing the camp's address. Login required, 10min rate limit per user per camp
- **Multiple links with platform auto-detection** — replaces single URL field with dynamic list. Auto-detects Instagram, Facebook, X, TikTok, Discord, YouTube, LinkedIn with platform icons
- **Lazy migration** — existing `WebOrSocialUrl` values read as fallback, migrated to `Links` jsonb on edit
- **ContactMethod field removed** — facilitated form replaces it
- **Website nudge** — edit form warns if no non-social-media URL is present

## Test plan

- [ ] Visit a camp detail page as anonymous — email should be hidden, links shown, contact button visible
- [ ] Click contact button as anonymous — should redirect to login
- [ ] Log in, click contact button — should show contact form
- [ ] Send a message — verify email arrives at camp's ContactEmail
- [ ] Try sending again immediately — should see rate limit message
- [ ] Edit a camp — verify dynamic links editor works (add/remove URLs)
- [ ] Edit a camp with legacy WebOrSocialUrl — should appear in links editor, migrates on save
- [ ] Check website nudge warning appears when only social URLs are present
- [ ] Verify all locales load without missing key errors (en/es/de/fr/it)

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)