### PR TITLE
feat: admin UX — shift signups summary column, log API endpoint

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -52,7 +52,7 @@
     <PackageVersion Include="Serilog.Sinks.Debug" Version="3.0.0" />
     <PackageVersion Include="Serilog.Sinks.OpenTelemetry" Version="4.2.0" />
     <!-- Image Processing -->
-    <PackageVersion Include="Magick.NET-Q8-AnyCPU" Version="14.11.0" />
+    <PackageVersion Include="Magick.NET-Q8-AnyCPU" Version="14.11.1" />
     <!-- Localization -->
     <PackageVersion Include="Microsoft.Extensions.Localization" Version="10.0.3" />
     <!-- Data Protection -->

--- a/src/Humans.Application/Interfaces/ITeamService.cs
+++ b/src/Humans.Application/Interfaces/ITeamService.cs
@@ -101,7 +101,8 @@ public record AdminTeamSummary(
     int DriveResourceCount,
     int RoleSlotCount,
     Instant CreatedAt,
-    bool IsChildTeam);
+    bool IsChildTeam,
+    int PendingShiftSignupCount);
 
 public record AdminTeamListResult(
     IReadOnlyList<AdminTeamSummary> Teams,

--- a/src/Humans.Infrastructure/Services/TeamService.cs
+++ b/src/Humans.Infrastructure/Services/TeamService.cs
@@ -1918,7 +1918,13 @@ public class TeamService : ITeamService
     {
         var (items, totalCount) = await GetAllTeamsForAdminAsync(page, pageSize, cancellationToken);
 
-        return new AdminTeamListResult(BuildAdminTeamSummaries(items), totalCount);
+        var pendingShiftCounts = await _dbContext.ShiftSignups
+            .Where(ss => ss.Status == SignupStatus.Pending)
+            .Select(ss => ss.Shift.Rota.TeamId)
+            .GroupBy(teamId => teamId)
+            .ToDictionaryAsync(g => g.Key, g => g.Count(), cancellationToken);
+
+        return new AdminTeamListResult(BuildAdminTeamSummaries(items, pendingShiftCounts), totalCount);
     }
 
     // ==========================================================================
@@ -1967,7 +1973,9 @@ public class TeamService : ITeamService
             .ToList(),
         ParentTeamId: team.ParentTeamId);
 
-    private static IReadOnlyList<AdminTeamSummary> BuildAdminTeamSummaries(IReadOnlyList<Team> teams)
+    private static IReadOnlyList<AdminTeamSummary> BuildAdminTeamSummaries(
+        IReadOnlyList<Team> teams,
+        IReadOnlyDictionary<Guid, int> pendingShiftCounts)
     {
         var ordered = new List<AdminTeamSummary>(teams.Count);
 
@@ -1978,19 +1986,20 @@ public class TeamService : ITeamService
                 continue;
             }
 
-            ordered.Add(CreateAdminTeamSummary(team, isChildTeam: false));
+            ordered.Add(CreateAdminTeamSummary(team, isChildTeam: false, pendingShiftCounts));
 
             var children = teams
                 .Where(child => child.ParentTeamId == team.Id)
                 .OrderBy(child => child.Name, StringComparer.OrdinalIgnoreCase);
 
-            ordered.AddRange(children.Select(child => CreateAdminTeamSummary(child, isChildTeam: true)));
+            ordered.AddRange(children.Select(child => CreateAdminTeamSummary(child, isChildTeam: true, pendingShiftCounts)));
         }
 
         return ordered;
     }
 
