### PR TITLE
Fix coordinator subteam perms + Google resource member rollup

### DIFF
--- a/docs/features/06-teams.md
+++ b/docs/features/06-teams.md
@@ -250,6 +250,14 @@ Teams are either **departments** (top-level, no parent) or **sub-teams** (have a
 - Permission checks cascade upward: checking coordinator status on a sub-team also checks the parent department
 - Both `TeamMember.Role == Coordinator` and `TeamRoleAssignment.IsManagement` paths are checked for consistency
 
+### Google Resource Rollup
+- Sub-team members are automatically included in the parent department's Google Group and Drive folder sync
+- Effective membership = direct department members + all active child team members (deduplicated)
+- Rollup is one-way: sub-team members get parent resources; parent members do NOT get sub-team resources
+- When a user joins a sub-team, they are immediately added to parent department resources
+- When a user leaves a sub-team, the reconciliation job removes them from parent resources (unless they remain in another sub-team or are a direct department member)
+- The department detail page (`/Teams/{slug}`) shows all effective humans with source team badges
+
 ### Display
 - Sub-team names display as "Department - SubTeam" on profile pills, team details, and MyTeams
 - `/Teams` page groups cards into: My Teams, Departments, System Teams

--- a/docs/features/06-teams.md
+++ b/docs/features/06-teams.md
@@ -244,6 +244,12 @@ Teams are either **departments** (top-level, no parent) or **sub-teams** (have a
 - `IsManagement` roles can be renamed and deleted (if no assignments)
 - No roles are auto-created on team creation — admins add roles manually
 
+### Permission Inheritance
+- Department coordinators automatically have management permissions on all child sub-teams
+- This includes: viewing/approving/rejecting join requests, managing members, editing sub-team pages
+- Permission checks cascade upward: checking coordinator status on a sub-team also checks the parent department
+- Both `TeamMember.Role == Coordinator` and `TeamRoleAssignment.IsManagement` paths are checked for consistency
+
 ### Display
 - Sub-team names display as "Department - SubTeam" on profile pills, team details, and MyTeams
 - `/Teams` page groups cards into: My Teams, Departments, System Teams

--- a/docs/features/07-google-integration.md
+++ b/docs/features/07-google-integration.md
@@ -235,7 +235,7 @@ All Drive API calls MUST use:
 
 ### Full Sync (SyncResourcePermissionsAsync)
 For Shared Drive folders:
-1. Load expected members from DB (team members where `LeftAt == null`)
+1. Load expected members from DB (team members where `LeftAt == null`, plus child team members for departments)
 2. List current direct permissions from Google (paginated, with `permissionDetails`)
 3. Filter to direct managed permissions only (exclude inherited, owner, service account)
 4. Add missing permissions (expected but not in Google)
@@ -243,7 +243,7 @@ For Shared Drive folders:
 6. Update `LastSyncedAt`
 
 For Google Groups:
-1. Load expected members from DB
+1. Load expected members from DB (team members where `LeftAt == null`, plus child team members for departments)
 2. List current group members from Google (paginated)
 3. Add missing members
 4. Remove stale members

--- a/src/Humans.Infrastructure/Services/GoogleWorkspaceSyncService.cs
+++ b/src/Humans.Infrastructure/Services/GoogleWorkspaceSyncService.cs
@@ -175,6 +175,25 @@ public class GoogleWorkspaceSyncService : IGoogleSyncService
         return _serviceAccountEmail;
     }
 
+    /// <summary>
+    /// Gets active members of all child teams for a department (subteam member rollup).
+    /// Returns empty if the team has no children.
+    /// </summary>
+    private async Task<List<TeamMember>> GetChildTeamMembersAsync(
+        Guid parentTeamId,
+        CancellationToken cancellationToken)
+    {
+        return await _dbContext.TeamMembers
+            .AsNoTracking()
+            .Include(tm => tm.User)
+            .Include(tm => tm.Team)
+            .Where(tm =>
+                tm.Team.ParentTeamId == parentTeamId &&
+                tm.Team.IsActive &&
+                tm.LeftAt == null)
+            .ToListAsync(cancellationToken);
+    }
+
     /// <inheritdoc />
     public async Task<GoogleResource> ProvisionTeamFolderAsync(
         Guid teamId,
@@ -636,6 +655,28 @@ public class GoogleWorkspaceSyncService : IGoogleSyncService
             }
         }
 
