### PR TITLE
Extract repeated patterns & CSS variable cleanup (#334, #335, #349)

### DIFF
--- a/src/Humans.Application/Interfaces/IShiftSignupService.cs
+++ b/src/Humans.Application/Interfaces/IShiftSignupService.cs
@@ -1,4 +1,5 @@
 using Humans.Domain.Entities;
+using Humans.Domain.Enums;
 
 namespace Humans.Application.Interfaces;
 
@@ -95,6 +96,39 @@ public interface IShiftSignupService
     /// Gets all no-show signups for a user, with shift/team context and reviewer info.
     /// </summary>
     Task<IReadOnlyList<ShiftSignup>> GetNoShowHistoryAsync(Guid userId);
+
+    /// <summary>
+    /// Gets active signup statuses (Confirmed or Pending) for a user in a specific event.
+    /// Returns a tuple of (shiftIds the user is signed up for, shiftId → status dictionary).
+    /// This is the single source of truth for "which shifts has this user actively signed up for?"
+    /// </summary>
+    Task<(HashSet<Guid> ShiftIds, Dictionary<Guid, SignupStatus> Statuses)> GetActiveSignupStatusesAsync(
+        Guid userId, Guid eventSettingsId);
+}
+
+/// <summary>
+/// Helper for resolving active signup statuses from an already-loaded list of signups.
+/// Use this when the caller already has signups from GetByUserAsync and needs the filtered result
+/// without an additional DB round-trip.
+/// </summary>
+public static class ShiftSignupHelper
+{
+    /// <summary>
+    /// Filters signups to active statuses (Confirmed or Pending) and returns shift IDs and status dictionary.
+    /// Single source of truth for "active signup statuses" filtering logic.
+    /// </summary>
+    public static (HashSet<Guid> ShiftIds, Dictionary<Guid, SignupStatus> Statuses) ResolveActiveStatuses(
+        IReadOnlyList<ShiftSignup> signups)
+    {
+        var active = signups
+            .Where(s => s.Status is SignupStatus.Confirmed or SignupStatus.Pending)
+            .ToList();
+
+        var shiftIds = active.Select(s => s.ShiftId).ToHashSet();
+        var statuses = active.ToDictionary(s => s.ShiftId, s => s.Status);
+
+        return (shiftIds, statuses);
+    }
 }
 
 /// <summary>

--- a/src/Humans.Infrastructure/Services/ShiftSignupService.cs
+++ b/src/Humans.Infrastructure/Services/ShiftSignupService.cs
@@ -774,6 +774,13 @@ public class ShiftSignupService : IShiftSignupService
             .ToListAsync();
     }
 
+    public async Task<(HashSet<Guid> ShiftIds, Dictionary<Guid, SignupStatus> Statuses)> GetActiveSignupStatusesAsync(
+        Guid userId, Guid eventSettingsId)
+    {
+        var signups = await GetByUserAsync(userId, eventSettingsId);
+        return ShiftSignupHelper.ResolveActiveStatuses(signups);
+    }
+
     private async Task<ShiftSignup?> GetSignupWithShiftAsync(Guid signupId)
     {
         return await _dbContext.ShiftSignups

--- a/src/Humans.Web/Controllers/GoogleController.cs
+++ b/src/Humans.Web/Controllers/GoogleController.cs
@@ -497,7 +497,7 @@ public class GoogleController : HumansControllerBase
         else
         {
             // Evict the nobodies.team email cache so the ViewComponent reflects the new email immediately
-            _cache.Remove("NobodiesTeamEmails_All");
+            _cache.Remove(ViewComponents.NobodiesEmailBadgeViewComponent.CacheKey);
 
             if (result.RecoveryEmail is not null)
             {

--- a/src/Humans.Web/Controllers/GoogleController.cs
+++ b/src/Humans.Web/Controllers/GoogleController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Caching.Memory;
 using Humans.Application.DTOs;
 using Humans.Application.Interfaces;
 using Humans.Domain.Constants;
@@ -20,6 +21,7 @@ public class GoogleController : HumansControllerBase
     private readonly ITeamResourceService _teamResourceService;
     private readonly IEmailProvisioningService _emailProvisioningService;
     private readonly IGoogleAdminService _googleAdminService;
+    private readonly IMemoryCache _cache;
     private readonly ILogger<GoogleController> _logger;
 
     public GoogleController(
@@ -29,6 +31,7 @@ public class GoogleController : HumansControllerBase
         ITeamResourceService teamResourceService,
         IEmailProvisioningService emailProvisioningService,
         IGoogleAdminService googleAdminService,
+        IMemoryCache cache,
         ILogger<GoogleController> logger)
         : base(userManager)
     {
@@ -37,6 +40,7 @@ public class GoogleController : HumansControllerBase
         _teamResourceService = teamResourceService;
         _emailProvisioningService = emailProvisioningService;
         _googleAdminService = googleAdminService;
+        _cache = cache;
         _logger = logger;
     }
 
@@ -490,13 +494,19 @@ public class GoogleController : HumansControllerBase
         {
             SetError(result.ErrorMessage ?? "Provisioning failed.");
         }
-        else if (result.RecoveryEmail is not null)
-        {
-            SetSuccess($"Account {result.FullEmail} provisioned and linked. Credentials sent to {result.RecoveryEmail}.");
-        }
         else
         {
-            SetSuccess($"Account {result.FullEmail} provisioned and linked. No recovery email found — credentials not sent.");
+            // Evict the nobodies.team email cache so the ViewComponent reflects the new email immediately
+            _cache.Remove("NobodiesTeamEmails_All");
+
+            if (result.RecoveryEmail is not null)
+            {
+                SetSuccess($"Account {result.FullEmail} provisioned and linked. Credentials sent to {result.RecoveryEmail}.");
+            }
+            else
+            {
+                SetSuccess($"Account {result.FullEmail} provisioned and linked. No recovery email found — credentials not sent.");
+            }
         }
 
         return RedirectToAction("AdminDetail", "Profile", new { id });

--- a/src/Humans.Web/Controllers/ProfileController.cs
+++ b/src/Humans.Web/Controllers/ProfileController.cs
@@ -1142,10 +1142,8 @@ public class ProfileController : HumansControllerBase
         var allRows = await _profileService.GetFilteredHumansAsync(search, filter);
         var totalCount = allRows.Count;
 
-        // Load @nobodies.team email status for all users (fine at ~500 users)
-        var nobodiesTeamByUser = await _userEmailService.GetNobodiesTeamEmailStatusByUserAsync();
-
         // Materialize for flexible sorting (fine at ~500 users)
+        // nobodies.team email status is now resolved by NobodiesEmailBadgeViewComponent in the view
         var allMatching = allRows.Select(r => new AdminHumanViewModel
         {
             Id = r.UserId,
@@ -1156,9 +1154,7 @@ public class ProfileController : HumansControllerBase
             LastLoginAt = r.LastLoginAt,
             HasProfile = r.HasProfile,
             IsApproved = r.IsApproved,
-            MembershipStatus = r.MembershipStatus,
-            HasNobodiesTeamEmail = nobodiesTeamByUser.ContainsKey(r.UserId),
-            NobodiesTeamEmailIsPrimary = nobodiesTeamByUser.TryGetValue(r.UserId, out var isPrimary) && isPrimary
+            MembershipStatus = r.MembershipStatus
         }).ToList();
 
         var ascending = !string.Equals(dir, "desc", StringComparison.OrdinalIgnoreCase);
@@ -1264,8 +1260,7 @@ public class ProfileController : HumansControllerBase
             }).ToList(),
         };
 
-        // Check for @nobodies.team email
-        viewModel.NobodiesTeamEmail = await _userEmailService.GetNobodiesTeamEmailAsync(id);
+        // nobodies.team email is now resolved by NobodiesEmailBadgeViewComponent in the view
 
         return View("AdminDetail", viewModel);
     }

--- a/src/Humans.Web/Controllers/ProfileController.cs
+++ b/src/Humans.Web/Controllers/ProfileController.cs
@@ -21,6 +21,7 @@ using Humans.Web.Authorization;
 using Humans.Web.Extensions;
 using Humans.Web.Models;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
 using NodaTime;
 
 namespace Humans.Web.Controllers;
@@ -46,6 +47,7 @@ public class ProfileController : HumansControllerBase
     private readonly ILogger<ProfileController> _logger;
     private readonly IStringLocalizer<SharedResource> _localizer;
     private readonly HumansDbContext _dbContext;
