### PR TITLE
Monthly maintenance: NuGet update, fix flaky E2E, About page sync

### DIFF
--- a/.claude/MAINTENANCE_LOG.md
+++ b/.claude/MAINTENANCE_LOG.md
@@ -4,7 +4,7 @@ Tracks when recurring maintenance processes were last run.
 
 | Process | Last Run | Next Due | Cadence | Est. Cost | Notes |
 |---------|----------|----------|---------|-----------|-------|
-| NuGet vulnerability check | 2026-03-08 | 2026-03-15 | Weekly | — | `dotnet list package --vulnerable` |
+| NuGet vulnerability check | 2026-04-05 | 2026-04-12 | Weekly | — | `dotnet list package --vulnerable` |
 | Todo audit | 2026-03-08 | 2026-03-15 | Weekly | — | Stale items, completed moves |
 | Code simplification | 2026-02-24 | — | After features | codex: ~5% | Dead code, unused abstractions |
 | ReSharper InspectCode | 2026-02-24 | 2026-03-03 | Weekly | — | `/resharper` — fix Tier 1+2 warnings. Codex can't run `jb` in sandbox. |
@@ -15,7 +15,7 @@ Tracks when recurring maintenance processes were last run.
 | Navigation audit | 2026-03-22 | 2026-04-22 | Monthly | — | `/nav-audit` — discoverability, backlinks |
 | GDPR audit | — | — | Quarterly | — | Exports, consent, PII logging |
 | Migration squash check | 2026-02-24 | 2026-03-24 | Monthly | — | Check `/Admin/DbVersion` on prod, QA (humans.n.burn.camp), and local dev. Oldest `lastApplied` across all three is the safe squash boundary. |
-| NuGet full update | 2026-03-08 | 2026-04-08 | Monthly | — | Non-security package updates |
-| About page package sync | 2026-03-08 | 2026-04-08 | Monthly | — | Update `About.cshtml` package versions after NuGet updates |
+| NuGet full update | 2026-04-05 | 2026-05-05 | Monthly | — | Non-security package updates |
+| About page package sync | 2026-04-05 | 2026-05-05 | Monthly | — | Update `About.cshtml` package versions after NuGet updates |
 | GitHub issue triage | 2026-03-08 | 2026-03-15 | Weekly | — | Sync issues vs todos.md |
 | Access matrix verification | 2026-03-18 | 2026-03-25 | Weekly | — | Compare `AccessMatrixDefinitions.cs` against actual controller auth checks |

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,16 +6,16 @@
   <ItemGroup>
     <!-- Core Framework -->
     <PackageVersion Include="HtmlSanitizer" Version="9.0.892" />
-    <PackageVersion Include="Markdig" Version="1.1.1" />
-    <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.Google" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.3" />
+    <PackageVersion Include="Markdig" Version="1.1.2" />
+    <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.Google" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.5" />
     <!-- Database -->
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.3" />
-    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
-    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5" />
+    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
+    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime" Version="10.0.1" />
     <!-- NodaTime -->
     <PackageVersion Include="NodaTime" Version="3.3.1" />
     <PackageVersion Include="NodaTime.Serialization.SystemTextJson" Version="1.3.1" />
@@ -32,7 +32,7 @@
     <!-- Google Workspace APIs -->
     <PackageVersion Include="Google.Apis.Admin.Directory.directory_v1" Version="1.73.0.4075" />
     <PackageVersion Include="Google.Apis.CloudIdentity.v1" Version="1.73.0.4030" />
-    <PackageVersion Include="Google.Apis.Drive.v3" Version="1.73.0.4068" />
+    <PackageVersion Include="Google.Apis.Drive.v3" Version="1.73.0.4098" />
     <PackageVersion Include="Google.Apis.DriveActivity.v2" Version="1.70.0.3880" />
     <PackageVersion Include="Google.Apis.Groupssettings.v1" Version="1.68.0.2721" />
     <PackageVersion Include="Google.Apis.Auth" Version="1.73.0" />
@@ -54,10 +54,10 @@
     <!-- Image Processing -->
     <PackageVersion Include="Magick.NET-Q8-AnyCPU" Version="14.11.1" />
     <!-- Localization -->
-    <PackageVersion Include="Microsoft.Extensions.Localization" Version="10.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.Localization" Version="10.0.5" />
     <!-- Data Protection -->
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="10.0.3" />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="10.0.5" />
     <!-- Health Checks -->
     <PackageVersion Include="AspNetCore.HealthChecks.NpgSql" Version="9.0.0" />
     <PackageVersion Include="AspNetCore.HealthChecks.Hangfire" Version="9.0.0" />
@@ -66,7 +66,7 @@
     <PackageVersion Include="MinVer" Version="7.0.0" />
     <!-- Analyzers -->
     <PackageVersion Include="Roslynator.Analyzers" Version="4.15.0" />
-    <PackageVersion Include="Meziantou.Analyzer" Version="3.0.19" />
+    <PackageVersion Include="Meziantou.Analyzer" Version="3.0.44" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15" />
     <!-- Testing -->
     <PackageVersion Include="coverlet.collector" Version="8.0.0" />

