### PR TITLE
Controller Extraction: Google & Notifications (#353, #356)

### DIFF
--- a/src/Humans.Application/Interfaces/IGoogleAdminService.cs
+++ b/src/Humans.Application/Interfaces/IGoogleAdminService.cs
@@ -1,0 +1,130 @@
+namespace Humans.Application.Interfaces;
+
+/// <summary>
+/// Service for Google Workspace admin operations:
+/// workspace account management, group linking, email backfill, account linking.
+/// Owns all mutation orchestration and SaveChangesAsync calls for these workflows.
+/// </summary>
+public interface IGoogleAdminService
+{
+    /// <summary>
+    /// Builds the workspace accounts list view model with matched user data.
+    /// </summary>
+    Task<WorkspaceAccountListResult> GetWorkspaceAccountListAsync(
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Provisions a new standalone @nobodies.team account (not linked to a user).
+    /// </summary>
+    Task<WorkspaceAccountActionResult> ProvisionStandaloneAccountAsync(
+        string emailPrefix, string firstName, string lastName,
+        Guid actorUserId, string actorDisplayName,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Suspends a @nobodies.team account.
+    /// </summary>
+    Task<WorkspaceAccountActionResult> SuspendAccountAsync(
+        string email, Guid actorUserId, string actorDisplayName,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Reactivates a suspended @nobodies.team account.
+    /// </summary>
+    Task<WorkspaceAccountActionResult> ReactivateAccountAsync(
+        string email, Guid actorUserId, string actorDisplayName,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Resets the password for a @nobodies.team account.
+    /// </summary>
+    Task<WorkspaceAccountActionResult> ResetPasswordAsync(
+        string email, Guid actorUserId, string actorDisplayName,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Links a @nobodies.team account to a user.
+    /// </summary>
+    Task<WorkspaceAccountActionResult> LinkAccountAsync(
+        string email, Guid userId,
+        Guid actorUserId, string actorDisplayName,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Applies email backfill corrections for selected users.
+    /// </summary>
+    Task<EmailBackfillActionResult> ApplyEmailBackfillAsync(
+        List<Guid> selectedUserIds, Dictionary<string, string> corrections,
+        Guid actorUserId,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Links a Google Group prefix to a team.
+    /// </summary>
+    Task<GroupLinkActionResult> LinkGroupToTeamAsync(
+        Guid teamId, string groupPrefix,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets active teams for the group linking UI.
+    /// </summary>
+    Task<IReadOnlyList<TeamSummary>> GetActiveTeamsAsync(
+        CancellationToken ct = default);
+}
+
+/// <summary>
+/// Result of loading workspace accounts with matched user data.
+/// </summary>
+public record WorkspaceAccountListResult(
+    IReadOnlyList<WorkspaceAccountInfo> Accounts,
+    int TotalAccounts,
+    int ActiveAccounts,
+    int SuspendedAccounts,
+    int LinkedAccounts,
+    int UnlinkedAccounts,
+    int NotPrimaryCount,
+    string? ErrorMessage = null);
+
+/// <summary>
+/// Individual workspace account with matched user info.
+/// </summary>
+public record WorkspaceAccountInfo(
+    string PrimaryEmail,
+    string FirstName,
+    string LastName,
+    bool IsSuspended,
+    DateTime CreationTime,
+    DateTime? LastLoginTime,
+    Guid? MatchedUserId,
+    string? MatchedDisplayName,
+    bool IsUsedAsPrimary);
+
+/// <summary>
+/// Result of a workspace account action (provision, suspend, reactivate, reset, link).
+/// </summary>
+public record WorkspaceAccountActionResult(
+    bool Success,
+    string? Message = null,
+    string? ErrorMessage = null,
+    string? TemporaryPassword = null);
+
+/// <summary>
+/// Result of applying email backfill corrections.
+/// </summary>
+public record EmailBackfillActionResult(
+    int UpdatedCount,
+    IReadOnlyList<string> Errors);
+
+/// <summary>
+/// Result of linking a group to a team.
+/// </summary>
+public record GroupLinkActionResult(
+    bool Success,
+    string? Message = null,
+    string? InfoMessage = null,
+    string? ErrorMessage = null);
+
+/// <summary>
+/// Minimal team info for dropdowns/selectors.
+/// </summary>
+public record TeamSummary(Guid Id, string Name);

--- a/src/Humans.Application/Interfaces/INotificationInboxService.cs
+++ b/src/Humans.Application/Interfaces/INotificationInboxService.cs
@@ -1,0 +1,129 @@
+using Humans.Domain.Enums;
+
+namespace Humans.Application.Interfaces;
+
+/// <summary>
+/// Service for notification inbox read models and write operations:
+/// inbox/popup queries, resolve/dismiss, mark-read, and badge cache invalidation.
+/// Complements INotificationService (which handles dispatching new notifications).
+/// </summary>
+public interface INotificationInboxService
+{
+    /// <summary>
+    /// Builds the notification inbox for a user with filtering, search, and tab support.
+    /// </summary>
+    Task<NotificationInboxResult> GetInboxAsync(
+        Guid userId, string? search, string filter, string tab,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Builds the notification popup (unresolved notifications) for a user.
+    /// </summary>
+    Task<NotificationPopupResult> GetPopupAsync(
+        Guid userId,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Resolves a notification (marks it as handled by the user).
+    /// Returns false if the notification was not found or user is not a recipient.
+    /// </summary>
+    Task<NotificationActionResult> ResolveAsync(
+        Guid notificationId, Guid userId,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Dismisses an informational notification.
+    /// Returns false if the notification is actionable (cannot be dismissed).
+    /// </summary>
+    Task<NotificationActionResult> DismissAsync(
+        Guid notificationId, Guid userId,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Marks a notification as read for the user.
+    /// </summary>
+    Task<NotificationActionResult> MarkReadAsync(
+        Guid notificationId, Guid userId,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Marks all unread notifications as read for the user.
+    /// </summary>
+    Task MarkAllReadAsync(
+        Guid userId,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Bulk-resolves selected actionable notifications.
+    /// </summary>
+    Task BulkResolveAsync(
+        List<Guid> notificationIds, Guid userId,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Bulk-dismisses selected informational notifications.
+    /// </summary>
+    Task BulkDismissAsync(
+        List<Guid> notificationIds, Guid userId,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Click-through: marks a notification as read and returns the action URL.
+    /// Returns null if the notification is not found or user is not a recipient.
+    /// </summary>
+    Task<string?> ClickThroughAsync(
+        Guid notificationId, Guid userId,
+        CancellationToken ct = default);
+}
+
+/// <summary>
+/// A single notification row in inbox/popup views.
+/// </summary>
+public record NotificationRowDto
+{
+    public Guid Id { get; init; }
+    public string Title { get; init; } = string.Empty;
+    public string? Body { get; init; }
+    public string? ActionUrl { get; init; }
+    public string? ActionLabel { get; init; }
+    public NotificationPriority Priority { get; init; }
+    public NotificationSource Source { get; init; }
+    public NotificationClass Class { get; init; }
+    public string? TargetGroupName { get; init; }
+    public DateTime CreatedAt { get; init; }
+    public bool IsRead { get; init; }
+    public bool IsResolved { get; init; }
+    public DateTime? ResolvedAt { get; init; }
+    public string? ResolvedByName { get; init; }
+    public List<string> RecipientInitials { get; init; } = [];
+    public int TotalRecipientCount { get; init; }
+}
+
+/// <summary>
+/// Result of the inbox query.
+/// </summary>
+public record NotificationInboxResult
+{
+    public List<NotificationRowDto> NeedsAttention { get; init; } = [];
+    public List<NotificationRowDto> Informational { get; init; } = [];
+    public List<NotificationRowDto> Resolved { get; init; } = [];
+    public int UnreadCount { get; init; }
+}
+
+/// <summary>
+/// Result of the popup query.
+/// </summary>
+public record NotificationPopupResult
+{
+    public List<NotificationRowDto> Actionable { get; init; } = [];
+    public List<NotificationRowDto> Informational { get; init; } = [];
+    public int ActionableCount { get; init; }
+}
+
+/// <summary>
+/// Result of a single notification action (resolve, dismiss, mark-read).
+/// </summary>
+public record NotificationActionResult(
+    bool Success,
+    bool NotFound = false,
+    bool Forbidden = false);

--- a/src/Humans.Infrastructure/Services/GoogleAdminService.cs
+++ b/src/Humans.Infrastructure/Services/GoogleAdminService.cs
@@ -1,0 +1,392 @@
+using Humans.Application.Helpers;
+using Humans.Application.Interfaces;
+using Humans.Domain.Enums;
+using Humans.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Humans.Infrastructure.Services;
+
+/// <summary>
+/// Service for Google Workspace admin operations:
+/// workspace account management, group linking, email backfill, account linking.
+/// </summary>
+public class GoogleAdminService : IGoogleAdminService
+{
+    private readonly HumansDbContext _dbContext;
+    private readonly IGoogleWorkspaceUserService _workspaceUserService;
+    private readonly IGoogleSyncService _googleSyncService;
+    private readonly IUserEmailService _userEmailService;
+    private readonly IAuditLogService _auditLogService;
+    private readonly ILogger<GoogleAdminService> _logger;
+
+    private const string NobodiesTeamDomain = "nobodies.team";
+
+    public GoogleAdminService(
+        HumansDbContext dbContext,
+        IGoogleWorkspaceUserService workspaceUserService,
+        IGoogleSyncService googleSyncService,
+        IUserEmailService userEmailService,
+        IAuditLogService auditLogService,
+        ILogger<GoogleAdminService> logger)
+    {
+        _dbContext = dbContext;
+        _workspaceUserService = workspaceUserService;
+        _googleSyncService = googleSyncService;
+        _userEmailService = userEmailService;
+        _auditLogService = auditLogService;
+        _logger = logger;
+    }
+
+    public async Task<WorkspaceAccountListResult> GetWorkspaceAccountListAsync(
+        CancellationToken ct = default)
+    {
+        try
+        {
+            var accounts = await _workspaceUserService.ListAccountsAsync(ct);
+
+            // Load all user emails to match accounts to humans
+            var allUserEmails = await _dbContext.UserEmails
+                .AsNoTracking()
+                .Include(ue => ue.User)
+                .ToListAsync(ct);
+
+            var accountInfos = new List<WorkspaceAccountInfo>();
+            var notPrimaryCount = 0;
+
+            foreach (var account in accounts)
+            {
+                var matchedEmail = allUserEmails.FirstOrDefault(ue =>
+                    string.Equals(ue.Email, account.PrimaryEmail, StringComparison.OrdinalIgnoreCase));
+
+                var isUsedAsPrimary = matchedEmail is { IsNotificationTarget: true };
+
+                // Count accounts that exist in the system but are not used as primary
+                if (matchedEmail is not null && !isUsedAsPrimary)
+                {
+                    notPrimaryCount++;
+                }
+
+                accountInfos.Add(new WorkspaceAccountInfo(
+                    PrimaryEmail: account.PrimaryEmail,
+                    FirstName: account.FirstName,
+                    LastName: account.LastName,
+                    IsSuspended: account.IsSuspended,
+                    CreationTime: account.CreationTime,
+                    LastLoginTime: account.LastLoginTime,
+                    MatchedUserId: matchedEmail?.UserId,
+                    MatchedDisplayName: matchedEmail?.User?.DisplayName,
+                    IsUsedAsPrimary: isUsedAsPrimary));
+            }
+
+            var sorted = accountInfos
+                .OrderBy(a => a.PrimaryEmail, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            var linkedCount = sorted.Count(a => a.MatchedUserId.HasValue);
+
+            return new WorkspaceAccountListResult(
+                Accounts: sorted,
+                TotalAccounts: sorted.Count,
+                ActiveAccounts: sorted.Count(a => !a.IsSuspended),
+                SuspendedAccounts: sorted.Count(a => a.IsSuspended),
+                LinkedAccounts: linkedCount,
+                UnlinkedAccounts: sorted.Count - linkedCount,
+                NotPrimaryCount: notPrimaryCount);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to load @nobodies.team accounts");
+            return new WorkspaceAccountListResult(
+                Accounts: [],
+                TotalAccounts: 0,
+                ActiveAccounts: 0,
+                SuspendedAccounts: 0,
+                LinkedAccounts: 0,
+                UnlinkedAccounts: 0,
+                NotPrimaryCount: 0,
+                ErrorMessage: "Failed to load @nobodies.team accounts. Check the logs for details.");
+        }
+    }
+
+    public async Task<WorkspaceAccountActionResult> ProvisionStandaloneAccountAsync(
+        string emailPrefix, string firstName, string lastName,
+        Guid actorUserId, string actorDisplayName,
+        CancellationToken ct = default)
+    {
+        var fullEmail = $"{emailPrefix.Trim().ToLowerInvariant()}@{NobodiesTeamDomain}";
+
+        // Check if account already exists
+        var existing = await _workspaceUserService.GetAccountAsync(fullEmail, ct);
+        if (existing is not null)
+        {
+            return new WorkspaceAccountActionResult(false,
+                ErrorMessage: $"Account {fullEmail} already exists.");
+        }
+
+        try
+        {
+            var tempPassword = PasswordGenerator.GenerateTemporary();
+
+            await _workspaceUserService.ProvisionAccountAsync(
+                fullEmail, firstName.Trim(), lastName.Trim(), tempPassword, ct: ct);
+
+            await _auditLogService.LogAsync(
+                AuditAction.WorkspaceAccountProvisioned,
+                "WorkspaceAccount", Guid.Empty,
+                $"Provisioned @{NobodiesTeamDomain} account: {fullEmail}",
+                actorUserId, actorDisplayName);
+            await _dbContext.SaveChangesAsync(ct);
+
+            return new WorkspaceAccountActionResult(true,
+                Message: $"Account {fullEmail} provisioned. Temporary password: {tempPassword}",
+                TemporaryPassword: tempPassword);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to provision @nobodies.team account: {Email}", fullEmail);
+            return new WorkspaceAccountActionResult(false,
+                ErrorMessage: $"Failed to provision {fullEmail}. Check logs for details.");
+        }
+    }
+
+    public async Task<WorkspaceAccountActionResult> SuspendAccountAsync(
+        string email, Guid actorUserId, string actorDisplayName,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            await _workspaceUserService.SuspendAccountAsync(email, ct);
+
+            await _auditLogService.LogAsync(
+                AuditAction.WorkspaceAccountSuspended,
+                "WorkspaceAccount", Guid.Empty,
+                $"Suspended @{NobodiesTeamDomain} account: {email}",
+                actorUserId, actorDisplayName);
+            await _dbContext.SaveChangesAsync(ct);
+
+            return new WorkspaceAccountActionResult(true,
+                Message: $"Account {email} suspended.");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to suspend account: {Email}", email);
+            return new WorkspaceAccountActionResult(false,
+                ErrorMessage: $"Failed to suspend {email}.");
+        }
+    }
+
+    public async Task<WorkspaceAccountActionResult> ReactivateAccountAsync(
+        string email, Guid actorUserId, string actorDisplayName,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            await _workspaceUserService.ReactivateAccountAsync(email, ct);
+
+            await _auditLogService.LogAsync(
+                AuditAction.WorkspaceAccountReactivated,
+                "WorkspaceAccount", Guid.Empty,
+                $"Reactivated @{NobodiesTeamDomain} account: {email}",
+                actorUserId, actorDisplayName);
+            await _dbContext.SaveChangesAsync(ct);
+
+            return new WorkspaceAccountActionResult(true,
+                Message: $"Account {email} reactivated.");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to reactivate account: {Email}", email);
+            return new WorkspaceAccountActionResult(false,
+                ErrorMessage: $"Failed to reactivate {email}.");
+        }
+    }
+
+    public async Task<WorkspaceAccountActionResult> ResetPasswordAsync(
+        string email, Guid actorUserId, string actorDisplayName,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            var newPassword = PasswordGenerator.GenerateTemporary();
+            await _workspaceUserService.ResetPasswordAsync(email, newPassword, ct);
+
+            await _auditLogService.LogAsync(
+                AuditAction.WorkspaceAccountPasswordReset,
+                "WorkspaceAccount", Guid.Empty,
+                $"Reset password for @{NobodiesTeamDomain} account: {email}",
+                actorUserId, actorDisplayName);
+            await _dbContext.SaveChangesAsync(ct);
+
+            return new WorkspaceAccountActionResult(true,
+                Message: $"Password reset for {email}. New temporary password: {newPassword}",
+                TemporaryPassword: newPassword);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to reset password for: {Email}", email);
+            return new WorkspaceAccountActionResult(false,
+                ErrorMessage: $"Failed to reset password for {email}.");
+        }
+    }
+
+    public async Task<WorkspaceAccountActionResult> LinkAccountAsync(
+        string email, Guid userId,
+        Guid actorUserId, string actorDisplayName,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            var user = await _dbContext.Users.FindAsync([userId], ct);
+            if (user is null)
+            {
+                return new WorkspaceAccountActionResult(false,
+                    ErrorMessage: "Human not found.");
+            }
+
+            // Check not already linked
+            var alreadyLinked = await _dbContext.UserEmails
+                .AnyAsync(ue => EF.Functions.ILike(ue.Email, email), ct);
+            if (alreadyLinked)
+            {
+                return new WorkspaceAccountActionResult(false,
+                    ErrorMessage: $"{email} is already linked to a human.");
+            }
+
+            // Add as verified email (also sets notification target for @nobodies.team)
+            await _userEmailService.AddVerifiedEmailAsync(userId, email, ct);
+
+            // Auto-set as Google service email
+            user.GoogleEmail = email;
+            await _dbContext.SaveChangesAsync(ct);
+
+            // Audit
+            await _auditLogService.LogAsync(
+                AuditAction.WorkspaceAccountLinked,
+                "WorkspaceAccount", userId,
+                $"Linked @{NobodiesTeamDomain} account {email} to {user.DisplayName}",
+                actorUserId, actorDisplayName);
+            await _dbContext.SaveChangesAsync(ct);
+
+            return new WorkspaceAccountActionResult(true,
+                Message: $"Linked {email} to {user.DisplayName}.");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to link {Email} to user {UserId}", email, userId);
+            return new WorkspaceAccountActionResult(false,
+                ErrorMessage: $"Failed to link {email}.");
+        }
+    }
+
+    public async Task<EmailBackfillActionResult> ApplyEmailBackfillAsync(
+        List<Guid> selectedUserIds, Dictionary<string, string> corrections,
+        Guid actorUserId,
+        CancellationToken ct = default)
+    {
+        var updated = 0;
+        var errors = new List<string>();
+
+        foreach (var userId in selectedUserIds)
+        {
+            if (!corrections.TryGetValue(userId.ToString(), out var googleEmail) || string.IsNullOrEmpty(googleEmail))
+                continue;
+
+            try
+            {
+                var user = await _dbContext.Users
+                    .Include(u => u.UserEmails)
+                    .FirstOrDefaultAsync(u => u.Id == userId, ct);
+
+                if (user is null)
+                {
+                    errors.Add($"User {userId} not found.");
+                    continue;
+                }
+
+                var oldEmail = user.Email;
+
+                user.Email = googleEmail;
+                user.UserName = googleEmail;
+                user.NormalizedEmail = googleEmail.ToUpperInvariant();
+                user.NormalizedUserName = googleEmail.ToUpperInvariant();
+
+                // Update OAuth UserEmail record if it exists
+                var oauthEmail = user.UserEmails.FirstOrDefault(e => e.IsOAuth);
+                if (oauthEmail is not null)
+                {
+                    oauthEmail.Email = googleEmail;
+                }
+
+                _logger.LogInformation(
+                    "Admin {AdminId} applying email backfill for user {UserId}: '{OldEmail}' -> '{NewEmail}'",
+                    actorUserId, userId, oldEmail, googleEmail);
+
+                updated++;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to update email for user {UserId}", userId);
+                errors.Add($"Error updating user {userId}: {ex.Message}");
+            }
+        }
+
+        if (updated > 0)
+            await _dbContext.SaveChangesAsync(ct);
+
+        return new EmailBackfillActionResult(updated, errors);
+    }
+
+    public async Task<GroupLinkActionResult> LinkGroupToTeamAsync(
+        Guid teamId, string groupPrefix,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            var team = await _dbContext.Teams.FindAsync([teamId], ct);
+            if (team is null)
+            {
+                return new GroupLinkActionResult(false, ErrorMessage: "Team not found.");
+            }
+
+            var normalizedPrefix = groupPrefix.Trim().ToLowerInvariant();
+            var previousPrefix = team.GoogleGroupPrefix;
+            team.GoogleGroupPrefix = normalizedPrefix;
+
+            var linkResult = await _googleSyncService.EnsureTeamGroupAsync(teamId);
+            if (linkResult.RequiresConfirmation)
+            {
+                await _dbContext.SaveChangesAsync(ct);
+                return new GroupLinkActionResult(true,
+                    InfoMessage: $"Linked group for team \"{team.Name}\". Note: {linkResult.WarningMessage}");
+            }
+
+            if (linkResult.ErrorMessage is not null)
+            {
+                team.GoogleGroupPrefix = previousPrefix;
+                return new GroupLinkActionResult(false,
+                    ErrorMessage: $"Could not link group: {linkResult.ErrorMessage}");
+            }
+
+            await _dbContext.SaveChangesAsync(ct);
+            return new GroupLinkActionResult(true,
+                Message: $"Successfully linked {normalizedPrefix}@nobodies.team to team \"{team.Name}\".");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to link group {GroupPrefix} to team {TeamId}", groupPrefix, teamId);
+            return new GroupLinkActionResult(false,
+                ErrorMessage: $"Failed to link group: {ex.Message}");
+        }
+    }
+
+    public async Task<IReadOnlyList<TeamSummary>> GetActiveTeamsAsync(
+        CancellationToken ct = default)
+    {
+        return await _dbContext.Teams
+            .Where(t => t.IsActive)
+            .OrderBy(t => t.Name)
+            .Select(t => new TeamSummary(t.Id, t.Name))
+            .ToListAsync(ct);
+    }
+}

--- a/src/Humans.Infrastructure/Services/NotificationInboxService.cs
+++ b/src/Humans.Infrastructure/Services/NotificationInboxService.cs
@@ -1,0 +1,391 @@
+using Humans.Application;
+using Humans.Application.Interfaces;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using Humans.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using NodaTime;
+
+namespace Humans.Infrastructure.Services;
+
+/// <summary>
+/// Service for notification inbox read models and write operations.
+/// </summary>
+public class NotificationInboxService : INotificationInboxService
+{
+    private readonly HumansDbContext _dbContext;
+    private readonly IClock _clock;
+    private readonly IMemoryCache _cache;
+    private readonly ILogger<NotificationInboxService> _logger;
+
+    public NotificationInboxService(
+        HumansDbContext dbContext,
+        IClock clock,
+        IMemoryCache cache,
+        ILogger<NotificationInboxService> logger)
+    {
+        _dbContext = dbContext;
+        _clock = clock;
+        _cache = cache;
+        _logger = logger;
+    }
+
+    public async Task<NotificationInboxResult> GetInboxAsync(
+        Guid userId, string? search, string filter, string tab,
+        CancellationToken ct = default)
+    {
+        // Resolved filter is incompatible with unread tab — resolved items are never unread
+        if (string.Equals(filter, "resolved", StringComparison.OrdinalIgnoreCase))
+            tab = "all";
+
+        var now = _clock.GetCurrentInstant();
+        var cutoff = now - Duration.FromDays(7);
+
+        var query = _dbContext.NotificationRecipients
+            .Where(nr => nr.UserId == userId)
+            .Include(nr => nr.Notification)
+                .ThenInclude(n => n.ResolvedByUser)
+            .Include(nr => nr.Notification)
+                .ThenInclude(n => n.Recipients)
+                    .ThenInclude(r => r.User)
+            .AsNoTrackingWithIdentityResolution();
+
+        // Tab filter
+        if (string.Equals(tab, "unread", StringComparison.OrdinalIgnoreCase))
+        {
+            query = query.Where(nr => nr.Notification.ResolvedAt == null && nr.ReadAt == null);
+        }
+        else
+        {
+            // All: unresolved + resolved within last 7 days
+            query = query.Where(nr =>
+                nr.Notification.ResolvedAt == null ||
+                nr.Notification.ResolvedAt > cutoff);
+        }
+
+        // Filter pills
+        if (string.Equals(filter, "action", StringComparison.OrdinalIgnoreCase))
+        {
+            query = query.Where(nr => nr.Notification.Class == NotificationClass.Actionable);
+        }
+        else if (string.Equals(filter, "shifts", StringComparison.OrdinalIgnoreCase))
+        {
+            query = query.Where(nr =>
+                nr.Notification.Source == NotificationSource.ShiftCoverageGap ||
+                nr.Notification.Source == NotificationSource.ShiftSignupChange);
+        }
+        else if (string.Equals(filter, "approvals", StringComparison.OrdinalIgnoreCase))
+        {
+            query = query.Where(nr =>
+                nr.Notification.Source == NotificationSource.ConsentReviewNeeded ||
+                nr.Notification.Source == NotificationSource.ApplicationSubmitted);
+        }
+        else if (string.Equals(filter, "resolved", StringComparison.OrdinalIgnoreCase))
+        {
+            query = query.Where(nr => nr.Notification.ResolvedAt != null);
+        }
+
+        // Search
+        if (!string.IsNullOrWhiteSpace(search) && search.Trim().Length >= 2)
+        {
+            var term = $"%{search.Trim()}%";
+            query = query.Where(nr =>
+                EF.Functions.ILike(nr.Notification.Title, term) ||
+                (nr.Notification.Body != null && EF.Functions.ILike(nr.Notification.Body, term)));
+        }
+
+        var recipients = await query
+            .OrderByDescending(nr => nr.Notification.CreatedAt)
+            .ToListAsync(ct);
+
+        var needsAttention = new List<NotificationRowDto>();
+        var informational = new List<NotificationRowDto>();
+        var resolved = new List<NotificationRowDto>();
+
+        foreach (var nr in recipients)
+        {
+            var row = MapToRow(nr);
+            if (row.IsResolved)
+                resolved.Add(row);
+            else if (nr.Notification.Class == NotificationClass.Actionable)
+                needsAttention.Add(row);
+            else
+                informational.Add(row);
+        }
+
+        var unreadCount = recipients.Count(nr =>
+            nr.Notification.ResolvedAt == null && nr.ReadAt == null);
+
+        return new NotificationInboxResult
+        {
+            NeedsAttention = needsAttention,
+            Informational = informational,
+            Resolved = resolved,
+            UnreadCount = unreadCount,
+        };
+    }
+
+    public async Task<NotificationPopupResult> GetPopupAsync(
+        Guid userId,
+        CancellationToken ct = default)
+    {
+        var recipients = await _dbContext.NotificationRecipients
+            .Where(nr => nr.UserId == userId && nr.Notification.ResolvedAt == null)
+            .Include(nr => nr.Notification)
+                .ThenInclude(n => n.Recipients)
+                    .ThenInclude(r => r.User)
+            .AsNoTrackingWithIdentityResolution()
+            .OrderByDescending(nr => nr.Notification.CreatedAt)
+            .ToListAsync(ct);
+
+        var actionable = new List<NotificationRowDto>();
+        var informational = new List<NotificationRowDto>();
+
+        foreach (var nr in recipients)
+        {
+            var row = MapToRow(nr);
+            if (nr.Notification.Class == NotificationClass.Actionable)
+                actionable.Add(row);
+            else
+                informational.Add(row);
+        }
+
+        return new NotificationPopupResult
+        {
+            Actionable = actionable,
+            Informational = informational,
+            ActionableCount = actionable.Count,
+        };
+    }
+
+    public async Task<NotificationActionResult> ResolveAsync(
+        Guid notificationId, Guid userId,
+        CancellationToken ct = default)
+    {
+        var notification = await _dbContext.Notifications
+            .Include(n => n.Recipients)
+            .FirstOrDefaultAsync(n => n.Id == notificationId, ct);
+
+        if (notification is null)
+            return new NotificationActionResult(false, NotFound: true);
+
+        if (!notification.Recipients.Any(r => r.UserId == userId))
+            return new NotificationActionResult(false, Forbidden: true);
+
+        if (notification.ResolvedAt is null)
+        {
+            notification.ResolvedAt = _clock.GetCurrentInstant();
+            notification.ResolvedByUserId = userId;
+            await _dbContext.SaveChangesAsync(ct);
+            InvalidateBadgeCaches(notification.Recipients.Select(r => r.UserId));
+        }
+
+        return new NotificationActionResult(true);
+    }
+
+    public async Task<NotificationActionResult> DismissAsync(
+        Guid notificationId, Guid userId,
+        CancellationToken ct = default)
+    {
+        var notification = await _dbContext.Notifications
+            .Include(n => n.Recipients)
+            .FirstOrDefaultAsync(n => n.Id == notificationId, ct);
+
+        if (notification is null)
+            return new NotificationActionResult(false, NotFound: true);
+
+        if (!notification.Recipients.Any(r => r.UserId == userId))
+            return new NotificationActionResult(false, Forbidden: true);
+
+        // Actionable notifications cannot be dismissed
+        if (notification.Class == NotificationClass.Actionable)
+            return new NotificationActionResult(false, Forbidden: true);
+
+        if (notification.ResolvedAt is null)
+        {
+            notification.ResolvedAt = _clock.GetCurrentInstant();
+            notification.ResolvedByUserId = userId;
+            await _dbContext.SaveChangesAsync(ct);
+            InvalidateBadgeCaches(notification.Recipients.Select(r => r.UserId));
+        }
+
+        return new NotificationActionResult(true);
+    }
+
+    public async Task<NotificationActionResult> MarkReadAsync(
+        Guid notificationId, Guid userId,
+        CancellationToken ct = default)
+    {
+        var recipient = await _dbContext.NotificationRecipients
+            .FirstOrDefaultAsync(nr => nr.NotificationId == notificationId && nr.UserId == userId, ct);
+
+        if (recipient is null)
+            return new NotificationActionResult(false, NotFound: true);
+
+        if (recipient.ReadAt is null)
+        {
+            recipient.ReadAt = _clock.GetCurrentInstant();
+            await _dbContext.SaveChangesAsync(ct);
+            InvalidateBadgeCaches([userId]);
+        }
+
+        return new NotificationActionResult(true);
+    }
+
+    public async Task MarkAllReadAsync(
+        Guid userId,
+        CancellationToken ct = default)
+    {
+        var now = _clock.GetCurrentInstant();
+
+        var unread = await _dbContext.NotificationRecipients
+            .Where(nr => nr.UserId == userId && nr.ReadAt == null)
+            .ToListAsync(ct);
+
+        foreach (var nr in unread)
+        {
+            nr.ReadAt = now;
+        }
+
+        if (unread.Count > 0)
+        {
+            await _dbContext.SaveChangesAsync(ct);
+            InvalidateBadgeCaches([userId]);
+        }
+    }
+
+    public async Task BulkResolveAsync(
+        List<Guid> notificationIds, Guid userId,
+        CancellationToken ct = default)
+    {
+        if (notificationIds.Count == 0) return;
+
+        var now = _clock.GetCurrentInstant();
+
+        var notifications = await _dbContext.Notifications
+            .Include(n => n.Recipients)
+            .Where(n => notificationIds.Contains(n.Id) &&
+                        n.Class == NotificationClass.Actionable &&
+                        n.ResolvedAt == null)
+            .ToListAsync(ct);
+
+        foreach (var notification in notifications)
+        {
+            if (notification.Recipients.Any(r => r.UserId == userId))
+            {
+                notification.ResolvedAt = now;
+                notification.ResolvedByUserId = userId;
+            }
+        }
+
+        if (notifications.Count > 0)
+        {
+            await _dbContext.SaveChangesAsync(ct);
+            var affectedUserIds = notifications.SelectMany(n => n.Recipients.Select(r => r.UserId)).Distinct();
+            InvalidateBadgeCaches(affectedUserIds);
+        }
+    }
+
+    public async Task BulkDismissAsync(
+        List<Guid> notificationIds, Guid userId,
+        CancellationToken ct = default)
+    {
+        if (notificationIds.Count == 0) return;
+
+        var now = _clock.GetCurrentInstant();
+
+        var notifications = await _dbContext.Notifications
+            .Include(n => n.Recipients)
+            .Where(n => notificationIds.Contains(n.Id) &&
+                        n.Class == NotificationClass.Informational &&
+                        n.ResolvedAt == null)
+            .ToListAsync(ct);
+
+        foreach (var notification in notifications)
+        {
+            if (notification.Recipients.Any(r => r.UserId == userId))
+            {
+                notification.ResolvedAt = now;
+                notification.ResolvedByUserId = userId;
+            }
+        }
+
+        if (notifications.Count > 0)
+        {
+            await _dbContext.SaveChangesAsync(ct);
+            var affectedUserIds = notifications.SelectMany(n => n.Recipients.Select(r => r.UserId)).Distinct();
+            InvalidateBadgeCaches(affectedUserIds);
+        }
+    }
+
+    public async Task<string?> ClickThroughAsync(
+        Guid notificationId, Guid userId,
+        CancellationToken ct = default)
+    {
+        var recipient = await _dbContext.NotificationRecipients
+            .Include(nr => nr.Notification)
+            .FirstOrDefaultAsync(nr => nr.NotificationId == notificationId && nr.UserId == userId, ct);
+
+        if (recipient is null)
+            return null;
+
+        // Mark as read on click-through
+        if (recipient.ReadAt is null)
+        {
+            recipient.ReadAt = _clock.GetCurrentInstant();
+            await _dbContext.SaveChangesAsync(ct);
+            InvalidateBadgeCaches([userId]);
+        }
+
+        return recipient.Notification.ActionUrl;
+    }
+
+    private static NotificationRowDto MapToRow(NotificationRecipient nr)
+    {
+        var n = nr.Notification;
+        var allRecipients = n.Recipients?.ToList() ?? [];
+
+        return new NotificationRowDto
+        {
+            Id = n.Id,
+            Title = n.Title,
+            Body = n.Body,
+            ActionUrl = n.ActionUrl,
+            ActionLabel = n.ActionLabel,
+            Priority = n.Priority,
+            Source = n.Source,
+            Class = n.Class,
+            TargetGroupName = n.TargetGroupName,
+            CreatedAt = n.CreatedAt.ToDateTimeUtc(),
+            IsRead = nr.ReadAt is not null,
+            IsResolved = n.ResolvedAt is not null,
+            ResolvedAt = n.ResolvedAt?.ToDateTimeUtc(),
+            ResolvedByName = n.ResolvedByUser?.DisplayName,
+            RecipientInitials = allRecipients
+                .Take(3)
+                .Select(r => GetInitials(r.User?.DisplayName))
+                .ToList(),
+            TotalRecipientCount = allRecipients.Count,
+        };
+    }
+
+    private static string GetInitials(string? displayName)
+    {
+        if (string.IsNullOrWhiteSpace(displayName))
+            return "?";
+        var parts = displayName.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        return parts.Length >= 2
+            ? $"{parts[0][0]}{parts[^1][0]}".ToUpperInvariant()
+            : parts[0][..Math.Min(2, parts[0].Length)].ToUpperInvariant();
+    }
+
+    private void InvalidateBadgeCaches(IEnumerable<Guid> userIds)
+    {
+        foreach (var userId in userIds)
+        {
+            _cache.Remove(CacheKeys.NotificationBadgeCounts(userId));
+        }
+    }
+}

--- a/src/Humans.Web/Controllers/GoogleController.cs
+++ b/src/Humans.Web/Controllers/GoogleController.cs
@@ -1,16 +1,12 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
 using Humans.Application.DTOs;
 using Humans.Application.Interfaces;
 using Humans.Domain.Constants;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
-using Humans.Infrastructure.Data;
 using Humans.Web.Authorization;
-using Humans.Web.Extensions;
-using Humans.Web.Helpers;
 using Humans.Web.Models;
 
 namespace Humans.Web.Controllers;
@@ -22,33 +18,25 @@ public class GoogleController : HumansControllerBase
     private readonly IGoogleSyncService _googleSyncService;
     private readonly IAuditLogService _auditLogService;
     private readonly ITeamResourceService _teamResourceService;
-    private readonly IGoogleWorkspaceUserService _workspaceUserService;
-    private readonly IUserEmailService _userEmailService;
     private readonly IEmailProvisioningService _emailProvisioningService;
-    private readonly HumansDbContext _dbContext;
+    private readonly IGoogleAdminService _googleAdminService;
     private readonly ILogger<GoogleController> _logger;
-
-    private const string NobodiesTeamDomain = "nobodies.team";
 
     public GoogleController(
         UserManager<User> userManager,
         IGoogleSyncService googleSyncService,
         IAuditLogService auditLogService,
         ITeamResourceService teamResourceService,
-        IGoogleWorkspaceUserService workspaceUserService,
-        IUserEmailService userEmailService,
         IEmailProvisioningService emailProvisioningService,
-        HumansDbContext dbContext,
+        IGoogleAdminService googleAdminService,
         ILogger<GoogleController> logger)
         : base(userManager)
     {
         _googleSyncService = googleSyncService;
         _auditLogService = auditLogService;
         _teamResourceService = teamResourceService;
-        _workspaceUserService = workspaceUserService;
-        _userEmailService = userEmailService;
         _emailProvisioningService = emailProvisioningService;
-        _dbContext = dbContext;
+        _googleAdminService = googleAdminService;
         _logger = logger;
     }
 
@@ -247,7 +235,8 @@ public class GoogleController : HumansControllerBase
         try
         {
             var result = await _googleSyncService.GetAllDomainGroupsAsync();
-            ViewBag.Teams = await _dbContext.Teams.Where(t => t.IsActive).OrderBy(t => t.Name).ToListAsync();
+            var teams = await _googleAdminService.GetActiveTeamsAsync();
+            ViewBag.Teams = teams;
             return View(result);
         }
         catch (Exception ex)
@@ -269,37 +258,14 @@ public class GoogleController : HumansControllerBase
             return RedirectToAction(nameof(AllGroups));
         }
 
-        try
-        {
-            var team = await _dbContext.Teams.FindAsync(teamId);
-            if (team is null) return NotFound();
+        var result = await _googleAdminService.LinkGroupToTeamAsync(teamId, groupPrefix);
 
-            var normalizedPrefix = groupPrefix.Trim().ToLowerInvariant();
-            var previousPrefix = team.GoogleGroupPrefix;
-            team.GoogleGroupPrefix = normalizedPrefix;
-
-            var linkResult = await _googleSyncService.EnsureTeamGroupAsync(teamId);
-            if (linkResult.RequiresConfirmation)
-            {
-                await _dbContext.SaveChangesAsync();
-                SetInfo($"Linked group for team \"{team.Name}\". Note: {linkResult.WarningMessage}");
-            }
-            else if (linkResult.ErrorMessage is not null)
-            {
-                team.GoogleGroupPrefix = previousPrefix;
-                SetError($"Could not link group: {linkResult.ErrorMessage}");
-            }
-            else
-            {
-                await _dbContext.SaveChangesAsync();
-                SetSuccess($"Successfully linked {normalizedPrefix}@nobodies.team to team \"{team.Name}\".");
-            }
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to link group {GroupPrefix} to team {TeamId}", groupPrefix, teamId);
-            SetError($"Failed to link group: {ex.Message}");
-        }
+        if (result.ErrorMessage is not null)
+            SetError(result.ErrorMessage);
+        else if (result.InfoMessage is not null)
+            SetInfo(result.InfoMessage);
+        else if (result.Message is not null)
+            SetSuccess(result.Message);
 
         return RedirectToAction(nameof(AllGroups));
     }
@@ -358,60 +324,13 @@ public class GoogleController : HumansControllerBase
         var currentUser = await GetCurrentUserAsync();
         if (currentUser is null) return Unauthorized();
 
-        var updated = 0;
-        var errors = new List<string>();
+        var result = await _googleAdminService.ApplyEmailBackfillAsync(
+            selectedUserIds, corrections, currentUser.Id);
 
-        foreach (var userId in selectedUserIds)
-        {
-            if (!corrections.TryGetValue(userId.ToString(), out var googleEmail) || string.IsNullOrEmpty(googleEmail))
-                continue;
-
-            try
-            {
-                var user = await _dbContext.Users
-                    .Include(u => u.UserEmails)
-                    .FirstOrDefaultAsync(u => u.Id == userId);
-
-                if (user is null)
-                {
-                    errors.Add($"User {userId} not found.");
-                    continue;
-                }
-
-                var oldEmail = user.Email;
-
-                user.Email = googleEmail;
-                user.UserName = googleEmail;
-                user.NormalizedEmail = googleEmail.ToUpperInvariant();
-                user.NormalizedUserName = googleEmail.ToUpperInvariant();
-
-                // Update OAuth UserEmail record if it exists
-                var oauthEmail = user.UserEmails.FirstOrDefault(e => e.IsOAuth);
-                if (oauthEmail is not null)
-                {
-                    oauthEmail.Email = googleEmail;
-                }
-
-                _logger.LogInformation(
-                    "Admin {AdminId} applying email backfill for user {UserId}: '{OldEmail}' -> '{NewEmail}'",
-                    currentUser.Id, userId, oldEmail, googleEmail);
-
-                updated++;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Failed to update email for user {UserId}", userId);
-                errors.Add($"Error updating user {userId}: {ex.Message}");
-            }
-        }
-
-        if (updated > 0)
-            await _dbContext.SaveChangesAsync();
-
-        if (errors.Count > 0)
-            SetError($"Applied {updated} correction(s) with {errors.Count} error(s): {string.Join("; ", errors)}");
+        if (result.Errors.Count > 0)
+            SetError($"Applied {result.UpdatedCount} correction(s) with {result.Errors.Count} error(s): {string.Join("; ", result.Errors)}");
         else
-            SetSuccess($"Applied {updated} email correction(s) successfully.");
+            SetSuccess($"Applied {result.UpdatedCount} email correction(s) successfully.");
 
         return RedirectToAction(nameof(Index));
     }
@@ -563,69 +482,36 @@ public class GoogleController : HumansControllerBase
     [HttpGet("Accounts")]
     public async Task<IActionResult> Accounts()
     {
-        try
+        var result = await _googleAdminService.GetWorkspaceAccountListAsync();
+
+        if (result.ErrorMessage is not null)
         {
-            var accounts = await _workspaceUserService.ListAccountsAsync();
-
-            // Load all user emails to match accounts to humans
-            var allUserEmails = await _dbContext.UserEmails
-                .AsNoTracking()
-                .Include(ue => ue.User)
-                .ToListAsync();
-
-            var accountViewModels = new List<WorkspaceEmailAccountViewModel>();
-            var notPrimaryCount = 0;
-
-            foreach (var account in accounts)
-            {
-                var matchedEmail = allUserEmails.FirstOrDefault(ue =>
-                    string.Equals(ue.Email, account.PrimaryEmail, StringComparison.OrdinalIgnoreCase));
-
-                var isUsedAsPrimary = matchedEmail is { IsNotificationTarget: true };
-
-                // Count accounts that exist in the system but are not used as primary
-                if (matchedEmail is not null && !isUsedAsPrimary)
-                {
-                    notPrimaryCount++;
-                }
-
-                accountViewModels.Add(new WorkspaceEmailAccountViewModel
-                {
-                    PrimaryEmail = account.PrimaryEmail,
-                    FirstName = account.FirstName,
-                    LastName = account.LastName,
-                    IsSuspended = account.IsSuspended,
-                    CreationTime = account.CreationTime,
-                    LastLoginTime = account.LastLoginTime,
-                    MatchedUserId = matchedEmail?.UserId,
-                    MatchedDisplayName = matchedEmail?.User?.DisplayName,
-                    IsUsedAsPrimary = isUsedAsPrimary
-                });
-            }
-
-            var linkedCount = accountViewModels.Count(a => a.MatchedUserId.HasValue);
-
-            var model = new WorkspaceEmailListViewModel
-            {
-                Accounts = accountViewModels
-                    .OrderBy(a => a.PrimaryEmail, StringComparer.OrdinalIgnoreCase)
-                    .ToList(),
-                TotalAccounts = accountViewModels.Count,
-                ActiveAccounts = accountViewModels.Count(a => !a.IsSuspended),
-                SuspendedAccounts = accountViewModels.Count(a => a.IsSuspended),
-                LinkedAccounts = linkedCount,
-                UnlinkedAccounts = accountViewModels.Count - linkedCount,
-                NotPrimaryCount = notPrimaryCount
-            };
-
-            return View(model);
+            SetError(result.ErrorMessage);
         }
-        catch (Exception ex)
+
+        var model = new WorkspaceEmailListViewModel
         {
-            _logger.LogError(ex, "Failed to load @nobodies.team accounts");
-            SetError("Failed to load @nobodies.team accounts. Check the logs for details.");
-            return View(new WorkspaceEmailListViewModel());
-        }
+            Accounts = result.Accounts.Select(a => new WorkspaceEmailAccountViewModel
+            {
+                PrimaryEmail = a.PrimaryEmail,
+                FirstName = a.FirstName,
+                LastName = a.LastName,
+                IsSuspended = a.IsSuspended,
+                CreationTime = a.CreationTime,
+                LastLoginTime = a.LastLoginTime,
+                MatchedUserId = a.MatchedUserId,
+                MatchedDisplayName = a.MatchedDisplayName,
+                IsUsedAsPrimary = a.IsUsedAsPrimary
+            }).ToList(),
+            TotalAccounts = result.TotalAccounts,
+            ActiveAccounts = result.ActiveAccounts,
+            SuspendedAccounts = result.SuspendedAccounts,
+            LinkedAccounts = result.LinkedAccounts,
+            UnlinkedAccounts = result.UnlinkedAccounts,
+            NotPrimaryCount = result.NotPrimaryCount
+        };
+
+        return View(model);
     }
 
     [HttpPost("Accounts/Provision")]
@@ -640,45 +526,19 @@ public class GoogleController : HumansControllerBase
             return RedirectToAction(nameof(Accounts));
         }
 
-        var emailPrefix = model.EmailPrefix.Trim().ToLowerInvariant();
-        var fullEmail = $"{emailPrefix}@{NobodiesTeamDomain}";
+        var currentUser = await GetCurrentUserAsync();
+        if (currentUser is null) return Unauthorized();
 
-        // Check if account already exists
-        var existing = await _workspaceUserService.GetAccountAsync(fullEmail);
-        if (existing is not null)
-        {
-            SetError($"Account {fullEmail} already exists.");
-            return RedirectToAction(nameof(Accounts));
-        }
+        var result = await _googleAdminService.ProvisionStandaloneAccountAsync(
+            model.EmailPrefix, model.FirstName, model.LastName,
+            currentUser.Id, currentUser.DisplayName);
 
-        try
-        {
-            // Generate a temporary password
-            var tempPassword = PasswordGenerator.GenerateTemporary();
+        if (result.Success)
+            SetSuccess(result.Message!);
+        else
+            SetError(result.ErrorMessage!);
 
-            await _workspaceUserService.ProvisionAccountAsync(
-                fullEmail, model.FirstName.Trim(), model.LastName.Trim(), tempPassword);
-
-            var currentUser = await GetCurrentUserAsync();
-            if (currentUser is not null)
-            {
-                await _auditLogService.LogAsync(
-                    AuditAction.WorkspaceAccountProvisioned,
-                    "WorkspaceAccount", Guid.Empty,
-                    $"Provisioned @{NobodiesTeamDomain} account: {fullEmail}",
-                    currentUser.Id, currentUser.DisplayName);
-                await _dbContext.SaveChangesAsync();
-            }
-
-            SetSuccess($"Account {fullEmail} provisioned. Temporary password: {tempPassword}");
-            return RedirectToAction(nameof(Accounts));
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to provision @nobodies.team account: {Email}", fullEmail);
-            SetError($"Failed to provision {fullEmail}. Check logs for details.");
-            return RedirectToAction(nameof(Accounts));
-        }
+        return RedirectToAction(nameof(Accounts));
     }
 
     [HttpPost("Accounts/Suspend")]
@@ -690,28 +550,16 @@ public class GoogleController : HumansControllerBase
             return BadRequest();
         }
 
-        try
-        {
-            await _workspaceUserService.SuspendAccountAsync(email);
+        var currentUser = await GetCurrentUserAsync();
+        if (currentUser is null) return Unauthorized();
 
-            var currentUser = await GetCurrentUserAsync();
-            if (currentUser is not null)
-            {
-                await _auditLogService.LogAsync(
-                    AuditAction.WorkspaceAccountSuspended,
-                    "WorkspaceAccount", Guid.Empty,
-                    $"Suspended @{NobodiesTeamDomain} account: {email}",
-                    currentUser.Id, currentUser.DisplayName);
-                await _dbContext.SaveChangesAsync();
-            }
+        var result = await _googleAdminService.SuspendAccountAsync(
+            email, currentUser.Id, currentUser.DisplayName);
 
-            SetSuccess($"Account {email} suspended.");
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to suspend account: {Email}", email);
-            SetError($"Failed to suspend {email}.");
-        }
+        if (result.Success)
+            SetSuccess(result.Message!);
+        else
+            SetError(result.ErrorMessage!);
 
         return RedirectToAction(nameof(Accounts));
     }
@@ -725,28 +573,16 @@ public class GoogleController : HumansControllerBase
             return BadRequest();
         }
 
-        try
-        {
-            await _workspaceUserService.ReactivateAccountAsync(email);
+        var currentUser = await GetCurrentUserAsync();
+        if (currentUser is null) return Unauthorized();
 
-            var currentUser = await GetCurrentUserAsync();
-            if (currentUser is not null)
-            {
-                await _auditLogService.LogAsync(
-                    AuditAction.WorkspaceAccountReactivated,
-                    "WorkspaceAccount", Guid.Empty,
-                    $"Reactivated @{NobodiesTeamDomain} account: {email}",
-                    currentUser.Id, currentUser.DisplayName);
-                await _dbContext.SaveChangesAsync();
-            }
+        var result = await _googleAdminService.ReactivateAccountAsync(
+            email, currentUser.Id, currentUser.DisplayName);
 
-            SetSuccess($"Account {email} reactivated.");
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to reactivate account: {Email}", email);
-            SetError($"Failed to reactivate {email}.");
-        }
+        if (result.Success)
+            SetSuccess(result.Message!);
+        else
+            SetError(result.ErrorMessage!);
 
         return RedirectToAction(nameof(Accounts));
     }
@@ -760,29 +596,16 @@ public class GoogleController : HumansControllerBase
             return BadRequest();
         }
 
-        try
-        {
-            var newPassword = PasswordGenerator.GenerateTemporary();
-            await _workspaceUserService.ResetPasswordAsync(email, newPassword);
+        var currentUser = await GetCurrentUserAsync();
+        if (currentUser is null) return Unauthorized();
 
-            var currentUser = await GetCurrentUserAsync();
-            if (currentUser is not null)
-            {
-                await _auditLogService.LogAsync(
-                    AuditAction.WorkspaceAccountPasswordReset,
-                    "WorkspaceAccount", Guid.Empty,
-                    $"Reset password for @{NobodiesTeamDomain} account: {email}",
-                    currentUser.Id, currentUser.DisplayName);
-                await _dbContext.SaveChangesAsync();
-            }
+        var result = await _googleAdminService.ResetPasswordAsync(
+            email, currentUser.Id, currentUser.DisplayName);
 
-            SetSuccess($"Password reset for {email}. New temporary password: {newPassword}");
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to reset password for: {Email}", email);
-            SetError($"Failed to reset password for {email}.");
-        }
+        if (result.Success)
+            SetSuccess(result.Message!);
+        else
+            SetError(result.ErrorMessage!);
 
         return RedirectToAction(nameof(Accounts));
     }
@@ -797,50 +620,16 @@ public class GoogleController : HumansControllerBase
             return RedirectToAction(nameof(Accounts));
         }
 
