### PR TITLE
Notification fixes: stacking, shift links, voting badges

### DIFF
--- a/src/Humans.Application/CacheKeys.cs
+++ b/src/Humans.Application/CacheKeys.cs
@@ -21,6 +21,8 @@ public static class CacheKeys
 
     public static string ShiftAuthorization(Guid userId) => $"shift-auth:{userId:N}";
 
+    public static string VotingBadge(Guid userId) => $"NavBadge:Voting:{userId:N}";
+
     public static string LegalDocument(string slug) => $"Legal:{slug}";
 
     // Magic link sentinel keys (rate limiting and replay prevention)

--- a/src/Humans.Application/Extensions/MemoryCacheExtensions.cs
+++ b/src/Humans.Application/Extensions/MemoryCacheExtensions.cs
@@ -80,6 +80,9 @@ public static class MemoryCacheExtensions
     public static void InvalidateShiftAuthorization(this IMemoryCache cache, Guid userId) =>
         cache.Remove(CacheKeys.ShiftAuthorization(userId));
 
+    public static void InvalidateVotingBadge(this IMemoryCache cache, Guid userId) =>
+        cache.Remove(CacheKeys.VotingBadge(userId));
+
     public static void InvalidateUserAccess(this IMemoryCache cache, Guid userId)
     {
         cache.InvalidateActiveTeams();

--- a/src/Humans.Application/Interfaces/INotificationInboxService.cs
+++ b/src/Humans.Application/Interfaces/INotificationInboxService.cs
@@ -74,6 +74,15 @@ public interface INotificationInboxService
     Task<string?> ClickThroughAsync(
         Guid notificationId, Guid userId,
         CancellationToken ct = default);
+
+    /// <summary>
+    /// Resolves all unresolved notifications of a given source type for a user.
+    /// Used for auto-resolving notifications when the underlying condition is fixed
+    /// (e.g., resolving AccessSuspended notifications when consents are completed).
+    /// </summary>
+    Task ResolveBySourceAsync(
+        Guid userId, NotificationSource source,
+        CancellationToken ct = default);
 }
 
 /// <summary>

--- a/src/Humans.Infrastructure/Jobs/SuspendNonCompliantMembersJob.cs
+++ b/src/Humans.Infrastructure/Jobs/SuspendNonCompliantMembersJob.cs
@@ -93,6 +93,12 @@ public class SuspendNonCompliantMembersJob : IRecurringJob
                     continue;
                 }
 
+                // Skip users who are already suspended — avoids re-sending notifications
+                if (user.Profile.IsSuspended)
+                {
+                    continue;
+                }
+
                 // 1. Set suspended flag on profile
                 user.Profile.IsSuspended = true;
                 user.Profile.UpdatedAt = now;

--- a/src/Humans.Infrastructure/Services/ApplicationDecisionService.cs
+++ b/src/Humans.Infrastructure/Services/ApplicationDecisionService.cs
@@ -120,6 +120,8 @@ public class ApplicationDecisionService : IApplicationDecisionService
 
         _cache.InvalidateNavBadgeCounts();
         _cache.InvalidateNotificationMeters();
+        foreach (var vote in application.BoardVotes)
+            _cache.InvalidateVotingBadge(vote.BoardMemberUserId);
         _metrics.RecordApplicationProcessed("approved");
         _logger.LogInformation("Application {ApplicationId} approved by {UserId}",
             application.Id, reviewerUserId);
@@ -225,6 +227,8 @@ public class ApplicationDecisionService : IApplicationDecisionService
 
         _cache.InvalidateNavBadgeCounts();
         _cache.InvalidateNotificationMeters();
+        foreach (var vote in application.BoardVotes)
+            _cache.InvalidateVotingBadge(vote.BoardMemberUserId);
         _metrics.RecordApplicationProcessed("rejected");
         _logger.LogInformation("Application {ApplicationId} rejected by {UserId}",
             application.Id, reviewerUserId);

