### PR TITLE
Google sync polish (#296, #300)

### DIFF
--- a/docs/features/07-google-integration.md
+++ b/docs/features/07-google-integration.md
@@ -500,6 +500,8 @@ Process: Reads SyncMode per service from sync_service_settings, then calls
 - `SyncMode.AddOnly` — job computes diff and only adds missing members
 - `SyncMode.AddAndRemove` — job computes diff, adds missing and removes extra members
 
+**Drive folder path updates:** After permission sync, the job calls `UpdateDriveFolderPathsAsync` to fetch the current folder name and parent chain for each active Drive resource via the Drive API (`files.get` with `fields=name,parents`). If a folder has been renamed or moved, `GoogleResource.Name` is updated to reflect the full logical path (e.g. "Shared Drive / Department / Subfolder"). This keeps the `/Teams/Sync` page accurate without requiring manual intervention.
+
 > **Currently disabled:** All jobs that modify Google permissions are disabled until the system is validated. Use the manual "Sync Now" button at `/Teams/Sync` or change sync modes at `/Admin/SyncSettings` instead.
 
 ### SystemTeamSyncJob

--- a/src/Humans.Application/Interfaces/IGoogleSyncService.cs
+++ b/src/Humans.Application/Interfaces/IGoogleSyncService.cs
@@ -142,4 +142,12 @@ public interface IGoogleSyncService
     /// Returns drift status for each group relative to the expected settings.
     /// </summary>
     Task<AllGroupsResult> GetAllDomainGroupsAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Fetches the current Drive folder path for each active Drive resource
+    /// and updates GoogleResource.Name when the folder has been moved or renamed.
+    /// Called during nightly reconciliation.
+    /// </summary>
+    /// <returns>Number of resources whose name was updated.</returns>
+    Task<int> UpdateDriveFolderPathsAsync(CancellationToken cancellationToken = default);
 }

--- a/src/Humans.Infrastructure/Jobs/GoogleResourceReconciliationJob.cs
+++ b/src/Humans.Infrastructure/Jobs/GoogleResourceReconciliationJob.cs
@@ -38,6 +38,13 @@ public class GoogleResourceReconciliationJob : IRecurringJob
             await _googleSyncService.SyncResourcesByTypeAsync(GoogleResourceType.DriveFolder, SyncAction.Execute, cancellationToken);
             await _googleSyncService.SyncResourcesByTypeAsync(GoogleResourceType.Group, SyncAction.Execute, cancellationToken);
 
+            // Update Drive folder paths (detects renames and moves)
+            var pathUpdates = await _googleSyncService.UpdateDriveFolderPathsAsync(cancellationToken);
+            if (pathUpdates > 0)
+            {
+                _logger.LogInformation("Updated {Count} Drive folder path(s) during reconciliation", pathUpdates);
+            }
+
             // Check Google Group settings for drift and auto-remediate
             var settingsResult = await _googleSyncService.CheckGroupSettingsAsync(cancellationToken);
             if (!settingsResult.Skipped && settingsResult.DriftCount > 0)

--- a/src/Humans.Infrastructure/Services/GoogleWorkspaceSyncService.cs
+++ b/src/Humans.Infrastructure/Services/GoogleWorkspaceSyncService.cs
@@ -1976,4 +1976,83 @@ public class GoogleWorkspaceSyncService : IGoogleSyncService
             };
         }
     }
