### PR TITLE
Add resource-based auth: camp lead permissions (#416)

### DIFF
--- a/src/Humans.Web/Authorization/AuthorizationPolicyExtensions.cs
+++ b/src/Humans.Web/Authorization/AuthorizationPolicyExtensions.cs
@@ -20,6 +20,7 @@ public static class AuthorizationPolicyExtensions
 
         // Resource-based authorization handlers (scoped — they depend on scoped services)
         services.AddScoped<IAuthorizationHandler, BudgetAuthorizationHandler>();
+        services.AddScoped<IAuthorizationHandler, CampAuthorizationHandler>();
 
         services.AddAuthorization(options =>
         {

--- a/src/Humans.Web/Authorization/Requirements/CampAuthorizationHandler.cs
+++ b/src/Humans.Web/Authorization/Requirements/CampAuthorizationHandler.cs
@@ -1,0 +1,49 @@
+using System.Security.Claims;
+using Humans.Application.Interfaces;
+using Humans.Domain.Entities;
+using Microsoft.AspNetCore.Authorization;
+
+namespace Humans.Web.Authorization.Requirements;
+
+/// <summary>
+/// Resource-based authorization handler for camp operations.
+/// Evaluates whether a user can perform management operations on a specific Camp.
+///
+/// Authorization logic:
+/// - Admin: allow any camp
+/// - CampAdmin: allow any camp
+/// - Camp lead: allow only their assigned camp
+/// - Everyone else: deny
+/// </summary>
+public class CampAuthorizationHandler : AuthorizationHandler<CampOperationRequirement, Camp>
+{
+    private readonly ICampService _campService;
+
+    public CampAuthorizationHandler(ICampService campService)
+    {
+        _campService = campService;
+    }
+
+    protected override async Task HandleRequirementAsync(
+        AuthorizationHandlerContext context,
+        CampOperationRequirement requirement,
+        Camp resource)
+    {
+        // Admin and CampAdmin can manage any camp
+        if (RoleChecks.IsCampAdmin(context.User))
+        {
+            context.Succeed(requirement);
+            return;
+        }
+
+        // Check if user is a lead for this specific camp
+        var userIdClaim = context.User.FindFirst(ClaimTypes.NameIdentifier);
+        if (userIdClaim is null || !Guid.TryParse(userIdClaim.Value, out var userId))
+            return;
+
+        if (await _campService.IsUserCampLeadAsync(userId, resource.Id))
+        {
+            context.Succeed(requirement);
+        }
+    }
+}

--- a/src/Humans.Web/Authorization/Requirements/CampOperationRequirement.cs
+++ b/src/Humans.Web/Authorization/Requirements/CampOperationRequirement.cs
@@ -1,0 +1,20 @@
+using Microsoft.AspNetCore.Authorization;
+
+namespace Humans.Web.Authorization.Requirements;
+
+/// <summary>
+/// Resource-based authorization requirement for camp operations.
+/// Used with IAuthorizationService.AuthorizeAsync(User, resource, requirement)
+/// where the resource is a Camp.
+/// </summary>
+public sealed class CampOperationRequirement : IAuthorizationRequirement
+{
+    public static readonly CampOperationRequirement Manage = new(nameof(Manage));
+
+    public string OperationName { get; }
+
+    private CampOperationRequirement(string operationName)
+    {
+        OperationName = operationName;
+    }
+}

--- a/src/Humans.Web/Controllers/CampController.cs
+++ b/src/Humans.Web/Controllers/CampController.cs
@@ -28,10 +28,11 @@ public class CampController : HumansCampControllerBase
         ICampContactService campContactService,
         INotificationService notificationService,
         UserManager<User> userManager,
+        IAuthorizationService authorizationService,
         IClock clock,
         ILogger<CampController> logger,
         IStringLocalizer<SharedResource> localizer)
-        : base(userManager, campService)
+        : base(userManager, campService, authorizationService)
     {
         _campService = campService;
         _campContactService = campContactService;

--- a/src/Humans.Web/Controllers/HumansCampControllerBase.cs
+++ b/src/Humans.Web/Controllers/HumansCampControllerBase.cs
@@ -1,6 +1,7 @@
 using Humans.Application.Interfaces;
 using Humans.Domain.Entities;
-using Humans.Web.Authorization;
+using Humans.Web.Authorization.Requirements;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 
@@ -9,11 +10,16 @@ namespace Humans.Web.Controllers;
 public abstract class HumansCampControllerBase : HumansControllerBase
 {
     private readonly ICampService _campService;
+    private readonly IAuthorizationService _authorizationService;
 
-    protected HumansCampControllerBase(UserManager<User> userManager, ICampService campService)
+    protected HumansCampControllerBase(
+        UserManager<User> userManager,
+        ICampService campService,
+        IAuthorizationService authorizationService)
         : base(userManager)
     {
         _campService = campService;
+        _authorizationService = authorizationService;
     }
 
     protected Task<Camp?> GetCampBySlugAsync(string slug)
@@ -23,15 +29,23 @@ public abstract class HumansCampControllerBase : HumansControllerBase
 
     protected async Task<(bool IsLead, bool IsCampAdmin)> ResolveCampViewerStateAsync(Camp camp)
     {
+        var canManage = (await _authorizationService.AuthorizeAsync(User, camp, CampOperationRequirement.Manage)).Succeeded;
+        if (!canManage)
+        {
+            return (false, false);
+        }
+
+        // Determine whether access is via lead or admin role for view-level distinctions
         var user = await GetCurrentUserAsync();
         if (user is null)
         {
             return (false, false);
         }
 
-        return (
-            await _campService.IsUserCampLeadAsync(user.Id, camp.Id),
-            RoleChecks.IsCampAdmin(User));
+        var isLead = await _campService.IsUserCampLeadAsync(user.Id, camp.Id);
+        var isCampAdmin = Authorization.RoleChecks.IsCampAdmin(User);
+
+        return (isLead, isCampAdmin);
     }
 
     protected async Task<(IActionResult? ErrorResult, User User, Camp Camp)> ResolveCampManagementAsync(string slug)
@@ -48,7 +62,8 @@ public abstract class HumansCampControllerBase : HumansControllerBase
             return (currentUserError, null!, camp);
         }
 
-        if (RoleChecks.IsCampAdmin(User) || await _campService.IsUserCampLeadAsync(user.Id, camp.Id))
+        var result = await _authorizationService.AuthorizeAsync(User, camp, CampOperationRequirement.Manage);
+        if (result.Succeeded)
         {
             return (null, user, camp);
         }

--- a/tests/Humans.Application.Tests/Authorization/AuthorizationPolicyTests.cs
+++ b/tests/Humans.Application.Tests/Authorization/AuthorizationPolicyTests.cs
@@ -24,8 +24,9 @@ public class AuthorizationPolicyTests : IDisposable
     {
         var services = new ServiceCollection();
         services.AddLogging();
-        // Register IBudgetService stub required by BudgetAuthorizationHandler
+        // Register service stubs required by resource-based authorization handlers
         services.AddScoped(_ => Substitute.For<IBudgetService>());
+        services.AddScoped(_ => Substitute.For<ICampService>());
         services.AddHumansAuthorizationPolicies();
         _serviceProvider = services.BuildServiceProvider();
         _authorizationService = _serviceProvider.GetRequiredService<IAuthorizationService>();

--- a/tests/Humans.Application.Tests/Authorization/CampAuthorizationHandlerTests.cs
+++ b/tests/Humans.Application.Tests/Authorization/CampAuthorizationHandlerTests.cs
@@ -1,0 +1,175 @@
+using System.Security.Claims;
+using AwesomeAssertions;
+using Humans.Application.Interfaces;
+using Humans.Domain.Constants;
+using Humans.Domain.Entities;
+using Humans.Web.Authorization.Requirements;
+using Microsoft.AspNetCore.Authorization;
+using NSubstitute;
+using Xunit;
+
+namespace Humans.Application.Tests.Authorization;
+
+/// <summary>
+/// Unit tests for CampAuthorizationHandler — resource-based authorization for camp operations.
+/// Tests cover: Admin override, CampAdmin override, camp lead access,
+/// denial for non-leads, and edge cases.
+/// </summary>
+public sealed class CampAuthorizationHandlerTests
+{
+    private readonly ICampService _campService = Substitute.For<ICampService>();
+    private readonly CampAuthorizationHandler _handler;
+
+    private static readonly Guid LeadCampId = Guid.NewGuid();
+    private static readonly Guid OtherCampId = Guid.NewGuid();
+    private static readonly Guid UserId = Guid.NewGuid();
+
+    public CampAuthorizationHandlerTests()
+    {
+        _handler = new CampAuthorizationHandler(_campService);
+
+        _campService.IsUserCampLeadAsync(UserId, LeadCampId, Arg.Any<CancellationToken>())
+            .Returns(true);
+        _campService.IsUserCampLeadAsync(UserId, OtherCampId, Arg.Any<CancellationToken>())
+            .Returns(false);
+    }
+
+    // --- Admin override ---
+
+    [Fact]
+    public async Task Admin_CanManageAnyCamp()
+    {
+        var user = CreateUserWithRoles(RoleNames.Admin);
+        var camp = CreateCamp(OtherCampId);
+
+        var result = await EvaluateAsync(user, camp);
+
+        result.Should().BeTrue();
+    }
+
+    // --- CampAdmin override ---
+
+    [Fact]
+    public async Task CampAdmin_CanManageAnyCamp()
+    {
+        var user = CreateUserWithRoles(RoleNames.CampAdmin);
+        var camp = CreateCamp(OtherCampId);
+
+        var result = await EvaluateAsync(user, camp);
+
+        result.Should().BeTrue();
+    }
+
+    // --- Camp lead access ---
+
+    [Fact]
+    public async Task CampLead_CanManageOwnCamp()
+    {
+        var user = CreateUser(UserId);
+        var camp = CreateCamp(LeadCampId);
+
+        var result = await EvaluateAsync(user, camp);
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task CampLead_CannotManageOtherCamp()
+    {
+        var user = CreateUser(UserId);
+        var camp = CreateCamp(OtherCampId);
+
+        var result = await EvaluateAsync(user, camp);
+
+        result.Should().BeFalse();
+    }
+
+    // --- Denial cases ---
+
+    [Fact]
+    public async Task RegularUser_DeniedOnAnyCamp()
+    {
+        var regularUserId = Guid.NewGuid();
+        _campService.IsUserCampLeadAsync(regularUserId, LeadCampId, Arg.Any<CancellationToken>())
+            .Returns(false);
+        var user = CreateUser(regularUserId);
+        var camp = CreateCamp(LeadCampId);
+
+        var result = await EvaluateAsync(user, camp);
+
+        result.Should().BeFalse();
+    }
+
+    // --- Edge cases ---
+
+    [Fact]
+    public async Task UnauthenticatedUser_Denied()
+    {
+        var user = new ClaimsPrincipal(new ClaimsIdentity());
+        var camp = CreateCamp(LeadCampId);
+
+        var result = await EvaluateAsync(user, camp);
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task UserWithInvalidIdClaim_Denied()
+    {
+        var claims = new List<Claim>
+        {
+            new(ClaimTypes.NameIdentifier, "not-a-guid"),
+            new(ClaimTypes.Name, "test@example.com")
+        };
+        var user = new ClaimsPrincipal(new ClaimsIdentity(claims, "TestAuth"));
+        var camp = CreateCamp(LeadCampId);
+
+        var result = await EvaluateAsync(user, camp);
+
+        result.Should().BeFalse();
+    }
+
+    // --- Helpers ---
+
+    private async Task<bool> EvaluateAsync(ClaimsPrincipal user, Camp resource)
+    {
+        var requirement = CampOperationRequirement.Manage;
+        var context = new AuthorizationHandlerContext(
+            [requirement], user, resource);
+
+        await _handler.HandleAsync(context);
+        return context.HasSucceeded;
+    }
+
+    private static Camp CreateCamp(Guid campId)
+    {
+        return new Camp
+        {
+            Id = campId
+        };
+    }
+
+    private static ClaimsPrincipal CreateUserWithRoles(params string[] roles)
+    {
+        var claims = new List<Claim>
+        {
+            new(ClaimTypes.NameIdentifier, Guid.NewGuid().ToString()),
+            new(ClaimTypes.Name, "admin@example.com")
+        };
+        foreach (var role in roles)
+        {
+            claims.Add(new Claim(ClaimTypes.Role, role));
+        }
+        return new ClaimsPrincipal(new ClaimsIdentity(claims, "TestAuth"));
+    }
+
+    private static ClaimsPrincipal CreateUser(Guid userId)
+    {
+        var claims = new List<Claim>
+        {
+            new(ClaimTypes.NameIdentifier, userId.ToString()),
+            new(ClaimTypes.Name, "lead@example.com")
+        };
+        return new ClaimsPrincipal(new ClaimsIdentity(claims, "TestAuth"));
+    }
+}


### PR DESCRIPTION
## Summary
- Add resource-based authorization for camp lead permissions (Phase 2b of auth transition)
- Camp leads can manage only their assigned camp, admin override works
- Following the same pattern established in Phase 2a (#415, budget editing)

## Issues
- Closes peterdrier/Humans#416 (upstream: nobodies-collective/Humans#416)

## Test plan
- [x] Camp leads can access admin actions for their assigned camp only
- [x] Admin can access admin actions for any camp
- [x] Non-lead users are denied camp admin actions
- [x] Views reflect permissions (hide/show based on auth)
- [x] Unit tests pass for all authorization paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>