### PR TITLE
Budget: show restricted groups with category-level visibility only

### DIFF
--- a/src/Humans.Application/Interfaces/IBudgetService.cs
+++ b/src/Humans.Application/Interfaces/IBudgetService.cs
@@ -52,6 +52,7 @@ public interface IBudgetService
 
     // Summary Computation
     BudgetSummaryResult ComputeBudgetSummary(IEnumerable<BudgetGroup> groups);
+    BudgetSummaryResult ComputeBudgetSummaryWithBuffers(IEnumerable<BudgetGroup> groups);
     IReadOnlyList<VatCashFlowEntry> ComputeVatCashFlowEntries(IEnumerable<BudgetGroup> groups);
     LocalDate ComputeVatSettlementDate(LocalDate expectedDate);
 }

--- a/src/Humans.Infrastructure/Services/BudgetService.cs
+++ b/src/Humans.Infrastructure/Services/BudgetService.cs
@@ -1037,6 +1037,60 @@ public class BudgetService : IBudgetService
         };
     }
 
+    public BudgetSummaryResult ComputeBudgetSummaryWithBuffers(IEnumerable<BudgetGroup> groups)
+    {
+        var groupList = groups.ToList();
+        var summary = ComputeBudgetSummary(groupList);
+
+        // Per-group buffer: allocated minus line-item total.
+        // Negative = expense buffer, positive = income buffer.
+        var groupBuffers = groupList
+            .Where(g => !g.IsTicketingGroup)
+            .Select(g => new
+            {
+                Name = $"{g.Name} Buffer",
+                Raw = g.Categories.Sum(c =>
+                    c.AllocatedAmount - c.LineItems.Where(li => !li.IsCashflowOnly).Sum(li => li.Amount))
+            })
+            .Where(b => b.Raw != 0)
+            .ToList();
+
+        var allExpenseEntries = summary.ExpenseSlices
+            .Select(s => new { s.Name, s.Amount })
+            .Concat(groupBuffers.Where(b => b.Raw < 0).Select(b => new { b.Name, Amount = Math.Abs(b.Raw) }))
+            .ToList();
+        var totalExpense = allExpenseEntries.Sum(s => s.Amount);
+
+        var allIncomeEntries = summary.IncomeSlices
+            .Select(s => new { s.Name, s.Amount })
+            .Concat(groupBuffers.Where(b => b.Raw > 0).Select(b => new { b.Name, Amount = b.Raw }))
+            .ToList();
+        var totalIncome = allIncomeEntries.Sum(s => s.Amount);
+
+        return new BudgetSummaryResult
+        {
+            TotalIncome = summary.TotalIncome,
+            TotalExpenses = summary.TotalExpenses,
+            NetBalance = summary.NetBalance,
+            IncomeSlices = allIncomeEntries
+                .Select(s => new BudgetSliceResult
+                {
+                    Name = s.Name,
+                    Amount = s.Amount,
+                    Percentage = totalIncome > 0 ? s.Amount / totalIncome * 100 : 0
+                })
+                .ToList(),
+            ExpenseSlices = allExpenseEntries
+                .Select(s => new BudgetSliceResult
+                {
+                    Name = s.Name,
+                    Amount = s.Amount,
+                    Percentage = totalExpense > 0 ? s.Amount / totalExpense * 100 : 0
+                })
+                .ToList()
+        };
+    }
+
     public IReadOnlyList<VatCashFlowEntry> ComputeVatCashFlowEntries(IEnumerable<BudgetGroup> groups)
     {
         return groups

--- a/src/Humans.Web/Controllers/BudgetController.cs
+++ b/src/Humans.Web/Controllers/BudgetController.cs
@@ -95,21 +95,22 @@ public class BudgetController : HumansControllerBase
                 .Where(li => !li.IsCashflowOnly)
                 .Sum(li => li.Amount);
 
-            // Compute per-group buffer: allocated money not yet detailed into line items
-            var bufferEntries = visibleGroups
+            // Compute per-group buffer: allocated money not yet detailed into line items.
+            // Negative = expense buffer, positive = income buffer.
+            var groupBuffers = visibleGroups
                 .Where(g => !g.IsTicketingGroup)
                 .Select(g => new
                 {
                     Name = $"{g.Name} Buffer",
-                    Amount = g.Categories.Sum(c =>
+                    Raw = g.Categories.Sum(c =>
                         c.AllocatedAmount - c.LineItems.Where(li => !li.IsCashflowOnly).Sum(li => li.Amount))
                 })
-                .Where(b => b.Amount > 0)
+                .Where(b => b.Raw != 0)
                 .ToList();
 
             var allExpenseEntries = summary.ExpenseSlices
                 .Select(s => new { s.Name, s.Amount })
-                .Concat(bufferEntries)
+                .Concat(groupBuffers.Where(b => b.Raw < 0).Select(b => new { b.Name, Amount = Math.Abs(b.Raw) }))
                 .ToList();
             var totalExpenseForSlices = allExpenseEntries.Sum(s => s.Amount);
             var expenseSlices = allExpenseEntries
@@ -118,6 +119,20 @@ public class BudgetController : HumansControllerBase
                     Name = s.Name,
                     Amount = s.Amount,
                     Percentage = totalExpenseForSlices > 0 ? s.Amount / totalExpenseForSlices * 100 : 0
+                })
+                .ToList();
+
+            var allIncomeEntries = summary.IncomeSlices
+                .Select(s => new { s.Name, s.Amount })
+                .Concat(groupBuffers.Where(b => b.Raw > 0).Select(b => new { b.Name, Amount = b.Raw }))
+                .ToList();
+            var totalIncomeForSlices = allIncomeEntries.Sum(s => s.Amount);
+            var incomeSlices = allIncomeEntries
+                .Select(s => new BudgetSlice
+                {
+                    Name = s.Name,
+                    Amount = s.Amount,
+                    Percentage = totalIncomeForSlices > 0 ? s.Amount / totalIncomeForSlices * 100 : 0
                 })
                 .ToList();
 
