### PR TITLE
Tech debt round 2: remove DbContext from Web layer controllers and ViewComponents

### DIFF
--- a/docs/features/communication-preferences.md
+++ b/docs/features/communication-preferences.md
@@ -23,7 +23,7 @@ System and Campaign Codes are always locked on — users cannot opt out. These c
 
 ### Ticketing Locking
 
-When a user has a matched `TicketOrder` (auto-matched by email), their Ticketing preference is locked on. Purchase confirmations and event information are mandatory for ticket holders. Users without ticket orders can opt in/out freely.
+When a user has a matched `TicketAttendee` record (auto-matched by email), their Ticketing preference is locked on. Purchase confirmations and event information are mandatory for ticket attendees. Users without a ticket attendee match can opt in/out freely.
 
 ### Facilitated Messages Opt-Out
 

--- a/src/Humans.Application/Interfaces/IAuditLogService.cs
+++ b/src/Humans.Application/Interfaces/IAuditLogService.cs
@@ -96,5 +96,5 @@ public record AuditLogPageResult(
     IReadOnlyList<AuditLogEntry> Items,
     int TotalCount,
     int AnomalyCount,
-    IReadOnlyDictionary<Guid, string> UserDisplayNames,
-    IReadOnlyDictionary<Guid, (string Name, string Slug)> TeamNames);
+    Dictionary<Guid, string> UserDisplayNames,
+    Dictionary<Guid, (string Name, string Slug)> TeamNames);

--- a/src/Humans.Application/Interfaces/IAuditLogService.cs
+++ b/src/Humans.Application/Interfaces/IAuditLogService.cs
@@ -77,6 +77,16 @@ public interface IAuditLogService
     /// </summary>
     Task<AuditLogPageResult> GetAuditLogPageAsync(
         string? actionFilter, int page, int pageSize, CancellationToken ct = default);
+
+    /// <summary>
+    /// Batch-loads user display names for a set of user IDs.
+    /// </summary>
+    Task<Dictionary<Guid, string>> GetUserDisplayNamesAsync(IReadOnlyList<Guid> userIds, CancellationToken ct = default);
+
+    /// <summary>
+    /// Batch-loads team names and slugs for a set of team IDs.
+    /// </summary>
+    Task<Dictionary<Guid, (string Name, string Slug)>> GetTeamNamesAsync(IReadOnlyList<Guid> teamIds, CancellationToken ct = default);
 }
 
 /// <summary>

--- a/src/Humans.Application/Interfaces/IAuditLogService.cs
+++ b/src/Humans.Application/Interfaces/IAuditLogService.cs
@@ -70,4 +70,21 @@ public interface IAuditLogService
         IReadOnlyList<AuditAction>? actions = null,
         int limit = 20,
         CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets a full audit log page with display name lookups for users and teams.
+    /// Used by Board/Admin audit log views to avoid direct DbContext access in controllers.
+    /// </summary>
+    Task<AuditLogPageResult> GetAuditLogPageAsync(
+        string? actionFilter, int page, int pageSize, CancellationToken ct = default);
 }
+
+/// <summary>
+/// Full audit log page with display name dictionaries for rendering.
+/// </summary>
+public record AuditLogPageResult(
+    IReadOnlyList<AuditLogEntry> Items,
+    int TotalCount,
+    int AnomalyCount,
+    IReadOnlyDictionary<Guid, string> UserDisplayNames,
+    IReadOnlyDictionary<Guid, (string Name, string Slug)> TeamNames);

--- a/src/Humans.Application/Interfaces/IBudgetService.cs
+++ b/src/Humans.Application/Interfaces/IBudgetService.cs
@@ -41,6 +41,7 @@ public interface IBudgetService
     Task DeleteCategoryAsync(Guid categoryId, Guid actorUserId);
 
     // Budget Line Items
+    Task<BudgetLineItem?> GetLineItemByIdAsync(Guid id);
     Task<BudgetLineItem> CreateLineItemAsync(Guid budgetCategoryId, string description, decimal amount, Guid? responsibleTeamId, string? notes, LocalDate? expectedDate, int vatRate, Guid actorUserId);
     Task UpdateLineItemAsync(Guid lineItemId, string description, decimal amount, Guid? responsibleTeamId, string? notes, LocalDate? expectedDate, int vatRate, Guid actorUserId);
     Task DeleteLineItemAsync(Guid lineItemId, Guid actorUserId);

--- a/src/Humans.Application/Interfaces/ICampService.cs
+++ b/src/Humans.Application/Interfaces/ICampService.cs
@@ -43,6 +43,11 @@ public interface ICampService
     Task<IReadOnlyList<CampPublicSummary>> GetCampPublicSummariesForYearAsync(int year, CancellationToken cancellationToken = default);
     Task<IReadOnlyList<CampPlacementSummary>> GetCampPlacementSummariesForYearAsync(int year, CancellationToken cancellationToken = default);
     Task<CampSettings> GetSettingsAsync(CancellationToken cancellationToken = default);
+    /// <summary>
+    /// Gets camps with their active leads (and lead user data) for a given year.
+    /// Optionally filters to specific season statuses.
+    /// </summary>
+    Task<List<Camp>> GetCampsWithLeadsForYearAsync(int year, IReadOnlyList<CampSeasonStatus>? statusFilter = null, CancellationToken cancellationToken = default);
     Task<List<Camp>> GetCampsByLeadUserIdAsync(Guid userId, CancellationToken cancellationToken = default);
     Task<List<CampSeason>> GetPendingSeasonsAsync(CancellationToken cancellationToken = default);
 

--- a/src/Humans.Application/Interfaces/IEmailOutboxService.cs
+++ b/src/Humans.Application/Interfaces/IEmailOutboxService.cs
@@ -1,7 +1,9 @@
+using Humans.Domain.Entities;
+
 namespace Humans.Application.Interfaces;
 
 /// <summary>
