### PR TITLE
feat: Stripe fee tracking for ticket orders (#126)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -74,6 +74,7 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageVersion Include="NodaTime.Testing" Version="3.3.1" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
+    <PackageVersion Include="Stripe.net" Version="51.0.0" />
     <PackageVersion Include="Testcontainers.PostgreSql" Version="4.10.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/src/Humans.Application/DTOs/TicketVendorDtos.cs
+++ b/src/Humans.Application/DTOs/TicketVendorDtos.cs
@@ -13,7 +13,9 @@ public record VendorOrderDto(
     string PaymentStatus,
     string? VendorDashboardUrl,
     Instant PurchasedAt,
-    IReadOnlyList<VendorTicketDto> Tickets);
+    IReadOnlyList<VendorTicketDto> Tickets,
+    string? StripePaymentIntentId = null,
+    decimal? DiscountAmount = null);
 
 /// <summary>Vendor-agnostic issued ticket data.</summary>
 public record VendorTicketDto(

--- a/src/Humans.Application/Interfaces/IStripeService.cs
+++ b/src/Humans.Application/Interfaces/IStripeService.cs
@@ -1,0 +1,22 @@
+namespace Humans.Application.Interfaces;
+
+/// <summary>
+/// Reads payment details from Stripe for fee tracking and payment method attribution.
+/// </summary>
+public interface IStripeService
+{
+    bool IsConfigured { get; }
+
+    /// <summary>
+    /// Look up a PaymentIntent and return fee breakdown and payment method details.
+    /// Returns null if the PaymentIntent has no successful charge.
+    /// </summary>
+    Task<StripePaymentDetails?> GetPaymentDetailsAsync(string paymentIntentId, CancellationToken ct = default);
+}
+
+/// <summary>Fee and payment method data extracted from a Stripe PaymentIntent's charge.</summary>
+public record StripePaymentDetails(
+    string PaymentMethod,
+    string? PaymentMethodDetail,
+    decimal StripeFee,
+    decimal ApplicationFee);

--- a/src/Humans.Domain/Entities/TicketOrder.cs
+++ b/src/Humans.Domain/Entities/TicketOrder.cs
@@ -50,6 +50,24 @@ public class TicketOrder
     /// <summary>When this record was last synced from the vendor.</summary>
     public Instant SyncedAt { get; set; }
 
+    /// <summary>Stripe PaymentIntent ID from vendor txn_id (e.g. pi_xxx). Used to look up fee details.</summary>
+    public string? StripePaymentIntentId { get; set; }
+
+    /// <summary>Payment method type from Stripe (e.g. "card", "link", "ideal", "bancontact", "klarna").</summary>
+    public string? PaymentMethod { get; set; }
+
+    /// <summary>Payment method detail — card brand for cards (e.g. "visa", "mastercard"), null for others.</summary>
+    public string? PaymentMethodDetail { get; set; }
+
+    /// <summary>Stripe processing fee in order currency.</summary>
+    public decimal? StripeFee { get; set; }
+
+    /// <summary>Application fee (Ticket Tailor platform fee) in order currency.</summary>
+    public decimal? ApplicationFee { get; set; }
+
+    /// <summary>Discount amount applied to order (from vendor line items). Stored as positive value.</summary>
+    public decimal? DiscountAmount { get; set; }
+
     /// <summary>Individual attendees (issued tickets) for this order.</summary>
     public ICollection<TicketAttendee> Attendees { get; set; } = new List<TicketAttendee>();
 }

--- a/src/Humans.Infrastructure/Data/Configurations/TicketOrderConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/TicketOrderConfiguration.cs
@@ -65,8 +65,27 @@ public class TicketOrderConfiguration : IEntityTypeConfiguration<TicketOrder>
             .HasForeignKey(a => a.TicketOrderId)
             .OnDelete(DeleteBehavior.Cascade);
 
+        builder.Property(o => o.StripePaymentIntentId)
+            .HasMaxLength(100);
+
+        builder.Property(o => o.PaymentMethod)
+            .HasMaxLength(50);
+
+        builder.Property(o => o.PaymentMethodDetail)
+            .HasMaxLength(50);
+
+        builder.Property(o => o.StripeFee)
+            .HasPrecision(10, 2);
+
+        builder.Property(o => o.ApplicationFee)
+            .HasPrecision(10, 2);
+
+        builder.Property(o => o.DiscountAmount)
+            .HasPrecision(10, 2);
+
         builder.HasIndex(o => o.BuyerEmail);
         builder.HasIndex(o => o.PurchasedAt);
         builder.HasIndex(o => o.MatchedUserId);
