### PR TITLE
Service ownership phase 1 and UnsubscribeController extraction

### DIFF
--- a/src/Humans.Application/Interfaces/ICommunicationPreferenceService.cs
+++ b/src/Humans.Application/Interfaces/ICommunicationPreferenceService.cs
@@ -60,4 +60,18 @@ public interface ICommunicationPreferenceService
     /// Returns a dictionary of header name → value pairs.
     /// </summary>
     Dictionary<string, string> GenerateUnsubscribeHeaders(Guid userId, MessageCategory category);
+
+    /// <summary>
+    /// Returns a set of user IDs (from the input list) whose inbox is disabled
+    /// for the given category. Users with no preference row are considered inbox-enabled.
+    /// </summary>
+    Task<IReadOnlySet<Guid>> GetUsersWithInboxDisabledAsync(
+        IReadOnlyList<Guid> userIds, MessageCategory category,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns whether any communication preferences exist for the given user.
+    /// </summary>
+    Task<bool> HasAnyPreferencesAsync(
+        Guid userId, CancellationToken cancellationToken = default);
 }

--- a/src/Humans.Application/Interfaces/ICommunicationPreferenceService.cs
+++ b/src/Humans.Application/Interfaces/ICommunicationPreferenceService.cs
@@ -74,4 +74,10 @@ public interface ICommunicationPreferenceService
     /// </summary>
     Task<bool> HasAnyPreferencesAsync(
         Guid userId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns the set of user IDs (from the input list) that have any communication preferences.
+    /// </summary>
+    Task<IReadOnlySet<Guid>> GetUsersWithAnyPreferencesAsync(
+        IReadOnlyList<Guid> userIds, CancellationToken cancellationToken = default);
 }

