### PR TITLE
Suppress notifications and refine profile visibility for hidden teams (#311)

### DIFF
--- a/src/Humans.Infrastructure/Jobs/SystemTeamSyncJob.cs
+++ b/src/Humans.Infrastructure/Jobs/SystemTeamSyncJob.cs
@@ -648,8 +648,8 @@ public class SystemTeamSyncJob : ISystemTeamSync
                 team.Name, toAdd.Count, toRemove.Count);
         }
 
-        // Send "added to team" emails for newly added members
-        if (toAdd.Count > 0)
+        // Send "added to team" emails for newly added members (skip hidden teams)
+        if (toAdd.Count > 0 && !team.IsHidden)
         {
             var resources = await _dbContext.GoogleResources
                 .AsNoTracking()

--- a/src/Humans.Infrastructure/Services/TeamService.cs
+++ b/src/Humans.Infrastructure/Services/TeamService.cs
@@ -350,15 +350,12 @@ public class TeamService : ITeamService
         Guid userId,
         CancellationToken cancellationToken = default)
     {
+        // This is the current user's own My Teams page — show all their memberships including hidden teams
         var allMemberships = await GetUserTeamsAsync(userId, cancellationToken);
+        var memberships = allMemberships;
         var isBoardMember = await _roleAssignmentService.IsUserBoardMemberAsync(userId, cancellationToken);
         var isAdmin = await _roleAssignmentService.IsUserAdminAsync(userId, cancellationToken);
         var isTeamsAdmin = await _roleAssignmentService.IsUserTeamsAdminAsync(userId, cancellationToken);
-        var canSeeHidden = isBoardMember || isAdmin || isTeamsAdmin;
-
-        var memberships = canSeeHidden
-            ? allMemberships
-            : allMemberships.Where(m => !m.Team.IsHidden).ToList();
 
         var coordinatorTeamIds = memberships
             .Where(m => (m.Role == TeamMemberRole.Coordinator || isBoardMember) && !m.Team.IsSystemTeam)

--- a/src/Humans.Infrastructure/Services/TeamService.cs
+++ b/src/Humans.Infrastructure/Services/TeamService.cs
@@ -629,6 +629,11 @@ public class TeamService : ITeamService
             throw new InvalidOperationException("Cannot request to join system team");
         }
 
+        if (team.IsHidden)
+        {
+            throw new InvalidOperationException("Cannot request to join a hidden team");
+        }
+
         if (!team.RequiresApproval)
         {
             throw new InvalidOperationException("This team does not require approval. Use JoinTeamDirectlyAsync instead.");
@@ -679,6 +684,11 @@ public class TeamService : ITeamService
         if (team.IsSystemTeam)
         {
             throw new InvalidOperationException("Cannot directly join system team");
+        }
+
+        if (team.IsHidden)
+        {
+            throw new InvalidOperationException("Cannot directly join a hidden team");
         }
 
         if (team.RequiresApproval)

--- a/src/Humans.Infrastructure/Services/TeamService.cs
+++ b/src/Humans.Infrastructure/Services/TeamService.cs
@@ -1833,6 +1833,8 @@ public class TeamService : ITeamService
 
     private async Task SendAddedToTeamEmailAsync(Guid userId, Team team, CancellationToken cancellationToken)
     {
+        if (team.IsHidden) return;
+
         try
         {
             var user = await _dbContext.Users

--- a/src/Humans.Web/Controllers/TeamController.cs
+++ b/src/Humans.Web/Controllers/TeamController.cs
@@ -483,6 +483,11 @@ public class TeamController : HumansControllerBase
             return BadRequest();
         }
 
+        if (team.IsHidden && !RoleChecks.IsTeamsAdminBoardOrAdmin(User))
+        {
+            return NotFound();
+        }
+
         try
         {
             if (team.RequiresApproval)

--- a/src/Humans.Web/ViewComponents/ProfileCardViewComponent.cs
+++ b/src/Humans.Web/ViewComponents/ProfileCardViewComponent.cs
@@ -111,7 +111,8 @@ public class ProfileCardViewComponent : ViewComponent
         // Get user's teams (excluding Volunteers system team)
         var userTeams = await _teamService.GetUserTeamsAsync(userId);
         var displayableTeams = userTeams
-            .Where(tm => tm.Team.SystemTeamType != SystemTeamType.Volunteers && !tm.Team.IsHidden)
+            .Where(tm => tm.Team.SystemTeamType != SystemTeamType.Volunteers
+                && (viewMode != ProfileCardViewMode.Public || !tm.Team.IsHidden))
             .OrderBy(tm => tm.Team.Name, StringComparer.Ordinal)
             .Select(tm => new TeamMembershipViewModel
             {

--- a/src/Humans.Web/Views/Profile/Index.cshtml
+++ b/src/Humans.Web/Views/Profile/Index.cshtml
@@ -57,7 +57,14 @@
             </div>
         }
 
-        <vc:profile-card user-id="@Model.UserId" view-mode="@(Model.IsOwnProfile ? ProfileCardViewMode.Self : ProfileCardViewMode.Public)" />
+        @{
+            var cardViewMode = Model.IsOwnProfile
+                ? ProfileCardViewMode.Self
+                : Humans.Web.Authorization.RoleChecks.IsTeamsAdminBoardOrAdmin(User)
+                    ? ProfileCardViewMode.Admin
+                    : ProfileCardViewMode.Public;
+        }
+        <vc:profile-card user-id="@Model.UserId" view-mode="@cardViewMode" />
 
         @if (Model.NoShowHistory != null && Model.NoShowHistory.Count > 0)
         {


### PR DESCRIPTION
## Summary
- **Notification suppression:** No email sent when a user is added to a hidden team (via direct add, join request approval, or system sync)
- **Profile card visibility:** Hidden teams now visible on Self and Admin views, hidden only for Public view
- **My Teams page:** Users see all their own memberships including hidden teams

Closes #311

## Test plan
- [ ] Add a user to a hidden team — no email sent
- [ ] Add a user to a normal team — email sent as before
- [ ] View own profile — hidden team membership visible
- [ ] Admin views a user's profile — hidden team membership visible
- [ ] Another regular user views the profile — hidden team membership NOT visible
- [ ] My Teams page shows hidden team memberships

🤖 Generated with [Claude Code](https://claude.com/claude-code)