### PR TITLE
Sprint batch 3: Small enhancements (#431, #430, #448)

### DIFF
--- a/src/Humans.Application/CacheKeys.cs
+++ b/src/Humans.Application/CacheKeys.cs
@@ -34,4 +34,48 @@ public static class CacheKeys
     // Magic link sentinel keys (rate limiting and replay prevention)
     public static string MagicLinkUsed(string tokenPrefix) => $"magic_link_used:{tokenPrefix}";
     public static string MagicLinkSignupRateLimit(string normalizedEmail) => $"magic_link_signup:{normalizedEmail}";
+
+    /// <summary>
+    /// Cache key type classification for the Admin Cache Stats page.
+    /// </summary>
+    public enum CacheKeyType
+    {
+        Static,
+        PerUser,
+        PerEntity,
+        RateLimit
+    }
+
+    /// <summary>
+    /// Metadata for a cache key prefix: configured TTL and key type.
+    /// </summary>
+    public record CacheKeyMeta(string Ttl, CacheKeyType Type);
+
+    /// <summary>
+    /// Static lookup of known cache key prefixes to their TTL and type classification.
+    /// </summary>
+    public static readonly IReadOnlyDictionary<string, CacheKeyMeta> Metadata =
+        new Dictionary<string, CacheKeyMeta>(StringComparer.Ordinal)
+        {
+            ["NavBadgeCounts"] = new("2 min", CacheKeyType.Static),
+            ["NotificationBadge"] = new("2 min", CacheKeyType.PerUser),
+            ["NotificationMeters"] = new("2 min", CacheKeyType.Static),
+            ["ApprovedProfiles"] = new("10 min", CacheKeyType.Static),
+            ["ActiveTeams"] = new("10 min", CacheKeyType.Static),
+            ["CampSettings"] = new("5 min", CacheKeyType.Static),
+            ["TicketEventSummary"] = new("15 min", CacheKeyType.PerEntity),
+            ["camps_year"] = new("5 min", CacheKeyType.PerEntity),
+            ["UserProfile"] = new("2 min", CacheKeyType.PerUser),
+            ["UserTicketCount"] = new("5 min", CacheKeyType.PerUser),
+            ["TicketDashboardStats"] = new("5 min", CacheKeyType.Static),
+            ["UserIdsWithTickets"] = new("5 min", CacheKeyType.Static),
+            ["CampContactRateLimit"] = new("10 min", CacheKeyType.RateLimit),
+            ["claims"] = new("60 sec", CacheKeyType.PerUser),
+            ["shift-auth"] = new("60 sec", CacheKeyType.PerUser),
+            ["NavBadge"] = new("2 min", CacheKeyType.PerUser),
+            ["Legal"] = new("1 hour", CacheKeyType.PerEntity),
+            ["magic_link_used"] = new("15 min", CacheKeyType.RateLimit),
+            ["magic_link_signup"] = new("60 sec", CacheKeyType.RateLimit),
+            ["NobodiesTeamEmails_All"] = new("2 min", CacheKeyType.Static),
+        };
 }

--- a/src/Humans.Application/Interfaces/ICacheStatsProvider.cs
+++ b/src/Humans.Application/Interfaces/ICacheStatsProvider.cs
@@ -10,6 +10,7 @@ public interface ICacheStatsProvider
     void Reset();
     long TotalHits { get; }
     long TotalMisses { get; }
+    int TotalActiveEntries { get; }
 }
 
 /// <summary>

--- a/src/Humans.Application/Interfaces/IShiftManagementService.cs
+++ b/src/Humans.Application/Interfaces/IShiftManagementService.cs
@@ -175,6 +175,13 @@ public interface IShiftManagementService
         Guid eventSettingsId, Guid? departmentId = null);
 
     /// <summary>
