### PR TITLE
Bug hunt: fix colspan mismatches, icon prefixes, and terminology

### DIFF
--- a/src/Humans.Web/Views/Admin/EditLegalDocument.cshtml
+++ b/src/Humans.Web/Views/Admin/EditLegalDocument.cshtml
@@ -93,7 +93,7 @@
                                 <strong>@version.VersionNumber</strong>
                                 @if (version.RequiresReConsent)
                                 {
-                                    <span class="badge bg-warning ms-1" title="Members must re-consent">Re-consent</span>
+                                    <span class="badge bg-warning ms-1" title="Humans must re-consent">Re-consent</span>
                                 }
                             </td>
                             <td>

--- a/src/Humans.Web/Views/Camp/Edit.cshtml
+++ b/src/Humans.Web/Views/Camp/Edit.cshtml
@@ -134,7 +134,7 @@
                 <div class="card-body">
                     <div class="row g-3">
                         <div class="col-md-4">
-                            <label asp-for="AcceptingMembers" class="form-label">Accepting New Members?</label>
+                            <label asp-for="AcceptingMembers" class="form-label">Accepting New Humans?</label>
                             <select asp-for="AcceptingMembers" class="form-select"
                                     asp-items="@(new SelectList(Enum.GetValues<YesNoMaybe>()))"></select>
                         </div>
@@ -163,7 +163,7 @@
                                     asp-items="@(new SelectList(Enum.GetValues<AdultPlayspacePolicy>()))"></select>
                         </div>
                         <div class="col-md-4">
-                            <label asp-for="MemberCount" class="form-label">Expected Members</label>
+                            <label asp-for="MemberCount" class="form-label">Expected Humans</label>
                             <input asp-for="MemberCount" class="form-control" type="number" min="1" />
                         </div>
                     </div>

--- a/src/Humans.Web/Views/Camp/Register.cshtml
+++ b/src/Humans.Web/Views/Camp/Register.cshtml
@@ -113,7 +113,7 @@
         <div class="card-body">
             <div class="row g-3">
                 <div class="col-md-4">
-                    <label asp-for="AcceptingMembers" class="form-label">Accepting New Members?</label>
+                    <label asp-for="AcceptingMembers" class="form-label">Accepting New Humans?</label>
                     <select asp-for="AcceptingMembers" class="form-select"
                             asp-items="@(new SelectList(Enum.GetValues<YesNoMaybe>()))"></select>
                 </div>
@@ -143,7 +143,7 @@
                             asp-items="@(new SelectList(Enum.GetValues<AdultPlayspacePolicy>()))"></select>
                 </div>
                 <div class="col-md-4">
-                    <label asp-for="MemberCount" class="form-label">Expected Members</label>
+                    <label asp-for="MemberCount" class="form-label">Expected Humans</label>
                     <input asp-for="MemberCount" class="form-control" type="number" min="1" />
                 </div>
             </div>

--- a/src/Humans.Web/Views/CityPlanning/Admin.cshtml
+++ b/src/Humans.Web/Views/CityPlanning/Admin.cshtml
@@ -7,7 +7,7 @@
     <div class="d-flex align-items-center gap-3 mb-4">
         <h1 class="mb-0">@Localizer["CityPlanning_Admin_Title"]</h1>
         <a href="/CityPlanning" class="btn btn-outline-secondary btn-sm">
-            <i class="fa fa-map"></i> @Localizer["CityPlanning_Admin_ViewMap"]
+            <i class="fa-solid fa-map"></i> @Localizer["CityPlanning_Admin_ViewMap"]
         </a>
     </div>
 
@@ -16,7 +16,7 @@
         <div class="col-md-6">
             <div class="card">
                 <div class="card-header fw-semibold">
-                    <i class="fa fa-door-open me-1"></i> @Localizer["CityPlanning_Admin_PlacementPhaseCard"] (@settings.Year)
+                    <i class="fa-solid fa-door-open me-1"></i> @Localizer["CityPlanning_Admin_PlacementPhaseCard"] (@settings.Year)
                 </div>
                 <div class="card-body">
                     <p class="mb-3">
@@ -43,7 +43,7 @@
                         <form method="post" action="/CityPlanning/Admin/ClosePlacement">
                             @Html.AntiForgeryToken()
                             <button type="submit" class="btn btn-warning">
