### PR TITLE
Profile fixes: shift signups for coordinators + Firefox edit buttons (#493, #495)

### DIFF
--- a/src/Humans.Web/Controllers/ProfileController.cs
+++ b/src/Humans.Web/Controllers/ProfileController.cs
@@ -1009,10 +1009,11 @@ public class ProfileController : HumansControllerBase
 
         // Load no-show history for coordinators/NoInfoAdmin/Admin viewing other profiles
         List<NoShowHistoryItem>? noShowHistory = null;
+        var viewerCanViewShiftHistory = false;
         if (!isOwnProfile)
         {
             var viewerIsCoordinator = (await _shiftMgmt.GetCoordinatorTeamIdsAsync(viewer.Id)).Count > 0;
-            var viewerCanViewShiftHistory = viewerIsCoordinator || ShiftRoleChecks.IsPrivilegedSignupApprover(User);
+            viewerCanViewShiftHistory = viewerIsCoordinator || ShiftRoleChecks.IsPrivilegedSignupApprover(User);
 
             if (viewerCanViewShiftHistory)
             {
@@ -1047,6 +1048,7 @@ public class ProfileController : HumansControllerBase
             IsOwnProfile = isOwnProfile,
             IsApproved = profile.IsApproved,
             NoShowHistory = noShowHistory,
+            CanViewShiftSignups = viewerCanViewShiftHistory,
         };
 
         return View("Index", viewModel);

--- a/src/Humans.Web/Models/ProfileViewModel.cs
+++ b/src/Humans.Web/Models/ProfileViewModel.cs
@@ -314,6 +314,12 @@ public class ProfileViewModel
     public List<NoShowHistoryItem>? NoShowHistory { get; set; }
 
     /// <summary>
+    /// Whether the viewer can see the shift signups section (coordinators, signup approvers, admins).
+    /// Uses the same gate as NoShowHistory. Only meaningful when IsOwnProfile is false.
+    /// </summary>
+    public bool CanViewShiftSignups { get; set; }
+
+    /// <summary>
     /// Languages for editing (owner only).
     /// </summary>
     public List<ProfileLanguageEditViewModel> EditableLanguages { get; set; } = [];

--- a/src/Humans.Web/Views/Profile/Edit.cshtml
+++ b/src/Humans.Web/Views/Profile/Edit.cshtml
@@ -504,13 +504,13 @@
 
     @if (!string.IsNullOrEmpty(ViewData["GoogleMapsApiKey"]?.ToString()))
     {
-        <script>
+        <script nonce="@Context.Items["CspNonce"]">
             (g=>{var h,a,k,p="The Google Maps JavaScript API",c="google",l="importLibrary",q="__ib__",m=document,b=window;b=b[c]||(b[c]={});var d=b.maps||(b.maps={}),r=new Set,e=new URLSearchParams,u=()=>h||(h=new Promise(async(f,n)=>{await (a=m.createElement("script"));e.set("libraries",[...r]+"");for(k in g)e.set(k.replace(/[A-Z]/g,t=>"_"+t[0].toLowerCase()),g[k]);e.set("callback",c+".maps."+q);a.src=`https://maps.${c}apis.com/maps/api/js?`+e;d[q]=f;a.onerror=()=>h=n(Error(p+" could not load."));a.nonce=m.querySelector("script[nonce]")?.nonce||"";m.head.append(a)}));d[l]?console.warn(p+" only loads once. Ignoring:",g):d[l]=(f,...n)=>r.add(f)&&u().then(()=>d[l](f,...n))})({
                 key: "@ViewData["GoogleMapsApiKey"]",
                 v: "weekly"
             });
         </script>
-        <script>
+        <script nonce="@Context.Items["CspNonce"]">
             async function initPlacesAutocomplete() {
                 try {
                     // Load the places library
@@ -605,12 +605,12 @@
     }
     else
     {
-        <script>
+        <script nonce="@Context.Items["CspNonce"]">
             console.warn("Google Maps API key not configured. Location autocomplete disabled.");
         </script>
     }
 
-    <script>
+    <script nonce="@Context.Items["CspNonce"]">
         (function() {
             const container = document.getElementById('contactFieldsContainer');
             const addButton = document.getElementById('addContactField');
@@ -921,7 +921,7 @@
             });
         })();
     </script>
-    <script>
+    <script nonce="@Context.Items["CspNonce"]">
         // Tier selection show/hide for application section and Asociado questions
         (function() {
             const tierRadios = document.querySelectorAll('input[name="SelectedTier"]');
@@ -943,7 +943,7 @@
             });
         })();
     </script>
