### PR TITLE
Show all validation errors at top of profile edit form

### DIFF
--- a/src/Humans.Web/Views/Profile/Edit.cshtml
+++ b/src/Humans.Web/Views/Profile/Edit.cshtml
@@ -8,7 +8,12 @@
         <h1>@Localizer["ProfileEdit_Title"]</h1>
 
         <form asp-action="Edit" method="post" enctype="multipart/form-data">
-            <div asp-validation-summary="ModelOnly" class="text-danger mb-3"></div>
+            @if (ViewData.ModelState!.ErrorCount > 0)
+            {
+                <div class="alert alert-danger mb-3" id="validationSummary">
+                    <div asp-validation-summary="All"></div>
+                </div>
+            }
 
             @* === Section ordering: Private first when fields are empty (new user) === *@
             @if (Model.ShowPrivateFirst)
@@ -847,10 +852,13 @@
             lastNameInput?.addEventListener('input', checkBurnerNameMatch);
             checkBurnerNameMatch();
 
-            // Scroll to first validation error
-            const firstError = document.querySelector('.field-validation-error:not(:empty), .text-danger:not(:empty)');
-            if (firstError) {
-                firstError.closest('.mb-3, .col-md-3, .card')?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+            // Scroll to validation summary if present, else first inline error
+            const summary = document.getElementById('validationSummary');
+            if (summary) {
+                summary.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            } else {
+                const firstError = document.querySelector('.field-validation-error:not(:empty)');
+                firstError?.closest('.mb-3, .col-md-3, .card')?.scrollIntoView({ behavior: 'smooth', block: 'center' });
             }
 
             // Clear on submit so saving doesn't trigger warning

--- a/src/Humans.Web/Views/Profile/Edit.cshtml
+++ b/src/Humans.Web/Views/Profile/Edit.cshtml
@@ -422,6 +422,13 @@
                 <partial name="_EditSectionPrivate" model="Model" />
             }
 
+            @if (ViewData.ModelState!.ErrorCount > 0)
+            {
+                <div class="alert alert-danger mb-3">
+                    <div asp-validation-summary="All"></div>
+                </div>
+            }
+
             <div class="d-flex justify-content-between">
                 <a asp-action="Index" class="btn btn-outline-secondary">@Localizer["Common_Cancel"]</a>
                 <button type="submit" class="btn btn-primary">@Localizer["Common_Save"]</button>

--- a/src/Humans.Web/Views/Profile/Edit.cshtml
+++ b/src/Humans.Web/Views/Profile/Edit.cshtml
@@ -289,10 +289,13 @@
                         <i class="fa-solid fa-plus me-1"></i> @Localizer["ProfileEdit_AddEntry"]
                     </button>
 
-                    <div class="form-check mb-3" id="noPriorBurnContainer" data-cv-required="@Localizer["Profile_BurnerCVRequired"].Value">
+                    <div class="form-check mb-3" id="noPriorBurnContainer">
                         <input type="checkbox" asp-for="NoPriorBurnExperience" class="form-check-input" id="noPriorBurnCheckbox" />
                         <label asp-for="NoPriorBurnExperience" class="form-check-label">@Localizer["Profile_NoPriorBurnExperience"]</label>
                         <span asp-validation-for="NoPriorBurnExperience" class="text-danger d-block"></span>
+                    </div>
+                    <div id="cvRequiredAlert" class="alert alert-danger d-none">
+                        @Localizer["Profile_BurnerCVRequired"]
                     </div>
 
                     <hr />
