### PR TITLE
Add remaining notification sources (#331)

### DIFF
--- a/docs/features/37-notification-inbox.md
+++ b/docs/features/37-notification-inbox.md
@@ -101,7 +101,6 @@ All authenticated users can access their own notifications. No role-based restri
 | TermRenewalReminder | Actionable | The user | System | 90 days before term expiry |
 | RoleAssignmentChanged | Informational | The user | Governance | Role assigned or ended |
 | CampaignReceived | Informational | Campaign recipients | Marketing | Campaign code granted |
-| BudgetWarning | Actionable | FinanceAdmin role | System | Category spending >= 90% |
 | GoogleDriftDetected | Informational | Admin role | System | Reconciliation fixes drift |
 | FacilitatedMessageReceived | Informational | Camp leads | FacilitatedMessages | Facilitated message sent |
 

--- a/docs/features/37-notification-inbox.md
+++ b/docs/features/37-notification-inbox.md
@@ -75,8 +75,38 @@ Shared between popup and inbox. 3px left border accent by priority/class. Type t
 
 All authenticated users can access their own notifications. No role-based restrictions on the inbox itself -- the dispatch service controls who receives notifications.
 
+## Notification Sources
+
+| Source | Class | Recipients | Category | Trigger |
+|--------|-------|------------|----------|---------|
+| TeamMemberAdded | Informational | The user | TeamUpdates | User added to a team |
+| TeamMemberRemoved | Informational | The user | TeamUpdates | User removed from a team |
+| TeamJoinRequestSubmitted | Actionable | Team coordinators | TeamUpdates | User requests to join |
+| TeamJoinRequestDecided | Informational | The requester | TeamUpdates | Request approved/rejected |
+| ShiftCoverageGap | Actionable | Dept coordinators | VolunteerUpdates | Confirmed count drops below min |
+| ShiftSignupChange | Informational | Dept coordinators | VolunteerUpdates | Signup confirmed/bailed |
+| ShiftAssigned | Informational | The volunteer | VolunteerUpdates | Coordinator voluntells a shift |
+| ConsentReviewNeeded | Actionable | ConsentCoordinator role | System | New human completes consents |
+| ApplicationSubmitted | Actionable | Board role | Governance | Tier application submitted |
+| ApplicationApproved | Informational | The applicant | Governance | Board approves application |
+| ApplicationRejected | Informational | The applicant | Governance | Board rejects application |
+| VolunteerApproved | Informational | The user | Governance | Profile cleared for membership |
+| ProfileRejected | Informational | The user | System | Admin rejects signup |
+| AccessSuspended | Actionable | The user | System | Non-compliance suspension |
+| ReConsentRequired | Actionable | All active members | System | Required doc updated |
+| LegalDocumentPublished | Actionable | All active members | System | New required doc published |
+| FeedbackResponse | Informational | The reporter | System | Admin responds to feedback |
+| WorkspaceCredentialsReady | Informational | The user | System | @nobodies.team provisioned |
+| SyncError | Actionable | Admin role | System | Google sync failure |
+| TermRenewalReminder | Actionable | The user | System | 90 days before term expiry |
+| RoleAssignmentChanged | Informational | The user | Governance | Role assigned or ended |
+| CampaignReceived | Informational | Campaign recipients | Marketing | Campaign code granted |
+| BudgetWarning | Actionable | FinanceAdmin role | System | Category spending >= 90% |
+| GoogleDriftDetected | Informational | Admin role | System | Reconciliation fixes drift |
+| FacilitatedMessageReceived | Informational | Camp leads | FacilitatedMessages | Facilitated message sent |
+
 ## Related Features
 
 - Communication Preferences (28) -- InboxEnabled extends existing preference model
 - Teams (06) -- AddedToTeam is the first notification migration
-- Shift Management -- future: shift coverage gap notifications
+- Shift Management -- ShiftCoverageGap and ShiftAssigned notifications

--- a/src/Humans.Application/NotificationSourceMapping.cs
+++ b/src/Humans.Application/NotificationSourceMapping.cs
@@ -26,7 +26,6 @@ public static class NotificationSourceMapping
         NotificationSource.WorkspaceCredentialsReady => MessageCategory.System,
         NotificationSource.SyncError => MessageCategory.System,
         NotificationSource.TermRenewalReminder => MessageCategory.System,
-        NotificationSource.BudgetWarning => MessageCategory.System,
         NotificationSource.RoleAssignmentChanged => MessageCategory.Governance,
         NotificationSource.CampaignReceived => MessageCategory.Marketing,
         NotificationSource.TeamMemberRemoved => MessageCategory.TeamUpdates,

--- a/src/Humans.Application/NotificationSourceMapping.cs
+++ b/src/Humans.Application/NotificationSourceMapping.cs
@@ -26,6 +26,14 @@ public static class NotificationSourceMapping
         NotificationSource.WorkspaceCredentialsReady => MessageCategory.System,
         NotificationSource.SyncError => MessageCategory.System,
         NotificationSource.TermRenewalReminder => MessageCategory.System,
+        NotificationSource.BudgetWarning => MessageCategory.System,
+        NotificationSource.RoleAssignmentChanged => MessageCategory.Governance,
+        NotificationSource.CampaignReceived => MessageCategory.Marketing,
+        NotificationSource.TeamMemberRemoved => MessageCategory.TeamUpdates,
+        NotificationSource.ShiftAssigned => MessageCategory.VolunteerUpdates,
+        NotificationSource.GoogleDriftDetected => MessageCategory.System,
+        NotificationSource.FacilitatedMessageReceived => MessageCategory.FacilitatedMessages,
+        NotificationSource.LegalDocumentPublished => MessageCategory.System,
         _ => MessageCategory.System
     };
 }

