### PR TITLE
fix: spec compliance fixes for ticket widgets (#265, #266)

### DIFF
--- a/src/Humans.Application/Interfaces/ITicketQueryService.cs
+++ b/src/Humans.Application/Interfaces/ITicketQueryService.cs
@@ -1,0 +1,24 @@
+namespace Humans.Application.Interfaces;
+
+/// <summary>
+/// Query service for ticket data — checks whether a user has tickets,
+/// counts matched tickets, etc. All matching logic (MatchedUserId,
+/// email fallback, case-insensitive) lives here.
+/// </summary>
+public interface ITicketQueryService
+{
+    /// <summary>
+    /// Count tickets associated with a user. Checks MatchedUserId on both
+    /// orders and attendees, then falls back to matching all verified user
+    /// emails against buyer/attendee emails (case-insensitive).
+    /// Only counts paid orders and valid/checked-in attendees.
+    /// </summary>
+    Task<int> GetUserTicketCountAsync(Guid userId);
+
+    /// <summary>
+    /// Get the set of user IDs that have at least one valid ticket,
+    /// using MatchedUserId on orders (paid only) and attendees (valid/checked-in).
+    /// Used for aggregate reporting like volunteer ticket coverage.
+    /// </summary>
+    Task<HashSet<Guid>> GetUserIdsWithTicketsAsync();
+}

--- a/src/Humans.Infrastructure/Services/TicketQueryService.cs
+++ b/src/Humans.Infrastructure/Services/TicketQueryService.cs
@@ -1,0 +1,77 @@
+using Microsoft.EntityFrameworkCore;
+using Humans.Application.Interfaces;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using Humans.Infrastructure.Data;
+
+namespace Humans.Infrastructure.Services;
+
+public class TicketQueryService : ITicketQueryService
+{
+    private readonly HumansDbContext _dbContext;
+
+    public TicketQueryService(HumansDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task<int> GetUserTicketCountAsync(Guid userId)
+    {
+        // First check by MatchedUserId (set during sync)
+        var attendeeCount = await _dbContext.TicketAttendees.CountAsync(a =>
+            a.MatchedUserId == userId &&
+            (a.Status == TicketAttendeeStatus.Valid || a.Status == TicketAttendeeStatus.CheckedIn));
+
+        var buyerCount = await _dbContext.TicketOrders.CountAsync(o =>
+            o.MatchedUserId == userId &&
+            o.PaymentStatus == TicketPaymentStatus.Paid);
+
+        if (attendeeCount > 0 || buyerCount > 0)
+            return Math.Max(attendeeCount, buyerCount);
+
+        // Fallback: check all verified user emails (case-insensitive)
+        // ToUpper() translates to SQL UPPER() in EF/Npgsql — analyzer MA0011 is a false positive here
+#pragma warning disable MA0011
+        var userEmails = await _dbContext.Set<UserEmail>()
+            .Where(e => e.UserId == userId && e.IsVerified)
+            .Select(e => e.Email.ToUpper())
+            .ToListAsync();
+
+        if (userEmails.Count == 0)
+            return 0;
+
+        attendeeCount = await _dbContext.TicketAttendees.CountAsync(a =>
+            a.AttendeeEmail != null &&
+            userEmails.Contains(a.AttendeeEmail.ToUpper()) &&
+            (a.Status == TicketAttendeeStatus.Valid || a.Status == TicketAttendeeStatus.CheckedIn));
+
+        if (attendeeCount > 0)
+            return attendeeCount;
+
+        buyerCount = await _dbContext.TicketOrders.CountAsync(o =>
+            userEmails.Contains(o.BuyerEmail.ToUpper()) &&
+            o.PaymentStatus == TicketPaymentStatus.Paid);
+#pragma warning restore MA0011
+
+        return buyerCount;
+    }
+
+    public async Task<HashSet<Guid>> GetUserIdsWithTicketsAsync()
+    {
+        var attendeeUserIds = await _dbContext.TicketAttendees
+            .Where(a => a.MatchedUserId != null &&
+                (a.Status == TicketAttendeeStatus.Valid || a.Status == TicketAttendeeStatus.CheckedIn))
+            .Select(a => a.MatchedUserId!.Value)
+            .Distinct()
+            .ToListAsync();
+
+        var buyerUserIds = await _dbContext.TicketOrders
+            .Where(o => o.MatchedUserId != null &&
+                o.PaymentStatus == TicketPaymentStatus.Paid)
+            .Select(o => o.MatchedUserId!.Value)
+            .Distinct()
+            .ToListAsync();
+
+        return attendeeUserIds.Union(buyerUserIds).ToHashSet();
+    }
+}

--- a/src/Humans.Web/Controllers/HomeController.cs
+++ b/src/Humans.Web/Controllers/HomeController.cs
@@ -249,40 +249,52 @@ public class HomeController : HumansControllerBase
             _logger.LogError(ex, "Failed to load shift cards for dashboard");
         }
 
-        // Ticket summary — guarded, failures must never crash the homepage
+        // Per-user ticket status — always renders, shows warning when unconfigured
+        viewModel.TicketPurchaseUrl = "https://tickets.nobodies.team";
+        viewModel.TicketsConfigured = _ticketSettings.IsConfigured;
         try
         {
             if (_ticketSettings.IsConfigured)
             {
-                var ticketsSold = await _dbContext.TicketAttendees.CountAsync(a =>
-                    a.Status == TicketAttendeeStatus.Valid || a.Status == TicketAttendeeStatus.CheckedIn);
+                // Check tickets matched by MatchedUserId (auto-matched during sync)
+                var attendeeCount = await _dbContext.TicketAttendees.CountAsync(a =>
+                    a.MatchedUserId == user.Id &&
+                    (a.Status == TicketAttendeeStatus.Valid || a.Status == TicketAttendeeStatus.CheckedIn));
 
-                var totalCapacity = 0;
-                try
+                var buyerCount = await _dbContext.TicketOrders.CountAsync(o =>
+                    o.MatchedUserId == user.Id);
+
+                // Also check all verified user emails for unmatched orders/attendees
+                if (attendeeCount == 0 && buyerCount == 0)
                 {
-                    var summary = await _cache.GetOrCreateAsync(CacheKeys.TicketEventSummary, async entry =>
+                    var userEmails = await _dbContext.Set<Domain.Entities.UserEmail>()
+                        .Where(e => e.UserId == user.Id && e.IsVerified)
+                        .Select(e => e.Email)
+                        .ToListAsync();
+
+                    if (userEmails.Count > 0)
                     {
-                        entry.AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(15);
-                        return await _vendorService.GetEventSummaryAsync(_ticketSettings.EventId);
-                    });
-                    totalCapacity = summary?.TotalCapacity ?? 0;
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogWarning(ex, "Could not fetch event summary for homepage ticket card");
+                        attendeeCount = await _dbContext.TicketAttendees.CountAsync(a =>
+                            a.AttendeeEmail != null &&
+                            userEmails.Contains(a.AttendeeEmail) &&
+                            (a.Status == TicketAttendeeStatus.Valid || a.Status == TicketAttendeeStatus.CheckedIn));
+
+                        if (attendeeCount == 0)
+                        {
+                            buyerCount = await _dbContext.TicketOrders.CountAsync(o =>
+                                userEmails.Contains(o.BuyerEmail));
+                        }
+                    }
                 }
 
-                viewModel.TicketsConfigured = true;
-                viewModel.TicketsSold = ticketsSold;
-                viewModel.TicketCapacity = totalCapacity;
-                viewModel.TicketCoveragePercent = totalCapacity > 0
-                    ? Math.Round(ticketsSold * 100m / totalCapacity, 1)
-                    : 0;
+                var totalTickets = Math.Max(attendeeCount, buyerCount);
+                viewModel.HasTicket = totalTickets > 0;
+                viewModel.UserTicketCount = totalTickets;
             }
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to load ticket summary for homepage dashboard");
+            _logger.LogError(ex, "Failed to load ticket status for user {UserId}", user.Id);
         }
 
         return View("Dashboard", viewModel);

