### PR TITLE
feat: enhancements — timezone detection, admin digest, ticket reporting

### DIFF
--- a/src/Humans.Application/DTOs/AdminDigestCounts.cs
+++ b/src/Humans.Application/DTOs/AdminDigestCounts.cs
@@ -1,0 +1,15 @@
+namespace Humans.Application.DTOs;
+
+/// <summary>
+/// Counts for the Admin daily digest email — system health and operational items.
+/// </summary>
+public record AdminDigestCounts(
+    int PendingDeletions,
+    int PendingConsents,
+    int TeamJoinRequests,
+    int OnboardingReview,
+    int StillOnboarding,
+    int BoardVotingTotal,
+    int FailedSyncOutboxEvents,
+    bool TicketSyncError,
+    string? TicketSyncErrorMessage);

--- a/src/Humans.Application/Interfaces/IEmailRenderer.cs
+++ b/src/Humans.Application/Interfaces/IEmailRenderer.cs
@@ -86,6 +86,11 @@ public interface IEmailRenderer
     EmailContent RenderBoardDailyDigest(string boardMemberName, string date, IReadOnlyList<BoardDigestTierGroup> tierGroups, BoardDigestOutstandingCounts? outstandingCounts = null, string? culture = null);
 
     /// <summary>
+    /// Admin daily digest of system health and pending actions.
+    /// </summary>
+    EmailContent RenderAdminDailyDigest(string adminName, string date, AdminDigestCounts counts, string? culture = null);
+
+    /// <summary>
     /// Feedback response notification.
     /// </summary>
     EmailContent RenderFeedbackResponse(string userName, string originalDescription, string responseMessage, string reportLink, string? culture = null);

