### PR TITLE
Replace magic string ViewModel properties with domain enums (#60)

### DIFF
--- a/src/Humans.Web/Controllers/ApplicationController.cs
+++ b/src/Humans.Web/Controllers/ApplicationController.cs
@@ -47,7 +47,7 @@ public class ApplicationController : HumansControllerBase
             Applications = applications.Select(a => new ApplicationSummaryViewModel
             {
                 Id = a.Id,
-                Status = a.Status.ToString(),
+                Status = a.Status,
                 MembershipTier = a.MembershipTier,
                 SubmittedAt = a.SubmittedAt.ToDateTimeUtc(),
                 ResolvedAt = a.ResolvedAt?.ToDateTimeUtc(),
@@ -151,7 +151,7 @@ public class ApplicationController : HumansControllerBase
         var viewModel = new ApplicationDetailViewModel
         {
             Id = application.Id,
-            Status = application.Status.ToString(),
+            Status = application.Status,
             Motivation = application.Motivation,
             AdditionalInfo = application.AdditionalInfo,
             SignificantContribution = application.SignificantContribution,
@@ -167,7 +167,7 @@ public class ApplicationController : HumansControllerBase
                 .OrderByDescending(h => h.ChangedAt)
                 .Select(h => new ApplicationHistoryViewModel
                 {
-                    Status = h.Status.ToString(),
+                    Status = h.Status,
                     ChangedAt = h.ChangedAt.ToDateTimeUtc(),
                     ChangedBy = h.ChangedByUser.DisplayName,
                     Notes = h.Notes
@@ -212,11 +212,11 @@ public class ApplicationController : HumansControllerBase
             UserId = a.UserId,
             UserEmail = a.User.Email ?? string.Empty,
             UserDisplayName = a.User.DisplayName,
-            Status = a.Status.ToString(),
+            Status = a.Status,
             StatusBadgeClass = a.Status.GetBadgeClass(),
             SubmittedAt = a.SubmittedAt.ToDateTimeUtc(),
             MotivationPreview = a.Motivation.Length > 100 ? a.Motivation[..100] + "..." : a.Motivation,
-            MembershipTier = a.MembershipTier.ToString()
+            MembershipTier = a.MembershipTier
         }).ToList();
 
         var viewModel = new AdminApplicationListViewModel
@@ -250,7 +250,7 @@ public class ApplicationController : HumansControllerBase
             UserEmail = application.User.Email ?? string.Empty,
             UserDisplayName = application.User.DisplayName,
             UserProfilePictureUrl = application.User.ProfilePictureUrl,
-            Status = application.Status.ToString(),
+            Status = application.Status,
             Motivation = application.Motivation,
             AdditionalInfo = application.AdditionalInfo,
             SignificantContribution = application.SignificantContribution,
@@ -266,7 +266,7 @@ public class ApplicationController : HumansControllerBase
                 .OrderByDescending(h => h.ChangedAt)
                 .Select(h => new ApplicationHistoryViewModel
                 {
-                    Status = h.Status.ToString(),
+                    Status = h.Status,
                     ChangedAt = h.ChangedAt.ToDateTimeUtc(),
                     ChangedBy = h.ChangedByUser.DisplayName,
                     Notes = h.Notes

--- a/src/Humans.Web/Controllers/BoardController.cs
+++ b/src/Humans.Web/Controllers/BoardController.cs
@@ -65,7 +65,7 @@ public class BoardController : HumansControllerBase
             {
                 Description = e.Description,
                 Timestamp = e.OccurredAt.ToDateTimeUtc(),
-                Type = e.Action.ToString()
+                Type = e.Action
             }).ToList(),
             TotalApplications = dashboardData.TotalApplications,
             ApprovedApplications = dashboardData.ApprovedApplications,
@@ -88,7 +88,7 @@ public class BoardController : HumansControllerBase
 
         var entries = items.Select(e => new AuditLogEntryViewModel
         {
-            Action = e.Action.ToString(),
+            Action = e.Action,
             Description = e.Description,
             OccurredAt = e.OccurredAt.ToDateTimeUtc(),
             ActorName = e.ActorName,

--- a/src/Humans.Web/Controllers/GovernanceController.cs
+++ b/src/Humans.Web/Controllers/GovernanceController.cs
@@ -73,7 +73,7 @@ public class GovernanceController : HumansControllerBase
         {
             StatutesContent = statutesContent,
             HasApplication = latestApplication != null,
-            ApplicationStatus = latestApplication?.Status.ToString(),
+            ApplicationStatus = latestApplication?.Status,
             ApplicationSubmittedAt = latestApplication?.SubmittedAt.ToDateTimeUtc(),
             ApplicationResolvedAt = latestApplication?.ResolvedAt?.ToDateTimeUtc(),
             ApplicationStatusBadgeClass = latestApplication?.Status.GetBadgeClass(),

--- a/src/Humans.Web/Controllers/HomeController.cs
+++ b/src/Humans.Web/Controllers/HomeController.cs
@@ -95,7 +95,7 @@ public class HomeController : HumansControllerBase
         {
             DisplayName = user.DisplayName,
             ProfilePictureUrl = user.ProfilePictureUrl,
-            MembershipStatus = membershipSnapshot.Status.ToString(),
+            MembershipStatus = membershipSnapshot.Status,
             HasProfile = profile != null,
             ProfileComplete = profile != null && !string.IsNullOrEmpty(profile.FirstName),
             PendingConsents = membershipSnapshot.PendingConsentCount,
@@ -106,7 +106,7 @@ public class HomeController : HumansControllerBase
             IsRejected = profile?.RejectedAt != null,
             RejectionReason = profile?.RejectionReason,
             HasPendingApplication = hasPendingApp,
-            LatestApplicationStatus = latestApplication?.Status.ToString(),
+            LatestApplicationStatus = latestApplication?.Status,
             LatestApplicationDate = latestApplication?.SubmittedAt.ToDateTimeUtc(),
             LatestApplicationTier = latestApplication?.MembershipTier,
             TermExpiresAt = termExpiresAt,

--- a/src/Humans.Web/Controllers/HumanController.cs
+++ b/src/Humans.Web/Controllers/HumanController.cs
@@ -307,7 +307,7 @@ public class HumanController : HumansControllerBase
                 .Select(a => new AdminHumanApplicationViewModel
                 {
                     Id = a.Id,
-                    Status = a.Status.ToString(),
+                    Status = a.Status,
                     SubmittedAt = a.SubmittedAt.ToDateTimeUtc()
                 }).ToList(),
             RoleAssignments = data.RoleAssignments.Select(ra => new AdminRoleAssignmentViewModel
@@ -324,7 +324,7 @@ public class HumanController : HumansControllerBase
             }).ToList(),
             AuditLog = data.AuditEntries.Select(e => new AuditLogEntryViewModel
             {
-                Action = e.Action,
+                Action = Enum.TryParse<AuditAction>(e.Action, out var parsedAction) ? parsedAction : default,
                 Description = e.Description,
                 OccurredAt = e.OccurredAt,
                 ActorName = e.ActorName ?? string.Empty,

--- a/src/Humans.Web/Controllers/HumansControllerBase.cs
+++ b/src/Humans.Web/Controllers/HumansControllerBase.cs
@@ -97,11 +97,11 @@ public abstract class HumansControllerBase : Controller
             BackLabel = backLabel,
             Entries = entries.Select(static entry => new GoogleSyncAuditEntryViewModel
             {
-                Action = entry.Action.ToString(),
+                Action = entry.Action,
                 Description = entry.Description,
                 UserEmail = entry.UserEmail,
                 Role = entry.Role,
-                SyncSource = entry.SyncSource?.ToString(),
+                SyncSource = entry.SyncSource,
                 OccurredAt = entry.OccurredAt.ToDateTimeUtc(),
                 Success = entry.Success,
                 ErrorMessage = entry.ErrorMessage,

--- a/src/Humans.Web/Controllers/ProfileController.cs
+++ b/src/Humans.Web/Controllers/ProfileController.cs
@@ -106,7 +106,7 @@ public class ProfileController : HumansControllerBase
         // Show tier application status (skip Withdrawn — not interesting)
         if (latestApplication != null && latestApplication.Status != ApplicationStatus.Withdrawn)
         {
-            viewModel.TierApplicationStatus = latestApplication.Status.ToString();
+            viewModel.TierApplicationStatus = latestApplication.Status;
             viewModel.TierApplicationTier = latestApplication.MembershipTier;
             viewModel.TierApplicationBadgeClass = latestApplication.Status.GetBadgeClass();
         }

--- a/src/Humans.Web/Controllers/TeamAdminController.cs
+++ b/src/Humans.Web/Controllers/TeamAdminController.cs
@@ -130,7 +130,7 @@ public class TeamAdminController : HumansTeamControllerBase
                 ProfilePictureUrl = m.User.ProfilePictureUrl,
                 HasCustomProfilePicture = customPictureByUserId.ContainsKey(m.UserId),
                 CustomProfilePictureUrl = customPictureByUserId.GetValueOrDefault(m.UserId),
-                Role = m.Role.ToString(),
+                Role = m.Role,
                 JoinedAt = m.JoinedAt.ToDateTimeUtc(),
                 IsCoordinator = m.Role == TeamMemberRole.Coordinator
             }).ToList();
@@ -146,7 +146,7 @@ public class TeamAdminController : HumansTeamControllerBase
                 UserDisplayName = r.User.DisplayName,
                 UserEmail = r.User.Email ?? "",
                 UserProfilePictureUrl = r.User.ProfilePictureUrl,
-                Status = r.Status.ToString(),
+                Status = r.Status,
                 Message = r.Message,
                 RequestedAt = r.RequestedAt.ToDateTimeUtc()
             }).ToList();
@@ -491,7 +491,7 @@ public class TeamAdminController : HumansTeamControllerBase
                 ProfilePictureUrl = m.User.ProfilePictureUrl,
                 HasCustomProfilePicture = customPictureByUserId.ContainsKey(m.UserId),
                 CustomProfilePictureUrl = customPictureByUserId.GetValueOrDefault(m.UserId),
-                Role = m.Role.ToString(),
+                Role = m.Role,
                 JoinedAt = m.JoinedAt.ToDateTimeUtc(),
                 IsCoordinator = m.Role == TeamMemberRole.Coordinator
             }).ToList()

--- a/src/Humans.Web/Controllers/TeamController.cs
+++ b/src/Humans.Web/Controllers/TeamController.cs
@@ -120,7 +120,7 @@ public class TeamController : HumansControllerBase
             IsActive = team.IsActive,
             RequiresApproval = team.RequiresApproval,
             IsSystemTeam = team.IsSystemTeam,
-            SystemTeamType = team.SystemTeamType != SystemTeamType.None ? team.SystemTeamType.ToString() : null,
+            SystemTeamType = team.SystemTeamType != SystemTeamType.None ? team.SystemTeamType : null,
             CreatedAt = team.CreatedAt.ToDateTimeUtc(),
             IsPublicPage = team.IsPublicPage,
             PageContent = team.PageContent,
@@ -193,7 +193,7 @@ public class TeamController : HumansControllerBase
             ProfilePictureUrl = member.ProfilePictureUrl,
             HasCustomProfilePicture = customPictureByUserId.ContainsKey(member.UserId),
             CustomProfilePictureUrl = customPictureByUserId.GetValueOrDefault(member.UserId),
-            Role = member.Role.ToString(),
+            Role = member.Role,
             JoinedAt = member.JoinedAt?.ToDateTimeUtc() ?? default,
             IsCoordinator = member.Role == TeamMemberRole.Coordinator
         };
@@ -293,9 +293,9 @@ public class TeamController : HumansControllerBase
             RoleDescription = slot.RoleDescription,
             RoleDefinitionId = slot.RoleDefinitionId,
             SlotNumber = slot.SlotNumber,
-            Priority = slot.Priority,
+            Priority = Enum.TryParse<SlotPriority>(slot.Priority, out var sp) ? sp : SlotPriority.None,
             PriorityBadgeClass = slot.PriorityBadgeClass,
-            Period = slot.Period,
+            Period = Enum.TryParse<RolePeriod>(slot.Period, out var rp) ? rp : RolePeriod.Event,
             IsFilled = slot.IsFilled,
             AssignedUserName = slot.AssignedUserName
         }).ToList();
@@ -344,7 +344,7 @@ public class TeamController : HumansControllerBase
                 TeamName = m.TeamName,
                 TeamSlug = m.TeamSlug,
                 IsSystemTeam = m.IsSystemTeam,
-                Role = m.Role.ToString(),
+                Role = m.Role,
                 IsCoordinator = m.Role == TeamMemberRole.Coordinator,
                 JoinedAt = m.JoinedAt.ToDateTimeUtc(),
                 CanLeave = m.CanLeave,
@@ -723,7 +723,7 @@ public class TeamController : HumansControllerBase
         IsActive = team.IsActive,
         RequiresApproval = team.RequiresApproval,
         IsSystemTeam = team.IsSystemTeam,
-        SystemTeamType = team.SystemTeamType,
+        SystemTeamType = Enum.TryParse<SystemTeamType>(team.SystemTeamType, out var stt) ? stt : null,
         MemberCount = team.MemberCount,
         PendingRequestCount = team.PendingRequestCount,
         HasMailGroup = team.HasMailGroup,

--- a/src/Humans.Web/Controllers/TicketController.cs
+++ b/src/Humans.Web/Controllers/TicketController.cs
@@ -414,7 +414,7 @@ public class TicketController : HumansControllerBase
                 Name = u.DisplayName,
                 Email = u.UserEmails.FirstOrDefault(e => e.IsNotificationTarget)?.Email ?? string.Empty,
                 Teams = string.Join(", ", u.TeamMemberships.Select(tm => tm.Team.Name)),
-                Tier = u.Profile?.MembershipTier.ToString() ?? "Volunteer",
+                Tier = u.Profile?.MembershipTier ?? MembershipTier.Volunteer,
             })
             .ToList();
 
@@ -703,10 +703,9 @@ public class TicketController : HumansControllerBase
                 u.TeamMemberships.Any(tm => string.Equals(tm.Team.Name, filterTeam, StringComparison.OrdinalIgnoreCase)));
         }
 
