### PR TITLE
Fix shift edit clobbering DayOffset, AdminOnly, Description (#168)

### DIFF
--- a/src/Humans.Web/Controllers/HumansControllerBase.cs
+++ b/src/Humans.Web/Controllers/HumansControllerBase.cs
@@ -59,6 +59,9 @@ public abstract class HumansControllerBase : Controller
 
     protected void SetError(string message)
     {
+        var logger = HttpContext.RequestServices.GetRequiredService<ILoggerFactory>()
+            .CreateLogger(GetType());
+        logger.LogWarning("Error toast: {Message} (Action: {Action})", message, ControllerContext.ActionDescriptor.ActionName);
         TempData["ErrorMessage"] = message;
     }
 

--- a/src/Humans.Web/Controllers/ShiftAdminController.cs
+++ b/src/Humans.Web/Controllers/ShiftAdminController.cs
@@ -264,7 +264,7 @@ public class ShiftAdminController : HumansControllerBase
 
         if (!model.StartTime.TryParseInvariantLocalTime(out var parsedTime))
         {
-            TempData["ErrorMessage"] = "Invalid start time format.";
+            SetError("Invalid start time format.");
             return RedirectToAction(nameof(Index), new { slug });
         }
 
@@ -309,7 +309,7 @@ public class ShiftAdminController : HumansControllerBase
 
         if (!model.StartTime.TryParseInvariantLocalTime(out var parsedTime))
         {
-            TempData["ErrorMessage"] = "Invalid start time format.";
+            SetError("Invalid start time format.");
             return RedirectToAction(nameof(Index), new { slug });
         }
 

--- a/src/Humans.Web/Extensions/DateTimeDisplayExtensions.cs
+++ b/src/Humans.Web/Extensions/DateTimeDisplayExtensions.cs
@@ -99,13 +99,16 @@ public static class DateTimeDisplayExtensions
         value?.ToDisplayDayMonth();
 
     public static string ToDisplayTime(this DateTime value) =>
-        value.ToString("HH:mm", CultureInfo.InvariantCulture);
+        value.ToString("H:mm", CultureInfo.InvariantCulture);
 
     public static string? ToDisplayTime(this DateTime? value) =>
         value?.ToDisplayTime();
 
     public static string ToDisplayTime(this Instant value, DateTimeZone timeZone) =>
-        value.InZone(timeZone).ToString("HH:mm", null);
+        value.InZone(timeZone).ToString("H:mm", null);
+
+    public static string ToDisplayTime(this LocalTime value) =>
+        value.ToString("H:mm", null);
 
     public static string ToDisplayShortDateTime(this ZonedDateTime value) =>
         value.ToString("ddd MMM d HH:mm", null);

--- a/src/Humans.Web/Views/ShiftAdmin/Index.cshtml
+++ b/src/Humans.Web/Views/ShiftAdmin/Index.cshtml
@@ -123,16 +123,16 @@
                                 <div class="col-md-2">
                                     <label class="form-label">Priority</label>
                                     <select name="Priority" class="form-select">
-                                        <option value="Normal" selected="@(rota.Priority == ShiftPriority.Normal)">Normal</option>
-                                        <option value="Important" selected="@(rota.Priority == ShiftPriority.Important)">Important</option>
-                                        <option value="Essential" selected="@(rota.Priority == ShiftPriority.Essential)">Essential</option>
+                                        <option value="Normal" selected="@(rota.Priority == ShiftPriority.Normal ? "selected" : null)">Normal</option>
+                                        <option value="Important" selected="@(rota.Priority == ShiftPriority.Important ? "selected" : null)">Important</option>
+                                        <option value="Essential" selected="@(rota.Priority == ShiftPriority.Essential ? "selected" : null)">Essential</option>
                                     </select>
                                 </div>
                                 <div class="col-md-2">
                                     <label class="form-label">Policy</label>
                                     <select name="Policy" class="form-select">
-                                        <option value="Public" selected="@(rota.Policy == SignupPolicy.Public)">Public</option>
-                                        <option value="RequireApproval" selected="@(rota.Policy == SignupPolicy.RequireApproval)">Require Approval</option>
+                                        <option value="Public" selected="@(rota.Policy == SignupPolicy.Public ? "selected" : null)">Public</option>
+                                        <option value="RequireApproval" selected="@(rota.Policy == SignupPolicy.RequireApproval ? "selected" : null)">Require Approval</option>
                                     </select>
                                 </div>
                                 <div class="col-md-3">
@@ -144,9 +144,9 @@
                                 <div class="col-md-2">
                                     <label class="form-label">Period</label>
                                     <select name="Period" class="form-select">
-                                        <option value="Build" selected="@(rota.Period == RotaPeriod.Build)">Set-up</option>
-                                        <option value="Event" selected="@(rota.Period == RotaPeriod.Event)">Event</option>
-                                        <option value="Strike" selected="@(rota.Period == RotaPeriod.Strike)">Strike</option>
+                                        <option value="Build" selected="@(rota.Period == RotaPeriod.Build ? "selected" : null)">Set-up</option>
+                                        <option value="Event" selected="@(rota.Period == RotaPeriod.Event ? "selected" : null)">Event</option>
+                                        <option value="Strike" selected="@(rota.Period == RotaPeriod.Strike ? "selected" : null)">Strike</option>
                                     </select>
                                 </div>
                                 <div class="col-md-6">
@@ -295,6 +295,7 @@
                                             <td colspan="@(Model.CanApproveSignups ? 7 : 6)">
                                                 <form asp-action="EditShift" asp-route-slug="@Model.Department.Slug" asp-route-shiftId="@shift.Id" method="post">
                                                     @Html.AntiForgeryToken()
+                                                    <input type="hidden" name="Description" value="@shift.Description" />
                                                     <div class="row g-2 align-items-end">
                                                         <div class="col-md-2">
                                                             <label class="form-label form-label-sm">Date</label>
@@ -303,7 +304,7 @@
                                                                 {
                                                                     var editDate = Model.EventSettings.GateOpeningDate.PlusDays(d);
                                                                     var editLabel = editDate.ToDisplayShiftDate();
-                                                                    <option value="@d" selected="@(d == shift.DayOffset)">@editLabel</option>
+                                                                    <option value="@d" selected="@(d == shift.DayOffset ? "selected" : null)">@editLabel</option>
                                                                 }
                                                             </select>
                                                         </div>
@@ -325,7 +326,7 @@
                                                         </div>
                                                         <div class="col-md-1">
                                                             <div class="form-check">
-                                                                <input type="checkbox" name="AdminOnly" value="true" class="form-check-input" checked="@shift.AdminOnly" />
+                                                                <input type="checkbox" name="AdminOnly" value="true" class="form-check-input" checked="@(shift.AdminOnly ? "checked" : null)" />
                                                                 <label class="form-check-label form-label-sm">Admin</label>
                                                             </div>
                                                         </div>
@@ -452,7 +453,7 @@
                                     {
                                         var date = Model.EventSettings.GateOpeningDate.PlusDays(d);
                                         var dateLabel = date.ToDisplayShiftDate();
-                                        <option value="@d" selected="@(d == periodRange.End)">@dateLabel</option>
+                                        <option value="@d" selected="@(d == periodRange.End ? "selected" : null)">@dateLabel</option>
                                     }
                                 </select>
                             </div>
@@ -509,7 +510,7 @@
                                             {
                                                 var date = Model.EventSettings.GateOpeningDate.PlusDays(d);
                                                 var label = date.ToDisplayShiftDate();
-                                                <option value="@d" selected="@(d == 0)">@label</option>
+                                                <option value="@d" selected="@(d == 0 ? "selected" : null)">@label</option>
                                             }
                                         </select>
                                     </div>
@@ -520,7 +521,7 @@
                                             {
                                                 var date = Model.EventSettings.GateOpeningDate.PlusDays(d);
                                                 var label = date.ToDisplayShiftDate();
-                                                <option value="@d" selected="@(d == Model.EventSettings.EventEndOffset)">@label</option>
+                                                <option value="@d" selected="@(d == Model.EventSettings.EventEndOffset ? "selected" : null)">@label</option>
                                             }
                                         </select>
                                     </div>
@@ -568,7 +569,7 @@
                                         {
                                             var date = Model.EventSettings.GateOpeningDate.PlusDays(d);
                                             var label = date.ToDisplayShiftDate();
-                                            <option value="@d" selected="@(d == 0)">@label</option>
+                                            <option value="@d" selected="@(d == 0 ? "selected" : null)">@label</option>
                                         }
                                     </select>
                                 </div>

--- a/src/Humans.Web/Views/ShiftAdmin/Index.cshtml
+++ b/src/Humans.Web/Views/ShiftAdmin/Index.cshtml
@@ -196,7 +196,7 @@
                                             @{
                                                 var shiftLabel = shift.IsAllDay
                                                     ? "All day"
-                                                    : $"{shift.StartTime.ToString("HH:mm", null)}–{shift.StartTime.PlusMinutes((int)shift.Duration.TotalMinutes).ToString("HH:mm", null)}";
+                                                    : $"{shift.StartTime.ToDisplayTime()}–{shift.StartTime.PlusMinutes((int)shift.Duration.TotalMinutes).ToDisplayTime()}";
                                             }
                                             @shiftLabel
                                             @if (shift.AdminOnly) { <span class="badge bg-dark">Admin Only</span> }
@@ -221,7 +221,7 @@
                                             };
                                         }
                                         <td><span class="badge @phaseBadge me-1">@phaseLabel</span>@shiftDateLabel</td>
