### PR TITLE
fix: multi-model code review fixes

### DIFF
--- a/src/Humans.Application/Interfaces/IUserEmailService.cs
+++ b/src/Humans.Application/Interfaces/IUserEmailService.cs
@@ -95,4 +95,12 @@ public interface IUserEmailService
         Guid userId,
         string email,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// If the user has a verified @nobodies.team email but GoogleEmail is null, sets it.
+    /// Returns true if GoogleEmail was updated.
+    /// </summary>
+    Task<bool> TryBackfillGoogleEmailAsync(
+        Guid userId,
+        CancellationToken cancellationToken = default);
 }

--- a/src/Humans.Infrastructure/Services/BudgetService.cs
+++ b/src/Humans.Infrastructure/Services/BudgetService.cs
@@ -208,13 +208,12 @@ public class BudgetService : IBudgetService
         if (year.Status == BudgetYearStatus.Active)
             throw new InvalidOperationException("Cannot delete an active budget year. Close it first.");
 
-        var now = _clock.GetCurrentInstant();
-
-        LogAudit(year.Id, nameof(BudgetYear), year.Id,
-            $"Deleted budget year '{year.Name}' ({year.Year})",
-            actorUserId, now);
-
-        await _dbContext.SaveChangesAsync();
+        // Remove audit logs first — FK to BudgetYearId is Restrict,
+        // so the year can't be deleted while audit entries reference it.
+        var auditLogs = await _dbContext.Set<BudgetAuditLog>()
+            .Where(a => a.BudgetYearId == yearId)
+            .ToListAsync();
+        _dbContext.Set<BudgetAuditLog>().RemoveRange(auditLogs);
 
         _dbContext.BudgetYears.Remove(year);
         await _dbContext.SaveChangesAsync();

--- a/src/Humans.Infrastructure/Services/UserEmailService.cs
+++ b/src/Humans.Infrastructure/Services/UserEmailService.cs
@@ -240,6 +240,8 @@ public class UserEmailService : IUserEmailService
         pendingEmail.UpdatedAt = _clock.GetCurrentInstant();
         await _dbContext.SaveChangesAsync(cancellationToken);
 
+        await TryBackfillGoogleEmailAsync(userId, cancellationToken);
+
         return new VerifyEmailResult(pendingEmail.Email, MergeRequestCreated: false);
     }
 
@@ -408,6 +410,30 @@ public class UserEmailService : IUserEmailService
         }
 
         await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> TryBackfillGoogleEmailAsync(
+        Guid userId,
+        CancellationToken cancellationToken = default)
+    {
+        var user = await _dbContext.Users.FindAsync([userId], cancellationToken);
+        if (user?.GoogleEmail is not null)
+            return false;
+
+        var nobodiesEmail = await _dbContext.UserEmails
+            .Where(ue => ue.UserId == userId
+                && ue.IsVerified
+                && EF.Functions.ILike(ue.Email, "%@nobodies.team"))
+            .Select(ue => ue.Email)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (nobodiesEmail is null || user is null)
+            return false;
+
+        user.GoogleEmail = nobodiesEmail;
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        return true;
     }
 
     /// <summary>

--- a/src/Humans.Web/Controllers/BudgetController.cs
+++ b/src/Humans.Web/Controllers/BudgetController.cs
@@ -201,7 +201,10 @@ public class BudgetController : HumansControllerBase
         var (errorResult, user) = await RequireCurrentUserAsync();
         if (errorResult is not null) return errorResult;
 
-        var authResult = await AuthorizeCategoryEditAsync(budgetCategoryId, user.Id);
+        var lineItem = await _dbContext.BudgetLineItems.FindAsync(id);
+        if (lineItem is null) return NotFound();
+
+        var authResult = await AuthorizeCategoryEditAsync(lineItem.BudgetCategoryId, user.Id);
         if (authResult is not null) return authResult;
 
         var nodaDate = expectedDate.HasValue ? LocalDate.FromDateTime(expectedDate.Value) : (LocalDate?)null;
@@ -216,7 +219,7 @@ public class BudgetController : HumansControllerBase
             _logger.LogError(ex, "Error updating line item {LineItemId}", id);
             SetError($"Failed to update line item: {ex.Message}");
         }
-        return RedirectToAction(nameof(CategoryDetail), new { id = budgetCategoryId });
+        return RedirectToAction(nameof(CategoryDetail), new { id = lineItem.BudgetCategoryId });
     }
 
     [HttpPost("LineItems/{id:guid}/Delete")]