--- a/src/Humans.Web/Controllers/HomeController.cs
+++ b/src/Humans.Web/Controllers/HomeController.cs
@@ -1,14 +1,10 @@
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
 using NodaTime;
-using Humans.Application;
 using Humans.Application.Interfaces;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
-using Humans.Infrastructure.Data;
 using Humans.Infrastructure.Services;
 using Humans.Web.Models;
 
@@ -23,10 +19,8 @@ public class HomeController : HumansControllerBase
     private readonly IShiftSignupService _shiftSignup;
     private readonly IConfiguration _configuration;
     private readonly IClock _clock;
-    private readonly HumansDbContext _dbContext;
-    private readonly ITicketVendorService _vendorService;
     private readonly TicketVendorSettings _ticketSettings;
-    private readonly IMemoryCache _cache;
+    private readonly ITicketQueryService _ticketQueryService;
     private readonly ILogger<HomeController> _logger;
 
     public HomeController(
@@ -38,10 +32,8 @@ public class HomeController : HumansControllerBase
         IShiftSignupService shiftSignup,
         IConfiguration configuration,
         IClock clock,
-        HumansDbContext dbContext,
-        ITicketVendorService vendorService,
         IOptions<TicketVendorSettings> ticketSettings,
-        IMemoryCache cache,
+        ITicketQueryService ticketQueryService,
         ILogger<HomeController> logger)
         : base(userManager)
     {
@@ -52,10 +44,8 @@ public class HomeController : HumansControllerBase
         _shiftSignup = shiftSignup;
         _configuration = configuration;
         _clock = clock;
-        _dbContext = dbContext;
-        _vendorService = vendorService;
         _ticketSettings = ticketSettings.Value;
-        _cache = cache;
+        _ticketQueryService = ticketQueryService;
         _logger = logger;
     }
 
