### PR TITLE
Sprint batch 3: Admin Profile Fixes (#458, #457)

### DIFF
--- a/src/Humans.Infrastructure/Services/ProfileService.cs
+++ b/src/Humans.Infrastructure/Services/ProfileService.cs
@@ -590,11 +590,18 @@ public class ProfileService : IProfileService
             })
             .ToListAsync(ct);
 
+        // Resolve notification-target emails for display (falls back to OAuth email)
+        var notificationEmails = await _dbContext.UserEmails
+            .Where(e => e.IsNotificationTarget && e.IsVerified)
+            .Select(e => new { e.UserId, e.Email })
+            .ToDictionaryAsync(e => e.UserId, e => e.Email, ct);
+
         if (!string.IsNullOrWhiteSpace(search))
         {
             users = users
                 .Where(u =>
                     u.Email.Contains(search, StringComparison.OrdinalIgnoreCase) ||
+                    (notificationEmails.TryGetValue(u.Id, out var ne) && ne.Contains(search, StringComparison.OrdinalIgnoreCase)) ||
                     u.DisplayName.Contains(search, StringComparison.OrdinalIgnoreCase))
                 .ToList();
         }
@@ -621,7 +628,7 @@ public class ProfileService : IProfileService
 
         return rows.Select(r => new Application.DTOs.AdminHumanRow(
             r.Id,
-            r.Email,
+            notificationEmails.TryGetValue(r.Id, out var primaryEmail) ? primaryEmail : r.Email,
             r.DisplayName,
             r.ProfilePictureUrl,
             r.CreatedAt,
@@ -644,6 +651,7 @@ public class ProfileService : IProfileService
             .Include(u => u.Profile)
             .Include(u => u.Applications)
             .Include(u => u.ConsentRecords)
+            .Include(u => u.UserEmails)
             .FirstOrDefaultAsync(u => u.Id == userId, ct);
 
         if (user is null)

--- a/src/Humans.Web/Controllers/ProfileController.cs
+++ b/src/Humans.Web/Controllers/ProfileController.cs
@@ -1290,7 +1290,7 @@ public class ProfileController : HumansControllerBase
         var viewModel = new AdminHumanDetailViewModel
         {
             UserId = data.User.Id,
-            Email = data.User.Email ?? string.Empty,
+            Email = data.User.GetEffectiveEmail() ?? string.Empty,
             DisplayName = data.User.DisplayName,
             ProfilePictureUrl = data.User.ProfilePictureUrl,
             CreatedAt = data.User.CreatedAt.ToDateTimeUtc(),

--- a/src/Humans.Web/Controllers/ProfileController.cs
+++ b/src/Humans.Web/Controllers/ProfileController.cs
@@ -1334,6 +1334,19 @@ public class ProfileController : HumansControllerBase
                 LanguageName = Helpers.LanguageCatalog.GetDisplayName(pl.LanguageCode),
                 Proficiency = pl.Proficiency
             }).ToList(),
+            OAuthEmail = data.User.Email,
+            GoogleServiceEmail = data.User.GetGoogleServiceEmail(),
+            GoogleEmailStatus = data.User.GoogleEmailStatus,
+            UserEmails = data.User.UserEmails
+                .OrderBy(e => e.DisplayOrder)
+                .Select(e => new AdminUserEmailViewModel
+                {
+                    Email = e.Email,
+                    IsOAuth = e.IsOAuth,
+                    IsVerified = e.IsVerified,
+                    IsNotificationTarget = e.IsNotificationTarget,
+                    Visibility = e.Visibility,
+                }).ToList(),
         };
 
         // nobodies.team email is now resolved by NobodiesEmailBadgeViewComponent in the view

--- a/src/Humans.Web/Models/AdminViewModels.cs
+++ b/src/Humans.Web/Models/AdminViewModels.cs
@@ -110,12 +110,27 @@ public class AdminHumanDetailViewModel
     // Workspace email
     public string? NobodiesTeamEmail { get; set; }
 