--- a/src/Humans.Application/Interfaces/IConsentService.cs
+++ b/src/Humans.Application/Interfaces/IConsentService.cs
@@ -16,4 +16,30 @@ public interface IConsentService
     Task<ConsentSubmitResult> SubmitConsentAsync(
         Guid userId, Guid documentVersionId, bool explicitConsent,
         string ipAddress, string userAgent, CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets all consent records for a user, ordered by most recent first,
+    /// with DocumentVersion and LegalDocument navigation properties loaded.
+    /// </summary>
+    Task<IReadOnlyList<ConsentRecord>> GetUserConsentRecordsAsync(
+        Guid userId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets the count of consent records for a user.
+    /// </summary>
+    Task<int> GetConsentRecordCountAsync(
+        Guid userId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets the set of document version IDs that a user has explicitly consented to.
+    /// </summary>
+    Task<IReadOnlySet<Guid>> GetConsentedVersionIdsAsync(
+        Guid userId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets a map of user ID → consented document version IDs for a batch of users.
+    /// Every input user ID appears in the result (with an empty set if no consents).
+    /// </summary>
+    Task<IReadOnlyDictionary<Guid, IReadOnlySet<Guid>>> GetConsentMapForUsersAsync(
+        IReadOnlyList<Guid> userIds, CancellationToken ct = default);
 }

--- a/src/Humans.Application/Interfaces/ILegalDocumentSyncService.cs
+++ b/src/Humans.Application/Interfaces/ILegalDocumentSyncService.cs
@@ -50,4 +50,12 @@ public interface ILegalDocumentSyncService
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The document version if found.</returns>
     Task<DocumentVersion?> GetVersionByIdAsync(Guid versionId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the current required document versions for a specific team.
+    /// Returns the latest effective version per required+active document scoped to the team.
+    /// Each returned DocumentVersion has its LegalDocument navigation loaded.
+    /// </summary>
+    Task<IReadOnlyList<DocumentVersion>> GetRequiredDocumentVersionsForTeamAsync(
+        Guid teamId, CancellationToken cancellationToken = default);
 }

--- a/src/Humans.Application/Interfaces/IUnsubscribeService.cs
+++ b/src/Humans.Application/Interfaces/IUnsubscribeService.cs
@@ -1,0 +1,47 @@
+using Humans.Domain.Enums;
+
+namespace Humans.Application.Interfaces;
+
+/// <summary>
+/// Handles token validation, user lookup, and unsubscribe actions
+/// for both new category-aware tokens and legacy campaign-only tokens.
+/// </summary>
+public interface IUnsubscribeService
+{
+    /// <summary>
+    /// Validates an unsubscribe token (new or legacy) and returns the resolved result.
+    /// </summary>
+    Task<UnsubscribeTokenResult> ValidateTokenAsync(string token, CancellationToken ct = default);
+
+    /// <summary>
+    /// Performs the unsubscribe action for a validated token.
+    /// </summary>
+    Task<UnsubscribeTokenResult> ConfirmUnsubscribeAsync(string token, string source, CancellationToken ct = default);
+}
+
+/// <summary>
+/// Result of validating an unsubscribe token.
+/// </summary>
+public record UnsubscribeTokenResult
+{
+    public bool IsValid { get; init; }
+    public bool IsExpired { get; init; }
+    public bool IsLegacy { get; init; }
+    public Guid? UserId { get; init; }
+    public string? DisplayName { get; init; }
+    public MessageCategory? Category { get; init; }
+
+    public static UnsubscribeTokenResult Invalid() => new() { IsValid = false };
+    public static UnsubscribeTokenResult Expired() => new() { IsValid = false, IsExpired = true };
+
+    public static UnsubscribeTokenResult Valid(
+        Guid userId, string displayName, MessageCategory category, bool isLegacy = false) =>
+        new()
+        {
+            IsValid = true,
+            UserId = userId,
+            DisplayName = displayName,
+            Category = category,
+            IsLegacy = isLegacy
+        };
+}

--- a/src/Humans.Infrastructure/Services/CommunicationPreferenceService.cs
+++ b/src/Humans.Infrastructure/Services/CommunicationPreferenceService.cs
@@ -257,6 +257,30 @@ public class CommunicationPreferenceService : ICommunicationPreferenceService
         return !await IsOptedOutAsync(userId, MessageCategory.FacilitatedMessages, cancellationToken);
     }
 
+    public async Task<IReadOnlySet<Guid>> GetUsersWithInboxDisabledAsync(
+        IReadOnlyList<Guid> userIds, MessageCategory category,
+        CancellationToken cancellationToken = default)
+    {
+        if (userIds.Count == 0)
+        {
+            return new HashSet<Guid>();
+        }
+
+        var disabledUserIds = await _db.CommunicationPreferences
+            .Where(cp => userIds.Contains(cp.UserId) && cp.Category == category && !cp.InboxEnabled)
+            .Select(cp => cp.UserId)
+            .ToListAsync(cancellationToken);
+
+        return disabledUserIds.ToHashSet();
+    }
+
+    public async Task<bool> HasAnyPreferencesAsync(
+        Guid userId, CancellationToken cancellationToken = default)
+    {
+        return await _db.CommunicationPreferences
+            .AnyAsync(cp => cp.UserId == userId, cancellationToken);
+    }
+
     public Dictionary<string, string> GenerateUnsubscribeHeaders(Guid userId, MessageCategory category)
     {
         var token = GenerateUnsubscribeToken(userId, category);

--- a/src/Humans.Infrastructure/Services/CommunicationPreferenceService.cs
+++ b/src/Humans.Infrastructure/Services/CommunicationPreferenceService.cs
@@ -281,6 +281,23 @@ public class CommunicationPreferenceService : ICommunicationPreferenceService
             .AnyAsync(cp => cp.UserId == userId, cancellationToken);
     }
 
+    public async Task<IReadOnlySet<Guid>> GetUsersWithAnyPreferencesAsync(
+        IReadOnlyList<Guid> userIds, CancellationToken cancellationToken = default)
+    {
+        if (userIds.Count == 0)
+        {
+            return new HashSet<Guid>();
+        }
+
+        var usersWithPrefs = await _db.CommunicationPreferences
+            .Where(cp => userIds.Contains(cp.UserId))
+            .Select(cp => cp.UserId)
+            .Distinct()
+            .ToListAsync(cancellationToken);
+
+        return usersWithPrefs.ToHashSet();
+    }
+
     public Dictionary<string, string> GenerateUnsubscribeHeaders(Guid userId, MessageCategory category)
     {
         var token = GenerateUnsubscribeToken(userId, category);

--- a/src/Humans.Infrastructure/Services/ConsentService.cs
+++ b/src/Humans.Infrastructure/Services/ConsentService.cs
@@ -16,6 +16,7 @@ public class ConsentService : IConsentService
     private readonly HumansDbContext _dbContext;
     private readonly IOnboardingService _onboardingService;
     private readonly IServiceProvider _serviceProvider;
+    private readonly ILegalDocumentSyncService _legalDocumentSyncService;
     private readonly INotificationInboxService _notificationInboxService;
     private readonly ISystemTeamSync _syncJob;
     private readonly IHumansMetrics _metrics;
@@ -26,6 +27,7 @@ public class ConsentService : IConsentService
         HumansDbContext dbContext,
         IOnboardingService onboardingService,
         IServiceProvider serviceProvider,
+        ILegalDocumentSyncService legalDocumentSyncService,
         INotificationInboxService notificationInboxService,
         ISystemTeamSync syncJob,
         IHumansMetrics metrics,
@@ -35,6 +37,7 @@ public class ConsentService : IConsentService
         _dbContext = dbContext;
         _onboardingService = onboardingService;
         _serviceProvider = serviceProvider;
+        _legalDocumentSyncService = legalDocumentSyncService;
         _notificationInboxService = notificationInboxService;
         _syncJob = syncJob;
         _metrics = metrics;
@@ -94,9 +97,7 @@ public class ConsentService : IConsentService
     public async Task<(DocumentVersion? Version, ConsentRecord? ExistingConsent, string? UserFullName)>
         GetConsentReviewDetailAsync(Guid documentVersionId, Guid userId, CancellationToken ct = default)
     {
-        var version = await _dbContext.DocumentVersions
-            .Include(v => v.LegalDocument)
-            .FirstOrDefaultAsync(v => v.Id == documentVersionId, ct);
+        var version = await _legalDocumentSyncService.GetVersionByIdAsync(documentVersionId, ct);
 
         if (version is null)
             return (null, null, null);
@@ -115,9 +116,7 @@ public class ConsentService : IConsentService
         Guid userId, Guid documentVersionId, bool explicitConsent,
         string ipAddress, string userAgent, CancellationToken ct = default)
     {
-        var version = await _dbContext.DocumentVersions
-            .Include(v => v.LegalDocument)
-            .FirstOrDefaultAsync(v => v.Id == documentVersionId, ct);
+        var version = await _legalDocumentSyncService.GetVersionByIdAsync(documentVersionId, ct);
 
         if (version is null)
             return new ConsentSubmitResult(false, ErrorKey: "NotFound");

--- a/src/Humans.Infrastructure/Services/ConsentService.cs
+++ b/src/Humans.Infrastructure/Services/ConsentService.cs
@@ -1,6 +1,7 @@
 using System.Security.Cryptography;
 using System.Text;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NodaTime;
 using Humans.Application.Interfaces;
@@ -14,7 +15,7 @@ public class ConsentService : IConsentService
 {
     private readonly HumansDbContext _dbContext;
     private readonly IOnboardingService _onboardingService;
-    private readonly IMembershipCalculator _membershipCalculator;
+    private readonly IServiceProvider _serviceProvider;
     private readonly INotificationInboxService _notificationInboxService;
     private readonly ISystemTeamSync _syncJob;
     private readonly IHumansMetrics _metrics;
@@ -24,7 +25,7 @@ public class ConsentService : IConsentService
     public ConsentService(
         HumansDbContext dbContext,
         IOnboardingService onboardingService,
-        IMembershipCalculator membershipCalculator,
+        IServiceProvider serviceProvider,
         INotificationInboxService notificationInboxService,
         ISystemTeamSync syncJob,
         IHumansMetrics metrics,
@@ -33,7 +34,7 @@ public class ConsentService : IConsentService
     {
         _dbContext = dbContext;
         _onboardingService = onboardingService;
-        _membershipCalculator = membershipCalculator;
+        _serviceProvider = serviceProvider;
         _notificationInboxService = notificationInboxService;
         _syncJob = syncJob;
         _metrics = metrics;
@@ -47,7 +48,8 @@ public class ConsentService : IConsentService
     {
         var now = _clock.GetCurrentInstant();
 
-        var userTeamIds = await _membershipCalculator.GetRequiredTeamIdsForUserAsync(userId, ct);
+        var membershipCalculator = _serviceProvider.GetRequiredService<IMembershipCalculator>();
+        var userTeamIds = await membershipCalculator.GetRequiredTeamIdsForUserAsync(userId, ct);
 
         var documents = await _dbContext.LegalDocuments
             .Where(d => d.IsActive && d.IsRequired && userTeamIds.Contains(d.TeamId))
@@ -158,7 +160,8 @@ public class ConsentService : IConsentService
         // Auto-resolve AccessSuspended notifications only once ALL required consents are complete
         try
         {
-            if (await _membershipCalculator.HasAllRequiredConsentsAsync(userId, ct))
+            var membershipCalc = _serviceProvider.GetRequiredService<IMembershipCalculator>();
+            if (await membershipCalc.HasAllRequiredConsentsAsync(userId, ct))
             {
                 await _notificationInboxService.ResolveBySourceAsync(userId, NotificationSource.AccessSuspended, ct);
             }
@@ -169,6 +172,63 @@ public class ConsentService : IConsentService
         }
 
         return new ConsentSubmitResult(true, DocumentName: version.LegalDocument.Name);
+    }
+
+    public async Task<IReadOnlyList<ConsentRecord>> GetUserConsentRecordsAsync(
+        Guid userId, CancellationToken ct = default)
+    {
+        return await _dbContext.ConsentRecords
+            .AsNoTracking()
+            .Include(c => c.DocumentVersion)
+                .ThenInclude(v => v.LegalDocument)
+            .Where(c => c.UserId == userId)
+            .OrderByDescending(c => c.ConsentedAt)
+            .ToListAsync(ct);
+    }
+
+    public async Task<int> GetConsentRecordCountAsync(
+        Guid userId, CancellationToken ct = default)
+    {
+        return await _dbContext.ConsentRecords
+            .CountAsync(cr => cr.UserId == userId, ct);
+    }
+
+    public async Task<IReadOnlySet<Guid>> GetConsentedVersionIdsAsync(
+        Guid userId, CancellationToken ct = default)
+    {
+        var ids = await _dbContext.ConsentRecords
+            .AsNoTracking()
+            .Where(cr => cr.UserId == userId && cr.ExplicitConsent)
+            .Select(cr => cr.DocumentVersionId)
+            .ToListAsync(ct);
+
+        return ids.ToHashSet();
+    }
+
+    public async Task<IReadOnlyDictionary<Guid, IReadOnlySet<Guid>>> GetConsentMapForUsersAsync(
+        IReadOnlyList<Guid> userIds, CancellationToken ct = default)
+    {
+        if (userIds.Count == 0)
+        {
+            return new Dictionary<Guid, IReadOnlySet<Guid>>();
+        }
+
+        var consents = await _dbContext.ConsentRecords
+            .AsNoTracking()
+            .Where(cr => userIds.Contains(cr.UserId) && cr.ExplicitConsent)
+            .Select(cr => new { cr.UserId, cr.DocumentVersionId })
+            .ToListAsync(ct);
+
+        var result = userIds.ToDictionary(
+            id => id,
+            _ => (IReadOnlySet<Guid>)new HashSet<Guid>());
+
+        foreach (var consent in consents)
+        {
+            ((HashSet<Guid>)result[consent.UserId]).Add(consent.DocumentVersionId);
+        }
+
+        return result;
     }
 
     private static string ComputeContentHash(string content)

--- a/src/Humans.Infrastructure/Services/ContactService.cs
+++ b/src/Humans.Infrastructure/Services/ContactService.cs
@@ -197,13 +197,15 @@ public class ContactService : IContactService
             })
             .ToListAsync(ct);
 
+        var contactIds = contacts.Select(c => c.Id).ToList();
+        var usersWithPrefs = await _preferenceService.GetUsersWithAnyPreferencesAsync(contactIds, ct);
+
         var results = new List<AdminContactRow>(contacts.Count);
         foreach (var c in contacts)
         {
-            var hasPref = await _preferenceService.HasAnyPreferencesAsync(c.Id, ct);
             results.Add(new AdminContactRow(
                 c.Id, c.Email, c.DisplayName, c.ContactSource,
-                c.ExternalSourceId, c.CreatedAt, hasPref));
+                c.ExternalSourceId, c.CreatedAt, usersWithPrefs.Contains(c.Id)));
         }
 
         return results;

--- a/src/Humans.Infrastructure/Services/ContactService.cs
+++ b/src/Humans.Infrastructure/Services/ContactService.cs
@@ -19,6 +19,7 @@ public class ContactService : IContactService
 {
     private readonly HumansDbContext _dbContext;
     private readonly UserManager<User> _userManager;
+    private readonly ICommunicationPreferenceService _preferenceService;
     private readonly IAuditLogService _auditLogService;
     private readonly IClock _clock;
     private readonly ILogger<ContactService> _logger;
@@ -26,12 +27,14 @@ public class ContactService : IContactService
     public ContactService(
         HumansDbContext dbContext,
         UserManager<User> userManager,
+        ICommunicationPreferenceService preferenceService,
         IAuditLogService auditLogService,
         IClock clock,
         ILogger<ContactService> logger)
     {
         _dbContext = dbContext;
         _userManager = userManager;
+        _preferenceService = preferenceService;
         _auditLogService = auditLogService;
         _clock = clock;
         _logger = logger;
@@ -181,23 +184,34 @@ public class ContactService : IContactService
                 (u.Email != null && EF.Functions.ILike(u.Email, pattern)));
         }
 
-        return await query
+        var contacts = await query
             .OrderByDescending(u => u.CreatedAt)
-            .Select(u => new AdminContactRow(
+            .Select(u => new
+            {
                 u.Id,
-                u.Email ?? string.Empty,
+                Email = u.Email ?? string.Empty,
                 u.DisplayName,
                 u.ContactSource,
                 u.ExternalSourceId,
                 u.CreatedAt,
-                u.CommunicationPreferences.Any()))
+            })
             .ToListAsync(ct);
+
+        var results = new List<AdminContactRow>(contacts.Count);
+        foreach (var c in contacts)
+        {
+            var hasPref = await _preferenceService.HasAnyPreferencesAsync(c.Id, ct);
+            results.Add(new AdminContactRow(
+                c.Id, c.Email, c.DisplayName, c.ContactSource,
+                c.ExternalSourceId, c.CreatedAt, hasPref));
+        }
+
+        return results;
     }
 
     public async Task<User?> GetContactDetailAsync(Guid userId, CancellationToken ct = default)
     {
         return await _dbContext.Users
-            .Include(u => u.CommunicationPreferences)
             .Include(u => u.UserEmails)
             .FirstOrDefaultAsync(u =>
                 u.Id == userId &&

--- a/src/Humans.Infrastructure/Services/FeedbackService.cs
+++ b/src/Humans.Infrastructure/Services/FeedbackService.cs
@@ -324,8 +324,8 @@ public class FeedbackService : IFeedbackService
             string newName = "Unassigned";
             if (assignedToUserId.HasValue)
             {
-                var user = await _dbContext.Users.FindAsync(new object[] { assignedToUserId.Value }, cancellationToken);
-                newName = user?.DisplayName ?? assignedToUserId.Value.ToString();
+                await _dbContext.Entry(report).Reference(r => r.AssignedToUser!).LoadAsync(cancellationToken);
+                newName = report.AssignedToUser?.DisplayName ?? assignedToUserId.Value.ToString();
             }
             changes.Add($"Assignee: {oldName} → {newName}");
         }
@@ -339,8 +339,8 @@ public class FeedbackService : IFeedbackService
             string newTeamName = "Unassigned";
             if (assignedToTeamId.HasValue)
             {
-                var team = await _dbContext.Teams.FindAsync(new object[] { assignedToTeamId.Value }, cancellationToken);
-                newTeamName = team?.Name ?? assignedToTeamId.Value.ToString();
+                await _dbContext.Entry(report).Reference(r => r.AssignedToTeam!).LoadAsync(cancellationToken);
+                newTeamName = report.AssignedToTeam?.Name ?? assignedToTeamId.Value.ToString();
             }
             changes.Add($"Team: {oldTeamName} → {newTeamName}");
         }

--- a/src/Humans.Infrastructure/Services/LegalDocumentSyncService.cs
+++ b/src/Humans.Infrastructure/Services/LegalDocumentSyncService.cs
@@ -187,6 +187,23 @@ public class LegalDocumentSyncService : ILegalDocumentSyncService
             .FirstOrDefaultAsync(v => v.Id == versionId, cancellationToken);
     }
 
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<DocumentVersion>> GetRequiredDocumentVersionsForTeamAsync(
+        Guid teamId, CancellationToken cancellationToken = default)
+    {
+        var now = _clock.GetCurrentInstant();
+
+        return await _dbContext.LegalDocuments
+            .AsNoTracking()
+            .Where(d => d.IsRequired && d.IsActive && d.TeamId == teamId)
+            .SelectMany(d => d.Versions)
+            .Where(v => v.EffectiveFrom <= now)
+            .Include(v => v.LegalDocument)
+            .GroupBy(v => v.LegalDocumentId)
+            .Select(g => g.OrderByDescending(v => v.EffectiveFrom).First())
+            .ToListAsync(cancellationToken);
+    }
+
     /// <summary>
     /// Syncs a single document from GitHub using folder-based discovery.
     /// </summary>

--- a/src/Humans.Infrastructure/Services/MembershipCalculator.cs
+++ b/src/Humans.Infrastructure/Services/MembershipCalculator.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using NodaTime;
 using Humans.Application.DTOs;
 using Humans.Application.Interfaces;
@@ -14,15 +15,23 @@ namespace Humans.Infrastructure.Services;
 public class MembershipCalculator : IMembershipCalculator
 {
     private readonly HumansDbContext _dbContext;
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ILegalDocumentSyncService _legalDocumentSyncService;
     private readonly IClock _clock;
 
     public MembershipCalculator(
         HumansDbContext dbContext,
+        IServiceProvider serviceProvider,
+        ILegalDocumentSyncService legalDocumentSyncService,
         IClock clock)
     {
         _dbContext = dbContext;
+        _serviceProvider = serviceProvider;
+        _legalDocumentSyncService = legalDocumentSyncService;
         _clock = clock;
     }
+
+    private IConsentService ConsentService => _serviceProvider.GetRequiredService<IConsentService>();
 
     public async Task<MembershipStatus> ComputeStatusAsync(
         Guid userId,
@@ -84,14 +93,14 @@ public class MembershipCalculator : IMembershipCalculator
 
         foreach (var teamId in eligibleTeamIds)
         {
-            var versions = await GetRequiredDocumentVersionsForTeamAsync(teamId, cancellationToken);
+            var versions = await _legalDocumentSyncService.GetRequiredDocumentVersionsForTeamAsync(teamId, cancellationToken);
             allRequiredVersionIds.AddRange(versions.Select(v => v.Id));
         }
 
         // Deduplicate in case a doc is shared across teams
         var requiredVersionIds = allRequiredVersionIds.Distinct().ToList();
 
-        var consentedVersionIds = await GetConsentedVersionIdsAsync(userId, cancellationToken);
+        var consentedVersionIds = await ConsentService.GetConsentedVersionIdsAsync(userId, cancellationToken);
         var missingVersionIds = requiredVersionIds
             .Where(id => !consentedVersionIds.Contains(id))
             .ToList();
@@ -124,13 +133,13 @@ public class MembershipCalculator : IMembershipCalculator
         Guid teamId,
         CancellationToken ct = default)
     {
-        var requiredVersions = await GetRequiredDocumentVersionsForTeamAsync(teamId, ct);
+        var requiredVersions = await _legalDocumentSyncService.GetRequiredDocumentVersionsForTeamAsync(teamId, ct);
         if (requiredVersions.Count == 0)
         {
             return true;
         }
 
-        var consentedVersionIds = await GetConsentedVersionIdsAsync(userId, ct);
+        var consentedVersionIds = await ConsentService.GetConsentedVersionIdsAsync(userId, ct);
         return requiredVersions.All(v => consentedVersionIds.Contains(v.Id));
     }
 
@@ -147,8 +156,8 @@ public class MembershipCalculator : IMembershipCalculator
         CancellationToken ct = default)
     {
         var now = _clock.GetCurrentInstant();
-        var requiredVersions = await GetRequiredDocumentVersionsForTeamAsync(teamId, ct);
-        var consentedVersionIds = await GetConsentedVersionIdsAsync(userId, ct);
+        var requiredVersions = await _legalDocumentSyncService.GetRequiredDocumentVersionsForTeamAsync(teamId, ct);
+        var consentedVersionIds = await ConsentService.GetConsentedVersionIdsAsync(userId, ct);
 
         return requiredVersions
             .Where(v => !consentedVersionIds.Contains(v.Id))
@@ -164,11 +173,11 @@ public class MembershipCalculator : IMembershipCalculator
         CancellationToken cancellationToken = default)
     {
         // Get current versions of all required documents (Volunteers team = global)
-        var requiredVersions = await GetRequiredDocumentVersionsForTeamAsync(SystemTeamIds.Volunteers, cancellationToken);
+        var requiredVersions = await _legalDocumentSyncService.GetRequiredDocumentVersionsForTeamAsync(SystemTeamIds.Volunteers, cancellationToken);
         var requiredVersionIds = requiredVersions.Select(v => v.Id).ToList();
 
         // Get versions the user has consented to
-        var consentedVersionIds = await GetConsentedVersionIdsAsync(userId, cancellationToken);
+        var consentedVersionIds = await ConsentService.GetConsentedVersionIdsAsync(userId, cancellationToken);
 
         // Find missing consents
         return requiredVersionIds
@@ -227,7 +236,7 @@ public class MembershipCalculator : IMembershipCalculator
             return new HashSet<Guid>();
         }
 
-        var requiredVersions = await GetRequiredDocumentVersionsForTeamAsync(teamId, ct);
+        var requiredVersions = await _legalDocumentSyncService.GetRequiredDocumentVersionsForTeamAsync(teamId, ct);
         var requiredVersionIds = requiredVersions.Select(v => v.Id).ToList();
 
         if (requiredVersionIds.Count == 0)
@@ -235,7 +244,7 @@ public class MembershipCalculator : IMembershipCalculator
             return userIdList.ToHashSet();
         }
 
