### PR TITLE
Polish profileless accounts: feedback, unsubscribe-as-auth, audience gauges (#437)

### DIFF
--- a/src/Humans.Web/Controllers/AdminController.cs
+++ b/src/Humans.Web/Controllers/AdminController.cs
@@ -299,4 +299,111 @@ public class AdminController : HumansControllerBase
 
         return RedirectToAction(nameof(CacheStats));
     }
+
+    [HttpGet("Audience")]
+    [Authorize(Policy = PolicyNames.AdminOnly)]
+    public async Task<IActionResult> AudienceSegmentation(int? year)
+    {
+        try
+        {
+            var allUserIds = await _dbContext.Users
+                .Select(u => u.Id)
+                .ToListAsync();
+
+            var profileUserIds = await _dbContext.Profiles
+                .Select(p => p.UserId)
+                .ToHashSetAsync();
+
+            // Get user IDs with tickets, optionally filtered by year
+            HashSet<Guid> ticketUserIds;
+            if (year.HasValue)
+            {
+                var yearStart = new DateTime(year.Value, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+                var yearEnd = new DateTime(year.Value + 1, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+                var orderUserIds = await _dbContext.TicketOrders
+                    .Where(o => o.MatchedUserId != null &&
+                                o.PurchasedAt >= NodaTime.Instant.FromDateTimeUtc(yearStart) &&
+                                o.PurchasedAt < NodaTime.Instant.FromDateTimeUtc(yearEnd))
+                    .Select(o => o.MatchedUserId!.Value)
+                    .Distinct()
+                    .ToListAsync();
+
+                var attendeeUserIds = await _dbContext.TicketAttendees
+                    .Where(a => a.MatchedUserId != null &&
+                                a.TicketOrder.PurchasedAt >= NodaTime.Instant.FromDateTimeUtc(yearStart) &&
+                                a.TicketOrder.PurchasedAt < NodaTime.Instant.FromDateTimeUtc(yearEnd))
+                    .Select(a => a.MatchedUserId!.Value)
+                    .Distinct()
+                    .ToListAsync();
+
+                ticketUserIds = orderUserIds.Concat(attendeeUserIds).ToHashSet();
+            }
+            else
+            {
+                var orderUserIds = await _dbContext.TicketOrders
+                    .Where(o => o.MatchedUserId != null)
+                    .Select(o => o.MatchedUserId!.Value)
+                    .Distinct()
+                    .ToListAsync();
+
+                var attendeeUserIds = await _dbContext.TicketAttendees
+                    .Where(a => a.MatchedUserId != null)
+                    .Select(a => a.MatchedUserId!.Value)
+                    .Distinct()
+                    .ToListAsync();
+
+                ticketUserIds = orderUserIds.Concat(attendeeUserIds).ToHashSet();
+            }
+
+            var totalAccounts = allUserIds.Count;
+            var withProfile = 0;
+            var withTicket = 0;
+            var withBoth = 0;
+            var withNeither = 0;
+
+            foreach (var userId in allUserIds)
+            {
+                var hasProfile = profileUserIds.Contains(userId);
+                var hasTicket = ticketUserIds.Contains(userId);
+
+                if (hasProfile) withProfile++;
+                if (hasTicket) withTicket++;
+                if (hasProfile && hasTicket) withBoth++;
+                if (!hasProfile && !hasTicket) withNeither++;
+            }
+
+            // Get available years from ticket orders
+            var availableYears = await _dbContext.TicketOrders
+                .Where(o => o.MatchedUserId != null)
+                .Select(o => o.PurchasedAt)
+                .Distinct()
+                .ToListAsync();
+
+            var years = availableYears
+                .Select(i => i.ToDateTimeUtc().Year)
+                .Distinct()
+                .OrderDescending()
+                .ToList();
+
+            var model = new AudienceSegmentationViewModel
+            {
+                TotalAccounts = totalAccounts,
+                WithTicket = withTicket,
+                WithProfile = withProfile,
+                WithBoth = withBoth,
+                WithNeither = withNeither,
+                AvailableYears = years,
+                SelectedYear = year,
+            };
+
+            return View(model);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error loading audience segmentation data");
+            SetError("Failed to load audience segmentation data.");
+            return RedirectToAction(nameof(Index));
+        }
+    }
 }

--- a/src/Humans.Web/Controllers/UnsubscribeController.cs
+++ b/src/Humans.Web/Controllers/UnsubscribeController.cs
@@ -1,7 +1,9 @@
 using System.Security.Cryptography;
 using Humans.Application.Interfaces;
+using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Humans.Infrastructure.Data;
 
@@ -12,17 +14,20 @@ public class UnsubscribeController : Controller
     private readonly HumansDbContext _db;
     private readonly ICommunicationPreferenceService _preferenceService;
     private readonly IDataProtectionProvider _dataProtection;
+    private readonly SignInManager<User> _signInManager;
     private readonly ILogger<UnsubscribeController> _logger;
 
     public UnsubscribeController(
         HumansDbContext db,
         ICommunicationPreferenceService preferenceService,
         IDataProtectionProvider dataProtection,
+        SignInManager<User> signInManager,
         ILogger<UnsubscribeController> logger)
     {
         _db = db;
         _preferenceService = preferenceService;
         _dataProtection = dataProtection;
+        _signInManager = signInManager;
         _logger = logger;
     }
 
@@ -38,9 +43,13 @@ public class UnsubscribeController : Controller
             if (user is null)
                 return NotFound();
 
-            ViewData["DisplayName"] = user.DisplayName;
-            ViewData["CategoryName"] = category.ToDisplayName();
-            return View();
+            // Sign in the user and redirect to communication preferences
+            await _signInManager.SignInAsync(user, isPersistent: false);
+            _logger.LogInformation(
+                "User {UserId} authenticated via unsubscribe link for {Category}",
+                userId, category);
+
+            return RedirectToCommunicationPreferences(user);
         }
 
         // Fall back to legacy campaign-only token
