### PR TITLE
Sprint batch 4: Quick Enhancements (#426, #444, #445, #455, #446)

### DIFF
--- a/src/Humans.Application/Interfaces/IProfileService.cs
+++ b/src/Humans.Application/Interfaces/IProfileService.cs
@@ -93,6 +93,12 @@ public interface IProfileService
     CachedProfile? GetCachedProfile(Guid userId);
 
     /// <summary>
+    /// Gets a cached profile by user ID, warming the cache first if cold.
+    /// Returns null only if the user has no approved profile.
+    /// </summary>
+    Task<CachedProfile?> GetCachedProfileAsync(Guid userId, CancellationToken ct = default);
+
+    /// <summary>
     /// Updates a single entry in the approved profiles cache.
     /// Pass null to remove the entry (e.g., on suspension/deletion).
     /// </summary>

--- a/src/Humans.Infrastructure/Services/ProfileService.cs
+++ b/src/Humans.Infrastructure/Services/ProfileService.cs
@@ -767,6 +767,12 @@ public class ProfileService : IProfileService
         return null;
     }
 
+    public async Task<CachedProfile?> GetCachedProfileAsync(Guid userId, CancellationToken ct = default)
+    {
+        var profiles = await GetCachedProfilesAsync(ct);
+        return profiles.TryGetValue(userId, out var profile) ? profile : null;
+    }
+
     public void UpdateProfileCache(Guid userId, CachedProfile? newValue)
         => _cache.UpdateApprovedProfile(userId, newValue);
 

--- a/src/Humans.Web/Controllers/AdminController.cs
+++ b/src/Humans.Web/Controllers/AdminController.cs
@@ -100,10 +100,12 @@ public class AdminController : HumansControllerBase
 
     [HttpGet("Logs")]
     [Authorize(Policy = PolicyNames.AdminOnly)]
-    public IActionResult Logs(int count = 50)
+    public IActionResult Logs(int count = 200)
     {
         count = Math.Clamp(count, 1, 200);
-        var events = Web.Infrastructure.InMemoryLogSink.Instance.GetEvents(count);
+        var sink = Web.Infrastructure.InMemoryLogSink.Instance;
+        var events = sink.GetEvents(count);
+        ViewBag.LifetimeCounts = sink.GetLifetimeCounts();
         return View(events);
     }
 

--- a/src/Humans.Web/Controllers/CampAdminController.cs
+++ b/src/Humans.Web/Controllers/CampAdminController.cs
@@ -60,6 +60,39 @@ public class CampAdminController : HumansControllerBase
                 }))
             .ToList();
 
+        // Load camps with leads for the summary table
+        var campsWithLeads = await _dbContext.Camps
+            .Include(c => c.Seasons.Where(s => s.Year == settings.PublicYear))
+            .Include(c => c.Leads.Where(l => l.LeftAt == null))
+                .ThenInclude(l => l.User)
+            .Where(c => c.Seasons.Any(s => s.Year == settings.PublicYear
+                && (s.Status == CampSeasonStatus.Active || s.Status == CampSeasonStatus.Full)))
+            .OrderBy(c => c.Seasons.Where(s => s.Year == settings.PublicYear).Select(s => s.Name).FirstOrDefault())
+            .ToListAsync();
+
+        var summaries = campsWithLeads.Select(c =>
+        {
+            var season = c.Seasons.FirstOrDefault();
+            return new CampSummaryRowViewModel
+            {
+                Name = season?.Name ?? c.Slug,
+                Slug = c.Slug,
+                AcceptingMembers = season?.AcceptingMembers.ToString() ?? "—",
+                MemberCount = season?.MemberCount ?? 0,
+                Zone = season?.SoundZone?.ToString() ?? "—",
+                SpaceRequirement = season?.SpaceRequirement?.ToString() ?? "—",
+                YearsParticipating = c.TimesAtNowhere,
+                Leads = c.Leads
+                    .Where(l => l.IsActive)
+                    .Select(l => new CampLeadViewModel
+                    {
+                        LeadId = l.Id,
+                        UserId = l.UserId,
+                        DisplayName = l.User.DisplayName
+                    }).ToList()
+            };
+        }).ToList();
+
         var vm = new CampAdminViewModel
         {
             PublicYear = settings.PublicYear,
@@ -69,6 +102,7 @@ public class CampAdminController : HumansControllerBase
                 s.Year == settings.PublicYear && (s.Status == CampSeasonStatus.Active || s.Status == CampSeasonStatus.Full))),
             WithdrawnCamps = withdrawnSeasons,
             NameLockDates = nameLockDates,
