### PR TITLE
Sprint batch 2: fix finance calculations

### DIFF
--- a/src/Humans.Application/DTOs/TicketDashboardDtos.cs
+++ b/src/Humans.Application/DTOs/TicketDashboardDtos.cs
@@ -12,6 +12,7 @@ public class TicketDashboardStats
     public decimal TotalApplicationFees { get; init; }
     public decimal NetRevenue { get; init; }
     public decimal AveragePrice { get; init; }
+    public decimal GrossAveragePrice { get; init; }
     public int UnmatchedOrderCount { get; init; }
 
     public List<FeeBreakdownByMethod> FeesByPaymentMethod { get; init; } = [];
@@ -120,6 +121,14 @@ public class CodeDetailDto
     public string? RedeemedByName { get; init; }
     public string? RedeemedByEmail { get; init; }
     public string? RedeemedOrderVendorId { get; init; }
+}
+
+/// <summary>Break-even calculation result.</summary>
+public class BreakEvenResult
+{
+    public int Target { get; init; }
+    public string? Detail { get; init; }
+    public string Currency { get; init; } = "EUR";
 }
 
 /// <summary>A single row in the orders list page.</summary>

--- a/src/Humans.Application/Interfaces/ITicketQueryService.cs
+++ b/src/Humans.Application/Interfaces/ITicketQueryService.cs
@@ -39,6 +39,16 @@ public interface ITicketQueryService
     Task<TicketDashboardStats> GetDashboardStatsAsync();
 
     /// <summary>
+    /// Calculate break-even target using gross average ticket price and planned expenses.
+    /// </summary>
+    /// <param name="ticketsSold">Current number of tickets sold.</param>
+    /// <param name="grossRevenue">Gross ticket revenue (TotalAmount sum).</param>
+    /// <param name="currency">Currency code for display.</param>
+    /// <param name="canAccessFinance">Whether the caller can see the finance detail breakdown.</param>
+    /// <param name="fallbackTarget">Fallback break-even target from settings when calculation is not possible.</param>
+    Task<BreakEvenResult> CalculateBreakEvenAsync(int ticketsSold, decimal grossRevenue, string currency, bool canAccessFinance, int fallbackTarget);
+
+    /// <summary>
     /// Compute weekly and quarterly sales aggregates for reporting.
     /// </summary>
     Task<TicketSalesAggregates> GetSalesAggregatesAsync();

--- a/src/Humans.Application/Interfaces/ITicketQueryService.cs
+++ b/src/Humans.Application/Interfaces/ITicketQueryService.cs
@@ -39,6 +39,12 @@ public interface ITicketQueryService
     Task<TicketDashboardStats> GetDashboardStatsAsync();
 
     /// <summary>
+    /// Get total gross ticket revenue (sum of TotalAmount for paid orders).
+    /// Used by cash flow runway calculations.
+    /// </summary>
+    Task<decimal> GetGrossTicketRevenueAsync();
+
+    /// <summary>
     /// Calculate break-even target using gross average ticket price and planned expenses.
     /// </summary>
     /// <param name="ticketsSold">Current number of tickets sold.</param>

--- a/src/Humans.Infrastructure/Services/TicketQueryService.cs
+++ b/src/Humans.Infrastructure/Services/TicketQueryService.cs
@@ -269,6 +269,13 @@ public class TicketQueryService : ITicketQueryService
         };
     }
 
+    public async Task<decimal> GetGrossTicketRevenueAsync()
+    {
+        return await _dbContext.TicketOrders
+            .Where(o => o.PaymentStatus == TicketPaymentStatus.Paid)
+            .SumAsync(o => o.TotalAmount);
+    }
+
     public async Task<BreakEvenResult> CalculateBreakEvenAsync(int ticketsSold, decimal grossRevenue, string currency, bool canAccessFinance, int fallbackTarget)
     {
         if (ticketsSold <= 0 || grossRevenue <= 0)

--- a/src/Humans.Infrastructure/Services/TicketQueryService.cs
+++ b/src/Humans.Infrastructure/Services/TicketQueryService.cs
@@ -289,13 +289,10 @@ public class TicketQueryService : ITicketQueryService
             return new BreakEvenResult { Target = fallbackTarget, Currency = currency };
         }
 