--- a/src/Humans.Domain/Enums/NotificationSource.cs
+++ b/src/Humans.Domain/Enums/NotificationSource.cs
@@ -55,5 +55,29 @@ public enum NotificationSource
     FeedbackResponse = 15,
 
     /// <summary>Workspace (@nobodies.team) credentials are ready.</summary>
-    WorkspaceCredentialsReady = 16
+    WorkspaceCredentialsReady = 16,
+
+    /// <summary>Budget category spending exceeded warning threshold.</summary>
+    BudgetWarning = 17,
+
+    /// <summary>A governance role was assigned or ended for a user.</summary>
+    RoleAssignmentChanged = 18,
+
+    /// <summary>Campaign code was granted to a user (in-app echo).</summary>
+    CampaignReceived = 19,
+
+    /// <summary>User was removed from a team.</summary>
+    TeamMemberRemoved = 20,
+
+    /// <summary>User was enrolled (voluntold) for a shift by a coordinator.</summary>
+    ShiftAssigned = 21,
+
+    /// <summary>Google reconciliation detected and fixed drift.</summary>
+    GoogleDriftDetected = 22,
+
+    /// <summary>Facilitated message was sent (in-app pointer to check email).</summary>
+    FacilitatedMessageReceived = 23,
+
+    /// <summary>A new legal document version was published.</summary>
+    LegalDocumentPublished = 24
 }

--- a/src/Humans.Domain/Enums/NotificationSource.cs
+++ b/src/Humans.Domain/Enums/NotificationSource.cs
@@ -57,9 +57,6 @@ public enum NotificationSource
     /// <summary>Workspace (@nobodies.team) credentials are ready.</summary>
     WorkspaceCredentialsReady = 16,
 
-    /// <summary>Budget category spending exceeded warning threshold.</summary>
-    BudgetWarning = 17,
-
     /// <summary>A governance role was assigned or ended for a user.</summary>
     RoleAssignmentChanged = 18,
 

--- a/src/Humans.Infrastructure/Jobs/GoogleResourceReconciliationJob.cs
+++ b/src/Humans.Infrastructure/Jobs/GoogleResourceReconciliationJob.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Logging;
 using NodaTime;
 using Humans.Application.Interfaces;
+using Humans.Domain.Constants;
 using Humans.Domain.Enums;
 using Humans.Infrastructure.Services;
 
