### PR TITLE
feat: shift signups component and guided discovery (#256, #251)

### DIFF
--- a/docs/features/25-shift-management.md
+++ b/docs/features/25-shift-management.md
@@ -73,6 +73,19 @@ See `docs/specs/shift-management-spec.md` for the full design specification.
 - Bail from confirmed or pending signups
 - Range bail via `BailRangeAsync` — bails all signups sharing a `SignupBlockId` (build/strike date-range signups)
 - Build shift bail blocked after EE close for non-privileged users
+- Reusable `ShiftSignupsViewComponent` shows categorized signups (upcoming/pending/past) on Dashboard and HumanDetail pages
+
+### US-25.7: Guided Shift Discovery
+**As a** volunteer with no upcoming shifts
+**I want to** see a guided introduction to shifts on my dashboard
+**So that** I understand how to get involved
+
+**Acceptance Criteria:**
+- When shift browsing is open and user has no upcoming or pending signups, Dashboard shows a discovery card
+- Discovery card explains the three shift phases (Set-up, Event, Strike) with brief descriptions
+- Urgent understaffed shifts are highlighted within the discovery card
+- Clear CTAs to browse all shifts and view own shift schedule
+- When user has existing signups, the standard shift signups component and urgent shifts list are shown instead
 
 ### US-25.6: Post-Event No-Show Tracking
 **As a** coordinator
@@ -131,6 +144,8 @@ Pending --> Cancelled   (system: shift deleted, account deletion)
 | `/Shifts/Mine` | View own signups (upcoming, pending, past) |
 | `/Shifts/Settings` | Admin: manage EventSettings |
 | `/Teams/{slug}/Shifts` | Coordinator: manage rotas/shifts for a department |
+| `/` (Dashboard) | Shift signups ViewComponent + guided discovery when no signups |
+| `/Human/{id}/Admin` | Shift signups ViewComponent (admin view of user's shifts) |
 
 ## Related Features
 

--- a/src/Humans.Web/Controllers/HomeController.cs
+++ b/src/Humans.Web/Controllers/HomeController.cs
@@ -121,6 +121,11 @@ public class HomeController : HumansControllerBase
         try
         {
             var activeEvent = await _shiftMgmt.GetActiveAsync();
+            if (activeEvent is not null)
+            {
+                viewModel.EventName = activeEvent.EventName;
+                viewModel.IsShiftBrowsingOpen = activeEvent.IsShiftBrowsingOpen;
+            }
             if (activeEvent is not null && activeEvent.IsShiftBrowsingOpen)
             {
                 var urgentShifts = await _shiftMgmt.GetUrgentShiftsAsync(activeEvent.Id, limit: 3);

--- a/src/Humans.Web/Controllers/HomeController.cs
+++ b/src/Humans.Web/Controllers/HomeController.cs
@@ -93,6 +93,7 @@ public class HomeController : HumansControllerBase
 
         var viewModel = new DashboardViewModel
         {
+            UserId = user.Id,
             DisplayName = user.DisplayName,
             ProfilePictureUrl = user.ProfilePictureUrl,
             MembershipStatus = membershipSnapshot.Status,

--- a/src/Humans.Web/Models/DashboardViewModel.cs
+++ b/src/Humans.Web/Models/DashboardViewModel.cs
@@ -4,6 +4,7 @@ namespace Humans.Web.Models;
 
 public class DashboardViewModel
 {
+    public Guid UserId { get; set; }
     public string DisplayName { get; set; } = string.Empty;
     public string? ProfilePictureUrl { get; set; }
     public MembershipStatus MembershipStatus { get; set; }

--- a/src/Humans.Web/Models/DashboardViewModel.cs
+++ b/src/Humans.Web/Models/DashboardViewModel.cs
@@ -37,6 +37,10 @@ public class DashboardViewModel
     public bool TermExpiresSoon { get; set; }
     public bool TermExpired { get; set; }
 
+    // Shift discovery
+    public bool IsShiftBrowsingOpen { get; set; }
+    public string? EventName { get; set; }
+
     // Quick stats
     public DateTime MemberSince { get; set; }
     public DateTime? LastLogin { get; set; }

--- a/src/Humans.Web/Models/ShiftViewModels.cs
+++ b/src/Humans.Web/Models/ShiftViewModels.cs
@@ -288,6 +288,25 @@ public class ShiftsSummaryCardViewModel
     public bool CanManageShifts { get; set; }
 }
 
+// === Shift Signups ViewComponent ===
+
+public enum ShiftSignupsViewMode
+{
+    Self,
+    Admin
+}
+
+public class ShiftSignupsViewModel
+{
+    public List<MySignupItem> Upcoming { get; set; } = [];
+    public List<MySignupItem> Pending { get; set; } = [];
+    public List<MySignupItem> Past { get; set; } = [];
+    public EventSettings? EventSettings { get; set; }
+    public ShiftSignupsViewMode ViewMode { get; set; }
+    public Guid UserId { get; set; }
+    public string? DisplayName { get; set; }
+}
+
 // === No-Show History ===
 
 public class NoShowHistoryItem

--- a/src/Humans.Web/ViewComponents/ShiftSignupsViewComponent.cs
+++ b/src/Humans.Web/ViewComponents/ShiftSignupsViewComponent.cs
@@ -1,0 +1,76 @@
+using Humans.Application.Interfaces;
+using Humans.Domain.Enums;
+using Humans.Web.Models;
+using Microsoft.AspNetCore.Mvc;
+using NodaTime;
+
+namespace Humans.Web.ViewComponents;
+
+public class ShiftSignupsViewComponent : ViewComponent
+{
+    private readonly IShiftSignupService _signupService;
+    private readonly IShiftManagementService _shiftMgmt;
+    private readonly IClock _clock;
+
+    public ShiftSignupsViewComponent(
+        IShiftSignupService signupService,
+        IShiftManagementService shiftMgmt,
+        IClock clock)
+    {
+        _signupService = signupService;
+        _shiftMgmt = shiftMgmt;
+        _clock = clock;
+    }
+
+    public async Task<IViewComponentResult> InvokeAsync(Guid userId, ShiftSignupsViewMode viewMode, string? displayName = null)
+    {
+        var es = await _shiftMgmt.GetActiveAsync();
+
+        var signups = es is not null
+            ? await _signupService.GetByUserAsync(userId, es.Id)
+            : [];
+
+        var now = _clock.GetCurrentInstant();
+        var model = new ShiftSignupsViewModel
+        {
+            EventSettings = es,
+            ViewMode = viewMode,
+            UserId = userId,
+            DisplayName = displayName
+        };
+
+        foreach (var signup in signups)
+        {
+            if (signup.Shift?.Rota?.Team is null || es is null)
+                continue;
+
+            var item = new MySignupItem
+            {
+                Signup = signup,
+                DepartmentName = signup.Shift.Rota.Team.Name,
+                AbsoluteStart = signup.Shift.GetAbsoluteStart(es),
+                AbsoluteEnd = signup.Shift.GetAbsoluteEnd(es)
+            };
+
+            switch (signup.Status)
+            {
+                case SignupStatus.Confirmed when item.AbsoluteStart > now:
+                    model.Upcoming.Add(item);
+                    break;
+                case SignupStatus.Pending:
+                    model.Pending.Add(item);
+                    break;
+                default:
+                    if (signup.Status is SignupStatus.Confirmed or SignupStatus.NoShow or SignupStatus.Bailed)
+                        model.Past.Add(item);
+                    break;
+            }
+        }
+
+        model.Upcoming = model.Upcoming.OrderBy(s => s.AbsoluteStart).ToList();
+        model.Pending = model.Pending.OrderBy(s => s.AbsoluteStart).ToList();
+        model.Past = model.Past.OrderByDescending(s => s.AbsoluteStart).ToList();
+
+        return View(model);
+    }
+}

--- a/src/Humans.Web/Views/Home/Dashboard.cshtml
+++ b/src/Humans.Web/Views/Home/Dashboard.cshtml
@@ -121,28 +121,93 @@ else if (Model.PendingConsents > 0)
             var shiftCards = ViewData["ShiftCards"] as Humans.Web.Models.ShiftCardsViewModel;
         }
 
-        <vc:shift-signups user-id="@Model.UserId" view-mode="@ShiftSignupsViewMode.Self" />
+        @{
+            var hasUpcomingShifts = shiftCards?.NextShifts.Count > 0 || shiftCards?.PendingCount > 0;
+        }
 
-        @if (shiftCards?.UrgentShifts.Count > 0)
+        @if (hasUpcomingShifts)
         {
-            <div class="card mb-4">
-                <div class="card-header">
-                    <h5 class="mb-0">Shifts Need Help</h5>
+            <vc:shift-signups user-id="@Model.UserId" view-mode="@ShiftSignupsViewMode.Self" />
+
+            @if (shiftCards?.UrgentShifts.Count > 0)
+            {
+                <div class="card mb-4">
+                    <div class="card-header">
+                        <h5 class="mb-0">Shifts Need Help</h5>
+                    </div>
+                    <div class="card-body">
+                        <ul class="list-unstyled mb-0">
+                            @foreach (var item in shiftCards.UrgentShifts)
+                            {
+                                <li class="mb-2">
+                                    <strong>@(item?.Shift?.Rota?.Name ?? "Unknown")</strong>
+                                    <span class="badge bg-danger">@(item?.RemainingSlots ?? 0) slots</span>
+                                    <br /><small class="text-muted">@(item?.DepartmentName ?? "")</small>
+                                </li>
+                            }
+                        </ul>
+                    </div>
+                    <div class="card-footer">
+                        <a asp-controller="Shifts" asp-action="Index" class="btn btn-sm btn-outline-success">Browse Volunteer Options</a>
+                    </div>
+                </div>
+            }
+        }
+        else if (Model.IsShiftBrowsingOpen)
+        {
+            @* Guided shift discovery — shown when user has no upcoming shifts *@
+            <div class="card mb-4 border-primary">
+                <div class="card-header bg-primary text-white">
+                    <h5 class="mb-0"><i class="fa-solid fa-hand-holding-heart me-2"></i>Get Involved — @Model.EventName</h5>
                 </div>
                 <div class="card-body">
-                    <ul class="list-unstyled mb-0">
-                        @foreach (var item in shiftCards.UrgentShifts)
-                        {
-                            <li class="mb-2">
-                                <strong>@(item?.Shift?.Rota?.Name ?? "Unknown")</strong>
-                                <span class="badge bg-danger">@(item?.RemainingSlots ?? 0) slots</span>
-                                <br /><small class="text-muted">@(item?.DepartmentName ?? "")</small>
-                            </li>
-                        }
-                    </ul>
+                    <p>The event runs on volunteer power. Pick shifts that fit your schedule — every hour helps.</p>
+
+                    <div class="row g-3 mb-3">
+                        <div class="col-md-4">
+                            <div class="border rounded p-3 h-100">
+                                <h6><span class="badge bg-info me-1">Set-up</span></h6>
+                                <small class="text-muted">Build the site before gates open. Physical work, flexible hours, great for meeting the crew.</small>
+                            </div>
+                        </div>
+                        <div class="col-md-4">
+                            <div class="border rounded p-3 h-100">
+                                <h6><span class="badge bg-success me-1">Event</span></h6>
+                                <small class="text-muted">Keep things running during the event. Bars, gates, safety, art — something for everyone.</small>
+                            </div>
+                        </div>
+                        <div class="col-md-4">
+                            <div class="border rounded p-3 h-100">
+                                <h6><span class="badge bg-secondary me-1">Strike</span></h6>
+                                <small class="text-muted">Take it all down and leave no trace. Satisfying work, usually shorter commitment.</small>
+                            </div>
+                        </div>
+                    </div>
+
+                    @if (shiftCards?.UrgentShifts.Count > 0)
+                    {
+                        <h6 class="mt-3"><i class="fa-solid fa-fire text-danger me-1"></i>Shifts that need humans now</h6>
+                        <ul class="list-unstyled mb-3">
+                            @foreach (var item in shiftCards.UrgentShifts)
+                            {
+                                <li class="d-flex justify-content-between align-items-center py-1">
+                                    <span>
+                                        <strong>@(item?.Shift?.Rota?.Name ?? "Unknown")</strong>
+                                        <small class="text-muted ms-1">@(item?.DepartmentName ?? "")</small>
+                                    </span>
+                                    <span class="badge bg-danger">@(item?.RemainingSlots ?? 0) slots open</span>
+                                </li>
+                            }
+                        </ul>
+                    }
                 </div>
-                <div class="card-footer">
-                    <a asp-controller="Shifts" asp-action="Index" class="btn btn-sm btn-outline-success">Browse Volunteer Options</a>
+                <div class="card-footer d-flex gap-2">
+                    <a asp-controller="Shifts" asp-action="Index" class="btn btn-primary">
+                        <i class="fa-solid fa-calendar-alt me-1"></i>Browse All Shifts
+                    </a>
+                    <a asp-controller="Shifts" asp-action="Mine" class="btn btn-outline-secondary">
+                        <i class="fa-solid fa-clipboard-list me-1"></i>My Shifts
+                    </a>
                 </div>
             </div>
         }

--- a/src/Humans.Web/Views/Home/Dashboard.cshtml
+++ b/src/Humans.Web/Views/Home/Dashboard.cshtml
@@ -119,17 +119,32 @@ else if (Model.PendingConsents > 0)
 
         @{
             var shiftCards = ViewData["ShiftCards"] as Humans.Web.Models.ShiftCardsViewModel;
-            if (shiftCards != null)
-            {
-                try
-                {
-                    await Html.RenderPartialAsync("_ShiftCards", shiftCards);
-                }
-                catch
-                {
-                    <div class="alert alert-warning mb-4">Shift cards could not be loaded.</div>
-                }
-            }
+        }
+
+        <vc:shift-signups user-id="@Model.UserId" view-mode="@ShiftSignupsViewMode.Self" />
+
+        @if (shiftCards?.UrgentShifts.Count > 0)
+        {
+            <div class="card mb-4">
+                <div class="card-header">
+                    <h5 class="mb-0">Shifts Need Help</h5>
+                </div>
+                <div class="card-body">
+                    <ul class="list-unstyled mb-0">
+                        @foreach (var item in shiftCards.UrgentShifts)
+                        {
+                            <li class="mb-2">
+                                <strong>@(item?.Shift?.Rota?.Name ?? "Unknown")</strong>
+                                <span class="badge bg-danger">@(item?.RemainingSlots ?? 0) slots</span>
+                                <br /><small class="text-muted">@(item?.DepartmentName ?? "")</small>
+                            </li>
+                        }
+                    </ul>
+                </div>
+                <div class="card-footer">
+                    <a asp-controller="Shifts" asp-action="Index" class="btn btn-sm btn-outline-success">Browse Volunteer Options</a>
+                </div>
+            </div>
         }
 
         @if (Model.IsVolunteerMember)

--- a/src/Humans.Web/Views/Human/HumanDetail.cshtml
+++ b/src/Humans.Web/Views/Human/HumanDetail.cshtml
@@ -198,6 +198,8 @@
             }
         </div>
 
+        <vc:shift-signups user-id="@Model.UserId" view-mode="@ShiftSignupsViewMode.Admin" display-name="@Model.DisplayName" />
+
         <div class="card mb-4">
             <div class="card-header">@Localizer["AdminHuman_AuditHistory"]</div>
             @if (Model.AuditLog.Count > 0)

--- a/src/Humans.Web/Views/Shared/Components/ShiftSignups/Default.cshtml
+++ b/src/Humans.Web/Views/Shared/Components/ShiftSignups/Default.cshtml
@@ -1,0 +1,149 @@
+@model Humans.Web.Models.ShiftSignupsViewModel
+@using Humans.Domain.Enums
+@using Humans.Web.Extensions
+@using NodaTime
+
+@{
+    var hasAny = Model.Upcoming.Count > 0 || Model.Pending.Count > 0 || Model.Past.Count > 0;
+    var es = Model.EventSettings;
+    var tz = es != null ? DateTimeZoneProviders.Tzdb[es.TimeZoneId] : null;
+    var isAdmin = Model.ViewMode == ShiftSignupsViewMode.Admin;
+    var label = isAdmin && !string.IsNullOrEmpty(Model.DisplayName)
+        ? $"{Model.DisplayName}'s Shifts"
+        : "Shift Signups";
+}
+
+@functions {
+    static string StatusBadge(SignupStatus status) => status switch
+    {
+        SignupStatus.Confirmed => "bg-success",
+        SignupStatus.Pending => "bg-warning",
+        SignupStatus.Bailed => "bg-danger",
+        SignupStatus.NoShow => "bg-danger",
+        _ => "bg-secondary"
+    };
+}
+
+<div class="card mb-4">
+    <div class="card-header d-flex justify-content-between align-items-center">
+        <span>@label</span>
+        @if (Model.Upcoming.Count + Model.Pending.Count > 0)
+        {
+            <span>
+                @if (Model.Upcoming.Count > 0)
+                {
+                    <span class="badge bg-success">@Model.Upcoming.Count confirmed</span>
+                }
+                @if (Model.Pending.Count > 0)
+                {
+                    <span class="badge bg-warning ms-1">@Model.Pending.Count pending</span>
+                }
+            </span>
+        }
+    </div>
+    @if (!hasAny)
+    {
+        <div class="card-body text-muted">
+            @if (es == null)
+            {
+                <text>No active event configured.</text>
+            }
+            else
+            {
+                <text>No shift signups yet.</text>
+                @if (!isAdmin)
+                {
+                    <a asp-controller="Shifts" asp-action="Index" class="ms-1">Browse available shifts</a>
+                }
+            }
+        </div>
+    }
+    else if (es != null && tz != null)
+    {
+        <div class="card-body p-0">
+            @if (Model.Upcoming.Count > 0)
+            {
+                <div class="px-3 pt-3 pb-1">
+                    <h6 class="text-success mb-2"><i class="fa-solid fa-check-circle me-1"></i>Upcoming (@Model.Upcoming.Count)</h6>
+                </div>
+                <div class="table-responsive">
+                    <table class="table table-sm mb-0">
+                        <tbody>
+                            @foreach (var item in Model.Upcoming)
+                            {
+                                var shift = item.Signup.Shift;
+                                <tr>
+                                    <td class="ps-3">@item.DepartmentName</td>
+                                    <td><strong>@shift.Rota.Name</strong></td>
+                                    <td>@es.GateOpeningDate.PlusDays(shift.DayOffset).ToDisplayShiftDate()</td>
+                                    <td>@item.AbsoluteStart.ToDisplayTime(tz)–@item.AbsoluteEnd.ToDisplayTime(tz)</td>
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
+                </div>
+            }
+            @if (Model.Pending.Count > 0)
+            {
+                <div class="px-3 pt-3 pb-1">
+                    <h6 class="text-warning mb-2"><i class="fa-solid fa-clock me-1"></i>Pending (@Model.Pending.Count)</h6>
+                </div>
+                <div class="table-responsive">
+                    <table class="table table-sm mb-0">
+                        <tbody>
+                            @foreach (var item in Model.Pending)
+                            {
+                                var shift = item.Signup.Shift;
+                                <tr>
+                                    <td class="ps-3">@item.DepartmentName</td>
+                                    <td><strong>@shift.Rota.Name</strong></td>
+                                    <td>@es.GateOpeningDate.PlusDays(shift.DayOffset).ToDisplayShiftDate()</td>
+                                    <td>@item.AbsoluteStart.ToDisplayTime(tz)–@item.AbsoluteEnd.ToDisplayTime(tz)</td>
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
+                </div>
+            }
+            @if (Model.Past.Count > 0)
+            {
+                var pastToShow = Model.Past.Take(5).ToList();
+                <div class="px-3 pt-3 pb-1">
+                    <h6 class="text-muted mb-2"><i class="fa-solid fa-history me-1"></i>Past (@Model.Past.Count)</h6>
+                </div>
+                <div class="table-responsive">
+                    <table class="table table-sm mb-0">
+                        <tbody>
+                            @foreach (var item in pastToShow)
+                            {
+                                var shift = item.Signup.Shift;
+                                <tr class="text-muted">
+                                    <td class="ps-3">@item.DepartmentName</td>
+                                    <td>@shift.Rota.Name</td>
+                                    <td>@es.GateOpeningDate.PlusDays(shift.DayOffset).ToDisplayShiftDate()</td>
+                                    <td><span class="badge @StatusBadge(item.Signup.Status)">@item.Signup.Status</span></td>
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
+                </div>
+                @if (Model.Past.Count > 5)
+                {
+                    <div class="px-3 py-2 text-muted small">
+                        + @(Model.Past.Count - 5) more
+                    </div>
+                }
+            }
+        </div>
+        <div class="card-footer">
+            @if (!isAdmin)
+            {
+                <a asp-controller="Shifts" asp-action="Mine" class="btn btn-sm btn-outline-primary">View All My Shifts</a>
+            }
+            else
+            {
+                <small class="text-muted">@Model.Upcoming.Count upcoming, @Model.Pending.Count pending, @Model.Past.Count past</small>
+            }
+        </div>
+    }
+</div>

--- a/src/Humans.Web/Views/_ViewImports.cshtml
+++ b/src/Humans.Web/Views/_ViewImports.cshtml
@@ -1,5 +1,6 @@
 @using Humans.Web
 @using Humans.Web.Extensions
+@using Humans.Web.Models
 @using Humans.Web.ViewComponents
 @using Humans.Domain.Entities
 @using Humans.Domain.Enums


### PR DESCRIPTION
## Summary
- **#256** — New `ShiftSignupsViewComponent` displays a human's shift signups categorized as Upcoming, Pending, and Past. Added to HumanDetail (admin view) and Dashboard (self view), replacing the basic `_ShiftCards` partial for signup display.
- **#251** — When a user has no upcoming shifts and shift browsing is open, the Dashboard shows a guided discovery card explaining the three shift phases (Set-up, Event, Strike), highlighting urgent understaffed shifts, and providing CTAs to browse shifts.

## Test plan
- [ ] Dashboard with no signups: verify discovery card appears with phase descriptions and urgent shifts
- [ ] Dashboard with existing signups: verify ShiftSignups component shows categorized list, no discovery card
- [ ] Dashboard with browsing closed and no signups: verify neither discovery card nor signups component appears
- [ ] HumanDetail page: verify shift signups section appears between Role Assignments and Audit History
- [ ] Verify urgent shifts still display when user has signups (separate "Shifts Need Help" card)

Closes #256
Closes #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)