### PR TITLE
Add sub-team manager role (#342)

### DIFF
--- a/docs/features/06-teams.md
+++ b/docs/features/06-teams.md
@@ -233,11 +233,13 @@ Teams are either **departments** (top-level, no parent) or **sub-teams** (have a
 - Only user-created teams can participate in hierarchy (system teams cannot be parents or children)
 - Only single-level nesting (a sub-team cannot also be a parent)
 - `ParentTeamId` is set during team creation or editing
-- When a team becomes a sub-team, all `IsManagement` flags on its roles are cleared and any Coordinator members are demoted to Member
+- When a department becomes a sub-team, its coordinators are immediately synced out of the Coordinators system team. Management roles and assignments are preserved (coordinators become sub-team managers).
 
-### Coordinator (IsManagement) Rules
-- Only departments can have an `IsManagement` role. Sub-teams cannot.
-- At most one role per department can have `IsManagement = true`
+### Coordinator / Manager (IsManagement) Rules
+- Both departments and sub-teams can have an `IsManagement` role
+- At most one role per team can have `IsManagement = true`
+- Department `IsManagement` role holders are **coordinators** (added to Coordinators system team, full department access)
+- Sub-team `IsManagement` role holders are **managers** (scoped to their sub-team only, not added to Coordinators system team, no Google resource access, no budget access)
 - Assigning a member to an `IsManagement` role sets their `TeamMember.Role = Coordinator`
 - Unassigning from an `IsManagement` role demotes to Member (if no other management assignments remain)
 - `IsManagement` cannot be toggled while members are assigned to the role
@@ -509,7 +511,7 @@ Teams can define named role slots that members fill. Each role has a configurabl
 
 - **Role Definition**: A named role on a team (e.g., "Social Media", "Designer") with a slot count and priority per slot
 - **Role Assignment**: Links a team member to a specific slot in a role definition
-- **IsManagement flag**: One role per department can be marked `IsManagement = true`. Assigning a member to this role sets their `TeamMember.Role = Coordinator`. Sub-teams cannot have IsManagement roles.
+- **IsManagement flag**: One role per team can be marked `IsManagement = true`. Assigning a member to this role sets their `TeamMember.Role = Coordinator`. On departments this grants coordinator access; on sub-teams this grants scoped manager access.
 - **Auto-add**: Assigning a non-member to a role automatically adds them to the team
 - **Roster Summary**: Cross-team view showing all slots with priority/status filtering
 

--- a/docs/sections/Shifts.md
+++ b/docs/sections/Shifts.md
@@ -2,7 +2,7 @@
 
 ## Concepts
 
-- A **Rota** is a named container for shifts, belonging to a department and an event. Each rota has a period (Build, Event, or Strike) that determines whether its shifts are all-day or time-slotted.
+- A **Rota** is a named container for shifts, belonging to a department or sub-team and an event. Each rota has a period (Build, Event, or Strike) that determines whether its shifts are all-day or time-slotted.
 - A **Shift** is a single work slot with a day offset, optional start time, duration, and maximum volunteer count.
 - A **Shift Signup** links a human to a shift. Signups progress through states: Pending, Confirmed, Refused, Bailed, Cancelled, or NoShow.
 - **Range Signups** link multiple shifts via a block ID. Operations on a range (bail, approve, refuse) apply to the entire block atomically.
@@ -17,7 +17,8 @@
 | Actor | Capabilities |
 |-------|-------------|
 | Any active human | Browse available shifts (when browsing is open or they have existing signups). Sign up for shifts. View own signups and schedule. Bail from own signups. Set general availability. Fill out volunteer event profile |
-| Department coordinator | Manage rotas and shifts for their department. Approve, refuse, and bail signups. Voluntell humans. Manage rota tags. View volunteer event profiles (except medical data) |
+| Department coordinator | Manage rotas and shifts for their department and all sub-teams. Approve, refuse, and bail signups. Voluntell humans. Manage rota tags. View volunteer event profiles (except medical data) |
+| Sub-team manager | Manage rotas and shifts for their sub-team only. Approve, refuse, and bail signups on their sub-team. Voluntell humans on their sub-team. Cannot manage sibling sub-teams or the parent department |
 | VolunteerCoordinator | All coordinator capabilities across all departments. Move rotas between departments. Access the cross-department shift dashboard |
 | NoInfoAdmin, Admin | Approve, refuse, and bail signups across all departments. View volunteer medical data. Access the cross-department shift dashboard |
 | Admin | Manage event settings (dates, timezone, early-entry capacity, global volunteer cap, shift browsing toggle) |
@@ -39,6 +40,7 @@
 - Regular humans **cannot** approve, refuse, or bail other humans' signups.
 - Regular humans **cannot** voluntell other humans.
 - Department coordinators **cannot** manage rotas or approve signups outside their own department.
+- Sub-team managers **cannot** manage rotas or approve signups outside their own sub-team (not siblings, not parent department).
 - Department coordinators **cannot** view volunteer medical data.
 - NoInfoAdmin **cannot** create or edit rotas or shifts. They can only manage signups (approve, refuse, bail) and view medical data.
 - VolunteerCoordinator **cannot** view volunteer medical data.
@@ -51,7 +53,7 @@
 
 ## Cross-Section Dependencies
 
-- **Teams**: Rotas belong to a department. Coordinator status on a department determines shift management access.
+- **Teams**: Rotas belong to a department or sub-team. Coordinator/manager status on a team determines shift management access. Sub-team managers have scoped access; department coordinators have access across all sub-teams.
 - **Profiles**: Volunteer event profile stores per-event volunteer data (skills, dietary, medical). NoShow history is shown on a human's profile to coordinators and privileged roles.
 - **Admin**: Event settings management is Admin-only.
 - **Email**: Signup status change notifications are queued through the email outbox.

--- a/docs/sections/Teams.md
+++ b/docs/sections/Teams.md
@@ -5,7 +5,8 @@
 - A **Department** is a team with no parent.
 - A **Sub-Team** is a team within a department. Only one level of nesting is allowed.
 - **System teams** (Volunteers, Coordinators, Board, Asociados, Colaboradors) are managed automatically — members cannot be manually added or removed.
-- A **Coordinator** is a team member assigned to the management role on a department. Sub-teams do not have coordinator roles.
+- A **Coordinator** is a team member assigned to the management role on a department. Coordinators have full authority over the department and all its sub-teams, including Google resource management. They are added to the Coordinators system team.
+- A **Sub-team Manager** is a team member assigned to the management role on a sub-team. Managers have scoped authority over their sub-team only: member management, join requests, roles, shifts, and team page editing. They **cannot** manage Google resources, the parent department, or sibling sub-teams. They are **not** added to the Coordinators system team.
 - A **Team Page** is a Markdown-based public or member-facing page for a department, with optional calls to action.
 
 ## Actors & Roles
@@ -15,14 +16,15 @@
 | Anyone (including anonymous) | Browse the team directory and view public team pages |
 | Any active human | View team detail pages, request to join a team, leave a team, withdraw a pending request, view own memberships, browse the birthday calendar, search humans, view the roster and map |
 | Coordinator | Manage members, approve/reject join requests, manage roles, edit the team page, and manage Google resources for their department (and its sub-teams) |
+| Sub-team Manager | Manage members, approve/reject join requests, manage roles, manage shifts, and edit the team page for their sub-team only. Cannot manage Google resources, the parent department, or sibling sub-teams |
 | TeamsAdmin | All coordinator capabilities on all teams. Create teams, edit team settings (name, slug, approval mode, parent, Google group prefix, budget flag), and link/unlink Google resources on all teams |
 | Board | All TeamsAdmin capabilities. Additionally can delete (deactivate) teams |
 | Admin | All Board capabilities. Additionally can execute Google sync actions, trigger system team sync, and view sync previews |
 
 ## Invariants
 
-- A department can have **at most one** role flagged as management (coordinator). This is enforced in both the toggle and edit paths. If present, members assigned to it gain coordinator-level access over the whole department: member management, join request handling, role management, and team page editing.
-- Sub-teams do not have coordinator roles.
+- A department can have **at most one** role flagged as management (coordinator). This is enforced in both the toggle and edit paths. If present, members assigned to it gain coordinator-level access over the whole department and all its sub-teams: member management, join request handling, role management, team page editing, and Google resource management.
+- A sub-team can have **at most one** role flagged as management (manager). Members assigned to it gain scoped management access over that sub-team only. Sub-team managers cannot manage Google resources, the parent department, or sibling sub-teams, and are not added to the Coordinators system team.
 - Members of sub-teams are also considered members of the department. They appear in the department's member roster and inherit the department's legal requirements and Google resource access (Drive folders, Groups).
 - A human can be a member of multiple teams simultaneously.
 - System team membership is managed exclusively by an automated sync job. Manual add/remove is blocked for system teams.
@@ -37,6 +39,7 @@
 
 - Regular humans **cannot** manage other teams' members, roles, or settings.
 - Coordinators **cannot** create, delete, or edit team admin settings (name, approval mode, parent, Google prefix). They can only edit the team page and manage members/roles for their own department.
+- Sub-team managers **cannot** manage Google resources, the parent department, sibling sub-teams, or team admin settings.
 - TeamsAdmin **cannot** delete teams or execute sync actions.
 - Nobody can manually add or remove members from system teams.
 
@@ -45,13 +48,13 @@
 - When a join request is approved, a team membership record is created and the human is notified.
 - When a member is removed from a team, all their role assignments for that team are also removed.
 - When a member is added or removed from a team, Google resource sync events (Drive, Groups) are queued.
-- When a coordinator role assignment changes, the Coordinators system team membership is recalculated for the affected human.
+- When a department coordinator role assignment changes, the Coordinators system team membership is recalculated for the affected human. Sub-team manager changes do not affect the Coordinators system team.
 - The system team sync job runs hourly, reconciling system team membership based on role assignments and tier status.
 
 ## Cross-Section Dependencies
 
 - **Google Integration**: Each team can have linked Google resources (Drive folders, Groups). Membership changes trigger sync outbox events.
-- **Shifts**: Rotas belong to a department. Coordinator status on a department determines shift management access.
+- **Shifts**: Rotas belong to a department or sub-team. Coordinator/manager status determines shift management access (scoped to their team).
 - **Budget**: Budget categories can be linked to a department. Coordinator status determines budget line item editing access.
 - **Onboarding**: Volunteer activation adds the human to the Volunteers system team.
 - **Governance**: Colaborador/Asociado approval or expiry adds/removes humans from the respective system teams.

--- a/src/Humans.Application/Interfaces/IShiftManagementService.cs
+++ b/src/Humans.Application/Interfaces/IShiftManagementService.cs
@@ -31,9 +31,9 @@ public interface IShiftManagementService
     Task<bool> CanApproveSignupsAsync(Guid userId, Guid departmentTeamId);
 
     /// <summary>
-    /// Gets all department team IDs where the user is a coordinator.
+    /// Gets all team IDs (departments and sub-teams) where the user is a coordinator or manager.
     /// </summary>
-    Task<IReadOnlyList<Guid>> GetCoordinatorDepartmentIdsAsync(Guid userId);
+    Task<IReadOnlyList<Guid>> GetCoordinatorTeamIdsAsync(Guid userId);
 
     // === EventSettings ===
 

--- a/src/Humans.Infrastructure/Jobs/SystemTeamSyncJob.cs
+++ b/src/Humans.Infrastructure/Jobs/SystemTeamSyncJob.cs
@@ -207,13 +207,14 @@ public class SystemTeamSyncJob : ISystemTeamSync
             return;
         }
 
-        // Get all current coordinators (excluding the Coordinators system team itself)
+        // Get all current department coordinators (sub-team managers are excluded)
         var leadUserIds = await _dbContext.TeamMembers
             .AsNoTracking()
             .Where(tm =>
                 tm.LeftAt == null &&
                 tm.Role == TeamMemberRole.Coordinator &&
-                tm.Team.SystemTeamType == SystemTeamType.None) // Only from user-created teams
+                tm.Team.SystemTeamType == SystemTeamType.None &&
+                tm.Team.ParentTeamId == null) // Only department coordinators, not sub-team managers
             .Select(tm => tm.UserId)
             .Distinct()
             .ToListAsync(cancellationToken);