-                                <i class="fa fa-lock me-1"></i> @Localizer["CityPlanning_Admin_ClosePlacement"]
+                                <i class="fa-solid fa-lock me-1"></i> @Localizer["CityPlanning_Admin_ClosePlacement"]
                             </button>
                         </form>
                     }
@@ -52,7 +52,7 @@
                         <form method="post" action="/CityPlanning/Admin/OpenPlacement">
                             @Html.AntiForgeryToken()
                             <button type="submit" class="btn btn-success">
-                                <i class="fa fa-lock-open me-1"></i> @Localizer["CityPlanning_Admin_OpenPlacement"]
+                                <i class="fa-solid fa-lock-open me-1"></i> @Localizer["CityPlanning_Admin_OpenPlacement"]
                             </button>
                         </form>
                     }
@@ -64,7 +64,7 @@
         <div class="col-md-6">
             <div class="card">
                 <div class="card-header fw-semibold">
-                    <i class="fa fa-calendar me-1"></i> @Localizer["CityPlanning_Admin_PlacementDatesCard"] (@settings.Year)
+                    <i class="fa-solid fa-calendar me-1"></i> @Localizer["CityPlanning_Admin_PlacementDatesCard"] (@settings.Year)
                 </div>
                 <div class="card-body">
                     <p class="text-muted small mb-3">@Localizer["CityPlanning_Admin_PlacementDatesHint"]</p>
@@ -81,7 +81,7 @@
                                    value="@(settings.PlacementClosesAt?.ToString("yyyy-MM-ddTHH:mm", null) ?? string.Empty)" />
                         </div>
                         <button type="submit" class="btn btn-primary btn-sm">
-                            <i class="fa fa-save me-1"></i> @Localizer["CityPlanning_Admin_SaveDates"]
+                            <i class="fa-solid fa-save me-1"></i> @Localizer["CityPlanning_Admin_SaveDates"]
                         </button>
                     </form>
                 </div>
@@ -92,21 +92,21 @@
         <div class="col-md-6">
             <div class="card">
                 <div class="card-header fw-semibold">