+            AllCampSummaries = summaries,
             PendingCamps = pendingSeasons.Select(s => new CampCardViewModel
             {
                 Id = s.CampId,

--- a/src/Humans.Web/Controllers/CampaignController.cs
+++ b/src/Humans.Web/Controllers/CampaignController.cs
@@ -1,10 +1,8 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
 using Humans.Application.DTOs;
 using Humans.Application.Interfaces;
-using Humans.Infrastructure.Data;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Humans.Web.Authorization;
@@ -18,18 +16,15 @@ public class CampaignController : HumansControllerBase
 {
     private readonly ICampaignService _campaignService;
     private readonly ITicketVendorService _vendorService;
-    private readonly HumansDbContext _dbContext;
 
     public CampaignController(
         ICampaignService campaignService,
         ITicketVendorService vendorService,
-        HumansDbContext dbContext,
         UserManager<User> userManager)
         : base(userManager)
     {
         _campaignService = campaignService;
         _vendorService = vendorService;
-        _dbContext = dbContext;
     }
 
     [HttpGet("")]
@@ -106,13 +101,12 @@ public class CampaignController : HumansControllerBase
                 return NotFound();
             }
 
-            // Detach so form value mutations aren't accidentally persisted
-            _dbContext.Entry(campaign).State = EntityState.Detached;
-            campaign.Title = title;
-            campaign.Description = description;
-            campaign.EmailSubject = emailSubject;
-            campaign.EmailBodyTemplate = emailBodyTemplate;
-            campaign.ReplyToAddress = replyToAddress;
+            // Pass submitted form values back via ViewBag for re-display
+            ViewBag.Title2 = title;
+            ViewBag.Description = description;
+            ViewBag.EmailSubject = emailSubject;
+            ViewBag.EmailBodyTemplate = emailBodyTemplate;
+            ViewBag.ReplyToAddress = replyToAddress;
             return View(campaign);
         }
 

--- a/src/Humans.Web/Infrastructure/InMemoryLogSink.cs
+++ b/src/Humans.Web/Infrastructure/InMemoryLogSink.cs
@@ -13,6 +13,7 @@ public sealed class InMemoryLogSink : ILogEventSink
 {
     private readonly ConcurrentQueue<LogEvent> _events = new();
     private readonly int _capacity;
+    private readonly ConcurrentDictionary<LogEventLevel, long> _lifetimeCounts = new();
 
     public InMemoryLogSink(int capacity = 200)
     {
@@ -21,13 +22,21 @@ public sealed class InMemoryLogSink : ILogEventSink
 
     public void Emit(LogEvent logEvent)
     {
+        _lifetimeCounts.AddOrUpdate(logEvent.Level, 1, (_, count) => count + 1);
         _events.Enqueue(logEvent);
         while (_events.Count > _capacity)
             _events.TryDequeue(out _);
     }
 
-    public IReadOnlyList<LogEvent> GetEvents(int count = 50) =>
+    public IReadOnlyList<LogEvent> GetEvents(int count = 200) =>
         _events.Reverse().Take(count).ToList();
+
+    /// <summary>
+    /// Returns cumulative counts per log level since application start.
+    /// These survive ring buffer eviction.
+    /// </summary>
+    public IReadOnlyDictionary<LogEventLevel, long> GetLifetimeCounts() =>
+        _lifetimeCounts.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
 
     /// <summary>Singleton instance registered in DI and Serilog config.</summary>
     public static InMemoryLogSink Instance { get; } = new();

--- a/src/Humans.Web/Models/CampViewModels.cs
+++ b/src/Humans.Web/Models/CampViewModels.cs
@@ -169,4 +169,17 @@ public class CampAdminViewModel
     public int TotalCamps { get; set; }
     public int ActiveCamps { get; set; }
     public Dictionary<int, NodaTime.LocalDate?> NameLockDates { get; set; } = new();
+    public List<CampSummaryRowViewModel> AllCampSummaries { get; set; } = new();
+}
+
+public class CampSummaryRowViewModel
+{
+    public string Name { get; set; } = string.Empty;
+    public string Slug { get; set; } = string.Empty;
+    public string AcceptingMembers { get; set; } = string.Empty;
+    public int MemberCount { get; set; }
+    public string Zone { get; set; } = string.Empty;
+    public string SpaceRequirement { get; set; } = string.Empty;
+    public int YearsParticipating { get; set; }
+    public List<CampLeadViewModel> Leads { get; set; } = new();
 }

--- a/src/Humans.Web/Resources/SharedResource.ca.resx
+++ b/src/Humans.Web/Resources/SharedResource.ca.resx
@@ -167,6 +167,13 @@
   <data name="Dashboard_RejectedMessage" xml:space="preserve"><value>El teu registre ha estat revisat i no va ser aprovat. Si tens preguntes, contacta amb l'equip d'administració.</value></data>
   <data name="Dashboard_RejectionReason" xml:space="preserve"><value>Motiu</value></data>
 
+  <!-- Guest Dashboard -->
+  <data name="Guest_GetInvolvedTitle" xml:space="preserve"><value>Vols participar?</value></data>
+  <data name="Guest_GetInvolvedDescription" xml:space="preserve"><value>Crea un perfil per ser voluntari i accedir a l'experi&#xE8;ncia completa de Humans &#x2014; torns, equips, governan&#xE7;a i m&#xE9;s.</value></data>
+  <data name="Guest_CreateProfile" xml:space="preserve"><value>Crear perfil</value></data>
+  <data name="Guest_Explore" xml:space="preserve"><value>Explorar</value></data>
+  <data name="Guest_Legal" xml:space="preserve"><value>Legal</value></data>
+
   <!-- ======================== -->
   <!-- Privacy Policy Page      -->
   <!-- ======================== -->

--- a/src/Humans.Web/Resources/SharedResource.de.resx
+++ b/src/Humans.Web/Resources/SharedResource.de.resx
@@ -167,6 +167,13 @@
   <data name="Dashboard_RejectedMessage" xml:space="preserve"><value>Ihre Anmeldung wurde gepr&#xFC;ft und nicht genehmigt. Bei Fragen wenden Sie sich bitte an das Admin-Team.</value></data>
   <data name="Dashboard_RejectionReason" xml:space="preserve"><value>Grund</value></data>
 
+  <!-- Guest Dashboard -->
+  <data name="Guest_GetInvolvedTitle" xml:space="preserve"><value>M&#xF6;chtest du mitmachen?</value></data>
+  <data name="Guest_GetInvolvedDescription" xml:space="preserve"><value>Erstelle ein Profil, um Freiwilliger zu werden und das volle Humans-Erlebnis zu nutzen &#x2014; Schichten, Teams, Governance und mehr.</value></data>
+  <data name="Guest_CreateProfile" xml:space="preserve"><value>Profil erstellen</value></data>
+  <data name="Guest_Explore" xml:space="preserve"><value>Entdecken</value></data>
+  <data name="Guest_Legal" xml:space="preserve"><value>Rechtliches</value></data>
+
   <!-- ======================== -->
   <!-- Privacy Policy Page      -->
   <!-- ======================== -->

--- a/src/Humans.Web/Resources/SharedResource.es.resx
+++ b/src/Humans.Web/Resources/SharedResource.es.resx
@@ -167,6 +167,13 @@
   <data name="Dashboard_RejectedMessage" xml:space="preserve"><value>Su registro ha sido revisado y no fue aprobado. Si tiene preguntas, contacte al equipo de administraci&#xF3;n.</value></data>
   <data name="Dashboard_RejectionReason" xml:space="preserve"><value>Motivo</value></data>
 
+  <!-- Guest Dashboard -->
+  <data name="Guest_GetInvolvedTitle" xml:space="preserve"><value>&#xBF;Quieres participar?</value></data>
+  <data name="Guest_GetInvolvedDescription" xml:space="preserve"><value>Crea un perfil para ser voluntario y acceder a la experiencia completa de Humans &#x2014; turnos, equipos, gobernanza y m&#xE1;s.</value></data>
+  <data name="Guest_CreateProfile" xml:space="preserve"><value>Crear perfil</value></data>
+  <data name="Guest_Explore" xml:space="preserve"><value>Explorar</value></data>
+  <data name="Guest_Legal" xml:space="preserve"><value>Legal</value></data>
+
   <!-- ======================== -->
   <!-- Privacy Policy Page      -->
   <!-- ======================== -->

--- a/src/Humans.Web/Resources/SharedResource.fr.resx
+++ b/src/Humans.Web/Resources/SharedResource.fr.resx
@@ -167,6 +167,13 @@
   <data name="Dashboard_RejectedMessage" xml:space="preserve"><value>Votre inscription a &#xE9;t&#xE9; examin&#xE9;e et n'a pas &#xE9;t&#xE9; approuv&#xE9;e. Si vous avez des questions, veuillez contacter l'&#xE9;quipe d'administration.</value></data>
   <data name="Dashboard_RejectionReason" xml:space="preserve"><value>Motif</value></data>
 
+  <!-- Guest Dashboard -->
+  <data name="Guest_GetInvolvedTitle" xml:space="preserve"><value>Envie de participer ?</value></data>
+  <data name="Guest_GetInvolvedDescription" xml:space="preserve"><value>Cr&#xE9;ez un profil pour devenir b&#xE9;n&#xE9;vole et acc&#xE9;der &#xE0; l'exp&#xE9;rience compl&#xE8;te Humans &#x2014; cr&#xE9;neaux, &#xE9;quipes, gouvernance et plus encore.</value></data>
+  <data name="Guest_CreateProfile" xml:space="preserve"><value>Cr&#xE9;er un profil</value></data>
+  <data name="Guest_Explore" xml:space="preserve"><value>Explorer</value></data>
+  <data name="Guest_Legal" xml:space="preserve"><value>Mentions l&#xE9;gales</value></data>
+
   <!-- ======================== -->
   <!-- Privacy Policy Page      -->
   <!-- ======================== -->

--- a/src/Humans.Web/Resources/SharedResource.it.resx
+++ b/src/Humans.Web/Resources/SharedResource.it.resx
@@ -167,6 +167,13 @@
   <data name="Dashboard_RejectedMessage" xml:space="preserve"><value>La Sua registrazione &#xE8; stata esaminata e non &#xE8; stata approvata. Per domande, contatti il team di amministrazione.</value></data>
   <data name="Dashboard_RejectionReason" xml:space="preserve"><value>Motivo</value></data>
 
+  <!-- Guest Dashboard -->
+  <data name="Guest_GetInvolvedTitle" xml:space="preserve"><value>Vuoi partecipare?</value></data>
+  <data name="Guest_GetInvolvedDescription" xml:space="preserve"><value>Crea un profilo per diventare volontario e accedere all'esperienza completa di Humans &#x2014; turni, team, governance e altro.</value></data>
+  <data name="Guest_CreateProfile" xml:space="preserve"><value>Crea profilo</value></data>
+  <data name="Guest_Explore" xml:space="preserve"><value>Esplora</value></data>
+  <data name="Guest_Legal" xml:space="preserve"><value>Legale</value></data>
+
   <!-- ======================== -->
   <!-- Privacy Policy Page      -->
   <!-- ======================== -->

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -167,6 +167,13 @@
   <data name="Dashboard_RejectedMessage" xml:space="preserve"><value>Your signup has been reviewed and was not approved. If you have questions, please contact the admin team.</value></data>
   <data name="Dashboard_RejectionReason" xml:space="preserve"><value>Reason</value></data>
 
+  <!-- Guest Dashboard -->
+  <data name="Guest_GetInvolvedTitle" xml:space="preserve"><value>Want to get involved?</value></data>
+  <data name="Guest_GetInvolvedDescription" xml:space="preserve"><value>Create a profile to become a volunteer and access the full Humans experience — shifts, teams, governance, and more.</value></data>
+  <data name="Guest_CreateProfile" xml:space="preserve"><value>Create Profile</value></data>
+  <data name="Guest_Explore" xml:space="preserve"><value>Explore</value></data>
+  <data name="Guest_Legal" xml:space="preserve"><value>Legal</value></data>
+
   <!-- ======================== -->
   <!-- Privacy Policy Page      -->
   <!-- ======================== -->

--- a/src/Humans.Web/TagHelpers/HumanLinkTagHelper.cs
+++ b/src/Humans.Web/TagHelpers/HumanLinkTagHelper.cs
@@ -75,7 +75,7 @@ public class HumanLinkTagHelper : TagHelper
         // Resolve display name and profile picture from cache when not explicitly provided
         if (string.IsNullOrEmpty(DisplayName) && UserId != Guid.Empty)
         {
-            var cached = _profileService.GetCachedProfile(UserId);
+            var cached = await _profileService.GetCachedProfileAsync(UserId);
             if (cached is not null)
             {
                 DisplayName = cached.DisplayName;

--- a/src/Humans.Web/Views/Admin/Logs.cshtml
+++ b/src/Humans.Web/Views/Admin/Logs.cshtml
@@ -1,12 +1,33 @@
 @model IReadOnlyList<Serilog.Events.LogEvent>
 @{
     ViewData["Title"] = "Application Logs";
+    var lifetimeCounts = ViewBag.LifetimeCounts as IReadOnlyDictionary<Serilog.Events.LogEventLevel, long>
+        ?? new Dictionary<Serilog.Events.LogEventLevel, long>();
 }
 
 <div class="container-fluid px-4">
     <div class="d-flex justify-content-between align-items-center mt-4 mb-3">
         <h1>Application Logs</h1>
-        <span class="text-muted">Last @Model.Count warnings and errors (in-memory buffer)</span>
+        <span class="text-muted">Showing @Model.Count of last 200 (in-memory buffer)</span>
+    </div>
+
+    <div class="d-flex gap-3 mb-3 flex-wrap">
+        @{
+            var levels = new[]
+            {
+                (Serilog.Events.LogEventLevel.Debug, "bg-secondary"),
+                (Serilog.Events.LogEventLevel.Information, "bg-info text-dark"),
+                (Serilog.Events.LogEventLevel.Warning, "bg-warning text-dark"),
+                (Serilog.Events.LogEventLevel.Error, "bg-danger"),
+                (Serilog.Events.LogEventLevel.Fatal, "bg-danger fw-bold"),
+            };
+        }
+        @foreach (var (level, badgeClass) in levels)
+        {
+            var count = lifetimeCounts.TryGetValue(level, out var c) ? c : 0;
+            <span class="badge @badgeClass">@level: @count</span>
+        }
+        <small class="text-muted align-self-center">(lifetime counts since app start)</small>
     </div>
 
     @if (Model.Count == 0)

--- a/src/Humans.Web/Views/AdminDuplicateAccounts/Index.cshtml
+++ b/src/Humans.Web/Views/AdminDuplicateAccounts/Index.cshtml
@@ -39,21 +39,11 @@ else
                             <div class="card mb-2 @(account.IsProfileComplete ? "border-success" : "border-secondary")">
                                 <div class="card-body">
                                     <div class="d-flex align-items-center mb-2">
-                                        @if (!string.IsNullOrEmpty(account.ProfilePictureUrl))
-                                        {
-                                            <img src="@account.ProfilePictureUrl" alt="" class="rounded-circle me-2" style="width: 40px; height: 40px; object-fit: cover;" />
-                                        }
-                                        else
-                                        {
-                                            <div class="rounded-circle bg-secondary d-flex align-items-center justify-content-center me-2" style="width: 40px; height: 40px;">
-                                                <i class="fa-solid fa-user text-white"></i>
-                                            </div>
-                                        }
-                                        <div>
-                                            <strong>@account.DisplayName</strong>
-                                            <br />
+                                        <human-link user-id="@account.UserId" display-name="@account.DisplayName"
+                                                    mode="AvatarName" size="40"
+                                                    profile-picture-url="@account.ProfilePictureUrl" admin="true">
                                             <small class="text-muted">@account.Email</small>
-                                        </div>
+                                        </human-link>
                                     </div>
                                     <table class="table table-sm table-borderless mb-2">
                                         <tbody>

--- a/src/Humans.Web/Views/Camp/Edit.cshtml
+++ b/src/Humans.Web/Views/Camp/Edit.cshtml
@@ -260,7 +260,7 @@
                 @foreach (var lead in Model.Leads)
                 {
                     <li class="list-group-item d-flex justify-content-between align-items-center">
-                        @lead.DisplayName
+                        <human-link user-id="@lead.UserId" display-name="@lead.DisplayName" />
                         @if (Model.Leads.Count > 1)
                         {
                             <form asp-action="RemoveLead" asp-route-slug="@Model.Slug" asp-route-leadId="@lead.LeadId" method="post" class="d-inline">

--- a/src/Humans.Web/Views/CampAdmin/Index.cshtml
+++ b/src/Humans.Web/Views/CampAdmin/Index.cshtml
@@ -246,6 +246,56 @@
     </div>
 </div>
 
+@* Camp Summary Table *@
+@if (Model.AllCampSummaries.Count > 0)
+{
+    <div class="card mb-4">
+        <div class="card-header">
+            <i class="fa-solid fa-table me-2"></i>Camp Summary (@Model.PublicYear)
+        </div>
+        <div class="table-responsive">
+            <table class="table table-sm table-hover mb-0">
+                <thead>
+                    <tr>
+                        <th>Camp Name</th>
+                        <th>Accepting</th>
+                        <th class="text-end">Humans</th>
+                        <th>Zone</th>
+                        <th>Space</th>
+                        <th class="text-end">Years</th>
+                        <th>Lead(s)</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var camp in Model.AllCampSummaries)
+                    {
+                        <tr>
+                            <td>
+                                <a asp-controller="Camp" asp-action="Details" asp-route-slug="@camp.Slug">@camp.Name</a>
+                            </td>
+                            <td>@camp.AcceptingMembers</td>
+                            <td class="text-end">@camp.MemberCount</td>
+                            <td>@camp.Zone</td>
+                            <td>@camp.SpaceRequirement</td>
+                            <td class="text-end">@camp.YearsParticipating</td>
+                            <td>
+                                @foreach (var lead in camp.Leads)
+                                {
+                                    <human-link user-id="@lead.UserId" display-name="@lead.DisplayName" />
+                                    if (lead != camp.Leads.Last())
+                                    {
+                                        <text>, </text>
+                                    }
+                                }
+                            </td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
+    </div>
+}
+
 @* All Camps quick list -- link to public page *@
 <div class="card mb-4">
     <div class="card-header d-flex justify-content-between align-items-center">

--- a/src/Humans.Web/Views/Campaign/Detail.cshtml
+++ b/src/Humans.Web/Views/Campaign/Detail.cshtml
@@ -192,7 +192,7 @@
                             _ => "bg-secondary"
                         };
                         <tr>
-                            <td>@grant.User.DisplayName</td>
+                            <td><human-link user-id="@grant.UserId" /></td>
                             <td class="text-muted small">@grant.User.Email</td>
                             <td><code>@grant.Code.Code</code></td>
                             <td>@grant.AssignedAt.ToDisplayDateTime()</td>

--- a/src/Humans.Web/Views/Campaign/Edit.cshtml
+++ b/src/Humans.Web/Views/Campaign/Edit.cshtml
@@ -1,6 +1,12 @@
 @model Humans.Domain.Entities.Campaign
 @{
     ViewData["Title"] = "Edit Campaign";
+    // On validation failure, prefer submitted form values (ViewBag) over the entity's persisted values
+    var title2 = ViewBag.Title2 as string ?? Model.Title;
+    var description = ViewBag.Description as string ?? Model.Description;
+    var emailSubject = ViewBag.EmailSubject as string ?? Model.EmailSubject;
+    var emailBodyTemplate = ViewBag.EmailBodyTemplate as string ?? Model.EmailBodyTemplate;
+    var replyToAddress = ViewBag.ReplyToAddress as string ?? Model.ReplyToAddress;
 }
 
 <h1>Edit Campaign</h1>
@@ -15,23 +21,23 @@
 
             <div class="mb-3">
                 <label for="title" class="form-label">Title</label>
-                <input type="text" class="form-control" id="title" name="title" value="@Model.Title" required />
+                <input type="text" class="form-control" id="title" name="title" value="@title2" required />
             </div>
 
             <div class="mb-3">
                 <label for="description" class="form-label">Description</label>
-                <textarea class="form-control" id="description" name="description" rows="3">@Model.Description</textarea>
+                <textarea class="form-control" id="description" name="description" rows="3">@description</textarea>
             </div>
 
             <div class="mb-3">
                 <label for="emailSubject" class="form-label">Email Subject</label>
-                <input type="text" class="form-control" id="emailSubject" name="emailSubject" value="@Model.EmailSubject" required />
+                <input type="text" class="form-control" id="emailSubject" name="emailSubject" value="@emailSubject" required />
                 <small class="form-text text-muted">You can use <code>{{Name}}</code> to insert the human's name.</small>
             </div>
 
             <div class="mb-3">
                 <label for="emailBodyTemplate" class="form-label">Email Body Template</label>
-                <textarea class="form-control font-monospace" id="emailBodyTemplate" name="emailBodyTemplate" rows="10" required>@Model.EmailBodyTemplate</textarea>
+                <textarea class="form-control font-monospace" id="emailBodyTemplate" name="emailBodyTemplate" rows="10" required>@emailBodyTemplate</textarea>
                 <div class="form-text">
                     <a href="#" data-bs-toggle="modal" data-bs-target="#markdownHelpModal">
                         <i class="fa-solid fa-circle-info me-1"></i>Markdown formatting is supported
@@ -42,7 +48,7 @@
 
             <div class="mb-3">
                 <label for="replyToAddress" class="form-label">Reply-To Address <span class="text-muted">(optional)</span></label>
-                <input type="email" class="form-control" id="replyToAddress" name="replyToAddress" value="@Model.ReplyToAddress" placeholder="e.g. tickets@nobodies.team">
+                <input type="email" class="form-control" id="replyToAddress" name="replyToAddress" value="@replyToAddress" placeholder="e.g. tickets@nobodies.team">
                 <small class="form-text text-muted">Recipients who reply to the campaign email will reach this address.</small>
             </div>
 

--- a/src/Humans.Web/Views/Email/EmailOutbox.cshtml
+++ b/src/Humans.Web/Views/Email/EmailOutbox.cshtml
@@ -124,7 +124,16 @@
                             _ => "bg-secondary"
                         };
                         <tr>
-                            <td>@(msg.User?.DisplayName ?? msg.RecipientName ?? "—")</td>
+                            <td>
+                                @if (msg.UserId.HasValue)
+                                {
+                                    <human-link user-id="@msg.UserId.Value" />
+                                }
+                                else
+                                {
+                                    @(msg.RecipientName ?? "—")
+                                }
+                            </td>
                             <td><code class="small">@msg.TemplateName</code></td>
                             <td class="small">@msg.RecipientEmail</td>
                             <td>

--- a/src/Humans.Web/Views/Finance/AuditLog.cshtml
+++ b/src/Humans.Web/Views/Finance/AuditLog.cshtml
@@ -55,7 +55,7 @@
                     {
                         <tr>
                             <td class="text-nowrap">@entry.OccurredAt.ToDateTimeUtc().ToString("g")</td>
-                            <td>@(entry.ActorUser?.DisplayName ?? entry.ActorUser?.Email ?? "Unknown")</td>
+                            <td><human-link user-id="@entry.ActorUserId" /></td>
                             <td><span class="badge bg-secondary">@entry.EntityType</span></td>
                             <td>@entry.Description</td>
                             <td>@(entry.FieldName ?? "")</td>

--- a/src/Humans.Web/Views/Google/EmailBackfillReview.cshtml
+++ b/src/Humans.Web/Views/Google/EmailBackfillReview.cshtml
@@ -65,7 +65,7 @@
                                                name="corrections[@mismatch.UserId]"
                                                value="@mismatch.GoogleEmail" />
                                     </td>
-                                    <td>@mismatch.DisplayName</td>
+                                    <td><human-link user-id="@mismatch.UserId" display-name="@mismatch.DisplayName" /></td>
                                     <td><code>@mismatch.StoredEmail</code></td>
                                     <td>
                                         <code class="text-success">@mismatch.GoogleEmail</code>

--- a/src/Humans.Web/Views/Guest/Index.cshtml
+++ b/src/Humans.Web/Views/Guest/Index.cshtml
@@ -14,13 +14,12 @@
         <div class="card mb-4">
             <div class="card-body text-center py-5">
                 <i class="fa-solid fa-user-plus fa-3x text-primary mb-3"></i>
-                <h3>Want to get involved?</h3>
+                <h3>@Localizer["Guest_GetInvolvedTitle"]</h3>
                 <p class="text-muted mb-3">
-                    Create a profile to become a volunteer and access the full Humans experience &mdash;
-                    shifts, teams, governance, and more.
+                    @Localizer["Guest_GetInvolvedDescription"]
                 </p>
                 <a asp-controller="Profile" asp-action="Edit" class="btn btn-primary btn-lg">
-                    <i class="fa-solid fa-id-card me-2"></i>Create Profile
+                    <i class="fa-solid fa-id-card me-2"></i>@Localizer["Guest_CreateProfile"]
                 </a>
             </div>
         </div>
@@ -29,7 +28,7 @@
     <div class="col-lg-4">
         <div class="card mb-4">
             <div class="card-header">
-                <h5 class="mb-0"><i class="fa-solid fa-compass me-2"></i>Explore</h5>
+                <h5 class="mb-0"><i class="fa-solid fa-compass me-2"></i>@Localizer["Guest_Explore"]</h5>
             </div>
             <div class="card-body">
                 <ul class="list-unstyled mb-0">
@@ -45,7 +44,7 @@
                     </li>
                     <li class="mb-2">
                         <a asp-controller="Legal" asp-action="Index">
-                            <i class="fa-solid fa-scale-balanced me-2"></i>Legal
+                            <i class="fa-solid fa-scale-balanced me-2"></i>@Localizer["Guest_Legal"]
                         </a>
                     </li>
                 </ul>

--- a/src/Humans.Web/Views/OnboardingReview/BoardVoting.cshtml
+++ b/src/Humans.Web/Views/OnboardingReview/BoardVoting.cshtml
@@ -32,7 +32,7 @@ else
                             @foreach (var member in Model.BoardMembers)
                             {
                                 <th class="text-center" style="min-width: 80px;">
-                                    <small>@member.DisplayName</small>
+                                    <small><human-link user-id="@member.UserId" display-name="@member.DisplayName" /></small>
                                 </th>
                             }
                             <th></th>
@@ -55,13 +55,9 @@ else
                             }
                             <tr data-href="@Url.Action("BoardVotingDetail", new { applicationId = app.ApplicationId })">
                                 <td>
-                                    <div class="d-flex align-items-center">
-                                        <vc:user-avatar profile-picture-url="@app.ProfilePictureUrl"
-                                                        display-name="@app.DisplayName"
-                                                        size="32"
-                                                        css-class="me-2" />
-                                        <span>@app.DisplayName</span>
-                                    </div>
+                                    <human-link user-id="@app.UserId" display-name="@app.DisplayName"
+                                                mode="AvatarName" size="32"
+                                                profile-picture-url="@app.ProfilePictureUrl" />
                                 </td>
                                 <td class="text-center">
                                     <span class="badge @(app.MembershipTier == MembershipTier.Asociado ? "bg-primary" : "bg-info")">

--- a/src/Humans.Web/Views/OnboardingReview/BoardVotingDetail.cshtml
+++ b/src/Humans.Web/Views/OnboardingReview/BoardVotingDetail.cshtml
@@ -96,7 +96,7 @@
                                     _ => "bg-secondary"
                                 };
                                 <tr>
-                                    <td>@v.DisplayName</td>
+                                    <td><human-link user-id="@v.BoardMemberUserId" display-name="@v.DisplayName" /></td>
                                     <td><span class="badge @badgeClass">@v.Vote</span></td>
                                 <td><small>@v.VotedAt.ToDisplayDate()</small></td>
                                     <td><small class="text-muted">@v.Note</small></td>

--- a/src/Humans.Web/Views/OnboardingReview/Index.cshtml
+++ b/src/Humans.Web/Views/OnboardingReview/Index.cshtml
@@ -27,18 +27,14 @@
     <div class="list-group mb-4">
         @foreach (var item in Model.PendingReviews)
         {
-            <a asp-action="Detail" asp-route-userId="@item.UserId" class="list-group-item list-group-item-action">
+            <div class="list-group-item">
                 <div class="d-flex justify-content-between align-items-center">
                     <div class="d-flex align-items-center">
-                        <vc:user-avatar profile-picture-url="@item.ProfilePictureUrl"
-                                        display-name="@item.DisplayName"
-                                        size="40"
-                                        css-class="me-3" />
-                        <div>
-                            <strong>@item.DisplayName</strong>
-                            <br />
+                        <human-link user-id="@item.UserId" display-name="@item.DisplayName"
+                                    mode="AvatarName" size="40"
+                                    profile-picture-url="@item.ProfilePictureUrl">
                             <small class="text-muted">@item.Email</small>
-                        </div>
+                        </human-link>
                     </div>
                     <div class="text-end">
                         @if (item.MembershipTier != MembershipTier.Volunteer)
@@ -53,10 +49,13 @@
                             </span>
                         }
                         <br />
-                                    <small class="text-muted">@item.ProfileCreatedAt.ToDisplayDate()</small>
+                        <small class="text-muted">@item.ProfileCreatedAt.ToDisplayDate()</small>
+                        <a asp-action="Detail" asp-route-userId="@item.UserId" class="btn btn-sm btn-outline-primary ms-2">
+                            <i class="fa-solid fa-eye me-1"></i>Review
+                        </a>
                     </div>
                 </div>
-            </a>
+            </div>
         }
     </div>
 }
@@ -71,18 +70,14 @@
     <div class="list-group mb-4">
         @foreach (var item in Model.FlaggedReviews)
         {
-            <a asp-action="Detail" asp-route-userId="@item.UserId" class="list-group-item list-group-item-action list-group-item-danger">
+            <div class="list-group-item list-group-item-danger">
                 <div class="d-flex justify-content-between align-items-center">
                     <div class="d-flex align-items-center">
-                        <vc:user-avatar profile-picture-url="@item.ProfilePictureUrl"
-                                        display-name="@item.DisplayName"
-                                        size="40"
-                                        css-class="me-3" />
-                        <div>
-                            <strong>@item.DisplayName</strong>
-                            <br />
+                        <human-link user-id="@item.UserId" display-name="@item.DisplayName"
+                                    mode="AvatarName" size="40"
+                                    profile-picture-url="@item.ProfilePictureUrl">
                             <small class="text-muted">@item.Email</small>
-                        </div>
+                        </human-link>
                     </div>
                     <div class="text-end">
                         @if (item.MembershipTier != MembershipTier.Volunteer)
@@ -98,10 +93,13 @@
                             </span>
                         }
                         <br />
-                                    <small class="text-muted">@item.ProfileCreatedAt.ToDisplayDate()</small>
+                        <small class="text-muted">@item.ProfileCreatedAt.ToDisplayDate()</small>
+                        <a asp-action="Detail" asp-route-userId="@item.UserId" class="btn btn-sm btn-outline-primary ms-2">
+                            <i class="fa-solid fa-eye me-1"></i>Review
+                        </a>
                     </div>
                 </div>
-            </a>
+            </div>
         }
     </div>
 }