-        try
-        {
-            var user = await _dbContext.Users.FindAsync(userId);
-            if (user is null)
-            {
-                SetError("Human not found.");
-                return RedirectToAction(nameof(Accounts));
-            }
+        var currentUser = await GetCurrentUserAsync();
+        if (currentUser is null) return Unauthorized();
 
-            // Check not already linked
-            var alreadyLinked = await _dbContext.UserEmails
-                .AnyAsync(ue => EF.Functions.ILike(ue.Email, email));
-            if (alreadyLinked)
-            {
-                SetError($"{email} is already linked to a human.");
-                return RedirectToAction(nameof(Accounts));
-            }
+        var result = await _googleAdminService.LinkAccountAsync(
+            email, userId, currentUser.Id, currentUser.DisplayName);
 
-            // Add as verified email (also sets notification target for @nobodies.team)
-            await _userEmailService.AddVerifiedEmailAsync(userId, email);
-
-            // Auto-set as Google service email
-            user.GoogleEmail = email;
-            await _dbContext.SaveChangesAsync();
-
-            // Audit
-            var currentUser = await GetCurrentUserAsync();
-            if (currentUser is not null)
-            {
-                await _auditLogService.LogAsync(
-                    AuditAction.WorkspaceAccountLinked,
-                    "WorkspaceAccount", userId,
-                    $"Linked @{NobodiesTeamDomain} account {email} to {user.DisplayName}",
-                    currentUser.Id, currentUser.DisplayName);
-                await _dbContext.SaveChangesAsync();
-            }
-
-            SetSuccess($"Linked {email} to {user.DisplayName}.");
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to link {Email} to user {UserId}", email, userId);
-            SetError($"Failed to link {email}.");
-        }
+        if (result.Success)
+            SetSuccess(result.Message!);
+        else
+            SetError(result.ErrorMessage!);
 
         return RedirectToAction(nameof(Accounts));
     }