--- a/src/Humans.Application/Interfaces/IEmailService.cs
+++ b/src/Humans.Application/Interfaces/IEmailService.cs
@@ -231,6 +231,17 @@ public interface IEmailService
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Sends an Admin daily digest email summarizing system health and pending actions.
+    /// </summary>
+    Task SendAdminDailyDigestAsync(
+        string email,
+        string name,
+        string date,
+        AdminDigestCounts counts,
+        string? culture = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Sends a feedback response notification to the reporter.
     /// </summary>
     Task SendFeedbackResponseAsync(

--- a/src/Humans.Infrastructure/Jobs/SendAdminDailyDigestJob.cs
+++ b/src/Humans.Infrastructure/Jobs/SendAdminDailyDigestJob.cs
@@ -1,0 +1,164 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using NodaTime;
+using Humans.Application.DTOs;
+using Humans.Application.Extensions;
+using Humans.Application.Interfaces;
+using Humans.Domain.Constants;
+using Humans.Domain.Enums;
+using Humans.Infrastructure.Data;
+using Humans.Infrastructure.Services;
+
+namespace Humans.Infrastructure.Jobs;
+
+/// <summary>
+/// Daily job that emails each Admin a digest of system health and pending actions.
+/// </summary>
+public class SendAdminDailyDigestJob
+{
+    private readonly HumansDbContext _dbContext;
+    private readonly IEmailService _emailService;
+    private readonly IMembershipCalculator _membershipCalculator;
+    private readonly HumansMetricsService _metrics;
+    private readonly ILogger<SendAdminDailyDigestJob> _logger;
+    private readonly IClock _clock;
+
+    public SendAdminDailyDigestJob(
+        HumansDbContext dbContext,
+        IEmailService emailService,
+        IMembershipCalculator membershipCalculator,
+        HumansMetricsService metrics,
+        ILogger<SendAdminDailyDigestJob> logger,
+        IClock clock)
+    {
+        _dbContext = dbContext;
+        _emailService = emailService;
+        _membershipCalculator = membershipCalculator;
+        _metrics = metrics;
+        _logger = logger;
+        _clock = clock;
+    }
+
+    public async Task ExecuteAsync(CancellationToken cancellationToken = default)
+    {
+        var now = _clock.GetCurrentInstant();
+        var todayUtc = now.InUtc().Date;
+        var dateLabel = todayUtc.ToIsoDateString();
+
+        _logger.LogInformation("Starting Admin daily digest job for {Date}", dateLabel);
+
+        try
+        {
+            // Pending deletions
+            var pendingDeletionsCount = await _dbContext.Users
+                .CountAsync(u => u.DeletionRequestedAt != null, cancellationToken);
+
+            // Pending consents
+            var allUserIds = await _dbContext.Users.Select(u => u.Id).ToListAsync(cancellationToken);
+            var usersWithAllConsents = await _membershipCalculator.GetUsersWithAllRequiredConsentsAsync(allUserIds, cancellationToken);
+
+            var leadUserIds = await _dbContext.TeamMembers
+                .Where(tm => tm.LeftAt == null && tm.Role == TeamMemberRole.Coordinator && tm.Team.SystemTeamType == SystemTeamType.None)
+                .Select(tm => tm.UserId)
+                .Distinct()
+                .ToListAsync(cancellationToken);
+            var leadsWithAllConsents = leadUserIds.Count > 0
+                ? await _membershipCalculator.GetUsersWithAllRequiredConsentsForTeamAsync(leadUserIds, SystemTeamIds.Coordinators, cancellationToken)
+                : (IReadOnlySet<Guid>)new HashSet<Guid>();
+
+            var pendingConsentsCount = allUserIds.Count(id =>
+                !usersWithAllConsents.Contains(id) ||
+                (leadUserIds.Contains(id) && !leadsWithAllConsents.Contains(id)));
+
+            // Team join requests
+            var teamJoinRequestCount = await _dbContext.TeamJoinRequests
+                .CountAsync(r => r.Status == TeamJoinRequestStatus.Pending, cancellationToken);
+
+            // Onboarding review
+            var onboardingReviewCount = await _dbContext.Profiles
+                .CountAsync(p => p.ConsentCheckStatus != null
+                    && (p.ConsentCheckStatus == ConsentCheckStatus.Pending || p.ConsentCheckStatus == ConsentCheckStatus.Flagged)
+                    && p.RejectedAt == null, cancellationToken);
+
+            var totalNotApproved = await _dbContext.Profiles
+                .CountAsync(p => !p.IsApproved && !p.IsSuspended, cancellationToken);
+            var stillOnboardingCount = Math.Max(0, totalNotApproved - onboardingReviewCount);
+
+            // Board voting
+            var boardVotingTotal = await _dbContext.Applications
+                .CountAsync(a => a.Status == ApplicationStatus.Submitted, cancellationToken);
+
+            // Stale Google sync outbox events (unprocessed with errors)
+            var failedSyncEvents = await _dbContext.GoogleSyncOutboxEvents
+                .CountAsync(e => e.ProcessedAt == null && e.LastError != null, cancellationToken);
+
+            // Ticket sync status
+            var ticketSyncState = await _dbContext.TicketSyncStates.FindAsync([1], cancellationToken);
+            var ticketSyncError = ticketSyncState?.SyncStatus == TicketSyncStatus.Error;
+            var ticketSyncErrorMessage = ticketSyncError ? ticketSyncState?.LastError : null;
+
+            var counts = new AdminDigestCounts(
+                pendingDeletionsCount,
+                pendingConsentsCount,
+                teamJoinRequestCount,
+                onboardingReviewCount,
+                stillOnboardingCount,
+                boardVotingTotal,
+                failedSyncEvents,
+                ticketSyncError,
+                ticketSyncErrorMessage);
+
+            // Skip if everything is clear
+            var hasItems = pendingDeletionsCount > 0 || pendingConsentsCount > 0
+                || teamJoinRequestCount > 0 || onboardingReviewCount > 0
+                || stillOnboardingCount > 0 || boardVotingTotal > 0
+                || failedSyncEvents > 0 || ticketSyncError;
+
+            if (!hasItems)
+            {
+                _logger.LogInformation("No pending items on {Date}, skipping Admin digest", dateLabel);
+                _metrics.RecordJobRun("admin_daily_digest", "skipped");
+                return;
+            }
+
+            // Find active Admins
+            var admins = await _dbContext.RoleAssignments
+                .Include(ra => ra.User)
+                    .ThenInclude(u => u.UserEmails)
+                .Where(ra => ra.RoleName == RoleNames.Admin
+                    && ra.ValidFrom <= now
+                    && (ra.ValidTo == null || ra.ValidTo.Value > now))
+                .Select(ra => ra.User)
+                .Distinct()
+                .ToListAsync(cancellationToken);
+
+            var sentCount = 0;
+            foreach (var admin in admins)
+            {
+                var email = admin.GetEffectiveEmail();
+                if (email is null)
+                {
+                    _logger.LogWarning("Admin {UserId} ({Name}) has no effective email, skipping digest",
+                        admin.Id, admin.DisplayName);
+                    continue;
+                }
+
+                await _emailService.SendAdminDailyDigestAsync(
+                    email, admin.DisplayName, dateLabel, counts,
+                    admin.PreferredLanguage, cancellationToken);
+                sentCount++;
+            }
+
+            _metrics.RecordJobRun("admin_daily_digest", "success");
+            _logger.LogInformation(
+                "Admin daily digest sent to {Count} admins for {Date}",
+                sentCount, dateLabel);
+        }
+        catch (Exception ex)
+        {
+            _metrics.RecordJobRun("admin_daily_digest", "failure");
+            _logger.LogError(ex, "Error sending Admin daily digest for {Date}", dateLabel);
+            throw;
+        }
+    }
+}

--- a/src/Humans.Infrastructure/Services/EmailRenderer.cs
+++ b/src/Humans.Infrastructure/Services/EmailRenderer.cs
@@ -329,6 +329,45 @@ public class EmailRenderer : IEmailRenderer
         return $"<h3>{HtmlEncode(header)}</h3>\n<ul>\n{string.Join("\n", items)}\n</ul>\n<hr/>";
     }
 
+    public EmailContent RenderAdminDailyDigest(string adminName, string date, AdminDigestCounts counts, string? culture = null)
+    {
+        // Admin digest is always English (admin pages aren't localized)
+        var subject = $"Admin Digest: {date}";
+
+        var items = new List<string>();
+
+        if (counts.PendingDeletions > 0)
+            items.Add($"<li><strong>{counts.PendingDeletions}</strong> account deletions pending <a href=\"{_settings.BaseUrl}/Admin\">&rarr;</a></li>");
+
+        if (counts.PendingConsents > 0)
+            items.Add($"<li><strong>{counts.PendingConsents}</strong> with outstanding consent requirements</li>");
+
+        if (counts.TeamJoinRequests > 0)
+            items.Add($"<li><strong>{counts.TeamJoinRequests}</strong> team join requests pending <a href=\"{_settings.BaseUrl}/Admin\">&rarr;</a></li>");
+
+        if (counts.OnboardingReview > 0)
+            items.Add($"<li><strong>{counts.OnboardingReview}</strong> awaiting onboarding review <a href=\"{_settings.BaseUrl}/OnboardingReview\">&rarr;</a></li>");
+
+        if (counts.StillOnboarding > 0)
+            items.Add($"<li><strong>{counts.StillOnboarding}</strong> still completing onboarding</li>");
+
+        if (counts.BoardVotingTotal > 0)
+            items.Add($"<li><strong>{counts.BoardVotingTotal}</strong> tier applications awaiting vote</li>");
+
+        if (counts.FailedSyncOutboxEvents > 0)
+            items.Add($"<li><strong>{counts.FailedSyncOutboxEvents}</strong> failed Google sync outbox events</li>");
+
+        if (counts.TicketSyncError)
+            items.Add($"<li>Ticket sync error: {HtmlEncode(counts.TicketSyncErrorMessage ?? "Unknown")}</li>");
+
+        var itemsHtml = items.Count > 0
+            ? $"<ul>\n{string.Join("\n", items)}\n</ul>"
+            : "<p>All clear — no pending items.</p>";
+
+        var body = $"<h2>Admin Digest — {HtmlEncode(date)}</h2>\n<p>Hi {HtmlEncode(adminName)},</p>\n<h3>Pending Actions &amp; System Health</h3>\n{itemsHtml}";
+        return new EmailContent(subject, body);
+    }
+
     public EmailContent RenderFeedbackResponse(string userName, string originalDescription, string responseMessage, string reportLink, string? culture = null)
     {
         using (WithCulture(culture))

--- a/src/Humans.Infrastructure/Services/OutboxEmailService.cs
+++ b/src/Humans.Infrastructure/Services/OutboxEmailService.cs
@@ -234,6 +234,19 @@ public class OutboxEmailService : IEmailService
     }
 
     /// <inheritdoc />
+    public async Task SendAdminDailyDigestAsync(
+        string email,
+        string name,
+        string date,
+        AdminDigestCounts counts,
+        string? culture = null,
+        CancellationToken cancellationToken = default)
+    {
+        var content = _renderer.RenderAdminDailyDigest(name, date, counts, culture);
+        await EnqueueAsync(email, name, content, "admin_daily_digest", cancellationToken);
+    }
+
+    /// <inheritdoc />
     public async Task SendFeedbackResponseAsync(
         string userEmail, string userName, string originalDescription,
         string responseMessage, string reportLink, string? culture = null,

--- a/src/Humans.Infrastructure/Services/SmtpEmailService.cs
+++ b/src/Humans.Infrastructure/Services/SmtpEmailService.cs
@@ -229,6 +229,20 @@ public class SmtpEmailService : IEmailService
     }
 
     /// <inheritdoc />
+    public async Task SendAdminDailyDigestAsync(
+        string email,
+        string name,
+        string date,
+        AdminDigestCounts counts,
+        string? culture = null,
+        CancellationToken cancellationToken = default)
+    {
+        var content = _renderer.RenderAdminDailyDigest(name, date, counts, culture);
+        await SendEmailAsync(email, content.Subject, content.HtmlBody, cancellationToken);
+        _metrics.RecordEmailSent("admin_daily_digest");
+    }
+
+    /// <inheritdoc />
     public async Task SendFeedbackResponseAsync(
         string userEmail, string userName, string originalDescription,
         string responseMessage, string reportLink, string? culture = null,

--- a/src/Humans.Infrastructure/Services/StubEmailService.cs
+++ b/src/Humans.Infrastructure/Services/StubEmailService.cs
@@ -206,6 +206,20 @@ public class StubEmailService : IEmailService
         return Task.CompletedTask;
     }
 
+    public Task SendAdminDailyDigestAsync(
+        string email,
+        string name,
+        string date,
+        AdminDigestCounts counts,
+        string? culture = null,
+        CancellationToken cancellationToken = default)
+    {
+        _logger.LogInformation(
+            "[STUB] Would send Admin daily digest to {Email} ({Name}) [Culture: {Culture}] for {Date} with counts: {@Counts}",
+            email, name, culture, date, counts);
+        return Task.CompletedTask;
+    }
+
     public Task SendFeedbackResponseAsync(
         string userEmail, string userName, string originalDescription,
         string responseMessage, string reportLink, string? culture = null,

--- a/src/Humans.Web/Controllers/TicketController.cs
+++ b/src/Humans.Web/Controllers/TicketController.cs
@@ -446,6 +446,68 @@ public class TicketController : HumansControllerBase
         return View(model);
     }
 
+    [HttpGet("SalesAggregates")]
+    public async Task<IActionResult> SalesAggregates()
+    {
+        // Load all paid orders with attendee counts in memory (small dataset at ~1,500 orders)
+        var orders = await _dbContext.TicketOrders
+            .Where(o => o.PaymentStatus == TicketPaymentStatus.Paid)
+            .Select(o => new { o.PurchasedAt, o.TotalAmount, AttendeeCount = o.Attendees.Count })
+            .ToListAsync();
+
+        // Weekly aggregates (ISO weeks, Mon–Sun)
+        var weeklySales = orders
+            .GroupBy(o =>
+            {
+                var date = o.PurchasedAt.InUtc().Date;
+                // NodaTime ISO day of week: Monday=1, Sunday=7
+                var monday = date.PlusDays(-(int)date.DayOfWeek + 1);
+                return monday;
+            })
+            .OrderBy(g => g.Key)
+            .Select(g =>
+            {
+                var monday = g.Key;
+                var sunday = monday.PlusDays(6);
+                return new WeeklySalesRow
+                {
+                    WeekLabel = $"{monday.ToString("MMM d", null)} – {sunday.ToString("MMM d", null)}",
+                    TicketsSold = g.Sum(o => o.AttendeeCount),
+                    GrossRevenue = g.Sum(o => o.TotalAmount),
+                    OrderCount = g.Count()
+                };
+            })
+            .ToList();
+
+        // Quarterly aggregates (Spanish tax quarters: Q1=Jan-Mar, Q2=Apr-Jun, Q3=Jul-Sep, Q4=Oct-Dec)
+        var quarterlySales = orders
+            .GroupBy(o =>
+            {
+                var date = o.PurchasedAt.InUtc().Date;
+                var quarter = (date.Month - 1) / 3 + 1;
+                return (date.Year, quarter);
+            })
+            .OrderBy(g => g.Key.Year).ThenBy(g => g.Key.quarter)
+            .Select(g => new QuarterlySalesRow
+            {
+                QuarterLabel = $"Q{g.Key.quarter} {g.Key.Year}",
+                Year = g.Key.Year,
+                Quarter = g.Key.quarter,
+                TicketsSold = g.Sum(o => o.AttendeeCount),
+                GrossRevenue = g.Sum(o => o.TotalAmount),
+                OrderCount = g.Count()
+            })
+            .ToList();
+
+        var model = new TicketSalesAggregatesViewModel
+        {
+            WeeklySales = weeklySales,
+            QuarterlySales = quarterlySales,
+        };
+
+        return View(model);
+    }
+
     [HttpPost("Sync")]
     [ValidateAntiForgeryToken]
     [Authorize(Roles = RoleGroups.TicketAdminOrAdmin)]

--- a/src/Humans.Web/Controllers/TimezoneApiController.cs
+++ b/src/Humans.Web/Controllers/TimezoneApiController.cs
@@ -1,0 +1,28 @@
+using Microsoft.AspNetCore.Mvc;
+using NodaTime;
+
+namespace Humans.Web.Controllers;
+
+[ApiController]
+[Route("api/timezone")]
+public class TimezoneApiController : ControllerBase
+{
+    public const string SessionKey = "UserTimeZone";
+
+    [HttpPost]
+    public IActionResult SetTimezone([FromBody] TimezoneRequest request)
+    {
+        if (string.IsNullOrWhiteSpace(request.TimeZone))
+            return BadRequest();
+
+        // Validate the timezone ID is known to NodaTime
+        var zone = DateTimeZoneProviders.Tzdb.GetZoneOrNull(request.TimeZone);
+        if (zone is null)
+            return BadRequest();
+
+        HttpContext.Session.SetString(SessionKey, request.TimeZone);
+        return Ok();
+    }
+
+    public record TimezoneRequest(string TimeZone);
+}

--- a/src/Humans.Web/Extensions/DateTimeDisplayExtensions.cs
+++ b/src/Humans.Web/Extensions/DateTimeDisplayExtensions.cs
@@ -1,11 +1,43 @@
 using System.Globalization;
 using Humans.Web.Controllers;
+using Microsoft.AspNetCore.Http;
 using NodaTime;
 
 namespace Humans.Web.Extensions;
 
 public static class DateTimeDisplayExtensions
 {
+    private static IHttpContextAccessor? _httpContextAccessor;
+
+    /// <summary>
+    /// Called once at startup to provide the IHttpContextAccessor.
+    /// After this, all parameterless Instant display methods automatically
+    /// resolve the user's timezone from the current request session.
+    /// </summary>
+    public static void Initialize(IHttpContextAccessor httpContextAccessor)
+    {
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    /// <summary>
+    /// Resolves the current user's timezone from session → UTC fallback.
+    /// Used internally by parameterless Instant overloads.
+    /// </summary>
+    private static DateTimeZone GetCurrentUserTimeZone()
+    {
+        var session = _httpContextAccessor?.HttpContext?.Session;
+        if (session is null) return DateTimeZone.Utc;
+
+        var sessionTz = session.GetString(TimezoneApiController.SessionKey);
+        if (!string.IsNullOrEmpty(sessionTz))
+        {
+            var zone = DateTimeZoneProviders.Tzdb.GetZoneOrNull(sessionTz);
+            if (zone is not null) return zone;
+        }
+
+        return DateTimeZone.Utc;
+    }
+
     /// <summary>
     /// Resolves the user's timezone from session, falling back to the event default or UTC.
     /// Fallback chain: session timezone → eventTimeZoneId → UTC.
@@ -28,7 +60,7 @@ public static class DateTimeDisplayExtensions
         return DateTimeZone.Utc;
     }
 
-    // --- Timezone-aware Instant overloads ---
+    // --- Timezone-aware Instant overloads (explicit) ---
 
     public static string ToDisplayDate(this Instant value, DateTimeZone timeZone) =>
         value.InZone(timeZone).Date.ToDisplayDate();
@@ -45,6 +77,7 @@ public static class DateTimeDisplayExtensions
     public static string ToDisplayCompactDayTime(this Instant value, DateTimeZone timeZone) =>
         value.InZone(timeZone).ToDateTimeUnspecified().ToDisplayCompactDayTime();
 
+    // --- DateTime display methods ---
 
     public static string ToDisplayDate(this DateTime value) =>
         value.ToString("d MMM yyyy", CultureInfo.CurrentCulture);
@@ -53,7 +86,7 @@ public static class DateTimeDisplayExtensions
         value?.ToDisplayDate();
 
     public static string ToDisplayDate(this Instant value) =>
-        value.ToDateTimeUtc().ToDisplayDate();
+        value.InZone(GetCurrentUserTimeZone()).ToDateTimeUnspecified().ToDisplayDate();
 
     public static string? ToDisplayDate(this Instant? value) =>
         value?.ToDisplayDate();
@@ -71,7 +104,7 @@ public static class DateTimeDisplayExtensions
         value?.ToDisplayLongDate();
 
     public static string ToDisplayLongDate(this Instant value) =>
-        value.ToDateTimeUtc().ToDisplayLongDate();
+        value.InZone(GetCurrentUserTimeZone()).ToDateTimeUnspecified().ToDisplayLongDate();
 
     public static string? ToDisplayLongDate(this Instant? value) =>
         value?.ToDisplayLongDate();
@@ -83,7 +116,7 @@ public static class DateTimeDisplayExtensions
         value?.ToDisplayLongDateTime();
 
     public static string ToDisplayLongDateTime(this Instant value) =>
-        value.ToDateTimeUtc().ToDisplayLongDateTime();
+        value.InZone(GetCurrentUserTimeZone()).ToDateTimeUnspecified().ToDisplayLongDateTime();
 
     public static string? ToDisplayLongDateTime(this Instant? value) =>
         value?.ToDisplayLongDateTime();
@@ -95,7 +128,7 @@ public static class DateTimeDisplayExtensions
         value?.ToDisplayDateTime();
 
     public static string ToDisplayDateTime(this Instant value) =>
-        value.ToDateTimeUtc().ToDisplayDateTime();
+        value.InZone(GetCurrentUserTimeZone()).ToDateTimeUnspecified().ToDisplayDateTime();
 
     public static string? ToDisplayDateTime(this Instant? value) =>
         value?.ToDisplayDateTime();
@@ -107,7 +140,7 @@ public static class DateTimeDisplayExtensions
         value?.ToDisplayCompactDate();
 
     public static string ToDisplayCompactDate(this Instant value) =>
-        value.ToDateTimeUtc().ToDisplayCompactDate();
+        value.InZone(GetCurrentUserTimeZone()).ToDateTimeUnspecified().ToDisplayCompactDate();
 
     public static string? ToDisplayCompactDate(this Instant? value) =>
         value?.ToDisplayCompactDate();
@@ -119,13 +152,13 @@ public static class DateTimeDisplayExtensions
         value?.ToDisplayCompactDateTime();
 
     public static string ToDisplayCompactDateTime(this Instant value) =>
-        value.ToDateTimeUtc().ToDisplayCompactDateTime();
+        value.InZone(GetCurrentUserTimeZone()).ToDateTimeUnspecified().ToDisplayCompactDateTime();
 
     public static string? ToDisplayCompactDateTime(this Instant? value) =>
         value?.ToDisplayCompactDateTime();
 
     public static string ToDisplayCompactDayTime(this Instant value) =>
-        value.ToDateTimeUtc().ToDisplayCompactDayTime();
+        value.InZone(GetCurrentUserTimeZone()).ToDateTimeUnspecified().ToDisplayCompactDayTime();
 
     public static string ToDisplayCompactDayTime(this DateTime value) =>
         value.ToString("MMM d", CultureInfo.CurrentCulture) + " @ " + value.ToString("HH:mm", CultureInfo.InvariantCulture);

--- a/src/Humans.Web/Extensions/DateTimeDisplayExtensions.cs
+++ b/src/Humans.Web/Extensions/DateTimeDisplayExtensions.cs
@@ -1,10 +1,51 @@
 using System.Globalization;
+using Humans.Web.Controllers;
 using NodaTime;
 
 namespace Humans.Web.Extensions;
 
 public static class DateTimeDisplayExtensions
 {
+    /// <summary>
+    /// Resolves the user's timezone from session, falling back to the event default or UTC.
+    /// Fallback chain: session timezone → eventTimeZoneId → UTC.
+    /// </summary>
+    public static DateTimeZone GetUserTimeZone(this ISession session, string? eventTimeZoneId = null)
+    {
+        var sessionTz = session.GetString(TimezoneApiController.SessionKey);
+        if (!string.IsNullOrEmpty(sessionTz))
+        {
+            var zone = DateTimeZoneProviders.Tzdb.GetZoneOrNull(sessionTz);
+            if (zone is not null) return zone;
+        }
+
+        if (!string.IsNullOrEmpty(eventTimeZoneId))
+        {
+            var zone = DateTimeZoneProviders.Tzdb.GetZoneOrNull(eventTimeZoneId);
+            if (zone is not null) return zone;
+        }
+
+        return DateTimeZone.Utc;
+    }
+
+    // --- Timezone-aware Instant overloads ---
+
+    public static string ToDisplayDate(this Instant value, DateTimeZone timeZone) =>
+        value.InZone(timeZone).Date.ToDisplayDate();
+
+    public static string ToDisplayDateTime(this Instant value, DateTimeZone timeZone) =>
+        value.InZone(timeZone).ToDateTimeUnspecified().ToDisplayDateTime();
+
+    public static string ToDisplayCompactDate(this Instant value, DateTimeZone timeZone) =>
+        value.InZone(timeZone).ToDateTimeUnspecified().ToDisplayCompactDate();
+
+    public static string ToDisplayCompactDateTime(this Instant value, DateTimeZone timeZone) =>
+        value.InZone(timeZone).ToDateTimeUnspecified().ToDisplayCompactDateTime();
+
+    public static string ToDisplayCompactDayTime(this Instant value, DateTimeZone timeZone) =>
+        value.InZone(timeZone).ToDateTimeUnspecified().ToDisplayCompactDayTime();
+
+
     public static string ToDisplayDate(this DateTime value) =>
         value.ToString("d MMM yyyy", CultureInfo.CurrentCulture);
 

--- a/src/Humans.Web/Extensions/RecurringJobExtensions.cs
+++ b/src/Humans.Web/Extensions/RecurringJobExtensions.cs
@@ -47,9 +47,13 @@ public static class RecurringJobExtensions
             ("term-renewal-reminder", () => RecurringJob.AddOrUpdate<TermRenewalReminderJob>(
                 "term-renewal-reminder", job => job.ExecuteAsync(CancellationToken.None), "0 5 * * 1")),
 
-            // Send Board daily digest of new approvals from the previous UTC day.
+            // Send Board digest of new approvals — every other day (odd days of month) at 02:00 UTC.
             ("send-board-daily-digest", () => RecurringJob.AddOrUpdate<SendBoardDailyDigestJob>(
-                "send-board-daily-digest", job => job.ExecuteAsync(CancellationToken.None), "0 2 * * *")),
+                "send-board-daily-digest", job => job.ExecuteAsync(CancellationToken.None), "0 2 1-31/2 * *")),
+
+            // Send Admin daily digest of system health and pending actions at 02:30 UTC.
+            ("send-admin-daily-digest", () => RecurringJob.AddOrUpdate<SendAdminDailyDigestJob>(
+                "send-admin-daily-digest", job => job.ExecuteAsync(CancellationToken.None), "30 2 * * *")),
 
             ("process-email-outbox", () => RecurringJob.AddOrUpdate<ProcessEmailOutboxJob>(
                 "process-email-outbox", job => job.ExecuteAsync(CancellationToken.None), "*/1 * * * *")),

--- a/src/Humans.Web/Models/TicketViewModels.cs
+++ b/src/Humans.Web/Models/TicketViewModels.cs
@@ -146,6 +146,31 @@ public class CampaignCodeSummary
     public decimal RedemptionRate { get; set; }
 }
 
