### PR TITLE
Shift browse UX: date picker fix, row compression, urgency scoring

### DIFF
--- a/docs/features/25-shift-management.md
+++ b/docs/features/25-shift-management.md
@@ -119,10 +119,11 @@ Pending --> Cancelled   (system: shift deleted, account deletion)
 
 ## Urgency Scoring
 
-`score = remainingSlots * priorityWeight * durationHours * understaffedMultiplier`
+`score = remainingSlots * priorityWeight * durationHours * understaffedMultiplier * proximityBoost`
 
 - Priority weights: Normal=1, Important=3, Essential=6
 - Understaffed multiplier: 2x when confirmed < minVolunteers, else 1x
+- Proximity boost: `1 + 10 / (1 + daysUntilStart)` — today ~11x, tomorrow ~6x, 7 days ~2.25x, 30 days ~1.3x
 - Score=0 when fully staffed (remaining=0)
 
 ## Routes

--- a/docs/features/25-shift-management.md
+++ b/docs/features/25-shift-management.md
@@ -43,6 +43,7 @@ See `docs/specs/shift-management-spec.md` for the full design specification.
 - Browse shifts filtered by department and date range (From/To date pickers; either may be omitted for open-ended range)
 - Filter by period (Set-up / Event / Strike toggle buttons)
 - Date picker and period tabs interact cleanly: selecting a date clears the active period tab (dates take precedence); selecting a period tab clears manual dates; date picker min/max constrains to the active period's range when a period is selected
+- Consecutive all-day shifts within the same rota are compressed into date ranges (e.g., "Jun 16–21, 6 days") with aggregated fill status; click to expand individual days
 - Only rotas with `IsVisibleToVolunteers = true` appear (privileged users see all)
 - See fill status (confirmed count vs max)
 - Sign up for a shift (auto-confirmed for Public policy, pending for RequireApproval)

--- a/docs/features/25-shift-management.md
+++ b/docs/features/25-shift-management.md
@@ -42,6 +42,7 @@ See `docs/specs/shift-management-spec.md` for the full design specification.
 **Acceptance Criteria:**
 - Browse shifts filtered by department and date range (From/To date pickers; either may be omitted for open-ended range)
 - Filter by period (Set-up / Event / Strike toggle buttons)
+- Date picker and period tabs interact cleanly: selecting a date clears the active period tab (dates take precedence); selecting a period tab clears manual dates; date picker min/max constrains to the active period's range when a period is selected
 - Only rotas with `IsVisibleToVolunteers = true` appear (privileged users see all)
 - See fill status (confirmed count vs max)
 - Sign up for a shift (auto-confirmed for Public policy, pending for RequireApproval)

--- a/src/Humans.Application/Interfaces/IShiftManagementService.cs
+++ b/src/Humans.Application/Interfaces/IShiftManagementService.cs
@@ -156,8 +156,9 @@ public interface IShiftManagementService
 
     /// <summary>
     /// Calculates the urgency score for a single shift.
+    /// Factors in remaining slots, priority, duration, understaffing, and time proximity.
     /// </summary>
-    double CalculateScore(Shift shift, int confirmedCount);
+    double CalculateScore(Shift shift, int confirmedCount, EventSettings eventSettings);
 
     // === Staffing & Summary ===
 

--- a/src/Humans.Infrastructure/Services/ShiftManagementService.cs
+++ b/src/Humans.Infrastructure/Services/ShiftManagementService.cs
@@ -485,7 +485,7 @@ public class ShiftManagementService : IShiftManagementService
             .Select(s =>
             {
                 var confirmedCount = s.ShiftSignups.Count(d => d.Status == SignupStatus.Confirmed);
-                var score = CalculateScore(s, confirmedCount);
+                var score = CalculateScore(s, confirmedCount, es);
                 var remaining = Math.Max(0, s.MaxVolunteers - confirmedCount);
                 return new UrgentShift(s, score, confirmedCount, remaining, s.Rota.Team.Name, []);
             })
