### PR TITLE
Scope unsubscribe links to comms preferences only

### DIFF
--- a/src/Humans.Web/Controllers/GuestController.cs
+++ b/src/Humans.Web/Controllers/GuestController.cs
@@ -70,6 +70,9 @@ public class GuestController : HumansControllerBase
 
     // ─── Communication Preferences ───────────────────────────────────
 
+    // WARNING: [AllowAnonymous] — accepts unauthenticated requests with a valid unsubscribe
+    // token (utoken). The token scopes access to THIS page only. Do not add links to other
+    // authenticated pages from the token-mode view. See EndpointAuthorizationTests allowlist.
     [HttpGet("Guest/CommunicationPreferences")]
     [AllowAnonymous]
     public async Task<IActionResult> CommunicationPreferences(string? utoken)
@@ -92,6 +95,8 @@ public class GuestController : HumansControllerBase
         }
     }
 
+    // WARNING: [AllowAnonymous] — paired with CommunicationPreferences GET above.
+    // See EndpointAuthorizationTests allowlist.
     [HttpPost("Guest/CommunicationPreferences/Update")]
     [AllowAnonymous]
     [ValidateAntiForgeryToken]

--- a/src/Humans.Web/Controllers/GuestController.cs
+++ b/src/Humans.Web/Controllers/GuestController.cs
@@ -71,15 +71,18 @@ public class GuestController : HumansControllerBase
     // ─── Communication Preferences ───────────────────────────────────
 
     [HttpGet("Guest/CommunicationPreferences")]
-    public async Task<IActionResult> CommunicationPreferences()
+    [AllowAnonymous]
+    public async Task<IActionResult> CommunicationPreferences(string? utoken)
     {
         try
         {
-            var user = await GetCurrentUserAsync();
-            if (user is null)
+            var userId = await ResolveUserIdOrTokenAsync(utoken);
+            if (userId is null)
                 return Challenge();
 
-            return View(await BuildCommunicationPreferencesViewModelAsync(user.Id));
+            var model = await BuildCommunicationPreferencesViewModelAsync(userId.Value);
+            model.UnsubscribeToken = utoken;
+            return View(model);
         }
         catch (Exception ex)
         {
@@ -90,20 +93,21 @@ public class GuestController : HumansControllerBase
     }
 
     [HttpPost("Guest/CommunicationPreferences/Update")]
+    [AllowAnonymous]
     [ValidateAntiForgeryToken]
-    public async Task<IActionResult> UpdatePreference(MessageCategory category, bool emailEnabled, bool alertEnabled)
+    public async Task<IActionResult> UpdatePreference(MessageCategory category, bool emailEnabled, bool alertEnabled, string? utoken)
     {
         try
         {
-            var user = await GetCurrentUserAsync();
-            if (user is null)
+            var userId = await ResolveUserIdOrTokenAsync(utoken);
+            if (userId is null)
                 return Unauthorized();
 
             if (category.IsAlwaysOn())
                 return BadRequest("Cannot change always-on categories.");
 
             await _commPrefService.UpdatePreferenceAsync(
-                user.Id, category, optedOut: !emailEnabled, inboxEnabled: alertEnabled, "Guest");
+                userId.Value, category, optedOut: !emailEnabled, inboxEnabled: alertEnabled, "Guest");
 
             return Ok();
         }
@@ -278,6 +282,32 @@ public class GuestController : HumansControllerBase
         viewModel.DeletionEligibleAfter = user.DeletionEligibleAfter?.ToDateTimeUtc();
 
         return viewModel;
+    }
+
+    /// <summary>
+    /// Resolves the user ID from the current session, or falls back to an unsubscribe token.
+    /// Returns null if neither is available.
+    /// </summary>
+    private async Task<Guid?> ResolveUserIdOrTokenAsync(string? utoken)
+    {
+        // Prefer authenticated session
+        var user = await GetCurrentUserAsync();
+        if (user is not null)
+            return user.Id;
+
+        // Fall back to unsubscribe token
+        if (string.IsNullOrEmpty(utoken))
+            return null;
+
+        var result = _commPrefService.ValidateUnsubscribeToken(utoken);
+        if (result is null)
+            return null;
+
+        var (userId, _) = result.Value;
+
+        // Verify user still exists
+        var exists = await _dbContext.Users.AnyAsync(u => u.Id == userId);
+        return exists ? userId : null;
     }
 
     private async Task<CommunicationPreferencesViewModel> BuildCommunicationPreferencesViewModelAsync(Guid userId)

