### PR TITLE
Redesign unauthenticated homepage (#337)

### DIFF
--- a/src/Humans.Web/Resources/SharedResource.de.resx
+++ b/src/Humans.Web/Resources/SharedResource.de.resx
@@ -105,23 +105,27 @@
   <!-- Home (Landing Page)      -->
   <!-- ======================== -->
   <data name="Home_Title" xml:space="preserve"><value>Startseite</value></data>
-  <data name="Home_Tagline" xml:space="preserve"><value>Mitgliederportal für Nobodies Collective</value></data>
-  <data name="Home_CTA" xml:space="preserve"><value>Neu hier? Melden Sie sich an, um loszulegen.</value></data>
-  <data name="Home_WhyTitle" xml:space="preserve"><value>Warum brauchen wir das?</value></data>
-  <data name="Home_WhyDescription" xml:space="preserve"><value>Als eingetragener Verein in Spanien hat Nobodies Collective gesetzliche Verpflichtungen. Bevor jemand auf gemeinsame Ressourcen zugreifen kann, müssen wir die Zustimmung zu unseren Richtlinien bestätigen. Dieses System erledigt das auf einfache Weise und hält alles aktuell.</value></data>
-  <data name="Home_ComplianceTitle" xml:space="preserve"><value>Rechtliche Compliance</value></data>
-  <data name="Home_ComplianceDescription" xml:space="preserve"><value>Um auf Vereinsressourcen zugreifen zu können, muss jeder unseren Richtlinien zustimmen: DSGVO-Datenverarbeitung, Datenschutzrichtlinie, Einwilligungsbedingungen und Creative-Commons-Lizenzierung. Dies ist ein einmaliger Vorgang (es sei denn, Dokumente werden aktualisiert).</value></data>
-  <data name="Home_ResourceAccessTitle" xml:space="preserve"><value>Ressourcenzugang</value></data>
-  <data name="Home_ResourceAccessDescription" xml:space="preserve"><value>Sobald Sie Ihr Profil und Ihre Einwilligungen abgeschlossen haben, erhalten Sie Zugang zu gemeinsamen Ressourcen: Google Drive-Ordnern, Team-Arbeitsbereichen und Kollaborations-Tools. Teams können für verschiedene Arbeitsgruppen konfiguriert werden.</value></data>
-  <data name="Home_DocumentUpdatesTitle" xml:space="preserve"><value>Dokumentenaktualisierungen</value></data>
-  <data name="Home_DocumentUpdatesDescription" xml:space="preserve"><value>Rechtliche Dokumente entwickeln sich weiter. Wenn sich Richtlinien wesentlich ändern, werden Sie aufgefordert, diese zu prüfen und erneut zuzustimmen. So wird sichergestellt, dass alle unter denselben aktuellen Vereinbarungen arbeiten.</value></data>
-  <data name="Home_VotingMembershipTitle" xml:space="preserve"><value>Stimmberechtigte Mitgliedschaft</value></data>
-  <data name="Home_VotingMembershipDescription" xml:space="preserve"><value>Unsere Satzung erfordert ein Verzeichnis stimmberechtigter Mitglieder für die Governance (Mitgliederversammlungen, Wahlen usw.). Wenn Sie an der Governance teilnehmen möchten, können Sie sich als stimmberechtigtes Mitglied bewerben. Dies ist vollkommen freiwillig.</value></data>
-  <data name="Home_GettingStartedTitle" xml:space="preserve"><value>Erste Schritte</value></data>
-  <data name="Home_Step1" xml:space="preserve"><value>&lt;strong&gt;Melden Sie sich an&lt;/strong&gt; mit Ihrem Google-Konto</value></data>
-  <data name="Home_Step2" xml:space="preserve"><value>&lt;strong&gt;Vervollständigen Sie Ihr Profil&lt;/strong&gt; mit grundlegenden Informationen</value></data>
-  <data name="Home_Step3" xml:space="preserve"><value>&lt;strong&gt;Prüfen und stimmen Sie zu&lt;/strong&gt; unseren rechtlichen Dokumenten (spanische Originale mit englischen Übersetzungen)</value></data>
-  <data name="Home_GettingStartedSummary" xml:space="preserve"><value>Das war's! Sobald Ihre Einwilligungen vorliegen, haben Sie Zugang zu den Vereinsressourcen. Wenn Sie daran interessiert sind, als stimmberechtigtes Mitglied an der Governance teilzunehmen, können Sie optional über Ihr Dashboard einen Antrag stellen.</value></data>
+  <data name="Home_Tagline" xml:space="preserve"><value>Wo Nobodies Collective sich organisiert</value></data>
+  <data name="Home_HeroDescription" xml:space="preserve"><value>Die Community-Plattform f&#xFC;r unsere humans &#x2014; melde dich f&#xFC;r Schichten an, tritt Teams bei, registriere dein Camp und hilf mit, dass Dinge passieren.</value></data>
+  <data name="Home_CTA" xml:space="preserve"><value>Loslegen</value></data>
+  <data name="Home_FeaturesTitle" xml:space="preserve"><value>Alles, was du zum Mitmachen brauchst</value></data>
+  <data name="Home_ShiftsTitle" xml:space="preserve"><value>Schichten &amp; Freiwilligenarbeit</value></data>
+  <data name="Home_ShiftsDescription" xml:space="preserve"><value>Schau dir verf&#xFC;gbare Schichten an, melde dich f&#xFC;r Event-Rollen an und behalte deinen Zeitplan im Blick. Sieh, was dringend ist und wo Hilfe am meisten gebraucht wird.</value></data>
+  <data name="Home_TeamsTitle" xml:space="preserve"><value>Teams &amp; Arbeitsgruppen</value></data>
+  <data name="Home_TeamsDescription" xml:space="preserve"><value>Selbstorganisierte Arbeitsgruppen mit Koordinatoren, geteilten Ressourcen und Genehmigungs-Workflows. Finde dein Team.</value></data>
+  <data name="Home_CampsTitle" xml:space="preserve"><value>Camps &amp; Barrios</value></data>
+  <data name="Home_CampsDescription" xml:space="preserve"><value>Registriere dein Camp, entdecke Nachbarn nach Stimmung oder Soundzone und melde dich jede Saison an.</value></data>
+  <data name="Home_TicketsTitle" xml:space="preserve"><value>Tickets &amp; Events</value></data>
+  <data name="Home_TicketsDescription" xml:space="preserve"><value>Ticketverkauf-Integration, Teilnehmer-Matching und Rabattaktionen &#x2014; alles mit deinem Profil verkn&#xFC;pft.</value></data>
+  <data name="Home_BudgetTitle" xml:space="preserve"><value>Budget-Transparenz</value></data>
+  <data name="Home_BudgetDescription" xml:space="preserve"><value>Sieh, wie Mittel auf Abteilungen verteilt werden. Offene Budgetplanung mit &#xF6;ffentlichen Zusammenfassungen.</value></data>
+  <data name="Home_ProfilesTitle" xml:space="preserve"><value>Profile &amp; Verzeichnis</value></data>
+  <data name="Home_ProfilesDescription" xml:space="preserve"><value>Ausf&#xFC;hrliche Profile mit Burner-Namen, Standorten und Notfallkontakten. Ein Geburtstagskalender und Verzeichnis f&#xFC;r die Community.</value></data>
+  <data name="Home_GettingStartedTitle" xml:space="preserve"><value>Schnelles Onboarding</value></data>
+  <data name="Home_Step1" xml:space="preserve"><value>&lt;strong&gt;Melde dich an&lt;/strong&gt; mit deinem Google-Konto</value></data>
+  <data name="Home_Step2" xml:space="preserve"><value>&lt;strong&gt;Richte dein Profil ein&lt;/strong&gt; &#x2014; Name, Standort und wie du erreichbar sein m&#xF6;chtest</value></data>
+  <data name="Home_Step3" xml:space="preserve"><value>&lt;strong&gt;Stimme dem Grundlegenden zu&lt;/strong&gt; &#x2014; wir k&#xFC;mmern uns um den Papierkram, damit du dich aufs Mitmachen konzentrieren kannst</value></data>
+  <data name="Home_GettingStartedSummary" xml:space="preserve"><value>Dauert nur ein paar Minuten. Danach bist du dabei &#x2014; Schichten durchst&#xF6;bern, Teams beitreten und loslegen.</value></data>
 
   <!-- ======================== -->
   <!-- Dashboard                -->

--- a/src/Humans.Web/Resources/SharedResource.es.resx
+++ b/src/Humans.Web/Resources/SharedResource.es.resx
@@ -105,23 +105,27 @@
   <!-- Home (Landing Page)      -->
   <!-- ======================== -->
   <data name="Home_Title" xml:space="preserve"><value>Inicio</value></data>
-  <data name="Home_Tagline" xml:space="preserve"><value>Portal de miembros de Nobodies Collective</value></data>
-  <data name="Home_CTA" xml:space="preserve"><value>&#xBF;Eres nuevo/a? Inicia sesi&#xF3;n para empezar.</value></data>
-  <data name="Home_WhyTitle" xml:space="preserve"><value>&#xBF;Por qu&#xE9; necesitamos esto?</value></data>
-  <data name="Home_WhyDescription" xml:space="preserve"><value>Como asociaci&#xF3;n registrada en Espa&#xF1;a, Nobodies Collective tiene obligaciones legales. Antes de que cualquier persona pueda acceder a los recursos compartidos, necesitamos confirmar su aceptaci&#xF3;n de nuestras pol&#xED;ticas. Este sistema se encarga de ello de forma sencilla y mantiene todo actualizado.</value></data>
-  <data name="Home_ComplianceTitle" xml:space="preserve"><value>Cumplimiento legal</value></data>
-  <data name="Home_ComplianceDescription" xml:space="preserve"><value>Para acceder a los recursos de la asociaci&#xF3;n, es necesario aceptar nuestras pol&#xED;ticas: tratamiento de datos seg&#xFA;n el RGPD, pol&#xED;tica de privacidad, t&#xE9;rminos de consentimiento y licencia Creative Commons. Es un proceso &#xFA;nico (salvo que se actualicen los documentos).</value></data>
-  <data name="Home_ResourceAccessTitle" xml:space="preserve"><value>Acceso a recursos</value></data>
-  <data name="Home_ResourceAccessDescription" xml:space="preserve"><value>Una vez que haya completado su perfil y sus consentimientos, tendr&#xE1; acceso a los recursos compartidos: carpetas de Google Drive, espacios de trabajo de equipo y herramientas de colaboraci&#xF3;n. Los equipos pueden configurarse para diferentes grupos de trabajo.</value></data>
-  <data name="Home_DocumentUpdatesTitle" xml:space="preserve"><value>Actualizaci&#xF3;n de documentos</value></data>
-  <data name="Home_DocumentUpdatesDescription" xml:space="preserve"><value>Los documentos legales evolucionan. Cuando las pol&#xED;ticas cambien de manera significativa, se le pedir&#xE1; que las revise y otorgue su consentimiento nuevamente. Esto garantiza que todos trabajen bajo los mismos acuerdos vigentes.</value></data>
-  <data name="Home_VotingMembershipTitle" xml:space="preserve"><value>Membres&#xED;a con derecho a voto</value></data>
-  <data name="Home_VotingMembershipDescription" xml:space="preserve"><value>Nuestros estatutos requieren un registro de miembros con derecho a voto para la gobernanza (asambleas generales, elecciones, etc.). Si desea participar en la gobernanza, puede solicitar ser miembro con derecho a voto. Esto es completamente opcional.</value></data>
-  <data name="Home_GettingStartedTitle" xml:space="preserve"><value>Primeros pasos</value></data>
-  <data name="Home_Step1" xml:space="preserve"><value>&lt;strong&gt;Inicie sesi&#xF3;n&lt;/strong&gt; con su cuenta de Google</value></data>
-  <data name="Home_Step2" xml:space="preserve"><value>&lt;strong&gt;Complete su perfil&lt;/strong&gt; con informaci&#xF3;n b&#xE1;sica</value></data>
-  <data name="Home_Step3" xml:space="preserve"><value>&lt;strong&gt;Revise y otorgue su consentimiento&lt;/strong&gt; a nuestros documentos legales (originales en espa&#xF1;ol con traducciones)</value></data>
-  <data name="Home_GettingStartedSummary" xml:space="preserve"><value>&#xA1;Eso es todo! Una vez que sus consentimientos est&#xE9;n en orden, tendr&#xE1; acceso a los recursos de la asociaci&#xF3;n. Si le interesa participar en la gobernanza como miembro con derecho a voto, puede enviar una solicitud de forma opcional desde su panel de control.</value></data>
+  <data name="Home_Tagline" xml:space="preserve"><value>Donde Nobodies Collective se organiza</value></data>
+  <data name="Home_HeroDescription" xml:space="preserve"><value>La plataforma comunitaria para nuestros humans &#x2014; ap&#xFA;ntate a turnos, &#xFA;nete a equipos, registra tu campamento y ayuda a que las cosas sucedan.</value></data>
+  <data name="Home_CTA" xml:space="preserve"><value>Empezar</value></data>
+  <data name="Home_FeaturesTitle" xml:space="preserve"><value>Todo lo que necesitas para participar</value></data>
+  <data name="Home_ShiftsTitle" xml:space="preserve"><value>Turnos y voluntariado</value></data>
+  <data name="Home_ShiftsDescription" xml:space="preserve"><value>Consulta los turnos disponibles, ap&#xFA;ntate a roles en eventos y lleva el control de tu horario. Mira qu&#xE9; es urgente y d&#xF3;nde se necesita m&#xE1;s ayuda.</value></data>
+  <data name="Home_TeamsTitle" xml:space="preserve"><value>Equipos y grupos de trabajo</value></data>
+  <data name="Home_TeamsDescription" xml:space="preserve"><value>Grupos de trabajo autoorganizados con coordinadores, recursos compartidos y flujos de aprobaci&#xF3;n. Encuentra tu equipo.</value></data>
+  <data name="Home_CampsTitle" xml:space="preserve"><value>Campamentos y barrios</value></data>
+  <data name="Home_CampsDescription" xml:space="preserve"><value>Registra tu campamento, descubre vecinos por ambiente o zona de sonido, y confirma tu participaci&#xF3;n cada temporada.</value></data>
+  <data name="Home_TicketsTitle" xml:space="preserve"><value>Entradas y eventos</value></data>
+  <data name="Home_TicketsDescription" xml:space="preserve"><value>Integraci&#xF3;n con venta de entradas, emparejamiento de asistentes y campa&#xF1;as de descuento &#x2014; todo vinculado a tu perfil.</value></data>
+  <data name="Home_BudgetTitle" xml:space="preserve"><value>Transparencia presupuestaria</value></data>
+  <data name="Home_BudgetDescription" xml:space="preserve"><value>Consulta c&#xF3;mo se asignan los fondos por departamento. Planificaci&#xF3;n presupuestaria abierta con res&#xFA;menes p&#xFA;blicos.</value></data>
+  <data name="Home_ProfilesTitle" xml:space="preserve"><value>Perfiles y directorio</value></data>
+  <data name="Home_ProfilesDescription" xml:space="preserve"><value>Perfiles completos con nombres de playa, ubicaciones y contactos de emergencia. Un calendario de cumplea&#xF1;os y directorio para la comunidad.</value></data>
+  <data name="Home_GettingStartedTitle" xml:space="preserve"><value>Registro r&#xE1;pido</value></data>
+  <data name="Home_Step1" xml:space="preserve"><value>&lt;strong&gt;Inicia sesi&#xF3;n&lt;/strong&gt; con tu cuenta de Google</value></data>
+  <data name="Home_Step2" xml:space="preserve"><value>&lt;strong&gt;Configura tu perfil&lt;/strong&gt; &#x2014; nombre, ubicaci&#xF3;n y c&#xF3;mo prefieres que te contacten</value></data>
+  <data name="Home_Step3" xml:space="preserve"><value>&lt;strong&gt;Acepta lo b&#xE1;sico&lt;/strong&gt; &#x2014; nosotros nos encargamos del papeleo para que t&#xFA; puedas participar</value></data>
+  <data name="Home_GettingStartedSummary" xml:space="preserve"><value>Son un par de minutos. Despu&#xE9;s, ya est&#xE1;s dentro &#x2014; consulta turnos, &#xFA;nete a equipos y empieza a contribuir.</value></data>
 
   <!-- ======================== -->
   <!-- Dashboard                -->

--- a/src/Humans.Web/Resources/SharedResource.fr.resx
+++ b/src/Humans.Web/Resources/SharedResource.fr.resx
@@ -105,23 +105,27 @@
   <!-- Home (Landing Page)      -->
   <!-- ======================== -->
   <data name="Home_Title" xml:space="preserve"><value>Accueil</value></data>
-  <data name="Home_Tagline" xml:space="preserve"><value>Portail des membres de Nobodies Collective</value></data>
-  <data name="Home_CTA" xml:space="preserve"><value>Nouveau/nouvelle ici&#xA0;? Connectez-vous pour commencer.</value></data>
-  <data name="Home_WhyTitle" xml:space="preserve"><value>Pourquoi avons-nous besoin de cela&#xA0;?</value></data>
-  <data name="Home_WhyDescription" xml:space="preserve"><value>En tant qu'association enregistr&#xE9;e en Espagne, Nobodies Collective a des obligations l&#xE9;gales. Avant que quiconque puisse acc&#xE9;der aux ressources partag&#xE9;es, nous devons confirmer l'acceptation de nos politiques. Ce syst&#xE8;me g&#xE8;re cela simplement et maintient tout &#xE0; jour.</value></data>
-  <data name="Home_ComplianceTitle" xml:space="preserve"><value>Conformit&#xE9; l&#xE9;gale</value></data>
-  <data name="Home_ComplianceDescription" xml:space="preserve"><value>Pour acc&#xE9;der aux ressources de l'association, chacun doit accepter nos politiques : traitement des donn&#xE9;es RGPD, politique de confidentialit&#xE9;, conditions de consentement et licence Creative Commons. C'est un processus unique (sauf mise &#xE0; jour des documents).</value></data>
-  <data name="Home_ResourceAccessTitle" xml:space="preserve"><value>Acc&#xE8;s aux ressources</value></data>
-  <data name="Home_ResourceAccessDescription" xml:space="preserve"><value>Une fois votre profil et vos consentements compl&#xE9;t&#xE9;s, vous aurez acc&#xE8;s aux ressources partag&#xE9;es : dossiers Google Drive, espaces de travail d'&#xE9;quipe et outils de collaboration. Les &#xE9;quipes peuvent &#xEA;tre configur&#xE9;es pour diff&#xE9;rents groupes de travail.</value></data>
-  <data name="Home_DocumentUpdatesTitle" xml:space="preserve"><value>Mises &#xE0; jour des documents</value></data>
-  <data name="Home_DocumentUpdatesDescription" xml:space="preserve"><value>Les documents l&#xE9;gaux &#xE9;voluent. Lorsque les politiques changent de mani&#xE8;re significative, il vous sera demand&#xE9; de les revoir et de renouveler votre consentement. Cela garantit que tous travaillent sous les m&#xEA;mes accords en vigueur.</value></data>
-  <data name="Home_VotingMembershipTitle" xml:space="preserve"><value>Adh&#xE9;sion avec droit de vote</value></data>
-  <data name="Home_VotingMembershipDescription" xml:space="preserve"><value>Nos statuts exigent un registre des membres votants pour la gouvernance (assembl&#xE9;es g&#xE9;n&#xE9;rales, &#xE9;lections, etc.). Si vous souhaitez participer &#xE0; la gouvernance, vous pouvez demander &#xE0; devenir membre votant. Cela est enti&#xE8;rement facultatif.</value></data>
-  <data name="Home_GettingStartedTitle" xml:space="preserve"><value>Pour commencer</value></data>
-  <data name="Home_Step1" xml:space="preserve"><value>&lt;strong&gt;Connectez-vous&lt;/strong&gt; avec votre compte Google</value></data>
-  <data name="Home_Step2" xml:space="preserve"><value>&lt;strong&gt;Compl&#xE9;tez votre profil&lt;/strong&gt; avec les informations de base</value></data>
-  <data name="Home_Step3" xml:space="preserve"><value>&lt;strong&gt;Consultez et consentez&lt;/strong&gt; &#xE0; nos documents l&#xE9;gaux (originaux en espagnol avec traductions en anglais)</value></data>
-  <data name="Home_GettingStartedSummary" xml:space="preserve"><value>C'est tout&#xA0;! Une fois vos consentements en ordre, vous aurez acc&#xE8;s aux ressources de l'association. Si vous souhaitez participer &#xE0; la gouvernance en tant que membre votant, vous pouvez &#xE9;ventuellement soumettre une candidature depuis votre tableau de bord.</value></data>
+  <data name="Home_Tagline" xml:space="preserve"><value>L&#xE0; o&#xF9; Nobodies Collective s'organise</value></data>
+  <data name="Home_HeroDescription" xml:space="preserve"><value>La plateforme communautaire pour nos humans &#x2014; inscris-toi aux cr&#xE9;neaux, rejoins des &#xE9;quipes, enregistre ton camp et aide &#xE0; faire bouger les choses.</value></data>
+  <data name="Home_CTA" xml:space="preserve"><value>C'est parti</value></data>
+  <data name="Home_FeaturesTitle" xml:space="preserve"><value>Tout ce qu'il faut pour participer</value></data>
+  <data name="Home_ShiftsTitle" xml:space="preserve"><value>Cr&#xE9;neaux &amp; b&#xE9;n&#xE9;volat</value></data>
+  <data name="Home_ShiftsDescription" xml:space="preserve"><value>Consulte les cr&#xE9;neaux disponibles, inscris-toi &#xE0; des r&#xF4;les d'&#xE9;v&#xE9;nement et suis ton planning. Vois ce qui est urgent et o&#xF9; l'aide est la plus n&#xE9;cessaire.</value></data>
+  <data name="Home_TeamsTitle" xml:space="preserve"><value>&#xC9;quipes &amp; groupes de travail</value></data>
+  <data name="Home_TeamsDescription" xml:space="preserve"><value>Des groupes de travail auto-organis&#xE9;s avec coordinateurs, ressources partag&#xE9;es et workflows d'approbation. Trouve ton &#xE9;quipe.</value></data>
+  <data name="Home_CampsTitle" xml:space="preserve"><value>Camps &amp; barrios</value></data>
+  <data name="Home_CampsDescription" xml:space="preserve"><value>Enregistre ton camp, d&#xE9;couvre tes voisins par ambiance ou zone sonore, et confirme ta participation chaque saison.</value></data>
+  <data name="Home_TicketsTitle" xml:space="preserve"><value>Billetterie &amp; &#xE9;v&#xE9;nements</value></data>
+  <data name="Home_TicketsDescription" xml:space="preserve"><value>Int&#xE9;gration de la vente de billets, mise en relation des participants et campagnes de r&#xE9;duction &#x2014; le tout li&#xE9; &#xE0; ton profil.</value></data>
+  <data name="Home_BudgetTitle" xml:space="preserve"><value>Transparence budg&#xE9;taire</value></data>
+  <data name="Home_BudgetDescription" xml:space="preserve"><value>Vois comment les fonds sont r&#xE9;partis entre les d&#xE9;partements. Planification budg&#xE9;taire ouverte avec des r&#xE9;sum&#xE9;s publics.</value></data>
+  <data name="Home_ProfilesTitle" xml:space="preserve"><value>Profils &amp; annuaire</value></data>
+  <data name="Home_ProfilesDescription" xml:space="preserve"><value>Des profils riches avec noms de playa, localisations et contacts d'urgence. Un calendrier d'anniversaires et un annuaire pour la communaut&#xE9;.</value></data>
+  <data name="Home_GettingStartedTitle" xml:space="preserve"><value>Inscription rapide</value></data>
+  <data name="Home_Step1" xml:space="preserve"><value>&lt;strong&gt;Connecte-toi&lt;/strong&gt; avec ton compte Google</value></data>
+  <data name="Home_Step2" xml:space="preserve"><value>&lt;strong&gt;Configure ton profil&lt;/strong&gt; &#x2014; nom, localisation et comment tu pr&#xE9;f&#xE8;res &#xEA;tre contact&#xE9;(e)</value></data>
+  <data name="Home_Step3" xml:space="preserve"><value>&lt;strong&gt;Accepte les bases&lt;/strong&gt; &#x2014; on s'occupe de la paperasse pour que tu puisses te concentrer sur la participation</value></data>
+  <data name="Home_GettingStartedSummary" xml:space="preserve"><value>&#xC7;a prend quelques minutes. Apr&#xE8;s, tu es dedans &#x2014; consulte les cr&#xE9;neaux, rejoins des &#xE9;quipes et commence &#xE0; contribuer.</value></data>
 
   <!-- ======================== -->
   <!-- Dashboard                -->

--- a/src/Humans.Web/Resources/SharedResource.it.resx
+++ b/src/Humans.Web/Resources/SharedResource.it.resx
@@ -105,23 +105,27 @@
   <!-- Home (Landing Page)      -->
   <!-- ======================== -->
   <data name="Home_Title" xml:space="preserve"><value>Home</value></data>
-  <data name="Home_Tagline" xml:space="preserve"><value>Portale membri di Nobodies Collective</value></data>
-  <data name="Home_CTA" xml:space="preserve"><value>Sei nuovo/a? Accedi per iniziare.</value></data>
-  <data name="Home_WhyTitle" xml:space="preserve"><value>Perché ne abbiamo bisogno?</value></data>
-  <data name="Home_WhyDescription" xml:space="preserve"><value>In quanto associazione registrata in Spagna, Nobodies Collective ha obblighi legali. Prima che qualcuno possa accedere alle risorse condivise, è necessario confermare l'accettazione delle nostre politiche. Questo sistema gestisce tutto in modo semplice e mantiene tutto aggiornato.</value></data>
-  <data name="Home_ComplianceTitle" xml:space="preserve"><value>Conformità legale</value></data>
-  <data name="Home_ComplianceDescription" xml:space="preserve"><value>Per accedere alle risorse dell'associazione, è necessario accettare le nostre politiche: trattamento dei dati GDPR, informativa sulla privacy, termini di consenso e licenza Creative Commons. Si tratta di una procedura una tantum (salvo aggiornamenti dei documenti).</value></data>
-  <data name="Home_ResourceAccessTitle" xml:space="preserve"><value>Accesso alle risorse</value></data>
-  <data name="Home_ResourceAccessDescription" xml:space="preserve"><value>Una volta completato il profilo e i consensi, avrà accesso alle risorse condivise: cartelle Google Drive, spazi di lavoro del team e strumenti di collaborazione. I team possono essere configurati per diversi gruppi di lavoro.</value></data>
-  <data name="Home_DocumentUpdatesTitle" xml:space="preserve"><value>Aggiornamenti dei documenti</value></data>
-  <data name="Home_DocumentUpdatesDescription" xml:space="preserve"><value>I documenti legali si evolvono. Quando le politiche cambiano in modo significativo, Le verrà chiesto di rivederle e fornire nuovamente il consenso. Questo garantisce che tutti operino secondo gli stessi accordi aggiornati.</value></data>
-  <data name="Home_VotingMembershipTitle" xml:space="preserve"><value>Membri con diritto di voto</value></data>
-  <data name="Home_VotingMembershipDescription" xml:space="preserve"><value>Il nostro statuto richiede un elenco di membri con diritto di voto per la governance (assemblee generali, elezioni, ecc.). Se desidera partecipare alla governance, può fare domanda per diventare membro votante. Questo è del tutto facoltativo.</value></data>
-  <data name="Home_GettingStartedTitle" xml:space="preserve"><value>Come iniziare</value></data>
-  <data name="Home_Step1" xml:space="preserve"><value>&lt;strong&gt;Acceda&lt;/strong&gt; con il Suo account Google</value></data>
-  <data name="Home_Step2" xml:space="preserve"><value>&lt;strong&gt;Completi il Suo profilo&lt;/strong&gt; con le informazioni di base</value></data>
-  <data name="Home_Step3" xml:space="preserve"><value>&lt;strong&gt;Esamini e acconsenta&lt;/strong&gt; ai nostri documenti legali (originali in spagnolo con traduzione in inglese)</value></data>
-  <data name="Home_GettingStartedSummary" xml:space="preserve"><value>Ecco fatto! Una volta forniti i consensi, avrà accesso alle risorse dell'associazione. Se è interessato a partecipare alla governance come membro votante, può facoltativamente presentare una domanda dalla Sua dashboard.</value></data>
+  <data name="Home_Tagline" xml:space="preserve"><value>Dove Nobodies Collective si organizza</value></data>
+  <data name="Home_HeroDescription" xml:space="preserve"><value>La piattaforma della comunit&#xE0; per i nostri humans &#x2014; iscriviti ai turni, unisciti ai team, registra il tuo camp e aiuta a far succedere le cose.</value></data>
+  <data name="Home_CTA" xml:space="preserve"><value>Inizia</value></data>
+  <data name="Home_FeaturesTitle" xml:space="preserve"><value>Tutto ci&#xF2; che serve per partecipare</value></data>
+  <data name="Home_ShiftsTitle" xml:space="preserve"><value>Turni &amp; volontariato</value></data>
+  <data name="Home_ShiftsDescription" xml:space="preserve"><value>Consulta i turni disponibili, iscriviti ai ruoli degli eventi e tieni traccia del tuo programma. Scopri cosa &#xE8; urgente e dove serve pi&#xF9; aiuto.</value></data>
+  <data name="Home_TeamsTitle" xml:space="preserve"><value>Team &amp; gruppi di lavoro</value></data>
+  <data name="Home_TeamsDescription" xml:space="preserve"><value>Gruppi di lavoro auto-organizzati con coordinatori, risorse condivise e flussi di approvazione. Trova il tuo team.</value></data>
+  <data name="Home_CampsTitle" xml:space="preserve"><value>Camp &amp; barrios</value></data>
+  <data name="Home_CampsDescription" xml:space="preserve"><value>Registra il tuo camp, scopri i vicini per atmosfera o zona sonora e conferma la tua partecipazione ogni stagione.</value></data>
+  <data name="Home_TicketsTitle" xml:space="preserve"><value>Biglietteria &amp; eventi</value></data>
+  <data name="Home_TicketsDescription" xml:space="preserve"><value>Integrazione con la vendita biglietti, abbinamento partecipanti e campagne sconto &#x2014; tutto collegato al tuo profilo.</value></data>
+  <data name="Home_BudgetTitle" xml:space="preserve"><value>Trasparenza del budget</value></data>
+  <data name="Home_BudgetDescription" xml:space="preserve"><value>Scopri come vengono distribuiti i fondi tra i dipartimenti. Pianificazione del budget aperta con riepiloghi pubblici.</value></data>
+  <data name="Home_ProfilesTitle" xml:space="preserve"><value>Profili &amp; directory</value></data>
+  <data name="Home_ProfilesDescription" xml:space="preserve"><value>Profili completi con nomi playa, localit&#xE0; e contatti di emergenza. Un calendario dei compleanni e una directory per la comunit&#xE0;.</value></data>
+  <data name="Home_GettingStartedTitle" xml:space="preserve"><value>Registrazione rapida</value></data>
+  <data name="Home_Step1" xml:space="preserve"><value>&lt;strong&gt;Accedi&lt;/strong&gt; con il tuo account Google</value></data>
+  <data name="Home_Step2" xml:space="preserve"><value>&lt;strong&gt;Configura il tuo profilo&lt;/strong&gt; &#x2014; nome, localit&#xE0; e come preferisci essere contattato/a</value></data>
+  <data name="Home_Step3" xml:space="preserve"><value>&lt;strong&gt;Accetta le basi&lt;/strong&gt; &#x2014; ci occupiamo noi delle pratiche cos&#xEC; puoi concentrarti sulla partecipazione</value></data>
+  <data name="Home_GettingStartedSummary" xml:space="preserve"><value>Ci vogliono un paio di minuti. Dopo, sei dentro &#x2014; sfoglia i turni, unisciti ai team e inizia a contribuire.</value></data>
 
   <!-- ======================== -->
   <!-- Dashboard                -->

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -105,23 +105,27 @@
   <!-- Home (Landing Page)      -->
   <!-- ======================== -->
   <data name="Home_Title" xml:space="preserve"><value>Home</value></data>
-  <data name="Home_Tagline" xml:space="preserve"><value>Membership portal for Nobodies Collective</value></data>
-  <data name="Home_CTA" xml:space="preserve"><value>New here? Sign in to get started.</value></data>
-  <data name="Home_WhyTitle" xml:space="preserve"><value>Why do we need this?</value></data>
-  <data name="Home_WhyDescription" xml:space="preserve"><value>As a registered association in Spain, Nobodies Collective has legal obligations. Before anyone can access shared resources, we need to confirm agreement to our policies. This system handles that simply and keeps everything current.</value></data>
-  <data name="Home_ComplianceTitle" xml:space="preserve"><value>Legal Compliance</value></data>
-  <data name="Home_ComplianceDescription" xml:space="preserve"><value>To access association resources, everyone needs to agree to our policies: GDPR data handling, privacy policy, consent terms, and Creative Commons licensing. This is a one-time process (unless documents are updated).</value></data>
-  <data name="Home_ResourceAccessTitle" xml:space="preserve"><value>Resource Access</value></data>
-  <data name="Home_ResourceAccessDescription" xml:space="preserve"><value>Once you've completed your profile and consents, you'll have access to shared resources: Google Drive folders, team workspaces, and collaboration tools. Teams can be configured for different working groups.</value></data>
-  <data name="Home_DocumentUpdatesTitle" xml:space="preserve"><value>Document Updates</value></data>
-  <data name="Home_DocumentUpdatesDescription" xml:space="preserve"><value>Legal documents evolve. When policies change in meaningful ways, you'll be asked to review and re-consent. This ensures everyone is working under the same current agreements.</value></data>
-  <data name="Home_VotingMembershipTitle" xml:space="preserve"><value>Voting Membership</value></data>
-  <data name="Home_VotingMembershipDescription" xml:space="preserve"><value>Our by-laws require a roll of voting members for governance (general assemblies, elections, etc.). If you'd like to participate in governance, you can apply to become a voting member. This is entirely optional.</value></data>
-  <data name="Home_GettingStartedTitle" xml:space="preserve"><value>Getting started</value></data>
+  <data name="Home_Tagline" xml:space="preserve"><value>Where Nobodies Collective organizes</value></data>
+  <data name="Home_HeroDescription" xml:space="preserve"><value>The community platform for our humans — sign up for shifts, join teams, register your camp, and help make things happen.</value></data>
+  <data name="Home_CTA" xml:space="preserve"><value>Get started</value></data>
+  <data name="Home_FeaturesTitle" xml:space="preserve"><value>Everything you need to participate</value></data>
+  <data name="Home_ShiftsTitle" xml:space="preserve"><value>Shifts &amp; Volunteering</value></data>
+  <data name="Home_ShiftsDescription" xml:space="preserve"><value>Browse open shifts, sign up for event roles, and track your schedule. See what's urgent and where help is needed most.</value></data>
+  <data name="Home_TeamsTitle" xml:space="preserve"><value>Teams &amp; Working Groups</value></data>
+  <data name="Home_TeamsDescription" xml:space="preserve"><value>Self-organizing working groups with coordinators, shared resources, and approval workflows. Find your crew.</value></data>
+  <data name="Home_CampsTitle" xml:space="preserve"><value>Camps &amp; Barrios</value></data>
+  <data name="Home_CampsDescription" xml:space="preserve"><value>Register your camp, discover neighbors by vibe or sound zone, and opt in each season. Find your spot on the map.</value></data>
+  <data name="Home_TicketsTitle" xml:space="preserve"><value>Ticketing &amp; Events</value></data>
+  <data name="Home_TicketsDescription" xml:space="preserve"><value>Ticket sales integration, attendee matching, and discount campaigns — all linked to your profile.</value></data>
+  <data name="Home_BudgetTitle" xml:space="preserve"><value>Budget Transparency</value></data>
+  <data name="Home_BudgetDescription" xml:space="preserve"><value>See how funds are allocated across departments. Open budget planning with public summaries everyone can review.</value></data>
+  <data name="Home_ProfilesTitle" xml:space="preserve"><value>Profiles &amp; Directory</value></data>
+  <data name="Home_ProfilesDescription" xml:space="preserve"><value>Rich profiles with burner names, locations, and emergency contacts. A birthday calendar and human directory for the community.</value></data>
+  <data name="Home_GettingStartedTitle" xml:space="preserve"><value>Quick onboarding</value></data>
   <data name="Home_Step1" xml:space="preserve"><value>&lt;strong&gt;Sign in&lt;/strong&gt; with your Google account</value></data>
-  <data name="Home_Step2" xml:space="preserve"><value>&lt;strong&gt;Complete your profile&lt;/strong&gt; with basic information</value></data>
-  <data name="Home_Step3" xml:space="preserve"><value>&lt;strong&gt;Review and consent&lt;/strong&gt; to our legal documents (Spanish originals with translations)</value></data>
-  <data name="Home_GettingStartedSummary" xml:space="preserve"><value>That's it! Once your consents are in place, you'll have access to association resources. If you're interested in participating in governance as a voting member, you can optionally submit an application from your dashboard.</value></data>
+  <data name="Home_Step2" xml:space="preserve"><value>&lt;strong&gt;Set up your profile&lt;/strong&gt; — name, location, and how you'd like to be reached</value></data>
+  <data name="Home_Step3" xml:space="preserve"><value>&lt;strong&gt;Agree to the basics&lt;/strong&gt; — we handle the paperwork so you can focus on participating</value></data>
+  <data name="Home_GettingStartedSummary" xml:space="preserve"><value>Takes a couple of minutes. After that, you're in — browse shifts, join teams, and start contributing.</value></data>
 
   <!-- ======================== -->
   <!-- Dashboard                -->

--- a/src/Humans.Web/Views/Home/Index.cshtml
+++ b/src/Humans.Web/Views/Home/Index.cshtml
@@ -2,93 +2,124 @@
     ViewData["Title"] = Localizer["Home_Title"].Value;
 }
 
-<div class="text-center mb-5">
+<section class="home-hero text-center">
     <h1 class="display-4">@Localizer["Nav_Brand"]</h1>
-    <p class="lead">@Localizer["Home_Tagline"]</p>
-
-    <div class="mt-4">
-        <p class="text-muted mb-3">@Localizer["Home_CTA"]</p>
-        <a asp-controller="Account" asp-action="Login" class="btn btn-primary btn-lg">
-            @Localizer["Login_Title"]
-        </a>
-    </div>
-</div>
+    <p class="lead home-hero-subtitle">@Localizer["Home_Tagline"]</p>
+    <p class="home-hero-description">@Localizer["Home_HeroDescription"]</p>
+    <a asp-controller="Account" asp-action="Login" class="btn btn-primary btn-lg mt-2">
+        <i class="fa-solid fa-right-to-bracket me-2"></i>@Localizer["Login_Title"]
+    </a>
+</section>
 
 <div class="row justify-content-center">
-    <div class="col-lg-8">
-        <div class="card mb-4">
-            <div class="card-body">
-                <h2 class="h4 mb-3">@Localizer["Home_WhyTitle"]</h2>
-                <p>
-                    @Localizer["Home_WhyDescription"]
-                </p>
+    <div class="col-lg-10">
+        <h2 class="text-center h3 mb-4">@Localizer["Home_FeaturesTitle"]</h2>
+
+        <div class="row g-4 mb-5">
+            <div class="col-md-6 col-lg-4">
+                <div class="card h-100 home-feature-card">
+                    <div class="card-body text-center">
+                        <div class="home-feature-icon">
+                            <i class="fa-solid fa-calendar-check"></i>
+                        </div>
+                        <h3 class="h5">@Localizer["Home_ShiftsTitle"]</h3>
+                        <p class="text-muted mb-0">@Localizer["Home_ShiftsDescription"]</p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-md-6 col-lg-4">
+                <div class="card h-100 home-feature-card">
+                    <div class="card-body text-center">
+                        <div class="home-feature-icon">
+                            <i class="fa-solid fa-people-group"></i>
+                        </div>
+                        <h3 class="h5">@Localizer["Home_TeamsTitle"]</h3>
+                        <p class="text-muted mb-0">@Localizer["Home_TeamsDescription"]</p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-md-6 col-lg-4">
+                <div class="card h-100 home-feature-card">
+                    <div class="card-body text-center">
+                        <div class="home-feature-icon">
+                            <i class="fa-solid fa-campground"></i>
+                        </div>
+                        <h3 class="h5">@Localizer["Home_CampsTitle"]</h3>
+                        <p class="text-muted mb-0">@Localizer["Home_CampsDescription"]</p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-md-6 col-lg-4">
+                <div class="card h-100 home-feature-card">
+                    <div class="card-body text-center">
+                        <div class="home-feature-icon">
+                            <i class="fa-solid fa-ticket"></i>
+                        </div>
+                        <h3 class="h5">@Localizer["Home_TicketsTitle"]</h3>
+                        <p class="text-muted mb-0">@Localizer["Home_TicketsDescription"]</p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-md-6 col-lg-4">
+                <div class="card h-100 home-feature-card">
+                    <div class="card-body text-center">
+                        <div class="home-feature-icon">
+                            <i class="fa-solid fa-coins"></i>
+                        </div>
+                        <h3 class="h5">@Localizer["Home_BudgetTitle"]</h3>
+                        <p class="text-muted mb-0">@Localizer["Home_BudgetDescription"]</p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-md-6 col-lg-4">
+                <div class="card h-100 home-feature-card">
+                    <div class="card-body text-center">
+                        <div class="home-feature-icon">
+                            <i class="fa-solid fa-address-card"></i>
+                        </div>
+                        <h3 class="h5">@Localizer["Home_ProfilesTitle"]</h3>
+                        <p class="text-muted mb-0">@Localizer["Home_ProfilesDescription"]</p>
+                    </div>
+                </div>
             </div>
         </div>
 
-        <div class="row">
-            <div class="col-md-6 mb-4">
-                <div class="card h-100">
+        <div class="row justify-content-center mb-5">
+            <div class="col-lg-8">
+                <div class="card home-onboarding-card">
                     <div class="card-body">
-                        <h3 class="h5">@Localizer["Home_ComplianceTitle"]</h3>
-                        <p class="text-muted mb-0">
-                            @Localizer["Home_ComplianceDescription"]
-                        </p>
-                    </div>
-                </div>
-            </div>
-
-            <div class="col-md-6 mb-4">
-                <div class="card h-100">
-                    <div class="card-body">
-                        <h3 class="h5">@Localizer["Home_ResourceAccessTitle"]</h3>
-                        <p class="text-muted mb-0">
-                            @Localizer["Home_ResourceAccessDescription"]
-                        </p>
-                    </div>
-                </div>
-            </div>
-
-            <div class="col-md-6 mb-4">
-                <div class="card h-100">
-                    <div class="card-body">
-                        <h3 class="h5">@Localizer["Home_DocumentUpdatesTitle"]</h3>
-                        <p class="text-muted mb-0">
-                            @Localizer["Home_DocumentUpdatesDescription"]
-                        </p>
-                    </div>
-                </div>
-            </div>
-
-            <div class="col-md-6 mb-4">
-                <div class="card h-100">
-                    <div class="card-body">
-                        <h3 class="h5">@Localizer["Home_VotingMembershipTitle"]</h3>
-                        <p class="text-muted mb-0">
-                            @Localizer["Home_VotingMembershipDescription"]
+                        <h2 class="h4 mb-3 text-center">@Localizer["Home_GettingStartedTitle"]</h2>
+                        <div class="home-steps">
+                            <div class="home-step">
+                                <span class="home-step-number">1</span>
+                                <span>@Html.Raw(Localizer["Home_Step1"].Value)</span>
+                            </div>
+                            <div class="home-step">
+                                <span class="home-step-number">2</span>
+                                <span>@Html.Raw(Localizer["Home_Step2"].Value)</span>
+                            </div>
+                            <div class="home-step">
+                                <span class="home-step-number">3</span>
+                                <span>@Html.Raw(Localizer["Home_Step3"].Value)</span>
+                            </div>
+                        </div>
+                        <p class="mb-0 text-muted text-center mt-3">
+                            @Localizer["Home_GettingStartedSummary"]
                         </p>
                     </div>
                 </div>
             </div>
         </div>
 
-        <div class="card">
-            <div class="card-body">
-                <h2 class="h4 mb-3">@Localizer["Home_GettingStartedTitle"]</h2>
-                <ol class="mb-3">
-                    <li class="mb-2">
-                        @Html.Raw(Localizer["Home_Step1"].Value)
-                    </li>
-                    <li class="mb-2">
-                        @Html.Raw(Localizer["Home_Step2"].Value)
-                    </li>
-                    <li class="mb-2">
-                        @Html.Raw(Localizer["Home_Step3"].Value)
-                    </li>
-                </ol>
-                <p class="mb-0 text-muted">
-                    @Localizer["Home_GettingStartedSummary"]
-                </p>
-            </div>
+        <div class="text-center mb-4">
+            <a asp-controller="Account" asp-action="Login" class="btn btn-primary btn-lg">
+                <i class="fa-solid fa-right-to-bracket me-2"></i>@Localizer["Home_CTA"]
+            </a>
         </div>
     </div>
 </div>

--- a/src/Humans.Web/wwwroot/css/site.css
+++ b/src/Humans.Web/wwwroot/css/site.css
@@ -688,14 +688,100 @@ a:hover {
     background: var(--h-sepia-light);
 }
 
-/* --- Home hero section --- */
-.text-center.mb-5 {
-    padding: 3rem 0 2rem;
+/* --- Home (unauthenticated landing page) --- */
+.home-hero {
+    padding: 3.5rem 1rem 2.5rem;
+    margin-bottom: 2rem;
 }
 
-.text-center.mb-5 .display-4 {
+.home-hero .display-4 {
     color: var(--h-aged-ink);
     margin-bottom: 0.5rem;
+}
+
+.home-hero-subtitle {
+    font-size: 1.35rem;
+    margin-bottom: 0.75rem;
+}
+
+.home-hero-description {
+    max-width: 600px;
+    margin: 0 auto 1rem;
+    color: var(--h-sepia);
+    font-size: 1.05rem;
+    line-height: 1.7;
+}
+
+/* Feature cards grid */
+.home-feature-card {
+    border-color: var(--h-border-light);
+    transition: box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.home-feature-card:hover {
+    box-shadow: var(--h-shadow-lg);
+    transform: translateY(-2px);
+}
+
+.home-feature-icon {
+    width: 56px;
+    height: 56px;
+    margin: 0 auto 1rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    background-color: var(--h-parchment);
+    color: var(--h-gold-dark);
+    font-size: 1.4rem;
+}
+
+/* Onboarding steps */
+.home-onboarding-card {
+    border-left: 4px solid var(--h-gold);
+}
+
+.home-steps {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.home-step {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    font-size: 1rem;
+}
+
+.home-step-number {
+    flex-shrink: 0;
+    width: 32px;
+    height: 32px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    background-color: var(--h-gold);
+    color: var(--h-aged-ink);
+    font-weight: 700;
+    font-size: 0.9rem;
+    font-family: var(--h-font-body);
+}
+
+/* Responsive: stack feature cards nicely on mobile */
+@media (max-width: 767.98px) {
+    .home-hero {
+        padding: 2rem 0.5rem 1.5rem;
+    }
+
+    .home-hero .display-4 {
+        font-size: 2.2rem;
+    }
+
+    .home-hero-subtitle {
+        font-size: 1.1rem;
+    }
 }
 
 /* --- Decorative rule — used as section separator --- */


### PR DESCRIPTION
## Summary
- **#337** — Redesign unauthenticated homepage from compliance-focused to community platform showcase

Replaces four compliance-focused feature cards (Legal Compliance, Resource Access, Document Updates, Voting Membership) with six community platform features: Shifts & Volunteering, Teams & Working Groups, Camps & Barrios, Ticketing & Events, Budget Transparency, and Profiles & Directory.

Hero section now leads with "Where Nobodies Collective organizes." Legal consent is folded into the quick onboarding steps as a minor note. All five locale resource files updated (en, es, de, fr, it). New homepage CSS with feature card grid, numbered onboarding steps, and mobile-responsive layout using existing design tokens.

## Spec Compliance
All acceptance criteria verified:
- **#337**: PASS (6/6 criteria)
  - 6 non-governance feature cards (shifts, teams, camps, ticketing, budget, profiles)
  - Legal/consent demoted to onboarding step 3 ("Agree to the basics")
  - Hero communicates community platform identity
  - Two prominent sign-in CTAs (hero + bottom)
  - Responsive Bootstrap grid with mobile breakpoint CSS
  - No authenticated view changes (Dashboard untouched)

## Code Review
Self-reviewed against CODE_REVIEW_RULES.md. No critical issues. Pure view/CSS/resource change — no controller, service, or database modifications.

## Test plan
- [ ] Visit homepage while logged out — verify new hero, 6 feature cards, onboarding steps, and CTA buttons
- [ ] Switch language to es/de/fr/it — verify translated content renders correctly
- [ ] Resize browser to mobile width — verify cards stack and hero text scales
- [ ] Log in — verify dashboard (authenticated view) is unchanged
- [ ] Check that sign-in buttons link to the login page

🤖 Generated with [Claude Code](https://claude.com/claude-code) sprint swarm