### PR TITLE
fix: batch bug fixes from Codex code review

### DIFF
--- a/src/Humans.Infrastructure/Jobs/ProcessEmailOutboxJob.cs
+++ b/src/Humans.Infrastructure/Jobs/ProcessEmailOutboxJob.cs
@@ -92,6 +92,7 @@ public class ProcessEmailOutboxJob : IRecurringJob
                     _logger.LogInformation(
                         "Skipped email {MessageId} to test address {Email}",
                         message.Id, message.RecipientEmail);
+                    await _dbContext.SaveChangesAsync(cancellationToken);
                     continue;
                 }
 
@@ -129,6 +130,8 @@ public class ProcessEmailOutboxJob : IRecurringJob
                     }
                 }
 
+                await _dbContext.SaveChangesAsync(cancellationToken);
+
                 // Throttle: 1 second delay between sends to avoid SMTP rate limits
                 await Task.Delay(1000, cancellationToken);
             }
@@ -162,18 +165,17 @@ public class ProcessEmailOutboxJob : IRecurringJob
                     message.Id,
                     message.TemplateName,
                     message.RetryCount);
+
+                await _dbContext.SaveChangesAsync(cancellationToken);
             }
         }
 
-        // 5. Save all changes
-        await _dbContext.SaveChangesAsync(cancellationToken);
-
-        // 6. Set outbox_pending gauge
+        // 5. Set outbox_pending gauge
         var pendingCount = await _dbContext.EmailOutboxMessages
             .CountAsync(m => m.SentAt == null && m.RetryCount < _settings.OutboxMaxRetries, cancellationToken);
         _metrics.SetEmailOutboxPending(pendingCount);
 
-        // 7. Record successful job run
+        // 6. Record successful job run
         _metrics.RecordJobRun("process_email_outbox", "success");
     }
 }

--- a/src/Humans.Infrastructure/Jobs/ProcessGoogleSyncOutboxJob.cs
+++ b/src/Humans.Infrastructure/Jobs/ProcessGoogleSyncOutboxJob.cs
@@ -77,6 +77,7 @@ public class ProcessGoogleSyncOutboxJob : IRecurringJob
                 outboxEvent.ProcessedAt = _clock.GetCurrentInstant();
                 outboxEvent.LastError = null;
                 _metrics.RecordSyncOperation("success");
+                await _dbContext.SaveChangesAsync(cancellationToken);
             }
             catch (Exception ex)
             {
@@ -92,10 +93,10 @@ public class ProcessGoogleSyncOutboxJob : IRecurringJob
                     outboxEvent.Id,
                     outboxEvent.EventType,
                     outboxEvent.RetryCount);
+
+                await _dbContext.SaveChangesAsync(cancellationToken);
             }
         }
-
-        await _dbContext.SaveChangesAsync(cancellationToken);
         _metrics.RecordJobRun("process_google_sync_outbox", "success");
     }
 }

