### PR TITLE
Sprint batch 2: Google integration fixes (#372, #381)

### DIFF
--- a/src/Humans.Infrastructure/Services/DriveActivityMonitorService.cs
+++ b/src/Humans.Infrastructure/Services/DriveActivityMonitorService.cs
@@ -72,6 +72,7 @@ public class DriveActivityMonitorService : IDriveActivityMonitorService
         var activityService = await GetActivityServiceAsync();
         var serviceAccountEmail = await GetServiceAccountEmailAsync(cancellationToken);
         var anomalyCount = 0;
+        var hadFailures = false;
 
         // Use time-window dedup: only process events since the last successful run.
         // Falls back to 24 hours on first run or if the stored timestamp is missing.
@@ -98,6 +99,7 @@ public class DriveActivityMonitorService : IDriveActivityMonitorService
             }
             catch (Exception ex)
             {
+                hadFailures = true;
                 _logger.LogError(ex, "Error checking Drive activity for resource {ResourceId} ({GoogleId})",
                     resource.Id, resource.GoogleId);
             }
@@ -114,10 +116,16 @@ public class DriveActivityMonitorService : IDriveActivityMonitorService
                 resources.Count);
         }
 
-        // Save the run timestamp so the next invocation only processes newer events.
-        // This is saved regardless of whether anomalies were found — we've processed all
-        // events up to 'now' and don't want to re-process them.
-        await SaveLastRunTimestampAsync(now, cancellationToken);
+        // Only advance the last-run marker when every resource was processed successfully.
+        // If any resource failed, we keep the old marker so the next run re-checks those events.
+        if (hadFailures)
+        {
+            _logger.LogWarning("Skipping last-run marker update due to partial failures — next run will re-process from {LookbackTime}", filterTime);
+        }
+        else
+        {
+            await SaveLastRunTimestampAsync(now, cancellationToken);
+        }
 
         return anomalyCount;
     }

--- a/src/Humans.Infrastructure/Services/DriveActivityMonitorService.cs
+++ b/src/Humans.Infrastructure/Services/DriveActivityMonitorService.cs
@@ -40,6 +40,7 @@ public class DriveActivityMonitorService : IDriveActivityMonitorService
     private readonly Dictionary<string, string> _peopleIdCache = new(StringComparer.Ordinal);
 
     private const string JobName = "DriveActivityMonitorJob";
+    private const string LastRunSettingKey = "DriveActivityMonitor:LastRunAt";
 
     public DriveActivityMonitorService(
         HumansDbContext dbContext,
@@ -72,9 +73,14 @@ public class DriveActivityMonitorService : IDriveActivityMonitorService
         var serviceAccountEmail = await GetServiceAccountEmailAsync(cancellationToken);
         var anomalyCount = 0;
 
-        // Check activity from the last 24 hours
-        var lookbackTime = _clock.GetCurrentInstant().Minus(Duration.FromHours(24));
+        // Use time-window dedup: only process events since the last successful run.
+        // Falls back to 24 hours on first run or if the stored timestamp is missing.
+        var now = _clock.GetCurrentInstant();
+        var lookbackTime = await GetLastRunTimestampAsync(cancellationToken)
+            ?? now.Minus(Duration.FromHours(24));
         var filterTime = lookbackTime.ToInvariantInstantString();
+
+        _logger.LogDebug("Drive activity monitor checking events since {LookbackTime}", filterTime);
 
         foreach (var resource in resources)
         {
@@ -82,7 +88,7 @@ public class DriveActivityMonitorService : IDriveActivityMonitorService
             {
                 var anomalies = await CheckResourceActivityAsync(
                     activityService, resource.GoogleId, resource.Id, resource.Name,
-                    serviceAccountEmail, filterTime, lookbackTime, cancellationToken);
+                    serviceAccountEmail, filterTime, cancellationToken);
                 anomalyCount += anomalies;
             }
             catch (Google.GoogleApiException ex) when (ex.Error?.Code == 404)
@@ -99,7 +105,6 @@ public class DriveActivityMonitorService : IDriveActivityMonitorService
 
         if (anomalyCount > 0)
         {
-            await _dbContext.SaveChangesAsync(cancellationToken);
             _logger.LogWarning("Detected {AnomalyCount} anomalous permission change(s) across {ResourceCount} resources",
                 anomalyCount, resources.Count);
         }
@@ -108,6 +113,11 @@ public class DriveActivityMonitorService : IDriveActivityMonitorService
             _logger.LogInformation("Drive activity check completed: no anomalous changes detected across {ResourceCount} resources",
                 resources.Count);
         }
