### PR TITLE
Fix shift badge inconsistency and email transliteration

### DIFF
--- a/src/Humans.Infrastructure/Humans.Infrastructure.csproj
+++ b/src/Humans.Infrastructure/Humans.Infrastructure.csproj
@@ -1,6 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Humans.Application.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Humans.Application\Humans.Application.csproj" />
   </ItemGroup>
 

--- a/src/Humans.Infrastructure/Services/EmailProvisioningService.cs
+++ b/src/Humans.Infrastructure/Services/EmailProvisioningService.cs
@@ -163,7 +163,8 @@ public class EmailProvisioningService : IEmailProvisioningService
     /// <summary>
     /// Transliterates an email prefix to ASCII by applying German-specific mappings
     /// (ü→ue, ö→oe, ä→ae, ß→ss) first, then stripping remaining diacritics via
-    /// Unicode NFD decomposition. Returns null if the result still contains non-ASCII.
+    /// Unicode NFD decomposition. Returns null if the result contains non-ASCII or
+    /// invalid email local-part characters; returns empty string if input was blank.
     /// </summary>
     internal static string? SanitizeEmailPrefix(string prefix)
     {
@@ -202,10 +203,10 @@ public class EmailProvisioningService : IEmailProvisioningService
 
         var ascii = result.ToString().ToLowerInvariant();
 
-        // Validate result is ASCII-only (printable, no whitespace except what's valid in email local part)
+        // Validate result contains only valid ASCII email local-part characters
         foreach (var ch in ascii)
         {
-            if (ch > 127)
+            if (ch > 127 || ch <= ' ' || ch == 0x7F)
                 return null;
         }
 

--- a/src/Humans.Infrastructure/Services/EmailProvisioningService.cs
+++ b/src/Humans.Infrastructure/Services/EmailProvisioningService.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+using System.Text;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -57,7 +59,11 @@ public class EmailProvisioningService : IEmailProvisioningService
         if (user is null)
             return new EmailProvisioningResult(false, ErrorMessage: "User not found.");
 
-        var fullEmail = $"{emailPrefix.Trim().ToLowerInvariant()}@nobodies.team";
+        var sanitizedPrefix = SanitizeEmailPrefix(emailPrefix);
+        if (sanitizedPrefix is null)
+            return new EmailProvisioningResult(false, ErrorMessage: "Email prefix contains characters that cannot be transliterated to ASCII. Please choose a different prefix.");
+
+        var fullEmail = $"{sanitizedPrefix}@nobodies.team";
 
         try
         {
@@ -152,5 +158,57 @@ public class EmailProvisioningService : IEmailProvisioningService
             _logger.LogError(ex, "Failed to provision @nobodies.team account {Email} for user {UserId}", fullEmail, userId);
             return new EmailProvisioningResult(false, fullEmail, ErrorMessage: $"Failed to provision {fullEmail}. Check logs for details.");
         }
+    }
+
+    /// <summary>
+    /// Transliterates an email prefix to ASCII by applying German-specific mappings
+    /// (ü→ue, ö→oe, ä→ae, ß→ss) first, then stripping remaining diacritics via
+    /// Unicode NFD decomposition. Returns null if the result still contains non-ASCII.
+    /// </summary>
+    internal static string? SanitizeEmailPrefix(string prefix)
+    {
+        var trimmed = prefix.Trim();
+
+        // German-specific mappings (must be applied before NFD stripping)
+        var sb = new StringBuilder(trimmed.Length);
+        foreach (var ch in trimmed)
+        {
+            var mapped = ch switch
+            {
+                'ü' => "ue",
+                'Ü' => "ue",
+                'ö' => "oe",
+                'Ö' => "oe",
+                'ä' => "ae",
+                'Ä' => "ae",
+                'ß' => "ss",
+                _ => null
+            };
+
+            if (mapped is not null)
+                sb.Append(mapped);
+            else
+                sb.Append(ch);
+        }
+
+        // NFD decomposition: split base characters from combining marks, then strip marks
+        var normalized = sb.ToString().Normalize(NormalizationForm.FormD);
+        var result = new StringBuilder(normalized.Length);
+        foreach (var ch in normalized)
+        {
+            if (CharUnicodeInfo.GetUnicodeCategory(ch) != UnicodeCategory.NonSpacingMark)
+                result.Append(ch);
+        }
+
+        var ascii = result.ToString().ToLowerInvariant();
+
+        // Validate result is ASCII-only (printable, no whitespace except what's valid in email local part)
+        foreach (var ch in ascii)
+        {
+            if (ch > 127)
+                return null;
+        }
+
+        return ascii;
     }
 }

