### PR TITLE
Add languages on profile (#394)

### DIFF
--- a/src/Humans.Domain/Entities/Profile.cs
+++ b/src/Humans.Domain/Entities/Profile.cs
@@ -283,4 +283,9 @@ public class Profile
     /// Volunteer history entries documenting involvement in events, roles, and camps.
     /// </summary>
     public ICollection<VolunteerHistoryEntry> VolunteerHistory { get; } = new List<VolunteerHistoryEntry>();
+
+    /// <summary>
+    /// Languages spoken by the member with proficiency levels.
+    /// </summary>
+    public ICollection<ProfileLanguage> Languages { get; } = new List<ProfileLanguage>();
 }

--- a/src/Humans.Domain/Entities/ProfileLanguage.cs
+++ b/src/Humans.Domain/Entities/ProfileLanguage.cs
@@ -1,0 +1,35 @@
+using Humans.Domain.Enums;
+
+namespace Humans.Domain.Entities;
+
+/// <summary>
+/// A language spoken by a member, with proficiency level.
+/// Uses ISO 639-1 two-letter language codes.
+/// </summary>
+public class ProfileLanguage
+{
+    /// <summary>
+    /// Unique identifier.
+    /// </summary>
+    public Guid Id { get; init; }
+
+    /// <summary>
+    /// Foreign key to the profile.
+    /// </summary>
+    public Guid ProfileId { get; init; }
+
+    /// <summary>
+    /// Navigation property to the profile.
+    /// </summary>
+    public Profile Profile { get; set; } = null!;
+
+    /// <summary>
+    /// ISO 639-1 two-letter language code (e.g., "en", "es", "de").
+    /// </summary>
+    public string LanguageCode { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Self-assessed proficiency level.
+    /// </summary>
+    public LanguageProficiency Proficiency { get; set; }
+}

--- a/src/Humans.Domain/Enums/LanguageProficiency.cs
+++ b/src/Humans.Domain/Enums/LanguageProficiency.cs
@@ -1,0 +1,27 @@
+namespace Humans.Domain.Enums;
+
+/// <summary>
+/// Proficiency level for a spoken language.
+/// </summary>
+public enum LanguageProficiency
+{
+    /// <summary>
+    /// Basic understanding and communication.
+    /// </summary>
+    Basic = 0,
+
+    /// <summary>
+    /// Able to hold conversations on everyday topics.
+    /// </summary>
+    Conversational = 1,
+
+    /// <summary>
+    /// Comfortable speaking in most situations.
+    /// </summary>
+    Fluent = 2,
+
+    /// <summary>
+    /// Native or bilingual proficiency.
+    /// </summary>
+    Native = 3
+}

--- a/src/Humans.Infrastructure/Data/Configurations/ProfileLanguageConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/ProfileLanguageConfiguration.cs
@@ -1,0 +1,32 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+
+namespace Humans.Infrastructure.Data.Configurations;
+
+public class ProfileLanguageConfiguration : IEntityTypeConfiguration<ProfileLanguage>
+{
+    public void Configure(EntityTypeBuilder<ProfileLanguage> builder)
+    {
+        builder.ToTable("profile_languages");
+
+        builder.HasKey(pl => pl.Id);
+
+        builder.Property(pl => pl.LanguageCode)
+            .IsRequired()
+            .HasMaxLength(10);
+
+        builder.Property(pl => pl.Proficiency)
+            .IsRequired()
+            .HasConversion<string>()
+            .HasMaxLength(50);
+
+        builder.HasOne(pl => pl.Profile)
+            .WithMany(p => p.Languages)
+            .HasForeignKey(pl => pl.ProfileId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasIndex(pl => pl.ProfileId);
+    }
+}

--- a/src/Humans.Infrastructure/Data/HumansDbContext.cs
+++ b/src/Humans.Infrastructure/Data/HumansDbContext.cs
@@ -77,6 +77,7 @@ public class HumansDbContext : IdentityDbContext<User, IdentityRole<Guid>, Guid>
     public DbSet<VolunteerTagPreference> VolunteerTagPreferences => Set<VolunteerTagPreference>();
     public DbSet<Notification> Notifications => Set<Notification>();
     public DbSet<NotificationRecipient> NotificationRecipients => Set<NotificationRecipient>();
+    public DbSet<ProfileLanguage> ProfileLanguages => Set<ProfileLanguage>();
 
     protected override void OnModelCreating(ModelBuilder builder)
     {

--- a/src/Humans.Infrastructure/Migrations/20260407020305_AddProfileLanguages.Designer.cs
+++ b/src/Humans.Infrastructure/Migrations/20260407020305_AddProfileLanguages.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Humans.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Humans.Infrastructure.Migrations
 {
     [DbContext(typeof(HumansDbContext))]
-    partial class HumansDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260407020305_AddProfileLanguages")]
+    partial class AddProfileLanguages
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Humans.Infrastructure/Migrations/20260407020305_AddProfileLanguages.cs
+++ b/src/Humans.Infrastructure/Migrations/20260407020305_AddProfileLanguages.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Humans.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddProfileLanguages : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "profile_languages",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    ProfileId = table.Column<Guid>(type: "uuid", nullable: false),
+                    LanguageCode = table.Column<string>(type: "character varying(10)", maxLength: 10, nullable: false),
+                    Proficiency = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_profile_languages", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_profile_languages_profiles_ProfileId",
+                        column: x => x.ProfileId,
+                        principalTable: "profiles",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_profile_languages_ProfileId",
+                table: "profile_languages",
+                column: "ProfileId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "profile_languages");
+        }
+    }
+}

--- a/src/Humans.Web/Controllers/ProfileController.cs
+++ b/src/Humans.Web/Controllers/ProfileController.cs
@@ -174,6 +174,15 @@ public class ProfileController : HumansControllerBase
             ? await _volunteerHistoryService.GetAllAsync(profile.Id)
             : [];
 
+        // Get profile languages for editing
+        var languages = profile is not null
+            ? await _dbContext.ProfileLanguages
+                .AsNoTracking()
+                .Where(pl => pl.ProfileId == profile.Id)
+                .OrderBy(pl => pl.LanguageCode)
+                .ToListAsync()
+            : [];
+
         var hasCustomPicture = profile?.HasCustomProfilePicture == true;
 
         // Initial setup = no profile or not yet approved (onboarding)
@@ -234,6 +243,12 @@ public class ProfileController : HumansControllerBase
                 DateString = vh.Date.ToIsoDateString(),
                 EventName = vh.EventName,
                 Description = vh.Description
+            }).ToList(),
+            EditableLanguages = languages.Select(pl => new ProfileLanguageEditViewModel
+            {
+                Id = pl.Id,
+                LanguageCode = pl.LanguageCode,
+                Proficiency = pl.Proficiency
             }).ToList()
         };
 
