### PR TITLE
Hidden team support (#302)

### DIFF
--- a/docs/features/36-hidden-teams.md
+++ b/docs/features/36-hidden-teams.md
@@ -1,0 +1,34 @@
+# Hidden Teams
+
+## Business Context
+
+Campaigns (code distribution) target teams to determine who receives codes. Some use cases -- like low-income ticket programs -- require grouping users into a team for targeting, but exposing that membership would violate privacy. Hidden teams allow admins to create privacy-sensitive groups without revealing membership to other users.
+
+## Data Model
+
+- `Team.IsHidden` (bool, default `false`) -- when true, the team is invisible to non-admin users.
+
+## Visibility Rules
+
+| Viewer | Can see hidden teams? |
+|--------|----------------------|
+| Anonymous | No |
+| Regular authenticated human | No -- not on profile cards, team listings, public pages, birthday calendars, or "My Teams" |
+| Admin / Board / TeamsAdmin | Yes -- full visibility in team directory, detail pages, admin summary, and "My Teams" |
+| Campaigns | Yes -- campaigns target by team ID, unaffected by visibility |
+
+## Touchpoints
+
+- **Team directory** (`GetTeamDirectoryAsync`): hidden teams excluded for non-admin users
+- **Team detail page** (`GetTeamDetailAsync`): returns null for hidden teams when viewer is not Admin/Board/TeamsAdmin
+- **Profile card** (`ProfileCardViewComponent`): hidden teams filtered alongside the existing Volunteers filter
+- **Birthday team names** (`GetNonSystemTeamNamesByUserIdsAsync`): hidden teams excluded
+- **My Teams** (`GetMyTeamMembershipsAsync`): hidden teams excluded for non-admin users
+- **Join flow**: hidden teams return 404 for non-admin users
+- **Admin summary**: shows "Hidden" badge on hidden teams
+- **Create/Edit team forms**: checkbox toggle for IsHidden
+
+## Related Features
+
+- [Teams](06-teams.md) -- base team management
+- [Campaigns](22-campaigns.md) -- code distribution targeting

--- a/docs/sections/Teams.md
+++ b/docs/sections/Teams.md
@@ -31,6 +31,7 @@
 - Each team has a unique slug used for URL routing. A custom slug can override the auto-generated one.
 - A Google Group prefix, if set, provisions a @nobodies.team group for the team.
 - Only departments (not sub-teams or system teams) can have public team pages.
+- A **hidden team** (`IsHidden = true`) is invisible to non-admin users: it does not appear on profile cards, team listings, public pages, birthday team names, or the "My Teams" page. Only Admin, Board, and TeamsAdmin can see and manage hidden teams. Campaigns can still target hidden teams for code distribution.
 
 ## Negative Access Rules
 

--- a/src/Humans.Application/Interfaces/ITeamService.cs
+++ b/src/Humans.Application/Interfaces/ITeamService.cs
@@ -8,7 +8,7 @@ namespace Humans.Application.Interfaces;
 public record CachedTeam(
     Guid Id, string Name, string? Description, string Slug,
     bool IsSystemTeam, SystemTeamType SystemTeamType, bool RequiresApproval,
-    bool IsPublicPage, Instant CreatedAt, List<CachedTeamMember> Members,
+    bool IsPublicPage, bool IsHidden, Instant CreatedAt, List<CachedTeamMember> Members,
     Guid? ParentTeamId = null);
 
 public record CachedTeamMember(
@@ -102,7 +102,8 @@ public record AdminTeamSummary(
     int RoleSlotCount,
     Instant CreatedAt,
     bool IsChildTeam,
-    int PendingShiftSignupCount);
+    int PendingShiftSignupCount,
+    bool IsHidden);
 
 public record AdminTeamListResult(
     IReadOnlyList<AdminTeamSummary> Teams,
@@ -122,6 +123,7 @@ public interface ITeamService
         bool requiresApproval,
         Guid? parentTeamId = null,
         string? googleGroupPrefix = null,
+        bool isHidden = false,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -180,6 +182,7 @@ public interface ITeamService
         string? googleGroupPrefix = null,
         string? customSlug = null,
         bool? hasBudget = null,
+        bool? isHidden = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/src/Humans.Domain/Entities/Team.cs
+++ b/src/Humans.Domain/Entities/Team.cs
@@ -113,6 +113,14 @@ public class Team
     public bool HasBudget { get; set; }
 
     /// <summary>
+    /// Whether this team is hidden from non-admin users.
+    /// Hidden teams do not appear on profile cards, team listings, or public pages,
+    /// but remain fully visible and manageable by Admin/TeamsAdmin.
+    /// Campaigns can still target hidden teams for code distribution.
+    /// </summary>
+    public bool IsHidden { get; set; }
+
+    /// <summary>
     /// Optional parent team ID for one-level hierarchy (departments).
     /// A team with a parent cannot itself be a parent.
     /// </summary>

--- a/src/Humans.Infrastructure/Data/Configurations/TeamConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/TeamConfiguration.cs
@@ -69,6 +69,9 @@ public class TeamConfiguration : IEntityTypeConfiguration<Team>
         builder.Property(t => t.HasBudget)
             .IsRequired();
 
+        builder.Property(t => t.IsHidden)
+            .IsRequired();
+
         builder.Property(t => t.PageContent)
             .HasMaxLength(50000);
 
@@ -147,7 +150,8 @@ public class TeamConfiguration : IEntityTypeConfiguration<Team>
                 CallsToAction = (List<CallToAction>?)null,
                 CustomSlug = (string?)null,
                 ShowCoordinatorsOnPublicPage = true,
-                HasBudget = false
+                HasBudget = false,
+                IsHidden = false
             },
             new
             {
@@ -169,7 +173,8 @@ public class TeamConfiguration : IEntityTypeConfiguration<Team>
                 CallsToAction = (List<CallToAction>?)null,
                 CustomSlug = (string?)null,
                 ShowCoordinatorsOnPublicPage = true,
-                HasBudget = false
+                HasBudget = false,
+                IsHidden = false
             },
             new
             {
@@ -191,7 +196,8 @@ public class TeamConfiguration : IEntityTypeConfiguration<Team>
                 CallsToAction = (List<CallToAction>?)null,
                 CustomSlug = (string?)null,
                 ShowCoordinatorsOnPublicPage = true,
-                HasBudget = false
+                HasBudget = false,
+                IsHidden = false
             },
             new
             {
@@ -213,7 +219,8 @@ public class TeamConfiguration : IEntityTypeConfiguration<Team>
                 CallsToAction = (List<CallToAction>?)null,
                 CustomSlug = (string?)null,
                 ShowCoordinatorsOnPublicPage = true,
-                HasBudget = false
+                HasBudget = false,
+                IsHidden = false
             },
             new
             {
@@ -235,7 +242,8 @@ public class TeamConfiguration : IEntityTypeConfiguration<Team>
                 CallsToAction = (List<CallToAction>?)null,
                 CustomSlug = (string?)null,
                 ShowCoordinatorsOnPublicPage = true,
-                HasBudget = false
+                HasBudget = false,
+                IsHidden = false
             },
             new
             {
@@ -257,7 +265,8 @@ public class TeamConfiguration : IEntityTypeConfiguration<Team>
                 CallsToAction = (List<CallToAction>?)null,
                 CustomSlug = (string?)null,
                 ShowCoordinatorsOnPublicPage = true,
-                HasBudget = false
+                HasBudget = false,
+                IsHidden = false
             });
     }
 }

