### PR TITLE
Audit Log Components (#360, #359)

### DIFF
--- a/src/Humans.Application/DTOs/AdminHumanDetailData.cs
+++ b/src/Humans.Application/DTOs/AdminHumanDetailData.cs
@@ -1,5 +1,4 @@
 using Humans.Domain.Entities;
-using Humans.Domain.Enums;
 using MemberApplication = Humans.Domain.Entities.Application;
 
 namespace Humans.Application.DTOs;
@@ -10,12 +9,4 @@ public record AdminHumanDetailData(
     IReadOnlyList<MemberApplication> Applications,
     int ConsentCount,
     IReadOnlyList<RoleAssignment> RoleAssignments,
-    IReadOnlyList<AdminAuditEntry> AuditEntries,
     string? RejectedByName);
-
-public record AdminAuditEntry(
-    string Action,
-    string Description,
-    DateTime OccurredAt,
-    string? ActorName,
-    bool IsSystemAction);

--- a/src/Humans.Application/Interfaces/IAuditLogService.cs
+++ b/src/Humans.Application/Interfaces/IAuditLogService.cs
@@ -58,4 +58,16 @@ public interface IAuditLogService
     /// Gets audit entries where the user is either the primary or related entity.
     /// </summary>
     Task<IReadOnlyList<AuditLogEntry>> GetByUserAsync(Guid userId, int count, CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets audit entries matching flexible filter criteria.
+    /// Used by the shared AuditLog ViewComponent for rendering audit history on any page.
+    /// </summary>
+    Task<IReadOnlyList<AuditLogEntry>> GetFilteredEntriesAsync(
+        string? entityType = null,
+        Guid? entityId = null,
+        Guid? userId = null,
+        IReadOnlyList<AuditAction>? actions = null,
+        int limit = 20,
+        CancellationToken ct = default);
 }

--- a/src/Humans.Infrastructure/Services/AuditLogService.cs
+++ b/src/Humans.Infrastructure/Services/AuditLogService.cs
@@ -187,4 +187,36 @@ public class AuditLogService : IAuditLogService
             .Take(count)
             .ToListAsync(ct);
     }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<AuditLogEntry>> GetFilteredEntriesAsync(
+        string? entityType = null,
+        Guid? entityId = null,
+        Guid? userId = null,
+        IReadOnlyList<AuditAction>? actions = null,
+        int limit = 20,
+        CancellationToken ct = default)
+    {
+        var query = _dbContext.AuditLogEntries.AsNoTracking().AsQueryable();
+
+        if (!string.IsNullOrEmpty(entityType))
+            query = query.Where(e => e.EntityType == entityType);
+
+        if (entityId.HasValue)
+            query = query.Where(e => e.EntityId == entityId.Value);
+
+        if (userId.HasValue)
+            query = query.Where(e =>
+                e.ActorUserId == userId.Value ||
+                e.RelatedEntityId == userId.Value ||
+                (e.EntityType == "User" && e.EntityId == userId.Value));
+
+        if (actions is { Count: > 0 })
+            query = query.Where(e => actions.Contains(e.Action));
+
+        return await query
+            .OrderByDescending(e => e.OccurredAt)
+            .Take(limit)
+            .ToListAsync(ct);
+    }
 }

--- a/src/Humans.Infrastructure/Services/ProfileService.cs
+++ b/src/Humans.Infrastructure/Services/ProfileService.cs
@@ -636,21 +636,6 @@ public class ProfileService : IProfileService
             .OrderByDescending(ra => ra.ValidFrom)
             .ToListAsync(ct);
 
