### PR TITLE
Track yearly event participation with self-service opt-out

### DIFF
--- a/docs/features/event-participation.md
+++ b/docs/features/event-participation.md
@@ -1,0 +1,64 @@
+# Event Participation Tracking
+
+## Business Context
+
+Track yearly event participation status for each human, enabling self-service opt-out for those not attending and providing admin visibility into participation breakdown.
+
+## User Stories
+
+### As a human, I want to declare I'm not attending this year
+- Dashboard ticket widget shows "Not attending this year" button when no ticket linked
+- Clicking sets participation status to NotAttending
+- Can undo the declaration to return to default state
+
+### As a ticket holder, my participation is auto-tracked
+- Ticket sync creates/updates participation records automatically
+- Valid ticket -> Ticketed status
+- Checked in -> Attended status (permanent, cannot revert)
+- Ticket purchase overrides a previous NotAttending declaration
+- Ticket void/transfer with no remaining tickets removes Ticketed record
+
+### As an admin, I can see participation breakdown
+- Donut chart on ticket dashboard: Has Ticket / No Ticket / Not Coming
+- "Who Hasn't Bought" excludes humans who declared not attending
+
+### As an admin, I can backfill historical data
+- CSV import of UserId,Status pairs for a given year
+- Available via Tickets > Backfill tab (admin only)
+
+## Data Model
+
+### EventParticipation
+| Property | Type | Notes |
+|----------|------|-------|
+| Id | Guid | PK |
+| UserId | Guid | FK to User (Cascade) |
+| Year | int | Event year |
+| Status | ParticipationStatus | NotAttending, Ticketed, Attended, NoShow |
+| DeclaredAt | Instant? | When user self-declared NotAttending |
+| Source | ParticipationSource | UserDeclared, TicketSync, AdminBackfill |
+
+**Unique constraint:** (UserId, Year)
+
+### EventSettings.Year
+Added `Year` (int) to EventSettings so participation records can be linked to the correct event year.
+
+## Status Lifecycle
+
+| Transition | Trigger |
+|---|---|
+| (none) -> NotAttending | User clicks "Not attending this year" |
+| (none) -> Ticketed | Ticket sync matches valid ticket |
+| NotAttending -> Ticketed | Ticket purchase overrides |
+| Ticketed -> Attended | Ticket sync sees CheckedIn |
+| Ticketed -> NoShow | Post-event derivation |
+| Ticketed -> (removed) | All valid tickets voided/transferred |
+
+Attended is permanent -- cannot be reverted by any mechanism.
+
+## Related Features
+
+- Ticket sync (TicketSyncService)
+- Dashboard ticket widget
+- Ticket admin dashboard
+- "Who Hasn't Bought" metrics

--- a/docs/sections/Tickets.md
+++ b/docs/sections/Tickets.md
@@ -33,9 +33,14 @@
 
 - When ticket sync runs, new orders and attendees are imported and existing ones are updated.
 - Auto-matching runs during sync: orders and attendees are matched to humans by email.
+- Ticket sync derives EventParticipation records: valid ticket -> Ticketed, checked-in -> Attended (permanent).
+- When a user's last valid ticket is voided/transferred, their TicketSync-sourced participation record is removed.
+- Ticket purchase overrides a NotAttending declaration.
+- "Who Hasn't Bought" excludes humans who declared not attending.
 
 ## Cross-Section Dependencies
 
 - **Campaigns**: TicketAdmin can generate discount codes for campaigns via the ticket vendor integration.
 - **Profiles**: Ticket orders and attendees are auto-matched against human email addresses.
 - **Admin**: Sync configuration and manual vendor operations are Admin-only.
+- **Event Participation**: Ticket sync auto-creates/updates EventParticipation records. Admin can backfill historical data via Tickets > Backfill.

--- a/src/Humans.Application/Interfaces/IUserService.cs
+++ b/src/Humans.Application/Interfaces/IUserService.cs
@@ -1,0 +1,51 @@
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+
+namespace Humans.Application.Interfaces;
+
+/// <summary>
+/// Service owning user-level concerns. Currently focused on event participation.
+/// </summary>
+public interface IUserService
+{
+    /// <summary>
+    /// Get the participation record for a user in a given year. Returns null if no record exists.
+    /// </summary>
+    Task<EventParticipation?> GetParticipationAsync(Guid userId, int year);
+
+    /// <summary>
+    /// Get all participation records for a given year.
+    /// </summary>
+    Task<List<EventParticipation>> GetAllParticipationsForYearAsync(int year);
+
+    /// <summary>
+    /// Declare that the user is not attending this year's event.
+    /// </summary>
+    Task<EventParticipation> DeclareNotAttendingAsync(Guid userId, int year);
+
+    /// <summary>
+    /// Undo a "not attending" declaration. Removes the record.
+    /// Only works if the current status is NotAttending with Source=UserDeclared.
+    /// </summary>
+    Task<bool> UndoNotAttendingAsync(Guid userId, int year);
+
+    /// <summary>
+    /// Set participation status from ticket sync. Handles the lifecycle rules:
+    /// - Valid ticket → Ticketed
+    /// - Checked in → Attended (permanent)
+    /// - Ticket purchase overrides NotAttending
+    /// </summary>
+    Task SetParticipationFromTicketSyncAsync(Guid userId, int year, ParticipationStatus status);
+
+    /// <summary>
+    /// Remove a TicketSync-sourced participation record when a user no longer has valid tickets.
+    /// Does not remove UserDeclared or AdminBackfill records.
+    /// Does not remove Attended records (permanent).
+    /// </summary>
+    Task RemoveTicketSyncParticipationAsync(Guid userId, int year);
+
+    /// <summary>
+    /// Bulk import historical participation data (admin backfill).
+    /// </summary>
+    Task<int> BackfillParticipationsAsync(int year, List<(Guid UserId, ParticipationStatus Status)> entries);
+}

--- a/src/Humans.Domain/Entities/EventParticipation.cs
+++ b/src/Humans.Domain/Entities/EventParticipation.cs
@@ -1,0 +1,43 @@
+using Humans.Domain.Enums;
+using NodaTime;
+
+namespace Humans.Domain.Entities;
+
+/// <summary>
+/// Per-user, per-year record tracking event participation status.
+/// No record = unknown/no response yet (default state, not stored).
+/// </summary>
+public class EventParticipation
+{
+    public Guid Id { get; init; }
+
+    /// <summary>
+    /// The user this participation record belongs to.
+    /// </summary>
+    public Guid UserId { get; set; }
+
+    /// <summary>
+    /// The event year (e.g. 2026).
+    /// </summary>
+    public int Year { get; set; }
+
+    /// <summary>
+    /// Current participation status.
+    /// </summary>
+    public ParticipationStatus Status { get; set; }
+
+    /// <summary>
+    /// When the user self-declared NotAttending (null for other sources).
+    /// </summary>
+    public Instant? DeclaredAt { get; set; }
+
+    /// <summary>
+    /// How the status was set.
+    /// </summary>
+    public ParticipationSource Source { get; set; }
+
+    /// <summary>
+    /// Navigation property to the user.
+    /// </summary>
+    public User User { get; set; } = null!;
+}