--- a/src/Humans.Infrastructure/Services/EmailProvisioningService.cs
+++ b/src/Humans.Infrastructure/Services/EmailProvisioningService.cs
@@ -60,7 +60,7 @@ public class EmailProvisioningService : IEmailProvisioningService
             return new EmailProvisioningResult(false, ErrorMessage: "User not found.");
 
         var sanitizedPrefix = SanitizeEmailPrefix(emailPrefix);
-        if (sanitizedPrefix is null)
+        if (string.IsNullOrEmpty(sanitizedPrefix))
             return new EmailProvisioningResult(false, ErrorMessage: "Email prefix contains characters that cannot be transliterated to ASCII. Please choose a different prefix.");
 
         var fullEmail = $"{sanitizedPrefix}@nobodies.team";

--- a/src/Humans.Web/Resources/SharedResource.ca.resx
+++ b/src/Humans.Web/Resources/SharedResource.ca.resx
@@ -1587,6 +1587,7 @@
   <data name="Shifts_GeneralAvailability" xml:space="preserve"><value>Disponibilitat general</value></data>
   <data name="Shifts_AvailabilityHelp" xml:space="preserve"><value>Marca els dies que estàs disponible per ajudar. Els coordinadors poden veure qui està disponible en assignar torns.</value></data>
   <data name="Shifts_SaveAvailability" xml:space="preserve"><value>Desar disponibilitat</value></data>
+  <data name="Shifts_SlotsFull" xml:space="preserve"><value>Alguns dies encara necessiten ajuda, però totes les places disponibles estan completes. Torna més tard per si s'obren places.</value></data>
 
   <data name="ShiftDash_Title" xml:space="preserve"><value>Tauler de torns</value></data>
   <data name="ShiftDash_ShiftsCount" xml:space="preserve"><value>{0} torns</value><comment>{0} = count</comment></data>

--- a/src/Humans.Web/Resources/SharedResource.de.resx
+++ b/src/Humans.Web/Resources/SharedResource.de.resx
@@ -1585,6 +1585,7 @@
   <data name="Shifts_GeneralAvailability" xml:space="preserve"><value>Allgemeine Verfügbarkeit</value></data>
   <data name="Shifts_AvailabilityHelp" xml:space="preserve"><value>Markiere, an welchen Tagen du helfen kannst. Koordinatoren können sehen, wer verfügbar ist.</value></data>
   <data name="Shifts_SaveAvailability" xml:space="preserve"><value>Verfügbarkeit speichern</value></data>
+  <data name="Shifts_SlotsFull" xml:space="preserve"><value>Einige Tage brauchen noch Hilfe, aber alle verfügbaren Plätze sind derzeit belegt. Schau später noch einmal vorbei, falls Plätze frei werden.</value></data>
 
   <data name="ShiftDash_Title" xml:space="preserve"><value>Schicht-Dashboard</value></data>
   <data name="ShiftDash_ShiftsCount" xml:space="preserve"><value>{0} Schichten</value><comment>{0} = count</comment></data>

--- a/src/Humans.Web/Resources/SharedResource.es.resx
+++ b/src/Humans.Web/Resources/SharedResource.es.resx
@@ -1587,6 +1587,7 @@
   <data name="Shifts_GeneralAvailability" xml:space="preserve"><value>Disponibilidad general</value></data>
   <data name="Shifts_AvailabilityHelp" xml:space="preserve"><value>Marca los días que estás disponible para ayudar. Los coordinadores pueden ver quién está disponible al asignar turnos.</value></data>
   <data name="Shifts_SaveAvailability" xml:space="preserve"><value>Guardar disponibilidad</value></data>
+  <data name="Shifts_SlotsFull" xml:space="preserve"><value>Algunos días aún necesitan ayuda, pero todos los turnos disponibles están completos. Vuelve más tarde por si se abren plazas.</value></data>
 
   <data name="ShiftDash_Title" xml:space="preserve"><value>Panel de turnos</value></data>
   <data name="ShiftDash_ShiftsCount" xml:space="preserve"><value>{0} turnos</value><comment>{0} = count</comment></data>

