### PR TITLE
Fix coordinator role uniqueness enforcement

### DIFF
--- a/docs/sections/Teams.md
+++ b/docs/sections/Teams.md
@@ -21,7 +21,7 @@
 
 ## Invariants
 
-- A department can have zero or one role flagged as management (coordinator). If present, members assigned to it gain coordinator-level access over the whole department: member management, join request handling, role management, and team page editing.
+- A department can have **at most one** role flagged as management (coordinator). This is enforced in both the toggle and edit paths. If present, members assigned to it gain coordinator-level access over the whole department: member management, join request handling, role management, and team page editing.
 - Sub-teams do not have coordinator roles.
 - Members of sub-teams are also considered members of the department. They appear in the department's member roster and inherit the department's legal requirements and Google resource access (Drive folders, Groups).
 - A human can be a member of multiple teams simultaneously.

--- a/src/Humans.Infrastructure/Services/TeamService.cs
+++ b/src/Humans.Infrastructure/Services/TeamService.cs
@@ -1419,6 +1419,17 @@ public class TeamService : ITeamService
                     .ToListAsync(cancellationToken)
                 : [];
 
+        // If setting IsManagement, check no other role in the same team already has it
+        if (isManagement && !definition.IsManagement)
+        {
+            var existingManagement = await _dbContext.Set<TeamRoleDefinition>()
+                .AnyAsync(d => d.TeamId == definition.TeamId && d.Id != roleDefinitionId && d.IsManagement, cancellationToken);
+            if (existingManagement)
+            {
+                throw new InvalidOperationException("Another role in this team is already marked as the management role");
+            }
+        }
+
         // If clearing IsManagement, demote any coordinators who have no other management assignments
         if (definition.IsManagement && !isManagement)
         {
@@ -1515,6 +1526,7 @@ public class TeamService : ITeamService
         var definition = await _dbContext.Set<TeamRoleDefinition>()
             .Include(d => d.Team)
             .Include(d => d.Assignments)
+                .ThenInclude(a => a.TeamMember)
             .FirstOrDefaultAsync(d => d.Id == roleDefinitionId, cancellationToken)
             ?? throw new InvalidOperationException($"Role definition {roleDefinitionId} not found");
 
@@ -1525,19 +1537,51 @@ public class TeamService : ITeamService
             throw new InvalidOperationException("User does not have permission to manage role definitions for this team");
         }
 
-        if (definition.Assignments.Count > 0)
-        {
-            throw new InvalidOperationException("Cannot change IsManagement while members are assigned to the role");
-        }
+        // Collect affected user IDs for shift auth invalidation (before any changes)
+        var usersNeedingShiftAuthorizationInvalidation =
+            IsShiftAuthorizationDefinition(definition) &&
+            definition.IsManagement != isManagement &&
+            definition.Assignments.Count > 0
+                ? definition.Assignments.Select(a => a.TeamMember.UserId).Distinct().ToList()
+                : [];
+        var demotedMembers = false;
 
         if (isManagement)
         {
+            // Cannot promote a role with assigned members (would bulk-promote without individual review)
+            if (definition.Assignments.Count > 0)
+            {
+                throw new InvalidOperationException("Cannot set IsManagement while members are assigned to the role");
+            }
+
             // Check no other role in the same team already has IsManagement = true
             var existingManagement = await _dbContext.Set<TeamRoleDefinition>()
                 .AnyAsync(d => d.TeamId == definition.TeamId && d.Id != roleDefinitionId && d.IsManagement, cancellationToken);
             if (existingManagement)
             {
                 throw new InvalidOperationException("Another role in this team is already marked as the management role");
+            }
+        }
+        else if (definition.IsManagement && definition.Assignments.Count > 0)
+        {
+            // Clearing IsManagement with assigned members — demote coordinators who have no other management role
+            var assignedMemberIds = definition.Assignments.Select(a => a.TeamMemberId).ToList();
+            var members = await _dbContext.TeamMembers
+                .Where(m => assignedMemberIds.Contains(m.Id) && m.Role == TeamMemberRole.Coordinator)
+                .ToListAsync(cancellationToken);
+
+            foreach (var member in members)
+            {
+                var hasOtherManagement = await _dbContext.Set<TeamRoleAssignment>()
+                    .AnyAsync(a => a.TeamMemberId == member.Id
+                        && a.TeamRoleDefinitionId != roleDefinitionId
+                        && a.TeamRoleDefinition.IsManagement, cancellationToken);
+
+                if (!hasOtherManagement)
+                {
+                    member.Role = TeamMemberRole.Member;
+                    demotedMembers = true;
+                }
             }
         }
 
@@ -1552,6 +1596,12 @@ public class TeamService : ITeamService
             relatedEntityId: definition.TeamId, relatedEntityType: nameof(Team));
 
         await _dbContext.SaveChangesAsync(cancellationToken);