--- a/src/Humans.Infrastructure/Services/CommunicationPreferenceService.cs
+++ b/src/Humans.Infrastructure/Services/CommunicationPreferenceService.cs
@@ -194,7 +194,7 @@ public class CommunicationPreferenceService : ICommunicationPreferenceService
     {
         var token = GenerateUnsubscribeToken(userId, category);
         var oneClickUrl = $"{_baseUrl}/Unsubscribe/OneClick?token={WebUtility.UrlEncode(token)}";
-        var browserUrl = $"{_baseUrl}/Unsubscribe/{token}";
+        var browserUrl = $"{_baseUrl}/Unsubscribe/{Uri.EscapeDataString(token)}";
 
         return new Dictionary<string, string>(StringComparer.Ordinal)
         {

--- a/src/Humans.Infrastructure/Services/ContactService.cs
+++ b/src/Humans.Infrastructure/Services/ContactService.cs
@@ -42,10 +42,30 @@ public class ContactService : IContactService
         string? externalSourceId = null, CancellationToken ct = default)
     {
         var normalizedEmail = EmailNormalization.NormalizeForComparison(email);
+        var alternateEmail = GetAlternateComparableEmail(normalizedEmail);
 
         // Check for existing user with this email
-        var existingUser = await _dbContext.Users
-            .FirstOrDefaultAsync(u => u.NormalizedEmail == normalizedEmail.ToUpperInvariant(), ct);
+        User? existingUser;
+        if (alternateEmail is null)
+        {
+            existingUser = await _dbContext.Users
+                .FirstOrDefaultAsync(u =>
+                    (u.Email != null && EF.Functions.ILike(u.Email, normalizedEmail)) ||
+                    (u.GoogleEmail != null && EF.Functions.ILike(u.GoogleEmail, normalizedEmail)),
+                    ct);
+        }
+        else
+        {
+            existingUser = await _dbContext.Users
+                .FirstOrDefaultAsync(u =>
+                    (u.Email != null && (
+                        EF.Functions.ILike(u.Email, normalizedEmail) ||
+                        EF.Functions.ILike(u.Email, alternateEmail))) ||
+                    (u.GoogleEmail != null && (
+                        EF.Functions.ILike(u.GoogleEmail, normalizedEmail) ||
+                        EF.Functions.ILike(u.GoogleEmail, alternateEmail))),
+                    ct);
+        }
 
         if (existingUser is not null)
         {
@@ -60,10 +80,22 @@ public class ContactService : IContactService
         }
 
         // Also check UserEmails table
-        var existingUserEmail = await _dbContext.UserEmails
-            .Include(ue => ue.User)
-            .FirstOrDefaultAsync(ue => ue.IsVerified &&
-                EF.Functions.ILike(ue.Email, email), ct);
+        UserEmail? existingUserEmail;
+        if (alternateEmail is null)
+        {
+            existingUserEmail = await _dbContext.UserEmails
+                .Include(ue => ue.User)
+                .FirstOrDefaultAsync(ue => ue.IsVerified &&
+                    EF.Functions.ILike(ue.Email, normalizedEmail), ct);
+        }
+        else
+        {
+            existingUserEmail = await _dbContext.UserEmails
+                .Include(ue => ue.User)
+                .FirstOrDefaultAsync(ue => ue.IsVerified &&
+                    (EF.Functions.ILike(ue.Email, normalizedEmail) ||
+                     EF.Functions.ILike(ue.Email, alternateEmail)), ct);
+        }
 
         if (existingUserEmail is not null)
         {
@@ -126,6 +158,16 @@ public class ContactService : IContactService
             user.Id, email, source);
 
         return user;
+    }
+
+    private static string? GetAlternateComparableEmail(string normalizedEmail)
+    {
+        if (normalizedEmail.EndsWith("@gmail.com", StringComparison.Ordinal))
+        {
+            return $"{normalizedEmail[..^"@gmail.com".Length]}@googlemail.com";
+        }
+
+        return null;
     }
 
     public async Task<IReadOnlyList<AdminContactRow>> GetFilteredContactsAsync(

--- a/src/Humans.Infrastructure/Services/GoogleWorkspaceSyncService.cs
+++ b/src/Humans.Infrastructure/Services/GoogleWorkspaceSyncService.cs
@@ -1277,7 +1277,7 @@ public class GoogleWorkspaceSyncService : IGoogleSyncService
         var existingActiveByEmail = await _dbContext.GoogleResources
             .Include(r => r.Team)
             .Where(r => r.IsActive && r.ResourceType == GoogleResourceType.Group)
-            .Where(r => r.Url != null && string.Equals(r.Url, expectedUrl, StringComparison.OrdinalIgnoreCase))
+            .Where(r => r.Url != null && EF.Functions.ILike(r.Url!, expectedUrl))
             .FirstOrDefaultAsync(cancellationToken);
 
         if (existingActiveByEmail is not null)
@@ -1291,7 +1291,7 @@ public class GoogleWorkspaceSyncService : IGoogleSyncService
         // Check for inactive resource for this team (reactivation scenario) BEFORE deactivating anything
         var inactiveForTeam = await _dbContext.GoogleResources
             .Where(r => !r.IsActive && r.ResourceType == GoogleResourceType.Group && r.TeamId == teamId)
-            .Where(r => r.Url != null && string.Equals(r.Url, expectedUrl, StringComparison.OrdinalIgnoreCase))
+            .Where(r => r.Url != null && EF.Functions.ILike(r.Url!, expectedUrl))
             .FirstOrDefaultAsync(cancellationToken);
 
         if (inactiveForTeam is not null && !confirmReactivation)

--- a/src/Humans.Infrastructure/Services/GoogleWorkspaceSyncService.cs
+++ b/src/Humans.Infrastructure/Services/GoogleWorkspaceSyncService.cs
@@ -1277,7 +1277,7 @@ public class GoogleWorkspaceSyncService : IGoogleSyncService
         var existingActiveByEmail = await _dbContext.GoogleResources
             .Include(r => r.Team)
             .Where(r => r.IsActive && r.ResourceType == GoogleResourceType.Group)
-            .Where(r => r.Url != null && r.Url.EndsWith($"/g/{team.GoogleGroupPrefix}"))
+            .Where(r => r.Url != null && string.Equals(r.Url, expectedUrl, StringComparison.OrdinalIgnoreCase))
             .FirstOrDefaultAsync(cancellationToken);
 
         if (existingActiveByEmail is not null)
@@ -1291,7 +1291,7 @@ public class GoogleWorkspaceSyncService : IGoogleSyncService
         // Check for inactive resource for this team (reactivation scenario) BEFORE deactivating anything
         var inactiveForTeam = await _dbContext.GoogleResources
             .Where(r => !r.IsActive && r.ResourceType == GoogleResourceType.Group && r.TeamId == teamId)
-            .Where(r => r.Url != null && r.Url.EndsWith($"/g/{team.GoogleGroupPrefix}"))
+            .Where(r => r.Url != null && string.Equals(r.Url, expectedUrl, StringComparison.OrdinalIgnoreCase))
             .FirstOrDefaultAsync(cancellationToken);
 
         if (inactiveForTeam is not null && !confirmReactivation)

--- a/src/Humans.Infrastructure/Services/TicketSyncService.cs
+++ b/src/Humans.Infrastructure/Services/TicketSyncService.cs
@@ -404,12 +404,23 @@ public class TicketSyncService : ITicketSyncService
         return result;
     }
 
-    private static TicketAttendeeStatus ParseAttendeeStatus(string status) =>
-        status.ToLowerInvariant() switch
+    private TicketAttendeeStatus ParseAttendeeStatus(string status)
+    {
+        var result = status.ToLowerInvariant() switch
         {
             "valid" or "active" => TicketAttendeeStatus.Valid,
             "void" or "voided" => TicketAttendeeStatus.Void,
             "checked_in" => TicketAttendeeStatus.CheckedIn,
-            _ => TicketAttendeeStatus.Valid
+            _ => TicketAttendeeStatus.Void
         };
+
+        if (result == TicketAttendeeStatus.Void &&
+            !string.Equals(status, "void", StringComparison.OrdinalIgnoreCase) &&
+            !string.Equals(status, "voided", StringComparison.OrdinalIgnoreCase))
+        {
+            _logger.LogWarning("Unknown attendee status '{Status}' from vendor, defaulting to Void", status);
+        }
+
+        return result;
+    }
 }

