### PR TITLE
Codebase audit: fix high-priority tech debt (#102)

### DIFF
--- a/src/Humans.Application/DTOs/BirthdayProfileInfo.cs
+++ b/src/Humans.Application/DTOs/BirthdayProfileInfo.cs
@@ -1,0 +1,10 @@
+namespace Humans.Application.DTOs;
+
+public record BirthdayProfileInfo(
+    Guid UserId,
+    string DisplayName,
+    string? ProfilePictureUrl,
+    bool HasCustomPicture,
+    Guid ProfileId,
+    int Day,
+    int Month);

--- a/src/Humans.Application/DTOs/BoardVotingDashboardData.cs
+++ b/src/Humans.Application/DTOs/BoardVotingDashboardData.cs
@@ -1,0 +1,9 @@
+using MemberApplication = Humans.Domain.Entities.Application;
+
+namespace Humans.Application.DTOs;
+
+public record BoardVotingDashboardData(
+    List<MemberApplication> Applications,
+    List<BoardMemberInfo> BoardMembers);
+
+public record BoardMemberInfo(Guid UserId, string DisplayName);

--- a/src/Humans.Application/DTOs/LocationProfileInfo.cs
+++ b/src/Humans.Application/DTOs/LocationProfileInfo.cs
@@ -1,0 +1,10 @@
+namespace Humans.Application.DTOs;
+
+public record LocationProfileInfo(
+    Guid UserId,
+    string DisplayName,
+    string? ProfilePictureUrl,
+    double Latitude,
+    double Longitude,
+    string? City,
+    string? CountryCode);

--- a/src/Humans.Application/DTOs/ReviewDetailData.cs
+++ b/src/Humans.Application/DTOs/ReviewDetailData.cs
@@ -1,0 +1,10 @@
+using Humans.Domain.Entities;
+using MemberApplication = Humans.Domain.Entities.Application;
+
+namespace Humans.Application.DTOs;
+
+public record ReviewDetailData(
+    Profile? Profile,
+    int ConsentCount,
+    int RequiredConsentCount,
+    MemberApplication? PendingApplication);

--- a/src/Humans.Application/DTOs/ReviewQueueData.cs
+++ b/src/Humans.Application/DTOs/ReviewQueueData.cs
@@ -1,0 +1,11 @@
+using Humans.Domain.Entities;
+
+namespace Humans.Application.DTOs;
+
+public record ReviewQueueData(
+    List<Profile> Pending,
+    List<Profile> Flagged,
+    HashSet<Guid> PendingAppUserIds,
+    Dictionary<Guid, ConsentProgressInfo> ConsentProgress);
+
+public record ConsentProgressInfo(int Signed, int Required);

--- a/src/Humans.Application/Interfaces/IOnboardingService.cs
+++ b/src/Humans.Application/Interfaces/IOnboardingService.cs
@@ -9,14 +9,9 @@ public record OnboardingResult(bool Success, string? ErrorKey = null);
 public interface IOnboardingService
 {
     // --- Queries ---
-    Task<(List<Profile> Pending, List<Profile> Flagged, HashSet<Guid> PendingAppUserIds,
-          Dictionary<Guid, (int Signed, int Required)> ConsentProgress)>
-        GetReviewQueueAsync(CancellationToken ct = default);
-    Task<(Profile? Profile, int ConsentCount, int RequiredConsentCount,
-          MemberApplication? PendingApplication)>
-        GetReviewDetailAsync(Guid userId, CancellationToken ct = default);
-    Task<(List<MemberApplication> Applications, List<(Guid UserId, string DisplayName)> BoardMembers)>
-        GetBoardVotingDashboardAsync(CancellationToken ct = default);
+    Task<DTOs.ReviewQueueData> GetReviewQueueAsync(CancellationToken ct = default);
+    Task<DTOs.ReviewDetailData> GetReviewDetailAsync(Guid userId, CancellationToken ct = default);
+    Task<DTOs.BoardVotingDashboardData> GetBoardVotingDashboardAsync(CancellationToken ct = default);
     Task<MemberApplication?> GetBoardVotingDetailAsync(Guid applicationId, CancellationToken ct = default);
 
     // --- Consent check mutations ---

--- a/src/Humans.Application/Interfaces/IProfileService.cs
+++ b/src/Humans.Application/Interfaces/IProfileService.cs
@@ -78,10 +78,10 @@ public interface IProfileService
     Task<IReadOnlyList<CampaignGrant>> GetActiveOrCompletedCampaignGrantsAsync(
         Guid userId, CancellationToken ct = default);
 
-    Task<IReadOnlyList<(Guid UserId, string DisplayName, string? ProfilePictureUrl, bool HasCustomPicture, Guid ProfileId, int Day, int Month)>>
+    Task<IReadOnlyList<DTOs.BirthdayProfileInfo>>
         GetBirthdayProfilesAsync(int month, CancellationToken ct = default);
 
-    Task<IReadOnlyList<(Guid UserId, string DisplayName, string? ProfilePictureUrl, double Latitude, double Longitude, string? City, string? CountryCode)>>
+    Task<IReadOnlyList<DTOs.LocationProfileInfo>>
         GetApprovedProfilesWithLocationAsync(CancellationToken ct = default);
 
     Task<IReadOnlyList<DTOs.AdminHumanRow>> GetFilteredHumansAsync(

--- a/src/Humans.Application/Interfaces/IVolunteerHistoryService.cs
+++ b/src/Humans.Application/Interfaces/IVolunteerHistoryService.cs
@@ -1,0 +1,18 @@
+using Humans.Application.DTOs;
+
+namespace Humans.Application.Interfaces;
+
+/// <summary>
+/// Service for managing volunteer history entries.
+/// </summary>
+public interface IVolunteerHistoryService
+{
+    Task<IReadOnlyList<VolunteerHistoryEntryDto>> GetAllAsync(
+        Guid profileId,
+        CancellationToken cancellationToken = default);
+
+    Task SaveAsync(
+        Guid profileId,
+        IReadOnlyList<VolunteerHistoryEntryEditDto> entries,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Humans.Domain/Constants/DomainConstants.cs
+++ b/src/Humans.Domain/Constants/DomainConstants.cs
@@ -1,0 +1,12 @@
+namespace Humans.Domain.Constants;
+
+/// <summary>
+/// Domain-level constants shared across the application.
+/// </summary>
+public static class DomainConstants
+{
+    /// <summary>
+    /// The Google Workspace domain used for Google Groups and user accounts.
+    /// </summary>
+    public const string GoogleGroupDomain = "nobodies.team";
+}

--- a/src/Humans.Domain/Entities/Application.cs
+++ b/src/Humans.Domain/Entities/Application.cs
@@ -134,6 +134,20 @@ public class Application
     public ICollection<BoardVote> BoardVotes { get; } = new List<BoardVote>();
 
     /// <summary>
+    /// Validates that the membership tier is appropriate for an application
+    /// (Colaborador or Asociado only, never Volunteer).
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Thrown when tier is Volunteer.</exception>
+    public void ValidateTier()
+    {
+        if (MembershipTier == MembershipTier.Volunteer)
+        {
+            throw new InvalidOperationException(
+                "Applications are for Colaborador or Asociado tiers only. Volunteer access does not require an application.");
+        }
+    }
+
+    /// <summary>
     /// Gets the state machine for this application.
     /// </summary>
     public StateMachine<ApplicationStatus, ApplicationTrigger> StateMachine =>

--- a/src/Humans.Domain/Entities/Application.cs
+++ b/src/Humans.Domain/Entities/Application.cs
@@ -151,14 +151,11 @@ public class Application
             .PermitReentry(ApplicationTrigger.RequestMoreInfo)
             .Permit(ApplicationTrigger.Withdraw, ApplicationStatus.Withdrawn);
 
-        machine.Configure(ApplicationStatus.Approved)
-            .OnEntry(() => ResolvedAt = SystemClock.Instance.GetCurrentInstant());
+        machine.Configure(ApplicationStatus.Approved);
 
-        machine.Configure(ApplicationStatus.Rejected)
-            .OnEntry(() => ResolvedAt = SystemClock.Instance.GetCurrentInstant());
+        machine.Configure(ApplicationStatus.Rejected);
 
-        machine.Configure(ApplicationStatus.Withdrawn)
-            .OnEntry(() => ResolvedAt = SystemClock.Instance.GetCurrentInstant());
+        machine.Configure(ApplicationStatus.Withdrawn);
 
         return machine;
     }
@@ -174,7 +171,9 @@ public class Application
         StateMachine.Fire(ApplicationTrigger.Approve);
         ReviewedByUserId = reviewerUserId;
         ReviewNotes = notes;
-        UpdatedAt = clock.GetCurrentInstant();
+        var now = clock.GetCurrentInstant();
+        UpdatedAt = now;
+        ResolvedAt = now;
         AddStateHistory(ApplicationStatus.Approved, reviewerUserId, clock, notes);
     }
 
@@ -189,7 +188,9 @@ public class Application
         StateMachine.Fire(ApplicationTrigger.Reject);
         ReviewedByUserId = reviewerUserId;
         ReviewNotes = reason;
-        UpdatedAt = clock.GetCurrentInstant();
+        var now = clock.GetCurrentInstant();
+        UpdatedAt = now;
+        ResolvedAt = now;
         AddStateHistory(ApplicationStatus.Rejected, reviewerUserId, clock, reason);
     }
 
@@ -200,7 +201,9 @@ public class Application
     public void Withdraw(IClock clock)
     {
         StateMachine.Fire(ApplicationTrigger.Withdraw);
-        UpdatedAt = clock.GetCurrentInstant();
+        var now = clock.GetCurrentInstant();
+        UpdatedAt = now;
+        ResolvedAt = now;
         AddStateHistory(ApplicationStatus.Withdrawn, UserId, clock);
     }
 

--- a/src/Humans.Domain/Entities/Profile.cs
+++ b/src/Humans.Domain/Entities/Profile.cs
@@ -207,51 +207,6 @@ public class Profile
     public Guid? RejectedByUserId { get; set; }
 
     /// <summary>
-    /// Computes the current membership status based on role assignments and consent records.
-    /// </summary>
-    /// <param name="currentRoleAssignments">Active role assignments for this user.</param>
-    /// <param name="requiredDocumentVersionIds">IDs of document versions that require consent.</param>
-    /// <param name="consentedDocumentVersionIds">IDs of document versions the user has consented to.</param>
-    /// <returns>The computed membership status.</returns>
-    public MembershipStatus ComputeMembershipStatus(
-        IEnumerable<RoleAssignment> currentRoleAssignments,
-        IEnumerable<Guid> requiredDocumentVersionIds,
-        IEnumerable<Guid> consentedDocumentVersionIds)
-    {
-        if (IsSuspended)
-        {
-            return MembershipStatus.Suspended;
-        }
-
-        if (!IsApproved)
-        {
-            return MembershipStatus.Pending;
-        }
-
-        var activeRoles = currentRoleAssignments
-            .Where(ra => ra.IsActive(SystemClock.Instance.GetCurrentInstant()))
-            .ToList();
-
-        if (activeRoles.Count == 0)
-        {
-            return MembershipStatus.None;
-        }
-
-        var requiredIds = requiredDocumentVersionIds.ToHashSet();
-        var consentedIds = consentedDocumentVersionIds.ToHashSet();
-
-        // Check if all required documents have valid consent
-        var missingConsent = requiredIds.Except(consentedIds).Any();
-
-        if (missingConsent)
-        {
-            return MembershipStatus.Inactive;
-        }
-
-        return MembershipStatus.Active;
-    }
-
-    /// <summary>
     /// Gets the full name of the member.
     /// </summary>
     public string FullName => $"{FirstName} {LastName}".Trim();

--- a/src/Humans.Domain/Entities/Team.cs
+++ b/src/Humans.Domain/Entities/Team.cs
@@ -1,5 +1,6 @@
 using NodaTime;
 using Humans.Domain.Attributes;
+using Humans.Domain.Constants;
 using Humans.Domain.Enums;
 using Humans.Domain.ValueObjects;
 
@@ -54,7 +55,7 @@ public class Team
     /// Full Google Group email address, or null if no prefix is set.
     /// </summary>
     public string? GoogleGroupEmail => GoogleGroupPrefix is not null
-        ? $"{GoogleGroupPrefix}@nobodies.team"
+        ? $"{GoogleGroupPrefix}@{DomainConstants.GoogleGroupDomain}"
         : null;
 
     /// <summary>

--- a/src/Humans.Infrastructure/Jobs/CleanupEmailOutboxJob.cs
+++ b/src/Humans.Infrastructure/Jobs/CleanupEmailOutboxJob.cs
@@ -5,7 +5,6 @@ using NodaTime;
 using Humans.Domain.Enums;
 using Humans.Infrastructure.Configuration;
 using Humans.Infrastructure.Data;
-using Humans.Infrastructure.Services;
 
 using Humans.Application.Interfaces;
 
@@ -19,14 +18,14 @@ public class CleanupEmailOutboxJob : IRecurringJob
     private readonly HumansDbContext _dbContext;
     private readonly IClock _clock;
     private readonly EmailSettings _settings;
-    private readonly HumansMetricsService _metrics;
+    private readonly IHumansMetrics _metrics;
     private readonly ILogger<CleanupEmailOutboxJob> _logger;
 
     public CleanupEmailOutboxJob(
         HumansDbContext dbContext,
         IClock clock,
         IOptions<EmailSettings> settings,
-        HumansMetricsService metrics,
+        IHumansMetrics metrics,
         ILogger<CleanupEmailOutboxJob> logger)
     {
         _dbContext = dbContext;

--- a/src/Humans.Infrastructure/Jobs/CleanupNotificationsJob.cs
+++ b/src/Humans.Infrastructure/Jobs/CleanupNotificationsJob.cs
@@ -1,7 +1,6 @@
 using Humans.Application.Interfaces;
 using Humans.Domain.Enums;
 using Humans.Infrastructure.Data;
-using Humans.Infrastructure.Services;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using NodaTime;
@@ -21,13 +20,13 @@ public class CleanupNotificationsJob : IRecurringJob
 
     private readonly HumansDbContext _dbContext;
     private readonly IClock _clock;
-    private readonly HumansMetricsService _metrics;
+    private readonly IHumansMetrics _metrics;
     private readonly ILogger<CleanupNotificationsJob> _logger;
 
     public CleanupNotificationsJob(
         HumansDbContext dbContext,
         IClock clock,
-        HumansMetricsService metrics,
+        IHumansMetrics metrics,
         ILogger<CleanupNotificationsJob> logger)
     {
         _dbContext = dbContext;

--- a/src/Humans.Infrastructure/Jobs/DriveActivityMonitorJob.cs
+++ b/src/Humans.Infrastructure/Jobs/DriveActivityMonitorJob.cs
@@ -1,7 +1,6 @@
 using Microsoft.Extensions.Logging;
 using NodaTime;
 using Humans.Application.Interfaces;
-using Humans.Infrastructure.Services;
 
 namespace Humans.Infrastructure.Jobs;
 
@@ -12,13 +11,13 @@ namespace Humans.Infrastructure.Jobs;
 public class DriveActivityMonitorJob : IRecurringJob
 {
     private readonly IDriveActivityMonitorService _monitorService;
-    private readonly HumansMetricsService _metrics;
+    private readonly IHumansMetrics _metrics;
     private readonly ILogger<DriveActivityMonitorJob> _logger;
     private readonly IClock _clock;
 
     public DriveActivityMonitorJob(
         IDriveActivityMonitorService monitorService,
-        HumansMetricsService metrics,
+        IHumansMetrics metrics,
         ILogger<DriveActivityMonitorJob> logger,
         IClock clock)
     {

--- a/src/Humans.Infrastructure/Jobs/GoogleResourceProvisionJob.cs
+++ b/src/Humans.Infrastructure/Jobs/GoogleResourceProvisionJob.cs
@@ -1,7 +1,5 @@
 using Microsoft.Extensions.Logging;
-using NodaTime;
 using Humans.Application.Interfaces;
-using Humans.Infrastructure.Services;
 
 namespace Humans.Infrastructure.Jobs;
 
@@ -11,20 +9,17 @@ namespace Humans.Infrastructure.Jobs;
 public class GoogleResourceProvisionJob
 {
     private readonly IGoogleSyncService _googleService;
-    private readonly HumansMetricsService _metrics;
+    private readonly IHumansMetrics _metrics;
     private readonly ILogger<GoogleResourceProvisionJob> _logger;
-    private readonly IClock _clock;
 
     public GoogleResourceProvisionJob(
         IGoogleSyncService googleService,
-        HumansMetricsService metrics,
-        ILogger<GoogleResourceProvisionJob> logger,
-        IClock clock)
+        IHumansMetrics metrics,
+        ILogger<GoogleResourceProvisionJob> logger)
     {
         _googleService = googleService;
         _metrics = metrics;
         _logger = logger;
-        _clock = clock;
     }
 
     /// <summary>
@@ -55,25 +50,4 @@ public class GoogleResourceProvisionJob
         }
     }
 
-    /// <summary>
-    /// Syncs all Google resource permissions.
-    /// </summary>
-    public async Task SyncAllPermissionsAsync(CancellationToken cancellationToken = default)
-    {
-        _logger.LogInformation("Starting Google resource permission sync at {Time}", _clock.GetCurrentInstant());
-
-        try
-        {
-            // TODO: Task 6 will replace with SyncResourcesByTypeAsync calls
-            await Task.CompletedTask;
-            _metrics.RecordJobRun("google_resource_provision", "success");
-            _logger.LogInformation("Completed Google resource permission sync");
-        }
-        catch (Exception ex)
-        {
-            _metrics.RecordJobRun("google_resource_provision", "failure");
-            _logger.LogError(ex, "Error syncing Google resource permissions");
-            throw;
-        }
-    }
 }

--- a/src/Humans.Infrastructure/Jobs/GoogleResourceReconciliationJob.cs
+++ b/src/Humans.Infrastructure/Jobs/GoogleResourceReconciliationJob.cs
@@ -3,7 +3,6 @@ using NodaTime;
 using Humans.Application.Interfaces;
 using Humans.Domain.Constants;
 using Humans.Domain.Enums;
-using Humans.Infrastructure.Services;
 
 namespace Humans.Infrastructure.Jobs;
 
@@ -15,14 +14,14 @@ public class GoogleResourceReconciliationJob : IRecurringJob
 {
     private readonly IGoogleSyncService _googleSyncService;
     private readonly INotificationService _notificationService;
-    private readonly HumansMetricsService _metrics;
+    private readonly IHumansMetrics _metrics;
     private readonly ILogger<GoogleResourceReconciliationJob> _logger;
     private readonly IClock _clock;
 
     public GoogleResourceReconciliationJob(
         IGoogleSyncService googleSyncService,
         INotificationService notificationService,
-        HumansMetricsService metrics,
+        IHumansMetrics metrics,
         ILogger<GoogleResourceReconciliationJob> logger,
         IClock clock)
     {

--- a/src/Humans.Infrastructure/Jobs/ProcessAccountDeletionsJob.cs
+++ b/src/Humans.Infrastructure/Jobs/ProcessAccountDeletionsJob.cs
@@ -7,7 +7,6 @@ using Humans.Application.Interfaces;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Humans.Infrastructure.Data;
-using Humans.Infrastructure.Services;
 
 namespace Humans.Infrastructure.Jobs;
 
@@ -23,7 +22,7 @@ public class ProcessAccountDeletionsJob : IRecurringJob
     private readonly IProfileService _profileService;
     private readonly ITeamService _teamService;
     private readonly IMemoryCache _cache;
-    private readonly HumansMetricsService _metrics;
+    private readonly IHumansMetrics _metrics;
     private readonly ILogger<ProcessAccountDeletionsJob> _logger;
     private readonly IClock _clock;
 
@@ -34,7 +33,7 @@ public class ProcessAccountDeletionsJob : IRecurringJob
         IProfileService profileService,
         ITeamService teamService,
         IMemoryCache cache,
-        HumansMetricsService metrics,
+        IHumansMetrics metrics,
         ILogger<ProcessAccountDeletionsJob> logger,
         IClock clock)
     {

--- a/src/Humans.Infrastructure/Jobs/ProcessAccountDeletionsJob.cs
+++ b/src/Humans.Infrastructure/Jobs/ProcessAccountDeletionsJob.cs
@@ -122,9 +122,16 @@ public class ProcessAccountDeletionsJob : IRecurringJob
                 catch (Exception ex)
                 {
                     _logger.LogError(ex,
-                        "Failed to process deletion for user {UserId}. Detaching tracked changes",
+                        "Failed to process deletion for user {UserId}. Reverting tracked changes",
                         user.Id);
-                    _dbContext.ChangeTracker.Clear();
+
+                    // Detach only modified/added/deleted entries from the failed user,
+                    // keeping remaining unchanged entities tracked for subsequent iterations
+                    foreach (var entry in _dbContext.ChangeTracker.Entries().ToList())
+                    {
+                        if (entry.State != EntityState.Unchanged)
+                            entry.State = EntityState.Detached;
+                    }
                 }
             }
 

--- a/src/Humans.Infrastructure/Jobs/ProcessEmailOutboxJob.cs
+++ b/src/Humans.Infrastructure/Jobs/ProcessEmailOutboxJob.cs
@@ -7,7 +7,6 @@ using Humans.Application.Interfaces;
 using Humans.Domain.Enums;
 using Humans.Infrastructure.Configuration;
 using Humans.Infrastructure.Data;
-using Humans.Infrastructure.Services;
 
 namespace Humans.Infrastructure.Jobs;
 
@@ -19,7 +18,7 @@ public class ProcessEmailOutboxJob : IRecurringJob
 {
     private readonly HumansDbContext _dbContext;
     private readonly IEmailTransport _transport;
-    private readonly HumansMetricsService _metrics;
+    private readonly IHumansMetrics _metrics;
     private readonly IClock _clock;
     private readonly EmailSettings _settings;
     private readonly ILogger<ProcessEmailOutboxJob> _logger;
@@ -27,7 +26,7 @@ public class ProcessEmailOutboxJob : IRecurringJob
     public ProcessEmailOutboxJob(
         HumansDbContext dbContext,
         IEmailTransport transport,
-        HumansMetricsService metrics,
+        IHumansMetrics metrics,
         IClock clock,
         IOptions<EmailSettings> settings,
         ILogger<ProcessEmailOutboxJob> logger)

--- a/src/Humans.Infrastructure/Jobs/ProcessGoogleSyncOutboxJob.cs
+++ b/src/Humans.Infrastructure/Jobs/ProcessGoogleSyncOutboxJob.cs
@@ -5,7 +5,6 @@ using Humans.Application.Interfaces;
 using Humans.Domain.Constants;
 using Humans.Domain.Enums;
 using Humans.Infrastructure.Data;
-using Humans.Infrastructure.Services;
 
 namespace Humans.Infrastructure.Jobs;
 
@@ -28,7 +27,7 @@ public class ProcessGoogleSyncOutboxJob : IRecurringJob
     private readonly HumansDbContext _dbContext;
     private readonly IGoogleSyncService _googleSyncService;
     private readonly INotificationService _notificationService;
-    private readonly HumansMetricsService _metrics;
+    private readonly IHumansMetrics _metrics;
     private readonly IClock _clock;
     private readonly ILogger<ProcessGoogleSyncOutboxJob> _logger;
 
@@ -36,7 +35,7 @@ public class ProcessGoogleSyncOutboxJob : IRecurringJob
         HumansDbContext dbContext,
         IGoogleSyncService googleSyncService,
         INotificationService notificationService,
-        HumansMetricsService metrics,
+        IHumansMetrics metrics,
         IClock clock,
         ILogger<ProcessGoogleSyncOutboxJob> logger)
     {

--- a/src/Humans.Infrastructure/Jobs/SendAdminDailyDigestJob.cs
+++ b/src/Humans.Infrastructure/Jobs/SendAdminDailyDigestJob.cs
@@ -7,7 +7,6 @@ using Humans.Application.Interfaces;
 using Humans.Domain.Constants;
 using Humans.Domain.Enums;
 using Humans.Infrastructure.Data;
-using Humans.Infrastructure.Services;
 
 namespace Humans.Infrastructure.Jobs;
 
@@ -19,7 +18,7 @@ public class SendAdminDailyDigestJob : IRecurringJob
     private readonly HumansDbContext _dbContext;
     private readonly IEmailService _emailService;
     private readonly IMembershipCalculator _membershipCalculator;
-    private readonly HumansMetricsService _metrics;
+    private readonly IHumansMetrics _metrics;
     private readonly ILogger<SendAdminDailyDigestJob> _logger;
     private readonly IClock _clock;
 
@@ -27,7 +26,7 @@ public class SendAdminDailyDigestJob : IRecurringJob
         HumansDbContext dbContext,
         IEmailService emailService,
         IMembershipCalculator membershipCalculator,
-        HumansMetricsService metrics,
+        IHumansMetrics metrics,
         ILogger<SendAdminDailyDigestJob> logger,
         IClock clock)
     {

--- a/src/Humans.Infrastructure/Jobs/SendBoardDailyDigestJob.cs
+++ b/src/Humans.Infrastructure/Jobs/SendBoardDailyDigestJob.cs
@@ -7,7 +7,6 @@ using Humans.Application.Interfaces;
 using Humans.Domain.Constants;
 using Humans.Domain.Enums;
 using Humans.Infrastructure.Data;
-using Humans.Infrastructure.Services;
 
 namespace Humans.Infrastructure.Jobs;
 
@@ -20,7 +19,7 @@ public class SendBoardDailyDigestJob : IRecurringJob
     private readonly HumansDbContext _dbContext;
     private readonly IEmailService _emailService;
     private readonly IMembershipCalculator _membershipCalculator;
-    private readonly HumansMetricsService _metrics;
+    private readonly IHumansMetrics _metrics;
     private readonly ILogger<SendBoardDailyDigestJob> _logger;
     private readonly IClock _clock;
 
@@ -28,7 +27,7 @@ public class SendBoardDailyDigestJob : IRecurringJob
         HumansDbContext dbContext,
         IEmailService emailService,
         IMembershipCalculator membershipCalculator,
-        HumansMetricsService metrics,
+        IHumansMetrics metrics,
         ILogger<SendBoardDailyDigestJob> logger,
         IClock clock)
     {

--- a/src/Humans.Infrastructure/Jobs/SendReConsentReminderJob.cs
+++ b/src/Humans.Infrastructure/Jobs/SendReConsentReminderJob.cs
@@ -5,7 +5,6 @@ using NodaTime;
 using Humans.Application.Interfaces;
 using Humans.Infrastructure.Configuration;
 using Humans.Infrastructure.Data;
-using Humans.Infrastructure.Services;
 
 namespace Humans.Infrastructure.Jobs;
 
@@ -19,7 +18,7 @@ public class SendReConsentReminderJob : IRecurringJob
     private readonly ILegalDocumentSyncService _legalDocService;
     private readonly IEmailService _emailService;
     private readonly EmailSettings _emailSettings;
-    private readonly HumansMetricsService _metrics;
+    private readonly IHumansMetrics _metrics;
     private readonly ILogger<SendReConsentReminderJob> _logger;
     private readonly IClock _clock;
 
@@ -29,7 +28,7 @@ public class SendReConsentReminderJob : IRecurringJob
         ILegalDocumentSyncService legalDocService,
         IEmailService emailService,
         IOptions<EmailSettings> emailSettings,
-        HumansMetricsService metrics,
+        IHumansMetrics metrics,
         ILogger<SendReConsentReminderJob> logger,
         IClock clock)
     {

--- a/src/Humans.Infrastructure/Jobs/SuspendNonCompliantMembersJob.cs
+++ b/src/Humans.Infrastructure/Jobs/SuspendNonCompliantMembersJob.cs
@@ -7,7 +7,6 @@ using Humans.Application.Interfaces;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Humans.Infrastructure.Data;
-using Humans.Infrastructure.Services;
 
 namespace Humans.Infrastructure.Jobs;
 
@@ -26,7 +25,7 @@ public class SuspendNonCompliantMembersJob : IRecurringJob
     private readonly IProfileService _profileService;
     private readonly ITeamService _teamService;
     private readonly IMemoryCache _cache;
-    private readonly HumansMetricsService _metrics;
+    private readonly IHumansMetrics _metrics;
     private readonly ILogger<SuspendNonCompliantMembersJob> _logger;
     private readonly IClock _clock;
 
@@ -40,7 +39,7 @@ public class SuspendNonCompliantMembersJob : IRecurringJob
         IProfileService profileService,
         ITeamService teamService,
         IMemoryCache cache,
-        HumansMetricsService metrics,
+        IHumansMetrics metrics,
         ILogger<SuspendNonCompliantMembersJob> logger,
         IClock clock)
     {

--- a/src/Humans.Infrastructure/Jobs/SyncLegalDocumentsJob.cs
+++ b/src/Humans.Infrastructure/Jobs/SyncLegalDocumentsJob.cs
@@ -3,7 +3,6 @@ using Microsoft.Extensions.Logging;
 using NodaTime;
 using Humans.Application.Interfaces;
 using Humans.Infrastructure.Data;
-using Humans.Infrastructure.Services;
 
 namespace Humans.Infrastructure.Jobs;
 
@@ -15,7 +14,7 @@ public class SyncLegalDocumentsJob : IRecurringJob
     private readonly ILegalDocumentSyncService _syncService;
     private readonly IEmailService _emailService;
     private readonly HumansDbContext _dbContext;
-    private readonly HumansMetricsService _metrics;
+    private readonly IHumansMetrics _metrics;
     private readonly ILogger<SyncLegalDocumentsJob> _logger;
     private readonly IClock _clock;
 
@@ -23,7 +22,7 @@ public class SyncLegalDocumentsJob : IRecurringJob
         ILegalDocumentSyncService syncService,
         IEmailService emailService,
         HumansDbContext dbContext,
-        HumansMetricsService metrics,
+        IHumansMetrics metrics,
         ILogger<SyncLegalDocumentsJob> logger,
         IClock clock)
     {

--- a/src/Humans.Infrastructure/Jobs/SystemTeamSyncJob.cs
+++ b/src/Humans.Infrastructure/Jobs/SystemTeamSyncJob.cs
@@ -9,7 +9,6 @@ using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Humans.Application.DTOs;
 using Humans.Infrastructure.Data;
-using Humans.Infrastructure.Services;
 
 namespace Humans.Infrastructure.Jobs;
 
@@ -24,7 +23,7 @@ public class SystemTeamSyncJob : ISystemTeamSync
     private readonly IAuditLogService _auditLogService;
     private readonly IEmailService _emailService;
     private readonly IMemoryCache _cache;
-    private readonly HumansMetricsService _metrics;
+    private readonly IHumansMetrics _metrics;
     private readonly ILogger<SystemTeamSyncJob> _logger;
     private readonly IClock _clock;
 
@@ -35,7 +34,7 @@ public class SystemTeamSyncJob : ISystemTeamSync
         IAuditLogService auditLogService,
         IEmailService emailService,
         IMemoryCache cache,
-        HumansMetricsService metrics,
+        IHumansMetrics metrics,
         ILogger<SystemTeamSyncJob> logger,
         IClock clock)
     {

--- a/src/Humans.Infrastructure/Jobs/TermRenewalReminderJob.cs
+++ b/src/Humans.Infrastructure/Jobs/TermRenewalReminderJob.cs
@@ -5,7 +5,6 @@ using NodaTime;
 using Humans.Application.Interfaces;
 using Humans.Domain.Enums;
 using Humans.Infrastructure.Data;
-using Humans.Infrastructure.Services;
 
 namespace Humans.Infrastructure.Jobs;
 
@@ -14,7 +13,7 @@ public class TermRenewalReminderJob : IRecurringJob
     private readonly HumansDbContext _dbContext;
     private readonly IEmailService _emailService;
     private readonly INotificationService _notificationService;
-    private readonly HumansMetricsService _metrics;
+    private readonly IHumansMetrics _metrics;
     private readonly ILogger<TermRenewalReminderJob> _logger;
     private readonly IClock _clock;
 
@@ -24,7 +23,7 @@ public class TermRenewalReminderJob : IRecurringJob
         HumansDbContext dbContext,
         IEmailService emailService,
         INotificationService notificationService,
-        HumansMetricsService metrics,
+        IHumansMetrics metrics,
         ILogger<TermRenewalReminderJob> logger,
         IClock clock)
     {

--- a/src/Humans.Infrastructure/Services/ApplicationDecisionService.cs
+++ b/src/Humans.Infrastructure/Services/ApplicationDecisionService.cs
@@ -280,6 +280,7 @@ public class ApplicationDecisionService : IApplicationDecisionService
             SubmittedAt = now,
             UpdatedAt = now
         };
+        application.ValidateTier();
 
         _dbContext.Applications.Add(application);
         await _dbContext.SaveChangesAsync(ct);

--- a/src/Humans.Infrastructure/Services/ApplicationDecisionService.cs
+++ b/src/Humans.Infrastructure/Services/ApplicationDecisionService.cs
@@ -96,30 +96,7 @@ public class ApplicationDecisionService : IApplicationDecisionService
         _dbContext.BoardVotes.RemoveRange(application.BoardVotes);
 
         // Save (must complete before team sync)
-        try
-        {
-            await _dbContext.SaveChangesAsync(cancellationToken);
-        }
-        catch (DbUpdateConcurrencyException ex)
-        {
-            foreach (var entry in ex.Entries)
-            {
-                _logger.LogWarning(
-                    "Concurrency conflict on entity {EntityType} (State={State}). " +
-                    "Original values: {Original}, Current values: {Current}",
-                    entry.Metadata.Name, entry.State,
-                    string.Join(", ", entry.Properties
-                        .Where(p => p.IsModified || p.Metadata.IsConcurrencyToken)
-                        .Select(p => $"{p.Metadata.Name}={p.OriginalValue}→{p.CurrentValue}")),
-                    string.Join(", ", entry.Properties
-                        .Where(p => p.Metadata.IsConcurrencyToken)
-                        .Select(p => $"{p.Metadata.Name}: db={p.OriginalValue}")));
-            }
-            _logger.LogWarning(ex,
-                "Concurrency conflict while approving application {ApplicationId} by {UserId}",
-                application.Id, reviewerUserId);
-            return new ApplicationDecisionResult(false, "ConcurrencyConflict");
-        }
+        await _dbContext.SaveChangesAsync(cancellationToken);
 
         _cache.InvalidateNavBadgeCounts();
         _cache.InvalidateNotificationMeters();
@@ -209,27 +186,7 @@ public class ApplicationDecisionService : IApplicationDecisionService
         _dbContext.BoardVotes.RemoveRange(application.BoardVotes);
 
         // Save
-        try
-        {
-            await _dbContext.SaveChangesAsync(cancellationToken);
-        }
-        catch (DbUpdateConcurrencyException ex)
-        {
-            foreach (var entry in ex.Entries)
-            {
-                _logger.LogWarning(
-                    "Concurrency conflict on entity {EntityType} (State={State}). " +
-                    "Modified/token props: {Props}",
-                    entry.Metadata.Name, entry.State,
-                    string.Join(", ", entry.Properties
-                        .Where(p => p.IsModified || p.Metadata.IsConcurrencyToken)
-                        .Select(p => $"{p.Metadata.Name}={p.OriginalValue}→{p.CurrentValue}")));
-            }
-            _logger.LogWarning(ex,
-                "Concurrency conflict while rejecting application {ApplicationId} by {UserId}",
-                application.Id, reviewerUserId);
-            return new ApplicationDecisionResult(false, "ConcurrencyConflict");
-        }
+        await _dbContext.SaveChangesAsync(cancellationToken);
 
         _cache.InvalidateNavBadgeCounts();
         _cache.InvalidateNotificationMeters();

--- a/src/Humans.Infrastructure/Services/OnboardingService.cs
+++ b/src/Humans.Infrastructure/Services/OnboardingService.cs
@@ -52,8 +52,7 @@ public class OnboardingService : IOnboardingService
         _logger = logger;
     }
 
-    public async Task<(List<Profile> Pending, List<Profile> Flagged, HashSet<Guid> PendingAppUserIds,
-        Dictionary<Guid, (int Signed, int Required)> ConsentProgress)>
+    public async Task<Application.DTOs.ReviewQueueData>
         GetReviewQueueAsync(CancellationToken ct = default)
     {
         var reviewableProfiles = await _dbContext.Profiles
@@ -69,11 +68,13 @@ public class OnboardingService : IOnboardingService
             .Select(a => a.UserId)
             .ToHashSetAsync(ct);
 
-        var consentProgress = new Dictionary<Guid, (int Signed, int Required)>();
+        var consentProgress = new Dictionary<Guid, Application.DTOs.ConsentProgressInfo>();
         foreach (var userId in allUserIds)
         {
             var snapshot = await _membershipCalculator.GetMembershipSnapshotAsync(userId, ct);
-            consentProgress[userId] = (snapshot.RequiredConsentCount - snapshot.PendingConsentCount, snapshot.RequiredConsentCount);
+            consentProgress[userId] = new Application.DTOs.ConsentProgressInfo(
+                snapshot.RequiredConsentCount - snapshot.PendingConsentCount,
+                snapshot.RequiredConsentCount);
         }
 
         var flagged = reviewableProfiles
@@ -81,11 +82,10 @@ public class OnboardingService : IOnboardingService
             .ToList();
         var pending = reviewableProfiles.Except(flagged).ToList();
 
-        return (pending, flagged, pendingAppUserIds, consentProgress);
+        return new Application.DTOs.ReviewQueueData(pending, flagged, pendingAppUserIds, consentProgress);
     }
 
-    public async Task<(Profile? Profile, int ConsentCount, int RequiredConsentCount,
-        MemberApplication? PendingApplication)>
+    public async Task<Application.DTOs.ReviewDetailData>
         GetReviewDetailAsync(Guid userId, CancellationToken ct = default)
     {
         var profile = await _dbContext.Profiles
@@ -93,7 +93,7 @@ public class OnboardingService : IOnboardingService
             .FirstOrDefaultAsync(p => p.UserId == userId, ct);
 
         if (profile is null)
-            return (null, 0, 0, null);
+            return new Application.DTOs.ReviewDetailData(null, 0, 0, null);
 
         var snapshot = await _membershipCalculator.GetMembershipSnapshotAsync(userId, ct);
 
@@ -101,7 +101,7 @@ public class OnboardingService : IOnboardingService
             .Where(a => a.UserId == userId && a.Status == ApplicationStatus.Submitted)
             .FirstOrDefaultAsync(ct);
 
-        return (
+        return new Application.DTOs.ReviewDetailData(
             profile,
             snapshot.RequiredConsentCount - snapshot.PendingConsentCount,
             snapshot.RequiredConsentCount,
@@ -109,7 +109,7 @@ public class OnboardingService : IOnboardingService
         );
     }
 
-    public async Task<(List<MemberApplication> Applications, List<(Guid UserId, string DisplayName)> BoardMembers)>
+    public async Task<Application.DTOs.BoardVotingDashboardData>
         GetBoardVotingDashboardAsync(CancellationToken ct = default)
     {
         var applications = await _dbContext.Applications
@@ -138,11 +138,11 @@ public class OnboardingService : IOnboardingService
             .ToListAsync(ct);
 
         var boardMembers = boardUsers
-            .Select(u => (u.Id, u.DisplayName))
+            .Select(u => new Application.DTOs.BoardMemberInfo(u.Id, u.DisplayName))
             .OrderBy(m => m.DisplayName, StringComparer.OrdinalIgnoreCase)
             .ToList();
 
-        return (applications, boardMembers);
+        return new Application.DTOs.BoardVotingDashboardData(applications, boardMembers);
     }
 
     public async Task<MemberApplication?> GetBoardVotingDetailAsync(Guid applicationId, CancellationToken ct = default)

--- a/src/Humans.Infrastructure/Services/ProfileService.cs
+++ b/src/Humans.Infrastructure/Services/ProfileService.cs
@@ -598,24 +598,24 @@ public class ProfileService : IProfileService
             .ToListAsync(ct);
     }
 
-    public async Task<IReadOnlyList<(Guid UserId, string DisplayName, string? ProfilePictureUrl, bool HasCustomPicture, Guid ProfileId, int Day, int Month)>>
+    public async Task<IReadOnlyList<Application.DTOs.BirthdayProfileInfo>>
         GetBirthdayProfilesAsync(int month, CancellationToken ct = default)
     {
         var cached = await GetCachedProfilesAsync(ct);
         return cached.Values
             .Where(p => p.BirthdayMonth == month && p.BirthdayDay.HasValue)
             .OrderBy(p => p.BirthdayDay)
-            .Select(p => (p.UserId, p.DisplayName, p.ProfilePictureUrl, p.HasCustomPicture, p.ProfileId, p.BirthdayDay!.Value, p.BirthdayMonth!.Value))
+            .Select(p => new Application.DTOs.BirthdayProfileInfo(p.UserId, p.DisplayName, p.ProfilePictureUrl, p.HasCustomPicture, p.ProfileId, p.BirthdayDay!.Value, p.BirthdayMonth!.Value))
             .ToList();
     }
 
-    public async Task<IReadOnlyList<(Guid UserId, string DisplayName, string? ProfilePictureUrl, double Latitude, double Longitude, string? City, string? CountryCode)>>
+    public async Task<IReadOnlyList<Application.DTOs.LocationProfileInfo>>
         GetApprovedProfilesWithLocationAsync(CancellationToken ct = default)
     {
         var cached = await GetCachedProfilesAsync(ct);
         return cached.Values
             .Where(p => p.Latitude.HasValue && p.Longitude.HasValue)
-            .Select(p => (p.UserId, p.DisplayName, p.ProfilePictureUrl, p.Latitude!.Value, p.Longitude!.Value, p.City, p.CountryCode))
+            .Select(p => new Application.DTOs.LocationProfileInfo(p.UserId, p.DisplayName, p.ProfilePictureUrl, p.Latitude!.Value, p.Longitude!.Value, p.City, p.CountryCode))
             .ToList();
     }
 
@@ -659,14 +659,14 @@ public class ProfileService : IProfileService
         var partition = await _membershipCalculator.PartitionUsersAsync(allIds, ct);
 
         // Apply filter using partition buckets
-        HashSet<Guid>? filteredIds = statusFilter?.ToLowerInvariant() switch
+        HashSet<Guid>? filteredIds = statusFilter switch
         {
-            "active" => partition.Active,
-            "missingconsents" => partition.MissingConsents,
-            "pending" => partition.PendingApproval,
-            "suspended" => partition.Suspended,
-            "incomplete" => partition.IncompleteSignup,
-            "deleting" => partition.PendingDeletion,
+            _ when string.Equals(statusFilter, "active", StringComparison.OrdinalIgnoreCase) => partition.Active,
+            _ when string.Equals(statusFilter, "missingconsents", StringComparison.OrdinalIgnoreCase) => partition.MissingConsents,
+            _ when string.Equals(statusFilter, "pending", StringComparison.OrdinalIgnoreCase) => partition.PendingApproval,
+            _ when string.Equals(statusFilter, "suspended", StringComparison.OrdinalIgnoreCase) => partition.Suspended,
+            _ when string.Equals(statusFilter, "incomplete", StringComparison.OrdinalIgnoreCase) => partition.IncompleteSignup,
+            _ when string.Equals(statusFilter, "deleting", StringComparison.OrdinalIgnoreCase) => partition.PendingDeletion,
             _ => null
         };
 

--- a/src/Humans.Infrastructure/Services/ProfileService.cs
+++ b/src/Humans.Infrastructure/Services/ProfileService.cs
@@ -255,6 +255,7 @@ public class ProfileService : IProfileService
                         SubmittedAt = now,
                         UpdatedAt = now
                     };
+                    application.ValidateTier();
                     _dbContext.Applications.Add(application);
                 }
             }

