### PR TITLE
Session 3: Shift UI polish + Public Legal section (#184, #180, #176, #194)

### DIFF
--- a/docs/superpowers/plans/2026-03-23-session3-shift-polish-legal-section.md
+++ b/docs/superpowers/plans/2026-03-23-session3-shift-polish-legal-section.md
@@ -1,0 +1,1031 @@
+# Session 3: Shift UI Polish + Public Legal Section — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement shift UI polish (#184, #180, #176) and a public legal document section (#194).
+
+**Architecture:** Batch 5 is view/label changes plus a new service method for range voluntell. Batch 9 extracts a reusable `LegalDocumentService` from GovernanceController, creates a new public `LegalController`, and adds navigation links.
+
+**Tech Stack:** ASP.NET Core 9, EF Core, Razor views, xUnit + NSubstitute + AwesomeAssertions, NodaTime, Octokit (GitHub API)
+
+**Spec:** `docs/superpowers/specs/2026-03-23-session3-shift-polish-legal-section.md`
+
+**Issues:** #184, #180, #176, #194
+
+---
+
+## File Map
+
+### Batch 5: Shift UI Polish
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Modify | `src/Humans.Web/Views/Shifts/Index.cshtml` | #184: heading + button text; #180: period headers + labeled date pickers |
+| Modify | `src/Humans.Web/Views/Shifts/Mine.cshtml` | #184: "Browse Shifts" link text |
+| Modify | `src/Humans.Web/Views/Home/_ShiftCards.cshtml` | #184: "Browse Shifts" button text |
+| Modify | `src/Humans.Web/Views/Vol/Register.cshtml` | #184: "Browse Shifts" link text |
+| Modify | `src/Humans.Web/Views/Team/Details.cshtml` | #184: remove duplicate shift link, always show shifts card |
+| Modify | `src/Humans.Web/Views/Shared/_ShiftsSummaryCard.cshtml` | #184: handle empty summary state |
+| Modify | `src/Humans.Web/Controllers/TeamController.cs` | #184: always provide ShiftsSummary for departments |
+| Modify | `src/Humans.Infrastructure/Services/TeamPageService.cs` | #184: always return summary for departments |
+| Modify | `src/Humans.Infrastructure/Services/ShiftSignupService.cs` | #176: add VoluntellRangeAsync |
+| Modify | `src/Humans.Application/Interfaces/IShiftSignupService.cs` | #176: add VoluntellRangeAsync to interface |
+| Modify | `src/Humans.Web/Controllers/ShiftAdminController.cs` | #176: add VoluntellRange action |
+| Modify | `src/Humans.Web/Views/ShiftAdmin/Index.cshtml` | #176: range voluntell form UI |
+| Modify | `tests/Humans.Application.Tests/Services/ShiftSignupServiceTests.cs` | #176: tests for VoluntellRangeAsync |
+
+### Batch 9: Public Legal Section
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Create | `src/Humans.Application/Interfaces/ILegalDocumentService.cs` | Interface + LegalDocumentDefinition record |
+| Create | `src/Humans.Infrastructure/Services/LegalDocumentService.cs` | GitHub-fetching impl with per-doc caching |
+| Create | `src/Humans.Web/Controllers/LegalController.cs` | Public legal page controller |
+| Create | `src/Humans.Web/Models/LegalPageViewModel.cs` | View model for legal page |
+| Create | `src/Humans.Web/Views/Legal/Index.cshtml` | Pill nav + full-page tabbed doc viewer |
+| Create | `tests/Humans.Application.Tests/Services/LegalDocumentServiceTests.cs` | Service tests |
+| Modify | `src/Humans.Web/Controllers/GovernanceController.cs` | Refactor to use ILegalDocumentService |
+| Modify | `src/Humans.Application/CacheKeys.cs` | Add Legal document cache key pattern |
+| Modify | `src/Humans.Web/Program.cs` | Register ILegalDocumentService |
+| Modify | `src/Humans.Web/Authorization/MembershipRequiredFilter.cs` | Exempt LegalController |
+| Modify | `src/Humans.Web/Views/Shared/_Layout.cshtml` | Add public "Legal" nav link |
+| Modify | `src/Humans.Web/Views/Shared/_LoginPartial.cshtml` | Add "Legal" to profile dropdown |
+
+---
+
+## Task 1: Shift UI Text/Label Cleanup (#184)
+
+**Files:**
+- Modify: `src/Humans.Web/Views/Shifts/Index.cshtml:37,147`
+- Modify: `src/Humans.Web/Views/Shifts/Mine.cshtml:39`
+- Modify: `src/Humans.Web/Views/Home/_ShiftCards.cshtml:47`
+- Modify: `src/Humans.Web/Views/Vol/Register.cshtml:51`
+- Modify: `src/Humans.Web/Views/Team/Details.cshtml:299-301,334-339`
+- Modify: `src/Humans.Web/Views/Shared/_ShiftsSummaryCard.cshtml`
+- Modify: `src/Humans.Infrastructure/Services/TeamPageService.cs:137-173`
+- Modify: `src/Humans.Web/Controllers/TeamController.cs:202-217`
+
+- [ ] **Step 1: Change "Browse Shifts" → "Browse Volunteer Options" in Shifts/Index.cshtml**
+
+In `src/Humans.Web/Views/Shifts/Index.cshtml`, line 37, change:
+```html
+<h2>Browse Shifts</h2>
+```
+to:
+```html
+<h2>Browse Volunteer Options</h2>
+```
+
+- [ ] **Step 2: Change "Sign Up for Range" button text in Shifts/Index.cshtml**
+
+In `src/Humans.Web/Views/Shifts/Index.cshtml`, line 147, change:
+```html
+<button type="submit" class="btn btn-sm btn-success">Sign Up for Range</button>
+```
+to a period-specific label (this form only appears for Build/Strike rotas):
+```html
+<button type="submit" class="btn btn-sm btn-success">
+    Sign up for @(rotaGroup.Rota.Period == RotaPeriod.Build ? "set-up" : "strike") dates
+</button>
+```
+Note: Task 2 will group rotas by period, but this button text works regardless since the `isBuildStrike` check already limits it to Build/Strike.
+
+- [ ] **Step 3: Change "Browse Shifts" in Mine.cshtml**
+
+In `src/Humans.Web/Views/Shifts/Mine.cshtml`, line 39, change:
+```html
+<a asp-action="Index" class="btn btn-outline-primary">Browse Shifts</a>
+```
+to:
+```html
+<a asp-action="Index" class="btn btn-outline-primary">Browse Volunteer Options</a>
+```
+
+- [ ] **Step 4: Change "Browse Shifts" in _ShiftCards.cshtml**
+
+In `src/Humans.Web/Views/Home/_ShiftCards.cshtml`, line 47, change:
+```html
+<a asp-controller="Shifts" asp-action="Index" class="btn btn-sm btn-outline-success">Browse Shifts</a>
+```
+to:
+```html
+<a asp-controller="Shifts" asp-action="Index" class="btn btn-sm btn-outline-success">Browse Volunteer Options</a>
+```
+
+- [ ] **Step 5: Change "Browse Shifts" in Register.cshtml**
+
+In `src/Humans.Web/Views/Vol/Register.cshtml`, line 51, change `Browse Shifts` to `Browse Volunteer Options` (keep the icon).
+
+- [ ] **Step 6: Remove duplicate shift link from Team Management card**
+
+In `src/Humans.Web/Views/Team/Details.cshtml`, delete lines 334-339:
+```html
+@if (Model.ParentTeam == null && !Model.IsSystemTeam)
+{
+    <a asp-controller="ShiftAdmin" asp-action="Index" asp-route-slug="@Model.Slug" class="list-group-item list-group-item-action">
+        @Localizer["Nav_Shifts"]
+    </a>
+}
+```
+
+- [ ] **Step 7: Make Shifts card always show for departments**
+
+In `src/Humans.Infrastructure/Services/TeamPageService.cs`, modify `GetShiftsSummaryAsync()` (around line 137) to return a summary even when no shifts exist for departments. If the team is a non-child, non-system team and the user is authenticated, return a `TeamPageShiftsSummary` with zero counts instead of `null`.
+
+- [ ] **Step 8: Update _ShiftsSummaryCard to handle empty state**
+
+In `src/Humans.Web/Views/Shared/_ShiftsSummaryCard.cshtml`, wrap the progress bar and stats in a conditional so they only show when `Model.TotalSlots > 0`. The "Manage Shifts" button should always show when `Model.CanManageShifts`:
+
+```html
+@if (Model.TotalSlots > 0)
+{
+    @* existing progress bar and stats (lines 8-27) *@
+}
+@if (Model.CanManageShifts)
+{
+    <a href="@Model.ShiftsUrl" class="btn btn-sm btn-outline-primary mt-2 w-100">Manage Shifts</a>
+}
+```
+
+- [ ] **Step 9: Build and verify**
+
+Run: `dotnet build src/Humans.Web`
+Expected: Build succeeds with no errors.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/Humans.Web/Views/Shifts/Index.cshtml src/Humans.Web/Views/Shifts/Mine.cshtml \
+  src/Humans.Web/Views/Home/_ShiftCards.cshtml src/Humans.Web/Views/Vol/Register.cshtml \
+  src/Humans.Web/Views/Team/Details.cshtml src/Humans.Web/Views/Shared/_ShiftsSummaryCard.cshtml \
+  src/Humans.Infrastructure/Services/TeamPageService.cs src/Humans.Web/Controllers/TeamController.cs
+git commit -m "fix: shift UI text/label cleanup and always show shifts card (#184)"
+```
+
+---
+
+## Task 2: Clarify Rota Period Separation (#180)
+
+**Files:**
+- Modify: `src/Humans.Web/Views/Shifts/Index.cshtml:90-170`
+
+- [ ] **Step 1: Group rotas by period and add section headers**
+
+In `src/Humans.Web/Views/Shifts/Index.cshtml`, inside the department card body (around line 94), change from iterating `dept.Rotas` directly to grouping by period first:
+
+```csharp
+@{
+    var rotasByPeriod = dept.Rotas
+        .GroupBy(r => r.Rota.Period)
+        .OrderBy(g => g.Key) // Build=0, Event=1, Strike=2
+        .ToList();
+}
+@foreach (var periodGroup in rotasByPeriod)
+{
+    var periodName = periodGroup.Key == RotaPeriod.Build ? "Set-up"
+        : periodGroup.Key == RotaPeriod.Strike ? "Strike"
+        : "Event";
+    <h5 class="mt-4 mb-2 border-bottom pb-1">
+        <span class="badge @(periodGroup.Key == RotaPeriod.Build ? "bg-info" : periodGroup.Key == RotaPeriod.Strike ? "bg-secondary" : "bg-success") me-1">@periodName</span>
+        @periodName
+    </h5>
+    @foreach (var rotaGroup in periodGroup)
+    {
+        @* existing rota rendering code *@
+    }
+}
+```
+
+- [ ] **Step 2: Add empty period note**
+
+When a period group has rotas but all shifts are full or unavailable, show a note. Inside each period group's `@foreach`, after the rota rendering, add a check: if no rota in the group has available shifts, display:
+
+```html
+@{
+    var hasAvailable = periodGroup.Any(r => r.Shifts.Any(s => s.RemainingSlots > 0));
+}
+@if (!hasAvailable)
+{
+    <p class="text-muted fst-italic">All @periodName.ToLower() shifts are full.</p>
+}
+```
+
+- [ ] **Step 3: Build and verify**
+
+Run: `dotnet build src/Humans.Web`
+Expected: Build succeeds.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Humans.Web/Views/Shifts/Index.cshtml
+git commit -m "feat: add period section headers and labeled date pickers (#180)"
+```
+
+---
+
+## Task 3: Batch Voluntell Service Method + Tests (#176)
+
+**Files:**
+- Modify: `src/Humans.Application/Interfaces/IShiftSignupService.cs`
+- Modify: `src/Humans.Infrastructure/Services/ShiftSignupService.cs`
+- Modify: `tests/Humans.Application.Tests/Services/ShiftSignupServiceTests.cs`
+
+- [ ] **Step 1: Write failing test — VoluntellRange creates confirmed signups across date range**
+
+In `tests/Humans.Application.Tests/Services/ShiftSignupServiceTests.cs`, add:
+
+```csharp
+[Fact]
+public async Task VoluntellRange_CreatesConfirmedSignupsAcrossDateRange()
+{
+    var (es, rota, _) = SeedShiftScenario(SignupPolicy.RequireApproval);
+    // Seed 3 consecutive all-day shifts
+    var shift1 = SeedAllDayShift(rota, dayOffset: 0);
+    var shift2 = SeedAllDayShift(rota, dayOffset: 1);
+    var shift3 = SeedAllDayShift(rota, dayOffset: 2);
+    var volunteerId = Guid.NewGuid();
+    var enrollerId = Guid.NewGuid();
+    await _dbContext.SaveChangesAsync();
+
+    var result = await _service.VoluntellRangeAsync(volunteerId, rota.Id, 0, 2, enrollerId);
+
+    result.Success.Should().BeTrue();
+    var signups = await _dbContext.ShiftSignups
+        .Where(s => s.UserId == volunteerId)
+        .ToListAsync();
+    signups.Should().HaveCount(3);
+    signups.Should().AllSatisfy(s =>
+    {
+        s.Status.Should().Be(SignupStatus.Confirmed);
+        s.Enrolled.Should().BeTrue();
+        s.EnrolledByUserId.Should().Be(enrollerId);
+    });
+    // All should share a SignupBlockId
+    signups.Select(s => s.SignupBlockId).Distinct().Should().HaveCount(1);
+}
+```
+
+Note: you may need to add a `SeedAllDayShift` helper if one doesn't exist. Check the existing test helpers in the file — look for how `SeedShiftScenario` creates shifts and replicate the pattern for multiple all-day shifts.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test tests/Humans.Application.Tests --filter "VoluntellRange_CreatesConfirmedSignupsAcrossDateRange" -v n`
+Expected: FAIL — `VoluntellRangeAsync` method does not exist.
+
+- [ ] **Step 3: Write failing test — VoluntellRange skips existing signups**
+
+```csharp
+[Fact]
+public async Task VoluntellRange_SkipsShiftsWhereUserAlreadySignedUp()
+{
+    var (es, rota, _) = SeedShiftScenario(SignupPolicy.RequireApproval);
+    var shift1 = SeedAllDayShift(rota, dayOffset: 0);
+    var shift2 = SeedAllDayShift(rota, dayOffset: 1);
+    var volunteerId = Guid.NewGuid();
+    var enrollerId = Guid.NewGuid();
+    // Pre-existing signup on shift1
+    _dbContext.ShiftSignups.Add(new ShiftSignup
+    {
+        Id = Guid.NewGuid(),
+        UserId = volunteerId,
+        ShiftId = shift1.Id,
+        Status = SignupStatus.Confirmed,
+        CreatedAt = TestNow,
+        UpdatedAt = TestNow
+    });
+    await _dbContext.SaveChangesAsync();
+
+    var result = await _service.VoluntellRangeAsync(volunteerId, rota.Id, 0, 1, enrollerId);
+
+    result.Success.Should().BeTrue();
+    var newSignups = await _dbContext.ShiftSignups
+        .Where(s => s.UserId == volunteerId && s.EnrolledByUserId == enrollerId)
+        .ToListAsync();
+    newSignups.Should().HaveCount(1);
+    newSignups[0].ShiftId.Should().Be(shift2.Id);
+}
+```
+
+- [ ] **Step 4: Write failing test — VoluntellRange returns error for invalid rota**
+
+```csharp
+[Fact]
+public async Task VoluntellRange_ReturnsError_WhenRotaNotFound()
+{
+    var volunteerId = Guid.NewGuid();
+    var enrollerId = Guid.NewGuid();
+
+    var result = await _service.VoluntellRangeAsync(volunteerId, Guid.NewGuid(), 0, 2, enrollerId);
+
+    result.Success.Should().BeFalse();
+    result.Error.Should().NotBeNullOrEmpty();
+}
+```
+
+- [ ] **Step 5: Add VoluntellRangeAsync to IShiftSignupService interface**
+
+In `src/Humans.Application/Interfaces/IShiftSignupService.cs`, add:
+
+```csharp
+Task<SignupResult> VoluntellRangeAsync(Guid userId, Guid rotaId, int startDayOffset, int endDayOffset, Guid enrollerUserId);
+```
+
+- [ ] **Step 6: Implement VoluntellRangeAsync in ShiftSignupService**
+
+In `src/Humans.Infrastructure/Services/ShiftSignupService.cs`, add the method after `VoluntellAsync`:
+
+```csharp
+public async Task<SignupResult> VoluntellRangeAsync(
+    Guid userId, Guid rotaId, int startDayOffset, int endDayOffset, Guid enrollerUserId)
+{
+    var rota = await _dbContext.Rotas
+        .Include(r => r.Shifts)
+        .FirstOrDefaultAsync(r => r.Id == rotaId);
+
+    if (rota is null)
+        return SignupResult.Fail("Rota not found.");
+
+    var shiftsInRange = rota.Shifts
+        .Where(s => s.IsAllDay && s.DayOffset >= startDayOffset && s.DayOffset <= endDayOffset)
+        .OrderBy(s => s.DayOffset)
+        .ToList();
+
+    if (shiftsInRange.Count == 0)
+        return SignupResult.Fail("No shifts found in the specified range.");
+
+    // Check for existing signups to skip
+    var existingSignupShiftIds = await _dbContext.ShiftSignups
+        .Where(s => s.UserId == userId
+            && shiftsInRange.Select(sh => sh.Id).Contains(s.ShiftId)
+            && (s.Status == SignupStatus.Confirmed || s.Status == SignupStatus.Pending))
+        .Select(s => s.ShiftId)
+        .ToListAsync();
+
+    var shiftsToAssign = shiftsInRange
+        .Where(s => !existingSignupShiftIds.Contains(s.Id))
+        .ToList();
+
+    if (shiftsToAssign.Count == 0)
+        return SignupResult.Fail("Volunteer is already signed up for all shifts in this range.");
+
+    var now = _clock.GetCurrentInstant();
+    var blockId = Guid.NewGuid();
+
+    foreach (var shift in shiftsToAssign)
+    {
+        var signup = new ShiftSignup
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            ShiftId = shift.Id,
+            Status = SignupStatus.Confirmed,
+            Enrolled = true,
+            EnrolledByUserId = enrollerUserId,
+            ReviewedByUserId = enrollerUserId,
+            ReviewedAt = now,
+            SignupBlockId = blockId,
+            CreatedAt = now,
+            UpdatedAt = now
+        };
+        _dbContext.ShiftSignups.Add(signup);
+    }
+
+    await _dbContext.SaveChangesAsync();
+
+    // SignupResult.Ok takes a ShiftSignup — return the first one created
+    var firstSignup = await _dbContext.ShiftSignups
+        .FirstAsync(s => s.SignupBlockId == blockId);
+    return SignupResult.Ok(firstSignup);
+}
+```
+
+Note: Verify the exact `SignupResult.Ok` signature — it takes a `ShiftSignup` parameter. If the caller needs to know how many shifts were assigned, the success message in the controller can say "Volunteer assigned to {count} shifts."
+
+- [ ] **Step 7: Run all tests to verify they pass**
+
+Run: `dotnet test tests/Humans.Application.Tests --filter "VoluntellRange" -v n`
+Expected: All 3 tests PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/Humans.Application/Interfaces/IShiftSignupService.cs \
+  src/Humans.Infrastructure/Services/ShiftSignupService.cs \
+  tests/Humans.Application.Tests/Services/ShiftSignupServiceTests.cs
+git commit -m "feat: add VoluntellRangeAsync for batch shift assignment (#176)"
+```
+
+---
+
+## Task 4: Batch Voluntell Controller + Admin UI (#176)
+
+**Depends on:** Task 3
+
+**Files:**
+- Modify: `src/Humans.Web/Controllers/ShiftAdminController.cs`
+- Modify: `src/Humans.Web/Views/ShiftAdmin/Index.cshtml`
+
+- [ ] **Step 1: Add VoluntellRange action to ShiftAdminController**
+
+In `src/Humans.Web/Controllers/ShiftAdminController.cs`, add after the existing `Voluntell` action (around line 526):
+
+```csharp
+[HttpPost("VoluntellRange")]
+[ValidateAntiForgeryToken]
+public async Task<IActionResult> VoluntellRange(string slug, Guid rotaId, int startDayOffset, int endDayOffset, Guid userId)
+{
+    var (teamError, currentUser, team) = await ResolveDepartmentApprovalAsync(slug);
+    if (teamError is not null) return teamError;
+
+    var rota = await _shiftMgmt.GetRotaByIdAsync(rotaId);
+    if (rota is null) return NotFound();
+    if (rota.TeamId != team.Id) return NotFound();
+
+    var result = await _signupService.VoluntellRangeAsync(userId, rotaId, startDayOffset, endDayOffset, currentUser.Id);
+    if (result.Success)
+    {
+        SetSuccess("Volunteer assigned to shift range.");
+    }
+    else
+    {
+        SetError(result.Error ?? "Range assignment failed.");
+    }
+
+    return RedirectToAction(nameof(Index), new { slug });
+}
+```
+
+Note: Check if `_shiftMgmt.GetRotaByIdAsync` exists. If not, use the pattern from the existing `Voluntell` action to validate the rota belongs to the team. You may need to query the rota through `_dbContext` or an existing service method.
+
+- [ ] **Step 2: Add range voluntell form to ShiftAdmin view**
+
+In `src/Humans.Web/Views/ShiftAdmin/Index.cshtml`, for Build/Strike rotas only, add a range voluntell form at the top of each rota section (before the shift table). Place it after the rota header and description, gated on `Model.CanApproveSignups`. Use the same pattern as the volunteer-facing range signup but with an additional volunteer search field:
+
+```html
+@if (Model.CanApproveSignups && isBuildStrike)
+{
+    var availableAdminShifts = allDayShifts.Where(s => !s.IsPast).ToList();
+    if (availableAdminShifts.Count > 0)
+    {
+        var rangeFormId = $"voluntell-range-{rota.Id}";
+        <div class="card card-body bg-light mb-3">
+            <form asp-action="VoluntellRange" method="post" class="row g-2 align-items-end" id="@rangeFormId">
+                @Html.AntiForgeryToken()
+                <input type="hidden" name="rotaId" value="@rota.Id" />
+                <div class="col-auto">
+                    <label class="form-label form-label-sm">Start</label>
+                    <select name="startDayOffset" class="form-select form-select-sm">
+                        @foreach (var s in availableAdminShifts)
+                        {
+                            <option value="@s.Shift.DayOffset">@es.GateOpeningDate.PlusDays(s.Shift.DayOffset).ToDisplayShiftDate()</option>
+                        }
+                    </select>
+                </div>
+                <div class="col-auto">
+                    <label class="form-label form-label-sm">End</label>
+                    <select name="endDayOffset" class="form-select form-select-sm">
+                        @foreach (var s in availableAdminShifts)
+                        {
+                            <option value="@s.Shift.DayOffset" selected="@(s == availableAdminShifts.Last() ? "selected" : null)">@es.GateOpeningDate.PlusDays(s.Shift.DayOffset).ToDisplayShiftDate()</option>
+                        }
+                    </select>
+                </div>
+                <div class="col-auto">
+                    <label class="form-label form-label-sm">Volunteer</label>
+                    <input type="text" class="form-control form-control-sm voluntell-range-search"
+                           data-rota-id="@rota.Id"
+                           placeholder="Search by name (min 2 chars)..." />
+                    <input type="hidden" name="userId" class="voluntell-range-user-id" data-rota-id="@rota.Id" />
+                    <div class="voluntell-range-results" data-rota-id="@rota.Id"></div>
+                </div>
+                <div class="col-auto">
+                    <button type="submit" class="btn btn-sm btn-success">Assign to Range</button>
+                </div>
+            </form>
+        </div>
+    }
+}
+```
+
+- [ ] **Step 3: Add JavaScript for range voluntell search**
+
+At the bottom of `src/Humans.Web/Views/ShiftAdmin/Index.cshtml`, in the existing `@section Scripts` block, add JS that handles the `.voluntell-range-search` inputs. Follow the exact same AJAX pattern as the existing single-shift volunteer search but target the range-specific CSS classes:
+
+```javascript
+document.querySelectorAll('.voluntell-range-search').forEach(input => {
+    let debounceTimer;
+    input.addEventListener('input', function () {
+        const rotaId = this.dataset.rotaId;
+        const query = this.value.trim();
+        const resultsDiv = document.querySelector(`.voluntell-range-results[data-rota-id="${rotaId}"]`);
+        const userIdInput = document.querySelector(`.voluntell-range-user-id[data-rota-id="${rotaId}"]`);
+
+        clearTimeout(debounceTimer);
+        if (query.length < 2) {
+            resultsDiv.innerHTML = '';
+            return;
+        }
+
+        debounceTimer = setTimeout(async () => {
+            const response = await fetch(`${window.location.pathname}/SearchVolunteers?query=${encodeURIComponent(query)}`);
+            const volunteers = await response.json();
+            resultsDiv.innerHTML = volunteers.map(v =>
+                `<div class="dropdown-item voluntell-range-pick" style="cursor:pointer"
+                      data-user-id="${v.id}" data-rota-id="${rotaId}">
+                    ${v.displayName}
+                </div>`
+            ).join('');
+        }, 300);
+    });
+});
+
+document.addEventListener('click', function (e) {
+    if (e.target.classList.contains('voluntell-range-pick')) {
+        const rotaId = e.target.dataset.rotaId;
+        const userId = e.target.dataset.userId;
+        const name = e.target.textContent.trim();
+        document.querySelector(`.voluntell-range-user-id[data-rota-id="${rotaId}"]`).value = userId;
+        document.querySelector(`.voluntell-range-search[data-rota-id="${rotaId}"]`).value = name;
+        document.querySelector(`.voluntell-range-results[data-rota-id="${rotaId}"]`).innerHTML = '';
+    }
+});
+```
+
+Note: Review the existing volunteer search JS in the same file and match its exact patterns (API endpoint URL construction, response shape, error handling). The above is a starting point — adapt to match.
+
+- [ ] **Step 4: Build and verify**
+
+Run: `dotnet build src/Humans.Web`
+Expected: Build succeeds.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Humans.Web/Controllers/ShiftAdminController.cs \
+  src/Humans.Web/Views/ShiftAdmin/Index.cshtml
+git commit -m "feat: add range voluntell UI for batch shift assignment (#176)"
+```
+
+---
+
+## Task 5: LegalDocumentService — Interface + Implementation + Tests (#194)
+
+**Files:**
+- Create: `src/Humans.Application/Interfaces/ILegalDocumentService.cs`
+- Create: `src/Humans.Infrastructure/Services/LegalDocumentService.cs`
+- Create: `tests/Humans.Application.Tests/Services/LegalDocumentServiceTests.cs`
+- Modify: `src/Humans.Application/CacheKeys.cs`
+- Modify: `src/Humans.Web/Program.cs`
+
+- [ ] **Step 1: Write failing test — GetAvailableDocuments returns document list**
+
+Create `tests/Humans.Application.Tests/Services/LegalDocumentServiceTests.cs`:
+
+```csharp
+using Humans.Application.Interfaces;
+using Humans.Infrastructure.Services;
+using Humans.Infrastructure.Configuration;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Humans.Application.Tests.Services;
+
+public class LegalDocumentServiceTests
+{
+    private readonly ILegalDocumentService _service;
+
+    public LegalDocumentServiceTests()
+    {
+        var cache = new MemoryCache(new MemoryCacheOptions());
+        var logger = Substitute.For<ILogger<LegalDocumentService>>();
+        var settings = new GitHubSettings
+        {
+            Owner = "nobodies-collective",
+            Repository = "legal"
+        };
+        _service = new LegalDocumentService(cache, logger, settings);
+    }
+
+    [Fact]
+    public void GetAvailableDocuments_ReturnsStatutes()
+    {
+        var docs = _service.GetAvailableDocuments();
+
+        docs.Should().NotBeEmpty();
+        docs.Should().Contain(d => d.Slug == "statutes");
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test tests/Humans.Application.Tests --filter "GetAvailableDocuments_ReturnsStatutes" -v n`
+Expected: FAIL — types do not exist.
+
+- [ ] **Step 3: Create ILegalDocumentService interface**
+
+Create `src/Humans.Application/Interfaces/ILegalDocumentService.cs`:
+
+```csharp
+namespace Humans.Application.Interfaces;
+
+public record LegalDocumentDefinition(string Slug, string DisplayName, string RepoFolder, string FilePrefix);
+
+public interface ILegalDocumentService
+{
+    IReadOnlyList<LegalDocumentDefinition> GetAvailableDocuments();
+    Task<Dictionary<string, string>> GetDocumentContentAsync(string slug);
+}
+```
+
+- [ ] **Step 4: Add cache key to CacheKeys.cs**
+
+In `src/Humans.Application/CacheKeys.cs`, add:
+
+```csharp
+public static string LegalDocument(string slug) => $"Legal:{slug}";
+```
+
+- [ ] **Step 5: Create LegalDocumentService implementation**
+
+Create `src/Humans.Infrastructure/Services/LegalDocumentService.cs`:
+
+```csharp
+using System.Text.RegularExpressions;
+using Humans.Application;
+using Humans.Application.Interfaces;
+using Humans.Infrastructure.Configuration;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using Octokit;
+
+namespace Humans.Infrastructure.Services;
+
+public class LegalDocumentService : ILegalDocumentService
+{
+    private static readonly LegalDocumentDefinition[] Documents =
+    [
+        new("statutes", "Statutes", "Estatutos", "ESTATUTOS"),
+    ];
+
+    private static readonly Regex LanguageFilePattern = new(
+        @"^(?<name>.+?)(?:-(?<lang>[A-Za-z]{2}))?\.md$",
+        RegexOptions.Compiled,
+        TimeSpan.FromSeconds(1));
+
+    private static readonly TimeSpan CacheTtl = TimeSpan.FromHours(1);
+
+    private readonly IMemoryCache _cache;
+    private readonly ILogger<LegalDocumentService> _logger;
+    private readonly GitHubSettings _gitHubSettings;
+
+    public LegalDocumentService(
+        IMemoryCache cache,
+        ILogger<LegalDocumentService> logger,
+        GitHubSettings gitHubSettings)
+    {
+        _cache = cache;
+        _logger = logger;
+        _gitHubSettings = gitHubSettings;
+    }
+
+    public IReadOnlyList<LegalDocumentDefinition> GetAvailableDocuments() => Documents;
+
+    public async Task<Dictionary<string, string>> GetDocumentContentAsync(string slug)
+    {
+        var definition = Documents.FirstOrDefault(d =>
+            string.Equals(d.Slug, slug, StringComparison.OrdinalIgnoreCase));
+
+        if (definition is null)
+            return new Dictionary<string, string>(StringComparer.Ordinal);
+
+        try
+        {
+            return await _cache.GetOrCreateAsync(
+                CacheKeys.LegalDocument(slug),
+                async entry =>
+                {
+                    entry.AbsoluteExpirationRelativeToNow = CacheTtl;
+                    return await FetchDocumentContentAsync(definition);
+                }) ?? new Dictionary<string, string>(StringComparer.Ordinal);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to fetch legal document {Slug} from GitHub", slug);
+            return new Dictionary<string, string>(StringComparer.Ordinal);
+        }
+    }
+
+    private async Task<Dictionary<string, string>> FetchDocumentContentAsync(LegalDocumentDefinition definition)
+    {
+        var client = new GitHubClient(new ProductHeaderValue("NobodiesHumans"));
+        if (!string.IsNullOrEmpty(_gitHubSettings.AccessToken))
+        {
+            client.Credentials = new Credentials(_gitHubSettings.AccessToken);
+        }
+
+        var files = await client.Repository.Content.GetAllContents(
+            _gitHubSettings.Owner,
+            _gitHubSettings.Repository,
+            definition.RepoFolder);
+
+        var content = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var file in files.Where(f =>
+            f.Name.StartsWith(definition.FilePrefix, StringComparison.OrdinalIgnoreCase) &&
+            f.Name.EndsWith(".md", StringComparison.OrdinalIgnoreCase)))
+        {
+            var match = LanguageFilePattern.Match(file.Name);
+            if (!match.Success) continue;
+
+            var lang = match.Groups["lang"].Success
+                ? match.Groups["lang"].Value.ToLowerInvariant()
+                : "es";
+
+            var fileContent = await client.Repository.Content.GetAllContents(
+                _gitHubSettings.Owner,
+                _gitHubSettings.Repository,
+                file.Path);
+
+            if (fileContent.Count > 0 && fileContent[0].Content is not null)
+            {
+                content[lang] = fileContent[0].Content;
+            }
+        }
+
+        return content;
+    }
+}
+```
+
+- [ ] **Step 6: Register service in Program.cs**
+
+In `src/Humans.Web/Program.cs`, find where other services are registered (search for `AddScoped<IShiftSignupService>` or similar) and add:
+
+```csharp
+builder.Services.AddScoped<ILegalDocumentService, LegalDocumentService>();
+```
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `dotnet test tests/Humans.Application.Tests --filter "LegalDocumentService" -v n`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/Humans.Application/Interfaces/ILegalDocumentService.cs \
+  src/Humans.Infrastructure/Services/LegalDocumentService.cs \
+  src/Humans.Application/CacheKeys.cs \
+  src/Humans.Web/Program.cs \
+  tests/Humans.Application.Tests/Services/LegalDocumentServiceTests.cs
+git commit -m "feat: add LegalDocumentService with GitHub fetching and caching (#194)"
+```
+
+---
+
+## Task 6: LegalController + View + Navigation (#194)
+
+**Depends on:** Task 5
+
+**Files:**
+- Create: `src/Humans.Web/Controllers/LegalController.cs`
+- Create: `src/Humans.Web/Models/LegalPageViewModel.cs`
+- Create: `src/Humans.Web/Views/Legal/Index.cshtml`
+- Modify: `src/Humans.Web/Authorization/MembershipRequiredFilter.cs`
+- Modify: `src/Humans.Web/Views/Shared/_Layout.cshtml`
+- Modify: `src/Humans.Web/Views/Shared/_LoginPartial.cshtml`
+
+- [ ] **Step 1: Create LegalPageViewModel**
+
+Create `src/Humans.Web/Models/LegalPageViewModel.cs`:
+
+```csharp
+using Humans.Application.Interfaces;
+
+namespace Humans.Web.Models;
+
+public class LegalPageViewModel
+{
+    public required IReadOnlyList<LegalDocumentDefinition> AllDocuments { get; init; }
+    public required string CurrentSlug { get; init; }
+    public required string CurrentDocumentName { get; init; }
+    public required TabbedMarkdownDocumentsViewModel DocumentContent { get; init; }
+}
+```
+
+- [ ] **Step 2: Create LegalController**
+
+Create `src/Humans.Web/Controllers/LegalController.cs`:
+
+```csharp
+using Humans.Application.Interfaces;
+using Humans.Web.Extensions;
+using Humans.Web.Models;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Humans.Web.Controllers;
+
+[Route("Legal")]
+[AllowAnonymous]
+public class LegalController : Controller
+{
+    private readonly ILegalDocumentService _legalDocService;
+
+    public LegalController(ILegalDocumentService legalDocService)
+    {
+        _legalDocService = legalDocService;
+    }
+
+    [HttpGet("{slug?}")]
+    public async Task<IActionResult> Index(string? slug)
+    {
+        var documents = _legalDocService.GetAvailableDocuments();
+        if (documents.Count == 0)
+            return NotFound();
+
+        var currentDoc = slug is not null
+            ? documents.FirstOrDefault(d => string.Equals(d.Slug, slug, StringComparison.OrdinalIgnoreCase))
+            : documents[0];
+
+        if (currentDoc is null)
+            return NotFound();
+
+        var content = await _legalDocService.GetDocumentContentAsync(currentDoc.Slug);
+        var orderedContent = content.OrderByDisplayLanguage(canonicalFirst: true).ToList();
+        var defaultLang = content.GetDefaultDocumentLanguage();
+
+        var viewModel = new LegalPageViewModel
+        {
+            AllDocuments = documents,
+            CurrentSlug = currentDoc.Slug,
+            CurrentDocumentName = currentDoc.DisplayName,
+            DocumentContent = new TabbedMarkdownDocumentsViewModel
+            {
+                Documents = orderedContent,
+                DefaultLanguage = defaultLang,
+                TabsId = "legal-tabs",
+                ContentId = "legal-tabs-content",
+                ContentStyle = "",  // Full-page, no max-height
+                EmptyMessage = "Document not yet available.",
+                UseLegalLanguageLabels = true
+            }
+        };
+
+        ViewData["Title"] = currentDoc.DisplayName;
+        return View(viewModel);
+    }
+}
+```
+
+- [ ] **Step 3: Add "Legal" to MembershipRequiredFilter exempt list**
+
+In `src/Humans.Web/Authorization/MembershipRequiredFilter.cs`, add `"Legal"` to the `ExemptControllers` set (around line 15-32).
+
+- [ ] **Step 4: Create Legal/Index.cshtml view**
+
+Create `src/Humans.Web/Views/Legal/Index.cshtml`:
+
+```html
+@model Humans.Web.Models.LegalPageViewModel
+
+@{
+    ViewData["Title"] = Model.CurrentDocumentName;
+}
+
+<h2>@Model.CurrentDocumentName</h2>
+
+@if (Model.AllDocuments.Count > 1)
+{
+    <ul class="nav nav-pills mb-4">
+        @foreach (var doc in Model.AllDocuments)
+        {
+            <li class="nav-item">
+                <a class="nav-link @(doc.Slug == Model.CurrentSlug ? "active" : "")"
+                   asp-action="Index" asp-route-slug="@doc.Slug">
+                    @doc.DisplayName
+                </a>
+            </li>
+        }
+    </ul>
+}
+
+@await Html.PartialAsync("_TabbedMarkdownDocuments", Model.DocumentContent)
+```
+
+- [ ] **Step 5: Add "Legal" link to navbar for logged-out users**
+
+In `src/Humans.Web/Views/Shared/_Layout.cshtml`, after the Teams nav item (around line 47) and before the `@if (User.Identity?.IsAuthenticated == true)` check (line 48), add:
+
+```html
+@if (User.Identity?.IsAuthenticated != true)
+{
+    <li class="nav-item">
+        <a class="nav-link" asp-controller="Legal" asp-action="Index">Legal</a>
+    </li>
+}
+```
+
+- [ ] **Step 6: Add "Legal" link to profile dropdown for logged-in users**
+
+In `src/Humans.Web/Views/Shared/_LoginPartial.cshtml`, after the Governance link (around line 58), add:
+
+```html
+<li>
+    <a class="dropdown-item d-flex align-items-center gap-2" asp-controller="Legal" asp-action="Index">
+        <i class="fa-solid fa-scale-balanced fa-fw"></i> Legal
+    </a>
+</li>
+```
+
+- [ ] **Step 7: Build and verify**
+
+Run: `dotnet build src/Humans.Web`
+Expected: Build succeeds.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/Humans.Web/Controllers/LegalController.cs \
+  src/Humans.Web/Models/LegalPageViewModel.cs \
+  src/Humans.Web/Views/Legal/Index.cshtml \
+  src/Humans.Web/Authorization/MembershipRequiredFilter.cs \
+  src/Humans.Web/Views/Shared/_Layout.cshtml \
+  src/Humans.Web/Views/Shared/_LoginPartial.cshtml
+git commit -m "feat: add public Legal section with pill nav and tabbed doc viewer (#194)"
+```
+
+---
+
+## Task 7: Refactor GovernanceController to Use LegalDocumentService (#194)
+
+**Depends on:** Task 5
+
+**Files:**
+- Modify: `src/Humans.Web/Controllers/GovernanceController.cs`
+
+- [ ] **Step 1: Replace GitHub fetching with ILegalDocumentService injection**
+
+In `src/Humans.Web/Controllers/GovernanceController.cs`:
+
+1. Remove these fields/constants:
+   - `private static readonly Regex LanguageFilePattern` (lines 33-36)
+   - `private static readonly TimeSpan StatutesCacheTtl` (line 32)
+   - `private readonly IMemoryCache _cache` field
+   - `private readonly GitHubSettings _gitHubSettings` field
+
+2. Add `ILegalDocumentService` to the constructor:
+   ```csharp
+   private readonly ILegalDocumentService _legalDocService;
+   ```
+
+3. Update constructor to inject `ILegalDocumentService` instead of `IMemoryCache` and `GitHubSettings`. Keep other existing dependencies (`IClock`, `ILogger`, etc.).
+
+4. In the `Index` action, replace the call to `GetStatutesContentAsync()` with:
+   ```csharp
+   var statutesContent = await _legalDocService.GetDocumentContentAsync("statutes");
+   ```
+
+5. Delete private methods:
+   - `GetStatutesContentAsync()` (lines 92-107)
+   - `FetchStatutesContentAsync()` (lines 109-147)
+
+6. Remove unused `using` statements (`Octokit`, `Microsoft.Extensions.Caching.Memory` if no longer needed).
+
+- [ ] **Step 2: Build and verify**
+
+Run: `dotnet build src/Humans.Web`
+Expected: Build succeeds.
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `dotnet test Humans.slnx`
+Expected: All tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Humans.Web/Controllers/GovernanceController.cs
+git commit -m "refactor: GovernanceController uses shared LegalDocumentService (#194)"
+```
+
+---
+
+## Dependency Graph
+
+```
+Task 1 (#184 labels)          ─── independent
+Task 2 (#180 rota separation) ─── independent (but touches same file as Task 1)
+Task 3 (#176 service)         ─── independent
+Task 4 (#176 UI)              ─── depends on Task 3
+Task 5 (#194 service)         ─── independent
+Task 6 (#194 controller+nav)  ─── depends on Task 5
+Task 7 (#194 governance)      ─── depends on Task 5
+```
+
+**Parallel groups:**
+- Group A: Tasks 1, 2 (shift views — overlap on Index.cshtml, merge carefully)
+- Group B: Tasks 3 → 4 (voluntell, sequential)
+- Group C: Tasks 5 → 6, 7 (legal, 6 and 7 can run in parallel after 5)

--- a/docs/superpowers/specs/2026-03-23-session3-shift-polish-legal-section.md
+++ b/docs/superpowers/specs/2026-03-23-session3-shift-polish-legal-section.md
@@ -30,7 +30,7 @@ Four locations:
 - Change: always render the Shifts card for department teams (parent teams that aren't system teams)
 - When no `ShiftsSummary` data exists, show just the "Manage Shifts" button without the progress bar
 - Requires the controller to always provide a `ShiftsUrl` even when there are no shifts yet
-- May need a minimal `ShiftsSummaryCardViewModel` with just the URL and `CanManageShifts` flag
+- Controller must always populate a `ShiftsSummaryCardViewModel` for departments — with zero counts if no shifts exist, plus the URL and `CanManageShifts` flag
 
 #### Nav_Shifts resource key
 
@@ -88,7 +88,7 @@ Logic combines `SignUpRangeAsync` (date range iteration, `SignupBlockId` for gro
 - Create confirmed signups with shared `SignupBlockId`
 - Set `Enrolled = true` and `EnrolledByUserId = enrollerUserId`
 - Skip shifts where user is already signed up (don't error, just skip)
-- Check for overlap conflicts (error if any)
+- Check for overlap conflicts — same semantics as existing `VoluntellAsync` (error if user already has a confirmed/pending signup on the same shift)
 - Return `SignupResult` with count of assigned shifts
 
 #### New controller action: `VoluntellRange`
@@ -163,7 +163,7 @@ public class LegalController : Controller
 ```
 
 - Add `"Legal"` to `MembershipRequiredFilter` exempt list
-- Single action: `GET /Legal/{slug?}` defaults to first document
+- Single action: `GET /Legal/{slug?}` defaults to first document; returns 404 for invalid slugs
 
 **View model:**
 

--- a/docs/superpowers/specs/2026-03-23-session3-shift-polish-legal-section.md
+++ b/docs/superpowers/specs/2026-03-23-session3-shift-polish-legal-section.md
@@ -1,0 +1,215 @@
+# Session 3: Shift UI Polish + Public Legal Section
+
+**Date:** 2026-03-23
+**Issues:** #184, #180, #176, #194
+
+## Batch 5: Shift UI Polish
+
+### #184 — Text/Label Cleanup
+
+#### 1. "Browse Shifts" → "Browse Volunteer Options"
+
+Four locations:
+- `Views/Shifts/Index.cshtml:37` — page `<h2>` heading
+- `Views/Shifts/Mine.cshtml:39` — link back to browse
+- `Views/Home/_ShiftCards.cshtml:47` — dashboard link button
+- `Views/Vol/Register.cshtml:51` — onboarding link
+
+#### 2. "Sign Up for Range" → "Sign up for these dates"
+
+- `Views/Shifts/Index.cshtml:147` — range signup form button
+
+#### 3. Remove duplicate shift link from Team Management card
+
+- Delete lines 334-339 in `Views/Team/Details.cshtml` (the `Nav_Shifts` link in Team Management card)
+- The Shifts summary card (`_ShiftsSummaryCard.cshtml`) already has "Manage Shifts" — this is the single entry point
+
+#### 4. Always show Shifts card for departments
+
+- `Views/Team/Details.cshtml:299` — currently gated on `Model.ShiftsSummary != null`
+- Change: always render the Shifts card for department teams (parent teams that aren't system teams)
+- When no `ShiftsSummary` data exists, show just the "Manage Shifts" button without the progress bar
+- Requires the controller to always provide a `ShiftsUrl` even when there are no shifts yet
+- May need a minimal `ShiftsSummaryCardViewModel` with just the URL and `CanManageShifts` flag
+
+#### Nav_Shifts resource key
+
+`Nav_Shifts` currently resolves to "Volunteer" in all locales. This is used in:
+- Main navbar (`_Layout.cshtml:54`) — keep as-is, "Volunteer" is correct for the public nav link
+- Team Management card (`Details.cshtml:337`) — being removed entirely
+
+No resource key changes needed.
+
+---
+
+### #180 — Clarify Rota Separation (Build/Event/Strike)
+
+#### Period section headers
+
+Group rotas by period within each department card. Add bold section headers before each period group:
+- **"Set-up"** (Build period)
+- **"Event"** (Event period)
+- **"Strike"** (Strike period)
+
+With a horizontal rule or visual divider between period groups.
+
+#### Period-labeled date pickers
+
+Relabel the range signup form button per period:
+- Build rotas: **"Sign up for set-up dates"**
+- Strike rotas: **"Sign up for strike dates"**
+
+#### Empty period note
+
+If a period group has rotas but all shifts are full, show: "All [period] shifts are full."
+
+#### Implementation
+
+Changes in `Views/Shifts/Index.cshtml`:
+- Group `dept.Rotas` by `Rota.Period` before iterating
+- Add period header `<h5>` with the period display name and a `<hr>` divider
+- Modify the range signup button text to include the period name
+
+---
+
+### #176 — Batch Voluntell (Range Assignment)
+
+#### New service method: `VoluntellRangeAsync`
+
+In `ShiftSignupService.cs`:
+
+```csharp
+public async Task<SignupResult> VoluntellRangeAsync(
+    Guid userId, Guid rotaId, int startDayOffset, int endDayOffset, Guid enrollerUserId)
+```
+
+Logic combines `SignUpRangeAsync` (date range iteration, `SignupBlockId` for grouped bail) with `VoluntellAsync` (confirmed signup, `EnrolledByUserId`, no approval needed):
+- Iterate all-day shifts in the rota between `startDayOffset` and `endDayOffset`
+- Create confirmed signups with shared `SignupBlockId`
+- Set `Enrolled = true` and `EnrolledByUserId = enrollerUserId`
+- Skip shifts where user is already signed up (don't error, just skip)
+- Check for overlap conflicts (error if any)
+- Return `SignupResult` with count of assigned shifts
+
+#### New controller action: `VoluntellRange`
+
+In `ShiftAdminController.cs`:
+
+```csharp
+[HttpPost("VoluntellRange")]
+[ValidateAntiForgeryToken]
+public async Task<IActionResult> VoluntellRange(string slug, Guid rotaId, int startDayOffset, int endDayOffset, Guid userId)
+```
+
+- Requires `ResolveDepartmentApprovalAsync` (same auth as single Voluntell)
+- Validates rota belongs to team
+- Calls `VoluntellRangeAsync`
+- Redirects back to ShiftAdmin Index
+
+#### Admin view UI
+
+In `Views/ShiftAdmin/Index.cshtml`, for Build/Strike rotas only:
+- Single form at the top of each rota section (above the shift table)
+- Date range picker: start/end `<select>` dropdowns with available day offsets
+- Volunteer search field: text input with JS-driven search (reusing existing `SearchVolunteers` pattern)
+- Submit button: "Assign to Range"
+- Only visible when `Model.CanApproveSignups`
+
+---
+
+## Batch 9: Public Legal Section (#194)
+
+### New service: `ILegalDocumentService` / `LegalDocumentService`
+
+**Interface** in `Humans.Application`:
+
+```csharp
+public interface ILegalDocumentService
+{
+    IReadOnlyList<LegalDocumentDefinition> GetAvailableDocuments();
+    Task<Dictionary<string, string>> GetDocumentContentAsync(string slug);
+}
+
+public record LegalDocumentDefinition(string Slug, string DisplayName, string RepoFolder, string FilePrefix);
+```
+
+**Implementation** in `Humans.Infrastructure`:
+
+Hardcoded document definitions:
+```csharp
+private static readonly LegalDocumentDefinition[] Documents =
+[
+    new("statutes", "Statutes", "Estatutos", "ESTATUTOS"),
+    // Future: new("privacy-policy", "Privacy Policy", "Privacy", "PRIVACY"),
+];
+```
+
+**Methods:**
+- `GetAvailableDocuments()` — returns the static list
+- `GetDocumentContentAsync(string slug)` — looks up definition by slug, fetches from GitHub using `RepoFolder` + `FilePrefix`, caches per-document with key `Legal:{slug}`, 1-hour TTL
+
+**GitHub fetching:** Generalized from `GovernanceController.FetchStatutesContentAsync()`:
+- Uses `GitHubSettings` for owner/repo/token/branch
+- Fetches all `.md` files in `RepoFolder` matching `FilePrefix*`
+- Extracts language code from filename via existing `LanguageFilePattern` regex
+- Returns `Dictionary<string, string>` (lang code → markdown content)
+
+### New controller: `LegalController`
+
+```csharp
+[Route("Legal")]
+[AllowAnonymous]
+public class LegalController : Controller
+```
+
+- Add `"Legal"` to `MembershipRequiredFilter` exempt list
+- Single action: `GET /Legal/{slug?}` defaults to first document
+
+**View model:**
+
+```csharp
+public class LegalPageViewModel
+{
+    public IReadOnlyList<LegalDocumentDefinition> AllDocuments { get; init; }
+    public string CurrentSlug { get; init; }
+    public string CurrentDocumentName { get; init; }
+    public TabbedMarkdownDocumentsViewModel DocumentContent { get; init; }
+}
+```
+
+**View** (`Views/Legal/Index.cshtml`):
+- Pill nav across top: `<ul class="nav nav-pills mb-4">` listing all documents, active pill for current slug
+- Below: full-page `_TabbedMarkdownDocuments` partial with no height constraint (override `ContentStyle` to remove `max-height: 500px`)
+- Page title: current document name
+
+### Navigation changes
+
+**Logged out** (`_Layout.cshtml`):
+- Add "Legal" link in top navbar, after Teams, before any auth-gated items
+- Visible to all visitors
+
+**Logged in** (`_LoginPartial.cshtml`):
+- Add "Legal" link in profile dropdown menu
+- Icon: `fa-scale-balanced`
+- Placed after Governance link (or after Consents if user doesn't see Governance)
+
+### Governance page refactoring
+
+- `GovernanceController` injects `ILegalDocumentService` instead of `IMemoryCache` + `GitHubClient`
+- `Index` action calls `_legalDocService.GetDocumentContentAsync("statutes")`
+- Delete private methods: `GetStatutesContentAsync()`, `FetchStatutesContentAsync()`
+- Delete `StatutesCacheTtl` constant and `LanguageFilePattern` regex (moved to service)
+- View unchanged — still embeds statutes in its existing card layout with `max-height` scroll
+
+### Adding new documents
+
+To add a new legal document (e.g., Privacy Policy):
+1. Add markdown files to `nobodies-collective/legal` repo (e.g., `Privacy/PRIVACY.md`, `Privacy/PRIVACY-en.md`)
+2. Add entry to `LegalDocumentService.Documents` array
+3. No other code changes — pill nav auto-populates, routing handles it
+
+---
+
+## Future work
+
+- #198: Refactor shift views into reusable partials (low priority)

--- a/src/Humans.Application/CacheKeys.cs
+++ b/src/Humans.Application/CacheKeys.cs
@@ -17,4 +17,6 @@ public static class CacheKeys
     public static string RoleAssignmentClaims(Guid userId) => $"claims:{userId:N}";
 
     public static string ShiftAuthorization(Guid userId) => $"shift-auth:{userId:N}";
+
+    public static string LegalDocument(string slug) => $"Legal:{slug}";
 }

--- a/src/Humans.Application/CacheKeys.cs
+++ b/src/Humans.Application/CacheKeys.cs
@@ -6,7 +6,6 @@ public static class CacheKeys
     public const string ApprovedProfiles = "ApprovedProfiles";
     public const string ActiveTeams = "ActiveTeams";
     public const string CampSettings = "CampSettings";
-    public const string GovernanceStatutes = "GovernanceStatutes";
     public const string TicketEventSummary = "TicketEventSummary";
 
     public static string CampSeasonsByYear(int year) => $"camps_year_{year}";

--- a/src/Humans.Application/Interfaces/ILegalDocumentService.cs
+++ b/src/Humans.Application/Interfaces/ILegalDocumentService.cs
@@ -1,0 +1,9 @@
+namespace Humans.Application.Interfaces;
+
+public record LegalDocumentDefinition(string Slug, string DisplayName, string RepoFolder, string FilePrefix);
+
+public interface ILegalDocumentService
+{
+    IReadOnlyList<LegalDocumentDefinition> GetAvailableDocuments();
+    Task<Dictionary<string, string>> GetDocumentContentAsync(string slug);
+}

--- a/src/Humans.Application/Interfaces/IShiftSignupService.cs
+++ b/src/Humans.Application/Interfaces/IShiftSignupService.cs
@@ -34,6 +34,13 @@ public interface IShiftSignupService
     Task<SignupResult> VoluntellAsync(Guid userId, Guid shiftId, Guid enrollerUserId);
 
     /// <summary>
+    /// Creates confirmed signups across a date range on behalf of a volunteer (batch voluntell).
+    /// Skips shifts where the user already has an active signup.
+    /// All signups share a SignupBlockId for grouped bail.
+    /// </summary>
+    Task<SignupResult> VoluntellRangeAsync(Guid userId, Guid rotaId, int startDayOffset, int endDayOffset, Guid enrollerUserId);
+
+    /// <summary>
     /// Marks a confirmed signup as no-show (post-shift only).
     /// </summary>
     Task<SignupResult> MarkNoShowAsync(Guid signupId, Guid reviewerUserId);

--- a/src/Humans.Infrastructure/Services/LegalDocumentService.cs
+++ b/src/Humans.Infrastructure/Services/LegalDocumentService.cs
@@ -1,0 +1,108 @@
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Octokit;
+using Humans.Application;
+using Humans.Application.Interfaces;
+using Humans.Infrastructure.Configuration;
+
+namespace Humans.Infrastructure.Services;
+
+public partial class LegalDocumentService : ILegalDocumentService
+{
+    private static readonly IReadOnlyList<LegalDocumentDefinition> Documents =
+    [
+        new("statutes", "Statutes", "Estatutos", "ESTATUTOS"),
+    ];
+
+    private static readonly TimeSpan CacheTtl = TimeSpan.FromHours(1);
+
+    [GeneratedRegex(@"^(?<name>.+?)(?:-(?<lang>[A-Za-z]{2}))?\.md$", RegexOptions.None, 1000)]
+    private static partial Regex LanguageFilePattern();
+
+    private readonly IMemoryCache _cache;
+    private readonly ILogger<LegalDocumentService> _logger;
+    private readonly GitHubSettings _gitHubSettings;
+
+    public LegalDocumentService(
+        IMemoryCache cache,
+        ILogger<LegalDocumentService> logger,
+        IOptions<GitHubSettings> gitHubSettings)
+    {
+        _cache = cache;
+        _logger = logger;
+        _gitHubSettings = gitHubSettings.Value;
+    }
+
+    public IReadOnlyList<LegalDocumentDefinition> GetAvailableDocuments() => Documents;
+
+    public async Task<Dictionary<string, string>> GetDocumentContentAsync(string slug)
+    {
+        var cacheKey = CacheKeys.LegalDocument(slug);
+
+        return await _cache.GetOrCreateAsync(cacheKey, async entry =>
+        {
+            entry.AbsoluteExpirationRelativeToNow = CacheTtl;
+
+            try
+            {
+                var definition = Documents.FirstOrDefault(d =>
+                    string.Equals(d.Slug, slug, StringComparison.OrdinalIgnoreCase));
+
+                if (definition is null)
+                {
+                    _logger.LogWarning("Unknown legal document slug: {Slug}", slug);
+                    return new Dictionary<string, string>(StringComparer.Ordinal);
+                }
+
+                return await FetchDocumentContentAsync(definition);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to fetch legal document {Slug} from GitHub", slug);
+                return new Dictionary<string, string>(StringComparer.Ordinal);
+            }
+        }) ?? new Dictionary<string, string>(StringComparer.Ordinal);
+    }
+
+    private async Task<Dictionary<string, string>> FetchDocumentContentAsync(LegalDocumentDefinition definition)
+    {
+        var client = new GitHubClient(new ProductHeaderValue("NobodiesHumans"));
+        if (!string.IsNullOrEmpty(_gitHubSettings.AccessToken))
+        {
+            client.Credentials = new Credentials(_gitHubSettings.AccessToken);
+        }
+
+        var files = await client.Repository.Content.GetAllContents(
+            _gitHubSettings.Owner,
+            _gitHubSettings.Repository,
+            definition.RepoFolder);
+
+        var content = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var file in files.Where(f =>
+            f.Name.StartsWith(definition.FilePrefix, StringComparison.OrdinalIgnoreCase) &&
+            f.Name.EndsWith(".md", StringComparison.OrdinalIgnoreCase)))
+        {
+            var match = LanguageFilePattern().Match(file.Name);
+            if (!match.Success) continue;
+
+            var lang = match.Groups["lang"].Success
+                ? match.Groups["lang"].Value.ToLowerInvariant()
+                : "es";
+
+            // Fetch full content (GetAllContents for a directory only returns metadata)
+            var fileContent = await client.Repository.Content.GetAllContents(
+                _gitHubSettings.Owner,
+                _gitHubSettings.Repository,
+                file.Path);
+
+            if (fileContent.Count > 0 && fileContent[0].Content is not null)
+            {
+                content[lang] = fileContent[0].Content;
+            }
+        }
+
+        return content;
+    }
+}

--- a/src/Humans.Infrastructure/Services/ShiftSignupService.cs
+++ b/src/Humans.Infrastructure/Services/ShiftSignupService.cs
@@ -267,6 +267,76 @@ public class ShiftSignupService : IShiftSignupService
         return SignupResult.Ok(signup);
     }
 
+    public async Task<SignupResult> VoluntellRangeAsync(Guid userId, Guid rotaId, int startDayOffset, int endDayOffset, Guid enrollerUserId)
+    {
+        var rota = await _dbContext.Rotas
+            .Include(r => r.EventSettings)
+            .Include(r => r.Shifts)
+            .FirstOrDefaultAsync(r => r.Id == rotaId);
+
+        if (rota is null) return SignupResult.Fail("Rota not found.");
+
+        // Find all-day shifts in the range
+        var shiftsInRange = rota.Shifts
+            .Where(s => s.IsAllDay && s.DayOffset >= startDayOffset && s.DayOffset <= endDayOffset)
+            .OrderBy(s => s.DayOffset)
+            .ToList();
+
+        if (shiftsInRange.Count == 0)
+            return SignupResult.Fail("No shifts found in the specified date range.");
+
+        // Check for existing signups to skip (Confirmed or Pending)
+        var shiftIdsInRange = shiftsInRange.Select(s => s.Id).ToHashSet();
+        var existingShiftIds = await _dbContext.ShiftSignups
+            .Where(s => s.UserId == userId && shiftIdsInRange.Contains(s.ShiftId) &&
+                         (s.Status == SignupStatus.Pending || s.Status == SignupStatus.Confirmed))
+            .Select(s => s.ShiftId)
+            .ToHashSetAsync();
+
+        var shiftsToAssign = shiftsInRange
+            .Where(s => !existingShiftIds.Contains(s.Id))
+            .ToList();
+
+        if (shiftsToAssign.Count == 0)
+            return SignupResult.Fail("Already signed up for all shifts in this range.");
+
+        // Create confirmed signups with shared SignupBlockId
+        var blockId = Guid.NewGuid();
+        var now = _clock.GetCurrentInstant();
+        ShiftSignup? firstSignup = null;
+
+        foreach (var shift in shiftsToAssign)
+        {
+            var signup = new ShiftSignup
+            {
+                Id = Guid.NewGuid(),
+                UserId = userId,
+                ShiftId = shift.Id,
+                SignupBlockId = blockId,
+                Status = SignupStatus.Confirmed,
+                Enrolled = true,
+                EnrolledByUserId = enrollerUserId,
+                ReviewedByUserId = enrollerUserId,
+                ReviewedAt = now,
+                CreatedAt = now,
+                UpdatedAt = now
+            };
+
+            _dbContext.ShiftSignups.Add(signup);
+            firstSignup ??= signup;
+
+            await _auditLogService.LogAsync(
+                AuditAction.ShiftSignupVoluntold, nameof(ShiftSignup), signup.Id,
+                $"Voluntold range for '{rota.Name}' day {shift.DayOffset} (block {blockId})",
+                enrollerUserId, "Enroller",
+                userId, nameof(User));
+        }
+
+        await _dbContext.SaveChangesAsync();
+
+        return SignupResult.Ok(firstSignup!);
+    }
+
     public async Task<SignupResult> MarkNoShowAsync(Guid signupId, Guid reviewerUserId)
     {
         var signup = await LoadSignupWithShiftAsync(signupId);

--- a/src/Humans.Infrastructure/Services/ShiftSignupService.cs
+++ b/src/Humans.Infrastructure/Services/ShiftSignupService.cs
@@ -300,12 +300,31 @@ public class ShiftSignupService : IShiftSignupService
         if (shiftsToAssign.Count == 0)
             return SignupResult.Fail("Already signed up for all shifts in this range.");
 
+        // Overlap check — skip shifts that conflict with existing confirmed signups in other rotas
+        var es = rota.EventSettings;
+        var skippedOverlaps = new List<string>();
+        var assignable = new List<Shift>();
+        foreach (var shift in shiftsToAssign)
+        {
+            var overlapWarning = await CheckOverlapAsync(userId, shift, es);
+            if (overlapWarning is not null)
+                skippedOverlaps.Add(overlapWarning);
+            else
+                assignable.Add(shift);
+        }
+
+        if (assignable.Count == 0)
+            return SignupResult.Fail("All shifts in range have time conflicts with existing signups.");
+
         // Create confirmed signups with shared SignupBlockId
         var blockId = Guid.NewGuid();
         var now = _clock.GetCurrentInstant();
         ShiftSignup? firstSignup = null;
+        string? warning = skippedOverlaps.Count > 0
+            ? $"Skipped {skippedOverlaps.Count} shift(s) due to time conflicts."
+            : null;
 
-        foreach (var shift in shiftsToAssign)
+        foreach (var shift in assignable)
         {
             var signup = new ShiftSignup
             {
@@ -334,7 +353,7 @@ public class ShiftSignupService : IShiftSignupService
 
         await _dbContext.SaveChangesAsync();
 
-        return SignupResult.Ok(firstSignup!);
+        return SignupResult.Ok(firstSignup!, warning);
     }
 
     public async Task<SignupResult> MarkNoShowAsync(Guid signupId, Guid reviewerUserId)

--- a/src/Humans.Infrastructure/Services/TeamPageService.cs
+++ b/src/Humans.Infrastructure/Services/TeamPageService.cs
@@ -149,20 +149,20 @@ public class TeamPageService : ITeamPageService
             return null;
         }
 
+        var canManageShifts = canManageShiftsByRole ||
+            await _shiftManagementService.IsDeptCoordinatorAsync(userId.Value, team.Id);
+
         var activeEvent = await _shiftManagementService.GetActiveAsync();
         if (activeEvent is null)
         {
-            return null;
+            return new TeamPageShiftsSummary(0, 0, 0, 0, canManageShifts);
         }
 
         var summaryData = await _shiftManagementService.GetShiftsSummaryAsync(activeEvent.Id, team.Id);
         if (summaryData is null)
         {
-            return null;
+            return new TeamPageShiftsSummary(0, 0, 0, 0, canManageShifts);
         }
-
-        var canManageShifts = canManageShiftsByRole ||
-            await _shiftManagementService.IsDeptCoordinatorAsync(userId.Value, team.Id);
 
         return new TeamPageShiftsSummary(
             summaryData.TotalSlots,

--- a/src/Humans.Web/Authorization/MembershipRequiredFilter.cs
+++ b/src/Humans.Web/Authorization/MembershipRequiredFilter.cs
@@ -29,6 +29,7 @@ public class MembershipRequiredFilter : IAsyncActionFilter
         "CampApi",          // Public API ([AllowAnonymous])
         "Feedback",         // Feedback submission — accessible to all authenticated users
         "FeedbackApi",      // API key auth, no membership required
+        "Legal",            // Public legal documents ([AllowAnonymous])
     };
 
     public Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)

--- a/src/Humans.Web/Controllers/GovernanceController.cs
+++ b/src/Humans.Web/Controllers/GovernanceController.cs
@@ -1,17 +1,12 @@
-using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Caching.Memory;
-using Microsoft.Extensions.Options;
 using NodaTime;
-using Octokit;
 using Humans.Application;
 using Humans.Application.Interfaces;
 using Humans.Domain.Constants;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
-using Humans.Infrastructure.Configuration;
 using Humans.Web.Extensions;
 using Humans.Web.Models;
 
@@ -22,24 +17,16 @@ namespace Humans.Web.Controllers;
 public class GovernanceController : HumansControllerBase
 {
     private readonly ILogger<GovernanceController> _logger;
-    private readonly IMemoryCache _cache;
-    private readonly GitHubSettings _gitHubSettings;
+    private readonly ILegalDocumentService _legalDocService;
     private readonly IProfileService _profileService;
     private readonly IApplicationDecisionService _applicationDecisionService;
     private readonly IRoleAssignmentService _roleAssignmentService;
     private readonly IClock _clock;
 
-    private static readonly TimeSpan StatutesCacheTtl = TimeSpan.FromHours(1);
-    private static readonly Regex LanguageFilePattern = new(
-        @"^(?<name>.+?)(?:-(?<lang>[A-Za-z]{2}))?\.md$",
-        RegexOptions.Compiled,
-        TimeSpan.FromSeconds(1));
-
     public GovernanceController(
         UserManager<Domain.Entities.User> userManager,
         ILogger<GovernanceController> logger,
-        IMemoryCache cache,
-        IOptions<GitHubSettings> gitHubSettings,
+        ILegalDocumentService legalDocService,
         IProfileService profileService,
         IApplicationDecisionService applicationDecisionService,
         IRoleAssignmentService roleAssignmentService,
@@ -47,8 +34,7 @@ public class GovernanceController : HumansControllerBase
         : base(userManager)
     {
         _logger = logger;
-        _cache = cache;
-        _gitHubSettings = gitHubSettings.Value;
+        _legalDocService = legalDocService;
         _profileService = profileService;
         _applicationDecisionService = applicationDecisionService;
         _roleAssignmentService = roleAssignmentService;
@@ -64,7 +50,7 @@ public class GovernanceController : HumansControllerBase
         var applications = await _applicationDecisionService.GetUserApplicationsAsync(user.Id);
         var latestApplication = applications.Count > 0 ? applications[0] : null;
 
-        var statutesContent = await GetStatutesContentAsync();
+        var statutesContent = await _legalDocService.GetDocumentContentAsync("statutes");
 
         // Tier member counts for the sidebar
         var (colaboradorCount, asociadoCount) = await _profileService.GetTierCountsAsync();
@@ -84,66 +70,6 @@ public class GovernanceController : HumansControllerBase
         };
 
         return View(viewModel);
-    }
-
-    /// <summary>
-    /// Fetches statutes markdown content from GitHub, cached for 1 hour.
-    /// </summary>
-    private async Task<Dictionary<string, string>> GetStatutesContentAsync()
-    {
-        try
-        {
-            return await _cache.GetOrCreateAsync(CacheKeys.GovernanceStatutes, async entry =>
-            {
-                entry.AbsoluteExpirationRelativeToNow = StatutesCacheTtl;
-                return await FetchStatutesContentAsync();
-            }) ?? new Dictionary<string, string>(StringComparer.Ordinal);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Failed to fetch statutes from GitHub");
-            return new Dictionary<string, string>(StringComparer.Ordinal);
-        }
-    }
-
-    private async Task<Dictionary<string, string>> FetchStatutesContentAsync()
-    {
-        var client = new GitHubClient(new ProductHeaderValue("NobodiesHumans"));
-        if (!string.IsNullOrEmpty(_gitHubSettings.AccessToken))
-        {
-            client.Credentials = new Credentials(_gitHubSettings.AccessToken);
-        }
-
-        var files = await client.Repository.Content.GetAllContents(
-            _gitHubSettings.Owner,
-            _gitHubSettings.Repository,
-            "Estatutos");
-
-        var content = new Dictionary<string, string>(StringComparer.Ordinal);
-        foreach (var file in files.Where(f =>
-            f.Name.StartsWith("ESTATUTOS", StringComparison.OrdinalIgnoreCase) &&
-            f.Name.EndsWith(".md", StringComparison.OrdinalIgnoreCase)))
-        {
-            var match = LanguageFilePattern.Match(file.Name);
-            if (!match.Success) continue;
-
-            var lang = match.Groups["lang"].Success
-                ? match.Groups["lang"].Value.ToLowerInvariant()
-                : "es";
-
-            // Fetch full content (GetAllContents for a directory only returns metadata)
-            var fileContent = await client.Repository.Content.GetAllContents(
-                _gitHubSettings.Owner,
-                _gitHubSettings.Repository,
-                file.Path);
-
-            if (fileContent.Count > 0 && fileContent[0].Content is not null)
-            {
-                content[lang] = fileContent[0].Content;
-            }
-        }
-
-        return content;
     }
 
     [Authorize(Roles = RoleGroups.BoardOrAdmin)]

--- a/src/Humans.Web/Controllers/LegalController.cs
+++ b/src/Humans.Web/Controllers/LegalController.cs
@@ -1,0 +1,58 @@
+using Humans.Application.Interfaces;
+using Humans.Web.Extensions;
+using Humans.Web.Models;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Humans.Web.Controllers;
+
+[Route("Legal")]
+[AllowAnonymous]
+public class LegalController : Controller
+{
+    private readonly ILegalDocumentService _legalDocService;
+
+    public LegalController(ILegalDocumentService legalDocService)
+    {
+        _legalDocService = legalDocService;
+    }
+
+    [HttpGet("{slug?}")]
+    public async Task<IActionResult> Index(string? slug)
+    {
+        var documents = _legalDocService.GetAvailableDocuments();
+        if (documents.Count == 0)
+            return NotFound();
+
+        var currentDoc = slug is not null
+            ? documents.FirstOrDefault(d => string.Equals(d.Slug, slug, StringComparison.OrdinalIgnoreCase))
+            : documents[0];
+
+        if (currentDoc is null)
+            return NotFound();
+
+        var content = await _legalDocService.GetDocumentContentAsync(currentDoc.Slug);
+        var orderedContent = content.OrderByDisplayLanguage(canonicalFirst: true).ToList();
+        var defaultLang = content.GetDefaultDocumentLanguage();
+
+        var viewModel = new LegalPageViewModel
+        {
+            AllDocuments = documents,
+            CurrentSlug = currentDoc.Slug,
+            CurrentDocumentName = currentDoc.DisplayName,
+            DocumentContent = new TabbedMarkdownDocumentsViewModel
+            {
+                Documents = orderedContent,
+                DefaultLanguage = defaultLang,
+                TabsId = "legal-tabs",
+                ContentId = "legal-tabs-content",
+                ContentStyle = "",
+                EmptyMessage = "Document not yet available.",
+                UseLegalLanguageLabels = true
+            }
+        };
+
+        ViewData["Title"] = currentDoc.DisplayName;
+        return View(viewModel);
+    }
+}

--- a/src/Humans.Web/Controllers/ShiftAdminController.cs
+++ b/src/Humans.Web/Controllers/ShiftAdminController.cs
@@ -560,6 +560,30 @@ public class ShiftAdminController : HumansTeamControllerBase
         return RedirectToAction(nameof(Index), new { slug });
     }
 
+    [HttpPost("VoluntellRange")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> VoluntellRange(string slug, Guid rotaId, int startDayOffset, int endDayOffset, Guid userId)
+    {
+        var (teamError, currentUser, team) = await ResolveDepartmentApprovalAsync(slug);
+        if (teamError is not null) return teamError;
+
+        var rota = await _shiftMgmt.GetRotaByIdAsync(rotaId);
+        if (rota is null) return NotFound();
+        if (rota.TeamId != team.Id) return NotFound();
+
+        var result = await _signupService.VoluntellRangeAsync(userId, rotaId, startDayOffset, endDayOffset, currentUser.Id);
+        if (result.Success)
+        {
+            SetSuccess("Volunteer assigned to shift range.");
+        }
+        else
+        {
+            SetError(result.Error ?? "Range assignment failed.");
+        }
+
+        return RedirectToAction(nameof(Index), new { slug });
+    }
+
     private async Task<(IActionResult? ErrorResult, User User, Team Team)> ResolveDepartmentManagementAsync(string slug)
     {
         return await ResolveDepartmentAccessAsync(

--- a/src/Humans.Web/Controllers/ShiftAdminController.cs
+++ b/src/Humans.Web/Controllers/ShiftAdminController.cs
@@ -574,7 +574,9 @@ public class ShiftAdminController : HumansTeamControllerBase
         var result = await _signupService.VoluntellRangeAsync(userId, rotaId, startDayOffset, endDayOffset, currentUser.Id);
         if (result.Success)
         {
-            SetSuccess("Volunteer assigned to shift range.");
+            SetSuccess(result.Warning is not null
+                ? $"Volunteer assigned to shift range. Note: {result.Warning}"
+                : "Volunteer assigned to shift range.");
         }
         else
         {

--- a/src/Humans.Web/Extensions/InfrastructureServiceCollectionExtensions.cs
+++ b/src/Humans.Web/Extensions/InfrastructureServiceCollectionExtensions.cs
@@ -32,6 +32,7 @@ public static class InfrastructureServiceCollectionExtensions
         services.AddScoped<VolunteerHistoryService>();
         services.AddScoped<ILegalDocumentSyncService, LegalDocumentSyncService>();
         services.AddScoped<IAdminLegalDocumentService, AdminLegalDocumentService>();
+        services.AddScoped<ILegalDocumentService, LegalDocumentService>();
 
         var googleWorkspaceConfig = configuration.GetSection(GoogleWorkspaceSettings.SectionName);
         var hasGoogleCredentials = !string.IsNullOrEmpty(googleWorkspaceConfig["ServiceAccountKeyPath"]) ||

--- a/src/Humans.Web/Models/LegalPageViewModel.cs
+++ b/src/Humans.Web/Models/LegalPageViewModel.cs
@@ -1,0 +1,11 @@
+using Humans.Application.Interfaces;
+
+namespace Humans.Web.Models;
+
+public class LegalPageViewModel
+{
+    public required IReadOnlyList<LegalDocumentDefinition> AllDocuments { get; init; }
+    public required string CurrentSlug { get; init; }
+    public required string CurrentDocumentName { get; init; }
+    public required TabbedMarkdownDocumentsViewModel DocumentContent { get; init; }
+}

--- a/src/Humans.Web/Views/Home/_ShiftCards.cshtml
+++ b/src/Humans.Web/Views/Home/_ShiftCards.cshtml
@@ -44,7 +44,7 @@
             </ul>
         </div>
         <div class="card-footer">
-            <a asp-controller="Shifts" asp-action="Index" class="btn btn-sm btn-outline-success">Browse Shifts</a>
+            <a asp-controller="Shifts" asp-action="Index" class="btn btn-sm btn-outline-success">Browse Volunteer Options</a>
         </div>
     </div>
 }

--- a/src/Humans.Web/Views/Legal/Index.cshtml
+++ b/src/Humans.Web/Views/Legal/Index.cshtml
@@ -4,21 +4,21 @@
     ViewData["Title"] = Model.CurrentDocumentName;
 }
 
-<h2>@Model.CurrentDocumentName</h2>
+<ul class="nav nav-pills justify-content-center mb-4">
+    @foreach (var doc in Model.AllDocuments)
+    {
+        <li class="nav-item">
+            <a class="nav-link @(doc.Slug == Model.CurrentSlug ? "active" : "")"
+               asp-action="Index" asp-route-slug="@doc.Slug">
+                @doc.DisplayName
+            </a>
+        </li>
+    }
+</ul>
 
-@if (Model.AllDocuments.Count > 1)
-{
-    <ul class="nav nav-pills mb-4">
-        @foreach (var doc in Model.AllDocuments)
-        {
-            <li class="nav-item">
-                <a class="nav-link @(doc.Slug == Model.CurrentSlug ? "active" : "")"
-                   asp-action="Index" asp-route-slug="@doc.Slug">
-                    @doc.DisplayName
-                </a>
-            </li>
-        }
-    </ul>
-}
-
-@await Html.PartialAsync("_TabbedMarkdownDocuments", Model.DocumentContent)
+<div class="card">
+    <div class="card-header">@Model.CurrentDocumentName</div>
+    <div class="card-body p-0">
+        @await Html.PartialAsync("_TabbedMarkdownDocuments", Model.DocumentContent)
+    </div>
+</div>

--- a/src/Humans.Web/Views/Legal/Index.cshtml
+++ b/src/Humans.Web/Views/Legal/Index.cshtml
@@ -1,0 +1,24 @@
+@model Humans.Web.Models.LegalPageViewModel
+
+@{
+    ViewData["Title"] = Model.CurrentDocumentName;
+}
+
+<h2>@Model.CurrentDocumentName</h2>
+
+@if (Model.AllDocuments.Count > 1)
+{
+    <ul class="nav nav-pills mb-4">
+        @foreach (var doc in Model.AllDocuments)
+        {
+            <li class="nav-item">
+                <a class="nav-link @(doc.Slug == Model.CurrentSlug ? "active" : "")"
+                   asp-action="Index" asp-route-slug="@doc.Slug">
+                    @doc.DisplayName
+                </a>
+            </li>
+        }
+    </ul>
+}
+
+@await Html.PartialAsync("_TabbedMarkdownDocuments", Model.DocumentContent)

--- a/src/Humans.Web/Views/Shared/_Layout.cshtml
+++ b/src/Humans.Web/Views/Shared/_Layout.cshtml
@@ -45,6 +45,12 @@
                         <li class="nav-item">
                             <a class="nav-link" asp-area="" asp-controller="Team" asp-action="Index">@Localizer["Nav_Teams"]</a>
                         </li>
+                        @if (User.Identity?.IsAuthenticated != true)
+                        {
+                            <li class="nav-item">
+                                <a class="nav-link" asp-controller="Legal" asp-action="Index">Legal</a>
+                            </li>
+                        }
                         @if (User.Identity?.IsAuthenticated == true)
                         {
                             var isActiveMember = User.HasClaim(Humans.Web.Authorization.RoleAssignmentClaimsTransformation.ActiveMemberClaimType, Humans.Web.Authorization.RoleAssignmentClaimsTransformation.ActiveClaimValue) || Humans.Web.Authorization.RoleChecks.IsTeamsAdminBoardOrAdmin(User);

--- a/src/Humans.Web/Views/Shared/_LoginPartial.cshtml
+++ b/src/Humans.Web/Views/Shared/_LoginPartial.cshtml
@@ -57,6 +57,11 @@
                 </li>
             }
             <li>
+                <a class="dropdown-item d-flex align-items-center gap-2" asp-controller="Legal" asp-action="Index">
+                    <i class="fa-solid fa-scale-balanced fa-fw"></i> Legal
+                </a>
+            </li>
+            <li>
                 <a class="dropdown-item d-flex align-items-center gap-2" asp-controller="Home" asp-action="About">
                     <i class="fa-solid fa-info-circle fa-fw"></i> @Localizer["Nav_About"]
                 </a>

--- a/src/Humans.Web/Views/Shared/_ShiftsSummaryCard.cshtml
+++ b/src/Humans.Web/Views/Shared/_ShiftsSummaryCard.cshtml
@@ -5,25 +5,30 @@
         <h6 class="mb-0"><i class="fa-solid fa-clock me-1"></i> Shifts</h6>
     </div>
     <div class="card-body">
-        @{
-            var fillPct = Model.TotalSlots > 0 ? (int)(100.0 * Model.ConfirmedCount / Model.TotalSlots) : 0;
-            var barClass = fillPct >= 80 ? "bg-success" : fillPct >= 50 ? "bg-warning" : "bg-danger";
-        }
-        <div class="progress mb-3" style="height: 20px;">
-            <div class="progress-bar @barClass" role="progressbar"
-                 style="width: @fillPct%;" aria-valuenow="@fillPct" aria-valuemin="0" aria-valuemax="100">
-                @fillPct%
-            </div>
-        </div>
-        <div class="d-flex justify-content-between align-items-center mb-2">
-            <span>@Model.ConfirmedCount / @Model.TotalSlots slots filled</span>
-            <span>@Model.UniqueVolunteerCount humans signed up</span>
-        </div>
-        @if (Model.PendingCount > 0)
+        @if (Model.TotalSlots > 0)
         {
-            <a href="@Model.ShiftsUrl" class="badge bg-warning text-dark text-decoration-none">
-                @Model.PendingCount pending
-            </a>
+            var fillPct = (int)(100.0 * Model.ConfirmedCount / Model.TotalSlots);
+            var barClass = fillPct >= 80 ? "bg-success" : fillPct >= 50 ? "bg-warning" : "bg-danger";
+            <div class="progress mb-3" style="height: 20px;">
+                <div class="progress-bar @barClass" role="progressbar"
+                     style="width: @fillPct%;" aria-valuenow="@fillPct" aria-valuemin="0" aria-valuemax="100">
+                    @fillPct%
+                </div>
+            </div>
+            <div class="d-flex justify-content-between align-items-center mb-2">
+                <span>@Model.ConfirmedCount / @Model.TotalSlots slots filled</span>
+                <span>@Model.UniqueVolunteerCount humans signed up</span>
+            </div>
+            @if (Model.PendingCount > 0)
+            {
+                <a href="@Model.ShiftsUrl" class="badge bg-warning text-dark text-decoration-none">
+                    @Model.PendingCount pending
+                </a>
+            }
+        }
+        else
+        {
+            <p class="text-muted mb-0">No shifts configured yet.</p>
         }
         @if (Model.CanManageShifts)
         {

--- a/src/Humans.Web/Views/ShiftAdmin/Index.cshtml
+++ b/src/Humans.Web/Views/ShiftAdmin/Index.cshtml
@@ -8,6 +8,7 @@
     ViewData["Title"] = $"Shifts - {Model.Department.Name}";
     var searchUrl = Url.Action(nameof(ShiftAdminController.SearchVolunteers), "ShiftAdmin", new { slug = Model.Department.Slug });
     var voluntellUrl = Url.Action(nameof(ShiftAdminController.Voluntell), "ShiftAdmin", new { slug = Model.Department.Slug });
+    var voluntellRangeUrl = Url.Action(nameof(ShiftAdminController.VoluntellRange), "ShiftAdmin", new { slug = Model.Department.Slug });
 }
 
 @{
@@ -522,6 +523,63 @@
                     </div>
                 }
 
+                @* Range Voluntell for Build/Strike rotas *@
+                @if (Model.CanApproveSignups && rota.Period != RotaPeriod.Event && rota.Shifts.Count > 0)
+                {
+                    var rangeVoluntellId = "range-voluntell-" + rota.Id.ToString("N");
+                    var firstShiftId = rota.Shifts.OrderBy(s => s.DayOffset).First().Id;
+                    var rvPeriodRange = rota.Period == RotaPeriod.Build
+                        ? (Start: Model.EventSettings.BuildStartOffset, End: -1)
+                        : (Start: Model.EventSettings.EventEndOffset + 1, End: Model.EventSettings.StrikeEndOffset);
+                    <div class="mt-3 border-top pt-3">
+                        <button class="btn btn-sm btn-outline-success" type="button" data-bs-toggle="collapse" data-bs-target="#@rangeVoluntellId">
+                            Voluntell Range
+                        </button>
+                        <div class="collapse mt-2" id="@rangeVoluntellId">
+                            <form method="post" action="@voluntellRangeUrl">
+                                @Html.AntiForgeryToken()
+                                <input type="hidden" name="rotaId" value="@rota.Id" />
+                                <input type="hidden" name="userId" value="" class="voluntell-range-userId" />
+                                <div class="row g-2 align-items-end mb-2">
+                                    <div class="col-auto">
+                                        <label class="form-label form-label-sm">Start</label>
+                                        <select name="startDayOffset" class="form-select form-select-sm">
+                                            @for (var d = rvPeriodRange.Start; d <= rvPeriodRange.End; d++)
+                                            {
+                                                var date = Model.EventSettings.GateOpeningDate.PlusDays(d);
+                                                var dateLabel = date.ToDisplayShiftDate();
+                                                <option value="@d">@dateLabel</option>
+                                            }
+                                        </select>
+                                    </div>
+                                    <div class="col-auto">
+                                        <label class="form-label form-label-sm">End</label>
+                                        <select name="endDayOffset" class="form-select form-select-sm">
+                                            @for (var d = rvPeriodRange.Start; d <= rvPeriodRange.End; d++)
+                                            {
+                                                var date = Model.EventSettings.GateOpeningDate.PlusDays(d);
+                                                var dateLabel = date.ToDisplayShiftDate();
+                                                <option value="@d" selected="@(d == rvPeriodRange.End ? "selected" : null)">@dateLabel</option>
+                                            }
+                                        </select>
+                                    </div>
+                                    <div class="col-md-3">
+                                        <label class="form-label form-label-sm">Human</label>
+                                        <input type="text" class="form-control form-control-sm voluntell-range-search"
+                                               data-shift-id="@firstShiftId"
+                                               data-rota-id="@rota.Id.ToString("N")"
+                                               placeholder="Search by name (min 2 chars)..." />
+                                    </div>
+                                    <div class="col-auto">
+                                        <button type="submit" class="btn btn-sm btn-success voluntell-range-submit" disabled>Assign to Range</button>
+                                    </div>
+                                </div>
+                                <div class="voluntell-range-results" data-rota-id="@rota.Id.ToString("N")"></div>
+                            </form>
+                        </div>
+                    </div>
+                }
+
                 @* Generate Shifts for Event-period rotas *@
                 @if (Model.CanManageShifts && rota.Period == RotaPeriod.Event && rota.Shifts.Count == 0)
                 {
@@ -851,6 +909,78 @@
         var maxInput = form.querySelector('input[name="MaxVolunteers"]');
         if (minInput && maxInput) syncMinCap(minInput, maxInput);
     });
+
+    // Range voluntell: search + select volunteer for batch assignment
+    (function() {
+        var rangeSearchUrl = '@Html.Raw(searchUrl)';
+        var rangeDebounceTimer;
+
+        document.addEventListener('input', function(e) {
+            var input = e.target;
+            if (!input.classList.contains('voluntell-range-search')) return;
+
+            clearTimeout(rangeDebounceTimer);
+            rangeDebounceTimer = setTimeout(function() {
+                var shiftId = input.dataset.shiftId;
+                var rotaId = input.dataset.rotaId;
+                var query = input.value.trim();
+                var resultsDiv = document.querySelector('.voluntell-range-results[data-rota-id="' + rotaId + '"]');
+                if (!resultsDiv) return;
+
+                if (query.length < 2) {
+                    resultsDiv.innerHTML = '';
+                    return;
+                }
+
+                var url = rangeSearchUrl + '?shiftId=' + encodeURIComponent(shiftId) + '&query=' + encodeURIComponent(query);
+                fetch(url, { headers: { 'X-Requested-With': 'XMLHttpRequest' } })
+                    .then(function(resp) { return resp.json(); })
+                    .then(function(data) { renderRangeResults(data, rotaId, resultsDiv); })
+                    .catch(function() {
+                        resultsDiv.innerHTML = '<p class="text-danger small mb-0">Search failed.</p>';
+                    });
+            }, 300);
+        });
+
+        function renderRangeResults(results, rotaId, container) {
+            if (!results || results.length === 0) {
+                container.innerHTML = '<p class="text-muted small mb-0">No results.</p>';
+                return;
+            }
+
+            var html = '<ul class="list-group list-group-flush">';
+            results.forEach(function(result) {
+                html += '<li class="list-group-item list-group-item-action voluntell-range-pick" style="cursor:pointer"'
+                    + ' data-user-id="' + escapeHtml(result.userId) + '"'
+                    + ' data-display-name="' + escapeHtml(result.displayName) + '"'
+                    + ' data-rota-id="' + escapeHtml(rotaId) + '">';
+                html += '<strong>' + escapeHtml(result.displayName) + '</strong>';
+                html += ' <small class="text-muted">(' + result.bookedShiftCount + ' shifts)</small>';
+                html += '</li>';
+            });
+            html += '</ul>';
+            container.innerHTML = html;
+        }
+
+        document.addEventListener('click', function(e) {
+            var pick = e.target.closest('.voluntell-range-pick');
+            if (!pick) return;
+
+            var rotaId = pick.dataset.rotaId;
+            var userId = pick.dataset.userId;
+            var displayName = pick.dataset.displayName;
+
+            var form = pick.closest('form');
+            if (!form) return;
+
+            form.querySelector('.voluntell-range-userId').value = userId;
+            form.querySelector('.voluntell-range-search').value = displayName;
+            form.querySelector('.voluntell-range-submit').disabled = false;
+
+            var resultsDiv = form.querySelector('.voluntell-range-results');
+            if (resultsDiv) resultsDiv.innerHTML = '';
+        });
+    }());
 
     // Scroll to fragment on page load (for newly created rotas)
     if (window.location.hash) {

--- a/src/Humans.Web/Views/ShiftAdmin/Index.cshtml
+++ b/src/Humans.Web/Views/ShiftAdmin/Index.cshtml
@@ -919,6 +919,13 @@
             var input = e.target;
             if (!input.classList.contains('voluntell-range-search')) return;
 
+            // Reset selection when input changes to prevent stale userId submission
+            var rotaIdForReset = input.dataset.rotaId;
+            var hiddenInput = document.querySelector('.voluntell-range-userId[data-rota-id="' + rotaIdForReset + '"]');
+            if (hiddenInput) hiddenInput.value = '';
+            var submitBtn = input.closest('form')?.querySelector('button[type="submit"]');
+            if (submitBtn) submitBtn.disabled = true;
+
             clearTimeout(rangeDebounceTimer);
             rangeDebounceTimer = setTimeout(function() {
                 var shiftId = input.dataset.shiftId;

--- a/src/Humans.Web/Views/Shifts/Index.cshtml
+++ b/src/Humans.Web/Views/Shifts/Index.cshtml
@@ -34,7 +34,7 @@
 
 <div class="container py-4">
     <div class="d-flex justify-content-between align-items-center mb-4">
-        <h2>Browse Shifts</h2>
+        <h2>Browse Volunteer Options</h2>
         <div class="d-flex gap-2">
             <vc:access-matrix section="Shifts" />
             @if (User.IsInRole(Humans.Domain.Constants.RoleNames.NoInfoAdmin) || User.IsInRole(Humans.Domain.Constants.RoleNames.Admin) || User.IsInRole(Humans.Domain.Constants.RoleNames.VolunteerCoordinator))
@@ -153,7 +153,7 @@
                                         </select>
                                     </div>
                                     <div class="col-auto">
-                                        <button type="submit" class="btn btn-sm btn-success">Sign Up for Range</button>
+                                        <button type="submit" class="btn btn-sm btn-success">Sign up for @(rotaGroup.Rota.Period == RotaPeriod.Build ? "set-up" : "strike") dates</button>
                                     </div>
                                 </form>
                             }

--- a/src/Humans.Web/Views/Shifts/Index.cshtml
+++ b/src/Humans.Web/Views/Shifts/Index.cshtml
@@ -99,7 +99,27 @@
                     <h5 class="mb-0">@dept.TeamName</h5>
                 </div>
                 <div class="card-body">
-                    @foreach (var rotaGroup in dept.Rotas)
+                    @{
+                        var rotasByPeriod = dept.Rotas
+                            .GroupBy(r => r.Rota.Period)
+                            .OrderBy(g => g.Key)
+                            .ToList();
+                    }
+                    @foreach (var periodGroup in rotasByPeriod)
+                    {
+                        var periodName = periodGroup.Key == RotaPeriod.Build ? "Set-up"
+                            : periodGroup.Key == RotaPeriod.Strike ? "Strike"
+                            : "Event";
+                        <h5 class="mt-4 mb-2 border-bottom pb-1">
+                            <span class="badge @(periodGroup.Key == RotaPeriod.Build ? "bg-info" : periodGroup.Key == RotaPeriod.Strike ? "bg-secondary" : "bg-success") me-1">@periodName</span>
+                            @periodName
+                        </h5>
+                        var hasAvailable = periodGroup.Any(r => r.Shifts.Any(s => s.RemainingSlots > 0));
+                        @if (!hasAvailable)
+                        {
+                            <p class="text-muted fst-italic">All @periodName.ToLowerInvariant() shifts are full.</p>
+                        }
+                    @foreach (var rotaGroup in periodGroup)
                     {
                         var hasAllDayShifts = rotaGroup.Shifts.Any(s => s.Shift.IsAllDay);
                         var hasTimedShifts = rotaGroup.Shifts.Any(s => !s.Shift.IsAllDay);
@@ -303,6 +323,7 @@
                                 </table>
                             </div>
                         }
+                    }
                     }
                 </div>
             </div>

--- a/src/Humans.Web/Views/Shifts/Mine.cshtml
+++ b/src/Humans.Web/Views/Shifts/Mine.cshtml
@@ -36,7 +36,7 @@
 <div class="container py-4">
     <div class="d-flex justify-content-between align-items-center mb-4">
         <h2>My Shifts</h2>
-        <a asp-action="Index" class="btn btn-outline-primary">Browse Shifts</a>
+        <a asp-action="Index" class="btn btn-outline-primary">Browse Volunteer Options</a>
     </div>
 
     <vc:temp-data-alerts />

--- a/src/Humans.Web/Views/Team/Details.cshtml
+++ b/src/Humans.Web/Views/Team/Details.cshtml
@@ -331,12 +331,6 @@
                     <a asp-controller="AdminLegalDocuments" asp-action="LegalDocuments" asp-route-teamId="@Model.Id" class="list-group-item list-group-item-action">
                         @Localizer["TeamDetail_ManageConsents"]
                     </a>
-                    @if (Model.ParentTeam == null && !Model.IsSystemTeam)
-                    {
-                        <a asp-controller="ShiftAdmin" asp-action="Index" asp-route-slug="@Model.Slug" class="list-group-item list-group-item-action">
-                            @Localizer["Nav_Shifts"]
-                        </a>
-                    }
                 </div>
             </div>
         }

--- a/src/Humans.Web/Views/Vol/Register.cshtml
+++ b/src/Humans.Web/Views/Vol/Register.cshtml
@@ -48,7 +48,7 @@
 
                     <div class="d-flex justify-content-center gap-3">
                         <a asp-controller="Shifts" asp-action="Index" class="btn btn-primary">
-                            <i class="fa-solid fa-calendar-days me-1"></i>Browse Shifts
+                            <i class="fa-solid fa-calendar-days me-1"></i>Browse Volunteer Options
                         </a>
                         <a asp-controller="Profile" asp-action="Index" class="btn btn-outline-secondary">
                             <i class="fa-solid fa-user me-1"></i>My Profile

--- a/tests/Humans.Application.Tests/Services/LegalDocumentServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/LegalDocumentServiceTests.cs
@@ -1,0 +1,98 @@
+using AwesomeAssertions;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Humans.Application.Interfaces;
+using Humans.Infrastructure.Configuration;
+using Humans.Infrastructure.Services;
+using Xunit;
+
+namespace Humans.Application.Tests.Services;
+
+public class LegalDocumentServiceTests : IDisposable
+{
+    private readonly IMemoryCache _cache;
+    private readonly LegalDocumentService _service;
+
+    public LegalDocumentServiceTests()
+    {
+        _cache = new MemoryCache(new MemoryCacheOptions());
+        var gitHubSettings = Options.Create(new GitHubSettings
+        {
+            Owner = "test-owner",
+            Repository = "test-repo",
+        });
+
+        _service = new LegalDocumentService(
+            _cache,
+            NullLogger<LegalDocumentService>.Instance,
+            gitHubSettings);
+    }
+
+    public void Dispose()
+    {
+        _cache.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public void GetAvailableDocuments_ReturnsStatutes()
+    {
+        var documents = _service.GetAvailableDocuments();
+
+        documents.Should().HaveCount(1);
+        var statutes = documents[0];
+        statutes.Slug.Should().Be("statutes");
+        statutes.DisplayName.Should().Be("Statutes");
+        statutes.RepoFolder.Should().Be("Estatutos");
+        statutes.FilePrefix.Should().Be("ESTATUTOS");
+    }
+
+    [Fact]
+    public void GetAvailableDocuments_ReturnsReadOnlyList()
+    {
+        var documents = _service.GetAvailableDocuments();
+
+        documents.Should().BeAssignableTo<IReadOnlyList<LegalDocumentDefinition>>();
+    }
+
+    [Fact]
+    public async Task GetDocumentContentAsync_UnknownSlug_ReturnsEmptyDictionary()
+    {
+        var result = await _service.GetDocumentContentAsync("nonexistent");
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetDocumentContentAsync_GitHubFailure_ReturnsEmptyDictionary()
+    {
+        // With invalid owner/repo and no real GitHub connection, this should fail gracefully
+        var result = await _service.GetDocumentContentAsync("statutes");
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetDocumentContentAsync_CachesResult()
+    {
+        // First call - will fail but cache the empty result
+        var result1 = await _service.GetDocumentContentAsync("statutes");
+
+        // Second call - should return cached result
+        var result2 = await _service.GetDocumentContentAsync("statutes");
+
+        result1.Should().BeEmpty();
+        result2.Should().BeEmpty();
+
+        // Verify cache key exists
+        _cache.TryGetValue(CacheKeys.LegalDocument("statutes"), out _).Should().BeTrue();
+    }
+
+    [Fact]
+    public void CacheKey_LegalDocument_FormatsCorrectly()
+    {
+        CacheKeys.LegalDocument("statutes").Should().Be("Legal:statutes");
+        CacheKeys.LegalDocument("privacy-policy").Should().Be("Legal:privacy-policy");
+    }
+}

--- a/tests/Humans.Application.Tests/Services/ShiftSignupServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/ShiftSignupServiceTests.cs
@@ -386,6 +386,81 @@ public class ShiftSignupServiceTests : IDisposable
     }
 
     // ============================================================
+    // VoluntellRange
+    // ============================================================
+
+    [Fact]
+    public async Task VoluntellRange_CreatesConfirmedSignupsAcrossDateRange()
+    {
+        // Arrange: rota with 3 all-day shifts (days -3 to -1)
+        var (es, rota, _) = SeedShiftScenario(SignupPolicy.RequireApproval);
+        rota.Period = RotaPeriod.Build;
+        for (var day = -3; day <= -1; day++)
+            SeedAllDayShift(rota, day);
+        var volunteerId = Guid.NewGuid();
+        var enrollerId = Guid.NewGuid();
+        await _dbContext.SaveChangesAsync();
+
+        // Act
+        var result = await _service.VoluntellRangeAsync(volunteerId, rota.Id, -3, -1, enrollerId);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        var signups = await _dbContext.ShiftSignups
+            .Where(s => s.UserId == volunteerId)
+            .ToListAsync();
+        signups.Should().HaveCount(3);
+        signups.Should().AllSatisfy(s =>
+        {
+            s.Status.Should().Be(SignupStatus.Confirmed);
+            s.Enrolled.Should().BeTrue();
+            s.EnrolledByUserId.Should().Be(enrollerId);
+            s.SignupBlockId.Should().NotBeNull();
+        });
+        signups.Select(s => s.SignupBlockId).Distinct().Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task VoluntellRange_SkipsShiftsWhereUserAlreadySignedUp()
+    {
+        // Arrange: rota with 3 all-day shifts, user already signed up on day -2
+        var (es, rota, _) = SeedShiftScenario(SignupPolicy.RequireApproval);
+        rota.Period = RotaPeriod.Build;
+        for (var day = -3; day <= -1; day++)
+            SeedAllDayShift(rota, day);
+        var volunteerId = Guid.NewGuid();
+        var enrollerId = Guid.NewGuid();
+        await _dbContext.SaveChangesAsync();
+
+        // Pre-existing signup on day -2
+        var dayMinus2Shift = await _dbContext.Shifts
+            .FirstAsync(s => s.RotaId == rota.Id && s.DayOffset == -2);
+        SeedSignup(volunteerId, dayMinus2Shift.Id, SignupStatus.Confirmed);
+        await _dbContext.SaveChangesAsync();
+
+        // Act
+        var result = await _service.VoluntellRangeAsync(volunteerId, rota.Id, -3, -1, enrollerId);
+
+        // Assert: only 2 new signups (day -3 and day -1), skipping day -2
+        result.Success.Should().BeTrue();
+        var newSignups = await _dbContext.ShiftSignups
+            .Where(s => s.UserId == volunteerId && s.Enrolled)
+            .ToListAsync();
+        newSignups.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task VoluntellRange_ReturnsError_WhenRotaNotFound()
+    {
+        // Act
+        var result = await _service.VoluntellRangeAsync(Guid.NewGuid(), Guid.NewGuid(), -3, -1, Guid.NewGuid());
+
+        // Assert
+        result.Success.Should().BeFalse();
+        result.Error.Should().Contain("Rota not found");
+    }
+
+    // ============================================================
     // Helpers
     // ============================================================
 


### PR DESCRIPTION
## Summary

- **#184** — Rename "Browse Shifts" → "Browse Volunteer Options", period-specific range signup buttons, remove duplicate shift link from Team Management card, always show Shifts card for departments
- **#180** — Group rotas by Build/Event/Strike period with section headers, "all full" messages
- **#176** — Batch voluntell: new `VoluntellRangeAsync` service method + controller action + admin UI with date range picker and volunteer search
- **#194** — Public Legal section: extract `LegalDocumentService` from GovernanceController, new public `/Legal/{slug?}` page with pill nav and tabbed multi-language doc viewer, navigation links for logged-in and logged-out users

## Test plan
- [x] Verify "Browse Volunteer Options" heading on /Shifts
- [ ] Verify period sections (Set-up/Event/Strike) on shift browse page
- [x] Verify range signup button says "Sign up for set-up dates" / "Sign up for strike dates"
- [x] Verify Shifts card shows on team detail pages for departments without shifts
- [ ] Verify batch voluntell form appears on ShiftAdmin for Build/Strike rotas
- [x] Verify /Legal shows Statutes publicly (no auth required)
- [x] Verify "Legal" link appears in navbar when logged out
- [x] Verify "Legal" link appears in profile dropdown when logged in
- [x] Verify Governance page still shows Statutes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>