-/// Service for managing email outbox messages (retry, discard).
+/// Service for managing email outbox messages (retry, discard, stats, pause/resume).
 /// </summary>
 public interface IEmailOutboxService
 {
@@ -16,4 +18,30 @@ public interface IEmailOutboxService
     /// Returns the recipient email if found, or null if the message does not exist.
     /// </summary>
     Task<string?> DiscardMessageAsync(Guid id, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets aggregate statistics and recent messages for the email outbox dashboard.
+    /// </summary>
+    Task<EmailOutboxStats> GetOutboxStatsAsync(int recentMessageCount = 50, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets whether email sending is currently paused.
+    /// </summary>
+    Task<bool> IsEmailPausedAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Sets the email sending paused state.
+    /// </summary>
+    Task SetEmailPausedAsync(bool paused, CancellationToken cancellationToken = default);
 }
+
+/// <summary>
+/// Aggregate statistics for the email outbox dashboard.
+/// </summary>
+public record EmailOutboxStats(
+    int TotalCount,
+    int QueuedCount,
+    int SentLast24HoursCount,
+    int FailedCount,
+    bool IsPaused,
+    IReadOnlyList<EmailOutboxMessage> RecentMessages);

--- a/src/Humans.Application/Interfaces/INotificationInboxService.cs
+++ b/src/Humans.Application/Interfaces/INotificationInboxService.cs
@@ -83,6 +83,13 @@ public interface INotificationInboxService
     Task ResolveBySourceAsync(
         Guid userId, NotificationSource source,
         CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets unread notification badge counts for a user (actionable + informational).
+    /// Used by the notification bell ViewComponent.
+    /// </summary>
+    Task<(int Actionable, int Informational)> GetUnreadBadgeCountsAsync(
+        Guid userId, CancellationToken ct = default);
 }
 
 /// <summary>

--- a/src/Humans.Application/Interfaces/IOnboardingService.cs
+++ b/src/Humans.Application/Interfaces/IOnboardingService.cs
@@ -42,6 +42,17 @@ public interface IOnboardingService
     // --- Shared: consent-check pending (used by ConsentController + ProfileController) ---
     Task<bool> SetConsentCheckPendingIfEligibleAsync(Guid userId, CancellationToken ct = default);
 
+    // --- Badge counts ---
+    /// <summary>
+    /// Gets the count of profiles pending consent review (not yet approved, not rejected).
+    /// </summary>
+    Task<int> GetPendingReviewCountAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets the count of submitted applications that the given board member has not yet voted on.
+    /// </summary>
+    Task<int> GetUnvotedApplicationCountAsync(Guid boardMemberUserId, CancellationToken ct = default);
+
     // --- Admin ---
     Task<DTOs.AdminDashboardData> GetAdminDashboardAsync(CancellationToken ct = default);
     Task<OnboardingResult> PurgeHumanAsync(Guid userId, CancellationToken ct = default);

--- a/src/Humans.Application/Interfaces/ITeamService.cs
+++ b/src/Humans.Application/Interfaces/ITeamService.cs
@@ -72,6 +72,13 @@ public record MyTeamMembershipSummary(
     bool CanLeave,
     int PendingRequestCount);
 
+public record UserTeamGoogleResource(
+    string TeamName,
+    string TeamSlug,
+    string ResourceName,
+    GoogleResourceType ResourceType,
+    string? Url);
+
 public record TeamRosterSlotSummary(
     string TeamName,
     string TeamSlug,
@@ -163,6 +170,13 @@ public interface ITeamService
     /// Gets all teams the user is a member of.
     /// </summary>
     Task<IReadOnlyList<TeamMember>> GetUserTeamsAsync(Guid userId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets active Google resources grouped by team for a user's active team memberships.
+    /// Used by the MyGoogleResources view component on the dashboard.
+    /// </summary>
+    Task<IReadOnlyList<UserTeamGoogleResource>> GetUserTeamGoogleResourcesAsync(Guid userId, CancellationToken cancellationToken = default);
+
 
     /// <summary>
     /// Gets the current user's team memberships with viewer-specific pending-request counts.

--- a/src/Humans.Application/Interfaces/ITeamService.cs
+++ b/src/Humans.Application/Interfaces/ITeamService.cs
@@ -177,7 +177,6 @@ public interface ITeamService
     /// </summary>
     Task<IReadOnlyList<UserTeamGoogleResource>> GetUserTeamGoogleResourcesAsync(Guid userId, CancellationToken cancellationToken = default);
 
-
     /// <summary>
     /// Gets the current user's team memberships with viewer-specific pending-request counts.
     /// </summary>

--- a/src/Humans.Application/Interfaces/ITicketQueryService.cs
+++ b/src/Humans.Application/Interfaces/ITicketQueryService.cs
@@ -1,4 +1,5 @@
 using Humans.Application.DTOs;
+using NodaTime;
 
 namespace Humans.Application.Interfaces;
 
@@ -122,7 +123,7 @@ public interface ITicketQueryService
 /// </summary>
 public record UserTicketOrderSummary(
     string BuyerName,
-    DateTime PurchasedAt,
+    Instant PurchasedAt,
     int AttendeeCount,
     decimal TotalAmount,
     string Currency);

--- a/src/Humans.Application/Interfaces/ITicketQueryService.cs
+++ b/src/Humans.Application/Interfaces/ITicketQueryService.cs
@@ -107,10 +107,10 @@ public interface ITicketQueryService
     Task<List<OrderExportRow>> GetOrderExportDataAsync();
 
     /// <summary>
-    /// Checks whether a user has any ticket association (order or attendee match).
-    /// Used for guest dashboard and communication preferences.
+    /// Checks whether a user has a matched ticket attendee record.
+    /// Used for guest dashboard and communication preferences ticketing lock.
     /// </summary>
-    Task<bool> HasAnyTicketAssociationAsync(Guid userId);
+    Task<bool> HasTicketAttendeeMatchAsync(Guid userId);
 
     /// <summary>
     /// Gets ticket order summaries for a specific user (as buyer), ordered by most recent first.

--- a/src/Humans.Application/Interfaces/ITicketQueryService.cs
+++ b/src/Humans.Application/Interfaces/ITicketQueryService.cs
@@ -104,4 +104,25 @@ public interface ITicketQueryService
     /// Get all orders for CSV export, ordered by purchase date descending.
     /// </summary>
     Task<List<OrderExportRow>> GetOrderExportDataAsync();
+
+    /// <summary>
+    /// Checks whether a user has any ticket association (order or attendee match).
+    /// Used for guest dashboard and communication preferences.
+    /// </summary>
+    Task<bool> HasAnyTicketAssociationAsync(Guid userId);
+
+    /// <summary>
+    /// Gets ticket order summaries for a specific user (as buyer), ordered by most recent first.
+    /// </summary>
+    Task<List<UserTicketOrderSummary>> GetUserTicketOrderSummariesAsync(Guid userId);
 }
+
+/// <summary>
+/// Summary of a ticket order for display on user-facing pages.
+/// </summary>
+public record UserTicketOrderSummary(
+    string BuyerName,
+    DateTime PurchasedAt,
+    int AttendeeCount,
+    decimal TotalAmount,
+    string Currency);

--- a/src/Humans.Domain/Constants/SystemSettingKeys.cs
+++ b/src/Humans.Domain/Constants/SystemSettingKeys.cs
@@ -1,0 +1,9 @@
+namespace Humans.Domain.Constants;
+
+/// <summary>
+/// Well-known keys for the SystemSettings table.
+/// </summary>
+public static class SystemSettingKeys
+{
+    public const string IsEmailSendingPaused = "IsEmailSendingPaused";
+}

--- a/src/Humans.Infrastructure/Jobs/ProcessEmailOutboxJob.cs
+++ b/src/Humans.Infrastructure/Jobs/ProcessEmailOutboxJob.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NodaTime;
 using Humans.Application.Interfaces;
+using Humans.Domain.Constants;
 using Humans.Domain.Enums;
 using Humans.Infrastructure.Configuration;
 using Humans.Infrastructure.Data;
@@ -43,7 +44,7 @@ public class ProcessEmailOutboxJob : IRecurringJob
     {
         // 1. Check global pause flag
         var pauseSetting = await _dbContext.SystemSettings
-            .FirstOrDefaultAsync(s => s.Key == "IsEmailSendingPaused", cancellationToken);
+            .FirstOrDefaultAsync(s => s.Key == SystemSettingKeys.IsEmailSendingPaused, cancellationToken);
 
         if (pauseSetting is { Value: "true" })
         {

--- a/src/Humans.Infrastructure/Services/AuditLogService.cs
+++ b/src/Humans.Infrastructure/Services/AuditLogService.cs
@@ -213,19 +213,10 @@ public class AuditLogService : IAuditLogService
                 teamIds.Add(e.RelatedEntityId.Value);
         }
 
-        var userDisplayNames = userIds.Count > 0
-            ? (IReadOnlyDictionary<Guid, string>)await _dbContext.Users.AsNoTracking()
-                .Where(u => userIds.Contains(u.Id))
-                .ToDictionaryAsync(u => u.Id, u => u.DisplayName, ct)
-            : new Dictionary<Guid, string>();
+        var userDisplayNames = await GetUserDisplayNamesAsync(userIds.ToList(), ct);
+        var teamNameLookup = await GetTeamNamesAsync(teamIds.ToList(), ct);
 
-        var teamNames = teamIds.Count > 0
-            ? (IReadOnlyDictionary<Guid, (string Name, string Slug)>)await _dbContext.Teams.AsNoTracking()
-                .Where(t => teamIds.Contains(t.Id))
-                .ToDictionaryAsync(t => t.Id, t => (t.Name, t.Slug), ct)
-            : new Dictionary<Guid, (string Name, string Slug)>();
-
-        return new AuditLogPageResult(items, totalCount, anomalyCount, userDisplayNames, teamNames);
+        return new AuditLogPageResult(items, totalCount, anomalyCount, userDisplayNames, teamNameLookup);
     }
 
     /// <inheritdoc />
@@ -258,5 +249,27 @@ public class AuditLogService : IAuditLogService
             .OrderByDescending(e => e.OccurredAt)
             .Take(limit)
             .ToListAsync(ct);
+    }
+
+    /// <inheritdoc />
+    public async Task<Dictionary<Guid, string>> GetUserDisplayNamesAsync(IReadOnlyList<Guid> userIds, CancellationToken ct = default)
+    {
+        if (userIds.Count == 0)
+            return new Dictionary<Guid, string>();
+
+        return await _dbContext.Users.AsNoTracking()
+            .Where(u => userIds.Contains(u.Id))
+            .ToDictionaryAsync(u => u.Id, u => u.DisplayName, ct);
+    }
+
+    /// <inheritdoc />
+    public async Task<Dictionary<Guid, (string Name, string Slug)>> GetTeamNamesAsync(IReadOnlyList<Guid> teamIds, CancellationToken ct = default)
+    {
+        if (teamIds.Count == 0)
+            return new Dictionary<Guid, (string Name, string Slug)>();
+
+        return await _dbContext.Teams.AsNoTracking()
+            .Where(t => teamIds.Contains(t.Id))
+            .ToDictionaryAsync(t => t.Id, t => (t.Name, t.Slug), ct);
     }
 }

--- a/src/Humans.Infrastructure/Services/AuditLogService.cs
+++ b/src/Humans.Infrastructure/Services/AuditLogService.cs
@@ -186,6 +186,49 @@ public class AuditLogService : IAuditLogService
     }
 
     /// <inheritdoc />
