### PR TITLE
fix: bug batch — noreply email, group settings, camp admin, googlemail

### DIFF
--- a/docs/superpowers/specs/2026-03-14-email-outbox-campaigns-design.md
+++ b/docs/superpowers/specs/2026-03-14-email-outbox-campaigns-design.md
@@ -456,6 +456,6 @@ The complete substitution vocabulary for campaign templates:
 
 ## Future Considerations
 
-**Bounce processing:** When SMTP accepts a message but the recipient's server later rejects it (mailbox full, invalid address), a bounce email is sent back to `noreply@nobodies.team`. Currently these accumulate unread. A future enhancement could add inbound bounce parsing to update outbox status from Sent → Bounced, enabling proactive admin notification. This is out of scope for v1 — the admin outbox dashboard lets admins spot patterns manually for now.
+**Bounce processing:** When SMTP accepts a message but the recipient's server later rejects it (mailbox full, invalid address), a bounce email is sent back to the configured From address. Currently these accumulate unread. A future enhancement could add inbound bounce parsing to update outbox status from Sent → Bounced, enabling proactive admin notification. This is out of scope for v1 — the admin outbox dashboard lets admins spot patterns manually for now.
 
 **Low-income ticket lottery:** The Campaign entity is designed to be reusable for future lottery-based code assignment. The assignment logic (how codes map to humans) differs, but the Campaign/CampaignCode/CampaignGrant structure and email delivery pipeline remain the same.

--- a/src/Humans.Application/Interfaces/ICampService.cs
+++ b/src/Humans.Application/Interfaces/ICampService.cs
@@ -39,6 +39,7 @@ public interface ICampService
         CampDirectoryFilter? filter = null,
         CancellationToken cancellationToken = default);
     Task<List<Camp>> GetCampsForYearAsync(int year, CancellationToken cancellationToken = default);
+    Task<List<Camp>> GetAllCampsForYearAsync(int year, CancellationToken cancellationToken = default);
     Task<IReadOnlyList<CampPublicSummary>> GetCampPublicSummariesForYearAsync(int year, CancellationToken cancellationToken = default);
     Task<IReadOnlyList<CampPlacementSummary>> GetCampPlacementSummariesForYearAsync(int year, CancellationToken cancellationToken = default);
     Task<CampSettings> GetSettingsAsync(CancellationToken cancellationToken = default);

--- a/src/Humans.Infrastructure/Services/CampService.cs
+++ b/src/Humans.Infrastructure/Services/CampService.cs
@@ -287,6 +287,16 @@ public class CampService : ICampService
         }) ?? [];
     }
 
+    public async Task<List<Camp>> GetAllCampsForYearAsync(int year, CancellationToken cancellationToken = default)
+    {
+        return await _dbContext.Camps
+            .Include(b => b.Seasons.Where(s => s.Year == year))
+            .Include(b => b.Images.OrderBy(i => i.SortOrder))
+            .Include(b => b.HistoricalNames)
+            .Where(b => b.Seasons.Any(s => s.Year == year))
+            .ToListAsync(cancellationToken);
+    }
+
     public async Task<IReadOnlyList<CampPublicSummary>> GetCampPublicSummariesForYearAsync(
         int year,
         CancellationToken cancellationToken = default)

--- a/src/Humans.Infrastructure/Services/GoogleWorkspaceSyncService.cs
+++ b/src/Humans.Infrastructure/Services/GoogleWorkspaceSyncService.cs
@@ -278,16 +278,7 @@ public class GoogleWorkspaceSyncService : IGoogleSyncService
         try
         {
             var groupssettingsService = await GetGroupssettingsServiceAsync();
-            var groupSettings = new Google.Apis.Groupssettings.v1.Data.Groups
-            {
-                WhoCanJoin = _settings.Groups.WhoCanJoin,
-                WhoCanViewMembership = _settings.Groups.WhoCanViewMembership,
-                WhoCanContactOwner = _settings.Groups.WhoCanContactOwner,
-                WhoCanPostMessage = _settings.Groups.WhoCanPostMessage,
-                WhoCanViewGroup = _settings.Groups.WhoCanViewGroup,
-                WhoCanModerateMembers = _settings.Groups.WhoCanModerateMembers,
-                AllowExternalMembers = _settings.Groups.AllowExternalMembers ? "true" : "false",
-            };
+            var groupSettings = BuildExpectedGroupSettings();
             await groupssettingsService.Groups.Update(groupSettings, groupEmail).ExecuteAsync(cancellationToken);
             _logger.LogInformation("Applied group settings to '{GroupEmail}'", groupEmail);
         }