+        // Subteam member rollup: also add to parent department resources
+        var team = await _dbContext.Teams.AsNoTracking()
+            .FirstOrDefaultAsync(t => t.Id == teamId, cancellationToken);
+        if (team?.ParentTeamId is not null)
+        {
+            var parentResources = await _dbContext.GoogleResources
+                .Where(r => r.TeamId == team.ParentTeamId && r.IsActive)
+                .ToListAsync(cancellationToken);
+
+            foreach (var resource in parentResources)
+            {
+                if (resource.ResourceType == GoogleResourceType.Group)
+                {
+                    await AddUserToGroupAsync(resource.Id, googleEmail, cancellationToken);
+                }
+                else
+                {
+                    await AddUserToDriveAsync(resource, googleEmail, cancellationToken);
+                }
+            }
+        }
+
         await _dbContext.SaveChangesAsync(cancellationToken);
     }
 
@@ -829,6 +870,19 @@ public class GoogleWorkspaceSyncService : IGoogleSyncService
                 .Where(tm => tm.User.GetGoogleServiceEmail() is not null)
                 .Select(tm => new { Email = tm.User.GetGoogleServiceEmail(), tm.User.DisplayName })
                 .ToList();
+
+            // Subteam member rollup: include child team members for departments
+            var childMembers = await GetChildTeamMembersAsync(resource.TeamId, cancellationToken);
+            foreach (var cm in childMembers)
+            {
+                var email = cm.User.GetGoogleServiceEmail();
+                if (email is not null && !expectedMembers.Any(m =>
+                    NormalizingEmailComparer.Instance.Equals(m.Email, email)))
+                {
+                    expectedMembers.Add(new { Email = (string?)email, cm.User.DisplayName });
+                }
+            }
+
             var expectedEmails = new HashSet<string>(
                 expectedMembers.Select(m => m.Email!), NormalizingEmailComparer.Instance);
 
@@ -1003,6 +1057,25 @@ public class GoogleWorkspaceSyncService : IGoogleSyncService
                     else
                     {
                         membersByEmail[memberEmail] = (tm.User.DisplayName, new List<string> { teamName });
+                    }
+                }
+
+                // Subteam member rollup: include child team members for departments
+                var childMembers = await GetChildTeamMembersAsync(resource.TeamId, cancellationToken);
+                foreach (var cm in childMembers)
+                {
+                    var memberEmail = cm.User.GetGoogleServiceEmail();
+                    if (memberEmail is null) continue;
+
+                    var childTeamName = cm.Team.Name;
+                    if (membersByEmail.TryGetValue(memberEmail, out var existing2))
+                    {
+                        if (!existing2.TeamNames.Contains(childTeamName, StringComparer.Ordinal))
+                            existing2.TeamNames.Add(childTeamName);
+                    }
+                    else
+                    {
+                        membersByEmail[memberEmail] = (cm.User.DisplayName, new List<string> { childTeamName });
                     }
                 }
             }

--- a/src/Humans.Infrastructure/Services/ShiftManagementService.cs
+++ b/src/Humans.Infrastructure/Services/ShiftManagementService.cs
@@ -95,7 +95,8 @@ public class ShiftManagementService : IShiftManagementService
 
     private async Task<IReadOnlyList<Guid>> LoadCoordinatorDepartmentIdsAsync(Guid userId)
     {
-        return await _dbContext.TeamRoleAssignments
+        // Check via IsManagement role assignment
+        var byRoleAssignment = await _dbContext.TeamRoleAssignments
             .AsNoTracking()
             .Where(tra =>
                 tra.TeamMember.UserId == userId &&
@@ -104,8 +105,21 @@ public class ShiftManagementService : IShiftManagementService
                 tra.TeamRoleDefinition.Team.ParentTeamId == null &&
                 tra.TeamRoleDefinition.Team.SystemTeamType == SystemTeamType.None)
             .Select(tra => tra.TeamRoleDefinition.TeamId)
-            .Distinct()
             .ToListAsync();
+
+        // Also check via TeamMember.Role == Coordinator (may be out of sync with IsManagement)
+        var byMemberRole = await _dbContext.TeamMembers
+            .AsNoTracking()
+            .Where(tm =>
+                tm.UserId == userId &&
+                tm.LeftAt == null &&
+                tm.Role == TeamMemberRole.Coordinator &&
+                tm.Team.ParentTeamId == null &&
+                tm.Team.SystemTeamType == SystemTeamType.None)
+            .Select(tm => tm.TeamId)
+            .ToListAsync();
+
+        return byRoleAssignment.Union(byMemberRole).Distinct().ToList();
     }
 
     private async Task<bool> HasActiveRoleAsync(Guid userId, string roleName)