--- a/src/Humans.Web/Controllers/NotificationController.cs
+++ b/src/Humans.Web/Controllers/NotificationController.cs
@@ -15,18 +15,15 @@ public class NotificationController : HumansControllerBase
 {
     private readonly INotificationInboxService _inboxService;
     private readonly IStringLocalizer<SharedResource> _localizer;
-    private readonly ILogger<NotificationController> _logger;
 
     public NotificationController(
         INotificationInboxService inboxService,
         UserManager<User> userManager,
-        IStringLocalizer<SharedResource> localizer,
-        ILogger<NotificationController> logger)
+        IStringLocalizer<SharedResource> localizer)
         : base(userManager)
     {
         _inboxService = inboxService;
         _localizer = localizer;
-        _logger = logger;
     }
 
     [HttpGet("")]

--- a/src/Humans.Web/Controllers/NotificationController.cs
+++ b/src/Humans.Web/Controllers/NotificationController.cs
@@ -1,16 +1,11 @@
 using Humans.Application;
+using Humans.Application.Interfaces;
 using Humans.Domain.Entities;
-using Humans.Domain.Enums;
-using Humans.Infrastructure.Data;
-using Humans.Web.Extensions;
 using Humans.Web.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Localization;
-using NodaTime;
 
 namespace Humans.Web.Controllers;
 