+    public async Task<AuditLogPageResult> GetAuditLogPageAsync(
+        string? actionFilter, int page, int pageSize, CancellationToken ct = default)
+    {
+        var (items, totalCount, anomalyCount) = await GetFilteredAsync(actionFilter, page, pageSize, ct);
+
+        // Collect all user IDs that might appear as actors or subjects
+        var userIds = new HashSet<Guid>();
+        var teamIds = new HashSet<Guid>();
+
+        foreach (var e in items)
+        {
+            if (e.ActorUserId.HasValue)
+                userIds.Add(e.ActorUserId.Value);
+
+            // Subject user ID: User/Profile/WorkspaceAccount entity types, or related User
+            if (e.EntityType is "User" or "Profile" or "WorkspaceAccount")
+                userIds.Add(e.EntityId);
+            else if (string.Equals(e.RelatedEntityType, "User", StringComparison.Ordinal) && e.RelatedEntityId.HasValue)
+                userIds.Add(e.RelatedEntityId.Value);
+
+            // Target team ID
+            if (string.Equals(e.EntityType, "Team", StringComparison.Ordinal))
+                teamIds.Add(e.EntityId);
+            else if (string.Equals(e.RelatedEntityType, "Team", StringComparison.Ordinal) && e.RelatedEntityId.HasValue)
+                teamIds.Add(e.RelatedEntityId.Value);
+        }
+
+        var userDisplayNames = userIds.Count > 0
+            ? (IReadOnlyDictionary<Guid, string>)await _dbContext.Users.AsNoTracking()
+                .Where(u => userIds.Contains(u.Id))
+                .ToDictionaryAsync(u => u.Id, u => u.DisplayName, ct)
+            : new Dictionary<Guid, string>();
+
+        var teamNames = teamIds.Count > 0
+            ? (IReadOnlyDictionary<Guid, (string Name, string Slug)>)await _dbContext.Teams.AsNoTracking()
+                .Where(t => teamIds.Contains(t.Id))
+                .ToDictionaryAsync(t => t.Id, t => (t.Name, t.Slug), ct)
+            : new Dictionary<Guid, (string Name, string Slug)>();
+
+        return new AuditLogPageResult(items, totalCount, anomalyCount, userDisplayNames, teamNames);
+    }
+
+    /// <inheritdoc />
     public async Task<IReadOnlyList<AuditLogEntry>> GetFilteredEntriesAsync(
         string? entityType = null,
         Guid? entityId = null,

--- a/src/Humans.Infrastructure/Services/BudgetService.cs
+++ b/src/Humans.Infrastructure/Services/BudgetService.cs
@@ -654,6 +654,11 @@ public class BudgetService : IBudgetService
 
     // ───────────────────────── Budget Line Items ─────────────────────────
 
+    public async Task<BudgetLineItem?> GetLineItemByIdAsync(Guid id)
+    {
+        return await _dbContext.BudgetLineItems.FindAsync(id);
+    }
+
     public async Task<BudgetLineItem> CreateLineItemAsync(
         Guid budgetCategoryId, string description, decimal amount,
         Guid? responsibleTeamId, string? notes, LocalDate? expectedDate,

--- a/src/Humans.Infrastructure/Services/CampService.cs
+++ b/src/Humans.Infrastructure/Services/CampService.cs
@@ -319,6 +319,25 @@ public class CampService : ICampService
             .ToList();
     }
 
+    /// <inheritdoc />
+    public async Task<List<Camp>> GetCampsWithLeadsForYearAsync(int year, IReadOnlyList<CampSeasonStatus>? statusFilter = null, CancellationToken cancellationToken = default)
+    {
+        var query = _dbContext.Camps
+            .Include(c => c.Seasons.Where(s => s.Year == year))
+            .Include(c => c.Leads.Where(l => l.LeftAt == null))
+                .ThenInclude(l => l.User)
+            .Where(c => c.Seasons.Any(s => s.Year == year));
+
+        if (statusFilter is { Count: > 0 })
+        {
+            query = query.Where(c => c.Seasons.Any(s => s.Year == year && statusFilter.Contains(s.Status)));
+        }
+
+        return await query
+            .OrderBy(c => c.Seasons.Where(s => s.Year == year).Select(s => s.Name).FirstOrDefault())
+            .ToListAsync(cancellationToken);
+    }
+
     public async Task<List<Camp>> GetCampsByLeadUserIdAsync(Guid userId, CancellationToken cancellationToken = default)
     {
         return await _dbContext.Camps

--- a/src/Humans.Infrastructure/Services/EmailOutboxService.cs
+++ b/src/Humans.Infrastructure/Services/EmailOutboxService.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using NodaTime;
 using Humans.Application.Interfaces;
+using Humans.Domain.Constants;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Humans.Infrastructure.Data;
@@ -72,17 +73,17 @@ public class EmailOutboxService : IEmailOutboxService
     public async Task<bool> IsEmailPausedAsync(CancellationToken cancellationToken = default)
     {
         var setting = await _dbContext.SystemSettings
-            .FirstOrDefaultAsync(s => s.Key == "IsEmailSendingPaused", cancellationToken);
+            .FirstOrDefaultAsync(s => s.Key == SystemSettingKeys.IsEmailSendingPaused, cancellationToken);
         return string.Equals(setting?.Value, "true", StringComparison.OrdinalIgnoreCase);
     }
 
     public async Task SetEmailPausedAsync(bool paused, CancellationToken cancellationToken = default)
     {
         var setting = await _dbContext.SystemSettings
-            .FirstOrDefaultAsync(s => s.Key == "IsEmailSendingPaused", cancellationToken);
+            .FirstOrDefaultAsync(s => s.Key == SystemSettingKeys.IsEmailSendingPaused, cancellationToken);
         if (setting is null)
         {
-            setting = new SystemSetting { Key = "IsEmailSendingPaused", Value = paused ? "true" : "false" };
+            setting = new SystemSetting { Key = SystemSettingKeys.IsEmailSendingPaused, Value = paused ? "true" : "false" };
             _dbContext.SystemSettings.Add(setting);
         }
         else

--- a/src/Humans.Infrastructure/Services/EmailOutboxService.cs
+++ b/src/Humans.Infrastructure/Services/EmailOutboxService.cs
@@ -1,4 +1,7 @@
+using Microsoft.EntityFrameworkCore;
+using NodaTime;
 using Humans.Application.Interfaces;
+using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Humans.Infrastructure.Data;
 
@@ -7,10 +10,12 @@ namespace Humans.Infrastructure.Services;
 public class EmailOutboxService : IEmailOutboxService
 {
     private readonly HumansDbContext _dbContext;
+    private readonly IClock _clock;
 
-    public EmailOutboxService(HumansDbContext dbContext)
+    public EmailOutboxService(HumansDbContext dbContext, IClock clock)
     {
         _dbContext = dbContext;
+        _clock = clock;
     }
 
     public async Task<string?> RetryMessageAsync(Guid id, CancellationToken cancellationToken = default)
@@ -38,5 +43,52 @@ public class EmailOutboxService : IEmailOutboxService
         await _dbContext.SaveChangesAsync(cancellationToken);
 
         return recipient;
+    }
+
+    public async Task<EmailOutboxStats> GetOutboxStatsAsync(int recentMessageCount = 50, CancellationToken cancellationToken = default)
+    {
+        var now = _clock.GetCurrentInstant();
+        var cutoff24H = now - Duration.FromHours(24);
+
+        var totalCount = await _dbContext.EmailOutboxMessages.CountAsync(cancellationToken);
+        var queuedCount = await _dbContext.EmailOutboxMessages
+            .CountAsync(m => m.Status == EmailOutboxStatus.Queued, cancellationToken);
+        var sentLast24H = await _dbContext.EmailOutboxMessages
+            .CountAsync(m => m.Status == EmailOutboxStatus.Sent && m.SentAt > cutoff24H, cancellationToken);
+        var failedCount = await _dbContext.EmailOutboxMessages
+            .CountAsync(m => m.Status == EmailOutboxStatus.Failed, cancellationToken);
+
+        var isPaused = await IsEmailPausedAsync(cancellationToken);
+
+        var messages = await _dbContext.EmailOutboxMessages
+            .Include(m => m.User)
+            .OrderByDescending(m => m.CreatedAt)
+            .Take(recentMessageCount)
+            .ToListAsync(cancellationToken);
+
+        return new EmailOutboxStats(totalCount, queuedCount, sentLast24H, failedCount, isPaused, messages);
+    }
+
+    public async Task<bool> IsEmailPausedAsync(CancellationToken cancellationToken = default)
+    {
+        var setting = await _dbContext.SystemSettings
+            .FirstOrDefaultAsync(s => s.Key == "IsEmailSendingPaused", cancellationToken);
+        return string.Equals(setting?.Value, "true", StringComparison.OrdinalIgnoreCase);
+    }
+
+    public async Task SetEmailPausedAsync(bool paused, CancellationToken cancellationToken = default)
+    {
+        var setting = await _dbContext.SystemSettings
+            .FirstOrDefaultAsync(s => s.Key == "IsEmailSendingPaused", cancellationToken);
+        if (setting is null)
+        {
+            setting = new SystemSetting { Key = "IsEmailSendingPaused", Value = paused ? "true" : "false" };
+            _dbContext.SystemSettings.Add(setting);
+        }
+        else
+        {
+            setting.Value = paused ? "true" : "false";
+        }
+        await _dbContext.SaveChangesAsync(cancellationToken);
     }
 }

--- a/src/Humans.Infrastructure/Services/NotificationInboxService.cs
+++ b/src/Humans.Infrastructure/Services/NotificationInboxService.cs
@@ -369,6 +369,25 @@ public class NotificationInboxService : INotificationInboxService
         InvalidateBadgeCaches([userId]);
     }
 
+    /// <inheritdoc />
+    public async Task<(int Actionable, int Informational)> GetUnreadBadgeCountsAsync(
+        Guid userId, CancellationToken ct = default)
+    {
+        var actionableCount = await _dbContext.NotificationRecipients
+            .CountAsync(nr => nr.UserId == userId &&
+                              nr.ReadAt == null &&
+                              nr.Notification.ResolvedAt == null &&
+                              nr.Notification.Class == NotificationClass.Actionable, ct);
+
+        var informationalCount = await _dbContext.NotificationRecipients
+            .CountAsync(nr => nr.UserId == userId &&
+                              nr.ReadAt == null &&
+                              nr.Notification.ResolvedAt == null &&
+                              nr.Notification.Class == NotificationClass.Informational, ct);
+
+        return (actionableCount, informationalCount);
+    }
+
     private static NotificationRowDto MapToRow(NotificationRecipient nr)
     {
         var n = nr.Notification;

--- a/src/Humans.Infrastructure/Services/OnboardingService.cs
+++ b/src/Humans.Infrastructure/Services/OnboardingService.cs
@@ -581,6 +581,21 @@ public class OnboardingService : IOnboardingService
         await _syncJob.SyncAsociadosMembershipForUserAsync(userId, CancellationToken.None);
     }
 
+    /// <inheritdoc />
+    public async Task<int> GetPendingReviewCountAsync(CancellationToken ct = default)
+    {
+        return await _dbContext.Profiles
+            .CountAsync(p => !p.IsApproved && p.RejectedAt == null, ct);
+    }
+
+    /// <inheritdoc />
+    public async Task<int> GetUnvotedApplicationCountAsync(Guid boardMemberUserId, CancellationToken ct = default)
+    {
+        return await _dbContext.Applications
+            .CountAsync(a => a.Status == ApplicationStatus.Submitted
+                && !a.BoardVotes.Any(v => v.BoardMemberUserId == boardMemberUserId), ct);
+    }
+
     public async Task<Application.DTOs.AdminDashboardData> GetAdminDashboardAsync(CancellationToken ct = default)
     {
         var allUserIds = await _dbContext.Users.Select(u => u.Id).ToListAsync(ct);

--- a/src/Humans.Infrastructure/Services/TeamService.cs
+++ b/src/Humans.Infrastructure/Services/TeamService.cs
@@ -362,6 +362,27 @@ public class TeamService : ITeamService
             .ToListAsync(cancellationToken);
     }
 
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<UserTeamGoogleResource>> GetUserTeamGoogleResourcesAsync(Guid userId, CancellationToken cancellationToken = default)
+    {
+        var teamResources = await _dbContext.TeamMembers
+            .AsNoTracking()
+            .Where(tm => tm.UserId == userId && tm.LeftAt == null)
+            .SelectMany(tm => tm.Team.GoogleResources
+                .Where(r => r.IsActive)
+                .Select(r => new UserTeamGoogleResource(
+                    tm.Team.Name,
+                    tm.Team.Slug,
+                    r.Name,
+                    r.ResourceType,
+                    r.Url)))
+            .OrderBy(r => r.TeamName)
+            .ThenBy(r => r.ResourceName)
+            .ToListAsync(cancellationToken);
+
+        return teamResources;
+    }
+
     public async Task<IReadOnlyList<MyTeamMembershipSummary>> GetMyTeamMembershipsAsync(
         Guid userId,
         CancellationToken cancellationToken = default)

--- a/src/Humans.Infrastructure/Services/TicketQueryService.cs
+++ b/src/Humans.Infrastructure/Services/TicketQueryService.cs
@@ -872,6 +872,32 @@ public class TicketQueryService : ITicketQueryService
         return filteredHumans.ToList();
     }
 
