### PR TITLE
Google Groups settings drift detection (#169)

### DIFF
--- a/docs/features/07-google-integration.md
+++ b/docs/features/07-google-integration.md
@@ -308,6 +308,21 @@ When `GoogleGroupPrefix` is cleared, the existing Group resource is deactivated 
 ### Group Settings
 Group creation now applies the configured `GoogleWorkspace:Groups` settings from appsettings. Previously, new groups received Google defaults. This ensures groups are configured consistently (e.g., `AllowExternalMembers = true` per R-04).
 
+### Group Settings Drift Detection
+Settings applied at group creation can drift if someone changes them manually in Google Admin. The system detects this drift without auto-fixing:
+
+**Checked settings** (from `GoogleWorkspace:Groups` config):
+- WhoCanJoin, WhoCanViewMembership, WhoCanContactOwner, WhoCanPostMessage, WhoCanViewGroup, WhoCanModerateMembers, AllowExternalMembers
+
+**Additional monitored settings** (sensible defaults):
+- IsArchived (expected: false), MembersCanPostAsTheGroup (expected: false), IncludeInGlobalAddressList (expected: true), AllowWebPosting (expected: true), MessageModerationLevel (expected: MODERATE_NONE), SpamModerationLevel (expected: MODERATE), EnableCollaborativeInbox (expected: false)
+
+**Nightly check:** Runs as part of `GoogleResourceReconciliationJob` (daily at 03:00). Drifts are logged as warnings.
+
+**Manual trigger:** Admin page at `/Admin` has a "Check Group Settings" button. Results show at `/Admin/GroupSettingsResults` with per-group cards listing each drifted setting (expected vs actual) and links to the group in Google.
+
+**SyncSettings respected:** If GoogleGroups sync mode is set to None, the check is skipped entirely.
+
 ## Resource Linking (Pre-Shared Access Model)
 
 Instead of creating resources with domain-wide delegation, admins can link existing Google resources that have been pre-shared with the service account.

--- a/docs/features/08-background-jobs.md
+++ b/docs/features/08-background-jobs.md
@@ -220,6 +220,8 @@ Both call `SyncVolunteersMembershipForUserAsync(userId)`, which evaluates a sing
 | `AddOnly` | Only adds missing members — never removes |
 | `AddAndRemove` | Full sync: adds missing + removes extra members |
 
+**Group settings drift check**: After membership reconciliation, the job also checks all active Google Groups for settings drift (e.g., someone changed WhoCanPost in Google Admin). This is detect-only — drifts are logged as warnings but not auto-fixed. Respects the GoogleGroups sync mode: skipped entirely if set to None.
+
 > **Currently disabled** in Program.cs. Use manual "Sync Now" at `/Teams/Sync` or configure sync modes at `/Admin/SyncSettings` instead.
 
 ## Hangfire Configuration

--- a/docs/features/09-administration.md
+++ b/docs/features/09-administration.md
@@ -157,6 +157,8 @@ Approval and consent completion both trigger `SyncVolunteersMembershipForUserAsy
 | `/Admin/GoogleSync` | GoogleSync | Legacy Google resource sync status |
 | `/Admin/GoogleSync/Apply` | ApplyGoogleSync | POST: Run legacy full sync |
 | `/Admin/SyncSettings` | SyncSettings | Per-service sync mode configuration |
+| `/Admin/CheckGroupSettings` | CheckGroupSettings | POST: Check Google Group settings for drift |
+| `/Admin/GroupSettingsResults` | GroupSettingsResults | Display group settings drift results |
 | `/Admin/DbVersion` | DbVersion | Database migration version |
 
 ### Sync Status (`/Teams/Sync`) — TeamsAdmin, Board, Admin

--- a/src/Humans.Application/DTOs/GroupSettingsDriftResult.cs
+++ b/src/Humans.Application/DTOs/GroupSettingsDriftResult.cs
@@ -28,6 +28,7 @@ public class GroupSettingsDriftReport
 public class GroupSettingsDriftResult
 {
     public List<GroupSettingsDriftReport> Reports { get; init; } = [];
+    public Dictionary<string, string> ExpectedSettings { get; init; } = [];
     public int TotalGroups => Reports.Count;
     public int OkCount => Reports.Count(r => r.IsOk);
     public int DriftCount => Reports.Count(r => r.HasDrift);

--- a/src/Humans.Application/DTOs/GroupSettingsDriftResult.cs
+++ b/src/Humans.Application/DTOs/GroupSettingsDriftResult.cs
@@ -1,0 +1,37 @@
+namespace Humans.Application.DTOs;
+
+/// <summary>
+/// A single setting that differs from the expected value.
+/// </summary>
+public record GroupSettingDrift(string SettingName, string ExpectedValue, string ActualValue);
+
+/// <summary>
+/// Drift report for a single Google Group's settings.
+/// </summary>
+public class GroupSettingsDriftReport
+{
+    public string GroupEmail { get; init; } = string.Empty;
+    public string GroupName { get; init; } = string.Empty;
+    public string? Url { get; init; }
+    public Guid ResourceId { get; init; }
+    public string? ErrorMessage { get; init; }
+    public List<GroupSettingDrift> Drifts { get; init; } = [];
+
+    public bool HasDrift => Drifts.Count > 0;
+    public bool HasError => ErrorMessage != null;
+    public bool IsOk => !HasDrift && !HasError;
+}
+
+/// <summary>
+/// Aggregated result of checking group settings across all groups.
+/// </summary>
+public class GroupSettingsDriftResult
+{
+    public List<GroupSettingsDriftReport> Reports { get; init; } = [];
+    public int TotalGroups => Reports.Count;
+    public int OkCount => Reports.Count(r => r.IsOk);
+    public int DriftCount => Reports.Count(r => r.HasDrift);
+    public int ErrorCount => Reports.Count(r => r.HasError);
+    public bool Skipped { get; init; }
+    public string? SkipReason { get; init; }
+}

--- a/src/Humans.Application/Interfaces/IGoogleSyncService.cs
+++ b/src/Humans.Application/Interfaces/IGoogleSyncService.cs
@@ -113,4 +113,12 @@ public interface IGoogleSyncService
     /// <param name="userId">The user ID.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     Task RestoreUserToAllTeamsAsync(Guid userId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Checks all active Google Groups for settings drift against the expected configuration.
+    /// Detect-only: does not modify any settings.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Drift results for all groups, or a skipped result if sync is disabled.</returns>
+    Task<GroupSettingsDriftResult> CheckGroupSettingsAsync(CancellationToken cancellationToken = default);
 }

--- a/src/Humans.Infrastructure/Jobs/GoogleResourceReconciliationJob.cs
+++ b/src/Humans.Infrastructure/Jobs/GoogleResourceReconciliationJob.cs
@@ -38,6 +38,18 @@ public class GoogleResourceReconciliationJob
             await _googleSyncService.SyncResourcesByTypeAsync(GoogleResourceType.DriveFolder, SyncAction.Execute, cancellationToken);
             await _googleSyncService.SyncResourcesByTypeAsync(GoogleResourceType.Group, SyncAction.Execute, cancellationToken);
 
+            // Check Google Group settings for drift (detect only, does not fix)
+            var settingsResult = await _googleSyncService.CheckGroupSettingsAsync(cancellationToken);
+            if (!settingsResult.Skipped && settingsResult.DriftCount > 0)
+            {
+                _logger.LogWarning("Google Group settings drift detected: {DriftCount} group(s) with settings drift out of {Total}",
+                    settingsResult.DriftCount, settingsResult.TotalGroups);
+            }
+            if (settingsResult.ErrorCount > 0)
+            {
+                _logger.LogWarning("Google Group settings check had {ErrorCount} error(s)", settingsResult.ErrorCount);
+            }
+
             _metrics.RecordJobRun("google_resource_reconciliation", "success");
             _logger.LogInformation("Completed Google resource reconciliation");
         }

--- a/src/Humans.Infrastructure/Services/GoogleWorkspaceSyncService.cs
+++ b/src/Humans.Infrastructure/Services/GoogleWorkspaceSyncService.cs
@@ -1316,8 +1316,30 @@ public class GoogleWorkspaceSyncService : IGoogleSyncService
             reports.Add(report);
         }
 
-        return new GroupSettingsDriftResult { Reports = reports };
+        return new GroupSettingsDriftResult
+        {
+            Reports = reports,
+            ExpectedSettings = BuildExpectedSettingsDictionary()
+        };
     }
+
+    private Dictionary<string, string> BuildExpectedSettingsDictionary() => new(StringComparer.Ordinal)
+    {
+        ["WhoCanJoin"] = _settings.Groups.WhoCanJoin,
+        ["WhoCanViewMembership"] = _settings.Groups.WhoCanViewMembership,
+        ["WhoCanContactOwner"] = _settings.Groups.WhoCanContactOwner,
+        ["WhoCanPostMessage"] = _settings.Groups.WhoCanPostMessage,
+        ["WhoCanViewGroup"] = _settings.Groups.WhoCanViewGroup,
+        ["WhoCanModerateMembers"] = _settings.Groups.WhoCanModerateMembers,
+        ["AllowExternalMembers"] = _settings.Groups.AllowExternalMembers ? "true" : "false",
+        ["IsArchived"] = "false",
+        ["MembersCanPostAsTheGroup"] = "false",
+        ["IncludeInGlobalAddressList"] = "true",
+        ["AllowWebPosting"] = "true",
+        ["MessageModerationLevel"] = "MODERATE_NONE",
+        ["SpamModerationLevel"] = "MODERATE",
+        ["EnableCollaborativeInbox"] = "false"
+    };
 
     private async Task<GroupSettingsDriftReport> CheckSingleGroupSettingsAsync(
         GoogleResource resource,

--- a/src/Humans.Infrastructure/Services/GoogleWorkspaceSyncService.cs
+++ b/src/Humans.Infrastructure/Services/GoogleWorkspaceSyncService.cs
@@ -1328,6 +1328,7 @@ public class GoogleWorkspaceSyncService : IGoogleSyncService
         {
             var groupssettingsService = await GetGroupssettingsServiceAsync();
             var request = groupssettingsService.Groups.Get(groupEmail);
+            request.Alt = Google.Apis.Groupssettings.v1.GroupssettingsBaseServiceRequest<Google.Apis.Groupssettings.v1.Data.Groups>.AltEnum.Json;
             var actual = await request.ExecuteAsync(cancellationToken);
 
             var drifts = new List<GroupSettingDrift>();

--- a/src/Humans.Infrastructure/Services/GoogleWorkspaceSyncService.cs
+++ b/src/Humans.Infrastructure/Services/GoogleWorkspaceSyncService.cs
@@ -1266,4 +1266,144 @@ public class GoogleWorkspaceSyncService : IGoogleSyncService
             }
         }
     }
+
+    /// <inheritdoc />
+    public async Task<GroupSettingsDriftResult> CheckGroupSettingsAsync(CancellationToken cancellationToken = default)
+    {
+        var mode = await _syncSettingsService.GetModeAsync(SyncServiceType.GoogleGroups, cancellationToken);
+        if (mode == SyncMode.None)
+        {
+            _logger.LogInformation("Google Groups sync is disabled — skipping settings drift check");
+            return new GroupSettingsDriftResult
+            {
+                Skipped = true,
+                SkipReason = "Google Groups sync mode is set to None"
+            };
+        }
+
+        var groupResources = await _dbContext.GoogleResources
+            .Include(r => r.Team)
+            .Where(r => r.ResourceType == GoogleResourceType.Group && r.IsActive)
+            .ToListAsync(cancellationToken);
+
+        _logger.LogInformation("Checking group settings for {Count} active Google Groups", groupResources.Count);
+
+        var reports = new List<GroupSettingsDriftReport>();
+
+        foreach (var resource in groupResources)
+        {
+            var groupEmail = resource.Team.GoogleGroupEmail;
+            if (string.IsNullOrEmpty(groupEmail))
+            {
+                // Fall back to deriving email from URL
+                var prefix = resource.Url?.Split("/g/", StringSplitOptions.None).LastOrDefault();
+                groupEmail = prefix != null ? $"{prefix}@{_settings.Domain}" : null;
+            }
+
+            if (string.IsNullOrEmpty(groupEmail))
+            {
+                reports.Add(new GroupSettingsDriftReport
+                {
+                    ResourceId = resource.Id,
+                    GroupName = resource.Name,
+                    Url = resource.Url,
+                    ErrorMessage = "Cannot determine group email address"
+                });
+                continue;
+            }
+
+            var report = await CheckSingleGroupSettingsAsync(resource, groupEmail, cancellationToken);
+            reports.Add(report);
+        }
+
+        return new GroupSettingsDriftResult { Reports = reports };
+    }
+
+    private async Task<GroupSettingsDriftReport> CheckSingleGroupSettingsAsync(
+        GoogleResource resource,
+        string groupEmail,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var groupssettingsService = await GetGroupssettingsServiceAsync();
+            var request = groupssettingsService.Groups.Get(groupEmail);
+            var actual = await request.ExecuteAsync(cancellationToken);
+
+            var drifts = new List<GroupSettingDrift>();
+
+            // Compare against the expected settings (same ones applied at group creation)
+            CompareGroupSetting(drifts, "WhoCanJoin", _settings.Groups.WhoCanJoin, actual.WhoCanJoin);
+            CompareGroupSetting(drifts, "WhoCanViewMembership", _settings.Groups.WhoCanViewMembership, actual.WhoCanViewMembership);
+            CompareGroupSetting(drifts, "WhoCanContactOwner", _settings.Groups.WhoCanContactOwner, actual.WhoCanContactOwner);
+            CompareGroupSetting(drifts, "WhoCanPostMessage", _settings.Groups.WhoCanPostMessage, actual.WhoCanPostMessage);
+            CompareGroupSetting(drifts, "WhoCanViewGroup", _settings.Groups.WhoCanViewGroup, actual.WhoCanViewGroup);
+            CompareGroupSetting(drifts, "WhoCanModerateMembers", _settings.Groups.WhoCanModerateMembers, actual.WhoCanModerateMembers);
+            CompareGroupSetting(drifts, "AllowExternalMembers",
+                _settings.Groups.AllowExternalMembers ? "true" : "false", actual.AllowExternalMembers);
+
+            // Additional settings worth monitoring (not set at creation but important for group health)
+            CompareGroupSetting(drifts, "IsArchived", "false", actual.IsArchived);
+            CompareGroupSetting(drifts, "MembersCanPostAsTheGroup", "false", actual.MembersCanPostAsTheGroup);
+            CompareGroupSetting(drifts, "IncludeInGlobalAddressList", "true", actual.IncludeInGlobalAddressList);
+            CompareGroupSetting(drifts, "AllowWebPosting", "true", actual.AllowWebPosting);
+            CompareGroupSetting(drifts, "MessageModerationLevel", "MODERATE_NONE", actual.MessageModerationLevel);
+            CompareGroupSetting(drifts, "SpamModerationLevel", "MODERATE", actual.SpamModerationLevel);
+            CompareGroupSetting(drifts, "EnableCollaborativeInbox", "false", actual.EnableCollaborativeInbox);
+
+            if (drifts.Count > 0)
+            {
+                _logger.LogWarning("Group '{GroupEmail}' has {DriftCount} setting drift(s): {Drifts}",
+                    groupEmail, drifts.Count,
+                    string.Join(", ", drifts.Select(d => $"{d.SettingName}: expected={d.ExpectedValue}, actual={d.ActualValue}")));
+            }
+
+            return new GroupSettingsDriftReport
+            {
+                ResourceId = resource.Id,
+                GroupEmail = groupEmail,
+                GroupName = resource.Name,
+                Url = resource.Url,
+                Drifts = drifts
+            };
+        }
+        catch (Google.GoogleApiException ex) when (ex.Error?.Code is 404 or 403)
+        {
+            _logger.LogWarning("Cannot read settings for group '{GroupEmail}' (HTTP {Code})",
+                groupEmail, ex.Error.Code);
+            return new GroupSettingsDriftReport
+            {
+                ResourceId = resource.Id,
+                GroupEmail = groupEmail,
+                GroupName = resource.Name,
+                Url = resource.Url,
+                ErrorMessage = $"Google API error: {ex.Error.Code} — {ex.Error.Message}"
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error checking settings for group '{GroupEmail}'", groupEmail);
+            return new GroupSettingsDriftReport
+            {
+                ResourceId = resource.Id,
+                GroupEmail = groupEmail,
+                GroupName = resource.Name,
+                Url = resource.Url,
+                ErrorMessage = $"Error: {ex.Message}"
+            };
+        }
+    }
+
+    private static void CompareGroupSetting(
+        List<GroupSettingDrift> drifts,
+        string settingName,
+        string expectedValue,
+        string? actualValue)
+    {
+        if (actualValue == null) return;
+        if (!string.Equals(expectedValue, actualValue, StringComparison.OrdinalIgnoreCase))
+        {
+            drifts.Add(new GroupSettingDrift(settingName, expectedValue, actualValue));
+        }
+    }
 }

--- a/src/Humans.Infrastructure/Services/StubGoogleSyncService.cs
+++ b/src/Humans.Infrastructure/Services/StubGoogleSyncService.cs
@@ -112,6 +112,12 @@ public class StubGoogleSyncService : IGoogleSyncService
         return Task.CompletedTask;
     }
 
+    public Task<GroupSettingsDriftResult> CheckGroupSettingsAsync(CancellationToken cancellationToken = default)
+    {
+        _logger.LogInformation("[STUB] Would check Google Group settings for drift");
+        return Task.FromResult(new GroupSettingsDriftResult());
+    }
+
     public Task<SyncPreviewResult> SyncResourcesByTypeAsync(
         GoogleResourceType resourceType,
         SyncAction action,

--- a/src/Humans.Web/Controllers/AdminController.cs
+++ b/src/Humans.Web/Controllers/AdminController.cs
@@ -497,4 +497,42 @@ public class AdminController : HumansControllerBase
         return RedirectToAction(nameof(Index));
     }
 
+    [HttpPost("CheckGroupSettings")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> CheckGroupSettings(
+        [FromServices] IGoogleSyncService googleSyncService)
+    {
+        try
+        {
+            var result = await googleSyncService.CheckGroupSettingsAsync();
+            TempData["GroupSettingsResult"] = System.Text.Json.JsonSerializer.Serialize(result);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to check Google Group settings");
+            SetError($"Settings check failed: {ex.Message}");
+            return RedirectToAction(nameof(Index));
+        }
+
+        return RedirectToAction(nameof(GroupSettingsResults));
+    }
+
+    [HttpGet("GroupSettingsResults")]
+    public IActionResult GroupSettingsResults()
+    {
+        Application.DTOs.GroupSettingsDriftResult? result = null;
+        if (TempData["GroupSettingsResult"] is string json)
+        {
+            result = System.Text.Json.JsonSerializer.Deserialize<Application.DTOs.GroupSettingsDriftResult>(json);
+        }
+
+        if (result == null)
+        {
+            SetInfo("No group settings results to display. Run the check first.");
+            return RedirectToAction(nameof(Index));
+        }
+
+        return View(result);
+    }
+
 }

--- a/src/Humans.Web/Views/Admin/GroupSettingsResults.cshtml
+++ b/src/Humans.Web/Views/Admin/GroupSettingsResults.cshtml
@@ -1,0 +1,103 @@
+@model Humans.Application.DTOs.GroupSettingsDriftResult
+@{
+    ViewData["Title"] = "Google Group Settings Check";
+}
+
+<div class="container-fluid px-4">
+    <div class="d-flex justify-content-between align-items-center mt-4 mb-3">
+        <h1>Group Settings Check</h1>
+        <a asp-action="Index" class="btn btn-outline-secondary btn-sm">
+            <i class="fa-solid fa-arrow-left me-1"></i>Back to Admin
+        </a>
+    </div>
+
+    @if (Model.Skipped)
+    {
+        <div class="alert alert-secondary">
+            <i class="fa-solid fa-circle-pause me-1"></i>Check skipped: @Model.SkipReason
+        </div>
+    }
+    else if (Model.DriftCount == 0 && Model.ErrorCount == 0)
+    {
+        <div class="alert alert-success">
+            <i class="fa-solid fa-check-circle me-1"></i>All @Model.TotalGroups group(s) have correct settings.
+        </div>
+    }
+    else
+    {
+        <div class="alert alert-info">
+            <i class="fa-solid fa-magnifying-glass me-1"></i>Checked @Model.TotalGroups group(s):
+            <strong>@Model.OkCount</strong> OK,
+            <strong>@Model.DriftCount</strong> with drift,
+            <strong>@Model.ErrorCount</strong> with errors.
+        </div>
+    }
+
+    @foreach (var report in Model.Reports.OrderByDescending(r => r.HasDrift).ThenByDescending(r => r.HasError))
+    {
+        var headerClass = report.HasDrift ? "bg-warning text-dark" : report.HasError ? "bg-danger text-white" : "bg-success text-white";
+        <div class="card mb-3">
+            <div class="card-header d-flex justify-content-between align-items-center @headerClass">
+                <div>
+                    <strong>@report.GroupName</strong>
+                    <small class="ms-2">@report.GroupEmail</small>
+                </div>
+                @if (report.HasDrift)
+                {
+                    <span class="badge bg-dark">@report.Drifts.Count drift(s)</span>
+                }
+                else if (report.HasError)
+                {
+                    <span class="badge bg-dark">Error</span>
+                }
+                else
+                {
+                    <span class="badge bg-dark">OK</span>
+                }
+            </div>
+
+            @if (report.HasError)
+            {
+                <div class="card-body">
+                    <div class="text-danger">
+                        <i class="fa-solid fa-triangle-exclamation me-1"></i>@report.ErrorMessage
+                    </div>
+                </div>
+            }
+
+            @if (report.HasDrift)
+            {
+                <div class="card-body p-0">
+                    <table class="table table-sm mb-0">
+                        <thead>
+                            <tr>
+                                <th>Setting</th>
+                                <th>Expected</th>
+                                <th>Actual</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach (var drift in report.Drifts)
+                            {
+                                <tr>
+                                    <td><code>@drift.SettingName</code></td>
+                                    <td><span class="badge bg-success">@drift.ExpectedValue</span></td>
+                                    <td><span class="badge bg-danger">@drift.ActualValue</span></td>
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
+                </div>
+            }
+
+            @if (report.Url != null)
+            {
+                <div class="card-footer text-muted small">
+                    <a href="@report.Url" target="_blank" rel="noopener">
+                        <i class="fa-solid fa-arrow-up-right-from-square me-1"></i>Open in Google Groups
+                    </a>
+                </div>
+            }
+        </div>
+    }
+</div>

--- a/src/Humans.Web/Views/Admin/GroupSettingsResults.cshtml
+++ b/src/Humans.Web/Views/Admin/GroupSettingsResults.cshtml
@@ -100,4 +100,32 @@
             }
         </div>
     }
+
+    @if (Model.ExpectedSettings.Count > 0)
+    {
+        <div class="card mt-4 mb-4">
+            <div class="card-header bg-light">
+                <i class="fa-solid fa-list-check me-1"></i><strong>Expected Settings Reference</strong>
+            </div>
+            <div class="card-body p-0">
+                <table class="table table-sm table-striped mb-0">
+                    <thead>
+                        <tr>
+                            <th>Setting</th>
+                            <th>Expected Value</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var setting in Model.ExpectedSettings)
+                        {
+                            <tr>
+                                <td><code>@setting.Key</code></td>
+                                <td><span class="badge bg-success">@setting.Value</span></td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    }
 </div>

--- a/src/Humans.Web/Views/Admin/Index.cshtml
+++ b/src/Humans.Web/Views/Admin/Index.cshtml
@@ -56,6 +56,19 @@
                 </form>
             </div>
         </div>
+
+        <div class="card mb-4">
+            <div class="card-header">Google Group Settings</div>
+            <div class="card-body">
+                <form asp-action="CheckGroupSettings" method="post">
+                    @Html.AntiForgeryToken()
+                    <button type="submit" class="btn btn-outline-primary">
+                        <i class="fa-solid fa-magnifying-glass me-1"></i>Check Group Settings
+                    </button>
+                    <small class="text-muted d-block mt-1">Checks all Google Groups for settings drift. Does not modify anything.</small>
+                </form>
+            </div>
+        </div>
     </div>
 
     <div class="col-md-6">

--- a/tests/Humans.Application.Tests/Jobs/GoogleResourceReconciliationJobTests.cs
+++ b/tests/Humans.Application.Tests/Jobs/GoogleResourceReconciliationJobTests.cs
@@ -5,6 +5,7 @@ using NodaTime;
 using NodaTime.Testing;
 using NSubstitute;
 using Humans.Application.Interfaces;
+using Humans.Application.DTOs;
 using Humans.Domain.Enums;
 using Humans.Infrastructure.Jobs;
 using Humans.Infrastructure.Services;
@@ -43,6 +44,9 @@ public class GoogleResourceReconciliationJobTests : IDisposable
     [Fact]
     public async Task ExecuteAsync_SyncsBothResourceTypes()
     {
+        _googleSyncService.CheckGroupSettingsAsync(Arg.Any<CancellationToken>())
+            .Returns(new GroupSettingsDriftResult());
+
         await _job.ExecuteAsync();
 
         await _googleSyncService.Received(1)


### PR DESCRIPTION
## Summary
- One global expected-settings template for all groups (baseline from creation config + conversation history on)
- Checks 14 settings per group (7 from config + 7 monitored defaults)
- Nightly check integrated into `GoogleResourceReconciliationJob`
- Manual trigger on Admin page with per-group result cards showing expected vs actual
- Detect only — no auto-fix
- Respects SyncSettings (skips when mode=None)

## Test plan
- [ ] Navigate to Admin page — verify "Google Group Settings" card with "Check Group Settings" button
- [ ] Click "Check Group Settings" — verify results page shows per-group drift reports
- [ ] With GoogleGroups sync mode set to None — verify check is skipped with reason message

Closes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)