@@ -554,7 +554,7 @@ public class ShiftManagementService : IShiftManagementService
             .Select(s =>
             {
                 var confirmedCount = s.ShiftSignups.Count(d => d.Status == SignupStatus.Confirmed);
-                var score = CalculateScore(s, confirmedCount);
+                var score = CalculateScore(s, confirmedCount, es);
                 var remaining = Math.Max(0, s.MaxVolunteers - confirmedCount);
                 var signups = includeSignups
                     ? s.ShiftSignups
@@ -571,7 +571,7 @@ public class ShiftManagementService : IShiftManagementService
             .ToList();
     }
 
-    public double CalculateScore(Shift shift, int confirmedCount)
+    public double CalculateScore(Shift shift, int confirmedCount, EventSettings eventSettings)
     {
         var remainingSlots = Math.Max(0, shift.MaxVolunteers - confirmedCount);
         if (remainingSlots == 0) return 0;
@@ -580,7 +580,15 @@ public class ShiftManagementService : IShiftManagementService
         var durationHours = shift.Duration.TotalHours;
         var understaffedMultiplier = confirmedCount < shift.MinVolunteers ? 2 : 1;
 
-        return remainingSlots * priorityWeight * durationHours * understaffedMultiplier;
+        // Time proximity: shifts happening sooner get a significant boost.
+        // Formula: 1 + 10 / (1 + daysUntilStart)
+        // Today → 11x, tomorrow → 6x, 7 days → 2.25x, 30 days → 1.32x
+        var now = _clock.GetCurrentInstant();
+        var shiftStart = shift.GetAbsoluteStart(eventSettings);
+        var daysUntilStart = Math.Max(0, (shiftStart - now).TotalDays);
+        var proximityBoost = 1.0 + (10.0 / (1.0 + daysUntilStart));
+
+        return remainingSlots * priorityWeight * durationHours * understaffedMultiplier * proximityBoost;
     }
 
     // ============================================================

--- a/src/Humans.Web/Controllers/ShiftsController.cs
+++ b/src/Humans.Web/Controllers/ShiftsController.cs
@@ -76,6 +76,11 @@ public class ShiftsController : HumansControllerBase
         if (!string.IsNullOrEmpty(toDate) && LocalDatePattern.Iso.Parse(toDate) is { Success: true } toResult)
             filterToDate = toResult.Value;
 
+        // Explicit dates take precedence over period tab — prevents conflicting filters
+        // (e.g., user picks a date outside the active period's range)
+        if ((!string.IsNullOrEmpty(fromDate) || !string.IsNullOrEmpty(toDate)) && !string.IsNullOrEmpty(period))
+            period = null;
+
         // Apply period filter — compute date boundaries from EventSettings offsets
         if (!string.IsNullOrEmpty(period) && Enum.TryParse<ShiftPeriod>(period, true, out var parsedPeriod))
         {

--- a/src/Humans.Web/Views/Shifts/Index.cshtml
+++ b/src/Humans.Web/Views/Shifts/Index.cshtml
@@ -120,18 +120,6 @@
                 this.form.submit();
             });
         });
-        // Expand/collapse compressed date ranges
-        document.querySelectorAll('.shift-range-header').forEach(function(el) {
-            el.addEventListener('click', function() {
-                var rangeKey = this.getAttribute('data-range');
-                var icon = this.querySelector('.range-icon');
-                var rows = document.querySelectorAll('.range-detail-' + rangeKey);
-                var expanding = rows[0].classList.contains('d-none');
-                rows.forEach(function(row) { row.classList.toggle('d-none', !expanding); });
-                icon.classList.toggle('fa-chevron-right', !expanding);
-                icon.classList.toggle('fa-chevron-down', expanding);
-            });
-        });
     </script>
 
     @if (!Model.EventSettings.IsShiftBrowsingOpen)
@@ -488,3 +476,17 @@
         }
     }
 </div>