+    private readonly IMemoryCache _cache;
     private readonly IClock _clock;
 
     private const int MaxProfilePictureUploadBytes = 20 * 1024 * 1024; // 20MB upload limit
@@ -89,6 +91,7 @@ public class ProfileController : HumansControllerBase
         ILogger<ProfileController> logger,
         IStringLocalizer<SharedResource> localizer,
         HumansDbContext dbContext,
+        IMemoryCache cache,
         IClock clock)
         : base(userManager)
     {
@@ -109,6 +112,7 @@ public class ProfileController : HumansControllerBase
         _logger = logger;
         _localizer = localizer;
         _dbContext = dbContext;
+        _cache = cache;
         _clock = clock;
     }
 
@@ -536,6 +540,7 @@ public class ProfileController : HumansControllerBase
         {
             var decodedToken = HttpUtility.UrlDecode(token);
             var result = await _userEmailService.VerifyEmailAsync(userId, decodedToken);
+            _cache.Remove(ViewComponents.NobodiesEmailBadgeViewComponent.CacheKey);
 
             if (result.MergeRequestCreated)
             {
@@ -586,6 +591,7 @@ public class ProfileController : HumansControllerBase
         try
         {
             await _userEmailService.SetNotificationTargetAsync(user.Id, emailId);
+            _cache.Remove(ViewComponents.NobodiesEmailBadgeViewComponent.CacheKey);
             SetSuccess(_localizer["Profile_NotificationTargetUpdated"].Value);
         }
         catch (Exception ex) when (ex is ValidationException or InvalidOperationException)
@@ -636,6 +642,7 @@ public class ProfileController : HumansControllerBase
         try
         {
             await _userEmailService.DeleteEmailAsync(user.Id, emailId);
+            _cache.Remove(ViewComponents.NobodiesEmailBadgeViewComponent.CacheKey);
             SetSuccess(_localizer["Profile_EmailDeleted"].Value);
         }
         catch (Exception ex) when (ex is ValidationException or InvalidOperationException)

--- a/src/Humans.Web/Controllers/ShiftsController.cs
+++ b/src/Humans.Web/Controllers/ShiftsController.cs
@@ -60,13 +60,7 @@ public class ShiftsController : HumansControllerBase
         if (!es.IsShiftBrowsingOpen && !isPrivileged && !hasSignups)
             return View("BrowsingClosed");
 
-        var userSignupShiftIds = userSignups
-            .Where(s => s.Status is SignupStatus.Confirmed or SignupStatus.Pending)
-            .Select(s => s.ShiftId)
-            .ToHashSet();
-        var userSignupStatuses = userSignups
-            .Where(s => s.Status is SignupStatus.Confirmed or SignupStatus.Pending)
-            .ToDictionary(s => s.ShiftId, s => s.Status);
+        var (userSignupShiftIds, userSignupStatuses) = ShiftSignupHelper.ResolveActiveStatuses(userSignups);
 
         // Parse date range filters
         LocalDate? filterFromDate = null;

--- a/src/Humans.Web/Controllers/TeamAdminController.cs
+++ b/src/Humans.Web/Controllers/TeamAdminController.cs
@@ -21,7 +21,6 @@ public class TeamAdminController : HumansTeamControllerBase
     private readonly ITeamResourceService _teamResourceService;
     private readonly IGoogleSyncService _googleSyncService;
     private readonly IProfileService _profileService;
-    private readonly IUserEmailService _userEmailService;
     private readonly IEmailProvisioningService _emailProvisioningService;
     private readonly ISystemTeamSync _systemTeamSyncJob;
     private readonly ILogger<TeamAdminController> _logger;
@@ -32,7 +31,6 @@ public class TeamAdminController : HumansTeamControllerBase
         ITeamResourceService teamResourceService,
         IGoogleSyncService googleSyncService,
         IProfileService profileService,
-        IUserEmailService userEmailService,
         IEmailProvisioningService emailProvisioningService,
         UserManager<User> userManager,
         ISystemTeamSync systemTeamSyncJob,
@@ -44,7 +42,6 @@ public class TeamAdminController : HumansTeamControllerBase
         _teamResourceService = teamResourceService;
         _googleSyncService = googleSyncService;
         _profileService = profileService;
-        _userEmailService = userEmailService;
         _emailProvisioningService = emailProvisioningService;
         _systemTeamSyncJob = systemTeamSyncJob;
         _logger = logger;
@@ -129,9 +126,7 @@ public class TeamAdminController : HumansTeamControllerBase
             p => p.UserId,
             p => Url.Action(nameof(ProfileController.Picture), "Profile", new { id = p.ProfileId, v = p.UpdatedAtTicks })!);
 
-        // Batch-load @nobodies.team email status for all displayed members
-        var nobodiesEmails = await _userEmailService.GetNobodiesTeamEmailsByUserIdsAsync(memberUserIds);
-
+        // nobodies.team email is now resolved by NobodiesEmailBadgeViewComponent in the view
         var members = pagedMembers
             .Select(m => new TeamMemberViewModel
             {
@@ -143,8 +138,7 @@ public class TeamAdminController : HumansTeamControllerBase
                 CustomProfilePictureUrl = customPictureByUserId.GetValueOrDefault(m.UserId),
                 Role = m.Role,
                 JoinedAt = m.JoinedAt.ToDateTimeUtc(),
-                IsCoordinator = m.Role == TeamMemberRole.Coordinator,
-                NobodiesTeamEmail = nobodiesEmails.GetValueOrDefault(m.UserId)
+                IsCoordinator = m.Role == TeamMemberRole.Coordinator
             }).ToList();
 
         var pendingRequests = await _teamService.GetPendingRequestsForTeamAsync(team.Id);

--- a/src/Humans.Web/Controllers/TeamAdminController.cs
+++ b/src/Humans.Web/Controllers/TeamAdminController.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Localization;
 using Humans.Application.Interfaces;
 using Humans.Web.Authorization;
@@ -23,6 +24,7 @@ public class TeamAdminController : HumansTeamControllerBase
     private readonly IProfileService _profileService;
     private readonly IEmailProvisioningService _emailProvisioningService;
     private readonly ISystemTeamSync _systemTeamSyncJob;
+    private readonly IMemoryCache _cache;
     private readonly ILogger<TeamAdminController> _logger;
     private readonly IStringLocalizer<SharedResource> _localizer;
 
@@ -34,6 +36,7 @@ public class TeamAdminController : HumansTeamControllerBase
         IEmailProvisioningService emailProvisioningService,
         UserManager<User> userManager,
         ISystemTeamSync systemTeamSyncJob,
+        IMemoryCache cache,
         ILogger<TeamAdminController> logger,
         IStringLocalizer<SharedResource> localizer)
         : base(userManager, teamService)
@@ -44,6 +47,7 @@ public class TeamAdminController : HumansTeamControllerBase
         _profileService = profileService;
         _emailProvisioningService = emailProvisioningService;
         _systemTeamSyncJob = systemTeamSyncJob;
+        _cache = cache;
         _logger = logger;
         _localizer = localizer;
     }
@@ -306,13 +310,19 @@ public class TeamAdminController : HumansTeamControllerBase
         {
             SetError(result.ErrorMessage ?? "Provisioning failed.");
         }
-        else if (result.RecoveryEmail is not null)
-        {
-            SetSuccess($"Account {result.FullEmail} provisioned and linked. Credentials sent to {result.RecoveryEmail}.");
-        }
         else
         {
-            SetSuccess($"Account {result.FullEmail} provisioned and linked. No recovery email found — credentials not sent.");
+            // Evict the nobodies.team email cache so the ViewComponent reflects the new email immediately
+            _cache.Remove("NobodiesTeamEmails_All");
+
+            if (result.RecoveryEmail is not null)
+            {
+                SetSuccess($"Account {result.FullEmail} provisioned and linked. Credentials sent to {result.RecoveryEmail}.");
+            }
+            else
+            {
+                SetSuccess($"Account {result.FullEmail} provisioned and linked. No recovery email found — credentials not sent.");
+            }
         }
 
         return RedirectToAction(nameof(Members), new { slug });

