### PR TITLE
Add feedback assignment to humans and teams (#410)

### DIFF
--- a/docs/sections/Feedback.md
+++ b/docs/sections/Feedback.md
@@ -10,7 +10,7 @@
 | Actor | Capabilities |
 |-------|-------------|
 | Any authenticated human | Submit feedback (with optional screenshot). View and reply to their own feedback reports. Accessible even during onboarding (before becoming an active member) |
-| FeedbackAdmin, Admin | View all feedback reports. Update status. Add admin notes. Send email responses to reporters. Link GitHub issues. Reply to any report |
+| FeedbackAdmin, Admin | View all feedback reports. Update status. Assign to humans or teams. Add admin notes. Send email responses to reporters. Link GitHub issues. Reply to any report |
 | API (key auth) | Full CRUD on feedback reports via the REST API (no user session required) |
 
 ## Invariants
@@ -20,11 +20,13 @@
 - Feedback status follows: Open then Acknowledged then Resolved or WontFix.
 - Regular humans can only see their own feedback reports. FeedbackAdmin and Admin can see all reports.
 - A report tracks whether it needs a reply (the reporter sent a message that the admin has not yet responded to).
+- A report can optionally be assigned to a human and/or a team. Both assignments are independent and nullable.
+- Assignment changes are audit-logged.
 
 ## Negative Access Rules
 
 - Regular humans **cannot** view other humans' feedback reports.
-- Regular humans **cannot** update feedback status, add admin notes, link GitHub issues, or send admin responses.
+- Regular humans **cannot** update feedback status, assign reports, add admin notes, link GitHub issues, or send admin responses.
 - FeedbackAdmin **cannot** perform system administration tasks — their elevated access is scoped to feedback only.
 
 ## Triggers

--- a/src/Humans.Application/Interfaces/IFeedbackService.cs
+++ b/src/Humans.Application/Interfaces/IFeedbackService.cs
@@ -16,7 +16,9 @@ public interface IFeedbackService
 
     Task<IReadOnlyList<FeedbackReport>> GetFeedbackListAsync(
         FeedbackStatus? status = null, FeedbackCategory? category = null,
-        Guid? reporterUserId = null, int limit = 50,
+        Guid? reporterUserId = null, Guid? assignedToUserId = null,
+        Guid? assignedToTeamId = null, bool? unassignedOnly = null,
+        int limit = 50,
         CancellationToken cancellationToken = default);
 
     Task UpdateStatusAsync(
@@ -32,6 +34,10 @@ public interface IFeedbackService
 
     Task<IReadOnlyList<FeedbackMessage>> GetMessagesAsync(
         Guid reportId, CancellationToken cancellationToken = default);
+
+    Task UpdateAssignmentAsync(
+        Guid id, Guid? assignedToUserId, Guid? assignedToTeamId, Guid actorUserId,
+        CancellationToken cancellationToken = default);
 
     Task<int> GetActionableCountAsync(
         CancellationToken cancellationToken = default);

--- a/src/Humans.Application/Interfaces/IFeedbackService.cs
+++ b/src/Humans.Application/Interfaces/IFeedbackService.cs
@@ -36,7 +36,7 @@ public interface IFeedbackService
         Guid reportId, CancellationToken cancellationToken = default);
 
     Task UpdateAssignmentAsync(
-        Guid id, Guid? assignedToUserId, Guid? assignedToTeamId, Guid actorUserId,
+        Guid id, Guid? assignedToUserId, Guid? assignedToTeamId, Guid? actorUserId,
         CancellationToken cancellationToken = default);
 
     Task<int> GetActionableCountAsync(

--- a/src/Humans.Domain/Entities/FeedbackReport.cs
+++ b/src/Humans.Domain/Entities/FeedbackReport.cs
@@ -32,5 +32,11 @@ public class FeedbackReport
     public Guid? ResolvedByUserId { get; set; }
     public User? ResolvedByUser { get; set; }
 
+    public Guid? AssignedToUserId { get; set; }
+    public User? AssignedToUser { get; set; }
+
+    public Guid? AssignedToTeamId { get; set; }
+    public Team? AssignedToTeam { get; set; }
+
     public ICollection<FeedbackMessage> Messages { get; set; } = new List<FeedbackMessage>();
 }

--- a/src/Humans.Domain/Enums/AuditAction.cs
+++ b/src/Humans.Domain/Enums/AuditAction.cs
@@ -73,4 +73,5 @@ public enum AuditAction
     ContactCreated,
     RotaMovedToTeam,
     GoogleResourceInheritanceDriftCorrected,
+    FeedbackAssignmentChanged,
 }

