### PR TITLE
Sprint batch 3: Team page enhancements (#375, #374)

### DIFF
--- a/src/Humans.Application/Interfaces/IShiftManagementService.cs
+++ b/src/Humans.Application/Interfaces/IShiftManagementService.cs
@@ -181,6 +181,12 @@ public interface IShiftManagementService
         Guid eventSettingsId, Guid departmentTeamId);
 
     /// <summary>
+    /// Gets aggregated shifts summary across multiple teams. Returns null if no rotas.
+    /// </summary>
+    Task<ShiftsSummaryData?> GetShiftsSummaryForTeamsAsync(
+        Guid eventSettingsId, IReadOnlyList<Guid> teamIds);
+
+    /// <summary>
     /// Gets all parent teams that have active rotas in the given event.
     /// </summary>
     Task<IReadOnlyList<(Guid TeamId, string TeamName)>> GetDepartmentsWithRotasAsync(

--- a/src/Humans.Application/Interfaces/ITeamPageService.cs
+++ b/src/Humans.Application/Interfaces/ITeamPageService.cs
@@ -25,7 +25,8 @@ public record TeamPageShiftsSummary(
     int ConfirmedCount,
     int PendingCount,
     int UniqueVolunteerCount,
-    bool CanManageShifts);
+    bool CanManageShifts,
+    int IncludesSubTeamCount = 0);
 
 public record TeamPageDetailResult(
     Team Team,

--- a/src/Humans.Application/Interfaces/ITeamService.cs
+++ b/src/Humans.Application/Interfaces/ITeamService.cs
@@ -315,6 +315,15 @@ public interface ITeamService
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Gets the management role definition name for each team that has one.
+    /// </summary>
+    /// <param name="teamIds">The team IDs to check.</param>
+    /// <returns>Dictionary mapping team ID to the management role name.</returns>
+    Task<IReadOnlyDictionary<Guid, string>> GetManagementRoleNamesByTeamIdsAsync(
+        IEnumerable<Guid> teamIds,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Gets non-system team names for users, grouped by user ID.
     /// Used for birthday display.
     /// </summary>

--- a/src/Humans.Infrastructure/Services/ShiftManagementService.cs
+++ b/src/Humans.Infrastructure/Services/ShiftManagementService.cs
@@ -781,6 +781,39 @@ public class ShiftManagementService : IShiftManagementService
                 .Count());
     }
 
+    public async Task<ShiftsSummaryData?> GetShiftsSummaryForTeamsAsync(
+        Guid eventSettingsId, IReadOnlyList<Guid> teamIds)
+    {
+        if (teamIds.Count == 0) return null;
+
+        var rotas = await _dbContext.Rotas
+            .AsNoTracking()
+            .Include(r => r.Shifts).ThenInclude(s => s.ShiftSignups)
+            .Where(r => r.EventSettingsId == eventSettingsId && teamIds.Contains(r.TeamId))
+            .ToListAsync();
+
+        if (rotas.Count == 0) return null;
+
+        var allShifts = rotas.SelectMany(r => r.Shifts).ToList();
+        if (allShifts.Count == 0) return null;
+
+        var allSignups = allShifts.SelectMany(s => s.ShiftSignups).ToList();
+
+        return new ShiftsSummaryData(
+            TotalSlots: allShifts.Sum(s => s.MaxVolunteers),
+            ConfirmedCount: allSignups.Count(s => s.Status == SignupStatus.Confirmed),
+            PendingCount: allSignups
+                .Where(s => s.Status == SignupStatus.Pending)
+                .Select(s => s.SignupBlockId ?? s.Id)
+                .Distinct()
+                .Count(),
+            UniqueVolunteerCount: allSignups
+                .Where(s => s.Status == SignupStatus.Confirmed)
+                .Select(s => s.UserId)
+                .Distinct()
+                .Count());
+    }
+
     public async Task<IReadOnlyList<(Guid TeamId, string TeamName)>> GetDepartmentsWithRotasAsync(
         Guid eventSettingsId)
     {

--- a/src/Humans.Infrastructure/Services/TeamPageService.cs
+++ b/src/Humans.Infrastructure/Services/TeamPageService.cs
@@ -175,13 +175,23 @@ public class TeamPageService : ITeamPageService
                 return new TeamPageShiftsSummary(0, 0, 0, 0, canManageShifts);
             }
 
