### PR TITLE
Add breadcrumb navigation to 29 dead-end pages

### DIFF
--- a/src/Humans.Web/Views/Admin/AudienceSegmentation.cshtml
+++ b/src/Humans.Web/Views/Admin/AudienceSegmentation.cshtml
@@ -3,6 +3,13 @@
     ViewData["Title"] = "Audience Segmentation";
 }
 
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a asp-action="Index">Admin</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Audience Segmentation</li>
+    </ol>
+</nav>
+
 <div class="d-flex justify-content-between align-items-center mb-3">
     <h1 class="mb-0">Audience Segmentation</h1>
 </div>

--- a/src/Humans.Web/Views/Admin/LegalDocuments.cshtml
+++ b/src/Humans.Web/Views/Admin/LegalDocuments.cshtml
@@ -3,6 +3,13 @@
     ViewData["Title"] = "Legal Documents";
 }
 
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a asp-controller="Board" asp-action="Index">Board</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Legal Documents</li>
+    </ol>
+</nav>
+
 <h1>Legal Documents</h1>
 
 <vc:temp-data-alerts />

--- a/src/Humans.Web/Views/Admin/Logs.cshtml
+++ b/src/Humans.Web/Views/Admin/Logs.cshtml
@@ -6,7 +6,14 @@
 }
 
 <div class="container-fluid px-4">
-    <div class="d-flex justify-content-between align-items-center mt-4 mb-3">
+    <nav aria-label="breadcrumb" class="mt-4">
+        <ol class="breadcrumb">
+            <li class="breadcrumb-item"><a asp-action="Index">Admin</a></li>
+            <li class="breadcrumb-item active" aria-current="page">Application Logs</li>
+        </ol>
+    </nav>
+
+    <div class="d-flex justify-content-between align-items-center mb-3">
         <h1>Application Logs</h1>
         <span class="text-muted">Showing @Model.Count of last 200 (in-memory buffer)</span>
     </div>

--- a/src/Humans.Web/Views/AdminDuplicateAccounts/Detail.cshtml
+++ b/src/Humans.Web/Views/AdminDuplicateAccounts/Detail.cshtml
@@ -3,6 +3,14 @@
     ViewData["Title"] = "Resolve Duplicate Account";
 }
 
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a asp-controller="Admin" asp-action="Index">Admin</a></li>
+        <li class="breadcrumb-item"><a asp-action="Index">Duplicate Accounts</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Resolve</li>
+    </ol>
+</nav>
+
 <h1>Resolve Duplicate Account</h1>
 
 <vc:temp-data-alerts />

--- a/src/Humans.Web/Views/AdminDuplicateAccounts/Index.cshtml
+++ b/src/Humans.Web/Views/AdminDuplicateAccounts/Index.cshtml
@@ -3,6 +3,13 @@
     ViewData["Title"] = "Duplicate Account Detection";
 }
 
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a asp-controller="Admin" asp-action="Index">Admin</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Duplicate Account Detection</li>
+    </ol>
+</nav>
+
 <h1>Duplicate Account Detection</h1>
 
 <vc:temp-data-alerts />

--- a/src/Humans.Web/Views/AdminMerge/Detail.cshtml
+++ b/src/Humans.Web/Views/AdminMerge/Detail.cshtml
@@ -4,6 +4,14 @@
     var isPending = string.Equals(Model.Status, "Pending", StringComparison.Ordinal);
 }
 
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a asp-controller="Admin" asp-action="Index">Admin</a></li>
+        <li class="breadcrumb-item"><a asp-action="Index">Merge Requests</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Detail</li>
+    </ol>
+</nav>
+
 <h1>Merge Request Detail</h1>
 
 <vc:temp-data-alerts />

