### PR TITLE
feat: contact account type for external marketing contacts (#205)

### DIFF
--- a/.claude/DATA_MODEL.md
+++ b/.claude/DATA_MODEL.md
@@ -13,7 +13,7 @@
 
 | Entity | Purpose |
 |--------|---------|
-| User | Custom IdentityUser with Google OAuth |
+| User | Custom IdentityUser with Google OAuth. AccountType distinguishes Members from Contacts. |
 | Profile | Member profile with computed MembershipStatus, MembershipTier, ConsentCheckStatus |
 | UserEmail | Email addresses per user (login, verified, notifications) |
 | ContactField | Contact info with per-field visibility controls |
@@ -335,6 +335,34 @@ Per-user, per-category email opt-in/opt-out preferences. One row per user per ca
 **Indexes:** UserId
 
 Defaults are created lazily: System=on, EventOperations=on, CommunityUpdates=off, Marketing=off.
+
+### AccountType
+
+Distinguishes full members from lightweight external contacts.
+
+| Value | Int | Description |
+|-------|-----|-------------|
+| Member | 0 | Full platform member (OAuth login, profile, teams) |
+| Contact | 1 | External contact (MailerLite, TicketTailor, manual). No login. |
+| Deactivated | 2 | Deactivated (e.g., after contact-to-member merge). Preserved for audit. |
+
+Stored as string. Defaults to `Member`. Added in `AddContactAccountType` migration.
+
+### ContactSource
+
+Where an external contact was imported from. Nullable — only set for Contact accounts.
+
+| Value | Int | Description |
+|-------|-----|-------------|
+| Manual | 0 | Manually created by admin |
+| MailerLite | 1 | Imported from MailerLite |
+| TicketTailor | 2 | Imported from TicketTailor |
+
+Stored as string. User also has `ExternalSourceId` (string, max 256) for dedup.
+
+**Contact merge paths:**
+- **Same email**: auto-merged on OAuth signup/login via `ContactService.MergeContactToMemberAsync`
+- **Different email**: handled by existing `AccountMergeRequest` admin workflow when member adds contact's email via Profile → Emails
 
 ## Enums
 

--- a/docs/features/29-contact-accounts.md
+++ b/docs/features/29-contact-accounts.md
@@ -1,0 +1,85 @@
+# Feature 29: Contact Accounts
+
+**Issue:** [#205](https://github.com/nobodies-collective/Humans/issues/205)
+**Dependencies:** #97 (Communication Preferences)
+**Used by:** #200 (MailerLite sync), #206 (TicketTailor import)
+
+## Business Context
+
+Humans syncs with MailerLite (mailing list) and TicketTailor (ticket sales) which contain people who aren't Humans members. These people need to exist in Humans for unified communication preference management, but they shouldn't be treated as full members (no login, no profile, no team rosters).
+
+## Data Model
+
+An `AccountType` enum on the existing `User` entity distinguishes Members from Contacts. This reuses all existing email and preference infrastructure.
+
+**New properties on User:**
+- `AccountType` (enum: Member, Contact, Deactivated) — defaults to Member
+- `ContactSource` (nullable enum: Manual, MailerLite, TicketTailor) — where the contact came from
+- `ExternalSourceId` (nullable string, max 256) — external system ID for deduplication
+
+**Indexes:**
+- `AccountType` (for query filtering)
+- `(ContactSource, ExternalSourceId)` filtered where ExternalSourceId IS NOT NULL (for import dedup)
+
+## Contact Creation
+
+Contacts are created via `IContactService.CreateContactAsync()`:
+1. Email is normalized and checked for duplicates
+2. If a contact already exists for the same email, returns the existing one (idempotent)
+3. If a member exists for the email, throws (use merge flow instead)
+4. Creates User with `AccountType.Contact`, locked out (no login)
+5. Creates UserEmail record (verified, non-OAuth)
+6. Sets default communication preferences: Marketing opted-in, EventOperations opted-out
+
+Sources: admin manual creation, MailerLite import (#200), TicketTailor import (#206).
+
+## Contact-to-Member Merge
+
+Two paths handle upgrading a contact to a member:
+
+### Same-email auto-merge
+When someone signs up via Google OAuth with the same email as an existing contact:
+- New member account is created normally
+- System automatically calls `MergeContactToMemberAsync`
+- Contact's communication preferences migrate to member (member's existing preferences win on conflict)
+- Contact's UserEmails migrate to member (duplicates dropped)
+- Contact account is set to `Deactivated`
+- Audit logged on both accounts
+
+### Different-email admin merge
+When a member adds an email that belongs to a contact (e.g., member signed up with Gmail, contact exists with their TicketTailor email):
+- Existing `AccountMergeRequest` workflow triggers (admin-reviewed)
+- When admin accepts, `AccountMergeService` detects source is a Contact and uses the lighter `MergeContactToMemberAsync` instead of full anonymization
+
+## Query Filtering
+
+Contacts are excluded from all member-facing queries:
+- `ProfileService.GetFilteredHumansAsync()` — `.Where(u => u.AccountType == AccountType.Member)`
+- `ProfileService.SearchApprovedUsersAsync()` — same filter
+- `OnboardingService.GetAdminDashboardAsync()` — member count excludes contacts
+
+Naturally safe (no filter needed): MembershipCalculator, team/shift queries, Board queries — all filter by Profile, which contacts don't have.
+
+## Admin UI
+
+**Contacts list** at `/Human/Admin/Contacts`:
+- Search by name/email
+- Shows source, external ID, preference status
+- Link from the Humans admin page
+
+**Contact detail** at `/Human/{id}/Admin/Contact`:
+- Contact info, source, external ID
+- Communication preferences
+- Audit log
+
+**Manual creation** at `/Human/Admin/Contacts/Create`:
+- Email, display name, source
+
+## Acceptance Criteria
+
+- [x] External contacts can be created without OAuth/login
+- [x] Contact records track source (MailerLite, TicketTailor, manual)
+- [x] Contacts have communication preferences (same model as members)
+- [x] Contact-to-member upgrade merges records and preserves history
+- [x] Admin view distinguishes contacts from members
+- [x] Contacts do not appear in member counts, team rosters, or volunteer workflows

--- a/src/Humans.Application/DTOs/AdminContactRow.cs
+++ b/src/Humans.Application/DTOs/AdminContactRow.cs
@@ -1,0 +1,12 @@
+using Humans.Domain.Enums;
+
+namespace Humans.Application.DTOs;
+
+public record AdminContactRow(
+    Guid UserId,
+    string Email,
+    string DisplayName,
+    ContactSource? ContactSource,
+    string? ExternalSourceId,
+    DateTime CreatedAt,
+    bool HasCommunicationPreferences);

--- a/src/Humans.Application/Interfaces/IContactService.cs
+++ b/src/Humans.Application/Interfaces/IContactService.cs
@@ -1,0 +1,52 @@
+using Humans.Application.DTOs;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+
+namespace Humans.Application.Interfaces;
+
+/// <summary>
+/// Manages lightweight external contacts (MailerLite, TicketTailor, manual).
+/// Contacts exist for communication preference tracking but cannot log in.
+/// </summary>
+public interface IContactService
+{
+    /// <summary>
+    /// Creates a contact account. Idempotent — returns the existing contact if one
+    /// already exists for the same email. Throws if a full member already has this email.
+    /// </summary>
+    Task<User> CreateContactAsync(
+        string email, string displayName, ContactSource source,
+        string? externalSourceId = null, CancellationToken ct = default);
+
+    /// <summary>
+    /// Finds an existing contact by email (normalized comparison).
+    /// Returns null if no contact exists with this email.
+    /// </summary>
+    Task<User?> FindContactByEmailAsync(string email, CancellationToken ct = default);
+
+    /// <summary>
+    /// Finds an existing contact by external system source and ID.
+    /// </summary>
+    Task<User?> FindContactByExternalIdAsync(
+        ContactSource source, string externalSourceId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns all contacts, optionally filtered by email/name search.
+    /// </summary>
+    Task<IReadOnlyList<AdminContactRow>> GetFilteredContactsAsync(
+        string? search, CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets a single contact by user ID with communication preferences loaded.
+    /// </summary>
+    Task<User?> GetContactDetailAsync(Guid userId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Merges a contact into a member account. Migrates communication preferences
+    /// (member's existing preferences win on conflict), migrates UserEmails, and
+    /// deactivates the contact account. Logs audit entries on both accounts.
+    /// </summary>
+    Task MergeContactToMemberAsync(
+        User contactUser, User memberUser,
+        Guid? actorUserId, string actorName, CancellationToken ct = default);
+}

--- a/src/Humans.Domain/Entities/User.cs
+++ b/src/Humans.Domain/Entities/User.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Identity;
 using NodaTime;
+using Humans.Domain.Enums;
 
 namespace Humans.Domain.Entities;
 
@@ -115,6 +116,28 @@ public class User : IdentityUser<Guid>
     /// Whether to suppress email notifications for schedule changes.
     /// </summary>
     public bool SuppressScheduleChangeEmails { get; set; }
+
+    /// <summary>
+    /// Type of account: Member (full platform user) or Contact (external, no login).
+    /// Defaults to Member so existing users are unaffected.
+    /// </summary>
+    public AccountType AccountType { get; set; } = AccountType.Member;
+
+    /// <summary>
+    /// Where this contact was imported from. Only set for Contact accounts.
+    /// </summary>
+    public ContactSource? ContactSource { get; set; }
+
+    /// <summary>
+    /// External system ID for deduplication (e.g., MailerLite subscriber ID, TicketTailor attendee ID).
+    /// Only set for Contact accounts.
+    /// </summary>
+    public string? ExternalSourceId { get; set; }
+
+    /// <summary>
+    /// Whether this is a lightweight contact (not a full member).
+    /// </summary>
+    public bool IsContact => AccountType == AccountType.Contact;
 
     /// <summary>
     /// Navigation property to communication preferences.

--- a/src/Humans.Domain/Enums/AccountType.cs
+++ b/src/Humans.Domain/Enums/AccountType.cs
@@ -1,0 +1,25 @@
+namespace Humans.Domain.Enums;
+
+/// <summary>
+/// Distinguishes full members from lightweight external contacts.
+/// Stored as string in DB; new values can be appended without migration.
+/// </summary>
+public enum AccountType
+{
+    /// <summary>
+    /// Full platform member (signed up via OAuth, has profile, teams, etc.).
+    /// </summary>
+    Member = 0,
+
+    /// <summary>
+    /// External contact imported from MailerLite, TicketTailor, or manual entry.
+    /// No login, no profile — exists for communication preference tracking.
+    /// </summary>
+    Contact = 1,
+
+    /// <summary>
+    /// Deactivated account (e.g., after contact-to-member merge).
+    /// Preserved for audit trail.
+    /// </summary>
+    Deactivated = 2
+}

--- a/src/Humans.Domain/Enums/AuditAction.cs
+++ b/src/Humans.Domain/Enums/AuditAction.cs
@@ -69,4 +69,6 @@ public enum AuditAction
     AccountMergeRejected,
     GoogleResourceSettingsRemediated,
     CommunicationPreferenceChanged,
+    ContactCreated,
+    ContactMergedToMember,
 }

--- a/src/Humans.Domain/Enums/ContactSource.cs
+++ b/src/Humans.Domain/Enums/ContactSource.cs
@@ -1,0 +1,23 @@
+namespace Humans.Domain.Enums;
+
+/// <summary>
+/// Where an external contact was imported from.
+/// Stored as string in DB; new values can be appended without migration.
+/// </summary>
+public enum ContactSource
+{
+    /// <summary>
+    /// Manually created by an admin.
+    /// </summary>
+    Manual = 0,
+
+    /// <summary>
+    /// Imported from MailerLite mailing list.
+    /// </summary>
+    MailerLite = 1,
+
+    /// <summary>
+    /// Imported from TicketTailor ticket purchase.
+    /// </summary>
+    TicketTailor = 2
+}

--- a/src/Humans.Infrastructure/Data/Configurations/UserConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/UserConfiguration.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Humans.Domain.Entities;
+using Humans.Domain.Enums;
 
 namespace Humans.Infrastructure.Data.Configurations;
 
@@ -58,6 +59,24 @@ public class UserConfiguration : IEntityTypeConfiguration<User>
             .OnDelete(DeleteBehavior.Cascade);
 
         builder.HasIndex(u => u.Email);
+
+        // Contact account type support (#205)
+        builder.Property(u => u.AccountType)
+            .HasConversion<string>()
+            .HasMaxLength(50)
+            .HasDefaultValue(AccountType.Member);
+
+        builder.Property(u => u.ContactSource)
+            .HasConversion<string>()
+            .HasMaxLength(50);
+
+        builder.Property(u => u.ExternalSourceId)
+            .HasMaxLength(256);
+
+        builder.HasIndex(u => u.AccountType);
+
+        builder.HasIndex(u => new { u.ContactSource, u.ExternalSourceId })
+            .HasFilter("external_source_id IS NOT NULL");
 
         // Ignore GetEffectiveEmail (method, not property - EF won't map it, but defensive)
     }

--- a/src/Humans.Infrastructure/Migrations/20260324215116_AddContactAccountType.Designer.cs
+++ b/src/Humans.Infrastructure/Migrations/20260324215116_AddContactAccountType.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Humans.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Humans.Infrastructure.Migrations
 {
     [DbContext(typeof(HumansDbContext))]
-    partial class HumansDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260324215116_AddContactAccountType")]
+    partial class AddContactAccountType
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Humans.Infrastructure/Migrations/20260324215116_AddContactAccountType.cs
+++ b/src/Humans.Infrastructure/Migrations/20260324215116_AddContactAccountType.cs
@@ -1,0 +1,71 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Humans.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddContactAccountType : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "AccountType",
+                table: "users",
+                type: "character varying(50)",
+                maxLength: 50,
+                nullable: false,
+                defaultValue: "Member");
+
+            migrationBuilder.AddColumn<string>(
+                name: "ContactSource",
+                table: "users",
+                type: "character varying(50)",
+                maxLength: 50,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ExternalSourceId",
+                table: "users",
+                type: "character varying(256)",
+                maxLength: 256,
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_users_AccountType",
+                table: "users",
+                column: "AccountType");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_users_ContactSource_ExternalSourceId",
+                table: "users",
+                columns: new[] { "ContactSource", "ExternalSourceId" },
+                filter: "external_source_id IS NOT NULL");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_users_AccountType",
+                table: "users");
+
+            migrationBuilder.DropIndex(
+                name: "IX_users_ContactSource_ExternalSourceId",
+                table: "users");
+
+            migrationBuilder.DropColumn(
+                name: "AccountType",
+                table: "users");
+
+            migrationBuilder.DropColumn(
+                name: "ContactSource",
+                table: "users");
+
+            migrationBuilder.DropColumn(
+                name: "ExternalSourceId",
+                table: "users");
+        }
+    }
+}