+<script>
+    // Expand/collapse compressed date ranges — must run after table HTML is rendered
+    document.querySelectorAll('.shift-range-header').forEach(function(el) {
+        el.addEventListener('click', function() {
+            var rangeKey = this.getAttribute('data-range');
+            var icon = this.querySelector('.range-icon');
+            var rows = document.querySelectorAll('.range-detail-' + rangeKey);
+            var expanding = rows[0].classList.contains('d-none');
+            rows.forEach(function(row) { row.classList.toggle('d-none', !expanding); });
+            icon.classList.toggle('fa-chevron-right', !expanding);
+            icon.classList.toggle('fa-chevron-down', expanding);
+        });
+    });
+</script>

--- a/src/Humans.Web/Views/Shifts/Index.cshtml
+++ b/src/Humans.Web/Views/Shifts/Index.cshtml
@@ -6,6 +6,20 @@
     ViewData["Title"] = "Shifts";
     var es = Model.EventSettings;
     var tz = DateTimeZoneProviders.Tzdb[es.TimeZoneId];
+
+    // Compute date picker bounds — tighten to active period's range
+    var pickerMin = es.GateOpeningDate.PlusDays(es.BuildStartOffset);
+    var pickerMax = es.GateOpeningDate.PlusDays(es.StrikeEndOffset);
+    if (!string.IsNullOrEmpty(Model.FilterPeriod) && Enum.TryParse<ShiftPeriod>(Model.FilterPeriod, true, out var activePeriodEnum))
+    {
+        (pickerMin, pickerMax) = activePeriodEnum switch
+        {
+            ShiftPeriod.Build => (es.GateOpeningDate.PlusDays(es.BuildStartOffset), es.GateOpeningDate.PlusDays(-1)),
+            ShiftPeriod.Event => (es.GateOpeningDate, es.GateOpeningDate.PlusDays(es.EventEndOffset)),
+            ShiftPeriod.Strike => (es.GateOpeningDate.PlusDays(es.EventEndOffset + 1), es.GateOpeningDate.PlusDays(es.StrikeEndOffset)),
+            _ => (pickerMin, pickerMax)
+        };
+    }
 }
 
 @functions {
@@ -65,14 +79,14 @@
         <div class="col-auto">
             <label class="form-label mb-1">From</label>
             <input type="date" name="fromDate" class="form-control form-control-sm" value="@Model.FilterFromDate"
-                   min="@Model.EventSettings.GateOpeningDate.PlusDays(Model.EventSettings.BuildStartOffset).ToString("yyyy-MM-dd", null)"
-                   max="@Model.EventSettings.GateOpeningDate.PlusDays(Model.EventSettings.StrikeEndOffset).ToString("yyyy-MM-dd", null)" />
+                   min="@pickerMin.ToString("yyyy-MM-dd", null)"
+                   max="@pickerMax.ToString("yyyy-MM-dd", null)" />
         </div>
         <div class="col-auto">
             <label class="form-label mb-1">To</label>
             <input type="date" name="toDate" class="form-control form-control-sm" value="@Model.FilterToDate"
-                   min="@Model.EventSettings.GateOpeningDate.PlusDays(Model.EventSettings.BuildStartOffset).ToString("yyyy-MM-dd", null)"
-                   max="@Model.EventSettings.GateOpeningDate.PlusDays(Model.EventSettings.StrikeEndOffset).ToString("yyyy-MM-dd", null)" />
+                   min="@pickerMin.ToString("yyyy-MM-dd", null)"
+                   max="@pickerMax.ToString("yyyy-MM-dd", null)" />
         </div>
         @if (Model.FilterDepartmentId.HasValue || !string.IsNullOrEmpty(Model.FilterFromDate) || !string.IsNullOrEmpty(Model.FilterToDate) || !string.IsNullOrEmpty(Model.FilterPeriod))
         {
@@ -96,8 +110,15 @@
            class="btn btn-sm @(activePeriod == "Strike" ? "btn-secondary" : "btn-outline-secondary")">Strike</a>
     </div>
     <script>
-        document.querySelectorAll('[name="departmentId"], [name="fromDate"], [name="toDate"]').forEach(function(el) {
+        document.querySelectorAll('[name="departmentId"]').forEach(function(el) {
             el.addEventListener('change', function() { this.form.submit(); });
+        });
+        document.querySelectorAll('[name="fromDate"], [name="toDate"]').forEach(function(el) {
+            el.addEventListener('change', function() {
+                // Dates take precedence — clear the period tab so results aren't constrained
+                this.form.querySelector('[name="period"]').value = '';
+                this.form.submit();
+            });
         });
     </script>
 

--- a/src/Humans.Web/Views/Shifts/Index.cshtml
+++ b/src/Humans.Web/Views/Shifts/Index.cshtml
@@ -120,6 +120,18 @@
                 this.form.submit();
             });
         });