--- a/src/Humans.Web/Controllers/UnsubscribeController.cs
+++ b/src/Humans.Web/Controllers/UnsubscribeController.cs
@@ -1,11 +1,8 @@
 using System.Security.Cryptography;
 using Humans.Application.Interfaces;
-using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Microsoft.AspNetCore.DataProtection;
-using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
 using Humans.Infrastructure.Data;
 
 namespace Humans.Web.Controllers;
@@ -15,20 +12,17 @@ public class UnsubscribeController : Controller
     private readonly HumansDbContext _db;
     private readonly ICommunicationPreferenceService _preferenceService;
     private readonly IDataProtectionProvider _dataProtection;
-    private readonly SignInManager<User> _signInManager;
     private readonly ILogger<UnsubscribeController> _logger;
 
     public UnsubscribeController(
         HumansDbContext db,
         ICommunicationPreferenceService preferenceService,
         IDataProtectionProvider dataProtection,
-        SignInManager<User> signInManager,
         ILogger<UnsubscribeController> logger)
     {
         _db = db;
         _preferenceService = preferenceService;
         _dataProtection = dataProtection;
-        _signInManager = signInManager;
         _logger = logger;
     }
 
@@ -39,18 +33,15 @@ public class UnsubscribeController : Controller
         var result = _preferenceService.ValidateUnsubscribeToken(token);
         if (result is not null)
         {
-            var (userId, category) = result.Value;
+            var (userId, _) = result.Value;
             var user = await _db.Users.FindAsync(userId);
             if (user is null)
                 return NotFound();
 
-            // Sign in the user and redirect to communication preferences
-            await _signInManager.SignInAsync(user, isPersistent: false);
-            _logger.LogInformation(
-                "User {UserId} authenticated via unsubscribe link for {Category}",
-                userId, category);
-
-            return await RedirectToCommunicationPreferencesAsync(user);
+            // Redirect to comms preferences with token — no session created
+            return RedirectToAction(
+                nameof(GuestController.CommunicationPreferences), "Guest",
+                new { utoken = token });
         }
 
         // Fall back to legacy campaign-only token
@@ -72,13 +63,10 @@ public class UnsubscribeController : Controller
 
             await _preferenceService.UpdatePreferenceAsync(userId, category, optedOut: true, source: "MagicLink");
 
-            // Sign in and redirect to communication preferences
-            await _signInManager.SignInAsync(user, isPersistent: false);
-            _logger.LogInformation(
-                "User {UserId} unsubscribed from {Category} and authenticated via unsubscribe link",
-                userId, category);
-
-            return await RedirectToCommunicationPreferencesAsync(user);
+            // Redirect to comms preferences with token — no session created
+            return RedirectToAction(
+                nameof(GuestController.CommunicationPreferences), "Guest",
+                new { utoken = token });
         }
 
         // Fall back to legacy campaign-only token
@@ -117,18 +105,6 @@ public class UnsubscribeController : Controller
         }
     }
 
-    /// <summary>
-    /// Redirects to the appropriate communication preferences page based on whether the user has a profile.
-    /// Profileless users go to Guest/CommunicationPreferences; users with profiles go to Profile/CommunicationPreferences.
-    /// </summary>
-    private async Task<IActionResult> RedirectToCommunicationPreferencesAsync(User user)
-    {
-        var hasProfile = await _db.Profiles.AnyAsync(p => p.UserId == user.Id);
-        return hasProfile
-            ? RedirectToAction(nameof(ProfileController.CommunicationPreferences), "Profile")
-            : RedirectToAction(nameof(GuestController.CommunicationPreferences), "Guest");
-    }
-
     private async Task<IActionResult> TryLegacyToken(string token)
     {
         var protector = _dataProtection
@@ -153,13 +129,9 @@ public class UnsubscribeController : Controller
         if (user is null)
             return NotFound();
 
-        // Sign in the user and redirect to communication preferences
-        await _signInManager.SignInAsync(user, isPersistent: false);
-        _logger.LogInformation(
-            "User {UserId} authenticated via legacy unsubscribe link",
-            userId);
-
-        return await RedirectToCommunicationPreferencesAsync(user);
+        ViewData["DisplayName"] = user.DisplayName;
+        ViewData["CategoryName"] = MessageCategory.Marketing.ToDisplayName();
+        return View();
     }
 
     private async Task<IActionResult> TryLegacyConfirm(string token)
