### PR TITLE
feat: UI polish — popover, barrios cards, markdown rendering

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -52,7 +52,7 @@
     <PackageVersion Include="Serilog.Sinks.Debug" Version="3.0.0" />
     <PackageVersion Include="Serilog.Sinks.OpenTelemetry" Version="4.2.0" />
     <!-- Image Processing -->
-    <PackageVersion Include="Magick.NET-Q8-AnyCPU" Version="14.11.0" />
+    <PackageVersion Include="Magick.NET-Q8-AnyCPU" Version="14.11.1" />
     <!-- Localization -->
     <PackageVersion Include="Microsoft.Extensions.Localization" Version="10.0.3" />
     <!-- Data Protection -->

--- a/src/Humans.Domain/Attributes/MarkdownContentAttribute.cs
+++ b/src/Humans.Domain/Attributes/MarkdownContentAttribute.cs
@@ -1,0 +1,8 @@
+namespace Humans.Domain.Attributes;
+
+/// <summary>
+/// Marks a string property as containing Markdown content.
+/// Views rendering these properties should use Html.SanitizedMarkdown() rather than raw output.
+/// </summary>
+[AttributeUsage(AttributeTargets.Property)]
+public sealed class MarkdownContentAttribute : Attribute;

--- a/src/Humans.Domain/Entities/CampSeason.cs
+++ b/src/Humans.Domain/Entities/CampSeason.cs
@@ -1,3 +1,4 @@
+using Humans.Domain.Attributes;
 using Humans.Domain.Enums;
 using NodaTime;
 
@@ -17,6 +18,7 @@ public class CampSeason
 
     public CampSeasonStatus Status { get; set; } = CampSeasonStatus.Pending;
 
+    [MarkdownContent]
     public string BlurbLong { get; set; } = string.Empty;
     public string BlurbShort { get; set; } = string.Empty;
     public string Languages { get; set; } = string.Empty;
@@ -24,6 +26,7 @@ public class CampSeason
     public YesNoMaybe AcceptingMembers { get; set; }
     public YesNoMaybe KidsWelcome { get; set; }
     public KidsVisitingPolicy KidsVisiting { get; set; }
+    [MarkdownContent]
     public string? KidsAreaDescription { get; set; }
 
     public PerformanceSpaceStatus HasPerformanceSpace { get; set; }

--- a/src/Humans.Domain/Entities/Rota.cs
+++ b/src/Humans.Domain/Entities/Rota.cs
@@ -1,3 +1,4 @@
+using Humans.Domain.Attributes;
 using Humans.Domain.Enums;
 using NodaTime;
 
@@ -32,6 +33,7 @@ public class Rota
     /// <summary>
     /// Optional description of what this rota covers.
     /// </summary>
+    [MarkdownContent]
     public string? Description { get; set; }
 
     /// <summary>
@@ -53,6 +55,7 @@ public class Rota
     /// <summary>
     /// Meeting point, pre-shift instructions, what to bring. Shared by all shifts in the rota.
     /// </summary>
+    [MarkdownContent]
     [System.ComponentModel.DataAnnotations.MaxLength(2000)]
     public string? PracticalInfo { get; set; }
 

--- a/src/Humans.Domain/Entities/Shift.cs
+++ b/src/Humans.Domain/Entities/Shift.cs
@@ -1,3 +1,4 @@
+using Humans.Domain.Attributes;
 using Humans.Domain.Enums;
 using NodaTime;
 
@@ -22,6 +23,7 @@ public class Shift
     /// <summary>
     /// Optional description of shift duties.
     /// </summary>
+    [MarkdownContent]
     public string? Description { get; set; }
 
     /// <summary>

--- a/src/Humans.Domain/Entities/Team.cs
+++ b/src/Humans.Domain/Entities/Team.cs
@@ -1,4 +1,5 @@
 using NodaTime;
+using Humans.Domain.Attributes;
 using Humans.Domain.Enums;
 using Humans.Domain.ValueObjects;
 
