### PR TITLE
Add i18n for user-facing views

### DIFF
--- a/src/Humans.Web/Resources/SharedResource.ca.resx
+++ b/src/Humans.Web/Resources/SharedResource.ca.resx
@@ -810,6 +810,7 @@
   <data name="AdminAddRole_BoardDesc" xml:space="preserve"><value>Permisos de membre de la junta</value></data>
   <data name="AdminAddRole_TeamsAdminDesc" xml:space="preserve"><value>Gestionar tots els equips i pertinences</value></data>
   <data name="AdminAddRole_ConsentCoordinatorDesc" xml:space="preserve"><value>Verificacions de seguretat durant la incorporació</value></data>
+  <data name="AdminAddRole_CampAdminDesc" xml:space="preserve"><value>Gestionar el mapa del camp i les fases de col·locació</value></data>
   <data name="AdminAddRole_VolunteerCoordinatorDesc" xml:space="preserve"><value>Facilitació de la incorporació, gestió de torns global</value></data>
   <data name="AdminAddRole_NoInfoAdminDesc" xml:space="preserve"><value>Aprovar inscripcions en torns, veure dades mèdiques de voluntaris</value></data>
   <data name="AdminAddRole_NotesLabel" xml:space="preserve"><value>Notes (opcional)</value></data>
@@ -1321,41 +1322,41 @@
   <data name="Notification_Bell_AriaLabel" xml:space="preserve"><value>Notificacions</value></data>
   <data name="Notification_Popup_AriaLabel" xml:space="preserve"><value>Finestra de notificacions</value></data>
   <data name="Notification_Popup_Title" xml:space="preserve"><value>Notificacions</value></data>
-  <data name="Notification_Popup_NeedAction" xml:space="preserve"><value>cal acció</value></data>
-  <data name="Notification_Popup_Close" xml:space="preserve"><value>Tanca les notificacions</value></data>
-  <data name="Notification_Popup_CaughtUp" xml:space="preserve"><value>Ja ho tens tot al dia.</value></data>
+  <data name="Notification_Popup_NeedAction" xml:space="preserve"><value>requereixen acció</value></data>
+  <data name="Notification_Popup_Close" xml:space="preserve"><value>Tancar notificacions</value></data>
+  <data name="Notification_Popup_CaughtUp" xml:space="preserve"><value>Estàs al dia.</value></data>
   <data name="Notification_Popup_NoUnread" xml:space="preserve"><value>No hi ha notificacions sense llegir.</value></data>
-  <data name="Notification_Section_NeedsAttention" xml:space="preserve"><value>Necessita la teva atenció</value></data>
+  <data name="Notification_Section_NeedsAttention" xml:space="preserve"><value>Requereix la teva atenció</value></data>
   <data name="Notification_Section_Recent" xml:space="preserve"><value>Recents</value></data>
-  <data name="Notification_Section_Informational" xml:space="preserve"><value>Informativa</value></data>
-  <data name="Notification_Section_Resolved" xml:space="preserve"><value>Resolt</value></data>
+  <data name="Notification_Section_Informational" xml:space="preserve"><value>Informatius</value></data>
+  <data name="Notification_Section_Resolved" xml:space="preserve"><value>Resolts</value></data>
   <data name="Notification_Section_WorkQueues" xml:space="preserve"><value>Cues de treball</value></data>
-  <data name="Notification_MarkAllRead" xml:space="preserve"><value>Marca-ho tot com a llegit</value></data>
+  <data name="Notification_MarkAllRead" xml:space="preserve"><value>Marcar tot com a llegit</value></data>
   <data name="Notification_SeeAll" xml:space="preserve"><value>Veure totes les notificacions</value></data>
   <data name="Notification_PageTitle" xml:space="preserve"><value>Totes les notificacions</value></data>
-  <data name="Notification_SearchPlaceholder" xml:space="preserve"><value>Cerca notificacions...</value></data>
+  <data name="Notification_SearchPlaceholder" xml:space="preserve"><value>Cercar notificacions...</value></data>
   <data name="Notification_Filter_All" xml:space="preserve"><value>Totes</value></data>
-  <data name="Notification_Filter_NeedsAction" xml:space="preserve"><value>Cal acció</value></data>
+  <data name="Notification_Filter_NeedsAction" xml:space="preserve"><value>Requereix acció</value></data>
   <data name="Notification_Filter_Shifts" xml:space="preserve"><value>Torns</value></data>
   <data name="Notification_Filter_Approvals" xml:space="preserve"><value>Aprovacions</value></data>
-  <data name="Notification_Filter_Resolved" xml:space="preserve"><value>Resolt</value></data>
+  <data name="Notification_Filter_Resolved" xml:space="preserve"><value>Resolts</value></data>
   <data name="Notification_Tab_Unread" xml:space="preserve"><value>Sense llegir</value></data>
   <data name="Notification_Tab_All" xml:space="preserve"><value>Totes</value></data>
   <data name="Notification_Inbox_Title" xml:space="preserve"><value>Notificacions</value></data>
   <data name="Notification_Tag_Urgent" xml:space="preserve"><value>Urgent</value></data>
   <data name="Notification_Tag_Action" xml:space="preserve"><value>Acció</value></data>
   <data name="Notification_Tag_Info" xml:space="preserve"><value>Info</value></data>
-  <data name="Notification_Dismiss" xml:space="preserve"><value>Descarta</value></data>
+  <data name="Notification_Dismiss" xml:space="preserve"><value>Descartar</value></data>
   <data name="Notification_HandledBy" xml:space="preserve"><value>Gestionat per {0}, {1}</value></data>
-  <data name="Notification_Pref_InboxEnabled" xml:space="preserve"><value>Notificacions dins de l’app</value></data>
+  <data name="Notification_Pref_InboxEnabled" xml:space="preserve"><value>Notificacions dins l'aplicació</value></data>
   <data name="Notification_DefaultActionLabel" xml:space="preserve"><value>Veure →</value></data>
   <data name="Notification_TimeAgo_JustNow" xml:space="preserve"><value>ara mateix</value></data>
-  <data name="Notification_TimeAgo_Minutes" xml:space="preserve"><value>fa {0} min</value></data>
-  <data name="Notification_TimeAgo_Hours" xml:space="preserve"><value>fa {0} h</value></data>
-  <data name="Notification_TimeAgo_Days" xml:space="preserve"><value>fa {0} d</value></data>
-  <data name="Notification_Bulk_Selected" xml:space="preserve"><value>{0} seleccionades</value></data>
-  <data name="Notification_Bulk_Resolve" xml:space="preserve"><value>Resol les seleccionades</value></data>
-  <data name="Notification_Bulk_Dismiss" xml:space="preserve"><value>Descarta les seleccionades</value></data>
+  <data name="Notification_TimeAgo_Minutes" xml:space="preserve"><value>fa {0}m</value></data>
+  <data name="Notification_TimeAgo_Hours" xml:space="preserve"><value>fa {0}h</value></data>
+  <data name="Notification_TimeAgo_Days" xml:space="preserve"><value>fa {0}d</value></data>
+  <data name="Notification_Bulk_Selected" xml:space="preserve"><value>{0} seleccionats</value></data>
+  <data name="Notification_Bulk_Resolve" xml:space="preserve"><value>Resoldre seleccionats</value></data>
+  <data name="Notification_Bulk_Dismiss" xml:space="preserve"><value>Descartar seleccionats</value></data>
 
   <!-- Get Involved card (Dashboard) -->
   <data name="GetInvolved_Title" xml:space="preserve"><value>Participa</value></data>
@@ -1434,5 +1435,257 @@
   <data name="CityPlanning_Help_OverlapsDiscordChannel" xml:space="preserve"><value>Discord #city-planning</value></data>
   <data name="CityPlanning_Help_ColorsTitle" xml:space="preserve"><value>Colors &amp; zones sonores</value></data>
   <data name="CityPlanning_Help_ColorsBody" xml:space="preserve"><value>Cada barrio està acolorit segons la seva zona sonora preferida (editable des de la pàgina del barrio).</value></data>
+
+
+  <!-- ======================== -->
+  <!-- User-Facing Views        -->
+  <!-- ======================== -->
+  <data name="Feedback_PageTitle" xml:space="preserve"><value>Comentaris</value></data>
+  <data name="Feedback_AllStatuses" xml:space="preserve"><value>Tots els estats</value></data>
+  <data name="Feedback_AllCategories" xml:space="preserve"><value>Totes les categories</value></data>
+  <data name="Feedback_AllReporters" xml:space="preserve"><value>Tots els informants</value></data>
+  <data name="Feedback_AllAssignees" xml:space="preserve"><value>Tots els assignats</value></data>
+  <data name="Feedback_AssignedToMe" xml:space="preserve"><value>Assignat a mi</value></data>
+  <data name="Feedback_AllTeams" xml:space="preserve"><value>Tots els equips</value></data>
+  <data name="Feedback_UnassignedOnly" xml:space="preserve"><value>Només sense assignar</value></data>
+  <data name="Feedback_Clear" xml:space="preserve"><value>Netejar</value></data>
+  <data name="Feedback_NoReports" xml:space="preserve"><value>No s'han trobat informes de comentaris.</value></data>
+  <data name="Feedback_Unassigned" xml:space="preserve"><value>Sense assignar</value></data>
+  <data name="Feedback_NeedsReply" xml:space="preserve"><value>necessita resposta</value></data>
+  <data name="Feedback_SelectReport" xml:space="preserve"><value>Selecciona un informe per veure els detalls</value></data>
+  <data name="Feedback_Conversation" xml:space="preserve"><value>Conversa</value></data>
+  <data name="Feedback_NoMessages" xml:space="preserve"><value>Encara no hi ha missatges.</value></data>
+  <data name="Feedback_MessagePlaceholder" xml:space="preserve"><value>Escriu un missatge...</value></data>
+  <data name="Feedback_Send" xml:space="preserve"><value>Envia</value></data>
+  <data name="Feedback_ResolvedAt" xml:space="preserve"><value>Resolt {0}</value><comment>{0} = date/time</comment></data>
+  <data name="Feedback_ResolvedBy" xml:space="preserve"><value>per {0}</value><comment>{0} = name</comment></data>
+  <data name="Feedback_NoTeam" xml:space="preserve"><value>Sense equip</value></data>
+  <data name="Feedback_ScreenshotLink" xml:space="preserve"><value>Captura de pantalla</value></data>
+
+  <data name="Unsub_Title" xml:space="preserve"><value>Donar-se de baixa dels correus</value></data>
+  <data name="Unsub_Heading" xml:space="preserve"><value>Donar-se de baixa dels correus {0}?</value><comment>{0} = category name</comment></data>
+  <data name="Unsub_Greeting" xml:space="preserve"><value>Hola {0},</value><comment>{0} = display name</comment></data>
+  <data name="Unsub_ConfirmMessage" xml:space="preserve"><value>Si confirmes, deixaràs de rebre correus de {0} de Humans.</value><comment>{0} = category name</comment></data>
+  <data name="Unsub_ConfirmButton" xml:space="preserve"><value>Confirmar baixa</value></data>
+  <data name="Unsub_DoneTitle" xml:space="preserve"><value>T'has donat de baixa</value></data>
+  <data name="Unsub_DoneMessage" xml:space="preserve"><value>Ja no rebràs correus de {0} de Humans.</value><comment>{0} = category name</comment></data>
+  <data name="Unsub_DoneManage" xml:space="preserve"><value>Pots gestionar les teves preferències de comunicació des de les teves</value></data>
+  <data name="Unsub_DoneManageLink" xml:space="preserve"><value>preferències de comunicació</value></data>
+  <data name="Unsub_BackHome" xml:space="preserve"><value>Tornar a l'inici</value></data>
+  <data name="Unsub_ExpiredTitle" xml:space="preserve"><value>Enllaç de baixa caducat</value></data>
+  <data name="Unsub_ExpiredHeading" xml:space="preserve"><value>Aquest enllaç de baixa ha caducat</value></data>
+  <data name="Unsub_ExpiredMessage" xml:space="preserve"><value>Fes servir l'enllaç d'un correu més recent, o</value></data>
+  <data name="Unsub_ExpiredSignIn" xml:space="preserve"><value>inicia sessió per gestionar les teves preferències de comunicació</value></data>
+
+  <data name="CommPrefs_Title" xml:space="preserve"><value>Preferències de comunicació</value></data>
+  <data name="CommPrefs_Description" xml:space="preserve"><value>Tria quines comunicacions reps i com.</value></data>
+  <data name="CommPrefs_Category" xml:space="preserve"><value>Categoria</value></data>
+  <data name="CommPrefs_Email" xml:space="preserve"><value>Correu</value></data>
+  <data name="CommPrefs_Alert" xml:space="preserve"><value>Alerta</value></data>
+  <data name="CommPrefs_BackToProfile" xml:space="preserve"><value>Tornar al perfil</value></data>
+  <data name="CommPrefs_BackToDashboard" xml:space="preserve"><value>Tornar al tauler</value></data>
+
+  <data name="Emails_Header_Email" xml:space="preserve"><value>Correu</value></data>
+  <data name="Emails_Header_Status" xml:space="preserve"><value>Estat</value></data>
+  <data name="Emails_Header_Notifications" xml:space="preserve"><value>Notificacions</value></data>
+  <data name="Emails_Header_Visibility" xml:space="preserve"><value>Visibilitat del perfil</value></data>
+  <data name="Emails_SignIn" xml:space="preserve"><value>Inici de sessió</value></data>
+  <data name="Emails_MergePending" xml:space="preserve"><value>Fusió pendent</value></data>
+  <data name="Emails_Verified" xml:space="preserve"><value>Verificat</value></data>
+  <data name="Emails_StatusPending" xml:space="preserve"><value>Pendent</value></data>
+  <data name="Emails_Unverified" xml:space="preserve"><value>No verificat</value></data>
+  <data name="Emails_NotifActive" xml:space="preserve"><value>Actiu</value></data>
+  <data name="Emails_SetAsTarget" xml:space="preserve"><value>Establir com a destinatari</value></data>
+  <data name="Emails_VerifyFirst" xml:space="preserve"><value>Verifica primer</value></data>
+  <data name="Emails_Visibility_Hidden" xml:space="preserve"><value>Ocult</value></data>
+  <data name="Emails_Visibility_AllHumans" xml:space="preserve"><value>Tots els humans</value></data>
+  <data name="Emails_Visibility_MyTeams" xml:space="preserve"><value>Els meus equips</value></data>
+  <data name="Emails_Visibility_CoordinatorsBoard" xml:space="preserve"><value>Coordinadors + Junta</value></data>
+  <data name="Emails_Visibility_BoardOnly" xml:space="preserve"><value>Només junta</value></data>
+  <data name="Emails_ConfirmRemove" xml:space="preserve"><value>Segur que vols eliminar aquest correu?</value></data>
+  <data name="Emails_GoogleTitle" xml:space="preserve"><value>Correu de serveis de Google</value></data>
+  <data name="Emails_GoogleDescription" xml:space="preserve"><value>Aquest correu s'utilitza per a Grups de Google i unitats compartides.</value></data>
+  <data name="Emails_GoogleAutoNobodies" xml:space="preserve"><value>El teu correu @nobodies.team s'utilitza automàticament.</value></data>
+  <data name="Emails_GoogleRejected" xml:space="preserve"><value>La sincronització de Google ha fallat. El correu actual ha estat rebutjat per Google. Selecciona un altre correu.</value></data>
+  <data name="Emails_GoogleValid" xml:space="preserve"><value>La sincronització de Google funciona amb el correu actual.</value></data>
+  <data name="Emails_AutoSelected" xml:space="preserve"><value>Seleccionat automàticament</value></data>
+  <data name="Emails_GoogleRejectedBadge" xml:space="preserve"><value>Rebutjat</value></data>
+  <data name="Emails_UseThis" xml:space="preserve"><value>Usar aquest</value></data>
+
+  <data name="ShiftInfo_Title" xml:space="preserve"><value>Preferències de torns</value></data>
+  <data name="ShiftInfo_StepOf" xml:space="preserve"><value>Pas {0} de {1}</value><comment>{0} = current step, {1} = total steps</comment></data>
+  <data name="ShiftInfo_SkillsTitle" xml:space="preserve"><value>En què ets bo/bona?</value></data>
+  <data name="ShiftInfo_SkillsSubtitle" xml:space="preserve"><value>Selecciona les habilitats que t'agradaria fer servir. Les pots canviar en qualsevol moment.</value></data>
+  <data name="ShiftInfo_WorkStyleTitle" xml:space="preserve"><value>Com t'agrada treballar?</value></data>
+  <data name="ShiftInfo_WorkStyleSubtitle" xml:space="preserve"><value>Ajuda als coordinadors a assignar-te torns que s'adaptin al teu estil i disponibilitat.</value></data>
+  <data name="ShiftInfo_LanguagesTitle" xml:space="preserve"><value>Quins idiomes parles?</value></data>
+  <data name="ShiftInfo_LanguagesSubtitle" xml:space="preserve"><value>Això ens ajuda a ubicar-te en equips on puguis comunicar-te bé.</value></data>
+  <data name="ShiftInfo_OtherSkills" xml:space="preserve"><value>Quines altres habilitats tens?</value></data>
+  <data name="ShiftInfo_WorkTime" xml:space="preserve"><value>Quan prefereixes treballar?</value></data>
+  <data name="ShiftInfo_OtherPrefs" xml:space="preserve"><value>Altres preferències</value></data>
+  <data name="ShiftInfo_OtherLanguages" xml:space="preserve"><value>Quins altres idiomes parles?</value></data>
+  <data name="ShiftInfo_Continue" xml:space="preserve"><value>Continuar</value></data>
+
+  <data name="Shifts_Title" xml:space="preserve"><value>Torns</value></data>
+  <data name="Shifts_BrowseTitle" xml:space="preserve"><value>Explorar opcions de voluntariat</value></data>
+  <data name="Shifts_Department" xml:space="preserve"><value>Departament</value></data>
+  <data name="Shifts_AllDepartments" xml:space="preserve"><value>Tots els departaments</value></data>
+  <data name="Shifts_From" xml:space="preserve"><value>Des de</value></data>
+  <data name="Shifts_To" xml:space="preserve"><value>Fins a</value></data>
+  <data name="Shifts_ClearFilters" xml:space="preserve"><value>Netejar filtres</value></data>
+  <data name="Shifts_All" xml:space="preserve"><value>Tots</value></data>
+  <data name="Shifts_SetUp" xml:space="preserve"><value>Muntatge</value></data>
+  <data name="Shifts_Event" xml:space="preserve"><value>Esdeveniment</value></data>
+  <data name="Shifts_Strike" xml:space="preserve"><value>Desmuntatge</value></data>
+  <data name="Shifts_FilterByTag" xml:space="preserve"><value>Filtrar per etiqueta:</value></data>
+  <data name="Shifts_SetPreferences" xml:space="preserve"><value>Configura les teves preferències</value></data>
+  <data name="Shifts_PreferencesHelp" xml:space="preserve"><value>Selecciona etiquetes que coincideixin amb el treball que t'agrada. Els torns coincidents es ressaltaran amb una estrella.</value></data>
+  <data name="Shifts_SavePreferences" xml:space="preserve"><value>Desar preferències</value></data>
+  <data name="Shifts_NotOpenYet" xml:space="preserve"><value>Els torns encara no estan oberts. Només coordinadors i administradors poden veure aquesta pàgina.</value></data>
+  <data name="Shifts_NoShiftsAvailable" xml:space="preserve"><value>Encara no hi ha torns disponibles.</value></data>
+  <data name="Shifts_AllShiftsFull" xml:space="preserve"><value>Tots els torns de {0} estan complets.</value><comment>{0} = period name</comment></data>
+  <data name="Shifts_Start" xml:space="preserve"><value>Inici</value></data>
+  <data name="Shifts_End" xml:space="preserve"><value>Fi</value></data>
+  <data name="Shifts_SignUpForDates" xml:space="preserve"><value>Inscriure's en dates de {0}</value><comment>{0} = period name (e.g. set-up, strike)</comment></data>
+  <data name="Shifts_Date" xml:space="preserve"><value>Data</value></data>
+  <data name="Shifts_Filled" xml:space="preserve"><value>Ocupats</value></data>
+  <data name="Shifts_Days" xml:space="preserve"><value>dies</value></data>
+  <data name="Shifts_Total" xml:space="preserve"><value>total</value></data>
+    <data name="Shifts_SignedUpAllDays" xml:space="preserve"><value>Inscrit (tots els {0} dies)</value><comment>{0} = count</comment></data>
+    <data name="Shifts_SignedUpPartial" xml:space="preserve"><value>Inscrit ({0} de {1})</value><comment>{0} = count</comment></data>
+  <data name="Shifts_Full" xml:space="preserve"><value>Complet</value></data>
+  <data name="Shifts_NeedsHelp" xml:space="preserve"><value>Necessita ajuda</value></data>
+  <data name="Shifts_DayNeedsHelp" xml:space="preserve"><value>{0} dia necessita ajuda</value><comment>{0} = number of days</comment></data>
+  <data name="Shifts_DaysNeedHelp" xml:space="preserve"><value>{0} dies necessiten ajuda</value><comment>{0} = number of days</comment></data>
+  <data name="Shifts_ClickToExpand" xml:space="preserve"><value>clic per expandir</value></data>
+  <data name="Shifts_Shift" xml:space="preserve"><value>Torn</value></data>
+  <data name="Shifts_Phase" xml:space="preserve"><value>Fase</value></data>
+  <data name="Shifts_Time" xml:space="preserve"><value>Hora</value></data>
+  <data name="Shifts_Duration" xml:space="preserve"><value>Durada</value></data>
+  <data name="Shifts_AllDay" xml:space="preserve"><value>Tot el dia</value></data>
+  <data name="Shifts_FullDay" xml:space="preserve"><value>Dia complet</value></data>
+  <data name="Shifts_Essential" xml:space="preserve"><value>Essencial</value></data>
+  <data name="Shifts_Important" xml:space="preserve"><value>Important</value></data>
+  <data name="Shifts_AllPhases" xml:space="preserve"><value>Totes les fases</value></data>
+  <data name="Shifts_HiddenBadge" xml:space="preserve"><value>Ocult</value></data>
+  <data name="Shifts_MatchesPrefs" xml:space="preserve"><value>Coincideix amb les teves preferències</value></data>
+  <data name="Shifts_SignUpButton" xml:space="preserve"><value>Inscriure's</value></data>
+  <data name="Shifts_BrowsingClosed" xml:space="preserve"><value>L'exploració de torns encara no està oberta. Torna més tard!</value></data>
+  <data name="Shifts_NoActiveEvent" xml:space="preserve"><value>No hi ha cap esdeveniment actiu configurat. Un administrador ha de configurar els ajustos de l'esdeveniment primer.</value></data>
+  <data name="Shifts_ConfigureEvent" xml:space="preserve"><value>Configurar ajustos de l'esdeveniment</value></data>
+  <data name="Shifts_MyShiftsTitle" xml:space="preserve"><value>Els meus torns</value></data>
+  <data name="Shifts_UpcomingShifts" xml:space="preserve"><value>Propers torns</value></data>
+  <data name="Shifts_PendingApproval" xml:space="preserve"><value>Pendent d'aprovació</value></data>
+  <data name="Shifts_Past" xml:space="preserve"><value>Passats</value></data>
+  <data name="Shifts_Bail" xml:space="preserve"><value>Cancel·lar</value></data>
+  <data name="Shifts_BailConfirm" xml:space="preserve"><value>Segur que vols cancel·lar?</value></data>
+  <data name="Shifts_BailRangeConfirm" xml:space="preserve"><value>Cancel·lar tots els {0} dies?</value><comment>{0} = number of days</comment></data>
+  <data name="Shifts_WithdrawButton" xml:space="preserve"><value>Retirar</value></data>
+  <data name="Shifts_NoSignups" xml:space="preserve"><value>Encara no t'has inscrit en cap torn.</value></data>
+  <data name="Shifts_BrowseAvailable" xml:space="preserve"><value>Explorar torns disponibles</value></data>
+  <data name="Shifts_NoActiveEventConfigured" xml:space="preserve"><value>No hi ha cap esdeveniment actiu configurat.</value></data>
+  <data name="Shifts_GeneralAvailability" xml:space="preserve"><value>Disponibilitat general</value></data>
+  <data name="Shifts_AvailabilityHelp" xml:space="preserve"><value>Marca els dies que estàs disponible per ajudar. Els coordinadors poden veure qui està disponible en assignar torns.</value></data>
+  <data name="Shifts_SaveAvailability" xml:space="preserve"><value>Desar disponibilitat</value></data>
+
+  <data name="ShiftDash_Title" xml:space="preserve"><value>Tauler de torns</value></data>
+  <data name="ShiftDash_ShiftsCount" xml:space="preserve"><value>{0} torns</value><comment>{0} = count</comment></data>
+  <data name="ShiftDash_Date" xml:space="preserve"><value>Data</value></data>
+  <data name="ShiftDash_Department" xml:space="preserve"><value>Departament</value></data>
+  <data name="ShiftDash_AllDepartments" xml:space="preserve"><value>Tots els departaments</value></data>
+  <data name="ShiftDash_Filter" xml:space="preserve"><value>Filtrar</value></data>
+  <data name="ShiftDash_Clear" xml:space="preserve"><value>Netejar</value></data>
+  <data name="ShiftDash_NoShiftsMatch" xml:space="preserve"><value>Cap torn coincideix amb els filtres actuals.</value></data>
+  <data name="ShiftDash_Shift" xml:space="preserve"><value>Torn</value></data>
+  <data name="ShiftDash_DateTime" xml:space="preserve"><value>Data / Hora</value></data>
+  <data name="ShiftDash_Slots" xml:space="preserve"><value>Places</value></data>
+  <data name="ShiftDash_Priority" xml:space="preserve"><value>Prioritat</value></data>
+  <data name="ShiftDash_Voluntell" xml:space="preserve"><value>Voluntell</value></data>
+  <data name="ShiftDash_SearchHumans" xml:space="preserve"><value>Cercar humans per a: {0}</value><comment>{0} = shift/rota name</comment></data>
+  <data name="ShiftDash_SearchPlaceholder" xml:space="preserve"><value>Escriu un nom (mín. 2 caràcters)...</value></data>
+  <data name="ShiftDash_NoHumansFound" xml:space="preserve"><value>No s'han trobat humans.</value></data>
+  <data name="ShiftDash_SearchFailed" xml:space="preserve"><value>La cerca ha fallat.</value></data>
+  <data name="ShiftDash_ScheduleConflict" xml:space="preserve"><value>Conflicte d'horari</value></data>
+
+  <data name="Nav_Legal" xml:space="preserve"><value>Legal</value></data>
+  <data name="Nav_Staff" xml:space="preserve"><value>Equip</value></data>
+
+  <data name="ProfileCard_Suspended" xml:space="preserve"><value>Suspès</value></data>
+  <data name="ProfileCard_PendingBadge" xml:space="preserve"><value>Pendent</value></data>
+  <data name="ProfileCard_Teams" xml:space="preserve"><value>Equips:</value></data>
+  <data name="ProfileCard_Joined" xml:space="preserve"><value>Unit/da el {0}</value><comment>{0} = date</comment></data>
+  <data name="ProfileCard_LastLogin" xml:space="preserve"><value>Últim accés {0}</value><comment>{0} = date</comment></data>
+
+  <data name="ShiftsSummary_Title" xml:space="preserve"><value>Torns</value></data>
+  <data name="ShiftsSummary_SlotsFilled" xml:space="preserve"><value>{0} / {1} places ocupades</value><comment>{0} = filled, {1} = total</comment></data>
+  <data name="ShiftsSummary_HumansSignedUp" xml:space="preserve"><value>{0} humans inscrits</value><comment>{0} = count</comment></data>
+  <data name="ShiftsSummary_PendingCount" xml:space="preserve"><value>{0} pendents</value><comment>{0} = count</comment></data>
+  <data name="ShiftsSummary_NoShifts" xml:space="preserve"><value>Encara no hi ha torns configurats.</value></data>
+  <data name="ShiftsSummary_IncludesSubTeams" xml:space="preserve"><value>Inclou torns de {0} subequip(s)</value><comment>{0} = count</comment></data>
+  <data name="ShiftsSummary_ManageShifts" xml:space="preserve"><value>Gestionar torns</value></data>
+
+  <data name="Medical_Badge" xml:space="preserve"><value>Mèdic</value></data>
+
+  <data name="Privacy_Lead" xml:space="preserve"><value>Humans gestiona la pertinença a Nobodies Collective i processa dades personals d'acord amb el RGPD i la llei espanyola de protecció de dades (LOPDGDD).</value></data>
+  <data name="Privacy_DataControllerTitle" xml:space="preserve"><value>Responsable del tractament</value></data>
+  <data name="Privacy_DataControllerBody" xml:space="preserve"><value>Una associació sense ànim de lucre espanyola registrada a Andalusia.</value></data>
+  <data name="Privacy_DataControllerDPO" xml:space="preserve"><value>Per a consultes sobre protecció de dades, contacta amb el nostre Delegat de Protecció de Dades a:</value></data>
+  <data name="Privacy_DataWeCollectTitle" xml:space="preserve"><value>Dades que recopilem</value></data>
+  <data name="Privacy_DataWeCollectIntro" xml:space="preserve"><value>Recopilem i processem les següents categories de dades personals:</value></data>
+  <data name="Privacy_Collect_Identity" xml:space="preserve"><value>Nom, correu electrònic (de l'autenticació de Google), nom per mostrar</value></data>
+  <data name="Privacy_Collect_Contact" xml:space="preserve"><value>Telèfon, ciutat, país (opcional)</value></data>
+  <data name="Privacy_Collect_Profile" xml:space="preserve"><value>Biografia, pertinença a equips, assignacions de rols</value></data>
+  <data name="Privacy_Collect_Technical" xml:space="preserve"><value>Adreça IP i agent d'usuari (per a registres de consentiment)</value></data>
+  <data name="Privacy_Collect_Application" xml:space="preserve"><value>Sol·licituds de pertinença i declaracions de motivació</value></data>
+  <data name="Privacy_Collect_Consent" xml:space="preserve"><value>Registres de la teva acceptació de documents legals</value></data>
+  <data name="Privacy_LegalBasisTitle" xml:space="preserve"><value>Base legal del tractament</value></data>
+  <data name="Privacy_LegalBasisIntro" xml:space="preserve"><value>Processem les teves dades en base a:</value></data>
+  <data name="Privacy_Legal_Contract" xml:space="preserve"><value>Tractament necessari per a la gestió de pertinença</value></data>
+  <data name="Privacy_Legal_LegitimateInterest" xml:space="preserve"><value>Manteniment de registres organitzatius i comunicació</value></data>
+  <data name="Privacy_Legal_LegalObligation" xml:space="preserve"><value>Compliment de la normativa espanyola sobre associacions</value></data>
+  <data name="Privacy_Legal_Consent" xml:space="preserve"><value>Per a dades opcionals que triïs proporcionar</value></data>
+  <data name="Privacy_HowWeUseTitle" xml:space="preserve"><value>Com fem servir les teves dades</value></data>
+  <data name="Privacy_Use_Membership" xml:space="preserve"><value>Per gestionar la teva pertinença i participació en equips</value></data>
+  <data name="Privacy_Use_Communicate" xml:space="preserve"><value>Per comunicar-nos amb tu sobre activitats de l'organització</value></data>
+  <data name="Privacy_Use_LegalCompliance" xml:space="preserve"><value>Per mantenir registres de compliment legal</value></data>
+  <data name="Privacy_Use_Connections" xml:space="preserve"><value>Per facilitar connexions entre humans (segons la teva configuració de visibilitat)</value></data>
+  <data name="Privacy_DataRetentionTitle" xml:space="preserve"><value>Retenció de dades</value></data>
+  <data name="Privacy_DataRetentionIntro" xml:space="preserve"><value>Conservem les teves dades segons les següents polítiques:</value></data>
+  <data name="Privacy_Retention_Active" xml:space="preserve"><value>Dades conservades mentre el teu compte estigui actiu</value></data>
+  <data name="Privacy_Retention_Inactive" xml:space="preserve"><value>Dades conservades fins a 7 anys per compliment legal</value></data>
+  <data name="Privacy_Retention_Consent" xml:space="preserve"><value>Conservats indefinidament segons el RGPD</value></data>
+  <data name="Privacy_Retention_Deleted" xml:space="preserve"><value>Anonimitzats després d'un període de gràcia de 30 dies</value></data>
+  <data name="Privacy_YourRightsTitle" xml:space="preserve"><value>Els teus drets</value></data>
+  <data name="Privacy_YourRightsIntro" xml:space="preserve"><value>Segons el RGPD, tens els següents drets:</value></data>
+  <data name="Privacy_Rights_Access" xml:space="preserve"><value>Sol·licitar una còpia de les teves dades personals</value></data>
+  <data name="Privacy_Rights_Rectification" xml:space="preserve"><value>Sol·licitar la correcció de dades inexactes</value></data>
+  <data name="Privacy_Rights_Erasure" xml:space="preserve"><value>Sol·licitar l'eliminació de les teves dades (&quot;dret a l'oblit&quot;)</value></data>
+  <data name="Privacy_Rights_Portability" xml:space="preserve"><value>Rebre les teves dades en format llegible per màquina</value></data>
+  <data name="Privacy_Rights_Restriction" xml:space="preserve"><value>Sol·licitar la limitació del tractament</value></data>
+  <data name="Privacy_Rights_Objection" xml:space="preserve"><value>Oposar-te a certs tipus de tractament</value></data>
+  <data name="Privacy_YourRightsExercise" xml:space="preserve"><value>Per exercir aquests drets, visita la teva configuració de {0} o contacta'ns a {1}.</value><comment>{0} = Privacy &amp; Data link, {1} = DPO email</comment></data>
+  <data name="Privacy_PrivacyAndData" xml:space="preserve"><value>Privacitat i dades</value></data>
+  <data name="Privacy_CookiesTitle" xml:space="preserve"><value>Cookies</value></data>
+  <data name="Privacy_CookiesIntro" xml:space="preserve"><value>Aquest lloc només utilitza cookies essencials necessàries per a:</value></data>
+  <data name="Privacy_Cookies_Auth" xml:space="preserve"><value>Autenticació d'usuari i gestió de sessions</value></data>
+  <data name="Privacy_Cookies_Antiforgery" xml:space="preserve"><value>Tokens anti-falsificació per a seguretat de formularis</value></data>
+  <data name="Privacy_Cookies_Consent" xml:space="preserve"><value>Preferència de consentiment de cookies</value></data>
+  <data name="Privacy_CookiesNoTracking" xml:space="preserve"><value>No fem servir cookies d'anàlisi, publicitat ni seguiment de tercers.</value></data>
+  <data name="Privacy_DataSecurityTitle" xml:space="preserve"><value>Seguretat de dades</value></data>
+  <data name="Privacy_DataSecurityIntro" xml:space="preserve"><value>Implementem mesures tècniques i organitzatives apropiades per protegir les teves dades, incloent:</value></data>
+  <data name="Privacy_Security_Encryption" xml:space="preserve"><value>Xifratge en trànsit (HTTPS)</value></data>
+  <data name="Privacy_Security_OAuth" xml:space="preserve"><value>Autenticació segura via Google OAuth</value></data>
+  <data name="Privacy_Security_AccessControls" xml:space="preserve"><value>Controls d'accés i registre d'auditoria</value></data>
+  <data name="Privacy_Security_Reviews" xml:space="preserve"><value>Revisions de seguretat periòdiques</value></data>
+  <data name="Privacy_ThirdPartyTitle" xml:space="preserve"><value>Serveis de tercers</value></data>
+  <data name="Privacy_ThirdPartyIntro" xml:space="preserve"><value>Utilitzem els següents serveis de tercers:</value></data>
+  <data name="Privacy_ThirdParty_GoogleOAuth" xml:space="preserve"><value>Per a autenticació segura</value></data>
+  <data name="Privacy_ThirdParty_GoogleWorkspace" xml:space="preserve"><value>Per a provisió de recursos d'equip (unitats compartides, grups)</value></data>
+  <data name="Privacy_ChangesTitle" xml:space="preserve"><value>Canvis a aquesta política</value></data>
+  <data name="Privacy_ChangesBody" xml:space="preserve"><value>Podem actualitzar aquesta política de privacitat de tant en tant. Notificarem als humans actius sobre canvis significatius per correu.</value></data>
+  <data name="Privacy_ContactTitle" xml:space="preserve"><value>Contacte i reclamacions</value></data>
+  <data name="Privacy_ContactBody" xml:space="preserve"><value>Per a preguntes o dubtes sobre aquesta política, contacta amb el nostre Delegat de Protecció de Dades a {0}.</value><comment>{0} = DPO email</comment></data>
+  <data name="Privacy_ComplaintBody" xml:space="preserve"><value>Si no estàs satisfet amb la nostra resposta, tens dret a presentar una reclamació davant l'Agència Espanyola de Protecció de Dades (AEPD) a {0}.</value><comment>{0} = AEPD URL</comment></data>
+
 
 </root>

--- a/src/Humans.Web/Resources/SharedResource.de.resx
+++ b/src/Humans.Web/Resources/SharedResource.de.resx
@@ -1317,44 +1317,44 @@
   <data name="Todo_ShiftInfo_Action" xml:space="preserve"><value>Schichtinformationen ausf&#xFC;llen</value></data>
 
   <!-- Notification Inbox -->
