### PR TITLE
Add resource access card and sensitive team warning (#338, #339)

### DIFF
--- a/src/Humans.Application/Interfaces/ITeamService.cs
+++ b/src/Humans.Application/Interfaces/ITeamService.cs
@@ -183,6 +183,7 @@ public interface ITeamService
         string? customSlug = null,
         bool? hasBudget = null,
         bool? isHidden = null,
+        bool? isSensitive = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/src/Humans.Domain/Entities/Team.cs
+++ b/src/Humans.Domain/Entities/Team.cs
@@ -121,6 +121,13 @@ public class Team
     public bool IsHidden { get; set; }
 
     /// <summary>
+    /// Whether this team handles sensitive information. Admin-only flag, not publicly visible.
+    /// When true, adding or approving members triggers a deterrent confirmation modal
+    /// showing the audit record that will be created.
+    /// </summary>
+    public bool IsSensitive { get; set; }
+
+    /// <summary>
     /// Optional parent team ID for one-level hierarchy (departments).
     /// A team with a parent cannot itself be a parent.
     /// </summary>

--- a/src/Humans.Infrastructure/Data/Configurations/TeamConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/TeamConfiguration.cs
@@ -72,6 +72,9 @@ public class TeamConfiguration : IEntityTypeConfiguration<Team>
         builder.Property(t => t.IsHidden)
             .IsRequired();
 
+        builder.Property(t => t.IsSensitive)
+            .IsRequired();
+
         builder.Property(t => t.PageContent)
             .HasMaxLength(50000);
 
@@ -151,7 +154,8 @@ public class TeamConfiguration : IEntityTypeConfiguration<Team>
                 CustomSlug = (string?)null,
                 ShowCoordinatorsOnPublicPage = true,
                 HasBudget = false,
-                IsHidden = false
+                IsHidden = false,
+                IsSensitive = false
             },
             new
             {
@@ -174,7 +178,8 @@ public class TeamConfiguration : IEntityTypeConfiguration<Team>
                 CustomSlug = (string?)null,
                 ShowCoordinatorsOnPublicPage = true,
                 HasBudget = false,
-                IsHidden = false
+                IsHidden = false,
+                IsSensitive = false
             },
             new
             {
@@ -197,7 +202,8 @@ public class TeamConfiguration : IEntityTypeConfiguration<Team>
                 CustomSlug = (string?)null,
                 ShowCoordinatorsOnPublicPage = true,
                 HasBudget = false,
-                IsHidden = false
+                IsHidden = false,
+                IsSensitive = false
             },
             new
             {
@@ -220,7 +226,8 @@ public class TeamConfiguration : IEntityTypeConfiguration<Team>
                 CustomSlug = (string?)null,
                 ShowCoordinatorsOnPublicPage = true,
                 HasBudget = false,
-                IsHidden = false
+                IsHidden = false,
+                IsSensitive = false
             },
             new
             {
@@ -243,7 +250,8 @@ public class TeamConfiguration : IEntityTypeConfiguration<Team>
                 CustomSlug = (string?)null,
                 ShowCoordinatorsOnPublicPage = true,
                 HasBudget = false,
-                IsHidden = false
+                IsHidden = false,
+                IsSensitive = false
             },
             new
             {
@@ -266,7 +274,8 @@ public class TeamConfiguration : IEntityTypeConfiguration<Team>
                 CustomSlug = (string?)null,
                 ShowCoordinatorsOnPublicPage = true,
                 HasBudget = false,
-                IsHidden = false
+                IsHidden = false,
+                IsSensitive = false
             });
     }
 }