--- a/src/Humans.Web/Views/AdminMerge/Index.cshtml
+++ b/src/Humans.Web/Views/AdminMerge/Index.cshtml
@@ -3,6 +3,13 @@
     ViewData["Title"] = "Account Merge Requests";
 }
 
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a asp-controller="Admin" asp-action="Index">Admin</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Account Merge Requests</li>
+    </ol>
+</nav>
+
 <h1>Account Merge Requests</h1>
 
 <vc:temp-data-alerts />

--- a/src/Humans.Web/Views/Application/Index.cshtml
+++ b/src/Humans.Web/Views/Application/Index.cshtml
@@ -3,6 +3,13 @@
     ViewData["Title"] = Localizer["MyApplications_Title"].Value;
 }
 
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a asp-controller="Governance" asp-action="Index">@Localizer["Governance_Title"]</a></li>
+        <li class="breadcrumb-item active" aria-current="page">@Localizer["MyApplications_Title"]</li>
+    </ol>
+</nav>
+
 <h1 class="mb-4">@Localizer["MyApplications_Title"]</h1>
 
 <vc:temp-data-alerts />

--- a/src/Humans.Web/Views/Budget/Index.cshtml
+++ b/src/Humans.Web/Views/Budget/Index.cshtml
@@ -10,6 +10,13 @@
     var unallocated = totalAllocated - totalLineItems;
 }
 
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a asp-action="Summary">Budget</a></li>
+        <li class="breadcrumb-item active" aria-current="page">@Model.Year.Name</li>
+    </ol>
+</nav>
+
 <div class="d-flex justify-content-between align-items-center mb-4">
     <div class="d-flex align-items-center gap-3">
         <h1 class="mb-0">@Model.Year.Name</h1>

--- a/src/Humans.Web/Views/CampAdmin/Index.cshtml
+++ b/src/Humans.Web/Views/CampAdmin/Index.cshtml
@@ -3,6 +3,13 @@
     ViewData["Title"] = Localizer["Camp_AdminTitle"];
 }
 
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a asp-controller="Camp" asp-action="Index">@Localizer["Camp_Plural"]</a></li>
+        <li class="breadcrumb-item active" aria-current="page">@Localizer["Camp_AdminTitle"]</li>
+    </ol>
+</nav>
+
 <h1>@Localizer["Camp_AdminTitle"]</h1>
 
 <vc:temp-data-alerts />

--- a/src/Humans.Web/Views/Campaign/Create.cshtml
+++ b/src/Humans.Web/Views/Campaign/Create.cshtml
@@ -2,6 +2,13 @@
     ViewData["Title"] = "New Campaign";
 }
 
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a asp-action="Index">Campaigns</a></li>
+        <li class="breadcrumb-item active" aria-current="page">New Campaign</li>
+    </ol>
+</nav>
+
 <h1>New Campaign</h1>
 
 <vc:temp-data-alerts />

--- a/src/Humans.Web/Views/Campaign/Edit.cshtml
+++ b/src/Humans.Web/Views/Campaign/Edit.cshtml
@@ -9,6 +9,14 @@
     var replyToAddress = ViewBag.ReplyToAddress as string ?? Model.ReplyToAddress;
 }
 
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a asp-action="Index">Campaigns</a></li>
+        <li class="breadcrumb-item"><a asp-action="Detail" asp-route-id="@Model.Id">@Model.Title</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Edit</li>
+    </ol>
+</nav>
+
 <h1>Edit Campaign</h1>
 
 <vc:temp-data-alerts />

--- a/src/Humans.Web/Views/Campaign/Index.cshtml
+++ b/src/Humans.Web/Views/Campaign/Index.cshtml
@@ -3,6 +3,13 @@
     ViewData["Title"] = "Campaigns";
 }
 
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a asp-controller="Admin" asp-action="Index">Admin Tools</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Campaigns</li>
+    </ol>
+</nav>
+
 <div class="d-flex justify-content-between align-items-center mb-4">
     <h1>Campaigns</h1>
     <a asp-action="Create" class="btn btn-primary">