-        var consentsByUser = await GetConsentMapForUsersAsync(userIdList, ct);
+        var consentsByUser = await ConsentService.GetConsentMapForUsersAsync(userIdList, ct);
 
         var requiredSet = requiredVersionIds.ToHashSet();
         var result = new HashSet<Guid>();
@@ -264,7 +273,7 @@ public class MembershipCalculator : IMembershipCalculator
 
         var now = _clock.GetCurrentInstant();
 
-        var requiredVersions = await GetRequiredDocumentVersionsForTeamAsync(SystemTeamIds.Volunteers, cancellationToken);
+        var requiredVersions = await _legalDocumentSyncService.GetRequiredDocumentVersionsForTeamAsync(SystemTeamIds.Volunteers, cancellationToken);
         var expiredVersions = requiredVersions
             .Where(v =>
             {
@@ -281,7 +290,7 @@ public class MembershipCalculator : IMembershipCalculator
         var expiredVersionIds = expiredVersions.Select(v => v.Id).ToHashSet();
 
         // Get consented version IDs for all users in batch
-        var consentsByUser = await GetConsentMapForUsersAsync(userIdList, cancellationToken);
+        var consentsByUser = await ConsentService.GetConsentMapForUsersAsync(userIdList, cancellationToken);
 
         var result = new HashSet<Guid>();
         foreach (var userId in userIdList)
@@ -419,60 +428,4 @@ public class MembershipCalculator : IMembershipCalculator
             pendingDeletion);
     }
 
