### PR TITLE
[codex] document qa-first pull request workflow

### DIFF
--- a/PROCESSES.md
+++ b/PROCESSES.md
@@ -22,7 +22,9 @@ How to use the skills and agents in this project. Ordered by typical workflow.
 
 **What it does:** Launches an agent swarm — one agent per batch, each in its own worktree. Parallel-safe batches run concurrently (max 3). Each agent implements issues sequentially, runs spec review per-issue, runs code review per-batch, fixes failures in a loop (max 3 iterations), and creates one PR per batch.
 
-**Output:** PRs on peterdrier/Humans, one per batch. Summary report showing pass/fail per batch.
+**Output:** QA PRs on peterdrier/Humans, one per batch. Summary report showing pass/fail per batch.
+
+See [docs/pull-request-workflow.md](docs/pull-request-workflow.md) for the repo-specific QA-first PR flow.
 
 ```
 /execute-sprint batch 2       # execute one batch
@@ -116,6 +118,7 @@ These are used internally by the skills above:
 2. **`/execute-sprint batch N`** — let the swarm do the work (or work manually)
 3. **`/spec-review`** — verify before PR (automatic in execute-sprint)
 4. **`/code-review`** — quality check before PR (automatic in execute-sprint)
-5. **Merge PRs** — squash merge to main, Coolify auto-deploys to QA
-6. **`/test-site`** — smoke test the deployment
-7. **`/finish`** — clean up, capture context
+5. **Merge or land the QA PR** — `peterdrier/Humans` drives the QA deploy path
+6. **`/test-site`** — smoke test the QA deployment
+7. **Open the upstream production PR** — only after QA passes, target `nobodies-collective/Humans`
+8. **`/finish`** — clean up, capture context

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,6 +44,7 @@ Business requirements, user stories, data model, and workflows for each feature 
 |----------|-------------|
 | [Admin Role Setup](admin-role-setup.md) | Adding initial admin users via SQL |
 | [GUID Reservations](guid-reservations.md) | Reserved deterministic GUID blocks for seeded data |
+| [Pull Request Workflow](pull-request-workflow.md) | QA-first PR flow: `peterdrier/Humans` before upstream |
 | [Google & External Service Setup](google-service-account-setup.md) | OAuth, service account, Maps, GitHub credentials |
 
 ## Repository Metrics

--- a/docs/pull-request-workflow.md
+++ b/docs/pull-request-workflow.md
@@ -1,0 +1,80 @@
+# Pull Request Workflow
+
+## Purpose
+
+This document describes the repository-specific pull request flow for Humans.
+
+It exists because this codebase does **not** use the default "open a PR straight to upstream" workflow.
+
+## Source Of Truth
+
+This workflow was clarified by Peter on April 5, 2026 in the discussion on:
+
+- `nobodies-collective/Humans#376`
+
+Peter's note was:
+
+> Our workflow is: feature branch → PR on peterdrier/Humans (QA auto-deploys via Coolify) → review & test → then PR to upstream when ready for production.
+
+## Default PR Flow
+
+When you have a branch ready for review, use this sequence:
+
+1. Create or update the feature branch with the intended changes.
+2. Open the **first PR** against `peterdrier/Humans`.
+3. Use that QA PR for review, QA deploy, and testing.
+4. Only after the change has passed QA and is ready for production, open a **second PR** against `nobodies-collective/Humans`.
+
+In short:
+
+- `peterdrier/Humans` is the **QA PR target**
+- `nobodies-collective/Humans` is the **production PR target**
+
+## Why
+
+The QA PR target is not just a mirror of upstream.
+
+- PRs on `peterdrier/Humans` drive the QA pipeline
+- QA auto-deploys from there via Coolify
+- review and testing happen there first
+- upstream PRs should represent changes that are already QA-vetted
+
+Because of that, opening the first PR directly on `nobodies-collective/Humans` is the wrong default for this repo.
+
+## Practical Rules
+
+- Do **not** open the first PR on `nobodies-collective/Humans` unless someone explicitly says the change has already cleared QA and is ready for the upstream production PR.
+- When someone says "make a PR" without further qualification, assume they mean the **QA PR** on `peterdrier/Humans`.
+- If you accidentally open the first PR on upstream, close it and reopen the change through the QA repo.
+- Keep the QA PR and the later upstream PR as close as possible in commit content so the production PR reflects what actually passed QA.
+
+## Branch And Repo Notes
+
+The important thing is the **base repository**, not necessarily where the branch was first created.
+
+Depending on permissions and local remote setup, the feature branch may live in:
+
+- `peterdrier/Humans`, or
+- another repo or fork that can open a PR into `peterdrier/Humans`
+
+But the review flow still remains:
+
+- first PR targets `peterdrier/Humans`
+- later production PR targets `nobodies-collective/Humans`
+
+## Codex Guidance
+
+When Codex is asked to publish work from this codebase:
+
+- default the first PR to `peterdrier/Humans`
+- treat `nobodies-collective/Humans` as the production follow-up PR target
+- if a user explicitly asks for the upstream PR, verify whether QA has already happened before using that repo as the target
+
+## Example
+
+The seeder work that prompted this clarification followed this pattern after correction:
+
+- mistaken initial upstream PR: `nobodies-collective/Humans#376`
+- QA PR: `peterdrier/Humans#137`
+
+The upstream PR was closed in favor of the QA-first flow.


### PR DESCRIPTION
## What changed

This PR documents the Humans repository's QA-first pull request workflow.

- adds `docs/pull-request-workflow.md` as the canonical guide
- links that guide from `docs/README.md`
- updates `PROCESSES.md` so the execution flow points at the QA-first PR path

## Why

Peter clarified on `nobodies-collective/Humans#376` that this repo does not use the default "open the first PR on upstream" workflow.

The intended flow is:

`feature branch -> QA PR on peterdrier/Humans -> QA deploy/review/test -> upstream PR on nobodies-collective/Humans`

This change captures that in the repo docs so future PRs go to the correct place by default.

## Impact

- contributors have a single repo-local explanation of the PR flow
- Codex and other agents have an explicit documented default for PR targets
- `PROCESSES.md` no longer implies a direct upstream-first merge path

## Validation

- docs-only change
- no build or tests run

## Source

Workflow guidance came from Peter's comment on `nobodies-collective/Humans#376`, which redirected the earlier upstream PR into the QA pipeline on `peterdrier/Humans`.