+    /// <inheritdoc />
+    public async Task<bool> HasAnyTicketAssociationAsync(Guid userId)
+    {
+        var hasOrder = await _dbContext.TicketOrders
+            .AnyAsync(o => o.MatchedUserId == userId);
+        if (hasOrder) return true;
+
+        return await _dbContext.TicketAttendees
+            .AnyAsync(a => a.MatchedUserId == userId);
+    }
+
+    /// <inheritdoc />
+    public async Task<List<UserTicketOrderSummary>> GetUserTicketOrderSummariesAsync(Guid userId)
+    {
+        return await _dbContext.TicketOrders
+            .Where(o => o.MatchedUserId == userId)
+            .OrderByDescending(o => o.PurchasedAt)
+            .Select(o => new UserTicketOrderSummary(
+                o.BuyerName,
+                o.PurchasedAt.ToDateTimeUtc(),
+                o.Attendees.Count,
+                o.TotalAmount,
+                o.Currency))
+            .ToListAsync();
+    }
+
     private static bool HasSearchTerm([NotNullWhen(true)] string? value, int minLength = 2) =>
         !string.IsNullOrWhiteSpace(value) && value.Trim().Length >= minLength;
 

--- a/src/Humans.Infrastructure/Services/TicketQueryService.cs
+++ b/src/Humans.Infrastructure/Services/TicketQueryService.cs
@@ -891,7 +891,7 @@ public class TicketQueryService : ITicketQueryService
             .OrderByDescending(o => o.PurchasedAt)
             .Select(o => new UserTicketOrderSummary(
                 o.BuyerName,
-                o.PurchasedAt.ToDateTimeUtc(),
+                o.PurchasedAt,
                 o.Attendees.Count,
                 o.TotalAmount,
                 o.Currency))

--- a/src/Humans.Infrastructure/Services/TicketQueryService.cs
+++ b/src/Humans.Infrastructure/Services/TicketQueryService.cs
@@ -873,12 +873,8 @@ public class TicketQueryService : ITicketQueryService
     }
 
     /// <inheritdoc />
-    public async Task<bool> HasAnyTicketAssociationAsync(Guid userId)
+    public async Task<bool> HasTicketAttendeeMatchAsync(Guid userId)
     {
-        var hasOrder = await _dbContext.TicketOrders
-            .AnyAsync(o => o.MatchedUserId == userId);
-        if (hasOrder) return true;
-
         return await _dbContext.TicketAttendees
             .AnyAsync(a => a.MatchedUserId == userId);
     }

--- a/src/Humans.Web/Controllers/BoardController.cs
+++ b/src/Humans.Web/Controllers/BoardController.cs
@@ -1,11 +1,9 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
 using Humans.Application.Interfaces;
 using Humans.Domain.Constants;
 using Humans.Domain.Entities;
-using Humans.Infrastructure.Data;
 using Humans.Web.Authorization;
 using Humans.Web.Models;
 
@@ -17,18 +15,15 @@ public class BoardController : HumansControllerBase
 {
     private readonly IAuditLogService _auditLogService;
     private readonly IOnboardingService _onboardingService;
-    private readonly HumansDbContext _dbContext;
 
     public BoardController(
         IAuditLogService auditLogService,
         IOnboardingService onboardingService,
-        UserManager<User> userManager,
-        HumansDbContext dbContext)
+        UserManager<User> userManager)
         : base(userManager)
     {
         _auditLogService = auditLogService;
         _onboardingService = onboardingService;
-        _dbContext = dbContext;
     }
 
     [HttpGet("")]
