### PR TITLE
fix: add team ownership check to ApproveRange/RefuseRange

### DIFF
--- a/src/Humans.Application/Interfaces/IShiftSignupService.cs
+++ b/src/Humans.Application/Interfaces/IShiftSignupService.cs
@@ -82,6 +82,11 @@ public interface IShiftSignupService
     Task<ShiftSignup?> GetByIdAsync(Guid signupId);
 
     /// <summary>
+    /// Gets the first signup in a block with Shift.Rota included (for team ownership checks).
+    /// </summary>
+    Task<ShiftSignup?> GetByBlockIdFirstAsync(Guid signupBlockId);
+
+    /// <summary>
     /// Gets all signups for a shift.
     /// </summary>
     Task<IReadOnlyList<ShiftSignup>> GetByShiftAsync(Guid shiftId);

--- a/src/Humans.Infrastructure/Services/ShiftSignupService.cs
+++ b/src/Humans.Infrastructure/Services/ShiftSignupService.cs
@@ -649,6 +649,13 @@ public class ShiftSignupService : IShiftSignupService
             .FirstOrDefaultAsync(d => d.Id == signupId);
     }
 
+    public async Task<ShiftSignup?> GetByBlockIdFirstAsync(Guid signupBlockId)
+    {
+        return await _dbContext.ShiftSignups
+            .Include(s => s.Shift).ThenInclude(s => s.Rota)
+            .FirstOrDefaultAsync(s => s.SignupBlockId == signupBlockId);
+    }
+
     public async Task<IReadOnlyList<ShiftSignup>> GetByShiftAsync(Guid shiftId)
     {
         return await _dbContext.ShiftSignups

--- a/src/Humans.Web/Controllers/ShiftAdminController.cs
+++ b/src/Humans.Web/Controllers/ShiftAdminController.cs
@@ -449,8 +449,11 @@ public class ShiftAdminController : HumansTeamControllerBase
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> ApproveRange(string slug, Guid signupBlockId)
     {
-        var (teamError, user, _) = await ResolveDepartmentApprovalAsync(slug);
+        var (teamError, user, team) = await ResolveDepartmentApprovalAsync(slug);
         if (teamError is not null) return teamError;
+
+        var probe = await _signupService.GetByBlockIdFirstAsync(signupBlockId);
+        if (probe is null || probe.Shift.Rota.TeamId != team.Id) return NotFound();
 
         var result = await _signupService.ApproveRangeAsync(signupBlockId, user.Id);
         if (result.Success)
@@ -465,8 +468,11 @@ public class ShiftAdminController : HumansTeamControllerBase
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> RefuseRange(string slug, Guid signupBlockId, string? reason)
     {
-        var (teamError, user, _) = await ResolveDepartmentApprovalAsync(slug);
+        var (teamError, user, team) = await ResolveDepartmentApprovalAsync(slug);
         if (teamError is not null) return teamError;
+
+        var probe = await _signupService.GetByBlockIdFirstAsync(signupBlockId);
+        if (probe is null || probe.Shift.Rota.TeamId != team.Id) return NotFound();
 
         var result = await _signupService.RefuseRangeAsync(signupBlockId, user.Id, reason);
         if (result.Success)


### PR DESCRIPTION
## Summary
- **Security fix**: `ApproveRange` and `RefuseRange` discarded the resolved team and passed `signupBlockId` directly to the service with no team ownership validation
- A coordinator of Team A could approve/refuse signups belonging to Team B
- Now probes the block for team ownership before proceeding, matching single-item `ApproveSignup`/`RefuseSignup`

## Test plan
- [ ] Verify approve/refuse range still works for the correct team
- [ ] Verify a coordinator cannot approve/refuse signups from another team's block

🤖 Generated with [Claude Code](https://claude.com/claude-code)