### PR TITLE
ReSharper InspectCode: fix 122 Tier 1+2 warnings

### DIFF
--- a/.claude/MAINTENANCE_LOG.md
+++ b/.claude/MAINTENANCE_LOG.md
@@ -7,7 +7,7 @@ Tracks when recurring maintenance processes were last run.
 | NuGet vulnerability check | 2026-03-08 | 2026-03-15 | Weekly | — | `dotnet list package --vulnerable` |
 | Todo audit | 2026-03-08 | 2026-03-15 | Weekly | — | Stale items, completed moves |
 | Code simplification | 2026-02-24 | — | After features | codex: ~5% | Dead code, unused abstractions |
-| ReSharper InspectCode | 2026-02-24 | 2026-03-03 | Weekly | — | `/resharper` — fix Tier 1+2 warnings. Codex can't run `jb` in sandbox. |
+| ReSharper InspectCode | 2026-04-05 | 2026-04-12 | Weekly | — | `/resharper` — fix Tier 1+2 warnings. Codex can't run `jb` in sandbox. |
 | Context cleanup | 2026-03-18 | 2026-04-18 | Monthly | — | CLAUDE.md, .claude/, todos.md |
 | Feature spec sync | 2026-02-12 | 2026-03-12 | Monthly | — | docs/features/ vs implementation |
 | i18n audit | 2026-02-24 | 2026-03-24 | Monthly | gemini: ~2% | Missing translations |

--- a/src/Humans.Application/DTOs/ResourceSyncDiff.cs
+++ b/src/Humans.Application/DTOs/ResourceSyncDiff.cs
@@ -1,4 +1,3 @@
-using Humans.Domain.Enums;
 
 namespace Humans.Application.DTOs;
 

--- a/src/Humans.Application/Interfaces/IDuplicateAccountService.cs
+++ b/src/Humans.Application/Interfaces/IDuplicateAccountService.cs
@@ -1,4 +1,3 @@
-using Humans.Domain.Entities;
 
 namespace Humans.Application.Interfaces;
 

--- a/src/Humans.Application/Interfaces/IProfileService.cs
+++ b/src/Humans.Application/Interfaces/IProfileService.cs
@@ -1,6 +1,5 @@
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
-using NodaTime;
 using MemberApplication = Humans.Domain.Entities.Application;
 
 namespace Humans.Application.Interfaces;

--- a/src/Humans.Infrastructure/Data/Configurations/BudgetCategoryConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/BudgetCategoryConfiguration.cs
@@ -1,7 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Humans.Domain.Entities;
-using Humans.Domain.Enums;
 
 namespace Humans.Infrastructure.Data.Configurations;
 

--- a/src/Humans.Infrastructure/Data/Configurations/BudgetYearConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/BudgetYearConfiguration.cs
@@ -1,7 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Humans.Domain.Entities;
-using Humans.Domain.Enums;
 
 namespace Humans.Infrastructure.Data.Configurations;
 

--- a/src/Humans.Infrastructure/Data/Configurations/RotaConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/RotaConfiguration.cs
@@ -1,5 +1,4 @@
 using Humans.Domain.Entities;
-using Humans.Domain.Enums;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 

--- a/src/Humans.Infrastructure/Data/Configurations/TeamRoleDefinitionConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/TeamRoleDefinitionConfiguration.cs
@@ -1,7 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
-using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 

--- a/src/Humans.Infrastructure/Jobs/SendAdminDailyDigestJob.cs
+++ b/src/Humans.Infrastructure/Jobs/SendAdminDailyDigestJob.cs
@@ -64,7 +64,7 @@ public class SendAdminDailyDigestJob : IRecurringJob
                 .ToListAsync(cancellationToken);
             var leadsWithAllConsents = leadUserIds.Count > 0
                 ? await _membershipCalculator.GetUsersWithAllRequiredConsentsForTeamAsync(leadUserIds, SystemTeamIds.Coordinators, cancellationToken)
-                : (IReadOnlySet<Guid>)new HashSet<Guid>();
+                : new HashSet<Guid>();
 
             var pendingConsentsCount = allUserIds.Count(id =>
                 !usersWithAllConsents.Contains(id) ||

--- a/src/Humans.Infrastructure/Jobs/SendBoardDailyDigestJob.cs
+++ b/src/Humans.Infrastructure/Jobs/SendBoardDailyDigestJob.cs
@@ -124,7 +124,7 @@ public class SendBoardDailyDigestJob : IRecurringJob
                 .ToListAsync(cancellationToken);
             var leadsWithAllConsents = leadUserIds.Count > 0
                 ? await _membershipCalculator.GetUsersWithAllRequiredConsentsForTeamAsync(leadUserIds, SystemTeamIds.Coordinators, cancellationToken)
-                : (IReadOnlySet<Guid>)new HashSet<Guid>();
+                : new HashSet<Guid>();
 
             var pendingConsentsCount = allUserIds.Count(id =>
                 !usersWithAllConsents.Contains(id) ||

--- a/src/Humans.Infrastructure/Jobs/SystemTeamSyncJob.cs
+++ b/src/Humans.Infrastructure/Jobs/SystemTeamSyncJob.cs
@@ -2,7 +2,6 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using NodaTime;
-using Humans.Application;
 using Humans.Application.Extensions;
 using Humans.Application.Interfaces;
 using Humans.Domain.Constants;

--- a/src/Humans.Infrastructure/Services/ApplicationDecisionService.cs
+++ b/src/Humans.Infrastructure/Services/ApplicationDecisionService.cs
@@ -2,7 +2,6 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using NodaTime;
-using Humans.Application;
 using Humans.Application.Extensions;
 using Humans.Application.Interfaces;
 using Humans.Domain;

--- a/src/Humans.Infrastructure/Services/CampService.cs
+++ b/src/Humans.Infrastructure/Services/CampService.cs
@@ -8,7 +8,6 @@ using Humans.Infrastructure.Data;
 using Humans.Infrastructure.Helpers;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
-using Microsoft.Extensions.Logging;
 using NodaTime;
 
 namespace Humans.Infrastructure.Services;
@@ -20,7 +19,6 @@ public class CampService : ICampService
     private readonly ISystemTeamSync _systemTeamSync;
     private readonly IClock _clock;
     private readonly IMemoryCache _cache;
-    private readonly ILogger<CampService> _logger;
 
     private static readonly TimeSpan CampsForYearCacheTtl = TimeSpan.FromMinutes(5);
     private static readonly TimeSpan CampSettingsCacheTtl = TimeSpan.FromMinutes(5);
@@ -30,15 +28,13 @@ public class CampService : ICampService
         IAuditLogService auditLogService,
         ISystemTeamSync systemTeamSync,
         IClock clock,
-        IMemoryCache cache,
-        ILogger<CampService> logger)
+        IMemoryCache cache)
     {
         _dbContext = dbContext;
         _auditLogService = auditLogService;
         _systemTeamSync = systemTeamSync;
         _clock = clock;
         _cache = cache;
-        _logger = logger;
     }
 
     // ==========================================================================