-        if (!string.IsNullOrEmpty(filterTier))
+        if (!string.IsNullOrEmpty(filterTier) && Enum.TryParse<MembershipTier>(filterTier, ignoreCase: true, out var parsedTier))
         {
-            filteredHumans = filteredHumans.Where(u =>
-                string.Equals(u.Profile?.MembershipTier.ToString(), filterTier, StringComparison.OrdinalIgnoreCase));
+            filteredHumans = filteredHumans.Where(u => u.Profile?.MembershipTier == parsedTier);
         }
 
         if (search.HasSearchTerm(1))

--- a/src/Humans.Web/Extensions/AuditLogUiExtensions.cs
+++ b/src/Humans.Web/Extensions/AuditLogUiExtensions.cs
@@ -4,8 +4,6 @@ namespace Humans.Web.Extensions;
 
 public static class AuditLogUiExtensions
 {
-    private const string AnomalyActionName = nameof(AuditAction.AnomalousPermissionDetected);
-
     public static bool IsAuditFilterSelected(this string? currentFilter, string filter)
     {
         return string.Equals(currentFilter, filter, StringComparison.Ordinal);
@@ -20,23 +18,23 @@ public static class AuditLogUiExtensions
         return currentFilter.IsAuditFilterSelected(filter) ? selectedClass : defaultClass;
     }
 
-    public static bool IsAnomalousPermissionAction(this string? action)
+    public static bool IsAnomalousPermissionAction(this AuditAction action)
     {
-        return string.Equals(action, AnomalyActionName, StringComparison.Ordinal);
+        return action == AuditAction.AnomalousPermissionDetected;
     }
 
-    public static string ToAuditEntryRowClass(this string? action)
+    public static string ToAuditEntryRowClass(this AuditAction action)
     {
         return action.IsAnomalousPermissionAction() ? "table-warning" : string.Empty;
     }
 
-    public static string ToAuditBadgeClass(this string? action)
+    public static string ToAuditBadgeClass(this AuditAction action)
     {
         return action.IsAnomalousPermissionAction() ? "bg-warning text-dark" : "bg-secondary";
     }
 
-    public static string ToAuditBadgeLabel(this string? action)
+    public static string ToAuditBadgeLabel(this AuditAction action)
     {
-        return action.IsAnomalousPermissionAction() ? "Anomaly" : action ?? string.Empty;
+        return action.IsAnomalousPermissionAction() ? "Anomaly" : action.ToString();
     }
 }