@@ -130,7 +145,7 @@ public class BudgetController : HumansControllerBase
                 TotalExpenses = summary.TotalExpenses,
                 NetBalance = summary.NetBalance,
                 TotalLineItems = totalLineItems,
-                IncomeSlices = summary.IncomeSlices.Select(s => new BudgetSlice { Name = s.Name, Amount = s.Amount, Percentage = s.Percentage }).ToList(),
+                IncomeSlices = incomeSlices,
                 ExpenseSlices = expenseSlices,
                 IsCoordinator = coordinatorTeamIds.Count > 0 || (await _authService.AuthorizeAsync(User, PolicyNames.FinanceAdminOrAdmin)).Succeeded
             };

--- a/src/Humans.Web/Controllers/BudgetController.cs
+++ b/src/Humans.Web/Controllers/BudgetController.cs
@@ -86,8 +86,7 @@ public class BudgetController : HumansControllerBase
                 return View("NoActiveBudget");
             }
 
-            // Only show non-restricted groups in public summary
-            var visibleGroups = activeYear.Groups.Where(g => !g.IsRestricted).ToList();
+            var visibleGroups = activeYear.Groups.ToList();
             var summary = _budgetService.ComputeBudgetSummary(visibleGroups);
 
             var totalLineItems = visibleGroups

--- a/src/Humans.Web/Controllers/BudgetController.cs
+++ b/src/Humans.Web/Controllers/BudgetController.cs
@@ -95,6 +95,32 @@ public class BudgetController : HumansControllerBase
                 .Where(li => !li.IsCashflowOnly)
                 .Sum(li => li.Amount);
 
+            // Compute per-group buffer: allocated money not yet detailed into line items
+            var bufferEntries = visibleGroups
+                .Where(g => !g.IsTicketingGroup)
+                .Select(g => new
+                {
+                    Name = $"{g.Name} Buffer",
+                    Amount = g.Categories.Sum(c =>
+                        c.AllocatedAmount - c.LineItems.Where(li => !li.IsCashflowOnly).Sum(li => li.Amount))
+                })
+                .Where(b => b.Amount > 0)
+                .ToList();
+
+            var allExpenseEntries = summary.ExpenseSlices
+                .Select(s => new { s.Name, s.Amount })
+                .Concat(bufferEntries)
+                .ToList();
+            var totalExpenseForSlices = allExpenseEntries.Sum(s => s.Amount);
+            var expenseSlices = allExpenseEntries
+                .Select(s => new BudgetSlice
+                {
+                    Name = s.Name,
+                    Amount = s.Amount,
+                    Percentage = totalExpenseForSlices > 0 ? s.Amount / totalExpenseForSlices * 100 : 0
+                })
+                .ToList();
+
             var coordinatorTeamIds = await _budgetService.GetEffectiveCoordinatorTeamIdsAsync(user.Id);
 
             var model = new BudgetSummaryViewModel