--- a/src/Humans.Infrastructure/Migrations/20260401011947_AddTeamIsHidden.Designer.cs
+++ b/src/Humans.Infrastructure/Migrations/20260401011947_AddTeamIsHidden.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Humans.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Humans.Infrastructure.Migrations
 {
     [DbContext(typeof(HumansDbContext))]
-    partial class HumansDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260401011947_AddTeamIsHidden")]
+    partial class AddTeamIsHidden
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Humans.Infrastructure/Migrations/20260401011947_AddTeamIsHidden.cs
+++ b/src/Humans.Infrastructure/Migrations/20260401011947_AddTeamIsHidden.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Humans.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTeamIsHidden : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsHidden",
+                table: "teams",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.UpdateData(
+                table: "teams",
+                keyColumn: "Id",
+                keyValue: new Guid("00000000-0000-0000-0001-000000000001"),
+                column: "IsHidden",
+                value: false);
+
+            migrationBuilder.UpdateData(
+                table: "teams",
+                keyColumn: "Id",
+                keyValue: new Guid("00000000-0000-0000-0001-000000000002"),
+                column: "IsHidden",
+                value: false);
+
+            migrationBuilder.UpdateData(
+                table: "teams",
+                keyColumn: "Id",
+                keyValue: new Guid("00000000-0000-0000-0001-000000000003"),
+                column: "IsHidden",
+                value: false);
+
+            migrationBuilder.UpdateData(
+                table: "teams",
+                keyColumn: "Id",
+                keyValue: new Guid("00000000-0000-0000-0001-000000000004"),
+                column: "IsHidden",
+                value: false);
+
+            migrationBuilder.UpdateData(
+                table: "teams",
+                keyColumn: "Id",
+                keyValue: new Guid("00000000-0000-0000-0001-000000000005"),
+                column: "IsHidden",
+                value: false);
+
+            migrationBuilder.UpdateData(
+                table: "teams",
+                keyColumn: "Id",
+                keyValue: new Guid("00000000-0000-0000-0001-000000000006"),
+                column: "IsHidden",
+                value: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsHidden",
+                table: "teams");
+        }
+    }
+}