-        var visibleGroups = canAccessFinance
-            ? activeBudgetYear.Groups
-            : activeBudgetYear.Groups.Where(g => !g.IsRestricted).ToList();
-
-        // Use raw expense line items (not ComputeBudgetSummary) to avoid VAT adjustments.
-        // Revenue is gross, so expenses must also be gross for an apples-to-apples comparison.
-        var plannedExpenses = Math.Abs(visibleGroups
+        // Use ALL groups (including restricted) — break-even must reflect total planned expenses
+        // regardless of the caller's finance visibility. The canAccessFinance flag only controls
+        // whether the detail breakdown string is shown.
+        var plannedExpenses = Math.Abs(activeBudgetYear.Groups
             .SelectMany(g => g.Categories)
             .SelectMany(c => c.LineItems)
             .Where(li => !li.IsCashflowOnly && li.Amount < 0)

--- a/src/Humans.Infrastructure/Services/TicketQueryService.cs
+++ b/src/Humans.Infrastructure/Services/TicketQueryService.cs
@@ -21,11 +21,13 @@ public class TicketQueryService : ITicketQueryService
 
     private readonly HumansDbContext _dbContext;
     private readonly IMemoryCache _cache;
+    private readonly IBudgetService _budgetService;
 
-    public TicketQueryService(HumansDbContext dbContext, IMemoryCache cache)
+    public TicketQueryService(HumansDbContext dbContext, IMemoryCache cache, IBudgetService budgetService)
     {
         _dbContext = dbContext;
         _cache = cache;
+        _budgetService = budgetService;
     }
 
     public async Task<int> GetUserTicketCountAsync(Guid userId)
@@ -145,6 +147,7 @@ public class TicketQueryService : ITicketQueryService
         var totalAppFees = await paidOrders.SumAsync(o => o.ApplicationFee ?? 0m);
         var netRevenue = revenue - totalStripeFees - totalAppFees;
         var avgPrice = ticketsSold > 0 ? netRevenue / ticketsSold : 0;
+        var grossAvgPrice = ticketsSold > 0 ? revenue / ticketsSold : 0;
         var unmatchedCount = await orders.CountAsync(o => o.MatchedUserId == null);
 
         // Fee breakdown by payment method (load in memory — small dataset)
@@ -252,6 +255,7 @@ public class TicketQueryService : ITicketQueryService
             TotalApplicationFees = totalAppFees,
             NetRevenue = netRevenue,
             AveragePrice = avgPrice,
+            GrossAveragePrice = grossAvgPrice,
             UnmatchedOrderCount = unmatchedCount,
             FeesByPaymentMethod = feesByMethod,
             DailySalesPoints = dailySalesPoints,
@@ -263,6 +267,66 @@ public class TicketQueryService : ITicketQueryService
             VolunteersWithTickets = volunteersWithTickets,
             VolunteerCoveragePercent = volunteerCoveragePct,
         };
+    }
+
+    public async Task<BreakEvenResult> CalculateBreakEvenAsync(int ticketsSold, decimal grossRevenue, string currency, bool canAccessFinance, int fallbackTarget)
+    {
+        if (ticketsSold <= 0 || grossRevenue <= 0)
+        {
+            return new BreakEvenResult { Target = fallbackTarget, Currency = currency };
+        }
+
+        var activeBudgetYear = await _budgetService.GetActiveYearAsync();
+        if (activeBudgetYear is null)
+        {
+            return new BreakEvenResult { Target = fallbackTarget, Currency = currency };
+        }
+
+        var visibleGroups = canAccessFinance
+            ? activeBudgetYear.Groups
+            : activeBudgetYear.Groups.Where(g => !g.IsRestricted).ToList();
+
+        // Use raw expense line items (not ComputeBudgetSummary) to avoid VAT adjustments.
+        // Revenue is gross, so expenses must also be gross for an apples-to-apples comparison.
+        var plannedExpenses = Math.Abs(visibleGroups
+            .SelectMany(g => g.Categories)
+            .SelectMany(c => c.LineItems)
+            .Where(li => !li.IsCashflowOnly && li.Amount < 0)
+            .Sum(li => li.Amount));
+        if (plannedExpenses <= 0)
+        {
+            return new BreakEvenResult { Target = fallbackTarget, Currency = currency };
+        }
+
+        // Break-even target from current realized gross average revenue per ticket:
+        // A = tickets sold so far, B = gross revenue so far, C = gross planned expenses
+        // D = remaining expenses = C - B
+        // E = gross average ticket price = B / A
+        // F = remaining tickets = D / E
+        // G = break-even target = A + F
+        // Finance hover shows D / E = F tickets still to sell.
+        var grossAverageTicketPrice = grossRevenue / ticketsSold;
+
+        var remainingExpenses = Math.Max(0m, plannedExpenses - grossRevenue);
+        long remainingTicketsToSell = 0;
+        if (remainingExpenses > 0)
+        {
+            var remainingTicketCount = Math.Ceiling(remainingExpenses / grossAverageTicketPrice);
+            remainingTicketsToSell = remainingTicketCount > int.MaxValue
+                ? int.MaxValue
+                : decimal.ToInt32(remainingTicketCount);
+        }
+
+        var breakEvenTarget = (long)ticketsSold + remainingTicketsToSell;
+        var target = breakEvenTarget > int.MaxValue
+            ? int.MaxValue
+            : (int)breakEvenTarget;
+
+        var detail = canAccessFinance
+            ? $"{currency} {remainingExpenses:N2} remaining expenses / {currency} {grossAverageTicketPrice:N2} gross avg. per ticket = {remainingTicketsToSell:N0} tickets still to sell"
+            : null;
+
+        return new BreakEvenResult { Target = target, Detail = detail, Currency = currency };
     }
 
     public async Task<CodeTrackingData> GetCodeTrackingDataAsync(string? search)