--- a/src/Humans.Infrastructure/Services/AccountMergeService.cs
+++ b/src/Humans.Infrastructure/Services/AccountMergeService.cs
@@ -19,6 +19,7 @@ public class AccountMergeService : IAccountMergeService
     private readonly IAuditLogService _auditLogService;
     private readonly IProfileService _profileService;
     private readonly ITeamService _teamService;
+    private readonly IContactService _contactService;
     private readonly ILogger<AccountMergeService> _logger;
     private readonly IClock _clock;
 
@@ -27,6 +28,7 @@ public class AccountMergeService : IAccountMergeService
         IAuditLogService auditLogService,
         IProfileService profileService,
         ITeamService teamService,
+        IContactService contactService,
         ILogger<AccountMergeService> logger,
         IClock clock)
     {
@@ -34,6 +36,7 @@ public class AccountMergeService : IAccountMergeService
         _auditLogService = auditLogService;
         _profileService = profileService;
         _teamService = teamService;
+        _contactService = contactService;
         _logger = logger;
         _clock = clock;
     }
@@ -83,49 +86,76 @@ public class AccountMergeService : IAccountMergeService
             "Admin {AdminId} accepting merge request {RequestId}: merging {SourceUserId} ({SourceName}) into {TargetUserId} ({TargetName})",
             adminUserId, requestId, sourceUser.Id, sourceDisplayName, targetUser.Id, targetUser.DisplayName);
 
