### PR TITLE
Sprint batch 1: Quick fixes (#442, #440, #441, #424, #447)

### DIFF
--- a/src/Humans.Application/Interfaces/IProfileService.cs
+++ b/src/Humans.Application/Interfaces/IProfileService.cs
@@ -87,6 +87,12 @@ public interface IProfileService
     Task<IReadOnlyList<HumanSearchResult>> SearchHumansAsync(string query, CancellationToken ct = default);
 
     /// <summary>
+    /// Gets a cached profile by user ID from the in-memory cache.
+    /// Returns null on cache miss (no DB query).
+    /// </summary>
+    CachedProfile? GetCachedProfile(Guid userId);
+
+    /// <summary>
     /// Updates a single entry in the approved profiles cache.
     /// Pass null to remove the entry (e.g., on suspension/deletion).
     /// </summary>

--- a/src/Humans.Application/Interfaces/ITeamService.cs
+++ b/src/Humans.Application/Interfaces/ITeamService.cs
@@ -86,6 +86,8 @@ public record TeamRosterSlotSummary(
     Guid? AssignedUserId,
     string? AssignedUserName);
 
+public record TeamOptionDto(Guid Id, string Name);
+
 public record AdminTeamSummary(
     Guid Id,
     string Name,
@@ -330,6 +332,11 @@ public interface ITeamService
     Task<IReadOnlyDictionary<Guid, List<string>>> GetNonSystemTeamNamesByUserIdsAsync(
         IEnumerable<Guid> userIds,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets active teams as lightweight Id+Name options for dropdown lists.
+    /// </summary>
+    Task<IReadOnlyList<TeamOptionDto>> GetActiveTeamOptionsAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Gets all teams for admin list with active member counts and pending request counts.

--- a/src/Humans.Infrastructure/Services/FeedbackService.cs
+++ b/src/Humans.Infrastructure/Services/FeedbackService.cs
@@ -382,11 +382,14 @@ public class FeedbackService : IFeedbackService
     public async Task<IReadOnlyList<(Guid UserId, string DisplayName, int Count)>> GetDistinctReportersAsync(
         CancellationToken cancellationToken = default)
     {
-        return await _dbContext.FeedbackReports
+        var reports = await _dbContext.FeedbackReports
             .Include(f => f.User)
-            .GroupBy(f => new { f.UserId, f.User.DisplayName })
-            .Select(g => ValueTuple.Create(g.Key.UserId, g.Key.DisplayName, g.Count()))
-            .OrderBy(r => r.Item2)
             .ToListAsync(cancellationToken);
+
+        return reports
+            .GroupBy(f => new { f.UserId, f.User.DisplayName })
+            .Select(g => (g.Key.UserId, g.Key.DisplayName, g.Count()))
+            .OrderBy(r => r.DisplayName, StringComparer.OrdinalIgnoreCase)
+            .ToList();
     }
 }

--- a/src/Humans.Infrastructure/Services/ProfileService.cs
+++ b/src/Humans.Infrastructure/Services/ProfileService.cs
@@ -754,6 +754,18 @@ public class ProfileService : IProfileService
         }) ?? new();
     }
 
+    public CachedProfile? GetCachedProfile(Guid userId)
+    {
+        if (_cache.TryGetExistingValue<ConcurrentDictionary<Guid, CachedProfile>>(
+                CacheKeys.ApprovedProfiles, out var cached)
+            && cached.TryGetValue(userId, out var profile))
+        {
+            return profile;
+        }
+
+        return null;
+    }
+
     public void UpdateProfileCache(Guid userId, CachedProfile? newValue)
         => _cache.UpdateApprovedProfile(userId, newValue);
 

--- a/src/Humans.Infrastructure/Services/TeamService.cs
+++ b/src/Humans.Infrastructure/Services/TeamService.cs
@@ -190,6 +190,16 @@ public class TeamService : ITeamService
             .ToListAsync(cancellationToken);
     }
 
+    public async Task<IReadOnlyList<TeamOptionDto>> GetActiveTeamOptionsAsync(CancellationToken cancellationToken = default)
+    {
+        return await _dbContext.Teams
+            .AsNoTracking()
+            .Where(t => t.IsActive)
+            .OrderBy(t => t.Name)
+            .Select(t => new TeamOptionDto(t.Id, t.Name))
+            .ToListAsync(cancellationToken);
+    }
+
     public async Task<TeamDirectoryResult> GetTeamDirectoryAsync(
         Guid? userId,
         CancellationToken cancellationToken = default)

