### PR TITLE
Add admin tool to detect and fix renamed @nobodies.team emails (#459)

### DIFF
--- a/src/Humans.Application/DTOs/EmailRenameDetectionResult.cs
+++ b/src/Humans.Application/DTOs/EmailRenameDetectionResult.cs
@@ -1,0 +1,24 @@
+namespace Humans.Application.DTOs;
+
+/// <summary>
+/// A detected email rename: the user's stored GoogleEmail differs from
+/// the current primaryEmail returned by Google Directory API.
+/// </summary>
+public class EmailRenameInfo
+{
+    public Guid UserId { get; init; }
+    public string DisplayName { get; init; } = string.Empty;
+    public string OldEmail { get; init; } = string.Empty;
+    public string NewEmail { get; init; } = string.Empty;
+    public int AffectedResourceCount { get; init; }
+}
+
+/// <summary>
+/// Result of scanning for renamed @nobodies.team emails.
+/// </summary>
+public class EmailRenameDetectionResult
+{
+    public List<EmailRenameInfo> Renames { get; init; } = [];
+    public int TotalUsersChecked { get; init; }
+    public string? ErrorMessage { get; init; }
+}

--- a/src/Humans.Application/Interfaces/IGoogleAdminService.cs
+++ b/src/Humans.Application/Interfaces/IGoogleAdminService.cs
@@ -1,3 +1,5 @@
+using Humans.Application.DTOs;
+
 namespace Humans.Application.Interfaces;
 
 /// <summary>
@@ -70,6 +72,21 @@ public interface IGoogleAdminService
     /// </summary>
     Task<IReadOnlyList<TeamSummary>> GetActiveTeamsAsync(
         CancellationToken ct = default);
+
+    /// <summary>
+    /// Detects @nobodies.team email renames by comparing stored GoogleEmail
+    /// against current primaryEmail from Google Directory API.
+    /// </summary>
+    Task<EmailRenameDetectionResult> DetectEmailRenamesAsync(
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Fixes a detected email rename by updating User.GoogleEmail and the
+    /// corresponding UserEmail record to the new primary email.
+    /// </summary>
+    Task<EmailRenameFixResult> FixEmailRenameAsync(
+        Guid userId, string newEmail, Guid actorUserId,
+        CancellationToken ct = default);
 }
 
 /// <summary>
@@ -128,3 +145,11 @@ public record GroupLinkActionResult(
 /// Minimal team info for dropdowns/selectors.
 /// </summary>
 public record TeamSummary(Guid Id, string Name);
+
+/// <summary>
+/// Result of fixing a single email rename.
+/// </summary>
+public record EmailRenameFixResult(
+    bool Success,
+    string? Message = null,
+    string? ErrorMessage = null);

--- a/src/Humans.Domain/Enums/AuditAction.cs
+++ b/src/Humans.Domain/Enums/AuditAction.cs
@@ -74,4 +74,5 @@ public enum AuditAction
     RotaMovedToTeam,
     GoogleResourceInheritanceDriftCorrected,
     FeedbackAssignmentChanged,
+    GoogleEmailRenamed,
 }

--- a/src/Humans.Infrastructure/Services/GoogleAdminService.cs
+++ b/src/Humans.Infrastructure/Services/GoogleAdminService.cs
@@ -1,3 +1,4 @@
+using Humans.Application.DTOs;
 using Humans.Application.Helpers;
 using Humans.Application.Interfaces;
 using Humans.Domain.Constants;
@@ -424,5 +425,155 @@ public class GoogleAdminService : IGoogleAdminService
             .OrderBy(t => t.Name)
             .Select(t => new TeamSummary(t.Id, t.Name))
             .ToListAsync(ct);
+    }
+
+    public async Task<EmailRenameDetectionResult> DetectEmailRenamesAsync(
+        CancellationToken ct = default)
+    {
+        try
+        {
+            // Load all users with a @nobodies.team GoogleEmail
+            var usersWithGoogleEmail = await _dbContext.Users
+                .AsNoTracking()
+                .Where(u => u.GoogleEmail != null)
+                .Select(u => new { u.Id, u.DisplayName, u.GoogleEmail })
+                .ToListAsync(ct);
+
+            var nobodiesUsers = usersWithGoogleEmail
+                .Where(u => u.GoogleEmail!.EndsWith($"@{NobodiesTeamDomain}", StringComparison.OrdinalIgnoreCase))
+                .ToList();
+
+            // Load resource counts per team for affected resource calculation
+            var teamResourceCounts = await _dbContext.GoogleResources
+                .Where(r => r.IsActive)
+                .GroupBy(r => r.TeamId)
+                .Select(g => new { TeamId = g.Key, Count = g.Count() })
+                .ToDictionaryAsync(x => x.TeamId, x => x.Count, ct);
+
+            // Load active team memberships per user
+            var userTeamIds = await _dbContext.TeamMembers
+                .Where(tm => tm.LeftAt == null)
+                .Where(tm => nobodiesUsers.Select(u => u.Id).Contains(tm.UserId))
+                .Select(tm => new { tm.UserId, tm.TeamId })
+                .ToListAsync(ct);
+
+            var userTeamLookup = userTeamIds
+                .GroupBy(x => x.UserId)
+                .ToDictionary(g => g.Key, g => g.Select(x => x.TeamId).ToList());
+
+            var renames = new List<EmailRenameInfo>();
+
+            foreach (var user in nobodiesUsers)
+            {
+                try
+                {
+                    var account = await _workspaceUserService.GetAccountAsync(user.GoogleEmail!, ct);
+
+                    if (account is null)
+                    {
+                        // Account not found — skip (could be deleted or suspended)
+                        continue;
+                    }
+
+                    if (!string.Equals(account.PrimaryEmail, user.GoogleEmail, StringComparison.OrdinalIgnoreCase))
+                    {
+                        // Email was renamed
+                        var affectedResources = 0;
+                        if (userTeamLookup.TryGetValue(user.Id, out var teamIds))
+                        {
+                            affectedResources = teamIds.Sum(tid =>
+                                teamResourceCounts.TryGetValue(tid, out var count) ? count : 0);
+                        }
+
+                        renames.Add(new EmailRenameInfo
+                        {
+                            UserId = user.Id,
+                            DisplayName = user.DisplayName ?? "Unknown",
+                            OldEmail = user.GoogleEmail!,
+                            NewEmail = account.PrimaryEmail,
+                            AffectedResourceCount = affectedResources
+                        });
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex,
+                        "Failed to check email rename for user {UserId} ({Email})",
+                        user.Id, user.GoogleEmail);
+                }
+            }
+
+            return new EmailRenameDetectionResult
+            {
+                Renames = renames,
+                TotalUsersChecked = nobodiesUsers.Count
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to detect email renames");
+            return new EmailRenameDetectionResult
+            {
+                ErrorMessage = "Failed to detect email renames. Check the logs for details."
+            };
+        }
+    }
+
+    public async Task<EmailRenameFixResult> FixEmailRenameAsync(
+        Guid userId, string newEmail, Guid actorUserId,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            var user = await _dbContext.Users
+                .Include(u => u.UserEmails)
+                .FirstOrDefaultAsync(u => u.Id == userId, ct);
+
+            if (user is null)
+            {
+                return new EmailRenameFixResult(false, ErrorMessage: "Human not found.");
+            }
+
+            var oldEmail = user.GoogleEmail;
+            if (string.IsNullOrEmpty(oldEmail))
+            {
+                return new EmailRenameFixResult(false,
+                    ErrorMessage: "Human does not have a GoogleEmail set.");
+            }
+
+            // Update User.GoogleEmail
+            user.GoogleEmail = newEmail;
+
+            // Update the corresponding UserEmail record if one exists for the old email
+            var oldUserEmail = user.UserEmails.FirstOrDefault(ue =>
+                string.Equals(ue.Email, oldEmail, StringComparison.OrdinalIgnoreCase));
+
+            if (oldUserEmail is not null)
+            {
+                oldUserEmail.Email = newEmail;
+                oldUserEmail.UpdatedAt = _clock.GetCurrentInstant();
+            }
+
+            _logger.LogInformation(
+                "Admin {AdminId} fixing email rename for user {UserId}: '{OldEmail}' -> '{NewEmail}'",
+                actorUserId, userId, oldEmail, newEmail);
+
+            await _auditLogService.LogAsync(
+                AuditAction.GoogleEmailRenamed,
+                "User", userId,
+                $"Fixed email rename: {oldEmail} -> {newEmail}",
+                actorUserId);
+
+            await _dbContext.SaveChangesAsync(ct);
+
+            return new EmailRenameFixResult(true,
+                Message: $"Updated email for {user.DisplayName}: {oldEmail} -> {newEmail}");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to fix email rename for user {UserId}", userId);
+            return new EmailRenameFixResult(false,
+                ErrorMessage: $"Failed to fix email rename: {ex.Message}");
+        }
     }
 }