--- a/src/Humans.Infrastructure/Migrations/20260402132720_AddTeamIsSensitive.Designer.cs
+++ b/src/Humans.Infrastructure/Migrations/20260402132720_AddTeamIsSensitive.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Humans.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Humans.Infrastructure.Migrations
 {
     [DbContext(typeof(HumansDbContext))]
-    partial class HumansDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260402132720_AddTeamIsSensitive")]
+    partial class AddTeamIsSensitive
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Humans.Infrastructure/Migrations/20260402132720_AddTeamIsSensitive.cs
+++ b/src/Humans.Infrastructure/Migrations/20260402132720_AddTeamIsSensitive.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Humans.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTeamIsSensitive : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsSensitive",
+                table: "teams",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.UpdateData(
+                table: "teams",
+                keyColumn: "Id",
+                keyValue: new Guid("00000000-0000-0000-0001-000000000001"),
+                column: "IsSensitive",
+                value: false);
+
+            migrationBuilder.UpdateData(
+                table: "teams",
+                keyColumn: "Id",
+                keyValue: new Guid("00000000-0000-0000-0001-000000000002"),
+                column: "IsSensitive",
+                value: false);
+
+            migrationBuilder.UpdateData(
+                table: "teams",
+                keyColumn: "Id",
+                keyValue: new Guid("00000000-0000-0000-0001-000000000003"),
+                column: "IsSensitive",
+                value: false);
+
+            migrationBuilder.UpdateData(
+                table: "teams",
+                keyColumn: "Id",
+                keyValue: new Guid("00000000-0000-0000-0001-000000000004"),
+                column: "IsSensitive",
+                value: false);
+
+            migrationBuilder.UpdateData(
+                table: "teams",
+                keyColumn: "Id",
+                keyValue: new Guid("00000000-0000-0000-0001-000000000005"),
+                column: "IsSensitive",
+                value: false);
+
+            migrationBuilder.UpdateData(
+                table: "teams",
+                keyColumn: "Id",
+                keyValue: new Guid("00000000-0000-0000-0001-000000000006"),
+                column: "IsSensitive",
+                value: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsSensitive",
+                table: "teams");
+        }
+    }
+}

--- a/src/Humans.Infrastructure/Services/TeamService.cs
+++ b/src/Humans.Infrastructure/Services/TeamService.cs
@@ -418,6 +418,7 @@ public class TeamService : ITeamService
         string? customSlug = null,
         bool? hasBudget = null,
         bool? isHidden = null,
+        bool? isSensitive = null,
         CancellationToken cancellationToken = default)
     {
         var team = await _dbContext.Teams.FindAsync(new object[] { teamId }, cancellationToken)
@@ -510,6 +511,8 @@ public class TeamService : ITeamService
             team.HasBudget = hasBudget.Value;
         if (isHidden.HasValue)
             team.IsHidden = isHidden.Value;
+        if (isSensitive.HasValue)
+            team.IsSensitive = isSensitive.Value;
         team.UpdatedAt = _clock.GetCurrentInstant();
 
         if (becomingChild)

--- a/src/Humans.Web/Controllers/TeamAdminController.cs
+++ b/src/Humans.Web/Controllers/TeamAdminController.cs
@@ -163,6 +163,48 @@ public class TeamAdminController : HumansTeamControllerBase
                 RequestedAt = r.RequestedAt.ToDateTimeUtc()
             }).ToList();
 