@@ -86,6 +87,7 @@ public class Team
     /// <summary>
     /// Free-form markdown content for the public team page.
     /// </summary>
+    [MarkdownContent]
     public string? PageContent { get; set; }
 
     /// <summary>

--- a/src/Humans.Domain/Entities/TeamRoleDefinition.cs
+++ b/src/Humans.Domain/Entities/TeamRoleDefinition.cs
@@ -1,4 +1,5 @@
 using NodaTime;
+using Humans.Domain.Attributes;
 using Humans.Domain.Enums;
 
 namespace Humans.Domain.Entities;
@@ -31,6 +32,7 @@ public class TeamRoleDefinition
     /// <summary>
     /// Optional description of the role's responsibilities.
     /// </summary>
+    [MarkdownContent]
     public string? Description { get; set; }
 
     /// <summary>

--- a/src/Humans.Web/Controllers/AdminMergeController.cs
+++ b/src/Humans.Web/Controllers/AdminMergeController.cs
@@ -103,6 +103,8 @@ public class AdminMergeController : HumansControllerBase
                 : profile?.IsApproved == true ? "Active" : "Pending",
             MemberSince = profile?.CreatedAt.ToDateTimeUtc(),
             LastLogin = user.LastLoginAt?.ToDateTimeUtc(),
+            City = profile?.City,
+            CountryCode = profile?.CountryCode,
             Teams = activeTeamNames
         };
     }

--- a/src/Humans.Web/Controllers/HumanController.cs
+++ b/src/Humans.Web/Controllers/HumanController.cs
@@ -141,7 +141,8 @@ public class HumanController : HumansControllerBase
         if (profile is null) return NotFound();
 
         var teams = await _dbContext.TeamMembers
-            .Where(tm => tm.UserId == id && tm.LeftAt == null)
+            .Where(tm => tm.UserId == id && tm.LeftAt == null
+                && tm.Team!.SystemTeamType != SystemTeamType.Volunteers)
             .Select(tm => tm.Team!.Name)
             .OrderBy(n => n)
             .ToListAsync();
@@ -155,6 +156,8 @@ public class HumanController : HumansControllerBase
             MembershipTier = profile.MembershipTier.ToString(),
             MembershipStatus = profile.IsSuspended ? "Suspended"
                 : profile.IsApproved ? "Active" : "Pending",
+            City = profile.City,
+            CountryCode = profile.CountryCode,
             Teams = teams
         };
 

--- a/src/Humans.Web/Controllers/HumanController.cs
+++ b/src/Humans.Web/Controllers/HumanController.cs
@@ -147,12 +147,17 @@ public class HumanController : HumansControllerBase
             .OrderBy(n => n)
             .ToListAsync();
 