--- a/src/Humans.Infrastructure/Data/Configurations/FeedbackReportConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/FeedbackReportConfiguration.cs
@@ -58,8 +58,20 @@ public class FeedbackReportConfiguration : IEntityTypeConfiguration<FeedbackRepo
             .HasForeignKey(f => f.ResolvedByUserId)
             .OnDelete(DeleteBehavior.SetNull);
 
+        builder.HasOne(f => f.AssignedToUser)
+            .WithMany()
+            .HasForeignKey(f => f.AssignedToUserId)
+            .OnDelete(DeleteBehavior.SetNull);
+
+        builder.HasOne(f => f.AssignedToTeam)
+            .WithMany()
+            .HasForeignKey(f => f.AssignedToTeamId)
+            .OnDelete(DeleteBehavior.SetNull);
+
         builder.HasIndex(f => f.Status);
         builder.HasIndex(f => f.CreatedAt);
         builder.HasIndex(f => f.UserId);
+        builder.HasIndex(f => f.AssignedToUserId);
+        builder.HasIndex(f => f.AssignedToTeamId);
     }
 }

--- a/src/Humans.Infrastructure/Migrations/20260407170514_AddFeedbackAssignment.Designer.cs
+++ b/src/Humans.Infrastructure/Migrations/20260407170514_AddFeedbackAssignment.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Humans.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Humans.Infrastructure.Migrations
 {
     [DbContext(typeof(HumansDbContext))]
-    partial class HumansDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260407170514_AddFeedbackAssignment")]
+    partial class AddFeedbackAssignment
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Humans.Infrastructure/Migrations/20260407170514_AddFeedbackAssignment.cs
+++ b/src/Humans.Infrastructure/Migrations/20260407170514_AddFeedbackAssignment.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Humans.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddFeedbackAssignment : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "AssignedToTeamId",
+                table: "feedback_reports",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "AssignedToUserId",
+                table: "feedback_reports",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_feedback_reports_AssignedToTeamId",
+                table: "feedback_reports",
+                column: "AssignedToTeamId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_feedback_reports_AssignedToUserId",
+                table: "feedback_reports",
+                column: "AssignedToUserId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_feedback_reports_teams_AssignedToTeamId",
+                table: "feedback_reports",
+                column: "AssignedToTeamId",
+                principalTable: "teams",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_feedback_reports_users_AssignedToUserId",
+                table: "feedback_reports",
+                column: "AssignedToUserId",
+                principalTable: "users",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_feedback_reports_teams_AssignedToTeamId",
+                table: "feedback_reports");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_feedback_reports_users_AssignedToUserId",
+                table: "feedback_reports");
+
+            migrationBuilder.DropIndex(
+                name: "IX_feedback_reports_AssignedToTeamId",
+                table: "feedback_reports");
+
+            migrationBuilder.DropIndex(
+                name: "IX_feedback_reports_AssignedToUserId",
+                table: "feedback_reports");
+
+            migrationBuilder.DropColumn(
+                name: "AssignedToTeamId",
+                table: "feedback_reports");
+
+            migrationBuilder.DropColumn(
+                name: "AssignedToUserId",
+                table: "feedback_reports");
+        }
+    }
+}

--- a/src/Humans.Infrastructure/Services/FeedbackService.cs
+++ b/src/Humans.Infrastructure/Services/FeedbackService.cs
@@ -118,6 +118,8 @@ public class FeedbackService : IFeedbackService
         return await _dbContext.FeedbackReports
             .Include(f => f.User)
             .Include(f => f.ResolvedByUser)
+            .Include(f => f.AssignedToUser)
+            .Include(f => f.AssignedToTeam)
             .Include(f => f.Messages.OrderBy(m => m.CreatedAt))
                 .ThenInclude(m => m.SenderUser)
             .FirstOrDefaultAsync(f => f.Id == id, cancellationToken);