--- a/src/Humans.Infrastructure/Services/VolunteerHistoryService.cs
+++ b/src/Humans.Infrastructure/Services/VolunteerHistoryService.cs
@@ -10,7 +10,7 @@ namespace Humans.Infrastructure.Services;
 /// <summary>
 /// Service for managing volunteer history entries.
 /// </summary>
-public class VolunteerHistoryService
+public class VolunteerHistoryService : IVolunteerHistoryService
 {
     private readonly HumansDbContext _dbContext;
     private readonly IClock _clock;

--- a/src/Humans.Web/Constants/TempDataKeys.cs
+++ b/src/Humans.Web/Constants/TempDataKeys.cs
@@ -1,0 +1,15 @@
+namespace Humans.Web.Constants;
+
+/// <summary>
+/// Constants for TempData dictionary keys used across controllers and view components.
+/// </summary>
+public static class TempDataKeys
+{
+    public const string SuccessMessage = "SuccessMessage";
+    public const string ErrorMessage = "ErrorMessage";
+    public const string InfoMessage = "InfoMessage";
+    public const string SyncReport = "SyncReport";
+    public const string GroupSettingsResult = "GroupSettingsResult";
+    public const string EmailBackfillResult = "EmailBackfillResult";
+    public const string EmailRenameResult = "EmailRenameResult";
+}

--- a/src/Humans.Web/Controllers/AdminController.cs
+++ b/src/Humans.Web/Controllers/AdminController.cs
@@ -163,10 +163,10 @@ public class AdminController : HumansControllerBase
     [HttpGet("DbVersion")]
     [AllowAnonymous]
     [Produces("application/json")]
-    public async Task<IActionResult> DbVersion()
+    public async Task<IActionResult> DbVersion(CancellationToken ct)
     {
-        var applied = (await _dbContext.Database.GetAppliedMigrationsAsync()).ToList();
-        var pending = await _dbContext.Database.GetPendingMigrationsAsync();
+        var applied = (await _dbContext.Database.GetAppliedMigrationsAsync(ct)).ToList();
+        var pending = await _dbContext.Database.GetPendingMigrationsAsync(ct);
 
         return Ok(new
         {

--- a/src/Humans.Web/Controllers/AdminController.cs
+++ b/src/Humans.Web/Controllers/AdminController.cs
@@ -72,7 +72,7 @@ public class AdminController : HumansControllerBase
         if (user.Id == currentUser?.Id)
         {
             SetError("You cannot purge your own account.");
-            return RedirectToAction("AdminDetail", "Profile", new { id });
+            return RedirectToAction(nameof(ProfileController.AdminDetail), "Profile", new { id });
         }
 
         var displayName = user.DisplayName;
@@ -95,7 +95,7 @@ public class AdminController : HumansControllerBase
         }
 
         SetSuccess($"Purged {displayName}. They will get a fresh account on next login.");
-        return RedirectToAction("AdminList", "Profile");
+        return RedirectToAction(nameof(ProfileController.AdminList), "Profile");
     }
 
     [HttpGet("Logs")]

--- a/src/Humans.Web/Controllers/CampAdminController.cs
+++ b/src/Humans.Web/Controllers/CampAdminController.cs
@@ -265,7 +265,7 @@ public class CampAdminController : HumansControllerBase
         }
 
         if (!string.IsNullOrEmpty(returnSlug))
-            return RedirectToAction("Details", "Camp", new { slug = returnSlug });
+            return RedirectToAction(nameof(CampController.Details), "Camp", new { slug = returnSlug });
         return RedirectToAction(nameof(Index));
     }
 

