### PR TITLE
Staff & About Pages (#317)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,7 +145,7 @@ dotnet run --project src/Humans.Web
 
 ## About Page / License Attribution
 
-The About page (`Views/Home/About.cshtml`) lists all production NuGet packages and frontend CDN dependencies with versions and licenses. **After any NuGet package update, add the new package versions to the About page.** This is tracked as a monthly maintenance task tied to the NuGet full update cycle.
+The About page (`Views/About/Index.cshtml`) lists all production NuGet packages and frontend CDN dependencies with versions and licenses. **After any NuGet package update, add the new package versions to the About page.** This is tracked as a monthly maintenance task tied to the NuGet full update cycle.
 
 The project is licensed under **AGPL-3.0** (`LICENSE` at repo root).
 

--- a/src/Humans.Web/Controllers/AboutController.cs
+++ b/src/Humans.Web/Controllers/AboutController.cs
@@ -1,0 +1,93 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using NodaTime;
+using Humans.Application.Interfaces;
+using Humans.Domain.Constants;
+using Humans.Domain.Entities;
+using Humans.Web.Models;
+
+namespace Humans.Web.Controllers;
+
+[Route("[controller]")]
+public class AboutController : HumansControllerBase
+{
+    private readonly IRoleAssignmentService _roleAssignmentService;
+    private readonly IClock _clock;
+    private readonly ILogger<AboutController> _logger;
+
+    public AboutController(
+        UserManager<User> userManager,
+        IRoleAssignmentService roleAssignmentService,
+        IClock clock,
+        ILogger<AboutController> logger)
+        : base(userManager)
+    {
+        _roleAssignmentService = roleAssignmentService;
+        _clock = clock;
+        _logger = logger;
+    }
+
+    [HttpGet("")]
+    public IActionResult Index()
+    {
+        return View();
+    }
+
+    [Authorize]
+    [HttpGet("Staff")]
+    public async Task<IActionResult> Staff()
+    {
+        try
+        {
+            var now = _clock.GetCurrentInstant();
+
+            // Load all active role assignments with user data — ~500 users, fits in memory
+            var (assignments, _) = await _roleAssignmentService.GetFilteredAsync(
+                roleFilter: null, activeOnly: true, page: 1, pageSize: 500, now);
+
+            // Define role display order and metadata
+            var roleDefinitions = StaffViewModel.GetRoleDefinitions();
+
+            var roleSections = new List<StaffRoleSectionViewModel>();
+
+            foreach (var roleDef in roleDefinitions)
+            {
+                var holders = assignments
+                    .Where(ra => string.Equals(ra.RoleName, roleDef.RoleName, StringComparison.Ordinal))
+                    .Select(ra => new StaffRoleHolderViewModel
+                    {
+                        UserId = ra.UserId,
+                        DisplayName = ra.User.DisplayName,
+                        ProfilePictureUrl = ra.User.ProfilePictureUrl
+                    })
+                    .OrderBy(h => h.DisplayName, StringComparer.OrdinalIgnoreCase)
+                    .ToList();
+
+                if (holders.Count > 0)
+                {
+                    roleSections.Add(new StaffRoleSectionViewModel
+                    {
+                        RoleName = roleDef.RoleName,
+                        DisplayTitle = roleDef.DisplayTitle,
+                        Blurb = roleDef.Blurb,
+                        Icon = roleDef.Icon,
+                        Holders = holders
+                    });
+                }
+            }
+
+            var viewModel = new StaffViewModel
+            {
+                RoleSections = roleSections
+            };
+
+            return View(viewModel);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to load staff page");
+            return View(new StaffViewModel { RoleSections = [] });
+        }
+    }
+}

--- a/src/Humans.Web/Controllers/AboutController.cs
+++ b/src/Humans.Web/Controllers/AboutController.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Mvc;
 using NodaTime;
 using Humans.Application.Interfaces;
 using Humans.Domain.Entities;
+using Humans.Web.Helpers;
 using Humans.Web.Models;
 
 namespace Humans.Web.Controllers;
@@ -12,17 +13,20 @@ namespace Humans.Web.Controllers;
 public class AboutController : HumansControllerBase
 {
     private readonly IRoleAssignmentService _roleAssignmentService;
+    private readonly IProfileService _profileService;
     private readonly IClock _clock;
     private readonly ILogger<AboutController> _logger;
 
     public AboutController(
         UserManager<User> userManager,
         IRoleAssignmentService roleAssignmentService,
+        IProfileService profileService,
         IClock clock,
         ILogger<AboutController> logger)
         : base(userManager)
     {
         _roleAssignmentService = roleAssignmentService;
+        _profileService = profileService;
         _clock = clock;
         _logger = logger;
     }
@@ -45,6 +49,11 @@ public class AboutController : HumansControllerBase
             var (assignments, _) = await _roleAssignmentService.GetFilteredAsync(
                 roleFilter: null, activeOnly: true, page: 1, pageSize: 500, now);
 
+            // Resolve effective profile picture URLs (custom uploads take priority over Google avatars)
+            var effectiveUrls = await ProfilePictureUrlHelper.BuildEffectiveUrlsAsync(
+                _profileService, Url,
+                assignments.Select(ra => (ra.UserId, ra.User.ProfilePictureUrl)));
+
             // Define role display order and metadata
             var roleDefinitions = StaffViewModel.GetRoleDefinitions();
 
@@ -58,7 +67,7 @@ public class AboutController : HumansControllerBase
                     {
                         UserId = ra.UserId,
                         DisplayName = ra.User.DisplayName,
-                        ProfilePictureUrl = ra.User.ProfilePictureUrl
+                        ProfilePictureUrl = effectiveUrls.GetValueOrDefault(ra.UserId)
                     })
                     .OrderBy(h => h.DisplayName, StringComparer.OrdinalIgnoreCase)
                     .ToList();

--- a/src/Humans.Web/Controllers/AboutController.cs
+++ b/src/Humans.Web/Controllers/AboutController.cs
@@ -3,7 +3,6 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using NodaTime;
 using Humans.Application.Interfaces;
-using Humans.Domain.Constants;
 using Humans.Domain.Entities;
 using Humans.Web.Models;
 

--- a/src/Humans.Web/Controllers/HomeController.cs
+++ b/src/Humans.Web/Controllers/HomeController.cs
@@ -251,11 +251,6 @@ public class HomeController : HumansControllerBase
         return View();
     }
 
