### PR TITLE
Fix cache invalidation, job error handling, and UI issues

### DIFF
--- a/src/Humans.Infrastructure/Jobs/CleanupEmailOutboxJob.cs
+++ b/src/Humans.Infrastructure/Jobs/CleanupEmailOutboxJob.cs
@@ -37,23 +37,32 @@ public class CleanupEmailOutboxJob : IRecurringJob
 
     public async Task ExecuteAsync(CancellationToken cancellationToken = default)
     {
-        var cutoff = _clock.GetCurrentInstant() - Duration.FromDays(_settings.OutboxRetentionDays);
-
-        var toDelete = await _dbContext.EmailOutboxMessages
-            .Where(m => m.Status == EmailOutboxStatus.Sent && m.SentAt < cutoff)
-            .ToListAsync(cancellationToken);
-
-        if (toDelete.Count > 0)
+        try
         {
-            _dbContext.EmailOutboxMessages.RemoveRange(toDelete);
-            await _dbContext.SaveChangesAsync(cancellationToken);
+            var cutoff = _clock.GetCurrentInstant() - Duration.FromDays(_settings.OutboxRetentionDays);
+
+            var toDelete = await _dbContext.EmailOutboxMessages
+                .Where(m => m.Status == EmailOutboxStatus.Sent && m.SentAt < cutoff)
+                .ToListAsync(cancellationToken);
+
+            if (toDelete.Count > 0)
+            {
+                _dbContext.EmailOutboxMessages.RemoveRange(toDelete);
+                await _dbContext.SaveChangesAsync(cancellationToken);
+            }
+
+            _logger.LogInformation(
+                "CleanupEmailOutboxJob deleted {Count} sent messages older than {Cutoff}",
+                toDelete.Count,
+                cutoff);
+
+            _metrics.RecordJobRun("cleanup_email_outbox", "success");
         }
-
-        _logger.LogInformation(
-            "CleanupEmailOutboxJob deleted {Count} sent messages older than {Cutoff}",
-            toDelete.Count,
-            cutoff);
-
-        _metrics.RecordJobRun("cleanup_email_outbox", "success");
+        catch (Exception ex)
+        {
+            _metrics.RecordJobRun("cleanup_email_outbox", "failure");
+            _logger.LogError(ex, "Error cleaning up email outbox");
+            throw;
+        }
     }
 }

