### PR TITLE
Add end-to-end reconciliation test rig for Google sync soft-delete paths (#508)

### DIFF
--- a/docs/superpowers/plans/2026-04-16-google-sync-reconciliation-tests.md
+++ b/docs/superpowers/plans/2026-04-16-google-sync-reconciliation-tests.md
@@ -1,0 +1,212 @@
+# Issue #508 — Google reconciliation soft-delete test rig
+
+## Goal
+
+Add end-to-end test coverage for `GoogleWorkspaceSyncService.SyncResourcesByTypeAsync` so
+the six reconciliation scenarios from issue #508 are pinned by automated tests instead of
+by careful reading + Codex review.
+
+## Seam design
+
+**Problem**: `GoogleWorkspaceSyncService` calls `CloudIdentityService.Groups.Memberships.*`
+and `DriveService.Permissions.*` directly through the concrete Google SDK client classes.
+Those classes are sealed / awkward to fake. Tests need a way to substitute the API surface
+without touching the rest of the service.
+
+**Approach**: Introduce two narrow internal interfaces — `IGoogleGroupMembershipClient`
+and `IGoogleDrivePermissionClient` — that expose only the operations the reconciliation
+path uses (list / create / delete). Real implementations wrap `CloudIdentityService` /
+`DriveService`. Fake implementations back everything with dictionaries for tests.
+
+The interfaces live in `src/Humans.Infrastructure/Google/` and are `internal` — exposed to
+`Humans.Application.Tests` via the existing `InternalsVisibleTo` attribute.
+
+`GoogleWorkspaceSyncService` gains a second `internal` constructor overload that takes the
+two clients explicitly. The default production constructor builds them lazily from the
+existing `GetDriveServiceAsync()` / `GetCloudIdentityServiceAsync()` helpers — so
+production behavior is byte-identical, only reconciliation code paths route through the
+clients.
+
+**Out of scope**: `SyncTeamGroupMembersAsync`, group settings drift, path reconciliation,
+and provisioning methods keep their direct Google SDK calls. Only the paths hit by
+`SyncResourcesByTypeAsync` + `AddUserTo{Drive,Group}Async` + `RemoveUserFrom{Drive,Group}Async`
+need the seam.
+
+## Interface surface
+
+```csharp
+internal interface IGoogleGroupMembershipClient
+{
+    Task<IReadOnlyList<Membership>> ListMembershipsAsync(string groupId, CancellationToken ct);
+    Task CreateMembershipAsync(string groupId, string userEmail, CancellationToken ct);
+    Task DeleteMembershipAsync(string membershipName, CancellationToken ct);
+}
+
+internal interface IGoogleDrivePermissionClient
+{
+    Task<IReadOnlyList<Permission>> ListPermissionsAsync(string fileId, CancellationToken ct);
+    Task<string> CreatePermissionAsync(string fileId, string userEmail, string role, CancellationToken ct);
+    Task DeletePermissionAsync(string fileId, string permissionId, CancellationToken ct);
+}
+```
+
+- Google SDK POCOs (`Membership`, `Permission`) are used as-is in return types — they're plain
+  data classes the rest of the service already uses, so there's no translation layer.
+- `CreatePermissionAsync` returns the new permission id so callers/tests can verify.
+- `CreateMembershipAsync` does not return anything — the sync service doesn't use the result.
+- Errors surface as thrown exceptions. 404/403 handling in `SyncGroupResourceAsync` keeps its
+  `GoogleApiException` catch; fakes throw `GoogleApiException` or a simulated exception type
+  when a test seeds an error scenario.
+
+## Files to create
+
+1. `src/Humans.Infrastructure/Google/IGoogleGroupMembershipClient.cs` — interface.
+2. `src/Humans.Infrastructure/Google/IGoogleDrivePermissionClient.cs` — interface.
+3. `src/Humans.Infrastructure/Google/RealGoogleGroupMembershipClient.cs` — wraps `CloudIdentityService`.
+4. `src/Humans.Infrastructure/Google/RealGoogleDrivePermissionClient.cs` — wraps `DriveService`.
+5. `tests/Humans.Application.Tests/Fakes/FakeGoogleGroupMembershipClient.cs` — in-memory impl.
+6. `tests/Humans.Application.Tests/Fakes/FakeGoogleDrivePermissionClient.cs` — in-memory impl.
+7. `tests/Humans.Application.Tests/Services/GoogleWorkspaceSyncServiceReconciliationTests.cs` — tests.
+
+## Files to modify
+
+1. `src/Humans.Infrastructure/Services/GoogleWorkspaceSyncService.cs`:
+   - Add `_groupMembershipClient` / `_drivePermissionClient` private fields.
+   - Add private `GetGroupMembershipClientAsync()` / `GetDrivePermissionClientAsync()` that
+     lazily build real clients when not overridden.
+   - Add `internal` constructor overload accepting the two clients (for tests).
+   - Refactor 6 call sites to go through the new clients:
+     - `SyncGroupResourceAsync`: inline membership listing + `GoogleApiException` catch.
+     - `SyncDriveResourceGroupAsync`: use helper that delegates to client.
+     - `ExecuteDriveSyncActionsAsync`: the permission lookup before removal.
+     - `AddUserToGroupAsync`: `.Memberships.Create(...)` call.
+     - `RemoveUserFromGroupAsync`: lookup + `.Memberships.Delete(...)` call.
+     - `AddUserToDriveAsync` / `RemoveUserFromDriveAsync`: `.Permissions.*` calls.
+   - Keep `ListDrivePermissionsAsync` helper but make it delegate to the client (or remove).
+
+## Fake design
+
+### `FakeGoogleGroupMembershipClient`
+- `Dictionary<string, List<Membership>> _memberships` keyed by `groupId`.
+- `CreateMembershipAsync` adds a new `Membership` with `Name = "groups/{gid}/memberships/{guid}"`
+  and `PreferredMemberKey.Id = email`. Throws 409 `GoogleApiException` if already present
+  (so the idempotent path in `AddUserToGroupAsync` is exercised).
+- `DeleteMembershipAsync` removes the matching `Name`.
+- `ListMembershipsAsync` returns a snapshot of the list for the given group.
+- `AddFailingGroup(groupId)` registers a group id whose list/create/delete operations all
+  throw — used for the "shared-GoogleId error" scenario.
+- `AddInitialMembership(groupId, email)` seeds an existing membership.
+
+### `FakeGoogleDrivePermissionClient`
+- `Dictionary<string, List<Permission>> _permissions` keyed by `fileId`.
+- `CreatePermissionAsync` adds a new `Permission` with `Id = Guid`, `Type = "user"`,
+  `EmailAddress = email`, `Role = role`, `PermissionDetails = null` (direct, not inherited).
+- `DeletePermissionAsync` removes by `permissionId`.
+- `AddInitialPermission(fileId, email, role, inherited: false)` seeds an existing permission.
+  Setting `inherited: true` populates `PermissionDetails` with an inherited entry so the
+  reconciler classifies it as `Inherited` (not `Extra`).
+- `AddFailingFile(fileId)` — list/delete throws.
+
+Both fakes also expose read-only snapshots (`GetMemberships(groupId)` / `GetPermissions(fileId)`)
+so test assertions can read the post-execute state directly.
+
+## Test scenarios (one `[Fact]` each)
+
+All tests construct `GoogleWorkspaceSyncService` via the internal test constructor with the
+fake clients, seed an InMemory `HumansDbContext` + `StubTeamResourceService`, and call
+`SyncResourcesByTypeAsync(...SyncAction.Execute)` end-to-end.
+
+### 1. `SoftDeletedTeam_RevokesDriveAndGroupPermissions_AndDeactivatesResourcesPerType`
+- Seed: team (`IsActive = false`), 2 members (`LeftAt` set), 1 DriveFolder resource + 1 Group resource, both active.
+- Fake Drive has direct permissions for both members on the folder.
+- Fake Group has memberships for both members.
+- Sync mode `AddAndRemove` for both services.
+- Run `SyncResourcesByTypeAsync(DriveFolder)` → assert fake Drive has 0 permissions
+  (SA allowed), DB row for DriveFolder is `IsActive = false`, DB row for Group is still
+  `IsActive = true` (scoped per type).
+- Run `SyncResourcesByTypeAsync(Group)` → assert fake Group has 0 memberships, DB row for
+  Group is now `IsActive = false`.
+
+### 2. `SharedGoogleIdDriveGroup_WhenApiFails_NoTeamInGroupIsDeactivated`
+- Seed: two soft-deleted teams A and B, each with a DriveFolder row pointing at the same
+  `GoogleId` (shared folder). Fake Drive is configured to throw on `ListPermissionsAsync`
+  for that GoogleId.
+- Run `SyncResourcesByTypeAsync(DriveFolder)` → assert both teams' DriveFolder rows remain
+  `IsActive = true`, both rows retain `ErrorMessage`, and `DeactivateResourcesForTeamAsync`
+  was not called (by asserting via a spy on `ITeamResourceService` or by reading DB state).
+
+### 3. `PartialErrorWithinTeam_DefersDeactivationForTeamAndType`
+- Seed: one soft-deleted team with TWO DriveFolder rows — different GoogleIds. Fake Drive
+  throws on one of them, succeeds on the other.
+- Run `SyncResourcesByTypeAsync(DriveFolder)` → assert BOTH rows remain `IsActive = true`
+  (the clean row must not get swept up by a scoped deactivation call because the team has
+  an errored row of the same type).
+
+### 4. `DriveFolderPass_DoesNotDeactivateGroupRowForSoftDeletedTeam`
+- Seed: soft-deleted team with DriveFolder + Group rows, fake Drive empty, fake Group with
+  existing memberships.
+- Run `SyncResourcesByTypeAsync(DriveFolder)` only.
+- Assert: DriveFolder row `IsActive = false`, Group row still `IsActive = true` (would make
+  the Group pass on the next tick skip the team otherwise).
+
+### 5. `AddOnlyMode_DoesNotDeactivateSoftDeletedTeamResources`
+- Same scenario as test 1, but sync mode set to `AddOnly` for GoogleDrive.
+- Run `SyncResourcesByTypeAsync(DriveFolder)` → fake Drive permissions UNCHANGED (RemoveUser
+  short-circuits on AddOnly), DB row STILL `IsActive = true` (post-execute cleanup skipped).
+
+### 6. `NoneMode_DoesNotDeactivateSoftDeletedTeamResources`
+- Same scenario as test 1, but sync mode set to `None` for GoogleDrive.
+- Run `SyncResourcesByTypeAsync(DriveFolder)` → permissions UNCHANGED, DB row still active.
+
+## Real `ITeamResourceService` vs stub in tests
+
+The reconciliation service resolves `ITeamResourceService` via `IServiceProvider`. Tests can
+wire the real `StubTeamResourceService` (which is a full impl, not a no-op — see
+`TeamResourceServiceDeactivateTests`) or register `TeamResourceService` itself. Given the
+production path is tested via `TeamResourceService` and the stub is used in other tests
+already, prefer `StubTeamResourceService` unless it differs meaningfully from
+`TeamResourceService.DeactivateResourcesForTeamAsync`.
+
+Quick check: `StubTeamResourceService.DeactivateResourcesForTeamAsync` is "logically
+identical" per `TeamResourceServiceDeactivateTests` docstring. Use it.
+
+## Test base class
+
+A `GoogleWorkspaceSyncServiceTestBase` helper encapsulates:
+- InMemory `HumansDbContext` + `IDbContextFactory` (simple wrapper).
+- `FakeClock`, null logger.
+- Fake `IAuditLogService` (NSubstitute).
+- `StubTeamResourceService` wired into an `IServiceProvider` substitute.
+- `ISyncSettingsService` with mutable `SyncMode` state.
+- `GoogleWorkspaceSettings` with a dummy service account JSON (so `GetServiceAccountEmailAsync`
+  works and doesn't throw).
+- `FakeGoogleDrivePermissionClient` + `FakeGoogleGroupMembershipClient`.
+- Seeding helpers: `SeedTeam(softDeleted: bool)`, `SeedMember(teamId, email, leftAt: Instant?)`,
+  `SeedGoogleResource(teamId, type, googleId, isActive)`.
+
+## Execution order
+
+1. Refactor `GoogleWorkspaceSyncService` to introduce the clients (interfaces + real impls +
+   field + getter + internal constructor + refactor call sites). Build to confirm unchanged
+   behavior.
+2. Run full `dotnet test Humans.slnx` to confirm no regression.
+3. Add fakes.
+4. Add test base class + tests one at a time. Each test drives any fake API clarifications
+   needed.
+5. Final build + test + `dotnet format`.
+
+## Verification checklist
+
+- [ ] `dotnet build Humans.slnx` clean.
+- [ ] `dotnet test Humans.slnx --filter FullyQualifiedName~GoogleWorkspaceSyncServiceReconciliationTests` → 6 new tests pass.
+- [ ] `dotnet test Humans.slnx` → no regressions in the existing `Humans.Application.Tests` suite.
+- [ ] All 6 acceptance criteria from issue #508 have a corresponding named `[Fact]`.
+- [ ] Fakes live in `tests/Humans.Application.Tests/Fakes/` and are reusable (no per-test state leakage).
+- [ ] No production API change visible to non-test callers (`internal` ctor only).
+
+## PR
+
+- Base: `peterdrier/Humans:main` (PR #227 is here but not upstream yet).
+- Title: `Add end-to-end reconciliation test rig for Google sync soft-delete paths (#508)`.
+- Body: scenario list + note that seam is `internal`-only.
+- Closes: #508.

--- a/src/Humans.Infrastructure/GoogleSync/IGoogleDrivePermissionClient.cs
+++ b/src/Humans.Infrastructure/GoogleSync/IGoogleDrivePermissionClient.cs
@@ -1,0 +1,32 @@
+using Google.Apis.Drive.v3.Data;
+
+namespace Humans.Infrastructure.GoogleSync;
+
+/// <summary>
+/// Narrow seam over <see cref="global::Google.Apis.Drive.v3.DriveService"/> used by
+/// <see cref="Services.GoogleWorkspaceSyncService"/>'s reconciliation + gateway paths.
+/// Exists so the reconciliation tests can substitute an in-memory fake without touching the
+/// SDK's sealed concrete types. Only the operations the reconciliation path uses are exposed.
+/// Always targets Shared Drives (<c>SupportsAllDrives = true</c>) and requests
+/// <c>permissionDetails</c> so callers can distinguish direct from inherited permissions.
+/// </summary>
+internal interface IGoogleDrivePermissionClient
+{
+    /// <summary>
+    /// Returns all permissions on the given Drive file or folder id, including inherited
+    /// ones on Shared Drives. Pagination is handled internally.
+    /// </summary>
+    Task<IReadOnlyList<Permission>> ListPermissionsAsync(string fileId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Creates a direct user permission on the given file id and returns the new permission id.
+    /// <paramref name="role"/> is the Drive API role string (e.g. <c>reader</c>, <c>writer</c>,
+    /// <c>fileOrganizer</c>).
+    /// </summary>
+    Task<string> CreatePermissionAsync(string fileId, string userEmail, string role, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Deletes the permission identified by <paramref name="permissionId"/> from the given file.
+    /// </summary>
+    Task DeletePermissionAsync(string fileId, string permissionId, CancellationToken cancellationToken);
+}

--- a/src/Humans.Infrastructure/GoogleSync/IGoogleGroupMembershipClient.cs
+++ b/src/Humans.Infrastructure/GoogleSync/IGoogleGroupMembershipClient.cs
@@ -1,0 +1,36 @@
+using Google.Apis.CloudIdentity.v1.Data;
+
+namespace Humans.Infrastructure.GoogleSync;
+
+/// <summary>
+/// Narrow seam over <see cref="global::Google.Apis.CloudIdentity.v1.CloudIdentityService"/> used by
+/// <see cref="Services.GoogleWorkspaceSyncService"/>'s reconciliation + gateway paths.
+/// Exists so the reconciliation tests can substitute an in-memory fake without touching the
+/// SDK's sealed concrete types. Only the operations the reconciliation path uses are exposed.
+/// </summary>
+internal interface IGoogleGroupMembershipClient
+{
+    /// <summary>
+    /// Returns all memberships on the given Google Group id. Pagination is handled internally.
+    /// </summary>
+    /// <exception cref="global::Google.GoogleApiException">
+    /// Thrown with <c>Error.Code = 404</c> when the group does not exist in Google and with
+    /// <c>Error.Code = 403</c> when the service account lacks access.
+    /// </exception>
+    Task<IReadOnlyList<Membership>> ListMembershipsAsync(string groupId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Creates a MEMBER membership for the given email on the given group id.
+    /// </summary>
+    /// <exception cref="global::Google.GoogleApiException">
+    /// Thrown with <c>Error.Code = 409</c> if the user is already a member, and <c>403</c> for
+    /// permission errors or rejected emails.
+    /// </exception>
+    Task CreateMembershipAsync(string groupId, string userEmail, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Deletes the membership identified by its full resource name
+    /// (<c>groups/{groupId}/memberships/{membershipId}</c>).
+    /// </summary>
+    Task DeleteMembershipAsync(string membershipName, CancellationToken cancellationToken);
+}

--- a/src/Humans.Infrastructure/GoogleSync/RealGoogleDrivePermissionClient.cs
+++ b/src/Humans.Infrastructure/GoogleSync/RealGoogleDrivePermissionClient.cs
@@ -1,0 +1,65 @@
+using Google.Apis.Drive.v3;
+using Google.Apis.Drive.v3.Data;
+
+namespace Humans.Infrastructure.GoogleSync;
+
+/// <summary>
+/// Production <see cref="IGoogleDrivePermissionClient"/> that delegates to a
+/// <see cref="DriveService"/>. Always sets <c>SupportsAllDrives = true</c> and requests
+/// <c>permissionDetails</c> so the caller can distinguish direct from inherited Shared Drive
+/// permissions.
+/// </summary>
+internal sealed class RealGoogleDrivePermissionClient : IGoogleDrivePermissionClient
+{
+    private readonly DriveService _service;
+
+    public RealGoogleDrivePermissionClient(DriveService service)
+    {
+        _service = service;
+    }
+
+    public async Task<IReadOnlyList<Permission>> ListPermissionsAsync(string fileId, CancellationToken cancellationToken)
+    {
+        var result = new List<Permission>();
+        string? pageToken = null;
+        do
+        {
+            var request = _service.Permissions.List(fileId);
+            request.SupportsAllDrives = true;
+            request.Fields = "nextPageToken, permissions(id, emailAddress, role, type, permissionDetails)";
+            if (pageToken is not null)
+                request.PageToken = pageToken;
+
+            var response = await request.ExecuteAsync(cancellationToken);
+            if (response.Permissions is not null)
+                result.AddRange(response.Permissions);
+
+            pageToken = response.NextPageToken;
+        } while (!string.IsNullOrEmpty(pageToken));
+
+        return result;
+    }
+
+    public async Task<string> CreatePermissionAsync(string fileId, string userEmail, string role, CancellationToken cancellationToken)
+    {
+        var permission = new Permission
+        {
+            Type = "user",
+            Role = role,
+            EmailAddress = userEmail
+        };
+
+        var request = _service.Permissions.Create(permission, fileId);
+        request.SupportsAllDrives = true;
+        request.SendNotificationEmail = false;
+        var created = await request.ExecuteAsync(cancellationToken);
+        return created.Id;
+    }
+
+    public async Task DeletePermissionAsync(string fileId, string permissionId, CancellationToken cancellationToken)
+    {
+        var request = _service.Permissions.Delete(fileId, permissionId);
+        request.SupportsAllDrives = true;
+        await request.ExecuteAsync(cancellationToken);
+    }
+}

--- a/src/Humans.Infrastructure/GoogleSync/RealGoogleGroupMembershipClient.cs
+++ b/src/Humans.Infrastructure/GoogleSync/RealGoogleGroupMembershipClient.cs
@@ -1,0 +1,59 @@
+using Google.Apis.CloudIdentity.v1;
+using Google.Apis.CloudIdentity.v1.Data;
+
+namespace Humans.Infrastructure.GoogleSync;
+
+/// <summary>
+/// Production <see cref="IGoogleGroupMembershipClient"/> that delegates to a
+/// <see cref="CloudIdentityService"/>. Pagination is handled here so callers can treat
+/// <see cref="ListMembershipsAsync"/> as a single read.
+/// </summary>
+internal sealed class RealGoogleGroupMembershipClient : IGoogleGroupMembershipClient
+{
+    private readonly CloudIdentityService _service;
+
+    public RealGoogleGroupMembershipClient(CloudIdentityService service)
+    {
+        _service = service;
+    }
+
+    public async Task<IReadOnlyList<Membership>> ListMembershipsAsync(string groupId, CancellationToken cancellationToken)
+    {
+        var result = new List<Membership>();
+        string? pageToken = null;
+        do
+        {
+            var request = _service.Groups.Memberships.List($"groups/{groupId}");
+            request.PageSize = 200;
+            if (pageToken is not null)
+                request.PageToken = pageToken;
+
+            var response = await request.ExecuteAsync(cancellationToken);
+            if (response.Memberships is not null)
+                result.AddRange(response.Memberships);
+
+            pageToken = response.NextPageToken;
+        } while (!string.IsNullOrEmpty(pageToken));
+
+        return result;
+    }
+
+    public async Task CreateMembershipAsync(string groupId, string userEmail, CancellationToken cancellationToken)
+    {
+        var membership = new Membership
+        {
+            PreferredMemberKey = new EntityKey { Id = userEmail },
+            Roles = [new MembershipRole { Name = "MEMBER" }]
+        };
+
+        await _service.Groups.Memberships
+            .Create(membership, $"groups/{groupId}")
+            .ExecuteAsync(cancellationToken);
+    }
+
+    public async Task DeleteMembershipAsync(string membershipName, CancellationToken cancellationToken)
+    {
+        await _service.Groups.Memberships.Delete(membershipName)
+            .ExecuteAsync(cancellationToken);
+    }
+}

--- a/src/Humans.Infrastructure/Services/GoogleWorkspaceSyncService.cs
+++ b/src/Humans.Infrastructure/Services/GoogleWorkspaceSyncService.cs
@@ -18,6 +18,7 @@ using Humans.Domain.Enums;
 using Humans.Domain.Helpers;
 using Humans.Infrastructure.Configuration;
 using Humans.Infrastructure.Data;
+using Humans.Infrastructure.GoogleSync;
 
 namespace Humans.Infrastructure.Services;
 
@@ -46,6 +47,9 @@ public class GoogleWorkspaceSyncService : IGoogleSyncService
     private GroupssettingsService? _groupssettingsService;
     private string? _serviceAccountEmail;
 
+    private IGoogleGroupMembershipClient? _groupMembershipClient;
+    private IGoogleDrivePermissionClient? _drivePermissionClient;
+
     public GoogleWorkspaceSyncService(
         HumansDbContext dbContext,
         IDbContextFactory<HumansDbContext> dbContextFactory,
@@ -64,6 +68,32 @@ public class GoogleWorkspaceSyncService : IGoogleSyncService
         _syncSettingsService = syncSettingsService;
         _serviceProvider = serviceProvider;
         _logger = logger;
+    }
+
+    /// <summary>
+    /// Test-only constructor that lets reconciliation tests substitute fake Google API
+    /// clients for <see cref="IGoogleGroupMembershipClient"/> and
+    /// <see cref="IGoogleDrivePermissionClient"/>. Production code MUST use the
+    /// public constructor — this one bypasses the Google credential setup entirely and will
+    /// fail on any code path that still uses the raw <see cref="CloudIdentityService"/> /
+    /// <see cref="DriveService"/> clients.
+    /// </summary>
+    internal GoogleWorkspaceSyncService(
+        HumansDbContext dbContext,
+        IDbContextFactory<HumansDbContext> dbContextFactory,
+        IOptions<GoogleWorkspaceSettings> settings,
+        IClock clock,
+        IAuditLogService auditLogService,
+        ISyncSettingsService syncSettingsService,
+        IServiceProvider serviceProvider,
+        ILogger<GoogleWorkspaceSyncService> logger,
+        IGoogleGroupMembershipClient groupMembershipClient,
+        IGoogleDrivePermissionClient drivePermissionClient)
+        : this(dbContext, dbContextFactory, settings, clock, auditLogService,
+            syncSettingsService, serviceProvider, logger)
+    {
+        _groupMembershipClient = groupMembershipClient;
+        _drivePermissionClient = drivePermissionClient;
     }
 
     private async Task<CloudIdentityService> GetCloudIdentityServiceAsync()
@@ -139,6 +169,26 @@ public class GoogleWorkspaceSyncService : IGoogleSyncService
         });
 
         return _directoryService;
+    }
+
+    private async Task<IGoogleGroupMembershipClient> GetGroupMembershipClientAsync()
+    {
+        if (_groupMembershipClient is not null)
+            return _groupMembershipClient;
+
+        var cloudIdentity = await GetCloudIdentityServiceAsync();
+        _groupMembershipClient = new RealGoogleGroupMembershipClient(cloudIdentity);
+        return _groupMembershipClient;
+    }
+
+    private async Task<IGoogleDrivePermissionClient> GetDrivePermissionClientAsync()
+    {
+        if (_drivePermissionClient is not null)
+            return _drivePermissionClient;
+
+        var drive = await GetDriveServiceAsync();
+        _drivePermissionClient = new RealGoogleDrivePermissionClient(drive);
+        return _drivePermissionClient;
     }
 
     private async Task<GoogleCredential> GetCredentialAsync(params string[] scopes)
@@ -223,7 +273,8 @@ public class GoogleWorkspaceSyncService : IGoogleSyncService
             .Include(tm => tm.User)
             .Include(tm => tm.Team)
             .Where(tm =>
-                distinctIds.Contains(tm.Team.ParentTeamId!.Value) &&
+                tm.Team.ParentTeamId.HasValue &&
+                distinctIds.Contains(tm.Team.ParentTeamId.Value) &&
                 tm.Team.IsActive &&
                 tm.LeftAt == null)
             .ToListAsync(cancellationToken);
@@ -443,19 +494,11 @@ public class GoogleWorkspaceSyncService : IGoogleSyncService
             return;
         }
 
-        var cloudIdentity = await GetCloudIdentityServiceAsync();
-
-        var membership = new Membership
-        {
-            PreferredMemberKey = new EntityKey { Id = userEmail },
-            Roles = [new MembershipRole { Name = "MEMBER" }]
-        };
+        var groupClient = await GetGroupMembershipClientAsync();
 
         try
         {
-            await cloudIdentity.Groups.Memberships
-                .Create(membership, $"groups/{resource.GoogleId}")
-                .ExecuteAsync(cancellationToken);
+            await groupClient.CreateMembershipAsync(resource.GoogleId, userEmail, cancellationToken);
 
             await _auditLogService.LogGoogleSyncAsync(
                 AuditAction.GoogleResourceAccessGranted, groupResourceId,
@@ -537,27 +580,12 @@ public class GoogleWorkspaceSyncService : IGoogleSyncService
             return;
         }
 
-        var cloudIdentity = await GetCloudIdentityServiceAsync();
+        var groupClient = await GetGroupMembershipClientAsync();
 
-        // Look up membership name for this email
-        string? membershipName = null;
-        string? nextPageToken = null;
-        do
-        {
-            var membersRequest = cloudIdentity.Groups.Memberships.List($"groups/{resource.GoogleId}");
-            membersRequest.PageSize = 200;
-            membersRequest.PageToken = nextPageToken;
-            var membersResponse = await membersRequest.ExecuteAsync(cancellationToken);
-
-            var match = membersResponse.Memberships?.FirstOrDefault(m =>
-                string.Equals(m.PreferredMemberKey?.Id, userEmail, StringComparison.OrdinalIgnoreCase));
-            if (match is not null)
-            {
-                membershipName = match.Name;
-                break;
-            }
-            nextPageToken = membersResponse.NextPageToken;
-        } while (nextPageToken is not null);
+        var memberships = await groupClient.ListMembershipsAsync(resource.GoogleId, cancellationToken);
+        var membershipName = memberships
+            .FirstOrDefault(m => string.Equals(m.PreferredMemberKey?.Id, userEmail, StringComparison.OrdinalIgnoreCase))
+            ?.Name;
 
         if (membershipName is null)
         {
@@ -565,8 +593,7 @@ public class GoogleWorkspaceSyncService : IGoogleSyncService
             return;
         }
 
-        await cloudIdentity.Groups.Memberships.Delete(membershipName)
-            .ExecuteAsync(cancellationToken);
+        await groupClient.DeleteMembershipAsync(membershipName, cancellationToken);
 
         await _auditLogService.LogGoogleSyncAsync(
             AuditAction.GoogleResourceAccessRevoked, groupResourceId,
@@ -602,21 +629,12 @@ public class GoogleWorkspaceSyncService : IGoogleSyncService
         }
 
         var effectiveLevel = permissionLevelOverride ?? resource.DrivePermissionLevel;
-        var drive = await GetDriveServiceAsync();
+        var driveClient = await GetDrivePermissionClientAsync();
         var apiRole = effectiveLevel.ToApiRole();
-        var permission = new Google.Apis.Drive.v3.Data.Permission
-        {
-            Type = "user",
-            Role = apiRole,
-            EmailAddress = userEmail
-        };
 
         try
         {
-            var createReq = drive.Permissions.Create(permission, resource.GoogleId);
-            createReq.SupportsAllDrives = true;
-            createReq.SendNotificationEmail = false;
-            await createReq.ExecuteAsync(cancellationToken);
+            await driveClient.CreatePermissionAsync(resource.GoogleId, userEmail, apiRole, cancellationToken);
 
             await _auditLogService.LogGoogleSyncAsync(
                 AuditAction.GoogleResourceAccessGranted, resource.Id,
@@ -648,10 +666,8 @@ public class GoogleWorkspaceSyncService : IGoogleSyncService
             return;
         }
 
-        var drive = await GetDriveServiceAsync();
-        var deleteReq = drive.Permissions.Delete(resource.GoogleId, permissionId);
-        deleteReq.SupportsAllDrives = true;
-        await deleteReq.ExecuteAsync(cancellationToken);
+        var driveClient = await GetDrivePermissionClientAsync();
+        await driveClient.DeletePermissionAsync(resource.GoogleId, permissionId, cancellationToken);
 
         await _auditLogService.LogGoogleSyncAsync(
             AuditAction.GoogleResourceAccessRevoked, resource.Id,
@@ -890,34 +906,6 @@ public class GoogleWorkspaceSyncService : IGoogleSyncService
         return true;
     }
 
-    private static async Task<List<Google.Apis.Drive.v3.Data.Permission>> ListDrivePermissionsAsync(
-        DriveService drive, string fileId, CancellationToken cancellationToken)
-    {
-        var permissions = new List<Google.Apis.Drive.v3.Data.Permission>();
-        string? pageToken = null;
-
-        do
-        {
-            var listReq = drive.Permissions.List(fileId);
-            listReq.SupportsAllDrives = true;
-            listReq.Fields = "nextPageToken, permissions(id, emailAddress, role, type, permissionDetails)";
-            if (pageToken is not null)
-            {
-                listReq.PageToken = pageToken;
-            }
-
-            var response = await listReq.ExecuteAsync(cancellationToken);
-            if (response.Permissions is not null)
-            {
-                permissions.AddRange(response.Permissions);
-            }
-
-            pageToken = response.NextPageToken;
-        } while (!string.IsNullOrEmpty(pageToken));
-
-        return permissions;
-    }
-
     /// <inheritdoc />
     public async Task<SyncPreviewResult> SyncResourcesByTypeAsync(
         GoogleResourceType resourceType,
@@ -949,9 +937,9 @@ public class GoogleWorkspaceSyncService : IGoogleSyncService
         if (resourceType == GoogleResourceType.Group)
         {
             // Eagerly initialize Google API clients before parallel execution to avoid
-            // non-thread-safe lazy init race in GetCloudIdentityServiceAsync/GetDriveServiceAsync.
+            // non-thread-safe lazy init race in the getter helpers.
             if (resources.Count > 0)
-                await GetCloudIdentityServiceAsync();
+                await GetGroupMembershipClientAsync();
 
             // Groups: one group per team — compute diffs in parallel (Google API reads only).
             // Each task gets its own DbContext via factory; semaphore throttles concurrency.
@@ -982,7 +970,7 @@ public class GoogleWorkspaceSyncService : IGoogleSyncService
         {
             // Eagerly initialize Drive client before parallel execution
             if (resources.Count > 0)
-                await GetDriveServiceAsync();
+                await GetDrivePermissionClientAsync();
 
             // Drive resources: group by GoogleId since multiple teams can share one resource.
             // Each task gets its own DbContext via factory; semaphore throttles concurrency.
@@ -1142,9 +1130,13 @@ public class GoogleWorkspaceSyncService : IGoogleSyncService
         {
             // Expected: team's active members (use Google service email preference)
             // Skip users with Rejected GoogleEmailStatus — their email was permanently
-            // rejected by Google (no Google account associated with the address)
+            // rejected by Google (no Google account associated with the address).
+            // The tm.LeftAt == null check is also applied by the filtered Include on the
+            // calling query; repeating it here keeps the code provider-agnostic since the
+            // EF Core InMemory provider does not honor filtered Includes.
             var expectedMembers = resource.Team.Members
-                .Where(tm => tm.User.GetGoogleServiceEmail() is not null
+                .Where(tm => tm.LeftAt == null
+                    && tm.User.GetGoogleServiceEmail() is not null
                     && tm.User.GoogleEmailStatus != GoogleEmailStatus.Rejected)
                 .Select(tm => new { Email = tm.User.GetGoogleServiceEmail(), tm.User.DisplayName, tm.User.Id, tm.User.ProfilePictureUrl })
                 .ToList();
@@ -1169,7 +1161,7 @@ public class GoogleWorkspaceSyncService : IGoogleSyncService
                 expectedMembers.Select(m => m.Email!), NormalizingEmailComparer.Instance);
 
             // Current: Google Group members via Cloud Identity
-            var cloudIdentity = await GetCloudIdentityServiceAsync();
+            var groupClient = await GetGroupMembershipClientAsync();
             var saEmail = await GetServiceAccountEmailAsync();
             var currentEmails = new HashSet<string>(NormalizingEmailComparer.Instance);
             // Track membership resource names for deletion (email → "groups/{id}/memberships/{id}")
@@ -1177,31 +1169,16 @@ public class GoogleWorkspaceSyncService : IGoogleSyncService
 
             try
             {
-                string? pageToken = null;
-                do
+                var memberships = await groupClient.ListMembershipsAsync(resource.GoogleId, cancellationToken);
+                foreach (var membership in memberships)
                 {
-                    var membersRequest = cloudIdentity.Groups.Memberships.List($"groups/{resource.GoogleId}");
-                    membersRequest.PageSize = 200;
-                    if (pageToken is not null)
-                        membersRequest.PageToken = pageToken;
-
-                    var membersResponse = await membersRequest.ExecuteAsync(cancellationToken);
-
-                    if (membersResponse.Memberships is not null)
+                    var email = membership.PreferredMemberKey?.Id;
+                    if (!string.IsNullOrEmpty(email))
                     {
-                        foreach (var membership in membersResponse.Memberships)
-                        {
-                            var email = membership.PreferredMemberKey?.Id;
-                            if (!string.IsNullOrEmpty(email))
-                            {
-                                currentEmails.Add(email);
-                                membershipNames[email] = membership.Name;
-                            }
-                        }
+                        currentEmails.Add(email);
+                        membershipNames[email] = membership.Name;
                     }
-
-                    pageToken = membersResponse.NextPageToken;
-                } while (!string.IsNullOrEmpty(pageToken));
+                }
             }
             catch (Google.GoogleApiException ex) when (ex.Error?.Code is 404 or 403)
             {
@@ -1408,8 +1385,8 @@ public class GoogleWorkspaceSyncService : IGoogleSyncService
         var extraMembers = diff.Members.Where(m => m.State == MemberSyncState.Extra).ToList();
         if (extraMembers.Count > 0)
         {
-            var drive = await GetDriveServiceAsync();
-            var permissions = await ListDrivePermissionsAsync(drive, primary.GoogleId, cancellationToken);
+            var driveClient = await GetDrivePermissionClientAsync();
+            var permissions = await driveClient.ListPermissionsAsync(primary.GoogleId, cancellationToken);
 
             foreach (var member in extraMembers)
             {
@@ -1477,7 +1454,10 @@ public class GoogleWorkspaceSyncService : IGoogleSyncService
                 var level = resource.DrivePermissionLevel is DrivePermissionLevel.None
                     ? null : resource.DrivePermissionLevel.ToString();
                 var teamLink = new TeamLink(resource.Team.Name, resource.Team.Slug, level);
-                foreach (var tm in resource.Team.Members)
+                // The tm.LeftAt == null check is also applied by the filtered Include on the
+                // calling query; repeating it here keeps the code provider-agnostic since the
+                // EF Core InMemory provider does not honor filtered Includes.
+                foreach (var tm in resource.Team.Members.Where(tm => tm.LeftAt == null))
                 {
                     var memberEmail = tm.User.GetGoogleServiceEmail();
                     if (memberEmail is null || tm.User.GoogleEmailStatus == GoogleEmailStatus.Rejected)
@@ -1522,8 +1502,8 @@ public class GoogleWorkspaceSyncService : IGoogleSyncService
                 .DistinctBy(tl => tl.Slug, StringComparer.Ordinal).ToList();
 
             // Current: Drive permissions
-            var drive = await GetDriveServiceAsync();
-            var permissions = await ListDrivePermissionsAsync(drive, primary.GoogleId, cancellationToken);
+            var driveClient = await GetDrivePermissionClientAsync();
+            var permissions = await driveClient.ListPermissionsAsync(primary.GoogleId, cancellationToken);
             // All user permissions (direct + inherited) — for checking if member already has access
             var allEmails = new HashSet<string>(NormalizingEmailComparer.Instance);
             // Only direct managed permissions — for detecting removable extras

--- a/tests/Humans.Application.Tests/Fakes/FakeGoogleDrivePermissionClient.cs
+++ b/tests/Humans.Application.Tests/Fakes/FakeGoogleDrivePermissionClient.cs
@@ -1,0 +1,133 @@
+using System.Net;
+using Google;
+using Google.Apis.Drive.v3.Data;
+using Google.Apis.Requests;
+using Humans.Infrastructure.GoogleSync;
+
+namespace Humans.Application.Tests.Fakes;
+
+/// <summary>
+/// In-memory fake for <see cref="IGoogleDrivePermissionClient"/> used by reconciliation tests.
+/// State is keyed by Drive file id and tracks both direct and inherited permissions so tests
+/// can verify the direct/inherited split that reconciliation relies on.
+/// </summary>
+internal sealed class FakeGoogleDrivePermissionClient : IGoogleDrivePermissionClient
+{
+    private readonly Dictionary<string, List<Permission>> _state = new(StringComparer.Ordinal);
+    private readonly HashSet<string> _failingFiles = new(StringComparer.Ordinal);
+
+    public IReadOnlyList<Permission> GetPermissions(string fileId) =>
+        _state.TryGetValue(fileId, out var list)
+            ? list.ToList()
+            : [];
+
+    /// <summary>
+    /// Seeds a direct (non-inherited) user permission on the given file.
+    /// </summary>
+    public void SeedDirectPermission(string fileId, string email, string role = "writer")
+    {
+        if (!_state.TryGetValue(fileId, out var list))
+        {
+            list = [];
+            _state[fileId] = list;
+        }
+
+        list.Add(new Permission
+        {
+            Id = Guid.NewGuid().ToString("N"),
+            Type = "user",
+            Role = role,
+            EmailAddress = email,
+            PermissionDetails = null
+        });
+    }
+
+    /// <summary>
+    /// Seeds an inherited permission — reconciliation treats these as read-only and
+    /// classifies them as <c>Inherited</c>, never <c>Extra</c>.
+    /// </summary>
+    public void SeedInheritedPermission(string fileId, string email, string role = "reader")
+    {
+        if (!_state.TryGetValue(fileId, out var list))
+        {
+            list = [];
+            _state[fileId] = list;
+        }
+
+        list.Add(new Permission
+        {
+            Id = Guid.NewGuid().ToString("N"),
+            Type = "user",
+            Role = role,
+            EmailAddress = email,
+            PermissionDetails =
+            [
+                new Permission.PermissionDetailsData { Inherited = true, Role = role }
+            ]
+        });
+    }
+
+    /// <summary>
+    /// Registers a file id whose List/Create/Delete operations all throw a generic exception.
+    /// Used to exercise the error-path branches in SyncDriveResourceGroupAsync and the
+    /// post-execute softDeletedTeamIds filter.
+    /// </summary>
+    public void FailFile(string fileId) => _failingFiles.Add(fileId);
+
+    public Task<IReadOnlyList<Permission>> ListPermissionsAsync(string fileId, CancellationToken cancellationToken)
+    {
+        if (_failingFiles.Contains(fileId))
+            throw BuildApiException(HttpStatusCode.NotFound, $"File {fileId} not found.");
+
+        return Task.FromResult<IReadOnlyList<Permission>>(GetPermissions(fileId));
+    }
+
+    public Task<string> CreatePermissionAsync(string fileId, string userEmail, string role, CancellationToken cancellationToken)
+    {
+        if (_failingFiles.Contains(fileId))
+            throw BuildApiException(HttpStatusCode.Forbidden, "Simulated failure on CreatePermission.");
+
+        if (!_state.TryGetValue(fileId, out var list))
+        {
+            list = [];
+            _state[fileId] = list;
+        }
+
+        var id = Guid.NewGuid().ToString("N");
+        list.Add(new Permission
+        {
+            Id = id,
+            Type = "user",
+            Role = role,
+            EmailAddress = userEmail,
+            PermissionDetails = null
+        });
+        return Task.FromResult(id);
+    }
+
+    public Task DeletePermissionAsync(string fileId, string permissionId, CancellationToken cancellationToken)
+    {
+        if (_failingFiles.Contains(fileId))
+            throw BuildApiException(HttpStatusCode.Forbidden, "Simulated failure on DeletePermission.");
+
+        if (!_state.TryGetValue(fileId, out var list))
+            return Task.CompletedTask;
+
+        list.RemoveAll(p => string.Equals(p.Id, permissionId, StringComparison.Ordinal));
+        return Task.CompletedTask;
+    }
+
+    private static GoogleApiException BuildApiException(HttpStatusCode code, string message)
+    {
+        var error = new RequestError
+        {
+            Code = (int)code,
+            Message = message
+        };
+        return new GoogleApiException("Drive", message)
+        {
+            Error = error,
+            HttpStatusCode = code
+        };
+    }
+}

--- a/tests/Humans.Application.Tests/Fakes/FakeGoogleGroupMembershipClient.cs
+++ b/tests/Humans.Application.Tests/Fakes/FakeGoogleGroupMembershipClient.cs
@@ -1,0 +1,116 @@
+using System.Net;
+using Google;
+using Google.Apis.CloudIdentity.v1.Data;
+using Google.Apis.Requests;
+using Humans.Infrastructure.GoogleSync;
+
+namespace Humans.Application.Tests.Fakes;
+
+/// <summary>
+/// In-memory fake for <see cref="IGoogleGroupMembershipClient"/> used by reconciliation tests.
+/// State is keyed by the Google Group id (not the full <c>groups/{id}</c> resource name).
+/// </summary>
+internal sealed class FakeGoogleGroupMembershipClient : IGoogleGroupMembershipClient
+{
+    private readonly Dictionary<string, List<Membership>> _state = new(StringComparer.Ordinal);
+    private readonly HashSet<string> _failingGroups = new(StringComparer.Ordinal);
+
+    public IReadOnlyList<Membership> GetMemberships(string groupId) =>
+        _state.TryGetValue(groupId, out var list)
+            ? list.ToList()
+            : [];
+
+    /// <summary>
+    /// Seeds an existing membership on the given group. Uses a deterministic membership
+    /// resource name so tests can assert against it.
+    /// </summary>
+    public void SeedMembership(string groupId, string email)
+    {
+        if (!_state.TryGetValue(groupId, out var list))
+        {
+            list = [];
+            _state[groupId] = list;
+        }
+
+        list.Add(new Membership
+        {
+            Name = $"groups/{groupId}/memberships/{Guid.NewGuid():N}",
+            PreferredMemberKey = new EntityKey { Id = email }
+        });
+    }
+
+    /// <summary>
+    /// Registers a group id whose List/Create/Delete operations all throw a generic exception.
+    /// Used to exercise the error-path branches in SyncGroupResourceAsync and the post-execute
+    /// softDeletedTeamIds filter.
+    /// </summary>
+    public void FailGroup(string groupId) => _failingGroups.Add(groupId);
+
+    public Task<IReadOnlyList<Membership>> ListMembershipsAsync(string groupId, CancellationToken cancellationToken)
+    {
+        if (_failingGroups.Contains(groupId))
+            throw BuildApiException(HttpStatusCode.NotFound, $"Group {groupId} not found.");
+
+        return Task.FromResult<IReadOnlyList<Membership>>(GetMemberships(groupId));
+    }
+
+    public Task CreateMembershipAsync(string groupId, string userEmail, CancellationToken cancellationToken)
+    {
+        if (_failingGroups.Contains(groupId))
+            throw BuildApiException(HttpStatusCode.Forbidden, "Simulated failure on CreateMembership.");
+
+        if (!_state.TryGetValue(groupId, out var list))
+        {
+            list = [];
+            _state[groupId] = list;
+        }
+
+        var existing = list.FirstOrDefault(m =>
+            string.Equals(m.PreferredMemberKey?.Id, userEmail, StringComparison.OrdinalIgnoreCase));
+        if (existing is not null)
+            throw BuildApiException((HttpStatusCode)409, $"{userEmail} is already a member.");
+
+        list.Add(new Membership
+        {
+            Name = $"groups/{groupId}/memberships/{Guid.NewGuid():N}",
+            PreferredMemberKey = new EntityKey { Id = userEmail }
+        });
+        return Task.CompletedTask;
+    }
+
+    public Task DeleteMembershipAsync(string membershipName, CancellationToken cancellationToken)
+    {
+        // membershipName format: "groups/{groupId}/memberships/{membershipId}"
+        var parts = membershipName.Split('/');
+        if (parts.Length < 4
+            || !string.Equals(parts[0], "groups", StringComparison.Ordinal)
+            || !string.Equals(parts[2], "memberships", StringComparison.Ordinal))
+        {
+            throw new ArgumentException($"Malformed membership name: {membershipName}", nameof(membershipName));
+        }
+
+        var groupId = parts[1];
+        if (_failingGroups.Contains(groupId))
+            throw BuildApiException(HttpStatusCode.Forbidden, "Simulated failure on DeleteMembership.");
+
+        if (!_state.TryGetValue(groupId, out var list))
+            return Task.CompletedTask;
+
+        list.RemoveAll(m => string.Equals(m.Name, membershipName, StringComparison.Ordinal));
+        return Task.CompletedTask;
+    }
+
+    private static GoogleApiException BuildApiException(HttpStatusCode code, string message)
+    {
+        var error = new RequestError
+        {
+            Code = (int)code,
+            Message = message
+        };
+        return new GoogleApiException("CloudIdentity", message)
+        {
+            Error = error,
+            HttpStatusCode = code
+        };
+    }
+}

--- a/tests/Humans.Application.Tests/Services/GoogleWorkspaceSyncServiceReconciliationTests.cs
+++ b/tests/Humans.Application.Tests/Services/GoogleWorkspaceSyncServiceReconciliationTests.cs
@@ -1,4 +1,5 @@
 using AwesomeAssertions;
+using Humans.Application.DTOs;
 using Humans.Application.Interfaces;
 using Humans.Application.Tests.Fakes;
 using Humans.Domain.Entities;
@@ -231,7 +232,7 @@ public sealed class GoogleWorkspaceSyncServiceReconciliationTests : IDisposable
     // stays IsActive = true after the DriveFolder pass.
 
     // -------------------------------------------------------------------------
-    // Scenario 5: AddOnly mode skips deactivation
+    // Scenario 5: AddOnly mode — soft-deleted team
     // -------------------------------------------------------------------------
 
     [Fact]
@@ -254,17 +255,13 @@ public sealed class GoogleWorkspaceSyncServiceReconciliationTests : IDisposable
 
         result.Diffs.Should().ContainSingle()
             .Which.ErrorMessage.Should().BeNull();
-
-        // The diff correctly reported Alice as Extra, but RemoveUserFromDrive
-        // short-circuited because mode != AddAndRemove, and the post-execute
-        // deactivation block also skips when mode != AddAndRemove.
         _driveClient.GetPermissions(folder.GoogleId).Should().ContainSingle(p => p.EmailAddress == alice.Email);
         var row = await _dbContext.GoogleResources.AsNoTracking().SingleAsync(r => r.Id == folder.Id);
         row.IsActive.Should().BeTrue();
     }
 
     // -------------------------------------------------------------------------
-    // Scenario 6: None mode skips deactivation
+    // Scenario 6: None mode — soft-deleted team
     // -------------------------------------------------------------------------
 
     [Fact]
@@ -289,6 +286,405 @@ public sealed class GoogleWorkspaceSyncServiceReconciliationTests : IDisposable
         _driveClient.GetPermissions(folder.GoogleId).Should().ContainSingle(p => p.EmailAddress == alice.Email);
         var row = await _dbContext.GoogleResources.AsNoTracking().SingleAsync(r => r.Id == folder.Id);
         row.IsActive.Should().BeTrue();
+    }
+
+    // =========================================================================
+    // ADD PATH — missing members get provisioned
+    // =========================================================================
+
+    [Fact]
+    public async Task MissingGroupMember_IsAddedOnExecute()
+    {
+        _syncSettings.SetMode(SyncServiceType.GoogleGroups, SyncMode.AddAndRemove);
+
+        var team = SeedTeam();
+        var alice = SeedUser("alice@nobodies.team", "Alice");
+        SeedActiveMember(team.Id, alice.Id);
+
+        var group = SeedResource(team.Id, GoogleResourceType.Group, "group-add");
+        // No membership seeded in the fake — Alice is Missing.
+
+        await _dbContext.SaveChangesAsync();
+        var service = BuildService();
+
+        await service.SyncResourcesByTypeAsync(GoogleResourceType.Group, SyncAction.Execute);
+
+        _groupClient.GetMemberships(group.GoogleId)
+            .Should().ContainSingle(m => m.PreferredMemberKey!.Id == alice.Email);
+    }
+
+    [Fact]
+    public async Task MissingDriveMember_IsAddedWithCorrectRole()
+    {
+        _syncSettings.SetMode(SyncServiceType.GoogleDrive, SyncMode.AddAndRemove);
+
+        var team = SeedTeam();
+        var alice = SeedUser("alice@nobodies.team", "Alice");
+        SeedActiveMember(team.Id, alice.Id);
+
+        var folder = SeedResource(team.Id, GoogleResourceType.DriveFolder, "folder-add",
+            driveLevel: DrivePermissionLevel.ContentManager);
+        // No permission seeded — Alice is Missing.
+
+        await _dbContext.SaveChangesAsync();
+        var service = BuildService();
+
+        await service.SyncResourcesByTypeAsync(GoogleResourceType.DriveFolder, SyncAction.Execute);
+
+        var perms = _driveClient.GetPermissions(folder.GoogleId);
+        perms.Should().ContainSingle(p =>
+            p.EmailAddress == alice.Email && p.Role == "fileOrganizer");
+    }
+
+    // =========================================================================
+    // NO-OP PATH — correct state, no side effects
+    // =========================================================================
+
+    [Fact]
+    public async Task CorrectGroupMember_NoMutationsOccur()
+    {
+        _syncSettings.SetMode(SyncServiceType.GoogleGroups, SyncMode.AddAndRemove);
+
+        var team = SeedTeam();
+        var alice = SeedUser("alice@nobodies.team", "Alice");
+        SeedActiveMember(team.Id, alice.Id);
+
+        var group = SeedResource(team.Id, GoogleResourceType.Group, "group-noop");
+        _groupClient.SeedMembership(group.GoogleId, alice.Email!);
+
+        await _dbContext.SaveChangesAsync();
+        var service = BuildService();
+
+        var result = await service.SyncResourcesByTypeAsync(GoogleResourceType.Group, SyncAction.Execute);
+
+        var diff = result.Diffs.Should().ContainSingle().Subject;
+        diff.ErrorMessage.Should().BeNull();
+        diff.Members.Should().ContainSingle(m => m.State == MemberSyncState.Correct);
+        _groupClient.GetMemberships(group.GoogleId).Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task CorrectDriveMember_NoMutationsOccur()
+    {
+        _syncSettings.SetMode(SyncServiceType.GoogleDrive, SyncMode.AddAndRemove);
+
+        var team = SeedTeam();
+        var alice = SeedUser("alice@nobodies.team", "Alice");
+        SeedActiveMember(team.Id, alice.Id);
+
+        var folder = SeedResource(team.Id, GoogleResourceType.DriveFolder, "folder-noop");
+        _driveClient.SeedDirectPermission(folder.GoogleId, alice.Email!, "writer");
+
+        await _dbContext.SaveChangesAsync();
+        var service = BuildService();
+
+        var result = await service.SyncResourcesByTypeAsync(GoogleResourceType.DriveFolder, SyncAction.Execute);
+
+        var diff = result.Diffs.Should().ContainSingle().Subject;
+        diff.ErrorMessage.Should().BeNull();
+        diff.Members.Should().ContainSingle(m => m.State == MemberSyncState.Correct);
+        _driveClient.GetPermissions(folder.GoogleId).Should().ContainSingle();
+    }
+
+    // =========================================================================
+    // REMOVE PATH — extra members on active team
+    // =========================================================================
+
+    [Fact]
+    public async Task ExtraGroupMember_IsRemovedOnExecute()
+    {
+        _syncSettings.SetMode(SyncServiceType.GoogleGroups, SyncMode.AddAndRemove);
+
+        var team = SeedTeam();
+        var group = SeedResource(team.Id, GoogleResourceType.Group, "group-extra");
+        _groupClient.SeedMembership(group.GoogleId, "stranger@example.com");
+
+        await _dbContext.SaveChangesAsync();
+        var service = BuildService();
+
+        await service.SyncResourcesByTypeAsync(GoogleResourceType.Group, SyncAction.Execute);
+
+        _groupClient.GetMemberships(group.GoogleId).Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ExtraDirectDrivePermission_IsRemovedOnExecute()
+    {
+        _syncSettings.SetMode(SyncServiceType.GoogleDrive, SyncMode.AddAndRemove);
+
+        var team = SeedTeam();
+        var folder = SeedResource(team.Id, GoogleResourceType.DriveFolder, "folder-extra");
+        _driveClient.SeedDirectPermission(folder.GoogleId, "stranger@example.com");
+
+        await _dbContext.SaveChangesAsync();
+        var service = BuildService();
+
+        await service.SyncResourcesByTypeAsync(GoogleResourceType.DriveFolder, SyncAction.Execute);
+
+        _driveClient.GetPermissions(folder.GoogleId).Should().BeEmpty();
+    }
+
+    // =========================================================================
+    // WRONG ROLE — member at wrong Drive permission level gets upgraded
+    // =========================================================================
+
+    [Fact]
+    public async Task DriveMember_AtWrongRole_IsUpgraded()
+    {
+        _syncSettings.SetMode(SyncServiceType.GoogleDrive, SyncMode.AddAndRemove);
+
+        var team = SeedTeam();
+        var alice = SeedUser("alice@nobodies.team", "Alice");
+        SeedActiveMember(team.Id, alice.Id);
+
+        var folder = SeedResource(team.Id, GoogleResourceType.DriveFolder, "folder-role",
+            driveLevel: DrivePermissionLevel.ContentManager);
+        // Alice is at "reader" (Viewer) but the resource expects ContentManager ("fileOrganizer").
+        _driveClient.SeedDirectPermission(folder.GoogleId, alice.Email!, "reader");
+
+        await _dbContext.SaveChangesAsync();
+        var service = BuildService();
+
+        var result = await service.SyncResourcesByTypeAsync(GoogleResourceType.DriveFolder, SyncAction.Execute);
+
+        var diff = result.Diffs.Should().ContainSingle().Subject;
+        diff.Members.Should().ContainSingle(m => m.State == MemberSyncState.WrongRole);
+
+        // After execute, the fake should have a new permission at the correct level
+        // (the old one stays — real Google API replaces; our fake just adds, which is fine
+        // for verifying the upgrade was attempted with the correct role).
+        _driveClient.GetPermissions(folder.GoogleId)
+            .Should().Contain(p => p.Role == "fileOrganizer" && p.EmailAddress == alice.Email);
+    }
+
+    // =========================================================================
+    // MIXED TRANSITIONS — correct + missing + extra in one tick
+    // =========================================================================
+
+    [Fact]
+    public async Task GroupReconciliation_MixedState_AddsRemovesAndKeeps()
+    {
+        _syncSettings.SetMode(SyncServiceType.GoogleGroups, SyncMode.AddAndRemove);
+
+        var team = SeedTeam();
+        var alice = SeedUser("alice@nobodies.team", "Alice");
+        var bob = SeedUser("bob@nobodies.team", "Bob");
+        SeedActiveMember(team.Id, alice.Id);
+        SeedActiveMember(team.Id, bob.Id);
+
+        var group = SeedResource(team.Id, GoogleResourceType.Group, "group-mixed");
+        _groupClient.SeedMembership(group.GoogleId, alice.Email!);
+        _groupClient.SeedMembership(group.GoogleId, "stranger@example.com");
+
+        await _dbContext.SaveChangesAsync();
+        var service = BuildService();
+
+        var result = await service.SyncResourcesByTypeAsync(GoogleResourceType.Group, SyncAction.Execute);
+
+        var diff = result.Diffs.Should().ContainSingle().Subject;
+        diff.Members.Should().Contain(m => m.Email == alice.Email && m.State == MemberSyncState.Correct);
+        diff.Members.Should().Contain(m => m.Email == bob.Email && m.State == MemberSyncState.Missing);
+        diff.Members.Should().Contain(m => m.Email == "stranger@example.com" && m.State == MemberSyncState.Extra);
+
+        var remaining = _groupClient.GetMemberships(group.GoogleId);
+        remaining.Should().HaveCount(2);
+        remaining.Select(m => m.PreferredMemberKey!.Id).Should().Contain(alice.Email)
+            .And.Contain(bob.Email)
+            .And.NotContain("stranger@example.com");
+    }
+
+    // =========================================================================
+    // SHARED GoogleId UNION — Drive folder linked to two teams
+    // =========================================================================
+
+    [Fact]
+    public async Task SharedGoogleIdDrive_UnionOfTeamMembersIsExpected()
+    {
+        _syncSettings.SetMode(SyncServiceType.GoogleDrive, SyncMode.AddAndRemove);
+
+        var teamA = SeedTeam(slug: "alpha");
+        var teamB = SeedTeam(slug: "bravo");
+        var alice = SeedUser("alice@nobodies.team", "Alice");
+        var bob = SeedUser("bob@nobodies.team", "Bob");
+        SeedActiveMember(teamA.Id, alice.Id);
+        SeedActiveMember(teamB.Id, bob.Id);
+
+        const string sharedFolder = "shared-folder-union";
+        SeedResource(teamA.Id, GoogleResourceType.DriveFolder, sharedFolder);
+        SeedResource(teamB.Id, GoogleResourceType.DriveFolder, sharedFolder);
+        // Neither has a permission yet — both Alice and Bob should be added.
+
+        await _dbContext.SaveChangesAsync();
+        var service = BuildService();
+
+        await service.SyncResourcesByTypeAsync(GoogleResourceType.DriveFolder, SyncAction.Execute);
+
+        var perms = _driveClient.GetPermissions(sharedFolder);
+        perms.Select(p => p.EmailAddress).Should().Contain(alice.Email).And.Contain(bob.Email);
+    }
+
+    [Fact]
+    public async Task SharedGoogleIdDrive_MaxPermissionLevelWins()
+    {
+        _syncSettings.SetMode(SyncServiceType.GoogleDrive, SyncMode.AddAndRemove);
+
+        var teamA = SeedTeam(slug: "alpha-lv");
+        var teamB = SeedTeam(slug: "bravo-lv");
+        var alice = SeedUser("alice@nobodies.team", "Alice");
+        SeedActiveMember(teamA.Id, alice.Id);
+        SeedActiveMember(teamB.Id, alice.Id);
+
+        const string sharedFolder = "shared-folder-level";
+        SeedResource(teamA.Id, GoogleResourceType.DriveFolder, sharedFolder,
+            driveLevel: DrivePermissionLevel.Viewer);
+        SeedResource(teamB.Id, GoogleResourceType.DriveFolder, sharedFolder,
+            driveLevel: DrivePermissionLevel.ContentManager);
+        // No existing permission — Alice should be added at max (ContentManager → fileOrganizer).
+
+        await _dbContext.SaveChangesAsync();
+        var service = BuildService();
+
+        await service.SyncResourcesByTypeAsync(GoogleResourceType.DriveFolder, SyncAction.Execute);
+
+        _driveClient.GetPermissions(sharedFolder)
+            .Should().ContainSingle(p =>
+                p.EmailAddress == alice.Email && p.Role == "fileOrganizer");
+    }
+
+    // =========================================================================
+    // INHERITED PERMISSION — never flagged as Extra or removed
+    // =========================================================================
+
+    [Fact]
+    public async Task InheritedDrivePermission_IsNotTreatedAsExtra()
+    {
+        _syncSettings.SetMode(SyncServiceType.GoogleDrive, SyncMode.AddAndRemove);
+
+        var team = SeedTeam();
+        var folder = SeedResource(team.Id, GoogleResourceType.DriveFolder, "folder-inherited");
+        _driveClient.SeedInheritedPermission(folder.GoogleId, "shared-drive-user@example.com");
+
+        await _dbContext.SaveChangesAsync();
+        var service = BuildService();
+
+        var result = await service.SyncResourcesByTypeAsync(GoogleResourceType.DriveFolder, SyncAction.Execute);
+
+        var diff = result.Diffs.Should().ContainSingle().Subject;
+        diff.Members.Should().ContainSingle(m =>
+            m.Email == "shared-drive-user@example.com" && m.State == MemberSyncState.Inherited);
+        _driveClient.GetPermissions(folder.GoogleId).Should().ContainSingle(
+            "inherited permissions must never be deleted by reconciliation");
+    }
+
+    // =========================================================================
+    // AddOnly MODE — adds missing but does NOT remove extras
+    // =========================================================================
+
+    [Fact]
+    public async Task AddOnlyMode_AddsMissingButKeepsExtras()
+    {
+        _syncSettings.SetMode(SyncServiceType.GoogleGroups, SyncMode.AddOnly);
+
+        var team = SeedTeam();
+        var alice = SeedUser("alice@nobodies.team", "Alice");
+        SeedActiveMember(team.Id, alice.Id);
+
+        var group = SeedResource(team.Id, GoogleResourceType.Group, "group-addonly");
+        _groupClient.SeedMembership(group.GoogleId, "stranger@example.com");
+
+        await _dbContext.SaveChangesAsync();
+        var service = BuildService();
+
+        await service.SyncResourcesByTypeAsync(GoogleResourceType.Group, SyncAction.Execute);
+
+        var members = _groupClient.GetMemberships(group.GoogleId);
+        members.Should().HaveCount(2);
+        members.Select(m => m.PreferredMemberKey!.Id)
+            .Should().Contain(alice.Email, "missing member should be added in AddOnly mode")
+            .And.Contain("stranger@example.com", "extra member should NOT be removed in AddOnly mode");
+    }
+
+    // =========================================================================
+    // SUB-TEAM ROLLUP — child team members expected in parent's resource
+    // =========================================================================
+
+    [Fact]
+    public async Task SubTeamRollup_ChildMembersAreExpectedInParentGroup()
+    {
+        _syncSettings.SetMode(SyncServiceType.GoogleGroups, SyncMode.AddAndRemove);
+
+        var department = SeedTeam(slug: "dept");
+        var childTeam = SeedTeam(slug: "child");
+        childTeam.ParentTeamId = department.Id;
+
+        var alice = SeedUser("alice@nobodies.team", "Alice");
+        SeedActiveMember(childTeam.Id, alice.Id);
+
+        var group = SeedResource(department.Id, GoogleResourceType.Group, "group-dept");
+        // Alice is not on the department team directly, but is on a child team.
+
+        await _dbContext.SaveChangesAsync();
+        var service = BuildService();
+
+        await service.SyncResourcesByTypeAsync(GoogleResourceType.Group, SyncAction.Execute);
+
+        _groupClient.GetMemberships(group.GoogleId)
+            .Should().ContainSingle(m => m.PreferredMemberKey!.Id == alice.Email,
+                "child team members must be rolled up into the parent's Google resource");
+    }
+
+    // =========================================================================
+    // SERVICE ACCOUNT FILTER — SA email not flagged as Extra
+    // =========================================================================
+
+    [Fact]
+    public async Task ServiceAccountEmail_IsNotFlaggedAsExtra()
+    {
+        _syncSettings.SetMode(SyncServiceType.GoogleGroups, SyncMode.AddAndRemove);
+
+        var team = SeedTeam();
+        var group = SeedResource(team.Id, GoogleResourceType.Group, "group-sa");
+        // The SA email comes from GetServiceAccountEmailAsync which returns
+        // "unknown@serviceaccount.iam.gserviceaccount.com" when no key is configured.
+        _groupClient.SeedMembership(group.GoogleId, "unknown@serviceaccount.iam.gserviceaccount.com");
+
+        await _dbContext.SaveChangesAsync();
+        var service = BuildService();
+
+        var result = await service.SyncResourcesByTypeAsync(GoogleResourceType.Group, SyncAction.Execute);
+
+        var diff = result.Diffs.Should().ContainSingle().Subject;
+        diff.Members.Should().BeEmpty("the SA email should be silently excluded from the diff");
+        _groupClient.GetMemberships(group.GoogleId).Should().ContainSingle(
+            "SA membership must not be removed by reconciliation");
+    }
+
+    // =========================================================================
+    // DriveFile PARITY — same code path as DriveFolder
+    // =========================================================================
+
+    [Fact]
+    public async Task DriveFile_ReconcilesIdenticallyToDriveFolder()
+    {
+        _syncSettings.SetMode(SyncServiceType.GoogleDrive, SyncMode.AddAndRemove);
+
+        var team = SeedTeam();
+        var alice = SeedUser("alice@nobodies.team", "Alice");
+        SeedActiveMember(team.Id, alice.Id);
+
+        var file = SeedResource(team.Id, GoogleResourceType.DriveFile, "file-parity");
+        _driveClient.SeedDirectPermission(file.GoogleId, "stranger@example.com");
+
+        await _dbContext.SaveChangesAsync();
+        var service = BuildService();
+
+        await service.SyncResourcesByTypeAsync(GoogleResourceType.DriveFile, SyncAction.Execute);
+
+        var perms = _driveClient.GetPermissions(file.GoogleId);
+        perms.Should().ContainSingle(p => p.EmailAddress == alice.Email,
+            "missing member should be added on DriveFile just like DriveFolder");
+        perms.Should().NotContain(p => p.EmailAddress == "stranger@example.com",
+            "extra permission should be removed on DriveFile just like DriveFolder");
     }
 
     // -------------------------------------------------------------------------
@@ -352,6 +748,17 @@ public sealed class GoogleWorkspaceSyncServiceReconciliationTests : IDisposable
         return user;
     }
 
+    private void SeedActiveMember(Guid teamId, Guid userId)
+    {
+        _dbContext.TeamMembers.Add(new TeamMember
+        {
+            Id = Guid.NewGuid(),
+            TeamId = teamId,
+            UserId = userId,
+            JoinedAt = _clock.GetCurrentInstant() - Duration.FromDays(30)
+        });
+    }
+
     private void SeedLeftMember(Guid teamId, Guid userId)
     {
         var now = _clock.GetCurrentInstant();
@@ -365,7 +772,8 @@ public sealed class GoogleWorkspaceSyncServiceReconciliationTests : IDisposable
         });
     }
 
-    private GoogleResource SeedResource(Guid teamId, GoogleResourceType type, string googleId)
+    private GoogleResource SeedResource(Guid teamId, GoogleResourceType type, string googleId,
+        DrivePermissionLevel driveLevel = DrivePermissionLevel.Contributor)
     {
         var resource = new GoogleResource
         {
@@ -378,7 +786,7 @@ public sealed class GoogleWorkspaceSyncServiceReconciliationTests : IDisposable
             IsActive = true,
             DrivePermissionLevel = type == GoogleResourceType.Group
                 ? DrivePermissionLevel.None
-                : DrivePermissionLevel.Contributor,
+                : driveLevel,
             ProvisionedAt = _clock.GetCurrentInstant() - Duration.FromDays(10)
         };
         _dbContext.GoogleResources.Add(resource);

--- a/tests/Humans.Application.Tests/Services/GoogleWorkspaceSyncServiceReconciliationTests.cs
+++ b/tests/Humans.Application.Tests/Services/GoogleWorkspaceSyncServiceReconciliationTests.cs
@@ -1,0 +1,421 @@
+using AwesomeAssertions;
+using Humans.Application.Interfaces;
+using Humans.Application.Tests.Fakes;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using Humans.Infrastructure.Configuration;
+using Humans.Infrastructure.Data;
+using Humans.Infrastructure.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NodaTime;
+using NodaTime.Testing;
+using NSubstitute;
+using Xunit;
+
+namespace Humans.Application.Tests.Services;
+
+/// <summary>
+/// End-to-end coverage for <see cref="GoogleWorkspaceSyncService.SyncResourcesByTypeAsync"/>
+/// — the reconciliation path that PR #227 layered multiple fixes onto. See issue #508:
+/// every scenario here guards against a specific bug that was found by review instead of by
+/// a failing test.
+/// </summary>
+public sealed class GoogleWorkspaceSyncServiceReconciliationTests : IDisposable
+{
+    private readonly string _dbName = Guid.NewGuid().ToString();
+    private readonly HumansDbContext _dbContext;
+    private readonly InMemoryDbContextFactory _dbContextFactory;
+    private readonly FakeClock _clock;
+    private readonly IAuditLogService _auditLogService;
+    private readonly StubTeamResourceService _teamResourceService;
+    private readonly FakeSyncSettingsService _syncSettings;
+    private readonly FakeGoogleGroupMembershipClient _groupClient = new();
+    private readonly FakeGoogleDrivePermissionClient _driveClient = new();
+    private readonly IServiceProvider _serviceProvider;
+
+    public GoogleWorkspaceSyncServiceReconciliationTests()
+    {
+        _dbContext = BuildDbContext(_dbName);
+        _dbContextFactory = new InMemoryDbContextFactory(_dbName);
+        _clock = new FakeClock(Instant.FromUtc(2026, 4, 16, 12, 0));
+        _auditLogService = Substitute.For<IAuditLogService>();
+        _syncSettings = new FakeSyncSettingsService();
+
+        var serviceProvider = Substitute.For<IServiceProvider>();
+        serviceProvider.GetService(typeof(IAuditLogService)).Returns(_auditLogService);
+        serviceProvider.GetService(typeof(ITeamService)).Returns(Substitute.For<ITeamService>());
+        _teamResourceService = new StubTeamResourceService(
+            _dbContext,
+            Options.Create(new TeamResourceManagementSettings()),
+            serviceProvider,
+            Substitute.For<IRoleAssignmentService>(),
+            _clock,
+            NullLogger<StubTeamResourceService>.Instance);
+        serviceProvider.GetService(typeof(ITeamResourceService)).Returns(_teamResourceService);
+        _serviceProvider = serviceProvider;
+    }
+
+    public void Dispose()
+    {
+        _dbContext.Dispose();
+    }
+
+    // -------------------------------------------------------------------------
+    // Scenario 1: Soft-deleted team — revoke Drive + Group, deactivate per type
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task SoftDeletedTeam_DriveFolderPass_RevokesPermissionsAndDeactivatesOnlyDriveRow()
+    {
+        // Arrange: one soft-deleted team with a Drive folder + Group, both
+        // still IsActive = true. Both members have active Google access that
+        // should be revoked on the first reconciliation tick.
+        _syncSettings.SetMode(SyncServiceType.GoogleDrive, SyncMode.AddAndRemove);
+        _syncSettings.SetMode(SyncServiceType.GoogleGroups, SyncMode.AddAndRemove);
+
+        var team = SeedTeam(softDeleted: true);
+        var alice = SeedUser("alice@nobodies.team", "Alice");
+        var bob = SeedUser("bob@nobodies.team", "Bob");
+        SeedLeftMember(team.Id, alice.Id);
+        SeedLeftMember(team.Id, bob.Id);
+
+        var driveFolder = SeedResource(team.Id, GoogleResourceType.DriveFolder, "drive-soft-delete");
+        var group = SeedResource(team.Id, GoogleResourceType.Group, "group-soft-delete");
+        _driveClient.SeedDirectPermission(driveFolder.GoogleId, alice.Email!);
+        _driveClient.SeedDirectPermission(driveFolder.GoogleId, bob.Email!);
+        _groupClient.SeedMembership(group.GoogleId, alice.Email!);
+        _groupClient.SeedMembership(group.GoogleId, bob.Email!);
+
+        await _dbContext.SaveChangesAsync();
+
+        var service = BuildService();
+
+        // Act: run only the DriveFolder pass.
+        var result = await service.SyncResourcesByTypeAsync(GoogleResourceType.DriveFolder, SyncAction.Execute);
+
+        // Assert: diff has no error; Drive permissions are gone from the fake.
+        result.Diffs.Should().ContainSingle()
+            .Which.ErrorMessage.Should().BeNull();
+        _driveClient.GetPermissions(driveFolder.GoogleId).Should().BeEmpty();
+        _groupClient.GetMemberships(group.GoogleId).Should().HaveCount(2,
+            "the Group pass has not run yet and Drive reconciliation must not touch Group state");
+
+        // The DriveFolder row is deactivated; the Group row is NOT — this is the
+        // per-type scoping that guards the Drive-then-Group ordering.
+        var rows = await _dbContext.GoogleResources.AsNoTracking()
+            .Where(r => r.TeamId == team.Id)
+            .ToListAsync();
+        rows.Single(r => r.ResourceType == GoogleResourceType.DriveFolder).IsActive.Should().BeFalse();
+        rows.Single(r => r.ResourceType == GoogleResourceType.Group).IsActive.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task SoftDeletedTeam_GroupPass_RevokesMembershipsAndDeactivatesGroupRow()
+    {
+        _syncSettings.SetMode(SyncServiceType.GoogleDrive, SyncMode.AddAndRemove);
+        _syncSettings.SetMode(SyncServiceType.GoogleGroups, SyncMode.AddAndRemove);
+
+        var team = SeedTeam(softDeleted: true);
+        var alice = SeedUser("alice@nobodies.team", "Alice");
+        SeedLeftMember(team.Id, alice.Id);
+
+        var group = SeedResource(team.Id, GoogleResourceType.Group, "group-only");
+        _groupClient.SeedMembership(group.GoogleId, alice.Email!);
+
+        await _dbContext.SaveChangesAsync();
+        var service = BuildService();
+
+        var result = await service.SyncResourcesByTypeAsync(GoogleResourceType.Group, SyncAction.Execute);
+
+        result.Diffs.Should().ContainSingle()
+            .Which.ErrorMessage.Should().BeNull();
+        _groupClient.GetMemberships(group.GoogleId).Should().BeEmpty();
+
+        var row = await _dbContext.GoogleResources.AsNoTracking().SingleAsync(r => r.TeamId == team.Id);
+        row.IsActive.Should().BeFalse();
+    }
+
+    // -------------------------------------------------------------------------
+    // Scenario 2: Shared GoogleId Drive group — error defers ALL rows
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task SharedGoogleIdDriveGroup_WhenListFails_NoTeamInGroupIsDeactivated()
+    {
+        // Arrange: two soft-deleted teams both linked to the same Drive folder.
+        // The fake throws on ListPermissionsAsync for that GoogleId, so the
+        // diff's ErrorMessage is non-null. Neither row may be deactivated —
+        // otherwise the drive row for the "secondary" team is lost forever
+        // because SyncDriveResourceGroupAsync only surfaces the primary ResourceId.
+        _syncSettings.SetMode(SyncServiceType.GoogleDrive, SyncMode.AddAndRemove);
+        _syncSettings.SetMode(SyncServiceType.GoogleGroups, SyncMode.AddAndRemove);
+
+        var teamA = SeedTeam(softDeleted: true, slug: "team-a");
+        var teamB = SeedTeam(softDeleted: true, slug: "team-b");
+        var alice = SeedUser("alice@nobodies.team", "Alice");
+        SeedLeftMember(teamA.Id, alice.Id);
+        SeedLeftMember(teamB.Id, alice.Id);
+
+        const string sharedFolderId = "shared-folder-fail";
+        SeedResource(teamA.Id, GoogleResourceType.DriveFolder, sharedFolderId);
+        SeedResource(teamB.Id, GoogleResourceType.DriveFolder, sharedFolderId);
+        _driveClient.FailFile(sharedFolderId);
+
+        await _dbContext.SaveChangesAsync();
+        var service = BuildService();
+
+        var result = await service.SyncResourcesByTypeAsync(GoogleResourceType.DriveFolder, SyncAction.Execute);
+
+        // Diff carries the error; both rows stay IsActive = true.
+        result.Diffs.Should().ContainSingle()
+            .Which.ErrorMessage.Should().NotBeNullOrEmpty();
+
+        var rows = await _dbContext.GoogleResources.AsNoTracking()
+            .Where(r => r.GoogleId == sharedFolderId)
+            .ToListAsync();
+        rows.Should().HaveCount(2);
+        rows.Should().AllSatisfy(r => r.IsActive.Should().BeTrue(
+            "a failed Drive group must leave every row in the group active so the next tick can retry"));
+    }
+
+    // -------------------------------------------------------------------------
+    // Scenario 3: Partial error within one team defers deactivation
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task SoftDeletedTeam_WithOneErroredAndOneCleanDrive_DefersDeactivationForBoth()
+    {
+        // One soft-deleted team with TWO DriveFolder rows pointing at different
+        // GoogleIds. The fake errors on folder-a but succeeds on folder-b.
+        // DeactivateResourcesForTeamAsync(team, DriveFolder) is all-or-nothing
+        // by design, so the clean row must NOT be swept inactive — otherwise a
+        // follow-up call to DeactivateResourcesForTeamAsync would also flip the
+        // errored row and its stale access would be lost forever.
+        _syncSettings.SetMode(SyncServiceType.GoogleDrive, SyncMode.AddAndRemove);
+        _syncSettings.SetMode(SyncServiceType.GoogleGroups, SyncMode.AddAndRemove);
+
+        var team = SeedTeam(softDeleted: true);
+        var alice = SeedUser("alice@nobodies.team", "Alice");
+        SeedLeftMember(team.Id, alice.Id);
+
+        const string erroredFolder = "folder-a-errors";
+        const string cleanFolder = "folder-b-ok";
+        SeedResource(team.Id, GoogleResourceType.DriveFolder, erroredFolder);
+        SeedResource(team.Id, GoogleResourceType.DriveFolder, cleanFolder);
+        _driveClient.SeedDirectPermission(cleanFolder, alice.Email!);
+        _driveClient.FailFile(erroredFolder);
+
+        await _dbContext.SaveChangesAsync();
+        var service = BuildService();
+
+        var result = await service.SyncResourcesByTypeAsync(GoogleResourceType.DriveFolder, SyncAction.Execute);
+
+        result.Diffs.Should().HaveCount(2);
+        // Clean folder had its permission revoked...
+        _driveClient.GetPermissions(cleanFolder).Should().BeEmpty();
+        // ...but neither row is deactivated because the team has a same-type errored row.
+        var rows = await _dbContext.GoogleResources.AsNoTracking()
+            .Where(r => r.TeamId == team.Id)
+            .ToListAsync();
+        rows.Should().HaveCount(2);
+        rows.Should().AllSatisfy(r => r.IsActive.Should().BeTrue(
+            "a partial error within one team+type defers the entire team from deactivation"));
+    }
+
+    // -------------------------------------------------------------------------
+    // Scenario 4: DriveFolder pass must NOT deactivate Group row
+    // -------------------------------------------------------------------------
+    // Merged with scenario 1 — the first test already asserts that the Group row
+    // stays IsActive = true after the DriveFolder pass.
+
+    // -------------------------------------------------------------------------
+    // Scenario 5: AddOnly mode skips deactivation
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task SoftDeletedTeam_DriveInAddOnlyMode_DoesNotRevokeOrDeactivate()
+    {
+        _syncSettings.SetMode(SyncServiceType.GoogleDrive, SyncMode.AddOnly);
+        _syncSettings.SetMode(SyncServiceType.GoogleGroups, SyncMode.AddAndRemove);
+
+        var team = SeedTeam(softDeleted: true);
+        var alice = SeedUser("alice@nobodies.team", "Alice");
+        SeedLeftMember(team.Id, alice.Id);
+
+        var folder = SeedResource(team.Id, GoogleResourceType.DriveFolder, "folder-addonly");
+        _driveClient.SeedDirectPermission(folder.GoogleId, alice.Email!);
+
+        await _dbContext.SaveChangesAsync();
+        var service = BuildService();
+
+        var result = await service.SyncResourcesByTypeAsync(GoogleResourceType.DriveFolder, SyncAction.Execute);
+
+        result.Diffs.Should().ContainSingle()
+            .Which.ErrorMessage.Should().BeNull();
+
+        // The diff correctly reported Alice as Extra, but RemoveUserFromDrive
+        // short-circuited because mode != AddAndRemove, and the post-execute
+        // deactivation block also skips when mode != AddAndRemove.
+        _driveClient.GetPermissions(folder.GoogleId).Should().ContainSingle(p => p.EmailAddress == alice.Email);
+        var row = await _dbContext.GoogleResources.AsNoTracking().SingleAsync(r => r.Id == folder.Id);
+        row.IsActive.Should().BeTrue();
+    }
+
+    // -------------------------------------------------------------------------
+    // Scenario 6: None mode skips deactivation
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task SoftDeletedTeam_DriveInNoneMode_DoesNotRevokeOrDeactivate()
+    {
+        _syncSettings.SetMode(SyncServiceType.GoogleDrive, SyncMode.None);
+        _syncSettings.SetMode(SyncServiceType.GoogleGroups, SyncMode.AddAndRemove);
+
+        var team = SeedTeam(softDeleted: true);
+        var alice = SeedUser("alice@nobodies.team", "Alice");
+        SeedLeftMember(team.Id, alice.Id);
+
+        var folder = SeedResource(team.Id, GoogleResourceType.DriveFolder, "folder-none");
+        _driveClient.SeedDirectPermission(folder.GoogleId, alice.Email!);
+
+        await _dbContext.SaveChangesAsync();
+        var service = BuildService();
+
+        var result = await service.SyncResourcesByTypeAsync(GoogleResourceType.DriveFolder, SyncAction.Execute);
+
+        result.Diffs.Should().ContainSingle().Which.ErrorMessage.Should().BeNull();
+        _driveClient.GetPermissions(folder.GoogleId).Should().ContainSingle(p => p.EmailAddress == alice.Email);
+        var row = await _dbContext.GoogleResources.AsNoTracking().SingleAsync(r => r.Id == folder.Id);
+        row.IsActive.Should().BeTrue();
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private GoogleWorkspaceSyncService BuildService()
+    {
+        return new GoogleWorkspaceSyncService(
+            _dbContext,
+            _dbContextFactory,
+            Options.Create(new GoogleWorkspaceSettings()),
+            _clock,
+            _auditLogService,
+            _syncSettings,
+            _serviceProvider,
+            NullLogger<GoogleWorkspaceSyncService>.Instance,
+            _groupClient,
+            _driveClient);
+    }
+
+    private static HumansDbContext BuildDbContext(string name)
+    {
+        var options = new DbContextOptionsBuilder<HumansDbContext>()
+            .UseInMemoryDatabase(name)
+            .Options;
+        return new HumansDbContext(options);
+    }
+
+    private Team SeedTeam(bool softDeleted = false, string? slug = null)
+    {
+        var now = _clock.GetCurrentInstant();
+        var team = new Team
+        {
+            Id = Guid.NewGuid(),
+            Name = slug ?? $"Team-{Guid.NewGuid():N}"[..12],
+            Slug = slug ?? Guid.NewGuid().ToString("N")[..12],
+            IsActive = !softDeleted,
+            CreatedAt = now,
+            UpdatedAt = now
+        };
+        _dbContext.Teams.Add(team);
+        return team;
+    }
+
+    private User SeedUser(string email, string displayName)
+    {
+        var user = new User
+        {
+            Id = Guid.NewGuid(),
+            UserName = email,
+            Email = email,
+            NormalizedEmail = email.ToUpperInvariant(),
+            NormalizedUserName = email.ToUpperInvariant(),
+            DisplayName = displayName,
+            GoogleEmail = email,
+            GoogleEmailStatus = GoogleEmailStatus.Unknown,
+            CreatedAt = _clock.GetCurrentInstant()
+        };
+        _dbContext.Users.Add(user);
+        return user;
+    }
+
+    private void SeedLeftMember(Guid teamId, Guid userId)
+    {
+        var now = _clock.GetCurrentInstant();
+        _dbContext.TeamMembers.Add(new TeamMember
+        {
+            Id = Guid.NewGuid(),
+            TeamId = teamId,
+            UserId = userId,
+            JoinedAt = now - Duration.FromDays(30),
+            LeftAt = now - Duration.FromDays(1)
+        });
+    }
+
+    private GoogleResource SeedResource(Guid teamId, GoogleResourceType type, string googleId)
+    {
+        var resource = new GoogleResource
+        {
+            Id = Guid.NewGuid(),
+            TeamId = teamId,
+            Name = $"{type}-{googleId}",
+            GoogleId = googleId,
+            Url = $"https://example.com/{googleId}",
+            ResourceType = type,
+            IsActive = true,
+            DrivePermissionLevel = type == GoogleResourceType.Group
+                ? DrivePermissionLevel.None
+                : DrivePermissionLevel.Contributor,
+            ProvisionedAt = _clock.GetCurrentInstant() - Duration.FromDays(10)
+        };
+        _dbContext.GoogleResources.Add(resource);
+        return resource;
+    }
+
+    // Mutable ISyncSettingsService impl so tests can flip modes without a mock setup call.
+    private sealed class FakeSyncSettingsService : ISyncSettingsService
+    {
+        private readonly Dictionary<SyncServiceType, SyncMode> _modes = new();
+
+        public void SetMode(SyncServiceType serviceType, SyncMode mode) => _modes[serviceType] = mode;
+
+        public Task<SyncMode> GetModeAsync(SyncServiceType serviceType, CancellationToken ct = default)
+            => Task.FromResult(_modes.TryGetValue(serviceType, out var mode) ? mode : SyncMode.None);
+
+        public Task<List<SyncServiceSettings>> GetAllAsync(CancellationToken ct = default)
+            => Task.FromResult(_modes
+                .Select(kv => new SyncServiceSettings { ServiceType = kv.Key, SyncMode = kv.Value })
+                .ToList());
+
+        public Task UpdateModeAsync(SyncServiceType serviceType, SyncMode mode, Guid actorUserId, CancellationToken ct = default)
+        {
+            _modes[serviceType] = mode;
+            return Task.CompletedTask;
+        }
+    }
+
+    // The sync service's parallel reconciliation path pulls a fresh DbContext per task from
+    // the factory. The InMemory provider keys databases by name, so handing out new instances
+    // pointing at the same name keeps state coherent with the scoped _dbContext in the test.
+    private sealed class InMemoryDbContextFactory : IDbContextFactory<HumansDbContext>
+    {
+        private readonly string _name;
+
+        public InMemoryDbContextFactory(string name) => _name = name;
+
+        public HumansDbContext CreateDbContext() => BuildDbContext(_name);
+    }
+}


### PR DESCRIPTION
## Summary

Closes #508 — the verification gap PR #227 left behind. That PR layered multiple fixes onto `SyncResourcesByTypeAsync` for soft-deleted team Google revocation, but every bug was caught by Codex review rather than a failing test. This adds six end-to-end regression tests that pin each scenario.

### Seam refactor
Introduces two narrow internal interfaces in `src/Humans.Infrastructure/GoogleSync/`:
- `IGoogleGroupMembershipClient` — list/create/delete memberships on a Group id.
- `IGoogleDrivePermissionClient` — list/create/delete permissions on a file id.

Real impls wrap `CloudIdentityService` / `DriveService` and hide pagination. A new `internal` constructor overload on `GoogleWorkspaceSyncService` lets tests substitute fakes without reflection. Production path and DI registration are unchanged — the public constructor builds the real clients lazily from the existing `GetXxxServiceAsync()` helpers.

The reconciliation + gateway paths (`SyncGroupResourceAsync`, `SyncDriveResourceGroupAsync`, `ExecuteDriveSyncActionsAsync`, `AddUserTo{Group,Drive}Async`, `RemoveUserFrom{Group,Drive}Async`) route Google calls through the new clients. Other paths (`SyncTeamGroupMembersAsync`, group settings drift, provisioning) keep using the raw SDK services as before — the seam is scoped to what reconciliation tests need to reach.

### Two defensive production fixes unlocked by the tests
- `PreloadChildTeamMembersAsync` now guards `ParentTeamId` with `.HasValue` before `Contains` instead of force-unwrapping with `!.Value`. The old pattern works on Postgres (lifted into SQL) but crashes on InMemory because the filter is evaluated client-side.
- `SyncGroupResourceAsync` and `SyncDriveResourceGroupAsync` now apply a client-side `tm.LeftAt == null` filter when iterating `resource.Team.Members`. The calling query already applies this via `Include(...).ThenInclude(t => t.Members.Where(...))`, but the EF Core InMemory provider does not honor filtered Includes. The redundant filter is a no-op on Postgres and makes reconciliation provider-independent — so tests reflect the same semantics as production.

### Fakes (tests/Humans.Application.Tests/Fakes/)
- `FakeGoogleGroupMembershipClient` — dictionary-backed state, `SeedMembership`, `FailGroup` (throws `GoogleApiException` 404/403), 409 on duplicate create.
- `FakeGoogleDrivePermissionClient` — same shape for file permissions, with `SeedDirectPermission` / `SeedInheritedPermission` (the latter populates `PermissionDetails` so the reconciler classifies it as `Inherited`, not `Extra`) and `FailFile`.

### Scenarios pinned
1. `SoftDeletedTeam_DriveFolderPass_RevokesPermissionsAndDeactivatesOnlyDriveRow` — covers the soft-delete revocation path AND the per-type deactivation scoping (scenarios 1 + 4 from the issue — the DriveFolder row flips inactive but the Group row stays active for the Group pass).
2. `SoftDeletedTeam_GroupPass_RevokesMembershipsAndDeactivatesGroupRow` — same shape for the Group pass.
3. `SharedGoogleIdDriveGroup_WhenListFails_NoTeamInGroupIsDeactivated` — two teams sharing the same `GoogleId`, fake errors on that file → the `erroredGoogleIds` guard leaves every row in the group active.
4. `SoftDeletedTeam_WithOneErroredAndOneCleanDrive_DefersDeactivationForBoth` — partial error within one team defers the entire team+type from deactivation.
5. `SoftDeletedTeam_DriveInAddOnlyMode_DoesNotRevokeOrDeactivate` — `AddOnly` skips both the removal path and the post-execute deactivation.
6. `SoftDeletedTeam_DriveInNoneMode_DoesNotRevokeOrDeactivate` — same for `None`.

## Test plan
- [x] `dotnet build Humans.slnx` clean.
- [x] `dotnet test tests/Humans.Application.Tests/Humans.Application.Tests.csproj` → 1017 passed (1011 previous + 6 new).
- [x] `dotnet test tests/Humans.Domain.Tests/Humans.Domain.Tests.csproj` → 108 passed.
- [x] `dotnet format Humans.slnx --verify-no-changes` clean.
- [ ] Integration tests not executed locally (Docker-dependent); will be gated on CI.
- [ ] QA smoke: run reconciliation in the QA environment after merge and confirm existing soft-deleted team resources are still revoked as expected (no production behavior change, but worth a manual verification since the Google API is now routed through a new seam).

🤖 Generated with [Claude Code](https://claude.com/claude-code)