### PR TITLE
Sprint batch 1: Quick fixes (#379, #380, #378)

### DIFF
--- a/src/Humans.Infrastructure/Services/ShiftSignupService.cs
+++ b/src/Humans.Infrastructure/Services/ShiftSignupService.cs
@@ -530,7 +530,8 @@ public class ShiftSignupService : IShiftSignupService
 
         if (conflictingDays.Count > 0)
         {
-            var dayList = string.Join(", ", conflictingDays);
+            var dayList = string.Join(", ", conflictingDays.Select(offset =>
+                FormatShiftDate(es.GateOpeningDate.PlusDays(offset))));
             return SignupResult.Fail($"Time conflict on day(s): {dayList}.");
         }
 
@@ -554,7 +555,11 @@ public class ShiftSignupService : IShiftSignupService
             return SignupResult.Fail("All shifts in this range are at capacity.");
 
         if (fullDays.Count > 0)
-            warning = $"Day(s) {string.Join(", ", fullDays)} skipped (at capacity).";
+        {
+            var dayList = string.Join(", ", fullDays.Select(offset =>
+                FormatShiftDate(es.GateOpeningDate.PlusDays(offset))));
+            warning = $"Day(s) {dayList} are at capacity.";
+        }
 
         // EE cap check for build shifts
         if (rota.Period == RotaPeriod.Build)
@@ -573,7 +578,9 @@ public class ShiftSignupService : IShiftSignupService
 
             if (fullEeDays.Count > 0)
             {
-                var eeWarning = $"Early entry capacity reached for day(s): {string.Join(", ", fullEeDays)}.";
+                var eeDayList = string.Join(", ", fullEeDays.Select(offset =>
+                    FormatShiftDate(es.GateOpeningDate.PlusDays(offset))));
+                var eeWarning = $"Early entry capacity reached for day(s): {eeDayList}.";
                 warning = warning is null ? eeWarning : $"{warning} {eeWarning}";
             }
         }
@@ -973,4 +980,11 @@ public class ShiftSignupService : IShiftSignupService
             _logger.LogError(ex, "Failed to dispatch ShiftSignupChange notification for signup {SignupId}", signup.Id);
         }
     }
+
+    /// <summary>
+    /// Formats a LocalDate for display in shift messages (e.g., "Wed Jul 1").
+    /// Mirrors the Web-layer ToDisplayShiftDate() extension.
+    /// </summary>
+    private static string FormatShiftDate(LocalDate date) =>
+        date.DayOfWeek.ToString()[..3] + " " + date.ToString("MMM d", null);
 }