@@ -396,14 +397,15 @@ public class SystemTeamSyncJob : ISystemTeamSync
             return;
         }
 
-        // Check if user is currently Coordinator of any user-created team
+        // Check if user is currently Coordinator of any department (sub-team managers excluded)
         var isCoordinatorAnywhere = await _dbContext.TeamMembers
             .AsNoTracking()
             .AnyAsync(tm =>
                 tm.UserId == userId &&
                 tm.LeftAt == null &&
                 tm.Role == TeamMemberRole.Coordinator &&
-                tm.Team.SystemTeamType == SystemTeamType.None,
+                tm.Team.SystemTeamType == SystemTeamType.None &&
+                tm.Team.ParentTeamId == null, // Only department coordinators
                 cancellationToken);
 
         var isEligible = isCoordinatorAnywhere

--- a/src/Humans.Infrastructure/Services/BudgetService.cs
+++ b/src/Humans.Infrastructure/Services/BudgetService.cs
@@ -887,20 +887,22 @@ public class BudgetService : IBudgetService
 
     public async Task<HashSet<Guid>> GetEffectiveCoordinatorTeamIdsAsync(Guid userId)
     {
-        // Teams where user is direct coordinator
+        // Teams where user is direct coordinator (departments only — sub-team managers don't get budget access)
         var directTeamIds = await _dbContext.TeamMembers
             .AsNoTracking()
-            .Where(tm => tm.UserId == userId && tm.LeftAt == null && tm.Role == TeamMemberRole.Coordinator)
+            .Where(tm => tm.UserId == userId && tm.LeftAt == null && tm.Role == TeamMemberRole.Coordinator
+                         && tm.Team.ParentTeamId == null)
             .Select(tm => tm.TeamId)
             .ToListAsync();
 
-        // Teams where user has management role assignment
+        // Teams where user has management role assignment (departments only)
         var mgmtTeamIds = await _dbContext.Set<TeamRoleAssignment>()
             .AsNoTracking()
             .Where(tra =>
                 tra.TeamMember.UserId == userId &&
                 tra.TeamMember.LeftAt == null &&
-                tra.TeamRoleDefinition.IsManagement)
+                tra.TeamRoleDefinition.IsManagement &&
+                tra.TeamRoleDefinition.Team.ParentTeamId == null)
             .Select(tra => tra.TeamMember.TeamId)
             .ToListAsync();
 