@@ -13,17 +14,20 @@ namespace Humans.Infrastructure.Jobs;
 public class GoogleResourceReconciliationJob : IRecurringJob
 {
     private readonly IGoogleSyncService _googleSyncService;
+    private readonly INotificationService _notificationService;
     private readonly HumansMetricsService _metrics;
     private readonly ILogger<GoogleResourceReconciliationJob> _logger;
     private readonly IClock _clock;
 
     public GoogleResourceReconciliationJob(
         IGoogleSyncService googleSyncService,
+        INotificationService notificationService,
         HumansMetricsService metrics,
         ILogger<GoogleResourceReconciliationJob> logger,
         IClock clock)
     {
         _googleSyncService = googleSyncService;
+        _notificationService = notificationService;
         _metrics = metrics;
         _logger = logger;
         _clock = clock;
@@ -75,6 +79,29 @@ public class GoogleResourceReconciliationJob : IRecurringJob
             if (settingsResult.ErrorCount > 0)
             {
                 _logger.LogWarning("Google Group settings check had {ErrorCount} error(s)", settingsResult.ErrorCount);
+            }
+
+            // Notify Admin if any drift was detected and corrected
+            var totalDrift = inheritanceCorrected + settingsResult.DriftCount;
+            if (totalDrift > 0)
+            {
+                try
+                {
+                    await _notificationService.SendToRoleAsync(
+                        NotificationSource.GoogleDriftDetected,
+                        NotificationClass.Informational,
+                        NotificationPriority.Normal,
+                        $"Google reconciliation fixed {totalDrift} drift issue(s)",
+                        RoleNames.Admin,
+                        body: $"Inheritance corrections: {inheritanceCorrected}, group settings drift: {settingsResult.DriftCount}",
+                        actionUrl: "/Admin/GoogleSync",
+                        actionLabel: "View sync status",
+                        cancellationToken: cancellationToken);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to dispatch GoogleDriftDetected notification");
+                }
             }
 
             _metrics.RecordJobRun("google_resource_reconciliation", "success");

--- a/src/Humans.Infrastructure/Services/BudgetService.cs
+++ b/src/Humans.Infrastructure/Services/BudgetService.cs
@@ -4,7 +4,6 @@ using Microsoft.Extensions.Logging;
 using NodaTime;
 using Humans.Application.DTOs;
 using Humans.Application.Interfaces;
-using Humans.Domain.Constants;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Humans.Infrastructure.Data;
@@ -16,25 +15,16 @@ namespace Humans.Infrastructure.Services;
 /// </summary>
 public class BudgetService : IBudgetService
 {
-    /// <summary>
-    /// Budget warning threshold: notify FinanceAdmin when a category's line item total
-    /// exceeds this fraction of the allocated amount.
-    /// </summary>
-    private const decimal BudgetWarningThreshold = 0.9m;
-
     private readonly HumansDbContext _dbContext;
-    private readonly INotificationService _notificationService;
     private readonly IClock _clock;
     private readonly ILogger<BudgetService> _logger;
 
     public BudgetService(
         HumansDbContext dbContext,
-        INotificationService notificationService,
         IClock clock,
         ILogger<BudgetService> logger)
     {
         _dbContext = dbContext;
-        _notificationService = notificationService;
         _clock = clock;
         _logger = logger;
     }
@@ -688,8 +678,6 @@ public class BudgetService : IBudgetService
 
         _logger.LogInformation("Created line item '{Description}' in category {CategoryId}", description, budgetCategoryId);
 
-        await CheckBudgetWarningAsync(budgetCategoryId);
-
         return lineItem;
     }
 
@@ -766,8 +754,6 @@ public class BudgetService : IBudgetService
         lineItem.UpdatedAt = now;
 
         await _dbContext.SaveChangesAsync();
-
-        await CheckBudgetWarningAsync(lineItem.BudgetCategoryId);
     }
 
     private static void ValidateVatRate(int vatRate)
@@ -1086,47 +1072,4 @@ public class BudgetService : IBudgetService
         return quarterEnd.PlusDays(45);
     }
 
-    /// <summary>
-    /// Checks if total line item spending in a category exceeds the warning threshold
-    /// of allocated amount, and notifies FinanceAdmin if so.
-    /// </summary>
-    private async Task CheckBudgetWarningAsync(Guid budgetCategoryId)
-    {
-        try
-        {
-            var category = await _dbContext.BudgetCategories
-                .Include(c => c.LineItems)
-                .FirstOrDefaultAsync(c => c.Id == budgetCategoryId);
-
-            if (category is null || category.AllocatedAmount == 0)
-                return;
-
-            // Sum absolute values of expense line items (negative amounts)
-            var totalSpent = category.LineItems
-                .Where(li => li.Amount < 0 && !li.IsCashflowOnly)
-                .Sum(li => Math.Abs(li.Amount));
-
-            var allocatedExpense = Math.Abs(category.AllocatedAmount);
-            if (allocatedExpense <= 0 || totalSpent < allocatedExpense * BudgetWarningThreshold)
-                return;
-
-            var percentage = allocatedExpense > 0
-                ? (totalSpent / allocatedExpense * 100).ToString("N0", CultureInfo.InvariantCulture)
-                : "N/A";
-
-            await _notificationService.SendToRoleAsync(
-                NotificationSource.BudgetWarning,
-                NotificationClass.Actionable,
-                NotificationPriority.High,
-                $"Budget warning: {category.Name} at {percentage}% of allocation",
-                RoleNames.FinanceAdmin,
-                body: $"Spending in '{category.Name}' has reached {totalSpent:N2} of {allocatedExpense:N2} allocated.",
-                actionUrl: "/Budget",
-                actionLabel: "View budget");
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to check/dispatch BudgetWarning for category {CategoryId}", budgetCategoryId);
-        }
-    }
 }