@@ -256,40 +246,9 @@ public class HomeController : HumansControllerBase
         {
             if (_ticketSettings.IsConfigured)
             {
-                // Check tickets matched by MatchedUserId (auto-matched during sync)
-                var attendeeCount = await _dbContext.TicketAttendees.CountAsync(a =>
-                    a.MatchedUserId == user.Id &&
-                    (a.Status == TicketAttendeeStatus.Valid || a.Status == TicketAttendeeStatus.CheckedIn));
-
-                var buyerCount = await _dbContext.TicketOrders.CountAsync(o =>
-                    o.MatchedUserId == user.Id);
-
-                // Also check all verified user emails for unmatched orders/attendees
-                if (attendeeCount == 0 && buyerCount == 0)
-                {
-                    var userEmails = await _dbContext.Set<Domain.Entities.UserEmail>()
-                        .Where(e => e.UserId == user.Id && e.IsVerified)
-                        .Select(e => e.Email)
-                        .ToListAsync();
-
-                    if (userEmails.Count > 0)
-                    {
-                        attendeeCount = await _dbContext.TicketAttendees.CountAsync(a =>
-                            a.AttendeeEmail != null &&
-                            userEmails.Contains(a.AttendeeEmail) &&
-                            (a.Status == TicketAttendeeStatus.Valid || a.Status == TicketAttendeeStatus.CheckedIn));
-
-                        if (attendeeCount == 0)
-                        {
-                            buyerCount = await _dbContext.TicketOrders.CountAsync(o =>
-                                userEmails.Contains(o.BuyerEmail));
-                        }
-                    }
-                }
-
-                var totalTickets = Math.Max(attendeeCount, buyerCount);
-                viewModel.HasTicket = totalTickets > 0;
-                viewModel.UserTicketCount = totalTickets;
+                var ticketCount = await _ticketQueryService.GetUserTicketCountAsync(user.Id);
+                viewModel.HasTicket = ticketCount > 0;
+                viewModel.UserTicketCount = ticketCount;
             }
         }
         catch (Exception ex)