--- a/src/Humans.Infrastructure/Services/ShiftManagementService.cs
+++ b/src/Humans.Infrastructure/Services/ShiftManagementService.cs
@@ -52,8 +52,8 @@ public class ShiftManagementService : IShiftManagementService
 
     public async Task<bool> IsDeptCoordinatorAsync(Guid userId, Guid departmentTeamId)
     {
-        var deptIds = await GetCoordinatorDepartmentIdsAsync(userId);
-        if (deptIds.Contains(departmentTeamId))
+        var teamIds = await GetCoordinatorTeamIdsAsync(userId);
+        if (teamIds.Contains(departmentTeamId))
             return true;
 
         // Parent department coordinators can manage child teams
@@ -62,7 +62,7 @@ public class ShiftManagementService : IShiftManagementService
             .Select(t => t.ParentTeamId)
             .FirstOrDefaultAsync();
 
-        return parentTeamId is not null && deptIds.Contains(parentTeamId.Value);
+        return parentTeamId is not null && teamIds.Contains(parentTeamId.Value);
     }
 
     public async Task<bool> CanManageShiftsAsync(Guid userId, Guid departmentTeamId)
@@ -86,17 +86,17 @@ public class ShiftManagementService : IShiftManagementService
         return await IsDeptCoordinatorAsync(userId, departmentTeamId);
     }
 