@@ -795,34 +798,20 @@
         (function() {
             const form = document.querySelector('form[action*="Edit"]');
             const checkbox = document.getElementById('noPriorBurnCheckbox');
-            const container = document.getElementById('noPriorBurnContainer');
             const historyContainer = document.getElementById('volunteerHistoryContainer');
-            if (!form || !checkbox || !container || !historyContainer) return;
+            const cvAlert = document.getElementById('cvRequiredAlert');
+            if (!form || !checkbox || !historyContainer || !cvAlert) return;
 
-            const message = container.dataset.cvRequired;
-            const errorSpan = container.querySelector('.text-danger');
-
-            function clearCvError() {
-                if (errorSpan) {
-                    errorSpan.textContent = '';
-                    errorSpan.classList.remove('field-validation-error');
-                }
-            }
-
-            checkbox.addEventListener('change', clearCvError);
+            checkbox.addEventListener('change', () => cvAlert.classList.add('d-none'));
 
             form.addEventListener('submit', function(e) {
                 const hasRows = historyContainer.querySelectorAll('.volunteer-history-row').length > 0;
                 if (!checkbox.checked && !hasRows) {
                     e.preventDefault();
-                    if (errorSpan) {
-                        errorSpan.textContent = message;
-                        errorSpan.classList.add('field-validation-error');
-                    }
-                    container.scrollIntoView({ behavior: 'smooth', block: 'center' });
-                    checkbox.focus();
+                    cvAlert.classList.remove('d-none');
+                    cvAlert.scrollIntoView({ behavior: 'smooth', block: 'center' });
                 } else {
-                    clearCvError();
+                    cvAlert.classList.add('d-none');
                 }
             });
         })();

--- a/src/Humans.Web/Views/Profile/Edit.cshtml
+++ b/src/Humans.Web/Views/Profile/Edit.cshtml
@@ -289,7 +289,7 @@
                         <i class="fa-solid fa-plus me-1"></i> @Localizer["ProfileEdit_AddEntry"]
                     </button>
 
-                    <div class="form-check mb-3" id="noPriorBurnContainer">
+                    <div class="form-check mb-3" id="noPriorBurnContainer" data-cv-required="@Localizer["Profile_BurnerCVRequired"].Value">
                         <input type="checkbox" asp-for="NoPriorBurnExperience" class="form-check-input" id="noPriorBurnCheckbox" />
                         <label asp-for="NoPriorBurnExperience" class="form-check-label">@Localizer["Profile_NoPriorBurnExperience"]</label>
                         <span asp-validation-for="NoPriorBurnExperience" class="text-danger d-block"></span>
@@ -795,16 +795,34 @@
         (function() {
             const form = document.querySelector('form[action*="Edit"]');
             const checkbox = document.getElementById('noPriorBurnCheckbox');
+            const container = document.getElementById('noPriorBurnContainer');
             const historyContainer = document.getElementById('volunteerHistoryContainer');
-            if (!form || !checkbox || !historyContainer) return;
+            if (!form || !checkbox || !container || !historyContainer) return;
+
+            const message = container.dataset.cvRequired;
+            const errorSpan = container.querySelector('.text-danger');
+
+            function clearCvError() {
+                if (errorSpan) {
+                    errorSpan.textContent = '';
+                    errorSpan.classList.remove('field-validation-error');
+                }
+            }
+
+            checkbox.addEventListener('change', clearCvError);
 
             form.addEventListener('submit', function(e) {
                 const hasRows = historyContainer.querySelectorAll('.volunteer-history-row').length > 0;
                 if (!checkbox.checked && !hasRows) {
                     e.preventDefault();
-                    // Focus the checkbox area
-                    checkbox.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                    if (errorSpan) {
+                        errorSpan.textContent = message;
+                        errorSpan.classList.add('field-validation-error');
+                    }
+                    container.scrollIntoView({ behavior: 'smooth', block: 'center' });
                     checkbox.focus();
+                } else {
+                    clearCvError();
                 }
             });
         })();


### PR DESCRIPTION
## Summary
- Switch profile edit validation summary from `ModelOnly` to `All` so every field error is listed at the top of the form in a prominent `alert-danger` banner
- Scroll to the validation summary on page load when errors exist
- Fixes the "silent failed save" problem where an off-screen validation error (e.g. phone format) blocked saving with no visible feedback — which was the root cause of #345

## Test plan
- [ ] Edit profile, leave a required field empty (e.g. clear Burner Name), save → alert banner at top lists the error
- [ ] Edit profile, enter a phone number without `+` prefix, save → alert banner at top lists the phone format error, page scrolls to it
- [ ] Edit profile with valid data, save → no alert banner, redirects to profile view normally
- [ ] On a long form where the error field is off-screen, confirm the page scrolls to the top summary

Closes #344

🤖 Generated with [Claude Code](https://claude.com/claude-code)