### PR TITLE
Service ownership phase 2: CityPlanning and Shifts

### DIFF
--- a/.claude/DEPENDENCY_GRAPH.md
+++ b/.claude/DEPENDENCY_GRAPH.md
@@ -157,10 +157,13 @@ graph LR
     Team -. "(target)" .-> User
     TPage -. "(target)" .-> User
 
-    CityPlan -. "(target)" .-> Camp
+    CityPlan --> Camp
+    CityPlan --> Team
+    CityPlan --> Prof
 
-    ShiftMgmt -. "(target)" .-> Role
-    ShiftSign -. "(target)" .-> Team
+    ShiftMgmt --> Role
+    ShiftMgmt --> Team
+    ShiftSign --> Team
 
     Consent -. "(target)" .-> Prof
 
@@ -186,7 +189,7 @@ Based on the target state:
 
 2. **ProfileService <-> ConsentService**: ProfileService calls ConsentService, ConsentService needs profile data `(target)`. Same pattern — may need interface extraction.
 
-3. **TeamService <-> ShiftManagementService**: TeamService already calls ShiftManagementService, and ShiftManagementService currently queries TeamMembers `(target: calls TeamService)`. Will create a cycle. Resolve by extracting a shared query interface or having ShiftManagementService take team IDs as parameters instead of looking them up.
+3. **TeamService <-> ShiftManagementService**: TeamService calls ShiftManagementService, and ShiftManagementService now calls TeamService. Circular dependency resolved via `IServiceProvider` lazy resolution in ShiftManagementService (same pattern as ConsentService and MembershipCalculator).
 
 ## Fan-in hotspots (most depended-on services)
 
@@ -195,8 +198,8 @@ Based on the target state:
 | `AuditLogService` | 12 | 0 |
 | `NotificationService` | 7 | 0 |
 | `EmailService` | 7 | 0 |
-| `RoleAssignmentService` | 3 | +2 (Shifts, Profiles) |
-| `TeamService` | 5 | +4 (Campaigns, Shifts, Google x2) |
+| `RoleAssignmentService` | 4 | +1 (Profiles) |
+| `TeamService` | 8 | +2 (Campaigns, Google x2) |
 | `UserService` | 1 | +5 (Teams x2, Campaigns, Google x2, Tickets) |
 | `ProfileService` | 4 | +1 (Consent) |
 | `CampService` | 0 | +2 (CityPlanning, Profiles) |

--- a/src/Humans.Application/Interfaces/ICampService.cs
+++ b/src/Humans.Application/Interfaces/ICampService.cs
@@ -74,6 +74,14 @@ public interface ICampService
     Task AddHistoricalNameAsync(Guid campId, string name, CancellationToken cancellationToken = default);
     Task RemoveHistoricalNameAsync(Guid historicalNameId, CancellationToken cancellationToken = default);
 
+    // Cross-service queries (used by CityPlanningService)
+    Task<SoundZone?> GetCampSeasonSoundZoneAsync(Guid campSeasonId, CancellationToken cancellationToken = default);
+    Task<string?> GetCampSeasonNameAsync(Guid campSeasonId, CancellationToken cancellationToken = default);
+    Task<CampSeasonInfo?> GetCampSeasonInfoAsync(Guid campSeasonId, CancellationToken cancellationToken = default);
+    Task<IReadOnlyDictionary<Guid, CampSeasonDisplayData>> GetCampSeasonDisplayDataForYearAsync(int year, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<CampSeasonBrief>> GetCampSeasonBriefsForYearAsync(int year, CancellationToken cancellationToken = default);
+    Task<Guid?> GetCampLeadSeasonIdForYearAsync(Guid userId, int year, CancellationToken cancellationToken = default);
+
     // Authorization checks
     Task<bool> IsUserCampLeadAsync(Guid userId, Guid campId, CancellationToken cancellationToken = default);
 
@@ -252,3 +260,19 @@ public record CampPlacementSummary(
     string? ContainerNotes,
     string Status,
     string? ElectricalGrid);
+
+/// <summary>
+/// Core camp season info for cross-service lookups (CampId + Year).
+/// </summary>
+public record CampSeasonInfo(Guid CampSeasonId, Guid CampId, int Year);
+
+/// <summary>
+/// Display data for camp seasons: name, camp slug, and sound zone.
+/// Used by CityPlanningService for polygon display/export.
+/// </summary>
+public record CampSeasonDisplayData(string Name, string CampSlug, SoundZone? SoundZone);
+
+/// <summary>
+/// Lightweight camp season summary (ID, name, camp slug) for listing.
+/// </summary>
+public record CampSeasonBrief(Guid CampSeasonId, string Name, string CampSlug);

--- a/src/Humans.Application/Interfaces/IRoleAssignmentService.cs
+++ b/src/Humans.Application/Interfaces/IRoleAssignmentService.cs
@@ -52,4 +52,10 @@ public interface IRoleAssignmentService
     /// Checks if a user has an active TeamsAdmin role assignment.
     /// </summary>
     Task<bool> IsUserTeamsAdminAsync(Guid userId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Checks if a user has an active assignment for the specified role.
+    /// Generic version — prefer the specific Is*Async methods when available.
+    /// </summary>
+    Task<bool> HasActiveRoleAsync(Guid userId, string roleName, CancellationToken cancellationToken = default);
 }

--- a/src/Humans.Application/Interfaces/ITeamService.cs
+++ b/src/Humans.Application/Interfaces/ITeamService.cs
@@ -467,6 +467,26 @@ public interface ITeamService
         CancellationToken cancellationToken = default);
 
     // ==========================================================================
+    // Coordinator Queries
+    // ==========================================================================
+
+    /// <summary>
+    /// Gets all non-system team IDs where the user is a coordinator or has a management role.
+    /// Used by shift services for authorization — avoids cross-service team table queries.
+    /// </summary>
+    Task<IReadOnlyList<Guid>> GetUserCoordinatedTeamIdsAsync(
+        Guid userId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the user IDs of all active coordinators for a team (Coordinator member role).
+    /// Used by shift services for notification dispatch.
+    /// </summary>
+    Task<IReadOnlyList<Guid>> GetCoordinatorUserIdsAsync(
+        Guid teamId,
+        CancellationToken cancellationToken = default);
+
+    // ==========================================================================
     // Cache Helpers
     // ==========================================================================
 

--- a/src/Humans.Infrastructure/Services/CampService.cs
+++ b/src/Humans.Infrastructure/Services/CampService.cs
@@ -937,6 +937,73 @@ public class CampService : ICampService
     }
 
     // ==========================================================================
