### PR TITLE
feat: communication preferences with RFC 8058 unsubscribe (#97)

### DIFF
--- a/.claude/DATA_MODEL.md
+++ b/.claude/DATA_MODEL.md
@@ -5,7 +5,8 @@
 - [Key Entities](#key-entities) | [Relationships](#relationships) | [User Entity](#user-entity) | [Profile Entity](#profile-entity)
 - [Application Entity](#application-entity) | [BoardVote Entity](#boardvote-entity) | [EmailOutboxMessage Entity](#emailoutboxmessage-entity)
 - [Campaign](#campaign-entity) | [CampaignCode](#campaigncode-entity) | [CampaignGrant](#campaigngrant-entity) | [SystemSetting](#systemsetting-entity) | [FeedbackReport](#feedbackreport-entity)
-- [Enums](#enums): MembershipTier, ConsentCheckStatus, VoteChoice, ApplicationStatus, SystemTeamType, AuditAction, RotaPeriod, RolePeriod
+- [CommunicationPreference Entity](#communicationpreference-entity)
+- [Enums](#enums): MembershipTier, ConsentCheckStatus, VoteChoice, ApplicationStatus, SystemTeamType, AuditAction, MessageCategory, RotaPeriod, RolePeriod
 - [Constants](#constants) | [ContactField Entity](#contactfield-entity) | [Term Lifecycle](#term-lifecycle) | [Camp Enums](#camp-enums)
 
 ## Key Entities
@@ -316,6 +317,25 @@ In-app feedback submitted by authenticated users. Admins triage via the admin UI
 **Table:** `feedback_reports`
 **Indexes:** Status, CreatedAt, UserId
 
+## CommunicationPreference Entity
+
+Per-user, per-category email opt-in/opt-out preferences. One row per user per category. Used for CAN-SPAM/GDPR compliance.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| Id | Guid | PK |
+| UserId | Guid | FK → User (Cascade) |
+| Category | MessageCategory | Enum stored as string |
+| OptedOut | bool | true = user opted out |
+| UpdatedAt | Instant | Last change |
+| UpdateSource | string (100) | "Profile", "MagicLink", "OneClick", "Default", "DataMigration" |
+
+**Table:** `communication_preferences`
+**Unique constraint:** `(UserId, Category)`
+**Indexes:** UserId
+
+Defaults are created lazily: System=on, EventOperations=on, CommunityUpdates=off, Marketing=off.
+
 ## Enums
 
 ### MembershipTier
@@ -341,6 +361,19 @@ Status of the consent check performed by a Consent Coordinator during onboarding
 | Flagged | 2 | Safety concern flagged — blocks Volunteer access |
 
 Stored as string via `HasConversion<string>()`. Nullable on Profile (null until all consents signed).
+
+### MessageCategory
+
+Categories of system communications for preference management.
+
+| Value | Int | Description |
+|-------|-----|-------------|
+| System | 0 | Critical account/consent/security notifications. Always on. |
+| EventOperations | 1 | Shift changes, schedule updates, team additions. Default: on. |
+| CommunityUpdates | 2 | Community news, facilitated messages. Default: off. |
+| Marketing | 3 | Campaign emails, promotions. Default: off. |
+
+Stored as string via `HasConversion<string>()`.
 
 ### VoteChoice
 

--- a/docs/features/28-communication-preferences.md
+++ b/docs/features/28-communication-preferences.md
@@ -1,0 +1,109 @@
+# Feature 28: Communication Preferences
+
+## Business Context
+
+The platform sends various types of emails: system notifications, event operations, community updates, and marketing/campaign emails. Humans need granular control over which categories they receive, with CAN-SPAM and GDPR-compliant unsubscribe flows that work without login.
+
+This replaces the previous boolean-only approach (`UnsubscribedFromCampaigns`, `SuppressScheduleChangeEmails`) with a proper per-category preference model.
+
+## Message Categories
+
+| Category | Default | Opt-outable | Examples |
+|----------|---------|-------------|----------|
+| System | On | No | Account, consent, security, welcome, verification |
+| EventOperations | On | Yes | Shift changes, schedule updates, team additions, board digest |
+| CommunityUpdates | Off | Yes | Facilitated messages, community news |
+| Marketing | Off | Yes | Campaign codes, promotions |
+
+## Data Model
+
+### CommunicationPreference Entity
+
+| Field | Type | Notes |
+|-------|------|-------|
+| Id | Guid | PK |
+| UserId | Guid | FK to User |
+| Category | MessageCategory (string) | Enum stored as string |
+| OptedOut | bool | true = user opted out |
+| UpdatedAt | Instant | Last change timestamp |
+| UpdateSource | string (100) | "Profile", "MagicLink", "OneClick", "DataMigration", "Default" |
+
+**Unique constraint:** `(UserId, Category)` — one row per user per category.
+
+Defaults are created lazily on first access via `GetPreferencesAsync()`.
+
+### MessageCategory Enum
+
+`System = 0`, `EventOperations = 1`, `CommunityUpdates = 2`, `Marketing = 3`
+
+## Unsubscribe Flows
+
+### Magic-Link Unsubscribe (Browser)
+
+1. Email footer contains an unsubscribe link: `/Unsubscribe/{token}`
+2. Token is DataProtection-encrypted, time-limited (90 days), payload: `{userId}|{category}`
+3. GET shows confirmation page with category name
+4. POST confirms unsubscribe, updates preference, logs audit entry
+
+### RFC 8058 One-Click Unsubscribe (Email Client)
+
+1. Outgoing emails include `List-Unsubscribe` and `List-Unsubscribe-Post` headers
+2. Email clients can POST to `/Unsubscribe/OneClick` with the token
+3. No anti-forgery token required (comes from email client, not browser)
+4. Returns HTTP 200 on success
+
+### Legacy Backward Compatibility
+
+Old `CampaignUnsubscribe` protector tokens (from pre-existing campaign emails) are still accepted. They are decoded as the Marketing category.
+
+## Profile Management
+
+Route: `/Profile/Notifications` (authenticated)
+
+Displays all four categories as checkboxes:
+- System: always on, disabled (cannot opt out)
+- EventOperations, CommunityUpdates, Marketing: toggleable
+
+Changes are persisted via `ICommunicationPreferenceService.UpdatePreferenceAsync()` and audit-logged.
+
+## Email Integration
+
+### Header Injection
+
+Opt-outable emails include:
+- `List-Unsubscribe: <{baseUrl}/Unsubscribe/{token}>` (RFC 8058)
+- `List-Unsubscribe-Post: List-Unsubscribe=One-Click`
+
+### Footer Link
+
+Email template footer includes "Unsubscribe from these emails" link for opt-outable categories.
+
+### Preference Checking
+
+Before queueing an opt-outable email, the service checks if the user has opted out. If opted out, the email is silently suppressed and logged.
+
+## Audit Trail
+
+All preference changes are recorded as `AuditAction.CommunicationPreferenceChanged` with:
+- Entity type: "User", entity ID: userId
+- Description includes category name, action (opted in/out), and source
+
+## Migration from Legacy Fields
+
+The old `User.UnsubscribedFromCampaigns` and `User.SuppressScheduleChangeEmails` fields remain on the User entity but are deprecated. A data migration seeds `CommunicationPreference` rows from these existing values. New code reads exclusively from the `CommunicationPreference` table.
+
+## Related Features
+
+- **Feature 22 (Campaigns):** Campaign send wave now uses preference service instead of direct `UnsubscribedFromCampaigns` check, and includes RFC 8058 headers
+- **Issue #205 (AccountType):** CommunicationPreference is user-level, independent of account type
+- **Issue #200 (MailerLite sync):** Preference table provides query surface for syncing opt-out status
+
+## Routes
+
+| Route | Method | Auth | Purpose |
+|-------|--------|------|---------|
+| /Profile/Notifications | GET | Yes | View preferences |
+| /Profile/Notifications | POST | Yes | Update preferences |
+| /Unsubscribe/{token} | GET | No | Confirmation page |
+| /Unsubscribe/{token} | POST | No | Confirm unsubscribe |
+| /Unsubscribe/OneClick | POST | No | RFC 8058 one-click |

--- a/src/Humans.Application/Interfaces/ICommunicationPreferenceService.cs
+++ b/src/Humans.Application/Interfaces/ICommunicationPreferenceService.cs
@@ -1,0 +1,48 @@
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+
+namespace Humans.Application.Interfaces;
+
+/// <summary>
+/// Manages per-user communication preferences and unsubscribe tokens.
+/// </summary>
+public interface ICommunicationPreferenceService
+{
+    /// <summary>
+    /// Returns all preferences for a user, creating defaults for any missing categories.
+    /// </summary>
+    Task<IReadOnlyList<CommunicationPreference>> GetPreferencesAsync(
+        Guid userId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns whether a user has opted out of a specific category.
+    /// </summary>
+    Task<bool> IsOptedOutAsync(
+        Guid userId, MessageCategory category, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Updates opt-out status for a specific category. Idempotent.
+    /// Logs an audit entry for compliance.
+    /// </summary>
+    Task UpdatePreferenceAsync(
+        Guid userId, MessageCategory category, bool optedOut, string source,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Generates a time-limited unsubscribe token encoding userId + category.
+    /// Token expires after ~90 days.
+    /// </summary>
+    string GenerateUnsubscribeToken(Guid userId, MessageCategory category);
+
+    /// <summary>
+    /// Validates and decodes an unsubscribe token.
+    /// Returns null if the token is invalid or expired.
+    /// </summary>
+    (Guid UserId, MessageCategory Category)? ValidateUnsubscribeToken(string token);
+
+    /// <summary>
+    /// Generates RFC 8058 List-Unsubscribe headers for a given user and category.
+    /// Returns a dictionary of header name → value pairs.
+    /// </summary>
+    Dictionary<string, string> GenerateUnsubscribeHeaders(Guid userId, MessageCategory category);
+}

--- a/src/Humans.Domain/Entities/CommunicationPreference.cs
+++ b/src/Humans.Domain/Entities/CommunicationPreference.cs
@@ -1,0 +1,40 @@
+using Humans.Domain.Enums;
+using NodaTime;
+
+namespace Humans.Domain.Entities;
+
+/// <summary>
+/// Tracks a user's opt-in/opt-out preference for a specific message category.
+/// One row per user per category. Used for CAN-SPAM/GDPR compliance.
+/// </summary>
+public class CommunicationPreference
+{
+    public Guid Id { get; init; }
+
+    public Guid UserId { get; init; }
+
+    /// <summary>
+    /// The message category this preference applies to.
+    /// </summary>
+    public MessageCategory Category { get; init; }
+
+    /// <summary>
+    /// True if the user has opted out of this category.
+    /// </summary>
+    public bool OptedOut { get; set; }
+
+    /// <summary>
+    /// When this preference was last changed.
+    /// </summary>
+    public Instant UpdatedAt { get; set; }
+
+    /// <summary>
+    /// How this preference was set: "Profile", "MagicLink", "DataMigration", etc.
+    /// </summary>
+    public string UpdateSource { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Navigation to the user.
+    /// </summary>
+    public User User { get; init; } = null!;
+}

--- a/src/Humans.Domain/Entities/User.cs
+++ b/src/Humans.Domain/Entities/User.cs
@@ -115,4 +115,9 @@ public class User : IdentityUser<Guid>
     /// Whether to suppress email notifications for schedule changes.
     /// </summary>
     public bool SuppressScheduleChangeEmails { get; set; }
+
+    /// <summary>
+    /// Navigation property to communication preferences.
+    /// </summary>
+    public ICollection<CommunicationPreference> CommunicationPreferences { get; } = new List<CommunicationPreference>();
 }

--- a/src/Humans.Domain/Enums/AuditAction.cs
+++ b/src/Humans.Domain/Enums/AuditAction.cs
@@ -68,4 +68,5 @@ public enum AuditAction
     AccountMergeAccepted,
     AccountMergeRejected,
     GoogleResourceSettingsRemediated,
+    CommunicationPreferenceChanged,
 }

--- a/src/Humans.Domain/Enums/MessageCategory.cs
+++ b/src/Humans.Domain/Enums/MessageCategory.cs
@@ -26,3 +26,24 @@ public enum MessageCategory
     /// </summary>
     Marketing = 3
 }
+
+public static class MessageCategoryExtensions
+{
+    public static string ToDisplayName(this MessageCategory category) => category switch
+    {
+        MessageCategory.System => "System",
+        MessageCategory.EventOperations => "Event Operations",
+        MessageCategory.CommunityUpdates => "Community Updates",
+        MessageCategory.Marketing => "Marketing",
+        _ => category.ToString(),
+    };
+
+    public static string ToDescription(this MessageCategory category) => category switch
+    {
+        MessageCategory.System => "Critical account, consent, and security notifications. Always on.",
+        MessageCategory.EventOperations => "Shift changes, schedule updates, and team notifications.",
+        MessageCategory.CommunityUpdates => "General community news and facilitated messages.",
+        MessageCategory.Marketing => "Campaign emails and promotions.",
+        _ => string.Empty,
+    };
+}

--- a/src/Humans.Domain/Enums/MessageCategory.cs
+++ b/src/Humans.Domain/Enums/MessageCategory.cs
@@ -1,0 +1,28 @@
+namespace Humans.Domain.Enums;
+
+/// <summary>
+/// Categories of system communications for preference management.
+/// Stored as string in DB; new values can be appended without migration.
+/// </summary>
+public enum MessageCategory
+{
+    /// <summary>
+    /// Critical system messages (account, consent, security). Always on — cannot opt out.
+    /// </summary>
+    System = 0,
+
+    /// <summary>
+    /// Shift changes, schedule updates, team additions. Default: on.
+    /// </summary>
+    EventOperations = 1,
+
+    /// <summary>
+    /// General community news and facilitated messages. Default: off.
+    /// </summary>
+    CommunityUpdates = 2,
+
+    /// <summary>
+    /// Campaign emails, promotions. Default: off.
+    /// </summary>
+    Marketing = 3
+}

--- a/src/Humans.Infrastructure/Data/Configurations/CommunicationPreferenceConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/CommunicationPreferenceConfiguration.cs
@@ -1,0 +1,36 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Humans.Domain.Entities;
+
+namespace Humans.Infrastructure.Data.Configurations;
+
+public class CommunicationPreferenceConfiguration : IEntityTypeConfiguration<CommunicationPreference>
+{
+    public void Configure(EntityTypeBuilder<CommunicationPreference> builder)
+    {
+        builder.ToTable("communication_preferences");
+
+        builder.HasKey(cp => cp.Id);
+
+        builder.Property(cp => cp.Category)
+            .HasConversion<string>()
+            .HasMaxLength(50)
+            .IsRequired();
+
+        builder.Property(cp => cp.OptedOut)
+            .IsRequired();
+
+        builder.Property(cp => cp.UpdatedAt)
+            .IsRequired();
+
+        builder.Property(cp => cp.UpdateSource)
+            .HasMaxLength(100)
+            .IsRequired();
+
+        // One preference per user per category
+        builder.HasIndex(cp => new { cp.UserId, cp.Category })
+            .IsUnique();
+
+        builder.HasIndex(cp => cp.UserId);
+    }
+}

--- a/src/Humans.Infrastructure/Data/Configurations/UserConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/UserConfiguration.cs
@@ -52,6 +52,11 @@ public class UserConfiguration : IEntityTypeConfiguration<User>
             .HasForeignKey(e => e.UserId)
             .OnDelete(DeleteBehavior.Cascade);
 
+        builder.HasMany(u => u.CommunicationPreferences)
+            .WithOne(cp => cp.User)
+            .HasForeignKey(cp => cp.UserId)
+            .OnDelete(DeleteBehavior.Cascade);
+
         builder.HasIndex(u => u.Email);
 
         // Ignore GetEffectiveEmail (method, not property - EF won't map it, but defensive)

--- a/src/Humans.Infrastructure/Data/HumansDbContext.cs
+++ b/src/Humans.Infrastructure/Data/HumansDbContext.cs
@@ -63,6 +63,7 @@ public class HumansDbContext : IdentityDbContext<User, IdentityRole<Guid>, Guid>
     public DbSet<FeedbackReport> FeedbackReports => Set<FeedbackReport>();
     public DbSet<FeedbackMessage> FeedbackMessages => Set<FeedbackMessage>();
     public DbSet<AccountMergeRequest> AccountMergeRequests => Set<AccountMergeRequest>();
+    public DbSet<CommunicationPreference> CommunicationPreferences => Set<CommunicationPreference>();
 
     protected override void OnModelCreating(ModelBuilder builder)
     {

--- a/src/Humans.Infrastructure/Helpers/BrandedEmailTemplate.cs
+++ b/src/Humans.Infrastructure/Helpers/BrandedEmailTemplate.cs
@@ -4,12 +4,16 @@ namespace Humans.Infrastructure.Helpers;
 
 public static class BrandedEmailTemplate
 {
-    public static string Wrap(string content, string baseUrl, string environmentName)
+    public static string Wrap(string content, string baseUrl, string environmentName, string? unsubscribeUrl = null)
     {
         var isProduction = string.Equals(environmentName, "Production", StringComparison.OrdinalIgnoreCase);
         var envLabel = string.Equals(environmentName, "Staging", StringComparison.OrdinalIgnoreCase)
             ? "QA"
             : environmentName.ToUpperInvariant();
+        var unsubscribeFooter = unsubscribeUrl is not null
+            ? $"""<p style="font-size: 11px; color: #8b7355; margin: 8px 0 0 0;"><a href="{WebUtility.HtmlEncode(unsubscribeUrl)}" style="color: #8b7355;">Unsubscribe from these emails</a></p>"""
+            : "";
+
         var envBanner = isProduction
             ? ""
             : $"""
@@ -45,6 +49,7 @@ public static class BrandedEmailTemplate
                     Humans &mdash; Nobodies Collective<br>
                     <a href="{{baseUrl}}" style="color: #8b6914;">{{baseUrl}}</a>
                 </p>
+                {{unsubscribeFooter}}
             </div>
             </body>
             </html>

--- a/src/Humans.Infrastructure/Helpers/EmailBodyComposer.cs
+++ b/src/Humans.Infrastructure/Helpers/EmailBodyComposer.cs
@@ -5,10 +5,11 @@ public static class EmailBodyComposer
     public static (string HtmlBody, string PlainTextBody) Compose(
         string htmlContent,
         string baseUrl,
-        string environmentName)
+        string environmentName,
+        string? unsubscribeUrl = null)
     {
         return (
-            BrandedEmailTemplate.Wrap(htmlContent, baseUrl, environmentName),
+            BrandedEmailTemplate.Wrap(htmlContent, baseUrl, environmentName, unsubscribeUrl),
             HtmlPlainTextConverter.Convert(htmlContent));
     }
 }

--- a/src/Humans.Infrastructure/Migrations/20260324160718_AddCommunicationPreferences.Designer.cs
+++ b/src/Humans.Infrastructure/Migrations/20260324160718_AddCommunicationPreferences.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Humans.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Humans.Infrastructure.Migrations
 {
     [DbContext(typeof(HumansDbContext))]
-    partial class HumansDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260324160718_AddCommunicationPreferences")]
+    partial class AddCommunicationPreferences
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Humans.Infrastructure/Migrations/20260324160718_AddCommunicationPreferences.cs
+++ b/src/Humans.Infrastructure/Migrations/20260324160718_AddCommunicationPreferences.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NodaTime;
+
+#nullable disable
+
+namespace Humans.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCommunicationPreferences : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "communication_preferences",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    UserId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Category = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    OptedOut = table.Column<bool>(type: "boolean", nullable: false),
+                    UpdatedAt = table.Column<Instant>(type: "timestamp with time zone", nullable: false),
+                    UpdateSource = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_communication_preferences", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_communication_preferences_users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_communication_preferences_UserId",
+                table: "communication_preferences",
+                column: "UserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_communication_preferences_UserId_Category",
+                table: "communication_preferences",
+                columns: new[] { "UserId", "Category" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "communication_preferences");
+        }
+    }
+}

--- a/src/Humans.Infrastructure/Services/CampaignService.cs
+++ b/src/Humans.Infrastructure/Services/CampaignService.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Text.Json;
 using Humans.Application.DTOs;
 using Humans.Application.Interfaces;
 using Humans.Domain.Entities;
@@ -19,6 +20,7 @@ public class CampaignService : ICampaignService
     private readonly HumansDbContext _dbContext;
     private readonly IClock _clock;
     private readonly IHumansMetrics _metrics;
+    private readonly ICommunicationPreferenceService _commPrefService;
     private readonly EmailSettings _settings;
     private readonly string _environmentName;
     private readonly ILogger<CampaignService> _logger;
@@ -27,6 +29,7 @@ public class CampaignService : ICampaignService
         HumansDbContext dbContext,
         IClock clock,
         IHumansMetrics metrics,
+        ICommunicationPreferenceService commPrefService,
         IOptions<EmailSettings> settings,
         IHostEnvironment hostEnvironment,
         ILogger<CampaignService> logger)
@@ -34,6 +37,7 @@ public class CampaignService : ICampaignService
         _dbContext = dbContext;
         _clock = clock;
         _metrics = metrics;
+        _commPrefService = commPrefService;
         _settings = settings.Value;
         _environmentName = hostEnvironment.EnvironmentName;
         _logger = logger;
@@ -489,8 +493,20 @@ public class CampaignService : ICampaignService
             .Replace("{{Code}}", code, StringComparison.Ordinal)
             .Replace("{{Name}}", name, StringComparison.Ordinal);
 
+        // Generate unsubscribe headers and footer link for Marketing category
+        var unsubHeaders = _commPrefService.GenerateUnsubscribeHeaders(user.Id, MessageCategory.Marketing);
+        string? unsubscribeUrl = null;
+        string? extraHeadersJson = null;
+        if (unsubHeaders is not null)
+        {
+            if (unsubHeaders.TryGetValue("List-Unsubscribe", out var listUnsub))
+                unsubscribeUrl = listUnsub.Trim('<', '>');
+            extraHeadersJson = JsonSerializer.Serialize(unsubHeaders);
+        }
+
         // Wrap in email template
-        var (wrappedHtml, plainText) = EmailBodyComposer.Compose(renderedBody, _settings.BaseUrl, _environmentName);
+        var (wrappedHtml, plainText) = EmailBodyComposer.Compose(
+            renderedBody, _settings.BaseUrl, _environmentName, unsubscribeUrl);
 
         return new EmailOutboxMessage
         {
@@ -504,6 +520,7 @@ public class CampaignService : ICampaignService
             UserId = user.Id,
             CampaignGrantId = grantId,
             ReplyTo = campaign.ReplyToAddress,
+            ExtraHeaders = extraHeadersJson,
             Status = EmailOutboxStatus.Queued,
             CreatedAt = now
         };

--- a/src/Humans.Infrastructure/Services/CommunicationPreferenceService.cs
+++ b/src/Humans.Infrastructure/Services/CommunicationPreferenceService.cs
@@ -1,0 +1,203 @@
+using System.Security.Cryptography;
+using System.Text.Json;
+using Humans.Application.Interfaces;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using Humans.Infrastructure.Configuration;
+using Humans.Infrastructure.Data;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NodaTime;
+
+namespace Humans.Infrastructure.Services;
+
+public class CommunicationPreferenceService : ICommunicationPreferenceService
+{
+    private const string ProtectorPurpose = "CommunicationPreference";
+    private static readonly TimeSpan TokenLifetime = TimeSpan.FromDays(90);
+
+    private static readonly Dictionary<MessageCategory, bool> DefaultOptedOut = new()
+    {
+        [MessageCategory.System] = false,
+        [MessageCategory.EventOperations] = false,
+        [MessageCategory.CommunityUpdates] = true,
+        [MessageCategory.Marketing] = true,
+    };
+
+    private readonly HumansDbContext _db;
+    private readonly ITimeLimitedDataProtector _protector;
+    private readonly IClock _clock;
+    private readonly IAuditLogService _auditLog;
+    private readonly string _baseUrl;
+    private readonly ILogger<CommunicationPreferenceService> _logger;
+
+    public CommunicationPreferenceService(
+        HumansDbContext db,
+        IDataProtectionProvider dataProtection,
+        IClock clock,
+        IAuditLogService auditLog,
+        IOptions<EmailSettings> emailSettings,
+        ILogger<CommunicationPreferenceService> logger)
+    {
+        _db = db;
+        _protector = dataProtection.CreateProtector(ProtectorPurpose).ToTimeLimitedDataProtector();
+        _clock = clock;
+        _auditLog = auditLog;
+        _baseUrl = emailSettings.Value.BaseUrl.TrimEnd('/');
+        _logger = logger;
+    }
+
+    public async Task<IReadOnlyList<CommunicationPreference>> GetPreferencesAsync(
+        Guid userId, CancellationToken cancellationToken = default)
+    {
+        var existing = await _db.CommunicationPreferences
+            .Where(cp => cp.UserId == userId)
+            .ToListAsync(cancellationToken);
+
+        var now = _clock.GetCurrentInstant();
+        var created = false;
+
+        foreach (var category in DefaultOptedOut.Keys)
+        {
+            if (existing.Any(cp => cp.Category == category))
+                continue;
+
+            var pref = new CommunicationPreference
+            {
+                Id = Guid.NewGuid(),
+                UserId = userId,
+                Category = category,
+                OptedOut = DefaultOptedOut[category],
+                UpdatedAt = now,
+                UpdateSource = "Default",
+            };
+            _db.CommunicationPreferences.Add(pref);
+            existing.Add(pref);
+            created = true;
+        }
+
+        if (created)
+            await _db.SaveChangesAsync(cancellationToken);
+
+        return existing
+            .OrderBy(cp => cp.Category)
+            .ToList()
+            .AsReadOnly();
+    }
+
+    public async Task<bool> IsOptedOutAsync(
+        Guid userId, MessageCategory category, CancellationToken cancellationToken = default)
+    {
+        // System messages can never be opted out of
+        if (category == MessageCategory.System)
+            return false;
+
+        var pref = await _db.CommunicationPreferences
+            .FirstOrDefaultAsync(
+                cp => cp.UserId == userId && cp.Category == category,
+                cancellationToken);
+
+        // If no preference row, use the default
+        return pref?.OptedOut ?? DefaultOptedOut.GetValueOrDefault(category, false);
+    }
+
+    public async Task UpdatePreferenceAsync(
+        Guid userId, MessageCategory category, bool optedOut, string source,
+        CancellationToken cancellationToken = default)
+    {
+        // System messages cannot be opted out of
+        if (category == MessageCategory.System)
+        {
+            _logger.LogWarning("Attempted to change System preference for user {UserId} — ignored", userId);
+            return;
+        }
+
+        var now = _clock.GetCurrentInstant();
+
+        var pref = await _db.CommunicationPreferences
+            .FirstOrDefaultAsync(
+                cp => cp.UserId == userId && cp.Category == category,
+                cancellationToken);
+
+        if (pref is null)
+        {
+            pref = new CommunicationPreference
+            {
+                Id = Guid.NewGuid(),
+                UserId = userId,
+                Category = category,
+                OptedOut = optedOut,
+                UpdatedAt = now,
+                UpdateSource = source,
+            };
+            _db.CommunicationPreferences.Add(pref);
+        }
+        else
+        {
+            if (pref.OptedOut == optedOut)
+                return; // idempotent — no change needed
+
+            pref.OptedOut = optedOut;
+            pref.UpdatedAt = now;
+            pref.UpdateSource = source;
+        }
+
+        var description = optedOut
+            ? $"{category} opted out via {source}"
+            : $"{category} opted in via {source}";
+
+        await _auditLog.LogAsync(
+            AuditAction.CommunicationPreferenceChanged,
+            "User", userId, description,
+            "CommunicationPreferenceService");
+
+        await _db.SaveChangesAsync(cancellationToken);
+
+        _logger.LogInformation(
+            "User {UserId} communication preference {Category} set to OptedOut={OptedOut} via {Source}",
+            userId, category, optedOut, source);
+    }
+
+    public string GenerateUnsubscribeToken(Guid userId, MessageCategory category)
+    {
+        var payload = $"{userId}|{category}";
+        return _protector.Protect(payload, TokenLifetime);
+    }
+
+    public (Guid UserId, MessageCategory Category)? ValidateUnsubscribeToken(string token)
+    {
+        try
+        {
+            var payload = _protector.Unprotect(token);
+            var parts = payload.Split('|');
+            if (parts.Length != 2)
+                return null;
+
+            if (!Guid.TryParse(parts[0], out var userId))
+                return null;
+
+            if (!Enum.TryParse<MessageCategory>(parts[1], out var category))
+                return null;
+
+            return (userId, category);
+        }
+        catch (CryptographicException)
+        {
+            return null;
+        }
+    }
+
+    public Dictionary<string, string> GenerateUnsubscribeHeaders(Guid userId, MessageCategory category)
+    {
+        var token = GenerateUnsubscribeToken(userId, category);
+        var url = $"{_baseUrl}/Unsubscribe/{token}";
+
+        return new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["List-Unsubscribe"] = $"<{url}>",
+            ["List-Unsubscribe-Post"] = "List-Unsubscribe=One-Click",
+        };
+    }
+}

--- a/src/Humans.Infrastructure/Services/CommunicationPreferenceService.cs
+++ b/src/Humans.Infrastructure/Services/CommunicationPreferenceService.cs
@@ -1,5 +1,5 @@
+using System.Net;
 using System.Security.Cryptography;
-using System.Text.Json;
 using Humans.Application.Interfaces;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
@@ -192,11 +192,12 @@ public class CommunicationPreferenceService : ICommunicationPreferenceService
     public Dictionary<string, string> GenerateUnsubscribeHeaders(Guid userId, MessageCategory category)
     {
         var token = GenerateUnsubscribeToken(userId, category);
-        var url = $"{_baseUrl}/Unsubscribe/{token}";
+        var oneClickUrl = $"{_baseUrl}/Unsubscribe/OneClick?token={WebUtility.UrlEncode(token)}";
+        var browserUrl = $"{_baseUrl}/Unsubscribe/{token}";
 
         return new Dictionary<string, string>(StringComparer.Ordinal)
         {
-            ["List-Unsubscribe"] = $"<{url}>",
+            ["List-Unsubscribe"] = $"<{oneClickUrl}>, <{browserUrl}>",
             ["List-Unsubscribe-Post"] = "List-Unsubscribe=One-Click",
         };
     }

--- a/src/Humans.Infrastructure/Services/OutboxEmailService.cs
+++ b/src/Humans.Infrastructure/Services/OutboxEmailService.cs
@@ -27,6 +27,7 @@ public class OutboxEmailService : IEmailService
     private readonly IHumansMetrics _metrics;
     private readonly IClock _clock;
     private readonly IBackgroundJobClient _backgroundJobClient;
+    private readonly ICommunicationPreferenceService _commPrefService;
     private readonly ILogger<OutboxEmailService> _logger;
     private readonly EmailSettings _settings;
     private readonly string _environmentName;
@@ -39,6 +40,7 @@ public class OutboxEmailService : IEmailService
         IHostEnvironment hostEnvironment,
         IOptions<EmailSettings> settings,
         IBackgroundJobClient backgroundJobClient,
+        ICommunicationPreferenceService commPrefService,
         ILogger<OutboxEmailService> logger)
     {
         _dbContext = dbContext;
@@ -46,6 +48,7 @@ public class OutboxEmailService : IEmailService
         _metrics = metrics;
         _clock = clock;
         _backgroundJobClient = backgroundJobClient;
+        _commPrefService = commPrefService;
         _logger = logger;
         _settings = settings.Value;
         _environmentName = hostEnvironment.EnvironmentName;
@@ -187,7 +190,8 @@ public class OutboxEmailService : IEmailService
     {
         var resourceList = resources.ToList();
         var content = _renderer.RenderAddedToTeam(userName, teamName, teamSlug, resourceList, culture);
-        await EnqueueAsync(userEmail, userName, content, "added_to_team", cancellationToken);
+        await EnqueueAsync(userEmail, userName, content, "added_to_team", cancellationToken,
+            category: MessageCategory.EventOperations);
     }
 
     /// <inheritdoc />
@@ -264,15 +268,42 @@ public class OutboxEmailService : IEmailService
         string templateName,
         CancellationToken cancellationToken,
         bool triggerImmediate = false,
-        string? replyTo = null)
+        string? replyTo = null,
+        MessageCategory? category = null)
     {
-        var (wrappedHtml, plainText) = EmailBodyComposer.Compose(content.HtmlBody, _settings.BaseUrl, _environmentName);
-
         // Look up user by email to set UserId for profile email history
         var userId = await _dbContext.UserEmails
             .Where(ue => ue.Email == recipientEmail && ue.IsVerified)
             .Select(ue => (Guid?)ue.UserId)
             .FirstOrDefaultAsync(cancellationToken);
+
+        // Check opt-out for non-System categories
+        if (category is not null && category != MessageCategory.System && userId.HasValue)
+        {
+            if (await _commPrefService.IsOptedOutAsync(userId.Value, category.Value, cancellationToken))
+            {
+                _logger.LogInformation(
+                    "Email suppressed: {TemplateName} to {Recipient} — opted out of {Category}",
+                    templateName, recipientEmail, category.Value);
+                return;
+            }
+        }
+
+        // Generate unsubscribe URL and headers for opt-outable categories
+        string? unsubscribeUrl = null;
+        string? extraHeadersJson = null;
+        if (category is not null && category != MessageCategory.System && userId.HasValue)
+        {
+            var headers = _commPrefService.GenerateUnsubscribeHeaders(userId.Value, category.Value);
+            extraHeadersJson = System.Text.Json.JsonSerializer.Serialize(headers);
+
+            // Extract URL for footer link (strip angle brackets from List-Unsubscribe header)
+            if (headers.TryGetValue("List-Unsubscribe", out var listUnsub))
+                unsubscribeUrl = listUnsub.Trim('<', '>');
+        }
+
+        var (wrappedHtml, plainText) = EmailBodyComposer.Compose(
+            content.HtmlBody, _settings.BaseUrl, _environmentName, unsubscribeUrl);
 
         var message = new EmailOutboxMessage
         {
@@ -285,6 +316,7 @@ public class OutboxEmailService : IEmailService
             TemplateName = templateName,
             UserId = userId,
             ReplyTo = replyTo,
+            ExtraHeaders = extraHeadersJson,
             Status = EmailOutboxStatus.Queued,
             CreatedAt = _clock.GetCurrentInstant()
         };

--- a/src/Humans.Web/Controllers/ProfileController.cs
+++ b/src/Humans.Web/Controllers/ProfileController.cs
@@ -808,7 +808,7 @@ public class ProfileController : HumansControllerBase
         }
     }
 
-    [HttpGet("Notifications")]
+    [HttpGet("/Profile/Notifications")]
     public async Task<IActionResult> Notifications()
     {
         try
@@ -840,7 +840,7 @@ public class ProfileController : HumansControllerBase
         }
     }
 
-    [HttpPost("Notifications")]
+    [HttpPost("/Profile/Notifications")]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> Notifications(CommunicationPreferencesViewModel model)
     {

--- a/src/Humans.Web/Controllers/ProfileController.cs
+++ b/src/Humans.Web/Controllers/ProfileController.cs
@@ -28,6 +28,7 @@ public class ProfileController : HumansControllerBase
     private readonly VolunteerHistoryService _volunteerHistoryService;
     private readonly IEmailService _emailService;
     private readonly IUserEmailService _userEmailService;
+    private readonly ICommunicationPreferenceService _commPrefService;
     private readonly IConfiguration _configuration;
     private readonly ILogger<ProfileController> _logger;
     private readonly IStringLocalizer<SharedResource> _localizer;
@@ -63,6 +64,7 @@ public class ProfileController : HumansControllerBase
         VolunteerHistoryService volunteerHistoryService,
         IEmailService emailService,
         IUserEmailService userEmailService,
+        ICommunicationPreferenceService commPrefService,
         IConfiguration configuration,
         ILogger<ProfileController> logger,
         IStringLocalizer<SharedResource> localizer,
@@ -75,6 +77,7 @@ public class ProfileController : HumansControllerBase
         _volunteerHistoryService = volunteerHistoryService;
         _emailService = emailService;
         _userEmailService = userEmailService;
+        _commPrefService = commPrefService;
         _configuration = configuration;
         _logger = logger;
         _localizer = localizer;
@@ -814,10 +817,17 @@ public class ProfileController : HumansControllerBase
             if (user is null)
                 return NotFound();
 
-            var viewModel = new NotificationSettingsViewModel
+            var prefs = await _commPrefService.GetPreferencesAsync(user.Id);
+            var viewModel = new CommunicationPreferencesViewModel
             {
-                SuppressScheduleChangeEmails = user.SuppressScheduleChangeEmails,
-                UnsubscribedFromCampaigns = user.UnsubscribedFromCampaigns
+                Categories = prefs.Select(p => new CategoryPreferenceItem
+                {
+                    Category = p.Category,
+                    DisplayName = GetCategoryDisplayName(p.Category),
+                    Description = GetCategoryDescription(p.Category),
+                    OptedOut = p.OptedOut,
+                    IsEditable = p.Category != MessageCategory.System,
+                }).ToList()
             };
 
             return View(viewModel);
@@ -832,7 +842,7 @@ public class ProfileController : HumansControllerBase
 
     [HttpPost("Notifications")]
     [ValidateAntiForgeryToken]
-    public async Task<IActionResult> Notifications(NotificationSettingsViewModel model)
+    public async Task<IActionResult> Notifications(CommunicationPreferencesViewModel model)
     {
         try
         {
@@ -840,10 +850,14 @@ public class ProfileController : HumansControllerBase
             if (user is null)
                 return NotFound();
 
-            user.SuppressScheduleChangeEmails = model.SuppressScheduleChangeEmails;
-            user.UnsubscribedFromCampaigns = model.UnsubscribedFromCampaigns;
+            foreach (var item in model.Categories)
+            {
+                if (item.Category == MessageCategory.System)
+                    continue;
 
-            await _userManager.UpdateAsync(user);
+                await _commPrefService.UpdatePreferenceAsync(
+                    user.Id, item.Category, item.OptedOut, "Profile");
+            }
 
             SetSuccess(_localizer["Profile_Updated"].Value);
             return RedirectToAction(nameof(Notifications));
@@ -855,6 +869,24 @@ public class ProfileController : HumansControllerBase
             return View(model);
         }
     }
+
+    private static string GetCategoryDisplayName(MessageCategory category) => category switch
+    {
+        MessageCategory.System => "System",
+        MessageCategory.EventOperations => "Event Operations",
+        MessageCategory.CommunityUpdates => "Community Updates",
+        MessageCategory.Marketing => "Marketing",
+        _ => category.ToString(),
+    };
+
+    private static string GetCategoryDescription(MessageCategory category) => category switch
+    {
+        MessageCategory.System => "Critical account, consent, and security notifications. Always on.",
+        MessageCategory.EventOperations => "Shift changes, schedule updates, and team notifications.",
+        MessageCategory.CommunityUpdates => "General community news and facilitated messages.",
+        MessageCategory.Marketing => "Campaign emails and promotions.",
+        _ => string.Empty,
+    };
 
     [HttpGet]
     [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]

--- a/src/Humans.Web/Controllers/ProfileController.cs
+++ b/src/Humans.Web/Controllers/ProfileController.cs
@@ -739,7 +739,7 @@ public class ProfileController : HumansControllerBase
         return RedirectToAction(nameof(Privacy));
     }
 
-    [HttpGet("ShiftInfo")]
+    [HttpGet("/Profile/ShiftInfo")]
     public async Task<IActionResult> ShiftInfo()
     {
         try
@@ -773,7 +773,7 @@ public class ProfileController : HumansControllerBase
         }
     }
 
-    [HttpPost("ShiftInfo")]
+    [HttpPost("/Profile/ShiftInfo")]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> ShiftInfo(ShiftInfoViewModel model)
     {

--- a/src/Humans.Web/Controllers/ProfileController.cs
+++ b/src/Humans.Web/Controllers/ProfileController.cs
@@ -823,8 +823,8 @@ public class ProfileController : HumansControllerBase
                 Categories = prefs.Select(p => new CategoryPreferenceItem
                 {
                     Category = p.Category,
-                    DisplayName = GetCategoryDisplayName(p.Category),
-                    Description = GetCategoryDescription(p.Category),
+                    DisplayName = p.Category.ToDisplayName(),
+                    Description = p.Category.ToDescription(),
                     OptedOut = p.OptedOut,
                     IsEditable = p.Category != MessageCategory.System,
                 }).ToList()
@@ -869,24 +869,6 @@ public class ProfileController : HumansControllerBase
             return View(model);
         }
     }
-
-    private static string GetCategoryDisplayName(MessageCategory category) => category switch
-    {
-        MessageCategory.System => "System",
-        MessageCategory.EventOperations => "Event Operations",
-        MessageCategory.CommunityUpdates => "Community Updates",
-        MessageCategory.Marketing => "Marketing",
-        _ => category.ToString(),
-    };
-
-    private static string GetCategoryDescription(MessageCategory category) => category switch
-    {
-        MessageCategory.System => "Critical account, consent, and security notifications. Always on.",
-        MessageCategory.EventOperations => "Shift changes, schedule updates, and team notifications.",
-        MessageCategory.CommunityUpdates => "General community news and facilitated messages.",
-        MessageCategory.Marketing => "Campaign emails and promotions.",
-        _ => string.Empty,
-    };
 
     [HttpGet]
     [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]

--- a/src/Humans.Web/Controllers/UnsubscribeController.cs
+++ b/src/Humans.Web/Controllers/UnsubscribeController.cs
@@ -39,8 +39,7 @@ public class UnsubscribeController : Controller
                 return NotFound();
 
             ViewData["DisplayName"] = user.DisplayName;
-            ViewData["CategoryName"] = GetCategoryDisplayName(category);
-            ViewData["Token"] = token;
+            ViewData["CategoryName"] = category.ToDisplayName();
             return View();
         }
 
@@ -63,7 +62,7 @@ public class UnsubscribeController : Controller
 
             await _preferenceService.UpdatePreferenceAsync(userId, category, optedOut: true, source: "MagicLink");
 
-            ViewData["CategoryName"] = GetCategoryDisplayName(category);
+            ViewData["CategoryName"] = category.ToDisplayName();
             return View("Done");
         }
 
@@ -73,25 +72,34 @@ public class UnsubscribeController : Controller
 
     /// <summary>
     /// RFC 8058 one-click unsubscribe endpoint.
-    /// Email clients POST List-Unsubscribe=One-Click — no anti-forgery token.
+    /// Email clients POST List-Unsubscribe=One-Click to the URL in the List-Unsubscribe header,
+    /// which includes the token as a query parameter. No anti-forgery token required.
     /// </summary>
     [HttpPost("/Unsubscribe/OneClick")]
     [IgnoreAntiforgeryToken]
-    public async Task<IActionResult> OneClick([FromForm(Name = "token")] string token)
+    public async Task<IActionResult> OneClick([FromQuery] string token)
     {
-        var result = _preferenceService.ValidateUnsubscribeToken(token);
-        if (result is null)
-            return BadRequest();
+        try
+        {
+            var result = _preferenceService.ValidateUnsubscribeToken(token);
+            if (result is null)
+                return BadRequest();
 
-        var (userId, category) = result.Value;
-        var user = await _db.Users.FindAsync(userId);
-        if (user is null)
-            return NotFound();
+            var (userId, category) = result.Value;
+            var user = await _db.Users.FindAsync(userId);
+            if (user is null)
+                return NotFound();
 
-        await _preferenceService.UpdatePreferenceAsync(userId, category, optedOut: true, source: "OneClick");
+            await _preferenceService.UpdatePreferenceAsync(userId, category, optedOut: true, source: "OneClick");
 
-        _logger.LogInformation("RFC 8058 one-click unsubscribe: user {UserId} from {Category}", userId, category);
-        return Ok();
+            _logger.LogInformation("RFC 8058 one-click unsubscribe: user {UserId} from {Category}", userId, category);
+            return Ok();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to process RFC 8058 one-click unsubscribe");
+            return StatusCode(500);
+        }
     }
 
     private async Task<IActionResult> TryLegacyToken(string token)
@@ -119,8 +127,7 @@ public class UnsubscribeController : Controller
             return NotFound();
 
         ViewData["DisplayName"] = user.DisplayName;
-        ViewData["CategoryName"] = GetCategoryDisplayName(MessageCategory.Marketing);
-        ViewData["Token"] = token;
+        ViewData["CategoryName"] = MessageCategory.Marketing.ToDisplayName();
         return View();
     }
 
@@ -151,16 +158,7 @@ public class UnsubscribeController : Controller
         // Use the new preference service for legacy tokens too
         await _preferenceService.UpdatePreferenceAsync(userId, MessageCategory.Marketing, optedOut: true, source: "MagicLink");
 
-        ViewData["CategoryName"] = GetCategoryDisplayName(MessageCategory.Marketing);
+        ViewData["CategoryName"] = MessageCategory.Marketing.ToDisplayName();
         return View("Done");
     }
-
-    private static string GetCategoryDisplayName(MessageCategory category) => category switch
-    {
-        MessageCategory.System => "System",
-        MessageCategory.EventOperations => "Event Operations",
-        MessageCategory.CommunityUpdates => "Community Updates",
-        MessageCategory.Marketing => "Marketing",
-        _ => category.ToString(),
-    };
 }

--- a/src/Humans.Web/Controllers/UnsubscribeController.cs
+++ b/src/Humans.Web/Controllers/UnsubscribeController.cs
@@ -1,4 +1,6 @@
 using System.Security.Cryptography;
+using Humans.Application.Interfaces;
+using Humans.Domain.Enums;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Mvc;
 using Humans.Infrastructure.Data;
@@ -8,21 +10,91 @@ namespace Humans.Web.Controllers;
 public class UnsubscribeController : Controller
 {
     private readonly HumansDbContext _db;
+    private readonly ICommunicationPreferenceService _preferenceService;
     private readonly IDataProtectionProvider _dataProtection;
     private readonly ILogger<UnsubscribeController> _logger;
 
     public UnsubscribeController(
         HumansDbContext db,
+        ICommunicationPreferenceService preferenceService,
         IDataProtectionProvider dataProtection,
         ILogger<UnsubscribeController> logger)
     {
         _db = db;
+        _preferenceService = preferenceService;
         _dataProtection = dataProtection;
         _logger = logger;
     }
 
     [HttpGet("/Unsubscribe/{token}")]
     public async Task<IActionResult> Index(string token)
+    {
+        // Try new category-aware token first
+        var result = _preferenceService.ValidateUnsubscribeToken(token);
+        if (result is not null)
+        {
+            var (userId, category) = result.Value;
+            var user = await _db.Users.FindAsync(userId);
+            if (user is null)
+                return NotFound();
+
+            ViewData["DisplayName"] = user.DisplayName;
+            ViewData["CategoryName"] = GetCategoryDisplayName(category);
+            ViewData["Token"] = token;
+            return View();
+        }
+
+        // Fall back to legacy campaign-only token
+        return await TryLegacyToken(token);
+    }
+
+    [HttpPost("/Unsubscribe/{token}")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Confirm(string token)
+    {
+        // Try new category-aware token first
+        var result = _preferenceService.ValidateUnsubscribeToken(token);
+        if (result is not null)
+        {
+            var (userId, category) = result.Value;
+            var user = await _db.Users.FindAsync(userId);
+            if (user is null)
+                return NotFound();
+
+            await _preferenceService.UpdatePreferenceAsync(userId, category, optedOut: true, source: "MagicLink");
+
+            ViewData["CategoryName"] = GetCategoryDisplayName(category);
+            return View("Done");
+        }
+
+        // Fall back to legacy campaign-only token
+        return await TryLegacyConfirm(token);
+    }
+
+    /// <summary>
+    /// RFC 8058 one-click unsubscribe endpoint.
+    /// Email clients POST List-Unsubscribe=One-Click — no anti-forgery token.
+    /// </summary>
+    [HttpPost("/Unsubscribe/OneClick")]
+    [IgnoreAntiforgeryToken]
+    public async Task<IActionResult> OneClick([FromForm(Name = "token")] string token)
+    {
+        var result = _preferenceService.ValidateUnsubscribeToken(token);
+        if (result is null)
+            return BadRequest();
+
+        var (userId, category) = result.Value;
+        var user = await _db.Users.FindAsync(userId);
+        if (user is null)
+            return NotFound();
+
+        await _preferenceService.UpdatePreferenceAsync(userId, category, optedOut: true, source: "OneClick");
+
+        _logger.LogInformation("RFC 8058 one-click unsubscribe: user {UserId} from {Category}", userId, category);
+        return Ok();
+    }
+
+    private async Task<IActionResult> TryLegacyToken(string token)
     {
         var protector = _dataProtection
             .CreateProtector("CampaignUnsubscribe")
@@ -47,12 +119,12 @@ public class UnsubscribeController : Controller
             return NotFound();
 
         ViewData["DisplayName"] = user.DisplayName;
+        ViewData["CategoryName"] = GetCategoryDisplayName(MessageCategory.Marketing);
+        ViewData["Token"] = token;
         return View();
     }
 
-    [HttpPost("/Unsubscribe/{token}")]
-    [ValidateAntiForgeryToken]
-    public async Task<IActionResult> Confirm(string token)
+    private async Task<IActionResult> TryLegacyConfirm(string token)
     {
         var protector = _dataProtection
             .CreateProtector("CampaignUnsubscribe")
@@ -76,13 +148,19 @@ public class UnsubscribeController : Controller
         if (user is null)
             return NotFound();
 
-        if (!user.UnsubscribedFromCampaigns)
-        {
-            user.UnsubscribedFromCampaigns = true;
-            await _db.SaveChangesAsync();
-            _logger.LogInformation("User {UserId} unsubscribed from campaign emails", userId);
-        }
+        // Use the new preference service for legacy tokens too
+        await _preferenceService.UpdatePreferenceAsync(userId, MessageCategory.Marketing, optedOut: true, source: "MagicLink");
 
+        ViewData["CategoryName"] = GetCategoryDisplayName(MessageCategory.Marketing);
         return View("Done");
     }
+
+    private static string GetCategoryDisplayName(MessageCategory category) => category switch
+    {
+        MessageCategory.System => "System",
+        MessageCategory.EventOperations => "Event Operations",
+        MessageCategory.CommunityUpdates => "Community Updates",
+        MessageCategory.Marketing => "Marketing",
+        _ => category.ToString(),
+    };
 }

--- a/src/Humans.Web/Extensions/InfrastructureServiceCollectionExtensions.cs
+++ b/src/Humans.Web/Extensions/InfrastructureServiceCollectionExtensions.cs
@@ -26,6 +26,7 @@ public static class InfrastructureServiceCollectionExtensions
         services.AddScoped<ITeamService, TeamService>();
         services.AddScoped<ITeamPageService, TeamPageService>();
         services.AddScoped<ICampService, CampService>();
+        services.AddScoped<ICommunicationPreferenceService, CommunicationPreferenceService>();
         services.AddScoped<ICampaignService, CampaignService>();
         services.AddScoped<IContactFieldService, ContactFieldService>();
         services.AddScoped<IUserEmailService, UserEmailService>();

--- a/src/Humans.Web/Models/CommunicationPreferenceViewModels.cs
+++ b/src/Humans.Web/Models/CommunicationPreferenceViewModels.cs
@@ -1,0 +1,17 @@
+using Humans.Domain.Enums;
+
+namespace Humans.Web.Models;
+
+public class CommunicationPreferencesViewModel
+{
+    public List<CategoryPreferenceItem> Categories { get; set; } = [];
+}
+
+public class CategoryPreferenceItem
+{
+    public MessageCategory Category { get; set; }
+    public string DisplayName { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public bool OptedOut { get; set; }
+    public bool IsEditable { get; set; }
+}

--- a/src/Humans.Web/Models/ShiftViewModels.cs
+++ b/src/Humans.Web/Models/ShiftViewModels.cs
@@ -248,17 +248,6 @@ public class ShiftInfoViewModel
     public static readonly string[] LanguageOptions = ["English", "Spanish", "German", "French", "Italian", "Portuguese", "Other"];
 }
 
-// === Notification Settings ===
-
-public class NotificationSettingsViewModel
-{
-    [Display(Name = "Suppress schedule change emails")]
-    public bool SuppressScheduleChangeEmails { get; set; }
-
-    [Display(Name = "Unsubscribe from campaign emails")]
-    public bool UnsubscribedFromCampaigns { get; set; }
-}
-
 // === Dashboard ===
 
 public class ShiftDashboardViewModel

--- a/src/Humans.Web/Views/Home/About.cshtml
+++ b/src/Humans.Web/Views/Home/About.cshtml
@@ -18,7 +18,8 @@
     </p>
     <p class="mt-4 mb-0 text-muted">
         With additional help from
-        <a href="https://github.com/jokin" target="_blank" rel="noopener noreferrer">Jokin</a>.
+        <a href="https://github.com/jokin" target="_blank" rel="noopener noreferrer">Jokin</a>
+        and <a href="https://github.com/veryaaron" target="_blank" rel="noopener noreferrer">Aaron</a>.
     </p>
 </div>
 

--- a/src/Humans.Web/Views/Profile/Notifications.cshtml
+++ b/src/Humans.Web/Views/Profile/Notifications.cshtml
@@ -1,4 +1,4 @@
-@model Humans.Web.Models.NotificationSettingsViewModel
+@model Humans.Web.Models.CommunicationPreferencesViewModel
 @{
     ViewData["Title"] = "Notification Settings";
 }
@@ -22,19 +22,36 @@
 
             <div class="card mb-4">
                 <div class="card-body">
-                    <div class="form-check mb-3">
-                        <input type="checkbox" id="SuppressScheduleChangeEmails" name="SuppressScheduleChangeEmails" value="true" class="form-check-input"
-                               @(Model.SuppressScheduleChangeEmails ? "checked" : "") />
-                        <label for="SuppressScheduleChangeEmails" class="form-check-label">Suppress schedule change emails</label>
-                        <div class="form-text">Disable notifications when your shift schedule is updated.</div>
-                    </div>
+                    @for (var i = 0; i < Model.Categories.Count; i++)
+                    {
+                        var item = Model.Categories[i];
+                        <input type="hidden" name="Categories[@i].Category" value="@item.Category" />
 
-                    <div class="form-check mb-3">
-                        <input type="checkbox" id="UnsubscribedFromCampaigns" name="UnsubscribedFromCampaigns" value="true" class="form-check-input"
-                               @(Model.UnsubscribedFromCampaigns ? "checked" : "") />
-                        <label for="UnsubscribedFromCampaigns" class="form-check-label">Unsubscribe from campaign emails</label>
-                        <div class="form-text">Stop receiving promotional and campaign emails.</div>
-                    </div>
+                        <div class="form-check mb-3">
+                            @if (item.IsEditable)
+                            {
+                                <input type="hidden" name="Categories[@i].OptedOut" value="false" />
+                                <input type="checkbox"
+                                       id="Categories_@(i)_OptedOut"
+                                       name="Categories[@i].OptedOut"
+                                       value="true"
+                                       class="form-check-input"
+                                       @(item.OptedOut ? "checked" : "") />
+                            }
+                            else
+                            {
+                                <input type="checkbox"
+                                       id="Categories_@(i)_OptedOut"
+                                       class="form-check-input"
+                                       disabled
+                                       @(item.OptedOut ? "checked" : "") />
+                            }
+                            <label for="Categories_@(i)_OptedOut" class="form-check-label">
+                                Unsubscribe from @item.DisplayName
+                            </label>
+                            <div class="form-text">@item.Description</div>
+                        </div>
+                    }
                 </div>
             </div>
 

--- a/src/Humans.Web/Views/Unsubscribe/Done.cshtml
+++ b/src/Humans.Web/Views/Unsubscribe/Done.cshtml
@@ -1,9 +1,15 @@
 @{
     ViewData["Title"] = "You've been unsubscribed";
+    var categoryName = ViewData["CategoryName"] as string ?? "these";
 }
 
 <h1>You've been unsubscribed</h1>
 
-<p>You will no longer receive campaign emails from Humans.</p>
+<p>You will no longer receive @categoryName emails from Humans.</p>
+
+<p>
+    You can manage all your communication preferences from your
+    <a asp-controller="Profile" asp-action="Notifications">notification settings</a>.
+</p>
 
 <p><a asp-controller="Home" asp-action="Index">Back to home</a></p>

--- a/src/Humans.Web/Views/Unsubscribe/Expired.cshtml
+++ b/src/Humans.Web/Views/Unsubscribe/Expired.cshtml
@@ -4,6 +4,9 @@
 
 <h1>This unsubscribe link has expired</h1>
 
-<p>Please use the link from a more recent email, or sign in to manage your preferences.</p>
+<p>
+    Please use the link from a more recent email, or
+    <a asp-controller="Profile" asp-action="Notifications">sign in to manage your notification preferences</a>.
+</p>
 
 <p><a asp-controller="Home" asp-action="Index">Back to home</a></p>

--- a/src/Humans.Web/Views/Unsubscribe/Index.cshtml
+++ b/src/Humans.Web/Views/Unsubscribe/Index.cshtml
@@ -1,16 +1,17 @@
 @{
-    ViewData["Title"] = "Unsubscribe from Campaign Emails";
+    ViewData["Title"] = "Unsubscribe from Emails";
     var displayName = ViewData["DisplayName"] as string;
+    var categoryName = ViewData["CategoryName"] as string ?? "these";
 }
 
-<h1>Unsubscribe from campaign emails?</h1>
+<h1>Unsubscribe from @categoryName emails?</h1>
 
 @if (!string.IsNullOrEmpty(displayName))
 {
     <p>Hi <strong>@displayName</strong>,</p>
 }
 
-<p>If you confirm, you will no longer receive campaign emails from Humans.</p>
+<p>If you confirm, you will no longer receive @categoryName emails from Humans.</p>
 
 <form method="post">
     @Html.AntiForgeryToken()

--- a/tests/Humans.Application.Tests/Services/CampaignServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/CampaignServiceTests.cs
@@ -45,6 +45,7 @@ public class CampaignServiceTests : IDisposable
             _dbContext,
             _clock,
             _metrics,
+            Substitute.For<ICommunicationPreferenceService>(),
             emailSettings,
             hostEnvironment,
             NullLogger<CampaignService>.Instance);

--- a/tests/Humans.Application.Tests/Services/OutboxEmailServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/OutboxEmailServiceTests.cs
@@ -53,6 +53,7 @@ public class OutboxEmailServiceTests : IDisposable
             hostEnvironment,
             emailSettings,
             _backgroundJobClient,
+            Substitute.For<ICommunicationPreferenceService>(),
             NullLogger<OutboxEmailService>.Instance);
     }
 


### PR DESCRIPTION
## Summary

Aaron's PR [nobodies-collective/Humans#207](https://github.com/nobodies-collective/Humans/pull/207) cherry-picked to QA with fixes:

- **Critical fix:** RFC 8058 one-click unsubscribe was broken — `List-Unsubscribe` header pointed to `/Unsubscribe/{token}` which has `[ValidateAntiForgeryToken]`, so email clients would get 400. Now correctly points to `/Unsubscribe/OneClick?token=` which has `[IgnoreAntiforgeryToken]`
- **Deduplicated** `GetCategoryDisplayName`/`GetCategoryDescription` into shared `MessageCategoryExtensions` on the enum
- **Removed** dead `NotificationSettingsViewModel` class
- **Cleanup:** unused `System.Text.Json` import, unused `ViewData["Token"]` assignments, added try-catch to OneClick action

### From Aaron's PR (unchanged)
- `CommunicationPreference` entity with `MessageCategory` enum (System, EventOperations, CommunityUpdates, Marketing)
- `ICommunicationPreferenceService` with DataProtection token generation, RFC 8058 headers, preference-based email suppression
- Category-aware magic-link unsubscribe + backward compat with legacy campaign tokens
- Dynamic per-category toggles on `/Profile/Notifications`
- `List-Unsubscribe` + `List-Unsubscribe-Post` headers on opt-outable emails
- Audit logging via `AuditAction.CommunicationPreferenceChanged`
- EF migration `AddCommunicationPreferences` (clean, generated from current snapshot)

## Test plan

- [ ] `dotnet build` succeeds (0 errors, 0 warnings)
- [ ] All unit tests pass
- [ ] Profile /Notifications page shows all 4 categories with correct defaults
- [ ] System category disabled (cannot opt out)
- [ ] Toggling preferences saves and reloads correctly
- [ ] Old campaign unsubscribe tokens still work (backward compat)
- [ ] Verify `List-Unsubscribe` header points to `/Unsubscribe/OneClick?token=`

🤖 Generated with [Claude Code](https://claude.com/claude-code)