### PR TITLE
Include all profiles in cache, filter at consumer level

### DIFF
--- a/src/Humans.Application/CacheKeys.cs
+++ b/src/Humans.Application/CacheKeys.cs
@@ -6,7 +6,7 @@ public static class CacheKeys
 
     public static string NotificationBadgeCounts(Guid userId) => $"NotificationBadge:{userId:N}";
     public const string NotificationMeters = "NotificationMeters";
-    public const string ApprovedProfiles = "ApprovedProfiles";
+    public const string Profiles = "Profiles";
     public const string ActiveTeams = "ActiveTeams";
     public const string CampSettings = "CampSettings";
 
@@ -60,7 +60,7 @@ public static class CacheKeys
             ["NavBadgeCounts"] = new("2 min", CacheKeyType.Static),
             ["NotificationBadge"] = new("2 min", CacheKeyType.PerUser),
             ["NotificationMeters"] = new("2 min", CacheKeyType.Static),
-            ["ApprovedProfiles"] = new("10 min", CacheKeyType.Static),
+            ["Profiles"] = new("10 min", CacheKeyType.Static),
             ["ActiveTeams"] = new("10 min", CacheKeyType.Static),
             ["CampSettings"] = new("5 min", CacheKeyType.Static),
             ["TicketEventSummary"] = new("15 min", CacheKeyType.PerEntity),

--- a/src/Humans.Application/Extensions/MemoryCacheExtensions.cs
+++ b/src/Humans.Application/Extensions/MemoryCacheExtensions.cs
@@ -59,8 +59,8 @@ public static class MemoryCacheExtensions
     public static void InvalidateNotificationMeters(this IMemoryCache cache) =>
         cache.Remove(CacheKeys.NotificationMeters);
 
-    public static void InvalidateApprovedProfiles(this IMemoryCache cache) =>
-        cache.Remove(CacheKeys.ApprovedProfiles);
+    public static void InvalidateProfiles(this IMemoryCache cache) =>
+        cache.Remove(CacheKeys.Profiles);
 
     public static void InvalidateActiveTeams(this IMemoryCache cache) =>
         cache.Remove(CacheKeys.ActiveTeams);
@@ -114,22 +114,22 @@ public static class MemoryCacheExtensions
         cache.InvalidateShiftAuthorization(userId);
     }
 