+        // Expand/collapse compressed date ranges
+        document.querySelectorAll('.shift-range-header').forEach(function(el) {
+            el.addEventListener('click', function() {
+                var rangeKey = this.getAttribute('data-range');
+                var icon = this.querySelector('.range-icon');
+                var rows = document.querySelectorAll('.range-detail-' + rangeKey);
+                var expanding = rows[0].classList.contains('d-none');
+                rows.forEach(function(row) { row.classList.toggle('d-none', !expanding); });
+                icon.classList.toggle('fa-chevron-right', !expanding);
+                icon.classList.toggle('fa-chevron-down', expanding);
+            });
+        });
     </script>
 
     @if (!Model.EventSettings.IsShiftBrowsingOpen)
@@ -222,59 +234,163 @@
                                     </div>
                                 </form>
                             }
+                            var dateRanges = new List<List<Humans.Web.Models.ShiftDisplayItem>>();
+                            List<Humans.Web.Models.ShiftDisplayItem>? currentRange = null;
+                            foreach (var s in allDayShifts)
+                            {
+                                if (currentRange == null || s.Shift.DayOffset != currentRange.Last().Shift.DayOffset + 1)
+                                {
+                                    currentRange = new List<Humans.Web.Models.ShiftDisplayItem> { s };
+                                    dateRanges.Add(currentRange);
+                                }
+                                else
+                                {
+                                    currentRange.Add(s);
+                                }
+                            }
                             <div class="table-responsive">
                                 <table class="table table-sm">
                                     <thead>
                                         <tr><th>Date</th><th>Filled</th><th>Status</th>@if (Model.ShowSignups) {<th>@Localizer["Shifts_SignedUp"]</th>}</tr>
                                     </thead>
                                     <tbody>
