### PR TITLE
Per-resource Drive permission level (#116)

### DIFF
--- a/src/Humans.Application/DTOs/ResourceSyncDiff.cs
+++ b/src/Humans.Application/DTOs/ResourceSyncDiff.cs
@@ -9,7 +9,8 @@ public record MemberSyncStatus(
     string Email,
     string DisplayName,
     MemberSyncState State,
-    List<string> TeamNames);
+    List<string> TeamNames,
+    string? CurrentRole = null);
 
 /// <summary>
 /// Whether a member is correctly synced, missing, or extra.

--- a/src/Humans.Application/DTOs/ResourceSyncDiff.cs
+++ b/src/Humans.Application/DTOs/ResourceSyncDiff.cs
@@ -34,6 +34,9 @@ public class ResourceSyncDiff
     public string? Url { get; init; }
     public string? ErrorMessage { get; init; }
 
+    /// <summary>The permission level team members will get on this resource.</summary>
+    public string? PermissionLevel { get; init; }
+
     /// <summary>All teams that link to this resource.</summary>
     public List<string> LinkedTeams { get; init; } = [];
 

--- a/src/Humans.Application/Interfaces/ITeamResourceService.cs
+++ b/src/Humans.Application/Interfaces/ITeamResourceService.cs
@@ -1,5 +1,6 @@
 using Humans.Application.DTOs;
 using Humans.Domain.Entities;
+using Humans.Domain.Enums;
 
 namespace Humans.Application.Interfaces;
 
@@ -19,19 +20,19 @@ public interface ITeamResourceService
     /// Links an existing Google Drive folder to a team by URL.
     /// The folder must be pre-shared with the service account as Editor.
     /// </summary>
-    Task<LinkResourceResult> LinkDriveFolderAsync(Guid teamId, string folderUrl, CancellationToken ct = default);
+    Task<LinkResourceResult> LinkDriveFolderAsync(Guid teamId, string folderUrl, DrivePermissionLevel permissionLevel = DrivePermissionLevel.Contributor, CancellationToken ct = default);
 
     /// <summary>
     /// Links an existing Google Drive file (Sheet, Doc, etc.) to a team by URL.
     /// The file must be on a Shared Drive pre-shared with the service account.
     /// </summary>
-    Task<LinkResourceResult> LinkDriveFileAsync(Guid teamId, string fileUrl, CancellationToken ct = default);
+    Task<LinkResourceResult> LinkDriveFileAsync(Guid teamId, string fileUrl, DrivePermissionLevel permissionLevel = DrivePermissionLevel.Contributor, CancellationToken ct = default);
 
     /// <summary>
     /// Links a Google Drive resource (folder or file) to a team by URL.
     /// Automatically detects the resource type from the URL and routes accordingly.
     /// </summary>
-    Task<LinkResourceResult> LinkDriveResourceAsync(Guid teamId, string url, CancellationToken ct = default);
+    Task<LinkResourceResult> LinkDriveResourceAsync(Guid teamId, string url, DrivePermissionLevel permissionLevel = DrivePermissionLevel.Contributor, CancellationToken ct = default);
 
     /// <summary>
     /// Links an existing Google Group to a team by email address.

--- a/src/Humans.Domain/Entities/GoogleResource.cs
+++ b/src/Humans.Domain/Entities/GoogleResource.cs
@@ -62,4 +62,11 @@ public class GoogleResource
     /// Error message if provisioning or sync failed.
     /// </summary>
     public string? ErrorMessage { get; set; }
+
+    /// <summary>
+    /// Permission level for team members on this Drive resource.
+    /// Only applicable to Drive resources (folders, files, shared drives), not Groups.
+    /// Default is Contributor (writer) for backward compatibility.
+    /// </summary>
+    public DrivePermissionLevel DrivePermissionLevel { get; set; } = DrivePermissionLevel.Contributor;
 }