--- a/src/Humans.Web/Controllers/FinanceController.cs
+++ b/src/Humans.Web/Controllers/FinanceController.cs
@@ -18,12 +18,14 @@ public class FinanceController : HumansControllerBase
 {
     private readonly IBudgetService _budgetService;
     private readonly ITicketingBudgetService _ticketingBudgetService;
+    private readonly ITicketQueryService _ticketQueryService;
     private readonly HumansDbContext _dbContext;
     private readonly ILogger<FinanceController> _logger;
 
     public FinanceController(
         IBudgetService budgetService,
         ITicketingBudgetService ticketingBudgetService,
+        ITicketQueryService ticketQueryService,
         HumansDbContext dbContext,
         UserManager<User> userManager,
         ILogger<FinanceController> logger)
@@ -31,6 +33,7 @@ public class FinanceController : HumansControllerBase
     {
         _budgetService = budgetService;
         _ticketingBudgetService = ticketingBudgetService;
+        _ticketQueryService = ticketQueryService;
         _dbContext = dbContext;
         _logger = logger;
     }
@@ -139,7 +142,8 @@ public class FinanceController : HumansControllerBase
                 return RedirectToAction(nameof(Index));
             }
 
-            var model = BuildCashFlowModel(activeYear, period);
+            var grossTicketRevenue = await _ticketQueryService.GetGrossTicketRevenueAsync();
+            var model = BuildCashFlowModel(activeYear, period, grossTicketRevenue);
             return View(model);
         }
         catch (Exception ex)