--- a/src/Humans.Infrastructure/Services/ApplicationDecisionService.cs
+++ b/src/Humans.Infrastructure/Services/ApplicationDecisionService.cs
@@ -89,6 +89,9 @@ public class ApplicationDecisionService : IApplicationDecisionService
             $"{application.MembershipTier} application approved",
             reviewerUserId);
 
+        // Capture voter IDs before GDPR deletion clears the navigation collection
+        var voterIds = application.BoardVotes.Select(v => v.BoardMemberUserId).ToList();
+
         // GDPR: delete individual board votes
         _dbContext.BoardVotes.RemoveRange(application.BoardVotes);
 
@@ -120,8 +123,8 @@ public class ApplicationDecisionService : IApplicationDecisionService
 
         _cache.InvalidateNavBadgeCounts();
         _cache.InvalidateNotificationMeters();
-        foreach (var vote in application.BoardVotes)
-            _cache.InvalidateVotingBadge(vote.BoardMemberUserId);
+        foreach (var id in voterIds)
+            _cache.InvalidateVotingBadge(id);
         _metrics.RecordApplicationProcessed("approved");
         _logger.LogInformation("Application {ApplicationId} approved by {UserId}",
             application.Id, reviewerUserId);
@@ -199,6 +202,9 @@ public class ApplicationDecisionService : IApplicationDecisionService
             $"{application.MembershipTier} application rejected",
             reviewerUserId);
 
+        // Capture voter IDs before GDPR deletion clears the navigation collection
+        var voterIds = application.BoardVotes.Select(v => v.BoardMemberUserId).ToList();
+
         // GDPR: delete individual board votes
         _dbContext.BoardVotes.RemoveRange(application.BoardVotes);
 
@@ -227,8 +233,8 @@ public class ApplicationDecisionService : IApplicationDecisionService
 
         _cache.InvalidateNavBadgeCounts();
         _cache.InvalidateNotificationMeters();
-        foreach (var vote in application.BoardVotes)
-            _cache.InvalidateVotingBadge(vote.BoardMemberUserId);
+        foreach (var id in voterIds)
+            _cache.InvalidateVotingBadge(id);
         _metrics.RecordApplicationProcessed("rejected");
         _logger.LogInformation("Application {ApplicationId} rejected by {UserId}",
             application.Id, reviewerUserId);

--- a/src/Humans.Infrastructure/Services/ConsentService.cs
+++ b/src/Humans.Infrastructure/Services/ConsentService.cs
@@ -155,10 +155,13 @@ public class ConsentService : IConsentService
         await _syncJob.SyncVolunteersMembershipForUserAsync(userId);
         await _syncJob.SyncCoordinatorsMembershipForUserAsync(userId);
 
-        // Auto-resolve any outstanding AccessSuspended notifications (best-effort)
+        // Auto-resolve AccessSuspended notifications only once ALL required consents are complete
         try
         {
-            await _notificationInboxService.ResolveBySourceAsync(userId, NotificationSource.AccessSuspended, ct);
+            if (await _membershipCalculator.HasAllRequiredConsentsAsync(userId, ct))
+            {
+                await _notificationInboxService.ResolveBySourceAsync(userId, NotificationSource.AccessSuspended, ct);
+            }
         }
         catch (Exception ex)
         {

--- a/src/Humans.Infrastructure/Services/ConsentService.cs
+++ b/src/Humans.Infrastructure/Services/ConsentService.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Logging;
 using NodaTime;
 using Humans.Application.Interfaces;
 using Humans.Domain.Entities;
+using Humans.Domain.Enums;
 using Humans.Infrastructure.Data;
 
 namespace Humans.Infrastructure.Services;
@@ -14,6 +15,7 @@ public class ConsentService : IConsentService
     private readonly HumansDbContext _dbContext;
     private readonly IOnboardingService _onboardingService;
     private readonly IMembershipCalculator _membershipCalculator;
+    private readonly INotificationInboxService _notificationInboxService;
     private readonly ISystemTeamSync _syncJob;
     private readonly IHumansMetrics _metrics;
     private readonly IClock _clock;
@@ -23,6 +25,7 @@ public class ConsentService : IConsentService
         HumansDbContext dbContext,
         IOnboardingService onboardingService,
         IMembershipCalculator membershipCalculator,
+        INotificationInboxService notificationInboxService,
         ISystemTeamSync syncJob,
         IHumansMetrics metrics,
         IClock clock,
@@ -31,6 +34,7 @@ public class ConsentService : IConsentService
         _dbContext = dbContext;
         _onboardingService = onboardingService;
         _membershipCalculator = membershipCalculator;
+        _notificationInboxService = notificationInboxService;
         _syncJob = syncJob;
         _metrics = metrics;
         _clock = clock;
@@ -150,6 +154,16 @@ public class ConsentService : IConsentService
         // Sync system team memberships (adds user if eligible + all consents done)
         await _syncJob.SyncVolunteersMembershipForUserAsync(userId);
         await _syncJob.SyncCoordinatorsMembershipForUserAsync(userId);
+
+        // Auto-resolve any outstanding AccessSuspended notifications (best-effort)
+        try
+        {
+            await _notificationInboxService.ResolveBySourceAsync(userId, NotificationSource.AccessSuspended, ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to resolve AccessSuspended notifications for user {UserId}", userId);
+        }
 
         return new ConsentSubmitResult(true, DocumentName: version.LegalDocument.Name);
     }

--- a/src/Humans.Infrastructure/Services/NotificationInboxService.cs
+++ b/src/Humans.Infrastructure/Services/NotificationInboxService.cs
@@ -343,6 +343,32 @@ public class NotificationInboxService : INotificationInboxService
         return recipient.Notification.ActionUrl;
     }
 
