### PR TITLE
Bug hunt: caching, shifts, auth, UI fixes

### DIFF
--- a/src/Humans.Application/DTOs/DomainGroupInfo.cs
+++ b/src/Humans.Application/DTOs/DomainGroupInfo.cs
@@ -8,6 +8,7 @@ public class DomainGroupInfo
     public int MemberCount { get; init; }
     public string? LinkedTeamName { get; init; }
     public Guid? LinkedTeamId { get; init; }
+    public string? LinkedTeamSlug { get; init; }
     public Dictionary<string, string> ActualSettings { get; init; } = [];
     public List<GroupSettingDrift> Drifts { get; init; } = [];
     public bool HasDrift => Drifts.Count > 0;

--- a/src/Humans.Infrastructure/Services/GoogleWorkspaceSyncService.cs
+++ b/src/Humans.Infrastructure/Services/GoogleWorkspaceSyncService.cs
@@ -1948,6 +1948,7 @@ public class GoogleWorkspaceSyncService : IGoogleSyncService
                         MemberCount = (int)(group.DirectMembersCount ?? 0),
                         LinkedTeamName = linkedTeam?.Name,
                         LinkedTeamId = linkedTeam?.Id,
+                        LinkedTeamSlug = linkedTeam?.Slug,
                         ActualSettings = actualSettings,
                         Drifts = drifts,
                         ErrorMessage = errorMessage

--- a/src/Humans.Infrastructure/Services/LegalDocumentService.cs
+++ b/src/Humans.Infrastructure/Services/LegalDocumentService.cs
@@ -40,30 +40,32 @@ public partial class LegalDocumentService : ILegalDocumentService
     public async Task<Dictionary<string, string>> GetDocumentContentAsync(string slug)
     {
         var cacheKey = CacheKeys.LegalDocument(slug);
-
-        return await _cache.GetOrCreateAsync(cacheKey, async entry =>
+        if (_cache.TryGetValue<Dictionary<string, string>>(cacheKey, out var cachedContent) &&
+            cachedContent is not null)
         {
-            entry.AbsoluteExpirationRelativeToNow = CacheTtl;
+            return cachedContent;
+        }
 
-            try
+        try
+        {
+            var definition = Documents.FirstOrDefault(d =>
+                string.Equals(d.Slug, slug, StringComparison.OrdinalIgnoreCase));
+
+            if (definition is null)
             {
-                var definition = Documents.FirstOrDefault(d =>
-                    string.Equals(d.Slug, slug, StringComparison.OrdinalIgnoreCase));
-
-                if (definition is null)
-                {
-                    _logger.LogWarning("Unknown legal document slug: {Slug}", slug);
-                    return new Dictionary<string, string>(StringComparer.Ordinal);
-                }
-
-                return await GetDocumentContentAsync(definition);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "Failed to fetch legal document {Slug} from GitHub", slug);
+                _logger.LogWarning("Unknown legal document slug: {Slug}", slug);
                 return new Dictionary<string, string>(StringComparer.Ordinal);
             }
-        }) ?? new Dictionary<string, string>(StringComparer.Ordinal);
+
+            var content = await GetDocumentContentAsync(definition);
+            _cache.Set(cacheKey, content, CacheTtl);
+            return content;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to fetch legal document {Slug} from GitHub", slug);
+            return new Dictionary<string, string>(StringComparer.Ordinal);
+        }
     }
 
     private async Task<Dictionary<string, string>> GetDocumentContentAsync(LegalDocumentDefinition definition)

--- a/src/Humans.Infrastructure/Services/LegalDocumentService.cs
+++ b/src/Humans.Infrastructure/Services/LegalDocumentService.cs
@@ -17,6 +17,7 @@ public partial class LegalDocumentService : ILegalDocumentService
     ];
 
     private static readonly TimeSpan CacheTtl = TimeSpan.FromHours(1);