+public class TicketSalesAggregatesViewModel
+{
+    public List<WeeklySalesRow> WeeklySales { get; set; } = [];
+    public List<QuarterlySalesRow> QuarterlySales { get; set; } = [];
+    public string Currency { get; set; } = "EUR";
+}
+
+public class WeeklySalesRow
+{
+    public string WeekLabel { get; set; } = string.Empty; // "Mar 3 – Mar 9"
+    public int TicketsSold { get; set; }
+    public decimal GrossRevenue { get; set; }
+    public int OrderCount { get; set; }
+}
+
+public class QuarterlySalesRow
+{
+    public string QuarterLabel { get; set; } = string.Empty; // "Q1 2026"
+    public int Year { get; set; }
+    public int Quarter { get; set; }
+    public int TicketsSold { get; set; }
+    public decimal GrossRevenue { get; set; }
+    public int OrderCount { get; set; }
+}
+
 public class WhoHasntBoughtViewModel : PagedListViewModel
 {
     public WhoHasntBoughtViewModel() : base(25)

--- a/src/Humans.Web/Program.cs
+++ b/src/Humans.Web/Program.cs
@@ -270,6 +270,15 @@ builder.Services.AddRateLimiter(options =>
 // No explicit config needed — the app is only reachable through Traefik/Coolify
 // on internal Docker networks, so trusting any proxy is safe.
 
+// Session (used for browser-detected timezone — no DB migration needed)
+builder.Services.AddDistributedMemoryCache();
+builder.Services.AddSession(options =>
+{
+    options.IdleTimeout = TimeSpan.FromHours(8);
+    options.Cookie.HttpOnly = true;
+    options.Cookie.IsEssential = true;
+});
+
 // Configure Localization
 builder.Services.AddLocalization();
 
@@ -429,6 +438,8 @@ app.UseSerilogRequestLogging();
 
 app.UseAuthentication();
 app.UseAuthorization();
+
+app.UseSession();
 
 app.UseRequestLocalization();
 

--- a/src/Humans.Web/Program.cs
+++ b/src/Humans.Web/Program.cs
@@ -315,6 +315,10 @@ builder.Services.Configure<RequestLocalizationOptions>(options =>
 
 var app = builder.Build();
 
+// Initialize timezone-aware display extensions with IHttpContextAccessor
+// so all Instant.ToDisplay*() calls automatically use the user's session timezone.
+DateTimeDisplayExtensions.Initialize(app.Services.GetRequiredService<IHttpContextAccessor>());
+
 // Eagerly resolve HumansMetricsService so the background gauge-refresh timer starts
 // immediately — otherwise observable gauges emit nothing until first injection.
 app.Services.GetRequiredService<HumansMetricsService>();

--- a/src/Humans.Web/Views/Ticket/SalesAggregates.cshtml
+++ b/src/Humans.Web/Views/Ticket/SalesAggregates.cshtml
@@ -1,0 +1,124 @@
+@model Humans.Web.Models.TicketSalesAggregatesViewModel
+@{
+    ViewData["Title"] = "Sales Aggregates";
+}
+
+<div class="container-fluid px-4">
+    <div class="d-flex justify-content-between align-items-center mt-4 mb-2">
+        <h1 class="mb-0">Tickets</h1>
+        <vc:access-matrix section="Tickets" />
+    </div>
+
+    <partial name="_TicketNav" />
+
+    <!-- Weekly Sales -->
+    <div class="card mb-4">
+        <div class="card-header">
+            <i class="fa-solid fa-calendar-week"></i> Weekly Sales (Mon–Sun)
+        </div>
+        <div class="card-body p-0">
+            @if (Model.WeeklySales.Count > 0)
+            {
+                <table class="table table-sm table-hover mb-0">
+                    <thead>
+                        <tr>
+                            <th>Week</th>
+                            <th class="text-end">Orders</th>
+                            <th class="text-end">Tickets Sold</th>
+                            <th class="text-end">Gross Revenue</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var week in Model.WeeklySales)
+                        {
+                            <tr>
+                                <td>@week.WeekLabel</td>
+                                <td class="text-end">@week.OrderCount.ToString("N0")</td>
+                                <td class="text-end">@week.TicketsSold.ToString("N0")</td>
+                                <td class="text-end">@Model.Currency @week.GrossRevenue.ToString("N2")</td>
+                            </tr>
+                        }
+                    </tbody>
+                    <tfoot>
+                        <tr class="fw-bold">
+                            <td>Total</td>
+                            <td class="text-end">@Model.WeeklySales.Sum(w => w.OrderCount).ToString("N0")</td>
+                            <td class="text-end">@Model.WeeklySales.Sum(w => w.TicketsSold).ToString("N0")</td>
+                            <td class="text-end">@Model.Currency @Model.WeeklySales.Sum(w => w.GrossRevenue).ToString("N2")</td>
+                        </tr>
+                    </tfoot>
+                </table>
+            }
+            else
+            {
+                <div class="text-muted text-center py-3">No paid orders yet.</div>
+            }
+        </div>
+    </div>
+
+    <!-- Quarterly Sales (Spanish Tax Quarters) -->
+    <div class="card mb-4">
+        <div class="card-header">
+            <i class="fa-solid fa-chart-pie"></i> Quarterly Sales (Spanish Tax Quarters)
+        </div>
+        <div class="card-body p-0">
+            @if (Model.QuarterlySales.Count > 0)
+            {
+                <table class="table table-sm table-hover mb-0">
+                    <thead>
+                        <tr>
+                            <th>Quarter</th>
+                            <th class="text-end">Orders</th>
+                            <th class="text-end">Tickets Sold</th>
+                            <th class="text-end">Gross Revenue</th>
+                            <th class="text-end text-muted">VAT (est. 10%)</th>
+                            <th class="text-end text-muted">Net (est.)</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var q in Model.QuarterlySales)
+                        {
+                            var estimatedVat = Math.Round(q.GrossRevenue / 1.10m * 0.10m, 2);
+                            var estimatedNet = q.GrossRevenue - estimatedVat;
+                            <tr>
+                                <td>@q.QuarterLabel</td>
+                                <td class="text-end">@q.OrderCount.ToString("N0")</td>
+                                <td class="text-end">@q.TicketsSold.ToString("N0")</td>
+                                <td class="text-end">@Model.Currency @q.GrossRevenue.ToString("N2")</td>
+                                <td class="text-end text-muted">@Model.Currency @estimatedVat.ToString("N2")</td>
+                                <td class="text-end text-muted">@Model.Currency @estimatedNet.ToString("N2")</td>
+                            </tr>
+                        }
+                    </tbody>
+                    <tfoot>
+                        @{
+                            var totalGross = Model.QuarterlySales.Sum(q => q.GrossRevenue);
+                            var totalVat = Math.Round(totalGross / 1.10m * 0.10m, 2);
+                            var totalNet = totalGross - totalVat;
+                        }
+                        <tr class="fw-bold">
+                            <td>Total</td>
+                            <td class="text-end">@Model.QuarterlySales.Sum(q => q.OrderCount).ToString("N0")</td>
+                            <td class="text-end">@Model.QuarterlySales.Sum(q => q.TicketsSold).ToString("N0")</td>
+                            <td class="text-end">@Model.Currency @totalGross.ToString("N2")</td>
+                            <td class="text-end text-muted">@Model.Currency @totalVat.ToString("N2")</td>
+                            <td class="text-end text-muted">@Model.Currency @totalNet.ToString("N2")</td>
+                        </tr>
+                    </tfoot>
+                </table>
+                <div class="px-3 py-2">
+                    <small class="text-muted">
+                        <i class="fa-solid fa-circle-info"></i>
+                        VAT and net estimates assume 10% Spanish event ticket rate applied uniformly.
+                        Accurate VAT split (distinguishing VIP donations and standalone donations) requires
+                        additional data fields — see <a href="https://github.com/nobodies-collective/Humans/issues/217">#217</a> for details.
+                    </small>
+                </div>
+            }
+            else
+            {
+                <div class="text-muted text-center py-3">No paid orders yet.</div>
+            }
+        </div>
+    </div>
+</div>

--- a/src/Humans.Web/Views/Ticket/_TicketNav.cshtml
+++ b/src/Humans.Web/Views/Ticket/_TicketNav.cshtml
@@ -18,6 +18,9 @@
         <a class="nav-link @(controller == "WhoHasntBought" ? "active" : "")" asp-action="WhoHasntBought">Humans</a>
     </li>
     <li class="nav-item">
+        <a class="nav-link @(controller == "SalesAggregates" ? "active" : "")" asp-action="SalesAggregates">Aggregates</a>
+    </li>
+    <li class="nav-item">
         <a class="nav-link @(controller == "GateList" ? "active" : "")" asp-action="GateList">Gate List</a>
     </li>
 </ul>

--- a/src/Humans.Web/wwwroot/js/site.js
+++ b/src/Humans.Web/wwwroot/js/site.js
@@ -46,6 +46,22 @@ document.addEventListener('click', function (e) {
     }
 });
 
