### PR TITLE
UX + error handling fixes (#395, #396, #398)

### DIFF
--- a/src/Humans.Web/Controllers/FeedbackController.cs
+++ b/src/Humans.Web/Controllers/FeedbackController.cs
@@ -97,12 +97,19 @@ public class FeedbackController : HumansControllerBase
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> Submit(SubmitFeedbackViewModel model)
     {
+        var isAjax = Request.Headers.XRequestedWith == "XMLHttpRequest";
+
         var (userMissing, user) = await RequireCurrentUserAsync();
-        if (userMissing is not null) return userMissing;
+        if (userMissing is not null)
+        {
+            return isAjax ? Unauthorized() : userMissing;
+        }
 
         if (!ModelState.IsValid)
         {
-            SetError(_localizer["Feedback_Error"].Value);
+            var errorMsg = _localizer["Feedback_Error"].Value;
+            if (isAjax) return Json(new { success = false, message = errorMsg });
+            SetError(errorMsg);
             return LocalRedirect(Url.IsLocalUrl(model.PageUrl) ? model.PageUrl : "/");
         }
 
@@ -116,12 +123,16 @@ public class FeedbackController : HumansControllerBase
                 model.PageUrl, model.UserAgent, additionalContext,
                 model.Screenshot);
 
-            SetSuccess(_localizer["Feedback_Submitted"].Value);
+            var successMsg = _localizer["Feedback_Submitted"].Value;
+            if (isAjax) return Json(new { success = true, message = successMsg });
+            SetSuccess(successMsg);
         }
         catch (InvalidOperationException ex)
         {
-            _logger.LogWarning(ex, "Feedback submission failed for user {UserId}", user.Id);
-            SetError(_localizer["Feedback_Error"].Value);
+            _logger.LogDebug(ex, "Feedback submission failed for user {UserId}", user.Id);
+            var errorMsg = _localizer["Feedback_Error"].Value;
+            if (isAjax) return Json(new { success = false, message = errorMsg });
+            SetError(errorMsg);
         }
 
         return LocalRedirect(Url.IsLocalUrl(model.PageUrl) ? model.PageUrl : "/");

--- a/src/Humans.Web/Controllers/HumansControllerBase.cs
+++ b/src/Humans.Web/Controllers/HumansControllerBase.cs
@@ -60,7 +60,7 @@ public abstract class HumansControllerBase : Controller
     {
         var logger = HttpContext.RequestServices.GetRequiredService<ILoggerFactory>()
             .CreateLogger(GetType());
-        logger.LogWarning("Error toast: {Message} (Action: {Action})", message, ControllerContext.ActionDescriptor.ActionName);
+        logger.LogDebug("Error toast: {Message} (Action: {Action})", message, ControllerContext.ActionDescriptor.ActionName);
         TempData["ErrorMessage"] = message;
     }
 

--- a/src/Humans.Web/Controllers/TeamAdminController.cs
+++ b/src/Humans.Web/Controllers/TeamAdminController.cs
@@ -754,7 +754,7 @@ public class TeamAdminController : HumansTeamControllerBase
         }
         catch (Exception ex) when (ex is InvalidOperationException or DbUpdateException or ArgumentException)
         {
-            _logger.LogWarning(ex, "Failed to create role '{RoleName}' for team {TeamId} by user {UserId}", model.Name, team.Id, user.Id);
+            _logger.LogDebug(ex, "Failed to create role '{RoleName}' for team {TeamId} by user {UserId}", model.Name, team.Id, user.Id);
             SetError(ex.Message);
         }
 
@@ -765,10 +765,12 @@ public class TeamAdminController : HumansTeamControllerBase
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> EditRole(string slug, Guid roleId, EditRoleDefinitionModel model)
     {
+        var isAjax = Request.Headers.XRequestedWith == "XMLHttpRequest";
+
         var (teamError, user, team) = await ResolveTeamManagementAsync(slug);
         if (teamError is not null)
         {
-            return teamError;
+            return isAjax ? Unauthorized() : teamError;
         }
 
         try
@@ -782,11 +784,14 @@ public class TeamAdminController : HumansTeamControllerBase
                 priorities, model.SortOrder, model.IsManagement, model.Period, user.Id,
                 model.IsPublic);
 