--- a/src/Humans.Infrastructure/Jobs/CleanupNotificationsJob.cs
+++ b/src/Humans.Infrastructure/Jobs/CleanupNotificationsJob.cs
@@ -37,39 +37,48 @@ public class CleanupNotificationsJob : IRecurringJob
 
     public async Task ExecuteAsync(CancellationToken cancellationToken = default)
     {
-        var now = _clock.GetCurrentInstant();
-        var resolvedCutoff = now - ResolvedRetentionPeriod;
-        var informationalCutoff = now - InformationalRetentionPeriod;
-
-        // Pass 1: resolved notifications older than 7 days
-        var resolvedToDelete = await _dbContext.Notifications
-            .Where(n => n.ResolvedAt != null && n.ResolvedAt < resolvedCutoff)
-            .ToListAsync(cancellationToken);
-
-        if (resolvedToDelete.Count > 0)
+        try
         {
-            _dbContext.Notifications.RemoveRange(resolvedToDelete);
-            await _dbContext.SaveChangesAsync(cancellationToken);
+            var now = _clock.GetCurrentInstant();
+            var resolvedCutoff = now - ResolvedRetentionPeriod;
+            var informationalCutoff = now - InformationalRetentionPeriod;
+
+            // Pass 1: resolved notifications older than 7 days
+            var resolvedToDelete = await _dbContext.Notifications
+                .Where(n => n.ResolvedAt != null && n.ResolvedAt < resolvedCutoff)
+                .ToListAsync(cancellationToken);
+
+            if (resolvedToDelete.Count > 0)
+            {
+                _dbContext.Notifications.RemoveRange(resolvedToDelete);
+                await _dbContext.SaveChangesAsync(cancellationToken);
+            }
+
+            // Pass 2: unresolved informational notifications older than 30 days
+            var staleToDelete = await _dbContext.Notifications
+                .Where(n => n.ResolvedAt == null &&
+                            n.Class == NotificationClass.Informational &&
+                            n.CreatedAt < informationalCutoff)
+                .ToListAsync(cancellationToken);
+
+            if (staleToDelete.Count > 0)
+            {
+                _dbContext.Notifications.RemoveRange(staleToDelete);
+                await _dbContext.SaveChangesAsync(cancellationToken);
+            }
+
+            _logger.LogInformation(
+                "CleanupNotificationsJob: deleted {ResolvedCount} resolved (>{ResolvedDays}d) and {StaleCount} stale informational (>{StaleDays}d) notifications",
+                resolvedToDelete.Count, ResolvedRetentionPeriod.Days,
+                staleToDelete.Count, InformationalRetentionPeriod.Days);
+
+            _metrics.RecordJobRun("cleanup_notifications", "success");
         }
-
-        // Pass 2: unresolved informational notifications older than 30 days
-        var staleToDelete = await _dbContext.Notifications
-            .Where(n => n.ResolvedAt == null &&
-                        n.Class == NotificationClass.Informational &&
-                        n.CreatedAt < informationalCutoff)
-            .ToListAsync(cancellationToken);
-
-        if (staleToDelete.Count > 0)
+        catch (Exception ex)
         {
-            _dbContext.Notifications.RemoveRange(staleToDelete);
-            await _dbContext.SaveChangesAsync(cancellationToken);
+            _metrics.RecordJobRun("cleanup_notifications", "failure");
+            _logger.LogError(ex, "Error cleaning up notifications");
+            throw;
         }
-
-        _logger.LogInformation(
-            "CleanupNotificationsJob: deleted {ResolvedCount} resolved (>{ResolvedDays}d) and {StaleCount} stale informational (>{StaleDays}d) notifications",
-            resolvedToDelete.Count, ResolvedRetentionPeriod.Days,
-            staleToDelete.Count, InformationalRetentionPeriod.Days);
-
-        _metrics.RecordJobRun("cleanup_notifications", "success");
     }
 }