@@ -62,8 +71,13 @@ public class UnsubscribeController : Controller
 
             await _preferenceService.UpdatePreferenceAsync(userId, category, optedOut: true, source: "MagicLink");
 
-            ViewData["CategoryName"] = category.ToDisplayName();
-            return View("Done");
+            // Sign in and redirect to communication preferences
+            await _signInManager.SignInAsync(user, isPersistent: false);
+            _logger.LogInformation(
+                "User {UserId} unsubscribed from {Category} and authenticated via unsubscribe link",
+                userId, category);
+
+            return RedirectToCommunicationPreferences(user);
         }
 
         // Fall back to legacy campaign-only token
@@ -102,6 +116,18 @@ public class UnsubscribeController : Controller
         }
     }
 
+    /// <summary>
+    /// Redirects to the appropriate communication preferences page based on whether the user has a profile.
+    /// Profileless users go to Guest/CommunicationPreferences; users with profiles go to Profile/CommunicationPreferences.
+    /// </summary>
+    private IActionResult RedirectToCommunicationPreferences(User user)
+    {
+        var hasProfile = _db.Profiles.Any(p => p.UserId == user.Id);
+        return hasProfile
+            ? RedirectToAction(nameof(ProfileController.CommunicationPreferences), "Profile")
+            : RedirectToAction(nameof(GuestController.CommunicationPreferences), "Guest");
+    }
+
     private async Task<IActionResult> TryLegacyToken(string token)
     {
         var protector = _dataProtection
@@ -126,9 +152,13 @@ public class UnsubscribeController : Controller
         if (user is null)
             return NotFound();
 
-        ViewData["DisplayName"] = user.DisplayName;
-        ViewData["CategoryName"] = MessageCategory.Marketing.ToDisplayName();
-        return View();
+        // Sign in the user and redirect to communication preferences
+        await _signInManager.SignInAsync(user, isPersistent: false);
+        _logger.LogInformation(
+            "User {UserId} authenticated via legacy unsubscribe link",
+            userId);
+
+        return RedirectToCommunicationPreferences(user);
     }
 
     private async Task<IActionResult> TryLegacyConfirm(string token)
