### PR TITLE
feat: contact accounts — pre-provisioned Identity users (#205)

### DIFF
--- a/.claude/DATA_MODEL.md
+++ b/.claude/DATA_MODEL.md
@@ -135,6 +135,15 @@ Methods:
 - `GetGoogleServiceEmail()` → `GoogleEmail ?? Email` (for Google resource sync)
 - `GetEffectiveEmail()` → notification target email or OAuth email (for system notifications)
 
+### Contact Import Properties
+
+| Property | Type | Default | Purpose |
+|----------|------|---------|---------|
+| ContactSource | ContactSource? | null | Where imported from (Manual, MailerLite, TicketTailor); null for self-registered users |
+| ExternalSourceId | string?(256) | null | ID in the external source system |
+
+A contact is identified by `ContactSource != null && LastLoginAt == null`. When a contact authenticates, `LastLoginAt` is set and they become a regular user.
+
 ### Campaign-Related Properties
 
 | Property | Type | Default | Purpose |

--- a/docs/features/29-contact-accounts.md
+++ b/docs/features/29-contact-accounts.md
@@ -1,0 +1,109 @@
+# Feature 29: Contact Accounts
+
+## Business Context
+
+The org has external contacts from mailing lists (MailerLite), event ticket purchases (TicketTailor), and manual admin entry who aren't platform members yet. These contacts need to be tracked for communication preference management before they sign up.
+
+With magic link authentication (Feature 30) in place, contacts are **pre-provisioned Identity users** — real User rows with no credentials. When a contact authenticates by any method (magic link, Google OAuth), they claim their existing account with all history preserved. No merge flow needed.
+
+## Design Principles
+
+1. **Contacts are just users who haven't logged in yet.** `LastLoginAt == null` and `ContactSource != null` identifies a contact. No `AccountType` enum, no lockout hacks.
+2. **Work with Identity, not around it.** Contacts are created via `UserManager.CreateAsync` as normal users with `EmailConfirmed = true`.
+3. **No merge needed.** When a contact authenticates, they claim their existing row. Account linking (Feature 30) handles the case where they use Google OAuth.
+
+## User Stories
+
+### US-1: Admin creates a contact manually
+
+**As** a Board member or Admin,
+**I want** to add an external contact with an email and display name,
+**So that** the org can track communication preferences before they sign up.
+
+**Acceptance criteria:**
+- Admin navigates to Humans > Contacts > Add Contact
+- Enters email, display name, and source (Manual, MailerLite, TicketTailor)
+- Contact is created as a pre-provisioned user with `EmailConfirmed = true`
+- Contact appears in the contacts list
+- Duplicate emails are rejected with a clear message
+
+### US-2: Admin views contacts list
+
+**As** a Board member or Admin,
+**I want** to see all external contacts with their source and preferences status,
+**So that** I can manage the org's contact database.
+
+**Acceptance criteria:**
+- Contacts list shows name, email, source, created date, and preference status
+- Search filters by name or email
+- Link to each contact's detail page
+- "Back to Humans" link returns to the main humans list
+
+### US-3: Admin views contact detail
+
+**As** a Board member or Admin,
+**I want** to see a contact's full information including communication preferences and audit history,
+**So that** I can understand their engagement.
+
+**Acceptance criteria:**
+- Shows contact info (email, source, external ID, created date)
+- Shows communication preferences (opted in/out per category)
+- Shows audit log entries for the contact
+
+### US-4: Contact claims account on first login
+
+**As** an imported contact,
+**I want** to authenticate and land in my existing account,
+**So that** my communication preferences and history are preserved.
+
+**Acceptance criteria:**
+- Contact receives a magic link and clicks it → signs into existing account
+- Or authenticates via Google OAuth → account linking connects to existing user
+- `LastLoginAt` is set on first login
+- Contact no longer appears in the Contacts list (they're now an active user)
+- Normal onboarding flow begins (profile completion, consent)
+
+## Data Model
+
+### New fields on User
+
+| Field | Type | Nullable | Description |
+|-------|------|----------|-------------|
+| `ContactSource` | `ContactSource` enum (stored as string) | Yes | Where the contact was imported from: Manual, MailerLite, TicketTailor |
+| `ExternalSourceId` | `string(256)` | Yes | ID in the external source system |
+
+### Contact identification
+
+A contact is identified by: `ContactSource != null && LastLoginAt == null`
+
+When a contact authenticates, `LastLoginAt` is set, and they drop out of the contacts view — they're now a regular user.
+
+### ContactSource enum
+
+```
+Manual = 0      // Admin-created
+MailerLite = 1  // Mailing list import
+TicketTailor = 2 // Ticket purchase import
+```
+
+### Index
+
+Composite index on `(ContactSource, ExternalSourceId)` with filter `external_source_id IS NOT NULL` for external system lookups.
+
+## Authorization
+
+All contact management actions require **Board or Admin** role.
+
+## Routes
+
+| Method | Route | Action |
+|--------|-------|--------|
+| GET | `/Human/Admin/Contacts` | Contacts list |
+| GET | `/Human/Admin/Contacts/{id}` | Contact detail |
+| GET | `/Human/Admin/Contacts/Create` | Create contact form |
+| POST | `/Human/Admin/Contacts/Create` | Create contact submit |
+
+## Related Features
+
+- **Feature 28: Communication Preferences** — contacts can have preferences set before they authenticate
+- **Feature 30: Magic Link Authentication** — enables contacts to claim their accounts; account linking handles Google OAuth

--- a/src/Humans.Application/DTOs/AdminContactRow.cs
+++ b/src/Humans.Application/DTOs/AdminContactRow.cs
@@ -1,0 +1,13 @@
+using Humans.Domain.Enums;
+using NodaTime;
+
+namespace Humans.Application.DTOs;
+
+public record AdminContactRow(
+    Guid UserId,
+    string Email,
+    string DisplayName,
+    ContactSource? ContactSource,
+    string? ExternalSourceId,
+    Instant CreatedAt,
+    bool HasCommunicationPreferences);

--- a/src/Humans.Application/Interfaces/IContactService.cs
+++ b/src/Humans.Application/Interfaces/IContactService.cs
@@ -1,0 +1,33 @@
+using Humans.Application.DTOs;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+
+namespace Humans.Application.Interfaces;
+
+/// <summary>
+/// Manages external contacts imported from MailerLite, TicketTailor, or manual entry.
+/// Contacts are pre-provisioned Identity users with no credentials (LastLoginAt == null).
+/// When they authenticate by any method, they claim their existing account — no merge needed.
+/// </summary>
+public interface IContactService
+{
+    /// <summary>
+    /// Creates a pre-provisioned user for an external contact.
+    /// Idempotent — returns the existing user if one already exists for the same email.
+    /// </summary>
+    Task<User> CreateContactAsync(
+        string email, string displayName, ContactSource source,
+        string? externalSourceId = null, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns all contacts (users with ContactSource set and LastLoginAt == null),
+    /// optionally filtered by email/name search.
+    /// </summary>
+    Task<IReadOnlyList<AdminContactRow>> GetFilteredContactsAsync(
+        string? search, CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets a single contact by user ID with communication preferences loaded.
+    /// </summary>
+    Task<User?> GetContactDetailAsync(Guid userId, CancellationToken ct = default);
+}

--- a/src/Humans.Domain/Entities/User.cs
+++ b/src/Humans.Domain/Entities/User.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Identity;
 using NodaTime;
+using Humans.Domain.Enums;
 
 namespace Humans.Domain.Entities;
 
@@ -135,6 +136,16 @@ public class User : IdentityUser<Guid>
     /// Does NOT require UserEmails to be loaded.
     /// </summary>
     public string? GetGoogleServiceEmail() => GoogleEmail ?? Email;
+
+    /// <summary>
+    /// Where this user was imported from (null for self-registered users).
+    /// </summary>
+    public ContactSource? ContactSource { get; set; }
+
+    /// <summary>
+    /// ID in the external source system (e.g., MailerLite subscriber ID).
+    /// </summary>
+    public string? ExternalSourceId { get; set; }
 
     /// <summary>
     /// Navigation property to communication preferences.

--- a/src/Humans.Domain/Enums/AuditAction.cs
+++ b/src/Humans.Domain/Enums/AuditAction.cs
@@ -70,4 +70,5 @@ public enum AuditAction
     AccountMergeRejected,
     GoogleResourceSettingsRemediated,
     CommunicationPreferenceChanged,
+    ContactCreated,
 }

--- a/src/Humans.Domain/Enums/ContactSource.cs
+++ b/src/Humans.Domain/Enums/ContactSource.cs
@@ -1,0 +1,23 @@
+namespace Humans.Domain.Enums;
+
+/// <summary>
+/// Where an external contact was imported from.
+/// Stored as string in DB; new values can be appended without migration.
+/// </summary>
+public enum ContactSource
+{
+    /// <summary>
+    /// Manually created by an admin.
+    /// </summary>
+    Manual = 0,
+
+    /// <summary>
+    /// Imported from MailerLite mailing list.
+    /// </summary>
+    MailerLite = 1,
+
+    /// <summary>
+    /// Imported from TicketTailor ticket purchase.
+    /// </summary>
+    TicketTailor = 2
+}

--- a/src/Humans.Infrastructure/Data/Configurations/UserConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/UserConfiguration.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Humans.Domain.Entities;
+using Humans.Domain.Enums;
 
 namespace Humans.Infrastructure.Data.Configurations;
 
@@ -61,6 +62,17 @@ public class UserConfiguration : IEntityTypeConfiguration<User>
             .OnDelete(DeleteBehavior.Cascade);
 
         builder.HasIndex(u => u.Email);
+
+        // Contact import fields
+        builder.Property(u => u.ContactSource)
+            .HasConversion<string>()
+            .HasMaxLength(50);
+
+        builder.Property(u => u.ExternalSourceId)
+            .HasMaxLength(256);
+
+        builder.HasIndex(u => new { u.ContactSource, u.ExternalSourceId })
+            .HasFilter("\"ExternalSourceId\" IS NOT NULL");
 
         // Ignore GetEffectiveEmail (method, not property - EF won't map it, but defensive)
     }

--- a/src/Humans.Infrastructure/Migrations/20260325214626_AddContactFields.Designer.cs
+++ b/src/Humans.Infrastructure/Migrations/20260325214626_AddContactFields.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Humans.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Humans.Infrastructure.Migrations
 {
     [DbContext(typeof(HumansDbContext))]
-    partial class HumansDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260325214626_AddContactFields")]
+    partial class AddContactFields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Humans.Infrastructure/Migrations/20260325214626_AddContactFields.cs
+++ b/src/Humans.Infrastructure/Migrations/20260325214626_AddContactFields.cs
@@ -1,0 +1,50 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Humans.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddContactFields : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ContactSource",
+                table: "users",
+                type: "character varying(50)",
+                maxLength: 50,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ExternalSourceId",
+                table: "users",
+                type: "character varying(256)",
+                maxLength: 256,
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_users_ContactSource_ExternalSourceId",
+                table: "users",
+                columns: new[] { "ContactSource", "ExternalSourceId" },
+                filter: "\"ExternalSourceId\" IS NOT NULL");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_users_ContactSource_ExternalSourceId",
+                table: "users");
+
+            migrationBuilder.DropColumn(
+                name: "ContactSource",
+                table: "users");
+
+            migrationBuilder.DropColumn(
+                name: "ExternalSourceId",
+                table: "users");
+        }
+    }
+}

