### PR TITLE
Google Sync fixes: outbox errors, Drive Activity false positives, extra member resolution

### DIFF
--- a/src/Humans.Infrastructure/Jobs/ProcessGoogleSyncOutboxJob.cs
+++ b/src/Humans.Infrastructure/Jobs/ProcessGoogleSyncOutboxJob.cs
@@ -62,6 +62,16 @@ public class ProcessGoogleSyncOutboxJob : IRecurringJob
             return;
         }
 
+        // Pre-load contextual info for richer error messages
+        var userIds = pendingEvents.Select(e => e.UserId).Distinct().ToList();
+        var teamIds = pendingEvents.Select(e => e.TeamId).Distinct().ToList();
+        var userEmailLookup = await _dbContext.Users
+            .Where(u => userIds.Contains(u.Id))
+            .ToDictionaryAsync(u => u.Id, u => u.Email ?? "unknown", cancellationToken);
+        var teamNameLookup = await _dbContext.Teams
+            .Where(t => teamIds.Contains(t.Id))
+            .ToDictionaryAsync(t => t.Id, t => t.Name, cancellationToken);
+
         foreach (var outboxEvent in pendingEvents)
         {
             try
@@ -116,9 +126,11 @@ public class ProcessGoogleSyncOutboxJob : IRecurringJob
 
                 _logger.LogWarning(
                     ex,
-                    "Permanent failure processing Google sync outbox event {OutboxId} ({EventType}) — HTTP {StatusCode}, not retrying",
+                    "Permanent failure processing Google sync outbox event {OutboxId} ({EventType}) for user {UserEmail} in team {TeamName} — HTTP {StatusCode}, not retrying",
                     outboxEvent.Id,
                     outboxEvent.EventType,
+                    userEmailLookup.GetValueOrDefault(outboxEvent.UserId, "unknown"),
+                    teamNameLookup.GetValueOrDefault(outboxEvent.TeamId, outboxEvent.TeamId.ToString()),
                     ex.Error?.Code);
 
                 // Mark user's Google email as Rejected
@@ -136,10 +148,20 @@ public class ProcessGoogleSyncOutboxJob : IRecurringJob
 
                 _logger.LogError(
                     ex,
-                    "Failed processing Google sync outbox event {OutboxId} ({EventType}) attempt {Attempt}",
+                    "Failed processing Google sync outbox event {OutboxId} ({EventType}) for user {UserEmail} in team {TeamName} — attempt {Attempt}/{MaxRetries}",
                     outboxEvent.Id,
                     outboxEvent.EventType,
-                    outboxEvent.RetryCount);
+                    userEmailLookup.GetValueOrDefault(outboxEvent.UserId, "unknown"),
+                    teamNameLookup.GetValueOrDefault(outboxEvent.TeamId, outboxEvent.TeamId.ToString()),
+                    outboxEvent.RetryCount,
+                    MaxRetryCount);
+
+                // Mark as permanently failed when retries are exhausted
+                if (outboxEvent.RetryCount >= MaxRetryCount)
+                {
+                    outboxEvent.FailedPermanently = true;
+                    outboxEvent.ProcessedAt = _clock.GetCurrentInstant();
+                }
 
                 await _dbContext.SaveChangesAsync(cancellationToken);
 
@@ -155,7 +177,7 @@ public class ProcessGoogleSyncOutboxJob : IRecurringJob
                             "Google sync event failed after all retries",
                             RoleNames.Admin,
                             body: $"Event {outboxEvent.EventType} for team {outboxEvent.TeamId} failed: {outboxEvent.LastError?[..Math.Min(200, outboxEvent.LastError.Length)]}",
-                            actionUrl: "/Google/Sync",
+                            actionUrl: "/Google/SyncOutbox",
                             actionLabel: "View \u2192",
                             cancellationToken: cancellationToken);
                     }

--- a/src/Humans.Infrastructure/Services/DriveActivityMonitorService.cs
+++ b/src/Humans.Infrastructure/Services/DriveActivityMonitorService.cs
@@ -33,6 +33,7 @@ public class DriveActivityMonitorService : IDriveActivityMonitorService
     private DriveActivityService? _activityService;
     private DirectoryService? _directoryService;
     private string? _serviceAccountEmail;
+    private string? _serviceAccountClientId;
 
     /// <summary>
     /// Per-invocation cache for resolved people/ IDs to avoid repeated API calls.
