### PR TITLE
UI Polish Quick Wins (#357, #351, #358)

### DIFF
--- a/src/Humans.Web/Models/ProfileViewModel.cs
+++ b/src/Humans.Web/Models/ProfileViewModel.cs
@@ -389,6 +389,17 @@ public class ContactFieldViewModel
         ContactFieldVisibility.AllActiveProfiles => "Visible to all active members",
         _ => "Visibility unknown"
     };
+
+    /// <summary>
+    /// Short label for visibility badge pill. Null for public fields (no badge needed).
+    /// </summary>
+    public string? VisibilityBadgeText => Visibility switch
+    {
+        ContactFieldVisibility.BoardOnly => "Board only",
+        ContactFieldVisibility.CoordinatorsAndBoard => "Coordinators + Board",
+        ContactFieldVisibility.MyTeams => "My teams",
+        _ => null
+    };
 }
 
 /// <summary>
@@ -497,6 +508,17 @@ public class UserEmailDisplayViewModel
     public string Email { get; set; } = string.Empty;
     public bool IsNotificationTarget { get; set; }
     public ContactFieldVisibility? Visibility { get; set; }
+
+    /// <summary>
+    /// Short label for visibility badge pill. Null for public fields (no badge needed).
+    /// </summary>
+    public string? VisibilityBadgeText => Visibility switch
+    {
+        ContactFieldVisibility.BoardOnly => "Board only",
+        ContactFieldVisibility.CoordinatorsAndBoard => "Coordinators + Board",
+        ContactFieldVisibility.MyTeams => "My teams",
+        _ => null
+    };
 }
 
 /// <summary>

--- a/src/Humans.Web/Views/Shared/Components/MyGoogleResources/Default.cshtml
+++ b/src/Humans.Web/Views/Shared/Components/MyGoogleResources/Default.cshtml
@@ -10,27 +10,21 @@
             var icon = item.Resource.ResourceType == Humans.Domain.Enums.GoogleResourceType.Group
                 ? "fa-solid fa-users"
                 : "fa-solid fa-folder";
-            var typeLabel = item.Resource.ResourceType == Humans.Domain.Enums.GoogleResourceType.Group
-                ? "Group"
-                : "Drive";
 
-            <div class="list-group-item d-flex justify-content-between align-items-start">
+            <div class="list-group-item d-flex justify-content-between align-items-center py-2">
                 <div>
-                    <i class="@icon me-1 text-muted"></i>
+                    <i class="@icon me-2 text-muted"></i>
                     @if (item.Resource.Url is not null)
                     {
-                        <a href="@item.Resource.Url" target="_blank" rel="noopener noreferrer">@item.Resource.Name <i class="fa-solid fa-external-link-alt small"></i></a>
+                        <a href="@item.Resource.Url" target="_blank" rel="noopener noreferrer">@item.Resource.Name</a>
                     }
                     else
                     {
                         @item.Resource.Name
                     }
-                    <br />
-                    <small class="text-muted">
-                        <span class="badge bg-light text-dark border">@typeLabel</span>
-                        via <a asp-controller="Team" asp-action="Detail" asp-route-slug="@item.TeamSlug" class="text-decoration-none">@item.TeamName</a>
-                    </small>
                 </div>
+                <a asp-controller="Team" asp-action="Details" asp-route-slug="@item.TeamSlug"
+                   class="badge bg-light text-dark border text-decoration-none">@item.TeamName</a>
             </div>
         }
     </div>

--- a/src/Humans.Web/Views/Shared/Components/ProfileCard/Default.cshtml
+++ b/src/Humans.Web/Views/Shared/Components/ProfileCard/Default.cshtml
@@ -99,6 +99,10 @@
                         {
                             <span class="badge bg-primary ms-1" title="@Localizer["Profile_NotificationTarget"]" data-bs-toggle="tooltip"><i class="fa-solid fa-bell"></i> @Localizer["Profile_NotificationTargetShort"]</span>
                         }
+                        @if (email.VisibilityBadgeText is not null)
+                        {
+                            <span class="badge bg-light text-muted border ms-1">@email.VisibilityBadgeText</span>
+                        }
                     </dd>
                 }
                 @foreach (var field in Model.ContactFields)
