### PR TITLE
Add auto-label workflow for EF migration PRs

### DIFF
--- a/.github/workflows/label-db.yml
+++ b/.github/workflows/label-db.yml
@@ -1,0 +1,51 @@
+name: Label PRs with EF migrations
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  check-migrations:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for migration files in PR diff
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: files } = await github.rest.pulls.listFiles({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              per_page: 100
+            });
+
+            const hasMigration = files.some(f =>
+              f.filename.startsWith('src/Humans.Infrastructure/Migrations/') &&
+              f.status !== 'removed'
+            );
+
+            const labels = context.payload.pull_request.labels.map(l => l.name);
+            const hasLabel = labels.includes('db');
+
+            if (hasMigration && !hasLabel) {
+              core.info('Migration files found — adding db label');
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                labels: ['db']
+              });
+            } else if (!hasMigration && hasLabel) {
+              core.info('No migration files — removing db label');
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                name: 'db'
+              });
+            } else {
+              core.info(`No change needed (migrations: ${hasMigration}, label: ${hasLabel})`);
+            }

--- a/src/Humans.Infrastructure/Migrations/99999999999999_TestDbLabelWorkflow.cs
+++ b/src/Humans.Infrastructure/Migrations/99999999999999_TestDbLabelWorkflow.cs
@@ -1,0 +1,3 @@
+// Dummy migration to test the label-db GitHub Actions workflow.
+// This file should trigger the 'db' label on the PR.
+// Remove this file in a follow-up commit to test label removal.

--- a/src/Humans.Infrastructure/Migrations/99999999999999_TestDbLabelWorkflow.cs
+++ b/src/Humans.Infrastructure/Migrations/99999999999999_TestDbLabelWorkflow.cs
@@ -1,3 +1,0 @@
-// Dummy migration to test the label-db GitHub Actions workflow.
-// This file should trigger the 'db' label on the PR.
-// Remove this file in a follow-up commit to test label removal.


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/label-db.yml` — on PR open/sync, checks if the diff touches `src/Humans.Infrastructure/Migrations/` and adds/removes the `db` label accordingly
- Includes a dummy migration file to test the add-label path on this PR

## Test plan
- [ ] Verify the `db` label is auto-added to this PR (dummy migration present)
- [ ] Push a commit removing the dummy migration → verify `db` label is auto-removed
- [ ] Merge — future PRs with real migrations get labeled automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)