### PR TITLE
Fix pre-existing code review findings

### DIFF
--- a/src/Humans.Infrastructure/Data/Configurations/ShiftConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/ShiftConfiguration.cs
@@ -13,7 +13,7 @@ public class ShiftConfiguration : IEntityTypeConfiguration<Shift>
         builder.HasKey(s => s.Id);
 
         builder.Property(s => s.Description).HasMaxLength(2000);
-        builder.Property(e => e.IsAllDay).HasDefaultValue(false);
+        builder.Property(e => e.IsAllDay);
 
         builder.Property(s => s.Duration)
             .HasConversion(

--- a/src/Humans.Infrastructure/Data/Configurations/TeamConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/TeamConfiguration.cs
@@ -39,7 +39,8 @@ public class TeamConfiguration : IEntityTypeConfiguration<Team>
 
         builder.Property(t => t.RequiresApproval)
             .IsRequired()
-            .HasDefaultValue(true);
+            .HasDefaultValue(true)
+            .HasSentinel(true);
 
         builder.Property(t => t.SystemTeamType)
             .IsRequired()
@@ -59,12 +60,12 @@ public class TeamConfiguration : IEntityTypeConfiguration<Team>
             .HasMaxLength(256);
 
         builder.Property(t => t.IsPublicPage)
-            .IsRequired()
-            .HasDefaultValue(false);
+            .IsRequired();
 
         builder.Property(t => t.ShowCoordinatorsOnPublicPage)
             .IsRequired()
-            .HasDefaultValue(true);
+            .HasDefaultValue(true)
+            .HasSentinel(true);
 
         builder.Property(t => t.HasBudget)
             .IsRequired();

--- a/src/Humans.Infrastructure/Data/Migrations/20260404012716_FixBoolSentinelDefaults.Designer.cs
+++ b/src/Humans.Infrastructure/Data/Migrations/20260404012716_FixBoolSentinelDefaults.Designer.cs
@@ -3,18 +3,21 @@ using System;
 using Humans.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 #nullable disable
 
-namespace Humans.Infrastructure.Migrations
+namespace Humans.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(HumansDbContext))]
-    partial class HumansDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260404012716_FixBoolSentinelDefaults")]
+    partial class FixBoolSentinelDefaults
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Humans.Infrastructure/Data/Migrations/20260404012716_FixBoolSentinelDefaults.cs
+++ b/src/Humans.Infrastructure/Data/Migrations/20260404012716_FixBoolSentinelDefaults.cs
@@ -1,0 +1,54 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Humans.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class FixBoolSentinelDefaults : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<bool>(
+                name: "IsPublicPage",
+                table: "teams",
+                type: "boolean",
+                nullable: false,
+                oldClrType: typeof(bool),
+                oldType: "boolean",
+                oldDefaultValue: false);
+
+            migrationBuilder.AlterColumn<bool>(
+                name: "IsAllDay",
+                table: "shifts",
+                type: "boolean",
+                nullable: false,
+                oldClrType: typeof(bool),
+                oldType: "boolean",
+                oldDefaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<bool>(
+                name: "IsPublicPage",
+                table: "teams",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false,
+                oldClrType: typeof(bool),
+                oldType: "boolean");
+
+            migrationBuilder.AlterColumn<bool>(
+                name: "IsAllDay",
+                table: "shifts",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false,
+                oldClrType: typeof(bool),
+                oldType: "boolean");
+        }
+    }
+}

--- a/src/Humans.Infrastructure/Services/ShiftSignupService.cs
+++ b/src/Humans.Infrastructure/Services/ShiftSignupService.cs
@@ -682,6 +682,7 @@ public class ShiftSignupService : IShiftSignupService
         var signups = await _dbContext.ShiftSignups
             .Include(s => s.Shift).ThenInclude(s => s.Rota).ThenInclude(r => r.EventSettings)
             .Include(s => s.Shift).ThenInclude(s => s.Rota).ThenInclude(r => r.Team)
+            .Include(s => s.Shift).ThenInclude(s => s.ShiftSignups)
             .Where(s => s.SignupBlockId == signupBlockId &&
                         (s.Status == SignupStatus.Confirmed || s.Status == SignupStatus.Pending))
             .ToListAsync();