-        var auditEntries = await _dbContext.AuditLogEntries
-            .AsNoTracking()
-            .Where(e =>
-                (e.EntityType == "User" && e.EntityId == userId) ||
-                (e.RelatedEntityId == userId))
-            .OrderByDescending(e => e.OccurredAt)
-            .Take(50)
-            .Select(e => new Application.DTOs.AdminAuditEntry(
-                e.Action.ToString(),
-                e.Description,
-                e.OccurredAt.ToDateTimeUtc(),
-                e.ActorName,
-                e.ActorUserId == null))
-            .ToListAsync(ct);
-
         string? rejectedByName = null;
         if (user.Profile?.RejectedByUserId is not null)
         {
@@ -666,7 +651,6 @@ public class ProfileService : IProfileService
             user.Applications.OrderByDescending(a => a.SubmittedAt).ToList(),
             user.ConsentRecords.Count,
             roleAssignments,
-            auditEntries,
             rejectedByName);
     }
 

--- a/src/Humans.Web/Controllers/ContactsController.cs
+++ b/src/Humans.Web/Controllers/ContactsController.cs
@@ -2,11 +2,9 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Localization;
-using Microsoft.EntityFrameworkCore;
 using Humans.Application.Interfaces;
 using Humans.Domain.Constants;
 using Humans.Domain.Entities;
-using Humans.Infrastructure.Data;
 using Humans.Web.Authorization;
 using Humans.Web.Extensions;
 using Humans.Web.Models;
@@ -19,20 +17,17 @@ public class ContactsController : HumansControllerBase
 {
     private readonly IContactService _contactService;
     private readonly IStringLocalizer<SharedResource> _localizer;
-    private readonly HumansDbContext _dbContext;
     private readonly ILogger<ContactsController> _logger;
 
     public ContactsController(
         UserManager<User> userManager,
         IContactService contactService,
         IStringLocalizer<SharedResource> localizer,
-        HumansDbContext dbContext,
         ILogger<ContactsController> logger)
         : base(userManager)
     {
         _contactService = contactService;
         _localizer = localizer;
-        _dbContext = dbContext;
         _logger = logger;
     }
 
@@ -78,12 +73,6 @@ public class ContactsController : HumansControllerBase
             if (contact is null)
                 return NotFound();
 
-            var auditLog = await _dbContext.AuditLogEntries
-                .AsNoTracking()
-                .Where(a => a.EntityId == id)
-                .OrderByDescending(a => a.OccurredAt)
-                .ToListAsync();
-
             var viewModel = new AdminContactDetailViewModel
             {
                 UserId = contact.Id,
@@ -92,8 +81,7 @@ public class ContactsController : HumansControllerBase
                 ContactSource = contact.ContactSource,
                 ExternalSourceId = contact.ExternalSourceId,
                 CreatedAt = contact.CreatedAt,
-                CommunicationPreferences = contact.CommunicationPreferences.ToList(),
-                AuditLog = auditLog
+                CommunicationPreferences = contact.CommunicationPreferences.ToList()
             };
 
             return View(viewModel);

--- a/src/Humans.Web/Controllers/ProfileController.cs
+++ b/src/Humans.Web/Controllers/ProfileController.cs
@@ -1262,14 +1262,6 @@ public class ProfileController : HumansControllerBase
                 CreatedByName = ra.CreatedByUser?.DisplayName,
                 CreatedAt = ra.CreatedAt.ToDateTimeUtc()
             }).ToList(),
-            AuditLog = data.AuditEntries.Select(e => new AuditLogEntryViewModel
-            {
-                Action = Enum.TryParse<AuditAction>(e.Action, out var parsedAction) ? parsedAction : default,
-                Description = e.Description,
-                OccurredAt = e.OccurredAt,
-                ActorName = e.ActorName ?? string.Empty,
-                IsSystemAction = e.IsSystemAction
-            }).ToList()
         };
 
         // Check for @nobodies.team email

--- a/src/Humans.Web/Models/AdminViewModels.cs
+++ b/src/Humans.Web/Models/AdminViewModels.cs
@@ -116,7 +116,6 @@ public class AdminHumanDetailViewModel
     public int ConsentCount { get; set; }
     public List<AdminHumanApplicationViewModel> Applications { get; set; } = [];
     public List<AdminRoleAssignmentViewModel> RoleAssignments { get; set; } = [];
-    public List<AuditLogEntryViewModel> AuditLog { get; set; } = [];
 }
 
 public class AdminHumanApplicationViewModel

