### PR TITLE
Decouple consent check clearance from legal document signing (#365)

### DIFF
--- a/docs/features/16-onboarding-pipeline.md
+++ b/docs/features/16-onboarding-pipeline.md
@@ -2,7 +2,7 @@
 
 ## Business Context
 
-The onboarding pipeline defines the end-to-end journey from signup to active membership. All humans follow the same initial path: sign up, complete profile, sign consents. After that, a Consent Coordinator performs a safety check. Once cleared, the human is **automatically approved as a Volunteer** and gains full app access.
+The onboarding pipeline defines the end-to-end journey from signup to active membership. All humans follow the same initial path: sign up, complete profile, then two parallel tracks: sign legal documents and pass a Consent Coordinator profile review. Both must be complete before the human is added to the Volunteers team and gains full app access. The two tracks can happen in any order.
 
 During initial signup only, humans who want Colaborador or Asociado membership see the application form inline alongside their profile setup. This is a streamlined one-shot experience — the system creates both a Profile and an Application behind the scenes, but the user fills one unified form. The tier application proceeds through Board voting in parallel — it never blocks Volunteer access.
 
@@ -23,15 +23,11 @@ Profile Setup (one-shot onboarding experience)
     ├── [Optional] Tier selection → Colaborador/Asociado application form inline
     │
     ▼
-Sign Required Consents (Volunteers team docs)
+Two parallel tracks (either order):
+    ├── Sign Required Consents (Volunteers team docs)
+    └── Consent Coordinator profile review → Cleared or Flagged
     │
-    ▼
-[Auto] ConsentCheckStatus → Pending
-    │
-    ▼
-Consent Coordinator reviews → Cleared or Flagged
-    │
-    ▼ [Cleared]
+    ▼ [Both complete: Cleared + All docs signed]
     │
     ├── ALL humans → IsApproved = true → Volunteers team → ActiveMember ✓
     │
@@ -52,9 +48,9 @@ Consent Coordinator reviews → Cleared or Flagged
 **Acceptance Criteria:**
 - Sign up via Google OAuth
 - Fill basic profile
-- Sign required legal documents
-- System sets ConsentCheckStatus to Pending
-- Consent Coordinator clears → IsApproved = true → Volunteers team
+- Sign required legal documents (can happen before or after profile review)
+- Consent Coordinator clears profile review → IsApproved = true
+- Volunteers team membership granted when BOTH profile review cleared AND all legal docs signed
 - Dashboard shows "Active" status (no tier badge for Volunteer)
 
 ### US-16.2: New Human Onboarding (Colaborador/Asociado)
@@ -67,21 +63,21 @@ Consent Coordinator reviews → Cleared or Flagged
 - During profile setup, tier selector shows Colaborador/Asociado options
 - Selecting a tier reveals the application form inline (motivation, etc.)
 - Submitting creates both Profile and Application entities
-- After consent check clearance → Volunteer access immediately
+- After both profile review cleared AND legal docs signed → Volunteer access
 - Application enters Board voting queue in parallel
 - **This inline experience is one-shot** — after onboarding, profile edit has no application sections
 
 ### US-16.3: Consent Check Auto-Approve
 
 **As the** system
-**I want to** automatically approve humans as Volunteers after consent check clearance
+**I want to** automatically add humans to the Volunteers team when both profile review and legal documents are complete
 **So that** there is no manual Board step for basic Volunteer access
 
 **Acceptance Criteria:**
-- ConsentCheckStatus = Cleared triggers:
-  - `IsApproved = true`
-  - `SyncVolunteersMembershipForUserAsync` → Volunteers team
-  - ActiveMember claim on next request
+- Profile review clearance sets `IsApproved = true` (regardless of legal doc status)
+- `SyncVolunteersMembershipForUserAsync` checks BOTH `IsApproved` AND `HasAllRequiredConsents` independently
+- Volunteers team membership (and ActiveMember claim) granted only when both conditions are met
+- `IsApproved = true` is intentionally set before legal docs may be complete — it marks profile review approval, not full activation. The Volunteers team membership is the true activation gate.
 - Consent check is purely a Volunteer gate — independent of any tier application
 - Board approval is only for Colaborador/Asociado (via Board voting)
 
@@ -133,14 +129,19 @@ Consent Coordinator reviews → Cleared or Flagged
   - ConsentCheckStatus auto-set to Pending (if currently null)
   - Consent Coordinator notified
 
-### Stage 4: Consent Check (Volunteer Gate)
+### Stage 4: Profile Review (Volunteer Gate — parallel with Stage 3)
 
-**Trigger:** ConsentCheckStatus = Pending
+**Trigger:** Profile exists, not yet rejected (coordinators can review at any time)
 **Actor:** Consent Coordinator
 **Actions:**
-- Coordinator reviews profile and consent status
-- **Clear**: ConsentCheckStatus = Cleared → IsApproved = true → Volunteers team → ActiveMember
+- Coordinator reviews profile (can proceed regardless of legal document status)
+- Review queue shows legal document progress (X/Y signed) for context
+- **Clear**: ConsentCheckStatus = Cleared, IsApproved = true
+  - If all legal docs also signed → Volunteers team → ActiveMember
+  - If legal docs still pending → admission deferred until docs are signed
 - **Flag**: ConsentCheckStatus = Flagged with notes → access blocked, can be resolved later
+
+`IsApproved = true` is set on clearance even if legal docs are incomplete — it marks profile review approval, not full activation. The Volunteers team membership is the true activation gate, and `SyncVolunteersMembershipForUserAsync` independently checks both `IsApproved` AND `HasAllRequiredConsents`.
 
 This gate is about Volunteer access only. It does not evaluate tier applications.
 
@@ -201,7 +202,8 @@ Term expires: Dec 31, 2027
 4. **Volunteer access is never blocked by tier applications** — parallel tracks
 5. **Grandfather existing users** — consent check only for new signups after deployment
 6. **Auto-Pending** — system sets ConsentCheckStatus to Pending when all consents are signed
-7. **Immediate sync** — consent check clearance triggers immediate Volunteers team sync
+7. **Immediate sync** — both profile review clearance and legal document signing trigger `SyncVolunteersMembershipForUserAsync`, which independently checks both conditions
+8. **IsApproved ≠ activated** — `IsApproved = true` marks profile review approval; Volunteers team membership is the true activation gate
 8. **No Volunteer badge** — only Colaborador/Asociado badges on dashboard
 
 ## Related Features

--- a/docs/sections/Onboarding.md
+++ b/docs/sections/Onboarding.md
@@ -2,9 +2,9 @@
 
 ## Concepts
 
-- **Onboarding** is the process a new human goes through to become an active Volunteer: sign up via Google OAuth, complete their profile, consent to all required legal documents, and pass a safety review by a Consent Coordinator.
+- **Onboarding** is the process a new human goes through to become an active Volunteer: sign up via Google OAuth, complete their profile, consent to all required legal documents, and pass a profile review by a Consent Coordinator. The last two steps can happen in any order.
 - The **Membership Gate** restricts most of the application to active Volunteers. Humans still onboarding are limited to their profile, consent, feedback, legal documents, camps (public), and the home dashboard. All admin and coordinator roles bypass this gate entirely.
-- The **Consent Check** is the final gate before activation. A Consent Coordinator reviews and either clears (auto-approves the human as a Volunteer) or flags the check (blocks activation until Board or Admin review).
+- The **Profile Review** (consent check) and **Legal Document Signing** are independent, parallel tracks. A Consent Coordinator can clear the profile review before or after legal documents are signed. Admission to the Volunteers team only happens when both are complete.
 
 ## Actors & Roles
 
@@ -18,7 +18,7 @@
 
 ## Invariants
 
-- Onboarding steps: (1) complete profile, (2) consent to all required global legal documents, (3) consent check review by a Consent Coordinator, (4) auto-approval as Volunteer.
+- Onboarding steps: (1) complete profile, (2a) consent to all required global legal documents, (2b) profile review by a Consent Coordinator — these two can happen in any order, (3) auto-approval as Volunteer when both 2a and 2b are complete.
 - Volunteer onboarding is never blocked by tier applications — they are separate, parallel paths.
 - The ActiveMember status is derived from membership in the Volunteers system team.
 - All admin and coordinator roles bypass the membership gate entirely — they can access the full application regardless of membership status.
@@ -33,7 +33,8 @@
 ## Triggers
 
 - When a human completes their profile and signs all required documents: their consent check status becomes Pending.
-- When a consent check is cleared: the human becomes an active Volunteer, is added to the Volunteers system team, and gains access to the full application. A welcome email is sent.
+- When a profile review is cleared: the profile is approved. If all legal documents are also signed, the human is added to the Volunteers system team and a welcome email is sent. If documents are still pending, admission happens automatically when the last document is signed.
+- When a legal document is signed: the system checks if the profile is also approved. If both conditions are met, the human is added to the Volunteers team.
 - When a consent check is flagged: onboarding is blocked. Board or Admin must review.
 - When a signup is rejected: the rejection reason and timestamp are recorded on the profile. The human is notified.
 

--- a/src/Humans.Application/Interfaces/IOnboardingService.cs
+++ b/src/Humans.Application/Interfaces/IOnboardingService.cs
@@ -9,7 +9,8 @@ public record OnboardingResult(bool Success, string? ErrorKey = null);
 public interface IOnboardingService
 {
     // --- Queries ---
-    Task<(List<Profile> Pending, List<Profile> Flagged, HashSet<Guid> PendingAppUserIds)>
+    Task<(List<Profile> Pending, List<Profile> Flagged, HashSet<Guid> PendingAppUserIds,
+          Dictionary<Guid, (int Signed, int Required)> ConsentProgress)>
         GetReviewQueueAsync(CancellationToken ct = default);
     Task<(Profile? Profile, int ConsentCount, int RequiredConsentCount,
           MemberApplication? PendingApplication)>

--- a/src/Humans.Infrastructure/Services/OnboardingService.cs
+++ b/src/Humans.Infrastructure/Services/OnboardingService.cs
@@ -48,7 +48,8 @@ public class OnboardingService : IOnboardingService
         _logger = logger;
     }
 
-    public async Task<(List<Profile> Pending, List<Profile> Flagged, HashSet<Guid> PendingAppUserIds)>
+    public async Task<(List<Profile> Pending, List<Profile> Flagged, HashSet<Guid> PendingAppUserIds,
+        Dictionary<Guid, (int Signed, int Required)> ConsentProgress)>
         GetReviewQueueAsync(CancellationToken ct = default)
     {
         var reviewableProfiles = await _dbContext.Profiles
@@ -64,12 +65,19 @@ public class OnboardingService : IOnboardingService
             .Select(a => a.UserId)
             .ToHashSetAsync(ct);
 
+        var consentProgress = new Dictionary<Guid, (int Signed, int Required)>();
+        foreach (var userId in allUserIds)
+        {
+            var snapshot = await _membershipCalculator.GetMembershipSnapshotAsync(userId, ct);
+            consentProgress[userId] = (snapshot.RequiredConsentCount - snapshot.PendingConsentCount, snapshot.RequiredConsentCount);
+        }
+
         var flagged = reviewableProfiles
             .Where(p => p.ConsentCheckStatus == ConsentCheckStatus.Flagged)
             .ToList();
         var pending = reviewableProfiles.Except(flagged).ToList();
 
-        return (pending, flagged, pendingAppUserIds);
+        return (pending, flagged, pendingAppUserIds, consentProgress);
     }
 
     public async Task<(Profile? Profile, int ConsentCount, int RequiredConsentCount,
@@ -155,10 +163,6 @@ public class OnboardingService : IOnboardingService
 
         if (profile.RejectedAt is not null)
             return new OnboardingResult(false, "AlreadyRejected");
-
-        var hasAllRequiredConsents = await _membershipCalculator.HasAllRequiredConsentsAsync(userId, ct);
-        if (!hasAllRequiredConsents)
-            return new OnboardingResult(false, "ConsentsRequired");
 
         var now = _clock.GetCurrentInstant();
 

--- a/src/Humans.Infrastructure/Services/OnboardingService.cs
+++ b/src/Humans.Infrastructure/Services/OnboardingService.cs
@@ -185,7 +185,7 @@ public class OnboardingService : IOnboardingService
         await _dbContext.Entry(profile).Collection(p => p.VolunteerHistory).LoadAsync(ct);
         _cache.UpdateApprovedProfile(userId, CachedProfile.Create(profile, profile.User));
 
-        // Sync Volunteers team membership (adds to team + sends welcome email)
+        // Sync Volunteers team membership (adds to team if consents are also complete)
         await _syncJob.SyncVolunteersMembershipForUserAsync(userId, CancellationToken.None);
 
         // If user already has approved tier applications, sync those teams too.

--- a/src/Humans.Web/Controllers/OnboardingReviewController.cs
+++ b/src/Humans.Web/Controllers/OnboardingReviewController.cs
@@ -43,12 +43,12 @@ public class OnboardingReviewController : HumansControllerBase
     [HttpGet("")]
     public async Task<IActionResult> Index()
     {
-        var (pending, flagged, pendingAppUserIds) = await _onboardingService.GetReviewQueueAsync();
+        var (pending, flagged, pendingAppUserIds, consentProgress) = await _onboardingService.GetReviewQueueAsync();
 
         var viewModel = new OnboardingReviewIndexViewModel
         {
-            PendingReviews = pending.Select(p => MapToItem(p, pendingAppUserIds)).ToList(),
-            FlaggedReviews = flagged.Select(p => MapToItem(p, pendingAppUserIds)).ToList()
+            PendingReviews = pending.Select(p => MapToItem(p, pendingAppUserIds, consentProgress)).ToList(),
+            FlaggedReviews = flagged.Select(p => MapToItem(p, pendingAppUserIds, consentProgress)).ToList()
         };
 
         return View(viewModel);
@@ -105,7 +105,6 @@ public class OnboardingReviewController : HumansControllerBase
                 SetError(result.ErrorKey switch
                 {
                     "AlreadyRejected" => _localizer["OnboardingReview_AlreadyRejected"].Value,
-                    "ConsentsRequired" => _localizer["OnboardingReview_ConsentsRequired"].Value,
                     _ => _localizer["OnboardingReview_Error"].Value
                 });
                 return RedirectToAction(nameof(Index));
@@ -386,8 +385,11 @@ public class OnboardingReviewController : HumansControllerBase
         return RedirectToAction(nameof(BoardVoting));
     }
 
-    private static OnboardingReviewItemViewModel MapToItem(Profile profile, HashSet<Guid> pendingAppUserIds)
+    private static OnboardingReviewItemViewModel MapToItem(
+        Profile profile, HashSet<Guid> pendingAppUserIds,
+        Dictionary<Guid, (int Signed, int Required)> consentProgress)
     {
+        var (signed, required) = consentProgress.GetValueOrDefault(profile.UserId);
         return new OnboardingReviewItemViewModel
         {
             UserId = profile.UserId,
@@ -397,7 +399,9 @@ public class OnboardingReviewController : HumansControllerBase
             ConsentCheckStatus = profile.ConsentCheckStatus,
             MembershipTier = profile.MembershipTier,
             ProfileCreatedAt = profile.CreatedAt.ToDateTimeUtc(),
-            HasPendingApplication = pendingAppUserIds.Contains(profile.UserId)
+            HasPendingApplication = pendingAppUserIds.Contains(profile.UserId),
+            ConsentCount = signed,
+            RequiredConsentCount = required
         };
     }
 }

--- a/src/Humans.Web/Models/OnboardingReviewViewModels.cs
+++ b/src/Humans.Web/Models/OnboardingReviewViewModels.cs
@@ -18,6 +18,8 @@ public class OnboardingReviewItemViewModel
     public MembershipTier MembershipTier { get; set; }
     public DateTime ProfileCreatedAt { get; set; }
     public bool HasPendingApplication { get; set; }
+    public int ConsentCount { get; set; }
+    public int RequiredConsentCount { get; set; }
 }
 
 public class OnboardingReviewDetailViewModel

