### PR TITLE
Profileless accounts: dashboard, pre-creation, GDPR deletion (#434, #436, #435)

### DIFF
--- a/src/Humans.Application/Interfaces/IAccountProvisioningService.cs
+++ b/src/Humans.Application/Interfaces/IAccountProvisioningService.cs
@@ -1,0 +1,32 @@
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+
+namespace Humans.Application.Interfaces;
+
+/// <summary>
+/// Provides idempotent account creation for import jobs (ticket import, MailerLite import).
+/// Looks up existing accounts by email across all UserEmails for dedup,
+/// creates User + UserEmail when no match exists.
+/// </summary>
+public interface IAccountProvisioningService
+{
+    /// <summary>
+    /// Finds an existing User by email (checking both User.Email and all UserEmail records)
+    /// or creates a new User + UserEmail if no match exists. Idempotent.
+    /// </summary>
+    /// <param name="email">The email address to look up or create an account for.</param>
+    /// <param name="displayName">Display name for the new account. Falls back to email prefix if null/empty.</param>
+    /// <param name="source">Where this contact was imported from.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The existing or newly created User, and whether a new account was created.</returns>
+    Task<AccountProvisioningResult> FindOrCreateUserByEmailAsync(
+        string email, string? displayName, ContactSource source,
+        CancellationToken ct = default);
+}
+
+/// <summary>
+/// Result of a find-or-create operation.
+/// </summary>
+/// <param name="User">The existing or newly created user.</param>
+/// <param name="Created">True if a new account was created; false if an existing one was found.</param>
+public record AccountProvisioningResult(User User, bool Created);

--- a/src/Humans.Domain/Entities/User.cs
+++ b/src/Humans.Domain/Entities/User.cs
@@ -98,6 +98,12 @@ public class User : IdentityUser<Guid>
     public Instant? DeletionScheduledFor { get; set; }
 
     /// <summary>
+    /// Earliest date the deletion can be processed (event hold for ticket holders).
+    /// When set, ProcessAccountDeletionsJob will not process until this date has passed.
+    /// </summary>
+    public Instant? DeletionEligibleAfter { get; set; }
+
+    /// <summary>
     /// Whether a deletion request is pending.
     /// </summary>
     public bool IsDeletionPending => DeletionRequestedAt.HasValue;

--- a/src/Humans.Infrastructure/Jobs/ProcessAccountDeletionsJob.cs
+++ b/src/Humans.Infrastructure/Jobs/ProcessAccountDeletionsJob.cs
@@ -61,13 +61,15 @@ public class ProcessAccountDeletionsJob : IRecurringJob
 
         try
         {
-            // Find accounts where deletion is scheduled and the time has passed
+            // Find accounts where deletion is scheduled and both the grace period
+            // and any event hold (DeletionEligibleAfter) have passed
             var usersToDelete = await _dbContext.Users
                 .Include(u => u.Profile)
                 .Include(u => u.UserEmails)
                 .Include(u => u.TeamMemberships)
                 .Include(u => u.RoleAssignments)
-                .Where(u => u.DeletionScheduledFor != null && u.DeletionScheduledFor <= now)
+                .Where(u => u.DeletionScheduledFor != null && u.DeletionScheduledFor <= now
+                    && (u.DeletionEligibleAfter == null || u.DeletionEligibleAfter <= now))
                 .ToListAsync(cancellationToken);
 
             if (usersToDelete.Count == 0)
@@ -172,6 +174,7 @@ public class ProcessAccountDeletionsJob : IRecurringJob
         // Clear deletion request fields (deletion is now complete)
         user.DeletionRequestedAt = null;
         user.DeletionScheduledFor = null;
+        user.DeletionEligibleAfter = null;
 
         // Disable login
         user.LockoutEnabled = true;

--- a/src/Humans.Infrastructure/Migrations/20260408105512_AddDeletionEligibleAfter.Designer.cs
+++ b/src/Humans.Infrastructure/Migrations/20260408105512_AddDeletionEligibleAfter.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Humans.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Humans.Infrastructure.Migrations
 {
     [DbContext(typeof(HumansDbContext))]
-    partial class HumansDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260408105512_AddDeletionEligibleAfter")]
+    partial class AddDeletionEligibleAfter
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Humans.Infrastructure/Migrations/20260408105512_AddDeletionEligibleAfter.cs
+++ b/src/Humans.Infrastructure/Migrations/20260408105512_AddDeletionEligibleAfter.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using NodaTime;
+
+#nullable disable
+
+namespace Humans.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDeletionEligibleAfter : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Instant>(
+                name: "DeletionEligibleAfter",
+                table: "users",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DeletionEligibleAfter",
+                table: "users");
+        }
+    }
+}