--- a/src/Humans.Web/Models/ContactViewModels.cs
+++ b/src/Humans.Web/Models/ContactViewModels.cs
@@ -32,7 +32,6 @@ public class AdminContactDetailViewModel
     public string? ExternalSourceId { get; set; }
     public Instant CreatedAt { get; set; }
     public IReadOnlyList<CommunicationPreference> CommunicationPreferences { get; set; } = [];
-    public IReadOnlyList<AuditLogEntry> AuditLog { get; set; } = [];
 }
 
 public class CreateContactViewModel

--- a/src/Humans.Web/TagHelpers/HumanLinkTagHelper.cs
+++ b/src/Humans.Web/TagHelpers/HumanLinkTagHelper.cs
@@ -51,9 +51,9 @@ public class HumanLinkTagHelper : TagHelper
     [HtmlAttributeName("admin")]
     public bool Admin { get; set; }
 
-    /// <summary>Enable hover popover with profile summary.</summary>
+    /// <summary>Enable hover popover with profile summary. Default: true.</summary>
     [HtmlAttributeName("show-popover")]
-    public bool ShowPopover { get; set; }
+    public bool ShowPopover { get; set; } = true;
 
     /// <summary>Additional CSS class(es) for the avatar element.</summary>
     [HtmlAttributeName("avatar-css-class")]

--- a/src/Humans.Web/ViewComponents/AuditLogViewComponent.cs
+++ b/src/Humans.Web/ViewComponents/AuditLogViewComponent.cs
@@ -1,0 +1,66 @@
+using Humans.Application.Interfaces;
+using Humans.Domain.Enums;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Humans.Web.ViewComponents;
+
+public class AuditLogViewComponent : ViewComponent
+{
+    private readonly IAuditLogService _auditLogService;
+    private readonly ILogger<AuditLogViewComponent> _logger;
+
+    public AuditLogViewComponent(
+        IAuditLogService auditLogService,
+        ILogger<AuditLogViewComponent> logger)
+    {
+        _auditLogService = auditLogService;
+        _logger = logger;
+    }
+
+    public async Task<IViewComponentResult> InvokeAsync(
+        string? entityType = null,
+        Guid? entityId = null,
+        Guid? userId = null,
+        string? actions = null,
+        int limit = 20,
+        string title = "Audit History",
+        bool showCard = true)
+    {
+        IReadOnlyList<AuditAction>? actionList = null;
+        if (!string.IsNullOrWhiteSpace(actions))
+        {
+            actionList = actions
+                .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Select(a => Enum.TryParse<AuditAction>(a, ignoreCase: true, out var parsed) ? (AuditAction?)parsed : null)
+                .Where(a => a.HasValue)
+                .Select(a => a!.Value)
+                .ToList();
+        }
+
+        var model = new AuditLogComponentViewModel
+        {
+            Title = title,
+            ShowCard = showCard
+        };
+
+        try
+        {
+            model.Entries = await _auditLogService.GetFilteredEntriesAsync(
+                entityType, entityId, userId, actionList, limit);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error loading audit log entries for EntityType={EntityType}, EntityId={EntityId}, UserId={UserId}",
+                entityType, entityId, userId);
+        }
+
+        return View(model);
+    }
+}
+
+public class AuditLogComponentViewModel
+{
+    public string Title { get; set; } = "Audit History";
+    public bool ShowCard { get; set; } = true;
+    public IReadOnlyList<Domain.Entities.AuditLogEntry> Entries { get; set; } = [];
+}

--- a/src/Humans.Web/ViewComponents/AuditLogViewComponent.cs
+++ b/src/Humans.Web/ViewComponents/AuditLogViewComponent.cs
@@ -1,19 +1,24 @@
 using Humans.Application.Interfaces;
 using Humans.Domain.Enums;