-            SetSuccess($"Role '{model.Name}' updated.");
+            var successMsg = $"Role '{model.Name}' updated.";
+            if (isAjax) return Json(new { success = true, message = successMsg });
+            SetSuccess(successMsg);
         }
         catch (Exception ex) when (ex is InvalidOperationException or DbUpdateException or ArgumentException)
         {
-            _logger.LogWarning(ex, "Failed to update role {RoleId} for team {TeamId} by user {UserId}", roleId, team.Id, user.Id);
+            _logger.LogDebug(ex, "Failed to update role {RoleId} for team {TeamId} by user {UserId}", roleId, team.Id, user.Id);
+            if (isAjax) return Json(new { success = false, message = ex.Message });
             SetError(ex.Message);
         }
 
@@ -810,7 +815,7 @@ public class TeamAdminController : HumansTeamControllerBase
         }
         catch (Exception ex) when (ex is InvalidOperationException or DbUpdateException or ArgumentException)
         {
-            _logger.LogWarning(ex, "Failed to delete role {RoleId} for team {TeamId} by user {UserId}", roleId, team.Id, user.Id);
+            _logger.LogDebug(ex, "Failed to delete role {RoleId} for team {TeamId} by user {UserId}", roleId, team.Id, user.Id);
             SetError(ex.Message);
         }
 
@@ -843,7 +848,7 @@ public class TeamAdminController : HumansTeamControllerBase
         }
         catch (Exception ex) when (ex is InvalidOperationException or DbUpdateException or ArgumentException)
         {
-            _logger.LogWarning(ex, "Failed to toggle management flag for role {RoleId} in team {TeamId} by user {UserId}", roleId, team.Id, user.Id);
+            _logger.LogDebug(ex, "Failed to toggle management flag for role {RoleId} in team {TeamId} by user {UserId}", roleId, team.Id, user.Id);
             SetError(ex.Message);
         }
 
@@ -868,7 +873,7 @@ public class TeamAdminController : HumansTeamControllerBase
         }
         catch (Exception ex) when (ex is InvalidOperationException or DbUpdateException or ArgumentException)
         {
-            _logger.LogWarning(ex, "Failed to assign member {MemberUserId} to role {RoleId} in team {TeamId} by user {UserId}", model.UserId, roleId, team.Id, user.Id);
+            _logger.LogDebug(ex, "Failed to assign member {MemberUserId} to role {RoleId} in team {TeamId} by user {UserId}", model.UserId, roleId, team.Id, user.Id);
             SetError(ex.Message);
         }
 
@@ -903,7 +908,7 @@ public class TeamAdminController : HumansTeamControllerBase
         }
         catch (Exception ex) when (ex is InvalidOperationException or DbUpdateException or ArgumentException)
         {
-            _logger.LogWarning(ex, "Failed to unassign member {MemberId} from role {RoleId} in team {TeamId} by user {UserId}", memberId, roleId, team.Id, user.Id);
+            _logger.LogDebug(ex, "Failed to unassign member {MemberId} from role {RoleId} in team {TeamId} by user {UserId}", memberId, roleId, team.Id, user.Id);
             SetError(ex.Message);
         }
 

--- a/src/Humans.Web/Controllers/TicketController.cs
+++ b/src/Humans.Web/Controllers/TicketController.cs
@@ -6,7 +6,6 @@ using Humans.Infrastructure.Jobs;
 using Humans.Infrastructure.Services;
 using Humans.Web.Authorization;
 using Humans.Web.Extensions;
-using Humans.Web.Authorization;
 using Humans.Web.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;

--- a/src/Humans.Web/Program.cs
+++ b/src/Humans.Web/Program.cs
@@ -165,7 +165,16 @@ builder.Services.AddAuthentication()
             {
                 var logger = context.HttpContext.RequestServices.GetRequiredService<ILoggerFactory>()
                     .CreateLogger("GoogleOAuth");
-                logger.LogWarning(context.Failure, "Google sign-in failed: {Error}", context.Failure?.Message);
+
+                var isCorrelationFailure = context.Failure?.Message?.Contains("Correlation", StringComparison.OrdinalIgnoreCase) == true;
+                if (isCorrelationFailure)
+                {
+                    logger.LogDebug(context.Failure, "Google sign-in correlation failed (expected for stale/duplicate requests)");
+                }
+                else
+                {
+                    logger.LogWarning(context.Failure, "Google sign-in failed: {Error}", context.Failure?.Message);
+                }
 
                 context.Response.Redirect("/Account/Login?error=sign-in-failed");
                 context.HandleResponse();

--- a/src/Humans.Web/Views/Shared/Components/FeedbackWidget/Default.cshtml
+++ b/src/Humans.Web/Views/Shared/Components/FeedbackWidget/Default.cshtml
@@ -53,4 +53,37 @@
         document.getElementById('feedbackPageUrl').value = window.location.href;
         document.getElementById('feedbackUserAgent').value = navigator.userAgent;
     });