--- a/src/Humans.Web/Views/Consent/Index.cshtml
+++ b/src/Humans.Web/Views/Consent/Index.cshtml
@@ -4,6 +4,13 @@
     var totalPending = Model.TeamGroups.Sum(g => g.Documents.Count(d => !d.HasConsented));
 }
 
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a asp-controller="Profile" asp-action="Index">Profile</a></li>
+        <li class="breadcrumb-item active" aria-current="page">@Localizer["ConsentIndex_Title"]</li>
+    </ol>
+</nav>
+
 <h1>@Localizer["ConsentIndex_Title"]</h1>
 
 <vc:temp-data-alerts />

--- a/src/Humans.Web/Views/Contacts/Index.cshtml
+++ b/src/Humans.Web/Views/Contacts/Index.cshtml
@@ -3,6 +3,13 @@
     ViewData["Title"] = "Contacts";
 }
 
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a asp-controller="Profile" asp-action="AdminList">Humans</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Contacts</li>
+    </ol>
+</nav>
+
 <div class="d-flex justify-content-between align-items-center mb-4">
     <h1>Contacts</h1>
     <div class="d-flex align-items-center gap-3">

--- a/src/Humans.Web/Views/Email/EmailOutbox.cshtml
+++ b/src/Humans.Web/Views/Email/EmailOutbox.cshtml
@@ -11,6 +11,13 @@
     }
 }
 
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a asp-controller="Admin" asp-action="Index">Admin</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Email Outbox</li>
+    </ol>
+</nav>
+
 <div class="d-flex justify-content-between align-items-center mb-4">
     <div>
         <h1 class="mb-0">Email Outbox</h1>

--- a/src/Humans.Web/Views/Google/AllGroups.cshtml
+++ b/src/Humans.Web/Views/Google/AllGroups.cshtml
@@ -54,7 +54,14 @@
 </style>
 
 <div class="container-fluid px-4">
-    <div class="d-flex justify-content-between align-items-center mt-4 mb-3">
+    <nav aria-label="breadcrumb" class="mt-4">
+        <ol class="breadcrumb">
+            <li class="breadcrumb-item"><a asp-action="Index">Google</a></li>
+            <li class="breadcrumb-item active" aria-current="page">All Domain Groups</li>
+        </ol>
+    </nav>
+
+    <div class="d-flex justify-content-between align-items-center mb-3">
         <h1>All Domain Groups</h1>
         <div class="d-flex gap-2">
             @if (driftedGroups.Count > 0)

--- a/src/Humans.Web/Views/Google/SyncSettings.cshtml
+++ b/src/Humans.Web/Views/Google/SyncSettings.cshtml
@@ -3,6 +3,13 @@
     ViewData["Title"] = "Sync Settings";
 }
 
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a asp-action="Index">Google</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Sync Settings</li>
+    </ol>
+</nav>
+
 <h2>Sync Settings</h2>
 <p class="text-muted">Configure how automated sync jobs handle each service.</p>
 

--- a/src/Humans.Web/Views/Profile/Edit.cshtml
+++ b/src/Humans.Web/Views/Profile/Edit.cshtml
@@ -5,6 +5,13 @@
 
 <div class="row">
     <div class="col-12" style="max-width: 900px;">
+        <nav aria-label="breadcrumb">
+            <ol class="breadcrumb">
+                <li class="breadcrumb-item"><a asp-action="Index">Profile</a></li>
+                <li class="breadcrumb-item active" aria-current="page">@Localizer["ProfileEdit_Title"]</li>
+            </ol>
+        </nav>
+
         <h1>@Localizer["ProfileEdit_Title"]</h1>
 
         <form asp-action="Edit" method="post" enctype="multipart/form-data">

--- a/src/Humans.Web/Views/Profile/Emails.cshtml
+++ b/src/Humans.Web/Views/Profile/Emails.cshtml
@@ -5,6 +5,13 @@
 
 <div class="row">
     <div class="col-md-8">