@@ -125,12 +127,16 @@ public class FeedbackService : IFeedbackService
 
     public async Task<IReadOnlyList<FeedbackReport>> GetFeedbackListAsync(
         FeedbackStatus? status = null, FeedbackCategory? category = null,
-        Guid? reporterUserId = null, int limit = 50,
+        Guid? reporterUserId = null, Guid? assignedToUserId = null,
+        Guid? assignedToTeamId = null, bool? unassignedOnly = null,
+        int limit = 50,
         CancellationToken cancellationToken = default)
     {
         var query = _dbContext.FeedbackReports
             .Include(f => f.User)
             .Include(f => f.ResolvedByUser)
+            .Include(f => f.AssignedToUser)
+            .Include(f => f.AssignedToTeam)
             .Include(f => f.Messages)
             .AsQueryable();
 
@@ -142,6 +148,15 @@ public class FeedbackService : IFeedbackService
 
         if (reporterUserId.HasValue)
             query = query.Where(f => f.UserId == reporterUserId.Value);
+
+        if (assignedToUserId.HasValue)
+            query = query.Where(f => f.AssignedToUserId == assignedToUserId.Value);
+
+        if (assignedToTeamId.HasValue)
+            query = query.Where(f => f.AssignedToTeamId == assignedToTeamId.Value);
+
+        if (unassignedOnly == true)
+            query = query.Where(f => f.AssignedToUserId == null && f.AssignedToTeamId == null);
 
         return await query
             .OrderByDescending(f => f.CreatedAt)
@@ -286,6 +301,62 @@ public class FeedbackService : IFeedbackService
             .OrderBy(m => m.CreatedAt)
             .AsNoTracking()
             .ToListAsync(cancellationToken);
+    }
+
+    public async Task UpdateAssignmentAsync(
+        Guid id, Guid? assignedToUserId, Guid? assignedToTeamId, Guid actorUserId,
+        CancellationToken cancellationToken = default)
+    {
+        var report = await _dbContext.FeedbackReports
+            .Include(f => f.AssignedToUser)
+            .Include(f => f.AssignedToTeam)
+            .FirstOrDefaultAsync(f => f.Id == id, cancellationToken)
+            ?? throw new InvalidOperationException($"Feedback report {id} not found");
+
+        var changes = new List<string>();
+
+        if (report.AssignedToUserId != assignedToUserId)
+        {
+            var oldName = report.AssignedToUser?.DisplayName ?? "Unassigned";
+            report.AssignedToUserId = assignedToUserId;
+
+            // Resolve new assignee name
+            string newName = "Unassigned";
+            if (assignedToUserId.HasValue)
+            {
+                var user = await _dbContext.Users.FindAsync(new object[] { assignedToUserId.Value }, cancellationToken);
+                newName = user?.DisplayName ?? assignedToUserId.Value.ToString();
+            }
+            changes.Add($"Assignee: {oldName} → {newName}");
+        }
+
+        if (report.AssignedToTeamId != assignedToTeamId)
+        {
+            var oldTeamName = report.AssignedToTeam?.Name ?? "Unassigned";
+            report.AssignedToTeamId = assignedToTeamId;
+
+            // Resolve new team name
+            string newTeamName = "Unassigned";
+            if (assignedToTeamId.HasValue)
+            {
+                var team = await _dbContext.Teams.FindAsync(new object[] { assignedToTeamId.Value }, cancellationToken);
+                newTeamName = team?.Name ?? assignedToTeamId.Value.ToString();
+            }
+            changes.Add($"Team: {oldTeamName} → {newTeamName}");
+        }
+
+        if (changes.Count == 0)
+            return;
+
+        report.UpdatedAt = _clock.GetCurrentInstant();
+
+        var description = $"Feedback {id} assignment changed: {string.Join("; ", changes)}";
+        await _auditLogService.LogAsync(
+            AuditAction.FeedbackAssignmentChanged, nameof(FeedbackReport), id,
+            description, actorUserId);
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        _logger.LogInformation("Feedback {ReportId} assignment updated by {ActorId}: {Changes}", id, actorUserId, string.Join("; ", changes));
     }
 
     public async Task<int> GetActionableCountAsync(

--- a/src/Humans.Infrastructure/Services/FeedbackService.cs
+++ b/src/Humans.Infrastructure/Services/FeedbackService.cs
@@ -304,7 +304,7 @@ public class FeedbackService : IFeedbackService
     }
 
     public async Task UpdateAssignmentAsync(
-        Guid id, Guid? assignedToUserId, Guid? assignedToTeamId, Guid actorUserId,
+        Guid id, Guid? assignedToUserId, Guid? assignedToTeamId, Guid? actorUserId,
         CancellationToken cancellationToken = default)
     {
         var report = await _dbContext.FeedbackReports
@@ -351,12 +351,21 @@ public class FeedbackService : IFeedbackService
         report.UpdatedAt = _clock.GetCurrentInstant();
 
         var description = $"Feedback {id} assignment changed: {string.Join("; ", changes)}";
-        await _auditLogService.LogAsync(
-            AuditAction.FeedbackAssignmentChanged, nameof(FeedbackReport), id,
-            description, actorUserId);
+        if (actorUserId.HasValue)
+        {
+            await _auditLogService.LogAsync(
+                AuditAction.FeedbackAssignmentChanged, nameof(FeedbackReport), id,
+                description, actorUserId.Value);
+        }
+        else
+        {
+            await _auditLogService.LogAsync(
+                AuditAction.FeedbackAssignmentChanged, nameof(FeedbackReport), id,
+                description, "API");
+        }
 
         await _dbContext.SaveChangesAsync(cancellationToken);
-        _logger.LogInformation("Feedback {ReportId} assignment updated by {ActorId}: {Changes}", id, actorUserId, string.Join("; ", changes));
+        _logger.LogInformation("Feedback {ReportId} assignment updated by {ActorId}: {Changes}", id, actorUserId?.ToString() ?? "API", string.Join("; ", changes));
     }
 
     public async Task<int> GetActionableCountAsync(

--- a/src/Humans.Web/Controllers/FeedbackApiController.cs
+++ b/src/Humans.Web/Controllers/FeedbackApiController.cs
@@ -51,7 +51,11 @@ public class FeedbackApiController : ControllerBase
             LastAdminMessageAt = r.LastAdminMessageAt?.ToDateTimeUtc(),
             ResolvedAt = r.ResolvedAt?.ToDateTimeUtc(),
             ResolvedByName = r.ResolvedByUser?.DisplayName,
-            MessageCount = r.Messages.Count
+            MessageCount = r.Messages.Count,
+            AssignedToUserId = r.AssignedToUserId,
+            AssignedToName = r.AssignedToUser?.DisplayName,
+            AssignedToTeamId = r.AssignedToTeamId,
+            AssignedToTeamName = r.AssignedToTeam?.Name
         });
 
         return Ok(result);
