### PR TITLE
Sync 6 stale feature specs with current implementation

### DIFF
--- a/.claude/MAINTENANCE_LOG.md
+++ b/.claude/MAINTENANCE_LOG.md
@@ -9,7 +9,7 @@ Tracks when recurring maintenance processes were last run.
 | Code simplification | 2026-02-24 | — | After features | codex: ~5% | Dead code, unused abstractions |
 | ReSharper InspectCode | 2026-02-24 | 2026-03-03 | Weekly | — | `/resharper` — fix Tier 1+2 warnings. Codex can't run `jb` in sandbox. |
 | Context cleanup | 2026-03-18 | 2026-04-18 | Monthly | — | CLAUDE.md, .claude/, todos.md |
-| Feature spec sync | 2026-02-12 | 2026-03-12 | Monthly | — | docs/features/ vs implementation |
+| Feature spec sync | 2026-04-05 | 2026-05-05 | Monthly | — | docs/features/ vs implementation |
 | i18n audit | 2026-02-24 | 2026-03-24 | Monthly | gemini: ~2% | Missing translations |
 | Data model doc sync | 2026-02-12 | As needed | As needed | — | .claude/DATA_MODEL.md vs entities |
 | Navigation audit | 2026-03-22 | 2026-04-22 | Monthly | — | `/nav-audit` — discoverability, backlinks |

--- a/docs/features/01-authentication.md
+++ b/docs/features/01-authentication.md
@@ -101,19 +101,45 @@ RoleAssignment
 
 ## Authorization Roles
 
+All roles are stored as temporal `RoleAssignment` records. Role claims are added to the user's identity via `RoleAssignmentClaimsTransformation` on each request.
+
+### Governance Roles (manage the platform)
+
 | Role | Description | Capabilities |
 |------|-------------|--------------|
 | **Admin** | System administrator | Full platform access, manage all features, Hangfire |
-| **Board** | Board member | Approve volunteers, approve team joins, view legal names, system oversight |
-| **Member** | Regular member | Access own profile, join teams, submit applications |
+| **Board** | Board member | Vote on tier applications, view legal names, system oversight |
+
+### Coordinator Roles (operational, bypass MembershipRequiredFilter)
+
+| Role | Description |
+|------|-------------|
+| **ConsentCoordinator** | Safety checks on new humans (clear/flag consent checks) |
+| **VolunteerCoordinator** | Read-only onboarding queue access; assists new humans |
+
+### Section Admin Roles (scoped to one functional area)
+
+| Role | Description |
+|------|-------------|
+| **HumanAdmin** | Human management pages, approve/suspend/reject humans, provision @nobodies.team accounts |
+| **TeamsAdmin** | System-wide team management; view sync status but not execute |
+| **CampAdmin** | Camp management and season approval |
+| **TicketAdmin** | Ticket vendor integration, discount codes, ticket data export |
+| **FeedbackAdmin** | View all feedback, respond to reporters, manage status |
+| **FinanceAdmin** | Budget management (years, groups, categories, line items) |
+| **NoInfoAdmin** | Approve/voluntell shift signups; access volunteer medical data |
 
 ### ActiveMember Claim
 
-In addition to governance roles (Admin, Board), `RoleAssignmentClaimsTransformation` adds an `ActiveMember` claim when the user is a member of the Volunteers team. This claim is the primary authorization gate for most application features.
+In addition to governance roles, `RoleAssignmentClaimsTransformation` adds an `ActiveMember` claim when the user is a member of the Volunteers team. This claim is the primary authorization gate for most application features.
 
 - **Granted when**: User is in the Volunteers team (approved + all consents signed)
 - **Checked by**: `MembershipRequiredFilter` (global action filter) and `_Layout.cshtml` (nav visibility)
 - **Effect**: Without this claim, users can only access onboarding pages (Home, Profile, Consent, Account, Application)
+
+### Authorization Policies
+
+The app registers named authorization policies (`PolicyNames` constants in `Humans.Web.Authorization`) backed by custom `IAuthorizationHandler` implementations. These are used in views and tag helpers (`authorize-policy` attribute) alongside role-based `[Authorize(Roles = "...")]` on controllers.
 
 See [Volunteer Status](05-volunteer-status.md) for the full onboarding pipeline and gating details.
 