+    public async Task ResolveBySourceAsync(
+        Guid userId, NotificationSource source,
+        CancellationToken ct = default)
+    {
+        var now = _clock.GetCurrentInstant();
+
+        var notifications = await _dbContext.Notifications
+            .Include(n => n.Recipients)
+            .Where(n => n.Source == source
+                && n.ResolvedAt == null
+                && n.Recipients.Any(r => r.UserId == userId))
+            .ToListAsync(ct);
+
+        if (notifications.Count == 0)
+            return;
+
+        foreach (var notification in notifications)
+        {
+            notification.ResolvedAt = now;
+            notification.ResolvedByUserId = userId;
+        }
+
+        await _dbContext.SaveChangesAsync(ct);
+        InvalidateBadgeCaches([userId]);
+    }
+
     private static NotificationRowDto MapToRow(NotificationRecipient nr)
     {
         var n = nr.Notification;

--- a/src/Humans.Infrastructure/Services/NotificationMeterProvider.cs
+++ b/src/Humans.Infrastructure/Services/NotificationMeterProvider.cs
@@ -57,16 +57,24 @@ public class NotificationMeterProvider : INotificationMeterProvider
             });
         }
 
-        // Applications pending board vote — Board
-        if (isBoard && counts.ApplicationsPendingVote > 0)
+        // Applications pending board vote — Board (per-user count)
+        if (isBoard)
         {
-            meters.Add(new NotificationMeter
+            var userIdClaim = user.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (Guid.TryParse(userIdClaim, out var boardMemberUserId))
             {
-                Title = "Applications pending board vote",
-                Count = counts.ApplicationsPendingVote,
-                ActionUrl = "/OnboardingReview/BoardVoting",
-                Priority = 9,
-            });
+                var pendingVoteCount = await GetPerUserVotingCountAsync(boardMemberUserId, cancellationToken);
+                if (pendingVoteCount > 0)
+                {
+                    meters.Add(new NotificationMeter
+                    {
+                        Title = "Applications pending your vote",
+                        Count = pendingVoteCount,
+                        ActionUrl = "/OnboardingReview/BoardVoting",
+                        Priority = 9,
+                    });
+                }
+            }
         }
 
         // Pending account deletions — Admin
@@ -153,6 +161,20 @@ public class NotificationMeterProvider : INotificationMeterProvider
         return counts!;
     }
 