+        // Load Google resources for the resource access summary card
+        var allTeamResources = await _teamResourceService.GetTeamResourcesAsync(team.Id);
+        var teamResources = allTeamResources.Where(r => r.IsActive).OrderBy(r => r.ResourceType).ThenBy(r => r.Name, StringComparer.Ordinal).ToList();
+
+        var parentDepartmentResources = new List<GoogleResource>();
+        string? parentDepartmentName = null;
+        string? parentDepartmentSlug = null;
+        if (team.ParentTeam is not null)
+        {
+            parentDepartmentName = team.ParentTeam.Name;
+            parentDepartmentSlug = team.ParentTeam.CustomSlug ?? team.ParentTeam.Slug;
+            var allParentResources = await _teamResourceService.GetTeamResourcesAsync(team.ParentTeam.Id);
+            parentDepartmentResources = allParentResources.Where(r => r.IsActive).OrderBy(r => r.ResourceType).ThenBy(r => r.Name, StringComparer.Ordinal).ToList();
+        }
+
+        static ResourceAccessViewModel MapResource(GoogleResource r) => new()
+        {
+            Name = r.Name,
+            ResourceType = r.ResourceType switch
+            {
+                GoogleResourceType.DriveFolder => "Drive Folder",
+                GoogleResourceType.SharedDrive => "Shared Drive",
+                GoogleResourceType.DriveFile => "Drive File",
+                GoogleResourceType.Group => "Google Group",
+                _ => r.ResourceType.ToString()
+            },
+            PermissionLevel = r.ResourceType == GoogleResourceType.Group
+                ? null
+                : r.DrivePermissionLevel != DrivePermissionLevel.None
+                    ? r.DrivePermissionLevel.ToString()
+                    : null,
+            Url = r.Url,
+            IconClass = r.ResourceType switch
+            {
+                GoogleResourceType.DriveFolder => "fa-solid fa-folder",
+                GoogleResourceType.SharedDrive => "fa-solid fa-hard-drive",
+                GoogleResourceType.DriveFile => "fa-solid fa-file",
+                GoogleResourceType.Group => "fa-solid fa-users",
+                _ => "fa-solid fa-link"
+            }
+        };
+
         var viewModel = new TeamMembersViewModel
         {
             TeamId = team.Id,
@@ -175,7 +217,13 @@ public class TeamAdminController : HumansTeamControllerBase
             PendingRequests = pendingRequestViewModels,
             TotalCount = totalCount,
             PageNumber = page,
-            PageSize = pageSize
+            PageSize = pageSize,
+            TeamResources = teamResources.Select(MapResource).ToList(),
+            ParentDepartmentResources = parentDepartmentResources.Select(MapResource).ToList(),
+            ParentDepartmentName = parentDepartmentName,
+            ParentDepartmentSlug = parentDepartmentSlug,
+            IsSensitive = team.IsSensitive,
+            ActorDisplayName = user.DisplayName
         };
 
         return View(viewModel);

--- a/src/Humans.Web/Controllers/TeamController.cs
+++ b/src/Humans.Web/Controllers/TeamController.cs
@@ -666,6 +666,7 @@ public class TeamController : HumansControllerBase
             IsSystemTeam = team.IsSystemTeam,
             HasBudget = team.HasBudget,
             IsHidden = team.IsHidden,
+            IsSensitive = team.IsSensitive,
             ParentTeamId = team.ParentTeamId,
             EligibleParents = await GetEligibleParentTeamsAsync(excludeTeamId: id, cancellationToken)
         };
@@ -691,7 +692,7 @@ public class TeamController : HumansControllerBase
 
         try
         {
-            await _teamService.UpdateTeamAsync(id, model.Name, model.Description, model.RequiresApproval, model.IsActive, model.ParentTeamId, model.GoogleGroupPrefix, model.CustomSlug, model.HasBudget, model.IsHidden);
+            await _teamService.UpdateTeamAsync(id, model.Name, model.Description, model.RequiresApproval, model.IsActive, model.ParentTeamId, model.GoogleGroupPrefix, model.CustomSlug, model.HasBudget, model.IsHidden, model.IsSensitive);
             var currentUser = await GetCurrentUserAsync();
             _logger.LogInformation("Admin {AdminId} updated team {TeamId}", currentUser?.Id, id);
 

--- a/src/Humans.Web/Models/TeamViewModels.cs
+++ b/src/Humans.Web/Models/TeamViewModels.cs
@@ -215,6 +215,7 @@ public class EditTeamViewModel : TeamFormViewModelBase
     public bool IsActive { get; set; }
     public bool IsSystemTeam { get; set; }
     public bool HasBudget { get; set; }
+    public bool IsSensitive { get; set; }
 }
 
 public class EditTeamPageViewModel
@@ -258,6 +259,45 @@ public class TeamMembersViewModel
     public List<TeamJoinRequestViewModel> PendingRequests { get; set; } = [];
     public bool CanManageRoles { get; set; }
     public bool CanProvisionEmails { get; set; }
