### PR TITLE
feat: shift browse UX — date range, period filter, rota visibility (#210, #185)

### DIFF
--- a/.claude/DATA_MODEL.md
+++ b/.claude/DATA_MODEL.md
@@ -46,7 +46,7 @@
 | TicketAttendee | Individual ticket holder (issued ticket, multiple per order) |
 | TicketSyncState | Singleton tracking ticket sync operational state |
 | EventSettings | Singleton event config — dates, timezone, EE capacity, caps |
-| Rota | Shift container — belongs to department + event, with Period (Build/Event/Strike) and optional PracticalInfo |
+| Rota | Shift container — belongs to department + event, with Period (Build/Event/Strike), optional PracticalInfo, and IsVisibleToVolunteers visibility toggle (default true) |
 | Shift | Single work slot — DayOffset + StartTime + Duration + IsAllDay flag |
 | ShiftSignup | Links User to Shift with state machine (Pending/Confirmed/Refused/Bailed/Cancelled/NoShow), optional SignupBlockId for range signups |
 | GeneralAvailability | Per-user per-event day availability (AvailableDayOffsets stored as jsonb) |

--- a/docs/features/25-shift-management.md
+++ b/docs/features/25-shift-management.md
@@ -27,6 +27,7 @@ See `docs/specs/shift-management-spec.md` for the full design specification.
 
 **Acceptance Criteria:**
 - Create rota with name, period (Build/Event/Strike), priority (Normal/Important/Essential), signup policy (Public/RequireApproval), and optional practical info
+- Toggle rota visibility (`IsVisibleToVolunteers`) — hidden rotas are excluded from volunteer browse but remain visible to coordinators/admins, enabling staged rollout of signup
 - Build/strike rotas use all-day shifts with date-range signup; event rotas use time-slotted shifts
 - Bulk shift creation: `CreateBuildStrikeShiftsAsync` for build/strike rotas (one all-day shift per day offset with per-day staffing), `GenerateEventShiftsAsync` for event rotas (Cartesian product of day offsets x time slots)
 - Create individual shifts with day offset, start time, duration, min/max volunteers
@@ -39,7 +40,9 @@ See `docs/specs/shift-management-spec.md` for the full design specification.
 **So that** I can contribute to the event
 
 **Acceptance Criteria:**
-- Browse shifts filtered by department and date
+- Browse shifts filtered by department and date range (From/To date pickers; either may be omitted for open-ended range)
+- Filter by period (Set-up / Event / Strike toggle buttons)
+- Only rotas with `IsVisibleToVolunteers = true` appear (privileged users see all)
 - See fill status (confirmed count vs max)
 - Sign up for a shift (auto-confirmed for Public policy, pending for RequireApproval)
 - Date-range signup for build/strike rotas via `SignUpRangeAsync` — creates signups for all all-day shifts in the range, linked by a shared `SignupBlockId`
@@ -85,7 +88,7 @@ See `docs/specs/shift-management-spec.md` for the full design specification.
 | Entity | Purpose |
 |--------|---------|
 | `EventSettings` | Singleton event config: dates, timezone, EE capacity, browsing toggle |
-| `Rota` | Shift container per department+event, with period (Build/Event/Strike), priority, signup policy, and practical info |
+| `Rota` | Shift container per department+event, with period (Build/Event/Strike), priority, signup policy, practical info, and visibility toggle (`IsVisibleToVolunteers`, default true) |
 | `Shift` | Single work slot: day offset, time, duration, volunteer min/max; IsAllDay flag for build/strike shifts |
 | `ShiftSignup` | User-to-shift link with state machine; SignupBlockId groups range signups |
 | `GeneralAvailability` | Per-user per-event day availability (general volunteer pool) |
@@ -124,7 +127,7 @@ Pending --> Cancelled   (system: shift deleted, account deletion)
 
 | Route | Purpose |
 |-------|---------|
-| `/Shifts` | Browse all shifts (filtered by department/date) |
+| `/Shifts` | Browse all shifts (filtered by department, date range, period) |
 | `/Shifts/Mine` | View own signups (upcoming, pending, past) |
 | `/Shifts/Settings` | Admin: manage EventSettings |
 | `/Teams/{slug}/Shifts` | Coordinator: manage rotas/shifts for a department |

--- a/src/Humans.Application/Interfaces/IShiftManagementService.cs
+++ b/src/Humans.Application/Interfaces/IShiftManagementService.cs
@@ -149,8 +149,10 @@ public interface IShiftManagementService
     /// Gets all active shifts for browse page, with optional filtering. Includes full shifts.
     /// </summary>
     Task<IReadOnlyList<UrgentShift>> GetBrowseShiftsAsync(
-        Guid eventSettingsId, Guid? departmentId = null, LocalDate? date = null,
-        bool includeAdminOnly = false, bool includeSignups = false);
+        Guid eventSettingsId, Guid? departmentId = null,
+        LocalDate? fromDate = null, LocalDate? toDate = null,
+        bool includeAdminOnly = false, bool includeSignups = false,
+        bool includeHidden = false);
 
     /// <summary>
     /// Calculates the urgency score for a single shift.