+
+    (function () {
+        var form = document.querySelector('#feedbackModal form');
+        if (!form) return;
+        form.addEventListener('submit', function (e) {
+            e.preventDefault();
+            var submitBtn = form.querySelector('button[type="submit"]');
+            if (submitBtn) submitBtn.disabled = true;
+            var formData = new FormData(form);
+            fetch(form.action, {
+                method: 'POST',
+                headers: { 'X-Requested-With': 'XMLHttpRequest' },
+                body: formData
+            })
+            .then(function (r) { return r.json(); })
+            .then(function (data) {
+                if (data.success) {
+                    form.reset();
+                    var modal = bootstrap.Modal.getInstance(document.getElementById('feedbackModal'));
+                    if (modal) modal.hide();
+                    showToast(data.message, 'success');
+                } else {
+                    showToast(data.message || 'Something went wrong.', 'danger');
+                }
+            })
+            .catch(function () {
+                showToast('Something went wrong. Please try again.', 'danger');
+            })
+            .finally(function () {
+                if (submitBtn) submitBtn.disabled = false;
+            });
+        });
+    })();
 </script>

--- a/src/Humans.Web/Views/Shared/_Layout.cshtml
+++ b/src/Humans.Web/Views/Shared/_Layout.cshtml
@@ -145,6 +145,9 @@
         </div>
     </div>
 
+    <!-- Toast container for AJAX notifications -->
+    <div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 1080;" id="toastContainer"></div>
+
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
             integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"
             crossorigin="anonymous"></script>

--- a/src/Humans.Web/Views/TeamAdmin/Roles.cshtml
+++ b/src/Humans.Web/Views/TeamAdmin/Roles.cshtml
@@ -327,5 +327,57 @@ document.querySelectorAll('.slot-count-input').forEach(function(input) {
         }
     });
 });
+
+// Dirty-state tracking for role edit forms
+document.querySelectorAll('form[action*="/Edit"]').forEach(function(form) {
+    var card = form.closest('.card');
+    var saveBtn = form.querySelector('button[type="submit"]');
+    var unsavedBadge = null;
+
+    function markDirty() {
+        if (unsavedBadge) return;
+        if (!card) return;
+        card.classList.add('border-warning');
+        unsavedBadge = document.createElement('span');
+        unsavedBadge.className = 'badge bg-warning text-dark ms-2 unsaved-badge';
+        unsavedBadge.textContent = 'Unsaved';
+        var header = card.querySelector('.card-header h5');
+        if (header) header.appendChild(unsavedBadge);
+    }
+
+    function clearDirty() {
+        if (card) card.classList.remove('border-warning');
+        if (unsavedBadge) { unsavedBadge.remove(); unsavedBadge = null; }
+    }
+
+    form.addEventListener('input', markDirty);
+    form.addEventListener('change', markDirty);
+
+    form.addEventListener('submit', function(e) {
+        e.preventDefault();
+        if (saveBtn) saveBtn.disabled = true;
+        var formData = new FormData(form);
+        fetch(form.action, {
+            method: 'POST',
+            headers: { 'X-Requested-With': 'XMLHttpRequest' },
+            body: formData
+        })
+        .then(function(r) { return r.json(); })
+        .then(function(data) {
+            if (data.success) {
+                clearDirty();
+                showToast(data.message, 'success');
+            } else {
+                showToast(data.message || 'Save failed.', 'danger');
+            }
+        })
+        .catch(function() {
+            showToast('Save failed. Please try again.', 'danger');
+        })
+        .finally(function() {
+            if (saveBtn) saveBtn.disabled = false;
+        });
+    });
+});
 </script>
 }