@@ -453,6 +468,29 @@ public class ProfileController : HumansControllerBase
             .ToList();
 
         await _volunteerHistoryService.SaveAsync(profileId, volunteerHistoryDtos);
+
+        // Save profile languages (remove-and-replace)
+        var existingLanguages = await _dbContext.ProfileLanguages
+            .Where(pl => pl.ProfileId == profileId)
+            .ToListAsync();
+        _dbContext.ProfileLanguages.RemoveRange(existingLanguages);
+
+        var newLanguages = model.EditableLanguages
+            .Where(l => !string.IsNullOrWhiteSpace(l.LanguageCode))
+            .Select(l => new ProfileLanguage
+            {
+                Id = Guid.NewGuid(),
+                ProfileId = profileId,
+                LanguageCode = l.LanguageCode.Trim(),
+                Proficiency = l.Proficiency
+            })
+            .ToList();
+
+        if (newLanguages.Count > 0)
+        {
+            _dbContext.ProfileLanguages.AddRange(newLanguages);
+        }
+        await _dbContext.SaveChangesAsync();
 
         SetSuccess(_localizer["Profile_Updated"].Value);
         return RedirectToAction(nameof(Me));
@@ -1239,6 +1277,14 @@ public class ProfileController : HumansControllerBase
             .CountAsync(m => m.UserId == id);
         ViewBag.OutboxCount = outboxCount;
 
+        var profileLanguages = data.Profile is not null
+            ? await _dbContext.ProfileLanguages
+                .AsNoTracking()
+                .Where(pl => pl.ProfileId == data.Profile.Id)
+                .OrderBy(pl => pl.LanguageCode)
+                .ToListAsync()
+            : [];
+
         var now = _clock.GetCurrentInstant();
 
         var viewModel = new AdminHumanDetailViewModel
@@ -1281,6 +1327,12 @@ public class ProfileController : HumansControllerBase
                 IsActive = ra.IsActive(now),
                 CreatedByName = ra.CreatedByUser?.DisplayName,
                 CreatedAt = ra.CreatedAt.ToDateTimeUtc()
+            }).ToList(),
+            Languages = profileLanguages.Select(pl => new ProfileLanguageDisplayViewModel
+            {
+                LanguageCode = pl.LanguageCode,
+                LanguageName = Helpers.LanguageCatalog.GetDisplayName(pl.LanguageCode),
+                Proficiency = pl.Proficiency
             }).ToList(),
         };
 