@@ -70,9 +65,9 @@ public class BoardController : HumansControllerBase
     public async Task<IActionResult> AuditLog(string? filter, int page = 1)
     {
         var pageSize = 50;
-        var (items, totalCount, anomalyCount) = await _auditLogService.GetFilteredAsync(filter, page, pageSize);
+        var result = await _auditLogService.GetAuditLogPageAsync(filter, page, pageSize);
 
-        var entries = items.Select(e => new AuditLogEntryViewModel
+        var entries = result.Items.Select(e => new AuditLogEntryViewModel
         {
             Action = e.Action,
             Description = e.Description,
@@ -85,43 +80,16 @@ public class BoardController : HumansControllerBase
             RelatedEntityId = e.RelatedEntityId
         }).ToList();
 
-        // Batch-load display names for all user IDs (actors + subjects)
-        var allUserIds = entries
-            .SelectMany(e => new[] { e.ActorUserId, e.SubjectUserId })
-            .Where(id => id.HasValue)
-            .Select(id => id!.Value)
-            .Distinct()
-            .ToList();
-
-        var userDisplayNames = allUserIds.Count > 0
-            ? await _dbContext.Users.AsNoTracking()
-                .Where(u => allUserIds.Contains(u.Id))
-                .ToDictionaryAsync(u => u.Id, u => u.DisplayName)
-            : new Dictionary<Guid, string>();
-
-        // Batch-load team names for target teams
-        var teamIds = entries
-            .Where(e => e.TargetTeamId.HasValue)
-            .Select(e => e.TargetTeamId!.Value)
-            .Distinct()
-            .ToList();
-
-        var teamNames = teamIds.Count > 0
-            ? await _dbContext.Teams.AsNoTracking()
-                .Where(t => teamIds.Contains(t.Id))
-                .ToDictionaryAsync(t => t.Id, t => (t.Name, t.Slug))
-            : new Dictionary<Guid, (string Name, string Slug)>();
-
         var viewModel = new AuditLogListViewModel
         {
             Entries = entries,
             ActionFilter = filter,
-            AnomalyCount = anomalyCount,
-            TotalCount = totalCount,
+            AnomalyCount = result.AnomalyCount,
+            TotalCount = result.TotalCount,
             PageNumber = page,
             PageSize = pageSize,
-            UserDisplayNames = userDisplayNames,
-            TeamNames = teamNames
+            UserDisplayNames = result.UserDisplayNames.ToDictionary(kv => kv.Key, kv => kv.Value),
+            TeamNames = result.TeamNames.ToDictionary(kv => kv.Key, kv => kv.Value)
         };
 
         return View("~/Views/Shared/AuditLog.cshtml", viewModel);

--- a/src/Humans.Web/Controllers/BoardController.cs
+++ b/src/Humans.Web/Controllers/BoardController.cs
@@ -88,8 +88,8 @@ public class BoardController : HumansControllerBase
             TotalCount = result.TotalCount,
             PageNumber = page,
             PageSize = pageSize,
-            UserDisplayNames = result.UserDisplayNames.ToDictionary(kv => kv.Key, kv => kv.Value),
-            TeamNames = result.TeamNames.ToDictionary(kv => kv.Key, kv => kv.Value)
+            UserDisplayNames = result.UserDisplayNames,
+            TeamNames = result.TeamNames
         };
 
         return View("~/Views/Shared/AuditLog.cshtml", viewModel);

--- a/src/Humans.Web/Controllers/BudgetController.cs
+++ b/src/Humans.Web/Controllers/BudgetController.cs
@@ -1,13 +1,11 @@
 using Humans.Application.Interfaces;
 using Humans.Domain.Entities;
-using Humans.Infrastructure.Data;
 using Humans.Web.Authorization;
 using Humans.Web.Authorization.Requirements;
 using Humans.Web.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
 using NodaTime;
 
 namespace Humans.Web.Controllers;
@@ -18,14 +16,12 @@ public class BudgetController : HumansControllerBase
 {
     private readonly IBudgetService _budgetService;
     private readonly ITeamService _teamService;
-    private readonly HumansDbContext _dbContext;
     private readonly IAuthorizationService _authService;
     private readonly ILogger<BudgetController> _logger;
 
     public BudgetController(
         IBudgetService budgetService,
         ITeamService teamService,
-        HumansDbContext dbContext,
         IAuthorizationService authService,
         UserManager<User> userManager,
         ILogger<BudgetController> logger)
@@ -33,7 +29,6 @@ public class BudgetController : HumansControllerBase
     {
         _budgetService = budgetService;
         _teamService = teamService;
-        _dbContext = dbContext;
         _authService = authService;
         _logger = logger;
     }
@@ -198,7 +193,7 @@ public class BudgetController : HumansControllerBase
         var (errorResult, user) = await RequireCurrentUserAsync();
         if (errorResult is not null) return errorResult;
 
-        var lineItem = await _dbContext.BudgetLineItems.FindAsync(id);
+        var lineItem = await _budgetService.GetLineItemByIdAsync(id);
         if (lineItem is null) return NotFound();
 
         var authResult = await AuthorizeCategoryEditAsync(lineItem.BudgetCategoryId);
@@ -226,7 +221,7 @@ public class BudgetController : HumansControllerBase
         var (errorResult, user) = await RequireCurrentUserAsync();
         if (errorResult is not null) return errorResult;
 
-        var lineItem = await _dbContext.BudgetLineItems.FindAsync(id);
+        var lineItem = await _budgetService.GetLineItemByIdAsync(id);
         if (lineItem is null) return NotFound();
 
         var authResult = await AuthorizeCategoryEditAsync(lineItem.BudgetCategoryId);

--- a/src/Humans.Web/Controllers/CampAdminController.cs
+++ b/src/Humans.Web/Controllers/CampAdminController.cs
@@ -3,14 +3,12 @@ using Humans.Application.Interfaces;
 using Humans.Domain.Constants;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
-using Humans.Infrastructure.Data;
 using Humans.Web.Authorization;
 using Humans.Web.Extensions;
 using Humans.Web.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
 
 namespace Humans.Web.Controllers;
 
@@ -20,18 +18,15 @@ namespace Humans.Web.Controllers;
 public class CampAdminController : HumansControllerBase
 {
     private readonly ICampService _campService;
-    private readonly HumansDbContext _dbContext;
     private readonly ILogger<CampAdminController> _logger;
 
     public CampAdminController(
         ICampService campService,
-        HumansDbContext dbContext,
         UserManager<User> userManager,
         ILogger<CampAdminController> logger)
         : base(userManager)
     {
         _campService = campService;
-        _dbContext = dbContext;
         _logger = logger;
     }
 
@@ -63,14 +58,8 @@ public class CampAdminController : HumansControllerBase
                 .ToList();
 
             // Load camps with leads for the summary table
-            var campsWithLeads = await _dbContext.Camps
-                .Include(c => c.Seasons.Where(s => s.Year == settings.PublicYear))
-                .Include(c => c.Leads.Where(l => l.LeftAt == null))
-                    .ThenInclude(l => l.User)
-                .Where(c => c.Seasons.Any(s => s.Year == settings.PublicYear
-                    && (s.Status == CampSeasonStatus.Active || s.Status == CampSeasonStatus.Full)))
-                .OrderBy(c => c.Seasons.Where(s => s.Year == settings.PublicYear).Select(s => s.Name).FirstOrDefault())
-                .ToListAsync();
+            var activeStatuses = new[] { CampSeasonStatus.Active, CampSeasonStatus.Full };
+            var campsWithLeads = await _campService.GetCampsWithLeadsForYearAsync(settings.PublicYear, activeStatuses);
 
             var summaries = campsWithLeads.Select(c =>
             {
@@ -277,13 +266,7 @@ public class CampAdminController : HumansControllerBase
             var settings = await _campService.GetSettingsAsync();
             var year = settings.PublicYear;
 
-            var camps = await _dbContext.Camps
-                .Include(c => c.Seasons.Where(s => s.Year == year))
-                .Include(c => c.Leads.Where(l => l.LeftAt == null))
-                    .ThenInclude(l => l.User)
-                .Where(c => c.Seasons.Any(s => s.Year == year))
-                .OrderBy(c => c.Seasons.Where(s => s.Year == year).Select(s => s.Name).FirstOrDefault())
-                .ToListAsync();
+            var camps = await _campService.GetCampsWithLeadsForYearAsync(year);
 
             var csv = new StringBuilder();
             csv.AppendCsvRow(

--- a/src/Humans.Web/Controllers/EmailController.cs
+++ b/src/Humans.Web/Controllers/EmailController.cs
@@ -1,7 +1,6 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using Humans.Application.DTOs;
 using Humans.Application.Interfaces;
@@ -9,10 +8,8 @@ using Humans.Domain.Constants;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Humans.Infrastructure.Configuration;
-using Humans.Infrastructure.Data;
 using Humans.Web.Authorization;
 using Humans.Web.Models;
-using NodaTime;
 
 namespace Humans.Web.Controllers;
 
@@ -20,16 +17,16 @@ namespace Humans.Web.Controllers;
 [Route("Email")]
 public class EmailController : HumansControllerBase
 {
-    private readonly HumansDbContext _dbContext;
+    private readonly IEmailOutboxService _outboxService;
     private readonly ILogger<EmailController> _logger;
 
     public EmailController(
         UserManager<User> userManager,
-        HumansDbContext dbContext,
+        IEmailOutboxService outboxService,
         ILogger<EmailController> logger)
         : base(userManager)
     {
-        _dbContext = dbContext;
+        _outboxService = outboxService;
         _logger = logger;
     }
 
@@ -40,37 +37,18 @@ public class EmailController : HumansControllerBase
     }
 
     [HttpGet("EmailOutbox")]
-    public async Task<IActionResult> EmailOutbox([FromServices] IClock clock)
+    public async Task<IActionResult> EmailOutbox()
     {
-        var now = clock.GetCurrentInstant();
-        var cutoff24h = now - Duration.FromHours(24);
-
-        var totalCount = await _dbContext.EmailOutboxMessages.CountAsync();
-        var queuedCount = await _dbContext.EmailOutboxMessages
-            .CountAsync(m => m.Status == EmailOutboxStatus.Queued);
-        var sentLast24H = await _dbContext.EmailOutboxMessages
-            .CountAsync(m => m.Status == EmailOutboxStatus.Sent && m.SentAt > cutoff24h);
-        var failedCount = await _dbContext.EmailOutboxMessages
-            .CountAsync(m => m.Status == EmailOutboxStatus.Failed);
-
-        var pausedSetting = await _dbContext.SystemSettings
-            .FirstOrDefaultAsync(s => s.Key == "IsEmailSendingPaused");
-        var isPaused = string.Equals(pausedSetting?.Value, "true", StringComparison.OrdinalIgnoreCase);
-
-        var messages = await _dbContext.EmailOutboxMessages
-            .Include(m => m.User)
-            .OrderByDescending(m => m.CreatedAt)
-            .Take(50)
-            .ToListAsync();
+        var stats = await _outboxService.GetOutboxStatsAsync();
 
         var viewModel = new EmailOutboxViewModel
         {
-            TotalMessageCount = totalCount,
-            QueuedCount = queuedCount,
-            SentLast24HoursCount = sentLast24H,
-            FailedCount = failedCount,
-            IsPaused = isPaused,
-            Messages = messages,
+            TotalMessageCount = stats.TotalCount,
+            QueuedCount = stats.QueuedCount,
+            SentLast24HoursCount = stats.SentLast24HoursCount,
+            FailedCount = stats.FailedCount,
+            IsPaused = stats.IsPaused,
+            Messages = stats.RecentMessages.ToList(),
         };
 
         return View(viewModel);
@@ -80,7 +58,7 @@ public class EmailController : HumansControllerBase
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> PauseEmailSending()
     {
-        await SetEmailPausedAsync(true);
+        await _outboxService.SetEmailPausedAsync(true);
         _logger.LogInformation("Admin {AdminId} paused email sending", User.Identity?.Name);
         SetSuccess("Email sending paused.");
         return RedirectToAction(nameof(EmailOutbox));
@@ -90,7 +68,7 @@ public class EmailController : HumansControllerBase
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> ResumeEmailSending()
     {
-        await SetEmailPausedAsync(false);
+        await _outboxService.SetEmailPausedAsync(false);
         _logger.LogInformation("Admin {AdminId} resumed email sending", User.Identity?.Name);
         SetSuccess("Email sending resumed.");
         return RedirectToAction(nameof(EmailOutbox));
@@ -98,9 +76,9 @@ public class EmailController : HumansControllerBase
 
     [HttpPost("EmailOutbox/Retry/{id:guid}")]
     [ValidateAntiForgeryToken]
-    public async Task<IActionResult> RetryEmailOutboxMessage(Guid id, [FromServices] IEmailOutboxService outboxService)
+    public async Task<IActionResult> RetryEmailOutboxMessage(Guid id)
     {
-        var recipient = await outboxService.RetryMessageAsync(id);
+        var recipient = await _outboxService.RetryMessageAsync(id);
         if (recipient is null) return NotFound();
 
         SetSuccess($"Message to {recipient} queued for retry.");
@@ -109,9 +87,9 @@ public class EmailController : HumansControllerBase
 
     [HttpPost("EmailOutbox/Discard/{id:guid}")]
     [ValidateAntiForgeryToken]
-    public async Task<IActionResult> DiscardEmailOutboxMessage(Guid id, [FromServices] IEmailOutboxService outboxService)
+    public async Task<IActionResult> DiscardEmailOutboxMessage(Guid id)
     {
-        var recipient = await outboxService.DiscardMessageAsync(id);
+        var recipient = await _outboxService.DiscardMessageAsync(id);
         if (recipient is null) return NotFound();
 
         SetSuccess($"Message to {recipient} discarded.");
@@ -225,19 +203,4 @@ public class EmailController : HumansControllerBase
         return View(new EmailPreviewViewModel { Previews = previews, FromAddress = settings.FromAddress });
     }
 
-    private async Task SetEmailPausedAsync(bool paused)
-    {
-        var setting = await _dbContext.SystemSettings
-            .FirstOrDefaultAsync(s => s.Key == "IsEmailSendingPaused");
-        if (setting is null)
-        {
-            setting = new SystemSetting { Key = "IsEmailSendingPaused", Value = paused ? "true" : "false" };
-            _dbContext.SystemSettings.Add(setting);
-        }
-        else
-        {
-            setting.Value = paused ? "true" : "false";
-        }
-        await _dbContext.SaveChangesAsync();
-    }
 }

--- a/src/Humans.Web/Controllers/GuestController.cs
+++ b/src/Humans.Web/Controllers/GuestController.cs
@@ -263,7 +263,7 @@ public class GuestController : HumansControllerBase
                 .Select(s => new GuestTicketOrderSummary
                 {
                     BuyerName = s.BuyerName,
-                    PurchasedAt = s.PurchasedAt,
+                    PurchasedAt = s.PurchasedAt.ToDateTimeUtc(),
                     AttendeeCount = s.AttendeeCount,
                     TotalAmount = s.TotalAmount,
                     Currency = s.Currency,

--- a/src/Humans.Web/Controllers/GuestController.cs
+++ b/src/Humans.Web/Controllers/GuestController.cs
@@ -1,12 +1,10 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
 using Humans.Application.Extensions;
 using Humans.Application.Interfaces;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
-using Humans.Infrastructure.Data;
 using Humans.Web.Models;
 using NodaTime;
 
@@ -21,7 +19,7 @@ public class GuestController : HumansControllerBase
 {
     private readonly ICommunicationPreferenceService _commPrefService;
     private readonly IProfileService _profileService;
-    private readonly HumansDbContext _dbContext;
+    private readonly ITicketQueryService _ticketQueryService;
     private readonly IClock _clock;
     private readonly ILogger<GuestController> _logger;
 
@@ -36,14 +34,14 @@ public class GuestController : HumansControllerBase
         UserManager<User> userManager,
         ICommunicationPreferenceService commPrefService,
         IProfileService profileService,
-        HumansDbContext dbContext,
+        ITicketQueryService ticketQueryService,
         IClock clock,
         ILogger<GuestController> logger)
         : base(userManager)
     {
         _commPrefService = commPrefService;
         _profileService = profileService;
-        _dbContext = dbContext;
+        _ticketQueryService = ticketQueryService;
         _clock = clock;
         _logger = logger;
     }
@@ -253,31 +251,24 @@ public class GuestController : HumansControllerBase
         };
 
         // Ticket status: check for matched ticket orders and attendees
-        var hasTicketOrder = await _dbContext.TicketOrders
-            .AnyAsync(o => o.MatchedUserId == user.Id);
+        var hasTickets = await _ticketQueryService.HasAnyTicketAssociationAsync(user.Id);
 
-        var hasTicketAttendee = await _dbContext.TicketAttendees
-            .AnyAsync(a => a.MatchedUserId == user.Id);
-
-        if (hasTicketOrder || hasTicketAttendee)
+        if (hasTickets)
         {
             viewModel.HasTickets = true;
 
             // Get ticket details for display
-            var ticketOrders = await _dbContext.TicketOrders
-                .Where(o => o.MatchedUserId == user.Id)
-                .OrderByDescending(o => o.PurchasedAt)
-                .Select(o => new GuestTicketOrderSummary
+            var orderSummaries = await _ticketQueryService.GetUserTicketOrderSummariesAsync(user.Id);
+            viewModel.TicketOrders = orderSummaries
+                .Select(s => new GuestTicketOrderSummary
                 {
-                    BuyerName = o.BuyerName,
-                    PurchasedAt = o.PurchasedAt.ToDateTimeUtc(),
-                    AttendeeCount = o.Attendees.Count,
-                    TotalAmount = o.TotalAmount,
-                    Currency = o.Currency,
+                    BuyerName = s.BuyerName,
+                    PurchasedAt = s.PurchasedAt,
+                    AttendeeCount = s.AttendeeCount,
+                    TotalAmount = s.TotalAmount,
+                    Currency = s.Currency,
                 })
-                .ToListAsync();
-
-            viewModel.TicketOrders = ticketOrders;
+                .ToList();
         }
 
         // Deletion request status
@@ -311,8 +302,8 @@ public class GuestController : HumansControllerBase
         var (userId, _) = result.Value;
 
         // Verify user still exists
-        var exists = await _dbContext.Users.AnyAsync(u => u.Id == userId);
-        return exists ? userId : null;
+        var exists = await FindUserByIdAsync(userId);
+        return exists is not null ? userId : null;
     }
 
     private async Task<CommunicationPreferencesViewModel> BuildCommunicationPreferencesViewModelAsync(Guid userId)
@@ -320,8 +311,7 @@ public class GuestController : HumansControllerBase
         var prefs = await _commPrefService.GetPreferencesAsync(userId);
         var prefsByCategory = prefs.ToDictionary(p => p.Category);
 
-        var hasTicketOrder = await _dbContext.TicketOrders
-            .AnyAsync(o => o.MatchedUserId == userId);
+        var hasTicketOrder = await _ticketQueryService.HasAnyTicketAssociationAsync(userId);
 
         var categories = new List<CategoryPreferenceItem>();
 

--- a/src/Humans.Web/Controllers/GuestController.cs
+++ b/src/Humans.Web/Controllers/GuestController.cs
@@ -251,7 +251,7 @@ public class GuestController : HumansControllerBase
         };
 
         // Ticket status: check for matched ticket orders and attendees
-        var hasTickets = await _ticketQueryService.HasAnyTicketAssociationAsync(user.Id);
+        var hasTickets = await _ticketQueryService.HasTicketAttendeeMatchAsync(user.Id);
 
         if (hasTickets)
         {
@@ -311,7 +311,7 @@ public class GuestController : HumansControllerBase
         var prefs = await _commPrefService.GetPreferencesAsync(userId);
         var prefsByCategory = prefs.ToDictionary(p => p.Category);
 
-        var hasTicketOrder = await _ticketQueryService.HasAnyTicketAssociationAsync(userId);
+        var hasTicketOrder = await _ticketQueryService.HasTicketAttendeeMatchAsync(userId);
 
         var categories = new List<CategoryPreferenceItem>();
 
@@ -332,7 +332,7 @@ public class GuestController : HumansControllerBase
                 AlertEnabled = pref?.InboxEnabled ?? true,
                 EmailEditable = !isAlwaysOn && !isTicketingLocked,
                 AlertEditable = !isAlwaysOn && !isTicketingLocked,
-                Note = isTicketingLocked ? "Locked — you have a ticket order for this year" : null,
+                Note = isTicketingLocked ? "Locked — you have a ticket for this year" : null,
             });
         }
 

--- a/src/Humans.Web/Controllers/ProfileController.cs
+++ b/src/Humans.Web/Controllers/ProfileController.cs
@@ -46,6 +46,7 @@ public class ProfileController : HumansControllerBase
     private readonly ILogger<ProfileController> _logger;
     private readonly IStringLocalizer<SharedResource> _localizer;
     private readonly HumansDbContext _dbContext;
+    private readonly ITicketQueryService _ticketQueryService;
     private readonly IMemoryCache _cache;
     private readonly IClock _clock;
 
@@ -90,6 +91,7 @@ public class ProfileController : HumansControllerBase
         ILogger<ProfileController> logger,
         IStringLocalizer<SharedResource> localizer,
         HumansDbContext dbContext,
+        ITicketQueryService ticketQueryService,
         IMemoryCache cache,
         IClock clock)
         : base(userManager)
@@ -111,6 +113,7 @@ public class ProfileController : HumansControllerBase
         _logger = logger;
         _localizer = localizer;
         _dbContext = dbContext;
+        _ticketQueryService = ticketQueryService;
         _cache = cache;
         _clock = clock;
     }
@@ -1646,9 +1649,8 @@ public class ProfileController : HumansControllerBase
         var prefs = await _commPrefService.GetPreferencesAsync(userId);
         var prefsByCategory = prefs.ToDictionary(p => p.Category);
 
-        // Check if user has a matched ticket order (locks ticketing preference)
-        var hasTicketOrder = await _dbContext.TicketOrders
-            .AnyAsync(o => o.MatchedUserId == userId);
+        // Check if user is a matched ticket attendee (locks ticketing preference)
+        var hasTicketOrder = await _ticketQueryService.HasTicketAttendeeMatchAsync(userId);
 
         var categories = new List<CategoryPreferenceItem>();
 
@@ -1669,7 +1671,7 @@ public class ProfileController : HumansControllerBase
                 AlertEnabled = pref?.InboxEnabled ?? true,
                 EmailEditable = !isAlwaysOn && !isTicketingLocked,
                 AlertEditable = !isAlwaysOn && !isTicketingLocked,
-                Note = isTicketingLocked ? "Locked — you have a ticket order for this year" : null,
+                Note = isTicketingLocked ? "Locked — you have a ticket for this year" : null,
             });
         }
 

--- a/src/Humans.Web/ViewComponents/AuditLogViewComponent.cs
+++ b/src/Humans.Web/ViewComponents/AuditLogViewComponent.cs
@@ -1,24 +1,19 @@
 using Humans.Application.Interfaces;
 using Humans.Domain.Enums;
-using Humans.Infrastructure.Data;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
 
 namespace Humans.Web.ViewComponents;
 
 public class AuditLogViewComponent : ViewComponent
 {
     private readonly IAuditLogService _auditLogService;
-    private readonly HumansDbContext _dbContext;
     private readonly ILogger<AuditLogViewComponent> _logger;
 
     public AuditLogViewComponent(
         IAuditLogService auditLogService,
-        HumansDbContext dbContext,
         ILogger<AuditLogViewComponent> logger)
     {
         _auditLogService = auditLogService;
-        _dbContext = dbContext;
         _logger = logger;
     }
 
@@ -54,7 +49,6 @@ public class AuditLogViewComponent : ViewComponent
                 entityType, entityId, userId, actionList, limit);
 
             // Batch-load display names for all referenced user IDs
-            // (actors, subjects via EntityId for User/Profile types, and RelatedEntityId for User types)
             var userIds = model.Entries
                 .SelectMany(e => new Guid?[]
                 {
@@ -67,13 +61,7 @@ public class AuditLogViewComponent : ViewComponent
                 .Distinct()
                 .ToList();
 
-            if (userIds.Count > 0)
-            {
-                model.UserDisplayNames = await _dbContext.Users
-                    .AsNoTracking()
-                    .Where(u => userIds.Contains(u.Id))
-                    .ToDictionaryAsync(u => u.Id, u => u.DisplayName);
-            }
+            model.UserDisplayNames = await _auditLogService.GetUserDisplayNamesAsync(userIds);
 
             // Batch-load team names for entries that reference teams
             var teamIds = model.Entries
@@ -87,13 +75,7 @@ public class AuditLogViewComponent : ViewComponent
                 .Distinct()
                 .ToList();
 
-            if (teamIds.Count > 0)
-            {
-                model.TeamNames = await _dbContext.Teams
-                    .AsNoTracking()
-                    .Where(t => teamIds.Contains(t.Id))
-                    .ToDictionaryAsync(t => t.Id, t => (t.Name, t.Slug));
-            }
+            model.TeamNames = await _auditLogService.GetTeamNamesAsync(teamIds);
         }
         catch (Exception ex)
         {

--- a/src/Humans.Web/ViewComponents/MyGoogleResourcesViewComponent.cs
+++ b/src/Humans.Web/ViewComponents/MyGoogleResourcesViewComponent.cs
@@ -1,24 +1,23 @@
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
+using Humans.Application.Interfaces;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
-using Humans.Infrastructure.Data;
 
 namespace Humans.Web.ViewComponents;
 
 public class MyGoogleResourcesViewComponent : ViewComponent
 {
-    private readonly HumansDbContext _dbContext;
+    private readonly ITeamService _teamService;
     private readonly UserManager<User> _userManager;
     private readonly ILogger<MyGoogleResourcesViewComponent> _logger;
 
     public MyGoogleResourcesViewComponent(
-        HumansDbContext dbContext,
+        ITeamService teamService,
         UserManager<User> userManager,
         ILogger<MyGoogleResourcesViewComponent> logger)
     {
-        _dbContext = dbContext;
+        _teamService = teamService;
         _userManager = userManager;
         _logger = logger;
     }
@@ -31,45 +30,25 @@ public class MyGoogleResourcesViewComponent : ViewComponent
             if (user is null)
                 return Content(string.Empty);
 
-            // Get the user's active team memberships with their Google resources
-            var teamResources = await _dbContext.TeamMembers
-                .AsNoTracking()
-                .Where(tm => tm.UserId == user.Id && tm.LeftAt == null)
-                .Select(tm => new
-                {
-                    TeamName = tm.Team.Name,
-                    TeamSlug = tm.Team.Slug,
-                    Resources = tm.Team.GoogleResources
-                        .Where(r => r.IsActive)
-                        .Select(r => new MyGoogleResourceItem
-                        {
-                            Name = r.Name,
-                            ResourceType = r.ResourceType,
-                            Url = r.Url
-                        })
-                        .ToList()
-                })
-                .Where(t => t.Resources.Count > 0)
-                .OrderBy(t => t.TeamName)
-                .ToListAsync();
+            var resources = await _teamService.GetUserTeamGoogleResourcesAsync(user.Id);
 
-            if (teamResources.Count == 0)
+            if (resources.Count == 0)
                 return Content(string.Empty);
 
-            var model = new MyGoogleResourcesViewModel();
-
-            foreach (var team in teamResources)
+            var model = new MyGoogleResourcesViewModel
             {
-                foreach (var resource in team.Resources)
+                Resources = resources.Select(r => new MyGoogleResourceWithTeam
                 {
-                    model.Resources.Add(new MyGoogleResourceWithTeam
+                    TeamName = r.TeamName,
+                    TeamSlug = r.TeamSlug,
+                    Resource = new MyGoogleResourceItem
                     {
-                        TeamName = team.TeamName,
-                        TeamSlug = team.TeamSlug,
-                        Resource = resource
-                    });
-                }
-            }
+                        Name = r.ResourceName,
+                        ResourceType = r.ResourceType,
+                        Url = r.Url
+                    }
+                }).ToList()
+            };
 
             return View(model);
         }

--- a/src/Humans.Web/ViewComponents/NavBadgesViewComponent.cs
+++ b/src/Humans.Web/ViewComponents/NavBadgesViewComponent.cs
@@ -1,25 +1,22 @@
 using System.Security.Claims;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 using Humans.Application;
 using Humans.Application.Interfaces;
-using Humans.Domain.Enums;
-using Humans.Infrastructure.Data;
 
 namespace Humans.Web.ViewComponents;
 
 public class NavBadgesViewComponent : ViewComponent
 {
-    private readonly HumansDbContext _dbContext;
+    private readonly IOnboardingService _onboardingService;
     private readonly IFeedbackService _feedbackService;
     private readonly IMemoryCache _cache;
 
     private static readonly TimeSpan CacheDuration = TimeSpan.FromMinutes(2);
 
-    public NavBadgesViewComponent(HumansDbContext dbContext, IFeedbackService feedbackService, IMemoryCache cache)
+    public NavBadgesViewComponent(IOnboardingService onboardingService, IFeedbackService feedbackService, IMemoryCache cache)
     {
-        _dbContext = dbContext;
+        _onboardingService = onboardingService;
         _feedbackService = feedbackService;
         _cache = cache;
     }
@@ -30,9 +27,7 @@ public class NavBadgesViewComponent : ViewComponent
         {
             entry.AbsoluteExpirationRelativeToNow = CacheDuration;
 
-            var reviewCount = await _dbContext.Profiles
-                .CountAsync(p => !p.IsApproved && p.RejectedAt == null);
-
+            var reviewCount = await _onboardingService.GetPendingReviewCountAsync();
             var feedbackCount = await _feedbackService.GetActionableCountAsync();
 
             return (Review: reviewCount, Feedback: feedbackCount);
@@ -66,9 +61,7 @@ public class NavBadgesViewComponent : ViewComponent
         {
             entry.AbsoluteExpirationRelativeToNow = CacheDuration;
 
-            return await _dbContext.Applications
-                .CountAsync(a => a.Status == ApplicationStatus.Submitted
-                    && !a.BoardVotes.Any(v => v.BoardMemberUserId == currentUserId));
+            return await _onboardingService.GetUnvotedApplicationCountAsync(currentUserId);
         });
     }
 }