--- a/src/Humans.Infrastructure/Services/AccountProvisioningService.cs
+++ b/src/Humans.Infrastructure/Services/AccountProvisioningService.cs
@@ -1,0 +1,145 @@
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using NodaTime;
+using Humans.Application.Interfaces;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using Humans.Domain.Helpers;
+using Humans.Infrastructure.Data;
+
+namespace Humans.Infrastructure.Services;
+
+/// <summary>
+/// Idempotent account provisioning for import jobs.
+/// Looks up existing users by email across all UserEmail records using normalizing comparison,
+/// creates User + UserEmail when no match exists.
+/// </summary>
+public class AccountProvisioningService : IAccountProvisioningService
+{
+    private readonly HumansDbContext _dbContext;
+    private readonly UserManager<User> _userManager;
+    private readonly IAuditLogService _auditLogService;
+    private readonly IClock _clock;
+    private readonly ILogger<AccountProvisioningService> _logger;
+
+    public AccountProvisioningService(
+        HumansDbContext dbContext,
+        UserManager<User> userManager,
+        IAuditLogService auditLogService,
+        IClock clock,
+        ILogger<AccountProvisioningService> logger)
+    {
+        _dbContext = dbContext;
+        _userManager = userManager;
+        _auditLogService = auditLogService;
+        _clock = clock;
+        _logger = logger;
+    }
+
+    public async Task<AccountProvisioningResult> FindOrCreateUserByEmailAsync(
+        string email, string? displayName, ContactSource source,
+        CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(email);
+
+        // 1. Check UserEmail records (includes OAuth, verified, and unverified emails)
+        var allUserEmails = await _dbContext.UserEmails
+            .Include(ue => ue.User)
+            .ToListAsync(ct);
+
+        var matchingUserEmail = allUserEmails
+            .FirstOrDefault(ue => NormalizingEmailComparer.Instance.Equals(ue.Email, email));
+
+        if (matchingUserEmail is not null)
+        {
+            var existingUser = matchingUserEmail.User;
+            _logger.LogDebug(
+                "Found existing account {UserId} via UserEmail match for {Email} (source: {Source})",
+                existingUser.Id, email, source);
+
+            // Layer the ContactSource if the user was self-registered (no source yet)
+            if (existingUser.ContactSource is null)
+            {
+                existingUser.ContactSource = source;
+                await _dbContext.SaveChangesAsync(ct);
+            }
+
+            return new AccountProvisioningResult(existingUser, Created: false);
+        }
+
+        // 2. Also check User.Email directly (in case UserEmail record is missing)
+        var allUsers = await _dbContext.Users.ToListAsync(ct);
+        var matchingUser = allUsers
+            .FirstOrDefault(u => u.Email is not null &&
+                                 NormalizingEmailComparer.Instance.Equals(u.Email, email));
+
+        if (matchingUser is not null)
+        {
+            _logger.LogDebug(
+                "Found existing account {UserId} via User.Email match for {Email} (source: {Source})",
+                matchingUser.Id, email, source);
+
+            if (matchingUser.ContactSource is null)
+            {
+                matchingUser.ContactSource = source;
+                await _dbContext.SaveChangesAsync(ct);
+            }
+
+            return new AccountProvisioningResult(matchingUser, Created: false);
+        }
+
+        // 3. No match found — create new User + UserEmail
+        var resolvedDisplayName = string.IsNullOrWhiteSpace(displayName)
+            ? email.Split('@')[0]
+            : displayName;
+
+        var now = _clock.GetCurrentInstant();
+
+        var newUser = new User
+        {
+            UserName = email,
+            Email = email,
+            DisplayName = resolvedDisplayName,
+            ContactSource = source,
+            CreatedAt = now,
+            EmailConfirmed = true,
+        };
+
+        var result = await _userManager.CreateAsync(newUser);
+        if (!result.Succeeded)
+        {
+            var errors = string.Join(", ", result.Errors.Select(e => e.Description));
+            throw new InvalidOperationException($"Failed to create account for {email}: {errors}");
+        }
+
+        var userEmail = new UserEmail
+        {
+            Id = Guid.NewGuid(),
+            UserId = newUser.Id,
+            Email = email,
+            IsOAuth = false,
+            IsVerified = true,
+            IsNotificationTarget = true,
+            Visibility = null,
+            DisplayOrder = 0,
+            CreatedAt = now,
+            UpdatedAt = now,
+        };
+        _dbContext.UserEmails.Add(userEmail);
+
+        await _auditLogService.LogAsync(
+            AuditAction.ContactCreated,
+            nameof(User), newUser.Id,
+            $"Account pre-created from {source} — {email}",
+            nameof(AccountProvisioningService));
+
+        await _dbContext.SaveChangesAsync(ct);
+
+        _logger.LogInformation(
+            "Created new account {UserId} for {Email} (source: {Source}, displayName: {DisplayName})",
+            newUser.Id, email, source, resolvedDisplayName);
+
+        return new AccountProvisioningResult(newUser, Created: true);
+    }
+}

--- a/src/Humans.Infrastructure/Services/ProfileService.cs
+++ b/src/Humans.Infrastructure/Services/ProfileService.cs
@@ -375,6 +375,7 @@ public class ProfileService : IProfileService
 
         user.DeletionRequestedAt = null;
         user.DeletionScheduledFor = null;
+        user.DeletionEligibleAfter = null;
         await _dbContext.SaveChangesAsync(ct);
         _cache.InvalidateUserProfile(userId);
 

--- a/src/Humans.Web/Controllers/GuestController.cs
+++ b/src/Humans.Web/Controllers/GuestController.cs
@@ -142,6 +142,98 @@ public class GuestController : HumansControllerBase
         }
     }
 