+    private static readonly TimeSpan FailureCacheTtl = TimeSpan.FromSeconds(30);
 
     [GeneratedRegex(@"^(?<name>.+?)(?:-(?<lang>[A-Za-z]{2}))?\.md$", RegexOptions.None, 1000)]
     private static partial Regex LanguageFilePattern();
@@ -64,7 +65,9 @@ public partial class LegalDocumentService : ILegalDocumentService
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Failed to fetch legal document {Slug} from GitHub", slug);
-            return new Dictionary<string, string>(StringComparer.Ordinal);
+            var emptyContent = new Dictionary<string, string>(StringComparer.Ordinal);
+            _cache.Set(cacheKey, emptyContent, FailureCacheTtl);
+            return emptyContent;
         }
     }
 

--- a/src/Humans.Infrastructure/Services/ShiftSignupService.cs
+++ b/src/Humans.Infrastructure/Services/ShiftSignupService.cs
@@ -493,9 +493,23 @@ public class ShiftSignupService : IShiftSignupService
         // EE cap check for build shifts
         if (rota.Period == RotaPeriod.Build)
         {
-            var eeWarning = await CheckEeCapAsync(es, shiftsInRange[0].DayOffset);
-            if (eeWarning is not null)
+            var fullEeDays = new List<int>();
+            foreach (var dayOffset in shiftsInRange
+                         .Where(shift => shift.IsEarlyEntry)
+                         .Select(shift => shift.DayOffset)
+                         .Distinct()
+                         .OrderBy(day => day))
+            {
+                var eeWarning = await CheckEeCapAsync(es, dayOffset);
+                if (eeWarning is not null)
+                    fullEeDays.Add(dayOffset);
+            }
+
+            if (fullEeDays.Count > 0)
+            {
+                var eeWarning = $"Early entry capacity reached for day(s): {string.Join(", ", fullEeDays)}.";
                 warning = warning is null ? eeWarning : $"{warning} {eeWarning}";
+            }
         }
 
         // Create signups
@@ -754,7 +768,7 @@ public class ShiftSignupService : IShiftSignupService
         var currentEeCount = await _dbContext.ShiftSignups
             .Where(d => d.Status == SignupStatus.Confirmed &&
                         d.Shift.Rota.EventSettingsId == es.Id &&
-                        d.Shift.DayOffset < 0)
+                        d.Shift.DayOffset == dayOffset)
             .Select(d => d.UserId)
             .Distinct()
             .CountAsync();

--- a/src/Humans.Infrastructure/Services/TeamService.cs
+++ b/src/Humans.Infrastructure/Services/TeamService.cs
@@ -258,7 +258,8 @@ public class TeamService : ITeamService
             return null;
         }
 
-        if (!userId.HasValue && (!team.IsPublicPage || team.IsHidden))
+        if (!userId.HasValue &&
+            (!team.IsPublicPage || team.IsHidden || team.IsSystemTeam || team.ParentTeamId.HasValue))
         {
             return null;
         }
@@ -513,6 +514,11 @@ public class TeamService : ITeamService
             team.IsHidden = isHidden.Value;
         if (isSensitive.HasValue)
             team.IsSensitive = isSensitive.Value;
+        if (team.IsSystemTeam || parentTeamId.HasValue)
+        {
+            team.IsPublicPage = false;
+            team.ShowCoordinatorsOnPublicPage = false;
+        }
         team.UpdatedAt = _clock.GetCurrentInstant();
 
         if (becomingChild)
@@ -569,15 +575,20 @@ public class TeamService : ITeamService
         if (callsToAction.Count(c => c.Style == CallToActionStyle.Primary) > 1)
             throw new InvalidOperationException("Only one primary call to action is allowed.");
 
+        var canBePublic = !team.IsSystemTeam && !team.ParentTeamId.HasValue;
+
         // Only departments (no parent, non-system) can be made public
-        if (isPublicPage && (team.IsSystemTeam || team.ParentTeamId.HasValue))
+        if (isPublicPage && !canBePublic)
             throw new InvalidOperationException("Only departments (non-system, top-level teams) can be made public.");