@@ -158,7 +188,12 @@ public class UnsubscribeController : Controller
         // Use the new preference service for legacy tokens too
         await _preferenceService.UpdatePreferenceAsync(userId, MessageCategory.Marketing, optedOut: true, source: "MagicLink");
 
-        ViewData["CategoryName"] = MessageCategory.Marketing.ToDisplayName();
-        return View("Done");
+        // Sign in and redirect to communication preferences
+        await _signInManager.SignInAsync(user, isPersistent: false);
+        _logger.LogInformation(
+            "User {UserId} unsubscribed from Marketing and authenticated via legacy unsubscribe link",
+            userId);
+
+        return RedirectToCommunicationPreferences(user);
     }
 }

--- a/src/Humans.Web/Models/AdminViewModels.cs
+++ b/src/Humans.Web/Models/AdminViewModels.cs
@@ -456,3 +456,22 @@ public class DuplicateAccountDetailViewModel
     public List<string> Account1EmailSources { get; set; } = [];
     public List<string> Account2EmailSources { get; set; } = [];
 }
+
+/// <summary>
+/// Audience segmentation gauges for admin view.
+/// Shows total accounts, accounts with tickets, with profiles, both, or neither.
+/// </summary>
+public class AudienceSegmentationViewModel
+{
+    public int TotalAccounts { get; set; }
+    public int WithTicket { get; set; }
+    public int WithProfile { get; set; }
+    public int WithBoth { get; set; }
+    public int WithNeither { get; set; }
+
+    /// <summary>Available event years for filtering (e.g. 2025, 2026).</summary>
+    public List<int> AvailableYears { get; set; } = [];
+
+    /// <summary>Currently selected event year filter, or null for all time.</summary>
+    public int? SelectedYear { get; set; }
+}