-                                        @foreach (var item in allDayShifts)
+                                        @foreach (var range in dateRanges)
                                         {
-                                            var isFull = item.RemainingSlots <= 0;
-                                            var understaffed = item.ConfirmedCount < item.Shift.MinVolunteers;
-                                            <tr class="@(isFull ? "table-secondary" : "")">
-                                                <td>@es.GateOpeningDate.PlusDays(item.Shift.DayOffset).ToDisplayShiftDate()</td>
-                                                <td>
-                                                    <span class="@(understaffed ? "text-danger fw-bold" : "")">@item.ConfirmedCount</span>
-                                                    <small class="text-muted">/ @item.Shift.MaxVolunteers</small>
-                                                </td>
-                                                <td>
-                                                    @if (Model.UserSignupShiftIds.Contains(item.Shift.Id))
-                                                    {
-                                                        <span class="badge bg-info">Signed up</span>
-                                                    }
-                                                    else if (isFull)
-                                                    {
-                                                        <span class="badge bg-secondary">Full</span>
-                                                    }
-                                                    else if (understaffed)
-                                                    {
-                                                        <span class="badge bg-warning text-dark">Needs help</span>
-                                                    }
-                                                </td>
-                                                @if (Model.ShowSignups)
-                                                {
-                                                    <td>
-                                                        <div class="d-flex flex-wrap gap-1">
-                                                            @foreach (var signup in item.Signups)
-                                                            {
-                                                                <human-link user-id="@signup.UserId" display-name="@signup.DisplayName" mode="Avatar" size="26"
-                                                                           profile-picture-url="@signup.ProfilePictureUrl" show-popover="true"
-                                                                           title="@signup.DisplayName@(signup.Status == SignupStatus.Pending ? $" {Localizer["Shifts_Pending"]}" : "")"
-                                                                           class="@(signup.Status == SignupStatus.Pending ? "opacity-50" : "")"
-                                                                           style="@(signup.Status == SignupStatus.Pending ? "border: 1px dashed #6c757d; border-radius: 50%;" : "")" />
-                                                            }
-                                                        </div>
-                                                    </td>
-                                                }
-                                            </tr>
-                                            @if (!string.IsNullOrEmpty(item.Shift.Description))
+                                            if (range.Count > 1)
                                             {
-                                                <tr class="@(isFull ? "table-secondary" : "")">
-                                                    <td colspan="@(Model.ShowSignups ? 4 : 3)" class="text-muted small pt-0 pb-1 border-0">
-                                                        @Html.SanitizedMarkdown(item.Shift.Description)
+                                                var rangeKey = $"r{range.First().Shift.Id:N}";
+                                                var totalConfirmed = range.Sum(x => x.ConfirmedCount);
+                                                var totalMax = range.Sum(x => x.Shift.MaxVolunteers);
+                                                var anyUnderstaffed = range.Any(x => x.ConfirmedCount < x.Shift.MinVolunteers);
+                                                var daysNeedingHelp = range.Count(x => x.ConfirmedCount < x.Shift.MinVolunteers);
+                                                var allRangeFull = range.All(x => x.RemainingSlots <= 0);
+                                                var userSignedUpDays = range.Count(x => Model.UserSignupShiftIds.Contains(x.Shift.Id));
+                                                var rangeStart = es.GateOpeningDate.PlusDays(range.First().Shift.DayOffset);
+                                                var rangeEnd = es.GateOpeningDate.PlusDays(range.Last().Shift.DayOffset);
+                                                <tr class="@(allRangeFull ? "table-secondary" : "") shift-range-header" role="button" data-range="@rangeKey" style="cursor: pointer;">
+                                                    <td>
+                                                        <i class="fa-solid fa-chevron-right fa-xs me-1 range-icon"></i>
+                                                        @rangeStart.ToDisplayShiftDate()–@rangeEnd.ToDisplayShiftDate()
+                                                        <small class="text-muted">(@range.Count days)</small>
                                                     </td>
+                                                    <td>
+                                                        <span class="@(anyUnderstaffed ? "text-danger fw-bold" : "")">@totalConfirmed</span>
+                                                        <small class="text-muted">/ @totalMax total</small>
+                                                    </td>
+                                                    <td>
+                                                        @if (userSignedUpDays == range.Count)
+                                                        {
+                                                            <span class="badge bg-info">Signed up (all @range.Count days)</span>
+                                                        }
+                                                        else if (userSignedUpDays > 0)
+                                                        {
+                                                            <span class="badge bg-info">Signed up (@userSignedUpDays of @range.Count)</span>
+                                                        }
+                                                        else if (allRangeFull)
+                                                        {
+                                                            <span class="badge bg-secondary">Full</span>
+                                                        }
+                                                        else if (daysNeedingHelp > 0)
+                                                        {
+                                                            <span class="badge bg-warning text-dark">@daysNeedingHelp @(daysNeedingHelp == 1 ? "day needs" : "days need") help</span>
+                                                        }
+                                                    </td>
+                                                    @if (Model.ShowSignups)
+                                                    {
+                                                        <td><small class="text-muted fst-italic">click to expand</small></td>
+                                                    }
                                                 </tr>
+                                                @foreach (var item in range)
+                                                {
+                                                    var isFull = item.RemainingSlots <= 0;
+                                                    var understaffed = item.ConfirmedCount < item.Shift.MinVolunteers;
+                                                    <tr class="d-none range-detail-@rangeKey @(isFull ? "table-secondary" : "")">
+                                                        <td class="ps-4">@es.GateOpeningDate.PlusDays(item.Shift.DayOffset).ToDisplayShiftDate()</td>
+                                                        <td>
+                                                            <span class="@(understaffed ? "text-danger fw-bold" : "")">@item.ConfirmedCount</span>
+                                                            <small class="text-muted">/ @item.Shift.MaxVolunteers</small>
+                                                        </td>
+                                                        <td>
+                                                            @if (Model.UserSignupShiftIds.Contains(item.Shift.Id))
+                                                            {
+                                                                <span class="badge bg-info">Signed up</span>
+                                                            }
+                                                            else if (isFull)
+                                                            {
+                                                                <span class="badge bg-secondary">Full</span>
+                                                            }
+                                                            else if (understaffed)
+                                                            {
+                                                                <span class="badge bg-warning text-dark">Needs help</span>
+                                                            }
+                                                        </td>
+                                                        @if (Model.ShowSignups)
+                                                        {
+                                                            <td>
+                                                                <div class="d-flex flex-wrap gap-1">
+                                                                    @foreach (var signup in item.Signups)
+                                                                    {
+                                                                        <human-link user-id="@signup.UserId" display-name="@signup.DisplayName" mode="Avatar" size="26"
+                                                                                   profile-picture-url="@signup.ProfilePictureUrl" show-popover="true"
+                                                                                   title="@signup.DisplayName@(signup.Status == SignupStatus.Pending ? $" {Localizer["Shifts_Pending"]}" : "")"
+                                                                                   class="@(signup.Status == SignupStatus.Pending ? "opacity-50" : "")"
+                                                                                   style="@(signup.Status == SignupStatus.Pending ? "border: 1px dashed #6c757d; border-radius: 50%;" : "")" />
+                                                                    }
+                                                                </div>
+                                                            </td>
+                                                        }
+                                                    </tr>
+                                                }
+                                            }
+                                            else
+                                            {
+                                                var item = range[0];
+                                                var isFull = item.RemainingSlots <= 0;
+                                                var understaffed = item.ConfirmedCount < item.Shift.MinVolunteers;
+                                                <tr class="@(isFull ? "table-secondary" : "")">
+                                                    <td>@es.GateOpeningDate.PlusDays(item.Shift.DayOffset).ToDisplayShiftDate()</td>
+                                                    <td>
+                                                        <span class="@(understaffed ? "text-danger fw-bold" : "")">@item.ConfirmedCount</span>
+                                                        <small class="text-muted">/ @item.Shift.MaxVolunteers</small>
+                                                    </td>
+                                                    <td>
+                                                        @if (Model.UserSignupShiftIds.Contains(item.Shift.Id))
+                                                        {
+                                                            <span class="badge bg-info">Signed up</span>
+                                                        }
+                                                        else if (isFull)
+                                                        {
+                                                            <span class="badge bg-secondary">Full</span>
+                                                        }
+                                                        else if (understaffed)
+                                                        {
+                                                            <span class="badge bg-warning text-dark">Needs help</span>
+                                                        }
+                                                    </td>
+                                                    @if (Model.ShowSignups)
+                                                    {
+                                                        <td>
+                                                            <div class="d-flex flex-wrap gap-1">
+                                                                @foreach (var signup in item.Signups)
+                                                                {
+                                                                    <human-link user-id="@signup.UserId" display-name="@signup.DisplayName" mode="Avatar" size="26"
+                                                                               profile-picture-url="@signup.ProfilePictureUrl" show-popover="true"
+                                                                               title="@signup.DisplayName@(signup.Status == SignupStatus.Pending ? $" {Localizer["Shifts_Pending"]}" : "")"
+                                                                               class="@(signup.Status == SignupStatus.Pending ? "opacity-50" : "")"
+                                                                               style="@(signup.Status == SignupStatus.Pending ? "border: 1px dashed #6c757d; border-radius: 50%;" : "")" />
+                                                                }
+                                                            </div>
+                                                        </td>
+                                                    }
+                                                </tr>
+                                                @if (!string.IsNullOrEmpty(item.Shift.Description))
+                                                {
+                                                    <tr class="@(isFull ? "table-secondary" : "")">
+                                                        <td colspan="@(Model.ShowSignups ? 4 : 3)" class="text-muted small pt-0 pb-1 border-0">
+                                                            @Html.SanitizedMarkdown(item.Shift.Description)
+                                                        </td>
+                                                    </tr>
+                                                }
                                             }
                                         }
                                     </tbody>