--- a/src/Humans.Infrastructure/Services/TicketSyncService.cs
+++ b/src/Humans.Infrastructure/Services/TicketSyncService.cs
@@ -3,6 +3,7 @@ using Humans.Application.Interfaces;
 using Humans.Application;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
+using Humans.Domain.Helpers;
 using Humans.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
@@ -156,14 +157,14 @@ public class TicketSyncService : ITicketSyncService
     private async Task<Dictionary<string, Guid>> BuildEmailLookupAsync(CancellationToken ct)
     {
         // Match against ALL user emails (OAuth, verified, unverified)
-        // Case-insensitive via OrdinalIgnoreCase dictionary and GroupBy
+        // Normalize for comparison so gmail/googlemail aliases resolve to the same human.
         // If multiple users share same email, prefer the one where it's the OAuth email
         var userEmails = await _dbContext.Set<UserEmail>()
             .Select(ue => new { ue.Email, ue.UserId, ue.IsOAuth })
             .ToListAsync(ct);
 
-        var lookup = new Dictionary<string, Guid>(StringComparer.OrdinalIgnoreCase);
-        var grouped = userEmails.GroupBy(e => e.Email, StringComparer.OrdinalIgnoreCase);
+        var lookup = new Dictionary<string, Guid>(NormalizingEmailComparer.Instance);
+        var grouped = userEmails.GroupBy(e => e.Email, NormalizingEmailComparer.Instance);
         foreach (var group in grouped)
         {
             var entries = group.ToList();
@@ -382,7 +383,9 @@ public class TicketSyncService : ITicketSyncService
     }
 
     private static Guid? LookupUserId(Dictionary<string, Guid> lookup, string? email) =>
-        email is not null && lookup.TryGetValue(email, out var userId) ? userId : null;
+        email is not null && lookup.TryGetValue(EmailNormalization.NormalizeForComparison(email), out var userId)
+            ? userId
+            : null;
 
     private TicketPaymentStatus ParsePaymentStatus(string status)
     {

--- a/src/Humans.Infrastructure/Services/UserEmailService.cs
+++ b/src/Humans.Infrastructure/Services/UserEmailService.cs
@@ -525,7 +525,14 @@ public class UserEmailService : IUserEmailService
                 && ue.IsVerified
                 && EF.Functions.ILike(ue.Email, "%@nobodies.team"))
             .GroupBy(ue => ue.UserId)
-            .Select(g => new { UserId = g.Key, Email = g.First().Email })
+            .Select(g => new
+            {
+                UserId = g.Key,
+                Email = g.OrderByDescending(ue => ue.IsNotificationTarget)
+                    .ThenBy(ue => ue.CreatedAt)
+                    .Select(ue => ue.Email)
+                    .First()
+            })
             .ToDictionaryAsync(x => x.UserId, x => x.Email, cancellationToken);
     }
 