+    // Email diagnostics (read-only card)
+    public string? OAuthEmail { get; set; }
+    public string? GoogleServiceEmail { get; set; }
+    public GoogleEmailStatus GoogleEmailStatus { get; set; }
+    public List<AdminUserEmailViewModel> UserEmails { get; set; } = [];
+
     // Stats
     public int ApplicationCount { get; set; }
     public int ConsentCount { get; set; }
     public List<AdminHumanApplicationViewModel> Applications { get; set; } = [];
     public List<AdminRoleAssignmentViewModel> RoleAssignments { get; set; } = [];
     public IReadOnlyList<ProfileLanguageDisplayViewModel> Languages { get; set; } = [];
+}
+
+public class AdminUserEmailViewModel
+{
+    public string Email { get; set; } = string.Empty;
+    public bool IsOAuth { get; set; }
+    public bool IsVerified { get; set; }
+    public bool IsNotificationTarget { get; set; }
+    public ContactFieldVisibility? Visibility { get; set; }
 }
 
 public class AdminHumanApplicationViewModel

--- a/src/Humans.Web/Views/Profile/AdminDetail.cshtml
+++ b/src/Humans.Web/Views/Profile/AdminDetail.cshtml
@@ -295,6 +295,77 @@
             </div>
         </div>
 
+        <div class="card mb-4">
+            <div class="card-header"><i class="fa-solid fa-at me-1"></i> Emails</div>
+            <div class="card-body p-0">
+                @if (Model.UserEmails.Count > 0)
+                {
+                    <ul class="list-group list-group-flush">
+                        @foreach (var email in Model.UserEmails)
+                        {
+                            <li class="list-group-item">
+                                <div class="d-flex justify-content-between align-items-start">
+                                    <code class="text-break">@email.Email</code>
+                                    <div class="d-flex gap-1 flex-shrink-0 ms-2">
+                                        @if (email.IsOAuth)
+                                        {
+                                            <span class="badge bg-info" title="OAuth login email">OAuth</span>
+                                        }
+                                        @if (email.IsVerified)
+                                        {
+                                            <span class="badge bg-success" title="Verified">
+                                                <i class="fa-solid fa-check"></i>
+                                            </span>
+                                        }
+                                        else
+                                        {
+                                            <span class="badge bg-warning" title="Unverified">
+                                                <i class="fa-solid fa-clock"></i>
+                                            </span>
+                                        }
+                                        @if (email.IsNotificationTarget)
+                                        {
+                                            <span class="badge bg-primary" title="Notification target">
+                                                <i class="fa-solid fa-bell"></i>
+                                            </span>
+                                        }
+                                    </div>
+                                </div>
+                                @if (email.Visibility.HasValue)
+                                {
+                                    <small class="text-muted">Visibility: @email.Visibility</small>
+                                }
+                            </li>
+                        }
+                    </ul>
+                }
+                else
+                {
+                    <div class="card-body">
+                        <span class="text-muted">No email records</span>
+                    </div>
+                }
+            </div>
+            <div class="card-footer small text-muted">
+                <div class="d-flex justify-content-between">
+                    <span>Google service email:</span>
+                    <code>@(Model.GoogleServiceEmail ?? "—")</code>
+                </div>
+                <div class="d-flex justify-content-between">
+                    <span>Google email status:</span>
+                    @{
+                        var googleStatusBadge = Model.GoogleEmailStatus switch
+                        {
+                            GoogleEmailStatus.Valid => "bg-success",
+                            GoogleEmailStatus.Rejected => "bg-danger",
+                            _ => "bg-secondary"
+                        };
+                    }
+                    <span class="badge @googleStatusBadge">@Model.GoogleEmailStatus</span>
+                </div>
+            </div>
+        </div>
+
         <div class="card">
             <div class="card-header">@Localizer["TeamDetail_Actions"]</div>
             <div class="card-body">


### PR DESCRIPTION
## Summary
- Show primary/notification-target email on Admin pages instead of OAuth signup email (#458)
- Add read-only email card to admin detail page for diagnosing email issues (#457)

## Issues
- Closes peterdrier/Humans#458 (upstream: nobodies-collective/Humans#458)
- Closes peterdrier/Humans#457 (upstream: nobodies-collective/Humans#457)

## Test plan
- [ ] Admin Detail shows primary email (notification target) instead of OAuth email
- [ ] Admin List shows primary email in row subtitle
- [ ] Falls back to OAuth email when no notification target set
- [x] Email card shows all UserEmail records with badges
- [x] Email card shows Google service email and status
- [ ] Email card is read-only (no edit buttons)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>