### PR TITLE
Section help pages: Guide, Glossary, and Access Matrix tabs

### DIFF
--- a/src/Humans.Web/Extensions/HtmlHelperExtensions.cs
+++ b/src/Humans.Web/Extensions/HtmlHelperExtensions.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using System.Text.Encodings.Web;
 using Ganss.Xss;
+using Markdig;
 using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Mvc.Rendering;
 
@@ -26,7 +27,10 @@ public static class HtmlHelperExtensions
             return HtmlString.Empty;
         }
 
-        var rendered = Markdig.Markdown.ToHtml(markdown);
+        var pipeline = new MarkdownPipelineBuilder()
+            .UseAdvancedExtensions()
+            .Build();
+        var rendered = Markdown.ToHtml(markdown, pipeline);
         var sanitized = new HtmlSanitizer().Sanitize(rendered);
         return new HtmlString(sanitized);
     }

--- a/src/Humans.Web/Models/AccessMatrixDefinitions.cs
+++ b/src/Humans.Web/Models/AccessMatrixDefinitions.cs
@@ -118,6 +118,36 @@ public static class AccessMatrixDefinitions
                 Feature("Discount codes", "Board", D, "TicketAdmin", A),
             ]
         },
+
+        ["Profile"] = new AccessMatrixData
+        {
+            SectionName = "Profile",
+            Roles = ["Volunteer", "Coordinator", "Board", "Admin"],
+            Features =
+            [
+                Feature("View own profile", "Volunteer", A, "Coordinator", A, "Board", A, "Admin", A),
+                Feature("Edit own profile", "Volunteer", A, "Coordinator", A, "Board", A, "Admin", A),
+                Feature("View other profiles", "Volunteer", L, "Coordinator", A, "Board", A, "Admin", A),
+                Feature("View contact fields", "Volunteer", L, "Coordinator", L, "Board", A, "Admin", A),
+                Feature("Admin view of profile", "Volunteer", D, "Coordinator", D, "Board", A, "Admin", A),
+            ]
+        },
+
+        ["Admin"] = new AccessMatrixData
+        {
+            SectionName = "Admin Tools",
+            Roles = ["Admin"],
+            Features =
+            [
+                Feature("Configuration status", "Admin", A),
+                Feature("Sync settings", "Admin", A),
+                Feature("Email outbox", "Admin", A),
+                Feature("Background jobs", "Admin", A),
+                Feature("All humans list", "Admin", A),
+                Feature("Role assignments", "Admin", A),
+                Feature("Legal documents", "Admin", A),
+            ]
+        },
     };
 
     // Shorthand aliases for readability

