### PR TITLE
Sprint batch 1: Shift Bugs (#451, #452)

### DIFF
--- a/src/Humans.Infrastructure/Services/ShiftManagementService.cs
+++ b/src/Humans.Infrastructure/Services/ShiftManagementService.cs
@@ -520,7 +520,7 @@ public class ShiftManagementService : IShiftManagementService
 
         if (date.HasValue)
         {
-            var dayOffset = Period.Between(es.GateOpeningDate, date.Value).Days;
+            var dayOffset = Period.Between(es.GateOpeningDate, date.Value, PeriodUnits.Days).Days;
             query = query.Where(s => s.DayOffset == dayOffset);
         }
 
@@ -587,13 +587,13 @@ public class ShiftManagementService : IShiftManagementService
 
         if (fromDate.HasValue)
         {
-            var fromOffset = Period.Between(es.GateOpeningDate, fromDate.Value).Days;
+            var fromOffset = Period.Between(es.GateOpeningDate, fromDate.Value, PeriodUnits.Days).Days;
             query = query.Where(s => s.DayOffset >= fromOffset);
         }
 
         if (toDate.HasValue)
         {
-            var toOffset = Period.Between(es.GateOpeningDate, toDate.Value).Days;
+            var toOffset = Period.Between(es.GateOpeningDate, toDate.Value, PeriodUnits.Days).Days;
             query = query.Where(s => s.DayOffset <= toOffset);
         }
 

--- a/src/Humans.Infrastructure/Services/ShiftSignupService.cs
+++ b/src/Humans.Infrastructure/Services/ShiftSignupService.cs
@@ -992,7 +992,7 @@ public class ShiftSignupService : IShiftSignupService
                 $"Coverage gap: {shift.Rota.Name} day {shift.DayOffset}",
                 coordinatorIds,
                 body: $"Only {confirmedCount}/{shift.MinVolunteers} volunteers confirmed.",
-                actionUrl: $"/Shifts/Dashboard?departmentId={teamId}",
+                actionUrl: $"/Shifts?departmentId={teamId}",
                 actionLabel: "Find cover \u2192");
         }
         catch (Exception ex)
@@ -1037,7 +1037,7 @@ public class ShiftSignupService : IShiftSignupService
                 $"Shift signup change: {rotaName}",
                 coordinatorIds,
                 body: enrichedDescription,
-                actionUrl: $"/Shifts/Dashboard?departmentId={teamId}&rotaId={rota.Id}",
+                actionUrl: $"/Shifts?departmentId={teamId}",
                 actionLabel: "View \u2192");
         }
         catch (Exception ex)


### PR DESCRIPTION
## Summary
- Fix shift notification links to point to browse view instead of dashboard (#451)
- Fix shift period filter to correctly filter by date range (#452)

## Issues
- Closes peterdrier/Humans#451 (upstream: nobodies-collective/Humans#451)
- Closes peterdrier/Humans#452 (upstream: nobodies-collective/Humans#452)

## Test plan
- [ ] Verify shift notifications link to /Shifts instead of /Shifts/Dashboard
- [ ] Verify period filter correctly filters shifts by Set-up/Event/Strike
- [x] Verify dashboard still accessible to privileged users

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>