### PR TITLE
feat: ticket dashboard widgets (#264, #265, #266)

### DIFF
--- a/src/Humans.Web/Controllers/HomeController.cs
+++ b/src/Humans.Web/Controllers/HomeController.cs
@@ -1,9 +1,15 @@
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
 using NodaTime;
+using Humans.Application;
 using Humans.Application.Interfaces;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
+using Humans.Infrastructure.Data;
+using Humans.Infrastructure.Services;
 using Humans.Web.Models;
 
 namespace Humans.Web.Controllers;
@@ -17,6 +23,10 @@ public class HomeController : HumansControllerBase
     private readonly IShiftSignupService _shiftSignup;
     private readonly IConfiguration _configuration;
     private readonly IClock _clock;
+    private readonly HumansDbContext _dbContext;
+    private readonly ITicketVendorService _vendorService;
+    private readonly TicketVendorSettings _ticketSettings;
+    private readonly IMemoryCache _cache;
     private readonly ILogger<HomeController> _logger;
 
     public HomeController(
@@ -28,6 +38,10 @@ public class HomeController : HumansControllerBase
         IShiftSignupService shiftSignup,
         IConfiguration configuration,
         IClock clock,
+        HumansDbContext dbContext,
+        ITicketVendorService vendorService,
+        IOptions<TicketVendorSettings> ticketSettings,
+        IMemoryCache cache,
         ILogger<HomeController> logger)
         : base(userManager)
     {
@@ -38,6 +52,10 @@ public class HomeController : HumansControllerBase
         _shiftSignup = shiftSignup;
         _configuration = configuration;
         _clock = clock;
+        _dbContext = dbContext;
+        _vendorService = vendorService;
+        _ticketSettings = ticketSettings.Value;
+        _cache = cache;
         _logger = logger;
     }
 
@@ -229,6 +247,42 @@ public class HomeController : HumansControllerBase
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to load shift cards for dashboard");
+        }
+
+        // Ticket summary — guarded, failures must never crash the homepage
+        try
+        {
+            if (_ticketSettings.IsConfigured)
+            {
+                var ticketsSold = await _dbContext.TicketAttendees.CountAsync(a =>
+                    a.Status == TicketAttendeeStatus.Valid || a.Status == TicketAttendeeStatus.CheckedIn);
+
+                var totalCapacity = 0;
+                try
+                {
+                    var summary = await _cache.GetOrCreateAsync(CacheKeys.TicketEventSummary, async entry =>
+                    {
+                        entry.AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(15);
+                        return await _vendorService.GetEventSummaryAsync(_ticketSettings.EventId);
+                    });
+                    totalCapacity = summary?.TotalCapacity ?? 0;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Could not fetch event summary for homepage ticket card");
+                }
+
+                viewModel.TicketsConfigured = true;
+                viewModel.TicketsSold = ticketsSold;
+                viewModel.TicketCapacity = totalCapacity;
+                viewModel.TicketCoveragePercent = totalCapacity > 0
+                    ? Math.Round(ticketsSold * 100m / totalCapacity, 1)
+                    : 0;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to load ticket summary for homepage dashboard");
         }
 
         return View("Dashboard", viewModel);

--- a/src/Humans.Web/Controllers/TicketController.cs
+++ b/src/Humans.Web/Controllers/TicketController.cs
@@ -198,10 +198,16 @@ public class TicketController : HumansControllerBase
             totalActiveVolunteers = await _dbContext.Set<TeamMember>()
                 .CountAsync(tm => tm.TeamId == volunteersTeamId && tm.LeftAt == null);
 
-            var matchedUserIds = await GetMatchedTicketUserIdsAsync();
+            var validTicketUserIds = await _dbContext.TicketAttendees
+                .Where(a => a.MatchedUserId != null &&
+                    (a.Status == TicketAttendeeStatus.Valid || a.Status == TicketAttendeeStatus.CheckedIn))
+                .Select(a => a.MatchedUserId!.Value)
+                .Distinct()
+                .ToListAsync();
+
             volunteersWithTickets = await _dbContext.Set<TeamMember>()
                 .Where(tm => tm.TeamId == volunteersTeamId && tm.LeftAt == null)
-                .CountAsync(tm => matchedUserIds.Contains(tm.UserId));
+                .CountAsync(tm => validTicketUserIds.Contains(tm.UserId));
         }
 
         var volunteerCoveragePct = totalActiveVolunteers > 0