--- a/src/Humans.Infrastructure/Services/ContactService.cs
+++ b/src/Humans.Infrastructure/Services/ContactService.cs
@@ -1,0 +1,169 @@
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using NodaTime;
+using Humans.Application.DTOs;
+using Humans.Application.Interfaces;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using Humans.Domain.Helpers;
+using Humans.Infrastructure.Data;
+
+namespace Humans.Infrastructure.Services;
+
+/// <summary>
+/// Manages external contacts as pre-provisioned Identity users.
+/// Contacts have no credentials and LastLoginAt == null until they authenticate.
+/// </summary>
+public class ContactService : IContactService
+{
+    private readonly HumansDbContext _dbContext;
+    private readonly UserManager<User> _userManager;
+    private readonly IAuditLogService _auditLogService;
+    private readonly IClock _clock;
+    private readonly ILogger<ContactService> _logger;
+
+    public ContactService(
+        HumansDbContext dbContext,
+        UserManager<User> userManager,
+        IAuditLogService auditLogService,
+        IClock clock,
+        ILogger<ContactService> logger)
+    {
+        _dbContext = dbContext;
+        _userManager = userManager;
+        _auditLogService = auditLogService;
+        _clock = clock;
+        _logger = logger;
+    }
+
+    public async Task<User> CreateContactAsync(
+        string email, string displayName, ContactSource source,
+        string? externalSourceId = null, CancellationToken ct = default)
+    {
+        var normalizedEmail = EmailNormalization.NormalizeForComparison(email);
+
+        // Check for existing user with this email
+        var existingUser = await _dbContext.Users
+            .FirstOrDefaultAsync(u => u.NormalizedEmail == normalizedEmail.ToUpperInvariant(), ct);
+
+        if (existingUser is not null)
+        {
+            if (existingUser.ContactSource is not null && existingUser.LastLoginAt is null)
+            {
+                _logger.LogDebug("Contact already exists for {Email}, returning existing", email);
+                return existingUser;
+            }
+
+            throw new InvalidOperationException(
+                $"An active account already exists for email {email}.");
+        }
+
+        // Also check UserEmails table
+        var existingUserEmail = await _dbContext.UserEmails
+            .Include(ue => ue.User)
+            .FirstOrDefaultAsync(ue => ue.IsVerified &&
+                EF.Functions.ILike(ue.Email, email), ct);
+
+        if (existingUserEmail is not null)
+        {
+            if (existingUserEmail.User.ContactSource is not null && existingUserEmail.User.LastLoginAt is null)
+            {
+                return existingUserEmail.User;
+            }
+
+            throw new InvalidOperationException(
+                $"Email {email} is already verified on an existing account.");
+        }
+
+        var now = _clock.GetCurrentInstant();
+
+        var user = new User
+        {
+            UserName = email,
+            Email = email,
+            DisplayName = displayName,
+            ContactSource = source,
+            ExternalSourceId = externalSourceId,
+            CreatedAt = now,
+            EmailConfirmed = true
+        };
+
+        var result = await _userManager.CreateAsync(user);
+        if (!result.Succeeded)
+        {
+            var errors = string.Join(", ", result.Errors.Select(e => e.Description));
+            throw new InvalidOperationException($"Failed to create contact: {errors}");
+        }
+
+        // Create UserEmail record
+        var userEmail = new UserEmail
+        {
+            Id = Guid.NewGuid(),
+            UserId = user.Id,
+            Email = email,
+            IsOAuth = false,
+            IsVerified = true,
+            IsNotificationTarget = true,
+            Visibility = null,
+            DisplayOrder = 0,
+            CreatedAt = now,
+            UpdatedAt = now
+        };
+        _dbContext.UserEmails.Add(userEmail);
+
+        // Audit log
+        await _auditLogService.LogAsync(
+            AuditAction.ContactCreated,
+            nameof(User), user.Id,
+            $"Contact created from {source}{(externalSourceId is not null ? $" (ID: {externalSourceId})" : "")} — {email}",
+            "ContactService");
+
+        await _dbContext.SaveChangesAsync(ct);
+
+        _logger.LogInformation(
+            "Created contact {UserId} for {Email} from {Source}",
+            user.Id, email, source);
+
+        return user;
+    }
+
+    public async Task<IReadOnlyList<AdminContactRow>> GetFilteredContactsAsync(
+        string? search, CancellationToken ct = default)
+    {
+        var query = _dbContext.Users
+            .AsNoTracking()
+            .Where(u => u.ContactSource != null && u.LastLoginAt == null);
+
+        if (!string.IsNullOrWhiteSpace(search))
+        {
+            var pattern = $"%{search}%";
+            query = query.Where(u =>
+                EF.Functions.ILike(u.DisplayName, pattern) ||
+                (u.Email != null && EF.Functions.ILike(u.Email, pattern)));
+        }
+
+        return await query
+            .OrderByDescending(u => u.CreatedAt)
+            .Select(u => new AdminContactRow(
+                u.Id,
+                u.Email ?? string.Empty,
+                u.DisplayName,
+                u.ContactSource,
+                u.ExternalSourceId,
+                u.CreatedAt,
+                u.CommunicationPreferences.Any()))
+            .ToListAsync(ct);
+    }
+
+    public async Task<User?> GetContactDetailAsync(Guid userId, CancellationToken ct = default)
+    {
+        return await _dbContext.Users
+            .Include(u => u.CommunicationPreferences)
+            .Include(u => u.UserEmails)
+            .FirstOrDefaultAsync(u =>
+                u.Id == userId &&
+                u.ContactSource != null &&
+                u.LastLoginAt == null, ct);
+    }
+}