--- a/src/Humans.Infrastructure/Services/UserEmailService.cs
+++ b/src/Humans.Infrastructure/Services/UserEmailService.cs
@@ -98,6 +98,8 @@ public class UserEmailService : IUserEmailService
         CancellationToken cancellationToken = default)
     {
         email = email.Trim();
+        var normalizedEmail = EmailNormalization.NormalizeForComparison(email);
+        var alternateEmail = GetAlternateComparableEmail(normalizedEmail);
 
         // Validate email format
         if (!new EmailAddressAttribute().IsValid(email))
@@ -106,8 +108,15 @@ public class UserEmailService : IUserEmailService
         }
 
         // Check if this email already exists for this user
-        var existingForUser = await _dbContext.UserEmails
-            .AnyAsync(e => e.UserId == userId && EF.Functions.ILike(e.Email, email), cancellationToken);
+        var existingForUser = alternateEmail is null
+            ? await _dbContext.UserEmails.AnyAsync(
+                e => e.UserId == userId && EF.Functions.ILike(e.Email, normalizedEmail),
+                cancellationToken)
+            : await _dbContext.UserEmails.AnyAsync(
+                e => e.UserId == userId &&
+                    (EF.Functions.ILike(e.Email, normalizedEmail) ||
+                     EF.Functions.ILike(e.Email, alternateEmail)),
+                cancellationToken);
 
         if (existingForUser)
         {
@@ -115,10 +124,18 @@ public class UserEmailService : IUserEmailService
         }
 
         // Check if there's already a pending merge request for this email from this user
-        var pendingMerge = await _dbContext.AccountMergeRequests
-            .AnyAsync(r => r.TargetUserId == userId
-                && EF.Functions.ILike(r.Email, email)
-                && r.Status == AccountMergeRequestStatus.Pending, cancellationToken);
+        var pendingMerge = alternateEmail is null
+            ? await _dbContext.AccountMergeRequests.AnyAsync(
+                r => r.TargetUserId == userId
+                    && EF.Functions.ILike(r.Email, normalizedEmail)
+                    && r.Status == AccountMergeRequestStatus.Pending,
+                cancellationToken)
+            : await _dbContext.AccountMergeRequests.AnyAsync(
+                r => r.TargetUserId == userId
+                    && (EF.Functions.ILike(r.Email, normalizedEmail) ||
+                        EF.Functions.ILike(r.Email, alternateEmail))
+                    && r.Status == AccountMergeRequestStatus.Pending,
+                cancellationToken);
 
         if (pendingMerge)
         {
@@ -127,14 +144,21 @@ public class UserEmailService : IUserEmailService
 
         // Check uniqueness among verified emails (case-insensitive)
         // Instead of blocking, flag as conflict for merge flow
-        var isConflict = await _dbContext.UserEmails
-            .AnyAsync(e => e.UserId != userId && e.IsVerified && EF.Functions.ILike(e.Email, email), cancellationToken);
+        var isConflict = alternateEmail is null
+            ? await _dbContext.UserEmails.AnyAsync(
+                e => e.UserId != userId && e.IsVerified && EF.Functions.ILike(e.Email, normalizedEmail),
+                cancellationToken)
+            : await _dbContext.UserEmails.AnyAsync(
+                e => e.UserId != userId && e.IsVerified &&
+                    (EF.Functions.ILike(e.Email, normalizedEmail) ||
+                     EF.Functions.ILike(e.Email, alternateEmail)),
+                cancellationToken);
 
         var user = await _userManager.FindByIdAsync(userId.ToString())
             ?? throw new InvalidOperationException("User not found.");
 
         // Check if same as OAuth login email
-        if (string.Equals(email, user.Email, StringComparison.OrdinalIgnoreCase))
+        if (EmailNormalization.EmailsMatch(email, user.Email))
         {
             throw new ValidationException("This is already your sign-in email.");
         }
@@ -202,10 +226,16 @@ public class UserEmailService : IUserEmailService
         }
 
         // Check if this email is verified on another account