--- a/src/Humans.Domain/Enums/DrivePermissionLevel.cs
+++ b/src/Humans.Domain/Enums/DrivePermissionLevel.cs
@@ -1,0 +1,49 @@
+namespace Humans.Domain.Enums;
+
+/// <summary>
+/// Google Drive permission role level for resources.
+/// Display names match Google Drive UI; ToApiRole() maps to the API string.
+/// </summary>
+public enum DrivePermissionLevel
+{
+    /// <summary>
+    /// Read-only access. Google API role: "reader".
+    /// </summary>
+    Viewer = 0,
+
+    /// <summary>
+    /// Can view and add comments. Google API role: "commenter".
+    /// </summary>
+    Commenter = 1,
+
+    /// <summary>
+    /// Full read/write access. Google API role: "writer".
+    /// </summary>
+    Contributor = 2,
+
+    /// <summary>
+    /// Can organize files within folders. Google API role: "fileOrganizer".
+    /// </summary>
+    ContentManager = 3,
+
+    /// <summary>
+    /// Full management including permissions. Google API role: "organizer".
+    /// </summary>
+    Manager = 4
+}
+
+public static class DrivePermissionLevelExtensions
+{
+    /// <summary>
+    /// Maps the enum to the Google Drive API role string.
+    /// </summary>
+    public static string ToApiRole(this DrivePermissionLevel level) => level switch
+    {
+        DrivePermissionLevel.Viewer => "reader",
+        DrivePermissionLevel.Commenter => "commenter",
+        DrivePermissionLevel.Contributor => "writer",
+        DrivePermissionLevel.ContentManager => "fileOrganizer",
+        DrivePermissionLevel.Manager => "organizer",
+        _ => "writer"
+    };
+}

--- a/src/Humans.Infrastructure/Data/Configurations/GoogleResourceConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/GoogleResourceConfiguration.cs
@@ -33,6 +33,10 @@ public class GoogleResourceConfiguration : IEntityTypeConfiguration<GoogleResour
         builder.Property(gr => gr.ErrorMessage)
             .HasMaxLength(2000);
 
+        builder.Property(gr => gr.DrivePermissionLevel)
+            .HasConversion<string>()
+            .HasMaxLength(20);
+
         builder.HasIndex(gr => gr.GoogleId);
 
         builder.HasIndex(gr => gr.TeamId);

--- a/src/Humans.Infrastructure/Migrations/20260322174819_AddDrivePermissionLevelToGoogleResource.Designer.cs
+++ b/src/Humans.Infrastructure/Migrations/20260322174819_AddDrivePermissionLevelToGoogleResource.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Humans.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Humans.Infrastructure.Migrations
 {
     [DbContext(typeof(HumansDbContext))]
-    partial class HumansDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260322174819_AddDrivePermissionLevelToGoogleResource")]
+    partial class AddDrivePermissionLevelToGoogleResource
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Humans.Infrastructure/Migrations/20260322174819_AddDrivePermissionLevelToGoogleResource.cs
+++ b/src/Humans.Infrastructure/Migrations/20260322174819_AddDrivePermissionLevelToGoogleResource.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Humans.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDrivePermissionLevelToGoogleResource : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "DrivePermissionLevel",
+                table: "google_resources",
+                type: "character varying(20)",
+                maxLength: 20,
+                nullable: false,
+                defaultValue: "Contributor");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DrivePermissionLevel",
+                table: "google_resources");
+        }
+    }
+}

--- a/src/Humans.Infrastructure/Services/GoogleWorkspaceSyncService.cs
+++ b/src/Humans.Infrastructure/Services/GoogleWorkspaceSyncService.cs
@@ -1095,6 +1095,7 @@ public class GoogleWorkspaceSyncService : IGoogleSyncService
                 ResourceType = primary.ResourceType.ToString(),
                 GoogleId = primary.GoogleId,
                 Url = primary.Url,
+                PermissionLevel = primary.DrivePermissionLevel.ToString(),
                 LinkedTeams = linkedTeams,
                 Members = members
             };
@@ -1116,6 +1117,7 @@ public class GoogleWorkspaceSyncService : IGoogleSyncService
                 ResourceType = primary.ResourceType.ToString(),
                 GoogleId = primary.GoogleId,
                 Url = primary.Url,
+                PermissionLevel = primary.DrivePermissionLevel.ToString(),
                 LinkedTeams = resources.Select(r => r.Team.Name).Distinct(StringComparer.Ordinal).ToList(),
                 ErrorMessage = ex.Message
             };