+// Timezone detection — send browser IANA timezone to server session (once per session)
+(function () {
+    try {
+        var tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+        if (tz && !sessionStorage.getItem('tz_sent')) {
+            fetch('/api/timezone', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ timeZone: tz })
+            }).then(function (r) {
+                if (r.ok) sessionStorage.setItem('tz_sent', '1');
+            });
+        }
+    } catch (_) { /* Intl not supported — fall back to server default */ }
+})();
+
 // Human profile popover (lazy-loaded on first hover)
 (function () {
     var cache = {};


### PR DESCRIPTION
## Summary

- **#238 Timezone detection**: Browser timezone detected via `Intl.DateTimeFormat().resolvedOptions().timeZone`, sent to server via `/api/timezone`, stored in HTTP session. New `GetUserTimeZone()` extension on `ISession` with fallback chain (session → EventSettings → UTC). Timezone-aware `Instant` display overloads added to `DateTimeDisplayExtensions`. Session middleware added to `Program.cs`. No migration.

- **#228 Admin digest + board schedule**: New `SendAdminDailyDigestJob` sends daily digest (02:30 UTC) to Admin role users covering: pending deletions, outstanding consents, team join requests, onboarding review, board voting backlog, failed Google sync outbox events, and ticket sync errors. Board digest schedule changed from daily (`0 2 * * *`) to every-other-day (`0 2 1-31/2 * *`). Full email pipeline: DTO, IEmailService, IEmailRenderer, OutboxEmailService, StubEmailService, SmtpEmailService.

- **#217 Ticket reporting (partial)**: New `/Tickets/SalesAggregates` page with weekly (Mon–Sun) and quarterly (Spanish tax Q1–Q4) aggregate tables showing order count, tickets sold, and gross revenue. Quarterly view includes estimated VAT/net columns with disclaimer. Nav tab added to ticket nav.

### #217 — VAT/VIP/Donation status (deferred)

TT API investigation confirms 4 line item types: `ticket`, `gift_card`, `donation`, `tax`. 7 orders currently have standalone donations (10–50 EUR). TT also returns a `tax` line item per order — **however, TT's VAT calculation is incorrect**: it applies 10% to the full ticket price, not accounting for the VIP split (first €315 taxable, remainder is VAT-free donation). We need to compute VAT ourselves with the split logic. This requires entity changes (`DonationAmount`, `VatAmount` on `TicketOrder`) and sync service updates — deferred to a follow-up.

Closes #238, closes #228

## Test plan
- [ ] Verify timezone JS fires on page load (check Network tab for `/api/timezone` POST)
- [ ] Verify session stores timezone (inspect via `/api/timezone` response)
- [ ] Verify Admin digest job appears in Hangfire dashboard
- [ ] Verify Board digest cron changed to every-other-day
- [ ] Verify `/Tickets/SalesAggregates` shows weekly and quarterly tables
- [ ] Verify Aggregates tab appears in ticket nav

🤖 Generated with [Claude Code](https://claude.com/claude-code)