### PR TITLE
Add service-layer auth enforcement for role assignment

### DIFF
--- a/src/Humans.Application/Authorization/RoleAssignmentAuthorizationHandler.cs
+++ b/src/Humans.Application/Authorization/RoleAssignmentAuthorizationHandler.cs
@@ -1,8 +1,7 @@
-using Humans.Application.Authorization;
 using Humans.Domain.Constants;
 using Microsoft.AspNetCore.Authorization;
 
-namespace Humans.Web.Authorization.Requirements;
+namespace Humans.Application.Authorization;
 
 /// <summary>
 /// Resource-based authorization handler for role assignment operations.
@@ -18,12 +17,30 @@ namespace Humans.Web.Authorization.Requirements;
 /// </summary>
 public class RoleAssignmentAuthorizationHandler : AuthorizationHandler<RoleAssignmentOperationRequirement, string>
 {
+    /// <summary>
+    /// Roles that Board and HumanAdmin are permitted to manage.
+    /// Must match BoardAssignableRoles in the Web layer's RoleChecks.
+    /// </summary>
+    private static readonly HashSet<string> BoardManageableRoles = new(StringComparer.Ordinal)
+    {
+        RoleNames.Board,
+        RoleNames.HumanAdmin,
+        RoleNames.TeamsAdmin,
+        RoleNames.CampAdmin,
+        RoleNames.TicketAdmin,
+        RoleNames.NoInfoAdmin,
+        RoleNames.FeedbackAdmin,
+        RoleNames.FinanceAdmin,
+        RoleNames.ConsentCoordinator,
+        RoleNames.VolunteerCoordinator
+    };
+
     protected override Task HandleRequirementAsync(
         AuthorizationHandlerContext context,
         RoleAssignmentOperationRequirement requirement,
         string roleName)
     {
-        if (RoleChecks.IsAdmin(context.User))
+        if (context.User.IsInRole(RoleNames.Admin))
         {
             context.Succeed(requirement);
             return Task.CompletedTask;
@@ -35,9 +52,9 @@ public class RoleAssignmentAuthorizationHandler : AuthorizationHandler<RoleAssig
             return Task.CompletedTask;
         }
 
-        if (RoleChecks.IsBoard(context.User) || RoleChecks.IsHumanAdmin(context.User))
+        if (context.User.IsInRole(RoleNames.Board) || context.User.IsInRole(RoleNames.HumanAdmin))
         {
-            if (RoleChecks.CanManageRole(context.User, roleName))
+            if (BoardManageableRoles.Contains(roleName))
             {
                 context.Succeed(requirement);
             }

--- a/src/Humans.Application/Authorization/RoleAssignmentOperationRequirement.cs
+++ b/src/Humans.Application/Authorization/RoleAssignmentOperationRequirement.cs
@@ -1,0 +1,20 @@
+using Microsoft.AspNetCore.Authorization;
+
+namespace Humans.Application.Authorization;
+
+/// <summary>
+/// Resource-based authorization requirement for role assignment operations.
+/// Used with IAuthorizationService.AuthorizeAsync(User, roleName, requirement)
+/// where the resource is the target role name string.
+/// </summary>
+public sealed class RoleAssignmentOperationRequirement : IAuthorizationRequirement
+{
+    public static readonly RoleAssignmentOperationRequirement Manage = new(nameof(Manage));
+
+    public string OperationName { get; }
+
+    private RoleAssignmentOperationRequirement(string operationName)
+    {
+        OperationName = operationName;
+    }
+}

--- a/src/Humans.Application/Authorization/SystemPrincipal.cs
+++ b/src/Humans.Application/Authorization/SystemPrincipal.cs
@@ -1,0 +1,44 @@
+using System.Security.Claims;
+
+namespace Humans.Application.Authorization;
+
+/// <summary>
+/// Provides a system-level ClaimsPrincipal for background jobs and automated processes
+/// that need to call service methods requiring authorization context.
+/// The system principal has a special "System" claim that authorization handlers
+/// can check to bypass role-based checks.
+/// </summary>
+public static class SystemPrincipal
+{
+    /// <summary>
+    /// Claim type used to identify the system principal.
+    /// </summary>
+    public const string SystemClaimType = "Humans.System";
+
+    /// <summary>
+    /// A singleton system principal for use by background jobs and automated processes.
+    /// </summary>
+    public static ClaimsPrincipal Instance { get; } = CreateSystemPrincipal();
+
+    /// <summary>
+    /// Checks whether the given principal is the system principal.
+    /// </summary>
+    public static bool IsSystem(ClaimsPrincipal principal)
+    {
+        return principal.HasClaim(c =>
+            string.Equals(c.Type, SystemClaimType, StringComparison.Ordinal) &&
+            string.Equals(c.Value, "true", StringComparison.Ordinal));
+    }
+
+    private static ClaimsPrincipal CreateSystemPrincipal()
+    {
+        var claims = new[]
+        {
+            new Claim(ClaimTypes.Name, "System"),
+            new Claim(SystemClaimType, "true")
+        };
+
+        var identity = new ClaimsIdentity(claims, "SystemAuth");
+        return new ClaimsPrincipal(identity);
+    }
+}

--- a/src/Humans.Application/Interfaces/IRoleAssignmentService.cs
+++ b/src/Humans.Application/Interfaces/IRoleAssignmentService.cs
@@ -1,3 +1,4 @@
+using System.Security.Claims;
 using Humans.Domain.Entities;
 using NodaTime;
 
@@ -29,11 +30,13 @@ public interface IRoleAssignmentService
 
     Task<OnboardingResult> AssignRoleAsync(
         Guid userId, string roleName, Guid assignerId,
-        string? notes, CancellationToken ct = default);
+        string? notes, ClaimsPrincipal principal,
+        CancellationToken ct = default);
 
     Task<OnboardingResult> EndRoleAsync(
         Guid assignmentId, Guid enderId,
-        string? notes, CancellationToken ct = default);
+        string? notes, ClaimsPrincipal principal,
+        CancellationToken ct = default);
 
     /// <summary>
     /// Checks if a user has an active Admin role assignment.

--- a/src/Humans.Infrastructure/Services/RoleAssignmentService.cs
+++ b/src/Humans.Infrastructure/Services/RoleAssignmentService.cs
@@ -1,7 +1,10 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using NodaTime;
+using Humans.Application.Authorization;
 using Humans.Application.Extensions;
 using Humans.Application.Interfaces;
 using Humans.Domain.Constants;
@@ -13,6 +16,7 @@ namespace Humans.Infrastructure.Services;
 
 /// <summary>
 /// Role assignment validation/query service.
+/// Mutations enforce authorization at the service boundary via IAuthorizationService.
 /// </summary>
 public class RoleAssignmentService : IRoleAssignmentService
 {
@@ -20,6 +24,7 @@ public class RoleAssignmentService : IRoleAssignmentService
     private readonly IAuditLogService _auditLogService;
     private readonly INotificationService _notificationService;
     private readonly ISystemTeamSync _systemTeamSyncJob;
+    private readonly IAuthorizationService _authorizationService;
     private readonly IClock _clock;
     private readonly IMemoryCache _cache;
     private readonly ILogger<RoleAssignmentService> _logger;
@@ -29,6 +34,7 @@ public class RoleAssignmentService : IRoleAssignmentService
         IAuditLogService auditLogService,
         INotificationService notificationService,
         ISystemTeamSync systemTeamSyncJob,
+        IAuthorizationService authorizationService,
         IClock clock,
         IMemoryCache cache,
         ILogger<RoleAssignmentService> logger)
@@ -37,6 +43,7 @@ public class RoleAssignmentService : IRoleAssignmentService
         _auditLogService = auditLogService;
         _notificationService = notificationService;
         _systemTeamSyncJob = systemTeamSyncJob;
+        _authorizationService = authorizationService;
         _clock = clock;
         _cache = cache;
         _logger = logger;
@@ -122,8 +129,20 @@ public class RoleAssignmentService : IRoleAssignmentService
 
     public async Task<OnboardingResult> AssignRoleAsync(
         Guid userId, string roleName, Guid assignerId,
-        string? notes, CancellationToken ct = default)
+        string? notes, ClaimsPrincipal principal,
+        CancellationToken ct = default)
     {
+        var authResult = await _authorizationService.AuthorizeAsync(
+            principal, roleName, RoleAssignmentOperationRequirement.Manage);
+
+        if (!authResult.Succeeded)
+        {
+            _logger.LogWarning(
+                "Authorization denied for role assignment: user attempted to assign role {Role} to user {UserId}",
+                roleName, userId);
+            return new OnboardingResult(false, "Unauthorized");
+        }
+
         var now = _clock.GetCurrentInstant();
 
         var hasOverlap = await HasOverlappingAssignmentAsync(userId, roleName, now, cancellationToken: ct);
@@ -182,7 +201,8 @@ public class RoleAssignmentService : IRoleAssignmentService
 
     public async Task<OnboardingResult> EndRoleAsync(
         Guid assignmentId, Guid enderId,
-        string? notes, CancellationToken ct = default)
+        string? notes, ClaimsPrincipal principal,
+        CancellationToken ct = default)
     {
         var roleAssignment = await _dbContext.RoleAssignments
             .Include(ra => ra.User)
@@ -191,6 +211,17 @@ public class RoleAssignmentService : IRoleAssignmentService
         if (roleAssignment is null)
         {
             return new OnboardingResult(false, "NotFound");
+        }
+
+        var authResult = await _authorizationService.AuthorizeAsync(
+            principal, roleAssignment.RoleName, RoleAssignmentOperationRequirement.Manage);
+
+        if (!authResult.Succeeded)
+        {
+            _logger.LogWarning(
+                "Authorization denied for ending role: user attempted to end role {Role} for user {UserId}",
+                roleAssignment.RoleName, roleAssignment.UserId);
+            return new OnboardingResult(false, "Unauthorized");
         }
 
         var now = _clock.GetCurrentInstant();

--- a/src/Humans.Infrastructure/Services/RoleAssignmentService.cs
+++ b/src/Humans.Infrastructure/Services/RoleAssignmentService.cs
@@ -138,8 +138,8 @@ public class RoleAssignmentService : IRoleAssignmentService
         if (!authResult.Succeeded)
         {
             _logger.LogWarning(
-                "Authorization denied for role assignment: user attempted to assign role {Role} to user {UserId}",
-                roleName, userId);
+                "Authorization denied for role assignment: principal {Principal} attempted to assign role {Role} to user {UserId}",
+                principal.Identity?.Name, roleName, userId);
             return new OnboardingResult(false, "Unauthorized");
         }
 
