### PR TITLE
Add EF Core query monitoring dashboard (#22)

### DIFF
--- a/src/Humans.Infrastructure/Data/QueryMonitoringInterceptor.cs
+++ b/src/Humans.Infrastructure/Data/QueryMonitoringInterceptor.cs
@@ -119,27 +119,27 @@ public partial class QueryMonitoringInterceptor : DbCommandInterceptor
     private static string? ExtractFromClause(string sql)
     {
         var match = FromTablePattern().Match(sql);
-        return match.Success ? match.Groups[1].Value : null;
+        return match.Success ? match.Groups["table"].Value : null;
     }
 
     private static string? ExtractInsertTable(string sql)
     {
         var match = InsertTablePattern().Match(sql);
-        return match.Success ? match.Groups[1].Value : null;
+        return match.Success ? match.Groups["table"].Value : null;
     }
 
     private static string? ExtractUpdateTable(string sql)
     {
         var match = UpdateTablePattern().Match(sql);
-        return match.Success ? match.Groups[1].Value : null;
+        return match.Success ? match.Groups["table"].Value : null;
     }
 
-    [GeneratedRegex(@"\bFROM\s+(""?[\w.]+""?)", RegexOptions.IgnoreCase)]
+    [GeneratedRegex(@"\bFROM\s+(?<table>""?[\w.]+""?)", RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture | RegexOptions.NonBacktracking)]
     private static partial Regex FromTablePattern();
 
-    [GeneratedRegex(@"\bINSERT\s+INTO\s+(""?[\w.]+""?)", RegexOptions.IgnoreCase)]
+    [GeneratedRegex(@"\bINSERT\s+INTO\s+(?<table>""?[\w.]+""?)", RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture | RegexOptions.NonBacktracking)]
     private static partial Regex InsertTablePattern();
 
-    [GeneratedRegex(@"\bUPDATE\s+(""?[\w.]+""?)", RegexOptions.IgnoreCase)]
+    [GeneratedRegex(@"\bUPDATE\s+(?<table>""?[\w.]+""?)", RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture | RegexOptions.NonBacktracking)]
     private static partial Regex UpdateTablePattern();
 }

--- a/src/Humans.Infrastructure/Data/QueryMonitoringInterceptor.cs
+++ b/src/Humans.Infrastructure/Data/QueryMonitoringInterceptor.cs
@@ -134,12 +134,12 @@ public partial class QueryMonitoringInterceptor : DbCommandInterceptor
         return match.Success ? match.Groups[1].Value : null;
     }
 