-        var conflictingEmail = await _dbContext.UserEmails
-            .FirstOrDefaultAsync(e => e.Id != pendingEmail.Id
+        var normalizedPendingEmail = EmailNormalization.NormalizeForComparison(pendingEmail.Email);
+        var alternatePendingEmail = GetAlternateComparableEmail(normalizedPendingEmail);
+        var conflictingEmail = alternatePendingEmail is null
+            ? await _dbContext.UserEmails.FirstOrDefaultAsync(e => e.Id != pendingEmail.Id
                 && e.IsVerified
-                && EF.Functions.ILike(e.Email, pendingEmail.Email), cancellationToken);
+                && EF.Functions.ILike(e.Email, normalizedPendingEmail), cancellationToken)
+            : await _dbContext.UserEmails.FirstOrDefaultAsync(e => e.Id != pendingEmail.Id
+                && e.IsVerified
+                && (EF.Functions.ILike(e.Email, normalizedPendingEmail) ||
+                    EF.Functions.ILike(e.Email, alternatePendingEmail)), cancellationToken);
 
         if (conflictingEmail is not null)
         {
@@ -361,10 +391,19 @@ public class UserEmailService : IUserEmailService
         string email,
         CancellationToken cancellationToken = default)
     {
+        var normalizedEmail = EmailNormalization.NormalizeForComparison(email);
+        var alternateEmail = GetAlternateComparableEmail(normalizedEmail);
+
         // Skip if email already exists for this user
-        var exists = await _dbContext.UserEmails
-            .AnyAsync(ue => ue.UserId == userId
-                && EF.Functions.ILike(ue.Email, email), cancellationToken);
+        var exists = alternateEmail is null
+            ? await _dbContext.UserEmails.AnyAsync(
+                ue => ue.UserId == userId && EF.Functions.ILike(ue.Email, normalizedEmail),
+                cancellationToken)
+            : await _dbContext.UserEmails.AnyAsync(
+                ue => ue.UserId == userId &&
+                    (EF.Functions.ILike(ue.Email, normalizedEmail) ||
+                     EF.Functions.ILike(ue.Email, alternateEmail)),
+                cancellationToken);
         if (exists)
             return;
 
@@ -502,4 +541,15 @@ public class UserEmailService : IUserEmailService
             ContactFieldVisibility.MyTeams => [ContactFieldVisibility.MyTeams, ContactFieldVisibility.AllActiveProfiles],
             _ => [ContactFieldVisibility.AllActiveProfiles]
         };
+
+    private static string? GetAlternateComparableEmail(string normalizedEmail)
+    {
+        if (normalizedEmail.EndsWith("@gmail.com", StringComparison.Ordinal))
+            return $"{normalizedEmail[..^"@gmail.com".Length]}@googlemail.com";
+
+        if (normalizedEmail.EndsWith("@googlemail.com", StringComparison.Ordinal))
+            return $"{normalizedEmail[..^"@googlemail.com".Length]}@gmail.com";
+
+        return null;
+    }
 }

--- a/src/Humans.Web/Controllers/FeedbackApiController.cs
+++ b/src/Humans.Web/Controllers/FeedbackApiController.cs
@@ -131,6 +131,10 @@ public class FeedbackApiController : ControllerBase
                 CreatedAt = message.CreatedAt.ToDateTimeUtc()
             });
         }
+        catch (InvalidOperationException)
+        {
+            return NotFound();
+        }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to post message on feedback {FeedbackId}", id);
@@ -146,6 +150,10 @@ public class FeedbackApiController : ControllerBase
             await _feedbackService.UpdateStatusAsync(id, model.Status, null);
             return Ok(new { success = true });
         }
+        catch (InvalidOperationException)
+        {
+            return NotFound();
+        }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to update feedback {FeedbackId} status", id);
@@ -160,6 +168,10 @@ public class FeedbackApiController : ControllerBase
         {
             await _feedbackService.SetGitHubIssueNumberAsync(id, model.IssueNumber);
             return Ok(new { success = true });
+        }
+        catch (InvalidOperationException)
+        {
+            return NotFound();
         }
         catch (Exception ex)
         {

--- a/src/Humans.Web/Controllers/FeedbackController.cs
+++ b/src/Humans.Web/Controllers/FeedbackController.cs
@@ -151,6 +151,10 @@ public class FeedbackController : HumansControllerBase
             await _feedbackService.PostMessageAsync(id, user.Id, model.Content, isAdmin);
             SetSuccess("Message posted.");
         }
+        catch (InvalidOperationException)
+        {
+            return NotFound();
+        }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to post message on feedback {FeedbackId}", id);
@@ -173,6 +177,10 @@ public class FeedbackController : HumansControllerBase
             await _feedbackService.UpdateStatusAsync(id, model.Status, user.Id);
             SetSuccess("Status updated.");
         }
+        catch (InvalidOperationException)
+        {
+            return NotFound();
+        }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to update feedback {FeedbackId} status", id);
@@ -191,6 +199,10 @@ public class FeedbackController : HumansControllerBase
         {
             await _feedbackService.SetGitHubIssueNumberAsync(id, model.IssueNumber);
             SetSuccess("GitHub issue linked.");
+        }
+        catch (InvalidOperationException)
+        {
+            return NotFound();
         }
         catch (Exception ex)
         {

--- a/src/Humans.Web/Controllers/TeamController.cs
+++ b/src/Humans.Web/Controllers/TeamController.cs
@@ -12,6 +12,7 @@ using Humans.Web.Extensions;
 using Humans.Web.Helpers;
 using Humans.Web.Models;
 using Microsoft.AspNetCore.Identity;
+using NodaTime;
 
 namespace Humans.Web.Controllers;
 
@@ -27,6 +28,7 @@ public class TeamController : HumansControllerBase
     private readonly IStringLocalizer<SharedResource> _localizer;
     private readonly IConfiguration _configuration;
     private readonly ILogger<TeamController> _logger;
+    private readonly IClock _clock;
 
     public TeamController(
         ITeamService teamService,
@@ -37,6 +39,7 @@ public class TeamController : HumansControllerBase
         ISystemTeamSync systemTeamSync,
         IStringLocalizer<SharedResource> localizer,
         IConfiguration configuration,
+        IClock clock,
         ILogger<TeamController> logger)
         : base(userManager)
     {
@@ -47,6 +50,7 @@ public class TeamController : HumansControllerBase
         _systemTeamSync = systemTeamSync;
         _localizer = localizer;
         _configuration = configuration;
+        _clock = clock;
         _logger = logger;
     }
 
@@ -267,9 +271,10 @@ public class TeamController : HumansControllerBase
             return currentUserError;
         }
 