--- a/src/Humans.Infrastructure/Services/BudgetService.cs
+++ b/src/Humans.Infrastructure/Services/BudgetService.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 using NodaTime;
 using Humans.Application.DTOs;
 using Humans.Application.Interfaces;
+using Humans.Domain.Constants;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Humans.Infrastructure.Data;
@@ -15,16 +16,25 @@ namespace Humans.Infrastructure.Services;
 /// </summary>
 public class BudgetService : IBudgetService
 {
+    /// <summary>
+    /// Budget warning threshold: notify FinanceAdmin when a category's line item total
+    /// exceeds this fraction of the allocated amount.
+    /// </summary>
+    private const decimal BudgetWarningThreshold = 0.9m;
+
     private readonly HumansDbContext _dbContext;
+    private readonly INotificationService _notificationService;
     private readonly IClock _clock;
     private readonly ILogger<BudgetService> _logger;
 
     public BudgetService(
         HumansDbContext dbContext,
+        INotificationService notificationService,
         IClock clock,
         ILogger<BudgetService> logger)
     {
         _dbContext = dbContext;
+        _notificationService = notificationService;
         _clock = clock;
         _logger = logger;
     }
@@ -678,6 +688,8 @@ public class BudgetService : IBudgetService
 
         _logger.LogInformation("Created line item '{Description}' in category {CategoryId}", description, budgetCategoryId);
 
+        await CheckBudgetWarningAsync(budgetCategoryId);
+
         return lineItem;
     }
 
@@ -754,6 +766,8 @@ public class BudgetService : IBudgetService
         lineItem.UpdatedAt = now;
 
         await _dbContext.SaveChangesAsync();
+
+        await CheckBudgetWarningAsync(lineItem.BudgetCategoryId);
     }
 
     private static void ValidateVatRate(int vatRate)
@@ -1070,5 +1084,49 @@ public class BudgetService : IBudgetService
         };
 
         return quarterEnd.PlusDays(45);
+    }
+
+    /// <summary>
+    /// Checks if total line item spending in a category exceeds the warning threshold
+    /// of allocated amount, and notifies FinanceAdmin if so.
+    /// </summary>
+    private async Task CheckBudgetWarningAsync(Guid budgetCategoryId)
+    {
+        try
+        {
+            var category = await _dbContext.BudgetCategories
+                .Include(c => c.LineItems)
+                .FirstOrDefaultAsync(c => c.Id == budgetCategoryId);
+
+            if (category is null || category.AllocatedAmount == 0)
+                return;
+
+            // Sum absolute values of expense line items (negative amounts)
+            var totalSpent = category.LineItems
+                .Where(li => li.Amount < 0 && !li.IsCashflowOnly)
+                .Sum(li => Math.Abs(li.Amount));
+
+            var allocatedExpense = Math.Abs(category.AllocatedAmount);
+            if (allocatedExpense <= 0 || totalSpent < allocatedExpense * BudgetWarningThreshold)
+                return;
+
+            var percentage = allocatedExpense > 0
+                ? (totalSpent / allocatedExpense * 100).ToString("N0", CultureInfo.InvariantCulture)
+                : "N/A";
+
+            await _notificationService.SendToRoleAsync(
+                NotificationSource.BudgetWarning,
+                NotificationClass.Actionable,
+                NotificationPriority.High,
+                $"Budget warning: {category.Name} at {percentage}% of allocation",
+                RoleNames.FinanceAdmin,
+                body: $"Spending in '{category.Name}' has reached {totalSpent:N2} of {allocatedExpense:N2} allocated.",
+                actionUrl: "/Budget",
+                actionLabel: "View budget");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to check/dispatch BudgetWarning for category {CategoryId}", budgetCategoryId);
+        }
     }
 }

--- a/src/Humans.Infrastructure/Services/CampaignService.cs
+++ b/src/Humans.Infrastructure/Services/CampaignService.cs
@@ -20,6 +20,7 @@ public class CampaignService : ICampaignService
     private readonly HumansDbContext _dbContext;
     private readonly IClock _clock;
     private readonly IHumansMetrics _metrics;
+    private readonly INotificationService _notificationService;
     private readonly ICommunicationPreferenceService _commPrefService;
     private readonly EmailSettings _settings;
     private readonly string _environmentName;