--- a/src/Humans.Web/Resources/SharedResource.fr.resx
+++ b/src/Humans.Web/Resources/SharedResource.fr.resx
@@ -1585,6 +1585,7 @@
   <data name="Shifts_GeneralAvailability" xml:space="preserve"><value>Disponibilité générale</value></data>
   <data name="Shifts_AvailabilityHelp" xml:space="preserve"><value>Indiquez les jours où vous êtes disponible. Les coordinateurs peuvent voir qui est disponible lors de l'attribution des quarts.</value></data>
   <data name="Shifts_SaveAvailability" xml:space="preserve"><value>Enregistrer la disponibilité</value></data>
+  <data name="Shifts_SlotsFull" xml:space="preserve"><value>Certains jours ont encore besoin d'aide, mais tous les créneaux disponibles sont complets. Reviens plus tard au cas où des places se libèrent.</value></data>
 
   <data name="ShiftDash_Title" xml:space="preserve"><value>Tableau de bord des quarts</value></data>
   <data name="ShiftDash_ShiftsCount" xml:space="preserve"><value>{0} quarts</value><comment>{0} = count</comment></data>

--- a/src/Humans.Web/Resources/SharedResource.it.resx
+++ b/src/Humans.Web/Resources/SharedResource.it.resx
@@ -1585,6 +1585,7 @@
   <data name="Shifts_GeneralAvailability" xml:space="preserve"><value>Disponibilità generale</value></data>
   <data name="Shifts_AvailabilityHelp" xml:space="preserve"><value>Segna i giorni in cui sei disponibile. I coordinatori possono vedere chi è disponibile quando assegnano i turni.</value></data>
   <data name="Shifts_SaveAvailability" xml:space="preserve"><value>Salva disponibilità</value></data>
+  <data name="Shifts_SlotsFull" xml:space="preserve"><value>Alcuni giorni hanno ancora bisogno di aiuto, ma tutti i posti disponibili sono al completo. Riprova più tardi nel caso si liberino dei posti.</value></data>
 
   <data name="ShiftDash_Title" xml:space="preserve"><value>Dashboard turni</value></data>
   <data name="ShiftDash_ShiftsCount" xml:space="preserve"><value>{0} turni</value><comment>{0} = count</comment></data>

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -1605,6 +1605,7 @@
   <data name="Shifts_GeneralAvailability" xml:space="preserve"><value>General Availability</value></data>
   <data name="Shifts_AvailabilityHelp" xml:space="preserve"><value>Mark which days you're available to help. Coordinators can see who's in the pool when assigning shifts.</value></data>
   <data name="Shifts_SaveAvailability" xml:space="preserve"><value>Save Availability</value></data>
+  <data name="Shifts_SlotsFull" xml:space="preserve"><value>Some days still need help but all available slots are currently full. Check back later in case spots open up.</value></data>
 
   <data name="ShiftDash_Title" xml:space="preserve"><value>Shift Dashboard</value></data>
   <data name="ShiftDash_ShiftsCount" xml:space="preserve"><value>{0} shifts</value><comment>{0} = count</comment></data>

--- a/src/Humans.Web/Views/Shifts/Index.cshtml
+++ b/src/Humans.Web/Views/Shifts/Index.cshtml
@@ -308,6 +308,13 @@
                                     </div>
                                 </form>
                             }
+                            else if (allDayShifts.Any(s => s.ConfirmedCount < s.Shift.MinVolunteers))
+                            {
+                                <div class="alert alert-info py-2 mb-3">
+                                    <i class="fa-solid fa-circle-info me-1"></i>
+                                    Some days still need help but all available slots are currently full. Check back later in case spots open up.
+                                </div>
+                            }
                             var dateRanges = new List<List<Humans.Web.Models.ShiftDisplayItem>>();
                             List<Humans.Web.Models.ShiftDisplayItem>? currentRange = null;
                             foreach (var s in allDayShifts)

--- a/src/Humans.Web/Views/Shifts/Index.cshtml
+++ b/src/Humans.Web/Views/Shifts/Index.cshtml
@@ -308,11 +308,11 @@
                                     </div>
                                 </form>
                             }