+
+    /// <inheritdoc />
+    public async Task<int> UpdateDriveFolderPathsAsync(CancellationToken cancellationToken = default)
+    {
+        var driveResources = await _dbContext.GoogleResources
+            .Where(r => r.ResourceType == GoogleResourceType.DriveFolder && r.IsActive)
+            .ToListAsync(cancellationToken);
+
+        if (driveResources.Count == 0)
+            return 0;
+
+        var drive = await GetDriveServiceAsync();
+        var updatedCount = 0;
+
+        foreach (var resource in driveResources)
+        {
+            try
+            {
+                var fullPath = await ResolveDriveFolderPathAsync(drive, resource.GoogleId, cancellationToken);
+                if (fullPath is not null && !string.Equals(resource.Name, fullPath, StringComparison.Ordinal))
+                {
+                    _logger.LogInformation(
+                        "Drive folder path changed for resource {ResourceId}: '{OldName}' -> '{NewName}'",
+                        resource.Id, resource.Name, fullPath);
+                    resource.Name = fullPath;
+                    updatedCount++;
+                }
+            }
+            catch (Google.GoogleApiException ex) when (ex.Error?.Code == 404)
+            {
+                _logger.LogWarning("Drive folder {GoogleId} not found (resource {ResourceId}) — may have been deleted",
+                    resource.GoogleId, resource.Id);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to resolve Drive folder path for resource {ResourceId} ({GoogleId})",
+                    resource.Id, resource.GoogleId);
+            }
+        }
+
+        if (updatedCount > 0)
+            await _dbContext.SaveChangesAsync(cancellationToken);
+
+        return updatedCount;
+    }
+
+    /// <summary>
+    /// Resolves the full path of a Drive folder by walking the parent chain.
+    /// Returns a path like "Shared Drive / Department / Subfolder".
+    /// </summary>
+    private async Task<string?> ResolveDriveFolderPathAsync(
+        DriveService drive, string fileId, CancellationToken cancellationToken)
+    {
+        var segments = new List<string>();
+        var currentId = fileId;
+        // Safety limit to prevent infinite loops on circular references
+        const int maxDepth = 20;
+
+        for (var depth = 0; depth < maxDepth; depth++)
+        {
+            var request = drive.Files.Get(currentId);
+            request.SupportsAllDrives = true;
+            request.Fields = "name, parents";
+            var file = await request.ExecuteAsync(cancellationToken);
+
+            segments.Add(file.Name);
+
+            if (file.Parents is null || file.Parents.Count == 0)
+                break;
+
+            currentId = file.Parents[0];
+        }
+
+        if (segments.Count == 0)
+            return null;
+
+        segments.Reverse();
+        return string.Join(" / ", segments);
+    }
 }

--- a/src/Humans.Infrastructure/Services/StubGoogleSyncService.cs
+++ b/src/Humans.Infrastructure/Services/StubGoogleSyncService.cs
@@ -136,6 +136,12 @@ public class StubGoogleSyncService : IGoogleSyncService
         return Task.FromResult(new AllGroupsResult());
     }
 