-                                        <td>@shift.StartTime.ToString("HH:mm", null)</td>
+                                        <td>@shift.StartTime.ToDisplayTime()</td>
                                         <td>@(shift.IsAllDay ? "Full day" : $"{shift.Duration.TotalHours}h")</td>
                                         @{
                                             var confirmed = shift.ShiftSignups.Count(d => d.Status == SignupStatus.Confirmed);
@@ -310,7 +310,7 @@
                                                         </div>
                                                         <div class="col-md-1">
                                                             <label class="form-label form-label-sm">Start</label>
-                                                            <input type="time" name="StartTime" value="@shift.StartTime" class="form-control form-control-sm" />
+                                                            <input type="time" name="StartTime" value="@shift.StartTime.ToString("HH:mm", null)" class="form-control form-control-sm" />
                                                         </div>
                                                         <div class="col-md-1">
                                                             <label class="form-label form-label-sm">Hours</label>


### PR DESCRIPTION
## Summary
- Fixed Razor boolean attribute rendering bug: `selected="@(condition)"` renders `selected="False"` which HTML interprets as selected (presence = true)
- DayOffset dropdown had every option selected, so browser used the last one — silently moving the shift to a different day on every save
- Also fixed `checked` attribute on AdminOnly checkbox (was always true) and added hidden Description field (was being cleared)
- Fixed same `selected` anti-pattern in rota edit forms on the same page

## Test plan
- [ ] Edit a shift on /Teams/barrios/Shifts, change MaxVolunteers, save — verify value persists and shift stays on correct day
- [ ] Edit a shift's AdminOnly checkbox — verify it toggles correctly
- [ ] Edit a shift with a description — verify description is preserved after save
- [ ] Edit a rota's Priority/Policy/Period — verify selections persist

Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)