--- a/docs/features/07-google-integration.md
+++ b/docs/features/07-google-integration.md
@@ -439,15 +439,15 @@ Actions:
 
 ## Sync Status Page
 
-### Route: `/Teams/Sync`
-Accessible to TeamsAdmin, Board, and Admin. Shows drift across all active resources with a tabbed interface (Google Drive / Google Groups).
+### Route: `/Google/Sync`
+Accessible to TeamsAdmin, Board, and Admin. Shows drift across all active resources with a tabbed interface (Google Drive / Google Groups). Formerly at `/Teams/Sync`.
 
 | Route | Method | Auth | Action |
 |-------|--------|------|--------|
-| `/Teams/Sync` | GET | TeamsAdmin, Board, Admin | Sync status page |
-| `/Teams/Sync/Preview/{resourceType}` | GET | TeamsAdmin, Board, Admin | AJAX: preview drift for resource type |
-| `/Teams/Sync/Execute/{resourceId}` | POST | Admin only | Execute sync for one resource |
-| `/Teams/Sync/ExecuteAll/{resourceType}` | POST | Admin only | Execute sync for all resources of a type |
+| `/Google/Sync` | GET | TeamsAdmin, Board, Admin | Sync status page |
+| `/Google/Sync/Preview/{resourceType}` | GET | TeamsAdmin, Board, Admin | AJAX: preview drift for resource type |
+| `/Google/Sync/Execute/{resourceId}` | POST | Admin only | Execute sync for one resource |
+| `/Google/Sync/ExecuteAll/{resourceType}` | POST | Admin only | Execute sync for all resources of a type |
 
 ### Summary Cards (per tab)
 - **Total Resources** — count of active GoogleResource records of that type
@@ -459,25 +459,17 @@ Accessible to TeamsAdmin, Board, and Admin. Shows drift across all active resour
 Per resource: Name, Team, Status badge, members to add/remove.
 Drifted resources shown first, then in-sync.
 
-### Admin Sync Settings Page
+### Sync Settings Page
 
-#### Route: `/Admin/SyncSettings`
-Admin-only page for configuring per-service sync modes.
-
-| Route | Method | Action |
-|-------|--------|--------|
-| `/Admin/SyncSettings` | GET | View current sync mode per service |
-| `/Admin/SyncSettings` | POST | Update sync mode for a service |
-
-### Legacy Admin Sync Page
-
-#### Route: `/Admin/GoogleSync`
-Retained for backward compatibility. Shows the old-style combined sync preview/apply.
+#### Route: `/Google/SyncSettings`
+Admin-only page for configuring per-service sync modes. Formerly at `/Admin/SyncSettings`.
 
 | Route | Method | Action |
 |-------|--------|--------|
-| `/Admin/GoogleSync` | GET | Preview drift (read-only API calls) |
-| `/Admin/GoogleSync/Apply` | POST | Run full sync now |
+| `/Google/SyncSettings` | GET | View current sync mode per service |
+| `/Google/SyncSettings` | POST | Update sync mode for a service |
+
+> **Note:** The legacy `/Admin/GoogleSync` route (combined sync preview/apply) has been removed. All sync operations are now at `/Google/Sync`.
 
 ## Stub Implementations
 

--- a/docs/features/08-background-jobs.md
+++ b/docs/features/08-background-jobs.md
@@ -12,11 +12,20 @@ Several system operations need to run automatically without user interaction: sy
 | SendReConsentReminderJob | Daily | Remind about missing consents |
 | SuspendNonCompliantMembersJob | Daily 4:30 AM | Enforce compliance deadlines |
 | ProcessAccountDeletionsJob | Daily | Process account deletion requests |
+| TermRenewalReminderJob | Daily | Notify humans with approaching Colaborador/Asociado term expiry |
+| ProcessEmailOutboxJob | Frequent | Send emails queued in the outbox table |
+| CleanupEmailOutboxJob | Daily | Delete old processed outbox entries |
+| ProcessGoogleSyncOutboxJob | Frequent | Process Google sync outbox (add/remove from Groups and Drive) |
+| TicketSyncJob | Daily | Sync ticket orders from TicketTailor |
+| TicketingBudgetSyncJob | Daily 4:30 AM | Materialize weekly ticket actuals into budget line items |
+| SendAdminDailyDigestJob | Daily | Email digest to Admin: sync health, anomalies |
+| SendBoardDailyDigestJob | Daily | Email digest to Board: pending signups, applications |
+| CleanupNotificationsJob | Daily | Delete resolved notifications older than 7 days |
 | SystemTeamSyncJob | **DISABLED** | Sync system team membership + Google permissions |
 | GoogleResourceReconciliationJob | **DISABLED** | Full Google resource reconciliation |
 | DriveActivityMonitorJob | Hourly | Check Drive Activity API for anomalous permission changes |
 