--- a/src/Humans.Infrastructure/Services/TeamService.cs
+++ b/src/Humans.Infrastructure/Services/TeamService.cs
@@ -280,9 +280,7 @@ public class TeamService : ITeamService
 
         var currentUserId = userId.Value;
         var isCurrentUserMember = activeMembers.Any(m => m.UserId == currentUserId);
-        var isCurrentUserCoordinator = activeMembers.Any(m =>
-            m.UserId == currentUserId &&
-            m.Role == TeamMemberRole.Coordinator);
+        var isCurrentUserCoordinator = await IsUserCoordinatorOfTeamAsync(team.Id, currentUserId, cancellationToken);
         var isBoardMember = await IsUserBoardMemberAsync(currentUserId, cancellationToken);
         var isAdmin = await IsUserAdminAsync(currentUserId, cancellationToken);
         var isTeamsAdmin = await IsUserTeamsAdminAsync(currentUserId, cancellationToken);

--- a/src/Humans.Web/Controllers/TeamController.cs
+++ b/src/Humans.Web/Controllers/TeamController.cs
@@ -147,6 +147,32 @@ public class TeamController : HumansControllerBase
             ShiftsSummary = MapShiftsSummary(teamPage.ShiftsSummary, slug)
         };
 
+        // Subteam member rollup: for departments, show child team members not already direct members
+        if (teamPage.IsAuthenticated && teamPage.ChildTeams.Any())
+        {
+            var directMemberUserIds = new HashSet<Guid>(viewModel.Members.Select(m => m.UserId));
+            var addedUserIds = new HashSet<Guid>();
+
+            foreach (var child in teamPage.ChildTeams)
+            {
+                var childMembers = await _teamService.GetTeamMembersAsync(child.Id);
+                foreach (var cm in childMembers)
+                {
+                    if (directMemberUserIds.Contains(cm.UserId) || !addedUserIds.Add(cm.UserId))
+                        continue;
+
+                    viewModel.ChildTeamMembers.Add(new ChildTeamMemberViewModel
+                    {
+                        UserId = cm.UserId,
+                        DisplayName = cm.User.DisplayName,
+                        ProfilePictureUrl = cm.User.ProfilePictureUrl,
+                        ChildTeamName = child.Name,
+                        ChildTeamSlug = child.Slug
+                    });
+                }
+            }
+        }
+
         return View(viewModel);
     }
 

--- a/src/Humans.Web/Controllers/VolController.cs
+++ b/src/Humans.Web/Controllers/VolController.cs
@@ -379,12 +379,55 @@ public class VolController : HumansControllerBase
                 });
             }
 
+            // Build effective members: direct department members + all child team members
+            var effectiveMembersDict = new Dictionary<Guid, DepartmentDetailViewModel.EffectiveMember>();
+
+            // Direct department members
+            var directMembers = await _teamService.GetTeamMembersAsync(team.Id);
+            foreach (var dm in directMembers)
+            {
+                effectiveMembersDict[dm.UserId] = new DepartmentDetailViewModel.EffectiveMember
+                {
+                    UserId = dm.UserId,
+                    DisplayName = dm.User.DisplayName,
+                    ProfilePictureUrl = dm.User.ProfilePictureUrl,
+                    SourceTeams = [team.Name]
+                };
+            }
+
+            // Child team members (rollup)
+            foreach (var child in childTeams)
+            {
+                var childMembers = await _teamService.GetTeamMembersAsync(child.Id);
+                foreach (var cm in childMembers)
+                {
+                    if (effectiveMembersDict.TryGetValue(cm.UserId, out var existing))
+                    {
+                        if (!existing.SourceTeams.Contains(child.Name, StringComparer.Ordinal))
+                            existing.SourceTeams.Add(child.Name);
+                    }
+                    else
+                    {
+                        effectiveMembersDict[cm.UserId] = new DepartmentDetailViewModel.EffectiveMember
+                        {
+                            UserId = cm.UserId,
+                            DisplayName = cm.User.DisplayName,
+                            ProfilePictureUrl = cm.User.ProfilePictureUrl,
+                            SourceTeams = [child.Name]
+                        };
+                    }
+                }
+            }
+
             var model = new DepartmentDetailViewModel
             {
                 Department = team,
                 ChildTeams = childCards,
                 IsCoordinator = isCoordinator,
-                EventSettings = es
+                EventSettings = es,
+                EffectiveMembers = effectiveMembersDict.Values
+                    .OrderBy(m => m.DisplayName, StringComparer.OrdinalIgnoreCase)
+                    .ToList()
             };
 
             return View(model);

