### PR TITLE
Add notifications API endpoint for external consumers

### DIFF
--- a/src/Humans.Web/Controllers/NotificationApiController.cs
+++ b/src/Humans.Web/Controllers/NotificationApiController.cs
@@ -1,0 +1,137 @@
+using System.Security.Claims;
+using Humans.Application.Interfaces;
+using Humans.Infrastructure.Data;
+using Humans.Web.Filters;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using NodaTime;
+using NodaTime.Text;
+
+namespace Humans.Web.Controllers;
+
+[ApiController]
+[Route("api/notifications")]
+[ServiceFilter(typeof(NotificationApiKeyAuthFilter))]
+public class NotificationApiController : ControllerBase
+{
+    private readonly INotificationInboxService _inboxService;
+    private readonly INotificationMeterProvider _meterProvider;
+    private readonly HumansDbContext _dbContext;
+    private readonly IClock _clock;
+    private readonly NotificationApiSettings _settings;
+    private readonly ILogger<NotificationApiController> _logger;
+
+    public NotificationApiController(
+        INotificationInboxService inboxService,
+        INotificationMeterProvider meterProvider,
+        HumansDbContext dbContext,
+        IClock clock,
+        IOptions<NotificationApiSettings> settings,
+        ILogger<NotificationApiController> logger)
+    {
+        _inboxService = inboxService;
+        _meterProvider = meterProvider;
+        _dbContext = dbContext;
+        _clock = clock;
+        _settings = settings.Value;
+        _logger = logger;
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> Get(
+        [FromQuery] string? since = null,
+        CancellationToken ct = default)
+    {
+        if (!Guid.TryParse(_settings.UserId, out var userId))
+        {
+            _logger.LogError("NotificationApi:UserId is not configured or invalid");
+            return StatusCode(503, new { error = "UserId not configured" });
+        }
+
+        try
+        {
+            // Build inbox query — unread tab, no filter, no search
+            var inbox = await _inboxService.GetInboxAsync(userId, search: null, filter: "", tab: "unread", ct);
+
+            var notifications = inbox.NeedsAttention
+                .Concat(inbox.Informational)
+                .AsEnumerable();
+
+            // Apply since filter if provided
+            if (since is not null)
+            {
+                var parseResult = LocalDatePattern.Iso.Parse(since);
+                if (!parseResult.Success)
+                {
+                    return BadRequest(new { error = "Invalid 'since' format. Use yyyy-MM-dd." });
+                }
+
+                var sinceInstant = parseResult.Value.AtStartOfDayInZone(DateTimeZone.Utc).ToInstant();
+                var sinceUtc = sinceInstant.ToDateTimeUtc();
+                notifications = notifications.Where(n => n.CreatedAt >= sinceUtc);
+            }
+
+            var notificationList = notifications.Select(n => new
+            {
+                Date = n.CreatedAt,
+                Source = n.Source.ToString(),
+                Subject = n.Title,
+                Link = n.ActionUrl,
+                Priority = n.Priority.ToString().ToLowerInvariant(),
+                Class = n.Class.ToString().ToLowerInvariant(),
+                Unread = !n.IsRead,
+            }).ToList();
+
+            // Build meters using a ClaimsPrincipal for the configured user
+            var principal = await BuildClaimsPrincipalAsync(userId, ct);
+            var meters = await _meterProvider.GetMetersForUserAsync(principal, ct);
+
+            var meterList = meters.Select(m => new
+            {
+                Label = m.Title,
+                m.Count,
+                Link = m.ActionUrl,
+            }).ToList();
+
+            return Ok(new
+            {
+                Notifications = notificationList,
+                Meters = meterList,
+            });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to retrieve notifications for API");
+            return StatusCode(500, new { error = "Failed to retrieve notifications" });
+        }
+    }
+
+    private async Task<ClaimsPrincipal> BuildClaimsPrincipalAsync(Guid userId, CancellationToken ct)
+    {
+        var now = _clock.GetCurrentInstant();
+
+        var roles = await _dbContext.RoleAssignments
+            .AsNoTracking()
+            .Where(ra =>
+                ra.UserId == userId &&
+                ra.ValidFrom <= now &&
+                (ra.ValidTo == null || ra.ValidTo > now))
+            .Select(ra => ra.RoleName)
+            .Distinct()
+            .ToListAsync(ct);
+
+        var claims = new List<Claim>
+        {
+            new(ClaimTypes.NameIdentifier, userId.ToString()),
+        };
+
+        foreach (var role in roles)
+        {
+            claims.Add(new Claim(ClaimTypes.Role, role));
+        }
+
+        var identity = new ClaimsIdentity(claims, "ApiKey");
+        return new ClaimsPrincipal(identity);
+    }
+}

--- a/src/Humans.Web/Controllers/NotificationApiController.cs
+++ b/src/Humans.Web/Controllers/NotificationApiController.cs
@@ -2,6 +2,7 @@ using System.Security.Claims;
 using Humans.Application.Interfaces;
 using Humans.Infrastructure.Data;
 using Humans.Web.Filters;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
@@ -12,6 +13,7 @@ namespace Humans.Web.Controllers;
 
 [ApiController]
 [Route("api/notifications")]
+[AllowAnonymous]
 [ServiceFilter(typeof(NotificationApiKeyAuthFilter))]
 public class NotificationApiController : ControllerBase
 {

--- a/src/Humans.Web/Extensions/InfrastructureServiceCollectionExtensions.cs
+++ b/src/Humans.Web/Extensions/InfrastructureServiceCollectionExtensions.cs
@@ -204,6 +204,14 @@ public static class InfrastructureServiceCollectionExtensions
         });
         services.AddScoped<LogApiKeyAuthFilter>();
 