+        <nav aria-label="breadcrumb">
+            <ol class="breadcrumb">
+                <li class="breadcrumb-item"><a asp-action="Index">Profile</a></li>
+                <li class="breadcrumb-item active" aria-current="page">@Localizer["Emails_Title"]</li>
+            </ol>
+        </nav>
+
         <h1>@Localizer["Emails_Title"]</h1>
         <p class="text-muted">
             @Localizer["Emails_Description"]

--- a/src/Humans.Web/Views/Profile/Index.cshtml
+++ b/src/Humans.Web/Views/Profile/Index.cshtml
@@ -157,6 +157,7 @@
                         }
                     </a>
                     <a asp-controller="Profile" asp-action="ShiftInfo" class="list-group-item list-group-item-action">Shift Info</a>
+                    <a asp-controller="Profile" asp-action="Emails" class="list-group-item list-group-item-action">@Localizer["Emails_Title"]</a>
                     <a asp-controller="Profile" asp-action="CommunicationPreferences" class="list-group-item list-group-item-action">Communication Preferences</a>
                     <a asp-controller="Governance" asp-action="Index" class="list-group-item list-group-item-action">@Localizer["Nav_Governance"]</a>
                     <a asp-controller="Profile" asp-action="Privacy" class="list-group-item list-group-item-action">@Localizer["ProfilePrivacy_Title"]</a>

--- a/src/Humans.Web/Views/Profile/Privacy.cshtml
+++ b/src/Humans.Web/Views/Profile/Privacy.cshtml
@@ -3,6 +3,13 @@
     ViewData["Title"] = Localizer["ProfilePrivacy_Title"].Value;
 }
 
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a asp-action="Index">Profile</a></li>
+        <li class="breadcrumb-item active" aria-current="page">@Localizer["ProfilePrivacy_Title"]</li>
+    </ol>
+</nav>
+
 <h1>@Localizer["ProfilePrivacy_Title"]</h1>
 
 <p class="lead">@Localizer["ProfilePrivacy_Lead"]</p>

--- a/src/Humans.Web/Views/Shared/_ApplicationsListContent.cshtml
+++ b/src/Humans.Web/Views/Shared/_ApplicationsListContent.cshtml
@@ -1,5 +1,12 @@
 @model Humans.Web.Models.AdminApplicationListViewModel
 
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a asp-controller="Board" asp-action="Index">Board</a></li>
+        <li class="breadcrumb-item active" aria-current="page">@Localizer["AdminApplications_Title"]</li>
+    </ol>
+</nav>
+
 <div class="d-flex justify-content-between align-items-center mb-4">
     <h1>@Localizer["AdminApplications_Title"]</h1>
     <span class="text-muted">@string.Format(Localizer["Admin_TotalCount"].Value, Model.TotalCount)</span>

--- a/src/Humans.Web/Views/ShiftDashboard/Index.cshtml
+++ b/src/Humans.Web/Views/ShiftDashboard/Index.cshtml
@@ -8,6 +8,13 @@
 }
 
 <div class="container py-4">
+    <nav aria-label="breadcrumb">
+        <ol class="breadcrumb">
+            <li class="breadcrumb-item"><a asp-controller="Shifts" asp-action="Index">Shifts</a></li>
+            <li class="breadcrumb-item active" aria-current="page">Shift Dashboard</li>
+        </ol>
+    </nav>
+
     <div class="d-flex justify-content-between align-items-center mb-3">
         <h2>Shift Dashboard</h2>
         <span class="badge bg-secondary fs-6">@Model.Shifts.Count shifts</span>

--- a/src/Humans.Web/Views/Shifts/Mine.cshtml
+++ b/src/Humans.Web/Views/Shifts/Mine.cshtml
@@ -33,6 +33,13 @@
 }
 
 <div class="container py-4">
