### PR TITLE
feat: add HumanAdmin role

### DIFF
--- a/src/Humans.Domain/Constants/RoleGroups.cs
+++ b/src/Humans.Domain/Constants/RoleGroups.cs
@@ -24,4 +24,9 @@ public static class RoleGroups
     public const string TicketAdminOrAdmin = RoleNames.TicketAdmin + "," + RoleNames.Admin;
 
     public const string FeedbackAdminOrAdmin = RoleNames.FeedbackAdmin + "," + RoleNames.Admin;
+
+    public const string HumanAdminBoardOrAdmin =
+        RoleNames.HumanAdmin + "," + RoleNames.Board + "," + RoleNames.Admin;
+
+    public const string HumanAdminOrAdmin = RoleNames.HumanAdmin + "," + RoleNames.Admin;
 }

--- a/src/Humans.Domain/Constants/RoleNames.cs
+++ b/src/Humans.Domain/Constants/RoleNames.cs
@@ -56,4 +56,10 @@ public static class RoleNames
     /// manage feedback status, and link GitHub issues.
     /// </summary>
     public const string FeedbackAdmin = "FeedbackAdmin";
+
+    /// <summary>
+    /// Human Administrator — can view human admin pages, approve/suspend/reject humans,
+    /// provision @nobodies.team email accounts, and manage role assignments.
+    /// </summary>
+    public const string HumanAdmin = "HumanAdmin";
 }

--- a/src/Humans.Web/Authorization/RoleChecks.cs
+++ b/src/Humans.Web/Authorization/RoleChecks.cs
@@ -9,6 +9,7 @@ public static class RoleChecks
     [
         RoleNames.Admin,
         RoleNames.Board,
+        RoleNames.HumanAdmin,
         RoleNames.TeamsAdmin,
         RoleNames.CampAdmin,
         RoleNames.TicketAdmin,
@@ -21,6 +22,7 @@ public static class RoleChecks
     private static readonly string[] BoardAssignableRoles =
     [
         RoleNames.Board,
+        RoleNames.HumanAdmin,
         RoleNames.TeamsAdmin,
         RoleNames.CampAdmin,
         RoleNames.TicketAdmin,
@@ -81,6 +83,7 @@ public static class RoleChecks
     {
         return IsTeamsAdminBoardOrAdmin(user) ||
                IsCampAdmin(user) ||
+               IsHumanAdmin(user) ||
                user.IsInRole(RoleNames.TicketAdmin) ||
                user.IsInRole(RoleNames.NoInfoAdmin) ||
                user.IsInRole(RoleNames.ConsentCoordinator) ||
@@ -89,7 +92,21 @@ public static class RoleChecks
 
     public static IReadOnlyList<string> GetAssignableRoles(ClaimsPrincipal user)
     {
-        return IsAdmin(user) ? AdminAssignableRoles : BoardAssignableRoles;
+        if (IsAdmin(user))
+            return AdminAssignableRoles;
+        if (IsBoard(user) || IsHumanAdmin(user))
+            return BoardAssignableRoles;
+        return [];
+    }
+
+    public static bool IsHumanAdmin(ClaimsPrincipal user)
+    {
+        return user.IsInRole(RoleNames.HumanAdmin);
+    }
+
+    public static bool IsHumanAdminBoardOrAdmin(ClaimsPrincipal user)
+    {
+        return IsAdminOrBoard(user) || IsHumanAdmin(user);
     }
 
     public static bool IsFeedbackAdmin(ClaimsPrincipal user)
@@ -104,9 +121,10 @@ public static class RoleChecks
             return true;
         }
 
-        if (IsBoard(user))
+        if (IsBoard(user) || IsHumanAdmin(user))
         {
             return string.Equals(roleName, RoleNames.Board, StringComparison.Ordinal) ||
+                   string.Equals(roleName, RoleNames.HumanAdmin, StringComparison.Ordinal) ||
                    string.Equals(roleName, RoleNames.TeamsAdmin, StringComparison.Ordinal) ||
                    string.Equals(roleName, RoleNames.ConsentCoordinator, StringComparison.Ordinal) ||
                    string.Equals(roleName, RoleNames.VolunteerCoordinator, StringComparison.Ordinal) ||

--- a/src/Humans.Web/Controllers/HumanController.cs
+++ b/src/Humans.Web/Controllers/HumanController.cs
@@ -252,7 +252,7 @@ public class HumanController : HumansControllerBase
         return RedirectToAction(nameof(View), new { id });
     }
 
-    [Authorize(Roles = RoleGroups.BoardOrAdmin)]
+    [Authorize(Roles = RoleGroups.HumanAdminBoardOrAdmin)]
     [HttpGet("Admin")]
     public async Task<IActionResult> Humans(string? search, string? filter, string sort = "name", string dir = "asc", int page = 1)
     {
@@ -323,7 +323,7 @@ public class HumanController : HumansControllerBase
         return View(viewModel);
     }
 
-    [Authorize(Roles = RoleGroups.BoardOrAdmin)]
+    [Authorize(Roles = RoleGroups.HumanAdminBoardOrAdmin)]
     [HttpGet("{id:guid}/Admin")]
     public async Task<IActionResult> HumanDetail(Guid id)
     {
@@ -407,7 +407,7 @@ public class HumanController : HumansControllerBase
         return View(viewModel);
     }
 
-    [Authorize(Roles = RoleNames.Admin)]
+    [Authorize(Roles = RoleGroups.HumanAdminOrAdmin)]
     [HttpPost("{id:guid}/ProvisionEmail")]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> ProvisionEmail(Guid id, string emailPrefix)
@@ -478,7 +478,7 @@ public class HumanController : HumansControllerBase
         return RedirectToAction(nameof(HumanDetail), new { id });
     }
 
-    [Authorize(Roles = RoleGroups.BoardOrAdmin)]
+    [Authorize(Roles = RoleGroups.HumanAdminBoardOrAdmin)]
     [HttpGet("{id:guid}/Outbox")]
     public async Task<IActionResult> Outbox(Guid id)
     {
@@ -491,7 +491,7 @@ public class HumanController : HumansControllerBase
         return View("~/Views/Profile/Outbox.cshtml", messages);
     }
 
-    [Authorize(Roles = RoleGroups.BoardOrAdmin)]
+    [Authorize(Roles = RoleGroups.HumanAdminBoardOrAdmin)]
     [HttpPost("{id:guid}/Admin/Suspend")]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> SuspendHuman(Guid id, string? notes)
@@ -508,7 +508,7 @@ public class HumanController : HumansControllerBase
         return RedirectToAction(nameof(HumanDetail), new { id });
     }
 
