### PR TITLE
Quick fixes: notification link, rota layout, cash flow runway

### DIFF
--- a/src/Humans.Infrastructure/Services/NotificationMeterProvider.cs
+++ b/src/Humans.Infrastructure/Services/NotificationMeterProvider.cs
@@ -76,7 +76,7 @@ public class NotificationMeterProvider : INotificationMeterProvider
             {
                 Title = "Pending account deletions",
                 Count = counts.PendingDeletions,
-                ActionUrl = "/Admin",
+                ActionUrl = "/Profile/Admin?filter=deleting&sort=name&dir=asc",
                 Priority = 8,
             });
         }

--- a/src/Humans.Web/Views/Finance/CashFlow.cshtml
+++ b/src/Humans.Web/Views/Finance/CashFlow.cshtml
@@ -55,11 +55,22 @@
                     </tr>
                 </thead>
                 <tbody>
+                    @{
+                        var runwayExhausted = false;
+                    }
                     @foreach (var periodRow in Model.Periods)
                     {
                         var detailId = $"period-{periodRow.PeriodStart.ToString("yyyyMMdd", null)}";
-                        <tr class="fw-semibold" role="button" data-bs-toggle="collapse" data-bs-target="#@detailId">
-                            <td>@periodRow.Label</td>
+                        var isRunwayBoundary = !runwayExhausted && periodRow.RunningNet < 0;
+                        if (isRunwayBoundary) { runwayExhausted = true; }
+                        <tr class="fw-semibold @(isRunwayBoundary ? "table-warning" : "")" role="button" data-bs-toggle="collapse" data-bs-target="#@detailId">
+                            <td>
+                                @periodRow.Label
+                                @if (isRunwayBoundary)
+                                {
+                                    <span class="badge bg-warning text-dark ms-2"><i class="fa-solid fa-triangle-exclamation me-1"></i>Funds exhausted</span>
+                                }
+                            </td>
                             <td class="text-end text-success">&euro;@periodRow.IncomeTotal.ToString("N2")</td>
                             <td class="text-end text-danger">&euro;@Math.Abs(periodRow.ExpenseTotal).ToString("N2")</td>
                             <td class="text-end @(periodRow.Net >= 0 ? "text-success" : "text-danger")">

--- a/src/Humans.Web/Views/ShiftAdmin/Index.cshtml
+++ b/src/Humans.Web/Views/ShiftAdmin/Index.cshtml
@@ -224,15 +224,6 @@
                                         <option value="RequireApproval" selected="@(rota.Policy == SignupPolicy.RequireApproval ? "selected" : null)">Require Approval</option>
                                     </select>
                                 </div>
-                                <div class="col-md-3">
-                                    <label class="form-label">Description</label>
-                                    <textarea name="Description" class="form-control" rows="2">@rota.Description</textarea>
-                                    <div class="form-text">
-                                        <a href="#" data-bs-toggle="modal" data-bs-target="#markdownHelpModal">
-                                            <i class="fa-solid fa-circle-info me-1"></i>Markdown
-                                        </a>
-                                    </div>
-                                </div>
                             </div>
                             <div class="row g-2 mt-2 align-items-end">
                                 <div class="col-md-2">
@@ -244,7 +235,16 @@
                                         <option value="All" selected="@(rota.Period == RotaPeriod.All ? "selected" : null)">All Phases</option>
                                     </select>
                                 </div>
-                                <div class="col-md-6">
+                                <div class="col-md-4">
+                                    <label class="form-label">Description</label>
+                                    <textarea name="Description" class="form-control" rows="2">@rota.Description</textarea>
+                                    <div class="form-text">
+                                        <a href="#" data-bs-toggle="modal" data-bs-target="#markdownHelpModal">
+                                            <i class="fa-solid fa-circle-info me-1"></i>Markdown
+                                        </a>
+                                    </div>
+                                </div>
+                                <div class="col-md-4">
                                     <label class="form-label">Practical Info</label>
                                     <textarea name="PracticalInfo" class="form-control" rows="2" placeholder="Meeting point, instructions...">@rota.PracticalInfo</textarea>
                                     <div class="form-text">


### PR DESCRIPTION
## Summary
- **#390**: Fix pending deletions notification to link to filtered profile admin list instead of /Admin
- **#393**: Move rota description textarea from cramped col-md-3 in row 1 to col-md-4 in row 2 alongside Practical Info
- **#387**: Add visual runway indicator (warning badge + row highlight) on Cash Flow view where running net first goes negative

Closes #390, closes #393, closes #387

## Test plan
- [ ] Click pending deletions notification → lands on `/Profile/Admin?filter=deleting&sort=name&dir=asc`
- [ ] Edit a rota → Description textarea has adequate width, form usable on mobile
- [ ] Cash Flow view with negative running net → first negative period highlighted with "Funds exhausted" badge
- [ ] Cash Flow view with all-positive running net → no indicator shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)