--- a/src/Humans.Domain/Entities/Rota.cs
+++ b/src/Humans.Domain/Entities/Rota.cs
@@ -57,6 +57,12 @@ public class Rota
     public string? PracticalInfo { get; set; }
 
     /// <summary>
+    /// Whether this rota is visible to volunteers on the browse page.
+    /// Coordinators can disable to stage rollout of signup.
+    /// </summary>
+    public bool IsVisibleToVolunteers { get; set; } = true;
+
+    /// <summary>
     /// When this rota was created.
     /// </summary>
     public Instant CreatedAt { get; init; }

--- a/src/Humans.Infrastructure/Data/Configurations/RotaConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/RotaConfiguration.cs
@@ -24,6 +24,10 @@ public class RotaConfiguration : IEntityTypeConfiguration<Rota>
         builder.Property(e => e.PracticalInfo)
             .HasMaxLength(2000);
 
+        builder.Property(r => r.IsVisibleToVolunteers)
+            .HasDefaultValue(true)
+            .HasSentinel(true);
+
         builder.HasIndex(r => new { r.EventSettingsId, r.TeamId });
 
         builder.HasOne(r => r.EventSettings)

--- a/src/Humans.Infrastructure/Migrations/20260325224025_AddRotaIsVisibleToVolunteers.Designer.cs
+++ b/src/Humans.Infrastructure/Migrations/20260325224025_AddRotaIsVisibleToVolunteers.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Humans.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Humans.Infrastructure.Migrations
 {
     [DbContext(typeof(HumansDbContext))]
-    partial class HumansDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260325224025_AddRotaIsVisibleToVolunteers")]
+    partial class AddRotaIsVisibleToVolunteers
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Humans.Infrastructure/Migrations/20260325224025_AddRotaIsVisibleToVolunteers.cs
+++ b/src/Humans.Infrastructure/Migrations/20260325224025_AddRotaIsVisibleToVolunteers.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Humans.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRotaIsVisibleToVolunteers : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsVisibleToVolunteers",
+                table: "rotas",
+                type: "boolean",
+                nullable: false,
+                defaultValue: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsVisibleToVolunteers",
+                table: "rotas");
+        }
+    }
+}