--- a/tests/Humans.Application.Tests/Services/ShiftUrgencyTests.cs
+++ b/tests/Humans.Application.Tests/Services/ShiftUrgencyTests.cs
@@ -17,10 +17,17 @@ public class ShiftUrgencyTests : IDisposable
     private readonly HumansDbContext _dbContext;
     private readonly ShiftManagementService _service;
 
+    // Clock is March 1, 2026 12:00 UTC. Distant event settings (~122 days out)
+    // keep proximity boost small so base score tests remain meaningful.
+    private static readonly Instant TestNow = Instant.FromUtc(2026, 3, 1, 12, 0);
+    private static readonly EventSettings DistantEvent = new()
+    {
+        GateOpeningDate = new LocalDate(2026, 7, 1),
+        TimeZoneId = "UTC"
+    };
+
     public ShiftUrgencyTests()
     {
-        // ShiftManagementService requires a DbContext even though CalculateScore is pure;
-        // create a minimal one to satisfy the constructor.
         var options = new DbContextOptionsBuilder<HumansDbContext>()
             .UseInMemoryDatabase(Guid.NewGuid().ToString())
             .Options;
@@ -29,7 +36,7 @@ public class ShiftUrgencyTests : IDisposable
         _service = new ShiftManagementService(
             _dbContext,
             new MemoryCache(new MemoryCacheOptions()),
-            new FakeClock(Instant.FromUtc(2026, 3, 1, 12, 0)),
+            new FakeClock(TestNow),
             NullLogger<ShiftManagementService>.Instance);
     }
 