--- a/src/Humans.Web/Extensions/StatusBadgeExtensions.cs
+++ b/src/Humans.Web/Extensions/StatusBadgeExtensions.cs
@@ -23,21 +23,16 @@ public static class StatusBadgeExtensions
     }
 
     /// <summary>
-    /// Gets the Bootstrap badge CSS class for an application status string.
+    /// Gets the Bootstrap badge CSS class for an application status (nullable).
     /// </summary>
-    public static string GetApplicationStatusBadgeClass(string? status)
+    public static string GetBadgeClass(this ApplicationStatus? status)
     {
-        return status switch
-        {
-            "Submitted" => "bg-primary",
-            "Approved" => "bg-success",
-            "Rejected" => "bg-danger",
-            _ => "bg-secondary"
-        };
+        return status.HasValue ? status.Value.GetBadgeClass() : "bg-secondary";
     }
 
     /// <summary>
     /// Gets the Bootstrap badge CSS class for a membership status string.
+    /// Used by the admin human list, which uses MembershipStatusLabels (not the enum).
     /// </summary>
     public static string GetMembershipStatusBadgeClass(string? status)
     {

--- a/src/Humans.Web/Models/AdminViewModels.cs
+++ b/src/Humans.Web/Models/AdminViewModels.cs
@@ -37,7 +37,7 @@ public class RecentActivityViewModel
 {
     public string Description { get; set; } = string.Empty;
     public DateTime Timestamp { get; set; }
-    public string Type { get; set; } = string.Empty;
+    public AuditAction Type { get; set; }
 }
 
 public class AdminHumanListViewModel : PagedListViewModel
@@ -108,7 +108,7 @@ public class AdminHumanDetailViewModel
 public class AdminHumanApplicationViewModel
 {
     public Guid Id { get; set; }
-    public string Status { get; set; } = string.Empty;
+    public ApplicationStatus Status { get; set; }
     public DateTime SubmittedAt { get; set; }
 }
 
@@ -129,11 +129,11 @@ public class AdminApplicationViewModel
     public Guid UserId { get; set; }
     public string UserEmail { get; set; } = string.Empty;
     public string UserDisplayName { get; set; } = string.Empty;
-    public string Status { get; set; } = string.Empty;
+    public ApplicationStatus Status { get; set; }
     public string StatusBadgeClass { get; set; } = "bg-secondary";
     public DateTime SubmittedAt { get; set; }
     public string MotivationPreview { get; set; } = string.Empty;
-    public string MembershipTier { get; set; } = string.Empty;
+    public MembershipTier MembershipTier { get; set; }
 }
 
 public class AdminApplicationDetailViewModel : ApplicationDetailViewModelBase