--- a/src/Humans.Web/Controllers/VolController.cs
+++ b/src/Humans.Web/Controllers/VolController.cs
@@ -352,7 +352,7 @@ public class VolController : HumansControllerBase
 
             var isCoordinator = RoleChecks.IsAdmin(User) ||
                                 User.IsInRole(RoleNames.VolunteerCoordinator) ||
-                                await _shiftMgmt.IsDeptCoordinatorAsync(user.Id, team.Id);
+                                await _teamService.IsUserCoordinatorOfTeamAsync(team.Id, user.Id);
 
             var allTeams = await _teamService.GetAllTeamsAsync();
             var childTeams = allTeams.Where(t => t.ParentTeamId == team.Id && t.IsActive).ToList();
@@ -416,7 +416,7 @@ public class VolController : HumansControllerBase
 
             var isCoordinator = RoleChecks.IsAdmin(User) ||
                                 User.IsInRole(RoleNames.VolunteerCoordinator) ||
-                                await _shiftMgmt.IsDeptCoordinatorAsync(user.Id, parent.Id);
+                                await _teamService.IsUserCoordinatorOfTeamAsync(child.Id, user.Id);
 
             var members = await _teamService.GetTeamMembersAsync(child.Id);
 

--- a/src/Humans.Web/Models/TeamViewModels.cs
+++ b/src/Humans.Web/Models/TeamViewModels.cs
@@ -77,6 +77,26 @@ public class TeamDetailViewModel
     public Guid? CurrentUserPendingRequestId { get; set; }
     public int PendingRequestCount { get; set; }
     public ShiftsSummaryCardViewModel? ShiftsSummary { get; set; }
+
+    /// <summary>
+    /// Members from child teams rolled up to this department. Only populated for departments.
+    /// </summary>
+    public List<ChildTeamMemberViewModel> ChildTeamMembers { get; set; } = [];
+}
+
+public class ChildTeamMemberViewModel
+{
+    public Guid UserId { get; set; }
+    public string DisplayName { get; set; } = string.Empty;
+    public string? ProfilePictureUrl { get; set; }
+    public bool HasCustomProfilePicture { get; set; }
+    public string? CustomProfilePictureUrl { get; set; }
+    public string ChildTeamName { get; set; } = string.Empty;
+    public string ChildTeamSlug { get; set; } = string.Empty;
+
+    public string? EffectiveProfilePictureUrl => HasCustomProfilePicture
+        ? CustomProfilePictureUrl
+        : ProfilePictureUrl;
 }
 
 public class TeamMemberViewModel

--- a/src/Humans.Web/Models/Vol/DepartmentDetailViewModel.cs
+++ b/src/Humans.Web/Models/Vol/DepartmentDetailViewModel.cs
@@ -8,6 +8,7 @@ public class DepartmentDetailViewModel
     public List<ChildTeamCard> ChildTeams { get; set; } = [];
     public bool IsCoordinator { get; set; }
     public EventSettings EventSettings { get; set; } = null!;
+    public List<EffectiveMember> EffectiveMembers { get; set; } = [];
 
     public class ChildTeamCard
     {
@@ -18,5 +19,13 @@ public class DepartmentDetailViewModel
         public int TotalSlots { get; set; }
         public int FilledSlots { get; set; }
         public int PendingRequestCount { get; set; }
+    }
+
+    public class EffectiveMember
+    {
+        public Guid UserId { get; set; }
+        public string DisplayName { get; set; } = string.Empty;
+        public string? ProfilePictureUrl { get; set; }
+        public List<string> SourceTeams { get; set; } = [];
     }
 }

--- a/src/Humans.Web/Views/Team/Details.cshtml
+++ b/src/Humans.Web/Views/Team/Details.cshtml
@@ -212,6 +212,29 @@
             </div>
         </div>
         }
+
+        @if (Model.IsAuthenticated && Model.ChildTeamMembers.Any())
+        {
+        <div class="card mb-4">
+            <div class="card-header">
+                <span>Humans via sub-teams (@Model.ChildTeamMembers.Count)</span>
+            </div>
+            <div class="card-body">
+                <div class="row g-3">
+                    @foreach (var member in Model.ChildTeamMembers)
+                    {
+                        <div class="col-6 col-sm-4 col-md-3">
+                            <human-link user-id="@member.UserId" display-name="@member.DisplayName"
+                                        mode="Card" size="102"
+                                        profile-picture-url="@member.EffectiveProfilePictureUrl">
+                                <span class="badge bg-secondary bg-opacity-50 small">@member.ChildTeamName</span>
+                            </human-link>
+                        </div>
+                    }
+                </div>
+            </div>
+        </div>
+        }
     </div>
 
     <div class="col-md-4">