--- a/src/Humans.Infrastructure/Services/GoogleWorkspaceSyncService.cs
+++ b/src/Humans.Infrastructure/Services/GoogleWorkspaceSyncService.cs
@@ -1000,10 +1000,15 @@ public class GoogleWorkspaceSyncService : IGoogleSyncService
             var allEmails = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             // Only direct managed permissions — for detecting removable extras
             var directEmails = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            // Email → current Google role (reader, writer, etc.)
+            var roleByEmail = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             foreach (var perm in permissions)
             {
                 if (IsAnyUserPermission(perm))
+                {
                     allEmails.Add(perm.EmailAddress);
+                    roleByEmail[perm.EmailAddress] = perm.Role;
+                }
                 if (IsDirectManagedPermission(perm))
                     directEmails.Add(perm.EmailAddress);
             }
@@ -1016,7 +1021,8 @@ public class GoogleWorkspaceSyncService : IGoogleSyncService
                 var state = allEmails.Contains(email)
                     ? MemberSyncState.Correct
                     : MemberSyncState.Missing;
-                members.Add(new MemberSyncStatus(email, displayName, state, teamNames));
+                roleByEmail.TryGetValue(email, out var currentRole);
+                members.Add(new MemberSyncStatus(email, displayName, state, teamNames, currentRole));
             }
 
             var saEmail = await GetServiceAccountEmailAsync();
@@ -1031,7 +1037,8 @@ public class GoogleWorkspaceSyncService : IGoogleSyncService
                     var state = directEmails.Contains(email)
                         ? MemberSyncState.Extra
                         : MemberSyncState.Inherited;
-                    members.Add(new MemberSyncStatus(email, email, state, []));
+                    roleByEmail.TryGetValue(email, out var extraRole);
+                    members.Add(new MemberSyncStatus(email, email, state, [], extraRole));
                 }
             }
 

--- a/src/Humans.Infrastructure/Services/GoogleWorkspaceSyncService.cs
+++ b/src/Humans.Infrastructure/Services/GoogleWorkspaceSyncService.cs
@@ -443,10 +443,11 @@ public class GoogleWorkspaceSyncService : IGoogleSyncService
         }
 
         var drive = await GetDriveServiceAsync();
+        var apiRole = resource.DrivePermissionLevel.ToApiRole();
         var permission = new Google.Apis.Drive.v3.Data.Permission
         {
             Type = "user",
-            Role = "writer",
+            Role = apiRole,
             EmailAddress = userEmail
         };
 
@@ -458,9 +459,9 @@ public class GoogleWorkspaceSyncService : IGoogleSyncService
 
             await _auditLogService.LogGoogleSyncAsync(
                 AuditAction.GoogleResourceAccessGranted, resource.Id,
-                $"Granted Drive access to {userEmail} ({resource.Name})",
+                $"Granted Drive access ({resource.DrivePermissionLevel}) to {userEmail} ({resource.Name})",
                 nameof(GoogleWorkspaceSyncService),
-                userEmail, "writer", GoogleSyncSource.ManualSync, success: true);
+                userEmail, apiRole, GoogleSyncSource.ManualSync, success: true);
 
             _logger.LogInformation("Granted Drive access to {Email} on {GoogleId}", userEmail, resource.GoogleId);
         }
@@ -497,7 +498,7 @@ public class GoogleWorkspaceSyncService : IGoogleSyncService
             AuditAction.GoogleResourceAccessRevoked, resource.Id,
             $"Removed Drive access for {userEmail} ({resource.Name})",
             nameof(GoogleWorkspaceSyncService),
-            userEmail, "writer", GoogleSyncSource.ManualSync, success: true);
+            userEmail, resource.DrivePermissionLevel.ToApiRole(), GoogleSyncSource.ManualSync, success: true);
 
         _logger.LogInformation("Removed Drive access for {Email} on {GoogleId}", userEmail, resource.GoogleId);
     }

--- a/src/Humans.Infrastructure/Services/StubTeamResourceService.cs
+++ b/src/Humans.Infrastructure/Services/StubTeamResourceService.cs
@@ -44,7 +44,7 @@ public class StubTeamResourceService : ITeamResourceService
     }
 
     /// <inheritdoc />