+
+        var normalizedShowCoordinatorsOnPublicPage =
+            canBePublic && isPublicPage && showCoordinatorsOnPublicPage;
 
         var now = _clock.GetCurrentInstant();
         team.PageContent = pageContent;
         team.CallsToAction = callsToAction;
         team.IsPublicPage = isPublicPage;
-        team.ShowCoordinatorsOnPublicPage = showCoordinatorsOnPublicPage;
+        team.ShowCoordinatorsOnPublicPage = normalizedShowCoordinatorsOnPublicPage;
         team.PageContentUpdatedAt = now;
         team.PageContentUpdatedByUserId = updatedByUserId;
         team.UpdatedAt = now;

--- a/src/Humans.Infrastructure/Services/TicketTailorService.cs
+++ b/src/Humans.Infrastructure/Services/TicketTailorService.cs
@@ -172,41 +172,45 @@ public class TicketTailorService : ITicketVendorService
         string eventId, CancellationToken ct = default)
     {
         var cacheKey = CacheKeys.TicketEventSummary(eventId);
-        return await _cache.GetOrCreateAsync(cacheKey, async entry =>
+        if (_cache.TryGetValue<VendorEventSummaryDto>(cacheKey, out var cachedSummary) &&
+            cachedSummary is not null)
         {
-            entry.AbsoluteExpirationRelativeToNow = EventSummaryCacheTtl;
+            return cachedSummary;
+        }
 
-            var response = await _httpClient.GetAsync($"{BaseUrl}/events/{eventId}", ct);
+        var response = await _httpClient.GetAsync($"{BaseUrl}/events/{eventId}", ct);
 
-            if (!response.IsSuccessStatusCode)
-            {
-                _logger.LogWarning(
-                    "TicketTailor event summary API returned {StatusCode} for event {EventId}",
-                    (int)response.StatusCode, eventId);
+        if (!response.IsSuccessStatusCode)
+        {
+            _logger.LogWarning(
+                "TicketTailor event summary API returned {StatusCode} for event {EventId}",
+                (int)response.StatusCode, eventId);
 
-                if ((int)response.StatusCode >= 500)
-                    return new VendorEventSummaryDto(eventId, "Unknown", 0, 0, 0);
+            if ((int)response.StatusCode >= 500)
+                return new VendorEventSummaryDto(eventId, "Unknown", 0, 0, 0);
 
-                response.EnsureSuccessStatusCode();
-            }
+            response.EnsureSuccessStatusCode();
+        }
 
-            var evt = await response.Content.ReadFromJsonAsync<TtEvent>(JsonOptions, ct);
+        var evt = await response.Content.ReadFromJsonAsync<TtEvent>(JsonOptions, ct);
 
-            // Capacity comes from ticket_groups (waves share the same pool).
-            // Summing ticket_types.quantity_total is wrong — waves are subdivisions, not additive.
-            var totalCapacity = evt?.TicketGroups?.Sum(g => g.MaxQuantity ?? 0) ?? 0;
-            // Fall back to ungrouped ticket types if no groups defined
-            if (totalCapacity == 0)
-                totalCapacity = evt?.TicketTypes?.Sum(tt => tt.QuantityTotal ?? 0) ?? 0;
-            var ticketsSold = evt?.TotalIssuedTickets ?? 0;
+        // Capacity comes from ticket_groups (waves share the same pool).
+        // Summing ticket_types.quantity_total is wrong — waves are subdivisions, not additive.
+        var totalCapacity = evt?.TicketGroups?.Sum(g => g.MaxQuantity ?? 0) ?? 0;
+        // Fall back to ungrouped ticket types if no groups defined
+        if (totalCapacity == 0)
+            totalCapacity = evt?.TicketTypes?.Sum(tt => tt.QuantityTotal ?? 0) ?? 0;
+        var ticketsSold = evt?.TotalIssuedTickets ?? 0;
 
-            return new VendorEventSummaryDto(
-                EventId: eventId,
-                EventName: evt?.Name ?? "Unknown",
-                TotalCapacity: totalCapacity,
-                TicketsSold: ticketsSold,
-                TicketsRemaining: totalCapacity - ticketsSold);
-        }) ?? new VendorEventSummaryDto(eventId, "Unknown", 0, 0, 0);
+        var summary = new VendorEventSummaryDto(
+            EventId: eventId,
+            EventName: evt?.Name ?? "Unknown",
+            TotalCapacity: totalCapacity,
+            TicketsSold: ticketsSold,
+            TicketsRemaining: totalCapacity - ticketsSold);
+
+        _cache.Set(cacheKey, summary, EventSummaryCacheTtl);
+        return summary;
     }
 
     public async Task<IReadOnlyList<string>> GenerateDiscountCodesAsync(

--- a/src/Humans.Web/Controllers/AccountController.cs
+++ b/src/Humans.Web/Controllers/AccountController.cs
@@ -56,14 +56,14 @@ public class AccountController : Controller
         if (remoteError is not null)
         {
             _logger.LogWarning("External login error: {Error}", remoteError);
-            return RedirectToAction(nameof(Login));
+            return RedirectToAction(nameof(Login), new { returnUrl, error = "oauth" });
         }
 
         var info = await _signInManager.GetExternalLoginInfoAsync();
         if (info is null)
         {
             _logger.LogWarning("Could not get external login info");
-            return RedirectToAction(nameof(Login));
+            return RedirectToAction(nameof(Login), new { returnUrl, error = "oauth" });
         }
 
         // Sign in the user with this external login provider if the user already has a login
@@ -151,7 +151,7 @@ public class AccountController : Controller
         if (string.IsNullOrEmpty(email))
         {
             _logger.LogWarning("Email not provided by external provider");
-            return RedirectToAction(nameof(Login));
+            return RedirectToAction(nameof(Login), new { returnUrl, error = "oauth" });
         }
 
         // Account linking: check if a user already exists with this email
@@ -222,6 +222,7 @@ public class AccountController : Controller
             ModelState.AddModelError(string.Empty, error.Description);
         }
 
