### PR TITLE
Sprint batch 2: Google Sync Improvements (#454, #453)

### DIFF
--- a/docs/features/07-google-integration.md
+++ b/docs/features/07-google-integration.md
@@ -515,11 +515,11 @@ When system teams are synced, Google permissions are also updated:
 
 The `ProcessGoogleSyncOutboxJob` classifies Google API errors into two categories:
 
-**Permanent failures (HTTP 400, 404):** User-level errors — invalid email format or user not found. The outbox event is marked `FailedPermanently = true` and the user's `GoogleEmailStatus` is set to `Rejected`. While rejected, no new sync events are enqueued for that user. The user must update their Google email (Profile → Emails), which resets `GoogleEmailStatus` to `Unknown` and triggers re-sync for all current team memberships.
+**Permanent failures (HTTP 400, 403, 404):** User-level errors — invalid email format, no Google account for that address, or user not found. The outbox event is marked `FailedPermanently = true` and the user's `GoogleEmailStatus` is set to `Rejected`. While rejected, no new sync events are enqueued for that user and the user is excluded from all sync paths (reconciliation, outbox, direct add). The user must update their Google email (Profile → Emails), which resets `GoogleEmailStatus` to `Unknown` and triggers re-sync for all current team memberships.
 
-**Transient failures (all other errors including 403, 429, 5xx):** Retried up to 10 times. HTTP 403 is treated as transient because it typically indicates a resource-level permission issue (service account lacks access to a Group or Drive), not a user email problem.
+**Transient failures (all other errors including 429, 5xx):** Retried up to 10 times with exponential backoff.
 
-`GoogleEmailStatus` is set to `Valid` only after a successful `AddUserToTeamResources` event where the team has linked Google resources — ensuring the email was actually accepted by a Google API call.
+`GoogleEmailStatus` is set to `Valid` only after a successful `AddUserToTeamResources` event where the team has linked Google resources — ensuring the email was actually accepted by a Google API call. A `Rejected` status is never overwritten with `Valid`; the user must change their email to reset it.
 
 ### Resource-Level Retry Strategy
 ```
@@ -536,7 +536,7 @@ On Google API error (resource provisioning):
 | Rate limit exceeded (429) | Transient — retry with backoff |
 | User not found (404) | Permanent — mark user email rejected |
 | Invalid email (400) | Permanent — mark user email rejected |
-| Permission denied (403) | Transient — resource-level issue, retry |
+| Permission denied (403) | Permanent — no Google account for address, mark rejected |
 | Folder not found | Re-provision |
 | Inherited permission delete | Skip (cannot remove inherited Shared Drive permissions) |
 

--- a/docs/features/11-preferred-email.md
+++ b/docs/features/11-preferred-email.md
@@ -179,7 +179,7 @@ Uses ASP.NET Identity's built-in token providers:
 
 When `GoogleEmail` differs from the OAuth email (e.g., after linking a @nobodies.team address), `AddUserToTeamResourcesAsync` proactively removes the old OAuth email from Google Groups to prevent duplicate email delivery. This means the cleanup is immediate rather than waiting for the daily reconciliation cycle.
 
-Users with `GoogleEmailStatus == Rejected` are excluded from all sync paths (reconciliation, outbox, direct add). A 403 "Permission denied" from the Groups API for an ineligible email domain (e.g., proton.me) is treated as a permanent rejection.
+Users with `GoogleEmailStatus == Rejected` are excluded from all sync paths (reconciliation, outbox, direct add). A 403 "Permission denied" from the Groups API — typically because the email address does not have a Google account associated with it — is treated as a permanent rejection.
 
 ### Background Jobs
 These jobs use `GetEffectiveEmail()` to send to the notification target:

--- a/docs/features/11-preferred-email.md
+++ b/docs/features/11-preferred-email.md
@@ -177,6 +177,10 @@ Uses ASP.NET Identity's built-in token providers:
 - Adding/removing users from Shared Drive folders
 - Drift detection for membership sync
 
+When `GoogleEmail` differs from the OAuth email (e.g., after linking a @nobodies.team address), `AddUserToTeamResourcesAsync` proactively removes the old OAuth email from Google Groups to prevent duplicate email delivery. This means the cleanup is immediate rather than waiting for the daily reconciliation cycle.
+
+Users with `GoogleEmailStatus == Rejected` are excluded from all sync paths (reconciliation, outbox, direct add). A 403 "Permission denied" from the Groups API for an ineligible email domain (e.g., proton.me) is treated as a permanent rejection.
+
 ### Background Jobs
 These jobs use `GetEffectiveEmail()` to send to the notification target:
 - `SendReConsentReminderJob` - consent reminder emails

--- a/src/Humans.Infrastructure/Jobs/ProcessGoogleSyncOutboxJob.cs
+++ b/src/Humans.Infrastructure/Jobs/ProcessGoogleSyncOutboxJob.cs
@@ -20,11 +20,10 @@ public class ProcessGoogleSyncOutboxJob : IRecurringJob
 
     /// <summary>
     /// HTTP status codes that indicate a permanent user-level failure (do not retry).
-    /// 400 = bad request (invalid email format), 404 = user not found.
-    /// Note: 403 is excluded because it typically indicates a resource-level permission issue
-    /// (service account lacks access), not a user email problem.
+    /// 400 = bad request (invalid email format), 403 = email domain ineligible for
+    /// Google Groups (e.g., proton.me), 404 = user not found.
     /// </summary>
-    private static readonly HashSet<int> PermanentErrorCodes = [400, 404];
+    private static readonly HashSet<int> PermanentErrorCodes = [400, 403, 404];
 
     private readonly HumansDbContext _dbContext;
     private readonly IGoogleSyncService _googleSyncService;

--- a/src/Humans.Infrastructure/Jobs/ProcessGoogleSyncOutboxJob.cs
+++ b/src/Humans.Infrastructure/Jobs/ProcessGoogleSyncOutboxJob.cs
@@ -203,6 +203,10 @@ public class ProcessGoogleSyncOutboxJob : IRecurringJob
         var user = await _dbContext.Users.FindAsync([userId], cancellationToken);
         if (user is not null)
         {
+            // Never overwrite Rejected with Valid — Rejected is terminal until the user changes their email
+            if (status == GoogleEmailStatus.Valid && user.GoogleEmailStatus == GoogleEmailStatus.Rejected)
+                return;
+
             user.GoogleEmailStatus = status;
         }
     }

--- a/src/Humans.Infrastructure/Services/GoogleWorkspaceSyncService.cs
+++ b/src/Humans.Infrastructure/Services/GoogleWorkspaceSyncService.cs
@@ -472,8 +472,8 @@ public class GoogleWorkspaceSyncService : IGoogleSyncService
 
             // Mark the user's Google email as Rejected so sync stops retrying
             var user = await _dbContext.Users
-                .FirstOrDefaultAsync(u => string.Equals(u.Email, userEmail) ||
-                    string.Equals(u.GoogleEmail, userEmail), cancellationToken);
+                .FirstOrDefaultAsync(u => EF.Functions.ILike(u.Email!, userEmail) ||
+                    (u.GoogleEmail != null && EF.Functions.ILike(u.GoogleEmail, userEmail)), cancellationToken);
             if (user is not null && user.GoogleEmailStatus != GoogleEmailStatus.Rejected)
             {
                 user.GoogleEmailStatus = GoogleEmailStatus.Rejected;

--- a/src/Humans.Infrastructure/Services/GoogleWorkspaceSyncService.cs
+++ b/src/Humans.Infrastructure/Services/GoogleWorkspaceSyncService.cs
@@ -467,7 +467,7 @@ public class GoogleWorkspaceSyncService : IGoogleSyncService
         {
             _logger.LogWarning(
                 "Google rejected {UserEmail} for group {GroupName} ({GroupId}) — HTTP 403. " +
-                "This typically means the email domain is ineligible for Google Groups membership",
+                "This typically means the email address does not have a Google account associated with it",
                 userEmail, resource.Name, resource.GoogleId);
 
             // Mark the user's Google email as Rejected so sync stops retrying
@@ -482,7 +482,7 @@ public class GoogleWorkspaceSyncService : IGoogleSyncService
 
             await _auditLogService.LogGoogleSyncAsync(
                 AuditAction.GoogleResourceAccessGranted, groupResourceId,
-                $"Google rejected {userEmail} for group {resource.Name} — email domain ineligible (HTTP 403)",
+                $"Google rejected {userEmail} for group {resource.Name} — no Google account for this address (HTTP 403)",
                 nameof(GoogleWorkspaceSyncService),
                 userEmail, "MEMBER", GoogleSyncSource.ManualSync, success: false);
         }
@@ -1056,7 +1056,7 @@ public class GoogleWorkspaceSyncService : IGoogleSyncService
         {
             // Expected: team's active members (use Google service email preference)
             // Skip users with Rejected GoogleEmailStatus — their email was permanently
-            // rejected by Google (e.g., ineligible domain like proton.me)
+            // rejected by Google (no Google account associated with the address)
             var expectedMembers = resource.Team.Members
                 .Where(tm => tm.User.GetGoogleServiceEmail() is not null
                     && tm.User.GoogleEmailStatus != GoogleEmailStatus.Rejected)

--- a/src/Humans.Infrastructure/Services/GoogleWorkspaceSyncService.cs
+++ b/src/Humans.Infrastructure/Services/GoogleWorkspaceSyncService.cs
@@ -748,6 +748,12 @@ public class GoogleWorkspaceSyncService : IGoogleSyncService
             return;
         }
 
+        // When GoogleEmail differs from the OAuth email, the old email should be removed
+        // from Groups to prevent duplicate delivery (e.g., user got @nobodies.team address)
+        var previousEmail = !string.Equals(googleEmail, user.Email, StringComparison.OrdinalIgnoreCase)
+            ? user.Email
+            : null;
+
         var resources = await _dbContext.GoogleResources
             .Where(r => r.TeamId == teamId && r.IsActive)
             .ToListAsync(cancellationToken);
@@ -757,6 +763,12 @@ public class GoogleWorkspaceSyncService : IGoogleSyncService
             if (resource.ResourceType == GoogleResourceType.Group)
             {
                 await AddUserToGroupAsync(resource.Id, googleEmail, cancellationToken);
+
+                // Remove the old OAuth email from the group to avoid duplicate delivery
+                if (previousEmail is not null)
+                {
+                    await RemoveUserFromGroupAsync(resource.Id, previousEmail, cancellationToken);
+                }
             }
             else
             {
@@ -781,6 +793,12 @@ public class GoogleWorkspaceSyncService : IGoogleSyncService
                 if (resource.ResourceType == GoogleResourceType.Group)
                 {
                     await AddUserToGroupAsync(resource.Id, googleEmail, cancellationToken);
+
+                    // Remove the old OAuth email from the parent group too
+                    if (previousEmail is not null)
+                    {
+                        await RemoveUserFromGroupAsync(resource.Id, previousEmail, cancellationToken);
+                    }
                 }
                 else
                 {

--- a/src/Humans.Infrastructure/Services/GoogleWorkspaceSyncService.cs
+++ b/src/Humans.Infrastructure/Services/GoogleWorkspaceSyncService.cs
@@ -463,6 +463,29 @@ public class GoogleWorkspaceSyncService : IGoogleSyncService
         {
             _logger.LogDebug("User {UserEmail} is already a member of group {GroupId}", userEmail, resource.GoogleId);
         }
+        catch (Google.GoogleApiException ex) when (ex.Error?.Code == 403)
+        {
+            _logger.LogWarning(
+                "Google rejected {UserEmail} for group {GroupName} ({GroupId}) — HTTP 403. " +
+                "This typically means the email domain is ineligible for Google Groups membership",
+                userEmail, resource.Name, resource.GoogleId);
+
+            // Mark the user's Google email as Rejected so sync stops retrying
+            var user = await _dbContext.Users
+                .FirstOrDefaultAsync(u => string.Equals(u.Email, userEmail) ||
+                    string.Equals(u.GoogleEmail, userEmail), cancellationToken);
+            if (user is not null && user.GoogleEmailStatus != GoogleEmailStatus.Rejected)
+            {
+                user.GoogleEmailStatus = GoogleEmailStatus.Rejected;
+                await _dbContext.SaveChangesAsync(cancellationToken);
+            }
+
+            await _auditLogService.LogGoogleSyncAsync(
+                AuditAction.GoogleResourceAccessGranted, groupResourceId,
+                $"Google rejected {userEmail} for group {resource.Name} — email domain ineligible (HTTP 403)",
+                nameof(GoogleWorkspaceSyncService),
+                userEmail, "MEMBER", GoogleSyncSource.ManualSync, success: false);
+        }
     }
 
     /// <inheritdoc />
@@ -630,10 +653,11 @@ public class GoogleWorkspaceSyncService : IGoogleSyncService
             return;
         }
 
-        // Get current team members
+        // Get current team members (skip users with rejected Google email status)
         var teamMembers = await _dbContext.TeamMembers
             .Include(tm => tm.User)
-            .Where(tm => tm.TeamId == teamId && tm.LeftAt == null)
+            .Where(tm => tm.TeamId == teamId && tm.LeftAt == null
+                && tm.User.GoogleEmailStatus != GoogleEmailStatus.Rejected)
             .Select(tm => tm.User.GoogleEmail ?? tm.User.Email)
             .Where(email => email != null)
             .ToListAsync(cancellationToken);
@@ -715,6 +739,12 @@ public class GoogleWorkspaceSyncService : IGoogleSyncService
         if (googleEmail is null)
         {
             _logger.LogWarning("User {UserId} not found or has no email", userId);
+            return;
+        }
+
+        if (user!.GoogleEmailStatus == GoogleEmailStatus.Rejected)
+        {
+            _logger.LogDebug("Skipping AddUserToTeamResources for user {UserId} — GoogleEmailStatus is Rejected", userId);
             return;
         }
 
@@ -1007,8 +1037,11 @@ public class GoogleWorkspaceSyncService : IGoogleSyncService
         try
         {
             // Expected: team's active members (use Google service email preference)
+            // Skip users with Rejected GoogleEmailStatus — their email was permanently
+            // rejected by Google (e.g., ineligible domain like proton.me)
             var expectedMembers = resource.Team.Members
-                .Where(tm => tm.User.GetGoogleServiceEmail() is not null)
+                .Where(tm => tm.User.GetGoogleServiceEmail() is not null
+                    && tm.User.GoogleEmailStatus != GoogleEmailStatus.Rejected)
                 .Select(tm => new { Email = tm.User.GetGoogleServiceEmail(), tm.User.DisplayName, tm.User.Id, tm.User.ProfilePictureUrl })
                 .ToList();
 
@@ -1019,7 +1052,9 @@ public class GoogleWorkspaceSyncService : IGoogleSyncService
             foreach (var cm in childMembers)
             {
                 var email = cm.User.GetGoogleServiceEmail();
-                if (email is not null && !expectedMembers.Any(m =>
+                if (email is not null
+                    && cm.User.GoogleEmailStatus != GoogleEmailStatus.Rejected
+                    && !expectedMembers.Any(m =>
                     NormalizingEmailComparer.Instance.Equals(m.Email, email)))
                 {
                     expectedMembers.Add(new { Email = (string?)email, cm.User.DisplayName, cm.User.Id, cm.User.ProfilePictureUrl });
@@ -1341,7 +1376,8 @@ public class GoogleWorkspaceSyncService : IGoogleSyncService
                 foreach (var tm in resource.Team.Members)
                 {
                     var memberEmail = tm.User.GetGoogleServiceEmail();
-                    if (memberEmail is null) continue;
+                    if (memberEmail is null || tm.User.GoogleEmailStatus == GoogleEmailStatus.Rejected)
+                        continue;
 
                     if (membersByEmail.TryGetValue(memberEmail, out var existing))
                     {
@@ -1361,7 +1397,8 @@ public class GoogleWorkspaceSyncService : IGoogleSyncService
                 foreach (var cm in childMembers)
                 {
                     var memberEmail = cm.User.GetGoogleServiceEmail();
-                    if (memberEmail is null) continue;
+                    if (memberEmail is null || cm.User.GoogleEmailStatus == GoogleEmailStatus.Rejected)
+                        continue;
 
                     var childTeamLink = new TeamLink(cm.Team.Name, cm.Team.Slug, level);
                     if (membersByEmail.TryGetValue(memberEmail, out var existing2))


### PR DESCRIPTION
## Summary
- Handle Google Groups 403 rejection for ineligible emails (#454)
- Manage Google Group email delivery preferences during sync (#453)

## Issues
- Closes peterdrier/Humans#454 (upstream: nobodies-collective/Humans#454)
- Closes peterdrier/Humans#453 (upstream: nobodies-collective/Humans#453)

## Test plan
- [ ] Verify 403 rejections for ineligible emails are caught gracefully
- [ ] Verify rejected emails are marked and sync doesn't retry
- [ ] Verify @nobodies.team notification target controls group membership email
- [ ] Verify duplicate personal email removed from groups when @nobodies.team preferred

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>