### PR TITLE
Fix silent exception swallowing and Drive permission email normalization

### DIFF
--- a/src/Humans.Infrastructure/Services/GoogleWorkspaceSyncService.cs
+++ b/src/Humans.Infrastructure/Services/GoogleWorkspaceSyncService.cs
@@ -1349,7 +1349,7 @@ public class GoogleWorkspaceSyncService : IGoogleSyncService
                 {
                     var permToRemove = permissions.FirstOrDefault(p =>
                         IsDirectManagedPermission(p) &&
-                        string.Equals(p.EmailAddress, member.Email, StringComparison.OrdinalIgnoreCase));
+                        NormalizingEmailComparer.Instance.Equals(p.EmailAddress, member.Email));
 
                     if (permToRemove is null)
                     {
@@ -1565,7 +1565,7 @@ public class GoogleWorkspaceSyncService : IGoogleSyncService
                         // Find the direct managed permission for this user
                         var permToRemove = permissions.FirstOrDefault(p =>
                             IsDirectManagedPermission(p) &&
-                            string.Equals(p.EmailAddress, member.Email, StringComparison.OrdinalIgnoreCase));
+                            NormalizingEmailComparer.Instance.Equals(p.EmailAddress, member.Email));
 
                         if (permToRemove is null)
                         {

--- a/src/Humans.Web/Controllers/FeedbackController.cs
+++ b/src/Humans.Web/Controllers/FeedbackController.cs
@@ -183,7 +183,7 @@ public class FeedbackController : HumansControllerBase
         }
         catch (InvalidOperationException ex)
         {
-            _logger.LogDebug(ex, "Feedback submission failed for user {UserId}", user.Id);
+            _logger.LogWarning(ex, "Feedback submission failed for user {UserId}", user.Id);
             var errorMsg = _localizer["Feedback_Error"].Value;
             if (isAjax) return Json(new { success = false, message = errorMsg });
             SetError(errorMsg);

--- a/src/Humans.Web/Controllers/TeamAdminController.cs
+++ b/src/Humans.Web/Controllers/TeamAdminController.cs
@@ -758,7 +758,7 @@ public class TeamAdminController : HumansTeamControllerBase
         }
         catch (Exception ex) when (ex is InvalidOperationException or DbUpdateException or ArgumentException)
         {
-            _logger.LogDebug(ex, "Failed to create role '{RoleName}' for team {TeamId} by user {UserId}", model.Name, team.Id, user.Id);
+            _logger.LogWarning(ex, "Failed to create role '{RoleName}' for team {TeamId} by user {UserId}", model.Name, team.Id, user.Id);
             SetError(ex.Message);
         }
 
@@ -806,7 +806,7 @@ public class TeamAdminController : HumansTeamControllerBase
         }
         catch (Exception ex) when (ex is InvalidOperationException or DbUpdateException or ArgumentException)
         {
-            _logger.LogDebug(ex, "Failed to update role {RoleId} for team {TeamId} by user {UserId}", roleId, team.Id, user.Id);
+            _logger.LogWarning(ex, "Failed to update role {RoleId} for team {TeamId} by user {UserId}", roleId, team.Id, user.Id);
             if (isAjax) return Json(new { success = false, message = ex.Message });
             SetError(ex.Message);
         }
@@ -831,7 +831,7 @@ public class TeamAdminController : HumansTeamControllerBase
         }
         catch (Exception ex) when (ex is InvalidOperationException or DbUpdateException or ArgumentException)
         {
-            _logger.LogDebug(ex, "Failed to delete role {RoleId} for team {TeamId} by user {UserId}", roleId, team.Id, user.Id);
+            _logger.LogWarning(ex, "Failed to delete role {RoleId} for team {TeamId} by user {UserId}", roleId, team.Id, user.Id);
             SetError(ex.Message);
         }
 
@@ -869,7 +869,7 @@ public class TeamAdminController : HumansTeamControllerBase
         }
         catch (Exception ex) when (ex is InvalidOperationException or DbUpdateException or ArgumentException)
         {
-            _logger.LogDebug(ex, "Failed to toggle management flag for role {RoleId} in team {TeamId} by user {UserId}", roleId, team.Id, user.Id);
+            _logger.LogWarning(ex, "Failed to toggle management flag for role {RoleId} in team {TeamId} by user {UserId}", roleId, team.Id, user.Id);
             SetError(ex.Message);
         }
 
@@ -894,7 +894,7 @@ public class TeamAdminController : HumansTeamControllerBase
         }
         catch (Exception ex) when (ex is InvalidOperationException or DbUpdateException or ArgumentException)
         {
-            _logger.LogDebug(ex, "Failed to assign member {MemberUserId} to role {RoleId} in team {TeamId} by user {UserId}", model.UserId, roleId, team.Id, user.Id);
+            _logger.LogWarning(ex, "Failed to assign member {MemberUserId} to role {RoleId} in team {TeamId} by user {UserId}", model.UserId, roleId, team.Id, user.Id);
             SetError(ex.Message);
         }
 
@@ -929,7 +929,7 @@ public class TeamAdminController : HumansTeamControllerBase
         }
         catch (Exception ex) when (ex is InvalidOperationException or DbUpdateException or ArgumentException)
         {
-            _logger.LogDebug(ex, "Failed to unassign member {MemberId} from role {RoleId} in team {TeamId} by user {UserId}", memberId, roleId, team.Id, user.Id);
+            _logger.LogWarning(ex, "Failed to unassign member {MemberId} from role {RoleId} in team {TeamId} by user {UserId}", memberId, roleId, team.Id, user.Id);
             SetError(ex.Message);
         }
 


### PR DESCRIPTION
## Summary
- **Fix silent exception swallowing:** 7 `LogDebug` calls in catch blocks changed to `LogWarning` in TeamAdminController (6) and FeedbackController (1). These exceptions were invisible in production logging.
- **Fix Drive permission email comparison:** `GoogleWorkspaceSyncService.cs` used `OrdinalIgnoreCase` instead of `NormalizingEmailComparer` for Drive permission lookups, causing gmail/googlemail address mismatches to silently skip permission removal — a real sync drift bug.

Phases 4 (form field preservation), 5 (EF bool sentinel), 7 (null refs), 9 (orphan pages), and 12 (infra config) were all clean.

All 874 tests passing, zero build warnings.

## Test plan
- [ ] Verify TeamAdmin error scenarios log at Warning level (check logs after triggering a team admin error)
- [ ] Verify Google Drive permission sync correctly handles googlemail.com addresses
- [ ] `dotnet build && dotnet test` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)