### PR TITLE
Fix city planning authorization: claims-first + consolidate queries

### DIFF
--- a/docs/features/38-city-planning.md
+++ b/docs/features/38-city-planning.md
@@ -115,7 +115,7 @@ Own camp polygon uses 2× outline width and higher fill opacity. Active edit pol
 | Export GeoJSON | Map admin |
 | Admin panel (placement toggle, dates, zone uploads) | Map admin |
 
-Map admin is determined by `ICityPlanningService.IsUserMapAdminAsync` (role-based, implementation in Infrastructure).
+Map admin is determined at the controller level via claims-first pattern: `RoleChecks.IsCampAdmin(User)` for global roles, then `ICityPlanningService.IsCityPlanningTeamMemberAsync` for team-specific access.
 
 ## URL Structure
 

--- a/src/Humans.Application/Interfaces/ICityPlanningService.cs
+++ b/src/Humans.Application/Interfaces/ICityPlanningService.cs
@@ -24,9 +24,8 @@ public interface ICityPlanningService
         Guid campSeasonId, Guid historyId, Guid restoredByUserId,
         CancellationToken cancellationToken = default);
 
-    // Authorization
+    // Authorization (global role checks belong at the controller level via claims)
     Task<bool> CanUserEditAsync(Guid userId, Guid campSeasonId, CancellationToken cancellationToken = default);
-    Task<bool> IsUserMapAdminAsync(Guid userId, CancellationToken cancellationToken = default);
     Task<bool> IsCityPlanningTeamMemberAsync(Guid userId, CancellationToken cancellationToken = default);
 
     // Settings (creates row on demand for PublicYear)

--- a/src/Humans.Infrastructure/Services/CityPlanningService.cs
+++ b/src/Humans.Infrastructure/Services/CityPlanningService.cs
@@ -160,25 +160,6 @@ public class CityPlanningService : ICityPlanningService
         return await SaveCampPolygonAsync(campSeasonId, entry.GeoJson, entry.AreaSqm, restoredByUserId, note, cancellationToken);
     }
 