@@ -84,6 +88,10 @@ public class FeedbackApiController : ControllerBase
             LastAdminMessageAt = r.LastAdminMessageAt?.ToDateTimeUtc(),
             ResolvedAt = r.ResolvedAt?.ToDateTimeUtc(),
             ResolvedByName = r.ResolvedByUser?.DisplayName,
+            AssignedToUserId = r.AssignedToUserId,
+            AssignedToName = r.AssignedToUser?.DisplayName,
+            AssignedToTeamId = r.AssignedToTeamId,
+            AssignedToTeamName = r.AssignedToTeam?.Name,
             Messages = r.Messages.Select(m => new
             {
                 m.Id,
@@ -158,6 +166,25 @@ public class FeedbackApiController : ControllerBase
         {
             _logger.LogError(ex, "Failed to update feedback {FeedbackId} status", id);
             return StatusCode(500, new { error = "Failed to update status" });
+        }
+    }
+
+    [HttpPatch("{id}/assignment")]
+    public async Task<IActionResult> UpdateAssignment(Guid id, [FromBody] UpdateFeedbackAssignmentModel model)
+    {
+        try
+        {
+            await _feedbackService.UpdateAssignmentAsync(id, model.AssignedToUserId, model.AssignedToTeamId, Guid.Empty);
+            return Ok(new { success = true });
+        }
+        catch (InvalidOperationException)
+        {
+            return NotFound();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to update assignment for feedback {FeedbackId}", id);
+            return StatusCode(500, new { error = "Failed to update assignment" });
         }
     }
 

--- a/src/Humans.Web/Controllers/FeedbackApiController.cs
+++ b/src/Humans.Web/Controllers/FeedbackApiController.cs
@@ -174,7 +174,7 @@ public class FeedbackApiController : ControllerBase
     {
         try
         {
-            await _feedbackService.UpdateAssignmentAsync(id, model.AssignedToUserId, model.AssignedToTeamId, Guid.Empty);
+            await _feedbackService.UpdateAssignmentAsync(id, model.AssignedToUserId, model.AssignedToTeamId, null);
             return Ok(new { success = true });
         }
         catch (InvalidOperationException)

--- a/src/Humans.Web/Controllers/FeedbackController.cs
+++ b/src/Humans.Web/Controllers/FeedbackController.cs
@@ -16,24 +16,31 @@ namespace Humans.Web.Controllers;
 public class FeedbackController : HumansControllerBase
 {
     private readonly IFeedbackService _feedbackService;
+    private readonly ITeamService _teamService;
+    private readonly IProfileService _profileService;
     private readonly IStringLocalizer<SharedResource> _localizer;
     private readonly ILogger<FeedbackController> _logger;
 
     public FeedbackController(
         IFeedbackService feedbackService,
+        ITeamService teamService,
+        IProfileService profileService,
         UserManager<User> userManager,
         IStringLocalizer<SharedResource> localizer,
         ILogger<FeedbackController> logger)
         : base(userManager)
     {
         _feedbackService = feedbackService;
+        _teamService = teamService;
+        _profileService = profileService;
         _localizer = localizer;
         _logger = logger;
     }
 
     [HttpGet("")]
     public async Task<IActionResult> Index(
-        FeedbackStatus? status, FeedbackCategory? category, Guid? reporterUserId, Guid? selected)
+        FeedbackStatus? status, FeedbackCategory? category, Guid? reporterUserId,
+        Guid? assignedTo, Guid? team, bool unassigned, Guid? selected)
     {
         var (userMissing, user) = await RequireCurrentUserAsync();
         if (userMissing is not null) return userMissing;
@@ -41,7 +48,30 @@ public class FeedbackController : HumansControllerBase
         var isAdmin = RoleChecks.IsFeedbackAdmin(User);
         Guid? reporterFilter = isAdmin ? reporterUserId : user.Id;
 
-        var reports = await _feedbackService.GetFeedbackListAsync(status, category, reporterFilter);
+        var reports = await _feedbackService.GetFeedbackListAsync(
+            status, category, reporterFilter,
+            assignedToUserId: isAdmin ? assignedTo : null,
+            assignedToTeamId: isAdmin ? team : null,
+            unassignedOnly: isAdmin && unassigned ? true : null);
+
+        var assigneeOptions = new List<AssigneeOption>();
+        var teamOptions = new List<TeamOption>();
+
+        if (isAdmin)
+        {
+            var allTeams = await _teamService.GetAllTeamsAsync();
+            teamOptions = allTeams
+                .Where(t => t.IsActive)
+                .OrderBy(t => t.Name, StringComparer.OrdinalIgnoreCase)
+                .Select(t => new TeamOption { Id = t.Id, Name = t.Name })
+                .ToList();
+
+            var humans = await _profileService.GetFilteredHumansAsync(null, "Active");
+            assigneeOptions = humans
+                .OrderBy(h => h.DisplayName, StringComparer.OrdinalIgnoreCase)
+                .Select(h => new AssigneeOption { Id = h.UserId, DisplayName = h.DisplayName })
+                .ToList();
+        }
 
         var reporters = new List<ReporterDropdownItem>();
         if (isAdmin)
@@ -61,8 +91,14 @@ public class FeedbackController : HumansControllerBase
             CategoryFilter = category,
             ReporterFilter = isAdmin ? reporterUserId : null,
             Reporters = reporters,
+            AssignedToFilter = assignedTo,
+            TeamFilter = team,
+            UnassignedFilter = unassigned,
             IsAdmin = isAdmin,
             SelectedReportId = selected,
+            CurrentUserId = user.Id,
+            AssigneeOptions = assigneeOptions,
+            TeamOptions = teamOptions,
             Reports = reports.Select(r => new FeedbackListItemViewModel
             {
                 Id = r.Id,
@@ -78,7 +114,11 @@ public class FeedbackController : HumansControllerBase
                 GitHubIssueNumber = r.GitHubIssueNumber,
                 NeedsReply = (r.LastReporterMessageAt.HasValue &&
                     (!r.LastAdminMessageAt.HasValue || r.LastReporterMessageAt > r.LastAdminMessageAt)) ||
-                    (r.Status == FeedbackStatus.Open && !r.LastAdminMessageAt.HasValue)
+                    (r.Status == FeedbackStatus.Open && !r.LastAdminMessageAt.HasValue),
+                AssignedToName = r.AssignedToUser?.DisplayName,
+                AssignedToUserId = r.AssignedToUserId,
+                AssignedToTeamName = r.AssignedToTeam?.Name,
+                AssignedToTeamId = r.AssignedToTeamId
             }).ToList()
         };
 
@@ -98,6 +138,11 @@ public class FeedbackController : HumansControllerBase
         if (!isAdmin && report.UserId != user.Id) return NotFound();
 
         var viewModel = MapDetailViewModel(report, isAdmin);
+
+        if (isAdmin)
+        {
+            await PopulateAssignmentOptionsAsync(viewModel);
+        }
 
         if (Request.Headers.XRequestedWith == "XMLHttpRequest")
         {
@@ -215,6 +260,32 @@ public class FeedbackController : HumansControllerBase
         return RedirectToAction(nameof(Index), new { selected = id });
     }
 
+    [HttpPost("{id}/Assignment")]
+    [Authorize(Roles = RoleGroups.FeedbackAdminOrAdmin)]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> UpdateAssignment(Guid id, UpdateFeedbackAssignmentModel model)
+    {
+        try
+        {
+            var (userMissing, user) = await RequireCurrentUserAsync();
+            if (userMissing is not null) return userMissing;
+
+            await _feedbackService.UpdateAssignmentAsync(id, model.AssignedToUserId, model.AssignedToTeamId, user.Id);
+            SetSuccess("Assignment updated.");
+        }
+        catch (InvalidOperationException)
+        {
+            return NotFound();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to update assignment for feedback {FeedbackId}", id);
+            SetError("Failed to update assignment.");
+        }
+
+        return RedirectToAction(nameof(Index), new { selected = id });
+    }
+
     [HttpPost("{id}/GitHubIssue")]
     [Authorize(Policy = PolicyNames.FeedbackAdminOrAdmin)]
     [ValidateAntiForgeryToken]
@@ -259,6 +330,10 @@ public class FeedbackController : HumansControllerBase
             ResolvedAt = report.ResolvedAt?.ToDateTimeUtc(),
             ResolvedByName = report.ResolvedByUser?.DisplayName,
             IsAdmin = isAdmin,
+            AssignedToUserId = report.AssignedToUserId,
+            AssignedToName = report.AssignedToUser?.DisplayName,
+            AssignedToTeamId = report.AssignedToTeamId,
+            AssignedToTeamName = report.AssignedToTeam?.Name,
             Messages = report.Messages.Select(m => new FeedbackMessageViewModel
             {
                 Id = m.Id,
@@ -269,5 +344,21 @@ public class FeedbackController : HumansControllerBase
                 IsReporter = m.SenderUserId.HasValue && m.SenderUserId == report.UserId
             }).ToList()
         };
+    }
+
+    private async Task PopulateAssignmentOptionsAsync(FeedbackDetailViewModel viewModel)
+    {
+        var allTeams = await _teamService.GetAllTeamsAsync();
+        viewModel.TeamOptions = allTeams
+            .Where(t => t.IsActive)
+            .OrderBy(t => t.Name, StringComparer.OrdinalIgnoreCase)
+            .Select(t => new TeamOption { Id = t.Id, Name = t.Name })
+            .ToList();
+
+        var humans = await _profileService.GetFilteredHumansAsync(null, "Active");
+        viewModel.AssigneeOptions = humans
+            .OrderBy(h => h.DisplayName, StringComparer.OrdinalIgnoreCase)
+            .Select(h => new AssigneeOption { Id = h.UserId, DisplayName = h.DisplayName })
+            .ToList();
     }
 }