-    private async Task<List<Domain.Entities.DocumentVersion>> GetRequiredDocumentVersionsForTeamAsync(
-        Guid teamId,
-        CancellationToken cancellationToken)
-    {
-        var now = _clock.GetCurrentInstant();
-
-        return await _dbContext.LegalDocuments
-            .AsNoTracking()
-            .Where(d => d.IsRequired && d.IsActive && d.TeamId == teamId)
-            .SelectMany(d => d.Versions)
-            .Where(v => v.EffectiveFrom <= now)
-            .Include(v => v.LegalDocument)
-            .GroupBy(v => v.LegalDocumentId)
-            .Select(g => g.OrderByDescending(v => v.EffectiveFrom).First())
-            .ToListAsync(cancellationToken);
-    }
-
-    private async Task<IReadOnlySet<Guid>> GetConsentedVersionIdsAsync(
-        Guid userId,
-        CancellationToken cancellationToken)
-    {
-        var ids = await _dbContext.ConsentRecords
-            .AsNoTracking()
-            .Where(cr => cr.UserId == userId && cr.ExplicitConsent)
-            .Select(cr => cr.DocumentVersionId)
-            .ToListAsync(cancellationToken);
-
-        return ids.ToHashSet();
-    }
-
-    private async Task<IReadOnlyDictionary<Guid, IReadOnlySet<Guid>>> GetConsentMapForUsersAsync(
-        List<Guid> userIds,
-        CancellationToken cancellationToken)
-    {
-        if (userIds.Count == 0)
-        {
-            return new Dictionary<Guid, IReadOnlySet<Guid>>();
-        }
-
-        var consents = await _dbContext.ConsentRecords
-            .AsNoTracking()
-            .Where(cr => userIds.Contains(cr.UserId) && cr.ExplicitConsent)
-            .Select(cr => new { cr.UserId, cr.DocumentVersionId })
-            .ToListAsync(cancellationToken);
-
-        var result = userIds.ToDictionary(
-            id => id,
-            _ => (IReadOnlySet<Guid>)new HashSet<Guid>());
-
-        foreach (var consent in consents)
-        {
-            ((HashSet<Guid>)result[consent.UserId]).Add(consent.DocumentVersionId);
-        }
-
-        return result;
-    }
 }