+    public Task<int> UpdateDriveFolderPathsAsync(CancellationToken cancellationToken = default)
+    {
+        _logger.LogInformation("[STUB] Would update Drive folder paths");
+        return Task.FromResult(0);
+    }
+
     public Task<SyncPreviewResult> SyncResourcesByTypeAsync(
         GoogleResourceType resourceType,
         SyncAction action,

--- a/src/Humans.Web/ViewComponents/MyGoogleResourcesViewComponent.cs
+++ b/src/Humans.Web/ViewComponents/MyGoogleResourcesViewComponent.cs
@@ -1,0 +1,101 @@
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using Humans.Infrastructure.Data;
+
+namespace Humans.Web.ViewComponents;
+
+public class MyGoogleResourcesViewComponent : ViewComponent
+{
+    private readonly HumansDbContext _dbContext;
+    private readonly UserManager<User> _userManager;
+    private readonly ILogger<MyGoogleResourcesViewComponent> _logger;
+
+    public MyGoogleResourcesViewComponent(
+        HumansDbContext dbContext,
+        UserManager<User> userManager,
+        ILogger<MyGoogleResourcesViewComponent> logger)
+    {
+        _dbContext = dbContext;
+        _userManager = userManager;
+        _logger = logger;
+    }
+
+    public async Task<IViewComponentResult> InvokeAsync()
+    {
+        try
+        {
+            var user = await _userManager.GetUserAsync(UserClaimsPrincipal);
+            if (user is null)
+                return Content(string.Empty);
+
+            // Get the user's active team memberships with their Google resources
+            var teamResources = await _dbContext.TeamMembers
+                .AsNoTracking()
+                .Where(tm => tm.UserId == user.Id && tm.LeftAt == null)
+                .Select(tm => new
+                {
+                    TeamName = tm.Team.Name,
+                    TeamSlug = tm.Team.Slug,
+                    Resources = tm.Team.GoogleResources
+                        .Where(r => r.IsActive)
+                        .Select(r => new MyGoogleResourceItem
+                        {
+                            Name = r.Name,
+                            ResourceType = r.ResourceType,
+                            Url = r.Url
+                        })
+                        .ToList()
+                })
+                .Where(t => t.Resources.Count > 0)
+                .OrderBy(t => t.TeamName)
+                .ToListAsync();
+
+            if (teamResources.Count == 0)
+                return Content(string.Empty);
+
+            var model = new MyGoogleResourcesViewModel();
+
+            foreach (var team in teamResources)
+            {
+                foreach (var resource in team.Resources)
+                {
+                    model.Resources.Add(new MyGoogleResourceWithTeam
+                    {
+                        TeamName = team.TeamName,
+                        TeamSlug = team.TeamSlug,
+                        Resource = resource
+                    });
+                }
+            }
+
+            return View(model);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to load Google resources for current user");
+            return Content(string.Empty);
+        }
+    }
+}
+
+public class MyGoogleResourcesViewModel
+{
+    public List<MyGoogleResourceWithTeam> Resources { get; set; } = [];
+}
+
+public class MyGoogleResourceWithTeam
+{
+    public string TeamName { get; set; } = string.Empty;
+    public string TeamSlug { get; set; } = string.Empty;
+    public MyGoogleResourceItem Resource { get; set; } = null!;
+}
+
+public class MyGoogleResourceItem
+{
+    public string Name { get; set; } = string.Empty;
+    public GoogleResourceType ResourceType { get; set; }
+    public string? Url { get; set; }
+}

--- a/src/Humans.Web/Views/Home/Dashboard.cshtml
+++ b/src/Humans.Web/Views/Home/Dashboard.cshtml
@@ -237,6 +237,11 @@
             </div>
         </div>
 
+        @if (Model.IsVolunteerMember)
+        {
+            @await Component.InvokeAsync("MyGoogleResources")
+        }
+
         <div class="card mb-4">
             <div class="card-header">@Localizer["Dashboard_YourMembership"]</div>
             <div class="card-body">

--- a/src/Humans.Web/Views/Shared/Components/MyGoogleResources/Default.cshtml
+++ b/src/Humans.Web/Views/Shared/Components/MyGoogleResources/Default.cshtml
@@ -1,0 +1,48 @@
+@model Humans.Web.ViewComponents.MyGoogleResourcesViewModel
+
+<div class="card mb-4">
+    <div class="card-header">
+        <i class="fa-solid fa-cloud me-1"></i> Your Google Resources
+    </div>
+    <div class="list-group list-group-flush">
+        @foreach (var item in Model.Resources)
+        {
+            var icon = item.Resource.ResourceType == Humans.Domain.Enums.GoogleResourceType.Group
+                ? "fa-solid fa-users"
+                : "fa-solid fa-folder";
+            var typeLabel = item.Resource.ResourceType == Humans.Domain.Enums.GoogleResourceType.Group
+                ? "Group"
+                : "Drive";
+
+            if (item.Resource.Url is not null)
+            {
+                <a href="@item.Resource.Url" target="_blank" rel="noopener noreferrer" class="list-group-item list-group-item-action d-flex justify-content-between align-items-start">
+                    <div>
+                        <i class="@icon me-1 text-muted"></i>
+                        @item.Resource.Name
+                        <br />
+                        <small class="text-muted">
+                            <span class="badge bg-light text-dark border">@typeLabel</span>
+                            via <a asp-controller="Team" asp-action="Detail" asp-route-slug="@item.TeamSlug" class="text-decoration-none" @* prevent outer link navigation *@ onclick="event.stopPropagation();">@item.TeamName</a>
+                        </small>
+                    </div>
+                    <i class="fa-solid fa-external-link-alt text-muted align-self-center"></i>
+                </a>
+            }
+            else
+            {
+                <div class="list-group-item d-flex justify-content-between align-items-start">
+                    <div>
+                        <i class="@icon me-1 text-muted"></i>
+                        @item.Resource.Name
+                        <br />
+                        <small class="text-muted">
+                            <span class="badge bg-light text-dark border">@typeLabel</span>
+                            via <a asp-controller="Team" asp-action="Detail" asp-route-slug="@item.TeamSlug" class="text-decoration-none">@item.TeamName</a>
+                        </small>
+                    </div>
+                </div>
+            }
+        }
+    </div>
+</div>

--- a/src/Humans.Web/Views/Shared/Components/MyGoogleResources/Default.cshtml
+++ b/src/Humans.Web/Views/Shared/Components/MyGoogleResources/Default.cshtml
@@ -14,35 +14,24 @@
                 ? "Group"
                 : "Drive";
 
-            if (item.Resource.Url is not null)
-            {
-                <a href="@item.Resource.Url" target="_blank" rel="noopener noreferrer" class="list-group-item list-group-item-action d-flex justify-content-between align-items-start">
-                    <div>
-                        <i class="@icon me-1 text-muted"></i>
+            <div class="list-group-item d-flex justify-content-between align-items-start">
+                <div>
+                    <i class="@icon me-1 text-muted"></i>
+                    @if (item.Resource.Url is not null)
+                    {
+                        <a href="@item.Resource.Url" target="_blank" rel="noopener noreferrer">@item.Resource.Name <i class="fa-solid fa-external-link-alt small"></i></a>
+                    }
+                    else
+                    {
                         @item.Resource.Name
-                        <br />
-                        <small class="text-muted">
-                            <span class="badge bg-light text-dark border">@typeLabel</span>
-                            via <a asp-controller="Team" asp-action="Detail" asp-route-slug="@item.TeamSlug" class="text-decoration-none" @* prevent outer link navigation *@ onclick="event.stopPropagation();">@item.TeamName</a>
-                        </small>
-                    </div>
-                    <i class="fa-solid fa-external-link-alt text-muted align-self-center"></i>
-                </a>
-            }
-            else
-            {
-                <div class="list-group-item d-flex justify-content-between align-items-start">
-                    <div>
-                        <i class="@icon me-1 text-muted"></i>
-                        @item.Resource.Name
-                        <br />
-                        <small class="text-muted">
-                            <span class="badge bg-light text-dark border">@typeLabel</span>
-                            via <a asp-controller="Team" asp-action="Detail" asp-route-slug="@item.TeamSlug" class="text-decoration-none">@item.TeamName</a>
-                        </small>
-                    </div>
+                    }
+                    <br />
+                    <small class="text-muted">
+                        <span class="badge bg-light text-dark border">@typeLabel</span>
+                        via <a asp-controller="Team" asp-action="Detail" asp-route-slug="@item.TeamSlug" class="text-decoration-none">@item.TeamName</a>
+                    </small>
                 </div>
-            }
+            </div>
         }
     </div>
 </div>


