### PR TITLE
Fix access matrix documentation to match actual auth behavior

### DIFF
--- a/src/Humans.Web/Models/AccessMatrixDefinitions.cs
+++ b/src/Humans.Web/Models/AccessMatrixDefinitions.cs
@@ -48,9 +48,10 @@ public static class AccessMatrixDefinitions
             [
                 Feature("View teams & join", "Volunteer", A, "Coordinator", A, "Board", A, "TeamsAdmin", A),
                 Feature("View team details", "Volunteer", A, "Coordinator", A, "Board", A, "TeamsAdmin", A),
-                Feature("Manage members", "Volunteer", D, "Coordinator", A, "Board", D, "TeamsAdmin", A),
-                Feature("Manage roles", "Volunteer", D, "Coordinator", A, "Board", D, "TeamsAdmin", A),
-                Feature("Create/delete teams", "Volunteer", D, "Coordinator", D, "Board", A, "TeamsAdmin", A),
+                Feature("Manage members", "Volunteer", D, "Coordinator", A, "Board", A, "TeamsAdmin", A),
+                Feature("Manage roles", "Volunteer", D, "Coordinator", A, "Board", A, "TeamsAdmin", A),
+                Feature("Create teams", "Volunteer", D, "Coordinator", D, "Board", A, "TeamsAdmin", A),
+                Feature("Delete teams", "Volunteer", D, "Coordinator", D, "Board", A, "TeamsAdmin", D),
                 Feature("Google resource sync", "Volunteer", D, "Coordinator", D, "Board", D, "TeamsAdmin", L),
             ]
         },
@@ -115,21 +116,21 @@ public static class AccessMatrixDefinitions
             [
                 Feature("View tickets & orders", "Board", A, "TicketAdmin", A),
                 Feature("Sync operations", "Board", D, "TicketAdmin", A),
-                Feature("Discount codes", "Board", D, "TicketAdmin", A),
+                Feature("Discount codes", "Board", A, "TicketAdmin", A),
             ]
         },
 
         ["Profile"] = new AccessMatrixData
         {
             SectionName = "Profile",
-            Roles = ["Volunteer", "Coordinator", "Board", "Admin"],
+            Roles = ["Volunteer", "Coordinator", "Board", "HumanAdmin", "Admin"],
             Features =
             [
-                Feature("View own profile", "Volunteer", A, "Coordinator", A, "Board", A, "Admin", A),
-                Feature("Edit own profile", "Volunteer", A, "Coordinator", A, "Board", A, "Admin", A),
-                Feature("View other profiles", "Volunteer", L, "Coordinator", A, "Board", A, "Admin", A),
-                Feature("View contact fields", "Volunteer", L, "Coordinator", L, "Board", A, "Admin", A),
-                Feature("Admin view of profile", "Volunteer", D, "Coordinator", D, "Board", A, "Admin", A),
+                Feature("View own profile", "Volunteer", A, "Coordinator", A, "Board", A, "HumanAdmin", A, "Admin", A),
+                Feature("Edit own profile", "Volunteer", A, "Coordinator", A, "Board", A, "HumanAdmin", A, "Admin", A),
+                Feature("View other profiles", "Volunteer", L, "Coordinator", A, "Board", A, "HumanAdmin", A, "Admin", A),
+                Feature("View contact fields", "Volunteer", L, "Coordinator", L, "Board", A, "HumanAdmin", A, "Admin", A),
+                Feature("Admin view of profile", "Volunteer", D, "Coordinator", D, "Board", A, "HumanAdmin", A, "Admin", A),
             ]
         },
 


### PR DESCRIPTION
## Summary
- Split "Create/delete teams" into separate rows: TeamsAdmin can create teams (`TeamsAdminBoardOrAdmin` policy) but cannot delete them (`BoardOrAdmin` policy)
- Fix Board access level from Denied to Allowed for "Manage members" and "Manage roles" in Teams section (`TeamAuthorizationHandler` uses `IsTeamsAdminBoardOrAdmin` which includes Board)
- Fix Board access level from Denied to Allowed for "Discount codes" in Tickets section (controller-level `TicketAdminBoardOrAdmin` policy includes Board)
- Add HumanAdmin role to Profile section with appropriate access levels (`AdminList`/`AdminDetail` actions use `HumanAdminBoardOrAdmin` policy)

## Test plan
- [ ] Verify build passes
- [ ] Access matrix page renders correctly with new rows and roles
- [ ] No controller code was changed -- documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)