+        var effectivePictureUrl = profile.HasCustomProfilePicture
+            ? Url.Action(nameof(ProfileController.Picture), "Profile",
+                new { id = profile.Id, v = profile.UpdatedAt.ToUnixTimeTicks() })
+            : profile.User.ProfilePictureUrl;
+
         var vm = new ProfileSummaryViewModel
         {
             UserId = id,
             DisplayName = profile.User.DisplayName,
             Email = profile.User.Email,
-            ProfilePictureUrl = profile.User.ProfilePictureUrl,
+            ProfilePictureUrl = effectivePictureUrl,
             MembershipTier = profile.MembershipTier.ToString(),
             MembershipStatus = profile.IsSuspended ? "Suspended"
                 : profile.IsApproved ? "Active" : "Pending",

--- a/src/Humans.Web/Controllers/HumanController.cs
+++ b/src/Humans.Web/Controllers/HumanController.cs
@@ -138,7 +138,7 @@ public class HumanController : HumansControllerBase
     public async Task<IActionResult> Popover(Guid id)
     {
         var profile = await _profileService.GetProfileAsync(id);
-        if (profile is null) return NotFound();
+        if (profile is null || profile.IsSuspended) return NotFound();
 
         var teams = await _dbContext.TeamMembers
             .Where(tm => tm.UserId == id && tm.LeftAt == null

--- a/src/Humans.Web/Models/AdminViewModels.cs
+++ b/src/Humans.Web/Models/AdminViewModels.cs
@@ -327,6 +327,8 @@ public class ProfileSummaryViewModel
     public string? MembershipStatus { get; set; }
     public DateTime? MemberSince { get; set; }
     public DateTime? LastLogin { get; set; }
+    public string? City { get; set; }
+    public string? CountryCode { get; set; }
     public List<string> Teams { get; set; } = [];
 }
 

--- a/src/Humans.Web/Resources/SharedResource.de.resx
+++ b/src/Humans.Web/Resources/SharedResource.de.resx
@@ -1202,4 +1202,7 @@
 
   <data name="MagicLinkSent_Message" xml:space="preserve"><value>Wir haben einen Link an diese E-Mail-Adresse von humans@nobodies.team gesendet. Überprüfen Sie Ihren Posteingang (und den Spam-Ordner).</value></data>
 
+  <!-- Camp Cards -->
+  <data name="CampCard_NeedsPhoto" xml:space="preserve"><value>Dieses Barrio braucht ein Foto!</value></data>
+
 </root>

--- a/src/Humans.Web/Resources/SharedResource.es.resx
+++ b/src/Humans.Web/Resources/SharedResource.es.resx
@@ -1222,4 +1222,7 @@
 
   <data name="MagicLinkSent_Message" xml:space="preserve"><value>Hemos enviado un enlace a esa dirección de correo desde humans@nobodies.team. Revisa tu bandeja de entrada (y la carpeta de spam).</value></data>
 
+  <!-- Camp Cards -->
+  <data name="CampCard_NeedsPhoto" xml:space="preserve"><value>¡Este barrio necesita una foto!</value></data>
+
 </root>

--- a/src/Humans.Web/Resources/SharedResource.fr.resx
+++ b/src/Humans.Web/Resources/SharedResource.fr.resx
@@ -1202,4 +1202,7 @@
 
   <data name="MagicLinkSent_Message" xml:space="preserve"><value>Nous avons envoyé un lien à cette adresse e-mail depuis humans@nobodies.team. Vérifiez votre boîte de réception (et le dossier spam).</value></data>
 
+  <!-- Camp Cards -->
+  <data name="CampCard_NeedsPhoto" xml:space="preserve"><value>Ce barrio a besoin d'une photo !</value></data>
+
 </root>

--- a/src/Humans.Web/Resources/SharedResource.it.resx
+++ b/src/Humans.Web/Resources/SharedResource.it.resx
@@ -1202,4 +1202,7 @@
 
   <data name="MagicLinkSent_Message" xml:space="preserve"><value>Abbiamo inviato un link a quell'indirizzo email da humans@nobodies.team. Controlla la posta in arrivo (e la cartella spam).</value></data>
 
+  <!-- Camp Cards -->
+  <data name="CampCard_NeedsPhoto" xml:space="preserve"><value>Questo barrio ha bisogno di una foto!</value></data>
+
 </root>

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -1247,4 +1247,7 @@
   <data name="MagicLinkConfirm_Message" xml:space="preserve"><value>Click the button below to sign in to your account.</value></data>
   <data name="MagicLinkConfirm_SignIn" xml:space="preserve"><value>Sign in</value></data>
 
+  <!-- Camp Cards -->
+  <data name="CampCard_NeedsPhoto" xml:space="preserve"><value>This barrio needs a photo!</value></data>
+
 </root>

--- a/src/Humans.Web/Views/Camp/Details.cshtml
+++ b/src/Humans.Web/Views/Camp/Details.cshtml
@@ -124,7 +124,7 @@
                                     @if (!string.IsNullOrEmpty(season.KidsAreaDescription))
                                     {
                                         <dt>Kids Area</dt>
-                                        <dd>@season.KidsAreaDescription</dd>
+                                        <dd>@Html.SanitizedMarkdown(season.KidsAreaDescription)</dd>
                                     }
                                 }
                             </dl>

--- a/src/Humans.Web/Views/Camp/_CampCard.cshtml
+++ b/src/Humans.Web/Views/Camp/_CampCard.cshtml
@@ -7,9 +7,17 @@
             <img src="@Model.ImageUrl" class="card-img-top" alt="@Model.Name"
                  style="height: 200px; object-fit: cover;" />
         }