--- a/src/Humans.Web/Controllers/GoogleController.cs
+++ b/src/Humans.Web/Controllers/GoogleController.cs
@@ -737,6 +737,81 @@ public class GoogleController : HumansControllerBase
         return View(events);
     }
 
+    // --- Email Rename Detection ---
+
+    [HttpPost("CheckEmailRenames")]
+    [Authorize(Policy = PolicyNames.AdminOnly)]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> CheckEmailRenames()
+    {
+        try
+        {
+            var result = await _googleAdminService.DetectEmailRenamesAsync();
+            TempData["EmailRenameResult"] = System.Text.Json.JsonSerializer.Serialize(result);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to check email renames");
+            SetError($"Email rename check failed: {ex.Message}");
+            return RedirectToAction(nameof(Index));
+        }
+
+        return RedirectToAction(nameof(EmailRenames));
+    }
+
+    [HttpGet("EmailRenames")]
+    [Authorize(Policy = PolicyNames.AdminOnly)]
+    public IActionResult EmailRenames()
+    {
+        EmailRenameDetectionResult? result = null;
+        if (TempData["EmailRenameResult"] is string json)
+        {
+            result = System.Text.Json.JsonSerializer.Deserialize<EmailRenameDetectionResult>(json);
+        }
+
+        if (result is null)
+        {
+            SetInfo("No email rename results to display. Run the check first.");
+            return RedirectToAction(nameof(Index));
+        }
+
+        return View(result);
+    }
+
+    [HttpPost("FixEmailRename")]
+    [Authorize(Policy = PolicyNames.AdminOnly)]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> FixEmailRename(
+        [FromForm] Guid userId, [FromForm] string newEmail)
+    {
+        if (userId == Guid.Empty || string.IsNullOrWhiteSpace(newEmail))
+        {
+            SetError("Invalid request.");
+            return RedirectToAction(nameof(Index));
+        }
+
+        var currentUser = await GetCurrentUserAsync();
+        if (currentUser is null) return Unauthorized();
+
+        try
+        {
+            var result = await _googleAdminService.FixEmailRenameAsync(
+                userId, newEmail, currentUser.Id);
+
+            if (result.Success)
+                SetSuccess(result.Message!);
+            else
+                SetError(result.ErrorMessage!);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to fix email rename for user {UserId}", userId);
+            SetError($"Failed to fix email rename: {ex.Message}");
+        }
+
+        return RedirectToAction(nameof(Index));
+    }
+
     // --- Index ---
 
     [HttpGet("")]