--- a/src/Humans.Web/Controllers/TicketController.cs
+++ b/src/Humans.Web/Controllers/TicketController.cs
@@ -84,7 +84,7 @@ public class TicketController : HumansControllerBase
         var totalStripeFees = await paidOrders.SumAsync(o => (decimal?)o.StripeFee ?? 0m);
         var totalAppFees = await paidOrders.SumAsync(o => (decimal?)o.ApplicationFee ?? 0m);
         var netRevenue = revenue - totalStripeFees - totalAppFees;
-        var avgPrice = ticketsSold > 0 ? revenue / ticketsSold : 0;
+        var avgPrice = ticketsSold > 0 ? netRevenue / ticketsSold : 0;
         var unmatchedCount = await orders.CountAsync(o => o.MatchedUserId == null);
 
         // Fee breakdown by payment method (load in memory — small dataset)
@@ -198,12 +198,20 @@ public class TicketController : HumansControllerBase
             totalActiveVolunteers = await _dbContext.Set<TeamMember>()
                 .CountAsync(tm => tm.TeamId == volunteersTeamId && tm.LeftAt == null);
 
-            var validTicketUserIds = await _dbContext.TicketAttendees
+            var attendeeUserIds = await _dbContext.TicketAttendees
                 .Where(a => a.MatchedUserId != null &&
                     (a.Status == TicketAttendeeStatus.Valid || a.Status == TicketAttendeeStatus.CheckedIn))
                 .Select(a => a.MatchedUserId!.Value)
                 .Distinct()
                 .ToListAsync();
+
+            var buyerUserIds = await _dbContext.TicketOrders
+                .Where(o => o.MatchedUserId != null)
+                .Select(o => o.MatchedUserId!.Value)
+                .Distinct()
+                .ToListAsync();
+
+            var validTicketUserIds = attendeeUserIds.Union(buyerUserIds).ToList();
 
             volunteersWithTickets = await _dbContext.Set<TeamMember>()
                 .Where(tm => tm.TeamId == volunteersTeamId && tm.LeftAt == null)

--- a/src/Humans.Web/Controllers/TicketController.cs
+++ b/src/Humans.Web/Controllers/TicketController.cs
@@ -29,6 +29,7 @@ public class TicketController : HumansControllerBase
     private readonly HumansDbContext _dbContext;
     private readonly ITicketVendorService _vendorService;
     private readonly TicketVendorSettings _settings;
+    private readonly ITicketQueryService _ticketQueryService;
     private readonly IMemoryCache _cache;
     private readonly ILogger<TicketController> _logger;
 
@@ -36,6 +37,7 @@ public class TicketController : HumansControllerBase
         HumansDbContext dbContext,
         ITicketVendorService vendorService,
         IOptions<TicketVendorSettings> settings,
+        ITicketQueryService ticketQueryService,
         IMemoryCache cache,
         UserManager<User> userManager,
         ILogger<TicketController> logger)
@@ -44,6 +46,7 @@ public class TicketController : HumansControllerBase
         _dbContext = dbContext;
         _vendorService = vendorService;
         _settings = settings.Value;
+        _ticketQueryService = ticketQueryService;
         _cache = cache;
         _logger = logger;
     }
@@ -198,24 +201,11 @@ public class TicketController : HumansControllerBase
             totalActiveVolunteers = await _dbContext.Set<TeamMember>()
                 .CountAsync(tm => tm.TeamId == volunteersTeamId && tm.LeftAt == null);
 
-            var attendeeUserIds = await _dbContext.TicketAttendees
-                .Where(a => a.MatchedUserId != null &&
-                    (a.Status == TicketAttendeeStatus.Valid || a.Status == TicketAttendeeStatus.CheckedIn))
-                .Select(a => a.MatchedUserId!.Value)
-                .Distinct()
-                .ToListAsync();
-
-            var buyerUserIds = await _dbContext.TicketOrders
-                .Where(o => o.MatchedUserId != null)
-                .Select(o => o.MatchedUserId!.Value)
-                .Distinct()
-                .ToListAsync();
-
-            var validTicketUserIds = attendeeUserIds.Union(buyerUserIds).ToList();
+            var userIdsWithTickets = await _ticketQueryService.GetUserIdsWithTicketsAsync();
 
             volunteersWithTickets = await _dbContext.Set<TeamMember>()
                 .Where(tm => tm.TeamId == volunteersTeamId && tm.LeftAt == null)