-    public async Task<bool> IsUserMapAdminAsync(Guid userId, CancellationToken cancellationToken = default)
-    {
-        var now = _clock.GetCurrentInstant();
-        if (await _dbContext.RoleAssignments.AnyAsync(ra =>
-                ra.UserId == userId &&
-                (ra.RoleName == RoleNames.Admin || ra.RoleName == RoleNames.CampAdmin) &&
-                ra.ValidFrom <= now &&
-                (ra.ValidTo == null || ra.ValidTo > now),
-                cancellationToken))
-            return true;
-
-        var team = await _dbContext.Teams
-            .FirstOrDefaultAsync(t => t.Slug == _options.Value.CityPlanningTeamSlug, cancellationToken);
-        if (team == null) return false;
-
-        return await _dbContext.TeamMembers
-            .AnyAsync(tm => tm.TeamId == team.Id && tm.UserId == userId && tm.LeftAt == null, cancellationToken);
-    }
-
     public async Task<bool> IsCityPlanningTeamMemberAsync(Guid userId, CancellationToken cancellationToken = default)
     {
         var team = await _dbContext.Teams
@@ -191,7 +172,9 @@ public class CityPlanningService : ICityPlanningService
 
     public async Task<bool> CanUserEditAsync(Guid userId, Guid campSeasonId, CancellationToken cancellationToken = default)
     {
-        if (await IsUserMapAdminAsync(userId, cancellationToken)) return true;
+        // Global role checks (Admin, CampAdmin) are done at the controller level via claims.
+        // This method only checks team-specific access: city planning team membership + camp lead.
+        if (await IsCityPlanningTeamMemberAsync(userId, cancellationToken)) return true;
 
         var settings = await GetSettingsAsync(cancellationToken);
         if (!settings.IsPlacementOpen) return false;

--- a/src/Humans.Web/Controllers/CityPlanningApiController.cs
+++ b/src/Humans.Web/Controllers/CityPlanningApiController.cs
@@ -80,7 +80,8 @@ public class CityPlanningApiController : ControllerBase
         CancellationToken cancellationToken)
     {
         var userId = CurrentUserId();
-        if (!await _cityPlanningService.CanUserEditAsync(userId, campSeasonId, cancellationToken))
+        if (!RoleChecks.IsCampAdmin(User) &&
+            !await _cityPlanningService.CanUserEditAsync(userId, campSeasonId, cancellationToken))
             return Forbid();
 
         if (string.IsNullOrWhiteSpace(request.GeoJson) || !IsValidJson(request.GeoJson))

--- a/tests/Humans.Application.Tests/Services/CityPlanningServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/CityPlanningServiceTests.cs
@@ -166,19 +166,22 @@ public class CityPlanningServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task IsUserMapAdminAsync_CampAdminRole_ReturnsTrue()
+    public async Task IsCityPlanningTeamMemberAsync_TeamMember_ReturnsTrue()
     {
-        var adminId = await SeedCampAdminUserAsync();
-        var result = await _sut.IsUserMapAdminAsync(adminId);
+        var plannerId = await SeedCityPlanningTeamMemberAsync();
+        var result = await _sut.IsCityPlanningTeamMemberAsync(plannerId);
         result.Should().BeTrue();
     }
 
     [Fact]
-    public async Task IsUserMapAdminAsync_CityPlanningTeamMember_ReturnsTrue()
+    public async Task IsCityPlanningTeamMemberAsync_NonMember_ReturnsFalse()
     {
-        var plannerId = await SeedCityPlanningTeamMemberAsync();
-        var result = await _sut.IsUserMapAdminAsync(plannerId);
-        result.Should().BeTrue();
+        var otherUser = new User { Id = Guid.NewGuid(), UserName = "other@test.com", Email = "other@test.com" };
+        _dbContext.Users.Add(otherUser);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _sut.IsCityPlanningTeamMemberAsync(otherUser.Id);
+        result.Should().BeFalse();
     }
 
     [Fact]
@@ -189,17 +192,6 @@ public class CityPlanningServiceTests : IDisposable
         await SeedMapSettingsAsync(placementOpen: false);
 
         var result = await _sut.CanUserEditAsync(plannerId, season.Id);
-        result.Should().BeTrue();
-    }
-
-    [Fact]
-    public async Task CanUserEditAsync_CampAdmin_AlwaysTrue_EvenWhenPlacementClosed()
-    {
-        var adminId = await SeedCampAdminUserAsync();
-        var (_, season, _) = await SeedCampWithLeadAsync();
-        await SeedMapSettingsAsync(placementOpen: false);
-
-        var result = await _sut.CanUserEditAsync(adminId, season.Id);
         result.Should().BeTrue();
     }
 


### PR DESCRIPTION
## Summary

- **Claims-first fix**: `SaveCampPolygon` API endpoint was delegating authorization entirely to `CanUserEditAsync` in the service, which queried `RoleAssignments` DB for global roles (Admin, CampAdmin) — violating the claims-first rule. Now checks `RoleChecks.IsCampAdmin(User)` at the controller level first.
- **Remove `IsUserMapAdminAsync`**: This method queried the DB for global roles that should only be checked via claims. Removed from service and interface.
- **Consolidate team queries**: `CanUserEditAsync` now calls `IsCityPlanningTeamMemberAsync` directly instead of going through `IsUserMapAdminAsync` (which duplicated the same team slug lookup). Eliminates double DB hit per request.

## Test plan

- [x] All 26 city planning tests pass
- [x] Build clean (0 warnings, 0 errors)
- [x] `dotnet format --verify-no-changes` passes
- [ ] Verify map admin can still edit polygons on QA
- [ ] Verify camp leads can still place polygons when placement is open
- [ ] Verify non-admin, non-lead users cannot edit polygons

🤖 Generated with [Claude Code](https://claude.com/claude-code)