+    // ─── GDPR Deletion Request ─────────────────────────────────────
+
+    [HttpPost("Guest/RequestDeletion")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> RequestDeletion()
+    {
+        var user = await GetCurrentUserAsync();
+        if (user is null)
+            return Challenge();
+
+        try
+        {
+            if (user.IsDeletionPending)
+            {
+                SetError("A deletion request is already pending.");
+                return RedirectToAction(nameof(Index));
+            }
+
+            var now = _clock.GetCurrentInstant();
+            var gracePeriod = Duration.FromDays(30);
+
+            // Check for upcoming event tickets — if ticket holder, set EligibleAfter to post-event
+            var eventHoldDate = await GetEventHoldDateAsync(user.Id);
+
+            user.DeletionRequestedAt = now;
+            user.DeletionScheduledFor = now.Plus(gracePeriod);
+            user.DeletionEligibleAfter = eventHoldDate;
+
+            await UpdateCurrentUserAsync(user);
+
+            if (eventHoldDate.HasValue)
+            {
+                SetSuccess(
+                    $"Deletion request recorded. Because you have tickets for an upcoming event, " +
+                    $"your account will be deleted after {eventHoldDate.Value.ToDateTimeUtc():d MMM yyyy}.");
+            }
+            else
+            {
+                SetSuccess(
+                    $"Deletion request recorded. Your account will be permanently deleted on " +
+                    $"{user.DeletionScheduledFor.Value.ToDateTimeUtc():d MMM yyyy}.");
+            }
+
+            _logger.LogWarning(
+                "Profileless user {UserId} requested account deletion. Scheduled: {ScheduledFor}, EligibleAfter: {EligibleAfter}",
+                user.Id, user.DeletionScheduledFor, eventHoldDate);
+
+            return RedirectToAction(nameof(Index));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to process deletion request for user {UserId}", user.Id);
+            SetError("Failed to process deletion request. Please try again.");
+            return RedirectToAction(nameof(Index));
+        }
+    }
+
+    [HttpPost("Guest/CancelDeletion")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> CancelDeletion()
+    {
+        var user = await GetCurrentUserAsync();
+        if (user is null)
+            return Challenge();
+
+        try
+        {
+            if (!user.IsDeletionPending)
+            {
+                SetError("No deletion request is pending.");
+                return RedirectToAction(nameof(Index));
+            }
+
+            user.DeletionRequestedAt = null;
+            user.DeletionScheduledFor = null;
+            user.DeletionEligibleAfter = null;
+
+            await UpdateCurrentUserAsync(user);
+
+            SetSuccess("Deletion request cancelled.");
+            _logger.LogInformation("Profileless user {UserId} cancelled deletion request", user.Id);
+
+            return RedirectToAction(nameof(Index));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to cancel deletion request for user {UserId}", user.Id);
+            SetError("Failed to cancel deletion request. Please try again.");
+            return RedirectToAction(nameof(Index));
+        }
+    }
+
     // ─── Private Helpers ─────────────────────────────────────────────
 
     private async Task<GuestDashboardViewModel> BuildDashboardViewModelAsync(User user)
@@ -183,8 +275,48 @@ public class GuestController : HumansControllerBase
         viewModel.IsDeletionPending = user.IsDeletionPending;
         viewModel.DeletionRequestedAt = user.DeletionRequestedAt?.ToDateTimeUtc();
         viewModel.DeletionScheduledFor = user.DeletionScheduledFor?.ToDateTimeUtc();
+        viewModel.DeletionEligibleAfter = user.DeletionEligibleAfter?.ToDateTimeUtc();
 
         return viewModel;
+    }
+
+    /// <summary>
+    /// If the user has tickets for an upcoming event, returns the post-event date
+    /// (StrikeEndOffset + 1 day after GateOpeningDate). Otherwise returns null.
+    /// </summary>
+    private async Task<Instant?> GetEventHoldDateAsync(Guid userId)
+    {
+        var hasTickets = await _dbContext.TicketOrders
+            .AnyAsync(o => o.MatchedUserId == userId);
+
+        if (!hasTickets)
+        {
+            hasTickets = await _dbContext.TicketAttendees
+                .AnyAsync(a => a.MatchedUserId == userId);
+        }
+
+        if (!hasTickets)
+            return null;
+
+        // Find the active event
+        var activeEvent = await _dbContext.EventSettings
+            .FirstOrDefaultAsync(e => e.IsActive);
+
+        if (activeEvent is null)
+            return null;
+
+        // Compute post-event date: GateOpeningDate + StrikeEndOffset + 1 day
+        var tz = DateTimeZoneProviders.Tzdb.GetZoneOrNull(activeEvent.TimeZoneId)
+                 ?? DateTimeZone.Utc;
+        var postEventDate = activeEvent.GateOpeningDate
+            .PlusDays(activeEvent.StrikeEndOffset + 1);
+        var postEventInstant = postEventDate
+            .AtStartOfDayInZone(tz)
+            .ToInstant();
+
+        // Only apply hold if the event is in the future
+        var now = _clock.GetCurrentInstant();
+        return postEventInstant > now ? postEventInstant : null;
     }
 
     private async Task<CommunicationPreferencesViewModel> BuildCommunicationPreferencesViewModelAsync(Guid userId)

--- a/src/Humans.Web/Controllers/GuestController.cs
+++ b/src/Humans.Web/Controllers/GuestController.cs
@@ -1,21 +1,51 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Humans.Application.Extensions;
+using Humans.Application.Interfaces;
 using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using Humans.Infrastructure.Data;
+using Humans.Web.Models;
+using NodaTime;
 
 namespace Humans.Web.Controllers;
 
 /// <summary>
 /// Dashboard for profileless accounts (authenticated users without a Profile).
-/// Phase A shell: basic landing page with placeholder sections.
-/// Later phases will add comms preferences, GDPR tools, ticket status, and create-profile CTA.
+/// Provides comms preferences, GDPR tools, ticket status, and create-profile CTA.
 /// </summary>
 [Authorize]
 public class GuestController : HumansControllerBase
 {
-    public GuestController(UserManager<User> userManager)
+    private readonly ICommunicationPreferenceService _commPrefService;
+    private readonly IProfileService _profileService;
+    private readonly HumansDbContext _dbContext;
+    private readonly IClock _clock;
+    private readonly ILogger<GuestController> _logger;
+
+    private static readonly System.Text.Json.JsonSerializerOptions ExportJsonOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
+
+    public GuestController(
+        UserManager<User> userManager,
+        ICommunicationPreferenceService commPrefService,
+        IProfileService profileService,
+        HumansDbContext dbContext,
+        IClock clock,
+        ILogger<GuestController> logger)
         : base(userManager)
     {
+        _commPrefService = commPrefService;
+        _profileService = profileService;
+        _dbContext = dbContext;
+        _clock = clock;
+        _logger = logger;
     }
 
     public async Task<IActionResult> Index()
@@ -26,7 +56,168 @@ public class GuestController : HumansControllerBase
             return Challenge();
         }
 
-        ViewData["DisplayName"] = user.DisplayName;
-        return View();
+        try
+        {
+            var viewModel = await BuildDashboardViewModelAsync(user);
+            return View(viewModel);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to load Guest dashboard for user {UserId}", user.Id);
+            return View(new GuestDashboardViewModel { DisplayName = user.DisplayName });
+        }
+    }
+
+    // ─── Communication Preferences ───────────────────────────────────
+
+    [HttpGet("Guest/CommunicationPreferences")]
+    public async Task<IActionResult> CommunicationPreferences()
+    {
+        try
+        {
+            var user = await GetCurrentUserAsync();
+            if (user is null)
+                return Challenge();
+
+            return View(await BuildCommunicationPreferencesViewModelAsync(user.Id));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to load communication preferences");
+            SetError("Failed to load communication preferences.");
+            return RedirectToAction(nameof(Index));
+        }
+    }
+
+    [HttpPost("Guest/CommunicationPreferences/Update")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> UpdatePreference(MessageCategory category, bool emailEnabled, bool alertEnabled)
+    {
+        try
+        {
+            var user = await GetCurrentUserAsync();
+            if (user is null)
+                return Unauthorized();
+
+            if (category.IsAlwaysOn())
+                return BadRequest("Cannot change always-on categories.");
+
+            await _commPrefService.UpdatePreferenceAsync(
+                user.Id, category, optedOut: !emailEnabled, inboxEnabled: alertEnabled, "Guest");
+
+            return Ok();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to save communication preference for {Category}", category);
+            return StatusCode(500);
+        }
+    }
+
+    // ─── GDPR Data Export ────────────────────────────────────────────
+
+    [HttpGet("Guest/DownloadData")]
+    [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
+    public async Task<IActionResult> DownloadData()
+    {
+        var user = await GetCurrentUserAsync();
+        if (user is null)
+            return Challenge();
+
+        try
+        {
+            var exportData = await _profileService.ExportDataAsync(user.Id);
+
+            var json = System.Text.Json.JsonSerializer.Serialize(exportData, ExportJsonOptions);
+            var bytes = System.Text.Encoding.UTF8.GetBytes(json);
+            var fileName = $"nobodies-data-export-{DateTime.UtcNow.ToIsoDateString()}.json";
+
+            return File(bytes, "application/json", fileName);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to export data for user {UserId}", user.Id);
+            SetError("Failed to export data. Please try again.");
+            return RedirectToAction(nameof(Index));
+        }
+    }
+
+    // ─── Private Helpers ─────────────────────────────────────────────
+
+    private async Task<GuestDashboardViewModel> BuildDashboardViewModelAsync(User user)
+    {
+        var viewModel = new GuestDashboardViewModel
+        {
+            DisplayName = user.DisplayName,
+        };
+
+        // Ticket status: check for matched ticket orders and attendees
+        var hasTicketOrder = await _dbContext.TicketOrders
+            .AnyAsync(o => o.MatchedUserId == user.Id);
+
+        var hasTicketAttendee = await _dbContext.TicketAttendees
+            .AnyAsync(a => a.MatchedUserId == user.Id);
+
+        if (hasTicketOrder || hasTicketAttendee)
+        {
+            viewModel.HasTickets = true;
+
+            // Get ticket details for display
+            var ticketOrders = await _dbContext.TicketOrders
+                .Where(o => o.MatchedUserId == user.Id)
+                .OrderByDescending(o => o.PurchasedAt)
+                .Select(o => new GuestTicketOrderSummary
+                {
+                    BuyerName = o.BuyerName,
+                    PurchasedAt = o.PurchasedAt.ToDateTimeUtc(),
+                    AttendeeCount = o.Attendees.Count,
+                    TotalAmount = o.TotalAmount,
+                    Currency = o.Currency,
+                })
+                .ToListAsync();
+
+            viewModel.TicketOrders = ticketOrders;
+        }
+
+        // Deletion request status
+        viewModel.IsDeletionPending = user.IsDeletionPending;
+        viewModel.DeletionRequestedAt = user.DeletionRequestedAt?.ToDateTimeUtc();
+        viewModel.DeletionScheduledFor = user.DeletionScheduledFor?.ToDateTimeUtc();
+
+        return viewModel;
+    }
+
+    private async Task<CommunicationPreferencesViewModel> BuildCommunicationPreferencesViewModelAsync(Guid userId)
+    {
+        var prefs = await _commPrefService.GetPreferencesAsync(userId);
+        var prefsByCategory = prefs.ToDictionary(p => p.Category);
+
+        var hasTicketOrder = await _dbContext.TicketOrders
+            .AnyAsync(o => o.MatchedUserId == userId);
+
+        var categories = new List<CategoryPreferenceItem>();
+
+        foreach (var category in MessageCategoryExtensions.ActiveCategories)
+        {
+            var pref = prefsByCategory.GetValueOrDefault(category);
+            var isAlwaysOn = category.IsAlwaysOn();
+            var isTicketingLocked = category == MessageCategory.Ticketing && hasTicketOrder;
+
+            categories.Add(new CategoryPreferenceItem
+            {
+                Category = category,
+                DisplayName = category == MessageCategory.Ticketing
+                    ? $"Ticketing — {DateTime.UtcNow.Year}"
+                    : category.ToDisplayName(),
+                Description = category.ToDescription(),
+                EmailEnabled = pref is null || !pref.OptedOut,
+                AlertEnabled = pref?.InboxEnabled ?? true,
+                EmailEditable = !isAlwaysOn && !isTicketingLocked,
+                AlertEditable = !isAlwaysOn && !isTicketingLocked,
+                Note = isTicketingLocked ? "Locked — you have a ticket order for this year" : null,
+            });
+        }
+
+        return new CommunicationPreferencesViewModel { Categories = categories };
     }
 }

--- a/src/Humans.Web/Controllers/ProfileController.cs
+++ b/src/Humans.Web/Controllers/ProfileController.cs
@@ -431,6 +431,18 @@ public class ProfileController : HumansControllerBase
             user.Id, model.BurnerName, saveRequest,
             CultureInfo.CurrentUICulture.TwoLetterISOLanguageName);
 