@@ -189,12 +161,7 @@ public class UnsubscribeController : Controller
         // Use the new preference service for legacy tokens too
         await _preferenceService.UpdatePreferenceAsync(userId, MessageCategory.Marketing, optedOut: true, source: "MagicLink");
 
-        // Sign in and redirect to communication preferences
-        await _signInManager.SignInAsync(user, isPersistent: false);
-        _logger.LogInformation(
-            "User {UserId} unsubscribed from Marketing and authenticated via legacy unsubscribe link",
-            userId);
-
-        return await RedirectToCommunicationPreferencesAsync(user);
+        ViewData["CategoryName"] = MessageCategory.Marketing.ToDisplayName();
+        return View("Done");
     }
 }

--- a/src/Humans.Web/Models/CommunicationPreferenceViewModels.cs
+++ b/src/Humans.Web/Models/CommunicationPreferenceViewModels.cs
@@ -5,6 +5,12 @@ namespace Humans.Web.Models;
 public class CommunicationPreferencesViewModel
 {
     public List<CategoryPreferenceItem> Categories { get; set; } = [];
+
+    /// <summary>
+    /// When set, the page is accessed via an unsubscribe token instead of a full session.
+    /// The token must be included in AJAX update calls for authorization.
+    /// </summary>
+    public string? UnsubscribeToken { get; set; }
 }
 
 public class CategoryPreferenceItem

--- a/src/Humans.Web/Views/Guest/CommunicationPreferences.cshtml
+++ b/src/Humans.Web/Views/Guest/CommunicationPreferences.cshtml
@@ -5,12 +5,15 @@
 
 <div class="row">
     <div class="col-12" style="max-width: 900px;">
-        <nav aria-label="breadcrumb">
-            <ol class="breadcrumb">
-                <li class="breadcrumb-item"><a asp-action="Index">Dashboard</a></li>
-                <li class="breadcrumb-item active" aria-current="page">Communication Preferences</li>
-            </ol>
-        </nav>
+        @if (string.IsNullOrEmpty(Model.UnsubscribeToken))
+        {
+            <nav aria-label="breadcrumb">
+                <ol class="breadcrumb">
+                    <li class="breadcrumb-item"><a asp-action="Index">Dashboard</a></li>
+                    <li class="breadcrumb-item active" aria-current="page">Communication Preferences</li>
+                </ol>
+            </nav>
+        }
 
         <h1>Communication Preferences</h1>
         <p class="text-muted">Choose which communications you receive and how.</p>
@@ -84,7 +87,10 @@
             </div>
         </div>
 
-        <a asp-action="Index" class="btn btn-outline-secondary">Back to Dashboard</a>
+        @if (string.IsNullOrEmpty(Model.UnsubscribeToken))
+        {
+            <a asp-action="Index" class="btn btn-outline-secondary">Back to Dashboard</a>
+        }
     </div>
 </div>
 
@@ -105,6 +111,10 @@
             body.append('alertEnabled', alertCb ? alertCb.checked : true);
             body.append('__RequestVerificationToken',
                 document.querySelector('input[name="__RequestVerificationToken"]').value);
+            @if (!string.IsNullOrEmpty(Model.UnsubscribeToken))
+            {
+                @:body.append('utoken', '@Html.Raw(Html.Encode(Model.UnsubscribeToken))');
+            }
 
             this.disabled = true;
             var self = this;

--- a/src/Humans.Web/Views/Unsubscribe/Done.cshtml
+++ b/src/Humans.Web/Views/Unsubscribe/Done.cshtml
@@ -9,7 +9,7 @@
 
 <p>
     You can manage all your communication preferences from your