+        ViewData["ReturnUrl"] = returnUrl;
         return View(nameof(Login));
     }
 

--- a/src/Humans.Web/Controllers/AccountController.cs
+++ b/src/Humans.Web/Controllers/AccountController.cs
@@ -140,7 +140,7 @@ public class AccountController : Controller
                 }
             }
 
-            return RedirectToPage("/Account/Lockout");
+            return RedirectToAction(nameof(Login), new { returnUrl, error = "lockedout" });
         }
 
         // No existing login — try to link to an existing account by email

--- a/src/Humans.Web/Controllers/ShiftsController.cs
+++ b/src/Humans.Web/Controllers/ShiftsController.cs
@@ -329,7 +329,7 @@ public class ShiftsController : HumansControllerBase
 
             switch (signup.Status)
             {
-                case SignupStatus.Confirmed when item.AbsoluteStart > now:
+                case SignupStatus.Confirmed when item.AbsoluteEnd > now:
                     model.Upcoming.Add(item);
                     break;
                 case SignupStatus.Pending:

--- a/src/Humans.Web/Views/Account/Login.cshtml
+++ b/src/Humans.Web/Views/Account/Login.cshtml
@@ -17,10 +17,11 @@
         </div>
     }
     <div class="col-md-6">
-        <div class="card mt-5">
-            <div class="card-body text-center">
-                <h2 class="card-title mb-4">@Localizer["Login_Title"]</h2>
-                <p class="text-muted mb-4">@Localizer["Login_Description"]</p>
+            <div class="card mt-5">
+                <div class="card-body text-center">
+                    <h2 class="card-title mb-4">@Localizer["Login_Title"]</h2>
+                    <p class="text-muted mb-4">@Localizer["Login_Description"]</p>
+                    <div asp-validation-summary="ModelOnly" class="alert alert-danger mb-4"></div>
 
                 <form asp-controller="Account" asp-action="ExternalLogin" method="post">
                     <input type="hidden" name="provider" value="Google" />