+            // Count only child teams that actually have shifts in the active event
+            var childTeamsWithShifts = await _dbContext.Rotas
+                .AsNoTracking()
+                .Where(r => r.EventSettingsId == activeEvent.Id
+                    && childTeams.Contains(r.TeamId)
+                    && r.Shifts.Any())
+                .Select(r => r.TeamId)
+                .Distinct()
+                .CountAsync(cancellationToken);
+
             return new TeamPageShiftsSummary(
                 aggregatedData.TotalSlots,
                 aggregatedData.ConfirmedCount,
                 aggregatedData.PendingCount,
                 aggregatedData.UniqueVolunteerCount,
                 canManageShifts,
-                childTeams.Count);
+                childTeamsWithShifts);
         }
 
         // Child team or standalone team: show only own shifts

--- a/src/Humans.Infrastructure/Services/TeamPageService.cs
+++ b/src/Humans.Infrastructure/Services/TeamPageService.cs
@@ -157,6 +157,34 @@ public class TeamPageService : ITeamPageService
             return new TeamPageShiftsSummary(0, 0, 0, 0, canManageShifts);
         }
 
+        // For parent teams, aggregate shifts from the parent team plus all child teams
+        var childTeams = await _dbContext.Teams
+            .AsNoTracking()
+            .Where(t => t.ParentTeamId == team.Id && t.IsActive)
+            .Select(t => t.Id)
+            .ToListAsync(cancellationToken);
+
+        if (childTeams.Count > 0)
+        {
+            var allTeamIds = new List<Guid> { team.Id };
+            allTeamIds.AddRange(childTeams);
+
+            var aggregatedData = await _shiftManagementService.GetShiftsSummaryForTeamsAsync(activeEvent.Id, allTeamIds);
+            if (aggregatedData is null)
+            {
+                return new TeamPageShiftsSummary(0, 0, 0, 0, canManageShifts);
+            }
+
+            return new TeamPageShiftsSummary(
+                aggregatedData.TotalSlots,
+                aggregatedData.ConfirmedCount,
+                aggregatedData.PendingCount,
+                aggregatedData.UniqueVolunteerCount,
+                canManageShifts,
+                childTeams.Count);
+        }
+
+        // Child team or standalone team: show only own shifts
         var summaryData = await _shiftManagementService.GetShiftsSummaryAsync(activeEvent.Id, team.Id);
         if (summaryData is null)
         {

--- a/src/Humans.Infrastructure/Services/TeamService.cs
+++ b/src/Humans.Infrastructure/Services/TeamService.cs
@@ -2005,7 +2005,7 @@ public class TeamService : ITeamService
 
         return await _dbContext.Set<TeamRoleDefinition>()
             .AsNoTracking()
-            .Where(d => teamIdList.Contains(d.TeamId) && d.IsManagement)
+            .Where(d => teamIdList.Contains(d.TeamId) && d.IsManagement && d.IsPublic)
             .ToDictionaryAsync(d => d.TeamId, d => d.Name, cancellationToken);
     }
 

--- a/src/Humans.Infrastructure/Services/TeamService.cs
+++ b/src/Humans.Infrastructure/Services/TeamService.cs
@@ -1993,6 +1993,22 @@ public class TeamService : ITeamService
         return result;
     }
 
+    public async Task<IReadOnlyDictionary<Guid, string>> GetManagementRoleNamesByTeamIdsAsync(
+        IEnumerable<Guid> teamIds,
+        CancellationToken cancellationToken = default)
+    {
+        var teamIdList = teamIds.ToList();
+        if (teamIdList.Count == 0)
+        {
+            return new Dictionary<Guid, string>();
+        }
+
+        return await _dbContext.Set<TeamRoleDefinition>()
+            .AsNoTracking()
+            .Where(d => teamIdList.Contains(d.TeamId) && d.IsManagement)
+            .ToDictionaryAsync(d => d.TeamId, d => d.Name, cancellationToken);
+    }
+
     public async Task<IReadOnlyDictionary<Guid, List<string>>> GetNonSystemTeamNamesByUserIdsAsync(
         IEnumerable<Guid> userIds,
         CancellationToken cancellationToken = default)