--- a/src/Humans.Web/Controllers/HumanController.cs
+++ b/src/Humans.Web/Controllers/HumanController.cs
@@ -30,6 +30,7 @@ public class HumanController : HumansControllerBase
     private readonly IShiftManagementService _shiftMgmt;
     private readonly IGoogleWorkspaceUserService _workspaceUserService;
     private readonly IUserEmailService _userEmailService;
+    private readonly IContactService _contactService;
     private readonly IClock _clock;
     private readonly IStringLocalizer<SharedResource> _localizer;
     private readonly HumansDbContext _dbContext;
@@ -46,6 +47,7 @@ public class HumanController : HumansControllerBase
         IShiftManagementService shiftMgmt,
         IGoogleWorkspaceUserService workspaceUserService,
         IUserEmailService userEmailService,
+        IContactService contactService,
         IClock clock,
         IStringLocalizer<SharedResource> localizer,
         HumansDbContext dbContext,
@@ -62,6 +64,7 @@ public class HumanController : HumansControllerBase
         _shiftMgmt = shiftMgmt;
         _workspaceUserService = workspaceUserService;
         _userEmailService = userEmailService;
+        _contactService = contactService;
         _clock = clock;
         _localizer = localizer;
         _dbContext = dbContext;
@@ -681,6 +684,118 @@ public class HumanController : HumansControllerBase
 
         SetSuccess(string.Format(_localizer["Admin_RoleEnded"].Value, roleAssignment.RoleName, roleAssignment.User.DisplayName));
         return RedirectToAction(nameof(HumanDetail), new { id = roleAssignment.UserId });