--- a/src/Humans.Web/Resources/SharedResource.de.resx
+++ b/src/Humans.Web/Resources/SharedResource.de.resx
@@ -905,8 +905,6 @@
   <data name="OnboardingReview_NoPending" xml:space="preserve"><value>Keine Humans warten auf eine Pr&#xFC;fung.</value></data>
   <data name="OnboardingReview_PendingSection" xml:space="preserve"><value>Ausstehende Pr&#xFC;fung</value></data>
   <data name="OnboardingReview_FlaggedSection" xml:space="preserve"><value>Zur Nachverfolgung markiert</value></data>
-  <data name="OnboardingReview_Pending" xml:space="preserve"><value>Einwilligungen bereit</value></data>
-  <data name="OnboardingReview_ConsentsNotStarted" xml:space="preserve"><value>Einwilligungen nicht begonnen</value></data>
   <data name="OnboardingReview_FlaggedBadge" xml:space="preserve"><value>Markiert</value></data>
   <data name="OnboardingReview_ProfileSummary" xml:space="preserve"><value>Profil&#xFC;bersicht</value></data>
   <data name="OnboardingReview_NewHumanSummary" xml:space="preserve"><value>Neuer Human &#x2013; Zusammenfassung</value></data>
@@ -933,7 +931,6 @@
   <data name="OnboardingReview_RejectHelp" xml:space="preserve"><value>Die Ablehnung verweigert die Anmeldung dieses Humans dauerhaft und sendet eine Benachrichtigungs-E-Mail.</value></data>
   <data name="OnboardingReview_Rejected" xml:space="preserve"><value>Die Anmeldung wurde abgelehnt.</value></data>
   <data name="OnboardingReview_AlreadyRejected" xml:space="preserve"><value>Dieser Human wurde bereits abgelehnt.</value></data>