+        // Cancel any pending deletion request when creating a profile
+        if (isInitialSetup && user.IsDeletionPending)
+        {
+            user.DeletionRequestedAt = null;
+            user.DeletionScheduledFor = null;
+            user.DeletionEligibleAfter = null;
+            await UserManager.UpdateAsync(user);
+            _logger.LogInformation(
+                "Cancelled pending deletion request for user {UserId} on profile creation",
+                user.Id);
+        }
+
         // Save contact fields
         var contactFieldDtos = model.EditableContactFields
             .Where(cf => !string.IsNullOrWhiteSpace(cf.Value))

--- a/src/Humans.Web/Extensions/InfrastructureServiceCollectionExtensions.cs
+++ b/src/Humans.Web/Extensions/InfrastructureServiceCollectionExtensions.cs
@@ -152,6 +152,7 @@ public static class InfrastructureServiceCollectionExtensions
         services.AddScoped<IAccountMergeService, AccountMergeService>();
         services.AddScoped<IDuplicateAccountService, DuplicateAccountService>();
         services.AddScoped<IContactService, ContactService>();
+        services.AddScoped<IAccountProvisioningService, AccountProvisioningService>();
         services.AddScoped<IMagicLinkService, MagicLinkService>();
         services.AddScoped<IFeedbackService, FeedbackService>();
         services.AddScoped<IBudgetService, BudgetService>();

--- a/src/Humans.Web/Models/GuestViewModels.cs
+++ b/src/Humans.Web/Models/GuestViewModels.cs
@@ -1,0 +1,39 @@
+namespace Humans.Web.Models;
+
+/// <summary>
+/// View model for the Guest dashboard (profileless accounts).
+/// </summary>
+public class GuestDashboardViewModel
+{
+    public string DisplayName { get; set; } = string.Empty;
+
+    /// <summary>Whether the user has any matched ticket orders or attendee records.</summary>
+    public bool HasTickets { get; set; }
+
+    /// <summary>Summary of the user's ticket orders.</summary>
+    public List<GuestTicketOrderSummary> TicketOrders { get; set; } = [];
+
+    /// <summary>Whether a deletion request is pending.</summary>
+    public bool IsDeletionPending { get; set; }
+
+    /// <summary>When deletion was requested (for display).</summary>
+    public DateTime? DeletionRequestedAt { get; set; }
+
+    /// <summary>When the account is scheduled for deletion (for display).</summary>
+    public DateTime? DeletionScheduledFor { get; set; }
+
+    /// <summary>Earliest date the deletion can be processed (event hold).</summary>
+    public DateTime? DeletionEligibleAfter { get; set; }
+}
+
+/// <summary>
+/// Summary of a ticket order for the Guest dashboard.
+/// </summary>
+public class GuestTicketOrderSummary
+{
+    public string BuyerName { get; set; } = string.Empty;
+    public DateTime PurchasedAt { get; set; }
+    public int AttendeeCount { get; set; }
+    public decimal TotalAmount { get; set; }
+    public string Currency { get; set; } = string.Empty;
+}

--- a/src/Humans.Web/Program.cs
+++ b/src/Humans.Web/Program.cs
@@ -601,7 +601,42 @@ app.MapHub<CityPlanningHub>("/hubs/city-planning");
 {
     using var scope = app.Services.CreateScope();
     var dbContext = scope.ServiceProvider.GetRequiredService<HumansDbContext>();
-    await dbContext.Database.MigrateAsync();
+    var migrationLogger = scope.ServiceProvider.GetRequiredService<ILoggerFactory>().CreateLogger("DatabaseMigration");
+    var dbName = dbContext.Database.GetDbConnection().Database;
+
+    try
+    {
+        var pending = (await dbContext.Database.GetPendingMigrationsAsync()).ToList();
+        var applied = (await dbContext.Database.GetAppliedMigrationsAsync()).ToList();
+
+        migrationLogger.LogInformation(
+            "Database {Database}: {AppliedCount} applied migrations, {PendingCount} pending",
+            dbName, applied.Count, pending.Count);
+
+        if (pending.Count > 0)
+        {
+            foreach (var migration in pending)
+                migrationLogger.LogInformation("Pending migration: {Migration}", migration);
+
+            await dbContext.Database.MigrateAsync();
+
+            var nowApplied = (await dbContext.Database.GetAppliedMigrationsAsync()).ToList();
+            migrationLogger.LogInformation(
+                "Database {Database}: migrations complete — {AppliedCount} total applied",
+                dbName, nowApplied.Count);
+        }
+        else
+        {
+            migrationLogger.LogInformation("Database {Database}: schema is up to date", dbName);
+        }
+    }
+    catch (Exception ex)
+    {
+        migrationLogger.LogError(ex,
+            "Database migration failed for {Database}. The application may not function correctly",
+            dbName);
+        throw;
+    }
 }
 
 if (!app.Environment.IsEnvironment("Testing"))