-    public Task<LinkResourceResult> LinkDriveFolderAsync(Guid teamId, string folderUrl, CancellationToken ct = default)
+    public Task<LinkResourceResult> LinkDriveFolderAsync(Guid teamId, string folderUrl, DrivePermissionLevel permissionLevel = DrivePermissionLevel.Contributor, CancellationToken ct = default)
     {
         _logger.LogInformation("[STUB] Would link Drive folder from URL '{FolderUrl}' to team {TeamId}", folderUrl, teamId);
 
@@ -66,7 +66,8 @@ public class StubTeamResourceService : ITeamResourceService
             Url = folderUrl,
             ProvisionedAt = now,
             LastSyncedAt = now,
-            IsActive = true
+            IsActive = true,
+            DrivePermissionLevel = permissionLevel
         };
 
         _dbContext.GoogleResources.Add(resource);
@@ -76,7 +77,7 @@ public class StubTeamResourceService : ITeamResourceService
     }
 
     /// <inheritdoc />
-    public Task<LinkResourceResult> LinkDriveFileAsync(Guid teamId, string fileUrl, CancellationToken ct = default)
+    public Task<LinkResourceResult> LinkDriveFileAsync(Guid teamId, string fileUrl, DrivePermissionLevel permissionLevel = DrivePermissionLevel.Contributor, CancellationToken ct = default)
     {
         _logger.LogInformation("[STUB] Would link Drive file from URL '{FileUrl}' to team {TeamId}", fileUrl, teamId);
 
@@ -98,7 +99,8 @@ public class StubTeamResourceService : ITeamResourceService
             Url = fileUrl,
             ProvisionedAt = now,
             LastSyncedAt = now,
-            IsActive = true
+            IsActive = true,
+            DrivePermissionLevel = permissionLevel
         };
 
         _dbContext.GoogleResources.Add(resource);
@@ -108,11 +110,12 @@ public class StubTeamResourceService : ITeamResourceService
     }
 
     /// <inheritdoc />
-    public Task<LinkResourceResult> LinkDriveResourceAsync(Guid teamId, string url, CancellationToken ct = default)
+    public Task<LinkResourceResult> LinkDriveResourceAsync(Guid teamId, string url, DrivePermissionLevel permissionLevel = DrivePermissionLevel.Contributor, CancellationToken ct = default)
     {
         return TeamResourceInputValidation.LinkDriveResourceAsync(
             teamId,
             url,
+            permissionLevel,
             ct,
             LinkDriveFolderAsync,
             LinkDriveFileAsync);

--- a/src/Humans.Infrastructure/Services/TeamResourceInputValidation.cs
+++ b/src/Humans.Infrastructure/Services/TeamResourceInputValidation.cs
@@ -1,4 +1,5 @@
 using Humans.Application.DTOs;
+using Humans.Domain.Enums;
 
 namespace Humans.Infrastructure.Services;
 
@@ -7,18 +8,19 @@ internal static class TeamResourceInputValidation
     public static Task<LinkResourceResult> LinkDriveResourceAsync(
         Guid teamId,
         string url,
+        DrivePermissionLevel permissionLevel,
         CancellationToken ct,
-        Func<Guid, string, CancellationToken, Task<LinkResourceResult>> linkDriveFolderAsync,
-        Func<Guid, string, CancellationToken, Task<LinkResourceResult>> linkDriveFileAsync)
+        Func<Guid, string, DrivePermissionLevel, CancellationToken, Task<LinkResourceResult>> linkDriveFolderAsync,
+        Func<Guid, string, DrivePermissionLevel, CancellationToken, Task<LinkResourceResult>> linkDriveFileAsync)
     {
         if (TeamResourceService.ParseDriveFolderId(url) != null)
         {
-            return linkDriveFolderAsync(teamId, url, ct);
+            return linkDriveFolderAsync(teamId, url, permissionLevel, ct);
         }
 
         if (TeamResourceService.ParseDriveFileId(url) != null)
         {
-            return linkDriveFileAsync(teamId, url, ct);
+            return linkDriveFileAsync(teamId, url, permissionLevel, ct);
         }
 
         return Task.FromResult(new LinkResourceResult(false,

--- a/src/Humans.Infrastructure/Services/TeamResourceService.cs
+++ b/src/Humans.Infrastructure/Services/TeamResourceService.cs
@@ -58,7 +58,7 @@ public partial class TeamResourceService : ITeamResourceService
     }
 
     /// <inheritdoc />
-    public async Task<LinkResourceResult> LinkDriveFolderAsync(Guid teamId, string folderUrl, CancellationToken ct = default)
+    public async Task<LinkResourceResult> LinkDriveFolderAsync(Guid teamId, string folderUrl, DrivePermissionLevel permissionLevel = DrivePermissionLevel.Contributor, CancellationToken ct = default)
     {
         var folderId = ParseDriveFolderId(folderUrl);
         if (folderId == null)
@@ -126,15 +126,21 @@ public partial class TeamResourceService : ITeamResourceService
                     Url = file.WebViewLink,
                     ProvisionedAt = now,
                     LastSyncedAt = now,
-                    IsActive = true
+                    IsActive = true,
+                    DrivePermissionLevel = permissionLevel
                 };
                 _dbContext.GoogleResources.Add(resource);
             }
 
+            if (inactive != null)
+            {
+                inactive.DrivePermissionLevel = permissionLevel;
+            }
+
             await _dbContext.SaveChangesAsync(ct);
 
-            _logger.LogInformation("Linked Drive folder {FolderId} ({FolderName}) to team {TeamId}",
-                file.Id, file.Name, teamId);
+            _logger.LogInformation("Linked Drive folder {FolderId} ({FolderName}) to team {TeamId} with permission {Permission}",
+                file.Id, file.Name, teamId, permissionLevel);
 
             return new LinkResourceResult(true, Resource: resource);
         }