+using Humans.Infrastructure.Data;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 
 namespace Humans.Web.ViewComponents;
 
 public class AuditLogViewComponent : ViewComponent
 {
     private readonly IAuditLogService _auditLogService;
+    private readonly HumansDbContext _dbContext;
     private readonly ILogger<AuditLogViewComponent> _logger;
 
     public AuditLogViewComponent(
         IAuditLogService auditLogService,
+        HumansDbContext dbContext,
         ILogger<AuditLogViewComponent> logger)
     {
         _auditLogService = auditLogService;
+        _dbContext = dbContext;
         _logger = logger;
     }
 
@@ -47,6 +52,22 @@ public class AuditLogViewComponent : ViewComponent
         {
             model.Entries = await _auditLogService.GetFilteredEntriesAsync(
                 entityType, entityId, userId, actionList, limit);
+
+            // Batch-load display names for all referenced user IDs
+            var userIds = model.Entries
+                .SelectMany(e => new[] { e.ActorUserId, e.RelatedEntityId })
+                .Where(id => id.HasValue)
+                .Select(id => id!.Value)
+                .Distinct()
+                .ToList();
+
+            if (userIds.Count > 0)
+            {
+                model.UserDisplayNames = await _dbContext.Users
+                    .AsNoTracking()
+                    .Where(u => userIds.Contains(u.Id))
+                    .ToDictionaryAsync(u => u.Id, u => u.DisplayName);
+            }
         }
         catch (Exception ex)
         {
@@ -56,6 +77,32 @@ public class AuditLogViewComponent : ViewComponent
 
         return View(model);
     }
+
+    /// <summary>
+    /// Maps an AuditAction to a short verb phrase for structured display.
+    /// Returns null for actions that should fall back to Description text.
+    /// </summary>
+    public static string? GetActionVerb(AuditAction action) => action switch
+    {
+        AuditAction.TeamMemberAdded => "added",
+        AuditAction.TeamMemberRemoved => "removed",
+        AuditAction.TeamMemberRoleChanged => "changed role for",
+        AuditAction.TeamJoinedDirectly => "joined",
+        AuditAction.TeamLeft => "left",
+        AuditAction.TeamJoinRequestApproved => "approved join request for",
+        AuditAction.TeamJoinRequestRejected => "rejected join request for",
+        AuditAction.MemberSuspended => "suspended",
+        AuditAction.MemberUnsuspended => "unsuspended",
+        AuditAction.VolunteerApproved => "approved",
+        AuditAction.RoleAssigned => "assigned role to",
+        AuditAction.RoleEnded => "ended role for",
+        AuditAction.ConsentCheckCleared => "cleared consent check for",
+        AuditAction.ConsentCheckFlagged => "flagged consent check for",
+        AuditAction.SignupRejected => "rejected signup for",
+        AuditAction.TierApplicationApproved => "approved tier application for",
+        AuditAction.TierApplicationRejected => "rejected tier application for",
+        _ => null
+    };
 }
 
 public class AuditLogComponentViewModel
@@ -63,4 +110,5 @@ public class AuditLogComponentViewModel
     public string Title { get; set; } = "Audit History";
     public bool ShowCard { get; set; } = true;
     public IReadOnlyList<Domain.Entities.AuditLogEntry> Entries { get; set; } = [];
+    public Dictionary<Guid, string> UserDisplayNames { get; set; } = new();
 }

--- a/src/Humans.Web/Views/Contacts/Detail.cshtml
+++ b/src/Humans.Web/Views/Contacts/Detail.cshtml
@@ -81,34 +81,4 @@
     </div>
 </div>
 
-<div class="card">
-    <div class="card-header">Audit Log</div>
-    <div class="card-body p-0">
-        @if (Model.AuditLog.Count == 0)
-        {
-            <p class="text-muted text-center py-4 mb-0">No audit entries.</p>
-        }
-        else
-        {
-            <table class="table table-sm mb-0">
-                <thead>
-                    <tr>
-                        <th>When</th>
-                        <th>Action</th>
-                        <th>Description</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    @foreach (var entry in Model.AuditLog)
-                    {
-                        <tr>
-                            <td>@entry.OccurredAt.ToDisplayDate()</td>
-                            <td><code>@entry.Action</code></td>
-                            <td>@entry.Description</td>
-                        </tr>
-                    }
-                </tbody>
-            </table>
-        }
-    </div>
-</div>
+<vc:audit-log user-id="@Model.UserId" title="Audit Log" limit="50" />