--- a/src/Humans.Infrastructure/Jobs/ProcessAccountDeletionsJob.cs
+++ b/src/Humans.Infrastructure/Jobs/ProcessAccountDeletionsJob.cs
@@ -138,6 +138,7 @@ public class ProcessAccountDeletionsJob : IRecurringJob
             foreach (var userId in processedUserIds)
             {
                 _profileService.UpdateProfileCache(userId, null);
+                _cache.InvalidateUserProfile(userId);
                 _teamService.RemoveMemberFromAllTeamsCache(userId);
                 _cache.InvalidateRoleAssignmentClaims(userId);
                 _cache.InvalidateShiftAuthorization(userId);

--- a/src/Humans.Infrastructure/Jobs/ProcessGoogleSyncOutboxJob.cs
+++ b/src/Humans.Infrastructure/Jobs/ProcessGoogleSyncOutboxJob.cs
@@ -49,146 +49,156 @@ public class ProcessGoogleSyncOutboxJob : IRecurringJob
 
     public async Task ExecuteAsync(CancellationToken cancellationToken = default)
     {
-        var pendingEvents = await _dbContext.GoogleSyncOutboxEvents
-            .Where(e => e.ProcessedAt == null && !e.FailedPermanently && e.RetryCount < MaxRetryCount)
-            .OrderBy(e => e.OccurredAt)
-            .Take(BatchSize)
-            .ToListAsync(cancellationToken);
-
-        if (pendingEvents.Count == 0)
+        try
         {
-            return;
-        }
+            var pendingEvents = await _dbContext.GoogleSyncOutboxEvents
+                .Where(e => e.ProcessedAt == null && !e.FailedPermanently && e.RetryCount < MaxRetryCount)
+                .OrderBy(e => e.OccurredAt)
+                .Take(BatchSize)
+                .ToListAsync(cancellationToken);
 
-        // Pre-load contextual info for richer error messages
-        var userIds = pendingEvents.Select(e => e.UserId).Distinct().ToList();
-        var teamIds = pendingEvents.Select(e => e.TeamId).Distinct().ToList();
-        var userEmailLookup = await _dbContext.Users
-            .Where(u => userIds.Contains(u.Id))
-            .ToDictionaryAsync(u => u.Id, u => u.Email ?? "unknown", cancellationToken);
-        var teamNameLookup = await _dbContext.Teams
-            .Where(t => teamIds.Contains(t.Id))
-            .ToDictionaryAsync(t => t.Id, t => t.Name, cancellationToken);
-
-        foreach (var outboxEvent in pendingEvents)
-        {
-            try
+            if (pendingEvents.Count == 0)
             {
-                switch (outboxEvent.EventType)
+                return;
+            }
+
+            // Pre-load contextual info for richer error messages
+            var userIds = pendingEvents.Select(e => e.UserId).Distinct().ToList();
+            var teamIds = pendingEvents.Select(e => e.TeamId).Distinct().ToList();
+            var userEmailLookup = await _dbContext.Users
+                .Where(u => userIds.Contains(u.Id))
+                .ToDictionaryAsync(u => u.Id, u => u.Email ?? "unknown", cancellationToken);
+            var teamNameLookup = await _dbContext.Teams
+                .Where(t => teamIds.Contains(t.Id))
+                .ToDictionaryAsync(t => t.Id, t => t.Name, cancellationToken);
+
+            foreach (var outboxEvent in pendingEvents)
+            {
+                try
                 {
-                    case GoogleSyncOutboxEventTypes.AddUserToTeamResources:
-                        await _googleSyncService.AddUserToTeamResourcesAsync(
-                            outboxEvent.TeamId,
-                            outboxEvent.UserId,
-                            cancellationToken);
-                        break;
-
-                    case GoogleSyncOutboxEventTypes.RemoveUserFromTeamResources:
-                        await _googleSyncService.RemoveUserFromTeamResourcesAsync(
-                            outboxEvent.TeamId,
-                            outboxEvent.UserId,
-                            cancellationToken);
-                        break;
-
-                    default:
-                        throw new InvalidOperationException($"Unknown outbox event type '{outboxEvent.EventType}'.");
-                }
-
-                outboxEvent.ProcessedAt = _clock.GetCurrentInstant();
-                outboxEvent.LastError = null;
-                _metrics.RecordSyncOperation("success");
-
-                // Only mark user as Valid when the event actually touched Google APIs
-                // (AddUserToTeamResources with linked resources). RemoveUserFromTeamResources
-                // is a no-op, and Add with zero resources doesn't validate the email.
-                if (string.Equals(outboxEvent.EventType, GoogleSyncOutboxEventTypes.AddUserToTeamResources, StringComparison.Ordinal))
-                {
-                    var hasResources = await _dbContext.GoogleResources
-                        .AnyAsync(r => r.TeamId == outboxEvent.TeamId && r.IsActive, cancellationToken);
-                    if (hasResources)
+                    switch (outboxEvent.EventType)
                     {
-                        await MarkUserGoogleEmailStatusAsync(outboxEvent.UserId, GoogleEmailStatus.Valid, cancellationToken);
+                        case GoogleSyncOutboxEventTypes.AddUserToTeamResources:
+                            await _googleSyncService.AddUserToTeamResourcesAsync(
+                                outboxEvent.TeamId,
+                                outboxEvent.UserId,
+                                cancellationToken);
+                            break;
+
+                        case GoogleSyncOutboxEventTypes.RemoveUserFromTeamResources:
+                            await _googleSyncService.RemoveUserFromTeamResourcesAsync(
+                                outboxEvent.TeamId,
+                                outboxEvent.UserId,
+                                cancellationToken);
+                            break;
+
+                        default:
+                            throw new InvalidOperationException($"Unknown outbox event type '{outboxEvent.EventType}'.");
                     }
+
+                    outboxEvent.ProcessedAt = _clock.GetCurrentInstant();
+                    outboxEvent.LastError = null;
+                    _metrics.RecordSyncOperation("success");
+
+                    // Only mark user as Valid when the event actually touched Google APIs
+                    // (AddUserToTeamResources with linked resources). RemoveUserFromTeamResources
+                    // is a no-op, and Add with zero resources doesn't validate the email.
+                    if (string.Equals(outboxEvent.EventType, GoogleSyncOutboxEventTypes.AddUserToTeamResources, StringComparison.Ordinal))
+                    {
+                        var hasResources = await _dbContext.GoogleResources
+                            .AnyAsync(r => r.TeamId == outboxEvent.TeamId && r.IsActive, cancellationToken);
+                        if (hasResources)
+                        {
+                            await MarkUserGoogleEmailStatusAsync(outboxEvent.UserId, GoogleEmailStatus.Valid, cancellationToken);
+                        }
+                    }
+
+                    await _dbContext.SaveChangesAsync(cancellationToken);
                 }
-
-                await _dbContext.SaveChangesAsync(cancellationToken);
-            }
-            catch (Google.GoogleApiException ex) when (IsPermanentError(ex))
-            {
-                _metrics.RecordSyncOperation("permanent_failure");
-                outboxEvent.FailedPermanently = true;
-                outboxEvent.ProcessedAt = _clock.GetCurrentInstant();
-                outboxEvent.LastError = ex.Message.Length > 4000
-                    ? ex.Message[..4000]
-                    : ex.Message;
-
-                _logger.LogWarning(
-                    ex,
-                    "Permanent failure processing Google sync outbox event {OutboxId} ({EventType}) for user {UserEmail} in team {TeamName} — HTTP {StatusCode}, not retrying",
-                    outboxEvent.Id,
-                    outboxEvent.EventType,
-                    userEmailLookup.GetValueOrDefault(outboxEvent.UserId, "unknown"),
-                    teamNameLookup.GetValueOrDefault(outboxEvent.TeamId, outboxEvent.TeamId.ToString()),
-                    ex.Error?.Code);
-
-                // Mark user's Google email as Rejected
-                await MarkUserGoogleEmailStatusAsync(outboxEvent.UserId, GoogleEmailStatus.Rejected, cancellationToken);
-
-                await _dbContext.SaveChangesAsync(cancellationToken);
-            }
-            catch (Exception ex)
-            {
-                _metrics.RecordSyncOperation("failure");
-                outboxEvent.RetryCount += 1;
-                outboxEvent.LastError = ex.Message.Length > 4000
-                    ? ex.Message[..4000]
-                    : ex.Message;
-
-                _logger.LogError(
-                    ex,
-                    "Failed processing Google sync outbox event {OutboxId} ({EventType}) for user {UserEmail} in team {TeamName} — attempt {Attempt}/{MaxRetries}",
-                    outboxEvent.Id,
-                    outboxEvent.EventType,
-                    userEmailLookup.GetValueOrDefault(outboxEvent.UserId, "unknown"),
-                    teamNameLookup.GetValueOrDefault(outboxEvent.TeamId, outboxEvent.TeamId.ToString()),
-                    outboxEvent.RetryCount,
-                    MaxRetryCount);
-
-                // Mark as permanently failed when retries are exhausted
-                if (outboxEvent.RetryCount >= MaxRetryCount)
+                catch (Google.GoogleApiException ex) when (IsPermanentError(ex))
                 {
+                    _metrics.RecordSyncOperation("permanent_failure");
                     outboxEvent.FailedPermanently = true;
                     outboxEvent.ProcessedAt = _clock.GetCurrentInstant();
+                    outboxEvent.LastError = ex.Message.Length > 4000
+                        ? ex.Message[..4000]
+                        : ex.Message;
+
+                    _logger.LogWarning(
+                        ex,
+                        "Permanent failure processing Google sync outbox event {OutboxId} ({EventType}) for user {UserEmail} in team {TeamName} — HTTP {StatusCode}, not retrying",
+                        outboxEvent.Id,
+                        outboxEvent.EventType,
+                        userEmailLookup.GetValueOrDefault(outboxEvent.UserId, "unknown"),
+                        teamNameLookup.GetValueOrDefault(outboxEvent.TeamId, outboxEvent.TeamId.ToString()),
+                        ex.Error?.Code);
+
+                    // Mark user's Google email as Rejected
+                    await MarkUserGoogleEmailStatusAsync(outboxEvent.UserId, GoogleEmailStatus.Rejected, cancellationToken);
+
+                    await _dbContext.SaveChangesAsync(cancellationToken);
                 }
-
-                await _dbContext.SaveChangesAsync(cancellationToken);
-
-                // Notify admins on final failure (exhausted retries)
-                if (outboxEvent.RetryCount >= MaxRetryCount)
+                catch (Exception ex)
                 {
-                    try
+                    _metrics.RecordSyncOperation("failure");
+                    outboxEvent.RetryCount += 1;
+                    outboxEvent.LastError = ex.Message.Length > 4000
+                        ? ex.Message[..4000]
+                        : ex.Message;
+
+                    _logger.LogError(
+                        ex,
+                        "Failed processing Google sync outbox event {OutboxId} ({EventType}) for user {UserEmail} in team {TeamName} — attempt {Attempt}/{MaxRetries}",
+                        outboxEvent.Id,
+                        outboxEvent.EventType,
+                        userEmailLookup.GetValueOrDefault(outboxEvent.UserId, "unknown"),
+                        teamNameLookup.GetValueOrDefault(outboxEvent.TeamId, outboxEvent.TeamId.ToString()),
+                        outboxEvent.RetryCount,
+                        MaxRetryCount);
+
+                    // Mark as permanently failed when retries are exhausted
+                    if (outboxEvent.RetryCount >= MaxRetryCount)
                     {
-                        await _notificationService.SendToRoleAsync(
-                            NotificationSource.SyncError,
-                            NotificationClass.Actionable,
-                            NotificationPriority.High,
-                            "Google sync event failed after all retries",
-                            RoleNames.Admin,
-                            body: $"Event {outboxEvent.EventType} for team {outboxEvent.TeamId} failed: {outboxEvent.LastError?[..Math.Min(200, outboxEvent.LastError.Length)]}",
-                            actionUrl: "/Google/SyncOutbox",
-                            actionLabel: "View \u2192",
-                            cancellationToken: cancellationToken);
+                        outboxEvent.FailedPermanently = true;
+                        outboxEvent.ProcessedAt = _clock.GetCurrentInstant();
                     }
-                    catch (Exception notifEx)
+
+                    await _dbContext.SaveChangesAsync(cancellationToken);
+
+                    // Notify admins on final failure (exhausted retries)
+                    if (outboxEvent.RetryCount >= MaxRetryCount)
                     {
-                        _logger.LogError(notifEx,
-                            "Failed to dispatch SyncError notification for outbox event {OutboxId}",
-                            outboxEvent.Id);
+                        try
+                        {
+                            await _notificationService.SendToRoleAsync(
+                                NotificationSource.SyncError,
+                                NotificationClass.Actionable,
+                                NotificationPriority.High,
+                                "Google sync event failed after all retries",
+                                RoleNames.Admin,
+                                body: $"Event {outboxEvent.EventType} for team {outboxEvent.TeamId} failed: {outboxEvent.LastError?[..Math.Min(200, outboxEvent.LastError.Length)]}",
+                                actionUrl: "/Google/SyncOutbox",
+                                actionLabel: "View \u2192",
+                                cancellationToken: cancellationToken);
+                        }
+                        catch (Exception notifEx)
+                        {
+                            _logger.LogError(notifEx,
+                                "Failed to dispatch SyncError notification for outbox event {OutboxId}",
+                                outboxEvent.Id);
+                        }
                     }
                 }
             }
+
+            _metrics.RecordJobRun("process_google_sync_outbox", "success");
         }
-        _metrics.RecordJobRun("process_google_sync_outbox", "success");
+        catch (Exception ex)
+        {
+            _metrics.RecordJobRun("process_google_sync_outbox", "failure");
+            _logger.LogError(ex, "Error processing Google sync outbox");
+            throw;
+        }
     }
 
     private static bool IsPermanentError(Google.GoogleApiException ex)

--- a/src/Humans.Infrastructure/Jobs/SuspendNonCompliantMembersJob.cs
+++ b/src/Humans.Infrastructure/Jobs/SuspendNonCompliantMembersJob.cs
@@ -177,6 +177,8 @@ public class SuspendNonCompliantMembersJob : IRecurringJob
                 {
                     _profileService.UpdateProfileCache(userId, null);
                     _cache.InvalidateUserProfile(userId);
+                    _cache.InvalidateRoleAssignmentClaims(userId);
+                    _cache.InvalidateShiftAuthorization(userId);
                     _teamService.RemoveMemberFromAllTeamsCache(userId);
                 }
             }