@@ -156,7 +162,7 @@ public partial class TeamResourceService : ITeamResourceService
     }
 
     /// <inheritdoc />
-    public async Task<LinkResourceResult> LinkDriveFileAsync(Guid teamId, string fileUrl, CancellationToken ct = default)
+    public async Task<LinkResourceResult> LinkDriveFileAsync(Guid teamId, string fileUrl, DrivePermissionLevel permissionLevel = DrivePermissionLevel.Contributor, CancellationToken ct = default)
     {
         var fileId = ParseDriveFileId(fileUrl);
         if (fileId == null)
@@ -224,15 +230,21 @@ public partial class TeamResourceService : ITeamResourceService
                     Url = file.WebViewLink,
                     ProvisionedAt = now,
                     LastSyncedAt = now,
-                    IsActive = true
+                    IsActive = true,
+                    DrivePermissionLevel = permissionLevel
                 };
                 _dbContext.GoogleResources.Add(resource);
             }
 
+            if (inactive != null)
+            {
+                inactive.DrivePermissionLevel = permissionLevel;
+            }
+
             await _dbContext.SaveChangesAsync(ct);
 
-            _logger.LogInformation("Linked Drive file {FileId} ({FileName}) to team {TeamId}",
-                file.Id, file.Name, teamId);
+            _logger.LogInformation("Linked Drive file {FileId} ({FileName}) to team {TeamId} with permission {Permission}",
+                file.Id, file.Name, teamId, permissionLevel);
 
             return new LinkResourceResult(true, Resource: resource);
         }
@@ -254,11 +266,12 @@ public partial class TeamResourceService : ITeamResourceService
     }
 
     /// <inheritdoc />
-    public async Task<LinkResourceResult> LinkDriveResourceAsync(Guid teamId, string url, CancellationToken ct = default)
+    public async Task<LinkResourceResult> LinkDriveResourceAsync(Guid teamId, string url, DrivePermissionLevel permissionLevel = DrivePermissionLevel.Contributor, CancellationToken ct = default)
     {
         return await TeamResourceInputValidation.LinkDriveResourceAsync(
             teamId,
             url,
+            permissionLevel,
             ct,
             LinkDriveFolderAsync,
             LinkDriveFileAsync);

--- a/src/Humans.Web/Controllers/TeamAdminController.cs
+++ b/src/Humans.Web/Controllers/TeamAdminController.cs
@@ -299,7 +299,9 @@ public class TeamAdminController : HumansTeamControllerBase
                 ProvisionedAt = r.ProvisionedAt.ToDateTimeUtc(),
                 LastSyncedAt = r.LastSyncedAt?.ToDateTimeUtc(),
                 IsActive = r.IsActive,
-                ErrorMessage = r.ErrorMessage
+                ErrorMessage = r.ErrorMessage,
+                DrivePermissionLevel = r.DrivePermissionLevel,
+                IsDriveResource = r.ResourceType is GoogleResourceType.DriveFolder or GoogleResourceType.DriveFile or GoogleResourceType.SharedDrive
             }).ToList()
         };
 