-  <data name="OnboardingReview_ConsentsRequired" xml:space="preserve"><value>Die Einarbeitung kann erst freigegeben werden, wenn alle erforderlichen Vereinbarungen unterzeichnet sind.</value></data>
   <data name="OnboardingReview_LegalDocuments" xml:space="preserve"><value>Rechtliche Dokumente</value></data>
   <data name="OnboardingReview_DocsComplete" xml:space="preserve"><value>Vollst&#xE4;ndig</value></data>
   <data name="OnboardingReview_DocsPending" xml:space="preserve"><value>Ausstehend</value></data>

--- a/src/Humans.Web/Resources/SharedResource.de.resx
+++ b/src/Humans.Web/Resources/SharedResource.de.resx
@@ -919,13 +919,13 @@
   <data name="OnboardingReview_Actions" xml:space="preserve"><value>Aktionen</value></data>
   <data name="OnboardingReview_NotesPlaceholder" xml:space="preserve"><value>Optionale Notizen...</value></data>
   <data name="OnboardingReview_ClearButton" xml:space="preserve"><value>Freigeben &amp; Genehmigen</value></data>
-  <data name="OnboardingReview_ClearHelp" xml:space="preserve"><value>Die Freigabe genehmigt diesen Human automatisch als Freiwilligen.</value></data>
-  <data name="OnboardingReview_ClearConfirm" xml:space="preserve"><value>Dieser Human wird als Freiwilliger genehmigt. Fortfahren?</value></data>
+  <data name="OnboardingReview_ClearHelp" xml:space="preserve"><value>Genehmigt die Profil&#xFC;berpr&#xFC;fung. Der Human tritt Freiwilligen bei, wenn auch die rechtlichen Dokumente unterzeichnet sind.</value></data>
+  <data name="OnboardingReview_ClearConfirm" xml:space="preserve"><value>Die Profil&#xFC;berpr&#xFC;fung dieses Humans wird freigegeben. Fortfahren?</value></data>
   <data name="OnboardingReview_FlagButton" xml:space="preserve"><value>Zur Pr&#xFC;fung markieren</value></data>
   <data name="OnboardingReview_FlagReasonPlaceholder" xml:space="preserve"><value>Grund der Markierung...</value></data>
   <data name="OnboardingReview_FlagConfirm" xml:space="preserve"><value>Dieser Human wird zur weiteren Pr&#xFC;fung markiert. Fortfahren?</value></data>
   <data name="OnboardingReview_AlreadyCleared" xml:space="preserve"><value>Dieser Human wurde bereits freigegeben.</value></data>
-  <data name="OnboardingReview_Cleared" xml:space="preserve"><value>Einwilligungspr&#xFC;fung freigegeben. Human als Freiwilliger genehmigt.</value></data>
+  <data name="OnboardingReview_Cleared" xml:space="preserve"><value>Profil&#xFC;berpr&#xFC;fung freigegeben.</value></data>
   <data name="OnboardingReview_Flagged" xml:space="preserve"><value>Human zur weiteren Pr&#xFC;fung markiert.</value></data>
   <data name="OnboardingReview_RejectButton" xml:space="preserve"><value>Anmeldung ablehnen</value></data>
   <data name="OnboardingReview_RejectReasonPlaceholder" xml:space="preserve"><value>Ablehnungsgrund...</value></data>