@@ -198,7 +198,7 @@ public class EndRoleAssignmentViewModel
 
 public class AuditLogEntryViewModel
 {
-    public string Action { get; set; } = string.Empty;
+    public AuditAction Action { get; set; }
     public string Description { get; set; } = string.Empty;
     public DateTime OccurredAt { get; set; }
     public string ActorName { get; set; } = string.Empty;
@@ -218,11 +218,11 @@ public class AuditLogListViewModel : PagedListViewModel
 
 public class GoogleSyncAuditEntryViewModel
 {
-    public string Action { get; set; } = string.Empty;
+    public AuditAction Action { get; set; }
     public string Description { get; set; } = string.Empty;
     public string? UserEmail { get; set; }
     public string? Role { get; set; }
-    public string? SyncSource { get; set; }
+    public GoogleSyncSource? SyncSource { get; set; }
     public DateTime OccurredAt { get; set; }
     public bool? Success { get; set; }
     public string? ErrorMessage { get; set; }

--- a/src/Humans.Web/Models/ApplicationViewModels.cs
+++ b/src/Humans.Web/Models/ApplicationViewModels.cs
@@ -12,7 +12,7 @@ public class ApplicationIndexViewModel
 public class ApplicationSummaryViewModel
 {
     public Guid Id { get; set; }
-    public string Status { get; set; } = string.Empty;
+    public ApplicationStatus Status { get; set; }
     public MembershipTier MembershipTier { get; set; }
     public DateTime SubmittedAt { get; set; }
     public DateTime? ResolvedAt { get; set; }
@@ -22,7 +22,7 @@ public class ApplicationSummaryViewModel
 public abstract class ApplicationDetailViewModelBase
 {
     public Guid Id { get; set; }
-    public string Status { get; set; } = string.Empty;
+    public ApplicationStatus Status { get; set; }
     public string Motivation { get; set; } = string.Empty;
     public string? AdditionalInfo { get; set; }
     public string? SignificantContribution { get; set; }
@@ -43,7 +43,7 @@ public class ApplicationDetailViewModel : ApplicationDetailViewModelBase
 
 public class ApplicationHistoryViewModel
 {
-    public string Status { get; set; } = string.Empty;
+    public ApplicationStatus Status { get; set; }
     public DateTime ChangedAt { get; set; }
     public string ChangedBy { get; set; } = string.Empty;
     public string? Notes { get; set; }

--- a/src/Humans.Web/Models/DashboardViewModel.cs
+++ b/src/Humans.Web/Models/DashboardViewModel.cs
@@ -6,7 +6,7 @@ public class DashboardViewModel
 {
     public string DisplayName { get; set; } = string.Empty;
     public string? ProfilePictureUrl { get; set; }
-    public string MembershipStatus { get; set; } = "None";
+    public MembershipStatus MembershipStatus { get; set; }
 
     // Profile
     public bool HasProfile { get; set; }
@@ -27,7 +27,7 @@ public class DashboardViewModel
 
     // Applications
     public bool HasPendingApplication { get; set; }
-    public string? LatestApplicationStatus { get; set; }
+    public ApplicationStatus? LatestApplicationStatus { get; set; }
     public DateTime? LatestApplicationDate { get; set; }
     public MembershipTier? LatestApplicationTier { get; set; }
 

--- a/src/Humans.Web/Models/GovernanceViewModels.cs
+++ b/src/Humans.Web/Models/GovernanceViewModels.cs
@@ -1,3 +1,5 @@
+using Humans.Domain.Enums;
+
 namespace Humans.Web.Models;
 
 public class GovernanceIndexViewModel
@@ -8,7 +10,7 @@ public class GovernanceIndexViewModel
     public Dictionary<string, string> StatutesContent { get; set; } = new(StringComparer.Ordinal);
 
     public bool HasApplication { get; set; }
-    public string? ApplicationStatus { get; set; }
+    public ApplicationStatus? ApplicationStatus { get; set; }
     public DateTime? ApplicationSubmittedAt { get; set; }
     public DateTime? ApplicationResolvedAt { get; set; }
     public string? ApplicationStatusBadgeClass { get; set; }

--- a/src/Humans.Web/Models/ProfileCardViewModel.cs
+++ b/src/Humans.Web/Models/ProfileCardViewModel.cs
@@ -16,7 +16,7 @@ public class ProfileCardViewModel
     public string? CustomProfilePictureUrl { get; set; }
     public string BurnerName { get; set; } = string.Empty;
     public string? Pronouns { get; set; }
-    public string MembershipStatus { get; set; } = "None";
+    public MembershipStatus MembershipStatus { get; set; }
     public bool IsApproved { get; set; }
     public string? City { get; set; }
     public string? CountryCode { get; set; }

--- a/src/Humans.Web/Models/ProfileViewModel.cs
+++ b/src/Humans.Web/Models/ProfileViewModel.cs
@@ -155,7 +155,7 @@ public class ProfileViewModel
     /// </summary>
     public bool RemoveProfilePicture { get; set; }
 
-    public string MembershipStatus { get; set; } = "None";
+    public MembershipStatus MembershipStatus { get; set; }
     public bool IsApproved { get; set; }
     public bool HasPendingConsents { get; set; }
     public int PendingConsentCount { get; set; }
@@ -163,7 +163,7 @@ public class ProfileViewModel
     /// <summary>
     /// Status of the user's latest tier application (Submitted, Approved, Rejected), or null if none.
     /// </summary>
-    public string? TierApplicationStatus { get; set; }
+    public ApplicationStatus? TierApplicationStatus { get; set; }
 
     /// <summary>
     /// The tier the user applied for (Colaborador or Asociado), or null if no application.

--- a/src/Humans.Web/Models/TeamViewModels.cs
+++ b/src/Humans.Web/Models/TeamViewModels.cs
@@ -44,7 +44,7 @@ public class TeamDetailViewModel
     public bool IsActive { get; set; }
     public bool RequiresApproval { get; set; }
     public bool IsSystemTeam { get; set; }
-    public string? SystemTeamType { get; set; }
+    public SystemTeamType? SystemTeamType { get; set; }
     public DateTime CreatedAt { get; set; }
 
     public Team? ParentTeam { get; init; }
@@ -86,7 +86,7 @@ public class TeamMemberViewModel
     public string? ProfilePictureUrl { get; set; }
     public bool HasCustomProfilePicture { get; set; }
     public string? CustomProfilePictureUrl { get; set; }
-    public string Role { get; set; } = string.Empty;
+    public TeamMemberRole Role { get; set; }
     public DateTime JoinedAt { get; set; }
     public bool IsCoordinator { get; set; }
 
@@ -110,7 +110,7 @@ public class MyTeamMembershipViewModel
     public string TeamName { get; set; } = string.Empty;
     public string TeamSlug { get; set; } = string.Empty;
     public bool IsSystemTeam { get; set; }
-    public string Role { get; set; } = string.Empty;
+    public TeamMemberRole Role { get; set; }
     public bool IsCoordinator { get; set; }
     public DateTime JoinedAt { get; set; }
     public bool CanLeave { get; set; }
@@ -123,7 +123,7 @@ public class TeamJoinRequestSummaryViewModel
     public Guid TeamId { get; set; }
     public string TeamName { get; set; } = string.Empty;
     public string TeamSlug { get; set; } = string.Empty;
-    public string Status { get; set; } = string.Empty;
+    public TeamJoinRequestStatus Status { get; set; }
     public string StatusBadgeClass { get; set; } = "bg-secondary";
     public DateTime RequestedAt { get; set; }
 }
@@ -148,7 +148,7 @@ public class TeamJoinRequestViewModel
     public string UserDisplayName { get; set; } = string.Empty;
     public string UserEmail { get; set; } = string.Empty;
     public string? UserProfilePictureUrl { get; set; }
-    public string Status { get; set; } = string.Empty;
+    public TeamJoinRequestStatus Status { get; set; }
     public string? Message { get; set; }
     public DateTime RequestedAt { get; set; }
     public DateTime? ResolvedAt { get; set; }
@@ -297,7 +297,7 @@ public class TeamRoleDefinitionViewModel
             slots.Add(new TeamRoleSlotViewModel
             {
                 SlotIndex = i,
-                Priority = priority.ToString(),
+                Priority = priority,
                 PriorityBadgeClass = priority switch
                 {
                     SlotPriority.Critical => "bg-danger",
@@ -333,7 +333,7 @@ public class TeamRoleDefinitionViewModel
 public class TeamRoleSlotViewModel
 {
     public int SlotIndex { get; set; }
-    public string Priority { get; set; } = string.Empty;
+    public SlotPriority Priority { get; set; }
     public string PriorityBadgeClass { get; set; } = string.Empty;
     public bool IsFilled { get; set; }
     public Guid? AssignedUserId { get; set; }
@@ -396,9 +396,9 @@ public class RosterSlotViewModel
     public string? RoleDescription { get; set; }
     public Guid RoleDefinitionId { get; set; }
     public int SlotNumber { get; set; }
-    public string Priority { get; set; } = string.Empty;
+    public SlotPriority Priority { get; set; }
     public string PriorityBadgeClass { get; set; } = string.Empty;
-    public string Period { get; set; } = "YearRound";
+    public RolePeriod Period { get; set; }
     public bool IsFilled { get; set; }
     public string? AssignedUserName { get; set; }
 }
@@ -439,7 +439,7 @@ public class AdminTeamViewModel
     public bool IsActive { get; set; }
     public bool RequiresApproval { get; set; }
     public bool IsSystemTeam { get; set; }
-    public string? SystemTeamType { get; set; }
+    public SystemTeamType? SystemTeamType { get; set; }
     public int MemberCount { get; set; }
     public int PendingRequestCount { get; set; }
     public bool HasMailGroup { get; set; }

--- a/src/Humans.Web/Models/TicketViewModels.cs
+++ b/src/Humans.Web/Models/TicketViewModels.cs
@@ -166,5 +166,5 @@ public class WhoHasntBoughtRow
     public string Name { get; set; } = string.Empty;
     public string Email { get; set; } = string.Empty;
     public string Teams { get; set; } = string.Empty;
-    public string Tier { get; set; } = string.Empty;
+    public MembershipTier Tier { get; set; }
 }

--- a/src/Humans.Web/ViewComponents/ProfileCardViewComponent.cs
+++ b/src/Humans.Web/ViewComponents/ProfileCardViewComponent.cs
@@ -130,7 +130,7 @@ public class ProfileCardViewComponent : ViewComponent
             CustomProfilePictureUrl = pictureUrl,
             BurnerName = profile?.BurnerName ?? string.Empty,
             Pronouns = profile?.Pronouns,
-            MembershipStatus = membershipSnapshot.Status.ToString(),
+            MembershipStatus = membershipSnapshot.Status,
             IsApproved = profile?.IsApproved ?? false,
             City = profile?.City,
             CountryCode = profile?.CountryCode,

--- a/src/Humans.Web/Views/Application/ApplicationDetail.cshtml
+++ b/src/Humans.Web/Views/Application/ApplicationDetail.cshtml
@@ -17,7 +17,7 @@
     <div class="col-md-8">
         <div class="d-flex justify-content-between align-items-center mb-3">
             <h1>@Localizer["AdminAppDetail_ApplicationReview"]</h1>
-            <span class="badge fs-5 @StatusBadgeExtensions.GetApplicationStatusBadgeClass(Model.Status)">@Localizer["ApplicationStatus_" + Model.Status]</span>
+            <span class="badge fs-5 @Model.Status.GetBadgeClass()">@Localizer["ApplicationStatus_" + Model.Status.ToString()]</span>
         </div>
 
         <div class="card mb-4">

--- a/src/Humans.Web/Views/Application/Details.cshtml
+++ b/src/Humans.Web/Views/Application/Details.cshtml
@@ -16,7 +16,7 @@
     <div class="col-md-8">
         <div class="d-flex justify-content-between align-items-center mb-3">
             <h1>@Localizer["ApplicationDetail_Title"]</h1>
-            <span class="badge fs-5 @StatusBadgeExtensions.GetApplicationStatusBadgeClass(Model.Status)">@Localizer["ApplicationStatus_" + Model.Status]</span>
+            <span class="badge fs-5 @Model.Status.GetBadgeClass()">@Localizer["ApplicationStatus_" + Model.Status.ToString()]</span>
         </div>
 
         <div class="card mb-4">

--- a/src/Humans.Web/Views/Application/Index.cshtml
+++ b/src/Humans.Web/Views/Application/Index.cshtml
@@ -30,7 +30,7 @@
             <div class="card">
                 <div class="card-header d-flex justify-content-between align-items-center">
                     <a asp-action="Details" asp-route-id="@app.Id" class="text-decoration-none">@Localizer["Governance_YourApplication"]</a>
-                    <span class="badge @app.StatusBadgeClass">@Localizer["ApplicationStatus_" + app.Status]</span>
+                    <span class="badge @app.StatusBadgeClass">@Localizer["ApplicationStatus_" + app.Status.ToString()]</span>
                 </div>
                 <div class="card-body">
                     <dl class="row mb-0">
@@ -44,17 +44,17 @@
                         }
                     </dl>
 
-                    @if (app.Status == "Submitted")
+                    @if (app.Status == ApplicationStatus.Submitted)
                     {
                         <hr />
                         <p class="text-muted mb-0">@Localizer["Governance_UnderReviewMessage"]</p>
                     }
-                    else if (app.Status == "Approved")
+                    else if (app.Status == ApplicationStatus.Approved)
                     {
                         <hr />
                         <p class="text-success mb-0">@Localizer["Governance_ApprovedMessage"]</p>
                     }
-                    else if (app.Status == "Rejected")
+                    else if (app.Status == ApplicationStatus.Rejected)
                     {
                         <hr />
                         <p class="text-muted mb-0">@Localizer["Governance_RejectedMessage"]</p>

--- a/src/Humans.Web/Views/Governance/Index.cshtml
+++ b/src/Humans.Web/Views/Governance/Index.cshtml
@@ -43,7 +43,7 @@
             <div class="card">
                 <div class="card-header d-flex justify-content-between align-items-center">
                     <span>@Localizer["Governance_YourApplication"]</span>
-                    <span class="badge @Model.ApplicationStatusBadgeClass">@Localizer["ApplicationStatus_" + Model.ApplicationStatus]</span>
+                    <span class="badge @Model.ApplicationStatusBadgeClass">@Localizer["ApplicationStatus_" + Model.ApplicationStatus.ToString()]</span>
                 </div>
                 <div class="card-body">
                     <dl class="row mb-0">
@@ -57,17 +57,17 @@
                         }
                     </dl>
 
-                    @if (Model.ApplicationStatus == "Submitted")
+                    @if (Model.ApplicationStatus == ApplicationStatus.Submitted)
                     {
                         <hr />
                         <p class="text-muted mb-0">@Localizer["Governance_UnderReviewMessage"]</p>
                     }
-                    else if (Model.ApplicationStatus == "Approved")
+                    else if (Model.ApplicationStatus == ApplicationStatus.Approved)
                     {
                         <hr />
                         <p class="text-success mb-0">@Localizer["Governance_ApprovedMessage"]</p>
                     }
-                    else if (Model.ApplicationStatus == "Rejected")
+                    else if (Model.ApplicationStatus == ApplicationStatus.Rejected)
                     {
                         <hr />
                         <p class="text-muted mb-0">@Localizer["Governance_RejectedMessage"]</p>

--- a/src/Humans.Web/Views/Home/Dashboard.cshtml
+++ b/src/Humans.Web/Views/Home/Dashboard.cshtml
@@ -184,7 +184,7 @@ else if (Model.PendingConsents > 0)
                                 {
                                     <span class="badge bg-info me-1">@Model.LatestApplicationTier.Value</span>
                                 }
-                                <span class="badge @StatusBadgeExtensions.GetApplicationStatusBadgeClass(Model.LatestApplicationStatus)">@Localizer["ApplicationStatus_" + Model.LatestApplicationStatus]</span>
+                                <span class="badge @Model.LatestApplicationStatus.GetBadgeClass()">@Localizer["ApplicationStatus_" + Model.LatestApplicationStatus.ToString()]</span>
                             </div>
                             <small class="text-muted">@Model.LatestApplicationDate?.ToDisplayDate()</small>
                         </div>

--- a/src/Humans.Web/Views/Profile/Index.cshtml
+++ b/src/Humans.Web/Views/Profile/Index.cshtml
@@ -42,15 +42,15 @@
         {
             var alertClass = Model.TierApplicationStatus switch
             {
-                "Approved" => "alert-success",
-                "Rejected" => "alert-danger",
+                ApplicationStatus.Approved => "alert-success",
+                ApplicationStatus.Rejected => "alert-danger",
                 _ => "alert-info"
             };
             <div class="alert @alertClass" role="alert">
                 <div class="d-flex justify-content-between align-items-center">
                     <span>
                         @string.Format(Localizer["Profile_TierApplicationStatus"].Value, Model.TierApplicationTier)
-                        <span class="badge @Model.TierApplicationBadgeClass ms-1">@Localizer["ApplicationStatus_" + Model.TierApplicationStatus]</span>
+                        <span class="badge @Model.TierApplicationBadgeClass ms-1">@Localizer["ApplicationStatus_" + Model.TierApplicationStatus.ToString()]</span>
                     </span>
                     <a asp-controller="Governance" asp-action="Index" class="alert-link">@Localizer["Profile_TierApplicationDetails"]</a>
                 </div>

--- a/src/Humans.Web/Views/Shared/GoogleSyncAudit.cshtml
+++ b/src/Humans.Web/Views/Shared/GoogleSyncAudit.cshtml
@@ -50,7 +50,7 @@ else
                             </td>
                             <td>@(entry.UserEmail ?? "--")</td>
                             <td>@(entry.Role ?? "--")</td>
-                            <td>@(entry.SyncSource ?? "--")</td>
+                            <td>@(entry.SyncSource?.ToString() ?? "--")</td>
                             <td>
                                 @if (entry.Success == true)
                                 {

--- a/src/Humans.Web/Views/Team/Roster.cshtml
+++ b/src/Humans.Web/Views/Team/Roster.cshtml
@@ -69,7 +69,7 @@ else
                 var hasDescription = !string.IsNullOrEmpty(slot.RoleDescription);
                 var collapseId = $"roster-desc-{slot.RoleDefinitionId:N}";
                 var isFirstSlotForRole = hasDescription && shownDescriptions.Add(slot.RoleDefinitionId);
-                <tr class="@(slot is { IsFilled: false, Priority: "Critical" } ? "table-danger" : "")">
+                <tr class="@(slot is { IsFilled: false, Priority: SlotPriority.Critical } ? "table-danger" : "")">
                     <td><a href="@Url.Action("Details", "Team", new { slug = slot.TeamSlug })">@slot.TeamName</a></td>
                     <td>
                         @slot.RoleName
@@ -84,16 +84,16 @@ else
                     @{
                         var periodBadge = slot.Period switch
                         {
-                            "Build" => "bg-info",
-                            "Event" => "bg-success",
-                            "Strike" => "bg-secondary",
+                            RolePeriod.Build => "bg-info",
+                            RolePeriod.Event => "bg-success",
+                            RolePeriod.Strike => "bg-secondary",
                             _ => "bg-light text-dark"
                         };
-                        var periodLabel = slot.Period switch { "YearRound" => "Year-round", "Build" => "Set-up", _ => slot.Period };
+                        var periodLabel = slot.Period switch { RolePeriod.YearRound => "Year-round", RolePeriod.Build => "Set-up", _ => slot.Period.ToString() };
                     }
                     <td><span class="badge @periodBadge">@periodLabel</span></td>
                     <td>@slot.SlotNumber</td>
-                    <td><span class="badge @slot.PriorityBadgeClass">@(slot.Priority == "NiceToHave" ? "Nice to Have" : slot.Priority)</span></td>
+                    <td><span class="badge @slot.PriorityBadgeClass">@(slot.Priority == SlotPriority.NiceToHave ? "Nice to Have" : slot.Priority.ToString())</span></td>
                     <td>
                         @if (slot.IsFilled)
                         {

--- a/src/Humans.Web/Views/Team/_RosterSection.cshtml
+++ b/src/Humans.Web/Views/Team/_RosterSection.cshtml
@@ -55,7 +55,7 @@
                                     </td>
                                 }
                                 <td>@(slot.SlotIndex + 1)</td>
-                                <td><span class="badge @slot.PriorityBadgeClass">@(slot.Priority == "NiceToHave" ? "Nice to Have" : slot.Priority)</span></td>
+                                <td><span class="badge @slot.PriorityBadgeClass">@(slot.Priority == SlotPriority.NiceToHave ? "Nice to Have" : slot.Priority.ToString())</span></td>
                                 <td>
                                     @if (slot.IsFilled)
                                     {

--- a/src/Humans.Web/Views/TeamAdmin/Roles.cshtml
+++ b/src/Humans.Web/Views/TeamAdmin/Roles.cshtml
@@ -86,7 +86,7 @@
                         <div class="d-flex flex-wrap gap-2 priorities-container" data-role-id="@role.Id">
                             @for (var i = 0; i < role.SlotCount; i++)
                             {
-                                var currentPriority = i < role.Slots.Count ? role.Slots[i].Priority : "None";
+                                var currentPriority = i < role.Slots.Count ? role.Slots[i].Priority.ToString() : "None";
                                 <div class="input-group input-group-sm" style="max-width: 200px;">
                                     <span class="input-group-text">@(i + 1)</span>
                                     <select name="Priorities" class="form-select form-select-sm">
@@ -147,7 +147,7 @@
                         {
                             <tr>
                                 <td>@(slot.SlotIndex + 1)</td>
-                                <td><span class="badge @slot.PriorityBadgeClass">@(slot.Priority == "NiceToHave" ? "Nice to Have" : slot.Priority)</span></td>
+                                <td><span class="badge @slot.PriorityBadgeClass">@(slot.Priority == SlotPriority.NiceToHave ? "Nice to Have" : slot.Priority.ToString())</span></td>
                                 <td>
                                     @if (slot.IsFilled)
                                     {


### PR DESCRIPTION
## Summary
- Replaced ~50 sites across 31 files where domain enums were `.ToString()`'d into string ViewModel properties
- 10 ViewModels updated: `ApplicationStatus`, `MembershipStatus`, `AuditAction`, `TeamMemberRole`, `SlotPriority`, `RolePeriod`, `TeamJoinRequestStatus`, `SystemTeamType`, `GoogleSyncSource`, `MembershipTier`
- 10 controllers cleaned of `.ToString()` calls
- `StatusBadgeExtensions` and `AuditLogUiExtensions` rewritten to accept enums directly
- 8 views updated from string comparisons to enum comparisons
- JSON API controllers intentionally kept as strings (no global `JsonStringEnumConverter`)

## Test plan
- [ ] Navigate to application listing — verify status badges render correctly
- [ ] Navigate to admin audit log — verify action labels and icons display
- [ ] Navigate to team roster — verify role/priority/period display
- [ ] Navigate to profile — verify membership status badge
- [ ] Navigate to governance — verify application status display
- [ ] Build passes with zero warnings

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)