--- a/src/Humans.Infrastructure/Services/TeamService.cs
+++ b/src/Humans.Infrastructure/Services/TeamService.cs
@@ -55,6 +55,7 @@ public class TeamService : ITeamService
         bool requiresApproval,
         Guid? parentTeamId = null,
         string? googleGroupPrefix = null,
+        bool isHidden = false,
         CancellationToken cancellationToken = default)
     {
         var baseSlug = Helpers.SlugHelper.GenerateSlug(name);
@@ -98,6 +99,7 @@ public class TeamService : ITeamService
                 Slug = slug,
                 IsActive = true,
                 RequiresApproval = requiresApproval,
+                IsHidden = isHidden,
                 ParentTeamId = parentTeamId,
                 GoogleGroupPrefix = googleGroupPrefix,
                 SystemTeamType = SystemTeamType.None,
@@ -122,8 +124,8 @@ public class TeamService : ITeamService
                 }
 
                 UpsertCachedTeam(new CachedTeam(team.Id, team.Name, team.Description, team.Slug,
-                    team.IsSystemTeam, team.SystemTeamType, team.RequiresApproval, team.IsPublicPage, team.CreatedAt, [],
-                    ParentTeamId: parentTeamId));
+                    team.IsSystemTeam, team.SystemTeamType, team.RequiresApproval, team.IsPublicPage, team.IsHidden,
+                    team.CreatedAt, [], ParentTeamId: parentTeamId));
                 _logger.LogInformation("Created team {TeamName} with slug {Slug}", name, slug);
                 return team;
             }
@@ -192,7 +194,7 @@ public class TeamService : ITeamService
         if (!userId.HasValue)
         {
             var publicDepartments = cachedTeams.Values
-                .Where(t => t.IsPublicPage && !t.IsSystemTeam && t.ParentTeamId is null)
+                .Where(t => t.IsPublicPage && !t.IsSystemTeam && !t.IsHidden && t.ParentTeamId is null)
                 .OrderBy(t => t.Name, StringComparer.OrdinalIgnoreCase)
                 .Select(t => CreateDirectorySummary(t, cachedTeams, userId))
                 .ToList();
@@ -206,11 +208,16 @@ public class TeamService : ITeamService
         }
 
         var isBoardMember = await _roleAssignmentService.IsUserBoardMemberAsync(userId.Value, cancellationToken);
-        var canCreateTeam = isBoardMember ||
-            await _roleAssignmentService.IsUserAdminAsync(userId.Value, cancellationToken) ||
-            await _roleAssignmentService.IsUserTeamsAdminAsync(userId.Value, cancellationToken);
+        var isAdmin = await _roleAssignmentService.IsUserAdminAsync(userId.Value, cancellationToken);
+        var isTeamsAdmin = await _roleAssignmentService.IsUserTeamsAdminAsync(userId.Value, cancellationToken);
+        var canCreateTeam = isBoardMember || isAdmin || isTeamsAdmin;
+        var canSeeHiddenTeams = canCreateTeam; // Admin, Board, and TeamsAdmin can see hidden teams
 