-    private static AdminTeamSummary CreateAdminTeamSummary(Team team, bool isChildTeam)
+    private static AdminTeamSummary CreateAdminTeamSummary(
+        Team team, bool isChildTeam, IReadOnlyDictionary<Guid, int> pendingShiftCounts)
     {
         var systemTeamType = team.SystemTeamType != SystemTeamType.None
             ? team.SystemTeamType.ToString()
@@ -2017,7 +2026,8 @@ public class TeamService : ITeamService
             driveResourceCount,
             team.RoleDefinitions.Sum(role => role.SlotCount),
             team.CreatedAt,
-            isChildTeam);
+            isChildTeam,
+            pendingShiftCounts.GetValueOrDefault(team.Id));
     }
 
     private static TeamDirectorySummary CreateDirectorySummary(

--- a/src/Humans.Infrastructure/Services/TeamService.cs
+++ b/src/Humans.Infrastructure/Services/TeamService.cs
@@ -1918,11 +1918,22 @@ public class TeamService : ITeamService
     {
         var (items, totalCount) = await GetAllTeamsForAdminAsync(page, pageSize, cancellationToken);
 
-        var pendingShiftCounts = await _dbContext.ShiftSignups
-            .Where(ss => ss.Status == SignupStatus.Pending)
-            .Select(ss => ss.Shift.Rota.TeamId)
-            .GroupBy(teamId => teamId)
-            .ToDictionaryAsync(g => g.Key, g => g.Count(), cancellationToken);
+        var activeEventId = await _dbContext.EventSettings
+            .Where(e => e.IsActive)
+            .Select(e => e.Id)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        var pendingShiftCounts = activeEventId == Guid.Empty
+            ? new Dictionary<Guid, int>()
+            : await (
+                from rota in _dbContext.Rotas
+                where rota.EventSettingsId == activeEventId
+                join shift in _dbContext.Shifts on rota.Id equals shift.RotaId
+                join signup in _dbContext.ShiftSignups on shift.Id equals signup.ShiftId
+                where signup.Status == SignupStatus.Pending
+                group signup by rota.TeamId into g
+                select new { TeamId = g.Key, Count = g.Count() }
+            ).ToDictionaryAsync(x => x.TeamId, x => x.Count, cancellationToken);
 
         return new AdminTeamListResult(BuildAdminTeamSummaries(items, pendingShiftCounts), totalCount);
     }

--- a/src/Humans.Web/Controllers/LogApiController.cs
+++ b/src/Humans.Web/Controllers/LogApiController.cs
@@ -7,7 +7,7 @@ namespace Humans.Web.Controllers;
 
 [ApiController]
 [Route("api/logs")]
-[ServiceFilter(typeof(ApiKeyAuthFilter))]
+[ServiceFilter(typeof(LogApiKeyAuthFilter))]
 public class LogApiController : ControllerBase
 {
     [HttpGet]
@@ -17,22 +17,29 @@ public class LogApiController : ControllerBase
     {
         count = Math.Clamp(count, 1, 200);
 
-        LogEventLevel? minLogLevel = minLevel?.ToUpper(System.Globalization.CultureInfo.InvariantCulture) switch
+        LogEventLevel? minLogLevel = null;
+        if (minLevel is not null)
         {
-            "WARNING" => LogEventLevel.Warning,
-            "ERROR" => LogEventLevel.Error,
-            "FATAL" => LogEventLevel.Fatal,
-            _ => null
-        };
+            minLogLevel = minLevel.ToUpper(System.Globalization.CultureInfo.InvariantCulture) switch
+            {
+                "WARNING" => LogEventLevel.Warning,
+                "ERROR" => LogEventLevel.Error,
+                "FATAL" => LogEventLevel.Fatal,
+                _ => null
+            };
 
-        var events = InMemoryLogSink.Instance.GetEvents(count);
+            if (!minLogLevel.HasValue)
+                return BadRequest(new { error = $"Invalid minLevel '{minLevel}'. Valid values: Warning, Error, Fatal" });
+        }
+
+        var events = InMemoryLogSink.Instance.GetEvents(200);
 
         if (minLogLevel.HasValue)
         {
             events = events.Where(e => e.Level >= minLogLevel.Value).ToList();
         }
 
-        var result = events.Select(e => new
+        var result = events.Take(count).Select(e => new
         {
             Timestamp = e.Timestamp.UtcDateTime,
             Level = e.Level.ToString(),

--- a/src/Humans.Web/Controllers/LogApiController.cs
+++ b/src/Humans.Web/Controllers/LogApiController.cs
@@ -1,0 +1,45 @@
+using Microsoft.AspNetCore.Mvc;
+using Humans.Web.Filters;
+using Humans.Web.Infrastructure;
+using Serilog.Events;
+
+namespace Humans.Web.Controllers;
+
+[ApiController]
+[Route("api/logs")]
+[ServiceFilter(typeof(ApiKeyAuthFilter))]
+public class LogApiController : ControllerBase
+{
+    [HttpGet]
+    public IActionResult Get(
+        [FromQuery] int count = 50,
+        [FromQuery] string? minLevel = null)
+    {
+        count = Math.Clamp(count, 1, 200);
+
+        LogEventLevel? minLogLevel = minLevel?.ToUpper(System.Globalization.CultureInfo.InvariantCulture) switch
+        {
+            "WARNING" => LogEventLevel.Warning,
+            "ERROR" => LogEventLevel.Error,
+            "FATAL" => LogEventLevel.Fatal,
+            _ => null
+        };
+
+        var events = InMemoryLogSink.Instance.GetEvents(count);
+
+        if (minLogLevel.HasValue)
+        {
+            events = events.Where(e => e.Level >= minLogLevel.Value).ToList();
+        }
+
+        var result = events.Select(e => new
+        {
+            Timestamp = e.Timestamp.UtcDateTime,
+            Level = e.Level.ToString(),
+            Message = e.RenderMessage(),
+            Exception = e.Exception?.ToString()
+        });
+
+        return Ok(result);
+    }
+}

--- a/src/Humans.Web/Controllers/TeamController.cs
+++ b/src/Humans.Web/Controllers/TeamController.cs
@@ -774,7 +774,8 @@ public class TeamController : HumansControllerBase
         DriveResourceCount = team.DriveResourceCount,
         RoleSlotCount = team.RoleSlotCount,
         CreatedAt = team.CreatedAt.ToDateTimeUtc(),
-        IsChildTeam = team.IsChildTeam
+        IsChildTeam = team.IsChildTeam,
+        PendingShiftSignupCount = team.PendingShiftSignupCount
     };
 
     private async Task<List<Microsoft.AspNetCore.Mvc.Rendering.SelectListItem>> GetEligibleParentTeamsAsync(

--- a/src/Humans.Web/Extensions/DateTimeDisplayExtensions.cs
+++ b/src/Humans.Web/Extensions/DateTimeDisplayExtensions.cs
@@ -83,6 +83,12 @@ public static class DateTimeDisplayExtensions
     public static string? ToDisplayCompactDateTime(this Instant? value) =>
         value?.ToDisplayCompactDateTime();
 
+    public static string ToDisplayCompactDayTime(this Instant value) =>
+        value.ToDateTimeUtc().ToDisplayCompactDayTime();
+
+    public static string ToDisplayCompactDayTime(this DateTime value) =>
+        value.ToString("MMM d", CultureInfo.CurrentCulture) + " @ " + value.ToString("HH:mm", CultureInfo.InvariantCulture);
+
     public static string ToDisplayShiftDate(this LocalDate value) =>
         value.DayOfWeek.ToString()[..3] + " " + value.ToString("MMM d", null);
 

--- a/src/Humans.Web/Extensions/InfrastructureServiceCollectionExtensions.cs
+++ b/src/Humans.Web/Extensions/InfrastructureServiceCollectionExtensions.cs
@@ -115,6 +115,13 @@ public static class InfrastructureServiceCollectionExtensions
         });
         services.AddScoped<ApiKeyAuthFilter>();
 
+        // Log API key (separate credential from feedback)
+        services.Configure<LogApiSettings>(opts =>
+        {
+            opts.ApiKey = Environment.GetEnvironmentVariable("LOG_API_KEY") ?? string.Empty;
+        });
+        services.AddScoped<LogApiKeyAuthFilter>();
+
         // Ticket vendor integration
         services.Configure<TicketVendorSettings>(opts =>
         {

--- a/src/Humans.Web/Filters/ApiKeyAuthFilter.cs
+++ b/src/Humans.Web/Filters/ApiKeyAuthFilter.cs
@@ -10,14 +10,19 @@ public class FeedbackApiSettings
     public string ApiKey { get; set; } = string.Empty;
 }
 
-public class ApiKeyAuthFilter : IAuthorizationFilter
+public class LogApiSettings
+{
+    public string ApiKey { get; set; } = string.Empty;
+}
+
+public abstract class ApiKeyAuthFilterBase : IAuthorizationFilter
 {
     private const string ApiKeyHeaderName = "X-Api-Key";
     private readonly string _apiKey;
 
-    public ApiKeyAuthFilter(IOptions<FeedbackApiSettings> settings)
+    protected ApiKeyAuthFilterBase(string apiKey)
     {
-        _apiKey = settings.Value.ApiKey;
+        _apiKey = apiKey;
     }
 
     public void OnAuthorization(AuthorizationFilterContext context)
@@ -35,3 +40,9 @@ public class ApiKeyAuthFilter : IAuthorizationFilter
         }
     }
 }
+
+public class ApiKeyAuthFilter(IOptions<FeedbackApiSettings> settings)
+    : ApiKeyAuthFilterBase(settings.Value.ApiKey);
+
+public class LogApiKeyAuthFilter(IOptions<LogApiSettings> settings)
+    : ApiKeyAuthFilterBase(settings.Value.ApiKey);

--- a/src/Humans.Web/Models/TeamViewModels.cs
+++ b/src/Humans.Web/Models/TeamViewModels.cs
@@ -462,6 +462,7 @@ public class AdminTeamViewModel
     public int RoleSlotCount { get; set; }
     public DateTime CreatedAt { get; set; }
     public bool IsChildTeam { get; set; }
+    public int PendingShiftSignupCount { get; set; }
 }
 
 /// <summary>

--- a/src/Humans.Web/Resources/SharedResource.de.resx
+++ b/src/Humans.Web/Resources/SharedResource.de.resx
@@ -746,7 +746,8 @@
   <data name="AdminTeams_Name" xml:space="preserve"><value>Name</value></data>
   <data name="AdminTeams_Type" xml:space="preserve"><value>Typ</value></data>
   <data name="AdminTeams_Members" xml:space="preserve"><value>Mitglieder</value></data>
-  <data name="AdminTeams_Pending" xml:space="preserve"><value>Ausstehend</value></data>
+  <data name="AdminTeams_PendingJoins" xml:space="preserve"><value>Offene Beitritte</value></data>
+  <data name="AdminTeams_PendingShifts" xml:space="preserve"><value>Offene Schichten</value></data>
   <data name="AdminTeams_MailGroup" xml:space="preserve"><value>Mailgruppe</value></data>
   <data name="AdminTeams_DriveResources" xml:space="preserve"><value>Drive</value></data>
   <data name="AdminTeams_Created" xml:space="preserve"><value>Erstellt</value></data>

--- a/src/Humans.Web/Resources/SharedResource.es.resx
+++ b/src/Humans.Web/Resources/SharedResource.es.resx
@@ -751,7 +751,8 @@
   <data name="AdminTeams_Name" xml:space="preserve"><value>Nombre</value></data>
   <data name="AdminTeams_Type" xml:space="preserve"><value>Tipo</value></data>
   <data name="AdminTeams_Members" xml:space="preserve"><value>Miembros</value></data>
-  <data name="AdminTeams_Pending" xml:space="preserve"><value>Pendientes</value></data>
+  <data name="AdminTeams_PendingJoins" xml:space="preserve"><value>Solicitudes pendientes</value></data>
+  <data name="AdminTeams_PendingShifts" xml:space="preserve"><value>Turnos pendientes</value></data>
   <data name="AdminTeams_MailGroup" xml:space="preserve"><value>Grupo de correo</value></data>
   <data name="AdminTeams_DriveResources" xml:space="preserve"><value>Drive</value></data>
   <data name="AdminTeams_Created" xml:space="preserve"><value>Creado</value></data>

--- a/src/Humans.Web/Resources/SharedResource.fr.resx
+++ b/src/Humans.Web/Resources/SharedResource.fr.resx
@@ -746,7 +746,8 @@
   <data name="AdminTeams_Name" xml:space="preserve"><value>Nom</value></data>
   <data name="AdminTeams_Type" xml:space="preserve"><value>Type</value></data>
   <data name="AdminTeams_Members" xml:space="preserve"><value>Membres</value></data>
-  <data name="AdminTeams_Pending" xml:space="preserve"><value>En attente</value></data>
+  <data name="AdminTeams_PendingJoins" xml:space="preserve"><value>Demandes en attente</value></data>
+  <data name="AdminTeams_PendingShifts" xml:space="preserve"><value>Postes en attente</value></data>
   <data name="AdminTeams_MailGroup" xml:space="preserve"><value>Groupe mail</value></data>
   <data name="AdminTeams_DriveResources" xml:space="preserve"><value>Drive</value></data>
   <data name="AdminTeams_Created" xml:space="preserve"><value>Cr&#xE9;&#xE9;</value></data>

--- a/src/Humans.Web/Resources/SharedResource.it.resx
+++ b/src/Humans.Web/Resources/SharedResource.it.resx
@@ -746,7 +746,8 @@
   <data name="AdminTeams_Name" xml:space="preserve"><value>Nome</value></data>
   <data name="AdminTeams_Type" xml:space="preserve"><value>Tipo</value></data>
   <data name="AdminTeams_Members" xml:space="preserve"><value>Membri</value></data>
-  <data name="AdminTeams_Pending" xml:space="preserve"><value>In sospeso</value></data>
+  <data name="AdminTeams_PendingJoins" xml:space="preserve"><value>Adesioni in sospeso</value></data>
+  <data name="AdminTeams_PendingShifts" xml:space="preserve"><value>Turni in sospeso</value></data>
   <data name="AdminTeams_MailGroup" xml:space="preserve"><value>Gruppo mail</value></data>
   <data name="AdminTeams_DriveResources" xml:space="preserve"><value>Drive</value></data>
   <data name="AdminTeams_Created" xml:space="preserve"><value>Creato</value></data>

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -740,7 +740,8 @@
   <data name="AdminTeams_Name" xml:space="preserve"><value>Name</value></data>
   <data name="AdminTeams_Type" xml:space="preserve"><value>Type</value></data>
   <data name="AdminTeams_Members" xml:space="preserve"><value>Members</value></data>
-  <data name="AdminTeams_Pending" xml:space="preserve"><value>Pending</value></data>
+  <data name="AdminTeams_PendingJoins" xml:space="preserve"><value>Pending Joins</value></data>
+  <data name="AdminTeams_PendingShifts" xml:space="preserve"><value>Pending Shifts</value></data>
   <data name="AdminTeams_MailGroup" xml:space="preserve"><value>Mail Group</value></data>
   <data name="AdminTeams_DriveResources" xml:space="preserve"><value>Drive</value></data>
   <data name="AdminTeams_Created" xml:space="preserve"><value>Created</value></data>

--- a/src/Humans.Web/Views/ShiftAdmin/Index.cshtml
+++ b/src/Humans.Web/Views/ShiftAdmin/Index.cshtml
@@ -80,7 +80,7 @@
                                             @signupDate.ToDisplayShiftDate()
                                         }
                                     </td>