-    public async Task<IReadOnlyList<Guid>> GetCoordinatorDepartmentIdsAsync(Guid userId)
+    public async Task<IReadOnlyList<Guid>> GetCoordinatorTeamIdsAsync(Guid userId)
     {
         var result = await _cache.GetOrCreateAsync(CacheKeys.ShiftAuthorization(userId), async entry =>
         {
             entry.AbsoluteExpirationRelativeToNow = AuthCacheDuration;
-            return await QueryCoordinatorDepartmentIdsAsync(userId);
+            return await QueryCoordinatorTeamIdsAsync(userId);
         });
         return result ?? [];
     }
 
-    private async Task<IReadOnlyList<Guid>> QueryCoordinatorDepartmentIdsAsync(Guid userId)
+    private async Task<IReadOnlyList<Guid>> QueryCoordinatorTeamIdsAsync(Guid userId)
     {
         // Check via IsManagement role assignment (departments and sub-teams)
         var byRoleAssignment = await _dbContext.TeamRoleAssignments
@@ -214,8 +214,6 @@ public class ShiftManagementService : IShiftManagementService
 
         if (team is null)
             throw new InvalidOperationException("Team not found.");
-        if (team.ParentTeamId is not null)
-            throw new InvalidOperationException("Rotas can only be created on parent teams (departments).");
         if (team.SystemTeamType != SystemTeamType.None)
             throw new InvalidOperationException("Rotas cannot be created on system teams.");
 

--- a/src/Humans.Infrastructure/Services/ShiftManagementService.cs
+++ b/src/Humans.Infrastructure/Services/ShiftManagementService.cs
@@ -98,14 +98,13 @@ public class ShiftManagementService : IShiftManagementService
 
     private async Task<IReadOnlyList<Guid>> QueryCoordinatorDepartmentIdsAsync(Guid userId)
     {
-        // Check via IsManagement role assignment
+        // Check via IsManagement role assignment (departments and sub-teams)
         var byRoleAssignment = await _dbContext.TeamRoleAssignments
             .AsNoTracking()
             .Where(tra =>
                 tra.TeamMember.UserId == userId &&
                 tra.TeamMember.LeftAt == null &&
                 tra.TeamRoleDefinition.IsManagement &&
-                tra.TeamRoleDefinition.Team.ParentTeamId == null &&
                 tra.TeamRoleDefinition.Team.SystemTeamType == SystemTeamType.None)
             .Select(tra => tra.TeamRoleDefinition.TeamId)
             .ToListAsync();
@@ -117,7 +116,6 @@ public class ShiftManagementService : IShiftManagementService
                 tm.UserId == userId &&
                 tm.LeftAt == null &&
                 tm.Role == TeamMemberRole.Coordinator &&
-                tm.Team.ParentTeamId == null &&
                 tm.Team.SystemTeamType == SystemTeamType.None)
             .Select(tm => tm.TeamId)
             .ToListAsync();

--- a/src/Humans.Infrastructure/Services/TeamService.cs
+++ b/src/Humans.Infrastructure/Services/TeamService.cs
@@ -478,9 +478,9 @@ public class TeamService : ITeamService
             customSlug = null;
         }
 
-        // If team is becoming a sub-team, clear IsManagement and demote coordinators
-        var becomingChild = parentTeamId.HasValue && !team.ParentTeamId.HasValue;
-        var usersNeedingShiftAuthorizationInvalidation = becomingChild
+        // If team is changing parent, invalidate shift auth for management role holders
+        var parentChanging = parentTeamId != team.ParentTeamId;
+        var usersNeedingShiftAuthorizationInvalidation = parentChanging
             ? await _dbContext.Set<TeamRoleAssignment>()
                 .Where(a => a.TeamRoleDefinition.TeamId == teamId && a.TeamRoleDefinition.IsManagement)
                 .Select(a => a.TeamMember.UserId)
@@ -520,32 +520,6 @@ public class TeamService : ITeamService
             team.ShowCoordinatorsOnPublicPage = false;
         }
         team.UpdatedAt = _clock.GetCurrentInstant();
-
-        if (becomingChild)
-        {
-            var managementRoles = await _dbContext.Set<TeamRoleDefinition>()
-                .Where(d => d.TeamId == teamId && d.IsManagement)
-                .ToListAsync(cancellationToken);
-            foreach (var role in managementRoles)
-            {
-                role.IsManagement = false;
-                role.UpdatedAt = team.UpdatedAt;
-            }
-
-            var coordinators = await _dbContext.TeamMembers
-                .Where(m => m.TeamId == teamId && m.LeftAt == null && m.Role == TeamMemberRole.Coordinator)
-                .ToListAsync(cancellationToken);
-            foreach (var member in coordinators)
-            {
-                member.Role = TeamMemberRole.Member;
-            }
-
-            if (managementRoles.Count > 0 || coordinators.Count > 0)
-            {
-                _logger.LogInformation("Team {TeamId} became a sub-team: cleared {RoleCount} management roles, demoted {MemberCount} coordinators",
-                    teamId, managementRoles.Count, coordinators.Count);
-            }
-        }
 
         await _dbContext.SaveChangesAsync(cancellationToken);
 