@@ -42,38 +49,64 @@ public class ShiftUrgencyTests : IDisposable
     [Fact]
     public void CalculateScore_NormalPriority_5Remaining_4h_ReturnsExpected()
     {
-        // remaining=5, priority=Normal(1), duration=4h, understaffed=false(1)
-        // 5 * 1 * 4 * 1 = 20
+        // Base: remaining=5, priority=Normal(1), duration=4h, understaffed=false(1) → 20
+        // Proximity boost ≈ 1.08 (shift is ~122 days out) → ~21.6
         var shift = MakeShift(ShiftPriority.Normal, minVol: 2, maxVol: 7, durationHours: 4);
-        var confirmedCount = 2; // remaining = 7 - 2 = 5, confirmed >= min so no understaffed
+        var confirmedCount = 2;
 
-        var score = _service.CalculateScore(shift, confirmedCount);
+        var score = _service.CalculateScore(shift, confirmedCount, DistantEvent);
 
-        score.Should().Be(20);
+        score.Should().BeApproximately(20 * 1.08, 0.5);
     }
 
     [Fact]
     public void CalculateScore_EssentialPriority_2Remaining_8h_Understaffed_ReturnsExpected()
     {
-        // remaining=2, priority=Essential(6), duration=8h, understaffed=true(2)
-        // 2 * 6 * 8 * 2 = 192
+        // Base: remaining=2, priority=Essential(6), duration=8h, understaffed=true(2) → 192
+        // Proximity boost ≈ 1.08 → ~207
         var shift = MakeShift(ShiftPriority.Essential, minVol: 5, maxVol: 6, durationHours: 8);
-        var confirmedCount = 4; // remaining = 6 - 4 = 2, confirmed(4) < min(5) so understaffed
+        var confirmedCount = 4;
 
-        var score = _service.CalculateScore(shift, confirmedCount);
+        var score = _service.CalculateScore(shift, confirmedCount, DistantEvent);
 
-        score.Should().Be(192);
+        score.Should().BeApproximately(192 * 1.08, 5);
     }
 
     [Fact]
     public void CalculateScore_FullyStaffed_ReturnsZero()
     {
         var shift = MakeShift(ShiftPriority.Important, minVol: 2, maxVol: 5, durationHours: 4);
-        var confirmedCount = 5; // remaining = 5 - 5 = 0
+        var confirmedCount = 5;
 
-        var score = _service.CalculateScore(shift, confirmedCount);
+        var score = _service.CalculateScore(shift, confirmedCount, DistantEvent);
 
         score.Should().Be(0);
+    }
+
+    [Fact]
+    public void CalculateScore_ImminentShift_RanksHigherThanDistantWithMoreSlots()
+    {
+        // A shift tomorrow with 5 empty slots should outrank a shift 30 days out with 20 slots
+        var tomorrowEvent = new EventSettings
+        {
+            GateOpeningDate = new LocalDate(2026, 3, 2),
+            TimeZoneId = "UTC"
+        };
+        var distantEvent = new EventSettings
+        {
+            GateOpeningDate = new LocalDate(2026, 3, 31),
+            TimeZoneId = "UTC"
+        };
+
+        var tomorrowShift = MakeShift(ShiftPriority.Normal, minVol: 2, maxVol: 7, durationHours: 8);
+        var distantShift = MakeShift(ShiftPriority.Normal, minVol: 2, maxVol: 12, durationHours: 8);
+
+        // Tomorrow: 5 remaining, ~1 day out → base=40, proximity ≈ 6x → ~240
+        var tomorrowScore = _service.CalculateScore(tomorrowShift, 2, tomorrowEvent);
+        // 30 days: 10 remaining, ~30 days out → base=80, proximity ≈ 1.3x → ~104
+        var distantScore = _service.CalculateScore(distantShift, 2, distantEvent);
+
+        tomorrowScore.Should().BeGreaterThan(distantScore);
     }
 
     private static Shift MakeShift(ShiftPriority priority, int minVol, int maxVol, double durationHours)