@@ -582,7 +586,7 @@ public class FinanceController : HumansControllerBase
     /// Generates synthetic VAT settlement entries at their settlement dates.
     /// Restricted groups are included (FinanceAdmin-only page).
     /// </summary>
-    private CashFlowViewModel BuildCashFlowModel(BudgetYear year, string period)
+    private CashFlowViewModel BuildCashFlowModel(BudgetYear year, string period, decimal grossTicketRevenue)
     {
         // Normalize period parameter
         if (!string.Equals(period, "weekly", StringComparison.OrdinalIgnoreCase) &&
@@ -615,12 +619,24 @@ public class FinanceController : HumansControllerBase
             var grouped = isWeekly ? GroupByWeek(scheduled) : GroupByMonth(scheduled);
 
             decimal runningNet = 0;
+            // Expense-only runway: start from gross ticket revenue, subtract only expenses.
+            // Income line items do NOT extend the runway — they're budgeted, not realized.
+            decimal runningExpenseBalance = grossTicketRevenue;
+            var fundsExhausted = false;
             foreach (var pg in grouped.OrderBy(g => g.PeriodStart))
             {
                 var periodIncome = pg.Items.Where(x => x.Amount > 0).Sum(x => x.Amount);
                 var periodExpense = pg.Items.Where(x => x.Amount < 0).Sum(x => x.Amount);
                 var periodNet = periodIncome + periodExpense;
                 runningNet += periodNet;
+
+                // Subtract expenses (periodExpense is negative, so add it to subtract)
+                runningExpenseBalance += periodExpense;
+                var isExhausted = !fundsExhausted && runningExpenseBalance <= 0;
+                if (isExhausted)
+                {
+                    fundsExhausted = true;
+                }
 
                 var categories = BuildCategoryRows(pg.Items);
 
@@ -633,6 +649,7 @@ public class FinanceController : HumansControllerBase
                     ExpenseTotal = periodExpense,
                     Net = periodNet,
                     RunningNet = runningNet,
+                    FundsExhausted = isExhausted,
                     Categories = categories
                 });
             }