--- a/src/Humans.Domain/Entities/EventSettings.cs
+++ b/src/Humans.Domain/Entities/EventSettings.cs
@@ -19,6 +19,11 @@ public class EventSettings
     public string EventName { get; set; } = string.Empty;
 
     /// <summary>
+    /// The year of this event (e.g., 2026).
+    /// </summary>
+    public int Year { get; set; }
+
+    /// <summary>
     /// IANA timezone ID (e.g., "Europe/Madrid").
     /// </summary>
     public string TimeZoneId { get; set; } = string.Empty;

--- a/src/Humans.Domain/Entities/User.cs
+++ b/src/Humans.Domain/Entities/User.cs
@@ -163,4 +163,9 @@ public class User : IdentityUser<Guid>
     /// Navigation property to communication preferences.
     /// </summary>
     public ICollection<CommunicationPreference> CommunicationPreferences { get; } = new List<CommunicationPreference>();
+
+    /// <summary>
+    /// Navigation property to event participation records.
+    /// </summary>
+    public ICollection<EventParticipation> EventParticipations { get; } = new List<EventParticipation>();
 }

--- a/src/Humans.Domain/Enums/ParticipationSource.cs
+++ b/src/Humans.Domain/Enums/ParticipationSource.cs
@@ -1,0 +1,22 @@
+namespace Humans.Domain.Enums;
+
+/// <summary>
+/// How an EventParticipation status was set.
+/// </summary>
+public enum ParticipationSource
+{
+    /// <summary>
+    /// User self-declared (e.g. "Not attending this year").
+    /// </summary>
+    UserDeclared = 0,
+
+    /// <summary>
+    /// Automatically set by ticket sync.
+    /// </summary>
+    TicketSync = 1,
+
+    /// <summary>
+    /// Manually backfilled by an admin.
+    /// </summary>
+    AdminBackfill = 2,
+}

--- a/src/Humans.Domain/Enums/ParticipationStatus.cs
+++ b/src/Humans.Domain/Enums/ParticipationStatus.cs
@@ -1,0 +1,27 @@
+namespace Humans.Domain.Enums;
+
+/// <summary>
+/// Status of a user's participation in a yearly event.
+/// </summary>
+public enum ParticipationStatus
+{
+    /// <summary>
+    /// User has declared they are not attending this year.
+    /// </summary>
+    NotAttending = 0,
+
+    /// <summary>
+    /// User has a valid ticket for the event.
+    /// </summary>
+    Ticketed = 1,
+
+    /// <summary>
+    /// User attended the event (checked in).
+    /// </summary>
+    Attended = 2,
+
+    /// <summary>
+    /// User had a ticket but did not attend (post-event derivation).
+    /// </summary>
+    NoShow = 3,
+}