-    [Authorize(Roles = RoleGroups.BoardOrAdmin)]
+    [Authorize(Roles = RoleGroups.HumanAdminBoardOrAdmin)]
     [HttpPost("{id:guid}/Admin/Unsuspend")]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> UnsuspendHuman(Guid id)
@@ -525,7 +525,7 @@ public class HumanController : HumansControllerBase
         return RedirectToAction(nameof(HumanDetail), new { id });
     }
 
-    [Authorize(Roles = RoleGroups.BoardOrAdmin)]
+    [Authorize(Roles = RoleGroups.HumanAdminBoardOrAdmin)]
     [HttpPost("{id:guid}/Admin/Approve")]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> ApproveVolunteer(Guid id)
@@ -542,7 +542,7 @@ public class HumanController : HumansControllerBase
         return RedirectToAction(nameof(HumanDetail), new { id });
     }
 
-    [Authorize(Roles = RoleGroups.BoardOrAdmin)]
+    [Authorize(Roles = RoleGroups.HumanAdminBoardOrAdmin)]
     [HttpPost("{id:guid}/Admin/Reject")]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> RejectSignup(Guid id, string? reason)
@@ -565,7 +565,7 @@ public class HumanController : HumansControllerBase
         return RedirectToAction(nameof(HumanDetail), new { id });
     }
 
-    [Authorize(Roles = RoleGroups.BoardOrAdmin)]
+    [Authorize(Roles = RoleGroups.HumanAdminBoardOrAdmin)]
     [HttpGet("{id:guid}/Admin/GoogleSyncAudit")]
     public async Task<IActionResult> HumanGoogleSyncAudit(Guid id)
     {
@@ -584,7 +584,7 @@ public class HumanController : HumansControllerBase
             entries);
     }
 
-    [Authorize(Roles = RoleGroups.BoardOrAdmin)]
+    [Authorize(Roles = RoleGroups.HumanAdminBoardOrAdmin)]
     [HttpGet("{id:guid}/Admin/Roles/Add")]
     public async Task<IActionResult> AddRole(Guid id)
     {
@@ -604,7 +604,7 @@ public class HumanController : HumansControllerBase
         return View(viewModel);
     }
 
-    [Authorize(Roles = RoleGroups.BoardOrAdmin)]
+    [Authorize(Roles = RoleGroups.HumanAdminBoardOrAdmin)]
     [HttpPost("{id:guid}/Admin/Roles/Add")]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> AddRole(Guid id, CreateRoleAssignmentViewModel model)
@@ -649,7 +649,7 @@ public class HumanController : HumansControllerBase
         return RedirectToAction(nameof(HumanDetail), new { id });
     }
 
-    [Authorize(Roles = RoleGroups.BoardOrAdmin)]
+    [Authorize(Roles = RoleGroups.HumanAdminBoardOrAdmin)]
     [HttpPost("{id:guid}/Admin/Roles/{roleId:guid}/End")]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> EndRole(Guid id, Guid roleId, string? notes)