-                .CountAsync(tm => validTicketUserIds.Contains(tm.UserId));
+                .CountAsync(tm => userIdsWithTickets.Contains(tm.UserId));
         }
 
         var volunteerCoveragePct = totalActiveVolunteers > 0

--- a/src/Humans.Web/Extensions/InfrastructureServiceCollectionExtensions.cs
+++ b/src/Humans.Web/Extensions/InfrastructureServiceCollectionExtensions.cs
@@ -135,6 +135,7 @@ public static class InfrastructureServiceCollectionExtensions
         });
         services.AddHttpClient<ITicketVendorService, TicketTailorService>();
         services.AddScoped<ITicketSyncService, TicketSyncService>();
+        services.AddScoped<ITicketQueryService, TicketQueryService>();
 
         // Stripe integration (read-only — fee tracking and payment method attribution)
         services.Configure<StripeSettings>(opts =>

--- a/src/Humans.Web/Models/DashboardViewModel.cs
+++ b/src/Humans.Web/Models/DashboardViewModel.cs
@@ -45,9 +45,9 @@ public class DashboardViewModel
     public DateTime MemberSince { get; set; }
     public DateTime? LastLogin { get; set; }
 
-    // Ticket summary
+    // Per-user ticket status
     public bool TicketsConfigured { get; set; }
-    public int TicketsSold { get; set; }
-    public int TicketCapacity { get; set; }
-    public decimal TicketCoveragePercent { get; set; }
+    public bool HasTicket { get; set; }
+    public int UserTicketCount { get; set; }
+    public string? TicketPurchaseUrl { get; set; }
 }

--- a/src/Humans.Web/Views/Home/Dashboard.cshtml
+++ b/src/Humans.Web/Views/Home/Dashboard.cshtml
@@ -212,40 +212,6 @@ else if (Model.PendingConsents > 0)
             </div>
         }
 
-        <div class="card mb-4">
-            <div class="card-header">
-                <i class="fa-solid fa-ticket me-1"></i> Your Ticket
-            </div>
-            <div class="card-body">
-                @if (!Model.TicketsConfigured)
-                {
-                    <div class="alert alert-warning mb-0">
-                        <i class="fa-solid fa-triangle-exclamation me-1"></i> Ticket vendor not configured. Contact an admin.
-                    </div>
-                }
-                else if (Model.HasTicket)
-                {
-                    <div class="d-flex align-items-center">
-                        <i class="fa-solid fa-circle-check text-success fs-3 me-3"></i>
-                        <div>
-                            <strong>Thanks for getting your ticket!</strong>
-                            @if (Model.UserTicketCount > 1)
-                            {
-                                <br /><span class="text-muted">You have @Model.UserTicketCount tickets</span>
-                            }
-                        </div>
-                    </div>
-                }
-                else
-                {
-                    <p class="mb-2">We don't see a ticket linked to your account yet.</p>
-                    <a href="@Model.TicketPurchaseUrl" target="_blank" rel="noopener" class="btn btn-primary">
-                        <i class="fa-solid fa-external-link-alt me-1"></i> Buy your ticket now
-                    </a>
-                }
-            </div>
-        </div>
-
         @if (Model.IsVolunteerMember)
         {
             @if (Model.MembershipTier != MembershipTier.Volunteer)
@@ -318,6 +284,40 @@ else if (Model.PendingConsents > 0)
     </div>
 
     <div class="col-md-4">
+        <div class="card mb-4">
+            <div class="card-header">
+                <i class="fa-solid fa-ticket me-1"></i> Your Ticket
+            </div>
+            <div class="card-body">
+                @if (!Model.TicketsConfigured)
+                {
+                    <div class="alert alert-warning mb-0">
+                        <i class="fa-solid fa-triangle-exclamation me-1"></i> Ticket vendor not configured. Contact an admin.
+                    </div>
+                }
+                else if (Model.HasTicket)
+                {
+                    <div class="d-flex align-items-center">
+                        <i class="fa-solid fa-circle-check text-success fs-3 me-3"></i>
+                        <div>
+                            <strong>Thanks for getting your ticket!</strong>
+                            @if (Model.UserTicketCount > 1)
+                            {
+                                <br /><span class="text-muted">You have @Model.UserTicketCount tickets</span>
+                            }
+                        </div>
+                    </div>
+                }
+                else
+                {
+                    <p class="mb-2">We don't see a ticket linked to your account yet.</p>
+                    <a href="@Model.TicketPurchaseUrl" target="_blank" rel="noopener" class="btn btn-primary">
+                        <i class="fa-solid fa-external-link-alt me-1"></i> Buy your ticket now
+                    </a>
+                }
+            </div>
+        </div>
+
         <div class="card mb-4">
             <div class="card-header">@Localizer["Dashboard_YourMembership"]</div>
             <div class="card-body">

--- a/src/Humans.Web/Views/Home/Dashboard.cshtml
+++ b/src/Humans.Web/Views/Home/Dashboard.cshtml
@@ -212,6 +212,39 @@ else if (Model.PendingConsents > 0)
             </div>
         }
 