--- a/src/Humans.Infrastructure/Data/Configurations/EventParticipationConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/EventParticipationConfiguration.cs
@@ -1,0 +1,40 @@
+using Humans.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Humans.Infrastructure.Data.Configurations;
+
+public class EventParticipationConfiguration : IEntityTypeConfiguration<EventParticipation>
+{
+    public void Configure(EntityTypeBuilder<EventParticipation> builder)
+    {
+        builder.ToTable("event_participations");
+
+        builder.HasKey(ep => ep.Id);
+
+        builder.Property(ep => ep.UserId)
+            .IsRequired();
+
+        builder.Property(ep => ep.Year)
+            .IsRequired();
+
+        builder.Property(ep => ep.Status)
+            .HasConversion<string>()
+            .HasMaxLength(50)
+            .IsRequired();
+
+        builder.Property(ep => ep.Source)
+            .HasConversion<string>()
+            .HasMaxLength(50)
+            .IsRequired();
+
+        // Unique constraint on (UserId, Year)
+        builder.HasIndex(ep => new { ep.UserId, ep.Year })
+            .IsUnique();
+
+        builder.HasOne(ep => ep.User)
+            .WithMany(u => u.EventParticipations)
+            .HasForeignKey(ep => ep.UserId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/src/Humans.Infrastructure/Data/HumansDbContext.cs
+++ b/src/Humans.Infrastructure/Data/HumansDbContext.cs
@@ -78,6 +78,7 @@ public class HumansDbContext : IdentityDbContext<User, IdentityRole<Guid>, Guid>
     public DbSet<Notification> Notifications => Set<Notification>();
     public DbSet<NotificationRecipient> NotificationRecipients => Set<NotificationRecipient>();
     public DbSet<ProfileLanguage> ProfileLanguages => Set<ProfileLanguage>();
+    public DbSet<EventParticipation> EventParticipations => Set<EventParticipation>();
 
     protected override void OnModelCreating(ModelBuilder builder)
     {

--- a/src/Humans.Infrastructure/Migrations/20260410151810_AddEventParticipationAndEventSettingsYear.Designer.cs
+++ b/src/Humans.Infrastructure/Migrations/20260410151810_AddEventParticipationAndEventSettingsYear.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Humans.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Humans.Infrastructure.Migrations
 {
     [DbContext(typeof(HumansDbContext))]
-    partial class HumansDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260410151810_AddEventParticipationAndEventSettingsYear")]
+    partial class AddEventParticipationAndEventSettingsYear
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Humans.Infrastructure/Migrations/20260410151810_AddEventParticipationAndEventSettingsYear.cs
+++ b/src/Humans.Infrastructure/Migrations/20260410151810_AddEventParticipationAndEventSettingsYear.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NodaTime;
+
+#nullable disable
+
+namespace Humans.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddEventParticipationAndEventSettingsYear : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "Year",
+                table: "event_settings",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.CreateTable(
+                name: "event_participations",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    UserId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Year = table.Column<int>(type: "integer", nullable: false),
+                    Status = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    DeclaredAt = table.Column<Instant>(type: "timestamp with time zone", nullable: true),
+                    Source = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_event_participations", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_event_participations_users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_event_participations_UserId_Year",
+                table: "event_participations",
+                columns: new[] { "UserId", "Year" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "event_participations");
+
+            migrationBuilder.DropColumn(
+                name: "Year",
+                table: "event_settings");
+        }
+    }
+}

--- a/src/Humans.Infrastructure/Migrations/20260410151810_AddEventParticipationAndEventSettingsYear.cs
+++ b/src/Humans.Infrastructure/Migrations/20260410151810_AddEventParticipationAndEventSettingsYear.cs
@@ -19,6 +19,10 @@ namespace Humans.Infrastructure.Migrations
                 nullable: false,
                 defaultValue: 0);
 
+            // Backfill Year from GateOpeningDate so the feature isn't inert after deploy
+            migrationBuilder.Sql(
+                @"UPDATE event_settings SET ""Year"" = EXTRACT(YEAR FROM ""GateOpeningDate"")::integer WHERE ""GateOpeningDate"" IS NOT NULL;");
+
             migrationBuilder.CreateTable(
                 name: "event_participations",
                 columns: table => new

--- a/src/Humans.Infrastructure/Services/TicketQueryService.cs
+++ b/src/Humans.Infrastructure/Services/TicketQueryService.cs
@@ -578,6 +578,23 @@ public class TicketQueryService : ITicketQueryService
                 u.TeamMemberships.Any(tm => tm.TeamId == volunteersTeamId && tm.LeftAt == null))
             .ToList();
 
+        // Exclude humans who declared not attending this year
+        var activeEvent = await _dbContext.EventSettings
+            .FirstOrDefaultAsync(e => e.IsActive);
+        if (activeEvent is not null && activeEvent.Year > 0)
+        {
+            var notAttendingUserIds = await _dbContext.EventParticipations
+                .Where(ep => ep.Year == activeEvent.Year
+                    && ep.Status == ParticipationStatus.NotAttending)
+                .Select(ep => ep.UserId)
+                .ToListAsync();
+
+            var notAttendingSet = new HashSet<Guid>(notAttendingUserIds);
+            activeHumans = activeHumans
+                .Where(u => !notAttendingSet.Contains(u.Id))
+                .ToList();
+        }
+
         var filteredHumans = FilterWhoHasntBoughtHumans(
             activeHumans,
             matchedUserIds,

--- a/src/Humans.Infrastructure/Services/TicketSyncService.cs
+++ b/src/Humans.Infrastructure/Services/TicketSyncService.cs
@@ -23,6 +23,7 @@ public class TicketSyncService : ITicketSyncService
     private readonly IClock _clock;
     private readonly TicketVendorSettings _settings;
     private readonly IMemoryCache _cache;
+    private readonly IUserService _userService;
     private readonly ILogger<TicketSyncService> _logger;
 
     public TicketSyncService(
@@ -32,7 +33,8 @@ public class TicketSyncService : ITicketSyncService
         IClock clock,
         IOptions<TicketVendorSettings> settings,
         ILogger<TicketSyncService> logger,
-        IMemoryCache cache)
+        IMemoryCache cache,
+        IUserService userService)
     {
         _dbContext = dbContext;
         _vendorService = vendorService;
@@ -40,6 +42,7 @@ public class TicketSyncService : ITicketSyncService
         _clock = clock;
         _settings = settings.Value;
         _cache = cache;
+        _userService = userService;
         _logger = logger;
     }
 
@@ -111,6 +114,9 @@ public class TicketSyncService : ITicketSyncService
 
             // Match discount codes to campaign grants
             var codesRedeemed = await MatchDiscountCodesAsync(ct);
+
+            // Sync event participation records
+            await SyncEventParticipationsAsync(ct);
 
             // Update sync state
             syncState.SyncStatus = TicketSyncStatus.Idle;
@@ -450,6 +456,74 @@ public class TicketSyncService : ITicketSyncService
             syncState.LastSyncAt = null;
             await _dbContext.SaveChangesAsync();
         }
+    }
+
+    /// <summary>
+    /// Derive EventParticipation records from current ticket data.
+    /// For each matched user: 1+ valid tickets → Ticketed, any checked-in → Attended.
+    /// If user had Ticketed from TicketSync but now has 0 valid tickets → remove record.
+    /// </summary>
+    private async Task SyncEventParticipationsAsync(CancellationToken ct)
+    {
+        // Determine the event year from EventSettings
+        var activeEvent = await _dbContext.EventSettings
+            .FirstOrDefaultAsync(e => e.IsActive, ct);
+
+        if (activeEvent is null || activeEvent.Year == 0)
+            return;
+
+        var year = activeEvent.Year;
+
+        // Get all attendees matched to users
+        var matchedAttendees = await _dbContext.TicketAttendees
+            .Where(a => a.MatchedUserId != null)
+            .Select(a => new { a.MatchedUserId, a.Status })
+            .ToListAsync(ct);
+
+        // Group by user
+        var userTicketStatuses = matchedAttendees
+            .GroupBy(a => a.MatchedUserId!.Value)
+            .ToDictionary(
+                g => g.Key,
+                g => g.Select(a => a.Status).ToList());
+
+        // Process users with tickets
+        foreach (var (userId, statuses) in userTicketStatuses)
+        {
+            var hasCheckedIn = statuses.Any(s => s == TicketAttendeeStatus.CheckedIn);
+            var hasValidTicket = statuses.Any(s =>
+                s == TicketAttendeeStatus.Valid || s == TicketAttendeeStatus.CheckedIn);
+
+            if (hasCheckedIn)
+            {
+                await _userService.SetParticipationFromTicketSyncAsync(
+                    userId, year, ParticipationStatus.Attended);
+            }
+            else if (hasValidTicket)
+            {
+                await _userService.SetParticipationFromTicketSyncAsync(
+                    userId, year, ParticipationStatus.Ticketed);
+            }
+        }
+
+        // Handle users who previously had tickets but no longer do
+        var existingTicketSyncParticipations = await _dbContext.EventParticipations
+            .Where(ep => ep.Year == year
+                && ep.Source == ParticipationSource.TicketSync
+                && ep.Status == ParticipationStatus.Ticketed)
+            .ToListAsync(ct);
+
+        foreach (var ep in existingTicketSyncParticipations)
+        {
+            if (!userTicketStatuses.ContainsKey(ep.UserId) ||
+                !userTicketStatuses[ep.UserId].Any(s =>
+                    s == TicketAttendeeStatus.Valid || s == TicketAttendeeStatus.CheckedIn))
+            {
+                await _userService.RemoveTicketSyncParticipationAsync(ep.UserId, year);
+            }
+        }
+
+        await _dbContext.SaveChangesAsync(ct);
     }
 
     private static Guid? LookupUserId(Dictionary<string, Guid> lookup, string? email) =>

--- a/src/Humans.Infrastructure/Services/TicketSyncService.cs
+++ b/src/Humans.Infrastructure/Services/TicketSyncService.cs
@@ -474,9 +474,9 @@ public class TicketSyncService : ITicketSyncService
 
         var year = activeEvent.Year;
 
-        // Get all attendees matched to users
+        // Get attendees matched to users for the active vendor event only
         var matchedAttendees = await _dbContext.TicketAttendees
-            .Where(a => a.MatchedUserId != null)
+            .Where(a => a.MatchedUserId != null && a.VendorEventId == _settings.EventId)
             .Select(a => new { a.MatchedUserId, a.Status })
             .ToListAsync(ct);
 