--- a/src/Humans.Infrastructure/Services/NotificationService.cs
+++ b/src/Humans.Infrastructure/Services/NotificationService.cs
@@ -17,17 +17,20 @@ namespace Humans.Infrastructure.Services;
 public class NotificationService : INotificationService
 {
     private readonly HumansDbContext _dbContext;
+    private readonly ICommunicationPreferenceService _preferenceService;
     private readonly IClock _clock;
     private readonly IMemoryCache _cache;
     private readonly ILogger<NotificationService> _logger;
 
     public NotificationService(
         HumansDbContext dbContext,
+        ICommunicationPreferenceService preferenceService,
         IClock clock,
         IMemoryCache cache,
         ILogger<NotificationService> logger)
     {
         _dbContext = dbContext;
+        _preferenceService = preferenceService;
         _clock = clock;
         _cache = cache;
         _logger = logger;
@@ -55,12 +58,9 @@ public class NotificationService : INotificationService
         var now = _clock.GetCurrentInstant();
         var category = source.ToMessageCategory();
 
-        // Load preferences for all recipients at once
-        var preferences = await _dbContext.CommunicationPreferences
-            .Where(cp => recipientUserIds.Contains(cp.UserId) && cp.Category == category)
-            .ToListAsync(cancellationToken);
-
-        var prefByUser = preferences.ToDictionary(p => p.UserId);
+        // Load inbox-disabled users for the category via the preference service
+        var inboxDisabled = await _preferenceService.GetUsersWithInboxDisabledAsync(
+            recipientUserIds, category, cancellationToken);
 
         // For individual target, create one notification per user
         foreach (var userId in recipientUserIds)
@@ -68,7 +68,7 @@ public class NotificationService : INotificationService
             // Check InboxEnabled preference — informational can be suppressed
             if (notificationClass == NotificationClass.Informational)
             {
-                if (prefByUser.TryGetValue(userId, out var pref) && !pref.InboxEnabled)
+                if (inboxDisabled.Contains(userId))
                 {
                     _logger.LogDebug(
                         "Skipping informational notification for user {UserId} — InboxEnabled=false for {Category}",
@@ -145,12 +145,9 @@ public class NotificationService : INotificationService
         var now = _clock.GetCurrentInstant();
         var category = source.ToMessageCategory();
 
-        // Load preferences for all team members
-        var preferences = await _dbContext.CommunicationPreferences
-            .Where(cp => memberUserIds.Contains(cp.UserId) && cp.Category == category)
-            .ToListAsync(cancellationToken);
-
-        var prefByUser = preferences.ToDictionary(p => p.UserId);
+        // Load inbox-disabled users for the category via the preference service
+        var inboxDisabled = await _preferenceService.GetUsersWithInboxDisabledAsync(
+            memberUserIds, category, cancellationToken);
 
         // Group target: one shared notification
         var notification = new Notification
@@ -171,7 +168,7 @@ public class NotificationService : INotificationService
         {
             // Check InboxEnabled preference — informational can be suppressed
             if (notificationClass == NotificationClass.Informational &&
-                prefByUser.TryGetValue(userId, out var pref) && !pref.InboxEnabled)
+                inboxDisabled.Contains(userId))
             {
                 continue;
             }
@@ -229,12 +226,9 @@ public class NotificationService : INotificationService
 
         var category = source.ToMessageCategory();
 
-        // Load preferences
-        var preferences = await _dbContext.CommunicationPreferences
-            .Where(cp => roleUserIds.Contains(cp.UserId) && cp.Category == category)
-            .ToListAsync(cancellationToken);
-
-        var prefByUser = preferences.ToDictionary(p => p.UserId);
+        // Load inbox-disabled users for the category via the preference service
+        var inboxDisabled = await _preferenceService.GetUsersWithInboxDisabledAsync(
+            roleUserIds, category, cancellationToken);
 
         // Group target: one shared notification
         var notification = new Notification
@@ -254,7 +248,7 @@ public class NotificationService : INotificationService
         foreach (var userId in roleUserIds)
         {
             if (notificationClass == NotificationClass.Informational &&
-                prefByUser.TryGetValue(userId, out var pref) && !pref.InboxEnabled)
+                inboxDisabled.Contains(userId))
             {
                 continue;
             }

--- a/src/Humans.Infrastructure/Services/ProfileService.cs
+++ b/src/Humans.Infrastructure/Services/ProfileService.cs
@@ -21,6 +21,7 @@ public class ProfileService : IProfileService
     private readonly IEmailService _emailService;
     private readonly IAuditLogService _auditLogService;
     private readonly IMembershipCalculator _membershipCalculator;
+    private readonly IConsentService _consentService;
     private readonly IClock _clock;
     private readonly IMemoryCache _cache;
     private readonly ILogger<ProfileService> _logger;
@@ -31,6 +32,7 @@ public class ProfileService : IProfileService
         IEmailService emailService,
         IAuditLogService auditLogService,
         IMembershipCalculator membershipCalculator,
+        IConsentService consentService,
         IClock clock,
         IMemoryCache cache,
         ILogger<ProfileService> logger)
@@ -40,6 +42,7 @@ public class ProfileService : IProfileService
         _emailService = emailService;
         _auditLogService = auditLogService;
         _membershipCalculator = membershipCalculator;
+        _consentService = consentService;
         _clock = clock;
         _cache = cache;
         _logger = logger;
@@ -452,13 +455,7 @@ public class ProfileService : IProfileService
             .OrderByDescending(a => a.SubmittedAt)
             .ToListAsync(ct);
 
-        var consents = await _dbContext.ConsentRecords
-            .AsNoTracking()
-            .Include(c => c.DocumentVersion)
-                .ThenInclude(v => v.LegalDocument)
-            .Where(c => c.UserId == userId)
-            .OrderByDescending(c => c.ConsentedAt)
-            .ToListAsync(ct);
+        var consents = await _consentService.GetUserConsentRecordsAsync(userId, ct);
 
         var teamMemberships = await _dbContext.TeamMembers
             .AsNoTracking()
@@ -698,12 +695,13 @@ public class ProfileService : IProfileService
         var user = await _dbContext.Users
             .Include(u => u.Profile)
             .Include(u => u.Applications)
-            .Include(u => u.ConsentRecords)
             .Include(u => u.UserEmails)
             .FirstOrDefaultAsync(u => u.Id == userId, ct);
 
         if (user is null)
             return null;
+
+        var consentCount = await _consentService.GetConsentRecordCountAsync(userId, ct);
 
         var roleAssignments = await _dbContext.RoleAssignments
             .AsNoTracking()
@@ -725,7 +723,7 @@ public class ProfileService : IProfileService
             user,
             user.Profile,
             user.Applications.OrderByDescending(a => a.SubmittedAt).ToList(),
-            user.ConsentRecords.Count,
+            consentCount,
             roleAssignments,
             rejectedByName);
     }

--- a/src/Humans.Infrastructure/Services/UnsubscribeService.cs
+++ b/src/Humans.Infrastructure/Services/UnsubscribeService.cs
@@ -46,28 +46,14 @@ public class UnsubscribeService : IUnsubscribeService
 
     public async Task<UnsubscribeTokenResult> ConfirmUnsubscribeAsync(string token, string source, CancellationToken ct = default)
     {
-        // Try new category-aware token first
-        var result = _preferenceService.ValidateUnsubscribeToken(token);
-        if (result is not null)
-        {
-            var (userId, category) = result.Value;
-            var user = await _db.Users.FindAsync(new object[] { userId }, ct);
-            if (user is null)
-                return UnsubscribeTokenResult.Invalid();
+        var result = await ValidateTokenAsync(token, ct);
+        if (!result.IsValid || !result.UserId.HasValue || !result.Category.HasValue)
+            return result;
 
-            await _preferenceService.UpdatePreferenceAsync(userId, category, optedOut: true, source: source);
-            return UnsubscribeTokenResult.Valid(userId, user.DisplayName, category);
-        }
+        await _preferenceService.UpdatePreferenceAsync(
+            result.UserId.Value, result.Category.Value, optedOut: true, source: source);
 
-        // Fall back to legacy campaign-only token
-        var legacyResult = await ValidateLegacyTokenAsync(token, ct);
-        if (legacyResult.IsValid && legacyResult.UserId.HasValue)
-        {
-            await _preferenceService.UpdatePreferenceAsync(
-                legacyResult.UserId.Value, MessageCategory.Marketing, optedOut: true, source: source);
-        }
-
-        return legacyResult;
+        return result;
     }
 
     private async Task<UnsubscribeTokenResult> ValidateLegacyTokenAsync(string token, CancellationToken ct)

--- a/src/Humans.Infrastructure/Services/UnsubscribeService.cs
+++ b/src/Humans.Infrastructure/Services/UnsubscribeService.cs
@@ -1,0 +1,99 @@
+using System.Security.Cryptography;
+using Humans.Application.Interfaces;
+using Humans.Domain.Enums;
+using Humans.Infrastructure.Data;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.Extensions.Logging;
+
+namespace Humans.Infrastructure.Services;
+
+public class UnsubscribeService : IUnsubscribeService
+{
+    private readonly HumansDbContext _db;
+    private readonly ICommunicationPreferenceService _preferenceService;
+    private readonly IDataProtectionProvider _dataProtection;
+    private readonly ILogger<UnsubscribeService> _logger;
+
+    public UnsubscribeService(
+        HumansDbContext db,
+        ICommunicationPreferenceService preferenceService,
+        IDataProtectionProvider dataProtection,
+        ILogger<UnsubscribeService> logger)
+    {
+        _db = db;
+        _preferenceService = preferenceService;
+        _dataProtection = dataProtection;
+        _logger = logger;
+    }
+
+    public async Task<UnsubscribeTokenResult> ValidateTokenAsync(string token, CancellationToken ct = default)
+    {
+        // Try new category-aware token first
+        var result = _preferenceService.ValidateUnsubscribeToken(token);
+        if (result is not null)
+        {
+            var (userId, category) = result.Value;
+            var user = await _db.Users.FindAsync(new object[] { userId }, ct);
+            if (user is null)
+                return UnsubscribeTokenResult.Invalid();
+
+            return UnsubscribeTokenResult.Valid(userId, user.DisplayName, category);
+        }
+
+        // Fall back to legacy campaign-only token
+        return await ValidateLegacyTokenAsync(token, ct);
+    }
+
+    public async Task<UnsubscribeTokenResult> ConfirmUnsubscribeAsync(string token, string source, CancellationToken ct = default)
+    {
+        // Try new category-aware token first
+        var result = _preferenceService.ValidateUnsubscribeToken(token);
+        if (result is not null)
+        {
+            var (userId, category) = result.Value;
+            var user = await _db.Users.FindAsync(new object[] { userId }, ct);
+            if (user is null)
+                return UnsubscribeTokenResult.Invalid();
+
+            await _preferenceService.UpdatePreferenceAsync(userId, category, optedOut: true, source: source);
+            return UnsubscribeTokenResult.Valid(userId, user.DisplayName, category);
+        }
+
+        // Fall back to legacy campaign-only token
+        var legacyResult = await ValidateLegacyTokenAsync(token, ct);
+        if (legacyResult.IsValid && legacyResult.UserId.HasValue)
+        {
+            await _preferenceService.UpdatePreferenceAsync(
+                legacyResult.UserId.Value, MessageCategory.Marketing, optedOut: true, source: source);
+        }
+
+        return legacyResult;
+    }
+
+    private async Task<UnsubscribeTokenResult> ValidateLegacyTokenAsync(string token, CancellationToken ct)
+    {
+        var protector = _dataProtection
+            .CreateProtector("CampaignUnsubscribe")
+            .ToTimeLimitedDataProtector();
+
+        Guid userId;
+        try
+        {
+            var userIdString = protector.Unprotect(token);
+            userId = Guid.Parse(userIdString);
+        }
+        catch (CryptographicException ex)
+        {
+            _logger.LogWarning(ex, "Unsubscribe token was expired or invalid");
+            if (ex.Message.Contains("expired", StringComparison.OrdinalIgnoreCase))
+                return UnsubscribeTokenResult.Expired();
+            return UnsubscribeTokenResult.Invalid();
+        }
+
+        var user = await _db.Users.FindAsync(new object[] { userId }, ct);
+        if (user is null)
+            return UnsubscribeTokenResult.Invalid();
+
+        return UnsubscribeTokenResult.Valid(userId, user.DisplayName, MessageCategory.Marketing, isLegacy: true);
+    }
+}

--- a/src/Humans.Web/Controllers/ContactsController.cs
+++ b/src/Humans.Web/Controllers/ContactsController.cs
@@ -15,17 +15,20 @@ namespace Humans.Web.Controllers;
 public class ContactsController : HumansControllerBase
 {
     private readonly IContactService _contactService;
+    private readonly ICommunicationPreferenceService _preferenceService;
     private readonly IStringLocalizer<SharedResource> _localizer;
     private readonly ILogger<ContactsController> _logger;
 
     public ContactsController(
         UserManager<User> userManager,
         IContactService contactService,
+        ICommunicationPreferenceService preferenceService,
         IStringLocalizer<SharedResource> localizer,
         ILogger<ContactsController> logger)
         : base(userManager)
     {
         _contactService = contactService;
+        _preferenceService = preferenceService;
         _localizer = localizer;
         _logger = logger;
     }
@@ -72,6 +75,8 @@ public class ContactsController : HumansControllerBase
             if (contact is null)
                 return NotFound();
 
+            var preferences = await _preferenceService.GetPreferencesAsync(contact.Id);
+
             var viewModel = new AdminContactDetailViewModel
             {
                 UserId = contact.Id,
@@ -80,7 +85,7 @@ public class ContactsController : HumansControllerBase
                 ContactSource = contact.ContactSource,
                 ExternalSourceId = contact.ExternalSourceId,
                 CreatedAt = contact.CreatedAt,
-                CommunicationPreferences = contact.CommunicationPreferences.ToList()
+                CommunicationPreferences = preferences.ToList()
             };
 
             return View(viewModel);

--- a/src/Humans.Web/Controllers/UnsubscribeController.cs
+++ b/src/Humans.Web/Controllers/UnsubscribeController.cs
@@ -1,76 +1,70 @@
-using System.Security.Cryptography;
 using Humans.Application.Interfaces;
 using Humans.Domain.Enums;
-using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Mvc;
-using Humans.Infrastructure.Data;
 
 namespace Humans.Web.Controllers;
 
 public class UnsubscribeController : Controller
 {
-    private readonly HumansDbContext _db;
-    private readonly ICommunicationPreferenceService _preferenceService;
-    private readonly IDataProtectionProvider _dataProtection;
+    private readonly IUnsubscribeService _unsubscribeService;
     private readonly ILogger<UnsubscribeController> _logger;
 
     public UnsubscribeController(
-        HumansDbContext db,
-        ICommunicationPreferenceService preferenceService,
-        IDataProtectionProvider dataProtection,
+        IUnsubscribeService unsubscribeService,
         ILogger<UnsubscribeController> logger)
     {
-        _db = db;
-        _preferenceService = preferenceService;
-        _dataProtection = dataProtection;
+        _unsubscribeService = unsubscribeService;
         _logger = logger;
     }
 
     [HttpGet("/Unsubscribe/{token}")]
     public async Task<IActionResult> Index(string token)
     {
-        // Try new category-aware token first
-        var result = _preferenceService.ValidateUnsubscribeToken(token);
-        if (result is not null)
-        {
-            var (userId, _) = result.Value;
-            var user = await _db.Users.FindAsync(userId);
-            if (user is null)
-                return NotFound();
+        var result = await _unsubscribeService.ValidateTokenAsync(token);
 
-            // Redirect to comms preferences with token — no session created
+        if (result.IsExpired)
+            return View("Expired");
+
+        if (!result.IsValid)
+            return NotFound();
+
+        if (!result.IsLegacy)
+        {
+            // New tokens redirect to comms preferences with token — no session created
             return RedirectToAction(
                 nameof(GuestController.CommunicationPreferences), "Guest",
                 new { utoken = token });
         }
 
-        // Fall back to legacy campaign-only token
-        return await TryLegacyToken(token);
+        // Legacy tokens show the unsubscribe confirmation page
+        ViewData["DisplayName"] = result.DisplayName;
+        ViewData["CategoryName"] = MessageCategory.Marketing.ToDisplayName();
+        return View();
     }
 
     [HttpPost("/Unsubscribe/{token}")]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> Confirm(string token)
     {
-        // Try new category-aware token first
-        var result = _preferenceService.ValidateUnsubscribeToken(token);
-        if (result is not null)
+        var result = await _unsubscribeService.ConfirmUnsubscribeAsync(token, "MagicLink");
+
+        if (result.IsExpired)
+            return View("Expired");
+
+        if (!result.IsValid)
+            return NotFound();
+
+        if (!result.IsLegacy)
         {
-            var (userId, category) = result.Value;
-            var user = await _db.Users.FindAsync(userId);
-            if (user is null)
-                return NotFound();
-
-            await _preferenceService.UpdatePreferenceAsync(userId, category, optedOut: true, source: "MagicLink");
-
-            // Redirect to comms preferences with token — no session created
+            // New tokens redirect to comms preferences with token — no session created
             return RedirectToAction(
                 nameof(GuestController.CommunicationPreferences), "Guest",
                 new { utoken = token });
         }
 
-        // Fall back to legacy campaign-only token
-        return await TryLegacyConfirm(token);
+        // Legacy tokens show the done page
+        ViewData["CategoryName"] = MessageCategory.Marketing.ToDisplayName();
+        return View("Done");
     }
 
     /// <summary>
@@ -84,18 +78,13 @@ public class UnsubscribeController : Controller
     {
         try
         {
-            var result = _preferenceService.ValidateUnsubscribeToken(token);
-            if (result is null)
+            var result = await _unsubscribeService.ConfirmUnsubscribeAsync(token, "OneClick");
+            if (!result.IsValid)
                 return BadRequest();
 
-            var (userId, category) = result.Value;
-            var user = await _db.Users.FindAsync(userId);
-            if (user is null)
-                return NotFound();
-
-            await _preferenceService.UpdatePreferenceAsync(userId, category, optedOut: true, source: "OneClick");
-
-            _logger.LogInformation("RFC 8058 one-click unsubscribe: user {UserId} from {Category}", userId, category);
+            _logger.LogInformation(
+                "RFC 8058 one-click unsubscribe: user {UserId} from {Category}",
+                result.UserId, result.Category);
             return Ok();
         }
         catch (Exception ex)
@@ -103,65 +92,5 @@ public class UnsubscribeController : Controller
             _logger.LogError(ex, "Failed to process RFC 8058 one-click unsubscribe");
             return StatusCode(500);
         }
-    }
-
-    private async Task<IActionResult> TryLegacyToken(string token)
-    {
-        var protector = _dataProtection
-            .CreateProtector("CampaignUnsubscribe")
-            .ToTimeLimitedDataProtector();
-
-        Guid userId;
-        try
-        {
-            var userIdString = protector.Unprotect(token);
-            userId = Guid.Parse(userIdString);
-        }
-        catch (CryptographicException ex)
-        {
-            _logger.LogWarning(ex, "Unsubscribe token was expired or invalid");
-            if (ex.Message.Contains("expired", StringComparison.OrdinalIgnoreCase))
-                return View("Expired");
-            return NotFound();
-        }
-
-        var user = await _db.Users.FindAsync(userId);
-        if (user is null)
-            return NotFound();
-
-        ViewData["DisplayName"] = user.DisplayName;
-        ViewData["CategoryName"] = MessageCategory.Marketing.ToDisplayName();
-        return View();
-    }
-
-    private async Task<IActionResult> TryLegacyConfirm(string token)
-    {
-        var protector = _dataProtection
-            .CreateProtector("CampaignUnsubscribe")
-            .ToTimeLimitedDataProtector();
-
-        Guid userId;
-        try
-        {
-            var userIdString = protector.Unprotect(token);
-            userId = Guid.Parse(userIdString);
-        }
-        catch (CryptographicException ex)
-        {
-            _logger.LogWarning(ex, "Unsubscribe token was expired or invalid on POST");
-            if (ex.Message.Contains("expired", StringComparison.OrdinalIgnoreCase))
-                return View("Expired");
-            return NotFound();
-        }
-
-        var user = await _db.Users.FindAsync(userId);
-        if (user is null)
-            return NotFound();
-
-        // Use the new preference service for legacy tokens too
-        await _preferenceService.UpdatePreferenceAsync(userId, MessageCategory.Marketing, optedOut: true, source: "MagicLink");
-
-        ViewData["CategoryName"] = MessageCategory.Marketing.ToDisplayName();
-        return View("Done");
     }
 }

--- a/src/Humans.Web/Extensions/InfrastructureServiceCollectionExtensions.cs
+++ b/src/Humans.Web/Extensions/InfrastructureServiceCollectionExtensions.cs
@@ -92,6 +92,7 @@ public static class InfrastructureServiceCollectionExtensions
         services.AddScoped<ICityPlanningService, CityPlanningService>();
         services.AddScoped<ICampContactService, CampContactService>();
         services.AddScoped<ICommunicationPreferenceService, CommunicationPreferenceService>();
+        services.AddScoped<IUnsubscribeService, UnsubscribeService>();
         services.AddScoped<ICampaignService, CampaignService>();
         services.AddScoped<IContactFieldService, ContactFieldService>();
         services.AddScoped<IUserEmailService, UserEmailService>();

--- a/tests/Humans.Application.Tests/Services/AdminLegalDocumentServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/AdminLegalDocumentServiceTests.cs
@@ -198,5 +198,10 @@ public class AdminLegalDocumentServiceTests : IDisposable
         {
             return Task.FromResult<DocumentVersion?>(null);
         }
+
+        public Task<IReadOnlyList<DocumentVersion>> GetRequiredDocumentVersionsForTeamAsync(Guid teamId, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult<IReadOnlyList<DocumentVersion>>(Array.Empty<DocumentVersion>());
+        }
     }
 }

--- a/tests/Humans.Application.Tests/Services/ConsentServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/ConsentServiceTests.cs
@@ -34,8 +34,12 @@ public class ConsentServiceTests : IDisposable
 
         _dbContext = new HumansDbContext(options);
         _clock = new FakeClock(Instant.FromUtc(2026, 3, 1, 12, 0));
+
+        var serviceProvider = Substitute.For<IServiceProvider>();
+        serviceProvider.GetService(typeof(IMembershipCalculator)).Returns(_membershipCalculator);
+
         _service = new ConsentService(
-            _dbContext, _onboardingService, _membershipCalculator,
+            _dbContext, _onboardingService, serviceProvider,
             _notificationInboxService, _syncJob, _metrics, _clock,
             NullLogger<ConsentService>.Instance);
     }