-    <script>
+    <script nonce="@Context.Items["CspNonce"]">
         // Client-side CV validation: block submit if no CV rows and checkbox unchecked
         (function() {
             const form = document.querySelector('form[action*="Edit"]');
@@ -966,7 +966,7 @@
             });
         })();
     </script>
-    <script>
+    <script nonce="@Context.Items["CspNonce"]">
         // Toggle volunteer history section visibility based on "No Prior Burn Experience" checkbox
         (function() {
             const checkbox = document.getElementById('noPriorBurnCheckbox');
@@ -984,7 +984,7 @@
             checkbox.addEventListener('change', toggleHistorySection);
         })();
     </script>
-    <script>
+    <script nonce="@Context.Items["CspNonce"]">
         // Unsaved-changes guard
         (function () {
             const form = document.querySelector('form[action*="Edit"]');

--- a/src/Humans.Web/Views/Profile/Index.cshtml
+++ b/src/Humans.Web/Views/Profile/Index.cshtml
@@ -66,6 +66,11 @@
         }
         <vc:profile-card user-id="@Model.UserId" view-mode="@cardViewMode" />
 
+        @if (!Model.IsOwnProfile && Model.CanViewShiftSignups)
+        {
+            <vc:shift-signups user-id="@Model.UserId" view-mode="@ShiftSignupsViewMode.Admin" display-name="@Model.DisplayName" />
+        }
+
         @if (Model.NoShowHistory != null && Model.NoShowHistory.Count > 0)
         {
             <div class="card mb-3">


### PR DESCRIPTION
## Summary

Two profile-related fixes:

- **#493** — Volunteer coordinators viewing another human's profile now see the ShiftSignups component (previously only visible on the admin detail view). Reuses the existing no-show-history gate (`viewerIsCoordinator || ShiftRoleChecks.IsPrivilegedSignupApprover(User)`) so the surface is consistent across both blocks. New `CanViewShiftSignups` flag on `ProfileViewModel` plus an `@if` block in `Views/Profile/Index.cshtml`.

- **#495** — `+ Add language` and `+ Add entry` (burner CV) buttons on `/Profile/Me/Edit` did nothing on click in Firefox 149. Root cause: every inline `<script>` block in `Views/Profile/Edit.cshtml` was missing the `nonce="@Context.Items[\"CspNonce\"]"` attribute, so the strict `script-src` policy from `CspNonceMiddleware` blocked them. The Google Maps loader inside the same file already calls `m.querySelector(\"script[nonce]\")?.nonce` to copy the page nonce onto its dynamically-injected tag — which only makes sense if the surrounding scripts were intended to carry the nonce. Added the nonce attribute to all eight inline scripts. CSS hover/pressed states still rendering was the giveaway: the page DOM was fine, only the JS handlers were dead.

## Test plan

- [ ] Sign in as a non-admin coordinator, visit another volunteer's `/Profile/{id}`, confirm the ShiftSignups card renders.
- [ ] Sign in as a regular non-coordinator, visit another profile, confirm the card does NOT render.
- [ ] Open `/Profile/{id}/Admin` as admin, confirm the existing AdminDetail view still shows signups (untouched).
- [ ] In Firefox, open `/Profile/Me/Edit`, click `+ Add language` and `+ Add entry`, confirm new rows appear and remove buttons work.
- [ ] In Chrome, repeat the same edit-page interactions, confirm nothing regressed and no new CSP violations in the console.

Closes #493
Closes #495

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>