-  <data name="Notification_Bell_AriaLabel" xml:space="preserve"><value>Notifications</value></data>
-  <data name="Notification_Popup_AriaLabel" xml:space="preserve"><value>Notification popup</value></data>
-  <data name="Notification_Popup_Title" xml:space="preserve"><value>Notifications</value></data>
-  <data name="Notification_Popup_NeedAction" xml:space="preserve"><value>need action</value></data>
-  <data name="Notification_Popup_Close" xml:space="preserve"><value>Close notifications</value></data>
-  <data name="Notification_Popup_CaughtUp" xml:space="preserve"><value>You're all caught up.</value></data>
-  <data name="Notification_Popup_NoUnread" xml:space="preserve"><value>No unread notifications.</value></data>
-  <data name="Notification_Section_NeedsAttention" xml:space="preserve"><value>Needs your attention</value></data>
-  <data name="Notification_Section_Recent" xml:space="preserve"><value>Recent</value></data>
-  <data name="Notification_Section_Informational" xml:space="preserve"><value>Informational</value></data>
-  <data name="Notification_Section_Resolved" xml:space="preserve"><value>Resolved</value></data>
-  <data name="Notification_Section_WorkQueues" xml:space="preserve"><value>Work queues</value></data>
-  <data name="Notification_MarkAllRead" xml:space="preserve"><value>Mark all as read</value></data>
-  <data name="Notification_SeeAll" xml:space="preserve"><value>See all notifications</value></data>
-  <data name="Notification_PageTitle" xml:space="preserve"><value>All notifications</value></data>
-  <data name="Notification_SearchPlaceholder" xml:space="preserve"><value>Search notifications...</value></data>
-  <data name="Notification_Filter_All" xml:space="preserve"><value>All</value></data>
-  <data name="Notification_Filter_NeedsAction" xml:space="preserve"><value>Needs action</value></data>
-  <data name="Notification_Filter_Shifts" xml:space="preserve"><value>Shifts</value></data>
-  <data name="Notification_Filter_Approvals" xml:space="preserve"><value>Approvals</value></data>
-  <data name="Notification_Filter_Resolved" xml:space="preserve"><value>Resolved</value></data>
-  <data name="Notification_Tab_Unread" xml:space="preserve"><value>Unread</value></data>
-  <data name="Notification_Tab_All" xml:space="preserve"><value>All</value></data>
-  <data name="Notification_Inbox_Title" xml:space="preserve"><value>Notifications</value></data>
-  <data name="Notification_Tag_Urgent" xml:space="preserve"><value>Urgent</value></data>
-  <data name="Notification_Tag_Action" xml:space="preserve"><value>Action</value></data>
+  <data name="Notification_Bell_AriaLabel" xml:space="preserve"><value>Benachrichtigungen</value></data>
+  <data name="Notification_Popup_AriaLabel" xml:space="preserve"><value>Benachrichtigungs-Popup</value></data>
+  <data name="Notification_Popup_Title" xml:space="preserve"><value>Benachrichtigungen</value></data>
+  <data name="Notification_Popup_NeedAction" xml:space="preserve"><value>erfordern Aktion</value></data>
+  <data name="Notification_Popup_Close" xml:space="preserve"><value>Benachrichtigungen schließen</value></data>
+  <data name="Notification_Popup_CaughtUp" xml:space="preserve"><value>Du bist auf dem Laufenden.</value></data>
+  <data name="Notification_Popup_NoUnread" xml:space="preserve"><value>Keine ungelesenen Benachrichtigungen.</value></data>
+  <data name="Notification_Section_NeedsAttention" xml:space="preserve"><value>Erfordert deine Aufmerksamkeit</value></data>
+  <data name="Notification_Section_Recent" xml:space="preserve"><value>Kürzlich</value></data>
+  <data name="Notification_Section_Informational" xml:space="preserve"><value>Informativ</value></data>
+  <data name="Notification_Section_Resolved" xml:space="preserve"><value>Erledigt</value></data>
+  <data name="Notification_Section_WorkQueues" xml:space="preserve"><value>Arbeitswarteschlangen</value></data>
+  <data name="Notification_MarkAllRead" xml:space="preserve"><value>Alle als gelesen markieren</value></data>
+  <data name="Notification_SeeAll" xml:space="preserve"><value>Alle Benachrichtigungen ansehen</value></data>
+  <data name="Notification_PageTitle" xml:space="preserve"><value>Alle Benachrichtigungen</value></data>
+  <data name="Notification_SearchPlaceholder" xml:space="preserve"><value>Benachrichtigungen suchen...</value></data>
+  <data name="Notification_Filter_All" xml:space="preserve"><value>Alle</value></data>
+  <data name="Notification_Filter_NeedsAction" xml:space="preserve"><value>Aktion nötig</value></data>
+  <data name="Notification_Filter_Shifts" xml:space="preserve"><value>Schichten</value></data>
+  <data name="Notification_Filter_Approvals" xml:space="preserve"><value>Genehmigungen</value></data>
+  <data name="Notification_Filter_Resolved" xml:space="preserve"><value>Erledigt</value></data>
+  <data name="Notification_Tab_Unread" xml:space="preserve"><value>Ungelesen</value></data>
+  <data name="Notification_Tab_All" xml:space="preserve"><value>Alle</value></data>
+  <data name="Notification_Inbox_Title" xml:space="preserve"><value>Benachrichtigungen</value></data>
+  <data name="Notification_Tag_Urgent" xml:space="preserve"><value>Dringend</value></data>
+  <data name="Notification_Tag_Action" xml:space="preserve"><value>Aktion</value></data>
   <data name="Notification_Tag_Info" xml:space="preserve"><value>Info</value></data>
-  <data name="Notification_Dismiss" xml:space="preserve"><value>Dismiss</value></data>
-  <data name="Notification_HandledBy" xml:space="preserve"><value>Handled by {0}, {1}</value></data>
-  <data name="Notification_Pref_InboxEnabled" xml:space="preserve"><value>In-app notifications</value></data>
-  <data name="Notification_DefaultActionLabel" xml:space="preserve"><value>View →</value></data>
-  <data name="Notification_TimeAgo_JustNow" xml:space="preserve"><value>just now</value></data>
-  <data name="Notification_TimeAgo_Minutes" xml:space="preserve"><value>{0}m ago</value></data>
-  <data name="Notification_TimeAgo_Hours" xml:space="preserve"><value>{0}h ago</value></data>
-  <data name="Notification_TimeAgo_Days" xml:space="preserve"><value>{0}d ago</value></data>
-  <data name="Notification_Bulk_Selected" xml:space="preserve"><value>{0} selected</value></data>
-  <data name="Notification_Bulk_Resolve" xml:space="preserve"><value>Resolve selected</value></data>
-  <data name="Notification_Bulk_Dismiss" xml:space="preserve"><value>Dismiss selected</value></data>
+  <data name="Notification_Dismiss" xml:space="preserve"><value>Verwerfen</value></data>
+  <data name="Notification_HandledBy" xml:space="preserve"><value>Bearbeitet von {0}, {1}</value></data>
+  <data name="Notification_Pref_InboxEnabled" xml:space="preserve"><value>In-App-Benachrichtigungen</value></data>
+  <data name="Notification_DefaultActionLabel" xml:space="preserve"><value>Ansehen →</value></data>
+  <data name="Notification_TimeAgo_JustNow" xml:space="preserve"><value>gerade eben</value></data>
+  <data name="Notification_TimeAgo_Minutes" xml:space="preserve"><value>vor {0}m</value></data>
+  <data name="Notification_TimeAgo_Hours" xml:space="preserve"><value>vor {0}h</value></data>
+  <data name="Notification_TimeAgo_Days" xml:space="preserve"><value>vor {0}d</value></data>
+  <data name="Notification_Bulk_Selected" xml:space="preserve"><value>{0} ausgewählt</value></data>
+  <data name="Notification_Bulk_Resolve" xml:space="preserve"><value>Ausgewählte erledigen</value></data>
+  <data name="Notification_Bulk_Dismiss" xml:space="preserve"><value>Ausgewählte verwerfen</value></data>
 
   <!-- Get Involved card (Dashboard) -->
   <data name="GetInvolved_Title" xml:space="preserve"><value>Mach mit</value></data>
@@ -1433,5 +1433,257 @@
   <data name="CityPlanning_Help_OverlapsDiscordChannel" xml:space="preserve"><value>Discord #city-planning</value></data>
   <data name="CityPlanning_Help_ColorsTitle" xml:space="preserve"><value>Farben &amp; Klangzonen</value></data>
   <data name="CityPlanning_Help_ColorsBody" xml:space="preserve"><value>Jedes Barrio ist entsprechend seiner bevorzugten Klangzone eingefärbt (auf der Barrio-Seite bearbeitbar).</value></data>
+
+
+  <!-- ======================== -->
+  <!-- User-Facing Views        -->
+  <!-- ======================== -->
+  <data name="Feedback_PageTitle" xml:space="preserve"><value>Feedback</value></data>
+  <data name="Feedback_AllStatuses" xml:space="preserve"><value>Alle Status</value></data>
+  <data name="Feedback_AllCategories" xml:space="preserve"><value>Alle Kategorien</value></data>
+  <data name="Feedback_AllReporters" xml:space="preserve"><value>Alle Melder</value></data>
+  <data name="Feedback_AllAssignees" xml:space="preserve"><value>Alle Zugewiesenen</value></data>
+  <data name="Feedback_AssignedToMe" xml:space="preserve"><value>Mir zugewiesen</value></data>
+  <data name="Feedback_AllTeams" xml:space="preserve"><value>Alle Teams</value></data>
+  <data name="Feedback_UnassignedOnly" xml:space="preserve"><value>Nur nicht zugewiesen</value></data>
+  <data name="Feedback_Clear" xml:space="preserve"><value>Zurücksetzen</value></data>
+  <data name="Feedback_NoReports" xml:space="preserve"><value>Keine Feedback-Berichte gefunden.</value></data>
+  <data name="Feedback_Unassigned" xml:space="preserve"><value>Nicht zugewiesen</value></data>
+  <data name="Feedback_NeedsReply" xml:space="preserve"><value>Antwort nötig</value></data>
+  <data name="Feedback_SelectReport" xml:space="preserve"><value>Bericht auswählen für Details</value></data>
+  <data name="Feedback_Conversation" xml:space="preserve"><value>Konversation</value></data>
+  <data name="Feedback_NoMessages" xml:space="preserve"><value>Noch keine Nachrichten.</value></data>
+  <data name="Feedback_MessagePlaceholder" xml:space="preserve"><value>Nachricht eingeben...</value></data>
+  <data name="Feedback_Send" xml:space="preserve"><value>Senden</value></data>
+  <data name="Feedback_ResolvedAt" xml:space="preserve"><value>Gelöst {0}</value><comment>{0} = date/time</comment></data>
+  <data name="Feedback_ResolvedBy" xml:space="preserve"><value>von {0}</value><comment>{0} = name</comment></data>
+  <data name="Feedback_NoTeam" xml:space="preserve"><value>Kein Team</value></data>
+  <data name="Feedback_ScreenshotLink" xml:space="preserve"><value>Screenshot</value></data>
+
+  <data name="Unsub_Title" xml:space="preserve"><value>E-Mails abbestellen</value></data>
+  <data name="Unsub_Heading" xml:space="preserve"><value>Von {0}-E-Mails abmelden?</value><comment>{0} = category name</comment></data>
+  <data name="Unsub_Greeting" xml:space="preserve"><value>Hallo {0},</value><comment>{0} = display name</comment></data>
+  <data name="Unsub_ConfirmMessage" xml:space="preserve"><value>Wenn du bestätigst, erhältst du keine {0}-E-Mails mehr von Humans.</value><comment>{0} = category name</comment></data>
+  <data name="Unsub_ConfirmButton" xml:space="preserve"><value>Abmeldung bestätigen</value></data>
+  <data name="Unsub_DoneTitle" xml:space="preserve"><value>Abgemeldet</value></data>
+  <data name="Unsub_DoneMessage" xml:space="preserve"><value>Du erhältst keine {0}-E-Mails mehr von Humans.</value><comment>{0} = category name</comment></data>
+  <data name="Unsub_DoneManage" xml:space="preserve"><value>Du kannst alle Kommunikationseinstellungen verwalten unter</value></data>
+  <data name="Unsub_DoneManageLink" xml:space="preserve"><value>Kommunikationseinstellungen</value></data>
+  <data name="Unsub_BackHome" xml:space="preserve"><value>Zurück zur Startseite</value></data>
+  <data name="Unsub_ExpiredTitle" xml:space="preserve"><value>Abmelde-Link abgelaufen</value></data>
+  <data name="Unsub_ExpiredHeading" xml:space="preserve"><value>Dieser Abmelde-Link ist abgelaufen</value></data>
+  <data name="Unsub_ExpiredMessage" xml:space="preserve"><value>Bitte verwende den Link aus einer neueren E-Mail, oder</value></data>
+  <data name="Unsub_ExpiredSignIn" xml:space="preserve"><value>melde dich an, um deine Kommunikationseinstellungen zu verwalten</value></data>
+
+  <data name="CommPrefs_Title" xml:space="preserve"><value>Kommunikationseinstellungen</value></data>
+  <data name="CommPrefs_Description" xml:space="preserve"><value>Wähle, welche Mitteilungen du erhältst und wie.</value></data>
+  <data name="CommPrefs_Category" xml:space="preserve"><value>Kategorie</value></data>
+  <data name="CommPrefs_Email" xml:space="preserve"><value>E-Mail</value></data>
+  <data name="CommPrefs_Alert" xml:space="preserve"><value>Benachrichtigung</value></data>
+  <data name="CommPrefs_BackToProfile" xml:space="preserve"><value>Zurück zum Profil</value></data>
+  <data name="CommPrefs_BackToDashboard" xml:space="preserve"><value>Zurück zum Dashboard</value></data>
+
+  <data name="Emails_Header_Email" xml:space="preserve"><value>E-Mail</value></data>
+  <data name="Emails_Header_Status" xml:space="preserve"><value>Status</value></data>
+  <data name="Emails_Header_Notifications" xml:space="preserve"><value>Benachrichtigungen</value></data>
+  <data name="Emails_Header_Visibility" xml:space="preserve"><value>Profil-Sichtbarkeit</value></data>
+  <data name="Emails_SignIn" xml:space="preserve"><value>Anmeldung</value></data>
+  <data name="Emails_MergePending" xml:space="preserve"><value>Zusammenführung ausstehend</value></data>
+  <data name="Emails_Verified" xml:space="preserve"><value>Verifiziert</value></data>
+  <data name="Emails_StatusPending" xml:space="preserve"><value>Ausstehend</value></data>
+  <data name="Emails_Unverified" xml:space="preserve"><value>Nicht verifiziert</value></data>
+  <data name="Emails_NotifActive" xml:space="preserve"><value>Aktiv</value></data>
+  <data name="Emails_SetAsTarget" xml:space="preserve"><value>Als Ziel setzen</value></data>
+  <data name="Emails_VerifyFirst" xml:space="preserve"><value>Zuerst verifizieren</value></data>
+  <data name="Emails_Visibility_Hidden" xml:space="preserve"><value>Versteckt</value></data>
+  <data name="Emails_Visibility_AllHumans" xml:space="preserve"><value>Alle humans</value></data>
+  <data name="Emails_Visibility_MyTeams" xml:space="preserve"><value>Meine Teams</value></data>
+  <data name="Emails_Visibility_CoordinatorsBoard" xml:space="preserve"><value>Koordinatoren + Vorstand</value></data>
+  <data name="Emails_Visibility_BoardOnly" xml:space="preserve"><value>Nur Vorstand</value></data>
+  <data name="Emails_ConfirmRemove" xml:space="preserve"><value>Bist du sicher, dass du diese E-Mail entfernen möchtest?</value></data>
+  <data name="Emails_GoogleTitle" xml:space="preserve"><value>Google-Dienste-E-Mail</value></data>
+  <data name="Emails_GoogleDescription" xml:space="preserve"><value>Diese E-Mail wird für Google Groups und freigegebene Laufwerke verwendet.</value></data>
+  <data name="Emails_GoogleAutoNobodies" xml:space="preserve"><value>Deine @nobodies.team E-Mail wird automatisch verwendet.</value></data>
+  <data name="Emails_GoogleRejected" xml:space="preserve"><value>Google-Synchronisierung fehlgeschlagen. Die aktuelle E-Mail wurde von Google abgelehnt. Wähle eine andere E-Mail.</value></data>
+  <data name="Emails_GoogleValid" xml:space="preserve"><value>Google-Synchronisierung funktioniert mit der aktuellen E-Mail.</value></data>
+  <data name="Emails_AutoSelected" xml:space="preserve"><value>Automatisch ausgewählt</value></data>
+  <data name="Emails_GoogleRejectedBadge" xml:space="preserve"><value>Abgelehnt</value></data>
+  <data name="Emails_UseThis" xml:space="preserve"><value>Verwenden</value></data>
+
+  <data name="ShiftInfo_Title" xml:space="preserve"><value>Schichtpräferenzen</value></data>
+  <data name="ShiftInfo_StepOf" xml:space="preserve"><value>Schritt {0} von {1}</value><comment>{0} = current step, {1} = total steps</comment></data>
+  <data name="ShiftInfo_SkillsTitle" xml:space="preserve"><value>Was kannst du gut?</value></data>
+  <data name="ShiftInfo_SkillsSubtitle" xml:space="preserve"><value>Wähle Fähigkeiten aus, die du einsetzen möchtest. Du kannst sie jederzeit ändern.</value></data>
+  <data name="ShiftInfo_WorkStyleTitle" xml:space="preserve"><value>Wie arbeitest du am liebsten?</value></data>
+  <data name="ShiftInfo_WorkStyleSubtitle" xml:space="preserve"><value>Hilf Koordinatoren, dich mit passenden Schichten zu verbinden.</value></data>
+  <data name="ShiftInfo_LanguagesTitle" xml:space="preserve"><value>Welche Sprachen sprichst du?</value></data>
+  <data name="ShiftInfo_LanguagesSubtitle" xml:space="preserve"><value>Das hilft uns, dich in Teams einzuteilen, in denen du gut kommunizieren kannst.</value></data>
+  <data name="ShiftInfo_OtherSkills" xml:space="preserve"><value>Welche anderen Fähigkeiten hast du?</value></data>
+  <data name="ShiftInfo_WorkTime" xml:space="preserve"><value>Wann arbeitest du am liebsten?</value></data>
+  <data name="ShiftInfo_OtherPrefs" xml:space="preserve"><value>Weitere Präferenzen</value></data>
+  <data name="ShiftInfo_OtherLanguages" xml:space="preserve"><value>Welche anderen Sprachen sprichst du?</value></data>
+  <data name="ShiftInfo_Continue" xml:space="preserve"><value>Weiter</value></data>
+
+  <data name="Shifts_Title" xml:space="preserve"><value>Schichten</value></data>
+  <data name="Shifts_BrowseTitle" xml:space="preserve"><value>Freiwilligen-Optionen durchsuchen</value></data>
+  <data name="Shifts_Department" xml:space="preserve"><value>Abteilung</value></data>
+  <data name="Shifts_AllDepartments" xml:space="preserve"><value>Alle Abteilungen</value></data>
+  <data name="Shifts_From" xml:space="preserve"><value>Von</value></data>
+  <data name="Shifts_To" xml:space="preserve"><value>Bis</value></data>
+  <data name="Shifts_ClearFilters" xml:space="preserve"><value>Filter zurücksetzen</value></data>
+  <data name="Shifts_All" xml:space="preserve"><value>Alle</value></data>
+  <data name="Shifts_SetUp" xml:space="preserve"><value>Aufbau</value></data>
+  <data name="Shifts_Event" xml:space="preserve"><value>Veranstaltung</value></data>
+  <data name="Shifts_Strike" xml:space="preserve"><value>Abbau</value></data>
+  <data name="Shifts_FilterByTag" xml:space="preserve"><value>Nach Tag filtern:</value></data>
+  <data name="Shifts_SetPreferences" xml:space="preserve"><value>Präferenzen festlegen</value></data>
+  <data name="Shifts_PreferencesHelp" xml:space="preserve"><value>Wähle Tags aus, die zur Art von Arbeit passen, die du magst. Passende Schichten werden mit einem Stern markiert.</value></data>
+  <data name="Shifts_SavePreferences" xml:space="preserve"><value>Präferenzen speichern</value></data>
+  <data name="Shifts_NotOpenYet" xml:space="preserve"><value>Schichten sind noch nicht geöffnet. Nur Koordinatoren und Admins können diese Seite sehen.</value></data>
+  <data name="Shifts_NoShiftsAvailable" xml:space="preserve"><value>Noch keine Schichten verfügbar.</value></data>
+  <data name="Shifts_AllShiftsFull" xml:space="preserve"><value>Alle {0}-Schichten sind voll.</value><comment>{0} = period name</comment></data>
+  <data name="Shifts_Start" xml:space="preserve"><value>Start</value></data>
+  <data name="Shifts_End" xml:space="preserve"><value>Ende</value></data>
+  <data name="Shifts_SignUpForDates" xml:space="preserve"><value>Für {0}-Termine anmelden</value><comment>{0} = period name (e.g. set-up, strike)</comment></data>
+  <data name="Shifts_Date" xml:space="preserve"><value>Datum</value></data>
+  <data name="Shifts_Filled" xml:space="preserve"><value>Belegt</value></data>
+  <data name="Shifts_Days" xml:space="preserve"><value>Tage</value></data>
+  <data name="Shifts_Total" xml:space="preserve"><value>gesamt</value></data>
+    <data name="Shifts_SignedUpAllDays" xml:space="preserve"><value>Angemeldet (alle {0} Tage)</value><comment>{0} = count</comment></data>
+    <data name="Shifts_SignedUpPartial" xml:space="preserve"><value>Angemeldet ({0} von {1})</value><comment>{0} = count</comment></data>
+  <data name="Shifts_Full" xml:space="preserve"><value>Voll</value></data>
+  <data name="Shifts_NeedsHelp" xml:space="preserve"><value>Hilfe nötig</value></data>
+  <data name="Shifts_DayNeedsHelp" xml:space="preserve"><value>{0} Tag braucht Hilfe</value><comment>{0} = number of days</comment></data>
+  <data name="Shifts_DaysNeedHelp" xml:space="preserve"><value>{0} Tage brauchen Hilfe</value><comment>{0} = number of days</comment></data>
+  <data name="Shifts_ClickToExpand" xml:space="preserve"><value>klicken zum Aufklappen</value></data>
+  <data name="Shifts_Shift" xml:space="preserve"><value>Schicht</value></data>
+  <data name="Shifts_Phase" xml:space="preserve"><value>Phase</value></data>
+  <data name="Shifts_Time" xml:space="preserve"><value>Zeit</value></data>
+  <data name="Shifts_Duration" xml:space="preserve"><value>Dauer</value></data>
+  <data name="Shifts_AllDay" xml:space="preserve"><value>Ganztägig</value></data>
+  <data name="Shifts_FullDay" xml:space="preserve"><value>Ganzer Tag</value></data>
+  <data name="Shifts_Essential" xml:space="preserve"><value>Essentiell</value></data>
+  <data name="Shifts_Important" xml:space="preserve"><value>Wichtig</value></data>
+  <data name="Shifts_AllPhases" xml:space="preserve"><value>Alle Phasen</value></data>
+  <data name="Shifts_HiddenBadge" xml:space="preserve"><value>Versteckt</value></data>
+  <data name="Shifts_MatchesPrefs" xml:space="preserve"><value>Passt zu deinen Präferenzen</value></data>
+  <data name="Shifts_SignUpButton" xml:space="preserve"><value>Anmelden</value></data>
+  <data name="Shifts_BrowsingClosed" xml:space="preserve"><value>Schichten-Übersicht ist noch nicht geöffnet. Schau später wieder!</value></data>
+  <data name="Shifts_NoActiveEvent" xml:space="preserve"><value>Kein aktives Event konfiguriert. Ein Admin muss zuerst die Event-Einstellungen einrichten.</value></data>
+  <data name="Shifts_ConfigureEvent" xml:space="preserve"><value>Event-Einstellungen konfigurieren</value></data>
+  <data name="Shifts_MyShiftsTitle" xml:space="preserve"><value>Meine Schichten</value></data>
+  <data name="Shifts_UpcomingShifts" xml:space="preserve"><value>Kommende Schichten</value></data>
+  <data name="Shifts_PendingApproval" xml:space="preserve"><value>Genehmigung ausstehend</value></data>
+  <data name="Shifts_Past" xml:space="preserve"><value>Vergangen</value></data>
+  <data name="Shifts_Bail" xml:space="preserve"><value>Absagen</value></data>
+  <data name="Shifts_BailConfirm" xml:space="preserve"><value>Bist du sicher, dass du absagen möchtest?</value></data>
+  <data name="Shifts_BailRangeConfirm" xml:space="preserve"><value>Von allen {0} Tagen absagen?</value><comment>{0} = number of days</comment></data>
+  <data name="Shifts_WithdrawButton" xml:space="preserve"><value>Zurückziehen</value></data>
+  <data name="Shifts_NoSignups" xml:space="preserve"><value>Noch keine Schicht-Anmeldungen.</value></data>
+  <data name="Shifts_BrowseAvailable" xml:space="preserve"><value>Verfügbare Schichten durchsuchen</value></data>
+  <data name="Shifts_NoActiveEventConfigured" xml:space="preserve"><value>Kein aktives Event konfiguriert.</value></data>
+  <data name="Shifts_GeneralAvailability" xml:space="preserve"><value>Allgemeine Verfügbarkeit</value></data>
+  <data name="Shifts_AvailabilityHelp" xml:space="preserve"><value>Markiere, an welchen Tagen du helfen kannst. Koordinatoren können sehen, wer verfügbar ist.</value></data>
+  <data name="Shifts_SaveAvailability" xml:space="preserve"><value>Verfügbarkeit speichern</value></data>
+
+  <data name="ShiftDash_Title" xml:space="preserve"><value>Schicht-Dashboard</value></data>
+  <data name="ShiftDash_ShiftsCount" xml:space="preserve"><value>{0} Schichten</value><comment>{0} = count</comment></data>
+  <data name="ShiftDash_Date" xml:space="preserve"><value>Datum</value></data>
+  <data name="ShiftDash_Department" xml:space="preserve"><value>Abteilung</value></data>
+  <data name="ShiftDash_AllDepartments" xml:space="preserve"><value>Alle Abteilungen</value></data>
+  <data name="ShiftDash_Filter" xml:space="preserve"><value>Filtern</value></data>
+  <data name="ShiftDash_Clear" xml:space="preserve"><value>Zurücksetzen</value></data>
+  <data name="ShiftDash_NoShiftsMatch" xml:space="preserve"><value>Keine Schichten passen zu den aktuellen Filtern.</value></data>
+  <data name="ShiftDash_Shift" xml:space="preserve"><value>Schicht</value></data>
+  <data name="ShiftDash_DateTime" xml:space="preserve"><value>Datum / Zeit</value></data>
+  <data name="ShiftDash_Slots" xml:space="preserve"><value>Plätze</value></data>
+  <data name="ShiftDash_Priority" xml:space="preserve"><value>Priorität</value></data>
+  <data name="ShiftDash_Voluntell" xml:space="preserve"><value>Voluntell</value></data>
+  <data name="ShiftDash_SearchHumans" xml:space="preserve"><value>Humans suchen für: {0}</value><comment>{0} = shift/rota name</comment></data>
+  <data name="ShiftDash_SearchPlaceholder" xml:space="preserve"><value>Namen eingeben (min. 2 Zeichen)...</value></data>
+  <data name="ShiftDash_NoHumansFound" xml:space="preserve"><value>Keine humans gefunden.</value></data>
+  <data name="ShiftDash_SearchFailed" xml:space="preserve"><value>Suche fehlgeschlagen.</value></data>
+  <data name="ShiftDash_ScheduleConflict" xml:space="preserve"><value>Terminkonflikt</value></data>
+
+  <data name="Nav_Legal" xml:space="preserve"><value>Recht</value></data>
+  <data name="Nav_Staff" xml:space="preserve"><value>Team</value></data>
+
+  <data name="ProfileCard_Suspended" xml:space="preserve"><value>Gesperrt</value></data>
+  <data name="ProfileCard_PendingBadge" xml:space="preserve"><value>Ausstehend</value></data>
+  <data name="ProfileCard_Teams" xml:space="preserve"><value>Teams:</value></data>
+  <data name="ProfileCard_Joined" xml:space="preserve"><value>Beigetreten {0}</value><comment>{0} = date</comment></data>
+  <data name="ProfileCard_LastLogin" xml:space="preserve"><value>Letzter Login {0}</value><comment>{0} = date</comment></data>
+
+  <data name="ShiftsSummary_Title" xml:space="preserve"><value>Schichten</value></data>
+  <data name="ShiftsSummary_SlotsFilled" xml:space="preserve"><value>{0} / {1} Plätze belegt</value><comment>{0} = filled, {1} = total</comment></data>
+  <data name="ShiftsSummary_HumansSignedUp" xml:space="preserve"><value>{0} humans angemeldet</value><comment>{0} = count</comment></data>
+  <data name="ShiftsSummary_PendingCount" xml:space="preserve"><value>{0} ausstehend</value><comment>{0} = count</comment></data>
+  <data name="ShiftsSummary_NoShifts" xml:space="preserve"><value>Noch keine Schichten konfiguriert.</value></data>
+  <data name="ShiftsSummary_IncludesSubTeams" xml:space="preserve"><value>Enthält Schichten von {0} Sub-Team(s)</value><comment>{0} = count</comment></data>
+  <data name="ShiftsSummary_ManageShifts" xml:space="preserve"><value>Schichten verwalten</value></data>
+
+  <data name="Medical_Badge" xml:space="preserve"><value>Medizinisch</value></data>
+
+  <data name="Privacy_Lead" xml:space="preserve"><value>Humans verwaltet die Mitgliedschaft von Nobodies Collective und verarbeitet personenbezogene Daten gemäß DSGVO und spanischem Datenschutzrecht (LOPDGDD).</value></data>
+  <data name="Privacy_DataControllerTitle" xml:space="preserve"><value>Verantwortlicher</value></data>
+  <data name="Privacy_DataControllerBody" xml:space="preserve"><value>Ein spanischer gemeinnütziger Verein mit Sitz in Andalusien.</value></data>
+  <data name="Privacy_DataControllerDPO" xml:space="preserve"><value>Für Datenschutzanfragen kontaktiere unseren Datenschutzbeauftragten unter:</value></data>
+  <data name="Privacy_DataWeCollectTitle" xml:space="preserve"><value>Daten, die wir erheben</value></data>
+  <data name="Privacy_DataWeCollectIntro" xml:space="preserve"><value>Wir erheben und verarbeiten folgende Kategorien personenbezogener Daten:</value></data>
+  <data name="Privacy_Collect_Identity" xml:space="preserve"><value>Name, E-Mail-Adresse (aus der Google-Authentifizierung), Anzeigename</value></data>
+  <data name="Privacy_Collect_Contact" xml:space="preserve"><value>Telefonnummer, Stadt, Land (optional)</value></data>
+  <data name="Privacy_Collect_Profile" xml:space="preserve"><value>Biografie, Teammitgliedschaften, Rollenzuweisungen</value></data>
+  <data name="Privacy_Collect_Technical" xml:space="preserve"><value>IP-Adresse und User-Agent (für Einwilligungsprotokolle)</value></data>
+  <data name="Privacy_Collect_Application" xml:space="preserve"><value>Mitgliedsanträge und Motivationsschreiben</value></data>
+  <data name="Privacy_Collect_Consent" xml:space="preserve"><value>Aufzeichnungen deiner Zustimmung zu rechtlichen Dokumenten</value></data>
+  <data name="Privacy_LegalBasisTitle" xml:space="preserve"><value>Rechtsgrundlage der Verarbeitung</value></data>
+  <data name="Privacy_LegalBasisIntro" xml:space="preserve"><value>Wir verarbeiten deine Daten auf folgender Grundlage:</value></data>
+  <data name="Privacy_Legal_Contract" xml:space="preserve"><value>Verarbeitung notwendig für die Mitgliederverwaltung</value></data>
+  <data name="Privacy_Legal_LegitimateInterest" xml:space="preserve"><value>Führung organisatorischer Aufzeichnungen und Kommunikation</value></data>
+  <data name="Privacy_Legal_LegalObligation" xml:space="preserve"><value>Einhaltung spanischer Vereinsvorschriften</value></data>
+  <data name="Privacy_Legal_Consent" xml:space="preserve"><value>Für optionale Daten, die du freiwillig angibst</value></data>
+  <data name="Privacy_HowWeUseTitle" xml:space="preserve"><value>Wie wir deine Daten verwenden</value></data>
+  <data name="Privacy_Use_Membership" xml:space="preserve"><value>Zur Verwaltung deiner Mitgliedschaft und Teamteilnahme</value></data>
+  <data name="Privacy_Use_Communicate" xml:space="preserve"><value>Um mit dir über organisatorische Aktivitäten zu kommunizieren</value></data>
+  <data name="Privacy_Use_LegalCompliance" xml:space="preserve"><value>Zur Führung gesetzlich vorgeschriebener Aufzeichnungen</value></data>
+  <data name="Privacy_Use_Connections" xml:space="preserve"><value>Um Verbindungen zwischen humans zu ermöglichen (basierend auf deinen Sichtbarkeitseinstellungen)</value></data>
+  <data name="Privacy_DataRetentionTitle" xml:space="preserve"><value>Datenspeicherung</value></data>
+  <data name="Privacy_DataRetentionIntro" xml:space="preserve"><value>Wir speichern deine Daten gemäß folgender Richtlinien:</value></data>
+  <data name="Privacy_Retention_Active" xml:space="preserve"><value>Daten werden gespeichert, solange dein Konto aktiv ist</value></data>
+  <data name="Privacy_Retention_Inactive" xml:space="preserve"><value>Daten bis zu 7 Jahre gespeichert für gesetzliche Anforderungen</value></data>
+  <data name="Privacy_Retention_Consent" xml:space="preserve"><value>Unbegrenzt gespeichert gemäß DSGVO-Anforderungen</value></data>
+  <data name="Privacy_Retention_Deleted" xml:space="preserve"><value>Nach 30-tägiger Frist anonymisiert</value></data>
+  <data name="Privacy_YourRightsTitle" xml:space="preserve"><value>Deine Rechte</value></data>
+  <data name="Privacy_YourRightsIntro" xml:space="preserve"><value>Gemäß DSGVO hast du folgende Rechte:</value></data>
+  <data name="Privacy_Rights_Access" xml:space="preserve"><value>Eine Kopie deiner personenbezogenen Daten anfordern</value></data>
+  <data name="Privacy_Rights_Rectification" xml:space="preserve"><value>Berichtigung ungenauer Daten anfordern</value></data>
+  <data name="Privacy_Rights_Erasure" xml:space="preserve"><value>Löschung deiner Daten beantragen (&quot;Recht auf Vergessenwerden&quot;)</value></data>
+  <data name="Privacy_Rights_Portability" xml:space="preserve"><value>Deine Daten in maschinenlesbarem Format erhalten</value></data>
+  <data name="Privacy_Rights_Restriction" xml:space="preserve"><value>Einschränkung der Verarbeitung beantragen</value></data>
+  <data name="Privacy_Rights_Objection" xml:space="preserve"><value>Widerspruch gegen bestimmte Arten der Verarbeitung einlegen</value></data>
+  <data name="Privacy_YourRightsExercise" xml:space="preserve"><value>Um diese Rechte auszuüben, besuche deine {0}-Einstellungen oder kontaktiere uns unter {1}.</value><comment>{0} = Privacy &amp; Data link, {1} = DPO email</comment></data>
+  <data name="Privacy_PrivacyAndData" xml:space="preserve"><value>Datenschutz &amp; Daten</value></data>
+  <data name="Privacy_CookiesTitle" xml:space="preserve"><value>Cookies</value></data>
+  <data name="Privacy_CookiesIntro" xml:space="preserve"><value>Diese Website verwendet nur essenzielle Cookies, die benötigt werden für:</value></data>
+  <data name="Privacy_Cookies_Auth" xml:space="preserve"><value>Benutzerauthentifizierung und Sitzungsverwaltung</value></data>
+  <data name="Privacy_Cookies_Antiforgery" xml:space="preserve"><value>Anti-Fälschungs-Token für Formularsicherheit</value></data>
+  <data name="Privacy_Cookies_Consent" xml:space="preserve"><value>Cookie-Einwilligungspräferenz</value></data>
+  <data name="Privacy_CookiesNoTracking" xml:space="preserve"><value>Wir verwenden keine Analyse-, Werbe- oder Tracking-Cookies von Drittanbietern.</value></data>
+  <data name="Privacy_DataSecurityTitle" xml:space="preserve"><value>Datensicherheit</value></data>
+  <data name="Privacy_DataSecurityIntro" xml:space="preserve"><value>Wir setzen angemessene technische und organisatorische Maßnahmen zum Schutz deiner Daten um, darunter:</value></data>
+  <data name="Privacy_Security_Encryption" xml:space="preserve"><value>Verschlüsselung bei der Übertragung (HTTPS)</value></data>
+  <data name="Privacy_Security_OAuth" xml:space="preserve"><value>Sichere Authentifizierung über Google OAuth</value></data>
+  <data name="Privacy_Security_AccessControls" xml:space="preserve"><value>Zugriffskontrollen und Audit-Protokollierung</value></data>
+  <data name="Privacy_Security_Reviews" xml:space="preserve"><value>Regelmäßige Sicherheitsüberprüfungen</value></data>
+  <data name="Privacy_ThirdPartyTitle" xml:space="preserve"><value>Drittanbieter-Dienste</value></data>
+  <data name="Privacy_ThirdPartyIntro" xml:space="preserve"><value>Wir nutzen folgende Drittanbieter-Dienste:</value></data>
+  <data name="Privacy_ThirdParty_GoogleOAuth" xml:space="preserve"><value>Für sichere Authentifizierung</value></data>
+  <data name="Privacy_ThirdParty_GoogleWorkspace" xml:space="preserve"><value>Für Team-Ressourcenbereitstellung (freigegebene Laufwerke, Gruppen)</value></data>
+  <data name="Privacy_ChangesTitle" xml:space="preserve"><value>Änderungen dieser Richtlinie</value></data>
+  <data name="Privacy_ChangesBody" xml:space="preserve"><value>Wir können diese Datenschutzrichtlinie von Zeit zu Zeit aktualisieren. Wir werden aktive humans über wesentliche Änderungen per E-Mail benachrichtigen.</value></data>
+  <data name="Privacy_ContactTitle" xml:space="preserve"><value>Kontakt &amp; Beschwerden</value></data>
+  <data name="Privacy_ContactBody" xml:space="preserve"><value>Bei Fragen oder Bedenken zu dieser Richtlinie kontaktiere unseren Datenschutzbeauftragten unter {0}.</value><comment>{0} = DPO email</comment></data>
+  <data name="Privacy_ComplaintBody" xml:space="preserve"><value>Wenn du mit unserer Antwort nicht zufrieden bist, hast du das Recht, eine Beschwerde bei der Spanischen Datenschutzbehörde (AEPD) unter {0} einzureichen.</value><comment>{0} = AEPD URL</comment></data>
+
 
 </root>