--- a/src/Humans.Web/Views/Profile/AdminList.cshtml
+++ b/src/Humans.Web/Views/Profile/AdminList.cshtml
@@ -106,16 +106,11 @@
                     {
                         <tr>
                             <td>
-                                <div class="d-flex align-items-center">
-                                    <vc:user-avatar profile-picture-url="@member.ProfilePictureUrl"
-                                                    display-name="@member.DisplayName"
-                                                    size="32"
-                                                    css-class="me-2" />
-                                    <div>
-                                        <div>@member.DisplayName</div>
-                                        <small class="text-muted">@member.Email</small>
-                                    </div>
-                                </div>
+                                <human-link user-id="@member.Id" display-name="@member.DisplayName"
+                                            mode="AvatarName" size="32"
+                                            profile-picture-url="@member.ProfilePictureUrl" admin="true">
+                                    <small class="text-muted">@member.Email</small>
+                                </human-link>
                             </td>
                             <td>@member.CreatedAt.ToDisplayDate()</td>
                             <td>

--- a/src/Humans.Web/Views/Vol/DepartmentDetail.cshtml
+++ b/src/Humans.Web/Views/Vol/DepartmentDetail.cshtml
@@ -104,8 +104,9 @@ else
                         {
                             <tr>
                                 <td class="d-flex align-items-center gap-2">
-                                    <vc:user-avatar profile-picture-url="@member.ProfilePictureUrl" display-name="@member.DisplayName" size="28" />
-                                    @member.DisplayName
+                                    <human-link user-id="@member.UserId" display-name="@member.DisplayName"
+                                                mode="AvatarName" size="28"
+                                                profile-picture-url="@member.ProfilePictureUrl" />
                                 </td>
                                 <td>
                                     @foreach (var teamName in member.SourceTeams)


### PR DESCRIPTION
## Summary
- Fix entity detach anti-pattern in CampaignController (#426)
- Enhance Admin Logs: default 200 entries + level summary (#444)
- Add camp summary table to Barrios Admin page (#445)
- Localize Guest dashboard hardcoded strings (#455)
- Replace plain-text names with human-link across 11 views (#446)

## Issues
- Closes peterdrier/Humans#426 (upstream: nobodies-collective/Humans#426)
- Closes peterdrier/Humans#444 (upstream: nobodies-collective/Humans#444)
- Closes peterdrier/Humans#445 (upstream: nobodies-collective/Humans#445)
- Closes peterdrier/Humans#455 (upstream: nobodies-collective/Humans#455)
- Closes peterdrier/Humans#446 (upstream: nobodies-collective/Humans#446)

## Test plan
- [ ] CampaignController edit re-display works without EntityState.Detached
- [ ] Admin Logs shows 200 entries and level summary counts
- [x] Barrios Admin shows camp summary table with human-links for leads
- [x] Guest dashboard strings are localized in all 6 locales (en, es, de, fr, it, ca)
- [x] All 11 views show clickable human-link instead of plain text names

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>