### PR TITLE
fix: i18n audit — missing translations, orphan cleanup, untranslated keys

### DIFF
--- a/src/Humans.Web/Resources/SharedResource.de.resx
+++ b/src/Humans.Web/Resources/SharedResource.de.resx
@@ -55,15 +55,15 @@
   <data name="Nav_Home" xml:space="preserve"><value>Startseite</value></data>
   <data name="Nav_MyProfile" xml:space="preserve"><value>Mein Profil</value></data>
   <data name="Nav_Teams" xml:space="preserve"><value>Teams</value></data>
-  <data name="Nav_Shifts" xml:space="preserve"><value>Volunteer</value></data>
-  <data name="Nav_Roster" xml:space="preserve"><value>Roster</value></data>
+  <data name="Nav_Shifts" xml:space="preserve"><value>Freiwillige</value></data>
+  <data name="Nav_Roster" xml:space="preserve"><value>Dienstplan</value></data>
   <data name="Nav_Consents" xml:space="preserve"><value>Vereinbarungen</value></data>
   <data name="Nav_Governance" xml:space="preserve"><value>Governance</value></data>
   <data name="Nav_Privacy" xml:space="preserve"><value>Datenschutz</value></data>
   <data name="Nav_About" xml:space="preserve"><value>&#xDC;ber uns</value></data>
   <data name="Nav_Admin" xml:space="preserve"><value>Admin</value></data>
   <data name="Nav_OnboardingReview" xml:space="preserve"><value>Pr&#xFC;fwarteschlange</value></data>
-  <data name="Nav_MyFeedback" xml:space="preserve"><value>My Feedback</value></data>
+  <data name="Nav_MyFeedback" xml:space="preserve"><value>Mein Feedback</value></data>
 
 
   <!-- ======================== -->
@@ -87,7 +87,7 @@
   <data name="Login_Title" xml:space="preserve"><value>Anmelden</value></data>
   <data name="Login_Description" xml:space="preserve"><value>Melden Sie sich an, um auf Humans zuzugreifen.</value></data>
   <data name="Login_SignInWithGoogle" xml:space="preserve"><value>Mit Google anmelden</value></data>
-  <data name="Login_SignInFailed" xml:space="preserve"><value>Sign-in failed. This can happen if you took too long or your browser blocked cookies. Please try again.</value></data>
+  <data name="Login_SignInFailed" xml:space="preserve"><value>Anmeldung fehlgeschlagen. Dies kann passieren, wenn du zu lange gewartet hast oder dein Browser Cookies blockiert hat. Bitte versuche es erneut.</value></data>
   <data name="AccessDenied_Title" xml:space="preserve"><value>Zugriff verweigert</value></data>
   <data name="AccessDenied_Description" xml:space="preserve"><value>Sie haben keine Berechtigung, auf diese Seite zuzugreifen.</value></data>
 
@@ -174,7 +174,6 @@
   <data name="Profile_Title" xml:space="preserve"><value>Mein Profil</value></data>
   <data name="ProfileEdit_Title" xml:space="preserve"><value>Profil bearbeiten</value></data>
   <data name="ProfilePrivacy_Title" xml:space="preserve"><value>Meine Daten</value></data>
-  <data name="PreferredEmail_Title" xml:space="preserve"><value>Bevorzugte E-Mail</value></data>
   <data name="VerifyEmail_Title" xml:space="preserve"><value>E-Mail-Verifizierung</value></data>
   <data name="VerifyEmail_GoToSettings" xml:space="preserve"><value>Zu den E-Mail-Einstellungen</value></data>
   <data name="VerifyEmail_GoHome" xml:space="preserve"><value>Zur Startseite</value></data>
@@ -198,7 +197,7 @@
   <data name="Profile_NoContactInfo" xml:space="preserve"><value>Noch keine Kontaktdaten hinzugefügt.</value></data>
   <data name="Profile_AddSome" xml:space="preserve"><value>Einige hinzufügen</value></data>
   <data name="Profile_Teams" xml:space="preserve"><value>Teams</value></data>
-  <data name="Profile_Coordinator" xml:space="preserve"><value>Coordinator</value></data>
+  <data name="Profile_Coordinator" xml:space="preserve"><value>Koordinator</value></data>
   <data name="Profile_MembershipTier" xml:space="preserve"><value>Mitgliedschaftsstufe</value></data>
   <data name="Profile_Motivation" xml:space="preserve"><value>Motivation</value></data>
   <data name="Profile_AdditionalInfo" xml:space="preserve"><value>Zus&#xE4;tzliche Informationen (optional)</value></data>
@@ -242,8 +241,6 @@
   <data name="ProfileEdit_AddContactField" xml:space="preserve"><value>Kontaktfeld hinzufügen</value></data>
   <data name="ProfileEdit_BurnerCVHelp" xml:space="preserve"><value>Dokumentieren Sie Ihre Beteiligung an Veranstaltungen, Rollen und Camps. Einträge werden nach Datum sortiert (neueste zuerst).</value></data>
   <data name="ProfileEdit_AddEntry" xml:space="preserve"><value>Eintrag hinzufügen</value></data>
-  <data name="ProfileEdit_ManagePreferredEmail" xml:space="preserve"><value>Bevorzugte E-Mail verwalten</value></data>
-  <data name="ProfileEdit_PreferredEmailHelp" xml:space="preserve"><value>Legen Sie eine andere E-Mail-Adresse für den Empfang von Systembenachrichtigungen fest.</value></data>
 
   <!-- Profile Privacy View -->
   <data name="ProfilePrivacy_Lead" xml:space="preserve"><value>Verwalten Sie Ihre persönlichen Daten und Datenschutzeinstellungen.</value></data>
@@ -278,27 +275,6 @@
   <data name="ProfilePrivacy_CancelNoRestore" xml:space="preserve"><value>Das Abbrechen stellt Ihre fr&#xFC;heren Teammitgliedschaften nicht wieder her. Sie m&#xFC;ssen den Teams erneut beitreten.</value></data>
 
   <!-- Preferred Email View -->
-  <data name="PreferredEmail_Description" xml:space="preserve"><value>Standardmäßig werden Systembenachrichtigungen an Ihre Anmelde-E-Mail gesendet. Sie können eine andere E-Mail-Adresse für den Empfang dieser Benachrichtigungen angeben.</value></data>
-  <data name="PreferredEmail_CurrentSettings" xml:space="preserve"><value>Aktuelle E-Mail-Einstellungen</value></data>
-  <data name="PreferredEmail_SignInEmail" xml:space="preserve"><value>Anmelde-E-Mail</value></data>
-  <data name="PreferredEmail_GoogleAccount" xml:space="preserve"><value>Google-Konto</value></data>
-  <data name="PreferredEmail_NotSet" xml:space="preserve"><value>Nicht festgelegt (Anmelde-E-Mail wird verwendet)</value></data>
-  <data name="PreferredEmail_Verified" xml:space="preserve"><value>Verifiziert</value></data>
-  <data name="PreferredEmail_PendingVerification" xml:space="preserve"><value>Verifizierung ausstehend</value></data>
-  <data name="PreferredEmail_NotificationsSentTo" xml:space="preserve"><value>Benachrichtigungen gesendet an</value></data>
-  <data name="PreferredEmail_Preferred" xml:space="preserve"><value>bevorzugt</value></data>
-  <data name="PreferredEmail_SignInEmailLabel" xml:space="preserve"><value>Anmelde-E-Mail</value></data>
-  <data name="PreferredEmail_VerificationSent" xml:space="preserve"><value>Eine Bestätigungs-E-Mail wurde an {0} gesendet. Bitte überprüfen Sie Ihren Posteingang und klicken Sie auf den Bestätigungslink.</value><comment>{0} = email address</comment></data>
-  <data name="PreferredEmail_ResendCooldown" xml:space="preserve"><value>Sie können in {0} Minute(n) eine neue Bestätigungs-E-Mail anfordern.</value><comment>{0} = minutes remaining</comment></data>
-  <data name="PreferredEmail_SetTitle" xml:space="preserve"><value>Bevorzugte E-Mail festlegen</value></data>
-  <data name="PreferredEmail_ChangeTitle" xml:space="preserve"><value>Bevorzugte E-Mail ändern</value></data>
-  <data name="PreferredEmail_VerificationWillBeSent" xml:space="preserve"><value>Eine Bestätigungs-E-Mail wird an diese Adresse gesendet.</value></data>
-  <data name="PreferredEmail_SendVerification" xml:space="preserve"><value>Bestätigungs-E-Mail senden</value></data>
-  <data name="PreferredEmail_RemoveTitle" xml:space="preserve"><value>Bevorzugte E-Mail entfernen</value></data>
-  <data name="PreferredEmail_RemoveDescription" xml:space="preserve"><value>Entfernen Sie Ihre bevorzugte E-Mail und verwenden Sie Ihre Anmelde-E-Mail für alle Systembenachrichtigungen.</value></data>
-  <data name="PreferredEmail_RemoveConfirm" xml:space="preserve"><value>Sind Sie sicher, dass Sie Ihre bevorzugte E-Mail entfernen möchten?</value></data>
-  <data name="PreferredEmail_RemoveButton" xml:space="preserve"><value>Bevorzugte E-Mail entfernen</value></data>
-  <data name="PreferredEmail_BackToEdit" xml:space="preserve"><value>Zurück zur Profilbearbeitung</value></data>
 
   <!-- Profile Controller TempData -->
   <data name="Profile_Updated" xml:space="preserve"><value>Profil erfolgreich aktualisiert.</value></data>