@@ -934,6 +934,10 @@
   <data name="OnboardingReview_Rejected" xml:space="preserve"><value>Die Anmeldung wurde abgelehnt.</value></data>
   <data name="OnboardingReview_AlreadyRejected" xml:space="preserve"><value>Dieser Human wurde bereits abgelehnt.</value></data>
   <data name="OnboardingReview_ConsentsRequired" xml:space="preserve"><value>Die Einarbeitung kann erst freigegeben werden, wenn alle erforderlichen Vereinbarungen unterzeichnet sind.</value></data>
+  <data name="OnboardingReview_LegalDocuments" xml:space="preserve"><value>Rechtliche Dokumente</value></data>
+  <data name="OnboardingReview_DocsComplete" xml:space="preserve"><value>Vollst&#xE4;ndig</value></data>
+  <data name="OnboardingReview_DocsPending" xml:space="preserve"><value>Ausstehend</value></data>
+  <data name="OnboardingReview_DocsNote" xml:space="preserve"><value>Die Profil&#xFC;berpr&#xFC;fung kann unabh&#xE4;ngig erfolgen. Der Human tritt Freiwilligen bei, wenn alle Dokumente unterzeichnet sind.</value></data>
 
   <!-- Board Voting -->
   <data name="Nav_BoardVoting" xml:space="preserve"><value>Vorstandsabstimmung</value></data>

--- a/src/Humans.Web/Resources/SharedResource.es.resx
+++ b/src/Humans.Web/Resources/SharedResource.es.resx
@@ -924,13 +924,13 @@
   <data name="OnboardingReview_Actions" xml:space="preserve"><value>Acciones</value></data>
   <data name="OnboardingReview_NotesPlaceholder" xml:space="preserve"><value>Notas opcionales...</value></data>
   <data name="OnboardingReview_ClearButton" xml:space="preserve"><value>Aprobar y activar</value></data>
-  <data name="OnboardingReview_ClearHelp" xml:space="preserve"><value>Aprobar activar&#xE1; autom&#xE1;ticamente a este humano como Voluntario.</value></data>
-  <data name="OnboardingReview_ClearConfirm" xml:space="preserve"><value>Esto aprobar&#xE1; a este humano como Voluntario. &#xBF;Continuar?</value></data>
+  <data name="OnboardingReview_ClearHelp" xml:space="preserve"><value>Aprueba la revisi&#xF3;n del perfil. El humano se unir&#xE1; a Voluntarios cuando los documentos legales tambi&#xE9;n est&#xE9;n firmados.</value></data>
+  <data name="OnboardingReview_ClearConfirm" xml:space="preserve"><value>Esto aprobar&#xE1; la revisi&#xF3;n del perfil de este humano. &#xBF;Continuar?</value></data>
   <data name="OnboardingReview_FlagButton" xml:space="preserve"><value>Marcar para revisi&#xF3;n</value></data>
   <data name="OnboardingReview_FlagReasonPlaceholder" xml:space="preserve"><value>Motivo del marcado...</value></data>
   <data name="OnboardingReview_FlagConfirm" xml:space="preserve"><value>Esto marcar&#xE1; a este humano para revisi&#xF3;n adicional. &#xBF;Continuar?</value></data>
   <data name="OnboardingReview_AlreadyCleared" xml:space="preserve"><value>Este humano ya ha sido aprobado.</value></data>
-  <data name="OnboardingReview_Cleared" xml:space="preserve"><value>Verificaci&#xF3;n aprobada. Humano activado como Voluntario.</value></data>
+  <data name="OnboardingReview_Cleared" xml:space="preserve"><value>Revisi&#xF3;n de perfil aprobada.</value></data>
   <data name="OnboardingReview_Flagged" xml:space="preserve"><value>Humano marcado para revisi&#xF3;n adicional.</value></data>
   <data name="OnboardingReview_RejectButton" xml:space="preserve"><value>Rechazar registro</value></data>
   <data name="OnboardingReview_RejectReasonPlaceholder" xml:space="preserve"><value>Motivo del rechazo...</value></data>
@@ -939,6 +939,10 @@
   <data name="OnboardingReview_Rejected" xml:space="preserve"><value>El registro ha sido rechazado.</value></data>
   <data name="OnboardingReview_AlreadyRejected" xml:space="preserve"><value>Este human ya ha sido rechazado.</value></data>
   <data name="OnboardingReview_ConsentsRequired" xml:space="preserve"><value>No se puede aprobar la incorporaci&#xF3;n hasta que se firmen todos los acuerdos requeridos.</value></data>
+  <data name="OnboardingReview_LegalDocuments" xml:space="preserve"><value>Documentos legales</value></data>
+  <data name="OnboardingReview_DocsComplete" xml:space="preserve"><value>Completo</value></data>
+  <data name="OnboardingReview_DocsPending" xml:space="preserve"><value>Pendiente</value></data>
+  <data name="OnboardingReview_DocsNote" xml:space="preserve"><value>La revisi&#xF3;n del perfil puede realizarse de forma independiente. El humano se unir&#xE1; a Voluntarios cuando todos los documentos est&#xE9;n firmados.</value></data>
 
   <!-- Board Voting -->
   <data name="Nav_BoardVoting" xml:space="preserve"><value>Votaci&#xF3;n de la Junta</value></data>

--- a/src/Humans.Web/Resources/SharedResource.es.resx
+++ b/src/Humans.Web/Resources/SharedResource.es.resx
@@ -910,8 +910,6 @@
   <data name="OnboardingReview_NoPending" xml:space="preserve"><value>Ning&#xFA;n humano est&#xE1; esperando revisi&#xF3;n.</value></data>
   <data name="OnboardingReview_PendingSection" xml:space="preserve"><value>Pendientes de revisi&#xF3;n</value></data>
   <data name="OnboardingReview_FlaggedSection" xml:space="preserve"><value>Marcados para seguimiento</value></data>
-  <data name="OnboardingReview_Pending" xml:space="preserve"><value>Consentimientos listos</value></data>
-  <data name="OnboardingReview_ConsentsNotStarted" xml:space="preserve"><value>Consentimientos no iniciados</value></data>
   <data name="OnboardingReview_FlaggedBadge" xml:space="preserve"><value>Marcado</value></data>
   <data name="OnboardingReview_ProfileSummary" xml:space="preserve"><value>Resumen del perfil</value></data>
   <data name="OnboardingReview_NewHumanSummary" xml:space="preserve"><value>Resumen del nuevo human</value></data>
@@ -938,7 +936,6 @@
   <data name="OnboardingReview_RejectHelp" xml:space="preserve"><value>Rechazar denegar&#xE1; permanentemente el registro de este human y enviar&#xE1; un email de notificaci&#xF3;n.</value></data>
   <data name="OnboardingReview_Rejected" xml:space="preserve"><value>El registro ha sido rechazado.</value></data>
   <data name="OnboardingReview_AlreadyRejected" xml:space="preserve"><value>Este human ya ha sido rechazado.</value></data>
-  <data name="OnboardingReview_ConsentsRequired" xml:space="preserve"><value>No se puede aprobar la incorporaci&#xF3;n hasta que se firmen todos los acuerdos requeridos.</value></data>
   <data name="OnboardingReview_LegalDocuments" xml:space="preserve"><value>Documentos legales</value></data>
   <data name="OnboardingReview_DocsComplete" xml:space="preserve"><value>Completo</value></data>
   <data name="OnboardingReview_DocsPending" xml:space="preserve"><value>Pendiente</value></data>