--- a/src/Humans.Web/Views/Guest/CommunicationPreferences.cshtml
+++ b/src/Humans.Web/Views/Guest/CommunicationPreferences.cshtml
@@ -1,0 +1,133 @@
+@model Humans.Web.Models.CommunicationPreferencesViewModel
+@{
+    ViewData["Title"] = "Communication Preferences";
+}
+
+<div class="row">
+    <div class="col-12" style="max-width: 900px;">
+        <nav aria-label="breadcrumb">
+            <ol class="breadcrumb">
+                <li class="breadcrumb-item"><a asp-action="Index">Dashboard</a></li>
+                <li class="breadcrumb-item active" aria-current="page">Communication Preferences</li>
+            </ol>
+        </nav>
+
+        <h1>Communication Preferences</h1>
+        <p class="text-muted">Choose which communications you receive and how.</p>
+
+        <vc:temp-data-alerts />
+
+        <div class="card mb-4">
+            <div class="table-responsive">
+                <table class="table table-hover mb-0 align-middle">
+                    <thead>
+                        <tr>
+                            <th style="min-width: 250px;">Category</th>
+                            <th class="text-center" style="width: 100px;">Email</th>
+                            <th class="text-center" style="width: 100px;">Alert</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @for (var i = 0; i < Model.Categories.Count; i++)
+                        {
+                            var item = Model.Categories[i];
+
+                            <tr class="@(!item.EmailEditable ? "table-light" : "")">
+                                <td>
+                                    <div class="fw-semibold">@item.DisplayName</div>
+                                    <div class="form-text mb-0">@item.Description</div>
+                                    @if (item.Note is not null)
+                                    {
+                                        <div class="form-text text-warning-emphasis mb-0">
+                                            <i class="fa-solid fa-lock fa-xs me-1"></i>@item.Note
+                                        </div>
+                                    }
+                                </td>
+                                <td class="text-center">
+                                    @if (item.EmailEditable)
+                                    {
+                                        <input type="checkbox"
+                                               class="form-check-input pref-toggle"
+                                               data-category="@item.Category"
+                                               data-channel="email"
+                                               @(item.EmailEnabled ? "checked" : null) />
+                                    }
+                                    else
+                                    {
+                                        <input type="checkbox"
+                                               class="form-check-input"
+                                               disabled
+                                               checked />
+                                    }
+                                </td>
+                                <td class="text-center">
+                                    @if (item.AlertEditable)
+                                    {
+                                        <input type="checkbox"
+                                               class="form-check-input pref-toggle"
+                                               data-category="@item.Category"
+                                               data-channel="alert"
+                                               @(item.AlertEnabled ? "checked" : null) />
+                                    }
+                                    else
+                                    {
+                                        <input type="checkbox"
+                                               class="form-check-input"
+                                               disabled
+                                               checked />
+                                    }
+                                </td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
+        </div>
+
+        <a asp-action="Index" class="btn btn-outline-secondary">Back to Dashboard</a>
+    </div>
+</div>
+
+@section Scripts {
+<script>
+    document.querySelectorAll('.pref-toggle').forEach(function (cb) {
+        cb.addEventListener('change', function () {
+            var row = this.closest('tr');
+            var category = this.dataset.category;
+            var value = this.checked;
+
+            var emailCb = row.querySelector('[data-channel="email"]');
+            var alertCb = row.querySelector('[data-channel="alert"]');
+
+            var body = new URLSearchParams();
+            body.append('category', category);
+            body.append('emailEnabled', emailCb ? emailCb.checked : true);
+            body.append('alertEnabled', alertCb ? alertCb.checked : true);
+            body.append('__RequestVerificationToken',
+                document.querySelector('input[name="__RequestVerificationToken"]').value);
+
+            this.disabled = true;
+            var self = this;
+
+            fetch('@Url.Action("UpdatePreference")', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                body: body.toString()
+            }).then(function (resp) {
+                if (!resp.ok) throw new Error(resp.statusText);
+                row.classList.add('table-success');
+                setTimeout(function () { row.classList.remove('table-success'); }, 600);
+            }).catch(function () {
+                self.checked = !value;
+                row.classList.add('table-danger');
+                setTimeout(function () { row.classList.remove('table-danger'); }, 1500);
+            }).finally(function () {
+                self.disabled = false;
+            });
+        });
+    });
+</script>
+}
+
+@* Anti-forgery token for AJAX posts *@
+<form id="__AjaxAntiForgeryForm" asp-antiforgery="true" style="display:none;"></form>

--- a/src/Humans.Web/Views/Guest/Index.cshtml
+++ b/src/Humans.Web/Views/Guest/Index.cshtml
@@ -9,6 +9,8 @@
     </div>
 </div>
 
+<vc:temp-data-alerts />
+
 <div class="row">
     <div class="col-lg-8">
         @* ─── Create Profile CTA ─── *@
@@ -104,9 +106,9 @@
                         You can request deletion of your account and all associated data.
                         If you have tickets for an upcoming event, the deletion will be held until after the event.
                     </p>
-                    <form asp-action="RequestDeletion" method="post" class="d-inline">
-                        <button type="submit" class="btn btn-outline-danger btn-sm"
-                                onclick="return confirm('Are you sure you want to request account deletion? This action can be cancelled before the deletion date.');">
+                    <form asp-action="RequestDeletion" method="post" class="d-inline"
+                          data-confirm="Are you sure you want to request account deletion? This action can be cancelled before the deletion date.">
+                        <button type="submit" class="btn btn-outline-danger btn-sm">
                             <i class="fa-solid fa-trash-can me-1"></i>Request Account Deletion
                         </button>
                     </form>

--- a/src/Humans.Web/Views/Guest/Index.cshtml
+++ b/src/Humans.Web/Views/Guest/Index.cshtml
@@ -1,16 +1,17 @@
+@model Humans.Web.Models.GuestDashboardViewModel
 @{
     ViewData["Title"] = Localizer["Dashboard_Title"].Value;
-    var displayName = ViewData["DisplayName"] as string ?? "";
 }
 
 <div class="row mb-4">
     <div class="col">
-        <h1>@Html.Raw(string.Format(Localizer["Dashboard_Welcome"].Value, Html.Encode(displayName)))</h1>
+        <h1>@Html.Raw(string.Format(Localizer["Dashboard_Welcome"].Value, Html.Encode(Model.DisplayName)))</h1>
     </div>
 </div>
 
 <div class="row">
     <div class="col-lg-8">