--- a/src/Humans.Web/Controllers/TeamAdminController.cs
+++ b/src/Humans.Web/Controllers/TeamAdminController.cs
@@ -313,7 +313,7 @@ public class TeamAdminController : HumansTeamControllerBase
         else
         {
             // Evict the nobodies.team email cache so the ViewComponent reflects the new email immediately
-            _cache.Remove("NobodiesTeamEmails_All");
+            _cache.Remove(ViewComponents.NobodiesEmailBadgeViewComponent.CacheKey);
 
             if (result.RecoveryEmail is not null)
             {

--- a/src/Humans.Web/Controllers/VolController.cs
+++ b/src/Humans.Web/Controllers/VolController.cs
@@ -136,13 +136,7 @@ public class VolController : HumansControllerBase
             if (!es.IsShiftBrowsingOpen && !isPrivileged && !hasSignups)
                 return View("BrowsingClosed");
 
-            var userSignupShiftIds = userSignups
-                .Where(s => s.Status is SignupStatus.Confirmed or SignupStatus.Pending)
-                .Select(s => s.ShiftId)
-                .ToHashSet();
-            var userSignupStatuses = userSignups
-                .Where(s => s.Status is SignupStatus.Confirmed or SignupStatus.Pending)
-                .ToDictionary(s => s.ShiftId, s => s.Status);
+            var (userSignupShiftIds, userSignupStatuses) = ShiftSignupHelper.ResolveActiveStatuses(userSignups);
 
             // Parse date range filters
             LocalDate? filterFromDate = null;
@@ -485,13 +479,7 @@ public class VolController : HumansControllerBase
                 });
             }
 
-            var userSignups = await _signupService.GetByUserAsync(user.Id, es.Id);
-            var userSignupShiftIds = userSignups
-                .Where(s => s.Status is SignupStatus.Confirmed or SignupStatus.Pending)
-                .Select(s => s.ShiftId).ToHashSet();
-            var userSignupStatuses = userSignups
-                .Where(s => s.Status is SignupStatus.Confirmed or SignupStatus.Pending)
-                .ToDictionary(s => s.ShiftId, s => s.Status);
+            var (userSignupShiftIds, userSignupStatuses) = await _signupService.GetActiveSignupStatusesAsync(user.Id, es.Id);
 
             var pendingRequests = isCoordinator
                 ? (await _teamService.GetPendingRequestsForTeamAsync(child.Id)).ToList()

--- a/src/Humans.Web/ViewComponents/NobodiesEmailBadgeViewComponent.cs
+++ b/src/Humans.Web/ViewComponents/NobodiesEmailBadgeViewComponent.cs
@@ -20,7 +20,7 @@ public class NobodiesEmailBadgeViewComponent : ViewComponent
     private readonly IUserEmailService _userEmailService;
     private readonly IMemoryCache _cache;
 
-    private const string CacheKey = "NobodiesTeamEmails_All";
+    public const string CacheKey = "NobodiesTeamEmails_All";
     private static readonly TimeSpan CacheTtl = TimeSpan.FromMinutes(2);
 
     public NobodiesEmailBadgeViewComponent(

--- a/src/Humans.Web/ViewComponents/NobodiesEmailBadgeViewComponent.cs
+++ b/src/Humans.Web/ViewComponents/NobodiesEmailBadgeViewComponent.cs
@@ -1,0 +1,88 @@
+using Humans.Application.Interfaces;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Humans.Web.ViewComponents;
+
+/// <summary>
+/// Renders a nobodies.team email badge or status indicator for a user.
+/// Uses IMemoryCache with short TTL to prevent N+1 queries on list pages.
+///
+/// Modes:
+///   "badge"     — icon badge (ProfileCard)
+///   "status"    — warning badge when email not primary (AdminList)
+///   "email"     — show actual email address
+///   "provision" — show email or provisioning form (TeamAdmin/Members)
+///   "detail"    — show email + linked badge, or provisioning form (AdminDetail)
+/// </summary>
+public class NobodiesEmailBadgeViewComponent : ViewComponent
+{
+    private readonly IUserEmailService _userEmailService;
+    private readonly IMemoryCache _cache;
+
+    private const string CacheKey = "NobodiesTeamEmails_All";
+    private static readonly TimeSpan CacheTtl = TimeSpan.FromMinutes(2);
+
+    public NobodiesEmailBadgeViewComponent(
+        IUserEmailService userEmailService,
+        IMemoryCache cache)
+    {
+        _userEmailService = userEmailService;
+        _cache = cache;
+    }
+
+    /// <summary>
+    /// Renders a nobodies.team email badge for the given user.
+    /// </summary>
+    /// <param name="userId">The user to check.</param>
+    /// <param name="mode">Display mode — see class doc.</param>
+    /// <param name="teamSlug">Team slug for provisioning form (provision mode only).</param>
+    /// <param name="displayName">User display name for confirm dialog (provision mode only).</param>
+    public async Task<IViewComponentResult> InvokeAsync(
+        Guid userId,
+        string mode = "badge",
+        string? teamSlug = null,
+        string? displayName = null)
+    {
+        var allStatuses = await GetCachedStatusesAsync();
+
+        var hasEmail = allStatuses.TryGetValue(userId, out var info);
+
+        ViewBag.UserId = userId;
+        ViewBag.HasEmail = hasEmail;
+        ViewBag.Email = hasEmail ? info.Email : null;
+        ViewBag.IsPrimary = hasEmail && info.IsPrimary;
+        ViewBag.Mode = mode;
+        ViewBag.TeamSlug = teamSlug;
+        ViewBag.DisplayName = displayName;
+
+        return View();
+    }
+
+    private async Task<Dictionary<Guid, (string Email, bool IsPrimary)>> GetCachedStatusesAsync()
+    {
+        if (_cache.TryGetValue(CacheKey, out Dictionary<Guid, (string Email, bool IsPrimary)>? cached) && cached is not null)
+            return cached;
+
+        // Load all nobodies.team email statuses at once — fine at ~500 users
+        var statusByUser = await _userEmailService.GetNobodiesTeamEmailStatusByUserAsync();
+
+        // Also load actual email addresses for users who have them
+        var userIds = statusByUser.Keys.ToList();
+        var emailsByUser = userIds.Count > 0
+            ? await _userEmailService.GetNobodiesTeamEmailsByUserIdsAsync(userIds)
+            : new Dictionary<Guid, string>();
+
+        var result = new Dictionary<Guid, (string Email, bool IsPrimary)>();
+        foreach (var (uid, isPrimary) in statusByUser)
+        {
+            if (emailsByUser.TryGetValue(uid, out var email))
+            {
+                result[uid] = (email, isPrimary);
+            }
+        }
+
+        _cache.Set(CacheKey, result, CacheTtl);
+        return result;
+    }
+}

--- a/src/Humans.Web/ViewComponents/ProfileCardViewComponent.cs
+++ b/src/Humans.Web/ViewComponents/ProfileCardViewComponent.cs
@@ -96,12 +96,7 @@ public class ProfileCardViewComponent : ViewComponent
         }
         var visibleEmails = await _userEmailService.GetVisibleEmailsAsync(userId, accessLevel);
 
-        // Check if user has a @nobodies.team email (from all emails, not just visible)
-        var hasNobodiesTeamEmail = await _dbContext.UserEmails
-            .AsNoTracking()
-            .AnyAsync(ue => ue.UserId == userId
-                && ue.IsVerified
-                && EF.Functions.ILike(ue.Email, "%@nobodies.team"));
+        // nobodies.team email badge is now handled by NobodiesEmailBadgeViewComponent
 
         // Get volunteer history entries
         var volunteerHistory = profile is not null
@@ -157,7 +152,7 @@ public class ProfileCardViewComponent : ViewComponent
             EmergencyContactRelationship = canViewLegalName ? profile?.EmergencyContactRelationship : null,
             HasPendingConsents = membershipSnapshot.PendingConsentCount > 0,
             PendingConsentCount = membershipSnapshot.PendingConsentCount,