--- a/src/Humans.Web/Helpers/LanguageCatalog.cs
+++ b/src/Humans.Web/Helpers/LanguageCatalog.cs
@@ -1,0 +1,106 @@
+namespace Humans.Web.Helpers;
+
+/// <summary>
+/// ISO 639-1 language code catalog with English display names.
+/// Contains the most commonly spoken languages relevant to the community.
+/// </summary>
+public static class LanguageCatalog
+{
+    /// <summary>
+    /// Sorted dictionary of ISO 639-1 code to English language name.
+    /// </summary>
+    public static readonly IReadOnlyDictionary<string, string> Languages =
+        new SortedDictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["af"] = "Afrikaans",
+            ["am"] = "Amharic",
+            ["ar"] = "Arabic",
+            ["az"] = "Azerbaijani",
+            ["be"] = "Belarusian",
+            ["bg"] = "Bulgarian",
+            ["bn"] = "Bengali",
+            ["bs"] = "Bosnian",
+            ["ca"] = "Catalan",
+            ["cs"] = "Czech",
+            ["cy"] = "Welsh",
+            ["da"] = "Danish",
+            ["de"] = "German",
+            ["el"] = "Greek",
+            ["en"] = "English",
+            ["eo"] = "Esperanto",
+            ["es"] = "Spanish",
+            ["et"] = "Estonian",
+            ["eu"] = "Basque",
+            ["fa"] = "Persian",
+            ["fi"] = "Finnish",
+            ["fr"] = "French",
+            ["ga"] = "Irish",
+            ["gl"] = "Galician",
+            ["gu"] = "Gujarati",
+            ["ha"] = "Hausa",
+            ["he"] = "Hebrew",
+            ["hi"] = "Hindi",
+            ["hr"] = "Croatian",
+            ["hu"] = "Hungarian",
+            ["hy"] = "Armenian",
+            ["id"] = "Indonesian",
+            ["is"] = "Icelandic",
+            ["it"] = "Italian",
+            ["ja"] = "Japanese",
+            ["ka"] = "Georgian",
+            ["kk"] = "Kazakh",
+            ["km"] = "Khmer",
+            ["kn"] = "Kannada",
+            ["ko"] = "Korean",
+            ["ku"] = "Kurdish",
+            ["la"] = "Latin",
+            ["lt"] = "Lithuanian",
+            ["lv"] = "Latvian",
+            ["mk"] = "Macedonian",
+            ["ml"] = "Malayalam",
+            ["mn"] = "Mongolian",
+            ["mr"] = "Marathi",
+            ["ms"] = "Malay",
+            ["mt"] = "Maltese",
+            ["my"] = "Burmese",
+            ["ne"] = "Nepali",
+            ["nl"] = "Dutch",
+            ["no"] = "Norwegian",
+            ["pa"] = "Punjabi",
+            ["pl"] = "Polish",
+            ["ps"] = "Pashto",
+            ["pt"] = "Portuguese",
+            ["ro"] = "Romanian",
+            ["ru"] = "Russian",
+            ["si"] = "Sinhala",
+            ["sk"] = "Slovak",
+            ["sl"] = "Slovenian",
+            ["so"] = "Somali",
+            ["sq"] = "Albanian",
+            ["sr"] = "Serbian",
+            ["sv"] = "Swedish",
+            ["sw"] = "Swahili",
+            ["ta"] = "Tamil",
+            ["te"] = "Telugu",
+            ["th"] = "Thai",
+            ["tl"] = "Filipino",
+            ["tr"] = "Turkish",
+            ["uk"] = "Ukrainian",
+            ["ur"] = "Urdu",
+            ["uz"] = "Uzbek",
+            ["vi"] = "Vietnamese",
+            ["zh"] = "Chinese",
+            ["zu"] = "Zulu"
+        };
+
+    /// <summary>
+    /// Gets the display name for a language code, or the code itself if not found.
+    /// </summary>
+    public static string GetDisplayName(string? languageCode)
+    {
+        if (string.IsNullOrWhiteSpace(languageCode))
+            return string.Empty;
+
+        return Languages.TryGetValue(languageCode, out var name) ? name : languageCode;
+    }
+}

--- a/src/Humans.Web/Models/AdminViewModels.cs
+++ b/src/Humans.Web/Models/AdminViewModels.cs
@@ -115,6 +115,7 @@ public class AdminHumanDetailViewModel
     public int ConsentCount { get; set; }
     public List<AdminHumanApplicationViewModel> Applications { get; set; } = [];
     public List<AdminRoleAssignmentViewModel> RoleAssignments { get; set; } = [];
+    public IReadOnlyList<ProfileLanguageDisplayViewModel> Languages { get; set; } = [];
 }
 
 public class AdminHumanApplicationViewModel

--- a/src/Humans.Web/Models/ProfileCardViewModel.cs
+++ b/src/Humans.Web/Models/ProfileCardViewModel.cs
@@ -1,5 +1,6 @@
 using NodaTime;
 using Humans.Domain.Enums;
+using Humans.Web.Helpers;
 using Humans.Web.ViewComponents;
 
 namespace Humans.Web.Models;