-                                    <td>@first.CreatedAt</td>
+                                    <td>@first.CreatedAt.ToDisplayCompactDayTime()</td>
                                     <td>
                                         @if (isRange && first.SignupBlockId.HasValue)
                                         {

--- a/src/Humans.Web/Views/Team/Summary.cshtml
+++ b/src/Humans.Web/Views/Team/Summary.cshtml
@@ -21,7 +21,8 @@
                     <th>@Localizer["AdminTeams_Name"]</th>
                     <th>@Localizer["AdminTeams_Type"]</th>
                     <th>@Localizer["AdminTeams_Members"]</th>
-                    <th>@Localizer["AdminTeams_Pending"]</th>
+                    <th>Pending Joins</th>
+                    <th>Pending Shifts</th>
                     <th>@Localizer["AdminTeams_MailGroup"]</th>
                     <th>Slots</th>
                     <th>@Localizer["AdminTeams_DriveResources"]</th>
@@ -64,6 +65,18 @@
                             {
                                 <a asp-controller="TeamAdmin" asp-action="Members" asp-route-slug="@team.Slug">
                                     <span class="badge bg-warning">@team.PendingRequestCount</span>
+                                </a>
+                            }
+                            else
+                            {
+                                <span class="text-muted">0</span>
+                            }
+                        </td>
+                        <td>
+                            @if (team.PendingShiftSignupCount > 0)
+                            {
+                                <a asp-controller="ShiftAdmin" asp-action="Index" asp-route-slug="@team.Slug">
+                                    <span class="badge bg-warning">@team.PendingShiftSignupCount</span>
                                 </a>
                             }
                             else

--- a/src/Humans.Web/Views/Team/Summary.cshtml
+++ b/src/Humans.Web/Views/Team/Summary.cshtml
@@ -21,8 +21,8 @@
                     <th>@Localizer["AdminTeams_Name"]</th>
                     <th>@Localizer["AdminTeams_Type"]</th>
                     <th>@Localizer["AdminTeams_Members"]</th>
-                    <th>Pending Joins</th>
-                    <th>Pending Shifts</th>
+                    <th>@Localizer["AdminTeams_PendingJoins"]</th>
+                    <th>@Localizer["AdminTeams_PendingShifts"]</th>
                     <th>@Localizer["AdminTeams_MailGroup"]</th>
                     <th>Slots</th>
                     <th>@Localizer["AdminTeams_DriveResources"]</th>
@@ -75,9 +75,16 @@
                         <td>
                             @if (team.PendingShiftSignupCount > 0)
                             {
-                                <a asp-controller="ShiftAdmin" asp-action="Index" asp-route-slug="@team.Slug">
+                                @if (Humans.Web.Authorization.RoleChecks.IsAdminOrBoard(User))
+                                {
+                                    <a asp-controller="ShiftAdmin" asp-action="Index" asp-route-slug="@team.Slug">
+                                        <span class="badge bg-warning">@team.PendingShiftSignupCount</span>
+                                    </a>
+                                }
+                                else
+                                {
                                     <span class="badge bg-warning">@team.PendingShiftSignupCount</span>
-                                </a>
+                                }
                             }
                             else
                             {

--- a/tests/Humans.Application.Tests/Services/TeamServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/TeamServiceTests.cs
@@ -1332,6 +1332,60 @@ public class TeamServiceTests : IDisposable
         result[0].IsFilled.Should().BeFalse();
     }
 
+    // ==========================================================================
+    // GetAdminTeamListAsync — PendingShiftSignupCount
+    // ==========================================================================
+
+    [Fact]
+    public async Task GetAdminTeamListAsync_CountsPendingShiftSignupsForActiveEvent()
+    {
+        var team = SeedTeam("Dept A");
+        var user = SeedUser();
+        SeedTeamMember(team.Id, user.Id);
+
+        var activeEvent = SeedEventSettings("Active Event", isActive: true);
+        var inactiveEvent = SeedEventSettings("Old Event", isActive: false);
+
+        // Rota on active event with 2 pending signups
+        var activeRota = SeedRota(team.Id, activeEvent.Id, "Gate Shifts");
+        var shift1 = SeedShift(activeRota.Id);
+        SeedShiftSignup(shift1.Id, user.Id, SignupStatus.Pending);
+        SeedShiftSignup(shift1.Id, Guid.NewGuid(), SignupStatus.Pending);
+        SeedShiftSignup(shift1.Id, Guid.NewGuid(), SignupStatus.Confirmed); // not pending
+
+        // Rota on inactive event — should NOT be counted
+        var oldRota = SeedRota(team.Id, inactiveEvent.Id, "Old Shifts");
+        var oldShift = SeedShift(oldRota.Id);
+        SeedShiftSignup(oldShift.Id, user.Id, SignupStatus.Pending);
+
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _service.GetAdminTeamListAsync(1, 500);
+
+        var summary = result.Teams.Should().ContainSingle(t => t.Name == "Dept A").Subject;
+        summary.PendingShiftSignupCount.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task GetAdminTeamListAsync_ReturnsZeroPendingShifts_WhenNoActiveEvent()
+    {
+        var team = SeedTeam("Dept B");
+        var user = SeedUser();
+        SeedTeamMember(team.Id, user.Id);
+
+        var inactiveEvent = SeedEventSettings("Past Event", isActive: false);
+        var rota = SeedRota(team.Id, inactiveEvent.Id, "Shifts");
+        var shift = SeedShift(rota.Id);
+        SeedShiftSignup(shift.Id, user.Id, SignupStatus.Pending);
+
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _service.GetAdminTeamListAsync(1, 500);
+
+        var summary = result.Teams.Should().ContainSingle(t => t.Name == "Dept B").Subject;
+        summary.PendingShiftSignupCount.Should().Be(0);
+    }
+
     // --- Helpers ---
 
     private User SeedUser(Guid? id = null, string displayName = "Test User")
@@ -1443,5 +1497,72 @@ public class TeamServiceTests : IDisposable
         };
         _dbContext.TeamRoleAssignments.Add(assignment);
         return assignment;
+    }
+
+    private EventSettings SeedEventSettings(string name, bool isActive)
+    {
+        var es = new EventSettings
+        {
+            Id = Guid.NewGuid(),
+            EventName = name,
+            TimeZoneId = "Europe/Madrid",
+            GateOpeningDate = new LocalDate(2026, 7, 1),
+            BuildStartOffset = -7,
+            EventEndOffset = 5,
+            StrikeEndOffset = 7,
+            IsActive = isActive,
+            CreatedAt = _clock.GetCurrentInstant(),
+            UpdatedAt = _clock.GetCurrentInstant()
+        };
+        _dbContext.EventSettings.Add(es);
+        return es;
+    }
+
+    private Rota SeedRota(Guid teamId, Guid eventSettingsId, string name)
+    {
+        var rota = new Rota
+        {
+            Id = Guid.NewGuid(),
+            TeamId = teamId,
+            EventSettingsId = eventSettingsId,
+            Name = name,
+            CreatedAt = _clock.GetCurrentInstant(),
+            UpdatedAt = _clock.GetCurrentInstant()
+        };
+        _dbContext.Rotas.Add(rota);
+        return rota;
+    }
+
+    private Shift SeedShift(Guid rotaId)
+    {
+        var shift = new Shift
+        {
+            Id = Guid.NewGuid(),
+            RotaId = rotaId,
+            DayOffset = 0,
+            StartTime = new LocalTime(9, 0),
+            Duration = Duration.FromHours(4),
+            MinVolunteers = 1,
+            MaxVolunteers = 5,
+            CreatedAt = _clock.GetCurrentInstant(),
+            UpdatedAt = _clock.GetCurrentInstant()
+        };
+        _dbContext.Shifts.Add(shift);
+        return shift;
+    }
+
+    private ShiftSignup SeedShiftSignup(Guid shiftId, Guid userId, SignupStatus status)
+    {
+        var signup = new ShiftSignup
+        {
+            Id = Guid.NewGuid(),
+            ShiftId = shiftId,
+            UserId = userId,
+            Status = status,
+            CreatedAt = _clock.GetCurrentInstant(),
+            UpdatedAt = _clock.GetCurrentInstant()
+        };
+        _dbContext.ShiftSignups.Add(signup);
+        return signup;
     }
 }


### PR DESCRIPTION
## Summary
- **#226**: Add "Pending Shifts" column to Teams Summary page — counts pending `ShiftSignup` records per team via Rota→Shift→ShiftSignup chain. Renames existing "Pending" column to "Pending Joins" for clarity. Links non-zero counts to the team's shift admin page.
- **#222**: Add `GET /api/logs` endpoint behind `ApiKeyAuthFilter` (X-Api-Key auth). Returns JSON array from `InMemoryLogSink` with `count` (1-200, default 50) and `minLevel` (Warning/Error/Fatal) query params.

## Test plan
- [x] Verify Teams Summary shows "Pending Joins" and "Pending Shifts" columns
- [ ] Create a pending shift signup and confirm the count appears with link to shift admin
- [ ] `curl -H "X-Api-Key: $KEY" https://qa.url/api/logs` returns log events
- [ ] `curl -H "X-Api-Key: $KEY" https://qa.url/api/logs?count=5&minLevel=Error` filters correctly
- [ ] Request without API key returns 401

Closes #226, closes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)