@@ -333,7 +335,7 @@ public class TeamAdminController : HumansTeamControllerBase
             return RedirectToAction(nameof(Resources), new { slug });
         }
 
-        var result = await _teamResourceService.LinkDriveResourceAsync(team.Id, model.ResourceUrl);
+        var result = await _teamResourceService.LinkDriveResourceAsync(team.Id, model.ResourceUrl, model.PermissionLevel);
 
         if (result.Success)
         {

--- a/src/Humans.Web/Models/TeamResourceViewModels.cs
+++ b/src/Humans.Web/Models/TeamResourceViewModels.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using Humans.Domain.Enums;
 
 namespace Humans.Web.Models;
 
@@ -22,12 +23,16 @@ public class GoogleResourceViewModel
     public DateTime? LastSyncedAt { get; set; }
     public bool IsActive { get; set; }
     public string? ErrorMessage { get; set; }
+    public DrivePermissionLevel DrivePermissionLevel { get; set; }
+    public bool IsDriveResource { get; set; }
 }
 
 public class LinkDriveResourceModel
 {
     [Required(ErrorMessage = "Please enter a Google Drive URL.")]
     public string ResourceUrl { get; set; } = string.Empty;
+
+    public DrivePermissionLevel PermissionLevel { get; set; } = DrivePermissionLevel.Contributor;
 }
 
 public class LinkGroupModel