+    }
+
+    [Authorize(Roles = RoleGroups.BoardOrAdmin)]
+    [HttpGet("Admin/Contacts")]
+    public async Task<IActionResult> Contacts(string? search)
+    {
+        try
+        {
+            var allRows = await _contactService.GetFilteredContactsAsync(search);
+
+            var viewModel = new AdminContactListViewModel
+            {
+                TotalCount = allRows.Count,
+                SearchTerm = search,
+                Contacts = allRows.Select(r => new AdminContactViewModel
+                {
+                    Id = r.UserId,
+                    Email = r.Email,
+                    DisplayName = r.DisplayName,
+                    ContactSource = r.ContactSource,
+                    ExternalSourceId = r.ExternalSourceId,
+                    CreatedAt = r.CreatedAt,
+                    HasCommunicationPreferences = r.HasCommunicationPreferences
+                }).ToList()
+            };
+
+            return View(viewModel);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error loading contacts list");
+            SetError(_localizer["Common_Error"].Value);
+            return RedirectToAction(nameof(Humans));
+        }
+    }
+
+    [Authorize(Roles = RoleGroups.BoardOrAdmin)]
+    [HttpGet("Admin/Contacts/{id:guid}")]
+    public async Task<IActionResult> ContactDetail(Guid id)
+    {
+        try
+        {
+            var contact = await _contactService.GetContactDetailAsync(id);
+            if (contact is null)
+                return NotFound();
+
+            var auditLog = await _dbContext.AuditLogEntries
+                .AsNoTracking()
+                .Where(a => a.EntityId == id)
+                .OrderByDescending(a => a.OccurredAt)
+                .ToListAsync();
+
+            var viewModel = new AdminContactDetailViewModel
+            {
+                UserId = contact.Id,
+                Email = contact.Email ?? string.Empty,
+                DisplayName = contact.DisplayName,
+                ContactSource = contact.ContactSource,
+                ExternalSourceId = contact.ExternalSourceId,
+                CreatedAt = contact.CreatedAt,
+                CommunicationPreferences = contact.CommunicationPreferences.ToList(),
+                AuditLog = auditLog
+            };
+
+            return View(viewModel);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error loading contact detail for {ContactId}", id);
+            SetError(_localizer["Common_Error"].Value);
+            return RedirectToAction(nameof(Contacts));
+        }
+    }
+
+    [Authorize(Roles = RoleGroups.BoardOrAdmin)]
+    [HttpGet("Admin/Contacts/Create")]
+    public IActionResult CreateContact()
+    {
+        return View(new CreateContactViewModel());
+    }
+
+    [Authorize(Roles = RoleGroups.BoardOrAdmin)]
+    [HttpPost("Admin/Contacts/Create")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> CreateContact(CreateContactViewModel model)
+    {
+        if (!ModelState.IsValid)
+            return View(model);
+
+        try
+        {
+            var currentUser = await GetCurrentUserAsync();
+            if (currentUser is null)
+                return Unauthorized();
+
+            var contact = await _contactService.CreateContactAsync(
+                model.Email, model.DisplayName, model.Source);
+
+            SetSuccess($"Contact created for {model.Email}.");
+            return RedirectToAction(nameof(ContactDetail), new { id = contact.Id });
+        }
+        catch (InvalidOperationException ex)
+        {
+            ModelState.AddModelError(string.Empty, ex.Message);
+            return View(model);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error creating contact for {Email}", model.Email);
+            ModelState.AddModelError(string.Empty, _localizer["Common_Error"].Value);
+            return View(model);
+        }
     }
 
 }