--- a/src/Humans.Infrastructure/Services/TeamService.cs
+++ b/src/Humans.Infrastructure/Services/TeamService.cs
@@ -26,6 +26,7 @@ public class TeamService : ITeamService
     private readonly INotificationService _notificationService;
     private readonly IRoleAssignmentService _roleAssignmentService;
     private readonly IShiftManagementService _shiftManagementService;
+    private readonly ISystemTeamSync _systemTeamSync;
     private readonly IClock _clock;
     private readonly IMemoryCache _cache;
     private readonly ILogger<TeamService> _logger;
@@ -37,6 +38,7 @@ public class TeamService : ITeamService
         INotificationService notificationService,
         IRoleAssignmentService roleAssignmentService,
         IShiftManagementService shiftManagementService,
+        ISystemTeamSync systemTeamSync,
         IClock clock,
         IMemoryCache cache,
         ILogger<TeamService> logger)
@@ -47,6 +49,7 @@ public class TeamService : ITeamService
         _notificationService = notificationService;
         _roleAssignmentService = roleAssignmentService;
         _shiftManagementService = shiftManagementService;
+        _systemTeamSync = systemTeamSync;
         _clock = clock;
         _cache = cache;
         _logger = logger;
@@ -479,6 +482,7 @@ public class TeamService : ITeamService
         }
 
         // If team is changing parent, invalidate shift auth for management role holders
+        var becomingChild = parentTeamId.HasValue && !team.ParentTeamId.HasValue;
         var parentChanging = parentTeamId != team.ParentTeamId;
         var usersNeedingShiftAuthorizationInvalidation = parentChanging
             ? await _dbContext.Set<TeamRoleAssignment>()
@@ -525,6 +529,16 @@ public class TeamService : ITeamService
 
         _cache.InvalidateActiveTeams();
         InvalidateShiftAuthorization(usersNeedingShiftAuthorizationInvalidation);
+
+        // When a department becomes a sub-team, its coordinators must be removed from
+        // the Coordinators system team immediately (not waiting for the hourly sync)
+        if (becomingChild && usersNeedingShiftAuthorizationInvalidation.Count > 0)
+        {
+            foreach (var userId in usersNeedingShiftAuthorizationInvalidation)
+            {
+                await _systemTeamSync.SyncCoordinatorsMembershipForUserAsync(userId, cancellationToken);
+            }
+        }
 
         _logger.LogInformation("Updated team {TeamId} ({TeamName})", teamId, name);
 
@@ -1399,7 +1413,6 @@ public class TeamService : ITeamService
         definition.SortOrder = sortOrder;
         var invalidatedActiveTeams = false;
         var usersNeedingShiftAuthorizationInvalidation =
-            definition.Team.ParentTeamId is null &&
             definition.Team.SystemTeamType == SystemTeamType.None &&
             definition.IsManagement != isManagement &&
             definition.Assignments.Count > 0
@@ -2291,7 +2304,6 @@ public class TeamService : ITeamService
 
     private static bool IsShiftAuthorizationDefinition(TeamRoleDefinition definition) =>
         definition.IsManagement &&
-        definition.Team.ParentTeamId is null &&
         definition.Team.SystemTeamType == SystemTeamType.None;
 
     public void RemoveMemberFromAllTeamsCache(Guid userId)

--- a/src/Humans.Web/Controllers/ProfileController.cs
+++ b/src/Humans.Web/Controllers/ProfileController.cs
@@ -960,7 +960,7 @@ public class ProfileController : HumansControllerBase
         List<NoShowHistoryItem>? noShowHistory = null;
         if (!isOwnProfile)
         {
-            var viewerIsCoordinator = (await _shiftMgmt.GetCoordinatorDepartmentIdsAsync(viewer.Id)).Count > 0;
+            var viewerIsCoordinator = (await _shiftMgmt.GetCoordinatorTeamIdsAsync(viewer.Id)).Count > 0;
             var viewerCanViewShiftHistory = viewerIsCoordinator || ShiftRoleChecks.IsPrivilegedSignupApprover(User);
 
             if (viewerCanViewShiftHistory)

--- a/src/Humans.Web/Controllers/ShiftsController.cs
+++ b/src/Humans.Web/Controllers/ShiftsController.cs
@@ -52,7 +52,7 @@ public class ShiftsController : HumansControllerBase
         if (es is null) return View("NoActiveEvent");
 
         var isPrivileged = ShiftRoleChecks.IsPrivilegedSignupApprover(User) ||
-                           (await _shiftMgmt.GetCoordinatorDepartmentIdsAsync(user.Id)).Count > 0;
+                           (await _shiftMgmt.GetCoordinatorTeamIdsAsync(user.Id)).Count > 0;
 
         var userSignups = await _signupService.GetByUserAsync(user.Id, es.Id);
         var hasSignups = userSignups.Count > 0;

--- a/src/Humans.Web/Controllers/TeamAdminController.cs
+++ b/src/Humans.Web/Controllers/TeamAdminController.cs
@@ -374,7 +374,7 @@ public class TeamAdminController : HumansTeamControllerBase
             return NotFound();
         }
 
-        if (!await CanManageResourcesAsync(team.Id, user.Id))
+        if (!await CanManageResourcesAsync(team, user.Id))
         {
             return Forbid();
         }