+
+        // Save the run timestamp so the next invocation only processes newer events.
+        // This is saved regardless of whether anomalies were found — we've processed all
+        // events up to 'now' and don't want to re-process them.
+        await SaveLastRunTimestampAsync(now, cancellationToken);
 
         return anomalyCount;
     }
@@ -119,7 +129,6 @@ public class DriveActivityMonitorService : IDriveActivityMonitorService
         string resourceName,
         string serviceAccountEmail,
         string filterTime,
-        Instant lookbackInstant,
         CancellationToken cancellationToken)
     {
         var anomalyCount = 0;
@@ -146,20 +155,6 @@ public class DriveActivityMonitorService : IDriveActivityMonitorService
                         !IsInitiatedByServiceAccount(activity, serviceAccountEmail))
                     {
                         var description = await BuildAnomalyDescriptionAsync(activity, resourceName, cancellationToken);
-
-                        // Skip if this exact anomaly was already logged within the lookback window
-                        var alreadyLogged = await _dbContext.AuditLogEntries
-                            .AsNoTracking()
-                            .AnyAsync(e => e.Action == AuditAction.AnomalousPermissionDetected
-                                && e.EntityId == resourceId
-                                && e.Description == description
-                                && e.OccurredAt >= lookbackInstant, cancellationToken);
-
-                        if (alreadyLogged)
-                        {
-                            continue;
-                        }
-
                         var actorEmail = await GetActorEmailAsync(activity, cancellationToken);
 
                         _logger.LogWarning(
@@ -402,6 +397,57 @@ public class DriveActivityMonitorService : IDriveActivityMonitorService
             _logger.LogWarning(ex, "Error resolving {PersonName} via local DB", personName);
             return null;
         }
+    }
+
+    /// <summary>
+    /// Reads the last successful run timestamp from SystemSettings.
+    /// Returns null if no previous run has been recorded (first run).
+    /// </summary>
+    private async Task<Instant?> GetLastRunTimestampAsync(CancellationToken cancellationToken)
+    {
+        var setting = await _dbContext.SystemSettings
+            .FirstOrDefaultAsync(s => s.Key == LastRunSettingKey, cancellationToken);
+
+        if (setting is null || string.IsNullOrEmpty(setting.Value))
+        {
+            return null;
+        }
+
+        var pattern = NodaTime.Text.InstantPattern.General;
+        var result = pattern.Parse(setting.Value);
+        if (result.Success)
+        {
+            return result.Value;
+        }
+
+        _logger.LogWarning("Could not parse stored Drive activity monitor timestamp '{Value}', falling back to default lookback",
+            setting.Value);
+        return null;
+    }
+
+    /// <summary>
+    /// Saves the run timestamp to SystemSettings so subsequent runs only process newer events.
+    /// </summary>
+    private async Task SaveLastRunTimestampAsync(Instant timestamp, CancellationToken cancellationToken)
+    {
+        var value = timestamp.ToInvariantInstantString();
+        var setting = await _dbContext.SystemSettings
+            .FirstOrDefaultAsync(s => s.Key == LastRunSettingKey, cancellationToken);
+
+        if (setting is not null)
+        {
+            setting.Value = value;
+        }
+        else
+        {
+            _dbContext.SystemSettings.Add(new SystemSetting
+            {
+                Key = LastRunSettingKey,
+                Value = value
+            });
+        }
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
     }
 
     private async Task<DriveActivityService> GetActivityServiceAsync()

--- a/src/Humans.Web/Controllers/AdminController.cs
+++ b/src/Humans.Web/Controllers/AdminController.cs
@@ -4,14 +4,13 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Humans.Application.Configuration;
 using Humans.Application.Interfaces;
-using Humans.Domain.Constants;
 using Humans.Domain.Entities;