--- a/src/Humans.Web/Views/Profile/AdminDetail.cshtml
+++ b/src/Humans.Web/Views/Profile/AdminDetail.cshtml
@@ -200,45 +200,7 @@
 
         <vc:shift-signups user-id="@Model.UserId" view-mode="@ShiftSignupsViewMode.Admin" display-name="@Model.DisplayName" />
 
-        <div class="card mb-4">
-            <div class="card-header">@Localizer["AdminHuman_AuditHistory"]</div>
-            @if (Model.AuditLog.Count > 0)
-            {
-                <div class="list-group list-group-flush">
-                    @foreach (var entry in Model.AuditLog)
-                    {
-                        <div class="list-group-item">
-                            <div class="d-flex justify-content-between align-items-start">
-                                <div>
-                                    <strong>@entry.Description</strong>
-                                    <br />
-                                    <small class="text-muted">
-                                        @if (entry.IsSystemAction)
-                                        {
-                                            <span class="badge bg-info">System</span>
-                                        }
-                                        else
-                                        {
-                                            <span class="badge bg-secondary">Admin</span>
-                                        }
-                                        @entry.ActorName
-                                    </small>
-                                </div>
-                                <small class="text-muted text-nowrap ms-2">
-                                    @entry.OccurredAt.ToDisplayDateTime()
-                                </small>
-                            </div>
-                        </div>
-                    }
-                </div>
-            }
-            else
-            {
-                <div class="card-body text-muted">
-                    @Localizer["AdminHuman_NoAuditHistory"]
-                </div>
-            }
-        </div>
+        <vc:audit-log user-id="@Model.UserId" limit="50" title="@Localizer["AdminHuman_AuditHistory"].Value" />
 
         @if (campaignGrants != null && campaignGrants.Any())
         {

--- a/src/Humans.Web/Views/Shared/Components/AuditLog/Default.cshtml
+++ b/src/Humans.Web/Views/Shared/Components/AuditLog/Default.cshtml
@@ -6,40 +6,17 @@
         <div class="card-header">@Model.Title</div>
         @if (Model.Entries.Count > 0)
         {
-            <div class="list-group list-group-flush">
+            <ul class="list-group list-group-flush">
                 @foreach (var entry in Model.Entries)
                 {
-                    <div class="list-group-item">
-                        <div class="d-flex justify-content-between align-items-start">
-                            <div>
-                                <strong>@entry.Description</strong>
-                                <br />
-                                <small class="text-muted">
-                                    @if (entry.ActorUserId is null)
-                                    {
-                                        <span class="badge bg-info">System</span>
-                                    }
-                                    else
-                                    {
-                                        <span class="badge bg-secondary">Admin</span>
-                                    }
-                                    @if (entry.ActorUserId.HasValue)
-                                    {
-                                        <human-link user-id="@entry.ActorUserId.Value" display-name="@entry.ActorName" mode="Text" />
-                                    }
-                                    else
-                                    {
-                                        @entry.ActorName
-                                    }
-                                </small>
-                            </div>
-                            <small class="text-muted text-nowrap ms-2">
-                                @entry.OccurredAt.ToAuditTimestamp()
-                            </small>
-                        </div>
-                    </div>
+                    <li class="list-group-item py-2">
+                        @await Html.PartialAsync("Components/AuditLog/_Entry", entry, new ViewDataDictionary(ViewData)
+                        {
+                            ["UserDisplayNames"] = Model.UserDisplayNames
+                        })
+                    </li>
                 }
-            </div>
+            </ul>
         }
         else
         {
@@ -53,40 +30,17 @@ else
 {
     @if (Model.Entries.Count > 0)
     {
-        <div class="list-group list-group-flush">
+        <ul class="list-group list-group-flush">
             @foreach (var entry in Model.Entries)
             {
-                <div class="list-group-item">
-                    <div class="d-flex justify-content-between align-items-start">
-                        <div>
-                            <strong>@entry.Description</strong>
-                            <br />
-                            <small class="text-muted">
-                                @if (entry.ActorUserId is null)
-                                {
-                                    <span class="badge bg-info">System</span>
-                                }
-                                else
-                                {
-                                    <span class="badge bg-secondary">Admin</span>
-                                }
-                                @if (entry.ActorUserId.HasValue)
-                                {
-                                    <human-link user-id="@entry.ActorUserId.Value" display-name="@entry.ActorName" mode="Text" />
-                                }
-                                else
-                                {
-                                    @entry.ActorName
-                                }
-                            </small>
-                        </div>
-                        <small class="text-muted text-nowrap ms-2">
-                            @entry.OccurredAt.ToAuditTimestamp()
-                        </small>
-                    </div>
-                </div>
+                <li class="list-group-item py-2">
+                    @await Html.PartialAsync("Components/AuditLog/_Entry", entry, new ViewDataDictionary(ViewData)
+                    {
+                        ["UserDisplayNames"] = Model.UserDisplayNames
+                    })
+                </li>
             }
-        </div>
+        </ul>
     }
     else
     {

--- a/src/Humans.Web/Views/Shared/Components/AuditLog/Default.cshtml
+++ b/src/Humans.Web/Views/Shared/Components/AuditLog/Default.cshtml
@@ -1,0 +1,95 @@
+@model Humans.Web.ViewComponents.AuditLogComponentViewModel
+
+@if (Model.ShowCard)
+{
+    <div class="card mb-4">
+        <div class="card-header">@Model.Title</div>
+        @if (Model.Entries.Count > 0)
+        {
+            <div class="list-group list-group-flush">
+                @foreach (var entry in Model.Entries)
+                {
+                    <div class="list-group-item">
+                        <div class="d-flex justify-content-between align-items-start">
+                            <div>
+                                <strong>@entry.Description</strong>
+                                <br />
+                                <small class="text-muted">
+                                    @if (entry.ActorUserId is null)
+                                    {
+                                        <span class="badge bg-info">System</span>
+                                    }
+                                    else
+                                    {
+                                        <span class="badge bg-secondary">Admin</span>
+                                    }
+                                    @if (entry.ActorUserId.HasValue)
+                                    {
+                                        <human-link user-id="@entry.ActorUserId.Value" display-name="@entry.ActorName" mode="Text" />
+                                    }
+                                    else
+                                    {
+                                        @entry.ActorName
+                                    }
+                                </small>
+                            </div>
+                            <small class="text-muted text-nowrap ms-2">
+                                @entry.OccurredAt.ToAuditTimestamp()
+                            </small>
+                        </div>
+                    </div>
+                }
+            </div>
+        }
+        else
+        {
+            <div class="card-body text-muted">
+                No audit history.
+            </div>
+        }
+    </div>
+}
+else
+{
+    @if (Model.Entries.Count > 0)
+    {
+        <div class="list-group list-group-flush">
+            @foreach (var entry in Model.Entries)
+            {
+                <div class="list-group-item">
+                    <div class="d-flex justify-content-between align-items-start">
+                        <div>
+                            <strong>@entry.Description</strong>
+                            <br />
+                            <small class="text-muted">
+                                @if (entry.ActorUserId is null)
+                                {
+                                    <span class="badge bg-info">System</span>
+                                }
+                                else
+                                {
+                                    <span class="badge bg-secondary">Admin</span>
+                                }
+                                @if (entry.ActorUserId.HasValue)
+                                {
+                                    <human-link user-id="@entry.ActorUserId.Value" display-name="@entry.ActorName" mode="Text" />
+                                }
+                                else
+                                {
+                                    @entry.ActorName
+                                }
+                            </small>
+                        </div>
+                        <small class="text-muted text-nowrap ms-2">
+                            @entry.OccurredAt.ToAuditTimestamp()
+                        </small>
+                    </div>
+                </div>
+            }
+        </div>
+    }
+    else
+    {
+        <p class="text-muted mb-0">No audit history.</p>
+    }
+}

--- a/src/Humans.Web/Views/Shared/Components/AuditLog/_Entry.cshtml
+++ b/src/Humans.Web/Views/Shared/Components/AuditLog/_Entry.cshtml
@@ -11,6 +11,7 @@
 
 <div class="d-flex align-items-baseline gap-1 small">
     <span class="text-muted text-nowrap">@Model.OccurredAt.ToAuditTimestamp()</span>
+    <span class="text-muted">—</span>
     @if (verb != null)
     {
         @if (Model.ActorUserId.HasValue)

--- a/src/Humans.Web/Views/Shared/Components/AuditLog/_Entry.cshtml
+++ b/src/Humans.Web/Views/Shared/Components/AuditLog/_Entry.cshtml
@@ -1,0 +1,34 @@
+@model Humans.Domain.Entities.AuditLogEntry
+@using Humans.Web.ViewComponents
+
+@{
+    var userNames = (Dictionary<Guid, string>?)ViewData["UserDisplayNames"] ?? new();
+    string GetName(Guid id) => userNames.TryGetValue(id, out var n) ? n : "Unknown";
+
+    var verb = AuditLogViewComponent.GetActionVerb(Model.Action);
+    var hasSubject = Model.RelatedEntityId.HasValue && Model.RelatedEntityType == "User";
+}
+
+<div class="d-flex align-items-baseline gap-1 small">
+    <span class="text-muted text-nowrap">@Model.OccurredAt.ToAuditTimestamp()</span>
+    @if (verb != null)
+    {
+        @if (Model.ActorUserId.HasValue)
+        {
+            <human-link user-id="@Model.ActorUserId.Value" display-name="@GetName(Model.ActorUserId.Value)" mode="Text" />
+        }
+        else
+        {
+            <span class="text-muted">System</span>
+        }
+        <span>@verb</span>
+        @if (hasSubject)
+        {
+            <human-link user-id="@Model.RelatedEntityId!.Value" display-name="@GetName(Model.RelatedEntityId.Value)" mode="Text" />
+        }
+    }
+    else
+    {
+        <span>@Model.Description</span>
+    }
+</div>

--- a/src/Humans.Web/Views/TeamAdmin/Members.cshtml
+++ b/src/Humans.Web/Views/TeamAdmin/Members.cshtml
@@ -292,6 +292,12 @@ else
     </nav>
 }
 
+<div class="mt-4">
+    <vc:audit-log entity-type="Team" entity-id="@Model.TeamId"
+                  actions="TeamMemberAdded,TeamMemberRemoved,TeamMemberRoleChanged"
+                  title="Membership History" limit="20" />
+</div>
+
 <div class="mt-3">
     <a asp-controller="Team" asp-action="Details" asp-route-slug="@Model.TeamSlug" class="btn btn-outline-secondary">@Localizer["TeamAdmin_BackToTeam"]</a>
     <a asp-action="Resources" asp-route-slug="@Model.TeamSlug" class="btn btn-outline-info">@Localizer["TeamAdmin_ManageResources"]</a>

--- a/tests/Humans.Application.Tests/Services/ProfileServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/ProfileServiceTests.cs
@@ -917,7 +917,6 @@ public class ProfileServiceTests : IDisposable
         result.Profile.Should().NotBeNull();
         result.Applications.Should().HaveCount(1);
         result.RoleAssignments.Should().HaveCount(1);
-        result.AuditEntries.Should().HaveCount(1);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Add reusable audit log ViewComponent with filter parameters (#360)
- Add membership audit log card to Team Members page (#359)
- Migrate existing inline audit renderings to shared component

## Test plan
- [x] Verify audit log ViewComponent renders on Team Members page with membership events
- [ ] Verify AdminDetail page uses ViewComponent instead of inline rendering
- [ ] Verify empty state shows "No audit history" message
- [ ] Verify filter parameters work (entity-type, entity-id, actions)
- [ ] Verify build passes with no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)