--- a/src/Humans.Web/ViewComponents/NotificationBellViewComponent.cs
+++ b/src/Humans.Web/ViewComponents/NotificationBellViewComponent.cs
@@ -1,9 +1,7 @@
 using Humans.Application;
-using Humans.Domain.Enums;
-using Humans.Infrastructure.Data;
+using Humans.Application.Interfaces;
 using Humans.Web.Models;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 using System.Security.Claims;
 
@@ -11,14 +9,14 @@ namespace Humans.Web.ViewComponents;
 
 public class NotificationBellViewComponent : ViewComponent
 {
-    private readonly HumansDbContext _dbContext;
+    private readonly INotificationInboxService _notificationInboxService;
     private readonly IMemoryCache _cache;
 
     private static readonly TimeSpan CacheDuration = TimeSpan.FromMinutes(2);
 
-    public NotificationBellViewComponent(HumansDbContext dbContext, IMemoryCache cache)
+    public NotificationBellViewComponent(INotificationInboxService notificationInboxService, IMemoryCache cache)
     {
-        _dbContext = dbContext;
+        _notificationInboxService = notificationInboxService;
         _cache = cache;
     }
 
@@ -34,17 +32,7 @@ public class NotificationBellViewComponent : ViewComponent
         {
             entry.AbsoluteExpirationRelativeToNow = CacheDuration;
 
-            var actionableCount = await _dbContext.NotificationRecipients
-                .CountAsync(nr => nr.UserId == userId.Value &&
-                                  nr.ReadAt == null &&
-                                  nr.Notification.ResolvedAt == null &&
-                                  nr.Notification.Class == NotificationClass.Actionable);
-
-            var informationalCount = await _dbContext.NotificationRecipients
-                .CountAsync(nr => nr.UserId == userId.Value &&
-                                  nr.ReadAt == null &&
-                                  nr.Notification.ResolvedAt == null &&
-                                  nr.Notification.Class == NotificationClass.Informational);
+            var (actionableCount, informationalCount) = await _notificationInboxService.GetUnreadBadgeCountsAsync(userId.Value);
 
             return new NotificationBadgeViewModel
             {

--- a/tests/Humans.Application.Tests/Services/AccountProvisioningServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/AccountProvisioningServiceTests.cs
@@ -61,6 +61,12 @@ file sealed class StubAuditLog : IAuditLogService
             Array.Empty<AuditLogEntry>(), 0, 0,
             new Dictionary<Guid, string>(),
             new Dictionary<Guid, (string Name, string Slug)>()));
+
+    public Task<Dictionary<Guid, string>> GetUserDisplayNamesAsync(IReadOnlyList<Guid> userIds, CancellationToken ct = default) =>
+        Task.FromResult(new Dictionary<Guid, string>());
+
+    public Task<Dictionary<Guid, (string Name, string Slug)>> GetTeamNamesAsync(IReadOnlyList<Guid> teamIds, CancellationToken ct = default) =>
+        Task.FromResult(new Dictionary<Guid, (string Name, string Slug)>());
 }
 
 public class AccountProvisioningServiceTests : IDisposable

