### PR TITLE
Quick wins (#304, #298)

### DIFF
--- a/src/Humans.Web/Controllers/AdminController.cs
+++ b/src/Humans.Web/Controllers/AdminController.cs
@@ -391,6 +391,7 @@ public class AdminController : HumansControllerBase
         var now = clock.GetCurrentInstant();
         var cutoff24h = now - Duration.FromHours(24);
 
+        var totalCount = await _dbContext.EmailOutboxMessages.CountAsync();
         var queuedCount = await _dbContext.EmailOutboxMessages
             .CountAsync(m => m.Status == EmailOutboxStatus.Queued);
         var sentLast24H = await _dbContext.EmailOutboxMessages
@@ -410,6 +411,7 @@ public class AdminController : HumansControllerBase
 
         var viewModel = new EmailOutboxViewModel
         {
+            TotalMessageCount = totalCount,
             QueuedCount = queuedCount,
             SentLast24HoursCount = sentLast24H,
             FailedCount = failedCount,

--- a/src/Humans.Web/Models/AdminViewModels.cs
+++ b/src/Humans.Web/Models/AdminViewModels.cs
@@ -335,6 +335,7 @@ public class ProfileSummaryViewModel
 
 public class EmailOutboxViewModel
 {
+    public int TotalMessageCount { get; set; }
     public int QueuedCount { get; set; }
     public int SentLast24HoursCount { get; set; }
     public int FailedCount { get; set; }

--- a/src/Humans.Web/Views/Admin/EmailOutbox.cshtml
+++ b/src/Humans.Web/Views/Admin/EmailOutbox.cshtml
@@ -3,6 +3,14 @@
 @{
     ViewData["Title"] = "Email Outbox";
 }
+@functions {
+    static string FormatApproxCount(int count)
+    {
+        if (count < 1000) return count.ToString();
+        if (count < 10_000) return $"~{count / 1000.0:0.#}k";
+        return $"~{count / 1000}k";
+    }
+}
 
 <div class="d-flex justify-content-between align-items-center mb-4">
     <div>
@@ -42,7 +50,15 @@
 <vc:temp-data-alerts />
 
 <div class="row g-3 mb-4">
-    <div class="col-6 col-md-3">
+    <div class="col-6 col-md">
+        <div class="card text-center">
+            <div class="card-body">
+                <div class="display-6 fw-bold text-primary">@FormatApproxCount(Model.TotalMessageCount)</div>
+                <div class="text-muted small">Total Messages</div>
+            </div>
+        </div>
+    </div>
+    <div class="col-6 col-md">
         <div class="card text-center">
             <div class="card-body">
                 <div class="display-6 fw-bold text-warning">@Model.QueuedCount</div>
@@ -50,7 +66,7 @@
             </div>
         </div>
     </div>
-    <div class="col-6 col-md-3">
+    <div class="col-6 col-md">
         <div class="card text-center">
             <div class="card-body">
                 <div class="display-6 fw-bold text-success">@Model.SentLast24HoursCount</div>
@@ -58,7 +74,7 @@
             </div>
         </div>
     </div>
-    <div class="col-6 col-md-3">
+    <div class="col-6 col-md">
         <div class="card text-center">
             <div class="card-body">
                 <div class="display-6 fw-bold text-danger">@Model.FailedCount</div>
@@ -66,7 +82,7 @@
             </div>
         </div>
     </div>
-    <div class="col-6 col-md-3">
+    <div class="col-6 col-md">
         <div class="card text-center">
             <div class="card-body">
                 <div class="display-6 fw-bold text-secondary">10/min</div>

--- a/src/Humans.Web/Views/Shared/_LanguageChooser.cshtml
+++ b/src/Humans.Web/Views/Shared/_LanguageChooser.cshtml
@@ -10,7 +10,7 @@
         @currentLanguageName
     </button>
     <ul class="dropdown-menu dropdown-menu-end">
-        @foreach (var culture in CultureCatalog.SupportedCultureCodes)
+        @foreach (var culture in CultureCatalog.SupportedCultureCodes.OrderBy(c => c.ToDisplayLanguageName(), StringComparer.Ordinal))
         {
             <li>
                 <form asp-controller="Language" asp-action="SetLanguage" method="post">


### PR DESCRIPTION
## Summary
- **#304** — Sort language dropdown alphabetically by display name (Castellano, Deutsch, English, Français, Italiano)
- **#298** — Add "Total Messages" stat card to Email Outbox admin page with human-friendly abbreviated count (~2.1k, ~15k)

## Spec Compliance
All acceptance criteria verified per-issue during implementation.
- #304: PASS (2/2 criteria)
- #298: PASS (2/2 criteria)

## Code Review
Self-reviewed against CODE_REVIEW_RULES.md. No critical issues.

## Test plan
- [ ] Verify language dropdown shows languages sorted alphabetically: Castellano, Deutsch, English, Français, Italiano
- [ ] Verify current language is still highlighted as active in the dropdown
- [ ] Verify Email Outbox page shows a "Total Messages" card as the first stat card
- [ ] Verify count displays in abbreviated format for large counts (e.g., ~2.1k)
- [ ] Verify exact count shows for small counts (< 1000)

🤖 Generated with [Claude Code](https://claude.com/claude-code) sprint swarm