-                    <i class="fa fa-draw-polygon me-1"></i> @Localizer["CityPlanning_Admin_LimitZoneCard"] (@settings.Year)
+                    <i class="fa-solid fa-draw-polygon me-1"></i> @Localizer["CityPlanning_Admin_LimitZoneCard"] (@settings.Year)
                 </div>
                 <div class="card-body">
                     @if (settings.LimitZoneGeoJson != null)
                     {
-                        <p class="text-success mb-3"><i class="fa fa-check-circle me-1"></i> @Localizer["CityPlanning_Admin_LimitZoneUploaded"]</p>
+                        <p class="text-success mb-3"><i class="fa-solid fa-check-circle me-1"></i> @Localizer["CityPlanning_Admin_LimitZoneUploaded"]</p>
                         <div class="d-flex gap-2">
                             <a href="/CityPlanning/Admin/DownloadLimitZone" class="btn btn-outline-secondary btn-sm" download="limit-zone-@(settings.Year).geojson">
-                                <i class="fa fa-download me-1"></i> @Localizer["CityPlanning_Admin_Download"]
+                                <i class="fa-solid fa-download me-1"></i> @Localizer["CityPlanning_Admin_Download"]
                             </a>
                             <form method="post" action="/CityPlanning/Admin/DeleteLimitZone" class="d-inline">
                                 @Html.AntiForgeryToken()
                                 <button type="submit" class="btn btn-outline-danger btn-sm"
                                         data-confirm="@Localizer["CityPlanning_Admin_LimitZoneDeleteConfirm"]">
-                                    <i class="fa fa-trash me-1"></i> @Localizer["CityPlanning_Admin_Remove"]
+                                    <i class="fa-solid fa-trash me-1"></i> @Localizer["CityPlanning_Admin_Remove"]
                                 </button>
                             </form>
                         </div>
@@ -122,7 +122,7 @@
                             <input type="file" name="file" accept=".geojson,.json" class="form-control form-control-sm" required />
                         </div>
                         <button type="submit" class="btn btn-primary btn-sm">
-                            <i class="fa fa-upload me-1"></i> @Localizer["CityPlanning_Admin_Upload"]
+                            <i class="fa-solid fa-upload me-1"></i> @Localizer["CityPlanning_Admin_Upload"]
                         </button>
                     </form>
                 </div>
@@ -133,21 +133,21 @@
         <div class="col-md-6">
             <div class="card">
                 <div class="card-header fw-semibold">
-                    <i class="fa fa-layer-group me-1"></i> @Localizer["CityPlanning_Admin_OfficialZonesCard"] (@settings.Year)
+                    <i class="fa-solid fa-layer-group me-1"></i> @Localizer["CityPlanning_Admin_OfficialZonesCard"] (@settings.Year)
                 </div>
                 <div class="card-body">
                     @if (settings.OfficialZonesGeoJson != null)
                     {
-                        <p class="text-success mb-3"><i class="fa fa-check-circle me-1"></i> @Localizer["CityPlanning_Admin_OfficialZonesUploaded"]</p>
+                        <p class="text-success mb-3"><i class="fa-solid fa-check-circle me-1"></i> @Localizer["CityPlanning_Admin_OfficialZonesUploaded"]</p>
                         <div class="d-flex gap-2">
                             <a href="/CityPlanning/Admin/DownloadOfficialZones" class="btn btn-outline-secondary btn-sm" download="official-zones-@(settings.Year).geojson">
-                                <i class="fa fa-download me-1"></i> @Localizer["CityPlanning_Admin_Download"]
+                                <i class="fa-solid fa-download me-1"></i> @Localizer["CityPlanning_Admin_Download"]
                             </a>
                             <form method="post" action="/CityPlanning/Admin/DeleteOfficialZones" class="d-inline">
                                 @Html.AntiForgeryToken()
                                 <button type="submit" class="btn btn-outline-danger btn-sm"
                                         data-confirm="@Localizer["CityPlanning_Admin_OfficialZonesDeleteConfirm"]">
-                                    <i class="fa fa-trash me-1"></i> @Localizer["CityPlanning_Admin_Remove"]
+                                    <i class="fa-solid fa-trash me-1"></i> @Localizer["CityPlanning_Admin_Remove"]
                                 </button>
                             </form>
                         </div>
@@ -163,7 +163,7 @@
                             <input type="file" name="file" accept=".geojson,.json" class="form-control form-control-sm" required />
                         </div>
                         <button type="submit" class="btn btn-primary btn-sm">
-                            <i class="fa fa-upload me-1"></i> @Localizer["CityPlanning_Admin_Upload"]
+                            <i class="fa-solid fa-upload me-1"></i> @Localizer["CityPlanning_Admin_Upload"]
                         </button>
                     </form>
                 </div>
@@ -174,12 +174,12 @@
         <div class="col-12">
             <div class="card">
                 <div class="card-header fw-semibold">
-                    <i class="fa fa-file-export me-1"></i> @Localizer["CityPlanning_Admin_ExportCard"]
+                    <i class="fa-solid fa-file-export me-1"></i> @Localizer["CityPlanning_Admin_ExportCard"]
                 </div>
                 <div class="card-body">
                     <p class="mb-2">@string.Format(Localizer["CityPlanning_Admin_ExportDescription"].Value, settings.Year)</p>
                     <a href="/api/city-planning/export.geojson?year=@settings.Year" class="btn btn-outline-secondary btn-sm" download="city-planning-@(settings.Year).geojson">
-                        <i class="fa fa-download me-1"></i> @string.Format(Localizer["CityPlanning_Admin_DownloadGeoJson"].Value, settings.Year)
+                        <i class="fa-solid fa-download me-1"></i> @string.Format(Localizer["CityPlanning_Admin_DownloadGeoJson"].Value, settings.Year)
                     </a>
                 </div>
             </div>

--- a/src/Humans.Web/Views/CityPlanning/Index.cshtml
+++ b/src/Humans.Web/Views/CityPlanning/Index.cshtml
@@ -58,7 +58,7 @@
                     }
                 </div>
                 <button class="btn btn-primary btn-sm small" data-bs-toggle="modal" data-bs-target="#placement-help-modal">
-                    <i class="fa fa-question-circle me-1"></i>@Localizer["CityPlanning_HelpButton"]
+                    <i class="fa-solid fa-question-circle me-1"></i>@Localizer["CityPlanning_HelpButton"]
                 </button>
             </div>
         </div>
@@ -74,7 +74,7 @@
             @if (isPlacementOpen && !string.IsNullOrEmpty(userCampSeasonId))
             {
                 <button id="add-my-barrio-btn" class="btn btn-primary btn-sm shadow" style="display:none">
-                    <i class="fa fa-plus me-1"></i> @Localizer["CityPlanning_AddMyBarrioButton"]
+                    <i class="fa-solid fa-plus me-1"></i> @Localizer["CityPlanning_AddMyBarrioButton"]
                 </button>
             }
             @if (isMapAdmin && seasonsWithout.Any())
@@ -90,13 +90,13 @@
                 </div>
             }
             <button id="save-btn" class="btn btn-success btn-sm" style="display:none" disabled>