--- a/tests/Humans.Application.Tests/Services/AccountProvisioningServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/AccountProvisioningServiceTests.cs
@@ -54,6 +54,13 @@ file sealed class StubAuditLog : IAuditLogService
         int limit = 20,
         CancellationToken ct = default) =>
         Task.FromResult<IReadOnlyList<AuditLogEntry>>(Array.Empty<AuditLogEntry>());
+
+    public Task<AuditLogPageResult> GetAuditLogPageAsync(
+        string? actionFilter, int page, int pageSize, CancellationToken ct = default) =>
+        Task.FromResult(new AuditLogPageResult(
+            Array.Empty<AuditLogEntry>(), 0, 0,
+            new Dictionary<Guid, string>(),
+            new Dictionary<Guid, (string Name, string Slug)>()));
 }
 
 public class AccountProvisioningServiceTests : IDisposable

--- a/tests/Humans.Application.Tests/Services/CommunicationPreferenceServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/CommunicationPreferenceServiceTests.cs
@@ -55,6 +55,13 @@ file sealed class StubAuditLogService : IAuditLogService
         int limit = 20,
         CancellationToken ct = default) =>
         Task.FromResult<IReadOnlyList<AuditLogEntry>>(Array.Empty<AuditLogEntry>());
+
+    public Task<AuditLogPageResult> GetAuditLogPageAsync(
+        string? actionFilter, int page, int pageSize, CancellationToken ct = default) =>
+        Task.FromResult(new AuditLogPageResult(
+            Array.Empty<AuditLogEntry>(), 0, 0,
+            new Dictionary<Guid, string>(),
+            new Dictionary<Guid, (string Name, string Slug)>()));
 }
 
 public class CommunicationPreferenceServiceTests : IDisposable