--- a/src/Humans.Web/Models/FeedbackViewModels.cs
+++ b/src/Humans.Web/Models/FeedbackViewModels.cs
@@ -29,8 +29,20 @@ public class FeedbackPageViewModel
     public FeedbackCategory? CategoryFilter { get; set; }
     public Guid? ReporterFilter { get; set; }
     public List<ReporterDropdownItem> Reporters { get; set; } = new();
+    public Guid? AssignedToFilter { get; set; }
+    public Guid? TeamFilter { get; set; }
+    public bool UnassignedFilter { get; set; }
     public bool IsAdmin { get; set; }
     public Guid? SelectedReportId { get; set; }
+    public Guid CurrentUserId { get; set; }
+    public List<AssigneeOption> AssigneeOptions { get; set; } = new();
+    public List<TeamOption> TeamOptions { get; set; } = new();
+}
+
+public class AssigneeOption
+{
+    public Guid Id { get; set; }
+    public string DisplayName { get; set; } = string.Empty;
 }
 
 public class ReporterDropdownItem
@@ -54,6 +66,10 @@ public class FeedbackListItemViewModel
     public int MessageCount { get; set; }
     public bool NeedsReply { get; set; }
     public int? GitHubIssueNumber { get; set; }
+    public string? AssignedToName { get; set; }
+    public Guid? AssignedToUserId { get; set; }
+    public string? AssignedToTeamName { get; set; }
+    public Guid? AssignedToTeamId { get; set; }
 }
 
 public class FeedbackDetailViewModel