-            HasNobodiesTeamEmail = hasNobodiesTeamEmail,
+            // HasNobodiesTeamEmail resolved by NobodiesEmailBadgeViewComponent in the view
             ViewMode = viewMode,
             CanViewLegalName = canViewLegalName,
             UserEmails = visibleEmails.Select(e => new UserEmailDisplayViewModel

--- a/src/Humans.Web/Views/Budget/Summary.cshtml
+++ b/src/Humans.Web/Views/Budget/Summary.cshtml
@@ -173,15 +173,21 @@
     }
 
     function renderBudgetCharts() {
+        var cs = getComputedStyle(document.documentElement);
+        var cv = function(n) { return cs.getPropertyValue(n).trim(); };
         var incomeColors = [
-            '#198754', '#20c997', '#0dcaf0', '#0d6efd', '#6f42c1',
-            '#d63384', '#ffc107', '#fd7e14', '#6610f2', '#adb5bd',
-            '#495057', '#e83e8c', '#17a2b8', '#28a745', '#007bff'
+            cv('--h-chart-cat-1'), cv('--h-chart-cat-2'), cv('--h-chart-cat-3'),
+            cv('--h-chart-cat-4'), cv('--h-chart-cat-5'), cv('--h-chart-cat-6'),
+            cv('--h-chart-cat-7'), cv('--h-chart-cat-8'), cv('--h-chart-cat-9'),
+            cv('--h-chart-cat-10'), cv('--h-chart-cat-11'), cv('--h-chart-cat-12'),
+            cv('--h-chart-cat-13'), cv('--h-chart-cat-14'), cv('--h-chart-cat-15')
         ];
         var expenseColors = [
-            '#dc3545', '#fd7e14', '#ffc107', '#e83e8c', '#6f42c1',
-            '#0d6efd', '#0dcaf0', '#20c997', '#198754', '#adb5bd',
-            '#495057', '#d63384', '#17a2b8', '#6610f2', '#28a745'
+            cv('--h-chart-exp-1'), cv('--h-chart-exp-2'), cv('--h-chart-exp-3'),
+            cv('--h-chart-exp-4'), cv('--h-chart-exp-5'), cv('--h-chart-exp-6'),
+            cv('--h-chart-exp-7'), cv('--h-chart-exp-8'), cv('--h-chart-exp-9'),
+            cv('--h-chart-exp-10'), cv('--h-chart-exp-11'), cv('--h-chart-exp-12'),
+            cv('--h-chart-exp-13'), cv('--h-chart-exp-14'), cv('--h-chart-exp-15')
         ];
         var tooltipCallback = {
             label: function(ctx) {
@@ -207,7 +213,7 @@
                         data: incomeData,
                         backgroundColor: incomeColors.slice(0, incomeData.length),
                         borderWidth: 2,
-                        borderColor: '#fff'
+                        borderColor: cv('--h-bg-elevated')
                     }]
                 },
                 options: {
@@ -229,7 +235,7 @@
                         data: expenseData,
                         backgroundColor: expenseColors.slice(0, expenseData.length),
                         borderWidth: 2,
-                        borderColor: '#fff'
+                        borderColor: cv('--h-bg-elevated')
                     }]
                 },
                 options: {

--- a/src/Humans.Web/Views/ColorPalette/Index.cshtml
+++ b/src/Humans.Web/Views/ColorPalette/Index.cshtml
@@ -133,6 +133,7 @@
             @await Html.PartialAsync("_Swatch", ("--h-sage", "Success"))
             @await Html.PartialAsync("_Swatch", ("--h-sage-dark", "Success Dark"))
             @await Html.PartialAsync("_Swatch", ("--h-amber", "Warning"))
+            @await Html.PartialAsync("_Swatch", ("--h-amber-dark", "Warning Dark"))
             @await Html.PartialAsync("_Swatch", ("--h-amber-light", "Warning Light"))
             @await Html.PartialAsync("_Swatch", ("--h-rust", "Danger"))
             @await Html.PartialAsync("_Swatch", ("--h-blue-muted", "Primary / Info"))
@@ -145,11 +146,52 @@
         <div class="cp-grid">
             @await Html.PartialAsync("_Swatch", ("--h-text", "Text (aged-ink)"))
             @await Html.PartialAsync("_Swatch", ("--h-text-secondary", "Text Secondary (sepia)"))
+            @await Html.PartialAsync("_Swatch", ("--h-text-on-dark", "Text on Dark"))
             @await Html.PartialAsync("_Swatch", ("--h-bg", "Background (parchment-light)"))
             @await Html.PartialAsync("_Swatch", ("--h-bg-card", "Card Background (warm-white)"))
             @await Html.PartialAsync("_Swatch", ("--h-bg-elevated", "Elevated Background"))
             @await Html.PartialAsync("_Swatch", ("--h-accent", "Accent (gold)"))
             @await Html.PartialAsync("_Swatch", ("--h-accent-hover", "Accent Hover (gold-dark)"))
+        </div>
+    </div>
+
+    <div class="cp-section">
+        <h2><i class="fa-solid fa-triangle-exclamation me-2"></i>Alert Tokens</h2>
+        <p class="text-muted mb-3">Background and text colors for alert/feedback UI.</p>
+        <div class="cp-grid">
+            @await Html.PartialAsync("_Swatch", ("--h-alert-warning-bg", "Warning BG"))
+            @await Html.PartialAsync("_Swatch", ("--h-alert-warning-text", "Warning Text"))
+            @await Html.PartialAsync("_Swatch", ("--h-alert-info-bg", "Info BG"))
+            @await Html.PartialAsync("_Swatch", ("--h-alert-info-text", "Info Text"))
+            @await Html.PartialAsync("_Swatch", ("--h-alert-success-bg", "Success BG"))
+            @await Html.PartialAsync("_Swatch", ("--h-alert-success-text", "Success Text"))
+            @await Html.PartialAsync("_Swatch", ("--h-alert-danger-bg", "Danger BG"))
+            @await Html.PartialAsync("_Swatch", ("--h-alert-danger-text", "Danger Text"))
+        </div>
+    </div>
+
+    <div class="cp-section">
+        <h2><i class="fa-solid fa-toggle-on me-2"></i>Interactive Tokens</h2>
+        <p class="text-muted mb-3">Colors for form elements, chips, and interactive UI.</p>
+        <div class="cp-grid">
+            @await Html.PartialAsync("_Swatch", ("--h-muted-bg", "Muted Background"))
+            @await Html.PartialAsync("_Swatch", ("--h-muted-border", "Muted Border"))
+            @await Html.PartialAsync("_Swatch", ("--h-muted-border-hover", "Muted Border Hover"))
+            @await Html.PartialAsync("_Swatch", ("--h-muted-text", "Muted Text"))
+            @await Html.PartialAsync("_Swatch", ("--h-focus-ring", "Focus Ring"))
+            @await Html.PartialAsync("_Swatch", ("--h-selected-bg", "Selected Background"))
+            @await Html.PartialAsync("_Swatch", ("--h-chip-text", "Chip Text"))
+        </div>
+    </div>
+
+    <div class="cp-section">
+        <h2><i class="fa-solid fa-chart-pie me-2"></i>Chart Tokens</h2>
+        <p class="text-muted mb-3">Colors for Chart.js and data visualization.</p>
+        <div class="cp-grid">
+            @await Html.PartialAsync("_Swatch", ("--h-chart-success", "Chart Success"))
+            @await Html.PartialAsync("_Swatch", ("--h-chart-warning", "Chart Warning"))
+            @await Html.PartialAsync("_Swatch", ("--h-chart-danger", "Chart Danger"))
+            @await Html.PartialAsync("_Swatch", ("--h-chart-muted", "Chart Muted"))
         </div>
     </div>
 

--- a/src/Humans.Web/Views/Google/AllGroups.cshtml
+++ b/src/Humans.Web/Views/Google/AllGroups.cshtml
@@ -170,7 +170,7 @@
                                     var isCellDeprecated = deprecatedKeys.Contains(key);
                                     if (hasDrift)
                                     {
-                                        <td style="background-color: #f8d7da; color: #842029;" title="Expected: @expected">
+                                        <td style="background-color: var(--h-alert-danger-bg); color: var(--h-alert-danger-text);" title="Expected: @expected">
                                             <small>@actual</small>
                                         </td>
                                     }

--- a/src/Humans.Web/Views/Profile/AdminDetail.cshtml
+++ b/src/Humans.Web/Views/Profile/AdminDetail.cshtml
@@ -278,28 +278,7 @@
         <div class="card mb-4">
             <div class="card-header">@@nobodies.team Email</div>
             <div class="card-body">
-                @if (Model.NobodiesTeamEmail is not null)
-                {
-                    <p class="mb-0">
-                        <code>@Model.NobodiesTeamEmail</code>
-                        <span class="badge bg-success ms-1">Linked</span>
-                    </p>
-                }
-                else
-                {
-                    <form asp-controller="Google" asp-action="ProvisionEmail" asp-route-id="@Model.UserId" method="post">
-                        @Html.AntiForgeryToken()
-                        <div class="input-group mb-2">
-                            <input type="text" name="emailPrefix" class="form-control form-control-sm"
-                                   placeholder="username" required />
-                            <span class="input-group-text">@@nobodies.team</span>
-                        </div>
-                        <button type="submit" class="btn btn-primary btn-sm w-100"
-                                data-confirm="Provision a new @@nobodies.team account for this human?">
-                            <i class="fa-solid fa-plus me-1"></i>Provision Email
-                        </button>
-                    </form>
-                }
+                @await Component.InvokeAsync("NobodiesEmailBadge", new { userId = Model.UserId, mode = "detail" })
             </div>
         </div>
 

--- a/src/Humans.Web/Views/Profile/AdminList.cshtml
+++ b/src/Humans.Web/Views/Profile/AdminList.cshtml
@@ -139,14 +139,7 @@
                                 {
                                     <span class="badge bg-secondary">@Localizer["Admin_NoProfile"]</span>
                                 }
-                                @if (member.HasNobodiesTeamEmail && !member.NobodiesTeamEmailIsPrimary)
-                                {
-                                    <span class="badge bg-warning text-dark ms-1"
-                                          title="Has @@nobodies.team email but not using it as primary"
-                                          data-bs-toggle="tooltip">
-                                        <i class="fa-solid fa-at"></i>
-                                    </span>
-                                }
+                                @await Component.InvokeAsync("NobodiesEmailBadge", new { userId = member.Id, mode = "status" })
                             </td>
                             <td class="text-end">
                                 <a asp-action="AdminDetail" asp-route-id="@member.Id" class="btn btn-sm btn-outline-primary">

--- a/src/Humans.Web/Views/Profile/Edit.cshtml
+++ b/src/Humans.Web/Views/Profile/Edit.cshtml
@@ -539,7 +539,7 @@
             gmp-place-autocomplete input:focus {
                 border-color: var(--h-gold);
                 box-shadow: 0 0 0 3px rgba(201, 169, 110, 0.2);
-                background-color: #fff;
+                background-color: var(--h-bg-elevated);
                 outline: none;
             }
         </style>

--- a/src/Humans.Web/Views/Profile/ShiftInfo.cshtml
+++ b/src/Humans.Web/Views/Profile/ShiftInfo.cshtml
@@ -122,9 +122,9 @@
     /* Progress dots */
     .progress-dot {
         width: 10px; height: 10px; border-radius: 50%;
-        background: #dee2e6; display: inline-block; transition: background 0.2s;
+        background: var(--h-muted-border); display: inline-block; transition: background 0.2s;
     }
-    .progress-dot.active, .progress-dot.done { background: #0d6efd; }
+    .progress-dot.active, .progress-dot.done { background: var(--h-focus-ring); }
 
     /* Step panes */
     .step-pane { display: none; }
@@ -135,13 +135,13 @@
     .chip {
         display: inline-flex; align-items: center; gap: 4px;
         padding: 9px 16px; border-radius: 10px; cursor: pointer;
-        background: #f8f9fa; border: 1.5px solid #dee2e6; color: #495057;
+        background: var(--h-muted-bg); border: 1.5px solid var(--h-muted-border); color: var(--h-chip-text);
         font-size: 14px; user-select: none; transition: all 0.15s;
     }
-    .chip:hover { border-color: #adb5bd; }
-    .chip:focus-visible { outline: 2px solid #0d6efd; outline-offset: 2px; }
+    .chip:hover { border-color: var(--h-muted-border-hover); }
+    .chip:focus-visible { outline: 2px solid var(--h-focus-ring); outline-offset: 2px; }
     .chip.selected {
-        background: #e7f1ff; border-color: #0d6efd; color: #0d6efd; font-weight: 500;
+        background: var(--h-selected-bg); border-color: var(--h-focus-ring); color: var(--h-focus-ring); font-weight: 500;
     }
     .chip-emoji { font-size: 16px; min-width: 1.5em; text-align: center; }
 
@@ -155,16 +155,16 @@
     .radio-card {
         display: flex; flex-direction: column; align-items: center;
         padding: 16px 12px; border-radius: 10px; cursor: pointer; text-align: center;
-        background: #f8f9fa; border: 1.5px solid #dee2e6; transition: all 0.15s;
+        background: var(--h-muted-bg); border: 1.5px solid var(--h-muted-border); transition: all 0.15s;
     }
-    .radio-card:hover { border-color: #adb5bd; }
-    .radio-card:focus-visible { outline: 2px solid #0d6efd; outline-offset: 2px; }
+    .radio-card:hover { border-color: var(--h-muted-border-hover); }
+    .radio-card:focus-visible { outline: 2px solid var(--h-focus-ring); outline-offset: 2px; }
     .radio-card.selected {
-        background: #e7f1ff; border-color: #0d6efd;
+        background: var(--h-selected-bg); border-color: var(--h-focus-ring);
     }
     .rc-emoji { font-size: 24px; margin-bottom: 6px; }
-    .rc-label { font-weight: 600; font-size: 14px; color: #212529; }
-    .rc-desc { font-size: 12px; color: #6c757d; margin-top: 2px; }
+    .rc-label { font-weight: 600; font-size: 14px; color: var(--h-text); }
+    .rc-desc { font-size: 12px; color: var(--h-muted-text); margin-top: 2px; }
 </style>
 <script>
 (function() {

--- a/src/Humans.Web/Views/Shared/Components/AccessMatrix/Default.cshtml
+++ b/src/Humans.Web/Views/Shared/Components/AccessMatrix/Default.cshtml
@@ -19,9 +19,9 @@
 
 <div class="modal fade" id="@modalId" tabindex="-1" aria-labelledby="@(modalId)-label" aria-hidden="true">
     <div class="modal-dialog modal-lg modal-dialog-centered modal-dialog-scrollable">
-        <div class="modal-content" style="background-color: #faf5ef;">
+        <div class="modal-content" style="background-color: var(--h-parchment-light);">
             <div class="modal-header border-0 pb-0">
-                <h5 class="modal-title" id="@(modalId)-label" style="color: #5a3e2b;">
+                <h5 class="modal-title" id="@(modalId)-label" style="color: var(--h-aged-ink-light);">
                     @Model.SectionName
                 </h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
@@ -95,10 +95,10 @@
                             <table class="table table-sm mb-0">
                                 <thead>
                                     <tr>
-                                        <th class="text-uppercase small text-muted" style="color: #5a3e2b !important;">Feature</th>
+                                        <th class="text-uppercase small text-muted" style="color: var(--h-aged-ink-light) !important;">Feature</th>
                                         @foreach (var role in Model.AccessMatrix!.Roles)
                                         {
-                                            <th class="text-center text-uppercase small text-muted" style="color: #5a3e2b !important;">@role</th>
+                                            <th class="text-center text-uppercase small text-muted" style="color: var(--h-aged-ink-light) !important;">@role</th>
                                         }
                                     </tr>
                                 </thead>
@@ -106,7 +106,7 @@
                                     @foreach (var feature in Model.AccessMatrix.Features)
                                     {
                                         <tr>
-                                            <td style="color: #3a2a1a;">@feature.Name</td>
+                                            <td style="color: var(--h-aged-ink);">@feature.Name</td>
                                             @foreach (var role in Model.AccessMatrix.Roles)
                                             {
                                                 var level = feature.RoleAccess.GetValueOrDefault(role, AccessLevel.Denied);
@@ -141,20 +141,20 @@
     .section-help-content {
         font-size: 0.95rem;
         line-height: 1.7;
-        color: #3a2a1a;
+        color: var(--h-aged-ink);
     }
 
     .section-help-content h2 {
         font-size: 1.2rem;
         font-weight: 600;
-        color: #5a3e2b;
+        color: var(--h-aged-ink-light);
         margin-bottom: 0.75rem;
     }
 
     .section-help-content h3 {
         font-size: 1.05rem;
         font-weight: 600;
-        color: #5a3e2b;
+        color: var(--h-aged-ink-light);
         margin-top: 1.25rem;
         margin-bottom: 0.5rem;
     }
@@ -180,25 +180,25 @@
     .section-help-content table th,
     .section-help-content table td {
         padding: 0.5rem 0.75rem;
-        border-bottom: 1px solid #e0d5c8;
-        color: #3a2a1a;
+        border-bottom: 1px solid var(--h-border-light);
+        color: var(--h-aged-ink);
     }
 
     .section-help-content table th {
         font-weight: 600;
-        color: #5a3e2b;
+        color: var(--h-aged-ink-light);
         background-color: rgba(90, 62, 43, 0.05);
     }
 
     .section-help-pills .nav-link {
-        color: #5a3e2b;
+        color: var(--h-aged-ink-light);
         font-size: 0.875rem;
         padding: 0.375rem 0.75rem;
     }
 
     .section-help-pills .nav-link.active {
-        background-color: #5a3e2b;
-        color: #faf5ef;
+        background-color: var(--h-aged-ink-light);
+        color: var(--h-parchment-light);
     }
 
     .section-help-pills .nav-link:hover:not(.active) {

--- a/src/Humans.Web/Views/Shared/Components/NobodiesEmailBadge/Default.cshtml
+++ b/src/Humans.Web/Views/Shared/Components/NobodiesEmailBadge/Default.cshtml
@@ -1,0 +1,89 @@
+@{
+    Guid userId = ViewBag.UserId;
+    bool hasEmail = ViewBag.HasEmail;
+    string? email = ViewBag.Email;
+    bool isPrimary = ViewBag.IsPrimary;
+    string mode = ViewBag.Mode;
+    string? teamSlug = ViewBag.TeamSlug;
+    string? displayName = ViewBag.DisplayName;
+}
+
+@if (string.Equals(mode, "badge", StringComparison.Ordinal))
+{
+    @* Simple badge — shows icon when user has a nobodies.team email *@
+    if (hasEmail)
+    {
+        <span class="badge bg-light text-dark border ms-1" title="Has a @@nobodies.team email account" data-bs-toggle="tooltip">
+            <i class="fa-solid fa-at me-1"></i>nobodies.team
+        </span>
+    }
+}
+else if (string.Equals(mode, "status", StringComparison.Ordinal))
+{
+    @* Status mode — shows warning badge when email exists but isn't primary *@
+    if (hasEmail && !isPrimary)
+    {
+        <span class="badge bg-warning text-dark ms-1"
+              title="Has @@nobodies.team email but not using it as primary"
+              data-bs-toggle="tooltip">
+            <i class="fa-solid fa-at"></i>
+        </span>
+    }
+}
+else if (string.Equals(mode, "email", StringComparison.Ordinal))
+{
+    @* Email mode — shows the actual email address *@
+    if (email is not null)
+    {
+        <code class="small">@email</code>
+    }
+}
+else if (string.Equals(mode, "provision", StringComparison.Ordinal))
+{
+    @* Provision mode — shows email or provisioning form (TeamAdmin/Members) *@
+    if (email is not null)
+    {
+        <code class="small">@email</code>
+    }
+    else
+    {
+        <form asp-controller="TeamAdmin" asp-action="ProvisionEmail" asp-route-slug="@teamSlug" asp-route-userId="@userId" method="post" class="d-inline">
+            @Html.AntiForgeryToken()
+            <div class="input-group input-group-sm" style="min-width: 220px;">
+                <input type="text" name="emailPrefix" class="form-control form-control-sm"
+                       placeholder="username" required style="max-width: 120px;" />
+                <span class="input-group-text">@@nobodies.team</span>
+                <button type="submit" class="btn btn-sm btn-outline-primary"
+                        data-confirm="Provision a new @@nobodies.team account for @displayName?">
+                    <i class="fa-solid fa-plus"></i>
+                </button>
+            </div>
+        </form>
+    }
+}
+else if (string.Equals(mode, "detail", StringComparison.Ordinal))
+{
+    @* Detail mode — shows email + linked badge, or provisioning form (AdminDetail) *@
+    if (email is not null)
+    {
+        <p class="mb-0">
+            <code>@email</code>
+            <span class="badge bg-success ms-1">Linked</span>
+        </p>
+    }
+    else
+    {
+        <form asp-controller="Google" asp-action="ProvisionEmail" asp-route-id="@userId" method="post">
+            @Html.AntiForgeryToken()
+            <div class="input-group mb-2">
+                <input type="text" name="emailPrefix" class="form-control form-control-sm"
+                       placeholder="username" required />
+                <span class="input-group-text">@@nobodies.team</span>
+            </div>
+            <button type="submit" class="btn btn-primary btn-sm w-100"
+                    data-confirm="Provision a new @@nobodies.team account for this human?">
+                <i class="fa-solid fa-plus me-1"></i>Provision Email
+            </button>
+        </form>
+    }
+}

--- a/src/Humans.Web/Views/Shared/Components/ProfileCard/Default.cshtml
+++ b/src/Humans.Web/Views/Shared/Components/ProfileCard/Default.cshtml
@@ -28,12 +28,7 @@
                 {
                     <span class="@Model.PreferredLanguage.ToFlagClass()" title="@Model.PreferredLanguage.ToDisplayLanguageName()"></span>
                 }
-                @if (Model.HasNobodiesTeamEmail)
-                {
-                    <span class="badge bg-light text-dark border ms-1" title="Has a @@nobodies.team email account" data-bs-toggle="tooltip">
-                        <i class="fa-solid fa-at me-1"></i>nobodies.team
-                    </span>
-                }
+                @await Component.InvokeAsync("NobodiesEmailBadge", new { userId = Model.UserId, mode = "badge" })
                 @if (Model.Teams.Count > 0)
                 {
                     <div class="d-flex flex-wrap gap-2 mt-2">

--- a/src/Humans.Web/Views/Shared/_StaffingChart.cshtml
+++ b/src/Humans.Web/Views/Shared/_StaffingChart.cshtml
@@ -39,11 +39,18 @@
         var remaining = data.map(function(d) { return Math.max(0, d.totalSlots - d.confirmedCount); });
         var minLine = data.map(function(d) { return d.minSlots; });
 
+        var cs = getComputedStyle(document.documentElement);
+        var cv = function(n) { return cs.getPropertyValue(n).trim(); };
+        var chartSuccess = cv('--h-chart-success');
+        var chartWarning = cv('--h-chart-warning');
+        var chartDanger = cv('--h-chart-danger');
+        var chartMuted = cv('--h-chart-muted');
+
         var confirmedColors = data.map(function(d) {
-            if (d.totalSlots === 0) return '#198754';
-            if (d.confirmedCount >= d.minSlots) return '#198754';
-            if (d.minSlots > 0 && d.confirmedCount >= d.minSlots * 0.5) return '#ffc107';
-            return '#dc3545';
+            if (d.totalSlots === 0) return chartSuccess;
+            if (d.confirmedCount >= d.minSlots) return chartSuccess;
+            if (d.minSlots > 0 && d.confirmedCount >= d.minSlots * 0.5) return chartWarning;
+            return chartDanger;
         });
 
         new Chart(document.getElementById('@chartKey'), {
@@ -52,8 +59,8 @@
                 labels: labels,
                 datasets: [
                     { label: 'Confirmed', data: confirmed, backgroundColor: confirmedColors },
-                    { label: 'Remaining', data: remaining, backgroundColor: '#e9ecef' },
-                    { label: 'Min needed', data: minLine, type: 'line', borderColor: '#dc3545', borderDash: [5, 5], pointRadius: 0, fill: false, order: 0 }
+                    { label: 'Remaining', data: remaining, backgroundColor: chartMuted },
+                    { label: 'Min needed', data: minLine, type: 'line', borderColor: chartDanger, borderDash: [5, 5], pointRadius: 0, fill: false, order: 0 }
                 ]
             },
             options: {

--- a/src/Humans.Web/Views/ShiftAdmin/Index.cshtml
+++ b/src/Humans.Web/Views/ShiftAdmin/Index.cshtml
@@ -396,7 +396,7 @@
                                                                        profile-picture-url="@(ss.User?.ProfilePictureUrl != null ? $"/Profile/Picture?id={ss.UserId}" : null)" show-popover="true"
                                                                        title="@(ss.User?.DisplayName)@(ss.Status == SignupStatus.Pending ? $" ({Localizer["Shifts_Pending"]})" : "")"
                                                                        class="@(ss.Status == SignupStatus.Pending ? "opacity-50" : "")"
-                                                                       style="@(ss.Status == SignupStatus.Pending ? "border: 1px dashed #6c757d; border-radius: 50%;" : "")" />
+                                                                       style="@(ss.Status == SignupStatus.Pending ? "border: 1px dashed var(--h-muted-text); border-radius: 50%;" : "")" />
                                                         }
                                                     </div>
                                                 }

--- a/src/Humans.Web/Views/Shifts/Index.cshtml
+++ b/src/Humans.Web/Views/Shifts/Index.cshtml
@@ -404,7 +404,7 @@
                                                                                    profile-picture-url="@signup.ProfilePictureUrl" show-popover="true"
                                                                                    title="@signup.DisplayName@(signup.Status == SignupStatus.Pending ? $" {Localizer["Shifts_Pending"]}" : "")"
                                                                                    class="@(signup.Status == SignupStatus.Pending ? "opacity-50" : "")"
-                                                                                   style="@(signup.Status == SignupStatus.Pending ? "border: 1px dashed #6c757d; border-radius: 50%;" : "")" />
+                                                                                   style="@(signup.Status == SignupStatus.Pending ? "border: 1px dashed var(--h-muted-text); border-radius: 50%;" : "")" />
                                                                     }
                                                                 </div>
                                                             </td>
@@ -455,7 +455,7 @@
                                                                                profile-picture-url="@signup.ProfilePictureUrl" show-popover="true"
                                                                                title="@signup.DisplayName@(signup.Status == SignupStatus.Pending ? $" {Localizer["Shifts_Pending"]}" : "")"
                                                                                class="@(signup.Status == SignupStatus.Pending ? "opacity-50" : "")"
-                                                                               style="@(signup.Status == SignupStatus.Pending ? "border: 1px dashed #6c757d; border-radius: 50%;" : "")" />
+                                                                               style="@(signup.Status == SignupStatus.Pending ? "border: 1px dashed var(--h-muted-text); border-radius: 50%;" : "")" />
                                                                 }
                                                             </div>
                                                         </td>

--- a/src/Humans.Web/Views/Team/Map.cshtml
+++ b/src/Humans.Web/Views/Team/Map.cshtml
@@ -51,13 +51,26 @@ else
 
             @await Html.PartialAsync("~/Views/Shared/_EscapeHtmlScript.cshtml")
 
+            // Read CSS variables for JS-generated markup
+            const _cs = getComputedStyle(document.documentElement);
+            const cssVar = (name) => _cs.getPropertyValue(name).trim();
+            const clrMutedText = cssVar('--h-muted-text');
+            const clrTextOnDark = cssVar('--h-text-on-dark');
+            const clrTextSecondary = cssVar('--h-text-secondary');
+            const clrMapPin = cssVar('--h-map-pin');
+            const clrMapPinBorder = cssVar('--h-map-pin-border');
+            const clrMapClusterLarge = cssVar('--h-map-cluster-large');
+            const clrMapClusterLargeBorder = cssVar('--h-map-cluster-large-border');
+            const clrMapClusterMedium = cssVar('--h-map-cluster-medium');
+            const clrMapClusterMediumBorder = cssVar('--h-map-cluster-medium-border');
+
             function avatarHtml(m, size) {
                 const s = size || 40;
                 if (m.profilePictureUrl) {
                     return '<img src="' + escapeHtml(m.profilePictureUrl) + '" alt="" style="width:' + s + 'px;height:' + s + 'px;border-radius:50%;object-fit:cover;">';
                 }
                 const initials = (m.displayName || '?').split(' ').map(function(w){return w[0];}).join('').substring(0, 2).toUpperCase();
-                return '<div style="width:' + s + 'px;height:' + s + 'px;border-radius:50%;background:#6c757d;color:#fff;display:flex;align-items:center;justify-content:center;font-size:' + Math.round(s * 0.4) + 'px;font-weight:600;">' + escapeHtml(initials) + '</div>';
+                return '<div style="width:' + s + 'px;height:' + s + 'px;border-radius:50%;background:' + clrMutedText + ';color:' + clrTextOnDark + ';display:flex;align-items:center;justify-content:center;font-size:' + Math.round(s * 0.4) + 'px;font-weight:600;">' + escapeHtml(initials) + '</div>';
             }
 
             function personHtml(m) {
@@ -66,7 +79,7 @@ else
                     avatarHtml(m, 36) +
                     '<div>' +
                     '<a href="/Profile/' + m.userId + '" style="font-weight:600;text-decoration:none;">' + escapeHtml(m.displayName) + '</a>' +
-                    (location ? '<br><span style="color:#666;font-size:0.85em;">' + escapeHtml(location) + '</span>' : '') +
+                    (location ? '<br><span style="color:' + clrTextSecondary + ';font-size:0.85em;">' + escapeHtml(location) + '</span>' : '') +
                     '</div></div>';
             }
 
@@ -103,9 +116,9 @@ else
                         // Multi-person pin with count
                         const pin = new PinElement({
                             glyph: '' + group.length,
-                            glyphColor: '#fff',
-                            background: '#1a73e8',
-                            borderColor: '#1558b0',
+                            glyphColor: clrTextOnDark,
+                            background: clrMapPin,
+                            borderColor: clrMapPinBorder,
                             scale: 1.1
                         });
                         pinContent = pin.element;
@@ -150,9 +163,9 @@ else
                             }
                             var pin = new PinElement({
                                 glyph: '' + totalPeople,
-                                glyphColor: '#fff',
-                                background: totalPeople > 10 ? '#d93025' : totalPeople > 5 ? '#e8710a' : '#1a73e8',
-                                borderColor: totalPeople > 10 ? '#a5211a' : totalPeople > 5 ? '#b85a08' : '#1558b0',
+                                glyphColor: clrTextOnDark,
+                                background: totalPeople > 10 ? clrMapClusterLarge : totalPeople > 5 ? clrMapClusterMedium : clrMapPin,
+                                borderColor: totalPeople > 10 ? clrMapClusterLargeBorder : totalPeople > 5 ? clrMapClusterMediumBorder : clrMapPinBorder,
                                 scale: 1.2 + Math.min(totalPeople / 50, 0.6)
                             });
                             return new AdvancedMarkerElement({

--- a/src/Humans.Web/Views/TeamAdmin/Members.cshtml
+++ b/src/Humans.Web/Views/TeamAdmin/Members.cshtml
@@ -238,25 +238,7 @@
                             @if (Model.CanProvisionEmails)
                             {
                                 <td>
-                                    @if (member.NobodiesTeamEmail is not null)
-                                    {
-                                        <code class="small">@member.NobodiesTeamEmail</code>
-                                    }
-                                    else
-                                    {
-                                        <form asp-action="ProvisionEmail" asp-route-slug="@Model.TeamSlug" asp-route-userId="@member.UserId" method="post" class="d-inline">
-                                            @Html.AntiForgeryToken()
-                                            <div class="input-group input-group-sm" style="min-width: 220px;">
-                                                <input type="text" name="emailPrefix" class="form-control form-control-sm"
-                                                       placeholder="username" required style="max-width: 120px;" />
-                                                <span class="input-group-text">@@nobodies.team</span>
-                                                <button type="submit" class="btn btn-sm btn-outline-primary"
-                                                        data-confirm="Provision a new @@nobodies.team account for @member.DisplayName?">
-                                                    <i class="fa-solid fa-plus"></i>
-                                                </button>
-                                            </div>
-                                        </form>
-                                    }
+                                    @await Component.InvokeAsync("NobodiesEmailBadge", new { userId = member.UserId, mode = "provision", teamSlug = Model.TeamSlug, displayName = member.DisplayName })
                                 </td>
                             }
                             <td>@member.JoinedAt.ToDisplayCompactDate()</td>

--- a/src/Humans.Web/wwwroot/css/site.css
+++ b/src/Humans.Web/wwwroot/css/site.css
@@ -35,6 +35,7 @@ html { scrollbar-gutter: stable; }
     --h-sage:            #6b8f71;
     --h-sage-dark:       #4f7054;
     --h-amber:           #c48a2a;
+    --h-amber-dark:      #a87520;
     --h-amber-light:     #daa84a;
     --h-rust:            #a04030;
     --h-blue-muted:      #5b7d8f;
@@ -42,11 +43,59 @@ html { scrollbar-gutter: stable; }
     /* Semantic tokens */
     --h-text:            var(--h-aged-ink);
     --h-text-secondary:  var(--h-sepia);
+    --h-text-on-dark:    #fff;
     --h-bg:              var(--h-parchment-light);
     --h-bg-card:         var(--h-warm-white);
     --h-bg-elevated:     #fff;
     --h-accent:          var(--h-gold);
     --h-accent-hover:    var(--h-gold-dark);
+
+    /* Alert semantic tokens */
+    --h-alert-warning-bg:    #fdf1dc;
+    --h-alert-warning-text:  #6b5520;
+    --h-alert-info-bg:       #e5eff5;
+    --h-alert-info-text:     #2c5a72;
+    --h-alert-success-bg:    #e6f0e7;
+    --h-alert-success-text:  #3b5e3e;
+    --h-alert-danger-bg:     #f5e5e3;
+    --h-alert-danger-text:   #6e2e25;
+
+    /* Interactive/form tokens */
+    --h-muted-bg:            #f8f9fa;
+    --h-muted-border:        #dee2e6;
+    --h-muted-border-hover:  #adb5bd;
+    --h-muted-text:          #6c757d;
+    --h-focus-ring:          #0d6efd;
+    --h-selected-bg:         #e7f1ff;
+    --h-chip-text:           #495057;
+
+    /* Chart semantic tokens */
+    --h-chart-success:       #198754;
+    --h-chart-warning:       #ffc107;
+    --h-chart-danger:        #dc3545;
+    --h-chart-muted:         #e9ecef;
+
+    /* Map marker tokens */
+    --h-map-pin:             #1a73e8;
+    --h-map-pin-border:      #1558b0;
+    --h-map-cluster-large:   #d93025;
+    --h-map-cluster-large-border: #a5211a;
+    --h-map-cluster-medium:  #e8710a;
+    --h-map-cluster-medium-border: #b85a08;
+
+    /* Chart categorical palette (income) */
+    --h-chart-cat-1:  #198754; --h-chart-cat-2:  #20c997; --h-chart-cat-3:  #0dcaf0;
+    --h-chart-cat-4:  #0d6efd; --h-chart-cat-5:  #6f42c1; --h-chart-cat-6:  #d63384;
+    --h-chart-cat-7:  #ffc107; --h-chart-cat-8:  #fd7e14; --h-chart-cat-9:  #6610f2;
+    --h-chart-cat-10: #adb5bd; --h-chart-cat-11: #495057; --h-chart-cat-12: #e83e8c;
+    --h-chart-cat-13: #17a2b8; --h-chart-cat-14: #28a745; --h-chart-cat-15: #007bff;
+
+    /* Chart categorical palette (expense) — same colors in different order */
+    --h-chart-exp-1:  #dc3545; --h-chart-exp-2:  #fd7e14; --h-chart-exp-3:  #ffc107;
+    --h-chart-exp-4:  #e83e8c; --h-chart-exp-5:  #6f42c1; --h-chart-exp-6:  #0d6efd;
+    --h-chart-exp-7:  #0dcaf0; --h-chart-exp-8:  #20c997; --h-chart-exp-9:  #198754;
+    --h-chart-exp-10: #adb5bd; --h-chart-exp-11: #495057; --h-chart-exp-12: #d63384;
+    --h-chart-exp-13: #17a2b8; --h-chart-exp-14: #6610f2; --h-chart-exp-15: #28a745;
 
     /* Typography */
     --h-font-display:    'Cormorant Garamond', 'Garamond', 'Georgia', serif;
@@ -69,7 +118,7 @@ html { scrollbar-gutter: stable; }
 /* --- Environment Banner (non-production) --- */
 .env-banner {
     background: var(--h-rust);
-    color: #fff;
+    color: var(--h-text-on-dark);
     text-align: center;
     font-family: var(--h-font-body);
     font-size: 0.7rem;
@@ -401,15 +450,15 @@ h5, .h5 { font-size: 1.1rem; }
 .btn-warning {
     background-color: var(--h-amber);
     border-color: var(--h-amber);
-    color: #fff;
+    color: var(--h-text-on-dark);
     border-radius: var(--h-radius);
     font-weight: 700;
 }
 
 .btn-warning:hover {
-    background-color: #a87520;
-    border-color: #a87520;
-    color: #fff;
+    background-color: var(--h-amber-dark);
+    border-color: var(--h-amber-dark);
+    color: var(--h-text-on-dark);
 }
 
 .btn-outline-dark {
@@ -450,7 +499,7 @@ h5, .h5 { font-size: 1.1rem; }
 
 .bg-warning {
     background-color: var(--h-amber) !important;
-    color: #fff !important;
+    color: var(--h-text-on-dark) !important;
 }
 
 .bg-secondary {
@@ -473,26 +522,26 @@ h5, .h5 { font-size: 1.1rem; }
 }
 
 .alert-warning {
-    background-color: #fdf1dc;
-    color: #6b5520;
+    background-color: var(--h-alert-warning-bg);
+    color: var(--h-alert-warning-text);
     border-left: 4px solid var(--h-amber);
 }
 
 .alert-info {
-    background-color: #e5eff5;
-    color: #2c5a72;
+    background-color: var(--h-alert-info-bg);
+    color: var(--h-alert-info-text);
     border-left: 4px solid var(--h-blue-muted);
 }
 
 .alert-success {
-    background-color: #e6f0e7;
-    color: #3b5e3e;
+    background-color: var(--h-alert-success-bg);
+    color: var(--h-alert-success-text);
     border-left: 4px solid var(--h-sage);
 }
 
 .alert-danger {
-    background-color: #f5e5e3;
-    color: #6e2e25;
+    background-color: var(--h-alert-danger-bg);
+    color: var(--h-alert-danger-text);
     border-left: 4px solid var(--h-rust);
 }
 
@@ -529,7 +578,7 @@ h5, .h5 { font-size: 1.1rem; }
 .form-select:focus {
     border-color: var(--h-gold);
     box-shadow: 0 0 0 3px rgba(201, 169, 110, 0.2);
-    background-color: #fff;
+    background-color: var(--h-bg-elevated);
 }
 
 .form-label {
@@ -893,7 +942,7 @@ tr[data-href] {
 
 .notification-badge-danger {
     background-color: var(--h-rust);
-    color: #fff;
+    color: var(--h-text-on-dark);
     font-size: 0.6rem;
     font-weight: 700;
     line-height: 1;
@@ -967,7 +1016,7 @@ tr[data-href] {
 
 .notification-action-pill {
     background-color: var(--h-rust);
-    color: #fff;
+    color: var(--h-text-on-dark);
     font-size: 0.65rem;
     font-weight: 700;
 }
@@ -1117,17 +1166,17 @@ tr[data-href] {
 
 .notification-tag-urgent {
     background-color: var(--h-rust);
-    color: #fff;
+    color: var(--h-text-on-dark);
 }
 
 .notification-tag-action {
     background-color: var(--h-amber);
-    color: #fff;
+    color: var(--h-text-on-dark);
 }
 
 .notification-tag-info {
     background-color: var(--h-sage);
-    color: #fff;
+    color: var(--h-text-on-dark);
 }
 
 /* --- Group Avatar Cluster --- */
@@ -1243,7 +1292,7 @@ tr[data-href] {
 
 .notification-inbox-header {
     background-color: var(--h-sage-dark);
-    color: #fff;
+    color: var(--h-text-on-dark);
     padding: 0.6rem 1rem;
     display: flex;
     justify-content: space-between;
@@ -1266,12 +1315,12 @@ tr[data-href] {
 }
 
 .notification-tab.active {
-    color: #fff;
+    color: var(--h-text-on-dark);
     background-color: rgba(255, 255, 255, 0.2);
 }
 
 .notification-tab:hover {
-    color: #fff;
+    color: var(--h-text-on-dark);
 }
 
 .notification-inbox-body {


### PR DESCRIPTION
## Summary
- **#334** — Extract shift signup status resolution into `ShiftSignupHelper` and `IShiftSignupService.GetActiveSignupStatusesAsync()`, replacing duplicated LINQ across 3 controller locations
- **#335** — Create `NobodiesEmailBadgeViewComponent` with 2-minute IMemoryCache to resolve nobodies.team email status from userId, eliminating batch pre-loads in controllers (ProfileController, TeamAdminController, GoogleController)
- **#349** — Replace ~70 hardcoded hex colors across site.css and 13 view files with CSS custom properties; add alert, interactive, chart, and map semantic tokens; update ColorPalette page with new token sections

## Spec Compliance
All acceptance criteria verified per-issue during implementation.
- **#334** — PASS (4/4 criteria)
- **#335** — PASS (4/4 criteria)
- **#349** — PASS (5/5 criteria)

## Code Review
Self-reviewed against CODE_REVIEW_RULES.md. Cache invalidation gap identified and fixed (cache eviction added to provisioning endpoints). No other critical issues.

## Test plan
- [ ] Shift browser pages (Shifts/Index, Vol/Shifts, Vol/ChildTeamDetail) show correct signup status badges
- [ ] AdminList shows nobodies.team warning badge for users with email but non-primary
- [ ] AdminDetail shows nobodies.team email card with provisioning form
- [ ] TeamAdmin/Members shows nobodies.team email or provisioning form
- [ ] ProfileCard shows nobodies.team badge
- [ ] Email provisioning updates the badge immediately after redirect
- [ ] Visual appearance preserved: check AccessMatrix modal, alert colors, button colors, chart colors, map markers
- [ ] ColorPalette page (/ColorPalette) shows all new token sections

🤖 Generated with [Claude Code](https://claude.com/claude-code) sprint swarm