+using Humans.Web.Authorization;
 using Humans.Infrastructure.Data;
 using Humans.Web.Models;
 
 namespace Humans.Web.Controllers;
 
-[Authorize(Roles = RoleNames.Admin)]
 [Route("Admin")]
 public class AdminController : HumansControllerBase
 {
@@ -40,12 +39,14 @@ public class AdminController : HumansControllerBase
     }
 
     [HttpGet("")]
+    [Authorize(Policy = PolicyNames.AdminOnly)]
     public IActionResult Index()
     {
         return View();
     }
 
     [HttpPost("Humans/{id}/Purge")]
+    [Authorize(Policy = PolicyNames.AdminOnly)]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> PurgeHuman(Guid id)
     {
@@ -92,6 +93,7 @@ public class AdminController : HumansControllerBase
     }
 
     [HttpGet("Logs")]
+    [Authorize(Policy = PolicyNames.AdminOnly)]
     public IActionResult Logs(int count = 50)
     {
         count = Math.Clamp(count, 1, 200);
@@ -100,6 +102,7 @@ public class AdminController : HumansControllerBase
     }
 
     [HttpGet("Configuration")]
+    [Authorize(Policy = PolicyNames.AdminOnly)]
     public IActionResult Configuration()
     {
         var entries = _configRegistry.GetAll();
@@ -166,6 +169,7 @@ public class AdminController : HumansControllerBase
     }
 
     [HttpPost("ClearHangfireLocks")]