@@ -74,6 +90,12 @@ public class FeedbackDetailViewModel
     public DateTime? ResolvedAt { get; set; }
     public string? ResolvedByName { get; set; }
     public bool IsAdmin { get; set; }
+    public Guid? AssignedToUserId { get; set; }
+    public string? AssignedToName { get; set; }
+    public Guid? AssignedToTeamId { get; set; }
+    public string? AssignedToTeamName { get; set; }
+    public List<AssigneeOption> AssigneeOptions { get; set; } = new();
+    public List<TeamOption> TeamOptions { get; set; } = new();
     public List<FeedbackMessageViewModel> Messages { get; set; } = new();
 }
 
@@ -104,4 +126,10 @@ public class PostFeedbackMessageModel
     [Required]
     [StringLength(5000)]
     public string Content { get; set; } = string.Empty;
+}
+
+public class UpdateFeedbackAssignmentModel
+{
+    public Guid? AssignedToUserId { get; set; }
+    public Guid? AssignedToTeamId { get; set; }
 }

--- a/src/Humans.Web/Views/Feedback/Index.cshtml
+++ b/src/Humans.Web/Views/Feedback/Index.cshtml
@@ -7,7 +7,7 @@
     <h2 class="mb-3">Feedback</h2>
 
     <!-- Filter bar -->
