### PR TITLE
feat(vol): volunteer management section (/Vol)

### DIFF
--- a/docs/superpowers/plans/2026-03-19-vol-management.md
+++ b/docs/superpowers/plans/2026-03-19-vol-management.md
@@ -1,0 +1,632 @@
+# Vol — Volunteer Management Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Port the Figma Make volunteer management prototype into a new `/Vol` route with sub-navigation, coexisting with the current `/Shifts` section.
+
+**Architecture:** Single `VolController : HumansControllerBase` with `[Route("Vol")]`, using existing `IShiftSignupService`, `IShiftManagementService`, and `ITeamService`. New view models in `Models/Vol/`, Razor views in `Views/Vol/` with a shared `_VolLayout.cshtml` sub-nav. No domain/infrastructure changes.
+
+**Tech Stack:** ASP.NET Core MVC, Razor views, Bootstrap 5, Font Awesome 6, NodaTime, EF Core (existing services only)
+
+**Spec:** `docs/superpowers/specs/2026-03-19-vol-volunteer-management-design.md`
+
+**Worktree:** `.worktrees/vol-management` on branch `feature/vol-management`
+
+---
+
+## Task 1: Worktree, Scaffold & Nav Link
+
+Create the worktree, controller shell, shared layout, and "V" nav link. End state: `/Vol` loads and redirects to `/Vol/MyShifts` (which shows a placeholder), nav link visible to privileged roles.
+
+**Files:**
+- Create: `src/Humans.Web/Controllers/VolController.cs`
+- Create: `src/Humans.Web/Views/Vol/_VolLayout.cshtml`
+- Create: `src/Humans.Web/Views/Vol/_ViewStart.cshtml`
+- Create: `src/Humans.Web/Views/Vol/MyShifts.cshtml` (placeholder)
+- Modify: `src/Humans.Web/Views/Shared/_Layout.cshtml`
+
+- [ ] **Step 1: Create worktree and branch**
+
+```bash
+git worktree add .worktrees/vol-management -b feature/vol-management
+```
+
+All subsequent commands run from `.worktrees/vol-management/`.
+
+- [ ] **Step 2: Create the VolController shell**
+
+Create `src/Humans.Web/Controllers/VolController.cs`:
+
+```csharp
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Humans.Domain.Entities;
+using Humans.Application.Interfaces;
+using Humans.Web.Authorization;
+
+namespace Humans.Web.Controllers;
+
+[Authorize]
+[Route("Vol")]
+public class VolController : HumansControllerBase
+{
+    private readonly IShiftManagementService _shiftMgmt;
+    private readonly IShiftSignupService _signupService;
+    private readonly ITeamService _teamService;
+    private readonly IProfileService _profileService;
+    private readonly IGeneralAvailabilityService _availabilityService;
+    private readonly ILogger<VolController> _logger;
+    private readonly NodaTime.IClock _clock;
+
+    public VolController(
+        IShiftManagementService shiftMgmt,
+        IShiftSignupService signupService,
+        ITeamService teamService,
+        IProfileService profileService,
+        IGeneralAvailabilityService availabilityService,
+        UserManager<User> userManager,
+        ILogger<VolController> logger,
+        NodaTime.IClock clock)
+        : base(userManager)
+    {
+        _shiftMgmt = shiftMgmt;
+        _signupService = signupService;
+        _teamService = teamService;
+        _profileService = profileService;
+        _availabilityService = availabilityService;
+        _logger = logger;
+        _clock = clock;
+    }
+
+    [HttpGet("")]
+    public IActionResult Index() => RedirectToAction(nameof(MyShifts));
+
+    [HttpGet("MyShifts")]
+    public IActionResult MyShifts() => View();
+}
+```
+
+- [ ] **Step 3: Create `_ViewStart.cshtml`**
+
+Create `src/Humans.Web/Views/Vol/_ViewStart.cshtml`:
+
+```html
+@{
+    Layout = "~/Views/Vol/_VolLayout.cshtml";
+}
+```
+
+- [ ] **Step 4: Create `_VolLayout.cshtml` with sub-nav**
+
+Create `src/Humans.Web/Views/Vol/_VolLayout.cshtml`. This wraps the main `_Layout` and adds the page header + nav-pills sub-navigation. Reference the existing `_Layout.cshtml` nav patterns — use `RoleChecks`, `ShiftRoleChecks`, and `User.HasClaim(ActiveMemberClaimType, ActiveClaimValue)` for visibility checks. Use Font Awesome icons (`fa-solid fa-clipboard-list`, `fa-solid fa-calendar-days`, `fa-solid fa-users`, `fa-solid fa-bolt`, `fa-solid fa-chart-bar`, `fa-solid fa-gear`). Active tab determined by `ViewContext.RouteData`.
+
+- [ ] **Step 5: Create placeholder `MyShifts.cshtml`**
+
+Create `src/Humans.Web/Views/Vol/MyShifts.cshtml`:
+
+```html
+@{
+    ViewData["Title"] = "My Shifts";
+    ViewData["VolActiveTab"] = "MyShifts";
+}
+
+<div class="card">
+    <div class="card-body text-center py-5">
+        <i class="fa-solid fa-clipboard-list fa-2x text-muted mb-3"></i>
+        <p class="text-muted">My Shifts page — coming next.</p>
+    </div>
+</div>
+```
+
+- [ ] **Step 6: Add "V" nav link to `_Layout.cshtml`**
+
+In `src/Humans.Web/Views/Shared/_Layout.cshtml`, after the existing Shifts nav link, add:
+
+```html
+@if (RoleChecks.IsTeamsAdminBoardOrAdmin(User) || User.IsInRole(RoleNames.VolunteerCoordinator))
+{
+    <li class="nav-item">
+        <a class="nav-link" asp-controller="Vol" asp-action="Index">V</a>
+    </li>
+}
+```
+
+- [ ] **Step 7: Build and verify**
+
+```bash
+dotnet build Humans.slnx
+```
+
+Expected: build succeeds, no errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/Humans.Web/Controllers/VolController.cs \
+        src/Humans.Web/Views/Vol/_VolLayout.cshtml \
+        src/Humans.Web/Views/Vol/_ViewStart.cshtml \
+        src/Humans.Web/Views/Vol/MyShifts.cshtml \
+        src/Humans.Web/Views/Shared/_Layout.cshtml
+git commit -m "feat(vol): scaffold controller, layout, and nav link"
+```
+
+---
+
+## Task 2: View Models
+
+Create all view model classes. These are flat projections — no business logic, just properties. Each page gets its own model.
+
+**Files:**
+- Create: `src/Humans.Web/Models/Vol/MyShiftsViewModel.cs`
+- Create: `src/Humans.Web/Models/Vol/ShiftBrowserViewModel.cs`
+- Create: `src/Humans.Web/Models/Vol/TeamsOverviewViewModel.cs`
+- Create: `src/Humans.Web/Models/Vol/DepartmentDetailViewModel.cs`
+- Create: `src/Humans.Web/Models/Vol/ChildTeamDetailViewModel.cs`
+- Create: `src/Humans.Web/Models/Vol/UrgentShiftsViewModel.cs`
+- Create: `src/Humans.Web/Models/Vol/ManagementViewModel.cs`
+- Create: `src/Humans.Web/Models/Vol/SettingsViewModel.cs`
+
+- [ ] **Step 1: Create `MyShiftsViewModel.cs`**
+
+Properties: `List<MyShiftRow> Shifts`, `EventSettings EventSettings`. `MyShiftRow`: `Guid SignupId`, `string DutyTitle` (Rota.Name + Shift.Description), `string TeamName`, `Instant AbsoluteStart`, `Instant AbsoluteEnd`, `SignupStatus Status`, `bool CanBail` (Status is Confirmed or Pending). Reference existing `ShiftDisplayItem` for NodaTime patterns.
+
+- [ ] **Step 2: Create `ShiftBrowserViewModel.cs`**
+
+Properties: `EventSettings EventSettings`, `List<DepartmentShiftGroup> Departments` (reuse existing type from `ShiftViewModels.cs`), `List<DepartmentOption> AllDepartments`, `Guid? FilterDepartmentId`, `string? FilterDate`, `bool ShowFullShifts`, `HashSet<Guid> UserSignupShiftIds`, `Dictionary<Guid, SignupStatus> UserSignupStatuses`, `bool ShowSignups`, `bool IsPrivileged`. Follow the exact pattern from the existing `ShiftBrowseViewModel`.
+
+- [ ] **Step 3: Create `TeamsOverviewViewModel.cs`**
+
+Properties: `List<DepartmentCard> Departments`. `DepartmentCard`: `Guid TeamId`, `string Name`, `string Slug`, `string? Description`, `int ChildTeamCount`, `int TotalSlots`, `int FilledSlots`.
+
+- [ ] **Step 4: Create `DepartmentDetailViewModel.cs`**
+
+Properties: `Team Department`, `List<ChildTeamCard> ChildTeams`, `bool IsCoordinator`, `EventSettings EventSettings`. `ChildTeamCard`: `Guid TeamId`, `string Name`, `string Slug`, `int MemberCount`, `int TotalSlots`, `int FilledSlots`, `int PendingRequestCount`.
+
+- [ ] **Step 5: Create `ChildTeamDetailViewModel.cs`**
+
+Properties: `Team ChildTeam`, `Team Department`, `List<TeamMember> Members`, `List<RotaShiftGroup> Rotas` (reuse existing type), `List<TeamJoinRequest> PendingRequests`, `bool IsCoordinator`, `EventSettings EventSettings`, `HashSet<Guid> UserSignupShiftIds`, `Dictionary<Guid, SignupStatus> UserSignupStatuses`.
+
+- [ ] **Step 6: Create `UrgentShiftsViewModel.cs`**
+
+Properties: `List<UrgentShiftRow> Shifts`, `EventSettings EventSettings`. `UrgentShiftRow`: `Guid ShiftId`, `string DutyTitle`, `string TeamName`, `string TeamSlug`, `int DayOffset`, `LocalTime StartTime`, `Duration Duration`, `int Confirmed`, `int MaxVolunteers`, `ShiftPriority Priority`, `double UrgencyScore`. Reference existing `IShiftManagementService.GetUrgentShiftsAsync()` return type.
+
+- [ ] **Step 7: Create `ManagementViewModel.cs`**
+
+Properties: `bool SystemOpen`, `int? VolunteerCap`, `int ConfirmedVolunteerCount`, `EventSettings EventSettings`.
+
+- [ ] **Step 8: Create `SettingsViewModel.cs`**
+
+Properties: mirror `EventSettingsViewModel` from existing `ShiftViewModels.cs` — `Guid? Id`, `string EventName`, `string TimeZoneId`, `string GateOpeningDate`, `int BuildStartOffset`, `int EventEndOffset`, `int StrikeEndOffset`, `bool IsShiftBrowsingOpen`, `int? GlobalVolunteerCap`, `int ConfirmedVolunteerCount`. Add computed `int BuildDays`, `int EventDays`, `int StrikeDays`.
+
+- [ ] **Step 9: Build and commit**
+
+```bash
+dotnet build Humans.slnx
+git add src/Humans.Web/Models/Vol/
+git commit -m "feat(vol): add all view models"
+```
+
+---
+
+## Task 3: My Shifts Page
+
+Wire up the controller action and build the view. First fully functional page.
+
+**Files:**
+- Modify: `src/Humans.Web/Controllers/VolController.cs`
+- Modify: `src/Humans.Web/Views/Vol/MyShifts.cshtml`
+
+- [ ] **Step 1: Implement MyShifts action**
+
+In `VolController`, replace the placeholder `MyShifts()` action. Pattern:
+1. `ResolveCurrentUserOrChallengeAsync()`
+2. `_shiftMgmt.GetActiveAsync()` → guard `NoActiveEvent` view
+3. `_signupService.GetByUserAsync(user.Id)` → get all signups
+4. Map to `MyShiftsViewModel` with `MyShiftRow` list
+5. `return View(model)`
+
+Wrap in try-catch with `_logger.LogError`.
+
+- [ ] **Step 2: Implement Bail POST action**
+
+Add `[HttpPost("Bail")]` action:
+1. `[ValidateAntiForgeryToken]`
+2. Takes `Guid signupId`
+3. Auth check: own signup OR `CanApproveSignupsAsync`
+4. `_signupService.BailAsync(signupId, user.Id)`
+5. `SetSuccess("Bailed from shift.")`
+6. `RedirectToAction(nameof(MyShifts))`
+
+- [ ] **Step 3: Build the MyShifts view**
+
+Replace placeholder `MyShifts.cshtml`. Use Bootstrap card with table:
+- Desktop: `<table class="table table-sm">` with columns: Duty, Team, Date & Time, Status, Action
+- Status badges: `<span class="badge bg-success">Confirmed</span>`, `bg-warning` Pending, `bg-danger` Bailed, `bg-secondary` Refused/Cancelled/NoShow
+- Bail button: `<form asp-action="Bail" method="post" class="d-inline">` with `@Html.AntiForgeryToken()`, confirmation via `onclick="return confirm('Bail from this shift?')"`
+- Mobile: use `d-none d-md-table-row` / `d-md-none` pattern for responsive cards
+- Empty state: "No shifts booked yet" with link to All Shifts
+
+- [ ] **Step 4: Create `NoActiveEvent.cshtml` and `BrowsingClosed.cshtml`**
+
+Create `src/Humans.Web/Views/Vol/NoActiveEvent.cshtml` and `BrowsingClosed.cshtml` — simple alert cards matching the existing `/Shifts/` equivalents.
+
+- [ ] **Step 5: Build and commit**
+
+```bash
+dotnet build Humans.slnx
+git add src/Humans.Web/Controllers/VolController.cs \
+        src/Humans.Web/Views/Vol/MyShifts.cshtml \
+        src/Humans.Web/Views/Vol/NoActiveEvent.cshtml \
+        src/Humans.Web/Views/Vol/BrowsingClosed.cshtml
+git commit -m "feat(vol): implement My Shifts page with bail action"
+```
+
+---
+
+## Task 4: All Shifts Page (Phase 1 Filters)
+
+Shift browser with department filter, date filter, and open-only toggle. Rota cards grouped by department.
+
+**Files:**
+- Modify: `src/Humans.Web/Controllers/VolController.cs`
+- Create: `src/Humans.Web/Views/Vol/Shifts.cshtml`
+- Create: `src/Humans.Web/Views/Vol/_RotaCard.cshtml` (partial)
+- Create: `src/Humans.Web/Views/Vol/_ShiftRow.cshtml` (partial)
+
+- [ ] **Step 1: Implement Shifts GET action**
+
+Add `[HttpGet("Shifts")]` action. Follow the existing `ShiftsController.Index` pattern closely:
+1. Resolve user, check EventSettings, check browsing open
+2. `_shiftMgmt.GetBrowseShiftsAsync(es.Id, departmentId, date, ...)` for shift data
+3. `_shiftMgmt.GetDepartmentsWithRotasAsync(es.Id)` for department dropdown
+4. Get user's signup IDs for signed-up indicators
+5. Build `ShiftBrowserViewModel`, return View
+
+- [ ] **Step 2: Implement SignUp POST action**
+
+Add `[HttpPost("SignUp")]` action:
+1. `[ValidateAntiForgeryToken]`, takes `Guid shiftId`
+2. Auth: ActiveMember + browsing open (or privileged)
+3. `_signupService.SignUpAsync(shiftId, user.Id)`
+4. Handle result (success/warning/error)
+5. `RedirectToAction(nameof(Shifts))`
+
+- [ ] **Step 3: Create `_RotaCard.cshtml` partial**
+
+Partial for a single rota card. Receives a `RotaShiftGroup` model. Shows:
+- Card with header: rota name + priority badge
+- Description (if any)
+- Fill bar: `<div class="progress">` with percentage
+- Slots summary: "X / Y filled"
+- Collapsible shift rows via Bootstrap collapse (`data-bs-toggle="collapse"`)
+
+- [ ] **Step 4: Create `_ShiftRow.cshtml` partial**
+
+Partial for a single shift row within a rota. Shows:
+- Date (formatted from DayOffset + EventSettings.GateOpeningDate)
+- Time range
+- Volunteers filled/total
+- Priority badge
+- Policy badge (Public=green "Instant", RequireApproval=amber "Approval")
+- Sign Up / Bail / "Signed up" / "Full" button
+
+- [ ] **Step 5: Build `Shifts.cshtml` view**
+
+Assembles filter panel + department sections + rota cards:
+- Filter form (GET): department `<select>`, date `<input type="date">`, open-only `<input type="checkbox">`, clear link
+- Summary bar: rota count, shift count, open slots
+- Loop departments → render `_RotaCard` partials
+- Empty state for no results
+
+- [ ] **Step 6: Build and commit**
+
+```bash
+dotnet build Humans.slnx
+git add src/Humans.Web/Controllers/VolController.cs \
+        src/Humans.Web/Views/Vol/Shifts.cshtml \
+        src/Humans.Web/Views/Vol/_RotaCard.cshtml \
+        src/Humans.Web/Views/Vol/_ShiftRow.cshtml
+git commit -m "feat(vol): implement All Shifts page with Phase 1 filters"
+```
+
+---
+
+## Task 5: Teams Overview
+
+Department cards grid.
+
+**Files:**
+- Modify: `src/Humans.Web/Controllers/VolController.cs`
+- Create: `src/Humans.Web/Views/Vol/Teams.cshtml`
+
+- [ ] **Step 1: Implement Teams GET action**
+
+Add `[HttpGet("Teams")]`. Load parent teams (ParentTeamId == null, has rotas), aggregate staffing data per department, build `TeamsOverviewViewModel`.
+
+- [ ] **Step 2: Build `Teams.cshtml` view**
+
+Grid of Bootstrap cards (`row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4`). Each card:
+- Card header: department name
+- Card body: description, child team count, fill bar
+- Link to Department Detail: `asp-action="DepartmentDetail" asp-route-slug="@dept.Slug"`
+- Empty state for departments with no rotas
+
+- [ ] **Step 3: Build and commit**
+
+```bash
+dotnet build Humans.slnx
+git add src/Humans.Web/Controllers/VolController.cs \
+        src/Humans.Web/Views/Vol/Teams.cshtml
+git commit -m "feat(vol): implement Teams Overview page"
+```
+
+---
+
+## Task 6: Department Detail
+
+Child teams listed under a department with staffing data.
+
+**Files:**
+- Modify: `src/Humans.Web/Controllers/VolController.cs`
+- Create: `src/Humans.Web/Views/Vol/DepartmentDetail.cshtml`
+
+- [ ] **Step 1: Implement DepartmentDetail GET action**
+
+Add `[HttpGet("Teams/{slug}")]`. Load team by slug, verify it's a parent team (ParentTeamId == null), load child teams, staffing data, pending requests (if coordinator). Build `DepartmentDetailViewModel`.
+
+- [ ] **Step 2: Build `DepartmentDetail.cshtml` view**
+
+- Breadcrumb: Teams → Department Name
+- Department header with description
+- Child team cards: name, member count, fill stats
+- Each card links to `ChildTeamDetail`
+- Coordinator actions (if authorized): link to create rota (at department level)
+
+- [ ] **Step 3: Build and commit**
+
+```bash
+dotnet build Humans.slnx
+git add src/Humans.Web/Controllers/VolController.cs \
+        src/Humans.Web/Views/Vol/DepartmentDetail.cshtml
+git commit -m "feat(vol): implement Department Detail page"
+```
+
+---
+
+## Task 7: Child Team Detail
+
+Full team view with rotas, shifts, members, and coordinator actions.
+
+**Files:**
+- Modify: `src/Humans.Web/Controllers/VolController.cs`
+- Create: `src/Humans.Web/Views/Vol/ChildTeamDetail.cshtml`
+
+- [ ] **Step 1: Implement ChildTeamDetail GET action**
+
+Add `[HttpGet("Teams/{parentSlug}/{childSlug}")]`. Load parent team by `parentSlug`, child team by `childSlug`, verify child belongs to parent. Load members, rotas (filtered to this team's shifts), pending requests, user signup data. Check coordinator status. Build `ChildTeamDetailViewModel`.
+
+- [ ] **Step 2: Implement coordinator POST actions**
+
+Add Approve, Refuse, NoShow POST actions (if not already added):
+- `[HttpPost("Approve")]` with `Guid signupId` — `_signupService.ApproveAsync`
+- `[HttpPost("Refuse")]` with `Guid signupId` — `_signupService.RefuseAsync`
+- `[HttpPost("NoShow")]` with `Guid signupId` — `_signupService.MarkNoShowAsync`
+
+All gated by `CanApproveSignupsAsync`.
+
+- [ ] **Step 3: Build `ChildTeamDetail.cshtml` view**
+
+- Breadcrumb: Teams → Department → Team Name
+- Team header with description, member count
+- Member roster table (name, role, joined date)
+- Rotas section: reuse `_RotaCard` partial, filtered to this team
+- Pending requests (if coordinator): list with approve/reject buttons
+- Coordinator action buttons for shift management
+
+- [ ] **Step 4: Build and commit**
+
+```bash
+dotnet build Humans.slnx
+git add src/Humans.Web/Controllers/VolController.cs \
+        src/Humans.Web/Views/Vol/ChildTeamDetail.cshtml
+git commit -m "feat(vol): implement Child Team Detail page with coordinator actions"
+```
+
+---
+
+## Task 8: Urgent Shifts
+
+Urgency-sorted table with volunteer search and voluntell.
+
+**Files:**
+- Modify: `src/Humans.Web/Controllers/VolController.cs`
+- Create: `src/Humans.Web/Views/Vol/Urgent.cshtml`
+
+- [ ] **Step 1: Implement Urgent GET action**
+
+Add `[HttpGet("Urgent")]`. Guard: `CanAccessDashboard` check. Load `_shiftMgmt.GetUrgentShiftsAsync()`, map to `UrgentShiftsViewModel`.
+
+- [ ] **Step 2: Implement Voluntell POST action**
+
+Add `[HttpPost("Voluntell")]` with `Guid shiftId`, `Guid userId`:
+1. Guard: `CanAccessDashboard`
+2. `_signupService.VoluntellAsync(shiftId, userId, enrolledByUserId: user.Id)`
+3. `SetSuccess("Volunteer assigned.")`
+4. Redirect back
+
+- [ ] **Step 3: Implement volunteer search endpoint**
+
+Add `[HttpGet("SearchVolunteers")]` returning JSON. Reuse existing `ShiftVolunteerSearchBuilder` pattern from `ShiftDashboardController`. Takes `string? query`, `Guid shiftId`. Returns list of volunteer results with inline assign forms.
+
+- [ ] **Step 4: Build `Urgent.cshtml` view**
+
+- Section header with bolt icon
+- Table: Urgency bar, Duty (with tooltip), Team, Date & Time, Capacity bar, Priority badge, "Find volunteer" button
+- "Find volunteer" opens a simple search form (can be inline or modal using Bootstrap modal)
+- Search results show volunteer name, skills, booked shift count, "Assign" button
+- Mobile: card layout instead of table
+- Empty state: "All duties are fully staffed!"
+
+- [ ] **Step 5: Build and commit**
+
+```bash
+dotnet build Humans.slnx
+git add src/Humans.Web/Controllers/VolController.cs \
+        src/Humans.Web/Views/Vol/Urgent.cshtml
+git commit -m "feat(vol): implement Urgent Shifts page with voluntell"
+```
+
+---
+
+## Task 9: Management Dashboard
+
+Manager-only dashboard with system status, cap indicator, and placeholder export buttons.
+
+**Files:**
+- Modify: `src/Humans.Web/Controllers/VolController.cs`
+- Create: `src/Humans.Web/Views/Vol/Management.cshtml`
+
+- [ ] **Step 1: Implement Management GET action**
+
+Add `[HttpGet("Management")]`. Guard: `CanAccessDashboard`. Load EventSettings, confirmed volunteer count. Build `ManagementViewModel`.
+
+- [ ] **Step 2: Build `Management.cshtml` view**
+
+- System status banner: card with green/red accent showing Open/Closed, links to Settings
+- Volunteer Cap card: progress bar with thresholds (75% amber, 90% red), confirmed count / cap
+- Actions grid: 3 export buttons (disabled with "Phase 3" tooltip) + link to Settings
+- Use Bootstrap alert variants for status coloring
+
+- [ ] **Step 3: Build and commit**
+
+```bash
+dotnet build Humans.slnx
+git add src/Humans.Web/Controllers/VolController.cs \
+        src/Humans.Web/Views/Vol/Management.cshtml
+git commit -m "feat(vol): implement Management dashboard"
+```
+
+---
+
+## Task 10: Settings Page
+
+Event settings editor with system toggle and volunteer cap.
+
+**Files:**
+- Modify: `src/Humans.Web/Controllers/VolController.cs`
+- Create: `src/Humans.Web/Views/Vol/Settings.cshtml`
+
+- [ ] **Step 1: Implement Settings GET action**
+
+Add `[HttpGet("Settings")]`. Guard: Admin only. Load EventSettings, confirmed volunteer count. Build `SettingsViewModel`.
+
+- [ ] **Step 2: Implement Settings POST action**
+
+Add `[HttpPost("Settings")]` with `[ValidateAntiForgeryToken]`. Guard: Admin only. Update `IsShiftBrowsingOpen` and `GlobalVolunteerCap` on the existing EventSettings. `SetSuccess`. Redirect.
+
+- [ ] **Step 3: Build `Settings.cshtml` view**
+
+- Event Periods timeline: three styled cards showing Build/Event/Strike date ranges
+- System toggle: checkbox or toggle switch with confirmation JS for closing
+- Volunteer cap: number input with progress bar showing current fill
+- Access Matrix: static table showing feature × role grid
+- All wrapped in a `<form>` posting to Settings
+
+- [ ] **Step 4: Build and commit**
+
+```bash
+dotnet build Humans.slnx
+git add src/Humans.Web/Controllers/VolController.cs \
+        src/Humans.Web/Views/Vol/Settings.cshtml
+git commit -m "feat(vol): implement Settings page"
+```
+
+---
+
+## Task 11: Registration Placeholder
+
+Static page with "coming soon" messaging.
+
+**Files:**
+- Modify: `src/Humans.Web/Controllers/VolController.cs`
+- Create: `src/Humans.Web/Views/Vol/Register.cshtml`
+
+- [ ] **Step 1: Implement Register GET action**
+
+Add `[HttpGet("Register")]`. No auth required (public-facing). Return view with no model.
+
+- [ ] **Step 2: Build `Register.cshtml` view**
+
+Visual placeholder matching the Figma welcome screen:
+- Centered card with heart icon
+- "Volunteer with Elsewhere" heading
+- Period overview cards (Build/Event/Strike) — static content
+- Prominent alert: "Volunteer registration is being redesigned — use the existing signup flow for now."
+- Link to existing shift browser and profile page
+
+Note: this page does NOT use `_VolLayout.cshtml` sub-nav (it's standalone). Override layout in the view: `@{ Layout = "~/Views/Shared/_Layout.cshtml"; }`.
+
+- [ ] **Step 3: Build and commit**
+
+```bash
+dotnet build Humans.slnx
+git add src/Humans.Web/Controllers/VolController.cs \
+        src/Humans.Web/Views/Vol/Register.cshtml
+git commit -m "feat(vol): add Registration placeholder page"
+```
+
+---
+
+## Task 12: Polish & Verify
+
+Final pass: empty states, error handling, build verification.
+
+**Files:**
+- Various views and controller
+
+- [ ] **Step 1: Verify all empty states**
+
+Check each page renders correctly with:
+- No EventSettings → NoActiveEvent view
+- Browsing closed → BrowsingClosed view (for non-privileged on All Shifts)
+- Zero data in each list → appropriate empty state message
+
+- [ ] **Step 2: Error handling sweep**
+
+Verify all controller actions have try-catch with `_logger.LogError`. Verify all POST actions have `[ValidateAntiForgeryToken]`.
+
+- [ ] **Step 3: Full build and format check**
+
+```bash
+dotnet build Humans.slnx
+dotnet format --verify-no-changes Humans.slnx
+```
+
+Fix any formatting issues.
+
+- [ ] **Step 4: Final commit**
+
+```bash
+git add -u src/Humans.Web/Controllers/VolController.cs \
+           src/Humans.Web/Views/Vol/
+git commit -m "feat(vol): polish empty states and error handling"
+```
+
+---
+
+## Summary
+
+| Task | Page | Key Actions |
+|------|------|-------------|
+| 1 | Scaffold | Controller, layout, nav link |
+| 2 | View Models | All 8 view model classes |
+| 3 | My Shifts | GET + Bail POST |
+| 4 | All Shifts | GET + SignUp POST + filters |
+| 5 | Teams Overview | GET |
+| 6 | Department Detail | GET |
+| 7 | Child Team Detail | GET + Approve/Refuse/NoShow POST |
+| 8 | Urgent Shifts | GET + Voluntell POST + volunteer search |
+| 9 | Management | GET (dashboard) |
+| 10 | Settings | GET + POST |
+| 11 | Registration | GET (placeholder) |
+| 12 | Polish | Empty states, error handling, format |

--- a/docs/superpowers/specs/2026-03-19-vol-volunteer-management-design.md
+++ b/docs/superpowers/specs/2026-03-19-vol-volunteer-management-design.md
@@ -39,7 +39,7 @@ Port the full `/volunteer-management` section from the Figma Make prototype into
 New "V" link in `_Layout.cshtml`:
 - Position: alongside existing nav items
 - Label: "V" (short, non-confusing test label)
-- Visibility: `IsAdmin || IsBoard || IsTeamsAdminBoardOrAdmin || VolunteerCoordinator || ConsentCoordinator`
+- Visibility: `IsTeamsAdminBoardOrAdmin || VolunteerCoordinator` (covers Admin, Board, TeamsAdmin, VolunteerCoordinator)
 - Existing `/Shifts` nav stays untouched — both coexist
 
 ### Shared Layout
@@ -94,15 +94,13 @@ Current user's shift signups in a Bootstrap card with table layout.
 
 Shift browser with filters and rota cards grouped by department.
 
-**Filter panel (collapsible Bootstrap card):**
-- Text search (rota name, duty title, team name)
-- Department dropdown (multi-select)
-- Team dropdown (multi-select, filtered by department selection)
-- Period chips (Build/Event/Strike)
-- Day selector (buttons for each day offset, filtered by period)
-- Priority chips (Normal/Important/Essential)
+**Filter panel — Phase 1 (matches existing `GetBrowseShiftsAsync` params):**
+- Department dropdown (single select)
+- Date filter (single day)
 - Open Only toggle (default: on)
-- Clear all button with active filter count
+
+**Filter panel — Future phases (requires new service params or in-memory filtering + JS):**
+- Text search, multi-select departments/teams, period/priority chips, day selector, cascading filters, active filter count
 
 **Summary bar:** X rotas, Y shifts, Z open slots, W essential.
 
@@ -112,7 +110,7 @@ Shift browser with filters and rota cards grouped by department.
 - Expandable "Show shifts" → shift rows:
   - Date (from DayOffset), Time, Volunteers (filled/total), Priority badge, Policy (Public=Instant, RequireApproval=Approval), Sign Up / Bail button
 
-**Data:** `IShiftManagementService.GetBrowseShiftsAsync()` with filters. Rota metadata from `GetRotasByDepartmentAsync()`.
+**Data:** `IShiftManagementService.GetBrowseShiftsAsync()` with existing filter params. Rota metadata from `GetRotasByDepartmentAsync()`.
 
 **POST actions:**
 - `POST /Vol/SignUp` → `IShiftSignupService.SignUpAsync`
@@ -122,9 +120,9 @@ Shift browser with filters and rota cards grouped by department.
 
 Grid of department (parent team) cards.
 
-Each card: name, accent color (from team metadata or hardcoded per-team), description, child team count, aggregate shift fill stats, lead name.
+Each card: name, description, child team count, aggregate shift fill stats (from existing staffing data).
 
-**Data:** `ITeamService` for teams, `IShiftManagementService.GetStaffingDataAsync()` for fill stats.
+**Data:** `ITeamService` for teams, `IShiftManagementService.GetStaffingDataAsync()` for fill stats. Team accent colors and lead names are not in the data model — use uniform card styling for Phase 1.
 
 ### Department Detail (`GET /Vol/Teams/{slug}`)
 
@@ -134,7 +132,7 @@ Lists child teams as cards with:
 - Team name, member count
 - Rota fill rates per rota
 - Pending join requests count (if coordinator)
-- Coordinator actions (if authorized): create rota, manage members
+- Coordinator actions (if authorized): create rota (department-level — rotas belong to parent teams, not child teams), manage members
 
 **Data:** `ITeamService.GetTeamBySlugAsync()`, `IShiftManagementService.GetRotasByDepartmentAsync()`, `IShiftManagementService.GetStaffingDataAsync()`.
 
@@ -143,9 +141,9 @@ Lists child teams as cards with:
 Full team view:
 - Team info header (name, description, member count)
 - Member roster with role assignments
-- Rotas section: each rota as a card with shift grid (day × time), fill indicators, rota metadata (description, practical info)
+- Rotas section: shows rotas from the parent department filtered to shifts relevant to this child team, with shift grid (day × time), fill indicators, rota metadata (description, practical info)
 - Pending join requests (if coordinator)
-- Coordinator actions: create/edit rota, create/edit/delete shift, approve/refuse signups, voluntell, manage members
+- Coordinator actions: create/edit shift within existing rotas, approve/refuse signups, voluntell, manage members. Rota CRUD is at department level (see Department Detail).
 
 **Data:** Same services as Department Detail, plus `IShiftSignupService` for signup management.
 
@@ -167,13 +165,13 @@ Table of unfilled shifts sorted by urgency score.
 | Priority | Badge (Normal/Important/Essential) |
 | Action | "Find volunteer" button |
 
-**"Find volunteer" flow:**
-1. Modal with volunteer search (name, skill, team filters)
-2. Results list with availability indicators
-3. Click → volunteer profile modal (skills, teams, quirks, medical [restricted to NoInfoAdmin/Admin], booked shifts)
-4. "Assign" button → `IShiftSignupService.VoluntellAsync()`
+**"Find volunteer" flow — Phase 1:**
+Reuse existing `ShiftVolunteerSearchBuilder` pattern: single search endpoint returning results with inline assign buttons. The existing `VolunteerSearchResult` record already includes skills, quirks, languages, dietary, booked shift count, overlap detection, and medical (when authorized).
 
-**Data:** `IShiftManagementService.GetUrgentShiftsAsync()`. Volunteer search via user/profile queries.
+**"Find volunteer" flow — Future phase:**
+Nested modals (search → profile detail → assign) with richer filtering by skill and team.
+
+**Data:** `IShiftManagementService.GetUrgentShiftsAsync()`. Volunteer search via existing `ShiftVolunteerSearchBuilder`.
 
 ### Management (`GET /Vol/Management`)
 
@@ -181,9 +179,9 @@ Manager dashboard:
 - System status banner (Open/Closed link to Settings)
 - Global Volunteer Cap indicator (progress bar, amber at 75%, red at 90%)
 - Actions grid:
-  - Export All Rotas CSV → `GET /Vol/Export/Rotas`
-  - Export Early Entry CSV → `GET /Vol/Export/EarlyEntry`
-  - Export Cantina CSV → `GET /Vol/Export/Cantina`
+  - Export All Rotas CSV → `GET /Vol/Export/Rotas` (placeholder — column definitions in Phase 3)
+  - Export Early Entry CSV → `GET /Vol/Export/EarlyEntry` (placeholder — column definitions in Phase 3)
+  - Export Cantina CSV → `GET /Vol/Export/Cantina` (placeholder — column definitions in Phase 3)
   - Link to Event Settings
 
 **Data:** `EventSettings` for system status and cap. Confirmed volunteer count from signup queries.
@@ -197,24 +195,15 @@ Manager dashboard:
 
 **Data:** `EventSettings` entity — read and update.
 
-### Registration (`GET /Vol/Register`, `POST /Vol/Register`)
+### Registration (`GET /Vol/Register`) — PLACEHOLDER
 
-Multi-step wizard (server-side with form state in TempData or hidden fields):
+**Status:** UI only, not wired to backend. Page renders the wizard screens but the submit action is disabled with a "Coming soon" message.
 
-1. **Welcome** — period overview (Build/Event/Strike info cards), "Start Registration" button
-2. **Availability** — on-site only vs year-round (radio cards)
-3. **Period selection** — Build/Event/Strike checkboxes (styled as cards)
-4. **Path choice** — "General Volunteer" (assigned by coordinators) vs "Apply for Specific Roles" (choose teams)
-5. **If general:** Confirmation summary + optional notes textarea → submit
-6. **If specific:** Team picker (accordion by department with checkboxes) + notes → submit
-7. **Done** — confirmation message with links to dashboard and shift browser
+The Figma prototype has a multi-step registration wizard (welcome → availability → periods → path choice → team picker → confirmation). The existing app handles volunteer registration differently (profile + consent + auto-approval to Volunteers team, with `GeneralAvailability` for day-level availability).
 
-**Data:**
-- **General path:** Creates `GeneralAvailability` with `AvailableDayOffsets` derived from selected periods (e.g., Build → all day offsets in Build range from EventSettings). The availability type (on-site/year-round) and "general volunteer" preference are not captured by existing entities — store as a note in the `TeamJoinRequest.Message` field by creating a join request to the Volunteer Coordination team.
-- **Specific path:** Creates `TeamJoinRequest` per selected team, with the notes field populated from the wizard textarea.
-- No new entities or schema changes required. Period selection maps to concrete day offsets via EventSettings period boundaries.
+This page will be built as a visual placeholder to match the Figma design, with a prominent subtext: *"Volunteer registration is being redesigned — use the existing signup flow for now."* The backend integration requires design decisions about how the wizard maps to existing entities, which is deferred.
 
-**Note:** This supplements (does not replace) existing membership onboarding. It captures shift volunteering interest and team preferences.
+**Note:** This supplements (does not replace) existing membership onboarding.
 
 ## Data Flow
 
@@ -238,7 +227,7 @@ Each page gets a dedicated view model in `Models/Vol/`:
 - `UrgentShiftsViewModel` — urgency-sorted shift list
 - `ManagementViewModel` — system status, cap data, export links
 - `SettingsViewModel` — event settings form
-- `RegistrationViewModel` — wizard state
+- `RegistrationViewModel` — placeholder (static page, no backend wiring)
 
 ### Authorization
 
@@ -266,10 +255,10 @@ All POST endpoints require `[ValidateAntiForgeryToken]` per codebase convention.
 | Voluntell | `POST /Vol/Voluntell` | `CanAccessDashboard` (Admin, NoInfoAdmin, VolCoord) | `IShiftSignupService.VoluntellAsync` |
 | Mark no-show | `POST /Vol/NoShow` | `CanApproveSignupsAsync` (VolCoord, DeptCoordinator, Admin) | `IShiftSignupService.MarkNoShowAsync` |
 | Update settings | `POST /Vol/Settings` | Admin only | Update `EventSettings` |
-| Register | `POST /Vol/Register` | Authenticated | Create `GeneralAvailability` / `TeamJoinRequest` |
-| Export Rotas | `GET /Vol/Export/Rotas` | Admin or VolunteerCoordinator | FileResult CSV |
-| Export Early Entry | `GET /Vol/Export/EarlyEntry` | Admin or VolunteerCoordinator | FileResult CSV |
-| Export Cantina | `GET /Vol/Export/Cantina` | Admin or VolunteerCoordinator | FileResult CSV |
+| Register | `POST /Vol/Register` | Deferred (placeholder page) | — |
+| Export Rotas | `GET /Vol/Export/Rotas` | Deferred (Phase 3 — column defs TBD) | — |
+| Export Early Entry | `GET /Vol/Export/EarlyEntry` | Deferred (Phase 3 — column defs TBD) | — |
+| Export Cantina | `GET /Vol/Export/Cantina` | Deferred (Phase 3 — column defs TBD) | — |
 
 ## Empty States & Edge Cases
 
@@ -283,11 +272,11 @@ All POST endpoints require `[ValidateAntiForgeryToken]` per codebase convention.
 
 ## Implementation Notes
 
-- **Controller size:** If `VolController` exceeds ~500 lines, split into `VolShiftsController`, `VolTeamsController`, `VolAdminController` — all sharing `_VolLayout.cshtml`
+- **Controller size:** Single `VolController` is fine even at 1000+ lines. Split only if it becomes genuinely hard to navigate, not for arbitrary line count thresholds
 - **`_ViewStart.cshtml`:** Use `Views/Vol/_ViewStart.cshtml` to set `Layout = "_VolLayout"` so individual views don't need to declare it
 - **NodaTime:** View models should use `LocalDate`, `LocalTime`, `Duration` from NodaTime for date/time fields; formatting happens in the Razor views
 - **Localization:** Vol pages are user-facing — use existing localization patterns (`IStringLocalizer<SharedResource>`) for display strings
-- **Icons:** Use existing icon approach (Bootstrap Icons / Font Awesome as used elsewhere in the app)
+- **Icons:** Font Awesome 6 only (`fa-solid fa-*`). Bootstrap Icons are NOT loaded in this project (per CODING_RULES). Map Figma's Lucide icons to FA6 equivalents
 
 ## New Files
 
@@ -316,5 +305,5 @@ All POST endpoints require `[ValidateAntiForgeryToken]` per codebase convention.
 ## Future Phases
 
 - **Phase 2:** Tailwind CSS + Figma earth-tone palette reskin (CSS-only change, same Razor views)
-- **Phase 3 (optional):** React/Blazor interactivity for specific components
+- **Phase 3:** CSV export column definitions + implementation; advanced filter panel (multi-select, cascading, JS); nested volunteer search modals; registration backend integration; React/Blazor interactivity (optional)
 - **Swap:** When `/Vol` is validated, replace `/Shifts` nav link → `/Vol`, remove "V" label, make `/Vol` the primary volunteering section

--- a/src/Humans.Web/Controllers/VolController.cs
+++ b/src/Humans.Web/Controllers/VolController.cs
@@ -668,6 +668,38 @@ public class VolController : HumansControllerBase
         return RedirectToAction(nameof(Urgent));
     }
 
+    [HttpGet("Management")]
+    public async Task<IActionResult> Management()
+    {
+        try
+        {
+            if (!ShiftRoleChecks.CanAccessDashboard(User))
+                return Forbid();
+
+            var es = await _shiftMgmt.GetActiveAsync();
+            if (es == null) return View("NoActiveEvent");
+
+            var staffingData = await _shiftMgmt.GetStaffingDataAsync(es.Id);
+            var confirmedCount = staffingData.Sum(d => d.ConfirmedCount);
+
+            var model = new ManagementViewModel
+            {
+                SystemOpen = es.IsShiftBrowsingOpen,
+                VolunteerCap = es.GlobalVolunteerCap,
+                ConfirmedVolunteerCount = confirmedCount,
+                EventSettings = es
+            };
+
+            return View(model);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error loading Management dashboard");
+            SetError("Failed to load dashboard.");
+            return RedirectToAction(nameof(MyShifts));
+        }
+    }
+
     [HttpGet("SearchVolunteers")]
     public async Task<IActionResult> SearchVolunteers(Guid shiftId, string? query)
     {

--- a/src/Humans.Web/Controllers/VolController.cs
+++ b/src/Humans.Web/Controllers/VolController.cs
@@ -700,6 +700,71 @@ public class VolController : HumansControllerBase
         }
     }
 
+    [HttpGet("Settings")]
+    public async Task<IActionResult> Settings()
+    {
+        try
+        {
+            if (!RoleChecks.IsAdmin(User))
+                return Forbid();
+
+            var es = await _shiftMgmt.GetActiveAsync();
+            if (es == null) return View("NoActiveEvent");
+
+            var staffingData = await _shiftMgmt.GetStaffingDataAsync(es.Id);
+            var confirmedCount = staffingData.Sum(d => d.ConfirmedCount);
+
+            var model = new SettingsViewModel
+            {
+                Id = es.Id,
+                EventName = es.EventName,
+                TimeZoneId = es.TimeZoneId,
+                GateOpeningDate = LocalDatePattern.Iso.Format(es.GateOpeningDate),
+                BuildStartOffset = es.BuildStartOffset,
+                EventEndOffset = es.EventEndOffset,
+                StrikeEndOffset = es.StrikeEndOffset,
+                IsShiftBrowsingOpen = es.IsShiftBrowsingOpen,
+                GlobalVolunteerCap = es.GlobalVolunteerCap,
+                ConfirmedVolunteerCount = confirmedCount
+            };
+
+            return View(model);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error loading Vol Settings");
+            SetError("Failed to load settings.");
+            return RedirectToAction(nameof(Management));
+        }
+    }
+
+    [HttpPost("Settings")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Settings(bool isShiftBrowsingOpen, int? globalVolunteerCap)
+    {
+        try
+        {
+            if (!RoleChecks.IsAdmin(User))
+                return Forbid();
+
+            var es = await _shiftMgmt.GetActiveAsync();
+            if (es == null) return View("NoActiveEvent");
+
+            es.IsShiftBrowsingOpen = isShiftBrowsingOpen;
+            es.GlobalVolunteerCap = globalVolunteerCap;
+            await _shiftMgmt.UpdateAsync(es);
+
+            SetSuccess("Settings saved.");
+            return RedirectToAction(nameof(Settings));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error saving Vol Settings");
+            SetError("Failed to save settings.");
+            return RedirectToAction(nameof(Settings));
+        }
+    }
+
     [HttpGet("SearchVolunteers")]
     public async Task<IActionResult> SearchVolunteers(Guid shiftId, string? query)
     {

--- a/src/Humans.Web/Controllers/VolController.cs
+++ b/src/Humans.Web/Controllers/VolController.cs
@@ -1,0 +1,47 @@
+using Humans.Application.Interfaces;
+using Humans.Domain.Entities;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using NodaTime;
+
+namespace Humans.Web.Controllers;
+
+[Authorize]
+[Route("Vol")]
+public class VolController : HumansControllerBase
+{
+    private readonly IShiftManagementService _shiftMgmt;
+    private readonly IShiftSignupService _signupService;
+    private readonly ITeamService _teamService;
+    private readonly IProfileService _profileService;
+    private readonly IGeneralAvailabilityService _availabilityService;
+    private readonly ILogger<VolController> _logger;
+    private readonly IClock _clock;
+
+    public VolController(
+        IShiftManagementService shiftMgmt,
+        IShiftSignupService signupService,
+        ITeamService teamService,
+        IProfileService profileService,
+        IGeneralAvailabilityService availabilityService,
+        UserManager<User> userManager,
+        ILogger<VolController> logger,
+        IClock clock)
+        : base(userManager)
+    {
+        _shiftMgmt = shiftMgmt;
+        _signupService = signupService;
+        _teamService = teamService;
+        _profileService = profileService;
+        _availabilityService = availabilityService;
+        _logger = logger;
+        _clock = clock;
+    }
+
+    [HttpGet("")]
+    public IActionResult Index() => RedirectToAction(nameof(MyShifts));
+
+    [HttpGet("MyShifts")]
+    public IActionResult MyShifts() => View();
+}

--- a/src/Humans.Web/Controllers/VolController.cs
+++ b/src/Humans.Web/Controllers/VolController.cs
@@ -1,4 +1,5 @@
 using Humans.Application.Interfaces;
+using Humans.Domain.Constants;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Humans.Web.Authorization;
@@ -255,6 +256,113 @@ public class VolController : HumansControllerBase
             _logger.LogError(ex, "Error signing up for shift {ShiftId}", shiftId);
             SetError("Failed to sign up.");
             return RedirectToAction(nameof(Shifts));
+        }
+    }
+
+    [HttpGet("Teams")]
+    public async Task<IActionResult> Teams()
+    {
+        try
+        {
+            var (err, user) = await ResolveCurrentUserOrChallengeAsync();
+            if (err != null) return err;
+
+            var es = await _shiftMgmt.GetActiveAsync();
+            if (es == null) return View("NoActiveEvent");
+
+            var deptTuples = await _shiftMgmt.GetDepartmentsWithRotasAsync(es.Id);
+            var allTeams = await _teamService.GetAllTeamsAsync();
+
+            var departments = new List<TeamsOverviewViewModel.DepartmentCard>();
+            foreach (var (teamId, teamName) in deptTuples)
+            {
+                var team = allTeams.FirstOrDefault(t => t.Id == teamId);
+                if (team == null) continue;
+
+                var childTeamCount = allTeams.Count(t => t.ParentTeamId == teamId && t.IsActive);
+                var summary = await _shiftMgmt.GetShiftsSummaryAsync(es.Id, teamId);
+
+                departments.Add(new TeamsOverviewViewModel.DepartmentCard
+                {
+                    TeamId = teamId,
+                    Name = teamName,
+                    Slug = team.Slug,
+                    Description = team.Description,
+                    ChildTeamCount = childTeamCount,
+                    TotalSlots = summary?.TotalSlots ?? 0,
+                    FilledSlots = summary?.ConfirmedCount ?? 0
+                });
+            }
+
+            var model = new TeamsOverviewViewModel { Departments = departments };
+            return View(model);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error loading Teams Overview");
+            SetError("Failed to load teams.");
+            return RedirectToAction(nameof(MyShifts));
+        }
+    }
+
+    [HttpGet("Teams/{slug}")]
+    public async Task<IActionResult> DepartmentDetail(string slug)
+    {
+        try
+        {
+            var (err, user) = await ResolveCurrentUserOrChallengeAsync();
+            if (err != null) return err;
+
+            var es = await _shiftMgmt.GetActiveAsync();
+            if (es == null) return View("NoActiveEvent");
+
+            var team = await _teamService.GetTeamBySlugAsync(slug);
+            if (team == null || team.ParentTeamId != null) return NotFound();
+
+            var isCoordinator = RoleChecks.IsAdmin(User) ||
+                                User.IsInRole(RoleNames.VolunteerCoordinator) ||
+                                await _shiftMgmt.IsDeptCoordinatorAsync(user.Id, team.Id);
+
+            var allTeams = await _teamService.GetAllTeamsAsync();
+            var childTeams = allTeams.Where(t => t.ParentTeamId == team.Id && t.IsActive).ToList();
+
+            var pendingCounts = isCoordinator
+                ? await _teamService.GetPendingRequestCountsByTeamIdsAsync(childTeams.Select(t => t.Id))
+                : new Dictionary<Guid, int>();
+
+            var childCards = new List<DepartmentDetailViewModel.ChildTeamCard>();
+            foreach (var child in childTeams)
+            {
+                var members = await _teamService.GetTeamMembersAsync(child.Id);
+                var summary = await _shiftMgmt.GetShiftsSummaryAsync(es.Id, child.Id);
+
+                childCards.Add(new DepartmentDetailViewModel.ChildTeamCard
+                {
+                    TeamId = child.Id,
+                    Name = child.Name,
+                    Slug = child.Slug,
+                    MemberCount = members.Count,
+                    TotalSlots = summary?.TotalSlots ?? 0,
+                    FilledSlots = summary?.ConfirmedCount ?? 0,
+                    PendingRequestCount = pendingCounts.GetValueOrDefault(child.Id, 0)
+                });
+            }
+
+            var model = new DepartmentDetailViewModel
+            {
+                Department = team,
+                ChildTeams = childCards,
+                IsCoordinator = isCoordinator,
+                EventSettings = es
+            };
+
+            return View(model);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error loading department detail for slug {Slug}", slug);
+            SetError("Failed to load department.");
+            return RedirectToAction(nameof(Teams));
         }
     }
 }

--- a/src/Humans.Web/Controllers/VolController.cs
+++ b/src/Humans.Web/Controllers/VolController.cs
@@ -3,6 +3,8 @@ using Humans.Domain.Constants;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Humans.Web.Authorization;
+using Humans.Web.Extensions;
+using Humans.Web.Helpers;
 using Humans.Web.Models;
 using Humans.Web.Models.Vol;
 using Microsoft.AspNetCore.Authorization;
@@ -363,6 +365,336 @@ public class VolController : HumansControllerBase
             _logger.LogError(ex, "Error loading department detail for slug {Slug}", slug);
             SetError("Failed to load department.");
             return RedirectToAction(nameof(Teams));
+        }
+    }
+
+    [HttpGet("Teams/{parentSlug}/{childSlug}")]
+    public async Task<IActionResult> ChildTeamDetail(string parentSlug, string childSlug)
+    {
+        try
+        {
+            var (err, user) = await ResolveCurrentUserOrChallengeAsync();
+            if (err != null) return err;
+
+            var es = await _shiftMgmt.GetActiveAsync();
+            if (es == null) return View("NoActiveEvent");
+
+            var parent = await _teamService.GetTeamBySlugAsync(parentSlug);
+            if (parent == null || parent.ParentTeamId != null) return NotFound();
+
+            var child = await _teamService.GetTeamBySlugAsync(childSlug);
+            if (child == null || child.ParentTeamId != parent.Id) return NotFound();
+
+            var isCoordinator = RoleChecks.IsAdmin(User) ||
+                                User.IsInRole(RoleNames.VolunteerCoordinator) ||
+                                await _shiftMgmt.IsDeptCoordinatorAsync(user.Id, parent.Id);
+
+            var members = await _teamService.GetTeamMembersAsync(child.Id);
+
+            var rotas = await _shiftMgmt.GetRotasByDepartmentAsync(child.Id, es.Id);
+            var rotaGroups = new List<RotaShiftGroup>();
+            foreach (var rota in rotas)
+            {
+                var shifts = await _shiftMgmt.GetShiftsByRotaAsync(rota.Id);
+                rotaGroups.Add(new RotaShiftGroup
+                {
+                    Rota = rota,
+                    Shifts = shifts.Select(s =>
+                    {
+                        var (start, end, period) = _shiftMgmt.ResolveShiftTimes(s, es);
+                        return new ShiftDisplayItem
+                        {
+                            Shift = s,
+                            AbsoluteStart = start,
+                            AbsoluteEnd = end,
+                            Period = period,
+                            ConfirmedCount = s.ShiftSignups.Count(su => su.Status == SignupStatus.Confirmed),
+                            RemainingSlots = s.MaxVolunteers - s.ShiftSignups.Count(su => su.Status == SignupStatus.Confirmed)
+                        };
+                    }).OrderBy(s => s.AbsoluteStart).ToList()
+                });
+            }
+
+            var userSignups = await _signupService.GetByUserAsync(user.Id, es.Id);
+            var userSignupShiftIds = userSignups
+                .Where(s => s.Status is SignupStatus.Confirmed or SignupStatus.Pending)
+                .Select(s => s.ShiftId).ToHashSet();
+            var userSignupStatuses = userSignups
+                .Where(s => s.Status is SignupStatus.Confirmed or SignupStatus.Pending)
+                .ToDictionary(s => s.ShiftId, s => s.Status);
+
+            var pendingRequests = isCoordinator
+                ? (await _teamService.GetPendingRequestsForTeamAsync(child.Id)).ToList()
+                : [];
+
+            var model = new ChildTeamDetailViewModel
+            {
+                ChildTeam = child,
+                Department = parent,
+                Members = members.ToList(),
+                Rotas = rotaGroups,
+                PendingRequests = pendingRequests,
+                IsCoordinator = isCoordinator,
+                EventSettings = es,
+                UserSignupShiftIds = userSignupShiftIds,
+                UserSignupStatuses = userSignupStatuses
+            };
+
+            return View(model);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error loading child team detail for {ParentSlug}/{ChildSlug}", parentSlug, childSlug);
+            SetError("Failed to load team detail.");
+            return RedirectToAction(nameof(Teams));
+        }
+    }
+
+    [HttpPost("Approve")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Approve(Guid signupId, string? returnUrl)
+    {
+        try
+        {
+            var (err, user) = await ResolveCurrentUserOrChallengeAsync();
+            if (err != null) return err;
+
+            var signup = await _signupService.GetByIdAsync(signupId);
+            if (signup == null)
+            {
+                SetError("Signup not found.");
+                return returnUrl != null ? LocalRedirect(returnUrl) : RedirectToAction(nameof(MyShifts));
+            }
+
+            var canApprove = ShiftRoleChecks.IsPrivilegedSignupApprover(User) ||
+                             await _shiftMgmt.CanApproveSignupsAsync(user.Id, signup.Shift.Rota.TeamId);
+            if (!canApprove) return Forbid();
+
+            var result = await _signupService.ApproveAsync(signupId, user.Id);
+            if (result.Success)
+                SetSuccess("Signup approved.");
+            else
+                SetError(result.Error ?? "Approval failed.");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error approving signup {SignupId}", signupId);
+            SetError("Approval failed.");
+        }
+        return returnUrl != null ? LocalRedirect(returnUrl) : RedirectToAction(nameof(MyShifts));
+    }
+
+    [HttpPost("Refuse")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Refuse(Guid signupId, string? reason, string? returnUrl)
+    {
+        try
+        {
+            var (err, user) = await ResolveCurrentUserOrChallengeAsync();
+            if (err != null) return err;
+
+            var signup = await _signupService.GetByIdAsync(signupId);
+            if (signup == null)
+            {
+                SetError("Signup not found.");
+                return returnUrl != null ? LocalRedirect(returnUrl) : RedirectToAction(nameof(MyShifts));
+            }
+
+            var canApprove = ShiftRoleChecks.IsPrivilegedSignupApprover(User) ||
+                             await _shiftMgmt.CanApproveSignupsAsync(user.Id, signup.Shift.Rota.TeamId);
+            if (!canApprove) return Forbid();
+
+            var result = await _signupService.RefuseAsync(signupId, user.Id, reason);
+            if (result.Success)
+                SetSuccess("Signup refused.");
+            else
+                SetError(result.Error ?? "Refusal failed.");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error refusing signup {SignupId}", signupId);
+            SetError("Refusal failed.");
+        }
+        return returnUrl != null ? LocalRedirect(returnUrl) : RedirectToAction(nameof(MyShifts));
+    }
+
+    [HttpPost("NoShow")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> NoShow(Guid signupId, string? returnUrl)
+    {
+        try
+        {
+            var (err, user) = await ResolveCurrentUserOrChallengeAsync();
+            if (err != null) return err;
+
+            var signup = await _signupService.GetByIdAsync(signupId);
+            if (signup == null)
+            {
+                SetError("Signup not found.");
+                return returnUrl != null ? LocalRedirect(returnUrl) : RedirectToAction(nameof(MyShifts));
+            }
+
+            var canApprove = ShiftRoleChecks.IsPrivilegedSignupApprover(User) ||
+                             await _shiftMgmt.CanApproveSignupsAsync(user.Id, signup.Shift.Rota.TeamId);
+            if (!canApprove) return Forbid();
+
+            var result = await _signupService.MarkNoShowAsync(signupId, user.Id);
+            if (result.Success)
+                SetSuccess("Marked as no-show.");
+            else
+                SetError(result.Error ?? "No-show marking failed.");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error marking no-show for signup {SignupId}", signupId);
+            SetError("No-show marking failed.");
+        }
+        return returnUrl != null ? LocalRedirect(returnUrl) : RedirectToAction(nameof(MyShifts));
+    }
+
+    [HttpPost("ApproveJoinRequest")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> ApproveJoinRequest(Guid requestId, string? returnUrl)
+    {
+        try
+        {
+            var (err, user) = await ResolveCurrentUserOrChallengeAsync();
+            if (err != null) return err;
+
+            await _teamService.ApproveJoinRequestAsync(requestId, user.Id, null);
+            SetSuccess("Join request approved.");
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or ArgumentException)
+        {
+            SetError(ex.Message);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error approving join request {RequestId}", requestId);
+            SetError("Failed to approve join request.");
+        }
+        return returnUrl != null ? LocalRedirect(returnUrl) : RedirectToAction(nameof(Teams));
+    }
+
+    [HttpPost("RejectJoinRequest")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> RejectJoinRequest(Guid requestId, string? reason, string? returnUrl)
+    {
+        try
+        {
+            var (err, user) = await ResolveCurrentUserOrChallengeAsync();
+            if (err != null) return err;
+
+            await _teamService.RejectJoinRequestAsync(requestId, user.Id, reason ?? "Rejected by coordinator.");
+            SetSuccess("Join request rejected.");
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or ArgumentException)
+        {
+            SetError(ex.Message);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error rejecting join request {RequestId}", requestId);
+            SetError("Failed to reject join request.");
+        }
+        return returnUrl != null ? LocalRedirect(returnUrl) : RedirectToAction(nameof(Teams));
+    }
+
+    [HttpGet("Urgent")]
+    public async Task<IActionResult> Urgent()
+    {
+        try
+        {
+            if (!ShiftRoleChecks.CanAccessDashboard(User))
+                return Forbid();
+
+            var es = await _shiftMgmt.GetActiveAsync();
+            if (es == null) return View("NoActiveEvent");
+
+            var urgentShifts = await _shiftMgmt.GetUrgentShiftsAsync(es.Id);
+
+            var model = new UrgentShiftsViewModel
+            {
+                EventSettings = es,
+                Shifts = urgentShifts.Select(u => new UrgentShiftsViewModel.UrgentShiftRow
+                {
+                    ShiftId = u.Shift.Id,
+                    DutyTitle = u.Shift.Rota.Name + (string.IsNullOrEmpty(u.Shift.Description) ? "" : " — " + u.Shift.Description),
+                    TeamName = u.DepartmentName,
+                    TeamSlug = u.Shift.Rota.Team.Slug,
+                    DayOffset = u.Shift.DayOffset,
+                    StartTime = u.Shift.StartTime,
+                    Duration = u.Shift.Duration,
+                    Confirmed = u.ConfirmedCount,
+                    MaxVolunteers = u.Shift.MaxVolunteers,
+                    Priority = u.Shift.Rota.Priority,
+                    UrgencyScore = u.UrgencyScore
+                }).ToList()
+            };
+
+            return View(model);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error loading Urgent Shifts");
+            SetError("Failed to load urgent shifts.");
+            return RedirectToAction(nameof(MyShifts));
+        }
+    }
+
+    [HttpPost("Voluntell")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Voluntell(Guid shiftId, Guid userId)
+    {
+        try
+        {
+            if (!ShiftRoleChecks.CanAccessDashboard(User))
+                return Forbid();
+
+            var (err, currentUser) = await ResolveCurrentUserOrUnauthorizedAsync();
+            if (err != null) return err;
+
+            var result = await _signupService.VoluntellAsync(userId, shiftId, currentUser.Id);
+            if (result.Success)
+                SetSuccess("Volunteer assigned to shift.");
+            else
+                SetError(result.Error ?? "Failed to assign volunteer.");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error voluntelling user {UserId} for shift {ShiftId}", userId, shiftId);
+            SetError("Failed to assign volunteer.");
+        }
+        return RedirectToAction(nameof(Urgent));
+    }
+
+    [HttpGet("SearchVolunteers")]
+    public async Task<IActionResult> SearchVolunteers(Guid shiftId, string? query)
+    {
+        if (!ShiftRoleChecks.CanAccessDashboard(User))
+            return Forbid();
+
+        if (!query.HasSearchTerm())
+            return Json(Array.Empty<VolunteerSearchResult>());
+
+        try
+        {
+            var shift = await _shiftMgmt.GetShiftByIdAsync(shiftId);
+            if (shift == null) return NotFound();
+
+            var es = shift.Rota.EventSettings ?? await _shiftMgmt.GetActiveAsync();
+            if (es == null) return NotFound();
+
+            var results = await ShiftVolunteerSearchBuilder.BuildAsync(
+                shift, query, es,
+                ShiftRoleChecks.CanViewMedical(User),
+                UserManager, _profileService, _signupService, _availabilityService);
+            return Json(results);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Volunteer search failed for shift {ShiftId}, query '{Query}'", shiftId, query);
+            return StatusCode(500, new { error = "Search failed." });
         }
     }
 }

--- a/src/Humans.Web/Controllers/VolController.cs
+++ b/src/Humans.Web/Controllers/VolController.cs
@@ -1,11 +1,14 @@
 using Humans.Application.Interfaces;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
+using Humans.Web.Authorization;
+using Humans.Web.Models;
 using Humans.Web.Models.Vol;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using NodaTime;
+using NodaTime.Text;
 
 namespace Humans.Web.Controllers;
 
@@ -57,10 +60,10 @@ public class VolController : HumansControllerBase
 
             var signups = await _signupService.GetByUserAsync(user.Id, es.Id);
 
-            var model = new MyShiftsViewModel
+            var model = new Models.Vol.MyShiftsViewModel
             {
                 EventSettings = es,
-                Shifts = signups.Select(signup => new MyShiftsViewModel.MyShiftRow
+                Shifts = signups.Select(signup => new Models.Vol.MyShiftsViewModel.MyShiftRow
                 {
                     SignupId = signup.Id,
                     DutyTitle = string.IsNullOrWhiteSpace(signup.Shift.Description)
@@ -106,6 +109,152 @@ public class VolController : HumansControllerBase
         {
             _logger.LogError(ex, "Error bailing from shift {SignupId}", signupId);
             throw;
+        }
+    }
+
+    [HttpGet("Shifts")]
+    public async Task<IActionResult> Shifts(Guid? departmentId, string? date, bool showFull = false)
+    {
+        try
+        {
+            var (err, user) = await ResolveCurrentUserOrChallengeAsync();
+            if (err != null) return err;
+
+            var es = await _shiftMgmt.GetActiveAsync();
+            if (es == null) return View("NoActiveEvent");
+
+            var isPrivileged = ShiftRoleChecks.IsPrivilegedSignupApprover(User) ||
+                               (await _shiftMgmt.GetCoordinatorDepartmentIdsAsync(user.Id)).Count > 0;
+
+            var userSignups = await _signupService.GetByUserAsync(user.Id, es.Id);
+            var hasSignups = userSignups.Count > 0;
+
+            if (!es.IsShiftBrowsingOpen && !isPrivileged && !hasSignups)
+                return View("BrowsingClosed");
+
+            var userSignupShiftIds = userSignups
+                .Where(s => s.Status is SignupStatus.Confirmed or SignupStatus.Pending)
+                .Select(s => s.ShiftId)
+                .ToHashSet();
+            var userSignupStatuses = userSignups
+                .Where(s => s.Status is SignupStatus.Confirmed or SignupStatus.Pending)
+                .ToDictionary(s => s.ShiftId, s => s.Status);
+
+            // Parse date filter
+            LocalDate? filterDate = null;
+            if (!string.IsNullOrEmpty(date) && LocalDatePattern.Iso.Parse(date) is { Success: true } parseResult)
+                filterDate = parseResult.Value;
+
+            var browseShifts = await _shiftMgmt.GetBrowseShiftsAsync(
+                es.Id, departmentId: departmentId, date: filterDate,
+                includeAdminOnly: isPrivileged, includeSignups: isPrivileged);
+
+            // Group by department -> rota -> shift
+            var departments = browseShifts
+                .GroupBy(u => u.Shift.Rota.TeamId)
+                .Select(deptGroup =>
+                {
+                    var firstShift = deptGroup.First().Shift;
+                    return new DepartmentShiftGroup
+                    {
+                        TeamId = firstShift.Rota.TeamId,
+                        TeamName = firstShift.Rota.Team.Name,
+                        TeamSlug = firstShift.Rota.Team.Slug,
+                        Rotas = deptGroup.GroupBy(u => u.Shift.RotaId)
+                            .Select(rotaGroup =>
+                            {
+                                var rota = rotaGroup.First().Shift.Rota;
+                                return new RotaShiftGroup
+                                {
+                                    Rota = rota,
+                                    Shifts = rotaGroup.Select(u =>
+                                    {
+                                        var (start, end, period) = _shiftMgmt.ResolveShiftTimes(u.Shift, es);
+                                        return new ShiftDisplayItem
+                                        {
+                                            Shift = u.Shift,
+                                            AbsoluteStart = start,
+                                            AbsoluteEnd = end,
+                                            Period = period,
+                                            ConfirmedCount = u.ConfirmedCount,
+                                            RemainingSlots = u.RemainingSlots,
+                                            Signups = u.Signups.Select(s => new ShiftSignupInfo(
+                                                s.UserId, s.DisplayName, s.Status,
+                                                s.HasProfilePicture ? $"/Human/{s.UserId}/Picture" : null))
+                                                .ToList()
+                                        };
+                                    }).OrderBy(s => s.AbsoluteStart).ToList()
+                                };
+                            }).OrderBy(r => r.Rota.Name, StringComparer.Ordinal).ToList()
+                    };
+                }).OrderBy(d => d.TeamName, StringComparer.Ordinal).ToList();
+
+            List<DepartmentOption> allDepartments;
+            if (!departmentId.HasValue)
+            {
+                allDepartments = departments
+                    .Select(d => new DepartmentOption { TeamId = d.TeamId, Name = d.TeamName }).ToList();
+            }
+            else
+            {
+                var depts = await _shiftMgmt.GetDepartmentsWithRotasAsync(es.Id);
+                allDepartments = depts
+                    .Select(d => new DepartmentOption { TeamId = d.TeamId, Name = d.TeamName }).ToList();
+            }
+
+            var model = new ShiftBrowserViewModel
+            {
+                EventSettings = es,
+                FilterDepartmentId = departmentId,
+                FilterDate = date,
+                ShowFullShifts = showFull,
+                UserSignupShiftIds = userSignupShiftIds,
+                UserSignupStatuses = userSignupStatuses,
+                Departments = departments,
+                AllDepartments = allDepartments,
+                ShowSignups = isPrivileged,
+                IsPrivileged = isPrivileged
+            };
+
+            return View(model);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error loading All Shifts page");
+            SetError("Failed to load shifts.");
+            return RedirectToAction(nameof(MyShifts));
+        }
+    }
+
+    [HttpPost("SignUp")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> SignUp(Guid shiftId)
+    {
+        try
+        {
+            var (err, user) = await ResolveCurrentUserOrChallengeAsync();
+            if (err != null) return err;
+
+            var privileged = ShiftRoleChecks.IsPrivilegedSignupApprover(User);
+            var result = await _signupService.SignUpAsync(user.Id, shiftId, isPrivileged: privileged);
+
+            if (!result.Success)
+            {
+                SetError(result.Error ?? "Shift signup failed.");
+                return RedirectToAction(nameof(Shifts));
+            }
+
+            SetSuccess(result.Warning != null
+                ? $"Signed up successfully. Note: {result.Warning}"
+                : "Signed up successfully!");
+
+            return RedirectToAction(nameof(Shifts));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error signing up for shift {ShiftId}", shiftId);
+            SetError("Failed to sign up.");
+            return RedirectToAction(nameof(Shifts));
         }
     }
 }

--- a/src/Humans.Web/Controllers/VolController.cs
+++ b/src/Humans.Web/Controllers/VolController.cs
@@ -765,6 +765,10 @@ public class VolController : HumansControllerBase
         }
     }
 
+    [HttpGet("Register")]
+    [AllowAnonymous]
+    public IActionResult Register() => View();
+
     [HttpGet("SearchVolunteers")]
     public async Task<IActionResult> SearchVolunteers(Guid shiftId, string? query)
     {

--- a/src/Humans.Web/Controllers/VolController.cs
+++ b/src/Humans.Web/Controllers/VolController.cs
@@ -1,5 +1,7 @@
 using Humans.Application.Interfaces;
 using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using Humans.Web.Models.Vol;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
@@ -43,5 +45,67 @@ public class VolController : HumansControllerBase
     public IActionResult Index() => RedirectToAction(nameof(MyShifts));
 
     [HttpGet("MyShifts")]
-    public IActionResult MyShifts() => View();
+    public async Task<IActionResult> MyShifts()
+    {
+        try
+        {
+            var (currentUserNotFound, user) = await ResolveCurrentUserOrChallengeAsync();
+            if (currentUserNotFound != null) return currentUserNotFound;
+
+            var es = await _shiftMgmt.GetActiveAsync();
+            if (es == null) return View("NoActiveEvent");
+
+            var signups = await _signupService.GetByUserAsync(user.Id, es.Id);
+
+            var model = new MyShiftsViewModel
+            {
+                EventSettings = es,
+                Shifts = signups.Select(signup => new MyShiftsViewModel.MyShiftRow
+                {
+                    SignupId = signup.Id,
+                    DutyTitle = string.IsNullOrWhiteSpace(signup.Shift.Description)
+                        ? signup.Shift.Rota.Name
+                        : $"{signup.Shift.Rota.Name} — {signup.Shift.Description}",
+                    TeamName = signup.Shift.Rota.Team.Name,
+                    AbsoluteStart = signup.Shift.GetAbsoluteStart(es),
+                    AbsoluteEnd = signup.Shift.GetAbsoluteEnd(es),
+                    Status = signup.Status
+                }).OrderBy(s => s.AbsoluteStart).ToList()
+            };
+
+            return View(model);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error loading My Shifts");
+            throw;
+        }
+    }
+
+    [HttpPost("Bail")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Bail(Guid signupId)
+    {
+        try
+        {
+            var (currentUserNotFound, user) = await ResolveCurrentUserOrChallengeAsync();
+            if (currentUserNotFound != null) return currentUserNotFound;
+
+            var result = await _signupService.BailAsync(signupId, user.Id, null);
+
+            if (!result.Success)
+            {
+                SetError(result.Error ?? "Shift bail failed.");
+                return RedirectToAction(nameof(MyShifts));
+            }
+
+            SetSuccess("Successfully bailed from shift.");
+            return RedirectToAction(nameof(MyShifts));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error bailing from shift {SignupId}", signupId);
+            throw;
+        }
+    }
 }

--- a/src/Humans.Web/Models/Vol/ChildTeamDetailViewModel.cs
+++ b/src/Humans.Web/Models/Vol/ChildTeamDetailViewModel.cs
@@ -1,0 +1,17 @@
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+
+namespace Humans.Web.Models.Vol;
+
+public class ChildTeamDetailViewModel
+{
+    public Team ChildTeam { get; set; } = null!;
+    public Team Department { get; set; } = null!;
+    public List<TeamMember> Members { get; set; } = [];
+    public List<RotaShiftGroup> Rotas { get; set; } = [];
+    public List<TeamJoinRequest> PendingRequests { get; set; } = [];
+    public bool IsCoordinator { get; set; }
+    public EventSettings EventSettings { get; set; } = null!;
+    public HashSet<Guid> UserSignupShiftIds { get; set; } = [];
+    public Dictionary<Guid, SignupStatus> UserSignupStatuses { get; set; } = new();
+}

--- a/src/Humans.Web/Models/Vol/DepartmentDetailViewModel.cs
+++ b/src/Humans.Web/Models/Vol/DepartmentDetailViewModel.cs
@@ -1,0 +1,22 @@
+using Humans.Domain.Entities;
+
+namespace Humans.Web.Models.Vol;
+
+public class DepartmentDetailViewModel
+{
+    public Team Department { get; set; } = null!;
+    public List<ChildTeamCard> ChildTeams { get; set; } = [];
+    public bool IsCoordinator { get; set; }
+    public EventSettings EventSettings { get; set; } = null!;
+
+    public class ChildTeamCard
+    {
+        public Guid TeamId { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public string Slug { get; set; } = string.Empty;
+        public int MemberCount { get; set; }
+        public int TotalSlots { get; set; }
+        public int FilledSlots { get; set; }
+        public int PendingRequestCount { get; set; }
+    }
+}

--- a/src/Humans.Web/Models/Vol/ManagementViewModel.cs
+++ b/src/Humans.Web/Models/Vol/ManagementViewModel.cs
@@ -1,0 +1,11 @@
+using Humans.Domain.Entities;
+
+namespace Humans.Web.Models.Vol;
+
+public class ManagementViewModel
+{
+    public bool SystemOpen { get; set; }
+    public int? VolunteerCap { get; set; }
+    public int ConfirmedVolunteerCount { get; set; }
+    public EventSettings EventSettings { get; set; } = null!;
+}

--- a/src/Humans.Web/Models/Vol/MyShiftsViewModel.cs
+++ b/src/Humans.Web/Models/Vol/MyShiftsViewModel.cs
@@ -1,0 +1,22 @@
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using NodaTime;
+
+namespace Humans.Web.Models.Vol;
+
+public class MyShiftsViewModel
+{
+    public List<MyShiftRow> Shifts { get; set; } = [];
+    public EventSettings EventSettings { get; set; } = null!;
+
+    public class MyShiftRow
+    {
+        public Guid SignupId { get; set; }
+        public string DutyTitle { get; set; } = string.Empty;
+        public string TeamName { get; set; } = string.Empty;
+        public Instant AbsoluteStart { get; set; }
+        public Instant AbsoluteEnd { get; set; }
+        public SignupStatus Status { get; set; }
+        public bool CanBail => Status is SignupStatus.Confirmed or SignupStatus.Pending;
+    }
+}

--- a/src/Humans.Web/Models/Vol/SettingsViewModel.cs
+++ b/src/Humans.Web/Models/Vol/SettingsViewModel.cs
@@ -1,0 +1,19 @@
+namespace Humans.Web.Models.Vol;
+
+public class SettingsViewModel
+{
+    public Guid? Id { get; set; }
+    public string EventName { get; set; } = string.Empty;
+    public string TimeZoneId { get; set; } = string.Empty;
+    public string GateOpeningDate { get; set; } = string.Empty;
+    public int BuildStartOffset { get; set; }
+    public int EventEndOffset { get; set; }
+    public int StrikeEndOffset { get; set; }
+    public bool IsShiftBrowsingOpen { get; set; }
+    public int? GlobalVolunteerCap { get; set; }
+    public int ConfirmedVolunteerCount { get; set; }
+
+    public int BuildDays => -BuildStartOffset;
+    public int EventDays => EventEndOffset - 0;
+    public int StrikeDays => StrikeEndOffset - EventEndOffset;
+}

--- a/src/Humans.Web/Models/Vol/ShiftBrowserViewModel.cs
+++ b/src/Humans.Web/Models/Vol/ShiftBrowserViewModel.cs
@@ -1,0 +1,18 @@
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+
+namespace Humans.Web.Models.Vol;
+
+public class ShiftBrowserViewModel
+{
+    public EventSettings EventSettings { get; set; } = null!;
+    public List<DepartmentShiftGroup> Departments { get; set; } = [];
+    public List<DepartmentOption> AllDepartments { get; set; } = [];
+    public Guid? FilterDepartmentId { get; set; }
+    public string? FilterDate { get; set; }
+    public bool ShowFullShifts { get; set; }
+    public HashSet<Guid> UserSignupShiftIds { get; set; } = [];
+    public Dictionary<Guid, SignupStatus> UserSignupStatuses { get; set; } = new();
+    public bool ShowSignups { get; set; }
+    public bool IsPrivileged { get; set; }
+}

--- a/src/Humans.Web/Models/Vol/TeamsOverviewViewModel.cs
+++ b/src/Humans.Web/Models/Vol/TeamsOverviewViewModel.cs
@@ -1,0 +1,17 @@
+namespace Humans.Web.Models.Vol;
+
+public class TeamsOverviewViewModel
+{
+    public List<DepartmentCard> Departments { get; set; } = [];
+
+    public class DepartmentCard
+    {
+        public Guid TeamId { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public string Slug { get; set; } = string.Empty;
+        public string? Description { get; set; }
+        public int ChildTeamCount { get; set; }
+        public int TotalSlots { get; set; }
+        public int FilledSlots { get; set; }
+    }
+}

--- a/src/Humans.Web/Models/Vol/UrgentShiftsViewModel.cs
+++ b/src/Humans.Web/Models/Vol/UrgentShiftsViewModel.cs
@@ -1,0 +1,26 @@
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using NodaTime;
+
+namespace Humans.Web.Models.Vol;
+
+public class UrgentShiftsViewModel
+{
+    public List<UrgentShiftRow> Shifts { get; set; } = [];
+    public EventSettings EventSettings { get; set; } = null!;
+
+    public class UrgentShiftRow
+    {
+        public Guid ShiftId { get; set; }
+        public string DutyTitle { get; set; } = string.Empty;
+        public string TeamName { get; set; } = string.Empty;
+        public string TeamSlug { get; set; } = string.Empty;
+        public int DayOffset { get; set; }
+        public LocalTime StartTime { get; set; }
+        public Duration Duration { get; set; }
+        public int Confirmed { get; set; }
+        public int MaxVolunteers { get; set; }
+        public ShiftPriority Priority { get; set; }
+        public double UrgencyScore { get; set; }
+    }
+}

--- a/src/Humans.Web/Views/Shared/_Layout.cshtml
+++ b/src/Humans.Web/Views/Shared/_Layout.cshtml
@@ -55,6 +55,12 @@
                                     <a class="nav-link" asp-area="" asp-controller="Shifts" asp-action="Index">@Localizer["Nav_Shifts"]</a>
                                 </li>
                             }
+                            @if (Humans.Web.Authorization.RoleChecks.IsTeamsAdminBoardOrAdmin(User) || User.IsInRole(Humans.Domain.Constants.RoleNames.VolunteerCoordinator))
+                            {
+                                <li class="nav-item">
+                                    <a class="nav-link" asp-area="" asp-controller="Vol" asp-action="Index">V</a>
+                                </li>
+                            }
                         }
                         @if (Humans.Web.Authorization.RoleChecks.CanAccessReviewQueue(User))
                         {

--- a/src/Humans.Web/Views/Vol/BrowsingClosed.cshtml
+++ b/src/Humans.Web/Views/Vol/BrowsingClosed.cshtml
@@ -1,0 +1,9 @@
+@{
+    ViewData["Title"] = "Volunteering";
+    ViewData["VolActiveTab"] = "";
+}
+
+<div class="text-center py-4">
+    <h4>Shift Browsing Closed</h4>
+    <p class="text-muted mt-3">Shift browsing is not yet open. Check back later!</p>
+</div>

--- a/src/Humans.Web/Views/Vol/ChildTeamDetail.cshtml
+++ b/src/Humans.Web/Views/Vol/ChildTeamDetail.cshtml
@@ -1,0 +1,156 @@
+@model Humans.Web.Models.Vol.ChildTeamDetailViewModel
+
+@{
+    ViewData["Title"] = Model.ChildTeam.Name;
+    ViewData["VolActiveTab"] = "Teams";
+}
+
+<vc:temp-data-alerts />
+
+<nav aria-label="breadcrumb" class="mb-3">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a asp-action="Teams">Teams</a></li>
+        <li class="breadcrumb-item">
+            <a asp-action="DepartmentDetail" asp-route-slug="@Model.Department.Slug">@Model.Department.Name</a>
+        </li>
+        <li class="breadcrumb-item active" aria-current="page">@Model.ChildTeam.Name</li>
+    </ol>
+</nav>
+
+@if (!string.IsNullOrWhiteSpace(Model.ChildTeam.Description))
+{
+    <p class="text-muted">@Model.ChildTeam.Description</p>
+}
+
+<div class="d-flex align-items-center mb-4">
+    <span class="text-muted">
+        <i class="fa-solid fa-user me-1"></i>@Model.Members.Count human@(Model.Members.Count != 1 ? "s" : "")
+    </span>
+</div>
+
+@* Member roster *@
+<div class="card mb-4">
+    <div class="card-header">
+        <h5 class="mb-0"><i class="fa-solid fa-users me-2"></i>Humans</h5>
+    </div>
+    <div class="card-body p-0">
+        @if (Model.Members.Count == 0)
+        {
+            <div class="text-center py-4 text-muted">No humans in this team yet.</div>
+        }
+        else
+        {
+            <div class="table-responsive">
+                <table class="table table-sm mb-0">
+                    <thead>
+                        <tr>
+                            <th>Name</th>
+                            <th>Role</th>
+                            <th>Joined</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var member in Model.Members.OrderBy(m => m.User.DisplayName, StringComparer.OrdinalIgnoreCase))
+                        {
+                            <tr>
+                                <td>
+                                    <a asp-controller="Human" asp-action="View" asp-route-id="@member.UserId"
+                                       class="text-decoration-none">@member.User.DisplayName</a>
+                                </td>
+                                <td>
+                                    @if (member.Role == TeamMemberRole.Coordinator)
+                                    {
+                                        <span class="badge bg-primary">Coordinator</span>
+                                    }
+                                    else
+                                    {
+                                        <span class="text-muted">Member</span>
+                                    }
+                                </td>
+                                <td>@member.JoinedAt.ToDisplayDate()</td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
+        }
+    </div>
+</div>
+
+@* Rotas section *@
+@if (Model.Rotas.Count > 0)
+{
+    <div class="card mb-4">
+        <div class="card-header">
+            <h5 class="mb-0"><i class="fa-solid fa-calendar-days me-2"></i>Rotas</h5>
+        </div>
+        <div class="card-body">
+            @foreach (var rotaGroup in Model.Rotas.OrderBy(r => r.Rota.Name, StringComparer.Ordinal))
+            {
+                @await Html.PartialAsync("_RotaCard", (rotaGroup, Model.EventSettings, Model.UserSignupShiftIds, Model.UserSignupStatuses, Model.IsCoordinator))
+            }
+        </div>
+    </div>
+}
+
+@* Pending join requests (coordinator only) *@
+@if (Model.IsCoordinator && Model.PendingRequests.Count > 0)
+{
+    <div class="card mb-4">
+        <div class="card-header">
+            <h5 class="mb-0">
+                <i class="fa-solid fa-clock me-2"></i>Pending Join Requests
+                <span class="badge bg-warning text-dark ms-2">@Model.PendingRequests.Count</span>
+            </h5>
+        </div>
+        <div class="card-body p-0">
+            <div class="table-responsive">
+                <table class="table table-sm mb-0">
+                    <thead>
+                        <tr>
+                            <th>Name</th>
+                            <th>Message</th>
+                            <th>Requested</th>
+                            <th></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var request in Model.PendingRequests.OrderBy(r => r.RequestedAt))
+                        {
+                            <tr>
+                                <td>
+                                    <a asp-controller="Human" asp-action="View" asp-route-id="@request.UserId"
+                                       class="text-decoration-none">@request.User.DisplayName</a>
+                                </td>
+                                <td class="text-muted small">
+                                    @(string.IsNullOrWhiteSpace(request.Message) ? "—" : request.Message)
+                                </td>
+                                <td>@request.RequestedAt.ToDisplayDate()</td>
+                                <td class="text-end">
+                                    <form asp-controller="Vol" asp-action="ApproveJoinRequest" method="post" class="d-inline">
+                                        @Html.AntiForgeryToken()
+                                        <input type="hidden" name="requestId" value="@request.Id" />
+                                        <input type="hidden" name="returnUrl"
+                                               value="@Url.Action("ChildTeamDetail", "Vol", new { parentSlug = Model.Department.Slug, childSlug = Model.ChildTeam.Slug })" />
+                                        <button type="submit" class="btn btn-sm btn-success">
+                                            <i class="fa-solid fa-check me-1"></i>Approve
+                                        </button>
+                                    </form>
+                                    <form asp-controller="Vol" asp-action="RejectJoinRequest" method="post" class="d-inline ms-1">
+                                        @Html.AntiForgeryToken()
+                                        <input type="hidden" name="requestId" value="@request.Id" />
+                                        <input type="hidden" name="returnUrl"
+                                               value="@Url.Action("ChildTeamDetail", "Vol", new { parentSlug = Model.Department.Slug, childSlug = Model.ChildTeam.Slug })" />
+                                        <button type="submit" class="btn btn-sm btn-outline-danger">
+                                            <i class="fa-solid fa-xmark me-1"></i>Reject
+                                        </button>
+                                    </form>
+                                </td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+}

--- a/src/Humans.Web/Views/Vol/DepartmentDetail.cshtml
+++ b/src/Humans.Web/Views/Vol/DepartmentDetail.cshtml
@@ -1,0 +1,82 @@
+@model Humans.Web.Models.Vol.DepartmentDetailViewModel
+
+@{
+    ViewData["Title"] = Model.Department.Name;
+    ViewData["VolActiveTab"] = "Teams";
+}
+
+<vc:temp-data-alerts />
+
+<nav aria-label="breadcrumb" class="mb-3">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a asp-action="Teams">Teams</a></li>
+        <li class="breadcrumb-item active" aria-current="page">@Model.Department.Name</li>
+    </ol>
+</nav>
+
+@if (!string.IsNullOrWhiteSpace(Model.Department.Description))
+{
+    <p class="text-muted">@Model.Department.Description</p>
+}
+
+@if (Model.ChildTeams.Count == 0)
+{
+    <div class="card">
+        <div class="card-body text-center py-5">
+            <i class="fa-solid fa-users fa-2x text-muted mb-3"></i>
+            <p class="text-muted">No teams in this department yet.</p>
+        </div>
+    </div>
+}
+else
+{
+    <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4">
+        @foreach (var child in Model.ChildTeams)
+        {
+            var fillPct = child.TotalSlots > 0
+                ? (int)Math.Round(100.0 * child.FilledSlots / child.TotalSlots)
+                : 0;
+            var barClass = fillPct >= 80 ? "bg-success" : fillPct >= 50 ? "bg-warning" : "bg-danger";
+
+            <div class="col">
+                <div class="card h-100">
+                    <div class="card-header d-flex justify-content-between align-items-center">
+                        <h5 class="mb-0">
+                            <a asp-action="ChildTeamDetail"
+                               asp-route-parentSlug="@Model.Department.Slug"
+                               asp-route-childSlug="@child.Slug"
+                               class="text-decoration-none">
+                                @child.Name
+                            </a>
+                        </h5>
+                        @if (Model.IsCoordinator && child.PendingRequestCount > 0)
+                        {
+                            <span class="badge bg-warning text-dark" title="Pending join requests">
+                                @child.PendingRequestCount pending
+                            </span>
+                        }
+                    </div>
+                    <div class="card-body">
+                        <div class="d-flex justify-content-between text-muted small mb-2">
+                            <span><i class="fa-solid fa-user me-1"></i>@child.MemberCount human@(child.MemberCount != 1 ? "s" : "")</span>
+                            <span>@child.FilledSlots / @child.TotalSlots slots filled</span>
+                        </div>
+                        <div class="progress" style="height: 8px;">
+                            <div class="progress-bar @barClass" role="progressbar"
+                                 style="width: @(fillPct)%"
+                                 aria-valuenow="@fillPct" aria-valuemin="0" aria-valuemax="100"></div>
+                        </div>
+                    </div>
+                    <div class="card-footer text-end">
+                        <a asp-action="ChildTeamDetail"
+                           asp-route-parentSlug="@Model.Department.Slug"
+                           asp-route-childSlug="@child.Slug"
+                           class="btn btn-sm btn-outline-primary">
+                            View Details <i class="fa-solid fa-arrow-right ms-1"></i>
+                        </a>
+                    </div>
+                </div>
+            </div>
+        }
+    </div>
+}

--- a/src/Humans.Web/Views/Vol/Management.cshtml
+++ b/src/Humans.Web/Views/Vol/Management.cshtml
@@ -1,0 +1,116 @@
+@model Humans.Web.Models.Vol.ManagementViewModel
+
+@{
+    ViewData["Title"] = "Management";
+    ViewData["VolActiveTab"] = "Management";
+
+    var fillPercent = Model.VolunteerCap.HasValue && Model.VolunteerCap.Value > 0
+        ? (int)(100.0 * Model.ConfirmedVolunteerCount / Model.VolunteerCap.Value)
+        : 0;
+    var progressColor = fillPercent > 90 ? "bg-danger"
+        : fillPercent >= 75 ? "bg-warning"
+        : "bg-success";
+}
+
+<vc:temp-data-alerts />
+
+<div class="row g-4 mb-4">
+    @* System Status *@
+    <div class="col-md-6">
+        <div class="card h-100 @(Model.SystemOpen ? "border-start border-success border-4" : "border-start border-danger border-4")">
+            <div class="card-body">
+                <div class="d-flex align-items-center mb-2">
+                    @if (Model.SystemOpen)
+                    {
+                        <i class="fa-solid fa-circle-check fa-lg text-success me-2"></i>
+                        <h5 class="mb-0 text-success">System Open</h5>
+                    }
+                    else
+                    {
+                        <i class="fa-solid fa-circle-xmark fa-lg text-danger me-2"></i>
+                        <h5 class="mb-0 text-danger">System Closed</h5>
+                    }
+                </div>
+                <p class="text-muted mb-2">
+                    Humans can @(Model.SystemOpen ? "" : "not ")browse and sign up for shifts.
+                </p>
+                @if (Humans.Web.Authorization.RoleChecks.IsAdmin(User))
+                {
+                    <a asp-action="Settings" class="btn btn-sm btn-outline-secondary">
+                        <i class="fa-solid fa-gear me-1"></i>Change in Settings
+                    </a>
+                }
+            </div>
+        </div>
+    </div>
+
+    @* Volunteer Cap *@
+    <div class="col-md-6">
+        <div class="card h-100">
+            <div class="card-body">
+                <div class="d-flex align-items-center mb-2">
+                    <i class="fa-solid fa-users fa-lg text-primary me-2"></i>
+                    <h5 class="mb-0">Volunteer Cap</h5>
+                </div>
+                @if (Model.VolunteerCap.HasValue && Model.VolunteerCap.Value > 0)
+                {
+                    <div class="mb-2">
+                        <span class="fs-4 fw-bold">@Model.ConfirmedVolunteerCount</span>
+                        <span class="text-muted">/ @Model.VolunteerCap.Value confirmed</span>
+                    </div>
+                    <div class="progress" style="height: 12px;">
+                        <div class="progress-bar @progressColor" style="width: @(Math.Min(fillPercent, 100))%"
+                             role="progressbar" aria-valuenow="@Model.ConfirmedVolunteerCount"
+                             aria-valuemin="0" aria-valuemax="@Model.VolunteerCap.Value">
+                            @(fillPercent)%
+                        </div>
+                    </div>
+                }
+                else
+                {
+                    <p class="text-muted mb-0">
+                        <i class="fa-solid fa-infinity me-1"></i>No cap set
+                    </p>
+                    <p class="mb-0">
+                        <span class="fs-4 fw-bold">@Model.ConfirmedVolunteerCount</span>
+                        <span class="text-muted">confirmed</span>
+                    </p>
+                }
+            </div>
+        </div>
+    </div>
+</div>
+
+@* Actions *@
+<div class="card">
+    <div class="card-header">
+        <h5 class="mb-0"><i class="fa-solid fa-bolt me-2"></i>Actions</h5>
+    </div>
+    <div class="card-body">
+        <div class="row g-3">
+            <div class="col-md-3">
+                <button class="btn btn-outline-secondary w-100" disabled title="Phase 3">
+                    <i class="fa-solid fa-file-csv me-1"></i>Export Shifts
+                </button>
+            </div>
+            <div class="col-md-3">
+                <button class="btn btn-outline-secondary w-100" disabled title="Phase 3">
+                    <i class="fa-solid fa-file-arrow-down me-1"></i>Export Signups
+                </button>
+            </div>
+            <div class="col-md-3">
+                <button class="btn btn-outline-secondary w-100" disabled title="Phase 3">
+                    <i class="fa-solid fa-chart-pie me-1"></i>Staffing Report
+                </button>
+            </div>
+            @if (Humans.Web.Authorization.RoleChecks.IsAdmin(User))
+            {
+                <div class="col-md-3">
+                    <a asp-action="Settings" class="btn btn-outline-primary w-100">
+                        <i class="fa-solid fa-gear me-1"></i>Settings
+                    </a>
+                </div>
+            }
+        </div>
+    </div>
+</div>

--- a/src/Humans.Web/Views/Vol/MyShifts.cshtml
+++ b/src/Humans.Web/Views/Vol/MyShifts.cshtml
@@ -1,11 +1,77 @@
+@model Humans.Web.Models.Vol.MyShiftsViewModel
+@using Humans.Domain.Enums
+@using NodaTime
+
 @{
     ViewData["Title"] = "My Shifts";
     ViewData["VolActiveTab"] = "MyShifts";
+    var tz = DateTimeZoneProviders.Tzdb[Model.EventSettings.TimeZoneId];
 }
 
-<div class="card">
-    <div class="card-body text-center py-5">
-        <i class="fa-solid fa-clipboard-list fa-2x text-muted mb-3"></i>
-        <p class="text-muted">My Shifts page — coming next.</p>
+<vc:temp-data-alerts />
+
+@if (Model.Shifts.Count > 0)
+{
+    <div class="card">
+        <div class="card-header">
+            <h5 class="mb-0">My Shifts</h5>
+        </div>
+        <div class="card-body">
+            <div class="table-responsive">
+                <table class="table table-sm">
+                    <thead>
+                        <tr>
+                            <th>Duty</th>
+                            <th>Team</th>
+                            <th>Date & Time</th>
+                            <th>Status</th>
+                            <th></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var item in Model.Shifts)
+                        {
+                            var badgeClass = item.Status switch
+                            {
+                                SignupStatus.Confirmed => "bg-success",
+                                SignupStatus.Pending => "bg-warning",
+                                SignupStatus.Bailed => "bg-danger",
+                                _ => "bg-secondary"
+                            };
+                            <tr>
+                                <td>@item.DutyTitle</td>
+                                <td>@item.TeamName</td>
+                                <td>
+                                    @item.AbsoluteStart.InZone(tz).Date.ToDisplayShiftDate()
+                                    @item.AbsoluteStart.ToDisplayTime(tz)–@item.AbsoluteEnd.ToDisplayTime(tz)
+                                </td>
+                                <td><span class="badge @badgeClass">@item.Status</span></td>
+                                <td>
+                                    @if (item.CanBail)
+                                    {
+                                        <form asp-action="Bail" method="post" class="d-inline">
+                                            @Html.AntiForgeryToken()
+                                            <input type="hidden" name="signupId" value="@item.SignupId" />
+                                            <button type="submit" class="btn btn-sm btn-outline-danger"
+                                                    data-confirm="Bail from this shift?">Bail</button>
+                                        </form>
+                                    }
+                                </td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
+        </div>
     </div>
-</div>
+}
+else
+{
+    <div class="card">
+        <div class="card-body text-center py-5">
+            <i class="fa-solid fa-clipboard-list fa-2x text-muted mb-3"></i>
+            <p class="text-muted">No shifts booked yet.</p>
+            <a asp-action="Shifts" class="btn btn-outline-primary">Browse All Shifts</a>
+        </div>
+    </div>
+}

--- a/src/Humans.Web/Views/Vol/MyShifts.cshtml
+++ b/src/Humans.Web/Views/Vol/MyShifts.cshtml
@@ -1,0 +1,11 @@
+@{
+    ViewData["Title"] = "My Shifts";
+    ViewData["VolActiveTab"] = "MyShifts";
+}
+
+<div class="card">
+    <div class="card-body text-center py-5">
+        <i class="fa-solid fa-clipboard-list fa-2x text-muted mb-3"></i>
+        <p class="text-muted">My Shifts page — coming next.</p>
+    </div>
+</div>

--- a/src/Humans.Web/Views/Vol/NoActiveEvent.cshtml
+++ b/src/Humans.Web/Views/Vol/NoActiveEvent.cshtml
@@ -1,0 +1,13 @@
+@{
+    ViewData["Title"] = "Volunteering";
+    ViewData["VolActiveTab"] = "";
+}
+
+<div class="text-center py-4">
+    <h4>No Active Event</h4>
+    <p class="text-muted mt-3">No active event is configured. An admin needs to set up event settings first.</p>
+    @if (Humans.Web.Authorization.RoleChecks.IsAdmin(User))
+    {
+        <a asp-action="Settings" class="btn btn-primary mt-2">Configure Event Settings</a>
+    }
+</div>

--- a/src/Humans.Web/Views/Vol/Register.cshtml
+++ b/src/Humans.Web/Views/Vol/Register.cshtml
@@ -1,0 +1,61 @@
+@{
+    Layout = "~/Views/Shared/_Layout.cshtml";
+    ViewData["Title"] = "Volunteer with Elsewhere";
+}
+
+<div class="container py-5">
+    <div class="row justify-content-center">
+        <div class="col-lg-8">
+            <div class="card">
+                <div class="card-body text-center py-5">
+                    <i class="fa-solid fa-heart fa-3x text-danger mb-3"></i>
+                    <h2 class="mb-4">Volunteer with Elsewhere</h2>
+
+                    <div class="row g-3 mb-4 text-start">
+                        <div class="col-md-4">
+                            <div class="card border-warning h-100">
+                                <div class="card-body text-center">
+                                    <i class="fa-solid fa-hammer fa-lg text-warning mb-2"></i>
+                                    <h6>Build</h6>
+                                    <p class="text-muted small mb-0">Help create the city from scratch before gates open.</p>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-md-4">
+                            <div class="card border-success h-100">
+                                <div class="card-body text-center">
+                                    <i class="fa-solid fa-campground fa-lg text-success mb-2"></i>
+                                    <h6>Event</h6>
+                                    <p class="text-muted small mb-0">Keep the city running during the event itself.</p>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-md-4">
+                            <div class="card border-danger h-100">
+                                <div class="card-body text-center">
+                                    <i class="fa-solid fa-broom fa-lg text-danger mb-2"></i>
+                                    <h6>Strike</h6>
+                                    <p class="text-muted small mb-0">Leave no trace — help dismantle and restore the site.</p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="alert alert-info mb-4">
+                        <i class="fa-solid fa-circle-info me-1"></i>
+                        Volunteer registration is being redesigned — use the existing signup flow for now.
+                    </div>
+
+                    <div class="d-flex justify-content-center gap-3">
+                        <a asp-controller="Shifts" asp-action="Index" class="btn btn-primary">
+                            <i class="fa-solid fa-calendar-days me-1"></i>Browse Shifts
+                        </a>
+                        <a asp-controller="Profile" asp-action="Index" class="btn btn-outline-secondary">
+                            <i class="fa-solid fa-user me-1"></i>My Profile
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/Humans.Web/Views/Vol/Settings.cshtml
+++ b/src/Humans.Web/Views/Vol/Settings.cshtml
@@ -1,0 +1,204 @@
+@model Humans.Web.Models.Vol.SettingsViewModel
+
+@{
+    ViewData["Title"] = "Settings";
+    ViewData["VolActiveTab"] = "Settings";
+
+    var fillPercent = Model.GlobalVolunteerCap.HasValue && Model.GlobalVolunteerCap.Value > 0
+        ? (int)(100.0 * Model.ConfirmedVolunteerCount / Model.GlobalVolunteerCap.Value)
+        : 0;
+    var progressColor = fillPercent > 90 ? "bg-danger"
+        : fillPercent >= 75 ? "bg-warning"
+        : "bg-success";
+}
+
+<vc:temp-data-alerts />
+
+<form asp-action="Settings" method="post">
+    @Html.AntiForgeryToken()
+
+    @* Event Periods Timeline *@
+    <div class="card mb-4">
+        <div class="card-header">
+            <h5 class="mb-0"><i class="fa-solid fa-calendar-days me-2"></i>Event Periods — @Model.EventName</h5>
+        </div>
+        <div class="card-body">
+            <div class="row g-3">
+                <div class="col-md-4">
+                    <div class="card border-warning h-100">
+                        <div class="card-body text-center">
+                            <i class="fa-solid fa-hammer fa-lg text-warning mb-2"></i>
+                            <h6 class="card-title">Build</h6>
+                            <p class="fs-4 fw-bold mb-1">@Model.BuildDays days</p>
+                            <small class="text-muted">
+                                Day @Model.BuildStartOffset to Day 0
+                            </small>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-md-4">
+                    <div class="card border-success h-100">
+                        <div class="card-body text-center">
+                            <i class="fa-solid fa-campground fa-lg text-success mb-2"></i>
+                            <h6 class="card-title">Event</h6>
+                            <p class="fs-4 fw-bold mb-1">@Model.EventDays days</p>
+                            <small class="text-muted">
+                                Day 0 to Day @Model.EventEndOffset
+                            </small>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-md-4">
+                    <div class="card border-danger h-100">
+                        <div class="card-body text-center">
+                            <i class="fa-solid fa-broom fa-lg text-danger mb-2"></i>
+                            <h6 class="card-title">Strike</h6>
+                            <p class="fs-4 fw-bold mb-1">@Model.StrikeDays days</p>
+                            <small class="text-muted">
+                                Day @Model.EventEndOffset to Day @Model.StrikeEndOffset
+                            </small>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="text-muted mt-2">
+                <small><i class="fa-solid fa-info-circle me-1"></i>Gate opening: @Model.GateOpeningDate &middot; Timezone: @Model.TimeZoneId</small>
+            </div>
+        </div>
+    </div>
+
+    @* System Toggle *@
+    <div class="card mb-4">
+        <div class="card-header">
+            <h5 class="mb-0"><i class="fa-solid fa-toggle-on me-2"></i>System Toggle</h5>
+        </div>
+        <div class="card-body">
+            <div class="form-check form-switch">
+                <input class="form-check-input" type="checkbox" role="switch"
+                       id="isShiftBrowsingOpen" name="isShiftBrowsingOpen"
+                       value="true" @(Model.IsShiftBrowsingOpen ? "checked" : "")>
+                <label class="form-check-label" for="isShiftBrowsingOpen">
+                    Shift browsing open
+                </label>
+            </div>
+            <small class="text-muted">When off, only coordinators and admins can browse shifts.</small>
+        </div>
+    </div>
+
+    @* Volunteer Cap *@
+    <div class="card mb-4">
+        <div class="card-header">
+            <h5 class="mb-0"><i class="fa-solid fa-users me-2"></i>Volunteer Cap</h5>
+        </div>
+        <div class="card-body">
+            <div class="row align-items-end">
+                <div class="col-md-4">
+                    <label for="globalVolunteerCap" class="form-label">Global cap (leave empty for no limit)</label>
+                    <input type="number" class="form-control" id="globalVolunteerCap" name="globalVolunteerCap"
+                           value="@Model.GlobalVolunteerCap" min="0" />
+                </div>
+                <div class="col-md-8">
+                    @if (Model.GlobalVolunteerCap.HasValue && Model.GlobalVolunteerCap.Value > 0)
+                    {
+                        <div class="mb-2">
+                            <span class="fw-bold">@Model.ConfirmedVolunteerCount</span>
+                            <span class="text-muted">/ @Model.GlobalVolunteerCap.Value confirmed</span>
+                        </div>
+                        <div class="progress" style="height: 12px;">
+                            <div class="progress-bar @progressColor" style="width: @(Math.Min(fillPercent, 100))%"
+                                 role="progressbar">
+                                @(fillPercent)%
+                            </div>
+                        </div>
+                    }
+                    else
+                    {
+                        <p class="text-muted mb-0">
+                            <span class="fw-bold">@Model.ConfirmedVolunteerCount</span> confirmed &middot; No cap set
+                        </p>
+                    }
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="d-flex gap-2 mb-4">
+        <button type="submit" class="btn btn-primary">
+            <i class="fa-solid fa-floppy-disk me-1"></i>Save Settings
+        </button>
+        <a asp-action="Management" class="btn btn-outline-secondary">Cancel</a>
+    </div>
+</form>
+
+@* Access Matrix *@
+<div class="card mb-4">
+    <div class="card-header">
+        <h5 class="mb-0"><i class="fa-solid fa-shield-halved me-2"></i>Access Matrix</h5>
+    </div>
+    <div class="card-body">
+        <div class="table-responsive">
+            <table class="table table-bordered table-sm align-middle mb-0">
+                <thead class="table-light">
+                    <tr>
+                        <th>Feature</th>
+                        <th class="text-center">Volunteer</th>
+                        <th class="text-center">Coordinator</th>
+                        <th class="text-center">Vol. Coordinator</th>
+                        <th class="text-center">NoInfo Admin</th>
+                        <th class="text-center">Admin</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>My Shifts</td>
+                        <td class="text-center text-success">&check;</td>
+                        <td class="text-center text-success">&check;</td>
+                        <td class="text-center text-success">&check;</td>
+                        <td class="text-center text-success">&check;</td>
+                        <td class="text-center text-success">&check;</td>
+                    </tr>
+                    <tr>
+                        <td>All Shifts</td>
+                        <td class="text-center text-success">&check;</td>
+                        <td class="text-center text-success">&check;</td>
+                        <td class="text-center text-success">&check;</td>
+                        <td class="text-center text-success">&check;</td>
+                        <td class="text-center text-success">&check;</td>
+                    </tr>
+                    <tr>
+                        <td>Teams</td>
+                        <td class="text-center text-success">&check;</td>
+                        <td class="text-center text-success">&check;</td>
+                        <td class="text-center text-success">&check;</td>
+                        <td class="text-center text-success">&check;</td>
+                        <td class="text-center text-success">&check;</td>
+                    </tr>
+                    <tr>
+                        <td>Urgent</td>
+                        <td class="text-center text-muted">&mdash;</td>
+                        <td class="text-center text-muted">&mdash;</td>
+                        <td class="text-center text-success">&check;</td>
+                        <td class="text-center text-success">&check;</td>
+                        <td class="text-center text-success">&check;</td>
+                    </tr>
+                    <tr>
+                        <td>Management</td>
+                        <td class="text-center text-muted">&mdash;</td>
+                        <td class="text-center text-muted">&mdash;</td>
+                        <td class="text-center text-success">&check;</td>
+                        <td class="text-center text-success">&check;</td>
+                        <td class="text-center text-success">&check;</td>
+                    </tr>
+                    <tr>
+                        <td>Settings</td>
+                        <td class="text-center text-muted">&mdash;</td>
+                        <td class="text-center text-muted">&mdash;</td>
+                        <td class="text-center text-muted">&mdash;</td>
+                        <td class="text-center text-muted">&mdash;</td>
+                        <td class="text-center text-success">&check;</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>

--- a/src/Humans.Web/Views/Vol/Shifts.cshtml
+++ b/src/Humans.Web/Views/Vol/Shifts.cshtml
@@ -1,0 +1,71 @@
+@model Humans.Web.Models.Vol.ShiftBrowserViewModel
+@using Humans.Domain.Enums
+@using NodaTime
+
+@{
+    ViewData["Title"] = "All Shifts";
+    ViewData["VolActiveTab"] = "Shifts";
+    var es = Model.EventSettings;
+
+    var totalRotas = Model.Departments.Sum(d => d.Rotas.Count);
+    var totalShifts = Model.Departments.Sum(d => d.Rotas.Sum(r => r.Shifts.Count));
+    var totalOpenSlots = Model.Departments.Sum(d => d.Rotas.Sum(r => r.Shifts.Sum(s => Math.Max(0, s.RemainingSlots))));
+}
+
+<vc:temp-data-alerts />
+
+<form method="get" class="row g-2 mb-4 align-items-end">
+    <div class="col-auto">
+        <label class="form-label mb-1">Department</label>
+        <select name="departmentId" class="form-select form-select-sm" onchange="this.form.submit()">
+            <option value="">All Departments</option>
+            @foreach (var dept in Model.AllDepartments)
+            {
+                <option value="@dept.TeamId" selected="@(Model.FilterDepartmentId == dept.TeamId)">@dept.Name</option>
+            }
+        </select>
+    </div>
+    <div class="col-auto">
+        <label class="form-label mb-1">Date</label>
+        <input type="date" name="date" class="form-control form-control-sm" value="@Model.FilterDate" onchange="this.form.submit()" />
+    </div>
+    @if (Model.FilterDepartmentId.HasValue || !string.IsNullOrEmpty(Model.FilterDate))
+    {
+        <div class="col-auto">
+            <a asp-action="Shifts" class="btn btn-sm btn-outline-secondary">Clear Filters</a>
+        </div>
+    }
+</form>
+
+@if (!es.IsShiftBrowsingOpen)
+{
+    <div class="alert alert-danger">Shifts aren't open yet. Only coordinators and admins can see this page.</div>
+}
+
+@if (Model.Departments.Count == 0)
+{
+    <div class="alert alert-info">No shifts match the current filters.</div>
+}
+else
+{
+    <div class="d-flex gap-3 text-muted small mb-3">
+        <span><i class="fa-solid fa-layer-group me-1"></i>@totalRotas rota@(totalRotas != 1 ? "s" : "")</span>
+        <span><i class="fa-solid fa-clock me-1"></i>@totalShifts shift@(totalShifts != 1 ? "s" : "")</span>
+        <span><i class="fa-solid fa-user-plus me-1"></i>@totalOpenSlots open slot@(totalOpenSlots != 1 ? "s" : "")</span>
+    </div>
+
+    @foreach (var dept in Model.Departments)
+    {
+        <div class="card mb-4">
+            <div class="card-header">
+                <h5 class="mb-0">@dept.TeamName</h5>
+            </div>
+            <div class="card-body">
+                @foreach (var rotaGroup in dept.Rotas)
+                {
+                    @await Html.PartialAsync("_RotaCard", (rotaGroup, es, Model.UserSignupShiftIds, Model.UserSignupStatuses, Model.ShowSignups))
+                }
+            </div>
+        </div>
+    }
+}

--- a/src/Humans.Web/Views/Vol/Teams.cshtml
+++ b/src/Humans.Web/Views/Vol/Teams.cshtml
@@ -1,0 +1,62 @@
+@model Humans.Web.Models.Vol.TeamsOverviewViewModel
+
+@{
+    ViewData["Title"] = "Teams";
+    ViewData["VolActiveTab"] = "Teams";
+}
+
+<vc:temp-data-alerts />
+
+@if (Model.Departments.Count == 0)
+{
+    <div class="card">
+        <div class="card-body text-center py-5">
+            <i class="fa-solid fa-users fa-2x text-muted mb-3"></i>
+            <p class="text-muted">No departments with shifts configured yet.</p>
+        </div>
+    </div>
+}
+else
+{
+    <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4">
+        @foreach (var dept in Model.Departments)
+        {
+            var fillPct = dept.TotalSlots > 0
+                ? (int)Math.Round(100.0 * dept.FilledSlots / dept.TotalSlots)
+                : 0;
+            var barClass = fillPct >= 80 ? "bg-success" : fillPct >= 50 ? "bg-warning" : "bg-danger";
+
+            <div class="col">
+                <div class="card h-100">
+                    <div class="card-header">
+                        <h5 class="mb-0">
+                            <a asp-action="DepartmentDetail" asp-route-slug="@dept.Slug" class="text-decoration-none">
+                                @dept.Name
+                            </a>
+                        </h5>
+                    </div>
+                    <div class="card-body">
+                        @if (!string.IsNullOrWhiteSpace(dept.Description))
+                        {
+                            <p class="card-text text-muted small">@dept.Description</p>
+                        }
+                        <div class="d-flex justify-content-between text-muted small mb-2">
+                            <span><i class="fa-solid fa-users me-1"></i>@dept.ChildTeamCount team@(dept.ChildTeamCount != 1 ? "s" : "")</span>
+                            <span>@dept.FilledSlots / @dept.TotalSlots slots filled</span>
+                        </div>
+                        <div class="progress" style="height: 8px;">
+                            <div class="progress-bar @barClass" role="progressbar"
+                                 style="width: @(fillPct)%"
+                                 aria-valuenow="@fillPct" aria-valuemin="0" aria-valuemax="100"></div>
+                        </div>
+                    </div>
+                    <div class="card-footer text-end">
+                        <a asp-action="DepartmentDetail" asp-route-slug="@dept.Slug" class="btn btn-sm btn-outline-primary">
+                            View Teams <i class="fa-solid fa-arrow-right ms-1"></i>
+                        </a>
+                    </div>
+                </div>
+            </div>
+        }
+    </div>
+}

--- a/src/Humans.Web/Views/Vol/Urgent.cshtml
+++ b/src/Humans.Web/Views/Vol/Urgent.cshtml
@@ -1,0 +1,125 @@
+@model Humans.Web.Models.Vol.UrgentShiftsViewModel
+@using Humans.Domain.Enums
+@using NodaTime
+
+@{
+    ViewData["Title"] = "Urgent Shifts";
+    ViewData["VolActiveTab"] = "Urgent";
+    var searchUrl = Url.Action(nameof(Humans.Web.Controllers.VolController.SearchVolunteers), "Vol");
+    var voluntellUrl = Url.Action(nameof(Humans.Web.Controllers.VolController.Voluntell), "Vol");
+}
+
+<vc:temp-data-alerts />
+
+<div class="card">
+    <div class="card-header">
+        <h5 class="mb-0"><i class="fa-solid fa-bolt me-2"></i>Urgent Shifts</h5>
+    </div>
+    <div class="card-body">
+        @if (Model.Shifts.Count == 0)
+        {
+            <div class="text-center py-5">
+                <i class="fa-solid fa-circle-check fa-2x text-success mb-3"></i>
+                <p class="text-muted mb-0">All duties are fully staffed!</p>
+            </div>
+        }
+        else
+        {
+            <div class="table-responsive">
+                <table class="table table-hover align-middle mb-0">
+                    <thead class="table-light">
+                        <tr>
+                            <th style="width: 60px">Urgency</th>
+                            <th>Duty</th>
+                            <th>Team</th>
+                            <th>Date & Time</th>
+                            <th>Capacity</th>
+                            <th>Priority</th>
+                            <th></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var shift in Model.Shifts)
+                        {
+                            var shiftDate = Model.EventSettings.GateOpeningDate.PlusDays(shift.DayOffset);
+                            var fillPercent = shift.MaxVolunteers > 0
+                                ? (int)(100.0 * shift.Confirmed / shift.MaxVolunteers)
+                                : 0;
+                            var urgencyPercent = Math.Min(100, (int)(shift.UrgencyScore * 10));
+                            var urgencyColor = urgencyPercent >= 70 ? "bg-danger"
+                                : urgencyPercent >= 40 ? "bg-warning"
+                                : "bg-info";
+                            var priorityBadge = shift.Priority switch
+                            {
+                                ShiftPriority.Essential => "bg-danger",
+                                ShiftPriority.Important => "bg-warning text-dark",
+                                _ => "bg-secondary"
+                            };
+                            var collapseId = "voluntell-" + shift.ShiftId.ToString("N");
+
+                            <tr>
+                                <td>
+                                    <div class="progress" style="height: 8px;" title="Urgency: @shift.UrgencyScore.ToString("F1")">
+                                        <div class="progress-bar @urgencyColor" style="width: @(urgencyPercent)%"></div>
+                                    </div>
+                                </td>
+                                <td>@shift.DutyTitle</td>
+                                <td>@shift.TeamName</td>
+                                <td>
+                                    @shiftDate.ToDisplayShiftDate()
+                                    <small class="text-muted ms-1">@shift.StartTime.ToString("HH:mm", null)</small>
+                                </td>
+                                <td>
+                                    <span class="@(fillPercent < 50 ? "text-danger fw-bold" : "")">@shift.Confirmed</span><small class="text-muted"> / @shift.MaxVolunteers</small>
+                                    <div class="progress mt-1" style="height: 4px;">
+                                        <div class="progress-bar @(fillPercent < 50 ? "bg-danger" : "bg-success")" style="width: @(fillPercent)%"></div>
+                                    </div>
+                                </td>
+                                <td><span class="badge @priorityBadge">@shift.Priority</span></td>
+                                <td>
+                                    <button class="btn btn-sm btn-outline-primary"
+                                            type="button"
+                                            data-bs-toggle="collapse"
+                                            data-bs-target="#@collapseId"
+                                            data-shift-id="@shift.ShiftId">
+                                        <i class="fa-solid fa-magnifying-glass me-1"></i>Find
+                                    </button>
+                                </td>
+                            </tr>
+                            <tr class="collapse" id="@collapseId">
+                                <td colspan="7">
+                                    <div class="p-3 bg-light rounded border">
+                                        <label class="form-label fw-semibold">Search humans for: @shift.DutyTitle</label>
+                                        <input type="text"
+                                               class="form-control mb-2 volunteer-search-input"
+                                               placeholder="Type a name (min 2 chars)..."
+                                               data-shift-id="@shift.ShiftId"
+                                               autocomplete="off" />
+                                        <div class="volunteer-results" data-shift-id="@shift.ShiftId"></div>
+                                    </div>
+                                </td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
+        }
+    </div>
+</div>
+
+@section Scripts {
+<script>
+@await Html.PartialAsync("~/Views/Shared/_EscapeHtmlScript.cshtml")
+@await Html.PartialAsync("~/Views/Shared/_VolunteerSearchScript.cshtml", new ViewDataDictionary(ViewData)
+{
+    ["SearchUrl"] = searchUrl,
+    ["VoluntellUrl"] = voluntellUrl,
+    ["AssignButtonClass"] = "btn-success",
+    ["NoResultsText"] = "No humans found.",
+    ["ErrorText"] = "Search failed.",
+    ["OverlapLabel"] = "Schedule conflict",
+    ["DietaryPreferenceStyle"] = "muted",
+    ["ShowPoolBadge"] = false
+})
+</script>
+}

--- a/src/Humans.Web/Views/Vol/_RotaCard.cshtml
+++ b/src/Humans.Web/Views/Vol/_RotaCard.cshtml
@@ -1,0 +1,88 @@
+@model (Humans.Web.Models.RotaShiftGroup RotaGroup, Humans.Domain.Entities.EventSettings Es, HashSet<Guid> UserSignupShiftIds, Dictionary<Guid, Humans.Domain.Enums.SignupStatus> UserSignupStatuses, bool ShowSignups)
+@using Humans.Domain.Enums
+@using NodaTime
+
+@{
+    var rotaGroup = Model.RotaGroup;
+    var es = Model.Es;
+    var rota = rotaGroup.Rota;
+    var collapseId = $"rota-{rota.Id:N}";
+
+    var totalConfirmed = rotaGroup.Shifts.Sum(s => s.ConfirmedCount);
+    var totalMax = rotaGroup.Shifts.Sum(s => s.Shift.MaxVolunteers);
+    var fillPercent = totalMax > 0 ? (int)Math.Round(100.0 * totalConfirmed / totalMax) : 0;
+
+    var progressClass = fillPercent switch
+    {
+        >= 80 => "bg-success",
+        >= 50 => "bg-info",
+        >= 25 => "bg-warning",
+        _ => "bg-danger"
+    };
+
+    var periodBadge = rota.Period switch
+    {
+        RotaPeriod.Build => ("bg-info", "Set-up"),
+        RotaPeriod.Strike => ("bg-secondary", "Strike"),
+        _ => ("bg-success", "Event")
+    };
+}
+
+<div class="mb-3">
+    <div class="d-flex align-items-center justify-content-between cursor-pointer"
+         data-bs-toggle="collapse" data-bs-target="#@collapseId" role="button" aria-expanded="false" aria-controls="@collapseId">
+        <div>
+            <h6 class="mb-0 d-inline">@rota.Name</h6>
+            @if (rota.Priority == ShiftPriority.Essential)
+            {
+                <span class="badge bg-danger ms-1">Essential</span>
+            }
+            else if (rota.Priority == ShiftPriority.Important)
+            {
+                <span class="badge bg-warning text-dark ms-1">Important</span>
+            }
+            <span class="badge @periodBadge.Item1 ms-1">@periodBadge.Item2</span>
+            <small class="text-muted ms-2">@rotaGroup.Shifts.Count shift@(rotaGroup.Shifts.Count != 1 ? "s" : "")</small>
+        </div>
+        <i class="fa-solid fa-chevron-down text-muted"></i>
+    </div>
+
+    @if (!string.IsNullOrEmpty(rota.PracticalInfo))
+    {
+        <p class="text-muted small mb-1 mt-1">@rota.PracticalInfo</p>
+    }
+
+    <div class="progress mt-2" style="height: 6px;">
+        <div class="progress-bar @progressClass" role="progressbar"
+             style="width: @fillPercent%;" aria-valuenow="@totalConfirmed" aria-valuemin="0" aria-valuemax="@totalMax">
+        </div>
+    </div>
+    <small class="text-muted">@totalConfirmed / @totalMax filled</small>
+
+    <div class="collapse mt-2" id="@collapseId">
+        <div class="table-responsive">
+            <table class="table table-sm mb-0">
+                <thead>
+                    <tr>
+                        <th>Date</th>
+                        <th>Time</th>
+                        <th>Filled</th>
+                        <th>Priority</th>
+                        <th>Policy</th>
+                        @if (Model.ShowSignups)
+                        {
+                            <th>Signed Up</th>
+                        }
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var item in rotaGroup.Shifts)
+                    {
+                        @await Html.PartialAsync("_ShiftRow", (item, es, Model.UserSignupShiftIds, Model.UserSignupStatuses, Model.ShowSignups))
+                    }
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>

--- a/src/Humans.Web/Views/Vol/_ShiftRow.cshtml
+++ b/src/Humans.Web/Views/Vol/_ShiftRow.cshtml
@@ -1,0 +1,91 @@
+@model (Humans.Web.Models.ShiftDisplayItem Item, Humans.Domain.Entities.EventSettings Es, HashSet<Guid> UserSignupShiftIds, Dictionary<Guid, Humans.Domain.Enums.SignupStatus> UserSignupStatuses, bool ShowSignups)
+@using Humans.Domain.Enums
+@using NodaTime
+
+@{
+    var item = Model.Item;
+    var es = Model.Es;
+    var shift = item.Shift;
+    var tz = DateTimeZoneProviders.Tzdb[es.TimeZoneId];
+    var isFull = item.RemainingSlots <= 0;
+    var understaffed = item.ConfirmedCount < shift.MinVolunteers;
+    var isSignedUp = Model.UserSignupShiftIds.Contains(shift.Id);
+}
+
+<tr class="@(isFull && !isSignedUp ? "table-secondary" : "")">
+    <td>@es.GateOpeningDate.PlusDays(shift.DayOffset).ToDisplayShiftDate()</td>
+    <td>
+        @if (shift.IsAllDay)
+        {
+            <text>All day</text>
+        }
+        else
+        {
+            @item.AbsoluteStart.ToDisplayTime(tz)<text>&ndash;</text>@item.AbsoluteEnd.ToDisplayTime(tz)
+        }
+    </td>
+    <td>
+        <span class="@(understaffed ? "text-danger fw-bold" : "")">@item.ConfirmedCount</span>
+        <small class="text-muted">/ @shift.MaxVolunteers</small>
+        @if (understaffed)
+        {
+            <span class="badge bg-warning text-dark ms-1">Needs help</span>
+        }
+    </td>
+    <td>
+        @if (shift.Rota.Priority == ShiftPriority.Essential)
+        {
+            <span class="badge bg-danger">Essential</span>
+        }
+        else if (shift.Rota.Priority == ShiftPriority.Important)
+        {
+            <span class="badge bg-warning text-dark">Important</span>
+        }
+        else
+        {
+            <span class="text-muted">Normal</span>
+        }
+    </td>
+    <td>
+        @if (shift.Rota.Policy == SignupPolicy.Public)
+        {
+            <span class="badge bg-success">Instant</span>
+        }
+        else
+        {
+            <span class="badge bg-warning text-dark">Approval</span>
+        }
+    </td>
+    @if (Model.ShowSignups)
+    {
+        <td class="small">
+            @for (var i = 0; i < item.Signups.Count; i++)
+            {
+                var signup = item.Signups[i];
+                if (i > 0) { <text>, </text> }
+                <a asp-controller="Human" asp-action="View" asp-route-id="@signup.UserId"
+                   class="text-decoration-none @(signup.Status == SignupStatus.Pending ? "text-muted fst-italic" : "")">@signup.DisplayName</a>@if (signup.Status == SignupStatus.Pending)
+                {<small class="text-muted"> (pending)</small>}
+            }
+        </td>
+    }
+    <td>
+        @if (isSignedUp)
+        {
+            var status = Model.UserSignupStatuses.GetValueOrDefault(shift.Id);
+            <span class="badge bg-info">@status</span>
+        }
+        else if (isFull)
+        {
+            <span class="badge bg-secondary">Full</span>
+        }
+        else
+        {
+            <form asp-controller="Vol" asp-action="SignUp" method="post" class="d-inline">
+                @Html.AntiForgeryToken()
+                <input type="hidden" name="shiftId" value="@shift.Id" />
+                <button type="submit" class="btn btn-sm btn-success">Sign Up</button>
+            </form>
+        }
+    </td>
+</tr>

--- a/src/Humans.Web/Views/Vol/_ViewStart.cshtml
+++ b/src/Humans.Web/Views/Vol/_ViewStart.cshtml
@@ -1,0 +1,3 @@
+@{
+    Layout = "~/Views/Vol/_VolLayout.cshtml";
+}

--- a/src/Humans.Web/Views/Vol/_VolLayout.cshtml
+++ b/src/Humans.Web/Views/Vol/_VolLayout.cshtml
@@ -1,0 +1,51 @@
+@{
+    Layout = "~/Views/Shared/_Layout.cshtml";
+    var activeTab = ViewData["VolActiveTab"]?.ToString();
+}
+
+<div class="container py-4">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <h2>Volunteering</h2>
+    </div>
+    <ul class="nav nav-pills mb-4">
+        <li class="nav-item">
+            <a class="nav-link @(activeTab == "MyShifts" ? "active" : "")" asp-controller="Vol" asp-action="MyShifts">
+                <i class="fa-solid fa-clipboard-list me-1"></i>My Shifts
+            </a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link @(activeTab == "Shifts" ? "active" : "")" asp-controller="Vol" asp-action="Shifts">
+                <i class="fa-solid fa-calendar-days me-1"></i>All Shifts
+            </a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link @(activeTab == "Teams" ? "active" : "")" asp-controller="Vol" asp-action="Teams">
+                <i class="fa-solid fa-users me-1"></i>Teams
+            </a>
+        </li>
+        @if (Humans.Web.Authorization.ShiftRoleChecks.CanAccessDashboard(User))
+        {
+            <li class="nav-item">
+                <a class="nav-link @(activeTab == "Urgent" ? "active" : "")" asp-controller="Vol" asp-action="Urgent">
+                    <i class="fa-solid fa-bolt me-1"></i>Urgent
+                </a>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link @(activeTab == "Management" ? "active" : "")" asp-controller="Vol" asp-action="Management">
+                    <i class="fa-solid fa-chart-bar me-1"></i>Management
+                </a>
+            </li>
+        }
+        @if (Humans.Web.Authorization.RoleChecks.IsAdmin(User))
+        {
+            <li class="nav-item">
+                <a class="nav-link @(activeTab == "Settings" ? "active" : "")" asp-controller="Vol" asp-action="Settings">
+                    <i class="fa-solid fa-gear me-1"></i>Settings
+                </a>
+            </li>
+        }
+    </ul>
+    @RenderBody()
+</div>
+
+@await RenderSectionAsync("Scripts", required: false)


### PR DESCRIPTION
## Summary

- New `/Vol` route with sub-navigation, 10 pages: My Shifts, All Shifts, Teams Overview, Department Detail, Child Team Detail, Urgent Shifts, Management Dashboard, Settings, and Registration placeholder
- Single `VolController` with 20 actions, reusing existing shift/team/signup services — no domain or infrastructure changes
- Role-based access: volunteers see My Shifts/All Shifts/Teams, coordinators see Urgent/Management, admins see Settings
- "V" nav link added to main layout for privileged roles

## Test plan
- [ ] Build passes (`dotnet build Humans.slnx`)
- [ ] Format clean (`dotnet format --verify-no-changes`)
- [ ] Unit tests pass (463/463)
- [ ] Manual: visit /Vol as admin — all tabs load
- [ ] Manual: visit /Vol as regular volunteer — only My Shifts, All Shifts, Teams visible
- [ ] Manual: sign up for shift via /Vol/Shifts, verify appears in /Vol/MyShifts
- [ ] Manual: bail from shift via /Vol/MyShifts
- [ ] Manual: /Vol/Register renders standalone (no sub-nav)

🤖 Generated with [Claude Code](https://claude.com/claude-code)