@@ -41,6 +42,7 @@ public class ProfileCardViewModel
     public IReadOnlyList<ContactFieldViewModel> ContactFields { get; set; } = [];
     public IReadOnlyList<VolunteerHistoryEntryViewModel> VolunteerHistory { get; set; } = [];
     public IReadOnlyList<TeamMembershipViewModel> Teams { get; set; } = [];
+    public IReadOnlyList<ProfileLanguageDisplayViewModel> Languages { get; set; } = [];
 
     public bool IsOwnProfile => ViewMode == ProfileCardViewMode.Self;
 

--- a/src/Humans.Web/Models/ProfileViewModel.cs
+++ b/src/Humans.Web/Models/ProfileViewModel.cs
@@ -2,6 +2,7 @@ using System.ComponentModel.DataAnnotations;
 using NodaTime;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
+using Humans.Web.Helpers;
 
 namespace Humans.Web.Models;
 
@@ -311,6 +312,16 @@ public class ProfileViewModel
     /// No-show history for coordinators/admins viewing other profiles.
     /// </summary>
     public List<NoShowHistoryItem>? NoShowHistory { get; set; }
+
+    /// <summary>
+    /// Languages for editing (owner only).
+    /// </summary>
+    public List<ProfileLanguageEditViewModel> EditableLanguages { get; set; } = [];
+
+    /// <summary>
+    /// Languages for display (profile card).
+    /// </summary>
+    public IReadOnlyList<ProfileLanguageDisplayViewModel> Languages { get; set; } = [];
 }
 
 /// <summary>
@@ -518,6 +529,43 @@ public class UserEmailDisplayViewModel
         ContactFieldVisibility.CoordinatorsAndBoard => "Coordinators + Board",
         ContactFieldVisibility.MyTeams => "My teams",
         _ => null
+    };
+}
+
+/// <summary>
+/// Language entry for editing purposes.
+/// </summary>
+public class ProfileLanguageEditViewModel
+{
+    public Guid? Id { get; set; }
+
+    [Required]
+    [StringLength(10)]
+    public string LanguageCode { get; set; } = string.Empty;
+
+    [Required]
+    public LanguageProficiency Proficiency { get; set; }
+}
+
+/// <summary>
+/// Language entry for display purposes.
+/// </summary>
+public class ProfileLanguageDisplayViewModel
+{
+    public string LanguageCode { get; set; } = string.Empty;
+    public string LanguageName { get; set; } = string.Empty;
+    public LanguageProficiency Proficiency { get; set; }
+
+    /// <summary>
+    /// Bootstrap badge class for the proficiency level.
+    /// </summary>
+    public string ProficiencyBadgeClass => Proficiency switch
+    {
+        LanguageProficiency.Native => "bg-success",
+        LanguageProficiency.Fluent => "bg-primary",
+        LanguageProficiency.Conversational => "bg-info text-dark",
+        LanguageProficiency.Basic => "bg-secondary",
+        _ => "bg-secondary"
     };
 }
 

--- a/src/Humans.Web/Resources/SharedResource.ca.resx
+++ b/src/Humans.Web/Resources/SharedResource.ca.resx
@@ -241,6 +241,9 @@
   <data name="ProfileEdit_CityHelp" xml:space="preserve"><value>Cerca la teva ciutat per establir la teva ubicació.</value></data>
   <data name="ProfileEdit_CurrentLocation" xml:space="preserve"><value>Ubicació actual:</value></data>
   <data name="ProfileEdit_BioHelp" xml:space="preserve"><value>Explica'ns una mica sobre tu.</value></data>
+  <data name="Profile_Languages" xml:space="preserve"><value>Idiomes parlats</value></data>
+  <data name="ProfileEdit_LanguagesHelp" xml:space="preserve"><value>Quins idiomes parles? Aix&#xF2; ajuda a coordinar la nostra comunitat multiling&#xFC;e.</value></data>
+  <data name="ProfileEdit_AddLanguage" xml:space="preserve"><value>Afegir idioma</value></data>
   <data name="Profile_Pronouns" xml:space="preserve"><value>Pronoms</value></data>
   <data name="ProfileEdit_PronounsPlaceholder" xml:space="preserve"><value>p. ex., elli, ella, ell</value></data>
   <data name="ProfileEdit_ContactInfoHelp" xml:space="preserve"><value>Afegeix formes de contacte perquè altres humans puguin comunicar-se amb tu. Controla qui pot veure cada dada.</value></data>

--- a/src/Humans.Web/Resources/SharedResource.de.resx
+++ b/src/Humans.Web/Resources/SharedResource.de.resx
@@ -239,6 +239,9 @@
   <data name="ProfileEdit_CityHelp" xml:space="preserve"><value>Suchen Sie nach Ihrer Stadt, um Ihren Standort festzulegen.</value></data>
   <data name="ProfileEdit_CurrentLocation" xml:space="preserve"><value>Aktueller Standort:</value></data>
   <data name="ProfileEdit_BioHelp" xml:space="preserve"><value>Erzählen Sie uns ein wenig über sich.</value></data>