--- a/src/Humans.Web/Views/Account/Login.cshtml
+++ b/src/Humans.Web/Views/Account/Login.cshtml
@@ -3,6 +3,10 @@
 @{
     ViewData["Title"] = Localizer["Login_Title"].Value;
     var devAuthEnabled = !HostEnv.IsProduction() && Config.GetValue<bool>("DevAuth:Enabled");
+    var loginError = Context.Request.Query["error"].ToString();
+    var loginErrorMessage = string.Equals(loginError, "lockedout", StringComparison.Ordinal)
+        ? "This account is locked. Contact an admin if you need help signing in."
+        : Localizer["Login_SignInFailed"].Value;
 }
 
 <div class="row justify-content-center">
@@ -11,7 +15,7 @@
         <div class="col-md-6 mb-0">
             <div class="alert alert-warning alert-dismissible fade show mt-5 mb-0" role="alert">
                 <i class="fa-solid fa-triangle-exclamation me-1"></i>
-                @Localizer["Login_SignInFailed"]
+                @loginErrorMessage
                 <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
             </div>
         </div>

--- a/src/Humans.Web/Views/Google/AllGroups.cshtml
+++ b/src/Humans.Web/Views/Google/AllGroups.cshtml
@@ -117,9 +117,9 @@
                                 @group.DisplayName
                             </td>
                             <td>
-                                @if (group.LinkedTeamId is not null)
+                                @if (!string.IsNullOrWhiteSpace(group.LinkedTeamSlug))
                                 {
-                                    <a asp-controller="Team" asp-action="Detail" asp-route-id="@group.LinkedTeamId"
+                                    <a asp-controller="Team" asp-action="Details" asp-route-slug="@group.LinkedTeamSlug"
                                        class="badge bg-primary text-decoration-none">
                                         @group.LinkedTeamName
                                     </a>

--- a/src/Humans.Web/Views/Google/AllGroups.cshtml
+++ b/src/Humans.Web/Views/Google/AllGroups.cshtml
@@ -29,6 +29,30 @@
     var allSettingKeys = standardKeys.Concat(extraKeys).Concat(deprecatedKeys).ToList();
 }
 
+<style>
+    .all-groups-table .sticky-col-email {
+        position: sticky;
+        left: 0;
+        min-width: 12rem;
+        background: #fff;
+        z-index: 2;
+    }
+
+    .all-groups-table .sticky-col-name {
+        position: sticky;
+        left: 12rem;
+        min-width: 14rem;
+        background: #fff;
+        z-index: 2;
+    }
+
+    .all-groups-table thead .sticky-col-email,
+    .all-groups-table thead .sticky-col-name {
+        background: #f8f9fa;
+        z-index: 3;
+    }
+</style>
+
 <div class="container-fluid px-4">
     <div class="d-flex justify-content-between align-items-center mt-4 mb-3">
         <h1>All Domain Groups</h1>
@@ -79,11 +103,11 @@
         </div>
 
         <div style="overflow-x: auto;">
-            <table class="table table-sm table-hover" style="white-space: nowrap;">
+            <table class="table table-sm table-hover all-groups-table" style="white-space: nowrap;">
                 <thead class="table-light">
                     <tr>
-                        <th style="position: sticky; left: 0; background: inherit; z-index: 1;">Group Email</th>
-                        <th style="position: sticky; left: 0; background: inherit; z-index: 1;">Display Name</th>
+                        <th class="sticky-col-email">Group Email</th>
+                        <th class="sticky-col-name">Display Name</th>
                         <th>Team</th>
                         <th class="text-end">Members</th>
                         @foreach (var key in allSettingKeys)