--- a/src/Humans.Web/Controllers/AccountController.cs
+++ b/src/Humans.Web/Controllers/AccountController.cs
@@ -322,6 +322,9 @@ public class AccountController : Controller
     [HttpGet]
     public IActionResult MagicLinkSignup(string token, string? returnUrl = null)
     {
+        if (string.IsNullOrEmpty(token))
+            return View("MagicLinkError");
+
         var email = _magicLinkService.VerifySignupToken(token);
         if (email is null)
         {
@@ -338,6 +341,9 @@ public class AccountController : Controller
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> CompleteSignup(string token, string displayName, string? returnUrl = null)
     {
+        if (string.IsNullOrEmpty(token))
+            return View("MagicLinkError");
+
         returnUrl ??= Url.Content("~/");
 
         var email = _magicLinkService.VerifySignupToken(token);

--- a/src/Humans.Web/Resources/SharedResource.ca.resx
+++ b/src/Humans.Web/Resources/SharedResource.ca.resx
@@ -1314,4 +1314,17 @@
   <data name="Notification_Bulk_Resolve" xml:space="preserve"><value>Resol les seleccionades</value></data>
   <data name="Notification_Bulk_Dismiss" xml:space="preserve"><value>Descarta les seleccionades</value></data>
 
+  <!-- Get Involved card (Dashboard) -->
+  <data name="GetInvolved_Title" xml:space="preserve"><value>Participa</value></data>
+  <data name="GetInvolved_Intro" xml:space="preserve"><value>L'event funciona amb energia humana. Tria torns que encaixin al teu horari — cada hora compta.</value></data>
+  <data name="GetInvolved_Phase_Setup" xml:space="preserve"><value>Muntatge</value></data>
+  <data name="GetInvolved_Phase_Setup_Desc" xml:space="preserve"><value>Construeix el recinte abans d'obrir portes. Treball físic, horaris flexibles, ideal per conèixer l'equip.</value></data>
+  <data name="GetInvolved_Phase_Event" xml:space="preserve"><value>Esdeveniment</value></data>
+  <data name="GetInvolved_Phase_Event_Desc" xml:space="preserve"><value>Mantén-ho tot en marxa durant l'event. Barres, portes, seguretat, art — n'hi ha per a tothom.</value></data>
+  <data name="GetInvolved_Phase_Strike" xml:space="preserve"><value>Desmuntatge</value></data>
+  <data name="GetInvolved_Phase_Strike_Desc" xml:space="preserve"><value>Desmunta-ho tot i no deixis rastre. Treball gratificant, normalment de menor durada.</value></data>
+  <data name="GetInvolved_UrgentShifts" xml:space="preserve"><value>Torns que necessiten humans ara</value></data>
+  <data name="GetInvolved_BrowseAllShifts" xml:space="preserve"><value>Veure tots els torns</value></data>
+  <data name="GetInvolved_MyShifts" xml:space="preserve"><value>Els meus torns</value></data>
+
 </root>

--- a/src/Humans.Web/Resources/SharedResource.de.resx
+++ b/src/Humans.Web/Resources/SharedResource.de.resx
@@ -1312,4 +1312,17 @@
   <data name="Notification_Bulk_Resolve" xml:space="preserve"><value>Resolve selected</value></data>
   <data name="Notification_Bulk_Dismiss" xml:space="preserve"><value>Dismiss selected</value></data>
 
+  <!-- Get Involved card (Dashboard) -->
+  <data name="GetInvolved_Title" xml:space="preserve"><value>Mach mit</value></data>
+  <data name="GetInvolved_Intro" xml:space="preserve"><value>Das Event lebt von humans. Wähle Schichten, die in deinen Zeitplan passen — jede Stunde zählt.</value></data>
+  <data name="GetInvolved_Phase_Setup" xml:space="preserve"><value>Aufbau</value></data>
+  <data name="GetInvolved_Phase_Setup_Desc" xml:space="preserve"><value>Baue das Gelände auf, bevor die Tore öffnen. Körperliche Arbeit, flexible Zeiten, ideal um das Team kennenzulernen.</value></data>
+  <data name="GetInvolved_Phase_Event" xml:space="preserve"><value>Event</value></data>
+  <data name="GetInvolved_Phase_Event_Desc" xml:space="preserve"><value>Halte alles am Laufen während des Events. Bars, Einlass, Sicherheit, Kunst — für jeden etwas dabei.</value></data>
+  <data name="GetInvolved_Phase_Strike" xml:space="preserve"><value>Abbau</value></data>
+  <data name="GetInvolved_Phase_Strike_Desc" xml:space="preserve"><value>Alles abbauen und keine Spuren hinterlassen. Befriedigende Arbeit, meist kürzerer Einsatz.</value></data>
+  <data name="GetInvolved_UrgentShifts" xml:space="preserve"><value>Schichten, die jetzt humans brauchen</value></data>
+  <data name="GetInvolved_BrowseAllShifts" xml:space="preserve"><value>Alle Schichten ansehen</value></data>
+  <data name="GetInvolved_MyShifts" xml:space="preserve"><value>Meine Schichten</value></data>
+
 </root>

--- a/src/Humans.Web/Resources/SharedResource.es.resx
+++ b/src/Humans.Web/Resources/SharedResource.es.resx
@@ -1314,4 +1314,17 @@
   <data name="Notification_Bulk_Resolve" xml:space="preserve"><value>Resolve selected</value></data>
   <data name="Notification_Bulk_Dismiss" xml:space="preserve"><value>Dismiss selected</value></data>
 
+  <!-- Get Involved card (Dashboard) -->
+  <data name="GetInvolved_Title" xml:space="preserve"><value>Participa</value></data>
+  <data name="GetInvolved_Intro" xml:space="preserve"><value>El evento funciona con energía humana. Elige turnos que encajen en tu horario — cada hora cuenta.</value></data>
+  <data name="GetInvolved_Phase_Setup" xml:space="preserve"><value>Montaje</value></data>
+  <data name="GetInvolved_Phase_Setup_Desc" xml:space="preserve"><value>Construye el recinto antes de abrir puertas. Trabajo físico, horarios flexibles, ideal para conocer al equipo.</value></data>
+  <data name="GetInvolved_Phase_Event" xml:space="preserve"><value>Evento</value></data>
+  <data name="GetInvolved_Phase_Event_Desc" xml:space="preserve"><value>Mantén todo en marcha durante el evento. Barras, puertas, seguridad, arte — hay algo para todos.</value></data>
+  <data name="GetInvolved_Phase_Strike" xml:space="preserve"><value>Desmontaje</value></data>
+  <data name="GetInvolved_Phase_Strike_Desc" xml:space="preserve"><value>Desmonta todo y no dejes rastro. Trabajo gratificante, normalmente de menor duración.</value></data>
+  <data name="GetInvolved_UrgentShifts" xml:space="preserve"><value>Turnos que necesitan humans ahora</value></data>
+  <data name="GetInvolved_BrowseAllShifts" xml:space="preserve"><value>Ver todos los turnos</value></data>
+  <data name="GetInvolved_MyShifts" xml:space="preserve"><value>Mis turnos</value></data>
+
 </root>

--- a/src/Humans.Web/Resources/SharedResource.fr.resx
+++ b/src/Humans.Web/Resources/SharedResource.fr.resx
@@ -1312,4 +1312,17 @@
   <data name="Notification_Bulk_Resolve" xml:space="preserve"><value>Resolve selected</value></data>
   <data name="Notification_Bulk_Dismiss" xml:space="preserve"><value>Dismiss selected</value></data>
 
+  <!-- Get Involved card (Dashboard) -->
+  <data name="GetInvolved_Title" xml:space="preserve"><value>Participe</value></data>
+  <data name="GetInvolved_Intro" xml:space="preserve"><value>L'événement fonctionne grâce aux humans. Choisis des créneaux qui te conviennent — chaque heure compte.</value></data>
+  <data name="GetInvolved_Phase_Setup" xml:space="preserve"><value>Montage</value></data>
+  <data name="GetInvolved_Phase_Setup_Desc" xml:space="preserve"><value>Construis le site avant l'ouverture des portes. Travail physique, horaires flexibles, idéal pour rencontrer l'équipe.</value></data>
+  <data name="GetInvolved_Phase_Event" xml:space="preserve"><value>Événement</value></data>
+  <data name="GetInvolved_Phase_Event_Desc" xml:space="preserve"><value>Fais tourner les choses pendant l'événement. Bars, entrées, sécurité, art — il y en a pour tous.</value></data>
+  <data name="GetInvolved_Phase_Strike" xml:space="preserve"><value>Démontage</value></data>
+  <data name="GetInvolved_Phase_Strike_Desc" xml:space="preserve"><value>Tout démonter et ne laisser aucune trace. Travail satisfaisant, engagement généralement plus court.</value></data>
+  <data name="GetInvolved_UrgentShifts" xml:space="preserve"><value>Créneaux qui ont besoin de humans maintenant</value></data>
+  <data name="GetInvolved_BrowseAllShifts" xml:space="preserve"><value>Voir tous les créneaux</value></data>
+  <data name="GetInvolved_MyShifts" xml:space="preserve"><value>Mes créneaux</value></data>
+
 </root>

--- a/src/Humans.Web/Resources/SharedResource.it.resx
+++ b/src/Humans.Web/Resources/SharedResource.it.resx
@@ -1312,4 +1312,17 @@
   <data name="Notification_Bulk_Resolve" xml:space="preserve"><value>Resolve selected</value></data>
   <data name="Notification_Bulk_Dismiss" xml:space="preserve"><value>Dismiss selected</value></data>
 
+  <!-- Get Involved card (Dashboard) -->
+  <data name="GetInvolved_Title" xml:space="preserve"><value>Partecipa</value></data>
+  <data name="GetInvolved_Intro" xml:space="preserve"><value>L'evento funziona grazie agli humans. Scegli turni che si adattano ai tuoi orari — ogni ora conta.</value></data>
+  <data name="GetInvolved_Phase_Setup" xml:space="preserve"><value>Montaggio</value></data>
+  <data name="GetInvolved_Phase_Setup_Desc" xml:space="preserve"><value>Costruisci il sito prima dell'apertura. Lavoro fisico, orari flessibili, ideale per conoscere il team.</value></data>
+  <data name="GetInvolved_Phase_Event" xml:space="preserve"><value>Evento</value></data>
+  <data name="GetInvolved_Phase_Event_Desc" xml:space="preserve"><value>Fai funzionare tutto durante l'evento. Bar, ingressi, sicurezza, arte — ce n'è per tutti.</value></data>
+  <data name="GetInvolved_Phase_Strike" xml:space="preserve"><value>Smontaggio</value></data>
+  <data name="GetInvolved_Phase_Strike_Desc" xml:space="preserve"><value>Smonta tutto e non lasciare traccia. Lavoro soddisfacente, di solito impegno più breve.</value></data>
+  <data name="GetInvolved_UrgentShifts" xml:space="preserve"><value>Turni che hanno bisogno di humans adesso</value></data>
+  <data name="GetInvolved_BrowseAllShifts" xml:space="preserve"><value>Vedi tutti i turni</value></data>
+  <data name="GetInvolved_MyShifts" xml:space="preserve"><value>I miei turni</value></data>
+
 </root>

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -1328,4 +1328,17 @@
   <data name="Notification_Bulk_Resolve" xml:space="preserve"><value>Resolve selected</value></data>
   <data name="Notification_Bulk_Dismiss" xml:space="preserve"><value>Dismiss selected</value></data>
 
+  <!-- Get Involved card (Dashboard) -->
+  <data name="GetInvolved_Title" xml:space="preserve"><value>Get Involved</value></data>
+  <data name="GetInvolved_Intro" xml:space="preserve"><value>The event runs on human power. Pick shifts that fit your schedule — every hour helps.</value></data>
+  <data name="GetInvolved_Phase_Setup" xml:space="preserve"><value>Set-up</value></data>
+  <data name="GetInvolved_Phase_Setup_Desc" xml:space="preserve"><value>Build the site before gates open. Physical work, flexible hours, great for meeting the crew.</value></data>
+  <data name="GetInvolved_Phase_Event" xml:space="preserve"><value>Event</value></data>
+  <data name="GetInvolved_Phase_Event_Desc" xml:space="preserve"><value>Keep things running during the event. Bars, gates, safety, art — something for everyone.</value></data>
+  <data name="GetInvolved_Phase_Strike" xml:space="preserve"><value>Strike</value></data>
+  <data name="GetInvolved_Phase_Strike_Desc" xml:space="preserve"><value>Take it all down and leave no trace. Satisfying work, usually shorter commitment.</value></data>
+  <data name="GetInvolved_UrgentShifts" xml:space="preserve"><value>Shifts that need humans now</value></data>
+  <data name="GetInvolved_BrowseAllShifts" xml:space="preserve"><value>Browse All Shifts</value></data>
+  <data name="GetInvolved_MyShifts" xml:space="preserve"><value>My Shifts</value></data>
+
 </root>

--- a/src/Humans.Web/Views/Home/Dashboard.cshtml
+++ b/src/Humans.Web/Views/Home/Dashboard.cshtml
@@ -77,35 +77,35 @@
             @* Guided shift discovery — shown when user has no upcoming shifts *@
             <div class="card mb-4 border-primary">
                 <div class="card-header bg-primary text-white">
-                    <h5 class="mb-0"><i class="fa-solid fa-hand-holding-heart me-2"></i>Get Involved — @Model.EventName</h5>
+                    <h5 class="mb-0"><i class="fa-solid fa-hand-holding-heart me-2"></i>@Localizer["GetInvolved_Title"] — @Model.EventName</h5>
                 </div>
                 <div class="card-body">
-                    <p>The event runs on human power. Pick shifts that fit your schedule — every hour helps.</p>
+                    <p>@Localizer["GetInvolved_Intro"]</p>
 
                     <div class="row g-3 mb-3">
                         <div class="col-md-4">
                             <div class="border rounded p-3 h-100">
-                                <h6><span class="badge bg-info me-1">Set-up</span></h6>
-                                <small class="text-muted">Build the site before gates open. Physical work, flexible hours, great for meeting the crew.</small>
+                                <h6><span class="badge bg-info me-1">@Localizer["GetInvolved_Phase_Setup"]</span></h6>
+                                <small class="text-muted">@Localizer["GetInvolved_Phase_Setup_Desc"]</small>
                             </div>
                         </div>
                         <div class="col-md-4">
                             <div class="border rounded p-3 h-100">
-                                <h6><span class="badge bg-success me-1">Event</span></h6>
-                                <small class="text-muted">Keep things running during the event. Bars, gates, safety, art — something for everyone.</small>
+                                <h6><span class="badge bg-success me-1">@Localizer["GetInvolved_Phase_Event"]</span></h6>
+                                <small class="text-muted">@Localizer["GetInvolved_Phase_Event_Desc"]</small>
                             </div>
                         </div>
                         <div class="col-md-4">
                             <div class="border rounded p-3 h-100">
-                                <h6><span class="badge bg-secondary me-1">Strike</span></h6>
-                                <small class="text-muted">Take it all down and leave no trace. Satisfying work, usually shorter commitment.</small>
+                                <h6><span class="badge bg-secondary me-1">@Localizer["GetInvolved_Phase_Strike"]</span></h6>
+                                <small class="text-muted">@Localizer["GetInvolved_Phase_Strike_Desc"]</small>
                             </div>
                         </div>
                     </div>
 
                     @if (shiftCards?.UrgentShifts.Count > 0)
                     {
-                        <h6 class="mt-3"><i class="fa-solid fa-fire text-danger me-1"></i>Shifts that need humans now</h6>
+                        <h6 class="mt-3"><i class="fa-solid fa-fire text-danger me-1"></i>@Localizer["GetInvolved_UrgentShifts"]</h6>
                         <ul class="list-unstyled mb-3">
                             @foreach (var item in shiftCards.UrgentShifts)
                             {
@@ -122,10 +122,10 @@
                 </div>
                 <div class="card-footer d-flex gap-2">
                     <a asp-controller="Shifts" asp-action="Index" class="btn btn-primary">
-                        <i class="fa-solid fa-calendar-alt me-1"></i>Browse All Shifts
+                        <i class="fa-solid fa-calendar-alt me-1"></i>@Localizer["GetInvolved_BrowseAllShifts"]
                     </a>
                     <a asp-controller="Shifts" asp-action="Mine" class="btn btn-outline-secondary">
-                        <i class="fa-solid fa-clipboard-list me-1"></i>My Shifts
+                        <i class="fa-solid fa-clipboard-list me-1"></i>@Localizer["GetInvolved_MyShifts"]
                     </a>
                 </div>
             </div>

--- a/tests/Humans.Application.Tests/Services/ShiftSignupServiceEarlyEntryTests.cs
+++ b/tests/Humans.Application.Tests/Services/ShiftSignupServiceEarlyEntryTests.cs
@@ -97,7 +97,7 @@ public class ShiftSignupServiceEarlyEntryTests : IDisposable
         var result = await _service.SignUpRangeAsync(Guid.NewGuid(), rota.Id, -3, -1);
 
         result.Success.Should().BeTrue();
-        result.Warning.Should().Contain("-1");
+        result.Warning.Should().Contain("Tue Jun 30");
     }
 
     private (EventSettings eventSettings, Rota rota, Team team) SeedBuildScenario()


### PR DESCRIPTION
## Summary
- **#379** — Fix MagicLinkSignup null token crash: add null guard on GET and POST actions
- **#380** — Fix shift day offset display: show formatted dates in conflict/capacity messages
- **#378** — Localize Get Involved dashboard card for all 6 locales

## Issues
Closes nobodies-collective/Humans#379
Closes nobodies-collective/Humans#380
Closes nobodies-collective/Humans#378

## Test plan
- [x] Visit `/Account/MagicLinkSignup` with no token — should show error view, not 500
- [ ] Trigger shift conflict — message should show dates not numbers
- [x] Switch locale — Get Involved card text should be translated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>