### PR TITLE
Auth & View Cleanup (#336, #291)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -412,6 +412,55 @@ Stop and reconsider when a change introduces any of these:
 - a cache is added without a clear invalidation owner
 - a job re-implements a workflow that should be in a service
 
+## Rendering Rules
+
+Server-rendered Razor is the default rendering approach for all pages.
+
+Default rule:
+
+- page content is rendered server-side using Razor views, tag helpers, and view components
+- slow data loads use the partial-via-AJAX pattern: render the page frame server-side, load the slow section by fetching a Razor partial from an AJAX call
+
+Razor provides:
+
+- compile-time type safety
+- tag helpers and `asp-*` route generation
+- automatic HTML encoding (no manual `escapeHtml`)
+- localization via `IStringLocalizer`
+- view components for reusable data-fetching UI
+- authorization tag helpers for role-based visibility
+
+Do not use client-side `fetch()` + JavaScript DOM construction to build page content when Razor can render the same output. That pattern requires manual HTML escaping, duplicated rendering logic, projection DTOs solely for JSON serialization, and string-based URL construction that breaks on route constraint changes.
+
+### Valid exceptions
+
+Client-side JavaScript with `fetch()` is appropriate for:
+
+- **Autocomplete/search inputs** that need instant feedback on keystrokes (profile search, member search, volunteer search, shift volunteer search)
+- **Dynamic form field population** that responds to parent field changes (team Google resource dropdown)
+- **Progressive enhancement** for inline actions that avoid full page reloads (notification dismiss/mark-read, feedback detail panel loading)
+- **Utility behaviors** that are not page content (timezone detection, notification popup, profile popover on hover)
+
+These patterns use `fetch()` to enhance an already server-rendered page, not to replace server rendering entirely.
+
+### Current exceptions list
+
+All pages are server-rendered with Razor. The following use `fetch()` for the specific justified purposes listed above:
+
+| File | Purpose | Exception type |
+|------|---------|----------------|
+| `_HumanSearchInput.cshtml` | Profile autocomplete | Search input |
+| `_MemberSearchScript.cshtml` | Member search autocomplete | Search input |
+| `_VolunteerSearchScript.cshtml` | Volunteer search autocomplete | Search input |
+| `_TeamGoogleAndParentFields.cshtml` | Google resource dropdown on team change | Dynamic form field |
+| `ShiftAdmin/Index.cshtml` | Shift volunteer search + tag creation | Search input + inline action |
+| `Notification/Index.cshtml` | Dismiss/mark-read without reload | Progressive enhancement |
+| `Feedback/Index.cshtml` | Master-detail panel loading | Progressive enhancement |
+| `Google/Sync.cshtml` | Tab content loaded via Razor partial (slow Google API) | Partial-via-AJAX |
+| `site.js` | Timezone, notification popup, profile popover | Utility |
+
+When adding a new page that needs client-side data loading, add it to this list with justification. If a page has no entry here, it must be server-rendered.
+
 ## Direction of Travel
 
 We do not need a rewrite.

--- a/src/Humans.Web/Controllers/GoogleController.cs
+++ b/src/Humans.Web/Controllers/GoogleController.cs
@@ -434,7 +434,32 @@ public class GoogleController : HumansControllerBase
     public async Task<IActionResult> SyncPreview(GoogleResourceType resourceType)
     {
         var result = await _googleSyncService.SyncResourcesByTypeAsync(resourceType, SyncAction.Preview);
-        return Json(result);
+
+        // Sort resources alphabetically
+        result.Diffs.Sort((a, b) =>
+            string.Compare(a.ResourceName, b.ResourceName, StringComparison.Ordinal));
+
+        // Sort members within each resource: by state then by displayName
+        foreach (var diff in result.Diffs)
+        {
+            diff.Members.Sort((a, b) =>
+            {
+                var stateCompare = a.State.CompareTo(b.State);
+                return stateCompare != 0
+                    ? stateCompare
+                    : string.Compare(a.DisplayName, b.DisplayName, StringComparison.Ordinal);
+            });
+        }
+
+        var viewModel = new SyncTabContentViewModel
+        {
+            Result = result,
+            ResourceType = resourceType.ToString(),
+            CanExecuteActions = RoleChecks.IsAdmin(User),
+            CanViewAudit = RoleChecks.IsAdminOrBoard(User)
+        };
+
+        return PartialView("_SyncTabContent", viewModel);
     }
 
     [HttpPost("Sync/Execute/{resourceId}")]

--- a/src/Humans.Web/Models/TeamSyncViewModels.cs
+++ b/src/Humans.Web/Models/TeamSyncViewModels.cs
@@ -1,6 +1,16 @@
+using Humans.Application.DTOs;
+
 namespace Humans.Web.Models;
 
 public class TeamSyncViewModel
 {
     public bool CanExecuteActions { get; set; }
+}
+
+public class SyncTabContentViewModel
+{
+    public required SyncPreviewResult Result { get; init; }
+    public required string ResourceType { get; init; }
+    public bool CanExecuteActions { get; init; }
+    public bool CanViewAudit { get; init; }
 }

--- a/src/Humans.Web/TagHelpers/AuthorizeViewTagHelper.cs
+++ b/src/Humans.Web/TagHelpers/AuthorizeViewTagHelper.cs
@@ -1,0 +1,131 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using Humans.Web.Authorization;
+
+namespace Humans.Web.TagHelpers;
+
+/// <summary>
+/// Attribute-based TagHelper that conditionally renders an element based on
+/// a named authorization policy. Suppresses the element when the current user
+/// does not satisfy the policy.
+///
+/// Usage:
+///   &lt;li authorize-policy="Admin"&gt;Only admins see this&lt;/li&gt;
+///   &lt;div authorize-policy="CanAccessReviewQueue"&gt;...&lt;/div&gt;
+/// </summary>
+[HtmlTargetElement("*", Attributes = "authorize-policy")]
+public class AuthorizeViewTagHelper : TagHelper
+{
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public AuthorizeViewTagHelper(IHttpContextAccessor httpContextAccessor)
+    {
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    /// <summary>
+    /// Named policy to evaluate. Must match a key in <see cref="ViewPolicies"/>.
+    /// </summary>
+    [HtmlAttributeName("authorize-policy")]
+    public string Policy { get; set; } = "";
+
+    /// <summary>
+    /// Run before other TagHelpers to avoid unnecessary processing of suppressed elements.
+    /// </summary>
+    public override int Order => -1;
+
+    public override void Process(TagHelperContext context, TagHelperOutput output)
+    {
+        var user = _httpContextAccessor.HttpContext?.User;
+        if (user is null || !ViewPolicies.Evaluate(Policy, user))
+        {
+            output.SuppressOutput();
+            return;
+        }
+
+        // Remove the attribute from rendered HTML
+        output.Attributes.RemoveAll("authorize-policy");
+    }
+}
+
+/// <summary>
+/// Centralized view-level authorization policies. Each policy maps a string name
+/// to a role check function. Views reference policy names, not role combinations.
+///
+/// Add new policies here when new role-based visibility requirements emerge.
+/// </summary>
+public static class ViewPolicies
+{
+    public const string Admin = nameof(Admin);
+    public const string Board = nameof(Board);
+    public const string AdminOrBoard = nameof(AdminOrBoard);
+    public const string TeamsAdminBoardOrAdmin = nameof(TeamsAdminBoardOrAdmin);
+    public const string HumanAdminBoardOrAdmin = nameof(HumanAdminBoardOrAdmin);
+    public const string HumanAdmin = nameof(HumanAdmin);
+    public const string CampAdmin = nameof(CampAdmin);
+    public const string CanAccessReviewQueue = nameof(CanAccessReviewQueue);
+    public const string CanAccessTickets = nameof(CanAccessTickets);
+    public const string CanManageTickets = nameof(CanManageTickets);
+    public const string CanAccessVolunteers = nameof(CanAccessVolunteers);
+    public const string CanAccessFinance = nameof(CanAccessFinance);
+    public const string IsFeedbackAdmin = nameof(IsFeedbackAdmin);
+    public const string CanManageDepartment = nameof(CanManageDepartment);
+    public const string CanAccessDashboard = nameof(CanAccessDashboard);
+
+    /// <summary>
+    /// HumanAdmin who is NOT also Admin or Board. Used for the nav "Humans" link
+    /// that only shows when the user has HumanAdmin but not the broader Board/Admin access
+    /// (which already have their own Board nav link with fuller access).
+    /// </summary>
+    public const string HumanAdminOnly = nameof(HumanAdminOnly);
+
+    /// <summary>
+    /// Active member (Volunteers team member) OR TeamsAdmin/Board/Admin.
+    /// Used for nav items that require active membership or administrative roles.
+    /// </summary>
+    public const string IsActiveMember = nameof(IsActiveMember);
+
+    /// <summary>
+    /// Active member (Volunteers team) OR has shift dashboard access.
+    /// Used for Shifts nav visibility in main layout.
+    /// </summary>
+    public const string ActiveMemberOrShiftAccess = nameof(ActiveMemberOrShiftAccess);
+
+    private static readonly Dictionary<string, Func<ClaimsPrincipal, bool>> Policies = new(StringComparer.Ordinal)
+    {
+        [Admin] = RoleChecks.IsAdmin,
+        [Board] = RoleChecks.IsBoard,
+        [AdminOrBoard] = RoleChecks.IsAdminOrBoard,
+        [TeamsAdminBoardOrAdmin] = RoleChecks.IsTeamsAdminBoardOrAdmin,
+        [HumanAdminBoardOrAdmin] = RoleChecks.IsHumanAdminBoardOrAdmin,
+        [HumanAdmin] = RoleChecks.IsHumanAdmin,
+        [CampAdmin] = RoleChecks.IsCampAdmin,
+        [CanAccessReviewQueue] = RoleChecks.CanAccessReviewQueue,
+        [CanAccessTickets] = RoleChecks.CanAccessTickets,
+        [CanManageTickets] = RoleChecks.CanManageTickets,
+        [CanAccessVolunteers] = RoleChecks.CanAccessVolunteers,
+        [CanAccessFinance] = RoleChecks.CanAccessFinance,
+        [IsFeedbackAdmin] = RoleChecks.IsFeedbackAdmin,
+        [CanManageDepartment] = ShiftRoleChecks.CanManageDepartment,
+        [CanAccessDashboard] = ShiftRoleChecks.CanAccessDashboard,
+        [HumanAdminOnly] = user => RoleChecks.IsHumanAdmin(user) && !RoleChecks.IsAdminOrBoard(user),
+        [IsActiveMember] = user =>
+            user.HasClaim(RoleAssignmentClaimsTransformation.ActiveMemberClaimType,
+                RoleAssignmentClaimsTransformation.ActiveClaimValue) ||
+            RoleChecks.IsTeamsAdminBoardOrAdmin(user),
+        [ActiveMemberOrShiftAccess] = user =>
+            user.HasClaim(RoleAssignmentClaimsTransformation.ActiveMemberClaimType,
+                RoleAssignmentClaimsTransformation.ActiveClaimValue) ||
+            RoleChecks.IsTeamsAdminBoardOrAdmin(user) ||
+            ShiftRoleChecks.CanAccessDashboard(user),
+    };
+
+    /// <summary>
+    /// Evaluates the named policy against the given user.
+    /// Returns false for unknown policy names (fail-closed).
+    /// </summary>
+    public static bool Evaluate(string policyName, ClaimsPrincipal user)
+    {
+        return Policies.TryGetValue(policyName, out var check) && check(user);
+    }
+}

--- a/src/Humans.Web/TagHelpers/HumanLinkTagHelper.cs
+++ b/src/Humans.Web/TagHelpers/HumanLinkTagHelper.cs
@@ -65,6 +65,10 @@ public class HumanLinkTagHelper : TagHelper
 
     public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
     {
+        // Respect suppression from earlier tag helpers (e.g., AuthorizeViewTagHelper)
+        if (output.TagName is null)
+            return;
+
         var urlHelper = _urlHelperFactory.GetUrlHelper(ViewContext);
         var href = Admin
             ? urlHelper.Action("AdminDetail", "Profile", new { id = UserId })

--- a/src/Humans.Web/Views/Camp/Index.cshtml
+++ b/src/Humans.Web/Views/Camp/Index.cshtml
@@ -8,16 +8,13 @@
     <h1>@Localizer["Camp_Plural"] @Model.Year</h1>
     <div class="d-flex gap-2">
         <vc:access-matrix section="Camps" />
-        @if (Humans.Web.Authorization.RoleChecks.IsCampAdmin(User))
-        {
-            <a asp-controller="CampAdmin" asp-action="Index" class="btn btn-outline-secondary">
-                <i class="fa-solid fa-shield-halved me-1"></i> @Localizer["Camp_AdminTitle"]
-                @if (pendingCount > 0)
-                {
-                    <span class="badge bg-danger ms-1">@pendingCount</span>
-                }
-            </a>
-        }
+        <a asp-controller="CampAdmin" asp-action="Index" class="btn btn-outline-secondary" authorize-policy="CampAdmin">
+            <i class="fa-solid fa-shield-halved me-1"></i> @Localizer["Camp_AdminTitle"]
+            @if (pendingCount > 0)
+            {
+                <span class="badge bg-danger ms-1">@pendingCount</span>
+            }
+        </a>
         @if (User.Identity?.IsAuthenticated == true)
         {
             <a asp-action="Register" class="btn btn-primary">

--- a/src/Humans.Web/Views/CampAdmin/Index.cshtml
+++ b/src/Humans.Web/Views/CampAdmin/Index.cshtml
@@ -264,22 +264,19 @@
     </div>
 </div>
 
-@if (Humans.Web.Authorization.RoleChecks.IsAdmin(User))
-{
-    <div class="card mb-4 border-danger">
-        <div class="card-header bg-danger text-white">
-            <i class="fa-solid fa-triangle-exclamation me-2"></i>Danger Zone (Admin Only)
-        </div>
-        <div class="card-body">
-            <p class="text-muted">Permanently delete a camp and all its seasons, images, and leads.</p>
-            <form asp-controller="CampAdmin" asp-action="Delete" method="post" class="d-flex gap-2"
-                  onsubmit="return confirm('Are you sure? This action cannot be undone.');">
-                @Html.AntiForgeryToken()
-                <input type="text" name="campId" class="form-control form-control-sm" style="max-width: 320px;" placeholder="Camp ID (GUID)" required pattern="^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$" />
-                <button type="submit" class="btn btn-danger btn-sm text-nowrap">
-                    <i class="fa-solid fa-trash me-1"></i>Delete
-                </button>
-            </form>
-        </div>
+<div class="card mb-4 border-danger" authorize-policy="Admin">
+    <div class="card-header bg-danger text-white">
+        <i class="fa-solid fa-triangle-exclamation me-2"></i>Danger Zone (Admin Only)
     </div>
-}
+    <div class="card-body">
+        <p class="text-muted">Permanently delete a camp and all its seasons, images, and leads.</p>
+        <form asp-controller="CampAdmin" asp-action="Delete" method="post" class="d-flex gap-2"
+              onsubmit="return confirm('Are you sure? This action cannot be undone.');">
+            @Html.AntiForgeryToken()
+            <input type="text" name="campId" class="form-control form-control-sm" style="max-width: 320px;" placeholder="Camp ID (GUID)" required pattern="^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$" />
+            <button type="submit" class="btn btn-danger btn-sm text-nowrap">
+                <i class="fa-solid fa-trash me-1"></i>Delete
+            </button>
+        </form>
+    </div>
+</div>

--- a/src/Humans.Web/Views/Campaign/Detail.cshtml
+++ b/src/Humans.Web/Views/Campaign/Detail.cshtml
@@ -16,8 +16,8 @@
         CampaignStatus.Completed => "bg-info",
         _ => "bg-secondary"
     };
-    var isAdmin = Humans.Web.Authorization.RoleChecks.IsAdmin(User);
-    var canGenerateCodes = Humans.Web.Authorization.RoleChecks.CanManageTickets(User);
+    var isAdmin = Humans.Web.TagHelpers.ViewPolicies.Evaluate(Humans.Web.TagHelpers.ViewPolicies.Admin, User);
+    var canGenerateCodes = Humans.Web.TagHelpers.ViewPolicies.Evaluate(Humans.Web.TagHelpers.ViewPolicies.CanManageTickets, User);
 }
 
 <div class="d-flex justify-content-between align-items-center mb-4">

--- a/src/Humans.Web/Views/Google/Sync.cshtml
+++ b/src/Humans.Web/Views/Google/Sync.cshtml
@@ -38,15 +38,13 @@
 (function () {
     'use strict';
 
-    const canExecuteActions = @Json.Serialize(Model.CanExecuteActions);
     @await Html.PartialAsync("~/Views/Shared/_RequestVerificationTokenScript.cshtml")
 
-    const antiForgeryToken = getRequestVerificationToken('#antiForgeryForm input[name="__RequestVerificationToken"]');
-    const loadedTabs = {};
+    var antiForgeryToken = getRequestVerificationToken('#antiForgeryForm input[name="__RequestVerificationToken"]');
 
     // Resource type mapping: tab data-resource-type values to API enum values
     // DriveFolder = 0, Group = 2
-    const resourceTypeMap = { 'DriveFolder': 0, 'Group': 2 };
+    var resourceTypeMap = { 'DriveFolder': 0, 'Group': 2 };
 
     function getResourceTypeValue(name) {
         return resourceTypeMap[name] ?? name;
@@ -55,88 +53,39 @@
     // Load tab data on activation
     document.querySelectorAll('#syncTabs button[data-resource-type]').forEach(function (btn) {
         btn.addEventListener('shown.bs.tab', function () {
-            const resourceType = this.getAttribute('data-resource-type');
+            var resourceType = this.getAttribute('data-resource-type');
             loadTab(resourceType);
         });
     });
 
     // Load the initially active tab
-    const activeBtn = document.querySelector('#syncTabs button.active[data-resource-type]');
+    var activeBtn = document.querySelector('#syncTabs button.active[data-resource-type]');
     if (activeBtn) {
         loadTab(activeBtn.getAttribute('data-resource-type'));
     }
 
     function loadTab(resourceType) {
-        const paneId = resourceType === 'DriveFolder' ? 'drives-tab' : 'groups-tab';
-        const pane = document.getElementById(paneId);
+        var paneId = resourceType === 'DriveFolder' ? 'drives-tab' : 'groups-tab';
+        var pane = document.getElementById(paneId);
         pane.innerHTML = '<div class="text-center py-5"><div class="spinner-border" role="status"><span class="visually-hidden">Loading...</span></div></div>';
 
         fetch('/Google/Sync/Preview/' + getResourceTypeValue(resourceType))
-            .then(function (r) { return r.json(); })
-            .then(function (data) {
-                // Sort resources alphabetically
-                if (data.diffs) {
-                    data.diffs.sort(function (a, b) {
-                        return (a.resourceName || '').localeCompare(b.resourceName || '');
-                    });
-                    // Sort members within each resource: by state then by displayName
-                    data.diffs.forEach(function (diff) {
-                        if (diff.members) {
-                            diff.members.sort(function (a, b) {
-                                if (a.state !== b.state) return a.state - b.state;
-                                return (a.displayName || '').localeCompare(b.displayName || '');
-                            });
-                        }
-                    });
-                }
-                loadedTabs[resourceType] = data;
-                renderTab(pane, data, resourceType);
+            .then(function (r) {
+                if (!r.ok) throw new Error('Request failed: ' + r.status);
+                return r.text();
+            })
+            .then(function (html) {
+                pane.innerHTML = html;
+                bindTabActions(pane, resourceType);
             })
             .catch(function (err) {
-                pane.innerHTML = '<div class="alert alert-danger">Failed to load sync data: ' + escapeHtml(err.message) + '</div>';
+                pane.innerHTML = '<div class="alert alert-danger">Failed to load sync data: ' + err.message + '</div>';
             });
     }
 
-    function renderTab(pane, data, resourceType) {
-        let html = '';
-
-        // Summary cards
-        html += '<div class="row mb-4">';
-        html += summaryCard('Total', data.totalResources, '');
-        html += summaryCard('In Sync', data.inSyncCount, 'text-success');
-        html += summaryCard('Drifted', data.driftCount, 'text-warning', data.driftCount > 0 ? 'border-warning' : '');
-        html += summaryCard('Errors', data.errorCount, 'text-danger', data.errorCount > 0 ? 'border-danger' : '');
-        html += '</div>';
-
-        if (!data.diffs || data.diffs.length === 0) {
-            html += '<div class="alert alert-info">No resources found for this type.</div>';
-            pane.innerHTML = html;
-            return;
-        }
-
-        // Controls row
-        html += '<div class="d-flex justify-content-between align-items-center mb-3">';
-        html += '<div class="form-check form-switch">';
-        html += '<input class="form-check-input" type="checkbox" id="changesOnly-' + resourceType + '" checked>';
-        html += '<label class="form-check-label" for="changesOnly-' + resourceType + '">Show changes only</label>';
-        html += '</div>';
-        if (canExecuteActions && data.driftCount > 0) {
-            html += '<div class="d-flex gap-2">';
-            html += '<button class="btn btn-sm btn-outline-success" data-action="executeAll" data-sync-action="1" data-resource-type="' + resourceType + '">Add All Missing</button>';
-            html += '<button class="btn btn-sm btn-outline-primary" data-action="executeAll" data-sync-action="2" data-resource-type="' + resourceType + '">Sync All</button>';
-            html += '</div>';
-        }
-        html += '</div>';
-
-        // Resource cards
-        for (let i = 0; i < data.diffs.length; i++) {
-            html += renderResourceCard(data.diffs[i], resourceType, i);
-        }
-
-        pane.innerHTML = html;
-
-        // Bind toggle
-        const toggle = document.getElementById('changesOnly-' + resourceType);
+    function bindTabActions(pane, resourceType) {
+        // Bind changes-only toggle
+        var toggle = pane.querySelector('.sync-changes-toggle');
         if (toggle) {
             toggle.addEventListener('change', function () {
                 applyFilter(pane, this.checked);
@@ -144,159 +93,30 @@
             applyFilter(pane, toggle.checked);
         }
 
-        // Bind action buttons
+        // Bind execute-all buttons
         pane.querySelectorAll('[data-action="executeAll"]').forEach(function (btn) {
             btn.addEventListener('click', function () {
-                const syncAction = parseInt(this.getAttribute('data-sync-action'));
-                const rt = this.getAttribute('data-resource-type');
-                const actionName = syncAction === 1 ? 'add all missing humans' : 'sync all humans (add + remove)';
+                var syncAction = parseInt(this.getAttribute('data-sync-action'));
+                var rt = this.getAttribute('data-resource-type');
+                var actionName = syncAction === 1 ? 'add all missing humans' : 'sync all humans (add + remove)';
                 if (confirm('Are you sure you want to ' + actionName + ' for all ' + rt + ' resources?')) {
                     executeAll(rt, syncAction);
                 }
             });
         });
 
+        // Bind execute-single buttons
         pane.querySelectorAll('[data-action="executeSingle"]').forEach(function (btn) {
             btn.addEventListener('click', function () {
-                const resourceId = this.getAttribute('data-resource-id');
-                const syncAction = parseInt(this.getAttribute('data-sync-action'));
-                const resourceName = this.getAttribute('data-resource-name');
-                const actionName = syncAction === 1 ? 'add missing humans to' : 'sync all humans for';
+                var resourceId = this.getAttribute('data-resource-id');
+                var syncAction = parseInt(this.getAttribute('data-sync-action'));
+                var resourceName = this.getAttribute('data-resource-name');
+                var actionName = syncAction === 1 ? 'add missing humans to' : 'sync all humans for';
                 if (confirm('Are you sure you want to ' + actionName + ' "' + resourceName + '"?')) {
                     executeSingle(resourceId, syncAction, resourceType);
                 }
             });
         });
-    }
-
-    function summaryCard(label, value, textClass, borderClass) {
-        return '<div class="col-md-3"><div class="card text-center ' + (borderClass || '') + '">' +
-            '<div class="card-body"><h2 class="card-title mb-0 ' + textClass + '">' + value + '</h2>' +
-            '<p class="card-text text-muted">' + label + '</p></div></div></div>';
-    }
-
-    function renderResourceCard(diff, resourceType, index) {
-        const isInSync = diff.isInSync;
-        const hasError = diff.errorMessage != null;
-
-        let statusBadge;
-        if (hasError) {
-            statusBadge = '<span class="badge bg-danger">Error</span>';
-        } else if (isInSync) {
-            statusBadge = '<span class="badge bg-success">In Sync</span>';
-        } else {
-            statusBadge = '<span class="badge bg-warning text-dark">Drifted</span>';
-        }
-
-        const collapseId = 'collapse-' + resourceType + '-' + index;
-        const nameHtml = diff.url
-            ? '<a href="' + escapeHtml(diff.url) + '" target="_blank" rel="noopener noreferrer">' + escapeHtml(diff.resourceName) + '</a>'
-            : escapeHtml(diff.resourceName);
-
-        const teamsHtml = diff.linkedTeams && diff.linkedTeams.length > 0
-            ? diff.linkedTeams.map(function (t) {
-                var label = escapeHtml(t.name);
-                if (t.permissionLevel) label += ' <span class="text-muted fw-normal">\u00b7 ' + escapeHtml(t.permissionLevel) + '</span>';
-                return '<a href="/Teams/' + encodeURIComponent(t.slug) + '" class="badge bg-light text-dark border me-1 text-decoration-none">' + label + '</a>';
-            }).join('')
-            : '<span class="text-muted">None</span>';
-        const auditUrl = '@Url.Action("GoogleSyncResourceAudit", "Google", new { id = Guid.Empty })'.replace('00000000-0000-0000-0000-000000000000', diff.resourceId);
-        const canViewAudit = @Json.Serialize(Humans.Web.TagHelpers.ViewPolicies.Evaluate(Humans.Web.TagHelpers.ViewPolicies.AdminOrBoard, User));
-        const auditLinkHtml = canViewAudit
-            ? '<a class="btn btn-sm btn-outline-secondary" href="' + auditUrl.replace('__RESOURCE_ID__', diff.resourceId) + '">Audit</a>'
-            : '';
-
-        let html = '<div class="card mb-2' + (isInSync ? ' resource-in-sync' : '') + '">';
-        html += '<div class="card-header d-flex justify-content-between align-items-center py-2">';
-        html += '<div class="d-flex align-items-center gap-2">';
-        html += '<button class="btn btn-sm btn-link p-0 text-decoration-none" data-bs-toggle="collapse" data-bs-target="#' + collapseId + '" aria-expanded="false">';
-        html += '<i class="fa-solid fa-chevron-right collapse-icon"></i>';
-        html += '</button>';
-        html += '<span>' + nameHtml + '</span> ' + statusBadge;
-        html += '</div>';
-        html += '<div class="d-flex align-items-center gap-2">';
-        html += '<small class="text-muted">' + teamsHtml + '</small>';
-        if (auditLinkHtml) {
-            html += auditLinkHtml;
-        }
-        if (canExecuteActions && !isInSync && !hasError) {
-            html += '<button class="btn btn-sm btn-outline-success" data-action="executeSingle" data-resource-id="' + diff.resourceId + '" data-sync-action="1" data-resource-name="' + escapeHtml(diff.resourceName) + '">Add Missing</button>';
-            html += '<button class="btn btn-sm btn-outline-primary" data-action="executeSingle" data-resource-id="' + diff.resourceId + '" data-sync-action="2" data-resource-name="' + escapeHtml(diff.resourceName) + '">Sync All</button>';
-        }
-        html += '</div>';
-        html += '</div>';
-
-        // Collapsible member detail
-        html += '<div class="collapse" id="' + collapseId + '">';
-        html += '<div class="card-body p-0">';
-
-        if (hasError) {
-            html += '<div class="alert alert-danger m-3 mb-0">' + escapeHtml(diff.errorMessage) + '</div>';
-        } else if (diff.members && diff.members.length > 0) {
-            html += '<table class="table table-sm mb-0">';
-            var showPermission = diff.permissionLevel != null;
-            html += '<thead><tr><th>Email</th><th>Name</th><th>Status</th>' + (showPermission ? '<th>Role (current / expected)</th>' : '') + '<th>Teams</th></tr></thead>';
-            html += '<tbody>';
-            for (let j = 0; j < diff.members.length; j++) {
-                const m = diff.members[j];
-                let stateClass, stateLabel, badgeClass;
-                if (m.state === 0) { // Correct
-                    stateLabel = 'Correct';
-                    badgeClass = 'bg-success';
-                } else if (m.state === 1) { // Missing
-                    stateLabel = 'Missing';
-                    badgeClass = 'bg-warning text-dark';
-                } else if (m.state === 3) { // Inherited
-                    stateLabel = 'Inherited';
-                    badgeClass = 'bg-secondary';
-                } else if (m.state === 4) { // WrongRole
-                    stateLabel = 'Wrong Role';
-                    badgeClass = 'bg-info text-dark';
-                } else { // Extra
-                    stateLabel = 'Extra';
-                    badgeClass = 'bg-danger';
-                }
-                const memberTeams = m.teamLinks && m.teamLinks.length > 0
-                    ? m.teamLinks.map(function (t) { return '<a href="/Teams/' + encodeURIComponent(t.slug) + '" class="badge bg-light text-dark border me-1 text-decoration-none">' + escapeHtml(t.name) + '</a>'; }).join('')
-                    : '';
-                html += '<tr class="member-row" data-member-state="' + m.state + '">';
-                html += '<td>' + escapeHtml(m.email) + '</td>';
-                html += '<td>' + renderHumanLink(m) + '</td>';
-                html += '<td><span class="badge ' + badgeClass + '">' + stateLabel + '</span></td>';
-                if (showPermission) {
-                    var role = m.currentRole || '—';
-                    var expected = m.expectedRole || '—';
-                    html += '<td>' + escapeHtml(role) + ' / ' + escapeHtml(expected) + '</td>';
-                }
-                html += '<td>' + memberTeams + '</td>';
-                html += '</tr>';
-            }
-            html += '</tbody></table>';
-        } else {
-            html += '<div class="p-3 text-muted">No members</div>';
-        }
-
-        html += '</div></div>';
-        html += '</div>';
-
-        return html;
-    }
-
-    function renderHumanLink(m) {
-        var nameDisplay = m.displayName && m.displayName !== m.email ? m.displayName : '';
-        if (!nameDisplay) return '';
-        if (!m.userId) return escapeHtml(nameDisplay);
-
-        var initial = nameDisplay.charAt(0);
-        var avatarHtml;
-        if (m.profilePictureUrl) {
-            avatarHtml = '<img src="' + escapeHtml(m.profilePictureUrl) + '" alt="' + escapeHtml(nameDisplay) + '" class="rounded-circle me-2" style="width: 24px; height: 24px; object-fit: cover;" />';
-        } else {
-            avatarHtml = '<div class="bg-secondary rounded-circle d-flex align-items-center justify-content-center text-white me-2" style="width: 24px; height: 24px; font-size: 0.7rem; display: inline-flex !important;">' + escapeHtml(initial) + '</div>';
-        }
-
-        return '<a href="/Profile/' + encodeURIComponent(m.userId) + '/Admin" class="d-inline-flex align-items-center text-decoration-none text-reset" data-human-popover="true" data-user-id="' + escapeHtml(m.userId) + '">' +
-            avatarHtml + '<span>' + escapeHtml(nameDisplay) + '</span></a>';
     }
 
     function applyFilter(pane, changesOnly) {
@@ -334,7 +154,7 @@
     }
 
     function executeAll(resourceType, syncAction) {
-        const typeValue = getResourceTypeValue(resourceType);
+        var typeValue = getResourceTypeValue(resourceType);
         fetch('/Google/Sync/ExecuteAll/' + typeValue + '?action=' + syncAction, {
             method: 'POST',
             headers: {
@@ -354,15 +174,13 @@
         });
     }
 
-    @await Html.PartialAsync("~/Views/Shared/_EscapeHtmlScript.cshtml")
-
     // Rotate chevron on collapse toggle
     document.addEventListener('show.bs.collapse', function (e) {
-        const btn = e.target.previousElementSibling?.querySelector('.collapse-icon');
+        var btn = e.target.previousElementSibling?.querySelector('.collapse-icon');
         if (btn) btn.style.transform = 'rotate(90deg)';
     });
     document.addEventListener('hide.bs.collapse', function (e) {
-        const btn = e.target.previousElementSibling?.querySelector('.collapse-icon');
+        var btn = e.target.previousElementSibling?.querySelector('.collapse-icon');
         if (btn) btn.style.transform = '';
     });
 })();

--- a/src/Humans.Web/Views/Google/Sync.cshtml
+++ b/src/Humans.Web/Views/Google/Sync.cshtml
@@ -201,7 +201,7 @@
             }).join('')
             : '<span class="text-muted">None</span>';
         const auditUrl = '@Url.Action("GoogleSyncResourceAudit", "Google", new { id = Guid.Empty })'.replace('00000000-0000-0000-0000-000000000000', diff.resourceId);
-        const canViewAudit = @Json.Serialize(Humans.Web.Authorization.RoleChecks.IsAdminOrBoard(User));
+        const canViewAudit = @Json.Serialize(Humans.Web.TagHelpers.ViewPolicies.Evaluate(Humans.Web.TagHelpers.ViewPolicies.AdminOrBoard, User));
         const auditLinkHtml = canViewAudit
             ? '<a class="btn btn-sm btn-outline-secondary" href="' + auditUrl.replace('__RESOURCE_ID__', diff.resourceId) + '">Audit</a>'
             : '';

--- a/src/Humans.Web/Views/Google/_SyncTabContent.cshtml
+++ b/src/Humans.Web/Views/Google/_SyncTabContent.cshtml
@@ -1,0 +1,230 @@
+@model Humans.Web.Models.SyncTabContentViewModel
+@{
+    var result = Model.Result;
+    var resourceType = Model.ResourceType;
+}
+
+<div class="row mb-4">
+    <div class="col-md-3">
+        <div class="card text-center">
+            <div class="card-body">
+                <h2 class="card-title mb-0">@result.TotalResources</h2>
+                <p class="card-text text-muted">Total</p>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-3">
+        <div class="card text-center">
+            <div class="card-body">
+                <h2 class="card-title mb-0 text-success">@result.InSyncCount</h2>
+                <p class="card-text text-muted">In Sync</p>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-3">
+        <div class="card text-center @(result.DriftCount > 0 ? "border-warning" : "")">
+            <div class="card-body">
+                <h2 class="card-title mb-0 text-warning">@result.DriftCount</h2>
+                <p class="card-text text-muted">Drifted</p>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-3">
+        <div class="card text-center @(result.ErrorCount > 0 ? "border-danger" : "")">
+            <div class="card-body">
+                <h2 class="card-title mb-0 text-danger">@result.ErrorCount</h2>
+                <p class="card-text text-muted">Errors</p>
+            </div>
+        </div>
+    </div>
+</div>
+
+@if (result.Diffs.Count == 0)
+{
+    <div class="alert alert-info">No resources found for this type.</div>
+}
+else
+{
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <div class="form-check form-switch">
+            <input class="form-check-input sync-changes-toggle" type="checkbox" id="changesOnly-@resourceType" checked>
+            <label class="form-check-label" for="changesOnly-@resourceType">Show changes only</label>
+        </div>
+        @if (Model.CanExecuteActions && result.DriftCount > 0)
+        {
+            <div class="d-flex gap-2">
+                <button class="btn btn-sm btn-outline-success"
+                        data-action="executeAll" data-sync-action="1" data-resource-type="@resourceType">
+                    Add All Missing
+                </button>
+                <button class="btn btn-sm btn-outline-primary"
+                        data-action="executeAll" data-sync-action="2" data-resource-type="@resourceType">
+                    Sync All
+                </button>
+            </div>
+        }
+    </div>
+
+    @for (var i = 0; i < result.Diffs.Count; i++)
+    {
+        var diff = result.Diffs[i];
+        var hasError = diff.ErrorMessage is not null;
+        var collapseId = $"collapse-{resourceType}-{i}";
+        var showPermission = diff.PermissionLevel is not null;
+
+        <div class="card mb-2@(diff.IsInSync ? " resource-in-sync" : "")">
+            <div class="card-header d-flex justify-content-between align-items-center py-2">
+                <div class="d-flex align-items-center gap-2">
+                    <button class="btn btn-sm btn-link p-0 text-decoration-none"
+                            data-bs-toggle="collapse" data-bs-target="#@collapseId" aria-expanded="false">
+                        <i class="fa-solid fa-chevron-right collapse-icon"></i>
+                    </button>
+                    <span>
+                        @if (diff.Url is not null)
+                        {
+                            <a href="@diff.Url" target="_blank" rel="noopener noreferrer">@diff.ResourceName</a>
+                        }
+                        else
+                        {
+                            @diff.ResourceName
+                        }
+                    </span>
+                    @if (hasError)
+                    {
+                        <span class="badge bg-danger">Error</span>
+                    }
+                    else if (diff.IsInSync)
+                    {
+                        <span class="badge bg-success">In Sync</span>
+                    }
+                    else
+                    {
+                        <span class="badge bg-warning text-dark">Drifted</span>
+                    }
+                </div>
+                <div class="d-flex align-items-center gap-2">
+                    <small class="text-muted">
+                        @if (diff.LinkedTeams.Count > 0)
+                        {
+                            @foreach (var team in diff.LinkedTeams)
+                            {
+                                <a href="/Teams/@team.Slug" class="badge bg-light text-dark border me-1 text-decoration-none">
+                                    @team.Name
+                                    @if (team.PermissionLevel is not null)
+                                    {
+                                        <span class="text-muted fw-normal">&middot; @team.PermissionLevel</span>
+                                    }
+                                </a>
+                            }
+                        }
+                        else
+                        {
+                            <span class="text-muted">None</span>
+                        }
+                    </small>
+                    @if (Model.CanViewAudit)
+                    {
+                        <a class="btn btn-sm btn-outline-secondary"
+                           href="@Url.Action("GoogleSyncResourceAudit", "Google", new { id = diff.ResourceId })">Audit</a>
+                    }
+                    @if (Model.CanExecuteActions && !diff.IsInSync && !hasError)
+                    {
+                        <button class="btn btn-sm btn-outline-success"
+                                data-action="executeSingle" data-resource-id="@diff.ResourceId"
+                                data-sync-action="1" data-resource-name="@diff.ResourceName">
+                            Add Missing
+                        </button>
+                        <button class="btn btn-sm btn-outline-primary"
+                                data-action="executeSingle" data-resource-id="@diff.ResourceId"
+                                data-sync-action="2" data-resource-name="@diff.ResourceName">
+                            Sync All
+                        </button>
+                    }
+                </div>
+            </div>
+
+            <div class="collapse" id="@collapseId">
+                <div class="card-body p-0">
+                    @if (hasError)
+                    {
+                        <div class="alert alert-danger m-3 mb-0">@diff.ErrorMessage</div>
+                    }
+                    else if (diff.Members.Count > 0)
+                    {
+                        <table class="table table-sm mb-0">
+                            <thead>
+                                <tr>
+                                    <th>Email</th>
+                                    <th>Name</th>
+                                    <th>Status</th>
+                                    @if (showPermission)
+                                    {
+                                        <th>Role (current / expected)</th>
+                                    }
+                                    <th>Teams</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach (var m in diff.Members)
+                                {
+                                    var (stateLabel, badgeClass) = m.State switch
+                                    {
+                                        Humans.Application.DTOs.MemberSyncState.Correct => ("Correct", "bg-success"),
+                                        Humans.Application.DTOs.MemberSyncState.Missing => ("Missing", "bg-warning text-dark"),
+                                        Humans.Application.DTOs.MemberSyncState.Inherited => ("Inherited", "bg-secondary"),
+                                        Humans.Application.DTOs.MemberSyncState.WrongRole => ("Wrong Role", "bg-info text-dark"),
+                                        _ => ("Extra", "bg-danger")
+                                    };
+
+                                    <tr class="member-row" data-member-state="@((int)m.State)">
+                                        <td>@m.Email</td>
+                                        <td>
+                                            @{
+                                                var nameDisplay = !string.IsNullOrEmpty(m.DisplayName) && !string.Equals(m.DisplayName, m.Email, StringComparison.Ordinal)
+                                                    ? m.DisplayName : null;
+                                            }
+                                            @if (nameDisplay is not null && m.UserId.HasValue)
+                                            {
+                                                <a href="/Profile/@m.UserId/Admin"
+                                                   class="d-inline-flex align-items-center text-decoration-none text-reset"
+                                                   data-human-popover="true" data-user-id="@m.UserId">
+                                                    @await Component.InvokeAsync("UserAvatar", new
+                                                    {
+                                                        profilePictureUrl = m.ProfilePictureUrl,
+                                                        displayName = nameDisplay,
+                                                        size = 24,
+                                                        cssClass = "me-2"
+                                                    })
+                                                    <span>@nameDisplay</span>
+                                                </a>
+                                            }
+                                            else if (nameDisplay is not null)
+                                            {
+                                                @nameDisplay
+                                            }
+                                        </td>
+                                        <td><span class="badge @badgeClass">@stateLabel</span></td>
+                                        @if (showPermission)
+                                        {
+                                            <td>@(m.CurrentRole ?? "\u2014") / @(m.ExpectedRole ?? "\u2014")</td>
+                                        }
+                                        <td>
+                                            @foreach (var team in m.TeamLinks)
+                                            {
+                                                <a href="/Teams/@team.Slug" class="badge bg-light text-dark border me-1 text-decoration-none">@team.Name</a>
+                                            }
+                                        </td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </table>
+                    }
+                    else
+                    {
+                        <div class="p-3 text-muted">No members</div>
+                    }
+                </div>
+            </div>
+        </div>
+    }
+}

--- a/src/Humans.Web/Views/OnboardingReview/BoardVotingDetail.cshtml
+++ b/src/Humans.Web/Views/OnboardingReview/BoardVotingDetail.cshtml
@@ -112,46 +112,43 @@
     </div>
 
     <div class="col-md-4">
-        @if (Humans.Web.Authorization.RoleChecks.IsBoard(User))
-        {
-            <div class="card mb-4">
-                <div class="card-header">@Localizer["BoardVoting_CastVote"]</div>
-                <div class="card-body">
-                    <form asp-action="Vote" method="post">
-                        @Html.AntiForgeryToken()
-                        <input type="hidden" name="applicationId" value="@Model.ApplicationId" />
+        <div class="card mb-4" authorize-policy="Board">
+            <div class="card-header">@Localizer["BoardVoting_CastVote"]</div>
+            <div class="card-body">
+                <form asp-action="Vote" method="post">
+                    @Html.AntiForgeryToken()
+                    <input type="hidden" name="applicationId" value="@Model.ApplicationId" />
 
-                        <div class="mb-3">
-                            <label class="form-label">@Localizer["BoardVoting_YourVote"]</label>
-                            <div class="d-grid gap-2">
-                                @foreach (var choice in Enum.GetValues<VoteChoice>())
+                    <div class="mb-3">
+                        <label class="form-label">@Localizer["BoardVoting_YourVote"]</label>
+                        <div class="d-grid gap-2">
+                            @foreach (var choice in Enum.GetValues<VoteChoice>())
+                            {
+                                var btnClass = choice switch
                                 {
-                                    var btnClass = choice switch
-                                    {
-                                        VoteChoice.Yay => "btn-outline-success",
-                                        VoteChoice.Maybe => "btn-outline-warning",
-                                        VoteChoice.No => "btn-outline-danger",
-                                        VoteChoice.Abstain => "btn-outline-secondary",
-                                        _ => "btn-outline-secondary"
-                                    };
-                                    var isActive = Model.CurrentUserVote == choice;
-                                    <button type="submit" name="vote" value="@choice"
-                                            class="btn @(isActive ? btnClass.Replace("outline-", "", StringComparison.Ordinal) : btnClass)">
-                                        @choice
-                                    </button>
-                                }
-                            </div>
+                                    VoteChoice.Yay => "btn-outline-success",
+                                    VoteChoice.Maybe => "btn-outline-warning",
+                                    VoteChoice.No => "btn-outline-danger",
+                                    VoteChoice.Abstain => "btn-outline-secondary",
+                                    _ => "btn-outline-secondary"
+                                };
+                                var isActive = Model.CurrentUserVote == choice;
+                                <button type="submit" name="vote" value="@choice"
+                                        class="btn @(isActive ? btnClass.Replace("outline-", "", StringComparison.Ordinal) : btnClass)">
+                                    @choice
+                                </button>
+                            }
                         </div>
+                    </div>
 
-                        <div class="mb-3">
-                            <label for="voteNote" class="form-label">@Localizer["BoardVoting_Note"]</label>
-                            <textarea id="voteNote" name="note" class="form-control" rows="2"
-                                      placeholder="@Localizer["OnboardingReview_NotesPlaceholder"].Value">@Model.CurrentUserNote</textarea>
-                        </div>
-                    </form>
-                </div>
+                    <div class="mb-3">
+                        <label for="voteNote" class="form-label">@Localizer["BoardVoting_Note"]</label>
+                        <textarea id="voteNote" name="note" class="form-control" rows="2"
+                                  placeholder="@Localizer["OnboardingReview_NotesPlaceholder"].Value">@Model.CurrentUserNote</textarea>
+                    </div>
+                </form>
             </div>
-        }
+        </div>
 
         @if (Model.CanFinalize)
         {

--- a/src/Humans.Web/Views/Profile/Index.cshtml
+++ b/src/Humans.Web/Views/Profile/Index.cshtml
@@ -9,12 +9,9 @@
             <h1>@(Model.IsOwnProfile ? Localizer["Profile_Title"] : Model.DisplayName)</h1>
             <div class="d-flex gap-2">
                 <vc:access-matrix section="Profile" />
-                @if (Humans.Web.Authorization.RoleChecks.IsHumanAdminBoardOrAdmin(User))
-                {
-                    <human-link user-id="@Model.UserId" display-name="Admin" admin="true" class="btn btn-sm btn-outline-secondary">
-                        <i class="fa-solid fa-user-shield"></i> Admin
-                    </human-link>
-                }
+                <human-link user-id="@Model.UserId" display-name="Admin" admin="true" class="btn btn-sm btn-outline-secondary" authorize-policy="HumanAdminBoardOrAdmin">
+                    <i class="fa-solid fa-user-shield"></i> Admin
+                </human-link>
             </div>
         </div>
 
@@ -60,7 +57,7 @@
         @{
             var cardViewMode = Model.IsOwnProfile
                 ? ProfileCardViewMode.Self
-                : Humans.Web.Authorization.RoleChecks.IsTeamsAdminBoardOrAdmin(User)
+                : Humans.Web.TagHelpers.ViewPolicies.Evaluate(Humans.Web.TagHelpers.ViewPolicies.TeamsAdminBoardOrAdmin, User)
                     ? ProfileCardViewMode.Admin
                     : ProfileCardViewMode.Public;
         }

--- a/src/Humans.Web/Views/Shared/_Layout.cshtml
+++ b/src/Humans.Web/Views/Shared/_Layout.cshtml
@@ -51,79 +51,45 @@
                                 <a class="nav-link" asp-controller="Legal" asp-action="Index">Legal</a>
                             </li>
                         }
-                        @if (User.Identity?.IsAuthenticated == true)
-                        {
-                            var isActiveMember = User.HasClaim(Humans.Web.Authorization.RoleAssignmentClaimsTransformation.ActiveMemberClaimType, Humans.Web.Authorization.RoleAssignmentClaimsTransformation.ActiveClaimValue) || Humans.Web.Authorization.RoleChecks.IsTeamsAdminBoardOrAdmin(User);
-                            @if (isActiveMember || Humans.Web.Authorization.ShiftRoleChecks.CanAccessDashboard(User))
-                            {
-                                <li class="nav-item">
-                                    <a class="nav-link" asp-area="" asp-controller="Shifts" asp-action="Index">@Localizer["Nav_Shifts"]</a>
-                                </li>
-                            }
-                            @if (Humans.Web.Authorization.RoleChecks.CanAccessVolunteers(User))
-                            {
-                                <li class="nav-item">
-                                    <a class="nav-link" asp-area="" asp-controller="Vol" asp-action="Index">V</a>
-                                </li>
-                            }
-                        }
-                        @if (Humans.Web.Authorization.RoleChecks.CanAccessReviewQueue(User))
-                        {
-                            <li class="nav-item">
-                                <a class="nav-link" asp-area="" asp-controller="OnboardingReview" asp-action="Index">@Localizer["Nav_Review"] @await Component.InvokeAsync("NavBadges", new { queue = "review" })</a>
-                            </li>
-                        }
-                        @if (Humans.Web.Authorization.RoleChecks.IsAdminOrBoard(User))
-                        {
-                            <li class="nav-item">
-                                <a class="nav-link" asp-area="" asp-controller="OnboardingReview" asp-action="BoardVoting">@Localizer["Nav_Voting"] @await Component.InvokeAsync("NavBadges", new { queue = "voting" })</a>
-                            </li>
-                        }
-                        @if (Humans.Web.Authorization.RoleChecks.IsAdminOrBoard(User))
-                        {
-                            <li class="nav-item">
-                                <a class="nav-link" asp-area="" asp-controller="Board" asp-action="Index">@Localizer["Nav_Board"]</a>
-                            </li>
-                        }
-                        @if (Humans.Web.Authorization.RoleChecks.IsHumanAdmin(User) && !Humans.Web.Authorization.RoleChecks.IsAdminOrBoard(User))
-                        {
-                            <li class="nav-item">
-                                <a class="nav-link" asp-area="" asp-controller="Profile" asp-action="AdminList">Humans</a>
-                            </li>
-                        }
-                        @if (Humans.Web.Authorization.RoleChecks.IsAdmin(User))
-                        {
-                            <li class="nav-item">
-                                <a class="nav-link" asp-area="" asp-controller="Admin" asp-action="Index">@Localizer["Nav_Admin"]</a>
-                            </li>
-                            <li class="nav-item">
-                                <a class="nav-link" asp-area="" asp-controller="Google" asp-action="Index">Google</a>
-                            </li>
-                        }
-                        @if (Humans.Web.Authorization.RoleChecks.CanAccessTickets(User))
-                        {
-                            <li class="nav-item">
-                                <a class="nav-link" asp-area="" asp-controller="Ticket" asp-action="Index">Tickets</a>
-                            </li>
-                        }
-                        @if (Humans.Web.Authorization.RoleChecks.IsFeedbackAdmin(User))
-                        {
-                            <li class="nav-item">
-                                <a class="nav-link" asp-area="" asp-controller="Feedback" asp-action="Index">Feedback @await Component.InvokeAsync("NavBadges", new { queue = "feedback" })</a>
-                            </li>
-                        }
+                        <li class="nav-item" authorize-policy="ActiveMemberOrShiftAccess">
+                            <a class="nav-link" asp-area="" asp-controller="Shifts" asp-action="Index">@Localizer["Nav_Shifts"]</a>
+                        </li>
+                        <li class="nav-item" authorize-policy="CanAccessVolunteers">
+                            <a class="nav-link" asp-area="" asp-controller="Vol" asp-action="Index">V</a>
+                        </li>
+                        <li class="nav-item" authorize-policy="CanAccessReviewQueue">
+                            <a class="nav-link" asp-area="" asp-controller="OnboardingReview" asp-action="Index">@Localizer["Nav_Review"] @await Component.InvokeAsync("NavBadges", new { queue = "review" })</a>
+                        </li>
+                        <li class="nav-item" authorize-policy="AdminOrBoard">
+                            <a class="nav-link" asp-area="" asp-controller="OnboardingReview" asp-action="BoardVoting">@Localizer["Nav_Voting"] @await Component.InvokeAsync("NavBadges", new { queue = "voting" })</a>
+                        </li>
+                        <li class="nav-item" authorize-policy="AdminOrBoard">
+                            <a class="nav-link" asp-area="" asp-controller="Board" asp-action="Index">@Localizer["Nav_Board"]</a>
+                        </li>
+                        <li class="nav-item" authorize-policy="HumanAdminOnly">
+                            <a class="nav-link" asp-area="" asp-controller="Profile" asp-action="AdminList">Humans</a>
+                        </li>
+                        <li class="nav-item" authorize-policy="Admin">
+                            <a class="nav-link" asp-area="" asp-controller="Admin" asp-action="Index">@Localizer["Nav_Admin"]</a>
+                        </li>
+                        <li class="nav-item" authorize-policy="Admin">
+                            <a class="nav-link" asp-area="" asp-controller="Google" asp-action="Index">Google</a>
+                        </li>
+                        <li class="nav-item" authorize-policy="CanAccessTickets">
+                            <a class="nav-link" asp-area="" asp-controller="Ticket" asp-action="Index">Tickets</a>
+                        </li>
+                        <li class="nav-item" authorize-policy="IsFeedbackAdmin">
+                            <a class="nav-link" asp-area="" asp-controller="Feedback" asp-action="Index">Feedback @await Component.InvokeAsync("NavBadges", new { queue = "feedback" })</a>
+                        </li>
                         @if (User.Identity?.IsAuthenticated == true)
                         {
                             <li class="nav-item">
                                 <a class="nav-link" asp-area="" asp-controller="Budget" asp-action="Summary">Budget</a>
                             </li>
                         }
-                        @if (Humans.Web.Authorization.RoleChecks.CanAccessFinance(User))
-                        {
-                            <li class="nav-item">
-                                <a class="nav-link" asp-area="" asp-controller="Finance" asp-action="Index">Finance</a>
-                            </li>
-                        }
+                        <li class="nav-item" authorize-policy="CanAccessFinance">
+                            <a class="nav-link" asp-area="" asp-controller="Finance" asp-action="Index">Finance</a>
+                        </li>
                     </ul>
                     <div class="d-flex align-items-center gap-2">
                         @if (User.Identity?.IsAuthenticated == true)

--- a/src/Humans.Web/Views/Shared/_LoginPartial.cshtml
+++ b/src/Humans.Web/Views/Shared/_LoginPartial.cshtml
@@ -7,11 +7,6 @@
     var currentUser = await UserManager.GetUserAsync(User);
     var displayName = currentUser?.DisplayName ?? User.Identity?.Name;
     var email = currentUser?.Email;
-    var isActiveMember = User.HasClaim(
-        Humans.Web.Authorization.RoleAssignmentClaimsTransformation.ActiveMemberClaimType,
-        Humans.Web.Authorization.RoleAssignmentClaimsTransformation.ActiveClaimValue)
-        || Humans.Web.Authorization.RoleChecks.IsTeamsAdminBoardOrAdmin(User);
-
     <div class="dropdown" data-testid="user-nav">
         <button class="btn btn-link dropdown-toggle d-flex align-items-center gap-2 text-decoration-none p-0"
                 type="button"
@@ -48,14 +43,11 @@
                     <i class="fa-solid fa-file-contract fa-fw"></i> @Localizer["Nav_Consents"]
                 </a>
             </li>
-            @if (isActiveMember)
-            {
-                <li>
-                    <a class="dropdown-item d-flex align-items-center gap-2" asp-controller="Governance" asp-action="Index">
-                        <i class="fa-solid fa-landmark fa-fw"></i> @Localizer["Nav_Governance"]
-                    </a>
-                </li>
-            }
+            <li authorize-policy="IsActiveMember">
+                <a class="dropdown-item d-flex align-items-center gap-2" asp-controller="Governance" asp-action="Index">
+                    <i class="fa-solid fa-landmark fa-fw"></i> @Localizer["Nav_Governance"]
+                </a>
+            </li>
             <li>
                 <a class="dropdown-item d-flex align-items-center gap-2" asp-controller="Legal" asp-action="Index">
                     <i class="fa-solid fa-scale-balanced fa-fw"></i> Legal

--- a/src/Humans.Web/Views/Shifts/Index.cshtml
+++ b/src/Humans.Web/Views/Shifts/Index.cshtml
@@ -51,14 +51,8 @@
         <h2>Browse Volunteer Options</h2>
         <div class="d-flex gap-2">
             <vc:access-matrix section="Shifts" />
-            @if (Humans.Web.Authorization.ShiftRoleChecks.CanManageDepartment(User))
-            {
-                <a asp-controller="ShiftDashboard" asp-action="Index" class="btn btn-outline-warning"><i class="fa-solid fa-gauge-high me-1"></i>Dashboard</a>
-            }
-            @if (Humans.Web.Authorization.RoleChecks.IsAdmin(User))
-            {
-                <a asp-action="Settings" class="btn btn-outline-secondary"><i class="fa-solid fa-gear me-1"></i>Settings</a>
-            }
+            <a asp-controller="ShiftDashboard" asp-action="Index" class="btn btn-outline-warning" authorize-policy="CanManageDepartment"><i class="fa-solid fa-gauge-high me-1"></i>Dashboard</a>
+            <a asp-action="Settings" class="btn btn-outline-secondary" authorize-policy="Admin"><i class="fa-solid fa-gear me-1"></i>Settings</a>
             <a asp-action="Mine" class="btn btn-outline-primary">My Shifts</a>
         </div>
     </div>

--- a/src/Humans.Web/Views/Shifts/NoActiveEvent.cshtml
+++ b/src/Humans.Web/Views/Shifts/NoActiveEvent.cshtml
@@ -5,8 +5,5 @@
 <div class="container py-4 text-center">
     <h2>Shifts</h2>
     <p class="text-muted mt-4">No active event is configured. An admin needs to set up event settings first.</p>
-    @if (Humans.Web.Authorization.RoleChecks.IsAdmin(User))
-    {
-        <a asp-action="Settings" class="btn btn-primary mt-2">Configure Event Settings</a>
-    }
+    <a asp-action="Settings" class="btn btn-primary mt-2" authorize-policy="Admin">Configure Event Settings</a>
 </div>

--- a/src/Humans.Web/Views/Team/EditTeam.cshtml
+++ b/src/Humans.Web/Views/Team/EditTeam.cshtml
@@ -69,14 +69,11 @@
                         </div>
                     }
 
-                    @if (Humans.Web.Authorization.RoleChecks.IsAdmin(User))
-                    {
-                        <div class="mb-3 form-check">
-                            <input asp-for="IsSensitive" type="checkbox" class="form-check-input" />
-                            <label asp-for="IsSensitive" class="form-check-label">Sensitive team</label>
-                            <div class="form-text">When enabled, adding or approving humans triggers a confirmation modal showing the audit record that will be created. This flag is not visible to non-admin users.</div>
-                        </div>
-                    }
+                    <div class="mb-3 form-check" authorize-policy="Admin">
+                        <input asp-for="IsSensitive" type="checkbox" class="form-check-input" />
+                        <label asp-for="IsSensitive" class="form-check-label">Sensitive team</label>
+                        <div class="form-text">When enabled, adding or approving humans triggers a confirmation modal showing the audit record that will be created. This flag is not visible to non-admin users.</div>
+                    </div>
 
                     <div class="d-flex gap-2">
                         <button type="submit" class="btn btn-primary">@Localizer["Common_Save"]</button>

--- a/src/Humans.Web/Views/Team/Summary.cshtml
+++ b/src/Humans.Web/Views/Team/Summary.cshtml
@@ -5,10 +5,7 @@
 
 <div class="d-flex justify-content-between align-items-center mb-4">
     <h1>Teams Summary</h1>
-    @if (Humans.Web.Authorization.RoleChecks.IsAdminOrBoard(User))
-    {
-        <a asp-action="CreateTeam" class="btn btn-primary">@Localizer["Teams_CreateTeam"]</a>
-    }
+    <a asp-action="CreateTeam" class="btn btn-primary" authorize-policy="AdminOrBoard">@Localizer["Teams_CreateTeam"]</a>
 </div>
 
 <vc:temp-data-alerts />
@@ -28,10 +25,7 @@
                     <th>@Localizer["AdminTeams_DriveResources"]</th>
                     <th>@Localizer["Common_Status"]</th>
                     <th>@Localizer["AdminTeams_Created"]</th>
-                    @if (Humans.Web.Authorization.RoleChecks.IsAdminOrBoard(User))
-                    {
-                        <th>@Localizer["MyTeams_Actions"]</th>
-                    }
+                    <th authorize-policy="AdminOrBoard">@Localizer["MyTeams_Actions"]</th>
                 </tr>
             </thead>
             <tbody>
@@ -75,7 +69,7 @@
                         <td>
                             @if (team.PendingShiftSignupCount > 0)
                             {
-                                @if (Humans.Web.Authorization.RoleChecks.IsAdminOrBoard(User))
+                                @if (Humans.Web.TagHelpers.ViewPolicies.Evaluate(Humans.Web.TagHelpers.ViewPolicies.AdminOrBoard, User))
                                 {
                                     <a asp-controller="ShiftAdmin" asp-action="Index" asp-route-slug="@team.Slug">
                                         <span class="badge bg-warning">@team.PendingShiftSignupCount</span>
@@ -127,28 +121,25 @@
                             }
                         </td>
                         <td>@team.CreatedAt.ToDisplayCompactDate()</td>
-                        @if (Humans.Web.Authorization.RoleChecks.IsAdminOrBoard(User))
-                        {
-                            <td>
-                                @if (!team.IsSystemTeam)
-                                {
-                                    <div class="d-flex gap-1" role="group">
-                                        <a asp-action="EditTeam" asp-route-id="@team.Id" class="btn btn-sm btn-outline-primary">@Localizer["Common_Edit"]</a>
-                                        @if (team.IsActive)
-                                        {
-                                            <form asp-action="DeleteTeam" asp-route-id="@team.Id" method="post" class="d-inline">
-                                                @Html.AntiForgeryToken()
-                                                <button type="submit" class="btn btn-sm btn-outline-danger" data-confirm="@Localizer["AdminTeams_DeactivateConfirm"].Value">@Localizer["AdminTeams_Deactivate"]</button>
-                                            </form>
-                                        }
-                                    </div>
-                                }
-                                else
-                                {
-                                    <span class="text-muted">@Localizer["AdminTeams_SystemManaged"]</span>
-                                }
-                            </td>
-                        }
+                        <td authorize-policy="AdminOrBoard">
+                            @if (!team.IsSystemTeam)
+                            {
+                                <div class="d-flex gap-1" role="group">
+                                    <a asp-action="EditTeam" asp-route-id="@team.Id" class="btn btn-sm btn-outline-primary">@Localizer["Common_Edit"]</a>
+                                    @if (team.IsActive)
+                                    {
+                                        <form asp-action="DeleteTeam" asp-route-id="@team.Id" method="post" class="d-inline">
+                                            @Html.AntiForgeryToken()
+                                            <button type="submit" class="btn btn-sm btn-outline-danger" data-confirm="@Localizer["AdminTeams_DeactivateConfirm"].Value">@Localizer["AdminTeams_Deactivate"]</button>
+                                        </form>
+                                    }
+                                </div>
+                            }
+                            else
+                            {
+                                <span class="text-muted">@Localizer["AdminTeams_SystemManaged"]</span>
+                            }
+                        </td>
                     </tr>
                 }
             </tbody>

--- a/src/Humans.Web/Views/Ticket/Index.cshtml
+++ b/src/Humans.Web/Views/Ticket/Index.cshtml
@@ -296,25 +296,19 @@
                     <span class="badge bg-danger ms-2">Error</span>
                 }
             </span>
-            @if (Humans.Web.Authorization.RoleChecks.CanManageTickets(User))
-            {
-                <form asp-action="Sync" method="post" class="d-inline">
-                    @Html.AntiForgeryToken()
-                    <button type="submit" class="btn btn-sm btn-primary">
-                        <i class="fa-solid fa-sync"></i> Sync Now
-                    </button>
-                </form>
-                @if (Humans.Web.Authorization.RoleChecks.IsAdmin(User))
-                {
-                    <form asp-action="FullResync" method="post" class="d-inline ms-2"
-                          onsubmit="return confirm('This will re-fetch ALL orders from the vendor. Continue?');">
-                        @Html.AntiForgeryToken()
-                        <button type="submit" class="btn btn-sm btn-danger">
-                            <i class="fa-solid fa-arrows-rotate"></i> Full Re-sync
-                        </button>
-                    </form>
-                }
-            }
+            <form asp-action="Sync" method="post" class="d-inline" authorize-policy="CanManageTickets">
+                @Html.AntiForgeryToken()
+                <button type="submit" class="btn btn-sm btn-primary">
+                    <i class="fa-solid fa-sync"></i> Sync Now
+                </button>
+            </form>
+            <form asp-action="FullResync" method="post" class="d-inline ms-2" authorize-policy="Admin"
+                  onsubmit="return confirm('This will re-fetch ALL orders from the vendor. Continue?');">
+                @Html.AntiForgeryToken()
+                <button type="submit" class="btn btn-sm btn-danger">
+                    <i class="fa-solid fa-arrows-rotate"></i> Full Re-sync
+                </button>
+            </form>
         </div>
     </div>
 </div>

--- a/src/Humans.Web/Views/Vol/Management.cshtml
+++ b/src/Humans.Web/Views/Vol/Management.cshtml
@@ -34,12 +34,9 @@
                 <p class="text-muted mb-2">
                     Humans can @(Model.SystemOpen ? "" : "not ")browse and sign up for shifts.
                 </p>
-                @if (Humans.Web.Authorization.RoleChecks.IsAdmin(User))
-                {
-                    <a asp-action="Settings" class="btn btn-sm btn-outline-secondary">
-                        <i class="fa-solid fa-gear me-1"></i>Change in Settings
-                    </a>
-                }
+                <a asp-action="Settings" class="btn btn-sm btn-outline-secondary" authorize-policy="Admin">
+                    <i class="fa-solid fa-gear me-1"></i>Change in Settings
+                </a>
             </div>
         </div>
     </div>
@@ -103,14 +100,11 @@
                     <i class="fa-solid fa-chart-pie me-1"></i>Staffing Report
                 </button>
             </div>
-            @if (Humans.Web.Authorization.RoleChecks.IsAdmin(User))
-            {
-                <div class="col-md-3">
-                    <a asp-action="Settings" class="btn btn-outline-primary w-100">
-                        <i class="fa-solid fa-gear me-1"></i>Settings
-                    </a>
-                </div>
-            }
+            <div class="col-md-3" authorize-policy="Admin">
+                <a asp-action="Settings" class="btn btn-outline-primary w-100">
+                    <i class="fa-solid fa-gear me-1"></i>Settings
+                </a>
+            </div>
         </div>
     </div>
 </div>

--- a/src/Humans.Web/Views/Vol/NoActiveEvent.cshtml
+++ b/src/Humans.Web/Views/Vol/NoActiveEvent.cshtml
@@ -6,8 +6,5 @@
 <div class="text-center py-4">
     <h4>No Active Event</h4>
     <p class="text-muted mt-3">No active event is configured. An admin needs to set up event settings first.</p>
-    @if (Humans.Web.Authorization.RoleChecks.IsAdmin(User))
-    {
-        <a asp-action="Settings" class="btn btn-primary mt-2">Configure Event Settings</a>
-    }
+    <a asp-action="Settings" class="btn btn-primary mt-2" authorize-policy="Admin">Configure Event Settings</a>
 </div>

--- a/src/Humans.Web/Views/Vol/_VolLayout.cshtml
+++ b/src/Humans.Web/Views/Vol/_VolLayout.cshtml
@@ -23,27 +23,21 @@
                 <i class="fa-solid fa-users me-1"></i>Teams
             </a>
         </li>
-        @if (Humans.Web.Authorization.ShiftRoleChecks.CanAccessDashboard(User))
-        {
-            <li class="nav-item">
-                <a class="nav-link @(activeTab == "Urgent" ? "active" : "")" asp-controller="Vol" asp-action="Urgent">
-                    <i class="fa-solid fa-bolt me-1"></i>Urgent
-                </a>
-            </li>
-            <li class="nav-item">
-                <a class="nav-link @(activeTab == "Management" ? "active" : "")" asp-controller="Vol" asp-action="Management">
-                    <i class="fa-solid fa-chart-bar me-1"></i>Management
-                </a>
-            </li>
-        }
-        @if (Humans.Web.Authorization.RoleChecks.IsAdmin(User))
-        {
-            <li class="nav-item">
-                <a class="nav-link @(activeTab == "Settings" ? "active" : "")" asp-controller="Vol" asp-action="Settings">
-                    <i class="fa-solid fa-gear me-1"></i>Settings
-                </a>
-            </li>
-        }
+        <li class="nav-item" authorize-policy="CanAccessDashboard">
+            <a class="nav-link @(activeTab == "Urgent" ? "active" : "")" asp-controller="Vol" asp-action="Urgent">
+                <i class="fa-solid fa-bolt me-1"></i>Urgent
+            </a>
+        </li>
+        <li class="nav-item" authorize-policy="CanAccessDashboard">
+            <a class="nav-link @(activeTab == "Management" ? "active" : "")" asp-controller="Vol" asp-action="Management">
+                <i class="fa-solid fa-chart-bar me-1"></i>Management
+            </a>
+        </li>
+        <li class="nav-item" authorize-policy="Admin">
+            <a class="nav-link @(activeTab == "Settings" ? "active" : "")" asp-controller="Vol" asp-action="Settings">
+                <i class="fa-solid fa-gear me-1"></i>Settings
+            </a>
+        </li>
     </ul>
     @RenderBody()
 </div>


### PR DESCRIPTION
## Summary
- Replace 34 scattered RoleChecks.* calls in views with authorization TagHelpers (#336)
- Audit client-side rendered pages and convert/document per Razor-first guideline (#291)

## Test plan
- [ ] Verify nav menu visibility matches current behavior for all roles
- [ ] Verify all pages with RoleChecks replacements render correctly
- [ ] Verify audit documentation is complete
- [ ] Verify build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)