@@ -226,7 +229,10 @@ public class BudgetController : HumansControllerBase
         var (errorResult, user) = await RequireCurrentUserAsync();
         if (errorResult is not null) return errorResult;
 
-        var authResult = await AuthorizeCategoryEditAsync(budgetCategoryId, user.Id);
+        var lineItem = await _dbContext.BudgetLineItems.FindAsync(id);
+        if (lineItem is null) return NotFound();
+
+        var authResult = await AuthorizeCategoryEditAsync(lineItem.BudgetCategoryId, user.Id);
         if (authResult is not null) return authResult;
 
         try
@@ -239,7 +245,7 @@ public class BudgetController : HumansControllerBase
             _logger.LogError(ex, "Error deleting line item {LineItemId}", id);
             SetError($"Failed to delete line item: {ex.Message}");
         }
-        return RedirectToAction(nameof(CategoryDetail), new { id = budgetCategoryId });
+        return RedirectToAction(nameof(CategoryDetail), new { id = lineItem.BudgetCategoryId });
     }
 
     private async Task<IActionResult?> AuthorizeCategoryEditAsync(Guid categoryId, Guid userId)

--- a/src/Humans.Web/Controllers/ProfileController.cs
+++ b/src/Humans.Web/Controllers/ProfileController.cs
@@ -691,14 +691,8 @@ public class ProfileController : HumansControllerBase
         var hasNobodiesTeam = emails.Any(e => e.IsVerified &&
             e.Email.EndsWith("@nobodies.team", StringComparison.OrdinalIgnoreCase));
 
-        // Auto-heal: if user has @nobodies.team email but GoogleEmail is null, fix it
         if (hasNobodiesTeam && user.GoogleEmail is null)
-        {
-            var nobodiesEmail = emails.First(e => e.IsVerified &&
-                e.Email.EndsWith("@nobodies.team", StringComparison.OrdinalIgnoreCase));
-            user.GoogleEmail = nobodiesEmail.Email;
-            await _userManager.UpdateAsync(user);
-        }
+            await _userEmailService.TryBackfillGoogleEmailAsync(user.Id);
 
         return new EmailsViewModel
         {

--- a/src/Humans.Web/Controllers/TeamController.cs
+++ b/src/Humans.Web/Controllers/TeamController.cs
@@ -9,6 +9,7 @@ using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Humans.Web.Authorization;
 using Humans.Web.Extensions;
+using Humans.Web.Helpers;
 using Humans.Web.Models;
 using Microsoft.AspNetCore.Identity;
 
@@ -169,6 +170,20 @@ public class TeamController : HumansControllerBase
                         ChildTeamName = child.Name,
                         ChildTeamSlug = child.Slug
                     });
+                }
+            }
+
+            // Resolve custom profile pictures for child team members
+            if (viewModel.ChildTeamMembers.Count > 0)
+            {
+                var effectiveUrls = await ProfilePictureUrlHelper.BuildEffectiveUrlsAsync(
+                    _profileService, Url,
+                    viewModel.ChildTeamMembers.Select(m => (m.UserId, m.ProfilePictureUrl)));
+
+                foreach (var member in viewModel.ChildTeamMembers)
+                {
+                    if (effectiveUrls.TryGetValue(member.UserId, out var effectiveUrl))
+                        member.ProfilePictureUrl = effectiveUrl;
                 }
             }
         }

--- a/src/Humans.Web/ViewComponents/ShiftSignupsViewComponent.cs
+++ b/src/Humans.Web/ViewComponents/ShiftSignupsViewComponent.cs
@@ -11,65 +11,76 @@ public class ShiftSignupsViewComponent : ViewComponent
     private readonly IShiftSignupService _signupService;
     private readonly IShiftManagementService _shiftMgmt;
     private readonly IClock _clock;