--- a/src/Humans.Infrastructure/Services/UserService.cs
+++ b/src/Humans.Infrastructure/Services/UserService.cs
@@ -1,0 +1,209 @@
+using Humans.Application.Interfaces;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using Humans.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using NodaTime;
+
+namespace Humans.Infrastructure.Services;
+
+public class UserService : IUserService
+{
+    private readonly HumansDbContext _dbContext;
+    private readonly IClock _clock;
+    private readonly ILogger<UserService> _logger;
+
+    public UserService(
+        HumansDbContext dbContext,
+        IClock clock,
+        ILogger<UserService> logger)
+    {
+        _dbContext = dbContext;
+        _clock = clock;
+        _logger = logger;
+    }
+
+    public async Task<EventParticipation?> GetParticipationAsync(Guid userId, int year)
+    {
+        return await _dbContext.EventParticipations
+            .FirstOrDefaultAsync(ep => ep.UserId == userId && ep.Year == year);
+    }
+
+    public async Task<List<EventParticipation>> GetAllParticipationsForYearAsync(int year)
+    {
+        return await _dbContext.EventParticipations
+            .Where(ep => ep.Year == year)
+            .ToListAsync();
+    }
+
+    public async Task<EventParticipation> DeclareNotAttendingAsync(Guid userId, int year)
+    {
+        var existing = await _dbContext.EventParticipations
+            .FirstOrDefaultAsync(ep => ep.UserId == userId && ep.Year == year);
+
+        var now = _clock.GetCurrentInstant();
+
+        if (existing is not null)
+        {
+            // Don't override Attended status — it's permanent
+            if (existing.Status == ParticipationStatus.Attended)
+            {
+                _logger.LogWarning(
+                    "Cannot declare NotAttending for user {UserId} year {Year} — already Attended",
+                    userId, year);
+                return existing;
+            }
+
+            existing.Status = ParticipationStatus.NotAttending;
+            existing.Source = ParticipationSource.UserDeclared;
+            existing.DeclaredAt = now;
+        }
+        else
+        {
+            existing = new EventParticipation
+            {
+                Id = Guid.NewGuid(),
+                UserId = userId,
+                Year = year,
+                Status = ParticipationStatus.NotAttending,
+                Source = ParticipationSource.UserDeclared,
+                DeclaredAt = now,
+            };
+            _dbContext.EventParticipations.Add(existing);
+        }
+
+        await _dbContext.SaveChangesAsync();
+
+        _logger.LogInformation(
+            "User {UserId} declared NotAttending for year {Year}",
+            userId, year);
+
+        return existing;
+    }
+
+    public async Task<bool> UndoNotAttendingAsync(Guid userId, int year)
+    {
+        var existing = await _dbContext.EventParticipations
+            .FirstOrDefaultAsync(ep => ep.UserId == userId && ep.Year == year);
+
+        if (existing is null)
+            return false;
+
+        if (existing.Status != ParticipationStatus.NotAttending ||
+            existing.Source != ParticipationSource.UserDeclared)
+        {
+            _logger.LogWarning(
+                "Cannot undo NotAttending for user {UserId} year {Year} — status is {Status} from {Source}",
+                userId, year, existing.Status, existing.Source);
+            return false;
+        }
+
+        _dbContext.EventParticipations.Remove(existing);
+        await _dbContext.SaveChangesAsync();
+
+        _logger.LogInformation(
+            "User {UserId} undid NotAttending declaration for year {Year}",
+            userId, year);
+
+        return true;
+    }
+
+    public async Task SetParticipationFromTicketSyncAsync(Guid userId, int year, ParticipationStatus status)
+    {
+        var existing = await _dbContext.EventParticipations
+            .FirstOrDefaultAsync(ep => ep.UserId == userId && ep.Year == year);
+
+        if (existing is not null)
+        {
+            // Attended is permanent — never revert
+            if (existing.Status == ParticipationStatus.Attended)
+                return;
+
+            // Ticket purchase overrides NotAttending
+            existing.Status = status;
+            existing.Source = ParticipationSource.TicketSync;
+            existing.DeclaredAt = null;
+        }
+        else
+        {
+            existing = new EventParticipation
+            {
+                Id = Guid.NewGuid(),
+                UserId = userId,
+                Year = year,
+                Status = status,
+                Source = ParticipationSource.TicketSync,
+            };
+            _dbContext.EventParticipations.Add(existing);
+        }
+
+        // Note: caller is responsible for SaveChangesAsync (batch context)
+    }
+
+    public async Task RemoveTicketSyncParticipationAsync(Guid userId, int year)
+    {
+        var existing = await _dbContext.EventParticipations
+            .FirstOrDefaultAsync(ep => ep.UserId == userId && ep.Year == year);
+
+        if (existing is null)
+            return;
+
+        // Only remove TicketSync-sourced records
+        if (existing.Source != ParticipationSource.TicketSync)
+            return;
+
+        // Never remove Attended — it's permanent
+        if (existing.Status == ParticipationStatus.Attended)
+            return;
+
+        _dbContext.EventParticipations.Remove(existing);
+
+        // Note: caller is responsible for SaveChangesAsync (batch context)
+    }
+
+    public async Task<int> BackfillParticipationsAsync(int year, List<(Guid UserId, ParticipationStatus Status)> entries)
+    {
+        var existing = await _dbContext.EventParticipations
+            .Where(ep => ep.Year == year)
+            .ToDictionaryAsync(ep => ep.UserId);
+
+        var count = 0;
+        foreach (var (userId, status) in entries)
+        {
+            if (existing.TryGetValue(userId, out var ep))
+            {
+                // Don't override Attended — permanent
+                if (ep.Status == ParticipationStatus.Attended)
+                    continue;
+
+                ep.Status = status;
+                ep.Source = ParticipationSource.AdminBackfill;
+                ep.DeclaredAt = null;
+            }
+            else
+            {
+                var newEp = new EventParticipation
+                {
+                    Id = Guid.NewGuid(),
+                    UserId = userId,
+                    Year = year,
+                    Status = status,
+                    Source = ParticipationSource.AdminBackfill,
+                };
+                _dbContext.EventParticipations.Add(newEp);
+                existing[userId] = newEp;
+            }
+
+            count++;
+        }
+
+        await _dbContext.SaveChangesAsync();
+
+        _logger.LogInformation(
+            "Backfilled {Count} participation records for year {Year}",
+            count, year);
+
+        return count;
+    }
+}

--- a/src/Humans.Web/Controllers/HomeController.cs
+++ b/src/Humans.Web/Controllers/HomeController.cs
@@ -290,19 +290,26 @@ public class HomeController : HumansControllerBase
     [HttpPost]
     [Authorize]
     [ValidateAntiForgeryToken]