@@ -18,24 +13,18 @@ namespace Humans.Web.Controllers;
 [Route("Notifications")]
 public class NotificationController : HumansControllerBase
 {
-    private readonly HumansDbContext _dbContext;
-    private readonly IClock _clock;
-    private readonly IMemoryCache _cache;
+    private readonly INotificationInboxService _inboxService;
     private readonly IStringLocalizer<SharedResource> _localizer;
     private readonly ILogger<NotificationController> _logger;
 
     public NotificationController(
-        HumansDbContext dbContext,
+        INotificationInboxService inboxService,
         UserManager<User> userManager,
-        IClock clock,
-        IMemoryCache cache,
         IStringLocalizer<SharedResource> localizer,
         ILogger<NotificationController> logger)
         : base(userManager)
     {
-        _dbContext = dbContext;
-        _clock = clock;
-        _cache = cache;
+        _inboxService = inboxService;
         _localizer = localizer;
         _logger = logger;
     }
@@ -47,94 +36,20 @@ public class NotificationController : HumansControllerBase
         var (err, user) = await RequireCurrentUserAsync();
         if (err is not null) return err;
 
-        // Resolved filter is incompatible with unread tab — resolved items are never unread
+        // Resolved filter is incompatible with unread tab
         if (string.Equals(filter, "resolved", StringComparison.OrdinalIgnoreCase))
             tab = "all";
 
-        var now = _clock.GetCurrentInstant();
-        var cutoff = now - Duration.FromDays(7);
+        var result = await _inboxService.GetInboxAsync(user.Id, search, filter, tab);
 
-        var query = _dbContext.NotificationRecipients
-            .Where(nr => nr.UserId == user.Id)
-            .Include(nr => nr.Notification)
-                .ThenInclude(n => n.ResolvedByUser)
-            .Include(nr => nr.Notification)
-                .ThenInclude(n => n.Recipients)
-                    .ThenInclude(r => r.User)
-            .AsNoTrackingWithIdentityResolution();
-
-        // Tab filter
-        if (string.Equals(tab, "unread", StringComparison.OrdinalIgnoreCase))
-        {
-            query = query.Where(nr => nr.Notification.ResolvedAt == null && nr.ReadAt == null);
-        }
-        else
-        {
-            // All: unresolved + resolved within last 7 days
-            query = query.Where(nr =>
-                nr.Notification.ResolvedAt == null ||
-                nr.Notification.ResolvedAt > cutoff);
-        }
-
-        // Filter pills
-        if (string.Equals(filter, "action", StringComparison.OrdinalIgnoreCase))
-        {
-            query = query.Where(nr => nr.Notification.Class == NotificationClass.Actionable);
-        }
-        else if (string.Equals(filter, "shifts", StringComparison.OrdinalIgnoreCase))
-        {
-            query = query.Where(nr =>
-                nr.Notification.Source == NotificationSource.ShiftCoverageGap ||
-                nr.Notification.Source == NotificationSource.ShiftSignupChange);
-        }
-        else if (string.Equals(filter, "approvals", StringComparison.OrdinalIgnoreCase))
-        {
-            query = query.Where(nr =>
-                nr.Notification.Source == NotificationSource.ConsentReviewNeeded ||
-                nr.Notification.Source == NotificationSource.ApplicationSubmitted);
-        }
-        else if (string.Equals(filter, "resolved", StringComparison.OrdinalIgnoreCase))
-        {
-            query = query.Where(nr => nr.Notification.ResolvedAt != null);
-        }
-
-        // Search
-        if (!string.IsNullOrWhiteSpace(search) && search.Trim().Length >= 2)
-        {
-            var term = $"%{search.Trim()}%";
-            query = query.Where(nr =>
-                EF.Functions.ILike(nr.Notification.Title, term) ||
-                (nr.Notification.Body != null && EF.Functions.ILike(nr.Notification.Body, term)));
-        }
-
-        var recipients = await query
-            .OrderByDescending(nr => nr.Notification.CreatedAt)
-            .ToListAsync();
-
-        var needsAttention = new List<NotificationRowViewModel>();
-        var informational = new List<NotificationRowViewModel>();
-        var resolved = new List<NotificationRowViewModel>();
-
-        foreach (var nr in recipients)
-        {
-            var vm = MapToRow(nr);
-            if (vm.IsResolved)
-                resolved.Add(vm);
-            else if (nr.Notification.Class == NotificationClass.Actionable)
-                needsAttention.Add(vm);
-            else
-                informational.Add(vm);
-        }
-
-        var unreadCount = recipients.Count(nr =>
-            nr.Notification.ResolvedAt == null && nr.ReadAt == null);
+        var defaultActionLabel = _localizer["Notification_DefaultActionLabel"].Value;
 
         return View(new NotificationInboxViewModel
         {
-            NeedsAttention = needsAttention,
-            Informational = informational,
-            Resolved = resolved,
-            UnreadCount = unreadCount,
+            NeedsAttention = result.NeedsAttention.Select(r => MapToViewModel(r, defaultActionLabel)).ToList(),
+            Informational = result.Informational.Select(r => MapToViewModel(r, defaultActionLabel)).ToList(),
+            Resolved = result.Resolved.Select(r => MapToViewModel(r, defaultActionLabel)).ToList(),
+            UnreadCount = result.UnreadCount,
             SearchTerm = search,
             ActiveFilter = filter,
             ActiveTab = tab,
@@ -147,32 +62,15 @@ public class NotificationController : HumansControllerBase
         var (err, user) = await RequireCurrentUserAsync();
         if (err is not null) return err;
 
-        var recipients = await _dbContext.NotificationRecipients
-            .Where(nr => nr.UserId == user.Id && nr.Notification.ResolvedAt == null)
-            .Include(nr => nr.Notification)
-                .ThenInclude(n => n.Recipients)
-                    .ThenInclude(r => r.User)
-            .AsNoTrackingWithIdentityResolution()
-            .OrderByDescending(nr => nr.Notification.CreatedAt)
-            .ToListAsync();
+        var result = await _inboxService.GetPopupAsync(user.Id);
 
-        var actionable = new List<NotificationRowViewModel>();
-        var informational = new List<NotificationRowViewModel>();
-
-        foreach (var nr in recipients)
-        {
-            var vm = MapToRow(nr);
-            if (nr.Notification.Class == NotificationClass.Actionable)
-                actionable.Add(vm);
-            else
-                informational.Add(vm);
-        }
+        var defaultActionLabel = _localizer["Notification_DefaultActionLabel"].Value;
 
         return PartialView("_NotificationPopup", new NotificationPopupViewModel
         {
-            Actionable = actionable,
-            Informational = informational,
-            ActionableCount = actionable.Count,
+            Actionable = result.Actionable.Select(r => MapToViewModel(r, defaultActionLabel)).ToList(),
+            Informational = result.Informational.Select(r => MapToViewModel(r, defaultActionLabel)).ToList(),
+            ActionableCount = result.ActionableCount,
         });
     }
 
@@ -183,24 +81,10 @@ public class NotificationController : HumansControllerBase
         var (err, user) = await RequireCurrentUserAsync();
         if (err is not null) return err;
 
-        var notification = await _dbContext.Notifications
-            .Include(n => n.Recipients)
-            .FirstOrDefaultAsync(n => n.Id == id);
+        var result = await _inboxService.ResolveAsync(id, user.Id);
 
-        if (notification is null)
-            return NotFound();
-
-        // Verify the user is a recipient
-        if (!notification.Recipients.Any(r => r.UserId == user.Id))
-            return Forbid();
-
-        if (notification.ResolvedAt is null)
-        {
-            notification.ResolvedAt = _clock.GetCurrentInstant();
-            notification.ResolvedByUserId = user.Id;
-            await _dbContext.SaveChangesAsync();
-            InvalidateBadgeCaches(notification.Recipients.Select(r => r.UserId));
-        }
+        if (result.NotFound) return NotFound();
+        if (result.Forbidden) return Forbid();
 
         if (Request.Headers.XRequestedWith == "XMLHttpRequest")
             return Ok();
@@ -215,28 +99,10 @@ public class NotificationController : HumansControllerBase
         var (err, user) = await RequireCurrentUserAsync();
         if (err is not null) return err;
 
-        var notification = await _dbContext.Notifications
-            .Include(n => n.Recipients)
-            .FirstOrDefaultAsync(n => n.Id == id);
+        var result = await _inboxService.DismissAsync(id, user.Id);
 
-        if (notification is null)
-            return NotFound();
-
-        // Verify the user is a recipient
-        if (!notification.Recipients.Any(r => r.UserId == user.Id))
-            return Forbid();
-
-        // Actionable notifications cannot be dismissed
-        if (notification.Class == NotificationClass.Actionable)
-            return StatusCode(403);
-
-        if (notification.ResolvedAt is null)
-        {
-            notification.ResolvedAt = _clock.GetCurrentInstant();
-            notification.ResolvedByUserId = user.Id;
-            await _dbContext.SaveChangesAsync();
-            InvalidateBadgeCaches(notification.Recipients.Select(r => r.UserId));
-        }
+        if (result.NotFound) return NotFound();
+        if (result.Forbidden) return StatusCode(403);
 
         if (Request.Headers.XRequestedWith == "XMLHttpRequest")
             return Ok();
@@ -251,18 +117,9 @@ public class NotificationController : HumansControllerBase
         var (err, user) = await RequireCurrentUserAsync();
         if (err is not null) return err;
 
-        var recipient = await _dbContext.NotificationRecipients
-            .FirstOrDefaultAsync(nr => nr.NotificationId == id && nr.UserId == user.Id);
+        var result = await _inboxService.MarkReadAsync(id, user.Id);
 
-        if (recipient is null)
-            return NotFound();
-
-        if (recipient.ReadAt is null)
-        {
-            recipient.ReadAt = _clock.GetCurrentInstant();
-            await _dbContext.SaveChangesAsync();
-            InvalidateBadgeCaches([user.Id]);
-        }
+        if (result.NotFound) return NotFound();
 
         if (Request.Headers.XRequestedWith == "XMLHttpRequest")
             return Ok();
@@ -277,22 +134,7 @@ public class NotificationController : HumansControllerBase
         var (err, user) = await RequireCurrentUserAsync();
         if (err is not null) return err;
 
-        var now = _clock.GetCurrentInstant();
-
-        var unread = await _dbContext.NotificationRecipients
-            .Where(nr => nr.UserId == user.Id && nr.ReadAt == null)
-            .ToListAsync();
-
-        foreach (var nr in unread)
-        {
-            nr.ReadAt = now;
-        }
-
-        if (unread.Count > 0)
-        {
-            await _dbContext.SaveChangesAsync();
-            InvalidateBadgeCaches([user.Id]);
-        }
+        await _inboxService.MarkAllReadAsync(user.Id);
 
         if (Request.Headers.XRequestedWith == "XMLHttpRequest")
             return Ok();
@@ -310,30 +152,7 @@ public class NotificationController : HumansControllerBase
         if (selectedIds.Count == 0)
             return RedirectToAction(nameof(Index));
 
-        var now = _clock.GetCurrentInstant();
-
-        var notifications = await _dbContext.Notifications
-            .Include(n => n.Recipients)
-            .Where(n => selectedIds.Contains(n.Id) &&
-                        n.Class == NotificationClass.Actionable &&
-                        n.ResolvedAt == null)
-            .ToListAsync();
-
-        foreach (var notification in notifications)
-        {
-            if (notification.Recipients.Any(r => r.UserId == user.Id))
-            {
-                notification.ResolvedAt = now;
-                notification.ResolvedByUserId = user.Id;
-            }
-        }
-
-        if (notifications.Count > 0)
-        {
-            await _dbContext.SaveChangesAsync();
-            var affectedUserIds = notifications.SelectMany(n => n.Recipients.Select(r => r.UserId)).Distinct();
-            InvalidateBadgeCaches(affectedUserIds);
-        }
+        await _inboxService.BulkResolveAsync(selectedIds, user.Id);
 
         if (Request.Headers.XRequestedWith == "XMLHttpRequest")
             return Ok();
@@ -351,30 +170,7 @@ public class NotificationController : HumansControllerBase
         if (selectedIds.Count == 0)
             return RedirectToAction(nameof(Index));
 
-        var now = _clock.GetCurrentInstant();
-
-        var notifications = await _dbContext.Notifications
-            .Include(n => n.Recipients)
-            .Where(n => selectedIds.Contains(n.Id) &&
-                        n.Class == NotificationClass.Informational &&
-                        n.ResolvedAt == null)
-            .ToListAsync();
-
-        foreach (var notification in notifications)
-        {
-            if (notification.Recipients.Any(r => r.UserId == user.Id))
-            {
-                notification.ResolvedAt = now;
-                notification.ResolvedByUserId = user.Id;
-            }
-        }
-
-        if (notifications.Count > 0)
-        {
-            await _dbContext.SaveChangesAsync();
-            var affectedUserIds = notifications.SelectMany(n => n.Recipients.Select(r => r.UserId)).Distinct();
-            InvalidateBadgeCaches(affectedUserIds);
-        }
+        await _inboxService.BulkDismissAsync(selectedIds, user.Id);
 
         if (Request.Headers.XRequestedWith == "XMLHttpRequest")
             return Ok();
@@ -388,72 +184,34 @@ public class NotificationController : HumansControllerBase
         var (err, user) = await RequireCurrentUserAsync();
         if (err is not null) return err;
 
-        var recipient = await _dbContext.NotificationRecipients
-            .Include(nr => nr.Notification)
-            .FirstOrDefaultAsync(nr => nr.NotificationId == id && nr.UserId == user.Id);
+        var url = await _inboxService.ClickThroughAsync(id, user.Id);
 
-        if (recipient is null)
-            return RedirectToAction(nameof(Index));
-
-        // Mark as read on click-through
-        if (recipient.ReadAt is null)
-        {
-            recipient.ReadAt = _clock.GetCurrentInstant();
-            await _dbContext.SaveChangesAsync();
-            InvalidateBadgeCaches([user.Id]);
-        }
-
-        var url = recipient.Notification.ActionUrl;
         if (!string.IsNullOrEmpty(url) && Url.IsLocalUrl(url))
             return LocalRedirect(url);
 
         return RedirectToAction(nameof(Index));
     }
 
-    private NotificationRowViewModel MapToRow(NotificationRecipient nr)
+    private static NotificationRowViewModel MapToViewModel(NotificationRowDto dto, string defaultActionLabel)
     {
-        var n = nr.Notification;
-        var allRecipients = n.Recipients?.ToList() ?? [];
-
         return new NotificationRowViewModel
         {
-            Id = n.Id,
-            Title = n.Title,
-            Body = n.Body,
-            ActionUrl = n.ActionUrl,
-            ActionLabel = n.ActionLabel ?? _localizer["Notification_DefaultActionLabel"].Value,
-            Priority = n.Priority,
-            Source = n.Source,
-            Class = n.Class,
-            TargetGroupName = n.TargetGroupName,
-            CreatedAt = n.CreatedAt.ToDateTimeUtc(),
-            IsRead = nr.ReadAt is not null,
-            IsResolved = n.ResolvedAt is not null,
-            ResolvedAt = n.ResolvedAt?.ToDateTimeUtc(),
-            ResolvedByName = n.ResolvedByUser?.DisplayName,
-            RecipientInitials = allRecipients
-                .Take(3)
-                .Select(r => GetInitials(r.User?.DisplayName))
-                .ToList(),
-            TotalRecipientCount = allRecipients.Count,
+            Id = dto.Id,
+            Title = dto.Title,
+            Body = dto.Body,
+            ActionUrl = dto.ActionUrl,
+            ActionLabel = dto.ActionLabel ?? defaultActionLabel,
+            Priority = dto.Priority,
+            Source = dto.Source,
+            Class = dto.Class,
+            TargetGroupName = dto.TargetGroupName,
+            CreatedAt = dto.CreatedAt,
+            IsRead = dto.IsRead,
+            IsResolved = dto.IsResolved,
+            ResolvedAt = dto.ResolvedAt,
+            ResolvedByName = dto.ResolvedByName,
+            RecipientInitials = dto.RecipientInitials,
+            TotalRecipientCount = dto.TotalRecipientCount,
         };
-    }
-
-    private static string GetInitials(string? displayName)
-    {
-        if (string.IsNullOrWhiteSpace(displayName))
-            return "?";
-        var parts = displayName.Split(' ', StringSplitOptions.RemoveEmptyEntries);
-        return parts.Length >= 2
-            ? $"{parts[0][0]}{parts[^1][0]}".ToUpperInvariant()
-            : parts[0][..Math.Min(2, parts[0].Length)].ToUpperInvariant();
-    }
-
-    private void InvalidateBadgeCaches(IEnumerable<Guid> userIds)
-    {
-        foreach (var userId in userIds)
-        {
-            _cache.Remove(CacheKeys.NotificationBadgeCounts(userId));
-        }
     }
 }