@@ -857,7 +833,7 @@
   <data name="ProfileEdit_PictureHelp" xml:space="preserve"><value>Laden Sie ein JPEG-, PNG-, WebP- oder HEIC-Bild hoch (max. 20MB). Gro&#xDF;e Bilder werden automatisch verkleinert. Dies ersetzt Ihren Google-Avatar.</value></data>
   <data name="ProfileEdit_RemovePicture" xml:space="preserve"><value>Benutzerdefiniertes Bild entfernen (zum Google-Avatar zur&#xFC;ckkehren)</value></data>
   <data name="ProfileEdit_DateOfBirthHelp" xml:space="preserve"><value>Nur f&#xFC;r Sie und den Vorstand sichtbar. Wird f&#xFC;r den Geburtstagskalender verwendet.</value></data>
-  <data name="TeamDetail_TeamCoordinators" xml:space="preserve"><value>Coordinators</value></data>
+  <data name="TeamDetail_TeamCoordinators" xml:space="preserve"><value>Koordinatoren</value></data>
 
   <!-- Team Public Pages -->
   <data name="TeamDetail_AboutTeam" xml:space="preserve"><value>Über</value></data>
@@ -1132,8 +1108,8 @@
   <data name="Email_BoardDigest_PendingDeletions" xml:space="preserve"><value>{0} Kontol&#xF6;schungen ausstehend</value><comment>{0} = count</comment></data>
 
   <!-- Navigation restructure -->
-  <data name="Nav_Review" xml:space="preserve"><value>Review</value></data>
-  <data name="Nav_Voting" xml:space="preserve"><value>Voting</value></data>
+  <data name="Nav_Review" xml:space="preserve"><value>Überprüfung</value></data>
+  <data name="Nav_Voting" xml:space="preserve"><value>Abstimmung</value></data>
   <data name="Nav_Board" xml:space="preserve"><value>Board</value></data>
 
   <!-- Team admin: add member -->
@@ -1217,4 +1193,64 @@
   <!-- Camp Cards -->
   <data name="CampCard_NeedsPhoto" xml:space="preserve"><value>Dieses Barrio braucht ein Foto!</value></data>
 
+  <data name="CompleteSignup_DisplayNameLabel" xml:space="preserve"><value>Anzeigename</value></data>
+  <data name="CompleteSignup_Submit" xml:space="preserve"><value>Konto erstellen</value></data>
+  <data name="CompleteSignup_Title" xml:space="preserve"><value>Registrierung abschließen</value></data>
+  <data name="Consent_ActionRequired" xml:space="preserve"><value>Handlung erforderlich</value></data>
+  <data name="Consent_LastUpdated" xml:space="preserve"><value>Zuletzt aktualisiert</value></data>
+  <data name="Email_EmailVerification_Merge_Body" xml:space="preserve"><value><h2>Kontoverknüpfung bestätigen</h2>
+<p>Hallo {0},</p>
+<p>Du hast angefordert, <strong>{1}</strong> zu deinem Konto hinzuzufügen. Diese E-Mail-Adresse ist derzeit mit einem anderen Konto verknüpft.</p>
+<p>Wenn du diese E-Mail bestätigst, wird eine Zusammenführungsanfrage zur Überprüfung durch einen Administrator eingereicht. Nach Genehmigung werden die Daten des anderen Kontos in dein Konto übernommen und das doppelte Konto wird archiviert.</p>
+<p>Bitte klicke auf den folgenden Link, um die Zusammenführung zu bestätigen und anzufordern:</p>
+<p><a href="{2}">Bestätigen und Zusammenführung anfordern</a></p>
+<p>Dieser Link läuft in 24 Stunden ab.</p>
+<p>Falls du dies nicht angefordert hast, kannst du diese E-Mail ignorieren. Es werden keine Änderungen vorgenommen.</p>
+<p>Das Humans Team</p></value></data>
+  <data name="Email_FacilitatedMessage_Body" xml:space="preserve"><value><h2>Nachricht von {1}</h2><p>Hallo {0},</p><p>{1} hat dir eine Nachricht über Humans gesendet:</p><hr /><p>{2}</p><hr />{3}</value></data>
+  <data name="Email_FacilitatedMessage_NoContactInfo" xml:space="preserve"><value>Dieser Mensch hat sich entschieden, seine Kontaktdaten nicht zu teilen.</value></data>
+  <data name="Email_FacilitatedMessage_Subject" xml:space="preserve"><value>Humans Nachricht von: {0}</value></data>
+  <data name="Email_MagicLinkLogin_Body" xml:space="preserve"><value><p>Hallo {0},</p><p>Klicke auf den folgenden Link, um dich anzumelden:</p><p><a href="{1}">Bei Nobodies anmelden</a></p><p>Dieser Link läuft in 15 Minuten ab und kann nur einmal verwendet werden.</p><p>Falls du dies nicht angefordert hast, kannst du diese E-Mail ignorieren.</p></value></data>
+  <data name="Email_MagicLinkLogin_Subject" xml:space="preserve"><value>Dein Anmeldelink für Nobodies</value></data>
+  <data name="Email_MagicLinkSignup_Body" xml:space="preserve"><value><p>Willkommen bei Nobodies!</p><p>Klicke auf den folgenden Link, um dein Konto zu erstellen:</p><p><a href="{0}">Konto erstellen</a></p><p>Dieser Link läuft in 15 Minuten ab und kann nur einmal verwendet werden.</p><p>Falls du dies nicht angefordert hast, kannst du diese E-Mail ignorieren.</p></value></data>
+  <data name="Email_MagicLinkSignup_Subject" xml:space="preserve"><value>Willkommen bei Nobodies — bestätige deine E-Mail</value></data>
+  <data name="Emails_AddNew" xml:space="preserve"><value>E-Mail-Adresse hinzufügen</value></data>
+  <data name="Emails_BackToEdit" xml:space="preserve"><value>Zurück zum Profil bearbeiten</value></data>
+  <data name="Emails_Description" xml:space="preserve"><value>Verwalte deine E-Mail-Adressen. Deine Anmelde-E-Mail ist immer enthalten. Füge weitere E-Mails hinzu, lege fest welche Benachrichtigungen erhält und steuere die Profilsichtbarkeit.</value></data>
+  <data name="Emails_ManageEmails" xml:space="preserve"><value>E-Mail-Adressen</value></data>
+  <data name="Emails_ManageEmailsHelp" xml:space="preserve"><value>Weitere E-Mail-Adressen hinzufügen, Benachrichtigungen steuern und Profilsichtbarkeit einstellen.</value></data>
+  <data name="Emails_ManageLater" xml:space="preserve"><value>Du kannst nach Abschluss der Einrichtung weitere E-Mail-Adressen in deinem Profil hinzufügen und verwalten.</value></data>
+  <data name="Emails_ResendCooldown" xml:space="preserve"><value>Du kannst in {0} Minute(n) eine neue Bestätigungs-E-Mail anfordern.</value></data>
+  <data name="Emails_SendVerification" xml:space="preserve"><value>Bestätigungs-E-Mail senden</value></data>
+  <data name="Emails_Title" xml:space="preserve"><value>E-Mail-Adressen</value></data>
+  <data name="Emails_VerificationWillBeSent" xml:space="preserve"><value>Eine Bestätigungs-E-Mail wird an diese Adresse gesendet.</value></data>
+  <data name="Emails_YourEmails" xml:space="preserve"><value>Deine E-Mail-Adressen</value></data>
+  <data name="Login_MagicLink_Placeholder" xml:space="preserve"><value>deine@email.com</value></data>
+  <data name="Login_MagicLink_Submit" xml:space="preserve"><value>Anmeldelink senden</value></data>
+  <data name="Login_MagicLink_Title" xml:space="preserve"><value>Oder per E-Mail anmelden</value></data>
+  <data name="MagicLinkConfirm_Message" xml:space="preserve"><value>Klicke auf die Schaltfläche unten, um dich bei deinem Konto anzumelden.</value></data>
+  <data name="MagicLinkConfirm_SignIn" xml:space="preserve"><value>Anmelden</value></data>
+  <data name="MagicLinkConfirm_Title" xml:space="preserve"><value>Anmelden</value></data>
+  <data name="MagicLinkError_Message" xml:space="preserve"><value>Dieser Anmeldelink ist abgelaufen oder wurde bereits verwendet.</value></data>
+  <data name="MagicLinkError_RequestNew" xml:space="preserve"><value>Neuen Link anfordern</value></data>
+  <data name="MagicLinkError_Title" xml:space="preserve"><value>Link abgelaufen oder ungültig</value></data>
+  <data name="MagicLinkSent_BackToLogin" xml:space="preserve"><value>Zurück zur Anmeldung</value></data>
+  <data name="MagicLinkSent_Title" xml:space="preserve"><value>Überprüfe deine E-Mails</value></data>
+  <data name="ProfileEdit_ManageEmails" xml:space="preserve"><value>E-Mail-Adressen</value></data>
+  <data name="ProfileEdit_ManageEmailsHelp" xml:space="preserve"><value>E-Mail-Adressen hinzufügen, Benachrichtigungseinstellungen festlegen und Profilsichtbarkeit steuern.</value></data>
+  <data name="Profile_Day" xml:space="preserve"><value>Tag</value></data>
+  <data name="Profile_Month" xml:space="preserve"><value>Monat</value></data>
+  <data name="Profile_NotificationTarget" xml:space="preserve"><value>Systembenachrichtigungen werden an diese Adresse gesendet</value></data>
+  <data name="Profile_NotificationTargetShort" xml:space="preserve"><value>Benachrichtigungen</value></data>
+  <data name="SendMessage_Breadcrumb" xml:space="preserve"><value>Nachricht senden</value></data>
+  <data name="SendMessage_Button" xml:space="preserve"><value>{0} eine Nachricht senden</value></data>
+  <data name="SendMessage_Heading" xml:space="preserve"><value>{0} eine Nachricht senden</value></data>
+  <data name="SendMessage_IncludeContactInfo" xml:space="preserve"><value>Meine Kontaktdaten einschließen</value></data>
+  <data name="SendMessage_IncludeContactInfoHelp" xml:space="preserve"><value>Dein Name und deine E-Mail-Adresse werden hinzugefügt, damit die Person dir direkt antworten kann.</value></data>
+  <data name="SendMessage_MessageLabel" xml:space="preserve"><value>Nachricht</value></data>
+  <data name="SendMessage_PlainTextOnly" xml:space="preserve"><value>Nur Klartext. Maximal 2000 Zeichen.</value></data>
+  <data name="SendMessage_Send" xml:space="preserve"><value>Nachricht senden</value></data>
+  <data name="SendMessage_Success" xml:space="preserve"><value>Deine Nachricht wurde an {0} gesendet.</value></data>
+  <data name="SendMessage_Title" xml:space="preserve"><value>{0} eine Nachricht senden</value></data>
+  <data name="TeamDetail_ManageConsents" xml:space="preserve"><value>Rechtliche Dokumente</value></data>
 </root>

--- a/src/Humans.Web/Resources/SharedResource.es.resx
+++ b/src/Humans.Web/Resources/SharedResource.es.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:element name="root" msdata:IsDataSet="true">
@@ -55,15 +55,15 @@
   <data name="Nav_Home" xml:space="preserve"><value>Inicio</value></data>
   <data name="Nav_MyProfile" xml:space="preserve"><value>Mi perfil</value></data>
   <data name="Nav_Teams" xml:space="preserve"><value>Equipos</value></data>
-  <data name="Nav_Shifts" xml:space="preserve"><value>Volunteer</value></data>
-  <data name="Nav_Roster" xml:space="preserve"><value>Roster</value></data>
+  <data name="Nav_Shifts" xml:space="preserve"><value>Voluntariado</value></data>
+  <data name="Nav_Roster" xml:space="preserve"><value>Lista</value></data>
   <data name="Nav_Consents" xml:space="preserve"><value>Acuerdos</value></data>
   <data name="Nav_Governance" xml:space="preserve"><value>Gobernanza</value></data>
   <data name="Nav_Privacy" xml:space="preserve"><value>Privacidad</value></data>
   <data name="Nav_About" xml:space="preserve"><value>Acerca de</value></data>
   <data name="Nav_Admin" xml:space="preserve"><value>Admin</value></data>
   <data name="Nav_OnboardingReview" xml:space="preserve"><value>Cola de revisi&#xF3;n</value></data>
-  <data name="Nav_MyFeedback" xml:space="preserve"><value>My Feedback</value></data>
+  <data name="Nav_MyFeedback" xml:space="preserve"><value>Mi feedback</value></data>
 
 
   <!-- ======================== -->
@@ -87,7 +87,7 @@
   <data name="Login_Title" xml:space="preserve"><value>Iniciar sesi&#xF3;n</value></data>
   <data name="Login_Description" xml:space="preserve"><value>Inicia sesi&#xF3;n para acceder a Humans.</value></data>
   <data name="Login_SignInWithGoogle" xml:space="preserve"><value>Iniciar sesi&#xF3;n con Google</value></data>
-  <data name="Login_SignInFailed" xml:space="preserve"><value>Sign-in failed. This can happen if you took too long or your browser blocked cookies. Please try again.</value></data>
+  <data name="Login_SignInFailed" xml:space="preserve"><value>Error de inicio de sesión. Esto puede ocurrir si tardaste demasiado o tu navegador bloqueó las cookies. Por favor, inténtalo de nuevo.</value></data>
   <data name="AccessDenied_Title" xml:space="preserve"><value>Acceso denegado</value></data>
   <data name="AccessDenied_Description" xml:space="preserve"><value>No tiene permiso para acceder a esta p&#xE1;gina.</value></data>
 
@@ -174,7 +174,6 @@
   <data name="Profile_Title" xml:space="preserve"><value>Mi perfil</value></data>
   <data name="ProfileEdit_Title" xml:space="preserve"><value>Editar perfil</value></data>
   <data name="ProfilePrivacy_Title" xml:space="preserve"><value>Mis datos</value></data>
-  <data name="PreferredEmail_Title" xml:space="preserve"><value>Correo electr&#xF3;nico preferido</value></data>
   <data name="VerifyEmail_Title" xml:space="preserve"><value>Verificaci&#xF3;n de correo electr&#xF3;nico</value></data>
   <data name="VerifyEmail_GoToSettings" xml:space="preserve"><value>Ir a ajustes de correo preferido</value></data>
   <data name="VerifyEmail_GoHome" xml:space="preserve"><value>Ir a la p&#xE1;gina de inicio</value></data>
@@ -200,7 +199,7 @@
   <data name="Profile_NotificationTarget" xml:space="preserve"><value>Las notificaciones del sistema se env&#xED;an a esta direcci&#xF3;n</value></data>
   <data name="Profile_NotificationTargetShort" xml:space="preserve"><value>Notificaciones</value></data>
   <data name="Profile_Teams" xml:space="preserve"><value>Equipos</value></data>
-  <data name="Profile_Coordinator" xml:space="preserve"><value>Coordinator</value></data>
+  <data name="Profile_Coordinator" xml:space="preserve"><value>Coordinador</value></data>
   <data name="Profile_MembershipTier" xml:space="preserve"><value>Nivel de membres&#xED;a</value></data>
   <data name="Profile_Motivation" xml:space="preserve"><value>Motivaci&#xF3;n</value></data>
   <data name="Profile_AdditionalInfo" xml:space="preserve"><value>Informaci&#xF3;n adicional (opcional)</value></data>
@@ -244,8 +243,6 @@
   <data name="ProfileEdit_AddContactField" xml:space="preserve"><value>A&#xF1;adir campo de contacto</value></data>
   <data name="ProfileEdit_BurnerCVHelp" xml:space="preserve"><value>Documente su participaci&#xF3;n en eventos, roles y campamentos. Las entradas se ordenan por fecha (m&#xE1;s recientes primero).</value></data>
   <data name="ProfileEdit_AddEntry" xml:space="preserve"><value>A&#xF1;adir entrada</value></data>
-  <data name="ProfileEdit_ManagePreferredEmail" xml:space="preserve"><value>Gestionar correo preferido</value></data>
-  <data name="ProfileEdit_PreferredEmailHelp" xml:space="preserve"><value>Establezca una direcci&#xF3;n de correo diferente para recibir las notificaciones del sistema.</value></data>
 
   <!-- Profile Privacy View -->
   <data name="ProfilePrivacy_Lead" xml:space="preserve"><value>Gestione sus datos personales y ajustes de privacidad.</value></data>
@@ -280,27 +277,6 @@
   <data name="ProfilePrivacy_CancelNoRestore" xml:space="preserve"><value>Cancelar no restaurar&#xE1; sus membres&#xED;as de equipo anteriores. Deber&#xE1; volver a unirse a los equipos.</value></data>
 
   <!-- Preferred Email View -->
-  <data name="PreferredEmail_Description" xml:space="preserve"><value>Por defecto, las notificaciones del sistema se env&#xED;an a su correo de inicio de sesi&#xF3;n. Puede especificar una direcci&#xF3;n de correo diferente para recibir estas notificaciones.</value></data>
-  <data name="PreferredEmail_CurrentSettings" xml:space="preserve"><value>Configuraci&#xF3;n actual del correo</value></data>
-  <data name="PreferredEmail_SignInEmail" xml:space="preserve"><value>Correo de inicio de sesi&#xF3;n</value></data>
-  <data name="PreferredEmail_GoogleAccount" xml:space="preserve"><value>Cuenta de Google</value></data>
-  <data name="PreferredEmail_NotSet" xml:space="preserve"><value>No configurado (se usa el correo de inicio de sesi&#xF3;n)</value></data>
-  <data name="PreferredEmail_Verified" xml:space="preserve"><value>Verificado</value></data>
-  <data name="PreferredEmail_PendingVerification" xml:space="preserve"><value>Verificaci&#xF3;n pendiente</value></data>
-  <data name="PreferredEmail_NotificationsSentTo" xml:space="preserve"><value>Las notificaciones se env&#xED;an a</value></data>
-  <data name="PreferredEmail_Preferred" xml:space="preserve"><value>preferido</value></data>
-  <data name="PreferredEmail_SignInEmailLabel" xml:space="preserve"><value>correo de inicio de sesi&#xF3;n</value></data>
-  <data name="PreferredEmail_VerificationSent" xml:space="preserve"><value>Se ha enviado un correo de verificaci&#xF3;n a {0}. Por favor, revise su bandeja de entrada y haga clic en el enlace de verificaci&#xF3;n.</value><comment>{0} = email address</comment></data>
-  <data name="PreferredEmail_ResendCooldown" xml:space="preserve"><value>Puede solicitar un nuevo correo de verificaci&#xF3;n en {0} minuto(s).</value><comment>{0} = minutes remaining</comment></data>
-  <data name="PreferredEmail_SetTitle" xml:space="preserve"><value>Establecer correo preferido</value></data>
-  <data name="PreferredEmail_ChangeTitle" xml:space="preserve"><value>Cambiar correo preferido</value></data>
-  <data name="PreferredEmail_VerificationWillBeSent" xml:space="preserve"><value>Se enviar&#xE1; un correo de verificaci&#xF3;n a esta direcci&#xF3;n.</value></data>
-  <data name="PreferredEmail_SendVerification" xml:space="preserve"><value>Enviar correo de verificaci&#xF3;n</value></data>
-  <data name="PreferredEmail_RemoveTitle" xml:space="preserve"><value>Eliminar correo preferido</value></data>
-  <data name="PreferredEmail_RemoveDescription" xml:space="preserve"><value>Elimine su correo preferido y utilice su correo de inicio de sesi&#xF3;n para todas las notificaciones del sistema.</value></data>
-  <data name="PreferredEmail_RemoveConfirm" xml:space="preserve"><value>&#xBF;Est&#xE1; seguro de que desea eliminar su correo preferido?</value></data>
-  <data name="PreferredEmail_RemoveButton" xml:space="preserve"><value>Eliminar correo preferido</value></data>
-  <data name="PreferredEmail_BackToEdit" xml:space="preserve"><value>Volver a editar perfil</value></data>
 
   <!-- Profile Controller TempData -->
   <data name="Profile_Updated" xml:space="preserve"><value>Perfil actualizado correctamente.</value></data>
@@ -862,7 +838,7 @@
   <data name="ProfileEdit_PictureHelp" xml:space="preserve"><value>Suba una imagen JPEG, PNG, WebP o HEIC (m&#xE1;x. 20MB). Las im&#xE1;genes grandes se redimensionan autom&#xE1;ticamente. Esto reemplaza su avatar de Google.</value></data>
   <data name="ProfileEdit_RemovePicture" xml:space="preserve"><value>Eliminar foto personalizada (volver al avatar de Google)</value></data>
   <data name="ProfileEdit_DateOfBirthHelp" xml:space="preserve"><value>Solo visible para usted y la junta directiva. Se usa para el calendario de cumplea&#xF1;os.</value></data>
-  <data name="TeamDetail_TeamCoordinators" xml:space="preserve"><value>Coordinators</value></data>
+  <data name="TeamDetail_TeamCoordinators" xml:space="preserve"><value>Coordinadores</value></data>
 
   <!-- Team Public Pages -->
   <data name="TeamDetail_AboutTeam" xml:space="preserve"><value>Sobre</value></data>
@@ -1137,8 +1113,8 @@
   <data name="Email_BoardDigest_PendingDeletions" xml:space="preserve"><value>{0} eliminaciones de cuenta pendientes</value><comment>{0} = count</comment></data>
 
   <!-- Navigation restructure -->
-  <data name="Nav_Review" xml:space="preserve"><value>Review</value></data>
-  <data name="Nav_Voting" xml:space="preserve"><value>Voting</value></data>
+  <data name="Nav_Review" xml:space="preserve"><value>Revisión</value></data>
+  <data name="Nav_Voting" xml:space="preserve"><value>Votación</value></data>
   <data name="Nav_Board" xml:space="preserve"><value>Board</value></data>
 
   <!-- Team admin: add member -->
@@ -1237,4 +1213,46 @@
   <!-- Camp Cards -->
   <data name="CampCard_NeedsPhoto" xml:space="preserve"><value>¡Este barrio necesita una foto!</value></data>
 
+  <data name="CompleteSignup_DisplayNameLabel" xml:space="preserve"><value>Nombre para mostrar</value></data>
+  <data name="CompleteSignup_Submit" xml:space="preserve"><value>Crear cuenta</value></data>
+  <data name="CompleteSignup_Title" xml:space="preserve"><value>Completa tu registro</value></data>
+  <data name="Email_EmailVerification_Merge_Body" xml:space="preserve"><value><h2>Verificación de fusión de cuentas</h2>
+<p>Hola {0},</p>
+<p>Has solicitado agregar <strong>{1}</strong> a tu cuenta. Esta dirección de correo está actualmente vinculada a otra cuenta.</p>
+<p>Si verificas este correo, se enviará una solicitud de fusión para revisión del administrador. Una vez aprobada, los datos de la otra cuenta se fusionarán con la tuya y la cuenta duplicada será archivada.</p>
+<p>Haz clic en el siguiente enlace para verificar y solicitar la fusión:</p>
+<p><a href="{2}">Verificar y solicitar fusión</a></p>
+<p>Este enlace expira en 24 horas.</p>
+<p>Si no solicitaste esto, puedes ignorar este correo. No se realizarán cambios.</p>
+<p>El equipo de Humans</p></value></data>
+  <data name="Email_MagicLinkLogin_Body" xml:space="preserve"><value><p>Hola {0},</p><p>Haz clic en el siguiente enlace para iniciar sesión:</p><p><a href="{1}">Iniciar sesión en Nobodies</a></p><p>Este enlace expira en 15 minutos y solo se puede usar una vez.</p><p>Si no solicitaste esto, puedes ignorar este correo.</p></value></data>
+  <data name="Email_MagicLinkLogin_Subject" xml:space="preserve"><value>Tu enlace de inicio de sesión para Nobodies</value></data>
+  <data name="Email_MagicLinkSignup_Body" xml:space="preserve"><value><p>¡Bienvenido a Nobodies!</p><p>Haz clic en el siguiente enlace para crear tu cuenta:</p><p><a href="{0}">Crear tu cuenta</a></p><p>Este enlace expira en 15 minutos y solo se puede usar una vez.</p><p>Si no solicitaste esto, puedes ignorar este correo.</p></value></data>
+  <data name="Email_MagicLinkSignup_Subject" xml:space="preserve"><value>Bienvenido a Nobodies — confirma tu correo electrónico</value></data>
+  <data name="Emails_AddNew" xml:space="preserve"><value>Agregar dirección de correo</value></data>
+  <data name="Emails_BackToEdit" xml:space="preserve"><value>Volver a editar perfil</value></data>
+  <data name="Emails_Description" xml:space="preserve"><value>Gestiona tus direcciones de correo electrónico. Tu correo de inicio de sesión siempre está incluido. Agrega correos adicionales, elige cuál recibe notificaciones y controla la visibilidad del perfil.</value></data>
+  <data name="Emails_ManageEmails" xml:space="preserve"><value>Direcciones de correo</value></data>
+  <data name="Emails_ManageEmailsHelp" xml:space="preserve"><value>Agregar direcciones de correo adicionales, controlar notificaciones y establecer la visibilidad del perfil.</value></data>
+  <data name="Emails_ManageLater" xml:space="preserve"><value>Puedes agregar y gestionar direcciones de correo adicionales desde tu perfil después de completar la configuración.</value></data>
+  <data name="Emails_ResendCooldown" xml:space="preserve"><value>Puedes solicitar un nuevo correo de verificación en {0} minuto(s).</value></data>
+  <data name="Emails_SendVerification" xml:space="preserve"><value>Enviar correo de verificación</value></data>
+  <data name="Emails_Title" xml:space="preserve"><value>Direcciones de correo</value></data>
+  <data name="Emails_VerificationWillBeSent" xml:space="preserve"><value>Se enviará un correo de verificación a esta dirección.</value></data>
+  <data name="Emails_YourEmails" xml:space="preserve"><value>Tus direcciones de correo</value></data>
+  <data name="Login_MagicLink_Placeholder" xml:space="preserve"><value>tu@email.com</value></data>
+  <data name="Login_MagicLink_Submit" xml:space="preserve"><value>Enviarme un enlace de inicio de sesión</value></data>
+  <data name="Login_MagicLink_Title" xml:space="preserve"><value>O iniciar sesión con correo</value></data>
+  <data name="MagicLinkConfirm_Message" xml:space="preserve"><value>Haz clic en el botón de abajo para iniciar sesión en tu cuenta.</value></data>
+  <data name="MagicLinkConfirm_SignIn" xml:space="preserve"><value>Iniciar sesión</value></data>
+  <data name="MagicLinkConfirm_Title" xml:space="preserve"><value>Iniciar sesión</value></data>
+  <data name="MagicLinkError_Message" xml:space="preserve"><value>Este enlace de inicio de sesión ha expirado o ya ha sido utilizado.</value></data>
+  <data name="MagicLinkError_RequestNew" xml:space="preserve"><value>Solicitar un nuevo enlace</value></data>
+  <data name="MagicLinkError_Title" xml:space="preserve"><value>Enlace expirado o inválido</value></data>
+  <data name="MagicLinkSent_BackToLogin" xml:space="preserve"><value>Volver al inicio de sesión</value></data>
+  <data name="MagicLinkSent_Title" xml:space="preserve"><value>Revisa tu correo</value></data>
+  <data name="ProfileEdit_ManageEmails" xml:space="preserve"><value>Direcciones de correo</value></data>
+  <data name="ProfileEdit_ManageEmailsHelp" xml:space="preserve"><value>Agregar direcciones de correo, establecer preferencias de notificación y controlar la visibilidad del perfil.</value></data>
+  <data name="Profile_Day" xml:space="preserve"><value>Día</value></data>
+  <data name="Profile_Month" xml:space="preserve"><value>Mes</value></data>
 </root>

--- a/src/Humans.Web/Resources/SharedResource.fr.resx
+++ b/src/Humans.Web/Resources/SharedResource.fr.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:element name="root" msdata:IsDataSet="true">
@@ -55,15 +55,15 @@
   <data name="Nav_Home" xml:space="preserve"><value>Accueil</value></data>
   <data name="Nav_MyProfile" xml:space="preserve"><value>Mon profil</value></data>
   <data name="Nav_Teams" xml:space="preserve"><value>&#xC9;quipes</value></data>
-  <data name="Nav_Shifts" xml:space="preserve"><value>Volunteer</value></data>
-  <data name="Nav_Roster" xml:space="preserve"><value>Roster</value></data>
+  <data name="Nav_Shifts" xml:space="preserve"><value>Bénévolat</value></data>
+  <data name="Nav_Roster" xml:space="preserve"><value>Liste</value></data>
   <data name="Nav_Consents" xml:space="preserve"><value>Accords</value></data>
   <data name="Nav_Governance" xml:space="preserve"><value>Gouvernance</value></data>
   <data name="Nav_Privacy" xml:space="preserve"><value>Confidentialit&#xE9;</value></data>
   <data name="Nav_About" xml:space="preserve"><value>&#xC0; propos</value></data>
   <data name="Nav_Admin" xml:space="preserve"><value>Admin</value></data>
   <data name="Nav_OnboardingReview" xml:space="preserve"><value>File d'attente</value></data>
-  <data name="Nav_MyFeedback" xml:space="preserve"><value>My Feedback</value></data>
+  <data name="Nav_MyFeedback" xml:space="preserve"><value>Mon feedback</value></data>
 
 
   <!-- ======================== -->
@@ -87,7 +87,7 @@
   <data name="Login_Title" xml:space="preserve"><value>Connexion</value></data>
   <data name="Login_Description" xml:space="preserve"><value>Connectez-vous pour acc&#xE9;der &#xE0; Humans.</value></data>
   <data name="Login_SignInWithGoogle" xml:space="preserve"><value>Se connecter avec Google</value></data>
-  <data name="Login_SignInFailed" xml:space="preserve"><value>Sign-in failed. This can happen if you took too long or your browser blocked cookies. Please try again.</value></data>
+  <data name="Login_SignInFailed" xml:space="preserve"><value>Échec de la connexion. Cela peut se produire si vous avez mis trop de temps ou si votre navigateur a bloqué les cookies. Veuillez réessayer.</value></data>
   <data name="AccessDenied_Title" xml:space="preserve"><value>Acc&#xE8;s refus&#xE9;</value></data>
   <data name="AccessDenied_Description" xml:space="preserve"><value>Vous n'avez pas la permission d'acc&#xE9;der &#xE0; cette page.</value></data>
 
@@ -174,7 +174,6 @@
   <data name="Profile_Title" xml:space="preserve"><value>Mon profil</value></data>
   <data name="ProfileEdit_Title" xml:space="preserve"><value>Modifier le profil</value></data>
   <data name="ProfilePrivacy_Title" xml:space="preserve"><value>Mes donn&#xE9;es</value></data>
-  <data name="PreferredEmail_Title" xml:space="preserve"><value>Adresse e-mail pr&#xE9;f&#xE9;r&#xE9;e</value></data>
   <data name="VerifyEmail_Title" xml:space="preserve"><value>V&#xE9;rification de l'adresse e-mail</value></data>
   <data name="VerifyEmail_GoToSettings" xml:space="preserve"><value>Acc&#xE9;der aux param&#xE8;tres de l'e-mail pr&#xE9;f&#xE9;r&#xE9;</value></data>
   <data name="VerifyEmail_GoHome" xml:space="preserve"><value>Retour &#xE0; l'accueil</value></data>
@@ -198,7 +197,7 @@
   <data name="Profile_NoContactInfo" xml:space="preserve"><value>Aucune coordonn&#xE9;e ajout&#xE9;e pour le moment.</value></data>
   <data name="Profile_AddSome" xml:space="preserve"><value>En ajouter</value></data>
   <data name="Profile_Teams" xml:space="preserve"><value>&#xC9;quipes</value></data>
-  <data name="Profile_Coordinator" xml:space="preserve"><value>Coordinator</value></data>
+  <data name="Profile_Coordinator" xml:space="preserve"><value>Coordinateur</value></data>
   <data name="Profile_MembershipTier" xml:space="preserve"><value>Niveau d'adh&#xE9;sion</value></data>
   <data name="Profile_Motivation" xml:space="preserve"><value>Motivation</value></data>
   <data name="Profile_AdditionalInfo" xml:space="preserve"><value>Informations suppl&#xE9;mentaires (facultatif)</value></data>
@@ -242,8 +241,6 @@
   <data name="ProfileEdit_AddContactField" xml:space="preserve"><value>Ajouter un champ de contact</value></data>
   <data name="ProfileEdit_BurnerCVHelp" xml:space="preserve"><value>Documentez votre participation aux &#xE9;v&#xE9;nements, r&#xF4;les et camps. Les entr&#xE9;es sont tri&#xE9;es par date (les plus r&#xE9;centes en premier).</value></data>
   <data name="ProfileEdit_AddEntry" xml:space="preserve"><value>Ajouter une entr&#xE9;e</value></data>
-  <data name="ProfileEdit_ManagePreferredEmail" xml:space="preserve"><value>G&#xE9;rer l'e-mail pr&#xE9;f&#xE9;r&#xE9;</value></data>
-  <data name="ProfileEdit_PreferredEmailHelp" xml:space="preserve"><value>D&#xE9;finissez une adresse e-mail diff&#xE9;rente pour recevoir les notifications du syst&#xE8;me.</value></data>
 
   <!-- Profile Privacy View -->
   <data name="ProfilePrivacy_Lead" xml:space="preserve"><value>G&#xE9;rez vos donn&#xE9;es personnelles et vos param&#xE8;tres de confidentialit&#xE9;.</value></data>
@@ -278,27 +275,6 @@
   <data name="ProfilePrivacy_CancelNoRestore" xml:space="preserve"><value>L'annulation ne restaurera pas vos anciennes appartenances aux &#xE9;quipes. Vous devrez rejoindre les &#xE9;quipes &#xE0; nouveau.</value></data>
 
   <!-- Preferred Email View -->
-  <data name="PreferredEmail_Description" xml:space="preserve"><value>Par d&#xE9;faut, les notifications du syst&#xE8;me sont envoy&#xE9;es &#xE0; votre adresse de connexion. Vous pouvez sp&#xE9;cifier une adresse e-mail diff&#xE9;rente pour recevoir ces notifications.</value></data>
-  <data name="PreferredEmail_CurrentSettings" xml:space="preserve"><value>Param&#xE8;tres actuels de l'e-mail</value></data>
-  <data name="PreferredEmail_SignInEmail" xml:space="preserve"><value>E-mail de connexion</value></data>
-  <data name="PreferredEmail_GoogleAccount" xml:space="preserve"><value>Compte Google</value></data>
-  <data name="PreferredEmail_NotSet" xml:space="preserve"><value>Non d&#xE9;fini (utilisation de l'e-mail de connexion)</value></data>
-  <data name="PreferredEmail_Verified" xml:space="preserve"><value>V&#xE9;rifi&#xE9;</value></data>
-  <data name="PreferredEmail_PendingVerification" xml:space="preserve"><value>V&#xE9;rification en attente</value></data>
-  <data name="PreferredEmail_NotificationsSentTo" xml:space="preserve"><value>Notifications envoy&#xE9;es &#xE0;</value></data>
-  <data name="PreferredEmail_Preferred" xml:space="preserve"><value>pr&#xE9;f&#xE9;r&#xE9;</value></data>
-  <data name="PreferredEmail_SignInEmailLabel" xml:space="preserve"><value>e-mail de connexion</value></data>
-  <data name="PreferredEmail_VerificationSent" xml:space="preserve"><value>Un e-mail de v&#xE9;rification a &#xE9;t&#xE9; envoy&#xE9; &#xE0; {0}. Veuillez consulter votre bo&#xEE;te de r&#xE9;ception et cliquer sur le lien de v&#xE9;rification.</value><comment>{0} = email address</comment></data>
-  <data name="PreferredEmail_ResendCooldown" xml:space="preserve"><value>Vous pourrez demander un nouvel e-mail de v&#xE9;rification dans {0} minute(s).</value><comment>{0} = minutes remaining</comment></data>
-  <data name="PreferredEmail_SetTitle" xml:space="preserve"><value>D&#xE9;finir l'e-mail pr&#xE9;f&#xE9;r&#xE9;</value></data>
-  <data name="PreferredEmail_ChangeTitle" xml:space="preserve"><value>Modifier l'e-mail pr&#xE9;f&#xE9;r&#xE9;</value></data>
-  <data name="PreferredEmail_VerificationWillBeSent" xml:space="preserve"><value>Un e-mail de v&#xE9;rification sera envoy&#xE9; &#xE0; cette adresse.</value></data>
-  <data name="PreferredEmail_SendVerification" xml:space="preserve"><value>Envoyer l'e-mail de v&#xE9;rification</value></data>
-  <data name="PreferredEmail_RemoveTitle" xml:space="preserve"><value>Supprimer l'e-mail pr&#xE9;f&#xE9;r&#xE9;</value></data>
-  <data name="PreferredEmail_RemoveDescription" xml:space="preserve"><value>Supprimez votre e-mail pr&#xE9;f&#xE9;r&#xE9; et utilisez votre e-mail de connexion pour toutes les notifications du syst&#xE8;me.</value></data>
-  <data name="PreferredEmail_RemoveConfirm" xml:space="preserve"><value>&#xCA;tes-vous s&#xFB;r de vouloir supprimer votre e-mail pr&#xE9;f&#xE9;r&#xE9; ?</value></data>
-  <data name="PreferredEmail_RemoveButton" xml:space="preserve"><value>Supprimer l'e-mail pr&#xE9;f&#xE9;r&#xE9;</value></data>
-  <data name="PreferredEmail_BackToEdit" xml:space="preserve"><value>Retour &#xE0; la modification du profil</value></data>
 
   <!-- Profile Controller TempData -->
   <data name="Profile_Updated" xml:space="preserve"><value>Profil mis &#xE0; jour avec succ&#xE8;s.</value></data>
@@ -857,7 +833,7 @@
   <data name="ProfileEdit_PictureHelp" xml:space="preserve"><value>T&#xE9;l&#xE9;chargez une image JPEG, PNG, WebP ou HEIC (max. 20 Mo). Les grandes images sont redimensionn&#xE9;es automatiquement. Ceci remplace votre avatar Google.</value></data>
   <data name="ProfileEdit_RemovePicture" xml:space="preserve"><value>Supprimer la photo personnalis&#xE9;e (revenir &#xE0; l'avatar Google)</value></data>
   <data name="ProfileEdit_DateOfBirthHelp" xml:space="preserve"><value>Visible uniquement par vous et le conseil d'administration. Utilis&#xE9; pour le calendrier des anniversaires.</value></data>
-  <data name="TeamDetail_TeamCoordinators" xml:space="preserve"><value>Coordinators</value></data>
+  <data name="TeamDetail_TeamCoordinators" xml:space="preserve"><value>Coordinateurs</value></data>
 
   <!-- Team Public Pages -->
   <data name="TeamDetail_AboutTeam" xml:space="preserve"><value>À propos</value></data>
@@ -1132,8 +1108,8 @@
   <data name="Email_BoardDigest_PendingDeletions" xml:space="preserve"><value>{0} suppressions de compte en attente</value><comment>{0} = count</comment></data>
 
   <!-- Navigation restructure -->
-  <data name="Nav_Review" xml:space="preserve"><value>Review</value></data>
-  <data name="Nav_Voting" xml:space="preserve"><value>Voting</value></data>
+  <data name="Nav_Review" xml:space="preserve"><value>Examen</value></data>
+  <data name="Nav_Voting" xml:space="preserve"><value>Vote</value></data>
   <data name="Nav_Board" xml:space="preserve"><value>Board</value></data>
 
   <!-- Team admin: add member -->
@@ -1217,4 +1193,64 @@
   <!-- Camp Cards -->
   <data name="CampCard_NeedsPhoto" xml:space="preserve"><value>Ce barrio a besoin d'une photo !</value></data>
 
+  <data name="CompleteSignup_DisplayNameLabel" xml:space="preserve"><value>Nom d'affichage</value></data>
+  <data name="CompleteSignup_Submit" xml:space="preserve"><value>Créer un compte</value></data>
+  <data name="CompleteSignup_Title" xml:space="preserve"><value>Finaliser votre inscription</value></data>
+  <data name="Consent_ActionRequired" xml:space="preserve"><value>Action requise</value></data>
+  <data name="Consent_LastUpdated" xml:space="preserve"><value>Dernière mise à jour</value></data>
+  <data name="Email_EmailVerification_Merge_Body" xml:space="preserve"><value><h2>Vérification de fusion de comptes</h2>
+<p>Bonjour {0},</p>
+<p>Vous avez demandé à ajouter <strong>{1}</strong> à votre compte. Cette adresse e-mail est actuellement liée à un autre compte.</p>
+<p>Si vous vérifiez cet e-mail, une demande de fusion sera soumise pour examen par un administrateur. Une fois approuvée, les données de l'autre compte seront fusionnées dans le vôtre et le compte en double sera archivé.</p>
+<p>Veuillez cliquer sur le lien ci-dessous pour vérifier et demander la fusion :</p>
+<p><a href="{2}">Vérifier et demander la fusion</a></p>
+<p>Ce lien expire dans 24 heures.</p>
+<p>Si vous n'avez pas fait cette demande, vous pouvez ignorer cet e-mail. Aucune modification ne sera effectuée.</p>
+<p>L'équipe Humans</p></value></data>
+  <data name="Email_FacilitatedMessage_Body" xml:space="preserve"><value><h2>Message de {1}</h2><p>Bonjour {0},</p><p>{1} vous a envoyé un message via Humans :</p><hr /><p>{2}</p><hr />{3}</value></data>
+  <data name="Email_FacilitatedMessage_NoContactInfo" xml:space="preserve"><value>Cet humain a choisi de ne pas partager ses coordonnées.</value></data>
+  <data name="Email_FacilitatedMessage_Subject" xml:space="preserve"><value>Message Humans de : {0}</value></data>
+  <data name="Email_MagicLinkLogin_Body" xml:space="preserve"><value><p>Bonjour {0},</p><p>Cliquez sur le lien ci-dessous pour vous connecter :</p><p><a href="{1}">Se connecter à Nobodies</a></p><p>Ce lien expire dans 15 minutes et ne peut être utilisé qu'une seule fois.</p><p>Si vous n'avez pas demandé ceci, vous pouvez ignorer cet e-mail.</p></value></data>
+  <data name="Email_MagicLinkLogin_Subject" xml:space="preserve"><value>Votre lien de connexion pour Nobodies</value></data>
+  <data name="Email_MagicLinkSignup_Body" xml:space="preserve"><value><p>Bienvenue chez Nobodies !</p><p>Cliquez sur le lien ci-dessous pour créer votre compte :</p><p><a href="{0}">Créer votre compte</a></p><p>Ce lien expire dans 15 minutes et ne peut être utilisé qu'une seule fois.</p><p>Si vous n'avez pas demandé ceci, vous pouvez ignorer cet e-mail.</p></value></data>
+  <data name="Email_MagicLinkSignup_Subject" xml:space="preserve"><value>Bienvenue chez Nobodies — confirmez votre e-mail</value></data>
+  <data name="Emails_AddNew" xml:space="preserve"><value>Ajouter une adresse e-mail</value></data>
+  <data name="Emails_BackToEdit" xml:space="preserve"><value>Retour à la modification du profil</value></data>
+  <data name="Emails_Description" xml:space="preserve"><value>Gérez vos adresses e-mail. Votre adresse de connexion est toujours incluse. Ajoutez des e-mails supplémentaires, définissez laquelle reçoit les notifications et contrôlez la visibilité du profil.</value></data>
+  <data name="Emails_ManageEmails" xml:space="preserve"><value>Adresses e-mail</value></data>
+  <data name="Emails_ManageEmailsHelp" xml:space="preserve"><value>Ajouter des adresses e-mail supplémentaires, gérer les notifications et définir la visibilité du profil.</value></data>
+  <data name="Emails_ManageLater" xml:space="preserve"><value>Vous pourrez ajouter et gérer des adresses e-mail supplémentaires depuis votre profil après avoir terminé la configuration.</value></data>
+  <data name="Emails_ResendCooldown" xml:space="preserve"><value>Vous pourrez demander un nouvel e-mail de vérification dans {0} minute(s).</value></data>
+  <data name="Emails_SendVerification" xml:space="preserve"><value>Envoyer un e-mail de vérification</value></data>
+  <data name="Emails_Title" xml:space="preserve"><value>Adresses e-mail</value></data>
+  <data name="Emails_VerificationWillBeSent" xml:space="preserve"><value>Un e-mail de vérification sera envoyé à cette adresse.</value></data>
+  <data name="Emails_YourEmails" xml:space="preserve"><value>Vos adresses e-mail</value></data>
+  <data name="Login_MagicLink_Placeholder" xml:space="preserve"><value>votre@email.com</value></data>
+  <data name="Login_MagicLink_Submit" xml:space="preserve"><value>M'envoyer un lien de connexion</value></data>
+  <data name="Login_MagicLink_Title" xml:space="preserve"><value>Ou se connecter par e-mail</value></data>
+  <data name="MagicLinkConfirm_Message" xml:space="preserve"><value>Cliquez sur le bouton ci-dessous pour vous connecter à votre compte.</value></data>
+  <data name="MagicLinkConfirm_SignIn" xml:space="preserve"><value>Se connecter</value></data>
+  <data name="MagicLinkConfirm_Title" xml:space="preserve"><value>Se connecter</value></data>
+  <data name="MagicLinkError_Message" xml:space="preserve"><value>Ce lien de connexion a expiré ou a déjà été utilisé.</value></data>
+  <data name="MagicLinkError_RequestNew" xml:space="preserve"><value>Demander un nouveau lien</value></data>
+  <data name="MagicLinkError_Title" xml:space="preserve"><value>Lien expiré ou invalide</value></data>
+  <data name="MagicLinkSent_BackToLogin" xml:space="preserve"><value>Retour à la connexion</value></data>
+  <data name="MagicLinkSent_Title" xml:space="preserve"><value>Vérifiez vos e-mails</value></data>
+  <data name="ProfileEdit_ManageEmails" xml:space="preserve"><value>Adresses e-mail</value></data>
+  <data name="ProfileEdit_ManageEmailsHelp" xml:space="preserve"><value>Ajouter des adresses e-mail, définir les préférences de notification et contrôler la visibilité du profil.</value></data>
+  <data name="Profile_Day" xml:space="preserve"><value>Jour</value></data>
+  <data name="Profile_Month" xml:space="preserve"><value>Mois</value></data>
+  <data name="Profile_NotificationTarget" xml:space="preserve"><value>Les notifications système sont envoyées à cette adresse</value></data>
+  <data name="Profile_NotificationTargetShort" xml:space="preserve"><value>Notifications</value></data>
+  <data name="SendMessage_Breadcrumb" xml:space="preserve"><value>Envoyer un message</value></data>
+  <data name="SendMessage_Button" xml:space="preserve"><value>Envoyer un message à {0}</value></data>
+  <data name="SendMessage_Heading" xml:space="preserve"><value>Envoyer un message à {0}</value></data>
+  <data name="SendMessage_IncludeContactInfo" xml:space="preserve"><value>Inclure mes coordonnées</value></data>
+  <data name="SendMessage_IncludeContactInfoHelp" xml:space="preserve"><value>Votre nom et votre e-mail seront inclus pour que la personne puisse vous répondre directement.</value></data>
+  <data name="SendMessage_MessageLabel" xml:space="preserve"><value>Message</value></data>
+  <data name="SendMessage_PlainTextOnly" xml:space="preserve"><value>Texte brut uniquement. Maximum 2000 caractères.</value></data>
+  <data name="SendMessage_Send" xml:space="preserve"><value>Envoyer le message</value></data>
+  <data name="SendMessage_Success" xml:space="preserve"><value>Votre message a été envoyé à {0}.</value></data>
+  <data name="SendMessage_Title" xml:space="preserve"><value>Envoyer un message à {0}</value></data>
+  <data name="TeamDetail_ManageConsents" xml:space="preserve"><value>Documents juridiques</value></data>
 </root>

--- a/src/Humans.Web/Resources/SharedResource.it.resx
+++ b/src/Humans.Web/Resources/SharedResource.it.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:element name="root" msdata:IsDataSet="true">
@@ -55,15 +55,15 @@
   <data name="Nav_Home" xml:space="preserve"><value>Home</value></data>
   <data name="Nav_MyProfile" xml:space="preserve"><value>Il mio Profilo</value></data>
   <data name="Nav_Teams" xml:space="preserve"><value>Team</value></data>
-  <data name="Nav_Shifts" xml:space="preserve"><value>Volunteer</value></data>
-  <data name="Nav_Roster" xml:space="preserve"><value>Roster</value></data>
+  <data name="Nav_Shifts" xml:space="preserve"><value>Volontariato</value></data>
+  <data name="Nav_Roster" xml:space="preserve"><value>Elenco</value></data>
   <data name="Nav_Consents" xml:space="preserve"><value>Accordi</value></data>
   <data name="Nav_Governance" xml:space="preserve"><value>Governance</value></data>
   <data name="Nav_Privacy" xml:space="preserve"><value>Privacy</value></data>
   <data name="Nav_About" xml:space="preserve"><value>Chi siamo</value></data>
   <data name="Nav_Admin" xml:space="preserve"><value>Admin</value></data>
   <data name="Nav_OnboardingReview" xml:space="preserve"><value>Coda di revisione</value></data>
-  <data name="Nav_MyFeedback" xml:space="preserve"><value>My Feedback</value></data>
+  <data name="Nav_MyFeedback" xml:space="preserve"><value>Il mio feedback</value></data>
 
 
   <!-- ======================== -->
@@ -87,7 +87,7 @@
   <data name="Login_Title" xml:space="preserve"><value>Accedi</value></data>
   <data name="Login_Description" xml:space="preserve"><value>Accedi per accedere a Humans.</value></data>
   <data name="Login_SignInWithGoogle" xml:space="preserve"><value>Accedi con Google</value></data>
-  <data name="Login_SignInFailed" xml:space="preserve"><value>Sign-in failed. This can happen if you took too long or your browser blocked cookies. Please try again.</value></data>
+  <data name="Login_SignInFailed" xml:space="preserve"><value>Accesso non riuscito. Questo può accadere se hai impiegato troppo tempo o se il tuo browser ha bloccato i cookie. Per favore riprova.</value></data>
   <data name="AccessDenied_Title" xml:space="preserve"><value>Accesso negato</value></data>
   <data name="AccessDenied_Description" xml:space="preserve"><value>Non dispone dei permessi necessari per accedere a questa pagina.</value></data>
 
@@ -174,7 +174,6 @@
   <data name="Profile_Title" xml:space="preserve"><value>Il mio Profilo</value></data>
   <data name="ProfileEdit_Title" xml:space="preserve"><value>Modifica Profilo</value></data>
   <data name="ProfilePrivacy_Title" xml:space="preserve"><value>I miei dati</value></data>
-  <data name="PreferredEmail_Title" xml:space="preserve"><value>Email preferita</value></data>
   <data name="VerifyEmail_Title" xml:space="preserve"><value>Verifica email</value></data>
   <data name="VerifyEmail_GoToSettings" xml:space="preserve"><value>Vai alle impostazioni email</value></data>
   <data name="VerifyEmail_GoHome" xml:space="preserve"><value>Vai alla Home</value></data>
@@ -198,7 +197,7 @@
   <data name="Profile_NoContactInfo" xml:space="preserve"><value>Nessuna informazione di contatto aggiunta.</value></data>
   <data name="Profile_AddSome" xml:space="preserve"><value>Aggiungi</value></data>
   <data name="Profile_Teams" xml:space="preserve"><value>Team</value></data>
-  <data name="Profile_Coordinator" xml:space="preserve"><value>Coordinator</value></data>
+  <data name="Profile_Coordinator" xml:space="preserve"><value>Coordinatore</value></data>
   <data name="Profile_MembershipTier" xml:space="preserve"><value>Livello di adesione</value></data>
   <data name="Profile_Motivation" xml:space="preserve"><value>Motivazione</value></data>
   <data name="Profile_AdditionalInfo" xml:space="preserve"><value>Informazioni aggiuntive (facoltativo)</value></data>
@@ -242,8 +241,6 @@
   <data name="ProfileEdit_AddContactField" xml:space="preserve"><value>Aggiungi campo contatto</value></data>
   <data name="ProfileEdit_BurnerCVHelp" xml:space="preserve"><value>Documenti il Suo coinvolgimento in eventi, ruoli e camp. Le voci sono ordinate per data (più recenti prima).</value></data>
   <data name="ProfileEdit_AddEntry" xml:space="preserve"><value>Aggiungi voce</value></data>
-  <data name="ProfileEdit_ManagePreferredEmail" xml:space="preserve"><value>Gestisci email preferita</value></data>
-  <data name="ProfileEdit_PreferredEmailHelp" xml:space="preserve"><value>Imposti un indirizzo email diverso per ricevere le notifiche di sistema.</value></data>
 
   <!-- Profile Privacy View -->
   <data name="ProfilePrivacy_Lead" xml:space="preserve"><value>Gestisca i Suoi dati personali e le impostazioni sulla privacy.</value></data>
@@ -278,27 +275,6 @@
   <data name="ProfilePrivacy_CancelNoRestore" xml:space="preserve"><value>L'annullamento non ripristiner&#xE0; le Sue precedenti appartenenze ai team. Dovr&#xE0; riunirsi ai team.</value></data>
 
   <!-- Preferred Email View -->
-  <data name="PreferredEmail_Description" xml:space="preserve"><value>Per impostazione predefinita, le notifiche di sistema vengono inviate al Suo indirizzo email di accesso. Può specificare un indirizzo email diverso per ricevere queste notifiche.</value></data>
-  <data name="PreferredEmail_CurrentSettings" xml:space="preserve"><value>Impostazioni email attuali</value></data>
-  <data name="PreferredEmail_SignInEmail" xml:space="preserve"><value>Email di accesso</value></data>
-  <data name="PreferredEmail_GoogleAccount" xml:space="preserve"><value>Account Google</value></data>
-  <data name="PreferredEmail_NotSet" xml:space="preserve"><value>Non impostata (viene utilizzata l'email di accesso)</value></data>
-  <data name="PreferredEmail_Verified" xml:space="preserve"><value>Verificata</value></data>
-  <data name="PreferredEmail_PendingVerification" xml:space="preserve"><value>Verifica in sospeso</value></data>
-  <data name="PreferredEmail_NotificationsSentTo" xml:space="preserve"><value>Notifiche inviate a</value></data>
-  <data name="PreferredEmail_Preferred" xml:space="preserve"><value>preferita</value></data>
-  <data name="PreferredEmail_SignInEmailLabel" xml:space="preserve"><value>email di accesso</value></data>
-  <data name="PreferredEmail_VerificationSent" xml:space="preserve"><value>Un'email di verifica è stata inviata a {0}. Controlli la Sua casella di posta e clicchi sul link di verifica.</value><comment>{0} = email address</comment></data>
-  <data name="PreferredEmail_ResendCooldown" xml:space="preserve"><value>Potrà richiedere una nuova email di verifica tra {0} minuto/i.</value><comment>{0} = minutes remaining</comment></data>
-  <data name="PreferredEmail_SetTitle" xml:space="preserve"><value>Imposta email preferita</value></data>
-  <data name="PreferredEmail_ChangeTitle" xml:space="preserve"><value>Cambia email preferita</value></data>
-  <data name="PreferredEmail_VerificationWillBeSent" xml:space="preserve"><value>Un'email di verifica verrà inviata a questo indirizzo.</value></data>
-  <data name="PreferredEmail_SendVerification" xml:space="preserve"><value>Invia email di verifica</value></data>
-  <data name="PreferredEmail_RemoveTitle" xml:space="preserve"><value>Rimuovi email preferita</value></data>
-  <data name="PreferredEmail_RemoveDescription" xml:space="preserve"><value>Rimuova l'email preferita e utilizzi l'email di accesso per tutte le notifiche di sistema.</value></data>
-  <data name="PreferredEmail_RemoveConfirm" xml:space="preserve"><value>È sicuro/a di voler rimuovere l'email preferita?</value></data>
-  <data name="PreferredEmail_RemoveButton" xml:space="preserve"><value>Rimuovi email preferita</value></data>
-  <data name="PreferredEmail_BackToEdit" xml:space="preserve"><value>Torna alla modifica del profilo</value></data>
 
   <!-- Profile Controller TempData -->
   <data name="Profile_Updated" xml:space="preserve"><value>Profilo aggiornato con successo.</value></data>
@@ -857,7 +833,7 @@
   <data name="ProfileEdit_PictureHelp" xml:space="preserve"><value>Carica un'immagine JPEG, PNG, WebP o HEIC (max 20MB). Le immagini grandi vengono ridimensionate automaticamente. Questo sostituisce il tuo avatar di Google.</value></data>
   <data name="ProfileEdit_RemovePicture" xml:space="preserve"><value>Rimuovi foto personalizzata (torna all'avatar di Google)</value></data>
   <data name="ProfileEdit_DateOfBirthHelp" xml:space="preserve"><value>Visibile solo a te e al consiglio. Utilizzato per il calendario dei compleanni.</value></data>
-  <data name="TeamDetail_TeamCoordinators" xml:space="preserve"><value>Coordinators</value></data>
+  <data name="TeamDetail_TeamCoordinators" xml:space="preserve"><value>Coordinatori</value></data>
 
   <!-- Team Public Pages -->
   <data name="TeamDetail_AboutTeam" xml:space="preserve"><value>Informazioni</value></data>
@@ -1132,8 +1108,8 @@
   <data name="Email_BoardDigest_PendingDeletions" xml:space="preserve"><value>{0} eliminazioni di account in sospeso</value><comment>{0} = count</comment></data>
 
   <!-- Navigation restructure -->
-  <data name="Nav_Review" xml:space="preserve"><value>Review</value></data>
-  <data name="Nav_Voting" xml:space="preserve"><value>Voting</value></data>
+  <data name="Nav_Review" xml:space="preserve"><value>Revisione</value></data>
+  <data name="Nav_Voting" xml:space="preserve"><value>Votazione</value></data>
   <data name="Nav_Board" xml:space="preserve"><value>Board</value></data>
 
   <!-- Team admin: add member -->
@@ -1217,4 +1193,64 @@
   <!-- Camp Cards -->
   <data name="CampCard_NeedsPhoto" xml:space="preserve"><value>Questo barrio ha bisogno di una foto!</value></data>
 
+  <data name="CompleteSignup_DisplayNameLabel" xml:space="preserve"><value>Nome visualizzato</value></data>
+  <data name="CompleteSignup_Submit" xml:space="preserve"><value>Crea account</value></data>
+  <data name="CompleteSignup_Title" xml:space="preserve"><value>Completa la registrazione</value></data>
+  <data name="Consent_ActionRequired" xml:space="preserve"><value>Azione richiesta</value></data>
+  <data name="Consent_LastUpdated" xml:space="preserve"><value>Ultimo aggiornamento</value></data>
+  <data name="Email_EmailVerification_Merge_Body" xml:space="preserve"><value><h2>Verifica unione account</h2>
+<p>Ciao {0},</p>
+<p>Hai richiesto di aggiungere <strong>{1}</strong> al tuo account. Questo indirizzo e-mail è attualmente collegato a un altro account.</p>
+<p>Se verifichi questa e-mail, verrà inviata una richiesta di unione per la revisione dell'amministratore. Una volta approvata, i dati dell'altro account verranno uniti al tuo e l'account duplicato verrà archiviato.</p>
+<p>Fai clic sul link qui sotto per verificare e richiedere l'unione:</p>
+<p><a href="{2}">Verifica e richiedi unione</a></p>
+<p>Questo link scade tra 24 ore.</p>
+<p>Se non hai richiesto questo, puoi ignorare questa e-mail. Non verranno apportate modifiche.</p>
+<p>Il team di Humans</p></value></data>
+  <data name="Email_FacilitatedMessage_Body" xml:space="preserve"><value><h2>Messaggio da {1}</h2><p>Ciao {0},</p><p>{1} ti ha inviato un messaggio tramite Humans:</p><hr /><p>{2}</p><hr />{3}</value></data>
+  <data name="Email_FacilitatedMessage_NoContactInfo" xml:space="preserve"><value>Questo umano ha scelto di non condividere le proprie informazioni di contatto.</value></data>
+  <data name="Email_FacilitatedMessage_Subject" xml:space="preserve"><value>Messaggio Humans da: {0}</value></data>
+  <data name="Email_MagicLinkLogin_Body" xml:space="preserve"><value><p>Ciao {0},</p><p>Fai clic sul link qui sotto per accedere:</p><p><a href="{1}">Accedi a Nobodies</a></p><p>Questo link scade tra 15 minuti e può essere utilizzato solo una volta.</p><p>Se non hai richiesto questo, puoi ignorare questa e-mail.</p></value></data>
+  <data name="Email_MagicLinkLogin_Subject" xml:space="preserve"><value>Il tuo link di accesso per Nobodies</value></data>
+  <data name="Email_MagicLinkSignup_Body" xml:space="preserve"><value><p>Benvenuto su Nobodies!</p><p>Fai clic sul link qui sotto per creare il tuo account:</p><p><a href="{0}">Crea il tuo account</a></p><p>Questo link scade tra 15 minuti e può essere utilizzato solo una volta.</p><p>Se non hai richiesto questo, puoi ignorare questa e-mail.</p></value></data>
+  <data name="Email_MagicLinkSignup_Subject" xml:space="preserve"><value>Benvenuto su Nobodies — conferma la tua e-mail</value></data>
+  <data name="Emails_AddNew" xml:space="preserve"><value>Aggiungi indirizzo e-mail</value></data>
+  <data name="Emails_BackToEdit" xml:space="preserve"><value>Torna alla modifica del profilo</value></data>
+  <data name="Emails_Description" xml:space="preserve"><value>Gestisci i tuoi indirizzi e-mail. Il tuo indirizzo di accesso è sempre incluso. Aggiungi e-mail aggiuntive, scegli quale riceve le notifiche e controlla la visibilità del profilo.</value></data>
+  <data name="Emails_ManageEmails" xml:space="preserve"><value>Indirizzi e-mail</value></data>
+  <data name="Emails_ManageEmailsHelp" xml:space="preserve"><value>Aggiungi indirizzi e-mail aggiuntivi, gestisci le notifiche e imposta la visibilità del profilo.</value></data>
+  <data name="Emails_ManageLater" xml:space="preserve"><value>Puoi aggiungere e gestire indirizzi e-mail aggiuntivi dal tuo profilo dopo aver completato la configurazione.</value></data>
+  <data name="Emails_ResendCooldown" xml:space="preserve"><value>Puoi richiedere una nuova e-mail di verifica tra {0} minuto/i.</value></data>
+  <data name="Emails_SendVerification" xml:space="preserve"><value>Invia e-mail di verifica</value></data>
+  <data name="Emails_Title" xml:space="preserve"><value>Indirizzi e-mail</value></data>
+  <data name="Emails_VerificationWillBeSent" xml:space="preserve"><value>Verrà inviata un'e-mail di verifica a questo indirizzo.</value></data>
+  <data name="Emails_YourEmails" xml:space="preserve"><value>I tuoi indirizzi e-mail</value></data>
+  <data name="Login_MagicLink_Placeholder" xml:space="preserve"><value>tua@email.com</value></data>
+  <data name="Login_MagicLink_Submit" xml:space="preserve"><value>Inviami un link di accesso</value></data>
+  <data name="Login_MagicLink_Title" xml:space="preserve"><value>Oppure accedi con e-mail</value></data>
+  <data name="MagicLinkConfirm_Message" xml:space="preserve"><value>Fai clic sul pulsante qui sotto per accedere al tuo account.</value></data>
+  <data name="MagicLinkConfirm_SignIn" xml:space="preserve"><value>Accedi</value></data>
+  <data name="MagicLinkConfirm_Title" xml:space="preserve"><value>Accedi</value></data>
+  <data name="MagicLinkError_Message" xml:space="preserve"><value>Questo link di accesso è scaduto o è già stato utilizzato.</value></data>
+  <data name="MagicLinkError_RequestNew" xml:space="preserve"><value>Richiedi un nuovo link</value></data>
+  <data name="MagicLinkError_Title" xml:space="preserve"><value>Link scaduto o non valido</value></data>
+  <data name="MagicLinkSent_BackToLogin" xml:space="preserve"><value>Torna all'accesso</value></data>
+  <data name="MagicLinkSent_Title" xml:space="preserve"><value>Controlla la tua e-mail</value></data>
+  <data name="ProfileEdit_ManageEmails" xml:space="preserve"><value>Indirizzi e-mail</value></data>
+  <data name="ProfileEdit_ManageEmailsHelp" xml:space="preserve"><value>Aggiungi indirizzi e-mail, imposta le preferenze di notifica e controlla la visibilità del profilo.</value></data>
+  <data name="Profile_Day" xml:space="preserve"><value>Giorno</value></data>
+  <data name="Profile_Month" xml:space="preserve"><value>Mese</value></data>
+  <data name="Profile_NotificationTarget" xml:space="preserve"><value>Le notifiche di sistema vengono inviate a questo indirizzo</value></data>
+  <data name="Profile_NotificationTargetShort" xml:space="preserve"><value>Notifiche</value></data>
+  <data name="SendMessage_Breadcrumb" xml:space="preserve"><value>Invia messaggio</value></data>
+  <data name="SendMessage_Button" xml:space="preserve"><value>Invia un messaggio a {0}</value></data>
+  <data name="SendMessage_Heading" xml:space="preserve"><value>Invia un messaggio a {0}</value></data>
+  <data name="SendMessage_IncludeContactInfo" xml:space="preserve"><value>Includi le mie informazioni di contatto</value></data>
+  <data name="SendMessage_IncludeContactInfoHelp" xml:space="preserve"><value>Il tuo nome e la tua e-mail verranno inclusi in modo che possano risponderti direttamente.</value></data>
+  <data name="SendMessage_MessageLabel" xml:space="preserve"><value>Messaggio</value></data>
+  <data name="SendMessage_PlainTextOnly" xml:space="preserve"><value>Solo testo normale. Massimo 2000 caratteri.</value></data>
+  <data name="SendMessage_Send" xml:space="preserve"><value>Invia messaggio</value></data>
+  <data name="SendMessage_Success" xml:space="preserve"><value>Il tuo messaggio è stato inviato a {0}.</value></data>
+  <data name="SendMessage_Title" xml:space="preserve"><value>Invia un messaggio a {0}</value></data>
+  <data name="TeamDetail_ManageConsents" xml:space="preserve"><value>Documenti legali</value></data>
 </root>


### PR DESCRIPTION
## Summary
- Add 34–52 missing keys per locale (de/es/fr/it) for magic link login, multi-email management, facilitated messaging, and complete signup features
- Remove 24 orphan `PreferredEmail_*` keys from all 4 locales (dead feature replaced by multi-email system)
- Translate `Login_SignInFailed` error message and nav items (`My Feedback`, `Review`, `Roster`, `Volunteer`, `Voting`) plus role labels (`Coordinator/s`) in all 4 locales
- All locales now have exactly 886 keys matching the base file

## Test plan
- [ ] Switch locale to de/es/fr/it and verify magic link login pages render translated text
- [ ] Check email management page (`/Profile/Emails`) shows translated labels
- [ ] Verify nav bar items are translated in all locales
- [ ] Confirm `Login_SignInFailed` error shows translated message (trigger by blocking cookies or slow auth)

🤖 Generated with [Claude Code](https://claude.com/claude-code)