### PR TITLE
feat: budget phase 2 — coordinator view & public summary

### DIFF
--- a/docs/features/31-budget.md
+++ b/docs/features/31-budget.md
@@ -189,13 +189,24 @@ Outbound invoices to members/barrios:
 - Budget CRUD at `/Finance/*` via FinanceController
 - Field-level audit trail with old/new values (separate BudgetAuditLog table)
 - Nav link visible to FinanceAdmin + Admin
-- **Not yet implemented:** Coordinator view (#233), public summary (#234), visibility enforcement (IsRestricted/IsDepartmentGroup stored but not enforced)
 - **Exit:** Can recreate 2026 spreadsheet budget in the app
 
-### V2a: Public View (1-2 sessions)
-- Public budget summary page (pie chart, speedometer)
-- Aggregated data only
-- **Exit:** General member can see "where does my ticket money go"
+### V1b: Coordinator View & Public Summary — IMPLEMENTED (#233, #234)
+- **Coordinator view** at `/Budget` via BudgetController (#233):
+  - Any team coordinator sees all department budgets (non-restricted groups)
+  - Can add/edit/delete line items within own department only
+  - Per-category unallocated remainder and progress bar
+  - `IsRestricted` groups hidden from coordinator view
+  - Authorization uses `GetEffectiveCoordinatorTeamIdsAsync` (includes child teams)
+  - All changes audit-logged via existing BudgetAuditLog
+- **Public summary** at `/Budget/Summary` (#234):
+  - All authenticated members see budget allocation pie chart (Chart.js doughnut)
+  - Progress bar showing overall budget utilization
+  - Breakdown table with category amounts and percentages
+  - No line-item, salary, or overhead detail visible
+  - Coordinators see link to department detail view
+- **Nav:** "Budget" link visible to all authenticated users; "Finance" link remains FinanceAdmin-only
+- **Exit:** Coordinators can manage their department budgets; all members see where money goes
 
 ### V2b: Stripe Integration (2-3 sessions)
 - Stripe sync job

--- a/src/Humans.Application/Interfaces/IBudgetService.cs
+++ b/src/Humans.Application/Interfaces/IBudgetService.cs
@@ -36,6 +36,9 @@ public interface IBudgetService
     Task UpdateLineItemAsync(Guid lineItemId, string description, decimal amount, Guid? responsibleTeamId, string? notes, LocalDate? expectedDate, Guid actorUserId);
     Task DeleteLineItemAsync(Guid lineItemId, Guid actorUserId);
 
+    // Coordinator
+    Task<HashSet<Guid>> GetEffectiveCoordinatorTeamIdsAsync(Guid userId);
+
     // Audit Log
     Task<IReadOnlyList<BudgetAuditLog>> GetAuditLogAsync(Guid? budgetYearId);
 }

--- a/src/Humans.Infrastructure/Services/BudgetService.cs
+++ b/src/Humans.Infrastructure/Services/BudgetService.cs
@@ -682,6 +682,47 @@ public class BudgetService : IBudgetService
         _dbContext.BudgetAuditLogs.Add(entry);
     }
 
+    // ───────────────────────── Coordinator ─────────────────────────
+
+    public async Task<HashSet<Guid>> GetEffectiveCoordinatorTeamIdsAsync(Guid userId)
+    {
+        // Teams where user is direct coordinator
+        var directTeamIds = await _dbContext.TeamMembers
+            .AsNoTracking()
+            .Where(tm => tm.UserId == userId && tm.LeftAt == null && tm.Role == TeamMemberRole.Coordinator)
+            .Select(tm => tm.TeamId)
+            .ToListAsync();
+
+        // Teams where user has management role assignment
+        var mgmtTeamIds = await _dbContext.Set<TeamRoleAssignment>()
+            .AsNoTracking()
+            .Where(tra =>
+                tra.TeamMember.UserId == userId &&
+                tra.TeamMember.LeftAt == null &&
+                tra.TeamRoleDefinition.IsManagement)
+            .Select(tra => tra.TeamMember.TeamId)
+            .ToListAsync();
+
+        var coordinatorTeamIds = directTeamIds.Concat(mgmtTeamIds).ToHashSet();
+
+        // Include child teams (department coordinators manage child team budgets)
+        if (coordinatorTeamIds.Count > 0)
+        {
+            var childTeamIds = await _dbContext.Teams
+                .AsNoTracking()
+                .Where(t => t.ParentTeamId != null && coordinatorTeamIds.Contains(t.ParentTeamId.Value))
+                .Select(t => t.Id)
+                .ToListAsync();
+
+            foreach (var childId in childTeamIds)
+                coordinatorTeamIds.Add(childId);
+        }
+
+        return coordinatorTeamIds;
+    }
+
+    // ───────────────────────── Audit Helpers ─────────────────────────
+
     /// <summary>
     /// Logs a create/delete action with a free-text description.
     /// </summary>

--- a/src/Humans.Web/Controllers/BudgetController.cs
+++ b/src/Humans.Web/Controllers/BudgetController.cs
@@ -1,0 +1,268 @@
+using Humans.Application.Interfaces;
+using Humans.Domain.Entities;
+using Humans.Infrastructure.Data;
+using Humans.Web.Authorization;
+using Humans.Web.Models;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using NodaTime;
+
+namespace Humans.Web.Controllers;
+
+[Authorize]
+[Route("Budget")]
+public class BudgetController : HumansControllerBase
+{
+    private readonly IBudgetService _budgetService;
+    private readonly HumansDbContext _dbContext;
+    private readonly ILogger<BudgetController> _logger;
+
+    public BudgetController(
+        IBudgetService budgetService,
+        HumansDbContext dbContext,
+        UserManager<User> userManager,
+        ILogger<BudgetController> logger)
+        : base(userManager)
+    {
+        _budgetService = budgetService;
+        _dbContext = dbContext;
+        _logger = logger;
+    }
+
+    [HttpGet("")]
+    public async Task<IActionResult> Index()
+    {
+        try
+        {
+            var (errorResult, user) = await RequireCurrentUserAsync();
+            if (errorResult is not null) return errorResult;
+
+            var isFinanceAdmin = RoleChecks.IsFinanceAdmin(User);
+            var coordinatorTeamIds = await _budgetService.GetEffectiveCoordinatorTeamIdsAsync(user.Id);
+
+            if (!isFinanceAdmin && coordinatorTeamIds.Count == 0)
+                return RedirectToAction(nameof(Summary));
+
+            var activeYear = await _budgetService.GetActiveYearAsync();
+            if (activeYear is null)
+            {
+                SetInfo("No active budget year.");
+                return View("NoActiveBudget");
+            }
+
+            var model = new CoordinatorBudgetViewModel
+            {
+                Year = activeYear,
+                EditableTeamIds = coordinatorTeamIds,
+                IsFinanceAdmin = isFinanceAdmin
+            };
+            return View(model);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error loading coordinator budget view");
+            SetError("Failed to load budget data.");
+            return View("NoActiveBudget");
+        }
+    }
+
+    [HttpGet("Summary")]
+    public async Task<IActionResult> Summary()
+    {
+        try
+        {
+            var (errorResult, user) = await RequireCurrentUserAsync();
+            if (errorResult is not null) return errorResult;
+
+            var activeYear = await _budgetService.GetActiveYearAsync();
+            if (activeYear is null)
+            {
+                SetInfo("No active budget year.");
+                return View("NoActiveBudget");
+            }
+
+            // Only show non-restricted groups in public summary
+            var visibleGroups = activeYear.Groups.Where(g => !g.IsRestricted).ToList();
+            var totalBudget = visibleGroups.SelectMany(g => g.Categories).Sum(c => c.AllocatedAmount);
+            var totalLineItems = visibleGroups.SelectMany(g => g.Categories)
+                .SelectMany(c => c.LineItems).Sum(li => li.Amount);
+
+            // Build slices from categories (aggregated by category name)
+            var slices = visibleGroups
+                .SelectMany(g => g.Categories)
+                .Where(c => c.AllocatedAmount > 0)
+                .OrderByDescending(c => c.AllocatedAmount)
+                .Select(c => new BudgetSlice
+                {
+                    Name = c.Name,
+                    Amount = c.AllocatedAmount,
+                    Percentage = totalBudget > 0 ? c.AllocatedAmount / totalBudget * 100 : 0
+                })
+                .ToList();
+
+            var coordinatorTeamIds = await _budgetService.GetEffectiveCoordinatorTeamIdsAsync(user.Id);
+
+            var model = new BudgetSummaryViewModel
+            {
+                YearName = activeYear.Name,
+                TotalBudget = totalBudget,
+                TotalLineItems = totalLineItems,
+                Slices = slices,
+                IsCoordinator = coordinatorTeamIds.Count > 0 || RoleChecks.IsFinanceAdmin(User)
+            };
+            return View(model);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error loading budget summary");
+            SetError("Failed to load budget summary.");
+            return View("NoActiveBudget");
+        }
+    }
+
+    [HttpGet("Category/{id:guid}")]
+    public async Task<IActionResult> CategoryDetail(Guid id)
+    {
+        try
+        {
+            var (errorResult, user) = await RequireCurrentUserAsync();
+            if (errorResult is not null) return errorResult;
+
+            var category = await _budgetService.GetCategoryByIdAsync(id);
+            if (category is null) return NotFound();
+
+            // Block access to restricted groups for non-finance users
+            var isFinanceAdmin = RoleChecks.IsFinanceAdmin(User);
+            if (category.BudgetGroup?.IsRestricted == true && !isFinanceAdmin)
+                return Forbid();
+
+            var coordinatorTeamIds = await _budgetService.GetEffectiveCoordinatorTeamIdsAsync(user.Id);
+            if (!isFinanceAdmin && coordinatorTeamIds.Count == 0)
+                return Forbid();
+
+            var canEdit = category.TeamId.HasValue && coordinatorTeamIds.Contains(category.TeamId.Value);
+
+            var teams = await _dbContext.Teams
+                .Where(t => t.IsActive)
+                .OrderBy(t => t.Name)
+                .Select(t => new TeamOption { Id = t.Id, Name = t.Name })
+                .ToListAsync();
+
+            var model = new CoordinatorCategoryDetailViewModel
+            {
+                Category = category,
+                CanEdit = canEdit || isFinanceAdmin,
+                IsFinanceAdmin = isFinanceAdmin,
+                Teams = teams
+            };
+            return View(model);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error loading budget category {CategoryId}", id);
+            SetError("Failed to load category.");
+            return RedirectToAction(nameof(Index));
+        }
+    }
+
+    [HttpPost("LineItems/Create")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> CreateLineItem(Guid budgetCategoryId, string description, decimal amount,
+        Guid? responsibleTeamId, string? notes, DateTime? expectedDate)
+    {
+        var (errorResult, user) = await RequireCurrentUserAsync();
+        if (errorResult is not null) return errorResult;
+
+        var authResult = await AuthorizeCategoryEditAsync(budgetCategoryId, user.Id);
+        if (authResult is not null) return authResult;
+
+        var nodaDate = expectedDate.HasValue ? LocalDate.FromDateTime(expectedDate.Value) : (LocalDate?)null;
+
+        try
+        {
+            await _budgetService.CreateLineItemAsync(budgetCategoryId, description, amount, responsibleTeamId, notes, nodaDate, user.Id);
+            SetSuccess($"Line item '{description}' created.");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error creating line item in category {CategoryId}", budgetCategoryId);
+            SetError($"Failed to create line item: {ex.Message}");
+        }
+        return RedirectToAction(nameof(CategoryDetail), new { id = budgetCategoryId });
+    }
+
+    [HttpPost("LineItems/{id:guid}/Update")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> UpdateLineItem(Guid id, string description, decimal amount,
+        Guid? responsibleTeamId, string? notes, DateTime? expectedDate, Guid budgetCategoryId)
+    {
+        var (errorResult, user) = await RequireCurrentUserAsync();
+        if (errorResult is not null) return errorResult;
+
+        var authResult = await AuthorizeCategoryEditAsync(budgetCategoryId, user.Id);
+        if (authResult is not null) return authResult;
+
+        var nodaDate = expectedDate.HasValue ? LocalDate.FromDateTime(expectedDate.Value) : (LocalDate?)null;
+
+        try
+        {
+            await _budgetService.UpdateLineItemAsync(id, description, amount, responsibleTeamId, notes, nodaDate, user.Id);
+            SetSuccess($"Line item '{description}' updated.");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error updating line item {LineItemId}", id);
+            SetError($"Failed to update line item: {ex.Message}");
+        }
+        return RedirectToAction(nameof(CategoryDetail), new { id = budgetCategoryId });
+    }
+
+    [HttpPost("LineItems/{id:guid}/Delete")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> DeleteLineItem(Guid id, Guid budgetCategoryId)
+    {
+        var (errorResult, user) = await RequireCurrentUserAsync();
+        if (errorResult is not null) return errorResult;
+
+        var authResult = await AuthorizeCategoryEditAsync(budgetCategoryId, user.Id);
+        if (authResult is not null) return authResult;
+
+        try
+        {
+            await _budgetService.DeleteLineItemAsync(id, user.Id);
+            SetSuccess("Line item deleted.");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error deleting line item {LineItemId}", id);
+            SetError($"Failed to delete line item: {ex.Message}");
+        }
+        return RedirectToAction(nameof(CategoryDetail), new { id = budgetCategoryId });
+    }
+
+    private async Task<IActionResult?> AuthorizeCategoryEditAsync(Guid categoryId, Guid userId)
+    {
+        if (RoleChecks.IsFinanceAdmin(User))
+            return null;
+
+        var category = await _budgetService.GetCategoryByIdAsync(categoryId);
+        if (category is null) return NotFound();
+
+        if (category.BudgetGroup?.IsRestricted == true)
+            return Forbid();
+
+        if (!category.TeamId.HasValue)
+            return Forbid();
+
+        var coordinatorTeamIds = await _budgetService.GetEffectiveCoordinatorTeamIdsAsync(userId);
+        if (!coordinatorTeamIds.Contains(category.TeamId.Value))
+        {
+            SetError("You can only edit line items in your own department's budget.");
+            return RedirectToAction(nameof(CategoryDetail), new { id = categoryId });
+        }
+
+        return null;
+    }
+}

--- a/src/Humans.Web/Models/BudgetViewModels.cs
+++ b/src/Humans.Web/Models/BudgetViewModels.cs
@@ -1,0 +1,40 @@
+using Humans.Domain.Entities;
+
+namespace Humans.Web.Models;
+
+public class CoordinatorBudgetViewModel
+{
+    public required BudgetYear Year { get; init; }
+    public required HashSet<Guid> EditableTeamIds { get; init; }
+    public bool IsFinanceAdmin { get; init; }
+}
+
+public class CoordinatorCategoryDetailViewModel
+{
+    public required BudgetCategory Category { get; init; }
+    public bool CanEdit { get; init; }
+    public bool IsFinanceAdmin { get; init; }
+    public required IReadOnlyList<TeamOption> Teams { get; init; }
+}
+
+public class TeamOption
+{
+    public Guid Id { get; init; }
+    public string Name { get; init; } = string.Empty;
+}
+
+public class BudgetSummaryViewModel
+{
+    public required string YearName { get; init; }
+    public decimal TotalBudget { get; init; }
+    public decimal TotalLineItems { get; init; }
+    public required IReadOnlyList<BudgetSlice> Slices { get; init; }
+    public bool IsCoordinator { get; init; }
+}
+
+public class BudgetSlice
+{
+    public required string Name { get; init; }
+    public decimal Amount { get; init; }
+    public decimal Percentage { get; init; }
+}

--- a/src/Humans.Web/Views/Budget/CategoryDetail.cshtml
+++ b/src/Humans.Web/Views/Budget/CategoryDetail.cshtml
@@ -213,7 +213,14 @@
                         <option value="">None</option>
                         @foreach (var team in Model.Teams)
                         {
-                            <option value="@team.Id">@team.Name</option>
+                            if (category.TeamId == team.Id)
+                            {
+                                <option value="@team.Id" selected>@team.Name</option>
+                            }
+                            else
+                            {
+                                <option value="@team.Id">@team.Name</option>
+                            }
                         }
                     </select>
                 </div>

--- a/src/Humans.Web/Views/Budget/CategoryDetail.cshtml
+++ b/src/Humans.Web/Views/Budget/CategoryDetail.cshtml
@@ -1,0 +1,242 @@
+@using Humans.Domain.Enums
+@model Humans.Web.Models.CoordinatorCategoryDetailViewModel
+@{
+    ViewData["Title"] = $"Budget - {Model.Category.Name}";
+    var category = Model.Category;
+    var group = category.BudgetGroup;
+    var year = group?.BudgetYear;
+    var lineItemTotal = category.LineItems.Sum(li => li.Amount);
+    var unallocated = category.AllocatedAmount - lineItemTotal;
+}
+
+<nav aria-label="breadcrumb" class="mb-3">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a asp-action="Index">Budget</a></li>
+        @if (group is not null)
+        {
+            <li class="breadcrumb-item">@group.Name</li>
+        }
+        <li class="breadcrumb-item active">@category.Name</li>
+    </ol>
+</nav>
+
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <h1 class="mb-0">@category.Name</h1>
+    @if (Model.CanEdit)
+    {
+        <span class="badge bg-success fs-6">Editable</span>
+    }
+    else
+    {
+        <span class="badge bg-secondary fs-6">Read-only</span>
+    }
+</div>
+
+<vc:temp-data-alerts />
+
+<div class="row mb-4">
+    <div class="col-md-4">
+        <div class="card text-center">
+            <div class="card-body">
+                <h6 class="card-subtitle mb-2 text-muted">Allocated</h6>
+                <h3 class="card-title mb-0">&euro;@category.AllocatedAmount.ToString("N2")</h3>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-4">
+        <div class="card text-center">
+            <div class="card-body">
+                <h6 class="card-subtitle mb-2 text-muted">Detailed in Line Items</h6>
+                <h3 class="card-title mb-0">&euro;@lineItemTotal.ToString("N2")</h3>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-4">
+        <div class="card text-center">
+            <div class="card-body">
+                <h6 class="card-subtitle mb-2 text-muted">Unallocated</h6>
+                <h3 class="card-title mb-0 @(unallocated < 0 ? "text-danger" : "")">
+                    &euro;@unallocated.ToString("N2")
+                </h3>
+            </div>
+        </div>
+    </div>
+</div>
+
+@if (category.AllocatedAmount > 0)
+{
+    var pct = lineItemTotal / category.AllocatedAmount * 100;
+    var barClass = pct > 100 ? "bg-danger" : pct > 80 ? "bg-warning" : "bg-success";
+    <div class="mb-4">
+        <div class="d-flex justify-content-between mb-1">
+            <small class="text-muted">Budget utilization</small>
+            <small class="text-muted">@pct.ToString("N0")%</small>
+        </div>
+        <div class="progress" style="height: 8px;">
+            <div class="progress-bar @barClass" style="width: @Math.Min(pct, 100).ToString("N0")%"></div>
+        </div>
+    </div>
+}
+
+<!-- Line Items -->
+<div class="card">
+    <div class="card-header d-flex justify-content-between align-items-center">
+        <span>Line Items</span>
+        <span class="badge bg-secondary">@category.LineItems.Count items</span>
+    </div>
+    @if (category.LineItems.Any())
+    {
+        <div class="table-responsive">
+            <table class="table table-sm table-hover mb-0">
+                <thead>
+                    <tr>
+                        <th>Description</th>
+                        <th class="text-end">Amount</th>
+                        <th>Responsible Team</th>
+                        <th>Notes</th>
+                        <th>Expected Date</th>
+                        @if (Model.CanEdit)
+                        {
+                            <th class="text-end" style="min-width: 120px;">Actions</th>
+                        }
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var item in category.LineItems.OrderBy(li => li.SortOrder))
+                    {
+                        var editId = $"edit-{item.Id.ToString("N")}";
+                        <tr>
+                            <td>@item.Description</td>
+                            <td class="text-end">&euro;@item.Amount.ToString("N2")</td>
+                            <td>@(item.ResponsibleTeam?.Name ?? "\u2014")</td>
+                            <td class="text-muted">@(item.Notes ?? "")</td>
+                            <td>@item.ExpectedDate?.ToString("d MMM yyyy", System.Globalization.CultureInfo.InvariantCulture)</td>
+                            @if (Model.CanEdit)
+                            {
+                                <td class="text-end">
+                                    <button class="btn btn-outline-secondary btn-sm" type="button" data-bs-toggle="collapse" data-bs-target="#@editId">
+                                        <i class="fa-solid fa-pen"></i>
+                                    </button>
+                                    <form asp-action="DeleteLineItem" asp-route-id="@item.Id" method="post" class="d-inline">
+                                        @Html.AntiForgeryToken()
+                                        <input type="hidden" name="budgetCategoryId" value="@category.Id" />
+                                        <button type="submit" class="btn btn-outline-danger btn-sm" onclick="return confirm('Delete this line item?')">
+                                            <i class="fa-solid fa-trash"></i>
+                                        </button>
+                                    </form>
+                                </td>
+                            }
+                        </tr>
+                        @if (Model.CanEdit)
+                        {
+                            <tr class="collapse" id="@editId">
+                                <td colspan="6" class="bg-light">
+                                    <form asp-action="UpdateLineItem" asp-route-id="@item.Id" method="post" class="row g-2 p-2 align-items-end">
+                                        @Html.AntiForgeryToken()
+                                        <input type="hidden" name="budgetCategoryId" value="@category.Id" />
+                                        <div class="col-md-3">
+                                            <label class="form-label form-label-sm">Description</label>
+                                            <input type="text" name="description" class="form-control form-control-sm" value="@item.Description" required />
+                                        </div>
+                                        <div class="col-md-2">
+                                            <label class="form-label form-label-sm">Amount (&euro;)</label>
+                                            <input type="number" name="amount" class="form-control form-control-sm" step="0.01" value="@item.Amount" required />
+                                        </div>
+                                        <div class="col-md-2">
+                                            <label class="form-label form-label-sm">Responsible Team</label>
+                                            <select name="responsibleTeamId" class="form-select form-select-sm">
+                                                <option value="">None</option>
+                                                @foreach (var team in Model.Teams)
+                                                {
+                                                    if (item.ResponsibleTeamId == team.Id)
+                                                    {
+                                                        <option value="@team.Id" selected>@team.Name</option>
+                                                    }
+                                                    else
+                                                    {
+                                                        <option value="@team.Id">@team.Name</option>
+                                                    }
+                                                }
+                                            </select>
+                                        </div>
+                                        <div class="col-md-2">
+                                            <label class="form-label form-label-sm">Notes</label>
+                                            <input type="text" name="notes" class="form-control form-control-sm" value="@item.Notes" />
+                                        </div>
+                                        <div class="col-md-2">
+                                            <label class="form-label form-label-sm">Expected Date</label>
+                                            <input type="date" name="expectedDate" class="form-control form-control-sm" value="@item.ExpectedDate?.ToDateTimeUnspecified().ToString("yyyy-MM-dd")" />
+                                        </div>
+                                        <div class="col-md-1">
+                                            <button type="submit" class="btn btn-primary btn-sm w-100">Save</button>
+                                        </div>
+                                    </form>
+                                </td>
+                            </tr>
+                        }
+                    }
+                </tbody>
+            </table>
+        </div>
+    }
+    else
+    {
+        <div class="card-body text-center text-muted py-4">
+            @if (Model.CanEdit)
+            {
+                <text>No line items yet. Add one below to detail your department's budget.</text>
+            }
+            else
+            {
+                <text>No line items yet.</text>
+            }
+        </div>
+    }
+    @if (Model.CanEdit)
+    {
+        <div class="card-footer bg-light">
+            <h6 class="mb-2">Add Line Item</h6>
+            <form asp-action="CreateLineItem" method="post" class="row g-2 align-items-end">
+                @Html.AntiForgeryToken()
+                <input type="hidden" name="budgetCategoryId" value="@category.Id" />
+                <div class="col-md-3">
+                    <label class="form-label form-label-sm">Description</label>
+                    <input type="text" name="description" class="form-control form-control-sm" required />
+                </div>
+                <div class="col-md-2">
+                    <label class="form-label form-label-sm">Amount (&euro;)</label>
+                    <input type="number" name="amount" class="form-control form-control-sm" step="0.01" min="0" value="0" required />
+                </div>
+                <div class="col-md-2">
+                    <label class="form-label form-label-sm">Responsible Team</label>
+                    <select name="responsibleTeamId" class="form-select form-select-sm">
+                        <option value="">None</option>
+                        @foreach (var team in Model.Teams)
+                        {
+                            <option value="@team.Id">@team.Name</option>
+                        }
+                    </select>
+                </div>
+                <div class="col-md-2">
+                    <label class="form-label form-label-sm">Notes</label>
+                    <input type="text" name="notes" class="form-control form-control-sm" />
+                </div>
+                <div class="col-md-2">
+                    <label class="form-label form-label-sm">Expected Date</label>
+                    <input type="date" name="expectedDate" class="form-control form-control-sm" />
+                </div>
+                <div class="col-md-1">
+                    <button type="submit" class="btn btn-primary btn-sm w-100">
+                        <i class="fa-solid fa-plus me-1"></i>Add
+                    </button>
+                </div>
+            </form>
+        </div>
+    }
+</div>
+
+<div class="mt-3">
+    <a asp-action="Index" class="btn btn-outline-secondary">
+        <i class="fa-solid fa-arrow-left me-1"></i>Back to Budget
+    </a>
+</div>

--- a/src/Humans.Web/Views/Budget/Index.cshtml
+++ b/src/Humans.Web/Views/Budget/Index.cshtml
@@ -102,12 +102,12 @@
                             {
                                 var catLineItemTotal = cat.LineItems.Sum(li => li.Amount);
                                 var catUnallocated = cat.AllocatedAmount - catLineItemTotal;
-                                var isEditable = Model.IsFinanceAdmin ||
-                                    (cat.TeamId.HasValue && Model.EditableTeamIds.Contains(cat.TeamId.Value));
+                                var isOwnDept = cat.TeamId.HasValue && Model.EditableTeamIds.Contains(cat.TeamId.Value);
+                                var isEditable = Model.IsFinanceAdmin || isOwnDept;
                                 <tr>
                                     <td>
                                         @cat.Name
-                                        @if (isEditable)
+                                        @if (isOwnDept)
                                         {
                                             <span class="badge bg-success ms-1">Your dept</span>
                                         }

--- a/src/Humans.Web/Views/Budget/Index.cshtml
+++ b/src/Humans.Web/Views/Budget/Index.cshtml
@@ -1,0 +1,145 @@
+@using Humans.Domain.Enums
+@model Humans.Web.Models.CoordinatorBudgetViewModel
+@{
+    ViewData["Title"] = $"Budget - {Model.Year.Name}";
+    var groups = Model.Year.Groups
+        .Where(g => !g.IsRestricted || Model.IsFinanceAdmin)
+        .OrderBy(g => g.SortOrder)
+        .ToList();
+    var totalAllocated = groups.SelectMany(g => g.Categories).Sum(c => c.AllocatedAmount);
+    var totalLineItems = groups.SelectMany(g => g.Categories).SelectMany(c => c.LineItems).Sum(li => li.Amount);
+    var unallocated = totalAllocated - totalLineItems;
+}
+
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <div class="d-flex align-items-center gap-3">
+        <h1 class="mb-0">@Model.Year.Name</h1>
+        <span class="badge bg-success fs-6">@Model.Year.Status</span>
+    </div>
+    @if (Model.IsFinanceAdmin)
+    {
+        <a asp-controller="Finance" asp-action="Index" class="btn btn-outline-primary">
+            <i class="fa-solid fa-gear me-1"></i>Finance Admin
+        </a>
+    }
+</div>
+
+<vc:temp-data-alerts />
+
+<div class="row mb-4">
+    <div class="col-md-4">
+        <div class="card text-center">
+            <div class="card-body">
+                <h6 class="card-subtitle mb-2 text-muted">Total Allocated</h6>
+                <h3 class="card-title mb-0">&euro;@totalAllocated.ToString("N2")</h3>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-4">
+        <div class="card text-center">
+            <div class="card-body">
+                <h6 class="card-subtitle mb-2 text-muted">Detailed in Line Items</h6>
+                <h3 class="card-title mb-0">&euro;@totalLineItems.ToString("N2")</h3>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-4">
+        <div class="card text-center">
+            <div class="card-body">
+                <h6 class="card-subtitle mb-2 text-muted">Unallocated</h6>
+                <h3 class="card-title mb-0 @(unallocated < 0 ? "text-danger" : "")">
+                    &euro;@unallocated.ToString("N2")
+                </h3>
+            </div>
+        </div>
+    </div>
+</div>
+
+@if (!groups.Any())
+{
+    <div class="card">
+        <div class="card-body text-center py-4">
+            <p class="text-muted mb-0">No budget groups available yet.</p>
+        </div>
+    </div>
+}
+
+@foreach (var group in groups)
+{
+    var groupAllocated = group.Categories.Sum(c => c.AllocatedAmount);
+    var groupLineItems = group.Categories.SelectMany(c => c.LineItems).Sum(li => li.Amount);
+    var collapseId = $"group-{group.Id.ToString("N")}";
+
+    <div class="card mb-3">
+        <div class="card-header d-flex justify-content-between align-items-center" role="button" data-bs-toggle="collapse" data-bs-target="#@collapseId">
+            <div>
+                <strong>@group.Name</strong>
+                <span class="text-muted ms-2">(@group.Categories.Count categories)</span>
+                @if (group.IsDepartmentGroup)
+                {
+                    <span class="badge bg-info ms-1">Departments</span>
+                }
+            </div>
+            <span class="text-muted">&euro;@groupAllocated.ToString("N2")</span>
+        </div>
+        <div id="@collapseId" class="collapse show">
+            <div class="card-body p-0">
+                @if (group.Categories.Any())
+                {
+                    <table class="table table-sm table-hover mb-0">
+                        <thead>
+                            <tr>
+                                <th>Category</th>
+                                <th class="text-end">Allocated</th>
+                                <th class="text-end">Line Items</th>
+                                <th class="text-end">Unallocated</th>
+                                <th>Type</th>
+                                <th></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach (var cat in group.Categories.OrderBy(c => c.SortOrder))
+                            {
+                                var catLineItemTotal = cat.LineItems.Sum(li => li.Amount);
+                                var catUnallocated = cat.AllocatedAmount - catLineItemTotal;
+                                var isEditable = Model.IsFinanceAdmin ||
+                                    (cat.TeamId.HasValue && Model.EditableTeamIds.Contains(cat.TeamId.Value));
+                                <tr>
+                                    <td>
+                                        @cat.Name
+                                        @if (isEditable)
+                                        {
+                                            <span class="badge bg-success ms-1">Your dept</span>
+                                        }
+                                    </td>
+                                    <td class="text-end">&euro;@cat.AllocatedAmount.ToString("N2")</td>
+                                    <td class="text-end">&euro;@catLineItemTotal.ToString("N2")</td>
+                                    <td class="text-end @(catUnallocated < 0 ? "text-danger" : "")">
+                                        &euro;@catUnallocated.ToString("N2")
+                                    </td>
+                                    <td>
+                                        <span class="badge bg-@(cat.ExpenditureType == ExpenditureType.CapEx ? "primary" : "secondary")">
+                                            @cat.ExpenditureType
+                                        </span>
+                                    </td>
+                                    <td class="text-end">
+                                        <a asp-action="CategoryDetail" asp-route-id="@cat.Id"
+                                           class="btn btn-outline-@(isEditable ? "primary" : "secondary") btn-sm">
+                                            @(isEditable ? "Manage" : "View") <i class="fa-solid fa-arrow-right ms-1"></i>
+                                        </a>
+                                    </td>
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
+                }
+                else
+                {
+                    <div class="card-body text-center text-muted py-3">
+                        No categories in this group.
+                    </div>
+                }
+            </div>
+        </div>
+    </div>
+}

--- a/src/Humans.Web/Views/Budget/NoActiveBudget.cshtml
+++ b/src/Humans.Web/Views/Budget/NoActiveBudget.cshtml
@@ -1,0 +1,15 @@
+@{
+    ViewData["Title"] = "Budget";
+}
+
+<h1 class="mb-4">Budget</h1>
+
+<vc:temp-data-alerts />
+
+<div class="card">
+    <div class="card-body text-center py-5">
+        <i class="fa-solid fa-chart-pie fa-3x text-muted mb-3"></i>
+        <h4 class="text-muted">No Active Budget</h4>
+        <p class="text-muted mb-0">There is no active budget year to display. A finance admin will set one up when budget planning begins.</p>
+    </div>
+</div>

--- a/src/Humans.Web/Views/Budget/Summary.cshtml
+++ b/src/Humans.Web/Views/Budget/Summary.cshtml
@@ -1,0 +1,162 @@
+@model Humans.Web.Models.BudgetSummaryViewModel
+@{
+    ViewData["Title"] = $"Budget - {Model.YearName}";
+    var spentPct = Model.TotalBudget > 0 ? Model.TotalLineItems / Model.TotalBudget * 100 : 0;
+    var gaugeClass = spentPct > 100 ? "bg-danger" : spentPct > 80 ? "bg-warning" : "bg-success";
+}
+
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <h1 class="mb-0">Budget Overview</h1>
+    @if (Model.IsCoordinator)
+    {
+        <a asp-action="Index" class="btn btn-outline-primary">
+            <i class="fa-solid fa-list me-1"></i>Department Detail
+        </a>
+    }
+</div>
+
+<vc:temp-data-alerts />
+
+<p class="text-muted mb-4">How the @Model.YearName budget is allocated across departments and infrastructure.</p>
+
+<!-- Summary Cards -->
+<div class="row mb-4">
+    <div class="col-md-6">
+        <div class="card text-center">
+            <div class="card-body">
+                <h6 class="card-subtitle mb-2 text-muted">Total Budget</h6>
+                <h2 class="card-title mb-0">&euro;@Model.TotalBudget.ToString("N0")</h2>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-6">
+        <div class="card text-center">
+            <div class="card-body">
+                <h6 class="card-subtitle mb-2 text-muted">Planned Spending</h6>
+                <h2 class="card-title mb-0">&euro;@Model.TotalLineItems.ToString("N0")</h2>
+                <div class="mt-2">
+                    <div class="d-flex justify-content-between mb-1">
+                        <small class="text-muted">Budget utilization</small>
+                        <small class="text-muted">@spentPct.ToString("N0")%</small>
+                    </div>
+                    <div class="progress" style="height: 10px;">
+                        <div class="progress-bar @gaugeClass" style="width: @Math.Min(spentPct, 100).ToString("N0")%"></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+@{
+    var jsonOpts = new System.Text.Json.JsonSerializerOptions { PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase };
+    var chartLabels = Model.Slices.Select(s => s.Name).ToList();
+    var chartData = Model.Slices.Select(s => s.Amount).ToList();
+}
+
+@if (Model.Slices.Any())
+{
+    <div class="row">
+        <!-- Pie Chart -->
+        <div class="col-lg-7 mb-4">
+            <div class="card">
+                <div class="card-header">Budget Allocation</div>
+                <div class="card-body">
+                    <canvas id="budgetPieChart"></canvas>
+                </div>
+            </div>
+        </div>
+
+        <!-- Breakdown Table -->
+        <div class="col-lg-5 mb-4">
+            <div class="card">
+                <div class="card-header">Breakdown</div>
+                <div class="table-responsive">
+                    <table class="table table-sm mb-0">
+                        <thead>
+                            <tr>
+                                <th>Category</th>
+                                <th class="text-end">Amount</th>
+                                <th class="text-end">Share</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach (var slice in Model.Slices)
+                            {
+                                <tr>
+                                    <td>@slice.Name</td>
+                                    <td class="text-end">&euro;@slice.Amount.ToString("N0")</td>
+                                    <td class="text-end">@slice.Percentage.ToString("N1")%</td>
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script>
+    if (typeof Chart === 'undefined') {
+        var s = document.createElement('script');
+        s.src = 'https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js';
+        s.onload = function() { renderBudgetPie(); };
+        document.head.appendChild(s);
+    } else {
+        document.addEventListener('DOMContentLoaded', function() { renderBudgetPie(); });
+    }
+
+    function renderBudgetPie() {
+        var labels = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(chartLabels, jsonOpts));
+        var data = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(chartData, jsonOpts));
+
+        var colors = [
+            '#0d6efd', '#198754', '#ffc107', '#dc3545', '#0dcaf0',
+            '#6f42c1', '#fd7e14', '#20c997', '#d63384', '#6610f2',
+            '#adb5bd', '#495057', '#e83e8c', '#17a2b8', '#28a745'
+        ];
+
+        new Chart(document.getElementById('budgetPieChart'), {
+            type: 'doughnut',
+            data: {
+                labels: labels,
+                datasets: [{
+                    data: data,
+                    backgroundColor: colors.slice(0, data.length),
+                    borderWidth: 2,
+                    borderColor: '#fff'
+                }]
+            },
+            options: {
+                responsive: true,
+                plugins: {
+                    legend: {
+                        position: 'bottom',
+                        labels: { padding: 16, usePointStyle: true }
+                    },
+                    tooltip: {
+                        callbacks: {
+                            label: function(ctx) {
+                                var val = ctx.raw;
+                                var total = ctx.dataset.data.reduce(function(a, b) { return a + b; }, 0);
+                                var pct = total > 0 ? (val / total * 100).toFixed(1) : 0;
+                                return ctx.label + ': \u20ac' + val.toLocaleString() + ' (' + pct + '%)';
+                            }
+                        }
+                    }
+                }
+            }
+        });
+    }
+    </script>
+}
+else
+{
+    <div class="card">
+        <div class="card-body text-center py-5">
+            <i class="fa-solid fa-chart-pie fa-3x text-muted mb-3"></i>
+            <h4 class="text-muted">Budget data not available yet</h4>
+            <p class="text-muted mb-0">Budget allocations will appear here once they are set up by the finance team.</p>
+        </div>
+    </div>
+}

--- a/src/Humans.Web/Views/Budget/Summary.cshtml
+++ b/src/Humans.Web/Views/Budget/Summary.cshtml
@@ -3,6 +3,9 @@
     ViewData["Title"] = $"Budget - {Model.YearName}";
     var spentPct = Model.TotalBudget > 0 ? Model.TotalLineItems / Model.TotalBudget * 100 : 0;
     var gaugeClass = spentPct > 100 ? "bg-danger" : spentPct > 80 ? "bg-warning" : "bg-success";
+    var jsonOpts = new System.Text.Json.JsonSerializerOptions { PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase };
+    var chartLabels = Model.Slices.Select(s => s.Name).ToList();
+    var chartData = Model.Slices.Select(s => s.Percentage).ToList();
 }
 
 <div class="d-flex justify-content-between align-items-center mb-4">
@@ -19,40 +22,19 @@
 
 <p class="text-muted mb-4">How the @Model.YearName budget is allocated across departments and infrastructure.</p>
 
-<!-- Summary Cards -->
-<div class="row mb-4">
-    <div class="col-md-6">
-        <div class="card text-center">
-            <div class="card-body">
-                <h6 class="card-subtitle mb-2 text-muted">Total Budget</h6>
-                <h2 class="card-title mb-0">&euro;@Model.TotalBudget.ToString("N0")</h2>
-            </div>
+<!-- Budget utilization -->
+<div class="card mb-4">
+    <div class="card-body">
+        <div class="d-flex justify-content-between align-items-center mb-2">
+            <h5 class="mb-0">Budget Utilization</h5>
+            <span class="fs-4 fw-bold">@spentPct.ToString("N0")%</span>
         </div>
-    </div>
-    <div class="col-md-6">
-        <div class="card text-center">
-            <div class="card-body">
-                <h6 class="card-subtitle mb-2 text-muted">Planned Spending</h6>
-                <h2 class="card-title mb-0">&euro;@Model.TotalLineItems.ToString("N0")</h2>
-                <div class="mt-2">
-                    <div class="d-flex justify-content-between mb-1">
-                        <small class="text-muted">Budget utilization</small>
-                        <small class="text-muted">@spentPct.ToString("N0")%</small>
-                    </div>
-                    <div class="progress" style="height: 10px;">
-                        <div class="progress-bar @gaugeClass" style="width: @Math.Min(spentPct, 100).ToString("N0")%"></div>
-                    </div>
-                </div>
-            </div>
+        <div class="progress" style="height: 12px;">
+            <div class="progress-bar @gaugeClass" style="width: @Math.Min(spentPct, 100).ToString("N0")%"></div>
         </div>
+        <small class="text-muted mt-1 d-block">Percentage of the total budget detailed in line items.</small>
     </div>
 </div>
-
-@{
-    var jsonOpts = new System.Text.Json.JsonSerializerOptions { PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase };
-    var chartLabels = Model.Slices.Select(s => s.Name).ToList();
-    var chartData = Model.Slices.Select(s => s.Amount).ToList();
-}
 
 @if (Model.Slices.Any())
 {
@@ -76,7 +58,6 @@
                         <thead>
                             <tr>
                                 <th>Category</th>
-                                <th class="text-end">Amount</th>
                                 <th class="text-end">Share</th>
                             </tr>
                         </thead>
@@ -85,7 +66,6 @@
                             {
                                 <tr>
                                     <td>@slice.Name</td>
-                                    <td class="text-end">&euro;@slice.Amount.ToString("N0")</td>
                                     <td class="text-end">@slice.Percentage.ToString("N1")%</td>
                                 </tr>
                             }
@@ -137,10 +117,7 @@
                     tooltip: {
                         callbacks: {
                             label: function(ctx) {
-                                var val = ctx.raw;
-                                var total = ctx.dataset.data.reduce(function(a, b) { return a + b; }, 0);
-                                var pct = total > 0 ? (val / total * 100).toFixed(1) : 0;
-                                return ctx.label + ': \u20ac' + val.toLocaleString() + ' (' + pct + '%)';
+                                return ctx.label + ': ' + ctx.raw.toFixed(1) + '%';
                             }
                         }
                     }

--- a/src/Humans.Web/Views/Finance/CategoryDetail.cshtml
+++ b/src/Humans.Web/Views/Finance/CategoryDetail.cshtml
@@ -226,7 +226,16 @@
                     <option value="">None</option>
                     @foreach (var team in teams)
                     {
-                        <option value="@team.Id">@team.Name</option>
+                        var teamId = (Guid)team.Id;
+                        var teamName = (string)team.Name;
+                        if (Model.TeamId == teamId)
+                        {
+                            <option value="@teamId" selected>@teamName</option>
+                        }
+                        else
+                        {
+                            <option value="@teamId">@teamName</option>
+                        }
                     }
                 </select>
             </div>

--- a/src/Humans.Web/Views/Shared/_Layout.cshtml
+++ b/src/Humans.Web/Views/Shared/_Layout.cshtml
@@ -109,6 +109,12 @@
                                 <a class="nav-link" asp-area="" asp-controller="Feedback" asp-action="Index">Feedback @await Component.InvokeAsync("NavBadges", new { queue = "feedback" })</a>
                             </li>
                         }
+                        @if (User.Identity?.IsAuthenticated == true)
+                        {
+                            <li class="nav-item">
+                                <a class="nav-link" asp-area="" asp-controller="Budget" asp-action="Summary">Budget</a>
+                            </li>
+                        }
                         @if (Humans.Web.Authorization.RoleChecks.CanAccessFinance(User))
                         {
                             <li class="nav-item">


### PR DESCRIPTION
## Summary
- **#233**: Coordinators can view all department budgets and edit line items within their own department. Restricted groups (overhead/salary) hidden. Authorization via `GetEffectiveCoordinatorTeamIdsAsync` which includes child team cascading.
- **#234**: All authenticated members see a public budget summary at `/Budget/Summary` with doughnut pie chart (Chart.js), utilization progress bar, and breakdown table. No line-item or salary detail visible.
- Nav: "Budget" link visible to all authenticated users; "Finance" remains admin-only.

## Test plan
- [ ] As a coordinator: navigate to `/Budget`, verify own department shows "Your dept" badge and editable controls
- [ ] As a coordinator: add/edit/delete line items in own department — verify audit log entries created
- [ ] As a coordinator: verify other departments show as read-only (no edit controls)
- [ ] As a coordinator: verify restricted groups (IsRestricted=true) are hidden
- [ ] As a regular member: navigate to `/Budget`, verify redirect to `/Budget/Summary`
- [ ] As a regular member: verify pie chart renders with correct proportions
- [ ] As a regular member: verify no line-item detail or salary/overhead categories visible
- [ ] As FinanceAdmin: verify can access both `/Budget` (coordinator view) and `/Finance` (admin view)

🤖 Generated with [Claude Code](https://claude.com/claude-code)