+  <data name="Profile_Languages" xml:space="preserve"><value>Gesprochene Sprachen</value></data>
+  <data name="ProfileEdit_LanguagesHelp" xml:space="preserve"><value>Welche Sprachen sprichst du? Das hilft bei der Koordination in unserer mehrsprachigen Community.</value></data>
+  <data name="ProfileEdit_AddLanguage" xml:space="preserve"><value>Sprache hinzuf&#xFC;gen</value></data>
   <data name="Profile_Pronouns" xml:space="preserve"><value>Pronomen</value></data>
   <data name="ProfileEdit_PronounsPlaceholder" xml:space="preserve"><value>z. B., they/them, sie/ihr, er/ihm</value></data>
   <data name="ProfileEdit_ContactInfoHelp" xml:space="preserve"><value>Fügen Sie Kontaktmöglichkeiten für andere humans hinzu. Kontrollieren Sie, wer welche Information sehen kann.</value></data>

--- a/src/Humans.Web/Resources/SharedResource.es.resx
+++ b/src/Humans.Web/Resources/SharedResource.es.resx
@@ -241,6 +241,9 @@
   <data name="ProfileEdit_CityHelp" xml:space="preserve"><value>Busque su ciudad para establecer su ubicaci&#xF3;n.</value></data>
   <data name="ProfileEdit_CurrentLocation" xml:space="preserve"><value>Ubicaci&#xF3;n actual:</value></data>
   <data name="ProfileEdit_BioHelp" xml:space="preserve"><value>Cu&#xE9;ntenos un poco sobre usted.</value></data>
+  <data name="Profile_Languages" xml:space="preserve"><value>Idiomas hablados</value></data>
+  <data name="ProfileEdit_LanguagesHelp" xml:space="preserve"><value>&#xBF;Qu&#xE9; idiomas hablas? Esto ayuda a coordinar nuestra comunidad multiling&#xFC;e.</value></data>
+  <data name="ProfileEdit_AddLanguage" xml:space="preserve"><value>A&#xF1;adir idioma</value></data>
   <data name="Profile_Pronouns" xml:space="preserve"><value>Pronombres</value></data>
   <data name="ProfileEdit_PronounsPlaceholder" xml:space="preserve"><value>p. ej., elle, ella, &#xE9;l</value></data>
   <data name="ProfileEdit_ContactInfoHelp" xml:space="preserve"><value>A&#xF1;ada formas de contacto para que otros humans puedan comunicarse con usted. Controle qui&#xE9;n puede ver cada dato.</value></data>

--- a/src/Humans.Web/Resources/SharedResource.fr.resx
+++ b/src/Humans.Web/Resources/SharedResource.fr.resx
@@ -239,6 +239,9 @@
   <data name="ProfileEdit_CityHelp" xml:space="preserve"><value>Recherchez votre ville pour d&#xE9;finir votre localisation.</value></data>
   <data name="ProfileEdit_CurrentLocation" xml:space="preserve"><value>Localisation actuelle :</value></data>
   <data name="ProfileEdit_BioHelp" xml:space="preserve"><value>Parlez-nous un peu de vous.</value></data>
+  <data name="Profile_Languages" xml:space="preserve"><value>Langues parl&#xE9;es</value></data>
+  <data name="ProfileEdit_LanguagesHelp" xml:space="preserve"><value>Quelles langues parlez-vous ? Cela aide &#xE0; coordonner notre communaut&#xE9; multilingue.</value></data>
+  <data name="ProfileEdit_AddLanguage" xml:space="preserve"><value>Ajouter une langue</value></data>
   <data name="Profile_Pronouns" xml:space="preserve"><value>Pronoms</value></data>
   <data name="ProfileEdit_PronounsPlaceholder" xml:space="preserve"><value>ex., iel, elle, il</value></data>
   <data name="ProfileEdit_ContactInfoHelp" xml:space="preserve"><value>Ajoutez des moyens de contact pour que les autres humans puissent vous joindre. Contr&#xF4;lez qui peut voir chaque information.</value></data>

--- a/src/Humans.Web/Resources/SharedResource.it.resx
+++ b/src/Humans.Web/Resources/SharedResource.it.resx
@@ -239,6 +239,9 @@
   <data name="ProfileEdit_CityHelp" xml:space="preserve"><value>Cerchi la Sua città per impostare la Sua posizione.</value></data>
   <data name="ProfileEdit_CurrentLocation" xml:space="preserve"><value>Posizione attuale:</value></data>
   <data name="ProfileEdit_BioHelp" xml:space="preserve"><value>Ci racconti qualcosa di sé.</value></data>