-    public async Task<IActionResult> DeclareNotAttending(int year)
+    public async Task<IActionResult> DeclareNotAttending()
     {
         var (errorResult, user) = await ResolveCurrentUserAsync();
         if (errorResult is not null) return errorResult;
 
         try
         {
-            await _userService.DeclareNotAttendingAsync(user.Id, year);
+            var activeEvent = await _shiftMgmt.GetActiveAsync();
+            if (activeEvent is null || activeEvent.Year <= 0)
+            {
+                SetError("No active event configured.");
+                return RedirectToAction(nameof(Index));
+            }
+
+            await _userService.DeclareNotAttendingAsync(user.Id, activeEvent.Year);
             SetSuccess("You've been marked as not attending this year.");
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to declare not attending for user {UserId} year {Year}", user.Id, year);
+            _logger.LogError(ex, "Failed to declare not attending for user {UserId}", user.Id);
             SetError("Something went wrong. Please try again.");
         }
 
@@ -312,14 +319,21 @@ public class HomeController : HumansControllerBase
     [HttpPost]
     [Authorize]
     [ValidateAntiForgeryToken]
-    public async Task<IActionResult> UndoNotAttending(int year)
+    public async Task<IActionResult> UndoNotAttending()
     {
         var (errorResult, user) = await ResolveCurrentUserAsync();
         if (errorResult is not null) return errorResult;
 
         try
         {
-            var undone = await _userService.UndoNotAttendingAsync(user.Id, year);
+            var activeEvent = await _shiftMgmt.GetActiveAsync();
+            if (activeEvent is null || activeEvent.Year <= 0)
+            {
+                SetError("No active event configured.");
+                return RedirectToAction(nameof(Index));
+            }
+
+            var undone = await _userService.UndoNotAttendingAsync(user.Id, activeEvent.Year);
             if (undone)
             {
                 SetSuccess("Your declaration has been removed.");
@@ -331,7 +345,7 @@ public class HomeController : HumansControllerBase
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to undo not attending for user {UserId} year {Year}", user.Id, year);
+            _logger.LogError(ex, "Failed to undo not attending for user {UserId}", user.Id);
             SetError("Something went wrong. Please try again.");
         }
 

--- a/src/Humans.Web/Controllers/HomeController.cs
+++ b/src/Humans.Web/Controllers/HomeController.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
@@ -23,6 +24,7 @@ public class HomeController : HumansControllerBase
     private readonly IClock _clock;
     private readonly TicketVendorSettings _ticketSettings;
     private readonly ITicketQueryService _ticketQueryService;
+    private readonly IUserService _userService;
     private readonly ILogger<HomeController> _logger;
 
     public HomeController(
@@ -37,6 +39,7 @@ public class HomeController : HumansControllerBase
         IClock clock,
         IOptions<TicketVendorSettings> ticketSettings,
         ITicketQueryService ticketQueryService,
+        IUserService userService,
         ILogger<HomeController> logger)
         : base(userManager)
     {
@@ -50,6 +53,7 @@ public class HomeController : HumansControllerBase
         _clock = clock;
         _ticketSettings = ticketSettings.Value;
         _ticketQueryService = ticketQueryService;
+        _userService = userService;
         _logger = logger;
     }
 
@@ -138,10 +142,20 @@ public class HomeController : HumansControllerBase
             LastLogin = user.LastLoginAt?.ToDateTimeUtc()
         };
 
+        // Load active event once — used by shift cards, ticket widget, and participation
+        EventSettings? activeEvent = null;
+        try
+        {
+            activeEvent = await _shiftMgmt.GetActiveAsync();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to load active event for dashboard");
+        }
+
         // Shift cards — fully guarded, failures must never crash the homepage
         try
         {
-            var activeEvent = await _shiftMgmt.GetActiveAsync();
             if (activeEvent is not null)
             {
                 viewModel.EventName = activeEvent.EventName;
@@ -255,7 +269,73 @@ public class HomeController : HumansControllerBase
             _logger.LogError(ex, "Failed to load ticket status for user {UserId}", user.Id);
         }
 
+        // Event participation status
+        try
+        {
+            if (activeEvent is not null && activeEvent.Year > 0)
+            {
+                viewModel.EventYear = activeEvent.Year;
+                var participation = await _userService.GetParticipationAsync(user.Id, activeEvent.Year);
+                viewModel.ParticipationStatus = participation?.Status;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to load participation status for user {UserId}", user.Id);
+        }
+
         return View("Dashboard", viewModel);
+    }
+
+    [HttpPost]
+    [Authorize]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> DeclareNotAttending(int year)
+    {
+        var (errorResult, user) = await ResolveCurrentUserAsync();
+        if (errorResult is not null) return errorResult;
+
+        try
+        {
+            await _userService.DeclareNotAttendingAsync(user.Id, year);
+            SetSuccess("You've been marked as not attending this year.");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to declare not attending for user {UserId} year {Year}", user.Id, year);
+            SetError("Something went wrong. Please try again.");
+        }
+
+        return RedirectToAction(nameof(Index));
+    }
+
+    [HttpPost]
+    [Authorize]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> UndoNotAttending(int year)
+    {
+        var (errorResult, user) = await ResolveCurrentUserAsync();
+        if (errorResult is not null) return errorResult;
+
+        try
+        {
+            var undone = await _userService.UndoNotAttendingAsync(user.Id, year);
+            if (undone)
+            {
+                SetSuccess("Your declaration has been removed.");
+            }
+            else
+            {
+                SetError("Could not undo — your status may have been updated by ticket sync.");
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to undo not attending for user {UserId} year {Year}", user.Id, year);
+            SetError("Something went wrong. Please try again.");
+        }
+
+        return RedirectToAction(nameof(Index));
     }
 
     public IActionResult Privacy()

--- a/src/Humans.Web/Controllers/TicketController.cs
+++ b/src/Humans.Web/Controllers/TicketController.cs
@@ -2,6 +2,7 @@ using Hangfire;
 using Humans.Application.Interfaces;
 using Humans.Domain.Constants;
 using Humans.Domain.Entities;
+using Humans.Domain.Enums;
 using Humans.Infrastructure.Jobs;
 using Humans.Infrastructure.Services;
 using Humans.Web.Authorization;
@@ -22,6 +23,8 @@ public class TicketController : HumansControllerBase
     private readonly TicketVendorSettings _settings;
     private readonly ITicketQueryService _ticketQueryService;
     private readonly ITicketSyncService _ticketSyncService;
+    private readonly IUserService _userService;
+    private readonly IShiftManagementService _shiftMgmt;
     private readonly ILogger<TicketController> _logger;
 
     public TicketController(
@@ -29,6 +32,8 @@ public class TicketController : HumansControllerBase
         IOptions<TicketVendorSettings> settings,
         ITicketQueryService ticketQueryService,
         ITicketSyncService ticketSyncService,
+        IUserService userService,
+        IShiftManagementService shiftMgmt,
         UserManager<User> userManager,
         ILogger<TicketController> logger)
         : base(userManager)
@@ -37,6 +42,8 @@ public class TicketController : HumansControllerBase
         _settings = settings.Value;
         _ticketQueryService = ticketQueryService;
         _ticketSyncService = ticketSyncService;
+        _userService = userService;
+        _shiftMgmt = shiftMgmt;
         _logger = logger;
     }
 
@@ -112,6 +119,31 @@ public class TicketController : HumansControllerBase
             VolunteersWithTickets = stats.VolunteersWithTickets,
             VolunteerCoveragePercent = stats.VolunteerCoveragePercent,
         };
+
+        // Participation breakdown for donut chart
+        try
+        {
+            var activeEvent = await _shiftMgmt.GetActiveAsync();
+            if (activeEvent is not null && activeEvent.Year > 0)
+            {
+                var participations = await _userService.GetAllParticipationsForYearAsync(activeEvent.Year);
+                var notAttendingCount = participations.Count(p => p.Status == ParticipationStatus.NotAttending);
+                var hasTicketCount = participations.Count(p =>
+                    p.Status == ParticipationStatus.Ticketed ||
+                    p.Status == ParticipationStatus.Attended);
+
+                // "No Ticket" = total active volunteers minus those with tickets minus those who declared not attending
+                var noTicketCount = Math.Max(0, stats.TotalActiveVolunteers - hasTicketCount - notAttendingCount);
+
+                model.ParticipationNotAttending = notAttendingCount;
+                model.ParticipationHasTicket = hasTicketCount;
+                model.ParticipationNoTicket = noTicketCount;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to load participation breakdown for ticket dashboard");
+        }
 
         return View(model);
     }
@@ -351,6 +383,67 @@ public class TicketController : HumansControllerBase
 
         BackgroundJob.Enqueue<TicketSyncJob>(job => job.ExecuteAsync(CancellationToken.None));
         SetSuccess("Full re-sync triggered. All orders will be re-fetched.");
+        return RedirectToAction(nameof(Index));
+    }
+
+    [HttpGet("Participation/Backfill")]
+    [Authorize(Policy = PolicyNames.AdminOnly)]
+    public async Task<IActionResult> ParticipationBackfill()
+    {
+        var activeEvent = await _shiftMgmt.GetActiveAsync();
+        var model = new ParticipationBackfillViewModel
+        {
+            Year = activeEvent?.Year ?? DateTime.UtcNow.Year,
+        };
+        return View(model);
+    }
+
+    [HttpPost("Participation/Backfill")]
+    [ValidateAntiForgeryToken]
+    [Authorize(Policy = PolicyNames.AdminOnly)]
+    public async Task<IActionResult> ParticipationBackfill(ParticipationBackfillViewModel model)
+    {
+        if (!ModelState.IsValid || string.IsNullOrWhiteSpace(model.CsvData))
+        {
+            SetError("Please provide CSV data with UserId and Status columns.");
+            return View(model);
+        }
+
+        try
+        {
+            var entries = new List<(Guid UserId, ParticipationStatus Status)>();
+            var lines = model.CsvData.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+            foreach (var line in lines)
+            {
+                var parts = line.Split(',', StringSplitOptions.TrimEntries);
+                if (parts.Length < 2) continue;
+
+                // Skip header row
+                if (string.Equals(parts[0], "UserId", StringComparison.OrdinalIgnoreCase)) continue;
+
+                if (!Guid.TryParse(parts[0], out var userId)) continue;
+                if (!Enum.TryParse<ParticipationStatus>(parts[1], ignoreCase: true, out var status)) continue;
+
+                entries.Add((userId, status));
+            }
+
+            if (entries.Count == 0)
+            {
+                SetError("No valid entries found in the CSV data.");
+                return View(model);
+            }
+
+            var count = await _userService.BackfillParticipationsAsync(model.Year, entries);
+            SetSuccess($"Successfully backfilled {count} participation records for {model.Year}.");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to backfill participation data for year {Year}", model.Year);
+            SetError("Failed to process backfill data. Check the format and try again.");
+            return View(model);
+        }
+
         return RedirectToAction(nameof(Index));
     }
 

--- a/src/Humans.Web/Controllers/TicketController.cs
+++ b/src/Humans.Web/Controllers/TicketController.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
+using NodaTime;
 
 namespace Humans.Web.Controllers;
 
@@ -25,6 +26,7 @@ public class TicketController : HumansControllerBase
     private readonly ITicketSyncService _ticketSyncService;
     private readonly IUserService _userService;
     private readonly IShiftManagementService _shiftMgmt;
+    private readonly IClock _clock;
     private readonly ILogger<TicketController> _logger;
 
     public TicketController(
@@ -34,6 +36,7 @@ public class TicketController : HumansControllerBase
         ITicketSyncService ticketSyncService,
         IUserService userService,
         IShiftManagementService shiftMgmt,
+        IClock clock,
         UserManager<User> userManager,
         ILogger<TicketController> logger)
         : base(userManager)
@@ -44,6 +47,7 @@ public class TicketController : HumansControllerBase
         _ticketSyncService = ticketSyncService;
         _userService = userService;
         _shiftMgmt = shiftMgmt;
+        _clock = clock;
         _logger = logger;
     }
 
