### PR TITLE
Enhance SyncOutbox table with name, Google email, and resource details (#461)

### DIFF
--- a/src/Humans.Web/Controllers/GoogleController.cs
+++ b/src/Humans.Web/Controllers/GoogleController.cs
@@ -722,18 +722,25 @@ public class GoogleController : HumansControllerBase
             .Take(200)
             .ToListAsync();
 
-        // Resolve user emails and team names for display
+        // Resolve display info for events
         var userIds = events.Select(e => e.UserId).Distinct().ToList();
         var teamIds = events.Select(e => e.TeamId).Distinct().ToList();
-        var userLookup = await dbContext.Users
+        var googleEmailLookup = await dbContext.Users
             .Where(u => userIds.Contains(u.Id))
-            .ToDictionaryAsync(u => u.Id, u => u.Email ?? "unknown");
+            .ToDictionaryAsync(u => u.Id, u => u.GetGoogleServiceEmail() ?? "unknown");
         var teamLookup = await dbContext.Teams
             .Where(t => teamIds.Contains(t.Id))
             .ToDictionaryAsync(t => t.Id, t => t.Name);
+        var resourceLookup = await dbContext.GoogleResources
+            .Where(r => teamIds.Contains(r.TeamId) && r.IsActive)
+            .GroupBy(r => r.TeamId)
+            .ToDictionaryAsync(
+                g => g.Key,
+                g => g.Select(r => $"{r.Name} ({r.ResourceType})").ToList());
 
-        ViewBag.UserLookup = userLookup;
+        ViewBag.GoogleEmailLookup = googleEmailLookup;
         ViewBag.TeamLookup = teamLookup;
+        ViewBag.ResourceLookup = resourceLookup;
         return View(events);
     }
 

--- a/src/Humans.Web/Views/Google/_SyncOutboxTable.cshtml
+++ b/src/Humans.Web/Views/Google/_SyncOutboxTable.cshtml
@@ -1,8 +1,9 @@
 @using Humans.Web.Extensions
 @model IList<Humans.Domain.Entities.GoogleSyncOutboxEvent>
 @{
-    var userLookup = (Dictionary<Guid, string>)ViewData["UserLookup"]!;
+    var googleEmailLookup = (Dictionary<Guid, string>)ViewData["GoogleEmailLookup"]!;
     var teamLookup = (Dictionary<Guid, string>)ViewData["TeamLookup"]!;
+    var resourceLookup = (Dictionary<Guid, List<string>>)ViewData["ResourceLookup"]!;
     var showError = (bool)ViewData["ShowError"]!;
 }
 
@@ -18,7 +19,9 @@ else
                 <tr>
                     <th>Event Type</th>
                     <th>Human</th>
+                    <th>Google Email</th>
                     <th>Team</th>
+                    <th>Resource</th>
                     <th>Occurred</th>
                     <th>Retries</th>
                     @if (showError)
@@ -30,14 +33,29 @@ else
             <tbody>
                 @foreach (var evt in Model)
                 {
-                    var userEmail = userLookup.GetValueOrDefault(evt.UserId, "unknown");
+                    var googleEmail = googleEmailLookup.GetValueOrDefault(evt.UserId, "unknown");
                     var teamName = teamLookup.GetValueOrDefault(evt.TeamId, evt.TeamId.ToString());
+                    var resources = resourceLookup.GetValueOrDefault(evt.TeamId);
                     <tr>
                         <td><code>@evt.EventType</code></td>
                         <td>
-                            <human-link user-id="@evt.UserId" display-name="@userEmail" admin="true" show-popover="true" />
+                            <human-link user-id="@evt.UserId" admin="true" show-popover="true" />
                         </td>
+                        <td><small class="text-muted">@googleEmail</small></td>
                         <td>@teamName</td>
+                        <td>
+                            @if (resources is { Count: > 0 })
+                            {
+                                @foreach (var resource in resources)
+                                {
+                                    <div><small>@resource</small></div>
+                                }
+                            }
+                            else
+                            {
+                                <small class="text-muted">-</small>
+                            }
+                        </td>
                         <td class="text-nowrap">@evt.OccurredAt.ToDisplayDateTime()</td>
                         <td>
                             @if (evt.RetryCount > 0)


### PR DESCRIPTION
## Summary
- Shows human display name instead of OAuth email in SyncOutbox tables
- Adds Google Email column showing the address sync actually uses
- Adds Resource column showing target Google resource type and name
- Applied to both pending and failed event tables

Closes nobodies-collective/Humans#461

## Test plan
- [ ] Pending events table shows display name, Google email, and resource columns
- [ ] Failed events table shows the same columns
- [ ] Resources show correct type (Drive/Group) and name

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>