--- a/src/Humans.Infrastructure/Services/ApplicationDecisionService.cs
+++ b/src/Humans.Infrastructure/Services/ApplicationDecisionService.cs
@@ -100,6 +100,7 @@ public class ApplicationDecisionService : IApplicationDecisionService
 
         _cache.InvalidateNavBadgeCounts();
         _cache.InvalidateNotificationMeters();
+        _cache.InvalidateUserProfile(application.UserId);
         foreach (var id in voterIds)
             _cache.InvalidateVotingBadge(id);
         _metrics.RecordApplicationProcessed("approved");

--- a/src/Humans.Web/Authorization/RoleAssignmentClaimsTransformation.cs
+++ b/src/Humans.Web/Authorization/RoleAssignmentClaimsTransformation.cs
@@ -90,6 +90,12 @@ public class RoleAssignmentClaimsTransformation : IClaimsTransformation
         var now = _clock.GetCurrentInstant();
         var claims = new List<Claim>();
 
+        // Check suspension status — suspended users lose ActiveMember claim
+        // but keep role claims (Admin/Board) so they can manage their own unsuspension
+        var isSuspended = await dbContext.Profiles
+            .AsNoTracking()
+            .AnyAsync(p => p.UserId == userId && p.IsSuspended);
+
         var activeRoles = await dbContext.RoleAssignments
             .AsNoTracking()
             .Where(ra =>
@@ -105,16 +111,19 @@ public class RoleAssignmentClaimsTransformation : IClaimsTransformation
             claims.Add(new Claim(ClaimTypes.Role, role));
         }
 