-        // 1. Add primary to any non-system teams the duplicate is in (via service)
-        //    System teams (e.g. Volunteers) are managed automatically — skip them.
-        var sourceTeams = await _teamService.GetUserTeamsAsync(sourceUser.Id, ct);
-        var targetTeamIds = (await _teamService.GetUserTeamsAsync(targetUser.Id, ct))
-            .Select(m => m.TeamId).ToHashSet();
-
-        foreach (var membership in sourceTeams.Where(m => !m.Team.IsSystemTeam && !targetTeamIds.Contains(m.TeamId)))
+        if (sourceUser.AccountType == AccountType.Contact)
         {
-            await _teamService.AddMemberToTeamAsync(membership.TeamId, targetUser.Id, adminUserId, ct);
+            // Lightweight merge: source is an external contact, not a full member.
+            // Delete source emails first to avoid unique constraint on pending email verify.
+            var sourceEmails = await _dbContext.UserEmails
+                .Where(e => e.UserId == sourceUser.Id)
+                .ToListAsync(ct);
+            _dbContext.UserEmails.RemoveRange(sourceEmails);
+            await _dbContext.SaveChangesAsync(ct);
+
+            // Verify the pending email on the target
+            var pendingEmail = await _dbContext.UserEmails
+                .FirstOrDefaultAsync(e => e.Id == request.PendingEmailId, ct)
+                ?? throw new InvalidOperationException(
+                    $"Pending email {request.PendingEmailId} no longer exists. Cannot complete merge.");
+            pendingEmail.IsVerified = true;
+            pendingEmail.UpdatedAt = now;
+
+            // Delegate preference migration + deactivation to ContactService
+            await _contactService.MergeContactToMemberAsync(
+                sourceUser, targetUser, adminUserId, adminDisplayName, ct);
+        }
+        else
+        {
+            // Full member-to-member merge (existing logic)
+
+            // 1. Add primary to any non-system teams the duplicate is in (via service)
+            //    System teams (e.g. Volunteers) are managed automatically — skip them.
+            var sourceTeams = await _teamService.GetUserTeamsAsync(sourceUser.Id, ct);
+            var targetTeamIds = (await _teamService.GetUserTeamsAsync(targetUser.Id, ct))
+                .Select(m => m.TeamId).ToHashSet();
+
+            foreach (var membership in sourceTeams.Where(m => !m.Team.IsSystemTeam && !targetTeamIds.Contains(m.TeamId)))
+            {
+                await _teamService.AddMemberToTeamAsync(membership.TeamId, targetUser.Id, adminUserId, ct);
+            }
+
+            // 2. Remove duplicate from all non-system teams (via service)
+            foreach (var membership in sourceTeams.Where(m => !m.Team.IsSystemTeam))
+            {
+                await _teamService.RemoveMemberAsync(membership.TeamId, sourceUser.Id, adminUserId, ct);
+            }
+
+            // 3. End duplicate's active role assignments (system sync will re-evaluate)
+            foreach (var role in sourceUser.RoleAssignments.Where(r => r.ValidTo == null))
+            {
+                role.ValidTo = now;
+            }
+
+            // 4. Delete duplicate's email rows (must happen before verifying
+            //    the pending email to avoid unique constraint violation)
+            var sourceEmails = await _dbContext.UserEmails
+                .Where(e => e.UserId == sourceUser.Id)
+                .ToListAsync(ct);
+            _dbContext.UserEmails.RemoveRange(sourceEmails);
+            await _dbContext.SaveChangesAsync(ct);
+
+            // 5. Verify the pending email on the primary account
+            var pendingEmail = await _dbContext.UserEmails
+                .FirstOrDefaultAsync(e => e.Id == request.PendingEmailId, ct)
+                ?? throw new InvalidOperationException(
+                    $"Pending email {request.PendingEmailId} no longer exists. Cannot complete merge.");
+            pendingEmail.IsVerified = true;
+            pendingEmail.UpdatedAt = now;
+
+            // 6. Anonymize the duplicate account
+            await AnonymizeSourceAccountAsync(sourceUser, now, ct);
         }
 
-        // 2. Remove duplicate from all non-system teams (via service)
-        foreach (var membership in sourceTeams.Where(m => !m.Team.IsSystemTeam))
-        {
-            await _teamService.RemoveMemberAsync(membership.TeamId, sourceUser.Id, adminUserId, ct);
-        }
-
-        // 3. End duplicate's active role assignments (system sync will re-evaluate)
-        foreach (var role in sourceUser.RoleAssignments.Where(r => r.ValidTo == null))
-        {
-            role.ValidTo = now;
-        }
-
-        // 4. Delete duplicate's email rows (must happen before verifying
-        //    the pending email to avoid unique constraint violation)
-        var sourceEmails = await _dbContext.UserEmails
-            .Where(e => e.UserId == sourceUser.Id)
-            .ToListAsync(ct);
-        _dbContext.UserEmails.RemoveRange(sourceEmails);
-        await _dbContext.SaveChangesAsync(ct);
-
-        // 5. Verify the pending email on the primary account
-        var pendingEmail = await _dbContext.UserEmails
-            .FirstOrDefaultAsync(e => e.Id == request.PendingEmailId, ct)
-            ?? throw new InvalidOperationException(
-                $"Pending email {request.PendingEmailId} no longer exists. Cannot complete merge.");
-        pendingEmail.IsVerified = true;
-        pendingEmail.UpdatedAt = now;
-
-        // 6. Anonymize the duplicate account
-        await AnonymizeSourceAccountAsync(sourceUser, now, ct);
-
-        // 6. Mark the merge request as accepted
+        // 7. Mark the merge request as accepted
         request.Status = AccountMergeRequestStatus.Accepted;
         request.ResolvedAt = now;
         request.ResolvedByUserId = adminUserId;

