### PR TITLE
fix: Google group drift detection + budget year soft-delete

### DIFF
--- a/docs/features/31-budget.md
+++ b/docs/features/31-budget.md
@@ -71,6 +71,7 @@ BudgetYear ("2026", "2027-A", ...)
 - Each line item has: description, amount, responsible team (FK → Team), optional notes
 - CapEx/OpEx flag is on `BudgetCategory`, not line items
 - No arbitrary nesting beyond four levels
+- `BudgetYear` supports soft-delete (`IsDeleted`, `DeletedAt`): "deleting" a year archives it instead of removing data, preserving all audit log history. Archived years are hidden from non-admin views but remain visible on the Finance Admin page and in the audit log year filter.
 
 ### Budget Audit Log
 

--- a/src/Humans.Application/Interfaces/IBudgetService.cs
+++ b/src/Humans.Application/Interfaces/IBudgetService.cs
@@ -10,7 +10,7 @@ namespace Humans.Application.Interfaces;
 public interface IBudgetService
 {
     // Budget Years
-    Task<IReadOnlyList<BudgetYear>> GetAllYearsAsync();
+    Task<IReadOnlyList<BudgetYear>> GetAllYearsAsync(bool includeArchived = false);
     Task<BudgetYear?> GetYearByIdAsync(Guid id);
     Task<BudgetYear?> GetActiveYearAsync();
     Task<BudgetYear> CreateYearAsync(string year, string name, Guid actorUserId);

--- a/src/Humans.Domain/Entities/BudgetYear.cs
+++ b/src/Humans.Domain/Entities/BudgetYear.cs
@@ -14,6 +14,8 @@ public class BudgetYear
     public BudgetYearStatus Status { get; set; } = BudgetYearStatus.Draft;
     public Instant CreatedAt { get; init; }
     public Instant UpdatedAt { get; set; }
+    public bool IsDeleted { get; set; }
+    public Instant? DeletedAt { get; set; }
     public ICollection<BudgetGroup> Groups { get; } = new List<BudgetGroup>();
     public ICollection<BudgetAuditLog> AuditLogs { get; } = new List<BudgetAuditLog>();
 }

--- a/src/Humans.Infrastructure/Data/Configurations/BudgetYearConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/BudgetYearConfiguration.cs
@@ -17,6 +17,7 @@ public class BudgetYearConfiguration : IEntityTypeConfiguration<BudgetYear>
         builder.Property(b => b.Status).IsRequired().HasConversion<string>().HasMaxLength(50);
         builder.Property(b => b.CreatedAt).IsRequired();
         builder.Property(b => b.UpdatedAt).IsRequired();
+        builder.Property(b => b.DeletedAt);
 
         builder.HasMany(b => b.Groups).WithOne(g => g.BudgetYear).HasForeignKey(g => g.BudgetYearId).OnDelete(DeleteBehavior.Cascade);
         builder.HasMany(b => b.AuditLogs).WithOne(a => a.BudgetYear).HasForeignKey(a => a.BudgetYearId).OnDelete(DeleteBehavior.Restrict);

--- a/src/Humans.Infrastructure/Migrations/20260330191510_SoftDeleteBudgetYear.Designer.cs
+++ b/src/Humans.Infrastructure/Migrations/20260330191510_SoftDeleteBudgetYear.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Humans.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Humans.Infrastructure.Migrations
 {
     [DbContext(typeof(HumansDbContext))]
-    partial class HumansDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260330191510_SoftDeleteBudgetYear")]
+    partial class SoftDeleteBudgetYear
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Humans.Infrastructure/Migrations/20260330191510_SoftDeleteBudgetYear.cs
+++ b/src/Humans.Infrastructure/Migrations/20260330191510_SoftDeleteBudgetYear.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using NodaTime;
+
+#nullable disable
+
+namespace Humans.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class SoftDeleteBudgetYear : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Instant>(
+                name: "DeletedAt",
+                table: "budget_years",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsDeleted",
+                table: "budget_years",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DeletedAt",
+                table: "budget_years");
+
+            migrationBuilder.DropColumn(
+                name: "IsDeleted",
+                table: "budget_years");
+        }
+    }
+}