@@ -116,11 +120,9 @@
                         {
                             @field.Value
                         }
-                        @if (Model.IsOwnProfile)
+                        @if (field.VisibilityBadgeText is not null)
                         {
-                            <i class="@field.VisibilityIconClass text-muted ms-2"
-                               title="@field.VisibilityTooltip"
-                               data-bs-toggle="tooltip"></i>
+                            <span class="badge bg-light text-muted border ms-1">@field.VisibilityBadgeText</span>
                         }
                     </dd>
                 }
@@ -250,6 +252,10 @@
                         @if (email.IsNotificationTarget)
                         {
                             <span class="badge bg-primary ms-1" title="@Localizer["Profile_NotificationTarget"]" data-bs-toggle="tooltip"><i class="fa-solid fa-bell"></i> @Localizer["Profile_NotificationTargetShort"]</span>
+                        }
+                        @if (email.VisibilityBadgeText is not null)
+                        {
+                            <span class="badge bg-light text-muted border ms-1">@email.VisibilityBadgeText</span>
                         }
                     </dd>
                 }

--- a/src/Humans.Web/Views/TeamAdmin/Members.cshtml
+++ b/src/Humans.Web/Views/TeamAdmin/Members.cshtml
@@ -26,16 +26,25 @@
 
 @if (Model.TeamResources.Any() || Model.ParentDepartmentResources.Any())
 {
-    <div class="card mb-4 border-danger">
-        <div class="card-header bg-danger d-flex align-items-center" style="color: var(--h-parchment);">
-            <i class="fa-solid fa-shield-halved me-2"></i>
-            <strong>Resource Access — Sensitive Team!</strong>
+    <div class="card mb-4 @(Model.IsSensitive ? "border-danger" : "")">
+        <div class="card-header @(Model.IsSensitive ? "bg-danger" : "bg-light") d-flex align-items-center" @(Model.IsSensitive ? "style=\"color: var(--h-parchment);\"" : "")>
+            <i class="fa-solid @(Model.IsSensitive ? "fa-shield-halved" : "fa-cloud") me-2"></i>
+            <strong>@(Model.IsSensitive ? "Resource Access — Sensitive Team!" : "Resource Access")</strong>
         </div>
         <div class="card-body">
-            <p class="mb-3">
-                <i class="fa-solid fa-hand me-1" style="font-size: 2.5rem; vertical-align: middle; color: var(--h-rust);"></i>
-                Adding or approving humans for this team grants access to the resources listed below.
-            </p>
+            @if (Model.IsSensitive)
+            {
+                <p class="mb-3">
+                    <i class="fa-solid fa-hand me-1" style="font-size: 2.5rem; vertical-align: middle; color: var(--h-rust);"></i>
+                    Adding or approving humans for this team grants access to the resources listed below.
+                </p>
+            }
+            else
+            {
+                <p class="mb-3 text-muted">
+                    Adding or approving humans for this team grants access to the resources listed below.
+                </p>
+            }
             @if (Model.TeamResources.Any())
             {
                 <h6 class="mb-2">@Model.TeamName</h6>
@@ -52,7 +61,6 @@
                             {
                                 @resource.Name
                             }
-                            <span class="badge bg-secondary ms-1">@resource.ResourceType</span>
                             @if (resource.PermissionLevel is not null)
                             {
                                 <span class="badge bg-info ms-1">@resource.PermissionLevel</span>
@@ -77,7 +85,6 @@
                             {
                                 @resource.Name
                             }
-                            <span class="badge bg-secondary ms-1">@resource.ResourceType</span>
                             @if (resource.PermissionLevel is not null)
                             {
                                 <span class="badge bg-info ms-1">@resource.PermissionLevel</span>


### PR DESCRIPTION
## Summary
- Fix resource access card: tone down styling for non-sensitive teams (#357)
- Simplify Google resources card layout on dashboard (#351)
- Show contact field visibility level to privileged viewers (#358)

## Test plan
- [x] Verify non-sensitive team Members page shows neutral resource card
- [x] Verify sensitive team Members page shows danger-styled card
- [x] Verify dashboard Google resources card is compact single-line layout
- [x] Verify contact field visibility badges appear for restricted fields on other profiles
- [x] Verify no badges on public ("All humans") fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)