@@ -432,7 +432,7 @@ public class TeamAdminController : HumansTeamControllerBase
             return NotFound();
         }
 
-        if (!await CanManageResourcesAsync(team.Id, user.Id))
+        if (!await CanManageResourcesAsync(team, user.Id))
         {
             return Forbid();
         }
@@ -478,7 +478,7 @@ public class TeamAdminController : HumansTeamControllerBase
             return NotFound();
         }
 
-        if (!await CanManageResourcesAsync(team.Id, user.Id))
+        if (!await CanManageResourcesAsync(team, user.Id))
         {
             return Forbid();
         }
@@ -524,7 +524,7 @@ public class TeamAdminController : HumansTeamControllerBase
             return NotFound();
         }
 
-        if (!await CanManageResourcesAsync(team.Id, user.Id))
+        if (!await CanManageResourcesAsync(team, user.Id))
         {
             return Forbid();
         }
@@ -557,7 +557,7 @@ public class TeamAdminController : HumansTeamControllerBase
             return NotFound();
         }
 
-        if (!await CanManageResourcesAsync(team.Id, user.Id))
+        if (!await CanManageResourcesAsync(team, user.Id))
         {
             return Forbid();
         }
@@ -593,7 +593,7 @@ public class TeamAdminController : HumansTeamControllerBase
             return NotFound();
         }
 
-        if (!await CanManageResourcesAsync(team.Id, user.Id))
+        if (!await CanManageResourcesAsync(team, user.Id))
         {
             return Forbid();
         }
@@ -620,7 +620,7 @@ public class TeamAdminController : HumansTeamControllerBase
             return NotFound();
         }
 
-        if (!await CanManageResourcesAsync(team.Id, user.Id))
+        if (!await CanManageResourcesAsync(team, user.Id))
         {
             return Forbid();
         }
@@ -999,10 +999,14 @@ public class TeamAdminController : HumansTeamControllerBase
         return Json(combined);
     }
 
-    private async Task<bool> CanManageResourcesAsync(Guid teamId, Guid userId)
+    private async Task<bool> CanManageResourcesAsync(Team team, Guid userId)
     {
         // Claims-first for global roles; DB only for team-specific coordinator check
-        return RoleChecks.IsTeamsAdminBoardOrAdmin(User) ||
-               await _teamResourceService.CanManageTeamResourcesAsync(teamId, userId);
+        if (RoleChecks.IsTeamsAdminBoardOrAdmin(User))
+            return true;
+
+        // Sub-team managers cannot manage Google resources — check at department level
+        var checkTeamId = team.ParentTeamId ?? team.Id;
+        return await _teamResourceService.CanManageTeamResourcesAsync(checkTeamId, userId);
     }
 }

--- a/src/Humans.Web/Controllers/VolController.cs
+++ b/src/Humans.Web/Controllers/VolController.cs
@@ -128,7 +128,7 @@ public class VolController : HumansControllerBase
             if (es is null) return View("NoActiveEvent");
 
             var isPrivileged = ShiftRoleChecks.IsPrivilegedSignupApprover(User) ||
-                               (await _shiftMgmt.GetCoordinatorDepartmentIdsAsync(user.Id)).Count > 0;
+                               (await _shiftMgmt.GetCoordinatorTeamIdsAsync(user.Id)).Count > 0;
 
             var userSignups = await _signupService.GetByUserAsync(user.Id, es.Id);
             var hasSignups = userSignups.Count > 0;

--- a/src/Humans.Web/Views/TeamAdmin/Roles.cshtml
+++ b/src/Humans.Web/Views/TeamAdmin/Roles.cshtml
@@ -105,31 +105,36 @@
                             }
                         </div>
                     </div>
-                    @if (!Model.IsChildTeam || role.IsManagement)
-                    {
+                    @{
                         var hasAssignments = role.Slots.Any(s => s.IsFilled);
-                        <div class="mb-3 form-check">
-                            @if (role.IsManagement && hasAssignments)
-                            {
-                                <input type="hidden" name="IsManagement" value="true" />
-                                <input type="checkbox" class="form-check-input" id="isManagement-@role.Id" checked disabled />
-                            }
-                            else
-                            {
-                                <input type="checkbox" class="form-check-input" id="isManagement-@role.Id"
-                                       name="IsManagement" value="true" @(role.IsManagement ? "checked" : null) />
-                            }
-                            <label class="form-check-label" for="isManagement-@role.Id">Coordinator role</label>
-                            @if (role.IsManagement && hasAssignments)
-                            {
-                                <div class="form-text text-warning">Unassign all humans before unchecking.</div>
-                            }
-                            else
-                            {
-                                <div class="form-text">Humans assigned to this role automatically become Coordinators.</div>
-                            }
-                        </div>
                     }
+                    <div class="mb-3 form-check">
+                        @if (role.IsManagement && hasAssignments)
+                        {
+                            <input type="hidden" name="IsManagement" value="true" />
+                            <input type="checkbox" class="form-check-input" id="isManagement-@role.Id" checked disabled />
+                        }
+                        else
+                        {
+                            <input type="checkbox" class="form-check-input" id="isManagement-@role.Id"
+                                   name="IsManagement" value="true" @(role.IsManagement ? "checked" : null) />
+                        }
+                        <label class="form-check-label" for="isManagement-@role.Id">
+                            @(Model.IsChildTeam ? "Manager role" : "Coordinator role")
+                        </label>
+                        @if (role.IsManagement && hasAssignments)
+                        {
+                            <div class="form-text text-warning">Unassign all humans before unchecking.</div>
+                        }
+                        else if (Model.IsChildTeam)
+                        {
+                            <div class="form-text">Humans assigned to this role can manage this sub-team's members, roles, and shifts.</div>
+                        }
+                        else
+                        {
+                            <div class="form-text">Humans assigned to this role automatically become Coordinators.</div>
+                        }
+                    </div>
                     <div class="mb-3 form-check">
                         <input type="checkbox" class="form-check-input" id="isPublic-@role.Id"
                                name="IsPublic" value="true" @(role.IsPublic ? "checked" : null) />

--- a/tests/Humans.Application.Tests/Services/ShiftManagementServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/ShiftManagementServiceTests.cs
@@ -351,4 +351,157 @@ public class ShiftManagementServiceTests : IDisposable
 
         return (es, rota);
     }