--- a/src/Humans.Web/wwwroot/js/site.js
+++ b/src/Humans.Web/wwwroot/js/site.js
@@ -230,13 +230,22 @@ function showToast(message, type) {
     toastEl.setAttribute('role', 'alert');
     toastEl.setAttribute('aria-live', 'assertive');
     toastEl.setAttribute('aria-atomic', 'true');
-    toastEl.innerHTML =
-        '<div class="d-flex">' +
-            '<div class="toast-body">' +
-                '<i class="fa-solid ' + iconClass + ' me-2"></i>' + message +
-            '</div>' +
-            '<button type="button" class="btn-close me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>' +
-        '</div>';
+    var wrapper = document.createElement('div');
+    wrapper.className = 'd-flex';
+    var body = document.createElement('div');
+    body.className = 'toast-body';
+    var icon = document.createElement('i');
+    icon.className = 'fa-solid ' + iconClass + ' me-2';
+    body.appendChild(icon);
+    body.appendChild(document.createTextNode(message));
+    wrapper.appendChild(body);
+    var closeBtn = document.createElement('button');
+    closeBtn.type = 'button';
+    closeBtn.className = 'btn-close me-2 m-auto';
+    closeBtn.setAttribute('data-bs-dismiss', 'toast');
+    closeBtn.setAttribute('aria-label', 'Close');
+    wrapper.appendChild(closeBtn);
+    toastEl.appendChild(wrapper);
     container.appendChild(toastEl);
     var toast = new bootstrap.Toast(toastEl, { delay: 4000 });
     toast.show();

--- a/src/Humans.Web/wwwroot/js/site.js
+++ b/src/Humans.Web/wwwroot/js/site.js
@@ -218,6 +218,31 @@ document.addEventListener('click', function (e) {
     });
 })();
 
+// Show a Bootstrap toast notification
+// Usage: showToast('Success!', 'success') or showToast('Error!', 'danger')
+function showToast(message, type) {
+    type = type || 'success';
+    var container = document.getElementById('toastContainer');
+    if (!container) return;
+    var iconClass = type === 'success' ? 'fa-check-circle text-success' : 'fa-exclamation-circle text-danger';
+    var toastEl = document.createElement('div');
+    toastEl.className = 'toast align-items-center border-0';
+    toastEl.setAttribute('role', 'alert');
+    toastEl.setAttribute('aria-live', 'assertive');
+    toastEl.setAttribute('aria-atomic', 'true');
+    toastEl.innerHTML =
+        '<div class="d-flex">' +
+            '<div class="toast-body">' +
+                '<i class="fa-solid ' + iconClass + ' me-2"></i>' + message +
+            '</div>' +
+            '<button type="button" class="btn-close me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>' +
+        '</div>';
+    container.appendChild(toastEl);
+    var toast = new bootstrap.Toast(toastEl, { delay: 4000 });
+    toast.show();
+    toastEl.addEventListener('hidden.bs.toast', function () { toastEl.remove(); });
+}
+
 // Human profile popover (lazy-loaded on first hover)
 (function () {
     var cache = {};


### PR DESCRIPTION
## Summary
- **#395**: Convert feedback widget from full-page POST to AJAX fetch submit — no more page redirect/reload on feedback submission, success shown as toast, form resets after submit
- **#396**: Convert role edit form saves to AJAX — saving one role no longer reloads the page and loses unsaved changes on other roles; dirty-state tracking with yellow border and "Unsaved" badge; toast notifications for save feedback
- **#398**: Downgrade predictable failure logs from Warning to Debug — Google sign-in correlation failures, role CRUD validation errors, feedback submission validation, and SetError() base method toast logging

Closes #395, closes #396, closes #398

## Test plan
- [x] Submit feedback via the widget — verify no page redirect, toast appears, form resets
- [ ] Submit feedback with validation error — verify error toast appears
- [x] Edit a role on the Roles page, change fields on two roles, save one — verify the other retains its unsaved changes with yellow border/"Unsaved" badge
- [x] Save a role successfully — verify toast appears and "Unsaved" indicator clears
- [ ] Trigger a Google sign-in correlation failure (e.g., stale login link) — verify redirect to login with user-friendly message, no Warning in logs
- [ ] Trigger a role validation error (e.g., management role conflict) — verify error appears as toast/alert, logged at Debug not Warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)