--- a/src/Humans.Web/Resources/SharedResource.fr.resx
+++ b/src/Humans.Web/Resources/SharedResource.fr.resx
@@ -919,13 +919,13 @@
   <data name="OnboardingReview_Actions" xml:space="preserve"><value>Actions</value></data>
   <data name="OnboardingReview_NotesPlaceholder" xml:space="preserve"><value>Notes facultatives...</value></data>
   <data name="OnboardingReview_ClearButton" xml:space="preserve"><value>Valider &amp; Approuver</value></data>
-  <data name="OnboardingReview_ClearHelp" xml:space="preserve"><value>La validation approuvera automatiquement ce human en tant que b&#xE9;n&#xE9;vole.</value></data>
-  <data name="OnboardingReview_ClearConfirm" xml:space="preserve"><value>Ce human sera approuv&#xE9; en tant que b&#xE9;n&#xE9;vole. Continuer ?</value></data>
+  <data name="OnboardingReview_ClearHelp" xml:space="preserve"><value>Approuve la r&#xE9;vision du profil. Le human rejoindra les B&#xE9;n&#xE9;voles lorsque les documents l&#xE9;gaux seront &#xE9;galement sign&#xE9;s.</value></data>
+  <data name="OnboardingReview_ClearConfirm" xml:space="preserve"><value>La r&#xE9;vision du profil de ce human sera valid&#xE9;e. Continuer ?</value></data>
   <data name="OnboardingReview_FlagButton" xml:space="preserve"><value>Signaler pour examen</value></data>
   <data name="OnboardingReview_FlagReasonPlaceholder" xml:space="preserve"><value>Motif du signalement...</value></data>
   <data name="OnboardingReview_FlagConfirm" xml:space="preserve"><value>Ce human sera signal&#xE9; pour examen compl&#xE9;mentaire. Continuer ?</value></data>
   <data name="OnboardingReview_AlreadyCleared" xml:space="preserve"><value>Ce human a d&#xE9;j&#xE0; &#xE9;t&#xE9; valid&#xE9;.</value></data>
-  <data name="OnboardingReview_Cleared" xml:space="preserve"><value>V&#xE9;rification du consentement valid&#xE9;e. Human approuv&#xE9; en tant que b&#xE9;n&#xE9;vole.</value></data>
+  <data name="OnboardingReview_Cleared" xml:space="preserve"><value>R&#xE9;vision du profil valid&#xE9;e.</value></data>
   <data name="OnboardingReview_Flagged" xml:space="preserve"><value>Human signal&#xE9; pour examen compl&#xE9;mentaire.</value></data>
   <data name="OnboardingReview_RejectButton" xml:space="preserve"><value>Refuser l'inscription</value></data>
   <data name="OnboardingReview_RejectReasonPlaceholder" xml:space="preserve"><value>Motif du refus...</value></data>
@@ -934,6 +934,10 @@
   <data name="OnboardingReview_Rejected" xml:space="preserve"><value>L'inscription a &#xE9;t&#xE9; refus&#xE9;e.</value></data>
   <data name="OnboardingReview_AlreadyRejected" xml:space="preserve"><value>Ce human a d&#xE9;j&#xE0; &#xE9;t&#xE9; refus&#xE9;.</value></data>
   <data name="OnboardingReview_ConsentsRequired" xml:space="preserve"><value>L'int&#xE9;gration ne peut pas &#xEA;tre valid&#xE9;e tant que tous les accords requis ne sont pas sign&#xE9;s.</value></data>
+  <data name="OnboardingReview_LegalDocuments" xml:space="preserve"><value>Documents l&#xE9;gaux</value></data>
+  <data name="OnboardingReview_DocsComplete" xml:space="preserve"><value>Complet</value></data>
+  <data name="OnboardingReview_DocsPending" xml:space="preserve"><value>En attente</value></data>
+  <data name="OnboardingReview_DocsNote" xml:space="preserve"><value>La r&#xE9;vision du profil peut se faire ind&#xE9;pendamment. Le human rejoindra les B&#xE9;n&#xE9;voles lorsque tous les documents seront sign&#xE9;s.</value></data>
 
   <!-- Board Voting -->
   <data name="Nav_BoardVoting" xml:space="preserve"><value>Vote du Conseil</value></data>

--- a/src/Humans.Web/Resources/SharedResource.fr.resx
+++ b/src/Humans.Web/Resources/SharedResource.fr.resx
@@ -905,8 +905,6 @@
   <data name="OnboardingReview_NoPending" xml:space="preserve"><value>Aucun human n'attend de r&#xE9;vision.</value></data>
   <data name="OnboardingReview_PendingSection" xml:space="preserve"><value>En attente d'examen</value></data>
   <data name="OnboardingReview_FlaggedSection" xml:space="preserve"><value>Signal&#xE9; pour suivi</value></data>
-  <data name="OnboardingReview_Pending" xml:space="preserve"><value>Consentements pr&#xEA;ts</value></data>
-  <data name="OnboardingReview_ConsentsNotStarted" xml:space="preserve"><value>Consentements non commenc&#xE9;s</value></data>
   <data name="OnboardingReview_FlaggedBadge" xml:space="preserve"><value>Signal&#xE9;</value></data>
   <data name="OnboardingReview_ProfileSummary" xml:space="preserve"><value>R&#xE9;sum&#xE9; du profil</value></data>
   <data name="OnboardingReview_NewHumanSummary" xml:space="preserve"><value>R&#xE9;sum&#xE9; du nouveau human</value></data>
@@ -933,7 +931,6 @@
   <data name="OnboardingReview_RejectHelp" xml:space="preserve"><value>Le refus refusera d&#xE9;finitivement l'inscription de ce human et enverra un email de notification.</value></data>
   <data name="OnboardingReview_Rejected" xml:space="preserve"><value>L'inscription a &#xE9;t&#xE9; refus&#xE9;e.</value></data>
   <data name="OnboardingReview_AlreadyRejected" xml:space="preserve"><value>Ce human a d&#xE9;j&#xE0; &#xE9;t&#xE9; refus&#xE9;.</value></data>
-  <data name="OnboardingReview_ConsentsRequired" xml:space="preserve"><value>L'int&#xE9;gration ne peut pas &#xEA;tre valid&#xE9;e tant que tous les accords requis ne sont pas sign&#xE9;s.</value></data>
   <data name="OnboardingReview_LegalDocuments" xml:space="preserve"><value>Documents l&#xE9;gaux</value></data>
   <data name="OnboardingReview_DocsComplete" xml:space="preserve"><value>Complet</value></data>
   <data name="OnboardingReview_DocsPending" xml:space="preserve"><value>En attente</value></data>

--- a/src/Humans.Web/Resources/SharedResource.it.resx
+++ b/src/Humans.Web/Resources/SharedResource.it.resx
@@ -905,8 +905,6 @@
   <data name="OnboardingReview_NoPending" xml:space="preserve"><value>Nessun human in attesa di revisione.</value></data>
   <data name="OnboardingReview_PendingSection" xml:space="preserve"><value>In attesa di revisione</value></data>
   <data name="OnboardingReview_FlaggedSection" xml:space="preserve"><value>Segnalato per approfondimento</value></data>
