### PR TITLE
Fix code review findings: CSP, sync error handling, email link sync

### DIFF
--- a/src/Humans.Infrastructure/Services/GoogleAdminService.cs
+++ b/src/Humans.Infrastructure/Services/GoogleAdminService.cs
@@ -1,9 +1,12 @@
 using Humans.Application.Helpers;
 using Humans.Application.Interfaces;
+using Humans.Domain.Constants;
+using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Humans.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using NodaTime;
 
 namespace Humans.Infrastructure.Services;
 
@@ -18,6 +21,7 @@ public class GoogleAdminService : IGoogleAdminService
     private readonly IGoogleSyncService _googleSyncService;
     private readonly IUserEmailService _userEmailService;
     private readonly IAuditLogService _auditLogService;
+    private readonly IClock _clock;
     private readonly ILogger<GoogleAdminService> _logger;
 
     private const string NobodiesTeamDomain = "nobodies.team";
@@ -28,6 +32,7 @@ public class GoogleAdminService : IGoogleAdminService
         IGoogleSyncService googleSyncService,
         IUserEmailService userEmailService,
         IAuditLogService auditLogService,
+        IClock clock,
         ILogger<GoogleAdminService> logger)
     {
         _dbContext = dbContext;
@@ -35,6 +40,7 @@ public class GoogleAdminService : IGoogleAdminService
         _googleSyncService = googleSyncService;
         _userEmailService = userEmailService;
         _auditLogService = auditLogService;
+        _clock = clock;
         _logger = logger;
     }
 
@@ -256,9 +262,39 @@ public class GoogleAdminService : IGoogleAdminService
             // Add as verified email (also sets notification target for @nobodies.team)
             await _userEmailService.AddVerifiedEmailAsync(userId, email, ct);
 
-            // Auto-set as Google service email
+            // Auto-set as Google service email and reset sync state
             user.GoogleEmail = email;
+            user.GoogleEmailStatus = GoogleEmailStatus.Unknown;
             await _dbContext.SaveChangesAsync(ct);