+  <data name="Profile_Languages" xml:space="preserve"><value>Lingue parlate</value></data>
+  <data name="ProfileEdit_LanguagesHelp" xml:space="preserve"><value>Quali lingue parli? Questo aiuta a coordinare la nostra comunit&#xE0; multilingue.</value></data>
+  <data name="ProfileEdit_AddLanguage" xml:space="preserve"><value>Aggiungi lingua</value></data>
   <data name="Profile_Pronouns" xml:space="preserve"><value>Pronomi</value></data>
   <data name="ProfileEdit_PronounsPlaceholder" xml:space="preserve"><value>es., loro, lei, lui</value></data>
   <data name="ProfileEdit_ContactInfoHelp" xml:space="preserve"><value>Aggiunga modalità di contatto per gli altri humans. Controlli chi può vedere ogni informazione.</value></data>

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -242,6 +242,9 @@
   <data name="ProfileEdit_CityHelp" xml:space="preserve"><value>Search for your city to set your location.</value></data>
   <data name="ProfileEdit_CurrentLocation" xml:space="preserve"><value>Current location:</value></data>
   <data name="ProfileEdit_BioHelp" xml:space="preserve"><value>Tell us a bit about yourself.</value></data>
+  <data name="Profile_Languages" xml:space="preserve"><value>Languages Spoken</value></data>
+  <data name="ProfileEdit_LanguagesHelp" xml:space="preserve"><value>What languages do you speak? This helps coordinate across our multilingual community.</value></data>
+  <data name="ProfileEdit_AddLanguage" xml:space="preserve"><value>Add Language</value></data>
   <data name="Profile_Pronouns" xml:space="preserve"><value>Pronouns</value></data>
   <data name="ProfileEdit_PronounsPlaceholder" xml:space="preserve"><value>e.g., they/them, she/her, he/him</value></data>
   <data name="ProfileEdit_ContactInfoHelp" xml:space="preserve"><value>Add ways for other humans to reach you. Control who can see each piece of information.</value></data>

--- a/src/Humans.Web/ViewComponents/ProfileCardViewComponent.cs
+++ b/src/Humans.Web/ViewComponents/ProfileCardViewComponent.cs
@@ -7,6 +7,7 @@ using Humans.Domain.Enums;
 using Humans.Infrastructure.Data;
 using Humans.Infrastructure.Services;
 using Humans.Web.Controllers;
+using Humans.Web.Helpers;
 using Humans.Web.Models;
 
 namespace Humans.Web.ViewComponents;
@@ -106,6 +107,15 @@ public class ProfileCardViewComponent : ViewComponent
             ? await _volunteerHistoryService.GetAllAsync(profile.Id)
             : [];
 
+        // Get profile languages
+        var profileLanguages = profile is not null
+            ? await _dbContext.ProfileLanguages
+                .AsNoTracking()
+                .Where(pl => pl.ProfileId == profile.Id)
+                .OrderBy(pl => pl.LanguageCode)
+                .ToListAsync()
+            : [];
+
         // Get user's teams (excluding Volunteers system team)
         var userTeams = await _teamService.GetUserTeamsAsync(userId);
         var displayableTeams = userTeams
@@ -180,6 +190,12 @@ public class ProfileCardViewComponent : ViewComponent
                 Description = vh.Description
             }).ToList(),
             Teams = displayableTeams,
+            Languages = profileLanguages.Select(pl => new ProfileLanguageDisplayViewModel
+            {
+                LanguageCode = pl.LanguageCode,
+                LanguageName = LanguageCatalog.GetDisplayName(pl.LanguageCode),
+                Proficiency = pl.Proficiency
+            }).ToList(),
             PreferredLanguage = user.PreferredLanguage,
             CanSendMessage = !isOwnProfile
                 && !visibleEmails.Any(e => e.Visibility >= ContactFieldVisibility.AllActiveProfiles)

--- a/src/Humans.Web/Views/Profile/AdminDetail.cshtml
+++ b/src/Humans.Web/Views/Profile/AdminDetail.cshtml
@@ -75,6 +75,22 @@
                     <dt class="col-sm-3">Language</dt>
                     <dd class="col-sm-9"><span class="@Model.PreferredLanguage.ToFlagClass() me-1"></span>@Model.PreferredLanguage.ToDisplayLanguageName()</dd>
 
