### PR TITLE
Fix review findings before production promotion

### DIFF
--- a/docs/features/07-google-integration.md
+++ b/docs/features/07-google-integration.md
@@ -280,7 +280,7 @@ Same diff logic as full sync, but read-only — no writes to Google APIs.
 
 ## Sync Mode Settings
 
-Per-service sync modes control what automated jobs and manual sync actions do. Stored in the `sync_service_settings` table and managed via the Admin Sync Settings page at `/Admin/SyncSettings`.
+Per-service sync modes control what automated jobs and manual sync actions do. Stored in the `sync_service_settings` table and managed via the Admin Sync Settings page at `/Google/SyncSettings`.
 
 ### SyncServiceSettings Entity
 ```
@@ -306,7 +306,7 @@ AddOnly       = 1  // Only add missing members
 AddAndRemove  = 2  // Add missing + remove extra members
 ```
 
-All services default to `SyncMode.None` (seed data). An Admin must explicitly enable sync from the `/Admin/SyncSettings` page before automated jobs or manual sync will modify Google resources.
+All services default to `SyncMode.None` (seed data). An Admin must explicitly enable sync from the `/Google/SyncSettings` page before automated jobs or manual sync will modify Google resources.
 
 ### ISyncSettingsService
 ```csharp
@@ -345,7 +345,7 @@ Settings applied at group creation can drift if someone changes them manually in
 
 **Nightly check + auto-remediation:** Runs as part of `GoogleResourceReconciliationJob` (daily at 03:00). When drift is detected, settings are automatically reapplied via `RemediateGroupSettingsAsync`. Each remediation is audit-logged (`GoogleResourceSettingsRemediated`). Failures are logged but don't stop the reconciliation.
 
-**Manual trigger:** Admin page at `/Admin` has a "Check Group Settings" button. Results show at `/Admin/GroupSettingsResults` with per-group cards listing each drifted setting (expected vs actual) and links to the group in Google.
+**Manual trigger:** The Google admin page at `/Google` has a "Check Group Settings" button. Results show at `/Google/GroupSettingsResults` with per-group cards listing each drifted setting (expected vs actual) and links to the group in Google.
 
 **SyncSettings respected:** If GoogleGroups sync mode is set to None, both the check and auto-remediation are skipped entirely.
 
@@ -462,7 +462,7 @@ Drifted resources shown first, then in-sync.
 ### Sync Settings Page
 
 #### Route: `/Google/SyncSettings`
-Admin-only page for configuring per-service sync modes. Formerly at `/Admin/SyncSettings`.
+Admin-only page for configuring per-service sync modes. Formerly at `/Google/SyncSettings`.
 
 | Route | Method | Action |
 |-------|--------|--------|
@@ -483,7 +483,7 @@ Stub vs. real implementation is selected automatically based on whether `GoogleW
 
 ### GoogleResourceReconciliationJob
 ```
-Schedule: 3:00 AM daily (CURRENTLY DISABLED — manual sync only via /Teams/Sync)
+Schedule: 3:00 AM daily (mode-gated via SyncSettings)
 Purpose: Full reconciliation of all Google resources with DB state
 Process: Reads SyncMode per service from sync_service_settings, then calls
          SyncResourcesByTypeAsync with the appropriate SyncAction
@@ -496,11 +496,11 @@ Process: Reads SyncMode per service from sync_service_settings, then calls
 
 **Drive folder path updates:** After permission sync, the job calls `UpdateDriveFolderPathsAsync` to fetch the current folder name and parent chain for each active Drive resource via the Drive API (`files.get` with `fields=name,parents`). If a folder has been renamed or moved, `GoogleResource.Name` is updated to reflect the full logical path (e.g. "Shared Drive / Department / Subfolder"). This keeps the `/Teams/Sync` page accurate without requiring manual intervention.
 
-> **Currently disabled:** All jobs that modify Google permissions are disabled until the system is validated. Use the manual "Sync Now" button at `/Teams/Sync` or change sync modes at `/Admin/SyncSettings` instead.
+> Jobs are active but mode-gated: each service must have its sync mode set to AddOnly or AddAndRemove at `/Google/SyncSettings` before the job will modify Google resources.
 
 ### SystemTeamSyncJob
 ```