--- a/src/Humans.Web/Resources/SharedResource.es.resx
+++ b/src/Humans.Web/Resources/SharedResource.es.resx
@@ -1319,44 +1319,44 @@
   <data name="Todo_ShiftInfo_Action" xml:space="preserve"><value>Completar info de turno</value></data>
 
   <!-- Notification Inbox -->
-  <data name="Notification_Bell_AriaLabel" xml:space="preserve"><value>Notifications</value></data>
-  <data name="Notification_Popup_AriaLabel" xml:space="preserve"><value>Notification popup</value></data>
-  <data name="Notification_Popup_Title" xml:space="preserve"><value>Notifications</value></data>
-  <data name="Notification_Popup_NeedAction" xml:space="preserve"><value>need action</value></data>
-  <data name="Notification_Popup_Close" xml:space="preserve"><value>Close notifications</value></data>
-  <data name="Notification_Popup_CaughtUp" xml:space="preserve"><value>You're all caught up.</value></data>
-  <data name="Notification_Popup_NoUnread" xml:space="preserve"><value>No unread notifications.</value></data>
-  <data name="Notification_Section_NeedsAttention" xml:space="preserve"><value>Needs your attention</value></data>
-  <data name="Notification_Section_Recent" xml:space="preserve"><value>Recent</value></data>
-  <data name="Notification_Section_Informational" xml:space="preserve"><value>Informational</value></data>
-  <data name="Notification_Section_Resolved" xml:space="preserve"><value>Resolved</value></data>
-  <data name="Notification_Section_WorkQueues" xml:space="preserve"><value>Work queues</value></data>
-  <data name="Notification_MarkAllRead" xml:space="preserve"><value>Mark all as read</value></data>
-  <data name="Notification_SeeAll" xml:space="preserve"><value>See all notifications</value></data>
-  <data name="Notification_PageTitle" xml:space="preserve"><value>All notifications</value></data>
-  <data name="Notification_SearchPlaceholder" xml:space="preserve"><value>Search notifications...</value></data>
-  <data name="Notification_Filter_All" xml:space="preserve"><value>All</value></data>
-  <data name="Notification_Filter_NeedsAction" xml:space="preserve"><value>Needs action</value></data>
-  <data name="Notification_Filter_Shifts" xml:space="preserve"><value>Shifts</value></data>
-  <data name="Notification_Filter_Approvals" xml:space="preserve"><value>Approvals</value></data>
-  <data name="Notification_Filter_Resolved" xml:space="preserve"><value>Resolved</value></data>
-  <data name="Notification_Tab_Unread" xml:space="preserve"><value>Unread</value></data>
-  <data name="Notification_Tab_All" xml:space="preserve"><value>All</value></data>
-  <data name="Notification_Inbox_Title" xml:space="preserve"><value>Notifications</value></data>
-  <data name="Notification_Tag_Urgent" xml:space="preserve"><value>Urgent</value></data>
-  <data name="Notification_Tag_Action" xml:space="preserve"><value>Action</value></data>
+  <data name="Notification_Bell_AriaLabel" xml:space="preserve"><value>Notificaciones</value></data>
+  <data name="Notification_Popup_AriaLabel" xml:space="preserve"><value>Ventana de notificaciones</value></data>
+  <data name="Notification_Popup_Title" xml:space="preserve"><value>Notificaciones</value></data>
+  <data name="Notification_Popup_NeedAction" xml:space="preserve"><value>requieren acción</value></data>
+  <data name="Notification_Popup_Close" xml:space="preserve"><value>Cerrar notificaciones</value></data>
+  <data name="Notification_Popup_CaughtUp" xml:space="preserve"><value>Estás al día.</value></data>
+  <data name="Notification_Popup_NoUnread" xml:space="preserve"><value>No hay notificaciones sin leer.</value></data>
+  <data name="Notification_Section_NeedsAttention" xml:space="preserve"><value>Requiere tu atención</value></data>
+  <data name="Notification_Section_Recent" xml:space="preserve"><value>Recientes</value></data>
+  <data name="Notification_Section_Informational" xml:space="preserve"><value>Informativos</value></data>
+  <data name="Notification_Section_Resolved" xml:space="preserve"><value>Resueltos</value></data>
+  <data name="Notification_Section_WorkQueues" xml:space="preserve"><value>Colas de trabajo</value></data>
+  <data name="Notification_MarkAllRead" xml:space="preserve"><value>Marcar todo como leído</value></data>
+  <data name="Notification_SeeAll" xml:space="preserve"><value>Ver todas las notificaciones</value></data>
+  <data name="Notification_PageTitle" xml:space="preserve"><value>Todas las notificaciones</value></data>
+  <data name="Notification_SearchPlaceholder" xml:space="preserve"><value>Buscar notificaciones...</value></data>
+  <data name="Notification_Filter_All" xml:space="preserve"><value>Todas</value></data>
+  <data name="Notification_Filter_NeedsAction" xml:space="preserve"><value>Requiere acción</value></data>
+  <data name="Notification_Filter_Shifts" xml:space="preserve"><value>Turnos</value></data>
+  <data name="Notification_Filter_Approvals" xml:space="preserve"><value>Aprobaciones</value></data>
+  <data name="Notification_Filter_Resolved" xml:space="preserve"><value>Resueltos</value></data>
+  <data name="Notification_Tab_Unread" xml:space="preserve"><value>Sin leer</value></data>
+  <data name="Notification_Tab_All" xml:space="preserve"><value>Todas</value></data>
+  <data name="Notification_Inbox_Title" xml:space="preserve"><value>Notificaciones</value></data>
+  <data name="Notification_Tag_Urgent" xml:space="preserve"><value>Urgente</value></data>
+  <data name="Notification_Tag_Action" xml:space="preserve"><value>Acción</value></data>
   <data name="Notification_Tag_Info" xml:space="preserve"><value>Info</value></data>
-  <data name="Notification_Dismiss" xml:space="preserve"><value>Dismiss</value></data>
-  <data name="Notification_HandledBy" xml:space="preserve"><value>Handled by {0}, {1}</value></data>
-  <data name="Notification_Pref_InboxEnabled" xml:space="preserve"><value>In-app notifications</value></data>
-  <data name="Notification_DefaultActionLabel" xml:space="preserve"><value>View →</value></data>
-  <data name="Notification_TimeAgo_JustNow" xml:space="preserve"><value>just now</value></data>
-  <data name="Notification_TimeAgo_Minutes" xml:space="preserve"><value>{0}m ago</value></data>
-  <data name="Notification_TimeAgo_Hours" xml:space="preserve"><value>{0}h ago</value></data>
-  <data name="Notification_TimeAgo_Days" xml:space="preserve"><value>{0}d ago</value></data>
-  <data name="Notification_Bulk_Selected" xml:space="preserve"><value>{0} selected</value></data>
-  <data name="Notification_Bulk_Resolve" xml:space="preserve"><value>Resolve selected</value></data>
-  <data name="Notification_Bulk_Dismiss" xml:space="preserve"><value>Dismiss selected</value></data>
+  <data name="Notification_Dismiss" xml:space="preserve"><value>Descartar</value></data>
+  <data name="Notification_HandledBy" xml:space="preserve"><value>Gestionado por {0}, {1}</value></data>
+  <data name="Notification_Pref_InboxEnabled" xml:space="preserve"><value>Notificaciones en la aplicación</value></data>
+  <data name="Notification_DefaultActionLabel" xml:space="preserve"><value>Ver →</value></data>
+  <data name="Notification_TimeAgo_JustNow" xml:space="preserve"><value>ahora mismo</value></data>
+  <data name="Notification_TimeAgo_Minutes" xml:space="preserve"><value>hace {0}m</value></data>
+  <data name="Notification_TimeAgo_Hours" xml:space="preserve"><value>hace {0}h</value></data>
+  <data name="Notification_TimeAgo_Days" xml:space="preserve"><value>hace {0}d</value></data>
+  <data name="Notification_Bulk_Selected" xml:space="preserve"><value>{0} seleccionados</value></data>
+  <data name="Notification_Bulk_Resolve" xml:space="preserve"><value>Resolver seleccionados</value></data>
+  <data name="Notification_Bulk_Dismiss" xml:space="preserve"><value>Descartar seleccionados</value></data>
 
   <!-- Get Involved card (Dashboard) -->
   <data name="GetInvolved_Title" xml:space="preserve"><value>Participa</value></data>
@@ -1435,5 +1435,257 @@
   <data name="CityPlanning_Help_OverlapsDiscordChannel" xml:space="preserve"><value>Discord #city-planning</value></data>
   <data name="CityPlanning_Help_ColorsTitle" xml:space="preserve"><value>Colores y zonas de sonido</value></data>
   <data name="CityPlanning_Help_ColorsBody" xml:space="preserve"><value>Cada barrio está coloreado según su zona de sonido preferida (editable desde la página de tu barrio).</value></data>
+
+
+  <!-- ======================== -->
+  <!-- User-Facing Views        -->
+  <!-- ======================== -->
+  <data name="Feedback_PageTitle" xml:space="preserve"><value>Comentarios</value></data>
+  <data name="Feedback_AllStatuses" xml:space="preserve"><value>Todos los estados</value></data>
+  <data name="Feedback_AllCategories" xml:space="preserve"><value>Todas las categorías</value></data>
+  <data name="Feedback_AllReporters" xml:space="preserve"><value>Todos los informantes</value></data>
+  <data name="Feedback_AllAssignees" xml:space="preserve"><value>Todos los asignados</value></data>
+  <data name="Feedback_AssignedToMe" xml:space="preserve"><value>Asignado a mí</value></data>
+  <data name="Feedback_AllTeams" xml:space="preserve"><value>Todos los equipos</value></data>
+  <data name="Feedback_UnassignedOnly" xml:space="preserve"><value>Solo sin asignar</value></data>
+  <data name="Feedback_Clear" xml:space="preserve"><value>Limpiar</value></data>
+  <data name="Feedback_NoReports" xml:space="preserve"><value>No se encontraron informes de comentarios.</value></data>
+  <data name="Feedback_Unassigned" xml:space="preserve"><value>Sin asignar</value></data>
+  <data name="Feedback_NeedsReply" xml:space="preserve"><value>necesita respuesta</value></data>
+  <data name="Feedback_SelectReport" xml:space="preserve"><value>Selecciona un informe para ver detalles</value></data>
+  <data name="Feedback_Conversation" xml:space="preserve"><value>Conversación</value></data>
+  <data name="Feedback_NoMessages" xml:space="preserve"><value>Aún no hay mensajes.</value></data>
+  <data name="Feedback_MessagePlaceholder" xml:space="preserve"><value>Escribe un mensaje...</value></data>
+  <data name="Feedback_Send" xml:space="preserve"><value>Enviar</value></data>
+  <data name="Feedback_ResolvedAt" xml:space="preserve"><value>Resuelto {0}</value><comment>{0} = date/time</comment></data>
+  <data name="Feedback_ResolvedBy" xml:space="preserve"><value>por {0}</value><comment>{0} = name</comment></data>
+  <data name="Feedback_NoTeam" xml:space="preserve"><value>Sin equipo</value></data>
+  <data name="Feedback_ScreenshotLink" xml:space="preserve"><value>Captura de pantalla</value></data>
+
+  <data name="Unsub_Title" xml:space="preserve"><value>Darse de baja de correos</value></data>
+  <data name="Unsub_Heading" xml:space="preserve"><value>¿Darse de baja de correos de {0}?</value><comment>{0} = category name</comment></data>
+  <data name="Unsub_Greeting" xml:space="preserve"><value>Hola {0},</value><comment>{0} = display name</comment></data>
+  <data name="Unsub_ConfirmMessage" xml:space="preserve"><value>Si confirmas, dejarás de recibir correos de {0} de Humans.</value><comment>{0} = category name</comment></data>
+  <data name="Unsub_ConfirmButton" xml:space="preserve"><value>Confirmar baja</value></data>
+  <data name="Unsub_DoneTitle" xml:space="preserve"><value>Te has dado de baja</value></data>
+  <data name="Unsub_DoneMessage" xml:space="preserve"><value>Ya no recibirás correos de {0} de Humans.</value><comment>{0} = category name</comment></data>
+  <data name="Unsub_DoneManage" xml:space="preserve"><value>Puedes gestionar tus preferencias de comunicación desde tus</value></data>
+  <data name="Unsub_DoneManageLink" xml:space="preserve"><value>preferencias de comunicación</value></data>
+  <data name="Unsub_BackHome" xml:space="preserve"><value>Volver al inicio</value></data>
+  <data name="Unsub_ExpiredTitle" xml:space="preserve"><value>Enlace de baja caducado</value></data>
+  <data name="Unsub_ExpiredHeading" xml:space="preserve"><value>Este enlace de baja ha caducado</value></data>
+  <data name="Unsub_ExpiredMessage" xml:space="preserve"><value>Usa el enlace de un correo más reciente, o</value></data>
+  <data name="Unsub_ExpiredSignIn" xml:space="preserve"><value>inicia sesión para gestionar tus preferencias de comunicación</value></data>
+
+  <data name="CommPrefs_Title" xml:space="preserve"><value>Preferencias de comunicación</value></data>
+  <data name="CommPrefs_Description" xml:space="preserve"><value>Elige qué comunicaciones recibes y cómo.</value></data>
+  <data name="CommPrefs_Category" xml:space="preserve"><value>Categoría</value></data>
+  <data name="CommPrefs_Email" xml:space="preserve"><value>Correo</value></data>
+  <data name="CommPrefs_Alert" xml:space="preserve"><value>Alerta</value></data>
+  <data name="CommPrefs_BackToProfile" xml:space="preserve"><value>Volver al perfil</value></data>
+  <data name="CommPrefs_BackToDashboard" xml:space="preserve"><value>Volver al panel</value></data>
+
+  <data name="Emails_Header_Email" xml:space="preserve"><value>Correo</value></data>
+  <data name="Emails_Header_Status" xml:space="preserve"><value>Estado</value></data>
+  <data name="Emails_Header_Notifications" xml:space="preserve"><value>Notificaciones</value></data>
+  <data name="Emails_Header_Visibility" xml:space="preserve"><value>Visibilidad del perfil</value></data>
+  <data name="Emails_SignIn" xml:space="preserve"><value>Inicio de sesión</value></data>
+  <data name="Emails_MergePending" xml:space="preserve"><value>Fusión pendiente</value></data>
+  <data name="Emails_Verified" xml:space="preserve"><value>Verificado</value></data>
+  <data name="Emails_StatusPending" xml:space="preserve"><value>Pendiente</value></data>
+  <data name="Emails_Unverified" xml:space="preserve"><value>No verificado</value></data>
+  <data name="Emails_NotifActive" xml:space="preserve"><value>Activo</value></data>
+  <data name="Emails_SetAsTarget" xml:space="preserve"><value>Establecer como destino</value></data>
+  <data name="Emails_VerifyFirst" xml:space="preserve"><value>Verifica primero</value></data>
+  <data name="Emails_Visibility_Hidden" xml:space="preserve"><value>Oculto</value></data>
+  <data name="Emails_Visibility_AllHumans" xml:space="preserve"><value>Todos los humans</value></data>
+  <data name="Emails_Visibility_MyTeams" xml:space="preserve"><value>Mis equipos</value></data>
+  <data name="Emails_Visibility_CoordinatorsBoard" xml:space="preserve"><value>Coordinadores + Junta</value></data>
+  <data name="Emails_Visibility_BoardOnly" xml:space="preserve"><value>Solo junta</value></data>
+  <data name="Emails_ConfirmRemove" xml:space="preserve"><value>¿Seguro que quieres eliminar este correo?</value></data>
+  <data name="Emails_GoogleTitle" xml:space="preserve"><value>Correo de servicios de Google</value></data>
+  <data name="Emails_GoogleDescription" xml:space="preserve"><value>Este correo se usa para acceder a Grupos de Google y unidades compartidas.</value></data>
+  <data name="Emails_GoogleAutoNobodies" xml:space="preserve"><value>Tu correo @nobodies.team se usa automáticamente.</value></data>
+  <data name="Emails_GoogleRejected" xml:space="preserve"><value>La sincronización de Google falló. El correo actual fue rechazado por Google. Selecciona otro correo para reintentar.</value></data>
+  <data name="Emails_GoogleValid" xml:space="preserve"><value>La sincronización de Google funciona con el correo actual.</value></data>
+  <data name="Emails_AutoSelected" xml:space="preserve"><value>Seleccionado automáticamente</value></data>
+  <data name="Emails_GoogleRejectedBadge" xml:space="preserve"><value>Rechazado</value></data>
+  <data name="Emails_UseThis" xml:space="preserve"><value>Usar este</value></data>
+
+  <data name="ShiftInfo_Title" xml:space="preserve"><value>Preferencias de turnos</value></data>
+  <data name="ShiftInfo_StepOf" xml:space="preserve"><value>Paso {0} de {1}</value><comment>{0} = current step, {1} = total steps</comment></data>
+  <data name="ShiftInfo_SkillsTitle" xml:space="preserve"><value>¿En qué eres bueno/a?</value></data>
+  <data name="ShiftInfo_SkillsSubtitle" xml:space="preserve"><value>Selecciona las habilidades que te gustaría usar. Puedes cambiarlas en cualquier momento.</value></data>
+  <data name="ShiftInfo_WorkStyleTitle" xml:space="preserve"><value>¿Cómo te gusta trabajar?</value></data>
+  <data name="ShiftInfo_WorkStyleSubtitle" xml:space="preserve"><value>Ayuda a los coordinadores a asignarte turnos que se adapten a tu estilo y disponibilidad.</value></data>
+  <data name="ShiftInfo_LanguagesTitle" xml:space="preserve"><value>¿Qué idiomas hablas?</value></data>
+  <data name="ShiftInfo_LanguagesSubtitle" xml:space="preserve"><value>Esto nos ayuda a ubicarte en equipos donde puedas comunicarte bien.</value></data>
+  <data name="ShiftInfo_OtherSkills" xml:space="preserve"><value>¿Qué otras habilidades tienes?</value></data>
+  <data name="ShiftInfo_WorkTime" xml:space="preserve"><value>¿Cuándo prefieres trabajar?</value></data>
+  <data name="ShiftInfo_OtherPrefs" xml:space="preserve"><value>Otras preferencias</value></data>
+  <data name="ShiftInfo_OtherLanguages" xml:space="preserve"><value>¿Qué otros idiomas hablas?</value></data>
+  <data name="ShiftInfo_Continue" xml:space="preserve"><value>Continuar</value></data>
+
+  <data name="Shifts_Title" xml:space="preserve"><value>Turnos</value></data>
+  <data name="Shifts_BrowseTitle" xml:space="preserve"><value>Explorar opciones de voluntariado</value></data>
+  <data name="Shifts_Department" xml:space="preserve"><value>Departamento</value></data>
+  <data name="Shifts_AllDepartments" xml:space="preserve"><value>Todos los departamentos</value></data>
+  <data name="Shifts_From" xml:space="preserve"><value>Desde</value></data>
+  <data name="Shifts_To" xml:space="preserve"><value>Hasta</value></data>
+  <data name="Shifts_ClearFilters" xml:space="preserve"><value>Limpiar filtros</value></data>
+  <data name="Shifts_All" xml:space="preserve"><value>Todos</value></data>
+  <data name="Shifts_SetUp" xml:space="preserve"><value>Montaje</value></data>
+  <data name="Shifts_Event" xml:space="preserve"><value>Evento</value></data>
+  <data name="Shifts_Strike" xml:space="preserve"><value>Desmontaje</value></data>
+  <data name="Shifts_FilterByTag" xml:space="preserve"><value>Filtrar por etiqueta:</value></data>
+  <data name="Shifts_SetPreferences" xml:space="preserve"><value>Configura tus preferencias</value></data>
+  <data name="Shifts_PreferencesHelp" xml:space="preserve"><value>Selecciona etiquetas que coincidan con el trabajo que te gusta. Los turnos coincidentes se resaltarán con una estrella.</value></data>
+  <data name="Shifts_SavePreferences" xml:space="preserve"><value>Guardar preferencias</value></data>
+  <data name="Shifts_NotOpenYet" xml:space="preserve"><value>Los turnos aún no están abiertos. Solo coordinadores y administradores pueden ver esta página.</value></data>
+  <data name="Shifts_NoShiftsAvailable" xml:space="preserve"><value>Aún no hay turnos disponibles.</value></data>
+  <data name="Shifts_AllShiftsFull" xml:space="preserve"><value>Todos los turnos de {0} están completos.</value><comment>{0} = period name</comment></data>
+  <data name="Shifts_Start" xml:space="preserve"><value>Inicio</value></data>
+  <data name="Shifts_End" xml:space="preserve"><value>Fin</value></data>
+  <data name="Shifts_SignUpForDates" xml:space="preserve"><value>Inscribirse en fechas de {0}</value><comment>{0} = period name (e.g. set-up, strike)</comment></data>
+  <data name="Shifts_Date" xml:space="preserve"><value>Fecha</value></data>
+  <data name="Shifts_Filled" xml:space="preserve"><value>Ocupados</value></data>
+  <data name="Shifts_Days" xml:space="preserve"><value>días</value></data>
+  <data name="Shifts_Total" xml:space="preserve"><value>total</value></data>
+    <data name="Shifts_SignedUpAllDays" xml:space="preserve"><value>Inscrito (los {0} días)</value><comment>{0} = count</comment></data>
+    <data name="Shifts_SignedUpPartial" xml:space="preserve"><value>Inscrito ({0} de {1})</value><comment>{0} = count</comment></data>
+  <data name="Shifts_Full" xml:space="preserve"><value>Completo</value></data>
+  <data name="Shifts_NeedsHelp" xml:space="preserve"><value>Necesita ayuda</value></data>
+  <data name="Shifts_DayNeedsHelp" xml:space="preserve"><value>{0} día necesita ayuda</value><comment>{0} = number of days</comment></data>
+  <data name="Shifts_DaysNeedHelp" xml:space="preserve"><value>{0} días necesitan ayuda</value><comment>{0} = number of days</comment></data>
+  <data name="Shifts_ClickToExpand" xml:space="preserve"><value>clic para expandir</value></data>
+  <data name="Shifts_Shift" xml:space="preserve"><value>Turno</value></data>
+  <data name="Shifts_Phase" xml:space="preserve"><value>Fase</value></data>
+  <data name="Shifts_Time" xml:space="preserve"><value>Hora</value></data>
+  <data name="Shifts_Duration" xml:space="preserve"><value>Duración</value></data>
+  <data name="Shifts_AllDay" xml:space="preserve"><value>Todo el día</value></data>
+  <data name="Shifts_FullDay" xml:space="preserve"><value>Día completo</value></data>
+  <data name="Shifts_Essential" xml:space="preserve"><value>Esencial</value></data>
+  <data name="Shifts_Important" xml:space="preserve"><value>Importante</value></data>
+  <data name="Shifts_AllPhases" xml:space="preserve"><value>Todas las fases</value></data>
+  <data name="Shifts_HiddenBadge" xml:space="preserve"><value>Oculto</value></data>
+  <data name="Shifts_MatchesPrefs" xml:space="preserve"><value>Coincide con tus preferencias</value></data>
+  <data name="Shifts_SignUpButton" xml:space="preserve"><value>Inscribirse</value></data>
+  <data name="Shifts_BrowsingClosed" xml:space="preserve"><value>La exploración de turnos aún no está abierta. ¡Vuelve más tarde!</value></data>
+  <data name="Shifts_NoActiveEvent" xml:space="preserve"><value>No hay ningún evento activo configurado. Un administrador debe configurar los ajustes del evento primero.</value></data>
+  <data name="Shifts_ConfigureEvent" xml:space="preserve"><value>Configurar ajustes del evento</value></data>
+  <data name="Shifts_MyShiftsTitle" xml:space="preserve"><value>Mis turnos</value></data>
+  <data name="Shifts_UpcomingShifts" xml:space="preserve"><value>Próximos turnos</value></data>
+  <data name="Shifts_PendingApproval" xml:space="preserve"><value>Pendiente de aprobación</value></data>
+  <data name="Shifts_Past" xml:space="preserve"><value>Pasados</value></data>
+  <data name="Shifts_Bail" xml:space="preserve"><value>Cancelar</value></data>
+  <data name="Shifts_BailConfirm" xml:space="preserve"><value>¿Seguro que quieres cancelar?</value></data>
+  <data name="Shifts_BailRangeConfirm" xml:space="preserve"><value>¿Cancelar todos los {0} días?</value><comment>{0} = number of days</comment></data>
+  <data name="Shifts_WithdrawButton" xml:space="preserve"><value>Retirar</value></data>
+  <data name="Shifts_NoSignups" xml:space="preserve"><value>Aún no te has inscrito en ningún turno.</value></data>
+  <data name="Shifts_BrowseAvailable" xml:space="preserve"><value>Explorar turnos disponibles</value></data>
+  <data name="Shifts_NoActiveEventConfigured" xml:space="preserve"><value>No hay evento activo configurado.</value></data>
+  <data name="Shifts_GeneralAvailability" xml:space="preserve"><value>Disponibilidad general</value></data>
+  <data name="Shifts_AvailabilityHelp" xml:space="preserve"><value>Marca los días que estás disponible para ayudar. Los coordinadores pueden ver quién está disponible al asignar turnos.</value></data>
+  <data name="Shifts_SaveAvailability" xml:space="preserve"><value>Guardar disponibilidad</value></data>
+
+  <data name="ShiftDash_Title" xml:space="preserve"><value>Panel de turnos</value></data>
+  <data name="ShiftDash_ShiftsCount" xml:space="preserve"><value>{0} turnos</value><comment>{0} = count</comment></data>
+  <data name="ShiftDash_Date" xml:space="preserve"><value>Fecha</value></data>
+  <data name="ShiftDash_Department" xml:space="preserve"><value>Departamento</value></data>
+  <data name="ShiftDash_AllDepartments" xml:space="preserve"><value>Todos los departamentos</value></data>
+  <data name="ShiftDash_Filter" xml:space="preserve"><value>Filtrar</value></data>
+  <data name="ShiftDash_Clear" xml:space="preserve"><value>Limpiar</value></data>
+  <data name="ShiftDash_NoShiftsMatch" xml:space="preserve"><value>Ningún turno coincide con los filtros actuales.</value></data>
+  <data name="ShiftDash_Shift" xml:space="preserve"><value>Turno</value></data>
+  <data name="ShiftDash_DateTime" xml:space="preserve"><value>Fecha / Hora</value></data>
+  <data name="ShiftDash_Slots" xml:space="preserve"><value>Plazas</value></data>
+  <data name="ShiftDash_Priority" xml:space="preserve"><value>Prioridad</value></data>
+  <data name="ShiftDash_Voluntell" xml:space="preserve"><value>Voluntell</value></data>
+  <data name="ShiftDash_SearchHumans" xml:space="preserve"><value>Buscar humans para: {0}</value><comment>{0} = shift/rota name</comment></data>
+  <data name="ShiftDash_SearchPlaceholder" xml:space="preserve"><value>Escribe un nombre (mín. 2 caracteres)...</value></data>
+  <data name="ShiftDash_NoHumansFound" xml:space="preserve"><value>No se encontraron humans.</value></data>
+  <data name="ShiftDash_SearchFailed" xml:space="preserve"><value>La búsqueda falló.</value></data>
+  <data name="ShiftDash_ScheduleConflict" xml:space="preserve"><value>Conflicto de horario</value></data>
+
+  <data name="Nav_Legal" xml:space="preserve"><value>Legal</value></data>
+  <data name="Nav_Staff" xml:space="preserve"><value>Equipo</value></data>
+
+  <data name="ProfileCard_Suspended" xml:space="preserve"><value>Suspendido</value></data>
+  <data name="ProfileCard_PendingBadge" xml:space="preserve"><value>Pendiente</value></data>
+  <data name="ProfileCard_Teams" xml:space="preserve"><value>Equipos:</value></data>
+  <data name="ProfileCard_Joined" xml:space="preserve"><value>Se unió en {0}</value><comment>{0} = date</comment></data>
+  <data name="ProfileCard_LastLogin" xml:space="preserve"><value>Último acceso {0}</value><comment>{0} = date</comment></data>
+
+  <data name="ShiftsSummary_Title" xml:space="preserve"><value>Turnos</value></data>
+  <data name="ShiftsSummary_SlotsFilled" xml:space="preserve"><value>{0} / {1} plazas ocupadas</value><comment>{0} = filled, {1} = total</comment></data>
+  <data name="ShiftsSummary_HumansSignedUp" xml:space="preserve"><value>{0} humans inscritos</value><comment>{0} = count</comment></data>
+  <data name="ShiftsSummary_PendingCount" xml:space="preserve"><value>{0} pendientes</value><comment>{0} = count</comment></data>
+  <data name="ShiftsSummary_NoShifts" xml:space="preserve"><value>Aún no hay turnos configurados.</value></data>
+  <data name="ShiftsSummary_IncludesSubTeams" xml:space="preserve"><value>Incluye turnos de {0} subequipo(s)</value><comment>{0} = count</comment></data>
+  <data name="ShiftsSummary_ManageShifts" xml:space="preserve"><value>Gestionar turnos</value></data>
+
+  <data name="Medical_Badge" xml:space="preserve"><value>Médico</value></data>
+
+  <data name="Privacy_Lead" xml:space="preserve"><value>Humans gestiona la membresía de Nobodies Collective y procesa datos personales conforme al RGPD y la ley española de protección de datos (LOPDGDD).</value></data>
+  <data name="Privacy_DataControllerTitle" xml:space="preserve"><value>Responsable del tratamiento</value></data>
+  <data name="Privacy_DataControllerBody" xml:space="preserve"><value>Una asociación sin ánimo de lucro española registrada en Andalucía.</value></data>
+  <data name="Privacy_DataControllerDPO" xml:space="preserve"><value>Para consultas sobre protección de datos, contacta con nuestro Delegado de Protección de Datos en:</value></data>
+  <data name="Privacy_DataWeCollectTitle" xml:space="preserve"><value>Datos que recopilamos</value></data>
+  <data name="Privacy_DataWeCollectIntro" xml:space="preserve"><value>Recopilamos y procesamos las siguientes categorías de datos personales:</value></data>
+  <data name="Privacy_Collect_Identity" xml:space="preserve"><value>Nombre, correo electrónico (de la autenticación de Google), nombre para mostrar</value></data>
+  <data name="Privacy_Collect_Contact" xml:space="preserve"><value>Teléfono, ciudad, país (opcional)</value></data>
+  <data name="Privacy_Collect_Profile" xml:space="preserve"><value>Biografía, pertenencia a equipos, asignaciones de roles</value></data>
+  <data name="Privacy_Collect_Technical" xml:space="preserve"><value>Dirección IP y agente de usuario (para registros de consentimiento)</value></data>
+  <data name="Privacy_Collect_Application" xml:space="preserve"><value>Solicitudes de membresía y declaraciones de motivación</value></data>
+  <data name="Privacy_Collect_Consent" xml:space="preserve"><value>Registros de tu aceptación de documentos legales</value></data>
+  <data name="Privacy_LegalBasisTitle" xml:space="preserve"><value>Base legal del tratamiento</value></data>
+  <data name="Privacy_LegalBasisIntro" xml:space="preserve"><value>Procesamos tus datos en base a:</value></data>
+  <data name="Privacy_Legal_Contract" xml:space="preserve"><value>Tratamiento necesario para la gestión de membresía</value></data>
+  <data name="Privacy_Legal_LegitimateInterest" xml:space="preserve"><value>Mantenimiento de registros organizativos y comunicación</value></data>
+  <data name="Privacy_Legal_LegalObligation" xml:space="preserve"><value>Cumplimiento de la normativa española sobre asociaciones</value></data>
+  <data name="Privacy_Legal_Consent" xml:space="preserve"><value>Para datos opcionales que elijas proporcionar</value></data>
+  <data name="Privacy_HowWeUseTitle" xml:space="preserve"><value>Cómo usamos tus datos</value></data>
+  <data name="Privacy_Use_Membership" xml:space="preserve"><value>Para gestionar tu membresía y participación en equipos</value></data>
+  <data name="Privacy_Use_Communicate" xml:space="preserve"><value>Para comunicarnos contigo sobre actividades de la organización</value></data>
+  <data name="Privacy_Use_LegalCompliance" xml:space="preserve"><value>Para mantener registros de cumplimiento legal</value></data>
+  <data name="Privacy_Use_Connections" xml:space="preserve"><value>Para facilitar conexiones entre humans (según tu configuración de visibilidad)</value></data>
+  <data name="Privacy_DataRetentionTitle" xml:space="preserve"><value>Retención de datos</value></data>
+  <data name="Privacy_DataRetentionIntro" xml:space="preserve"><value>Conservamos tus datos según las siguientes políticas:</value></data>
+  <data name="Privacy_Retention_Active" xml:space="preserve"><value>Datos conservados mientras tu cuenta esté activa</value></data>
+  <data name="Privacy_Retention_Inactive" xml:space="preserve"><value>Datos conservados hasta 7 años por cumplimiento legal</value></data>
+  <data name="Privacy_Retention_Consent" xml:space="preserve"><value>Conservados indefinidamente según lo requiere el RGPD</value></data>
+  <data name="Privacy_Retention_Deleted" xml:space="preserve"><value>Anonimizados después de un periodo de gracia de 30 días</value></data>
+  <data name="Privacy_YourRightsTitle" xml:space="preserve"><value>Tus derechos</value></data>
+  <data name="Privacy_YourRightsIntro" xml:space="preserve"><value>Según el RGPD, tienes los siguientes derechos:</value></data>
+  <data name="Privacy_Rights_Access" xml:space="preserve"><value>Solicitar una copia de tus datos personales</value></data>
+  <data name="Privacy_Rights_Rectification" xml:space="preserve"><value>Solicitar la corrección de datos inexactos</value></data>
+  <data name="Privacy_Rights_Erasure" xml:space="preserve"><value>Solicitar la eliminación de tus datos (&quot;derecho al olvido&quot;)</value></data>
+  <data name="Privacy_Rights_Portability" xml:space="preserve"><value>Recibir tus datos en formato legible por máquina</value></data>
+  <data name="Privacy_Rights_Restriction" xml:space="preserve"><value>Solicitar la limitación del tratamiento</value></data>
+  <data name="Privacy_Rights_Objection" xml:space="preserve"><value>Oponerte a ciertos tipos de tratamiento</value></data>
+  <data name="Privacy_YourRightsExercise" xml:space="preserve"><value>Para ejercer estos derechos, visita tu configuración de {0} o contáctanos en {1}.</value><comment>{0} = Privacy &amp; Data link, {1} = DPO email</comment></data>
+  <data name="Privacy_PrivacyAndData" xml:space="preserve"><value>Privacidad y datos</value></data>
+  <data name="Privacy_CookiesTitle" xml:space="preserve"><value>Cookies</value></data>
+  <data name="Privacy_CookiesIntro" xml:space="preserve"><value>Este sitio solo usa cookies esenciales necesarias para:</value></data>
+  <data name="Privacy_Cookies_Auth" xml:space="preserve"><value>Autenticación de usuario y gestión de sesiones</value></data>
+  <data name="Privacy_Cookies_Antiforgery" xml:space="preserve"><value>Tokens anti-falsificación para seguridad de formularios</value></data>
+  <data name="Privacy_Cookies_Consent" xml:space="preserve"><value>Preferencia de consentimiento de cookies</value></data>
+  <data name="Privacy_CookiesNoTracking" xml:space="preserve"><value>No usamos cookies de análisis, publicidad ni seguimiento de terceros.</value></data>
+  <data name="Privacy_DataSecurityTitle" xml:space="preserve"><value>Seguridad de datos</value></data>
+  <data name="Privacy_DataSecurityIntro" xml:space="preserve"><value>Implementamos medidas técnicas y organizativas apropiadas para proteger tus datos, incluyendo:</value></data>
+  <data name="Privacy_Security_Encryption" xml:space="preserve"><value>Cifrado en tránsito (HTTPS)</value></data>
+  <data name="Privacy_Security_OAuth" xml:space="preserve"><value>Autenticación segura vía Google OAuth</value></data>
+  <data name="Privacy_Security_AccessControls" xml:space="preserve"><value>Controles de acceso y registro de auditoría</value></data>
+  <data name="Privacy_Security_Reviews" xml:space="preserve"><value>Revisiones de seguridad periódicas</value></data>
+  <data name="Privacy_ThirdPartyTitle" xml:space="preserve"><value>Servicios de terceros</value></data>
+  <data name="Privacy_ThirdPartyIntro" xml:space="preserve"><value>Usamos los siguientes servicios de terceros:</value></data>
+  <data name="Privacy_ThirdParty_GoogleOAuth" xml:space="preserve"><value>Para autenticación segura</value></data>
+  <data name="Privacy_ThirdParty_GoogleWorkspace" xml:space="preserve"><value>Para provisión de recursos de equipo (unidades compartidas, grupos)</value></data>
+  <data name="Privacy_ChangesTitle" xml:space="preserve"><value>Cambios a esta política</value></data>
+  <data name="Privacy_ChangesBody" xml:space="preserve"><value>Podemos actualizar esta política de privacidad periódicamente. Notificaremos a los humans activos sobre cambios significativos por correo.</value></data>
+  <data name="Privacy_ContactTitle" xml:space="preserve"><value>Contacto y reclamaciones</value></data>
+  <data name="Privacy_ContactBody" xml:space="preserve"><value>Para preguntas o dudas sobre esta política, contacta con nuestro Delegado de Protección de Datos en {0}.</value><comment>{0} = DPO email</comment></data>
+  <data name="Privacy_ComplaintBody" xml:space="preserve"><value>Si no estás satisfecho con nuestra respuesta, tienes derecho a presentar una reclamación ante la Agencia Española de Protección de Datos (AEPD) en {0}.</value><comment>{0} = AEPD URL</comment></data>
+
 
 </root>

--- a/src/Humans.Web/Resources/SharedResource.fr.resx
+++ b/src/Humans.Web/Resources/SharedResource.fr.resx
@@ -1318,43 +1318,43 @@
 
   <!-- Notification Inbox -->
   <data name="Notification_Bell_AriaLabel" xml:space="preserve"><value>Notifications</value></data>
-  <data name="Notification_Popup_AriaLabel" xml:space="preserve"><value>Notification popup</value></data>
+  <data name="Notification_Popup_AriaLabel" xml:space="preserve"><value>Popup de notifications</value></data>
   <data name="Notification_Popup_Title" xml:space="preserve"><value>Notifications</value></data>