-  <data name="OnboardingReview_Pending" xml:space="preserve"><value>Consensi pronti</value></data>
-  <data name="OnboardingReview_ConsentsNotStarted" xml:space="preserve"><value>Consensi non iniziati</value></data>
   <data name="OnboardingReview_FlaggedBadge" xml:space="preserve"><value>Segnalato</value></data>
   <data name="OnboardingReview_ProfileSummary" xml:space="preserve"><value>Riepilogo del profilo</value></data>
   <data name="OnboardingReview_NewHumanSummary" xml:space="preserve"><value>Riepilogo del nuovo human</value></data>
@@ -933,7 +931,6 @@
   <data name="OnboardingReview_RejectHelp" xml:space="preserve"><value>Il rifiuto negher&#xE0; permanentemente la registrazione di questo human e invierà un'email di notifica.</value></data>
   <data name="OnboardingReview_Rejected" xml:space="preserve"><value>La registrazione &#xE8; stata rifiutata.</value></data>
   <data name="OnboardingReview_AlreadyRejected" xml:space="preserve"><value>Questo human &#xE8; gi&#xE0; stato rifiutato.</value></data>
-  <data name="OnboardingReview_ConsentsRequired" xml:space="preserve"><value>L'onboarding non pu&#xF2; essere approvato finch&#xE9; non vengono firmati tutti gli accordi richiesti.</value></data>
   <data name="OnboardingReview_LegalDocuments" xml:space="preserve"><value>Documenti legali</value></data>
   <data name="OnboardingReview_DocsComplete" xml:space="preserve"><value>Completo</value></data>
   <data name="OnboardingReview_DocsPending" xml:space="preserve"><value>In attesa</value></data>

--- a/src/Humans.Web/Resources/SharedResource.it.resx
+++ b/src/Humans.Web/Resources/SharedResource.it.resx
@@ -919,13 +919,13 @@
   <data name="OnboardingReview_Actions" xml:space="preserve"><value>Azioni</value></data>
   <data name="OnboardingReview_NotesPlaceholder" xml:space="preserve"><value>Note facoltative...</value></data>
   <data name="OnboardingReview_ClearButton" xml:space="preserve"><value>Approva &amp; Conferma</value></data>
-  <data name="OnboardingReview_ClearHelp" xml:space="preserve"><value>L'approvazione confermer&#xE0; automaticamente questo human come volontario.</value></data>
-  <data name="OnboardingReview_ClearConfirm" xml:space="preserve"><value>Questo human verr&#xE0; approvato come volontario. Continuare?</value></data>
+  <data name="OnboardingReview_ClearHelp" xml:space="preserve"><value>Approva la revisione del profilo. Lo human entrer&#xE0; nei Volontari quando anche i documenti legali saranno firmati.</value></data>
+  <data name="OnboardingReview_ClearConfirm" xml:space="preserve"><value>La revisione del profilo di questo human verr&#xE0; approvata. Continuare?</value></data>
   <data name="OnboardingReview_FlagButton" xml:space="preserve"><value>Segnala per revisione</value></data>
   <data name="OnboardingReview_FlagReasonPlaceholder" xml:space="preserve"><value>Motivo della segnalazione...</value></data>
   <data name="OnboardingReview_FlagConfirm" xml:space="preserve"><value>Questo human verr&#xE0; segnalato per ulteriore revisione. Continuare?</value></data>
   <data name="OnboardingReview_AlreadyCleared" xml:space="preserve"><value>Questo human &#xE8; gi&#xE0; stato approvato.</value></data>
-  <data name="OnboardingReview_Cleared" xml:space="preserve"><value>Verifica del consenso completata. Human approvato come volontario.</value></data>
+  <data name="OnboardingReview_Cleared" xml:space="preserve"><value>Revisione del profilo approvata.</value></data>
   <data name="OnboardingReview_Flagged" xml:space="preserve"><value>Human segnalato per ulteriore revisione.</value></data>
   <data name="OnboardingReview_RejectButton" xml:space="preserve"><value>Rifiuta registrazione</value></data>
   <data name="OnboardingReview_RejectReasonPlaceholder" xml:space="preserve"><value>Motivo del rifiuto...</value></data>
@@ -934,6 +934,10 @@
   <data name="OnboardingReview_Rejected" xml:space="preserve"><value>La registrazione &#xE8; stata rifiutata.</value></data>
   <data name="OnboardingReview_AlreadyRejected" xml:space="preserve"><value>Questo human &#xE8; gi&#xE0; stato rifiutato.</value></data>
   <data name="OnboardingReview_ConsentsRequired" xml:space="preserve"><value>L'onboarding non pu&#xF2; essere approvato finch&#xE9; non vengono firmati tutti gli accordi richiesti.</value></data>
+  <data name="OnboardingReview_LegalDocuments" xml:space="preserve"><value>Documenti legali</value></data>
+  <data name="OnboardingReview_DocsComplete" xml:space="preserve"><value>Completo</value></data>
+  <data name="OnboardingReview_DocsPending" xml:space="preserve"><value>In attesa</value></data>
+  <data name="OnboardingReview_DocsNote" xml:space="preserve"><value>La revisione del profilo pu&#xF2; procedere in modo indipendente. Lo human entrer&#xE0; nei Volontari quando tutti i documenti saranno firmati.</value></data>
 
   <!-- Board Voting -->
   <data name="Nav_BoardVoting" xml:space="preserve"><value>Voto del Consiglio</value></data>

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -929,8 +929,6 @@
   <data name="OnboardingReview_NoPending" xml:space="preserve"><value>No humans are waiting for review.</value></data>
   <data name="OnboardingReview_PendingSection" xml:space="preserve"><value>Pending Review</value></data>
   <data name="OnboardingReview_FlaggedSection" xml:space="preserve"><value>Flagged for Follow-up</value></data>
-  <data name="OnboardingReview_Pending" xml:space="preserve"><value>Consents Ready</value></data>
-  <data name="OnboardingReview_ConsentsNotStarted" xml:space="preserve"><value>Consents Not Started</value></data>
   <data name="OnboardingReview_FlaggedBadge" xml:space="preserve"><value>Flagged</value></data>
   <data name="OnboardingReview_ProfileSummary" xml:space="preserve"><value>Profile Summary</value></data>
   <data name="OnboardingReview_NewHumanSummary" xml:space="preserve"><value>New Human Summary</value></data>
@@ -957,7 +955,6 @@
   <data name="OnboardingReview_RejectHelp" xml:space="preserve"><value>Rejecting will permanently deny this human's signup and send a notification email.</value></data>
   <data name="OnboardingReview_Rejected" xml:space="preserve"><value>Signup has been rejected.</value></data>
   <data name="OnboardingReview_AlreadyRejected" xml:space="preserve"><value>This human has already been rejected.</value></data>