+        builder.HasIndex(o => o.PaymentMethod);
     }
 }

--- a/src/Humans.Infrastructure/Data/Migrations/20260327201246_AddStripeFeeTracking.Designer.cs
+++ b/src/Humans.Infrastructure/Data/Migrations/20260327201246_AddStripeFeeTracking.Designer.cs
@@ -3,18 +3,21 @@ using System;
 using Humans.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 #nullable disable
 
-namespace Humans.Infrastructure.Migrations
+namespace Humans.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(HumansDbContext))]
-    partial class HumansDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260327201246_AddStripeFeeTracking")]
+    partial class AddStripeFeeTracking
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Humans.Infrastructure/Data/Migrations/20260327201246_AddStripeFeeTracking.cs
+++ b/src/Humans.Infrastructure/Data/Migrations/20260327201246_AddStripeFeeTracking.cs
@@ -1,0 +1,96 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Humans.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddStripeFeeTracking : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<decimal>(
+                name: "ApplicationFee",
+                table: "ticket_orders",
+                type: "numeric(10,2)",
+                precision: 10,
+                scale: 2,
+                nullable: true);
+
+            migrationBuilder.AddColumn<decimal>(
+                name: "DiscountAmount",
+                table: "ticket_orders",
+                type: "numeric(10,2)",
+                precision: 10,
+                scale: 2,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "PaymentMethod",
+                table: "ticket_orders",
+                type: "character varying(50)",
+                maxLength: 50,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "PaymentMethodDetail",
+                table: "ticket_orders",
+                type: "character varying(50)",
+                maxLength: 50,
+                nullable: true);
+
+            migrationBuilder.AddColumn<decimal>(
+                name: "StripeFee",
+                table: "ticket_orders",
+                type: "numeric(10,2)",
+                precision: 10,
+                scale: 2,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "StripePaymentIntentId",
+                table: "ticket_orders",
+                type: "character varying(100)",
+                maxLength: 100,
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ticket_orders_PaymentMethod",
+                table: "ticket_orders",
+                column: "PaymentMethod");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_ticket_orders_PaymentMethod",
+                table: "ticket_orders");
+
+            migrationBuilder.DropColumn(
+                name: "ApplicationFee",
+                table: "ticket_orders");
+
+            migrationBuilder.DropColumn(
+                name: "DiscountAmount",
+                table: "ticket_orders");
+
+            migrationBuilder.DropColumn(
+                name: "PaymentMethod",
+                table: "ticket_orders");
+
+            migrationBuilder.DropColumn(
+                name: "PaymentMethodDetail",
+                table: "ticket_orders");
+
+            migrationBuilder.DropColumn(
+                name: "StripeFee",
+                table: "ticket_orders");
+
+            migrationBuilder.DropColumn(
+                name: "StripePaymentIntentId",
+                table: "ticket_orders");
+        }
+    }
+}

--- a/src/Humans.Infrastructure/Humans.Infrastructure.csproj
+++ b/src/Humans.Infrastructure/Humans.Infrastructure.csproj
@@ -26,6 +26,7 @@
     <PackageReference Include="Google.Apis.DriveActivity.v2" />
     <PackageReference Include="Google.Apis.Groupssettings.v1" />
     <PackageReference Include="Google.Apis.Auth" />
+    <PackageReference Include="Stripe.net" />
   </ItemGroup>
 
 </Project>