@@ -110,10 +134,10 @@
                     @foreach (var group in Model.Groups)
                     {
                         <tr class="@(group.ErrorMessage is not null ? "table-danger" : "")">
-                            <td style="position: sticky; left: 0; background: white; z-index: 1;">
+                            <td class="sticky-col-email">
                                 <code class="small">@(group.GroupEmail.Split('@')[0])@@</code>
                             </td>
-                            <td style="position: sticky; left: 0; background: white; z-index: 1;">
+                            <td class="sticky-col-name">
                                 @group.DisplayName
                             </td>
                             <td>

--- a/src/Humans.Web/Views/Shared/_LanguageChooser.cshtml
+++ b/src/Humans.Web/Views/Shared/_LanguageChooser.cshtml
@@ -16,7 +16,7 @@
                 <form asp-controller="Language" asp-action="SetLanguage" method="post">
                     @Html.AntiForgeryToken()
                     <input type="hidden" name="culture" value="@culture" />
-                    <input type="hidden" name="returnUrl" value="@Context.Request.Path" />
+                    <input type="hidden" name="returnUrl" value="@(Context.Request.Path + Context.Request.QueryString)" />
                     <button type="submit" class="dropdown-item @(string.Equals(culture, currentCulture, StringComparison.Ordinal) ? "active" : "")">
                         @culture.ToDisplayLanguageName()
                     </button>

--- a/src/Humans.Web/Views/TeamAdmin/EditPage.cshtml
+++ b/src/Humans.Web/Views/TeamAdmin/EditPage.cshtml
@@ -50,7 +50,7 @@
     else
     {
         <input type="hidden" asp-for="IsPublicPage" value="false" />
-        <input type="hidden" asp-for="ShowCoordinatorsOnPublicPage" />
+        <input type="hidden" asp-for="ShowCoordinatorsOnPublicPage" value="false" />
         <div class="alert alert-info mb-4">
             Only top-level departments (non-system, no parent team) can be made public.
         </div>

--- a/tests/Humans.Application.Tests/Services/ShiftSignupServiceEarlyEntryTests.cs
+++ b/tests/Humans.Application.Tests/Services/ShiftSignupServiceEarlyEntryTests.cs
@@ -1,0 +1,183 @@
+using AwesomeAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging.Abstractions;
+using NodaTime;
+using NodaTime.Testing;
+using NSubstitute;
+using Humans.Application.Interfaces;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using Humans.Infrastructure.Data;
+using Humans.Infrastructure.Services;
+using Xunit;
+
+namespace Humans.Application.Tests.Services;
+
+public class ShiftSignupServiceEarlyEntryTests : IDisposable
+{
+    private readonly HumansDbContext _dbContext;
+    private readonly FakeClock _clock;
+    private readonly IAuditLogService _auditLog;
+    private readonly ShiftManagementService _shiftMgmt;
+    private readonly ShiftSignupService _service;
+
+    private static readonly Instant TestNow = Instant.FromUtc(2026, 6, 15, 12, 0);
+
+    public ShiftSignupServiceEarlyEntryTests()
+    {
+        var options = new DbContextOptionsBuilder<HumansDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        _dbContext = new HumansDbContext(options);
+        _clock = new FakeClock(TestNow);
+        _auditLog = Substitute.For<IAuditLogService>();
+
+        _shiftMgmt = new ShiftManagementService(
+            _dbContext,
+            _auditLog,
+            new MemoryCache(new MemoryCacheOptions()),
+            _clock,
+            NullLogger<ShiftManagementService>.Instance);
+
+        _service = new ShiftSignupService(
+            _dbContext,
+            _shiftMgmt,
+            _auditLog,
+            _clock,
+            NullLogger<ShiftSignupService>.Instance);
+    }
+
+    public void Dispose()
+    {
+        _dbContext.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public async Task SignUpAsync_IgnoresCapacityUsageFromDifferentEarlyEntryDay()
+    {
+        var (eventSettings, rota, _) = SeedBuildScenario();
+        eventSettings.EarlyEntryCapacity = new Dictionary<int, int>
+        {
+            [-3] = 2,
+            [-2] = 1
+        };
+
+        var existingShift = SeedAllDayShift(rota, -3);
+        var targetShift = SeedAllDayShift(rota, -2);
+        SeedSignup(Guid.NewGuid(), existingShift.Id, SignupStatus.Confirmed);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _service.SignUpAsync(Guid.NewGuid(), targetShift.Id);
+
+        result.Success.Should().BeTrue();
+        result.Warning.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task SignUpRangeAsync_WarnsWhenLaterEarlyEntryDayIsFull()
+    {
+        var (eventSettings, rota, _) = SeedBuildScenario();
+        eventSettings.EarlyEntryCapacity = new Dictionary<int, int>
+        {
+            [-3] = 2,
+            [-2] = 2,
+            [-1] = 1
+        };
+
+        SeedAllDayShift(rota, -3);
+        SeedAllDayShift(rota, -2);
+        var finalDayShift = SeedAllDayShift(rota, -1);
+        SeedSignup(Guid.NewGuid(), finalDayShift.Id, SignupStatus.Confirmed);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _service.SignUpRangeAsync(Guid.NewGuid(), rota.Id, -3, -1);
+
+        result.Success.Should().BeTrue();
+        result.Warning.Should().Contain("-1");
+    }
+
+    private (EventSettings eventSettings, Rota rota, Team team) SeedBuildScenario()
+    {
+        var eventSettings = new EventSettings
+        {
+            Id = Guid.NewGuid(),
+            EventName = "Test Event 2026",
+            TimeZoneId = "Europe/Madrid",
+            GateOpeningDate = new LocalDate(2026, 7, 1),
+            BuildStartOffset = -14,
+            EventEndOffset = 6,
+            StrikeEndOffset = 9,
+            IsShiftBrowsingOpen = true,
+            IsActive = true,
+            CreatedAt = TestNow,
+            UpdatedAt = TestNow
+        };
+        _dbContext.EventSettings.Add(eventSettings);
+
+        var team = new Team
+        {
+            Id = Guid.NewGuid(),
+            Name = "Build Department",
+            Slug = "build-department",
+            SystemTeamType = SystemTeamType.None,
+            CreatedAt = TestNow,
+            UpdatedAt = TestNow
+        };
+        _dbContext.Teams.Add(team);
+
+        var rota = new Rota
+        {
+            Id = Guid.NewGuid(),
+            EventSettingsId = eventSettings.Id,
+            TeamId = team.Id,
+            Name = "Build Rota",
+            Priority = ShiftPriority.Normal,
+            Policy = SignupPolicy.Public,
+            Period = RotaPeriod.Build,
+            CreatedAt = TestNow,
+            UpdatedAt = TestNow,
+            EventSettings = eventSettings,
+            Team = team
+        };
+        _dbContext.Rotas.Add(rota);
+
+        return (eventSettings, rota, team);
+    }
+
+    private Shift SeedAllDayShift(Rota rota, int dayOffset)
+    {
+        var shift = new Shift
+        {
+            Id = Guid.NewGuid(),
+            RotaId = rota.Id,
+            DayOffset = dayOffset,
+            IsAllDay = true,
+            StartTime = new LocalTime(0, 0),
+            Duration = Duration.FromHours(24),
+            MinVolunteers = 1,
+            MaxVolunteers = 5,
+            CreatedAt = TestNow,
+            UpdatedAt = TestNow,
+            Rota = rota
+        };
+
+        _dbContext.Shifts.Add(shift);
+        return shift;
+    }
+
+    private void SeedSignup(Guid userId, Guid shiftId, SignupStatus status)
+    {
+        _dbContext.ShiftSignups.Add(new ShiftSignup
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            ShiftId = shiftId,
+            Status = status,
+            CreatedAt = TestNow,
+            UpdatedAt = TestNow
+        });
+    }
+}

--- a/tests/Humans.Application.Tests/Services/TicketTailorServiceCachingTests.cs
+++ b/tests/Humans.Application.Tests/Services/TicketTailorServiceCachingTests.cs
@@ -1,0 +1,87 @@
+using System.Net;
+using System.Text.Json;
+using AwesomeAssertions;
+using Humans.Infrastructure.Services;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Humans.Application.Tests.Services;
+
+public class TicketTailorServiceCachingTests
+{
+    [Fact]
+    public async Task GetEventSummaryAsync_DoesNotCacheTransientServerFailures()
+    {
+        var handler = new CountingTicketTailorHandler();
+        handler.EnqueueResponse(HttpStatusCode.InternalServerError, new { error = "temporary outage" });
+        handler.EnqueueResponse(HttpStatusCode.OK, new
+        {
+            name = "Elsewhere 2026",
+            total_holds = 0,
+            total_issued_tickets = 96,
+            total_orders = 88,
+            ticket_types = new[]
+            {
+                new { quantity_total = 2000, quantity_issued = 86 },
+            },
+            ticket_groups = new[]
+            {
+                new { name = "Main tickets", max_quantity = 2000 },
+            }
+        });
+
+        var service = CreateService(handler);
+
+        var first = await service.GetEventSummaryAsync("ev_test");
+        var second = await service.GetEventSummaryAsync("ev_test");
+
+        first.EventName.Should().Be("Unknown");
+        first.TotalCapacity.Should().Be(0);
+
+        second.EventName.Should().Be("Elsewhere 2026");
+        second.TotalCapacity.Should().Be(2000);
+        second.TicketsSold.Should().Be(96);
+        handler.RequestCount.Should().Be(2);
+    }
+
+    private static TicketTailorService CreateService(HttpMessageHandler handler)
+    {
+        var client = new HttpClient(handler);
+        var cache = new MemoryCache(new MemoryCacheOptions());
+        var settings = Options.Create(new TicketVendorSettings
+        {
+            EventId = "ev_test",
+            SyncIntervalMinutes = 15,
+            ApiKey = "test_key"
+        });
+
+        return new TicketTailorService(client, settings, cache,
+            NullLogger<TicketTailorService>.Instance);
+    }
+}
+
+internal sealed class CountingTicketTailorHandler : HttpMessageHandler
+{
+    private readonly Queue<HttpResponseMessage> _responses = new();
+
+    public int RequestCount { get; private set; }
+
+    public void EnqueueResponse(HttpStatusCode status, object body)
+    {
+        _responses.Enqueue(new HttpResponseMessage(status)
+        {
+            Content = new StringContent(
+                JsonSerializer.Serialize(body),
+                System.Text.Encoding.UTF8,
+                "application/json")
+        });
+    }
+
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        RequestCount++;
+        return Task.FromResult(_responses.Dequeue());
+    }
+}


### PR DESCRIPTION
## Summary
- **Caching fixes**: TicketTailor 5xx responses and legal document fetch failures no longer cached as valid results
- **Shift fixes**: early-entry capacity checks now filter by day offset; confirmed current shifts no longer stuck as upcoming
- **Auth fixes**: locked-out external logins handled gracefully; retry state preserved after login failures
- **UI fixes**: overlapping sticky columns in domain groups view; broken team links on Google groups page; invalid public page state on child teams; language chooser preserves query state

Dropped "Preserve profile edit state on validation errors" — conflicted with Controller Consolidation PR (#312), needs clean re-application.

## Test plan
- [ ] Verify ticket dashboard loads after TicketTailor 5xx (should retry, not show cached "Unknown")
- [ ] Verify legal documents page recovers after transient fetch failure
- [ ] Verify early-entry shift signup respects per-day capacity limits
- [ ] Verify Google groups page team links work
- [ ] Verify language switcher preserves current page query params
- [ ] Verify locked-out Google login shows appropriate error

🤖 Generated with [Claude Code](https://claude.com/claude-code)