-Schedule: Hourly (CURRENTLY DISABLED — modifies Google permissions)
+Schedule: Hourly (mode-gated via SyncSettings)
 Purpose: Sync system team membership and Google resource permissions
 ```
 

--- a/src/Humans.Application/Interfaces/IProfileService.cs
+++ b/src/Humans.Application/Interfaces/IProfileService.cs
@@ -1,5 +1,6 @@
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
+using NodaTime;
 using MemberApplication = Humans.Domain.Entities.Application;
 
 namespace Humans.Application.Interfaces;
@@ -59,6 +60,12 @@ public interface IProfileService
     Task<Guid> SaveProfileAsync(Guid userId, string displayName, ProfileSaveRequest request, string language, CancellationToken ct = default);
     Task<OnboardingResult> RequestDeletionAsync(Guid userId, CancellationToken ct = default);
     Task<OnboardingResult> CancelDeletionAsync(Guid userId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns a post-event hold date if the user has tickets for the active event,
+    /// or null if no hold applies.
+    /// </summary>
+    Task<Instant?> GetEventHoldDateAsync(Guid userId, CancellationToken ct = default);
     Task<object> ExportDataAsync(Guid userId, CancellationToken ct = default);
     Task<(bool CanAdd, int MinutesUntilResend, Guid? PendingEmailId)>
         GetEmailCooldownInfoAsync(Guid pendingEmailId, CancellationToken ct = default);

--- a/src/Humans.Application/Interfaces/ITicketingBudgetService.cs
+++ b/src/Humans.Application/Interfaces/ITicketingBudgetService.cs
@@ -12,12 +12,12 @@ public interface ITicketingBudgetService
     /// Sync completed weeks of ticket sales into budget line items from TicketTailor/Stripe data,
     /// then refresh projections for future weeks.
     /// </summary>
-    Task<int> SyncActualsAsync(Guid budgetYearId);
+    Task<int> SyncActualsAsync(Guid budgetYearId, CancellationToken ct = default);
 
     /// <summary>
     /// Refresh projected line items only (no actuals sync). Called after saving projection parameters.
     /// </summary>
-    Task<int> RefreshProjectionsAsync(Guid budgetYearId);
+    Task<int> RefreshProjectionsAsync(Guid budgetYearId, CancellationToken ct = default);
 
     /// <summary>
     /// Compute projected line items for future weeks based on ticketing projection parameters

--- a/src/Humans.Infrastructure/Jobs/ProcessAccountDeletionsJob.cs
+++ b/src/Humans.Infrastructure/Jobs/ProcessAccountDeletionsJob.cs
@@ -100,8 +100,10 @@ public class ProcessAccountDeletionsJob : IRecurringJob
                         $"Account anonymized (was {originalName})",
                         nameof(ProcessAccountDeletionsJob));
 
-                    // Cache invalidation must follow the persisted anonymization even if the
-                    // best-effort confirmation email fails afterward.
+                    // Save atomically per user so a failure in one doesn't leave others
+                    // in a partially-persisted state
+                    await _dbContext.SaveChangesAsync(cancellationToken);
+
                     processedUserIds.Add(user.Id);
 
                     // Send confirmation to original email if we have it
@@ -121,13 +123,11 @@ public class ProcessAccountDeletionsJob : IRecurringJob
                 catch (Exception ex)
                 {
                     _logger.LogError(ex,
-                        "Failed to process deletion for user {UserId}",
+                        "Failed to process deletion for user {UserId}. Detaching tracked changes",
                         user.Id);
-                    // Continue processing other users
+                    _dbContext.ChangeTracker.Clear();
                 }
             }
-
-            await _dbContext.SaveChangesAsync(cancellationToken);
 
             foreach (var userId in processedUserIds)
             {

--- a/src/Humans.Infrastructure/Services/GoogleAdminService.cs
+++ b/src/Humans.Infrastructure/Services/GoogleAdminService.cs
@@ -541,8 +541,9 @@ public class GoogleAdminService : IGoogleAdminService
                     ErrorMessage: "Human does not have a GoogleEmail set.");
             }
 
-            // Update User.GoogleEmail
+            // Update User.GoogleEmail and reset sync status so reconciliation resumes
             user.GoogleEmail = newEmail;
+            user.GoogleEmailStatus = GoogleEmailStatus.Unknown;
 
             // Update the corresponding UserEmail record if one exists for the old email
             var oldUserEmail = user.UserEmails.FirstOrDefault(ue =>

--- a/src/Humans.Infrastructure/Services/GoogleWorkspaceSyncService.cs
+++ b/src/Humans.Infrastructure/Services/GoogleWorkspaceSyncService.cs
@@ -465,10 +465,28 @@ public class GoogleWorkspaceSyncService : IGoogleSyncService
         }
         catch (Google.GoogleApiException ex) when (ex.Error?.Code == 403)
         {
+            // Distinguish member-level rejection (no Google account) from
+            // service-account permission errors (caller lacks group access).
+            // Permission errors mention "caller" or "service account" in the message.
+            var errorMessage = ex.Error?.Message ?? ex.Message ?? "";
+            var isCallerPermissionError = errorMessage.Contains("caller", StringComparison.OrdinalIgnoreCase)
+                || errorMessage.Contains("service account", StringComparison.OrdinalIgnoreCase)
+                || errorMessage.Contains("does not have permission", StringComparison.OrdinalIgnoreCase);
+
+            if (isCallerPermissionError)
+            {
+                _logger.LogWarning(
+                    "Service account lacks permission to add members to group {GroupName} ({GroupId}) — HTTP 403: {ErrorMessage}",
+                    resource.Name, resource.GoogleId, errorMessage);
+                // Don't mark the user as rejected — this is a group/SA permission issue, not a user email issue
+                return;
+            }
+
             _logger.LogWarning(
                 "Google rejected {UserEmail} for group {GroupName} ({GroupId}) — HTTP 403. " +
-                "This typically means the email address does not have a Google account associated with it",
-                userEmail, resource.Name, resource.GoogleId);
+                "This typically means the email address does not have a Google account associated with it. " +
+                "Error: {ErrorMessage}",
+                userEmail, resource.Name, resource.GoogleId, errorMessage);
 
             // Mark the user's Google email as Rejected so sync stops retrying
             var user = await _dbContext.Users

--- a/src/Humans.Infrastructure/Services/ProfileService.cs
+++ b/src/Humans.Infrastructure/Services/ProfileService.cs
@@ -633,10 +633,12 @@ public class ProfileService : IProfileService
             .ToListAsync(ct);
 
         // Resolve notification-target emails for display (falls back to OAuth email)
-        var notificationEmails = await _dbContext.UserEmails
+        var notificationEmails = (await _dbContext.UserEmails
             .Where(e => e.IsNotificationTarget && e.IsVerified)
             .Select(e => new { e.UserId, e.Email })
-            .ToDictionaryAsync(e => e.UserId, e => e.Email, ct);
+            .ToListAsync(ct))
+            .GroupBy(e => e.UserId)
+            .ToDictionary(g => g.Key, g => g.First().Email);
 
         if (!string.IsNullOrWhiteSpace(search))
         {

--- a/src/Humans.Infrastructure/Services/ProfileService.cs
+++ b/src/Humans.Infrastructure/Services/ProfileService.cs
@@ -408,15 +408,18 @@ public class ProfileService : IProfileService
 
         var vendorEventId = syncState.VendorEventId;
 
+        // Only hold for paid orders with valid/checked-in attendees
         var hasTickets = await _dbContext.TicketOrders
             .AnyAsync(o => o.MatchedUserId == userId
-                && o.VendorEventId == vendorEventId, ct);
+                && o.VendorEventId == vendorEventId
+                && o.PaymentStatus == TicketPaymentStatus.Paid, ct);
 
         if (!hasTickets)
         {
             hasTickets = await _dbContext.TicketAttendees
                 .AnyAsync(a => a.MatchedUserId == userId
-                    && a.VendorEventId == vendorEventId, ct);
+                    && a.VendorEventId == vendorEventId
+                    && (a.Status == TicketAttendeeStatus.Valid || a.Status == TicketAttendeeStatus.CheckedIn), ct);
         }
 
         if (!hasTickets)

--- a/src/Humans.Infrastructure/Services/ProfileService.cs
+++ b/src/Humans.Infrastructure/Services/ProfileService.cs
@@ -393,6 +393,47 @@ public class ProfileService : IProfileService
         return new OnboardingResult(true);
     }
 
+    public async Task<Instant?> GetEventHoldDateAsync(Guid userId, CancellationToken ct = default)
+    {
+        var activeEvent = await _dbContext.EventSettings
+            .FirstOrDefaultAsync(e => e.IsActive, ct);
+
+        if (activeEvent is null)
+            return null;
+
+        // Use the sync state's VendorEventId to scope to the current event's tickets
+        var syncState = await _dbContext.Set<TicketSyncState>().FirstOrDefaultAsync(ct);
+        if (syncState is null || string.IsNullOrEmpty(syncState.VendorEventId))
+            return null;
+
+        var vendorEventId = syncState.VendorEventId;
+
+        var hasTickets = await _dbContext.TicketOrders
+            .AnyAsync(o => o.MatchedUserId == userId
+                && o.VendorEventId == vendorEventId, ct);
+
+        if (!hasTickets)
+        {
+            hasTickets = await _dbContext.TicketAttendees
+                .AnyAsync(a => a.MatchedUserId == userId
+                    && a.VendorEventId == vendorEventId, ct);
+        }
+
+        if (!hasTickets)
+            return null;
+
+        var tz = DateTimeZoneProviders.Tzdb.GetZoneOrNull(activeEvent.TimeZoneId)
+                 ?? DateTimeZone.Utc;
+        var postEventDate = activeEvent.GateOpeningDate
+            .PlusDays(activeEvent.StrikeEndOffset + 1);
+        var postEventInstant = postEventDate
+            .AtStartOfDayInZone(tz)
+            .ToInstant();
+
+        var now = _clock.GetCurrentInstant();
+        return postEventInstant > now ? postEventInstant : null;
+    }
+
     public async Task<object> ExportDataAsync(Guid userId, CancellationToken ct = default)
     {
         var user = await _dbContext.Users.FindAsync([userId], ct);

--- a/src/Humans.Infrastructure/Services/TicketingBudgetService.cs
+++ b/src/Humans.Infrastructure/Services/TicketingBudgetService.cs
@@ -34,132 +34,140 @@ public class TicketingBudgetService : ITicketingBudgetService
         _logger = logger;
     }
 
-    public async Task<int> SyncActualsAsync(Guid budgetYearId)
+    public async Task<int> SyncActualsAsync(Guid budgetYearId, CancellationToken ct = default)
     {
-        var ticketingGroup = await LoadTicketingGroupAsync(budgetYearId);
-        if (ticketingGroup is null)
+        try
         {
-            _logger.LogDebug("No ticketing group found for budget year {YearId}", budgetYearId);
-            return 0;
-        }
-
-        // Get categories by name
-        var revenueCategory = ticketingGroup.Categories.FirstOrDefault(c => string.Equals(c.Name, "Ticket Revenue", StringComparison.Ordinal));
-        var feesCategory = ticketingGroup.Categories.FirstOrDefault(c => string.Equals(c.Name, "Processing Fees", StringComparison.Ordinal));
-
-        if (revenueCategory is null || feesCategory is null)
-        {
-            _logger.LogWarning("Ticketing group missing expected categories for year {YearId}", budgetYearId);
-            return 0;
-        }
-
-        // Get the VAT rate from the projection parameters (for setting on revenue line items)
-        var projectionVatRate = ticketingGroup.TicketingProjection?.VatRate ?? 0;
-
-        // Load all paid orders with fees
-        var orders = await _dbContext.TicketOrders
-            .Where(o => o.PaymentStatus == TicketPaymentStatus.Paid)
-            .Select(o => new
+            var ticketingGroup = await LoadTicketingGroupAsync(budgetYearId);
+            if (ticketingGroup is null)
             {
-                o.PurchasedAt,
-                o.TotalAmount,
-                o.StripeFee,
-                o.ApplicationFee,
-                TicketCount = o.Attendees.Count(a =>
-                    a.Status == TicketAttendeeStatus.Valid || a.Status == TicketAttendeeStatus.CheckedIn)
-            })
-            .ToListAsync();
+                _logger.LogDebug("No ticketing group found for budget year {YearId}", budgetYearId);
+                return 0;
+            }
 
-        // Group by ISO week (Mon-Sun)
-        var today = _clock.GetCurrentInstant().InUtc().Date;
-        var currentWeekMonday = GetIsoMonday(today);
+            var revenueCategory = ticketingGroup.Categories.FirstOrDefault(c => string.Equals(c.Name, "Ticket Revenue", StringComparison.Ordinal));
+            var feesCategory = ticketingGroup.Categories.FirstOrDefault(c => string.Equals(c.Name, "Processing Fees", StringComparison.Ordinal));
 
-        var weeklyData = orders
-            .GroupBy(o =>
+            if (revenueCategory is null || feesCategory is null)
             {
-                var date = o.PurchasedAt.InUtc().Date;
-                return GetIsoMonday(date);
-            })
-            .Where(g => g.Key < currentWeekMonday) // Only completed weeks
-            .OrderBy(g => g.Key)
-            .Select(g =>
-            {
-                var monday = g.Key;
-                var sunday = monday.PlusDays(6);
-                return new
+                _logger.LogWarning("Ticketing group missing expected categories for year {YearId}", budgetYearId);
+                return 0;
+            }
+
+            var projectionVatRate = ticketingGroup.TicketingProjection?.VatRate ?? 0;
+
+            var orders = await _dbContext.TicketOrders
+                .Where(o => o.PaymentStatus == TicketPaymentStatus.Paid)
+                .Select(o => new
                 {
-                    Monday = monday,
-                    Sunday = sunday,
-                    Label = FormatWeekLabel(monday, sunday),
-                    TicketCount = g.Sum(o => o.TicketCount),
-                    Revenue = g.Sum(o => o.TotalAmount),
-                    StripeFees = g.Sum(o => o.StripeFee ?? 0m),
-                    TtFees = g.Sum(o => o.ApplicationFee ?? 0m)
-                };
-            })
-            .ToList();
+                    o.PurchasedAt,
+                    o.TotalAmount,
+                    o.StripeFee,
+                    o.ApplicationFee,
+                    TicketCount = o.Attendees.Count(a =>
+                        a.Status == TicketAttendeeStatus.Valid || a.Status == TicketAttendeeStatus.CheckedIn)
+                })
+                .ToListAsync(ct);
 
-        var now = _clock.GetCurrentInstant();
-        var lineItemsCreated = 0;
+            var today = _clock.GetCurrentInstant().InUtc().Date;
+            var currentWeekMonday = GetIsoMonday(today);
 
-        foreach (var week in weeklyData)
-        {
-            var weekDesc = week.Label;
+            var weeklyData = orders
+                .GroupBy(o =>
+                {
+                    var date = o.PurchasedAt.InUtc().Date;
+                    return GetIsoMonday(date);
+                })
+                .Where(g => g.Key < currentWeekMonday)
+                .OrderBy(g => g.Key)
+                .Select(g =>
+                {
+                    var monday = g.Key;
+                    var sunday = monday.PlusDays(6);
+                    return new
+                    {
+                        Monday = monday,
+                        Sunday = sunday,
+                        Label = FormatWeekLabel(monday, sunday),
+                        TicketCount = g.Sum(o => o.TicketCount),
+                        Revenue = g.Sum(o => o.TotalAmount),
+                        StripeFees = g.Sum(o => o.StripeFee ?? 0m),
+                        TtFees = g.Sum(o => o.ApplicationFee ?? 0m)
+                    };
+                })
+                .ToList();
 
-            // Revenue with VatRate set — existing VAT projection system handles the rest
-            lineItemsCreated += UpsertLineItem(revenueCategory, $"{RevenuePrefix}{weekDesc}",
-                week.Revenue, week.Monday, projectionVatRate, false, $"{week.TicketCount} tickets", now);
+            var now = _clock.GetCurrentInstant();
+            var lineItemsCreated = 0;
 
-            // Fees (negative amounts) — both Stripe and TT charge 21% IVA on fees
-            if (week.StripeFees > 0)
-                lineItemsCreated += UpsertLineItem(feesCategory, $"{StripePrefix}{weekDesc}",
-                    -week.StripeFees, week.Monday, FeeVatRate, false, null, now);
-            if (week.TtFees > 0)
-                lineItemsCreated += UpsertLineItem(feesCategory, $"{TtPrefix}{weekDesc}",
-                    -week.TtFees, week.Monday, FeeVatRate, false, null, now);
+            foreach (var week in weeklyData)
+            {
+                var weekDesc = week.Label;
+
+                lineItemsCreated += UpsertLineItem(revenueCategory, $"{RevenuePrefix}{weekDesc}",
+                    week.Revenue, week.Monday, projectionVatRate, false, $"{week.TicketCount} tickets", now);
+
+                if (week.StripeFees > 0)
+                    lineItemsCreated += UpsertLineItem(feesCategory, $"{StripePrefix}{weekDesc}",
+                        -week.StripeFees, week.Monday, FeeVatRate, false, null, now);
+                if (week.TtFees > 0)
+                    lineItemsCreated += UpsertLineItem(feesCategory, $"{TtPrefix}{weekDesc}",
+                        -week.TtFees, week.Monday, FeeVatRate, false, null, now);
+            }
+
+            if (weeklyData.Count > 0 && ticketingGroup.TicketingProjection is not null)
+            {
+                var totalRevenue = weeklyData.Sum(w => w.Revenue);
+                var totalStripeFees = weeklyData.Sum(w => w.StripeFees);
+                var totalTtFees = weeklyData.Sum(w => w.TtFees);
+                var totalTickets = weeklyData.Sum(w => w.TicketCount);
+
+                UpdateProjectionFromActuals(ticketingGroup.TicketingProjection,
+                    totalRevenue, totalStripeFees, totalTtFees, totalTickets, now);
+            }
+
+            lineItemsCreated += MaterializeProjections(ticketingGroup, revenueCategory, feesCategory, now);
+
+            if (_dbContext.ChangeTracker.HasChanges())
+                await _dbContext.SaveChangesAsync(ct);
+
+            _logger.LogInformation("Ticketing budget sync: {Created} line items created/updated for {Weeks} actual weeks + projections",
+                lineItemsCreated, weeklyData.Count);
+
+            return lineItemsCreated;
         }
-
-        // Update projection parameters from actuals (only when we have real data)
-        if (weeklyData.Count > 0 && ticketingGroup.TicketingProjection is not null)
+        catch (Exception ex)
         {
-            var totalRevenue = weeklyData.Sum(w => w.Revenue);
-            var totalStripeFees = weeklyData.Sum(w => w.StripeFees);
-            var totalTtFees = weeklyData.Sum(w => w.TtFees);
-            var totalTickets = weeklyData.Sum(w => w.TicketCount);
-
-            UpdateProjectionFromActuals(ticketingGroup.TicketingProjection,
-                totalRevenue, totalStripeFees, totalTtFees, totalTickets, now);
+            _logger.LogError(ex, "Failed to sync ticketing actuals for budget year {YearId}", budgetYearId);
+            throw;
         }
-
-        // Materialize projections for future weeks
-        lineItemsCreated += MaterializeProjections(ticketingGroup, revenueCategory, feesCategory, now);
-
-        if (_dbContext.ChangeTracker.HasChanges())
-            await _dbContext.SaveChangesAsync();
-
-        _logger.LogInformation("Ticketing budget sync: {Created} line items created/updated for {Weeks} actual weeks + projections",
-            lineItemsCreated, weeklyData.Count);
-
-        return lineItemsCreated;
     }
 
-    public async Task<int> RefreshProjectionsAsync(Guid budgetYearId)
+    public async Task<int> RefreshProjectionsAsync(Guid budgetYearId, CancellationToken ct = default)
     {
-        var ticketingGroup = await LoadTicketingGroupAsync(budgetYearId);
-        if (ticketingGroup is null) return 0;
+        try
+        {
+            var ticketingGroup = await LoadTicketingGroupAsync(budgetYearId);
+            if (ticketingGroup is null) return 0;
 
-        var revenueCategory = ticketingGroup.Categories.FirstOrDefault(c => string.Equals(c.Name, "Ticket Revenue", StringComparison.Ordinal));
-        var feesCategory = ticketingGroup.Categories.FirstOrDefault(c => string.Equals(c.Name, "Processing Fees", StringComparison.Ordinal));
-        if (revenueCategory is null || feesCategory is null) return 0;
+            var revenueCategory = ticketingGroup.Categories.FirstOrDefault(c => string.Equals(c.Name, "Ticket Revenue", StringComparison.Ordinal));
+            var feesCategory = ticketingGroup.Categories.FirstOrDefault(c => string.Equals(c.Name, "Processing Fees", StringComparison.Ordinal));
+            if (revenueCategory is null || feesCategory is null) return 0;
 
-        var now = _clock.GetCurrentInstant();
-        var created = MaterializeProjections(ticketingGroup, revenueCategory, feesCategory, now);
+            var now = _clock.GetCurrentInstant();
+            var created = MaterializeProjections(ticketingGroup, revenueCategory, feesCategory, now);
 
-        if (_dbContext.ChangeTracker.HasChanges())
-            await _dbContext.SaveChangesAsync();
+            if (_dbContext.ChangeTracker.HasChanges())
+                await _dbContext.SaveChangesAsync(ct);
 
-        _logger.LogInformation("Ticketing projections refreshed: {Count} line items", created);
-        return created;
+            _logger.LogInformation("Ticketing projections refreshed: {Count} line items", created);
+            return created;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to refresh ticketing projections for budget year {YearId}", budgetYearId);
+            throw;
+        }
     }
 
     /// <summary>

--- a/src/Humans.Web/Controllers/CampAdminController.cs
+++ b/src/Humans.Web/Controllers/CampAdminController.cs
@@ -38,83 +38,92 @@ public class CampAdminController : HumansControllerBase
     [HttpGet("")]
     public async Task<IActionResult> Index()
     {
-        var settings = await _campService.GetSettingsAsync();
-        var allCamps = await _campService.GetAllCampsForYearAsync(settings.PublicYear);
-        var pendingSeasons = await _campService.GetPendingSeasonsAsync();
+        try
+        {
+            var settings = await _campService.GetSettingsAsync();
+            var allCamps = await _campService.GetAllCampsForYearAsync(settings.PublicYear);
+            var pendingSeasons = await _campService.GetPendingSeasonsAsync();
 
-        var nameLockDates = settings.OpenSeasons.Count > 0
-            ? await _campService.GetNameLockDatesAsync(settings.OpenSeasons)
-            : new Dictionary<int, NodaTime.LocalDate?>();
+            var nameLockDates = settings.OpenSeasons.Count > 0
+                ? await _campService.GetNameLockDatesAsync(settings.OpenSeasons)
+                : new Dictionary<int, NodaTime.LocalDate?>();
 
-        var withdrawnSeasons = allCamps
-            .SelectMany(c => c.Seasons
-                .Where(s => s.Year == settings.PublicYear && s.Status == CampSeasonStatus.Withdrawn)
-                .Select(s => new CampCardViewModel
+            var withdrawnSeasons = allCamps
+                .SelectMany(c => c.Seasons
+                    .Where(s => s.Year == settings.PublicYear && s.Status == CampSeasonStatus.Withdrawn)
+                    .Select(s => new CampCardViewModel
+                    {
+                        Id = c.Id,
+                        SeasonId = s.Id,
+                        Slug = c.Slug,
+                        Name = s.Name,
+                        BlurbShort = s.BlurbShort,
+                        Status = s.Status
+                    }))
+                .ToList();
+
+            // Load camps with leads for the summary table
+            var campsWithLeads = await _dbContext.Camps
+                .Include(c => c.Seasons.Where(s => s.Year == settings.PublicYear))
+                .Include(c => c.Leads.Where(l => l.LeftAt == null))
+                    .ThenInclude(l => l.User)
+                .Where(c => c.Seasons.Any(s => s.Year == settings.PublicYear
+                    && (s.Status == CampSeasonStatus.Active || s.Status == CampSeasonStatus.Full)))
+                .OrderBy(c => c.Seasons.Where(s => s.Year == settings.PublicYear).Select(s => s.Name).FirstOrDefault())
+                .ToListAsync();
+
+            var summaries = campsWithLeads.Select(c =>
+            {
+                var season = c.Seasons.FirstOrDefault();
+                return new CampSummaryRowViewModel
                 {
-                    Id = c.Id,
-                    SeasonId = s.Id,
+                    Name = season?.Name ?? c.Slug,
                     Slug = c.Slug,
+                    AcceptingMembers = season?.AcceptingMembers.ToString() ?? "—",
+                    MemberCount = season?.MemberCount ?? 0,
+                    Zone = season?.SoundZone?.ToString() ?? "—",
+                    SpaceRequirement = season?.SpaceRequirement?.ToString() ?? "—",
+                    YearsParticipating = c.TimesAtNowhere,
+                    Leads = c.Leads
+                        .Where(l => l.IsActive)
+                        .Select(l => new CampLeadViewModel
+                        {
+                            LeadId = l.Id,
+                            UserId = l.UserId,
+                            DisplayName = l.User.DisplayName
+                        }).ToList()
+                };
+            }).ToList();
+
+            var vm = new CampAdminViewModel
+            {
+                PublicYear = settings.PublicYear,
+                OpenSeasons = settings.OpenSeasons,
+                TotalCamps = allCamps.Count,
+                ActiveCamps = allCamps.Count(b => b.Seasons.Any(s =>
+                    s.Year == settings.PublicYear && (s.Status == CampSeasonStatus.Active || s.Status == CampSeasonStatus.Full))),
+                WithdrawnCamps = withdrawnSeasons,
+                NameLockDates = nameLockDates,
+                AllCampSummaries = summaries,
+                PendingCamps = pendingSeasons.Select(s => new CampCardViewModel
+                {
+                    Id = s.CampId,
+                    SeasonId = s.Id,
+                    Slug = s.Camp?.Slug ?? string.Empty,
                     Name = s.Name,
                     BlurbShort = s.BlurbShort,
                     Status = s.Status
-                }))
-            .ToList();
-
-        // Load camps with leads for the summary table
-        var campsWithLeads = await _dbContext.Camps
-            .Include(c => c.Seasons.Where(s => s.Year == settings.PublicYear))
-            .Include(c => c.Leads.Where(l => l.LeftAt == null))
-                .ThenInclude(l => l.User)
-            .Where(c => c.Seasons.Any(s => s.Year == settings.PublicYear
-                && (s.Status == CampSeasonStatus.Active || s.Status == CampSeasonStatus.Full)))
-            .OrderBy(c => c.Seasons.Where(s => s.Year == settings.PublicYear).Select(s => s.Name).FirstOrDefault())
-            .ToListAsync();
-
-        var summaries = campsWithLeads.Select(c =>
-        {
-            var season = c.Seasons.FirstOrDefault();
-            return new CampSummaryRowViewModel
-            {
-                Name = season?.Name ?? c.Slug,
-                Slug = c.Slug,
-                AcceptingMembers = season?.AcceptingMembers.ToString() ?? "—",
-                MemberCount = season?.MemberCount ?? 0,
-                Zone = season?.SoundZone?.ToString() ?? "—",
-                SpaceRequirement = season?.SpaceRequirement?.ToString() ?? "—",
-                YearsParticipating = c.TimesAtNowhere,
-                Leads = c.Leads
-                    .Where(l => l.IsActive)
-                    .Select(l => new CampLeadViewModel
-                    {
-                        LeadId = l.Id,
-                        UserId = l.UserId,
-                        DisplayName = l.User.DisplayName
-                    }).ToList()
+                }).ToList()
             };
-        }).ToList();
 
-        var vm = new CampAdminViewModel
+            return View(vm);
+        }
+        catch (Exception ex)
         {
-            PublicYear = settings.PublicYear,
-            OpenSeasons = settings.OpenSeasons,
-            TotalCamps = allCamps.Count,
-            ActiveCamps = allCamps.Count(b => b.Seasons.Any(s =>
-                s.Year == settings.PublicYear && (s.Status == CampSeasonStatus.Active || s.Status == CampSeasonStatus.Full))),
-            WithdrawnCamps = withdrawnSeasons,
-            NameLockDates = nameLockDates,
-            AllCampSummaries = summaries,
-            PendingCamps = pendingSeasons.Select(s => new CampCardViewModel
-            {
-                Id = s.CampId,
-                SeasonId = s.Id,
-                Slug = s.Camp?.Slug ?? string.Empty,
-                Name = s.Name,
-                BlurbShort = s.BlurbShort,
-                Status = s.Status
-            }).ToList()
-        };
-
-        return View(vm);
+            _logger.LogError(ex, "Failed to load Barrios admin page");
+            SetError("Failed to load Barrios admin page.");
+            return RedirectToAction("Index", "Admin");
+        }
     }
 
     [HttpPost("Approve/{seasonId:guid}")]
@@ -169,8 +178,16 @@ public class CampAdminController : HumansControllerBase
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> OpenSeason([FromForm] int year)
     {
-        await _campService.OpenSeasonAsync(year);
-        SetSuccess($"Season {year} opened for registration.");
+        try
+        {
+            await _campService.OpenSeasonAsync(year);
+            SetSuccess($"Season {year} opened for registration.");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to open season {Year}", year);
+            SetError($"Failed to open season: {ex.Message}");
+        }
         return RedirectToAction(nameof(Index));
     }
 
@@ -178,8 +195,16 @@ public class CampAdminController : HumansControllerBase
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> CloseSeason(int year)
     {
-        await _campService.CloseSeasonAsync(year);
-        SetSuccess($"Season {year} closed for registration.");
+        try
+        {
+            await _campService.CloseSeasonAsync(year);
+            SetSuccess($"Season {year} closed for registration.");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to close season {Year}", year);
+            SetError($"Failed to close season: {ex.Message}");
+        }
         return RedirectToAction(nameof(Index));
     }
 
@@ -187,8 +212,16 @@ public class CampAdminController : HumansControllerBase
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> SetPublicYear(int year)
     {
-        await _campService.SetPublicYearAsync(year);
-        SetSuccess($"Public year set to {year}.");
+        try
+        {
+            await _campService.SetPublicYearAsync(year);
+            SetSuccess($"Public year set to {year}.");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to set public year to {Year}", year);
+            SetError($"Failed to set public year: {ex.Message}");
+        }
         return RedirectToAction(nameof(Index));
     }
 
@@ -203,8 +236,16 @@ public class CampAdminController : HumansControllerBase
             return RedirectToAction(nameof(Index));
         }
 
-        await _campService.SetNameLockDateAsync(year, parseResult.Value);
-        SetSuccess($"Name lock date for {year} set to {parseResult.Value}.");
+        try
+        {
+            await _campService.SetNameLockDateAsync(year, parseResult.Value);
+            SetSuccess($"Name lock date for {year} set to {parseResult.Value}.");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to set name lock date for {Year}", year);
+            SetError($"Failed to set name lock date: {ex.Message}");
+        }
         return RedirectToAction(nameof(Index));
     }
 
@@ -231,61 +272,70 @@ public class CampAdminController : HumansControllerBase
     [HttpGet("Export")]
     public async Task<IActionResult> ExportCamps()
     {
-        var settings = await _campService.GetSettingsAsync();
-        var year = settings.PublicYear;
-
-        var camps = await _dbContext.Camps
-            .Include(c => c.Seasons.Where(s => s.Year == year))
-            .Include(c => c.Leads.Where(l => l.LeftAt == null))
-                .ThenInclude(l => l.User)
-            .Where(c => c.Seasons.Any(s => s.Year == year))
-            .OrderBy(c => c.Seasons.Where(s => s.Year == year).Select(s => s.Name).FirstOrDefault())
-            .ToListAsync();
-
-        var csv = new StringBuilder();
-        csv.AppendCsvRow(
-            "Name", "Slug", "Status", "Contact Email", "Contact Phone",
-            "Leads", "Languages", "Member Count",
-            "Space Requirement", "Sound Zone", "Containers", "Electrical Grid",
-            "Accepting Members", "Kids Welcome", "Adult Playspace",
-            "Vibes", "Swiss Camp", "Times Participating");
-
-        foreach (var camp in camps)
+        try
         {
-            var season = camp.Seasons.FirstOrDefault();
-            if (season is null) continue;
+            var settings = await _campService.GetSettingsAsync();
+            var year = settings.PublicYear;
 
-            var leads = string.Join("; ", camp.Leads
-                .Where(l => l.IsActive)
-                .Select(l => $"{l.User.DisplayName} <{l.User.Email}>"));
+            var camps = await _dbContext.Camps
+                .Include(c => c.Seasons.Where(s => s.Year == year))
+                .Include(c => c.Leads.Where(l => l.LeftAt == null))
+                    .ThenInclude(l => l.User)
+                .Where(c => c.Seasons.Any(s => s.Year == year))
+                .OrderBy(c => c.Seasons.Where(s => s.Year == year).Select(s => s.Name).FirstOrDefault())
+                .ToListAsync();
 
-            var vibes = season.Vibes.Count > 0
-                ? string.Join(", ", season.Vibes)
-                : "";
-
+            var csv = new StringBuilder();
             csv.AppendCsvRow(
-                season.Name,
-                camp.Slug,
-                season.Status,
-                camp.ContactEmail,
-                camp.ContactPhone,
-                leads,
-                season.Languages,
-                season.MemberCount,
-                season.SpaceRequirement?.ToString() ?? "",
-                season.SoundZone?.ToString() ?? "",
-                season.ContainerCount,
-                season.ElectricalGrid?.ToString() ?? "",
-                season.AcceptingMembers,
-                season.KidsWelcome,
-                season.AdultPlayspace,
-                vibes,
-                camp.IsSwissCamp ? "Yes" : "No",
-                camp.TimesAtNowhere);
-        }
+                "Name", "Slug", "Status", "Contact Email", "Contact Phone",
+                "Leads", "Languages", "Member Count",
+                "Space Requirement", "Sound Zone", "Containers", "Electrical Grid",
+                "Accepting Members", "Kids Welcome", "Adult Playspace",
+                "Vibes", "Swiss Camp", "Times Participating");
 
-        return File(Encoding.UTF8.GetBytes(csv.ToString()),
-            "text/csv", $"barrios-{year}.csv");
+            foreach (var camp in camps)
+            {
+                var season = camp.Seasons.FirstOrDefault();
+                if (season is null) continue;
+
+                var leads = string.Join("; ", camp.Leads
+                    .Where(l => l.IsActive)
+                    .Select(l => $"{l.User.DisplayName} <{l.User.Email}>"));
+
+                var vibes = season.Vibes.Count > 0
+                    ? string.Join(", ", season.Vibes)
+                    : "";
+
+                csv.AppendCsvRow(
+                    season.Name,
+                    camp.Slug,
+                    season.Status,
+                    camp.ContactEmail,
+                    camp.ContactPhone,
+                    leads,
+                    season.Languages,
+                    season.MemberCount,
+                    season.SpaceRequirement?.ToString() ?? "",
+                    season.SoundZone?.ToString() ?? "",
+                    season.ContainerCount,
+                    season.ElectricalGrid?.ToString() ?? "",
+                    season.AcceptingMembers,
+                    season.KidsWelcome,
+                    season.AdultPlayspace,
+                    vibes,
+                    camp.IsSwissCamp ? "Yes" : "No",
+                    camp.TimesAtNowhere);
+            }
+
+            return File(Encoding.UTF8.GetBytes(csv.ToString()),
+                "text/csv", $"barrios-{year}.csv");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to export barrios");
+            SetError("Failed to export barrios.");
+            return RedirectToAction(nameof(Index));
+        }
     }
 
     [HttpPost("Delete")]

--- a/src/Humans.Web/Controllers/FinanceController.cs
+++ b/src/Humans.Web/Controllers/FinanceController.cs
@@ -49,7 +49,7 @@ public class FinanceController : HumansControllerBase
             }
 
             var allYears = await _budgetService.GetAllYearsAsync();
-            var model = BuildFinanceOverview(activeYear, allYears);
+            var model = await BuildFinanceOverviewAsync(activeYear, allYears);
             return View("YearDetail", model);
         }
         catch (Exception ex)
@@ -69,7 +69,7 @@ public class FinanceController : HumansControllerBase
             if (year is null) return NotFound();
 
             var allYears = await _budgetService.GetAllYearsAsync();
-            var model = BuildFinanceOverview(year, allYears);
+            var model = await BuildFinanceOverviewAsync(year, allYears);
             return View(model);
         }
         catch (Exception ex)
@@ -558,7 +558,7 @@ public class FinanceController : HumansControllerBase
     /// so FinanceAdmin sees everything on one page without navigating to /Budget/Summary.
     /// Also computes actual tickets sold for ticketing groups and stores in ViewBag.
     /// </summary>
-    private FinanceOverviewViewModel BuildFinanceOverview(BudgetYear year, IReadOnlyList<BudgetYear> allYears)
+    private async Task<FinanceOverviewViewModel> BuildFinanceOverviewAsync(BudgetYear year, IReadOnlyList<BudgetYear> allYears)
     {
         // All groups (including restricted) for FinanceAdmin summary, with buffer slices
         var summary = _budgetService.ComputeBudgetSummaryWithBuffers(year.Groups);
@@ -570,15 +570,16 @@ public class FinanceController : HumansControllerBase
             var actualSold = _ticketingBudgetService.GetActualTicketsSold(ticketingGroup);
             ViewBag.ActualTicketsSold = actualSold;
 
-            var proj = ticketingGroup.TicketingProjection;
-            if (proj?.StartDate is not null && proj.EventDate is not null)
+            // Use the projection engine to compute remaining tickets consistently
+            var projections = await _ticketingBudgetService.GetProjectionsAsync(ticketingGroup.Id);
+            if (projections.Count > 0)
             {
+                var projectedRemaining = projections.Sum(p => p.ProjectedTickets);
                 var today = SystemClock.Instance.GetCurrentInstant().InUtc().Date;
-                var daysToEvent = Period.Between(today, proj.EventDate.Value, PeriodUnits.Days).Days;
-                var remaining = Math.Max(0, daysToEvent);
-                var projectedRemaining = (int)Math.Round(proj.DailySalesRate * remaining);
+                var proj = ticketingGroup.TicketingProjection!;
+                var daysToEvent = Period.Between(today, proj.EventDate!.Value, PeriodUnits.Days).Days;
 
-                ViewBag.RemainingDays = remaining;
+                ViewBag.RemainingDays = Math.Max(0, daysToEvent);
                 ViewBag.ProjectedRemaining = projectedRemaining;
                 ViewBag.TotalTickets = actualSold + projectedRemaining;
             }

--- a/src/Humans.Web/Controllers/GoogleController.cs
+++ b/src/Humans.Web/Controllers/GoogleController.cs
@@ -497,7 +497,7 @@ public class GoogleController : HumansControllerBase
         return GoogleSyncAuditView(
             $"Google Sync Audit: {user.DisplayName}",
             Url.Action("AdminDetail", "Profile", new { id }),
-            "Back to Member Detail",
+            "Back to Human Detail",
             entries);
     }
 

--- a/src/Humans.Web/Controllers/GuestController.cs
+++ b/src/Humans.Web/Controllers/GuestController.cs
@@ -164,7 +164,7 @@ public class GuestController : HumansControllerBase
             var gracePeriod = Duration.FromDays(30);
 
             // Check for upcoming event tickets — if ticket holder, set EligibleAfter to post-event
-            var eventHoldDate = await GetEventHoldDateAsync(user.Id);
+            var eventHoldDate = await _profileService.GetEventHoldDateAsync(user.Id);
 
             user.DeletionRequestedAt = now;
             user.DeletionScheduledFor = now.Plus(gracePeriod);
@@ -278,45 +278,6 @@ public class GuestController : HumansControllerBase
         viewModel.DeletionEligibleAfter = user.DeletionEligibleAfter?.ToDateTimeUtc();
 
         return viewModel;
-    }
-
-    /// <summary>
-    /// If the user has tickets for an upcoming event, returns the post-event date
-    /// (StrikeEndOffset + 1 day after GateOpeningDate). Otherwise returns null.
-    /// </summary>
-    private async Task<Instant?> GetEventHoldDateAsync(Guid userId)
-    {
-        var hasTickets = await _dbContext.TicketOrders
-            .AnyAsync(o => o.MatchedUserId == userId);
-
-        if (!hasTickets)
-        {
-            hasTickets = await _dbContext.TicketAttendees
-                .AnyAsync(a => a.MatchedUserId == userId);
-        }
-
-        if (!hasTickets)
-            return null;
-
-        // Find the active event
-        var activeEvent = await _dbContext.EventSettings
-            .FirstOrDefaultAsync(e => e.IsActive);
-
-        if (activeEvent is null)
-            return null;
-
-        // Compute post-event date: GateOpeningDate + StrikeEndOffset + 1 day
-        var tz = DateTimeZoneProviders.Tzdb.GetZoneOrNull(activeEvent.TimeZoneId)
-                 ?? DateTimeZone.Utc;
-        var postEventDate = activeEvent.GateOpeningDate
-            .PlusDays(activeEvent.StrikeEndOffset + 1);
-        var postEventInstant = postEventDate
-            .AtStartOfDayInZone(tz)
-            .ToInstant();
-
-        // Only apply hold if the event is in the future
-        var now = _clock.GetCurrentInstant();
-        return postEventInstant > now ? postEventInstant : null;
     }
 
     private async Task<CommunicationPreferencesViewModel> BuildCommunicationPreferencesViewModelAsync(Guid userId)


### PR DESCRIPTION
## Summary
- Reset GoogleEmailStatus on email rename fix so sync resumes (#459)
- Scope GDPR deletion holds to active event tickets only (was matching all-time tickets)
- Align Finance projection display with MaterializeProjections engine
- Save per-user atomically in ProcessAccountDeletionsJob (GDPR compliance)
- Add error handling to TicketingBudgetService and CampAdminController
- Fix stale doc references and "Member" terminology

## Context
Findings from code review of origin/main vs upstream/main before production promotion. Includes both Claude review and Codex adversarial review findings.

## Test plan
- [x] All 950 tests pass
- [x] Format clean
- [ ] QA: verify email rename tool resets sync status
- [ ] QA: verify Guest deletion hold only applies for current event tickets

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>