--- a/src/Humans.Web/Extensions/InfrastructureServiceCollectionExtensions.cs
+++ b/src/Humans.Web/Extensions/InfrastructureServiceCollectionExtensions.cs
@@ -83,6 +83,7 @@ public static class InfrastructureServiceCollectionExtensions
         services.AddScoped<IRoleAssignmentService, RoleAssignmentService>();
         services.AddScoped<IAuditLogService, AuditLogService>();
         services.AddScoped<IAccountMergeService, AccountMergeService>();
+        services.AddScoped<IContactService, ContactService>();
         services.AddScoped<IMagicLinkService, MagicLinkService>();
         services.AddScoped<IFeedbackService, FeedbackService>();
         services.AddScoped<IApplicationDecisionService, ApplicationDecisionService>();

--- a/src/Humans.Web/Models/ContactViewModels.cs
+++ b/src/Humans.Web/Models/ContactViewModels.cs
@@ -1,0 +1,50 @@
+using System.ComponentModel.DataAnnotations;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using NodaTime;
+
+namespace Humans.Web.Models;
+
+public class AdminContactListViewModel
+{
+    public List<AdminContactViewModel> Contacts { get; set; } = [];
+    public int TotalCount { get; set; }
+    public string? SearchTerm { get; set; }
+}
+
+public class AdminContactViewModel
+{
+    public Guid Id { get; set; }
+    public string Email { get; set; } = string.Empty;
+    public string DisplayName { get; set; } = string.Empty;
+    public ContactSource? ContactSource { get; set; }
+    public string? ExternalSourceId { get; set; }
+    public Instant CreatedAt { get; set; }
+    public bool HasCommunicationPreferences { get; set; }
+}
+
+public class AdminContactDetailViewModel
+{
+    public Guid UserId { get; set; }
+    public string Email { get; set; } = string.Empty;
+    public string DisplayName { get; set; } = string.Empty;
+    public ContactSource? ContactSource { get; set; }
+    public string? ExternalSourceId { get; set; }
+    public Instant CreatedAt { get; set; }
+    public IReadOnlyList<CommunicationPreference> CommunicationPreferences { get; set; } = [];
+    public IReadOnlyList<AuditLogEntry> AuditLog { get; set; } = [];
+}
+
+public class CreateContactViewModel
+{
+    [Required]
+    [EmailAddress]
+    public string Email { get; set; } = string.Empty;
+
+    [Required]
+    [MaxLength(256)]
+    public string DisplayName { get; set; } = string.Empty;
+
+    [Required]
+    public ContactSource Source { get; set; } = ContactSource.Manual;
+}