--- a/src/Humans.Web/Extensions/InfrastructureServiceCollectionExtensions.cs
+++ b/src/Humans.Web/Extensions/InfrastructureServiceCollectionExtensions.cs
@@ -174,6 +174,7 @@ public static class InfrastructureServiceCollectionExtensions
         services.AddScoped<TermRenewalReminderJob>();
         services.AddScoped<CleanupNotificationsJob>();
         services.AddScoped<INotificationService, NotificationService>();
+        services.AddScoped<IGoogleAdminService, GoogleAdminService>();
 
         // Shift management services
         services.AddScoped<IShiftManagementService, ShiftManagementService>();

--- a/src/Humans.Web/Extensions/InfrastructureServiceCollectionExtensions.cs
+++ b/src/Humans.Web/Extensions/InfrastructureServiceCollectionExtensions.cs
@@ -174,6 +174,7 @@ public static class InfrastructureServiceCollectionExtensions
         services.AddScoped<TermRenewalReminderJob>();
         services.AddScoped<CleanupNotificationsJob>();
         services.AddScoped<INotificationService, NotificationService>();
+        services.AddScoped<INotificationInboxService, NotificationInboxService>();
         services.AddScoped<IGoogleAdminService, GoogleAdminService>();
 
         // Shift management services

--- a/src/Humans.Web/Views/Google/AllGroups.cshtml
+++ b/src/Humans.Web/Views/Google/AllGroups.cshtml
@@ -1,8 +1,8 @@
 @model Humans.Application.DTOs.AllGroupsResult