### PR DESCRIPTION
## Summary
- **#296** — Update Drive folder paths during nightly reconciliation. Walks the parent chain via the Drive API to keep GoogleResource.Name in sync with actual folder locations.
- **#300** — Add "My Google Resources" ViewComponent to the dashboard sidebar. Shows the current user's Groups and Drive folders obtained through team memberships, with type badges, team links, and external Google links.

## Spec Compliance
All acceptance criteria verified per-issue during implementation.
- #296: PASS (4/4 criteria)
- #300: PASS (4/4 criteria)

## Code Review
Self-reviewed against CODE_REVIEW_RULES.md. Found and fixed one CRITICAL issue: inline `onclick` handler in the Razor view violated CSP rules. Restructured to avoid nested anchors.

## Test plan
- [ ] Deploy to preview, log in as a user with team memberships that have Google resources
- [ ] Verify the "Your Google Resources" card appears in the dashboard right sidebar
- [ ] Verify each resource shows name, type badge (Group/Drive), and granting team name
- [ ] Verify resources with URLs link out to Google (opens in new tab)
- [ ] Verify the widget is hidden when the user has no team Google resources
- [ ] Trigger a nightly reconciliation run (or call UpdateDriveFolderPathsAsync manually) and verify Drive folder names update when folders have been moved

🤖 Generated with [Claude Code](https://claude.com/claude-code) sprint swarm