-    public IActionResult About()
-    {
-        return View();
-    }
-
     [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
     [Route("/Home/Error/{statusCode?}")]
     public IActionResult Error(int? statusCode = null)

--- a/src/Humans.Web/Models/StaffViewModels.cs
+++ b/src/Humans.Web/Models/StaffViewModels.cs
@@ -1,0 +1,81 @@
+using Humans.Domain.Constants;
+
+namespace Humans.Web.Models;
+
+public class StaffViewModel
+{
+    public IReadOnlyList<StaffRoleSectionViewModel> RoleSections { get; init; } = [];
+
+    /// <summary>
+    /// Defines the ordered list of roles with display metadata.
+    /// Order: community-facing roles first, full Admin last.
+    /// </summary>
+    public static IReadOnlyList<StaffRoleDefinition> GetRoleDefinitions() =>
+    [
+        new(RoleNames.Board, "The Board",
+            "Elected stewards of the collective. They guide strategy, approve tier applications, and make the big decisions so the rest of us can focus on making things happen.",
+            "fa-solid fa-crown"),
+
+        new(RoleNames.ConsentCoordinator, "Consent Coordinators",
+            "Guardians of trust and safety. They review every new human's consent journey, ensuring our community standards are understood and upheld from day one.",
+            "fa-solid fa-shield-heart"),
+
+        new(RoleNames.VolunteerCoordinator, "Volunteer Coordinators",
+            "The welcoming committee. They shepherd new humans through onboarding, answer the questions nobody else thinks to ask, and make sure no one gets lost along the way.",
+            "fa-solid fa-hand-holding-heart"),
+
+        new(RoleNames.TeamsAdmin, "Teams Stewards",
+            "Architects of collaboration. They organize the working groups, provision resources, and make sure every team has what it needs to thrive.",
+            "fa-solid fa-people-group"),
+
+        new(RoleNames.CampAdmin, "Camp Wranglers",
+            "Masters of the camp universe. They review registrations, manage settings, and keep the camp ecosystem running smoothly season after season.",
+            "fa-solid fa-campground"),
+
+        new(RoleNames.FinanceAdmin, "Finance Keepers",
+            "Stewards of the purse. They manage budgets, track expenditures, and ensure every euro is accounted for with the transparency a nonprofit deserves.",
+            "fa-solid fa-coins"),
+
+        new(RoleNames.TicketAdmin, "Ticket Alchemists",
+            "They conjure tickets from vendor APIs, match purchases to humans, and make sure the numbers add up before the gates open.",
+            "fa-solid fa-ticket"),
+
+        new(RoleNames.FeedbackAdmin, "Feedback Whisperers",
+            "Listeners of the community voice. They triage bug reports, field feature requests, and make sure every piece of feedback finds its way to the right hands.",
+            "fa-solid fa-comments"),
+
+        new(RoleNames.HumanAdmin, "Human Administrators",
+            "Keepers of the human directory. They manage profiles, handle role assignments, and provision workspace accounts. If you exist in this system, they probably helped.",
+            "fa-solid fa-users-gear"),
+
+        new(RoleNames.NoInfoAdmin, "NoInfo Stewards",
+            "Shift approval specialists with access to sensitive volunteer data. They approve signups and handle the operational details that keep events running.",
+            "fa-solid fa-clipboard-check"),
+
+        new(RoleNames.Admin, "Full Administrators",
+            "The ones who keep the lights on. Full system access, all the keys, all the responsibility. When something breaks at 3am, these are the humans who fix it.",
+            "fa-solid fa-gear")
+    ];
+}
+
+public record StaffRoleDefinition(
+    string RoleName,
+    string DisplayTitle,
+    string Blurb,
+    string Icon);
+
+public class StaffRoleSectionViewModel
+{
+    public string RoleName { get; init; } = string.Empty;
+    public string DisplayTitle { get; init; } = string.Empty;
+    public string Blurb { get; init; } = string.Empty;
+    public string Icon { get; init; } = string.Empty;
+    public IReadOnlyList<StaffRoleHolderViewModel> Holders { get; init; } = [];
+}
+
+public class StaffRoleHolderViewModel
+{
+    public Guid UserId { get; init; }
+    public string DisplayName { get; init; } = string.Empty;
+    public string? ProfilePictureUrl { get; init; }
+}

--- a/src/Humans.Web/Views/About/Index.cshtml
+++ b/src/Humans.Web/Views/About/Index.cshtml
@@ -21,6 +21,14 @@
         <a href="https://github.com/jokin" target="_blank" rel="noopener noreferrer">Jokin</a>
         and <a href="https://github.com/veryaaron" target="_blank" rel="noopener noreferrer">Aaron</a>.
     </p>
+    @if (User.Identity?.IsAuthenticated == true)
+    {
+        <p class="mt-4">
+            <a asp-controller="About" asp-action="Staff" class="btn btn-outline-primary">
+                <i class="fa-solid fa-users me-1"></i> Meet the Staff
+            </a>
+        </p>
+    }
 </div>
 
 <div class="card border-primary mb-5" style="max-width: 720px; margin: 0 auto;">

--- a/src/Humans.Web/Views/About/Staff.cshtml
+++ b/src/Humans.Web/Views/About/Staff.cshtml
@@ -38,20 +38,13 @@ else
                 @foreach (var holder in roleSection.Holders)
                 {
                     <div class="col-6 col-sm-4 col-md-3 col-lg-2">
-                        <div class="text-center">
-                            <a asp-controller="Human" asp-action="HumanProfile" asp-route-id="@holder.UserId"
-                               class="text-decoration-none text-body">
-                                <div class="d-flex justify-content-center mb-2">
-                                    @await Component.InvokeAsync("UserAvatar", new {
-                                        profilePictureUrl = holder.ProfilePictureUrl,
-                                        displayName = holder.DisplayName,
-                                        size = 80,
-                                        bgColor = "bg-primary"
-                                    })
-                                </div>
-                                <div class="fw-semibold small">@holder.DisplayName</div>
-                            </a>
-                        </div>
+                        <human-link user-id="@holder.UserId"
+                                    display-name="@holder.DisplayName"
+                                    profile-picture-url="@holder.ProfilePictureUrl"
+                                    mode="Card"
+                                    size="80"
+                                    avatar-bg-color="bg-primary"
+                                    show-popover="true" />
                     </div>
                 }
             </div>

--- a/src/Humans.Web/Views/About/Staff.cshtml
+++ b/src/Humans.Web/Views/About/Staff.cshtml
@@ -1,0 +1,66 @@
+@model StaffViewModel
+@{
+    ViewData["Title"] = "The Humans Behind the Curtain";
+}
+
+<div class="text-center my-5">
+    <h1 class="display-4" style="font-family: 'Cormorant Garamond', serif; font-weight: 700;">
+        <i class="fa-solid fa-scroll me-2"></i>The Humans Behind the Curtain
+    </h1>
+    <p class="lead mt-3" style="max-width: 700px; margin: 0 auto; font-style: italic;">
+        Every collective needs its keepers. These are the humans who volunteer their time and energy
+        to keep Nobodies running &mdash; from governance to tech support, from trust and safety to ticket alchemy.
+    </p>
+</div>
+
+@if (Model.RoleSections.Count == 0)
+{
+    <div class="text-center text-muted my-5">
+        <i class="fa-solid fa-ghost fa-3x mb-3"></i>
+        <p>No active role holders found. The castle appears to be empty.</p>
+    </div>
+}
+else
+{
+    @foreach (var roleSection in Model.RoleSections)
+    {
+        <section class="mb-5">
+            <div class="border-bottom pb-2 mb-4">
+                <h2 style="font-family: 'Cormorant Garamond', serif; font-weight: 600;">
+                    <i class="@roleSection.Icon me-2"></i>@roleSection.DisplayTitle
+                </h2>
+                <p class="text-muted mb-0" style="font-style: italic; max-width: 720px;">
+                    @roleSection.Blurb
+                </p>
+            </div>
+
+            <div class="row g-4">
+                @foreach (var holder in roleSection.Holders)
+                {
+                    <div class="col-6 col-sm-4 col-md-3 col-lg-2">
+                        <div class="text-center">
+                            <a asp-controller="Human" asp-action="HumanProfile" asp-route-id="@holder.UserId"
+                               class="text-decoration-none text-body">
+                                <div class="d-flex justify-content-center mb-2">
+                                    @await Component.InvokeAsync("UserAvatar", new {
+                                        profilePictureUrl = holder.ProfilePictureUrl,
+                                        displayName = holder.DisplayName,
+                                        size = 80,
+                                        bgColor = "bg-primary"
+                                    })
+                                </div>
+                                <div class="fw-semibold small">@holder.DisplayName</div>
+                            </a>
+                        </div>
+                    </div>
+                }
+            </div>
+        </section>
+    }
+}
+
+<div class="text-center my-5">
+    <a asp-controller="About" asp-action="Index" class="btn btn-outline-secondary">
+        <i class="fa-solid fa-arrow-left me-1"></i> Back to About
+    </a>
+</div>

--- a/src/Humans.Web/Views/Shared/_Layout.cshtml
+++ b/src/Humans.Web/Views/Shared/_Layout.cshtml
@@ -151,7 +151,7 @@
     <footer class="border-top py-3 text-muted text-center">
         <div class="container d-flex justify-content-between align-items-center">
             <div class="d-flex gap-3">
-                <a asp-controller="Home" asp-action="About" class="text-muted small">About</a>
+                <a asp-controller="About" asp-action="Index" class="text-muted small">About</a>
                 <a asp-controller="Home" asp-action="Privacy" class="text-muted small">@Localizer["Nav_Privacy"]</a>
                 @if (User.Identity?.IsAuthenticated == true)
                 {

--- a/src/Humans.Web/Views/Shared/_LoginPartial.cshtml
+++ b/src/Humans.Web/Views/Shared/_LoginPartial.cshtml
@@ -67,8 +67,13 @@
                 </a>
             </li>
             <li>
-                <a class="dropdown-item d-flex align-items-center gap-2" asp-controller="Home" asp-action="About">
+                <a class="dropdown-item d-flex align-items-center gap-2" asp-controller="About" asp-action="Index">
                     <i class="fa-solid fa-info-circle fa-fw"></i> @Localizer["Nav_About"]
+                </a>
+            </li>
+            <li>
+                <a class="dropdown-item d-flex align-items-center gap-2" asp-controller="About" asp-action="Staff">
+                    <i class="fa-solid fa-users fa-fw"></i> Staff
                 </a>
             </li>
             <li>

--- a/tests/Humans.Integration.Tests/AnonymousAccessTests.cs
+++ b/tests/Humans.Integration.Tests/AnonymousAccessTests.cs
@@ -20,7 +20,7 @@ public class AnonymousAccessTests : IntegrationTestBase
     [Fact]
     public async Task AboutPage_IsAccessibleAnonymously()
     {
-        var response = await Client.GetAsync("/Home/About");
+        var response = await Client.GetAsync("/About");
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
     }


### PR DESCRIPTION
## Summary
- **#317** — Create AboutController with `/About` (moved from HomeController) and `/About/Staff` (new staff display page). Staff page reads RoleAssignment entities, groups by role in specified display order, shows profile photo + display name. Whimsical Renaissance-toned role descriptions.

## Changes
- New `AboutController` with `/About` route (moved from `HomeController.About`) and `/About/Staff`
- Staff page shows current role holders grouped by role with profile photos via UserAvatar component
- 11 role sections with playful descriptions, community-facing roles first, Admin last
- All existing links to `/Home/About` updated to `/About` (footer, nav dropdown, integration test)
- Nav link to Staff added in profile dropdown and on About page
- CLAUDE.md updated to reference new view path

## Spec Compliance
- **#317** — PASS (9/9 acceptance criteria verified)

## Code Review
Self-reviewed against CODE_REVIEW_RULES.md. No critical issues.

## Test plan
- [ ] Visit `/About` — attribution page renders, "Meet the Staff" button visible when authenticated
- [ ] Visit `/About/Staff` — role holders displayed with photos, grouped by role
- [ ] Visit `/About/Staff` when unauthenticated — redirects to login
- [ ] Verify footer and profile dropdown links point to `/About` (not `/Home/About`)
- [ ] Verify roles appear in correct order (Board first, Admin last)
- [ ] Verify people with multiple roles appear in each section

🤖 Generated with [Claude Code](https://claude.com/claude-code) sprint swarm