-  <data name="OnboardingReview_ConsentsRequired" xml:space="preserve"><value>Cannot clear onboarding until all required agreements are signed.</value></data>
   <data name="OnboardingReview_LegalDocuments" xml:space="preserve"><value>Legal Documents</value></data>
   <data name="OnboardingReview_DocsComplete" xml:space="preserve"><value>Complete</value></data>
   <data name="OnboardingReview_DocsPending" xml:space="preserve"><value>Pending</value></data>

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -943,13 +943,13 @@
   <data name="OnboardingReview_Actions" xml:space="preserve"><value>Actions</value></data>
   <data name="OnboardingReview_NotesPlaceholder" xml:space="preserve"><value>Optional notes...</value></data>
   <data name="OnboardingReview_ClearButton" xml:space="preserve"><value>Clear &amp; Approve</value></data>
-  <data name="OnboardingReview_ClearHelp" xml:space="preserve"><value>Clearing will auto-approve this human as a Volunteer.</value></data>
-  <data name="OnboardingReview_ClearConfirm" xml:space="preserve"><value>This will approve this human as a Volunteer. Continue?</value></data>
+  <data name="OnboardingReview_ClearHelp" xml:space="preserve"><value>Approves the profile review. Human joins Volunteers once legal documents are also signed.</value></data>
+  <data name="OnboardingReview_ClearConfirm" xml:space="preserve"><value>This will clear the profile review for this human. Continue?</value></data>
   <data name="OnboardingReview_FlagButton" xml:space="preserve"><value>Flag for Review</value></data>
   <data name="OnboardingReview_FlagReasonPlaceholder" xml:space="preserve"><value>Reason for flagging...</value></data>
   <data name="OnboardingReview_FlagConfirm" xml:space="preserve"><value>This will flag this human for further review. Continue?</value></data>
   <data name="OnboardingReview_AlreadyCleared" xml:space="preserve"><value>This human has already been cleared.</value></data>
-  <data name="OnboardingReview_Cleared" xml:space="preserve"><value>Consent check cleared. Human approved as Volunteer.</value></data>
+  <data name="OnboardingReview_Cleared" xml:space="preserve"><value>Profile review cleared.</value></data>
   <data name="OnboardingReview_Flagged" xml:space="preserve"><value>Human flagged for further review.</value></data>
   <data name="OnboardingReview_RejectButton" xml:space="preserve"><value>Reject Signup</value></data>
   <data name="OnboardingReview_RejectReasonPlaceholder" xml:space="preserve"><value>Reason for rejection...</value></data>
@@ -958,6 +958,10 @@
   <data name="OnboardingReview_Rejected" xml:space="preserve"><value>Signup has been rejected.</value></data>
   <data name="OnboardingReview_AlreadyRejected" xml:space="preserve"><value>This human has already been rejected.</value></data>
   <data name="OnboardingReview_ConsentsRequired" xml:space="preserve"><value>Cannot clear onboarding until all required agreements are signed.</value></data>
+  <data name="OnboardingReview_LegalDocuments" xml:space="preserve"><value>Legal Documents</value></data>
+  <data name="OnboardingReview_DocsComplete" xml:space="preserve"><value>Complete</value></data>
+  <data name="OnboardingReview_DocsPending" xml:space="preserve"><value>Pending</value></data>
+  <data name="OnboardingReview_DocsNote" xml:space="preserve"><value>Profile review can proceed independently. Human will join Volunteers once all documents are signed.</value></data>
 
   <!-- Board Voting -->
   <data name="Nav_BoardVoting" xml:space="preserve"><value>Board Voting</value></data>

--- a/src/Humans.Web/Views/OnboardingReview/Detail.cshtml
+++ b/src/Humans.Web/Views/OnboardingReview/Detail.cshtml
@@ -56,6 +56,37 @@
     </div>
 
     <div class="col-md-4">
+        @if (Model.RequiredConsentCount > 0)
+        {
+            var allSigned = Model.ConsentCount >= Model.RequiredConsentCount;
+            <div class="card mb-4">
+                <div class="card-header">
+                    <i class="fa-solid fa-file-signature me-1"></i> @Localizer["OnboardingReview_LegalDocuments"]
+                </div>
+                <div class="card-body">
+                    <div class="d-flex justify-content-between align-items-center mb-2">
+                        <span>@Model.ConsentCount / @Model.RequiredConsentCount @Localizer["OnboardingReview_Signed"]</span>
+                        <span class="badge @(allSigned ? "bg-success" : "bg-warning")">
+                            @(allSigned ? Localizer["OnboardingReview_DocsComplete"] : Localizer["OnboardingReview_DocsPending"])
+                        </span>
+                    </div>
+                    <div class="progress" style="height: 8px;">
+                        <div class="progress-bar @(allSigned ? "bg-success" : "bg-warning")"
+                             role="progressbar"
+                             style="width: @(Model.RequiredConsentCount > 0 ? (int)(100.0 * Model.ConsentCount / Model.RequiredConsentCount) : 0)%"
+                             aria-valuenow="@Model.ConsentCount"
+                             aria-valuemin="0"
+                             aria-valuemax="@Model.RequiredConsentCount">
+                        </div>
+                    </div>
+                    @if (!allSigned)
+                    {
+                        <div class="form-text mt-2">@Localizer["OnboardingReview_DocsNote"]</div>
+                    }
+                </div>
+            </div>
+        }
+
         <div class="card mb-4">
             <div class="card-header">@Localizer["OnboardingReview_Actions"]</div>
             <div class="card-body">

--- a/src/Humans.Web/Views/OnboardingReview/Index.cshtml
+++ b/src/Humans.Web/Views/OnboardingReview/Index.cshtml
@@ -45,13 +45,12 @@
                         {
                             <span class="badge bg-info me-1">@item.MembershipTier</span>
                         }
-                        @if (item.ConsentCheckStatus == ConsentCheckStatus.Pending)
+                        @if (item.RequiredConsentCount > 0)
                         {
-                            <span class="badge bg-warning">@Localizer["OnboardingReview_Pending"]</span>
-                        }
-                        else
-                        {
-                            <span class="badge bg-secondary">@Localizer["OnboardingReview_ConsentsNotStarted"]</span>
+                            var allSigned = item.ConsentCount >= item.RequiredConsentCount;
+                            <span class="badge @(allSigned ? "bg-success" : "bg-secondary")">
+                                <i class="fa-solid fa-file-signature me-1"></i>@item.ConsentCount/@item.RequiredConsentCount
+                            </span>
                         }
                         <br />
                                     <small class="text-muted">@item.ProfileCreatedAt.ToDisplayDate()</small>
@@ -91,6 +90,13 @@
                             <span class="badge bg-info me-1">@item.MembershipTier</span>
                         }
                         <span class="badge bg-danger">@Localizer["OnboardingReview_FlaggedBadge"]</span>
+                        @if (item.RequiredConsentCount > 0)
+                        {
+                            var allSigned = item.ConsentCount >= item.RequiredConsentCount;
+                            <span class="badge @(allSigned ? "bg-success" : "bg-secondary")">
+                                <i class="fa-solid fa-file-signature me-1"></i>@item.ConsentCount/@item.RequiredConsentCount
+                            </span>
+                        }
                         <br />
                                     <small class="text-muted">@item.ProfileCreatedAt.ToDisplayDate()</small>
                     </div>