+        <div class="card mb-4">
+            <div class="card-header">
+                <i class="fa-solid fa-ticket me-1"></i> Your Ticket
+            </div>
+            <div class="card-body">
+                @if (!Model.TicketsConfigured)
+                {
+                    <div class="alert alert-warning mb-0">
+                        <i class="fa-solid fa-triangle-exclamation me-1"></i> Ticket vendor not configured. Contact an admin.
+                    </div>
+                }
+                else if (Model.HasTicket)
+                {
+                    <div class="d-flex align-items-center">
+                        <i class="fa-solid fa-circle-check text-success fs-3 me-3"></i>
+                        <div>
+                            <strong>Thanks for getting your ticket!</strong>
+                            @if (Model.UserTicketCount > 1)
+                            {
+                                <br /><span class="text-muted">You have @Model.UserTicketCount tickets</span>
+                            }
+                        </div>
+                    </div>
+                }
+                else
+                {
+                    <p class="mb-2">We don't see a ticket linked to your account yet.</p>
+                    <a href="@Model.TicketPurchaseUrl" target="_blank" rel="noopener" class="btn btn-primary">
+                        <i class="fa-solid fa-external-link-alt me-1"></i> Buy your ticket now
+                    </a>
+                }
+            </div>
+        </div>
 
         @if (Model.IsVolunteerMember)
         {

--- a/src/Humans.Web/Views/Ticket/Index.cshtml
+++ b/src/Humans.Web/Views/Ticket/Index.cshtml
@@ -86,7 +86,7 @@
         <div class="col">
             <div class="card h-100">
                 <div class="card-body">
-                    <h6 class="card-subtitle mb-2 text-muted">Avg. Ticket Price</h6>
+                    <h6 class="card-subtitle mb-2 text-muted">Avg. Net Price</h6>
                     <h3 class="card-title">@Model.Currency @Model.AveragePrice.ToString("N2")</h3>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- **#265-AC4** — Volunteer ticket coverage now counts both buyers (`TicketOrder.MatchedUserId`) and attendees (`TicketAttendee.MatchedUserId`). Previously only checked attendees, missing buyers who weren't listed as attendees.
- **#266-AC2** — Average ticket price now uses net revenue (after Stripe + application fees) instead of gross. Label changed to "Avg. Net Price" for clarity.

## Spec Compliance
Found by running spec compliance review against PR #64:

| Issue | Criterion | Was | Now |
|-------|-----------|-----|-----|
| #265 | AC4: Counts distinct volunteers as matched buyer or attendee | PARTIAL (attendees only) | PASS |
| #266 | AC2: Price reflects net revenue / tickets sold | FAIL (used gross) | PASS |

## Test plan
- [ ] Verify volunteer coverage count on `/Ticket` dashboard includes buyers who are volunteers
- [ ] Verify average price card shows net amount (lower than gross revenue / tickets)
- [ ] Verify label reads "Avg. Net Price"

🤖 Generated with [Claude Code](https://claude.com/claude-code) spec-review