### PR TITLE
Google Sync Improvements (#318, #14)

### DIFF
--- a/docs/features/07-google-integration.md
+++ b/docs/features/07-google-integration.md
@@ -519,9 +519,19 @@ When system teams are synced, Google permissions are also updated:
 
 ## Error Handling
 
-### Retry Strategy
+### Outbox Sync Error Classification
+
+The `ProcessGoogleSyncOutboxJob` classifies Google API errors into two categories:
+
+**Permanent failures (HTTP 400, 404):** User-level errors — invalid email format or user not found. The outbox event is marked `FailedPermanently = true` and the user's `GoogleEmailStatus` is set to `Rejected`. While rejected, no new sync events are enqueued for that user. The user must update their Google email (Profile → Emails), which resets `GoogleEmailStatus` to `Unknown` and triggers re-sync for all current team memberships.
+
+**Transient failures (all other errors including 403, 429, 5xx):** Retried up to 10 times. HTTP 403 is treated as transient because it typically indicates a resource-level permission issue (service account lacks access to a Group or Drive), not a user email problem.
+
+`GoogleEmailStatus` is set to `Valid` only after a successful `AddUserToTeamResources` event where the team has linked Google resources — ensuring the email was actually accepted by a Google API call.
+
+### Resource-Level Retry Strategy
 ```
-On Google API error:
+On Google API error (resource provisioning):
   1. Log error with details
   2. Store error in GoogleResource.ErrorMessage
   3. Set IsActive = false if persistent
@@ -531,11 +541,19 @@ On Google API error:
 ### Error Scenarios
 | Error | Handling |
 |-------|----------|
-| Rate limit exceeded | Exponential backoff |
-| User not in domain | Skip, log warning |
+| Rate limit exceeded (429) | Transient — retry with backoff |
+| User not found (404) | Permanent — mark user email rejected |
+| Invalid email (400) | Permanent — mark user email rejected |
+| Permission denied (403) | Transient — resource-level issue, retry |
 | Folder not found | Re-provision |
-| Permission denied | Alert admin |
 | Inherited permission delete | Skip (cannot remove inherited Shared Drive permissions) |
+
+### Admin Digest Reporting
+
+The daily admin digest reports sync health:
+- **Failed sync events (transient):** Unprocessed events with errors, still being retried
+- **Humans with rejected email:** Distinct users with `GoogleEmailStatus = Rejected`
+- **Transient retries:** Events being retried (have errors but not permanently failed)
 
 ## Security Considerations
 

--- a/docs/sections/GoogleIntegration.md
+++ b/docs/sections/GoogleIntegration.md
@@ -40,6 +40,8 @@ Team-level resource linking stays at `/Teams/{slug}/Resources` in `TeamAdminCont
 - Drive folders with `RestrictInheritedAccess = true` have `inheritedPermissionsDisabled` enforced by the reconciliation job. Drift (manual re-enablement of inheritance) is detected and corrected automatically, with an audit trail entry.
 - Sync settings are per-service (Google Drive, Google Groups, Discord). Setting a service to None disables sync without redeploying.
 - A human's Google service email is their @nobodies.team email if provisioned, otherwise their OAuth login email.
+- Each human has a `GoogleEmailStatus` (`Unknown`, `Valid`, `Rejected`). When Google permanently rejects an email (HTTP 400/403/404), the status is set to `Rejected` and new outbox events are not enqueued for that human. When a human changes their Google email, the status resets to `Unknown` and fresh sync events are enqueued.
+- Permanent Google API errors (HTTP 400, 403, 404) mark outbox events as `FailedPermanently` and stop retrying immediately. Transient errors (5xx, 429, etc.) continue retrying up to the configured limit.
 - The system authenticates to Google APIs as a service account — no domain-wide delegation or user impersonation.
 - There are exactly four gateway operations that can modify Google access, and all enforce the current sync mode before executing.
 
@@ -52,7 +54,7 @@ Team-level resource linking stays at `/Teams/{slug}/Resources` in `TeamAdminCont
 ## Triggers
 
 - When team membership changes, sync outbox events are queued for Google Group and Drive updates.
-- When a human's Google email changes, their Google resource memberships need re-sync.
+- When a human's Google email changes, `GoogleEmailStatus` resets to `Unknown` and fresh sync events are enqueued for all current team memberships.
 - When a Google resource is linked to a team, current team members are synced to that resource.
 - When a Google resource is unlinked, managed permissions are removed (if sync mode allows).
 - The system team sync job runs hourly, reconciling system team membership.

--- a/src/Humans.Application/DTOs/AdminDigestCounts.cs
+++ b/src/Humans.Application/DTOs/AdminDigestCounts.cs
@@ -11,5 +11,7 @@ public record AdminDigestCounts(
     int StillOnboarding,
     int BoardVotingTotal,
     int FailedSyncOutboxEvents,
+    int PermanentSyncFailures,
+    int TransientSyncRetries,
     bool TicketSyncError,
     string? TicketSyncErrorMessage);

--- a/src/Humans.Domain/Entities/GoogleSyncOutboxEvent.cs
+++ b/src/Humans.Domain/Entities/GoogleSyncOutboxEvent.cs
@@ -18,7 +18,7 @@ public class GoogleSyncOutboxEvent
     public string? LastError { get; set; }
 
     /// <summary>
-    /// Whether this event failed with a permanent error (HTTP 400/403/404).
+    /// Whether this event failed with a permanent error (HTTP 400/404).
     /// When true, ProcessedAt is set and the event is not retried.
     /// </summary>
     public bool FailedPermanently { get; set; }

--- a/src/Humans.Domain/Entities/GoogleSyncOutboxEvent.cs
+++ b/src/Humans.Domain/Entities/GoogleSyncOutboxEvent.cs
@@ -16,4 +16,10 @@ public class GoogleSyncOutboxEvent
     public int RetryCount { get; set; }
     public string DeduplicationKey { get; set; } = string.Empty;
     public string? LastError { get; set; }
+
+    /// <summary>
+    /// Whether this event failed with a permanent error (HTTP 400/403/404).
+    /// When true, ProcessedAt is set and the event is not retried.
+    /// </summary>
+    public bool FailedPermanently { get; set; }
 }

--- a/src/Humans.Domain/Entities/User.cs
+++ b/src/Humans.Domain/Entities/User.cs
@@ -131,6 +131,12 @@ public class User : IdentityUser<Guid>
     public string? GoogleEmail { get; set; }
 
     /// <summary>
+    /// Status of the user's Google email for sync operations.
+    /// Set to Rejected when a permanent Google API error occurs; reset to Unknown on email change.
+    /// </summary>
+    public GoogleEmailStatus GoogleEmailStatus { get; set; } = GoogleEmailStatus.Unknown;
+
+    /// <summary>
     /// Gets the email address used for Google services (Groups, Drive permissions).
     /// Returns GoogleEmail if set, otherwise falls back to the OAuth email.
     /// Does NOT require UserEmails to be loaded.

--- a/src/Humans.Domain/Enums/GoogleEmailStatus.cs
+++ b/src/Humans.Domain/Enums/GoogleEmailStatus.cs
@@ -1,0 +1,24 @@
+namespace Humans.Domain.Enums;
+
+/// <summary>
+/// Status of a user's Google email for Google Workspace sync operations.
+/// When Rejected, the system skips enqueuing new outbox events for this user.
+/// </summary>
+public enum GoogleEmailStatus
+{
+    /// <summary>
+    /// Default state — email has not been validated against Google APIs.
+    /// </summary>
+    Unknown = 0,
+
+    /// <summary>
+    /// Email has been successfully used with Google APIs.
+    /// </summary>
+    Valid = 1,
+
+    /// <summary>
+    /// Email was permanently rejected by Google APIs (HTTP 400/403/404).
+    /// User must update their Google email before sync events are enqueued.
+    /// </summary>
+    Rejected = 2
+}

--- a/src/Humans.Domain/Enums/GoogleEmailStatus.cs
+++ b/src/Humans.Domain/Enums/GoogleEmailStatus.cs
@@ -17,7 +17,7 @@ public enum GoogleEmailStatus
     Valid = 1,
 
     /// <summary>
-    /// Email was permanently rejected by Google APIs (HTTP 400/403/404).
+    /// Email was permanently rejected by Google APIs (HTTP 400/404).
     /// User must update their Google email before sync events are enqueued.
     /// </summary>
     Rejected = 2

--- a/src/Humans.Infrastructure/Data/Configurations/GoogleSyncOutboxEventConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/GoogleSyncOutboxEventConfiguration.cs
@@ -40,6 +40,9 @@ public class GoogleSyncOutboxEventConfiguration : IEntityTypeConfiguration<Googl
             .HasForeignKey(e => e.UserId)
             .OnDelete(DeleteBehavior.Cascade);
 
+        builder.Property(e => e.FailedPermanently)
+            .IsRequired();
+
         builder.HasIndex(e => new { e.ProcessedAt, e.OccurredAt });
         builder.HasIndex(e => new { e.TeamId, e.UserId, e.ProcessedAt });
         builder.HasIndex(e => e.DeduplicationKey)

--- a/src/Humans.Infrastructure/Data/Configurations/UserConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/UserConfiguration.cs
@@ -23,6 +23,13 @@ public class UserConfiguration : IEntityTypeConfiguration<User>
         builder.Property(u => u.GoogleEmail)
             .HasMaxLength(256);
 
+        builder.Property(u => u.GoogleEmailStatus)
+            .HasConversion<string>()
+            .HasMaxLength(50)
+            .HasDefaultValue(GoogleEmailStatus.Unknown)
+            .HasSentinel(GoogleEmailStatus.Unknown)
+            .IsRequired();
+
         builder.Property(u => u.CreatedAt)
             .IsRequired();
 

--- a/src/Humans.Infrastructure/Jobs/ProcessGoogleSyncOutboxJob.cs
+++ b/src/Humans.Infrastructure/Jobs/ProcessGoogleSyncOutboxJob.cs
@@ -19,10 +19,12 @@ public class ProcessGoogleSyncOutboxJob : IRecurringJob
     private const int MaxRetryCount = 10;
 
     /// <summary>
-    /// HTTP status codes that indicate a permanent failure (do not retry).
-    /// 400 = bad request (invalid email format), 403 = forbidden (no access), 404 = not found.
+    /// HTTP status codes that indicate a permanent user-level failure (do not retry).
+    /// 400 = bad request (invalid email format), 404 = user not found.
+    /// Note: 403 is excluded because it typically indicates a resource-level permission issue
+    /// (service account lacks access), not a user email problem.
     /// </summary>
-    private static readonly HashSet<int> PermanentErrorCodes = [400, 403, 404];
+    private static readonly HashSet<int> PermanentErrorCodes = [400, 404];
 
     private readonly HumansDbContext _dbContext;
     private readonly IGoogleSyncService _googleSyncService;
@@ -88,8 +90,18 @@ public class ProcessGoogleSyncOutboxJob : IRecurringJob
                 outboxEvent.LastError = null;
                 _metrics.RecordSyncOperation("success");
 
-                // Mark user as Valid on successful sync
-                await MarkUserGoogleEmailStatusAsync(outboxEvent.UserId, GoogleEmailStatus.Valid, cancellationToken);
+                // Only mark user as Valid when the event actually touched Google APIs
+                // (AddUserToTeamResources with linked resources). RemoveUserFromTeamResources
+                // is a no-op, and Add with zero resources doesn't validate the email.
+                if (string.Equals(outboxEvent.EventType, GoogleSyncOutboxEventTypes.AddUserToTeamResources, StringComparison.Ordinal))
+                {
+                    var hasResources = await _dbContext.GoogleResources
+                        .AnyAsync(r => r.TeamId == outboxEvent.TeamId && r.IsActive, cancellationToken);
+                    if (hasResources)
+                    {
+                        await MarkUserGoogleEmailStatusAsync(outboxEvent.UserId, GoogleEmailStatus.Valid, cancellationToken);
+                    }
+                }
 
                 await _dbContext.SaveChangesAsync(cancellationToken);
             }

--- a/src/Humans.Infrastructure/Jobs/ProcessGoogleSyncOutboxJob.cs
+++ b/src/Humans.Infrastructure/Jobs/ProcessGoogleSyncOutboxJob.cs
@@ -18,6 +18,12 @@ public class ProcessGoogleSyncOutboxJob : IRecurringJob
     private const int BatchSize = 100;
     private const int MaxRetryCount = 10;
 
+    /// <summary>
+    /// HTTP status codes that indicate a permanent failure (do not retry).
+    /// 400 = bad request (invalid email format), 403 = forbidden (no access), 404 = not found.
+    /// </summary>
+    private static readonly HashSet<int> PermanentErrorCodes = [400, 403, 404];
+
     private readonly HumansDbContext _dbContext;
     private readonly IGoogleSyncService _googleSyncService;
     private readonly INotificationService _notificationService;
@@ -44,7 +50,7 @@ public class ProcessGoogleSyncOutboxJob : IRecurringJob
     public async Task ExecuteAsync(CancellationToken cancellationToken = default)
     {
         var pendingEvents = await _dbContext.GoogleSyncOutboxEvents
-            .Where(e => e.ProcessedAt == null && e.RetryCount < MaxRetryCount)
+            .Where(e => e.ProcessedAt == null && !e.FailedPermanently && e.RetryCount < MaxRetryCount)
             .OrderBy(e => e.OccurredAt)
             .Take(BatchSize)
             .ToListAsync(cancellationToken);
@@ -81,6 +87,31 @@ public class ProcessGoogleSyncOutboxJob : IRecurringJob
                 outboxEvent.ProcessedAt = _clock.GetCurrentInstant();
                 outboxEvent.LastError = null;
                 _metrics.RecordSyncOperation("success");
+
+                // Mark user as Valid on successful sync
+                await MarkUserGoogleEmailStatusAsync(outboxEvent.UserId, GoogleEmailStatus.Valid, cancellationToken);
+
+                await _dbContext.SaveChangesAsync(cancellationToken);
+            }
+            catch (Google.GoogleApiException ex) when (IsPermanentError(ex))
+            {
+                _metrics.RecordSyncOperation("permanent_failure");
+                outboxEvent.FailedPermanently = true;
+                outboxEvent.ProcessedAt = _clock.GetCurrentInstant();
+                outboxEvent.LastError = ex.Message.Length > 4000
+                    ? ex.Message[..4000]
+                    : ex.Message;
+
+                _logger.LogWarning(
+                    ex,
+                    "Permanent failure processing Google sync outbox event {OutboxId} ({EventType}) — HTTP {StatusCode}, not retrying",
+                    outboxEvent.Id,
+                    outboxEvent.EventType,
+                    ex.Error?.Code);
+
+                // Mark user's Google email as Rejected
+                await MarkUserGoogleEmailStatusAsync(outboxEvent.UserId, GoogleEmailStatus.Rejected, cancellationToken);
+
                 await _dbContext.SaveChangesAsync(cancellationToken);
             }
             catch (Exception ex)
@@ -126,5 +157,20 @@ public class ProcessGoogleSyncOutboxJob : IRecurringJob
             }
         }
         _metrics.RecordJobRun("process_google_sync_outbox", "success");
+    }
+
+    private static bool IsPermanentError(Google.GoogleApiException ex)
+    {
+        return ex.Error?.Code is int code && PermanentErrorCodes.Contains(code);
+    }
+
+    private async Task MarkUserGoogleEmailStatusAsync(
+        Guid userId, GoogleEmailStatus status, CancellationToken cancellationToken)
+    {
+        var user = await _dbContext.Users.FindAsync([userId], cancellationToken);
+        if (user is not null)
+        {
+            user.GoogleEmailStatus = status;
+        }
     }
 }

--- a/src/Humans.Infrastructure/Jobs/SendAdminDailyDigestJob.cs
+++ b/src/Humans.Infrastructure/Jobs/SendAdminDailyDigestJob.cs
@@ -88,9 +88,17 @@ public class SendAdminDailyDigestJob : IRecurringJob
             var boardVotingTotal = await _dbContext.Applications
                 .CountAsync(a => a.Status == ApplicationStatus.Submitted, cancellationToken);
 
-            // Stale Google sync outbox events (unprocessed with errors)
+            // Stale Google sync outbox events (unprocessed with errors, excluding permanent failures)
             var failedSyncEvents = await _dbContext.GoogleSyncOutboxEvents
-                .CountAsync(e => e.ProcessedAt == null && e.LastError != null, cancellationToken);
+                .CountAsync(e => e.ProcessedAt == null && e.LastError != null && !e.FailedPermanently, cancellationToken);
+
+            // Permanent Google sync failures (user email rejected by Google)
+            var permanentSyncFailures = await _dbContext.GoogleSyncOutboxEvents
+                .CountAsync(e => e.FailedPermanently, cancellationToken);
+
+            // Transient retries (still being retried, have errors but not permanent)
+            var transientSyncRetries = await _dbContext.GoogleSyncOutboxEvents
+                .CountAsync(e => e.ProcessedAt == null && !e.FailedPermanently && e.RetryCount > 0, cancellationToken);
 
             // Ticket sync status
             var ticketSyncState = await _dbContext.TicketSyncStates.FindAsync([1], cancellationToken);
@@ -105,6 +113,8 @@ public class SendAdminDailyDigestJob : IRecurringJob
                 stillOnboardingCount,
                 boardVotingTotal,
                 failedSyncEvents,
+                permanentSyncFailures,
+                transientSyncRetries,
                 ticketSyncError,
                 ticketSyncErrorMessage);
 
@@ -112,7 +122,8 @@ public class SendAdminDailyDigestJob : IRecurringJob
             var hasItems = pendingDeletionsCount > 0 || pendingConsentsCount > 0
                 || teamJoinRequestCount > 0 || onboardingReviewCount > 0
                 || stillOnboardingCount > 0 || boardVotingTotal > 0
-                || failedSyncEvents > 0 || ticketSyncError;
+                || failedSyncEvents > 0 || permanentSyncFailures > 0
+                || transientSyncRetries > 0 || ticketSyncError;
 
             if (!hasItems)
             {

--- a/src/Humans.Infrastructure/Jobs/SendAdminDailyDigestJob.cs
+++ b/src/Humans.Infrastructure/Jobs/SendAdminDailyDigestJob.cs
@@ -92,9 +92,9 @@ public class SendAdminDailyDigestJob : IRecurringJob
             var failedSyncEvents = await _dbContext.GoogleSyncOutboxEvents
                 .CountAsync(e => e.ProcessedAt == null && e.LastError != null && !e.FailedPermanently, cancellationToken);
 
-            // Permanent Google sync failures (user email rejected by Google)
-            var permanentSyncFailures = await _dbContext.GoogleSyncOutboxEvents
-                .CountAsync(e => e.FailedPermanently, cancellationToken);
+            // Permanent Google sync failures — count distinct users with rejected email status
+            var permanentSyncFailures = await _dbContext.Users
+                .CountAsync(u => u.GoogleEmailStatus == GoogleEmailStatus.Rejected, cancellationToken);
 
             // Transient retries (still being retried, have errors but not permanent)
             var transientSyncRetries = await _dbContext.GoogleSyncOutboxEvents

--- a/src/Humans.Infrastructure/Migrations/20260403143319_AddGoogleSyncFailureTracking.Designer.cs
+++ b/src/Humans.Infrastructure/Migrations/20260403143319_AddGoogleSyncFailureTracking.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Humans.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Humans.Infrastructure.Migrations
 {
     [DbContext(typeof(HumansDbContext))]
-    partial class HumansDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260403143319_AddGoogleSyncFailureTracking")]
+    partial class AddGoogleSyncFailureTracking
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Humans.Infrastructure/Migrations/20260403143319_AddGoogleSyncFailureTracking.cs
+++ b/src/Humans.Infrastructure/Migrations/20260403143319_AddGoogleSyncFailureTracking.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Humans.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddGoogleSyncFailureTracking : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "GoogleEmailStatus",
+                table: "users",
+                type: "character varying(50)",
+                maxLength: 50,
+                nullable: false,
+                defaultValue: "Unknown");
+
+            migrationBuilder.AddColumn<bool>(
+                name: "FailedPermanently",
+                table: "google_sync_outbox",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "GoogleEmailStatus",
+                table: "users");
+
+            migrationBuilder.DropColumn(
+                name: "FailedPermanently",
+                table: "google_sync_outbox");
+        }
+    }
+}

--- a/src/Humans.Infrastructure/Services/DriveActivityMonitorService.cs
+++ b/src/Humans.Infrastructure/Services/DriveActivityMonitorService.cs
@@ -384,7 +384,7 @@ public class DriveActivityMonitorService : IDriveActivityMonitorService
                 .AsNoTracking()
                 .FirstOrDefaultAsync(l =>
                     l.ProviderKey == googleUserId &&
-                    string.Equals(l.LoginProvider, "Google", StringComparison.OrdinalIgnoreCase),
+                    l.LoginProvider == "Google",
                     cancellationToken);
 
             if (login is not null)

--- a/src/Humans.Infrastructure/Services/DriveActivityMonitorService.cs
+++ b/src/Humans.Infrastructure/Services/DriveActivityMonitorService.cs
@@ -1,8 +1,10 @@
 using System.Text.Json;
+using Google.Apis.Admin.Directory.directory_v1;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.DriveActivity.v2;
 using Google.Apis.DriveActivity.v2.Data;
 using Google.Apis.Services;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -29,7 +31,13 @@ public class DriveActivityMonitorService : IDriveActivityMonitorService
     private readonly ILogger<DriveActivityMonitorService> _logger;
 
     private DriveActivityService? _activityService;
+    private DirectoryService? _directoryService;
     private string? _serviceAccountEmail;
+
+    /// <summary>
+    /// Per-invocation cache for resolved people/ IDs to avoid repeated API calls.
+    /// </summary>
+    private readonly Dictionary<string, string> _peopleIdCache = new(StringComparer.Ordinal);
 
     private const string JobName = "DriveActivityMonitorJob";
 
@@ -137,7 +145,7 @@ public class DriveActivityMonitorService : IDriveActivityMonitorService
                     if (IsPermissionChangeActivity(activity) &&
                         !IsInitiatedByServiceAccount(activity, serviceAccountEmail))
                     {
-                        var description = BuildAnomalyDescription(activity, resourceName);
+                        var description = await BuildAnomalyDescriptionAsync(activity, resourceName, cancellationToken);
 
                         // Skip if this exact anomaly was already logged within the lookback window
                         var alreadyLogged = await _dbContext.AuditLogEntries
@@ -152,7 +160,7 @@ public class DriveActivityMonitorService : IDriveActivityMonitorService
                             continue;
                         }
 
-                        var actorEmail = GetActorEmail(activity);
+                        var actorEmail = await GetActorEmailAsync(activity, cancellationToken);
 
                         _logger.LogWarning(
                             "Anomalous permission change detected on {ResourceName} ({GoogleId}) by {Actor}: {Description}",
@@ -208,7 +216,7 @@ public class DriveActivityMonitorService : IDriveActivityMonitorService
         return false;
     }
 
-    private static string? GetActorEmail(DriveActivity activity)
+    private async Task<string?> GetActorEmailAsync(DriveActivity activity, CancellationToken cancellationToken)
     {
         if (activity.Actors is null || activity.Actors.Count == 0)
         {
@@ -219,7 +227,7 @@ public class DriveActivityMonitorService : IDriveActivityMonitorService
         {
             if (actor.User?.KnownUser?.PersonName is not null)
             {
-                return actor.User.KnownUser.PersonName;
+                return await ResolvePersonNameAsync(actor.User.KnownUser.PersonName, cancellationToken);
             }
 
             if (actor.Administrator is not null)
@@ -236,9 +244,10 @@ public class DriveActivityMonitorService : IDriveActivityMonitorService
         return null;
     }
 
-    private static string BuildAnomalyDescription(DriveActivity activity, string resourceName)
+    private async Task<string> BuildAnomalyDescriptionAsync(
+        DriveActivity activity, string resourceName, CancellationToken cancellationToken)
     {
-        var actorEmail = GetActorEmail(activity) ?? "unknown actor";
+        var actorEmail = await GetActorEmailAsync(activity, cancellationToken) ?? "unknown actor";
         var permChange = activity.PrimaryActionDetail?.PermissionChange;
         var parts = new List<string>();
 
@@ -246,7 +255,7 @@ public class DriveActivityMonitorService : IDriveActivityMonitorService
         {
             foreach (var perm in permChange.AddedPermissions)
             {
-                var target = GetPermissionTarget(perm);
+                var target = await GetPermissionTargetAsync(perm, cancellationToken);
                 var role = perm.Role ?? "unknown role";
                 parts.Add($"added {role} for {target}");
             }
@@ -256,7 +265,7 @@ public class DriveActivityMonitorService : IDriveActivityMonitorService
         {
             foreach (var perm in permChange.RemovedPermissions)
             {
-                var target = GetPermissionTarget(perm);
+                var target = await GetPermissionTargetAsync(perm, cancellationToken);
                 var role = perm.Role ?? "unknown role";
                 parts.Add($"removed {role} for {target}");
             }
@@ -269,11 +278,11 @@ public class DriveActivityMonitorService : IDriveActivityMonitorService
         return $"Anomalous permission change on '{resourceName}' by {actorEmail}: {changes}";
     }
 
-    private static string GetPermissionTarget(Permission permission)
+    private async Task<string> GetPermissionTargetAsync(Permission permission, CancellationToken cancellationToken)
     {
         if (permission.User?.KnownUser?.PersonName is not null)
         {
-            return permission.User.KnownUser.PersonName;
+            return await ResolvePersonNameAsync(permission.User.KnownUser.PersonName, cancellationToken);
         }
 
         if (permission.Group?.Email is not null)
@@ -294,6 +303,107 @@ public class DriveActivityMonitorService : IDriveActivityMonitorService
         return "unknown";
     }
 
+    /// <summary>
+    /// Resolves a Drive Activity API person name to an email address.
+    /// If the name is a people/ resource ID (e.g., "people/123456789"), attempts resolution via:
+    /// 1. Per-invocation cache
+    /// 2. Google Admin Directory API
+    /// 3. Local DB lookup (matching Google user IDs)
+    /// Falls back to the raw ID if all resolution fails.
+    /// </summary>
+    private async Task<string> ResolvePersonNameAsync(string personName, CancellationToken cancellationToken)
+    {
+        if (!personName.StartsWith("people/", StringComparison.Ordinal))
+        {
+            // Already an email address
+            return personName;
+        }
+
+        if (_peopleIdCache.TryGetValue(personName, out var cached))
+        {
+            return cached;
+        }
+
+        var resolved = await TryResolveViaDirectoryApiAsync(personName, cancellationToken)
+            ?? await TryResolveViaLocalDbAsync(personName, cancellationToken);
+
+        if (resolved is not null)
+        {
+            _peopleIdCache[personName] = resolved;
+            _logger.LogDebug("Resolved {PersonName} to {Email}", personName, resolved);
+            return resolved;
+        }
+
+        // Fall back to raw ID
+        _peopleIdCache[personName] = personName;
+        _logger.LogDebug("Could not resolve {PersonName} to an email address", personName);
+        return personName;
+    }
+
+    /// <summary>
+    /// Attempts to resolve a people/ ID to an email via the Admin Directory API.
+    /// The people/ ID from Drive Activity API corresponds to a Google user ID.
+    /// </summary>
+    private async Task<string?> TryResolveViaDirectoryApiAsync(string personName, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var directoryService = await GetDirectoryServiceAsync();
+            // Extract the numeric user ID from "people/123456789"
+            var userId = personName["people/".Length..];
+            var userRequest = directoryService.Users.Get(userId);
+            var user = await userRequest.ExecuteAsync(cancellationToken);
+            return user?.PrimaryEmail;
+        }
+        catch (Google.GoogleApiException ex) when (ex.Error?.Code is 404 or 403)
+        {
+            _logger.LogDebug("Directory API could not resolve {PersonName} (HTTP {Code})",
+                personName, ex.Error.Code);
+            return null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error resolving {PersonName} via Directory API", personName);
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Attempts to resolve a people/ ID by looking up the user in the local database.
+    /// Users authenticated via Google OAuth have their Google user ID stored in login claims.
+    /// </summary>
+    private async Task<string?> TryResolveViaLocalDbAsync(string personName, CancellationToken cancellationToken)
+    {
+        try
+        {
+            // Extract the numeric user ID from "people/123456789"
+            var googleUserId = personName["people/".Length..];
+
+            // Check ASP.NET Identity user logins for Google provider
+            var login = await _dbContext.Set<IdentityUserLogin<Guid>>()
+                .AsNoTracking()
+                .FirstOrDefaultAsync(l =>
+                    l.ProviderKey == googleUserId &&
+                    string.Equals(l.LoginProvider, "Google", StringComparison.OrdinalIgnoreCase),
+                    cancellationToken);
+
+            if (login is not null)
+            {
+                var user = await _dbContext.Users
+                    .AsNoTracking()
+                    .FirstOrDefaultAsync(u => u.Id == login.UserId, cancellationToken);
+                return user?.Email;
+            }
+
+            return null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error resolving {PersonName} via local DB", personName);
+            return null;
+        }
+    }
+
     private async Task<DriveActivityService> GetActivityServiceAsync()
     {
         if (_activityService is not null)
@@ -301,7 +411,7 @@ public class DriveActivityMonitorService : IDriveActivityMonitorService
             return _activityService;
         }
 
-        var credential = await GetCredentialAsync();
+        var credential = await GetCredentialAsync(DriveActivityService.Scope.DriveActivityReadonly);
 
         _activityService = new DriveActivityService(new BaseClientService.Initializer
         {
@@ -312,7 +422,25 @@ public class DriveActivityMonitorService : IDriveActivityMonitorService
         return _activityService;
     }
 
-    private async Task<GoogleCredential> GetCredentialAsync()
+    private async Task<DirectoryService> GetDirectoryServiceAsync()
+    {
+        if (_directoryService is not null)
+        {
+            return _directoryService;
+        }
+
+        var credential = await GetCredentialAsync(DirectoryService.Scope.AdminDirectoryUserReadonly);
+
+        _directoryService = new DirectoryService(new BaseClientService.Initializer
+        {
+            HttpClientInitializer = credential,
+            ApplicationName = "Humans"
+        });
+
+        return _directoryService;
+    }
+
+    private async Task<GoogleCredential> GetCredentialAsync(params string[] scopes)
     {
         GoogleCredential credential;
 
@@ -334,7 +462,7 @@ public class DriveActivityMonitorService : IDriveActivityMonitorService
                 "Google Workspace credentials not configured. Set ServiceAccountKeyPath or ServiceAccountKeyJson.");
         }
 
-        return credential.CreateScoped(DriveActivityService.Scope.DriveActivityReadonly);
+        return credential.CreateScoped(scopes);
     }
 
     private async Task<string> GetServiceAccountEmailAsync(CancellationToken ct)

--- a/src/Humans.Infrastructure/Services/EmailRenderer.cs
+++ b/src/Humans.Infrastructure/Services/EmailRenderer.cs
@@ -211,7 +211,13 @@ public class EmailRenderer : IEmailRenderer
             items.Add($"<li><strong>{counts.BoardVotingTotal}</strong> tier applications awaiting vote <a href=\"{_settings.BaseUrl}/OnboardingReview/BoardVoting\">&rarr;</a></li>");
 
         if (counts.FailedSyncOutboxEvents > 0)
-            items.Add($"<li><strong>{counts.FailedSyncOutboxEvents}</strong> failed Google sync outbox events <a href=\"{_settings.BaseUrl}/Google/Sync\">&rarr;</a></li>");
+            items.Add($"<li><strong>{counts.FailedSyncOutboxEvents}</strong> failed Google sync outbox events (transient, retrying) <a href=\"{_settings.BaseUrl}/Google/Sync\">&rarr;</a></li>");
+
+        if (counts.PermanentSyncFailures > 0)
+            items.Add($"<li><strong>{counts.PermanentSyncFailures}</strong> humans with rejected Google email (sync blocked) <a href=\"{_settings.BaseUrl}/Google/Sync\">&rarr;</a></li>");
+
+        if (counts.TransientSyncRetries > 0)
+            items.Add($"<li><strong>{counts.TransientSyncRetries}</strong> Google sync events retrying (transient errors) <a href=\"{_settings.BaseUrl}/Google/Sync\">&rarr;</a></li>");
 
         if (counts.TicketSyncError)
             items.Add($"<li>Ticket sync error: {HtmlEncode(counts.TicketSyncErrorMessage ?? "Unknown")} <a href=\"{_settings.BaseUrl}/Tickets\">&rarr;</a></li>");

--- a/src/Humans.Infrastructure/Services/TeamService.cs
+++ b/src/Humans.Infrastructure/Services/TeamService.cs
@@ -1961,6 +1961,16 @@ public class TeamService : ITeamService
         Guid userId,
         string eventType)
     {
+        // Skip enqueuing for users whose Google email was permanently rejected
+        var trackedUser = _dbContext.Users.Local.FirstOrDefault(u => u.Id == userId);
+        if (trackedUser?.GoogleEmailStatus == GoogleEmailStatus.Rejected)
+        {
+            _logger.LogDebug(
+                "Skipping Google sync outbox event {EventType} for user {UserId} — GoogleEmailStatus is Rejected",
+                eventType, userId);
+            return;
+        }
+
         _dbContext.GoogleSyncOutboxEvents.Add(new GoogleSyncOutboxEvent
         {
             Id = Guid.NewGuid(),

--- a/src/Humans.Infrastructure/Services/TeamService.cs
+++ b/src/Humans.Infrastructure/Services/TeamService.cs
@@ -1962,8 +1962,8 @@ public class TeamService : ITeamService
         string eventType)
     {
         // Skip enqueuing for users whose Google email was permanently rejected
-        var trackedUser = _dbContext.Users.Local.FirstOrDefault(u => u.Id == userId);
-        if (trackedUser?.GoogleEmailStatus == GoogleEmailStatus.Rejected)
+        var user = _dbContext.Users.Find(userId);
+        if (user?.GoogleEmailStatus == GoogleEmailStatus.Rejected)
         {
             _logger.LogDebug(
                 "Skipping Google sync outbox event {EventType} for user {UserId} — GoogleEmailStatus is Rejected",

--- a/src/Humans.Web/Controllers/ProfileController.cs
+++ b/src/Humans.Web/Controllers/ProfileController.cs
@@ -676,10 +676,19 @@ public class ProfileController : HumansControllerBase
             }
 
             // null = use OAuth email (default behavior)
+            var previousEmail = user.GoogleEmail;
             user.GoogleEmail = email.IsOAuth ? null : email.Email;
+            user.GoogleEmailStatus = GoogleEmailStatus.Unknown;
             await _userManager.UpdateAsync(user);
 
-            SetSuccess("Google service email updated.");
+            // If email changed, enqueue fresh sync events for all current team memberships
+            var newEmail = user.GetGoogleServiceEmail();
+            if (!string.Equals(previousEmail ?? user.Email, newEmail, StringComparison.OrdinalIgnoreCase))
+            {
+                await EnqueueResyncForUserTeamsAsync(user.Id);
+            }
+
+            SetSuccess("Google service email updated. Sync will be retried with the new email.");
         }
         catch (Exception ex)
         {
@@ -1506,8 +1515,45 @@ public class ProfileController : HumansControllerBase
             CanAddEmail = canAdd,
             MinutesUntilResend = minutesUntilResend,
             GoogleServiceEmail = user.GoogleEmail,
-            HasNobodiesTeamEmail = hasNobodiesTeam
+            HasNobodiesTeamEmail = hasNobodiesTeam,
+            GoogleEmailStatus = user.GoogleEmailStatus
         };
+    }
+
+    /// <summary>
+    /// Enqueues fresh AddUserToTeamResources sync events for all teams the user is currently a member of.
+    /// Used when the Google service email changes to trigger re-sync with the updated email.
+    /// </summary>
+    private async Task EnqueueResyncForUserTeamsAsync(Guid userId)
+    {
+        var memberships = await _dbContext.TeamMembers
+            .Where(tm => tm.UserId == userId && tm.LeftAt == null)
+            .Select(tm => new { tm.Id, tm.TeamId })
+            .ToListAsync();
+
+        var now = _clock.GetCurrentInstant();
+        foreach (var membership in memberships)
+        {
+            var dedupeKey = $"{membership.Id}:{GoogleSyncOutboxEventTypes.AddUserToTeamResources}:resync:{now}";
+            _dbContext.GoogleSyncOutboxEvents.Add(new GoogleSyncOutboxEvent
+            {
+                Id = Guid.NewGuid(),
+                EventType = GoogleSyncOutboxEventTypes.AddUserToTeamResources,
+                TeamId = membership.TeamId,
+                UserId = userId,
+                OccurredAt = now,
+                DeduplicationKey = dedupeKey
+            });
+        }
+
+        await _dbContext.SaveChangesAsync();
+
+        if (memberships.Count > 0)
+        {
+            _logger.LogInformation(
+                "Enqueued {Count} re-sync events for user {UserId} after Google email change",
+                memberships.Count, userId);
+        }
     }
 
     private async Task<CommunicationPreferencesViewModel> BuildCommunicationPreferencesViewModelAsync(Guid userId)

--- a/src/Humans.Web/Models/EmailsViewModel.cs
+++ b/src/Humans.Web/Models/EmailsViewModel.cs
@@ -41,6 +41,11 @@ public class EmailsViewModel
     /// Whether the user has a verified @nobodies.team email (which auto-locks Google preference).
     /// </summary>
     public bool HasNobodiesTeamEmail { get; set; }
+
+    /// <summary>
+    /// Status of the Google email for sync operations.
+    /// </summary>
+    public GoogleEmailStatus GoogleEmailStatus { get; set; }
 }
 
 /// <summary>

--- a/src/Humans.Web/Views/Profile/Emails.cshtml
+++ b/src/Humans.Web/Views/Profile/Emails.cshtml
@@ -138,6 +138,21 @@
                         <text>Your @@nobodies.team email is automatically used.</text>
                     }
                 </p>
+                @if (Model.GoogleEmailStatus == Humans.Domain.Enums.GoogleEmailStatus.Rejected)
+                {
+                    <div class="alert alert-danger mb-3">
+                        <i class="fa-solid fa-triangle-exclamation me-1"></i>
+                        <strong>Google sync failed.</strong> The current email was rejected by Google.
+                        Select a different email below to retry sync.
+                    </div>
+                }
+                else if (Model.GoogleEmailStatus == Humans.Domain.Enums.GoogleEmailStatus.Valid)
+                {
+                    <div class="alert alert-success mb-3 py-2">
+                        <i class="fa-solid fa-circle-check me-1"></i>
+                        Google sync is working with the current email.
+                    </div>
+                }
                 @foreach (var email in Model.Emails.Where(e => e.IsVerified))
                 {
                     <div class="d-flex align-items-center mb-2">
@@ -150,6 +165,10 @@
                             @if (email.IsNobodiesTeamDomain)
                             {
                                 <span class="badge bg-info text-dark ms-2">Auto-selected</span>
+                            }
+                            @if (Model.GoogleEmailStatus == Humans.Domain.Enums.GoogleEmailStatus.Rejected && !Model.HasNobodiesTeamEmail)
+                            {
+                                <span class="badge bg-danger ms-2">Rejected</span>
                             }
                         }
                         else if (!Model.HasNobodiesTeamEmail)


### PR DESCRIPTION
## Summary
- Handle permanent Google sync failures with error classification and user notification (#318)
- Resolve people/ IDs to email addresses in Drive Activity Monitor (#14)

## Test plan
- [ ] Verify permanent sync failures (400/403/404) are not retried
- [ ] Verify user can see Google sync status on profile
- [ ] Verify updating Google email triggers re-sync
- [ ] Verify Drive Activity Monitor resolves people/ IDs
- [ ] Verify daily digest distinguishes permanent vs transient failures
- [ ] Verify migration applies cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)