+    /// Gets per-day staffing hours across all periods, grouped by shift priority.
+    /// Hours = shift duration × MaxVolunteers. All-day shifts count as 8 hours per slot.
+    /// </summary>
+    Task<IReadOnlyList<DailyStaffingHours>> GetStaffingHoursAsync(
+        Guid eventSettingsId, Guid? departmentId = null);
+
+    /// <summary>
     /// Gets shifts summary for a department. Returns null if no rotas.
     /// </summary>
     Task<ShiftsSummaryData?> GetShiftsSummaryAsync(
@@ -262,3 +269,14 @@ public record ShiftsSummaryData(
     int ConfirmedCount,
     int PendingCount,
     int UniqueVolunteerCount);
+
+/// <summary>
+/// Per-day staffing hours grouped by shift priority for volume visualization.
+/// Hours = shift duration × MaxVolunteers. All-day shifts count as 8h per slot.
+/// </summary>
+public record DailyStaffingHours(
+    int DayOffset,
+    string DateLabel,
+    double EssentialHours,
+    double ImportantHours,
+    double NormalHours);

--- a/src/Humans.Infrastructure/Services/ShiftManagementService.cs
+++ b/src/Humans.Infrastructure/Services/ShiftManagementService.cs
@@ -746,6 +746,76 @@ public class ShiftManagementService : IShiftManagementService
         return results;
     }
 