+                    @if (Model.Languages.Count > 0)
+                    {
+                        <dt class="col-sm-3">@Localizer["Profile_Languages"]</dt>
+                        <dd class="col-sm-9">
+                            <div class="d-flex flex-wrap gap-1">
+                                @foreach (var lang in Model.Languages)
+                                {
+                                    <span class="badge @lang.ProficiencyBadgeClass">
+                                        @lang.LanguageName
+                                        <small class="ms-1 opacity-75">(@lang.Proficiency)</small>
+                                    </span>
+                                }
+                            </div>
+                        </dd>
+                    }
+
                     <dt class="col-sm-3">@Localizer["AdminHuman_ConsentCheck"]</dt>
                     <dd class="col-sm-9">
                         @if (Model.ConsentCheckStatus.HasValue)

--- a/src/Humans.Web/Views/Profile/Edit.cshtml
+++ b/src/Humans.Web/Views/Profile/Edit.cshtml
@@ -236,6 +236,59 @@
                         <span asp-validation-for="Bio" class="text-danger"></span>
                         <div class="form-text">@Localizer["ProfileEdit_BioHelp"]</div>
                     </div>
+
+                    <hr />
+                    <h6>@Localizer["Profile_Languages"]</h6>
+                    <p class="text-muted small mb-3">
+                        @Localizer["ProfileEdit_LanguagesHelp"]
+                    </p>
+
+                    <div id="languagesContainer">
+                        @for (var i = 0; i < Model.EditableLanguages.Count; i++)
+                        {
+                            <div class="language-row card mb-2" data-index="@i">
+                                <div class="card-body py-2">
+                                    <div class="row g-2 align-items-end">
+                                        <input type="hidden" name="EditableLanguages[@i].Id" value="@Model.EditableLanguages[i].Id" />
+
+                                        <div class="col-md-5">
+                                            <label class="form-label small" for="EditableLanguages_@(i)__LanguageCode">Language</label>
+                                            <select name="EditableLanguages[@i].LanguageCode" id="EditableLanguages_@(i)__LanguageCode" class="form-select form-select-sm language-code-select" required>
+                                                <option value="">— Select language —</option>
+                                                @foreach (var lang in Humans.Web.Helpers.LanguageCatalog.Languages)
+                                                {
+                                                    <option value="@lang.Key" selected="@(Model.EditableLanguages[i].LanguageCode == lang.Key ? "selected" : null)">@lang.Value (@lang.Key)</option>
+                                                }
+                                            </select>
+                                        </div>
+
+                                        <div class="col-md-4">
+                                            @{
+                                                var proficiency = Model.EditableLanguages[i].Proficiency;
+                                            }
+                                            <label class="form-label small" for="EditableLanguages_@(i)__Proficiency">Proficiency</label>
+                                            <select name="EditableLanguages[@i].Proficiency" id="EditableLanguages_@(i)__Proficiency" class="form-select form-select-sm" required>
+                                                <option value="Basic" selected="@(proficiency == LanguageProficiency.Basic ? "selected" : null)">Basic</option>
+                                                <option value="Conversational" selected="@(proficiency == LanguageProficiency.Conversational ? "selected" : null)">Conversational</option>
+                                                <option value="Fluent" selected="@(proficiency == LanguageProficiency.Fluent ? "selected" : null)">Fluent</option>
+                                                <option value="Native" selected="@(proficiency == LanguageProficiency.Native ? "selected" : null)">Native</option>
+                                            </select>
+                                        </div>
+
+                                        <div class="col-md-3 text-end">
+                                            <button type="button" class="btn btn-outline-danger btn-sm remove-language" title="Remove this language">
+                                                <i class="fa-solid fa-trash me-1"></i> Remove
+                                            </button>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        }
+                    </div>
+
+                    <button type="button" id="addLanguage" class="btn btn-outline-secondary btn-sm mb-3">
+                        <i class="fa-solid fa-plus me-1"></i> @Localizer["ProfileEdit_AddLanguage"]
+                    </button>
                 </div>
             </div>
 
@@ -770,6 +823,97 @@
                 row.querySelector('input[type="date"]').focus();
             });
         })();