+    [Authorize(Policy = PolicyNames.AdminOnly)]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> ClearHangfireLocks()
     {

--- a/src/Humans.Web/Controllers/GoogleController.cs
+++ b/src/Humans.Web/Controllers/GoogleController.cs
@@ -4,7 +4,6 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Caching.Memory;
 using Humans.Application.DTOs;
 using Humans.Application.Interfaces;
-using Humans.Domain.Constants;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Humans.Web.Authorization;
@@ -12,7 +11,6 @@ using Humans.Web.Models;
 
 namespace Humans.Web.Controllers;
 
-[Authorize(Roles = RoleNames.Admin)]
 [Route("Google")]
 public class GoogleController : HumansControllerBase
 {
@@ -47,6 +45,7 @@ public class GoogleController : HumansControllerBase
     // --- Sync Settings (from AdminController) ---
 
     [HttpGet("SyncSettings")]
+    [Authorize(Policy = PolicyNames.AdminOnly)]
     public async Task<IActionResult> SyncSettings([FromServices] ISyncSettingsService syncSettingsService)
     {
         var settings = await syncSettingsService.GetAllAsync();
@@ -65,6 +64,7 @@ public class GoogleController : HumansControllerBase
     }
 
     [HttpPost("SyncSettings")]
+    [Authorize(Policy = PolicyNames.AdminOnly)]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> UpdateSyncSetting(
         [FromServices] ISyncSettingsService syncSettingsService,
@@ -85,6 +85,7 @@ public class GoogleController : HumansControllerBase
     // --- System Team Sync (from AdminController) ---
 
     [HttpPost("SyncSystemTeams")]
+    [Authorize(Policy = PolicyNames.AdminOnly)]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> SyncSystemTeams(
         [FromServices] Humans.Infrastructure.Jobs.SystemTeamSyncJob systemTeamSyncJob)
@@ -105,6 +106,7 @@ public class GoogleController : HumansControllerBase
     }
 
     [HttpGet("SyncResults")]
+    [Authorize(Policy = PolicyNames.AdminOnly)]
     public IActionResult SyncResults()
     {
         SyncReport? report = null;
@@ -125,6 +127,7 @@ public class GoogleController : HumansControllerBase
     // --- Google Group Settings (from AdminController) ---
 
     [HttpPost("CheckGroupSettings")]
+    [Authorize(Policy = PolicyNames.AdminOnly)]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> CheckGroupSettings()
     {
@@ -144,6 +147,7 @@ public class GoogleController : HumansControllerBase
     }
 
     [HttpGet("GroupSettingsResults")]
+    [Authorize(Policy = PolicyNames.AdminOnly)]
     public IActionResult GroupSettingsResults()
     {
         GroupSettingsDriftResult? result = null;
@@ -162,6 +166,7 @@ public class GoogleController : HumansControllerBase
     }
 
     [HttpPost("RemediateGroupSettings")]
+    [Authorize(Policy = PolicyNames.AdminOnly)]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> RemediateGroupSettings(
         [FromForm] string groupEmail, [FromForm] string? returnUrl)
@@ -181,6 +186,7 @@ public class GoogleController : HumansControllerBase
     }
 
     [HttpPost("RemediateAllGroupSettings")]
+    [Authorize(Policy = PolicyNames.AdminOnly)]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> RemediateAllGroupSettings()
     {
@@ -234,6 +240,7 @@ public class GoogleController : HumansControllerBase
     // --- All Domain Groups (from AdminController) ---
 
     [HttpGet("AllGroups")]
+    [Authorize(Policy = PolicyNames.AdminOnly)]
     public async Task<IActionResult> AllGroups()
     {
         try
@@ -252,6 +259,7 @@ public class GoogleController : HumansControllerBase
     }
 
     [HttpPost("LinkGroupToTeam")]
+    [Authorize(Policy = PolicyNames.AdminOnly)]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> LinkGroupToTeam(
         [FromForm] Guid teamId, [FromForm] string groupPrefix)
@@ -277,6 +285,7 @@ public class GoogleController : HumansControllerBase
     // --- Email Backfill (from AdminController) ---
 
     [HttpPost("CheckEmailMismatches")]
+    [Authorize(Policy = PolicyNames.AdminOnly)]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> CheckEmailMismatches()
     {
@@ -296,6 +305,7 @@ public class GoogleController : HumansControllerBase
     }
 
     [HttpGet("EmailBackfillReview")]
+    [Authorize(Policy = PolicyNames.AdminOnly)]
     public IActionResult EmailBackfillReview()
     {
         EmailBackfillResult? result = null;
@@ -314,6 +324,7 @@ public class GoogleController : HumansControllerBase
     }
 
     [HttpPost("ApplyEmailBackfill")]
+    [Authorize(Policy = PolicyNames.AdminOnly)]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> ApplyEmailBackfill(
         [FromForm] List<Guid> selectedUserIds,
@@ -342,7 +353,7 @@ public class GoogleController : HumansControllerBase
     // --- Resource Sync Dashboard (from TeamController) ---
 
     [HttpGet("Sync")]
-    [Authorize(Roles = RoleGroups.TeamsAdminBoardOrAdmin)]
+    [Authorize(Policy = PolicyNames.TeamsAdminBoardOrAdmin)]
     public IActionResult Sync()
     {
         var viewModel = new TeamSyncViewModel
@@ -353,7 +364,7 @@ public class GoogleController : HumansControllerBase
     }
 
     [HttpGet("Sync/Preview/{resourceType}")]
-    [Authorize(Roles = RoleGroups.TeamsAdminBoardOrAdmin)]
+    [Authorize(Policy = PolicyNames.TeamsAdminBoardOrAdmin)]
     public async Task<IActionResult> SyncPreview(GoogleResourceType resourceType)
     {
         var result = await _googleSyncService.SyncResourcesByTypeAsync(resourceType, SyncAction.Preview);
@@ -386,6 +397,7 @@ public class GoogleController : HumansControllerBase
     }
 
     [HttpPost("Sync/Execute/{resourceId}")]
+    [Authorize(Policy = PolicyNames.AdminOnly)]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> SyncExecute(Guid resourceId)
     {
@@ -402,6 +414,7 @@ public class GoogleController : HumansControllerBase
     }
 
     [HttpPost("Sync/ExecuteAll/{resourceType}")]
+    [Authorize(Policy = PolicyNames.AdminOnly)]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> SyncExecuteAll(GoogleResourceType resourceType)
     {
@@ -420,7 +433,7 @@ public class GoogleController : HumansControllerBase
     // --- Drive Activity (from BoardController) ---
 
     [HttpPost("AuditLog/CheckDriveActivity")]
-    [Authorize(Roles = RoleGroups.BoardOrAdmin)]
+    [Authorize(Policy = PolicyNames.BoardOrAdmin)]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> CheckDriveActivity(
         [FromServices] IDriveActivityMonitorService monitorService)
@@ -449,7 +462,7 @@ public class GoogleController : HumansControllerBase
     // --- Sync Audit Views (from BoardController and HumanController) ---
 
     [HttpGet("Sync/Resource/{id:guid}/Audit")]
-    [Authorize(Roles = RoleGroups.BoardOrAdmin)]
+    [Authorize(Policy = PolicyNames.BoardOrAdmin)]
     public async Task<IActionResult> GoogleSyncResourceAudit(Guid id)
     {
         var resource = await _teamResourceService.GetResourceByIdAsync(id);
@@ -468,7 +481,7 @@ public class GoogleController : HumansControllerBase
     }
 
     [HttpGet("Human/{id:guid}/SyncAudit")]
-    [Authorize(Roles = RoleGroups.HumanAdminBoardOrAdmin)]
+    [Authorize(Policy = PolicyNames.HumanAdminBoardOrAdmin)]
     public async Task<IActionResult> HumanGoogleSyncAudit(Guid id)
     {
         var user = await FindUserByIdAsync(id);
@@ -489,7 +502,7 @@ public class GoogleController : HumansControllerBase
     // --- Human Email Provisioning (from HumanController) ---
 
     [HttpPost("Human/{id:guid}/ProvisionEmail")]
-    [Authorize(Roles = RoleGroups.HumanAdminOrAdmin)]
+    [Authorize(Policy = PolicyNames.HumanAdminOrAdmin)]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> ProvisionEmail(Guid id, string emailPrefix)
     {
@@ -531,6 +544,7 @@ public class GoogleController : HumansControllerBase
     // --- Workspace Accounts (from AdminEmailController) ---
 
     [HttpGet("Accounts")]
+    [Authorize(Policy = PolicyNames.AdminOnly)]
     public async Task<IActionResult> Accounts()
     {
         var result = await _googleAdminService.GetWorkspaceAccountListAsync();
@@ -566,6 +580,7 @@ public class GoogleController : HumansControllerBase
     }
 
     [HttpPost("Accounts/Provision")]
+    [Authorize(Policy = PolicyNames.AdminOnly)]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> ProvisionAccount(ProvisionWorkspaceAccountModel model)
     {
@@ -593,6 +608,7 @@ public class GoogleController : HumansControllerBase
     }
 
     [HttpPost("Accounts/Suspend")]
+    [Authorize(Policy = PolicyNames.AdminOnly)]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> SuspendAccount(string email)
     {
@@ -616,6 +632,7 @@ public class GoogleController : HumansControllerBase
     }
 
     [HttpPost("Accounts/Reactivate")]
+    [Authorize(Policy = PolicyNames.AdminOnly)]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> ReactivateAccount(string email)
     {
@@ -639,6 +656,7 @@ public class GoogleController : HumansControllerBase
     }
 
     [HttpPost("Accounts/ResetPassword")]
+    [Authorize(Policy = PolicyNames.AdminOnly)]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> ResetPassword(string email)
     {
@@ -662,6 +680,7 @@ public class GoogleController : HumansControllerBase
     }
 
     [HttpPost("Accounts/Link")]
+    [Authorize(Policy = PolicyNames.AdminOnly)]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> LinkAccount(string email, Guid userId)
     {
@@ -693,6 +712,7 @@ public class GoogleController : HumansControllerBase
     // --- Index ---
 
     [HttpGet("")]
+    [Authorize(Policy = PolicyNames.AdminOnly)]
     public IActionResult Index()
     {
         return View();


### PR DESCRIPTION
## Summary
- **#372** — Migrate GoogleController + AdminController to policy-based auth (Phase 1 step 5)
- **#381** — Fix Drive activity monitor re-detecting same anomalies via time-window dedup

## Issues
Closes nobodies-collective/Humans#372
Closes nobodies-collective/Humans#381

## Test plan
- [ ] TeamsAdmin can access /Google/Sync
- [ ] Board can access /Google/Sync audit logs
- [ ] Admin-only actions still blocked for non-admins
- [ ] Drive monitor only logs new anomalies, not previously seen ones
- [ ] Second monitor run with no new changes produces zero anomaly warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>