-        var isVolunteerMember = await dbContext.TeamMembers
-            .AsNoTracking()
-            .AnyAsync(tm =>
-                tm.UserId == userId &&
-                tm.TeamId == SystemTeamIds.Volunteers &&
-                !tm.LeftAt.HasValue);
-
-        if (isVolunteerMember)
+        if (!isSuspended)
         {
-            claims.Add(new Claim(ActiveMemberClaimType, ActiveClaimValue));
+            var isVolunteerMember = await dbContext.TeamMembers
+                .AsNoTracking()
+                .AnyAsync(tm =>
+                    tm.UserId == userId &&
+                    tm.TeamId == SystemTeamIds.Volunteers &&
+                    !tm.LeftAt.HasValue);
+
+            if (isVolunteerMember)
+            {
+                claims.Add(new Claim(ActiveMemberClaimType, ActiveClaimValue));
+            }
         }
 
         var hasProfile = await dbContext.Profiles

--- a/src/Humans.Web/Controllers/GoogleController.cs
+++ b/src/Humans.Web/Controllers/GoogleController.cs
@@ -729,6 +729,9 @@ public class GoogleController : HumansControllerBase
         var googleEmailLookup = await dbContext.Users
             .Where(u => userIds.Contains(u.Id))
             .ToDictionaryAsync(u => u.Id, u => u.GetGoogleServiceEmail() ?? "unknown");