--- a/tests/Humans.Application.Tests/Services/OnboardingServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/OnboardingServiceTests.cs
@@ -58,7 +58,6 @@ public class OnboardingServiceTests : IDisposable
         var userId = Guid.NewGuid();
         var reviewerId = Guid.NewGuid();
         await SeedProfileAsync(userId, consentCheckStatus: ConsentCheckStatus.Pending);
-        _membershipCalculator.HasAllRequiredConsentsAsync(userId, Arg.Any<CancellationToken>()).Returns(true);
 
         var result = await _service.ClearConsentCheckAsync(userId, reviewerId, "Reviewer", "All good");
 
@@ -92,16 +91,19 @@ public class OnboardingServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task ClearConsentCheckAsync_MissingConsents_ReturnsError()
+    public async Task ClearConsentCheckAsync_MissingConsents_StillSucceeds()
     {
         var userId = Guid.NewGuid();
         await SeedProfileAsync(userId, consentCheckStatus: ConsentCheckStatus.Pending);
-        _membershipCalculator.HasAllRequiredConsentsAsync(userId, Arg.Any<CancellationToken>()).Returns(false);
 
         var result = await _service.ClearConsentCheckAsync(userId, Guid.NewGuid(), "Reviewer", null);
 
-        result.Success.Should().BeFalse();
-        result.ErrorKey.Should().Be("ConsentsRequired");
+        result.Success.Should().BeTrue();
+        var profile = await _dbContext.Profiles.FirstAsync(p => p.UserId == userId);
+        profile.ConsentCheckStatus.Should().Be(ConsentCheckStatus.Cleared);
+        profile.IsApproved.Should().BeTrue();
+        // Sync job is called — it independently decides whether to add to team based on consent status
+        await _syncJob.Received().SyncVolunteersMembershipForUserAsync(userId, Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -398,8 +400,9 @@ public class OnboardingServiceTests : IDisposable
         var flaggedProfile = await _dbContext.Profiles.FirstAsync(p => p.UserId == flaggedId);
         flaggedProfile.ConsentCheckStatus = ConsentCheckStatus.Flagged;
         await _dbContext.SaveChangesAsync();
+        SetupDefaultMembershipSnapshot();
 
-        var (pending, flagged, _) = await _service.GetReviewQueueAsync();
+        var (pending, flagged, _, _) = await _service.GetReviewQueueAsync();
 
         pending.Should().HaveCount(2);
         pending.Select(p => p.UserId).Should().Contain(noConsentId);
@@ -414,7 +417,7 @@ public class OnboardingServiceTests : IDisposable
         var userId = Guid.NewGuid();
         await SeedUserWithProfileAsync(userId, isApproved: true);
 
-        var (pending, flagged, _) = await _service.GetReviewQueueAsync();
+        var (pending, flagged, _, _) = await _service.GetReviewQueueAsync();
 
         pending.Should().BeEmpty();
         flagged.Should().BeEmpty();
@@ -426,7 +429,7 @@ public class OnboardingServiceTests : IDisposable
         var userId = Guid.NewGuid();
         await SeedUserWithProfileAsync(userId, rejectedAt: _clock.GetCurrentInstant());
 
-        var (pending, flagged, _) = await _service.GetReviewQueueAsync();
+        var (pending, flagged, _, _) = await _service.GetReviewQueueAsync();
 
         pending.Should().BeEmpty();
         flagged.Should().BeEmpty();
@@ -438,10 +441,26 @@ public class OnboardingServiceTests : IDisposable
         var userId = Guid.NewGuid();
         await SeedUserWithProfileAsync(userId);
         await SeedApplicationForUserAsync(userId, Guid.NewGuid());
+        SetupDefaultMembershipSnapshot();
 
-        var (_, _, pendingAppUserIds) = await _service.GetReviewQueueAsync();
+        var (_, _, pendingAppUserIds, _) = await _service.GetReviewQueueAsync();
 
         pendingAppUserIds.Should().Contain(userId);
+    }
+
+    [Fact]
+    public async Task GetReviewQueueAsync_IncludesConsentProgress()
+    {
+        var userId = Guid.NewGuid();
+        await SeedUserWithProfileAsync(userId);
+        _membershipCalculator.GetMembershipSnapshotAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(new MembershipSnapshot(MembershipStatus.Pending, false, 3, 1, new List<Guid>()));
+
+        var (_, _, _, consentProgress) = await _service.GetReviewQueueAsync();
+
+        consentProgress.Should().ContainKey(userId);
+        consentProgress[userId].Signed.Should().Be(2); // 3 - 1
+        consentProgress[userId].Required.Should().Be(3);
     }
 
     [Fact]
@@ -475,8 +494,9 @@ public class OnboardingServiceTests : IDisposable
             UpdatedAt = now
         });
         await _dbContext.SaveChangesAsync();
+        SetupDefaultMembershipSnapshot();
 
-        var (pending, _, _) = await _service.GetReviewQueueAsync();
+        var (pending, _, _, _) = await _service.GetReviewQueueAsync();
 
         pending.Should().HaveCount(2);
         pending[0].UserId.Should().Be(olderId);
@@ -486,11 +506,12 @@ public class OnboardingServiceTests : IDisposable
     [Fact]
     public async Task GetReviewQueueAsync_EmptyWhenNone()
     {
-        var (pending, flagged, pendingAppUserIds) = await _service.GetReviewQueueAsync();
+        var (pending, flagged, pendingAppUserIds, consentProgress) = await _service.GetReviewQueueAsync();
 
         pending.Should().BeEmpty();
         flagged.Should().BeEmpty();
         pendingAppUserIds.Should().BeEmpty();
+        consentProgress.Should().BeEmpty();
     }
 
     // --- GetReviewDetailAsync ---
@@ -918,6 +939,12 @@ public class OnboardingServiceTests : IDisposable
     }
 
     // --- Helpers ---
+
+    private void SetupDefaultMembershipSnapshot()
+    {
+        _membershipCalculator.GetMembershipSnapshotAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(new MembershipSnapshot(MembershipStatus.Pending, false, 0, 0, new List<Guid>()));
+    }
 
     private async Task SeedProfileAsync(Guid userId,
         bool isApproved = false, bool isSuspended = false,


### PR DESCRIPTION
## Summary
- Removes the `HasAllRequiredConsentsAsync` gate from `ClearConsentCheckAsync` so Consent Coordinators can clear profile reviews independently of legal document signing
- Admission to the Volunteers team still requires both conditions — the sync job (`SyncVolunteersMembershipForUserAsync`) checks `IsApproved` AND `HasAllRequiredConsents` independently
- Adds legal document progress (X/Y signed with progress bar) to the onboarding review detail view and consent badges to the index list
- Updates localization strings across all 5 locales (en, es, de, fr, it)

Closes nobodies-collective/Humans#365

## Test plan
- [ ] Verify Consent Coordinator can clear a profile when legal docs are NOT yet signed
- [ ] Verify volunteer can sign legal docs before or after profile clearance
- [ ] Verify admission to Volunteers team only happens when both profile clearance AND all legal docs are signed
- [ ] Verify onboarding review index shows X/Y consent progress badges
- [ ] Verify detail view shows legal documents progress bar
- [ ] Verify all 55 onboarding service tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)