--- a/src/Humans.Infrastructure/Services/StripeService.cs
+++ b/src/Humans.Infrastructure/Services/StripeService.cs
@@ -1,0 +1,75 @@
+using Humans.Application.Interfaces;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Stripe;
+
+namespace Humans.Infrastructure.Services;
+
+public class StripeSettings
+{
+    /// <summary>Stripe restricted API key — populated from STRIPE_API_KEY env var.</summary>
+    public string ApiKey { get; set; } = string.Empty;
+
+    public bool IsConfigured => !string.IsNullOrEmpty(ApiKey);
+}
+
+public class StripeService : IStripeService
+{
+    private readonly StripeSettings _settings;
+    private readonly ILogger<StripeService> _logger;
+
+    public StripeService(IOptions<StripeSettings> settings, ILogger<StripeService> logger)
+    {
+        _settings = settings.Value;
+        _logger = logger;
+    }
+
+    public bool IsConfigured => _settings.IsConfigured;
+
+    public async Task<StripePaymentDetails?> GetPaymentDetailsAsync(
+        string paymentIntentId, CancellationToken ct = default)
+    {
+        var client = new StripeClient(_settings.ApiKey);
+        var piService = new PaymentIntentService(client);
+
+        var pi = await piService.GetAsync(paymentIntentId, new PaymentIntentGetOptions
+        {
+            Expand = ["latest_charge.balance_transaction"]
+        }, cancellationToken: ct);
+
+        var charge = pi.LatestCharge;
+        if (charge is null)
+        {
+            _logger.LogDebug("PaymentIntent {Id} has no charge", paymentIntentId);
+            return null;
+        }
+
+        // Payment method type and detail
+        var pmd = charge.PaymentMethodDetails;
+        var methodType = pmd?.Type ?? "unknown";
+        string? methodDetail = null;
+        if (string.Equals(methodType, "card", StringComparison.Ordinal) && pmd?.Card is not null)
+            methodDetail = pmd.Card.Brand;
+
+        // Fee breakdown from BalanceTransaction
+        decimal stripeFee = 0;
+        decimal applicationFee = 0;
+        var bt = charge.BalanceTransaction;
+        if (bt?.FeeDetails is not null)
+        {
+            foreach (var fd in bt.FeeDetails)
+            {
+                if (string.Equals(fd.Type, "stripe_fee", StringComparison.Ordinal))
+                    stripeFee += fd.Amount / 100m;
+                else if (string.Equals(fd.Type, "application_fee", StringComparison.Ordinal))
+                    applicationFee += fd.Amount / 100m;
+            }
+        }
+
+        return new StripePaymentDetails(
+            PaymentMethod: methodType,
+            PaymentMethodDetail: methodDetail,
+            StripeFee: stripeFee,
+            ApplicationFee: applicationFee);
+    }
+}