-        var summaries = cachedTeams.Values
+        var visibleTeams = canSeeHiddenTeams
+            ? cachedTeams.Values
+            : cachedTeams.Values.Where(t => !t.IsHidden);
+
+        var summaries = visibleTeams
             .Select(t => CreateDirectorySummary(t, cachedTeams, userId))
             .ToList();
 
@@ -248,7 +255,7 @@ public class TeamService : ITeamService
             return null;
         }
 
-        if (!userId.HasValue && !team.IsPublicPage)
+        if (!userId.HasValue && (!team.IsPublicPage || team.IsHidden))
         {
             return null;
         }
@@ -269,7 +276,7 @@ public class TeamService : ITeamService
                 Team: team,
                 Members: coordinators,
                 ChildTeams: team.ChildTeams
-                    .Where(c => c.IsActive && c.IsPublicPage)
+                    .Where(c => c.IsActive && c.IsPublicPage && !c.IsHidden)
                     .OrderBy(c => c.Name, StringComparer.Ordinal)
                     .ToList(),
                 RoleDefinitions: [],
@@ -291,6 +298,12 @@ public class TeamService : ITeamService
         var isAdmin = await _roleAssignmentService.IsUserAdminAsync(currentUserId, cancellationToken);
         var isTeamsAdmin = await _roleAssignmentService.IsUserTeamsAdminAsync(currentUserId, cancellationToken);
         var canManage = isCurrentUserCoordinator || isBoardMember || isAdmin || isTeamsAdmin;
+
+        // Hidden teams are only visible to Admin, Board, and TeamsAdmin
+        if (team.IsHidden && !isBoardMember && !isAdmin && !isTeamsAdmin)
+        {
+            return null;
+        }
         var pendingRequest = await GetUserPendingRequestAsync(team.Id, currentUserId, cancellationToken);
         var pendingRequestCount = canManage
             ? (await GetPendingRequestsForTeamAsync(team.Id, cancellationToken)).Count
@@ -337,8 +350,15 @@ public class TeamService : ITeamService
         Guid userId,
         CancellationToken cancellationToken = default)
     {
-        var memberships = await GetUserTeamsAsync(userId, cancellationToken);
+        var allMemberships = await GetUserTeamsAsync(userId, cancellationToken);
         var isBoardMember = await _roleAssignmentService.IsUserBoardMemberAsync(userId, cancellationToken);
+        var isAdmin = await _roleAssignmentService.IsUserAdminAsync(userId, cancellationToken);
+        var isTeamsAdmin = await _roleAssignmentService.IsUserTeamsAdminAsync(userId, cancellationToken);
+        var canSeeHidden = isBoardMember || isAdmin || isTeamsAdmin;
+
+        var memberships = canSeeHidden
+            ? allMemberships
+            : allMemberships.Where(m => !m.Team.IsHidden).ToList();
 
         var coordinatorTeamIds = memberships
             .Where(m => (m.Role == TeamMemberRole.Coordinator || isBoardMember) && !m.Team.IsSystemTeam)
@@ -397,6 +417,7 @@ public class TeamService : ITeamService
         string? googleGroupPrefix = null,
         string? customSlug = null,
         bool? hasBudget = null,
+        bool? isHidden = null,
         CancellationToken cancellationToken = default)
     {
         var team = await _dbContext.Teams.FindAsync(new object[] { teamId }, cancellationToken)
@@ -487,6 +508,8 @@ public class TeamService : ITeamService
         team.CustomSlug = customSlug;
         if (hasBudget.HasValue)
             team.HasBudget = hasBudget.Value;
+        if (isHidden.HasValue)
+            team.IsHidden = isHidden.Value;
         team.UpdatedAt = _clock.GetCurrentInstant();
 
         if (becomingChild)
@@ -1902,7 +1925,7 @@ public class TeamService : ITeamService
         var cached = await GetCachedTeamsAsync(cancellationToken);
         var result = new Dictionary<Guid, List<string>>();
 
-        foreach (var team in cached.Values.Where(t => t.SystemTeamType == SystemTeamType.None))
+        foreach (var team in cached.Values.Where(t => t.SystemTeamType == SystemTeamType.None && !t.IsHidden))
         {
             foreach (var member in team.Members.Where(m => userIdSet.Contains(m.UserId)))
             {
@@ -1993,6 +2016,7 @@ public class TeamService : ITeamService
         SystemTeamType: team.SystemTeamType,
         RequiresApproval: team.RequiresApproval,
         IsPublicPage: team.IsPublicPage,
+        IsHidden: team.IsHidden,
         CreatedAt: team.CreatedAt,
         Members: team.Members
             .Where(m => m.LeftAt is null)
@@ -2060,7 +2084,8 @@ public class TeamService : ITeamService
             team.RoleDefinitions.Sum(role => role.SlotCount),
             team.CreatedAt,
             isChildTeam,
-            pendingShiftCounts.GetValueOrDefault(team.Id));
+            pendingShiftCounts.GetValueOrDefault(team.Id),
+            team.IsHidden);
     }
 
     private static TeamDirectorySummary CreateDirectorySummary(

--- a/src/Humans.Web/Controllers/TeamController.cs
+++ b/src/Humans.Web/Controllers/TeamController.cs
@@ -431,6 +431,12 @@ public class TeamController : HumansControllerBase
             return RedirectToAction(nameof(Details), new { slug });
         }
 