--- a/src/Humans.Infrastructure/Services/ShiftManagementService.cs
+++ b/src/Humans.Infrastructure/Services/ShiftManagementService.cs
@@ -491,8 +491,10 @@ public class ShiftManagementService : IShiftManagementService
     }
 
     public async Task<IReadOnlyList<UrgentShift>> GetBrowseShiftsAsync(
-        Guid eventSettingsId, Guid? departmentId = null, LocalDate? date = null,
-        bool includeAdminOnly = false, bool includeSignups = false)
+        Guid eventSettingsId, Guid? departmentId = null,
+        LocalDate? fromDate = null, LocalDate? toDate = null,
+        bool includeAdminOnly = false, bool includeSignups = false,
+        bool includeHidden = false)
     {
         var es = await _dbContext.EventSettings.AsNoTracking()
             .FirstOrDefaultAsync(e => e.Id == eventSettingsId);
@@ -519,13 +521,22 @@ public class ShiftManagementService : IShiftManagementService
         if (!includeAdminOnly)
             query = query.Where(s => !s.AdminOnly);
 
+        if (!includeHidden)
+            query = query.Where(s => s.Rota.IsVisibleToVolunteers);
+
         if (departmentId.HasValue)
             query = query.Where(s => s.Rota.TeamId == departmentId.Value);
 
-        if (date.HasValue)
+        if (fromDate.HasValue)
         {
-            var dayOffset = Period.Between(es.GateOpeningDate, date.Value).Days;
-            query = query.Where(s => s.DayOffset == dayOffset);
+            var fromOffset = Period.Between(es.GateOpeningDate, fromDate.Value).Days;
+            query = query.Where(s => s.DayOffset >= fromOffset);
+        }
+
+        if (toDate.HasValue)
+        {
+            var toOffset = Period.Between(es.GateOpeningDate, toDate.Value).Days;
+            query = query.Where(s => s.DayOffset <= toOffset);
         }
 
         var shifts = await query.ToListAsync();

--- a/src/Humans.Web/Controllers/ShiftAdminController.cs
+++ b/src/Humans.Web/Controllers/ShiftAdminController.cs
@@ -363,6 +363,25 @@ public class ShiftAdminController : HumansTeamControllerBase
         return RedirectToAction(nameof(Index), new { slug });
     }
 
+    [HttpPost("Rotas/{rotaId}/ToggleVisibility")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> ToggleVisibility(string slug, Guid rotaId)
+    {
+        var (teamError, _, team) = await ResolveDepartmentManagementAsync(slug);
+        if (teamError is not null) return teamError;
+
+        var rota = await _shiftMgmt.GetRotaByIdAsync(rotaId);
+        if (rota is null) return NotFound();
+        if (rota.TeamId != team.Id) return NotFound();
+
+        rota.IsVisibleToVolunteers = !rota.IsVisibleToVolunteers;
+        await _shiftMgmt.UpdateRotaAsync(rota);
+
+        var label = rota.IsVisibleToVolunteers ? "visible to" : "hidden from";
+        SetSuccess($"Rota '{rota.Name}' is now {label} volunteers.");
+        return RedirectToAction(nameof(Index), new { slug });
+    }
+
     [HttpPost("Rotas/{rotaId}/Delete")]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> DeleteRota(string slug, Guid rotaId)

--- a/src/Humans.Web/Controllers/ShiftsController.cs
+++ b/src/Humans.Web/Controllers/ShiftsController.cs
@@ -40,7 +40,7 @@ public class ShiftsController : HumansControllerBase
     }
 
     [HttpGet("")]
-    public async Task<IActionResult> Index(Guid? departmentId, string? date, bool showFull = false)
+    public async Task<IActionResult> Index(Guid? departmentId, string? fromDate, string? toDate, string? period, bool showFull = false)
     {
         var (currentUserNotFound, user) = await ResolveCurrentUserOrChallengeAsync();
         if (currentUserNotFound is not null)
@@ -68,15 +68,28 @@ public class ShiftsController : HumansControllerBase
             .Where(s => s.Status is SignupStatus.Confirmed or SignupStatus.Pending)
             .ToDictionary(s => s.ShiftId, s => s.Status);
 
-        // Parse date filter
-        LocalDate? filterDate = null;
-        if (!string.IsNullOrEmpty(date) && LocalDatePattern.Iso.Parse(date) is { Success: true } parseResult)
-            filterDate = parseResult.Value;
+        // Parse date range filters
+        LocalDate? filterFromDate = null;
+        LocalDate? filterToDate = null;
+        if (!string.IsNullOrEmpty(fromDate) && LocalDatePattern.Iso.Parse(fromDate) is { Success: true } fromResult)
+            filterFromDate = fromResult.Value;
+        if (!string.IsNullOrEmpty(toDate) && LocalDatePattern.Iso.Parse(toDate) is { Success: true } toResult)
+            filterToDate = toResult.Value;
+
+        // Apply period filter — compute date boundaries from EventSettings offsets
+        if (!string.IsNullOrEmpty(period) && Enum.TryParse<ShiftPeriod>(period, true, out var parsedPeriod))
+        {
+            var (periodFrom, periodTo) = GetPeriodDateRange(es, parsedPeriod);
+            filterFromDate ??= periodFrom;
+            filterToDate ??= periodTo;
+        }
 
         // Build the browse view — show all active shifts, hide AdminOnly from regular volunteers
         var urgentShifts = await _shiftMgmt.GetBrowseShiftsAsync(
-            es.Id, departmentId: departmentId, date: filterDate,
-            includeAdminOnly: isPrivileged, includeSignups: isPrivileged);
+            es.Id, departmentId: departmentId,
+            fromDate: filterFromDate, toDate: filterToDate,
+            includeAdminOnly: isPrivileged, includeSignups: isPrivileged,
+            includeHidden: isPrivileged);
 
         // Group by department → rota → shift
         var departments = urgentShifts