--- a/src/Humans.Infrastructure/Services/TicketSyncService.cs
+++ b/src/Humans.Infrastructure/Services/TicketSyncService.cs
@@ -16,6 +16,7 @@ public class TicketSyncService : ITicketSyncService
 {
     private readonly HumansDbContext _dbContext;
     private readonly ITicketVendorService _vendorService;
+    private readonly IStripeService _stripeService;
     private readonly IClock _clock;
     private readonly TicketVendorSettings _settings;
     private readonly IMemoryCache _cache;
@@ -24,6 +25,7 @@ public class TicketSyncService : ITicketSyncService
     public TicketSyncService(
         HumansDbContext dbContext,
         ITicketVendorService vendorService,
+        IStripeService stripeService,
         IClock clock,
         IOptions<TicketVendorSettings> settings,
         ILogger<TicketSyncService> logger,
@@ -31,6 +33,7 @@ public class TicketSyncService : ITicketSyncService
     {
         _dbContext = dbContext;
         _vendorService = vendorService;
+        _stripeService = stripeService;
         _clock = clock;
         _settings = settings.Value;
         _cache = cache;
@@ -83,6 +86,9 @@ public class TicketSyncService : ITicketSyncService
             // Without this, newly added orders are only in the Change Tracker
             // and FirstOrDefaultAsync won't see them.
             await _dbContext.SaveChangesAsync(ct);
+
+            // Enrich orders with Stripe fee/payment method data
+            await EnrichOrdersWithStripeDataAsync(ct);
 
             // Sync all tickets (not grouped by order — we match by VendorTicketId)
             foreach (var ticketDto in tickets)
@@ -191,6 +197,8 @@ public class TicketSyncService : ITicketSyncService
             existing.VendorDashboardUrl = dto.VendorDashboardUrl;
             existing.SyncedAt = now;
             existing.MatchedUserId = LookupUserId(emailLookup, dto.BuyerEmail);
+            existing.StripePaymentIntentId = dto.StripePaymentIntentId;
+            existing.DiscountAmount = dto.DiscountAmount;
             return existing;
         }
 
@@ -209,6 +217,8 @@ public class TicketSyncService : ITicketSyncService
             PurchasedAt = dto.PurchasedAt,
             SyncedAt = now,
             MatchedUserId = LookupUserId(emailLookup, dto.BuyerEmail),
+            StripePaymentIntentId = dto.StripePaymentIntentId,
+            DiscountAmount = dto.DiscountAmount,
         };
 
         _dbContext.TicketOrders.Add(order);
@@ -316,6 +326,45 @@ public class TicketSyncService : ITicketSyncService
             await _dbContext.SaveChangesAsync(ct);
 
         return codesRedeemed;
+    }
+
+    private async Task EnrichOrdersWithStripeDataAsync(CancellationToken ct)
+    {
+        if (!_stripeService.IsConfigured)
+        {
+            _logger.LogDebug("Stripe not configured, skipping fee enrichment");
+            return;
+        }
+
+        // Find orders that have a Stripe PI but no fee data yet
+        var ordersToEnrich = await _dbContext.TicketOrders
+            .Where(o => o.StripePaymentIntentId != null && o.StripeFee == null)
+            .ToListAsync(ct);
+
+        if (ordersToEnrich.Count == 0) return;
+
+        _logger.LogInformation("Enriching {Count} orders with Stripe fee data", ordersToEnrich.Count);
+
+        foreach (var order in ordersToEnrich)
+        {
+            try
+            {
+                var details = await _stripeService.GetPaymentDetailsAsync(order.StripePaymentIntentId!, ct);
+                if (details is null) continue;
+
+                order.PaymentMethod = details.PaymentMethod;
+                order.PaymentMethodDetail = details.PaymentMethodDetail;
+                order.StripeFee = details.StripeFee;
+                order.ApplicationFee = details.ApplicationFee;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to fetch Stripe data for order {OrderId} (PI: {PaymentIntentId})",
+                    order.VendorOrderId, order.StripePaymentIntentId);
+            }
+        }
+
+        await _dbContext.SaveChangesAsync(ct);
     }
 
     private static Guid? LookupUserId(Dictionary<string, Guid> lookup, string? email) =>

--- a/src/Humans.Infrastructure/Services/TicketTailorService.cs
+++ b/src/Humans.Infrastructure/Services/TicketTailorService.cs
@@ -91,6 +91,7 @@ public class TicketTailorService : ITicketVendorService
                 // Discount codes are in line_items with type "gift_card",
                 // code embedded in description like "NCA Contributor Discount (DISC25-OPGYT8-004)"
                 var discountCode = ExtractDiscountCode(order.LineItems);
+                var discountAmount = ExtractDiscountAmount(order.LineItems);
 
                 orders.Add(new VendorOrderDto(
                     VendorOrderId: order.Id,
@@ -102,7 +103,9 @@ public class TicketTailorService : ITicketVendorService
                     PaymentStatus: order.Status ?? "completed",
                     VendorDashboardUrl: null, // TT doesn't expose dashboard URLs via API
                     PurchasedAt: purchasedAt,
-                    Tickets: []));
+                    Tickets: [],
+                    StripePaymentIntentId: order.TxnId,
+                    DiscountAmount: discountAmount));
             }
 
             cursor = body.Links?.Next is not null ? body.Data[^1].Id : null;
@@ -256,6 +259,21 @@ public class TicketTailorService : ITicketVendorService
         return discountItem.Description;
     }
 
+    /// <summary>
+    /// Sum the absolute value of gift_card line item totals (they're negative in the API).
+    /// Returns null if no discount was applied.
+    /// </summary>
+    private static decimal? ExtractDiscountAmount(List<TtLineItem>? lineItems)
+    {
+        if (lineItems is null) return null;
+
+        var discountCents = lineItems
+            .Where(li => string.Equals(li.Type, "gift_card", StringComparison.OrdinalIgnoreCase))
+            .Sum(li => Math.Abs(li.Total ?? 0));
+
+        return discountCents > 0 ? discountCents / 100m : null;
+    }
+
     // --- TicketTailor API response models ---
     // Must be internal (not private) for System.Text.Json deserialization
 