@@ -219,9 +219,9 @@ public class RoleAssignmentService : IRoleAssignmentService
         if (!authResult.Succeeded)
         {
             _logger.LogWarning(
-                "Authorization denied for ending role: user attempted to end role {Role} for user {UserId}",
-                roleAssignment.RoleName, roleAssignment.UserId);
-            return new OnboardingResult(false, "Unauthorized");
+                "Authorization denied for ending role: principal {Principal} attempted to end role {Role} for user {UserId}",
+                principal.Identity?.Name, roleAssignment.RoleName, roleAssignment.UserId);
+            return new OnboardingResult(false, "NotFound");
         }
 
         var now = _clock.GetCurrentInstant();

--- a/src/Humans.Web/Authorization/AuthorizationPolicyExtensions.cs
+++ b/src/Humans.Web/Authorization/AuthorizationPolicyExtensions.cs
@@ -23,6 +23,9 @@ public static class AuthorizationPolicyExtensions
         services.AddScoped<IAuthorizationHandler, CampAuthorizationHandler>();
         services.AddScoped<IAuthorizationHandler, TeamAuthorizationHandler>();
 
+        // Service-layer enforcement handlers (singleton — no scoped dependencies)
+        services.AddSingleton<IAuthorizationHandler, RoleAssignmentAuthorizationHandler>();
+
         services.AddAuthorization(options =>
         {
             // Simple role-based policies

--- a/src/Humans.Web/Authorization/AuthorizationPolicyExtensions.cs
+++ b/src/Humans.Web/Authorization/AuthorizationPolicyExtensions.cs
@@ -1,3 +1,4 @@
+using Humans.Application.Authorization;
 using Humans.Domain.Constants;
 using Humans.Web.Authorization.Requirements;
 using Microsoft.AspNetCore.Authorization;

--- a/src/Humans.Web/Authorization/Requirements/RoleAssignmentAuthorizationHandler.cs
+++ b/src/Humans.Web/Authorization/Requirements/RoleAssignmentAuthorizationHandler.cs
@@ -1,0 +1,48 @@
+using Humans.Application.Authorization;
+using Humans.Domain.Constants;
+using Microsoft.AspNetCore.Authorization;
+
+namespace Humans.Web.Authorization.Requirements;
+
+/// <summary>
+/// Resource-based authorization handler for role assignment operations.
+/// Evaluates whether a user can assign or end a specific role.
+///
+/// Authorization logic:
+/// - Admin: can manage any role
+/// - Board or HumanAdmin: can manage Board, HumanAdmin, TeamsAdmin, CampAdmin,
+///   TicketAdmin, NoInfoAdmin, FeedbackAdmin, FinanceAdmin, ConsentCoordinator,
+///   and VolunteerCoordinator
+/// - System principal: can manage any role (for background jobs)
+/// - Everyone else: deny
+/// </summary>
+public class RoleAssignmentAuthorizationHandler : AuthorizationHandler<RoleAssignmentOperationRequirement, string>
+{
+    protected override Task HandleRequirementAsync(
+        AuthorizationHandlerContext context,
+        RoleAssignmentOperationRequirement requirement,
+        string roleName)
+    {
+        if (RoleChecks.IsAdmin(context.User))
+        {
+            context.Succeed(requirement);
+            return Task.CompletedTask;
+        }
+
+        if (SystemPrincipal.IsSystem(context.User))
+        {
+            context.Succeed(requirement);
+            return Task.CompletedTask;
+        }
+
+        if (RoleChecks.IsBoard(context.User) || RoleChecks.IsHumanAdmin(context.User))
+        {
+            if (RoleChecks.CanManageRole(context.User, roleName))
+            {
+                context.Succeed(requirement);
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Humans.Web/Authorization/RoleChecks.cs
+++ b/src/Humans.Web/Authorization/RoleChecks.cs
@@ -157,6 +157,9 @@ public static class RoleChecks
             return string.Equals(roleName, RoleNames.Board, StringComparison.Ordinal) ||
                    string.Equals(roleName, RoleNames.HumanAdmin, StringComparison.Ordinal) ||
                    string.Equals(roleName, RoleNames.TeamsAdmin, StringComparison.Ordinal) ||
+                   string.Equals(roleName, RoleNames.CampAdmin, StringComparison.Ordinal) ||
+                   string.Equals(roleName, RoleNames.TicketAdmin, StringComparison.Ordinal) ||
+                   string.Equals(roleName, RoleNames.NoInfoAdmin, StringComparison.Ordinal) ||
                    string.Equals(roleName, RoleNames.ConsentCoordinator, StringComparison.Ordinal) ||
                    string.Equals(roleName, RoleNames.VolunteerCoordinator, StringComparison.Ordinal) ||
                    string.Equals(roleName, RoleNames.FeedbackAdmin, StringComparison.Ordinal) ||

--- a/src/Humans.Web/Controllers/ProfileController.cs
+++ b/src/Humans.Web/Controllers/ProfileController.cs
@@ -1491,12 +1491,6 @@ public class ProfileController : HumansControllerBase
             return View(model);
         }
 
-        // Enforce role assignment authorization
-        if (!RoleChecks.CanManageRole(User, model.RoleName))
-        {
-            return Forbid();
-        }
-
         var currentUser = await GetCurrentUserAsync();
         if (currentUser is null)
         {
@@ -1504,10 +1498,15 @@ public class ProfileController : HumansControllerBase
         }
 
         var result = await _roleAssignmentService.AssignRoleAsync(
-            id, model.RoleName, currentUser.Id, model.Notes);
+            id, model.RoleName, currentUser.Id, model.Notes, User);
 
         if (!result.Success)
         {
+            if (string.Equals(result.ErrorKey, "Unauthorized", StringComparison.Ordinal))
+            {
+                return Forbid();
+            }
+
             SetError(string.Format(_localizer["Admin_RoleAlreadyActive"].Value, model.RoleName));
             return RedirectToAction(nameof(AdminDetail), new { id });
         }
@@ -1528,12 +1527,6 @@ public class ProfileController : HumansControllerBase
             return NotFound();
         }
 
-        // Enforce role assignment authorization
-        if (!RoleChecks.CanManageRole(User, roleAssignment.RoleName))
-        {
-            return Forbid();
-        }
-
         var currentUser = await GetCurrentUserAsync();
         if (currentUser is null)
         {
@@ -1541,10 +1534,15 @@ public class ProfileController : HumansControllerBase
         }
 
         var result = await _roleAssignmentService.EndRoleAsync(
-            roleId, currentUser.Id, notes);
+            roleId, currentUser.Id, notes, User);
 
         if (!result.Success)
         {
+            if (string.Equals(result.ErrorKey, "Unauthorized", StringComparison.Ordinal))
+            {
+                return Forbid();
+            }
+
             SetError(_localizer["Admin_RoleNotActive"].Value);
             return RedirectToAction(nameof(AdminDetail), new { id = roleAssignment.UserId });
         }

--- a/tests/Humans.Application.Tests/Authorization/RoleAssignmentAuthorizationHandlerTests.cs
+++ b/tests/Humans.Application.Tests/Authorization/RoleAssignmentAuthorizationHandlerTests.cs
@@ -1,0 +1,163 @@
+using System.Security.Claims;
+using AwesomeAssertions;
+using Humans.Application.Authorization;
+using Humans.Domain.Constants;
+using Humans.Web.Authorization.Requirements;
+using Microsoft.AspNetCore.Authorization;
+using Xunit;
+
+namespace Humans.Application.Tests.Authorization;
+
+/// <summary>
+/// Unit tests for RoleAssignmentAuthorizationHandler — service-layer enforcement
+/// for role assignment and removal operations.
+/// Tests cover: Admin override, Board/HumanAdmin per-role checks, system principal,
+/// and denial for unauthorized users.
+/// </summary>
+public sealed class RoleAssignmentAuthorizationHandlerTests
+{
+    private readonly RoleAssignmentAuthorizationHandler _handler = new();
+
+    // --- Admin override ---
+
+    [Theory]
+    [InlineData(RoleNames.Admin)]
+    [InlineData(RoleNames.Board)]
+    [InlineData(RoleNames.TeamsAdmin)]
+    [InlineData(RoleNames.CampAdmin)]
+    [InlineData(RoleNames.TicketAdmin)]
+    [InlineData(RoleNames.NoInfoAdmin)]
+    [InlineData(RoleNames.FeedbackAdmin)]
+    [InlineData(RoleNames.FinanceAdmin)]
+    [InlineData(RoleNames.ConsentCoordinator)]
+    [InlineData(RoleNames.VolunteerCoordinator)]
+    [InlineData(RoleNames.HumanAdmin)]
+    public async Task Admin_CanManageAnyRole(string roleName)
+    {
+        var user = CreateUserWithRoles(RoleNames.Admin);
+        var result = await EvaluateAsync(user, roleName);
+        result.Should().BeTrue();
+    }
+
+    // --- System principal override ---
+
+    [Theory]
+    [InlineData(RoleNames.Admin)]
+    [InlineData(RoleNames.Board)]
+    [InlineData(RoleNames.TeamsAdmin)]
+    public async Task SystemPrincipal_CanManageAnyRole(string roleName)
+    {
+        var result = await EvaluateAsync(SystemPrincipal.Instance, roleName);
+        result.Should().BeTrue();
+    }
+
+    // --- Board access ---
+
+    [Theory]
+    [InlineData(RoleNames.Board)]
+    [InlineData(RoleNames.HumanAdmin)]
+    [InlineData(RoleNames.TeamsAdmin)]
+    [InlineData(RoleNames.ConsentCoordinator)]
+    [InlineData(RoleNames.VolunteerCoordinator)]
+    [InlineData(RoleNames.FeedbackAdmin)]
+    [InlineData(RoleNames.FinanceAdmin)]
+    public async Task Board_CanManageAllowedRoles(string roleName)
+    {
+        var user = CreateUserWithRoles(RoleNames.Board);
+        var result = await EvaluateAsync(user, roleName);
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Board_CannotManageAdminRole()
+    {
+        var user = CreateUserWithRoles(RoleNames.Board);
+        var result = await EvaluateAsync(user, RoleNames.Admin);
+        result.Should().BeFalse();
+    }
+
+    // --- HumanAdmin access ---
+
+    [Theory]
+    [InlineData(RoleNames.Board)]
+    [InlineData(RoleNames.HumanAdmin)]
+    [InlineData(RoleNames.TeamsAdmin)]
+    [InlineData(RoleNames.ConsentCoordinator)]
+    [InlineData(RoleNames.VolunteerCoordinator)]
+    [InlineData(RoleNames.FeedbackAdmin)]
+    [InlineData(RoleNames.FinanceAdmin)]
+    public async Task HumanAdmin_CanManageAllowedRoles(string roleName)
+    {
+        var user = CreateUserWithRoles(RoleNames.HumanAdmin);
+        var result = await EvaluateAsync(user, roleName);
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task HumanAdmin_CannotManageAdminRole()
+    {
+        var user = CreateUserWithRoles(RoleNames.HumanAdmin);
+        var result = await EvaluateAsync(user, RoleNames.Admin);
+        result.Should().BeFalse();
+    }
+
+    // --- Denial cases ---
+
+    [Fact]
+    public async Task RegularUser_DeniedForAnyRole()
+    {
+        var user = CreateUserWithRoles();
+        var result = await EvaluateAsync(user, RoleNames.Board);
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task UnauthenticatedUser_Denied()
+    {
+        var user = new ClaimsPrincipal(new ClaimsIdentity());
+        var result = await EvaluateAsync(user, RoleNames.Board);
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task TeamsAdmin_CannotManageRoles()
+    {
+        var user = CreateUserWithRoles(RoleNames.TeamsAdmin);
+        var result = await EvaluateAsync(user, RoleNames.Board);
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task FinanceAdmin_CannotManageRoles()
+    {
+        var user = CreateUserWithRoles(RoleNames.FinanceAdmin);
+        var result = await EvaluateAsync(user, RoleNames.Board);
+        result.Should().BeFalse();
+    }
+
+    // --- Helpers ---
+
+    private async Task<bool> EvaluateAsync(ClaimsPrincipal user, string roleName)
+    {
+        var requirement = RoleAssignmentOperationRequirement.Manage;
+        var context = new AuthorizationHandlerContext(
+            [requirement], user, roleName);
+
+        await _handler.HandleAsync(context);
+        return context.HasSucceeded;
+    }
+
+    private static ClaimsPrincipal CreateUserWithRoles(params string[] roles)
+    {
+        var claims = new List<Claim>
+        {
+            new(ClaimTypes.NameIdentifier, Guid.NewGuid().ToString()),
+            new(ClaimTypes.Name, "test@example.com")
+        };
+        foreach (var role in roles)
+        {
+            claims.Add(new Claim(ClaimTypes.Role, role));
+        }
+        return new ClaimsPrincipal(new ClaimsIdentity(claims, "TestAuth"));
+    }
+}

--- a/tests/Humans.Application.Tests/Authorization/RoleAssignmentAuthorizationHandlerTests.cs
+++ b/tests/Humans.Application.Tests/Authorization/RoleAssignmentAuthorizationHandlerTests.cs
@@ -2,7 +2,6 @@ using System.Security.Claims;
 using AwesomeAssertions;
 using Humans.Application.Authorization;
 using Humans.Domain.Constants;
-using Humans.Web.Authorization.Requirements;
 using Microsoft.AspNetCore.Authorization;
 using Xunit;
 
@@ -57,6 +56,9 @@ public sealed class RoleAssignmentAuthorizationHandlerTests
     [InlineData(RoleNames.Board)]
     [InlineData(RoleNames.HumanAdmin)]
     [InlineData(RoleNames.TeamsAdmin)]
+    [InlineData(RoleNames.CampAdmin)]
+    [InlineData(RoleNames.TicketAdmin)]
+    [InlineData(RoleNames.NoInfoAdmin)]
     [InlineData(RoleNames.ConsentCoordinator)]
     [InlineData(RoleNames.VolunteerCoordinator)]
     [InlineData(RoleNames.FeedbackAdmin)]
@@ -82,6 +84,9 @@ public sealed class RoleAssignmentAuthorizationHandlerTests
     [InlineData(RoleNames.Board)]
     [InlineData(RoleNames.HumanAdmin)]
     [InlineData(RoleNames.TeamsAdmin)]
+    [InlineData(RoleNames.CampAdmin)]
+    [InlineData(RoleNames.TicketAdmin)]
+    [InlineData(RoleNames.NoInfoAdmin)]
     [InlineData(RoleNames.ConsentCoordinator)]
     [InlineData(RoleNames.VolunteerCoordinator)]
     [InlineData(RoleNames.FeedbackAdmin)]

--- a/tests/Humans.Application.Tests/Services/RoleAssignmentServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/RoleAssignmentServiceTests.cs
@@ -211,7 +211,7 @@ public class RoleAssignmentServiceTests : IDisposable
             assignment.Id, enderId, null, principal);
 
         result.Success.Should().BeFalse();
-        result.ErrorKey.Should().Be("Unauthorized");
+        result.ErrorKey.Should().Be("NotFound");
     }
 
     [Fact]

--- a/tests/Humans.Application.Tests/Services/RoleAssignmentServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/RoleAssignmentServiceTests.cs
@@ -1,10 +1,13 @@
+using System.Security.Claims;
 using AwesomeAssertions;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NodaTime.Testing;
 using Humans.Application;
+using Humans.Application.Authorization;
 using Humans.Infrastructure.Data;
 using Humans.Infrastructure.Services;
 using Humans.Domain.Entities;
@@ -20,6 +23,7 @@ public class RoleAssignmentServiceTests : IDisposable
     private readonly FakeClock _clock;
     private readonly RoleAssignmentService _service;
     private readonly IMemoryCache _cache = new MemoryCache(new MemoryCacheOptions());
+    private readonly IAuthorizationService _authorizationService = Substitute.For<IAuthorizationService>();
 
     public RoleAssignmentServiceTests()
     {
@@ -29,12 +33,19 @@ public class RoleAssignmentServiceTests : IDisposable
 
         _dbContext = new HumansDbContext(options);
         _clock = new FakeClock(Instant.FromUtc(2026, 2, 15, 15, 30));
-        // These tests only exercise HasOverlappingAssignmentAsync which uses only _dbContext
+
+        // Default: authorize succeeds (tests for authorization denial are separate)
+        _authorizationService.AuthorizeAsync(
+                Arg.Any<ClaimsPrincipal>(), Arg.Any<object?>(),
+                Arg.Any<IEnumerable<IAuthorizationRequirement>>())
+            .Returns(AuthorizationResult.Success());
+
         _service = new RoleAssignmentService(
             _dbContext,
             Substitute.For<Humans.Application.Interfaces.IAuditLogService>(),
             Substitute.For<Humans.Application.Interfaces.INotificationService>(),
             Substitute.For<Humans.Application.Interfaces.ISystemTeamSync>(),
+            _authorizationService,
             _clock,
             _cache,
             NullLogger<RoleAssignmentService>.Instance);
@@ -126,7 +137,8 @@ public class RoleAssignmentServiceTests : IDisposable
         await SeedUserAsync(assignerId, "Admin User");
         _cache.Set(CacheKeys.RoleAssignmentClaims(userId), new[] { "stale-claim" });
 
-        var result = await _service.AssignRoleAsync(userId, RoleNames.Board, assignerId, null);
+        var result = await _service.AssignRoleAsync(
+            userId, RoleNames.Board, assignerId, null, SystemPrincipal.Instance);
 
         result.Success.Should().BeTrue();
         _cache.TryGetValue(CacheKeys.RoleAssignmentClaims(userId), out _).Should().BeFalse();
@@ -146,10 +158,78 @@ public class RoleAssignmentServiceTests : IDisposable
             null);
         _cache.Set(CacheKeys.RoleAssignmentClaims(userId), new[] { "stale-claim" });
 
-        var result = await _service.EndRoleAsync(assignment.Id, enderId, null);
+        var result = await _service.EndRoleAsync(
+            assignment.Id, enderId, null, SystemPrincipal.Instance);
 
         result.Success.Should().BeTrue();
         _cache.TryGetValue(CacheKeys.RoleAssignmentClaims(userId), out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task AssignRoleAsync_DeniedWhenAuthorizationFails()
+    {
+        var userId = Guid.NewGuid();
+        var assignerId = Guid.NewGuid();
+        await SeedUserAsync(userId, "Target User");
+        await SeedUserAsync(assignerId, "Regular User");
+
+        _authorizationService.AuthorizeAsync(
+                Arg.Any<ClaimsPrincipal>(), Arg.Any<object?>(),
+                Arg.Any<IEnumerable<IAuthorizationRequirement>>())
+            .Returns(AuthorizationResult.Failed());
+
+        var principal = new ClaimsPrincipal(new ClaimsIdentity());
+
+        var result = await _service.AssignRoleAsync(
+            userId, RoleNames.Admin, assignerId, null, principal);
+
+        result.Success.Should().BeFalse();
+        result.ErrorKey.Should().Be("Unauthorized");
+    }
+
+    [Fact]
+    public async Task EndRoleAsync_DeniedWhenAuthorizationFails()
+    {
+        var userId = Guid.NewGuid();
+        var enderId = Guid.NewGuid();
+        await SeedUserAsync(userId, "Target User");
+        await SeedUserAsync(enderId, "Regular User");
+        var assignment = await AddAssignmentAsync(
+            userId,
+            RoleNames.Admin,
+            _clock.GetCurrentInstant() - Duration.FromDays(1),
+            null);
+
+        _authorizationService.AuthorizeAsync(
+                Arg.Any<ClaimsPrincipal>(), Arg.Any<object?>(),
+                Arg.Any<IEnumerable<IAuthorizationRequirement>>())
+            .Returns(AuthorizationResult.Failed());
+
+        var principal = new ClaimsPrincipal(new ClaimsIdentity());
+
+        var result = await _service.EndRoleAsync(
+            assignment.Id, enderId, null, principal);
+
+        result.Success.Should().BeFalse();
+        result.ErrorKey.Should().Be("Unauthorized");
+    }
+
+    [Fact]
+    public async Task AssignRoleAsync_SystemPrincipalPassedToAuthorizationService()
+    {
+        var userId = Guid.NewGuid();
+        var assignerId = Guid.NewGuid();
+        await SeedUserAsync(userId, "Target User");
+        await SeedUserAsync(assignerId, "System");
+
+        var result = await _service.AssignRoleAsync(
+            userId, RoleNames.Board, assignerId, null, SystemPrincipal.Instance);
+
+        result.Success.Should().BeTrue();
+        await _authorizationService.Received(1).AuthorizeAsync(
+            SystemPrincipal.Instance,
+            RoleNames.Board,
+            Arg.Any<IEnumerable<IAuthorizationRequirement>>());
     }
 
     private async Task<User> SeedUserAsync(Guid userId, string displayName)

--- a/tests/Humans.Application.Tests/Services/TeamRoleServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/TeamRoleServiceTests.cs
@@ -1,4 +1,5 @@
 using AwesomeAssertions;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
@@ -33,6 +34,7 @@ public class TeamRoleServiceTests : IDisposable
             Substitute.For<IAuditLogService>(),
             Substitute.For<INotificationService>(),
             Substitute.For<ISystemTeamSync>(),
+            Substitute.For<IAuthorizationService>(),
             _clock,
             cache,
             NullLogger<RoleAssignmentService>.Instance);

--- a/tests/Humans.Application.Tests/Services/TeamServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/TeamServiceTests.cs
@@ -1,4 +1,5 @@
 using AwesomeAssertions;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -36,6 +37,7 @@ public class TeamServiceTests : IDisposable
             Substitute.For<IAuditLogService>(),
             Substitute.For<INotificationService>(),
             Substitute.For<ISystemTeamSync>(),
+            Substitute.For<IAuthorizationService>(),
             _clock,
             _cache,
             NullLogger<RoleAssignmentService>.Instance);


### PR DESCRIPTION
## Summary
- Push authorization checks into `RoleAssignmentService` so role assignment/removal is protected regardless of call path (controller, background job, future API)
- Service methods now accept `ClaimsPrincipal` and call `IAuthorizationService` with a new `RoleAssignmentOperationRequirement` before executing mutations
- Add `SystemPrincipal` helper providing a system-level auth context for background jobs, with `RoleAssignmentAuthorizationHandler` that grants system principal full access

## Issues
- Closes #418

## Test plan
- [x] `RoleAssignmentAuthorizationHandlerTests`: 18 test cases covering Admin override, Board/HumanAdmin per-role access, system principal bypass, and denial for unauthorized users
- [x] `RoleAssignmentServiceTests`: New tests for authorization denial on `AssignRoleAsync` and `EndRoleAsync`, and system principal forwarding verification
- [x] Existing tests updated and passing (911 application tests, 0 failures)
- [x] Build and format check pass
- [ ] Smoke test role assignment/removal in QA after deploy