-    <form method="get" class="feedback-filter-form d-flex gap-2 mb-3">
+    <form method="get" class="feedback-filter-form d-flex gap-2 mb-3 flex-wrap">
         <select name="status" class="form-select form-select-sm" style="width: auto;">
             <option value="">All Statuses</option>
             @foreach (var s in Enum.GetValues<Humans.Domain.Enums.FeedbackStatus>())
@@ -53,7 +53,62 @@
                 }
             </select>
         }
-        @if (Model.StatusFilter.HasValue || Model.CategoryFilter.HasValue || Model.ReporterFilter.HasValue)
+        @if (Model.IsAdmin)
+        {
+            <select name="assignedTo" class="form-select form-select-sm" style="width: auto;">
+                <option value="">All Assignees</option>
+                @if (Model.AssignedToFilter == Model.CurrentUserId)
+                {
+                    <option value="@Model.CurrentUserId" selected>Assigned to me</option>
+                }
+                else
+                {
+                    <option value="@Model.CurrentUserId">Assigned to me</option>
+                }
+                @foreach (var a in Model.AssigneeOptions)
+                {
+                    if (a.Id != Model.CurrentUserId)
+                    {
+                        if (Model.AssignedToFilter == a.Id)
+                        {
+                            <option value="@a.Id" selected>@a.DisplayName</option>
+                        }
+                        else
+                        {
+                            <option value="@a.Id">@a.DisplayName</option>
+                        }
+                    }
+                }
+            </select>
+            <select name="team" class="form-select form-select-sm" style="width: auto;">
+                <option value="">All Teams</option>
+                @foreach (var t in Model.TeamOptions)
+                {
+                    if (Model.TeamFilter == t.Id)
+                    {
+                        <option value="@t.Id" selected>@t.Name</option>
+                    }
+                    else
+                    {
+                        <option value="@t.Id">@t.Name</option>
+                    }
+                }
+            </select>
+            <div class="form-check form-check-inline align-self-center ms-1">
+                @if (Model.UnassignedFilter)
+                {
+                    <input class="form-check-input feedback-filter-checkbox" type="checkbox" name="unassigned" value="true"
+                           id="unassignedFilter" checked>
+                }
+                else
+                {
+                    <input class="form-check-input feedback-filter-checkbox" type="checkbox" name="unassigned" value="true"
+                           id="unassignedFilter">
+                }
+                <label class="form-check-label small" for="unassignedFilter">Unassigned only</label>
+            </div>
+        }
+        @if (Model.StatusFilter.HasValue || Model.CategoryFilter.HasValue || Model.ReporterFilter.HasValue || Model.AssignedToFilter.HasValue || Model.TeamFilter.HasValue || Model.UnassignedFilter)
         {
             <a asp-action="Index" class="btn btn-sm btn-outline-secondary">Clear</a>
         }