@@ -274,7 +292,8 @@ public class TicketTailorService : ITicketVendorService
         [property: JsonPropertyName("currency")] TtCurrency? Currency,
         [property: JsonPropertyName("status")] string? Status,
         [property: JsonPropertyName("created_at")] long CreatedAt,
-        [property: JsonPropertyName("line_items")] List<TtLineItem>? LineItems);
+        [property: JsonPropertyName("line_items")] List<TtLineItem>? LineItems,
+        [property: JsonPropertyName("txn_id")] string? TxnId);
 
     internal sealed record TtLineItem(
         [property: JsonPropertyName("description")] string? Description,

--- a/src/Humans.Web/Controllers/TicketController.cs
+++ b/src/Humans.Web/Controllers/TicketController.cs
@@ -79,11 +79,38 @@ public class TicketController : HumansControllerBase
         // Count both Valid and CheckedIn — both are sold tickets
         var ticketsSold = await attendees.CountAsync(a =>
             a.Status == TicketAttendeeStatus.Valid || a.Status == TicketAttendeeStatus.CheckedIn);
-        var revenue = await orders
-            .Where(o => o.PaymentStatus == TicketPaymentStatus.Paid)
-            .SumAsync(o => o.TotalAmount);
+        var paidOrders = orders.Where(o => o.PaymentStatus == TicketPaymentStatus.Paid);
+        var revenue = await paidOrders.SumAsync(o => o.TotalAmount);
+        var totalStripeFees = await paidOrders.SumAsync(o => (decimal?)o.StripeFee ?? 0m);
+        var totalAppFees = await paidOrders.SumAsync(o => (decimal?)o.ApplicationFee ?? 0m);
+        var netRevenue = revenue - totalStripeFees - totalAppFees;
         var avgPrice = ticketsSold > 0 ? revenue / ticketsSold : 0;
         var unmatchedCount = await orders.CountAsync(o => o.MatchedUserId == null);
+
+        // Fee breakdown by payment method (load in memory — small dataset)
+        var feeData = await paidOrders
+            .Where(o => o.PaymentMethod != null)
+            .Select(o => new { o.PaymentMethod, o.PaymentMethodDetail, o.TotalAmount, o.StripeFee, o.ApplicationFee })
+            .ToListAsync();
+
+        var feesByMethod = feeData
+            .GroupBy(o => o.PaymentMethodDetail != null ? $"{o.PaymentMethod}/{o.PaymentMethodDetail}" : o.PaymentMethod!, StringComparer.Ordinal)
+            .Select(g =>
+            {
+                var totalAmt = g.Sum(o => o.TotalAmount);
+                var totalStripe = g.Sum(o => o.StripeFee ?? 0);
+                return new PaymentMethodFeeBreakdown
+                {
+                    PaymentMethod = g.Key,
+                    OrderCount = g.Count(),
+                    TotalAmount = totalAmt,
+                    TotalStripeFees = totalStripe,
+                    TotalApplicationFees = g.Sum(o => o.ApplicationFee ?? 0),
+                    EffectiveRate = totalAmt > 0 ? Math.Round(totalStripe / totalAmt * 100, 2) : 0
+                };
+            })
+            .OrderByDescending(f => f.TotalStripeFees)
+            .ToList();
 
         // Cache vendor event summary (15-min TTL) to avoid API call on every page load
         int totalCapacity = 0;
@@ -165,6 +192,10 @@ public class TicketController : HumansControllerBase
             Revenue = revenue,
             AveragePrice = avgPrice,
             TicketsRemaining = totalCapacity - ticketsSold,
+            TotalStripeFees = totalStripeFees,
+            TotalApplicationFees = totalAppFees,
+            NetRevenue = netRevenue,
+            FeesByPaymentMethod = feesByMethod,
             DailySales = dailySalesPoints,
             UnmatchedOrderCount = unmatchedCount,
             SyncStatus = syncState?.SyncStatus ?? TicketSyncStatus.Idle,
@@ -206,6 +237,11 @@ public class TicketController : HumansControllerBase
                 TotalAmount = o.TotalAmount,
                 Currency = o.Currency,
                 DiscountCode = o.DiscountCode,
+                DiscountAmount = o.DiscountAmount,
+                PaymentMethod = o.PaymentMethod,
+                PaymentMethodDetail = o.PaymentMethodDetail,
+                StripeFee = o.StripeFee,
+                ApplicationFee = o.ApplicationFee,
                 PaymentStatus = o.PaymentStatus,
                 VendorDashboardUrl = o.VendorDashboardUrl,
                 MatchedUserId = o.MatchedUserId,
@@ -503,9 +539,11 @@ public class TicketController : HumansControllerBase
             .ToListAsync();
 
         var csv = new System.Text.StringBuilder();
-        csv.AppendCsvRow("Date", "Purchaser", "Email", "Tickets", "Amount", "Currency", "Code", "Status");
+        csv.AppendCsvRow("Date", "Purchaser", "Email", "Tickets", "Amount", "Currency",
+            "Code", "Discount", "Payment Method", "Stripe Fee", "TT Fee", "Status");
         foreach (var o in orderList)
         {
+            var method = o.PaymentMethodDetail != null ? $"{o.PaymentMethod}/{o.PaymentMethodDetail}" : o.PaymentMethod;
             csv.AppendCsvRow(
                 o.PurchasedAt.InUtc().Date.ToIsoDateString(),
                 o.BuyerName,
@@ -514,6 +552,10 @@ public class TicketController : HumansControllerBase
                 o.TotalAmount,
                 o.Currency,
                 o.DiscountCode,
+                o.DiscountAmount,
+                method,
+                o.StripeFee,
+                o.ApplicationFee,
                 o.PaymentStatus);
         }
 

--- a/src/Humans.Web/Extensions/InfrastructureServiceCollectionExtensions.cs
+++ b/src/Humans.Web/Extensions/InfrastructureServiceCollectionExtensions.cs
@@ -132,6 +132,13 @@ public static class InfrastructureServiceCollectionExtensions
         services.AddHttpClient<ITicketVendorService, TicketTailorService>();
         services.AddScoped<ITicketSyncService, TicketSyncService>();
 
+        // Stripe integration (read-only — fee tracking and payment method attribution)
+        services.Configure<StripeSettings>(opts =>
+        {
+            opts.ApiKey = Environment.GetEnvironmentVariable("STRIPE_API_KEY") ?? string.Empty;
+        });
+        services.AddScoped<IStripeService, StripeService>();
+
         return services;
     }
 }

