### PR TITLE
fix: add capacity and EE checks to batch shift approval

### DIFF
--- a/src/Humans.Application/Interfaces/IShiftSignupService.cs
+++ b/src/Humans.Application/Interfaces/IShiftSignupService.cs
@@ -82,6 +82,11 @@ public interface IShiftSignupService
     Task<ShiftSignup?> GetByIdAsync(Guid signupId);
 
     /// <summary>
+    /// Gets the first signup in a block with Shift.Rota included (for team ownership checks).
+    /// </summary>
+    Task<ShiftSignup?> GetByBlockIdFirstAsync(Guid signupBlockId);
+
+    /// <summary>
     /// Gets all signups for a shift.
     /// </summary>
     Task<IReadOnlyList<ShiftSignup>> GetByShiftAsync(Guid shiftId);

--- a/src/Humans.Infrastructure/Services/ShiftSignupService.cs
+++ b/src/Humans.Infrastructure/Services/ShiftSignupService.cs
@@ -552,9 +552,34 @@ public class ShiftSignupService : IShiftSignupService
 
         if (signups.Count == 0) return SignupResult.Fail("No pending signups found for this block.");
 
-        string? warning = null;
+        var warnings = new List<string>();
+        var now = _clock.GetCurrentInstant();
+
         foreach (var signup in signups)
         {
+            var es = signup.Shift.Rota.EventSettings;
+
+            // Capacity check (same as single-item ApproveAsync)
+            var confirmedCount = signup.Shift.ShiftSignups.Count(d => d.Status == SignupStatus.Confirmed);
+            if (confirmedCount >= signup.Shift.MaxVolunteers)
+                warnings.Add($"Day {signup.Shift.DayOffset} is at capacity.");
+
+            // EE cap revalidation for build shifts
+            if (signup.Shift.IsEarlyEntry)
+            {
+                var eeWarning = await CheckEeCapAsync(es, signup.Shift.DayOffset);
+                if (eeWarning is not null)
+                    warnings.Add(eeWarning);
+            }
+
+            // EE freeze check
+            if (signup.Shift.IsEarlyEntry && es.EarlyEntryClose.HasValue && now >= es.EarlyEntryClose.Value)
+            {
+                var isPrivileged = await IsPrivilegedAsync(reviewerUserId, signup.Shift.Rota.TeamId);
+                if (!isPrivileged)
+                    return SignupResult.Fail("Cannot approve build shift signups after early entry close.");
+            }
+
             signup.Confirm(reviewerUserId, _clock);
 
             await _auditLogService.LogAsync(
@@ -564,6 +589,7 @@ public class ShiftSignupService : IShiftSignupService
         }
 
         await _dbContext.SaveChangesAsync();
+        var warning = warnings.Count > 0 ? string.Join(" ", warnings.Distinct(StringComparer.Ordinal)) : null;
         return SignupResult.Ok(signups[0], warning);
     }
 

--- a/src/Humans.Infrastructure/Services/ShiftSignupService.cs
+++ b/src/Humans.Infrastructure/Services/ShiftSignupService.cs
@@ -649,6 +649,13 @@ public class ShiftSignupService : IShiftSignupService
             .FirstOrDefaultAsync(d => d.Id == signupId);
     }
 
+    public async Task<ShiftSignup?> GetByBlockIdFirstAsync(Guid signupBlockId)
+    {
+        return await _dbContext.ShiftSignups
+            .Include(s => s.Shift).ThenInclude(s => s.Rota)
+            .FirstOrDefaultAsync(s => s.SignupBlockId == signupBlockId);
+    }
+
     public async Task<IReadOnlyList<ShiftSignup>> GetByShiftAsync(Guid shiftId)
     {
         return await _dbContext.ShiftSignups

--- a/src/Humans.Web/Controllers/ShiftAdminController.cs
+++ b/src/Humans.Web/Controllers/ShiftAdminController.cs
@@ -449,8 +449,11 @@ public class ShiftAdminController : HumansTeamControllerBase
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> ApproveRange(string slug, Guid signupBlockId)
     {
-        var (teamError, user, _) = await ResolveDepartmentApprovalAsync(slug);
+        var (teamError, user, team) = await ResolveDepartmentApprovalAsync(slug);
         if (teamError is not null) return teamError;
+
+        var probe = await _signupService.GetByBlockIdFirstAsync(signupBlockId);
+        if (probe is null || probe.Shift.Rota.TeamId != team.Id) return NotFound();
 
         var result = await _signupService.ApproveRangeAsync(signupBlockId, user.Id);
         if (result.Success)
@@ -465,8 +468,11 @@ public class ShiftAdminController : HumansTeamControllerBase
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> RefuseRange(string slug, Guid signupBlockId, string? reason)
     {
-        var (teamError, user, _) = await ResolveDepartmentApprovalAsync(slug);
+        var (teamError, user, team) = await ResolveDepartmentApprovalAsync(slug);
         if (teamError is not null) return teamError;
+
+        var probe = await _signupService.GetByBlockIdFirstAsync(signupBlockId);
+        if (probe is null || probe.Shift.Rota.TeamId != team.Id) return NotFound();
 
         var result = await _signupService.RefuseRangeAsync(signupBlockId, user.Id, reason);
         if (result.Success)


### PR DESCRIPTION
## Summary
- `ApproveRangeAsync` was missing the capacity (`MaxVolunteers`), early entry cap, and EE freeze checks that single-item `ApproveAsync` enforces
- A coordinator could batch-approve signups that overfill shifts or bypass the early entry close deadline
- Now applies per-shift capacity warnings and hard EE freeze blocks, matching the single-item behavior

Stacks on #219 (team ownership check).

## Test plan
- [ ] Batch approve a range where one shift is at capacity — verify warning is shown
- [ ] Batch approve build shifts after EE close as non-privileged user — verify it's blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)