--- a/src/Humans.Web/Controllers/DevLoginController.cs
+++ b/src/Humans.Web/Controllers/DevLoginController.cs
@@ -120,7 +120,7 @@ public class DevLoginController : Controller
         await _signInManager.SignInAsync(user, isPersistent: false);
         _logger.LogWarning("DEV LOGIN: signed in as {Email} ({Id})", user.Email, user.Id);
 
-        return RedirectToAction("Index", "Home");
+        return RedirectToAction(nameof(HomeController.Index), "Home");
     }
 
     /// <summary>
@@ -158,7 +158,7 @@ public class DevLoginController : Controller
         await _signInManager.SignInAsync(user, isPersistent: false);
         _logger.LogWarning("DEV LOGIN: signed in as {Email} ({Id})", user.Email, user.Id);
 
-        return RedirectToAction("Index", "Home");
+        return RedirectToAction(nameof(HomeController.Index), "Home");
     }
 
     private bool IsDevAuthEnabled()

--- a/src/Humans.Web/Controllers/DevSeedController.cs
+++ b/src/Humans.Web/Controllers/DevSeedController.cs
@@ -64,7 +64,7 @@ public class DevSeedController : HumansControllerBase
             SetError("Budget seeding failed. Check logs for details.");
         }
 
-        return RedirectToAction("Index", "Admin");
+        return RedirectToAction(nameof(AdminController.Index), "Admin");
     }
 
     private bool IsDevSeedEnabled()