+    public async Task<IReadOnlyList<DailyStaffingHours>> GetStaffingHoursAsync(
+        Guid eventSettingsId, Guid? departmentId = null)
+    {
+        var es = await _dbContext.EventSettings.AsNoTracking()
+            .FirstOrDefaultAsync(e => e.Id == eventSettingsId);
+        if (es is null) return [];
+
+        var tz = DateTimeZoneProviders.Tzdb[es.TimeZoneId];
+
+        var dayOffsets = new List<int>();
+        for (var d = es.BuildStartOffset; d < 0; d++) dayOffsets.Add(d);
+        for (var d = 0; d <= es.EventEndOffset; d++) dayOffsets.Add(d);
+        for (var d = es.EventEndOffset + 1; d <= es.StrikeEndOffset; d++) dayOffsets.Add(d);
+
+        if (dayOffsets.Count == 0) return [];
+
+        var query = _dbContext.Shifts
+            .AsNoTracking()
+            .Include(s => s.Rota)
+            .Where(s => s.Rota.EventSettingsId == eventSettingsId);
+
+        if (departmentId.HasValue)
+            query = query.Where(s => s.Rota.TeamId == departmentId.Value);
+
+        var shifts = await query.ToListAsync();
+        var results = new List<DailyStaffingHours>();
+
+        foreach (var dayOffset in dayOffsets)
+        {
+            var dayDate = es.GateOpeningDate.PlusDays(dayOffset);
+            var dayStart = dayDate.AtStartOfDayInZone(tz).ToInstant();
+            var dayEnd = dayDate.PlusDays(1).AtStartOfDayInZone(tz).ToInstant();
+            var dateLabel = dayDate.DayOfWeek.ToString()[..3] + " " + dayDate.ToString("MMM d", null);
+
+            var overlapping = shifts.Where(s =>
+            {
+                var start = s.GetAbsoluteStart(es);
+                var end = s.GetAbsoluteEnd(es);
+                return start < dayEnd && end > dayStart;
+            }).ToList();
+
+            var essentialHours = 0.0;
+            var importantHours = 0.0;
+            var normalHours = 0.0;
+
+            foreach (var shift in overlapping)
+            {
+                var hours = shift.IsAllDay ? 8.0 : shift.Duration.TotalHours;
+                var totalHours = hours * shift.MaxVolunteers;
+
+                switch (shift.Rota.Priority)
+                {
+                    case ShiftPriority.Essential:
+                        essentialHours += totalHours;
+                        break;
+                    case ShiftPriority.Important:
+                        importantHours += totalHours;
+                        break;
+                    default:
+                        normalHours += totalHours;
+                        break;
+                }
+            }
+
+            results.Add(new DailyStaffingHours(dayOffset, dateLabel, essentialHours, importantHours, normalHours));
+        }
+
+        return results;
+    }
+
     public async Task<ShiftsSummaryData?> GetShiftsSummaryAsync(
         Guid eventSettingsId, Guid departmentTeamId)
     {

--- a/src/Humans.Infrastructure/Services/TrackingMemoryCache.cs
+++ b/src/Humans.Infrastructure/Services/TrackingMemoryCache.cs
@@ -6,14 +6,15 @@ namespace Humans.Infrastructure.Services;
 
 /// <summary>
 /// Decorator around <see cref="IMemoryCache"/> that tracks hit/miss statistics
-/// per cache key type. Registered as the primary IMemoryCache in DI so all
-/// existing consumers get automatic tracking with no code changes.
-/// Stats are in-memory only — reset on application restart.
+/// per cache key type and active entry counts. Registered as the primary
+/// IMemoryCache in DI so all existing consumers get automatic tracking with
+/// no code changes. Stats are in-memory only — reset on application restart.
 /// </summary>
 public sealed class TrackingMemoryCache : IMemoryCache, ICacheStatsProvider
 {
     private readonly IMemoryCache _inner;
     private readonly ConcurrentDictionary<string, CacheStatEntry> _stats = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, byte> _liveKeys = new(StringComparer.Ordinal);
 
     public TrackingMemoryCache(IMemoryCache inner)
     {
@@ -45,12 +46,24 @@ public sealed class TrackingMemoryCache : IMemoryCache, ICacheStatsProvider
 
     public ICacheEntry CreateEntry(object key)
     {
-        return _inner.CreateEntry(key);
+        var keyStr = key.ToString() ?? "(null)";
+        _liveKeys.TryAdd(keyStr, 0);
+
+        var entry = _inner.CreateEntry(key);
+        entry.RegisterPostEvictionCallback((evictedKey, _, _, _) =>
+        {
+            var evictedKeyStr = evictedKey.ToString() ?? "(null)";
+            _liveKeys.TryRemove(evictedKeyStr, out _);
+        });
+
+        return entry;
     }
 
     public void Remove(object key)
     {
         _inner.Remove(key);
+        var keyStr = key.ToString() ?? "(null)";
+        _liveKeys.TryRemove(keyStr, out _);
     }
 
     public void Dispose()
@@ -74,6 +87,23 @@ public sealed class TrackingMemoryCache : IMemoryCache, ICacheStatsProvider
 
     public long TotalHits => _stats.Values.Sum(e => e.Hits);
     public long TotalMisses => _stats.Values.Sum(e => e.Misses);
+
+    public int TotalActiveEntries => _liveKeys.Count;
+
+    /// <summary>
+    /// Gets the number of active cache entries per key type (prefix).
+    /// </summary>
+    public IReadOnlyDictionary<string, int> GetActiveEntryCounts()
+    {
+        var counts = new Dictionary<string, int>(StringComparer.Ordinal);
+        foreach (var key in _liveKeys.Keys)
+        {
+            var keyType = DeriveKeyType(key);
+            counts.TryGetValue(keyType, out var current);
+            counts[keyType] = current + 1;
+        }
+        return counts;
+    }
 
     /// <summary>
     /// Derive a human-readable "type" from the cache key.

--- a/src/Humans.Web/Controllers/AdminController.cs
+++ b/src/Humans.Web/Controllers/AdminController.cs
@@ -243,16 +243,29 @@ public class AdminController : HumansControllerBase
         try
         {
             var snapshot = _cacheStatsProvider.GetSnapshot();
+            var entryCounts = (_cacheStatsProvider as Humans.Infrastructure.Services.TrackingMemoryCache)
+                ?.GetActiveEntryCounts()
+                ?? new Dictionary<string, int>(StringComparer.Ordinal);
+
             var model = new CacheStatsViewModel
             {
                 TotalHits = _cacheStatsProvider.TotalHits,
                 TotalMisses = _cacheStatsProvider.TotalMisses,
-                Entries = snapshot.Select(e => new CacheStatEntryViewModel
+                TotalActiveEntries = _cacheStatsProvider.TotalActiveEntries,
+                Entries = snapshot.Select(e =>
                 {
-                    KeyType = e.KeyType,
-                    Hits = e.Hits,
-                    Misses = e.Misses,
-                    HitRatePercent = e.HitRatePercent
+                    entryCounts.TryGetValue(e.KeyType, out var activeCount);
+                    Application.CacheKeys.Metadata.TryGetValue(e.KeyType, out var meta);
+                    return new CacheStatEntryViewModel
+                    {
+                        KeyType = e.KeyType,
+                        Hits = e.Hits,
+                        Misses = e.Misses,
+                        HitRatePercent = e.HitRatePercent,
+                        ActiveEntries = activeCount,
+                        Ttl = meta?.Ttl ?? "—",
+                        Type = meta?.Type.ToString() ?? "—"
+                    };
                 }).ToList()
             };
             return View(model);

--- a/src/Humans.Web/Controllers/ShiftAdminController.cs
+++ b/src/Humans.Web/Controllers/ShiftAdminController.cs
@@ -98,6 +98,7 @@ public class ShiftAdminController : HumansTeamControllerBase
         }
 
         var staffingData = await _shiftMgmt.GetStaffingDataAsync(es.Id, team.Id);
+        var staffingHours = await _shiftMgmt.GetStaffingHoursAsync(es.Id, team.Id);
 
         var allDepartments = new List<DepartmentOption>();
         if (RoleChecks.IsVolunteerManager(User))
@@ -127,6 +128,7 @@ public class ShiftAdminController : HumansTeamControllerBase
             VolunteerProfiles = profileDict,
             CanViewMedical = canViewMedical,
             StaffingData = staffingData.ToList(),
+            StaffingHours = staffingHours.ToList(),
             Now = _clock.GetCurrentInstant(),
             AllDepartments = allDepartments,
             AllTags = allTags.ToList()

--- a/src/Humans.Web/Controllers/ShiftDashboardController.cs
+++ b/src/Humans.Web/Controllers/ShiftDashboardController.cs
@@ -61,6 +61,7 @@ public class ShiftDashboardController : HumansControllerBase
 
         var shifts = await _shiftMgmt.GetUrgentShiftsAsync(es.Id, limit: null, departmentId, filterDate);
         var staffingData = await _shiftMgmt.GetStaffingDataAsync(es.Id, departmentId);
+        var staffingHours = await _shiftMgmt.GetStaffingHoursAsync(es.Id, departmentId);
 
         var deptTuples = await _shiftMgmt.GetDepartmentsWithRotasAsync(es.Id);
         var departments = deptTuples.Select(d => new DepartmentOption
@@ -77,7 +78,8 @@ public class ShiftDashboardController : HumansControllerBase
             SelectedRotaId = rotaId,
             SelectedDate = date,
             EventSettings = es,
-            StaffingData = staffingData.ToList()
+            StaffingData = staffingData.ToList(),
+            StaffingHours = staffingHours.ToList()
         };
 
         return View(model);

--- a/src/Humans.Web/Controllers/TeamAdminController.cs
+++ b/src/Humans.Web/Controllers/TeamAdminController.cs
@@ -704,6 +704,8 @@ public class TeamAdminController : HumansTeamControllerBase
             p => p.UserId,
             p => Url.Action(nameof(ProfileController.Picture), "Profile", new { id = p.ProfileId, v = p.UpdatedAtTicks })!);
 
+        var canToggleManagement = RoleChecks.IsTeamsAdmin(User) || RoleChecks.IsAdmin(User);
+
         var viewModel = new RoleManagementViewModel
         {
             TeamId = team.Id,
@@ -712,6 +714,7 @@ public class TeamAdminController : HumansTeamControllerBase
             IsSystemTeam = team.IsSystemTeam,
             IsChildTeam = team.ParentTeamId.HasValue,
             CanManage = true,
+            CanToggleManagement = canToggleManagement,
             RoleDefinitions = definitions.Select(TeamRoleDefinitionViewModel.FromEntity).ToList(),
             TeamMembers = members.Select(m => new TeamMemberViewModel
             {
@@ -775,6 +778,18 @@ public class TeamAdminController : HumansTeamControllerBase
 
         try
         {
+            // If user lacks TeamsAdmin/Admin, preserve the existing IsManagement value
+            var canToggleManagement = RoleChecks.IsTeamsAdmin(User) || RoleChecks.IsAdmin(User);
+            if (!canToggleManagement)
+            {
+                var existingRoles = await _teamService.GetRoleDefinitionsAsync(team.Id);
+                var existingRole = existingRoles.FirstOrDefault(r => r.Id == roleId);
+                if (existingRole is not null)
+                {
+                    model.IsManagement = existingRole.IsManagement;
+                }
+            }
+
             var priorities = model.Priorities
                 .Select(p => Enum.Parse<SlotPriority>(p, ignoreCase: true))
                 .ToList();
@@ -830,6 +845,11 @@ public class TeamAdminController : HumansTeamControllerBase
         if (teamError is not null)
         {
             return teamError;
+        }
+
+        if (!RoleChecks.IsTeamsAdmin(User) && !RoleChecks.IsAdmin(User))
+        {
+            return Forbid();
         }
 
         try

--- a/src/Humans.Web/Models/AdminViewModels.cs
+++ b/src/Humans.Web/Models/AdminViewModels.cs
@@ -384,6 +384,7 @@ public class CacheStatsViewModel
 {
     public long TotalHits { get; set; }
     public long TotalMisses { get; set; }
+    public int TotalActiveEntries { get; set; }
 
     public double OverallHitRatePercent => TotalHits + TotalMisses > 0
         ? Math.Round(TotalHits * 100.0 / (TotalHits + TotalMisses), 1)
@@ -398,6 +399,9 @@ public class CacheStatEntryViewModel
     public long Hits { get; set; }
     public long Misses { get; set; }
     public double HitRatePercent { get; set; }
+    public int ActiveEntries { get; set; }
+    public string Ttl { get; set; } = string.Empty;
+    public string Type { get; set; } = string.Empty;
 }
 
 public class DuplicateAccountListViewModel

--- a/src/Humans.Web/Models/ShiftViewModels.cs
+++ b/src/Humans.Web/Models/ShiftViewModels.cs
@@ -227,6 +227,7 @@ public class ShiftAdminViewModel
     public Dictionary<Guid, VolunteerEventProfile> VolunteerProfiles { get; set; } = new();
     public bool CanViewMedical { get; set; }
     public List<DailyStaffingData> StaffingData { get; set; } = [];
+    public List<DailyStaffingHours> StaffingHours { get; set; } = [];
     public Instant Now { get; set; }
     public List<DepartmentOption> AllDepartments { get; set; } = [];
 

--- a/src/Humans.Web/Models/ShiftViewModels.cs
+++ b/src/Humans.Web/Models/ShiftViewModels.cs
@@ -406,6 +406,7 @@ public class ShiftDashboardViewModel
     public string? SelectedDate { get; set; }
     public EventSettings EventSettings { get; set; } = null!;
     public List<DailyStaffingData> StaffingData { get; set; } = [];
+    public List<DailyStaffingHours> StaffingHours { get; set; } = [];
 }
 
 public class VolunteerSearchResult

--- a/src/Humans.Web/Models/TeamViewModels.cs
+++ b/src/Humans.Web/Models/TeamViewModels.cs
@@ -435,6 +435,7 @@ public class RoleManagementViewModel
     public bool IsSystemTeam { get; set; }
     public bool IsChildTeam { get; set; }
     public bool CanManage { get; set; }
+    public bool CanToggleManagement { get; set; }
     public List<TeamRoleDefinitionViewModel> RoleDefinitions { get; set; } = [];
     public List<TeamMemberViewModel> TeamMembers { get; set; } = [];
 }

--- a/src/Humans.Web/Views/Admin/CacheStats.cshtml
+++ b/src/Humans.Web/Views/Admin/CacheStats.cshtml
@@ -23,7 +23,7 @@
 <vc:temp-data-alerts />
 
 <div class="row mb-4">
-    <div class="col-md-4">
+    <div class="col-md-3">
         <div class="card text-center">
             <div class="card-body">
                 <h5 class="card-title text-success">@Model.TotalHits.ToString("N0")</h5>
@@ -31,7 +31,7 @@
             </div>
         </div>
     </div>
-    <div class="col-md-4">
+    <div class="col-md-3">
         <div class="card text-center">
             <div class="card-body">
                 <h5 class="card-title text-danger">@Model.TotalMisses.ToString("N0")</h5>
@@ -39,11 +39,19 @@
             </div>
         </div>
     </div>
-    <div class="col-md-4">
+    <div class="col-md-3">
         <div class="card text-center">
             <div class="card-body">
                 <h5 class="card-title">@Model.OverallHitRatePercent.ToString("F1")%</h5>
                 <p class="card-text text-muted mb-0">Overall Hit Rate</p>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-3">
+        <div class="card text-center">
+            <div class="card-body">
+                <h5 class="card-title text-primary">@Model.TotalActiveEntries.ToString("N0")</h5>
+                <p class="card-text text-muted mb-0">Active Entries</p>
             </div>
         </div>
     </div>
@@ -62,9 +70,12 @@ else
             <thead>
                 <tr>
                     <th style="cursor:pointer;" data-sort-col="0">Key Type <i class="fa-solid fa-sort fa-xs"></i></th>
-                    <th style="cursor:pointer;" data-sort-col="1" class="text-end">Hits <i class="fa-solid fa-sort fa-xs"></i></th>
-                    <th style="cursor:pointer;" data-sort-col="2" class="text-end">Misses <i class="fa-solid fa-sort fa-xs"></i></th>
-                    <th style="cursor:pointer;" data-sort-col="3" class="text-end">Hit Rate % <i class="fa-solid fa-sort fa-xs"></i></th>
+                    <th style="cursor:pointer;" data-sort-col="1">Type <i class="fa-solid fa-sort fa-xs"></i></th>
+                    <th style="cursor:pointer;" data-sort-col="2" class="text-end">Entries <i class="fa-solid fa-sort fa-xs"></i></th>
+                    <th style="cursor:pointer;" data-sort-col="3">TTL <i class="fa-solid fa-sort fa-xs"></i></th>
+                    <th style="cursor:pointer;" data-sort-col="4" class="text-end">Hits <i class="fa-solid fa-sort fa-xs"></i></th>
+                    <th style="cursor:pointer;" data-sort-col="5" class="text-end">Misses <i class="fa-solid fa-sort fa-xs"></i></th>
+                    <th style="cursor:pointer;" data-sort-col="6" class="text-end">Hit Rate % <i class="fa-solid fa-sort fa-xs"></i></th>
                 </tr>
             </thead>
             <tbody>
@@ -76,8 +87,19 @@ else
                         >= 50 => "",
                         _ => "table-warning"
                     };
+                    var typeBadge = entry.Type switch
+                    {
+                        "Static" => "bg-primary",
+                        "PerUser" => "bg-info",
+                        "PerEntity" => "bg-secondary",
+                        "RateLimit" => "bg-warning text-dark",
+                        _ => "bg-light text-dark"
+                    };
                     <tr class="@rateClass">
                         <td>@entry.KeyType</td>
+                        <td><span class="badge @typeBadge">@entry.Type</span></td>
+                        <td class="text-end">@entry.ActiveEntries.ToString("N0")</td>
+                        <td>@entry.Ttl</td>
                         <td class="text-end">@entry.Hits.ToString("N0")</td>
                         <td class="text-end">@entry.Misses.ToString("N0")</td>
                         <td class="text-end">@entry.HitRatePercent.ToString("F1")%</td>
@@ -92,12 +114,13 @@ else
     <script>
         (function () {
             const sortDir = {};
+            const numericCols = [2, 4, 5, 6];
             document.querySelectorAll('#cacheStatsTable th[data-sort-col]').forEach(th => {
                 th.addEventListener('click', function () {
                     const colIndex = parseInt(this.dataset.sortCol);
                     const tbody = document.querySelector('#cacheStatsTable tbody');
                     const rows = Array.from(tbody.querySelectorAll('tr'));
-                    const isNumeric = colIndex >= 1;
+                    const isNumeric = numericCols.includes(colIndex);
 
                     sortDir[colIndex] = !sortDir[colIndex];
                     const dir = sortDir[colIndex] ? 1 : -1;

--- a/src/Humans.Web/Views/Shared/_StaffingHoursChart.cshtml
+++ b/src/Humans.Web/Views/Shared/_StaffingHoursChart.cshtml
@@ -1,0 +1,67 @@
+@using Humans.Application.Interfaces
+@model (List<DailyStaffingHours> Data, string ChartId)
+
+@{
+    var hasData = Model.Data.Any(d => d.EssentialHours > 0 || d.ImportantHours > 0 || d.NormalHours > 0);
+}
+
+@if (hasData)
+{
+    var chartKey = Model.ChartId;
+    var jsonOpts = new System.Text.Json.JsonSerializerOptions { PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase };
+
+    <script>
+    if (typeof Chart === 'undefined') {
+        var s = document.createElement('script');
+        s.src = 'https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js';
+        s.onload = function() { window['render_@(chartKey)'](); };
+        document.head.appendChild(s);
+    } else {
+        document.addEventListener('DOMContentLoaded', function() { window['render_@(chartKey)'](); });
+    }
+
+    window['render_@(chartKey)'] = function() {
+        var data = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.Data, jsonOpts));
+        var labels = data.map(function(d) { return d.dateLabel; });
+        var essential = data.map(function(d) { return Math.round(d.essentialHours * 10) / 10; });
+        var important = data.map(function(d) { return Math.round(d.importantHours * 10) / 10; });
+        var normal = data.map(function(d) { return Math.round(d.normalHours * 10) / 10; });
+
+        var cs = getComputedStyle(document.documentElement);
+        var cv = function(n) { return cs.getPropertyValue(n).trim(); };
+
+        new Chart(document.getElementById('@chartKey'), {
+            type: 'bar',
+            data: {
+                labels: labels,
+                datasets: [
+                    { label: 'Essential', data: essential, backgroundColor: cv('--h-chart-danger') },
+                    { label: 'Important', data: important, backgroundColor: cv('--h-chart-warning') },
+                    { label: 'Normal', data: normal, backgroundColor: cv('--h-chart-muted') }
+                ]
+            },
+            options: {
+                responsive: true,
+                scales: {
+                    x: { stacked: true },
+                    y: { stacked: true, beginAtZero: true, title: { display: true, text: 'Hours' } }
+                },
+                plugins: {
+                    tooltip: {
+                        callbacks: {
+                            label: function(ctx) { return ctx.dataset.label + ': ' + ctx.parsed.y + 'h'; }
+                        }
+                    }
+                }
+            }
+        });
+    };
+    </script>
+
+    <div class="card mb-4">
+        <div class="card-header"><h6 class="mb-0">Staffing Hours by Priority</h6></div>
+        <div class="card-body">
+            <canvas id="@chartKey" height="100"></canvas>
+        </div>
+    </div>
+}

--- a/src/Humans.Web/Views/ShiftAdmin/Index.cshtml
+++ b/src/Humans.Web/Views/ShiftAdmin/Index.cshtml
@@ -32,6 +32,9 @@
     @* Build/Strike Staffing Chart *@
     @await Html.PartialAsync("_StaffingChart", (Model.StaffingData, "deptStaffingChart"))
 
+    @* Staffing Hours by Priority *@
+    @await Html.PartialAsync("_StaffingHoursChart", (Model.StaffingHours, "deptStaffingHoursChart"))
+
     @* Pending Approvals *@
     @if (Model.PendingSignups.Count > 0 && Model.CanApproveSignups)
     {

--- a/src/Humans.Web/Views/ShiftDashboard/Index.cshtml
+++ b/src/Humans.Web/Views/ShiftDashboard/Index.cshtml
@@ -44,6 +44,9 @@
     @* Staffing chart *@
     @await Html.PartialAsync("_StaffingChart", (Model.StaffingData, "dashboardStaffingChart"))
 
+    @* Staffing hours chart *@
+    @await Html.PartialAsync("_StaffingHoursChart", (Model.StaffingHours, "dashboardStaffingHoursChart"))
+
     @* Urgency table *@
     @if (Model.Shifts.Count == 0)
     {

--- a/src/Humans.Web/Views/TeamAdmin/Roles.cshtml
+++ b/src/Humans.Web/Views/TeamAdmin/Roles.cshtml
@@ -109,10 +109,17 @@
                         var hasAssignments = role.Slots.Any(s => s.IsFilled);
                     }
                     <div class="mb-3 form-check">
-                        @if (role.IsManagement && hasAssignments)
+                        @if (!Model.CanToggleManagement || (role.IsManagement && hasAssignments))
                         {
-                            <input type="hidden" name="IsManagement" value="true" />
-                            <input type="checkbox" class="form-check-input" id="isManagement-@role.Id" checked disabled />
+                            <input type="hidden" name="IsManagement" value="@(role.IsManagement ? "true" : "false")" />
+                            @if (role.IsManagement)
+                            {
+                                <input type="checkbox" class="form-check-input" id="isManagement-@role.Id" checked disabled />
+                            }
+                            else
+                            {
+                                <input type="checkbox" class="form-check-input" id="isManagement-@role.Id" disabled />
+                            }
                         }
                         else
                         {
@@ -122,7 +129,11 @@
                         <label class="form-check-label" for="isManagement-@role.Id">
                             @(Model.IsChildTeam ? "Manager role" : "Coordinator role")
                         </label>
-                        @if (role.IsManagement && hasAssignments)
+                        @if (!Model.CanToggleManagement)
+                        {
+                            <div class="form-text text-muted">Only TeamsAdmin or Admin can change this setting.</div>
+                        }
+                        else if (role.IsManagement && hasAssignments)
                         {
                             <div class="form-text text-warning">Unassign all humans before unchecking.</div>
                         }


### PR DESCRIPTION
## Summary

- **#431** — Restrict "Coordinator role" (`IsManagement`) checkbox to TeamsAdmin and Admin roles. View renders checkbox as disabled for coordinators/managers, server-side strips unauthorized changes and ToggleManagement returns 403.
- **#430** — Add staffing hours chart to Shifts Dashboard showing total work volume per day stacked by priority (Essential/Important/Normal). All-day shifts count as 8h per slot; hours = duration x MaxVolunteers.
- **#448** — Enrich Admin Cache Stats page with live entry counts (tracked via PostEvictionCallbacks), configured TTL per key type, and key type classification (Static/PerUser/PerEntity/RateLimit). Adds a 4th summary card for total active entries.

## Test plan

- [x] Navigate to `/Teams/{slug}/Roles` as a coordinator (not TeamsAdmin/Admin) — IsManagement checkbox should be disabled with help text
- [x] Navigate to `/Teams/{slug}/Roles` as TeamsAdmin or Admin — IsManagement checkbox should be editable
- [ ] Try submitting an edited role with IsManagement changed as a coordinator via DevTools — server should preserve existing value
- [ ] Navigate to `/Shifts/Dashboard` — new "Staffing Hours by Priority" chart should appear below existing period charts
- [ ] Verify chart shows Essential (red) stacked at bottom, Important (yellow) in middle, Normal (gray) on top
- [x] Navigate to `/Admin/CacheStats` — table should show Entries, TTL, and Type columns
- [x] Verify summary cards include "Active Entries" count
- [x] Sort by new columns — sorting should work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)