--- a/src/Humans.Web/Views/Admin/AudienceSegmentation.cshtml
+++ b/src/Humans.Web/Views/Admin/AudienceSegmentation.cshtml
@@ -1,0 +1,171 @@
+@model Humans.Web.Models.AudienceSegmentationViewModel
+@{
+    ViewData["Title"] = "Audience Segmentation";
+}
+
+<div class="d-flex justify-content-between align-items-center mb-3">
+    <h1 class="mb-0">Audience Segmentation</h1>
+</div>
+
+<vc:temp-data-alerts />
+
+<div class="row mb-4">
+    <div class="col-md-6">
+        <form method="get" class="d-flex gap-2 align-items-center">
+            <label class="form-label mb-0 me-2 text-nowrap">Filter by ticket year:</label>
+            <select name="year" class="form-select form-select-sm" style="width: auto;" id="yearFilter">
+                <option value="">All time</option>
+                @foreach (var y in Model.AvailableYears)
+                {
+                    if (Model.SelectedYear == y)
+                    {
+                        <option value="@y" selected>@y</option>
+                    }
+                    else
+                    {
+                        <option value="@y">@y</option>
+                    }
+                }
+            </select>
+            @if (Model.SelectedYear.HasValue)
+            {
+                <a asp-action="AudienceSegmentation" class="btn btn-sm btn-outline-secondary">Clear</a>
+            }
+        </form>
+    </div>
+</div>
+
+<div class="row g-3 mb-4">
+    <div class="col-sm-6 col-lg">
+        <div class="card text-center h-100">
+            <div class="card-body">
+                <div class="display-4 fw-bold text-primary">@Model.TotalAccounts</div>
+                <div class="text-muted">Total Accounts</div>
+            </div>
+        </div>
+    </div>
+    <div class="col-sm-6 col-lg">
+        <div class="card text-center h-100">
+            <div class="card-body">
+                <div class="display-4 fw-bold text-success">@Model.WithProfile</div>
+                <div class="text-muted">With Profile</div>
+            </div>
+        </div>
+    </div>
+    <div class="col-sm-6 col-lg">
+        <div class="card text-center h-100">
+            <div class="card-body">
+                <div class="display-4 fw-bold text-info">@Model.WithTicket</div>
+                <div class="text-muted">With Ticket@(Model.SelectedYear.HasValue ? $" ({Model.SelectedYear})" : "")</div>
+            </div>
+        </div>
+    </div>
+    <div class="col-sm-6 col-lg">
+        <div class="card text-center h-100">
+            <div class="card-body">
+                <div class="display-4 fw-bold text-warning">@Model.WithBoth</div>
+                <div class="text-muted">Both</div>
+            </div>
+        </div>
+    </div>
+    <div class="col-sm-6 col-lg">
+        <div class="card text-center h-100">
+            <div class="card-body">
+                <div class="display-4 fw-bold text-secondary">@Model.WithNeither</div>
+                <div class="text-muted">Neither</div>
+            </div>
+        </div>
+    </div>
+</div>
+
+@if (Model.TotalAccounts > 0)
+{
+    var profileOnly = Model.WithProfile - Model.WithBoth;
+    var ticketOnly = Model.WithTicket - Model.WithBoth;
+    var profileOnlyPct = Math.Round(profileOnly * 100.0 / Model.TotalAccounts, 1);
+    var ticketOnlyPct = Math.Round(ticketOnly * 100.0 / Model.TotalAccounts, 1);
+    var bothPct = Math.Round(Model.WithBoth * 100.0 / Model.TotalAccounts, 1);
+    var neitherPct = Math.Round(Model.WithNeither * 100.0 / Model.TotalAccounts, 1);
+
+    <div class="card mb-4">
+        <div class="card-header">
+            <h5 class="mb-0">Breakdown</h5>
+        </div>
+        <div class="card-body">
+            <div class="mb-3">
+                <div class="d-flex justify-content-between mb-1">
+                    <span>Profile only (no ticket)</span>
+                    <span class="text-muted">@profileOnly</span>
+                </div>
+                <div class="progress" style="height: 24px;">
+                    <div class="progress-bar bg-success" style="width: @profileOnlyPct%"></div>
+                </div>
+            </div>
+            <div class="mb-3">
+                <div class="d-flex justify-content-between mb-1">
+                    <span>Ticket only (no profile)</span>
+                    <span class="text-muted">@ticketOnly</span>
+                </div>
+                <div class="progress" style="height: 24px;">
+                    <div class="progress-bar bg-info" style="width: @ticketOnlyPct%"></div>
+                </div>
+            </div>
+            <div class="mb-3">
+                <div class="d-flex justify-content-between mb-1">
+                    <span>Both (profile + ticket)</span>
+                    <span class="text-muted">@Model.WithBoth</span>
+                </div>
+                <div class="progress" style="height: 24px;">
+                    <div class="progress-bar bg-warning" style="width: @bothPct%"></div>
+                </div>
+            </div>
+            <div class="mb-3">
+                <div class="d-flex justify-content-between mb-1">
+                    <span>Neither (account only)</span>
+                    <span class="text-muted">@Model.WithNeither</span>
+                </div>
+                <div class="progress" style="height: 24px;">
+                    <div class="progress-bar bg-secondary" style="width: @neitherPct%"></div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    @if (Model.SelectedYear.HasValue)
+    {
+        <div class="card mb-4">
+            <div class="card-header">
+                <h5 class="mb-0">Targeting Insights</h5>
+            </div>
+            <div class="card-body">
+                <ul class="list-unstyled mb-0">
+                    <li class="mb-2">
+                        <i class="fa-solid fa-bullseye text-info me-2"></i>
+                        <strong>@ticketOnly</strong> humans had a @Model.SelectedYear ticket but no profile
+                        <span class="text-muted">&mdash; potential recruitment targets</span>
+                    </li>
+                    <li class="mb-2">
+                        <i class="fa-solid fa-check-double text-success me-2"></i>
+                        <strong>@Model.WithBoth</strong> humans had a @Model.SelectedYear ticket and a profile
+                        <span class="text-muted">&mdash; already engaged</span>
+                    </li>
+                    <li>
+                        <i class="fa-solid fa-user-slash text-secondary me-2"></i>
+                        <strong>@Model.WithNeither</strong> humans have neither a @Model.SelectedYear ticket nor a profile
+                        <span class="text-muted">&mdash; may need outreach</span>
+                    </li>
+                </ul>
+            </div>
+        </div>
+    }
+}
+
+<a asp-action="Index" class="btn btn-outline-secondary">Back to Admin</a>
+
+@section Scripts {
+<script>
+    document.getElementById('yearFilter').addEventListener('change', function () {
+        this.form.submit();
+    });
+</script>
+}