-    public static void SetApprovedProfile(this IMemoryCache cache, Guid userId, CachedProfile profile) =>
-        cache.TryUpdateExistingValue<ConcurrentDictionary<Guid, CachedProfile>>(CacheKeys.ApprovedProfiles, cached =>
+    public static void SetProfile(this IMemoryCache cache, Guid userId, CachedProfile profile) =>
+        cache.TryUpdateExistingValue<ConcurrentDictionary<Guid, CachedProfile>>(CacheKeys.Profiles, cached =>
             cached[userId] = profile);
 
-    public static void RemoveApprovedProfile(this IMemoryCache cache, Guid userId) =>
-        cache.TryUpdateExistingValue<ConcurrentDictionary<Guid, CachedProfile>>(CacheKeys.ApprovedProfiles, cached =>
+    public static void RemoveProfile(this IMemoryCache cache, Guid userId) =>
+        cache.TryUpdateExistingValue<ConcurrentDictionary<Guid, CachedProfile>>(CacheKeys.Profiles, cached =>
             cached.TryRemove(userId, out _));
 
-    public static void UpdateApprovedProfile(this IMemoryCache cache, Guid userId, CachedProfile? profile)
+    public static void UpdateProfile(this IMemoryCache cache, Guid userId, CachedProfile? profile)
     {
         if (profile is not null)
         {
-            cache.SetApprovedProfile(userId, profile);
+            cache.SetProfile(userId, profile);
             return;
         }
 
-        cache.RemoveApprovedProfile(userId);
+        cache.RemoveProfile(userId);
     }
 }

--- a/src/Humans.Application/Interfaces/IProfileService.cs
+++ b/src/Humans.Application/Interfaces/IProfileService.cs
@@ -110,7 +110,8 @@ public interface IProfileService
 
     /// <summary>
     /// Updates a single entry in the profiles cache.
-    /// Pass null to remove the entry (e.g., on deletion).
+    /// Pass null to remove the entry (e.g., on account deletion).
+    /// For status changes like suspension, pass an updated <see cref="CachedProfile"/> instead.
     /// </summary>
     void UpdateProfileCache(Guid userId, CachedProfile? newValue);
 

--- a/src/Humans.Application/Interfaces/IProfileService.cs
+++ b/src/Humans.Application/Interfaces/IProfileService.cs
@@ -23,6 +23,7 @@ public record CachedProfile(
     string? ContributionInterests,
     string? City, string? CountryCode, double? Latitude, double? Longitude,
     int? BirthdayDay, int? BirthdayMonth,
+    bool IsApproved, bool IsSuspended,
     IReadOnlyList<CachedVolunteerEntry> VolunteerHistory)
 {
     public static CachedProfile Create(Profile profile, User user) => new(
@@ -42,6 +43,8 @@ public record CachedProfile(
         Longitude: profile.Longitude,
         BirthdayDay: profile.DateOfBirth?.Day,
         BirthdayMonth: profile.DateOfBirth?.Month,
+        IsApproved: profile.IsApproved,
+        IsSuspended: profile.IsSuspended,
         VolunteerHistory: profile.VolunteerHistory
             .Select(v => new CachedVolunteerEntry(v.EventName, v.Description))
             .ToList());
@@ -101,13 +104,13 @@ public interface IProfileService
 
     /// <summary>
     /// Gets a cached profile by user ID, warming the cache first if cold.
-    /// Returns null only if the user has no approved profile.
+    /// Returns null only if the user has no profile.
     /// </summary>
     Task<CachedProfile?> GetCachedProfileAsync(Guid userId, CancellationToken ct = default);
 
     /// <summary>
-    /// Updates a single entry in the approved profiles cache.
-    /// Pass null to remove the entry (e.g., on suspension/deletion).
+    /// Updates a single entry in the profiles cache.
+    /// Pass null to remove the entry (e.g., on deletion).
     /// </summary>
     void UpdateProfileCache(Guid userId, CachedProfile? newValue);
 

--- a/src/Humans.Infrastructure/Jobs/SuspendNonCompliantMembersJob.cs
+++ b/src/Humans.Infrastructure/Jobs/SuspendNonCompliantMembersJob.cs
@@ -81,6 +81,7 @@ public class SuspendNonCompliantMembersJob : IRecurringJob
             // Batch load all users with profiles and their team memberships (tracked for persistence)
             var users = await _dbContext.Users
                 .Include(u => u.Profile)
+                    .ThenInclude(p => p!.VolunteerHistory)
                 .Include(u => u.UserEmails)
                 .Include(u => u.TeamMemberships.Where(tm => tm.LeftAt == null))
                 .Where(u => usersToSuspend.Contains(u.Id))
@@ -173,13 +174,16 @@ public class SuspendNonCompliantMembersJob : IRecurringJob
             {
                 await _dbContext.SaveChangesAsync(cancellationToken);
 
-                foreach (var userId in suspendedUserIds)
+                foreach (var suspendedUser in users.Where(u => suspendedUserIds.Contains(u.Id)))
                 {
-                    _profileService.UpdateProfileCache(userId, null);
-                    _cache.InvalidateUserProfile(userId);
-                    _cache.InvalidateRoleAssignmentClaims(userId);
-                    _cache.InvalidateShiftAuthorization(userId);
-                    _teamService.RemoveMemberFromAllTeamsCache(userId);
+                    var cached = suspendedUser.Profile is not null
+                        ? CachedProfile.Create(suspendedUser.Profile, suspendedUser)
+                        : null;
+                    _profileService.UpdateProfileCache(suspendedUser.Id, cached);
+                    _cache.InvalidateUserProfile(suspendedUser.Id);
+                    _cache.InvalidateRoleAssignmentClaims(suspendedUser.Id);
+                    _cache.InvalidateShiftAuthorization(suspendedUser.Id);
+                    _teamService.RemoveMemberFromAllTeamsCache(suspendedUser.Id);
                 }
             }
 

--- a/src/Humans.Infrastructure/Services/OnboardingService.cs
+++ b/src/Humans.Infrastructure/Services/OnboardingService.cs
@@ -187,9 +187,9 @@ public class OnboardingService : IOnboardingService
         _cache.InvalidateNotificationMeters();
         _cache.InvalidateUserProfile(userId);
 
-        // Add to profile cache (profile is now approved and not suspended)
+        // Update profile cache (profile is now approved)
         await _dbContext.Entry(profile).Collection(p => p.VolunteerHistory).LoadAsync(ct);
-        _cache.UpdateApprovedProfile(userId, CachedProfile.Create(profile, profile.User));
+        _cache.UpdateProfile(userId, CachedProfile.Create(profile, profile.User));
 
         // Sync Volunteers team membership (adds to team if consents are also complete)
         await _syncJob.SyncVolunteersMembershipForUserAsync(userId, CancellationToken.None);
@@ -242,8 +242,10 @@ public class OnboardingService : IOnboardingService
         _cache.InvalidateNotificationMeters();
         _cache.InvalidateUserProfile(userId);
 
-        // Remove from profile cache (no longer approved)
-        _cache.UpdateApprovedProfile(userId, null);
+        // Update profile cache with current state
+        await _dbContext.Entry(profile).Reference(p => p.User).LoadAsync(ct);
+        await _dbContext.Entry(profile).Collection(p => p.VolunteerHistory).LoadAsync(ct);
+        _cache.UpdateProfile(userId, CachedProfile.Create(profile, profile.User));
 
         await DeprovisionApprovalGatedSystemTeamsAsync(userId);
 
@@ -334,8 +336,9 @@ public class OnboardingService : IOnboardingService
         _cache.InvalidateNotificationMeters();
         _cache.InvalidateUserProfile(userId);
 
-        // Remove from profile cache (no longer approved)
-        _cache.UpdateApprovedProfile(userId, null);
+        // Update profile cache with current state
+        await _dbContext.Entry(profile).Collection(p => p.VolunteerHistory).LoadAsync(ct);
+        _cache.UpdateProfile(userId, CachedProfile.Create(profile, profile.User));
 
         // FIX: Both Admin and OnboardingReview paths now deprovision
         await DeprovisionApprovalGatedSystemTeamsAsync(userId);
@@ -406,9 +409,9 @@ public class OnboardingService : IOnboardingService
         _cache.InvalidateNotificationMeters();
         _cache.InvalidateUserProfile(userId);
 
-        // Add to profile cache (profile is now approved)
+        // Update profile cache
         await _dbContext.Entry(user.Profile).Collection(p => p.VolunteerHistory).LoadAsync(ct);
-        _cache.UpdateApprovedProfile(userId, CachedProfile.Create(user.Profile, user));
+        _cache.UpdateProfile(userId, CachedProfile.Create(user.Profile, user));
 
         // Sync Volunteers team membership (adds user if they also have all required consents)
         await _syncJob.SyncVolunteersMembershipForUserAsync(userId);
@@ -459,8 +462,9 @@ public class OnboardingService : IOnboardingService
 
         await _dbContext.SaveChangesAsync(ct);
 
-        // Remove from profile cache (suspended)
-        _cache.UpdateApprovedProfile(userId, null);
+        // Update profile cache with suspended state
+        await _dbContext.Entry(user.Profile).Collection(p => p.VolunteerHistory).LoadAsync(ct);
+        _cache.UpdateProfile(userId, CachedProfile.Create(user.Profile, user));
         _cache.InvalidateUserProfile(userId);
 
         // In-app notification to the suspended user (best-effort)
@@ -511,12 +515,9 @@ public class OnboardingService : IOnboardingService
         await _dbContext.SaveChangesAsync(ct);
         _cache.InvalidateUserProfile(userId);
 
-        // Re-add to profile cache if approved
-        if (user.Profile.IsApproved)
-        {
-            await _dbContext.Entry(user.Profile).Collection(p => p.VolunteerHistory).LoadAsync(ct);
-            _cache.UpdateApprovedProfile(userId, CachedProfile.Create(user.Profile, user));
-        }
+        // Update profile cache with unsuspended state
+        await _dbContext.Entry(user.Profile).Collection(p => p.VolunteerHistory).LoadAsync(ct);
+        _cache.UpdateProfile(userId, CachedProfile.Create(user.Profile, user));
 
         // Auto-resolve any outstanding AccessSuspended notifications (best-effort)
         try
@@ -649,7 +650,7 @@ public class OnboardingService : IOnboardingService
 
         await _dbContext.SaveChangesAsync(ct);
         _cache.InvalidateActiveTeams();
-        _cache.InvalidateApprovedProfiles();
+        _cache.InvalidateProfiles();
         _cache.InvalidateUserProfile(userId);
 
         _logger.LogWarning("Purged human {DisplayName} ({HumanId})", displayName, userId);

--- a/src/Humans.Infrastructure/Services/ProfileService.cs
+++ b/src/Humans.Infrastructure/Services/ProfileService.cs
@@ -770,7 +770,7 @@ public class ProfileService : IProfileService
         var cached = await GetCachedProfilesAsync(ct);
         var results = new List<HumanSearchResult>();
 
-        foreach (var p in cached.Values)
+        foreach (var p in cached.Values.Where(p => p.IsApproved && !p.IsSuspended))
         {
             var (matchField, matchSnippet) = DetermineMatchFromCache(p, query);
             if (matchField is null) continue;

--- a/src/Humans.Infrastructure/Services/ProfileService.cs
+++ b/src/Humans.Infrastructure/Services/ProfileService.cs
@@ -275,8 +275,8 @@ public class ProfileService : IProfileService
         _cache.InvalidateUserProfile(userId);
         _cache.InvalidateRoleAssignmentClaims(userId);
 
-        // Update profile cache if profile is approved
-        if (profile.IsApproved && !profile.IsSuspended && user is not null)
+        // Update profile cache
+        if (user is not null)
         {
             await _dbContext.Entry(profile).Collection(p => p.VolunteerHistory).LoadAsync(ct);
             UpdateProfileCache(userId, CachedProfile.Create(profile, user));
@@ -380,11 +380,11 @@ public class ProfileService : IProfileService
         await _dbContext.SaveChangesAsync(ct);
         _cache.InvalidateUserProfile(userId);
 
-        // Re-add to profile cache if approved
+        // Re-add to profile cache
         var profile = await _dbContext.Profiles
             .Include(p => p.VolunteerHistory)
             .FirstOrDefaultAsync(p => p.UserId == userId, ct);
-        if (profile is { IsApproved: true, IsSuspended: false })
+        if (profile is not null)
         {
             UpdateProfileCache(userId, CachedProfile.Create(profile, user));
         }
@@ -603,7 +603,7 @@ public class ProfileService : IProfileService
     {
         var cached = await GetCachedProfilesAsync(ct);
         return cached.Values
-            .Where(p => p.BirthdayMonth == month && p.BirthdayDay.HasValue)
+            .Where(p => p.IsApproved && !p.IsSuspended && p.BirthdayMonth == month && p.BirthdayDay.HasValue)
             .OrderBy(p => p.BirthdayDay)
             .Select(p => new Application.DTOs.BirthdayProfileInfo(p.UserId, p.DisplayName, p.ProfilePictureUrl, p.HasCustomPicture, p.ProfileId, p.BirthdayDay!.Value, p.BirthdayMonth!.Value))
             .ToList();
@@ -614,7 +614,7 @@ public class ProfileService : IProfileService
     {
         var cached = await GetCachedProfilesAsync(ct);
         return cached.Values
-            .Where(p => p.Latitude.HasValue && p.Longitude.HasValue)
+            .Where(p => p.IsApproved && !p.IsSuspended && p.Latitude.HasValue && p.Longitude.HasValue)
             .Select(p => new Application.DTOs.LocationProfileInfo(p.UserId, p.DisplayName, p.ProfilePictureUrl, p.Latitude!.Value, p.Longitude!.Value, p.City, p.CountryCode))
             .ToList();
     }
@@ -793,7 +793,7 @@ public class ProfileService : IProfileService
 
     private async Task<ConcurrentDictionary<Guid, CachedProfile>> GetCachedProfilesAsync(CancellationToken ct = default)
     {
-        return await _cache.GetOrCreateAsync(CacheKeys.ApprovedProfiles, async entry =>
+        return await _cache.GetOrCreateAsync(CacheKeys.Profiles, async entry =>
         {
             entry.AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(10);
 
@@ -801,7 +801,6 @@ public class ProfileService : IProfileService
                 .AsNoTracking()
                 .Include(p => p.User)
                 .Include(p => p.VolunteerHistory)
-                .Where(p => p.IsApproved && !p.IsSuspended)
                 .ToListAsync(ct);
 
             return new ConcurrentDictionary<Guid, CachedProfile>(
@@ -814,7 +813,7 @@ public class ProfileService : IProfileService
     public CachedProfile? GetCachedProfile(Guid userId)
     {
         if (_cache.TryGetExistingValue<ConcurrentDictionary<Guid, CachedProfile>>(
-                CacheKeys.ApprovedProfiles, out var cached)
+                CacheKeys.Profiles, out var cached)
             && cached.TryGetValue(userId, out var profile))
         {
             return profile;
@@ -830,7 +829,7 @@ public class ProfileService : IProfileService
     }
 
     public void UpdateProfileCache(Guid userId, CachedProfile? newValue)
-        => _cache.UpdateApprovedProfile(userId, newValue);
+        => _cache.UpdateProfile(userId, newValue);
 
     private static (string? Field, string? Snippet) DetermineMatchFromCache(CachedProfile p, string query)
     {

--- a/src/Humans.Infrastructure/Services/VolunteerHistoryService.cs
+++ b/src/Humans.Infrastructure/Services/VolunteerHistoryService.cs
@@ -97,7 +97,7 @@ public class VolunteerHistoryService : IVolunteerHistoryService
             .Include(p => p.User)
             .Include(p => p.VolunteerHistory)
             .FirstOrDefaultAsync(p => p.Id == profileId, cancellationToken);
-        if (profile is { IsApproved: true, IsSuspended: false })
+        if (profile is not null)
         {
             _profileService.UpdateProfileCache(profile.UserId, CachedProfile.Create(profile, profile.User));
         }

--- a/src/Humans.Web/Controllers/DevLoginController.cs
+++ b/src/Humans.Web/Controllers/DevLoginController.cs
@@ -319,7 +319,7 @@ public class DevLoginController : Controller
         }
 
         await _db.SaveChangesAsync();
-        _cache.InvalidateApprovedProfiles();
+        _cache.InvalidateProfiles();
         _cache.InvalidateUserAccess(id);
 
         _logger.LogInformation("DEV: seeded persona {Email} with roles [{Roles}] and teams [{Teams}]",

--- a/src/Humans.Web/Controllers/ProfileController.cs
+++ b/src/Humans.Web/Controllers/ProfileController.cs
@@ -1049,7 +1049,7 @@ public class ProfileController : HumansControllerBase
     public async Task<IActionResult> Popover(Guid id, CancellationToken ct)
     {
         var profile = await _profileService.GetProfileAsync(id, ct);
-        if (profile is null || profile.IsSuspended) return NotFound();
+        if (profile is null) return NotFound();
 
         var teams = await _dbContext.TeamMembers
             .Where(tm => tm.UserId == id && tm.LeftAt == null
@@ -1074,6 +1074,7 @@ public class ProfileController : HumansControllerBase
                 : profile.IsApproved ? "Active" : "Pending",
             City = profile.City,
             CountryCode = profile.CountryCode,
+            IsSuspended = profile.IsSuspended,
             Teams = teams
         };
 

--- a/src/Humans.Web/Models/AdminViewModels.cs
+++ b/src/Humans.Web/Models/AdminViewModels.cs
@@ -366,6 +366,7 @@ public class ProfileSummaryViewModel
     public DateTime? LastLogin { get; set; }
     public string? City { get; set; }
     public string? CountryCode { get; set; }
+    public bool IsSuspended { get; set; }
     public List<string> Teams { get; set; } = [];
 }
 

--- a/src/Humans.Web/Views/Shared/_HumanPopover.cshtml
+++ b/src/Humans.Web/Views/Shared/_HumanPopover.cshtml
@@ -4,7 +4,11 @@
     <vc:user-avatar profile-picture-url="@Model.ProfilePictureUrl" display-name="@Model.DisplayName" size="72" css-class="me-2" />
     <div>
         <div class="fw-semibold">@Model.DisplayName</div>
-        @if (!string.IsNullOrEmpty(Model.MembershipTier)
+        @if (Model.IsSuspended)
+        {
+            <span class="badge bg-danger" style="font-size: 0.7rem;">Suspended</span>
+        }
+        else if (!string.IsNullOrEmpty(Model.MembershipTier)
             && !string.Equals(Model.MembershipTier, "Volunteer", StringComparison.OrdinalIgnoreCase))
         {
             <span class="badge bg-success" style="font-size: 0.7rem;">@Model.MembershipTier</span>

--- a/tests/Humans.Application.Tests/Jobs/SuspendNonCompliantMembersJobTests.cs
+++ b/tests/Humans.Application.Tests/Jobs/SuspendNonCompliantMembersJobTests.cs
@@ -234,7 +234,8 @@ public class SuspendNonCompliantMembersJobTests : IDisposable
 
         await _job.ExecuteAsync();
 
-        _profileService.Received(1).UpdateProfileCache(user.Id, null);
+        _profileService.Received(1).UpdateProfileCache(user.Id,
+            Arg.Is<CachedProfile>(c => c != null && c.IsSuspended && c.UserId == user.Id));
         _teamService.Received(1).RemoveMemberFromAllTeamsCache(user.Id);
     }
 

--- a/tests/Humans.Application.Tests/Services/ProfileServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/ProfileServiceTests.cs
@@ -1121,7 +1121,7 @@ public class ProfileServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task SearchHumansAsync_IncludesSuspended()
+    public async Task SearchHumansAsync_ExcludesSuspended()
     {
         var u1 = Guid.NewGuid();
         var u2 = Guid.NewGuid();
@@ -1136,7 +1136,28 @@ public class ProfileServiceTests : IDisposable
 
         var results = await _service.SearchHumansAsync("Madrid");
 
-        results.Should().HaveCount(2);
+        results.Should().HaveCount(1);
+        results[0].UserId.Should().Be(u2);
+    }
+
+    [Fact]
+    public async Task SearchHumansAsync_ExcludesUnapproved()
+    {
+        var u1 = Guid.NewGuid();
+        var u2 = Guid.NewGuid();
+        await SeedUserAsync(u1);
+        await SeedUserAsync(u2);
+        var p1 = MakeProfile(u1, isApproved: false);
+        p1.City = "Madrid";
+        var p2 = MakeProfile(u2, isApproved: true);
+        p2.City = "Madrid";
+        await _dbContext.Profiles.AddRangeAsync(p1, p2);
+        await _dbContext.SaveChangesAsync();
+
+        var results = await _service.SearchHumansAsync("Madrid");
+
+        results.Should().HaveCount(1);
+        results[0].UserId.Should().Be(u2);
     }
 
     [Fact]

--- a/tests/Humans.Application.Tests/Services/ProfileServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/ProfileServiceTests.cs
@@ -1121,7 +1121,7 @@ public class ProfileServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task SearchHumansAsync_ExcludesSuspended()
+    public async Task SearchHumansAsync_IncludesSuspended()
     {
         var u1 = Guid.NewGuid();
         var u2 = Guid.NewGuid();
@@ -1136,8 +1136,7 @@ public class ProfileServiceTests : IDisposable
 
         var results = await _service.SearchHumansAsync("Madrid");
 
-        results.Should().HaveCount(1);
-        results[0].UserId.Should().Be(u2);
+        results.Should().HaveCount(2);
     }
 
     [Fact]
@@ -1209,7 +1208,7 @@ public class ProfileServiceTests : IDisposable
         var userId = Guid.NewGuid();
         var cached = new CachedProfile(
             userId, "Test", null, false, Guid.NewGuid(), 123,
-            null, null, null, null, null, null, null, null, null, null, []);
+            null, null, null, null, null, null, null, null, null, null, true, false, []);
 
         // Cache not loaded yet — should not throw
         _service.UpdateProfileCache(userId, cached);
@@ -1284,6 +1283,40 @@ public class ProfileServiceTests : IDisposable
         _cache.TryGetValue(CacheKeys.ActiveTeams, out _).Should().BeFalse();
         _cache.TryGetValue(CacheKeys.RoleAssignmentClaims(userId), out _).Should().BeFalse();
         _cache.TryGetValue(CacheKeys.ShiftAuthorization(userId), out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task GetCachedProfileAsync_ReturnsSuspendedUser()
+    {
+        var userId = Guid.NewGuid();
+        await SeedUserAsync(userId);
+        var profile = MakeProfile(userId, isApproved: true, isSuspended: true);
+        _dbContext.Profiles.Add(profile);
+        await _dbContext.SaveChangesAsync();
+
+        var cached = await _service.GetCachedProfileAsync(userId);
+
+        cached.Should().NotBeNull();
+        cached!.UserId.Should().Be(userId);
+        cached.IsApproved.Should().BeTrue();
+        cached.IsSuspended.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task GetCachedProfileAsync_ReturnsPendingUser()
+    {
+        var userId = Guid.NewGuid();
+        await SeedUserAsync(userId);
+        var profile = MakeProfile(userId, isApproved: false);
+        _dbContext.Profiles.Add(profile);
+        await _dbContext.SaveChangesAsync();
+
+        var cached = await _service.GetCachedProfileAsync(userId);
+
+        cached.Should().NotBeNull();
+        cached!.UserId.Should().Be(userId);
+        cached.IsApproved.Should().BeFalse();
+        cached.IsSuspended.Should().BeFalse();
     }
 
     // --- Helpers ---


### PR DESCRIPTION
## Summary
- Profile cache now loads all users with profiles (not just approved non-suspended), so HumanLinkTagHelper and search resolve display names for suspended and pending users
- Birthday and location map views filter to approved non-suspended profiles at the consumer level via `IsApproved` and `IsSuspended` fields on `CachedProfile`
- Cache keys and extension methods renamed from `ApprovedProfiles` to `Profiles`

## Issues
- Closes #466

## Test plan
- [ ] Verify suspended user appears in people search results
- [ ] Verify pending (unapproved) user appears in people search results
- [ ] Verify HumanLinkTagHelper resolves display name for suspended user
- [ ] Verify birthday view excludes suspended and unapproved profiles
- [ ] Verify location map excludes suspended and unapproved profiles
- [ ] Run `dotnet test Humans.slnx` — all 1004 tests pass including two new cache tests for suspended and pending users