@@ -105,7 +131,7 @@ public class BudgetController : HumansControllerBase
                 NetBalance = summary.NetBalance,
                 TotalLineItems = totalLineItems,
                 IncomeSlices = summary.IncomeSlices.Select(s => new BudgetSlice { Name = s.Name, Amount = s.Amount, Percentage = s.Percentage }).ToList(),
-                ExpenseSlices = summary.ExpenseSlices.Select(s => new BudgetSlice { Name = s.Name, Amount = s.Amount, Percentage = s.Percentage }).ToList(),
+                ExpenseSlices = expenseSlices,
                 IsCoordinator = coordinatorTeamIds.Count > 0 || (await _authService.AuthorizeAsync(User, PolicyNames.FinanceAdminOrAdmin)).Succeeded
             };
             return View(model);

--- a/src/Humans.Web/Controllers/BudgetController.cs
+++ b/src/Humans.Web/Controllers/BudgetController.cs
@@ -87,54 +87,13 @@ public class BudgetController : HumansControllerBase
             }
 
             var visibleGroups = activeYear.Groups.ToList();
-            var summary = _budgetService.ComputeBudgetSummary(visibleGroups);
+            var summary = _budgetService.ComputeBudgetSummaryWithBuffers(visibleGroups);
 
             var totalLineItems = visibleGroups
                 .SelectMany(g => g.Categories)
                 .SelectMany(c => c.LineItems)
                 .Where(li => !li.IsCashflowOnly)
                 .Sum(li => li.Amount);
-
-            // Compute per-group buffer: allocated money not yet detailed into line items.
-            // Negative = expense buffer, positive = income buffer.
-            var groupBuffers = visibleGroups
-                .Where(g => !g.IsTicketingGroup)
-                .Select(g => new
-                {
-                    Name = $"{g.Name} Buffer",
-                    Raw = g.Categories.Sum(c =>
-                        c.AllocatedAmount - c.LineItems.Where(li => !li.IsCashflowOnly).Sum(li => li.Amount))
-                })
-                .Where(b => b.Raw != 0)
-                .ToList();
-
-            var allExpenseEntries = summary.ExpenseSlices
-                .Select(s => new { s.Name, s.Amount })
-                .Concat(groupBuffers.Where(b => b.Raw < 0).Select(b => new { b.Name, Amount = Math.Abs(b.Raw) }))
-                .ToList();
-            var totalExpenseForSlices = allExpenseEntries.Sum(s => s.Amount);
-            var expenseSlices = allExpenseEntries
-                .Select(s => new BudgetSlice
-                {
-                    Name = s.Name,
-                    Amount = s.Amount,
-                    Percentage = totalExpenseForSlices > 0 ? s.Amount / totalExpenseForSlices * 100 : 0
-                })
-                .ToList();
-
-            var allIncomeEntries = summary.IncomeSlices
-                .Select(s => new { s.Name, s.Amount })
-                .Concat(groupBuffers.Where(b => b.Raw > 0).Select(b => new { b.Name, Amount = b.Raw }))
-                .ToList();
-            var totalIncomeForSlices = allIncomeEntries.Sum(s => s.Amount);
-            var incomeSlices = allIncomeEntries
-                .Select(s => new BudgetSlice
-                {
-                    Name = s.Name,
-                    Amount = s.Amount,
-                    Percentage = totalIncomeForSlices > 0 ? s.Amount / totalIncomeForSlices * 100 : 0
-                })
-                .ToList();
 
             var coordinatorTeamIds = await _budgetService.GetEffectiveCoordinatorTeamIdsAsync(user.Id);
 
@@ -145,8 +104,8 @@ public class BudgetController : HumansControllerBase
                 TotalExpenses = summary.TotalExpenses,
                 NetBalance = summary.NetBalance,
                 TotalLineItems = totalLineItems,
-                IncomeSlices = incomeSlices,
-                ExpenseSlices = expenseSlices,
+                IncomeSlices = summary.IncomeSlices.Select(s => new BudgetSlice { Name = s.Name, Amount = s.Amount, Percentage = s.Percentage }).ToList(),
+                ExpenseSlices = summary.ExpenseSlices.Select(s => new BudgetSlice { Name = s.Name, Amount = s.Amount, Percentage = s.Percentage }).ToList(),
                 IsCoordinator = coordinatorTeamIds.Count > 0 || (await _authService.AuthorizeAsync(User, PolicyNames.FinanceAdminOrAdmin)).Succeeded
             };
             return View(model);

