### PR TITLE
feat: shift preference wizard (#33)

### DIFF
--- a/docs/features/33-shift-preference-wizard.md
+++ b/docs/features/33-shift-preference-wizard.md
@@ -55,6 +55,19 @@ All data stores into the existing `VolunteerEventProfile` entity:
 - Toggle quirks (Sober Shift, etc.) → `Quirks[]`
 - Languages → `Languages[]`
 
+### New Quirk Values
+
+"All Day" and "No Preference" are **new values** being added to the quirk vocabulary. "Early Bird" and "Night Owl" already exist. No downstream impact — the volunteer search builder and shift admin views display quirks as-is from the string array, so new values render without code changes.
+
+### Time Preference Mutual Exclusivity
+
+Time preferences (Early Bird, Night Owl, All Day, No Preference) are mutually exclusive — a human picks exactly one. These are stored in the same `Quirks[]` array alongside toggle quirks, so the save logic must:
+
+1. **On POST:** Remove any existing time preference value from `Quirks[]` before adding the newly selected one. The set of time preference values is: `["Early Bird", "Night Owl", "All Day", "No Preference"]`.
+2. **On GET:** Extract the time preference from `Quirks[]` to pre-select the correct radio card. Toggle quirks populate the switches separately.
+
+The view model should expose `TimePreference` (string, nullable) separately from `SelectedQuirks` (list of toggle quirks) to make this split explicit in the view. The controller merges them back into a single `Quirks[]` on save.
+
 ### Fields Removed From This Page (Not Deleted)
 
 The following fields are no longer editable on `/Profile/ShiftInfo` but remain on `VolunteerEventProfile` and in the database. Existing data is preserved. These will move to the Dietary & Medical Nudge Modal (Feature 35):
@@ -87,7 +100,7 @@ The following fields are no longer editable on `/Profile/ShiftInfo` but remain o
 | File | Change |
 |------|--------|
 | `Views/Profile/ShiftInfo.cshtml` | Full rewrite — flat form → wizard |
-| `Models/ShiftViewModels.cs` | Stop binding dietary/allergy/medical fields |
+| `Models/ShiftViewModels.cs` | Remove dietary/allergy/medical properties; add `TimePreference` property (string); split `SelectedQuirks` to exclude time preferences |
 | `Controllers/ProfileController.cs` | POST stops writing dietary/medical fields; GET stops loading them into view model |
 
 ## Files NOT Modified

--- a/docs/features/33-shift-preference-wizard.md
+++ b/docs/features/33-shift-preference-wizard.md
@@ -68,6 +68,10 @@ Time preferences (Early Bird, Night Owl, All Day, No Preference) are mutually ex
 
 The view model should expose `TimePreference` (string, nullable) separately from `SelectedQuirks` (list of toggle quirks) to make this split explicit in the view. The controller merges them back into a single `Quirks[]` on save.
 
+**null vs "No Preference":** `TimePreference = null` means the user has never set a time preference (no radio card pre-selected). "No Preference" is a deliberate choice ("I'll take whatever's needed") and is stored as a quirk value. The wizard allows submitting without selecting a time preference — it's not required.
+
+The set of time preference values should be a `static readonly` array (like the existing `SkillOptions`) so both the strip-on-save and extract-on-load logic reference the same source of truth.
+
 ### Fields Removed From This Page (Not Deleted)
 
 The following fields are no longer editable on `/Profile/ShiftInfo` but remain on `VolunteerEventProfile` and in the database. Existing data is preserved. These will move to the Dietary & Medical Nudge Modal (Feature 35):

--- a/docs/features/33-shift-preference-wizard.md
+++ b/docs/features/33-shift-preference-wizard.md
@@ -1,0 +1,112 @@
+# 33 — Shift Preference Wizard
+
+## Business Context
+
+Volunteers need to tell coordinators about their skills, work style preferences, and languages so they can be matched with appropriate shifts. The current `/Profile/ShiftInfo` page is a flat form with bare checkboxes — functional but uninviting, especially on mobile. This feature replaces it with a guided 3-step wizard that collects the same data in a more engaging, mobile-friendly flow.
+
+This is the first of three related features:
+- **33 — Shift Preference Wizard** (this feature): Collect skills, work style, languages
+- **34 — Shift Recommendation Engine**: Fuzzy-match preferences against available shifts (separate spec)
+- **35 — Dietary & Medical Nudge Modal**: Collect dietary/allergy/medical info when a human signs up for a 6+ hour shift where the cantina provides meals (separate spec)
+
+## Authorization
+
+Same as current `/Profile/ShiftInfo` — any authenticated user can view and edit their own shift preferences. No role-based restrictions.
+
+## User Stories
+
+### US-33.1: Set Shift Preferences via Wizard
+**As a** human
+**I want to** set my shift preferences through a guided wizard
+**So that** coordinators can match me with shifts that fit my skills and availability
+
+**Acceptance Criteria:**
+- Wizard replaces the existing flat form at `GET /Profile/ShiftInfo`
+- 3 steps: Skills, Work Style, Languages
+- Step 1 (Skills): emoji-prefixed chip multi-select — Bartending, Cooking, Sound, DJ, First Aid, Electrical, Driving, Construction, Art, Other
+- Step 2 (Work Style): radio cards for time preference (Early Bird, Night Owl, All Day, No Preference) + Bootstrap toggle switches for quirks (Sober Shift, Work In Shade, No Heights, Physical Work OK, Quiet Work)
+- Step 3 (Languages): emoji-prefixed chip multi-select — English, Spanish, French, German, Italian, Portuguese, Other
+- Progress dots in header show current/completed/future steps
+- Step label, title, and subtitle update per step
+- Back/Continue navigation buttons; "Save" on final step
+- Single form POST on save — all selections submitted together
+- Pre-populated with existing `VolunteerEventProfile` data on return visits
+- Mobile-first: chip grid wraps with generous tap targets, radio cards stack vertically on small screens, full-width buttons on mobile
+
+### US-33.2: Accessible Wizard Interactions
+**As a** human using assistive technology
+**I want to** navigate and interact with the wizard using keyboard and screen reader
+**So that** I can set my preferences regardless of how I access the site
+
+**Acceptance Criteria:**
+- Chips backed by hidden checkbox inputs (screen reader accessible)
+- Chips have `role="checkbox"` and `aria-checked`
+- Radio cards backed by hidden radio inputs
+- Keyboard navigation: chips/cards are focusable, spacebar/enter toggles
+- Step transitions do not break focus management
+
+## Data Model
+
+**No schema changes. No migration.**
+
+All data stores into the existing `VolunteerEventProfile` entity:
+- Skills → `Skills[]` (string array)
+- Time preference (Early Bird / Night Owl / All Day / No Preference) → stored as a value in `Quirks[]`
+- Toggle quirks (Sober Shift, etc.) → `Quirks[]`
+- Languages → `Languages[]`
+
+### Fields Removed From This Page (Not Deleted)
+
+The following fields are no longer editable on `/Profile/ShiftInfo` but remain on `VolunteerEventProfile` and in the database. Existing data is preserved. These will move to the Dietary & Medical Nudge Modal (Feature 35):
+- `DietaryPreference`
+- `Allergies[]` + `AllergyOtherText`
+- `Intolerances[]` + `IntoleranceOtherText`
+- `MedicalConditions`
+
+## Visual Design
+
+**Style: Light Subtle** — Bootstrap color palette with custom chip components:
+- Unselected chip: `#f8f9fa` background, `#dee2e6` border, `#495057` text
+- Selected chip: `#e7f1ff` background, `#0d6efd` border, `#0d6efd` text, `font-weight: 500`
+- Emoji prefix on each chip as visual anchor
+- No visible checkboxes — selection indicated by color change
+- Radio cards: larger format with icon, label, description text; 2x2 grid on desktop, single column on mobile
+- Toggle switches: standard Bootstrap `form-check form-switch`
+- Progress: 3 dots (blue filled = active/completed, grey = future)
+
+## Step Content
+
+| Step | Label | Title | Subtitle |
+|------|-------|-------|----------|
+| 1 | Step 1 of 3 | What are you good at? | Select skills you'd like to use. You can change these anytime. |
+| 2 | Step 2 of 3 | How do you like to work? | Help coordinators match you with shifts that fit your style and availability. |
+| 3 | Step 3 of 3 | Which languages do you speak? | This helps us match you with teams where you can communicate well. |
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `Views/Profile/ShiftInfo.cshtml` | Full rewrite — flat form → wizard |
+| `Models/ShiftViewModels.cs` | Stop binding dietary/allergy/medical fields |
+| `Controllers/ProfileController.cs` | POST stops writing dietary/medical fields; GET stops loading them into view model |
+
+## Files NOT Modified
+
+- `VolunteerEventProfile` entity — untouched
+- EF mappings — no migration
+- No new JS files — inline `<script>` in the view
+- No new CSS files — Bootstrap utilities + small `<style>` block
+
+## Entry Points
+
+- Profile page → "Shift Info" link (existing)
+- Dashboard "Things to do" card → "Set up" action (issue #273)
+- Any future contextual links can point to `/Profile/ShiftInfo`
+
+## Related Features
+
+- [25 — Shift Management](25-shift-management.md): parent shift system
+- [Issue #273](https://github.com/nobodies-collective/Humans/issues/273): Dashboard "Things to do" wizard card
+- [Issue #186](https://github.com/nobodies-collective/Humans/issues/186): Custom labels/tags on rotas (future matching input)
+- Feature 34 — Shift Recommendation Engine (not yet specced)
+- [Feature 35 — Dietary & Medical Nudge Modal](35-dietary-medical-nudge.md) (placeholder)

--- a/docs/features/35-dietary-medical-nudge.md
+++ b/docs/features/35-dietary-medical-nudge.md
@@ -1,0 +1,28 @@
+# 35 — Dietary & Medical Nudge Modal (Placeholder)
+
+## Status: Not Yet Specced
+
+## Business Context
+
+The cantina feeds humans who work shifts of 6+ hours. Dietary preferences, allergies, intolerances, and medical conditions are only relevant once someone has a qualifying shift — not during initial preference setup.
+
+This feature will present a modal nudge (triggered from a dashboard card) when a human has signed up for a qualifying shift but hasn't filled out their dietary/medical info.
+
+## Scope (Rough)
+
+- Dashboard card: "We see you have a shift — tell us about your food needs"
+- Modal flow collecting: dietary preference, allergies (with "Other" text), intolerances (with "Other" text), medical conditions
+- Triggered when: human has a confirmed signup on a 6+ hour shift AND dietary fields are empty
+- Data stores into existing `VolunteerEventProfile` fields (already in schema)
+- Medical conditions visibility restricted to owner, NoInfo Admins, and Admins (existing rule)
+
+## Dependencies
+
+- Feature 33 (Shift Preference Wizard) removes dietary/medical from `/Profile/ShiftInfo`
+- Shift signup system (Feature 25) provides the qualifying shift trigger
+
+## Related Features
+
+- [33 — Shift Preference Wizard](33-shift-preference-wizard.md): removes dietary/medical from the preference page
+- [25 — Shift Management](25-shift-management.md): shift signup data
+- [Issue #273](https://github.com/nobodies-collective/Humans/issues/273): Dashboard "Things to do" card pattern

--- a/docs/superpowers/plans/2026-03-31-shift-preference-wizard.md
+++ b/docs/superpowers/plans/2026-03-31-shift-preference-wizard.md
@@ -1,0 +1,704 @@
+# Shift Preference Wizard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the flat `/Profile/ShiftInfo` form with a 3-step wizard (Skills, Work Style, Languages) using emoji chips, radio cards, and toggle switches.
+
+**Architecture:** Server-rendered Razor view with vanilla JS step navigation. Single `<form>` wraps all 3 steps; POST on final step saves to existing `VolunteerEventProfile` via `ProfileController`. View model splits time preferences from toggle quirks for mutual exclusivity handling.
+
+**Tech Stack:** ASP.NET Core MVC, Razor views, Bootstrap 5, vanilla JS, xUnit + AwesomeAssertions for tests, Playwright for e2e.
+
+**Spec:** `docs/features/33-shift-preference-wizard.md`
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `src/Humans.Web/Models/ShiftViewModels.cs` | Modify | Add `TimePreference`, `TimePreferenceOptions`, `ToggleQuirkOptions`; remove dietary/medical properties |
+| `src/Humans.Web/Controllers/ProfileController.cs` | Modify | GET: split quirks into time pref + toggles; POST: merge them back, stop writing dietary fields |
+| `src/Humans.Web/Views/Profile/ShiftInfo.cshtml` | Rewrite | 3-step wizard with chips, radio cards, toggles |
+| `tests/Humans.Application.Tests/ViewModels/ShiftInfoViewModelTests.cs` | Create | Unit tests for time preference split/merge logic |
+| `tests/e2e/tests/shift-preferences.spec.ts` | Create | E2e smoke tests for wizard page load, step navigation, save |
+
+---
+
+### Task 1: Update ShiftInfoViewModel
+
+**Files:**
+- Modify: `src/Humans.Web/Models/ShiftViewModels.cs:228-251`
+- Create: `tests/Humans.Application.Tests/ViewModels/ShiftInfoViewModelTests.cs`
+
+- [ ] **Step 1: Write tests for time preference extraction and merging**
+
+Create `tests/Humans.Application.Tests/ViewModels/ShiftInfoViewModelTests.cs`:
+
+```csharp
+using AwesomeAssertions;
+using Humans.Web.Models;
+using Xunit;
+
+namespace Humans.Application.Tests.ViewModels;
+
+public class ShiftInfoViewModelTests
+{
+    [Fact]
+    public void TimePreferenceOptions_contains_all_four_values()
+    {
+        ShiftInfoViewModel.TimePreferenceOptions.Should()
+            .BeEquivalentTo(["Early Bird", "Night Owl", "All Day", "No Preference"]);
+    }
+
+    [Fact]
+    public void ToggleQuirkOptions_excludes_time_preferences()
+    {
+        ShiftInfoViewModel.ToggleQuirkOptions.Should()
+            .BeEquivalentTo(["Sober Shift", "Work In Shade", "Quiet Work", "Physical Work OK", "No Heights"]);
+
+        // No overlap with time preferences
+        ShiftInfoViewModel.ToggleQuirkOptions.Should()
+            .NotContain(ShiftInfoViewModel.TimePreferenceOptions);
+    }
+
+    [Fact]
+    public void ExtractTimePreference_returns_matching_value_from_quirks()
+    {
+        var quirks = new List<string> { "Sober Shift", "Night Owl", "No Heights" };
+
+        var result = ShiftInfoViewModel.ExtractTimePreference(quirks);
+
+        result.Should().Be("Night Owl");
+    }
+
+    [Fact]
+    public void ExtractTimePreference_returns_null_when_no_time_pref()
+    {
+        var quirks = new List<string> { "Sober Shift", "No Heights" };
+
+        var result = ShiftInfoViewModel.ExtractTimePreference(quirks);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void ExtractToggleQuirks_excludes_time_preferences()
+    {
+        var quirks = new List<string> { "Sober Shift", "Night Owl", "No Heights" };
+
+        var result = ShiftInfoViewModel.ExtractToggleQuirks(quirks);
+
+        result.Should().BeEquivalentTo(["Sober Shift", "No Heights"]);
+    }
+
+    [Fact]
+    public void MergeQuirks_combines_time_pref_and_toggles()
+    {
+        var toggles = new List<string> { "Sober Shift", "No Heights" };
+
+        var result = ShiftInfoViewModel.MergeQuirks("Early Bird", toggles);
+
+        result.Should().BeEquivalentTo(["Sober Shift", "No Heights", "Early Bird"]);
+    }
+
+    [Fact]
+    public void MergeQuirks_with_null_time_pref_returns_toggles_only()
+    {
+        var toggles = new List<string> { "Sober Shift" };
+
+        var result = ShiftInfoViewModel.MergeQuirks(null, toggles);
+
+        result.Should().BeEquivalentTo(["Sober Shift"]);
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `dotnet test tests/Humans.Application.Tests --filter "FullyQualifiedName~ShiftInfoViewModelTests" -v minimal`
+Expected: Build errors — `TimePreferenceOptions`, `ToggleQuirkOptions`, `ExtractTimePreference`, `ExtractToggleQuirks`, `MergeQuirks` don't exist yet.
+
+- [ ] **Step 3: Update ShiftInfoViewModel**
+
+In `src/Humans.Web/Models/ShiftViewModels.cs`, replace the `ShiftInfoViewModel` class (lines 228–251) with:
+
+```csharp
+public class ShiftInfoViewModel
+{
+    public List<string> SelectedSkills { get; set; } = [];
+    public List<string> SelectedQuirks { get; set; } = []; // Toggle quirks only (no time prefs)
+    public string? TimePreference { get; set; } // Mutually exclusive: Early Bird, Night Owl, All Day, No Preference
+    public List<string> SelectedLanguages { get; set; } = [];
+
+    // Skill options with emoji prefixes for display
+    public static readonly string[] SkillOptions = ["Bartending", "First Aid", "Driving", "Sound", "Electrical", "Construction", "Cooking", "Art", "DJ", "Other"];
+    public static readonly string[] LanguageOptions = ["English", "Spanish", "German", "French", "Italian", "Portuguese", "Other"];
+
+    // Time preferences — mutually exclusive, stored as quirk value
+    public static readonly string[] TimePreferenceOptions = ["Early Bird", "Night Owl", "All Day", "No Preference"];
+
+    // Toggle quirks — multi-select, separate from time preference
+    public static readonly string[] ToggleQuirkOptions = ["Sober Shift", "Work In Shade", "Quiet Work", "Physical Work OK", "No Heights"];
+
+    // Combined QuirkOptions kept for backward compatibility (downstream consumers read quirks as flat array)
+    public static readonly string[] QuirkOptions = [.. ToggleQuirkOptions, .. TimePreferenceOptions];
+
+    // Emoji maps for view rendering
+    public static readonly Dictionary<string, string> SkillEmoji = new()
+    {
+        ["Bartending"] = "\U0001f378", ["Cooking"] = "\U0001f373", ["Sound"] = "\U0001f39a\ufe0f",
+        ["DJ"] = "\U0001f3a7", ["First Aid"] = "\U0001fa7a", ["Electrical"] = "\u26a1",
+        ["Driving"] = "\U0001f697", ["Construction"] = "\U0001f528", ["Art"] = "\U0001f3a8",
+        ["Other"] = "\u2728"
+    };
+
+    public static readonly Dictionary<string, string> LanguageEmoji = new()
+    {
+        ["English"] = "\U0001f1ec\U0001f1e7", ["Spanish"] = "\U0001f1ea\U0001f1f8",
+        ["French"] = "\U0001f1eb\U0001f1f7", ["German"] = "\U0001f1e9\U0001f1ea",
+        ["Italian"] = "\U0001f1ee\U0001f1f9", ["Portuguese"] = "\U0001f1f5\U0001f1f9",
+        ["Other"] = "\U0001f30d"
+    };
+
+    public static readonly Dictionary<string, string> TimePreferenceEmoji = new()
+    {
+        ["Early Bird"] = "\U0001f305", ["Night Owl"] = "\U0001f319",
+        ["All Day"] = "\u2600\ufe0f", ["No Preference"] = "\U0001f937"
+    };
+
+    public static readonly Dictionary<string, string> TimePreferenceDesc = new()
+    {
+        ["Early Bird"] = "Morning shifts, set up and prep",
+        ["Night Owl"] = "Evening and late-night shifts",
+        ["All Day"] = "Flexible, morning through evening",
+        ["No Preference"] = "I'll take whatever's needed"
+    };
+
+    /// <summary>Extract the time preference value from a flat quirks array.</summary>
+    public static string? ExtractTimePreference(List<string> quirks)
+        => quirks.FirstOrDefault(q => TimePreferenceOptions.Contains(q, StringComparer.Ordinal));
+
+    /// <summary>Extract toggle quirks (excluding time preferences) from a flat quirks array.</summary>
+    public static List<string> ExtractToggleQuirks(List<string> quirks)
+        => quirks.Where(q => !TimePreferenceOptions.Contains(q, StringComparer.Ordinal)).ToList();
+
+    /// <summary>Merge a time preference and toggle quirks back into a flat quirks array.</summary>
+    public static List<string> MergeQuirks(string? timePreference, List<string> toggleQuirks)
+    {
+        var result = new List<string>(toggleQuirks ?? []);
+        if (!string.IsNullOrEmpty(timePreference))
+            result.Add(timePreference);
+        return result;
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `dotnet test tests/Humans.Application.Tests --filter "FullyQualifiedName~ShiftInfoViewModelTests" -v minimal`
+Expected: All 7 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Humans.Web/Models/ShiftViewModels.cs tests/Humans.Application.Tests/ViewModels/ShiftInfoViewModelTests.cs
+git commit -m "feat(33): update ShiftInfoViewModel with time preference split and emoji maps"
+```
+
+---
+
+### Task 2: Update ProfileController
+
+**Files:**
+- Modify: `src/Humans.Web/Controllers/ProfileController.cs:798-865`
+
+- [ ] **Step 1: Update GET action**
+
+Replace the `ShiftInfo()` GET action (lines 798–830) with:
+
+```csharp
+[HttpGet("/Profile/ShiftInfo")]
+public async Task<IActionResult> ShiftInfo()
+{
+    try
+    {
+        var user = await GetCurrentUserAsync();
+        if (user is null)
+            return NotFound();
+
+        var profile = await _profileService.GetShiftProfileAsync(user.Id, includeMedical: false);
+        var allQuirks = profile?.Quirks ?? [];
+
+        var viewModel = new ShiftInfoViewModel
+        {
+            SelectedSkills = profile?.Skills ?? [],
+            SelectedQuirks = ShiftInfoViewModel.ExtractToggleQuirks(allQuirks),
+            TimePreference = ShiftInfoViewModel.ExtractTimePreference(allQuirks),
+            SelectedLanguages = profile?.Languages ?? [],
+        };
+
+        return View(viewModel);
+    }
+    catch (Exception ex)
+    {
+        _logger.LogError(ex, "Failed to load shift info for user");
+        SetError("Failed to load shift info.");
+        return RedirectToAction(nameof(Index));
+    }
+}
+```
+
+Key changes: `includeMedical: false`, split quirks into `SelectedQuirks` + `TimePreference`, removed dietary/allergy/medical fields.
+
+- [ ] **Step 2: Update POST action**
+
+Replace the `ShiftInfo(ShiftInfoViewModel model)` POST action (lines 832–865) with:
+
+```csharp
+[HttpPost("/Profile/ShiftInfo")]
+[ValidateAntiForgeryToken]
+public async Task<IActionResult> ShiftInfo(ShiftInfoViewModel model)
+{
+    try
+    {
+        var user = await GetCurrentUserAsync();
+        if (user is null)
+            return NotFound();
+
+        var shiftProfile = await _profileService.GetOrCreateShiftProfileAsync(user.Id);
+
+        shiftProfile.Skills = model.SelectedSkills ?? [];
+        shiftProfile.Quirks = ShiftInfoViewModel.MergeQuirks(model.TimePreference, model.SelectedQuirks ?? []);
+        shiftProfile.Languages = model.SelectedLanguages ?? [];
+
+        await _profileService.UpdateShiftProfileAsync(shiftProfile);
+
+        SetSuccess(_localizer["Profile_Updated"].Value);
+        return RedirectToAction(nameof(ShiftInfo));
+    }
+    catch (Exception ex)
+    {
+        _logger.LogError(ex, "Failed to save shift info for user");
+        SetError("Failed to save shift info.");
+        return View(model);
+    }
+}
+```
+
+Key changes: uses `MergeQuirks` to combine time pref + toggle quirks; stops writing dietary/allergy/medical fields. Existing dietary data on the entity is untouched.
+
+- [ ] **Step 3: Build to verify compilation**
+
+Run: `dotnet build src/Humans.Web`
+Expected: Build will FAIL because the Razor view still references removed model properties (`SelectedAllergies`, `DietaryPreference`, etc.). This is expected — the view is rewritten in Task 3. Verify the error messages are only from `ShiftInfo.cshtml`, not from the controller or model.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Humans.Web/Controllers/ProfileController.cs
+git commit -m "feat(33): update ProfileController to split time preference from toggle quirks"
+```
+
+---
+
+### Task 3: Rewrite ShiftInfo.cshtml as Wizard
+
+**Files:**
+- Rewrite: `src/Humans.Web/Views/Profile/ShiftInfo.cshtml`
+
+This is the largest task — the full wizard view. It replaces the entire existing file.
+
+- [ ] **Step 1: Write the wizard view**
+
+Rewrite `src/Humans.Web/Views/Profile/ShiftInfo.cshtml` with the complete wizard. The view has these sections:
+
+1. **Header**: breadcrumb, step label, title, subtitle, progress dots
+2. **Form**: single `<form>` wrapping all 3 step panes
+3. **Step 1 (Skills)**: emoji chip grid with hidden checkboxes
+4. **Step 2 (Work Style)**: radio cards for time preference + Bootstrap toggle switches for quirks
+5. **Step 3 (Languages)**: emoji chip grid with hidden checkboxes
+6. **Footer**: Back / Continue / Save buttons
+7. **Style block**: chip, radio-card, progress-dot CSS
+8. **Script block**: step navigation, chip toggle, radio card selection
+
+```cshtml
+@model Humans.Web.Models.ShiftInfoViewModel
+@{
+    ViewData["Title"] = "Shift Preferences";
+}
+
+<div class="row">
+    <div class="col-12" style="max-width: 560px; margin: 0 auto;">
+        <nav aria-label="breadcrumb">
+            <ol class="breadcrumb">
+                <li class="breadcrumb-item"><a asp-action="Index">Profile</a></li>
+                <li class="breadcrumb-item active" aria-current="page">Shift Preferences</li>
+            </ol>
+        </nav>
+
+        <vc:temp-data-alerts />
+
+        @* Wizard header *@
+        <div class="text-center mb-4">
+            <div class="text-muted text-uppercase small" id="stepLabel">Step 1 of 3</div>
+            <h1 class="h4 mt-1 mb-1" id="stepTitle">What are you good at?</h1>
+            <p class="text-muted small" id="stepSubtitle">Select skills you'd like to use. You can change these anytime.</p>
+            <div class="d-flex justify-content-center gap-2 mt-3" id="progressDots">
+                <span class="progress-dot active" data-step="0"></span>
+                <span class="progress-dot" data-step="1"></span>
+                <span class="progress-dot" data-step="2"></span>
+            </div>
+        </div>
+
+        <form asp-action="ShiftInfo" method="post" id="wizardForm">
+            @Html.AntiForgeryToken()
+
+            @* ===== STEP 0: Skills ===== *@
+            <div class="step-pane active" id="step-0">
+                <div class="chip-grid">
+                    @foreach (var skill in Humans.Web.Models.ShiftInfoViewModel.SkillOptions)
+                    {
+                        var isSelected = Model.SelectedSkills.Contains(skill);
+                        var emoji = Humans.Web.Models.ShiftInfoViewModel.SkillEmoji.GetValueOrDefault(skill, "");
+                        <label class="chip @(isSelected ? "selected" : "")" role="checkbox" aria-checked="@(isSelected ? "true" : "false")" tabindex="0">
+                            <input type="checkbox" name="SelectedSkills" value="@skill" class="d-none"
+                                   @(isSelected ? "checked" : "") />
+                            <span class="chip-emoji">@emoji</span> @skill
+                        </label>
+                    }
+                </div>
+            </div>
+
+            @* ===== STEP 1: Work Style ===== *@
+            <div class="step-pane" id="step-1">
+                <p class="fw-bold small text-muted mb-2">When do you prefer to work?</p>
+                <div class="radio-card-grid">
+                    @foreach (var tp in Humans.Web.Models.ShiftInfoViewModel.TimePreferenceOptions)
+                    {
+                        var isSelected = string.Equals(Model.TimePreference, tp, StringComparison.Ordinal);
+                        var emoji = Humans.Web.Models.ShiftInfoViewModel.TimePreferenceEmoji.GetValueOrDefault(tp, "");
+                        var desc = Humans.Web.Models.ShiftInfoViewModel.TimePreferenceDesc.GetValueOrDefault(tp, "");
+                        <label class="radio-card @(isSelected ? "selected" : "")" tabindex="0">
+                            <input type="radio" name="TimePreference" value="@tp" class="d-none"
+                                   @(isSelected ? "checked" : "") />
+                            <div class="rc-emoji">@emoji</div>
+                            <div class="rc-label">@tp</div>
+                            <div class="rc-desc">@desc</div>
+                        </label>
+                    }
+                </div>
+
+                <p class="fw-bold small text-muted mb-2 mt-4">Other preferences</p>
+                @foreach (var quirk in Humans.Web.Models.ShiftInfoViewModel.ToggleQuirkOptions)
+                {
+                    var isChecked = Model.SelectedQuirks.Contains(quirk);
+                    <div class="form-check form-switch mb-2">
+                        <input type="checkbox" name="SelectedQuirks" value="@quirk" class="form-check-input"
+                               id="quirk-@quirk.Replace(" ", "-")" @(isChecked ? "checked" : "") />
+                        <label class="form-check-label" for="quirk-@quirk.Replace(" ", "-")">@quirk</label>
+                    </div>
+                }
+            </div>
+
+            @* ===== STEP 2: Languages ===== *@
+            <div class="step-pane" id="step-2">
+                <div class="chip-grid">
+                    @foreach (var lang in Humans.Web.Models.ShiftInfoViewModel.LanguageOptions)
+                    {
+                        var isSelected = Model.SelectedLanguages.Contains(lang);
+                        var emoji = Humans.Web.Models.ShiftInfoViewModel.LanguageEmoji.GetValueOrDefault(lang, "");
+                        <label class="chip @(isSelected ? "selected" : "")" role="checkbox" aria-checked="@(isSelected ? "true" : "false")" tabindex="0">
+                            <input type="checkbox" name="SelectedLanguages" value="@lang" class="d-none"
+                                   @(isSelected ? "checked" : "") />
+                            <span class="chip-emoji">@emoji</span> @lang
+                        </label>
+                    }
+                </div>
+            </div>
+
+            @* ===== Navigation ===== *@
+            <div class="d-flex justify-content-between align-items-center mt-4">
+                <button type="button" class="btn btn-outline-secondary" id="backBtn" style="display:none" onclick="prevStep()">
+                    &larr; Back
+                </button>
+                <div></div>
+                <button type="button" class="btn btn-primary" id="nextBtn" onclick="nextStep()">
+                    Continue &rarr;
+                </button>
+                <button type="submit" class="btn btn-primary" id="saveBtn" style="display:none">
+                    Save
+                </button>
+            </div>
+        </form>
+    </div>
+</div>
+
+@section Styles {
+<style>
+    /* Progress dots */
+    .progress-dot {
+        width: 10px; height: 10px; border-radius: 50%;
+        background: #dee2e6; display: inline-block; transition: background 0.2s;
+    }
+    .progress-dot.active, .progress-dot.done { background: #0d6efd; }
+
+    /* Step panes */
+    .step-pane { display: none; }
+    .step-pane.active { display: block; }
+
+    /* Chip grid */
+    .chip-grid { display: flex; flex-wrap: wrap; gap: 10px; }
+    .chip {
+        display: inline-flex; align-items: center; gap: 4px;
+        padding: 9px 16px; border-radius: 10px; cursor: pointer;
+        background: #f8f9fa; border: 1.5px solid #dee2e6; color: #495057;
+        font-size: 14px; user-select: none; transition: all 0.15s;
+    }
+    .chip:hover { border-color: #adb5bd; }
+    .chip:focus-visible { outline: 2px solid #0d6efd; outline-offset: 2px; }
+    .chip.selected {
+        background: #e7f1ff; border-color: #0d6efd; color: #0d6efd; font-weight: 500;
+    }
+    .chip-emoji { font-size: 16px; }
+
+    /* Radio cards */
+    .radio-card-grid {
+        display: grid; grid-template-columns: 1fr 1fr; gap: 10px;
+    }
+    @@media (max-width: 575.98px) {
+        .radio-card-grid { grid-template-columns: 1fr; }
+    }
+    .radio-card {
+        display: flex; flex-direction: column; align-items: center;
+        padding: 16px 12px; border-radius: 10px; cursor: pointer; text-align: center;
+        background: #f8f9fa; border: 1.5px solid #dee2e6; transition: all 0.15s;
+    }
+    .radio-card:hover { border-color: #adb5bd; }
+    .radio-card:focus-visible { outline: 2px solid #0d6efd; outline-offset: 2px; }
+    .radio-card.selected {
+        background: #e7f1ff; border-color: #0d6efd;
+    }
+    .rc-emoji { font-size: 24px; margin-bottom: 6px; }
+    .rc-label { font-weight: 600; font-size: 14px; color: #212529; }
+    .rc-desc { font-size: 12px; color: #6c757d; margin-top: 2px; }
+</style>
+}
+
+@section Scripts {
+<script>
+(function() {
+    const STEPS = [
+        { label: 'Step 1 of 3', title: 'What are you good at?', subtitle: 'Select skills you\'d like to use. You can change these anytime.' },
+        { label: 'Step 2 of 3', title: 'How do you like to work?', subtitle: 'Help coordinators match you with shifts that fit your style and availability.' },
+        { label: 'Step 3 of 3', title: 'Which languages do you speak?', subtitle: 'This helps us match you with teams where you can communicate well.' }
+    ];
+
+    let current = 0;
+    const stepLabel = document.getElementById('stepLabel');
+    const stepTitle = document.getElementById('stepTitle');
+    const stepSubtitle = document.getElementById('stepSubtitle');
+    const backBtn = document.getElementById('backBtn');
+    const nextBtn = document.getElementById('nextBtn');
+    const saveBtn = document.getElementById('saveBtn');
+    const dots = document.querySelectorAll('.progress-dot');
+
+    function setStep(n) {
+        document.getElementById('step-' + current).classList.remove('active');
+        current = n;
+        document.getElementById('step-' + current).classList.add('active');
+
+        stepLabel.textContent = STEPS[n].label;
+        stepTitle.textContent = STEPS[n].title;
+        stepSubtitle.textContent = STEPS[n].subtitle;
+
+        dots.forEach(function(dot, i) {
+            dot.classList.remove('active', 'done');
+            if (i < n) dot.classList.add('done');
+            if (i === n) dot.classList.add('active');
+        });
+
+        backBtn.style.display = n === 0 ? 'none' : '';
+        nextBtn.style.display = n === STEPS.length - 1 ? 'none' : '';
+        saveBtn.style.display = n === STEPS.length - 1 ? '' : 'none';
+    }
+
+    window.nextStep = function() { if (current < STEPS.length - 1) setStep(current + 1); };
+    window.prevStep = function() { if (current > 0) setStep(current - 1); };
+
+    // Chip toggle
+    document.querySelectorAll('.chip').forEach(function(chip) {
+        function toggle() {
+            var cb = chip.querySelector('input[type="checkbox"]');
+            cb.checked = !cb.checked;
+            chip.classList.toggle('selected', cb.checked);
+            chip.setAttribute('aria-checked', cb.checked ? 'true' : 'false');
+        }
+        chip.addEventListener('click', function(e) {
+            if (e.target.tagName !== 'INPUT') toggle();
+        });
+        chip.addEventListener('keydown', function(e) {
+            if (e.key === ' ' || e.key === 'Enter') { e.preventDefault(); toggle(); }
+        });
+    });
+
+    // Radio card toggle
+    document.querySelectorAll('.radio-card').forEach(function(card) {
+        function select() {
+            document.querySelectorAll('.radio-card').forEach(function(c) { c.classList.remove('selected'); });
+            card.classList.add('selected');
+            card.querySelector('input[type="radio"]').checked = true;
+        }
+        card.addEventListener('click', function(e) {
+            if (e.target.tagName !== 'INPUT') select();
+        });
+        card.addEventListener('keydown', function(e) {
+            if (e.key === ' ' || e.key === 'Enter') { e.preventDefault(); select(); }
+        });
+    });
+})();
+</script>
+}
+```
+
+- [ ] **Step 2: Build to verify view compiles**
+
+Run: `dotnet build src/Humans.Web`
+Expected: Build succeeds with no errors.
+
+- [ ] **Step 3: Run all existing tests to verify no regressions**
+
+Run: `dotnet test Humans.slnx -v minimal`
+Expected: All tests pass. No existing tests reference the removed dietary/medical properties on `ShiftInfoViewModel`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Humans.Web/Views/Profile/ShiftInfo.cshtml
+git commit -m "feat(33): rewrite ShiftInfo as 3-step wizard with chips, radio cards, toggles"
+```
+
+---
+
+### Task 4: E2E Smoke Tests
+
+**Files:**
+- Create: `tests/e2e/tests/shift-preferences.spec.ts`
+
+- [ ] **Step 1: Write e2e tests**
+
+Create `tests/e2e/tests/shift-preferences.spec.ts`:
+
+```typescript
+import { test, expect } from '@playwright/test';
+import { loginAsVolunteer } from '../helpers/auth';
+
+test.describe('Shift Preference Wizard (33-shift-preference-wizard)', () => {
+  test('page loads with wizard step 1', async ({ page }) => {
+    await loginAsVolunteer(page);
+    await page.goto('/Profile/ShiftInfo');
+
+    await expect(page.locator('#stepTitle')).toHaveText('What are you good at?');
+    await expect(page.locator('#stepLabel')).toHaveText('Step 1 of 3');
+    await expect(page.locator('.progress-dot.active')).toHaveCount(1);
+  });
+
+  test('can navigate through all 3 steps', async ({ page }) => {
+    await loginAsVolunteer(page);
+    await page.goto('/Profile/ShiftInfo');
+
+    // Step 1 -> Step 2
+    await page.click('#nextBtn');
+    await expect(page.locator('#stepTitle')).toHaveText('How do you like to work?');
+    await expect(page.locator('#stepLabel')).toHaveText('Step 2 of 3');
+
+    // Step 2 -> Step 3
+    await page.click('#nextBtn');
+    await expect(page.locator('#stepTitle')).toHaveText('Which languages do you speak?');
+    await expect(page.locator('#stepLabel')).toHaveText('Step 3 of 3');
+    await expect(page.locator('#saveBtn')).toBeVisible();
+    await expect(page.locator('#nextBtn')).not.toBeVisible();
+  });
+
+  test('can go back from step 3 to step 1', async ({ page }) => {
+    await loginAsVolunteer(page);
+    await page.goto('/Profile/ShiftInfo');
+
+    await page.click('#nextBtn');
+    await page.click('#nextBtn');
+    await page.click('#backBtn');
+    await expect(page.locator('#stepTitle')).toHaveText('How do you like to work?');
+
+    await page.click('#backBtn');
+    await expect(page.locator('#stepTitle')).toHaveText('What are you good at?');
+    await expect(page.locator('#backBtn')).not.toBeVisible();
+  });
+
+  test('selecting a chip toggles it', async ({ page }) => {
+    await loginAsVolunteer(page);
+    await page.goto('/Profile/ShiftInfo');
+
+    const chip = page.locator('.chip', { hasText: 'Bartending' });
+    await chip.click();
+    await expect(chip).toHaveClass(/selected/);
+
+    await chip.click();
+    await expect(chip).not.toHaveClass(/selected/);
+  });
+
+  test('save submits and redirects back', async ({ page }) => {
+    await loginAsVolunteer(page);
+    await page.goto('/Profile/ShiftInfo');
+
+    // Select a skill
+    await page.locator('.chip', { hasText: 'Sound' }).click();
+
+    // Navigate to step 3
+    await page.click('#nextBtn');
+    await page.click('#nextBtn');
+
+    // Save
+    await page.click('#saveBtn');
+
+    // Should redirect back to same page with success message
+    await expect(page).toHaveURL(/\/Profile\/ShiftInfo/);
+  });
+});
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add tests/e2e/tests/shift-preferences.spec.ts
+git commit -m "test(33): add e2e smoke tests for shift preference wizard"
+```
+
+---
+
+### Task 5: Manual Verification & Cleanup
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `dotnet test Humans.slnx -v minimal`
+Expected: All tests pass.
+
+- [ ] **Step 2: Run the app locally and verify the wizard**
+
+Run: `dotnet run --project src/Humans.Web`
+
+Manual checks:
+- Navigate to `/Profile/ShiftInfo`
+- Verify step 1 shows skills as emoji chips
+- Click chips to select/deselect, verify visual toggle
+- Navigate to step 2, verify radio cards and toggle switches
+- Navigate to step 3, verify language chips
+- Save with selections, verify redirect with success message
+- Reload page, verify selections are pre-populated
+- Test on narrow viewport (mobile), verify chips wrap and radio cards stack
+
+- [ ] **Step 3: Verify dietary data is preserved**
+
+Check that an existing user's dietary/allergy/medical data is still in the database (not wiped by saving the wizard). The POST action no longer touches those fields, so they should remain untouched.
+
+- [ ] **Step 4: Update feature doc post-fix check**
+
+Review `docs/features/33-shift-preference-wizard.md` — confirm it matches what was implemented. No changes expected unless implementation deviated from spec.

--- a/docs/superpowers/specs/2026-03-31-shift-preference-wizard-design.md
+++ b/docs/superpowers/specs/2026-03-31-shift-preference-wizard-design.md
@@ -55,6 +55,19 @@ All data stores into the existing `VolunteerEventProfile` entity:
 - Toggle quirks (Sober Shift, etc.) → `Quirks[]`
 - Languages → `Languages[]`
 
+### New Quirk Values
+
+"All Day" and "No Preference" are **new values** being added to the quirk vocabulary. "Early Bird" and "Night Owl" already exist. No downstream impact — the volunteer search builder and shift admin views display quirks as-is from the string array, so new values render without code changes.
+
+### Time Preference Mutual Exclusivity
+
+Time preferences (Early Bird, Night Owl, All Day, No Preference) are mutually exclusive — a human picks exactly one. These are stored in the same `Quirks[]` array alongside toggle quirks, so the save logic must:
+
+1. **On POST:** Remove any existing time preference value from `Quirks[]` before adding the newly selected one. The set of time preference values is: `["Early Bird", "Night Owl", "All Day", "No Preference"]`.
+2. **On GET:** Extract the time preference from `Quirks[]` to pre-select the correct radio card. Toggle quirks populate the switches separately.
+
+The view model should expose `TimePreference` (string, nullable) separately from `SelectedQuirks` (list of toggle quirks) to make this split explicit in the view. The controller merges them back into a single `Quirks[]` on save.
+
 ### Fields Removed From This Page (Not Deleted)
 
 The following fields are no longer editable on `/Profile/ShiftInfo` but remain on `VolunteerEventProfile` and in the database. Existing data is preserved. These will move to the Dietary & Medical Nudge Modal (Feature 35):
@@ -87,7 +100,7 @@ The following fields are no longer editable on `/Profile/ShiftInfo` but remain o
 | File | Change |
 |------|--------|
 | `Views/Profile/ShiftInfo.cshtml` | Full rewrite — flat form → wizard |
-| `Models/ShiftViewModels.cs` | Stop binding dietary/allergy/medical fields |
+| `Models/ShiftViewModels.cs` | Remove dietary/allergy/medical properties; add `TimePreference` property (string); split `SelectedQuirks` to exclude time preferences |
 | `Controllers/ProfileController.cs` | POST stops writing dietary/medical fields; GET stops loading them into view model |
 
 ## Files NOT Modified

--- a/docs/superpowers/specs/2026-03-31-shift-preference-wizard-design.md
+++ b/docs/superpowers/specs/2026-03-31-shift-preference-wizard-design.md
@@ -68,6 +68,10 @@ Time preferences (Early Bird, Night Owl, All Day, No Preference) are mutually ex
 
 The view model should expose `TimePreference` (string, nullable) separately from `SelectedQuirks` (list of toggle quirks) to make this split explicit in the view. The controller merges them back into a single `Quirks[]` on save.
 
+**null vs "No Preference":** `TimePreference = null` means the user has never set a time preference (no radio card pre-selected). "No Preference" is a deliberate choice ("I'll take whatever's needed") and is stored as a quirk value. The wizard allows submitting without selecting a time preference — it's not required.
+
+The set of time preference values should be a `static readonly` array (like the existing `SkillOptions`) so both the strip-on-save and extract-on-load logic reference the same source of truth.
+
 ### Fields Removed From This Page (Not Deleted)
 
 The following fields are no longer editable on `/Profile/ShiftInfo` but remain on `VolunteerEventProfile` and in the database. Existing data is preserved. These will move to the Dietary & Medical Nudge Modal (Feature 35):

--- a/docs/superpowers/specs/2026-03-31-shift-preference-wizard-design.md
+++ b/docs/superpowers/specs/2026-03-31-shift-preference-wizard-design.md
@@ -1,0 +1,112 @@
+# 33 — Shift Preference Wizard
+
+## Business Context
+
+Volunteers need to tell coordinators about their skills, work style preferences, and languages so they can be matched with appropriate shifts. The current `/Profile/ShiftInfo` page is a flat form with bare checkboxes — functional but uninviting, especially on mobile. This feature replaces it with a guided 3-step wizard that collects the same data in a more engaging, mobile-friendly flow.
+
+This is the first of three related features:
+- **33 — Shift Preference Wizard** (this feature): Collect skills, work style, languages
+- **34 — Shift Recommendation Engine**: Fuzzy-match preferences against available shifts (separate spec)
+- **35 — Dietary & Medical Nudge Modal**: Collect dietary/allergy/medical info when a human signs up for a 6+ hour shift where the cantina provides meals (separate spec)
+
+## Authorization
+
+Same as current `/Profile/ShiftInfo` — any authenticated user can view and edit their own shift preferences. No role-based restrictions.
+
+## User Stories
+
+### US-33.1: Set Shift Preferences via Wizard
+**As a** human
+**I want to** set my shift preferences through a guided wizard
+**So that** coordinators can match me with shifts that fit my skills and availability
+
+**Acceptance Criteria:**
+- Wizard replaces the existing flat form at `GET /Profile/ShiftInfo`
+- 3 steps: Skills, Work Style, Languages
+- Step 1 (Skills): emoji-prefixed chip multi-select — Bartending, Cooking, Sound, DJ, First Aid, Electrical, Driving, Construction, Art, Other
+- Step 2 (Work Style): radio cards for time preference (Early Bird, Night Owl, All Day, No Preference) + Bootstrap toggle switches for quirks (Sober Shift, Work In Shade, No Heights, Physical Work OK, Quiet Work)
+- Step 3 (Languages): emoji-prefixed chip multi-select — English, Spanish, French, German, Italian, Portuguese, Other
+- Progress dots in header show current/completed/future steps
+- Step label, title, and subtitle update per step
+- Back/Continue navigation buttons; "Save" on final step
+- Single form POST on save — all selections submitted together
+- Pre-populated with existing `VolunteerEventProfile` data on return visits
+- Mobile-first: chip grid wraps with generous tap targets, radio cards stack vertically on small screens, full-width buttons on mobile
+
+### US-33.2: Accessible Wizard Interactions
+**As a** human using assistive technology
+**I want to** navigate and interact with the wizard using keyboard and screen reader
+**So that** I can set my preferences regardless of how I access the site
+
+**Acceptance Criteria:**
+- Chips backed by hidden checkbox inputs (screen reader accessible)
+- Chips have `role="checkbox"` and `aria-checked`
+- Radio cards backed by hidden radio inputs
+- Keyboard navigation: chips/cards are focusable, spacebar/enter toggles
+- Step transitions do not break focus management
+
+## Data Model
+
+**No schema changes. No migration.**
+
+All data stores into the existing `VolunteerEventProfile` entity:
+- Skills → `Skills[]` (string array)
+- Time preference (Early Bird / Night Owl / All Day / No Preference) → stored as a value in `Quirks[]`
+- Toggle quirks (Sober Shift, etc.) → `Quirks[]`
+- Languages → `Languages[]`
+
+### Fields Removed From This Page (Not Deleted)
+
+The following fields are no longer editable on `/Profile/ShiftInfo` but remain on `VolunteerEventProfile` and in the database. Existing data is preserved. These will move to the Dietary & Medical Nudge Modal (Feature 35):
+- `DietaryPreference`
+- `Allergies[]` + `AllergyOtherText`
+- `Intolerances[]` + `IntoleranceOtherText`
+- `MedicalConditions`
+
+## Visual Design
+
+**Style: Light Subtle** — Bootstrap color palette with custom chip components:
+- Unselected chip: `#f8f9fa` background, `#dee2e6` border, `#495057` text
+- Selected chip: `#e7f1ff` background, `#0d6efd` border, `#0d6efd` text, `font-weight: 500`
+- Emoji prefix on each chip as visual anchor
+- No visible checkboxes — selection indicated by color change
+- Radio cards: larger format with icon, label, description text; 2x2 grid on desktop, single column on mobile
+- Toggle switches: standard Bootstrap `form-check form-switch`
+- Progress: 3 dots (blue filled = active/completed, grey = future)
+
+## Step Content
+
+| Step | Label | Title | Subtitle |
+|------|-------|-------|----------|
+| 1 | Step 1 of 3 | What are you good at? | Select skills you'd like to use. You can change these anytime. |
+| 2 | Step 2 of 3 | How do you like to work? | Help coordinators match you with shifts that fit your style and availability. |
+| 3 | Step 3 of 3 | Which languages do you speak? | This helps us match you with teams where you can communicate well. |
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `Views/Profile/ShiftInfo.cshtml` | Full rewrite — flat form → wizard |
+| `Models/ShiftViewModels.cs` | Stop binding dietary/allergy/medical fields |
+| `Controllers/ProfileController.cs` | POST stops writing dietary/medical fields; GET stops loading them into view model |
+
+## Files NOT Modified
+
+- `VolunteerEventProfile` entity — untouched
+- EF mappings — no migration
+- No new JS files — inline `<script>` in the view
+- No new CSS files — Bootstrap utilities + small `<style>` block
+
+## Entry Points
+
+- Profile page → "Shift Info" link (existing)
+- Dashboard "Things to do" card → "Set up" action (issue #273)
+- Any future contextual links can point to `/Profile/ShiftInfo`
+
+## Related Features
+
+- [25 — Shift Management](25-shift-management.md): parent shift system
+- [Issue #273](https://github.com/nobodies-collective/Humans/issues/273): Dashboard "Things to do" wizard card
+- [Issue #186](https://github.com/nobodies-collective/Humans/issues/186): Custom labels/tags on rotas (future matching input)
+- Feature 34 — Shift Recommendation Engine (not yet specced)
+- [Feature 35 — Dietary & Medical Nudge Modal](35-dietary-medical-nudge.md) (placeholder)

--- a/src/Humans.Web/Controllers/ProfileController.cs
+++ b/src/Humans.Web/Controllers/ProfileController.cs
@@ -806,17 +806,13 @@ public class ProfileController : HumansControllerBase
 
             var profile = await _profileService.GetShiftProfileAsync(user.Id, includeMedical: true);
 
+            var quirks = profile?.Quirks ?? [];
             var viewModel = new ShiftInfoViewModel
             {
                 SelectedSkills = profile?.Skills ?? [],
-                SelectedQuirks = profile?.Quirks ?? [],
-                SelectedAllergies = profile?.Allergies ?? [],
-                SelectedIntolerances = profile?.Intolerances ?? [],
+                SelectedQuirks = ShiftInfoViewModel.ExtractToggleQuirks(quirks),
+                TimePreference = ShiftInfoViewModel.ExtractTimePreference(quirks),
                 SelectedLanguages = profile?.Languages ?? [],
-                DietaryPreference = profile?.DietaryPreference,
-                MedicalConditions = profile?.MedicalConditions,
-                AllergyOtherText = profile?.AllergyOtherText,
-                IntoleranceOtherText = profile?.IntoleranceOtherText
             };
 
             return View(viewModel);
@@ -842,14 +838,8 @@ public class ProfileController : HumansControllerBase
             var shiftProfile = await _profileService.GetOrCreateShiftProfileAsync(user.Id);
 
             shiftProfile.Skills = model.SelectedSkills ?? [];
-            shiftProfile.Quirks = model.SelectedQuirks ?? [];
-            shiftProfile.Allergies = model.SelectedAllergies ?? [];
-            shiftProfile.Intolerances = model.SelectedIntolerances ?? [];
-            shiftProfile.AllergyOtherText = model.SelectedAllergies?.Contains("Other", StringComparer.Ordinal) == true ? model.AllergyOtherText : null;
-            shiftProfile.IntoleranceOtherText = model.SelectedIntolerances?.Contains("Other", StringComparer.Ordinal) == true ? model.IntoleranceOtherText : null;
+            shiftProfile.Quirks = ShiftInfoViewModel.MergeQuirks(model.TimePreference, model.SelectedQuirks ?? []);
             shiftProfile.Languages = model.SelectedLanguages ?? [];
-            shiftProfile.DietaryPreference = model.DietaryPreference;
-            shiftProfile.MedicalConditions = model.MedicalConditions;
 
             await _profileService.UpdateShiftProfileAsync(shiftProfile);
 

--- a/src/Humans.Web/Controllers/ProfileController.cs
+++ b/src/Humans.Web/Controllers/ProfileController.cs
@@ -807,13 +807,22 @@ public class ProfileController : HumansControllerBase
             var profile = await _profileService.GetShiftProfileAsync(user.Id, includeMedical: false);
 
             var quirks = profile?.Quirks ?? [];
+            var skills = profile?.Skills ?? [];
+            var languages = profile?.Languages ?? [];
             var viewModel = new ShiftInfoViewModel
             {
-                SelectedSkills = profile?.Skills ?? [],
+                SelectedSkills = skills.Where(s => !s.StartsWith("Other:", StringComparison.Ordinal)).ToList(),
+                SkillOtherText = skills.FirstOrDefault(s => s.StartsWith("Other:", StringComparison.Ordinal))?.Substring(6).Trim(),
                 SelectedQuirks = ShiftInfoViewModel.ExtractToggleQuirks(quirks),
                 TimePreference = ShiftInfoViewModel.ExtractTimePreference(quirks),
-                SelectedLanguages = profile?.Languages ?? [],
+                SelectedLanguages = languages.Where(l => !l.StartsWith("Other:", StringComparison.Ordinal)).ToList(),
+                LanguageOtherText = languages.FirstOrDefault(l => l.StartsWith("Other:", StringComparison.Ordinal))?.Substring(6).Trim(),
             };
+            // If there was "Other: text" stored, ensure "Other" is in the selected list
+            if (viewModel.SkillOtherText is not null && !viewModel.SelectedSkills.Contains("Other", StringComparer.Ordinal))
+                viewModel.SelectedSkills.Add("Other");
+            if (viewModel.LanguageOtherText is not null && !viewModel.SelectedLanguages.Contains("Other", StringComparer.Ordinal))
+                viewModel.SelectedLanguages.Add("Other");
 
             return View(viewModel);
         }
@@ -837,9 +846,21 @@ public class ProfileController : HumansControllerBase
 
             var shiftProfile = await _profileService.GetOrCreateShiftProfileAsync(user.Id);
 
-            shiftProfile.Skills = model.SelectedSkills ?? [];
+            var skills = model.SelectedSkills ?? [];
+            if (skills.Contains("Other", StringComparer.Ordinal) && !string.IsNullOrWhiteSpace(model.SkillOtherText))
+            {
+                skills.Remove("Other");
+                skills.Add($"Other: {model.SkillOtherText.Trim()}");
+            }
+            shiftProfile.Skills = skills;
             shiftProfile.Quirks = ShiftInfoViewModel.MergeQuirks(model.TimePreference, model.SelectedQuirks ?? []);
-            shiftProfile.Languages = model.SelectedLanguages ?? [];
+            var languages = model.SelectedLanguages ?? [];
+            if (languages.Contains("Other", StringComparer.Ordinal) && !string.IsNullOrWhiteSpace(model.LanguageOtherText))
+            {
+                languages.Remove("Other");
+                languages.Add($"Other: {model.LanguageOtherText.Trim()}");
+            }
+            shiftProfile.Languages = languages;
 
             await _profileService.UpdateShiftProfileAsync(shiftProfile);
 

--- a/src/Humans.Web/Controllers/ProfileController.cs
+++ b/src/Humans.Web/Controllers/ProfileController.cs
@@ -804,7 +804,7 @@ public class ProfileController : HumansControllerBase
             if (user is null)
                 return NotFound();
 
-            var profile = await _profileService.GetShiftProfileAsync(user.Id, includeMedical: true);
+            var profile = await _profileService.GetShiftProfileAsync(user.Id, includeMedical: false);
 
             var quirks = profile?.Quirks ?? [];
             var viewModel = new ShiftInfoViewModel

--- a/src/Humans.Web/Models/ShiftViewModels.cs
+++ b/src/Humans.Web/Models/ShiftViewModels.cs
@@ -259,26 +259,70 @@ public class UrgentShiftItem
 public class ShiftInfoViewModel
 {
     public List<string> SelectedSkills { get; set; } = [];
-    public List<string> SelectedQuirks { get; set; } = [];
-    public List<string> SelectedAllergies { get; set; } = [];
-    public List<string> SelectedIntolerances { get; set; } = [];
+    public List<string> SelectedQuirks { get; set; } = []; // Toggle quirks only (no time prefs)
+    public string? TimePreference { get; set; } // Mutually exclusive: Early Bird, Night Owl, All Day, No Preference
     public List<string> SelectedLanguages { get; set; } = [];
-    public string? DietaryPreference { get; set; }
 
-    [DataType(DataType.MultilineText)]
-    [Display(Name = "Medical Conditions")]
-    public string? MedicalConditions { get; set; }
-
-    // Defined options from spec
+    // Skill options with emoji prefixes for display
     public static readonly string[] SkillOptions = ["Bartending", "First Aid", "Driving", "Sound", "Electrical", "Construction", "Cooking", "Art", "DJ", "Other"];
-    public static readonly string[] QuirkOptions = ["Sober Shift", "Work In Shade", "Night Owl", "Early Bird", "Quiet Work", "Physical Work OK", "No Heights"];
-    public string? AllergyOtherText { get; set; }
-    public string? IntoleranceOtherText { get; set; }
-
-    public static readonly string[] AllergyOptions = ["Celiac", "Shellfish", "Nuts", "Tree Nuts", "Soy", "Egg", "Other"];
-    public static readonly string[] IntoleranceOptions = ["Gluten", "Peppers", "Shellfish", "Nuts", "Egg", "Lactose", "Other"];
-    public static readonly string[] DietaryOptions = ["Omnivore", "Vegetarian", "Vegan", "Pescatarian"];
     public static readonly string[] LanguageOptions = ["English", "Spanish", "German", "French", "Italian", "Portuguese", "Other"];
+
+    // Time preferences — mutually exclusive, stored as quirk value
+    public static readonly string[] TimePreferenceOptions = ["Early Bird", "Night Owl", "All Day", "No Preference"];
+
+    // Toggle quirks — multi-select, separate from time preference
+    public static readonly string[] ToggleQuirkOptions = ["Sober Shift", "Work In Shade", "Quiet Work", "Physical Work OK", "No Heights"];
+
+    // Combined QuirkOptions kept for backward compatibility (downstream consumers read quirks as flat array)
+    public static readonly string[] QuirkOptions = [.. ToggleQuirkOptions, .. TimePreferenceOptions];
+
+    // Emoji maps for view rendering
+    public static readonly Dictionary<string, string> SkillEmoji = new(StringComparer.Ordinal)
+    {
+        ["Bartending"] = "\U0001f378", ["Cooking"] = "\U0001f373", ["Sound"] = "\U0001f39a\ufe0f",
+        ["DJ"] = "\U0001f3a7", ["First Aid"] = "\U0001fa7a", ["Electrical"] = "\u26a1",
+        ["Driving"] = "\U0001f697", ["Construction"] = "\U0001f528", ["Art"] = "\U0001f3a8",
+        ["Other"] = "\u2728"
+    };
+
+    public static readonly Dictionary<string, string> LanguageEmoji = new(StringComparer.Ordinal)
+    {
+        ["English"] = "\U0001f1ec\U0001f1e7", ["Spanish"] = "\U0001f1ea\U0001f1f8",
+        ["French"] = "\U0001f1eb\U0001f1f7", ["German"] = "\U0001f1e9\U0001f1ea",
+        ["Italian"] = "\U0001f1ee\U0001f1f9", ["Portuguese"] = "\U0001f1f5\U0001f1f9",
+        ["Other"] = "\U0001f30d"
+    };
+
+    public static readonly Dictionary<string, string> TimePreferenceEmoji = new(StringComparer.Ordinal)
+    {
+        ["Early Bird"] = "\U0001f305", ["Night Owl"] = "\U0001f319",
+        ["All Day"] = "\u2600\ufe0f", ["No Preference"] = "\U0001f937"
+    };
+
+    public static readonly Dictionary<string, string> TimePreferenceDesc = new(StringComparer.Ordinal)
+    {
+        ["Early Bird"] = "Morning shifts, set up and prep",
+        ["Night Owl"] = "Evening and late-night shifts",
+        ["All Day"] = "Flexible, morning through evening",
+        ["No Preference"] = "I'll take whatever's needed"
+    };
+
+    /// <summary>Extract the time preference value from a flat quirks array.</summary>
+    public static string? ExtractTimePreference(List<string> quirks)
+        => quirks.FirstOrDefault(q => TimePreferenceOptions.Contains(q, StringComparer.Ordinal));
+
+    /// <summary>Extract toggle quirks (excluding time preferences) from a flat quirks array.</summary>
+    public static List<string> ExtractToggleQuirks(List<string> quirks)
+        => quirks.Where(q => !TimePreferenceOptions.Contains(q, StringComparer.Ordinal)).ToList();
+
+    /// <summary>Merge a time preference and toggle quirks back into a flat quirks array.</summary>
+    public static List<string> MergeQuirks(string? timePreference, List<string> toggleQuirks)
+    {
+        var result = new List<string>(toggleQuirks ?? []);
+        if (!string.IsNullOrEmpty(timePreference))
+            result.Add(timePreference);
+        return result;
+    }
 }
 
 // === Dashboard ===

--- a/src/Humans.Web/Models/ShiftViewModels.cs
+++ b/src/Humans.Web/Models/ShiftViewModels.cs
@@ -273,9 +273,6 @@ public class ShiftInfoViewModel
     // Toggle quirks — multi-select, separate from time preference
     public static readonly string[] ToggleQuirkOptions = ["Sober Shift", "Work In Shade", "Quiet Work", "Physical Work OK", "No Heights"];
 
-    // Combined QuirkOptions kept for backward compatibility (downstream consumers read quirks as flat array)
-    public static readonly string[] QuirkOptions = [.. ToggleQuirkOptions, .. TimePreferenceOptions];
-
     // Emoji maps for view rendering
     public static readonly Dictionary<string, string> SkillEmoji = new(StringComparer.Ordinal)
     {

--- a/src/Humans.Web/Models/ShiftViewModels.cs
+++ b/src/Humans.Web/Models/ShiftViewModels.cs
@@ -259,9 +259,11 @@ public class UrgentShiftItem
 public class ShiftInfoViewModel
 {
     public List<string> SelectedSkills { get; set; } = [];
+    public string? SkillOtherText { get; set; }
     public List<string> SelectedQuirks { get; set; } = []; // Toggle quirks only (no time prefs)
     public string? TimePreference { get; set; } // Mutually exclusive: Early Bird, Night Owl, All Day, No Preference
     public List<string> SelectedLanguages { get; set; } = [];
+    public string? LanguageOtherText { get; set; }
 
     // Skill options with emoji prefixes for display
     public static readonly string[] SkillOptions = ["Bartending", "First Aid", "Driving", "Sound", "Electrical", "Construction", "Cooking", "Art", "DJ", "Other"];
@@ -284,9 +286,9 @@ public class ShiftInfoViewModel
 
     public static readonly Dictionary<string, string> LanguageEmoji = new(StringComparer.Ordinal)
     {
-        ["English"] = "\U0001f1ec\U0001f1e7", ["Spanish"] = "\U0001f1ea\U0001f1f8",
-        ["French"] = "\U0001f1eb\U0001f1f7", ["German"] = "\U0001f1e9\U0001f1ea",
-        ["Italian"] = "\U0001f1ee\U0001f1f9", ["Portuguese"] = "\U0001f1f5\U0001f1f9",
+        ["English"] = "EN", ["Spanish"] = "ES",
+        ["French"] = "FR", ["German"] = "DE",
+        ["Italian"] = "IT", ["Portuguese"] = "PT",
         ["Other"] = "\U0001f30d"
     };
 

--- a/src/Humans.Web/Models/ShiftViewModels.cs
+++ b/src/Humans.Web/Models/ShiftViewModels.cs
@@ -278,24 +278,35 @@ public class ShiftInfoViewModel
     // Emoji maps for view rendering
     public static readonly Dictionary<string, string> SkillEmoji = new(StringComparer.Ordinal)
     {
-        ["Bartending"] = "\U0001f378", ["Cooking"] = "\U0001f373", ["Sound"] = "\U0001f39a\ufe0f",
-        ["DJ"] = "\U0001f3a7", ["First Aid"] = "\U0001fa7a", ["Electrical"] = "\u26a1",
-        ["Driving"] = "\U0001f697", ["Construction"] = "\U0001f528", ["Art"] = "\U0001f3a8",
+        ["Bartending"] = "\U0001f378",
+        ["Cooking"] = "\U0001f373",
+        ["Sound"] = "\U0001f39a\ufe0f",
+        ["DJ"] = "\U0001f3a7",
+        ["First Aid"] = "\U0001fa7a",
+        ["Electrical"] = "\u26a1",
+        ["Driving"] = "\U0001f697",
+        ["Construction"] = "\U0001f528",
+        ["Art"] = "\U0001f3a8",
         ["Other"] = "\u2728"
     };
 
     public static readonly Dictionary<string, string> LanguageEmoji = new(StringComparer.Ordinal)
     {
-        ["English"] = "EN", ["Spanish"] = "ES",
-        ["French"] = "FR", ["German"] = "DE",
-        ["Italian"] = "IT", ["Portuguese"] = "PT",
+        ["English"] = "EN",
+        ["Spanish"] = "ES",
+        ["French"] = "FR",
+        ["German"] = "DE",
+        ["Italian"] = "IT",
+        ["Portuguese"] = "PT",
         ["Other"] = "\U0001f30d"
     };
 
     public static readonly Dictionary<string, string> TimePreferenceEmoji = new(StringComparer.Ordinal)
     {
-        ["Early Bird"] = "\U0001f305", ["Night Owl"] = "\U0001f319",
-        ["All Day"] = "\u2600\ufe0f", ["No Preference"] = "\U0001f937"
+        ["Early Bird"] = "\U0001f305",
+        ["Night Owl"] = "\U0001f319",
+        ["All Day"] = "\u2600\ufe0f",
+        ["No Preference"] = "\U0001f937"
     };
 
     public static readonly Dictionary<string, string> TimePreferenceDesc = new(StringComparer.Ordinal)

--- a/src/Humans.Web/Views/Profile/ShiftInfo.cshtml
+++ b/src/Humans.Web/Views/Profile/ShiftInfo.cshtml
@@ -92,20 +92,6 @@
                 </div>
             </div>
 
-            @* Preserve dietary/medical fields (added on main, not yet integrated into wizard UI) *@
-            <input type="hidden" name="DietaryPreference" value="@Model.DietaryPreference" />
-            @foreach (var allergy in Model.SelectedAllergies)
-            {
-                <input type="hidden" name="SelectedAllergies" value="@allergy" />
-            }
-            <input type="hidden" name="AllergyOtherText" value="@Model.AllergyOtherText" />
-            @foreach (var intolerance in Model.SelectedIntolerances)
-            {
-                <input type="hidden" name="SelectedIntolerances" value="@intolerance" />
-            }
-            <input type="hidden" name="IntoleranceOtherText" value="@Model.IntoleranceOtherText" />
-            <input type="hidden" name="MedicalConditions" value="@Model.MedicalConditions" />
-
             @* ===== Navigation ===== *@
             <div class="d-flex justify-content-between align-items-center mt-4">
                 <button type="button" class="btn btn-outline-secondary" id="backBtn" style="display:none">

--- a/src/Humans.Web/Views/Profile/ShiftInfo.cshtml
+++ b/src/Humans.Web/Views/Profile/ShiftInfo.cshtml
@@ -109,7 +109,7 @@
     </div>
 </div>
 
-@section Styles {
+@section Scripts {
 <style>
     /* Progress dots */
     .progress-dot {
@@ -158,9 +158,6 @@
     .rc-label { font-weight: 600; font-size: 14px; color: #212529; }
     .rc-desc { font-size: 12px; color: #6c757d; margin-top: 2px; }
 </style>
-}
-
-@section Scripts {
 <script>
 (function() {
     const STEPS = [

--- a/src/Humans.Web/Views/Profile/ShiftInfo.cshtml
+++ b/src/Humans.Web/Views/Profile/ShiftInfo.cshtml
@@ -108,11 +108,11 @@
 
             @* ===== Navigation ===== *@
             <div class="d-flex justify-content-between align-items-center mt-4">
-                <button type="button" class="btn btn-outline-secondary" id="backBtn" style="display:none" onclick="prevStep()">
+                <button type="button" class="btn btn-outline-secondary" id="backBtn" style="display:none">
                     &larr; Back
                 </button>
                 <div></div>
-                <button type="button" class="btn btn-primary" id="nextBtn" onclick="nextStep()">
+                <button type="button" class="btn btn-primary" id="nextBtn">
                     Continue &rarr;
                 </button>
                 <button type="submit" class="btn btn-primary" id="saveBtn" style="display:none">
@@ -212,8 +212,8 @@
         saveBtn.style.display = n === STEPS.length - 1 ? '' : 'none';
     }
 
-    window.nextStep = function() { if (current < STEPS.length - 1) setStep(current + 1); };
-    window.prevStep = function() { if (current > 0) setStep(current - 1); };
+    backBtn.addEventListener('click', function() { if (current > 0) setStep(current - 1); });
+    nextBtn.addEventListener('click', function() { if (current < STEPS.length - 1) setStep(current + 1); });
 
     // Chip toggle
     document.querySelectorAll('.chip').forEach(function(chip) {

--- a/src/Humans.Web/Views/Profile/ShiftInfo.cshtml
+++ b/src/Humans.Web/Views/Profile/ShiftInfo.cshtml
@@ -43,6 +43,10 @@
                         </label>
                     }
                 </div>
+                <div class="other-text-input mt-3" style="display: @(Model.SelectedSkills.Contains("Other") ? "block" : "none");">
+                    <input type="text" name="SkillOtherText" class="form-control" maxlength="200"
+                           value="@Model.SkillOtherText" placeholder="What other skills do you have?" />
+                </div>
             </div>
 
             @* ===== STEP 1: Work Style ===== *@
@@ -90,6 +94,10 @@
                         </label>
                     }
                 </div>
+                <div class="other-text-input mt-3" style="display: @(Model.SelectedLanguages.Contains("Other") ? "block" : "none");">
+                    <input type="text" name="LanguageOtherText" class="form-control" maxlength="200"
+                           value="@Model.LanguageOtherText" placeholder="What other languages do you speak?" />
+                </div>
             </div>
 
             @* ===== Navigation ===== *@
@@ -135,7 +143,7 @@
     .chip.selected {
         background: #e7f1ff; border-color: #0d6efd; color: #0d6efd; font-weight: 500;
     }
-    .chip-emoji { font-size: 16px; }
+    .chip-emoji { font-size: 16px; min-width: 1.5em; text-align: center; }
 
     /* Radio cards */
     .radio-card-grid {
@@ -205,9 +213,15 @@
             cb.checked = !cb.checked;
             chip.classList.toggle('selected', cb.checked);
             chip.setAttribute('aria-checked', cb.checked ? 'true' : 'false');
+            // Show/hide "Other" text input if this chip is the Other option
+            var otherInput = chip.closest('.step-pane')?.querySelector('.other-text-input');
+            if (otherInput && chip.textContent.trim().endsWith('Other')) {
+                otherInput.style.display = cb.checked ? 'block' : 'none';
+            }
         }
         chip.addEventListener('click', function(e) {
-            if (e.target.tagName !== 'INPUT') toggle();
+            e.preventDefault();
+            toggle();
         });
         chip.addEventListener('keydown', function(e) {
             if (e.key === ' ' || e.key === 'Enter') { e.preventDefault(); toggle(); }

--- a/src/Humans.Web/Views/Profile/ShiftInfo.cshtml
+++ b/src/Humans.Web/Views/Profile/ShiftInfo.cshtml
@@ -1,189 +1,250 @@
 @model Humans.Web.Models.ShiftInfoViewModel
 @{
-    ViewData["Title"] = "Shift Info";
+    ViewData["Title"] = "Shift Preferences";
 }
 
 <div class="row">
-    <div class="col-12" style="max-width: 900px;">
+    <div class="col-12" style="max-width: 560px; margin: 0 auto;">
         <nav aria-label="breadcrumb">
             <ol class="breadcrumb">
                 <li class="breadcrumb-item"><a asp-action="Index">Profile</a></li>
-                <li class="breadcrumb-item active" aria-current="page">Shift Info</li>
+                <li class="breadcrumb-item active" aria-current="page">Shift Preferences</li>
             </ol>
         </nav>
 
-        <h1>Shift Info</h1>
-        <p class="text-muted">Skills, preferences, and other information for shift coordination.</p>
-
         <vc:temp-data-alerts />
 
-        <form asp-action="ShiftInfo" method="post">
+        @* Wizard header *@
+        <div class="text-center mb-4">
+            <div class="text-muted text-uppercase small" id="stepLabel">Step 1 of 3</div>
+            <h1 class="h4 mt-1 mb-1" id="stepTitle">What are you good at?</h1>
+            <p class="text-muted small" id="stepSubtitle">Select skills you'd like to use. You can change these anytime.</p>
+            <div class="d-flex justify-content-center gap-2 mt-3" id="progressDots">
+                <span class="progress-dot active" data-step="0"></span>
+                <span class="progress-dot" data-step="1"></span>
+                <span class="progress-dot" data-step="2"></span>
+            </div>
+        </div>
+
+        <form asp-action="ShiftInfo" method="post" id="wizardForm">
             @Html.AntiForgeryToken()
 
-            @* Skills *@
-            <div class="card mb-4">
-                <div class="card-body">
-                    <label class="form-label fw-bold">Skills</label>
-                    <div class="row">
-                        @foreach (var skill in Humans.Web.Models.ShiftInfoViewModel.SkillOptions)
-                        {
-                            <div class="col-md-4 mb-1">
-                                <div class="form-check">
-                                    <input type="checkbox" name="SelectedSkills" value="@skill" class="form-check-input"
-                                           @(Model.SelectedSkills.Contains(skill) ? "checked" : null) />
-                                    <label class="form-check-label">@skill</label>
-                                </div>
-                            </div>
-                        }
-                    </div>
+            @* ===== STEP 0: Skills ===== *@
+            <div class="step-pane active" id="step-0">
+                <div class="chip-grid">
+                    @foreach (var skill in Humans.Web.Models.ShiftInfoViewModel.SkillOptions)
+                    {
+                        var isSelected = Model.SelectedSkills.Contains(skill);
+                        var emoji = Humans.Web.Models.ShiftInfoViewModel.SkillEmoji.GetValueOrDefault(skill, "");
+                        <label class="chip @(isSelected ? "selected" : "")" role="checkbox" aria-checked="@(isSelected ? "true" : "false")" tabindex="0">
+                            <input type="checkbox" name="SelectedSkills" value="@skill" class="d-none"
+                                   @(isSelected ? "checked" : "") />
+                            <span class="chip-emoji">@emoji</span> @skill
+                        </label>
+                    }
                 </div>
             </div>
 
-            @* Work Preferences (Toggle Quirks) *@
-            <div class="card mb-4">
-                <div class="card-body">
-                    <label class="form-label fw-bold">Work Preferences</label>
-                    <div class="row">
-                        @foreach (var quirk in Humans.Web.Models.ShiftInfoViewModel.ToggleQuirkOptions)
-                        {
-                            <div class="col-md-4 mb-1">
-                                <div class="form-check">
-                                    <input type="checkbox" name="SelectedQuirks" value="@quirk" class="form-check-input"
-                                           @(Model.SelectedQuirks.Contains(quirk) ? "checked" : null) />
-                                    <label class="form-check-label">@quirk</label>
-                                </div>
-                            </div>
-                        }
+            @* ===== STEP 1: Work Style ===== *@
+            <div class="step-pane" id="step-1">
+                <p class="fw-bold small text-muted mb-2">When do you prefer to work?</p>
+                <div class="radio-card-grid">
+                    @foreach (var tp in Humans.Web.Models.ShiftInfoViewModel.TimePreferenceOptions)
+                    {
+                        var isSelected = string.Equals(Model.TimePreference, tp, StringComparison.Ordinal);
+                        var emoji = Humans.Web.Models.ShiftInfoViewModel.TimePreferenceEmoji.GetValueOrDefault(tp, "");
+                        var desc = Humans.Web.Models.ShiftInfoViewModel.TimePreferenceDesc.GetValueOrDefault(tp, "");
+                        <label class="radio-card @(isSelected ? "selected" : "")" tabindex="0">
+                            <input type="radio" name="TimePreference" value="@tp" class="d-none"
+                                   @(isSelected ? "checked" : "") />
+                            <div class="rc-emoji">@emoji</div>
+                            <div class="rc-label">@tp</div>
+                            <div class="rc-desc">@desc</div>
+                        </label>
+                    }
+                </div>
+
+                <p class="fw-bold small text-muted mb-2 mt-4">Other preferences</p>
+                @foreach (var quirk in Humans.Web.Models.ShiftInfoViewModel.ToggleQuirkOptions)
+                {
+                    var isChecked = Model.SelectedQuirks.Contains(quirk);
+                    <div class="form-check form-switch mb-2">
+                        <input type="checkbox" name="SelectedQuirks" value="@quirk" class="form-check-input"
+                               id="quirk-@quirk.Replace(" ", "-")" @(isChecked ? "checked" : "") />
+                        <label class="form-check-label" for="quirk-@quirk.Replace(" ", "-")">@quirk</label>
                     </div>
+                }
+            </div>
+
+            @* ===== STEP 2: Languages ===== *@
+            <div class="step-pane" id="step-2">
+                <div class="chip-grid">
+                    @foreach (var lang in Humans.Web.Models.ShiftInfoViewModel.LanguageOptions)
+                    {
+                        var isSelected = Model.SelectedLanguages.Contains(lang);
+                        var emoji = Humans.Web.Models.ShiftInfoViewModel.LanguageEmoji.GetValueOrDefault(lang, "");
+                        <label class="chip @(isSelected ? "selected" : "")" role="checkbox" aria-checked="@(isSelected ? "true" : "false")" tabindex="0">
+                            <input type="checkbox" name="SelectedLanguages" value="@lang" class="d-none"
+                                   @(isSelected ? "checked" : "") />
+                            <span class="chip-emoji">@emoji</span> @lang
+                        </label>
+                    }
                 </div>
             </div>
 
-            @* Time Preference *@
-            <div class="card mb-4">
-                <div class="card-body">
-                    <label class="form-label fw-bold">Time Preference</label>
-                    <div class="row">
-                        @foreach (var pref in Humans.Web.Models.ShiftInfoViewModel.TimePreferenceOptions)
-                        {
-                            <div class="col-md-3 mb-1">
-                                <div class="form-check">
-                                    <input type="radio" name="TimePreference" value="@pref" class="form-check-input"
-                                           @(string.Equals(Model.TimePreference, pref, StringComparison.Ordinal) ? "checked" : "") />
-                                    <label class="form-check-label">@pref</label>
-                                </div>
-                            </div>
-                        }
-                    </div>
-                </div>
-            </div>
+            @* Preserve dietary/medical fields (added on main, not yet integrated into wizard UI) *@
+            <input type="hidden" name="DietaryPreference" value="@Model.DietaryPreference" />
+            @foreach (var allergy in Model.SelectedAllergies)
+            {
+                <input type="hidden" name="SelectedAllergies" value="@allergy" />
+            }
+            <input type="hidden" name="AllergyOtherText" value="@Model.AllergyOtherText" />
+            @foreach (var intolerance in Model.SelectedIntolerances)
+            {
+                <input type="hidden" name="SelectedIntolerances" value="@intolerance" />
+            }
+            <input type="hidden" name="IntoleranceOtherText" value="@Model.IntoleranceOtherText" />
+            <input type="hidden" name="MedicalConditions" value="@Model.MedicalConditions" />
 
-            @* Languages *@
-            <div class="card mb-4">
-                <div class="card-body">
-                    <label class="form-label fw-bold">Languages</label>
-                    <div class="row">
-                        @foreach (var lang in Humans.Web.Models.ShiftInfoViewModel.LanguageOptions)
-                        {
-                            <div class="col-md-4 mb-1">
-                                <div class="form-check">
-                                    <input type="checkbox" name="SelectedLanguages" value="@lang" class="form-check-input"
-                                           @(Model.SelectedLanguages.Contains(lang) ? "checked" : null) />
-                                    <label class="form-check-label">@lang</label>
-                                </div>
-                            </div>
-                        }
-                    </div>
-                </div>
-            </div>
-
-            @* Dietary *@
-            <div class="card mb-4">
-                <div class="card-body">
-                    <label class="form-label fw-bold">Dietary Preference</label>
-                    <div class="row">
-                        @foreach (var diet in Humans.Web.Models.ShiftInfoViewModel.DietaryOptions)
-                        {
-                            <div class="col-md-3 mb-1">
-                                <div class="form-check">
-                                    <input type="radio" name="DietaryPreference" value="@diet" class="form-check-input"
-                                           @(string.Equals(Model.DietaryPreference, diet, StringComparison.Ordinal) ? "checked" : null) />
-                                    <label class="form-check-label">@diet</label>
-                                </div>
-                            </div>
-                        }
-                        <div class="col-md-3 mb-1">
-                            <div class="form-check">
-                                <input type="radio" name="DietaryPreference" value="" class="form-check-input"
-                                       @(string.IsNullOrEmpty(Model.DietaryPreference) ? "checked" : null) />
-                                <label class="form-check-label text-muted">Not specified</label>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-
-            @* Allergies *@
-            <div class="card mb-4">
-                <div class="card-body">
-                    <label class="form-label fw-bold">Allergies</label>
-                    <div class="row">
-                        @foreach (var allergy in Humans.Web.Models.ShiftInfoViewModel.AllergyOptions)
-                        {
-                            <div class="col-md-4 mb-1">
-                                <div class="form-check">
-                                    <input type="checkbox" name="SelectedAllergies" value="@allergy" class="form-check-input"
-                                           @(Model.SelectedAllergies.Contains(allergy) ? "checked" : null)
-                                           @(string.Equals(allergy, "Other", StringComparison.Ordinal) ? "data-toggle-target=allergyOtherText" : "") />
-                                    <label class="form-check-label">@allergy</label>
-                                </div>
-                            </div>
-                        }
-                    </div>
-                    <div id="allergyOtherText" class="mt-2" style="display: @(Model.SelectedAllergies.Contains("Other") ? "block" : "none");">
-                        <input type="text" name="AllergyOtherText" class="form-control" maxlength="500"
-                               value="@Model.AllergyOtherText" placeholder="Please specify your other allergy" />
-                    </div>
-                </div>
-            </div>
-
-            @* Intolerances *@
-            <div class="card mb-4">
-                <div class="card-body">
-                    <label class="form-label fw-bold">Intolerances</label>
-                    <div class="row">
-                        @foreach (var intolerance in Humans.Web.Models.ShiftInfoViewModel.IntoleranceOptions)
-                        {
-                            <div class="col-md-4 mb-1">
-                                <div class="form-check">
-                                    <input type="checkbox" name="SelectedIntolerances" value="@intolerance" class="form-check-input"
-                                           @(Model.SelectedIntolerances.Contains(intolerance) ? "checked" : null)
-                                           @(string.Equals(intolerance, "Other", StringComparison.Ordinal) ? "data-toggle-target=intoleranceOtherText" : "") />
-                                    <label class="form-check-label">@intolerance</label>
-                                </div>
-                            </div>
-                        }
-                    </div>
-                    <div id="intoleranceOtherText" class="mt-2" style="display: @(Model.SelectedIntolerances.Contains("Other") ? "block" : "none");">
-                        <input type="text" name="IntoleranceOtherText" class="form-control" maxlength="500"
-                               value="@Model.IntoleranceOtherText" placeholder="Please specify your other intolerance" />
-                    </div>
-                </div>
-            </div>
-
-            @* Medical Conditions *@
-            <div class="card mb-4">
-                <div class="card-body">
-                    <label for="MedicalConditions" class="form-label fw-bold">Medical Conditions</label>
-                    <textarea id="MedicalConditions" name="MedicalConditions" class="form-control" rows="3"
-                              placeholder="Any conditions shift coordinators should know about">@Model.MedicalConditions</textarea>
-                    <div class="form-text text-warning">Visible only to you, NoInfo Admins, and Admins.</div>
-                </div>
-            </div>
-
-            <div class="d-flex justify-content-between">
-                <a asp-action="Index" class="btn btn-outline-secondary">Back to Profile</a>
-                <button type="submit" class="btn btn-primary">Save</button>
+            @* ===== Navigation ===== *@
+            <div class="d-flex justify-content-between align-items-center mt-4">
+                <button type="button" class="btn btn-outline-secondary" id="backBtn" style="display:none" onclick="prevStep()">
+                    &larr; Back
+                </button>
+                <div></div>
+                <button type="button" class="btn btn-primary" id="nextBtn" onclick="nextStep()">
+                    Continue &rarr;
+                </button>
+                <button type="submit" class="btn btn-primary" id="saveBtn" style="display:none">
+                    Save
+                </button>
             </div>
         </form>
     </div>
 </div>
+
+@section Styles {
+<style>
+    /* Progress dots */
+    .progress-dot {
+        width: 10px; height: 10px; border-radius: 50%;
+        background: #dee2e6; display: inline-block; transition: background 0.2s;
+    }
+    .progress-dot.active, .progress-dot.done { background: #0d6efd; }
+
+    /* Step panes */
+    .step-pane { display: none; }
+    .step-pane.active { display: block; }
+
+    /* Chip grid */
+    .chip-grid { display: flex; flex-wrap: wrap; gap: 10px; }
+    .chip {
+        display: inline-flex; align-items: center; gap: 4px;
+        padding: 9px 16px; border-radius: 10px; cursor: pointer;
+        background: #f8f9fa; border: 1.5px solid #dee2e6; color: #495057;
+        font-size: 14px; user-select: none; transition: all 0.15s;
+    }
+    .chip:hover { border-color: #adb5bd; }
+    .chip:focus-visible { outline: 2px solid #0d6efd; outline-offset: 2px; }
+    .chip.selected {
+        background: #e7f1ff; border-color: #0d6efd; color: #0d6efd; font-weight: 500;
+    }
+    .chip-emoji { font-size: 16px; }
+
+    /* Radio cards */
+    .radio-card-grid {
+        display: grid; grid-template-columns: 1fr 1fr; gap: 10px;
+    }
+    @@media (max-width: 575.98px) {
+        .radio-card-grid { grid-template-columns: 1fr; }
+    }
+    .radio-card {
+        display: flex; flex-direction: column; align-items: center;
+        padding: 16px 12px; border-radius: 10px; cursor: pointer; text-align: center;
+        background: #f8f9fa; border: 1.5px solid #dee2e6; transition: all 0.15s;
+    }
+    .radio-card:hover { border-color: #adb5bd; }
+    .radio-card:focus-visible { outline: 2px solid #0d6efd; outline-offset: 2px; }
+    .radio-card.selected {
+        background: #e7f1ff; border-color: #0d6efd;
+    }
+    .rc-emoji { font-size: 24px; margin-bottom: 6px; }
+    .rc-label { font-weight: 600; font-size: 14px; color: #212529; }
+    .rc-desc { font-size: 12px; color: #6c757d; margin-top: 2px; }
+</style>
+}
+
+@section Scripts {
+<script>
+(function() {
+    const STEPS = [
+        { label: 'Step 1 of 3', title: 'What are you good at?', subtitle: 'Select skills you\'d like to use. You can change these anytime.' },
+        { label: 'Step 2 of 3', title: 'How do you like to work?', subtitle: 'Help coordinators match you with shifts that fit your style and availability.' },
+        { label: 'Step 3 of 3', title: 'Which languages do you speak?', subtitle: 'This helps us match you with teams where you can communicate well.' }
+    ];
+
+    let current = 0;
+    const stepLabel = document.getElementById('stepLabel');
+    const stepTitle = document.getElementById('stepTitle');
+    const stepSubtitle = document.getElementById('stepSubtitle');
+    const backBtn = document.getElementById('backBtn');
+    const nextBtn = document.getElementById('nextBtn');
+    const saveBtn = document.getElementById('saveBtn');
+    const dots = document.querySelectorAll('.progress-dot');
+
+    function setStep(n) {
+        document.getElementById('step-' + current).classList.remove('active');
+        current = n;
+        document.getElementById('step-' + current).classList.add('active');
+
+        stepLabel.textContent = STEPS[n].label;
+        stepTitle.textContent = STEPS[n].title;
+        stepSubtitle.textContent = STEPS[n].subtitle;
+
+        dots.forEach(function(dot, i) {
+            dot.classList.remove('active', 'done');
+            if (i < n) dot.classList.add('done');
+            if (i === n) dot.classList.add('active');
+        });
+
+        backBtn.style.display = n === 0 ? 'none' : '';
+        nextBtn.style.display = n === STEPS.length - 1 ? 'none' : '';
+        saveBtn.style.display = n === STEPS.length - 1 ? '' : 'none';
+    }
+
+    window.nextStep = function() { if (current < STEPS.length - 1) setStep(current + 1); };
+    window.prevStep = function() { if (current > 0) setStep(current - 1); };
+
+    // Chip toggle
+    document.querySelectorAll('.chip').forEach(function(chip) {
+        function toggle() {
+            var cb = chip.querySelector('input[type="checkbox"]');
+            cb.checked = !cb.checked;
+            chip.classList.toggle('selected', cb.checked);
+            chip.setAttribute('aria-checked', cb.checked ? 'true' : 'false');
+        }
+        chip.addEventListener('click', function(e) {
+            if (e.target.tagName !== 'INPUT') toggle();
+        });
+        chip.addEventListener('keydown', function(e) {
+            if (e.key === ' ' || e.key === 'Enter') { e.preventDefault(); toggle(); }
+        });
+    });
+
+    // Radio card toggle
+    document.querySelectorAll('.radio-card').forEach(function(card) {
+        function select() {
+            document.querySelectorAll('.radio-card').forEach(function(c) { c.classList.remove('selected'); });
+            card.classList.add('selected');
+            card.querySelector('input[type="radio"]').checked = true;
+        }
+        card.addEventListener('click', function(e) {
+            if (e.target.tagName !== 'INPUT') select();
+        });
+        card.addEventListener('keydown', function(e) {
+            if (e.key === ' ' || e.key === 'Enter') { e.preventDefault(); select(); }
+        });
+    });
+})();
+</script>
+}

--- a/src/Humans.Web/Views/Profile/ShiftInfo.cshtml
+++ b/src/Humans.Web/Views/Profile/ShiftInfo.cshtml
@@ -13,7 +13,7 @@
         </nav>
 
         <h1>Shift Info</h1>
-        <p class="text-muted">Skills, dietary preferences, and other information for shift coordination.</p>
+        <p class="text-muted">Skills, preferences, and other information for shift coordination.</p>
 
         <vc:temp-data-alerts />
 
@@ -39,18 +39,37 @@
                 </div>
             </div>
 
-            @* Quirks *@
+            @* Work Preferences (Toggle Quirks) *@
             <div class="card mb-4">
                 <div class="card-body">
                     <label class="form-label fw-bold">Work Preferences</label>
                     <div class="row">
-                        @foreach (var quirk in Humans.Web.Models.ShiftInfoViewModel.QuirkOptions)
+                        @foreach (var quirk in Humans.Web.Models.ShiftInfoViewModel.ToggleQuirkOptions)
                         {
                             <div class="col-md-4 mb-1">
                                 <div class="form-check">
                                     <input type="checkbox" name="SelectedQuirks" value="@quirk" class="form-check-input"
                                            @(Model.SelectedQuirks.Contains(quirk) ? "checked" : null) />
                                     <label class="form-check-label">@quirk</label>
+                                </div>
+                            </div>
+                        }
+                    </div>
+                </div>
+            </div>
+
+            @* Time Preference *@
+            <div class="card mb-4">
+                <div class="card-body">
+                    <label class="form-label fw-bold">Time Preference</label>
+                    <div class="row">
+                        @foreach (var pref in Humans.Web.Models.ShiftInfoViewModel.TimePreferenceOptions)
+                        {
+                            <div class="col-md-3 mb-1">
+                                <div class="form-check">
+                                    <input type="radio" name="TimePreference" value="@pref" class="form-check-input"
+                                           @(string.Equals(Model.TimePreference, pref, StringComparison.Ordinal) ? "checked" : "") />
+                                    <label class="form-check-label">@pref</label>
                                 </div>
                             </div>
                         }
@@ -168,20 +187,3 @@
         </form>
     </div>
 </div>
-
-@section Scripts {
-<script>
-document.querySelectorAll('[data-toggle-target]').forEach(function(cb) {
-    cb.addEventListener('change', function() {
-        var target = document.getElementById(this.dataset.toggleTarget);
-        if (target) {
-            target.style.display = this.checked ? 'block' : 'none';
-            if (!this.checked) {
-                var input = target.querySelector('input');
-                if (input) input.value = '';
-            }
-        }
-    });
-});
-</script>
-}

--- a/tests/Humans.Application.Tests/ViewModels/ShiftInfoViewModelTests.cs
+++ b/tests/Humans.Application.Tests/ViewModels/ShiftInfoViewModelTests.cs
@@ -1,0 +1,76 @@
+using AwesomeAssertions;
+using Humans.Web.Models;
+using Xunit;
+
+namespace Humans.Application.Tests.ViewModels;
+
+public class ShiftInfoViewModelTests
+{
+    [Fact]
+    public void TimePreferenceOptions_contains_all_four_values()
+    {
+        ShiftInfoViewModel.TimePreferenceOptions.Should()
+            .BeEquivalentTo(["Early Bird", "Night Owl", "All Day", "No Preference"]);
+    }
+
+    [Fact]
+    public void ToggleQuirkOptions_excludes_time_preferences()
+    {
+        ShiftInfoViewModel.ToggleQuirkOptions.Should()
+            .BeEquivalentTo(["Sober Shift", "Work In Shade", "Quiet Work", "Physical Work OK", "No Heights"]);
+
+        // No overlap with time preferences
+        ShiftInfoViewModel.ToggleQuirkOptions.Should()
+            .NotContain(ShiftInfoViewModel.TimePreferenceOptions);
+    }
+
+    [Fact]
+    public void ExtractTimePreference_returns_matching_value_from_quirks()
+    {
+        var quirks = new List<string> { "Sober Shift", "Night Owl", "No Heights" };
+
+        var result = ShiftInfoViewModel.ExtractTimePreference(quirks);
+
+        result.Should().Be("Night Owl");
+    }
+
+    [Fact]
+    public void ExtractTimePreference_returns_null_when_no_time_pref()
+    {
+        var quirks = new List<string> { "Sober Shift", "No Heights" };
+
+        var result = ShiftInfoViewModel.ExtractTimePreference(quirks);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void ExtractToggleQuirks_excludes_time_preferences()
+    {
+        var quirks = new List<string> { "Sober Shift", "Night Owl", "No Heights" };
+
+        var result = ShiftInfoViewModel.ExtractToggleQuirks(quirks);
+
+        result.Should().BeEquivalentTo(["Sober Shift", "No Heights"]);
+    }
+
+    [Fact]
+    public void MergeQuirks_combines_time_pref_and_toggles()
+    {
+        var toggles = new List<string> { "Sober Shift", "No Heights" };
+
+        var result = ShiftInfoViewModel.MergeQuirks("Early Bird", toggles);
+
+        result.Should().BeEquivalentTo(["Sober Shift", "No Heights", "Early Bird"]);
+    }
+
+    [Fact]
+    public void MergeQuirks_with_null_time_pref_returns_toggles_only()
+    {
+        var toggles = new List<string> { "Sober Shift" };
+
+        var result = ShiftInfoViewModel.MergeQuirks(null, toggles);
+
+        result.Should().BeEquivalentTo(["Sober Shift"]);
+    }
+}

--- a/tests/e2e/tests/shift-preferences.spec.ts
+++ b/tests/e2e/tests/shift-preferences.spec.ts
@@ -1,0 +1,74 @@
+import { test, expect } from '@playwright/test';
+import { loginAsVolunteer } from '../helpers/auth';
+
+test.describe('Shift Preference Wizard (33-shift-preference-wizard)', () => {
+  test('page loads with wizard step 1', async ({ page }) => {
+    await loginAsVolunteer(page);
+    await page.goto('/Profile/ShiftInfo');
+
+    await expect(page.locator('#stepTitle')).toHaveText('What are you good at?');
+    await expect(page.locator('#stepLabel')).toHaveText('Step 1 of 3');
+    await expect(page.locator('.progress-dot.active')).toHaveCount(1);
+  });
+
+  test('can navigate through all 3 steps', async ({ page }) => {
+    await loginAsVolunteer(page);
+    await page.goto('/Profile/ShiftInfo');
+
+    // Step 1 -> Step 2
+    await page.click('#nextBtn');
+    await expect(page.locator('#stepTitle')).toHaveText('How do you like to work?');
+    await expect(page.locator('#stepLabel')).toHaveText('Step 2 of 3');
+
+    // Step 2 -> Step 3
+    await page.click('#nextBtn');
+    await expect(page.locator('#stepTitle')).toHaveText('Which languages do you speak?');
+    await expect(page.locator('#stepLabel')).toHaveText('Step 3 of 3');
+    await expect(page.locator('#saveBtn')).toBeVisible();
+    await expect(page.locator('#nextBtn')).not.toBeVisible();
+  });
+
+  test('can go back from step 3 to step 1', async ({ page }) => {
+    await loginAsVolunteer(page);
+    await page.goto('/Profile/ShiftInfo');
+
+    await page.click('#nextBtn');
+    await page.click('#nextBtn');
+    await page.click('#backBtn');
+    await expect(page.locator('#stepTitle')).toHaveText('How do you like to work?');
+
+    await page.click('#backBtn');
+    await expect(page.locator('#stepTitle')).toHaveText('What are you good at?');
+    await expect(page.locator('#backBtn')).not.toBeVisible();
+  });
+
+  test('selecting a chip toggles it', async ({ page }) => {
+    await loginAsVolunteer(page);
+    await page.goto('/Profile/ShiftInfo');
+
+    const chip = page.locator('.chip', { hasText: 'Bartending' });
+    await chip.click();
+    await expect(chip).toHaveClass(/selected/);
+
+    await chip.click();
+    await expect(chip).not.toHaveClass(/selected/);
+  });
+
+  test('save submits and redirects back', async ({ page }) => {
+    await loginAsVolunteer(page);
+    await page.goto('/Profile/ShiftInfo');
+
+    // Select a skill
+    await page.locator('.chip', { hasText: 'Sound' }).click();
+
+    // Navigate to step 3
+    await page.click('#nextBtn');
+    await page.click('#nextBtn');
+
+    // Save
+    await page.click('#saveBtn');
+
+    // Should redirect back to same page with success message
+    await expect(page).toHaveURL(/\/Profile\/ShiftInfo/);
+  });
+});


### PR DESCRIPTION
## Summary

- Replace flat `/Profile/ShiftInfo` form with a 3-step wizard (Skills → Work Style → Languages)
- Emoji chip multi-select for skills and languages, radio cards for time preference, Bootstrap toggle switches for quirks
- Mobile-first, accessible (keyboard nav, ARIA, hidden form inputs)
- Split time preferences from toggle quirks in the view model with Extract/Merge helpers
- Remove dietary/medical fields from this page (preserved in DB, moving to Feature 35)
- 7 new unit tests for time preference logic, 5 new e2e smoke tests

## Related

- Spec: `docs/features/33-shift-preference-wizard.md`
- Feature 35 placeholder: `docs/features/35-dietary-medical-nudge.md` + nobodies-collective/Humans#279
- Dashboard wizard card: nobodies-collective/Humans#273

## Test plan

- [ ] Navigate to `/Profile/ShiftInfo` — verify wizard loads at step 1
- [ ] Click through all 3 steps via Continue/Back
- [ ] Select skills, time preference, quirks, languages — Save
- [ ] Reload page — verify selections are pre-populated
- [ ] Test on mobile viewport — chips wrap, radio cards stack
- [ ] Verify existing dietary/allergy data is preserved in DB after saving wizard

🤖 Generated with [Claude Code](https://claude.com/claude-code)