--- a/src/Humans.Infrastructure/Services/CampaignService.cs
+++ b/src/Humans.Infrastructure/Services/CampaignService.cs
@@ -297,7 +297,7 @@ public class CampaignService : ICampaignService
     public async Task<WaveSendPreview> PreviewWaveSendAsync(Guid campaignId, Guid teamId,
         CancellationToken ct = default)
     {
-        var campaign = await _dbContext.Campaigns
+        _ = await _dbContext.Campaigns
             .FirstOrDefaultAsync(c => c.Id == campaignId, ct)
             ?? throw new InvalidOperationException($"Campaign {campaignId} not found.");
 

--- a/src/Humans.Infrastructure/Services/ConsentService.cs
+++ b/src/Humans.Infrastructure/Services/ConsentService.cs
@@ -3,10 +3,8 @@ using System.Text;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using NodaTime;
-using Humans.Application;
 using Humans.Application.Interfaces;
 using Humans.Domain.Entities;
-using Humans.Domain.Enums;
 using Humans.Infrastructure.Data;
 
 namespace Humans.Infrastructure.Services;

--- a/src/Humans.Infrastructure/Services/GoogleWorkspaceSyncService.cs
+++ b/src/Humans.Infrastructure/Services/GoogleWorkspaceSyncService.cs
@@ -1542,7 +1542,7 @@ public class GoogleWorkspaceSyncService : IGoogleSyncService
             if (string.IsNullOrEmpty(groupEmail))
             {
                 // Fall back to deriving email from URL
-                var prefix = resource.Url?.Split("/g/", StringSplitOptions.None).LastOrDefault();
+                var prefix = resource.Url?.Split("/g/").LastOrDefault();
                 groupEmail = prefix is not null ? $"{prefix}@{_settings.Domain}" : null;
             }
 

--- a/src/Humans.Infrastructure/Services/NotificationInboxService.cs
+++ b/src/Humans.Infrastructure/Services/NotificationInboxService.cs
@@ -5,7 +5,6 @@ using Humans.Domain.Enums;
 using Humans.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
-using Microsoft.Extensions.Logging;
 using NodaTime;
 
 namespace Humans.Infrastructure.Services;
@@ -18,18 +17,15 @@ public class NotificationInboxService : INotificationInboxService
     private readonly HumansDbContext _dbContext;
     private readonly IClock _clock;
     private readonly IMemoryCache _cache;
-    private readonly ILogger<NotificationInboxService> _logger;
 
     public NotificationInboxService(
         HumansDbContext dbContext,
         IClock clock,
-        IMemoryCache cache,
-        ILogger<NotificationInboxService> logger)
+        IMemoryCache cache)
     {
         _dbContext = dbContext;
         _clock = clock;
         _cache = cache;
-        _logger = logger;
     }
 
     public async Task<NotificationInboxResult> GetInboxAsync(

--- a/src/Humans.Infrastructure/Services/OnboardingService.cs
+++ b/src/Humans.Infrastructure/Services/OnboardingService.cs
@@ -1,9 +1,7 @@
-using System.Collections.Concurrent;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using NodaTime;
-using Humans.Application;
 using Humans.Application.Extensions;
 using Humans.Application.Interfaces;
 using Humans.Domain.Constants;

--- a/src/Humans.Infrastructure/Services/ProfileService.cs
+++ b/src/Humans.Infrastructure/Services/ProfileService.cs
@@ -1,5 +1,4 @@
 using System.Collections.Concurrent;
-using System.Globalization;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;

--- a/src/Humans.Infrastructure/Services/RoleAssignmentService.cs
+++ b/src/Humans.Infrastructure/Services/RoleAssignmentService.cs
@@ -2,7 +2,6 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using NodaTime;
-using Humans.Application;
 using Humans.Application.Extensions;
 using Humans.Application.Interfaces;
 using Humans.Domain.Constants;
@@ -142,8 +141,6 @@ public class RoleAssignmentService : IRoleAssignmentService
         };
 
         _dbContext.RoleAssignments.Add(roleAssignment);