@@ -71,8 +72,16 @@ public class DriveActivityMonitorService : IDriveActivityMonitorService
 
         var activityService = await GetActivityServiceAsync();
         var serviceAccountEmail = await GetServiceAccountEmailAsync(cancellationToken);
+        var serviceAccountClientId = await GetServiceAccountClientIdAsync(cancellationToken);
         var anomalyCount = 0;
         var hadFailures = false;
+
+        // Seed the people ID cache with the service account's client_id so that
+        // ResolvePersonNameAsync maps "people/{client_id}" back to the SA email.
+        if (serviceAccountClientId is not null)
+        {
+            _peopleIdCache[$"people/{serviceAccountClientId}"] = serviceAccountEmail;
+        }
 
         // Use time-window dedup: only process events since the last successful run.
         // Falls back to 24 hours on first run or if the stored timestamp is missing.
@@ -89,7 +98,7 @@ public class DriveActivityMonitorService : IDriveActivityMonitorService
             {
                 var anomalies = await CheckResourceActivityAsync(
                     activityService, resource.GoogleId, resource.Id, resource.Name,
-                    serviceAccountEmail, filterTime, cancellationToken);
+                    serviceAccountEmail, serviceAccountClientId, filterTime, cancellationToken);
                 anomalyCount += anomalies;
             }
             catch (Google.GoogleApiException ex) when (ex.Error?.Code == 404)
@@ -136,6 +145,7 @@ public class DriveActivityMonitorService : IDriveActivityMonitorService
         Guid resourceId,
         string resourceName,
         string serviceAccountEmail,