+        // Hidden teams cannot be joined by non-admin users
+        if (team.IsHidden && !RoleChecks.IsTeamsAdminBoardOrAdmin(User))
+        {
+            return NotFound();
+        }
+
         var isMember = await _teamService.IsUserMemberOfTeamAsync(team.Id, user.Id);
         if (isMember)
         {
@@ -633,7 +639,7 @@ public class TeamController : HumansControllerBase
 
         try
         {
-            var team = await _teamService.CreateTeamAsync(model.Name, model.Description, model.RequiresApproval, model.ParentTeamId, model.GoogleGroupPrefix);
+            var team = await _teamService.CreateTeamAsync(model.Name, model.Description, model.RequiresApproval, model.ParentTeamId, model.GoogleGroupPrefix, model.IsHidden);
             var currentUser = await GetCurrentUserAsync();
             _logger.LogInformation("Admin {AdminId} created team {TeamId} ({TeamName})", currentUser?.Id, team.Id, team.Name);
 
@@ -702,6 +708,7 @@ public class TeamController : HumansControllerBase
             IsActive = team.IsActive,
             IsSystemTeam = team.IsSystemTeam,
             HasBudget = team.HasBudget,
+            IsHidden = team.IsHidden,
             ParentTeamId = team.ParentTeamId,
             EligibleParents = await GetEligibleParentTeamsAsync(excludeTeamId: id, cancellationToken)
         };
@@ -727,7 +734,7 @@ public class TeamController : HumansControllerBase
 
         try
         {
-            await _teamService.UpdateTeamAsync(id, model.Name, model.Description, model.RequiresApproval, model.IsActive, model.ParentTeamId, model.GoogleGroupPrefix, model.CustomSlug, model.HasBudget);
+            await _teamService.UpdateTeamAsync(id, model.Name, model.Description, model.RequiresApproval, model.IsActive, model.ParentTeamId, model.GoogleGroupPrefix, model.CustomSlug, model.HasBudget, model.IsHidden);
             var currentUser = await GetCurrentUserAsync();
             _logger.LogInformation("Admin {AdminId} updated team {TeamId}", currentUser?.Id, id);
 
@@ -822,7 +829,8 @@ public class TeamController : HumansControllerBase
         RoleSlotCount = team.RoleSlotCount,
         CreatedAt = team.CreatedAt.ToDateTimeUtc(),
         IsChildTeam = team.IsChildTeam,
-        PendingShiftSignupCount = team.PendingShiftSignupCount
+        PendingShiftSignupCount = team.PendingShiftSignupCount,
+        IsHidden = team.IsHidden
     };
 
     private async Task<List<Microsoft.AspNetCore.Mvc.Rendering.SelectListItem>> GetEligibleParentTeamsAsync(

--- a/src/Humans.Web/Models/TeamFormViewModelBase.cs
+++ b/src/Humans.Web/Models/TeamFormViewModelBase.cs
@@ -18,6 +18,8 @@ public abstract class TeamFormViewModelBase
 
     public bool RequiresApproval { get; set; } = true;
 
+    public bool IsHidden { get; set; }
+
     public Guid? ParentTeamId { get; set; }
 
     /// <summary>

--- a/src/Humans.Web/Models/TeamViewModels.cs
+++ b/src/Humans.Web/Models/TeamViewModels.cs
@@ -494,6 +494,7 @@ public class AdminTeamViewModel
     public DateTime CreatedAt { get; set; }
     public bool IsChildTeam { get; set; }
     public int PendingShiftSignupCount { get; set; }
+    public bool IsHidden { get; set; }
 }
 
 /// <summary>

--- a/src/Humans.Web/ViewComponents/ProfileCardViewComponent.cs
+++ b/src/Humans.Web/ViewComponents/ProfileCardViewComponent.cs
@@ -111,7 +111,7 @@ public class ProfileCardViewComponent : ViewComponent
         // Get user's teams (excluding Volunteers system team)
         var userTeams = await _teamService.GetUserTeamsAsync(userId);
         var displayableTeams = userTeams
-            .Where(tm => tm.Team.SystemTeamType != SystemTeamType.Volunteers)
+            .Where(tm => tm.Team.SystemTeamType != SystemTeamType.Volunteers && !tm.Team.IsHidden)
             .OrderBy(tm => tm.Team.Name, StringComparer.Ordinal)
             .Select(tm => new TeamMembershipViewModel
             {

--- a/src/Humans.Web/Views/Shared/_TeamDescriptionAndApprovalFields.cshtml
+++ b/src/Humans.Web/Views/Shared/_TeamDescriptionAndApprovalFields.cshtml
@@ -21,4 +21,10 @@
             <div class="form-text">@Localizer["AdminTeams_RequireApprovalHelp"]</div>
         }
     </div>
+
+    <div class="mb-3 form-check">
+        <input asp-for="IsHidden" type="checkbox" class="form-check-input" disabled="@(isReadOnly ? "disabled" : null)" />
+        <label asp-for="IsHidden" class="form-check-label">Hidden team</label>
+        <div class="form-text">When enabled, this team is invisible to non-admin users. It will not appear on profile cards, team listings, or public pages. Useful for privacy-sensitive groups (e.g., assistance programs).</div>
+    </div>
 }

--- a/src/Humans.Web/Views/Team/Summary.cshtml
+++ b/src/Humans.Web/Views/Team/Summary.cshtml
@@ -121,6 +121,10 @@
                             {
                                 <span class="badge bg-secondary">@Localizer["AdminTeams_Inactive"]</span>
                             }
+                            @if (team.IsHidden)
+                            {
+                                <span class="badge bg-dark" title="This team is hidden from non-admin users"><i class="fa-solid fa-eye-slash me-1"></i>Hidden</span>
+                            }
                         </td>
                         <td>@team.CreatedAt.ToDisplayCompactDate()</td>
                         @if (Humans.Web.Authorization.RoleChecks.IsAdminOrBoard(User))


### PR DESCRIPTION
## Summary

- Add `IsHidden` bool to `Team` entity with EF migration
- Hidden teams are excluded from profile cards, team directory, detail pages, birthday calendars, "My Teams", and the join flow for non-admin users
- Admin/Board/TeamsAdmin retain full visibility and management of hidden teams
- Admin UI: checkbox toggle on create/edit forms, "Hidden" badge on the admin summary page
- Campaigns can still target hidden teams by ID (no change needed)

Closes #302

## Test plan

- [ ] Create a team with "Hidden" checked -- verify it does not appear in the team directory for regular users
- [ ] Verify hidden team does not appear on user profile cards
- [ ] Verify Admin/Board/TeamsAdmin can see and manage hidden teams normally
- [ ] Verify the "Hidden" badge appears on the admin summary page
- [ ] Edit an existing team to toggle IsHidden on and off
- [ ] Verify hidden teams still work as campaign targets
- [ ] Verify hidden teams do not appear on the birthday calendar team names

🤖 Generated with [Claude Code](https://claude.com/claude-code)