@@ -686,7 +686,7 @@ public class HumanController : HumansControllerBase
         return RedirectToAction(nameof(HumanDetail), new { id = roleAssignment.UserId });
     }
 
-    [Authorize(Roles = RoleGroups.BoardOrAdmin)]
+    [Authorize(Roles = RoleGroups.HumanAdminBoardOrAdmin)]
     [HttpGet("Admin/Contacts")]
     public async Task<IActionResult> Contacts(string? search)
     {
@@ -720,7 +720,7 @@ public class HumanController : HumansControllerBase
         }
     }
 
-    [Authorize(Roles = RoleGroups.BoardOrAdmin)]
+    [Authorize(Roles = RoleGroups.HumanAdminBoardOrAdmin)]
     [HttpGet("Admin/Contacts/{id:guid}")]
     public async Task<IActionResult> ContactDetail(Guid id)
     {
@@ -758,14 +758,14 @@ public class HumanController : HumansControllerBase
         }
     }
 
-    [Authorize(Roles = RoleGroups.BoardOrAdmin)]
+    [Authorize(Roles = RoleGroups.HumanAdminBoardOrAdmin)]
     [HttpGet("Admin/Contacts/Create")]
     public IActionResult CreateContact()
     {
         return View(new CreateContactViewModel());
     }
 
-    [Authorize(Roles = RoleGroups.BoardOrAdmin)]
+    [Authorize(Roles = RoleGroups.HumanAdminBoardOrAdmin)]
     [HttpPost("Admin/Contacts/Create")]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> CreateContact(CreateContactViewModel model)

--- a/src/Humans.Web/Views/Profile/Index.cshtml
+++ b/src/Humans.Web/Views/Profile/Index.cshtml
@@ -9,7 +9,7 @@
             <h1>@(Model.IsOwnProfile ? Localizer["Profile_Title"] : Model.DisplayName)</h1>
             <div class="d-flex gap-2">
                 <vc:access-matrix section="Profile" />
-                @if (Humans.Web.Authorization.RoleChecks.IsAdminOrBoard(User))
+                @if (Humans.Web.Authorization.RoleChecks.IsHumanAdminBoardOrAdmin(User))
                 {
                     <human-link user-id="@Model.UserId" display-name="Admin" admin="true" class="btn btn-sm btn-outline-secondary">
                         <i class="fa-solid fa-user-shield"></i> Admin

--- a/src/Humans.Web/Views/Shared/_Layout.cshtml
+++ b/src/Humans.Web/Views/Shared/_Layout.cshtml
@@ -85,6 +85,12 @@
                                 <a class="nav-link" asp-area="" asp-controller="Board" asp-action="Index">@Localizer["Nav_Board"]</a>
                             </li>
                         }
+                        @if (Humans.Web.Authorization.RoleChecks.IsHumanAdmin(User) && !Humans.Web.Authorization.RoleChecks.IsAdminOrBoard(User))
+                        {
+                            <li class="nav-item">
+                                <a class="nav-link" asp-area="" asp-controller="Human" asp-action="Humans">Humans</a>
+                            </li>
+                        }
                         @if (Humans.Web.Authorization.RoleChecks.IsAdmin(User))
                         {
                             <li class="nav-item">


### PR DESCRIPTION
## Summary
- Adds new `HumanAdmin` role for delegated human administration
- HumanAdmin can access `/Human/{id}/Admin` pages and all actions: approve, suspend, reject, provision @nobodies.team emails, manage role assignments
- Previously these required Board or Admin — now HumanAdmin is sufficient
- HumanAdmin gets a direct "Humans" nav link (Board/Admin users already reach it via Board dashboard)
- No migration needed — `RoleAssignmentClaimsTransformation` picks up any role name automatically

## Changes
- `RoleNames.cs` — new `HumanAdmin` constant
- `RoleGroups.cs` — new `HumanAdminBoardOrAdmin` and `HumanAdminOrAdmin` groups
- `HumanController.cs` — all admin actions: `BoardOrAdmin` → `HumanAdminBoardOrAdmin`; `ProvisionEmail`: `Admin` → `HumanAdminOrAdmin`
- `RoleChecks.cs` — helper methods, assignable roles, membership bypass, role management permissions
- `_Layout.cshtml` — "Humans" nav link for HumanAdmin users who don't also have Board/Admin

## Test plan
- [ ] Assign HumanAdmin role to a test user via dev login
- [ ] Verify "Humans" nav link appears
- [ ] Navigate to `/Human/{id}/Admin` — should load
- [ ] Test approve, suspend, unsuspend actions
- [ ] Test @nobodies.team email provisioning from the admin page
- [ ] Test add/end role assignment
- [ ] Verify Board and Admin access is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)