--- a/src/Humans.Web/Controllers/FinanceController.cs
+++ b/src/Humans.Web/Controllers/FinanceController.cs
@@ -561,8 +561,8 @@ public class FinanceController : HumansControllerBase
     /// </summary>
     private FinanceOverviewViewModel BuildFinanceOverview(BudgetYear year, IReadOnlyList<BudgetYear> allYears)
     {
-        // All groups (including restricted) for FinanceAdmin summary
-        var summary = _budgetService.ComputeBudgetSummary(year.Groups);
+        // All groups (including restricted) for FinanceAdmin summary, with buffer slices
+        var summary = _budgetService.ComputeBudgetSummaryWithBuffers(year.Groups);
 
         return new FinanceOverviewViewModel
         {

--- a/src/Humans.Web/Views/Budget/Index.cshtml
+++ b/src/Humans.Web/Views/Budget/Index.cshtml
@@ -2,7 +2,7 @@
 @{
     ViewData["Title"] = $"Budget - {Model.Year.Name}";
     var groups = Model.Year.Groups
-        .Where(g => (!g.IsRestricted && !g.IsTicketingGroup) || Model.IsFinanceAdmin)
+        .Where(g => !g.IsTicketingGroup || Model.IsFinanceAdmin)
         .OrderBy(g => g.SortOrder)
         .ToList();
     var totalAllocated = groups.SelectMany(g => g.Categories).Sum(c => c.AllocatedAmount);
@@ -77,6 +77,10 @@
                 {
                     <span class="badge bg-info ms-1">Departments</span>
                 }
+                @if (group.IsRestricted)
+                {
+                    <span class="badge bg-secondary ms-1"><i class="fa-solid fa-lock me-1"></i>Restricted</span>
+                }
             </div>
             <span class="text-muted">&euro;@groupAllocated.ToString("N2")</span>
         </div>
@@ -102,6 +106,7 @@
                                 var catUnallocated = cat.AllocatedAmount - catLineItemTotal;
                                 var isOwnDept = cat.TeamId.HasValue && Model.EditableTeamIds.Contains(cat.TeamId.Value);
                                 var isEditable = Model.IsFinanceAdmin || isOwnDept;
+                                var isGroupRestricted = group.IsRestricted && !Model.IsFinanceAdmin;
                                 <tr>
                                     <td>
                                         @cat.Name
@@ -121,10 +126,17 @@
                                         </span>
                                     </td>
                                     <td class="text-end">
-                                        <a asp-action="CategoryDetail" asp-route-id="@cat.Id"
-                                           class="btn btn-outline-@(isEditable ? "primary" : "secondary") btn-sm">
-                                            @(isEditable ? "Manage" : "View") <i class="fa-solid fa-arrow-right ms-1"></i>
-                                        </a>
+                                        @if (isGroupRestricted)
+                                        {
+                                            <span class="badge bg-secondary"><i class="fa-solid fa-lock me-1"></i>Restricted</span>
+                                        }
+                                        else
+                                        {
+                                            <a asp-action="CategoryDetail" asp-route-id="@cat.Id"
+                                               class="btn btn-outline-@(isEditable ? "primary" : "secondary") btn-sm">
+                                                @(isEditable ? "Manage" : "View") <i class="fa-solid fa-arrow-right ms-1"></i>
+                                            </a>
+                                        }
                                     </td>
                                 </tr>
                             }


### PR DESCRIPTION
## Summary
- Restricted budget groups now appear on the coordinator Budget page and public Summary instead of being completely hidden
- Categories show names, allocated amounts, and totals — but line-item detail is locked behind a "Restricted" badge
- CategoryDetail still returns Forbid() for non-finance-admins, so direct URL access is blocked
- Finance admins see everything as before

## Test plan
- [ ] As a coordinator, verify the Admin group now appears on /Budget with a "Restricted" badge on the group header
- [ ] Verify category rows in restricted groups show a lock badge instead of View/Manage buttons
- [ ] Verify /Budget/Summary totals now include restricted group amounts
- [ ] Verify clicking a restricted category URL directly still returns 403
- [ ] As a Finance Admin, verify full access to restricted group categories is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)