+        var displayNameLookup = await dbContext.Users
+            .Where(u => userIds.Contains(u.Id))
+            .ToDictionaryAsync(u => u.Id, u => u.DisplayName);
         var teamLookup = await dbContext.Teams
             .Where(t => teamIds.Contains(t.Id))
             .ToDictionaryAsync(t => t.Id, t => t.Name);
@@ -740,6 +743,7 @@ public class GoogleController : HumansControllerBase
                 g => g.Select(r => $"{r.Name} ({r.ResourceType})").ToList());
 
         ViewBag.GoogleEmailLookup = googleEmailLookup;
+        ViewBag.DisplayNameLookup = displayNameLookup;
         ViewBag.TeamLookup = teamLookup;
         ViewBag.ResourceLookup = resourceLookup;
         return View(events);

--- a/src/Humans.Web/Views/Google/_SyncOutboxTable.cshtml
+++ b/src/Humans.Web/Views/Google/_SyncOutboxTable.cshtml
@@ -2,6 +2,7 @@
 @model IList<Humans.Domain.Entities.GoogleSyncOutboxEvent>
 @{
     var googleEmailLookup = (Dictionary<Guid, string>)ViewData["GoogleEmailLookup"]!;
+    var displayNameLookup = (Dictionary<Guid, string>)ViewData["DisplayNameLookup"]!;
     var teamLookup = (Dictionary<Guid, string>)ViewData["TeamLookup"]!;
     var resourceLookup = (Dictionary<Guid, List<string>>)ViewData["ResourceLookup"]!;
     var showError = (bool)ViewData["ShowError"]!;
@@ -39,7 +40,8 @@ else
                     <tr>
                         <td><code>@evt.EventType</code></td>
                         <td>
-                            <human-link user-id="@evt.UserId" admin="true" show-popover="true" />
+                            <human-link user-id="@evt.UserId" admin="true" show-popover="true"
+                                        display-name="@displayNameLookup.GetValueOrDefault(evt.UserId, "Unknown")" />
                         </td>
                         <td><small class="text-muted">@googleEmail</small></td>
                         <td>@teamName</td>

--- a/src/Humans.Web/Views/Home/Dashboard.cshtml
+++ b/src/Humans.Web/Views/Home/Dashboard.cshtml
@@ -67,7 +67,7 @@
                         </ul>
                     </div>
                     <div class="card-footer">
-                        <a asp-controller="Shifts" asp-action="Index" class="btn btn-sm btn-outline-success">Browse Volunteer Options</a>
+                        <a asp-controller="Shifts" asp-action="Index" class="btn btn-sm btn-outline-success">Browse Shift Options</a>
                     </div>
                 </div>
             }

