### PR TITLE
feat: shift admin UX batch — HumanLink, batch approval, unassign

### DIFF
--- a/docs/features/25-shift-management.md
+++ b/docs/features/25-shift-management.md
@@ -55,7 +55,10 @@ See `docs/specs/shift-management-spec.md` for the full design specification.
 **Acceptance Criteria:**
 - Approve re-validates overlap (returns warning, not blocker)
 - Refuse with optional reason
+- Batch approve/refuse: `ApproveRangeAsync`/`RefuseRangeAsync` — approves or refuses all pending signups sharing a `SignupBlockId` in one action
+- Pending approvals table shows signup date and groups range signups with date range display
 - Voluntell: enroll a volunteer directly (auto-confirmed, sets Enrolled flag)
+- Remove: unassign a confirmed signup via `RemoveSignupAsync` — transitions to Cancelled with reviewer tracking
 
 ### US-25.5: Volunteer Manages Their Shifts
 **As a** volunteer
@@ -96,7 +99,7 @@ Pending --> Refused     (Refuse)
 Pending --> Bailed      (Bail)
 Confirmed --> Bailed    (Bail)
 Confirmed --> NoShow    (MarkNoShow, post-shift only)
-Confirmed --> Cancelled (system: shift deleted, account deletion)
+Confirmed --> Cancelled (system: shift deleted, account deletion, or coordinator removal)
 Pending --> Cancelled   (system: shift deleted, account deletion)
 ```
 

--- a/src/Humans.Application/Interfaces/IShiftSignupService.cs
+++ b/src/Humans.Application/Interfaces/IShiftSignupService.cs
@@ -46,10 +46,25 @@ public interface IShiftSignupService
     Task<SignupResult> MarkNoShowAsync(Guid signupId, Guid reviewerUserId);
 
     /// <summary>
+    /// Removes a confirmed signup (coordinator/admin unassignment).
+    /// </summary>
+    Task<SignupResult> RemoveSignupAsync(Guid signupId, Guid removedByUserId, string? reason);
+
+    /// <summary>
     /// Creates signups for a date range of all-day shifts (build/strike).
     /// All signups share a SignupBlockId for grouped bail.
     /// </summary>
     Task<SignupResult> SignUpRangeAsync(Guid userId, Guid rotaId, int startDayOffset, int endDayOffset, Guid? actorUserId = null, bool isPrivileged = false);
+
+    /// <summary>
+    /// Approves all pending signups sharing a SignupBlockId.
+    /// </summary>
+    Task<SignupResult> ApproveRangeAsync(Guid signupBlockId, Guid reviewerUserId);
+
+    /// <summary>
+    /// Refuses all pending signups sharing a SignupBlockId.
+    /// </summary>
+    Task<SignupResult> RefuseRangeAsync(Guid signupBlockId, Guid reviewerUserId, string? reason);
 
     /// <summary>
     /// Bails all signups sharing a SignupBlockId.

--- a/src/Humans.Domain/Entities/ShiftSignup.cs
+++ b/src/Humans.Domain/Entities/ShiftSignup.cs
@@ -163,4 +163,19 @@ public class ShiftSignup
         StatusReason = reason;
         UpdatedAt = clock.GetCurrentInstant();
     }
+
+    /// <summary>
+    /// Remove a confirmed signup (coordinator/admin unassignment).
+    /// </summary>
+    public void Remove(Guid removedByUserId, IClock clock, string? reason)
+    {
+        if (Status is not SignupStatus.Confirmed)
+            throw new InvalidOperationException($"Cannot remove signup in {Status} state");
+        var now = clock.GetCurrentInstant();
+        Status = SignupStatus.Cancelled;
+        ReviewedByUserId = removedByUserId;
+        ReviewedAt = now;
+        StatusReason = reason;
+        UpdatedAt = now;
+    }
 }

--- a/src/Humans.Infrastructure/Services/ShiftSignupService.cs
+++ b/src/Humans.Infrastructure/Services/ShiftSignupService.cs
@@ -380,6 +380,27 @@ public class ShiftSignupService : IShiftSignupService
         return SignupResult.Ok(signup);
     }
 
+    public async Task<SignupResult> RemoveSignupAsync(Guid signupId, Guid removedByUserId, string? reason)
+    {
+        var signup = await LoadSignupWithShiftAsync(signupId);
+        if (signup is null) return SignupResult.Fail("Signup not found.");
+
+        if (signup.Status != SignupStatus.Confirmed)
+            return SignupResult.Fail($"Cannot remove signup in {signup.Status} state.");
+
+        signup.Remove(removedByUserId, _clock, reason);
+
+        await _auditLogService.LogAsync(
+            AuditAction.ShiftSignupCancelled, nameof(ShiftSignup), signup.Id,
+            $"Removed from shift '{signup.Shift.Rota.Name}'" +
+            (reason is not null ? $": {reason}" : ""),
+            removedByUserId, "Reviewer");
+
+        await _dbContext.SaveChangesAsync();
+
+        return SignupResult.Ok(signup);
+    }
+
     public async Task<SignupResult> SignUpRangeAsync(Guid userId, Guid rotaId, int startDayOffset, int endDayOffset, Guid? actorUserId = null, bool isPrivileged = false)
     {
         var rota = await _dbContext.Rotas
@@ -518,6 +539,56 @@ public class ShiftSignupService : IShiftSignupService
         await _dbContext.SaveChangesAsync();
 
         return SignupResult.Ok(lastSignup!, warning);
+    }
+
+    public async Task<SignupResult> ApproveRangeAsync(Guid signupBlockId, Guid reviewerUserId)
+    {
+        var signups = await _dbContext.ShiftSignups
+            .Include(s => s.Shift).ThenInclude(s => s.Rota).ThenInclude(r => r.EventSettings)
+            .Include(s => s.Shift).ThenInclude(s => s.Rota).ThenInclude(r => r.Team)
+            .Include(s => s.Shift).ThenInclude(s => s.ShiftSignups)
+            .Where(s => s.SignupBlockId == signupBlockId && s.Status == SignupStatus.Pending)
+            .ToListAsync();
+
+        if (signups.Count == 0) return SignupResult.Fail("No pending signups found for this block.");
+
+        string? warning = null;
+        foreach (var signup in signups)
+        {
+            signup.Confirm(reviewerUserId, _clock);
+
+            await _auditLogService.LogAsync(
+                AuditAction.ShiftSignupConfirmed, nameof(ShiftSignup), signup.Id,
+                $"Range approved for shift '{signup.Shift.Rota.Name}' day {signup.Shift.DayOffset} (block {signupBlockId})",
+                reviewerUserId, "Reviewer");
+        }
+
+        await _dbContext.SaveChangesAsync();
+        return SignupResult.Ok(signups[0], warning);
+    }
+
+    public async Task<SignupResult> RefuseRangeAsync(Guid signupBlockId, Guid reviewerUserId, string? reason)
+    {
+        var signups = await _dbContext.ShiftSignups
+            .Include(s => s.Shift).ThenInclude(s => s.Rota)
+            .Where(s => s.SignupBlockId == signupBlockId && s.Status == SignupStatus.Pending)
+            .ToListAsync();
+
+        if (signups.Count == 0) return SignupResult.Fail("No pending signups found for this block.");
+
+        foreach (var signup in signups)
+        {
+            signup.Refuse(reviewerUserId, _clock, reason);
+
+            await _auditLogService.LogAsync(
+                AuditAction.ShiftSignupRefused, nameof(ShiftSignup), signup.Id,
+                $"Range refused for shift '{signup.Shift.Rota.Name}' day {signup.Shift.DayOffset} (block {signupBlockId})" +
+                (reason is not null ? $": {reason}" : ""),
+                reviewerUserId, "Reviewer");
+        }
+
+        await _dbContext.SaveChangesAsync();
+        return SignupResult.Ok(signups[0]);
     }
 
     public async Task BailRangeAsync(Guid signupBlockId, Guid actorUserId, string? reason = null)

--- a/src/Humans.Web/Controllers/HumanController.cs
+++ b/src/Humans.Web/Controllers/HumanController.cs
@@ -121,6 +121,33 @@ public class HumanController : HumansControllerBase
         return View("~/Views/Profile/Index.cshtml", viewModel);
     }
 
+    [HttpGet("{id:guid}/Popover")]
+    public async Task<IActionResult> Popover(Guid id)
+    {
+        var profile = await _profileService.GetProfileAsync(id);
+        if (profile is null) return NotFound();
+
+        var teams = await _dbContext.TeamMembers
+            .Where(tm => tm.UserId == id && tm.LeftAt == null)
+            .Select(tm => tm.Team!.Name)
+            .OrderBy(n => n)
+            .ToListAsync();
+
+        var vm = new ProfileSummaryViewModel
+        {
+            UserId = id,
+            DisplayName = profile.User.DisplayName,
+            Email = profile.User.Email,
+            ProfilePictureUrl = profile.User.ProfilePictureUrl,
+            MembershipTier = profile.MembershipTier.ToString(),
+            MembershipStatus = profile.IsSuspended ? "Suspended"
+                : profile.IsApproved ? "Active" : "Pending",
+            Teams = teams
+        };
+
+        return PartialView("_HumanPopover", vm);
+    }
+
     [HttpGet("{id:guid}/SendMessage")]
     public async Task<IActionResult> SendMessage(Guid id)
     {

--- a/src/Humans.Web/Controllers/ShiftAdminController.cs
+++ b/src/Humans.Web/Controllers/ShiftAdminController.cs
@@ -426,6 +426,38 @@ public class ShiftAdminController : HumansTeamControllerBase
         return RedirectToAction(nameof(Index), new { slug });
     }
 
+    [HttpPost("ApproveRange")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> ApproveRange(string slug, Guid signupBlockId)
+    {
+        var (teamError, user, _) = await ResolveDepartmentApprovalAsync(slug);
+        if (teamError is not null) return teamError;
+
+        var result = await _signupService.ApproveRangeAsync(signupBlockId, user.Id);
+        if (result.Success)
+            SetSuccess(result.Warning ?? "Range approved.");
+        else
+            SetError(result.Error ?? "Range approval failed.");
+
+        return RedirectToAction(nameof(Index), new { slug });
+    }
+
+    [HttpPost("RefuseRange")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> RefuseRange(string slug, Guid signupBlockId, string? reason)
+    {
+        var (teamError, user, _) = await ResolveDepartmentApprovalAsync(slug);
+        if (teamError is not null) return teamError;
+
+        var result = await _signupService.RefuseRangeAsync(signupBlockId, user.Id, reason);
+        if (result.Success)
+            SetSuccess("Range refused.");
+        else
+            SetError(result.Error ?? "Range refusal failed.");
+
+        return RedirectToAction(nameof(Index), new { slug });
+    }
+
     [HttpPost("Signups/{signupId}/Approve")]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> ApproveSignup(string slug, Guid signupId)
@@ -494,6 +526,26 @@ public class ShiftAdminController : HumansTeamControllerBase
         {
             SetError(result.Error ?? "No-show update failed.");
         }
+
+        return RedirectToAction(nameof(Index), new { slug });
+    }
+
+    [HttpPost("Signups/{signupId}/Remove")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> RemoveSignup(string slug, Guid signupId, string? reason)
+    {
+        var (teamError, user, team) = await ResolveDepartmentApprovalAsync(slug);
+        if (teamError is not null) return teamError;
+
+        var signupCheck = await _signupService.GetByIdAsync(signupId);
+        if (signupCheck is null) return NotFound();
+        if (signupCheck.Shift.Rota.TeamId != team.Id) return NotFound();
+
+        var result = await _signupService.RemoveSignupAsync(signupId, user.Id, reason);
+        if (result.Success)
+            SetSuccess("Signup removed.");
+        else
+            SetError(result.Error ?? "Remove failed.");
 
         return RedirectToAction(nameof(Index), new { slug });
     }

--- a/src/Humans.Web/TagHelpers/HumanLinkTagHelper.cs
+++ b/src/Humans.Web/TagHelpers/HumanLinkTagHelper.cs
@@ -1,0 +1,173 @@
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.Routing;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace Humans.Web.TagHelpers;
+
+/// <summary>
+/// Renders a link to a human's profile with configurable display modes.
+/// Replaces all raw asp-controller="Human" anchor tags across the app.
+/// </summary>
+[HtmlTargetElement("human-link", TagStructure = TagStructure.NormalOrSelfClosing)]
+public class HumanLinkTagHelper : TagHelper
+{
+    private readonly IUrlHelperFactory _urlHelperFactory;
+
+    public HumanLinkTagHelper(IUrlHelperFactory urlHelperFactory)
+    {
+        _urlHelperFactory = urlHelperFactory;
+    }
+
+    [HtmlAttributeNotBound]
+    [ViewContext]
+    public ViewContext ViewContext { get; set; } = null!;
+
+    /// <summary>User ID (required).</summary>
+    [HtmlAttributeName("user-id")]
+    public Guid UserId { get; set; }
+
+    /// <summary>Display name (required).</summary>
+    [HtmlAttributeName("display-name")]
+    public string DisplayName { get; set; } = "";
+
+    /// <summary>Profile picture URL (optional). If null, shows initial fallback.</summary>
+    [HtmlAttributeName("profile-picture-url")]
+    public string? ProfilePictureUrl { get; set; }
+
+    /// <summary>
+    /// Display mode: text (default), avatar, avatar-name, card.
+    /// </summary>
+    [HtmlAttributeName("mode")]
+    public HumanLinkMode Mode { get; set; } = HumanLinkMode.Text;
+
+    /// <summary>Avatar size in pixels. Only used for avatar/avatar-name/card modes. Default: 40.</summary>
+    [HtmlAttributeName("size")]
+    public int Size { get; set; } = 40;
+
+    /// <summary>If true, links to the admin HumanDetail page instead of the public View page.</summary>
+    [HtmlAttributeName("admin")]
+    public bool Admin { get; set; }
+
+    /// <summary>Enable hover popover with profile summary.</summary>
+    [HtmlAttributeName("show-popover")]
+    public bool ShowPopover { get; set; }
+
+    /// <summary>Additional CSS class(es) for the avatar element.</summary>
+    [HtmlAttributeName("avatar-css-class")]
+    public string? AvatarCssClass { get; set; }
+
+    /// <summary>Background color class for initial fallback avatar. Default: bg-secondary.</summary>
+    [HtmlAttributeName("avatar-bg-color")]
+    public string AvatarBgColor { get; set; } = "bg-secondary";
+
+    public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
+    {
+        var urlHelper = _urlHelperFactory.GetUrlHelper(ViewContext);
+        var href = Admin
+            ? urlHelper.Action("HumanDetail", "Human", new { id = UserId })
+            : urlHelper.Action("View", "Human", new { id = UserId });
+
+        output.TagName = "a";
+        output.Attributes.SetAttribute("href", href);
+
+        if (ShowPopover)
+        {
+            output.Attributes.Add("data-human-popover", "true");
+            output.Attributes.Add("data-user-id", UserId.ToString());
+        }
+
+        var childContent = await output.GetChildContentAsync();
+
+        switch (Mode)
+        {
+            case HumanLinkMode.Text:
+                MergeClass(output, "text-decoration-none");
+                if (childContent.IsEmptyOrWhiteSpace)
+                {
+                    output.Content.Append(DisplayName);
+                }
+                else
+                {
+                    output.Content.SetHtmlContent(childContent.GetContent());
+                }
+                break;
+
+            case HumanLinkMode.Avatar:
+                if (!output.Attributes.ContainsName("title"))
+                {
+                    output.Attributes.SetAttribute("title", DisplayName);
+                }
+                output.Content.SetHtmlContent(RenderAvatar());
+                break;
+
+            case HumanLinkMode.AvatarName:
+                MergeClass(output, "d-flex align-items-center text-decoration-none text-reset");
+                var avatarHtml = RenderAvatar(extraCssClass: "me-2");
+                var nameHtml = HtmlEncoder.Default.Encode(DisplayName);
+                var subContent = childContent.IsEmptyOrWhiteSpace
+                    ? ""
+                    : childContent.GetContent();
+                output.Content.SetHtmlContent(
+                    $"{avatarHtml}<div><div class=\"fw-semibold\">{nameHtml}</div>{subContent}</div>");
+                break;
+
+            case HumanLinkMode.Card:
+                MergeClass(output, "text-center text-decoration-none d-block");
+                var cardAvatar = RenderAvatar(extraCssClass: "mb-2 mx-auto");
+                var cardName = HtmlEncoder.Default.Encode(DisplayName);
+                var cardChild = childContent.IsEmptyOrWhiteSpace
+                    ? ""
+                    : childContent.GetContent();
+                output.Content.SetHtmlContent(
+                    $"{cardAvatar}<div class=\"small\">{cardName}</div>{cardChild}");
+                break;
+        }
+    }
+
+    private string RenderAvatar(string? extraCssClass = null)
+    {
+        var cssClasses = new List<string>();
+        if (!string.IsNullOrEmpty(AvatarCssClass)) cssClasses.Add(AvatarCssClass);
+        if (!string.IsNullOrEmpty(extraCssClass)) cssClasses.Add(extraCssClass);
+        var cssClassStr = string.Join(" ", cssClasses);
+
+        if (!string.IsNullOrEmpty(ProfilePictureUrl))
+        {
+            var altEncoded = HtmlEncoder.Default.Encode(DisplayName);
+            return $"<img src=\"{HtmlEncoder.Default.Encode(ProfilePictureUrl)}\" alt=\"{altEncoded}\" " +
+                   $"class=\"rounded-circle {cssClassStr}\" " +
+                   $"style=\"width: {Size}px; height: {Size}px; object-fit: cover;\" />";
+        }
+
+        var initial = string.IsNullOrEmpty(DisplayName) ? "?" : DisplayName[..1];
+        var fontRem = Math.Round(Size / 100.0 * 2.0, 1);
+        if (fontRem < 0.7) fontRem = 0.7;
+
+        return $"<div class=\"{AvatarBgColor} rounded-circle d-flex align-items-center justify-content-center text-white {cssClassStr}\" " +
+               $"style=\"width: {Size}px; height: {Size}px; font-size: {fontRem}rem;\">" +
+               $"{HtmlEncoder.Default.Encode(initial)}</div>";
+    }
+
+    private static void MergeClass(TagHelperOutput output, string classes)
+    {
+        if (output.Attributes.TryGetAttribute("class", out var existing))
+        {
+            output.Attributes.SetAttribute("class", $"{classes} {existing.Value}");
+        }
+        else
+        {
+            output.Attributes.SetAttribute("class", classes);
+        }
+    }
+}
+
+public enum HumanLinkMode
+{
+    Text,
+    Avatar,
+    AvatarName,
+    Card
+}

--- a/src/Humans.Web/TagHelpers/HumanLinkTagHelper.cs
+++ b/src/Humans.Web/TagHelpers/HumanLinkTagHelper.cs
@@ -71,6 +71,7 @@ public class HumanLinkTagHelper : TagHelper
             : urlHelper.Action("View", "Human", new { id = UserId });
 
         output.TagName = "a";
+        output.TagMode = TagMode.StartTagAndEndTag;
         output.Attributes.SetAttribute("href", href);
 
         if (ShowPopover)

--- a/src/Humans.Web/Views/Admin/SyncResults.cshtml
+++ b/src/Humans.Web/Views/Admin/SyncResults.cshtml
@@ -62,7 +62,7 @@
                                 <tr>
                                     <td><span class="badge @badgeClass">@change.Action</span></td>
                                     <td>
-                                        <human-link user-id="@change.User.UserId" display-name="@change.User.DisplayName" admin="true" />
+                                        <human-link user-id="@change.User.UserId" display-name="@change.User.DisplayName" admin="true" show-popover="true" />
                                     </td>
                                     <td class="text-muted">@change.Detail</td>
                                 </tr>

--- a/src/Humans.Web/Views/Admin/SyncResults.cshtml
+++ b/src/Humans.Web/Views/Admin/SyncResults.cshtml
@@ -62,9 +62,7 @@
                                 <tr>
                                     <td><span class="badge @badgeClass">@change.Action</span></td>
                                     <td>
-                                        <a asp-controller="Human" asp-action="Detail" asp-route-id="@change.User.UserId">
-                                            @change.User.DisplayName
-                                        </a>
+                                        <human-link user-id="@change.User.UserId" display-name="@change.User.DisplayName" admin="true" />
                                     </td>
                                     <td class="text-muted">@change.Detail</td>
                                 </tr>

--- a/src/Humans.Web/Views/AdminEmail/Index.cshtml
+++ b/src/Humans.Web/Views/AdminEmail/Index.cshtml
@@ -93,7 +93,7 @@
                             <td>
                                 @if (account.MatchedUserId.HasValue)
                                 {
-                                    <human-link user-id="@account.MatchedUserId.Value" display-name="@account.MatchedDisplayName" />
+                                    <human-link user-id="@account.MatchedUserId.Value" display-name="@account.MatchedDisplayName" show-popover="true" />
                                 }
                                 else
                                 {

--- a/src/Humans.Web/Views/AdminEmail/Index.cshtml
+++ b/src/Humans.Web/Views/AdminEmail/Index.cshtml
@@ -93,9 +93,7 @@
                             <td>
                                 @if (account.MatchedUserId.HasValue)
                                 {
-                                    <a asp-controller="Human" asp-action="View" asp-route-id="@account.MatchedUserId">
-                                        @account.MatchedDisplayName
-                                    </a>
+                                    <human-link user-id="@account.MatchedUserId.Value" display-name="@account.MatchedDisplayName" />
                                 }
                                 else
                                 {

--- a/src/Humans.Web/Views/AdminMerge/Index.cshtml
+++ b/src/Humans.Web/Views/AdminMerge/Index.cshtml
@@ -37,18 +37,14 @@ else
                     <tr>
                         <td><code>@request.Email</code></td>
                         <td>
-                            <a asp-controller="Human" asp-action="HumanDetail" asp-route-id="@request.PrimaryUserId">
-                                @request.PrimaryUserDisplayName
-                            </a>
+                            <human-link user-id="@request.PrimaryUserId" display-name="@request.PrimaryUserDisplayName" admin="true" />
                             @if (!string.IsNullOrEmpty(request.PrimaryUserEmail))
                             {
                                 <small class="text-muted">(@request.PrimaryUserEmail)</small>
                             }
                         </td>
                         <td>
-                            <a asp-controller="Human" asp-action="HumanDetail" asp-route-id="@request.DuplicateUserId">
-                                @request.DuplicateUserDisplayName
-                            </a>
+                            <human-link user-id="@request.DuplicateUserId" display-name="@request.DuplicateUserDisplayName" admin="true" />
                             @if (!string.IsNullOrEmpty(request.DuplicateUserEmail))
                             {
                                 <small class="text-muted">(@request.DuplicateUserEmail)</small>

--- a/src/Humans.Web/Views/AdminMerge/Index.cshtml
+++ b/src/Humans.Web/Views/AdminMerge/Index.cshtml
@@ -37,14 +37,14 @@ else
                     <tr>
                         <td><code>@request.Email</code></td>
                         <td>
-                            <human-link user-id="@request.PrimaryUserId" display-name="@request.PrimaryUserDisplayName" admin="true" />
+                            <human-link user-id="@request.PrimaryUserId" display-name="@request.PrimaryUserDisplayName" admin="true" show-popover="true" />
                             @if (!string.IsNullOrEmpty(request.PrimaryUserEmail))
                             {
                                 <small class="text-muted">(@request.PrimaryUserEmail)</small>
                             }
                         </td>
                         <td>
-                            <human-link user-id="@request.DuplicateUserId" display-name="@request.DuplicateUserDisplayName" admin="true" />
+                            <human-link user-id="@request.DuplicateUserId" display-name="@request.DuplicateUserDisplayName" admin="true" show-popover="true" />
                             @if (!string.IsNullOrEmpty(request.DuplicateUserEmail))
                             {
                                 <small class="text-muted">(@request.DuplicateUserEmail)</small>

--- a/src/Humans.Web/Views/Application/ApplicationDetail.cshtml
+++ b/src/Humans.Web/Views/Application/ApplicationDetail.cshtml
@@ -32,9 +32,9 @@
                         <h5 class="mb-0">@Model.UserDisplayName</h5>
                         <small class="text-muted">@Model.UserEmail</small>
                     </div>
-                    <a asp-controller="Human" asp-action="HumanDetail" asp-route-id="@Model.UserId" class="btn btn-sm btn-outline-secondary ms-auto">
+                    <human-link user-id="@Model.UserId" display-name="@Localizer["AdminAppDetail_ViewProfile"]" admin="true" class="btn btn-sm btn-outline-secondary ms-auto">
                         @Localizer["AdminAppDetail_ViewProfile"]
-                    </a>
+                    </human-link>
                 </div>
             </div>
         </div>

--- a/src/Humans.Web/Views/Camp/Details.cshtml
+++ b/src/Humans.Web/Views/Camp/Details.cshtml
@@ -285,7 +285,7 @@
                     @foreach (var lead in Model.Leads)
                     {
                         <li class="list-group-item">
-                            <a asp-controller="Human" asp-action="View" asp-route-id="@lead.UserId">@lead.DisplayName</a>
+                            <human-link user-id="@lead.UserId" display-name="@lead.DisplayName" />
                         </li>
                     }
                 </ul>

--- a/src/Humans.Web/Views/Camp/Details.cshtml
+++ b/src/Humans.Web/Views/Camp/Details.cshtml
@@ -285,7 +285,7 @@
                     @foreach (var lead in Model.Leads)
                     {
                         <li class="list-group-item">
-                            <human-link user-id="@lead.UserId" display-name="@lead.DisplayName" />
+                            <human-link user-id="@lead.UserId" display-name="@lead.DisplayName" show-popover="true" />
                         </li>
                     }
                 </ul>

--- a/src/Humans.Web/Views/Feedback/_Detail.cshtml
+++ b/src/Humans.Web/Views/Feedback/_Detail.cshtml
@@ -8,7 +8,7 @@
             <div class="text-muted small">
                 @if (Model.IsAdmin)
                 {
-                    <a asp-controller="Human" asp-action="Detail" asp-route-id="@Model.ReporterUserId">@Model.ReporterName</a>
+                    <human-link user-id="@Model.ReporterUserId" display-name="@Model.ReporterName" admin="true" />
                 }
                 else
                 {

--- a/src/Humans.Web/Views/Feedback/_Detail.cshtml
+++ b/src/Humans.Web/Views/Feedback/_Detail.cshtml
@@ -8,7 +8,7 @@
             <div class="text-muted small">
                 @if (Model.IsAdmin)
                 {
-                    <human-link user-id="@Model.ReporterUserId" display-name="@Model.ReporterName" admin="true" />
+                    <human-link user-id="@Model.ReporterUserId" display-name="@Model.ReporterName" admin="true" show-popover="true" />
                 }
                 else
                 {

--- a/src/Humans.Web/Views/Profile/Index.cshtml
+++ b/src/Humans.Web/Views/Profile/Index.cshtml
@@ -11,9 +11,9 @@
                 <vc:access-matrix section="Profile" />
                 @if (Humans.Web.Authorization.RoleChecks.IsAdminOrBoard(User))
                 {
-                    <a asp-controller="Human" asp-action="HumanDetail" asp-route-id="@Model.UserId" class="btn btn-sm btn-outline-secondary">
+                    <human-link user-id="@Model.UserId" display-name="Admin" admin="true" class="btn btn-sm btn-outline-secondary">
                         <i class="fa-solid fa-user-shield"></i> Admin
-                    </a>
+                    </human-link>
                 }
             </div>
         </div>

--- a/src/Humans.Web/Views/Profile/Outbox.cshtml
+++ b/src/Humans.Web/Views/Profile/Outbox.cshtml
@@ -12,9 +12,9 @@
             <h1>@ViewData["Title"]</h1>
             @if (isAdminView)
             {
-                <a asp-controller="Human" asp-action="HumanDetail" asp-route-id="@humanId" class="btn btn-outline-secondary btn-sm">
+                <human-link user-id="@humanId.Value" display-name="Back to Admin" admin="true" class="btn btn-outline-secondary btn-sm">
                     <i class="fa-solid fa-arrow-left me-1"></i>Back to Admin
-                </a>
+                </human-link>
             }
             else
             {

--- a/src/Humans.Web/Views/Shared/_HumanPopover.cshtml
+++ b/src/Humans.Web/Views/Shared/_HumanPopover.cshtml
@@ -1,0 +1,31 @@
+@model Humans.Web.Models.ProfileSummaryViewModel
+
+<div class="d-flex align-items-center" style="min-width: 200px;">
+    @if (!string.IsNullOrEmpty(Model.ProfilePictureUrl))
+    {
+        <img src="@Model.ProfilePictureUrl" alt="" class="rounded-circle me-2" style="width: 48px; height: 48px; object-fit: cover;" />
+    }
+    else
+    {
+        <div class="bg-secondary rounded-circle d-flex align-items-center justify-content-center text-white me-2"
+             style="width: 48px; height: 48px; font-size: 1rem;">
+            @Model.DisplayName[..1]
+        </div>
+    }
+    <div>
+        <div class="fw-semibold">@Model.DisplayName</div>
+        @if (!string.IsNullOrEmpty(Model.MembershipTier))
+        {
+            <span class="badge bg-success" style="font-size: 0.7rem;">@Model.MembershipTier</span>
+        }
+    </div>
+</div>
+@if (Model.Teams.Count > 0)
+{
+    <div class="mt-2 pt-2 border-top">
+        @foreach (var team in Model.Teams)
+        {
+            <span class="badge bg-light text-dark border me-1 mb-1" style="font-size: 0.7rem;">@team</span>
+        }
+    </div>
+}

--- a/src/Humans.Web/Views/Shared/_ProfileCard.cshtml
+++ b/src/Humans.Web/Views/Shared/_ProfileCard.cshtml
@@ -15,7 +15,7 @@
     }
     <div class="flex-grow-1">
         <h6 class="mb-0">
-            <a asp-controller="Human" asp-action="HumanDetail" asp-route-id="@Model.UserId">@Model.DisplayName</a>
+            <human-link user-id="@Model.UserId" display-name="@Model.DisplayName" admin="true" />
         </h6>
         <small class="text-muted">@Model.Email</small>
         <div class="mt-2">

--- a/src/Humans.Web/Views/Shared/_RolesListContent.cshtml
+++ b/src/Humans.Web/Views/Shared/_RolesListContent.cshtml
@@ -62,7 +62,7 @@
                     {
                         <tr class="@(ra.IsActive ? "" : "table-secondary")">
                             <td>
-                                <a asp-controller="Human" asp-action="HumanDetail" asp-route-id="@ra.UserId">@ra.UserDisplayName</a>
+                                <human-link user-id="@ra.UserId" display-name="@ra.UserDisplayName" admin="true" />
                                 <br />
                                 <small class="text-muted">@ra.UserEmail</small>
                             </td>

--- a/src/Humans.Web/Views/Shared/_RolesListContent.cshtml
+++ b/src/Humans.Web/Views/Shared/_RolesListContent.cshtml
@@ -62,7 +62,7 @@
                     {
                         <tr class="@(ra.IsActive ? "" : "table-secondary")">
                             <td>
-                                <human-link user-id="@ra.UserId" display-name="@ra.UserDisplayName" admin="true" />
+                                <human-link user-id="@ra.UserId" display-name="@ra.UserDisplayName" admin="true" show-popover="true" />
                                 <br />
                                 <small class="text-muted">@ra.UserEmail</small>
                             </td>

--- a/src/Humans.Web/Views/ShiftAdmin/Index.cshtml
+++ b/src/Humans.Web/Views/ShiftAdmin/Index.cshtml
@@ -38,6 +38,9 @@
     @* Pending Approvals *@
     @if (Model.PendingSignups.Count > 0 && Model.CanApproveSignups)
     {
+        var pendingGroups = Model.PendingSignups
+            .GroupBy(s => s.SignupBlockId.HasValue ? $"{s.UserId}|{s.SignupBlockId}" : s.Id.ToString())
+            .ToList();
         <div class="card mb-4 border-warning">
             <div class="card-header bg-warning text-dark">
                 <h5 class="mb-0">Pending Approvals (@Model.PendingSignups.Count)</h5>
@@ -46,31 +49,65 @@
                 <div class="table-responsive">
                     <table class="table table-sm">
                         <thead>
-                            <tr><th>Human</th><th>Profile</th><th>Shift</th><th>Submitted</th><th></th></tr>
+                            <tr><th>Human</th><th>Profile</th><th>Shift</th><th>Date</th><th>Submitted</th><th></th></tr>
                         </thead>
                         <tbody>
-                            @foreach (var signup in Model.PendingSignups)
+                            @foreach (var group in pendingGroups)
                             {
+                                var signups = group.OrderBy(s => s.Shift.DayOffset).ToList();
+                                var first = signups[0];
+                                var isRange = signups.Count > 1;
                                 <tr>
-                                    <td>@signup.User?.DisplayName</td>
+                                    <td><human-link user-id="@first.UserId" display-name="@first.User?.DisplayName" /></td>
                                     <td>
                                         @{
-                                            var pendingProfile = Model.VolunteerProfiles.GetValueOrDefault(signup.UserId);
+                                            var pendingProfile = Model.VolunteerProfiles.GetValueOrDefault(first.UserId);
                                         }
                                         @await Html.PartialAsync("_VolunteerProfileBadges", (pendingProfile, Model.CanViewMedical))
                                     </td>
-                                    <td>@signup.Shift.Rota.Name</td>
-                                    <td>@signup.CreatedAt</td>
+                                    <td>@first.Shift.Rota.Name</td>
                                     <td>
-                                        <form asp-action="ApproveSignup" asp-route-slug="@Model.Department.Slug" asp-route-signupId="@signup.Id" method="post" class="d-inline">
-                                            @Html.AntiForgeryToken()
-                                            <button type="submit" class="btn btn-sm btn-success">Approve</button>
-                                        </form>
-                                        <form asp-action="RefuseSignup" asp-route-slug="@Model.Department.Slug" asp-route-signupId="@signup.Id" method="post" class="d-inline">
-                                            @Html.AntiForgeryToken()
-                                            <input type="text" name="reason" placeholder="Reason (optional)" class="form-control form-control-sm d-inline-block" style="width: 150px; vertical-align: middle;" />
-                                            <button type="submit" class="btn btn-sm btn-danger">Refuse</button>
-                                        </form>
+                                        @if (isRange)
+                                        {
+                                            var firstDate = Model.EventSettings.GateOpeningDate.PlusDays(signups[0].Shift.DayOffset);
+                                            var lastDate = Model.EventSettings.GateOpeningDate.PlusDays(signups[^1].Shift.DayOffset);
+                                            <span>@firstDate.ToDisplayShiftDate() – @lastDate.ToDisplayShiftDate()</span>
+                                            <span class="badge bg-secondary ms-1">@signups.Count days</span>
+                                        }
+                                        else
+                                        {
+                                            var signupDate = Model.EventSettings.GateOpeningDate.PlusDays(first.Shift.DayOffset);
+                                            @signupDate.ToDisplayShiftDate()
+                                        }
+                                    </td>
+                                    <td>@first.CreatedAt</td>
+                                    <td>
+                                        @if (isRange && first.SignupBlockId.HasValue)
+                                        {
+                                            <form asp-action="ApproveRange" asp-route-slug="@Model.Department.Slug" method="post" class="d-inline">
+                                                @Html.AntiForgeryToken()
+                                                <input type="hidden" name="signupBlockId" value="@first.SignupBlockId" />
+                                                <button type="submit" class="btn btn-sm btn-success">Approve Range</button>
+                                            </form>
+                                            <form asp-action="RefuseRange" asp-route-slug="@Model.Department.Slug" method="post" class="d-inline">
+                                                @Html.AntiForgeryToken()
+                                                <input type="hidden" name="signupBlockId" value="@first.SignupBlockId" />
+                                                <input type="text" name="reason" placeholder="Reason (optional)" class="form-control form-control-sm d-inline-block" style="width: 150px; vertical-align: middle;" />
+                                                <button type="submit" class="btn btn-sm btn-danger">Refuse Range</button>
+                                            </form>
+                                        }
+                                        else
+                                        {
+                                            <form asp-action="ApproveSignup" asp-route-slug="@Model.Department.Slug" asp-route-signupId="@first.Id" method="post" class="d-inline">
+                                                @Html.AntiForgeryToken()
+                                                <button type="submit" class="btn btn-sm btn-success">Approve</button>
+                                            </form>
+                                            <form asp-action="RefuseSignup" asp-route-slug="@Model.Department.Slug" asp-route-signupId="@first.Id" method="post" class="d-inline">
+                                                @Html.AntiForgeryToken()
+                                                <input type="text" name="reason" placeholder="Reason (optional)" class="form-control form-control-sm d-inline-block" style="width: 150px; vertical-align: middle;" />
+                                                <button type="submit" class="btn btn-sm btn-danger">Refuse</button>
+                                            </form>
+                                        }
                                     </td>
                                 </tr>
                             }
@@ -250,8 +287,8 @@
                                                     {
                                                         var ss = activeSignups[i];
                                                         if (i > 0) { <text>, </text> }
-                                                        <a asp-controller="Human" asp-action="View" asp-route-id="@ss.UserId"
-                                                           class="text-decoration-none @(ss.Status == SignupStatus.Pending ? "text-muted fst-italic" : "")">@ss.User?.DisplayName</a>@if (ss.Status == SignupStatus.Pending)
+                                                        <human-link user-id="@ss.UserId" display-name="@ss.User?.DisplayName"
+                                                                   class="@(ss.Status == SignupStatus.Pending ? "text-muted fst-italic" : "")" />@if (ss.Status == SignupStatus.Pending)
                                                         {<small class="text-muted"> @Localizer["Shifts_Pending"]</small>}
                                                     }
                                                 }
@@ -260,14 +297,11 @@
                                                     <div class="d-flex flex-wrap gap-1">
                                                         @foreach (var ss in activeSignups)
                                                         {
-                                                            <a asp-controller="Human" asp-action="View" asp-route-id="@ss.UserId"
-                                                               title="@(ss.User?.DisplayName)@(ss.Status == SignupStatus.Pending ? $" ({Localizer["Shifts_Pending"]})" : "")"
-                                                               class="@(ss.Status == SignupStatus.Pending ? "opacity-50" : "")"
-                                                               style="@(ss.Status == SignupStatus.Pending ? "border: 1px dashed #6c757d; border-radius: 50%;" : "")">
-                                                                <vc:user-avatar profile-picture-url="@(ss.User?.ProfilePictureUrl != null ? $"/Human/{ss.UserId}/Picture" : null)"
-                                                                                display-name="@(ss.User?.DisplayName)"
-                                                                                size="26" />
-                                                            </a>
+                                                            <human-link user-id="@ss.UserId" display-name="@(ss.User?.DisplayName)" mode="Avatar" size="26"
+                                                                       profile-picture-url="@(ss.User?.ProfilePictureUrl != null ? $"/Human/{ss.UserId}/Picture" : null)"
+                                                                       title="@(ss.User?.DisplayName)@(ss.Status == SignupStatus.Pending ? $" ({Localizer["Shifts_Pending"]})" : "")"
+                                                                       class="@(ss.Status == SignupStatus.Pending ? "opacity-50" : "")"
+                                                                       style="@(ss.Status == SignupStatus.Pending ? "border: 1px dashed #6c757d; border-radius: 50%;" : "")" />
                                                         }
                                                     </div>
                                                 }
@@ -287,6 +321,17 @@
                                             }
                                             @if (Model.CanApproveSignups && !isPast)
                                             {
+                                                var confirmedSignups = shift.ShiftSignups
+                                                    .Where(ss => ss.Status == SignupStatus.Confirmed)
+                                                    .ToList();
+                                                if (confirmedSignups.Count > 0)
+                                                {
+                                                    var manageBtnId = "manage-" + shift.Id.ToString("N");
+                                                    <button class="btn btn-sm btn-outline-secondary ms-1" type="button"
+                                                            data-bs-toggle="collapse" data-bs-target="#@manageBtnId">
+                                                        Manage (@confirmedSignups.Count)
+                                                    </button>
+                                                }
                                                 var voluntellBtnId = "dept-voluntell-" + shift.Id.ToString("N");
                                                 <button class="btn btn-sm btn-outline-success ms-1" type="button"
                                                         data-bs-toggle="collapse" data-bs-target="#@voluntellBtnId">
@@ -367,6 +412,40 @@
                                             </td>
                                         </tr>
                                     }
+                                    @if (!isPast && Model.CanApproveSignups)
+                                    {
+                                        var manageSignups = shift.ShiftSignups
+                                            .Where(ss => ss.Status == SignupStatus.Confirmed)
+                                            .OrderBy(ss => ss.User?.DisplayName, StringComparer.OrdinalIgnoreCase)
+                                            .ToList();
+                                        if (manageSignups.Count > 0)
+                                        {
+                                            var manageCollapseId = "manage-" + shift.Id.ToString("N");
+                                            <tr class="collapse" id="@manageCollapseId">
+                                                <td colspan="@(Model.CanApproveSignups ? 7 : 6)">
+                                                    <div class="p-2">
+                                                        @foreach (var signup in manageSignups)
+                                                        {
+                                                            <div class="d-flex justify-content-between align-items-center border-bottom py-1">
+                                                                <div>
+                                                                    <human-link user-id="@signup.UserId" display-name="@signup.User?.DisplayName" />
+                                                                    @{
+                                                                        var manageProfile = Model.VolunteerProfiles.GetValueOrDefault(signup.UserId);
+                                                                    }
+                                                                    @await Html.PartialAsync("_VolunteerProfileBadges", (manageProfile, Model.CanViewMedical))
+                                                                </div>
+                                                                <form asp-action="RemoveSignup" asp-route-slug="@Model.Department.Slug" asp-route-signupId="@signup.Id" method="post" class="d-inline">
+                                                                    @Html.AntiForgeryToken()
+                                                                    <button type="submit" class="btn btn-sm btn-outline-secondary"
+                                                                            data-confirm="Remove this human from the shift?">Remove</button>
+                                                                </form>
+                                                            </div>
+                                                        }
+                                                    </div>
+                                                </td>
+                                            </tr>
+                                        }
+                                    }
                                     @if (isPast && shiftSignups.Count > 0 && Model.CanApproveSignups)
                                     {
                                         var signupsCollapseId = "signups-" + shift.Id.ToString("N");
@@ -385,7 +464,7 @@
                                                     {
                                                         <div class="d-flex justify-content-between align-items-center border-bottom py-1">
                                                             <div>
-                                                                <span>@signup.User?.DisplayName</span>
+                                                                <human-link user-id="@signup.UserId" display-name="@signup.User?.DisplayName" />
                                                                 @{
                                                                     var signupProfile = Model.VolunteerProfiles.GetValueOrDefault(signup.UserId);
                                                                 }
@@ -402,6 +481,11 @@
                                                             @if (signup.Status == SignupStatus.Confirmed)
                                                             {
                                                                 <div class="d-flex gap-1">
+                                                                    <form asp-action="RemoveSignup" asp-route-slug="@Model.Department.Slug" asp-route-signupId="@signup.Id" method="post" class="d-inline">
+                                                                        @Html.AntiForgeryToken()
+                                                                        <button type="submit" class="btn btn-sm btn-outline-secondary"
+                                                                                data-confirm="Remove this human from the shift?">Remove</button>
+                                                                    </form>
                                                                     <form asp-action="MarkNoShow" asp-route-slug="@Model.Department.Slug" asp-route-signupId="@signup.Id" method="post" class="d-inline">
                                                                         @Html.AntiForgeryToken()
                                                                         <button type="submit" class="btn btn-sm btn-outline-danger">Mark No-Show</button>

--- a/src/Humans.Web/Views/ShiftAdmin/Index.cshtml
+++ b/src/Humans.Web/Views/ShiftAdmin/Index.cshtml
@@ -58,7 +58,7 @@
                                 var first = signups[0];
                                 var isRange = signups.Count > 1;
                                 <tr>
-                                    <td><human-link user-id="@first.UserId" display-name="@first.User?.DisplayName" /></td>
+                                    <td><human-link user-id="@first.UserId" display-name="@first.User?.DisplayName" show-popover="true" /></td>
                                     <td>
                                         @{
                                             var pendingProfile = Model.VolunteerProfiles.GetValueOrDefault(first.UserId);
@@ -287,7 +287,7 @@
                                                     {
                                                         var ss = activeSignups[i];
                                                         if (i > 0) { <text>, </text> }
-                                                        <human-link user-id="@ss.UserId" display-name="@ss.User?.DisplayName"
+                                                        <human-link user-id="@ss.UserId" display-name="@ss.User?.DisplayName" show-popover="true"
                                                                    class="@(ss.Status == SignupStatus.Pending ? "text-muted fst-italic" : "")" />@if (ss.Status == SignupStatus.Pending)
                                                         {<small class="text-muted"> @Localizer["Shifts_Pending"]</small>}
                                                     }
@@ -298,7 +298,7 @@
                                                         @foreach (var ss in activeSignups)
                                                         {
                                                             <human-link user-id="@ss.UserId" display-name="@(ss.User?.DisplayName)" mode="Avatar" size="26"
-                                                                       profile-picture-url="@(ss.User?.ProfilePictureUrl != null ? $"/Human/{ss.UserId}/Picture" : null)"
+                                                                       profile-picture-url="@(ss.User?.ProfilePictureUrl != null ? $"/Human/{ss.UserId}/Picture" : null)" show-popover="true"
                                                                        title="@(ss.User?.DisplayName)@(ss.Status == SignupStatus.Pending ? $" ({Localizer["Shifts_Pending"]})" : "")"
                                                                        class="@(ss.Status == SignupStatus.Pending ? "opacity-50" : "")"
                                                                        style="@(ss.Status == SignupStatus.Pending ? "border: 1px dashed #6c757d; border-radius: 50%;" : "")" />
@@ -428,7 +428,7 @@
                                                         {
                                                             <div class="d-flex justify-content-between align-items-center border-bottom py-1">
                                                                 <div>
-                                                                    <human-link user-id="@signup.UserId" display-name="@signup.User?.DisplayName" />
+                                                                    <human-link user-id="@signup.UserId" display-name="@signup.User?.DisplayName" show-popover="true" />
                                                                     @{
                                                                         var manageProfile = Model.VolunteerProfiles.GetValueOrDefault(signup.UserId);
                                                                     }
@@ -464,7 +464,7 @@
                                                     {
                                                         <div class="d-flex justify-content-between align-items-center border-bottom py-1">
                                                             <div>
-                                                                <human-link user-id="@signup.UserId" display-name="@signup.User?.DisplayName" />
+                                                                <human-link user-id="@signup.UserId" display-name="@signup.User?.DisplayName" show-popover="true" />
                                                                 @{
                                                                     var signupProfile = Model.VolunteerProfiles.GetValueOrDefault(signup.UserId);
                                                                 }

--- a/src/Humans.Web/Views/Shifts/Index.cshtml
+++ b/src/Humans.Web/Views/Shifts/Index.cshtml
@@ -214,7 +214,7 @@
                                                             @foreach (var signup in item.Signups)
                                                             {
                                                                 <human-link user-id="@signup.UserId" display-name="@signup.DisplayName" mode="Avatar" size="26"
-                                                                           profile-picture-url="@signup.ProfilePictureUrl"
+                                                                           profile-picture-url="@signup.ProfilePictureUrl" show-popover="true"
                                                                            title="@signup.DisplayName@(signup.Status == SignupStatus.Pending ? $" ({Localizer["Shifts_Pending"]})" : "")"
                                                                            class="@(signup.Status == SignupStatus.Pending ? "opacity-50" : "")"
                                                                            style="@(signup.Status == SignupStatus.Pending ? "border: 1px dashed #6c757d; border-radius: 50%;" : "")" />
@@ -285,7 +285,7 @@
                                                         {
                                                             var signup = item.Signups[i];
                                                             if (i > 0) { <text>, </text> }
-                                                            <human-link user-id="@signup.UserId" display-name="@signup.DisplayName"
+                                                            <human-link user-id="@signup.UserId" display-name="@signup.DisplayName" show-popover="true"
                                                                        class="@(signup.Status == SignupStatus.Pending ? "text-muted fst-italic" : "")" />@if (signup.Status == SignupStatus.Pending)
                                                             {<small class="text-muted"> @Localizer["Shifts_Pending"]</small>}
                                                         }

--- a/src/Humans.Web/Views/Shifts/Index.cshtml
+++ b/src/Humans.Web/Views/Shifts/Index.cshtml
@@ -213,14 +213,11 @@
                                                         <div class="d-flex flex-wrap gap-1">
                                                             @foreach (var signup in item.Signups)
                                                             {
-                                                                <a asp-controller="Human" asp-action="View" asp-route-id="@signup.UserId"
-                                                                   title="@signup.DisplayName@(signup.Status == SignupStatus.Pending ? $" ({Localizer["Shifts_Pending"]})" : "")"
-                                                                   class="@(signup.Status == SignupStatus.Pending ? "opacity-50" : "")"
-                                                                   style="@(signup.Status == SignupStatus.Pending ? "border: 1px dashed #6c757d; border-radius: 50%;" : "")">
-                                                                    <vc:user-avatar profile-picture-url="@signup.ProfilePictureUrl"
-                                                                                    display-name="@signup.DisplayName"
-                                                                                    size="26" />
-                                                                </a>
+                                                                <human-link user-id="@signup.UserId" display-name="@signup.DisplayName" mode="Avatar" size="26"
+                                                                           profile-picture-url="@signup.ProfilePictureUrl"
+                                                                           title="@signup.DisplayName@(signup.Status == SignupStatus.Pending ? $" ({Localizer["Shifts_Pending"]})" : "")"
+                                                                           class="@(signup.Status == SignupStatus.Pending ? "opacity-50" : "")"
+                                                                           style="@(signup.Status == SignupStatus.Pending ? "border: 1px dashed #6c757d; border-radius: 50%;" : "")" />
                                                             }
                                                         </div>
                                                     </td>
@@ -288,8 +285,8 @@
                                                         {
                                                             var signup = item.Signups[i];
                                                             if (i > 0) { <text>, </text> }
-                                                            <a asp-controller="Human" asp-action="View" asp-route-id="@signup.UserId"
-                                                               class="text-decoration-none @(signup.Status == SignupStatus.Pending ? "text-muted fst-italic" : "")">@signup.DisplayName</a>@if (signup.Status == SignupStatus.Pending)
+                                                            <human-link user-id="@signup.UserId" display-name="@signup.DisplayName"
+                                                                       class="@(signup.Status == SignupStatus.Pending ? "text-muted fst-italic" : "")" />@if (signup.Status == SignupStatus.Pending)
                                                             {<small class="text-muted"> @Localizer["Shifts_Pending"]</small>}
                                                         }
                                                     </td>

--- a/src/Humans.Web/Views/Team/Birthdays.cshtml
+++ b/src/Humans.Web/Views/Team/Birthdays.cshtml
@@ -44,7 +44,7 @@
                             @foreach (var birthday in group)
                             {
                                 <human-link user-id="@birthday.UserId" display-name="@birthday.DisplayName"
-                                           mode="AvatarName" size="48"
+                                           mode="AvatarName" size="48" show-popover="true"
                                            profile-picture-url="@birthday.EffectiveProfilePictureUrl">
                                     @if (birthday.TeamNames.Count > 0)
                                     {

--- a/src/Humans.Web/Views/Team/Birthdays.cshtml
+++ b/src/Humans.Web/Views/Team/Birthdays.cshtml
@@ -43,20 +43,14 @@
                         <div class="d-flex flex-wrap gap-3">
                             @foreach (var birthday in group)
                             {
-                                <a asp-controller="Human" asp-action="View" asp-route-id="@birthday.UserId"
-                                   class="d-flex align-items-center text-decoration-none text-reset">
-                                    <vc:user-avatar profile-picture-url="@birthday.EffectiveProfilePictureUrl"
-                                                    display-name="@birthday.DisplayName"
-                                                    size="48"
-                                                    css-class="me-2" />
-                                    <div>
-                                        <div class="fw-semibold">@birthday.DisplayName</div>
-                                        @if (birthday.TeamNames.Count > 0)
-                                        {
-                                            <small class="text-muted">@string.Join(", ", birthday.TeamNames)</small>
-                                        }
-                                    </div>
-                                </a>
+                                <human-link user-id="@birthday.UserId" display-name="@birthday.DisplayName"
+                                           mode="AvatarName" size="48"
+                                           profile-picture-url="@birthday.EffectiveProfilePictureUrl">
+                                    @if (birthday.TeamNames.Count > 0)
+                                    {
+                                        <small class="text-muted">@string.Join(", ", birthday.TeamNames)</small>
+                                    }
+                                </human-link>
                             }
                         </div>
                     </div>

--- a/src/Humans.Web/Views/Team/Details.cshtml
+++ b/src/Humans.Web/Views/Team/Details.cshtml
@@ -163,15 +163,13 @@
                                 <div class="col-6 col-sm-4 col-md-3">
                                     @if (Model.IsAuthenticated)
                                     {
-                                        <a asp-controller="Human" asp-action="View" asp-route-id="@member.UserId" class="text-center text-decoration-none d-block">
-                                            <vc:user-avatar profile-picture-url="@member.EffectiveProfilePictureUrl"
-                                                            display-name="@member.DisplayName"
-                                                            size="128"
-                                                            css-class="mb-2 mx-auto border border-primary border-3"
-                                                            bg-color="bg-primary" />
-                                            <div class="fw-semibold small">@member.DisplayName</div>
+                                        <human-link user-id="@member.UserId" display-name="@member.DisplayName"
+                                                    mode="Card" size="128"
+                                                    profile-picture-url="@member.EffectiveProfilePictureUrl"
+                                                    avatar-css-class="border border-primary border-3"
+                                                    avatar-bg-color="bg-primary">
                                             @await Html.PartialAsync("_RoleBadge", TeamMemberRole.Coordinator)
-                                        </a>
+                                        </human-link>
                                     }
                                     else
                                     {
@@ -199,13 +197,9 @@
                             @foreach (var member in regularMembers)
                             {
                                 <div class="col-6 col-sm-4 col-md-3">
-                                    <a asp-controller="Human" asp-action="View" asp-route-id="@member.UserId" class="text-center text-decoration-none d-block">
-                                        <vc:user-avatar profile-picture-url="@member.EffectiveProfilePictureUrl"
-                                                        display-name="@member.DisplayName"
-                                                        size="102"
-                                                        css-class="mb-2 mx-auto" />
-                                        <div class="small">@member.DisplayName</div>
-                                    </a>
+                                    <human-link user-id="@member.UserId" display-name="@member.DisplayName"
+                                                mode="Card" size="102"
+                                                profile-picture-url="@member.EffectiveProfilePictureUrl" />
                                 </div>
                             }
                         </div>

--- a/src/Humans.Web/Views/Team/Search.cshtml
+++ b/src/Humans.Web/Views/Team/Search.cshtml
@@ -38,7 +38,7 @@
         <div class="list-group">
             @foreach (var result in Model.Results)
             {
-                <a asp-controller="Human" asp-action="View" asp-route-id="@result.UserId" class="list-group-item list-group-item-action">
+                <human-link user-id="@result.UserId" display-name="@result.DisplayName" class="list-group-item list-group-item-action">
                     <div class="d-flex align-items-center gap-3">
                         <vc:user-avatar profile-picture-url="@result.EffectiveProfilePictureUrl"
                                         display-name="@result.DisplayName"
@@ -67,7 +67,7 @@
                             }
                         </div>
                     </div>
-                </a>
+                </human-link>
             }
         </div>
     }

--- a/src/Humans.Web/Views/Team/Search.cshtml
+++ b/src/Humans.Web/Views/Team/Search.cshtml
@@ -38,7 +38,7 @@
         <div class="list-group">
             @foreach (var result in Model.Results)
             {
-                <human-link user-id="@result.UserId" display-name="@result.DisplayName" class="list-group-item list-group-item-action">
+                <human-link user-id="@result.UserId" display-name="@result.DisplayName" show-popover="true" class="list-group-item list-group-item-action">
                     <div class="d-flex align-items-center gap-3">
                         <vc:user-avatar profile-picture-url="@result.EffectiveProfilePictureUrl"
                                         display-name="@result.DisplayName"

--- a/src/Humans.Web/Views/TeamAdmin/Members.cshtml
+++ b/src/Humans.Web/Views/TeamAdmin/Members.cshtml
@@ -47,7 +47,7 @@
                         <tr>
                             <td>
                                 <human-link user-id="@request.UserId" display-name="@request.UserDisplayName"
-                                           mode="AvatarName" size="32"
+                                           mode="AvatarName" size="32" show-popover="true"
                                            profile-picture-url="@request.UserProfilePictureUrl">
                                     <small class="text-muted">@request.UserEmail</small>
                                 </human-link>
@@ -150,7 +150,7 @@
                         <tr>
                             <td>
                                 <human-link user-id="@member.UserId" display-name="@member.DisplayName"
-                                           mode="AvatarName" size="40"
+                                           mode="AvatarName" size="40" show-popover="true"
                                            profile-picture-url="@member.EffectiveProfilePictureUrl">
                                     <small class="text-muted">@member.Email</small>
                                 </human-link>

--- a/src/Humans.Web/Views/TeamAdmin/Members.cshtml
+++ b/src/Humans.Web/Views/TeamAdmin/Members.cshtml
@@ -46,18 +46,11 @@
                     {
                         <tr>
                             <td>
-                                <div class="d-flex align-items-center">
-                                    <vc:user-avatar profile-picture-url="@request.UserProfilePictureUrl"
-                                                    display-name="@request.UserDisplayName"
-                                                    size="32"
-                                                    css-class="me-2" />
-                                    <div>
-                                        <a asp-controller="Human" asp-action="View" asp-route-id="@request.UserId" class="text-decoration-none">
-                                            <strong>@request.UserDisplayName</strong>
-                                        </a><br>
-                                        <small class="text-muted">@request.UserEmail</small>
-                                    </div>
-                                </div>
+                                <human-link user-id="@request.UserId" display-name="@request.UserDisplayName"
+                                           mode="AvatarName" size="32"
+                                           profile-picture-url="@request.UserProfilePictureUrl">
+                                    <small class="text-muted">@request.UserEmail</small>
+                                </human-link>
                             </td>
                             <td>
                                 @if (!string.IsNullOrEmpty(request.Message))
@@ -156,18 +149,11 @@
                     {
                         <tr>
                             <td>
-                                <div class="d-flex align-items-center">
-                                    <vc:user-avatar profile-picture-url="@member.EffectiveProfilePictureUrl"
-                                                    display-name="@member.DisplayName"
-                                                    size="40"
-                                                    css-class="me-2" />
-                                    <div>
-                                        <a asp-controller="Human" asp-action="View" asp-route-id="@member.UserId" class="text-decoration-none">
-                                            <strong>@member.DisplayName</strong>
-                                        </a><br>
-                                        <small class="text-muted">@member.Email</small>
-                                    </div>
-                                </div>
+                                <human-link user-id="@member.UserId" display-name="@member.DisplayName"
+                                           mode="AvatarName" size="40"
+                                           profile-picture-url="@member.EffectiveProfilePictureUrl">
+                                    <small class="text-muted">@member.Email</small>
+                                </human-link>
                             </td>
                             <td>
                                 @await Html.PartialAsync("_RoleBadge", member.IsCoordinator ? TeamMemberRole.Coordinator : TeamMemberRole.Member)

--- a/src/Humans.Web/Views/Ticket/Attendees.cshtml
+++ b/src/Humans.Web/Views/Ticket/Attendees.cshtml
@@ -83,7 +83,7 @@
                         <td>
                             @if (a.MatchedUserId.HasValue)
                             {
-                                <human-link user-id="@a.MatchedUserId.Value" display-name="@a.MatchedUserName" admin="true">
+                                <human-link user-id="@a.MatchedUserId.Value" display-name="@a.MatchedUserName" admin="true" show-popover="true">
                                     <i class="fa-solid fa-check text-success"></i> @a.MatchedUserName
                                 </human-link>
                             }

--- a/src/Humans.Web/Views/Ticket/Attendees.cshtml
+++ b/src/Humans.Web/Views/Ticket/Attendees.cshtml
@@ -83,9 +83,9 @@
                         <td>
                             @if (a.MatchedUserId.HasValue)
                             {
-                                <a asp-controller="Human" asp-action="HumanDetail" asp-route-id="@a.MatchedUserId">
+                                <human-link user-id="@a.MatchedUserId.Value" display-name="@a.MatchedUserName" admin="true">
                                     <i class="fa-solid fa-check text-success"></i> @a.MatchedUserName
-                                </a>
+                                </human-link>
                             }
                             else
                             {

--- a/src/Humans.Web/Views/Ticket/Codes.cshtml
+++ b/src/Humans.Web/Views/Ticket/Codes.cshtml
@@ -103,7 +103,7 @@
                     <tr>
                         <td><code>@code.Code</code></td>
                         <td>
-                            <human-link user-id="@code.RecipientUserId" display-name="@code.RecipientName" admin="true" />
+                            <human-link user-id="@code.RecipientUserId" display-name="@code.RecipientName" admin="true" show-popover="true" />
                         </td>
                         <td>@code.CampaignTitle</td>
                         <td>

--- a/src/Humans.Web/Views/Ticket/Codes.cshtml
+++ b/src/Humans.Web/Views/Ticket/Codes.cshtml
@@ -103,7 +103,7 @@
                     <tr>
                         <td><code>@code.Code</code></td>
                         <td>
-                            <a asp-controller="Human" asp-action="HumanDetail" asp-route-id="@code.RecipientUserId">@code.RecipientName</a>
+                            <human-link user-id="@code.RecipientUserId" display-name="@code.RecipientName" admin="true" />
                         </td>
                         <td>@code.CampaignTitle</td>
                         <td>

--- a/src/Humans.Web/Views/Ticket/Orders.cshtml
+++ b/src/Humans.Web/Views/Ticket/Orders.cshtml
@@ -85,9 +85,9 @@
                         <td>
                             @if (order.MatchedUserId.HasValue)
                             {
-                                <a asp-controller="Human" asp-action="HumanDetail" asp-route-id="@order.MatchedUserId">
+                                <human-link user-id="@order.MatchedUserId.Value" display-name="@order.MatchedUserName" admin="true">
                                     <span class="badge bg-success"><i class="fa-solid fa-check"></i></span> @order.MatchedUserName
-                                </a>
+                                </human-link>
                             }
                             else
                             {

--- a/src/Humans.Web/Views/Ticket/Orders.cshtml
+++ b/src/Humans.Web/Views/Ticket/Orders.cshtml
@@ -85,7 +85,7 @@
                         <td>
                             @if (order.MatchedUserId.HasValue)
                             {
-                                <human-link user-id="@order.MatchedUserId.Value" display-name="@order.MatchedUserName" admin="true">
+                                <human-link user-id="@order.MatchedUserId.Value" display-name="@order.MatchedUserName" admin="true" show-popover="true">
                                     <span class="badge bg-success"><i class="fa-solid fa-check"></i></span> @order.MatchedUserName
                                 </human-link>
                             }

--- a/src/Humans.Web/Views/Ticket/WhoHasntBought.cshtml
+++ b/src/Humans.Web/Views/Ticket/WhoHasntBought.cshtml
@@ -62,7 +62,7 @@
                 {
                     <tr>
                         <td>
-                            <a asp-controller="Human" asp-action="HumanDetail" asp-route-id="@h.UserId">@h.Name</a>
+                            <human-link user-id="@h.UserId" display-name="@h.Name" admin="true" />
                         </td>
                         <td><small>@h.Email</small></td>
                         <td><small>@h.Teams</small></td>

--- a/src/Humans.Web/Views/Ticket/WhoHasntBought.cshtml
+++ b/src/Humans.Web/Views/Ticket/WhoHasntBought.cshtml
@@ -62,7 +62,7 @@
                 {
                     <tr>
                         <td>
-                            <human-link user-id="@h.UserId" display-name="@h.Name" admin="true" />
+                            <human-link user-id="@h.UserId" display-name="@h.Name" admin="true" show-popover="true" />
                         </td>
                         <td><small>@h.Email</small></td>
                         <td><small>@h.Teams</small></td>

--- a/src/Humans.Web/Views/Vol/ChildTeamDetail.cshtml
+++ b/src/Humans.Web/Views/Vol/ChildTeamDetail.cshtml
@@ -54,8 +54,7 @@
                         {
                             <tr>
                                 <td>
-                                    <a asp-controller="Human" asp-action="View" asp-route-id="@member.UserId"
-                                       class="text-decoration-none">@member.User.DisplayName</a>
+                                    <human-link user-id="@member.UserId" display-name="@member.User.DisplayName" />
                                 </td>
                                 <td>
                                     @if (member.Role == TeamMemberRole.Coordinator)
@@ -119,8 +118,7 @@
                         {
                             <tr>
                                 <td>
-                                    <a asp-controller="Human" asp-action="View" asp-route-id="@request.UserId"
-                                       class="text-decoration-none">@request.User.DisplayName</a>
+                                    <human-link user-id="@request.UserId" display-name="@request.User.DisplayName" />
                                 </td>
                                 <td class="text-muted small">
                                     @(string.IsNullOrWhiteSpace(request.Message) ? "—" : request.Message)

--- a/src/Humans.Web/Views/Vol/ChildTeamDetail.cshtml
+++ b/src/Humans.Web/Views/Vol/ChildTeamDetail.cshtml
@@ -54,7 +54,7 @@
                         {
                             <tr>
                                 <td>
-                                    <human-link user-id="@member.UserId" display-name="@member.User.DisplayName" />
+                                    <human-link user-id="@member.UserId" display-name="@member.User.DisplayName" show-popover="true" />
                                 </td>
                                 <td>
                                     @if (member.Role == TeamMemberRole.Coordinator)
@@ -118,7 +118,7 @@
                         {
                             <tr>
                                 <td>
-                                    <human-link user-id="@request.UserId" display-name="@request.User.DisplayName" />
+                                    <human-link user-id="@request.UserId" display-name="@request.User.DisplayName" show-popover="true" />
                                 </td>
                                 <td class="text-muted small">
                                     @(string.IsNullOrWhiteSpace(request.Message) ? "—" : request.Message)

--- a/src/Humans.Web/Views/Vol/_ShiftRow.cshtml
+++ b/src/Humans.Web/Views/Vol/_ShiftRow.cshtml
@@ -63,7 +63,7 @@
             {
                 var signup = item.Signups[i];
                 if (i > 0) { <text>, </text> }
-                <human-link user-id="@signup.UserId" display-name="@signup.DisplayName"
+                <human-link user-id="@signup.UserId" display-name="@signup.DisplayName" show-popover="true"
                            class="@(signup.Status == SignupStatus.Pending ? "text-muted fst-italic" : "")" />@if (signup.Status == SignupStatus.Pending)
                 {<small class="text-muted"> (pending)</small>}
             }

--- a/src/Humans.Web/Views/Vol/_ShiftRow.cshtml
+++ b/src/Humans.Web/Views/Vol/_ShiftRow.cshtml
@@ -63,8 +63,8 @@
             {
                 var signup = item.Signups[i];
                 if (i > 0) { <text>, </text> }
-                <a asp-controller="Human" asp-action="View" asp-route-id="@signup.UserId"
-                   class="text-decoration-none @(signup.Status == SignupStatus.Pending ? "text-muted fst-italic" : "")">@signup.DisplayName</a>@if (signup.Status == SignupStatus.Pending)
+                <human-link user-id="@signup.UserId" display-name="@signup.DisplayName"
+                           class="@(signup.Status == SignupStatus.Pending ? "text-muted fst-italic" : "")" />@if (signup.Status == SignupStatus.Pending)
                 {<small class="text-muted"> (pending)</small>}
             }
         </td>

--- a/src/Humans.Web/wwwroot/js/site.js
+++ b/src/Humans.Web/wwwroot/js/site.js
@@ -45,3 +45,38 @@ document.addEventListener('click', function (e) {
         window.location = row.getAttribute('data-href');
     }
 });
+
+// Human profile popover (lazy-loaded on first hover)
+(function () {
+    var cache = {};
+    document.addEventListener('mouseenter', function (e) {
+        var el = e.target.closest('[data-human-popover]');
+        if (!el || el._popoverInit) return;
+        el._popoverInit = true;
+
+        var userId = el.getAttribute('data-user-id');
+        if (!userId) return;
+
+        var popover = new bootstrap.Popover(el, {
+            trigger: 'hover focus',
+            placement: 'auto',
+            html: true,
+            content: '<div class="text-center p-2"><div class="spinner-border spinner-border-sm"></div></div>',
+            sanitize: false
+        });
+        popover.show();
+
+        if (cache[userId]) {
+            popover.setContent({ '.popover-body': cache[userId] });
+        } else {
+            fetch('/Human/' + userId + '/Popover')
+                .then(function (r) { return r.ok ? r.text() : ''; })
+                .then(function (html) {
+                    if (html) {
+                        cache[userId] = html;
+                        popover.setContent({ '.popover-body': html });
+                    }
+                });
+        }
+    }, true);
+})();


### PR DESCRIPTION
## Summary
- **#202**: Reusable `<human-link>` tag helper with text, avatar, avatar-name, and card modes + lazy-loaded profile popover. Migrated all ~30 raw `asp-controller="Human"` anchor tags across the codebase. Fixed 2 broken `asp-action="Detail"` links.
- **#201**: Clickable names in ShiftAdmin pending approvals and past signups (handled via HumanLink migration)
- **#214**: Pending approvals table now shows dates, groups range signups by SignupBlockId with date range display, and offers Approve Range / Refuse Range buttons for batch operations
- **#215**: Coordinators can unassign confirmed users from shifts via a Remove button (transitions to Cancelled status with reviewer tracking). Available in both active shift "Manage" expand and past shift details.

## Test plan
- [ ] Verify HumanLink renders correctly in text, avatar, avatar-name, and card modes across all migrated views
- [ ] Verify popover loads on hover when `show-popover="true"` is set
- [ ] Verify broken links on Feedback detail and SyncResults pages now work correctly
- [ ] Test pending approvals: single signup shows date, range signup shows grouped date range
- [ ] Test Approve Range / Refuse Range processes all signups in a block
- [ ] Test individual Approve/Refuse still works for single-day signups
- [ ] Test Remove button on active shifts (Manage expand) and past shifts
- [ ] Verify removed signup transitions to Cancelled status with reviewer recorded

🤖 Generated with [Claude Code](https://claude.com/claude-code)