--- a/src/Humans.Web/Controllers/GoogleController.cs
+++ b/src/Humans.Web/Controllers/GoogleController.cs
@@ -9,6 +9,7 @@ using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Humans.Infrastructure.Data;
 using Humans.Web.Authorization;
+using Humans.Web.Constants;
 using Humans.Web.Models;
 
 namespace Humans.Web.Controllers;
@@ -95,7 +96,7 @@ public class GoogleController : HumansControllerBase
         try
         {
             var report = await systemTeamSyncJob.ExecuteAsync();
-            TempData["SyncReport"] = System.Text.Json.JsonSerializer.Serialize(report);
+            TempData[TempDataKeys.SyncReport] = System.Text.Json.JsonSerializer.Serialize(report);
         }
         catch (Exception ex)
         {
@@ -112,7 +113,7 @@ public class GoogleController : HumansControllerBase
     public IActionResult SyncResults()
     {
         SyncReport? report = null;
-        if (TempData["SyncReport"] is string json)
+        if (TempData[TempDataKeys.SyncReport] is string json)
         {
             report = System.Text.Json.JsonSerializer.Deserialize<SyncReport>(json);
         }
@@ -136,7 +137,7 @@ public class GoogleController : HumansControllerBase
         try
         {
             var result = await _googleSyncService.CheckGroupSettingsAsync();
-            TempData["GroupSettingsResult"] = System.Text.Json.JsonSerializer.Serialize(result);
+            TempData[TempDataKeys.GroupSettingsResult] = System.Text.Json.JsonSerializer.Serialize(result);
         }
         catch (Exception ex)
         {
@@ -153,7 +154,7 @@ public class GoogleController : HumansControllerBase
     public IActionResult GroupSettingsResults()
     {
         GroupSettingsDriftResult? result = null;
-        if (TempData["GroupSettingsResult"] is string json)
+        if (TempData[TempDataKeys.GroupSettingsResult] is string json)
         {
             result = System.Text.Json.JsonSerializer.Deserialize<GroupSettingsDriftResult>(json);
         }
@@ -294,7 +295,7 @@ public class GoogleController : HumansControllerBase
         try
         {
             var result = await _googleSyncService.GetEmailMismatchesAsync();
-            TempData["EmailBackfillResult"] = System.Text.Json.JsonSerializer.Serialize(result);
+            TempData[TempDataKeys.EmailBackfillResult] = System.Text.Json.JsonSerializer.Serialize(result);
         }
         catch (Exception ex)
         {
@@ -311,7 +312,7 @@ public class GoogleController : HumansControllerBase
     public IActionResult EmailBackfillReview()
     {
         EmailBackfillResult? result = null;
-        if (TempData["EmailBackfillResult"] is string json)
+        if (TempData[TempDataKeys.EmailBackfillResult] is string json)
         {
             result = System.Text.Json.JsonSerializer.Deserialize<EmailBackfillResult>(json);
         }
@@ -458,7 +459,7 @@ public class GoogleController : HumansControllerBase
             SetError("Drive activity check failed. Check logs for details.");
         }
 
-        return RedirectToAction("AuditLog", "Board", new { filter = nameof(AuditAction.AnomalousPermissionDetected) });
+        return RedirectToAction(nameof(BoardController.AuditLog), "Board", new { filter = nameof(AuditAction.AnomalousPermissionDetected) });
     }
 
     // --- Sync Audit Views (from BoardController and HumanController) ---
@@ -511,7 +512,7 @@ public class GoogleController : HumansControllerBase
         if (string.IsNullOrWhiteSpace(emailPrefix))
         {
             SetError("Email prefix is required.");
-            return RedirectToAction("AdminDetail", "Profile", new { id });
+            return RedirectToAction(nameof(ProfileController.AdminDetail), "Profile", new { id });
         }
 
         var currentUser = await GetCurrentUserAsync();
@@ -540,7 +541,7 @@ public class GoogleController : HumansControllerBase
             }
         }
 
-        return RedirectToAction("AdminDetail", "Profile", new { id });
+        return RedirectToAction(nameof(ProfileController.AdminDetail), "Profile", new { id });
     }
 
     // --- Workspace Accounts (from AdminEmailController) ---
@@ -754,7 +755,7 @@ public class GoogleController : HumansControllerBase
         try
         {
             var result = await _googleAdminService.DetectEmailRenamesAsync();
-            TempData["EmailRenameResult"] = System.Text.Json.JsonSerializer.Serialize(result);
+            TempData[TempDataKeys.EmailRenameResult] = System.Text.Json.JsonSerializer.Serialize(result);
         }
         catch (Exception ex)
         {
@@ -771,7 +772,7 @@ public class GoogleController : HumansControllerBase
     public IActionResult EmailRenames()
     {
         EmailRenameDetectionResult? result = null;
-        if (TempData["EmailRenameResult"] is string json)
+        if (TempData[TempDataKeys.EmailRenameResult] is string json)
         {
             result = System.Text.Json.JsonSerializer.Deserialize<EmailRenameDetectionResult>(json);
         }

--- a/src/Humans.Web/Controllers/GuestController.cs
+++ b/src/Humans.Web/Controllers/GuestController.cs
@@ -130,7 +130,7 @@ public class GuestController : HumansControllerBase
 
             var json = System.Text.Json.JsonSerializer.Serialize(exportData, ExportJsonOptions);
             var bytes = System.Text.Encoding.UTF8.GetBytes(json);
-            var fileName = $"nobodies-data-export-{DateTime.UtcNow.ToIsoDateString()}.json";
+            var fileName = $"nobodies-data-export-{_clock.GetCurrentInstant().ToDateTimeUtc().ToIsoDateString()}.json";
 
             return File(bytes, "application/json", fileName);
         }
@@ -300,7 +300,7 @@ public class GuestController : HumansControllerBase
             {
                 Category = category,
                 DisplayName = category == MessageCategory.Ticketing
-                    ? $"Ticketing — {DateTime.UtcNow.Year}"
+                    ? $"Ticketing — {_clock.GetCurrentInstant().InUtc().Year}"
                     : category.ToDisplayName(),
                 Description = category.ToDescription(),
                 EmailEnabled = pref is null || !pref.OptedOut,

--- a/src/Humans.Web/Controllers/HumansControllerBase.cs
+++ b/src/Humans.Web/Controllers/HumansControllerBase.cs
@@ -1,4 +1,5 @@
 using Humans.Domain.Entities;
+using Humans.Web.Constants;
 using Humans.Web.Models;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
@@ -53,7 +54,7 @@ public abstract class HumansControllerBase : Controller
 
     protected void SetSuccess(string message)
     {
-        TempData["SuccessMessage"] = message;
+        TempData[TempDataKeys.SuccessMessage] = message;
     }
 
     protected void SetError(string message)
@@ -61,12 +62,12 @@ public abstract class HumansControllerBase : Controller
         var logger = HttpContext.RequestServices.GetRequiredService<ILoggerFactory>()
             .CreateLogger(GetType());
         logger.LogDebug("Error toast: {Message} (Action: {Action})", message, ControllerContext.ActionDescriptor.ActionName);
-        TempData["ErrorMessage"] = message;
+        TempData[TempDataKeys.ErrorMessage] = message;
     }
 
     protected void SetInfo(string message)
     {
-        TempData["InfoMessage"] = message;
+        TempData[TempDataKeys.InfoMessage] = message;
     }
 
     protected Task<IdentityResult> UpdateCurrentUserAsync(User user)

--- a/src/Humans.Web/Controllers/OnboardingReviewController.cs
+++ b/src/Humans.Web/Controllers/OnboardingReviewController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Localization;
 using NodaTime;
+using Humans.Application.DTOs;
 using Humans.Application.Interfaces;
 using Humans.Domain.Constants;
 using Humans.Domain.Entities;
@@ -40,24 +41,25 @@ public class OnboardingReviewController : HumansControllerBase
     }
 
     [HttpGet("")]
-    public async Task<IActionResult> Index()
+    public async Task<IActionResult> Index(CancellationToken ct)
     {
-        var (pending, flagged, pendingAppUserIds, consentProgress) = await _onboardingService.GetReviewQueueAsync();
+        var data = await _onboardingService.GetReviewQueueAsync(ct);
 
         var viewModel = new OnboardingReviewIndexViewModel
         {
-            PendingReviews = pending.Select(p => MapToItem(p, pendingAppUserIds, consentProgress)).ToList(),
-            FlaggedReviews = flagged.Select(p => MapToItem(p, pendingAppUserIds, consentProgress)).ToList()
+            PendingReviews = data.Pending.Select(p => MapToItem(p, data.PendingAppUserIds, data.ConsentProgress)).ToList(),
+            FlaggedReviews = data.Flagged.Select(p => MapToItem(p, data.PendingAppUserIds, data.ConsentProgress)).ToList()
         };
 
         return View(viewModel);
     }
 
     [HttpGet("{userId:guid}")]
-    public async Task<IActionResult> Detail(Guid userId)
+    public async Task<IActionResult> Detail(Guid userId, CancellationToken ct)
     {
+        var detail = await _onboardingService.GetReviewDetailAsync(userId, ct);
         var (profile, consentCount, requiredConsentCount, pendingApp) =
-            await _onboardingService.GetReviewDetailAsync(userId);
+            (detail.Profile, detail.ConsentCount, detail.RequiredConsentCount, detail.PendingApplication);
 
         if (profile is null)
             return NotFound();
@@ -183,9 +185,9 @@ public class OnboardingReviewController : HumansControllerBase
 
     [HttpGet("BoardVoting")]
     [Authorize(Policy = PolicyNames.BoardOrAdmin)]
-    public async Task<IActionResult> BoardVoting()
+    public async Task<IActionResult> BoardVoting(CancellationToken ct)
     {
-        var (applications, boardMembers) = await _onboardingService.GetBoardVotingDashboardAsync();
+        var (applications, boardMembers) = await _onboardingService.GetBoardVotingDashboardAsync(ct);
 
         var viewModel = new BoardVotingDashboardViewModel
         {
@@ -226,9 +228,9 @@ public class OnboardingReviewController : HumansControllerBase
 
     [HttpGet("BoardVoting/{applicationId:guid}")]
     [Authorize(Policy = PolicyNames.BoardOrAdmin)]
-    public async Task<IActionResult> BoardVotingDetail(Guid applicationId)
+    public async Task<IActionResult> BoardVotingDetail(Guid applicationId, CancellationToken ct)
     {
-        var application = await _onboardingService.GetBoardVotingDetailAsync(applicationId);
+        var application = await _onboardingService.GetBoardVotingDetailAsync(applicationId, ct);
         if (application is null)
             return NotFound();
 
@@ -387,9 +389,9 @@ public class OnboardingReviewController : HumansControllerBase
 
     private static OnboardingReviewItemViewModel MapToItem(
         Profile profile, HashSet<Guid> pendingAppUserIds,
-        Dictionary<Guid, (int Signed, int Required)> consentProgress)
+        Dictionary<Guid, ConsentProgressInfo> consentProgress)
     {
-        var (signed, required) = consentProgress.GetValueOrDefault(profile.UserId);
+        var progress = consentProgress.GetValueOrDefault(profile.UserId);
         return new OnboardingReviewItemViewModel
         {
             UserId = profile.UserId,
@@ -400,8 +402,8 @@ public class OnboardingReviewController : HumansControllerBase
             MembershipTier = profile.MembershipTier,
             ProfileCreatedAt = profile.CreatedAt.ToDateTimeUtc(),
             HasPendingApplication = pendingAppUserIds.Contains(profile.UserId),
-            ConsentCount = signed,
-            RequiredConsentCount = required
+            ConsentCount = progress?.Signed ?? 0,
+            RequiredConsentCount = progress?.Required ?? 0
         };
     }
 }

--- a/src/Humans.Web/Controllers/ProfileController.cs
+++ b/src/Humans.Web/Controllers/ProfileController.cs
@@ -32,7 +32,7 @@ public class ProfileController : HumansControllerBase
     private readonly UserManager<User> _userManager;
     private readonly IProfileService _profileService;
     private readonly IContactFieldService _contactFieldService;
-    private readonly VolunteerHistoryService _volunteerHistoryService;
+    private readonly IVolunteerHistoryService _volunteerHistoryService;
     private readonly IEmailService _emailService;
     private readonly IUserEmailService _userEmailService;
     private readonly ICommunicationPreferenceService _commPrefService;
@@ -76,7 +76,7 @@ public class ProfileController : HumansControllerBase
         UserManager<User> userManager,
         IProfileService profileService,
         IContactFieldService contactFieldService,
-        VolunteerHistoryService volunteerHistoryService,
+        IVolunteerHistoryService volunteerHistoryService,
         IEmailService emailService,
         IUserEmailService userEmailService,
         ICommunicationPreferenceService commPrefService,
@@ -963,7 +963,7 @@ public class ProfileController : HumansControllerBase
 
         var json = System.Text.Json.JsonSerializer.Serialize(exportData, ExportJsonOptions);
         var bytes = System.Text.Encoding.UTF8.GetBytes(json);
-        var fileName = $"nobodies-profiles-export-{DateTime.UtcNow.ToIsoDateString()}.json";
+        var fileName = $"nobodies-profiles-export-{_clock.GetCurrentInstant().ToDateTimeUtc().ToIsoDateString()}.json";
 
         return File(bytes, "application/json", fileName);
     }
@@ -1664,7 +1664,7 @@ public class ProfileController : HumansControllerBase
             {
                 Category = category,
                 DisplayName = category == MessageCategory.Ticketing
-                    ? $"Ticketing — {DateTime.UtcNow.Year}"
+                    ? $"Ticketing — {_clock.GetCurrentInstant().InUtc().Year}"
                     : category.ToDisplayName(),
                 Description = category.ToDescription(),
                 EmailEnabled = pref is null || !pref.OptedOut,

--- a/src/Humans.Web/Controllers/ProfileController.cs
+++ b/src/Humans.Web/Controllers/ProfileController.cs
@@ -121,15 +121,15 @@ public class ProfileController : HumansControllerBase
     public IActionResult Index() => RedirectToAction(nameof(Me));
 
     [HttpGet("Me")]
-    public async Task<IActionResult> Me()
+    public async Task<IActionResult> Me(CancellationToken ct)
     {
         var user = await GetCurrentUserAsync();
         if (user is null)
             return NotFound();
 
         var (profile, latestApplication, pendingConsentCount) =
-            await _profileService.GetProfileIndexDataAsync(user.Id);
-        var campaignGrants = await _profileService.GetActiveOrCompletedCampaignGrantsAsync(user.Id);
+            await _profileService.GetProfileIndexDataAsync(user.Id, ct);
+        var campaignGrants = await _profileService.GetActiveOrCompletedCampaignGrantsAsync(user.Id, ct);
 
         var viewModel = new ProfileViewModel
         {
@@ -155,23 +155,23 @@ public class ProfileController : HumansControllerBase
     }
 
     [HttpGet("Me/Edit")]
-    public async Task<IActionResult> Edit([FromQuery] bool preview = false)
+    public async Task<IActionResult> Edit([FromQuery] bool preview = false, CancellationToken ct = default)
     {
         var user = await GetCurrentUserAsync();
         if (user is null)
             return NotFound();
 
         var (profile, isTierLocked, pendingApplication) =
-            await _profileService.GetProfileEditDataAsync(user.Id);
+            await _profileService.GetProfileEditDataAsync(user.Id, ct);
 
         // Get all contact fields for editing
         var contactFields = profile is not null
-            ? await _contactFieldService.GetAllContactFieldsAsync(profile.Id)
+            ? await _contactFieldService.GetAllContactFieldsAsync(profile.Id, ct)
             : [];
 
         // Get all volunteer history entries for editing
         var volunteerHistory = profile is not null
-            ? await _volunteerHistoryService.GetAllAsync(profile.Id)
+            ? await _volunteerHistoryService.GetAllAsync(profile.Id, ct)
             : [];
 
         // Get profile languages for editing
@@ -180,7 +180,7 @@ public class ProfileController : HumansControllerBase
                 .AsNoTracking()
                 .Where(pl => pl.ProfileId == profile.Id)
                 .OrderBy(pl => pl.LanguageCode)
-                .ToListAsync()
+                .ToListAsync(ct)
             : [];
 
         var hasCustomPicture = profile?.HasCustomProfilePicture == true;
@@ -804,8 +804,6 @@ public class ProfileController : HumansControllerBase
             return RedirectToAction(nameof(Privacy));
         }
 
-        // Reload user to get updated deletion date
-        await GetCurrentUserAsync();
         var deletionDate = user.DeletionScheduledFor?.ToDateTimeUtc();
         SetSuccess(string.Format(CultureInfo.CurrentCulture,
             _localizer["Profile_DeletionRequested"].Value,
@@ -972,9 +970,9 @@ public class ProfileController : HumansControllerBase
 
     [HttpGet("Picture")]
     [ResponseCache(Duration = 3600, Location = ResponseCacheLocation.Client)]
-    public async Task<IActionResult> Picture(Guid id)
+    public async Task<IActionResult> Picture(Guid id, CancellationToken ct)
     {
-        var (data, contentType) = await _profileService.GetProfilePictureAsync(id);
+        var (data, contentType) = await _profileService.GetProfilePictureAsync(id, ct);
 
         if (data is null || string.IsNullOrEmpty(contentType))
             return NotFound();
@@ -985,9 +983,9 @@ public class ProfileController : HumansControllerBase
     // ─── View Another Profile ────────────────────────────────────────
 
     [HttpGet("{id:guid}")]
-    public async Task<IActionResult> ViewProfile(Guid id)
+    public async Task<IActionResult> ViewProfile(Guid id, CancellationToken ct)
     {
-        var profile = await _profileService.GetProfileAsync(id);
+        var profile = await _profileService.GetProfileAsync(id, ct);
 
         if (profile is null || profile.IsSuspended)
         {
@@ -1048,9 +1046,9 @@ public class ProfileController : HumansControllerBase
     }
 
     [HttpGet("{id:guid}/Popover")]
-    public async Task<IActionResult> Popover(Guid id)
+    public async Task<IActionResult> Popover(Guid id, CancellationToken ct)
     {
-        var profile = await _profileService.GetProfileAsync(id);
+        var profile = await _profileService.GetProfileAsync(id, ct);
         if (profile is null || profile.IsSuspended) return NotFound();
 
         var teams = await _dbContext.TeamMembers
@@ -1058,7 +1056,7 @@ public class ProfileController : HumansControllerBase
                 && tm.Team.SystemTeamType != SystemTeamType.Volunteers)
             .Select(tm => tm.Team.Name)
             .OrderBy(n => n)
-            .ToListAsync();
+            .ToListAsync(ct);
 
         var effectivePictureUrl = profile.HasCustomProfilePicture
             ? Url.Action(nameof(Picture), "Profile",
@@ -1188,7 +1186,7 @@ public class ProfileController : HumansControllerBase
     // ─── Search ──────────────────────────────────────────────────────
 
     [HttpGet("Search")]
-    public async Task<IActionResult> Search(string? q)
+    public async Task<IActionResult> Search(string? q, CancellationToken ct)
     {
         var viewModel = new HumanSearchViewModel { Query = q };
 
@@ -1197,7 +1195,7 @@ public class ProfileController : HumansControllerBase
             return View(viewModel);
         }
 
-        var results = await _profileService.SearchHumansAsync(q);
+        var results = await _profileService.SearchHumansAsync(q, ct);
 
         viewModel.Results = results
             .Select(r => r.ToHumanSearchViewModel(Url))
@@ -1210,10 +1208,10 @@ public class ProfileController : HumansControllerBase
 
     [Authorize(Policy = PolicyNames.HumanAdminBoardOrAdmin)]
     [HttpGet("Admin")]
-    public async Task<IActionResult> AdminList(string? search, string? filter, string sort = "name", string dir = "asc", int page = 1)
+    public async Task<IActionResult> AdminList(string? search, string? filter, string sort = "name", string dir = "asc", int page = 1, CancellationToken ct = default)
     {
         var pageSize = 20;
-        var allRows = await _profileService.GetFilteredHumansAsync(search, filter);
+        var allRows = await _profileService.GetFilteredHumansAsync(search, filter, ct);
         var totalCount = allRows.Count;
 
         // Materialize for flexible sorting (fine at ~500 users)
@@ -1269,9 +1267,9 @@ public class ProfileController : HumansControllerBase
 
     [Authorize(Policy = PolicyNames.HumanAdminBoardOrAdmin)]
     [HttpGet("{id:guid}/Admin")]
-    public async Task<IActionResult> AdminDetail(Guid id)
+    public async Task<IActionResult> AdminDetail(Guid id, CancellationToken ct)
     {
-        var data = await _profileService.GetAdminHumanDetailAsync(id);
+        var data = await _profileService.GetAdminHumanDetailAsync(id, ct);
         if (data is null)
         {
             return NotFound();
@@ -1282,11 +1280,11 @@ public class ProfileController : HumansControllerBase
             .Include(g => g.Code)
             .Where(g => g.UserId == id)
             .OrderByDescending(g => g.AssignedAt)
-            .ToListAsync();
+            .ToListAsync(ct);
         ViewBag.CampaignGrants = campaignGrants;
 
         var outboxCount = await _dbContext.EmailOutboxMessages
-            .CountAsync(m => m.UserId == id);
+            .CountAsync(m => m.UserId == id, ct);
         ViewBag.OutboxCount = outboxCount;
 
         var profileLanguages = data.Profile is not null
@@ -1294,7 +1292,7 @@ public class ProfileController : HumansControllerBase
                 .AsNoTracking()
                 .Where(pl => pl.ProfileId == data.Profile.Id)
                 .OrderBy(pl => pl.LanguageCode)
-                .ToListAsync()
+                .ToListAsync(ct)
             : [];
 
         var now = _clock.GetCurrentInstant();
@@ -1368,12 +1366,12 @@ public class ProfileController : HumansControllerBase
 
     [Authorize(Policy = PolicyNames.HumanAdminBoardOrAdmin)]
     [HttpGet("{id:guid}/Admin/Outbox")]
-    public async Task<IActionResult> AdminOutbox(Guid id)
+    public async Task<IActionResult> AdminOutbox(Guid id, CancellationToken ct)
     {
         var messages = await _dbContext.EmailOutboxMessages
             .Where(m => m.UserId == id)
             .OrderByDescending(m => m.CreatedAt)
-            .ToListAsync();
+            .ToListAsync(ct);
 
         ViewBag.HumanId = id;
         return View("Outbox", messages);

--- a/src/Humans.Web/Controllers/ShiftAdminController.cs
+++ b/src/Humans.Web/Controllers/ShiftAdminController.cs
@@ -62,7 +62,7 @@ public class ShiftAdminController : HumansTeamControllerBase
         if (es is null)
         {
             SetError("No active event settings configured.");
-            return RedirectToAction("Details", "Team", new { slug });
+            return RedirectToAction(nameof(TeamController.Details), "Team", new { slug });
         }
 
         var rotas = await _shiftMgmt.GetRotasByDepartmentAsync(team.Id, es.Id);

--- a/src/Humans.Web/Controllers/TeamAdminController.cs
+++ b/src/Humans.Web/Controllers/TeamAdminController.cs
@@ -1000,7 +1000,7 @@ public class TeamAdminController : HumansTeamControllerBase
                 user.Id);
 
             SetSuccess(_localizer["EditTeamPage_Saved"].Value);
-            return RedirectToAction("Details", "Team", new { slug });
+            return RedirectToAction(nameof(TeamController.Details), "Team", new { slug });
         }
         catch (InvalidOperationException ex)
         {

--- a/src/Humans.Web/Controllers/TeamController.cs
+++ b/src/Humans.Web/Controllers/TeamController.cs
@@ -66,13 +66,13 @@ public class TeamController : HumansControllerBase
 
     [AllowAnonymous]
     [HttpGet("")]
-    public async Task<IActionResult> Index()
+    public async Task<IActionResult> Index(CancellationToken ct)
     {
         var user = await GetCurrentUserAsync();
         var hasProfile = User.HasClaim(
             RoleAssignmentClaimsTransformation.HasProfileClaimType,
             RoleAssignmentClaimsTransformation.ActiveClaimValue);
-        var directory = await _teamService.GetTeamDirectoryAsync(hasProfile ? user?.Id : null);
+        var directory = await _teamService.GetTeamDirectoryAsync(hasProfile ? user?.Id : null, ct);
 
         ViewBag.CanViewSync = RoleChecks.IsTeamsAdminBoardOrAdmin(User);
 
@@ -106,7 +106,7 @@ public class TeamController : HumansControllerBase
 
     [AllowAnonymous]
     [HttpGet("{slug}")]
-    public async Task<IActionResult> Details(string slug)
+    public async Task<IActionResult> Details(string slug, CancellationToken ct)
     {
         var user = await GetCurrentUserAsync();
         var hasProfile = User.HasClaim(
@@ -116,7 +116,8 @@ public class TeamController : HumansControllerBase
         var teamPage = await _teamPageService.GetTeamPageDetailAsync(
             slug,
             effectiveUserId,
-            ShiftRoleChecks.CanManageDepartment(User));
+            ShiftRoleChecks.CanManageDepartment(User),
+            ct);
         if (teamPage is null)
         {
             return NotFound();
@@ -310,7 +311,7 @@ public class TeamController : HumansControllerBase
     }
 
     [HttpGet("Birthdays")]
-    public async Task<IActionResult> Birthdays(int? month)
+    public async Task<IActionResult> Birthdays(int? month, CancellationToken ct)
     {
         var (currentUserError, _) = await ResolveCurrentUserOrUnauthorizedAsync();
         if (currentUserError is not null)
@@ -324,11 +325,11 @@ public class TeamController : HumansControllerBase
             currentMonth = _clock.GetCurrentInstant().InZone(currentZone).Month;
 
         // Load all active profiles that have a date of birth
-        var profilesWithBirthdays = await _profileService.GetBirthdayProfilesAsync(currentMonth);
+        var profilesWithBirthdays = await _profileService.GetBirthdayProfilesAsync(currentMonth, ct);
 
         // Load team memberships for these users
         var userIds = profilesWithBirthdays.Select(p => p.UserId).ToList();
-        var teamsByUser = await _teamService.GetNonSystemTeamNamesByUserIdsAsync(userIds);
+        var teamsByUser = await _teamService.GetNonSystemTeamNamesByUserIdsAsync(userIds, ct);
 
         var monthName = new DateTime(2000, currentMonth, 1).ToString("MMMM", CultureInfo.CurrentCulture);
 
@@ -356,9 +357,9 @@ public class TeamController : HumansControllerBase
     }
 
     [HttpGet("Roster")]
-    public async Task<IActionResult> Roster(string? priority, string? status, string? period)
+    public async Task<IActionResult> Roster(string? priority, string? status, string? period, CancellationToken ct = default)
     {
-        var roster = await _teamService.GetRosterAsync(priority, status, period);
+        var roster = await _teamService.GetRosterAsync(priority, status, period, ct);
 
         var slots = roster.Select(slot => new RosterSlotViewModel
         {
@@ -380,9 +381,9 @@ public class TeamController : HumansControllerBase
     }
 
     [HttpGet("Map")]
-    public async Task<IActionResult> Map()
+    public async Task<IActionResult> Map(CancellationToken ct)
     {
-        var profiles = await _profileService.GetApprovedProfilesWithLocationAsync();
+        var profiles = await _profileService.GetApprovedProfilesWithLocationAsync(ct);
 
         var effectiveUrls = await Helpers.ProfilePictureUrlHelper.BuildEffectiveUrlsAsync(
             _profileService, Url,
@@ -406,7 +407,7 @@ public class TeamController : HumansControllerBase
     }
 
     [HttpGet("My")]
-    public async Task<IActionResult> MyTeams()
+    public async Task<IActionResult> MyTeams(CancellationToken ct)
     {
         var (currentUserError, user) = await ResolveCurrentUserOrUnauthorizedAsync();
         if (currentUserError is not null)
@@ -414,7 +415,7 @@ public class TeamController : HumansControllerBase
             return currentUserError;
         }
 
-        var membershipVMs = (await _teamService.GetMyTeamMembershipsAsync(user.Id))
+        var membershipVMs = (await _teamService.GetMyTeamMembershipsAsync(user.Id, ct))
             .Select(m => new MyTeamMembershipViewModel
             {
                 TeamId = m.TeamId,
@@ -652,9 +653,9 @@ public class TeamController : HumansControllerBase
 
     [HttpGet("Summary")]
     [Authorize(Policy = PolicyNames.TeamsAdminBoardOrAdmin)]
-    public async Task<IActionResult> Summary()
+    public async Task<IActionResult> Summary(CancellationToken ct)
     {
-        var result = await _teamService.GetAdminTeamListAsync(1, 500);
+        var result = await _teamService.GetAdminTeamListAsync(1, 500, ct);
 
         var viewModel = new AdminTeamListViewModel
         {

--- a/src/Humans.Web/Extensions/InfrastructureServiceCollectionExtensions.cs
+++ b/src/Humans.Web/Extensions/InfrastructureServiceCollectionExtensions.cs
@@ -96,7 +96,7 @@ public static class InfrastructureServiceCollectionExtensions
         services.AddScoped<IContactFieldService, ContactFieldService>();
         services.AddScoped<IUserEmailService, UserEmailService>();
         services.AddScoped<IEmailProvisioningService, EmailProvisioningService>();
-        services.AddScoped<VolunteerHistoryService>();
+        services.AddScoped<IVolunteerHistoryService, VolunteerHistoryService>();
         services.AddScoped<ILegalDocumentSyncService, LegalDocumentSyncService>();
         services.AddScoped<IAdminLegalDocumentService, AdminLegalDocumentService>();
         services.AddScoped<ILegalDocumentService, LegalDocumentService>();

--- a/src/Humans.Web/ViewComponents/ProfileCardViewComponent.cs
+++ b/src/Humans.Web/ViewComponents/ProfileCardViewComponent.cs
@@ -5,7 +5,6 @@ using Humans.Application.Interfaces;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Humans.Infrastructure.Data;
-using Humans.Infrastructure.Services;
 using Humans.Web.Controllers;
 using Humans.Web.Helpers;
 using Humans.Web.Models;
@@ -25,7 +24,7 @@ public class ProfileCardViewComponent : ViewComponent
     private readonly UserManager<User> _userManager;
     private readonly IContactFieldService _contactFieldService;
     private readonly IUserEmailService _userEmailService;
-    private readonly VolunteerHistoryService _volunteerHistoryService;
+    private readonly IVolunteerHistoryService _volunteerHistoryService;
     private readonly ITeamService _teamService;
     private readonly IRoleAssignmentService _roleAssignmentService;
     private readonly IMembershipCalculator _membershipCalculator;
@@ -36,7 +35,7 @@ public class ProfileCardViewComponent : ViewComponent
         UserManager<User> userManager,
         IContactFieldService contactFieldService,
         IUserEmailService userEmailService,
-        VolunteerHistoryService volunteerHistoryService,
+        IVolunteerHistoryService volunteerHistoryService,
         ITeamService teamService,
         IRoleAssignmentService roleAssignmentService,
         IMembershipCalculator membershipCalculator,

--- a/src/Humans.Web/ViewComponents/TempDataAlertsViewComponent.cs
+++ b/src/Humans.Web/ViewComponents/TempDataAlertsViewComponent.cs
@@ -1,3 +1,4 @@
+using Humans.Web.Constants;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Humans.Web.ViewComponents;
@@ -8,13 +9,13 @@ public class TempDataAlertsViewComponent : ViewComponent
     {
         var alerts = new List<TempDataAlert>();
 
-        if (TempData["SuccessMessage"] is string success)
+        if (TempData[TempDataKeys.SuccessMessage] is string success)
             alerts.Add(new TempDataAlert("success", success));
 
-        if (TempData["ErrorMessage"] is string error)
+        if (TempData[TempDataKeys.ErrorMessage] is string error)
             alerts.Add(new TempDataAlert("danger", error));
 
-        if (TempData["InfoMessage"] is string info)
+        if (TempData[TempDataKeys.InfoMessage] is string info)
             alerts.Add(new TempDataAlert("info", info));
 
         return View(alerts);

--- a/tests/Humans.Application.Tests/Authorization/EndpointAuthorizationTests.cs
+++ b/tests/Humans.Application.Tests/Authorization/EndpointAuthorizationTests.cs
@@ -1,0 +1,211 @@
+using System.Reflection;
+using AwesomeAssertions;
+using Humans.Web.Controllers;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Xunit;
+
+namespace Humans.Application.Tests.Authorization;
+
+/// <summary>
+/// Verifies that critical controller actions have the correct authorization attributes.
+/// Catches silent authorization regressions when attributes are accidentally removed or changed.
+/// </summary>
+public class EndpointAuthorizationTests
+{
+    // --- Admin endpoints must require Admin role ---
+
+    [Theory]
+    [InlineData(typeof(AdminController), "Index")]
+    [InlineData(typeof(AdminController), "PurgeHuman")]
+    [InlineData(typeof(AdminController), "Logs")]
+    [InlineData(typeof(AdminController), "Configuration")]
+    [InlineData(typeof(AdminController), "DbStats")]
+    [InlineData(typeof(AdminController), "CacheStats")]
+    [InlineData(typeof(AdminMergeController), null)] // class-level
+    [InlineData(typeof(EmailController), null)] // class-level
+    public void AdminEndpoint_RequiresAdminPolicy(Type controllerType, string? actionName)
+    {
+        AssertHasPolicy(controllerType, actionName, "AdminOnly");
+    }
+
+    // --- Board endpoints must require Board or Admin ---
+
+    [Theory]
+    [InlineData(typeof(BoardController), null)] // class-level
+    public void BoardEndpoint_RequiresBoardOrAdminPolicy(Type controllerType, string? actionName)
+    {
+        AssertHasPolicy(controllerType, actionName, "BoardOrAdmin");
+    }
+
+    // --- Google admin endpoints must require Admin ---
+
+    [Theory]
+    [InlineData("SyncSettings")]
+    [InlineData("UpdateSyncSetting")]
+    [InlineData("SyncSystemTeams")]
+    [InlineData("SyncResults")]
+    [InlineData("CheckGroupSettings")]
+    [InlineData("GroupSettingsResults")]
+    public void GoogleAdminEndpoint_RequiresAdminPolicy(string actionName)
+    {
+        AssertHasPolicy(typeof(GoogleController), actionName, "AdminOnly");
+    }
+
+    // --- Onboarding review endpoints ---
+
+    [Fact]
+    public void OnboardingReviewController_RequiresReviewQueueAccess()
+    {
+        AssertHasPolicy(typeof(OnboardingReviewController), null, "ReviewQueueAccess");
+    }
+
+    [Theory]
+    [InlineData("Clear")]
+    [InlineData("Flag")]
+    [InlineData("Reject")]
+    public void OnboardingReviewConsentActions_RequireConsentCoordinatorBoardOrAdmin(string actionName)
+    {
+        AssertHasPolicy(typeof(OnboardingReviewController), actionName, "ConsentCoordinatorBoardOrAdmin");
+    }
+
+    // --- Finance endpoints ---
+
+    [Fact]
+    public void FinanceController_RequiresFinanceAdminOrAdmin()
+    {
+        AssertHasPolicy(typeof(FinanceController), null, "FinanceAdminOrAdmin");
+    }
+
+    // --- POST actions must have ValidateAntiForgeryToken ---
+
+    [Fact]
+    public void AllPostActions_HaveAntiForgeryValidation()
+    {
+        var controllerTypes = typeof(HumansControllerBase).Assembly.GetTypes()
+            .Where(t => typeof(Controller).IsAssignableFrom(t) && !t.IsAbstract);
+
+        var violations = new List<string>();
+
+        foreach (var controller in controllerTypes)
+        {
+            // Check for controller-level auto-validation
+            var hasControllerLevelAutoValidation = controller.GetCustomAttribute<AutoValidateAntiforgeryTokenAttribute>() != null;
+
+            // Check if class-level ValidateAntiForgeryToken is applied
+            var hasControllerLevelValidation = controller.GetCustomAttribute<ValidateAntiForgeryTokenAttribute>() != null;
+
+            if (hasControllerLevelAutoValidation || hasControllerLevelValidation)
+                continue;
+
+            var postActions = controller.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+                .Where(m => m.GetCustomAttribute<HttpPostAttribute>() != null);
+
+            foreach (var action in postActions)
+            {
+                var hasActionValidation = action.GetCustomAttribute<ValidateAntiForgeryTokenAttribute>() != null;
+                var hasIgnoreValidation = action.GetCustomAttribute<IgnoreAntiforgeryTokenAttribute>() != null;
+
+                if (!hasActionValidation && !hasIgnoreValidation)
+                {
+                    violations.Add($"{controller.Name}.{action.Name}");
+                }
+            }
+        }
+
+        violations.Should().BeEmpty(
+            "all POST actions should have [ValidateAntiForgeryToken] or [AutoValidateAntiforgeryToken] at controller level. Violations: " +
+            string.Join(", ", violations));
+    }
+
+    // --- Authorize attribute coverage ---
+
+    [Fact]
+    public void AllControllerActions_HaveAuthorizeOrAllowAnonymous()
+    {
+        // Controllers that are intentionally anonymous (public-facing pages)
+        var anonymousControllers = new HashSet<string>(StringComparer.Ordinal)
+        {
+            "HomeController",
+            "AccountController",
+            "DevLoginController",
+            "ApiController",
+            "VersionController",
+            "AboutController",
+            "LanguageController",
+            "UnsubscribeController"
+        };
+
+        var controllerTypes = typeof(HumansControllerBase).Assembly.GetTypes()
+            .Where(t => typeof(Controller).IsAssignableFrom(t) && !t.IsAbstract)
+            .Where(t => !anonymousControllers.Contains(t.Name));
+
+        var violations = new List<string>();
+
+        foreach (var controller in controllerTypes)
+        {
+            var hasControllerAuth = controller.GetCustomAttribute<AuthorizeAttribute>() != null;
+            var hasControllerAllowAnon = controller.GetCustomAttribute<AllowAnonymousAttribute>() != null;
+
+            if (hasControllerAuth || hasControllerAllowAnon)
+                continue;
+
+            // Check each action
+            var actions = controller.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+                .Where(m => m.GetCustomAttribute<HttpGetAttribute>() != null ||
+                            m.GetCustomAttribute<HttpPostAttribute>() != null ||
+                            m.GetCustomAttribute<HttpPutAttribute>() != null ||
+                            m.GetCustomAttribute<HttpDeleteAttribute>() != null ||
+                            m.GetCustomAttribute<RouteAttribute>() != null);
+
+            foreach (var action in actions)
+            {
+                var hasActionAuth = action.GetCustomAttribute<AuthorizeAttribute>() != null;
+                var hasActionAllowAnon = action.GetCustomAttribute<AllowAnonymousAttribute>() != null;
+
+                if (!hasActionAuth && !hasActionAllowAnon)
+                {
+                    violations.Add($"{controller.Name}.{action.Name}");
+                }
+            }
+        }
+
+        violations.Should().BeEmpty(
+            "all controller actions (except intentionally anonymous ones) should have [Authorize] or [AllowAnonymous]. " +
+            "Unprotected: " + string.Join(", ", violations));
+    }
+
+    // --- Helpers ---
+
+    private static void AssertHasPolicy(Type controllerType, string? actionName, string expectedPolicy)
+    {
+        AuthorizeAttribute? attr;
+
+        if (actionName is null)
+        {
+            // Check class-level authorization
+            attr = controllerType.GetCustomAttribute<AuthorizeAttribute>();
+        }
+        else
+        {
+            // Check action-level authorization (may have overloads, find any match)
+            var methods = controllerType.GetMethods(BindingFlags.Public | BindingFlags.Instance)
+                .Where(m => string.Equals(m.Name, actionName, StringComparison.Ordinal))
+                .ToList();
+
+            methods.Should().NotBeEmpty($"action '{actionName}' should exist on {controllerType.Name}");
+
+            attr = methods
+                .Select(m => m.GetCustomAttribute<AuthorizeAttribute>())
+                .FirstOrDefault(a => a is not null);
+
+            // If not on the action, check class-level
+            attr ??= controllerType.GetCustomAttribute<AuthorizeAttribute>();
+        }
+
+        attr.Should().NotBeNull(
+            $"{controllerType.Name}{(actionName is not null ? "." + actionName : "")} should have [Authorize]");
+        attr!.Policy.Should().Be(expectedPolicy,
+            $"{controllerType.Name}{(actionName is not null ? "." + actionName : "")} should have Policy='{expectedPolicy}'");
+    }
+}

--- a/tests/Humans.Application.Tests/Jobs/ProcessAccountDeletionsJobTests.cs
+++ b/tests/Humans.Application.Tests/Jobs/ProcessAccountDeletionsJobTests.cs
@@ -360,18 +360,19 @@ public class ProcessAccountDeletionsJobTests : IDisposable
         _dbContext.Users.Add(user2);
         await _dbContext.SaveChangesAsync();
 
-        // Make audit log throw for first user to simulate failure
+        // Default: all audit log calls succeed
+        _auditLogService.LogAsync(
+            Arg.Any<AuditAction>(), Arg.Any<string>(), Arg.Any<Guid>(),
+            Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<Guid?>(), Arg.Any<string?>())
+            .Returns(Task.CompletedTask);
+
+        // Override: throw for first user to simulate failure
         _auditLogService.LogAsync(
             Arg.Any<AuditAction>(), Arg.Any<string>(), user1.Id,
             Arg.Any<string>(), Arg.Any<string>(),
             Arg.Any<Guid?>(), Arg.Any<string?>())
             .Returns(Task.FromException(new InvalidOperationException("DB error")));
-
-        _auditLogService.LogAsync(
-            Arg.Any<AuditAction>(), Arg.Any<string>(), user2Id,
-            Arg.Any<string>(), Arg.Any<string>(),
-            Arg.Any<Guid?>(), Arg.Any<string?>())
-            .Returns(Task.CompletedTask);
 
         await _job.ExecuteAsync();
 

--- a/tests/Humans.Application.Tests/Jobs/ProcessAccountDeletionsJobTests.cs
+++ b/tests/Humans.Application.Tests/Jobs/ProcessAccountDeletionsJobTests.cs
@@ -1,0 +1,416 @@
+using AwesomeAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NodaTime;
+using NodaTime.Testing;
+using NSubstitute;
+using Humans.Application.Interfaces;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using Humans.Infrastructure.Data;
+using Humans.Infrastructure.Jobs;
+using Humans.Infrastructure.Services;
+using Xunit;
+
+namespace Humans.Application.Tests.Jobs;
+
+public class ProcessAccountDeletionsJobTests : IDisposable
+{
+    private readonly HumansDbContext _dbContext;
+    private readonly IEmailService _emailService;
+    private readonly IAuditLogService _auditLogService;
+    private readonly IProfileService _profileService;
+    private readonly ITeamService _teamService;
+    private readonly IMemoryCache _cache;
+    private readonly HumansMetricsService _metrics;
+    private readonly FakeClock _clock;
+    private readonly ProcessAccountDeletionsJob _job;
+
+    private static readonly Instant Now = Instant.FromUtc(2026, 3, 14, 12, 0);
+
+    public ProcessAccountDeletionsJobTests()
+    {
+        var options = new DbContextOptionsBuilder<HumansDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        _dbContext = new HumansDbContext(options);
+        _emailService = Substitute.For<IEmailService>();
+        _auditLogService = Substitute.For<IAuditLogService>();
+        _profileService = Substitute.For<IProfileService>();
+        _teamService = Substitute.For<ITeamService>();
+        _cache = new MemoryCache(new MemoryCacheOptions());
+        _clock = new FakeClock(Now);
+        _metrics = new HumansMetricsService(
+            Substitute.For<IServiceScopeFactory>(),
+            Substitute.For<ILogger<HumansMetricsService>>());
+        var logger = Substitute.For<ILogger<ProcessAccountDeletionsJob>>();
+
+        _job = new ProcessAccountDeletionsJob(
+            _dbContext, _emailService, _auditLogService,
+            _profileService, _teamService, _cache, _metrics, logger, _clock);
+    }
+
+    public void Dispose()
+    {
+        _dbContext.Dispose();
+        _cache.Dispose();
+        _metrics.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_AnonymizesUserWhenGracePeriodExpired()
+    {
+        var user = await SeedUserScheduledForDeletion(Now - Duration.FromDays(1));
+
+        await _job.ExecuteAsync();
+
+        var updated = await _dbContext.Users.Include(u => u.Profile).SingleAsync();
+        updated.DisplayName.Should().Be("Deleted User");
+        updated.Email.Should().StartWith("deleted-");
+        updated.Email.Should().EndWith("@deleted.local");
+        updated.ProfilePictureUrl.Should().BeNull();
+        updated.PhoneNumber.Should().BeNull();
+        updated.DeletionScheduledFor.Should().BeNull();
+        updated.DeletionRequestedAt.Should().BeNull();
+        updated.LockoutEnd.Should().Be(DateTimeOffset.MaxValue);
+        updated.Profile!.FirstName.Should().Be("Deleted");
+        updated.Profile.LastName.Should().Be("User");
+        updated.Profile.Bio.Should().BeNull();
+        updated.Profile.City.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_SkipsUserWhenGracePeriodNotExpired()
+    {
+        var user = await SeedUserScheduledForDeletion(Now + Duration.FromDays(5));
+
+        await _job.ExecuteAsync();
+
+        var updated = await _dbContext.Users.SingleAsync();
+        updated.DisplayName.Should().Be("Test User");
+        updated.DeletionScheduledFor.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_SkipsUserWithFutureEventHold()
+    {
+        // Grace period expired but event hold is still active
+        var user = await SeedUserScheduledForDeletion(
+            Now - Duration.FromDays(1),
+            deletionEligibleAfter: Now + Duration.FromDays(10));
+
+        await _job.ExecuteAsync();
+
+        var updated = await _dbContext.Users.SingleAsync();
+        updated.DisplayName.Should().Be("Test User");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ProcessesUserWhenEventHoldExpired()
+    {
+        var user = await SeedUserScheduledForDeletion(
+            Now - Duration.FromDays(1),
+            deletionEligibleAfter: Now - Duration.FromDays(1));
+
+        await _job.ExecuteAsync();
+
+        var updated = await _dbContext.Users.SingleAsync();
+        updated.DisplayName.Should().Be("Deleted User");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_SendsConfirmationEmail()
+    {
+        var user = await SeedUserScheduledForDeletion(Now - Duration.FromDays(1));
+
+        await _job.ExecuteAsync();
+
+        await _emailService.Received(1).SendAccountDeletedAsync(
+            "test@example.com",
+            "Test User",
+            "en",
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_LogsAuditEntry()
+    {
+        var user = await SeedUserScheduledForDeletion(Now - Duration.FromDays(1));
+
+        await _job.ExecuteAsync();
+
+        await _auditLogService.Received(1).LogAsync(
+            AuditAction.AccountAnonymized,
+            nameof(User),
+            user.Id,
+            Arg.Is<string>(s => s.Contains("Test User")),
+            nameof(ProcessAccountDeletionsJob),
+            Arg.Any<Guid?>(),
+            Arg.Any<string?>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_RemovesContactFieldsAndVolunteerHistory()
+    {
+        var user = await SeedUserScheduledForDeletion(Now - Duration.FromDays(1));
+
+        // Seed contact fields
+        _dbContext.ContactFields.Add(new ContactField
+        {
+            Id = Guid.NewGuid(),
+            ProfileId = user.Profile!.Id,
+            FieldType = ContactFieldType.Phone,
+            Value = "+1234567890",
+            Visibility = ContactFieldVisibility.AllActiveProfiles
+        });
+
+        // Seed volunteer history
+        _dbContext.VolunteerHistoryEntries.Add(new VolunteerHistoryEntry
+        {
+            Id = Guid.NewGuid(),
+            ProfileId = user.Profile.Id,
+            EventName = "Test Event",
+            Description = "Testing"
+        });
+        await _dbContext.SaveChangesAsync();
+
+        await _job.ExecuteAsync();
+
+        var contactFields = await _dbContext.ContactFields
+            .Where(cf => cf.ProfileId == user.Profile.Id)
+            .CountAsync();
+        contactFields.Should().Be(0);
+
+        var historyEntries = await _dbContext.VolunteerHistoryEntries
+            .Where(vh => vh.ProfileId == user.Profile.Id)
+            .CountAsync();
+        historyEntries.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_EndsActiveTeamMemberships()
+    {
+        var user = await SeedUserScheduledForDeletion(Now - Duration.FromDays(1));
+
+        var team = new Team
+        {
+            Id = Guid.NewGuid(),
+            Name = "Test Team",
+            Slug = "test-team",
+            CreatedAt = Now - Duration.FromDays(100)
+        };
+        _dbContext.Teams.Add(team);
+
+        var membership = new TeamMember
+        {
+            Id = Guid.NewGuid(),
+            TeamId = team.Id,
+            UserId = user.Id,
+            JoinedAt = Now - Duration.FromDays(50),
+            LeftAt = null
+        };
+        _dbContext.TeamMembers.Add(membership);
+        await _dbContext.SaveChangesAsync();
+
+        // Re-read user so navigation property is populated
+        _dbContext.Entry(user).State = EntityState.Detached;
+
+        await _job.ExecuteAsync();
+
+        var updatedMembership = await _dbContext.TeamMembers.SingleAsync();
+        updatedMembership.LeftAt.Should().Be(Now);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_EndsActiveRoleAssignments()
+    {
+        var user = await SeedUserScheduledForDeletion(Now - Duration.FromDays(1));
+
+        var roleAssignment = new RoleAssignment
+        {
+            Id = Guid.NewGuid(),
+            UserId = user.Id,
+            RoleName = "Admin",
+            ValidFrom = Now - Duration.FromDays(30),
+            ValidTo = null,
+            CreatedByUserId = user.Id
+        };
+        _dbContext.RoleAssignments.Add(roleAssignment);
+        await _dbContext.SaveChangesAsync();
+
+        _dbContext.Entry(user).State = EntityState.Detached;
+
+        await _job.ExecuteAsync();
+
+        var updated = await _dbContext.RoleAssignments.SingleAsync();
+        updated.ValidTo.Should().Be(Now);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_CancelsActiveShiftSignups()
+    {
+        var user = await SeedUserScheduledForDeletion(Now - Duration.FromDays(1));
+
+        var shift = new Shift
+        {
+            Id = Guid.NewGuid(),
+            RotaId = Guid.NewGuid(),
+            StartTime = new LocalTime(10, 0),
+            Duration = Duration.FromHours(4),
+            MinVolunteers = 1,
+            MaxVolunteers = 10
+        };
+        _dbContext.Shifts.Add(shift);
+
+        var signup = new ShiftSignup
+        {
+            Id = Guid.NewGuid(),
+            ShiftId = shift.Id,
+            UserId = user.Id,
+            Status = SignupStatus.Confirmed
+        };
+        _dbContext.ShiftSignups.Add(signup);
+        await _dbContext.SaveChangesAsync();
+
+        _dbContext.Entry(user).State = EntityState.Detached;
+
+        await _job.ExecuteAsync();
+
+        var updatedSignup = await _dbContext.ShiftSignups.SingleAsync();
+        updatedSignup.Status.Should().Be(SignupStatus.Cancelled);
+        updatedSignup.StatusReason.Should().Be("Account deletion");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_RemovesUserEmails()
+    {
+        var user = await SeedUserScheduledForDeletion(Now - Duration.FromDays(1));
+
+        _dbContext.UserEmails.Add(new UserEmail
+        {
+            Id = Guid.NewGuid(),
+            UserId = user.Id,
+            Email = "secondary@example.com",
+            IsVerified = true,
+            IsNotificationTarget = false
+        });
+        await _dbContext.SaveChangesAsync();
+
+        _dbContext.Entry(user).State = EntityState.Detached;
+
+        await _job.ExecuteAsync();
+
+        var emailCount = await _dbContext.UserEmails.Where(e => e.UserId == user.Id).CountAsync();
+        emailCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_InvalidatesCaches()
+    {
+        var user = await SeedUserScheduledForDeletion(Now - Duration.FromDays(1));
+
+        await _job.ExecuteAsync();
+
+        _profileService.Received(1).UpdateProfileCache(user.Id, null);
+        _teamService.Received(1).RemoveMemberFromAllTeamsCache(user.Id);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NoUsersToDelete_DoesNothing()
+    {
+        // No users in DB at all
+        await _job.ExecuteAsync();
+
+        await _emailService.DidNotReceive().SendAccountDeletedAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ContinuesProcessingAfterIndividualFailure()
+    {
+        var user1 = await SeedUserScheduledForDeletion(Now - Duration.FromDays(1));
+
+        // Create a second user
+        var user2Id = Guid.NewGuid();
+        var user2 = new User
+        {
+            Id = user2Id,
+            UserName = "user2",
+            NormalizedUserName = "USER2",
+            Email = "user2@example.com",
+            NormalizedEmail = "USER2@EXAMPLE.COM",
+            DisplayName = "User Two",
+            DeletionRequestedAt = Now - Duration.FromDays(31),
+            DeletionScheduledFor = Now - Duration.FromDays(1),
+            PreferredLanguage = "en",
+            Profile = new Profile
+            {
+                Id = Guid.NewGuid(),
+                UserId = user2Id,
+                FirstName = "User",
+                LastName = "Two",
+                BurnerName = "UTwo"
+            }
+        };
+        _dbContext.Users.Add(user2);
+        await _dbContext.SaveChangesAsync();
+
+        // Make audit log throw for first user to simulate failure
+        _auditLogService.LogAsync(
+            Arg.Any<AuditAction>(), Arg.Any<string>(), user1.Id,
+            Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<Guid?>(), Arg.Any<string?>())
+            .Returns(Task.FromException(new InvalidOperationException("DB error")));
+
+        _auditLogService.LogAsync(
+            Arg.Any<AuditAction>(), Arg.Any<string>(), user2Id,
+            Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<Guid?>(), Arg.Any<string?>())
+            .Returns(Task.CompletedTask);
+
+        await _job.ExecuteAsync();
+
+        // Second user should still be processed (anonymized)
+        var updatedUser2 = await _dbContext.Users.SingleAsync(u => u.Id == user2Id);
+        updatedUser2.DisplayName.Should().Be("Deleted User");
+    }
+
+    private async Task<User> SeedUserScheduledForDeletion(
+        Instant deletionScheduledFor,
+        Instant? deletionEligibleAfter = null)
+    {
+        var userId = Guid.NewGuid();
+        var user = new User
+        {
+            Id = userId,
+            UserName = "testuser",
+            NormalizedUserName = "TESTUSER",
+            Email = "test@example.com",
+            NormalizedEmail = "TEST@EXAMPLE.COM",
+            DisplayName = "Test User",
+            DeletionRequestedAt = deletionScheduledFor - Duration.FromDays(30),
+            DeletionScheduledFor = deletionScheduledFor,
+            DeletionEligibleAfter = deletionEligibleAfter,
+            PreferredLanguage = "en",
+            Profile = new Profile
+            {
+                Id = Guid.NewGuid(),
+                UserId = userId,
+                FirstName = "Test",
+                LastName = "User",
+                BurnerName = "Tester",
+                Bio = "A test bio",
+                City = "Madrid"
+            }
+        };
+
+        _dbContext.Users.Add(user);
+        await _dbContext.SaveChangesAsync();
+        return user;
+    }
+}

--- a/tests/Humans.Application.Tests/Jobs/ProcessAccountDeletionsJobTests.cs
+++ b/tests/Humans.Application.Tests/Jobs/ProcessAccountDeletionsJobTests.cs
@@ -360,19 +360,19 @@ public class ProcessAccountDeletionsJobTests : IDisposable
         _dbContext.Users.Add(user2);
         await _dbContext.SaveChangesAsync();
 
-        // Default: all audit log calls succeed
+        // Throw for user1's entity ID, succeed for everything else
+        var failEntityId = user1.Id;
         _auditLogService.LogAsync(
             Arg.Any<AuditAction>(), Arg.Any<string>(), Arg.Any<Guid>(),
             Arg.Any<string>(), Arg.Any<string>(),
             Arg.Any<Guid?>(), Arg.Any<string?>())
-            .Returns(Task.CompletedTask);
-
-        // Override: throw for first user to simulate failure
-        _auditLogService.LogAsync(
-            Arg.Any<AuditAction>(), Arg.Any<string>(), user1.Id,
-            Arg.Any<string>(), Arg.Any<string>(),
-            Arg.Any<Guid?>(), Arg.Any<string?>())
-            .Returns(Task.FromException(new InvalidOperationException("DB error")));
+            .Returns(callInfo =>
+            {
+                var entityId = callInfo.ArgAt<Guid>(2);
+                if (entityId == failEntityId)
+                    return Task.FromException(new InvalidOperationException("DB error"));
+                return Task.CompletedTask;
+            });
 
         await _job.ExecuteAsync();
 

--- a/tests/Humans.Application.Tests/Jobs/SuspendNonCompliantMembersJobTests.cs
+++ b/tests/Humans.Application.Tests/Jobs/SuspendNonCompliantMembersJobTests.cs
@@ -1,0 +1,307 @@
+using AwesomeAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NodaTime;
+using NodaTime.Testing;
+using NSubstitute;
+using Humans.Application.Interfaces;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using Humans.Infrastructure.Data;
+using Humans.Infrastructure.Jobs;
+using Humans.Infrastructure.Services;
+using Xunit;
+
+namespace Humans.Application.Tests.Jobs;
+
+public class SuspendNonCompliantMembersJobTests : IDisposable
+{
+    private readonly HumansDbContext _dbContext;
+    private readonly IMembershipCalculator _membershipCalculator;
+    private readonly IEmailService _emailService;
+    private readonly INotificationService _notificationService;
+    private readonly IGoogleSyncService _googleSyncService;
+    private readonly IAuditLogService _auditLogService;
+    private readonly IProfileService _profileService;
+    private readonly ITeamService _teamService;
+    private readonly IMemoryCache _cache;
+    private readonly HumansMetricsService _metrics;
+    private readonly FakeClock _clock;
+    private readonly SuspendNonCompliantMembersJob _job;
+
+    private static readonly Instant Now = Instant.FromUtc(2026, 3, 14, 12, 0);
+
+    public SuspendNonCompliantMembersJobTests()
+    {
+        var options = new DbContextOptionsBuilder<HumansDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        _dbContext = new HumansDbContext(options);
+        _membershipCalculator = Substitute.For<IMembershipCalculator>();
+        _emailService = Substitute.For<IEmailService>();
+        _notificationService = Substitute.For<INotificationService>();
+        _googleSyncService = Substitute.For<IGoogleSyncService>();
+        _auditLogService = Substitute.For<IAuditLogService>();
+        _profileService = Substitute.For<IProfileService>();
+        _teamService = Substitute.For<ITeamService>();
+        _cache = new MemoryCache(new MemoryCacheOptions());
+        _clock = new FakeClock(Now);
+        _metrics = new HumansMetricsService(
+            Substitute.For<IServiceScopeFactory>(),
+            Substitute.For<ILogger<HumansMetricsService>>());
+        var logger = Substitute.For<ILogger<SuspendNonCompliantMembersJob>>();
+
+        _job = new SuspendNonCompliantMembersJob(
+            _dbContext, _membershipCalculator, _emailService,
+            _notificationService, _googleSyncService, _auditLogService,
+            _profileService, _teamService, _cache, _metrics, logger, _clock);
+    }
+
+    public void Dispose()
+    {
+        _dbContext.Dispose();
+        _cache.Dispose();
+        _metrics.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_SuspendsNonCompliantUser()
+    {
+        var user = await SeedUserWithProfile();
+        _membershipCalculator.GetUsersRequiringStatusUpdateAsync(Arg.Any<CancellationToken>())
+            .Returns(new List<Guid> { user.Id });
+
+        await _job.ExecuteAsync();
+
+        var updated = await _dbContext.Users.Include(u => u.Profile).SingleAsync();
+        updated.Profile!.IsSuspended.Should().BeTrue();
+        updated.Profile.UpdatedAt.Should().Be(Now);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NoUsersToSuspend_DoesNothing()
+    {
+        _membershipCalculator.GetUsersRequiringStatusUpdateAsync(Arg.Any<CancellationToken>())
+            .Returns(new List<Guid>());
+
+        await _job.ExecuteAsync();
+
+        await _emailService.DidNotReceive().SendAccessSuspendedAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<string?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_SkipsAlreadySuspendedUsers()
+    {
+        var user = await SeedUserWithProfile(isSuspended: true);
+        _membershipCalculator.GetUsersRequiringStatusUpdateAsync(Arg.Any<CancellationToken>())
+            .Returns(new List<Guid> { user.Id });
+
+        await _job.ExecuteAsync();
+
+        await _emailService.DidNotReceive().SendAccessSuspendedAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<string?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_SkipsUsersWithoutProfile()
+    {
+        var userId = Guid.NewGuid();
+        _dbContext.Users.Add(new User
+        {
+            Id = userId,
+            UserName = "noprofile",
+            NormalizedUserName = "NOPROFILE",
+            Email = "noprofile@example.com",
+            NormalizedEmail = "NOPROFILE@EXAMPLE.COM",
+            DisplayName = "No Profile",
+            PreferredLanguage = "en"
+        });
+        await _dbContext.SaveChangesAsync();
+
+        _membershipCalculator.GetUsersRequiringStatusUpdateAsync(Arg.Any<CancellationToken>())
+            .Returns(new List<Guid> { userId });
+
+        await _job.ExecuteAsync();
+
+        await _emailService.DidNotReceive().SendAccessSuspendedAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<string?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_SendsSuspensionEmail()
+    {
+        var user = await SeedUserWithProfile();
+        _membershipCalculator.GetUsersRequiringStatusUpdateAsync(Arg.Any<CancellationToken>())
+            .Returns(new List<Guid> { user.Id });
+
+        await _job.ExecuteAsync();
+
+        await _emailService.Received(1).SendAccessSuspendedAsync(
+            "test@example.com",
+            "Test User",
+            Arg.Is<string>(s => s.Contains("consent")),
+            "en",
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_SendsInAppNotification()
+    {
+        var user = await SeedUserWithProfile();
+        _membershipCalculator.GetUsersRequiringStatusUpdateAsync(Arg.Any<CancellationToken>())
+            .Returns(new List<Guid> { user.Id });
+
+        await _job.ExecuteAsync();
+
+        await _notificationService.Received(1).SendAsync(
+            NotificationSource.AccessSuspended,
+            NotificationClass.Actionable,
+            NotificationPriority.Critical,
+            Arg.Any<string>(),
+            Arg.Is<IReadOnlyList<Guid>>(ids => ids.Contains(user.Id)),
+            body: Arg.Any<string?>(),
+            actionUrl: "/Legal/Consent",
+            actionLabel: Arg.Any<string?>(),
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_RemovesFromTeamResources()
+    {
+        var user = await SeedUserWithProfile();
+        var team = new Team
+        {
+            Id = Guid.NewGuid(),
+            Name = "Test Team",
+            Slug = "test-team",
+            CreatedAt = Now - Duration.FromDays(100)
+        };
+        _dbContext.Teams.Add(team);
+
+        _dbContext.TeamMembers.Add(new TeamMember
+        {
+            Id = Guid.NewGuid(),
+            TeamId = team.Id,
+            UserId = user.Id,
+            JoinedAt = Now - Duration.FromDays(50),
+            LeftAt = null
+        });
+        await _dbContext.SaveChangesAsync();
+
+        _membershipCalculator.GetUsersRequiringStatusUpdateAsync(Arg.Any<CancellationToken>())
+            .Returns(new List<Guid> { user.Id });
+
+        await _job.ExecuteAsync();
+
+        await _googleSyncService.Received(1).RemoveUserFromTeamResourcesAsync(
+            team.Id, user.Id, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_LogsAuditEntry()
+    {
+        var user = await SeedUserWithProfile();
+        _membershipCalculator.GetUsersRequiringStatusUpdateAsync(Arg.Any<CancellationToken>())
+            .Returns(new List<Guid> { user.Id });
+
+        await _job.ExecuteAsync();
+
+        await _auditLogService.Received(1).LogAsync(
+            AuditAction.MemberSuspended,
+            nameof(User),
+            user.Id,
+            Arg.Is<string>(s => s.Contains("Test User")),
+            nameof(SuspendNonCompliantMembersJob),
+            Arg.Any<Guid?>(),
+            Arg.Any<string?>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_InvalidatesCaches()
+    {
+        var user = await SeedUserWithProfile();
+        _membershipCalculator.GetUsersRequiringStatusUpdateAsync(Arg.Any<CancellationToken>())
+            .Returns(new List<Guid> { user.Id });
+
+        await _job.ExecuteAsync();
+
+        _profileService.Received(1).UpdateProfileCache(user.Id, null);
+        _teamService.Received(1).RemoveMemberFromAllTeamsCache(user.Id);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ContinuesWhenGoogleSyncFails()
+    {
+        var user = await SeedUserWithProfile();
+        var team = new Team
+        {
+            Id = Guid.NewGuid(),
+            Name = "Test Team",
+            Slug = "test-team",
+            CreatedAt = Now - Duration.FromDays(100)
+        };
+        _dbContext.Teams.Add(team);
+
+        _dbContext.TeamMembers.Add(new TeamMember
+        {
+            Id = Guid.NewGuid(),
+            TeamId = team.Id,
+            UserId = user.Id,
+            JoinedAt = Now - Duration.FromDays(50),
+            LeftAt = null
+        });
+        await _dbContext.SaveChangesAsync();
+
+        _membershipCalculator.GetUsersRequiringStatusUpdateAsync(Arg.Any<CancellationToken>())
+            .Returns(new List<Guid> { user.Id });
+
+        _googleSyncService.RemoveUserFromTeamResourcesAsync(
+            Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException(new InvalidOperationException("Google API error")));
+
+        // Should not throw — Google sync failures are caught and logged
+        await _job.ExecuteAsync();
+
+        // User should still be suspended despite Google sync failure
+        var updated = await _dbContext.Users.Include(u => u.Profile).SingleAsync();
+        updated.Profile!.IsSuspended.Should().BeTrue();
+    }
+
+    private async Task<User> SeedUserWithProfile(bool isSuspended = false)
+    {
+        var userId = Guid.NewGuid();
+        var user = new User
+        {
+            Id = userId,
+            UserName = "testuser",
+            NormalizedUserName = "TESTUSER",
+            Email = "test@example.com",
+            NormalizedEmail = "TEST@EXAMPLE.COM",
+            DisplayName = "Test User",
+            PreferredLanguage = "en",
+            Profile = new Profile
+            {
+                Id = Guid.NewGuid(),
+                UserId = userId,
+                FirstName = "Test",
+                LastName = "User",
+                BurnerName = "Tester",
+                IsSuspended = isSuspended,
+                UpdatedAt = Now - Duration.FromDays(10)
+            }
+        };
+
+        _dbContext.Users.Add(user);
+        await _dbContext.SaveChangesAsync();
+        return user;
+    }
+}

--- a/tests/Humans.Domain.Tests/Entities/ApplicationTests.cs
+++ b/tests/Humans.Domain.Tests/Entities/ApplicationTests.cs
@@ -161,6 +161,29 @@ public class ApplicationTests
         application.BoardVotes.Should().BeEmpty();
     }
 
+    [Fact]
+    public void ValidateTier_RejectsVolunteer()
+    {
+        var application = CreateSubmittedApplication();
+        application.MembershipTier = MembershipTier.Volunteer;
+
+        var act = () => application.ValidateTier();
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Volunteer*");
+    }
+
+    [Theory]
+    [InlineData(MembershipTier.Colaborador)]
+    [InlineData(MembershipTier.Asociado)]
+    public void ValidateTier_AcceptsValidTiers(MembershipTier tier)
+    {
+        var application = CreateSubmittedApplication();
+        application.MembershipTier = tier;
+
+        var act = () => application.ValidateTier();
+        act.Should().NotThrow();
+    }
+
     private Application CreateSubmittedApplication()
     {
         return new Application

--- a/tests/Humans.Domain.Tests/Entities/ProfileTests.cs
+++ b/tests/Humans.Domain.Tests/Entities/ProfileTests.cs
@@ -42,91 +42,6 @@ public class ProfileTests
     }
 
     [Fact]
-    public void ComputeMembershipStatus_WhenSuspended_ShouldReturnSuspended()
-    {
-        var profile = CreateProfile();
-        profile.IsSuspended = true;
-
-        var status = profile.ComputeMembershipStatus(
-            CreateActiveRoleAssignments(),
-            [Guid.NewGuid()],
-            [Guid.NewGuid()]);
-
-        status.Should().Be(MembershipStatus.Suspended);
-    }
-
-    [Fact]
-    public void ComputeMembershipStatus_WithNoActiveRoles_ShouldReturnNone()
-    {
-        var profile = CreateProfile();
-
-        var status = profile.ComputeMembershipStatus(
-            [], // No roles
-            [Guid.NewGuid()],
-            [Guid.NewGuid()]);
-
-        status.Should().Be(MembershipStatus.None);
-    }
-
-    [Fact]
-    public void ComputeMembershipStatus_WhenNotApproved_ShouldReturnPending()
-    {
-        var profile = CreateProfile();
-        profile.IsApproved = false;
-
-        var status = profile.ComputeMembershipStatus(
-            CreateActiveRoleAssignments(),
-            [Guid.NewGuid()],
-            [Guid.NewGuid()]);
-
-        status.Should().Be(MembershipStatus.Pending);
-    }
-
-    [Fact]
-    public void ComputeMembershipStatus_WithMissingConsent_ShouldReturnInactive()
-    {
-        var profile = CreateProfile();
-        var requiredDocId = Guid.NewGuid();
-
-        var status = profile.ComputeMembershipStatus(
-            CreateActiveRoleAssignments(),
-            [requiredDocId],
-            []); // No consents
-
-        status.Should().Be(MembershipStatus.Inactive);
-    }
-
-    [Fact]
-    public void ComputeMembershipStatus_WithAllConsents_ShouldReturnActive()
-    {
-        var profile = CreateProfile();
-        var docId1 = Guid.NewGuid();
-        var docId2 = Guid.NewGuid();
-
-        var status = profile.ComputeMembershipStatus(
-            CreateActiveRoleAssignments(),
-            [docId1, docId2],
-            [docId1, docId2]);
-
-        status.Should().Be(MembershipStatus.Active);
-    }
-
-    [Fact]
-    public void ComputeMembershipStatus_WithPartialConsent_ShouldReturnInactive()
-    {
-        var profile = CreateProfile();
-        var docId1 = Guid.NewGuid();
-        var docId2 = Guid.NewGuid();
-
-        var status = profile.ComputeMembershipStatus(
-            CreateActiveRoleAssignments(),
-            [docId1, docId2],
-            [docId1]); // Only one consent
-
-        status.Should().Be(MembershipStatus.Inactive);
-    }
-
-    [Fact]
     public void NewProfile_ShouldDefaultToVolunteerTier()
     {
         var profile = CreateProfile();
@@ -216,21 +131,4 @@ public class ProfileTests
         };
     }
 
-    private static List<RoleAssignment> CreateActiveRoleAssignments()
-    {
-        var now = SystemClock.Instance.GetCurrentInstant();
-        return
-        [
-            new RoleAssignment
-            {
-                Id = Guid.NewGuid(),
-                UserId = Guid.NewGuid(),
-                RoleName = "Member",
-                ValidFrom = now - Duration.FromDays(30),
-                ValidTo = null,
-                CreatedAt = now - Duration.FromDays(30),
-                CreatedByUserId = Guid.NewGuid()
-            }
-        ];
-    }
 }


### PR DESCRIPTION
## Summary

### Batch 1 (prior agent)
- **Item 1**: Remove `SystemClock.Instance` bypass in Application state machine OnEntry callbacks; set `ResolvedAt` explicitly in `Approve`/`Reject`/`Withdraw` using injected `IClock`
- **Item 2**: Remove dead `Profile.ComputeMembershipStatus()` method and its tests (superseded by `MembershipCalculator` service)
- **Item 3**: Replace `DateTime.UtcNow` with `IClock` in `ProfileController` and `GuestController` (file name generation and ticketing year display)
- **Item 6**: Extract `IVolunteerHistoryService` interface in Application layer; register via interface in DI
- **Item 7**: Add `DomainConstants.GoogleGroupDomain` constant; replace hardcoded `@nobodies.team` in `Team.GoogleGroupEmail`
- **Item 8**: Remove `SyncAllPermissionsAsync` no-op stub from `GoogleResourceProvisionJob` (and unused `IClock` dependency)
- **Item 9**: Change all 14 Hangfire jobs from concrete `HumansMetricsService` to `IHumansMetrics` interface
- **Item 12**: Remove dead `DbUpdateConcurrencyException` catch blocks from `ApplicationDecisionService` (concurrency tokens were removed)

### Batch 2 (continuation)
- **Item 4**: Add tests for `ProcessAccountDeletionsJob` (12 tests) and `SuspendNonCompliantMembersJob` (10 tests) covering GDPR anonymization, grace periods, event holds, email notifications, cache invalidation, error resilience, and suspension workflow
- **Item 10**: Add endpoint authorization tests (22 tests) verifying authorization policies on critical actions, anti-forgery token coverage on all POST actions, and authentication requirement coverage across all controllers
- **Item 17**: Add `Application.ValidateTier()` domain guard rejecting Volunteer tier, called at both application creation points (ApplicationDecisionService and ProfileService)
- **Item 20**: Extract `TempDataKeys` constants class; replace all TempData string literals in HumansControllerBase, TempDataAlertsViewComponent, and GoogleController
- **Item 22**: Replace `RedirectToAction` string literals with `nameof()` for cross-controller redirects in 7 controllers

### Batch 3 (final pass)
- **Item 16**: Replace long tuple return types with dedicated record DTOs (`BirthdayProfileInfo`, `LocationProfileInfo`, `ReviewQueueData`, `ReviewDetailData`, `BoardVotingDashboardData`, `BoardMemberInfo`, `ConsentProgressInfo`) in `IProfileService` and `IOnboardingService`
- **Item 18**: Add `CancellationToken` to key GET controller actions in `ProfileController`, `TeamController`, `OnboardingReviewController`, `AdminController` and pass through to service/DB calls
- **Low-priority fixes**: Replace `ToLowerInvariant()` switch with `OrdinalIgnoreCase` comparison in `ProfileService.GetFilteredHumansAsync`; remove unnecessary `GetCurrentUserAsync` reload in `ProfileController.RequestDeletion`

### Skipped items (by design)
- **Item 5**: God class decomposition — explicitly forbidden by user
- **Item 11**: `RoleAssignmentClaimsTransformation` caching — already implemented (60s IMemoryCache)
- **Item 13**: `StubEmailService` — already has conditional registration
- **Item 15**: Deprecated `ContactFieldType.Email` — requires data migration, out of scope
- **Item 19**: Inconsistent result types — minimal benefit, deferred

Closes nobodies-collective/Humans#102

## Test plan
- [x] All existing tests pass (993 total: 108 domain + 865 application + 20 integration)
- [x] 44 new tests added (12 + 10 job tests, 22 authorization tests)
- [x] Build succeeds with 0 warnings
- [x] Format check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)