@@ -1402,23 +1393,45 @@ public class GoogleWorkspaceSyncService : IGoogleSyncService
         };
     }
 
-    private Dictionary<string, string> BuildExpectedSettingsDictionary() => new(StringComparer.Ordinal)
+    private Google.Apis.Groupssettings.v1.Data.Groups BuildExpectedGroupSettings() => new()
     {
-        ["WhoCanJoin"] = _settings.Groups.WhoCanJoin,
-        ["WhoCanViewMembership"] = _settings.Groups.WhoCanViewMembership,
-        ["WhoCanContactOwner"] = _settings.Groups.WhoCanContactOwner,
-        ["WhoCanPostMessage"] = _settings.Groups.WhoCanPostMessage,
-        ["WhoCanViewGroup"] = _settings.Groups.WhoCanViewGroup,
-        ["WhoCanModerateMembers"] = _settings.Groups.WhoCanModerateMembers,
-        ["AllowExternalMembers"] = _settings.Groups.AllowExternalMembers ? "true" : "false",
-        ["IsArchived"] = "true",
-        ["MembersCanPostAsTheGroup"] = "true",
-        ["IncludeInGlobalAddressList"] = "true",
-        ["AllowWebPosting"] = "true",
-        ["MessageModerationLevel"] = "MODERATE_NONE",
-        ["SpamModerationLevel"] = "MODERATE",
-        ["EnableCollaborativeInbox"] = "false"
+        WhoCanJoin = _settings.Groups.WhoCanJoin,
+        WhoCanViewMembership = _settings.Groups.WhoCanViewMembership,
+        WhoCanContactOwner = _settings.Groups.WhoCanContactOwner,
+        WhoCanPostMessage = _settings.Groups.WhoCanPostMessage,
+        WhoCanViewGroup = _settings.Groups.WhoCanViewGroup,
+        WhoCanModerateMembers = _settings.Groups.WhoCanModerateMembers,
+        AllowExternalMembers = _settings.Groups.AllowExternalMembers ? "true" : "false",
+        IsArchived = "true",
+        MembersCanPostAsTheGroup = "true",
+        IncludeInGlobalAddressList = "true",
+        AllowWebPosting = "true",
+        MessageModerationLevel = "MODERATE_NONE",
+        SpamModerationLevel = "MODERATE",
+        EnableCollaborativeInbox = "false"
     };
+
+    private Dictionary<string, string> BuildExpectedSettingsDictionary()
+    {
+        var gs = BuildExpectedGroupSettings();
+        return new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["WhoCanJoin"] = gs.WhoCanJoin,
+            ["WhoCanViewMembership"] = gs.WhoCanViewMembership,
+            ["WhoCanContactOwner"] = gs.WhoCanContactOwner,
+            ["WhoCanPostMessage"] = gs.WhoCanPostMessage,
+            ["WhoCanViewGroup"] = gs.WhoCanViewGroup,
+            ["WhoCanModerateMembers"] = gs.WhoCanModerateMembers,
+            ["AllowExternalMembers"] = gs.AllowExternalMembers,
+            ["IsArchived"] = gs.IsArchived,
+            ["MembersCanPostAsTheGroup"] = gs.MembersCanPostAsTheGroup,
+            ["IncludeInGlobalAddressList"] = gs.IncludeInGlobalAddressList,
+            ["AllowWebPosting"] = gs.AllowWebPosting,
+            ["MessageModerationLevel"] = gs.MessageModerationLevel,
+            ["SpamModerationLevel"] = gs.SpamModerationLevel,
+            ["EnableCollaborativeInbox"] = gs.EnableCollaborativeInbox
+        };
+    }
 
     private async Task<GroupSettingsDriftReport> CheckSingleGroupSettingsAsync(
         GoogleResource resource,
@@ -1444,7 +1457,7 @@ public class GoogleWorkspaceSyncService : IGoogleSyncService
             CompareGroupSetting(drifts, "AllowExternalMembers",
                 _settings.Groups.AllowExternalMembers ? "true" : "false", actual.AllowExternalMembers);
 
-            // Additional settings worth monitoring (not set at creation but important for group health)
+            // Additional settings (set at creation via BuildExpectedGroupSettings)
             CompareGroupSetting(drifts, "IsArchived", "true", actual.IsArchived);
             CompareGroupSetting(drifts, "MembersCanPostAsTheGroup", "true", actual.MembersCanPostAsTheGroup);
             CompareGroupSetting(drifts, "IncludeInGlobalAddressList", "true", actual.IncludeInGlobalAddressList);

--- a/src/Humans.Infrastructure/Services/GoogleWorkspaceSyncService.cs
+++ b/src/Humans.Infrastructure/Services/GoogleWorkspaceSyncService.cs
@@ -1411,27 +1411,27 @@ public class GoogleWorkspaceSyncService : IGoogleSyncService
         EnableCollaborativeInbox = "false"
     };
 