-        var currentMonth = month ?? DateTime.UtcNow.Month;
+        var currentZone = HttpContext.Session.GetUserTimeZone();
+        var currentMonth = month ?? _clock.GetCurrentInstant().InZone(currentZone).Month;
         if (currentMonth < 1 || currentMonth > 12)
-            currentMonth = DateTime.UtcNow.Month;
+            currentMonth = _clock.GetCurrentInstant().InZone(currentZone).Month;
 
         // Load all active profiles that have a date of birth
         var profilesWithBirthdays = await _profileService.GetBirthdayProfilesAsync(currentMonth);

--- a/src/Humans.Web/Models/ShiftViewModels.cs
+++ b/src/Humans.Web/Models/ShiftViewModels.cs
@@ -146,7 +146,7 @@ public class ShiftBrowseViewModel
     /// <summary>
     /// All available tags for the filter UI.
     /// </summary>
-    public List<ShiftTag> AllTags { get; set; } = [];
+    public List<Humans.Domain.Entities.ShiftTag> AllTags { get; set; } = [];
 
     /// <summary>
     /// Currently selected tag IDs for filtering.
@@ -233,7 +233,7 @@ public class ShiftAdminViewModel
     /// <summary>
     /// All available tags for the tag picker UI.
     /// </summary>
-    public List<ShiftTag> AllTags { get; set; } = [];
+    public List<Humans.Domain.Entities.ShiftTag> AllTags { get; set; } = [];
 }
 
 // === Homepage ===

--- a/src/Humans.Web/Views/Camp/Edit.cshtml
+++ b/src/Humans.Web/Views/Camp/Edit.cshtml
@@ -308,7 +308,7 @@
                                         {
                                             <input type="hidden" name="imageIds" value="@id" />
                                         }
-                                        <button type="submit" class="btn btn-sm btn-outline-secondary" title="Move up" @(currentIdx == 0 ? "disabled" : "")>
+                                        <button type="submit" class="btn btn-sm btn-outline-secondary" title="Move up" @(currentIdx == 0 ? "disabled" : null)>
                                             <i class="fa-solid fa-arrow-up"></i>
                                         </button>
                                     </form>
@@ -326,7 +326,7 @@
                                         {
                                             <input type="hidden" name="imageIds" value="@id" />
                                         }
-                                        <button type="submit" class="btn btn-sm btn-outline-secondary" title="Move down" @(downIdx == Model.Images.Count - 1 ? "disabled" : "")>
+                                        <button type="submit" class="btn btn-sm btn-outline-secondary" title="Move down" @(downIdx == Model.Images.Count - 1 ? "disabled" : null)>
                                             <i class="fa-solid fa-arrow-down"></i>
                                         </button>
                                     </form>

--- a/src/Humans.Web/Views/Finance/Admin.cshtml
+++ b/src/Humans.Web/Views/Finance/Admin.cshtml
@@ -192,7 +192,7 @@
                                 <div class="col-md-3">
                                     <div class="form-check mt-4">
                                         <input type="hidden" name="isRestricted" value="false" />
-                                        <input class="form-check-input" type="checkbox" name="isRestricted" value="true" id="restricted-@group.Id" @(group.IsRestricted ? "checked" : "") />
+                                        <input class="form-check-input" type="checkbox" name="isRestricted" value="true" id="restricted-@group.Id" @(group.IsRestricted ? "checked" : null) />
                                         <label class="form-check-label" for="restricted-@group.Id">Restricted</label>
                                     </div>
                                 </div>

--- a/src/Humans.Web/Views/Finance/AuditLog.cshtml
+++ b/src/Humans.Web/Views/Finance/AuditLog.cshtml
@@ -25,7 +25,7 @@
                         <option value="">All Years</option>
                         @foreach (var y in years)
                         {
-                            <option value="@y.Id" selected="@(yearId == y.Id)">@y.Name@(y.IsDeleted ? " (Archived)" : "")</option>
+                            <option value="@y.Id" selected="@(yearId == y.Id ? "selected" : null)">@y.Name@(y.IsDeleted ? " (Archived)" : "")</option>
                         }
                     </select>
                 </div>