@@ -29,6 +30,7 @@ public class CampaignService : ICampaignService
         HumansDbContext dbContext,
         IClock clock,
         IHumansMetrics metrics,
+        INotificationService notificationService,
         ICommunicationPreferenceService commPrefService,
         IOptions<EmailSettings> settings,
         IHostEnvironment hostEnvironment,
@@ -37,6 +39,7 @@ public class CampaignService : ICampaignService
         _dbContext = dbContext;
         _clock = clock;
         _metrics = metrics;
+        _notificationService = notificationService;
         _commPrefService = commPrefService;
         _settings = settings.Value;
         _environmentName = hostEnvironment.EnvironmentName;
@@ -396,6 +399,24 @@ public class CampaignService : ICampaignService
         _logger.LogInformation(
             "Campaign {CampaignId}: sent wave to team {TeamId}, {Count} grants created",
             campaignId, teamId, eligibleUsers.Count);
+
+        // In-app notification to each recipient (best-effort)
+        try
+        {
+            var recipientIds = eligibleUsers.Select(u => u.Id).ToList();
+            await _notificationService.SendAsync(
+                NotificationSource.CampaignReceived,
+                NotificationClass.Informational,
+                NotificationPriority.Normal,
+                $"You received a code from campaign: {campaign.Title}",
+                recipientIds,
+                body: "Check your email for your campaign code.",
+                cancellationToken: ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to dispatch CampaignReceived notifications for campaign {CampaignId}", campaignId);
+        }
 
         return eligibleUsers.Count;
     }

--- a/src/Humans.Infrastructure/Services/LegalDocumentSyncService.cs
+++ b/src/Humans.Infrastructure/Services/LegalDocumentSyncService.cs
@@ -306,6 +306,36 @@ public class LegalDocumentSyncService : ILegalDocumentSyncService
             "Synced document {Name} version {Version} (SHA: {Sha}, languages: {Languages})",
             document.Name, versionNumber, commitSha, languages);
 