--- a/src/Humans.Web/Controllers/BudgetController.cs
+++ b/src/Humans.Web/Controllers/BudgetController.cs
@@ -16,12 +16,14 @@ namespace Humans.Web.Controllers;
 public class BudgetController : HumansControllerBase
 {
     private readonly IBudgetService _budgetService;
+    private readonly ITeamService _teamService;
     private readonly HumansDbContext _dbContext;
     private readonly IAuthorizationService _authService;
     private readonly ILogger<BudgetController> _logger;
 
     public BudgetController(
         IBudgetService budgetService,
+        ITeamService teamService,
         HumansDbContext dbContext,
         IAuthorizationService authService,
         UserManager<User> userManager,
@@ -29,6 +31,7 @@ public class BudgetController : HumansControllerBase
         : base(userManager)
     {
         _budgetService = budgetService;
+        _teamService = teamService;
         _dbContext = dbContext;
         _authService = authService;
         _logger = logger;
@@ -140,11 +143,7 @@ public class BudgetController : HumansControllerBase
 
             var canEdit = category.TeamId.HasValue && coordinatorTeamIds.Contains(category.TeamId.Value);
 
-            var teams = await _dbContext.Teams
-                .Where(t => t.IsActive)
-                .OrderBy(t => t.Name)
-                .Select(t => new TeamOption { Id = t.Id, Name = t.Name })
-                .ToListAsync();
+            var teams = await _teamService.GetActiveTeamOptionsAsync();
 
             var model = new CoordinatorCategoryDetailViewModel
             {

--- a/src/Humans.Web/Controllers/FeedbackController.cs
+++ b/src/Humans.Web/Controllers/FeedbackController.cs
@@ -55,16 +55,11 @@ public class FeedbackController : HumansControllerBase
             unassignedOnly: isAdmin && unassigned ? true : null);
 
         var assigneeOptions = new List<AssigneeOption>();
-        var teamOptions = new List<TeamOption>();
+        var teamOptions = new List<TeamOptionDto>();
 
         if (isAdmin)
         {
-            var allTeams = await _teamService.GetAllTeamsAsync();
-            teamOptions = allTeams
-                .Where(t => t.IsActive)
-                .OrderBy(t => t.Name, StringComparer.OrdinalIgnoreCase)
-                .Select(t => new TeamOption { Id = t.Id, Name = t.Name })
-                .ToList();
+            teamOptions = (await _teamService.GetActiveTeamOptionsAsync()).ToList();
 
             var humans = await _profileService.GetFilteredHumansAsync(null, "Active");
             assigneeOptions = humans
@@ -348,22 +343,17 @@ public class FeedbackController : HumansControllerBase
 
     private async Task PopulateAssignmentOptionsAsync(FeedbackDetailViewModel viewModel)
     {
-        var allTeams = await _teamService.GetAllTeamsAsync();
-        viewModel.TeamOptions = allTeams
-            .Where(t => t.IsActive)
-            .OrderBy(t => t.Name, StringComparer.OrdinalIgnoreCase)
-            .Select(t => new TeamOption { Id = t.Id, Name = t.Name })
-            .ToList();
+        viewModel.TeamOptions = (await _teamService.GetActiveTeamOptionsAsync()).ToList();
 
         // Include currently assigned team even if inactive, to prevent silent clearing
         if (viewModel.AssignedToTeamId.HasValue &&
             viewModel.TeamOptions.All(t => t.Id != viewModel.AssignedToTeamId.Value))
         {
-            var inactiveTeam = allTeams.FirstOrDefault(t => t.Id == viewModel.AssignedToTeamId.Value);
+            var inactiveTeam = await _teamService.GetTeamByIdAsync(viewModel.AssignedToTeamId.Value);
             if (inactiveTeam is not null)
             {
                 viewModel.TeamOptions.Insert(0,
-                    new TeamOption { Id = inactiveTeam.Id, Name = $"{inactiveTeam.Name} (inactive)" });
+                    new TeamOptionDto(inactiveTeam.Id, $"{inactiveTeam.Name} (inactive)"));
             }
         }
 

--- a/src/Humans.Web/Controllers/FinanceController.cs
+++ b/src/Humans.Web/Controllers/FinanceController.cs
@@ -1,13 +1,11 @@
 using Humans.Application.Interfaces;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
-using Humans.Infrastructure.Data;
 using Humans.Web.Authorization;
 using Humans.Web.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
 using NodaTime;
 
 namespace Humans.Web.Controllers;
@@ -17,24 +15,24 @@ namespace Humans.Web.Controllers;
 public class FinanceController : HumansControllerBase
 {
     private readonly IBudgetService _budgetService;
+    private readonly ITeamService _teamService;
     private readonly ITicketingBudgetService _ticketingBudgetService;
     private readonly ITicketQueryService _ticketQueryService;
-    private readonly HumansDbContext _dbContext;
     private readonly ILogger<FinanceController> _logger;
 
     public FinanceController(
         IBudgetService budgetService,
+        ITeamService teamService,
         ITicketingBudgetService ticketingBudgetService,
         ITicketQueryService ticketQueryService,
-        HumansDbContext dbContext,
         UserManager<User> userManager,
         ILogger<FinanceController> logger)
         : base(userManager)
     {
         _budgetService = budgetService;
+        _teamService = teamService;
         _ticketingBudgetService = ticketingBudgetService;
         _ticketQueryService = ticketQueryService;
-        _dbContext = dbContext;
         _logger = logger;
     }
 
@@ -90,11 +88,7 @@ public class FinanceController : HumansControllerBase
             var category = await _budgetService.GetCategoryByIdAsync(id);
             if (category is null) return NotFound();
 
-            ViewBag.Teams = await _dbContext.Teams
-                .Where(t => t.IsActive)
-                .OrderBy(t => t.Name)
-                .Select(t => new { t.Id, t.Name })
-                .ToListAsync();
+            ViewBag.Teams = await _teamService.GetActiveTeamOptionsAsync();
 
             return View(category);
         }

--- a/src/Humans.Web/Models/BudgetViewModels.cs
+++ b/src/Humans.Web/Models/BudgetViewModels.cs
@@ -1,3 +1,4 @@
+using Humans.Application.Interfaces;
 using Humans.Domain.Entities;
 using NodaTime;
 
@@ -28,13 +29,7 @@ public class CoordinatorCategoryDetailViewModel
     public required BudgetCategory Category { get; init; }
     public bool CanEdit { get; init; }
     public bool IsFinanceAdmin { get; init; }
-    public required IReadOnlyList<TeamOption> Teams { get; init; }
-}
-
-public class TeamOption
-{
-    public Guid Id { get; init; }
-    public string Name { get; init; } = string.Empty;
+    public required IReadOnlyList<TeamOptionDto> Teams { get; init; }
 }
 
 public class BudgetSummaryViewModel

--- a/src/Humans.Web/Models/FeedbackViewModels.cs
+++ b/src/Humans.Web/Models/FeedbackViewModels.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
+using Humans.Application.Interfaces;
 using Humans.Domain.Enums;
 
 namespace Humans.Web.Models;
@@ -36,7 +37,7 @@ public class FeedbackPageViewModel
     public Guid? SelectedReportId { get; set; }
     public Guid CurrentUserId { get; set; }
     public List<AssigneeOption> AssigneeOptions { get; set; } = new();
-    public List<TeamOption> TeamOptions { get; set; } = new();
+    public List<TeamOptionDto> TeamOptions { get; set; } = new();
 }
 
 public class AssigneeOption
@@ -95,7 +96,7 @@ public class FeedbackDetailViewModel
     public Guid? AssignedToTeamId { get; set; }
     public string? AssignedToTeamName { get; set; }
     public List<AssigneeOption> AssigneeOptions { get; set; } = new();
-    public List<TeamOption> TeamOptions { get; set; } = new();
+    public List<TeamOptionDto> TeamOptions { get; set; } = new();
     public List<FeedbackMessageViewModel> Messages { get; set; } = new();
 }
 

--- a/src/Humans.Web/TagHelpers/HumanLinkTagHelper.cs
+++ b/src/Humans.Web/TagHelpers/HumanLinkTagHelper.cs
@@ -1,4 +1,5 @@
 using System.Text.Encodings.Web;
+using Humans.Application.Interfaces;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Mvc.Routing;
@@ -15,10 +16,12 @@ namespace Humans.Web.TagHelpers;
 public class HumanLinkTagHelper : TagHelper
 {
     private readonly IUrlHelperFactory _urlHelperFactory;
+    private readonly IProfileService _profileService;
 
-    public HumanLinkTagHelper(IUrlHelperFactory urlHelperFactory)
+    public HumanLinkTagHelper(IUrlHelperFactory urlHelperFactory, IProfileService profileService)
     {
         _urlHelperFactory = urlHelperFactory;
+        _profileService = profileService;
     }
 
     [HtmlAttributeNotBound]
@@ -68,6 +71,21 @@ public class HumanLinkTagHelper : TagHelper
         // Respect suppression from earlier tag helpers (e.g., AuthorizeViewTagHelper)
         if (output.TagName is null)
             return;
+
+        // Resolve display name and profile picture from cache when not explicitly provided
+        if (string.IsNullOrEmpty(DisplayName) && UserId != Guid.Empty)
+        {
+            var cached = _profileService.GetCachedProfile(UserId);
+            if (cached is not null)
+            {
+                DisplayName = cached.DisplayName;
+                ProfilePictureUrl ??= cached.ProfilePictureUrl;
+            }
+            else
+            {
+                DisplayName = "Unknown";
+            }
+        }
 
         var urlHelper = _urlHelperFactory.GetUrlHelper(ViewContext);
         var href = Admin

--- a/src/Humans.Web/ViewComponents/ProfileCardViewComponent.cs
+++ b/src/Humans.Web/ViewComponents/ProfileCardViewComponent.cs
@@ -112,7 +112,8 @@ public class ProfileCardViewComponent : ViewComponent
             ? await _dbContext.ProfileLanguages
                 .AsNoTracking()
                 .Where(pl => pl.ProfileId == profile.Id)
-                .OrderBy(pl => pl.LanguageCode)
+                .OrderByDescending(pl => pl.Proficiency)
+                .ThenBy(pl => pl.LanguageCode)
                 .ToListAsync()
             : [];
 

--- a/src/Humans.Web/ViewComponents/UserAvatarViewComponent.cs
+++ b/src/Humans.Web/ViewComponents/UserAvatarViewComponent.cs
@@ -1,16 +1,36 @@
+using Humans.Application.Interfaces;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Humans.Web.ViewComponents;
 
 public class UserAvatarViewComponent : ViewComponent
 {
+    private readonly IProfileService _profileService;
+
+    public UserAvatarViewComponent(IProfileService profileService)
+    {
+        _profileService = profileService;
+    }
+
     public IViewComponentResult Invoke(
-        string? profilePictureUrl,
-        string? displayName,
+        string? profilePictureUrl = null,
+        string? displayName = null,
         int size = 40,
         string? cssClass = null,
-        string bgColor = "bg-secondary")
+        string bgColor = "bg-secondary",
+        Guid? userId = null)
     {
+        // Resolve from cache when userId is provided and displayName/profilePictureUrl are not
+        if (userId.HasValue && userId.Value != Guid.Empty && string.IsNullOrEmpty(displayName))
+        {
+            var cached = _profileService.GetCachedProfile(userId.Value);
+            if (cached is not null)
+            {
+                displayName = cached.DisplayName;
+                profilePictureUrl ??= cached.ProfilePictureUrl;
+            }
+        }
+
         var initial = string.IsNullOrEmpty(displayName) ? "?" : displayName[0].ToString();
 
         // Scale font size proportionally: roughly size * 0.4 as rem, capped reasonably

--- a/src/Humans.Web/Views/Profile/Edit.cshtml
+++ b/src/Humans.Web/Views/Profile/Edit.cshtml
@@ -961,6 +961,24 @@
         })();
     </script>
     <script>
+        // Toggle volunteer history section visibility based on "No Prior Burn Experience" checkbox
+        (function() {
+            const checkbox = document.getElementById('noPriorBurnCheckbox');
+            const historyContainer = document.getElementById('volunteerHistoryContainer');
+            const addButton = document.getElementById('addVolunteerHistory');
+            if (!checkbox || !historyContainer || !addButton) return;
+
+            function toggleHistorySection() {
+                const hide = checkbox.checked;
+                historyContainer.style.display = hide ? 'none' : '';
+                addButton.style.display = hide ? 'none' : '';
+            }
+
+            toggleHistorySection();
+            checkbox.addEventListener('change', toggleHistorySection);
+        })();
+    </script>
+    <script>
         // Unsaved-changes guard
         (function () {
             const form = document.querySelector('form[action*="Edit"]');


### PR DESCRIPTION
## Summary

- **#442** — Fix Feedback page crash from untranslatable LINQ GroupBy: materialize with `ToListAsync()` before `GroupBy` to avoid EF Core/Npgsql translation failure
- **#440** — Toggle volunteer history section visibility based on "No Prior Burn Experience" checkbox state on profile edit page
- **#441** — Sort profile card languages by descending proficiency (Native first), then alphabetically by language code
- **#424** — Extract team dropdown queries from BudgetController and FinanceController into shared `ITeamService.GetActiveTeamOptionsAsync()` method
- **#447** — Make `<human-link>` tag helper and `UserAvatarViewComponent` self-resolving from user ID via in-memory profile cache, making `display-name` optional

## Test plan

- [x] `/Feedback` page loads without 500 error; reporter filter dropdown populates correctly
- [x] Profile edit page: checking "No Prior Burn Experience" hides volunteer history rows and add button; unchecking shows them again
- [x] Profile card languages display Native before Basic within the same profile
- [x] Budget coordinator category detail page loads with team dropdown populated
- [x] Finance category detail page loads with team dropdown populated
- [x] `<human-link user-id="@guid" />` without `display-name` renders correct burner name and avatar
- [x] Existing `<human-link>` usages with explicit `display-name` still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)