### PR TITLE
fix: add OrderBy to EF queries missing it (#286)

### DIFF
--- a/src/Humans.Infrastructure/Services/BudgetService.cs
+++ b/src/Humans.Infrastructure/Services/BudgetService.cs
@@ -60,6 +60,7 @@ public class BudgetService : IBudgetService
     public async Task<BudgetYear?> GetActiveYearAsync()
     {
         var activeYear = await _dbContext.BudgetYears
+            .OrderBy(y => y.Id)
             .FirstOrDefaultAsync(y => y.Status == BudgetYearStatus.Active && !y.IsDeleted);
 
         if (activeYear is null)
@@ -237,6 +238,7 @@ public class BudgetService : IBudgetService
 
         var deptGroup = await _dbContext.BudgetGroups
             .Include(g => g.Categories)
+            .OrderBy(g => g.Id)
             .FirstOrDefaultAsync(g => g.BudgetYearId == budgetYearId && g.IsDepartmentGroup)
             ?? throw new InvalidOperationException("No Departments group found for this budget year");
 

--- a/src/Humans.Infrastructure/Services/CampService.cs
+++ b/src/Humans.Infrastructure/Services/CampService.cs
@@ -340,6 +340,7 @@ public class CampService : ICampService
             entry.AbsoluteExpirationRelativeToNow = CampSettingsCacheTtl;
             return await _dbContext.CampSettings
                 .AsNoTracking()
+                .OrderBy(s => s.Id)
                 .FirstAsync(cancellationToken);
         }) ?? throw new InvalidOperationException("Camp settings not found.");
     }
@@ -1038,7 +1039,7 @@ public class CampService : ICampService
 
     public async Task SetPublicYearAsync(int year, CancellationToken cancellationToken = default)
     {
-        var settings = await _dbContext.CampSettings.FirstAsync(cancellationToken);
+        var settings = await _dbContext.CampSettings.OrderBy(s => s.Id).FirstAsync(cancellationToken);
         settings.PublicYear = year;
         await _dbContext.SaveChangesAsync(cancellationToken);
         _cache.InvalidateCampSettings();
@@ -1046,7 +1047,7 @@ public class CampService : ICampService
 
     public async Task OpenSeasonAsync(int year, CancellationToken cancellationToken = default)
     {
-        var settings = await _dbContext.CampSettings.FirstAsync(cancellationToken);
+        var settings = await _dbContext.CampSettings.OrderBy(s => s.Id).FirstAsync(cancellationToken);
         if (!settings.OpenSeasons.Contains(year))
         {
             settings.OpenSeasons.Add(year);
@@ -1057,7 +1058,7 @@ public class CampService : ICampService
 
     public async Task CloseSeasonAsync(int year, CancellationToken cancellationToken = default)
     {
-        var settings = await _dbContext.CampSettings.FirstAsync(cancellationToken);
+        var settings = await _dbContext.CampSettings.OrderBy(s => s.Id).FirstAsync(cancellationToken);
         if (settings.OpenSeasons.Remove(year))
         {
             await _dbContext.SaveChangesAsync(cancellationToken);

--- a/src/Humans.Infrastructure/Services/GoogleWorkspaceSyncService.cs
+++ b/src/Humans.Infrastructure/Services/GoogleWorkspaceSyncService.cs
@@ -1278,6 +1278,7 @@ public class GoogleWorkspaceSyncService : IGoogleSyncService
             .Include(r => r.Team)
             .Where(r => r.IsActive && r.ResourceType == GoogleResourceType.Group)
             .Where(r => r.Url != null && EF.Functions.ILike(r.Url!, expectedUrl))
+            .OrderBy(r => r.Id)
             .FirstOrDefaultAsync(cancellationToken);
 
         if (existingActiveByEmail is not null)
@@ -1292,6 +1293,7 @@ public class GoogleWorkspaceSyncService : IGoogleSyncService
         var inactiveForTeam = await _dbContext.GoogleResources
             .Where(r => !r.IsActive && r.ResourceType == GoogleResourceType.Group && r.TeamId == teamId)
             .Where(r => r.Url != null && EF.Functions.ILike(r.Url!, expectedUrl))
+            .OrderBy(r => r.Id)
             .FirstOrDefaultAsync(cancellationToken);
 
         if (inactiveForTeam is not null && !confirmReactivation)

--- a/src/Humans.Web/Helpers/ShiftVolunteerSearchBuilder.cs
+++ b/src/Humans.Web/Helpers/ShiftVolunteerSearchBuilder.cs
@@ -24,6 +24,7 @@ public static class ShiftVolunteerSearchBuilder
 
         var users = await userManager.Users
             .Where(u => EF.Functions.ILike(u.DisplayName, "%" + query + "%"))
+            .OrderBy(u => u.DisplayName)
             .Take(10)
             .ToListAsync();
 


### PR DESCRIPTION
## Summary
- **#286** — Added explicit `OrderBy` before `First`/`FirstOrDefault`/`Take` operators in 9 queries across 4 files to eliminate EF Core runtime warnings about non-deterministic results

## Files changed
- `CampService.cs` — 4 instances of `CampSettings.FirstAsync()` now have `.OrderBy(s => s.Id)`
- `BudgetService.cs` — 2 instances of `FirstOrDefaultAsync()` now have `.OrderBy(y/g => y/g.Id)`
- `GoogleWorkspaceSyncService.cs` — 2 instances of `FirstOrDefaultAsync()` now have `.OrderBy(r => r.Id)`
- `ShiftVolunteerSearchBuilder.cs` — 1 instance of `.Take(10)` now preceded by `.OrderBy(u => u.DisplayName)`

## Spec Compliance
- **#286** — PASS (9/9 queries fixed)

## Code Review
Self-reviewed against CODE_REVIEW_RULES.md. No critical issues — purely mechanical additions of OrderBy clauses.

## Test plan
- [ ] Verify no EF Core "First/FirstOrDefault without OrderBy" warnings in production logs after deploy
- [ ] Verify no EF Core "Skip/Take without OrderBy" warnings in production logs after deploy
- [ ] Spot-check camp settings, budget, Google group linking, and shift volunteer search functionality still works

🤖 Generated with [Claude Code](https://claude.com/claude-code) sprint swarm