-                <i class="fa fa-save me-1"></i> @Localizer["CityPlanning_SaveButton"]
+                <i class="fa-solid fa-save me-1"></i> @Localizer["CityPlanning_SaveButton"]
             </button>
             <button id="cancel-btn" class="btn btn-outline-secondary btn-sm" style="display:none">
-                <i class="fa fa-times me-1"></i> @Localizer["Common_Cancel"]
+                <i class="fa-solid fa-times me-1"></i> @Localizer["Common_Cancel"]
             </button>
             <button id="history-btn" class="btn btn-outline-primary btn-sm" style="display:none" disabled>
-                <i class="fa fa-history me-1"></i> @Localizer["CityPlanning_HistoryButton"]
+                <i class="fa-solid fa-history me-1"></i> @Localizer["CityPlanning_HistoryButton"]
             </button>
             </div>
         </div>
@@ -106,7 +106,7 @@
         <div class="card">
             <div class="card-body">
                 <a href="/CityPlanning/Admin" class="btn btn-outline-primary btn-sm">
-                    <i class="fa fa-cog me-1"></i> @Localizer["CityPlanning_AdminLink"]
+                    <i class="fa-solid fa-cog me-1"></i> @Localizer["CityPlanning_AdminLink"]
                 </a>
             </div>
         </div>

--- a/src/Humans.Web/Views/Shifts/Index.cshtml
+++ b/src/Humans.Web/Views/Shifts/Index.cshtml
@@ -552,7 +552,7 @@
                                             @if (!string.IsNullOrEmpty(shift.Description))
                                             {
                                                 <tr class="@(isFull ? "table-secondary" : "")">
-                                                    <td colspan="8" class="text-muted small pt-0 pb-1 border-0">
+                                                    <td colspan="@(Model.ShowSignups ? 8 : 7)" class="text-muted small pt-0 pb-1 border-0">
                                                         @Html.SanitizedMarkdown(shift.Description)
                                                     </td>
                                                 </tr>

--- a/src/Humans.Web/Views/Team/Roster.cshtml
+++ b/src/Humans.Web/Views/Team/Roster.cshtml
@@ -112,7 +112,7 @@ else
                 @if (isFirstSlotForRole)
                 {
                     <tr class="collapse" id="@collapseId">
-                        <td colspan="5">
+                        <td colspan="6">
                             <div class="role-description small text-muted">
                                 @Html.SanitizedMarkdown(slot.RoleDescription)
                             </div>

--- a/src/Humans.Web/Views/Ticket/Orders.cshtml
+++ b/src/Humans.Web/Views/Ticket/Orders.cshtml
@@ -146,7 +146,7 @@
                 }
                 @if (Model.Orders.Count == 0)
                 {
-                    <tr><td colspan="15" class="text-muted text-center">No orders found</td></tr>
+                    <tr><td colspan="14" class="text-muted text-center">No orders found</td></tr>
                 }
             </tbody>
         </table>


### PR DESCRIPTION
## Summary
- Fix colspan mismatch in timed shifts table when ShowSignups is false (8→dynamic)
- Fix UI terminology: "members" → "humans" in camp registration/edit forms and legal doc editor
- Fix 24 Font Awesome icon references in City Planning views from legacy `fa fa-*` to `fa-solid fa-*`
- Fix colspan mismatch in ticket orders empty-state row (15→14)
- Fix colspan mismatch in team roster description row (5→6)

All 874 tests passing, zero build warnings.

## Test plan
- [ ] Shifts page: verify description row spans full width with and without signup column
- [ ] Camp register/edit: verify "humans" terminology, no "members"
- [ ] City Planning: verify all icons render (fa-solid prefix)
- [ ] Ticket orders: verify "no orders" row spans correctly
- [ ] Team roster: verify role description row spans correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)