+
+        // Language Management
+        (function() {
+            const container = document.getElementById('languagesContainer');
+            const addButton = document.getElementById('addLanguage');
+            if (!container || !addButton) return;
+
+            const languageOptions = `@Html.Raw(string.Join("", Humans.Web.Helpers.LanguageCatalog.Languages.Select(l => $"<option value=\"{l.Key}\">{l.Value} ({l.Key})</option>")))`;
+
+            function getNextIndex() {
+                const rows = container.querySelectorAll('.language-row');
+                if (rows.length === 0) return 0;
+                const indices = Array.from(rows).map(r => parseInt(r.dataset.index) || 0);
+                return Math.max(...indices) + 1;
+            }
+
+            function createLanguageRow(index) {
+                const html = `
+                    <div class="language-row card mb-2" data-index="${index}">
+                        <div class="card-body py-2">
+                            <div class="row g-2 align-items-end">
+                                <input type="hidden" name="EditableLanguages[${index}].Id" value="" />
+
+                                <div class="col-md-5">
+                                    <label class="form-label small" for="EditableLanguages_${index}__LanguageCode">Language</label>
+                                    <select name="EditableLanguages[${index}].LanguageCode" id="EditableLanguages_${index}__LanguageCode" class="form-select form-select-sm language-code-select" required>
+                                        <option value="">— Select language —</option>
+                                        ${languageOptions}
+                                    </select>
+                                </div>
+
+                                <div class="col-md-4">
+                                    <label class="form-label small" for="EditableLanguages_${index}__Proficiency">Proficiency</label>
+                                    <select name="EditableLanguages[${index}].Proficiency" id="EditableLanguages_${index}__Proficiency" class="form-select form-select-sm" required>
+                                        <option value="Basic">Basic</option>
+                                        <option value="Conversational">Conversational</option>
+                                        <option value="Fluent">Fluent</option>
+                                        <option value="Native" selected>Native</option>
+                                    </select>
+                                </div>
+
+                                <div class="col-md-3 text-end">
+                                    <button type="button" class="btn btn-outline-danger btn-sm remove-language" title="Remove this language">
+                                        <i class="fa-solid fa-trash me-1"></i> Remove
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                `;
+                const template = document.createElement('template');
+                template.innerHTML = html.trim();
+                return template.content.firstChild;
+            }
+
+            function setupLanguageRow(row) {
+                const removeBtn = row.querySelector('.remove-language');
+                removeBtn.addEventListener('click', function() {
+                    row.remove();
+                    reindexLanguageRows();
+                });
+            }
+
+            function reindexLanguageRows() {
+                const rows = container.querySelectorAll('.language-row');
+                rows.forEach((row, idx) => {
+                    row.dataset.index = idx;
+                    row.querySelectorAll('[name]').forEach(input => {
+                        input.name = input.name.replace(/\[\d+\]/, `[${idx}]`);
+                    });
+                    row.querySelectorAll('[id]').forEach(el => {
+                        el.id = el.id.replace(/_\d+__/, `_${idx}__`);
+                    });
+                    row.querySelectorAll('label[for]').forEach(label => {
+                        label.setAttribute('for', label.getAttribute('for').replace(/_\d+__/, `_${idx}__`));
+                    });
+                });
+            }
+
+            // Setup existing rows
+            container.querySelectorAll('.language-row').forEach(setupLanguageRow);
+
+            // Add new row
+            addButton.addEventListener('click', function() {
+                const index = getNextIndex();
+                const row = createLanguageRow(index);
+                container.appendChild(row);
+                setupLanguageRow(row);
+                row.querySelector('.language-code-select').focus();
+            });
+        })();
     </script>
     <script>
         // Tier selection show/hide for application section and Asociado questions
@@ -841,8 +985,10 @@
             const opts = { childList: true };
             const cf = document.getElementById('contactFieldsContainer');
             const vh = document.getElementById('volunteerHistoryContainer');
+            const lc = document.getElementById('languagesContainer');
             if (cf) observer.observe(cf, opts);
             if (vh) observer.observe(vh, opts);
+            if (lc) observer.observe(lc, opts);
 
             // Burner name / legal name match warning
             const burnerNameInput = document.getElementById('BurnerName');

--- a/src/Humans.Web/Views/Shared/Components/ProfileCard/Default.cshtml
+++ b/src/Humans.Web/Views/Shared/Components/ProfileCard/Default.cshtml
@@ -148,6 +148,22 @@
             <p class="mb-0" style="white-space: pre-line">@Model.Bio</p>
         }
 
+        @* Languages *@
+        @if (Model.Languages.Count > 0)
+        {
+            <hr />
+            <h6 class="text-muted mb-2">@Localizer["Profile_Languages"]</h6>
+            <div class="d-flex flex-wrap gap-2">
+                @foreach (var lang in Model.Languages)
+                {
+                    <span class="badge @lang.ProficiencyBadgeClass">
+                        @lang.LanguageName
+                        <small class="ms-1 opacity-75">(@lang.Proficiency)</small>
+                    </span>
+                }
+            </div>
+        }
+
         @* Contribution Interests *@
         @if (!string.IsNullOrEmpty(Model.ContributionInterests))
         {


### PR DESCRIPTION
## Summary
- Add ProfileLanguage entity with ISO 639-1 codes and proficiency levels (Basic, Conversational, Fluent, Native)
- Languages section on profile edit with searchable dropdown and add/remove rows
- Languages display on profile card and admin detail view with color-coded proficiency badges
- EF Core migration for `profile_languages` table with cascade delete

Closes #394

## Test plan
- [ ] Profile edit: add languages with different proficiency levels, save
- [ ] Profile edit: save with no languages (optional field)
- [ ] Profile edit: remove a language, save
- [ ] Profile detail: languages display with proficiency badges
- [ ] Admin detail: languages visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)