--- a/tests/Humans.Application.Tests/Services/ConsentServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/ConsentServiceTests.cs
@@ -22,6 +22,7 @@ public class ConsentServiceTests : IDisposable
     private readonly ConsentService _service;
     private readonly IOnboardingService _onboardingService = Substitute.For<IOnboardingService>();
     private readonly IMembershipCalculator _membershipCalculator = Substitute.For<IMembershipCalculator>();
+    private readonly ILegalDocumentSyncService _legalDocumentSyncService = Substitute.For<ILegalDocumentSyncService>();
     private readonly INotificationInboxService _notificationInboxService = Substitute.For<INotificationInboxService>();
     private readonly ISystemTeamSync _syncJob = Substitute.For<ISystemTeamSync>();
     private readonly IHumansMetrics _metrics = Substitute.For<IHumansMetrics>();
@@ -38,8 +39,15 @@ public class ConsentServiceTests : IDisposable
         var serviceProvider = Substitute.For<IServiceProvider>();
         serviceProvider.GetService(typeof(IMembershipCalculator)).Returns(_membershipCalculator);
 
+        _legalDocumentSyncService
+            .GetVersionByIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo => _dbContext.DocumentVersions
+                .Include(v => v.LegalDocument)
+                .FirstOrDefaultAsync(v => v.Id == callInfo.ArgAt<Guid>(0)));
+
         _service = new ConsentService(
             _dbContext, _onboardingService, serviceProvider,
+            _legalDocumentSyncService,
             _notificationInboxService, _syncJob, _metrics, _clock,
             NullLogger<ConsentService>.Instance);
     }