+    private readonly ILogger<ShiftSignupsViewComponent> _logger;
 
     public ShiftSignupsViewComponent(
         IShiftSignupService signupService,
         IShiftManagementService shiftMgmt,
-        IClock clock)
+        IClock clock,
+        ILogger<ShiftSignupsViewComponent> logger)
     {
         _signupService = signupService;
         _shiftMgmt = shiftMgmt;
         _clock = clock;
+        _logger = logger;
     }
 
     public async Task<IViewComponentResult> InvokeAsync(Guid userId, ShiftSignupsViewMode viewMode, string? displayName = null)
     {
-        var es = await _shiftMgmt.GetActiveAsync();
-
-        var signups = es is not null
-            ? await _signupService.GetByUserAsync(userId, es.Id)
-            : [];
-
-        var now = _clock.GetCurrentInstant();
         var model = new ShiftSignupsViewModel
         {
-            EventSettings = es,
             ViewMode = viewMode,
             UserId = userId,
             DisplayName = displayName
         };
 
-        foreach (var signup in signups)
+        try
         {
-            if (signup.Shift?.Rota?.Team is null || es is null)
-                continue;
+            var es = await _shiftMgmt.GetActiveAsync();
 
-            var item = new MySignupItem
-            {
-                Signup = signup,
-                DepartmentName = signup.Shift.Rota.Team.Name,
-                AbsoluteStart = signup.Shift.GetAbsoluteStart(es),
-                AbsoluteEnd = signup.Shift.GetAbsoluteEnd(es)
-            };
+            var signups = es is not null
+                ? await _signupService.GetByUserAsync(userId, es.Id)
+                : [];
 
-            switch (signup.Status)
+            var now = _clock.GetCurrentInstant();
+            model.EventSettings = es;
+
+            foreach (var signup in signups)
             {
-                case SignupStatus.Confirmed when item.AbsoluteEnd > now:
-                    model.Upcoming.Add(item);
-                    break;
-                case SignupStatus.Pending:
-                    model.Pending.Add(item);
-                    break;
-                default:
-                    if (signup.Status is SignupStatus.Confirmed or SignupStatus.NoShow or SignupStatus.Bailed)
-                        model.Past.Add(item);
-                    break;
+                if (signup.Shift?.Rota?.Team is null || es is null)
+                    continue;
+
+                var item = new MySignupItem
+                {
+                    Signup = signup,
+                    DepartmentName = signup.Shift.Rota.Team.Name,
+                    AbsoluteStart = signup.Shift.GetAbsoluteStart(es),
+                    AbsoluteEnd = signup.Shift.GetAbsoluteEnd(es)
+                };
+
+                switch (signup.Status)
+                {
+                    case SignupStatus.Confirmed when item.AbsoluteEnd > now:
+                        model.Upcoming.Add(item);
+                        break;
+                    case SignupStatus.Pending:
+                        model.Pending.Add(item);
+                        break;
+                    default:
+                        if (signup.Status is SignupStatus.Confirmed or SignupStatus.NoShow or SignupStatus.Bailed)
+                            model.Past.Add(item);
+                        break;
+                }
             }
-        }
 
-        model.Upcoming = model.Upcoming.OrderBy(s => s.AbsoluteStart).ToList();
-        model.Pending = model.Pending.OrderBy(s => s.AbsoluteStart).ToList();
-        model.Past = model.Past.OrderByDescending(s => s.AbsoluteStart).ToList();
+            model.Upcoming = model.Upcoming.OrderBy(s => s.AbsoluteStart).ToList();
+            model.Pending = model.Pending.OrderBy(s => s.AbsoluteStart).ToList();
+            model.Past = model.Past.OrderByDescending(s => s.AbsoluteStart).ToList();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error loading shift signups for user {UserId}", userId);
+        }
 
         return View(model);
     }

--- a/src/Humans.Web/ViewComponents/ShiftSignupsViewComponent.cs
+++ b/src/Humans.Web/ViewComponents/ShiftSignupsViewComponent.cs
@@ -54,7 +54,7 @@ public class ShiftSignupsViewComponent : ViewComponent
 
             switch (signup.Status)
             {
-                case SignupStatus.Confirmed when item.AbsoluteStart > now:
+                case SignupStatus.Confirmed when item.AbsoluteEnd > now:
                     model.Upcoming.Add(item);
                     break;
                 case SignupStatus.Pending:

--- a/src/Humans.Web/Views/Shifts/Index.cshtml
+++ b/src/Humans.Web/Views/Shifts/Index.cshtml
@@ -328,6 +328,14 @@
                                                             </td>
                                                         }
                                                     </tr>
+                                                    @if (!string.IsNullOrEmpty(item.Shift.Description))
+                                                    {
+                                                        <tr class="d-none range-detail-@rangeKey @(isFull ? "table-secondary" : "")">
+                                                            <td colspan="@(Model.ShowSignups ? 4 : 3)" class="text-muted small pt-0 pb-1 border-0">
+                                                                @Html.SanitizedMarkdown(item.Shift.Description)
+                                                            </td>
+                                                        </tr>
+                                                    }
                                                 }
                                             }
                                             else

--- a/tests/Humans.Application.Tests/Humans.Application.Tests.csproj
+++ b/tests/Humans.Application.Tests/Humans.Application.Tests.csproj
@@ -3,6 +3,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Humans.Application\Humans.Application.csproj" />
     <ProjectReference Include="..\..\src\Humans.Infrastructure\Humans.Infrastructure.csproj" />