+        @* ─── Create Profile CTA ─── *@
         <div class="card mb-4">
             <div class="card-body text-center py-5">
                 <i class="fa-solid fa-user-plus fa-3x text-primary mb-3"></i>
@@ -24,9 +25,83 @@
                 </a>
             </div>
         </div>
+
+        @* ─── Ticket Status ─── *@
+        @if (Model.HasTickets)
+        {
+            <div class="card mb-4">
+                <div class="card-header">
+                    <h5 class="mb-0"><i class="fa-solid fa-ticket me-2"></i>Your Tickets</h5>
+                </div>
+                <div class="card-body">
+                    @if (Model.TicketOrders.Count > 0)
+                    {
+                        <div class="table-responsive">
+                            <table class="table table-sm mb-0">
+                                <thead>
+                                    <tr>
+                                        <th>Purchased</th>
+                                        <th>Buyer</th>
+                                        <th class="text-center">Tickets</th>
+                                        <th class="text-end">Amount</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    @foreach (var order in Model.TicketOrders)
+                                    {
+                                        <tr>
+                                            <td>@order.PurchasedAt.ToString("d MMM yyyy")</td>
+                                            <td>@order.BuyerName</td>
+                                            <td class="text-center">@order.AttendeeCount</td>
+                                            <td class="text-end">@order.TotalAmount.ToString("N2") @order.Currency</td>
+                                        </tr>
+                                    }
+                                </tbody>
+                            </table>
+                        </div>
+                    }
+                    else
+                    {
+                        <p class="mb-0">
+                            <i class="fa-solid fa-circle-check text-success me-2"></i>
+                            You have a ticket for the event.
+                        </p>
+                    }
+                </div>
+            </div>
+        }
+
+        @* ─── Communication Preferences ─── *@
+        <div class="card mb-4">
+            <div class="card-header d-flex justify-content-between align-items-center">
+                <h5 class="mb-0"><i class="fa-solid fa-bell me-2"></i>Communication Preferences</h5>
+                <a asp-action="CommunicationPreferences" class="btn btn-sm btn-outline-primary">
+                    <i class="fa-solid fa-pen me-1"></i>Manage
+                </a>
+            </div>
+            <div class="card-body">
+                <p class="text-muted mb-0">
+                    Control which communications you receive from Nobodies.
+                </p>
+            </div>
+        </div>
+
+        @* ─── GDPR / Privacy ─── *@
+        <div class="card mb-4">
+            <div class="card-header">
+                <h5 class="mb-0"><i class="fa-solid fa-shield-halved me-2"></i>Privacy &amp; Data</h5>
+            </div>
+            <div class="card-body">
+                <p class="text-muted">Download a copy of all data we hold about you.</p>
+                <a asp-action="DownloadData" class="btn btn-outline-secondary btn-sm">
+                    <i class="fa-solid fa-download me-1"></i>Download My Data
+                </a>
+            </div>
+        </div>
     </div>
 
     <div class="col-lg-4">
+        @* ─── Explore Links ─── *@
         <div class="card mb-4">
             <div class="card-header">
                 <h5 class="mb-0"><i class="fa-solid fa-compass me-2"></i>Explore</h5>
@@ -51,5 +126,36 @@
                 </ul>
             </div>
         </div>
+
+        @* ─── Deletion Status (if pending) ─── *@
+        @if (Model.IsDeletionPending)
+        {
+            <div class="card mb-4 border-warning">
+                <div class="card-header bg-warning-subtle">
+                    <h5 class="mb-0"><i class="fa-solid fa-triangle-exclamation me-2"></i>Deletion Pending</h5>
+                </div>
+                <div class="card-body">
+                    <p class="mb-1">
+                        You requested account deletion on
+                        <strong>@Model.DeletionRequestedAt?.ToString("d MMM yyyy")</strong>.
+                    </p>
+                    @if (Model.DeletionEligibleAfter.HasValue && Model.DeletionEligibleAfter > Model.DeletionScheduledFor)
+                    {
+                        <p class="mb-0 text-warning-emphasis">
+                            <i class="fa-solid fa-clock me-1"></i>
+                            Your account will be deleted after <strong>@Model.DeletionEligibleAfter?.ToString("d MMM yyyy")</strong>
+                            (held until after the event).
+                        </p>
+                    }
+                    else
+                    {
+                        <p class="mb-0">
+                            Your account will be permanently deleted on
+                            <strong>@Model.DeletionScheduledFor?.ToString("d MMM yyyy")</strong>.
+                        </p>
+                    }
+                </div>
+            </div>
+        }
     </div>
 </div>

--- a/src/Humans.Web/Views/Guest/Index.cshtml
+++ b/src/Humans.Web/Views/Guest/Index.cshtml
@@ -93,9 +93,24 @@
             </div>
             <div class="card-body">
                 <p class="text-muted">Download a copy of all data we hold about you.</p>
-                <a asp-action="DownloadData" class="btn btn-outline-secondary btn-sm">
+                <a asp-action="DownloadData" class="btn btn-outline-secondary btn-sm me-2">
                     <i class="fa-solid fa-download me-1"></i>Download My Data
                 </a>
+
+                @if (!Model.IsDeletionPending)
+                {
+                    <hr />
+                    <p class="text-muted mb-2">
+                        You can request deletion of your account and all associated data.
+                        If you have tickets for an upcoming event, the deletion will be held until after the event.
+                    </p>
+                    <form asp-action="RequestDeletion" method="post" class="d-inline">
+                        <button type="submit" class="btn btn-outline-danger btn-sm"
+                                onclick="return confirm('Are you sure you want to request account deletion? This action can be cancelled before the deletion date.');">
+                            <i class="fa-solid fa-trash-can me-1"></i>Request Account Deletion
+                        </button>
+                    </form>
+                }
             </div>
         </div>
     </div>
@@ -141,7 +156,7 @@
                     </p>
                     @if (Model.DeletionEligibleAfter.HasValue && Model.DeletionEligibleAfter > Model.DeletionScheduledFor)
                     {
-                        <p class="mb-0 text-warning-emphasis">
+                        <p class="mb-2 text-warning-emphasis">
                             <i class="fa-solid fa-clock me-1"></i>
                             Your account will be deleted after <strong>@Model.DeletionEligibleAfter?.ToString("d MMM yyyy")</strong>
                             (held until after the event).
@@ -149,11 +164,16 @@
                     }
                     else
                     {
-                        <p class="mb-0">
+                        <p class="mb-2">
                             Your account will be permanently deleted on
                             <strong>@Model.DeletionScheduledFor?.ToString("d MMM yyyy")</strong>.
                         </p>
                     }
+                    <form asp-action="CancelDeletion" method="post">
+                        <button type="submit" class="btn btn-sm btn-outline-success">
+                            <i class="fa-solid fa-rotate-left me-1"></i>Cancel Deletion
+                        </button>
+                    </form>
                 </div>
             </div>
         }