--- a/src/Humans.Web/Models/TicketViewModels.cs
+++ b/src/Humans.Web/Models/TicketViewModels.cs
@@ -13,6 +13,14 @@ public class TicketDashboardViewModel
     public int BreakEvenTarget { get; set; }
     public string Currency { get; set; } = "EUR";
 
+    // Fee tracking
+    public decimal TotalStripeFees { get; set; }
+    public decimal TotalApplicationFees { get; set; }
+    public decimal NetRevenue { get; set; }
+
+    // Fee breakdown by payment method
+    public List<PaymentMethodFeeBreakdown> FeesByPaymentMethod { get; set; } = [];
+
     // Daily sales chart data
     public List<DailySalesPoint> DailySales { get; set; } = [];
 
@@ -29,6 +37,16 @@ public class TicketDashboardViewModel
 
     // Who hasn't bought count (for dashboard link)
     public int WhoHasntBoughtCount { get; set; }
+}
+
+public class PaymentMethodFeeBreakdown
+{
+    public string PaymentMethod { get; set; } = string.Empty;
+    public int OrderCount { get; set; }
+    public decimal TotalAmount { get; set; }
+    public decimal TotalStripeFees { get; set; }
+    public decimal TotalApplicationFees { get; set; }
+    public decimal EffectiveRate { get; set; } // StripeFee as % of amount
 }
 
 public class DailySalesPoint
@@ -76,6 +94,11 @@ public class TicketOrderRow
     public decimal TotalAmount { get; set; }
     public string Currency { get; set; } = "EUR";
     public string? DiscountCode { get; set; }
+    public decimal? DiscountAmount { get; set; }
+    public string? PaymentMethod { get; set; }
+    public string? PaymentMethodDetail { get; set; }
+    public decimal? StripeFee { get; set; }
+    public decimal? ApplicationFee { get; set; }
     public TicketPaymentStatus PaymentStatus { get; set; }
     public string? VendorDashboardUrl { get; set; }
     public Guid? MatchedUserId { get; set; }