--- a/src/Humans.Web/Views/Human/ContactDetail.cshtml
+++ b/src/Humans.Web/Views/Human/ContactDetail.cshtml
@@ -1,0 +1,114 @@
+@model Humans.Web.Models.AdminContactDetailViewModel
+@{
+    ViewData["Title"] = $"Contact: {Model.DisplayName}";
+}
+
+<div class="mb-3">
+    <a asp-action="Contacts" class="btn btn-outline-secondary btn-sm">
+        <i class="fa-solid fa-arrow-left"></i> Back to Contacts
+    </a>
+</div>
+
+<h1>@Model.DisplayName</h1>
+<p class="text-muted">@Model.Email</p>
+
+<div class="row">
+    <div class="col-md-6">
+        <div class="card mb-4">
+            <div class="card-header">Contact Information</div>
+            <div class="card-body">
+                <dl class="row mb-0">
+                    <dt class="col-sm-4">Email</dt>
+                    <dd class="col-sm-8">@Model.Email</dd>
+
+                    <dt class="col-sm-4">Source</dt>
+                    <dd class="col-sm-8">
+                        <span class="badge bg-secondary">@(Model.ContactSource?.ToString() ?? "Unknown")</span>
+                    </dd>
+
+                    @if (!string.IsNullOrEmpty(Model.ExternalSourceId))
+                    {
+                        <dt class="col-sm-4">External ID</dt>
+                        <dd class="col-sm-8"><code>@Model.ExternalSourceId</code></dd>
+                    }
+
+                    <dt class="col-sm-4">Created</dt>
+                    <dd class="col-sm-8">@Model.CreatedAt.ToDisplayDate()</dd>
+                </dl>
+            </div>
+        </div>
+    </div>
+
+    <div class="col-md-6">
+        <div class="card mb-4">
+            <div class="card-header">Communication Preferences</div>
+            <div class="card-body">
+                @if (Model.CommunicationPreferences.Count == 0)
+                {
+                    <p class="text-muted mb-0">Using defaults.</p>
+                }
+                else
+                {
+                    <table class="table table-sm mb-0">
+                        <thead>
+                            <tr>
+                                <th>Category</th>
+                                <th>Status</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach (var pref in Model.CommunicationPreferences.OrderBy(p => p.Category))
+                            {
+                                <tr>
+                                    <td>@pref.Category</td>
+                                    <td>
+                                        @if (pref.OptedOut)
+                                        {
+                                            <span class="badge bg-danger">Opted Out</span>
+                                        }
+                                        else
+                                        {
+                                            <span class="badge bg-success">Opted In</span>
+                                        }
+                                    </td>
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
+                }
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="card">
+    <div class="card-header">Audit Log</div>
+    <div class="card-body p-0">
+        @if (Model.AuditLog.Count == 0)
+        {
+            <p class="text-muted text-center py-4 mb-0">No audit entries.</p>
+        }
+        else
+        {
+            <table class="table table-sm mb-0">
+                <thead>
+                    <tr>
+                        <th>When</th>
+                        <th>Action</th>
+                        <th>Description</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var entry in Model.AuditLog)
+                    {
+                        <tr>
+                            <td>@entry.OccurredAt.ToDisplayDate()</td>
+                            <td><code>@entry.Action</code></td>
+                            <td>@entry.Description</td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        }
+    </div>
+</div>

--- a/src/Humans.Web/Views/Human/Contacts.cshtml
+++ b/src/Humans.Web/Views/Human/Contacts.cshtml
@@ -1,0 +1,94 @@
+@model Humans.Web.Models.AdminContactListViewModel
+@{
+    ViewData["Title"] = "Contacts";
+}
+
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <h1>Contacts</h1>
+    <div class="d-flex align-items-center gap-3">
+        <span class="text-muted">@string.Format(Localizer["Admin_TotalCount"].Value, Model.TotalCount)</span>
+        <a asp-action="CreateContact" class="btn btn-primary btn-sm">
+            <i class="fa-solid fa-plus"></i> Add Contact
+        </a>
+    </div>
+</div>
+
+<div class="card mb-4">
+    <div class="card-body">
+        <form method="get" class="row g-3">
+            <div class="col-auto flex-grow-1">
+                <input type="text" name="search" class="form-control" placeholder="Search by name or email..."
+                       value="@Model.SearchTerm">
+            </div>
+            <div class="col-auto">
+                <button type="submit" class="btn btn-primary">@Localizer["Admin_Search"]</button>
+                @if (!string.IsNullOrEmpty(Model.SearchTerm))
+                {
+                    <a asp-action="Contacts" class="btn btn-outline-secondary">@Localizer["Admin_Clear"]</a>
+                }
+            </div>
+        </form>
+    </div>
+</div>
+
+<div class="mb-3">
+    <a asp-action="Humans" class="btn btn-outline-secondary btn-sm">
+        <i class="fa-solid fa-arrow-left"></i> Back to Humans
+    </a>
+</div>
+
+<div class="card">
+    <div class="card-body p-0">
+        @if (Model.Contacts.Count == 0)
+        {
+            <p class="text-muted text-center py-4 mb-0">No contacts found.</p>
+        }
+        else
+        {
+            <table class="table table-hover mb-0">
+                <thead>
+                    <tr>
+                        <th>Contact</th>
+                        <th>Source</th>
+                        <th>Created</th>
+                        <th>Preferences</th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var contact in Model.Contacts)
+                    {
+                        <tr>
+                            <td>
+                                <div>@contact.DisplayName</div>
+                                <small class="text-muted">@contact.Email</small>
+                            </td>
+                            <td>
+                                <span class="badge bg-secondary">@(contact.ContactSource?.ToString() ?? "Unknown")</span>
+                                @if (!string.IsNullOrEmpty(contact.ExternalSourceId))
+                                {
+                                    <br /><small class="text-muted">@contact.ExternalSourceId</small>
+                                }
+                            </td>
+                            <td>@contact.CreatedAt.ToDisplayDate()</td>
+                            <td>
+                                @if (contact.HasCommunicationPreferences)
+                                {
+                                    <span class="badge bg-success">Configured</span>
+                                }
+                                else
+                                {
+                                    <span class="badge bg-warning text-dark">Defaults</span>
+                                }
+                            </td>
+                            <td>
+                                <a asp-action="ContactDetail" asp-route-id="@contact.Id"
+                                   class="btn btn-sm btn-outline-primary">Detail</a>
+                            </td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        }
+    </div>
+</div>

--- a/src/Humans.Web/Views/Human/CreateContact.cshtml
+++ b/src/Humans.Web/Views/Human/CreateContact.cshtml
@@ -1,0 +1,43 @@
+@model Humans.Web.Models.CreateContactViewModel
+@{
+    ViewData["Title"] = "Create Contact";
+}
+
+<div class="mb-3">
+    <a asp-action="Contacts" class="btn btn-outline-secondary btn-sm">
+        <i class="fa-solid fa-arrow-left"></i> Back to Contacts
+    </a>
+</div>
+
+<h1>Create Contact</h1>
+<p class="text-muted">Add an external contact for communication preference tracking. Contacts can authenticate later via magic link or Google to claim their account.</p>
+
+<div class="card" style="max-width: 600px;">
+    <div class="card-body">
+        <form method="post" asp-action="CreateContact">
+            <div asp-validation-summary="All" class="text-danger mb-3"></div>
+
+            <div class="mb-3">
+                <label asp-for="Email" class="form-label">Email</label>
+                <input asp-for="Email" class="form-control" type="email" />
+                <span asp-validation-for="Email" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <label asp-for="DisplayName" class="form-label">Display Name</label>
+                <input asp-for="DisplayName" class="form-control" />
+                <span asp-validation-for="DisplayName" class="text-danger"></span>
+            </div>
+
+            <div class="mb-3">
+                <label asp-for="Source" class="form-label">Source</label>
+                <select asp-for="Source" class="form-select"
+                        asp-items="Html.GetEnumSelectList<Humans.Domain.Enums.ContactSource>()">
+                </select>
+                <span asp-validation-for="Source" class="text-danger"></span>
+            </div>
+
+            <button type="submit" class="btn btn-primary">Create Contact</button>
+        </form>
+    </div>
+</div>

--- a/src/Humans.Web/Views/Human/Humans.cshtml
+++ b/src/Humans.Web/Views/Human/Humans.cshtml
@@ -7,7 +7,12 @@
 
 <div class="d-flex justify-content-between align-items-center mb-4">
     <h1>@Localizer["AdminHumans_Title"]</h1>
-    <span class="text-muted">@string.Format(Localizer["Admin_TotalCount"].Value, Model.TotalCount)</span>
+    <div class="d-flex align-items-center gap-3">
+        <span class="text-muted">@string.Format(Localizer["Admin_TotalCount"].Value, Model.TotalCount)</span>
+        <a asp-action="Contacts" class="btn btn-outline-secondary btn-sm">
+            <i class="fa-solid fa-address-book"></i> Contacts
+        </a>
+    </div>
 </div>
 
 <div class="card mb-4">


### PR DESCRIPTION
## Summary

- Contacts (MailerLite, TicketTailor, manual) are pre-provisioned as real Identity users with no credentials
- When they authenticate via magic link or Google OAuth, they claim their existing account — no merge needed
- Reworks Aaron's PR #209: no AccountType enum, no lockout hacks, no merge service
- `ContactSource != null && LastLoginAt == null` identifies contacts
- Admin UI at `/Human/Admin/Contacts` (Board/Admin only): list, detail, create
- Feature spec: `docs/features/29-contact-accounts.md`

## What changed from Aaron's approach

| Aaron's PR #209 | This PR |
|------------------|---------|
| `AccountType` enum (Member/Contact/Deactivated) | `LastLoginAt == null` for never-authenticated |
| `LockoutEnd = MaxValue` to prevent login | No lockout — they just haven't authenticated yet |
| `MergeContactToMemberAsync` | No merge — the contact IS the user |
| Fights Identity (lockout hacks, merge flows) | Works with Identity (standard `UserManager.CreateAsync`) |

## Test plan

- [x] Create a contact manually via Admin UI
- [x] Verify contact appears in the contacts list
- [x] Verify duplicate email is rejected
- [x] Verify contact detail page shows info and audit log
- [ ] Send a magic link to a contact's email — verify they claim the existing account
- [ ] Verify claimed contact disappears from contacts list (LastLoginAt is now set)
- [ ] Verify Google OAuth with a contact's email links to existing account

🤖 Generated with [Claude Code](https://claude.com/claude-code)