+    <ProjectReference Include="..\..\src\Humans.Web\Humans.Web.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Humans.Application.Tests/Services/ShiftSignupsBucketingTests.cs
+++ b/tests/Humans.Application.Tests/Services/ShiftSignupsBucketingTests.cs
@@ -1,0 +1,165 @@
+using AwesomeAssertions;
+using Humans.Application.Interfaces;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using Humans.Web.Models;
+using Humans.Web.ViewComponents;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.ViewComponents;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.Extensions.Logging.Abstractions;
+using NodaTime;
+using NodaTime.Testing;
+using NSubstitute;
+using Xunit;
+
+namespace Humans.Application.Tests.Services;
+
+public class ShiftSignupsBucketingTests
+{
+    // Event starts July 1 at midnight UTC. Test clock is July 1 12:00 UTC (mid-event).
+    private static readonly Instant TestNow = Instant.FromUtc(2026, 7, 1, 12, 0);
+
+    private static readonly EventSettings TestEvent = new()
+    {
+        Id = Guid.NewGuid(),
+        GateOpeningDate = new LocalDate(2026, 7, 1),
+        TimeZoneId = "UTC"
+    };
+
+    private readonly Guid _userId = Guid.NewGuid();
+
+    [Fact]
+    public async Task InProgressConfirmedShift_BucketedAsUpcoming()
+    {
+        // Shift started at 08:00 (4h ago), ends at 16:00 (4h from now) → still in progress
+        var signup = MakeSignup(SignupStatus.Confirmed, dayOffset: 0, startHour: 8, durationHours: 8);
+        var model = await RunComponent([signup]);
+
+        model.Upcoming.Should().HaveCount(1);
+        model.Past.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task EndedConfirmedShift_BucketedAsPast()
+    {
+        // Shift started at 06:00, ended at 10:00 (2h ago) → past
+        var signup = MakeSignup(SignupStatus.Confirmed, dayOffset: 0, startHour: 6, durationHours: 4);
+        var model = await RunComponent([signup]);
+
+        model.Past.Should().HaveCount(1);
+        model.Upcoming.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task FutureConfirmedShift_BucketedAsUpcoming()
+    {
+        // Shift starts tomorrow at 08:00 → future
+        var signup = MakeSignup(SignupStatus.Confirmed, dayOffset: 1, startHour: 8, durationHours: 4);
+        var model = await RunComponent([signup]);
+
+        model.Upcoming.Should().HaveCount(1);
+        model.Past.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task PendingShift_BucketedAsPending()
+    {
+        var signup = MakeSignup(SignupStatus.Pending, dayOffset: 1, startHour: 8, durationHours: 4);
+        var model = await RunComponent([signup]);
+
+        model.Pending.Should().HaveCount(1);
+        model.Upcoming.Should().BeEmpty();
+        model.Past.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task NoShowShift_BucketedAsPast()
+    {
+        var signup = MakeSignup(SignupStatus.NoShow, dayOffset: 0, startHour: 6, durationHours: 4);
+        var model = await RunComponent([signup]);
+
+        model.Past.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task BailedShift_BucketedAsPast()
+    {
+        var signup = MakeSignup(SignupStatus.Bailed, dayOffset: 0, startHour: 6, durationHours: 4);
+        var model = await RunComponent([signup]);
+
+        model.Past.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task ServiceError_ReturnsEmptyModel()
+    {
+        var signupService = Substitute.For<IShiftSignupService>();
+        var shiftMgmt = Substitute.For<IShiftManagementService>();
+        shiftMgmt.GetActiveAsync()
+            .Returns(Task.FromException<EventSettings?>(new InvalidOperationException("DB down")));
+
+        var model = await RunComponent([], shiftMgmt, signupService);
+
+        model.Upcoming.Should().BeEmpty();
+        model.Pending.Should().BeEmpty();
+        model.Past.Should().BeEmpty();
+    }
+
+    private async Task<ShiftSignupsViewModel> RunComponent(
+        List<ShiftSignup> signups,
+        IShiftManagementService? shiftMgmt = null,
+        IShiftSignupService? signupService = null)
+    {
+        signupService ??= Substitute.For<IShiftSignupService>();
+        shiftMgmt ??= Substitute.For<IShiftManagementService>();
+
+        shiftMgmt.GetActiveAsync().Returns(TestEvent);
+        signupService.GetByUserAsync(_userId, TestEvent.Id)
+            .Returns(signups);
+
+        var clock = new FakeClock(TestNow);
+        var component = new ShiftSignupsViewComponent(
+            signupService, shiftMgmt, clock,
+            NullLogger<ShiftSignupsViewComponent>.Instance);
+
+        // Minimal ViewComponentContext for View() to work
+        var httpContext = new DefaultHttpContext();
+        var viewContext = new ViewContext
+        {
+            HttpContext = httpContext,
+            ViewData = new ViewDataDictionary(new EmptyModelMetadataProvider(), new ModelStateDictionary())
+        };
+        component.ViewComponentContext = new ViewComponentContext { ViewContext = viewContext };
+
+        var result = await component.InvokeAsync(_userId, ShiftSignupsViewMode.Self);
+        var viewResult = (ViewViewComponentResult)result;
+        return (ShiftSignupsViewModel)viewResult.ViewData!.Model!;
+    }
+
+    private static ShiftSignup MakeSignup(SignupStatus status, int dayOffset, int startHour, int durationHours)
+    {
+        var team = new Team { Id = Guid.NewGuid(), Name = "Test Dept" };
+        var rota = new Rota { Id = Guid.NewGuid(), Team = team, Priority = ShiftPriority.Normal };
+        var shift = new Shift
+        {
+            Id = Guid.NewGuid(),
+            Rota = rota,
+            DayOffset = dayOffset,
+            StartTime = new LocalTime(startHour, 0),
+            Duration = Duration.FromHours(durationHours),
+            MinVolunteers = 1,
+            MaxVolunteers = 5
+        };
+
+        return new ShiftSignup
+        {
+            Id = Guid.NewGuid(),
+            Shift = shift,
+            Status = status
+        };
+    }
+}

--- a/tests/Humans.Application.Tests/Services/ShiftSignupsBucketingTests.cs
+++ b/tests/Humans.Application.Tests/Services/ShiftSignupsBucketingTests.cs
@@ -114,12 +114,16 @@ public class ShiftSignupsBucketingTests
         IShiftManagementService? shiftMgmt = null,
         IShiftSignupService? signupService = null)
     {
+        var callerProvidedMocks = shiftMgmt is not null;
         signupService ??= Substitute.For<IShiftSignupService>();
         shiftMgmt ??= Substitute.For<IShiftManagementService>();
 
-        shiftMgmt.GetActiveAsync().Returns(TestEvent);
-        signupService.GetByUserAsync(_userId, TestEvent.Id)
-            .Returns(signups);
+        if (!callerProvidedMocks)
+        {
+            shiftMgmt.GetActiveAsync().Returns(TestEvent);
+            signupService.GetByUserAsync(_userId, TestEvent.Id)
+                .Returns(signups);
+        }
 
         var clock = new FakeClock(TestNow);
         var component = new ShiftSignupsViewComponent(


### PR DESCRIPTION
## Summary

Fixes found by parallel Claude + Codex + Gemini code review of the 7 commits on `main` since upstream fork.

- **fix: in-progress shifts incorrectly bucketed as past** — `ShiftSignupsViewComponent` used `AbsoluteStart` instead of `AbsoluteEnd`, hiding active shifts from volunteers
- **fix: authorize budget line item mutations against actual category** — IDOR: coordinators could modify other teams' line items by spoofing `budgetCategoryId` form param
- **fix: add error handling to ShiftSignupsViewComponent** — missing try-catch meant shift service errors could crash Dashboard and HumanDetail pages
- **fix: consolidate GoogleEmail backfill and close verification gap** — three duplicate implementations; `VerifyEmailAsync` path was missing backfill entirely
- **test: add shift signup bucketing and error handling tests** — 7 new tests covering all bucketing paths and error resilience
- **fix: resolve custom profile pictures for child team members** — sub-team members on team detail always showed Google avatars
- **fix: render shift descriptions in compressed date range detail rows** — multi-day range expansions dropped per-day descriptions
- **fix: budget year deletion blocked by audit log FK constraint** — `Restrict` FK on `BudgetAuditLog` → `BudgetYearId` caused deletion to always fail

## Test plan

- [x] All 533 tests pass (7 new)
- [x] `dotnet format --verify-no-changes` clean
- [ ] Verify shift signups show in-progress shifts as Upcoming on dashboard
- [ ] Verify budget coordinators cannot modify other teams' line items
- [ ] Verify dashboard still renders if shift service errors
- [ ] Verify sub-team members show custom profile pictures on team detail
- [ ] Verify multi-day range expansion shows shift descriptions
- [ ] Verify budget year deletion works for Draft/Closed years

🤖 Generated with [Claude Code](https://claude.com/claude-code)