--- a/src/Humans.Web/Views/Google/EmailRenames.cshtml
+++ b/src/Humans.Web/Views/Google/EmailRenames.cshtml
@@ -1,0 +1,93 @@
+@model Humans.Application.DTOs.EmailRenameDetectionResult
+@{
+    ViewData["Title"] = "Email Rename Detection";
+}
+
+<div class="container-fluid px-4">
+    <div class="d-flex justify-content-between align-items-center mt-4 mb-3">
+        <h1>Email Rename Detection</h1>
+        <a asp-action="Index" class="btn btn-outline-secondary btn-sm">
+            <i class="fa-solid fa-arrow-left me-1"></i>Back to Google
+        </a>
+    </div>
+
+    <vc:temp-data-alerts />
+
+    @if (!string.IsNullOrEmpty(Model.ErrorMessage))
+    {
+        <div class="alert alert-danger">
+            <i class="fa-solid fa-triangle-exclamation me-1"></i>Error: @Model.ErrorMessage
+        </div>
+    }
+    else if (Model.Renames.Count == 0)
+    {
+        <div class="alert alert-success">
+            <i class="fa-solid fa-check-circle me-1"></i>All @Model.TotalUsersChecked @@nobodies.team email(s) match Google Directory. No renames detected.
+        </div>
+    }
+    else
+    {
+        <div class="alert alert-warning">
+            <i class="fa-solid fa-triangle-exclamation me-1"></i>
+            Found <strong>@Model.Renames.Count</strong> renamed email(s) out of <strong>@Model.TotalUsersChecked</strong> @@nobodies.team users checked.
+            Review each rename and click <strong>Fix</strong> to update the stored email.
+        </div>
+
+        <div class="card mb-4">
+            <div class="card-header">
+                <i class="fa-solid fa-right-left me-1"></i>Detected Renames
+            </div>
+            <div class="card-body p-0">
+                <table class="table table-sm table-hover mb-0">
+                    <thead>
+                        <tr>
+                            <th>Human</th>
+                            <th>Old Email</th>
+                            <th></th>
+                            <th>New Email</th>
+                            <th>Affected Resources</th>
+                            <th style="width: 100px;"></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var rename in Model.Renames)
+                        {
+                            <tr>
+                                <td>@rename.DisplayName</td>
+                                <td><code class="text-danger">@rename.OldEmail</code></td>
+                                <td><i class="fa-solid fa-arrow-right text-muted"></i></td>
+                                <td><code class="text-success">@rename.NewEmail</code></td>
+                                <td>
+                                    @if (rename.AffectedResourceCount > 0)
+                                    {
+                                        <span class="badge bg-warning text-dark">@rename.AffectedResourceCount</span>
+                                    }
+                                    else
+                                    {
+                                        <span class="text-muted">0</span>
+                                    }
+                                </td>
+                                <td>
+                                    <form asp-action="FixEmailRename" method="post" class="d-inline">
+                                        @Html.AntiForgeryToken()
+                                        <input type="hidden" name="userId" value="@rename.UserId" />
+                                        <input type="hidden" name="newEmail" value="@rename.NewEmail" />
+                                        <button type="submit" class="btn btn-sm btn-outline-primary"
+                                                data-confirm="Update email for @rename.DisplayName from @rename.OldEmail to @rename.NewEmail?">
+                                            <i class="fa-solid fa-wrench me-1"></i>Fix
+                                        </button>
+                                    </form>
+                                </td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
+        </div>
+
+        <div class="text-muted small">
+            <i class="fa-solid fa-info-circle me-1"></i>
+            After fixing a rename, the next sync cycle will automatically resolve any Missing/Extra drift for that human's resources.
+        </div>
+    }
+</div>