-  <data name="Notification_Popup_NeedAction" xml:space="preserve"><value>need action</value></data>
-  <data name="Notification_Popup_Close" xml:space="preserve"><value>Close notifications</value></data>
-  <data name="Notification_Popup_CaughtUp" xml:space="preserve"><value>You're all caught up.</value></data>
-  <data name="Notification_Popup_NoUnread" xml:space="preserve"><value>No unread notifications.</value></data>
-  <data name="Notification_Section_NeedsAttention" xml:space="preserve"><value>Needs your attention</value></data>
-  <data name="Notification_Section_Recent" xml:space="preserve"><value>Recent</value></data>
-  <data name="Notification_Section_Informational" xml:space="preserve"><value>Informational</value></data>
-  <data name="Notification_Section_Resolved" xml:space="preserve"><value>Resolved</value></data>
-  <data name="Notification_Section_WorkQueues" xml:space="preserve"><value>Work queues</value></data>
-  <data name="Notification_MarkAllRead" xml:space="preserve"><value>Mark all as read</value></data>
-  <data name="Notification_SeeAll" xml:space="preserve"><value>See all notifications</value></data>
-  <data name="Notification_PageTitle" xml:space="preserve"><value>All notifications</value></data>
-  <data name="Notification_SearchPlaceholder" xml:space="preserve"><value>Search notifications...</value></data>
-  <data name="Notification_Filter_All" xml:space="preserve"><value>All</value></data>
-  <data name="Notification_Filter_NeedsAction" xml:space="preserve"><value>Needs action</value></data>
-  <data name="Notification_Filter_Shifts" xml:space="preserve"><value>Shifts</value></data>
-  <data name="Notification_Filter_Approvals" xml:space="preserve"><value>Approvals</value></data>
-  <data name="Notification_Filter_Resolved" xml:space="preserve"><value>Resolved</value></data>
-  <data name="Notification_Tab_Unread" xml:space="preserve"><value>Unread</value></data>
-  <data name="Notification_Tab_All" xml:space="preserve"><value>All</value></data>
+  <data name="Notification_Popup_NeedAction" xml:space="preserve"><value>nécessitent une action</value></data>
+  <data name="Notification_Popup_Close" xml:space="preserve"><value>Fermer les notifications</value></data>
+  <data name="Notification_Popup_CaughtUp" xml:space="preserve"><value>Vous êtes à jour.</value></data>
+  <data name="Notification_Popup_NoUnread" xml:space="preserve"><value>Aucune notification non lue.</value></data>
+  <data name="Notification_Section_NeedsAttention" xml:space="preserve"><value>Nécessite votre attention</value></data>
+  <data name="Notification_Section_Recent" xml:space="preserve"><value>Récentes</value></data>
+  <data name="Notification_Section_Informational" xml:space="preserve"><value>Informationnelles</value></data>
+  <data name="Notification_Section_Resolved" xml:space="preserve"><value>Résolues</value></data>
+  <data name="Notification_Section_WorkQueues" xml:space="preserve"><value>Files d'attente</value></data>
+  <data name="Notification_MarkAllRead" xml:space="preserve"><value>Tout marquer comme lu</value></data>
+  <data name="Notification_SeeAll" xml:space="preserve"><value>Voir toutes les notifications</value></data>
+  <data name="Notification_PageTitle" xml:space="preserve"><value>Toutes les notifications</value></data>
+  <data name="Notification_SearchPlaceholder" xml:space="preserve"><value>Rechercher des notifications...</value></data>
+  <data name="Notification_Filter_All" xml:space="preserve"><value>Toutes</value></data>
+  <data name="Notification_Filter_NeedsAction" xml:space="preserve"><value>Action nécessaire</value></data>
+  <data name="Notification_Filter_Shifts" xml:space="preserve"><value>Quarts</value></data>
+  <data name="Notification_Filter_Approvals" xml:space="preserve"><value>Approbations</value></data>
+  <data name="Notification_Filter_Resolved" xml:space="preserve"><value>Résolues</value></data>
+  <data name="Notification_Tab_Unread" xml:space="preserve"><value>Non lues</value></data>
+  <data name="Notification_Tab_All" xml:space="preserve"><value>Toutes</value></data>
   <data name="Notification_Inbox_Title" xml:space="preserve"><value>Notifications</value></data>
   <data name="Notification_Tag_Urgent" xml:space="preserve"><value>Urgent</value></data>
   <data name="Notification_Tag_Action" xml:space="preserve"><value>Action</value></data>
   <data name="Notification_Tag_Info" xml:space="preserve"><value>Info</value></data>
-  <data name="Notification_Dismiss" xml:space="preserve"><value>Dismiss</value></data>
-  <data name="Notification_HandledBy" xml:space="preserve"><value>Handled by {0}, {1}</value></data>
-  <data name="Notification_Pref_InboxEnabled" xml:space="preserve"><value>In-app notifications</value></data>
-  <data name="Notification_DefaultActionLabel" xml:space="preserve"><value>View →</value></data>
-  <data name="Notification_TimeAgo_JustNow" xml:space="preserve"><value>just now</value></data>
-  <data name="Notification_TimeAgo_Minutes" xml:space="preserve"><value>{0}m ago</value></data>
-  <data name="Notification_TimeAgo_Hours" xml:space="preserve"><value>{0}h ago</value></data>
-  <data name="Notification_TimeAgo_Days" xml:space="preserve"><value>{0}d ago</value></data>
-  <data name="Notification_Bulk_Selected" xml:space="preserve"><value>{0} selected</value></data>
-  <data name="Notification_Bulk_Resolve" xml:space="preserve"><value>Resolve selected</value></data>
-  <data name="Notification_Bulk_Dismiss" xml:space="preserve"><value>Dismiss selected</value></data>
+  <data name="Notification_Dismiss" xml:space="preserve"><value>Ignorer</value></data>
+  <data name="Notification_HandledBy" xml:space="preserve"><value>Géré par {0}, {1}</value></data>
+  <data name="Notification_Pref_InboxEnabled" xml:space="preserve"><value>Notifications dans l'application</value></data>
+  <data name="Notification_DefaultActionLabel" xml:space="preserve"><value>Voir →</value></data>
+  <data name="Notification_TimeAgo_JustNow" xml:space="preserve"><value>à l'instant</value></data>
+  <data name="Notification_TimeAgo_Minutes" xml:space="preserve"><value>il y a {0}m</value></data>
+  <data name="Notification_TimeAgo_Hours" xml:space="preserve"><value>il y a {0}h</value></data>
+  <data name="Notification_TimeAgo_Days" xml:space="preserve"><value>il y a {0}j</value></data>
+  <data name="Notification_Bulk_Selected" xml:space="preserve"><value>{0} sélectionné(s)</value></data>
+  <data name="Notification_Bulk_Resolve" xml:space="preserve"><value>Résoudre la sélection</value></data>
+  <data name="Notification_Bulk_Dismiss" xml:space="preserve"><value>Ignorer la sélection</value></data>
 
   <!-- Get Involved card (Dashboard) -->
   <data name="GetInvolved_Title" xml:space="preserve"><value>Participe</value></data>
@@ -1433,5 +1433,257 @@
   <data name="CityPlanning_Help_OverlapsDiscordChannel" xml:space="preserve"><value>Discord #city-planning</value></data>
   <data name="CityPlanning_Help_ColorsTitle" xml:space="preserve"><value>Couleurs &amp; zones sonores</value></data>
   <data name="CityPlanning_Help_ColorsBody" xml:space="preserve"><value>Chaque barrio est coloré selon sa zone sonore préférée (modifiable depuis la page de ton barrio).</value></data>