--- a/src/Humans.Web/Views/Home/Privacy.cshtml
+++ b/src/Humans.Web/Views/Home/Privacy.cshtml
@@ -5,8 +5,6 @@
 
 <p class="lead">Humans manages membership for Nobodies Collective and processes personal data in accordance with GDPR and Spanish data protection law (LOPDGDD).</p>
 
-<p><em>Last updated: @DateTime.UtcNow.ToDisplayMonthYear()</em></p>
-
 <h2>Data Controller</h2>
 <p>
     <strong>Nobodies Collective</strong><br />

--- a/src/Humans.Web/Views/Profile/Edit.cshtml
+++ b/src/Humans.Web/Views/Profile/Edit.cshtml
@@ -317,6 +317,10 @@
                             var isAsociado = Model.SelectedTier == MembershipTier.Asociado;
                         }
                         <div class="mb-3">
+                            @if (Model.IsTierLocked)
+                            {
+                                <input type="hidden" asp-for="SelectedTier" />
+                            }
                             <div class="form-check mb-3">
                                 @if (Model.IsTierLocked)
                                 {

--- a/src/Humans.Web/Views/Profile/Notifications.cshtml
+++ b/src/Humans.Web/Views/Profile/Notifications.cshtml
@@ -36,7 +36,7 @@
                                        name="Categories[@i].OptedOut"
                                        value="true"
                                        class="form-check-input"
-                                       @(item.OptedOut ? "checked" : "") />
+                                       @(item.OptedOut ? "checked" : null) />
                             }
                             else
                             {
@@ -44,7 +44,7 @@
                                        id="Categories_@(i)_OptedOut"
                                        class="form-check-input"
                                        disabled
-                                       @(item.OptedOut ? "checked" : "") />
+                                       @(item.OptedOut ? "checked" : null) />
                             }
                             <label for="Categories_@(i)_OptedOut" class="form-check-label">
                                 Unsubscribe from @item.DisplayName

--- a/src/Humans.Web/Views/Profile/ShiftInfo.cshtml
+++ b/src/Humans.Web/Views/Profile/ShiftInfo.cshtml
@@ -30,7 +30,7 @@
                             <div class="col-md-4 mb-1">
                                 <div class="form-check">
                                     <input type="checkbox" name="SelectedSkills" value="@skill" class="form-check-input"
-                                           @(Model.SelectedSkills.Contains(skill) ? "checked" : "") />
+                                           @(Model.SelectedSkills.Contains(skill) ? "checked" : null) />
                                     <label class="form-check-label">@skill</label>
                                 </div>
                             </div>
@@ -49,7 +49,7 @@
                             <div class="col-md-4 mb-1">
                                 <div class="form-check">
                                     <input type="checkbox" name="SelectedQuirks" value="@quirk" class="form-check-input"
-                                           @(Model.SelectedQuirks.Contains(quirk) ? "checked" : "") />
+                                           @(Model.SelectedQuirks.Contains(quirk) ? "checked" : null) />
                                     <label class="form-check-label">@quirk</label>
                                 </div>
                             </div>
@@ -68,7 +68,7 @@
                             <div class="col-md-4 mb-1">
                                 <div class="form-check">
                                     <input type="checkbox" name="SelectedLanguages" value="@lang" class="form-check-input"
-                                           @(Model.SelectedLanguages.Contains(lang) ? "checked" : "") />
+                                           @(Model.SelectedLanguages.Contains(lang) ? "checked" : null) />
                                     <label class="form-check-label">@lang</label>
                                 </div>
                             </div>
@@ -87,7 +87,7 @@
                             <div class="col-md-3 mb-1">
                                 <div class="form-check">
                                     <input type="radio" name="DietaryPreference" value="@diet" class="form-check-input"
-                                           @(string.Equals(Model.DietaryPreference, diet, StringComparison.Ordinal) ? "checked" : "") />
+                                           @(string.Equals(Model.DietaryPreference, diet, StringComparison.Ordinal) ? "checked" : null) />
                                     <label class="form-check-label">@diet</label>
                                 </div>
                             </div>
@@ -95,7 +95,7 @@
                         <div class="col-md-3 mb-1">
                             <div class="form-check">
                                 <input type="radio" name="DietaryPreference" value="" class="form-check-input"
-                                       @(string.IsNullOrEmpty(Model.DietaryPreference) ? "checked" : "") />
+                                       @(string.IsNullOrEmpty(Model.DietaryPreference) ? "checked" : null) />
                                 <label class="form-check-label text-muted">Not specified</label>
                             </div>
                         </div>
@@ -113,7 +113,7 @@
                             <div class="col-md-4 mb-1">
                                 <div class="form-check">
                                     <input type="checkbox" name="SelectedAllergies" value="@allergy" class="form-check-input"