-
-        var user = await _dbContext.Users.FindAsync([userId], ct);
 
         await _auditLogService.LogAsync(
             AuditAction.RoleAssigned, nameof(User), userId,

--- a/src/Humans.Infrastructure/Services/ShiftSignupService.cs
+++ b/src/Humans.Infrastructure/Services/ShiftSignupService.cs
@@ -1,5 +1,4 @@
 using Humans.Application.Interfaces;
-using Humans.Domain.Constants;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Humans.Infrastructure.Data;

--- a/src/Humans.Infrastructure/Services/StubTeamResourceService.cs
+++ b/src/Humans.Infrastructure/Services/StubTeamResourceService.cs
@@ -1,4 +1,3 @@
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NodaTime;

--- a/src/Humans.Infrastructure/Services/TeamPageService.cs
+++ b/src/Humans.Infrastructure/Services/TeamPageService.cs
@@ -48,7 +48,7 @@ public class TeamPageService : ITeamPageService
                 : [];
 
         var customPictures = await GetCustomPicturesByUserIdAsync(
-            visibleMembers as IReadOnlyList<TeamDetailMemberSummary> ?? visibleMembers.ToList(),
+            visibleMembers,
             cancellationToken);
         var members = visibleMembers
             .Select(member => new TeamPageMemberSummary(

--- a/src/Humans.Infrastructure/Services/TeamResourceService.cs
+++ b/src/Humans.Infrastructure/Services/TeamResourceService.cs
@@ -1,7 +1,6 @@
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using Google.Apis.CloudIdentity.v1;
-using Google.Apis.CloudIdentity.v1.Data;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Drive.v3;
 using Google.Apis.Services;

--- a/src/Humans.Infrastructure/Services/TeamService.cs
+++ b/src/Humans.Infrastructure/Services/TeamService.cs
@@ -11,7 +11,6 @@ using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Humans.Domain.ValueObjects;
 using Humans.Infrastructure.Data;
-using System.Text.RegularExpressions;
 
 namespace Humans.Infrastructure.Services;
 
@@ -361,8 +360,6 @@ public class TeamService : ITeamService
         var allMemberships = await GetUserTeamsAsync(userId, cancellationToken);
         var memberships = allMemberships;
         var isBoardMember = await _roleAssignmentService.IsUserBoardMemberAsync(userId, cancellationToken);
-        var isAdmin = await _roleAssignmentService.IsUserAdminAsync(userId, cancellationToken);
-        var isTeamsAdmin = await _roleAssignmentService.IsUserTeamsAdminAsync(userId, cancellationToken);
 
         var coordinatorTeamIds = memberships
             .Where(m => (m.Role == TeamMemberRole.Coordinator || isBoardMember) && !m.Team.IsSystemTeam)

--- a/src/Humans.Infrastructure/Services/TicketQueryService.cs
+++ b/src/Humans.Infrastructure/Services/TicketQueryService.cs
@@ -117,8 +117,8 @@ public class TicketQueryService : ITicketQueryService
             a.Status == TicketAttendeeStatus.Valid || a.Status == TicketAttendeeStatus.CheckedIn);
         var paidOrders = orders.Where(o => o.PaymentStatus == TicketPaymentStatus.Paid);
         var revenue = await paidOrders.SumAsync(o => o.TotalAmount);
-        var totalStripeFees = await paidOrders.SumAsync(o => (decimal?)o.StripeFee ?? 0m);
-        var totalAppFees = await paidOrders.SumAsync(o => (decimal?)o.ApplicationFee ?? 0m);
+        var totalStripeFees = await paidOrders.SumAsync(o => o.StripeFee ?? 0m);
+        var totalAppFees = await paidOrders.SumAsync(o => o.ApplicationFee ?? 0m);
         var netRevenue = revenue - totalStripeFees - totalAppFees;
         var avgPrice = ticketsSold > 0 ? netRevenue / ticketsSold : 0;
         var unmatchedCount = await orders.CountAsync(o => o.MatchedUserId == null);
@@ -593,7 +593,7 @@ public class TicketQueryService : ITicketQueryService
 
         if (HasSearchTerm(search, 1))
         {
-            var normalizedSearch = search!.ToLowerInvariant();
+            var normalizedSearch = search.ToLowerInvariant();
 #pragma warning disable MA0011 // EF LINQ: ToLower() translates to SQL lower()
             query = query.Where(o =>
                 o.BuyerName.ToLower().Contains(normalizedSearch) ||
@@ -668,7 +668,7 @@ public class TicketQueryService : ITicketQueryService
 
         if (HasSearchTerm(search, 1))
         {
-            var normalizedSearch = search!.ToLowerInvariant();
+            var normalizedSearch = search.ToLowerInvariant();
 #pragma warning disable MA0011 // EF LINQ: ToLower() translates to SQL lower()
             query = query.Where(a =>
                 a.AttendeeName.ToLower().Contains(normalizedSearch) ||
@@ -757,8 +757,8 @@ public class TicketQueryService : ITicketQueryService
         if (HasSearchTerm(search, 1))
         {
             filteredHumans = filteredHumans.Where(u =>
-                ContainsIgnoreCase(u.DisplayName, search!) ||
-                u.UserEmails.Any(e => ContainsIgnoreCase(e.Email, search!)));
+                ContainsIgnoreCase(u.DisplayName, search) ||
+                u.UserEmails.Any(e => ContainsIgnoreCase(e.Email, search)));
         }
 
         return filteredHumans.ToList();

--- a/src/Humans.Web/Authorization/MembershipRequiredFilter.cs
+++ b/src/Humans.Web/Authorization/MembershipRequiredFilter.cs
@@ -1,6 +1,5 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
-using Humans.Domain.Constants;
 
 namespace Humans.Web.Authorization;
 

--- a/src/Humans.Web/Controllers/ApplicationController.cs
+++ b/src/Humans.Web/Controllers/ApplicationController.cs
@@ -3,10 +3,8 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Localization;
-using Humans.Application;
 using Humans.Application.Interfaces;
 using Humans.Domain.Constants;
-using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Humans.Web.Extensions;
 using Humans.Web.Models;
@@ -17,7 +15,6 @@ namespace Humans.Web.Controllers;
 public class ApplicationController : HumansControllerBase
 {
     private readonly IApplicationDecisionService _applicationDecisionService;
-    private readonly UserManager<Domain.Entities.User> _userManager;
     private readonly IStringLocalizer<SharedResource> _localizer;
     private readonly ILogger<ApplicationController> _logger;
 
@@ -29,7 +26,6 @@ public class ApplicationController : HumansControllerBase
         : base(userManager)
     {
         _applicationDecisionService = applicationDecisionService;
-        _userManager = userManager;
         _localizer = localizer;
         _logger = logger;
     }

--- a/src/Humans.Web/Controllers/BoardController.cs
+++ b/src/Humans.Web/Controllers/BoardController.cs
@@ -6,7 +6,6 @@ using Humans.Application.Interfaces;
 using Humans.Domain.Constants;
 using Humans.Domain.Entities;
 using Humans.Infrastructure.Data;
-using Humans.Web.Extensions;
 using Humans.Web.Models;
 
 namespace Humans.Web.Controllers;

--- a/src/Humans.Web/Controllers/CampAdminController.cs
+++ b/src/Humans.Web/Controllers/CampAdminController.cs
@@ -10,7 +10,6 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Logging;
 
 namespace Humans.Web.Controllers;
 

--- a/src/Humans.Web/Controllers/CampController.cs
+++ b/src/Humans.Web/Controllers/CampController.cs
@@ -2,7 +2,6 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Humans.Application.Interfaces;
-using Humans.Domain.Constants;
 using Humans.Domain.Entities;
 using Humans.Domain.Helpers;
 using Humans.Domain.ValueObjects;

--- a/src/Humans.Web/Controllers/ConsentController.cs
+++ b/src/Humans.Web/Controllers/ConsentController.cs
@@ -2,7 +2,6 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Localization;
-using Humans.Application;
 using Humans.Application.Interfaces;
 using Humans.Domain.Entities;
 using Humans.Web.Models;

--- a/src/Humans.Web/Controllers/ContactsController.cs
+++ b/src/Humans.Web/Controllers/ContactsController.cs
@@ -5,8 +5,6 @@ using Microsoft.Extensions.Localization;
 using Humans.Application.Interfaces;
 using Humans.Domain.Constants;
 using Humans.Domain.Entities;
-using Humans.Web.Authorization;
-using Humans.Web.Extensions;
 using Humans.Web.Models;
 
 namespace Humans.Web.Controllers;

--- a/src/Humans.Web/Controllers/EmailController.cs
+++ b/src/Humans.Web/Controllers/EmailController.cs
@@ -10,7 +10,6 @@ using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Humans.Infrastructure.Configuration;
 using Humans.Infrastructure.Data;
-using Humans.Web.Extensions;
 using Humans.Web.Models;
 using NodaTime;
 

--- a/src/Humans.Web/Controllers/GovernanceController.cs
+++ b/src/Humans.Web/Controllers/GovernanceController.cs
@@ -2,10 +2,8 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using NodaTime;
-using Humans.Application;
 using Humans.Application.Interfaces;
 using Humans.Domain.Constants;
-using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Humans.Web.Extensions;
 using Humans.Web.Models;
@@ -16,7 +14,6 @@ namespace Humans.Web.Controllers;
 [Route("[controller]")]
 public class GovernanceController : HumansControllerBase
 {
-    private readonly ILogger<GovernanceController> _logger;
     private readonly ILegalDocumentService _legalDocService;
     private readonly IProfileService _profileService;
     private readonly IApplicationDecisionService _applicationDecisionService;
@@ -25,7 +22,6 @@ public class GovernanceController : HumansControllerBase
 
     public GovernanceController(
         UserManager<Domain.Entities.User> userManager,
-        ILogger<GovernanceController> logger,
         ILegalDocumentService legalDocService,
         IProfileService profileService,
         IApplicationDecisionService applicationDecisionService,
@@ -33,7 +29,6 @@ public class GovernanceController : HumansControllerBase
         IClock clock)
         : base(userManager)
     {
-        _logger = logger;
         _legalDocService = legalDocService;
         _profileService = profileService;
         _applicationDecisionService = applicationDecisionService;

--- a/src/Humans.Web/Controllers/HumansControllerBase.cs
+++ b/src/Humans.Web/Controllers/HumansControllerBase.cs
@@ -1,5 +1,4 @@
 using Humans.Domain.Entities;
-using Humans.Web.Extensions;
 using Humans.Web.Models;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;

--- a/src/Humans.Web/Controllers/NotificationController.cs
+++ b/src/Humans.Web/Controllers/NotificationController.cs
@@ -1,4 +1,3 @@
-using Humans.Application;
 using Humans.Application.Interfaces;
 using Humans.Domain.Entities;
 using Humans.Web.Models;

--- a/src/Humans.Web/Controllers/OnboardingReviewController.cs
+++ b/src/Humans.Web/Controllers/OnboardingReviewController.cs
@@ -3,7 +3,6 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Localization;
 using NodaTime;
-using Humans.Application;
 using Humans.Application.Interfaces;
 using Humans.Domain.Constants;
 using Humans.Domain.Entities;

--- a/src/Humans.Web/Controllers/ProfileController.cs
+++ b/src/Humans.Web/Controllers/ProfileController.cs
@@ -9,7 +9,6 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Localization;
-using Humans.Application;
 using Humans.Application.DTOs;
 using Humans.Application.Interfaces;
 using Humans.Domain.Constants;
@@ -1006,8 +1005,8 @@ public class ProfileController : HumansControllerBase
 
         var teams = await _dbContext.TeamMembers
             .Where(tm => tm.UserId == id && tm.LeftAt == null
-                && tm.Team!.SystemTeamType != SystemTeamType.Volunteers)
-            .Select(tm => tm.Team!.Name)
+                && tm.Team.SystemTeamType != SystemTeamType.Volunteers)
+            .Select(tm => tm.Team.Name)
             .OrderBy(n => n)
             .ToListAsync();
 

--- a/src/Humans.Web/Controllers/ShiftAdminController.cs
+++ b/src/Humans.Web/Controllers/ShiftAdminController.cs
@@ -1,5 +1,4 @@
 using Humans.Application.Interfaces;
-using Humans.Domain.Constants;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Humans.Web.Authorization;
@@ -9,7 +8,6 @@ using Humans.Web.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Logging;
 using NodaTime;
 
 namespace Humans.Web.Controllers;

--- a/src/Humans.Web/Controllers/ShiftDashboardController.cs
+++ b/src/Humans.Web/Controllers/ShiftDashboardController.cs
@@ -1,7 +1,6 @@
 using Humans.Application.Interfaces;
 using Humans.Domain.Constants;
 using Humans.Domain.Entities;
-using Humans.Domain.Enums;
 using Humans.Web.Authorization;
 using Humans.Web.Extensions;
 using Humans.Web.Helpers;
@@ -9,7 +8,6 @@ using Humans.Web.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Logging;
 using NodaTime;
 using NodaTime.Text;
 

--- a/src/Humans.Web/Controllers/TeamAdminController.cs
+++ b/src/Humans.Web/Controllers/TeamAdminController.cs
@@ -689,7 +689,7 @@ public class TeamAdminController : HumansTeamControllerBase
     [HttpGet("Roles")]
     public async Task<IActionResult> Roles(string slug)
     {
-        var (teamError, user, team) = await ResolveTeamManagementAsync(slug);
+        var (teamError, _, team) = await ResolveTeamManagementAsync(slug);
         if (teamError is not null)
         {
             return teamError;

--- a/src/Humans.Web/Controllers/TeamController.cs
+++ b/src/Humans.Web/Controllers/TeamController.cs
@@ -275,7 +275,7 @@ public class TeamController : HumansControllerBase
     [HttpGet("Birthdays")]
     public async Task<IActionResult> Birthdays(int? month)
     {
-        var (currentUserError, user) = await ResolveCurrentUserOrUnauthorizedAsync();
+        var (currentUserError, _) = await ResolveCurrentUserOrUnauthorizedAsync();
         if (currentUserError is not null)
         {
             return currentUserError;

--- a/src/Humans.Web/Controllers/VolController.cs
+++ b/src/Humans.Web/Controllers/VolController.cs
@@ -26,7 +26,6 @@ public class VolController : HumansControllerBase
     private readonly IProfileService _profileService;
     private readonly IGeneralAvailabilityService _availabilityService;
     private readonly ILogger<VolController> _logger;
-    private readonly IClock _clock;
 
     public VolController(
         IShiftManagementService shiftMgmt,
@@ -35,8 +34,7 @@ public class VolController : HumansControllerBase
         IProfileService profileService,
         IGeneralAvailabilityService availabilityService,
         UserManager<User> userManager,
-        ILogger<VolController> logger,
-        IClock clock)
+        ILogger<VolController> logger)
         : base(userManager)
     {
         _shiftMgmt = shiftMgmt;
@@ -45,7 +43,6 @@ public class VolController : HumansControllerBase
         _profileService = profileService;
         _availabilityService = availabilityService;
         _logger = logger;
-        _clock = clock;
     }
 
     [HttpGet("")]
@@ -289,7 +286,7 @@ public class VolController : HumansControllerBase
     {
         try
         {
-            var (err, user) = await ResolveCurrentUserOrChallengeAsync();
+            var (err, _) = await ResolveCurrentUserOrChallengeAsync();
             if (err is not null) return err;
 
             var es = await _shiftMgmt.GetActiveAsync();

--- a/src/Humans.Web/Extensions/DateTimeDisplayExtensions.cs
+++ b/src/Humans.Web/Extensions/DateTimeDisplayExtensions.cs
@@ -1,6 +1,5 @@
 using System.Globalization;
 using Humans.Web.Controllers;
-using Microsoft.AspNetCore.Http;
 using NodaTime;
 
 namespace Humans.Web.Extensions;

--- a/src/Humans.Web/Extensions/HtmlHelperExtensions.cs
+++ b/src/Humans.Web/Extensions/HtmlHelperExtensions.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using System.Text.Encodings.Web;
 using Ganss.Xss;
 using Markdig;

--- a/src/Humans.Web/Extensions/RecurringJobExtensions.cs
+++ b/src/Humans.Web/Extensions/RecurringJobExtensions.cs
@@ -1,7 +1,6 @@
 using Hangfire;
 using Humans.Application.Configuration;
 using Humans.Infrastructure.Jobs;
-using Microsoft.Extensions.Logging;
 
 namespace Humans.Web.Extensions;
 

--- a/src/Humans.Web/Models/AdminViewModels.cs
+++ b/src/Humans.Web/Models/AdminViewModels.cs
@@ -1,6 +1,5 @@
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
-using NodaTime;
 
 namespace Humans.Web.Models;
 
@@ -42,7 +41,7 @@ public class RecentActivityViewModel
 
 public class AdminHumanListViewModel : PagedListViewModel
 {
-    public AdminHumanListViewModel() : base(20)
+    public AdminHumanListViewModel() : base()
     {
     }
 
@@ -127,7 +126,7 @@ public class AdminHumanApplicationViewModel
 
 public class AdminApplicationListViewModel : PagedListViewModel
 {
-    public AdminApplicationListViewModel() : base(20)
+    public AdminApplicationListViewModel() : base()
     {
     }
 

--- a/src/Humans.Web/Models/TeamViewModels.cs
+++ b/src/Humans.Web/Models/TeamViewModels.cs
@@ -184,7 +184,7 @@ public class TeamJoinRequestViewModel
 
 public class PendingRequestsViewModel : PagedListViewModel
 {
-    public PendingRequestsViewModel() : base(20)
+    public PendingRequestsViewModel() : base()
     {
     }
 
@@ -247,7 +247,7 @@ public class CallToActionViewModel
 public class TeamMembersViewModel
     : PagedListViewModel
 {
-    public TeamMembersViewModel() : base(20)
+    public TeamMembersViewModel() : base()
     {
     }
 
@@ -509,7 +509,7 @@ public class HumanSearchResultViewModel
 
 public class AdminTeamListViewModel : PagedListViewModel
 {
-    public AdminTeamListViewModel() : base(20)
+    public AdminTeamListViewModel() : base()
     {
     }
 

--- a/src/Humans.Web/ViewComponents/AuditLogViewComponent.cs
+++ b/src/Humans.Web/ViewComponents/AuditLogViewComponent.cs
@@ -56,10 +56,10 @@ public class AuditLogViewComponent : ViewComponent
             // Batch-load display names for all referenced user IDs
             // (actors, subjects via EntityId for User/Profile types, and RelatedEntityId for User types)
             var userIds = model.Entries
-                .SelectMany(e => new[]
+                .SelectMany(e => new Guid?[]
                 {
                     e.ActorUserId,
-                    e.EntityType is "User" or "Profile" or "WorkspaceAccount" ? (Guid?)e.EntityId : null,
+                    e.EntityType is "User" or "Profile" or "WorkspaceAccount" ? e.EntityId : null,
                     string.Equals(e.RelatedEntityType, "User", StringComparison.Ordinal) ? e.RelatedEntityId : null
                 })
                 .Where(id => id.HasValue)
@@ -77,9 +77,9 @@ public class AuditLogViewComponent : ViewComponent
 
             // Batch-load team names for entries that reference teams
             var teamIds = model.Entries
-                .SelectMany(e => new[]
+                .SelectMany(e => new Guid?[]
                 {
-                    string.Equals(e.EntityType, "Team", StringComparison.Ordinal) ? (Guid?)e.EntityId : null,
+                    string.Equals(e.EntityType, "Team", StringComparison.Ordinal) ? e.EntityId : null,
                     string.Equals(e.RelatedEntityType, "Team", StringComparison.Ordinal) ? e.RelatedEntityId : null
                 })
                 .Where(id => id.HasValue)

--- a/src/Humans.Web/Views/Budget/CategoryDetail.cshtml
+++ b/src/Humans.Web/Views/Budget/CategoryDetail.cshtml
@@ -1,11 +1,8 @@
-@using Humans.Domain.Enums
-@using Humans.Web.Models
 @model Humans.Web.Models.CoordinatorCategoryDetailViewModel
 @{
     ViewData["Title"] = $"Budget - {Model.Category.Name}";
     var category = Model.Category;
     var group = category.BudgetGroup;
-    var year = group?.BudgetYear;
     var lineItemTotal = category.LineItems.Where(li => !li.IsCashflowOnly).Sum(li => li.Amount);
     var unallocated = category.AllocatedAmount - lineItemTotal;
 

--- a/src/Humans.Web/Views/Budget/Index.cshtml
+++ b/src/Humans.Web/Views/Budget/Index.cshtml
@@ -1,4 +1,3 @@
-@using Humans.Domain.Enums
 @model Humans.Web.Models.CoordinatorBudgetViewModel
 @{
     ViewData["Title"] = $"Budget - {Model.Year.Name}";
@@ -67,7 +66,6 @@
 @foreach (var group in groups)
 {
     var groupAllocated = group.Categories.Sum(c => c.AllocatedAmount);
-    var groupLineItems = group.Categories.SelectMany(c => c.LineItems).Where(li => !li.IsCashflowOnly).Sum(li => li.Amount);
     var collapseId = $"group-{group.Id.ToString("N")}";
 
     <div class="card mb-3">

--- a/src/Humans.Web/Views/Campaign/Detail.cshtml
+++ b/src/Humans.Web/Views/Campaign/Detail.cshtml
@@ -1,5 +1,4 @@
 @model Humans.Web.Models.CampaignDetailViewModel
-@using Humans.Domain.Constants
 @{
     ViewData["Title"] = Model.Campaign.Title;
     var totalCodes = Model.Stats.TotalCodes;

--- a/src/Humans.Web/Views/Email/EmailOutbox.cshtml
+++ b/src/Humans.Web/Views/Email/EmailOutbox.cshtml
@@ -1,5 +1,4 @@
 @model Humans.Web.Models.EmailOutboxViewModel
-@using Humans.Domain.Enums
 @{
     ViewData["Title"] = "Email Outbox";
 }

--- a/src/Humans.Web/Views/Feedback/Index.cshtml
+++ b/src/Humans.Web/Views/Feedback/Index.cshtml
@@ -1,5 +1,4 @@
 @model Humans.Web.Models.FeedbackPageViewModel
-@inject IStringLocalizer<SharedResource> Localizer
 @{
     ViewData["Title"] = "Feedback";
 }

--- a/src/Humans.Web/Views/Finance/CategoryDetail.cshtml
+++ b/src/Humans.Web/Views/Finance/CategoryDetail.cshtml
@@ -1,5 +1,3 @@
-@using Humans.Domain.Enums
-@using Humans.Web.Models
 @model BudgetCategory
 @{
     ViewData["Title"] = $"Finance - {Model.Name}";

--- a/src/Humans.Web/Views/Finance/YearDetail.cshtml
+++ b/src/Humans.Web/Views/Finance/YearDetail.cshtml
@@ -1,5 +1,3 @@
-@using Humans.Domain.Enums
-@using Humans.Web.Models
 @model FinanceOverviewViewModel
 @{
     ViewData["Title"] = $"Finance - {Model.Year.Name}";

--- a/src/Humans.Web/Views/Notification/Index.cshtml
+++ b/src/Humans.Web/Views/Notification/Index.cshtml
@@ -2,7 +2,6 @@
 @inject Microsoft.Extensions.Localization.IStringLocalizer<Humans.Web.SharedResource> Localizer
 @{
     ViewData["Title"] = Localizer["Notification_PageTitle"];
-    var hasUnresolved = Model.NeedsAttention.Count > 0 || Model.Informational.Count > 0;
 }
 
 <h1>@Localizer["Notification_PageTitle"]</h1>

--- a/src/Humans.Web/Views/Notification/_NotificationRow.cshtml
+++ b/src/Humans.Web/Views/Notification/_NotificationRow.cshtml
@@ -1,5 +1,4 @@
 @model Humans.Web.Models.NotificationRowViewModel
-@using Humans.Domain.Enums
 @inject Microsoft.Extensions.Localization.IStringLocalizer<Humans.Web.SharedResource> Localizer
 
 @{

--- a/src/Humans.Web/Views/Profile/AdminDetail.cshtml
+++ b/src/Humans.Web/Views/Profile/AdminDetail.cshtml
@@ -1,7 +1,4 @@
 @model Humans.Web.Models.AdminHumanDetailViewModel
-@using Humans.Domain.Entities
-@using Humans.Domain.Enums
-@using Humans.Web.Extensions
 @{
     ViewData["Title"] = string.Format(Localizer["AdminHumanDetail_Title"].Value, Model.DisplayName);
     var campaignGrants = (IList<CampaignGrant>?)ViewBag.CampaignGrants;

--- a/src/Humans.Web/Views/Profile/CommunicationPreferences.cshtml
+++ b/src/Humans.Web/Views/Profile/CommunicationPreferences.cshtml
@@ -1,5 +1,4 @@
 @model Humans.Web.Models.CommunicationPreferencesViewModel
-@inject Microsoft.Extensions.Localization.IStringLocalizer<Humans.Web.SharedResource> Localizer
 @{
     ViewData["Title"] = "Communication Preferences";
 }

--- a/src/Humans.Web/Views/Profile/Outbox.cshtml
+++ b/src/Humans.Web/Views/Profile/Outbox.cshtml
@@ -1,5 +1,4 @@
 @model IList<Humans.Domain.Entities.EmailOutboxMessage>
-@using Humans.Domain.Enums
 @{
     var humanId = (Guid?)ViewBag.HumanId;
     var isAdminView = humanId.HasValue;

--- a/src/Humans.Web/Views/Shared/Components/AccessMatrix/Default.cshtml
+++ b/src/Humans.Web/Views/Shared/Components/AccessMatrix/Default.cshtml
@@ -1,6 +1,4 @@
 @model Humans.Web.Models.SectionHelpViewModel
-@using Humans.Web.Models
-@using Humans.Web.Extensions
 
 @{
     var modalId = "sectionHelp-" + Model.SectionKey.Replace(" ", "");

--- a/src/Humans.Web/Views/Shared/Components/AuditLog/_Entry.cshtml
+++ b/src/Humans.Web/Views/Shared/Components/AuditLog/_Entry.cshtml
@@ -1,5 +1,4 @@
 @model Humans.Domain.Entities.AuditLogEntry
-@using Humans.Web.ViewComponents
 
 @{
     var userNames = (Dictionary<Guid, string>?)ViewData["UserDisplayNames"] ?? new();

--- a/src/Humans.Web/Views/Shared/Components/FeedbackWidget/Default.cshtml
+++ b/src/Humans.Web/Views/Shared/Components/FeedbackWidget/Default.cshtml
@@ -1,4 +1,3 @@
-@using Humans.Domain.Enums
 
 <!-- Floating feedback button -->
 <button type="button" class="btn btn-primary rounded-circle shadow position-fixed"

--- a/src/Humans.Web/Views/Shared/Components/ProfileCard/Default.cshtml
+++ b/src/Humans.Web/Views/Shared/Components/ProfileCard/Default.cshtml
@@ -1,5 +1,4 @@
 @model Humans.Web.Models.ProfileCardViewModel
-@using Humans.Web.Extensions
 
 @* === Card 1: Public Profile === *@
 <div class="card mb-4">

--- a/src/Humans.Web/Views/Shared/Components/ShiftSignups/Default.cshtml
+++ b/src/Humans.Web/Views/Shared/Components/ShiftSignups/Default.cshtml
@@ -1,6 +1,4 @@
 @model Humans.Web.Models.ShiftSignupsViewModel
-@using Humans.Domain.Enums
-@using Humans.Web.Extensions
 @using NodaTime
 
 @{

--- a/src/Humans.Web/Views/Shared/_VolunteerProfileBadges.cshtml
+++ b/src/Humans.Web/Views/Shared/_VolunteerProfileBadges.cshtml
@@ -1,4 +1,3 @@
-@using Humans.Domain.Entities
 @model (VolunteerEventProfile? Profile, bool ShowMedical)
 
 @if (Model.Profile != null)

--- a/src/Humans.Web/Views/ShiftAdmin/Index.cshtml
+++ b/src/Humans.Web/Views/ShiftAdmin/Index.cshtml
@@ -1,7 +1,4 @@
 @model Humans.Web.Models.ShiftAdminViewModel
-@using Humans.Application.Interfaces
-@using Humans.Domain.Entities
-@using Humans.Domain.Enums
 @using Humans.Web.Controllers
 
 @{

--- a/src/Humans.Web/Views/ShiftDashboard/Index.cshtml
+++ b/src/Humans.Web/Views/ShiftDashboard/Index.cshtml
@@ -1,6 +1,4 @@
 @model Humans.Web.Models.ShiftDashboardViewModel
-@using Humans.Application.Interfaces
-@using Humans.Domain.Enums
 @using Humans.Web.Controllers
 
 @{

--- a/src/Humans.Web/Views/Shifts/Index.cshtml
+++ b/src/Humans.Web/Views/Shifts/Index.cshtml
@@ -1,5 +1,4 @@
 @model Humans.Web.Models.ShiftBrowseViewModel
-@using Humans.Domain.Enums
 @using NodaTime
 
 @{

--- a/src/Humans.Web/Views/Shifts/Mine.cshtml
+++ b/src/Humans.Web/Views/Shifts/Mine.cshtml
@@ -1,5 +1,4 @@
 @model Humans.Web.Models.MyShiftsViewModel
-@using Humans.Domain.Enums
 @using NodaTime
 
 @{

--- a/src/Humans.Web/Views/Team/_RosterSection.cshtml
+++ b/src/Humans.Web/Views/Team/_RosterSection.cshtml
@@ -1,5 +1,4 @@
 @model List<Humans.Web.Models.TeamRoleDefinitionViewModel>
-@using Humans.Domain.Enums
 
 @{
     var canManage = (bool)(ViewData["CanManage"] ?? false);

--- a/src/Humans.Web/Views/TeamAdmin/Resources.cshtml
+++ b/src/Humans.Web/Views/TeamAdmin/Resources.cshtml
@@ -1,4 +1,3 @@
-@using Humans.Domain.Enums
 @model Humans.Web.Models.TeamResourcesViewModel
 @{
     ViewData["Title"] = string.Format(Localizer["TeamAdminResources_Title"].Value, Model.TeamName);

--- a/src/Humans.Web/Views/Ticket/Index.cshtml
+++ b/src/Humans.Web/Views/Ticket/Index.cshtml
@@ -32,9 +32,6 @@
                     <h3 class="card-title">@Model.TicketsSold.ToString("N0")</h3>
                     @if (Model.TotalCapacity > 0)
                     {
-                        var bePct = Model.BreakEvenTarget > 0
-                            ? (int)(Model.BreakEvenTarget * 100.0 / Model.TotalCapacity)
-                            : 0;
                         var soldPct = (int)(Model.TicketsSold * 100.0 / Model.TotalCapacity);
                         <div class="progress mt-2" style="height: 10px;">
                             <div class="progress-bar @(Model.TicketsSold >= Model.BreakEvenTarget ? "bg-success" : "bg-primary")" style="width: @(soldPct)%"></div>

--- a/src/Humans.Web/Views/Vol/MyShifts.cshtml
+++ b/src/Humans.Web/Views/Vol/MyShifts.cshtml
@@ -1,5 +1,4 @@
 @model Humans.Web.Models.Vol.MyShiftsViewModel
-@using Humans.Domain.Enums
 @using NodaTime
 
 @{

--- a/src/Humans.Web/Views/Vol/Shifts.cshtml
+++ b/src/Humans.Web/Views/Vol/Shifts.cshtml
@@ -1,6 +1,4 @@
 @model Humans.Web.Models.Vol.ShiftBrowserViewModel
-@using Humans.Domain.Enums
-@using NodaTime
 
 @{
     ViewData["Title"] = "All Shifts";

--- a/src/Humans.Web/Views/Vol/Urgent.cshtml
+++ b/src/Humans.Web/Views/Vol/Urgent.cshtml
@@ -1,6 +1,4 @@
 @model Humans.Web.Models.Vol.UrgentShiftsViewModel
-@using Humans.Domain.Enums
-@using NodaTime
 
 @{
     ViewData["Title"] = "Urgent Shifts";

--- a/src/Humans.Web/Views/Vol/_RotaCard.cshtml
+++ b/src/Humans.Web/Views/Vol/_RotaCard.cshtml
@@ -1,6 +1,4 @@
 @model (Humans.Web.Models.RotaShiftGroup RotaGroup, Humans.Domain.Entities.EventSettings Es, HashSet<Guid> UserSignupShiftIds, Dictionary<Guid, Humans.Domain.Enums.SignupStatus> UserSignupStatuses, bool ShowSignups)
-@using Humans.Domain.Enums
-@using NodaTime
 
 @{
     var rotaGroup = Model.RotaGroup;

--- a/src/Humans.Web/Views/Vol/_ShiftRow.cshtml
+++ b/src/Humans.Web/Views/Vol/_ShiftRow.cshtml
@@ -1,5 +1,4 @@
 @model (Humans.Web.Models.ShiftDisplayItem Item, Humans.Domain.Entities.EventSettings Es, HashSet<Guid> UserSignupShiftIds, Dictionary<Guid, Humans.Domain.Enums.SignupStatus> UserSignupStatuses, bool ShowSignups)
-@using Humans.Domain.Enums
 @using NodaTime
 
 @{

--- a/tests/Humans.Application.Tests/Services/CampServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/CampServiceTests.cs
@@ -38,8 +38,7 @@ public class CampServiceTests : IDisposable
             _auditLog,
             Substitute.For<ISystemTeamSync>(),
             _clock,
-            new MemoryCache(new MemoryCacheOptions()),
-            NullLogger<CampService>.Instance);
+            new MemoryCache(new MemoryCacheOptions()));
     }
 
     public void Dispose()

--- a/tests/Humans.Application.Tests/Services/NotificationInboxServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/NotificationInboxServiceTests.cs
@@ -31,8 +31,7 @@ public class NotificationInboxServiceTests : IDisposable
         _clock = new FakeClock(Instant.FromUtc(2026, 4, 1, 12, 0));
         _cache = new MemoryCache(new MemoryCacheOptions());
         _service = new NotificationInboxService(
-            _dbContext, _clock, _cache,
-            NullLogger<NotificationInboxService>.Instance);
+            _dbContext, _clock, _cache);
     }
 
     public void Dispose()


### PR DESCRIPTION
## Summary
Monthly ReSharper InspectCode run (33 days overdue). 742 warnings found, 122 fixed across 81 files:

**Tier 1 (25 fixes):**
- Removed unused fields: `_clock` (VolController), `_logger` (GovernanceController, CampService, NotificationInboxService), `_userManager` field (ApplicationController)
- Removed 11 unused local variables across services/controllers
- Removed 5 unused Razor variables/injects
- Updated 2 test constructors for removed dependencies

**Tier 2 (97 fixes):**
- 82 redundant `using` directives across 62 files
- 5 redundant casts (`decimal?`, `IReadOnlyList`, `Guid?`)
- 6 redundant default argument values (`base(20)`, `StringSplitOptions.None`)
- 4 redundant null-forgiving operators

**Skipped (with reason):**
- `UnusedAutoPropertyAccessor` (688 issues) — DTO/interface properties used via reflection/serialization per CODING_RULES.md
- `InconsistentNaming` — intentional names (`ICalToken`, `c10m`, etc.)
- `AccessToModifiedClosure` in Razor — known pattern, restructuring not worth it

## Test plan
- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — 886 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)