-> **Note:** `SystemTeamSyncJob` and `GoogleResourceReconciliationJob` are currently disabled because they modify Google Shared Drive and Group permissions. Use the manual "Sync Now" button at `/Teams/Sync` until automated sync is validated. Per-service sync modes are configured at `/Admin/SyncSettings`.
+> **Note:** `SystemTeamSyncJob` and `GoogleResourceReconciliationJob` are currently disabled because they modify Google Shared Drive and Group permissions. Use the manual "Sync Now" button at `/Google/Sync` until automated sync is validated. Per-service sync modes are configured at `/Google/SyncSettings`.
 
 ## Job Details
 

--- a/docs/features/09-administration.md
+++ b/docs/features/09-administration.md
@@ -122,53 +122,98 @@ Approval and consent completion both trigger `SyncVolunteersMembershipForUserAsy
 
 ### BoardController (`/Board/`) — Board, Admin
 
+`BoardController` is now a slim dashboard-only controller. Most human management and Google sync operations have been extracted to `ProfileController` and `GoogleController`.
+
 | Route | Action | Description |
 |-------|--------|-------------|
-| `/Board` | Index | Dashboard |
-| `/Board/Humans` | Humans | Member list with search |
-| `/Board/Humans/{id}` | HumanDetail | Individual member view |
-| `/Board/Humans/{id}/Approve` | ApproveVolunteer | POST: Approve volunteer |
-| `/Board/Humans/{id}/Suspend` | SuspendHuman | POST: Suspend member |
-| `/Board/Humans/{id}/Unsuspend` | UnsuspendHuman | POST: Unsuspend member |
-| `/Board/Humans/{id}/Reject` | RejectSignup | POST: Reject signup |
-| `/Board/Applications` | Applications | Application list |
-| `/Board/Applications/{id}` | ApplicationDetail | Application review |
-| `/Board/Teams` | Teams | Team list |
-| `/Board/Teams/Create` | CreateTeam | New team form |
-| `/Board/Teams/{id}/Edit` | EditTeam | Edit team (includes GoogleGroupPrefix) |
-| `/Board/Teams/{id}/Delete` | DeleteTeam | POST: Deactivate team |
-| `/Board/Roles` | Roles | Role assignment management |
-| `/Board/Humans/{id}/Roles/Add` | AddRole | Add role assignment |
-| `/Board/Roles/{id}/End` | EndRole | POST: End role assignment |
-| `/Board/AuditLog` | AuditLog | Global audit log |
-| `/Board/AuditLog/CheckDriveActivity` | CheckDriveActivity | POST: Manual Drive Activity check |
-| `/Board/GoogleSync/Resource/{id}/Audit` | GoogleSyncAudit | Resource sync audit log |
-| `/Board/Humans/{id}/GoogleSyncAudit` | HumanGoogleSyncAudit | User sync audit log |
+| `/Board` | Index | Dashboard with stats and recent audit log |
+| `/Board/AuditLog` | AuditLog | Global audit log (paginated, filterable) |
+
+### ProfileController (`/Profile/`) — Human management actions
+
+Human management (previously on `BoardController`) is now on `ProfileController` under the `/Profile/Admin` sub-path, accessible to HumanAdmin, Board, and Admin roles.
+
+| Route | Action | Roles |
+|-------|--------|-------|
+| `/Profile/Admin` | AdminList | HumanAdmin, Board, Admin — member list |
+| `/Profile/{id}/Admin` | AdminDetail | HumanAdmin, Board, Admin — member detail |
+| `/Profile/{id}/Admin/Outbox` | AdminOutbox | HumanAdmin, Board, Admin — view email outbox |
+| `/Profile/{id}/Admin/Suspend` | Suspend | POST: HumanAdmin, Board, Admin |
+| `/Profile/{id}/Admin/Unsuspend` | Unsuspend | POST: HumanAdmin, Board, Admin |
+| `/Profile/{id}/Admin/Approve` | Approve | POST: HumanAdmin, Board, Admin |
+| `/Profile/{id}/Admin/Reject` | Reject | POST: HumanAdmin, Board, Admin |
+| `/Profile/{id}/Admin/Roles/Add` | AddRole | GET/POST: HumanAdmin, Board, Admin |
+| `/Profile/{id}/Admin/Roles/{roleId}/End` | EndRole | POST: HumanAdmin, Board, Admin |
+
+### ContactsController (`/Contacts/`) — HumanAdmin, Board, Admin
+
+External contacts (not yet registered users) are managed at `/Contacts/`, NOT `/Human/Admin/Contacts/` as the spec may suggest.
+
+| Route | Action | Description |
+|-------|--------|-------------|
+| `/Contacts` | Index | Contacts list |
+| `/Contacts/{id}` | Detail | Contact detail |
+| `/Contacts/Create` | Create | GET/POST: Create contact |
+
+### GoogleController (`/Google/`) — Admin (mostly)
+
+Google sync, settings, account provisioning, and audit routes have been extracted from `AdminController` and `BoardController` into `GoogleController`. These were previously documented as `/Admin/*` or `/Board/*` routes.
+
+| Route | Auth | Description |
+|-------|------|-------------|
+| `/Google/SyncSettings` | Admin | GET/POST: Per-service sync mode configuration |
+| `/Google/SyncResults` | Admin | GET: Results of last sync check |
+| `/Google/CheckGroupSettings` | Admin | POST: Check Google Group settings for drift |
+| `/Google/GroupSettingsResults` | Admin | GET: Display group settings drift results |
+| `/Google/RemediateGroupSettings` | Admin | POST: Fix settings drift on one group |
+| `/Google/RemediateAllGroupSettings` | Admin | POST: Fix settings drift on all groups |
+| `/Google/AllGroups` | Admin | GET: All Google groups |
+| `/Google/Sync` | TeamsAdmin, Board, Admin | GET: Sync status page (tabbed: Drive/Groups) |
+| `/Google/Sync/Preview/{resourceType}` | TeamsAdmin, Board, Admin | GET: AJAX preview drift |
+| `/Google/Sync/Execute/{resourceId}` | Admin | POST: Sync one resource |
+| `/Google/Sync/ExecuteAll/{resourceType}` | Admin | POST: Sync all of a type |
+| `/Google/AuditLog/CheckDriveActivity` | Board, Admin | POST: Manual Drive Activity check |
+| `/Google/Sync/Resource/{id}/Audit` | Board, Admin | GET: Per-resource sync audit log |
+| `/Google/Human/{id}/SyncAudit` | HumanAdmin, Admin | GET: Per-user sync audit log |
+| `/Google/Human/{id}/ProvisionEmail` | Admin | POST: Provision @nobodies.team email |
+| `/Google/Accounts` | Admin | GET: All @nobodies.team accounts |
+| `/Google/Accounts/Provision` | Admin | POST: Provision account |
+| `/Google/Accounts/Suspend` | Admin | POST: Suspend account |
+| `/Google/Accounts/Reactivate` | Admin | POST: Reactivate account |
+| `/Google/Accounts/ResetPassword` | Admin | POST: Reset password |
+| `/Google/Accounts/Link` | Admin | POST: Link existing account |
+| `/Google/LinkGroupToTeam` | TeamsAdmin, Board, Admin | POST: Link group to team |
+| `/Google/CheckEmailMismatches` | Admin | POST: Check email mismatches |
+| `/Google/EmailBackfillReview` | HumanAdmin, Admin | GET: Review email backfill |
+| `/Google/ApplyEmailBackfill` | Admin | POST: Apply email backfill |
 
 ### AdminController (`/Admin/`) — Admin only
+
+`AdminController` is now a slim technical-operations controller.
 
 | Route | Action | Description |
 |-------|--------|-------------|
 | `/Admin` | Index | Admin dashboard |
 | `/Admin/Humans/{id}/Purge` | PurgeHuman | POST: Dev/QA user purge (non-production) |
-| `/Admin/SyncSystemTeams` | SyncSystemTeams | POST: Trigger system team sync |
 | `/Admin/Configuration` | Configuration | Configuration status page |
-| `/Admin/EmailPreview` | EmailPreview | Preview all system emails with language tabs |
-| `/Admin/GoogleSync` | GoogleSync | Legacy Google resource sync status |
-| `/Admin/GoogleSync/Apply` | ApplyGoogleSync | POST: Run legacy full sync |
-| `/Admin/SyncSettings` | SyncSettings | Per-service sync mode configuration |
-| `/Admin/CheckGroupSettings` | CheckGroupSettings | POST: Check Google Group settings for drift |
-| `/Admin/GroupSettingsResults` | GroupSettingsResults | Display group settings drift results |
+| `/Admin/Logs` | Logs | View recent log entries |
 | `/Admin/DbVersion` | DbVersion | Database migration version |
+| `/Admin/ClearHangfireLocks` | ClearHangfireLocks | POST: Admin-only lock cleanup |
 
-### Sync Status (`/Teams/Sync`) — TeamsAdmin, Board, Admin
+### AdminDuplicateAccountsController (`/Admin/DuplicateAccounts/`) — Admin only
+
+Duplicate account detection and resolution (added in Controller Consolidation PR).
 
 | Route | Action | Description |
 |-------|--------|-------------|
-| `/Teams/Sync` | Sync | Sync status dashboard (tabbed: Drive/Groups) |
-| `/Teams/Sync/Preview/{resourceType}` | SyncPreview | AJAX: Preview drift for resource type |
-| `/Teams/Sync/Execute/{resourceId}` | SyncExecute | POST: Sync one resource (Admin only) |
-| `/Teams/Sync/ExecuteAll/{resourceType}` | SyncExecuteAll | POST: Sync all of a type (Admin only) |
+| `/Admin/DuplicateAccounts` | Index | List duplicate account candidates |
+| `/Admin/DuplicateAccounts/{id}` | Detail | Review a specific duplicate candidate |
+
+### AdminMergeController (`/Admin/Merge/`) — Admin only
+
+| Route | Action | Description |
+|-------|--------|-------------|
+| `/Admin/Merge` | Index/actions | Merge account flows |
 
 ## Dashboard Metrics
 
@@ -328,25 +373,30 @@ A user can hold both roles simultaneously. Admin is a superset for role assignme
 
 ### Additional Roles
 
+All roles are defined in `RoleNames` constants and use temporal `RoleAssignment` records (same as Board and Admin).
+
 | Role | Purpose |
 |------|---------|
-| **TeamsAdmin** | System-wide team management (edit teams, approve joins, assign coordinators, configure Google Group prefixes). Can view sync status at `/Teams/Sync` but cannot execute sync actions. |
-| **ConsentCoordinator** | Safety checks on new humans during onboarding |
-| **VolunteerCoordinator** | Read-only access to onboarding review queue |
+| **HumanAdmin** | View human admin pages, approve/suspend/reject humans, provision @nobodies.team accounts, manage role assignments. Does NOT include Board or Admin capabilities. |
+| **TeamsAdmin** | System-wide team management (edit teams, approve joins, assign coordinators, configure Google Group prefixes). Can view sync status at `/Google/Sync` but cannot execute sync actions. |
+| **CampAdmin** | Manage camps, approve/reject season registrations, configure camp settings system-wide. |
+| **TicketAdmin** | Manage ticket vendor integration, trigger syncs, generate discount codes, export ticket data. |
+| **NoInfoAdmin** | Approve/voluntell shift signups (cannot create/edit shifts). Access to volunteer event profile medical data. |
+| **FeedbackAdmin** | View all feedback reports, respond to reporters, manage feedback status, link GitHub issues. |
+| **FinanceAdmin** | Manage budgets, budget years, groups, categories, and line items. Full Finance section access. |
+| **ConsentCoordinator** | Safety checks on new humans during onboarding. Can clear or flag consent checks. Bypasses MembershipRequiredFilter. |
+| **VolunteerCoordinator** | Read-only access to onboarding review queue. Bypasses MembershipRequiredFilter. |
 
-### How It Works
+### Authorization Foundation
+
+The app uses both role-based `[Authorize(Roles = "...")]` attributes (on controllers) and policy-based `[Authorize(Policy = "...")]` attributes (on views and tag helpers via `PolicyNames` constants). Policies are defined in `AuthorizationPolicyExtensions` and registered in `Program.cs`. Policy names are in `PolicyNames` constants.
 
 Role claims are synced from the `RoleAssignment` table to Identity claims via `RoleAssignmentClaimsTransformation` (an `IClaimsTransformation`). This makes `User.IsInRole()` and `[Authorize(Roles = "...")]` work correctly based on temporal role assignments.
 
-```csharp
-[Authorize(Roles = "Board,Admin")]
-[Route("Admin")]
-public class AdminController : Controller
-```
-
 ### Role Assignment Authorization
-- **Admin** can assign/end any role: Admin, Board, Coordinator
-- **Board** (non-Admin) can assign/end: Board, Coordinator only
+- **Admin** can assign/end any role
+- **Board** (non-Admin) can assign/end: Board, ConsentCoordinator, VolunteerCoordinator (not Admin)
+- **HumanAdmin** actions use `HumanAdminBoardOrAdmin` role group
 - Attempting to assign a role outside your permissions returns 403 Forbidden
 
 ### Hangfire Dashboard
@@ -378,22 +428,18 @@ _logger.LogInformation(
 
 | Action | Link | Badge |
 |--------|------|-------|
-| Review Pending Volunteers | `/Board/Humans?filter=pending` | Pending count |
-| Review Applications | `/Board/Applications` | Pending count |
-| Manage Humans | `/Board/Humans` | - |
-| Manage Teams | `/Board/Teams` | - |
-| Manage Roles | `/Board/Roles` | - |
+| Manage Humans | `/Profile/Admin` | - |
 | Audit Log | `/Board/AuditLog` | - |
-| Sync Status | `/Teams/Sync` | - |
+| Sync Status | `/Google/Sync` | - |
 
 ### Admin Dashboard (`/Admin`)
 
 | Action | Link | Badge |
 |--------|------|-------|
-| Sync Settings | `/Admin/SyncSettings` | - |
+| Sync Settings | `/Google/SyncSettings` | - |
 | Configuration Status | `/Admin/Configuration` | - |
-| Email Preview | `/Admin/EmailPreview` | - |
 | Background Jobs | `/hangfire` | - |
+| Check Group Settings | `/Google/CheckGroupSettings` | - |
 
 ## System Health
 

--- a/docs/features/12-audit-log.md
+++ b/docs/features/12-audit-log.md
@@ -46,23 +46,60 @@ Database triggers prevent UPDATE and DELETE on the `audit_log` table, matching t
 
 Stored as string in the database. New values can be appended without migration.
 
+**Team membership:**
 - `TeamMemberAdded` — System sync added a user to a team
 - `TeamMemberRemoved` — System sync removed a user from a team
-- `MemberSuspended` — Admin or system suspended a member
-- `MemberUnsuspended` — Admin unsuspended a member
-- `AccountAnonymized` — Account deletion job anonymized a user
-- `RoleAssigned` — Admin assigned a governance role
-- `RoleEnded` — Admin ended a governance role
-- `VolunteerApproved` — Admin approved a volunteer
-- `GoogleResourceAccessGranted` — Google resource access granted (Group or Drive folder)
-- `GoogleResourceAccessRevoked` — Google resource access revoked (Group or Drive folder)
-- `GoogleResourceProvisioned` — New Google resource created (Drive folder or Group)
 - `TeamJoinedDirectly` — User joined an open team directly
 - `TeamLeft` — User left a team voluntarily
 - `TeamJoinRequestApproved` — Approver approved a team join request
 - `TeamJoinRequestRejected` — Approver rejected a team join request
 - `TeamMemberRoleChanged` — Member role changed within a team
+- `TeamPageContentUpdated` — Team page content (markdown, CTAs, visibility) updated
+
+**Member lifecycle:**
+- `MemberSuspended` — Admin or system suspended a member
+- `MemberUnsuspended` — Admin unsuspended a member
+- `AccountAnonymized` — Account deletion job anonymized a user
+- `MembershipsRevokedOnDeletionRequest` — Memberships ended when deletion was requested
+- `VolunteerApproved` — Admin approved a volunteer
+- `ConsentCheckCleared` — Consent Coordinator cleared a consent check
+- `ConsentCheckFlagged` — Consent Coordinator flagged a consent check
+- `SignupRejected` — Signup rejected (sets RejectedAt)
+- `TierApplicationApproved` — Board approved a Colaborador/Asociado application
+- `TierApplicationRejected` — Board rejected a Colaborador/Asociado application
+- `TierDowngraded` — Human's tier was downgraded
+
+**Roles:**
+- `RoleAssigned` — Admin assigned a governance role
+- `RoleEnded` — Admin ended a governance role
+- `TeamRoleDefinitionCreated/Updated/Deleted` — Team role slot managed
+- `TeamRoleAssigned/Unassigned` — Member assigned to/from a team role slot
+
+**Google sync:**
+- `GoogleResourceAccessGranted` — Google resource access granted (Group or Drive folder)
+- `GoogleResourceAccessRevoked` — Google resource access revoked (Group or Drive folder)
+- `GoogleResourceProvisioned` — New Google resource created (Drive folder or Group)
+- `GoogleResourceDeactivated` — Google resource soft-unlinked
+- `GoogleResourceSettingsRemediated` — Group settings drift auto-corrected
+- `GoogleResourceInheritanceDriftCorrected` — Shared Drive inheritance setting fixed
 - `AnomalousPermissionDetected` — Drive Activity API detected a permission change not made by the system
+
+**Workspace accounts:**
+- `WorkspaceAccountProvisioned` — @nobodies.team account created
+- `WorkspaceAccountSuspended` — Workspace account suspended
+- `WorkspaceAccountReactivated` — Workspace account reactivated
+- `WorkspaceAccountPasswordReset` — Workspace account password reset
+- `WorkspaceAccountLinked` — Existing workspace account linked to a human
+
+**Other features:**
+- `FacilitatedMessageSent` — User-to-user message sent via Humans
+- `FeedbackResponseSent` / `FeedbackStatusChanged` — Feedback management
+- `CommunicationPreferenceChanged` — User changed email/alert preferences
+- `ContactCreated` — Admin created an external contact
+- `AccountMergeRequested/Accepted/Rejected` — Duplicate account merge flow
+- `CampCreated/Updated/Deleted`, `CampSeasonCreated/Approved/Rejected/Withdrawn/StatusChanged`, etc. — Camp management
+- `ShiftSignupConfirmed/Refused/Voluntold/Bailed/NoShow/Cancelled` — Shift lifecycle
+- `RotaMovedToTeam` — Shift rota reassigned to a different department
 
 ## Service Design
 
@@ -131,22 +168,25 @@ The service method sets `EntityType = "GoogleResource"` and `EntityId = resource
 
 ## User Interface
 
-### Global Audit Log Page (`/Admin/AuditLog`)
+### Global Audit Log Page (`/Board/AuditLog`)
 
-Displays all audit log entries with filtering by action type. Features:
+Accessible to Board and Admin. Displays all audit log entries with filtering by action type. Features:
 - Filter buttons: All, Anomalous Permissions, Access Granted/Revoked, Suspensions, Roles
 - Anomalous entries highlighted with warning styling
 - Alert banner showing total anomaly count
-- "Check Drive Activity Now" button for manual trigger
 - Paginated (50 per page)
 
-### Per-Resource Google Sync Audit (`/Admin/GoogleSync/Resource/{id}/Audit`)
+### Drive Activity Check (`/Google/AuditLog/CheckDriveActivity`)
 
-Displays all audit entries for a specific Google resource, queried by `ResourceId`. Shows structured Google sync details: user email, role, sync source, success/failure status, and error messages. Accessed via "Audit" button on each row of the Google Sync page.
+POST action on `GoogleController`. Manual trigger for the Drive Activity monitor. Redirects to `/Board/AuditLog?filter=AnomalousPermissionDetected` after completion.
 
-### Per-User Google Sync Audit (`/Admin/Humans/{id}/GoogleSyncAudit`)
+### Per-Resource Google Sync Audit (`/Google/Sync/Resource/{id}/Audit`)
 
-Displays all Google sync audit entries affecting a specific user, queried by `RelatedEntityId = userId` where `ResourceId IS NOT NULL`. Includes the Google resource name via navigation property. Accessed via "View Google Sync Audit" button on the Member Detail page sidebar.
+Displays all audit entries for a specific Google resource, queried by `ResourceId`. Shows structured Google sync details: user email, role, sync source, success/failure status, and error messages. Accessible to Board and Admin. Accessed via "Audit" button on each row of the Google Sync page.
+
+### Per-User Google Sync Audit (`/Google/Human/{id}/SyncAudit`)
+
+Displays all Google sync audit entries affecting a specific user, queried by `RelatedEntityId = userId` where `ResourceId IS NOT NULL`. Includes the Google resource name via navigation property. Accessible to HumanAdmin and Admin. Accessed via the Member Detail page sidebar.
 
 ### Per-User Audit View (MemberDetail page)
 
@@ -162,7 +202,7 @@ Each entry shows:
 
 ## Authorization
 
-Audit log is visible only to Board and Admin roles (inherits from AdminController's `[Authorize(Roles = "Board,Admin")]`).
+The global audit log (`/Board/AuditLog`) is visible only to Board and Admin roles — it lives on `BoardController` (`[Authorize(Roles = "Board,Admin")]`). The Finance audit log (`/Finance/AuditLog`) is restricted to FinanceAdmin and Admin. Per-resource and per-user Google sync audit views are on `GoogleController`.
 
 ## Related Features
 

--- a/docs/features/13-drive-activity-monitoring.md
+++ b/docs/features/13-drive-activity-monitoring.md
@@ -24,9 +24,10 @@ Nobodies Collective manages Google Shared Drive folders and Groups through the s
 **So that** I can verify the current state on demand
 
 **Acceptance Criteria:**
-- "Check Drive Activity Now" button on the Audit Log page
+- "Check Drive Activity Now" button on the Audit Log page (`/Board/AuditLog`)
 - Shows result count after completion
 - Redirects to filtered audit log view showing anomalous permission entries
+- Trigger endpoint: `POST /Google/AuditLog/CheckDriveActivity` (on `GoogleController`)
 
 ### US-13.3: Audit Log View with Anomaly Alerts
 **As a** Board member or Admin
@@ -34,12 +35,12 @@ Nobodies Collective manages Google Shared Drive folders and Groups through the s
 **So that** I can review system activity and investigate anomalies
 
 **Acceptance Criteria:**
-- Global audit log page at `/Admin/AuditLog`
+- Global audit log page at `/Board/AuditLog` (on `BoardController`, not `AdminController`)
 - Filter by action type (All, Anomalous Permissions, Access Granted/Revoked, Suspensions, Roles)
 - Anomalous entries highlighted with warning styling
 - Alert banner showing total anomaly count
 - Paginated (50 per page)
-- Accessible from admin dashboard quick actions
+- Accessible from Board dashboard
 
 ## Architecture
 
@@ -57,9 +58,9 @@ Nobodies Collective manages Google Shared Drive folders and Groups through the s
 - `DriveActivityMonitorJob` - Hangfire background job wrapper
 
 **Web:**
-- `AdminController.AuditLog` action - paginated audit log with filtering
-- `AdminController.CheckDriveActivity` action - manual trigger
-- `AuditLog.cshtml` view
+- `BoardController.AuditLog` action (`/Board/AuditLog`) - paginated audit log with filtering
+- `GoogleController.CheckDriveActivity` action (`POST /Google/AuditLog/CheckDriveActivity`) - manual trigger
+- `Views/Shared/AuditLog.cshtml` shared view
 
 ### Service Registration
 


### PR DESCRIPTION
## Summary
Monthly feature spec sync — last run was 2026-02-12, 24 days overdue. Audited all 36 specs in `docs/features/` against current code. Updated the 6 most stale:

- **09-administration.md** — major rewrite: documented ProfileController/GoogleController extraction, new ContactsController, AdminDuplicateAccountsController, AdminMergeController, all 9 roles
- **12-audit-log.md** — fixed 3 route references, expanded AuditAction enum documentation from 17 to 44+ values
- **01-authentication.md** — added 7 section-admin roles, coordinator roles, policy-based auth foundation
- **08-background-jobs.md** — added 9 missing shipped jobs, fixed Google sync route references
- **07-google-integration.md** — `/Teams/Sync` → `/Google/Sync` throughout
- **13-drive-activity-monitoring.md** — fixed controller and route references

## Test plan
- [x] Docs-only changes, no code impact
- [x] Verified routes against actual controllers via grep

🤖 Generated with [Claude Code](https://claude.com/claude-code)