--- a/src/Humans.Web/Views/Team/Details.cshtml
+++ b/src/Humans.Web/Views/Team/Details.cshtml
@@ -342,12 +342,15 @@
                     <a asp-controller="TeamAdmin" asp-action="Roles" asp-route-slug="@Model.Slug" class="list-group-item list-group-item-action">
                         Manage Roles
                     </a>
-                    <a asp-controller="TeamAdmin" asp-action="Resources" asp-route-slug="@Model.Slug" class="list-group-item list-group-item-action">
-                        @Localizer["TeamDetail_ManageResources"]
-                    </a>
-                    <a asp-controller="AdminLegalDocuments" asp-action="LegalDocuments" asp-route-teamId="@Model.Id" class="list-group-item list-group-item-action">
-                        @Localizer["TeamDetail_ManageConsents"]
-                    </a>
+                    @if (Model.CanCurrentUserEditTeam)
+                    {
+                        <a asp-controller="TeamAdmin" asp-action="Resources" asp-route-slug="@Model.Slug" class="list-group-item list-group-item-action">
+                            @Localizer["TeamDetail_ManageResources"]
+                        </a>
+                        <a asp-controller="AdminLegalDocuments" asp-action="LegalDocuments" asp-route-teamId="@Model.Id" class="list-group-item list-group-item-action">
+                            @Localizer["TeamDetail_ManageConsents"]
+                        </a>
+                    }
                 </div>
             </div>
         }

--- a/src/Humans.Web/Views/Vol/DepartmentDetail.cshtml
+++ b/src/Humans.Web/Views/Vol/DepartmentDetail.cshtml
@@ -80,3 +80,56 @@ else
         }
     </div>
 }
+
+@if (Model.EffectiveMembers.Count > 0)
+{
+    <div class="card mt-4">
+        <div class="card-header d-flex justify-content-between align-items-center">
+            <h5 class="mb-0">
+                <i class="fa-solid fa-users me-2"></i>All Humans
+                <span class="badge bg-secondary ms-2">@Model.EffectiveMembers.Count</span>
+            </h5>
+        </div>
+        <div class="card-body p-0">
+            <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                    <thead>
+                        <tr>
+                            <th>Human</th>
+                            <th>Teams</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var member in Model.EffectiveMembers)
+                        {
+                            <tr>
+                                <td class="d-flex align-items-center gap-2">
+                                    @if (!string.IsNullOrEmpty(member.ProfilePictureUrl))
+                                    {
+                                        <img src="@member.ProfilePictureUrl" alt="" class="rounded-circle" width="28" height="28" />
+                                    }
+                                    else
+                                    {
+                                        <span class="rounded-circle bg-light d-inline-flex align-items-center justify-content-center" style="width:28px;height:28px;">
+                                            <i class="fa-solid fa-user text-muted small"></i>
+                                        </span>
+                                    }
+                                    @member.DisplayName
+                                </td>
+                                <td>
+                                    @foreach (var teamName in member.SourceTeams)
+                                    {
+                                        var isDirect = string.Equals(teamName, Model.Department.Name, StringComparison.Ordinal);
+                                        <span class="badge @(isDirect ? "bg-primary" : "bg-secondary bg-opacity-50") me-1">
+                                            @teamName
+                                        </span>
+                                    }
+                                </td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+}


### PR DESCRIPTION
## Summary

- **#247** — Fix coordinator permissions not flowing to subteam join requests. `VolController.ChildTeamDetail` and `DepartmentDetail` used `ShiftManagementService.IsDeptCoordinatorAsync` which only checks `TeamRoleAssignment.IsManagement`. Replaced with the canonical `TeamService.IsUserCoordinatorOfTeamAsync` which checks both `TeamMember.Role == Coordinator` AND `IsManagement`, with parent team cascade. Also fixed `LoadCoordinatorDepartmentIdsAsync` in ShiftManagementService for consistency.

- **#250** — Add subteam member rollup to parent department Google resources. Members of subteams are now automatically included in the parent department's Google Group and Drive folder sync. `AddUserToTeamResourcesAsync` also grants parent resources on subteam join. Department detail page shows all effective humans with source team badges.

## Test plan

- [ ] Verify Deepark (coordinator of Creativity) can see and approve/reject join requests for Coon's House
- [ ] Verify department detail page shows all humans from all child teams with correct team badges
- [ ] Verify Google sync preview for a department shows subteam members as expected
- [ ] Verify adding a user to a subteam triggers parent department Google resource access
- [ ] Run full sync and verify no false positives (existing direct members unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)