@@ -147,7 +160,9 @@ public class ShiftsController : HumansControllerBase
         {
             EventSettings = es,
             FilterDepartmentId = departmentId,
-            FilterDate = date,
+            FilterFromDate = fromDate,
+            FilterToDate = toDate,
+            FilterPeriod = period,
             ShowFullShifts = showFull,
             UserSignupShiftIds = userSignupShiftIds,
             UserSignupStatuses = userSignupStatuses,
@@ -482,5 +497,24 @@ public class ShiftsController : HumansControllerBase
 
         SetSuccess("Event settings saved.");
         return RedirectToAction(nameof(Settings));
+    }
+
+    private static (LocalDate From, LocalDate To) GetPeriodDateRange(EventSettings es, ShiftPeriod period)
+    {
+        return period switch
+        {
+            ShiftPeriod.Build => (
+                es.GateOpeningDate.PlusDays(es.BuildStartOffset),
+                es.GateOpeningDate.PlusDays(-1)),
+            ShiftPeriod.Event => (
+                es.GateOpeningDate,
+                es.GateOpeningDate.PlusDays(es.EventEndOffset)),
+            ShiftPeriod.Strike => (
+                es.GateOpeningDate.PlusDays(es.EventEndOffset + 1),
+                es.GateOpeningDate.PlusDays(es.StrikeEndOffset)),
+            _ => (
+                es.GateOpeningDate.PlusDays(es.BuildStartOffset),
+                es.GateOpeningDate.PlusDays(es.StrikeEndOffset))
+        };
     }
 }

--- a/src/Humans.Web/Controllers/VolController.cs
+++ b/src/Humans.Web/Controllers/VolController.cs
@@ -116,7 +116,7 @@ public class VolController : HumansControllerBase
     }
 
     [HttpGet("Shifts")]