--- a/src/Humans.Infrastructure/Services/BudgetService.cs
+++ b/src/Humans.Infrastructure/Services/BudgetService.cs
@@ -30,11 +30,17 @@ public class BudgetService : IBudgetService
 
     // ───────────────────────── Budget Years ─────────────────────────
 
-    public async Task<IReadOnlyList<BudgetYear>> GetAllYearsAsync()
+    public async Task<IReadOnlyList<BudgetYear>> GetAllYearsAsync(bool includeArchived = false)
     {
-        return await _dbContext.BudgetYears
+        var query = _dbContext.BudgetYears
             .Include(y => y.Groups)
                 .ThenInclude(g => g.Categories)
+            .AsQueryable();
+
+        if (!includeArchived)
+            query = query.Where(y => !y.IsDeleted);
+
+        return await query
             .OrderByDescending(y => y.Year)
             .ToListAsync();
     }
@@ -54,7 +60,7 @@ public class BudgetService : IBudgetService
     public async Task<BudgetYear?> GetActiveYearAsync()
     {
         var activeYear = await _dbContext.BudgetYears
-            .FirstOrDefaultAsync(y => y.Status == BudgetYearStatus.Active);
+            .FirstOrDefaultAsync(y => y.Status == BudgetYearStatus.Active && !y.IsDeleted);
 
         if (activeYear is null)
             return null;
@@ -208,17 +214,21 @@ public class BudgetService : IBudgetService
         if (year.Status == BudgetYearStatus.Active)
             throw new InvalidOperationException("Cannot delete an active budget year. Close it first.");
 
-        // Remove audit logs first — FK to BudgetYearId is Restrict,
-        // so the year can't be deleted while audit entries reference it.
-        var auditLogs = await _dbContext.Set<BudgetAuditLog>()
-            .Where(a => a.BudgetYearId == yearId)
-            .ToListAsync();
-        _dbContext.Set<BudgetAuditLog>().RemoveRange(auditLogs);
+        var now = _clock.GetCurrentInstant();
 
-        _dbContext.BudgetYears.Remove(year);
+        // Soft-delete: mark as archived, preserve all data and audit logs
+        year.IsDeleted = true;
+        year.DeletedAt = now;
+        year.Status = BudgetYearStatus.Closed;
+        year.UpdatedAt = now;
+
+        LogAudit(year.Id, nameof(BudgetYear), year.Id,
+            $"Archived budget year '{year.Name}' ({year.Year})",
+            actorUserId, now);
+
         await _dbContext.SaveChangesAsync();
 
-        _logger.LogInformation("Deleted budget year {YearId} ({Year})", yearId, year.Year);
+        _logger.LogInformation("Archived budget year {YearId} ({Year})", yearId, year.Year);
     }
 
     public async Task<int> SyncDepartmentsAsync(Guid budgetYearId, Guid actorUserId)

--- a/src/Humans.Infrastructure/Services/GoogleWorkspaceSyncService.cs
+++ b/src/Humans.Infrastructure/Services/GoogleWorkspaceSyncService.cs
@@ -1817,21 +1817,13 @@ public class GoogleWorkspaceSyncService : IGoogleSyncService
                         Add("MaxMessageBytes", actual.MaxMessageBytes?.ToString(System.Globalization.CultureInfo.InvariantCulture));
 
                         // Compare against expected (only the enforced settings)