-                                           @(Model.SelectedAllergies.Contains(allergy) ? "checked" : "")
+                                           @(Model.SelectedAllergies.Contains(allergy) ? "checked" : null)
                                            @(string.Equals(allergy, "Other", StringComparison.Ordinal) ? "data-toggle-target=allergyOtherText" : "") />
                                     <label class="form-check-label">@allergy</label>
                                 </div>
@@ -137,7 +137,7 @@
                             <div class="col-md-4 mb-1">
                                 <div class="form-check">
                                     <input type="checkbox" name="SelectedIntolerances" value="@intolerance" class="form-check-input"
-                                           @(Model.SelectedIntolerances.Contains(intolerance) ? "checked" : "")
+                                           @(Model.SelectedIntolerances.Contains(intolerance) ? "checked" : null)
                                            @(string.Equals(intolerance, "Other", StringComparison.Ordinal) ? "data-toggle-target=intoleranceOtherText" : "") />
                                     <label class="form-check-label">@intolerance</label>
                                 </div>

--- a/src/Humans.Web/Views/TeamAdmin/EditPage.cshtml
+++ b/src/Humans.Web/Views/TeamAdmin/EditPage.cshtml
@@ -50,7 +50,7 @@
     else
     {
         <input type="hidden" asp-for="IsPublicPage" value="false" />
-        <input type="hidden" asp-for="ShowCoordinatorsOnPublicPage" value="true" />
+        <input type="hidden" asp-for="ShowCoordinatorsOnPublicPage" />
         <div class="alert alert-info mb-4">
             Only top-level departments (non-system, no parent team) can be made public.
         </div>

--- a/src/Humans.Web/Views/TeamAdmin/Roles.cshtml
+++ b/src/Humans.Web/Views/TeamAdmin/Roles.cshtml
@@ -117,7 +117,7 @@
                             else
                             {
                                 <input type="checkbox" class="form-check-input" id="isManagement-@role.Id"
-                                       name="IsManagement" value="true" @(role.IsManagement ? "checked" : "") />
+                                       name="IsManagement" value="true" @(role.IsManagement ? "checked" : null) />
                             }
                             <label class="form-check-label" for="isManagement-@role.Id">Coordinator role</label>
                             @if (role.IsManagement && hasAssignments)
@@ -132,7 +132,7 @@
                     }
                     <div class="mb-3 form-check">
                         <input type="checkbox" class="form-check-input" id="isPublic-@role.Id"
-                               name="IsPublic" value="true" @(role.IsPublic ? "checked" : "") />
+                               name="IsPublic" value="true" @(role.IsPublic ? "checked" : null) />
                         <input type="hidden" name="IsPublic" value="false" />
                         <label class="form-check-label" for="isPublic-@role.Id">Visible to volunteers</label>
                         <div class="form-text">When unchecked, this role is hidden from volunteer-facing views.</div>

--- a/src/Humans.Web/Views/Vol/Settings.cshtml
+++ b/src/Humans.Web/Views/Vol/Settings.cshtml
@@ -76,7 +76,7 @@
             <div class="form-check form-switch">
                 <input class="form-check-input" type="checkbox" role="switch"
                        id="isShiftBrowsingOpen" name="isShiftBrowsingOpen"
-                       value="true" @(Model.IsShiftBrowsingOpen ? "checked" : "")>
+                       value="true" @(Model.IsShiftBrowsingOpen ? "checked" : null)>
                 <label class="form-check-label" for="isShiftBrowsingOpen">
                     Shift browsing open
                 </label>


### PR DESCRIPTION
## Summary
16 bug fixes identified by Codex automated code review, covering:

- **Razor boolean attributes** — `selected`, `checked`, `disabled` rendered as `=""` instead of being removed when false (7 views)
- **Email normalization** — gmail/googlemail alias equivalence across contact, ticket, and user email matching
- **Outbox resilience** — per-message `SaveChangesAsync` in email and Google sync outbox jobs to prevent double-processing on crash
- **Data safety** — unknown ticket attendee statuses default to Void (not Valid), feedback endpoints return 404 for missing records
- **UI correctness** — budget audit year dropdown, locked profile tier postback, team page visibility flag, unsubscribe token URL encoding
- **Query correctness** — Google group URL matching uses exact match (ILike) instead of EndsWith, notification target email preferred for @nobodies.team lookups
- **Timezone** — birthday list uses request timezone instead of UTC

## Test plan
- [ ] Budget audit log: year filter dropdown selects correctly
- [ ] Profile edit: locked tier preserved on save
- [ ] Shift info: checkboxes preserve state on postback
- [ ] Birthday list: shows correct month near timezone boundaries
- [ ] Feedback: 404 on invalid feedback ID (not 500)
- [ ] Email outbox: verify no duplicate sends after restart
- [ ] Unsubscribe link: works with base64 tokens containing +/=

🤖 Generated with [Claude Code](https://claude.com/claude-code)