### PR TITLE
Quick fixes: ticket email hint, language query extraction (#460, #423)

### DIFF
--- a/src/Humans.Application/DTOs/AdminDashboardData.cs
+++ b/src/Humans.Application/DTOs/AdminDashboardData.cs
@@ -13,4 +13,7 @@ public record AdminDashboardData(
     int ApprovedApplications,
     int RejectedApplications,
     int ColaboradorApplied,
-    int AsociadoApplied);
+    int AsociadoApplied,
+    IReadOnlyList<LanguageCount> LanguageDistribution);
+
+public record LanguageCount(string Language, int Count);

--- a/src/Humans.Infrastructure/Services/OnboardingService.cs
+++ b/src/Humans.Infrastructure/Services/OnboardingService.cs
@@ -605,12 +605,22 @@ public class OnboardingService : IOnboardingService
             })
             .FirstOrDefaultAsync(ct);
 
+        var languageDistribution = (await _dbContext.Users
+            .Where(u => u.Profile != null && u.Profile.IsApproved && !u.Profile.IsSuspended)
+            .GroupBy(u => u.PreferredLanguage)
+            .Select(g => new { Language = g.Key, Count = g.Count() })
+            .OrderByDescending(g => g.Count)
+            .ToListAsync(ct))
+            .Select(g => new Application.DTOs.LanguageCount(g.Language, g.Count))
+            .ToList();
+
         return new Application.DTOs.AdminDashboardData(
             totalMembers, partition.IncompleteSignup.Count, partition.PendingApproval.Count,
             partition.Active.Count, partition.MissingConsents.Count,
             partition.Suspended.Count, partition.PendingDeletion.Count, pendingApplications,
             appStats?.Total ?? 0, appStats?.Approved ?? 0, appStats?.Rejected ?? 0,
-            appStats?.Colaborador ?? 0, appStats?.Asociado ?? 0);
+            appStats?.Colaborador ?? 0, appStats?.Asociado ?? 0,
+            languageDistribution);
     }
 
     public async Task<OnboardingResult> PurgeHumanAsync(Guid userId, CancellationToken ct = default)

--- a/src/Humans.Web/Controllers/BoardController.cs
+++ b/src/Humans.Web/Controllers/BoardController.cs
@@ -37,13 +37,6 @@ public class BoardController : HumansControllerBase
         var dashboardData = await _onboardingService.GetAdminDashboardAsync();
         var recentEntries = await _auditLogService.GetRecentAsync(15);
 
-        var languageDistribution = await _dbContext.Users
-            .Where(u => u.Profile != null && u.Profile.IsApproved && !u.Profile.IsSuspended)
-            .GroupBy(u => u.PreferredLanguage)
-            .Select(g => new { Language = g.Key, Count = g.Count() })
-            .OrderByDescending(g => g.Count)
-            .ToListAsync();
-
         var viewModel = new AdminDashboardViewModel
         {
             TotalMembers = dashboardData.TotalMembers,
@@ -65,7 +58,7 @@ public class BoardController : HumansControllerBase
             RejectedApplications = dashboardData.RejectedApplications,
             ColaboradorApplied = dashboardData.ColaboradorApplied,
             AsociadoApplied = dashboardData.AsociadoApplied,
-            LanguageDistribution = languageDistribution
+            LanguageDistribution = dashboardData.LanguageDistribution
                 .Select(l => new LanguageCountViewModel { Language = l.Language, Count = l.Count })
                 .ToList()
         };

--- a/src/Humans.Web/Views/Home/Dashboard.cshtml
+++ b/src/Humans.Web/Views/Home/Dashboard.cshtml
@@ -233,6 +233,7 @@
                     <a href="@Model.TicketPurchaseUrl" target="_blank" rel="noopener" class="btn btn-primary">
                         <i class="fa-solid fa-external-link-alt me-1"></i> Buy your ticket now
                     </a>
+                    <p class="text-muted small mt-2 mb-0">Bought on a different email? <a href="/Profile/Me/Emails">Add it here</a></p>
                 }
             </div>
         </div>


### PR DESCRIPTION
## Summary
- Add "Bought on a different email? Add it here" hint below no-ticket message on dashboard (#460)
- Move language distribution query from BoardController to OnboardingService, add LanguageCount DTO (#423)

Closes nobodies-collective/Humans#460
Closes nobodies-collective/Humans#423

## Test plan
- [x] Dashboard shows email hint when no ticket found
- [x] Hint links to /Profile/Me/Emails
- [x] Hint does not appear when ticket is found or vendor not configured
- [x] Board dashboard still shows language distribution correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>