+
+        if (demotedMembers)
+        {
+            _cache.InvalidateActiveTeams();
+        }
+        InvalidateShiftAuthorization(usersNeedingShiftAuthorizationInvalidation);
 
         _logger.LogInformation("Set IsManagement={IsManagement} on role definition {RoleDefinitionId}", isManagement, roleDefinitionId);
     }

--- a/tests/Humans.Application.Tests/Services/TeamRoleServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/TeamRoleServiceTests.cs
@@ -153,6 +153,83 @@ public class TeamRoleServiceTests : IDisposable
             .WithMessage("*Cannot reduce slot count*");
     }
 
+    [Fact]
+    public async Task UpdateRoleDefinitionAsync_SetIsManagement_WhenAnotherRoleAlreadyManagement_Throws()
+    {
+        var admin = SeedUser("Admin");
+        SeedAdminRole(admin);
+        var team = SeedTeam("Test Team");
+        var existingMgmt = SeedRoleDefinition(team, "Coordinator", slotCount: 1, sortOrder: 0, isManagement: true);
+        var otherRole = SeedRoleDefinition(team, "Designer", slotCount: 2, sortOrder: 1);
+        await _dbContext.SaveChangesAsync();
+
+        var act = () => _service.UpdateRoleDefinitionAsync(
+            otherRole.Id, "Designer", null, 2,
+            [SlotPriority.Critical, SlotPriority.Important], 1, true, RolePeriod.YearRound, admin.Id);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*already marked as the management role*");
+    }
+
+    [Fact]
+    public async Task UpdateRoleDefinitionAsync_SetIsManagement_WhenNoOtherManagement_Succeeds()
+    {
+        var admin = SeedUser("Admin");
+        SeedAdminRole(admin);
+        var team = SeedTeam("Test Team");
+        var role = SeedRoleDefinition(team, "Lead", slotCount: 1, sortOrder: 0);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _service.UpdateRoleDefinitionAsync(
+            role.Id, "Lead", null, 1,
+            [SlotPriority.Critical], 0, true, RolePeriod.YearRound, admin.Id);
+
+        result.IsManagement.Should().BeTrue();
+    }
+
+    // ==========================================================================
+    // SetRoleIsManagementAsync
+    // ==========================================================================
+
+    [Fact]
+    public async Task SetRoleIsManagementAsync_ClearWithAssignedMembers_DemotesCoordinators()
+    {
+        var admin = SeedUser("Admin");
+        SeedAdminRole(admin);
+        var team = SeedTeam("Test Team");
+        var user = SeedUser("User");
+        var mgmtRole = SeedRoleDefinition(team, "Coordinator", slotCount: 2, sortOrder: 0, isManagement: true);
+        var member = SeedMember(team, user, TeamMemberRole.Coordinator);
+        SeedRoleAssignment(mgmtRole, member, slotIndex: 0);
+        await _dbContext.SaveChangesAsync();
+
+        await _service.SetRoleIsManagementAsync(mgmtRole.Id, false, admin.Id);
+
+        var roleInDb = await _dbContext.Set<TeamRoleDefinition>().FindAsync(mgmtRole.Id);
+        roleInDb!.IsManagement.Should().BeFalse();
+
+        var memberInDb = await _dbContext.TeamMembers.FindAsync(member.Id);
+        memberInDb!.Role.Should().Be(TeamMemberRole.Member);
+    }
+
+    [Fact]
+    public async Task SetRoleIsManagementAsync_SetWithAssignedMembers_Throws()
+    {
+        var admin = SeedUser("Admin");
+        SeedAdminRole(admin);
+        var team = SeedTeam("Test Team");
+        var user = SeedUser("User");
+        var role = SeedRoleDefinition(team, "Designer", slotCount: 2, sortOrder: 1);
+        var member = SeedMember(team, user);
+        SeedRoleAssignment(role, member, slotIndex: 0);
+        await _dbContext.SaveChangesAsync();
+
+        var act = () => _service.SetRoleIsManagementAsync(role.Id, true, admin.Id);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*Cannot set IsManagement*");
+    }
+
     // ==========================================================================
     // AssignToRoleAsync
     // ==========================================================================


### PR DESCRIPTION
## Summary
- Add `IsManagement` uniqueness check to `UpdateRoleDefinitionAsync` — previously only the toggle (`SetRoleIsManagementAsync`) enforced this, so editing a role's details could bypass the one-coordinator-per-department invariant
- Allow unsetting `IsManagement` via toggle even when members are assigned — previously this was blocked, making it impossible to manually fix departments that already have multiple coordinator roles (like participant-wellness with 6)
- Proper demotion logic when unsetting: coordinators with no other management assignment are demoted to Member, shift auth cache invalidated, active teams cache invalidated
- 4 new unit tests covering both fixes
- Updated `docs/sections/Teams.md` invariant wording

Closes #340

## Test plan
- [ ] Verify toggle can unset coordinator flag on a role with assigned members (participant-wellness)
- [ ] Verify editing a role cannot set IsManagement when another role already has it
- [ ] Verify demoted members lose coordinator access after unsetting
- [ ] All 704 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)