-@using Humans.Domain.Entities
+@using Humans.Application.Interfaces
 @{
     ViewData["Title"] = "All Domain Groups";
-    var teams = ViewBag.Teams as List<Team> ?? [];
+    var teams = ViewBag.Teams as IReadOnlyList<TeamSummary> ?? [];
     var driftedGroups = Model.Groups.Where(g => g.HasDrift).ToList();
 
     // Standard = settings we enforce (from ExpectedSettings)

--- a/tests/Humans.Application.Tests/Services/GoogleAdminServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/GoogleAdminServiceTests.cs
@@ -1,0 +1,392 @@
+using AwesomeAssertions;
+using Humans.Application.Interfaces;
+using Humans.Domain.Entities;
+using Humans.Infrastructure.Data;
+using Humans.Infrastructure.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Xunit;
+
+namespace Humans.Application.Tests.Services;
+
+public class GoogleAdminServiceTests : IDisposable
+{
+    private readonly HumansDbContext _dbContext;
+    private readonly IGoogleWorkspaceUserService _workspaceUserService;
+    private readonly IGoogleSyncService _googleSyncService;
+    private readonly IUserEmailService _userEmailService;
+    private readonly IAuditLogService _auditLogService;
+    private readonly GoogleAdminService _service;
+
+    private readonly Guid _actorUserId = Guid.NewGuid();
+    private const string ActorDisplayName = "Admin User";
+
+    public GoogleAdminServiceTests()
+    {
+        var options = new DbContextOptionsBuilder<HumansDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        _dbContext = new HumansDbContext(options);
+        _workspaceUserService = Substitute.For<IGoogleWorkspaceUserService>();
+        _googleSyncService = Substitute.For<IGoogleSyncService>();
+        _userEmailService = Substitute.For<IUserEmailService>();
+        _auditLogService = Substitute.For<IAuditLogService>();
+
+        _service = new GoogleAdminService(
+            _dbContext,
+            _workspaceUserService,
+            _googleSyncService,
+            _userEmailService,
+            _auditLogService,
+            NullLogger<GoogleAdminService>.Instance);
+    }
+
+    public void Dispose()
+    {
+        _dbContext.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    // --- GetWorkspaceAccountListAsync ---
+
+    [Fact]
+    public async Task GetWorkspaceAccountListAsync_ReturnsAccountsWithMatchedUsers()
+    {
+        var userId = Guid.NewGuid();
+        var user = new User { Id = userId, Email = "test@example.com", DisplayName = "Test User" };
+        _dbContext.Users.Add(user);
+        _dbContext.UserEmails.Add(new UserEmail
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            Email = "alice@nobodies.team",
+            IsVerified = true,
+            IsNotificationTarget = true,
+        });
+        await _dbContext.SaveChangesAsync();
+
+        _workspaceUserService.ListAccountsAsync(Arg.Any<CancellationToken>())
+            .Returns([
+                new WorkspaceUserAccount("alice@nobodies.team", "Alice", "Smith", false,
+                    DateTime.UtcNow, DateTime.UtcNow),
+                new WorkspaceUserAccount("bob@nobodies.team", "Bob", "Jones", true,
+                    DateTime.UtcNow, null),
+            ]);
+
+        var result = await _service.GetWorkspaceAccountListAsync();
+
+        result.TotalAccounts.Should().Be(2);
+        result.ActiveAccounts.Should().Be(1);
+        result.SuspendedAccounts.Should().Be(1);
+        result.LinkedAccounts.Should().Be(1);
+        result.UnlinkedAccounts.Should().Be(1);
+        result.ErrorMessage.Should().BeNull();
+
+        var alice = result.Accounts.Single(a =>
+            string.Equals(a.PrimaryEmail, "alice@nobodies.team", StringComparison.OrdinalIgnoreCase));
+        alice.MatchedUserId.Should().Be(userId);
+        alice.IsUsedAsPrimary.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task GetWorkspaceAccountListAsync_ReturnsErrorOnException()
+    {
+        _workspaceUserService.ListAccountsAsync(Arg.Any<CancellationToken>())
+            .ThrowsAsync(new Exception("Google API error"));
+
+        var result = await _service.GetWorkspaceAccountListAsync();
+
+        result.ErrorMessage.Should().NotBeNull();
+        result.TotalAccounts.Should().Be(0);
+    }
+
+    // --- ProvisionStandaloneAccountAsync ---
+
+    [Fact]
+    public async Task ProvisionStandaloneAccountAsync_CreatesAccountAndAudits()
+    {
+        _workspaceUserService.GetAccountAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns((WorkspaceUserAccount?)null);
+        _workspaceUserService.ProvisionAccountAsync(
+                Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+                Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(new WorkspaceUserAccount("test@nobodies.team", "Test", "User", false,
+                DateTime.UtcNow, null));
+
+        var result = await _service.ProvisionStandaloneAccountAsync(
+            "test", "Test", "User", _actorUserId, ActorDisplayName);
+
+        result.Success.Should().BeTrue();
+        result.TemporaryPassword.Should().NotBeNullOrEmpty();
+        result.Message.Should().Contain("test@nobodies.team");
+
+        await _auditLogService.Received(1).LogAsync(
+            Arg.Any<Domain.Enums.AuditAction>(),
+            Arg.Any<string>(), Arg.Any<Guid>(),
+            Arg.Any<string>(), _actorUserId, ActorDisplayName,
+            Arg.Any<Guid?>(), Arg.Any<string?>());
+    }
+
+    [Fact]
+    public async Task ProvisionStandaloneAccountAsync_ReturnsErrorIfAlreadyExists()
+    {
+        _workspaceUserService.GetAccountAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new WorkspaceUserAccount("test@nobodies.team", "Test", "User", false,
+                DateTime.UtcNow, null));
+
+        var result = await _service.ProvisionStandaloneAccountAsync(
+            "test", "Test", "User", _actorUserId, ActorDisplayName);
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("already exists");
+    }
+
+    // --- SuspendAccountAsync ---
+
+    [Fact]
+    public async Task SuspendAccountAsync_SuspendsAndAudits()
+    {
+        var result = await _service.SuspendAccountAsync(
+            "test@nobodies.team", _actorUserId, ActorDisplayName);
+
+        result.Success.Should().BeTrue();
+        result.Message.Should().Contain("suspended");
+
+        await _workspaceUserService.Received(1)
+            .SuspendAccountAsync("test@nobodies.team", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SuspendAccountAsync_ReturnsErrorOnFailure()
+    {
+        _workspaceUserService.SuspendAccountAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new Exception("API error"));
+
+        var result = await _service.SuspendAccountAsync(
+            "test@nobodies.team", _actorUserId, ActorDisplayName);
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("Failed to suspend");
+    }
+
+    // --- ReactivateAccountAsync ---
+
+    [Fact]
+    public async Task ReactivateAccountAsync_ReactivatesAndAudits()
+    {
+        var result = await _service.ReactivateAccountAsync(
+            "test@nobodies.team", _actorUserId, ActorDisplayName);
+
+        result.Success.Should().BeTrue();
+        result.Message.Should().Contain("reactivated");
+
+        await _workspaceUserService.Received(1)
+            .ReactivateAccountAsync("test@nobodies.team", Arg.Any<CancellationToken>());
+    }
+
+    // --- ResetPasswordAsync ---
+
+    [Fact]
+    public async Task ResetPasswordAsync_ResetsAndReturnsNewPassword()
+    {
+        var result = await _service.ResetPasswordAsync(
+            "test@nobodies.team", _actorUserId, ActorDisplayName);
+
+        result.Success.Should().BeTrue();
+        result.TemporaryPassword.Should().NotBeNullOrEmpty();
+        result.Message.Should().Contain("Password reset");
+
+        await _workspaceUserService.Received(1)
+            .ResetPasswordAsync("test@nobodies.team", Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    // --- LinkAccountAsync ---
+
+    [Fact]
+    public async Task LinkAccountAsync_LinksEmailAndSetsGoogleEmail()
+    {
+        var userId = Guid.NewGuid();
+        var user = new User { Id = userId, Email = "test@example.com", DisplayName = "Test User" };
+        _dbContext.Users.Add(user);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _service.LinkAccountAsync(
+            "alice@nobodies.team", userId, _actorUserId, ActorDisplayName);
+
+        result.Success.Should().BeTrue();
+        result.Message.Should().Contain("Linked");
+
+        // Verify GoogleEmail was set
+        var updatedUser = await _dbContext.Users.FindAsync(userId);
+        updatedUser!.GoogleEmail.Should().Be("alice@nobodies.team");
+
+        await _userEmailService.Received(1)
+            .AddVerifiedEmailAsync(userId, "alice@nobodies.team", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task LinkAccountAsync_ReturnsErrorIfUserNotFound()
+    {
+        var result = await _service.LinkAccountAsync(
+            "alice@nobodies.team", Guid.NewGuid(), _actorUserId, ActorDisplayName);
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("not found");
+    }
+
+    [Fact]
+    public async Task LinkAccountAsync_ReturnsErrorIfEmailConflict()
+    {
+        // Note: ILike is not supported by in-memory provider, so this exercises
+        // the error path. The real duplicate check works on PostgreSQL.
+        var userId = Guid.NewGuid();
+        var user = new User { Id = userId, Email = "test@example.com", DisplayName = "Test" };
+        _dbContext.Users.Add(user);
+        _dbContext.UserEmails.Add(new UserEmail
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            Email = "alice@nobodies.team",
+            IsVerified = true,
+        });
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _service.LinkAccountAsync(
+            "alice@nobodies.team", userId, _actorUserId, ActorDisplayName);
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().NotBeNullOrEmpty();
+    }
+
+    // --- ApplyEmailBackfillAsync ---
+
+    [Fact]
+    public async Task ApplyEmailBackfillAsync_UpdatesEmailsAndReturnsCount()
+    {
+        var userId = Guid.NewGuid();
+        var user = new User
+        {
+            Id = userId,
+            Email = "old@example.com",
+            UserName = "old@example.com",
+            NormalizedEmail = "OLD@EXAMPLE.COM",
+            NormalizedUserName = "OLD@EXAMPLE.COM",
+            DisplayName = "Test",
+        };
+        _dbContext.Users.Add(user);
+        _dbContext.UserEmails.Add(new UserEmail
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            Email = "old@example.com",
+            IsOAuth = true,
+        });
+        await _dbContext.SaveChangesAsync();
+
+        var corrections = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            { userId.ToString(), "new@example.com" }
+        };
+
+        var result = await _service.ApplyEmailBackfillAsync(
+            [userId], corrections, _actorUserId);
+
+        result.UpdatedCount.Should().Be(1);
+        result.Errors.Should().BeEmpty();
+
+        var updatedUser = await _dbContext.Users.FindAsync(userId);
+        updatedUser!.Email.Should().Be("new@example.com");
+        updatedUser.NormalizedEmail.Should().Be("NEW@EXAMPLE.COM");
+    }
+
+    [Fact]
+    public async Task ApplyEmailBackfillAsync_SkipsUsersWithNoCorrection()
+    {
+        var userId = Guid.NewGuid();
+        var user = new User { Id = userId, Email = "test@example.com", DisplayName = "Test" };
+        _dbContext.Users.Add(user);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _service.ApplyEmailBackfillAsync(
+            [userId], new Dictionary<string, string>(StringComparer.Ordinal), _actorUserId);
+
+        result.UpdatedCount.Should().Be(0);
+    }
+
+    // --- LinkGroupToTeamAsync ---
+
+    [Fact]
+    public async Task LinkGroupToTeamAsync_LinksGroupAndSaves()
+    {
+        var teamId = Guid.NewGuid();
+        var team = new Team { Id = teamId, Name = "Test Team", IsActive = true, Slug = "test-team" };
+        _dbContext.Teams.Add(team);
+        await _dbContext.SaveChangesAsync();
+
+        _googleSyncService.EnsureTeamGroupAsync(teamId, false, Arg.Any<CancellationToken>())
+            .Returns(DTOs.GroupLinkResult.Ok());
+
+        var result = await _service.LinkGroupToTeamAsync(teamId, "test-team");
+
+        result.Success.Should().BeTrue();
+        result.Message.Should().Contain("test-team@nobodies.team");
+
+        var updatedTeam = await _dbContext.Teams.FindAsync(teamId);
+        updatedTeam!.GoogleGroupPrefix.Should().Be("test-team");
+    }
+
+    [Fact]
+    public async Task LinkGroupToTeamAsync_ReturnsErrorIfTeamNotFound()
+    {
+        var result = await _service.LinkGroupToTeamAsync(Guid.NewGuid(), "prefix");
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("not found");
+    }
+
+    [Fact]
+    public async Task LinkGroupToTeamAsync_RevertsOnError()
+    {
+        var teamId = Guid.NewGuid();
+        var team = new Team
+        {
+            Id = teamId,
+            Name = "Test Team",
+            IsActive = true,
+            Slug = "test-team",
+            GoogleGroupPrefix = "old-prefix"
+        };
+        _dbContext.Teams.Add(team);
+        await _dbContext.SaveChangesAsync();
+
+        _googleSyncService.EnsureTeamGroupAsync(teamId, false, Arg.Any<CancellationToken>())
+            .Returns(DTOs.GroupLinkResult.Error("Failed to create group"));
+
+        var result = await _service.LinkGroupToTeamAsync(teamId, "new-prefix");
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("Failed to create group");
+    }
+
+    // --- GetActiveTeamsAsync ---
+
+    [Fact]
+    public async Task GetActiveTeamsAsync_ReturnsOnlyActiveTeamsOrdered()
+    {
+        await _dbContext.Teams.AddRangeAsync(
+            new Team { Id = Guid.NewGuid(), Name = "Zebra", IsActive = true, Slug = "zebra" },
+            new Team { Id = Guid.NewGuid(), Name = "Alpha", IsActive = true, Slug = "alpha" },
+            new Team { Id = Guid.NewGuid(), Name = "Inactive", IsActive = false, Slug = "inactive" }
+        );
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _service.GetActiveTeamsAsync();
+
+        result.Should().HaveCount(2);
+        result[0].Name.Should().Be("Alpha");
+        result[1].Name.Should().Be("Zebra");
+    }
+}

--- a/tests/Humans.Application.Tests/Services/NotificationInboxServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/NotificationInboxServiceTests.cs
@@ -1,0 +1,348 @@
+using AwesomeAssertions;
+using Humans.Application.Interfaces;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using Humans.Infrastructure.Data;
+using Humans.Infrastructure.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging.Abstractions;
+using NodaTime;
+using NodaTime.Testing;
+using Xunit;
+
+namespace Humans.Application.Tests.Services;
+
+public class NotificationInboxServiceTests : IDisposable
+{
+    private readonly HumansDbContext _dbContext;
+    private readonly FakeClock _clock;
+    private readonly IMemoryCache _cache;
+    private readonly NotificationInboxService _service;
+    private readonly Guid _userId = Guid.NewGuid();
+
+    public NotificationInboxServiceTests()
+    {
+        var options = new DbContextOptionsBuilder<HumansDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        _dbContext = new HumansDbContext(options);
+        _clock = new FakeClock(Instant.FromUtc(2026, 4, 1, 12, 0));
+        _cache = new MemoryCache(new MemoryCacheOptions());
+        _service = new NotificationInboxService(
+            _dbContext, _clock, _cache,
+            NullLogger<NotificationInboxService>.Instance);
+    }
+
+    public void Dispose()
+    {
+        _dbContext.Dispose();
+        _cache.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private async Task<Notification> CreateNotification(
+        NotificationClass cls = NotificationClass.Informational,
+        NotificationSource source = NotificationSource.TeamMemberAdded,
+        Instant? resolvedAt = null,
+        Guid? resolvedByUserId = null)
+    {
+        var notification = new Notification
+        {
+            Id = Guid.NewGuid(),
+            Title = "Test Notification",
+            Body = "Test body",
+            ActionUrl = "/test",
+            Priority = NotificationPriority.Normal,
+            Source = source,
+            Class = cls,
+            CreatedAt = _clock.GetCurrentInstant(),
+            ResolvedAt = resolvedAt,
+            ResolvedByUserId = resolvedByUserId,
+        };
+
+        notification.Recipients.Add(new NotificationRecipient
+        {
+            NotificationId = notification.Id,
+            UserId = _userId,
+        });
+
+        _dbContext.Notifications.Add(notification);
+        await _dbContext.SaveChangesAsync();
+        return notification;
+    }
+
+    // --- ResolveAsync ---
+
+    [Fact]
+    public async Task ResolveAsync_ResolvesNotification()
+    {
+        var notification = await CreateNotification(NotificationClass.Actionable);
+
+        var result = await _service.ResolveAsync(notification.Id, _userId);
+
+        result.Success.Should().BeTrue();
+
+        var updated = await _dbContext.Notifications.FindAsync(notification.Id);
+        updated!.ResolvedAt.Should().NotBeNull();
+        updated.ResolvedByUserId.Should().Be(_userId);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_ReturnsNotFoundForMissingNotification()
+    {
+        var result = await _service.ResolveAsync(Guid.NewGuid(), _userId);
+
+        result.Success.Should().BeFalse();
+        result.NotFound.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ResolveAsync_ReturnsForbiddenIfNotRecipient()
+    {
+        var notification = await CreateNotification(NotificationClass.Actionable);
+
+        var result = await _service.ResolveAsync(notification.Id, Guid.NewGuid());
+
+        result.Success.Should().BeFalse();
+        result.Forbidden.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ResolveAsync_IdempotentIfAlreadyResolved()
+    {
+        var now = _clock.GetCurrentInstant();
+        var notification = await CreateNotification(
+            NotificationClass.Actionable,
+            resolvedAt: now,
+            resolvedByUserId: _userId);
+
+        var result = await _service.ResolveAsync(notification.Id, _userId);
+
+        result.Success.Should().BeTrue();
+    }
+
+    // --- DismissAsync ---
+
+    [Fact]
+    public async Task DismissAsync_DismissesInformationalNotification()
+    {
+        var notification = await CreateNotification(NotificationClass.Informational);
+
+        var result = await _service.DismissAsync(notification.Id, _userId);
+
+        result.Success.Should().BeTrue();
+
+        var updated = await _dbContext.Notifications.FindAsync(notification.Id);
+        updated!.ResolvedAt.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task DismissAsync_RejectsDismissOfActionableNotification()
+    {
+        var notification = await CreateNotification(NotificationClass.Actionable);
+
+        var result = await _service.DismissAsync(notification.Id, _userId);
+
+        result.Success.Should().BeFalse();
+        result.Forbidden.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task DismissAsync_ReturnsNotFoundForMissing()
+    {
+        var result = await _service.DismissAsync(Guid.NewGuid(), _userId);
+
+        result.Success.Should().BeFalse();
+        result.NotFound.Should().BeTrue();
+    }
+
+    // --- MarkReadAsync ---
+
+    [Fact]
+    public async Task MarkReadAsync_SetsReadAt()
+    {
+        var notification = await CreateNotification();
+
+        var result = await _service.MarkReadAsync(notification.Id, _userId);
+
+        result.Success.Should().BeTrue();
+
+        var recipient = await _dbContext.NotificationRecipients
+            .FirstAsync(nr => nr.NotificationId == notification.Id && nr.UserId == _userId);
+        recipient.ReadAt.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task MarkReadAsync_ReturnsNotFoundIfNotRecipient()
+    {
+        var notification = await CreateNotification();
+
+        var result = await _service.MarkReadAsync(notification.Id, Guid.NewGuid());
+
+        result.Success.Should().BeFalse();
+        result.NotFound.Should().BeTrue();
+    }
+
+    // --- MarkAllReadAsync ---
+
+    [Fact]
+    public async Task MarkAllReadAsync_MarksAllUnreadAsRead()
+    {
+        await CreateNotification();
+        await CreateNotification();
+
+        await _service.MarkAllReadAsync(_userId);
+
+        var unread = await _dbContext.NotificationRecipients
+            .Where(nr => nr.UserId == _userId && nr.ReadAt == null)
+            .CountAsync();
+        unread.Should().Be(0);
+    }
+
+    // --- BulkResolveAsync ---
+
+    [Fact]
+    public async Task BulkResolveAsync_ResolvesMultipleActionableNotifications()
+    {
+        var n1 = await CreateNotification(NotificationClass.Actionable);
+        var n2 = await CreateNotification(NotificationClass.Actionable);
+
+        await _service.BulkResolveAsync([n1.Id, n2.Id], _userId);
+
+        var resolved = await _dbContext.Notifications
+            .Where(n => n.ResolvedAt != null)
+            .CountAsync();
+        resolved.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task BulkResolveAsync_SkipsInformationalNotifications()
+    {
+        var actionable = await CreateNotification(NotificationClass.Actionable);
+        var informational = await CreateNotification(NotificationClass.Informational);
+
+        await _service.BulkResolveAsync([actionable.Id, informational.Id], _userId);
+
+        var resolvedActionable = await _dbContext.Notifications.FindAsync(actionable.Id);
+        resolvedActionable!.ResolvedAt.Should().NotBeNull();
+
+        var unresolvedInfo = await _dbContext.Notifications.FindAsync(informational.Id);
+        unresolvedInfo!.ResolvedAt.Should().BeNull();
+    }
+
+    // --- BulkDismissAsync ---
+
+    [Fact]
+    public async Task BulkDismissAsync_DismissesMultipleInformationalNotifications()
+    {
+        var n1 = await CreateNotification(NotificationClass.Informational);
+        var n2 = await CreateNotification(NotificationClass.Informational);
+
+        await _service.BulkDismissAsync([n1.Id, n2.Id], _userId);
+
+        var resolved = await _dbContext.Notifications
+            .Where(n => n.ResolvedAt != null)
+            .CountAsync();
+        resolved.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task BulkDismissAsync_SkipsActionableNotifications()
+    {
+        var actionable = await CreateNotification(NotificationClass.Actionable);
+        var informational = await CreateNotification(NotificationClass.Informational);
+
+        await _service.BulkDismissAsync([actionable.Id, informational.Id], _userId);
+
+        var unresolvedActionable = await _dbContext.Notifications.FindAsync(actionable.Id);
+        unresolvedActionable!.ResolvedAt.Should().BeNull();
+
+        var resolvedInfo = await _dbContext.Notifications.FindAsync(informational.Id);
+        resolvedInfo!.ResolvedAt.Should().NotBeNull();
+    }
+
+    // --- ClickThroughAsync ---
+
+    [Fact]
+    public async Task ClickThroughAsync_MarksReadAndReturnsUrl()
+    {
+        var notification = await CreateNotification();
+
+        var url = await _service.ClickThroughAsync(notification.Id, _userId);
+
+        url.Should().Be("/test");
+
+        var recipient = await _dbContext.NotificationRecipients
+            .FirstAsync(nr => nr.NotificationId == notification.Id && nr.UserId == _userId);
+        recipient.ReadAt.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task ClickThroughAsync_ReturnsNullIfNotRecipient()
+    {
+        var notification = await CreateNotification();
+
+        var url = await _service.ClickThroughAsync(notification.Id, Guid.NewGuid());
+
+        url.Should().BeNull();
+    }
+
+    // --- GetPopupAsync ---
+
+    [Fact]
+    public async Task GetPopupAsync_ReturnsUnresolvedNotificationsSplitByClass()
+    {
+        await CreateNotification(NotificationClass.Actionable);
+        await CreateNotification(NotificationClass.Informational);
+        await CreateNotification(
+            NotificationClass.Actionable,
+            resolvedAt: _clock.GetCurrentInstant(),
+            resolvedByUserId: _userId); // resolved — should not appear
+
+        var result = await _service.GetPopupAsync(_userId);
+
+        result.Actionable.Should().HaveCount(1);
+        result.Informational.Should().HaveCount(1);
+        result.ActionableCount.Should().Be(1);
+    }
+
+    // --- Cache invalidation ---
+
+    [Fact]
+    public async Task ResolveAsync_InvalidatesBadgeCache()
+    {
+        var notification = await CreateNotification(NotificationClass.Actionable);
+        var cacheKey = Application.CacheKeys.NotificationBadgeCounts(_userId);
+        _cache.Set(cacheKey, 5);
+
+        await _service.ResolveAsync(notification.Id, _userId);
+
+        _cache.TryGetValue(cacheKey, out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task MarkReadAsync_InvalidatesBadgeCache()
+    {
+        var notification = await CreateNotification();
+        var cacheKey = Application.CacheKeys.NotificationBadgeCounts(_userId);
+        _cache.Set(cacheKey, 3);
+
+        await _service.MarkReadAsync(notification.Id, _userId);
+
+        _cache.TryGetValue(cacheKey, out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task MarkAllReadAsync_InvalidatesBadgeCache()
+    {
+        await CreateNotification();
+        var cacheKey = Application.CacheKeys.NotificationBadgeCounts(_userId);
+        _cache.Set(cacheKey, 2);
+
+        await _service.MarkAllReadAsync(_userId);
+
+        _cache.TryGetValue(cacheKey, out _).Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary
- Extract GoogleController business logic into IGoogleAdminService/GoogleAdminService (#353)
- Extract NotificationController queries, mutations, and cache into INotificationInboxService/NotificationInboxService (#356)
- GoogleController no longer injects HumansDbContext — delegates to service for workspace account management, group linking, email backfill, and account linking
- NotificationController no longer injects HumansDbContext or IMemoryCache — delegates to service for inbox/popup queries, resolve/dismiss/mark-read, and badge cache invalidation
- 37 new service-level tests (17 GoogleAdmin + 20 NotificationInbox)

## Test plan
- [ ] Verify Google admin pages still work (groups, accounts, sync)
- [ ] Verify notification inbox, popup, mark-read, resolve all work
- [ ] Verify new service tests pass
- [ ] Verify build and existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)