+    // Cross-service queries (used by CityPlanningService)
+    // ==========================================================================
+
+    public async Task<SoundZone?> GetCampSeasonSoundZoneAsync(Guid campSeasonId,
+        CancellationToken cancellationToken = default)
+    {
+        return await _dbContext.CampSeasons
+            .Where(s => s.Id == campSeasonId)
+            .Select(s => s.SoundZone)
+            .FirstOrDefaultAsync(cancellationToken);
+    }
+
+    public async Task<string?> GetCampSeasonNameAsync(Guid campSeasonId,
+        CancellationToken cancellationToken = default)
+    {
+        return await _dbContext.CampSeasons
+            .Where(s => s.Id == campSeasonId)
+            .Select(s => s.Name)
+            .FirstOrDefaultAsync(cancellationToken);
+    }
+
+    public async Task<CampSeasonInfo?> GetCampSeasonInfoAsync(Guid campSeasonId,
+        CancellationToken cancellationToken = default)
+    {
+        return await _dbContext.CampSeasons
+            .Where(s => s.Id == campSeasonId)
+            .Select(s => new CampSeasonInfo(s.Id, s.CampId, s.Year))
+            .FirstOrDefaultAsync(cancellationToken);
+    }
+
+    public async Task<IReadOnlyDictionary<Guid, CampSeasonDisplayData>> GetCampSeasonDisplayDataForYearAsync(
+        int year, CancellationToken cancellationToken = default)
+    {
+        return await _dbContext.CampSeasons
+            .Include(s => s.Camp)
+            .Where(s => s.Year == year)
+            .ToDictionaryAsync(
+                s => s.Id,
+                s => new CampSeasonDisplayData(s.Name, s.Camp.Slug, s.SoundZone),
+                cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<CampSeasonBrief>> GetCampSeasonBriefsForYearAsync(
+        int year, CancellationToken cancellationToken = default)
+    {
+        return await _dbContext.CampSeasons
+            .Include(s => s.Camp)
+            .Where(s => s.Year == year)
+            .Select(s => new CampSeasonBrief(s.Id, s.Name, s.Camp.Slug))
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task<Guid?> GetCampLeadSeasonIdForYearAsync(Guid userId, int year,
+        CancellationToken cancellationToken = default)
+    {
+        return await _dbContext.CampLeads
+            .Where(l => l.UserId == userId && l.LeftAt == null)
+            .Join(_dbContext.CampSeasons,
+                l => l.CampId,
+                s => s.CampId,
+                (l, s) => s)
+            .Where(s => s.Year == year)
+            .Select(s => (Guid?)s.Id)
+            .FirstOrDefaultAsync(cancellationToken);
+    }
+
+    // ==========================================================================
     // Authorization checks
     // ==========================================================================
 

--- a/src/Humans.Infrastructure/Services/CityPlanningService.cs
+++ b/src/Humans.Infrastructure/Services/CityPlanningService.cs
@@ -72,7 +72,9 @@ public class CityPlanningService : ICityPlanningService
 
     public async Task<string?> GetUserDisplayNameAsync(Guid userId, CancellationToken cancellationToken = default)
     {
-        var profile = await _profileService.GetCachedProfileAsync(userId, cancellationToken);
+        // Use targeted per-user lookup (GetProfileAsync) instead of GetCachedProfileAsync
+        // to avoid warming the full profile cache on cold-cache paths like SignalR connect.
+        var profile = await _profileService.GetProfileAsync(userId, cancellationToken);
         return profile?.BurnerName;
     }
 
@@ -80,9 +82,11 @@ public class CityPlanningService : ICityPlanningService
     {
         // Get all camp seasons for the year from camp service
         var allSeasons = await _campService.GetCampSeasonBriefsForYearAsync(year, cancellationToken);
+        var seasonIdsForYear = allSeasons.Select(s => s.CampSeasonId).ToList();
 
-        // Get camp season IDs that already have polygons (owned table)
+        // Get camp season IDs that already have polygons, filtered in SQL to this year's seasons only
         var polygonSeasonIds = await _dbContext.CampPolygons
+            .Where(p => seasonIdsForYear.Contains(p.CampSeasonId))
             .Select(p => p.CampSeasonId)
             .ToListAsync(cancellationToken);
 

--- a/src/Humans.Infrastructure/Services/CityPlanningService.cs
+++ b/src/Humans.Infrastructure/Services/CityPlanningService.cs
@@ -1,5 +1,4 @@
 using Humans.Application.Interfaces;
-using Humans.Domain.Constants;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Humans.Infrastructure.Configuration;
@@ -15,61 +14,84 @@ public class CityPlanningService : ICityPlanningService
     private readonly HumansDbContext _dbContext;
     private readonly IClock _clock;
     private readonly IOptions<CityPlanningOptions> _options;
+    private readonly ICampService _campService;
+    private readonly ITeamService _teamService;
+    private readonly IProfileService _profileService;
 
-    public CityPlanningService(HumansDbContext dbContext, IClock clock, IOptions<CityPlanningOptions> options)
+    public CityPlanningService(
+        HumansDbContext dbContext,
+        IClock clock,
+        IOptions<CityPlanningOptions> options,
+        ICampService campService,
+        ITeamService teamService,
+        IProfileService profileService)
     {
         _dbContext = dbContext;
         _clock = clock;
         _options = options;
+        _campService = campService;
+        _teamService = teamService;
+        _profileService = profileService;
     }
 
     public async Task<List<CampPolygonDto>> GetCampPolygonsAsync(int year, CancellationToken cancellationToken = default)
     {
-        return await _dbContext.CampPolygons
-            .Include(p => p.CampSeason).ThenInclude(s => s.Camp)
-            .Where(p => p.CampSeason.Year == year)
-            .Select(p => new CampPolygonDto(
-                p.CampSeasonId,
-                p.CampSeason.Name,
-                p.CampSeason.Camp.Slug,
-                p.GeoJson,
-                p.AreaSqm,
-                p.CampSeason.SoundZone))
+        // Get display data for the year from camp service (keyed by campSeasonId)
+        var displayData = await _campService.GetCampSeasonDisplayDataForYearAsync(year, cancellationToken);
+        var seasonIds = displayData.Keys.ToList();
+
+        // Load polygons from owned table, filtered to the year's camp season IDs
+        var polygons = await _dbContext.CampPolygons
+            .Where(p => seasonIds.Contains(p.CampSeasonId))
             .ToListAsync(cancellationToken);
+
+        return polygons
+            .Select(p =>
+            {
+                var data = displayData[p.CampSeasonId];
+                return new CampPolygonDto(
+                    p.CampSeasonId,
+                    data.Name,
+                    data.CampSlug,
+                    p.GeoJson,
+                    p.AreaSqm,
+                    data.SoundZone);
+            })
+            .ToList();
     }
 
     public async Task<SoundZone?> GetCampSeasonSoundZoneAsync(Guid campSeasonId, CancellationToken cancellationToken = default)
     {
-        return await _dbContext.CampSeasons
-            .Where(s => s.Id == campSeasonId)
-            .Select(s => s.SoundZone)
-            .FirstOrDefaultAsync(cancellationToken);
+        return await _campService.GetCampSeasonSoundZoneAsync(campSeasonId, cancellationToken);
     }
 
     public async Task<string?> GetCampSeasonNameAsync(Guid campSeasonId, CancellationToken cancellationToken = default)
     {
-        return await _dbContext.CampSeasons
-            .Where(s => s.Id == campSeasonId)
-            .Select(s => s.Name)
-            .FirstOrDefaultAsync(cancellationToken);
+        return await _campService.GetCampSeasonNameAsync(campSeasonId, cancellationToken);
     }
 
     public async Task<string?> GetUserDisplayNameAsync(Guid userId, CancellationToken cancellationToken = default)
     {
-        return await _dbContext.Profiles
-            .Where(p => p.UserId == userId)
-            .Select(p => p.BurnerName)
-            .FirstOrDefaultAsync(cancellationToken);
+        var profile = await _profileService.GetCachedProfileAsync(userId, cancellationToken);
+        return profile?.BurnerName;
     }
 
     public async Task<List<CampSeasonSummaryDto>> GetCampSeasonsWithoutCampPolygonAsync(int year, CancellationToken cancellationToken = default)
     {
-        return await _dbContext.CampSeasons
-            .Include(s => s.Camp)
-            .Where(s => s.Year == year
-                && !_dbContext.CampPolygons.Any(p => p.CampSeasonId == s.Id))
-            .Select(s => new CampSeasonSummaryDto(s.Id, s.Name, s.Camp.Slug))
+        // Get all camp seasons for the year from camp service
+        var allSeasons = await _campService.GetCampSeasonBriefsForYearAsync(year, cancellationToken);
+
+        // Get camp season IDs that already have polygons (owned table)
+        var polygonSeasonIds = await _dbContext.CampPolygons
+            .Select(p => p.CampSeasonId)
             .ToListAsync(cancellationToken);
+
+        var polygonSeasonIdSet = new HashSet<Guid>(polygonSeasonIds);
+
+        return allSeasons
+            .Where(s => !polygonSeasonIdSet.Contains(s.CampSeasonId))
+            .Select(s => new CampSeasonSummaryDto(s.CampSeasonId, s.Name, s.CampSlug))
+            .ToList();
     }
 
     public async Task<List<CampPolygonHistoryEntryDto>> GetCampPolygonHistoryAsync(Guid campSeasonId, CancellationToken cancellationToken = default)
@@ -92,15 +114,7 @@ public class CityPlanningService : ICityPlanningService
 
     public async Task<Guid?> GetUserCampSeasonIdForYearAsync(Guid userId, int year, CancellationToken cancellationToken = default)
     {
-        return await _dbContext.CampLeads
-            .Where(l => l.UserId == userId && l.LeftAt == null)
-            .Join(_dbContext.CampSeasons,
-                l => l.CampId,
-                s => s.CampId,
-                (l, s) => s)
-            .Where(s => s.Year == year)
-            .Select(s => (Guid?)s.Id)
-            .FirstOrDefaultAsync(cancellationToken);
+        return await _campService.GetCampLeadSeasonIdForYearAsync(userId, year, cancellationToken);
     }
 
     public async Task<(CampPolygon polygon, CampPolygonHistory history)> SaveCampPolygonAsync(
@@ -162,12 +176,10 @@ public class CityPlanningService : ICityPlanningService
 
     public async Task<bool> IsCityPlanningTeamMemberAsync(Guid userId, CancellationToken cancellationToken = default)
     {
-        var team = await _dbContext.Teams
-            .FirstOrDefaultAsync(t => t.Slug == _options.Value.CityPlanningTeamSlug, cancellationToken);
+        var team = await _teamService.GetTeamBySlugAsync(_options.Value.CityPlanningTeamSlug, cancellationToken);
         if (team == null) return false;
 
-        return await _dbContext.TeamMembers
-            .AnyAsync(tm => tm.TeamId == team.Id && tm.UserId == userId && tm.LeftAt == null, cancellationToken);
+        return await _teamService.IsUserMemberOfTeamAsync(team.Id, userId, cancellationToken);
     }
 
     public async Task<bool> CanUserEditAsync(Guid userId, Guid campSeasonId, CancellationToken cancellationToken = default)
@@ -179,20 +191,16 @@ public class CityPlanningService : ICityPlanningService
         var settings = await GetSettingsAsync(cancellationToken);
         if (!settings.IsPlacementOpen) return false;
 
-        var campSeason = await _dbContext.CampSeasons
-            .FirstOrDefaultAsync(s => s.Id == campSeasonId, cancellationToken);
-        if (campSeason == null) return false;
-        if (campSeason.Year != settings.Year) return false;
+        var campSeasonInfo = await _campService.GetCampSeasonInfoAsync(campSeasonId, cancellationToken);
+        if (campSeasonInfo == null) return false;
+        if (campSeasonInfo.Year != settings.Year) return false;
 
-        return await _dbContext.CampLeads
-            .AnyAsync(l => l.CampId == campSeason.CampId && l.UserId == userId && l.LeftAt == null, cancellationToken);
+        return await _campService.IsUserCampLeadAsync(userId, campSeasonInfo.CampId, cancellationToken);
     }
 
     public async Task<CityPlanningSettings> GetSettingsAsync(CancellationToken cancellationToken = default)
     {
-        var campSettings = await _dbContext.CampSettings
-            .FirstOrDefaultAsync(cancellationToken)
-            ?? throw new InvalidOperationException("CampSettings row not found.");
+        var campSettings = await _campService.GetSettingsAsync(cancellationToken);
 
         var settings = await _dbContext.CityPlanningSettings
             .FirstOrDefaultAsync(s => s.Year == campSettings.PublicYear, cancellationToken);
@@ -270,9 +278,13 @@ public class CityPlanningService : ICityPlanningService
 
     public async Task<string> ExportAsGeoJsonAsync(int year, CancellationToken cancellationToken = default)
     {
+        // Get display data for the year from camp service (keyed by campSeasonId)
+        var displayData = await _campService.GetCampSeasonDisplayDataForYearAsync(year, cancellationToken);
+        var seasonIds = displayData.Keys.ToList();
+
+        // Load polygons from owned table, filtered to the year's camp season IDs
         var polygons = await _dbContext.CampPolygons
-            .Include(p => p.CampSeason).ThenInclude(s => s.Camp)
-            .Where(p => p.CampSeason.Year == year)
+            .Where(p => seasonIds.Contains(p.CampSeasonId))
             .ToListAsync(cancellationToken);
 
         var docs = new List<System.Text.Json.JsonDocument>();
@@ -280,6 +292,7 @@ public class CityPlanningService : ICityPlanningService
         {
             var features = polygons.Select(p =>
             {
+                var data = displayData[p.CampSeasonId];
                 var doc = System.Text.Json.JsonDocument.Parse(p.GeoJson);
                 docs.Add(doc);
                 var geom = doc.RootElement.TryGetProperty("geometry", out var g) ? g : doc.RootElement;
@@ -289,9 +302,9 @@ public class CityPlanningService : ICityPlanningService
                     geometry = geom,
                     properties = new
                     {
-                        campName = p.CampSeason.Name,
-                        campSlug = p.CampSeason.Camp.Slug,
-                        year = p.CampSeason.Year,
+                        campName = data.Name,
+                        campSlug = data.CampSlug,
+                        year,
                         areaSqm = p.AreaSqm
                     }
                 };

--- a/src/Humans.Infrastructure/Services/RoleAssignmentService.cs
+++ b/src/Humans.Infrastructure/Services/RoleAssignmentService.cs
@@ -309,4 +309,16 @@ public class RoleAssignmentService : IRoleAssignmentService
                 (ra.ValidTo == null || ra.ValidTo > now),
                 cancellationToken);
     }
+
+    public async Task<bool> HasActiveRoleAsync(Guid userId, string roleName, CancellationToken cancellationToken = default)
+    {
+        var now = _clock.GetCurrentInstant();
+        return await _dbContext.RoleAssignments
+            .AnyAsync(ra =>
+                ra.UserId == userId &&
+                ra.RoleName == roleName &&
+                ra.ValidFrom <= now &&
+                (ra.ValidTo == null || ra.ValidTo > now),
+                cancellationToken);
+    }
 }

--- a/src/Humans.Infrastructure/Services/ShiftManagementService.cs
+++ b/src/Humans.Infrastructure/Services/ShiftManagementService.cs
@@ -6,6 +6,7 @@ using Humans.Domain.Enums;
 using Humans.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NodaTime;
 
@@ -28,19 +29,28 @@ public class ShiftManagementService : IShiftManagementService
 
     private readonly HumansDbContext _dbContext;
     private readonly IAuditLogService _auditLogService;
+    private readonly IRoleAssignmentService _roleAssignmentService;
+    private readonly IServiceProvider _serviceProvider;
     private readonly IMemoryCache _cache;
     private readonly IClock _clock;
     private readonly ILogger<ShiftManagementService> _logger;
 
+    // Lazy-resolved to break circular dependency: TeamService → IShiftManagementService → ITeamService
+    private ITeamService TeamService => _serviceProvider.GetRequiredService<ITeamService>();
+
     public ShiftManagementService(
         HumansDbContext dbContext,
         IAuditLogService auditLogService,
+        IRoleAssignmentService roleAssignmentService,
+        IServiceProvider serviceProvider,
         IMemoryCache cache,
         IClock clock,
         ILogger<ShiftManagementService> logger)
     {
         _dbContext = dbContext;
         _auditLogService = auditLogService;
+        _roleAssignmentService = roleAssignmentService;
+        _serviceProvider = serviceProvider;
         _cache = cache;
         _clock = clock;
         _logger = logger;
@@ -57,12 +67,8 @@ public class ShiftManagementService : IShiftManagementService
             return true;
 
         // Parent department coordinators can manage child teams
-        var parentTeamId = await _dbContext.Teams.AsNoTracking()
-            .Where(t => t.Id == departmentTeamId)
-            .Select(t => t.ParentTeamId)
-            .FirstOrDefaultAsync();
-
-        return parentTeamId is not null && teamIds.Contains(parentTeamId.Value);
+        var team = await TeamService.GetTeamByIdAsync(departmentTeamId);
+        return team?.ParentTeamId is not null && teamIds.Contains(team.ParentTeamId.Value);
     }
 
     public async Task<bool> CanManageShiftsAsync(Guid userId, Guid departmentTeamId)
@@ -98,41 +104,12 @@ public class ShiftManagementService : IShiftManagementService
 
     private async Task<IReadOnlyList<Guid>> QueryCoordinatorTeamIdsAsync(Guid userId)
     {
-        // Check via IsManagement role assignment (departments and sub-teams)
-        var byRoleAssignment = await _dbContext.TeamRoleAssignments
-            .AsNoTracking()
-            .Where(tra =>
-                tra.TeamMember.UserId == userId &&
-                tra.TeamMember.LeftAt == null &&
-                tra.TeamRoleDefinition.IsManagement &&
-                tra.TeamRoleDefinition.Team.SystemTeamType == SystemTeamType.None)
-            .Select(tra => tra.TeamRoleDefinition.TeamId)
-            .ToListAsync();
-
-        // Also check via TeamMember.Role == Coordinator (may be out of sync with IsManagement)
-        var byMemberRole = await _dbContext.TeamMembers
-            .AsNoTracking()
-            .Where(tm =>
-                tm.UserId == userId &&
-                tm.LeftAt == null &&
-                tm.Role == TeamMemberRole.Coordinator &&
-                tm.Team.SystemTeamType == SystemTeamType.None)
-            .Select(tm => tm.TeamId)
-            .ToListAsync();
-
-        return byRoleAssignment.Union(byMemberRole).Distinct().ToList();
+        return await TeamService.GetUserCoordinatedTeamIdsAsync(userId);
     }
 
     private async Task<bool> HasActiveRoleAsync(Guid userId, string roleName)
     {
-        var now = _clock.GetCurrentInstant();
-        return await _dbContext.RoleAssignments
-            .AsNoTracking()
-            .AnyAsync(ra =>
-                ra.UserId == userId &&
-                ra.RoleName == roleName &&
-                ra.ValidFrom <= now &&
-                (ra.ValidTo == null || ra.ValidTo > now));
+        return await _roleAssignmentService.HasActiveRoleAsync(userId, roleName);
     }
 
     // ============================================================
@@ -209,8 +186,7 @@ public class ShiftManagementService : IShiftManagementService
 
     public async Task CreateRotaAsync(Rota rota)
     {
-        var team = await _dbContext.Teams.AsNoTracking()
-            .FirstOrDefaultAsync(t => t.Id == rota.TeamId);
+        var team = await TeamService.GetTeamByIdAsync(rota.TeamId);
 
         if (team is null)
             throw new InvalidOperationException("Team not found.");
@@ -242,8 +218,7 @@ public class ShiftManagementService : IShiftManagementService
         if (rota is null)
             throw new InvalidOperationException("Rota not found.");
 
-        var targetTeam = await _dbContext.Teams.AsNoTracking()
-            .FirstOrDefaultAsync(t => t.Id == targetTeamId);
+        var targetTeam = await TeamService.GetTeamByIdAsync(targetTeamId);
         if (targetTeam is null)
             throw new InvalidOperationException("Target team not found.");
         if (targetTeam.ParentTeamId is not null)

--- a/src/Humans.Infrastructure/Services/ShiftSignupService.cs
+++ b/src/Humans.Infrastructure/Services/ShiftSignupService.cs
@@ -3,6 +3,7 @@ using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Humans.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NodaTime;
 
@@ -17,14 +18,19 @@ public class ShiftSignupService : IShiftSignupService
     private readonly IShiftManagementService _shiftMgmt;
     private readonly IAuditLogService _auditLogService;
     private readonly INotificationService _notificationService;
+    private readonly IServiceProvider _serviceProvider;
     private readonly IClock _clock;
     private readonly ILogger<ShiftSignupService> _logger;
+
+    // Lazy-resolved to avoid adding a direct ITeamService dependency (used only for notifications)
+    private ITeamService TeamService => _serviceProvider.GetRequiredService<ITeamService>();
 
     public ShiftSignupService(
         HumansDbContext dbContext,
         IShiftManagementService shiftMgmt,
         IAuditLogService auditLogService,
         INotificationService notificationService,
+        IServiceProvider serviceProvider,
         IClock clock,
         ILogger<ShiftSignupService> logger)
     {
@@ -32,6 +38,7 @@ public class ShiftSignupService : IShiftSignupService
         _shiftMgmt = shiftMgmt;
         _auditLogService = auditLogService;
         _notificationService = notificationService;
+        _serviceProvider = serviceProvider;
         _clock = clock;
         _logger = logger;
     }
@@ -975,12 +982,7 @@ public class ShiftSignupService : IShiftSignupService
                 return;
 
             var teamId = shift.Rota.TeamId;
-            var coordinatorIds = await _dbContext.TeamMembers
-                .Where(tm => tm.TeamId == teamId
-                    && tm.LeftAt == null
-                    && tm.Role == TeamMemberRole.Coordinator)
-                .Select(tm => tm.UserId)
-                .ToListAsync();
+            var coordinatorIds = await TeamService.GetCoordinatorUserIdsAsync(teamId);
 
             if (coordinatorIds.Count == 0)
                 return;
@@ -1020,12 +1022,7 @@ public class ShiftSignupService : IShiftSignupService
             var enrichedDescription = $"{changeDescription} ({rotaName}, {FormatShiftDate(shiftDate)})";
 
             // Find coordinators for this department team
-            var coordinatorIds = await _dbContext.TeamMembers
-                .Where(tm => tm.TeamId == teamId
-                    && tm.LeftAt == null
-                    && tm.Role == TeamMemberRole.Coordinator)
-                .Select(tm => tm.UserId)
-                .ToListAsync();
+            var coordinatorIds = await TeamService.GetCoordinatorUserIdsAsync(teamId);
 
             if (coordinatorIds.Count == 0)
                 return;

--- a/src/Humans.Infrastructure/Services/ShiftSignupService.cs
+++ b/src/Humans.Infrastructure/Services/ShiftSignupService.cs
@@ -22,7 +22,7 @@ public class ShiftSignupService : IShiftSignupService
     private readonly IClock _clock;
     private readonly ILogger<ShiftSignupService> _logger;
 
-    // Lazy-resolved to avoid adding a direct ITeamService dependency (used only for notifications)
+    // Lazy-resolved for consistency with ShiftManagementService pattern (used only for notification coordinator lookups)
     private ITeamService TeamService => _serviceProvider.GetRequiredService<ITeamService>();
 
     public ShiftSignupService(

--- a/src/Humans.Infrastructure/Services/TeamService.cs
+++ b/src/Humans.Infrastructure/Services/TeamService.cs
@@ -2089,6 +2089,51 @@ public class TeamService : ITeamService
     }
 
     // ==========================================================================
+    // Coordinator Queries
+    // ==========================================================================
+
+    public async Task<IReadOnlyList<Guid>> GetUserCoordinatedTeamIdsAsync(
+        Guid userId,
+        CancellationToken cancellationToken = default)
+    {
+        // Check via IsManagement role assignment (departments and sub-teams)
+        var byRoleAssignment = await _dbContext.TeamRoleAssignments
+            .AsNoTracking()
+            .Where(tra =>
+                tra.TeamMember.UserId == userId &&
+                tra.TeamMember.LeftAt == null &&
+                tra.TeamRoleDefinition.IsManagement &&
+                tra.TeamRoleDefinition.Team.SystemTeamType == SystemTeamType.None)
+            .Select(tra => tra.TeamRoleDefinition.TeamId)
+            .ToListAsync(cancellationToken);
+
+        // Also check via TeamMember.Role == Coordinator (may be out of sync with IsManagement)
+        var byMemberRole = await _dbContext.TeamMembers
+            .AsNoTracking()
+            .Where(tm =>
+                tm.UserId == userId &&
+                tm.LeftAt == null &&
+                tm.Role == TeamMemberRole.Coordinator &&
+                tm.Team.SystemTeamType == SystemTeamType.None)
+            .Select(tm => tm.TeamId)
+            .ToListAsync(cancellationToken);
+
+        return byRoleAssignment.Union(byMemberRole).Distinct().ToList();
+    }
+
+    public async Task<IReadOnlyList<Guid>> GetCoordinatorUserIdsAsync(
+        Guid teamId,
+        CancellationToken cancellationToken = default)
+    {
+        return await _dbContext.TeamMembers
+            .Where(tm => tm.TeamId == teamId
+                && tm.LeftAt == null
+                && tm.Role == TeamMemberRole.Coordinator)
+            .Select(tm => tm.UserId)
+            .ToListAsync(cancellationToken);
+    }
+
+    // ==========================================================================
     // Team Cache
     // ==========================================================================
 

--- a/tests/Humans.Application.Tests/Services/CityPlanningServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/CityPlanningServiceTests.cs
@@ -1,7 +1,6 @@
 using AwesomeAssertions;
 using Humans.Application.Interfaces;
 using Xunit;
-using Humans.Domain.Constants;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Humans.Infrastructure.Configuration;
@@ -19,6 +18,9 @@ public class CityPlanningServiceTests : IDisposable
 {
     private readonly HumansDbContext _dbContext;
     private readonly FakeClock _clock;
+    private readonly ICampService _campService;
+    private readonly ITeamService _teamService;
+    private readonly IProfileService _profileService;
     private readonly CityPlanningService _sut;
     private readonly CityPlanningOptions _options = new() { CityPlanningTeamSlug = "city-planning" };
 
@@ -29,39 +31,26 @@ public class CityPlanningServiceTests : IDisposable
             .Options;
         _dbContext = new HumansDbContext(dbOptions);
         _clock = new FakeClock(Instant.FromUtc(2026, 3, 15, 12, 0, 0));
-        _sut = new CityPlanningService(_dbContext, _clock, Options.Create(_options));
+        _campService = Substitute.For<ICampService>();
+        _teamService = Substitute.For<ITeamService>();
+        _profileService = Substitute.For<IProfileService>();
+        _sut = new CityPlanningService(_dbContext, _clock, Options.Create(_options),
+            _campService, _teamService, _profileService);
     }
 
     public void Dispose() => _dbContext.Dispose();
 
     // --- Helpers ---
 
-    private async Task<(Camp camp, CampSeason season, User user)> SeedCampWithLeadAsync(int year = 2026)
+    private void SetupCampSettings(int publicYear = 2026)
     {
-        var user = new User { Id = Guid.NewGuid(), UserName = "lead@test.com", Email = "lead@test.com" };
-        _dbContext.Users.Add(user);
-
-        var camp = new Camp { Id = Guid.NewGuid(), Slug = "test-camp", ContactEmail = "e@test.com", CreatedByUserId = user.Id };
-        _dbContext.Camps.Add(camp);
-
-        var season = new CampSeason { Id = Guid.NewGuid(), CampId = camp.Id, Year = year, Name = "Test Camp", Status = CampSeasonStatus.Active };
-        _dbContext.CampSeasons.Add(season);
-
-        _dbContext.CampLeads.Add(new CampLead { Id = Guid.NewGuid(), CampId = camp.Id, UserId = user.Id, Role = CampLeadRole.Primary });
-
-        await _dbContext.SaveChangesAsync();
-        return (camp, season, user);
-    }
-
-    private async Task SeedCampSettingsAsync(int publicYear = 2026)
-    {
-        _dbContext.CampSettings.Add(new CampSettings { Id = Guid.NewGuid(), PublicYear = publicYear });
-        await _dbContext.SaveChangesAsync();
+        _campService.GetSettingsAsync(Arg.Any<CancellationToken>())
+            .Returns(new CampSettings { Id = Guid.NewGuid(), PublicYear = publicYear });
     }
 
     private async Task<CityPlanningSettings> SeedMapSettingsAsync(int year = 2026, bool placementOpen = false)
     {
-        await SeedCampSettingsAsync(year);
+        SetupCampSettings(year);
         var settings = new CityPlanningSettings
         {
             Year = year,
@@ -73,50 +62,21 @@ public class CityPlanningServiceTests : IDisposable
         return settings;
     }
 
-    private async Task<Guid> SeedCampAdminUserAsync()
-    {
-        var user = new User { Id = Guid.NewGuid(), UserName = "admin@test.com", Email = "admin@test.com" };
-        _dbContext.Users.Add(user);
-
-        _dbContext.RoleAssignments.Add(new RoleAssignment
-        {
-            Id = Guid.NewGuid(),
-            UserId = user.Id,
-            RoleName = RoleNames.CampAdmin,
-            ValidFrom = _clock.GetCurrentInstant().Minus(Duration.FromHours(1)),
-            CreatedAt = _clock.GetCurrentInstant(),
-            CreatedByUserId = user.Id
-        });
-
-        await _dbContext.SaveChangesAsync();
-        return user.Id;
-    }
-
-    private async Task<Guid> SeedCityPlanningTeamMemberAsync()
-    {
-        var user = new User { Id = Guid.NewGuid(), UserName = "planner@test.com", Email = "planner@test.com" };
-        _dbContext.Users.Add(user);
-
-        var team = new Team { Id = Guid.NewGuid(), Name = "City Planning", Slug = "city-planning" };
-        _dbContext.Teams.Add(team);
-        _dbContext.TeamMembers.Add(new TeamMember { Id = Guid.NewGuid(), TeamId = team.Id, UserId = user.Id });
-
-        await _dbContext.SaveChangesAsync();
-        return user.Id;
-    }
+    private static Guid NewUserId() => Guid.NewGuid();
 
     // --- Tests ---
 
     [Fact]
     public async Task SaveCampPolygonAsync_FirstSave_CreatesBothPolygonAndHistory()
     {
-        var (_, season, user) = await SeedCampWithLeadAsync();
+        var campSeasonId = Guid.NewGuid();
+        var userId = NewUserId();
         const string geoJson = """{"type":"Feature","geometry":{"type":"Polygon","coordinates":[[]]}}""";
 
-        await _sut.SaveCampPolygonAsync(season.Id, geoJson, 500.0, user.Id);
+        await _sut.SaveCampPolygonAsync(campSeasonId, geoJson, 500.0, userId);
 
-        var polygon = await _dbContext.CampPolygons.SingleAsync(p => p.CampSeasonId == season.Id);
-        var history = await _dbContext.CampPolygonHistories.SingleAsync(h => h.CampSeasonId == season.Id);
+        var polygon = await _dbContext.CampPolygons.SingleAsync(p => p.CampSeasonId == campSeasonId);
+        var history = await _dbContext.CampPolygonHistories.SingleAsync(h => h.CampSeasonId == campSeasonId);
 
         polygon.GeoJson.Should().Be(geoJson);
         polygon.AreaSqm.Should().Be(500.0);
@@ -127,16 +87,17 @@ public class CityPlanningServiceTests : IDisposable
     [Fact]
     public async Task SaveCampPolygonAsync_SecondSave_UpdatesPolygonAndAppendsHistory()
     {
-        var (_, season, user) = await SeedCampWithLeadAsync();
+        var campSeasonId = Guid.NewGuid();
+        var userId = NewUserId();
         const string geoJson1 = """{"type":"Feature","geometry":{"type":"Polygon","coordinates":[[[0,0],[1,0],[1,1],[0,0]]]}}""";
         const string geoJson2 = """{"type":"Feature","geometry":{"type":"Polygon","coordinates":[[[0,0],[2,0],[2,2],[0,0]]]}}""";
 
-        await _sut.SaveCampPolygonAsync(season.Id, geoJson1, 100.0, user.Id);
-        await _sut.SaveCampPolygonAsync(season.Id, geoJson2, 200.0, user.Id);
+        await _sut.SaveCampPolygonAsync(campSeasonId, geoJson1, 100.0, userId);
+        await _sut.SaveCampPolygonAsync(campSeasonId, geoJson2, 200.0, userId);
 
-        var polygonCount = await _dbContext.CampPolygons.CountAsync(p => p.CampSeasonId == season.Id);
-        var historyCount = await _dbContext.CampPolygonHistories.CountAsync(h => h.CampSeasonId == season.Id);
-        var polygon = await _dbContext.CampPolygons.SingleAsync(p => p.CampSeasonId == season.Id);
+        var polygonCount = await _dbContext.CampPolygons.CountAsync(p => p.CampSeasonId == campSeasonId);
+        var historyCount = await _dbContext.CampPolygonHistories.CountAsync(h => h.CampSeasonId == campSeasonId);
+        var polygon = await _dbContext.CampPolygons.SingleAsync(p => p.CampSeasonId == campSeasonId);
 
         polygonCount.Should().Be(1);
         historyCount.Should().Be(2);
@@ -147,19 +108,20 @@ public class CityPlanningServiceTests : IDisposable
     [Fact]
     public async Task RestoreCampPolygonVersionAsync_RestoresGeoJsonWithNote()
     {
-        var (_, season, user) = await SeedCampWithLeadAsync();
+        var campSeasonId = Guid.NewGuid();
+        var userId = NewUserId();
         const string originalGeoJson = """{"type":"Feature","geometry":{"type":"Polygon","coordinates":[[[0,0],[1,0],[1,1],[0,0]]]}}""";
 
-        var (_, historyEntry) = await _sut.SaveCampPolygonAsync(season.Id, originalGeoJson, 100.0, user.Id);
+        var (_, historyEntry) = await _sut.SaveCampPolygonAsync(campSeasonId, originalGeoJson, 100.0, userId);
         _clock.Advance(Duration.FromSeconds(1));
-        await _sut.SaveCampPolygonAsync(season.Id, """{"type":"Feature","geometry":{"type":"Polygon","coordinates":[[[0,0],[5,0],[5,5],[0,0]]]}}""", 999.0, user.Id);
+        await _sut.SaveCampPolygonAsync(campSeasonId, """{"type":"Feature","geometry":{"type":"Polygon","coordinates":[[[0,0],[5,0],[5,5],[0,0]]]}}""", 999.0, userId);
         _clock.Advance(Duration.FromSeconds(1));
 
-        await _sut.RestoreCampPolygonVersionAsync(season.Id, historyEntry.Id, user.Id);
+        await _sut.RestoreCampPolygonVersionAsync(campSeasonId, historyEntry.Id, userId);
 
-        var polygon = await _dbContext.CampPolygons.SingleAsync(p => p.CampSeasonId == season.Id);
+        var polygon = await _dbContext.CampPolygons.SingleAsync(p => p.CampSeasonId == campSeasonId);
         var latestHistory = await _dbContext.CampPolygonHistories
-            .OrderByDescending(h => h.ModifiedAt).FirstAsync(h => h.CampSeasonId == season.Id);
+            .OrderByDescending(h => h.ModifiedAt).FirstAsync(h => h.CampSeasonId == campSeasonId);
 
         polygon.GeoJson.Should().Be(originalGeoJson);
         latestHistory.Note.Should().StartWith("Restored from");
@@ -168,82 +130,136 @@ public class CityPlanningServiceTests : IDisposable
     [Fact]
     public async Task IsCityPlanningTeamMemberAsync_TeamMember_ReturnsTrue()
     {
-        var plannerId = await SeedCityPlanningTeamMemberAsync();
-        var result = await _sut.IsCityPlanningTeamMemberAsync(plannerId);
+        var userId = NewUserId();
+        var teamId = Guid.NewGuid();
+        var team = new Team { Id = teamId, Name = "City Planning", Slug = "city-planning" };
+
+        _teamService.GetTeamBySlugAsync("city-planning", Arg.Any<CancellationToken>())
+            .Returns(team);
+        _teamService.IsUserMemberOfTeamAsync(teamId, userId, Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        var result = await _sut.IsCityPlanningTeamMemberAsync(userId);
         result.Should().BeTrue();
     }
 
     [Fact]
     public async Task IsCityPlanningTeamMemberAsync_NonMember_ReturnsFalse()
     {
-        var otherUser = new User { Id = Guid.NewGuid(), UserName = "other@test.com", Email = "other@test.com" };
-        _dbContext.Users.Add(otherUser);
-        await _dbContext.SaveChangesAsync();
+        var userId = NewUserId();
+        var teamId = Guid.NewGuid();
+        var team = new Team { Id = teamId, Name = "City Planning", Slug = "city-planning" };
 
-        var result = await _sut.IsCityPlanningTeamMemberAsync(otherUser.Id);
+        _teamService.GetTeamBySlugAsync("city-planning", Arg.Any<CancellationToken>())
+            .Returns(team);
+        _teamService.IsUserMemberOfTeamAsync(teamId, userId, Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        var result = await _sut.IsCityPlanningTeamMemberAsync(userId);
         result.Should().BeFalse();
     }
 
     [Fact]
     public async Task CanUserEditAsync_CityPlanningTeamMember_AlwaysTrue_EvenWhenPlacementClosed()
     {
-        var plannerId = await SeedCityPlanningTeamMemberAsync();
-        var (_, season, _) = await SeedCampWithLeadAsync();
+        var userId = NewUserId();
+        var campSeasonId = Guid.NewGuid();
+        var teamId = Guid.NewGuid();
+        var team = new Team { Id = teamId, Name = "City Planning", Slug = "city-planning" };
         await SeedMapSettingsAsync(placementOpen: false);
 
-        var result = await _sut.CanUserEditAsync(plannerId, season.Id);
+        _teamService.GetTeamBySlugAsync("city-planning", Arg.Any<CancellationToken>())
+            .Returns(team);
+        _teamService.IsUserMemberOfTeamAsync(teamId, userId, Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        var result = await _sut.CanUserEditAsync(userId, campSeasonId);
         result.Should().BeTrue();
     }
 
     [Fact]
     public async Task CanUserEditAsync_LeadWithPlacementOpen_ReturnsTrue()
     {
-        var (_, season, user) = await SeedCampWithLeadAsync();
+        var userId = NewUserId();
+        var campId = Guid.NewGuid();
+        var campSeasonId = Guid.NewGuid();
         await SeedMapSettingsAsync(placementOpen: true);
 
-        var result = await _sut.CanUserEditAsync(user.Id, season.Id);
+        _teamService.GetTeamBySlugAsync("city-planning", Arg.Any<CancellationToken>())
+            .Returns((Team?)null);
+
+        _campService.GetCampSeasonInfoAsync(campSeasonId, Arg.Any<CancellationToken>())
+            .Returns(new CampSeasonInfo(campSeasonId, campId, 2026));
+        _campService.IsUserCampLeadAsync(userId, campId, Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        var result = await _sut.CanUserEditAsync(userId, campSeasonId);
         result.Should().BeTrue();
     }
 
     [Fact]
     public async Task CanUserEditAsync_LeadWithPlacementClosed_ReturnsFalse()
     {
-        var (_, season, user) = await SeedCampWithLeadAsync();
+        var userId = NewUserId();
+        var campId = Guid.NewGuid();
+        var campSeasonId = Guid.NewGuid();
         await SeedMapSettingsAsync(placementOpen: false);
 
-        var result = await _sut.CanUserEditAsync(user.Id, season.Id);
+        _teamService.GetTeamBySlugAsync("city-planning", Arg.Any<CancellationToken>())
+            .Returns((Team?)null);
+
+        _campService.GetCampSeasonInfoAsync(campSeasonId, Arg.Any<CancellationToken>())
+            .Returns(new CampSeasonInfo(campSeasonId, campId, 2026));
+        _campService.IsUserCampLeadAsync(userId, campId, Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        var result = await _sut.CanUserEditAsync(userId, campSeasonId);
         result.Should().BeFalse();
     }
 
     [Fact]
     public async Task CanUserEditAsync_LeadOfDifferentCamp_ReturnsFalse()
     {
-        var (_, season, _) = await SeedCampWithLeadAsync();
+        var userId = NewUserId();
+        var campId = Guid.NewGuid();
+        var campSeasonId = Guid.NewGuid();
         await SeedMapSettingsAsync(placementOpen: true);
 
-        // A different user who is NOT a lead on this camp
-        var otherUser = new User { Id = Guid.NewGuid(), UserName = "other@test.com", Email = "other@test.com" };
-        _dbContext.Users.Add(otherUser);
-        await _dbContext.SaveChangesAsync();
+        _teamService.GetTeamBySlugAsync("city-planning", Arg.Any<CancellationToken>())
+            .Returns((Team?)null);
 
-        var result = await _sut.CanUserEditAsync(otherUser.Id, season.Id);
+        _campService.GetCampSeasonInfoAsync(campSeasonId, Arg.Any<CancellationToken>())
+            .Returns(new CampSeasonInfo(campSeasonId, campId, 2026));
+        _campService.IsUserCampLeadAsync(userId, campId, Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        var result = await _sut.CanUserEditAsync(userId, campSeasonId);
         result.Should().BeFalse();
     }
 
     [Fact]
     public async Task CanUserEditAsync_LeadOfDifferentYear_ReturnsFalse()
     {
-        var (_, season2027, user) = await SeedCampWithLeadAsync(year: 2027);
+        var userId = NewUserId();
+        var campId = Guid.NewGuid();
+        var campSeasonId = Guid.NewGuid();
         await SeedMapSettingsAsync(year: 2026, placementOpen: true);
 
-        var result = await _sut.CanUserEditAsync(user.Id, season2027.Id);
+        _teamService.GetTeamBySlugAsync("city-planning", Arg.Any<CancellationToken>())
+            .Returns((Team?)null);
+
+        // Camp season is for 2027, but settings year is 2026
+        _campService.GetCampSeasonInfoAsync(campSeasonId, Arg.Any<CancellationToken>())
+            .Returns(new CampSeasonInfo(campSeasonId, campId, 2027));
+
+        var result = await _sut.CanUserEditAsync(userId, campSeasonId);
         result.Should().BeFalse();
     }
 
     [Fact]
     public async Task GetSettingsAsync_CreatesRowIfMissing()
     {
-        await SeedCampSettingsAsync(publicYear: 2026);
+        SetupCampSettings(publicYear: 2026);
 
         var settings = await _sut.GetSettingsAsync();
 
@@ -268,7 +284,7 @@ public class CityPlanningServiceTests : IDisposable
     public async Task OpenPlacementAsync_SetsIsPlacementOpenTrue()
     {
         await SeedMapSettingsAsync(placementOpen: false);
-        var adminId = await SeedCampAdminUserAsync();
+        var adminId = NewUserId();
 
         await _sut.OpenPlacementAsync(adminId);
 
@@ -281,7 +297,7 @@ public class CityPlanningServiceTests : IDisposable
     public async Task ClosePlacementAsync_SetsIsPlacementOpenFalse()
     {
         await SeedMapSettingsAsync(placementOpen: true);
-        var adminId = await SeedCampAdminUserAsync();
+        var adminId = NewUserId();
 
         await _sut.ClosePlacementAsync(adminId);
 
@@ -293,39 +309,61 @@ public class CityPlanningServiceTests : IDisposable
     [Fact]
     public async Task GetCampPolygonsAsync_ReturnsOnlyPolygonsForYear()
     {
-        var (_, season2026, user) = await SeedCampWithLeadAsync(year: 2026);
-        var (_, season2027, _) = await SeedCampWithLeadAsync(year: 2027);
+        var season2026Id = Guid.NewGuid();
+        var season2027Id = Guid.NewGuid();
+        var userId = NewUserId();
 
-        await _sut.SaveCampPolygonAsync(season2026.Id, """{"type":"Feature"}""", 100, user.Id);
-        await _sut.SaveCampPolygonAsync(season2027.Id, """{"type":"Feature"}""", 200, user.Id);
+        await _sut.SaveCampPolygonAsync(season2026Id, """{"type":"Feature"}""", 100, userId);
+        await _sut.SaveCampPolygonAsync(season2027Id, """{"type":"Feature"}""", 200, userId);
+
+        _campService.GetCampSeasonDisplayDataForYearAsync(2026, Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<Guid, CampSeasonDisplayData>
+            {
+                [season2026Id] = new("Test Camp 2026", "test-camp", null)
+            });
 
         var result = await _sut.GetCampPolygonsAsync(2026);
 
         result.Should().HaveCount(1);
-        result[0].CampSeasonId.Should().Be(season2026.Id);
+        result[0].CampSeasonId.Should().Be(season2026Id);
     }
 
     [Fact]
     public async Task GetCampSeasonsWithoutCampPolygonAsync_ExcludesSeasonsWithPolygon()
     {
-        var (_, seasonWith, user) = await SeedCampWithLeadAsync(year: 2026);
-        var (_, seasonWithout, _) = await SeedCampWithLeadAsync(year: 2026);
+        var seasonWithId = Guid.NewGuid();
+        var seasonWithoutId = Guid.NewGuid();
+        var userId = NewUserId();
 
-        await _sut.SaveCampPolygonAsync(seasonWith.Id, """{"type":"Feature"}""", 100, user.Id);
+        await _sut.SaveCampPolygonAsync(seasonWithId, """{"type":"Feature"}""", 100, userId);
+
+        _campService.GetCampSeasonBriefsForYearAsync(2026, Arg.Any<CancellationToken>())
+            .Returns(new List<CampSeasonBrief>
+            {
+                new(seasonWithId, "Camp With", "camp-with"),
+                new(seasonWithoutId, "Camp Without", "camp-without")
+            });
 
         var result = await _sut.GetCampSeasonsWithoutCampPolygonAsync(2026);
 
         result.Should().HaveCount(1);
-        result[0].CampSeasonId.Should().Be(seasonWithout.Id);
+        result[0].CampSeasonId.Should().Be(seasonWithoutId);
     }
 
     [Fact]
     public async Task ExportAsGeoJsonAsync_ReturnsFeatureCollection()
     {
-        var (_, season, user) = await SeedCampWithLeadAsync(year: 2026);
+        var campSeasonId = Guid.NewGuid();
+        var userId = NewUserId();
         const string geoJson = """{"type":"Feature","geometry":{"type":"Polygon","coordinates":[[[0,0],[1,0],[1,1],[0,0]]]},"properties":{}}""";
 
-        await _sut.SaveCampPolygonAsync(season.Id, geoJson, 100.0, user.Id);
+        await _sut.SaveCampPolygonAsync(campSeasonId, geoJson, 100.0, userId);
+
+        _campService.GetCampSeasonDisplayDataForYearAsync(2026, Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<Guid, CampSeasonDisplayData>
+            {
+                [campSeasonId] = new("Test Camp", "test-camp", null)
+            });
 
         var result = await _sut.ExportAsGeoJsonAsync(2026);
 
@@ -339,14 +377,19 @@ public class CityPlanningServiceTests : IDisposable
     [Fact]
     public async Task GetCampPolygonHistoryAsync_ReturnsEntriesInDescendingOrder()
     {
-        var (_, season, user) = await SeedCampWithLeadAsync();
+        var campSeasonId = Guid.NewGuid();
+        var userId = NewUserId();
+        // Seed a user for the nav property (still needed for ModifiedByUser Include)
+        var user = new User { Id = userId, UserName = "test@test.com", Email = "test@test.com", DisplayName = "Test User" };
+        _dbContext.Users.Add(user);
+        await _dbContext.SaveChangesAsync();
 
         _clock.Advance(Duration.FromSeconds(1));
-        await _sut.SaveCampPolygonAsync(season.Id, """{"type":"Feature"}""", 100.0, user.Id);
+        await _sut.SaveCampPolygonAsync(campSeasonId, """{"type":"Feature"}""", 100.0, userId);
         _clock.Advance(Duration.FromSeconds(1));
-        await _sut.SaveCampPolygonAsync(season.Id, """{"type":"Feature"}""", 200.0, user.Id);
+        await _sut.SaveCampPolygonAsync(campSeasonId, """{"type":"Feature"}""", 200.0, userId);
 
-        var history = await _sut.GetCampPolygonHistoryAsync(season.Id);
+        var history = await _sut.GetCampPolygonHistoryAsync(campSeasonId);
 
         history.Should().HaveCount(2);
         history[0].AreaSqm.Should().Be(200.0); // Most recent first
@@ -356,13 +399,18 @@ public class CityPlanningServiceTests : IDisposable
     [Fact]
     public async Task GetCampPolygonsAsync_IncludesSoundZone_WhenSet()
     {
-        var (_, season, user) = await SeedCampWithLeadAsync();
-        season.SoundZone = SoundZone.Blue;
-        await _dbContext.SaveChangesAsync();
+        var campSeasonId = Guid.NewGuid();
+        var userId = NewUserId();
         const string geoJson = """{"type":"Feature","geometry":{"type":"Polygon","coordinates":[[]]}}""";
-        await _sut.SaveCampPolygonAsync(season.Id, geoJson, 100.0, user.Id);
+        await _sut.SaveCampPolygonAsync(campSeasonId, geoJson, 100.0, userId);
 
-        var polygons = await _sut.GetCampPolygonsAsync(season.Year);
+        _campService.GetCampSeasonDisplayDataForYearAsync(2026, Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<Guid, CampSeasonDisplayData>
+            {
+                [campSeasonId] = new("Test Camp", "test-camp", SoundZone.Blue)
+            });
+
+        var polygons = await _sut.GetCampPolygonsAsync(2026);
 
         polygons.Single().SoundZone.Should().Be(SoundZone.Blue);
     }
@@ -370,12 +418,18 @@ public class CityPlanningServiceTests : IDisposable
     [Fact]
     public async Task GetCampPolygonsAsync_SoundZoneIsNull_WhenNotSet()
     {
-        var (_, season, user) = await SeedCampWithLeadAsync();
-        // SoundZone not set, defaults to null
+        var campSeasonId = Guid.NewGuid();
+        var userId = NewUserId();
         const string geoJson = """{"type":"Feature","geometry":{"type":"Polygon","coordinates":[[]]}}""";
-        await _sut.SaveCampPolygonAsync(season.Id, geoJson, 100.0, user.Id);
+        await _sut.SaveCampPolygonAsync(campSeasonId, geoJson, 100.0, userId);
 
-        var polygons = await _sut.GetCampPolygonsAsync(season.Year);
+        _campService.GetCampSeasonDisplayDataForYearAsync(2026, Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<Guid, CampSeasonDisplayData>
+            {
+                [campSeasonId] = new("Test Camp", "test-camp", null)
+            });
+
+        var polygons = await _sut.GetCampPolygonsAsync(2026);
 
         polygons.Single().SoundZone.Should().BeNull();
     }
@@ -383,11 +437,11 @@ public class CityPlanningServiceTests : IDisposable
     [Fact]
     public async Task GetCampSeasonSoundZoneAsync_ReturnsSoundZone_WhenSet()
     {
-        var (_, season, _) = await SeedCampWithLeadAsync();
-        season.SoundZone = SoundZone.Red;
-        await _dbContext.SaveChangesAsync();
+        var campSeasonId = Guid.NewGuid();
+        _campService.GetCampSeasonSoundZoneAsync(campSeasonId, Arg.Any<CancellationToken>())
+            .Returns(SoundZone.Red);
 
-        var result = await _sut.GetCampSeasonSoundZoneAsync(season.Id);
+        var result = await _sut.GetCampSeasonSoundZoneAsync(campSeasonId);
 
         result.Should().Be(SoundZone.Red);
     }
@@ -395,9 +449,11 @@ public class CityPlanningServiceTests : IDisposable
     [Fact]
     public async Task GetCampSeasonSoundZoneAsync_ReturnsNull_WhenNotSet()
     {
-        var (_, season, _) = await SeedCampWithLeadAsync();
+        var campSeasonId = Guid.NewGuid();
+        _campService.GetCampSeasonSoundZoneAsync(campSeasonId, Arg.Any<CancellationToken>())
+            .Returns((SoundZone?)null);
 
-        var result = await _sut.GetCampSeasonSoundZoneAsync(season.Id);
+        var result = await _sut.GetCampSeasonSoundZoneAsync(campSeasonId);
 
         result.Should().BeNull();
     }
@@ -462,5 +518,45 @@ public class CityPlanningServiceTests : IDisposable
         var updated = await _dbContext.CityPlanningSettings.SingleAsync();
         updated.OfficialZonesGeoJson.Should().BeNull();
         updated.UpdatedAt.Should().Be(_clock.GetCurrentInstant());
+    }
+
+    [Fact]
+    public async Task GetUserDisplayNameAsync_ReturnsProfileBurnerName()
+    {
+        var userId = Guid.NewGuid();
+        _profileService.GetCachedProfileAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(new CachedProfile(
+                userId, "Display Name", null, false, Guid.NewGuid(), 0,
+                "Burner Name", null, null, null, null, null, null, null,
+                null, null, true, false, []));
+
+        var result = await _sut.GetUserDisplayNameAsync(userId);
+
+        result.Should().Be("Burner Name");
+    }
+
+    [Fact]
+    public async Task GetUserDisplayNameAsync_ReturnsNull_WhenNoProfile()
+    {
+        var userId = Guid.NewGuid();
+        _profileService.GetCachedProfileAsync(userId, Arg.Any<CancellationToken>())
+            .Returns((CachedProfile?)null);
+
+        var result = await _sut.GetUserDisplayNameAsync(userId);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetUserCampSeasonIdForYearAsync_DelegatesToCampService()
+    {
+        var userId = Guid.NewGuid();
+        var campSeasonId = Guid.NewGuid();
+        _campService.GetCampLeadSeasonIdForYearAsync(userId, 2026, Arg.Any<CancellationToken>())
+            .Returns(campSeasonId);
+
+        var result = await _sut.GetUserCampSeasonIdForYearAsync(userId, 2026);
+
+        result.Should().Be(campSeasonId);
     }
 }

--- a/tests/Humans.Application.Tests/Services/CityPlanningServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/CityPlanningServiceTests.cs
@@ -524,11 +524,8 @@ public class CityPlanningServiceTests : IDisposable
     public async Task GetUserDisplayNameAsync_ReturnsProfileBurnerName()
     {
         var userId = Guid.NewGuid();
-        _profileService.GetCachedProfileAsync(userId, Arg.Any<CancellationToken>())
-            .Returns(new CachedProfile(
-                userId, "Display Name", null, false, Guid.NewGuid(), 0,
-                "Burner Name", null, null, null, null, null, null, null,
-                null, null, true, false, []));
+        _profileService.GetProfileAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(new Profile { UserId = userId, BurnerName = "Burner Name" });
 
         var result = await _sut.GetUserDisplayNameAsync(userId);
 
@@ -539,8 +536,8 @@ public class CityPlanningServiceTests : IDisposable
     public async Task GetUserDisplayNameAsync_ReturnsNull_WhenNoProfile()
     {
         var userId = Guid.NewGuid();
-        _profileService.GetCachedProfileAsync(userId, Arg.Any<CancellationToken>())
-            .Returns((CachedProfile?)null);
+        _profileService.GetProfileAsync(userId, Arg.Any<CancellationToken>())
+            .Returns((Profile?)null);
 
         var result = await _sut.GetUserDisplayNameAsync(userId);
 

--- a/tests/Humans.Application.Tests/Services/ShiftManagementServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/ShiftManagementServiceTests.cs
@@ -6,6 +6,7 @@ using Humans.Infrastructure.Data;
 using Humans.Infrastructure.Services;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NodaTime.Testing;
@@ -18,6 +19,8 @@ public class ShiftManagementServiceTests : IDisposable
 {
     private readonly HumansDbContext _dbContext;
     private readonly FakeClock _clock;
+    private readonly ITeamService _teamService;
+    private readonly IRoleAssignmentService _roleAssignmentService;
     private readonly ShiftManagementService _service;
 
     private static readonly Instant TestNow = Instant.FromUtc(2026, 6, 15, 12, 0);
@@ -30,10 +33,17 @@ public class ShiftManagementServiceTests : IDisposable
 
         _dbContext = new HumansDbContext(options);
         _clock = new FakeClock(TestNow);
+        _teamService = Substitute.For<ITeamService>();
+        _roleAssignmentService = Substitute.For<IRoleAssignmentService>();
+
+        var serviceProvider = Substitute.For<IServiceProvider>();
+        serviceProvider.GetService(typeof(ITeamService)).Returns(_teamService);
 
         _service = new ShiftManagementService(
             _dbContext,
             Substitute.For<IAuditLogService>(),
+            _roleAssignmentService,
+            serviceProvider,
             new MemoryCache(new MemoryCacheOptions()),
             _clock,
             NullLogger<ShiftManagementService>.Instance);
@@ -359,9 +369,14 @@ public class ShiftManagementServiceTests : IDisposable
     [Fact]
     public async Task IsDeptCoordinatorAsync_SubTeamManager_ReturnsTrue_ForOwnSubTeam()
     {
-        var (department, subTeam, user) = await SeedSubTeamManagerScenario();
+        var userId = Guid.NewGuid();
+        var subTeamId = Guid.NewGuid();
 
-        var result = await _service.IsDeptCoordinatorAsync(user.Id, subTeam.Id);
+        // User coordinates subTeam
+        _teamService.GetUserCoordinatedTeamIdsAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(new List<Guid> { subTeamId });
+
+        var result = await _service.IsDeptCoordinatorAsync(userId, subTeamId);
 
         result.Should().BeTrue();
     }
@@ -369,21 +384,29 @@ public class ShiftManagementServiceTests : IDisposable
     [Fact]
     public async Task IsDeptCoordinatorAsync_SubTeamManager_ReturnsFalse_ForSiblingSubTeam()
     {
-        var (department, subTeamA, user) = await SeedSubTeamManagerScenario();
-        var subTeamB = new Team
-        {
-            Id = Guid.NewGuid(),
-            Name = "SubTeamB",
-            Slug = "subteam-b",
-            SystemTeamType = SystemTeamType.None,
-            ParentTeamId = department.Id,
-            CreatedAt = TestNow,
-            UpdatedAt = TestNow
-        };
-        _dbContext.Teams.Add(subTeamB);
-        await _dbContext.SaveChangesAsync();
+        var userId = Guid.NewGuid();
+        var subTeamAId = Guid.NewGuid();
+        var subTeamBId = Guid.NewGuid();
+        var departmentId = Guid.NewGuid();
 
-        var result = await _service.IsDeptCoordinatorAsync(user.Id, subTeamB.Id);
+        // User coordinates subTeamA only
+        _teamService.GetUserCoordinatedTeamIdsAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(new List<Guid> { subTeamAId });
+
+        // subTeamB's parent is department (not in coordinated list)
+        _teamService.GetTeamByIdAsync(subTeamBId, Arg.Any<CancellationToken>())
+            .Returns(new Team
+            {
+                Id = subTeamBId,
+                Name = "SubTeamB",
+                Slug = "subteam-b",
+                SystemTeamType = SystemTeamType.None,
+                ParentTeamId = departmentId,
+                CreatedAt = TestNow,
+                UpdatedAt = TestNow
+            });
+
+        var result = await _service.IsDeptCoordinatorAsync(userId, subTeamBId);
 
         result.Should().BeFalse();
     }
@@ -391,9 +414,28 @@ public class ShiftManagementServiceTests : IDisposable
     [Fact]
     public async Task IsDeptCoordinatorAsync_SubTeamManager_ReturnsFalse_ForParentDepartment()
     {
-        var (department, _, user) = await SeedSubTeamManagerScenario();
+        var userId = Guid.NewGuid();
+        var subTeamId = Guid.NewGuid();
+        var departmentId = Guid.NewGuid();
 
-        var result = await _service.IsDeptCoordinatorAsync(user.Id, department.Id);
+        // User coordinates subTeam only
+        _teamService.GetUserCoordinatedTeamIdsAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(new List<Guid> { subTeamId });
+
+        // Department has no parent
+        _teamService.GetTeamByIdAsync(departmentId, Arg.Any<CancellationToken>())
+            .Returns(new Team
+            {
+                Id = departmentId,
+                Name = "Department",
+                Slug = "department",
+                SystemTeamType = SystemTeamType.None,
+                ParentTeamId = null,
+                CreatedAt = TestNow,
+                UpdatedAt = TestNow
+            });
+
+        var result = await _service.IsDeptCoordinatorAsync(userId, departmentId);
 
         result.Should().BeFalse();
     }
@@ -401,107 +443,29 @@ public class ShiftManagementServiceTests : IDisposable
     [Fact]
     public async Task IsDeptCoordinatorAsync_DepartmentCoordinator_ReturnsTrue_ForChildSubTeam()
     {
-        var department = new Team
-        {
-            Id = Guid.NewGuid(),
-            Name = "Dept",
-            Slug = "dept",
-            SystemTeamType = SystemTeamType.None,
-            CreatedAt = TestNow,
-            UpdatedAt = TestNow
-        };
-        var subTeam = new Team
-        {
-            Id = Guid.NewGuid(),
-            Name = "SubTeam",
-            Slug = "subteam",
-            SystemTeamType = SystemTeamType.None,
-            ParentTeamId = department.Id,
-            CreatedAt = TestNow,
-            UpdatedAt = TestNow
-        };
-        await _dbContext.Teams.AddRangeAsync(department, subTeam);
+        var userId = Guid.NewGuid();
+        var departmentId = Guid.NewGuid();
+        var subTeamId = Guid.NewGuid();
 
-        var user = SeedUser("DeptCoord");
-        var member = new TeamMember
-        {
-            Id = Guid.NewGuid(),
-            TeamId = department.Id,
-            Team = department,
-            UserId = user.Id,
-            User = user,
-            Role = TeamMemberRole.Coordinator,
-            JoinedAt = TestNow
-        };
-        _dbContext.TeamMembers.Add(member);
-        await _dbContext.SaveChangesAsync();
+        // User coordinates department
+        _teamService.GetUserCoordinatedTeamIdsAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(new List<Guid> { departmentId });
 
-        var result = await _service.IsDeptCoordinatorAsync(user.Id, subTeam.Id);
+        // subTeam's parent is department
+        _teamService.GetTeamByIdAsync(subTeamId, Arg.Any<CancellationToken>())
+            .Returns(new Team
+            {
+                Id = subTeamId,
+                Name = "SubTeam",
+                Slug = "subteam",
+                SystemTeamType = SystemTeamType.None,
+                ParentTeamId = departmentId,
+                CreatedAt = TestNow,
+                UpdatedAt = TestNow
+            });
+
+        var result = await _service.IsDeptCoordinatorAsync(userId, subTeamId);
 
         result.Should().BeTrue();
-    }
-
-    private async Task<(Team department, Team subTeam, User user)> SeedSubTeamManagerScenario()
-    {
-        var department = new Team
-        {
-            Id = Guid.NewGuid(),
-            Name = "Department",
-            Slug = "department",
-            SystemTeamType = SystemTeamType.None,
-            CreatedAt = TestNow,
-            UpdatedAt = TestNow
-        };
-        var subTeam = new Team
-        {
-            Id = Guid.NewGuid(),
-            Name = "SubTeam",
-            Slug = "subteam",
-            SystemTeamType = SystemTeamType.None,
-            ParentTeamId = department.Id,
-            CreatedAt = TestNow,
-            UpdatedAt = TestNow
-        };
-        await _dbContext.Teams.AddRangeAsync(department, subTeam);
-
-        var user = SeedUser("SubTeamMgr");
-        var member = new TeamMember
-        {
-            Id = Guid.NewGuid(),
-            TeamId = subTeam.Id,
-            Team = subTeam,
-            UserId = user.Id,
-            User = user,
-            Role = TeamMemberRole.Coordinator,
-            JoinedAt = TestNow
-        };
-        _dbContext.TeamMembers.Add(member);
-
-        var roleDef = new TeamRoleDefinition
-        {
-            Id = Guid.NewGuid(),
-            TeamId = subTeam.Id,
-            Name = "Manager",
-            IsManagement = true,
-            SlotCount = 1,
-            SortOrder = 0,
-            CreatedAt = TestNow,
-            UpdatedAt = TestNow
-        };
-        _dbContext.TeamRoleDefinitions.Add(roleDef);
-
-        var assignment = new TeamRoleAssignment
-        {
-            Id = Guid.NewGuid(),
-            TeamRoleDefinitionId = roleDef.Id,
-            TeamMemberId = member.Id,
-            SlotIndex = 0,
-            AssignedAt = TestNow,
-            AssignedByUserId = Guid.NewGuid()
-        };
-        _dbContext.TeamRoleAssignments.Add(assignment);
-
-        await _dbContext.SaveChangesAsync();
-        return (department, subTeam, user);
     }
 }

--- a/tests/Humans.Application.Tests/Services/ShiftSignupServiceEarlyEntryTests.cs
+++ b/tests/Humans.Application.Tests/Services/ShiftSignupServiceEarlyEntryTests.cs
@@ -1,6 +1,7 @@
 using AwesomeAssertions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NodaTime.Testing;
@@ -34,9 +35,16 @@ public class ShiftSignupServiceEarlyEntryTests : IDisposable
         _clock = new FakeClock(TestNow);
         _auditLog = Substitute.For<IAuditLogService>();
 
+        var teamService = Substitute.For<ITeamService>();
+        var roleAssignmentService = Substitute.For<IRoleAssignmentService>();
+        var serviceProvider = Substitute.For<IServiceProvider>();
+        serviceProvider.GetService(typeof(ITeamService)).Returns(teamService);
+
         _shiftMgmt = new ShiftManagementService(
             _dbContext,
             _auditLog,
+            roleAssignmentService,
+            serviceProvider,
             new MemoryCache(new MemoryCacheOptions()),
             _clock,
             NullLogger<ShiftManagementService>.Instance);
@@ -46,6 +54,7 @@ public class ShiftSignupServiceEarlyEntryTests : IDisposable
             _shiftMgmt,
             _auditLog,
             Substitute.For<INotificationService>(),
+            serviceProvider,
             _clock,
             NullLogger<ShiftSignupService>.Instance);
     }

--- a/tests/Humans.Application.Tests/Services/ShiftSignupServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/ShiftSignupServiceTests.cs
@@ -1,6 +1,7 @@
 using AwesomeAssertions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NodaTime.Testing;
@@ -36,9 +37,16 @@ public class ShiftSignupServiceTests : IDisposable
         _clock = new FakeClock(TestNow);
         _auditLog = Substitute.For<IAuditLogService>();
 
+        var teamService = Substitute.For<ITeamService>();
+        var roleAssignmentService = Substitute.For<IRoleAssignmentService>();
+        var serviceProvider = Substitute.For<IServiceProvider>();
+        serviceProvider.GetService(typeof(ITeamService)).Returns(teamService);
+
         _shiftMgmt = new ShiftManagementService(
             _dbContext,
             _auditLog,
+            roleAssignmentService,
+            serviceProvider,
             new MemoryCache(new MemoryCacheOptions()),
             _clock,
             NullLogger<ShiftManagementService>.Instance);
@@ -48,6 +56,7 @@ public class ShiftSignupServiceTests : IDisposable
             _shiftMgmt,
             _auditLog,
             Substitute.For<INotificationService>(),
+            serviceProvider,
             _clock,
             NullLogger<ShiftSignupService>.Instance);
     }

--- a/tests/Humans.Application.Tests/Services/ShiftUrgencyTests.cs
+++ b/tests/Humans.Application.Tests/Services/ShiftUrgencyTests.cs
@@ -5,6 +5,7 @@ using Humans.Domain.Enums;
 using Humans.Infrastructure.Services;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NodaTime.Testing;
@@ -35,9 +36,14 @@ public class ShiftUrgencyTests : IDisposable
             .Options;
         _dbContext = new HumansDbContext(options);
 
+        var serviceProvider = Substitute.For<IServiceProvider>();
+        serviceProvider.GetService(typeof(ITeamService)).Returns(Substitute.For<ITeamService>());
+
         _service = new ShiftManagementService(
             _dbContext,
             Substitute.For<IAuditLogService>(),
+            Substitute.For<IRoleAssignmentService>(),
+            serviceProvider,
             new MemoryCache(new MemoryCacheOptions()),
             new FakeClock(TestNow),
             NullLogger<ShiftManagementService>.Instance);

--- a/tests/Humans.Application.Tests/Services/TeamRoleServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/TeamRoleServiceTests.cs
@@ -1,6 +1,7 @@
 using AwesomeAssertions;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NodaTime.Testing;
@@ -38,9 +39,13 @@ public class TeamRoleServiceTests : IDisposable
             _clock,
             cache,
             NullLogger<RoleAssignmentService>.Instance);
+        var serviceProvider = Substitute.For<IServiceProvider>();
+        serviceProvider.GetService(typeof(ITeamService)).Returns(Substitute.For<ITeamService>());
         var shiftManagementService = new ShiftManagementService(
             _dbContext,
             Substitute.For<IAuditLogService>(),
+            roleAssignmentService,
+            serviceProvider,
             cache,
             _clock,
             NullLogger<ShiftManagementService>.Instance);

--- a/tests/Humans.Application.Tests/Services/TeamServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/TeamServiceTests.cs
@@ -2,6 +2,7 @@ using AwesomeAssertions;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NodaTime.Testing;
@@ -41,9 +42,13 @@ public class TeamServiceTests : IDisposable
             _clock,
             _cache,
             NullLogger<RoleAssignmentService>.Instance);
+        var serviceProvider = Substitute.For<IServiceProvider>();
+        serviceProvider.GetService(typeof(ITeamService)).Returns(Substitute.For<ITeamService>());
         var shiftManagementService = new ShiftManagementService(
             _dbContext,
             Substitute.For<IAuditLogService>(),
+            _roleAssignmentService,
+            serviceProvider,
             _cache,
             _clock,
             NullLogger<ShiftManagementService>.Instance);


### PR DESCRIPTION
## Summary

- CityPlanningService no longer queries CampSeasons, Camps, CampLeads, CampSettings, Teams, TeamMembers, or Profiles directly — routes through ICampService, ITeamService, and IProfileService
- ShiftManagementService/ShiftSignupService no longer query Teams, TeamMembers, TeamRoleAssignments, or RoleAssignments directly — routes through ITeamService and IRoleAssignmentService
- New service API methods added to CampService (6), TeamService (2), and RoleAssignmentService (1)
- Circular ShiftManagement↔TeamService dependency resolved via IServiceProvider lazy resolution (existing codebase pattern)

## Acceptance Criteria (from #471)

- [x] CityPlanningService does not query CampSeasons, Camps, CampLeads, or CampSettings directly
- [x] CityPlanningService calls CampService for all camp-related data and mutations
- [x] ShiftManagementService/ShiftSignupService call TeamService for membership/team data
- [x] ShiftManagementService calls RoleAssignmentService for role checks
- [x] CampService cache remains reliable
- [x] Existing tests pass (942/942 application tests)

## Test plan

- [x] `dotnet build Humans.slnx` — 0 errors, 0 warnings
- [x] `dotnet test Humans.slnx` — 942 application tests pass, 108 domain tests pass
- [x] Grep confirms zero `_dbContext.(CampSeasons|Camps|CampLeads|CampSettings|Teams|TeamMembers|Profiles)` in CityPlanningService
- [x] Grep confirms zero `_dbContext.(Teams|TeamMembers|TeamRoleAssignments|RoleAssignments)` in shift services
- [ ] QA deploy and smoke test city planning map and shift signup flows

Closes #471

🤖 Generated with [Claude Code](https://claude.com/claude-code)