@@ -393,7 +397,7 @@ public class TicketController : HumansControllerBase
         var activeEvent = await _shiftMgmt.GetActiveAsync();
         var model = new ParticipationBackfillViewModel
         {
-            Year = activeEvent?.Year ?? DateTime.UtcNow.Year,
+            Year = activeEvent?.Year ?? _clock.GetCurrentInstant().InUtc().Year,
         };
         return View(model);
     }

--- a/src/Humans.Web/Extensions/InfrastructureServiceCollectionExtensions.cs
+++ b/src/Humans.Web/Extensions/InfrastructureServiceCollectionExtensions.cs
@@ -161,6 +161,7 @@ public static class InfrastructureServiceCollectionExtensions
         services.AddScoped<IOnboardingService, OnboardingService>();
         services.AddScoped<IConsentService, ConsentService>();
         services.AddScoped<IProfileService, ProfileService>();
+        services.AddScoped<IUserService, UserService>();
         services.AddScoped<SystemTeamSyncJob>();
         services.AddScoped<ISystemTeamSync>(sp => sp.GetRequiredService<SystemTeamSyncJob>());
         services.AddScoped<SyncLegalDocumentsJob>();

--- a/src/Humans.Web/Models/DashboardViewModel.cs
+++ b/src/Humans.Web/Models/DashboardViewModel.cs
@@ -4,6 +4,10 @@ namespace Humans.Web.Models;
 
 public class DashboardViewModel
 {
+    // Event participation
+    public int? EventYear { get; set; }
+    public ParticipationStatus? ParticipationStatus { get; set; }
+
     public Guid UserId { get; set; }
     public string DisplayName { get; set; } = string.Empty;
     public string? ProfilePictureUrl { get; set; }

--- a/src/Humans.Web/Models/TicketViewModels.cs
+++ b/src/Humans.Web/Models/TicketViewModels.cs
@@ -43,6 +43,11 @@ public class TicketDashboardViewModel
     public int TotalActiveVolunteers { get; set; }
     public int VolunteersWithTickets { get; set; }
     public decimal VolunteerCoveragePercent { get; set; }
+
+    // Participation breakdown
+    public int ParticipationNotAttending { get; set; }
+    public int ParticipationNoTicket { get; set; }
+    public int ParticipationHasTicket { get; set; }
 }
 
 public class PaymentMethodFeeBreakdown