-                            else if (allDayShifts.Any(s => s.ConfirmedCount < s.Shift.MinVolunteers))
+                            else if (allDayShifts.All(s => s.RemainingSlots <= 0) && allDayShifts.Any(s => s.ConfirmedCount < s.Shift.MinVolunteers))
                             {
                                 <div class="alert alert-info py-2 mb-3">
                                     <i class="fa-solid fa-circle-info me-1"></i>
-                                    Some days still need help but all available slots are currently full. Check back later in case spots open up.
+                                    @Localizer["Shifts_SlotsFull"]
                                 </div>
                             }
                             var dateRanges = new List<List<Humans.Web.Models.ShiftDisplayItem>>();

--- a/tests/Humans.Application.Tests/Services/EmailProvisioningServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/EmailProvisioningServiceTests.cs
@@ -1,0 +1,75 @@
+using AwesomeAssertions;
+using Humans.Infrastructure.Services;
+using Xunit;
+
+namespace Humans.Application.Tests.Services;
+
+public class EmailProvisioningServiceTests
+{
+    [Theory]
+    [InlineData("mueller", "mueller")]
+    [InlineData("müller", "mueller")]
+    [InlineData("Müller", "mueller")]
+    [InlineData("schön", "schoen")]
+    [InlineData("Ärzte", "aerzte")]
+    [InlineData("straße", "strasse")]
+    public void SanitizeEmailPrefix_TransliteratesGermanCharacters(string input, string expected)
+    {
+        EmailProvisioningService.SanitizeEmailPrefix(input).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("garcía", "garcia")]
+    [InlineData("café", "cafe")]
+    [InlineData("naïve", "naive")]
+    [InlineData("résumé", "resume")]
+    [InlineData("señor", "senor")]
+    public void SanitizeEmailPrefix_StripsAccentsViaNfdDecomposition(string input, string expected)
+    {
+        EmailProvisioningService.SanitizeEmailPrefix(input).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("müller.garcía", "mueller.garcia")]
+    [InlineData("Böhm-López", "boehm-lopez")]
+    public void SanitizeEmailPrefix_HandlesMixedGermanAndAccented(string input, string expected)
+    {
+        EmailProvisioningService.SanitizeEmailPrefix(input).Should().Be(expected);
+    }
+
+    [Fact]
+    public void SanitizeEmailPrefix_ReturnsNullForNonTransliterableCharacters()
+    {
+        EmailProvisioningService.SanitizeEmailPrefix("田中").Should().BeNull();
+    }
+
+    [Fact]
+    public void SanitizeEmailPrefix_ReturnsEmptyForWhitespaceOnly()
+    {
+        EmailProvisioningService.SanitizeEmailPrefix("   ").Should().BeEmpty();
+    }
+
+    [Fact]
+    public void SanitizeEmailPrefix_ReturnsNullForEmbeddedSpaces()
+    {
+        EmailProvisioningService.SanitizeEmailPrefix("jo hn").Should().BeNull();
+    }
+
+    [Fact]
+    public void SanitizeEmailPrefix_TrimsLeadingAndTrailingWhitespace()
+    {
+        EmailProvisioningService.SanitizeEmailPrefix("  alice  ").Should().Be("alice");
+    }
+
+    [Fact]
+    public void SanitizeEmailPrefix_ConvertsToLowerCase()
+    {
+        EmailProvisioningService.SanitizeEmailPrefix("Alice").Should().Be("alice");
+    }
+
+    [Fact]
+    public void SanitizeEmailPrefix_ReturnsNullForEmbeddedControlCharacters()
+    {
+        EmailProvisioningService.SanitizeEmailPrefix("te\tst").Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary
- When shift days show "needs help" badge but all slots are full, display an informational message instead of hiding the form with no explanation
- Add ASCII transliteration for email provisioning prefixes: German-specific mappings (ue/oe/ae/ss) and Unicode NFD decomposition for other diacritics
- Return clear validation error if non-ASCII characters remain after transliteration

## Issues
- Closes #478
- Closes #479

## Test plan
- [ ] Navigate to Shifts page with a rota where days are below minimum staffing but all slots are at capacity — verify info message appears
- [ ] Navigate to Shifts page with available slots — verify signup form appears as before
- [ ] Provision an email with German umlauts (e.g., "müller") — verify it becomes "mueller@nobodies.team"
- [ ] Provision an email with other diacritics (e.g., "garcía") — verify it becomes "garcia@nobodies.team"
- [ ] Attempt to provision an email with characters that cannot be transliterated — verify clear error message without stack trace

🤖 Generated with [Claude Code](https://claude.com/claude-code)