+        // Notification API key + user mapping
+        services.Configure<NotificationApiSettings>(opts =>
+        {
+            opts.ApiKey = Environment.GetEnvironmentVariable("NOTIFICATION_API_KEY") ?? string.Empty;
+            opts.UserId = Environment.GetEnvironmentVariable("NOTIFICATION_API_USER_ID") ?? string.Empty;
+        });
+        services.AddScoped<NotificationApiKeyAuthFilter>();
+
         // Ticket vendor integration
         var ticketVendorApiKey = Environment.GetEnvironmentVariable("TICKET_VENDOR_API_KEY") ?? string.Empty;
 

--- a/src/Humans.Web/Filters/ApiKeyAuthFilter.cs
+++ b/src/Humans.Web/Filters/ApiKeyAuthFilter.cs
@@ -46,3 +46,12 @@ public class ApiKeyAuthFilter(IOptions<FeedbackApiSettings> settings)
 
 public class LogApiKeyAuthFilter(IOptions<LogApiSettings> settings)
     : ApiKeyAuthFilterBase(settings.Value.ApiKey);
+
+public class NotificationApiSettings
+{
+    public string ApiKey { get; set; } = string.Empty;
+    public string UserId { get; set; } = string.Empty;
+}
+
+public class NotificationApiKeyAuthFilter(IOptions<NotificationApiSettings> settings)
+    : ApiKeyAuthFilterBase(settings.Value.ApiKey);


### PR DESCRIPTION
## Summary
- New `GET /api/notifications` endpoint returning unread notifications and live meter counts
- Authenticated via `X-Api-Key` header with `NOTIFICATION_API_KEY` env var, maps to a specific user via `NOTIFICATION_API_USER_ID`
- Reuses existing `NotificationInboxService` (inbox) and `NotificationMeterProvider` (meters); supports optional `?since=yyyy-MM-dd` filtering

## Issues
- Closes #469

## Test plan
- [ ] Set `NOTIFICATION_API_KEY` and `NOTIFICATION_API_USER_ID` env vars, call `GET /api/notifications` with valid `X-Api-Key` header — verify 200 with notifications and meters
- [ ] Call without `X-Api-Key` header — verify 401
- [ ] Call with wrong API key — verify 401
- [ ] Call with no env vars configured — verify 503
- [ ] Call with `?since=2026-04-09` — verify only notifications on or after that date are returned
- [ ] Call with `?since=invalid` — verify 400 with error message