### PR TITLE
Fix doc inaccuracies from Codex review of #143

### DIFF
--- a/docs/features/08-background-jobs.md
+++ b/docs/features/08-background-jobs.md
@@ -16,10 +16,10 @@ Several system operations need to run automatically without user interaction: sy
 | ProcessEmailOutboxJob | Frequent | Send emails queued in the outbox table |
 | CleanupEmailOutboxJob | Daily | Delete old processed outbox entries |
 | ProcessGoogleSyncOutboxJob | Frequent | Process Google sync outbox (add/remove from Groups and Drive) |
-| TicketSyncJob | Daily | Sync ticket orders from TicketTailor |
+| TicketSyncJob | Every 15 min (configurable) | Sync ticket orders from TicketTailor |
 | TicketingBudgetSyncJob | Daily 4:30 AM | Materialize weekly ticket actuals into budget line items |
 | SendAdminDailyDigestJob | Daily | Email digest to Admin: sync health, anomalies |
-| SendBoardDailyDigestJob | Daily | Email digest to Board: pending signups, applications |
+| SendBoardDailyDigestJob | Every other day 2:00 AM | Email digest to Board: pending signups, applications |
 | CleanupNotificationsJob | Daily | Delete resolved notifications older than 7 days |
 | SystemTeamSyncJob | **DISABLED** | Sync system team membership + Google permissions |
 | GoogleResourceReconciliationJob | **DISABLED** | Full Google resource reconciliation |

--- a/docs/features/09-administration.md
+++ b/docs/features/09-administration.md
@@ -182,7 +182,7 @@ Google sync, settings, account provisioning, and audit routes have been extracte
 | `/Google/Accounts/Reactivate` | Admin | POST: Reactivate account |
 | `/Google/Accounts/ResetPassword` | Admin | POST: Reset password |
 | `/Google/Accounts/Link` | Admin | POST: Link existing account |
-| `/Google/LinkGroupToTeam` | TeamsAdmin, Board, Admin | POST: Link group to team |
+| `/Google/LinkGroupToTeam` | Admin | POST: Link group to team |
 | `/Google/CheckEmailMismatches` | Admin | POST: Check email mismatches |
 | `/Google/EmailBackfillReview` | HumanAdmin, Admin | GET: Review email backfill |
 | `/Google/ApplyEmailBackfill` | Admin | POST: Apply email backfill |
@@ -207,13 +207,16 @@ Duplicate account detection and resolution (added in Controller Consolidation PR
 | Route | Action | Description |
 |-------|--------|-------------|
 | `/Admin/DuplicateAccounts` | Index | List duplicate account candidates |
-| `/Admin/DuplicateAccounts/{id}` | Detail | Review a specific duplicate candidate |
+| `/Admin/DuplicateAccounts/Detail?userId1=&userId2=` | Detail | Review a specific duplicate candidate |
 
-### AdminMergeController (`/Admin/Merge/`) — Admin only
+### AdminMergeController (`/Admin/MergeRequests/`) — Admin only
 
 | Route | Action | Description |
 |-------|--------|-------------|
-| `/Admin/Merge` | Index/actions | Merge account flows |
+| `/Admin/MergeRequests` | Index | List pending merge requests |
+| `/Admin/MergeRequests/{id}` | Detail | Merge request detail |
+| `/Admin/MergeRequests/{id}/Accept` | Accept | Accept a merge request |
+| `/Admin/MergeRequests/{id}/Reject` | Reject | Reject a merge request |
 
 ## Dashboard Metrics
 


### PR DESCRIPTION
## Summary
- **AdminMergeController route**: `/Admin/Merge` → `/Admin/MergeRequests` with full route table
- **DuplicateAccounts detail endpoint**: `/{id}` → `/Detail?userId1=&userId2=`
- **LinkGroupToTeam authorization**: TeamsAdmin/Board/Admin → Admin only (class-level `[Authorize]`)
- **TicketSyncJob schedule**: Daily → Every 15 min (configurable via `TicketVendor:SyncIntervalMinutes`)
- **SendBoardDailyDigestJob schedule**: Daily → Every other day at 2:00 AM (`0 2 1-31/2 * *`)

All four findings from Codex review on #143 verified against actual code.

## Test plan
- [ ] Docs only — no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)