--- a/src/Humans.Web/Controllers/TicketController.cs
+++ b/src/Humans.Web/Controllers/TicketController.cs
@@ -184,6 +184,30 @@ public class TicketController : HumansControllerBase
             })
             .ToListAsync();
 
+        // Volunteer ticket coverage
+        var volunteersTeamId = await _dbContext.Set<Team>()
+            .Where(t => t.SystemTeamType == SystemTeamType.Volunteers)
+            .Select(t => t.Id)
+            .OrderBy(id => id)
+            .FirstOrDefaultAsync();
+
+        var totalActiveVolunteers = 0;
+        var volunteersWithTickets = 0;
+        if (volunteersTeamId != Guid.Empty)
+        {
+            totalActiveVolunteers = await _dbContext.Set<TeamMember>()
+                .CountAsync(tm => tm.TeamId == volunteersTeamId && tm.LeftAt == null);
+
+            var matchedUserIds = await GetMatchedTicketUserIdsAsync();
+            volunteersWithTickets = await _dbContext.Set<TeamMember>()
+                .Where(tm => tm.TeamId == volunteersTeamId && tm.LeftAt == null)
+                .CountAsync(tm => matchedUserIds.Contains(tm.UserId));
+        }
+
+        var volunteerCoveragePct = totalActiveVolunteers > 0
+            ? Math.Round(volunteersWithTickets * 100m / totalActiveVolunteers, 1)
+            : 0;
+
         var model = new TicketDashboardViewModel
         {
             TicketsSold = ticketsSold,
@@ -203,6 +227,9 @@ public class TicketController : HumansControllerBase
             LastSyncAt = syncState?.LastSyncAt,
             RecentOrders = recentOrders,
             IsConfigured = true,
+            TotalActiveVolunteers = totalActiveVolunteers,
+            VolunteersWithTickets = volunteersWithTickets,
+            VolunteerCoveragePercent = volunteerCoveragePct,
         };
 
         return View(model);

--- a/src/Humans.Web/Models/DashboardViewModel.cs
+++ b/src/Humans.Web/Models/DashboardViewModel.cs
@@ -44,4 +44,10 @@ public class DashboardViewModel
     // Quick stats
     public DateTime MemberSince { get; set; }
     public DateTime? LastLogin { get; set; }
+
+    // Ticket summary
+    public bool TicketsConfigured { get; set; }
+    public int TicketsSold { get; set; }
+    public int TicketCapacity { get; set; }
+    public decimal TicketCoveragePercent { get; set; }
 }

--- a/src/Humans.Web/Models/TicketViewModels.cs
+++ b/src/Humans.Web/Models/TicketViewModels.cs
@@ -37,6 +37,11 @@ public class TicketDashboardViewModel
 
     // Who hasn't bought count (for dashboard link)
     public int WhoHasntBoughtCount { get; set; }
+
+    // Volunteer ticket coverage
+    public int TotalActiveVolunteers { get; set; }
+    public int VolunteersWithTickets { get; set; }
+    public decimal VolunteerCoveragePercent { get; set; }
 }
 
 public class PaymentMethodFeeBreakdown

--- a/src/Humans.Web/Views/Home/Dashboard.cshtml
+++ b/src/Humans.Web/Views/Home/Dashboard.cshtml
@@ -212,6 +212,41 @@ else if (Model.PendingConsents > 0)
             </div>
         }
 