+
+    /// <summary>
+    /// Google resources linked to this team (active only). For the resource access summary card.
+    /// </summary>
+    public List<ResourceAccessViewModel> TeamResources { get; set; } = [];
+
+    /// <summary>
+    /// Google resources linked to the parent department (active only). Shown separately when this is a sub-team.
+    /// </summary>
+    public List<ResourceAccessViewModel> ParentDepartmentResources { get; set; } = [];
+
+    /// <summary>
+    /// Parent department name, if this is a sub-team.
+    /// </summary>
+    public string? ParentDepartmentName { get; set; }
+
+    /// <summary>
+    /// Parent department slug, for linking to its Resources page.
+    /// </summary>
+    public string? ParentDepartmentSlug { get; set; }
+
+    /// <summary>
+    /// Whether the team is flagged as sensitive (admin-only).
+    /// </summary>
+    public bool IsSensitive { get; set; }
+
+    /// <summary>
+    /// The current actor's display name (for audit preview in sensitive team modal).
+    /// </summary>
+    public string? ActorDisplayName { get; set; }
+}
+
+public class ResourceAccessViewModel
+{
+    public string Name { get; set; } = string.Empty;
+    public string ResourceType { get; set; } = string.Empty;
+    public string? PermissionLevel { get; set; }
+    public string? Url { get; set; }
+    public string IconClass { get; set; } = string.Empty;
 }
 
 public class BirthdayCalendarViewModel

--- a/src/Humans.Web/Views/Team/EditTeam.cshtml
+++ b/src/Humans.Web/Views/Team/EditTeam.cshtml
@@ -69,6 +69,15 @@
                         </div>
                     }
 
+                    @if (Humans.Web.Authorization.RoleChecks.IsAdmin(User))
+                    {
+                        <div class="mb-3 form-check">
+                            <input asp-for="IsSensitive" type="checkbox" class="form-check-input" />
+                            <label asp-for="IsSensitive" class="form-check-label">Sensitive team</label>
+                            <div class="form-text">When enabled, adding or approving humans triggers a confirmation modal showing the audit record that will be created. This flag is not visible to non-admin users.</div>
+                        </div>
+                    }
+
                     <div class="d-flex gap-2">
                         <button type="submit" class="btn btn-primary">@Localizer["Common_Save"]</button>
                         <a asp-action="Summary" class="btn btn-outline-secondary">@Localizer["Common_Cancel"]</a>

--- a/src/Humans.Web/Views/TeamAdmin/Members.cshtml
+++ b/src/Humans.Web/Views/TeamAdmin/Members.cshtml
@@ -26,14 +26,14 @@
 
 @if (Model.TeamResources.Any() || Model.ParentDepartmentResources.Any())
 {
-    <div class="card mb-4 border-warning">
-        <div class="card-header bg-warning bg-opacity-10 d-flex align-items-center">
-            <i class="fa-solid fa-shield-halved me-2 text-warning"></i>
+    <div class="card mb-4 border-danger">
+        <div class="card-header bg-danger bg-opacity-10 d-flex align-items-center">
+            <i class="fa-solid fa-shield-halved me-2 text-danger"></i>
             <strong>Resource Access</strong>
         </div>
         <div class="card-body">
             <p class="text-muted mb-3">
-                <i class="fa-solid fa-triangle-exclamation text-warning me-1"></i>
+                <i class="fa-solid fa-triangle-exclamation text-danger me-1"></i>
                 Adding or approving humans for this team grants access to the resources listed below.
             </p>
             @if (Model.TeamResources.Any())

--- a/src/Humans.Web/Views/TeamAdmin/Members.cshtml
+++ b/src/Humans.Web/Views/TeamAdmin/Members.cshtml
@@ -86,9 +86,6 @@
                     }
                 </ul>
             }
-            <a asp-action="Resources" asp-route-slug="@Model.TeamSlug" class="btn btn-sm btn-outline-info">
-                <i class="fa-solid fa-gear me-1"></i> Manage Resources
-            </a>
         </div>
     </div>
 }