--- a/src/Humans.Web/Models/AccessMatrixDefinitions.cs
+++ b/src/Humans.Web/Models/AccessMatrixDefinitions.cs
@@ -57,7 +57,7 @@ public static class AccessMatrixDefinitions
 
         ["Camps"] = new AccessMatrixData
         {
-            SectionName = "Camps",
+            SectionName = "Barrios",
             Roles = ["Volunteer", "Camp Lead", "CampAdmin"],
             Features =
             [

--- a/src/Humans.Web/Models/SectionHelpContent.cs
+++ b/src/Humans.Web/Models/SectionHelpContent.cs
@@ -1,0 +1,394 @@
+namespace Humans.Web.Models;
+
+/// <summary>
+/// Hardcoded markdown content for section help pages (Guide, Glossary).
+/// Content is updated via code releases — no admin editing.
+/// </summary>
+public static class SectionHelpContent
+{
+    public static string? GetGuide(string section) =>
+        Guides.GetValueOrDefault(section);
+
+    public static string? GetGlossary(string section) =>
+        Glossaries.GetValueOrDefault(section);
+
+    private static readonly Dictionary<string, string> Guides = new(StringComparer.Ordinal)
+    {
+        ["Teams"] = """
+            ## How Teams Work
+
+            Teams are how Nobodies Collective organises humans around shared interests and responsibilities. Every active human can browse teams and request to join.
+
+            ### Joining a Team
+
+            1. Browse the **Teams** page to see all available teams
+            2. Click on a team to view its details and current members
+            3. Click **Join** to become a member
+            4. Some teams are managed — a coordinator may review your request
+
+            ### Team Roles
+
+            - **Member** — standard team participant
+            - **Coordinator** — manages the team, can add/remove members and assign roles
+
+            ### What Happens Automatically
+
+            - When you join a team that has a **Google Group**, you are automatically added to that group
+            - When you leave a team, you are automatically removed from the linked Google Group
+            - When you join a team that has a **Shared Drive**, you are granted access automatically
+            - Team changes sync to Google resources hourly via the background sync job
+
+            ### Searching for Humans
+
+            Use the **Search** button to find humans across all teams by name or email. The **Roster** view shows all active humans in a flat list. The **Map** shows humans by location. **Birthdays** shows upcoming celebrations.
+            """,
+
+        ["Profile"] = """
+            ## Your Profile
+
+            Your profile is how other humans in the collective see you. Keep it up to date so people can find and contact you.
+
+            ### Completing Your Profile
+
+            1. Add your **display name** — this is how you appear across the system
+            2. Upload a **photo** so humans can recognise you
+            3. Set your **birthday** (month and day) — the collective celebrates birthdays together
+            4. Add **contact fields** (phone, social media, etc.) with visibility controls
+
+            ### Contact Visibility
+
+            Each contact field has a visibility level that controls who can see it:
+
+            - **All active humans** — visible to every active member
+            - **My teams** — visible only to humans on the same teams as you
+            - **Coordinators & Board** — visible only to team coordinators and the Board
+            - **Board only** — visible only to Board members
+
+            ### What Happens Automatically
+
+            - When your profile is complete and consents are signed, you become an **active human**
+            - Active humans are added to the **Volunteers** team automatically
+            - Your Google Workspace access is provisioned based on your team memberships
+            """,
+
+        ["Admin"] = """
+            ## Admin Tools
+
+            The Admin section provides system-wide management tools for administrators.
+
+            ### System Operations
+
+            - **Configuration Status** — view current system configuration and environment settings
+            - **Sync Settings** — control Google sync behaviour per service (None / Add Only / Add and Remove)
+            - **Email Outbox** — view and manage outbound emails
+            - **Background Jobs** — monitor Hangfire job status and history
+
+            ### Human Management
+
+            - **All Humans** — browse and search all registered humans
+            - **Role Assignments** — manage governance and system role assignments with temporal tracking
+            - **Legal Documents** — manage consent documents and their versions
+
+            ### Google Integration
+
+            - **System Team Sync** — runs hourly, syncs team memberships to Google Groups and Shared Drives
+            - **Reconciliation** — runs daily at 03:00, detects drift between expected and actual Google permissions
+
+            ### What Happens Automatically
+
+            - Hourly sync keeps Google Groups and Drive permissions in sync with team memberships
+            - Daily reconciliation reports any permission drift for manual review
+            - Email notifications are sent for role assignment changes
+            """,
+
+        ["Shifts"] = """
+            ## How Shifts Work
+
+            Shifts are time slots that need to be staffed during events. Humans can browse available shifts, sign up, and manage their availability.
+
+            ### Signing Up for Shifts
+
+            1. Browse available shifts on the **Shifts** page
+            2. Filter by date, department, or shift type to find what suits you
+            3. Click on a shift to see details and sign up
+            4. Some shifts require coordinator approval before your signup is confirmed
+
+            ### Managing Your Shifts
+
+            - Use **My Shifts** to see everything you have signed up for
+            - You can withdraw from a shift before it starts (unless the coordinator has locked signups)
+
+            ### Shift Phases
+
+            Shifts are grouped by event phase:
+
+            - **Set-up** — before the event, building and preparing
+            - **Event** — during the event itself
+            - **Strike** — after the event, teardown and cleanup
+
+            ### For Coordinators
+
+            - Create and manage **rotas** (recurring shift patterns)
+            - Approve or refuse signups for your department
+            - **Voluntell** — directly assign a human to a shift
+            - View the **Staffing Dashboard** for an overview of coverage
+
+            ### What Happens Automatically
+
+            - Confirmation emails are sent when your signup is approved
+            - Reminder notifications are sent before your shift starts
+            """,
+
+        ["Camps"] = """
+            ## How Camps Work
+
+            Camps are themed villages or spaces at events. Any human can register a camp, and camp admins approve them for the event.
+
+            ### Registering a Camp
+
+            1. Go to the **Camps** page
+            2. Click **Register a Camp**
+            3. Fill in camp details: name, description, theme, requirements
+            4. Submit for review — a camp admin will approve or request changes
+
+            ### Camp Lifecycle
+
+            1. **Draft** — you are building your camp registration
+            2. **Submitted** — awaiting admin review
+            3. **Approved** — your camp is confirmed for the event
+            4. **Rejected** — admin has declined (with feedback)
+
+            ### Camp Leads
+
+            The human who registers a camp becomes the **Camp Lead**. Camp leads can:
+
+            - Edit their camp details
+            - Manage camp members and roles
+            - Update camp status and requirements
+
+            ### What Happens Automatically
+
+            - Camp admins are notified when new camps are submitted for review
+            - Camp leads are notified when their camp is approved or rejected
+            """,
+
+        ["Governance"] = """
+            ## Governance & Tiers
+
+            Nobodies Collective has a tiered membership structure defined in the estatutos (bylaws). All humans start as **Volunteers**. Those who want more involvement can apply for higher tiers.
+
+            ### Membership Tiers
+
+            - **Volunteer** — the standard member. Can participate in teams, shifts, and camps
+            - **Colaborador** — active contributor with project/event responsibilities. 2-year term
+            - **Asociado** — voting member with governance rights (assemblies, elections). 2-year term
+
+            ### Applying for a Tier
+
+            1. Go to the **Governance** page
+            2. Review the estatutos to understand the responsibilities
+            3. Click **Apply** and select the tier you want
+            4. The Board reviews your application and votes
+            5. You are notified of the outcome
+
+            ### What Happens Automatically
+
+            - The Board is notified when a new tier application is submitted
+            - You receive a notification when the Board votes on your application
+            - Tier assignments expire after 2 years — you can reapply
+            """,
+
+        ["OnboardingReview"] = """
+            ## Onboarding Review
+
+            The onboarding review queue shows new humans who have signed up and need their consent documents reviewed before becoming active.
+
+            ### Review Process
+
+            1. New humans sign up, complete their profile, and consent to legal documents
+            2. A **Consent Coordinator** reviews the consent submissions
+            3. If everything is in order, the coordinator **clears** the human
+            4. The human automatically becomes active and is added to the Volunteers team
+
+            ### Flags and Rejections
+
+            - **Flag** — mark a signup for further review (e.g., incomplete information)
+            - **Reject** — decline a signup (with reason)
+
+            ### What Happens Automatically
+
+            - Cleared humans are automatically added to the Volunteers team
+            - Google Workspace access is provisioned for newly active humans
+            - The review queue badge in the nav updates in real-time
+            """,
+
+        ["Board"] = """
+            ## Board Dashboard
+
+            The Board dashboard provides an overview of the collective's membership and governance status.
+
+            ### Available Tools
+
+            - **Dashboard & stats** — membership counts, recent activity, growth trends
+            - **Audit log** — chronological record of all significant system actions
+            - **Member data export** — GDPR-compliant data export for individual humans
+
+            ### What Happens Automatically
+
+            - Dashboard stats refresh on each page load
+            - Audit log entries are created automatically for role changes, team changes, and consent events
+            """,
+
+        ["Tickets"] = """
+            ## Tickets
+
+            The tickets section manages event ticket sales integration with external ticket vendors.
+
+            ### Key Functions
+
+            - **View tickets & orders** — browse all ticket orders synced from the vendor
+            - **Sync operations** — trigger manual sync or view sync history
+            - **Discount codes** — manage promotional codes for ticket sales
+
+            ### What Happens Automatically
+
+            - Ticket data syncs from the vendor on a regular schedule
+            - Order status updates are reflected automatically
+            """,
+    };
+
+    private static readonly Dictionary<string, string> Glossaries = new(StringComparer.Ordinal)
+    {
+        ["Teams"] = """
+            ## Teams Glossary
+
+            | Term | Definition |
+            |------|-----------|
+            | **Human** | A member of Nobodies Collective. We say "humans", not "members" or "volunteers". |
+            | **Team** | A group of humans organised around a shared purpose or responsibility. |
+            | **Coordinator** | A human who manages a team — can add/remove members and assign roles. |
+            | **TeamsAdmin** | A system role that can create/delete teams and manage all team settings. |
+            | **Google Group** | An email distribution list linked to a team. Membership syncs automatically. |
+            | **Shared Drive** | A Google Drive folder linked to a team. Access syncs automatically. |
+            | **Roster** | A flat list of all active humans across all teams. |
+            | **System Team Sync** | The hourly background job that syncs team memberships to Google resources. |
+            """,
+
+        ["Profile"] = """
+            ## Profile Glossary
+
+            | Term | Definition |
+            |------|-----------|
+            | **Human** | A member of Nobodies Collective. We say "humans", not "members" or "volunteers". |
+            | **Display Name** | The name shown to other humans across the system. |
+            | **Birthday** | Month and day only (no year). Used for birthday celebrations. |
+            | **Contact Field** | A piece of contact information (phone, email, social media link) with visibility controls. |
+            | **Visibility** | Controls who can see a contact field: all humans, team members, coordinators, or Board only. |
+            | **Active Human** | A human who has completed their profile and signed all required consent documents. |
+            | **Consent** | Legal document agreement required for data processing (GDPR compliance). |
+            """,
+
+        ["Admin"] = """
+            ## Admin Glossary
+
+            | Term | Definition |
+            |------|-----------|
+            | **Human** | A member of Nobodies Collective. We say "humans", not "members" or "volunteers". |
+            | **Role Assignment** | A time-bound assignment of a governance or system role to a human. |
+            | **Sync Settings** | Per-service controls for Google sync: None, Add Only, or Add and Remove. |
+            | **Reconciliation** | Daily job that compares expected vs actual Google permissions and reports drift. |
+            | **Drift** | A discrepancy between what the system expects and what Google actually has. |
+            | **Legal Document** | A consent document (e.g., privacy policy) that humans must agree to. |
+            | **Document Version** | A specific revision of a legal document. New versions require re-consent. |
+            | **Audit Log** | An append-only record of significant system actions for accountability. |
+            | **Hangfire** | The background job processing system used for scheduled and recurring tasks. |
+            """,
+
+        ["Shifts"] = """
+            ## Shifts Glossary
+
+            | Term | Definition |
+            |------|-----------|
+            | **Human** | A member of Nobodies Collective. We say "humans", not "members" or "volunteers". |
+            | **Shift** | A time slot that needs to be staffed during an event. |
+            | **Rota** | A recurring pattern of shifts for a department or area. |
+            | **Signup** | A human's request to work a specific shift. May require approval. |
+            | **Voluntell** | When a coordinator directly assigns a human to a shift (no signup needed). |
+            | **Set-up (Build)** | The event phase before the event — building and preparing. |
+            | **Event** | The main event phase. |
+            | **Strike** | The post-event phase — teardown and cleanup. |
+            | **Staffing Dashboard** | An overview of shift coverage for coordinators and admins. |
+            | **NoInfoAdmin** | A shift admin role with access to shift management and the staffing dashboard. |
+            | **VolunteerCoordinator** | A role that manages volunteer assignments and shift staffing across departments. |
+            """,
+
+        ["Camps"] = """
+            ## Camps Glossary
+
+            | Term | Definition |
+            |------|-----------|
+            | **Human** | A member of Nobodies Collective. We say "humans", not "members" or "volunteers". |
+            | **Camp** | A themed village or space at an event. |
+            | **Camp Lead** | The human who registered the camp and manages it. |
+            | **CampAdmin** | A system role that can approve, reject, and manage all camps. |
+            | **Draft** | A camp registration that is still being prepared. |
+            | **Submitted** | A camp registration awaiting admin review. |
+            | **Approved** | A camp that has been confirmed for the event. |
+            | **Rejected** | A camp that has been declined by an admin. |
+            """,
+
+        ["Governance"] = """
+            ## Governance Glossary
+
+            | Term | Definition |
+            |------|-----------|
+            | **Human** | A member of Nobodies Collective. We say "humans", not "members" or "volunteers". |
+            | **Volunteer** | The standard membership tier. ~100% of humans. Auto-approved after onboarding. |
+            | **Colaborador** | Active contributor tier with project/event responsibilities. 2-year term. Requires Board vote. |
+            | **Asociado** | Voting member tier with governance rights (assemblies, elections). 2-year term. Requires Board vote. |
+            | **Estatutos** | The bylaws of Nobodies Collective, defining governance structure and membership tiers. |
+            | **Board** | The governing body that votes on tier applications and manages the collective. |
+            | **Application** | A formal request to move to a higher membership tier (Colaborador or Asociado). |
+            | **Board Vote** | The Board's decision on a tier application — approve or reject. |
+            """,
+
+        ["OnboardingReview"] = """
+            ## Onboarding Review Glossary
+
+            | Term | Definition |
+            |------|-----------|
+            | **Human** | A member of Nobodies Collective. We say "humans", not "members" or "volunteers". |
+            | **Onboarding** | The process a new human goes through: signup, profile, consent, review, activation. |
+            | **Consent Coordinator** | A role that reviews consent documents submitted by new humans. |
+            | **Clear** | Approving a new human's consent review, making them eligible for activation. |
+            | **Flag** | Marking a signup for additional review or follow-up. |
+            | **Active** | A human who has passed onboarding review and is a full participant. |
+            | **Volunteers Team** | The default team all active humans are added to automatically. |
+            """,
+
+        ["Board"] = """
+            ## Board Dashboard Glossary
+
+            | Term | Definition |
+            |------|-----------|
+            | **Human** | A member of Nobodies Collective. We say "humans", not "members" or "volunteers". |
+            | **Board** | The governing body of Nobodies Collective. |
+            | **Audit Log** | An append-only record of significant system actions for accountability and compliance. |
+            | **Data Export** | A GDPR-compliant export of a specific human's data. |
+            | **GDPR** | General Data Protection Regulation — EU data protection law that governs how member data is handled. |
+            """,
+
+        ["Tickets"] = """
+            ## Tickets Glossary
+
+            | Term | Definition |
+            |------|-----------|
+            | **Human** | A member of Nobodies Collective. We say "humans", not "members" or "volunteers". |
+            | **Ticket Vendor** | The external service that handles ticket sales (e.g., Pretix). |
+            | **Order** | A ticket purchase from the vendor, linked to a human where possible. |
+            | **Sync** | The process of pulling ticket data from the vendor into the system. |
+            | **Discount Code** | A promotional code that provides a discount on ticket purchases. |
+            | **TicketAdmin** | A role with access to ticket management, sync operations, and discount codes. |
+            """,
+    };
+}

--- a/src/Humans.Web/Models/SectionHelpContent.cs
+++ b/src/Humans.Web/Models/SectionHelpContent.cs
@@ -140,36 +140,36 @@ public static class SectionHelpContent
             """,
 
         ["Camps"] = """
-            ## How Camps Work
+            ## How Barrios Work
 
-            Camps are themed villages or spaces at events. Any human can register a camp, and camp admins approve them for the event.
+            Barrios are themed villages or spaces at events. Any human can register a barrio, and barrio admins approve them for the event.
 
-            ### Registering a Camp
+            ### Registering a Barrio
 
-            1. Go to the **Camps** page
-            2. Click **Register a Camp**
-            3. Fill in camp details: name, description, theme, requirements
-            4. Submit for review — a camp admin will approve or request changes
+            1. Go to the **Barrios** page
+            2. Click **Register a Barrio**
+            3. Fill in barrio details: name, description, theme, requirements
+            4. Submit for review — a barrio admin will approve or request changes
 
-            ### Camp Lifecycle
+            ### Barrio Lifecycle
 
-            1. **Draft** — you are building your camp registration
+            1. **Draft** — you are building your barrio registration
             2. **Submitted** — awaiting admin review
-            3. **Approved** — your camp is confirmed for the event
+            3. **Approved** — your barrio is confirmed for the event
             4. **Rejected** — admin has declined (with feedback)
 
-            ### Camp Leads
+            ### Barrio Leads
 
-            The human who registers a camp becomes the **Camp Lead**. Camp leads can:
+            The human who registers a barrio becomes the **Barrio Lead**. Barrio leads can:
 
-            - Edit their camp details
-            - Manage camp members and roles
-            - Update camp status and requirements
+            - Edit their barrio details
+            - Manage barrio members and roles
+            - Update barrio status and requirements
 
             ### What Happens Automatically
 
-            - Camp admins are notified when new camps are submitted for review
-            - Camp leads are notified when their camp is approved or rejected
+            - Barrio admins are notified when new barrios are submitted for review
+            - Barrio leads are notified when their barrio is approved or rejected
             """,
 
         ["Governance"] = """
@@ -260,135 +260,135 @@ public static class SectionHelpContent
     private static readonly Dictionary<string, string> Glossaries = new(StringComparer.Ordinal)
     {
         ["Teams"] = """
-            ## Teams Glossary
+## Teams Glossary
 
-            | Term | Definition |
-            |------|-----------|
-            | **Human** | A member of Nobodies Collective. We say "humans", not "members" or "volunteers". |
-            | **Team** | A group of humans organised around a shared purpose or responsibility. |
-            | **Coordinator** | A human who manages a team — can add/remove members and assign roles. |
-            | **TeamsAdmin** | A system role that can create/delete teams and manage all team settings. |
-            | **Google Group** | An email distribution list linked to a team. Membership syncs automatically. |
-            | **Shared Drive** | A Google Drive folder linked to a team. Access syncs automatically. |
-            | **Roster** | A flat list of all active humans across all teams. |
-            | **System Team Sync** | The hourly background job that syncs team memberships to Google resources. |
-            """,
+| Term | Definition |
+|------|-----------|
+| **Human** | A member of Nobodies Collective. We say "humans", not "members" or "volunteers". |
+| **Team** | A group of humans organised around a shared purpose or responsibility. |
+| **Coordinator** | A human who manages a team — can add/remove members and assign roles. |
+| **TeamsAdmin** | A system role that can create/delete teams and manage all team settings. |
+| **Google Group** | An email distribution list linked to a team. Membership syncs automatically. |
+| **Shared Drive** | A Google Drive folder linked to a team. Access syncs automatically. |
+| **Roster** | A flat list of all active humans across all teams. |
+| **System Team Sync** | The hourly background job that syncs team memberships to Google resources. |
+""",
 
         ["Profile"] = """
-            ## Profile Glossary
+## Profile Glossary
 
-            | Term | Definition |
-            |------|-----------|
-            | **Human** | A member of Nobodies Collective. We say "humans", not "members" or "volunteers". |
-            | **Display Name** | The name shown to other humans across the system. |
-            | **Birthday** | Month and day only (no year). Used for birthday celebrations. |
-            | **Contact Field** | A piece of contact information (phone, email, social media link) with visibility controls. |
-            | **Visibility** | Controls who can see a contact field: all humans, team members, coordinators, or Board only. |
-            | **Active Human** | A human who has completed their profile and signed all required consent documents. |
-            | **Consent** | Legal document agreement required for data processing (GDPR compliance). |
-            """,
+| Term | Definition |
+|------|-----------|
+| **Human** | A member of Nobodies Collective. We say "humans", not "members" or "volunteers". |
+| **Display Name** | The name shown to other humans across the system. |
+| **Birthday** | Month and day only (no year). Used for birthday celebrations. |
+| **Contact Field** | A piece of contact information (phone, email, social media link) with visibility controls. |
+| **Visibility** | Controls who can see a contact field: all humans, team members, coordinators, or Board only. |
+| **Active Human** | A human who has completed their profile and signed all required consent documents. |
+| **Consent** | Legal document agreement required for data processing (GDPR compliance). |
+""",
 
         ["Admin"] = """
-            ## Admin Glossary
+## Admin Glossary
 
-            | Term | Definition |
-            |------|-----------|
-            | **Human** | A member of Nobodies Collective. We say "humans", not "members" or "volunteers". |
-            | **Role Assignment** | A time-bound assignment of a governance or system role to a human. |
-            | **Sync Settings** | Per-service controls for Google sync: None, Add Only, or Add and Remove. |
-            | **Reconciliation** | Daily job that compares expected vs actual Google permissions and reports drift. |
-            | **Drift** | A discrepancy between what the system expects and what Google actually has. |
-            | **Legal Document** | A consent document (e.g., privacy policy) that humans must agree to. |
-            | **Document Version** | A specific revision of a legal document. New versions require re-consent. |
-            | **Audit Log** | An append-only record of significant system actions for accountability. |
-            | **Hangfire** | The background job processing system used for scheduled and recurring tasks. |
-            """,
+| Term | Definition |
+|------|-----------|
+| **Human** | A member of Nobodies Collective. We say "humans", not "members" or "volunteers". |
+| **Role Assignment** | A time-bound assignment of a governance or system role to a human. |
+| **Sync Settings** | Per-service controls for Google sync: None, Add Only, or Add and Remove. |
+| **Reconciliation** | Daily job that compares expected vs actual Google permissions and reports drift. |
+| **Drift** | A discrepancy between what the system expects and what Google actually has. |
+| **Legal Document** | A consent document (e.g., privacy policy) that humans must agree to. |
+| **Document Version** | A specific revision of a legal document. New versions require re-consent. |
+| **Audit Log** | An append-only record of significant system actions for accountability. |
+| **Hangfire** | The background job processing system used for scheduled and recurring tasks. |
+""",
 
         ["Shifts"] = """
-            ## Shifts Glossary
+## Shifts Glossary
 
-            | Term | Definition |
-            |------|-----------|
-            | **Human** | A member of Nobodies Collective. We say "humans", not "members" or "volunteers". |
-            | **Shift** | A time slot that needs to be staffed during an event. |
-            | **Rota** | A recurring pattern of shifts for a department or area. |
-            | **Signup** | A human's request to work a specific shift. May require approval. |
-            | **Voluntell** | When a coordinator directly assigns a human to a shift (no signup needed). |
-            | **Set-up (Build)** | The event phase before the event — building and preparing. |
-            | **Event** | The main event phase. |
-            | **Strike** | The post-event phase — teardown and cleanup. |
-            | **Staffing Dashboard** | An overview of shift coverage for coordinators and admins. |
-            | **NoInfoAdmin** | A shift admin role with access to shift management and the staffing dashboard. |
-            | **VolunteerCoordinator** | A role that manages volunteer assignments and shift staffing across departments. |
-            """,
+| Term | Definition |
+|------|-----------|
+| **Human** | A member of Nobodies Collective. We say "humans", not "members" or "volunteers". |
+| **Shift** | A time slot that needs to be staffed during an event. |
+| **Rota** | A recurring pattern of shifts for a department or area. |
+| **Signup** | A human's request to work a specific shift. May require approval. |
+| **Voluntell** | When a coordinator directly assigns a human to a shift (no signup needed). |
+| **Set-up (Build)** | The event phase before the event — building and preparing. |
+| **Event** | The main event phase. |
+| **Strike** | The post-event phase — teardown and cleanup. |
+| **Staffing Dashboard** | An overview of shift coverage for coordinators and admins. |
+| **NoInfoAdmin** | A shift admin role with access to shift management and the staffing dashboard. |
+| **VolunteerCoordinator** | A role that manages volunteer assignments and shift staffing across departments. |
+""",
 
         ["Camps"] = """
-            ## Camps Glossary
+## Barrios Glossary
 
-            | Term | Definition |
-            |------|-----------|
-            | **Human** | A member of Nobodies Collective. We say "humans", not "members" or "volunteers". |
-            | **Camp** | A themed village or space at an event. |
-            | **Camp Lead** | The human who registered the camp and manages it. |
-            | **CampAdmin** | A system role that can approve, reject, and manage all camps. |
-            | **Draft** | A camp registration that is still being prepared. |
-            | **Submitted** | A camp registration awaiting admin review. |
-            | **Approved** | A camp that has been confirmed for the event. |
-            | **Rejected** | A camp that has been declined by an admin. |
-            """,
+| Term | Definition |
+|------|-----------|
+| **Human** | A member of Nobodies Collective. We say "humans", not "members" or "volunteers". |
+| **Barrio** | A themed village or space at an event. |
+| **Barrio Lead** | The human who registered the barrio and manages it. |
+| **CampAdmin** | A system role that can approve, reject, and manage all barrios. |
+| **Draft** | A barrio registration that is still being prepared. |
+| **Submitted** | A barrio registration awaiting admin review. |
+| **Approved** | A barrio that has been confirmed for the event. |
+| **Rejected** | A barrio that has been declined by an admin. |
+""",
 
         ["Governance"] = """
-            ## Governance Glossary
+## Governance Glossary
 
-            | Term | Definition |
-            |------|-----------|
-            | **Human** | A member of Nobodies Collective. We say "humans", not "members" or "volunteers". |
-            | **Volunteer** | The standard membership tier. ~100% of humans. Auto-approved after onboarding. |
-            | **Colaborador** | Active contributor tier with project/event responsibilities. 2-year term. Requires Board vote. |
-            | **Asociado** | Voting member tier with governance rights (assemblies, elections). 2-year term. Requires Board vote. |
-            | **Estatutos** | The bylaws of Nobodies Collective, defining governance structure and membership tiers. |
-            | **Board** | The governing body that votes on tier applications and manages the collective. |
-            | **Application** | A formal request to move to a higher membership tier (Colaborador or Asociado). |
-            | **Board Vote** | The Board's decision on a tier application — approve or reject. |
-            """,
+| Term | Definition |
+|------|-----------|
+| **Human** | A member of Nobodies Collective. We say "humans", not "members" or "volunteers". |
+| **Volunteer** | The standard membership tier. ~100% of humans. Auto-approved after onboarding. |
+| **Colaborador** | Active contributor tier with project/event responsibilities. 2-year term. Requires Board vote. |
+| **Asociado** | Voting member tier with governance rights (assemblies, elections). 2-year term. Requires Board vote. |
+| **Estatutos** | The bylaws of Nobodies Collective, defining governance structure and membership tiers. |
+| **Board** | The governing body that votes on tier applications and manages the collective. |
+| **Application** | A formal request to move to a higher membership tier (Colaborador or Asociado). |
+| **Board Vote** | The Board's decision on a tier application — approve or reject. |
+""",
 
         ["OnboardingReview"] = """
-            ## Onboarding Review Glossary
+## Onboarding Review Glossary
 
-            | Term | Definition |
-            |------|-----------|
-            | **Human** | A member of Nobodies Collective. We say "humans", not "members" or "volunteers". |
-            | **Onboarding** | The process a new human goes through: signup, profile, consent, review, activation. |
-            | **Consent Coordinator** | A role that reviews consent documents submitted by new humans. |
-            | **Clear** | Approving a new human's consent review, making them eligible for activation. |
-            | **Flag** | Marking a signup for additional review or follow-up. |
-            | **Active** | A human who has passed onboarding review and is a full participant. |
-            | **Volunteers Team** | The default team all active humans are added to automatically. |
-            """,
+| Term | Definition |
+|------|-----------|
+| **Human** | A member of Nobodies Collective. We say "humans", not "members" or "volunteers". |
+| **Onboarding** | The process a new human goes through: signup, profile, consent, review, activation. |
+| **Consent Coordinator** | A role that reviews consent documents submitted by new humans. |
+| **Clear** | Approving a new human's consent review, making them eligible for activation. |
+| **Flag** | Marking a signup for additional review or follow-up. |
+| **Active** | A human who has passed onboarding review and is a full participant. |
+| **Volunteers Team** | The default team all active humans are added to automatically. |
+""",
 
         ["Board"] = """
-            ## Board Dashboard Glossary
+## Board Dashboard Glossary
 
-            | Term | Definition |
-            |------|-----------|
-            | **Human** | A member of Nobodies Collective. We say "humans", not "members" or "volunteers". |
-            | **Board** | The governing body of Nobodies Collective. |
-            | **Audit Log** | An append-only record of significant system actions for accountability and compliance. |
-            | **Data Export** | A GDPR-compliant export of a specific human's data. |
-            | **GDPR** | General Data Protection Regulation — EU data protection law that governs how member data is handled. |
-            """,
+| Term | Definition |
+|------|-----------|
+| **Human** | A member of Nobodies Collective. We say "humans", not "members" or "volunteers". |
+| **Board** | The governing body of Nobodies Collective. |
+| **Audit Log** | An append-only record of significant system actions for accountability and compliance. |
+| **Data Export** | A GDPR-compliant export of a specific human's data. |
+| **GDPR** | General Data Protection Regulation — EU data protection law that governs how member data is handled. |
+""",
 
         ["Tickets"] = """
-            ## Tickets Glossary
+## Tickets Glossary
 
-            | Term | Definition |
-            |------|-----------|
-            | **Human** | A member of Nobodies Collective. We say "humans", not "members" or "volunteers". |
-            | **Ticket Vendor** | The external service that handles ticket sales (e.g., Pretix). |
-            | **Order** | A ticket purchase from the vendor, linked to a human where possible. |
-            | **Sync** | The process of pulling ticket data from the vendor into the system. |
-            | **Discount Code** | A promotional code that provides a discount on ticket purchases. |
-            | **TicketAdmin** | A role with access to ticket management, sync operations, and discount codes. |
-            """,
+| Term | Definition |
+|------|-----------|
+| **Human** | A member of Nobodies Collective. We say "humans", not "members" or "volunteers". |
+| **Ticket Vendor** | The external service that handles ticket sales (e.g., Pretix). |
+| **Order** | A ticket purchase from the vendor, linked to a human where possible. |
+| **Sync** | The process of pulling ticket data from the vendor into the system. |
+| **Discount Code** | A promotional code that provides a discount on ticket purchases. |
+| **TicketAdmin** | A role with access to ticket management, sync operations, and discount codes. |
+""",
     };
 }

--- a/src/Humans.Web/Models/SectionHelpViewModel.cs
+++ b/src/Humans.Web/Models/SectionHelpViewModel.cs
@@ -1,0 +1,10 @@
+namespace Humans.Web.Models;
+
+public class SectionHelpViewModel
+{
+    public required string SectionKey { get; init; }
+    public required string SectionName { get; init; }
+    public string? GuideMarkdown { get; init; }
+    public string? GlossaryMarkdown { get; init; }
+    public AccessMatrixData? AccessMatrix { get; init; }
+}

--- a/src/Humans.Web/ViewComponents/AccessMatrixViewComponent.cs
+++ b/src/Humans.Web/ViewComponents/AccessMatrixViewComponent.cs
@@ -7,9 +7,24 @@ public class AccessMatrixViewComponent : ViewComponent
 {
     public IViewComponentResult Invoke(string section)
     {
-        if (!AccessMatrixDefinitions.Sections.TryGetValue(section, out var data))
+        AccessMatrixDefinitions.Sections.TryGetValue(section, out var accessMatrix);
+
+        var guide = SectionHelpContent.GetGuide(section);
+        var glossary = SectionHelpContent.GetGlossary(section);
+
+        // If no content at all, render nothing
+        if (accessMatrix is null && guide is null && glossary is null)
             return Content(string.Empty);
 
-        return View(data);
+        var model = new SectionHelpViewModel
+        {
+            SectionKey = section,
+            SectionName = accessMatrix?.SectionName ?? section,
+            GuideMarkdown = guide,
+            GlossaryMarkdown = glossary,
+            AccessMatrix = accessMatrix
+        };
+
+        return View(model);
     }
 }

--- a/src/Humans.Web/Views/Admin/Index.cshtml
+++ b/src/Humans.Web/Views/Admin/Index.cshtml
@@ -2,7 +2,10 @@
     ViewData["Title"] = "Admin Tools";
 }
 
-<h1>Admin Tools</h1>
+<div class="d-flex justify-content-between align-items-center mb-3">
+    <h1 class="mb-0">Admin Tools</h1>
+    <vc:access-matrix section="Admin" />
+</div>
 
 <vc:temp-data-alerts />
 

--- a/src/Humans.Web/Views/Profile/Index.cshtml
+++ b/src/Humans.Web/Views/Profile/Index.cshtml
@@ -7,12 +7,15 @@
     <div class="@(Model.IsOwnProfile ? "col-md-8" : "col-md-12")">
         <div class="d-flex justify-content-between align-items-center">
             <h1>@(Model.IsOwnProfile ? Localizer["Profile_Title"] : Model.DisplayName)</h1>
-            @if (Humans.Web.Authorization.RoleChecks.IsAdminOrBoard(User))
-            {
-                <a asp-controller="Human" asp-action="HumanDetail" asp-route-id="@Model.UserId" class="btn btn-sm btn-outline-secondary">
-                    <i class="fa-solid fa-user-shield"></i> Admin
-                </a>
-            }
+            <div class="d-flex gap-2">
+                <vc:access-matrix section="Profile" />
+                @if (Humans.Web.Authorization.RoleChecks.IsAdminOrBoard(User))
+                {
+                    <a asp-controller="Human" asp-action="HumanDetail" asp-route-id="@Model.UserId" class="btn btn-sm btn-outline-secondary">
+                        <i class="fa-solid fa-user-shield"></i> Admin
+                    </a>
+                }
+            </div>
         </div>
 
         @if (Model.IsOwnProfile)

--- a/src/Humans.Web/Views/Shared/Components/AccessMatrix/Default.cshtml
+++ b/src/Humans.Web/Views/Shared/Components/AccessMatrix/Default.cshtml
@@ -1,62 +1,207 @@
-@model Humans.Web.Models.AccessMatrixData
+@model Humans.Web.Models.SectionHelpViewModel
 @using Humans.Web.Models
+@using Humans.Web.Extensions
 
 @{
-    var modalId = "accessMatrix-" + Model.SectionName.Replace(" ", "");
-    var modalSize = Model.Roles.Count >= 3 ? "modal-lg" : "";
+    var modalId = "sectionHelp-" + Model.SectionKey.Replace(" ", "");
+    var hasGuide = !string.IsNullOrWhiteSpace(Model.GuideMarkdown);
+    var hasGlossary = !string.IsNullOrWhiteSpace(Model.GlossaryMarkdown);
+    var hasMatrix = Model.AccessMatrix is not null;
+    var tabCount = (hasGuide ? 1 : 0) + (hasGlossary ? 1 : 0) + (hasMatrix ? 1 : 0);
+    // Default to Guide tab (first available in order: Guide, Glossary, Access Matrix)
+    var defaultTab = hasGuide ? "guide" : hasGlossary ? "glossary" : "matrix";
 }
 
 <button type="button" class="btn btn-outline-secondary btn-sm" data-bs-toggle="modal" data-bs-target="#@modalId"
-        title="Access Matrix">
+        title="Section Help">
     <i class="fa-solid fa-circle-info"></i>
 </button>
 
 <div class="modal fade" id="@modalId" tabindex="-1" aria-labelledby="@(modalId)-label" aria-hidden="true">
-    <div class="modal-dialog @modalSize modal-dialog-centered">
+    <div class="modal-dialog modal-lg modal-dialog-centered modal-dialog-scrollable">
         <div class="modal-content" style="background-color: #faf5ef;">
-            <div class="modal-header border-0">
-                <h5 class="modal-title" id="@(modalId)-label" style="color: #5a3e2b;">Access Matrix</h5>
+            <div class="modal-header border-0 pb-0">
+                <h5 class="modal-title" id="@(modalId)-label" style="color: #5a3e2b;">
+                    @Model.SectionName
+                </h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
-            <div class="modal-body pt-0">
-                <table class="table table-sm mb-0">
-                    <thead>
-                        <tr>
-                            <th class="text-uppercase small text-muted" style="color: #5a3e2b !important;">Feature</th>
-                            @foreach (var role in Model.Roles)
-                            {
-                                <th class="text-center text-uppercase small text-muted" style="color: #5a3e2b !important;">@role</th>
-                            }
-                        </tr>
-                    </thead>
-                    <tbody>
-                        @foreach (var feature in Model.Features)
+            <div class="modal-body pt-2">
+                @if (tabCount > 1)
+                {
+                    <ul class="nav nav-pills section-help-pills mb-3" id="@(modalId)-tabs" role="tablist">
+                        @if (hasGuide)
                         {
-                            <tr>
-                                <td style="color: #3a2a1a;">@feature.Name</td>
-                                @foreach (var role in Model.Roles)
-                                {
-                                    var level = feature.RoleAccess.GetValueOrDefault(role, AccessLevel.Denied);
-                                    <td class="text-center">
-                                        @switch (level)
-                                        {
-                                            case AccessLevel.Allowed:
-                                                <i class="fa-solid fa-circle-check text-success"></i>
-                                                break;
-                                            case AccessLevel.Limited:
-                                                <i class="fa-solid fa-circle-half-stroke text-warning"></i>
-                                                break;
-                                            case AccessLevel.Denied:
-                                                <i class="fa-solid fa-lock text-muted"></i>
-                                                break;
-                                        }
-                                    </td>
-                                }
-                            </tr>
+                            <li class="nav-item" role="presentation">
+                                <button class="nav-link @(defaultTab == "guide" ? "active" : "")"
+                                        id="@(modalId)-guide-tab" data-bs-toggle="pill"
+                                        data-bs-target="#@(modalId)-guide" type="button" role="tab"
+                                        aria-controls="@(modalId)-guide"
+                                        aria-selected="@(defaultTab == "guide" ? "true" : "false")">
+                                    <i class="fa-solid fa-book-open me-1"></i> Guide
+                                </button>
+                            </li>
                         }
-                    </tbody>
-                </table>
+                        @if (hasGlossary)
+                        {
+                            <li class="nav-item" role="presentation">
+                                <button class="nav-link @(defaultTab == "glossary" ? "active" : "")"
+                                        id="@(modalId)-glossary-tab" data-bs-toggle="pill"
+                                        data-bs-target="#@(modalId)-glossary" type="button" role="tab"
+                                        aria-controls="@(modalId)-glossary"
+                                        aria-selected="@(defaultTab == "glossary" ? "true" : "false")">
+                                    <i class="fa-solid fa-spell-check me-1"></i> Glossary
+                                </button>
+                            </li>
+                        }
+                        @if (hasMatrix)
+                        {
+                            <li class="nav-item" role="presentation">
+                                <button class="nav-link @(defaultTab == "matrix" ? "active" : "")"
+                                        id="@(modalId)-matrix-tab" data-bs-toggle="pill"
+                                        data-bs-target="#@(modalId)-matrix" type="button" role="tab"
+                                        aria-controls="@(modalId)-matrix"
+                                        aria-selected="@(defaultTab == "matrix" ? "true" : "false")">
+                                    <i class="fa-solid fa-table-cells me-1"></i> Access Matrix
+                                </button>
+                            </li>
+                        }
+                    </ul>
+                }
+
+                <div class="tab-content" id="@(modalId)-content">
+                    @if (hasGuide)
+                    {
+                        <div class="tab-pane fade @(defaultTab == "guide" ? "show active" : "")"
+                             id="@(modalId)-guide" role="tabpanel" aria-labelledby="@(modalId)-guide-tab">
+                            <div class="section-help-content">
+                                @Html.SanitizedMarkdown(Model.GuideMarkdown)
+                            </div>
+                        </div>
+                    }
+                    @if (hasGlossary)
+                    {
+                        <div class="tab-pane fade @(defaultTab == "glossary" ? "show active" : "")"
+                             id="@(modalId)-glossary" role="tabpanel" aria-labelledby="@(modalId)-glossary-tab">
+                            <div class="section-help-content">
+                                @Html.SanitizedMarkdown(Model.GlossaryMarkdown)
+                            </div>
+                        </div>
+                    }
+                    @if (hasMatrix)
+                    {
+                        <div class="tab-pane fade @(defaultTab == "matrix" ? "show active" : "")"
+                             id="@(modalId)-matrix" role="tabpanel" aria-labelledby="@(modalId)-matrix-tab">
+                            <table class="table table-sm mb-0">
+                                <thead>
+                                    <tr>
+                                        <th class="text-uppercase small text-muted" style="color: #5a3e2b !important;">Feature</th>
+                                        @foreach (var role in Model.AccessMatrix!.Roles)
+                                        {
+                                            <th class="text-center text-uppercase small text-muted" style="color: #5a3e2b !important;">@role</th>
+                                        }
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    @foreach (var feature in Model.AccessMatrix.Features)
+                                    {
+                                        <tr>
+                                            <td style="color: #3a2a1a;">@feature.Name</td>
+                                            @foreach (var role in Model.AccessMatrix.Roles)
+                                            {
+                                                var level = feature.RoleAccess.GetValueOrDefault(role, AccessLevel.Denied);
+                                                <td class="text-center">
+                                                    @switch (level)
+                                                    {
+                                                        case AccessLevel.Allowed:
+                                                            <i class="fa-solid fa-circle-check text-success"></i>
+                                                            break;
+                                                        case AccessLevel.Limited:
+                                                            <i class="fa-solid fa-circle-half-stroke text-warning"></i>
+                                                            break;
+                                                        case AccessLevel.Denied:
+                                                            <i class="fa-solid fa-lock text-muted"></i>
+                                                            break;
+                                                    }
+                                                </td>
+                                            }
+                                        </tr>
+                                    }
+                                </tbody>
+                            </table>
+                        </div>
+                    }
+                </div>
             </div>
         </div>
     </div>
 </div>
+
+<style>
+    .section-help-content {
+        font-size: 0.95rem;
+        line-height: 1.7;
+        color: #3a2a1a;
+    }
+
+    .section-help-content h2 {
+        font-size: 1.2rem;
+        font-weight: 600;
+        color: #5a3e2b;
+        margin-bottom: 0.75rem;
+    }
+
+    .section-help-content h3 {
+        font-size: 1.05rem;
+        font-weight: 600;
+        color: #5a3e2b;
+        margin-top: 1.25rem;
+        margin-bottom: 0.5rem;
+    }
+
+    .section-help-content p {
+        margin-bottom: 0.75rem;
+    }
+
+    .section-help-content ul, .section-help-content ol {
+        margin-bottom: 0.75rem;
+        padding-left: 1.5rem;
+    }
+
+    .section-help-content li {
+        margin-bottom: 0.25rem;
+    }
+
+    .section-help-content table {
+        width: 100%;
+        margin-bottom: 1rem;
+    }
+
+    .section-help-content table th,
+    .section-help-content table td {
+        padding: 0.5rem 0.75rem;
+        border-bottom: 1px solid #e0d5c8;
+        color: #3a2a1a;
+    }
+
+    .section-help-content table th {
+        font-weight: 600;
+        color: #5a3e2b;
+        background-color: rgba(90, 62, 43, 0.05);
+    }
+
+    .section-help-pills .nav-link {
+        color: #5a3e2b;
+        font-size: 0.875rem;
+        padding: 0.375rem 0.75rem;
+    }
+
+    .section-help-pills .nav-link.active {
+        background-color: #5a3e2b;
+        color: #faf5ef;
+    }
+
+    .section-help-pills .nav-link:hover:not(.active) {
+        background-color: rgba(90, 62, 43, 0.1);
+    }
+</style>


### PR DESCRIPTION
## Summary
- Expanded existing `AccessMatrixViewComponent` into pill-navigated modal with three tabs: Guide | Glossary | Access Matrix
- Hardcoded markdown content for 9 sections (Teams, Profile, Admin, Shifts, Camps, Governance, Onboarding Review, Board, Tickets)
- Guide tabs cover how-to content, FAQ, and "what happens automatically" explanations
- Glossary tabs provide section-specific terminology in markdown tables
- Uses `@Html.SanitizedMarkdown(...)` for rendering, Font Awesome 6 icons on pills
- Added info buttons to Profile and Admin pages
- Tabs gracefully hidden when content absent; pill nav skipped when only one tab has content

## Test plan
- [ ] Click info button on Teams page — verify 3-tab modal opens (Guide | Glossary | Access Matrix)
- [ ] Switch between tabs — verify content renders as formatted markdown
- [ ] Check Profile page — verify info button present with Guide + Glossary content
- [ ] Check Admin page — verify info button present
- [ ] Check sections with no access matrix — verify only Guide + Glossary tabs shown (no empty tab)

🤖 Generated with [Claude Code](https://claude.com/claude-code)