+
+            // Enqueue re-sync for all current team memberships
+            var memberships = await _dbContext.TeamMembers
+                .Where(tm => tm.UserId == userId && tm.LeftAt == null)
+                .Select(tm => new { tm.Id, tm.TeamId })
+                .ToListAsync(ct);
+
+            var now = _clock.GetCurrentInstant();
+            foreach (var membership in memberships)
+            {
+                var dedupeKey = $"{membership.Id}:{GoogleSyncOutboxEventTypes.AddUserToTeamResources}:link:{now}";
+                _dbContext.GoogleSyncOutboxEvents.Add(new GoogleSyncOutboxEvent
+                {
+                    Id = Guid.NewGuid(),
+                    EventType = GoogleSyncOutboxEventTypes.AddUserToTeamResources,
+                    TeamId = membership.TeamId,
+                    UserId = userId,
+                    OccurredAt = now,
+                    DeduplicationKey = dedupeKey
+                });
+            }
+
+            if (memberships.Count > 0)
+            {
+                await _dbContext.SaveChangesAsync(ct);
+                _logger.LogInformation(
+                    "Enqueued {Count} re-sync events for user {UserId} after admin email link",
+                    memberships.Count, userId);
+            }
 
             // Audit
             await _auditLogService.LogAsync(

--- a/src/Humans.Web/Controllers/GoogleController.cs
+++ b/src/Humans.Web/Controllers/GoogleController.cs
@@ -389,16 +389,32 @@ public class GoogleController : HumansControllerBase
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> SyncExecute(Guid resourceId)
     {
-        var result = await _googleSyncService.SyncSingleResourceAsync(resourceId, SyncAction.Execute);
-        return Json(result);
+        try
+        {
+            var result = await _googleSyncService.SyncSingleResourceAsync(resourceId, SyncAction.Execute);
+            return Json(result);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to execute sync for resource {ResourceId}", resourceId);
+            return Json(new { ErrorMessage = ex.Message });
+        }
     }
 
     [HttpPost("Sync/ExecuteAll/{resourceType}")]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> SyncExecuteAll(GoogleResourceType resourceType)
     {
-        var result = await _googleSyncService.SyncResourcesByTypeAsync(resourceType, SyncAction.Execute);
-        return Json(result);
+        try
+        {
+            var result = await _googleSyncService.SyncResourcesByTypeAsync(resourceType, SyncAction.Execute);
+            return Json(result);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to execute sync for resource type {ResourceType}", resourceType);
+            return Json(new { ErrorMessage = ex.Message });
+        }
     }
 
     // --- Drive Activity (from BoardController) ---

--- a/src/Humans.Web/Views/CampAdmin/Index.cshtml
+++ b/src/Humans.Web/Views/CampAdmin/Index.cshtml
@@ -271,7 +271,7 @@
     <div class="card-body">
         <p class="text-muted">Permanently delete a camp and all its seasons, images, and leads.</p>
         <form asp-controller="CampAdmin" asp-action="Delete" method="post" class="d-flex gap-2"
-              onsubmit="return confirm('Are you sure? This action cannot be undone.');">
+              data-confirm="Are you sure? This action cannot be undone.">
             @Html.AntiForgeryToken()
             <input type="text" name="campId" class="form-control form-control-sm" style="max-width: 320px;" placeholder="Camp ID (GUID)" required pattern="^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$" />
             <button type="submit" class="btn btn-danger btn-sm text-nowrap">

--- a/src/Humans.Web/Views/Finance/AuditLog.cshtml
+++ b/src/Humans.Web/Views/Finance/AuditLog.cshtml
@@ -21,7 +21,7 @@
             <form method="get" asp-action="AuditLog" class="row g-2 align-items-end">
                 <div class="col-auto">
                     <label class="form-label">Filter by Year</label>
-                    <select name="yearId" class="form-select" onchange="this.form.submit()">
+                    <select name="yearId" class="form-select js-auto-submit">
                         <option value="">All Years</option>
                         @foreach (var y in years)
                         {

--- a/src/Humans.Web/Views/Ticket/Index.cshtml
+++ b/src/Humans.Web/Views/Ticket/Index.cshtml
@@ -303,7 +303,7 @@
                 </button>
             </form>
             <form asp-action="FullResync" method="post" class="d-inline ms-2" authorize-policy="AdminOnly"
-                  onsubmit="return confirm('This will re-fetch ALL orders from the vendor. Continue?');">
+                  data-confirm="This will re-fetch ALL orders from the vendor. Continue?">
                 @Html.AntiForgeryToken()
                 <button type="submit" class="btn btn-sm btn-danger">
                     <i class="fa-solid fa-arrows-rotate"></i> Full Re-sync <i class="fa-solid fa-lock auth-lock-icon"></i>

--- a/src/Humans.Web/wwwroot/js/site.js
+++ b/src/Humans.Web/wwwroot/js/site.js
@@ -38,6 +38,13 @@ document.addEventListener('submit', function (e) {
     }
 });
 
+// Auto-submit forms when a .js-auto-submit element changes
+document.addEventListener('change', function (e) {
+    if (e.target.closest('.js-auto-submit') && e.target.form) {
+        e.target.form.submit();
+    }
+});
+
 // Clickable table rows via [data-href]
 document.addEventListener('click', function (e) {
     var row = e.target.closest('tr[data-href]');

--- a/tests/Humans.Application.Tests/Services/GoogleAdminServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/GoogleAdminServiceTests.cs
@@ -5,6 +5,8 @@ using Humans.Infrastructure.Data;
 using Humans.Infrastructure.Services;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
+using NodaTime;
+using NodaTime.Testing;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
@@ -41,6 +43,7 @@ public class GoogleAdminServiceTests : IDisposable
             _googleSyncService,
             _userEmailService,
             _auditLogService,
+            new FakeClock(Instant.FromUtc(2026, 1, 1, 0, 0)),
             NullLogger<GoogleAdminService>.Instance);
     }
 


### PR DESCRIPTION
## Summary
- **CSP inline handlers**: replaced `onsubmit`/`onchange` with `data-confirm` and `js-auto-submit` in Ticket/Index, Finance/AuditLog, CampAdmin/Index — same patterns already used across the codebase. Promoted `js-auto-submit` handler to `site.js` as a global delegated listener.
- **Google sync AJAX error handling**: wrapped `SyncExecute` and `SyncExecuteAll` in try-catch so DB/API failures return JSON errors instead of HTML 500 pages.
- **Admin email link sync state**: `GoogleAdminService.LinkAccountAsync` now resets `GoogleEmailStatus` to `Unknown` and enqueues `AddUserToTeamResources` outbox events for all active team memberships — matching the self-service email change path in `ProfileController`.

## Test plan
- [x] All 886 tests pass
- [x] `dotnet format --verify-no-changes` clean
- [ ] Verify confirm dialogs work on Ticket/Index (Full Re-sync), CampAdmin/Index (Delete), Finance/AuditLog (year filter auto-submits)
- [ ] Trigger a sync execute failure and verify JSON error response in browser devtools
- [ ] Admin-link a workspace email for a user with team memberships, verify outbox events appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)