### PR TITLE
Add resource-based auth: scoped coordinator management (#417)

### DIFF
--- a/src/Humans.Web/Authorization/AuthorizationPolicyExtensions.cs
+++ b/src/Humans.Web/Authorization/AuthorizationPolicyExtensions.cs
@@ -21,6 +21,7 @@ public static class AuthorizationPolicyExtensions
         // Resource-based authorization handlers (scoped — they depend on scoped services)
         services.AddScoped<IAuthorizationHandler, BudgetAuthorizationHandler>();
         services.AddScoped<IAuthorizationHandler, CampAuthorizationHandler>();
+        services.AddScoped<IAuthorizationHandler, TeamAuthorizationHandler>();
 
         services.AddAuthorization(options =>
         {

--- a/src/Humans.Web/Authorization/Requirements/TeamAuthorizationHandler.cs
+++ b/src/Humans.Web/Authorization/Requirements/TeamAuthorizationHandler.cs
@@ -1,0 +1,49 @@
+using System.Security.Claims;
+using Humans.Application.Interfaces;
+using Humans.Domain.Entities;
+using Microsoft.AspNetCore.Authorization;
+
+namespace Humans.Web.Authorization.Requirements;
+
+/// <summary>
+/// Resource-based authorization handler for team management operations.
+/// Evaluates whether a user can perform coordinator/management operations on a specific Team.
+///
+/// Authorization logic:
+/// - Admin: allow any team
+/// - TeamsAdmin: allow any team
+/// - Team coordinator (or parent department coordinator): allow only their team
+/// - Everyone else: deny
+/// </summary>
+public class TeamAuthorizationHandler : AuthorizationHandler<TeamOperationRequirement, Team>
+{
+    private readonly ITeamService _teamService;
+
+    public TeamAuthorizationHandler(ITeamService teamService)
+    {
+        _teamService = teamService;
+    }
+
+    protected override async Task HandleRequirementAsync(
+        AuthorizationHandlerContext context,
+        TeamOperationRequirement requirement,
+        Team resource)
+    {
+        // Admin and TeamsAdmin can manage any team
+        if (RoleChecks.IsTeamsAdminBoardOrAdmin(context.User))
+        {
+            context.Succeed(requirement);
+            return;
+        }
+
+        // Check if user is a coordinator for this specific team (or its parent department)
+        var userIdClaim = context.User.FindFirst(ClaimTypes.NameIdentifier);
+        if (userIdClaim is null || !Guid.TryParse(userIdClaim.Value, out var userId))
+            return;
+
+        if (await _teamService.IsUserCoordinatorOfTeamAsync(resource.Id, userId))
+        {
+            context.Succeed(requirement);
+        }
+    }
+}

--- a/src/Humans.Web/Authorization/Requirements/TeamOperationRequirement.cs
+++ b/src/Humans.Web/Authorization/Requirements/TeamOperationRequirement.cs
@@ -1,0 +1,20 @@
+using Microsoft.AspNetCore.Authorization;
+
+namespace Humans.Web.Authorization.Requirements;
+
+/// <summary>
+/// Resource-based authorization requirement for team operations.
+/// Used with IAuthorizationService.AuthorizeAsync(User, resource, requirement)
+/// where the resource is a Team.
+/// </summary>
+public sealed class TeamOperationRequirement : IAuthorizationRequirement
+{
+    public static readonly TeamOperationRequirement ManageCoordinators = new(nameof(ManageCoordinators));
+
+    public string OperationName { get; }
+
+    private TeamOperationRequirement(string operationName)
+    {
+        OperationName = operationName;
+    }
+}

--- a/src/Humans.Web/Controllers/HumansTeamControllerBase.cs
+++ b/src/Humans.Web/Controllers/HumansTeamControllerBase.cs
@@ -1,7 +1,8 @@
 using Humans.Application.Interfaces;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
-using Humans.Web.Authorization;
+using Humans.Web.Authorization.Requirements;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 
@@ -10,11 +11,16 @@ namespace Humans.Web.Controllers;
 public abstract class HumansTeamControllerBase : HumansControllerBase
 {
     private readonly ITeamService _teamService;
+    private readonly IAuthorizationService _authorizationService;
 
-    protected HumansTeamControllerBase(UserManager<User> userManager, ITeamService teamService)
+    protected HumansTeamControllerBase(
+        UserManager<User> userManager,
+        ITeamService teamService,
+        IAuthorizationService authorizationService)
         : base(userManager)
     {
         _teamService = teamService;
+        _authorizationService = authorizationService;
     }
 
     protected async Task<(IActionResult? ErrorResult, User User, Team Team)> ResolveTeamManagementAsync(string slug)
@@ -22,14 +28,11 @@ public abstract class HumansTeamControllerBase : HumansControllerBase
         return await ResolveTeamAccessAsync(
             slug,
             static _ => true,
-            async (team, user) =>
+            async (team, _) =>
             {
-                if (RoleChecks.IsTeamsAdminBoardOrAdmin(User))
-                {
-                    return true;
-                }
-
-                return await _teamService.IsUserCoordinatorOfTeamAsync(team.Id, user.Id);
+                var result = await _authorizationService.AuthorizeAsync(
+                    User, team, TeamOperationRequirement.ManageCoordinators);
+                return result.Succeeded;
             });
     }
 

--- a/src/Humans.Web/Controllers/ShiftAdminController.cs
+++ b/src/Humans.Web/Controllers/ShiftAdminController.cs
@@ -31,9 +31,10 @@ public class ShiftAdminController : HumansTeamControllerBase
         IGeneralAvailabilityService availabilityService,
         IProfileService profileService,
         UserManager<User> userManager,
+        IAuthorizationService authorizationService,
         IClock clock,
         ILogger<ShiftAdminController> logger)
-        : base(userManager, teamService)
+        : base(userManager, teamService, authorizationService)
     {
         _teamService = teamService;
         _shiftMgmt = shiftMgmt;

--- a/src/Humans.Web/Controllers/TeamAdminController.cs
+++ b/src/Humans.Web/Controllers/TeamAdminController.cs
@@ -37,11 +37,12 @@ public class TeamAdminController : HumansTeamControllerBase
         IEmailProvisioningService emailProvisioningService,
         INotificationService notificationService,
         UserManager<User> userManager,
+        IAuthorizationService authorizationService,
         ISystemTeamSync systemTeamSyncJob,
         IMemoryCache cache,
         ILogger<TeamAdminController> logger,
         IStringLocalizer<SharedResource> localizer)
-        : base(userManager, teamService)
+        : base(userManager, teamService, authorizationService)
     {
         _teamService = teamService;
         _teamResourceService = teamResourceService;
@@ -938,18 +939,9 @@ public class TeamAdminController : HumansTeamControllerBase
     [HttpGet("EditPage")]
     public async Task<IActionResult> EditPage(string slug)
     {
-        var user = await GetCurrentUserAsync();
-        if (user is null)
-            return NotFound();
-
-        var team = await _teamService.GetTeamBySlugAsync(slug);
-        if (team is null)
-            return NotFound();
-
-        var isCoordinator = await _teamService.IsUserCoordinatorOfTeamAsync(team.Id, user.Id);
-        var canManage = isCoordinator || RoleChecks.IsTeamsAdminBoardOrAdmin(User);
-        if (!canManage)
-            return Forbid();
+        var (teamError, _, team) = await ResolveTeamManagementAsync(slug);
+        if (teamError is not null)
+            return teamError;
 
         var canBePublic = !team.IsSystemTeam && !team.ParentTeamId.HasValue;
 
@@ -979,18 +971,9 @@ public class TeamAdminController : HumansTeamControllerBase
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> EditPage(string slug, EditTeamPageViewModel model)
     {
-        var user = await GetCurrentUserAsync();
-        if (user is null)
-            return NotFound();
-
-        var team = await _teamService.GetTeamBySlugAsync(slug);
-        if (team is null)
-            return NotFound();
-
-        var isCoordinator = await _teamService.IsUserCoordinatorOfTeamAsync(team.Id, user.Id);
-        var canManage = isCoordinator || RoleChecks.IsTeamsAdminBoardOrAdmin(User);
-        if (!canManage)
-            return Forbid();
+        var (teamError, user, team) = await ResolveTeamManagementAsync(slug);
+        if (teamError is not null)
+            return teamError;
 
         if (!ModelState.IsValid)
         {

--- a/tests/Humans.Application.Tests/Authorization/AuthorizationPolicyTests.cs
+++ b/tests/Humans.Application.Tests/Authorization/AuthorizationPolicyTests.cs
@@ -27,6 +27,7 @@ public class AuthorizationPolicyTests : IDisposable
         // Register service stubs required by resource-based authorization handlers
         services.AddScoped(_ => Substitute.For<IBudgetService>());
         services.AddScoped(_ => Substitute.For<ICampService>());
+        services.AddScoped(_ => Substitute.For<ITeamService>());
         services.AddHumansAuthorizationPolicies();
         _serviceProvider = services.BuildServiceProvider();
         _authorizationService = _serviceProvider.GetRequiredService<IAuthorizationService>();

--- a/tests/Humans.Application.Tests/Authorization/TeamAuthorizationHandlerTests.cs
+++ b/tests/Humans.Application.Tests/Authorization/TeamAuthorizationHandlerTests.cs
@@ -1,0 +1,188 @@
+using System.Security.Claims;
+using AwesomeAssertions;
+using Humans.Application.Interfaces;
+using Humans.Domain.Constants;
+using Humans.Domain.Entities;
+using Humans.Web.Authorization.Requirements;
+using Microsoft.AspNetCore.Authorization;
+using NSubstitute;
+using Xunit;
+
+namespace Humans.Application.Tests.Authorization;
+
+/// <summary>
+/// Unit tests for TeamAuthorizationHandler — resource-based authorization for team management.
+/// Tests cover: Admin override, TeamsAdmin override, Board override, team coordinator access,
+/// denial for non-coordinators, and edge cases.
+/// </summary>
+public sealed class TeamAuthorizationHandlerTests
+{
+    private readonly ITeamService _teamService = Substitute.For<ITeamService>();
+    private readonly TeamAuthorizationHandler _handler;
+
+    private static readonly Guid CoordinatorTeamId = Guid.NewGuid();
+    private static readonly Guid OtherTeamId = Guid.NewGuid();
+    private static readonly Guid UserId = Guid.NewGuid();
+
+    public TeamAuthorizationHandlerTests()
+    {
+        _handler = new TeamAuthorizationHandler(_teamService);
+
+        _teamService.IsUserCoordinatorOfTeamAsync(CoordinatorTeamId, UserId)
+            .Returns(true);
+        _teamService.IsUserCoordinatorOfTeamAsync(OtherTeamId, UserId)
+            .Returns(false);
+    }
+
+    // --- Admin override ---
+
+    [Fact]
+    public async Task Admin_CanManageAnyTeam()
+    {
+        var user = CreateUserWithRoles(RoleNames.Admin);
+        var team = CreateTeam(OtherTeamId);
+
+        var result = await EvaluateAsync(user, team);
+
+        result.Should().BeTrue();
+    }
+
+    // --- TeamsAdmin override ---
+
+    [Fact]
+    public async Task TeamsAdmin_CanManageAnyTeam()
+    {
+        var user = CreateUserWithRoles(RoleNames.TeamsAdmin);
+        var team = CreateTeam(OtherTeamId);
+
+        var result = await EvaluateAsync(user, team);
+
+        result.Should().BeTrue();
+    }
+
+    // --- Board override ---
+
+    [Fact]
+    public async Task Board_CanManageAnyTeam()
+    {
+        var user = CreateUserWithRoles(RoleNames.Board);
+        var team = CreateTeam(OtherTeamId);
+
+        var result = await EvaluateAsync(user, team);
+
+        result.Should().BeTrue();
+    }
+
+    // --- Team coordinator access ---
+
+    [Fact]
+    public async Task Coordinator_CanManageOwnTeam()
+    {
+        var user = CreateUser(UserId);
+        var team = CreateTeam(CoordinatorTeamId);
+
+        var result = await EvaluateAsync(user, team);
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Coordinator_CannotManageOtherTeam()
+    {
+        var user = CreateUser(UserId);
+        var team = CreateTeam(OtherTeamId);
+
+        var result = await EvaluateAsync(user, team);
+
+        result.Should().BeFalse();
+    }
+
+    // --- Denial cases ---
+
+    [Fact]
+    public async Task RegularUser_DeniedOnAnyTeam()
+    {
+        var regularUserId = Guid.NewGuid();
+        _teamService.IsUserCoordinatorOfTeamAsync(CoordinatorTeamId, regularUserId)
+            .Returns(false);
+        var user = CreateUser(regularUserId);
+        var team = CreateTeam(CoordinatorTeamId);
+
+        var result = await EvaluateAsync(user, team);
+
+        result.Should().BeFalse();
+    }
+
+    // --- Edge cases ---
+
+    [Fact]
+    public async Task UnauthenticatedUser_Denied()
+    {
+        var user = new ClaimsPrincipal(new ClaimsIdentity());
+        var team = CreateTeam(CoordinatorTeamId);
+
+        var result = await EvaluateAsync(user, team);
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task UserWithInvalidIdClaim_Denied()
+    {
+        var claims = new List<Claim>
+        {
+            new(ClaimTypes.NameIdentifier, "not-a-guid"),
+            new(ClaimTypes.Name, "test@example.com")
+        };
+        var user = new ClaimsPrincipal(new ClaimsIdentity(claims, "TestAuth"));
+        var team = CreateTeam(CoordinatorTeamId);
+
+        var result = await EvaluateAsync(user, team);
+
+        result.Should().BeFalse();
+    }
+
+    // --- Helpers ---
+
+    private async Task<bool> EvaluateAsync(ClaimsPrincipal user, Team resource)
+    {
+        var requirement = TeamOperationRequirement.ManageCoordinators;
+        var context = new AuthorizationHandlerContext(
+            [requirement], user, resource);
+
+        await _handler.HandleAsync(context);
+        return context.HasSucceeded;
+    }
+
+    private static Team CreateTeam(Guid teamId)
+    {
+        return new Team
+        {
+            Id = teamId
+        };
+    }
+
+    private static ClaimsPrincipal CreateUserWithRoles(params string[] roles)
+    {
+        var claims = new List<Claim>
+        {
+            new(ClaimTypes.NameIdentifier, Guid.NewGuid().ToString()),
+            new(ClaimTypes.Name, "admin@example.com")
+        };
+        foreach (var role in roles)
+        {
+            claims.Add(new Claim(ClaimTypes.Role, role));
+        }
+        return new ClaimsPrincipal(new ClaimsIdentity(claims, "TestAuth"));
+    }
+
+    private static ClaimsPrincipal CreateUser(Guid userId)
+    {
+        var claims = new List<Claim>
+        {
+            new(ClaimTypes.NameIdentifier, userId.ToString()),
+            new(ClaimTypes.Name, "coordinator@example.com")
+        };
+        return new ClaimsPrincipal(new ClaimsIdentity(claims, "TestAuth"));
+    }
+}


### PR DESCRIPTION
## Summary
- Implements Phase 2c of the auth transition plan
- Adds TeamOperationRequirement and TeamAuthorizationHandler for scoped coordinator management
- Coordinators can only manage their own team; Admin/Board/TeamsAdmin override
- Replaces ad-hoc role checks in HumansTeamControllerBase and TeamAdminController EditPage with resource-based authorization
- Unit tests cover all authorization paths (admin, TeamsAdmin, Board, coordinator own/other team, regular user, unauthenticated, invalid ID)

Closes nobodies-collective/Humans#417

## Test plan
- [ ] Unit tests for TeamAuthorizationHandler (8 tests covering all paths)
- [ ] Verify coordinator can manage own team only
- [ ] Verify Admin/TeamsAdmin/Board can manage any team
- [ ] Verify regular users are denied
- [ ] Verify EditPage actions use resource-based auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>