--- a/src/Humans.Web/Controllers/TeamController.cs
+++ b/src/Humans.Web/Controllers/TeamController.cs
@@ -168,11 +168,34 @@ public class TeamController : HumansControllerBase
             var directMemberUserIds = new HashSet<Guid>(viewModel.Members.Select(m => m.UserId));
             var addedUserIds = new HashSet<Guid>();
 
+            // Build a lookup of management role definitions by child team ID
+            var childTeamIds = teamPage.ChildTeams.Select(c => c.Id).ToList();
+            var managementRolesByTeam = await _teamService.GetManagementRoleNamesByTeamIdsAsync(childTeamIds);
+
             foreach (var child in teamPage.ChildTeams)
             {
                 var childMembers = await _teamService.GetTeamMembersAsync(child.Id);
+                var managementRoleName = managementRolesByTeam.GetValueOrDefault(child.Id);
+
                 foreach (var cm in childMembers)
                 {
+                    var isCoordinator = cm.Role == TeamMemberRole.Coordinator;
+
+                    // Add coordinators to the subteam leads list (allow duplicates across teams)
+                    if (isCoordinator)
+                    {
+                        viewModel.SubteamLeads.Add(new ChildTeamMemberViewModel
+                        {
+                            UserId = cm.UserId,
+                            DisplayName = cm.User.DisplayName,
+                            ProfilePictureUrl = cm.User.ProfilePictureUrl,
+                            ChildTeamName = child.Name,
+                            ChildTeamSlug = child.Slug,
+                            IsCoordinator = true,
+                            RoleTitle = managementRoleName
+                        });
+                    }
+
                     if (directMemberUserIds.Contains(cm.UserId) || !addedUserIds.Add(cm.UserId))
                         continue;
 
@@ -182,19 +205,25 @@ public class TeamController : HumansControllerBase
                         DisplayName = cm.User.DisplayName,
                         ProfilePictureUrl = cm.User.ProfilePictureUrl,
                         ChildTeamName = child.Name,
-                        ChildTeamSlug = child.Slug
+                        ChildTeamSlug = child.Slug,
+                        IsCoordinator = isCoordinator,
+                        RoleTitle = isCoordinator ? managementRoleName : null
                     });
                 }
             }
 
-            // Resolve custom profile pictures for child team members
-            if (viewModel.ChildTeamMembers.Count > 0)
+            // Resolve custom profile pictures for child team members and subteam leads
+            var allChildUserEntries = viewModel.ChildTeamMembers
+                .Concat(viewModel.SubteamLeads)
+                .ToList();
+
+            if (allChildUserEntries.Count > 0)
             {
                 var effectiveUrls = await ProfilePictureUrlHelper.BuildEffectiveUrlsAsync(
                     _profileService, Url,
-                    viewModel.ChildTeamMembers.Select(m => (m.UserId, m.ProfilePictureUrl)));
+                    allChildUserEntries.Select(m => (m.UserId, m.ProfilePictureUrl)));
 
-                foreach (var member in viewModel.ChildTeamMembers)
+                foreach (var member in allChildUserEntries)
                 {
                     if (effectiveUrls.TryGetValue(member.UserId, out var effectiveUrl))
                         member.ProfilePictureUrl = effectiveUrl;
@@ -268,7 +297,8 @@ public class TeamController : HumansControllerBase
             PendingCount = summary.PendingCount,
             UniqueVolunteerCount = summary.UniqueVolunteerCount,
             ShiftsUrl = Url.Action(nameof(ShiftAdminController.Index), "ShiftAdmin", new { slug })!,
-            CanManageShifts = summary.CanManageShifts
+            CanManageShifts = summary.CanManageShifts,
+            IncludesSubTeamCount = summary.IncludesSubTeamCount
         };
     }
 

--- a/src/Humans.Web/Models/ShiftViewModels.cs
+++ b/src/Humans.Web/Models/ShiftViewModels.cs
@@ -431,6 +431,11 @@ public class ShiftsSummaryCardViewModel
     public int UniqueVolunteerCount { get; set; }
     public string ShiftsUrl { get; set; } = "";
     public bool CanManageShifts { get; set; }
+
+    /// <summary>
+    /// When > 0, indicates this summary includes data from child teams.
+    /// </summary>
+    public int IncludesSubTeamCount { get; set; }
 }
 
 // === Shift Signups ViewComponent ===