--- a/tests/Humans.Application.Tests/Services/AccountProvisioningServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/AccountProvisioningServiceTests.cs
@@ -1,0 +1,315 @@
+using AwesomeAssertions;
+using Humans.Application.Interfaces;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using Humans.Infrastructure.Data;
+using Humans.Infrastructure.Services;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using NodaTime;
+using NodaTime.Testing;
+using NSubstitute;
+using Xunit;
+
+namespace Humans.Application.Tests.Services;
+
+file sealed class StubAuditLog : IAuditLogService
+{
+    public Task LogAsync(AuditAction action, string entityType, Guid entityId,
+        string description, string jobName,
+        Guid? relatedEntityId = null, string? relatedEntityType = null) => Task.CompletedTask;
+
+    public Task LogAsync(AuditAction action, string entityType, Guid entityId,
+        string description, Guid actorUserId,
+        Guid? relatedEntityId = null, string? relatedEntityType = null) => Task.CompletedTask;
+
+    public Task LogGoogleSyncAsync(AuditAction action, Guid resourceId,
+        string description, string jobName,
+        string userEmail, string role, GoogleSyncSource source, bool success,
+        string? errorMessage = null,
+        Guid? relatedEntityId = null, string? relatedEntityType = null) => Task.CompletedTask;
+
+    public Task<IReadOnlyList<AuditLogEntry>> GetByResourceAsync(Guid resourceId) =>
+        Task.FromResult<IReadOnlyList<AuditLogEntry>>(Array.Empty<AuditLogEntry>());
+
+    public Task<IReadOnlyList<AuditLogEntry>> GetGoogleSyncByUserAsync(Guid userId) =>
+        Task.FromResult<IReadOnlyList<AuditLogEntry>>(Array.Empty<AuditLogEntry>());
+
+    public Task<IReadOnlyList<AuditLogEntry>> GetRecentAsync(int count, CancellationToken ct = default) =>
+        Task.FromResult<IReadOnlyList<AuditLogEntry>>(Array.Empty<AuditLogEntry>());
+
+    public Task<(IReadOnlyList<AuditLogEntry> Items, int TotalCount, int AnomalyCount)> GetFilteredAsync(
+        string? actionFilter, int page, int pageSize, CancellationToken ct = default) =>
+        Task.FromResult<(IReadOnlyList<AuditLogEntry>, int, int)>((Array.Empty<AuditLogEntry>(), 0, 0));
+
+    public Task<IReadOnlyList<AuditLogEntry>> GetByUserAsync(Guid userId, int count, CancellationToken ct = default) =>
+        Task.FromResult<IReadOnlyList<AuditLogEntry>>(Array.Empty<AuditLogEntry>());
+
+    public Task<IReadOnlyList<AuditLogEntry>> GetFilteredEntriesAsync(
+        string? entityType = null,
+        Guid? entityId = null,
+        Guid? userId = null,
+        IReadOnlyList<AuditAction>? actions = null,
+        int limit = 20,
+        CancellationToken ct = default) =>
+        Task.FromResult<IReadOnlyList<AuditLogEntry>>(Array.Empty<AuditLogEntry>());
+}
+
+public class AccountProvisioningServiceTests : IDisposable
+{
+    private readonly HumansDbContext _dbContext;
+    private readonly FakeClock _clock;
+    private readonly UserManager<User> _userManager;
+    private readonly AccountProvisioningService _service;
+
+    public AccountProvisioningServiceTests()
+    {
+        var options = new DbContextOptionsBuilder<HumansDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        _dbContext = new HumansDbContext(options);
+        _clock = new FakeClock(Instant.FromUtc(2026, 4, 8, 12, 0));
+
+        var store = Substitute.For<IUserStore<User>>();
+        _userManager = Substitute.For<UserManager<User>>(
+            store, null, null, null, null, null, null, null, null);
+
+        // Mock CreateAsync to add user to DbContext and return success
+        _userManager.CreateAsync(Arg.Any<User>())
+            .Returns(callInfo =>
+            {
+                var user = callInfo.Arg<User>();
+                if (user.Id == Guid.Empty)
+                    user.Id = Guid.NewGuid();
+                _dbContext.Users.Add(user);
+                _dbContext.SaveChanges();
+                return Task.FromResult(IdentityResult.Success);
+            });
+
+        _service = new AccountProvisioningService(
+            _dbContext,
+            _userManager,
+            new StubAuditLog(),
+            _clock,
+            NullLogger<AccountProvisioningService>.Instance);
+    }
+
+    public void Dispose()
+    {
+        _dbContext.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public async Task FindOrCreateUserByEmailAsync_CreatesNewUser_WhenNoExistingAccount()
+    {
+        var result = await _service.FindOrCreateUserByEmailAsync(
+            "alice@example.com", "Alice Smith", ContactSource.TicketTailor);
+
+        result.Created.Should().BeTrue();
+        result.User.Email.Should().Be("alice@example.com");
+        result.User.DisplayName.Should().Be("Alice Smith");
+        result.User.ContactSource.Should().Be(ContactSource.TicketTailor);
+
+        // Verify UserEmail was created
+        var userEmail = await _dbContext.UserEmails.FirstOrDefaultAsync(
+            ue => ue.UserId == result.User.Id);
+        userEmail.Should().NotBeNull();
+        userEmail!.Email.Should().Be("alice@example.com");
+        userEmail.IsNotificationTarget.Should().BeTrue();
+        userEmail.IsVerified.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task FindOrCreateUserByEmailAsync_FindsExisting_ByPrimaryEmail()
+    {
+        // Seed an existing user
+        var existingUser = new User
+        {
+            Id = Guid.NewGuid(),
+            UserName = "bob@example.com",
+            Email = "bob@example.com",
+            NormalizedEmail = "BOB@EXAMPLE.COM",
+            NormalizedUserName = "BOB@EXAMPLE.COM",
+            DisplayName = "Bob",
+            ContactSource = ContactSource.MailerLite,
+            CreatedAt = _clock.GetCurrentInstant(),
+        };
+        _dbContext.Users.Add(existingUser);
+        _dbContext.UserEmails.Add(new UserEmail
+        {
+            Id = Guid.NewGuid(),
+            UserId = existingUser.Id,
+            Email = "bob@example.com",
+            IsOAuth = true,
+            IsVerified = true,
+            IsNotificationTarget = true,
+            CreatedAt = _clock.GetCurrentInstant(),
+            UpdatedAt = _clock.GetCurrentInstant(),
+        });
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _service.FindOrCreateUserByEmailAsync(
+            "bob@example.com", "Bob Jones", ContactSource.TicketTailor);
+
+        result.Created.Should().BeFalse();
+        result.User.Id.Should().Be(existingUser.Id);
+    }
+
+    [Fact]
+    public async Task FindOrCreateUserByEmailAsync_FindsExisting_BySecondaryEmail()
+    {
+        // Seed a user with a secondary email
+        var existingUser = new User
+        {
+            Id = Guid.NewGuid(),
+            UserName = "carol@primary.com",
+            Email = "carol@primary.com",
+            NormalizedEmail = "CAROL@PRIMARY.COM",
+            NormalizedUserName = "CAROL@PRIMARY.COM",
+            DisplayName = "Carol",
+            CreatedAt = _clock.GetCurrentInstant(),
+        };
+        _dbContext.Users.Add(existingUser);
+        _dbContext.UserEmails.Add(new UserEmail
+        {
+            Id = Guid.NewGuid(),
+            UserId = existingUser.Id,
+            Email = "carol@primary.com",
+            IsOAuth = true,
+            IsVerified = true,
+            IsNotificationTarget = true,
+            CreatedAt = _clock.GetCurrentInstant(),
+            UpdatedAt = _clock.GetCurrentInstant(),
+        });
+        _dbContext.UserEmails.Add(new UserEmail
+        {
+            Id = Guid.NewGuid(),
+            UserId = existingUser.Id,
+            Email = "carol@secondary.com",
+            IsOAuth = false,
+            IsVerified = true,
+            IsNotificationTarget = false,
+            CreatedAt = _clock.GetCurrentInstant(),
+            UpdatedAt = _clock.GetCurrentInstant(),
+        });
+        await _dbContext.SaveChangesAsync();
+
+        // Look up by secondary email
+        var result = await _service.FindOrCreateUserByEmailAsync(
+            "carol@secondary.com", "Carol", ContactSource.TicketTailor);
+
+        result.Created.Should().BeFalse();
+        result.User.Id.Should().Be(existingUser.Id);
+    }
+
+    [Fact]
+    public async Task FindOrCreateUserByEmailAsync_DoesNotCreateDuplicates()
+    {
+        // Create the first time
+        var result1 = await _service.FindOrCreateUserByEmailAsync(
+            "dave@example.com", "Dave", ContactSource.TicketTailor);
+
+        result1.Created.Should().BeTrue();
+
+        // Call again with the same email
+        var result2 = await _service.FindOrCreateUserByEmailAsync(
+            "dave@example.com", "Dave Smith", ContactSource.MailerLite);
+
+        result2.Created.Should().BeFalse();
+        result2.User.Id.Should().Be(result1.User.Id);
+    }
+
+    [Fact]
+    public async Task FindOrCreateUserByEmailAsync_HandlesMultipleSources()
+    {
+        // First call from TicketTailor
+        var result1 = await _service.FindOrCreateUserByEmailAsync(
+            "emma@example.com", "Emma", ContactSource.TicketTailor);
+
+        result1.Created.Should().BeTrue();
+        result1.User.ContactSource.Should().Be(ContactSource.TicketTailor);
+
+        // Second call from MailerLite — should find existing, not re-create
+        var result2 = await _service.FindOrCreateUserByEmailAsync(
+            "emma@example.com", "Emma Jones", ContactSource.MailerLite);
+
+        result2.Created.Should().BeFalse();
+        result2.User.Id.Should().Be(result1.User.Id);
+        // ContactSource remains the original (first source wins)
+        result2.User.ContactSource.Should().Be(ContactSource.TicketTailor);
+    }
+
+    [Fact]
+    public async Task FindOrCreateUserByEmailAsync_SetsContactSource_OnSelfRegisteredUser()
+    {
+        // Seed a self-registered user (no ContactSource)
+        var existingUser = new User
+        {
+            Id = Guid.NewGuid(),
+            UserName = "frank@example.com",
+            Email = "frank@example.com",
+            NormalizedEmail = "FRANK@EXAMPLE.COM",
+            NormalizedUserName = "FRANK@EXAMPLE.COM",
+            DisplayName = "Frank",
+            ContactSource = null,
+            CreatedAt = _clock.GetCurrentInstant(),
+        };
+        _dbContext.Users.Add(existingUser);
+        _dbContext.UserEmails.Add(new UserEmail
+        {
+            Id = Guid.NewGuid(),
+            UserId = existingUser.Id,
+            Email = "frank@example.com",
+            IsOAuth = true,
+            IsVerified = true,
+            IsNotificationTarget = true,
+            CreatedAt = _clock.GetCurrentInstant(),
+            UpdatedAt = _clock.GetCurrentInstant(),
+        });
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _service.FindOrCreateUserByEmailAsync(
+            "frank@example.com", "Frank", ContactSource.TicketTailor);
+
+        result.Created.Should().BeFalse();
+        result.User.Id.Should().Be(existingUser.Id);
+        // ContactSource should now be set
+        result.User.ContactSource.Should().Be(ContactSource.TicketTailor);
+    }
+
+    [Fact]
+    public async Task FindOrCreateUserByEmailAsync_UsesEmailPrefix_WhenDisplayNameEmpty()
+    {
+        var result = await _service.FindOrCreateUserByEmailAsync(
+            "grace@example.com", null, ContactSource.MailerLite);
+
+        result.Created.Should().BeTrue();
+        result.User.DisplayName.Should().Be("grace");
+    }
+
+    [Fact]
+    public async Task FindOrCreateUserByEmailAsync_IsIdempotent_MultipleCalls()
+    {
+        var result1 = await _service.FindOrCreateUserByEmailAsync(
+            "henry@example.com", "Henry", ContactSource.TicketTailor);
+
+        var result2 = await _service.FindOrCreateUserByEmailAsync(
+            "henry@example.com", "Henry", ContactSource.TicketTailor);
+
+        var result3 = await _service.FindOrCreateUserByEmailAsync(
+            "henry@example.com", "Henry", ContactSource.TicketTailor);
+
+        result1.User.Id.Should().Be(result2.User.Id);
+        result2.User.Id.Should().Be(result3.User.Id);
+        result1.Created.Should().BeTrue();
+        result2.Created.Should().BeFalse();
+        result3.Created.Should().BeFalse();
+
+        // Only one user should exist
+        var userCount = await _dbContext.Users.CountAsync(u => u.Email == "henry@example.com");
+        userCount.Should().Be(1);
+    }
+}


### PR DESCRIPTION
## Summary
- Add real dashboard content for profileless accounts: comms prefs, data export, ticket status (#434)
- Add account pre-creation infrastructure for ticket/mailing list imports (#436)
- Add GDPR deletion request with event hold for profileless accounts (#435)

## Issues
- Closes peterdrier/Humans#434 (upstream: nobodies-collective/Humans#434)
- Closes peterdrier/Humans#436 (upstream: nobodies-collective/Humans#436)
- Closes peterdrier/Humans#435 (upstream: nobodies-collective/Humans#435)

## Test plan
- [ ] Profileless user sees comms prefs, data export, ticket status on dashboard
- [ ] Create Profile CTA works and enters initial-setup flow
- [ ] FindOrCreateUserByEmailAsync deduplicates correctly (8 unit tests pass)
- [ ] Deletion request flow works with event hold
- [ ] Creating profile cancels pending deletion request
- [ ] ProcessAccountDeletionsJob respects EligibleAfter and cancelled state
- [ ] EF migration is clean (single nullable column add)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>