+
+    // ============================================================
+    // IsDeptCoordinatorAsync — sub-team manager support
+    // ============================================================
+
+    [Fact]
+    public async Task IsDeptCoordinatorAsync_SubTeamManager_ReturnsTrue_ForOwnSubTeam()
+    {
+        var (department, subTeam, user) = await SeedSubTeamManagerScenario();
+
+        var result = await _service.IsDeptCoordinatorAsync(user.Id, subTeam.Id);
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task IsDeptCoordinatorAsync_SubTeamManager_ReturnsFalse_ForSiblingSubTeam()
+    {
+        var (department, subTeamA, user) = await SeedSubTeamManagerScenario();
+        var subTeamB = new Team
+        {
+            Id = Guid.NewGuid(),
+            Name = "SubTeamB",
+            Slug = "subteam-b",
+            SystemTeamType = SystemTeamType.None,
+            ParentTeamId = department.Id,
+            CreatedAt = TestNow,
+            UpdatedAt = TestNow
+        };
+        _dbContext.Teams.Add(subTeamB);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _service.IsDeptCoordinatorAsync(user.Id, subTeamB.Id);
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task IsDeptCoordinatorAsync_SubTeamManager_ReturnsFalse_ForParentDepartment()
+    {
+        var (department, _, user) = await SeedSubTeamManagerScenario();
+
+        var result = await _service.IsDeptCoordinatorAsync(user.Id, department.Id);
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task IsDeptCoordinatorAsync_DepartmentCoordinator_ReturnsTrue_ForChildSubTeam()
+    {
+        var department = new Team
+        {
+            Id = Guid.NewGuid(),
+            Name = "Dept",
+            Slug = "dept",
+            SystemTeamType = SystemTeamType.None,
+            CreatedAt = TestNow,
+            UpdatedAt = TestNow
+        };
+        var subTeam = new Team
+        {
+            Id = Guid.NewGuid(),
+            Name = "SubTeam",
+            Slug = "subteam",
+            SystemTeamType = SystemTeamType.None,
+            ParentTeamId = department.Id,
+            CreatedAt = TestNow,
+            UpdatedAt = TestNow
+        };
+        await _dbContext.Teams.AddRangeAsync(department, subTeam);
+
+        var user = SeedUser("DeptCoord");
+        var member = new TeamMember
+        {
+            Id = Guid.NewGuid(),
+            TeamId = department.Id,
+            Team = department,
+            UserId = user.Id,
+            User = user,
+            Role = TeamMemberRole.Coordinator,
+            JoinedAt = TestNow
+        };
+        _dbContext.TeamMembers.Add(member);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _service.IsDeptCoordinatorAsync(user.Id, subTeam.Id);
+
+        result.Should().BeTrue();
+    }
+
+    private async Task<(Team department, Team subTeam, User user)> SeedSubTeamManagerScenario()
+    {
+        var department = new Team
+        {
+            Id = Guid.NewGuid(),
+            Name = "Department",
+            Slug = "department",
+            SystemTeamType = SystemTeamType.None,
+            CreatedAt = TestNow,
+            UpdatedAt = TestNow
+        };
+        var subTeam = new Team
+        {
+            Id = Guid.NewGuid(),
+            Name = "SubTeam",
+            Slug = "subteam",
+            SystemTeamType = SystemTeamType.None,
+            ParentTeamId = department.Id,
+            CreatedAt = TestNow,
+            UpdatedAt = TestNow
+        };
+        await _dbContext.Teams.AddRangeAsync(department, subTeam);
+
+        var user = SeedUser("SubTeamMgr");
+        var member = new TeamMember
+        {
+            Id = Guid.NewGuid(),
+            TeamId = subTeam.Id,
+            Team = subTeam,
+            UserId = user.Id,
+            User = user,
+            Role = TeamMemberRole.Coordinator,
+            JoinedAt = TestNow
+        };
+        _dbContext.TeamMembers.Add(member);
+
+        var roleDef = new TeamRoleDefinition
+        {
+            Id = Guid.NewGuid(),
+            TeamId = subTeam.Id,
+            Name = "Manager",
+            IsManagement = true,
+            SlotCount = 1,
+            SortOrder = 0,
+            CreatedAt = TestNow,
+            UpdatedAt = TestNow
+        };
+        _dbContext.TeamRoleDefinitions.Add(roleDef);
+
+        var assignment = new TeamRoleAssignment
+        {
+            Id = Guid.NewGuid(),
+            TeamRoleDefinitionId = roleDef.Id,
+            TeamMemberId = member.Id,
+            SlotIndex = 0,
+            AssignedAt = TestNow,
+            AssignedByUserId = Guid.NewGuid()
+        };
+        _dbContext.TeamRoleAssignments.Add(assignment);
+
+        await _dbContext.SaveChangesAsync();
+        return (department, subTeam, user);
+    }
 }

--- a/tests/Humans.Application.Tests/Services/TeamRoleServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/TeamRoleServiceTests.cs
@@ -48,6 +48,7 @@ public class TeamRoleServiceTests : IDisposable
             Substitute.For<INotificationService>(),
             roleAssignmentService,
             shiftManagementService,
+            Substitute.For<ISystemTeamSync>(),
             _clock,
             cache,
             NullLogger<TeamService>.Instance);

--- a/tests/Humans.Application.Tests/Services/TeamServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/TeamServiceTests.cs
@@ -51,6 +51,7 @@ public class TeamServiceTests : IDisposable
             Substitute.For<INotificationService>(),
             _roleAssignmentService,
             shiftManagementService,
+            Substitute.For<ISystemTeamSync>(),
             _clock,
             _cache,
             NullLogger<TeamService>.Instance);