-    public async Task<IActionResult> Shifts(Guid? departmentId, string? date, bool showFull = false)
+    public async Task<IActionResult> Shifts(Guid? departmentId, string? fromDate, string? toDate, string? period, bool showFull = false)
     {
         try
         {
@@ -143,14 +143,40 @@ public class VolController : HumansControllerBase
                 .Where(s => s.Status is SignupStatus.Confirmed or SignupStatus.Pending)
                 .ToDictionary(s => s.ShiftId, s => s.Status);
 
-            // Parse date filter
-            LocalDate? filterDate = null;
-            if (!string.IsNullOrEmpty(date) && LocalDatePattern.Iso.Parse(date) is { Success: true } parseResult)
-                filterDate = parseResult.Value;
+            // Parse date range filters
+            LocalDate? filterFromDate = null;
+            LocalDate? filterToDate = null;
+            if (!string.IsNullOrEmpty(fromDate) && LocalDatePattern.Iso.Parse(fromDate) is { Success: true } fromResult)
+                filterFromDate = fromResult.Value;
+            if (!string.IsNullOrEmpty(toDate) && LocalDatePattern.Iso.Parse(toDate) is { Success: true } toResult)
+                filterToDate = toResult.Value;
+
+            // Apply period filter — compute date boundaries from EventSettings offsets
+            if (!string.IsNullOrEmpty(period) && Enum.TryParse<ShiftPeriod>(period, true, out var parsedPeriod))
+            {
+                var periodFrom = parsedPeriod switch
+                {
+                    ShiftPeriod.Build => es.GateOpeningDate.PlusDays(es.BuildStartOffset),
+                    ShiftPeriod.Event => es.GateOpeningDate,
+                    ShiftPeriod.Strike => es.GateOpeningDate.PlusDays(es.EventEndOffset + 1),
+                    _ => es.GateOpeningDate.PlusDays(es.BuildStartOffset)
+                };
+                var periodTo = parsedPeriod switch
+                {
+                    ShiftPeriod.Build => es.GateOpeningDate.PlusDays(-1),
+                    ShiftPeriod.Event => es.GateOpeningDate.PlusDays(es.EventEndOffset),
+                    ShiftPeriod.Strike => es.GateOpeningDate.PlusDays(es.StrikeEndOffset),
+                    _ => es.GateOpeningDate.PlusDays(es.StrikeEndOffset)
+                };
+                filterFromDate ??= periodFrom;
+                filterToDate ??= periodTo;
+            }
 
             var browseShifts = await _shiftMgmt.GetBrowseShiftsAsync(
-                es.Id, departmentId: departmentId, date: filterDate,
-                includeAdminOnly: isPrivileged, includeSignups: isPrivileged);
+                es.Id, departmentId: departmentId,
+                fromDate: filterFromDate, toDate: filterToDate,
+                includeAdminOnly: isPrivileged, includeSignups: isPrivileged,
+                includeHidden: isPrivileged);
 
             // Group by department -> rota -> shift
             var departments = browseShifts
@@ -209,7 +235,9 @@ public class VolController : HumansControllerBase
             {
                 EventSettings = es,
                 FilterDepartmentId = departmentId,
-                FilterDate = date,
+                FilterFromDate = fromDate,
+                FilterToDate = toDate,
+                FilterPeriod = period,
                 ShowFullShifts = showFull,
                 UserSignupShiftIds = userSignupShiftIds,
                 UserSignupStatuses = userSignupStatuses,

--- a/src/Humans.Web/Models/ShiftViewModels.cs
+++ b/src/Humans.Web/Models/ShiftViewModels.cs
@@ -125,7 +125,9 @@ public class ShiftBrowseViewModel
     public List<DepartmentShiftGroup> Departments { get; set; } = [];
     public List<DepartmentOption> AllDepartments { get; set; } = [];
     public Guid? FilterDepartmentId { get; set; }
-    public string? FilterDate { get; set; }
+    public string? FilterFromDate { get; set; }
+    public string? FilterToDate { get; set; }
+    public string? FilterPeriod { get; set; }
     public bool ShowFullShifts { get; set; }
     public HashSet<Guid> UserSignupShiftIds { get; set; } = [];
     public Dictionary<Guid, SignupStatus> UserSignupStatuses { get; set; } = new();

--- a/src/Humans.Web/Models/Vol/ShiftBrowserViewModel.cs
+++ b/src/Humans.Web/Models/Vol/ShiftBrowserViewModel.cs
@@ -9,7 +9,9 @@ public class ShiftBrowserViewModel
     public List<DepartmentShiftGroup> Departments { get; set; } = [];
     public List<DepartmentOption> AllDepartments { get; set; } = [];
     public Guid? FilterDepartmentId { get; set; }
-    public string? FilterDate { get; set; }
+    public string? FilterFromDate { get; set; }
+    public string? FilterToDate { get; set; }
+    public string? FilterPeriod { get; set; }
     public bool ShowFullShifts { get; set; }
     public HashSet<Guid> UserSignupShiftIds { get; set; } = [];
     public Dictionary<Guid, SignupStatus> UserSignupStatuses { get; set; } = new();

--- a/src/Humans.Web/Views/ShiftAdmin/Index.cshtml
+++ b/src/Humans.Web/Views/ShiftAdmin/Index.cshtml
@@ -128,6 +128,10 @@
                     <span class="badge bg-secondary ms-2">@rota.Priority</span>
                     <span class="badge bg-info ms-1">@rota.Policy</span>
                     <span class="badge bg-secondary ms-1">@(rota.Period == RotaPeriod.Build ? "Set-up" : rota.Period.ToString())</span>
+                    @if (!rota.IsVisibleToVolunteers)
+                    {
+                        <span class="badge bg-warning text-dark ms-1"><i class="fa-solid fa-eye-slash me-1"></i>Hidden</span>
+                    }
                     @if (!string.IsNullOrEmpty(rota.Description))
                     {
                         <div class="text-muted small mt-1">@Html.SanitizedMarkdown(rota.Description)</div>
@@ -139,7 +143,22 @@
                 </div>
                 @if (Model.CanManageShifts)
                 {
-                    <div>
+                    <div class="d-flex gap-1">
+                        <form asp-action="ToggleVisibility" asp-route-slug="@Model.Department.Slug" asp-route-rotaId="@rota.Id" method="post" class="d-inline">
+                            @Html.AntiForgeryToken()
+                            @if (rota.IsVisibleToVolunteers)
+                            {
+                                <button type="submit" class="btn btn-sm btn-outline-warning" title="Hide from volunteers">
+                                    <i class="fa-solid fa-eye-slash"></i>
+                                </button>
+                            }
+                            else
+                            {
+                                <button type="submit" class="btn btn-sm btn-warning" title="Show to volunteers">
+                                    <i class="fa-solid fa-eye"></i>
+                                </button>
+                            }
+                        </form>
                         <button class="btn btn-sm btn-outline-primary" type="button" data-bs-toggle="collapse" data-bs-target="#edit-rota-@rota.Id.ToString("N")">Edit</button>
                         <form asp-action="DeleteRota" asp-route-slug="@Model.Department.Slug" asp-route-rotaId="@rota.Id" method="post" class="d-inline">
                             @Html.AntiForgeryToken()

--- a/src/Humans.Web/Views/Shifts/Index.cshtml
+++ b/src/Humans.Web/Views/Shifts/Index.cshtml
@@ -63,20 +63,40 @@
             </select>
         </div>
         <div class="col-auto">
-            <label class="form-label mb-1">Date</label>
-            <input type="date" name="date" class="form-control form-control-sm" value="@Model.FilterDate"
+            <label class="form-label mb-1">From</label>
+            <input type="date" name="fromDate" class="form-control form-control-sm" value="@Model.FilterFromDate"
                    min="@Model.EventSettings.GateOpeningDate.PlusDays(Model.EventSettings.BuildStartOffset).ToString("yyyy-MM-dd", null)"
                    max="@Model.EventSettings.GateOpeningDate.PlusDays(Model.EventSettings.StrikeEndOffset).ToString("yyyy-MM-dd", null)" />
         </div>
-        @if (Model.FilterDepartmentId.HasValue || !string.IsNullOrEmpty(Model.FilterDate))
+        <div class="col-auto">
+            <label class="form-label mb-1">To</label>
+            <input type="date" name="toDate" class="form-control form-control-sm" value="@Model.FilterToDate"
+                   min="@Model.EventSettings.GateOpeningDate.PlusDays(Model.EventSettings.BuildStartOffset).ToString("yyyy-MM-dd", null)"
+                   max="@Model.EventSettings.GateOpeningDate.PlusDays(Model.EventSettings.StrikeEndOffset).ToString("yyyy-MM-dd", null)" />
+        </div>
+        @if (Model.FilterDepartmentId.HasValue || !string.IsNullOrEmpty(Model.FilterFromDate) || !string.IsNullOrEmpty(Model.FilterToDate) || !string.IsNullOrEmpty(Model.FilterPeriod))
         {
             <div class="col-auto">
                 <a asp-action="Index" class="btn btn-sm btn-outline-secondary">Clear Filters</a>
             </div>
         }
+        <input type="hidden" name="period" value="@Model.FilterPeriod" />
     </form>
+    @{
+        var activePeriod = Model.FilterPeriod ?? "";
+    }
+    <div class="btn-group mb-3" role="group" aria-label="Period filter">
+        <a href="@Url.Action("Index", new { departmentId = Model.FilterDepartmentId, fromDate = Model.FilterFromDate, toDate = Model.FilterToDate })"
+           class="btn btn-sm @(string.IsNullOrEmpty(activePeriod) ? "btn-primary" : "btn-outline-primary")">All</a>
+        <a href="@Url.Action("Index", new { departmentId = Model.FilterDepartmentId, period = "Build" })"
+           class="btn btn-sm @(activePeriod == "Build" ? "btn-info" : "btn-outline-info")">Set-up</a>
+        <a href="@Url.Action("Index", new { departmentId = Model.FilterDepartmentId, period = "Event" })"
+           class="btn btn-sm @(activePeriod == "Event" ? "btn-success" : "btn-outline-success")">Event</a>
+        <a href="@Url.Action("Index", new { departmentId = Model.FilterDepartmentId, period = "Strike" })"
+           class="btn btn-sm @(activePeriod == "Strike" ? "btn-secondary" : "btn-outline-secondary")">Strike</a>
+    </div>
     <script>
-        document.querySelectorAll('[name="departmentId"], [name="date"]').forEach(function(el) {
+        document.querySelectorAll('[name="departmentId"], [name="fromDate"], [name="toDate"]').forEach(function(el) {
             el.addEventListener('change', function() { this.form.submit(); });
         });
     </script>
@@ -134,6 +154,10 @@
                                 <span class="badge bg-warning text-dark ms-1">Important</span>
                             }
                             <span class="badge @(rotaGroup.Rota.Period switch { RotaPeriod.Build => "bg-info", RotaPeriod.Strike => "bg-secondary", RotaPeriod.All => "bg-primary", _ => "bg-success" }) ms-1">@(rotaGroup.Rota.Period switch { RotaPeriod.Build => "Set-up", RotaPeriod.All => "All Phases", _ => rotaGroup.Rota.Period.ToString() })</span>
+                            @if (!rotaGroup.Rota.IsVisibleToVolunteers)
+                            {
+                                <span class="badge bg-warning text-dark ms-1"><i class="fa-solid fa-eye-slash me-1"></i>Hidden</span>
+                            }
                         </h6>
                         @if (!string.IsNullOrEmpty(rotaGroup.Rota.Description))
                         {

--- a/src/Humans.Web/Views/Vol/Shifts.cshtml
+++ b/src/Humans.Web/Views/Vol/Shifts.cshtml
@@ -33,20 +33,40 @@
         </select>
     </div>
     <div class="col-auto">
-        <label class="form-label mb-1">Date</label>
-        <input type="date" name="date" class="form-control form-control-sm" value="@Model.FilterDate"
+        <label class="form-label mb-1">From</label>
+        <input type="date" name="fromDate" class="form-control form-control-sm" value="@Model.FilterFromDate"
                min="@es.GateOpeningDate.PlusDays(es.BuildStartOffset).ToString("yyyy-MM-dd", null)"
                max="@es.GateOpeningDate.PlusDays(es.StrikeEndOffset).ToString("yyyy-MM-dd", null)" />
     </div>
-    @if (Model.FilterDepartmentId.HasValue || !string.IsNullOrEmpty(Model.FilterDate))
+    <div class="col-auto">
+        <label class="form-label mb-1">To</label>
+        <input type="date" name="toDate" class="form-control form-control-sm" value="@Model.FilterToDate"
+               min="@es.GateOpeningDate.PlusDays(es.BuildStartOffset).ToString("yyyy-MM-dd", null)"
+               max="@es.GateOpeningDate.PlusDays(es.StrikeEndOffset).ToString("yyyy-MM-dd", null)" />
+    </div>
+    @if (Model.FilterDepartmentId.HasValue || !string.IsNullOrEmpty(Model.FilterFromDate) || !string.IsNullOrEmpty(Model.FilterToDate) || !string.IsNullOrEmpty(Model.FilterPeriod))
     {
         <div class="col-auto">
             <a asp-action="Shifts" class="btn btn-sm btn-outline-secondary">Clear Filters</a>
         </div>
     }
+    <input type="hidden" name="period" value="@Model.FilterPeriod" />
 </form>
+@{
+    var activePeriod = Model.FilterPeriod ?? "";
+}
+<div class="btn-group mb-3" role="group" aria-label="Period filter">
+    <a href="@Url.Action("Shifts", new { departmentId = Model.FilterDepartmentId, fromDate = Model.FilterFromDate, toDate = Model.FilterToDate })"
+       class="btn btn-sm @(string.IsNullOrEmpty(activePeriod) ? "btn-primary" : "btn-outline-primary")">All</a>
+    <a href="@Url.Action("Shifts", new { departmentId = Model.FilterDepartmentId, period = "Build" })"
+       class="btn btn-sm @(activePeriod == "Build" ? "btn-info" : "btn-outline-info")">Set-up</a>
+    <a href="@Url.Action("Shifts", new { departmentId = Model.FilterDepartmentId, period = "Event" })"
+       class="btn btn-sm @(activePeriod == "Event" ? "btn-success" : "btn-outline-success")">Event</a>
+    <a href="@Url.Action("Shifts", new { departmentId = Model.FilterDepartmentId, period = "Strike" })"
+       class="btn btn-sm @(activePeriod == "Strike" ? "btn-secondary" : "btn-outline-secondary")">Strike</a>
+</div>
 <script>
-    document.querySelectorAll('[name="departmentId"], [name="date"]').forEach(function(el) {
+    document.querySelectorAll('[name="departmentId"], [name="fromDate"], [name="toDate"]').forEach(function(el) {
         el.addEventListener('change', function() { this.form.submit(); });
     });
 </script>


### PR DESCRIPTION
## Summary

- **#210 — Date range filter:** Replace single date picker with From/To date inputs on `/Shifts` and `/Vol/Shifts`. Either date can be omitted for an open-ended range. Min/max constraints preserved.
- **#185 — Period filter:** Set-up / Event / Strike toggle buttons on both browse pages. Computes date boundaries from EventSettings offsets.
- **#185 — Rota visibility toggle:** `IsVisibleToVolunteers` bool on Rota entity (default true). Coordinators toggle via eye icon on ShiftAdmin page. Hidden rotas excluded from volunteer browse, visible to privileged users with "Hidden" badge.
- **EF migration:** Adds `IsVisibleToVolunteers` column to `rotas` table (default true). **Will need regeneration after Batch 3's migration merges.**

## Files changed

| Area | Files |
|------|-------|
| Domain | `Rota.cs` — new `IsVisibleToVolunteers` property |
| Application | `IShiftManagementService.cs` — `fromDate`/`toDate`/`includeHidden` params |
| Infrastructure | `ShiftManagementService.cs` — range filter + visibility filter |
| Infrastructure | `RotaConfiguration.cs` — column config with `HasDefaultValue(true).HasSentinel(true)` |
| Infrastructure | Migration — `AddRotaIsVisibleToVolunteers` |
| Web/Controllers | `ShiftsController`, `VolController` — date range + period parsing |
| Web/Controllers | `ShiftAdminController` — `ToggleVisibility` action |
| Web/Views | `Vol/Shifts.cshtml`, `Shifts/Index.cshtml` — From/To inputs + period toggles |
| Web/Views | `ShiftAdmin/Index.cshtml` — visibility toggle button + Hidden badge |
| Docs | `25-shift-management.md`, `DATA_MODEL.md` — updated |

## Test plan

- [x] Browse `/Shifts` — verify From/To date pickers replace single Date picker
- [x] Set only From date — shows shifts from that date onwards
- [x] Set only To date — shows shifts up to that date
- [x] Set both — shows shifts in range (inclusive)
- [x] Click Set-up/Event/Strike toggle — filters to correct period
- [ ] Period + date range combined — both filters apply
- [x] Clear Filters link resets all
- [x] `/Vol/Shifts` — same filter behavior
- [x] ShiftAdmin page — toggle eye icon to hide/show rota
- [x] Hidden rota disappears from volunteer browse, stays in admin browse with "Hidden" badge
- [x] Re-enable hidden rota — reappears for volunteers
- [ ] Migration applies cleanly: `dotnet ef database update`

🤖 Generated with [Claude Code](https://claude.com/claude-code)