--- a/src/Humans.Web/Views/Unsubscribe/Done.cshtml
+++ b/src/Humans.Web/Views/Unsubscribe/Done.cshtml
@@ -8,8 +8,7 @@
 <p>You will no longer receive @categoryName emails from Humans.</p>
 
 <p>
-    You can manage all your communication preferences from your
-    <a asp-controller="Account" asp-action="Login">communication preferences</a>.
+    <a asp-controller="Account" asp-action="Login">Sign in to manage your communication preferences</a>.
 </p>
 
 <p><a asp-controller="Home" asp-action="Index">Back to home</a></p>


### PR DESCRIPTION
## Summary

Fixes found during PR #465 production promotion review:

- **Cache invalidation gaps**: `ApplicationDecisionService.ApproveAsync` missing `InvalidateUserProfile` after tier change; `SuspendNonCompliantMembersJob` missing `InvalidateRoleAssignmentClaims`/`InvalidateShiftAuthorization` (suspended users retained auth claims for 60s); `ProcessAccountDeletionsJob` missing `InvalidateUserProfile` (stale display data for 2min after anonymization)
- **Job error handling**: `ProcessGoogleSyncOutboxJob`, `CleanupEmailOutboxJob`, `CleanupNotificationsJob` missing outer try-catch — no failure metrics recorded on DB-level errors
- **UI fixes**: Unsubscribe/Done link said "communication preferences" but routed to Login; Dashboard used prohibited "Volunteer" term
- **SyncOutbox display names**: Pass `display-name` from DB lookup so deleted/suspended users show their name instead of "Unknown"

## Test plan
- [x] `dotnet build` — clean
- [x] `dotnet test` — 1002 passed
- [x] `dotnet format --verify-no-changes` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)