+        string? serviceAccountClientId,
         string filterTime,
         CancellationToken cancellationToken)
     {
@@ -160,7 +170,7 @@ public class DriveActivityMonitorService : IDriveActivityMonitorService
                 foreach (var activity in response.Activities)
                 {
                     if (IsPermissionChangeActivity(activity) &&
-                        !IsInitiatedByServiceAccount(activity, serviceAccountEmail))
+                        !IsInitiatedByServiceAccount(activity, serviceAccountEmail, serviceAccountClientId))
                     {
                         var description = await BuildAnomalyDescriptionAsync(activity, resourceName, cancellationToken);
                         var actorEmail = await GetActorEmailAsync(activity, cancellationToken);
@@ -197,7 +207,8 @@ public class DriveActivityMonitorService : IDriveActivityMonitorService
         return activity.PrimaryActionDetail.PermissionChange is not null;
     }
 
-    private static bool IsInitiatedByServiceAccount(DriveActivity activity, string serviceAccountEmail)
+    private static bool IsInitiatedByServiceAccount(
+        DriveActivity activity, string serviceAccountEmail, string? serviceAccountClientId)
     {
         if (activity.Actors is null || activity.Actors.Count == 0)
         {
@@ -208,8 +219,18 @@ public class DriveActivityMonitorService : IDriveActivityMonitorService
         {
             if (actor.User?.KnownUser?.PersonName is not null)
             {
-                // The personName field contains the user's email in Drive Activity API
-                if (string.Equals(actor.User.KnownUser.PersonName, serviceAccountEmail, StringComparison.OrdinalIgnoreCase))
+                var personName = actor.User.KnownUser.PersonName;
+
+                // The personName field may contain the SA email directly
+                if (string.Equals(personName, serviceAccountEmail, StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+
+                // Drive Activity API often returns "people/{client_id}" instead of the email
+                // for service accounts. Match against the SA's client_id.
+                if (serviceAccountClientId is not null &&
+                    string.Equals(personName, $"people/{serviceAccountClientId}", StringComparison.Ordinal))
                 {
                     return true;
                 }
@@ -532,16 +553,7 @@ public class DriveActivityMonitorService : IDriveActivityMonitorService
 
     private async Task<string> ExtractServiceAccountEmailAsync(CancellationToken ct)
     {
-        string? json = null;
-
-        if (!string.IsNullOrEmpty(_settings.ServiceAccountKeyJson))
-        {
-            json = _settings.ServiceAccountKeyJson;
-        }
-        else if (!string.IsNullOrEmpty(_settings.ServiceAccountKeyPath))
-        {
-            json = await System.IO.File.ReadAllTextAsync(_settings.ServiceAccountKeyPath, ct);
-        }
+        var json = await GetServiceAccountJsonAsync(ct);
 
         if (json is not null)
         {
@@ -553,5 +565,46 @@ public class DriveActivityMonitorService : IDriveActivityMonitorService
         }
 
         return "unknown@serviceaccount.iam.gserviceaccount.com";
+    }
+
+    /// <summary>
+    /// Gets the service account's client_id from the key JSON.
+    /// Drive Activity API uses "people/{client_id}" to identify the SA as an actor.
+    /// </summary>
+    private async Task<string?> GetServiceAccountClientIdAsync(CancellationToken ct)
+    {
+        if (_serviceAccountClientId is not null)
+        {
+            return _serviceAccountClientId;
+        }
+
+        var json = await GetServiceAccountJsonAsync(ct);
+
+        if (json is not null)
+        {
+            using var doc = JsonDocument.Parse(json);
+            if (doc.RootElement.TryGetProperty("client_id", out var clientIdElement))
+            {
+                _serviceAccountClientId = clientIdElement.GetString();
+                return _serviceAccountClientId;
+            }
+        }
+
+        return null;
+    }
+
+    private async Task<string?> GetServiceAccountJsonAsync(CancellationToken ct)
+    {
+        if (!string.IsNullOrEmpty(_settings.ServiceAccountKeyJson))
+        {
+            return _settings.ServiceAccountKeyJson;
+        }
+
+        if (!string.IsNullOrEmpty(_settings.ServiceAccountKeyPath))
+        {
+            return await System.IO.File.ReadAllTextAsync(_settings.ServiceAccountKeyPath, ct);
+        }
+
+        return null;
     }
 }

--- a/src/Humans.Infrastructure/Services/GoogleWorkspaceSyncService.cs
+++ b/src/Humans.Infrastructure/Services/GoogleWorkspaceSyncService.cs
@@ -1073,13 +1073,20 @@ public class GoogleWorkspaceSyncService : IGoogleSyncService
                     UserId: expected.Id, ProfilePictureUrl: expected.ProfilePictureUrl));
             }
 
-            foreach (var email in currentEmails)
-            {
-                // Skip the service account — it's the group owner added at creation
-                if (string.Equals(email, saEmail, StringComparison.OrdinalIgnoreCase))
-                    continue;
+            var extraEmails = currentEmails
+                .Where(e => !expectedEmails.Contains(e) &&
+                    !string.Equals(e, saEmail, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+            var extraIdentities = await ResolveExtraEmailIdentitiesAsync(extraEmails, cancellationToken);
 
-                if (!expectedEmails.Contains(email))
+            foreach (var email in extraEmails)
+            {
+                if (extraIdentities.TryGetValue(email, out var identity))
+                {
+                    members.Add(new MemberSyncStatus(email, identity.DisplayName, MemberSyncState.Extra, [],
+                        UserId: identity.UserId, ProfilePictureUrl: identity.ProfilePictureUrl));
+                }
+                else
                 {
                     members.Add(new MemberSyncStatus(email, email, MemberSyncState.Extra, []));
                 }
@@ -1402,18 +1409,26 @@ public class GoogleWorkspaceSyncService : IGoogleSyncService
             }
 
             var saEmail = await GetServiceAccountEmailAsync();
-            foreach (var email in allEmails)
-            {
-                // Skip the service account — it manages the resources
-                if (string.Equals(email, saEmail, StringComparison.OrdinalIgnoreCase))
-                    continue;
+            var nonMemberEmails = allEmails
+                .Where(e => !membersByEmail.ContainsKey(e) &&
+                    !string.Equals(e, saEmail, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+            var extraIdentities = await ResolveExtraEmailIdentitiesAsync(nonMemberEmails, cancellationToken);
 
-                if (!membersByEmail.ContainsKey(email))
+            foreach (var email in nonMemberEmails)
+            {
+                var state = directEmails.Contains(email)
+                    ? MemberSyncState.Extra
+                    : MemberSyncState.Inherited;
+                roleByEmail.TryGetValue(email, out var extraRole);
+
+                if (extraIdentities.TryGetValue(email, out var identity))
                 {
-                    var state = directEmails.Contains(email)
-                        ? MemberSyncState.Extra
-                        : MemberSyncState.Inherited;
-                    roleByEmail.TryGetValue(email, out var extraRole);
+                    members.Add(new MemberSyncStatus(email, identity.DisplayName, state, [], extraRole,
+                        UserId: identity.UserId, ProfilePictureUrl: identity.ProfilePictureUrl));
+                }
+                else
+                {
                     members.Add(new MemberSyncStatus(email, email, state, [], extraRole));
                 }
             }
@@ -2344,5 +2359,34 @@ public class GoogleWorkspaceSyncService : IGoogleSyncService
             await _dbContext.SaveChangesAsync(cancellationToken);
 
         return correctedCount;
+    }
+
+    /// <summary>
+    /// Resolves extra emails against UserEmail records to get display names, user IDs, and profile pictures.
+    /// Returns a lookup keyed by email (case-insensitive) with user identity info.
+    /// </summary>
+    private async Task<Dictionary<string, (string DisplayName, Guid UserId, string? ProfilePictureUrl)>>
+        ResolveExtraEmailIdentitiesAsync(IEnumerable<string> emails, CancellationToken cancellationToken)
+    {
+        var emailList = emails.ToList();
+        if (emailList.Count == 0)
+            return new Dictionary<string, (string, Guid, string?)>(NormalizingEmailComparer.Instance);
+
+        var matches = await _dbContext.UserEmails
+            .AsNoTracking()
+            .Include(ue => ue.User)
+            .Where(ue => emailList.Contains(ue.Email))
+            .ToListAsync(cancellationToken);
+
+        var result = new Dictionary<string, (string DisplayName, Guid UserId, string? ProfilePictureUrl)>(
+            NormalizingEmailComparer.Instance);
+
+        foreach (var match in matches)
+        {
+            // First match wins (a user might have multiple matching emails)
+            result.TryAdd(match.Email, (match.User.DisplayName, match.UserId, match.User.ProfilePictureUrl));
+        }
+
+        return result;
     }
 }

--- a/src/Humans.Web/Controllers/GoogleController.cs
+++ b/src/Humans.Web/Controllers/GoogleController.cs
@@ -1,11 +1,13 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 using Humans.Application.DTOs;
 using Humans.Application.Interfaces;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
+using Humans.Infrastructure.Data;
 using Humans.Web.Authorization;
 using Humans.Web.Models;
 
@@ -707,6 +709,32 @@ public class GoogleController : HumansControllerBase
         }
 
         return RedirectToAction(nameof(Accounts));
+    }
+
+    // --- Sync Outbox ---
+
+    [HttpGet("SyncOutbox")]
+    [Authorize(Policy = PolicyNames.AdminOnly)]
+    public async Task<IActionResult> SyncOutbox([FromServices] HumansDbContext dbContext)
+    {
+        var events = await dbContext.GoogleSyncOutboxEvents
+            .OrderByDescending(e => e.OccurredAt)
+            .Take(200)
+            .ToListAsync();
+
+        // Resolve user emails and team names for display
+        var userIds = events.Select(e => e.UserId).Distinct().ToList();
+        var teamIds = events.Select(e => e.TeamId).Distinct().ToList();
+        var userLookup = await dbContext.Users
+            .Where(u => userIds.Contains(u.Id))
+            .ToDictionaryAsync(u => u.Id, u => u.Email ?? "unknown");
+        var teamLookup = await dbContext.Teams
+            .Where(t => teamIds.Contains(t.Id))
+            .ToDictionaryAsync(t => t.Id, t => t.Name);
+
+        ViewBag.UserLookup = userLookup;
+        ViewBag.TeamLookup = teamLookup;
+        return View(events);
     }
 
     // --- Index ---

--- a/src/Humans.Web/Views/Google/Index.cshtml
+++ b/src/Humans.Web/Views/Google/Index.cshtml
@@ -26,6 +26,9 @@
                 <a asp-action="Accounts" class="list-group-item list-group-item-action">
                     <i class="fa-solid fa-at me-2"></i>@@nobodies.team Accounts
                 </a>
+                <a asp-action="SyncOutbox" class="list-group-item list-group-item-action">
+                    <i class="fa-solid fa-clock-rotate-left me-2"></i>Sync Outbox
+                </a>
             </div>
         </div>
 

--- a/src/Humans.Web/Views/Google/SyncOutbox.cshtml
+++ b/src/Humans.Web/Views/Google/SyncOutbox.cshtml
@@ -1,0 +1,60 @@
+@using Humans.Web.Extensions
+@model IList<Humans.Domain.Entities.GoogleSyncOutboxEvent>
+@{
+    ViewData["Title"] = "Google Sync Outbox";
+    var userLookup = (Dictionary<Guid, string>)ViewBag.UserLookup;
+    var teamLookup = (Dictionary<Guid, string>)ViewBag.TeamLookup;
+}
+
+<div class="d-flex justify-content-between align-items-center mb-3">
+    <h1 class="mb-0">Google Sync Outbox</h1>
+    <a asp-action="Index" class="btn btn-outline-secondary btn-sm">
+        <i class="fa-solid fa-arrow-left me-1"></i>Back to Google Integration
+    </a>
+</div>
+
+<vc:temp-data-alerts />
+
+@{
+    var failedPermanently = Model.Where(e => e.FailedPermanently).ToList();
+    var pending = Model.Where(e => e.ProcessedAt == null && !e.FailedPermanently).ToList();
+    var processed = Model.Where(e => e.ProcessedAt != null && !e.FailedPermanently).ToList();
+}
+
+@if (failedPermanently.Count > 0)
+{
+    <div class="alert alert-danger">
+        <i class="fa-solid fa-triangle-exclamation me-1"></i>
+        <strong>@failedPermanently.Count permanently failed event(s)</strong> require manual attention.
+    </div>
+}
+
+<ul class="nav nav-tabs mb-3" role="tablist">
+    <li class="nav-item">
+        <button class="nav-link active" data-bs-toggle="tab" data-bs-target="#failed-tab" type="button">
+            Failed <span class="badge bg-danger ms-1">@failedPermanently.Count</span>
+        </button>
+    </li>
+    <li class="nav-item">
+        <button class="nav-link" data-bs-toggle="tab" data-bs-target="#pending-tab" type="button">
+            Pending <span class="badge bg-warning text-dark ms-1">@pending.Count</span>
+        </button>
+    </li>
+    <li class="nav-item">
+        <button class="nav-link" data-bs-toggle="tab" data-bs-target="#processed-tab" type="button">
+            Processed <span class="badge bg-success ms-1">@processed.Count</span>
+        </button>
+    </li>
+</ul>
+
+<div class="tab-content">
+    <div class="tab-pane fade show active" id="failed-tab">
+        @await Html.PartialAsync("_SyncOutboxTable", failedPermanently, new ViewDataDictionary(ViewData) { { "UserLookup", userLookup }, { "TeamLookup", teamLookup }, { "ShowError", true } })
+    </div>
+    <div class="tab-pane fade" id="pending-tab">
+        @await Html.PartialAsync("_SyncOutboxTable", pending, new ViewDataDictionary(ViewData) { { "UserLookup", userLookup }, { "TeamLookup", teamLookup }, { "ShowError", true } })
+    </div>
+    <div class="tab-pane fade" id="processed-tab">
+        @await Html.PartialAsync("_SyncOutboxTable", processed, new ViewDataDictionary(ViewData) { { "UserLookup", userLookup }, { "TeamLookup", teamLookup }, { "ShowError", false } })
+    </div>
+</div>

--- a/src/Humans.Web/Views/Google/SyncOutbox.cshtml
+++ b/src/Humans.Web/Views/Google/SyncOutbox.cshtml
@@ -2,8 +2,6 @@
 @model IList<Humans.Domain.Entities.GoogleSyncOutboxEvent>
 @{
     ViewData["Title"] = "Google Sync Outbox";
-    var userLookup = (Dictionary<Guid, string>)ViewBag.UserLookup;
-    var teamLookup = (Dictionary<Guid, string>)ViewBag.TeamLookup;
 }
 
 <div class="d-flex justify-content-between align-items-center mb-3">
@@ -49,12 +47,12 @@
 
 <div class="tab-content">
     <div class="tab-pane fade show active" id="failed-tab">
-        @await Html.PartialAsync("_SyncOutboxTable", failedPermanently, new ViewDataDictionary(ViewData) { { "UserLookup", userLookup }, { "TeamLookup", teamLookup }, { "ShowError", true } })
+        @await Html.PartialAsync("_SyncOutboxTable", failedPermanently, new ViewDataDictionary(ViewData) { { "ShowError", true } })
     </div>
     <div class="tab-pane fade" id="pending-tab">
-        @await Html.PartialAsync("_SyncOutboxTable", pending, new ViewDataDictionary(ViewData) { { "UserLookup", userLookup }, { "TeamLookup", teamLookup }, { "ShowError", true } })
+        @await Html.PartialAsync("_SyncOutboxTable", pending, new ViewDataDictionary(ViewData) { { "ShowError", true } })
     </div>
     <div class="tab-pane fade" id="processed-tab">
-        @await Html.PartialAsync("_SyncOutboxTable", processed, new ViewDataDictionary(ViewData) { { "UserLookup", userLookup }, { "TeamLookup", teamLookup }, { "ShowError", false } })
+        @await Html.PartialAsync("_SyncOutboxTable", processed, new ViewDataDictionary(ViewData) { { "ShowError", false } })
     </div>
 </div>

--- a/src/Humans.Web/Views/Google/_SyncOutboxTable.cshtml
+++ b/src/Humans.Web/Views/Google/_SyncOutboxTable.cshtml
@@ -1,0 +1,64 @@
+@using Humans.Web.Extensions
+@model IList<Humans.Domain.Entities.GoogleSyncOutboxEvent>
+@{
+    var userLookup = (Dictionary<Guid, string>)ViewData["UserLookup"]!;
+    var teamLookup = (Dictionary<Guid, string>)ViewData["TeamLookup"]!;
+    var showError = (bool)ViewData["ShowError"]!;
+}
+
+@if (Model.Count == 0)
+{
+    <div class="text-muted text-center py-4">No events.</div>
+}
+else
+{
+    <div class="table-responsive">
+        <table class="table table-sm table-hover mb-0">
+            <thead>
+                <tr>
+                    <th>Event Type</th>
+                    <th>Human</th>
+                    <th>Team</th>
+                    <th>Occurred</th>
+                    <th>Retries</th>
+                    @if (showError)
+                    {
+                        <th>Last Error</th>
+                    }
+                </tr>
+            </thead>
+            <tbody>
+                @foreach (var evt in Model)
+                {
+                    var userEmail = userLookup.GetValueOrDefault(evt.UserId, "unknown");
+                    var teamName = teamLookup.GetValueOrDefault(evt.TeamId, evt.TeamId.ToString());
+                    <tr>
+                        <td><code>@evt.EventType</code></td>
+                        <td>
+                            <human-link user-id="@evt.UserId" display-name="@userEmail" admin="true" show-popover="true" />
+                        </td>
+                        <td>@teamName</td>
+                        <td class="text-nowrap">@evt.OccurredAt.ToDisplayDateTime()</td>
+                        <td>
+                            @if (evt.RetryCount > 0)
+                            {
+                                <span class="badge bg-secondary">@evt.RetryCount</span>
+                            }
+                        </td>
+                        @if (showError)
+                        {
+                            <td>
+                                @if (!string.IsNullOrEmpty(evt.LastError))
+                                {
+                                    <small class="text-danger" title="@evt.LastError">
+                                        @(evt.LastError.Length > 120 ? evt.LastError[..120] + "..." : evt.LastError)
+                                    </small>
+                                }
+                            </td>
+                        }
+                    </tr>
+                }
+            </tbody>
+        </table>
+    </div>
+}

--- a/tests/Humans.Application.Tests/Jobs/ProcessGoogleSyncOutboxJobTests.cs
+++ b/tests/Humans.Application.Tests/Jobs/ProcessGoogleSyncOutboxJobTests.cs
@@ -111,7 +111,7 @@ public class ProcessGoogleSyncOutboxJobTests : IDisposable
             "Google sync event failed after all retries",
             RoleNames.Admin,
             Arg.Any<string?>(),
-            "/Google/Sync",
+            "/Google/SyncOutbox",
             "View \u2192",
             Arg.Any<CancellationToken>());
     }


### PR DESCRIPTION
## Summary
- **#397**: Add user email and team name to outbox error log messages, mark events `FailedPermanently = true` after max retries (with `ProcessedAt`), add Sync Outbox admin page (`/Google/SyncOutbox`) with failed/pending/processed tabs
- **#383**: Fix Drive Activity Monitor flagging its own permission changes by also matching `people/{client_id}` format (not just email), seed the people ID cache with the SA's client_id-to-email mapping
- **#388**: Resolve extra sync members against `UserEmail` records to show display name, avatar, and profile link for known humans (both Groups and Shared Drives sync tabs)

Closes #397, closes #383, closes #388

## Test plan
- [ ] Verify Sync Outbox page loads at `/Google/SyncOutbox` and is linked from Google Integration index
- [ ] Verify failed-permanently events show in the Failed tab with error details
- [ ] Verify Drive Activity Monitor does not flag SA-initiated permission changes (check audit log for false positives)
- [ ] Verify extra members with alternate emails show display names in Groups and Drive sync previews

🤖 Generated with [Claude Code](https://claude.com/claude-code)