+        @if (Model.TicketsConfigured)
+        {
+            <div class="card mb-4">
+                <div class="card-header">
+                    <i class="fa-solid fa-ticket"></i> Ticket Sales
+                </div>
+                <div class="card-body">
+                    <div class="d-flex justify-content-between align-items-center mb-2">
+                        <span>
+                            <strong>@Model.TicketsSold.ToString("N0")</strong>@(Model.TicketCapacity > 0 ? $" / {Model.TicketCapacity:N0}" : "") sold
+                        </span>
+                        @if (Model.TicketCapacity > 0)
+                        {
+                            <span class="fw-bold @(Model.TicketCoveragePercent >= 75 ? "text-success" : Model.TicketCoveragePercent >= 50 ? "text-warning" : "text-muted")">
+                                @Model.TicketCoveragePercent%
+                            </span>
+                        }
+                    </div>
+                    @if (Model.TicketCapacity > 0)
+                    {
+                        <div class="progress" style="height: 10px;">
+                            <div class="progress-bar @(Model.TicketCoveragePercent >= 75 ? "bg-success" : Model.TicketCoveragePercent >= 50 ? "bg-warning" : "bg-primary")"
+                                 style="width: @Model.TicketCoveragePercent%"></div>
+                        </div>
+                    }
+                    @if (Humans.Web.Authorization.RoleChecks.CanAccessTickets(User))
+                    {
+                        <div class="mt-2">
+                            <a asp-controller="Ticket" asp-action="Index" class="text-muted"><i class="fa-solid fa-arrow-right"></i> Ticket dashboard</a>
+                        </div>
+                    }
+                </div>
+            </div>
+        }
+
         @if (Model.IsVolunteerMember)
         {
             @if (Model.MembershipTier != MembershipTier.Volunteer)

--- a/src/Humans.Web/Views/Home/Dashboard.cshtml
+++ b/src/Humans.Web/Views/Home/Dashboard.cshtml
@@ -234,7 +234,7 @@ else if (Model.PendingConsents > 0)
                     {
                         <div class="progress" style="height: 10px;">
                             <div class="progress-bar @(Model.TicketCoveragePercent >= 75 ? "bg-success" : Model.TicketCoveragePercent >= 50 ? "bg-warning" : "bg-primary")"
-                                 style="width: @Model.TicketCoveragePercent%"></div>
+                                 style="width: @(Model.TicketCoveragePercent.ToString(System.Globalization.CultureInfo.InvariantCulture))%"></div>
                         </div>
                     }
                     @if (Humans.Web.Authorization.RoleChecks.CanAccessTickets(User))

--- a/src/Humans.Web/Views/Ticket/Index.cshtml
+++ b/src/Humans.Web/Views/Ticket/Index.cshtml
@@ -101,6 +101,34 @@
         </div>
     </div>
 
+    <!-- Volunteer Ticket Coverage -->
+    @if (Model.TotalActiveVolunteers > 0)
+    {
+        <div class="card mb-4">
+            <div class="card-header">
+                <i class="fa-solid fa-users"></i> Volunteer Ticket Coverage
+            </div>
+            <div class="card-body">
+                <div class="d-flex justify-content-between align-items-center mb-2">
+                    <span>
+                        <strong>@Model.VolunteersWithTickets</strong> / @Model.TotalActiveVolunteers humans have tickets
+                    </span>
+                    <span class="fs-4 fw-bold @(Model.VolunteerCoveragePercent >= 75 ? "text-success" : Model.VolunteerCoveragePercent >= 50 ? "text-warning" : "text-danger")">
+                        @Model.VolunteerCoveragePercent%
+                    </span>
+                </div>
+                <div class="progress" style="height: 20px;">
+                    <div class="progress-bar @(Model.VolunteerCoveragePercent >= 75 ? "bg-success" : Model.VolunteerCoveragePercent >= 50 ? "bg-warning" : "bg-danger")"
+                         style="width: @Model.VolunteerCoveragePercent%">
+                    </div>
+                </div>
+                <div class="mt-2">
+                    <a asp-action="WhoHasntBought" class="text-muted"><i class="fa-solid fa-arrow-right"></i> View details</a>
+                </div>
+            </div>
+        </div>
+    }
+
     <!-- Daily Sales Chart -->
     @if (Model.DailySales.Count > 0)
     {

--- a/src/Humans.Web/Views/Ticket/Index.cshtml
+++ b/src/Humans.Web/Views/Ticket/Index.cshtml
@@ -24,9 +24,9 @@
     <vc:temp-data-alerts />
 
     <!-- Summary Cards -->
-    <div class="row mb-4">
-        <div class="col-md-3">
-            <div class="card">
+    <div class="row row-cols-1 row-cols-md-3 row-cols-xl-5 g-3 mb-4">
+        <div class="col">
+            <div class="card h-100">
                 <div class="card-body">
                     <h6 class="card-subtitle mb-2 text-muted">Tickets Sold</h6>
                     <h3 class="card-title">@Model.TicketsSold.ToString("N0")</h3>
@@ -51,8 +51,8 @@
                 </div>
             </div>
         </div>
-        <div class="col-md-3">
-            <div class="card">
+        <div class="col">
+            <div class="card h-100">
                 <div class="card-body">
                     <h6 class="card-subtitle mb-2 text-muted">Gross Revenue</h6>
                     <h3 class="card-title">@Model.Currency @Model.Revenue.ToString("N0")</h3>
@@ -65,8 +65,8 @@
                 </div>
             </div>
         </div>
-        <div class="col-md-3">
-            <div class="card">
+        <div class="col">
+            <div class="card h-100">
                 <div class="card-body">
                     <h6 class="card-subtitle mb-2 text-muted">Net Revenue</h6>
                     <h3 class="card-title">@Model.Currency @Model.NetRevenue.ToString("N0")</h3>
@@ -83,8 +83,16 @@
                 </div>
             </div>
         </div>
-        <div class="col-md-3">
-            <div class="card">
+        <div class="col">
+            <div class="card h-100">
+                <div class="card-body">
+                    <h6 class="card-subtitle mb-2 text-muted">Avg. Ticket Price</h6>
+                    <h3 class="card-title">@Model.Currency @Model.AveragePrice.ToString("N2")</h3>
+                </div>
+            </div>
+        </div>
+        <div class="col">
+            <div class="card h-100">
                 <div class="card-body">
                     <h6 class="card-subtitle mb-2 text-muted">Remaining</h6>
                     <h3 class="card-title">@Model.TicketsRemaining.ToString("N0") tickets left</h3>

--- a/src/Humans.Web/Views/Ticket/Index.cshtml
+++ b/src/Humans.Web/Views/Ticket/Index.cshtml
@@ -119,7 +119,7 @@
                 </div>
                 <div class="progress" style="height: 20px;">
                     <div class="progress-bar @(Model.VolunteerCoveragePercent >= 75 ? "bg-success" : Model.VolunteerCoveragePercent >= 50 ? "bg-warning" : "bg-danger")"
-                         style="width: @Model.VolunteerCoveragePercent%">
+                         style="width: @(Model.VolunteerCoveragePercent.ToString(System.Globalization.CultureInfo.InvariantCulture))%">
                     </div>
                 </div>
                 <div class="mt-2">


### PR DESCRIPTION
## Summary

- **#266** — Restore average ticket price widget on ticketing dashboard. Added 5th summary card showing `AveragePrice` (already computed but never displayed). Adjusted grid from 4x `col-md-3` to responsive `row-cols` layout for 5 cards.
- **#265** — Add volunteer ticket coverage widget to ticketing dashboard. Computes active volunteers with tickets vs total (via Volunteers system team + matched user IDs). Shows count, percentage, and progress bar with link to "Who hasn't bought?" page.
- **#264** — Add ticket status card to homepage dashboard. Shows tickets sold / capacity with progress bar for all authenticated users. Admin link to ticket dashboard shown only for authorized roles. Fully guarded with try-catch to never crash the homepage.

## Test plan

- [ ] Verify ticketing dashboard shows all 5 summary cards in a responsive grid
- [ ] Verify average price card shows correct value with 2 decimal places
- [ ] Verify volunteer coverage card shows correct count and percentage with progress bar
- [ ] Verify homepage dashboard shows ticket sales card for authenticated users
- [ ] Verify ticket dashboard admin link only appears for users with ticket admin/board/admin roles
- [ ] Verify homepage doesn't break when ticket vendor is not configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)