--- a/src/Humans.Web/Views/Ticket/Index.cshtml
+++ b/src/Humans.Web/Views/Ticket/Index.cshtml
@@ -54,16 +54,32 @@
         <div class="col-md-3">
             <div class="card">
                 <div class="card-body">
-                    <h6 class="card-subtitle mb-2 text-muted">Revenue</h6>
+                    <h6 class="card-subtitle mb-2 text-muted">Gross Revenue</h6>
                     <h3 class="card-title">@Model.Currency @Model.Revenue.ToString("N0")</h3>
+                    @if (Model.TotalStripeFees > 0 || Model.TotalApplicationFees > 0)
+                    {
+                        var totalFees = Model.TotalStripeFees + Model.TotalApplicationFees;
+                        var feePct = Model.Revenue > 0 ? Math.Round(totalFees / Model.Revenue * 100, 1) : 0;
+                        <small class="text-muted">@feePct% in fees</small>
+                    }
                 </div>
             </div>
         </div>
         <div class="col-md-3">
             <div class="card">
                 <div class="card-body">
-                    <h6 class="card-subtitle mb-2 text-muted">Avg. Price</h6>
-                    <h3 class="card-title">@Model.Currency @Model.AveragePrice.ToString("N0")</h3>
+                    <h6 class="card-subtitle mb-2 text-muted">Net Revenue</h6>
+                    <h3 class="card-title">@Model.Currency @Model.NetRevenue.ToString("N0")</h3>
+                    @if (Model.TotalStripeFees > 0)
+                    {
+                        <small class="text-muted">
+                            Stripe: @Model.Currency @Model.TotalStripeFees.ToString("N0")
+                            @if (Model.TotalApplicationFees > 0)
+                            {
+                                <text> / TT: @Model.Currency @Model.TotalApplicationFees.ToString("N0")</text>
+                            }
+                        </small>
+                    }
                 </div>
             </div>
         </div>
@@ -86,6 +102,42 @@
             </div>
             <div class="card-body">
                 <canvas id="dailySalesChart" height="100"></canvas>
+            </div>
+        </div>
+    }
+
+    @if (Model.FeesByPaymentMethod.Count > 0)
+    {
+        <div class="card mb-4">
+            <div class="card-header">
+                <i class="fa-solid fa-credit-card"></i> Fees by Payment Method
+            </div>
+            <div class="card-body p-0">
+                <table class="table table-sm table-hover mb-0">
+                    <thead>
+                        <tr>
+                            <th>Payment Method</th>
+                            <th class="text-end">Orders</th>
+                            <th class="text-end">Gross Amount</th>
+                            <th class="text-end">Stripe Fee</th>
+                            <th class="text-end">TT Fee</th>
+                            <th class="text-end">Effective Rate</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var pm in Model.FeesByPaymentMethod)
+                        {
+                            <tr>
+                                <td>@pm.PaymentMethod</td>
+                                <td class="text-end">@pm.OrderCount</td>
+                                <td class="text-end">@Model.Currency @pm.TotalAmount.ToString("N0")</td>
+                                <td class="text-end">@Model.Currency @pm.TotalStripeFees.ToString("N2")</td>
+                                <td class="text-end">@Model.Currency @pm.TotalApplicationFees.ToString("N2")</td>
+                                <td class="text-end">@pm.EffectiveRate%</td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
             </div>
         </div>
     }

--- a/src/Humans.Web/Views/Ticket/Orders.cshtml
+++ b/src/Humans.Web/Views/Ticket/Orders.cshtml
@@ -54,7 +54,10 @@
                     <th>Email</th>
                     <th><a asp-action="Orders" asp-route-sortBy="tickets" asp-route-sortDesc="@(string.Equals(Model.SortBy, "tickets", StringComparison.OrdinalIgnoreCase) ? (!Model.SortDesc).ToString() : "true")" asp-route-search="@Model.Search" asp-route-pageSize="@Model.PageSize" asp-route-filterPaymentStatus="@Model.FilterPaymentStatus" asp-route-filterTicketType="@Model.FilterTicketType" asp-route-filterMatched="@Model.FilterMatched">Tickets</a></th>
                     <th><a asp-action="Orders" asp-route-sortBy="amount" asp-route-sortDesc="@(string.Equals(Model.SortBy, "amount", StringComparison.OrdinalIgnoreCase) ? (!Model.SortDesc).ToString() : "true")" asp-route-search="@Model.Search" asp-route-pageSize="@Model.PageSize" asp-route-filterPaymentStatus="@Model.FilterPaymentStatus" asp-route-filterTicketType="@Model.FilterTicketType" asp-route-filterMatched="@Model.FilterMatched">Amount</a></th>