--- a/src/Humans.Web/Views/Google/Index.cshtml
+++ b/src/Humans.Web/Views/Google/Index.cshtml
@@ -79,6 +79,22 @@
                 </a>
             </div>
         </div>
+
+        <div class="card mb-4">
+            <div class="card-header">Email Rename Detection</div>
+            <div class="card-body">
+                <form asp-action="CheckEmailRenames" method="post">
+                    @Html.AntiForgeryToken()
+                    <button type="submit" class="btn btn-outline-primary">
+                        <i class="fa-solid fa-right-left me-1"></i>Check Email Renames
+                    </button>
+                    <small class="text-muted d-block mt-1">Detects @@nobodies.team emails that were renamed in Google Workspace. Shows old vs new email and affected resource count.</small>
+                </form>
+                <a asp-action="EmailRenames" class="btn btn-outline-secondary btn-sm mt-3">
+                    <i class="fa-solid fa-list-check me-1"></i>View Last Results
+                </a>
+            </div>
+        </div>
     </div>
 
     <div class="col-md-6">


### PR DESCRIPTION
## Summary
- Add admin page to detect @nobodies.team email renames in Google Workspace
- Show old → new email mapping with affected resource count
- Fix button updates GoogleEmail and UserEmail records per user

## Issues
- Closes peterdrier/Humans#459 (upstream: nobodies-collective/Humans#459)

## Test plan
- [ ] Admin page detects renamed emails by comparing stored GoogleEmail vs Directory API
- [ ] Table shows user, old email, new email, affected resource count
- [ ] Fix button updates GoogleEmail and UserEmail records
- [ ] No auto-fix — requires explicit admin click
- [ ] Nav link added to Google admin section

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>