--- a/src/Humans.Web/Views/Team/Sync.cshtml
+++ b/src/Humans.Web/Views/Team/Sync.cshtml
@@ -233,7 +233,8 @@
             html += '<div class="alert alert-danger m-3 mb-0">' + escapeHtml(diff.errorMessage) + '</div>';
         } else if (diff.members && diff.members.length > 0) {
             html += '<table class="table table-sm mb-0">';
-            html += '<thead><tr><th>Email</th><th>Name</th><th>Status</th><th>Teams</th></tr></thead>';
+            var showPermission = diff.permissionLevel != null;
+            html += '<thead><tr><th>Email</th><th>Name</th><th>Status</th>' + (showPermission ? '<th>Permission</th>' : '') + '<th>Teams</th></tr></thead>';
             html += '<tbody>';
             for (let j = 0; j < diff.members.length; j++) {
                 const m = diff.members[j];
@@ -259,6 +260,9 @@
                 var nameDisplay = m.displayName && m.displayName !== m.email ? m.displayName : '';
                 html += '<td>' + escapeHtml(nameDisplay) + '</td>';
                 html += '<td><span class="badge ' + badgeClass + '">' + stateLabel + '</span></td>';
+                if (showPermission) {
+                    html += '<td><span class="badge bg-light text-dark border">' + escapeHtml(diff.permissionLevel) + '</span></td>';
+                }
                 html += '<td>' + memberTeams + '</td>';
                 html += '</tr>';
             }

--- a/src/Humans.Web/Views/Team/Sync.cshtml
+++ b/src/Humans.Web/Views/Team/Sync.cshtml
@@ -234,7 +234,7 @@
         } else if (diff.members && diff.members.length > 0) {
             html += '<table class="table table-sm mb-0">';
             var showPermission = diff.permissionLevel != null;
-            html += '<thead><tr><th>Email</th><th>Name</th><th>Status</th>' + (showPermission ? '<th>Permission</th>' : '') + '<th>Teams</th></tr></thead>';
+            html += '<thead><tr><th>Email</th><th>Name</th><th>Status</th>' + (showPermission ? '<th>Current Role</th>' : '') + '<th>Teams</th></tr></thead>';
             html += '<tbody>';
             for (let j = 0; j < diff.members.length; j++) {
                 const m = diff.members[j];
@@ -261,7 +261,8 @@
                 html += '<td>' + escapeHtml(nameDisplay) + '</td>';
                 html += '<td><span class="badge ' + badgeClass + '">' + stateLabel + '</span></td>';
                 if (showPermission) {
-                    html += '<td><span class="badge bg-light text-dark border">' + escapeHtml(diff.permissionLevel) + '</span></td>';
+                    var role = m.currentRole || '—';
+                    html += '<td>' + escapeHtml(role) + '</td>';
                 }
                 html += '<td>' + memberTeams + '</td>';
                 html += '</tr>';

--- a/src/Humans.Web/Views/Team/Sync.cshtml
+++ b/src/Humans.Web/Views/Team/Sync.cshtml
@@ -209,6 +209,9 @@
         html += '<i class="fa-solid fa-chevron-right collapse-icon"></i>';
         html += '</button>';
         html += '<span>' + nameHtml + '</span> ' + statusBadge;
+        if (diff.permissionLevel) {
+            html += ' <span class="badge bg-light text-dark border">' + escapeHtml(diff.permissionLevel) + '</span>';
+        }
         html += '</div>';
         html += '<div class="d-flex align-items-center gap-2">';
         html += '<small class="text-muted">' + teamsHtml + '</small>';

--- a/src/Humans.Web/Views/TeamAdmin/Resources.cshtml
+++ b/src/Humans.Web/Views/TeamAdmin/Resources.cshtml
@@ -42,6 +42,7 @@
                     <tr>
                         <th>@Localizer["AdminTeams_Name"]</th>
                         <th>@Localizer["AdminTeams_Type"]</th>
+                        <th>Permission</th>
                         <th>@Localizer["TeamAdmin_LastSynced"]</th>
                         <th>@Localizer["Common_Status"]</th>
                         <th>@Localizer["MyTeams_Actions"]</th>
@@ -77,6 +78,16 @@
                                 else
                                 {
                                     <span class="badge bg-secondary">@resource.ResourceType</span>
+                                }
+                            </td>
+                            <td>
+                                @if (resource.IsDriveResource)
+                                {
+                                    <span class="badge bg-light text-dark">@resource.DrivePermissionLevel</span>
+                                }
+                                else
+                                {
+                                    <span class="text-muted">—</span>
                                 }
                             </td>
                             <td>
@@ -131,6 +142,17 @@ else
                 <input type="url" class="form-control" id="resourceUrl" name="ResourceUrl"
                        placeholder="https://drive.google.com/drive/folders/... or https://docs.google.com/spreadsheets/d/..." required>
                 <div class="form-text">Paste a Google Drive folder, Sheets, Docs, Slides, or other file URL.</div>
+            </div>
+            <div class="mb-3">
+                <label for="permissionLevel" class="form-label">Permission Level</label>
+                <select class="form-select" id="permissionLevel" name="PermissionLevel" style="max-width: 300px;">
+                    <option value="Viewer">Viewer (read-only)</option>
+                    <option value="Commenter">Commenter</option>
+                    <option value="Contributor" selected>Contributor (read/write)</option>
+                    <option value="ContentManager">Content Manager</option>
+                    <option value="Manager">Manager</option>
+                </select>
+                <div class="form-text">Permission level granted to team members for this resource.</div>
             </div>
             <button type="submit" class="btn btn-primary">Link Resource</button>
         </form>

--- a/tests/Humans.Domain.Tests/Enums/EnumStringStabilityTests.cs
+++ b/tests/Humans.Domain.Tests/Enums/EnumStringStabilityTests.cs
@@ -147,6 +147,10 @@ public class EnumStringStabilityTests
         {
             typeof(RolePeriod),
             new[] { "YearRound", "Build", "Event", "Strike" }
+        },
+        {
+            typeof(DrivePermissionLevel),
+            new[] { "Viewer", "Commenter", "Contributor", "ContentManager", "Manager" }
         }
     };
 }


### PR DESCRIPTION
## Summary
- Moves `DrivePermissionLevel` from `Team` to `GoogleResource` — each Drive resource gets its own permission level
- Enum values match Google Drive UI: Viewer, Commenter, **Contributor** (default), ContentManager, Manager
- Sync service uses the resource's level instead of hardcoded "writer"
- Permission level dropdown added to the "Link Drive Resource" form on the Resources page
- Permission level shown as a column in the resources table
- Existing resources default to Contributor (backward compatible)

## Test plan
- [ ] Go to a team's Resources page (Teams → Summary → pick a team → Manage Resources)
- [ ] Link a Drive resource — verify the permission level dropdown is present and defaults to Contributor
- [ ] Verify the permission level column shows in the resources table
- [ ] Verify the permission column shows "—" for Google Group resources

🤖 Generated with [Claude Code](https://claude.com/claude-code)