### PR TITLE
Migrate Tickets + Finance controllers to policy-based auth (#371)

### DIFF
--- a/src/Humans.Web/Controllers/BudgetController.cs
+++ b/src/Humans.Web/Controllers/BudgetController.cs
@@ -17,17 +17,20 @@ public class BudgetController : HumansControllerBase
 {
     private readonly IBudgetService _budgetService;
     private readonly HumansDbContext _dbContext;
+    private readonly IAuthorizationService _authService;
     private readonly ILogger<BudgetController> _logger;
 
     public BudgetController(
         IBudgetService budgetService,
         HumansDbContext dbContext,
+        IAuthorizationService authService,
         UserManager<User> userManager,
         ILogger<BudgetController> logger)
         : base(userManager)
     {
         _budgetService = budgetService;
         _dbContext = dbContext;
+        _authService = authService;
         _logger = logger;
     }
 
@@ -39,7 +42,7 @@ public class BudgetController : HumansControllerBase
             var (errorResult, user) = await RequireCurrentUserAsync();
             if (errorResult is not null) return errorResult;
 
-            var isFinanceAdmin = RoleChecks.IsFinanceAdmin(User);
+            var isFinanceAdmin = (await _authService.AuthorizeAsync(User, PolicyNames.FinanceAdminOrAdmin)).Succeeded;
             var coordinatorTeamIds = await _budgetService.GetEffectiveCoordinatorTeamIdsAsync(user.Id);
 
             if (!isFinanceAdmin && coordinatorTeamIds.Count == 0)
@@ -104,7 +107,7 @@ public class BudgetController : HumansControllerBase
                 TotalLineItems = totalLineItems,
                 IncomeSlices = summary.IncomeSlices.Select(s => new BudgetSlice { Name = s.Name, Amount = s.Amount, Percentage = s.Percentage }).ToList(),
                 ExpenseSlices = summary.ExpenseSlices.Select(s => new BudgetSlice { Name = s.Name, Amount = s.Amount, Percentage = s.Percentage }).ToList(),
-                IsCoordinator = coordinatorTeamIds.Count > 0 || RoleChecks.IsFinanceAdmin(User)
+                IsCoordinator = coordinatorTeamIds.Count > 0 || (await _authService.AuthorizeAsync(User, PolicyNames.FinanceAdminOrAdmin)).Succeeded
             };
             return View(model);
         }
@@ -128,7 +131,7 @@ public class BudgetController : HumansControllerBase
             if (category is null) return NotFound();
 
             // Block access to restricted/ticketing groups for non-finance users
-            var isFinanceAdmin = RoleChecks.IsFinanceAdmin(User);
+            var isFinanceAdmin = (await _authService.AuthorizeAsync(User, PolicyNames.FinanceAdminOrAdmin)).Succeeded;
             if ((category.BudgetGroup?.IsRestricted == true || category.BudgetGroup?.IsTicketingGroup == true) && !isFinanceAdmin)
                 return Forbid();
 
@@ -244,7 +247,7 @@ public class BudgetController : HumansControllerBase
 
     private async Task<IActionResult?> AuthorizeCategoryEditAsync(Guid categoryId, Guid userId)
     {
-        if (RoleChecks.IsFinanceAdmin(User))
+        if ((await _authService.AuthorizeAsync(User, PolicyNames.FinanceAdminOrAdmin)).Succeeded)
             return null;
 
         var category = await _budgetService.GetCategoryByIdAsync(categoryId);

--- a/src/Humans.Web/Controllers/CampaignController.cs
+++ b/src/Humans.Web/Controllers/CampaignController.cs
@@ -5,9 +5,9 @@ using Microsoft.EntityFrameworkCore;
 using Humans.Application.DTOs;
 using Humans.Application.Interfaces;
 using Humans.Infrastructure.Data;
-using Humans.Domain.Constants;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
+using Humans.Web.Authorization;
 using Humans.Web.Models;
 
 namespace Humans.Web.Controllers;
@@ -33,7 +33,7 @@ public class CampaignController : HumansControllerBase
     }
 
     [HttpGet("")]
-    [Authorize(Roles = RoleNames.Admin)]
+    [Authorize(Policy = PolicyNames.AdminOnly)]
     public async Task<IActionResult> Index()
     {
         var campaigns = await _campaignService.GetAllAsync();
@@ -41,7 +41,7 @@ public class CampaignController : HumansControllerBase
     }
 
     [HttpGet("Create")]