--- a/src/Humans.Web/Views/Admin/Index.cshtml
+++ b/src/Humans.Web/Views/Admin/Index.cshtml
@@ -57,6 +57,9 @@
                 <a asp-controller="AdminDuplicateAccounts" asp-action="Index" class="list-group-item list-group-item-action">
                     <i class="fa-solid fa-clone me-2"></i>Duplicate Account Detection
                 </a>
+                <a asp-action="AudienceSegmentation" class="list-group-item list-group-item-action">
+                    <i class="fa-solid fa-chart-pie me-2"></i>Audience Segmentation
+                </a>
             </div>
         </div>
 

--- a/src/Humans.Web/Views/Unsubscribe/Done.cshtml
+++ b/src/Humans.Web/Views/Unsubscribe/Done.cshtml
@@ -9,7 +9,7 @@
 
 <p>
     You can manage all your communication preferences from your
-    <a asp-controller="Profile" asp-action="CommunicationPreferences">communication preferences</a>.
+    <a asp-controller="Guest" asp-action="CommunicationPreferences">communication preferences</a>.
 </p>
 
 <p><a asp-controller="Home" asp-action="Index">Back to home</a></p>

--- a/src/Humans.Web/Views/Unsubscribe/Expired.cshtml
+++ b/src/Humans.Web/Views/Unsubscribe/Expired.cshtml
@@ -6,7 +6,7 @@
 
 <p>
     Please use the link from a more recent email, or
-    <a asp-controller="Profile" asp-action="CommunicationPreferences">sign in to manage your communication preferences</a>.
+    <a asp-controller="Account" asp-action="Login">sign in to manage your communication preferences</a>.
 </p>
 
 <p><a asp-controller="Home" asp-action="Index">Back to home</a></p>


### PR DESCRIPTION
## Summary
- Unsubscribe links now authenticate the user and redirect to Guest/Profile communication preferences instead of a standalone page
- Adds admin audience segmentation view with gauges (total accounts, with ticket, with profile, both, neither) filterable by event year
- Fixes unsubscribe Done and Expired views for profileless users
- Edge case audit confirms no null-reference errors on any profileless-reachable page

Closes nobodies-collective/Humans#437
Closes nobodies-collective/Humans#377

## Test plan
- [ ] Submit feedback as profileless user — display name shows correctly
- [ ] Click unsubscribe link — lands on Guest dashboard comms preferences (authenticated)
- [ ] Click unsubscribe link as user with profile — lands on Profile comms preferences
- [ ] Check admin audience gauge page at /Admin/Audience — shows correct counts
- [ ] Filter audience gauges by year — counts update correctly
- [ ] Browse as profileless user — no null-reference errors
- [ ] Browse as regular user — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>