-                        CompareGroupSetting(drifts, "WhoCanJoin", _settings.Groups.WhoCanJoin, actual.WhoCanJoin);
-                        CompareGroupSetting(drifts, "WhoCanViewMembership", _settings.Groups.WhoCanViewMembership, actual.WhoCanViewMembership);
-                        CompareGroupSetting(drifts, "WhoCanContactOwner", _settings.Groups.WhoCanContactOwner, actual.WhoCanContactOwner);
-                        CompareGroupSetting(drifts, "WhoCanPostMessage", _settings.Groups.WhoCanPostMessage, actual.WhoCanPostMessage);
-                        CompareGroupSetting(drifts, "WhoCanViewGroup", _settings.Groups.WhoCanViewGroup, actual.WhoCanViewGroup);
-                        CompareGroupSetting(drifts, "WhoCanModerateMembers", _settings.Groups.WhoCanModerateMembers, actual.WhoCanModerateMembers);
-                        CompareGroupSetting(drifts, "AllowExternalMembers",
-                            _settings.Groups.AllowExternalMembers ? "true" : "false", actual.AllowExternalMembers);
-                        CompareGroupSetting(drifts, "IsArchived", "true", actual.IsArchived);
-                        CompareGroupSetting(drifts, "MembersCanPostAsTheGroup", "true", actual.MembersCanPostAsTheGroup);
-                        CompareGroupSetting(drifts, "IncludeInGlobalAddressList", "true", actual.IncludeInGlobalAddressList);
-                        CompareGroupSetting(drifts, "AllowWebPosting", "true", actual.AllowWebPosting);
-                        CompareGroupSetting(drifts, "MessageModerationLevel", "MODERATE_NONE", actual.MessageModerationLevel);
-                        CompareGroupSetting(drifts, "SpamModerationLevel", "MODERATE", actual.SpamModerationLevel);
-                        CompareGroupSetting(drifts, "EnableCollaborativeInbox", "false", actual.EnableCollaborativeInbox);
+                        // Uses the shared expectedSettings dictionary so creation, detection,
+                        // and remediation all agree on the same source of truth.
+                        foreach (var (key, expectedValue) in expectedSettings)
+                        {
+                            actualSettings.TryGetValue(key, out var actualValue);
+                            CompareGroupSetting(drifts, key, expectedValue, actualValue);
+                        }
                     }
                     catch (Google.GoogleApiException ex)
                     {

--- a/src/Humans.Web/Controllers/BudgetController.cs
+++ b/src/Humans.Web/Controllers/BudgetController.cs
@@ -256,6 +256,8 @@ public class BudgetController : HumansControllerBase
         var category = await _budgetService.GetCategoryByIdAsync(categoryId);
         if (category is null) return NotFound();
 
+        if (category.BudgetGroup?.BudgetYear?.IsDeleted == true) return NotFound();
+
         if (category.BudgetGroup?.IsRestricted == true)
             return Forbid();
 

--- a/src/Humans.Web/Controllers/FinanceController.cs
+++ b/src/Humans.Web/Controllers/FinanceController.cs
@@ -110,7 +110,7 @@ public class FinanceController : HumansControllerBase
 
             var entries = await _budgetService.GetAuditLogAsync(yearId);
             ViewBag.YearId = yearId;
-            ViewBag.Years = await _budgetService.GetAllYearsAsync();
+            ViewBag.Years = await _budgetService.GetAllYearsAsync(includeArchived: true);
             return View(entries);
         }
         catch (Exception ex)