-    private Dictionary<string, string> BuildExpectedSettingsDictionary()
+    private static Dictionary<string, string?> GroupSettingsToDict(Google.Apis.Groupssettings.v1.Data.Groups g) => new(StringComparer.Ordinal)
     {
-        var gs = BuildExpectedGroupSettings();
-        return new Dictionary<string, string>(StringComparer.Ordinal)
-        {
-            ["WhoCanJoin"] = gs.WhoCanJoin,
-            ["WhoCanViewMembership"] = gs.WhoCanViewMembership,
-            ["WhoCanContactOwner"] = gs.WhoCanContactOwner,
-            ["WhoCanPostMessage"] = gs.WhoCanPostMessage,
-            ["WhoCanViewGroup"] = gs.WhoCanViewGroup,
-            ["WhoCanModerateMembers"] = gs.WhoCanModerateMembers,
-            ["AllowExternalMembers"] = gs.AllowExternalMembers,
-            ["IsArchived"] = gs.IsArchived,
-            ["MembersCanPostAsTheGroup"] = gs.MembersCanPostAsTheGroup,
-            ["IncludeInGlobalAddressList"] = gs.IncludeInGlobalAddressList,
-            ["AllowWebPosting"] = gs.AllowWebPosting,
-            ["MessageModerationLevel"] = gs.MessageModerationLevel,
-            ["SpamModerationLevel"] = gs.SpamModerationLevel,
-            ["EnableCollaborativeInbox"] = gs.EnableCollaborativeInbox
-        };
-    }
+        ["WhoCanJoin"] = g.WhoCanJoin,
+        ["WhoCanViewMembership"] = g.WhoCanViewMembership,
+        ["WhoCanContactOwner"] = g.WhoCanContactOwner,
+        ["WhoCanPostMessage"] = g.WhoCanPostMessage,
+        ["WhoCanViewGroup"] = g.WhoCanViewGroup,
+        ["WhoCanModerateMembers"] = g.WhoCanModerateMembers,
+        ["AllowExternalMembers"] = g.AllowExternalMembers,
+        ["IsArchived"] = g.IsArchived,
+        ["MembersCanPostAsTheGroup"] = g.MembersCanPostAsTheGroup,
+        ["IncludeInGlobalAddressList"] = g.IncludeInGlobalAddressList,
+        ["AllowWebPosting"] = g.AllowWebPosting,
+        ["MessageModerationLevel"] = g.MessageModerationLevel,
+        ["SpamModerationLevel"] = g.SpamModerationLevel,
+        ["EnableCollaborativeInbox"] = g.EnableCollaborativeInbox
+    };
+
+    private Dictionary<string, string> BuildExpectedSettingsDictionary() =>
+        GroupSettingsToDict(BuildExpectedGroupSettings())
+            .ToDictionary(kvp => kvp.Key, kvp => kvp.Value!, StringComparer.Ordinal);
 
     private async Task<GroupSettingsDriftReport> CheckSingleGroupSettingsAsync(
         GoogleResource resource,
@@ -1446,25 +1446,11 @@ public class GoogleWorkspaceSyncService : IGoogleSyncService
             var actual = await request.ExecuteAsync(cancellationToken);
 
             var drifts = new List<GroupSettingDrift>();
+            var expected = BuildExpectedSettingsDictionary();
+            var actualDict = GroupSettingsToDict(actual);
 
-            // Compare against the expected settings (same ones applied at group creation)
-            CompareGroupSetting(drifts, "WhoCanJoin", _settings.Groups.WhoCanJoin, actual.WhoCanJoin);
-            CompareGroupSetting(drifts, "WhoCanViewMembership", _settings.Groups.WhoCanViewMembership, actual.WhoCanViewMembership);
-            CompareGroupSetting(drifts, "WhoCanContactOwner", _settings.Groups.WhoCanContactOwner, actual.WhoCanContactOwner);
-            CompareGroupSetting(drifts, "WhoCanPostMessage", _settings.Groups.WhoCanPostMessage, actual.WhoCanPostMessage);
-            CompareGroupSetting(drifts, "WhoCanViewGroup", _settings.Groups.WhoCanViewGroup, actual.WhoCanViewGroup);
-            CompareGroupSetting(drifts, "WhoCanModerateMembers", _settings.Groups.WhoCanModerateMembers, actual.WhoCanModerateMembers);
-            CompareGroupSetting(drifts, "AllowExternalMembers",
-                _settings.Groups.AllowExternalMembers ? "true" : "false", actual.AllowExternalMembers);
-
-            // Additional settings (set at creation via BuildExpectedGroupSettings)
-            CompareGroupSetting(drifts, "IsArchived", "true", actual.IsArchived);
-            CompareGroupSetting(drifts, "MembersCanPostAsTheGroup", "true", actual.MembersCanPostAsTheGroup);
-            CompareGroupSetting(drifts, "IncludeInGlobalAddressList", "true", actual.IncludeInGlobalAddressList);
-            CompareGroupSetting(drifts, "AllowWebPosting", "true", actual.AllowWebPosting);
-            CompareGroupSetting(drifts, "MessageModerationLevel", "MODERATE_NONE", actual.MessageModerationLevel);
-            CompareGroupSetting(drifts, "SpamModerationLevel", "MODERATE", actual.SpamModerationLevel);
-            CompareGroupSetting(drifts, "EnableCollaborativeInbox", "false", actual.EnableCollaborativeInbox);
+            foreach (var (key, expectedValue) in expected)
+                CompareGroupSetting(drifts, key, expectedValue, actualDict.GetValueOrDefault(key));
 
             if (drifts.Count > 0)
             {
@@ -1530,26 +1516,7 @@ public class GoogleWorkspaceSyncService : IGoogleSyncService
         try
         {
             var groupssettingsService = await GetGroupssettingsServiceAsync();
-            var expected = BuildExpectedSettingsDictionary();
-
-            var settings = new Google.Apis.Groupssettings.v1.Data.Groups
-            {
-                WhoCanJoin = expected["WhoCanJoin"],
-                WhoCanViewMembership = expected["WhoCanViewMembership"],
-                WhoCanContactOwner = expected["WhoCanContactOwner"],
-                WhoCanPostMessage = expected["WhoCanPostMessage"],
-                WhoCanViewGroup = expected["WhoCanViewGroup"],
-                WhoCanModerateMembers = expected["WhoCanModerateMembers"],
-                AllowExternalMembers = expected["AllowExternalMembers"],
-                IsArchived = expected["IsArchived"],
-                MembersCanPostAsTheGroup = expected["MembersCanPostAsTheGroup"],
-                IncludeInGlobalAddressList = expected["IncludeInGlobalAddressList"],
-                AllowWebPosting = expected["AllowWebPosting"],
-                MessageModerationLevel = expected["MessageModerationLevel"],
-                SpamModerationLevel = expected["SpamModerationLevel"],
-                EnableCollaborativeInbox = expected["EnableCollaborativeInbox"]
-            };
-
+            var settings = BuildExpectedGroupSettings();
             var request = groupssettingsService.Groups.Update(settings, groupEmail);
             await request.ExecuteAsync(cancellationToken);
 

--- a/src/Humans.Web/Controllers/AdminController.cs
+++ b/src/Humans.Web/Controllers/AdminController.cs
@@ -319,7 +319,7 @@ public class AdminController : HumansControllerBase
             previews[culture] = items;
         }
 
-        return View(new EmailPreviewViewModel { Previews = previews });
+        return View(new EmailPreviewViewModel { Previews = previews, FromAddress = settings.FromAddress });
     }
 
     [HttpGet("SyncSettings")]

--- a/src/Humans.Web/Controllers/CampAdminController.cs
+++ b/src/Humans.Web/Controllers/CampAdminController.cs
@@ -39,12 +39,26 @@ public class CampAdminController : HumansControllerBase
     public async Task<IActionResult> Index()
     {
         var settings = await _campService.GetSettingsAsync();
-        var allCamps = await _campService.GetCampsForYearAsync(settings.PublicYear);
+        var allCamps = await _campService.GetAllCampsForYearAsync(settings.PublicYear);
         var pendingSeasons = await _campService.GetPendingSeasonsAsync();
 
         var nameLockDates = settings.OpenSeasons.Count > 0
             ? await _campService.GetNameLockDatesAsync(settings.OpenSeasons)
             : new Dictionary<int, NodaTime.LocalDate?>();
+
+        var withdrawnSeasons = allCamps
+            .SelectMany(c => c.Seasons
+                .Where(s => s.Year == settings.PublicYear && s.Status == CampSeasonStatus.Withdrawn)
+                .Select(s => new CampCardViewModel
+                {
+                    Id = c.Id,
+                    SeasonId = s.Id,
+                    Slug = c.Slug,
+                    Name = s.Name,
+                    BlurbShort = s.BlurbShort,
+                    Status = s.Status
+                }))
+            .ToList();
 
         var vm = new CampAdminViewModel
         {
@@ -53,6 +67,8 @@ public class CampAdminController : HumansControllerBase
             TotalCamps = allCamps.Count,
             ActiveCamps = allCamps.Count(b => b.Seasons.Any(s =>
                 s.Year == settings.PublicYear && (s.Status == CampSeasonStatus.Active || s.Status == CampSeasonStatus.Full))),
+            WithdrawnCount = withdrawnSeasons.Count,
+            WithdrawnCamps = withdrawnSeasons,
             NameLockDates = nameLockDates,
             PendingCamps = pendingSeasons.Select(s => new CampCardViewModel
             {

--- a/src/Humans.Web/Controllers/CampAdminController.cs
+++ b/src/Humans.Web/Controllers/CampAdminController.cs
@@ -67,7 +67,6 @@ public class CampAdminController : HumansControllerBase
             TotalCamps = allCamps.Count,
             ActiveCamps = allCamps.Count(b => b.Seasons.Any(s =>
                 s.Year == settings.PublicYear && (s.Status == CampSeasonStatus.Active || s.Status == CampSeasonStatus.Full))),
-            WithdrawnCount = withdrawnSeasons.Count,
             WithdrawnCamps = withdrawnSeasons,
             NameLockDates = nameLockDates,
             PendingCamps = pendingSeasons.Select(s => new CampCardViewModel

--- a/src/Humans.Web/Models/AdminViewModels.cs
+++ b/src/Humans.Web/Models/AdminViewModels.cs
@@ -271,6 +271,7 @@ public class AdminConfigurationViewModel
 public class EmailPreviewViewModel
 {
     public Dictionary<string, List<EmailPreviewItem>> Previews { get; set; } = new(StringComparer.Ordinal);
+    public string FromAddress { get; set; } = string.Empty;
 }
 
 public class EmailPreviewItem

--- a/src/Humans.Web/Models/CampViewModels.cs
+++ b/src/Humans.Web/Models/CampViewModels.cs
@@ -168,6 +168,5 @@ public class CampAdminViewModel
     public List<int> OpenSeasons { get; set; } = new();
     public int TotalCamps { get; set; }
     public int ActiveCamps { get; set; }
-    public int WithdrawnCount { get; set; }
     public Dictionary<int, NodaTime.LocalDate?> NameLockDates { get; set; } = new();
 }

--- a/src/Humans.Web/Models/CampViewModels.cs
+++ b/src/Humans.Web/Models/CampViewModels.cs
@@ -163,9 +163,11 @@ public class CampContactViewModel
 public class CampAdminViewModel
 {
     public List<CampCardViewModel> PendingCamps { get; set; } = new();
+    public List<CampCardViewModel> WithdrawnCamps { get; set; } = new();
     public int PublicYear { get; set; }
     public List<int> OpenSeasons { get; set; } = new();
     public int TotalCamps { get; set; }
     public int ActiveCamps { get; set; }
+    public int WithdrawnCount { get; set; }
     public Dictionary<int, NodaTime.LocalDate?> NameLockDates { get; set; } = new();
 }

--- a/src/Humans.Web/Views/Admin/EmailPreview.cshtml
+++ b/src/Humans.Web/Views/Admin/EmailPreview.cshtml
@@ -65,7 +65,7 @@
                              aria-labelledby="@headingId" data-bs-parent="#emails-@lang.Key">
                             <div class="accordion-body p-0">
                                 <div class="p-3 bg-light border-bottom small">
-                                    <strong>From:</strong> noreply@@nobodies.team &nbsp;|&nbsp;
+                                    <strong>From:</strong> @Model.FromAddress &nbsp;|&nbsp;
                                     <strong>To:</strong> @email.Recipient &nbsp;|&nbsp;
                                     <strong>Subject:</strong> @email.Subject
                                 </div>

--- a/src/Humans.Web/Views/CampAdmin/Index.cshtml
+++ b/src/Humans.Web/Views/CampAdmin/Index.cshtml
@@ -36,8 +36,8 @@
     <div class="col-md-3">
         <div class="card text-center">
             <div class="card-body">
-                <h5 class="card-title">@(Model.OpenSeasons.Count > 0 ? string.Join(", ", Model.OpenSeasons) : "None")</h5>
-                <p class="card-text text-muted">Open Seasons</p>
+                <h5 class="card-title">@Model.WithdrawnCount</h5>
+                <p class="card-text text-muted">Withdrawn</p>
             </div>
         </div>
     </div>
@@ -106,6 +106,48 @@
         </div>
     }
 </div>
+
+@* Withdrawn Camps *@
+@if (Model.WithdrawnCamps.Count > 0)
+{
+    <div class="card mb-4">
+        <div class="card-header">
+            <i class="fa-solid fa-circle-pause me-2"></i>Withdrawn (@Model.WithdrawnCamps.Count)
+        </div>
+        <div class="table-responsive">
+            <table class="table table-hover mb-0">
+                <thead>
+                    <tr>
+                        <th>Name</th>
+                        <th>Description</th>
+                        <th class="text-end">Actions</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var camp in Model.WithdrawnCamps)
+                    {
+                        <tr>
+                            <td>
+                                <a asp-controller="Camp" asp-action="Details" asp-route-slug="@camp.Slug">
+                                    @camp.Name
+                                </a>
+                            </td>
+                            <td>@(camp.BlurbShort.Length > 100 ? camp.BlurbShort[..100] + "..." : camp.BlurbShort)</td>
+                            <td class="text-end">
+                                <form asp-controller="CampAdmin" asp-action="Reactivate" asp-route-seasonId="@camp.SeasonId" method="post" class="d-inline">
+                                    @Html.AntiForgeryToken()
+                                    <button type="submit" class="btn btn-outline-success btn-sm" title="Reactivate">
+                                        <i class="fa-solid fa-rotate-left me-1"></i>Reactivate
+                                    </button>
+                                </form>
+                            </td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
+    </div>
+}
 
 @* Season Management *@
 <div class="row">

--- a/src/Humans.Web/Views/CampAdmin/Index.cshtml
+++ b/src/Humans.Web/Views/CampAdmin/Index.cshtml
@@ -8,36 +8,44 @@
 <vc:temp-data-alerts />
 
 @* Summary cards *@
-<div class="row mb-4">
-    <div class="col-md-3">
-        <div class="card text-center">
+<div class="row row-cols-2 row-cols-md-5 g-3 mb-4">
+    <div class="col">
+        <div class="card text-center h-100">
             <div class="card-body">
                 <h5 class="card-title">@Model.TotalCamps</h5>
                 <p class="card-text text-muted">Total @Localizer["Camp_Plural"] (@Model.PublicYear)</p>
             </div>
         </div>
     </div>
-    <div class="col-md-3">
-        <div class="card text-center">
+    <div class="col">
+        <div class="card text-center h-100">
             <div class="card-body">
                 <h5 class="card-title">@Model.ActiveCamps</h5>
                 <p class="card-text text-muted">Active</p>
             </div>
         </div>
     </div>
-    <div class="col-md-3">
-        <div class="card text-center">
+    <div class="col">
+        <div class="card text-center h-100">
             <div class="card-body">
                 <h5 class="card-title">@Model.PendingCamps.Count</h5>
                 <p class="card-text text-muted">Pending Review</p>
             </div>
         </div>
     </div>
-    <div class="col-md-3">
-        <div class="card text-center">
+    <div class="col">
+        <div class="card text-center h-100">
             <div class="card-body">
-                <h5 class="card-title">@Model.WithdrawnCount</h5>
+                <h5 class="card-title">@Model.WithdrawnCamps.Count</h5>
                 <p class="card-text text-muted">Withdrawn</p>
+            </div>
+        </div>
+    </div>
+    <div class="col">
+        <div class="card text-center h-100">
+            <div class="card-body">
+                <h5 class="card-title">@(Model.OpenSeasons.Count > 0 ? string.Join(", ", Model.OpenSeasons) : "None")</h5>
+                <p class="card-text text-muted">Open Seasons</p>
             </div>
         </div>
     </div>
@@ -75,7 +83,7 @@
                                     @camp.Name
                                 </a>
                             </td>
-                            <td>@(camp.BlurbShort.Length > 100 ? camp.BlurbShort[..100] + "..." : camp.BlurbShort)</td>
+                            <td>@((camp.BlurbShort ?? "").Length > 100 ? camp.BlurbShort![..100] + "..." : camp.BlurbShort)</td>
                             <td>
                                 <input type="text" class="form-control form-control-sm" form="approve-@camp.SeasonId" name="notes" placeholder="Optional notes" />
                             </td>
@@ -132,7 +140,7 @@
                                     @camp.Name
                                 </a>
                             </td>
-                            <td>@(camp.BlurbShort.Length > 100 ? camp.BlurbShort[..100] + "..." : camp.BlurbShort)</td>
+                            <td>@((camp.BlurbShort ?? "").Length > 100 ? camp.BlurbShort![..100] + "..." : camp.BlurbShort)</td>
                             <td class="text-end">
                                 <form asp-controller="CampAdmin" asp-action="Reactivate" asp-route-seasonId="@camp.SeasonId" method="post" class="d-inline">
                                     @Html.AntiForgeryToken()

--- a/tests/Humans.Application.Tests/Services/OutboxEmailServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/OutboxEmailServiceTests.cs
@@ -41,7 +41,7 @@ public class OutboxEmailServiceTests : IDisposable
         var emailSettings = Options.Create(new EmailSettings
         {
             BaseUrl = "https://humans.nobodies.team",
-            FromAddress = "noreply@nobodies.team",
+            FromAddress = "humans@nobodies.team",
             FromName = "Nobodies Collective"
         });
 


### PR DESCRIPTION
## Summary
- **#227**: Replace hardcoded `noreply@` in EmailPreview with configured `EmailSettings.FromAddress`; fix test fixture to use `humans@nobodies.team`
- **#229**: Add 7 missing settings to Google Group creation (`IsArchived`, `MembersCanPostAsTheGroup`, `IncludeInGlobalAddressList`, `AllowWebPosting`, `MessageModerationLevel`, `SpamModerationLevel`, `EnableCollaborativeInbox`); extract shared `BuildExpectedGroupSettings()` so creation and drift detection can't diverge
- **#196**: Add `GetAllCampsForYearAsync` (no status filter) for admin use; show withdrawn camps count and reactivation table on camp admin dashboard
- **#139**: Verified googlemail fix from #193 is complete; closed issue

## Test plan
- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — 523/523 unit tests pass (integration tests fail on Docker auth, pre-existing)
- [x] `dotnet format --verify-no-changes` — clean
- [ ] QA: verify EmailPreview shows `humans@nobodies.team` as From address
- [ ] QA: create a Google Group and verify all 14 settings are applied
- [x] QA: withdraw a camp season, confirm it appears on camp admin page with Reactivate button

🤖 Generated with [Claude Code](https://claude.com/claude-code)