--- a/src/Humans.Infrastructure/Services/ContactService.cs
+++ b/src/Humans.Infrastructure/Services/ContactService.cs
@@ -1,0 +1,323 @@
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using NodaTime;
+using Humans.Application.DTOs;
+using Humans.Application.Interfaces;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using Humans.Domain.Helpers;
+using Humans.Infrastructure.Data;
+
+namespace Humans.Infrastructure.Services;
+
+/// <summary>
+/// Manages lightweight external contacts imported from MailerLite, TicketTailor, or manual entry.
+/// Contacts have communication preferences but cannot log in or access the platform.
+/// </summary>
+public class ContactService : IContactService
+{
+    private readonly HumansDbContext _dbContext;
+    private readonly UserManager<User> _userManager;
+    private readonly IAuditLogService _auditLogService;
+    private readonly ICommunicationPreferenceService _communicationPreferenceService;
+    private readonly IClock _clock;
+    private readonly ILogger<ContactService> _logger;
+
+    public ContactService(
+        HumansDbContext dbContext,
+        UserManager<User> userManager,
+        IAuditLogService auditLogService,
+        ICommunicationPreferenceService communicationPreferenceService,
+        IClock clock,
+        ILogger<ContactService> logger)
+    {
+        _dbContext = dbContext;
+        _userManager = userManager;
+        _auditLogService = auditLogService;
+        _communicationPreferenceService = communicationPreferenceService;
+        _clock = clock;
+        _logger = logger;
+    }
+
+    public async Task<User> CreateContactAsync(
+        string email, string displayName, ContactSource source,
+        string? externalSourceId = null, CancellationToken ct = default)
+    {
+        var normalizedEmail = EmailNormalization.NormalizeForComparison(email);
+
+        // Check for existing user with this email
+        var existingUser = await _dbContext.Users
+            .FirstOrDefaultAsync(u => u.NormalizedEmail == normalizedEmail.ToUpperInvariant(), ct);
+
+        if (existingUser is not null)
+        {
+            if (existingUser.AccountType == AccountType.Contact)
+            {
+                _logger.LogDebug("Contact already exists for {Email}, returning existing", email);
+                return existingUser;
+            }
+
+            throw new InvalidOperationException(
+                $"A member account already exists for email {email}. Use the account merge flow instead.");
+        }
+
+        // Also check UserEmails table for the email on any existing account
+        var existingUserEmail = await _dbContext.UserEmails
+            .Include(ue => ue.User)
+            .FirstOrDefaultAsync(ue => ue.IsVerified &&
+                EF.Functions.ILike(ue.Email, email), ct);
+
+        if (existingUserEmail is not null)
+        {
+            if (existingUserEmail.User.AccountType == AccountType.Contact)
+            {
+                return existingUserEmail.User;
+            }
+
+            throw new InvalidOperationException(
+                $"Email {email} is already verified on member account {existingUserEmail.UserId}.");
+        }
+
+        var now = _clock.GetCurrentInstant();
+
+        var user = new User
+        {
+            UserName = email,
+            Email = email,
+            DisplayName = displayName,
+            AccountType = AccountType.Contact,
+            ContactSource = source,
+            ExternalSourceId = externalSourceId,
+            CreatedAt = now,
+            EmailConfirmed = true
+        };
+
+        // Disable login for contacts
+        user.LockoutEnabled = true;
+        user.LockoutEnd = DateTimeOffset.MaxValue;
+
+        var result = await _userManager.CreateAsync(user);
+        if (!result.Succeeded)
+        {
+            var errors = string.Join(", ", result.Errors.Select(e => e.Description));
+            throw new InvalidOperationException($"Failed to create contact: {errors}");
+        }
+
+        // Create UserEmail record
+        var userEmail = new UserEmail
+        {
+            Id = Guid.NewGuid(),
+            UserId = user.Id,
+            Email = email,
+            IsOAuth = false,
+            IsVerified = true,
+            IsNotificationTarget = true,
+            Visibility = null,
+            DisplayOrder = 0,
+            CreatedAt = now,
+            UpdatedAt = now
+        };
+        _dbContext.UserEmails.Add(userEmail);
+
+        // Set default communication preferences: Marketing opted-in (the reason contacts exist),
+        // EventOperations opted-out (not a member)
+        await _communicationPreferenceService.UpdatePreferenceAsync(
+            user.Id, MessageCategory.Marketing, optedOut: false, "ContactCreation", ct);
+        await _communicationPreferenceService.UpdatePreferenceAsync(
+            user.Id, MessageCategory.EventOperations, optedOut: true, "ContactCreation", ct);
+
+        // Audit log
+        await _auditLogService.LogAsync(
+            AuditAction.ContactCreated,
+            nameof(User), user.Id,
+            $"Contact created from {source}{(externalSourceId is not null ? $" (ID: {externalSourceId})" : "")} — {email}",
+            "ContactService");
+
+        await _dbContext.SaveChangesAsync(ct);
+
+        _logger.LogInformation(
+            "Created contact {UserId} for {Email} from {Source}",
+            user.Id, email, source);
+
+        return user;
+    }
+
+    public async Task<User?> FindContactByEmailAsync(string email, CancellationToken ct = default)
+    {
+        var normalizedEmail = EmailNormalization.NormalizeForComparison(email).ToUpperInvariant();
+
+        return await _dbContext.Users
+            .FirstOrDefaultAsync(u =>
+                u.AccountType == AccountType.Contact &&
+                u.NormalizedEmail == normalizedEmail, ct);
+    }
+
+    public async Task<User?> FindContactByExternalIdAsync(
+        ContactSource source, string externalSourceId, CancellationToken ct = default)
+    {
+        return await _dbContext.Users
+            .FirstOrDefaultAsync(u =>
+                u.AccountType == AccountType.Contact &&
+                u.ContactSource == source &&
+                u.ExternalSourceId == externalSourceId, ct);
+    }
+
+    public async Task<IReadOnlyList<AdminContactRow>> GetFilteredContactsAsync(
+        string? search, CancellationToken ct = default)
+    {
+        var query = _dbContext.Users
+            .AsNoTracking()
+            .Where(u => u.AccountType == AccountType.Contact);
+
+        if (!string.IsNullOrWhiteSpace(search))
+        {
+            var pattern = $"%{search}%";
+            query = query.Where(u =>
+                EF.Functions.ILike(u.DisplayName, pattern) ||
+                (u.Email != null && EF.Functions.ILike(u.Email, pattern)));
+        }
+
+        return await query
+            .OrderByDescending(u => u.CreatedAt)
+            .Select(u => new AdminContactRow(
+                u.Id,
+                u.Email ?? string.Empty,
+                u.DisplayName,
+                u.ContactSource,
+                u.ExternalSourceId,
+                u.CreatedAt.ToDateTimeUtc(),
+                u.CommunicationPreferences.Any()))
+            .ToListAsync(ct);
+    }
+
+    public async Task<User?> GetContactDetailAsync(Guid userId, CancellationToken ct = default)
+    {
+        return await _dbContext.Users
+            .Include(u => u.CommunicationPreferences)
+            .Include(u => u.UserEmails)
+            .FirstOrDefaultAsync(u =>
+                u.Id == userId &&
+                u.AccountType == AccountType.Contact, ct);
+    }
+
+    public async Task MergeContactToMemberAsync(
+        User contactUser, User memberUser,
+        Guid? actorUserId, string actorName, CancellationToken ct = default)
+    {
+        _logger.LogInformation(
+            "Merging contact {ContactId} ({ContactEmail}) into member {MemberId} ({MemberEmail})",
+            contactUser.Id, contactUser.Email, memberUser.Id, memberUser.Email);
+
+        // 1. Migrate communication preferences (member's existing preferences win)
+        var contactPrefs = await _dbContext.CommunicationPreferences
+            .Where(cp => cp.UserId == contactUser.Id)
+            .ToListAsync(ct);
+
+        var memberPrefCategories = await _dbContext.CommunicationPreferences
+            .Where(cp => cp.UserId == memberUser.Id)
+            .Select(cp => cp.Category)
+            .ToListAsync(ct);
+
+        foreach (var pref in contactPrefs)
+        {
+            if (!memberPrefCategories.Contains(pref.Category))
+            {
+                // Member doesn't have this category — create it on the member
+                _dbContext.CommunicationPreferences.Add(new CommunicationPreference
+                {
+                    Id = Guid.NewGuid(),
+                    UserId = memberUser.Id,
+                    Category = pref.Category,
+                    OptedOut = pref.OptedOut,
+                    UpdatedAt = _clock.GetCurrentInstant(),
+                    UpdateSource = "ContactMerge",
+                    User = memberUser
+                });
+            }
+
+            // Remove the contact's preference regardless
+            _dbContext.CommunicationPreferences.Remove(pref);
+        }
+
+        // 2. Migrate UserEmails that the member doesn't already have
+        var contactEmails = await _dbContext.UserEmails
+            .Where(e => e.UserId == contactUser.Id)
+            .ToListAsync(ct);
+
+        var memberEmailAddresses = await _dbContext.UserEmails
+            .Where(e => e.UserId == memberUser.Id)
+            .Select(e => e.Email.ToLowerInvariant())
+            .ToListAsync(ct);
+
+        var memberEmailSet = new HashSet<string>(memberEmailAddresses, StringComparer.OrdinalIgnoreCase);
+
+        foreach (var contactEmail in contactEmails)
+        {
+            // Remove the contact's email record; if the member doesn't have it, re-create on their account
+            _dbContext.UserEmails.Remove(contactEmail);
+
+            if (!memberEmailSet.Contains(contactEmail.Email))
+            {
+                _dbContext.UserEmails.Add(new UserEmail
+                {
+                    Id = Guid.NewGuid(),
+                    UserId = memberUser.Id,
+                    Email = contactEmail.Email,
+                    IsOAuth = false,
+                    IsVerified = contactEmail.IsVerified,
+                    IsNotificationTarget = false,
+                    Visibility = contactEmail.Visibility,
+                    DisplayOrder = contactEmail.DisplayOrder,
+                    CreatedAt = contactEmail.CreatedAt,
+                    UpdatedAt = _clock.GetCurrentInstant()
+                });
+            }
+        }
+
+        // 3. Deactivate the contact (don't delete — preserve for audit trail)
+        contactUser.AccountType = AccountType.Deactivated;
+        contactUser.LockoutEnabled = true;
+        contactUser.LockoutEnd = DateTimeOffset.MaxValue;
+
+        // 4. Audit log on both accounts
+        if (actorUserId.HasValue)
+        {
+            await _auditLogService.LogAsync(
+                AuditAction.ContactMergedToMember,
+                nameof(User), contactUser.Id,
+                $"Contact merged into member {memberUser.DisplayName} ({memberUser.Email})",
+                actorUserId.Value, actorName,
+                relatedEntityId: memberUser.Id, relatedEntityType: nameof(User));
+
+            await _auditLogService.LogAsync(
+                AuditAction.ContactMergedToMember,
+                nameof(User), memberUser.Id,
+                $"Absorbed contact {contactUser.Email} from {contactUser.ContactSource}",
+                actorUserId.Value, actorName,
+                relatedEntityId: contactUser.Id, relatedEntityType: nameof(User));
+        }
+        else
+        {
+            await _auditLogService.LogAsync(
+                AuditAction.ContactMergedToMember,
+                nameof(User), contactUser.Id,
+                $"Contact merged into member {memberUser.DisplayName} ({memberUser.Email})",
+                actorName,
+                relatedEntityId: memberUser.Id, relatedEntityType: nameof(User));
+
+            await _auditLogService.LogAsync(
+                AuditAction.ContactMergedToMember,
+                nameof(User), memberUser.Id,
+                $"Absorbed contact {contactUser.Email} from {contactUser.ContactSource}",
+                actorName,
+                relatedEntityId: contactUser.Id, relatedEntityType: nameof(User));
+        }
+
+        await _dbContext.SaveChangesAsync(ct);
+
+        _logger.LogInformation(
+            "Contact {ContactId} merged into member {MemberId}",
+            contactUser.Id, memberUser.Id);
+    }
+}