-                    <th>Code</th>
+                    <th>Discount</th>
+                    <th>Method</th>
+                    <th>Stripe Fee</th>
+                    <th>TT Fee</th>
                     <th>Status</th>
                     <th>Matched</th>
                 </tr>
@@ -69,7 +72,28 @@
                         <td><small>@order.BuyerEmail</small></td>
                         <td><a asp-action="Attendees" asp-route-filterOrderId="@order.VendorOrderId">@order.AttendeeCount</a></td>
                         <td>@order.Currency @order.TotalAmount.ToString("N2")</td>
-                        <td>@(order.DiscountCode ?? "\u2014")</td>
+                        <td>
+                            @if (order.DiscountAmount.HasValue)
+                            {
+                                <span title="@(order.DiscountCode ?? "")">-@order.DiscountAmount.Value.ToString("N2")</span>
+                            }
+                            else
+                            {
+                                <text>&mdash;</text>
+                            }
+                        </td>
+                        <td>
+                            @if (order.PaymentMethod != null)
+                            {
+                                <small>@(order.PaymentMethodDetail != null ? $"{order.PaymentMethod}/{order.PaymentMethodDetail}" : order.PaymentMethod)</small>
+                            }
+                            else
+                            {
+                                <text>&mdash;</text>
+                            }
+                        </td>
+                        <td>@(order.StripeFee.HasValue ? order.StripeFee.Value.ToString("N2") : "\u2014")</td>
+                        <td>@(order.ApplicationFee.HasValue ? order.ApplicationFee.Value.ToString("N2") : "\u2014")</td>
                         <td>
                             @{
                                 var statusClass = order.PaymentStatus switch
@@ -98,7 +122,7 @@
                 }
                 @if (Model.Orders.Count == 0)
                 {
-                    <tr><td colspan="9" class="text-muted text-center">No orders found</td></tr>
+                    <tr><td colspan="13" class="text-muted text-center">No orders found</td></tr>
                 }
             </tbody>
         </table>

--- a/tests/Humans.Application.Tests/Services/TicketSyncServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/TicketSyncServiceTests.cs
@@ -22,6 +22,7 @@ public class TicketSyncServiceTests : IDisposable
     private readonly HumansDbContext _dbContext;
     private readonly FakeClock _clock;
     private readonly ITicketVendorService _vendorService;
+    private readonly IStripeService _stripeService;
     private readonly TicketSyncService _service;
 
     public TicketSyncServiceTests()
@@ -41,9 +42,11 @@ public class TicketSyncServiceTests : IDisposable
             ApiKey = "test_key"
         });
 
+        _stripeService = Substitute.For<IStripeService>();
         _service = new TicketSyncService(
             _dbContext,
             _vendorService,
+            _stripeService,
             _clock,
             settings,
             NullLogger<TicketSyncService>.Instance,
@@ -266,6 +269,7 @@ public class TicketSyncServiceTests : IDisposable
         var service = new TicketSyncService(
             _dbContext,
             _vendorService,
+            _stripeService,
             _clock,
             settings,
             NullLogger<TicketSyncService>.Instance,


### PR DESCRIPTION
## Summary
- Integrates directly with Stripe API to track payment processing fees per ticket order
- During sync, enriches orders with fee breakdown (Stripe processing vs TT application fee) and payment method type (card/visa, link, ideal, bancontact, klarna)
- Dashboard shows gross/net revenue with fee breakdown table by payment method and effective rates
- Orders page and CSV export include discount, payment method, and fee columns

Closes #126 (on upstream)

## Test plan
- [ ] Trigger a ticket sync — verify orders get Stripe fee data populated
- [ ] Check dashboard shows gross revenue, net revenue, fee percentages, and fee breakdown table
- [ ] Check orders page shows new columns (Discount, Method, Stripe Fee, TT Fee)
- [ ] Export orders CSV and verify new columns are present
- [ ] Verify orders without a Stripe PI (e.g. free tickets) show dashes gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)