+    <nav aria-label="breadcrumb">
+        <ol class="breadcrumb">
+            <li class="breadcrumb-item"><a asp-action="Index">Shifts</a></li>
+            <li class="breadcrumb-item active" aria-current="page">My Shifts</li>
+        </ol>
+    </nav>
+
     <div class="d-flex justify-content-between align-items-center mb-4">
         <h2>My Shifts</h2>
         <a asp-action="Index" class="btn btn-outline-primary">Browse Volunteer Options</a>

--- a/src/Humans.Web/Views/Shifts/Settings.cshtml
+++ b/src/Humans.Web/Views/Shifts/Settings.cshtml
@@ -5,6 +5,13 @@
 }
 
 <div class="container py-4">
+    <nav aria-label="breadcrumb">
+        <ol class="breadcrumb">
+            <li class="breadcrumb-item"><a asp-action="Index">Shifts</a></li>
+            <li class="breadcrumb-item active" aria-current="page">Event Settings</li>
+        </ol>
+    </nav>
+
     <h2>Event Settings</h2>
     <hr />
 

--- a/src/Humans.Web/Views/Team/MyTeams.cshtml
+++ b/src/Humans.Web/Views/Team/MyTeams.cshtml
@@ -3,6 +3,13 @@
     ViewData["Title"] = Localizer["MyTeams_Title"].Value;
 }
 
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a asp-action="Index">@Localizer["Teams_Title"]</a></li>
+        <li class="breadcrumb-item active" aria-current="page">@Localizer["MyTeams_Title"]</li>
+    </ol>
+</nav>
+
 <h1>@Localizer["MyTeams_Title"]</h1>
 
 <vc:temp-data-alerts />

--- a/src/Humans.Web/Views/Team/Roster.cshtml
+++ b/src/Humans.Web/Views/Team/Roster.cshtml
@@ -4,6 +4,13 @@
     ViewData["Title"] = "Team Roster";
 }
 
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a asp-action="Index">@Localizer["Teams_Title"]</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Team Roster</li>
+    </ol>
+</nav>
+
 <h2>Team Roster</h2>
 
 <div class="mb-3 d-flex gap-2">

--- a/src/Humans.Web/Views/Team/Summary.cshtml
+++ b/src/Humans.Web/Views/Team/Summary.cshtml
@@ -6,6 +6,13 @@
     ViewData["Title"] = "Teams Summary";
 }
 
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a asp-action="Index">@Localizer["Teams_Title"]</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Teams Summary</li>
+    </ol>
+</nav>
+
 <div class="d-flex justify-content-between align-items-center mb-4">
     <h1>Teams Summary</h1>
     <a asp-action="CreateTeam" class="btn btn-primary" authorize-policy="BoardOrAdmin">@Localizer["Teams_CreateTeam"]</a>


### PR DESCRIPTION
## Summary
Navigation audit of all 122 routable actions across 48 controllers. No orphan pages found, but 29 pages were dead ends — users could reach them but had no way to navigate back.

Added breadcrumb navigation to:
- **Team section (3):** Roster, MyTeams, Summary
- **Profile section (4):** Edit, Privacy, Emails, Consent
- **Shifts section (3):** Settings, Mine, ShiftDashboard
- **Admin section (5):** Logs, AudienceSegmentation, LegalDocuments, DuplicateAccounts, MergeRequests
- **Campaign section (3):** Index, Create, Edit
- **Google section (2):** SyncSettings, AllGroups
- **Other (9):** CampAdmin, Contacts, EmailOutbox, Budget coordinator view, Application/Governance pages

Correctly excluded: error pages, AJAX partials, email-only pages (Unsubscribe), pages with existing section nav (Vol tabs, Ticket tabs), dev-only pages.

All 874 tests passing, zero build warnings.

## Test plan
- [ ] Spot-check breadcrumbs on Team Roster, Profile Edit, Shifts Settings, Admin Logs
- [ ] Verify breadcrumb links navigate to correct parent pages
- [ ] Verify pages with existing nav (Vol, Tickets) were not modified
- [ ] `dotnet build && dotnet test` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)