-        <div class="card-body">
+        else
+        {
+            <div class="d-flex flex-column align-items-center justify-content-center text-muted bg-light"
+                 style="height: 200px;">
+                <i class="fa-solid fa-camera fa-2x mb-2"></i>
+                <small>@Localizer["CampCard_NeedsPhoto"]</small>
+            </div>
+        }
+        <div class="card-body d-flex flex-column">
             <h5 class="card-title">
-                <a asp-action="Details" asp-route-slug="@Model.Slug" class="text-decoration-none">
+                <a asp-action="Details" asp-route-slug="@Model.Slug" class="text-decoration-none stretched-link">
                     @Model.Name
                 </a>
             </h5>
@@ -31,7 +39,7 @@
                     </span>
                 }
             </div>
-            <div class="d-flex flex-wrap gap-1">
+            <div class="d-flex flex-wrap gap-1 mt-auto">
                 @if (Model.AcceptingMembers == YesNoMaybe.Yes)
                 {
                     <span class="badge bg-success">Accepting Members</span>
@@ -46,18 +54,13 @@
                 {
                     <span class="badge bg-warning text-dark">Full</span>
                 }
+                @if (Model.TimesAtNowhere > 0)
+                {
+                    <span class="badge bg-light text-dark border">
+                        <i class="fa-solid fa-fire text-warning me-1"></i>@Model.TimesAtNowhere year@(Model.TimesAtNowhere != 1 ? "s" : "")
+                    </span>
+                }
             </div>
-        </div>
-        <div class="card-footer bg-transparent">
-            <a asp-action="Details" asp-route-slug="@Model.Slug" class="btn btn-sm btn-outline-primary">
-                View Details
-            </a>
-            @if (Model.TimesAtNowhere > 0)
-            {
-                <small class="text-muted float-end mt-1">
-                    <i class="fa-solid fa-fire me-1"></i>@Model.TimesAtNowhere year@(Model.TimesAtNowhere != 1 ? "s" : "")
-                </small>
-            }
         </div>
     </div>
 </div>

--- a/src/Humans.Web/Views/Shared/_HumanPopover.cshtml
+++ b/src/Humans.Web/Views/Shared/_HumanPopover.cshtml
@@ -9,7 +9,7 @@
     {
         <div class="bg-secondary rounded-circle d-flex align-items-center justify-content-center text-white me-2"
              style="width: 72px; height: 72px; font-size: 1.25rem;">
-            @Model.DisplayName[..1]
+            @Model.DisplayName[..1].ToUpperInvariant()
         </div>
     }
     <div>

--- a/src/Humans.Web/Views/Shared/_HumanPopover.cshtml
+++ b/src/Humans.Web/Views/Shared/_HumanPopover.cshtml
@@ -3,20 +3,28 @@
 <div class="d-flex align-items-center" style="min-width: 200px;">
     @if (!string.IsNullOrEmpty(Model.ProfilePictureUrl))
     {
-        <img src="@Model.ProfilePictureUrl" alt="" class="rounded-circle me-2" style="width: 48px; height: 48px; object-fit: cover;" />
+        <img src="@Model.ProfilePictureUrl" alt="" class="rounded-circle me-2" style="width: 72px; height: 72px; object-fit: cover;" />
     }
     else
     {
         <div class="bg-secondary rounded-circle d-flex align-items-center justify-content-center text-white me-2"
-             style="width: 48px; height: 48px; font-size: 1rem;">
+             style="width: 72px; height: 72px; font-size: 1.25rem;">
             @Model.DisplayName[..1]
         </div>
     }
     <div>
         <div class="fw-semibold">@Model.DisplayName</div>
-        @if (!string.IsNullOrEmpty(Model.MembershipTier))
+        @if (!string.IsNullOrEmpty(Model.MembershipTier)
+            && !string.Equals(Model.MembershipTier, "Volunteer", StringComparison.OrdinalIgnoreCase))
         {
             <span class="badge bg-success" style="font-size: 0.7rem;">@Model.MembershipTier</span>
+        }
+        @if (!string.IsNullOrEmpty(Model.City) || !string.IsNullOrEmpty(Model.CountryCode))
+        {
+            <div class="text-muted small">
+                <i class="fa-solid fa-location-dot me-1"></i>@(string.Join(", ",
+                    new[] { Model.City, Model.CountryCode }.Where(s => !string.IsNullOrEmpty(s))))
+            </div>
         }
     </div>
 </div>

--- a/src/Humans.Web/Views/Shifts/Index.cshtml
+++ b/src/Humans.Web/Views/Shifts/Index.cshtml
@@ -239,7 +239,7 @@
                                                             {
                                                                 <human-link user-id="@signup.UserId" display-name="@signup.DisplayName" mode="Avatar" size="26"
                                                                            profile-picture-url="@signup.ProfilePictureUrl" show-popover="true"
-                                                                           title="@signup.DisplayName@(signup.Status == SignupStatus.Pending ? $" ({Localizer["Shifts_Pending"]})" : "")"
+                                                                           title="@signup.DisplayName@(signup.Status == SignupStatus.Pending ? $" {Localizer["Shifts_Pending"]}" : "")"
                                                                            class="@(signup.Status == SignupStatus.Pending ? "opacity-50" : "")"
                                                                            style="@(signup.Status == SignupStatus.Pending ? "border: 1px dashed #6c757d; border-radius: 50%;" : "")" />
                                                             }

--- a/src/Humans.Web/Views/Vol/_RotaCard.cshtml
+++ b/src/Humans.Web/Views/Vol/_RotaCard.cshtml
@@ -50,7 +50,7 @@
 
     @if (!string.IsNullOrEmpty(rota.PracticalInfo))
     {
-        <p class="text-muted small mb-1 mt-1">@rota.PracticalInfo</p>
+        <div class="text-muted small mb-1 mt-1">@Html.SanitizedMarkdown(rota.PracticalInfo)</div>
     }
 
     <div class="progress mt-2" style="height: 6px;">


### PR DESCRIPTION
## Summary
- **#223 Popover**: Enlarge photo/initial badge from 48→72px, hide Volunteer tier badge, filter Volunteers system team from team list, add City/CountryCode location display with graceful fallback
- **#224 Barrios cards**: Make entire card clickable via stretched-link on title, remove card-footer "View Details" button, relocate flame badge into card body, add localized photo placeholder (en+es) with camera icon when no image, consistent card heights via `d-flex flex-column` + `mt-auto`
- **#225 MarkdownContent attribute**: New `[MarkdownContent]` attribute in Domain, tagged on Rota.Description, Rota.PracticalInfo, Shift.Description, Team.PageContent, TeamRoleDefinition.Description, CampSeason.BlurbLong, CampSeason.KidsAreaDescription. Fixed raw output in `_RotaCard.cshtml` (PracticalInfo) and `Camp/Details.cshtml` (KidsAreaDescription). Team.Description assessed — left untagged (short description, not long-form markdown).

## Test plan
- [ ] Open any human-link popover → verify 72px photo, no "Volunteer" badge, no "Volunteers" team, city/country shown if available
- [ ] Browse /Camp → verify cards are fully clickable, no footer button, flame badge in body, placeholder shown for camps without images
- [ ] Check _RotaCard PracticalInfo renders markdown (bold, links, etc.)
- [ ] Check Camp Details KidsAreaDescription renders markdown
- [ ] Verify `[MarkdownContent]` attribute exists and compiles on tagged entity properties

🤖 Generated with [Claude Code](https://claude.com/claude-code)