--- a/src/Humans.Web/Views/TeamAdmin/Members.cshtml
+++ b/src/Humans.Web/Views/TeamAdmin/Members.cshtml
@@ -27,13 +27,13 @@
 @if (Model.TeamResources.Any() || Model.ParentDepartmentResources.Any())
 {
     <div class="card mb-4 border-danger">
-        <div class="card-header bg-danger text-white d-flex align-items-center">
+        <div class="card-header bg-danger d-flex align-items-center" style="color: var(--h-parchment);">
             <i class="fa-solid fa-shield-halved me-2"></i>
             <strong>Resource Access — Sensitive Team!</strong>
         </div>
         <div class="card-body">
             <p class="mb-3">
-                <i class="fa-solid fa-hand text-danger me-1" style="font-size: 2.5rem; vertical-align: middle;"></i>
+                <i class="fa-solid fa-hand me-1" style="font-size: 2.5rem; vertical-align: middle; color: var(--h-rust);"></i>
                 Adding or approving humans for this team grants access to the resources listed below.
             </p>
             @if (Model.TeamResources.Any())

--- a/src/Humans.Web/Views/TeamAdmin/Members.cshtml
+++ b/src/Humans.Web/Views/TeamAdmin/Members.cshtml
@@ -27,13 +27,13 @@
 @if (Model.TeamResources.Any() || Model.ParentDepartmentResources.Any())
 {
     <div class="card mb-4 border-danger">
-        <div class="card-header bg-danger bg-opacity-10 d-flex align-items-center">
-            <i class="fa-solid fa-shield-halved me-2 text-danger"></i>
-            <strong>Resource Access</strong>
+        <div class="card-header bg-danger text-white d-flex align-items-center">
+            <i class="fa-solid fa-shield-halved me-2"></i>
+            <strong>Resource Access — Sensitive Team!</strong>
         </div>
         <div class="card-body">
-            <p class="text-muted mb-3">
-                <i class="fa-solid fa-triangle-exclamation text-danger me-1"></i>
+            <p class="mb-3">
+                <i class="fa-solid fa-hand text-danger me-1" style="font-size: 2.5rem; vertical-align: middle;"></i>
                 Adding or approving humans for this team grants access to the resources listed below.
             </p>
             @if (Model.TeamResources.Any())

--- a/src/Humans.Web/Views/TeamAdmin/Members.cshtml
+++ b/src/Humans.Web/Views/TeamAdmin/Members.cshtml
@@ -24,6 +24,75 @@
     </div>
 }
 
+@if (Model.TeamResources.Any() || Model.ParentDepartmentResources.Any())
+{
+    <div class="card mb-4 border-warning">
+        <div class="card-header bg-warning bg-opacity-10 d-flex align-items-center">
+            <i class="fa-solid fa-shield-halved me-2 text-warning"></i>
+            <strong>Resource Access</strong>
+        </div>
+        <div class="card-body">
+            <p class="text-muted mb-3">
+                <i class="fa-solid fa-triangle-exclamation text-warning me-1"></i>
+                Adding or approving humans for this team grants access to the resources listed below.
+            </p>
+            @if (Model.TeamResources.Any())
+            {
+                <h6 class="mb-2">@Model.TeamName</h6>
+                <ul class="list-unstyled mb-2">
+                    @foreach (var resource in Model.TeamResources)
+                    {
+                        <li class="mb-1">
+                            <i class="@resource.IconClass me-1 text-muted"></i>
+                            @if (resource.Url is not null)
+                            {
+                                <a href="@resource.Url" target="_blank" rel="noopener">@resource.Name</a>
+                            }
+                            else
+                            {
+                                @resource.Name
+                            }
+                            <span class="badge bg-secondary ms-1">@resource.ResourceType</span>
+                            @if (resource.PermissionLevel is not null)
+                            {
+                                <span class="badge bg-info ms-1">@resource.PermissionLevel</span>
+                            }
+                        </li>
+                    }
+                </ul>
+            }
+            @if (Model.ParentDepartmentResources.Any())
+            {
+                <h6 class="mb-2">@Model.ParentDepartmentName (department)</h6>
+                <ul class="list-unstyled mb-2">
+                    @foreach (var resource in Model.ParentDepartmentResources)
+                    {
+                        <li class="mb-1">
+                            <i class="@resource.IconClass me-1 text-muted"></i>
+                            @if (resource.Url is not null)
+                            {
+                                <a href="@resource.Url" target="_blank" rel="noopener">@resource.Name</a>
+                            }
+                            else
+                            {
+                                @resource.Name
+                            }
+                            <span class="badge bg-secondary ms-1">@resource.ResourceType</span>
+                            @if (resource.PermissionLevel is not null)
+                            {
+                                <span class="badge bg-info ms-1">@resource.PermissionLevel</span>
+                            }
+                        </li>
+                    }
+                </ul>
+            }
+            <a asp-action="Resources" asp-route-slug="@Model.TeamSlug" class="btn btn-sm btn-outline-info">
+                <i class="fa-solid fa-gear me-1"></i> Manage Resources
+            </a>
+        </div>
+    </div>
+}
+
 @if (Model.PendingRequests.Any())
 {
     <div class="card mb-4">
@@ -231,6 +300,67 @@ else
     <a asp-action="Resources" asp-route-slug="@Model.TeamSlug" class="btn btn-outline-info">@Localizer["TeamAdmin_ManageResources"]</a>
 </div>
 
+@if (Model.IsSensitive)
+{
+    <div class="modal fade" id="sensitiveConfirmModal" tabindex="-1" aria-labelledby="sensitiveConfirmModalLabel" aria-hidden="true">
+        <div class="modal-dialog modal-lg">
+            <div class="modal-content border-danger">
+                <div class="modal-header bg-danger bg-opacity-10">
+                    <h5 class="modal-title" id="sensitiveConfirmModalLabel">
+                        <i class="fa-solid fa-shield-halved text-danger me-2"></i>
+                        Sensitive Team — Confirm Access Grant
+                    </h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <div class="alert alert-danger mb-3">
+                        <strong>This team handles sensitive information.</strong> Adding a human to this team grants them access to the resources listed below.
+                    </div>
+
+                    @if (Model.TeamResources.Any() || Model.ParentDepartmentResources.Any())
+                    {
+                        <h6>Resources that will be granted:</h6>
+                        <ul class="list-unstyled mb-3">
+                            @foreach (var resource in Model.TeamResources.Concat(Model.ParentDepartmentResources))
+                            {
+                                <li class="mb-1">
+                                    <i class="@resource.IconClass me-1 text-muted"></i>
+                                    @resource.Name
+                                    <span class="badge bg-secondary ms-1">@resource.ResourceType</span>
+                                    @if (resource.PermissionLevel is not null)
+                                    {
+                                        <span class="badge bg-info ms-1">@resource.PermissionLevel</span>
+                                    }
+                                </li>
+                            }
+                        </ul>
+                    }
+
+                    <div class="card bg-light mb-3">
+                        <div class="card-body py-2">
+                            <strong>This action will be recorded:</strong>
+                            <em id="sensitiveAuditPreview">
+                                @Model.ActorDisplayName granting <span id="sensitiveTargetName">this human</span> access to @Model.TeamName on @DateTime.UtcNow.ToString("d MMM yyyy") at @DateTime.UtcNow.ToString("HH:mm") UTC
+                            </em>
+                        </div>
+                    </div>
+
+                    <div class="form-check mb-2">
+                        <input type="checkbox" class="form-check-input" id="sensitiveAcknowledge" />
+                        <label class="form-check-label" for="sensitiveAcknowledge">
+                            <strong>I understand that this action is logged, attributed to me, and grants access to sensitive resources.</strong>
+                        </label>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <button type="button" class="btn btn-danger" id="sensitiveConfirmBtn" disabled>Confirm Access Grant</button>
+                </div>
+            </div>
+        </div>
+    </div>
+}
+
 @if (Model.CanManageRoles)
 {
     <script nonce="@Context.Items["CspNonce"]">
@@ -245,5 +375,81 @@ else
             ["NoResultsText"] = Localizer["TeamAdmin_NoResults"].Value,
             ["AddText"] = Localizer["TeamAdmin_Add"].Value
         })
+    </script>
+}
+
+@if (Model.IsSensitive)
+{
+    <script nonce="@Context.Items["CspNonce"]">
+    (function() {
+        var modal = document.getElementById('sensitiveConfirmModal');
+        if (!modal) return;
+        var bsModal = new bootstrap.Modal(modal);
+        var confirmBtn = document.getElementById('sensitiveConfirmBtn');
+        var acknowledgeBox = document.getElementById('sensitiveAcknowledge');
+        var targetNameSpan = document.getElementById('sensitiveTargetName');
+        var pendingForm = null;
+
+        acknowledgeBox.addEventListener('change', function() {
+            confirmBtn.disabled = !this.checked;
+        });
+
+        confirmBtn.addEventListener('click', function() {
+            if (pendingForm) {
+                pendingForm.submit();
+                pendingForm = null;
+            }
+            bsModal.hide();
+        });
+
+        // Intercept approve buttons (they have data-confirm attributes)
+        document.addEventListener('submit', function(e) {
+            var form = e.target;
+            var action = form.getAttribute('action') || '';
+            var isApprove = action.indexOf('/Approve') !== -1;
+            var isAdd = action.indexOf('/AddMember') !== -1;
+            if (!isApprove && !isAdd) return;
+
+            // Don't intercept if already confirmed
+            if (form.dataset.sensitiveConfirmed === 'true') return;
+
+            e.preventDefault();
+            pendingForm = form;
+
+            // Try to find the target name
+            var targetName = 'this human';
+            if (isApprove) {
+                var row = form.closest('tr');
+                if (row) {
+                    var nameEl = row.querySelector('strong, .fw-bold, [data-display-name]');
+                    if (nameEl) targetName = nameEl.textContent.trim();
+                }
+            } else if (isAdd) {
+                var parentItem = form.closest('.list-group-item');
+                if (parentItem) {
+                    var nameEl = parentItem.querySelector('strong');
+                    if (nameEl) targetName = nameEl.textContent.trim();
+                }
+            }
+            targetNameSpan.textContent = targetName;
+
+            // Reset checkbox
+            acknowledgeBox.checked = false;
+            confirmBtn.disabled = true;
+
+            // Mark form so it won't be intercepted again
+            form.dataset.sensitiveConfirmed = 'true';
+
+            bsModal.show();
+        });
+
+        // Reset confirmed flag when modal is hidden without confirming
+        modal.addEventListener('hidden.bs.modal', function() {
+            if (pendingForm) {
+                delete pendingForm.dataset.sensitiveConfirmed;
+                pendingForm = null;
+            }
+        });
+    })();
     </script>
 }