@@ -223,6 +228,12 @@ public class WhoHasntBoughtViewModel : PagedListViewModel
     public string? FilterTier { get; set; }
     public string? FilterTicketStatus { get; set; } // "bought", "not_bought", or null (all)
     public List<string> AvailableTeams { get; set; } = [];
+}
+
+public class ParticipationBackfillViewModel
+{
+    public int Year { get; set; }
+    public string? CsvData { get; set; }
 }
 
 public class WhoHasntBoughtRow

--- a/src/Humans.Web/Views/Home/Dashboard.cshtml
+++ b/src/Humans.Web/Views/Home/Dashboard.cshtml
@@ -238,7 +238,6 @@
                     </div>
                     <form asp-action="UndoNotAttending" method="post">
                         @Html.AntiForgeryToken()
-                        <input type="hidden" name="year" value="@Model.EventYear" />
                         <button type="submit" class="btn btn-outline-primary btn-sm">
                             <i class="fa-solid fa-rotate-left me-1"></i> Undo — I might attend
                         </button>
@@ -256,7 +255,6 @@
                         <hr />
                         <form asp-action="DeclareNotAttending" method="post">
                             @Html.AntiForgeryToken()
-                            <input type="hidden" name="year" value="@Model.EventYear" />
                             <button type="submit" class="btn btn-outline-secondary btn-sm">
                                 <i class="fa-solid fa-xmark me-1"></i> Not attending this year
                             </button>

--- a/src/Humans.Web/Views/Home/Dashboard.cshtml
+++ b/src/Humans.Web/Views/Home/Dashboard.cshtml
@@ -227,6 +227,23 @@
                         </div>
                     </div>
                 }
+                else if (Model.ParticipationStatus == ParticipationStatus.NotAttending)
+                {
+                    <div class="d-flex align-items-center mb-3">
+                        <i class="fa-solid fa-circle-xmark text-secondary fs-3 me-3"></i>
+                        <div>
+                            <strong>You're marked as not attending this year.</strong>
+                            <br /><span class="text-muted">Changed your mind? You can undo this below.</span>
+                        </div>
+                    </div>
+                    <form asp-action="UndoNotAttending" method="post">
+                        @Html.AntiForgeryToken()
+                        <input type="hidden" name="year" value="@Model.EventYear" />
+                        <button type="submit" class="btn btn-outline-primary btn-sm">
+                            <i class="fa-solid fa-rotate-left me-1"></i> Undo — I might attend
+                        </button>
+                    </form>
+                }
                 else
                 {
                     <p class="mb-2">We don't see a ticket linked to your account yet.</p>
@@ -234,6 +251,17 @@
                         <i class="fa-solid fa-external-link-alt me-1"></i> Buy your ticket now
                     </a>
                     <p class="text-muted small mt-2 mb-0">Bought on a different email? <a href="/Profile/Me/Emails">Add it here</a></p>
+                    @if (Model.EventYear.HasValue)
+                    {
+                        <hr />
+                        <form asp-action="DeclareNotAttending" method="post">
+                            @Html.AntiForgeryToken()
+                            <input type="hidden" name="year" value="@Model.EventYear" />
+                            <button type="submit" class="btn btn-outline-secondary btn-sm">
+                                <i class="fa-solid fa-xmark me-1"></i> Not attending this year
+                            </button>
+                        </form>
+                    }
                 }
             </div>
         </div>

--- a/src/Humans.Web/Views/Ticket/Index.cshtml
+++ b/src/Humans.Web/Views/Ticket/Index.cshtml
@@ -128,6 +128,45 @@
         </div>
     }
 
+    <!-- Participation Breakdown -->
+    @{
+        var participationTotal = Model.ParticipationNotAttending + Model.ParticipationNoTicket + Model.ParticipationHasTicket;
+    }
+    @if (participationTotal > 0)
+    {
+        <div class="card mb-4">
+            <div class="card-header">
+                <i class="fa-solid fa-chart-pie"></i> Participation Breakdown
+            </div>
+            <div class="card-body">
+                <div class="row align-items-center">
+                    <div class="col-md-6">
+                        <canvas id="participationChart" height="200"></canvas>
+                    </div>
+                    <div class="col-md-6">
+                        <ul class="list-unstyled">
+                            <li class="mb-2">
+                                <span class="badge bg-success">&nbsp;&nbsp;</span>
+                                <strong>Has Ticket:</strong> @Model.ParticipationHasTicket
+                                (@(participationTotal > 0 ? Math.Round((decimal)Model.ParticipationHasTicket / participationTotal * 100) : 0)%)
+                            </li>
+                            <li class="mb-2">
+                                <span class="badge bg-warning">&nbsp;&nbsp;</span>
+                                <strong>No Ticket:</strong> @Model.ParticipationNoTicket
+                                (@(participationTotal > 0 ? Math.Round((decimal)Model.ParticipationNoTicket / participationTotal * 100) : 0)%)
+                            </li>
+                            <li class="mb-2">
+                                <span class="badge bg-secondary">&nbsp;&nbsp;</span>
+                                <strong>Not Coming:</strong> @Model.ParticipationNotAttending
+                                (@(participationTotal > 0 ? Math.Round((decimal)Model.ParticipationNotAttending / participationTotal * 100) : 0)%)
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    }
+
     <!-- Daily Sales Chart -->
     @if (Model.DailySales.Count > 0)
     {
@@ -312,46 +351,74 @@
     </div>
 </div>
 
-@if (Model.DailySales.Count > 0)
+@if (Model.DailySales.Count > 0 || participationTotal > 0)
 {
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1/dist/chart.umd.min.js"
             integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ"
             crossorigin="anonymous"></script>
     <script>
         document.addEventListener('DOMContentLoaded', function() {
-            var data = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.DailySales, new System.Text.Json.JsonSerializerOptions { PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase }));
-            var ctx = document.getElementById('dailySalesChart').getContext('2d');
-            new Chart(ctx, {
-                type: 'bar',
-                data: {
-                    labels: data.map(d => d.date),
-                    datasets: [
-                        {
-                            label: 'Tickets Sold',
-                            data: data.map(d => d.ticketsSold),
-                            backgroundColor: 'rgba(54, 162, 235, 0.6)',
-                            order: 2
-                        },
-                        {
-                            label: '7-day Avg',
-                            data: data.map(d => d.rollingAverage),
-                            type: 'line',
-                            borderColor: 'rgba(255, 99, 132, 1)',
-                            borderWidth: 2,
-                            fill: false,
-                            pointRadius: 0,
-                            order: 1
+            @if (Model.DailySales.Count > 0)
+            {
+                <text>
+                var salesData = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.DailySales, new System.Text.Json.JsonSerializerOptions { PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase }));
+                var salesCtx = document.getElementById('dailySalesChart').getContext('2d');
+                new Chart(salesCtx, {
+                    type: 'bar',
+                    data: {
+                        labels: salesData.map(d => d.date),
+                        datasets: [
+                            {
+                                label: 'Tickets Sold',
+                                data: salesData.map(d => d.ticketsSold),
+                                backgroundColor: 'rgba(54, 162, 235, 0.6)',
+                                order: 2
+                            },
+                            {
+                                label: '7-day Avg',
+                                data: salesData.map(d => d.rollingAverage),
+                                type: 'line',
+                                borderColor: 'rgba(255, 99, 132, 1)',
+                                borderWidth: 2,
+                                fill: false,
+                                pointRadius: 0,
+                                order: 1
+                            }
+                        ]
+                    },
+                    options: {
+                        responsive: true,
+                        scales: {
+                            x: { display: true },
+                            y: { beginAtZero: true, title: { display: true, text: 'Tickets' } }
                         }
-                    ]
-                },
-                options: {
-                    responsive: true,
-                    scales: {
-                        x: { display: true },
-                        y: { beginAtZero: true, title: { display: true, text: 'Tickets' } }
                     }
-                }
-            });
+                });
+                </text>
+            }
+
+            @if (participationTotal > 0)
+            {
+                <text>
+                var partCtx = document.getElementById('participationChart').getContext('2d');
+                new Chart(partCtx, {
+                    type: 'doughnut',
+                    data: {
+                        labels: ['Has Ticket', 'No Ticket', 'Not Coming'],
+                        datasets: [{
+                            data: [@Model.ParticipationHasTicket, @Model.ParticipationNoTicket, @Model.ParticipationNotAttending],
+                            backgroundColor: ['#198754', '#ffc107', '#6c757d']
+                        }]
+                    },
+                    options: {
+                        responsive: true,
+                        plugins: {
+                            legend: { position: 'bottom' }
+                        }
+                    }
+                });
+                </text>
+            }
         });
     </script>
 }