+    private async Task<int> GetPerUserVotingCountAsync(Guid boardMemberUserId, CancellationToken cancellationToken)
+    {
+        var cacheKey = $"NavBadge:Voting:{boardMemberUserId:N}";
+        return await _cache.GetOrCreateAsync(cacheKey, async entry =>
+        {
+            entry.AbsoluteExpirationRelativeToNow = CacheDuration;
+
+            return await _dbContext.Applications
+                .CountAsync(a => a.Status == ApplicationStatus.Submitted
+                    && !a.BoardVotes.Any(v => v.BoardMemberUserId == boardMemberUserId),
+                    cancellationToken);
+        });
+    }
+
     private async Task<MeterCounts> ComputeCountsAsync(CancellationToken cancellationToken)
     {
         // Consent reviews pending (Pending or Flagged, not rejected)
@@ -161,10 +183,6 @@ public class NotificationMeterProvider : INotificationMeterProvider
                 && (p.ConsentCheckStatus == ConsentCheckStatus.Pending
                     || p.ConsentCheckStatus == ConsentCheckStatus.Flagged)
                 && p.RejectedAt == null, cancellationToken);
-
-        // Applications pending board vote
-        var applicationsPendingVote = await _dbContext.Applications
-            .CountAsync(a => a.Status == ApplicationStatus.Submitted, cancellationToken);
 
         // Pending account deletions
         var pendingDeletions = await _dbContext.Users