--- a/src/Humans.Web/Views/About/Index.cshtml
+++ b/src/Humans.Web/Views/About/Index.cshtml
@@ -128,31 +128,31 @@
                 <tr>
                     <td>Framework</td>
                     <td><a href="https://www.nuget.org/packages/Microsoft.AspNetCore.Identity.EntityFrameworkCore" target="_blank" rel="noopener noreferrer">Microsoft.AspNetCore.Identity.EntityFrameworkCore</a></td>
-                    <td>10.0.3</td>
+                    <td>10.0.5</td>
                     <td>MIT</td>
                 </tr>
                 <tr>
                     <td>Framework</td>
                     <td><a href="https://www.nuget.org/packages/Microsoft.AspNetCore.Authentication.Google" target="_blank" rel="noopener noreferrer">Microsoft.AspNetCore.Authentication.Google</a></td>
-                    <td>10.0.3</td>
+                    <td>10.0.5</td>
                     <td>MIT</td>
                 </tr>
                 <tr>
                     <td>Framework</td>
                     <td><a href="https://www.nuget.org/packages/Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" target="_blank" rel="noopener noreferrer">Microsoft.AspNetCore.DataProtection.EntityFrameworkCore</a></td>
-                    <td>10.0.3</td>
+                    <td>10.0.5</td>
                     <td>MIT</td>
                 </tr>
                 <tr>
                     <td>Framework</td>
                     <td><a href="https://www.nuget.org/packages/Microsoft.EntityFrameworkCore" target="_blank" rel="noopener noreferrer">Microsoft.EntityFrameworkCore</a></td>
-                    <td>10.0.3</td>
+                    <td>10.0.5</td>
                     <td>MIT</td>
                 </tr>
                 <tr>
                     <td>Framework</td>
                     <td><a href="https://www.nuget.org/packages/Microsoft.Extensions.Localization" target="_blank" rel="noopener noreferrer">Microsoft.Extensions.Localization</a></td>
-                    <td>10.0.3</td>
+                    <td>10.0.5</td>
                     <td>MIT</td>
                 </tr>
 
@@ -160,13 +160,13 @@
                 <tr>
                     <td>Database</td>
                     <td><a href="https://www.nuget.org/packages/Npgsql.EntityFrameworkCore.PostgreSQL" target="_blank" rel="noopener noreferrer">Npgsql.EntityFrameworkCore.PostgreSQL</a></td>
-                    <td>10.0.0</td>
+                    <td>10.0.1</td>
                     <td>PostgreSQL</td>
                 </tr>
                 <tr>
                     <td>Database</td>
                     <td><a href="https://www.nuget.org/packages/Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime" target="_blank" rel="noopener noreferrer">Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime</a></td>
-                    <td>10.0.0</td>
+                    <td>10.0.1</td>
                     <td>PostgreSQL</td>
                 </tr>
 
@@ -238,7 +238,7 @@
                 <tr>
                     <td>Google APIs</td>
                     <td><a href="https://www.nuget.org/packages/Google.Apis.Drive.v3" target="_blank" rel="noopener noreferrer">Google.Apis.Drive.v3</a></td>
-                    <td>1.73.0.4068</td>
+                    <td>1.73.0.4098</td>
                     <td>Apache-2.0</td>
                 </tr>
                 <tr>
@@ -338,7 +338,7 @@
                 <tr>
                     <td>Markdown</td>
                     <td><a href="https://www.nuget.org/packages/Markdig" target="_blank" rel="noopener noreferrer">Markdig</a></td>
-                    <td>1.1.1</td>
+                    <td>1.1.2</td>
                     <td>BSD-2-Clause</td>
                 </tr>
                 <tr>

--- a/tests/e2e/helpers/auth.ts
+++ b/tests/e2e/helpers/auth.ts
@@ -3,7 +3,7 @@ import { type Page, type APIResponse, expect } from '@playwright/test';
 const NAV_SELECTOR = '[data-testid="user-nav"], .navbar .dropdown:has(.profile-dropdown-menu)';
 
 async function loginAs(page: Page, slug: string): Promise<void> {
-  await page.goto(`/dev/login/${slug}`, { waitUntil: 'networkidle' });
+  await page.goto(`/dev/login/${slug}`, { waitUntil: 'domcontentloaded' });
   await page.waitForSelector(NAV_SELECTOR);
 }
 


### PR DESCRIPTION
## Summary
- **NuGet updates**: Microsoft.* 10.0.3→10.0.5, Npgsql.* 10.0.0→10.0.1, Google.Apis.Drive.v3 patch, Markdig 1.1.2, Meziantou.Analyzer 3.0.44
- **Fix flaky E2E**: nav-visibility tests (coordinator, feedbackAdmin) timed out on `networkidle` wait — changed to `domcontentloaded` since `waitForSelector(NAV_SELECTOR)` already ensures page readiness
- **About page**: synced all updated package versions
- **Maintenance log**: marked vuln check, NuGet full update, About page sync as done

## Test plan
- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — 886 tests pass (111 Domain + 755 Application + 20 Integration)
- [x] `dotnet format --verify-no-changes` — clean
- [ ] E2E tests pass on preview (nav-visibility no longer times out)

🤖 Generated with [Claude Code](https://claude.com/claude-code)