--- a/src/Humans.Web/Views/Finance/Admin.cshtml
+++ b/src/Humans.Web/Views/Finance/Admin.cshtml
@@ -92,7 +92,7 @@
                     </form>
                     <form asp-action="DeleteYear" asp-route-id="@budgetYear.Id" method="post" class="d-inline">
                         @Html.AntiForgeryToken()
-                        <button type="submit" class="btn btn-outline-danger btn-sm" onclick="return confirm('Archive this budget year? It will be hidden from non-admin views but audit logs will be preserved.')">
+                        <button type="submit" class="btn btn-outline-danger btn-sm" data-confirm="Archive this budget year? It will be hidden from non-admin views but audit logs will be preserved.">
                             <i class="fa-solid fa-box-archive me-1"></i>Archive
                         </button>
                     </form>
@@ -102,7 +102,7 @@
                     <form asp-action="UpdateYearStatus" asp-route-id="@budgetYear.Id" method="post" class="d-inline">
                         @Html.AntiForgeryToken()
                         <input type="hidden" name="status" value="@BudgetYearStatus.Closed" />
-                        <button type="submit" class="btn btn-warning btn-sm" onclick="return confirm('Close this budget year? It will become read-only.')">
+                        <button type="submit" class="btn btn-warning btn-sm" data-confirm="Close this budget year? It will become read-only.">
                             <i class="fa-solid fa-lock me-1"></i>Close
                         </button>
                     </form>
@@ -118,7 +118,7 @@
                     </form>
                     <form asp-action="DeleteYear" asp-route-id="@budgetYear.Id" method="post" class="d-inline">
                         @Html.AntiForgeryToken()
-                        <button type="submit" class="btn btn-outline-danger btn-sm" onclick="return confirm('Archive this budget year? It will be hidden from non-admin views but audit logs will be preserved.')">
+                        <button type="submit" class="btn btn-outline-danger btn-sm" data-confirm="Archive this budget year? It will be hidden from non-admin views but audit logs will be preserved.">
                             <i class="fa-solid fa-box-archive me-1"></i>Archive
                         </button>
                     </form>
@@ -172,7 +172,7 @@
                             {
                                 <form asp-action="DeleteGroup" asp-route-id="@group.Id" method="post" class="d-inline">
                                     @Html.AntiForgeryToken()
-                                    <button type="submit" class="btn btn-outline-danger btn-sm py-0" onclick="return confirm('Delete this group and all its categories?')">
+                                    <button type="submit" class="btn btn-outline-danger btn-sm py-0" data-confirm="Delete this group and all its categories?">
                                         <i class="fa-solid fa-trash"></i>
                                     </button>
                                 </form>


### PR DESCRIPTION
## Summary
- Replace `onclick="return confirm(...)"` with `data-confirm="..."` in Finance/Admin.cshtml — CSP blocks inline event handlers, so confirmation dialogs were silently not firing
- Add missing `.Include(s => s.Shift).ThenInclude(s => s.ShiftSignups)` to `BailRangeAsync` — `CheckAndNotifyCoverageGapAsync` accessed `shift.ShiftSignups` without it being loaded
- Remove `HasDefaultValue(false)` from `ShiftConfiguration.IsAllDay` and `TeamConfiguration.IsPublicPage` (EF bool sentinel trap)
- Add `HasSentinel(true)` to `TeamConfiguration.RequiresApproval` and `ShowCoordinatorsOnPublicPage` so explicitly setting `false` is persisted

## Test plan
- [x] `/Finance/Admin`: click Close on the 2026 budget year — browser confirmation dialog should appear (currently broken by CSP). Archive and delete-group buttons use the same fix but require Draft/Closed years or non-department groups to be visible.
- [ ] Shift bail range: bailing a block triggers coverage gap notifications to coordinators
- [x] Create a team with `RequiresApproval = false` and verify it persists
- [ ] Verify `IsPublicPage = false` persists correctly on team update

🤖 Generated with [Claude Code](https://claude.com/claude-code)