--- a/tests/Humans.Application.Tests/Services/MembershipCalculatorTests.cs
+++ b/tests/Humans.Application.Tests/Services/MembershipCalculatorTests.cs
@@ -2,6 +2,8 @@ using AwesomeAssertions;
 using Microsoft.EntityFrameworkCore;
 using NodaTime;
 using NodaTime.Testing;
+using NSubstitute;
+using Humans.Application.Interfaces;
 using Humans.Domain.Constants;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
@@ -16,6 +18,8 @@ public class MembershipCalculatorTests : IDisposable
     private readonly HumansDbContext _dbContext;
     private readonly FakeClock _clock;
     private readonly MembershipCalculator _service;
+    private readonly IConsentService _consentService = Substitute.For<IConsentService>();
+    private readonly ILegalDocumentSyncService _legalDocumentSyncService = Substitute.For<ILegalDocumentSyncService>();
 
     public MembershipCalculatorTests()
     {
@@ -25,7 +29,61 @@ public class MembershipCalculatorTests : IDisposable
 
         _dbContext = new HumansDbContext(options);
         _clock = new FakeClock(Instant.FromUtc(2026, 2, 15, 16, 0));
-        _service = new MembershipCalculator(_dbContext, _clock);
+
+        var serviceProvider = Substitute.For<IServiceProvider>();
+        serviceProvider.GetService(typeof(IConsentService)).Returns(_consentService);
+
+        _service = new MembershipCalculator(_dbContext, serviceProvider, _legalDocumentSyncService, _clock);
+
+        // Delegate to in-memory DB so seeded data is returned
+        _legalDocumentSyncService.GetRequiredDocumentVersionsForTeamAsync(
+            Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var teamId = callInfo.Arg<Guid>();
+                var now = _clock.GetCurrentInstant();
+                var versions = _dbContext.LegalDocuments
+                    .Where(d => d.IsRequired && d.IsActive && d.TeamId == teamId)
+                    .SelectMany(d => d.Versions)
+                    .Where(v => v.EffectiveFrom <= now)
+                    .Include(v => v.LegalDocument)
+                    .ToList()
+                    .GroupBy(v => v.LegalDocumentId)
+                    .Select(g => g.OrderByDescending(v => v.EffectiveFrom).First())
+                    .ToList();
+                return Task.FromResult<IReadOnlyList<DocumentVersion>>(versions);
+            });
+
+        _consentService.GetConsentedVersionIdsAsync(
+            Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var userId = callInfo.Arg<Guid>();
+                var ids = _dbContext.ConsentRecords
+                    .Where(cr => cr.UserId == userId && cr.ExplicitConsent)
+                    .Select(cr => cr.DocumentVersionId)
+                    .ToHashSet();
+                return Task.FromResult<IReadOnlySet<Guid>>(ids);
+            });
+
+        _consentService.GetConsentMapForUsersAsync(
+            Arg.Any<IReadOnlyList<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var userIds = callInfo.Arg<IReadOnlyList<Guid>>();
+                var consents = _dbContext.ConsentRecords
+                    .Where(cr => userIds.Contains(cr.UserId) && cr.ExplicitConsent)
+                    .Select(cr => new { cr.UserId, cr.DocumentVersionId })
+                    .ToList();
+                var result = userIds.ToDictionary(
+                    id => id,
+                    _ => (IReadOnlySet<Guid>)new HashSet<Guid>());
+                foreach (var c in consents)
+                {
+                    ((HashSet<Guid>)result[c.UserId]).Add(c.DocumentVersionId);
+                }
+                return Task.FromResult<IReadOnlyDictionary<Guid, IReadOnlySet<Guid>>>(result);
+            });
     }
 
     public void Dispose()