--- a/src/Humans.Web/Views/Ticket/ParticipationBackfill.cshtml
+++ b/src/Humans.Web/Views/Ticket/ParticipationBackfill.cshtml
@@ -1,0 +1,44 @@
+@model Humans.Web.Models.ParticipationBackfillViewModel
+@{
+    ViewData["Title"] = "Backfill Participation Data";
+}
+
+<div class="container-fluid px-4">
+    <div class="d-flex justify-content-between align-items-center mt-4 mb-2">
+        <h1 class="mb-0">Backfill Participation Data</h1>
+    </div>
+
+    <partial name="_TicketNav" />
+
+    <vc:temp-data-alerts />
+
+    <div class="card">
+        <div class="card-body">
+            <p class="text-muted">
+                Paste CSV data with <code>UserId,Status</code> columns to bulk-import historical participation records.
+                Valid statuses: <code>NotAttending</code>, <code>Ticketed</code>, <code>Attended</code>, <code>NoShow</code>.
+                Existing Attended records will not be overwritten (permanent).
+            </p>
+
+            <form asp-action="ParticipationBackfill" method="post">
+                @Html.AntiForgeryToken()
+
+                <div class="mb-3">
+                    <label asp-for="Year" class="form-label">Year</label>
+                    <input asp-for="Year" class="form-control" style="max-width: 200px;" />
+                </div>
+
+                <div class="mb-3">
+                    <label asp-for="CsvData" class="form-label">CSV Data</label>
+                    <textarea asp-for="CsvData" class="form-control font-monospace" rows="10"
+                              placeholder="UserId,Status&#10;3fa85f64-5717-4562-b3fc-2c963f66afa6,Attended&#10;..."></textarea>
+                </div>
+
+                <button type="submit" class="btn btn-primary">
+                    <i class="fa-solid fa-upload me-1"></i> Import
+                </button>
+                <a asp-action="Index" class="btn btn-outline-secondary ms-2">Cancel</a>
+            </form>
+        </div>
+    </div>
+</div>

--- a/src/Humans.Web/Views/Ticket/_TicketNav.cshtml
+++ b/src/Humans.Web/Views/Ticket/_TicketNav.cshtml
@@ -23,4 +23,7 @@
     <li class="nav-item">
         <a class="nav-link @(controller == "GateList" ? "active" : "")" asp-action="GateList">Gate List</a>
     </li>
+    <li class="nav-item" authorize-policy="AdminOnly">
+        <a class="nav-link @(controller == "ParticipationBackfill" ? "active" : "")" asp-action="ParticipationBackfill">Backfill</a>
+    </li>
 </ul>

--- a/tests/Humans.Application.Tests/Services/TicketSyncServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/TicketSyncServiceTests.cs
@@ -43,6 +43,7 @@ public class TicketSyncServiceTests : IDisposable
         });
 
         _stripeService = Substitute.For<IStripeService>();
+        var userService = Substitute.For<IUserService>();
         _service = new TicketSyncService(
             _dbContext,
             _vendorService,
@@ -50,7 +51,8 @@ public class TicketSyncServiceTests : IDisposable
             _clock,
             settings,
             NullLogger<TicketSyncService>.Instance,
-            new MemoryCache(new MemoryCacheOptions()));
+            new MemoryCache(new MemoryCacheOptions()),
+            userService);
 
         // Seed the singleton TicketSyncState row
         _dbContext.TicketSyncStates.Add(new TicketSyncState
@@ -287,7 +289,8 @@ public class TicketSyncServiceTests : IDisposable
             _clock,
             settings,
             NullLogger<TicketSyncService>.Instance,
-            new MemoryCache(new MemoryCacheOptions()));
+            new MemoryCache(new MemoryCacheOptions()),
+            Substitute.For<IUserService>());
 
         var result = await service.SyncOrdersAndAttendeesAsync();
 


### PR DESCRIPTION
## Summary
- Add `EventParticipation` entity with `(UserId, Year)` unique constraint and status lifecycle (NotAttending/Ticketed/Attended/NoShow) with source tracking (UserDeclared/TicketSync/AdminBackfill)
- Dashboard ticket widget: "Not attending this year" button with undo, ticket sync auto-derives participation records, participation donut chart on ticket dashboard, "Who Hasn't Bought" excludes not-attending humans
- Admin CSV backfill for historical participation data; adds `Year` field to `EventSettings`

## Issues
- Closes #467

## Test plan
- [x] Verify "Not attending this year" button appears in dashboard widget when no ticket is linked
- [x] Declare not attending, verify confirmation message and undo button appear
- [x] Undo declaration, verify default ticket widget returns
- [ ] Run ticket sync with matched attendees, verify EventParticipation records created (Ticketed/Attended)
- [ ] Verify Attended status cannot be reverted by any mechanism
- [ ] Verify ticket purchase overrides NotAttending declaration
- [ ] Verify ticket void with no remaining valid tickets removes Ticketed record
- [x] Check participation donut chart on ticket dashboard shows Has Ticket / No Ticket / Not Coming
- [x] Verify "Who Hasn't Bought" page excludes humans who declared not attending
- [ ] Test admin backfill CSV import via Tickets > Backfill tab
- [ ] Verify EF migration applies cleanly on fresh and existing databases
- [ ] Verify Year field on EventSettings is populated for active event

🤖 Generated with [Claude Code](https://claude.com/claude-code)