@@ -69,6 +124,7 @@
             @foreach (var report in Model.Reports)
             {
                 var isSelected = report.Id == Model.SelectedReportId;
+                var isUnassigned = report.AssignedToUserId == null && report.AssignedToTeamId == null;
                 <div class="feedback-list-item p-3 border-bottom @(isSelected ? "bg-body-tertiary border-start border-3 border-primary" : "")"
                      data-report-id="@report.Id"
                      style="cursor: pointer;">
@@ -94,11 +150,39 @@
                     {
                         <div class="text-muted" style="font-size: 0.75rem;">@report.CreatedAt.ToString("MMM dd, HH:mm")</div>
                     }
+                    <div class="d-flex justify-content-between align-items-center mt-1" style="font-size: 0.75rem;">
+                        <span class="text-muted"><i class="fa-solid fa-comment"></i> @report.MessageCount</span>
+                        @if (Model.IsAdmin)
+                        {
+                            <span class="d-flex gap-1 align-items-center">
+                                @if (!string.IsNullOrEmpty(report.AssignedToName))
+                                {
+                                    <span class="badge bg-primary bg-opacity-10 text-primary border border-primary-subtle" style="font-size: 0.65rem;"
+                                          title="Assigned to @report.AssignedToName">
+                                        <i class="fa-solid fa-user fa-xs"></i> @(report.AssignedToName.Length > 12 ? report.AssignedToName[..12] + "..." : report.AssignedToName)
+                                    </span>
+                                }
+                                @if (!string.IsNullOrEmpty(report.AssignedToTeamName))
+                                {
+                                    <span class="badge bg-warning bg-opacity-10 text-warning-emphasis border border-warning-subtle" style="font-size: 0.65rem;"
+                                          title="Team: @report.AssignedToTeamName">
+                                        <i class="fa-solid fa-users fa-xs"></i> @(report.AssignedToTeamName.Length > 12 ? report.AssignedToTeamName[..12] + "..." : report.AssignedToTeamName)
+                                    </span>
+                                }
+                                @if (isUnassigned)
+                                {
+                                    <span class="badge bg-secondary bg-opacity-10 text-secondary border border-secondary-subtle" style="font-size: 0.65rem;">
+                                        Unassigned
+                                    </span>
+                                }
+                            </span>
+                        }
+                    </div>
                     <div class="d-flex justify-content-between mt-1" style="font-size: 0.75rem;">
-                        <span class="text-muted">💬 @report.MessageCount</span>
+                        <span></span>
                         @if (report.NeedsReply && Model.IsAdmin)
                         {
-                            <span class="text-danger">● needs reply</span>
+                            <span class="text-danger"><i class="fa-solid fa-circle fa-xs"></i> needs reply</span>
                         }
                         @if (report.GitHubIssueNumber.HasValue)
                         {
@@ -151,6 +235,9 @@
         // Auto-submit filter forms
         document.querySelectorAll('.feedback-filter-form select').forEach(sel => {
             sel.addEventListener('change', () => sel.form.submit());
+        });
+        document.querySelectorAll('.feedback-filter-checkbox').forEach(cb => {
+            cb.addEventListener('change', () => cb.form.submit());
         });
         // Click handler for report list items
         document.querySelectorAll('[data-report-id]').forEach(el => {

--- a/src/Humans.Web/Views/Feedback/_Detail.cshtml
+++ b/src/Humans.Web/Views/Feedback/_Detail.cshtml
@@ -51,6 +51,54 @@
         }
     </div>
 
+    @if (Model.IsAdmin)
+    {
+        <div class="mt-2 d-flex gap-2 align-items-center flex-wrap">
+            <form asp-action="UpdateAssignment" asp-route-id="@Model.Id" method="post" class="d-inline">
+                @Html.AntiForgeryToken()
+                <input type="hidden" name="AssignedToTeamId" value="@Model.AssignedToTeamId" />
+                <div class="input-group input-group-sm" style="width: auto;">
+                    <span class="input-group-text"><i class="fa-solid fa-user fa-xs"></i></span>
+                    <select name="AssignedToUserId" class="form-select form-select-sm detail-auto-submit" style="width: auto; min-width: 160px;">
+                        <option value="">Unassigned</option>
+                        @foreach (var a in Model.AssigneeOptions)
+                        {
+                            if (Model.AssignedToUserId == a.Id)
+                            {
+                                <option value="@a.Id" selected>@a.DisplayName</option>
+                            }
+                            else
+                            {
+                                <option value="@a.Id">@a.DisplayName</option>
+                            }
+                        }
+                    </select>
+                </div>
+            </form>
+            <form asp-action="UpdateAssignment" asp-route-id="@Model.Id" method="post" class="d-inline">
+                @Html.AntiForgeryToken()
+                <input type="hidden" name="AssignedToUserId" value="@Model.AssignedToUserId" />
+                <div class="input-group input-group-sm" style="width: auto;">
+                    <span class="input-group-text"><i class="fa-solid fa-users fa-xs"></i></span>
+                    <select name="AssignedToTeamId" class="form-select form-select-sm detail-auto-submit" style="width: auto; min-width: 160px;">
+                        <option value="">No team</option>
+                        @foreach (var t in Model.TeamOptions)
+                        {
+                            if (Model.AssignedToTeamId == t.Id)
+                            {
+                                <option value="@t.Id" selected>@t.Name</option>
+                            }
+                            else
+                            {
+                                <option value="@t.Id">@t.Name</option>
+                            }
+                        }
+                    </select>
+                </div>
+            </form>
+        </div>
+    }
+
     @if (!string.IsNullOrEmpty(Model.UserAgent) || !string.IsNullOrEmpty(Model.AdditionalContext))
     {
         <div class="text-muted mt-2" style="font-size: 0.75rem;">


### PR DESCRIPTION
## Summary
- Add `AssignedToUserId` and `AssignedToTeamId` nullable FKs to FeedbackReport
- Assignment dropdowns in detail panel (admin-only, auto-submit)
- "Assigned to" and "Team" filter dropdowns in list view with "Assigned to me" shortcut
- PATCH API endpoint for assignment changes
- Audit logging for assignment changes
- EF migration included

Addresses #410.

## Test plan
- [ ] Assignment dropdowns appear in feedback detail panel (admin only)
- [ ] Changing assignee/team auto-saves without page reload
- [ ] Assignments visible in feedback list with visual indicators
- [ ] "Assigned to me" filter works correctly
- [ ] "Unassigned" filter works correctly
- [ ] Team filter works correctly
- [ ] Audit log records assignment changes
- [ ] PATCH /api/feedback/{id}/assignment works
- [ ] Existing feedback functionality unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>