--- a/tests/Humans.Application.Tests/Services/TeamServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/TeamServiceTests.cs
@@ -274,6 +274,59 @@ public class TeamServiceTests : IDisposable
         result.Should().BeFalse();
     }
 
+    [Fact]
+    public async Task IsUserCoordinatorOfTeamAsync_SubTeamManager_ReturnsTrue_ForOwnSubTeam()
+    {
+        var user = SeedUser();
+        var parent = SeedTeam("Department");
+        var child = SeedTeam("SubTeam");
+        child.ParentTeamId = parent.Id;
+        var member = SeedTeamMember(child.Id, user.Id, TeamMemberRole.Coordinator);
+        var roleDef = SeedTeamRoleDefinition(child.Id, isManagement: true);
+        SeedTeamRoleAssignment(roleDef.Id, member.Id);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _service.IsUserCoordinatorOfTeamAsync(child.Id, user.Id);
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task IsUserCoordinatorOfTeamAsync_SubTeamManager_ReturnsFalse_ForSiblingSubTeam()
+    {
+        var user = SeedUser();
+        var parent = SeedTeam("Department");
+        var childA = SeedTeam("SubTeamA");
+        childA.ParentTeamId = parent.Id;
+        var childB = SeedTeam("SubTeamB");
+        childB.ParentTeamId = parent.Id;
+        var member = SeedTeamMember(childA.Id, user.Id, TeamMemberRole.Coordinator);
+        var roleDef = SeedTeamRoleDefinition(childA.Id, isManagement: true);
+        SeedTeamRoleAssignment(roleDef.Id, member.Id);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _service.IsUserCoordinatorOfTeamAsync(childB.Id, user.Id);
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task IsUserCoordinatorOfTeamAsync_SubTeamManager_ReturnsFalse_ForParentDepartment()
+    {
+        var user = SeedUser();
+        var parent = SeedTeam("Department");
+        var child = SeedTeam("SubTeam");
+        child.ParentTeamId = parent.Id;
+        var member = SeedTeamMember(child.Id, user.Id, TeamMemberRole.Coordinator);
+        var roleDef = SeedTeamRoleDefinition(child.Id, isManagement: true);
+        SeedTeamRoleAssignment(roleDef.Id, member.Id);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _service.IsUserCoordinatorOfTeamAsync(parent.Id, user.Id);
+
+        result.Should().BeFalse();
+    }
+
     // ==========================================================================
     // CanUserApproveRequestsForTeamAsync
     // ==========================================================================


### PR DESCRIPTION
## Summary

- Allow `IsManagement` on sub-team roles, giving sub-team managers scoped permissions over their sub-team only
- Sub-team managers can manage members, roles, join requests, shifts, and team pages for their sub-team
- Sub-team managers **cannot** manage Google resources, the parent department, or sibling sub-teams
- Sub-team managers are **not** added to the Coordinators system team
- Department coordinators retain full authority over all sub-teams (unchanged)

## Changes

| File | What |
|------|------|
| `TeamService.cs` | Remove `becomingChild` block that cleared IsManagement when a team became a sub-team |
| `Roles.cshtml` | Show management toggle for sub-team roles (with "Manager role" label) |
| `SystemTeamSyncJob.cs` | Filter Coordinators system team to department coordinators only (`ParentTeamId == null`) |
| `TeamAdminController.cs` | Check Google resource access at department level (sub-team managers blocked) |
| `ShiftManagementService.cs` | Include sub-team IDs in coordinator team lookup (enables shift management) |
| `Teams.md` | Updated invariants and actor table for sub-team manager role |
| Tests | 7 new tests covering sub-team manager permission boundaries |

Closes nobodies-collective/Humans#342

## Test plan

- [ ] All 770 existing tests pass
- [ ] New tests verify sub-team manager can access own sub-team, cannot access siblings/parent
- [ ] New tests verify shift authorization recognizes sub-team managers
- [ ] Manual: create sub-team with management role, verify scoped access on QA

🤖 Generated with [Claude Code](https://claude.com/claude-code)