-    [Authorize(Roles = RoleNames.Admin)]
+    [Authorize(Policy = PolicyNames.AdminOnly)]
     public IActionResult Create()
     {
         return View();
@@ -49,7 +49,7 @@ public class CampaignController : HumansControllerBase
 
     [HttpPost("Create")]
     [ValidateAntiForgeryToken]
-    [Authorize(Roles = RoleNames.Admin)]
+    [Authorize(Policy = PolicyNames.AdminOnly)]
     public async Task<IActionResult> Create(string title, string? description, string emailSubject, string emailBodyTemplate, string? replyToAddress)
     {
         if (string.IsNullOrWhiteSpace(title))
@@ -78,7 +78,7 @@ public class CampaignController : HumansControllerBase
     }
 
     [HttpGet("Edit/{id:guid}")]
-    [Authorize(Roles = RoleNames.Admin)]
+    [Authorize(Policy = PolicyNames.AdminOnly)]
     public async Task<IActionResult> Edit(Guid id)
     {
         var campaign = await _campaignService.GetByIdAsync(id);
@@ -88,7 +88,7 @@ public class CampaignController : HumansControllerBase
 
     [HttpPost("Edit/{id:guid}")]
     [ValidateAntiForgeryToken]
-    [Authorize(Roles = RoleNames.Admin)]
+    [Authorize(Policy = PolicyNames.AdminOnly)]
     public async Task<IActionResult> Edit(Guid id, string title, string? description, string emailSubject, string emailBodyTemplate, string? replyToAddress)
     {
         if (string.IsNullOrWhiteSpace(title))
@@ -133,7 +133,7 @@ public class CampaignController : HumansControllerBase
     }
 
     [HttpGet("{id:guid}")]
-    [Authorize(Roles = RoleGroups.TicketAdminOrAdmin)]
+    [Authorize(Policy = PolicyNames.TicketAdminOrAdmin)]
     public async Task<IActionResult> Detail(Guid id)
     {
         var page = await _campaignService.GetDetailPageAsync(id);
@@ -148,7 +148,7 @@ public class CampaignController : HumansControllerBase
 
     [HttpPost("{id:guid}/ImportCodes")]
     [ValidateAntiForgeryToken]
-    [Authorize(Roles = RoleNames.Admin)]
+    [Authorize(Policy = PolicyNames.AdminOnly)]
     public async Task<IActionResult> ImportCodes(Guid id, IFormFile file)
     {
         if (file is null || file.Length == 0)
@@ -178,7 +178,7 @@ public class CampaignController : HumansControllerBase
 
     [HttpPost("{id:guid}/GenerateCodes")]
     [ValidateAntiForgeryToken]
-    [Authorize(Roles = RoleGroups.TicketAdminOrAdmin)]
+    [Authorize(Policy = PolicyNames.TicketAdminOrAdmin)]
     public async Task<IActionResult> GenerateCodes(Guid id, int count, string discountType, decimal discountValue)
     {
         var campaign = await _campaignService.GetByIdAsync(id);
@@ -212,7 +212,7 @@ public class CampaignController : HumansControllerBase
 
     [HttpPost("{id:guid}/Activate")]
     [ValidateAntiForgeryToken]
-    [Authorize(Roles = RoleNames.Admin)]
+    [Authorize(Policy = PolicyNames.AdminOnly)]
     public async Task<IActionResult> Activate(Guid id)
     {
         await _campaignService.ActivateAsync(id);
@@ -222,7 +222,7 @@ public class CampaignController : HumansControllerBase
 
     [HttpPost("{id:guid}/Complete")]
     [ValidateAntiForgeryToken]
-    [Authorize(Roles = RoleNames.Admin)]
+    [Authorize(Policy = PolicyNames.AdminOnly)]
     public async Task<IActionResult> Complete(Guid id)
     {
         await _campaignService.CompleteAsync(id);
@@ -231,7 +231,7 @@ public class CampaignController : HumansControllerBase
     }
 
     [HttpGet("{id:guid}/SendWave")]
-    [Authorize(Roles = RoleNames.Admin)]
+    [Authorize(Policy = PolicyNames.AdminOnly)]
     public async Task<IActionResult> SendWave(Guid id, Guid? teamId)
     {
         var page = await _campaignService.GetSendWavePageAsync(id, teamId);
@@ -248,7 +248,7 @@ public class CampaignController : HumansControllerBase
 
     [HttpPost("{id:guid}/SendWave")]
     [ValidateAntiForgeryToken]
-    [Authorize(Roles = RoleNames.Admin)]
+    [Authorize(Policy = PolicyNames.AdminOnly)]
     public async Task<IActionResult> SendWave(Guid id, Guid teamId)
     {
         var sentCount = await _campaignService.SendWaveAsync(id, teamId);
@@ -258,7 +258,7 @@ public class CampaignController : HumansControllerBase
 
     [HttpPost("Grants/{grantId:guid}/Resend")]
     [ValidateAntiForgeryToken]
-    [Authorize(Roles = RoleNames.Admin)]
+    [Authorize(Policy = PolicyNames.AdminOnly)]
     public async Task<IActionResult> Resend(Guid grantId)
     {
         var campaignId = await _campaignService.GetCampaignIdForGrantAsync(grantId);
@@ -271,7 +271,7 @@ public class CampaignController : HumansControllerBase
 
     [HttpPost("{id:guid}/RetryAllFailed")]
     [ValidateAntiForgeryToken]
-    [Authorize(Roles = RoleNames.Admin)]
+    [Authorize(Policy = PolicyNames.AdminOnly)]
     public async Task<IActionResult> RetryAllFailed(Guid id)
     {
         await _campaignService.RetryAllFailedAsync(id);

--- a/src/Humans.Web/Controllers/FinanceController.cs
+++ b/src/Humans.Web/Controllers/FinanceController.cs
@@ -1,8 +1,8 @@
 using Humans.Application.Interfaces;
-using Humans.Domain.Constants;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Humans.Infrastructure.Data;
+using Humans.Web.Authorization;
 using Humans.Web.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
@@ -12,7 +12,7 @@ using NodaTime;
 
 namespace Humans.Web.Controllers;
 
-[Authorize(Roles = RoleGroups.FinanceAdminOrAdmin)]
+[Authorize(Policy = PolicyNames.FinanceAdminOrAdmin)]
 [Route("Finance")]
 public class FinanceController : HumansControllerBase
 {

--- a/src/Humans.Web/Controllers/TicketController.cs
+++ b/src/Humans.Web/Controllers/TicketController.cs
@@ -5,6 +5,7 @@ using Humans.Domain.Entities;
 using Humans.Infrastructure.Jobs;
 using Humans.Infrastructure.Services;
 using Humans.Web.Extensions;
+using Humans.Web.Authorization;
 using Humans.Web.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
@@ -13,7 +14,7 @@ using Microsoft.Extensions.Options;
 
 namespace Humans.Web.Controllers;
 
-[Authorize(Roles = RoleGroups.TicketAdminBoardOrAdmin)]
+[Authorize(Policy = PolicyNames.TicketAdminBoardOrAdmin)]
 [Route("Tickets")]
 public class TicketController : HumansControllerBase
 {
@@ -327,7 +328,7 @@ public class TicketController : HumansControllerBase
 
     [HttpPost("Sync")]
     [ValidateAntiForgeryToken]
-    [Authorize(Roles = RoleGroups.TicketAdminOrAdmin)]
+    [Authorize(Policy = PolicyNames.TicketAdminOrAdmin)]
     public IActionResult Sync()
     {
         BackgroundJob.Enqueue<TicketSyncJob>(job => job.ExecuteAsync(CancellationToken.None));
@@ -337,7 +338,7 @@ public class TicketController : HumansControllerBase
 
     [HttpPost("FullResync")]
     [ValidateAntiForgeryToken]
-    [Authorize(Roles = RoleNames.Admin)]
+    [Authorize(Policy = PolicyNames.AdminOnly)]
     public async Task<IActionResult> FullResync()
     {
         await _ticketSyncService.ResetSyncStateForFullResyncAsync();
@@ -348,7 +349,7 @@ public class TicketController : HumansControllerBase
     }
 
     [HttpGet("Export/Attendees")]
-    [Authorize(Roles = RoleGroups.TicketAdminOrAdmin)]
+    [Authorize(Policy = PolicyNames.TicketAdminOrAdmin)]
     public async Task<IActionResult> ExportAttendees()
     {
         var rows = await _ticketQueryService.GetAttendeeExportDataAsync();
@@ -365,7 +366,7 @@ public class TicketController : HumansControllerBase
     }
 
     [HttpGet("Export/Orders")]
-    [Authorize(Roles = RoleGroups.TicketAdminOrAdmin)]
+    [Authorize(Policy = PolicyNames.TicketAdminOrAdmin)]
     public async Task<IActionResult> ExportOrders()
     {
         var rows = await _ticketQueryService.GetOrderExportDataAsync();


### PR DESCRIPTION
## Summary
- **#371** — Replace `[Authorize(Roles = ...)]` with `[Authorize(Policy = ...)]` in TicketController, CampaignController, FinanceController. Replace `RoleChecks.IsFinanceAdmin(User)` in BudgetController with `IAuthorizationService` policy checks.

Phase 1, step 3 of the authorization transition plan. Follows #366/#368 (layout migration).

### Controllers migrated
| Controller | Changes |
|---|---|
| `TicketController` | 5 `[Authorize(Roles)]` → `[Authorize(Policy)]` |
| `CampaignController` | 14 `[Authorize(Roles)]` → `[Authorize(Policy)]` |
| `FinanceController` | 1 `[Authorize(Roles)]` → `[Authorize(Policy)]` |
| `BudgetController` | 4 `RoleChecks.IsFinanceAdmin()` → `IAuthorizationService` |

## Spec Compliance
All acceptance criteria verified:
- No `[Authorize(Roles = ...)]` remains in target controllers — PASS
- No `RoleChecks.*` calls remain in BudgetController — PASS
- All policy names use `PolicyNames.cs` constants — PASS
- No behavior change (same roles, same policies) — PASS
- Build passes clean — PASS

## Code Review
Self-reviewed against CODE_REVIEW_RULES.md. No critical issues.

## Test plan
- [ ] Verify TicketAdmin can access /Tickets (TicketAdminBoardOrAdmin policy)
- [ ] Verify Admin can trigger full resync (AdminOnly policy)
- [ ] Verify FinanceAdmin can access /Finance and /Budget edit operations
- [ ] Verify regular member cannot access any of the above
- [ ] Verify Board member can view /Tickets but not manage tickets

🤖 Generated with [Claude Code](https://claude.com/claude-code) sprint swarm