### PR TITLE
Add resource-based auth for department-scoped budget editing (#415)

### DIFF
--- a/docs/features/31-budget.md
+++ b/docs/features/31-budget.md
@@ -199,7 +199,7 @@ Outbound invoices to members/barrios:
   - Can add/edit/delete line items within own department only
   - Per-category unallocated remainder and progress bar
   - `IsRestricted` groups hidden from coordinator view
-  - Authorization uses `GetEffectiveCoordinatorTeamIdsAsync` (includes child teams)
+  - Authorization uses resource-based auth via `BudgetAuthorizationHandler` + `BudgetOperationRequirement.Edit`, which delegates to `GetEffectiveCoordinatorTeamIdsAsync` (includes child teams)
   - All changes audit-logged via existing BudgetAuditLog
 - **Public summary** at `/Budget/Summary` (#234):
   - All authenticated members see budget allocation pie chart (Chart.js doughnut)

--- a/src/Humans.Web/Authorization/AuthorizationPolicyExtensions.cs
+++ b/src/Humans.Web/Authorization/AuthorizationPolicyExtensions.cs
@@ -18,6 +18,9 @@ public static class AuthorizationPolicyExtensions
         services.AddSingleton<IAuthorizationHandler, IsActiveMemberHandler>();
         services.AddSingleton<IAuthorizationHandler, HumanAdminOnlyHandler>();
 
+        // Resource-based authorization handlers (scoped — they depend on scoped services)
+        services.AddScoped<IAuthorizationHandler, BudgetAuthorizationHandler>();
+
         services.AddAuthorization(options =>
         {
             // Simple role-based policies

--- a/src/Humans.Web/Authorization/Requirements/BudgetAuthorizationHandler.cs
+++ b/src/Humans.Web/Authorization/Requirements/BudgetAuthorizationHandler.cs
@@ -1,0 +1,64 @@
+using System.Security.Claims;
+using Humans.Application.Interfaces;
+using Humans.Domain.Entities;
+using Microsoft.AspNetCore.Authorization;
+
+namespace Humans.Web.Authorization.Requirements;
+
+/// <summary>
+/// Resource-based authorization handler for budget operations.
+/// Evaluates whether a user can perform budget operations on a specific BudgetCategory.
+///
+/// Authorization logic:
+/// - Admin: allow any category
+/// - FinanceAdmin: allow any category
+/// - Department coordinator: allow only categories linked to their department
+/// - Everyone else: deny
+///
+/// Also denies edits on restricted groups and deleted budget years for non-admin users.
+/// </summary>
+public class BudgetAuthorizationHandler : AuthorizationHandler<BudgetOperationRequirement, BudgetCategory>
+{
+    private readonly IBudgetService _budgetService;
+
+    public BudgetAuthorizationHandler(IBudgetService budgetService)
+    {
+        _budgetService = budgetService;
+    }
+
+    protected override async Task HandleRequirementAsync(
+        AuthorizationHandlerContext context,
+        BudgetOperationRequirement requirement,
+        BudgetCategory resource)
+    {
+        // Admin and FinanceAdmin can edit any budget category
+        if (RoleChecks.IsFinanceAdmin(context.User))
+        {
+            context.Succeed(requirement);
+            return;
+        }
+
+        // Non-admin: deny on deleted budget years
+        if (resource.BudgetGroup?.BudgetYear?.IsDeleted == true)
+            return;
+
+        // Non-admin: deny on restricted groups
+        if (resource.BudgetGroup?.IsRestricted == true)
+            return;
+
+        // Category must be linked to a team for coordinator-based access
+        if (!resource.TeamId.HasValue)
+            return;
+
+        // Check if user is a coordinator for the category's department
+        var userIdClaim = context.User.FindFirst(ClaimTypes.NameIdentifier);
+        if (userIdClaim is null || !Guid.TryParse(userIdClaim.Value, out var userId))
+            return;
+
+        var coordinatorTeamIds = await _budgetService.GetEffectiveCoordinatorTeamIdsAsync(userId);
+        if (coordinatorTeamIds.Contains(resource.TeamId.Value))
+        {
+            context.Succeed(requirement);
+        }
+    }
+}

--- a/src/Humans.Web/Authorization/Requirements/BudgetOperationRequirement.cs
+++ b/src/Humans.Web/Authorization/Requirements/BudgetOperationRequirement.cs
@@ -1,0 +1,20 @@
+using Microsoft.AspNetCore.Authorization;
+
+namespace Humans.Web.Authorization.Requirements;
+
+/// <summary>
+/// Resource-based authorization requirement for budget operations.
+/// Used with IAuthorizationService.AuthorizeAsync(User, resource, requirement)
+/// where the resource is a BudgetCategory.
+/// </summary>
+public sealed class BudgetOperationRequirement : IAuthorizationRequirement
+{
+    public static readonly BudgetOperationRequirement Edit = new(nameof(Edit));
+
+    public string OperationName { get; }
+
+    private BudgetOperationRequirement(string operationName)
+    {
+        OperationName = operationName;
+    }
+}

--- a/src/Humans.Web/Controllers/BudgetController.cs
+++ b/src/Humans.Web/Controllers/BudgetController.cs
@@ -2,6 +2,7 @@ using Humans.Application.Interfaces;
 using Humans.Domain.Entities;
 using Humans.Infrastructure.Data;
 using Humans.Web.Authorization;
+using Humans.Web.Authorization.Requirements;
 using Humans.Web.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
@@ -138,7 +139,8 @@ public class BudgetController : HumansControllerBase
             if (!isFinanceAdmin && coordinatorTeamIds.Count == 0)
                 return Forbid();
 
-            var canEdit = category.TeamId.HasValue && coordinatorTeamIds.Contains(category.TeamId.Value);
+            // Use resource-based authorization to determine edit access
+            var canEdit = (await _authService.AuthorizeAsync(User, category, BudgetOperationRequirement.Edit)).Succeeded;
 
             var teams = await _dbContext.Teams
                 .Where(t => t.IsActive)
@@ -149,7 +151,7 @@ public class BudgetController : HumansControllerBase
             var model = new CoordinatorCategoryDetailViewModel
             {
                 Category = category,
-                CanEdit = canEdit || isFinanceAdmin,
+                CanEdit = canEdit,
                 IsFinanceAdmin = isFinanceAdmin,
                 Teams = teams
             };
@@ -171,7 +173,7 @@ public class BudgetController : HumansControllerBase
         var (errorResult, user) = await RequireCurrentUserAsync();
         if (errorResult is not null) return errorResult;
 
-        var authResult = await AuthorizeCategoryEditAsync(budgetCategoryId, user.Id);
+        var authResult = await AuthorizeCategoryEditAsync(budgetCategoryId);
         if (authResult is not null) return authResult;
 
         var nodaDate = expectedDate.HasValue ? LocalDate.FromDateTime(expectedDate.Value) : (LocalDate?)null;
@@ -200,7 +202,7 @@ public class BudgetController : HumansControllerBase
         var lineItem = await _dbContext.BudgetLineItems.FindAsync(id);
         if (lineItem is null) return NotFound();
 
-        var authResult = await AuthorizeCategoryEditAsync(lineItem.BudgetCategoryId, user.Id);
+        var authResult = await AuthorizeCategoryEditAsync(lineItem.BudgetCategoryId);
         if (authResult is not null) return authResult;
 
         var nodaDate = expectedDate.HasValue ? LocalDate.FromDateTime(expectedDate.Value) : (LocalDate?)null;
@@ -228,7 +230,7 @@ public class BudgetController : HumansControllerBase
         var lineItem = await _dbContext.BudgetLineItems.FindAsync(id);
         if (lineItem is null) return NotFound();
 
-        var authResult = await AuthorizeCategoryEditAsync(lineItem.BudgetCategoryId, user.Id);
+        var authResult = await AuthorizeCategoryEditAsync(lineItem.BudgetCategoryId);
         if (authResult is not null) return authResult;
 
         try
@@ -244,26 +246,20 @@ public class BudgetController : HumansControllerBase
         return RedirectToAction(nameof(CategoryDetail), new { id = lineItem.BudgetCategoryId });
     }
 
-    private async Task<IActionResult?> AuthorizeCategoryEditAsync(Guid categoryId, Guid userId)
+    /// <summary>
+    /// Loads the budget category and evaluates the resource-based BudgetOperationRequirement.Edit
+    /// authorization requirement. Returns an IActionResult to short-circuit the action if denied,
+    /// or null if authorized.
+    /// </summary>
+    private async Task<IActionResult?> AuthorizeCategoryEditAsync(Guid categoryId)
     {
-        if ((await _authService.AuthorizeAsync(User, PolicyNames.FinanceAdminOrAdmin)).Succeeded)
-            return null;
-
         var category = await _budgetService.GetCategoryByIdAsync(categoryId);
         if (category is null) return NotFound();
 
-        if (category.BudgetGroup?.BudgetYear?.IsDeleted == true) return NotFound();
-
-        if (category.BudgetGroup?.IsRestricted == true)
-            return Forbid();
-
-        if (!category.TeamId.HasValue)
-            return Forbid();
-
-        var coordinatorTeamIds = await _budgetService.GetEffectiveCoordinatorTeamIdsAsync(userId);
-        if (!coordinatorTeamIds.Contains(category.TeamId.Value))
+        var result = await _authService.AuthorizeAsync(User, category, BudgetOperationRequirement.Edit);
+        if (!result.Succeeded)
         {
-            SetError("You can only edit line items in your own department's budget.");
+            SetError("You do not have permission to edit this budget category.");
             return RedirectToAction(nameof(CategoryDetail), new { id = categoryId });
         }
 

--- a/tests/Humans.Application.Tests/Authorization/AuthorizationPolicyTests.cs
+++ b/tests/Humans.Application.Tests/Authorization/AuthorizationPolicyTests.cs
@@ -1,10 +1,12 @@
 using System.Security.Claims;
 using AwesomeAssertions;
+using Humans.Application.Interfaces;
 using Humans.Domain.Constants;
 using Humans.Web.Authorization;
 using Humans.Web.Authorization.Requirements;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
 using Xunit;
 
 namespace Humans.Application.Tests.Authorization;
@@ -22,6 +24,8 @@ public class AuthorizationPolicyTests : IDisposable
     {
         var services = new ServiceCollection();
         services.AddLogging();
+        // Register IBudgetService stub required by BudgetAuthorizationHandler
+        services.AddScoped(_ => Substitute.For<IBudgetService>());
         services.AddHumansAuthorizationPolicies();
         _serviceProvider = services.BuildServiceProvider();
         _authorizationService = _serviceProvider.GetRequiredService<IAuthorizationService>();

--- a/tests/Humans.Application.Tests/Authorization/BudgetAuthorizationHandlerTests.cs
+++ b/tests/Humans.Application.Tests/Authorization/BudgetAuthorizationHandlerTests.cs
@@ -1,0 +1,280 @@
+using System.Security.Claims;
+using AwesomeAssertions;
+using Humans.Application.Interfaces;
+using Humans.Domain.Constants;
+using Humans.Domain.Entities;
+using Humans.Web.Authorization.Requirements;
+using Microsoft.AspNetCore.Authorization;
+using NSubstitute;
+using Xunit;
+
+namespace Humans.Application.Tests.Authorization;
+
+/// <summary>
+/// Unit tests for BudgetAuthorizationHandler — the first resource-based authorization handler.
+/// Tests cover: Admin override, FinanceAdmin override, department coordinator access,
+/// denial for non-coordinators, restricted groups, deleted years, null team, and edge cases.
+/// </summary>
+public sealed class BudgetAuthorizationHandlerTests
+{
+    private readonly IBudgetService _budgetService = Substitute.For<IBudgetService>();
+    private readonly BudgetAuthorizationHandler _handler;
+
+    private static readonly Guid CoordinatorTeamId = Guid.NewGuid();
+    private static readonly Guid OtherTeamId = Guid.NewGuid();
+    private static readonly Guid UserId = Guid.NewGuid();
+
+    public BudgetAuthorizationHandlerTests()
+    {
+        _handler = new BudgetAuthorizationHandler(_budgetService);
+
+        _budgetService.GetEffectiveCoordinatorTeamIdsAsync(UserId)
+            .Returns(new HashSet<Guid> { CoordinatorTeamId });
+    }
+
+    // --- Admin override ---
+
+    [Fact]
+    public async Task Admin_CanEditAnyCategory()
+    {
+        var user = CreateUserWithRoles(RoleNames.Admin);
+        var category = CreateCategory(OtherTeamId);
+
+        var result = await EvaluateAsync(user, category);
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Admin_CanEditRestrictedGroupCategory()
+    {
+        var user = CreateUserWithRoles(RoleNames.Admin);
+        var category = CreateCategory(OtherTeamId, isRestricted: true);
+
+        var result = await EvaluateAsync(user, category);
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Admin_CanEditDeletedYearCategory()
+    {
+        var user = CreateUserWithRoles(RoleNames.Admin);
+        var category = CreateCategory(OtherTeamId, isDeleted: true);
+
+        var result = await EvaluateAsync(user, category);
+
+        result.Should().BeTrue();
+    }
+
+    // --- FinanceAdmin override ---
+
+    [Fact]
+    public async Task FinanceAdmin_CanEditAnyCategory()
+    {
+        var user = CreateUserWithRoles(RoleNames.FinanceAdmin);
+        var category = CreateCategory(OtherTeamId);
+
+        var result = await EvaluateAsync(user, category);
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task FinanceAdmin_CanEditRestrictedGroupCategory()
+    {
+        var user = CreateUserWithRoles(RoleNames.FinanceAdmin);
+        var category = CreateCategory(OtherTeamId, isRestricted: true);
+
+        var result = await EvaluateAsync(user, category);
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task FinanceAdmin_CanEditCategoryWithNoTeam()
+    {
+        var user = CreateUserWithRoles(RoleNames.FinanceAdmin);
+        var category = CreateCategory(teamId: null);
+
+        var result = await EvaluateAsync(user, category);
+
+        result.Should().BeTrue();
+    }
+
+    // --- Department coordinator access ---
+
+    [Fact]
+    public async Task Coordinator_CanEditOwnDepartmentCategory()
+    {
+        var user = CreateUser(UserId);
+        var category = CreateCategory(CoordinatorTeamId);
+
+        var result = await EvaluateAsync(user, category);
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Coordinator_CannotEditOtherDepartmentCategory()
+    {
+        var user = CreateUser(UserId);
+        var category = CreateCategory(OtherTeamId);
+
+        var result = await EvaluateAsync(user, category);
+
+        result.Should().BeFalse();
+    }
+
+    // --- Denial cases ---
+
+    [Fact]
+    public async Task Coordinator_DeniedOnRestrictedGroup()
+    {
+        var user = CreateUser(UserId);
+        var category = CreateCategory(CoordinatorTeamId, isRestricted: true);
+
+        var result = await EvaluateAsync(user, category);
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Coordinator_DeniedOnDeletedYear()
+    {
+        var user = CreateUser(UserId);
+        var category = CreateCategory(CoordinatorTeamId, isDeleted: true);
+
+        var result = await EvaluateAsync(user, category);
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Coordinator_DeniedOnCategoryWithNoTeam()
+    {
+        var user = CreateUser(UserId);
+        var category = CreateCategory(teamId: null);
+
+        var result = await EvaluateAsync(user, category);
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task RegularUser_DeniedOnAnyCategory()
+    {
+        var user = CreateUser(Guid.NewGuid());
+        _budgetService.GetEffectiveCoordinatorTeamIdsAsync(Arg.Any<Guid>())
+            .Returns(new HashSet<Guid>());
+        var category = CreateCategory(CoordinatorTeamId);
+
+        var result = await EvaluateAsync(user, category);
+
+        result.Should().BeFalse();
+    }
+
+    // --- Edge cases ---
+
+    [Fact]
+    public async Task UnauthenticatedUser_Denied()
+    {
+        var user = new ClaimsPrincipal(new ClaimsIdentity());
+        var category = CreateCategory(CoordinatorTeamId);
+
+        var result = await EvaluateAsync(user, category);
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task UserWithInvalidIdClaim_Denied()
+    {
+        var claims = new List<Claim>
+        {
+            new(ClaimTypes.NameIdentifier, "not-a-guid"),
+            new(ClaimTypes.Name, "test@example.com")
+        };
+        var user = new ClaimsPrincipal(new ClaimsIdentity(claims, "TestAuth"));
+        var category = CreateCategory(CoordinatorTeamId);
+
+        var result = await EvaluateAsync(user, category);
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task NullBudgetGroup_CoordinatorStillAllowed()
+    {
+        // Category with a team but no BudgetGroup navigation loaded
+        var user = CreateUser(UserId);
+        var category = new BudgetCategory
+        {
+            Id = Guid.NewGuid(),
+            TeamId = CoordinatorTeamId,
+            BudgetGroup = null
+        };
+
+        var result = await EvaluateAsync(user, category);
+
+        result.Should().BeTrue();
+    }
+
+    // --- Helpers ---
+
+    private async Task<bool> EvaluateAsync(ClaimsPrincipal user, BudgetCategory resource)
+    {
+        var requirement = BudgetOperationRequirement.Edit;
+        var context = new AuthorizationHandlerContext(
+            [requirement], user, resource);
+
+        await _handler.HandleAsync(context);
+        return context.HasSucceeded;
+    }
+
+    private static BudgetCategory CreateCategory(
+        Guid? teamId,
+        bool isRestricted = false,
+        bool isDeleted = false)
+    {
+        return new BudgetCategory
+        {
+            Id = Guid.NewGuid(),
+            TeamId = teamId,
+            BudgetGroup = new BudgetGroup
+            {
+                Id = Guid.NewGuid(),
+                IsRestricted = isRestricted,
+                BudgetYear = new BudgetYear
+                {
+                    Id = Guid.NewGuid(),
+                    IsDeleted = isDeleted
+                }
+            }
+        };
+    }
+
+    private static ClaimsPrincipal CreateUserWithRoles(params string[] roles)
+    {
+        var claims = new List<Claim>
+        {
+            new(ClaimTypes.NameIdentifier, Guid.NewGuid().ToString()),
+            new(ClaimTypes.Name, "admin@example.com")
+        };
+        foreach (var role in roles)
+        {
+            claims.Add(new Claim(ClaimTypes.Role, role));
+        }
+        return new ClaimsPrincipal(new ClaimsIdentity(claims, "TestAuth"));
+    }
+
+    private static ClaimsPrincipal CreateUser(Guid userId)
+    {
+        var claims = new List<Claim>
+        {
+            new(ClaimTypes.NameIdentifier, userId.ToString()),
+            new(ClaimTypes.Name, "coordinator@example.com")
+        };
+        return new ClaimsPrincipal(new ClaimsIdentity(claims, "TestAuth"));
+    }
+}


### PR DESCRIPTION
## Summary
- Implement Phase 2a of the authorization transition plan: resource-based authorization for budget editing
- Add `BudgetOperationRequirement` (sealed requirement with static `Edit` operation) and `BudgetAuthorizationHandler` that evaluates budget category edit permissions against the resource
- Authorization logic: Admin/FinanceAdmin can edit any category, department coordinators can edit only their department's categories, restricted groups and deleted years denied for non-admins
- Refactor `BudgetController.AuthorizeCategoryEditAsync` to use `IAuthorizationService.AuthorizeAsync(User, category, BudgetOperationRequirement.Edit)` instead of inline role/coordinator checks
- Update `CategoryDetail` GET action to use same resource-based auth for `CanEdit` determination
- Add 15 unit tests covering all authorization paths: admin override, FinanceAdmin override, coordinator own/other department, restricted groups, deleted years, null team, unauthenticated, invalid ID, null budget group

## Test plan
- [x] All 15 `BudgetAuthorizationHandlerTests` pass
- [x] All 109 existing `AuthorizationPolicyTests` pass (updated to provide `IBudgetService` stub for DI)
- [x] Full test suite passes (935 tests, 0 failures)
- [x] `dotnet format --verify-no-changes` clean
- [x] QA: verify coordinator can edit own department line items
- [x] QA: verify coordinator cannot edit other department line items
- [x] QA: verify Admin/FinanceAdmin can edit any category
- [x] QA: verify restricted group categories show as non-editable for coordinators

Closes #415

🤖 Generated with [Claude Code](https://claude.com/claude-code)