--- a/src/Humans.Web/Models/TeamViewModels.cs
+++ b/src/Humans.Web/Models/TeamViewModels.cs
@@ -79,6 +79,11 @@ public class TeamDetailViewModel
     public ShiftsSummaryCardViewModel? ShiftsSummary { get; set; }
 
     /// <summary>
+    /// Coordinators/leads from child teams. Only populated for departments with child team coordinators.
+    /// </summary>
+    public List<ChildTeamMemberViewModel> SubteamLeads { get; set; } = [];
+
+    /// <summary>
     /// Members from child teams rolled up to this department. Only populated for departments.
     /// </summary>
     public List<ChildTeamMemberViewModel> ChildTeamMembers { get; set; } = [];
@@ -93,6 +98,8 @@ public class ChildTeamMemberViewModel
     public string? CustomProfilePictureUrl { get; set; }
     public string ChildTeamName { get; set; } = string.Empty;
     public string ChildTeamSlug { get; set; } = string.Empty;
+    public bool IsCoordinator { get; set; }
+    public string? RoleTitle { get; set; }
 
     public string? EffectiveProfilePictureUrl => HasCustomProfilePicture
         ? CustomProfilePictureUrl

--- a/src/Humans.Web/Views/Shared/_ShiftsSummaryCard.cshtml
+++ b/src/Humans.Web/Views/Shared/_ShiftsSummaryCard.cshtml
@@ -30,6 +30,12 @@
         {
             <p class="text-muted mb-0">No shifts configured yet.</p>
         }
+        @if (Model.IncludesSubTeamCount > 0)
+        {
+            <small class="text-muted d-block mt-1">
+                <i class="fa-solid fa-sitemap me-1"></i>Includes shifts from @Model.IncludesSubTeamCount sub-team@(Model.IncludesSubTeamCount != 1 ? "s" : "")
+            </small>
+        }
         @if (Model.CanManageShifts)
         {
             <a href="@Model.ShiftsUrl" class="btn btn-sm btn-outline-primary mt-2 w-100">Manage Shifts <i class="fa-solid fa-lock auth-lock-icon"></i></a>

--- a/src/Humans.Web/Views/Team/Details.cshtml
+++ b/src/Humans.Web/Views/Team/Details.cshtml
@@ -213,6 +213,32 @@
         </div>
         }
 
+        @if (Model.IsAuthenticated && Model.SubteamLeads.Any())
+        {
+        <div class="card mb-4">
+            <div class="card-header">
+                <span>Subteam Leads (@Model.SubteamLeads.Count)</span>
+            </div>
+            <div class="card-body">
+                <div class="row g-3">
+                    @foreach (var lead in Model.SubteamLeads)
+                    {
+                        <div class="col-6 col-sm-4 col-md-3">
+                            <human-link user-id="@lead.UserId" display-name="@lead.DisplayName"
+                                        mode="Card" size="128"
+                                        profile-picture-url="@lead.EffectiveProfilePictureUrl"
+                                        avatar-css-class="border border-primary border-3"
+                                        avatar-bg-color="bg-primary">
+                                <span class="badge bg-primary small">@(lead.RoleTitle ?? "Coordinator")</span>
+                                <span class="badge bg-secondary bg-opacity-50 small">@lead.ChildTeamName</span>
+                            </human-link>
+                        </div>
+                    }
+                </div>
+            </div>
+        </div>
+        }
+
         @if (Model.IsAuthenticated && Model.ChildTeamMembers.Any())
         {
         <div class="card mb-4">


### PR DESCRIPTION
## Summary
- **#375** — Show subteam coordinators/leads on parent team page with name, avatar, subteam, and role
- **#374** — Aggregate shift summary counts across child teams on parent team pages

## Issues
Closes nobodies-collective/Humans#375
Closes nobodies-collective/Humans#374

## Test plan
- [ ] Parent team page shows "Subteam Leads" section with coordinators from child teams
- [ ] Section hidden when no child team coordinators exist
- [ ] Parent team shifts card shows aggregated counts from child teams
- [ ] Child team pages unaffected — show only their own shifts
- [ ] "Includes shifts from X sub-teams" annotation visible on parent pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>