### PR TITLE
Add option to promote subteams to Teams directory (#432)

### DIFF
--- a/docs/features/06-teams.md
+++ b/docs/features/06-teams.md
@@ -136,6 +136,7 @@ Nobodies Collective operates through self-organizing working groups (teams). Tea
 - Shows team name, description snippet, and "Learn More" link
 - No My Teams section, no admin buttons, no system teams shown
 - Authenticated users see the full existing layout unchanged
+- Subteams only appear if `IsPromotedToDirectory` is true; top-level teams always appear
 
 ## Data Model
 
@@ -158,7 +159,9 @@ Team
 ├── PageContentUpdatedAt: Instant? [last edit timestamp]
 ├── PageContentUpdatedByUserId: Guid? [FK → User, who last edited]
 ├── CallsToAction: List<CallToAction> [JSONB, max 3 items]
+├── IsPromotedToDirectory: bool [default false, promotes subteam to directory]
 ├── Computed: IsSystemTeam (SystemTeamType != None)
+├── Computed: IsInDirectory (ParentTeamId == null || IsPromotedToDirectory)
 ├── Computed: GoogleGroupEmail (prefix + "@nobodies.team", or null)
 └── Navigation: Members, JoinRequests, GoogleResources, ChildTeams, ParentTeam
 ```

--- a/docs/sections/Teams.md
+++ b/docs/sections/Teams.md
@@ -38,6 +38,7 @@
 - A Google Group prefix, if set, provisions a @nobodies.team group for the team.
 - Only departments (not sub-teams or system teams) can have public team pages.
 - A **hidden team** (`IsHidden = true`) is invisible to non-admin users: it does not appear on profile cards, team listings, public pages, birthday team names, or the "My Teams" page. Only Admin, Board, and TeamsAdmin can see and manage hidden teams. Campaigns can still target hidden teams for code distribution.
+- The Teams directory (`/Teams`) shows only **directory-visible** teams: top-level teams (departments) always appear; sub-teams only appear if `IsPromotedToDirectory` is true. Sub-teams are always accessible from their parent team's detail page regardless of this flag.
 
 ## Negative Access Rules
 

--- a/src/Humans.Application/Interfaces/ITeamService.cs
+++ b/src/Humans.Application/Interfaces/ITeamService.cs
@@ -8,7 +8,7 @@ namespace Humans.Application.Interfaces;
 public record CachedTeam(
     Guid Id, string Name, string? Description, string Slug,
     bool IsSystemTeam, SystemTeamType SystemTeamType, bool RequiresApproval,
-    bool IsPublicPage, bool IsHidden, Instant CreatedAt, List<CachedTeamMember> Members,
+    bool IsPublicPage, bool IsHidden, bool IsPromotedToDirectory, Instant CreatedAt, List<CachedTeamMember> Members,
     Guid? ParentTeamId = null);
 
 public record CachedTeamMember(
@@ -186,6 +186,7 @@ public interface ITeamService
         bool? hasBudget = null,
         bool? isHidden = null,
         bool? isSensitive = null,
+        bool? isPromotedToDirectory = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/src/Humans.Domain/Entities/Team.cs
+++ b/src/Humans.Domain/Entities/Team.cs
@@ -165,6 +165,19 @@ public class Team
     public ICollection<TeamRoleDefinition> RoleDefinitions { get; } = new List<TeamRoleDefinition>();
 
     /// <summary>
+    /// Whether this subteam is promoted to appear on the Teams directory page.
+    /// Only meaningful for subteams (ParentTeamId != null). Top-level teams always appear.
+    /// </summary>
+    public bool IsPromotedToDirectory { get; set; }
+
+    /// <summary>
+    /// Whether this team should appear in the Teams directory.
+    /// Top-level teams always appear; subteams only if promoted.
+    /// Not mapped to DB — use inline expression for EF queries.
+    /// </summary>
+    public bool IsInDirectory => ParentTeamId == null || IsPromotedToDirectory;
+
+    /// <summary>
     /// Whether this is a system-managed team.
     /// </summary>
     public bool IsSystemTeam => SystemTeamType != SystemTeamType.None;

--- a/src/Humans.Infrastructure/Data/Configurations/TeamConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/TeamConfiguration.cs
@@ -76,6 +76,9 @@ public class TeamConfiguration : IEntityTypeConfiguration<Team>
         builder.Property(t => t.IsSensitive)
             .IsRequired();
 
+        builder.Property(t => t.IsPromotedToDirectory)
+            .IsRequired();
+
         builder.Property(t => t.PageContent)
             .HasMaxLength(50000);
 
@@ -135,6 +138,7 @@ public class TeamConfiguration : IEntityTypeConfiguration<Team>
 
         // Ignore computed properties
         builder.Ignore(t => t.IsSystemTeam);
+        builder.Ignore(t => t.IsInDirectory);
         builder.Ignore(t => t.GoogleGroupEmail);
         builder.Ignore(t => t.DisplayName);
 
@@ -162,7 +166,8 @@ public class TeamConfiguration : IEntityTypeConfiguration<Team>
                 ShowCoordinatorsOnPublicPage = true,
                 HasBudget = false,
                 IsHidden = false,
-                IsSensitive = false
+                IsSensitive = false,
+                IsPromotedToDirectory = false
             },
             new
             {
@@ -186,7 +191,8 @@ public class TeamConfiguration : IEntityTypeConfiguration<Team>
                 ShowCoordinatorsOnPublicPage = true,
                 HasBudget = false,
                 IsHidden = false,
-                IsSensitive = false
+                IsSensitive = false,
+                IsPromotedToDirectory = false
             },
             new
             {
@@ -210,7 +216,8 @@ public class TeamConfiguration : IEntityTypeConfiguration<Team>
                 ShowCoordinatorsOnPublicPage = true,
                 HasBudget = false,
                 IsHidden = false,
-                IsSensitive = false
+                IsSensitive = false,
+                IsPromotedToDirectory = false
             },
             new
             {
@@ -234,7 +241,8 @@ public class TeamConfiguration : IEntityTypeConfiguration<Team>
                 ShowCoordinatorsOnPublicPage = true,
                 HasBudget = false,
                 IsHidden = false,
-                IsSensitive = false
+                IsSensitive = false,
+                IsPromotedToDirectory = false
             },
             new
             {
@@ -258,7 +266,8 @@ public class TeamConfiguration : IEntityTypeConfiguration<Team>
                 ShowCoordinatorsOnPublicPage = true,
                 HasBudget = false,
                 IsHidden = false,
-                IsSensitive = false
+                IsSensitive = false,
+                IsPromotedToDirectory = false
             },
             new
             {
@@ -282,7 +291,8 @@ public class TeamConfiguration : IEntityTypeConfiguration<Team>
                 ShowCoordinatorsOnPublicPage = true,
                 HasBudget = false,
                 IsHidden = false,
-                IsSensitive = false
+                IsSensitive = false,
+                IsPromotedToDirectory = false
             });
     }
 }

--- a/src/Humans.Infrastructure/Migrations/20260414231712_AddIsPromotedToDirectory.Designer.cs
+++ b/src/Humans.Infrastructure/Migrations/20260414231712_AddIsPromotedToDirectory.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Humans.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Humans.Infrastructure.Migrations
 {
     [DbContext(typeof(HumansDbContext))]
-    partial class HumansDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260414231712_AddIsPromotedToDirectory")]
+    partial class AddIsPromotedToDirectory
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Humans.Infrastructure/Migrations/20260414231712_AddIsPromotedToDirectory.cs
+++ b/src/Humans.Infrastructure/Migrations/20260414231712_AddIsPromotedToDirectory.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Humans.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddIsPromotedToDirectory : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsPromotedToDirectory",
+                table: "teams",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.UpdateData(
+                table: "teams",
+                keyColumn: "Id",
+                keyValue: new Guid("00000000-0000-0000-0001-000000000001"),
+                column: "IsPromotedToDirectory",
+                value: false);
+
+            migrationBuilder.UpdateData(
+                table: "teams",
+                keyColumn: "Id",
+                keyValue: new Guid("00000000-0000-0000-0001-000000000002"),
+                column: "IsPromotedToDirectory",
+                value: false);
+
+            migrationBuilder.UpdateData(
+                table: "teams",
+                keyColumn: "Id",
+                keyValue: new Guid("00000000-0000-0000-0001-000000000003"),
+                column: "IsPromotedToDirectory",
+                value: false);
+
+            migrationBuilder.UpdateData(
+                table: "teams",
+                keyColumn: "Id",
+                keyValue: new Guid("00000000-0000-0000-0001-000000000004"),
+                column: "IsPromotedToDirectory",
+                value: false);
+
+            migrationBuilder.UpdateData(
+                table: "teams",
+                keyColumn: "Id",
+                keyValue: new Guid("00000000-0000-0000-0001-000000000005"),
+                column: "IsPromotedToDirectory",
+                value: false);
+
+            migrationBuilder.UpdateData(
+                table: "teams",
+                keyColumn: "Id",
+                keyValue: new Guid("00000000-0000-0000-0001-000000000006"),
+                column: "IsPromotedToDirectory",
+                value: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsPromotedToDirectory",
+                table: "teams");
+        }
+    }
+}

--- a/src/Humans.Infrastructure/Services/TeamService.cs
+++ b/src/Humans.Infrastructure/Services/TeamService.cs
@@ -217,9 +217,13 @@ public class TeamService : ITeamService
 
         if (!userId.HasValue)
         {
+            // Top-level teams opt into the public directory via IsPublicPage.
+            // Subteams cannot set IsPublicPage (forced false in UpdateTeamAsync);
+            // their opt-in is IsPromotedToDirectory.
             var publicDepartments = cachedTeams.Values
-                .Where(t => t.IsPublicPage && !t.IsSystemTeam && !t.IsHidden
-                    && (t.ParentTeamId is null || t.IsPromotedToDirectory))
+                .Where(t => !t.IsSystemTeam && !t.IsHidden
+                    && ((t.ParentTeamId is null && t.IsPublicPage)
+                        || (t.ParentTeamId is not null && t.IsPromotedToDirectory)))
                 .OrderBy(t => t.Name, StringComparer.OrdinalIgnoreCase)
                 .Select(t => CreateDirectorySummary(t, cachedTeams, userId))
                 .ToList();
@@ -283,10 +287,17 @@ public class TeamService : ITeamService
             return null;
         }
 
-        if (!userId.HasValue &&
-            (!team.IsPublicPage || team.IsHidden || team.IsSystemTeam || team.ParentTeamId.HasValue))
+        if (!userId.HasValue)
         {
-            return null;
+            // Anonymous visitors can see top-level teams with IsPublicPage,
+            // or subteams that have been promoted to the directory.
+            var isAnonymouslyVisible = !team.IsHidden && !team.IsSystemTeam
+                && ((team.ParentTeamId is null && team.IsPublicPage)
+                    || (team.ParentTeamId is not null && team.IsPromotedToDirectory));
+            if (!isAnonymouslyVisible)
+            {
+                return null;
+            }
         }
 
         var activeMembers = team.Members

--- a/src/Humans.Infrastructure/Services/TeamService.cs
+++ b/src/Humans.Infrastructure/Services/TeamService.cs
@@ -139,7 +139,7 @@ public class TeamService : ITeamService
 
                 UpsertCachedTeam(new CachedTeam(team.Id, team.Name, team.Description, team.Slug,
                     team.IsSystemTeam, team.SystemTeamType, team.RequiresApproval, team.IsPublicPage, team.IsHidden,
-                    team.CreatedAt, [], ParentTeamId: parentTeamId));
+                    team.IsPromotedToDirectory, team.CreatedAt, [], ParentTeamId: parentTeamId));
                 _logger.LogInformation("Created team {TeamName} with slug {Slug}", name, slug);
                 return team;
             }
@@ -218,7 +218,8 @@ public class TeamService : ITeamService
         if (!userId.HasValue)
         {
             var publicDepartments = cachedTeams.Values
-                .Where(t => t.IsPublicPage && !t.IsSystemTeam && !t.IsHidden && t.ParentTeamId is null)
+                .Where(t => t.IsPublicPage && !t.IsSystemTeam && !t.IsHidden
+                    && (t.ParentTeamId is null || t.IsPromotedToDirectory))
                 .OrderBy(t => t.Name, StringComparer.OrdinalIgnoreCase)
                 .Select(t => CreateDirectorySummary(t, cachedTeams, userId))
                 .ToList();
@@ -241,7 +242,10 @@ public class TeamService : ITeamService
             ? cachedTeams.Values
             : cachedTeams.Values.Where(t => !t.IsHidden);
 
-        var summaries = visibleTeams
+        var directoryTeams = visibleTeams
+            .Where(t => t.ParentTeamId is null || t.IsPromotedToDirectory);
+
+        var summaries = directoryTeams
             .Select(t => CreateDirectorySummary(t, cachedTeams, userId))
             .ToList();
 
@@ -439,6 +443,7 @@ public class TeamService : ITeamService
         bool? hasBudget = null,
         bool? isHidden = null,
         bool? isSensitive = null,
+        bool? isPromotedToDirectory = null,
         CancellationToken cancellationToken = default)
     {
         var team = await _dbContext.Teams.FindAsync(new object[] { teamId }, cancellationToken)
@@ -534,6 +539,8 @@ public class TeamService : ITeamService
             team.IsHidden = isHidden.Value;
         if (isSensitive.HasValue)
             team.IsSensitive = isSensitive.Value;
+        if (isPromotedToDirectory.HasValue)
+            team.IsPromotedToDirectory = isPromotedToDirectory.Value;
         if (team.IsSystemTeam || parentTeamId.HasValue)
         {
             team.IsPublicPage = false;
@@ -2161,6 +2168,7 @@ public class TeamService : ITeamService
         RequiresApproval: team.RequiresApproval,
         IsPublicPage: team.IsPublicPage,
         IsHidden: team.IsHidden,
+        IsPromotedToDirectory: team.IsPromotedToDirectory,
         CreatedAt: team.CreatedAt,
         Members: team.Members
             .Where(m => m.LeftAt is null)

--- a/src/Humans.Web/Controllers/TeamController.cs
+++ b/src/Humans.Web/Controllers/TeamController.cs
@@ -760,6 +760,7 @@ public class TeamController : HumansControllerBase
             HasBudget = team.HasBudget,
             IsHidden = team.IsHidden,
             IsSensitive = team.IsSensitive,
+            IsPromotedToDirectory = team.IsPromotedToDirectory,
             ParentTeamId = team.ParentTeamId,
             EligibleParents = await GetEligibleParentTeamsAsync(excludeTeamId: id, cancellationToken)
         };
@@ -785,7 +786,7 @@ public class TeamController : HumansControllerBase
 
         try
         {
-            await _teamService.UpdateTeamAsync(id, model.Name, model.Description, model.RequiresApproval, model.IsActive, model.ParentTeamId, model.GoogleGroupPrefix, model.CustomSlug, model.HasBudget, model.IsHidden, model.IsSensitive);
+            await _teamService.UpdateTeamAsync(id, model.Name, model.Description, model.RequiresApproval, model.IsActive, model.ParentTeamId, model.GoogleGroupPrefix, model.CustomSlug, model.HasBudget, model.IsHidden, model.IsSensitive, model.IsPromotedToDirectory);
             var currentUser = await GetCurrentUserAsync();
             _logger.LogInformation("Admin {AdminId} updated team {TeamId}", currentUser?.Id, id);
 

--- a/src/Humans.Web/Models/TeamViewModels.cs
+++ b/src/Humans.Web/Models/TeamViewModels.cs
@@ -223,6 +223,7 @@ public class EditTeamViewModel : TeamFormViewModelBase
     public bool IsSystemTeam { get; set; }
     public bool HasBudget { get; set; }
     public bool IsSensitive { get; set; }
+    public bool IsPromotedToDirectory { get; set; }
 }
 
 public class EditTeamPageViewModel

--- a/src/Humans.Web/Views/Team/EditTeam.cshtml
+++ b/src/Humans.Web/Views/Team/EditTeam.cshtml
@@ -69,6 +69,15 @@
                         </div>
                     }
 
+                    @if (Model.ParentTeamId.HasValue)
+                    {
+                        <div class="mb-3 form-check">
+                            <input asp-for="IsPromotedToDirectory" type="checkbox" class="form-check-input" />
+                            <label asp-for="IsPromotedToDirectory" class="form-check-label">Show on Teams page</label>
+                            <div class="form-text">When enabled, this sub-team also appears on the main Teams directory page.</div>
+                        </div>
+                    }
+
                     <div class="mb-3 form-check" authorize-policy="AdminOnly">
                         <input asp-for="IsSensitive" type="checkbox" class="form-check-input" />
                         <label asp-for="IsSensitive" class="form-check-label">Sensitive team <i class="fa-solid fa-lock auth-lock-icon"></i></label>


### PR DESCRIPTION
## Summary
- Adds `IsPromotedToDirectory` property to Team entity (default `false`)
- Adds `IsInDirectory` computed property encapsulating visibility logic
- Filters `/Teams` directory to show only top-level teams and promoted subteams
- Adds "Show on Teams page" checkbox in team edit (visible for subteams only)
- Includes EF migration for new column

Closes nobodies-collective/Humans#432

## Test plan
- [ ] `/Teams` shows only top-level teams by default (subteams no longer clutter directory)
- [ ] Edit a subteam, check "Show on Teams page", save — subteam now appears on `/Teams`
- [ ] Uncheck the flag — subteam disappears from `/Teams`
- [ ] Top-level teams are unaffected (always appear)
- [ ] Checkbox only visible when editing a subteam (not shown for top-level teams)
- [ ] Unauthenticated `/Teams` view also respects the flag
- [ ] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>