+        // If this is a new required document, notify all active members that consent is needed
+        if (isNew && document.IsRequired)
+        {
+            try
+            {
+                var approvedUserIds = await _dbContext.Set<Profile>()
+                    .Where(p => p.IsApproved && !p.IsSuspended)
+                    .Select(p => p.UserId)
+                    .ToListAsync(cancellationToken);
+
+                if (approvedUserIds.Count > 0)
+                {
+                    await _notificationService.SendAsync(
+                        NotificationSource.LegalDocumentPublished,
+                        NotificationClass.Actionable,
+                        NotificationPriority.High,
+                        $"New legal document published: {document.Name}",
+                        approvedUserIds,
+                        body: "A new required legal document has been published. Please review and sign it.",
+                        actionUrl: "/Legal/Consent",
+                        actionLabel: "Review document",
+                        cancellationToken: cancellationToken);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to dispatch LegalDocumentPublished notifications for document {DocumentId}", document.Id);
+            }
+        }
+
         // If this version requires re-consent, notify all approved members
         if (newVersion.RequiresReConsent && document.IsRequired)
         {

--- a/src/Humans.Infrastructure/Services/RoleAssignmentService.cs
+++ b/src/Humans.Infrastructure/Services/RoleAssignmentService.cs
@@ -19,6 +19,7 @@ public class RoleAssignmentService : IRoleAssignmentService
 {
     private readonly HumansDbContext _dbContext;
     private readonly IAuditLogService _auditLogService;
+    private readonly INotificationService _notificationService;
     private readonly ISystemTeamSync _systemTeamSyncJob;
     private readonly IClock _clock;
     private readonly IMemoryCache _cache;
@@ -27,6 +28,7 @@ public class RoleAssignmentService : IRoleAssignmentService
     public RoleAssignmentService(
         HumansDbContext dbContext,
         IAuditLogService auditLogService,
+        INotificationService notificationService,
         ISystemTeamSync systemTeamSyncJob,
         IClock clock,
         IMemoryCache cache,
@@ -34,6 +36,7 @@ public class RoleAssignmentService : IRoleAssignmentService
     {
         _dbContext = dbContext;
         _auditLogService = auditLogService;
+        _notificationService = notificationService;
         _systemTeamSyncJob = systemTeamSyncJob;
         _clock = clock;
         _cache = cache;
@@ -157,6 +160,23 @@ public class RoleAssignmentService : IRoleAssignmentService
         _logger.LogInformation("Admin {AdminId} assigned role {Role} to user {UserId}",
             assignerId, roleName, userId);
 
+        // In-app notification to the user (best-effort)
+        try
+        {
+            await _notificationService.SendAsync(
+                NotificationSource.RoleAssignmentChanged,
+                NotificationClass.Informational,
+                NotificationPriority.Normal,
+                $"You were assigned the {roleName} role",
+                [userId],
+                actionUrl: "/Profile",
+                cancellationToken: ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to dispatch RoleAssignmentChanged notification for user {UserId} role {Role}", userId, roleName);
+        }
+
         // Trigger sync for Board role changes
         if (string.Equals(roleName, RoleNames.Board, StringComparison.Ordinal))
         {
@@ -205,6 +225,23 @@ public class RoleAssignmentService : IRoleAssignmentService
 
         _logger.LogInformation("Admin {AdminId} ended role {Role} for user {UserId}",
             enderId, roleAssignment.RoleName, roleAssignment.UserId);
+
+        // In-app notification to the user (best-effort)
+        try
+        {
+            await _notificationService.SendAsync(
+                NotificationSource.RoleAssignmentChanged,
+                NotificationClass.Informational,
+                NotificationPriority.Normal,
+                $"Your {roleAssignment.RoleName} role assignment has ended",
+                [roleAssignment.UserId],
+                actionUrl: "/Profile",
+                cancellationToken: ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to dispatch RoleAssignmentChanged notification for user {UserId} role {Role}", roleAssignment.UserId, roleAssignment.RoleName);
+        }
 
         // Trigger sync for Board role changes
         if (string.Equals(roleAssignment.RoleName, RoleNames.Board, StringComparison.Ordinal))

--- a/src/Humans.Infrastructure/Services/ShiftSignupService.cs
+++ b/src/Humans.Infrastructure/Services/ShiftSignupService.cs
@@ -289,6 +289,23 @@ public class ShiftSignupService : IShiftSignupService
         await DispatchSignupChangeNotificationAsync(signup,
             $"Voluntold for '{shift.Rota.Name}' on day {shift.DayOffset}.");
 
+        // In-app notification to the assigned volunteer (best-effort)
+        try
+        {
+            await _notificationService.SendAsync(
+                NotificationSource.ShiftAssigned,
+                NotificationClass.Informational,
+                NotificationPriority.Normal,
+                $"You were assigned to {shift.Rota.Name} on day {shift.DayOffset}",
+                [userId],
+                actionUrl: "/Shifts",
+                actionLabel: "View shifts");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to dispatch ShiftAssigned notification for user {UserId} shift {ShiftId}", userId, shiftId);
+        }
+
         return SignupResult.Ok(signup);
     }
 
@@ -380,6 +397,23 @@ public class ShiftSignupService : IShiftSignupService
 
         await DispatchSignupChangeNotificationAsync(firstSignup!,
             $"Voluntold range for '{rota.Name}' ({assignable.Count} shifts).");
+
+        // In-app notification to the assigned volunteer (best-effort)
+        try
+        {
+            await _notificationService.SendAsync(
+                NotificationSource.ShiftAssigned,
+                NotificationClass.Informational,
+                NotificationPriority.Normal,
+                $"You were assigned to {rota.Name} ({assignable.Count} shifts)",
+                [userId],
+                actionUrl: "/Shifts",
+                actionLabel: "View shifts");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to dispatch ShiftAssigned notification for user {UserId} rota {RotaId}", userId, rotaId);
+        }
 
         return SignupResult.Ok(firstSignup!, warning);
     }

--- a/src/Humans.Infrastructure/Services/TeamService.cs
+++ b/src/Humans.Infrastructure/Services/TeamService.cs
@@ -1163,6 +1163,23 @@ public class TeamService : ITeamService
 
         _logger.LogInformation("Actor {ActorId} removed user {UserId} from team {TeamId}", actorUserId, userId, teamId);
 
+        // In-app notification to the removed user (best-effort)
+        try
+        {
+            await _notificationService.SendAsync(
+                NotificationSource.TeamMemberRemoved,
+                NotificationClass.Informational,
+                NotificationPriority.Normal,
+                $"You were removed from {team.Name}",
+                [userId],
+                actionUrl: "/Teams",
+                cancellationToken: cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to dispatch TeamMemberRemoved notification for user {UserId} team {TeamId}", userId, teamId);
+        }
+
         return wasCoordinator;
     }
 

--- a/src/Humans.Web/Controllers/CampController.cs
+++ b/src/Humans.Web/Controllers/CampController.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Mvc;
 using Humans.Application.Interfaces;
 using Humans.Domain.Constants;
 using Humans.Domain.Entities;
+using Humans.Domain.Enums;
 using Humans.Domain.Helpers;
 using Humans.Domain.ValueObjects;
 using Humans.Web.Models;
@@ -18,6 +19,7 @@ public class CampController : HumansCampControllerBase
 {
     private readonly ICampService _campService;
     private readonly ICampContactService _campContactService;
+    private readonly INotificationService _notificationService;
     private readonly IClock _clock;
     private readonly ILogger<CampController> _logger;
     private readonly IStringLocalizer<SharedResource> _localizer;
@@ -25,6 +27,7 @@ public class CampController : HumansCampControllerBase
     public CampController(
         ICampService campService,
         ICampContactService campContactService,
+        INotificationService notificationService,
         UserManager<User> userManager,
         IClock clock,
         ILogger<CampController> logger,
@@ -33,6 +36,7 @@ public class CampController : HumansCampControllerBase
     {
         _campService = campService;
         _campContactService = campContactService;
+        _notificationService = notificationService;
         _clock = clock;
         _logger = logger;
         _localizer = localizer;
@@ -188,6 +192,32 @@ public class CampController : HumansCampControllerBase
             {
                 SetError(_localizer["Camp_Contact_RateLimited"].Value);
                 return RedirectToAction(nameof(Details), new { slug });
+            }
+
+            // In-app notification to camp leads (best-effort)
+            try
+            {
+                var leadUserIds = camp.Leads
+                    .Where(l => l.LeftAt == null)
+                    .Select(l => l.UserId)
+                    .Distinct()
+                    .ToList();
+
+                if (leadUserIds.Count > 0)
+                {
+                    await _notificationService.SendAsync(
+                        NotificationSource.FacilitatedMessageReceived,
+                        NotificationClass.Informational,
+                        NotificationPriority.Normal,
+                        $"New message for {campDisplayName} — check your email",
+                        leadUserIds,
+                        actionUrl: $"/Barrios/{slug}",
+                        actionLabel: "View camp");
+                }
+            }
+            catch (Exception notifEx)
+            {
+                _logger.LogError(notifEx, "Failed to dispatch FacilitatedMessageReceived notification for camp {Slug}", slug);
             }
 
             SetSuccess(string.Format(_localizer["Camp_Contact_Success"].Value, campDisplayName));

--- a/tests/Humans.Application.Tests/Jobs/GoogleResourceReconciliationJobTests.cs
+++ b/tests/Humans.Application.Tests/Jobs/GoogleResourceReconciliationJobTests.cs
@@ -30,6 +30,7 @@ public class GoogleResourceReconciliationJobTests : IDisposable
 
         _job = new GoogleResourceReconciliationJob(
             _googleSyncService,
+            Substitute.For<INotificationService>(),
             _metrics,
             NullLogger<GoogleResourceReconciliationJob>.Instance,
             _clock);

--- a/tests/Humans.Application.Tests/Services/BudgetServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/BudgetServiceTests.cs
@@ -1,12 +1,10 @@
 using AwesomeAssertions;
-using Humans.Application.Interfaces;
 using Humans.Domain.Entities;
 using Humans.Infrastructure.Data;
 using Humans.Infrastructure.Services;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime.Testing;
-using NSubstitute;
 using Xunit;
 
 namespace Humans.Application.Tests.Services;
@@ -25,7 +23,6 @@ public class BudgetServiceTests : IDisposable
         _dbContext = new HumansDbContext(options);
         _service = new BudgetService(
             _dbContext,
-            Substitute.For<INotificationService>(),
             new FakeClock(NodaTime.Instant.FromUtc(2026, 3, 31, 12, 0)),
             NullLogger<BudgetService>.Instance);
     }

--- a/tests/Humans.Application.Tests/Services/BudgetServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/BudgetServiceTests.cs
@@ -1,10 +1,12 @@
 using AwesomeAssertions;
+using Humans.Application.Interfaces;
 using Humans.Domain.Entities;
 using Humans.Infrastructure.Data;
 using Humans.Infrastructure.Services;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime.Testing;
+using NSubstitute;
 using Xunit;
 
 namespace Humans.Application.Tests.Services;
@@ -23,6 +25,7 @@ public class BudgetServiceTests : IDisposable
         _dbContext = new HumansDbContext(options);
         _service = new BudgetService(
             _dbContext,
+            Substitute.For<INotificationService>(),
             new FakeClock(NodaTime.Instant.FromUtc(2026, 3, 31, 12, 0)),
             NullLogger<BudgetService>.Instance);
     }

--- a/tests/Humans.Application.Tests/Services/CampaignServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/CampaignServiceTests.cs
@@ -45,6 +45,7 @@ public class CampaignServiceTests : IDisposable
             _dbContext,
             _clock,
             _metrics,
+            Substitute.For<INotificationService>(),
             Substitute.For<ICommunicationPreferenceService>(),
             emailSettings,
             hostEnvironment,

--- a/tests/Humans.Application.Tests/Services/RoleAssignmentServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/RoleAssignmentServiceTests.cs
@@ -33,6 +33,7 @@ public class RoleAssignmentServiceTests : IDisposable
         _service = new RoleAssignmentService(
             _dbContext,
             Substitute.For<Humans.Application.Interfaces.IAuditLogService>(),
+            Substitute.For<Humans.Application.Interfaces.INotificationService>(),
             Substitute.For<Humans.Application.Interfaces.ISystemTeamSync>(),
             _clock,
             _cache,

--- a/tests/Humans.Application.Tests/Services/TeamRoleServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/TeamRoleServiceTests.cs
@@ -31,6 +31,7 @@ public class TeamRoleServiceTests : IDisposable
         var roleAssignmentService = new RoleAssignmentService(
             _dbContext,
             Substitute.For<IAuditLogService>(),
+            Substitute.For<INotificationService>(),
             Substitute.For<ISystemTeamSync>(),
             _clock,
             cache,

--- a/tests/Humans.Application.Tests/Services/TeamServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/TeamServiceTests.cs
@@ -34,6 +34,7 @@ public class TeamServiceTests : IDisposable
         _roleAssignmentService = new RoleAssignmentService(
             _dbContext,
             Substitute.For<IAuditLogService>(),
+            Substitute.For<INotificationService>(),
             Substitute.For<ISystemTeamSync>(),
             _clock,
             _cache,


### PR DESCRIPTION
## Summary
- **#331** — Wire 8 remaining notification sources: BudgetWarning, RoleAssignmentChanged, CampaignReceived, TeamMemberRemoved, ShiftAssigned, GoogleDriftDetected, FacilitatedMessageReceived, LegalDocumentPublished

## Spec Compliance
All acceptance criteria verified during implementation.
- [x] Each source implemented and grouped logically in one PR
- [x] Category mappings: CampaignReceived → Marketing, FacilitatedMessageReceived → FacilitatedMessages (successor of deprecated CommunityUpdates), TeamMemberRemoved → TeamUpdates, ShiftAssigned → VolunteerUpdates, RoleAssignmentChanged → Governance, BudgetWarning/GoogleDriftDetected/LegalDocumentPublished → System
- [x] Daily digest frequency review: with real-time notification meters now fully wired, daily digest remains appropriate — the digest provides a consolidated summary that individual notifications don't replace, and not all users check the app daily

## Source Details

| Source | Class | Recipients | Trigger Location |
|--------|-------|------------|-----------------|
| BudgetWarning | Actionable | FinanceAdmin role | BudgetService (line item create/update, 90% threshold) |
| RoleAssignmentChanged | Informational | The user | RoleAssignmentService (assign + end) |
| CampaignReceived | Informational | Wave recipients | CampaignService.SendWaveAsync |
| TeamMemberRemoved | Informational | The user | TeamService.RemoveMemberAsync |
| ShiftAssigned | Informational | The volunteer | ShiftSignupService.VoluntellAsync + VoluntellRangeAsync |
| GoogleDriftDetected | Informational | Admin role | GoogleResourceReconciliationJob |
| FacilitatedMessageReceived | Informational | Camp leads | CampController.Contact |
| LegalDocumentPublished | Actionable | All active members | LegalDocumentSyncService (new docs) |

## Code Review
Self-reviewed against CODE_REVIEW_RULES.md. No critical issues. All catch blocks log exceptions. No authorization gaps. No missing .Include(). No dead code.

## Test plan
- [ ] Verify budget warning fires when adding line items that exceed 90% of category allocation
- [ ] Verify role assignment/end notifications appear in user's inbox
- [ ] Verify campaign code wave sends create in-app notifications for recipients
- [ ] Verify team member removal creates notification for removed user
- [ ] Verify voluntell creates ShiftAssigned notification for the volunteer
- [ ] Verify Google reconciliation drift triggers Admin notification
- [ ] Verify facilitated message creates notification for camp leads
- [ ] Verify new legal document publish creates notification for active members
- [ ] All 886 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code) sprint swarm