@@ -126,7 +126,7 @@ public class FinanceController : HumansControllerBase
     {
         try
         {
-            var years = await _budgetService.GetAllYearsAsync();
+            var years = await _budgetService.GetAllYearsAsync(includeArchived: true);
             return View(years);
         }
         catch (Exception ex)

--- a/src/Humans.Web/Views/Finance/Admin.cshtml
+++ b/src/Humans.Web/Views/Finance/Admin.cshtml
@@ -56,6 +56,10 @@
             <div>
                 <strong>@budgetYear.Name</strong>
                 <span class="badge bg-@(budgetYear.Status == BudgetYearStatus.Active ? "success" : budgetYear.Status == BudgetYearStatus.Draft ? "warning" : "secondary") ms-2">@budgetYear.Status</span>
+                @if (budgetYear.IsDeleted)
+                {
+                    <span class="badge bg-dark ms-1">Archived</span>
+                }
             </div>
             <div class="d-flex gap-1">
                 <a asp-action="YearDetail" asp-route-id="@budgetYear.Id" class="btn btn-outline-primary btn-sm">
@@ -66,11 +70,18 @@
         <div class="card-body">
             <!-- Year Settings -->
             <div class="mb-3">
-                <button class="btn btn-outline-secondary btn-sm" type="button" data-bs-toggle="collapse" data-bs-target="#@yearEditId">
-                    <i class="fa-solid fa-pen me-1"></i>Edit Year
-                </button>
+                @if (!budgetYear.IsDeleted)
+                {
+                    <button class="btn btn-outline-secondary btn-sm" type="button" data-bs-toggle="collapse" data-bs-target="#@yearEditId">
+                        <i class="fa-solid fa-pen me-1"></i>Edit Year
+                    </button>
+                }
 
-                @if (budgetYear.Status == BudgetYearStatus.Draft)
+                @if (budgetYear.IsDeleted)
+                {
+                    <span class="text-muted small">Archived — audit logs preserved</span>
+                }
+                else if (budgetYear.Status == BudgetYearStatus.Draft)
                 {
                     <form asp-action="UpdateYearStatus" asp-route-id="@budgetYear.Id" method="post" class="d-inline">
                         @Html.AntiForgeryToken()
@@ -81,8 +92,8 @@
                     </form>
                     <form asp-action="DeleteYear" asp-route-id="@budgetYear.Id" method="post" class="d-inline">
                         @Html.AntiForgeryToken()
-                        <button type="submit" class="btn btn-outline-danger btn-sm" onclick="return confirm('Delete this budget year and all its data?')">
-                            <i class="fa-solid fa-trash me-1"></i>Delete
+                        <button type="submit" class="btn btn-outline-danger btn-sm" onclick="return confirm('Archive this budget year? It will be hidden from non-admin views but audit logs will be preserved.')">
+                            <i class="fa-solid fa-box-archive me-1"></i>Archive
                         </button>
                     </form>
                 }
@@ -107,8 +118,8 @@
                     </form>
                     <form asp-action="DeleteYear" asp-route-id="@budgetYear.Id" method="post" class="d-inline">
                         @Html.AntiForgeryToken()
-                        <button type="submit" class="btn btn-outline-danger btn-sm" onclick="return confirm('Delete this budget year and all its data?')">
-                            <i class="fa-solid fa-trash me-1"></i>Delete
+                        <button type="submit" class="btn btn-outline-danger btn-sm" onclick="return confirm('Archive this budget year? It will be hidden from non-admin views but audit logs will be preserved.')">
+                            <i class="fa-solid fa-box-archive me-1"></i>Archive
                         </button>
                     </form>
                 }

--- a/src/Humans.Web/Views/Finance/AuditLog.cshtml
+++ b/src/Humans.Web/Views/Finance/AuditLog.cshtml
@@ -25,7 +25,7 @@
                         <option value="">All Years</option>
                         @foreach (var y in years)
                         {
-                            <option value="@y.Id" selected="@(yearId == y.Id)">@y.Name</option>
+                            <option value="@y.Id" selected="@(yearId == y.Id)">@y.Name@(y.IsDeleted ? " (Archived)" : "")</option>
                         }
                     </select>
                 </div>


### PR DESCRIPTION
## Summary
- **#229** — Fix Google Group EnableCollaborativeInbox drift by replacing hardcoded expected values in GetAllDomainGroupsAsync with the shared BuildExpectedSettingsDictionary(), ensuring creation, detection, and remediation all use the same source of truth
- **#270** — Replace destructive budget year deletion with soft-delete (IsDeleted/DeletedAt). Archived years preserve all audit log history, are hidden from non-admin views, but remain visible on Finance Admin and Audit Log pages

## Spec Compliance
All acceptance criteria verified per-issue during implementation.
- #229: PASS (4/4 criteria)
- #270: PASS (3/3 criteria + comment guidance)

## Code Review
Self-reviewed against CODE_REVIEW_RULES.md. No critical issues. Pre-existing boolean attribute patterns (selected, onclick) noted but not introduced by this batch.

## Test plan
- [ ] Deploy to QA and verify /Admin/AllGroups shows no EnableCollaborativeInbox drift (all 43 groups should be clean after next recon run)
- [ ] Remediate one drifted group via /Admin/AllGroups and confirm drift clears
- [ ] Create a test budget year on /Finance/Admin, archive it, verify it shows "Archived" badge
- [ ] Verify archived year is hidden from /Finance year picker and coordinator budget views
- [ ] Verify archived year's audit logs are still accessible at /Finance/AuditLog with year filter
- [ ] Verify EF migration applies cleanly: `dotnet ef database update`

🤖 Generated with [Claude Code](https://claude.com/claude-code) sprint swarm