--- a/src/Humans.Web/Controllers/TicketController.cs
+++ b/src/Humans.Web/Controllers/TicketController.cs
@@ -18,7 +18,6 @@ namespace Humans.Web.Controllers;
 [Route("Tickets")]
 public class TicketController : HumansControllerBase
 {
-    private readonly IBudgetService _budgetService;
     private readonly ITicketVendorService _vendorService;
     private readonly TicketVendorSettings _settings;
     private readonly ITicketQueryService _ticketQueryService;
@@ -26,7 +25,6 @@ public class TicketController : HumansControllerBase
     private readonly ILogger<TicketController> _logger;
 
     public TicketController(
-        IBudgetService budgetService,
         ITicketVendorService vendorService,
         IOptions<TicketVendorSettings> settings,
         ITicketQueryService ticketQueryService,
@@ -35,7 +33,6 @@ public class TicketController : HumansControllerBase
         ILogger<TicketController> logger)
         : base(userManager)
     {
-        _budgetService = budgetService;
         _vendorService = vendorService;
         _settings = settings.Value;
         _ticketQueryService = ticketQueryService;
@@ -54,7 +51,8 @@ public class TicketController : HumansControllerBase
         var stats = await _ticketQueryService.GetDashboardStatsAsync();
         var currency = stats.RecentOrders.FirstOrDefault()?.Currency ?? "EUR";
         var canAccessFinance = RoleChecks.CanAccessFinance(User);
-        var breakEven = await CalculateBreakEvenAsync(stats.TicketsSold, stats.Revenue, currency, canAccessFinance);
+        var breakEven = await _ticketQueryService.CalculateBreakEvenAsync(
+            stats.TicketsSold, stats.Revenue, currency, canAccessFinance, _settings.BreakEvenTarget);
 
         int totalCapacity = 0;
         try
@@ -73,9 +71,9 @@ public class TicketController : HumansControllerBase
             TotalCapacity = totalCapacity,
             BreakEvenDetail = breakEven.Detail,
             BreakEvenTarget = breakEven.Target,
-            Currency = breakEven.Currency,
+            Currency = currency,
             Revenue = stats.Revenue,
-            AveragePrice = stats.AveragePrice,
+            AveragePrice = stats.GrossAveragePrice,
             TicketsRemaining = totalCapacity - stats.TicketsSold,
             TotalStripeFees = stats.TotalStripeFees,
             TotalApplicationFees = stats.TotalApplicationFees,
@@ -117,68 +115,6 @@ public class TicketController : HumansControllerBase
 
         return View(model);
     }
-
-    private async Task<BreakEvenCalculation> CalculateBreakEvenAsync(int ticketsSold, decimal revenue, string currency, bool canAccessFinance)
-    {
-        if (ticketsSold <= 0 || revenue <= 0)
-        {
-            return new BreakEvenCalculation(_settings.BreakEvenTarget, null, currency);
-        }
-
-        var activeBudgetYear = await _budgetService.GetActiveYearAsync();
-        if (activeBudgetYear is null)
-        {
-            return new BreakEvenCalculation(_settings.BreakEvenTarget, null, currency);
-        }
-
-        var visibleGroups = canAccessFinance
-            ? activeBudgetYear.Groups
-            : activeBudgetYear.Groups.Where(g => !g.IsRestricted).ToList();
-
-        // Use raw expense line items (not ComputeBudgetSummary) to avoid VAT adjustments.
-        // Revenue is gross, so expenses must also be gross for an apples-to-apples comparison.
-        var plannedExpenses = Math.Abs(visibleGroups
-            .SelectMany(g => g.Categories)
-            .SelectMany(c => c.LineItems)
-            .Where(li => !li.IsCashflowOnly && li.Amount < 0)
-            .Sum(li => li.Amount));
-        if (plannedExpenses <= 0)
-        {
-            return new BreakEvenCalculation(_settings.BreakEvenTarget, null, currency);
-        }
-
-        // Break-even target from current realized average revenue per ticket:
-        // A = tickets sold so far, B = gross revenue so far, C = gross planned expenses
-        // D = remaining expenses = C - B
-        // E = average ticket price = B / A
-        // F = remaining tickets = D / E
-        // G = break-even target = A + F
-        // Finance hover shows D / E = F tickets still to sell.
-        var averageTicketPrice = revenue / ticketsSold;
-
-        var remainingExpenses = Math.Max(0m, plannedExpenses - revenue);
-        long remainingTicketsToSell = 0;
-        if (remainingExpenses > 0)
-        {
-            var remainingTicketCount = Math.Ceiling(remainingExpenses / averageTicketPrice);
-            remainingTicketsToSell = remainingTicketCount > int.MaxValue
-                ? int.MaxValue
-                : decimal.ToInt32(remainingTicketCount);
-        }
-
-        var breakEvenTarget = (long)ticketsSold + remainingTicketsToSell;
-        var target = breakEvenTarget > int.MaxValue
-            ? int.MaxValue
-            : (int)breakEvenTarget;
-
-        var detail = canAccessFinance
-            ? $"{currency} {remainingExpenses:N2} remaining expenses / {currency} {averageTicketPrice:N2} per ticket = {remainingTicketsToSell:N0} tickets still to sell"
-            : null;
-
-        return new BreakEvenCalculation(target, detail, currency);
-    }
-
-    private sealed record BreakEvenCalculation(int Target, string? Detail, string Currency);
 
     [HttpGet("Orders")]
     public async Task<IActionResult> Orders(

--- a/src/Humans.Web/Models/BudgetViewModels.cs
+++ b/src/Humans.Web/Models/BudgetViewModels.cs
@@ -87,6 +87,14 @@ public class CashFlowPeriodRow
     public decimal ExpenseTotal { get; init; }
     public decimal Net { get; init; }
     public decimal RunningNet { get; init; }
+
+    /// <summary>
+    /// True when cumulative expenses (ignoring income) have exceeded gross ticket revenue.
+    /// Used for the "Funds Exhausted" pill — marks the first period where the expense-only
+    /// runway runs out.
+    /// </summary>
+    public bool FundsExhausted { get; init; }
+
     public required IReadOnlyList<CashFlowCategoryRow> Categories { get; init; }
 }
 

--- a/src/Humans.Web/Views/Finance/CashFlow.cshtml
+++ b/src/Humans.Web/Views/Finance/CashFlow.cshtml
@@ -55,18 +55,13 @@
                     </tr>
                 </thead>
                 <tbody>
-                    @{
-                        var runwayExhausted = false;
-                    }
                     @foreach (var periodRow in Model.Periods)
                     {
                         var detailId = $"period-{periodRow.PeriodStart.ToString("yyyyMMdd", null)}";
-                        var isRunwayBoundary = !runwayExhausted && periodRow.RunningNet < 0;
-                        if (isRunwayBoundary) { runwayExhausted = true; }
-                        <tr class="fw-semibold @(isRunwayBoundary ? "table-warning" : "")" role="button" data-bs-toggle="collapse" data-bs-target="#@detailId">
+                        <tr class="fw-semibold @(periodRow.FundsExhausted ? "table-warning" : "")" role="button" data-bs-toggle="collapse" data-bs-target="#@detailId">
                             <td>
                                 @periodRow.Label
-                                @if (isRunwayBoundary)
+                                @if (periodRow.FundsExhausted)
                                 {
                                     <span class="badge bg-warning text-dark ms-2"><i class="fa-solid fa-triangle-exclamation me-1"></i>Funds exhausted</span>
                                 }

--- a/src/Humans.Web/Views/Ticket/Index.cshtml
+++ b/src/Humans.Web/Views/Ticket/Index.cshtml
@@ -85,7 +85,7 @@
         <div class="col">
             <div class="card h-100">
                 <div class="card-body">
-                    <h6 class="card-subtitle mb-2 text-muted">Avg. Net Price</h6>
+                    <h6 class="card-subtitle mb-2 text-muted">Avg. Gross Price</h6>
                     <h3 class="card-title">@Model.Currency @Model.AveragePrice.ToString("N2")</h3>
                 </div>
             </div>

--- a/tests/Humans.Application.Tests/Services/TicketQueryServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/TicketQueryServiceTests.cs
@@ -1,4 +1,5 @@
 using AwesomeAssertions;
+using Humans.Application.Interfaces;
 using Humans.Domain.Constants;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
@@ -7,6 +8,7 @@ using Humans.Infrastructure.Services;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 using NodaTime;
+using NSubstitute;
 using Xunit;
 
 namespace Humans.Application.Tests.Services;
@@ -23,7 +25,7 @@ public class TicketQueryServiceTests : IDisposable
             .Options;
 
         _dbContext = new HumansDbContext(options);
-        _service = new TicketQueryService(_dbContext, new MemoryCache(new MemoryCacheOptions()));
+        _service = new TicketQueryService(_dbContext, new MemoryCache(new MemoryCacheOptions()), Substitute.For<IBudgetService>());
     }
 
     public void Dispose()


### PR DESCRIPTION
## Summary
- Fix break-even to use gross average price and move calculation to service (#411)
- Fix "Funds Exhausted" pill to use expense-only runway (#412)

## Test plan
- [ ] Break-even target on Tickets dashboard uses gross revenue / tickets sold
- [ ] Break-even calculation no longer lives in controller
- [x] Funds Exhausted pill marks where expenses exceed gross ticket revenue
- [x] Income doesn't affect Funds Exhausted calculation
- [x] Both weekly and monthly views show correct pill placement

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>