@@ -193,7 +211,6 @@ public class NotificationMeterProvider : INotificationMeterProvider
         return new MeterCounts
         {
             ConsentReviewsPending = consentReviewsPending,
-            ApplicationsPendingVote = applicationsPendingVote,
             PendingDeletions = pendingDeletions,
             FailedSyncEvents = failedSyncEvents,
             OnboardingPending = onboardingPending,
@@ -205,7 +222,6 @@ public class NotificationMeterProvider : INotificationMeterProvider
     private sealed class MeterCounts
     {
         public int ConsentReviewsPending { get; init; }
-        public int ApplicationsPendingVote { get; init; }
         public int PendingDeletions { get; init; }
         public int FailedSyncEvents { get; init; }
         public int OnboardingPending { get; init; }

--- a/src/Humans.Infrastructure/Services/NotificationMeterProvider.cs
+++ b/src/Humans.Infrastructure/Services/NotificationMeterProvider.cs
@@ -163,7 +163,7 @@ public class NotificationMeterProvider : INotificationMeterProvider
 
     private async Task<int> GetPerUserVotingCountAsync(Guid boardMemberUserId, CancellationToken cancellationToken)
     {
-        var cacheKey = $"NavBadge:Voting:{boardMemberUserId:N}";
+        var cacheKey = CacheKeys.VotingBadge(boardMemberUserId);
         return await _cache.GetOrCreateAsync(cacheKey, async entry =>
         {
             entry.AbsoluteExpirationRelativeToNow = CacheDuration;

--- a/src/Humans.Infrastructure/Services/OnboardingService.cs
+++ b/src/Humans.Infrastructure/Services/OnboardingService.cs
@@ -293,6 +293,8 @@ public class OnboardingService : IOnboardingService
 
         await _dbContext.SaveChangesAsync(ct);
 
+        _cache.InvalidateVotingBadge(boardMemberUserId);
+
         _logger.LogInformation("Board member {UserId} voted {Vote} on application {ApplicationId}",
             boardMemberUserId, vote, applicationId);
 

--- a/src/Humans.Infrastructure/Services/OnboardingService.cs
+++ b/src/Humans.Infrastructure/Services/OnboardingService.cs
@@ -18,6 +18,7 @@ public class OnboardingService : IOnboardingService
     private readonly IAuditLogService _auditLogService;
     private readonly IEmailService _emailService;
     private readonly INotificationService _notificationService;
+    private readonly INotificationInboxService _notificationInboxService;
     private readonly ISystemTeamSync _syncJob;
     private readonly IMembershipCalculator _membershipCalculator;
     private readonly IHumansMetrics _metrics;
@@ -30,6 +31,7 @@ public class OnboardingService : IOnboardingService
         IAuditLogService auditLogService,
         IEmailService emailService,
         INotificationService notificationService,
+        INotificationInboxService notificationInboxService,
         ISystemTeamSync syncJob,
         IMembershipCalculator membershipCalculator,
         IHumansMetrics metrics,
@@ -41,6 +43,7 @@ public class OnboardingService : IOnboardingService
         _auditLogService = auditLogService;
         _emailService = emailService;
         _notificationService = notificationService;
+        _notificationInboxService = notificationInboxService;
         _syncJob = syncJob;
         _membershipCalculator = membershipCalculator;
         _metrics = metrics;
@@ -505,6 +508,16 @@ public class OnboardingService : IOnboardingService
         {
             await _dbContext.Entry(user.Profile).Collection(p => p.VolunteerHistory).LoadAsync(ct);
             _cache.UpdateApprovedProfile(userId, CachedProfile.Create(user.Profile, user));
+        }
+
+        // Auto-resolve any outstanding AccessSuspended notifications (best-effort)
+        try
+        {
+            await _notificationInboxService.ResolveBySourceAsync(userId, NotificationSource.AccessSuspended, ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to resolve AccessSuspended notifications for user {UserId}", userId);
         }
 
         _logger.LogInformation("Admin {AdminId} unsuspended human {HumanId}", adminId, userId);

--- a/src/Humans.Infrastructure/Services/ShiftSignupService.cs
+++ b/src/Humans.Infrastructure/Services/ShiftSignupService.cs
@@ -763,7 +763,7 @@ public class ShiftSignupService : IShiftSignupService
     public async Task<SignupResult> RefuseRangeAsync(Guid signupBlockId, Guid reviewerUserId, string? reason)
     {
         var signups = await _dbContext.ShiftSignups
-            .Include(s => s.Shift).ThenInclude(s => s.Rota)
+            .Include(s => s.Shift).ThenInclude(s => s.Rota).ThenInclude(r => r.EventSettings)
             .Where(s => s.SignupBlockId == signupBlockId && s.Status == SignupStatus.Pending)
             .ToListAsync();
 

--- a/src/Humans.Infrastructure/Services/ShiftSignupService.cs
+++ b/src/Humans.Infrastructure/Services/ShiftSignupService.cs
@@ -1009,8 +1009,15 @@ public class ShiftSignupService : IShiftSignupService
     {
         try
         {
-            var teamId = signup.Shift.Rota.TeamId;
-            var rotaName = signup.Shift.Rota.Name;
+            var shift = signup.Shift;
+            var rota = shift.Rota;
+            var teamId = rota.TeamId;
+            var rotaName = rota.Name;
+
+            // Enrich description with shift date and rota name for context
+            var es = rota.EventSettings;
+            var shiftDate = es.GateOpeningDate.PlusDays(shift.DayOffset);
+            var enrichedDescription = $"{changeDescription} ({rotaName}, {FormatShiftDate(shiftDate)})";
 
             // Find coordinators for this department team
             var coordinatorIds = await _dbContext.TeamMembers
@@ -1029,8 +1036,8 @@ public class ShiftSignupService : IShiftSignupService
                 NotificationPriority.Normal,
                 $"Shift signup change: {rotaName}",
                 coordinatorIds,
-                body: changeDescription,
-                actionUrl: $"/Shifts/Dashboard?departmentId={teamId}",
+                body: enrichedDescription,
+                actionUrl: $"/Shifts/Dashboard?departmentId={teamId}&rotaId={rota.Id}",
                 actionLabel: "View \u2192");
         }
         catch (Exception ex)

--- a/src/Humans.Web/Controllers/ShiftDashboardController.cs
+++ b/src/Humans.Web/Controllers/ShiftDashboardController.cs
@@ -42,7 +42,7 @@ public class ShiftDashboardController : HumansControllerBase
     }
 
     [HttpGet("")]
-    public async Task<IActionResult> Index(Guid? departmentId, string? date)
+    public async Task<IActionResult> Index(Guid? departmentId, Guid? rotaId, string? date)
     {
         var es = await _shiftMgmt.GetActiveAsync();
         if (es is null)
@@ -74,6 +74,7 @@ public class ShiftDashboardController : HumansControllerBase
             Shifts = shifts.ToList(),
             Departments = departments,
             SelectedDepartmentId = departmentId,
+            SelectedRotaId = rotaId,
             SelectedDate = date,
             EventSettings = es,
             StaffingData = staffingData.ToList()

--- a/src/Humans.Web/Models/ShiftViewModels.cs
+++ b/src/Humans.Web/Models/ShiftViewModels.cs
@@ -402,6 +402,7 @@ public class ShiftDashboardViewModel
     public List<UrgentShift> Shifts { get; set; } = [];
     public List<DepartmentOption> Departments { get; set; } = [];
     public Guid? SelectedDepartmentId { get; set; }
+    public Guid? SelectedRotaId { get; set; }
     public string? SelectedDate { get; set; }
     public EventSettings EventSettings { get; set; } = null!;
     public List<DailyStaffingData> StaffingData { get; set; } = [];

--- a/src/Humans.Web/ViewComponents/NavBadgesViewComponent.cs
+++ b/src/Humans.Web/ViewComponents/NavBadgesViewComponent.cs
@@ -61,7 +61,7 @@ public class NavBadgesViewComponent : ViewComponent
         if (!Guid.TryParse(claim, out var currentUserId))
             return 0;
 
-        var cacheKey = $"NavBadge:Voting:{currentUserId:N}";
+        var cacheKey = CacheKeys.VotingBadge(currentUserId);
         return await _cache.GetOrCreateAsync(cacheKey, async entry =>
         {
             entry.AbsoluteExpirationRelativeToNow = CacheDuration;

--- a/src/Humans.Web/ViewComponents/NavBadgesViewComponent.cs
+++ b/src/Humans.Web/ViewComponents/NavBadgesViewComponent.cs
@@ -1,3 +1,4 @@
+using System.Security.Claims;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
@@ -32,20 +33,42 @@ public class NavBadgesViewComponent : ViewComponent
             var reviewCount = await _dbContext.Profiles
                 .CountAsync(p => !p.IsApproved && p.RejectedAt == null);
 
-            var votingCount = await _dbContext.Applications
-                .CountAsync(a => a.Status == ApplicationStatus.Submitted);
-
             var feedbackCount = await _feedbackService.GetActionableCountAsync();
 
-            return (Review: reviewCount, Voting: votingCount, Feedback: feedbackCount);
+            return (Review: reviewCount, Feedback: feedbackCount);
         });
 
-        var count = string.Equals(queue, "review", StringComparison.OrdinalIgnoreCase)
-            ? counts.Review
-            : string.Equals(queue, "feedback", StringComparison.OrdinalIgnoreCase)
-            ? counts.Feedback
-            : counts.Voting;
+        int count;
+        if (string.Equals(queue, "voting", StringComparison.OrdinalIgnoreCase))
+        {
+            count = await GetPerUserVotingCountAsync();
+        }
+        else if (string.Equals(queue, "review", StringComparison.OrdinalIgnoreCase))
+        {
+            count = counts.Review;
+        }
+        else
+        {
+            count = counts.Feedback;
+        }
 
         return View(count);
+    }
+
+    private async Task<int> GetPerUserVotingCountAsync()
+    {
+        var claim = UserClaimsPrincipal.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (!Guid.TryParse(claim, out var currentUserId))
+            return 0;
+
+        var cacheKey = $"NavBadge:Voting:{currentUserId:N}";
+        return await _cache.GetOrCreateAsync(cacheKey, async entry =>
+        {
+            entry.AbsoluteExpirationRelativeToNow = CacheDuration;
+
+            return await _dbContext.Applications
+                .CountAsync(a => a.Status == ApplicationStatus.Submitted
+                    && !a.BoardVotes.Any(v => v.BoardMemberUserId == currentUserId));
+        });
     }
 }

--- a/src/Humans.Web/Views/ShiftDashboard/Index.cshtml
+++ b/src/Humans.Web/Views/ShiftDashboard/Index.cshtml
@@ -92,9 +92,10 @@
                         };
                         var priorityLabel = shift.Rota.Priority.ToString();
                         var understaffed = item.ConfirmedCount < shift.MinVolunteers;
+                        var isHighlighted = Model.SelectedRotaId.HasValue && shift.RotaId == Model.SelectedRotaId.Value;
                         var collapseId = "voluntell-" + shift.Id.ToString("N");
 
-                        <tr>
+                        <tr class="@(isHighlighted ? "table-warning" : "")">
                             <td>
                                 @shift.Rota.Name
                                 @if (shift.AdminOnly) { <span class="badge bg-dark ms-1">Admin</span> }

--- a/tests/Humans.Application.Tests/Services/ConsentServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/ConsentServiceTests.cs
@@ -22,6 +22,7 @@ public class ConsentServiceTests : IDisposable
     private readonly ConsentService _service;
     private readonly IOnboardingService _onboardingService = Substitute.For<IOnboardingService>();
     private readonly IMembershipCalculator _membershipCalculator = Substitute.For<IMembershipCalculator>();
+    private readonly INotificationInboxService _notificationInboxService = Substitute.For<INotificationInboxService>();
     private readonly ISystemTeamSync _syncJob = Substitute.For<ISystemTeamSync>();
     private readonly IHumansMetrics _metrics = Substitute.For<IHumansMetrics>();
 
@@ -35,7 +36,7 @@ public class ConsentServiceTests : IDisposable
         _clock = new FakeClock(Instant.FromUtc(2026, 3, 1, 12, 0));
         _service = new ConsentService(
             _dbContext, _onboardingService, _membershipCalculator,
-            _syncJob, _metrics, _clock,
+            _notificationInboxService, _syncJob, _metrics, _clock,
             NullLogger<ConsentService>.Instance);
     }
 

--- a/tests/Humans.Application.Tests/Services/OnboardingServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/OnboardingServiceTests.cs
@@ -25,6 +25,7 @@ public class OnboardingServiceTests : IDisposable
     private readonly IAuditLogService _auditLogService = Substitute.For<IAuditLogService>();
     private readonly IEmailService _emailService = Substitute.For<IEmailService>();
     private readonly INotificationService _notificationService = Substitute.For<INotificationService>();
+    private readonly INotificationInboxService _notificationInboxService = Substitute.For<INotificationInboxService>();
     private readonly ISystemTeamSync _syncJob = Substitute.For<ISystemTeamSync>();
     private readonly IMembershipCalculator _membershipCalculator = Substitute.For<IMembershipCalculator>();
     private readonly IHumansMetrics _metrics = Substitute.For<IHumansMetrics>();
@@ -39,7 +40,8 @@ public class OnboardingServiceTests : IDisposable
         _dbContext = new HumansDbContext(options);
         _clock = new FakeClock(Instant.FromUtc(2026, 3, 1, 12, 0));
         _service = new OnboardingService(
-            _dbContext, _auditLogService, _emailService, _notificationService, _syncJob,
+            _dbContext, _auditLogService, _emailService, _notificationService,
+            _notificationInboxService, _syncJob,
             _membershipCalculator, _metrics, _clock, _cache,
             NullLogger<OnboardingService>.Instance);
     }


### PR DESCRIPTION
## Summary
- **#384** Fix AccessSuspended notification stacking: skip already-suspended users in the suspension job, add `ResolveBySourceAsync` to auto-resolve notifications when consents are completed or admin unsuspends
- **#392** Fix shift signup notification links: include `rotaId` in action URL and enrich notification body with rota name and shift date for context
- **#389** Fix voting dashboard badge: show per-user pending vote count (excludes applications the board member has already voted on), with per-user cache keys

Closes #384, closes #392, closes #389

## Test plan
- [ ] Verify suspended user does not receive duplicate AccessSuspended notifications on repeated job runs
- [ ] Submit consent as a previously-suspended user and confirm AccessSuspended notification auto-resolves
- [ ] Admin unsuspend a user and confirm AccessSuspended notification auto-resolves
- [ ] Trigger a shift signup change notification and verify the action URL includes rotaId and the body includes date/rota context
- [ ] As a board member, vote on an application and verify the nav badge count decreases
- [ ] As a different board member who has not voted, verify the badge still shows the full count
- [ ] Verify non-board users see no voting badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)