--- a/src/Humans.Infrastructure/Services/OnboardingService.cs
+++ b/src/Humans.Infrastructure/Services/OnboardingService.cs
@@ -471,7 +471,9 @@ public class OnboardingService : IOnboardingService
 
     public async Task<Application.DTOs.AdminDashboardData> GetAdminDashboardAsync(CancellationToken ct = default)
     {
-        var allUserIds = await _dbContext.Users.Select(u => u.Id).ToListAsync(ct);
+        var allUserIds = await _dbContext.Users
+            .Where(u => u.AccountType == AccountType.Member)
+            .Select(u => u.Id).ToListAsync(ct);
         var totalMembers = allUserIds.Count;
         var partition = await _membershipCalculator.PartitionUsersAsync(allUserIds, ct);
 

--- a/src/Humans.Infrastructure/Services/ProfileService.cs
+++ b/src/Humans.Infrastructure/Services/ProfileService.cs
@@ -557,6 +557,7 @@ public class ProfileService : IProfileService
         string? search, string? statusFilter, CancellationToken ct = default)
     {
         var users = await _dbContext.Users
+            .Where(u => u.AccountType == AccountType.Member)
             .Select(u => new
             {
                 u.Id,
@@ -696,6 +697,7 @@ public class ProfileService : IProfileService
     {
         var pattern = $"%{query}%";
         return await _dbContext.Users
+            .Where(u => u.AccountType == AccountType.Member)
             .Where(u => u.Profile != null && u.Profile.IsApproved && !u.Profile.IsSuspended)
             .Where(u => EF.Functions.ILike(u.DisplayName, pattern) ||
                          (u.Email != null && EF.Functions.ILike(u.Email, pattern)))

--- a/src/Humans.Web/Controllers/AccountController.cs
+++ b/src/Humans.Web/Controllers/AccountController.cs
@@ -16,19 +16,22 @@ public class AccountController : Controller
     private readonly IClock _clock;
     private readonly ILogger<AccountController> _logger;
     private readonly IUserEmailService _userEmailService;
+    private readonly IContactService _contactService;
 
     public AccountController(
         SignInManager<User> signInManager,
         UserManager<User> userManager,
         IClock clock,
         ILogger<AccountController> logger,
-        IUserEmailService userEmailService)
+        IUserEmailService userEmailService,
+        IContactService contactService)
     {
         _signInManager = signInManager;
         _userManager = userManager;
         _clock = clock;
         _logger = logger;
         _userEmailService = userEmailService;
+        _contactService = contactService;
     }
 
     [HttpGet]
@@ -80,6 +83,18 @@ public class AccountController : Controller
             {
                 existingUser.LastLoginAt = _clock.GetCurrentInstant();
                 await _userManager.UpdateAsync(existingUser);
+
+                // Auto-merge if a contact exists with the same email
+                var loginEmail = info.Principal.FindFirstValue(ClaimTypes.Email);
+                if (!string.IsNullOrEmpty(loginEmail))
+                {
+                    var existingContact = await _contactService.FindContactByEmailAsync(loginEmail);
+                    if (existingContact is not null)
+                    {
+                        await _contactService.MergeContactToMemberAsync(
+                            existingContact, existingUser, null, "OAuth login auto-merge");
+                    }
+                }
             }
 
             _logger.LogInformation("User logged in with {Provider}", info.LoginProvider);
@@ -120,6 +135,14 @@ public class AccountController : Controller
             {
                 // Create OAuth UserEmail record for the login email
                 await _userEmailService.AddOAuthEmailAsync(user.Id, email);
+
+                // Auto-merge if a contact exists with the same email
+                var existingContact = await _contactService.FindContactByEmailAsync(email);
+                if (existingContact is not null)
+                {
+                    await _contactService.MergeContactToMemberAsync(
+                        existingContact, user, null, "OAuth signup auto-merge");
+                }
 
                 await _signInManager.SignInAsync(user, isPersistent: false);
                 _logger.LogInformation("User created an account using {Provider}", info.LoginProvider);

--- a/src/Humans.Web/Controllers/HumanController.cs
+++ b/src/Humans.Web/Controllers/HumanController.cs
@@ -27,6 +27,7 @@ public class HumanController : HumansControllerBase
     private readonly IRoleAssignmentService _roleAssignmentService;
     private readonly IShiftSignupService _shiftSignupService;
     private readonly IShiftManagementService _shiftMgmt;
+    private readonly IContactService _contactService;
     private readonly IClock _clock;
     private readonly IStringLocalizer<SharedResource> _localizer;
     private readonly HumansDbContext _dbContext;
@@ -40,6 +41,7 @@ public class HumanController : HumansControllerBase
         IRoleAssignmentService roleAssignmentService,
         IShiftSignupService shiftSignupService,
         IShiftManagementService shiftMgmt,
+        IContactService contactService,
         IClock clock,
         IStringLocalizer<SharedResource> localizer,
         HumansDbContext dbContext)
@@ -53,6 +55,7 @@ public class HumanController : HumansControllerBase
         _roleAssignmentService = roleAssignmentService;
         _shiftSignupService = shiftSignupService;
         _shiftMgmt = shiftMgmt;
+        _contactService = contactService;
         _clock = clock;
         _localizer = localizer;
         _dbContext = dbContext;
@@ -569,4 +572,98 @@ public class HumanController : HumansControllerBase
         return RedirectToAction(nameof(HumanDetail), new { id = roleAssignment.UserId });
     }
 
+    // ---- Contact Management ----
+
+    [Authorize(Roles = RoleGroups.BoardOrAdmin)]
+    [HttpGet("Admin/Contacts")]
+    public async Task<IActionResult> Contacts(string? search, int page = 1)
+    {
+        var pageSize = 20;
+        var allRows = await _contactService.GetFilteredContactsAsync(search);
+        var totalCount = allRows.Count;
+
+        var contacts = allRows
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .Select(r => new AdminContactViewModel
+            {
+                Id = r.UserId,
+                Email = r.Email,
+                DisplayName = r.DisplayName,
+                ContactSource = r.ContactSource,
+                ExternalSourceId = r.ExternalSourceId,
+                CreatedAt = r.CreatedAt,
+                HasCommunicationPreferences = r.HasCommunicationPreferences
+            })
+            .ToList();
+
+        var viewModel = new AdminContactListViewModel
+        {
+            Contacts = contacts,
+            SearchTerm = search,
+            TotalCount = totalCount,
+            PageNumber = page,
+        };
+
+        return View(viewModel);
+    }
+
+    [Authorize(Roles = RoleGroups.BoardOrAdmin)]
+    [HttpGet("{id:guid}/Admin/Contact")]
+    public async Task<IActionResult> ContactDetail(Guid id)
+    {
+        var contact = await _contactService.GetContactDetailAsync(id);
+        if (contact is null)
+        {
+            return NotFound();
+        }
+
+        var auditLog = await _auditLogService.GetByUserAsync(id, 50);
+
+        var viewModel = new AdminContactDetailViewModel
+        {
+            UserId = contact.Id,
+            Email = contact.Email ?? string.Empty,
+            DisplayName = contact.DisplayName,
+            ContactSource = contact.ContactSource,
+            ExternalSourceId = contact.ExternalSourceId,
+            CreatedAt = contact.CreatedAt.ToDateTimeUtc(),
+            CommunicationPreferences = contact.CommunicationPreferences.ToList(),
+            AuditLog = auditLog,
+        };
+
+        return View(viewModel);
+    }
+
+    [Authorize(Roles = RoleGroups.BoardOrAdmin)]
+    [HttpGet("Admin/Contacts/Create")]
+    public IActionResult CreateContact()
+    {
+        return View(new CreateContactViewModel());
+    }
+
+    [Authorize(Roles = RoleGroups.BoardOrAdmin)]
+    [HttpPost("Admin/Contacts/Create")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> CreateContact(CreateContactViewModel model)
+    {
+        if (!ModelState.IsValid)
+        {
+            return View(model);
+        }
+
+        try
+        {
+            var contact = await _contactService.CreateContactAsync(
+                model.Email, model.DisplayName, model.Source);
+
+            SetSuccess($"Contact created for {model.Email}.");
+            return RedirectToAction(nameof(ContactDetail), new { id = contact.Id });
+        }
+        catch (InvalidOperationException ex)
+        {
+            ModelState.AddModelError(string.Empty, ex.Message);
+            return View(model);
+        }
+    }
 }

--- a/src/Humans.Web/Extensions/InfrastructureServiceCollectionExtensions.cs
+++ b/src/Humans.Web/Extensions/InfrastructureServiceCollectionExtensions.cs
@@ -27,6 +27,7 @@ public static class InfrastructureServiceCollectionExtensions
         services.AddScoped<ITeamPageService, TeamPageService>();
         services.AddScoped<ICampService, CampService>();
         services.AddScoped<ICommunicationPreferenceService, CommunicationPreferenceService>();
+        services.AddScoped<IContactService, ContactService>();
         services.AddScoped<ICampaignService, CampaignService>();
         services.AddScoped<IContactFieldService, ContactFieldService>();
         services.AddScoped<IUserEmailService, UserEmailService>();

--- a/src/Humans.Web/Models/ContactViewModels.cs
+++ b/src/Humans.Web/Models/ContactViewModels.cs
@@ -1,0 +1,50 @@
+using System.ComponentModel.DataAnnotations;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+
+namespace Humans.Web.Models;
+
+public class AdminContactListViewModel : PagedListViewModel
+{
+    public AdminContactListViewModel() : base(20) { }
+
+    public List<AdminContactViewModel> Contacts { get; set; } = [];
+    public string? SearchTerm { get; set; }
+}
+
+public class AdminContactViewModel
+{
+    public Guid Id { get; set; }
+    public string Email { get; set; } = string.Empty;
+    public string DisplayName { get; set; } = string.Empty;
+    public ContactSource? ContactSource { get; set; }
+    public string? ExternalSourceId { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public bool HasCommunicationPreferences { get; set; }
+}
+
+public class AdminContactDetailViewModel
+{
+    public Guid UserId { get; set; }
+    public string Email { get; set; } = string.Empty;
+    public string DisplayName { get; set; } = string.Empty;
+    public ContactSource? ContactSource { get; set; }
+    public string? ExternalSourceId { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public IReadOnlyList<CommunicationPreference> CommunicationPreferences { get; set; } = [];
+    public IReadOnlyList<AuditLogEntry> AuditLog { get; set; } = [];
+}
+
+public class CreateContactViewModel
+{
+    [Required]
+    [EmailAddress]
+    public string Email { get; set; } = string.Empty;
+
+    [Required]
+    [MaxLength(256)]
+    public string DisplayName { get; set; } = string.Empty;
+
+    [Required]
+    public ContactSource Source { get; set; } = ContactSource.Manual;
+}

--- a/src/Humans.Web/Views/Human/ContactDetail.cshtml
+++ b/src/Humans.Web/Views/Human/ContactDetail.cshtml
@@ -1,0 +1,114 @@
+@model Humans.Web.Models.AdminContactDetailViewModel
+@{
+    ViewData["Title"] = $"Contact: {Model.DisplayName}";
+}
+
+<div class="mb-3">
+    <a asp-action="Contacts" class="btn btn-outline-secondary btn-sm">
+        <i class="bi bi-arrow-left"></i> Back to Contacts
+    </a>
+</div>
+
+<h1>@Model.DisplayName</h1>
+<p class="text-muted">@Model.Email</p>
+
+<div class="row">
+    <div class="col-md-6">
+        <div class="card mb-4">
+            <div class="card-header">Contact Information</div>
+            <div class="card-body">
+                <dl class="row mb-0">
+                    <dt class="col-sm-4">Email</dt>
+                    <dd class="col-sm-8">@Model.Email</dd>
+
+                    <dt class="col-sm-4">Source</dt>
+                    <dd class="col-sm-8">
+                        <span class="badge bg-secondary">@(Model.ContactSource?.ToString() ?? "Unknown")</span>
+                    </dd>
+
+                    @if (!string.IsNullOrEmpty(Model.ExternalSourceId))
+                    {
+                        <dt class="col-sm-4">External ID</dt>
+                        <dd class="col-sm-8"><code>@Model.ExternalSourceId</code></dd>
+                    }
+
+                    <dt class="col-sm-4">Created</dt>
+                    <dd class="col-sm-8">@Model.CreatedAt.ToDisplayDate()</dd>
+                </dl>
+            </div>
+        </div>
+    </div>
+
+    <div class="col-md-6">
+        <div class="card mb-4">
+            <div class="card-header">Communication Preferences</div>
+            <div class="card-body">
+                @if (Model.CommunicationPreferences.Count == 0)
+                {
+                    <p class="text-muted mb-0">Using defaults.</p>
+                }
+                else
+                {
+                    <table class="table table-sm mb-0">
+                        <thead>
+                            <tr>
+                                <th>Category</th>
+                                <th>Status</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach (var pref in Model.CommunicationPreferences.OrderBy(p => p.Category))
+                            {
+                                <tr>
+                                    <td>@pref.Category</td>
+                                    <td>
+                                        @if (pref.OptedOut)
+                                        {
+                                            <span class="badge bg-danger">Opted Out</span>
+                                        }
+                                        else
+                                        {
+                                            <span class="badge bg-success">Opted In</span>
+                                        }
+                                    </td>
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
+                }
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="card">
+    <div class="card-header">Audit Log</div>
+    <div class="card-body p-0">
+        @if (Model.AuditLog.Count == 0)
+        {
+            <p class="text-muted text-center py-4 mb-0">No audit entries.</p>
+        }
+        else
+        {
+            <table class="table table-sm mb-0">
+                <thead>
+                    <tr>
+                        <th>When</th>
+                        <th>Action</th>
+                        <th>Description</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var entry in Model.AuditLog)
+                    {
+                        <tr>
+                            <td>@entry.OccurredAt.ToDateTimeUtc().ToDisplayDate()</td>
+                            <td><code>@entry.Action</code></td>
+                            <td>@entry.Description</td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        }
+    </div>
+</div>

--- a/src/Humans.Web/Views/Human/Contacts.cshtml
+++ b/src/Humans.Web/Views/Human/Contacts.cshtml
@@ -1,0 +1,99 @@
+@model Humans.Web.Models.AdminContactListViewModel
+@{
+    ViewData["Title"] = "Contacts";
+}
+
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <h1>Contacts</h1>
+    <div class="d-flex align-items-center gap-3">
+        <span class="text-muted">@string.Format(Localizer["Admin_TotalCount"].Value, Model.TotalCount)</span>
+        <a asp-action="CreateContact" class="btn btn-primary btn-sm">
+            <i class="bi bi-plus-lg"></i> Add Contact
+        </a>
+    </div>
+</div>
+
+<div class="card mb-4">
+    <div class="card-body">
+        <form method="get" class="row g-3">
+            <div class="col-auto flex-grow-1">
+                <input type="text" name="search" class="form-control" placeholder="Search by name or email..."
+                       value="@Model.SearchTerm">
+            </div>
+            <div class="col-auto">
+                <button type="submit" class="btn btn-primary">@Localizer["Admin_Search"]</button>
+                @if (!string.IsNullOrEmpty(Model.SearchTerm))
+                {
+                    <a asp-action="Contacts" class="btn btn-outline-secondary">@Localizer["Admin_Clear"]</a>
+                }
+            </div>
+        </form>
+    </div>
+</div>
+
+<div class="mb-3">
+    <a asp-action="Humans" class="btn btn-outline-secondary btn-sm">
+        <i class="bi bi-arrow-left"></i> Back to Humans
+    </a>
+</div>
+
+<div class="card">
+    <div class="card-body p-0">
+        @if (Model.Contacts.Count == 0)
+        {
+            <p class="text-muted text-center py-4 mb-0">No contacts found.</p>
+        }
+        else
+        {
+            <table class="table table-hover mb-0">
+                <thead>
+                    <tr>
+                        <th>Contact</th>
+                        <th>Source</th>
+                        <th>Created</th>
+                        <th>Preferences</th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var contact in Model.Contacts)
+                    {
+                        <tr>
+                            <td>
+                                <div>@contact.DisplayName</div>
+                                <small class="text-muted">@contact.Email</small>
+                            </td>
+                            <td>
+                                <span class="badge bg-secondary">@(contact.ContactSource?.ToString() ?? "Unknown")</span>
+                                @if (!string.IsNullOrEmpty(contact.ExternalSourceId))
+                                {
+                                    <br /><small class="text-muted">@contact.ExternalSourceId</small>
+                                }
+                            </td>
+                            <td>@contact.CreatedAt.ToDisplayDate()</td>
+                            <td>
+                                @if (contact.HasCommunicationPreferences)
+                                {
+                                    <span class="badge bg-success">Configured</span>
+                                }
+                                else
+                                {
+                                    <span class="badge bg-warning text-dark">Defaults</span>
+                                }
+                            </td>
+                            <td>
+                                <a asp-action="ContactDetail" asp-route-id="@contact.Id"
+                                   class="btn btn-sm btn-outline-primary">Detail</a>
+                            </td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        }
+    </div>
+</div>
+
+@if (Model.TotalPages > 1)
+{
+    <partial name="_Pagination" model="Model" />
+}

--- a/src/Humans.Web/Views/Human/CreateContact.cshtml
+++ b/src/Humans.Web/Views/Human/CreateContact.cshtml
@@ -1,0 +1,43 @@
+@model Humans.Web.Models.CreateContactViewModel
+@{
+    ViewData["Title"] = "Create Contact";
+}
+
+<div class="mb-3">
+    <a asp-action="Contacts" class="btn btn-outline-secondary btn-sm">
+        <i class="bi bi-arrow-left"></i> Back to Contacts
+    </a>
+</div>
+
+<h1>Create Contact</h1>
+<p class="text-muted">Add an external contact for communication preference tracking. Contacts cannot log in.</p>
+
+<div class="card" style="max-width: 600px;">
+    <div class="card-body">
+        <form method="post" asp-action="CreateContact">
+            <div asp-validation-summary="All" class="text-danger mb-3"></div>
+
+            <div class="mb-3">
+                <label asp-for="Email" class="form-label">Email</label>
+                <input asp-for="Email" class="form-control" type="email" />
+                <span asp-validation-for="Email" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <label asp-for="DisplayName" class="form-label">Display Name</label>
+                <input asp-for="DisplayName" class="form-control" />
+                <span asp-validation-for="DisplayName" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <label asp-for="Source" class="form-label">Source</label>
+                <select asp-for="Source" class="form-select"
+                        asp-items="Html.GetEnumSelectList<Humans.Domain.Enums.ContactSource>()">
+                </select>
+                <span asp-validation-for="Source" class="text-danger"></span>
+            </div>
+
+            <button type="submit" class="btn btn-primary">Create Contact</button>
+        </form>
+    </div>
+</div>

--- a/src/Humans.Web/Views/Human/Humans.cshtml
+++ b/src/Humans.Web/Views/Human/Humans.cshtml
@@ -63,6 +63,9 @@
                 @Localizer["AdminHumans_Deleting"]
             </a>
         </div>
+        <a asp-action="Contacts" class="btn btn-outline-info ms-auto">
+            <i class="bi bi-person-rolodex"></i> Contacts
+        </a>
     </div>
 </div>
 

--- a/tests/Humans.Application.Tests/Services/ContactServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/ContactServiceTests.cs
@@ -1,0 +1,349 @@
+using AwesomeAssertions;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using NodaTime;
+using NodaTime.Testing;
+using NSubstitute;
+using Humans.Application.Interfaces;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using Humans.Infrastructure.Data;
+using Humans.Infrastructure.Services;
+using Xunit;
+
+namespace Humans.Application.Tests.Services;
+
+public class ContactServiceTests : IDisposable
+{
+    private readonly HumansDbContext _dbContext;
+    private readonly FakeClock _clock;
+    private readonly IAuditLogService _auditLogService;
+    private readonly ICommunicationPreferenceService _communicationPreferenceService;
+    private readonly UserManager<User> _userManager;
+    private readonly ContactService _service;
+
+    public ContactServiceTests()
+    {
+        var options = new DbContextOptionsBuilder<HumansDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        _dbContext = new HumansDbContext(options);
+        _clock = new FakeClock(Instant.FromUtc(2026, 3, 1, 12, 0));
+        _auditLogService = Substitute.For<IAuditLogService>();
+        _communicationPreferenceService = Substitute.For<ICommunicationPreferenceService>();
+
+        var store = Substitute.For<IUserStore<User>>();
+        _userManager = Substitute.For<UserManager<User>>(
+            store, null, null, null, null, null, null, null, null);
+
+        // Default: CreateAsync succeeds and adds user to DbContext
+        _userManager.CreateAsync(Arg.Any<User>())
+            .Returns(callInfo =>
+            {
+                var user = callInfo.Arg<User>();
+                if (user.Id == Guid.Empty) user.Id = Guid.NewGuid();
+                user.NormalizedEmail = user.Email?.ToUpperInvariant();
+                user.NormalizedUserName = user.UserName?.ToUpperInvariant();
+                _dbContext.Users.Add(user);
+                _dbContext.SaveChanges();
+                return IdentityResult.Success;
+            });
+
+        _service = new ContactService(
+            _dbContext,
+            _userManager,
+            _auditLogService,
+            _communicationPreferenceService,
+            _clock,
+            NullLogger<ContactService>.Instance);
+    }
+
+    public void Dispose()
+    {
+        _dbContext.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    // ==========================================================================
+    // CreateContactAsync
+    // ==========================================================================
+
+    [Fact]
+    public async Task CreateContactAsync_CreatesUserWithContactAccountType()
+    {
+        var result = await _service.CreateContactAsync(
+            "ticket@example.com", "Ticket Buyer", ContactSource.TicketTailor, "TT-123");
+
+        result.AccountType.Should().Be(AccountType.Contact);
+        result.ContactSource.Should().Be(ContactSource.TicketTailor);
+        result.ExternalSourceId.Should().Be("TT-123");
+        result.Email.Should().Be("ticket@example.com");
+        result.DisplayName.Should().Be("Ticket Buyer");
+        result.IsContact.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task CreateContactAsync_CreatesUserEmailRecord()
+    {
+        var result = await _service.CreateContactAsync(
+            "sub@example.com", "Subscriber", ContactSource.MailerLite);
+
+        var userEmail = await _dbContext.UserEmails
+            .FirstOrDefaultAsync(ue => ue.UserId == result.Id);
+
+        userEmail.Should().NotBeNull();
+        userEmail!.Email.Should().Be("sub@example.com");
+        userEmail.IsVerified.Should().BeTrue();
+        userEmail.IsOAuth.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task CreateContactAsync_SetsCommunicationPreferences()
+    {
+        await _service.CreateContactAsync(
+            "marketing@example.com", "Test", ContactSource.Manual);
+
+        // Should have called UpdatePreferenceAsync for Marketing (opted in)
+        await _communicationPreferenceService.Received(1).UpdatePreferenceAsync(
+            Arg.Any<Guid>(), MessageCategory.Marketing, false, "ContactCreation", Arg.Any<CancellationToken>());
+
+        // Should have called UpdatePreferenceAsync for EventOperations (opted out)
+        await _communicationPreferenceService.Received(1).UpdatePreferenceAsync(
+            Arg.Any<Guid>(), MessageCategory.EventOperations, true, "ContactCreation", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CreateContactAsync_ExistingContactEmail_ReturnsExisting()
+    {
+        var first = await _service.CreateContactAsync(
+            "dup@example.com", "First", ContactSource.MailerLite);
+
+        var second = await _service.CreateContactAsync(
+            "dup@example.com", "Second", ContactSource.TicketTailor);
+
+        second.Id.Should().Be(first.Id);
+    }
+
+    [Fact]
+    public async Task CreateContactAsync_ExistingMemberEmail_Throws()
+    {
+        // Seed a member user directly
+        var member = new User
+        {
+            Id = Guid.NewGuid(),
+            DisplayName = "Member",
+            UserName = "member@example.com",
+            Email = "member@example.com",
+            NormalizedEmail = "MEMBER@EXAMPLE.COM",
+            AccountType = AccountType.Member
+        };
+        _dbContext.Users.Add(member);
+        await _dbContext.SaveChangesAsync();
+
+        var act = () => _service.CreateContactAsync(
+            "member@example.com", "Duplicate", ContactSource.Manual);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*member account already exists*");
+    }
+
+    // ==========================================================================
+    // FindContactByEmailAsync
+    // ==========================================================================
+
+    [Fact]
+    public async Task FindContactByEmailAsync_ReturnsOnlyContacts()
+    {
+        // Seed a contact
+        var contact = SeedContact("find@example.com");
+        // Seed a member with different email
+        SeedMember("member@example.com");
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _service.FindContactByEmailAsync("find@example.com");
+        result.Should().NotBeNull();
+        result!.Id.Should().Be(contact.Id);
+
+        var memberResult = await _service.FindContactByEmailAsync("member@example.com");
+        memberResult.Should().BeNull();
+    }
+
+    // ==========================================================================
+    // FindContactByExternalIdAsync
+    // ==========================================================================
+
+    [Fact]
+    public async Task FindContactByExternalIdAsync_MatchesSourceAndId()
+    {
+        var contact = SeedContact("ext@example.com", ContactSource.TicketTailor, "TT-456");
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _service.FindContactByExternalIdAsync(
+            ContactSource.TicketTailor, "TT-456");
+        result.Should().NotBeNull();
+        result!.Id.Should().Be(contact.Id);
+
+        // Wrong source
+        var wrong = await _service.FindContactByExternalIdAsync(
+            ContactSource.MailerLite, "TT-456");
+        wrong.Should().BeNull();
+    }
+
+    // ==========================================================================
+    // GetFilteredContactsAsync
+    // ==========================================================================
+
+    [Fact]
+    public async Task GetFilteredContactsAsync_ReturnsOnlyContacts()
+    {
+        SeedContact("contact1@example.com");
+        SeedContact("contact2@example.com");
+        SeedMember("member@example.com");
+        await _dbContext.SaveChangesAsync();
+
+        var results = await _service.GetFilteredContactsAsync(null);
+        results.Should().HaveCount(2);
+        results.Should().AllSatisfy(r => r.Email.Should().Contain("contact"));
+    }
+
+    // ==========================================================================
+    // MergeContactToMemberAsync
+    // ==========================================================================
+
+    [Fact]
+    public async Task MergeContactToMemberAsync_DeactivatesContact()
+    {
+        var contact = SeedContact("merge@example.com");
+        var member = SeedMember("member@test.com");
+        await _dbContext.SaveChangesAsync();
+
+        await _service.MergeContactToMemberAsync(contact, member, null, "test-merge");
+
+        var updated = await _dbContext.Users.FindAsync(contact.Id);
+        updated!.AccountType.Should().Be(AccountType.Deactivated);
+    }
+
+    [Fact]
+    public async Task MergeContactToMemberAsync_MigratesPreferences_MemberWins()
+    {
+        var contact = SeedContact("pref@example.com");
+        var member = SeedMember("member@test.com");
+
+        // Contact has Marketing opted-in
+        _dbContext.CommunicationPreferences.Add(new CommunicationPreference
+        {
+            Id = Guid.NewGuid(),
+            UserId = contact.Id,
+            Category = MessageCategory.Marketing,
+            OptedOut = false,
+            UpdatedAt = _clock.GetCurrentInstant(),
+            UpdateSource = "ContactCreation",
+            User = contact
+        });
+
+        // Member already has Marketing opted-out (member's choice wins)
+        _dbContext.CommunicationPreferences.Add(new CommunicationPreference
+        {
+            Id = Guid.NewGuid(),
+            UserId = member.Id,
+            Category = MessageCategory.Marketing,
+            OptedOut = true,
+            UpdatedAt = _clock.GetCurrentInstant(),
+            UpdateSource = "Profile",
+            User = member
+        });
+
+        // Contact has CommunityUpdates (member doesn't) — should migrate
+        _dbContext.CommunicationPreferences.Add(new CommunicationPreference
+        {
+            Id = Guid.NewGuid(),
+            UserId = contact.Id,
+            Category = MessageCategory.CommunityUpdates,
+            OptedOut = false,
+            UpdatedAt = _clock.GetCurrentInstant(),
+            UpdateSource = "ContactCreation",
+            User = contact
+        });
+
+        await _dbContext.SaveChangesAsync();
+
+        await _service.MergeContactToMemberAsync(contact, member, null, "test-merge");
+
+        // Member's Marketing should still be opted-out (their preference wins)
+        var memberMarketing = await _dbContext.CommunicationPreferences
+            .FirstOrDefaultAsync(cp => cp.UserId == member.Id && cp.Category == MessageCategory.Marketing);
+        memberMarketing.Should().NotBeNull();
+        memberMarketing!.OptedOut.Should().BeTrue();
+
+        // Member should now have CommunityUpdates (migrated from contact)
+        var memberCommunity = await _dbContext.CommunicationPreferences
+            .FirstOrDefaultAsync(cp => cp.UserId == member.Id && cp.Category == MessageCategory.CommunityUpdates);
+        memberCommunity.Should().NotBeNull();
+        memberCommunity!.OptedOut.Should().BeFalse();
+
+        // Contact should have no preferences left
+        var contactPrefs = await _dbContext.CommunicationPreferences
+            .Where(cp => cp.UserId == contact.Id).ToListAsync();
+        contactPrefs.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task MergeContactToMemberAsync_AuditLogged()
+    {
+        var contact = SeedContact("audit@example.com");
+        var member = SeedMember("member@test.com");
+        await _dbContext.SaveChangesAsync();
+
+        await _service.MergeContactToMemberAsync(contact, member, null, "test-merge");
+
+        // Should have logged on both contact and member
+        await _auditLogService.Received(2).LogAsync(
+            AuditAction.ContactMergedToMember,
+            nameof(User), Arg.Any<Guid>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<Guid?>(), Arg.Any<string?>());
+    }
+
+    // ==========================================================================
+    // Helpers
+    // ==========================================================================
+
+    private User SeedContact(string email, ContactSource source = ContactSource.Manual, string? externalId = null)
+    {
+        var user = new User
+        {
+            Id = Guid.NewGuid(),
+            DisplayName = email.Split('@')[0],
+            UserName = email,
+            Email = email,
+            NormalizedEmail = email.ToUpperInvariant(),
+            NormalizedUserName = email.ToUpperInvariant(),
+            AccountType = AccountType.Contact,
+            ContactSource = source,
+            ExternalSourceId = externalId,
+            CreatedAt = _clock.GetCurrentInstant()
+        };
+        _dbContext.Users.Add(user);
+        return user;
+    }
+
+    private User SeedMember(string email)
+    {
+        var user = new User
+        {
+            Id = Guid.NewGuid(),
+            DisplayName = email.Split('@')[0],
+            UserName = email,
+            Email = email,
+            NormalizedEmail = email.ToUpperInvariant(),
+            NormalizedUserName = email.ToUpperInvariant(),
+            AccountType = AccountType.Member,
+            CreatedAt = _clock.GetCurrentInstant()
+        };
+        _dbContext.Users.Add(user);
+        return user;
+    }
+}


### PR DESCRIPTION
## Summary

Cherry-pick of Aaron's work from nobodies-collective/Humans#209 for QA evaluation.

- Add `AccountType` enum (Member, Contact, Deactivated) and `ContactSource` enum (Manual, MailerLite, TicketTailor) to User entity for lightweight external contacts
- Implement `IContactService` with email-deduplicated contact creation, external ID lookup, and preference-preserving contact-to-member merge
- Auto-merge on OAuth signup/login when a contact exists with the same email; different-email merges handled by existing `AccountMergeRequest` admin workflow
- Filter contacts from member queries (`ProfileService.GetFilteredHumansAsync`, `SearchApprovedUsersAsync`, `OnboardingService.GetAdminDashboardAsync`)
- Admin Contacts UI: list with search, detail with preferences + audit log, manual creation form
- 11 new unit tests, EF migration `AddContactAccountType`, feature doc

Depends on communication preferences (#97), which is already in production.

## Test plan

- [ ] `dotnet build` — 0 errors, 0 warnings
- [ ] All unit tests pass
- [ ] EF migration generates clean schema
- [ ] Admin /Contacts page lists contacts, excludes members
- [ ] Admin /Humans page excludes contacts from counts and list
- [ ] Manual contact creation works via admin UI
- [ ] OAuth signup with matching contact email triggers auto-merge
- [ ] Different-email merge via AccountMergeRequest uses lighter contact merge path
- [ ] Contact communication preferences migrate correctly on merge (member wins on conflict)

Upstream PR: nobodies-collective/Humans#209
Author: Aaron Ross (@veryaaron)