-    <a asp-controller="Guest" asp-action="CommunicationPreferences">communication preferences</a>.
+    <a asp-controller="Account" asp-action="Login">communication preferences</a>.
 </p>
 
 <p><a asp-controller="Home" asp-action="Index">Back to home</a></p>

--- a/tests/Humans.Application.Tests/Authorization/EndpointAuthorizationTests.cs
+++ b/tests/Humans.Application.Tests/Authorization/EndpointAuthorizationTests.cs
@@ -175,6 +175,55 @@ public class EndpointAuthorizationTests
             "Unprotected: " + string.Join(", ", violations));
     }
 
+    // --- AllowAnonymous scope guardrail ---
+
+    /// <summary>
+    /// Guards against accidental scope creep of [AllowAnonymous] on controllers that
+    /// have [Authorize] at class level. Any new anonymous endpoint on an authorized
+    /// controller must be explicitly added to this allowlist with a justification.
+    /// </summary>
+    [Fact]
+    public void AllowAnonymousOnAuthorizedControllers_IsExplicitlyAllowlisted()
+    {
+        // Allowlist: controller.action → why it's anonymous
+        // When adding a new entry, include a comment explaining why it needs anonymous access.
+        var allowlist = new HashSet<string>(StringComparer.Ordinal)
+        {
+            "GuestController.CommunicationPreferences",  // unsubscribe token passthrough (no session created)
+            "GuestController.UpdatePreference",           // AJAX updates from token-scoped comms prefs page
+            "TeamController.Index",                       // public team directory
+            "TeamController.Details",                     // public team detail page
+            "AdminController.DbVersion",                  // health check endpoint
+            "ProfileController.VerifyEmail",              // email verification link from email
+        };
+
+        // Also include any actions we discover that are already [AllowAnonymous] in ProfileController etc.
+        var controllerTypes = typeof(HumansControllerBase).Assembly.GetTypes()
+            .Where(t => typeof(Controller).IsAssignableFrom(t) && !t.IsAbstract)
+            .Where(t => t.GetCustomAttribute<AuthorizeAttribute>() != null);
+
+        var violations = new List<string>();
+
+        foreach (var controller in controllerTypes)
+        {
+            var actions = controller.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+                .Where(m => m.GetCustomAttribute<AllowAnonymousAttribute>() != null);
+
+            foreach (var action in actions)
+            {
+                var key = $"{controller.Name}.{action.Name}";
+                if (!allowlist.Contains(key))
+                {
+                    violations.Add(key);
+                }
+            }
+        }
+
+        violations.Should().BeEmpty(
+            "[AllowAnonymous] on an [Authorize] controller must be explicitly allowlisted in this test. " +
+            "New anonymous endpoints: " + string.Join(", ", violations));
+    }
+
     // --- Helpers ---
 
     private static void AssertHasPolicy(Type controllerType, string? actionName, string expectedPolicy)


### PR DESCRIPTION
## Summary
- Unsubscribe links no longer call `SignInAsync` — eliminates privilege escalation from email tokens to full sessions
- Token is passed through as `?utoken=` query param to `Guest/CommunicationPreferences`
- GuestController validates the token server-side on each request (GET and POST)
- View includes token in AJAX preference update calls, hides nav breadcrumb in token mode
- `SignInManager` dependency removed from `UnsubscribeController` entirely

**Before:** clicking an unsubscribe link in an email created a full authenticated session, granting access to the entire app.

**After:** the unsubscribe token is scoped to the communication preferences page only. No session is created. The token (already time-limited to ~90 days) serves as authorization for just that page.

## Test plan
- [ ] Click unsubscribe link from email → lands on comms preferences page (no breadcrumb/nav to dashboard)
- [ ] Toggle a preference via the checkboxes — should save successfully
- [ ] Navigate manually to another page (e.g., `/Profile/Me`) — should get login prompt, NOT be authenticated
- [ ] Authenticated user visiting `/Guest/CommunicationPreferences` directly still works normally (with breadcrumb)
- [ ] Legacy unsubscribe tokens still show the Done/Expired pages correctly
- [ ] Invalid/expired utoken → redirected to login

🤖 Generated with [Claude Code](https://claude.com/claude-code)