@@ -85,6 +118,8 @@ public class ShiftUrgencyTests : IDisposable
             MinVolunteers = minVol,
             MaxVolunteers = maxVol,
             Duration = Duration.FromHours(durationHours),
+            DayOffset = 0,
+            StartTime = new LocalTime(8, 0),
             Rota = rota
         };
     }


### PR DESCRIPTION
## Summary
- **#252** — Fix date picker / period tab conflict: selecting a date now clears the active period tab (dates take precedence), and the date picker constrains to the active period's range. Server-side defensive check also added.
- **#248** — Compress consecutive all-day shifts into expandable date ranges ("Jun 16–21, 6 days") with aggregated fill status and click-to-expand detail rows. Significantly reduces visual noise on build/strike rotas.
- **#249** — Add time-proximity factor to urgency scoring: `proximityBoost = 1 + 10/(1 + daysUntilStart)`. Imminent shifts get up to 11x weight, ensuring homepage shows "most needed soonest" instead of pure slot count.

## Test plan
- [x] Navigate to /Shifts, select a period tab, then pick a date outside that period → should switch to "All" and show results
- [x] On a period tab, verify date picker min/max is constrained to that period's range
- [x] Verify build/strike rotas with consecutive days show compressed date range rows
- [x] Click a compressed row → individual days expand with full detail
- [ ] Check homepage urgent shifts reflect proximity (closer shifts rank higher than distant ones with more slots)
- [ ] Run `dotnet test` — 526 application tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)