--- a/tests/Humans.Application.Tests/Services/CommunicationPreferenceServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/CommunicationPreferenceServiceTests.cs
@@ -62,6 +62,12 @@ file sealed class StubAuditLogService : IAuditLogService
             Array.Empty<AuditLogEntry>(), 0, 0,
             new Dictionary<Guid, string>(),
             new Dictionary<Guid, (string Name, string Slug)>()));
+
+    public Task<Dictionary<Guid, string>> GetUserDisplayNamesAsync(IReadOnlyList<Guid> userIds, CancellationToken ct = default) =>
+        Task.FromResult(new Dictionary<Guid, string>());
+
+    public Task<Dictionary<Guid, (string Name, string Slug)>> GetTeamNamesAsync(IReadOnlyList<Guid> teamIds, CancellationToken ct = default) =>
+        Task.FromResult(new Dictionary<Guid, (string Name, string Slug)>());
 }
 
 public class CommunicationPreferenceServiceTests : IDisposable


### PR DESCRIPTION
## Summary
Systematic removal of direct `HumansDbContext` injection from the Web layer, moving all queries behind Application-layer service interfaces.

**Controllers cleaned (6):**
- EmailController → `IEmailOutboxService` (outbox stats, pause/resume)
- BoardController → `IAuditLogService` (audit log with display names)
- CampAdminController → `ICampService` (camps with leads query)
- GuestController → `ITicketQueryService` (ticket associations, order summaries)
- UnsubscribeController → `UserManager<User>` (replaced raw DbContext user lookups)
- BudgetController → `IBudgetService` (line item by ID)

**ViewComponents cleaned (4):**
- NavBadgesViewComponent → `IOnboardingService` (pending review/unvoted counts)
- AuditLogViewComponent → `IAuditLogService` (batch display name lookups)
- NotificationBellViewComponent → `INotificationInboxService` (unread badge counts)
- MyGoogleResourcesViewComponent → `ITeamService` (user team Google resources)

**Other:**
- New `SystemSettingKeys` constants class replacing magic string `"IsEmailSendingPaused"`

All 874 tests passing, zero build warnings.

## Test plan
- [ ] Email admin page loads (outbox stats, pause/resume toggle)
- [ ] Board audit log displays with correct user/team names
- [ ] Camp admin table and CSV export work with status filter
- [ ] Guest dashboard ticket widget displays correctly
- [ ] Unsubscribe flow works for all notification types
- [ ] Budget line item edit/delete works
- [ ] Nav badges show correct pending counts
- [ ] Notification bell shows unread counts
- [ ] Google resources panel shows on profile
- [ ] `dotnet build && dotnet test` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)