-    [GeneratedRegex(@"\bFROM\s+(["""]?[\w.]+["""]?)", RegexOptions.IgnoreCase)]
+    [GeneratedRegex(@"\bFROM\s+(""?[\w.]+""?)", RegexOptions.IgnoreCase)]
     private static partial Regex FromTablePattern();
 
-    [GeneratedRegex(@"\bINSERT\s+INTO\s+(["""]?[\w.]+["""]?)", RegexOptions.IgnoreCase)]
+    [GeneratedRegex(@"\bINSERT\s+INTO\s+(""?[\w.]+""?)", RegexOptions.IgnoreCase)]
     private static partial Regex InsertTablePattern();
 
-    [GeneratedRegex(@"\bUPDATE\s+(["""]?[\w.]+["""]?)", RegexOptions.IgnoreCase)]
+    [GeneratedRegex(@"\bUPDATE\s+(""?[\w.]+""?)", RegexOptions.IgnoreCase)]
     private static partial Regex UpdateTablePattern();
 }

--- a/src/Humans.Infrastructure/Data/QueryMonitoringInterceptor.cs
+++ b/src/Humans.Infrastructure/Data/QueryMonitoringInterceptor.cs
@@ -1,0 +1,145 @@
+using System.Data.Common;
+using System.Diagnostics;
+using System.Text.RegularExpressions;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
+namespace Humans.Infrastructure.Data;
+
+/// <summary>
+/// EF Core interceptor that tracks query execution counts and timings in memory,
+/// grouped by operation type (SELECT/INSERT/UPDATE/DELETE) and table name.
+/// </summary>
+public partial class QueryMonitoringInterceptor : DbCommandInterceptor
+{
+    private readonly QueryStatistics _statistics;
+
+    public QueryMonitoringInterceptor(QueryStatistics statistics)
+    {
+        _statistics = statistics;
+    }
+
+    public override DbDataReader ReaderExecuted(DbCommand command, CommandExecutedEventData eventData,
+        DbDataReader result)
+    {
+        RecordExecution(command.CommandText, eventData.Duration);
+        return base.ReaderExecuted(command, eventData, result);
+    }
+
+    public override ValueTask<DbDataReader> ReaderExecutedAsync(DbCommand command,
+        CommandExecutedEventData eventData, DbDataReader result,
+        CancellationToken cancellationToken = default)
+    {
+        RecordExecution(command.CommandText, eventData.Duration);
+        return base.ReaderExecutedAsync(command, eventData, result, cancellationToken);
+    }
+
+    public override int NonQueryExecuted(DbCommand command, CommandExecutedEventData eventData, int result)
+    {
+        RecordExecution(command.CommandText, eventData.Duration);
+        return base.NonQueryExecuted(command, eventData, result);
+    }
+
+    public override ValueTask<int> NonQueryExecutedAsync(DbCommand command,
+        CommandExecutedEventData eventData, int result,
+        CancellationToken cancellationToken = default)
+    {
+        RecordExecution(command.CommandText, eventData.Duration);
+        return base.NonQueryExecutedAsync(command, eventData, result, cancellationToken);
+    }
+
+    public override object? ScalarExecuted(DbCommand command, CommandExecutedEventData eventData,
+        object? result)
+    {
+        RecordExecution(command.CommandText, eventData.Duration);
+        return base.ScalarExecuted(command, eventData, result);
+    }
+
+    public override ValueTask<object?> ScalarExecutedAsync(DbCommand command,
+        CommandExecutedEventData eventData, object? result,
+        CancellationToken cancellationToken = default)
+    {
+        RecordExecution(command.CommandText, eventData.Duration);
+        return base.ScalarExecutedAsync(command, eventData, result, cancellationToken);
+    }
+
+    private void RecordExecution(string commandText, TimeSpan duration)
+    {
+        var (operation, table) = ParseCommand(commandText);
+        if (operation is not null && table is not null)
+        {
+            _statistics.Record(operation, table, duration.TotalMilliseconds);
+        }
+    }
+
+    internal static (string? Operation, string? Table) ParseCommand(string commandText)
+    {
+        if (string.IsNullOrWhiteSpace(commandText))
+            return (null, null);
+
+        var trimmed = commandText.TrimStart();
+
+        // Determine operation from the first SQL keyword
+        string? operation = null;
+        if (trimmed.StartsWith("SELECT", StringComparison.OrdinalIgnoreCase))
+            operation = "SELECT";
+        else if (trimmed.StartsWith("INSERT", StringComparison.OrdinalIgnoreCase))
+            operation = "INSERT";
+        else if (trimmed.StartsWith("UPDATE", StringComparison.OrdinalIgnoreCase))
+            operation = "UPDATE";
+        else if (trimmed.StartsWith("DELETE", StringComparison.OrdinalIgnoreCase))
+            operation = "DELETE";
+
+        if (operation is null)
+            return (null, null);
+
+        // Extract table name based on operation
+        var table = operation switch
+        {
+            "SELECT" => ExtractFromClause(trimmed),
+            "INSERT" => ExtractInsertTable(trimmed),
+            "UPDATE" => ExtractUpdateTable(trimmed),
+            "DELETE" => ExtractFromClause(trimmed),
+            _ => null
+        };
+
+        if (table is null)
+            return (null, null);
+
+        // Strip schema prefix (e.g., "public.profiles" -> "profiles")
+        var dotIndex = table.IndexOf('.', StringComparison.Ordinal);
+        if (dotIndex >= 0 && dotIndex < table.Length - 1)
+            table = table[(dotIndex + 1)..];
+
+        // Remove surrounding quotes
+        table = table.Trim('"');
+
+        return (operation, table);
+    }
+
+    private static string? ExtractFromClause(string sql)
+    {
+        var match = FromTablePattern().Match(sql);
+        return match.Success ? match.Groups[1].Value : null;
+    }
+
+    private static string? ExtractInsertTable(string sql)
+    {
+        var match = InsertTablePattern().Match(sql);
+        return match.Success ? match.Groups[1].Value : null;
+    }
+
+    private static string? ExtractUpdateTable(string sql)
+    {
+        var match = UpdateTablePattern().Match(sql);
+        return match.Success ? match.Groups[1].Value : null;
+    }
+
+    [GeneratedRegex(@"\bFROM\s+(["""]?[\w.]+["""]?)", RegexOptions.IgnoreCase)]
+    private static partial Regex FromTablePattern();
+
+    [GeneratedRegex(@"\bINSERT\s+INTO\s+(["""]?[\w.]+["""]?)", RegexOptions.IgnoreCase)]
+    private static partial Regex InsertTablePattern();
+
+    [GeneratedRegex(@"\bUPDATE\s+(["""]?[\w.]+["""]?)", RegexOptions.IgnoreCase)]
+    private static partial Regex UpdateTablePattern();
+}

--- a/src/Humans.Infrastructure/Data/QueryStatistics.cs
+++ b/src/Humans.Infrastructure/Data/QueryStatistics.cs
@@ -1,0 +1,80 @@
+using System.Collections.Concurrent;
+
+namespace Humans.Infrastructure.Data;
+
+/// <summary>
+/// Thread-safe in-memory store for DB query execution statistics.
+/// Registered as a singleton — stats reset on application restart.
+/// </summary>
+public class QueryStatistics
+{
+    private readonly ConcurrentDictionary<string, QueryStatEntry> _entries = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Record a query execution for the given operation + table key.
+    /// </summary>
+    public void Record(string operation, string table, double elapsedMilliseconds)
+    {
+        var key = $"{operation}:{table}";
+        _entries.AddOrUpdate(
+            key,
+            _ => new QueryStatEntry(operation, table, 1, elapsedMilliseconds, elapsedMilliseconds),
+            (_, existing) => existing.Add(elapsedMilliseconds));
+    }
+
+    /// <summary>
+    /// Get a snapshot of all current statistics, ordered by count descending.
+    /// </summary>
+    public IReadOnlyList<QueryStatEntry> GetSnapshot()
+    {
+        return _entries.Values
+            .OrderByDescending(e => e.Count)
+            .ToList();
+    }
+
+    /// <summary>
+    /// Reset all counters.
+    /// </summary>
+    public void Reset()
+    {
+        _entries.Clear();
+    }
+
+    /// <summary>
+    /// Total number of tracked query executions across all keys.
+    /// </summary>
+    public long TotalCount => _entries.Values.Sum(e => e.Count);
+}
+
+/// <summary>
+/// Immutable snapshot of statistics for a single operation + table combination.
+/// </summary>
+public sealed class QueryStatEntry
+{
+    public string Operation { get; }
+    public string Table { get; }
+    public long Count { get; private set; }
+    public double TotalMilliseconds { get; private set; }
+    public double MaxMilliseconds { get; private set; }
+
+    public double AverageMilliseconds => Count > 0 ? TotalMilliseconds / Count : 0;
+
+    public QueryStatEntry(string operation, string table, long count, double totalMs, double maxMs)
+    {
+        Operation = operation;
+        Table = table;
+        Count = count;
+        TotalMilliseconds = totalMs;
+        MaxMilliseconds = maxMs;
+    }
+
+    internal QueryStatEntry Add(double elapsedMs)
+    {
+        // ConcurrentDictionary.AddOrUpdate serializes calls per key, so this is safe
+        Count++;
+        TotalMilliseconds += elapsedMs;
+        if (elapsedMs > MaxMilliseconds)
+            MaxMilliseconds = elapsedMs;
+        return this;
+    }
+}

--- a/src/Humans.Web/Controllers/AdminController.cs
+++ b/src/Humans.Web/Controllers/AdminController.cs
@@ -21,6 +21,7 @@ public class AdminController : HumansControllerBase
     private readonly IWebHostEnvironment _environment;
     private readonly IOnboardingService _onboardingService;
     private readonly ConfigurationRegistry _configRegistry;
+    private readonly QueryStatistics _queryStatistics;
 
     public AdminController(
         HumansDbContext dbContext,
@@ -28,7 +29,8 @@ public class AdminController : HumansControllerBase
         ILogger<AdminController> logger,
         IWebHostEnvironment environment,
         IOnboardingService onboardingService,
-        ConfigurationRegistry configRegistry)
+        ConfigurationRegistry configRegistry,
+        QueryStatistics queryStatistics)
         : base(userManager)
     {
         _dbContext = dbContext;
@@ -37,6 +39,7 @@ public class AdminController : HumansControllerBase
         _environment = environment;
         _onboardingService = onboardingService;
         _configRegistry = configRegistry;
+        _queryStatistics = queryStatistics;
     }
 
     [HttpGet("")]
@@ -163,6 +166,54 @@ public class AdminController : HumansControllerBase
             appliedCount = applied.Count,
             pendingCount = pending.Count()
         });
+    }
+
+    [HttpGet("DbStats")]
+    public IActionResult DbStats()
+    {
+        try
+        {
+            var snapshot = _queryStatistics.GetSnapshot();
+            var model = new DbStatsViewModel
+            {
+                TotalQueryCount = _queryStatistics.TotalCount,
+                Entries = snapshot.Select(e => new DbStatEntryViewModel
+                {
+                    Operation = e.Operation,
+                    Table = e.Table,
+                    Count = e.Count,
+                    AverageMs = Math.Round(e.AverageMilliseconds, 2),
+                    MaxMs = Math.Round(e.MaxMilliseconds, 2),
+                    TotalMs = Math.Round(e.TotalMilliseconds, 2)
+                }).ToList()
+            };
+            return View(model);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error loading DB stats");
+            SetError("Failed to load database statistics.");
+            return RedirectToAction(nameof(Index));
+        }
+    }
+
+    [HttpPost("DbStats/Reset")]
+    [ValidateAntiForgeryToken]
+    public IActionResult ResetDbStats()
+    {
+        try
+        {
+            _queryStatistics.Reset();
+            _logger.LogInformation("Admin reset DB query statistics");
+            SetSuccess("Query statistics have been reset.");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error resetting DB stats");
+            SetError("Failed to reset database statistics.");
+        }
+
+        return RedirectToAction(nameof(DbStats));
     }
 
     [HttpPost("ClearHangfireLocks")]

--- a/src/Humans.Web/Models/AdminViewModels.cs
+++ b/src/Humans.Web/Models/AdminViewModels.cs
@@ -364,6 +364,22 @@ public class EmailOutboxViewModel
     public List<EmailOutboxMessage> Messages { get; set; } = [];
 }
 
+public class DbStatsViewModel
+{
+    public long TotalQueryCount { get; set; }
+    public List<DbStatEntryViewModel> Entries { get; set; } = [];
+}
+
+public class DbStatEntryViewModel
+{
+    public string Operation { get; set; } = string.Empty;
+    public string Table { get; set; } = string.Empty;
+    public long Count { get; set; }
+    public double AverageMs { get; set; }
+    public double MaxMs { get; set; }
+    public double TotalMs { get; set; }
+}
+
 public class DuplicateAccountListViewModel
 {
     public List<DuplicateAccountGroupViewModel> Groups { get; set; } = [];

--- a/src/Humans.Web/Program.cs
+++ b/src/Humans.Web/Program.cs
@@ -91,6 +91,10 @@ builder.Services.AddSingleton(sp =>
     return dsb.Build();
 });
 
+// Query monitoring — singleton interceptor tracks execution counts by table + operation
+builder.Services.AddSingleton<QueryStatistics>();
+builder.Services.AddSingleton<QueryMonitoringInterceptor>();
+
 // Configure EF Core with PostgreSQL
 builder.Services.AddDbContext<HumansDbContext>((sp, options) =>
 {
@@ -100,6 +104,7 @@ builder.Services.AddDbContext<HumansDbContext>((sp, options) =>
         npgsqlOptions.MigrationsAssembly("Humans.Infrastructure");
         npgsqlOptions.UseQuerySplittingBehavior(QuerySplittingBehavior.SplitQuery);
     });
+    options.AddInterceptors(sp.GetRequiredService<QueryMonitoringInterceptor>());
     // Suppress "First/FirstOrDefault without OrderBy" warning — the codebase universally uses
     // .FirstOrDefaultAsync(e => e.Id == id) for PK lookups which are deterministic by definition.
     options.ConfigureWarnings(w => w.Ignore(CoreEventId.FirstWithoutOrderByAndFilterWarning));

--- a/src/Humans.Web/Views/Admin/DbStats.cshtml
+++ b/src/Humans.Web/Views/Admin/DbStats.cshtml
@@ -1,0 +1,95 @@
+@model DbStatsViewModel
+@{
+    ViewData["Title"] = "Database Query Statistics";
+}
+
+<div class="d-flex justify-content-between align-items-center mb-3">
+    <h1 class="mb-0">Database Query Statistics</h1>
+    <div class="d-flex align-items-center gap-3">
+        <span class="text-muted">@Model.TotalQueryCount.ToString("N0") total queries since last restart</span>
+        <form asp-action="ResetDbStats" method="post" class="d-inline">
+            @Html.AntiForgeryToken()
+            <button type="submit" class="btn btn-outline-warning btn-sm"
+                    data-confirm="Reset all query statistics?">
+                <i class="fa-solid fa-rotate-right me-1"></i>Reset
+            </button>
+        </form>
+        <a asp-action="Index" class="btn btn-outline-secondary btn-sm">
+            <i class="fa-solid fa-arrow-left me-1"></i>Admin
+        </a>
+    </div>
+</div>
+
+<vc:temp-data-alerts />
+
+@if (Model.Entries.Count == 0)
+{
+    <div class="alert alert-info">
+        <i class="fa-solid fa-info-circle me-1"></i>No query statistics recorded yet. Navigate around the app to generate data.
+    </div>
+}
+else
+{
+    <div class="table-responsive">
+        <table class="table table-sm table-hover font-monospace" style="font-size: 0.85rem;" id="dbStatsTable">
+            <thead>
+                <tr>
+                    <th style="cursor:pointer;" onclick="sortTable(0)">Operation <i class="fa-solid fa-sort fa-xs"></i></th>
+                    <th style="cursor:pointer;" onclick="sortTable(1)">Table <i class="fa-solid fa-sort fa-xs"></i></th>
+                    <th style="cursor:pointer;" onclick="sortTable(2)" class="text-end">Count <i class="fa-solid fa-sort fa-xs"></i></th>
+                    <th style="cursor:pointer;" onclick="sortTable(3)" class="text-end">Avg (ms) <i class="fa-solid fa-sort fa-xs"></i></th>
+                    <th style="cursor:pointer;" onclick="sortTable(4)" class="text-end">Max (ms) <i class="fa-solid fa-sort fa-xs"></i></th>
+                    <th style="cursor:pointer;" onclick="sortTable(5)" class="text-end">Total (ms) <i class="fa-solid fa-sort fa-xs"></i></th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach (var entry in Model.Entries)
+                {
+                    var opClass = entry.Operation switch
+                    {
+                        "SELECT" => "",
+                        "INSERT" => "table-success",
+                        "UPDATE" => "table-info",
+                        "DELETE" => "table-warning",
+                        _ => ""
+                    };
+                    <tr class="@opClass">
+                        <td>@entry.Operation</td>
+                        <td>@entry.Table</td>
+                        <td class="text-end">@entry.Count.ToString("N0")</td>
+                        <td class="text-end">@entry.AverageMs.ToString("F2")</td>
+                        <td class="text-end">@entry.MaxMs.ToString("F2")</td>
+                        <td class="text-end">@entry.TotalMs.ToString("F2")</td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+    </div>
+}
+
+@section Scripts {
+    <script>
+        // Simple client-side column sorting
+        let sortDir = {};
+        function sortTable(colIndex) {
+            const table = document.getElementById('dbStatsTable');
+            const tbody = table.querySelector('tbody');
+            const rows = Array.from(tbody.querySelectorAll('tr'));
+            const isNumeric = colIndex >= 2;
+
+            sortDir[colIndex] = !sortDir[colIndex];
+            const dir = sortDir[colIndex] ? 1 : -1;
+
+            rows.sort((a, b) => {
+                const aVal = a.cells[colIndex].textContent.trim().replace(/,/g, '');
+                const bVal = b.cells[colIndex].textContent.trim().replace(/,/g, '');
+                if (isNumeric) {
+                    return (parseFloat(aVal) - parseFloat(bVal)) * dir;
+                }
+                return aVal.localeCompare(bVal) * dir;
+            });
+
+            rows.forEach(row => tbody.appendChild(row));
+        }
+    </script>
+}

--- a/src/Humans.Web/Views/Admin/DbStats.cshtml
+++ b/src/Humans.Web/Views/Admin/DbStats.cshtml
@@ -34,12 +34,12 @@ else
         <table class="table table-sm table-hover font-monospace" style="font-size: 0.85rem;" id="dbStatsTable">
             <thead>
                 <tr>
-                    <th style="cursor:pointer;" onclick="sortTable(0)">Operation <i class="fa-solid fa-sort fa-xs"></i></th>
-                    <th style="cursor:pointer;" onclick="sortTable(1)">Table <i class="fa-solid fa-sort fa-xs"></i></th>
-                    <th style="cursor:pointer;" onclick="sortTable(2)" class="text-end">Count <i class="fa-solid fa-sort fa-xs"></i></th>
-                    <th style="cursor:pointer;" onclick="sortTable(3)" class="text-end">Avg (ms) <i class="fa-solid fa-sort fa-xs"></i></th>
-                    <th style="cursor:pointer;" onclick="sortTable(4)" class="text-end">Max (ms) <i class="fa-solid fa-sort fa-xs"></i></th>
-                    <th style="cursor:pointer;" onclick="sortTable(5)" class="text-end">Total (ms) <i class="fa-solid fa-sort fa-xs"></i></th>
+                    <th style="cursor:pointer;" data-sort-col="0">Operation <i class="fa-solid fa-sort fa-xs"></i></th>
+                    <th style="cursor:pointer;" data-sort-col="1">Table <i class="fa-solid fa-sort fa-xs"></i></th>
+                    <th style="cursor:pointer;" data-sort-col="2" class="text-end">Count <i class="fa-solid fa-sort fa-xs"></i></th>
+                    <th style="cursor:pointer;" data-sort-col="3" class="text-end">Avg (ms) <i class="fa-solid fa-sort fa-xs"></i></th>
+                    <th style="cursor:pointer;" data-sort-col="4" class="text-end">Max (ms) <i class="fa-solid fa-sort fa-xs"></i></th>
+                    <th style="cursor:pointer;" data-sort-col="5" class="text-end">Total (ms) <i class="fa-solid fa-sort fa-xs"></i></th>
                 </tr>
             </thead>
             <tbody>
@@ -69,27 +69,32 @@ else
 
 @section Scripts {
     <script>
-        // Simple client-side column sorting
-        let sortDir = {};
-        function sortTable(colIndex) {
-            const table = document.getElementById('dbStatsTable');
-            const tbody = table.querySelector('tbody');
-            const rows = Array.from(tbody.querySelectorAll('tr'));
-            const isNumeric = colIndex >= 2;
+        // Simple client-side column sorting (uses data attributes instead of
+        // inline onclick handlers, which are blocked by the CSP nonce policy)
+        (function () {
+            const sortDir = {};
+            document.querySelectorAll('#dbStatsTable th[data-sort-col]').forEach(th => {
+                th.addEventListener('click', function () {
+                    const colIndex = parseInt(this.dataset.sortCol);
+                    const tbody = document.querySelector('#dbStatsTable tbody');
+                    const rows = Array.from(tbody.querySelectorAll('tr'));
+                    const isNumeric = colIndex >= 2;
 
-            sortDir[colIndex] = !sortDir[colIndex];
-            const dir = sortDir[colIndex] ? 1 : -1;
+                    sortDir[colIndex] = !sortDir[colIndex];
+                    const dir = sortDir[colIndex] ? 1 : -1;
 
-            rows.sort((a, b) => {
-                const aVal = a.cells[colIndex].textContent.trim().replace(/,/g, '');
-                const bVal = b.cells[colIndex].textContent.trim().replace(/,/g, '');
-                if (isNumeric) {
-                    return (parseFloat(aVal) - parseFloat(bVal)) * dir;
-                }
-                return aVal.localeCompare(bVal) * dir;
+                    rows.sort((a, b) => {
+                        const aVal = a.cells[colIndex].textContent.trim().replace(/,/g, '');
+                        const bVal = b.cells[colIndex].textContent.trim().replace(/,/g, '');
+                        if (isNumeric) {
+                            return (parseFloat(aVal) - parseFloat(bVal)) * dir;
+                        }
+                        return aVal.localeCompare(bVal) * dir;
+                    });
+
+                    rows.forEach(row => tbody.appendChild(row));
+                });
             });
-
-            rows.forEach(row => tbody.appendChild(row));
-        }
+        })();
     </script>
 }

--- a/src/Humans.Web/Views/Admin/Index.cshtml
+++ b/src/Humans.Web/Views/Admin/Index.cshtml
@@ -41,6 +41,9 @@
                 <a asp-action="Logs" class="list-group-item list-group-item-action">
                     <i class="fa-solid fa-triangle-exclamation me-2"></i>Application Logs
                 </a>
+                <a asp-action="DbStats" class="list-group-item list-group-item-action">
+                    <i class="fa-solid fa-database me-2"></i>Database Query Statistics
+                </a>
                 <a asp-controller="Google" asp-action="Accounts" class="list-group-item list-group-item-action">
                     <i class="fa-solid fa-at me-2"></i>@@nobodies.team Accounts
                 </a>


### PR DESCRIPTION
## Summary
- Add `QueryMonitoringInterceptor` (`DbCommandInterceptor`) that tracks DB query counts by table + operation in memory
- Admin-only dashboard at `/Admin/DbStats` showing query statistics sorted by count with client-side column sorting
- Tracks execution count, average/max/total milliseconds per operation+table group
- No persistence — stats reset on restart, which is fine for a ~500-user system
- Manual reset button available on the dashboard

## Issues
Closes nobodies-collective/Humans#22

## Test plan
- [ ] Visit `/Admin/DbStats` as Admin — shows query statistics table
- [ ] Non-admin users cannot access the page
- [ ] Stats increment as you navigate the app
- [ ] Click column headers to sort by different columns
- [ ] Reset button clears all statistics
- [ ] No visible performance degradation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>