--- a/tests/Humans.Application.Tests/Services/MembershipPartitionTests.cs
+++ b/tests/Humans.Application.Tests/Services/MembershipPartitionTests.cs
@@ -2,6 +2,8 @@ using AwesomeAssertions;
 using Microsoft.EntityFrameworkCore;
 using NodaTime;
 using NodaTime.Testing;
+using NSubstitute;
+using Humans.Application.Interfaces;
 using Humans.Domain.Constants;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
@@ -16,6 +18,8 @@ public class MembershipPartitionTests : IDisposable
     private readonly HumansDbContext _dbContext;
     private readonly FakeClock _clock;
     private readonly MembershipCalculator _service;
+    private readonly IConsentService _consentService = Substitute.For<IConsentService>();
+    private readonly ILegalDocumentSyncService _legalDocumentSyncService = Substitute.For<ILegalDocumentSyncService>();
 
     public MembershipPartitionTests()
     {
@@ -25,7 +29,61 @@ public class MembershipPartitionTests : IDisposable
 
         _dbContext = new HumansDbContext(options);
         _clock = new FakeClock(Instant.FromUtc(2026, 3, 1, 12, 0));
-        _service = new MembershipCalculator(_dbContext, _clock);
+
+        var serviceProvider = Substitute.For<IServiceProvider>();
+        serviceProvider.GetService(typeof(IConsentService)).Returns(_consentService);
+
+        _service = new MembershipCalculator(_dbContext, serviceProvider, _legalDocumentSyncService, _clock);
+
+        // Delegate to in-memory DB so seeded data is returned
+        _legalDocumentSyncService.GetRequiredDocumentVersionsForTeamAsync(
+            Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var teamId = callInfo.Arg<Guid>();
+                var now = _clock.GetCurrentInstant();
+                var versions = _dbContext.LegalDocuments
+                    .Where(d => d.IsRequired && d.IsActive && d.TeamId == teamId)
+                    .SelectMany(d => d.Versions)
+                    .Where(v => v.EffectiveFrom <= now)
+                    .Include(v => v.LegalDocument)
+                    .ToList()
+                    .GroupBy(v => v.LegalDocumentId)
+                    .Select(g => g.OrderByDescending(v => v.EffectiveFrom).First())
+                    .ToList();
+                return Task.FromResult<IReadOnlyList<DocumentVersion>>(versions);
+            });
+
+        _consentService.GetConsentedVersionIdsAsync(
+            Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var userId = callInfo.Arg<Guid>();
+                var ids = _dbContext.ConsentRecords
+                    .Where(cr => cr.UserId == userId && cr.ExplicitConsent)
+                    .Select(cr => cr.DocumentVersionId)
+                    .ToHashSet();
+                return Task.FromResult<IReadOnlySet<Guid>>(ids);
+            });
+
+        _consentService.GetConsentMapForUsersAsync(
+            Arg.Any<IReadOnlyList<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var userIds = callInfo.Arg<IReadOnlyList<Guid>>();
+                var consents = _dbContext.ConsentRecords
+                    .Where(cr => userIds.Contains(cr.UserId) && cr.ExplicitConsent)
+                    .Select(cr => new { cr.UserId, cr.DocumentVersionId })
+                    .ToList();
+                var result = userIds.ToDictionary(
+                    id => id,
+                    _ => (IReadOnlySet<Guid>)new HashSet<Guid>());
+                foreach (var c in consents)
+                {
+                    ((HashSet<Guid>)result[c.UserId]).Add(c.DocumentVersionId);
+                }
+                return Task.FromResult<IReadOnlyDictionary<Guid, IReadOnlySet<Guid>>>(result);
+            });
 
         // Seed the Volunteers system team (needed for consent queries)
         _dbContext.Teams.Add(new Team

--- a/tests/Humans.Application.Tests/Services/NotificationServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/NotificationServiceTests.cs
@@ -1,4 +1,5 @@
 using AwesomeAssertions;
+using Humans.Application.Interfaces;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Humans.Infrastructure.Data;
@@ -8,6 +9,7 @@ using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NodaTime.Testing;
+using NSubstitute;
 using Xunit;
 
 namespace Humans.Application.Tests.Services;
@@ -18,6 +20,7 @@ public class NotificationServiceTests : IDisposable
     private readonly FakeClock _clock;
     private readonly IMemoryCache _cache;
     private readonly NotificationService _service;
+    private readonly ICommunicationPreferenceService _preferenceService = Substitute.For<ICommunicationPreferenceService>();
 
     public NotificationServiceTests()
     {
@@ -28,7 +31,22 @@ public class NotificationServiceTests : IDisposable
         _dbContext = new HumansDbContext(options);
         _clock = new FakeClock(Instant.FromUtc(2026, 4, 1, 12, 0));
         _cache = new MemoryCache(new MemoryCacheOptions());
-        _service = new NotificationService(_dbContext, _clock, _cache, NullLogger<NotificationService>.Instance);
+
+        // Delegate to in-memory DB so seeded preferences are respected
+        _preferenceService.GetUsersWithInboxDisabledAsync(
+            Arg.Any<IReadOnlyList<Guid>>(), Arg.Any<MessageCategory>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var userIds = callInfo.Arg<IReadOnlyList<Guid>>();
+                var category = callInfo.Arg<MessageCategory>();
+                var disabledIds = _dbContext.CommunicationPreferences
+                    .Where(cp => userIds.Contains(cp.UserId) && cp.Category == category && !cp.InboxEnabled)
+                    .Select(cp => cp.UserId)
+                    .ToHashSet();
+                return Task.FromResult<IReadOnlySet<Guid>>(disabledIds);
+            });
+
+        _service = new NotificationService(_dbContext, _preferenceService, _clock, _cache, NullLogger<NotificationService>.Instance);
     }
 
     public void Dispose()

--- a/tests/Humans.Application.Tests/Services/ProfileServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/ProfileServiceTests.cs
@@ -26,6 +26,7 @@ public class ProfileServiceTests : IDisposable
     private readonly IEmailService _emailService = Substitute.For<IEmailService>();
     private readonly IAuditLogService _auditLogService = Substitute.For<IAuditLogService>();
     private readonly IMembershipCalculator _membershipCalculator = Substitute.For<IMembershipCalculator>();
+    private readonly IConsentService _consentService = Substitute.For<IConsentService>();
     private readonly IMemoryCache _cache = new MemoryCache(new MemoryCacheOptions());
 
     public ProfileServiceTests()
@@ -38,7 +39,7 @@ public class ProfileServiceTests : IDisposable
         _clock = new FakeClock(Instant.FromUtc(2026, 3, 1, 12, 0));
         _service = new ProfileService(
             _dbContext, _onboardingService, _emailService, _auditLogService,
-            _membershipCalculator, _clock, _cache,
+            _membershipCalculator, _consentService, _clock, _cache,
             NullLogger<ProfileService>.Instance);
 
         // Default: return all input IDs as Active (sufficient for most tests that don't filter by status)


### PR DESCRIPTION
## Summary
- Enforce service data ownership for island services: MembershipCalculator, NotificationService, ProfileService, and ContactService now use IConsentService, ILegalDocumentSyncService, and ICommunicationPreferenceService APIs instead of querying consent_records, legal_documents, document_versions, and communication_preferences tables directly
- Extract token validation, user lookup, and legacy crypto logic from UnsubscribeController into a new IUnsubscribeService/UnsubscribeService, eliminating all direct DbContext and IDataProtectionProvider dependencies from the controller
- Fix circular DI dependency (MembershipCalculator -> ConsentService -> OnboardingService -> MembershipCalculator) by using IServiceProvider for lazy resolution

## Issues
- Closes #470
- Closes #422

## Test plan
- [x] All 1002 existing tests pass (874 application + 108 domain + 20 integration)
- [x] No circular dependency errors at startup (verified via integration tests)
- [x] dotnet format --verify-no-changes passes
- [ ] Verify unsubscribe flow works on preview (new token, legacy token, one-click)
- [ ] Verify consent dashboard and membership status computation are unaffected
- [ ] Verify notification delivery respects inbox disabled preferences

🤖 Generated with [Claude Code](https://claude.com/claude-code)