### PR DESCRIPTION
## Summary
- **#338**: Resource access summary card on the Team Members page listing all Google resources (Drive folders, Groups) for the team and parent department, with permission levels and a warning that approving/adding humans grants access
- **#339**: `IsSensitive` boolean on Team entity (admin-only toggle). When a sensitive team's approve/add forms are submitted, a confirmation modal intercepts with: list of resources being granted, preview of the exact audit record, and an acknowledgment checkbox that must be checked before proceeding

## Changes
- New `IsSensitive` property on Team entity + EF migration
- Admin-only toggle in Edit Team form
- Resource access card on Members page (visible when resources exist)
- Sensitive team confirmation modal with audit preview and acknowledgment checkbox
- `ResourceAccessViewModel` for clean resource display

References nobodies-collective/Humans#338, nobodies-collective/Humans#339

## Test plan
- [ ] Members page shows resource card when team has linked Drive folders/Groups
- [ ] Members page shows parent department resources separately for sub-teams
- [ ] Card hidden when no resources exist
- [ ] Admin can toggle IsSensitive in Edit Team
- [ ] Non-admin cannot see IsSensitive toggle
- [ ] Sensitive team: approve button triggers modal with resource list and audit preview
- [ ] Sensitive team: add member button triggers modal
- [ ] Modal blocks submission until acknowledgment checkbox is checked
- [ ] Non-sensitive teams work normally (no modal)
- [ ] All 700 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)