+
+
+  <!-- ======================== -->
+  <!-- User-Facing Views        -->
+  <!-- ======================== -->
+  <data name="Feedback_PageTitle" xml:space="preserve"><value>Retours</value></data>
+  <data name="Feedback_AllStatuses" xml:space="preserve"><value>Tous les statuts</value></data>
+  <data name="Feedback_AllCategories" xml:space="preserve"><value>Toutes les catégories</value></data>
+  <data name="Feedback_AllReporters" xml:space="preserve"><value>Tous les signaleurs</value></data>
+  <data name="Feedback_AllAssignees" xml:space="preserve"><value>Tous les assignés</value></data>
+  <data name="Feedback_AssignedToMe" xml:space="preserve"><value>Assigné à moi</value></data>
+  <data name="Feedback_AllTeams" xml:space="preserve"><value>Toutes les équipes</value></data>
+  <data name="Feedback_UnassignedOnly" xml:space="preserve"><value>Non assignés uniquement</value></data>
+  <data name="Feedback_Clear" xml:space="preserve"><value>Effacer</value></data>
+  <data name="Feedback_NoReports" xml:space="preserve"><value>Aucun rapport trouvé.</value></data>
+  <data name="Feedback_Unassigned" xml:space="preserve"><value>Non assigné</value></data>
+  <data name="Feedback_NeedsReply" xml:space="preserve"><value>réponse nécessaire</value></data>
+  <data name="Feedback_SelectReport" xml:space="preserve"><value>Sélectionnez un rapport pour voir les détails</value></data>
+  <data name="Feedback_Conversation" xml:space="preserve"><value>Conversation</value></data>
+  <data name="Feedback_NoMessages" xml:space="preserve"><value>Pas encore de messages.</value></data>
+  <data name="Feedback_MessagePlaceholder" xml:space="preserve"><value>Écrivez un message...</value></data>
+  <data name="Feedback_Send" xml:space="preserve"><value>Envoyer</value></data>
+  <data name="Feedback_ResolvedAt" xml:space="preserve"><value>Résolu {0}</value><comment>{0} = date/time</comment></data>
+  <data name="Feedback_ResolvedBy" xml:space="preserve"><value>par {0}</value><comment>{0} = name</comment></data>
+  <data name="Feedback_NoTeam" xml:space="preserve"><value>Aucune équipe</value></data>
+  <data name="Feedback_ScreenshotLink" xml:space="preserve"><value>Capture d'écran</value></data>
+
+  <data name="Unsub_Title" xml:space="preserve"><value>Se désabonner des e-mails</value></data>
+  <data name="Unsub_Heading" xml:space="preserve"><value>Se désabonner des e-mails {0} ?</value><comment>{0} = category name</comment></data>
+  <data name="Unsub_Greeting" xml:space="preserve"><value>Bonjour {0},</value><comment>{0} = display name</comment></data>
+  <data name="Unsub_ConfirmMessage" xml:space="preserve"><value>Si vous confirmez, vous ne recevrez plus les e-mails {0} de Humans.</value><comment>{0} = category name</comment></data>
+  <data name="Unsub_ConfirmButton" xml:space="preserve"><value>Confirmer le désabonnement</value></data>
+  <data name="Unsub_DoneTitle" xml:space="preserve"><value>Vous êtes désabonné(e)</value></data>
+  <data name="Unsub_DoneMessage" xml:space="preserve"><value>Vous ne recevrez plus les e-mails {0} de Humans.</value><comment>{0} = category name</comment></data>
+  <data name="Unsub_DoneManage" xml:space="preserve"><value>Vous pouvez gérer vos préférences de communication depuis vos</value></data>
+  <data name="Unsub_DoneManageLink" xml:space="preserve"><value>préférences de communication</value></data>
+  <data name="Unsub_BackHome" xml:space="preserve"><value>Retour à l'accueil</value></data>
+  <data name="Unsub_ExpiredTitle" xml:space="preserve"><value>Lien de désabonnement expiré</value></data>
+  <data name="Unsub_ExpiredHeading" xml:space="preserve"><value>Ce lien de désabonnement a expiré</value></data>
+  <data name="Unsub_ExpiredMessage" xml:space="preserve"><value>Veuillez utiliser le lien d'un e-mail plus récent, ou</value></data>
+  <data name="Unsub_ExpiredSignIn" xml:space="preserve"><value>connectez-vous pour gérer vos préférences de communication</value></data>
+
+  <data name="CommPrefs_Title" xml:space="preserve"><value>Préférences de communication</value></data>
+  <data name="CommPrefs_Description" xml:space="preserve"><value>Choisissez quelles communications vous recevez et comment.</value></data>
+  <data name="CommPrefs_Category" xml:space="preserve"><value>Catégorie</value></data>
+  <data name="CommPrefs_Email" xml:space="preserve"><value>E-mail</value></data>
+  <data name="CommPrefs_Alert" xml:space="preserve"><value>Alerte</value></data>
+  <data name="CommPrefs_BackToProfile" xml:space="preserve"><value>Retour au profil</value></data>
+  <data name="CommPrefs_BackToDashboard" xml:space="preserve"><value>Retour au tableau de bord</value></data>
+
+  <data name="Emails_Header_Email" xml:space="preserve"><value>E-mail</value></data>
+  <data name="Emails_Header_Status" xml:space="preserve"><value>Statut</value></data>
+  <data name="Emails_Header_Notifications" xml:space="preserve"><value>Notifications</value></data>
+  <data name="Emails_Header_Visibility" xml:space="preserve"><value>Visibilité du profil</value></data>
+  <data name="Emails_SignIn" xml:space="preserve"><value>Connexion</value></data>
+  <data name="Emails_MergePending" xml:space="preserve"><value>Fusion en attente</value></data>
+  <data name="Emails_Verified" xml:space="preserve"><value>Vérifié</value></data>
+  <data name="Emails_StatusPending" xml:space="preserve"><value>En attente</value></data>
+  <data name="Emails_Unverified" xml:space="preserve"><value>Non vérifié</value></data>
+  <data name="Emails_NotifActive" xml:space="preserve"><value>Actif</value></data>
+  <data name="Emails_SetAsTarget" xml:space="preserve"><value>Définir comme cible</value></data>
+  <data name="Emails_VerifyFirst" xml:space="preserve"><value>Vérifiez d'abord</value></data>
+  <data name="Emails_Visibility_Hidden" xml:space="preserve"><value>Masqué</value></data>
+  <data name="Emails_Visibility_AllHumans" xml:space="preserve"><value>Tous les humans</value></data>
+  <data name="Emails_Visibility_MyTeams" xml:space="preserve"><value>Mes équipes</value></data>
+  <data name="Emails_Visibility_CoordinatorsBoard" xml:space="preserve"><value>Coordinateurs + Bureau</value></data>
+  <data name="Emails_Visibility_BoardOnly" xml:space="preserve"><value>Bureau uniquement</value></data>
+  <data name="Emails_ConfirmRemove" xml:space="preserve"><value>Êtes-vous sûr de vouloir supprimer cet e-mail ?</value></data>
+  <data name="Emails_GoogleTitle" xml:space="preserve"><value>E-mail des services Google</value></data>
+  <data name="Emails_GoogleDescription" xml:space="preserve"><value>Cet e-mail est utilisé pour Google Groups et l'accès aux Drive partagés.</value></data>
+  <data name="Emails_GoogleAutoNobodies" xml:space="preserve"><value>Votre e-mail @nobodies.team est automatiquement utilisé.</value></data>
+  <data name="Emails_GoogleRejected" xml:space="preserve"><value>La synchronisation Google a échoué. L'e-mail actuel a été rejeté par Google. Sélectionnez un autre e-mail.</value></data>
+  <data name="Emails_GoogleValid" xml:space="preserve"><value>La synchronisation Google fonctionne avec l'e-mail actuel.</value></data>
+  <data name="Emails_AutoSelected" xml:space="preserve"><value>Sélectionné automatiquement</value></data>
+  <data name="Emails_GoogleRejectedBadge" xml:space="preserve"><value>Rejeté</value></data>
+  <data name="Emails_UseThis" xml:space="preserve"><value>Utiliser</value></data>
+
+  <data name="ShiftInfo_Title" xml:space="preserve"><value>Préférences de quarts</value></data>
+  <data name="ShiftInfo_StepOf" xml:space="preserve"><value>Étape {0} sur {1}</value><comment>{0} = current step, {1} = total steps</comment></data>
+  <data name="ShiftInfo_SkillsTitle" xml:space="preserve"><value>Qu'est-ce que vous savez faire ?</value></data>
+  <data name="ShiftInfo_SkillsSubtitle" xml:space="preserve"><value>Sélectionnez les compétences que vous souhaitez utiliser. Vous pouvez les modifier à tout moment.</value></data>
+  <data name="ShiftInfo_WorkStyleTitle" xml:space="preserve"><value>Comment aimez-vous travailler ?</value></data>
+  <data name="ShiftInfo_WorkStyleSubtitle" xml:space="preserve"><value>Aidez les coordinateurs à vous associer des quarts adaptés à votre style et disponibilité.</value></data>
+  <data name="ShiftInfo_LanguagesTitle" xml:space="preserve"><value>Quelles langues parlez-vous ?</value></data>
+  <data name="ShiftInfo_LanguagesSubtitle" xml:space="preserve"><value>Cela nous aide à vous placer dans des équipes où vous pouvez bien communiquer.</value></data>
+  <data name="ShiftInfo_OtherSkills" xml:space="preserve"><value>Quelles autres compétences avez-vous ?</value></data>
+  <data name="ShiftInfo_WorkTime" xml:space="preserve"><value>Quand préférez-vous travailler ?</value></data>
+  <data name="ShiftInfo_OtherPrefs" xml:space="preserve"><value>Autres préférences</value></data>
+  <data name="ShiftInfo_OtherLanguages" xml:space="preserve"><value>Quelles autres langues parlez-vous ?</value></data>
+  <data name="ShiftInfo_Continue" xml:space="preserve"><value>Continuer</value></data>
+
+  <data name="Shifts_Title" xml:space="preserve"><value>Quarts</value></data>
+  <data name="Shifts_BrowseTitle" xml:space="preserve"><value>Parcourir les options de bénévolat</value></data>
+  <data name="Shifts_Department" xml:space="preserve"><value>Département</value></data>
+  <data name="Shifts_AllDepartments" xml:space="preserve"><value>Tous les départements</value></data>
+  <data name="Shifts_From" xml:space="preserve"><value>De</value></data>
+  <data name="Shifts_To" xml:space="preserve"><value>À</value></data>
+  <data name="Shifts_ClearFilters" xml:space="preserve"><value>Effacer les filtres</value></data>
+  <data name="Shifts_All" xml:space="preserve"><value>Tous</value></data>
+  <data name="Shifts_SetUp" xml:space="preserve"><value>Montage</value></data>
+  <data name="Shifts_Event" xml:space="preserve"><value>Événement</value></data>
+  <data name="Shifts_Strike" xml:space="preserve"><value>Démontage</value></data>
+  <data name="Shifts_FilterByTag" xml:space="preserve"><value>Filtrer par tag :</value></data>
+  <data name="Shifts_SetPreferences" xml:space="preserve"><value>Définir vos préférences</value></data>
+  <data name="Shifts_PreferencesHelp" xml:space="preserve"><value>Sélectionnez les tags correspondant au type de travail que vous aimez. Les quarts correspondants seront mis en valeur avec une étoile.</value></data>
+  <data name="Shifts_SavePreferences" xml:space="preserve"><value>Enregistrer les préférences</value></data>
+  <data name="Shifts_NotOpenYet" xml:space="preserve"><value>Les quarts ne sont pas encore ouverts. Seuls les coordinateurs et admins peuvent voir cette page.</value></data>
+  <data name="Shifts_NoShiftsAvailable" xml:space="preserve"><value>Aucun quart disponible pour le moment.</value></data>
+  <data name="Shifts_AllShiftsFull" xml:space="preserve"><value>Tous les quarts de {0} sont complets.</value><comment>{0} = period name</comment></data>
+  <data name="Shifts_Start" xml:space="preserve"><value>Début</value></data>
+  <data name="Shifts_End" xml:space="preserve"><value>Fin</value></data>
+  <data name="Shifts_SignUpForDates" xml:space="preserve"><value>S'inscrire aux dates de {0}</value><comment>{0} = period name (e.g. set-up, strike)</comment></data>
+  <data name="Shifts_Date" xml:space="preserve"><value>Date</value></data>
+  <data name="Shifts_Filled" xml:space="preserve"><value>Rempli</value></data>
+  <data name="Shifts_Days" xml:space="preserve"><value>jours</value></data>
+  <data name="Shifts_Total" xml:space="preserve"><value>total</value></data>
+    <data name="Shifts_SignedUpAllDays" xml:space="preserve"><value>Inscrit ({0} jours)</value><comment>{0} = count</comment></data>
+    <data name="Shifts_SignedUpPartial" xml:space="preserve"><value>Inscrit ({0} sur {1})</value><comment>{0} = count</comment></data>
+  <data name="Shifts_Full" xml:space="preserve"><value>Complet</value></data>
+  <data name="Shifts_NeedsHelp" xml:space="preserve"><value>Aide nécessaire</value></data>
+  <data name="Shifts_DayNeedsHelp" xml:space="preserve"><value>{0} jour a besoin d'aide</value><comment>{0} = number of days</comment></data>
+  <data name="Shifts_DaysNeedHelp" xml:space="preserve"><value>{0} jours ont besoin d'aide</value><comment>{0} = number of days</comment></data>
+  <data name="Shifts_ClickToExpand" xml:space="preserve"><value>cliquez pour développer</value></data>
+  <data name="Shifts_Shift" xml:space="preserve"><value>Quart</value></data>
+  <data name="Shifts_Phase" xml:space="preserve"><value>Phase</value></data>
+  <data name="Shifts_Time" xml:space="preserve"><value>Heure</value></data>
+  <data name="Shifts_Duration" xml:space="preserve"><value>Durée</value></data>
+  <data name="Shifts_AllDay" xml:space="preserve"><value>Toute la journée</value></data>
+  <data name="Shifts_FullDay" xml:space="preserve"><value>Journée entière</value></data>
+  <data name="Shifts_Essential" xml:space="preserve"><value>Essentiel</value></data>
+  <data name="Shifts_Important" xml:space="preserve"><value>Important</value></data>
+  <data name="Shifts_AllPhases" xml:space="preserve"><value>Toutes les phases</value></data>
+  <data name="Shifts_HiddenBadge" xml:space="preserve"><value>Masqué</value></data>
+  <data name="Shifts_MatchesPrefs" xml:space="preserve"><value>Correspond à vos préférences</value></data>
+  <data name="Shifts_SignUpButton" xml:space="preserve"><value>S'inscrire</value></data>
+  <data name="Shifts_BrowsingClosed" xml:space="preserve"><value>La navigation des quarts n'est pas encore ouverte. Revenez plus tard !</value></data>
+  <data name="Shifts_NoActiveEvent" xml:space="preserve"><value>Aucun événement actif configuré. Un administrateur doit d'abord configurer les paramètres de l'événement.</value></data>
+  <data name="Shifts_ConfigureEvent" xml:space="preserve"><value>Configurer les paramètres de l'événement</value></data>
+  <data name="Shifts_MyShiftsTitle" xml:space="preserve"><value>Mes quarts</value></data>
+  <data name="Shifts_UpcomingShifts" xml:space="preserve"><value>Prochains quarts</value></data>
+  <data name="Shifts_PendingApproval" xml:space="preserve"><value>En attente d'approbation</value></data>
+  <data name="Shifts_Past" xml:space="preserve"><value>Passés</value></data>
+  <data name="Shifts_Bail" xml:space="preserve"><value>Se retirer</value></data>
+  <data name="Shifts_BailConfirm" xml:space="preserve"><value>Êtes-vous sûr de vouloir vous retirer ?</value></data>
+  <data name="Shifts_BailRangeConfirm" xml:space="preserve"><value>Se retirer des {0} jours ?</value><comment>{0} = number of days</comment></data>
+  <data name="Shifts_WithdrawButton" xml:space="preserve"><value>Retirer</value></data>
+  <data name="Shifts_NoSignups" xml:space="preserve"><value>Aucune inscription aux quarts pour le moment.</value></data>
+  <data name="Shifts_BrowseAvailable" xml:space="preserve"><value>Parcourir les quarts disponibles</value></data>
+  <data name="Shifts_NoActiveEventConfigured" xml:space="preserve"><value>Aucun événement actif configuré.</value></data>
+  <data name="Shifts_GeneralAvailability" xml:space="preserve"><value>Disponibilité générale</value></data>
+  <data name="Shifts_AvailabilityHelp" xml:space="preserve"><value>Indiquez les jours où vous êtes disponible. Les coordinateurs peuvent voir qui est disponible lors de l'attribution des quarts.</value></data>
+  <data name="Shifts_SaveAvailability" xml:space="preserve"><value>Enregistrer la disponibilité</value></data>
+
+  <data name="ShiftDash_Title" xml:space="preserve"><value>Tableau de bord des quarts</value></data>
+  <data name="ShiftDash_ShiftsCount" xml:space="preserve"><value>{0} quarts</value><comment>{0} = count</comment></data>
+  <data name="ShiftDash_Date" xml:space="preserve"><value>Date</value></data>
+  <data name="ShiftDash_Department" xml:space="preserve"><value>Département</value></data>
+  <data name="ShiftDash_AllDepartments" xml:space="preserve"><value>Tous les départements</value></data>
+  <data name="ShiftDash_Filter" xml:space="preserve"><value>Filtrer</value></data>
+  <data name="ShiftDash_Clear" xml:space="preserve"><value>Effacer</value></data>
+  <data name="ShiftDash_NoShiftsMatch" xml:space="preserve"><value>Aucun quart ne correspond aux filtres actuels.</value></data>
+  <data name="ShiftDash_Shift" xml:space="preserve"><value>Quart</value></data>
+  <data name="ShiftDash_DateTime" xml:space="preserve"><value>Date / Heure</value></data>
+  <data name="ShiftDash_Slots" xml:space="preserve"><value>Places</value></data>
+  <data name="ShiftDash_Priority" xml:space="preserve"><value>Priorité</value></data>
+  <data name="ShiftDash_Voluntell" xml:space="preserve"><value>Voluntell</value></data>
+  <data name="ShiftDash_SearchHumans" xml:space="preserve"><value>Rechercher des humans pour : {0}</value><comment>{0} = shift/rota name</comment></data>
+  <data name="ShiftDash_SearchPlaceholder" xml:space="preserve"><value>Tapez un nom (min. 2 caractères)...</value></data>
+  <data name="ShiftDash_NoHumansFound" xml:space="preserve"><value>Aucun humans trouvé.</value></data>
+  <data name="ShiftDash_SearchFailed" xml:space="preserve"><value>La recherche a échoué.</value></data>
+  <data name="ShiftDash_ScheduleConflict" xml:space="preserve"><value>Conflit d'horaire</value></data>
+
+  <data name="Nav_Legal" xml:space="preserve"><value>Juridique</value></data>
+  <data name="Nav_Staff" xml:space="preserve"><value>Équipe</value></data>
+
+  <data name="ProfileCard_Suspended" xml:space="preserve"><value>Suspendu</value></data>
+  <data name="ProfileCard_PendingBadge" xml:space="preserve"><value>En attente</value></data>
+  <data name="ProfileCard_Teams" xml:space="preserve"><value>Équipes :</value></data>
+  <data name="ProfileCard_Joined" xml:space="preserve"><value>Inscrit(e) en {0}</value><comment>{0} = date</comment></data>
+  <data name="ProfileCard_LastLogin" xml:space="preserve"><value>Dernière connexion {0}</value><comment>{0} = date</comment></data>
+
+  <data name="ShiftsSummary_Title" xml:space="preserve"><value>Quarts</value></data>
+  <data name="ShiftsSummary_SlotsFilled" xml:space="preserve"><value>{0} / {1} places remplies</value><comment>{0} = filled, {1} = total</comment></data>
+  <data name="ShiftsSummary_HumansSignedUp" xml:space="preserve"><value>{0} humans inscrits</value><comment>{0} = count</comment></data>
+  <data name="ShiftsSummary_PendingCount" xml:space="preserve"><value>{0} en attente</value><comment>{0} = count</comment></data>
+  <data name="ShiftsSummary_NoShifts" xml:space="preserve"><value>Aucun quart configuré pour le moment.</value></data>
+  <data name="ShiftsSummary_IncludesSubTeams" xml:space="preserve"><value>Inclut les quarts de {0} sous-équipe(s)</value><comment>{0} = count</comment></data>
+  <data name="ShiftsSummary_ManageShifts" xml:space="preserve"><value>Gérer les quarts</value></data>
+
+  <data name="Medical_Badge" xml:space="preserve"><value>Médical</value></data>
+
+  <data name="Privacy_Lead" xml:space="preserve"><value>Humans gère les adhésions de Nobodies Collective et traite les données personnelles conformément au RGPD et à la loi espagnole sur la protection des données (LOPDGDD).</value></data>
+  <data name="Privacy_DataControllerTitle" xml:space="preserve"><value>Responsable du traitement</value></data>
+  <data name="Privacy_DataControllerBody" xml:space="preserve"><value>Une association espagnole à but non lucratif enregistrée en Andalousie.</value></data>
+  <data name="Privacy_DataControllerDPO" xml:space="preserve"><value>Pour les questions relatives à la protection des données, contactez notre Délégué à la Protection des Données à :</value></data>
+  <data name="Privacy_DataWeCollectTitle" xml:space="preserve"><value>Données que nous collectons</value></data>
+  <data name="Privacy_DataWeCollectIntro" xml:space="preserve"><value>Nous collectons et traitons les catégories suivantes de données personnelles :</value></data>
+  <data name="Privacy_Collect_Identity" xml:space="preserve"><value>Nom, adresse e-mail (authentification Google), nom d'affichage</value></data>
+  <data name="Privacy_Collect_Contact" xml:space="preserve"><value>Numéro de téléphone, ville, pays (optionnel)</value></data>
+  <data name="Privacy_Collect_Profile" xml:space="preserve"><value>Bio, adhésions aux équipes, attributions de rôles</value></data>
+  <data name="Privacy_Collect_Technical" xml:space="preserve"><value>Adresse IP et agent utilisateur (pour les registres de consentement)</value></data>
+  <data name="Privacy_Collect_Application" xml:space="preserve"><value>Demandes d'adhésion et lettres de motivation</value></data>
+  <data name="Privacy_Collect_Consent" xml:space="preserve"><value>Enregistrements de votre accord aux documents juridiques</value></data>
+  <data name="Privacy_LegalBasisTitle" xml:space="preserve"><value>Base juridique du traitement</value></data>
+  <data name="Privacy_LegalBasisIntro" xml:space="preserve"><value>Nous traitons vos données sur la base de :</value></data>
+  <data name="Privacy_Legal_Contract" xml:space="preserve"><value>Traitement nécessaire à la gestion des adhésions</value></data>
+  <data name="Privacy_Legal_LegitimateInterest" xml:space="preserve"><value>Tenue des registres organisationnels et communication</value></data>
+  <data name="Privacy_Legal_LegalObligation" xml:space="preserve"><value>Conformité aux réglementations espagnoles sur les associations</value></data>
+  <data name="Privacy_Legal_Consent" xml:space="preserve"><value>Pour les données optionnelles que vous choisissez de fournir</value></data>
+  <data name="Privacy_HowWeUseTitle" xml:space="preserve"><value>Comment nous utilisons vos données</value></data>
+  <data name="Privacy_Use_Membership" xml:space="preserve"><value>Pour gérer votre adhésion et participation aux équipes</value></data>
+  <data name="Privacy_Use_Communicate" xml:space="preserve"><value>Pour communiquer avec vous au sujet des activités de l'organisation</value></data>
+  <data name="Privacy_Use_LegalCompliance" xml:space="preserve"><value>Pour maintenir les registres de conformité légale</value></data>
+  <data name="Privacy_Use_Connections" xml:space="preserve"><value>Pour faciliter les connexions entre humans (selon vos paramètres de visibilité)</value></data>
+  <data name="Privacy_DataRetentionTitle" xml:space="preserve"><value>Conservation des données</value></data>
+  <data name="Privacy_DataRetentionIntro" xml:space="preserve"><value>Nous conservons vos données selon les politiques suivantes :</value></data>
+  <data name="Privacy_Retention_Active" xml:space="preserve"><value>Données conservées tant que votre compte est actif</value></data>
+  <data name="Privacy_Retention_Inactive" xml:space="preserve"><value>Données conservées jusqu'à 7 ans pour conformité légale</value></data>
+  <data name="Privacy_Retention_Consent" xml:space="preserve"><value>Conservés indéfiniment conformément au RGPD</value></data>
+  <data name="Privacy_Retention_Deleted" xml:space="preserve"><value>Anonymisées après un délai de grâce de 30 jours</value></data>
+  <data name="Privacy_YourRightsTitle" xml:space="preserve"><value>Vos droits</value></data>
+  <data name="Privacy_YourRightsIntro" xml:space="preserve"><value>En vertu du RGPD, vous avez les droits suivants :</value></data>
+  <data name="Privacy_Rights_Access" xml:space="preserve"><value>Demander une copie de vos données personnelles</value></data>
+  <data name="Privacy_Rights_Rectification" xml:space="preserve"><value>Demander la correction de données inexactes</value></data>
+  <data name="Privacy_Rights_Erasure" xml:space="preserve"><value>Demander la suppression de vos données (« droit à l'oubli »)</value></data>
+  <data name="Privacy_Rights_Portability" xml:space="preserve"><value>Recevoir vos données dans un format lisible par machine</value></data>
+  <data name="Privacy_Rights_Restriction" xml:space="preserve"><value>Demander la limitation du traitement</value></data>
+  <data name="Privacy_Rights_Objection" xml:space="preserve"><value>S'opposer à certains types de traitement</value></data>
+  <data name="Privacy_YourRightsExercise" xml:space="preserve"><value>Pour exercer ces droits, visitez vos paramètres {0} ou contactez-nous à {1}.</value><comment>{0} = Privacy &amp; Data link, {1} = DPO email</comment></data>
+  <data name="Privacy_PrivacyAndData" xml:space="preserve"><value>Confidentialité &amp; données</value></data>
+  <data name="Privacy_CookiesTitle" xml:space="preserve"><value>Cookies</value></data>
+  <data name="Privacy_CookiesIntro" xml:space="preserve"><value>Ce site n'utilise que des cookies essentiels nécessaires pour :</value></data>
+  <data name="Privacy_Cookies_Auth" xml:space="preserve"><value>Authentification des utilisateurs et gestion des sessions</value></data>
+  <data name="Privacy_Cookies_Antiforgery" xml:space="preserve"><value>Jetons anti-falsification pour la sécurité des formulaires</value></data>
+  <data name="Privacy_Cookies_Consent" xml:space="preserve"><value>Préférence de consentement aux cookies</value></data>
+  <data name="Privacy_CookiesNoTracking" xml:space="preserve"><value>Nous n'utilisons pas de cookies d'analyse, de publicité ou de suivi tiers.</value></data>
+  <data name="Privacy_DataSecurityTitle" xml:space="preserve"><value>Sécurité des données</value></data>
+  <data name="Privacy_DataSecurityIntro" xml:space="preserve"><value>Nous mettons en œuvre des mesures techniques et organisationnelles appropriées pour protéger vos données, notamment :</value></data>
+  <data name="Privacy_Security_Encryption" xml:space="preserve"><value>Chiffrement en transit (HTTPS)</value></data>
+  <data name="Privacy_Security_OAuth" xml:space="preserve"><value>Authentification sécurisée via Google OAuth</value></data>
+  <data name="Privacy_Security_AccessControls" xml:space="preserve"><value>Contrôles d'accès et journalisation d'audit</value></data>
+  <data name="Privacy_Security_Reviews" xml:space="preserve"><value>Révisions de sécurité régulières</value></data>
+  <data name="Privacy_ThirdPartyTitle" xml:space="preserve"><value>Services tiers</value></data>
+  <data name="Privacy_ThirdPartyIntro" xml:space="preserve"><value>Nous utilisons les services tiers suivants :</value></data>
+  <data name="Privacy_ThirdParty_GoogleOAuth" xml:space="preserve"><value>Pour une authentification sécurisée</value></data>
+  <data name="Privacy_ThirdParty_GoogleWorkspace" xml:space="preserve"><value>Pour le provisionnement des ressources d'équipe (drives partagés, groupes)</value></data>
+  <data name="Privacy_ChangesTitle" xml:space="preserve"><value>Modifications de cette politique</value></data>
+  <data name="Privacy_ChangesBody" xml:space="preserve"><value>Nous pouvons mettre à jour cette politique de confidentialité de temps en temps. Nous informerons les humans actifs des changements importants par e-mail.</value></data>
+  <data name="Privacy_ContactTitle" xml:space="preserve"><value>Contact &amp; réclamations</value></data>
+  <data name="Privacy_ContactBody" xml:space="preserve"><value>Pour toute question ou préoccupation concernant cette politique, contactez notre Délégué à la Protection des Données à {0}.</value><comment>{0} = DPO email</comment></data>
+  <data name="Privacy_ComplaintBody" xml:space="preserve"><value>Si vous n'êtes pas satisfait de notre réponse, vous avez le droit de déposer une plainte auprès de l'Agence Espagnole de Protection des Données (AEPD) à {0}.</value><comment>{0} = AEPD URL</comment></data>
+
 
 </root>

--- a/src/Humans.Web/Resources/SharedResource.it.resx
+++ b/src/Humans.Web/Resources/SharedResource.it.resx
@@ -1317,44 +1317,44 @@
   <data name="Todo_ShiftInfo_Action" xml:space="preserve"><value>Compila info turno</value></data>
 
   <!-- Notification Inbox -->
-  <data name="Notification_Bell_AriaLabel" xml:space="preserve"><value>Notifications</value></data>
-  <data name="Notification_Popup_AriaLabel" xml:space="preserve"><value>Notification popup</value></data>
-  <data name="Notification_Popup_Title" xml:space="preserve"><value>Notifications</value></data>
-  <data name="Notification_Popup_NeedAction" xml:space="preserve"><value>need action</value></data>
-  <data name="Notification_Popup_Close" xml:space="preserve"><value>Close notifications</value></data>
-  <data name="Notification_Popup_CaughtUp" xml:space="preserve"><value>You're all caught up.</value></data>
-  <data name="Notification_Popup_NoUnread" xml:space="preserve"><value>No unread notifications.</value></data>
-  <data name="Notification_Section_NeedsAttention" xml:space="preserve"><value>Needs your attention</value></data>
-  <data name="Notification_Section_Recent" xml:space="preserve"><value>Recent</value></data>
-  <data name="Notification_Section_Informational" xml:space="preserve"><value>Informational</value></data>
-  <data name="Notification_Section_Resolved" xml:space="preserve"><value>Resolved</value></data>
-  <data name="Notification_Section_WorkQueues" xml:space="preserve"><value>Work queues</value></data>
-  <data name="Notification_MarkAllRead" xml:space="preserve"><value>Mark all as read</value></data>
-  <data name="Notification_SeeAll" xml:space="preserve"><value>See all notifications</value></data>
-  <data name="Notification_PageTitle" xml:space="preserve"><value>All notifications</value></data>
-  <data name="Notification_SearchPlaceholder" xml:space="preserve"><value>Search notifications...</value></data>
-  <data name="Notification_Filter_All" xml:space="preserve"><value>All</value></data>
-  <data name="Notification_Filter_NeedsAction" xml:space="preserve"><value>Needs action</value></data>
-  <data name="Notification_Filter_Shifts" xml:space="preserve"><value>Shifts</value></data>
-  <data name="Notification_Filter_Approvals" xml:space="preserve"><value>Approvals</value></data>
-  <data name="Notification_Filter_Resolved" xml:space="preserve"><value>Resolved</value></data>
-  <data name="Notification_Tab_Unread" xml:space="preserve"><value>Unread</value></data>
-  <data name="Notification_Tab_All" xml:space="preserve"><value>All</value></data>
-  <data name="Notification_Inbox_Title" xml:space="preserve"><value>Notifications</value></data>
-  <data name="Notification_Tag_Urgent" xml:space="preserve"><value>Urgent</value></data>
-  <data name="Notification_Tag_Action" xml:space="preserve"><value>Action</value></data>
+  <data name="Notification_Bell_AriaLabel" xml:space="preserve"><value>Notifiche</value></data>
+  <data name="Notification_Popup_AriaLabel" xml:space="preserve"><value>Popup notifiche</value></data>
+  <data name="Notification_Popup_Title" xml:space="preserve"><value>Notifiche</value></data>
+  <data name="Notification_Popup_NeedAction" xml:space="preserve"><value>richiedono azione</value></data>
+  <data name="Notification_Popup_Close" xml:space="preserve"><value>Chiudi notifiche</value></data>
+  <data name="Notification_Popup_CaughtUp" xml:space="preserve"><value>Sei in pari.</value></data>
+  <data name="Notification_Popup_NoUnread" xml:space="preserve"><value>Nessuna notifica non letta.</value></data>
+  <data name="Notification_Section_NeedsAttention" xml:space="preserve"><value>Richiede la tua attenzione</value></data>
+  <data name="Notification_Section_Recent" xml:space="preserve"><value>Recenti</value></data>
+  <data name="Notification_Section_Informational" xml:space="preserve"><value>Informativi</value></data>
+  <data name="Notification_Section_Resolved" xml:space="preserve"><value>Risolte</value></data>
+  <data name="Notification_Section_WorkQueues" xml:space="preserve"><value>Code di lavoro</value></data>
+  <data name="Notification_MarkAllRead" xml:space="preserve"><value>Segna tutto come letto</value></data>
+  <data name="Notification_SeeAll" xml:space="preserve"><value>Vedi tutte le notifiche</value></data>
+  <data name="Notification_PageTitle" xml:space="preserve"><value>Tutte le notifiche</value></data>
+  <data name="Notification_SearchPlaceholder" xml:space="preserve"><value>Cerca notifiche...</value></data>
+  <data name="Notification_Filter_All" xml:space="preserve"><value>Tutte</value></data>
+  <data name="Notification_Filter_NeedsAction" xml:space="preserve"><value>Azione necessaria</value></data>
+  <data name="Notification_Filter_Shifts" xml:space="preserve"><value>Turni</value></data>
+  <data name="Notification_Filter_Approvals" xml:space="preserve"><value>Approvazioni</value></data>
+  <data name="Notification_Filter_Resolved" xml:space="preserve"><value>Risolte</value></data>
+  <data name="Notification_Tab_Unread" xml:space="preserve"><value>Non lette</value></data>
+  <data name="Notification_Tab_All" xml:space="preserve"><value>Tutte</value></data>
+  <data name="Notification_Inbox_Title" xml:space="preserve"><value>Notifiche</value></data>
+  <data name="Notification_Tag_Urgent" xml:space="preserve"><value>Urgente</value></data>
+  <data name="Notification_Tag_Action" xml:space="preserve"><value>Azione</value></data>
   <data name="Notification_Tag_Info" xml:space="preserve"><value>Info</value></data>
-  <data name="Notification_Dismiss" xml:space="preserve"><value>Dismiss</value></data>
-  <data name="Notification_HandledBy" xml:space="preserve"><value>Handled by {0}, {1}</value></data>
-  <data name="Notification_Pref_InboxEnabled" xml:space="preserve"><value>In-app notifications</value></data>
-  <data name="Notification_DefaultActionLabel" xml:space="preserve"><value>View →</value></data>
-  <data name="Notification_TimeAgo_JustNow" xml:space="preserve"><value>just now</value></data>
-  <data name="Notification_TimeAgo_Minutes" xml:space="preserve"><value>{0}m ago</value></data>
-  <data name="Notification_TimeAgo_Hours" xml:space="preserve"><value>{0}h ago</value></data>
-  <data name="Notification_TimeAgo_Days" xml:space="preserve"><value>{0}d ago</value></data>
-  <data name="Notification_Bulk_Selected" xml:space="preserve"><value>{0} selected</value></data>
-  <data name="Notification_Bulk_Resolve" xml:space="preserve"><value>Resolve selected</value></data>
-  <data name="Notification_Bulk_Dismiss" xml:space="preserve"><value>Dismiss selected</value></data>
+  <data name="Notification_Dismiss" xml:space="preserve"><value>Ignora</value></data>
+  <data name="Notification_HandledBy" xml:space="preserve"><value>Gestito da {0}, {1}</value></data>
+  <data name="Notification_Pref_InboxEnabled" xml:space="preserve"><value>Notifiche in-app</value></data>
+  <data name="Notification_DefaultActionLabel" xml:space="preserve"><value>Vedi →</value></data>
+  <data name="Notification_TimeAgo_JustNow" xml:space="preserve"><value>proprio ora</value></data>
+  <data name="Notification_TimeAgo_Minutes" xml:space="preserve"><value>{0}m fa</value></data>
+  <data name="Notification_TimeAgo_Hours" xml:space="preserve"><value>{0}h fa</value></data>
+  <data name="Notification_TimeAgo_Days" xml:space="preserve"><value>{0}g fa</value></data>
+  <data name="Notification_Bulk_Selected" xml:space="preserve"><value>{0} selezionati</value></data>
+  <data name="Notification_Bulk_Resolve" xml:space="preserve"><value>Risolvi selezionati</value></data>
+  <data name="Notification_Bulk_Dismiss" xml:space="preserve"><value>Ignora selezionati</value></data>
 
   <!-- Get Involved card (Dashboard) -->
   <data name="GetInvolved_Title" xml:space="preserve"><value>Partecipa</value></data>
@@ -1433,5 +1433,257 @@
   <data name="CityPlanning_Help_OverlapsDiscordChannel" xml:space="preserve"><value>Discord #city-planning</value></data>
   <data name="CityPlanning_Help_ColorsTitle" xml:space="preserve"><value>Colori &amp; zone sonore</value></data>
   <data name="CityPlanning_Help_ColorsBody" xml:space="preserve"><value>Ogni barrio è colorato in base alla sua zona sonora preferita (modificabile dalla pagina del barrio).</value></data>
+
+
+  <!-- ======================== -->
+  <!-- User-Facing Views        -->
+  <!-- ======================== -->
+  <data name="Feedback_PageTitle" xml:space="preserve"><value>Feedback</value></data>
+  <data name="Feedback_AllStatuses" xml:space="preserve"><value>Tutti gli stati</value></data>
+  <data name="Feedback_AllCategories" xml:space="preserve"><value>Tutte le categorie</value></data>
+  <data name="Feedback_AllReporters" xml:space="preserve"><value>Tutti i segnalatori</value></data>
+  <data name="Feedback_AllAssignees" xml:space="preserve"><value>Tutti gli assegnatari</value></data>
+  <data name="Feedback_AssignedToMe" xml:space="preserve"><value>Assegnato a me</value></data>
+  <data name="Feedback_AllTeams" xml:space="preserve"><value>Tutti i team</value></data>
+  <data name="Feedback_UnassignedOnly" xml:space="preserve"><value>Solo non assegnati</value></data>
+  <data name="Feedback_Clear" xml:space="preserve"><value>Cancella</value></data>
+  <data name="Feedback_NoReports" xml:space="preserve"><value>Nessun rapporto trovato.</value></data>
+  <data name="Feedback_Unassigned" xml:space="preserve"><value>Non assegnato</value></data>
+  <data name="Feedback_NeedsReply" xml:space="preserve"><value>risposta necessaria</value></data>
+  <data name="Feedback_SelectReport" xml:space="preserve"><value>Seleziona un rapporto per i dettagli</value></data>
+  <data name="Feedback_Conversation" xml:space="preserve"><value>Conversazione</value></data>
+  <data name="Feedback_NoMessages" xml:space="preserve"><value>Ancora nessun messaggio.</value></data>
+  <data name="Feedback_MessagePlaceholder" xml:space="preserve"><value>Scrivi un messaggio...</value></data>
+  <data name="Feedback_Send" xml:space="preserve"><value>Invia</value></data>
+  <data name="Feedback_ResolvedAt" xml:space="preserve"><value>Risolto {0}</value><comment>{0} = date/time</comment></data>
+  <data name="Feedback_ResolvedBy" xml:space="preserve"><value>da {0}</value><comment>{0} = name</comment></data>
+  <data name="Feedback_NoTeam" xml:space="preserve"><value>Nessun team</value></data>
+  <data name="Feedback_ScreenshotLink" xml:space="preserve"><value>Screenshot</value></data>
+
+  <data name="Unsub_Title" xml:space="preserve"><value>Annulla iscrizione e-mail</value></data>
+  <data name="Unsub_Heading" xml:space="preserve"><value>Annullare l'iscrizione alle e-mail {0}?</value><comment>{0} = category name</comment></data>
+  <data name="Unsub_Greeting" xml:space="preserve"><value>Ciao {0},</value><comment>{0} = display name</comment></data>
+  <data name="Unsub_ConfirmMessage" xml:space="preserve"><value>Se confermi, non riceverai più e-mail {0} da Humans.</value><comment>{0} = category name</comment></data>
+  <data name="Unsub_ConfirmButton" xml:space="preserve"><value>Conferma annullamento</value></data>
+  <data name="Unsub_DoneTitle" xml:space="preserve"><value>Iscrizione annullata</value></data>
+  <data name="Unsub_DoneMessage" xml:space="preserve"><value>Non riceverai più e-mail {0} da Humans.</value><comment>{0} = category name</comment></data>
+  <data name="Unsub_DoneManage" xml:space="preserve"><value>Puoi gestire le preferenze di comunicazione dalle tue</value></data>
+  <data name="Unsub_DoneManageLink" xml:space="preserve"><value>preferenze di comunicazione</value></data>
+  <data name="Unsub_BackHome" xml:space="preserve"><value>Torna alla home</value></data>
+  <data name="Unsub_ExpiredTitle" xml:space="preserve"><value>Link di annullamento scaduto</value></data>
+  <data name="Unsub_ExpiredHeading" xml:space="preserve"><value>Questo link di annullamento è scaduto</value></data>
+  <data name="Unsub_ExpiredMessage" xml:space="preserve"><value>Usa il link da un'e-mail più recente, o</value></data>
+  <data name="Unsub_ExpiredSignIn" xml:space="preserve"><value>accedi per gestire le preferenze di comunicazione</value></data>
+
+  <data name="CommPrefs_Title" xml:space="preserve"><value>Preferenze di comunicazione</value></data>
+  <data name="CommPrefs_Description" xml:space="preserve"><value>Scegli quali comunicazioni ricevere e come.</value></data>
+  <data name="CommPrefs_Category" xml:space="preserve"><value>Categoria</value></data>
+  <data name="CommPrefs_Email" xml:space="preserve"><value>E-mail</value></data>
+  <data name="CommPrefs_Alert" xml:space="preserve"><value>Avviso</value></data>
+  <data name="CommPrefs_BackToProfile" xml:space="preserve"><value>Torna al profilo</value></data>
+  <data name="CommPrefs_BackToDashboard" xml:space="preserve"><value>Torna alla dashboard</value></data>
+
+  <data name="Emails_Header_Email" xml:space="preserve"><value>E-mail</value></data>
+  <data name="Emails_Header_Status" xml:space="preserve"><value>Stato</value></data>
+  <data name="Emails_Header_Notifications" xml:space="preserve"><value>Notifiche</value></data>
+  <data name="Emails_Header_Visibility" xml:space="preserve"><value>Visibilità profilo</value></data>
+  <data name="Emails_SignIn" xml:space="preserve"><value>Accesso</value></data>
+  <data name="Emails_MergePending" xml:space="preserve"><value>Unione in sospeso</value></data>
+  <data name="Emails_Verified" xml:space="preserve"><value>Verificata</value></data>
+  <data name="Emails_StatusPending" xml:space="preserve"><value>In sospeso</value></data>
+  <data name="Emails_Unverified" xml:space="preserve"><value>Non verificata</value></data>
+  <data name="Emails_NotifActive" xml:space="preserve"><value>Attivo</value></data>
+  <data name="Emails_SetAsTarget" xml:space="preserve"><value>Imposta come destinazione</value></data>
+  <data name="Emails_VerifyFirst" xml:space="preserve"><value>Verifica prima</value></data>
+  <data name="Emails_Visibility_Hidden" xml:space="preserve"><value>Nascosto</value></data>
+  <data name="Emails_Visibility_AllHumans" xml:space="preserve"><value>Tutti gli humans</value></data>
+  <data name="Emails_Visibility_MyTeams" xml:space="preserve"><value>I miei team</value></data>
+  <data name="Emails_Visibility_CoordinatorsBoard" xml:space="preserve"><value>Coordinatori + Consiglio</value></data>
+  <data name="Emails_Visibility_BoardOnly" xml:space="preserve"><value>Solo consiglio</value></data>
+  <data name="Emails_ConfirmRemove" xml:space="preserve"><value>Sei sicuro di voler rimuovere questa e-mail?</value></data>
+  <data name="Emails_GoogleTitle" xml:space="preserve"><value>E-mail servizi Google</value></data>
+  <data name="Emails_GoogleDescription" xml:space="preserve"><value>Questa e-mail viene usata per Google Groups e Drive condivisi.</value></data>
+  <data name="Emails_GoogleAutoNobodies" xml:space="preserve"><value>La tua e-mail @nobodies.team viene usata automaticamente.</value></data>
+  <data name="Emails_GoogleRejected" xml:space="preserve"><value>Sincronizzazione Google fallita. L'e-mail attuale è stata rifiutata da Google. Seleziona un'altra e-mail.</value></data>
+  <data name="Emails_GoogleValid" xml:space="preserve"><value>La sincronizzazione Google funziona con l'e-mail attuale.</value></data>
+  <data name="Emails_AutoSelected" xml:space="preserve"><value>Selezionata automaticamente</value></data>
+  <data name="Emails_GoogleRejectedBadge" xml:space="preserve"><value>Rifiutata</value></data>
+  <data name="Emails_UseThis" xml:space="preserve"><value>Usa questa</value></data>
+
+  <data name="ShiftInfo_Title" xml:space="preserve"><value>Preferenze turni</value></data>
+  <data name="ShiftInfo_StepOf" xml:space="preserve"><value>Passaggio {0} di {1}</value><comment>{0} = current step, {1} = total steps</comment></data>
+  <data name="ShiftInfo_SkillsTitle" xml:space="preserve"><value>In cosa sei bravo/a?</value></data>
+  <data name="ShiftInfo_SkillsSubtitle" xml:space="preserve"><value>Seleziona le abilità che vorresti usare. Puoi cambiarle in qualsiasi momento.</value></data>
+  <data name="ShiftInfo_WorkStyleTitle" xml:space="preserve"><value>Come ti piace lavorare?</value></data>
+  <data name="ShiftInfo_WorkStyleSubtitle" xml:space="preserve"><value>Aiuta i coordinatori ad assegnarti turni adatti al tuo stile e disponibilità.</value></data>
+  <data name="ShiftInfo_LanguagesTitle" xml:space="preserve"><value>Quali lingue parli?</value></data>
+  <data name="ShiftInfo_LanguagesSubtitle" xml:space="preserve"><value>Questo ci aiuta ad inserirti in team dove puoi comunicare bene.</value></data>
+  <data name="ShiftInfo_OtherSkills" xml:space="preserve"><value>Quali altre abilità hai?</value></data>
+  <data name="ShiftInfo_WorkTime" xml:space="preserve"><value>Quando preferisci lavorare?</value></data>
+  <data name="ShiftInfo_OtherPrefs" xml:space="preserve"><value>Altre preferenze</value></data>
+  <data name="ShiftInfo_OtherLanguages" xml:space="preserve"><value>Quali altre lingue parli?</value></data>
+  <data name="ShiftInfo_Continue" xml:space="preserve"><value>Continua</value></data>
+
+  <data name="Shifts_Title" xml:space="preserve"><value>Turni</value></data>
+  <data name="Shifts_BrowseTitle" xml:space="preserve"><value>Sfoglia opzioni di volontariato</value></data>
+  <data name="Shifts_Department" xml:space="preserve"><value>Dipartimento</value></data>
+  <data name="Shifts_AllDepartments" xml:space="preserve"><value>Tutti i dipartimenti</value></data>
+  <data name="Shifts_From" xml:space="preserve"><value>Da</value></data>
+  <data name="Shifts_To" xml:space="preserve"><value>A</value></data>
+  <data name="Shifts_ClearFilters" xml:space="preserve"><value>Cancella filtri</value></data>
+  <data name="Shifts_All" xml:space="preserve"><value>Tutti</value></data>
+  <data name="Shifts_SetUp" xml:space="preserve"><value>Montaggio</value></data>
+  <data name="Shifts_Event" xml:space="preserve"><value>Evento</value></data>
+  <data name="Shifts_Strike" xml:space="preserve"><value>Smontaggio</value></data>
+  <data name="Shifts_FilterByTag" xml:space="preserve"><value>Filtra per tag:</value></data>
+  <data name="Shifts_SetPreferences" xml:space="preserve"><value>Imposta le tue preferenze</value></data>
+  <data name="Shifts_PreferencesHelp" xml:space="preserve"><value>Seleziona i tag che corrispondono al tipo di lavoro che ti piace. I turni corrispondenti saranno evidenziati con una stella.</value></data>
+  <data name="Shifts_SavePreferences" xml:space="preserve"><value>Salva preferenze</value></data>
+  <data name="Shifts_NotOpenYet" xml:space="preserve"><value>I turni non sono ancora aperti. Solo coordinatori e admin possono vedere questa pagina.</value></data>
+  <data name="Shifts_NoShiftsAvailable" xml:space="preserve"><value>Nessun turno disponibile al momento.</value></data>
+  <data name="Shifts_AllShiftsFull" xml:space="preserve"><value>Tutti i turni di {0} sono completi.</value><comment>{0} = period name</comment></data>
+  <data name="Shifts_Start" xml:space="preserve"><value>Inizio</value></data>
+  <data name="Shifts_End" xml:space="preserve"><value>Fine</value></data>
+  <data name="Shifts_SignUpForDates" xml:space="preserve"><value>Iscriviti per le date di {0}</value><comment>{0} = period name (e.g. set-up, strike)</comment></data>
+  <data name="Shifts_Date" xml:space="preserve"><value>Data</value></data>
+  <data name="Shifts_Filled" xml:space="preserve"><value>Occupati</value></data>
+  <data name="Shifts_Days" xml:space="preserve"><value>giorni</value></data>
+  <data name="Shifts_Total" xml:space="preserve"><value>totale</value></data>
+    <data name="Shifts_SignedUpAllDays" xml:space="preserve"><value>Iscritto (tutti i {0} giorni)</value><comment>{0} = count</comment></data>
+    <data name="Shifts_SignedUpPartial" xml:space="preserve"><value>Iscritto ({0} di {1})</value><comment>{0} = count</comment></data>
+  <data name="Shifts_Full" xml:space="preserve"><value>Completo</value></data>
+  <data name="Shifts_NeedsHelp" xml:space="preserve"><value>Serve aiuto</value></data>
+  <data name="Shifts_DayNeedsHelp" xml:space="preserve"><value>{0} giorno ha bisogno di aiuto</value><comment>{0} = number of days</comment></data>
+  <data name="Shifts_DaysNeedHelp" xml:space="preserve"><value>{0} giorni hanno bisogno di aiuto</value><comment>{0} = number of days</comment></data>
+  <data name="Shifts_ClickToExpand" xml:space="preserve"><value>clicca per espandere</value></data>
+  <data name="Shifts_Shift" xml:space="preserve"><value>Turno</value></data>
+  <data name="Shifts_Phase" xml:space="preserve"><value>Fase</value></data>
+  <data name="Shifts_Time" xml:space="preserve"><value>Ora</value></data>
+  <data name="Shifts_Duration" xml:space="preserve"><value>Durata</value></data>
+  <data name="Shifts_AllDay" xml:space="preserve"><value>Tutto il giorno</value></data>
+  <data name="Shifts_FullDay" xml:space="preserve"><value>Giornata intera</value></data>
+  <data name="Shifts_Essential" xml:space="preserve"><value>Essenziale</value></data>
+  <data name="Shifts_Important" xml:space="preserve"><value>Importante</value></data>
+  <data name="Shifts_AllPhases" xml:space="preserve"><value>Tutte le fasi</value></data>
+  <data name="Shifts_HiddenBadge" xml:space="preserve"><value>Nascosto</value></data>
+  <data name="Shifts_MatchesPrefs" xml:space="preserve"><value>Corrisponde alle tue preferenze</value></data>
+  <data name="Shifts_SignUpButton" xml:space="preserve"><value>Iscriviti</value></data>
+  <data name="Shifts_BrowsingClosed" xml:space="preserve"><value>La consultazione dei turni non è ancora aperta. Torna più tardi!</value></data>
+  <data name="Shifts_NoActiveEvent" xml:space="preserve"><value>Nessun evento attivo configurato. Un amministratore deve prima configurare le impostazioni dell'evento.</value></data>
+  <data name="Shifts_ConfigureEvent" xml:space="preserve"><value>Configura impostazioni evento</value></data>
+  <data name="Shifts_MyShiftsTitle" xml:space="preserve"><value>I miei turni</value></data>
+  <data name="Shifts_UpcomingShifts" xml:space="preserve"><value>Prossimi turni</value></data>
+  <data name="Shifts_PendingApproval" xml:space="preserve"><value>In attesa di approvazione</value></data>
+  <data name="Shifts_Past" xml:space="preserve"><value>Passati</value></data>
+  <data name="Shifts_Bail" xml:space="preserve"><value>Ritirati</value></data>
+  <data name="Shifts_BailConfirm" xml:space="preserve"><value>Sei sicuro di volerti ritirare?</value></data>
+  <data name="Shifts_BailRangeConfirm" xml:space="preserve"><value>Ritirarsi da tutti i {0} giorni?</value><comment>{0} = number of days</comment></data>
+  <data name="Shifts_WithdrawButton" xml:space="preserve"><value>Ritira</value></data>
+  <data name="Shifts_NoSignups" xml:space="preserve"><value>Nessuna iscrizione ai turni ancora.</value></data>
+  <data name="Shifts_BrowseAvailable" xml:space="preserve"><value>Sfoglia turni disponibili</value></data>
+  <data name="Shifts_NoActiveEventConfigured" xml:space="preserve"><value>Nessun evento attivo configurato.</value></data>
+  <data name="Shifts_GeneralAvailability" xml:space="preserve"><value>Disponibilità generale</value></data>
+  <data name="Shifts_AvailabilityHelp" xml:space="preserve"><value>Segna i giorni in cui sei disponibile. I coordinatori possono vedere chi è disponibile quando assegnano i turni.</value></data>
+  <data name="Shifts_SaveAvailability" xml:space="preserve"><value>Salva disponibilità</value></data>
+
+  <data name="ShiftDash_Title" xml:space="preserve"><value>Dashboard turni</value></data>
+  <data name="ShiftDash_ShiftsCount" xml:space="preserve"><value>{0} turni</value><comment>{0} = count</comment></data>
+  <data name="ShiftDash_Date" xml:space="preserve"><value>Data</value></data>
+  <data name="ShiftDash_Department" xml:space="preserve"><value>Dipartimento</value></data>
+  <data name="ShiftDash_AllDepartments" xml:space="preserve"><value>Tutti i dipartimenti</value></data>
+  <data name="ShiftDash_Filter" xml:space="preserve"><value>Filtra</value></data>
+  <data name="ShiftDash_Clear" xml:space="preserve"><value>Cancella</value></data>
+  <data name="ShiftDash_NoShiftsMatch" xml:space="preserve"><value>Nessun turno corrisponde ai filtri attuali.</value></data>
+  <data name="ShiftDash_Shift" xml:space="preserve"><value>Turno</value></data>
+  <data name="ShiftDash_DateTime" xml:space="preserve"><value>Data / Ora</value></data>
+  <data name="ShiftDash_Slots" xml:space="preserve"><value>Posti</value></data>
+  <data name="ShiftDash_Priority" xml:space="preserve"><value>Priorità</value></data>
+  <data name="ShiftDash_Voluntell" xml:space="preserve"><value>Voluntell</value></data>
+  <data name="ShiftDash_SearchHumans" xml:space="preserve"><value>Cerca humans per: {0}</value><comment>{0} = shift/rota name</comment></data>
+  <data name="ShiftDash_SearchPlaceholder" xml:space="preserve"><value>Digita un nome (min. 2 caratteri)...</value></data>
+  <data name="ShiftDash_NoHumansFound" xml:space="preserve"><value>Nessun humans trovato.</value></data>
+  <data name="ShiftDash_SearchFailed" xml:space="preserve"><value>Ricerca fallita.</value></data>
+  <data name="ShiftDash_ScheduleConflict" xml:space="preserve"><value>Conflitto di orario</value></data>
+
+  <data name="Nav_Legal" xml:space="preserve"><value>Legale</value></data>
+  <data name="Nav_Staff" xml:space="preserve"><value>Staff</value></data>
+
+  <data name="ProfileCard_Suspended" xml:space="preserve"><value>Sospeso</value></data>
+  <data name="ProfileCard_PendingBadge" xml:space="preserve"><value>In sospeso</value></data>
+  <data name="ProfileCard_Teams" xml:space="preserve"><value>Team:</value></data>
+  <data name="ProfileCard_Joined" xml:space="preserve"><value>Iscritto/a il {0}</value><comment>{0} = date</comment></data>
+  <data name="ProfileCard_LastLogin" xml:space="preserve"><value>Ultimo accesso {0}</value><comment>{0} = date</comment></data>
+
+  <data name="ShiftsSummary_Title" xml:space="preserve"><value>Turni</value></data>
+  <data name="ShiftsSummary_SlotsFilled" xml:space="preserve"><value>{0} / {1} posti occupati</value><comment>{0} = filled, {1} = total</comment></data>
+  <data name="ShiftsSummary_HumansSignedUp" xml:space="preserve"><value>{0} humans iscritti</value><comment>{0} = count</comment></data>
+  <data name="ShiftsSummary_PendingCount" xml:space="preserve"><value>{0} in sospeso</value><comment>{0} = count</comment></data>
+  <data name="ShiftsSummary_NoShifts" xml:space="preserve"><value>Nessun turno configurato ancora.</value></data>
+  <data name="ShiftsSummary_IncludesSubTeams" xml:space="preserve"><value>Include turni da {0} sotto-team</value><comment>{0} = count</comment></data>
+  <data name="ShiftsSummary_ManageShifts" xml:space="preserve"><value>Gestisci turni</value></data>
+
+  <data name="Medical_Badge" xml:space="preserve"><value>Medico</value></data>
+
+  <data name="Privacy_Lead" xml:space="preserve"><value>Humans gestisce l'appartenenza a Nobodies Collective e tratta i dati personali in conformità con il GDPR e la legge spagnola sulla protezione dei dati (LOPDGDD).</value></data>
+  <data name="Privacy_DataControllerTitle" xml:space="preserve"><value>Titolare del trattamento</value></data>
+  <data name="Privacy_DataControllerBody" xml:space="preserve"><value>Un'associazione senza scopo di lucro spagnola registrata in Andalusia.</value></data>
+  <data name="Privacy_DataControllerDPO" xml:space="preserve"><value>Per richieste sulla protezione dei dati, contatta il nostro Responsabile della Protezione dei Dati a:</value></data>
+  <data name="Privacy_DataWeCollectTitle" xml:space="preserve"><value>Dati che raccogliamo</value></data>
+  <data name="Privacy_DataWeCollectIntro" xml:space="preserve"><value>Raccogliamo e trattiamo le seguenti categorie di dati personali:</value></data>
+  <data name="Privacy_Collect_Identity" xml:space="preserve"><value>Nome, indirizzo e-mail (dall'autenticazione Google), nome visualizzato</value></data>
+  <data name="Privacy_Collect_Contact" xml:space="preserve"><value>Numero di telefono, città, paese (opzionale)</value></data>
+  <data name="Privacy_Collect_Profile" xml:space="preserve"><value>Biografia, appartenenze ai team, assegnazioni di ruolo</value></data>
+  <data name="Privacy_Collect_Technical" xml:space="preserve"><value>Indirizzo IP e user agent (per i registri di consenso)</value></data>
+  <data name="Privacy_Collect_Application" xml:space="preserve"><value>Domande di adesione e dichiarazioni di motivazione</value></data>
+  <data name="Privacy_Collect_Consent" xml:space="preserve"><value>Registri del tuo consenso ai documenti legali</value></data>
+  <data name="Privacy_LegalBasisTitle" xml:space="preserve"><value>Base giuridica del trattamento</value></data>
+  <data name="Privacy_LegalBasisIntro" xml:space="preserve"><value>Trattiamo i tuoi dati sulla base di:</value></data>
+  <data name="Privacy_Legal_Contract" xml:space="preserve"><value>Trattamento necessario per la gestione dell'adesione</value></data>
+  <data name="Privacy_Legal_LegitimateInterest" xml:space="preserve"><value>Mantenimento dei registri organizzativi e comunicazione</value></data>
+  <data name="Privacy_Legal_LegalObligation" xml:space="preserve"><value>Conformità alle normative spagnole sulle associazioni</value></data>
+  <data name="Privacy_Legal_Consent" xml:space="preserve"><value>Per i dati opzionali che scegli di fornire</value></data>
+  <data name="Privacy_HowWeUseTitle" xml:space="preserve"><value>Come utilizziamo i tuoi dati</value></data>
+  <data name="Privacy_Use_Membership" xml:space="preserve"><value>Per gestire la tua adesione e partecipazione ai team</value></data>
+  <data name="Privacy_Use_Communicate" xml:space="preserve"><value>Per comunicare con te riguardo le attività dell'organizzazione</value></data>
+  <data name="Privacy_Use_LegalCompliance" xml:space="preserve"><value>Per mantenere i registri di conformità legale</value></data>
+  <data name="Privacy_Use_Connections" xml:space="preserve"><value>Per facilitare connessioni tra humans (in base alle tue impostazioni di visibilità)</value></data>
+  <data name="Privacy_DataRetentionTitle" xml:space="preserve"><value>Conservazione dei dati</value></data>
+  <data name="Privacy_DataRetentionIntro" xml:space="preserve"><value>Conserviamo i tuoi dati secondo le seguenti politiche:</value></data>
+  <data name="Privacy_Retention_Active" xml:space="preserve"><value>Dati conservati finché il tuo account è attivo</value></data>
+  <data name="Privacy_Retention_Inactive" xml:space="preserve"><value>Dati conservati fino a 7 anni per conformità legale</value></data>
+  <data name="Privacy_Retention_Consent" xml:space="preserve"><value>Conservati indefinitamente come richiesto dal GDPR</value></data>
+  <data name="Privacy_Retention_Deleted" xml:space="preserve"><value>Anonimizzati dopo un periodo di grazia di 30 giorni</value></data>
+  <data name="Privacy_YourRightsTitle" xml:space="preserve"><value>I tuoi diritti</value></data>
+  <data name="Privacy_YourRightsIntro" xml:space="preserve"><value>Ai sensi del GDPR, hai i seguenti diritti:</value></data>
+  <data name="Privacy_Rights_Access" xml:space="preserve"><value>Richiedere una copia dei tuoi dati personali</value></data>
+  <data name="Privacy_Rights_Rectification" xml:space="preserve"><value>Richiedere la correzione di dati inesatti</value></data>
+  <data name="Privacy_Rights_Erasure" xml:space="preserve"><value>Richiedere la cancellazione dei tuoi dati (&quot;diritto all'oblio&quot;)</value></data>
+  <data name="Privacy_Rights_Portability" xml:space="preserve"><value>Ricevere i tuoi dati in formato leggibile da macchina</value></data>
+  <data name="Privacy_Rights_Restriction" xml:space="preserve"><value>Richiedere la limitazione del trattamento</value></data>
+  <data name="Privacy_Rights_Objection" xml:space="preserve"><value>Opporsi a determinati tipi di trattamento</value></data>
+  <data name="Privacy_YourRightsExercise" xml:space="preserve"><value>Per esercitare questi diritti, visita le impostazioni {0} o contattaci a {1}.</value><comment>{0} = Privacy &amp; Data link, {1} = DPO email</comment></data>
+  <data name="Privacy_PrivacyAndData" xml:space="preserve"><value>Privacy e dati</value></data>
+  <data name="Privacy_CookiesTitle" xml:space="preserve"><value>Cookie</value></data>
+  <data name="Privacy_CookiesIntro" xml:space="preserve"><value>Questo sito utilizza solo cookie essenziali necessari per:</value></data>
+  <data name="Privacy_Cookies_Auth" xml:space="preserve"><value>Autenticazione utente e gestione delle sessioni</value></data>
+  <data name="Privacy_Cookies_Antiforgery" xml:space="preserve"><value>Token anti-falsificazione per la sicurezza dei moduli</value></data>
+  <data name="Privacy_Cookies_Consent" xml:space="preserve"><value>Preferenza di consenso ai cookie</value></data>
+  <data name="Privacy_CookiesNoTracking" xml:space="preserve"><value>Non utilizziamo cookie di analisi, pubblicità o tracciamento di terze parti.</value></data>
+  <data name="Privacy_DataSecurityTitle" xml:space="preserve"><value>Sicurezza dei dati</value></data>
+  <data name="Privacy_DataSecurityIntro" xml:space="preserve"><value>Implementiamo misure tecniche e organizzative appropriate per proteggere i tuoi dati, tra cui:</value></data>
+  <data name="Privacy_Security_Encryption" xml:space="preserve"><value>Crittografia in transito (HTTPS)</value></data>
+  <data name="Privacy_Security_OAuth" xml:space="preserve"><value>Autenticazione sicura tramite Google OAuth</value></data>
+  <data name="Privacy_Security_AccessControls" xml:space="preserve"><value>Controlli di accesso e registrazione audit</value></data>
+  <data name="Privacy_Security_Reviews" xml:space="preserve"><value>Revisioni di sicurezza regolari</value></data>
+  <data name="Privacy_ThirdPartyTitle" xml:space="preserve"><value>Servizi di terze parti</value></data>
+  <data name="Privacy_ThirdPartyIntro" xml:space="preserve"><value>Utilizziamo i seguenti servizi di terze parti:</value></data>
+  <data name="Privacy_ThirdParty_GoogleOAuth" xml:space="preserve"><value>Per l'autenticazione sicura</value></data>
+  <data name="Privacy_ThirdParty_GoogleWorkspace" xml:space="preserve"><value>Per il provisioning delle risorse del team (drive condivisi, gruppi)</value></data>
+  <data name="Privacy_ChangesTitle" xml:space="preserve"><value>Modifiche a questa politica</value></data>
+  <data name="Privacy_ChangesBody" xml:space="preserve"><value>Potremmo aggiornare questa politica sulla privacy di tanto in tanto. Notificheremo gli humans attivi dei cambiamenti significativi via e-mail.</value></data>
+  <data name="Privacy_ContactTitle" xml:space="preserve"><value>Contatti e reclami</value></data>
+  <data name="Privacy_ContactBody" xml:space="preserve"><value>Per domande o dubbi su questa politica, contatta il nostro Responsabile della Protezione dei Dati a {0}.</value><comment>{0} = DPO email</comment></data>
+  <data name="Privacy_ComplaintBody" xml:space="preserve"><value>Se non sei soddisfatto della nostra risposta, hai il diritto di presentare un reclamo all'Agenzia Spagnola per la Protezione dei Dati (AEPD) a {0}.</value><comment>{0} = AEPD URL</comment></data>
+
 
 </root>

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -1454,4 +1454,256 @@
   <data name="CityPlanning_Help_ColorsTitle" xml:space="preserve"><value>Colours &amp; sound zones</value></data>
   <data name="CityPlanning_Help_ColorsBody" xml:space="preserve"><value>Each barrio is coloured by its preferred sound zone (editable from your barrio page).</value></data>
 
+
+  <!-- ======================== -->
+  <!-- User-Facing Views        -->
+  <!-- ======================== -->
+  <data name="Feedback_PageTitle" xml:space="preserve"><value>Feedback</value></data>
+  <data name="Feedback_AllStatuses" xml:space="preserve"><value>All Statuses</value></data>
+  <data name="Feedback_AllCategories" xml:space="preserve"><value>All Categories</value></data>
+  <data name="Feedback_AllReporters" xml:space="preserve"><value>All Reporters</value></data>
+  <data name="Feedback_AllAssignees" xml:space="preserve"><value>All Assignees</value></data>
+  <data name="Feedback_AssignedToMe" xml:space="preserve"><value>Assigned to me</value></data>
+  <data name="Feedback_AllTeams" xml:space="preserve"><value>All Teams</value></data>
+  <data name="Feedback_UnassignedOnly" xml:space="preserve"><value>Unassigned only</value></data>
+  <data name="Feedback_Clear" xml:space="preserve"><value>Clear</value></data>
+  <data name="Feedback_NoReports" xml:space="preserve"><value>No feedback reports found.</value></data>
+  <data name="Feedback_Unassigned" xml:space="preserve"><value>Unassigned</value></data>
+  <data name="Feedback_NeedsReply" xml:space="preserve"><value>needs reply</value></data>
+  <data name="Feedback_SelectReport" xml:space="preserve"><value>Select a report to view details</value></data>
+  <data name="Feedback_Conversation" xml:space="preserve"><value>Conversation</value></data>
+  <data name="Feedback_NoMessages" xml:space="preserve"><value>No messages yet.</value></data>
+  <data name="Feedback_MessagePlaceholder" xml:space="preserve"><value>Type a message...</value></data>
+  <data name="Feedback_Send" xml:space="preserve"><value>Send</value></data>
+  <data name="Feedback_ResolvedAt" xml:space="preserve"><value>Resolved {0}</value><comment>{0} = date/time</comment></data>
+  <data name="Feedback_ResolvedBy" xml:space="preserve"><value>by {0}</value><comment>{0} = name</comment></data>
+  <data name="Feedback_NoTeam" xml:space="preserve"><value>No team</value></data>
+  <data name="Feedback_ScreenshotLink" xml:space="preserve"><value>Screenshot</value></data>
+
+  <data name="Unsub_Title" xml:space="preserve"><value>Unsubscribe from Emails</value></data>
+  <data name="Unsub_Heading" xml:space="preserve"><value>Unsubscribe from {0} emails?</value><comment>{0} = category name</comment></data>
+  <data name="Unsub_Greeting" xml:space="preserve"><value>Hi {0},</value><comment>{0} = display name</comment></data>
+  <data name="Unsub_ConfirmMessage" xml:space="preserve"><value>If you confirm, you will no longer receive {0} emails from Humans.</value><comment>{0} = category name</comment></data>
+  <data name="Unsub_ConfirmButton" xml:space="preserve"><value>Confirm Unsubscribe</value></data>
+  <data name="Unsub_DoneTitle" xml:space="preserve"><value>You've been unsubscribed</value></data>
+  <data name="Unsub_DoneMessage" xml:space="preserve"><value>You will no longer receive {0} emails from Humans.</value><comment>{0} = category name</comment></data>
+  <data name="Unsub_DoneManage" xml:space="preserve"><value>You can manage all your communication preferences from your</value></data>
+  <data name="Unsub_DoneManageLink" xml:space="preserve"><value>communication preferences</value></data>
+  <data name="Unsub_BackHome" xml:space="preserve"><value>Back to home</value></data>
+  <data name="Unsub_ExpiredTitle" xml:space="preserve"><value>Unsubscribe link expired</value></data>
+  <data name="Unsub_ExpiredHeading" xml:space="preserve"><value>This unsubscribe link has expired</value></data>
+  <data name="Unsub_ExpiredMessage" xml:space="preserve"><value>Please use the link from a more recent email, or</value></data>
+  <data name="Unsub_ExpiredSignIn" xml:space="preserve"><value>sign in to manage your communication preferences</value></data>
+
+  <data name="CommPrefs_Title" xml:space="preserve"><value>Communication Preferences</value></data>
+  <data name="CommPrefs_Description" xml:space="preserve"><value>Choose which communications you receive and how.</value></data>
+  <data name="CommPrefs_Category" xml:space="preserve"><value>Category</value></data>
+  <data name="CommPrefs_Email" xml:space="preserve"><value>Email</value></data>
+  <data name="CommPrefs_Alert" xml:space="preserve"><value>Alert</value></data>
+  <data name="CommPrefs_BackToProfile" xml:space="preserve"><value>Back to Profile</value></data>
+  <data name="CommPrefs_BackToDashboard" xml:space="preserve"><value>Back to Dashboard</value></data>
+
+  <data name="Emails_Header_Email" xml:space="preserve"><value>Email</value></data>
+  <data name="Emails_Header_Status" xml:space="preserve"><value>Status</value></data>
+  <data name="Emails_Header_Notifications" xml:space="preserve"><value>Notifications</value></data>
+  <data name="Emails_Header_Visibility" xml:space="preserve"><value>Profile Visibility</value></data>
+  <data name="Emails_SignIn" xml:space="preserve"><value>Sign-in</value></data>
+  <data name="Emails_MergePending" xml:space="preserve"><value>Merge pending</value></data>
+  <data name="Emails_Verified" xml:space="preserve"><value>Verified</value></data>
+  <data name="Emails_StatusPending" xml:space="preserve"><value>Pending</value></data>
+  <data name="Emails_Unverified" xml:space="preserve"><value>Unverified</value></data>
+  <data name="Emails_NotifActive" xml:space="preserve"><value>Active</value></data>
+  <data name="Emails_SetAsTarget" xml:space="preserve"><value>Set as target</value></data>
+  <data name="Emails_VerifyFirst" xml:space="preserve"><value>Verify first</value></data>
+  <data name="Emails_Visibility_Hidden" xml:space="preserve"><value>Hidden</value></data>
+  <data name="Emails_Visibility_AllHumans" xml:space="preserve"><value>All humans</value></data>
+  <data name="Emails_Visibility_MyTeams" xml:space="preserve"><value>My teams</value></data>
+  <data name="Emails_Visibility_CoordinatorsBoard" xml:space="preserve"><value>Coordinators + Board</value></data>
+  <data name="Emails_Visibility_BoardOnly" xml:space="preserve"><value>Board only</value></data>
+  <data name="Emails_ConfirmRemove" xml:space="preserve"><value>Are you sure you want to remove this email?</value></data>
+  <data name="Emails_GoogleTitle" xml:space="preserve"><value>Google Services Email</value></data>
+  <data name="Emails_GoogleDescription" xml:space="preserve"><value>This email is used for Google Groups and Shared Drive access.</value></data>
+  <data name="Emails_GoogleAutoNobodies" xml:space="preserve"><value>Your @nobodies.team email is automatically used.</value></data>
+  <data name="Emails_GoogleRejected" xml:space="preserve"><value>Google sync failed. The current email was rejected by Google. Select a different email below to retry sync.</value></data>
+  <data name="Emails_GoogleValid" xml:space="preserve"><value>Google sync is working with the current email.</value></data>
+  <data name="Emails_AutoSelected" xml:space="preserve"><value>Auto-selected</value></data>
+  <data name="Emails_GoogleRejectedBadge" xml:space="preserve"><value>Rejected</value></data>
+  <data name="Emails_UseThis" xml:space="preserve"><value>Use this</value></data>
+
+  <data name="ShiftInfo_Title" xml:space="preserve"><value>Shift Preferences</value></data>
+  <data name="ShiftInfo_StepOf" xml:space="preserve"><value>Step {0} of {1}</value><comment>{0} = current step, {1} = total steps</comment></data>
+  <data name="ShiftInfo_SkillsTitle" xml:space="preserve"><value>What are you good at?</value></data>
+  <data name="ShiftInfo_SkillsSubtitle" xml:space="preserve"><value>Select skills you'd like to use. You can change these anytime.</value></data>
+  <data name="ShiftInfo_WorkStyleTitle" xml:space="preserve"><value>How do you like to work?</value></data>
+  <data name="ShiftInfo_WorkStyleSubtitle" xml:space="preserve"><value>Help coordinators match you with shifts that fit your style and availability.</value></data>
+  <data name="ShiftInfo_LanguagesTitle" xml:space="preserve"><value>Which languages do you speak?</value></data>
+  <data name="ShiftInfo_LanguagesSubtitle" xml:space="preserve"><value>This helps us match you with teams where you can communicate well.</value></data>
+  <data name="ShiftInfo_OtherSkills" xml:space="preserve"><value>What other skills do you have?</value></data>
+  <data name="ShiftInfo_WorkTime" xml:space="preserve"><value>When do you prefer to work?</value></data>
+  <data name="ShiftInfo_OtherPrefs" xml:space="preserve"><value>Other preferences</value></data>
+  <data name="ShiftInfo_OtherLanguages" xml:space="preserve"><value>What other languages do you speak?</value></data>
+  <data name="ShiftInfo_Continue" xml:space="preserve"><value>Continue</value></data>
+
+  <data name="Shifts_Title" xml:space="preserve"><value>Shifts</value></data>
+  <data name="Shifts_BrowseTitle" xml:space="preserve"><value>Browse Volunteer Options</value></data>
+  <data name="Shifts_Department" xml:space="preserve"><value>Department</value></data>
+  <data name="Shifts_AllDepartments" xml:space="preserve"><value>All Departments</value></data>
+  <data name="Shifts_From" xml:space="preserve"><value>From</value></data>
+  <data name="Shifts_To" xml:space="preserve"><value>To</value></data>
+  <data name="Shifts_ClearFilters" xml:space="preserve"><value>Clear Filters</value></data>
+  <data name="Shifts_All" xml:space="preserve"><value>All</value></data>
+  <data name="Shifts_SetUp" xml:space="preserve"><value>Set-up</value></data>
+  <data name="Shifts_Event" xml:space="preserve"><value>Event</value></data>
+  <data name="Shifts_Strike" xml:space="preserve"><value>Strike</value></data>
+  <data name="Shifts_FilterByTag" xml:space="preserve"><value>Filter by tag:</value></data>
+  <data name="Shifts_SetPreferences" xml:space="preserve"><value>Set your preferences</value></data>
+  <data name="Shifts_PreferencesHelp" xml:space="preserve"><value>Select tags that match the kind of work you enjoy. Matching shifts will be highlighted with a star.</value></data>
+  <data name="Shifts_SavePreferences" xml:space="preserve"><value>Save Preferences</value></data>
+  <data name="Shifts_NotOpenYet" xml:space="preserve"><value>Shifts aren't open yet. Only coordinators and admins can see this page.</value></data>
+  <data name="Shifts_NoShiftsAvailable" xml:space="preserve"><value>No shifts available yet.</value></data>
+  <data name="Shifts_AllShiftsFull" xml:space="preserve"><value>All {0} shifts are full.</value><comment>{0} = period name</comment></data>
+  <data name="Shifts_Start" xml:space="preserve"><value>Start</value></data>
+  <data name="Shifts_End" xml:space="preserve"><value>End</value></data>
+  <data name="Shifts_SignUpForDates" xml:space="preserve"><value>Sign up for {0} dates</value><comment>{0} = period name (e.g. set-up, strike)</comment></data>
+  <data name="Shifts_Date" xml:space="preserve"><value>Date</value></data>
+  <data name="Shifts_Filled" xml:space="preserve"><value>Filled</value></data>
+  <data name="Shifts_Days" xml:space="preserve"><value>days</value></data>
+  <data name="Shifts_Total" xml:space="preserve"><value>total</value></data>
+    <data name="Shifts_SignedUpAllDays" xml:space="preserve"><value>Signed up (all {0} days)</value><comment>{0} = count</comment></data>
+    <data name="Shifts_SignedUpPartial" xml:space="preserve"><value>Signed up ({0} of {1})</value><comment>{0} = count</comment></data>
+  <data name="Shifts_Full" xml:space="preserve"><value>Full</value></data>
+  <data name="Shifts_NeedsHelp" xml:space="preserve"><value>Needs help</value></data>
+  <data name="Shifts_DayNeedsHelp" xml:space="preserve"><value>{0} day needs help</value><comment>{0} = number of days</comment></data>
+  <data name="Shifts_DaysNeedHelp" xml:space="preserve"><value>{0} days need help</value><comment>{0} = number of days</comment></data>
+  <data name="Shifts_ClickToExpand" xml:space="preserve"><value>click to expand</value></data>
+  <data name="Shifts_Shift" xml:space="preserve"><value>Shift</value></data>
+  <data name="Shifts_Phase" xml:space="preserve"><value>Phase</value></data>
+  <data name="Shifts_Time" xml:space="preserve"><value>Time</value></data>
+  <data name="Shifts_Duration" xml:space="preserve"><value>Duration</value></data>
+  <data name="Shifts_AllDay" xml:space="preserve"><value>All day</value></data>
+  <data name="Shifts_FullDay" xml:space="preserve"><value>Full day</value></data>
+  <data name="Shifts_Essential" xml:space="preserve"><value>Essential</value></data>
+  <data name="Shifts_Important" xml:space="preserve"><value>Important</value></data>
+  <data name="Shifts_AllPhases" xml:space="preserve"><value>All Phases</value></data>
+  <data name="Shifts_HiddenBadge" xml:space="preserve"><value>Hidden</value></data>
+  <data name="Shifts_MatchesPrefs" xml:space="preserve"><value>Matches your preferences</value></data>
+  <data name="Shifts_SignUpButton" xml:space="preserve"><value>Sign Up</value></data>
+  <data name="Shifts_BrowsingClosed" xml:space="preserve"><value>Shift browsing is not yet open. Check back later!</value></data>
+  <data name="Shifts_NoActiveEvent" xml:space="preserve"><value>No active event is configured. An admin needs to set up event settings first.</value></data>
+  <data name="Shifts_ConfigureEvent" xml:space="preserve"><value>Configure Event Settings</value></data>
+  <data name="Shifts_MyShiftsTitle" xml:space="preserve"><value>My Shifts</value></data>
+  <data name="Shifts_UpcomingShifts" xml:space="preserve"><value>Upcoming Shifts</value></data>
+  <data name="Shifts_PendingApproval" xml:space="preserve"><value>Pending Approval</value></data>
+  <data name="Shifts_Past" xml:space="preserve"><value>Past</value></data>
+  <data name="Shifts_Bail" xml:space="preserve"><value>Bail</value></data>
+  <data name="Shifts_BailConfirm" xml:space="preserve"><value>Are you sure you want to bail?</value></data>
+  <data name="Shifts_BailRangeConfirm" xml:space="preserve"><value>Bail from all {0} days?</value><comment>{0} = number of days</comment></data>
+  <data name="Shifts_WithdrawButton" xml:space="preserve"><value>Withdraw</value></data>
+  <data name="Shifts_NoSignups" xml:space="preserve"><value>No shift signups yet.</value></data>
+  <data name="Shifts_BrowseAvailable" xml:space="preserve"><value>Browse available shifts</value></data>
+  <data name="Shifts_NoActiveEventConfigured" xml:space="preserve"><value>No active event configured.</value></data>
+  <data name="Shifts_GeneralAvailability" xml:space="preserve"><value>General Availability</value></data>
+  <data name="Shifts_AvailabilityHelp" xml:space="preserve"><value>Mark which days you're available to help. Coordinators can see who's in the pool when assigning shifts.</value></data>
+  <data name="Shifts_SaveAvailability" xml:space="preserve"><value>Save Availability</value></data>
+
+  <data name="ShiftDash_Title" xml:space="preserve"><value>Shift Dashboard</value></data>
+  <data name="ShiftDash_ShiftsCount" xml:space="preserve"><value>{0} shifts</value><comment>{0} = count</comment></data>
+  <data name="ShiftDash_Date" xml:space="preserve"><value>Date</value></data>
+  <data name="ShiftDash_Department" xml:space="preserve"><value>Department</value></data>
+  <data name="ShiftDash_AllDepartments" xml:space="preserve"><value>All departments</value></data>
+  <data name="ShiftDash_Filter" xml:space="preserve"><value>Filter</value></data>
+  <data name="ShiftDash_Clear" xml:space="preserve"><value>Clear</value></data>
+  <data name="ShiftDash_NoShiftsMatch" xml:space="preserve"><value>No shifts match the current filters.</value></data>
+  <data name="ShiftDash_Shift" xml:space="preserve"><value>Shift</value></data>
+  <data name="ShiftDash_DateTime" xml:space="preserve"><value>Date / Time</value></data>
+  <data name="ShiftDash_Slots" xml:space="preserve"><value>Slots</value></data>
+  <data name="ShiftDash_Priority" xml:space="preserve"><value>Priority</value></data>
+  <data name="ShiftDash_Voluntell" xml:space="preserve"><value>Voluntell</value></data>
+  <data name="ShiftDash_SearchHumans" xml:space="preserve"><value>Search humans for: {0}</value><comment>{0} = shift/rota name</comment></data>
+  <data name="ShiftDash_SearchPlaceholder" xml:space="preserve"><value>Type a name (min 2 chars)...</value></data>
+  <data name="ShiftDash_NoHumansFound" xml:space="preserve"><value>No humans found.</value></data>
+  <data name="ShiftDash_SearchFailed" xml:space="preserve"><value>Search failed.</value></data>
+  <data name="ShiftDash_ScheduleConflict" xml:space="preserve"><value>Schedule conflict</value></data>
+
+  <data name="Nav_Legal" xml:space="preserve"><value>Legal</value></data>
+  <data name="Nav_Staff" xml:space="preserve"><value>Staff</value></data>
+
+  <data name="ProfileCard_Suspended" xml:space="preserve"><value>Suspended</value></data>
+  <data name="ProfileCard_PendingBadge" xml:space="preserve"><value>Pending</value></data>
+  <data name="ProfileCard_Teams" xml:space="preserve"><value>Teams:</value></data>
+  <data name="ProfileCard_Joined" xml:space="preserve"><value>Joined {0}</value><comment>{0} = date</comment></data>
+  <data name="ProfileCard_LastLogin" xml:space="preserve"><value>Last login {0}</value><comment>{0} = date</comment></data>
+
+  <data name="ShiftsSummary_Title" xml:space="preserve"><value>Shifts</value></data>
+  <data name="ShiftsSummary_SlotsFilled" xml:space="preserve"><value>{0} / {1} slots filled</value><comment>{0} = filled, {1} = total</comment></data>
+  <data name="ShiftsSummary_HumansSignedUp" xml:space="preserve"><value>{0} humans signed up</value><comment>{0} = count</comment></data>
+  <data name="ShiftsSummary_PendingCount" xml:space="preserve"><value>{0} pending</value><comment>{0} = count</comment></data>
+  <data name="ShiftsSummary_NoShifts" xml:space="preserve"><value>No shifts configured yet.</value></data>
+  <data name="ShiftsSummary_IncludesSubTeams" xml:space="preserve"><value>Includes shifts from {0} sub-team(s)</value><comment>{0} = count</comment></data>
+  <data name="ShiftsSummary_ManageShifts" xml:space="preserve"><value>Manage Shifts</value></data>
+
+  <data name="Medical_Badge" xml:space="preserve"><value>Medical</value></data>
+
+  <data name="Privacy_Lead" xml:space="preserve"><value>Humans manages membership for Nobodies Collective and processes personal data in accordance with GDPR and Spanish data protection law (LOPDGDD).</value></data>
+  <data name="Privacy_DataControllerTitle" xml:space="preserve"><value>Data Controller</value></data>
+  <data name="Privacy_DataControllerBody" xml:space="preserve"><value>A Spanish nonprofit association registered in Andalucia.</value></data>
+  <data name="Privacy_DataControllerDPO" xml:space="preserve"><value>For data protection inquiries, contact our Data Protection Officer at:</value></data>
+  <data name="Privacy_DataWeCollectTitle" xml:space="preserve"><value>Data We Collect</value></data>
+  <data name="Privacy_DataWeCollectIntro" xml:space="preserve"><value>We collect and process the following categories of personal data:</value></data>
+  <data name="Privacy_Collect_Identity" xml:space="preserve"><value>Name, email address (from Google authentication), display name/burner name</value></data>
+  <data name="Privacy_Collect_Contact" xml:space="preserve"><value>Phone number, city, country (optional)</value></data>
+  <data name="Privacy_Collect_Profile" xml:space="preserve"><value>Bio, team memberships, role assignments</value></data>
+  <data name="Privacy_Collect_Technical" xml:space="preserve"><value>IP address and user agent (for consent records)</value></data>
+  <data name="Privacy_Collect_Application" xml:space="preserve"><value>Membership applications and motivation statements</value></data>
+  <data name="Privacy_Collect_Consent" xml:space="preserve"><value>Records of your agreement to legal documents</value></data>
+  <data name="Privacy_LegalBasisTitle" xml:space="preserve"><value>Legal Basis for Processing</value></data>
+  <data name="Privacy_LegalBasisIntro" xml:space="preserve"><value>We process your data based on:</value></data>
+  <data name="Privacy_Legal_Contract" xml:space="preserve"><value>Processing necessary for membership management</value></data>
+  <data name="Privacy_Legal_LegitimateInterest" xml:space="preserve"><value>Maintaining organizational records and communication</value></data>
+  <data name="Privacy_Legal_LegalObligation" xml:space="preserve"><value>Compliance with Spanish nonprofit regulations</value></data>
+  <data name="Privacy_Legal_Consent" xml:space="preserve"><value>For optional data you choose to provide</value></data>
+  <data name="Privacy_HowWeUseTitle" xml:space="preserve"><value>How We Use Your Data</value></data>
+  <data name="Privacy_Use_Membership" xml:space="preserve"><value>To manage your membership and team participation</value></data>
+  <data name="Privacy_Use_Communicate" xml:space="preserve"><value>To communicate with you about organizational activities</value></data>
+  <data name="Privacy_Use_LegalCompliance" xml:space="preserve"><value>To maintain legal compliance records</value></data>
+  <data name="Privacy_Use_Connections" xml:space="preserve"><value>To facilitate connections between humans (based on your visibility settings)</value></data>
+  <data name="Privacy_DataRetentionTitle" xml:space="preserve"><value>Data Retention</value></data>
+  <data name="Privacy_DataRetentionIntro" xml:space="preserve"><value>We retain your data according to the following policies:</value></data>
+  <data name="Privacy_Retention_Active" xml:space="preserve"><value>Data retained while your account is active</value></data>
+  <data name="Privacy_Retention_Inactive" xml:space="preserve"><value>Data retained for up to 7 years for legal compliance</value></data>
+  <data name="Privacy_Retention_Consent" xml:space="preserve"><value>Retained indefinitely as required for GDPR compliance</value></data>
+  <data name="Privacy_Retention_Deleted" xml:space="preserve"><value>Anonymized after 30-day grace period</value></data>
+  <data name="Privacy_YourRightsTitle" xml:space="preserve"><value>Your Rights</value></data>
+  <data name="Privacy_YourRightsIntro" xml:space="preserve"><value>Under GDPR, you have the following rights:</value></data>
+  <data name="Privacy_Rights_Access" xml:space="preserve"><value>Request a copy of your personal data</value></data>
+  <data name="Privacy_Rights_Rectification" xml:space="preserve"><value>Request correction of inaccurate data</value></data>
+  <data name="Privacy_Rights_Erasure" xml:space="preserve"><value>Request deletion of your data (&quot;right to be forgotten&quot;)</value></data>
+  <data name="Privacy_Rights_Portability" xml:space="preserve"><value>Receive your data in a machine-readable format</value></data>
+  <data name="Privacy_Rights_Restriction" xml:space="preserve"><value>Request limitation of processing</value></data>
+  <data name="Privacy_Rights_Objection" xml:space="preserve"><value>Object to certain types of processing</value></data>
+  <data name="Privacy_YourRightsExercise" xml:space="preserve"><value>To exercise these rights, visit your {0} settings or contact us at {1}.</value><comment>{0} = Privacy &amp; Data link, {1} = DPO email</comment></data>
+  <data name="Privacy_PrivacyAndData" xml:space="preserve"><value>Privacy &amp; Data</value></data>
+  <data name="Privacy_CookiesTitle" xml:space="preserve"><value>Cookies</value></data>
+  <data name="Privacy_CookiesIntro" xml:space="preserve"><value>This site uses only essential cookies required for:</value></data>
+  <data name="Privacy_Cookies_Auth" xml:space="preserve"><value>User authentication and session management</value></data>
+  <data name="Privacy_Cookies_Antiforgery" xml:space="preserve"><value>Anti-forgery tokens for form security</value></data>
+  <data name="Privacy_Cookies_Consent" xml:space="preserve"><value>Cookie consent preference</value></data>
+  <data name="Privacy_CookiesNoTracking" xml:space="preserve"><value>We do not use analytics, advertising, or third-party tracking cookies.</value></data>
+  <data name="Privacy_DataSecurityTitle" xml:space="preserve"><value>Data Security</value></data>
+  <data name="Privacy_DataSecurityIntro" xml:space="preserve"><value>We implement appropriate technical and organizational measures to protect your data, including:</value></data>
+  <data name="Privacy_Security_Encryption" xml:space="preserve"><value>Encryption in transit (HTTPS)</value></data>
+  <data name="Privacy_Security_OAuth" xml:space="preserve"><value>Secure authentication via Google OAuth</value></data>
+  <data name="Privacy_Security_AccessControls" xml:space="preserve"><value>Access controls and audit logging</value></data>
+  <data name="Privacy_Security_Reviews" xml:space="preserve"><value>Regular security reviews</value></data>
+  <data name="Privacy_ThirdPartyTitle" xml:space="preserve"><value>Third-Party Services</value></data>
+  <data name="Privacy_ThirdPartyIntro" xml:space="preserve"><value>We use the following third-party services:</value></data>
+  <data name="Privacy_ThirdParty_GoogleOAuth" xml:space="preserve"><value>For secure authentication</value></data>
+  <data name="Privacy_ThirdParty_GoogleWorkspace" xml:space="preserve"><value>For team resource provisioning (shared drives, groups)</value></data>
+  <data name="Privacy_ChangesTitle" xml:space="preserve"><value>Changes to This Policy</value></data>
+  <data name="Privacy_ChangesBody" xml:space="preserve"><value>We may update this privacy policy from time to time. We will notify active humans of significant changes via email.</value></data>
+  <data name="Privacy_ContactTitle" xml:space="preserve"><value>Contact &amp; Complaints</value></data>
+  <data name="Privacy_ContactBody" xml:space="preserve"><value>For questions or concerns about this policy, contact our Data Protection Officer at {0}.</value><comment>{0} = DPO email</comment></data>
+  <data name="Privacy_ComplaintBody" xml:space="preserve"><value>If you are not satisfied with our response, you have the right to lodge a complaint with the Spanish Data Protection Agency (AEPD) at {0}.</value><comment>{0} = AEPD URL</comment></data>
+
+
 </root>

--- a/src/Humans.Web/Views/Feedback/Index.cshtml
+++ b/src/Humans.Web/Views/Feedback/Index.cshtml
@@ -1,15 +1,15 @@
 @model Humans.Web.Models.FeedbackPageViewModel
 @{
-    ViewData["Title"] = "Feedback";
+    ViewData["Title"] = Localizer["Feedback_PageTitle"].Value;
 }
 
 <div class="container-fluid">
-    <h2 class="mb-3">Feedback</h2>
+    <h2 class="mb-3">@Localizer["Feedback_PageTitle"]</h2>
 
     <!-- Filter bar -->
     <form method="get" class="feedback-filter-form d-flex gap-2 mb-3 flex-wrap">
         <select name="status" class="form-select form-select-sm" style="width: auto;">
-            <option value="">All Statuses</option>
+            <option value="">@Localizer["Feedback_AllStatuses"]</option>
             @foreach (var s in Enum.GetValues<Humans.Domain.Enums.FeedbackStatus>())
             {
                 if (Model.StatusFilter == s)
@@ -23,7 +23,7 @@
             }
         </select>
         <select name="category" class="form-select form-select-sm" style="width: auto;">
-            <option value="">All Categories</option>
+            <option value="">@Localizer["Feedback_AllCategories"]</option>
             @foreach (var c in Enum.GetValues<Humans.Domain.Enums.FeedbackCategory>())
             {
                 if (Model.CategoryFilter == c)
@@ -39,7 +39,7 @@
         @if (Model.IsAdmin && Model.Reporters.Count > 0)
         {
             <select name="reporterUserId" class="form-select form-select-sm" style="width: auto;">
-                <option value="">All Reporters</option>
+                <option value="">@Localizer["Feedback_AllReporters"]</option>
                 @foreach (var r in Model.Reporters)
                 {
                     if (Model.ReporterFilter == r.UserId)
@@ -56,14 +56,14 @@
         @if (Model.IsAdmin)
         {
             <select name="assignedTo" class="form-select form-select-sm" style="width: auto;">
-                <option value="">All Assignees</option>
+                <option value="">@Localizer["Feedback_AllAssignees"]</option>
                 @if (Model.AssignedToFilter == Model.CurrentUserId)
                 {
-                    <option value="@Model.CurrentUserId" selected>Assigned to me</option>
+                    <option value="@Model.CurrentUserId" selected>@Localizer["Feedback_AssignedToMe"]</option>
                 }
                 else
                 {
-                    <option value="@Model.CurrentUserId">Assigned to me</option>
+                    <option value="@Model.CurrentUserId">@Localizer["Feedback_AssignedToMe"]</option>
                 }
                 @foreach (var a in Model.AssigneeOptions)
                 {
@@ -81,7 +81,7 @@
                 }
             </select>
             <select name="team" class="form-select form-select-sm" style="width: auto;">
-                <option value="">All Teams</option>
+                <option value="">@Localizer["Feedback_AllTeams"]</option>
                 @foreach (var t in Model.TeamOptions)
                 {
                     if (Model.TeamFilter == t.Id)
@@ -105,12 +105,12 @@
                     <input class="form-check-input feedback-filter-checkbox" type="checkbox" name="unassigned" value="true"
                            id="unassignedFilter">
                 }
-                <label class="form-check-label small" for="unassignedFilter">Unassigned only</label>
+                <label class="form-check-label small" for="unassignedFilter">@Localizer["Feedback_UnassignedOnly"]</label>
             </div>
         }
         @if (Model.StatusFilter.HasValue || Model.CategoryFilter.HasValue || Model.ReporterFilter.HasValue || Model.AssignedToFilter.HasValue || Model.TeamFilter.HasValue || Model.UnassignedFilter)
         {
-            <a asp-action="Index" class="btn btn-sm btn-outline-secondary">Clear</a>
+            <a asp-action="Index" class="btn btn-sm btn-outline-secondary">@Localizer["Feedback_Clear"]</a>
         }
     </form>
 
@@ -119,7 +119,7 @@
         <div class="col-md-5 col-lg-4 border-end overflow-auto" style="max-height: 80vh;">
             @if (Model.Reports.Count == 0)
             {
-                <p class="text-muted p-3">No feedback reports found.</p>
+                <p class="text-muted p-3">@Localizer["Feedback_NoReports"]</p>
             }
             @foreach (var report in Model.Reports)
             {
@@ -172,7 +172,7 @@
                                 @if (isUnassigned)
                                 {
                                     <span class="badge bg-secondary bg-opacity-10 text-secondary border border-secondary-subtle" style="font-size: 0.65rem;">
-                                        Unassigned
+                                        @Localizer["Feedback_Unassigned"]
                                     </span>
                                 }
                             </span>
@@ -182,7 +182,7 @@
                         <span></span>
                         @if (report.NeedsReply && Model.IsAdmin)
                         {
-                            <span class="text-danger"><i class="fa-solid fa-circle fa-xs"></i> needs reply</span>
+                            <span class="text-danger"><i class="fa-solid fa-circle fa-xs"></i> @Localizer["Feedback_NeedsReply"]</span>
                         }
                         @if (report.GitHubIssueNumber.HasValue)
                         {
@@ -196,7 +196,7 @@
         <!-- Right panel: detail -->
         <div class="col-md-7 col-lg-8" id="detail-panel">
             <div class="d-flex align-items-center justify-content-center h-100 text-muted">
-                <p>Select a report to view details</p>
+                <p>@Localizer["Feedback_SelectReport"]</p>
             </div>
         </div>
     </div>

--- a/src/Humans.Web/Views/Feedback/_Detail.cshtml
+++ b/src/Humans.Web/Views/Feedback/_Detail.cshtml
@@ -60,7 +60,7 @@
                 <div class="input-group input-group-sm" style="width: auto;">
                     <span class="input-group-text"><i class="fa-solid fa-user fa-xs"></i></span>
                     <select name="AssignedToUserId" class="form-select form-select-sm detail-auto-submit" style="width: auto; min-width: 160px;">
-                        <option value="">Unassigned</option>
+                        <option value="">@Localizer["Feedback_Unassigned"]</option>
                         @foreach (var a in Model.AssigneeOptions)
                         {
                             if (Model.AssignedToUserId == a.Id)
@@ -81,7 +81,7 @@
                 <div class="input-group input-group-sm" style="width: auto;">
                     <span class="input-group-text"><i class="fa-solid fa-users fa-xs"></i></span>
                     <select name="AssignedToTeamId" class="form-select form-select-sm detail-auto-submit" style="width: auto; min-width: 160px;">
-                        <option value="">No team</option>
+                        <option value="">@Localizer["Feedback_NoTeam"]</option>
                         @foreach (var t in Model.TeamOptions)
                         {
                             if (Model.AssignedToTeamId == t.Id)
@@ -125,17 +125,17 @@
 {
     <div class="mb-3">
         <a href="@Model.ScreenshotUrl" target="_blank" class="text-muted small">
-            <i class="fa-solid fa-paperclip"></i> Screenshot
+            <i class="fa-solid fa-paperclip"></i> @Localizer["Feedback_ScreenshotLink"]
         </a>
     </div>
 }
 
 <!-- Conversation -->
-<h6 class="text-muted text-uppercase mb-3" style="font-size: 0.75rem; letter-spacing: 0.05em;">Conversation</h6>
+<h6 class="text-muted text-uppercase mb-3" style="font-size: 0.75rem; letter-spacing: 0.05em;">@Localizer["Feedback_Conversation"]</h6>
 
 @if (Model.Messages.Count == 0)
 {
-    <p class="text-muted small">No messages yet.</p>
+    <p class="text-muted small">@Localizer["Feedback_NoMessages"]</p>
 }
 
 @foreach (var msg in Model.Messages)
@@ -154,18 +154,18 @@
     @Html.AntiForgeryToken()
     <div class="d-flex gap-2">
         <textarea name="Content" class="form-control form-control-sm" rows="2"
-                  placeholder="Type a message..." required maxlength="5000"></textarea>
-        <button type="submit" class="btn btn-primary btn-sm align-self-end">Send</button>
+                  placeholder="@Localizer["Feedback_MessagePlaceholder"].Value" required maxlength="5000"></textarea>
+        <button type="submit" class="btn btn-primary btn-sm align-self-end">@Localizer["Feedback_Send"]</button>
     </div>
 </form>
 
 @if (Model.ResolvedAt.HasValue)
 {
     <div class="text-muted small mt-3">
-        Resolved @Model.ResolvedAt.Value.ToString("MMM dd, HH:mm")
+        @Html.Raw(string.Format(Localizer["Feedback_ResolvedAt"].Value, Html.Encode(Model.ResolvedAt.Value.ToString("MMM dd, HH:mm"))))
         @if (!string.IsNullOrEmpty(Model.ResolvedByName))
         {
-            <text> by @Model.ResolvedByName</text>
+            <text> @Html.Raw(string.Format(Localizer["Feedback_ResolvedBy"].Value, Html.Encode(Model.ResolvedByName)))</text>
         }
     </div>
 }

--- a/src/Humans.Web/Views/Guest/CommunicationPreferences.cshtml
+++ b/src/Humans.Web/Views/Guest/CommunicationPreferences.cshtml
@@ -1,6 +1,6 @@
 @model Humans.Web.Models.CommunicationPreferencesViewModel
 @{
-    ViewData["Title"] = "Communication Preferences";
+    ViewData["Title"] = Localizer["CommPrefs_Title"].Value;
 }
 
 <div class="row">
@@ -9,14 +9,14 @@
         {
             <nav aria-label="breadcrumb">
                 <ol class="breadcrumb">
-                    <li class="breadcrumb-item"><a asp-action="Index">Dashboard</a></li>
-                    <li class="breadcrumb-item active" aria-current="page">Communication Preferences</li>
+                    <li class="breadcrumb-item"><a asp-action="Index">@Localizer["Dashboard_Title"]</a></li>
+                    <li class="breadcrumb-item active" aria-current="page">@Localizer["CommPrefs_Title"]</li>
                 </ol>
             </nav>
         }
 
-        <h1>Communication Preferences</h1>
-        <p class="text-muted">Choose which communications you receive and how.</p>
+        <h1>@Localizer["CommPrefs_Title"]</h1>
+        <p class="text-muted">@Localizer["CommPrefs_Description"]</p>
 
         <vc:temp-data-alerts />
 
@@ -25,9 +25,9 @@
                 <table class="table table-hover mb-0 align-middle">
                     <thead>
                         <tr>
-                            <th style="min-width: 250px;">Category</th>
-                            <th class="text-center" style="width: 100px;">Email</th>
-                            <th class="text-center" style="width: 100px;">Alert</th>
+                            <th style="min-width: 250px;">@Localizer["CommPrefs_Category"]</th>
+                            <th class="text-center" style="width: 100px;">@Localizer["CommPrefs_Email"]</th>
+                            <th class="text-center" style="width: 100px;">@Localizer["CommPrefs_Alert"]</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -89,7 +89,7 @@
 
         @if (string.IsNullOrEmpty(Model.UnsubscribeToken))
         {
-            <a asp-action="Index" class="btn btn-outline-secondary">Back to Dashboard</a>
+            <a asp-action="Index" class="btn btn-outline-secondary">@Localizer["CommPrefs_BackToDashboard"]</a>
         }
     </div>
 </div>

--- a/src/Humans.Web/Views/Home/Privacy.cshtml
+++ b/src/Humans.Web/Views/Home/Privacy.cshtml
@@ -3,101 +3,103 @@
 }
 <h1>@Localizer["Privacy_Title"]</h1>
 
-<p class="lead">Humans manages membership for Nobodies Collective and processes personal data in accordance with GDPR and Spanish data protection law (LOPDGDD).</p>
+<p class="lead">@Localizer["Privacy_Lead"]</p>
 
-<h2>Data Controller</h2>
+<h2>@Localizer["Privacy_DataControllerTitle"]</h2>
 <p>
     <strong>Nobodies Collective</strong><br />
-    A Spanish nonprofit association registered in Andalucia.<br />
-    For data protection inquiries, contact our Data Protection Officer at: <a href="mailto:@(ViewData["DpoEmail"])">@ViewData["DpoEmail"]</a>
+    @Localizer["Privacy_DataControllerBody"]<br />
+    @Localizer["Privacy_DataControllerDPO"] <a href="mailto:@(ViewData["DpoEmail"])">@ViewData["DpoEmail"]</a>
 </p>
 
-<h2>Data We Collect</h2>
-<p>We collect and process the following categories of personal data:</p>
+<h2>@Localizer["Privacy_DataWeCollectTitle"]</h2>
+<p>@Localizer["Privacy_DataWeCollectIntro"]</p>
 <ul>
-    <li><strong>Identity data:</strong> Name, email address (from Google authentication), display name/burner name</li>
-    <li><strong>Contact data:</strong> Phone number, city, country (optional)</li>
-    <li><strong>Profile data:</strong> Bio, team memberships, role assignments</li>
-    <li><strong>Technical data:</strong> IP address and user agent (for consent records)</li>
-    <li><strong>Application data:</strong> Membership applications and motivation statements</li>
-    <li><strong>Consent records:</strong> Records of your agreement to legal documents</li>
+    <li><strong>@Localizer["Privacy_Collect_Identity"]</strong></li>
+    <li><strong>@Localizer["Privacy_Collect_Contact"]</strong></li>
+    <li><strong>@Localizer["Privacy_Collect_Profile"]</strong></li>
+    <li><strong>@Localizer["Privacy_Collect_Technical"]</strong></li>
+    <li><strong>@Localizer["Privacy_Collect_Application"]</strong></li>
+    <li><strong>@Localizer["Privacy_Collect_Consent"]</strong></li>
 </ul>
 
-<h2>Legal Basis for Processing</h2>
-<p>We process your data based on:</p>
+<h2>@Localizer["Privacy_LegalBasisTitle"]</h2>
+<p>@Localizer["Privacy_LegalBasisIntro"]</p>
 <ul>
-    <li><strong>Contract:</strong> Processing necessary for membership management</li>
-    <li><strong>Legitimate interest:</strong> Maintaining organizational records and communication</li>
-    <li><strong>Legal obligation:</strong> Compliance with Spanish nonprofit regulations</li>
-    <li><strong>Consent:</strong> For optional data you choose to provide</li>
+    <li><strong>@Localizer["Privacy_Legal_Contract"]</strong></li>
+    <li><strong>@Localizer["Privacy_Legal_LegitimateInterest"]</strong></li>
+    <li><strong>@Localizer["Privacy_Legal_LegalObligation"]</strong></li>
+    <li><strong>@Localizer["Privacy_Legal_Consent"]</strong></li>
 </ul>
 
-<h2>How We Use Your Data</h2>
+<h2>@Localizer["Privacy_HowWeUseTitle"]</h2>
 <ul>
-    <li>To manage your membership and team participation</li>
-    <li>To communicate with you about organizational activities</li>
-    <li>To maintain legal compliance records</li>
-    <li>To facilitate connections between humans (based on your visibility settings)</li>
+    <li>@Localizer["Privacy_Use_Membership"]</li>
+    <li>@Localizer["Privacy_Use_Communicate"]</li>
+    <li>@Localizer["Privacy_Use_LegalCompliance"]</li>
+    <li>@Localizer["Privacy_Use_Connections"]</li>
 </ul>
 
-<h2>Data Retention</h2>
-<p>We retain your data according to the following policies:</p>
+<h2>@Localizer["Privacy_DataRetentionTitle"]</h2>
+<p>@Localizer["Privacy_DataRetentionIntro"]</p>
 <ul>
-    <li><strong>Active accounts:</strong> Data retained while your account is active</li>
-    <li><strong>Inactive accounts:</strong> Data retained for up to 7 years for legal compliance</li>
-    <li><strong>Consent records:</strong> Retained indefinitely as required for GDPR compliance</li>
-    <li><strong>Deleted accounts:</strong> Anonymized after 30-day grace period</li>
+    <li><strong>@Localizer["Privacy_Retention_Active"]</strong></li>
+    <li><strong>@Localizer["Privacy_Retention_Inactive"]</strong></li>
+    <li><strong>@Localizer["Privacy_Retention_Consent"]</strong></li>
+    <li><strong>@Localizer["Privacy_Retention_Deleted"]</strong></li>
 </ul>
 
-<h2>Your Rights</h2>
-<p>Under GDPR, you have the following rights:</p>
+<h2>@Localizer["Privacy_YourRightsTitle"]</h2>
+<p>@Localizer["Privacy_YourRightsIntro"]</p>
 <ul>
-    <li><strong>Access:</strong> Request a copy of your personal data</li>
-    <li><strong>Rectification:</strong> Request correction of inaccurate data</li>
-    <li><strong>Erasure:</strong> Request deletion of your data ("right to be forgotten")</li>
-    <li><strong>Portability:</strong> Receive your data in a machine-readable format</li>
-    <li><strong>Restriction:</strong> Request limitation of processing</li>
-    <li><strong>Objection:</strong> Object to certain types of processing</li>
+    <li><strong>@Localizer["Privacy_Rights_Access"]</strong></li>
+    <li><strong>@Localizer["Privacy_Rights_Rectification"]</strong></li>
+    <li><strong>@Localizer["Privacy_Rights_Erasure"]</strong></li>
+    <li><strong>@Localizer["Privacy_Rights_Portability"]</strong></li>
+    <li><strong>@Localizer["Privacy_Rights_Restriction"]</strong></li>
+    <li><strong>@Localizer["Privacy_Rights_Objection"]</strong></li>
 </ul>
 <p>
-    To exercise these rights, visit your <a asp-controller="Profile" asp-action="Privacy">Privacy & Data</a> settings or contact us at
-    <a href="mailto:@(ViewData["DpoEmail"])">@ViewData["DpoEmail"]</a>.
+    @Html.Raw(string.Format(
+        Localizer["Privacy_YourRightsExercise"].Value,
+        "<a href=\"" + Html.Encode(Url.Action("Privacy", "Profile")) + "\">" + Localizer["Privacy_PrivacyAndData"].Value + "</a>",
+        "<a href=\"mailto:" + Html.Encode(ViewData["DpoEmail"]) + "\">" + Html.Encode(ViewData["DpoEmail"]) + "</a>"))
 </p>
 
-<h2>Cookies</h2>
-<p>This site uses only essential cookies required for:</p>
+<h2>@Localizer["Privacy_CookiesTitle"]</h2>
+<p>@Localizer["Privacy_CookiesIntro"]</p>
 <ul>
-    <li>User authentication and session management</li>
-    <li>Anti-forgery tokens for form security</li>
-    <li>Cookie consent preference</li>
+    <li>@Localizer["Privacy_Cookies_Auth"]</li>
+    <li>@Localizer["Privacy_Cookies_Antiforgery"]</li>
+    <li>@Localizer["Privacy_Cookies_Consent"]</li>
 </ul>
-<p>We do not use analytics, advertising, or third-party tracking cookies.</p>
+<p>@Localizer["Privacy_CookiesNoTracking"]</p>
 
-<h2>Data Security</h2>
-<p>We implement appropriate technical and organizational measures to protect your data, including:</p>
+<h2>@Localizer["Privacy_DataSecurityTitle"]</h2>
+<p>@Localizer["Privacy_DataSecurityIntro"]</p>
 <ul>
-    <li>Encryption in transit (HTTPS)</li>
-    <li>Secure authentication via Google OAuth</li>
-    <li>Access controls and audit logging</li>
-    <li>Regular security reviews</li>
-</ul>
-
-<h2>Third-Party Services</h2>
-<p>We use the following third-party services:</p>
-<ul>
-    <li><strong>Google OAuth:</strong> For secure authentication (Google's <a href="https://policies.google.com/privacy" target="_blank" rel="noopener noreferrer">Privacy Policy</a>)</li>
-    <li><strong>Google Workspace:</strong> For team resource provisioning (shared drives, groups)</li>
+    <li>@Localizer["Privacy_Security_Encryption"]</li>
+    <li>@Localizer["Privacy_Security_OAuth"]</li>
+    <li>@Localizer["Privacy_Security_AccessControls"]</li>
+    <li>@Localizer["Privacy_Security_Reviews"]</li>
 </ul>
 
-<h2>Changes to This Policy</h2>
-<p>We may update this privacy policy from time to time. We will notify active humans of significant changes via email.</p>
+<h2>@Localizer["Privacy_ThirdPartyTitle"]</h2>
+<p>@Localizer["Privacy_ThirdPartyIntro"]</p>
+<ul>
+    <li><strong>Google OAuth:</strong> @Localizer["Privacy_ThirdParty_GoogleOAuth"] (Google's <a href="https://policies.google.com/privacy" target="_blank" rel="noopener noreferrer">Privacy Policy</a>)</li>
+    <li><strong>Google Workspace:</strong> @Localizer["Privacy_ThirdParty_GoogleWorkspace"]</li>
+</ul>
 
-<h2>Contact & Complaints</h2>
+<h2>@Localizer["Privacy_ChangesTitle"]</h2>
+<p>@Localizer["Privacy_ChangesBody"]</p>
+
+<h2>@Localizer["Privacy_ContactTitle"]</h2>
 <p>
-    For questions or concerns about this policy, contact our Data Protection Officer at
-    <a href="mailto:@(ViewData["DpoEmail"])">@ViewData["DpoEmail"]</a>.
+    @Html.Raw(string.Format(Localizer["Privacy_ContactBody"].Value,
+        "<a href=\"mailto:" + Html.Encode(ViewData["DpoEmail"]) + "\">" + Html.Encode(ViewData["DpoEmail"]) + "</a>"))
 </p>
 <p>
-    If you are not satisfied with our response, you have the right to lodge a complaint with the
-    Spanish Data Protection Agency (AEPD) at <a href="https://www.aepd.es" target="_blank" rel="noopener noreferrer">www.aepd.es</a>.
+    @Html.Raw(string.Format(Localizer["Privacy_ComplaintBody"].Value,
+        "<a href=\"https://www.aepd.es\" target=\"_blank\" rel=\"noopener noreferrer\">www.aepd.es</a>"))
 </p>

--- a/src/Humans.Web/Views/Profile/CommunicationPreferences.cshtml
+++ b/src/Humans.Web/Views/Profile/CommunicationPreferences.cshtml
@@ -1,19 +1,19 @@
 @model Humans.Web.Models.CommunicationPreferencesViewModel
 @{
-    ViewData["Title"] = "Communication Preferences";
+    ViewData["Title"] = Localizer["CommPrefs_Title"].Value;
 }
 
 <div class="row">
     <div class="col-12" style="max-width: 900px;">
         <nav aria-label="breadcrumb">
             <ol class="breadcrumb">
-                <li class="breadcrumb-item"><a asp-action="Index">Profile</a></li>
-                <li class="breadcrumb-item active" aria-current="page">Communication Preferences</li>
+                <li class="breadcrumb-item"><a asp-action="Index">@Localizer["Nav_MyProfile"]</a></li>
+                <li class="breadcrumb-item active" aria-current="page">@Localizer["CommPrefs_Title"]</li>
             </ol>
         </nav>
 
-        <h1>Communication Preferences</h1>
-        <p class="text-muted">Choose which communications you receive and how.</p>
+        <h1>@Localizer["CommPrefs_Title"]</h1>
+        <p class="text-muted">@Localizer["CommPrefs_Description"]</p>
 
         <vc:temp-data-alerts />
 
@@ -22,9 +22,9 @@
                 <table class="table table-hover mb-0 align-middle">
                     <thead>
                         <tr>
-                            <th style="min-width: 250px;">Category</th>
-                            <th class="text-center" style="width: 100px;">Email</th>
-                            <th class="text-center" style="width: 100px;">Alert</th>
+                            <th style="min-width: 250px;">@Localizer["CommPrefs_Category"]</th>
+                            <th class="text-center" style="width: 100px;">@Localizer["CommPrefs_Email"]</th>
+                            <th class="text-center" style="width: 100px;">@Localizer["CommPrefs_Alert"]</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -84,7 +84,7 @@
             </div>
         </div>
 
-        <a asp-action="Index" class="btn btn-outline-secondary">Back to Profile</a>
+        <a asp-action="Index" class="btn btn-outline-secondary">@Localizer["CommPrefs_BackToProfile"]</a>
     </div>
 </div>
 

--- a/src/Humans.Web/Views/Profile/Emails.cshtml
+++ b/src/Humans.Web/Views/Profile/Emails.cshtml
@@ -21,10 +21,10 @@
                     <table class="table table-hover mb-0">
                         <thead>
                             <tr>
-                                <th>Email</th>
-                                <th>Status</th>
-                                <th>Notifications</th>
-                                <th>Profile Visibility</th>
+                                <th>@Localizer["Emails_Header_Email"]</th>
+                                <th>@Localizer["Emails_Header_Status"]</th>
+                                <th>@Localizer["Emails_Header_Notifications"]</th>
+                                <th>@Localizer["Emails_Header_Visibility"]</th>
                                 <th></th>
                             </tr>
                         </thead>
@@ -36,38 +36,38 @@
                                         <code>@email.Email</code>
                                         @if (email.IsOAuth)
                                         {
-                                            <span class="badge bg-secondary ms-1">Sign-in</span>
+                                            <span class="badge bg-secondary ms-1">@Localizer["Emails_SignIn"]</span>
                                         }
                                     </td>
                                     <td>
                                         @if (email.IsMergePending)
                                         {
                                             <span class="badge bg-info text-dark">
-                                                <i class="fa-solid fa-code-merge me-1"></i>Merge pending
+                                                <i class="fa-solid fa-code-merge me-1"></i>@Localizer["Emails_MergePending"]
                                             </span>
                                         }
                                         else if (email.IsVerified)
                                         {
                                             <span class="badge bg-success">
-                                                <i class="fa-solid fa-check me-1"></i>Verified
+                                                <i class="fa-solid fa-check me-1"></i>@Localizer["Emails_Verified"]
                                             </span>
                                         }
                                         else if (email.IsPendingVerification)
                                         {
                                             <span class="badge bg-warning text-dark">
-                                                <i class="fa-solid fa-clock me-1"></i>Pending
+                                                <i class="fa-solid fa-clock me-1"></i>@Localizer["Emails_StatusPending"]
                                             </span>
                                         }
                                         else
                                         {
-                                            <span class="badge bg-secondary">Unverified</span>
+                                            <span class="badge bg-secondary">@Localizer["Emails_Unverified"]</span>
                                         }
                                     </td>
                                     <td>
                                         @if (email.IsNotificationTarget)
                                         {
                                             <span class="badge bg-primary">
-                                                <i class="fa-solid fa-bell me-1"></i>Active
+                                                <i class="fa-solid fa-bell me-1"></i>@Localizer["Emails_NotifActive"]
                                             </span>
                                         }
                                         else if (email.IsVerified)
@@ -76,13 +76,13 @@
                                                 @Html.AntiForgeryToken()
                                                 <input type="hidden" name="emailId" value="@email.Id" />
                                                 <button type="submit" class="btn btn-outline-primary btn-sm">
-                                                    Set as target
+                                                    @Localizer["Emails_SetAsTarget"]
                                                 </button>
                                             </form>
                                         }
                                         else
                                         {
-                                            <span class="text-muted small">Verify first</span>
+                                            <span class="text-muted small">@Localizer["Emails_VerifyFirst"]</span>
                                         }
                                     </td>
                                     <td>
@@ -92,11 +92,11 @@
                                                 @Html.AntiForgeryToken()
                                                 <input type="hidden" name="emailId" value="@email.Id" />
                                                 <select name="visibility" class="form-select form-select-sm js-auto-submit" style="width: auto; display: inline-block;">
-                                                    <option value="" selected="@(email.Visibility == null ? "selected" : null)">Hidden</option>
-                                                    <option value="AllActiveProfiles" selected="@(email.Visibility == ContactFieldVisibility.AllActiveProfiles ? "selected" : null)">All humans</option>
-                                                    <option value="MyTeams" selected="@(email.Visibility == ContactFieldVisibility.MyTeams ? "selected" : null)">My teams</option>
-                                                    <option value="CoordinatorsAndBoard" selected="@(email.Visibility == ContactFieldVisibility.CoordinatorsAndBoard ? "selected" : null)">Coordinators + Board</option>
-                                                    <option value="BoardOnly" selected="@(email.Visibility == ContactFieldVisibility.BoardOnly ? "selected" : null)">Board only</option>
+                                                    <option value="" selected="@(email.Visibility == null ? "selected" : null)">@Localizer["Emails_Visibility_Hidden"]</option>
+                                                    <option value="AllActiveProfiles" selected="@(email.Visibility == ContactFieldVisibility.AllActiveProfiles ? "selected" : null)">@Localizer["Emails_Visibility_AllHumans"]</option>
+                                                    <option value="MyTeams" selected="@(email.Visibility == ContactFieldVisibility.MyTeams ? "selected" : null)">@Localizer["Emails_Visibility_MyTeams"]</option>
+                                                    <option value="CoordinatorsAndBoard" selected="@(email.Visibility == ContactFieldVisibility.CoordinatorsAndBoard ? "selected" : null)">@Localizer["Emails_Visibility_CoordinatorsBoard"]</option>
+                                                    <option value="BoardOnly" selected="@(email.Visibility == ContactFieldVisibility.BoardOnly ? "selected" : null)">@Localizer["Emails_Visibility_BoardOnly"]</option>
                                                 </select>
                                             </form>
                                         }
@@ -109,7 +109,7 @@
                                         @if (!email.IsOAuth)
                                         {
                                             <form asp-action="DeleteEmail" method="post" class="d-inline"
-                                                  data-confirm="Are you sure you want to remove this email?">
+                                                  data-confirm="@Localizer["Emails_ConfirmRemove"].Value">
                                                 @Html.AntiForgeryToken()
                                                 <input type="hidden" name="emailId" value="@email.Id" />
                                                 <button type="submit" class="btn btn-outline-danger btn-sm">
@@ -128,29 +128,28 @@
 
         <div class="card mb-4">
             <div class="card-header">
-                <h5 class="mb-0"><i class="fa-brands fa-google me-2"></i>Google Services Email</h5>
+                <h5 class="mb-0"><i class="fa-brands fa-google me-2"></i>@Localizer["Emails_GoogleTitle"]</h5>
             </div>
             <div class="card-body">
                 <p class="text-muted small mb-3">
-                    This email is used for Google Groups and Shared Drive access.
+                    @Localizer["Emails_GoogleDescription"]
                     @if (Model.HasNobodiesTeamEmail)
                     {
-                        <text>Your @@nobodies.team email is automatically used.</text>
+                        <text>@Localizer["Emails_GoogleAutoNobodies"]</text>
                     }
                 </p>
                 @if (Model.GoogleEmailStatus == Humans.Domain.Enums.GoogleEmailStatus.Rejected)
                 {
                     <div class="alert alert-danger mb-3">
                         <i class="fa-solid fa-triangle-exclamation me-1"></i>
-                        <strong>Google sync failed.</strong> The current email was rejected by Google.
-                        Select a different email below to retry sync.
+                        @Localizer["Emails_GoogleRejected"]
                     </div>
                 }
                 else if (Model.GoogleEmailStatus == Humans.Domain.Enums.GoogleEmailStatus.Valid)
                 {
                     <div class="alert alert-success mb-3 py-2">
                         <i class="fa-solid fa-circle-check me-1"></i>
-                        Google sync is working with the current email.
+                        @Localizer["Emails_GoogleValid"]
                     </div>
                 }
                 @foreach (var email in Model.Emails.Where(e => e.IsVerified))
@@ -159,16 +158,16 @@
                         @if (email.IsGoogleServiceEmail)
                         {
                             <span class="badge bg-primary me-2">
-                                <i class="fa-solid fa-check me-1"></i>Active
+                                <i class="fa-solid fa-check me-1"></i>@Localizer["Emails_NotifActive"]
                             </span>
                             <code>@email.Email</code>
                             @if (email.IsNobodiesTeamDomain)
                             {
-                                <span class="badge bg-info text-dark ms-2">Auto-selected</span>
+                                <span class="badge bg-info text-dark ms-2">@Localizer["Emails_AutoSelected"]</span>
                             }
                             @if (Model.GoogleEmailStatus == Humans.Domain.Enums.GoogleEmailStatus.Rejected && !Model.HasNobodiesTeamEmail)
                             {
-                                <span class="badge bg-danger ms-2">Rejected</span>
+                                <span class="badge bg-danger ms-2">@Localizer["Emails_GoogleRejectedBadge"]</span>
                             }
                         }
                         else if (!Model.HasNobodiesTeamEmail)
@@ -176,7 +175,7 @@
                             <form asp-action="SetGoogleServiceEmail" method="post" class="d-inline me-2">
                                 @Html.AntiForgeryToken()
                                 <input type="hidden" name="emailId" value="@email.Id" />
-                                <button type="submit" class="btn btn-outline-primary btn-sm">Use this</button>
+                                <button type="submit" class="btn btn-outline-primary btn-sm">@Localizer["Emails_UseThis"]</button>
                             </form>
                             <code>@email.Email</code>
                         }

--- a/src/Humans.Web/Views/Profile/ShiftInfo.cshtml
+++ b/src/Humans.Web/Views/Profile/ShiftInfo.cshtml
@@ -1,14 +1,14 @@
 @model Humans.Web.Models.ShiftInfoViewModel
 @{
-    ViewData["Title"] = "Shift Preferences";
+    ViewData["Title"] = Localizer["ShiftInfo_Title"].Value;
 }
 
 <div class="row">
     <div class="col-12" style="max-width: 560px; margin: 0 auto;">
         <nav aria-label="breadcrumb">
             <ol class="breadcrumb">
-                <li class="breadcrumb-item"><a asp-action="Index">Profile</a></li>
-                <li class="breadcrumb-item active" aria-current="page">Shift Preferences</li>
+                <li class="breadcrumb-item"><a asp-action="Index">@Localizer["Nav_MyProfile"]</a></li>
+                <li class="breadcrumb-item active" aria-current="page">@Localizer["ShiftInfo_Title"]</li>
             </ol>
         </nav>
 
@@ -16,9 +16,9 @@
 
         @* Wizard header *@
         <div class="text-center mb-4">
-            <div class="text-muted text-uppercase small" id="stepLabel">Step 1 of 3</div>
-            <h1 class="h4 mt-1 mb-1" id="stepTitle">What are you good at?</h1>
-            <p class="text-muted small" id="stepSubtitle">Select skills you'd like to use. You can change these anytime.</p>
+            <div class="text-muted text-uppercase small" id="stepLabel">@string.Format(Localizer["ShiftInfo_StepOf"].Value, 1, 3)</div>
+            <h1 class="h4 mt-1 mb-1" id="stepTitle">@Localizer["ShiftInfo_SkillsTitle"]</h1>
+            <p class="text-muted small" id="stepSubtitle">@Localizer["ShiftInfo_SkillsSubtitle"]</p>
             <div class="d-flex justify-content-center gap-2 mt-3" id="progressDots">
                 <span class="progress-dot active" data-step="0"></span>
                 <span class="progress-dot" data-step="1"></span>
@@ -45,13 +45,13 @@
                 </div>
                 <div class="other-text-input mt-3" style="display: @(Model.SelectedSkills.Contains("Other") ? "block" : "none");">
                     <input type="text" name="SkillOtherText" class="form-control" maxlength="200"
-                           value="@Model.SkillOtherText" placeholder="What other skills do you have?" />
+                           value="@Model.SkillOtherText" placeholder="@Localizer["ShiftInfo_OtherSkills"].Value" />
                 </div>
             </div>
 
             @* ===== STEP 1: Work Style ===== *@
             <div class="step-pane" id="step-1">
-                <p class="fw-bold small text-muted mb-2">When do you prefer to work?</p>
+                <p class="fw-bold small text-muted mb-2">@Localizer["ShiftInfo_WorkTime"]</p>
                 <div class="radio-card-grid">
                     @foreach (var tp in Humans.Web.Models.ShiftInfoViewModel.TimePreferenceOptions)
                     {
@@ -68,7 +68,7 @@
                     }
                 </div>
 
-                <p class="fw-bold small text-muted mb-2 mt-4">Other preferences</p>
+                <p class="fw-bold small text-muted mb-2 mt-4">@Localizer["ShiftInfo_OtherPrefs"]</p>
                 @foreach (var quirk in Humans.Web.Models.ShiftInfoViewModel.ToggleQuirkOptions)
                 {
                     var isChecked = Model.SelectedQuirks.Contains(quirk);
@@ -96,21 +96,21 @@
                 </div>
                 <div class="other-text-input mt-3" style="display: @(Model.SelectedLanguages.Contains("Other") ? "block" : "none");">
                     <input type="text" name="LanguageOtherText" class="form-control" maxlength="200"
-                           value="@Model.LanguageOtherText" placeholder="What other languages do you speak?" />
+                           value="@Model.LanguageOtherText" placeholder="@Localizer["ShiftInfo_OtherLanguages"].Value" />
                 </div>
             </div>
 
             @* ===== Navigation ===== *@
             <div class="d-flex justify-content-between align-items-center mt-4">
                 <button type="button" class="btn btn-outline-secondary" id="backBtn" style="display:none">
-                    &larr; Back
+                    &larr; @Localizer["Common_Back"]
                 </button>
                 <div></div>
                 <button type="button" class="btn btn-primary" id="nextBtn">
-                    Continue &rarr;
+                    @Localizer["ShiftInfo_Continue"] &rarr;
                 </button>
                 <button type="submit" class="btn btn-primary" id="saveBtn" style="display:none">
-                    Save
+                    @Localizer["Common_Save"]
                 </button>
             </div>
         </form>
@@ -169,9 +169,9 @@
 <script>
 (function() {
     const STEPS = [
-        { label: 'Step 1 of 3', title: 'What are you good at?', subtitle: 'Select skills you\'d like to use. You can change these anytime.' },
-        { label: 'Step 2 of 3', title: 'How do you like to work?', subtitle: 'Help coordinators match you with shifts that fit your style and availability.' },
-        { label: 'Step 3 of 3', title: 'Which languages do you speak?', subtitle: 'This helps us match you with teams where you can communicate well.' }
+        { label: '@Html.Raw(string.Format(Localizer["ShiftInfo_StepOf"].Value, 1, 3))', title: '@Html.Raw(Localizer["ShiftInfo_SkillsTitle"].Value.Replace("'", "\\'"))', subtitle: '@Html.Raw(Localizer["ShiftInfo_SkillsSubtitle"].Value.Replace("'", "\\'"))' },
+        { label: '@Html.Raw(string.Format(Localizer["ShiftInfo_StepOf"].Value, 2, 3))', title: '@Html.Raw(Localizer["ShiftInfo_WorkStyleTitle"].Value.Replace("'", "\\'"))', subtitle: '@Html.Raw(Localizer["ShiftInfo_WorkStyleSubtitle"].Value.Replace("'", "\\'"))' },
+        { label: '@Html.Raw(string.Format(Localizer["ShiftInfo_StepOf"].Value, 3, 3))', title: '@Html.Raw(Localizer["ShiftInfo_LanguagesTitle"].Value.Replace("'", "\\'"))', subtitle: '@Html.Raw(Localizer["ShiftInfo_LanguagesSubtitle"].Value.Replace("'", "\\'"))' }
     ];
 
     let current = 0;

--- a/src/Humans.Web/Views/Shared/_LoginPartial.cshtml
+++ b/src/Humans.Web/Views/Shared/_LoginPartial.cshtml
@@ -50,7 +50,7 @@
             </li>
             <li>
                 <a class="dropdown-item d-flex align-items-center gap-2" asp-controller="Legal" asp-action="Index">
-                    <i class="fa-solid fa-scale-balanced fa-fw"></i> Legal
+                    <i class="fa-solid fa-scale-balanced fa-fw"></i> @Localizer["Nav_Legal"]
                 </a>
             </li>
             <li>
@@ -65,7 +65,7 @@
             </li>
             <li>
                 <a class="dropdown-item d-flex align-items-center gap-2" asp-controller="About" asp-action="Staff">
-                    <i class="fa-solid fa-users fa-fw"></i> Staff
+                    <i class="fa-solid fa-users fa-fw"></i> @Localizer["Nav_Staff"]
                 </a>
             </li>
             <li>

--- a/src/Humans.Web/Views/Shared/_ProfileCard.cshtml
+++ b/src/Humans.Web/Views/Shared/_ProfileCard.cshtml
@@ -14,11 +14,11 @@
             }
             else if (Model.MembershipStatus == "Suspended")
             {
-                <span class="badge bg-danger me-1">Suspended</span>
+                <span class="badge bg-danger me-1">@Localizer["ProfileCard_Suspended"]</span>
             }
             else
             {
-                <span class="badge bg-warning text-dark me-1">Pending</span>
+                <span class="badge bg-warning text-dark me-1">@Localizer["ProfileCard_PendingBadge"]</span>
             }
             @if (!string.IsNullOrEmpty(Model.PreferredLanguage))
             {
@@ -28,7 +28,7 @@
         @if (Model.Teams.Count > 0)
         {
             <div class="mt-2">
-                <small class="text-muted">Teams:</small>
+                <small class="text-muted">@Localizer["ProfileCard_Teams"]</small>
                 @foreach (var team in Model.Teams)
                 {
                     <span class="badge bg-light text-dark border">@team</span>
@@ -38,11 +38,11 @@
         <div class="mt-2 text-muted" style="font-size: 0.8rem;">
             @if (Model.MemberSince.HasValue)
             {
-                <span>Joined @Model.MemberSince.Value.ToString("MMM yyyy")</span>
+                <span>@string.Format(Localizer["ProfileCard_Joined"].Value, Model.MemberSince.Value.ToString("MMM yyyy"))</span>
             }
             @if (Model.LastLogin.HasValue)
             {
-                <span class="ms-2">Last login @Model.LastLogin.Value.ToString("d MMM yyyy")</span>
+                <span class="ms-2">@string.Format(Localizer["ProfileCard_LastLogin"].Value, Model.LastLogin.Value.ToString("d MMM yyyy"))</span>
             }
         </div>
     </div>

--- a/src/Humans.Web/Views/Shared/_ShiftsSummaryCard.cshtml
+++ b/src/Humans.Web/Views/Shared/_ShiftsSummaryCard.cshtml
@@ -2,7 +2,7 @@
 
 <div class="card mb-4">
     <div class="card-header">
-        <h6 class="mb-0"><i class="fa-solid fa-clock me-1"></i> Shifts</h6>
+        <h6 class="mb-0"><i class="fa-solid fa-clock me-1"></i> @Localizer["ShiftsSummary_Title"]</h6>
     </div>
     <div class="card-body">
         @if (Model.TotalSlots > 0)
@@ -16,29 +16,29 @@
                 </div>
             </div>
             <div class="d-flex justify-content-between align-items-center mb-2">
-                <span>@Model.ConfirmedCount / @Model.TotalSlots slots filled</span>
-                <span>@Model.UniqueVolunteerCount humans signed up</span>
+                <span>@string.Format(Localizer["ShiftsSummary_SlotsFilled"].Value, Model.ConfirmedCount, Model.TotalSlots)</span>
+                <span>@string.Format(Localizer["ShiftsSummary_HumansSignedUp"].Value, Model.UniqueVolunteerCount)</span>
             </div>
             @if (Model.PendingCount > 0)
             {
                 <a href="@Model.ShiftsUrl" class="badge bg-warning text-dark text-decoration-none">
-                    @Model.PendingCount pending
+                    @string.Format(Localizer["ShiftsSummary_PendingCount"].Value, Model.PendingCount)
                 </a>
             }
         }
         else
         {
-            <p class="text-muted mb-0">No shifts configured yet.</p>
+            <p class="text-muted mb-0">@Localizer["ShiftsSummary_NoShifts"]</p>
         }
         @if (Model.IncludesSubTeamCount > 0)
         {
             <small class="text-muted d-block mt-1">
-                <i class="fa-solid fa-sitemap me-1"></i>Includes shifts from @Model.IncludesSubTeamCount sub-team@(Model.IncludesSubTeamCount != 1 ? "s" : "")
+                <i class="fa-solid fa-sitemap me-1"></i>@string.Format(Localizer["ShiftsSummary_IncludesSubTeams"].Value, Model.IncludesSubTeamCount)
             </small>
         }
         @if (Model.CanManageShifts)
         {
-            <a href="@Model.ShiftsUrl" class="btn btn-sm btn-outline-primary mt-2 w-100">Manage Shifts <i class="fa-solid fa-lock auth-lock-icon"></i></a>
+            <a href="@Model.ShiftsUrl" class="btn btn-sm btn-outline-primary mt-2 w-100">@Localizer["ShiftsSummary_ManageShifts"] <i class="fa-solid fa-lock auth-lock-icon"></i></a>
         }
     </div>
 </div>

--- a/src/Humans.Web/Views/Shared/_VolunteerProfileBadges.cshtml
+++ b/src/Humans.Web/Views/Shared/_VolunteerProfileBadges.cshtml
@@ -21,7 +21,7 @@
         }
         @if (Model.ShowMedical && !string.IsNullOrEmpty(Model.Profile.MedicalConditions))
         {
-            <span class="badge bg-danger" title="@Model.Profile.MedicalConditions">Medical</span>
+            <span class="badge bg-danger" title="@Model.Profile.MedicalConditions">@Localizer["Medical_Badge"]</span>
         }
     </span>
 }

--- a/src/Humans.Web/Views/ShiftDashboard/Index.cshtml
+++ b/src/Humans.Web/Views/ShiftDashboard/Index.cshtml
@@ -2,15 +2,15 @@
 @using Humans.Web.Controllers
 
 @{
-    ViewData["Title"] = "Shift Dashboard";
+    ViewData["Title"] = Localizer["ShiftDash_Title"].Value;
     var searchUrl = Url.Action(nameof(ShiftDashboardController.SearchVolunteers), "ShiftDashboard");
     var voluntellUrl = Url.Action(nameof(ShiftDashboardController.Voluntell), "ShiftDashboard");
 }
 
 <div class="container py-4">
     <div class="d-flex justify-content-between align-items-center mb-3">
-        <h2>Shift Dashboard</h2>
-        <span class="badge bg-secondary fs-6">@Model.Shifts.Count shifts</span>
+        <h2>@Localizer["ShiftDash_Title"]</h2>
+        <span class="badge bg-secondary fs-6">@string.Format(Localizer["ShiftDash_ShiftsCount"].Value, Model.Shifts.Count)</span>
     </div>
 
     <vc:temp-data-alerts />
@@ -20,13 +20,13 @@
         <div class="card-body">
             <form method="get" class="row g-2 align-items-end">
                 <div class="col-md-3">
-                    <label class="form-label">Date</label>
+                    <label class="form-label">@Localizer["ShiftDash_Date"]</label>
                     <input type="date" name="date" value="@Model.SelectedDate" class="form-control" />
                 </div>
                 <div class="col-md-4">
-                    <label class="form-label">Department</label>
+                    <label class="form-label">@Localizer["ShiftDash_Department"]</label>
                     <select name="departmentId" class="form-select">
-                        <option value="">All departments</option>
+                        <option value="">@Localizer["ShiftDash_AllDepartments"]</option>
                         @foreach (var dept in Model.Departments)
                         {
                             <option value="@dept.TeamId" selected="@(Model.SelectedDepartmentId == dept.TeamId ? "selected" : null)">@dept.Name</option>
@@ -34,8 +34,8 @@
                     </select>
                 </div>
                 <div class="col-md-auto">
-                    <button type="submit" class="btn btn-primary">Filter</button>
-                    <a asp-action="Index" class="btn btn-outline-secondary ms-1">Clear</a>
+                    <button type="submit" class="btn btn-primary">@Localizer["ShiftDash_Filter"]</button>
+                    <a asp-action="Index" class="btn btn-outline-secondary ms-1">@Localizer["ShiftDash_Clear"]</a>
                 </div>
             </form>
         </div>
@@ -50,7 +50,7 @@
     @* Urgency table *@
     @if (Model.Shifts.Count == 0)
     {
-        <div class="alert alert-info">No shifts match the current filters.</div>
+        <div class="alert alert-info">@Localizer["ShiftDash_NoShiftsMatch"]</div>
     }
     else
     {
@@ -58,11 +58,11 @@
             <table class="table table-hover align-middle">
                 <thead class="table-light">
                     <tr>
-                        <th>Shift</th>
-                        <th>Department</th>
-                        <th>Date / Time</th>
-                        <th>Slots</th>
-                        <th>Priority</th>
+                        <th>@Localizer["ShiftDash_Shift"]</th>
+                        <th>@Localizer["ShiftDash_Department"]</th>
+                        <th>@Localizer["ShiftDash_DateTime"]</th>
+                        <th>@Localizer["ShiftDash_Slots"]</th>
+                        <th>@Localizer["ShiftDash_Priority"]</th>
                         <th></th>
                     </tr>
                 </thead>
@@ -82,9 +82,9 @@
                         };
                         var periodLabel = period switch
                         {
-                            ShiftPeriod.Build => "Set-up",
-                            ShiftPeriod.Event => "Event",
-                            ShiftPeriod.Strike => "Strike",
+                            ShiftPeriod.Build => Localizer["Shifts_SetUp"].Value,
+                            ShiftPeriod.Event => Localizer["Shifts_Event"].Value,
+                            ShiftPeriod.Strike => Localizer["Shifts_Strike"].Value,
                             _ => ""
                         };
                         var priorityBadge = shift.Rota.Priority switch
@@ -120,17 +120,17 @@
                                         data-bs-toggle="collapse"
                                         data-bs-target="#@collapseId"
                                         data-shift-id="@shift.Id">
-                                    Voluntell
+                                    @Localizer["ShiftDash_Voluntell"]
                                 </button>
                             </td>
                         </tr>
                         <tr class="collapse" id="@collapseId">
                             <td colspan="6">
                                 <div class="p-3 bg-light rounded border">
-                                    <label class="form-label fw-semibold">Search humans for: @shift.Rota.Name</label>
+                                    <label class="form-label fw-semibold">@string.Format(Localizer["ShiftDash_SearchHumans"].Value, shift.Rota.Name)</label>
                                     <input type="text"
                                            class="form-control mb-2 volunteer-search-input"
-                                           placeholder="Type a name (min 2 chars)..."
+                                           placeholder="@Localizer["ShiftDash_SearchPlaceholder"].Value"
                                            data-shift-id="@shift.Id"
                                            autocomplete="off" />
                                     <div class="volunteer-results" data-shift-id="@shift.Id"></div>
@@ -152,9 +152,9 @@
     ["SearchUrl"] = searchUrl,
     ["VoluntellUrl"] = voluntellUrl,
     ["AssignButtonClass"] = "btn-success",
-    ["NoResultsText"] = "No humans found.",
-    ["ErrorText"] = "Search failed.",
-    ["OverlapLabel"] = "Schedule conflict",
+    ["NoResultsText"] = Localizer["ShiftDash_NoHumansFound"].Value,
+    ["ErrorText"] = Localizer["ShiftDash_SearchFailed"].Value,
+    ["OverlapLabel"] = Localizer["ShiftDash_ScheduleConflict"].Value,
     ["DietaryPreferenceStyle"] = "muted",
     ["ShowPoolBadge"] = false
 })

--- a/src/Humans.Web/Views/Shifts/BrowsingClosed.cshtml
+++ b/src/Humans.Web/Views/Shifts/BrowsingClosed.cshtml
@@ -1,8 +1,8 @@
 @{
-    ViewData["Title"] = "Shifts";
+    ViewData["Title"] = Localizer["Shifts_Title"].Value;
 }
 
 <div class="container py-4 text-center">
-    <h2>Shifts</h2>
-    <p class="text-muted mt-4">Shift browsing is not yet open. Check back later!</p>
+    <h2>@Localizer["Shifts_Title"]</h2>
+    <p class="text-muted mt-4">@Localizer["Shifts_BrowsingClosed"]</p>
 </div>

--- a/src/Humans.Web/Views/Shifts/Index.cshtml
+++ b/src/Humans.Web/Views/Shifts/Index.cshtml
@@ -2,7 +2,7 @@
 @using NodaTime
 
 @{
-    ViewData["Title"] = "Shifts";
+    ViewData["Title"] = Localizer["Shifts_Title"].Value;
     var es = Model.EventSettings;
     var tz = DateTimeZoneProviders.Tzdb[es.TimeZoneId];
 
@@ -26,9 +26,9 @@
     {
         return shift.GetShiftPeriod(es) switch
         {
-            ShiftPeriod.Build => "Set-up",
-            ShiftPeriod.Event => "Event",
-            ShiftPeriod.Strike => "Strike",
+            ShiftPeriod.Build => Localizer["Shifts_SetUp"].Value,
+            ShiftPeriod.Event => Localizer["Shifts_Event"].Value,
+            ShiftPeriod.Strike => Localizer["Shifts_Strike"].Value,
             _ => ""
         };
     }
@@ -47,12 +47,12 @@
 
 <div class="container py-4">
     <div class="d-flex justify-content-between align-items-center mb-4">
-        <h2>Browse Volunteer Options</h2>
+        <h2>@Localizer["Shifts_BrowseTitle"]</h2>
         <div class="d-flex gap-2">
             <vc:access-matrix section="Shifts" />
             <a asp-controller="ShiftDashboard" asp-action="Index" class="btn btn-outline-warning" authorize-policy="ShiftDepartmentManager"><i class="fa-solid fa-gauge-high me-1"></i>Dashboard <i class="fa-solid fa-lock auth-lock-icon"></i></a>
             <a asp-action="Settings" class="btn btn-outline-secondary" authorize-policy="AdminOnly"><i class="fa-solid fa-gear me-1"></i>Settings <i class="fa-solid fa-lock auth-lock-icon"></i></a>
-            <a asp-action="Mine" class="btn btn-outline-primary">My Shifts</a>
+            <a asp-action="Mine" class="btn btn-outline-primary">@Localizer["Shifts_MyShiftsTitle"]</a>
         </div>
     </div>
 
@@ -60,9 +60,9 @@
 
     <form method="get" class="row g-2 mb-4 align-items-end">
         <div class="col-auto">
-            <label class="form-label mb-1">Department</label>
+            <label class="form-label mb-1">@Localizer["Shifts_Department"]</label>
             <select name="departmentId" class="form-select form-select-sm">
-                <option value="">All Departments</option>
+                <option value="">@Localizer["Shifts_AllDepartments"]</option>
                 @foreach (var dept in Model.AllDepartments)
                 {
                     <option value="@dept.TeamId" selected="@(Model.FilterDepartmentId == dept.TeamId ? "selected" : null)">@dept.Name</option>
@@ -70,13 +70,13 @@
             </select>
         </div>
         <div class="col-auto">
-            <label class="form-label mb-1">From</label>
+            <label class="form-label mb-1">@Localizer["Shifts_From"]</label>
             <input type="date" name="fromDate" class="form-control form-control-sm" value="@Model.FilterFromDate"
                    min="@pickerMin.ToString("yyyy-MM-dd", null)"
                    max="@pickerMax.ToString("yyyy-MM-dd", null)" />
         </div>
         <div class="col-auto">
-            <label class="form-label mb-1">To</label>
+            <label class="form-label mb-1">@Localizer["Shifts_To"]</label>
             <input type="date" name="toDate" class="form-control form-control-sm" value="@Model.FilterToDate"
                    min="@pickerMin.ToString("yyyy-MM-dd", null)"
                    max="@pickerMax.ToString("yyyy-MM-dd", null)" />
@@ -84,7 +84,7 @@
         @if (Model.FilterDepartmentId.HasValue || !string.IsNullOrEmpty(Model.FilterFromDate) || !string.IsNullOrEmpty(Model.FilterToDate) || !string.IsNullOrEmpty(Model.FilterPeriod) || Model.FilterTagIds.Count > 0)
         {
             <div class="col-auto">
-                <a asp-action="Index" class="btn btn-sm btn-outline-secondary">Clear Filters</a>
+                <a asp-action="Index" class="btn btn-sm btn-outline-secondary">@Localizer["Shifts_ClearFilters"]</a>
             </div>
         }
         <input type="hidden" name="period" value="@Model.FilterPeriod" />
@@ -98,20 +98,20 @@
     }
     <div class="btn-group mb-3" role="group" aria-label="Period filter">
         <a href="@Url.Action("Index", new { departmentId = Model.FilterDepartmentId, fromDate = Model.FilterFromDate, toDate = Model.FilterToDate })"
-           class="btn btn-sm @(string.IsNullOrEmpty(activePeriod) ? "btn-primary" : "btn-outline-primary")">All</a>
+           class="btn btn-sm @(string.IsNullOrEmpty(activePeriod) ? "btn-primary" : "btn-outline-primary")">@Localizer["Shifts_All"]</a>
         <a href="@Url.Action("Index", new { departmentId = Model.FilterDepartmentId, period = "Build" })"
-           class="btn btn-sm @(activePeriod == "Build" ? "btn-info" : "btn-outline-info")">Set-up</a>
+           class="btn btn-sm @(activePeriod == "Build" ? "btn-info" : "btn-outline-info")">@Localizer["Shifts_SetUp"]</a>
         <a href="@Url.Action("Index", new { departmentId = Model.FilterDepartmentId, period = "Event" })"
-           class="btn btn-sm @(activePeriod == "Event" ? "btn-success" : "btn-outline-success")">Event</a>
+           class="btn btn-sm @(activePeriod == "Event" ? "btn-success" : "btn-outline-success")">@Localizer["Shifts_Event"]</a>
         <a href="@Url.Action("Index", new { departmentId = Model.FilterDepartmentId, period = "Strike" })"
-           class="btn btn-sm @(activePeriod == "Strike" ? "btn-secondary" : "btn-outline-secondary")">Strike</a>
+           class="btn btn-sm @(activePeriod == "Strike" ? "btn-secondary" : "btn-outline-secondary")">@Localizer["Shifts_Strike"]</a>
     </div>
 
     @if (Model.AllTags.Count > 0)
     {
         <div class="mb-3">
             <div class="d-flex flex-wrap gap-1 align-items-center">
-                <small class="text-muted me-1"><i class="fa-solid fa-tags me-1"></i>Filter by tag:</small>
+                <small class="text-muted me-1"><i class="fa-solid fa-tags me-1"></i>@Localizer["Shifts_FilterByTag"]</small>
                 @foreach (var tag in Model.AllTags)
                 {
                     var isActive = Model.FilterTagIds.Contains(tag.Id);
@@ -150,7 +150,7 @@
     {
         <div class="mb-3">
             <button class="btn btn-sm btn-outline-secondary" type="button" data-bs-toggle="collapse" data-bs-target="#tag-preferences-panel">
-                <i class="fa-solid fa-sliders me-1"></i>Set your preferences
+                <i class="fa-solid fa-sliders me-1"></i>@Localizer["Shifts_SetPreferences"]
                 @if (Model.UserPreferredTagIds.Count > 0)
                 {
                     <span class="badge bg-primary ms-1">@Model.UserPreferredTagIds.Count</span>
@@ -158,7 +158,7 @@
             </button>
             <div class="collapse @(Model.UserPreferredTagIds.Count == 0 ? "" : "")" id="tag-preferences-panel">
                 <div class="card card-body mt-2">
-                    <p class="small text-muted mb-2">Select tags that match the kind of work you enjoy. Matching shifts will be highlighted with a <i class="fa-solid fa-star text-warning"></i>.</p>
+                    <p class="small text-muted mb-2">@Localizer["Shifts_PreferencesHelp"] <i class="fa-solid fa-star text-warning"></i></p>
                     <form asp-action="SaveTagPreferences" method="post">
                         @Html.AntiForgeryToken()
                         <div class="d-flex flex-wrap gap-2 mb-2">
@@ -172,7 +172,7 @@
                                 </div>
                             }
                         </div>
-                        <button type="submit" class="btn btn-sm btn-primary">Save Preferences</button>
+                        <button type="submit" class="btn btn-sm btn-primary">@Localizer["Shifts_SavePreferences"]</button>
                     </form>
                 </div>
             </div>
@@ -194,12 +194,12 @@
 
     @if (!Model.EventSettings.IsShiftBrowsingOpen)
     {
-        <div class="alert alert-danger">Shifts aren't open yet. Only coordinators and admins can see this page.</div>
+        <div class="alert alert-danger">@Localizer["Shifts_NotOpenYet"]</div>
     }
 
     @if (Model.Departments.Count == 0)
     {
-        <div class="alert alert-info">No shifts available yet.</div>
+        <div class="alert alert-info">@Localizer["Shifts_NoShiftsAvailable"]</div>
     }
     else
     {
@@ -218,9 +218,9 @@
                     }
                     @foreach (var periodGroup in rotasByPeriod)
                     {
-                        var periodName = periodGroup.Key == RotaPeriod.Build ? "Set-up"
-                            : periodGroup.Key == RotaPeriod.Strike ? "Strike"
-                            : "Event";
+                        var periodName = periodGroup.Key == RotaPeriod.Build ? Localizer["Shifts_SetUp"].Value
+                            : periodGroup.Key == RotaPeriod.Strike ? Localizer["Shifts_Strike"].Value
+                            : Localizer["Shifts_Event"].Value;
                         <h5 class="mt-4 mb-2 border-bottom pb-1">
                             <span class="badge @(periodGroup.Key == RotaPeriod.Build ? "bg-info" : periodGroup.Key == RotaPeriod.Strike ? "bg-secondary" : "bg-success") me-1">@periodName</span>
                             @periodName
@@ -228,7 +228,7 @@
                         var hasAvailable = periodGroup.Any(r => r.Shifts.Any(s => s.RemainingSlots > 0));
                         @if (!hasAvailable)
                         {
-                            <p class="text-muted fst-italic">All @periodName.ToLowerInvariant() shifts are full.</p>
+                            <p class="text-muted fst-italic">@string.Format(Localizer["Shifts_AllShiftsFull"].Value, periodName.ToLowerInvariant())</p>
                         }
                     @foreach (var rotaGroup in periodGroup)
                     {
@@ -240,21 +240,21 @@
                         <h6 class="mt-3">
                             @if (rotaMatchesPreference)
                             {
-                                <i class="fa-solid fa-star text-warning me-1" title="Matches your preferences"></i>
+                                <i class="fa-solid fa-star text-warning me-1" title="@Localizer["Shifts_MatchesPrefs"].Value"></i>
                             }
                             @rotaGroup.Rota.Name
                             @if (rotaGroup.Rota.Priority == ShiftPriority.Essential)
                             {
-                                <span class="badge bg-danger ms-1">Essential</span>
+                                <span class="badge bg-danger ms-1">@Localizer["Shifts_Essential"]</span>
                             }
                             else if (rotaGroup.Rota.Priority == ShiftPriority.Important)
                             {
-                                <span class="badge bg-warning text-dark ms-1">Important</span>
+                                <span class="badge bg-warning text-dark ms-1">@Localizer["Shifts_Important"]</span>
                             }
-                            <span class="badge @(rotaGroup.Rota.Period switch { RotaPeriod.Build => "bg-info", RotaPeriod.Strike => "bg-secondary", RotaPeriod.All => "bg-primary", _ => "bg-success" }) ms-1">@(rotaGroup.Rota.Period switch { RotaPeriod.Build => "Set-up", RotaPeriod.All => "All Phases", _ => rotaGroup.Rota.Period.ToString() })</span>
+                            <span class="badge @(rotaGroup.Rota.Period switch { RotaPeriod.Build => "bg-info", RotaPeriod.Strike => "bg-secondary", RotaPeriod.All => "bg-primary", _ => "bg-success" }) ms-1">@(rotaGroup.Rota.Period switch { RotaPeriod.Build => Localizer["Shifts_SetUp"].Value, RotaPeriod.All => Localizer["Shifts_AllPhases"].Value, _ => rotaGroup.Rota.Period.ToString() })</span>
                             @if (!rotaGroup.Rota.IsVisibleToVolunteers)
                             {
-                                <span class="badge bg-warning text-dark ms-1"><i class="fa-solid fa-eye-slash me-1"></i>Hidden</span>
+                                <span class="badge bg-warning text-dark ms-1"><i class="fa-solid fa-eye-slash me-1"></i>@Localizer["Shifts_HiddenBadge"]</span>
                             }
                             @foreach (var tag in rotaGroup.Rota.Tags.OrderBy(t => t.Name, StringComparer.Ordinal))
                             {
@@ -286,7 +286,7 @@
                                     @if (!string.IsNullOrEmpty(Model.FilterPeriod)) { <input type="hidden" name="period" value="@Model.FilterPeriod" /> }
                                     @foreach (var tagId in Model.FilterTagIds) { <input type="hidden" name="tags" value="@tagId" /> }
                                     <div class="col-auto">
-                                        <label class="form-label form-label-sm">Start</label>
+                                        <label class="form-label form-label-sm">@Localizer["Shifts_Start"]</label>
                                         <select name="startDayOffset" class="form-select form-select-sm">
                                             @foreach (var s in availableShifts)
                                             {
@@ -295,7 +295,7 @@
                                         </select>
                                     </div>
                                     <div class="col-auto">
-                                        <label class="form-label form-label-sm">End</label>
+                                        <label class="form-label form-label-sm">@Localizer["Shifts_End"]</label>
                                         <select name="endDayOffset" class="form-select form-select-sm">
                                             @foreach (var s in availableShifts)
                                             {
@@ -304,7 +304,7 @@
                                         </select>
                                     </div>
                                     <div class="col-auto">
-                                        <button type="submit" class="btn btn-sm btn-success">Sign up for @(rotaGroup.Rota.Period == RotaPeriod.Build ? "set-up" : "strike") dates</button>
+                                        <button type="submit" class="btn btn-sm btn-success">@string.Format(Localizer["Shifts_SignUpForDates"].Value, rotaGroup.Rota.Period == RotaPeriod.Build ? Localizer["Shifts_SetUp"].Value.ToLowerInvariant() : Localizer["Shifts_Strike"].Value.ToLowerInvariant())</button>
                                     </div>
                                 </form>
                             }
@@ -325,7 +325,7 @@
                             <div class="table-responsive">
                                 <table class="table table-sm">
                                     <thead>
-                                        <tr><th>Date</th><th>Filled</th><th>Status</th>@if (Model.ShowSignups) {<th>@Localizer["Shifts_SignedUp"]</th>}</tr>
+                                        <tr><th>@Localizer["Shifts_Date"]</th><th>@Localizer["Shifts_Filled"]</th><th>@Localizer["Common_Status"]</th>@if (Model.ShowSignups) {<th>@Localizer["Shifts_SignedUp"]</th>}</tr>
                                     </thead>
                                     <tbody>
                                         @foreach (var range in dateRanges)
@@ -345,33 +345,33 @@
                                                     <td>
                                                         <i class="fa-solid fa-chevron-right fa-xs me-1 range-icon"></i>
                                                         @rangeStart.ToDisplayShiftDate()–@rangeEnd.ToDisplayShiftDate()
-                                                        <small class="text-muted">(@range.Count days)</small>
+                                                        <small class="text-muted">(@range.Count @Localizer["Shifts_Days"])</small>
                                                     </td>
                                                     <td>
                                                         <span class="@(anyUnderstaffed ? "text-danger fw-bold" : "")">@totalConfirmed</span>
-                                                        <small class="text-muted">/ @totalMax total</small>
+                                                        <small class="text-muted">/ @totalMax @Localizer["Shifts_Total"]</small>
                                                     </td>
                                                     <td>
                                                         @if (userSignedUpDays == range.Count)
                                                         {
-                                                            <span class="badge bg-info">Signed up (all @range.Count days)</span>
+                                                            <span class="badge bg-info">@string.Format(Localizer["Shifts_SignedUpAllDays"].Value, range.Count)</span>
                                                         }
                                                         else if (userSignedUpDays > 0)
                                                         {
-                                                            <span class="badge bg-info">Signed up (@userSignedUpDays of @range.Count)</span>
+                                                            <span class="badge bg-info">@string.Format(Localizer["Shifts_SignedUpPartial"].Value, userSignedUpDays, range.Count)</span>
                                                         }
                                                         else if (allRangeFull)
                                                         {
-                                                            <span class="badge bg-secondary">Full</span>
+                                                            <span class="badge bg-secondary">@Localizer["Shifts_Full"]</span>
                                                         }
                                                         else if (daysNeedingHelp > 0)
                                                         {
-                                                            <span class="badge bg-warning text-dark">@daysNeedingHelp @(daysNeedingHelp == 1 ? "day needs" : "days need") help</span>
+                                                            <span class="badge bg-warning text-dark">@string.Format((daysNeedingHelp == 1 ? Localizer["Shifts_DayNeedsHelp"] : Localizer["Shifts_DaysNeedHelp"]).Value, daysNeedingHelp)</span>
                                                         }
                                                     </td>
                                                     @if (Model.ShowSignups)
                                                     {
-                                                        <td><small class="text-muted fst-italic">click to expand</small></td>
+                                                        <td><small class="text-muted fst-italic">@Localizer["Shifts_ClickToExpand"]</small></td>
                                                     }
                                                 </tr>
                                                 @foreach (var item in range)
@@ -387,15 +387,15 @@
                                                         <td>
                                                             @if (Model.UserSignupShiftIds.Contains(item.Shift.Id))
                                                             {
-                                                                <span class="badge bg-info">Signed up</span>
+                                                                <span class="badge bg-info">@Localizer["Shifts_SignedUp"]</span>
                                                             }
                                                             else if (isFull)
                                                             {
-                                                                <span class="badge bg-secondary">Full</span>
+                                                                <span class="badge bg-secondary">@Localizer["Shifts_Full"]</span>
                                                             }
                                                             else if (understaffed)
                                                             {
-                                                                <span class="badge bg-warning text-dark">Needs help</span>
+                                                                <span class="badge bg-warning text-dark">@Localizer["Shifts_NeedsHelp"]</span>
                                                             }
                                                         </td>
                                                         @if (Model.ShowSignups)
@@ -438,15 +438,15 @@
                                                     <td>
                                                         @if (Model.UserSignupShiftIds.Contains(item.Shift.Id))
                                                         {
-                                                            <span class="badge bg-info">Signed up</span>
+                                                            <span class="badge bg-info">@Localizer["Shifts_SignedUp"]</span>
                                                         }
                                                         else if (isFull)
                                                         {
-                                                            <span class="badge bg-secondary">Full</span>
+                                                            <span class="badge bg-secondary">@Localizer["Shifts_Full"]</span>
                                                         }
                                                         else if (understaffed)
                                                         {
-                                                            <span class="badge bg-warning text-dark">Needs help</span>
+                                                            <span class="badge bg-warning text-dark">@Localizer["Shifts_NeedsHelp"]</span>
                                                         }
                                                     </td>
                                                     @if (Model.ShowSignups)
@@ -488,12 +488,12 @@
                                 <table class="table table-sm">
                                     <thead>
                                         <tr>
-                                            <th>Shift</th>
-                                            <th>Phase</th>
-                                            <th>Date</th>
-                                            <th>Time</th>
-                                            <th>Duration</th>
-                                            <th>Filled</th>
+                                            <th>@Localizer["Shifts_Shift"]</th>
+                                            <th>@Localizer["Shifts_Phase"]</th>
+                                            <th>@Localizer["Shifts_Date"]</th>
+                                            <th>@Localizer["Shifts_Time"]</th>
+                                            <th>@Localizer["Shifts_Duration"]</th>
+                                            <th>@Localizer["Shifts_Filled"]</th>
                                             @if (Model.ShowSignups)
                                             {
                                                 <th>@Localizer["Shifts_SignedUp"]</th>
@@ -508,17 +508,17 @@
                                             var isFull = item.RemainingSlots <= 0;
                                             var understaffed = item.ConfirmedCount < shift.MinVolunteers;
                                             <tr class="@(isFull ? "table-secondary" : "")">
-                                                <td>@(shift.IsAllDay ? "All day" : $"{shift.StartTime.ToDisplayTime()}–{shift.StartTime.PlusMinutes((int)shift.Duration.TotalMinutes).ToDisplayTime()}")</td>
+                                                <td>@(shift.IsAllDay ? Localizer["Shifts_AllDay"].Value : $"{shift.StartTime.ToDisplayTime()}–{shift.StartTime.PlusMinutes((int)shift.Duration.TotalMinutes).ToDisplayTime()}")</td>
                                                 <td><span class="badge @GetPhaseBadge(shift, es)">@GetPhase(shift, es)</span></td>
                                                 <td>@es.GateOpeningDate.PlusDays(shift.DayOffset).ToDisplayShiftDate()</td>
                                                 <td>@item.AbsoluteStart.ToDisplayTime(tz)</td>
-                                                <td>@(shift.IsAllDay ? "Full day" : $"{shift.Duration.TotalHours}h")</td>
+                                                <td>@(shift.IsAllDay ? Localizer["Shifts_FullDay"].Value : $"{shift.Duration.TotalHours}h")</td>
                                                 <td>
                                                     <span class="@(understaffed ? "text-danger fw-bold" : "")">@item.ConfirmedCount</span>
                                                     <small class="text-muted">/ @shift.MinVolunteers–@shift.MaxVolunteers</small>
                                                     @if (understaffed)
                                                     {
-                                                        <span class="badge bg-warning text-dark">Needs help</span>
+                                                        <span class="badge bg-warning text-dark">@Localizer["Shifts_NeedsHelp"]</span>
                                                     }
                                                 </td>
                                                 @if (Model.ShowSignups)
@@ -542,7 +542,7 @@
                                                     }
                                                     else if (isFull)
                                                     {
-                                                        <span class="badge bg-secondary">Full</span>
+                                                        <span class="badge bg-secondary">@Localizer["Shifts_Full"]</span>
                                                     }
                                                     else
                                                     {
@@ -554,7 +554,7 @@
                                                             @if (!string.IsNullOrEmpty(Model.FilterToDate)) { <input type="hidden" name="toDate" value="@Model.FilterToDate" /> }
                                                             @if (!string.IsNullOrEmpty(Model.FilterPeriod)) { <input type="hidden" name="period" value="@Model.FilterPeriod" /> }
                                                             @foreach (var tagId in Model.FilterTagIds) { <input type="hidden" name="tags" value="@tagId" /> }
-                                                            <button type="submit" class="btn btn-sm btn-success">Sign Up</button>
+                                                            <button type="submit" class="btn btn-sm btn-success">@Localizer["Shifts_SignUpButton"]</button>
                                                         </form>
                                                     }
                                                 </td>

--- a/src/Humans.Web/Views/Shifts/Mine.cshtml
+++ b/src/Humans.Web/Views/Shifts/Mine.cshtml
@@ -2,7 +2,7 @@
 @using NodaTime
 
 @{
-    ViewData["Title"] = "My Shifts";
+    ViewData["Title"] = Localizer["Shifts_MyShiftsTitle"].Value;
     var tz = Model.EventSettings != null ? DateTimeZoneProviders.Tzdb[Model.EventSettings.TimeZoneId] : null;
 }
 
@@ -12,9 +12,9 @@
         var period = shift.GetShiftPeriod(es);
         return period switch
         {
-            ShiftPeriod.Build => "Set-up",
-            ShiftPeriod.Event => "Event",
-            ShiftPeriod.Strike => "Strike",
+            ShiftPeriod.Build => Localizer["Shifts_SetUp"].Value,
+            ShiftPeriod.Event => Localizer["Shifts_Event"].Value,
+            ShiftPeriod.Strike => Localizer["Shifts_Strike"].Value,
             _ => ""
         };
     }
@@ -34,15 +34,15 @@
 
 <div class="container py-4">
     <div class="d-flex justify-content-between align-items-center mb-4">
-        <h2>My Shifts</h2>
-        <a asp-action="Index" class="btn btn-outline-primary">Browse Volunteer Options</a>
+        <h2>@Localizer["Shifts_MyShiftsTitle"]</h2>
+        <a asp-action="Index" class="btn btn-outline-primary">@Localizer["Shifts_BrowseTitle"]</a>
     </div>
 
     <vc:temp-data-alerts />
 
     @if (Model.EventSettings == null)
     {
-        <div class="alert alert-info">No active event configured.</div>
+        <div class="alert alert-info">@Localizer["Shifts_NoActiveEventConfigured"]</div>
     }
     else
     {
@@ -51,7 +51,7 @@
         @if (Model.Upcoming.Count > 0)
         {
             <div class="card mb-4">
-                <div class="card-header"><h5 class="mb-0">Upcoming Shifts</h5></div>
+                <div class="card-header"><h5 class="mb-0">@Localizer["Shifts_UpcomingShifts"]</h5></div>
                 <div class="card-body">
                     @{
                         // Group build/strike range signups by SignupBlockId, show individual signups separately
@@ -83,7 +83,7 @@
                                     @Html.AntiForgeryToken()
                                     <input type="hidden" name="signupBlockId" value="@block.Key" />
                                     <button type="submit" class="btn btn-sm btn-outline-danger"
-                                            data-confirm="Bail from all @block.Count() days?">Bail</button>
+                                            data-confirm="@string.Format(Localizer["Shifts_BailRangeConfirm"].Value, block.Count())">@Localizer["Shifts_Bail"]</button>
                                 </form>
                             </div>
                         }
@@ -94,7 +94,7 @@
                         <div class="table-responsive">
                             <table class="table table-sm">
                                 <thead>
-                                    <tr><th>Department</th><th>Shift</th><th>Phase</th><th>Date</th><th>Time</th><th>Duration</th><th></th></tr>
+                                    <tr><th>@Localizer["Shifts_Department"]</th><th>@Localizer["Shifts_Shift"]</th><th>@Localizer["Shifts_Phase"]</th><th>@Localizer["Shifts_Date"]</th><th>@Localizer["Shifts_Time"]</th><th>@Localizer["Shifts_Duration"]</th><th></th></tr>
                                 </thead>
                                 <tbody>
                                     @foreach (var item in individualItems)
@@ -112,7 +112,7 @@
                                                     @Html.AntiForgeryToken()
                                                     <input type="hidden" name="signupId" value="@item.Signup.Id" />
                                                     <button type="submit" class="btn btn-sm btn-outline-danger"
-                                                            data-confirm="Are you sure you want to bail?">Bail</button>
+                                                            data-confirm="@Localizer["Shifts_BailConfirm"].Value">@Localizer["Shifts_Bail"]</button>
                                                 </form>
                                             </td>
                                         </tr>
@@ -128,12 +128,12 @@
         @if (Model.Pending.Count > 0)
         {
             <div class="card mb-4">
-                <div class="card-header"><h5 class="mb-0">Pending Approval</h5></div>
+                <div class="card-header"><h5 class="mb-0">@Localizer["Shifts_PendingApproval"]</h5></div>
                 <div class="card-body">
                     <div class="table-responsive">
                         <table class="table table-sm">
                             <thead>
-                                <tr><th>Department</th><th>Shift</th><th>Phase</th><th>Date</th><th>Time</th><th>Duration</th><th></th></tr>
+                                <tr><th>@Localizer["Shifts_Department"]</th><th>@Localizer["Shifts_Shift"]</th><th>@Localizer["Shifts_Phase"]</th><th>@Localizer["Shifts_Date"]</th><th>@Localizer["Shifts_Time"]</th><th>@Localizer["Shifts_Duration"]</th><th></th></tr>
                             </thead>
                             <tbody>
                                 @foreach (var item in Model.Pending)
@@ -150,7 +150,7 @@
                                             <form asp-action="Bail" method="post" class="d-inline">
                                                 @Html.AntiForgeryToken()
                                                 <input type="hidden" name="signupId" value="@item.Signup.Id" />
-                                                <button type="submit" class="btn btn-sm btn-outline-secondary">Withdraw</button>
+                                                <button type="submit" class="btn btn-sm btn-outline-secondary">@Localizer["Shifts_WithdrawButton"]</button>
                                             </form>
                                         </td>
                                     </tr>
@@ -165,12 +165,12 @@
         @if (Model.Past.Count > 0)
         {
             <div class="card mb-4">
-                <div class="card-header"><h5 class="mb-0">Past</h5></div>
+                <div class="card-header"><h5 class="mb-0">@Localizer["Shifts_Past"]</h5></div>
                 <div class="card-body">
                     <div class="table-responsive">
                         <table class="table table-sm">
                             <thead>
-                                <tr><th>Department</th><th>Shift</th><th>Phase</th><th>Date</th><th>Time</th><th>Duration</th><th>Status</th></tr>
+                                <tr><th>@Localizer["Shifts_Department"]</th><th>@Localizer["Shifts_Shift"]</th><th>@Localizer["Shifts_Phase"]</th><th>@Localizer["Shifts_Date"]</th><th>@Localizer["Shifts_Time"]</th><th>@Localizer["Shifts_Duration"]</th><th>@Localizer["Common_Status"]</th></tr>
                             </thead>
                             <tbody>
                                 @foreach (var item in Model.Past)
@@ -195,14 +195,14 @@
 
         @if (Model.Upcoming.Count == 0 && Model.Pending.Count == 0 && Model.Past.Count == 0)
         {
-            <div class="alert alert-info">No shift signups yet. <a asp-action="Index">Browse available shifts</a>.</div>
+            <div class="alert alert-info">@Localizer["Shifts_NoSignups"] <a asp-action="Index">@Localizer["Shifts_BrowseAvailable"]</a>.</div>
         }
 
         @* General Availability *@
         <div class="card mb-4">
-            <div class="card-header"><h5 class="mb-0">General Availability</h5></div>
+            <div class="card-header"><h5 class="mb-0">@Localizer["Shifts_GeneralAvailability"]</h5></div>
             <div class="card-body">
-                <p class="text-muted small">Mark which days you're available to help. Coordinators can see who's in the pool when assigning shifts.</p>
+                <p class="text-muted small">@Localizer["Shifts_AvailabilityHelp"]</p>
                 <form asp-action="SaveAvailability" method="post">
                     @Html.AntiForgeryToken()
                     <div class="row row-cols-auto g-2 mb-3">
@@ -220,7 +220,7 @@
                             </div>
                         }
                     </div>
-                    <button type="submit" class="btn btn-sm btn-primary">Save Availability</button>
+                    <button type="submit" class="btn btn-sm btn-primary">@Localizer["Shifts_SaveAvailability"]</button>
                 </form>
             </div>
         </div>

--- a/src/Humans.Web/Views/Shifts/NoActiveEvent.cshtml
+++ b/src/Humans.Web/Views/Shifts/NoActiveEvent.cshtml
@@ -1,9 +1,9 @@
 @{
-    ViewData["Title"] = "Shifts";
+    ViewData["Title"] = Localizer["Shifts_Title"].Value;
 }
 
 <div class="container py-4 text-center">
-    <h2>Shifts</h2>
-    <p class="text-muted mt-4">No active event is configured. An admin needs to set up event settings first.</p>
-    <a asp-action="Settings" class="btn btn-primary mt-2" authorize-policy="AdminOnly">Configure Event Settings <i class="fa-solid fa-lock auth-lock-icon"></i></a>
+    <h2>@Localizer["Shifts_Title"]</h2>
+    <p class="text-muted mt-4">@Localizer["Shifts_NoActiveEvent"]</p>
+    <a asp-action="Settings" class="btn btn-primary mt-2" authorize-policy="AdminOnly">@Localizer["Shifts_ConfigureEvent"] <i class="fa-solid fa-lock auth-lock-icon"></i></a>
 </div>

--- a/src/Humans.Web/Views/Unsubscribe/Done.cshtml
+++ b/src/Humans.Web/Views/Unsubscribe/Done.cshtml
@@ -1,14 +1,15 @@
 @{
-    ViewData["Title"] = "You've been unsubscribed";
+    ViewData["Title"] = Localizer["Unsub_DoneTitle"].Value;
     var categoryName = ViewData["CategoryName"] as string ?? "these";
 }
 
-<h1>You've been unsubscribed</h1>
+<h1>@Localizer["Unsub_DoneTitle"]</h1>
 
-<p>You will no longer receive @categoryName emails from Humans.</p>
+<p>@Html.Raw(string.Format(Localizer["Unsub_DoneMessage"].Value, Html.Encode(categoryName)))</p>
 
 <p>
-    <a asp-controller="Account" asp-action="Login">Sign in to manage your communication preferences</a>.
+    @Localizer["Unsub_DoneManage"]
+    <a asp-controller="Account" asp-action="Login">@Localizer["Unsub_DoneManageLink"]</a>.
 </p>
 
-<p><a asp-controller="Home" asp-action="Index">Back to home</a></p>
+<p><a asp-controller="Home" asp-action="Index">@Localizer["Unsub_BackHome"]</a></p>

--- a/src/Humans.Web/Views/Unsubscribe/Expired.cshtml
+++ b/src/Humans.Web/Views/Unsubscribe/Expired.cshtml
@@ -1,12 +1,12 @@
 @{
-    ViewData["Title"] = "Unsubscribe link expired";
+    ViewData["Title"] = Localizer["Unsub_ExpiredTitle"].Value;
 }
 
-<h1>This unsubscribe link has expired</h1>
+<h1>@Localizer["Unsub_ExpiredHeading"]</h1>
 
 <p>
-    Please use the link from a more recent email, or
-    <a asp-controller="Account" asp-action="Login">sign in to manage your communication preferences</a>.
+    @Localizer["Unsub_ExpiredMessage"]
+    <a asp-controller="Account" asp-action="Login">@Localizer["Unsub_ExpiredSignIn"]</a>.
 </p>
 
-<p><a asp-controller="Home" asp-action="Index">Back to home</a></p>
+<p><a asp-controller="Home" asp-action="Index">@Localizer["Unsub_BackHome"]</a></p>

--- a/src/Humans.Web/Views/Unsubscribe/Index.cshtml
+++ b/src/Humans.Web/Views/Unsubscribe/Index.cshtml
@@ -1,20 +1,20 @@
 @{
-    ViewData["Title"] = "Unsubscribe from Emails";
+    ViewData["Title"] = Localizer["Unsub_Title"].Value;
     var displayName = ViewData["DisplayName"] as string;
     var categoryName = ViewData["CategoryName"] as string ?? "these";
 }
 
-<h1>Unsubscribe from @categoryName emails?</h1>
+<h1>@Html.Raw(string.Format(Localizer["Unsub_Heading"].Value, Html.Encode(categoryName)))</h1>
 
 @if (!string.IsNullOrEmpty(displayName))
 {
-    <p>Hi <strong>@displayName</strong>,</p>
+    <p>@Html.Raw(string.Format(Localizer["Unsub_Greeting"].Value, "<strong>" + Html.Encode(displayName) + "</strong>"))</p>
 }
 
-<p>If you confirm, you will no longer receive @categoryName emails from Humans.</p>
+<p>@Html.Raw(string.Format(Localizer["Unsub_ConfirmMessage"].Value, Html.Encode(categoryName)))</p>
 
 <form method="post">
     @Html.AntiForgeryToken()
-    <button type="submit" class="btn btn-danger">Confirm Unsubscribe</button>
-    <a asp-controller="Home" asp-action="Index" class="btn btn-secondary ms-2">Cancel</a>
+    <button type="submit" class="btn btn-danger">@Localizer["Unsub_ConfirmButton"]</button>
+    <a asp-controller="Home" asp-action="Index" class="btn btn-secondary ms-2">@Localizer["Common_Cancel"]</a>
 </form>


### PR DESCRIPTION
## Summary
- Localize 17 user-facing views: Feedback (2), Unsubscribe (3), Profile/CommunicationPreferences, Profile/Emails, Profile/ShiftInfo, Shifts (4), ShiftDashboard, Guest/CommunicationPreferences, Home/Privacy, and 5 Shared partials (_LoginPartial, _ProfileCard, _ShiftsSummaryCard, _VolunteerProfileBadges)
- Add 234 new localization keys to SharedResource.resx with translations in all 5 locales (es, de, fr, it, ca)
- Translate 37 previously-untranslated `Notification_*` keys across all locale files
- Add missing Catalan `AdminAddRole_CampAdminDesc` key
- All views use `@Localizer["Key"]` pattern consistent with existing localized views
- Build passes with zero warnings/errors, format check clean

## Views localized
| Area | Views | Notes |
|------|-------|-------|
| Feedback | Index, _Detail | Filter labels, messages, conversation UI |
| Unsubscribe | Index, Done, Expired | Full flow including dynamic category names |
| Profile | CommunicationPreferences, Emails, ShiftInfo | Wizard steps, table headers, Google email section |
| Shifts | Index, Mine, BrowsingClosed, NoActiveEvent | Period names, badges, signup statuses, availability |
| ShiftDashboard | Index | Filter bar, table headers, voluntell search |
| Guest | CommunicationPreferences | Breadcrumbs, table headers |
| Home | Privacy | Full privacy policy text (~50 keys) |
| Shared | _LoginPartial, _ProfileCard, _ShiftsSummaryCard, _VolunteerProfileBadges | Nav items, badges, summary text |

## Test plan
- [ ] Switch language to each locale (es, de, fr, it, ca) and verify translated text appears on all localized views
- [ ] Verify Feedback views render correctly with filter labels translated
- [ ] Verify Unsubscribe flow works with dynamic category name interpolation
- [ ] Verify ShiftInfo wizard step labels update when navigating steps
- [ ] Verify Shifts browse page badges and period names display correctly
- [ ] Verify Privacy page renders complete translated content
- [ ] Verify notification popup/inbox shows translated text

🤖 Generated with [Claude Code](https://claude.com/claude-code)