### PR TITLE
Volunteer Coordinator Dashboard

### DIFF
--- a/docs/features/25-shift-management.md
+++ b/docs/features/25-shift-management.md
@@ -187,7 +187,7 @@ Pending --> Cancelled   (system: shift deleted, account deletion)
 
 **Panels:**
 
-- **Overview counters** — five cards: shifts filled (with per-period Build/Event/Strike fill chips coloured ≥80% green / 60–79% amber / <60% red), ticket holders, ticket holders engaged (primary-bordered emphasis card; sub-line shows how many humans haven't signed up), non-ticket signups, stale pending (warning-bordered when > 0).
+- **Overview counters** — five cards: shifts filled (with per-period Build/Event/Strike fill chips coloured ≥80% green / 60–79% amber / <60% red), ticket holders, ticket holding volunteers (primary-bordered emphasis card; sub-line shows how many ticket-holding humans haven't signed up), non-ticket signups, stale pending (warning-bordered when > 0).
 - **Departments table** — one row per parent team, sorted by ascending fill %. Clicking a row expands to either three period sub-rows (Build/Event/Strike) when the department has no subteams, or a subgroup table showing each subteam (plus a "Direct" row for rotas attached to the parent itself) with per-period fill % chips.
 - **Coordinator activity** — teams that have ≥1 pending signup, one row each listing coordinator names, oldest login across that team's coordinators (rendered red if > 7 days or never), and pending signup count. Hidden entirely if no team has pending signups.
 - **Trends chart** — line chart with three series (new signups, new ticket sales, distinct logins / DAU) over a selectable window (7/30/90 days, All). Window toggle re-renders via `asp-route-trendWindow=`. DAU series is dashed with a tooltip noting that only the last login per human is stored (older buckets undercount).
@@ -197,7 +197,7 @@ Pending --> Cancelled   (system: shift deleted, account deletion)
 - **Shift filled** — confirmed signup count ≥ `MinVolunteers`.
 - **Period fill rate** — filled shifts in the period / total shifts in the period, expressed as a percentage. Aggregates ignore AdminOnly shifts' visibility.
 - **Ticket holder** — a human with an active ticket for the event.
-- **Ticket holder engaged** — a ticket holder with at least one non-bailed/non-refused/non-cancelled signup on an event-period shift.
+- **Ticket holding volunteer** — a ticket holder who has at least one shift signup on a visible, non-AdminOnly shift of this event, with any status other than `Cancelled`. Pending, Refused, Bailed, and NoShow all count as "engaged with the shift system", so the metric is "ticket holders we've gotten in front of", not "currently committed to work a shift".
 - **Non-ticket signup** — distinct humans who have ≥1 non-bailed/non-refused/non-cancelled signup but no active ticket.
 - **Stale pending** — a pending signup whose `CreatedAt` is more than 3 days ago.
 - **Subgroup aggregate invariant** — department totals equal the sum of subgroup totals (including the synthetic "Direct" row for rotas whose team is the parent itself).

--- a/docs/features/25-shift-management.md
+++ b/docs/features/25-shift-management.md
@@ -179,6 +179,42 @@ Pending --> Cancelled   (system: shift deleted, account deletion)
 | `/` (Dashboard) | Shift signups ViewComponent + guided discovery when no signups |
 | `/Human/{id}/Admin` | Shift signups ViewComponent (admin view of user's shifts) |
 
+## Coordinator Dashboard
+
+**Purpose:** Give Volunteer Coordinators, NoInfoAdmins, and Admins a single cross-department view that answers the weekly coordination questions: is overall staffing tracking toward the event, which departments are behind, which coordinator teams have stale pending signups, and are new signups / ticket sales trending.
+
+**Route:** `/Shifts/Dashboard` (existing) — the four dashboard panels render above the legacy urgent-shifts filter.
+
+**Panels:**
+
+- **Overview counters** — five cards: shifts filled (with per-period Build/Event/Strike fill chips coloured ≥80% green / 60–79% amber / <60% red), ticket holders, ticket holders engaged (primary-bordered emphasis card; sub-line shows how many humans haven't signed up), non-ticket signups, stale pending (warning-bordered when > 0).
+- **Departments table** — one row per parent team, sorted by ascending fill %. Clicking a row expands to either three period sub-rows (Build/Event/Strike) when the department has no subteams, or a subgroup table showing each subteam (plus a "Direct" row for rotas attached to the parent itself) with per-period fill % chips.
+- **Coordinator activity** — teams that have ≥1 pending signup, one row each listing coordinator names, oldest login across that team's coordinators (rendered red if > 7 days or never), and pending signup count. Hidden entirely if no team has pending signups.
+- **Trends chart** — line chart with three series (new signups, new ticket sales, distinct logins / DAU) over a selectable window (7/30/90 days, All). Window toggle re-renders via `asp-route-trendWindow=`. DAU series is dashed with a tooltip noting that only the last login per human is stored (older buckets undercount).
+
+**Metric definitions:**
+
+- **Shift filled** — confirmed signup count ≥ `MinVolunteers`.
+- **Period fill rate** — filled shifts in the period / total shifts in the period, expressed as a percentage. Aggregates ignore AdminOnly shifts' visibility.
+- **Ticket holder** — a human with an active ticket for the event.
+- **Ticket holder engaged** — a ticket holder with at least one non-bailed/non-refused/non-cancelled signup on an event-period shift.
+- **Non-ticket signup** — distinct humans who have ≥1 non-bailed/non-refused/non-cancelled signup but no active ticket.
+- **Stale pending** — a pending signup whose `CreatedAt` is more than 3 days ago.
+- **Subgroup aggregate invariant** — department totals equal the sum of subgroup totals (including the synthetic "Direct" row for rotas whose team is the parent itself).
+- **DAU** — distinct humans whose last login falls on the bucket date in the event timezone. Limitation: the system stores only the most recent login per human, so older buckets are biased low.
+
+**Authorization:** Controller action is gated by `[Authorize(Policy = PolicyNames.ShiftDashboardAccess)]` → Admin, NoInfoAdmin, VolunteerCoordinator. The service (`IShiftManagementService`) is auth-free per `design-rules.md`.
+
+**Caching:** Each dashboard query memoizes into `IMemoryCache` with a 5-minute sliding expiration. Keys:
+
+- `dashboard-overview:{eventSettingsId}`
+- `dashboard-coordinator-activity:{eventSettingsId}`
+- `dashboard-trends:{eventSettingsId}:{window}`
+
+At ~500-human scale, the dashboard view hits the cache on most loads and the underlying aggregation queries only run on first visit per coordinator per 5 minutes. Signup mutations do NOT currently invalidate these caches — counters lag real state by up to 5 minutes after approving, refusing, bailing, or creating signups (tracked as a follow-up; see the dashboard spec).
+
+**Development seeder:** `DevelopmentDashboardSeeder` populates a realistic demo dataset (one event, several departments including one with subteams, ticket holders with mixed signup states, pending signups of varying ages, and ~85 days of spread signup/ticket/login activity for the trend chart). Exposed at `POST /dev/seed/dashboard`, button rendered on `/Shifts/Dashboard` only when the app is running in the Development environment. Not reachable in QA / preview / production regardless of role.
+
 ## Related Features
 
 - **Teams** (06): Departments are parent teams; coordinator roles grant shift management access

--- a/docs/sections/Shifts.md
+++ b/docs/sections/Shifts.md
@@ -34,6 +34,8 @@
 - Rota period (Build, Event, Strike) determines the shift creation UX (all-day vs. time-slotted) and signup UX (date-range vs. individual).
 - Medical data in volunteer event profiles is restricted to Admin and NoInfoAdmin.
 - When shift browsing is closed, regular volunteers can only see shifts if they already have signups. Coordinators and privileged roles can always browse.
+- All dashboard methods on `IShiftManagementService` (`GetDashboardOverviewAsync`, `GetCoordinatorActivityAsync`, `GetDashboardTrendsAsync`) require the `ShiftDashboardAccess` policy at the controller. The service itself is auth-free per design rules.
+- `DevelopmentDashboardSeeder` and its `POST /dev/seed/dashboard` endpoint are gated to `IWebHostEnvironment.IsDevelopment()` only. QA, preview, and production environments cannot invoke it regardless of role.
 
 ## Negative Access Rules
 

--- a/docs/superpowers/plans/2026-04-19-volunteer-coordinator-dashboard.md
+++ b/docs/superpowers/plans/2026-04-19-volunteer-coordinator-dashboard.md
@@ -1,0 +1,559 @@
+# Volunteer Coordinator Dashboard Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend `/Shifts/Dashboard` with overview counters, a departments staffing table that unfolds into subgroups (subteams with rotas, or period breakdown as fallback), coordinator activity list, and a trends chart; ship as a single PR with a local-only seeder.
+
+**Architecture:** Add three new methods to `IShiftManagementService` (overview, coordinator activity, trends), new DTOs in `Humans.Application/DTOs/`. The controller renders a `ShiftDashboardViewModel` extended with the new panels. Views are partials rendered above existing content. Caching via `IMemoryCache` with invalidation hooks in `ShiftSignupService`. A new `DevelopmentDashboardSeeder` + `POST /dev/seed/dashboard` endpoint (gated to `IsDevelopment()` only) provides deterministic manual-test data including Infrastructure → Power / Plumbing subteams.
+
+**Tech Stack:** .NET 9, EF Core, NodaTime, xUnit + AwesomeAssertions + NSubstitute, Bootstrap 5.3, Chart.js 4.5.
+
+**Spec:** `docs/superpowers/specs/2026-04-19-volunteer-coordinator-dashboard-design.md`
+
+---
+
+## Chunk 1: DTOs, enum, interface extension
+
+### Task 1.1: Add `TrendWindow` enum
+
+**Files:**
+- Create: `src/Humans.Application/Enums/TrendWindow.cs`
+
+- [ ] **Step 1: Create the enum file**
+
+```csharp
+namespace Humans.Application.Enums;
+
+public enum TrendWindow
+{
+    Last7Days,
+    Last30Days,
+    Last90Days,
+    All
+}
+```
+
+- [ ] **Step 2: Build to verify** — `dotnet build Humans.slnx`. Expected: success.
+
+### Task 1.2: Add DTO records
+
+**Files:**
+- Create: `src/Humans.Application/DTOs/DashboardOverview.cs` (holds all dashboard records)
+
+- [ ] **Step 1: Write records**
+
+```csharp
+using NodaTime;
+
+namespace Humans.Application.DTOs;
+
+public record DashboardOverview(
+    int TotalShifts,
+    int FilledShifts,
+    PeriodBreakdown PeriodFillRates,
+    int TicketHolderCount,
+    int TicketHoldersEngaged,
+    int NonTicketSignups,
+    int StalePendingCount,
+    IReadOnlyList<DepartmentStaffingRow> Departments);
+
+public record PeriodBreakdown(double BuildPct, double EventPct, double StrikePct);
+
+public record DepartmentStaffingRow(
+    Guid DepartmentId,
+    string DepartmentName,
+    int TotalShifts,
+    int FilledShifts,
+    int SlotsRemaining,
+    PeriodStaffing Build,
+    PeriodStaffing Event,
+    PeriodStaffing Strike,
+    IReadOnlyList<SubgroupStaffingRow> Subgroups);
+
+public record SubgroupStaffingRow(
+    Guid? TeamId,
+    string Name,
+    bool IsDirect,
+    int TotalShifts,
+    int FilledShifts,
+    int SlotsRemaining,
+    PeriodStaffing Build,
+    PeriodStaffing Event,
+    PeriodStaffing Strike);
+
+public record PeriodStaffing(int Total, int Filled, int SlotsRemaining);
+
+public record CoordinatorActivityRow(
+    Guid TeamId,
+    string TeamName,
+    IReadOnlyList<CoordinatorLogin> Coordinators,
+    int PendingSignupCount);
+
+public record CoordinatorLogin(Guid UserId, string DisplayName, Instant? LastLoginAt);
+
+public record DashboardTrendPoint(
+    LocalDate Date,
+    int NewSignups,
+    int NewTicketSales,
+    int DistinctLogins);
+```
+
+- [ ] **Step 2: Build** — `dotnet build Humans.slnx`. Expected: success.
+
+### Task 1.3: Extend `IShiftManagementService`
+
+**Files:**
+- Modify: `src/Humans.Application/Interfaces/IShiftManagementService.cs`
+
+- [ ] **Step 1: Add `using Humans.Application.DTOs; using Humans.Application.Enums;` at the top.**
+
+- [ ] **Step 2: Append three method signatures** immediately above the `// === Shift Tags ===` section:
+
+```csharp
+/// <summary>
+/// Gets the full dashboard overview (counters + per-department staffing rows with subgroup drill-down).
+/// </summary>
+Task<DashboardOverview> GetDashboardOverviewAsync(Guid eventSettingsId);
+
+/// <summary>
+/// Gets per-team coordinator activity, scoped to teams with at least one pending signup.
+/// </summary>
+Task<IReadOnlyList<CoordinatorActivityRow>> GetCoordinatorActivityAsync(Guid eventSettingsId);
+
+/// <summary>
+/// Gets daily trend points (signups, ticket sales, distinct logins) for the window.
+/// </summary>
+Task<IReadOnlyList<DashboardTrendPoint>> GetDashboardTrendsAsync(Guid eventSettingsId, TrendWindow window);
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/Humans.Application/Enums/TrendWindow.cs \
+        src/Humans.Application/DTOs/DashboardOverview.cs \
+        src/Humans.Application/Interfaces/IShiftManagementService.cs
+git commit -m "Add dashboard DTOs, TrendWindow enum, and IShiftManagementService contract"
+```
+
+---
+
+## Chunk 2: ShiftManagementService implementation (TDD)
+
+### Task 2.1: Create test file with fixture
+
+**Files:**
+- Create: `tests/Humans.Application.Tests/Services/ShiftDashboardMetricsTests.cs`
+
+- [ ] **Step 1: Scaffold test class** mirroring `ShiftUrgencyTests` setup (`HumansDbContext` with in-memory provider, `FakeClock`, service instance). Use `TestNow = Instant.FromUtc(2026, 7, 1, 12, 0)` and an `EventSettings` with `GateOpeningDate = LocalDate(2026, 8, 1)`, `BuildStartOffset = -14`, `EventEndOffset = 6`, `StrikeEndOffset = 9`, `TimeZoneId = "UTC"`, `IsActive = true`.
+
+- [ ] **Step 2: Run to verify compiles** — `dotnet test tests/Humans.Application.Tests/ --filter FullyQualifiedName~ShiftDashboardMetricsTests`. Expected: no tests found, but compiles clean.
+
+### Task 2.2: Counter basics test — empty database
+
+- [ ] **Step 1: Add test**
+
+```csharp
+[Fact]
+public async Task GetDashboardOverviewAsync_NoData_ReturnsZeroCounters()
+{
+    var es = await SeedActiveEventAsync();
+    var result = await _service.GetDashboardOverviewAsync(es.Id);
+    result.TotalShifts.Should().Be(0);
+    result.FilledShifts.Should().Be(0);
+    result.TicketHolderCount.Should().Be(0);
+    result.TicketHoldersEngaged.Should().Be(0);
+    result.NonTicketSignups.Should().Be(0);
+    result.StalePendingCount.Should().Be(0);
+    result.Departments.Should().BeEmpty();
+}
+```
+
+- [ ] **Step 2: Run to verify fails** — Expected: build fails (method missing on service).
+
+- [ ] **Step 3: Add stub in `ShiftManagementService`** that returns zero-valued record so test runs but fails with meaningful assertion.
+
+### Task 2.3: Implement core overview query
+
+**Files:**
+- Modify: `src/Humans.Infrastructure/Services/ShiftManagementService.cs`
+
+- [ ] **Step 1: Implement `GetDashboardOverviewAsync`** — cached via `_cache.GetOrCreate($"dashboard-overview:{eventSettingsId}", ...)` with 5-minute sliding TTL. Loads:
+  - All visible shifts (`!shift.AdminOnly && shift.Rota.IsVisibleToVolunteers`) in the event, with `Include(s => s.Rota).ThenInclude(r => r.Team).ThenInclude(t => t.ParentTeam)`.
+  - All confirmed signups for those shifts (project to `shiftId → confirmedCount` dict).
+  - All paid `TicketOrder` matched to users (`PaymentStatus == Paid && MatchedUserId != null`) — project to `HashSet<Guid>` of ticket-holder user IDs.
+  - All non-cancelled signups in the event — project to `HashSet<Guid>` of engaged user IDs.
+  - Count stale-pending: `status == Pending && createdAt < now - 3 days`.
+
+- [ ] **Step 2: Compute counters**:
+  - `TotalShifts` = visible shifts count
+  - `FilledShifts` = shifts where confirmed count ≥ `MinVolunteers`
+  - `PeriodFillRates` = per-period filled / total (use `shift.GetShiftPeriod(es)`)
+  - `TicketHolderCount` = ticket-holder user-ID count
+  - `TicketHoldersEngaged` = intersection of ticket-holder + engaged user-ID sets
+  - `NonTicketSignups` = engaged minus ticket-holder
+  - `StalePendingCount` — query `ShiftSignups` directly, scoped to event via rota.
+
+- [ ] **Step 3: Run empty-DB test** — Expected: PASS.
+
+### Task 2.4: Filled-shift threshold tests
+
+- [ ] **Step 1: Add three tests** covering `MinVolunteers - 1` (not filled), `=` (filled), `+1` (still filled). Build per-test: event + team + rota + 1 shift (`MinVolunteers = 3, MaxVolunteers = 5`) + N confirmed signups.
+
+- [ ] **Step 2: Run** — Expected: PASS (implementation already handles this).
+
+### Task 2.5: Ticket-holder classification tests
+
+- [ ] **Step 1: Add tests**:
+  - User with `PaymentStatus = Paid, MatchedUserId = U` → ticket holder (counted once even across multiple orders)
+  - User with `PaymentStatus = Refunded` only → NOT ticket holder
+  - User with signups and paid order → engaged
+  - User with signups and no paid order → non-ticket signup
+  - Ticket holder with only `Cancelled` signups → NOT engaged
+
+- [ ] **Step 2: Run** — iterate until green. Commit after all pass:
+
+```bash
+git add tests/Humans.Application.Tests/Services/ShiftDashboardMetricsTests.cs \
+        src/Humans.Infrastructure/Services/ShiftManagementService.cs
+git commit -m "Dashboard overview counters with TDD coverage"
+```
+
+### Task 2.6: Department rows — no subteams
+
+- [ ] **Step 1: Add test** — event with two parent teams (Gate, Kitchen), each with 1 rota and 2 shifts. Assert `Departments` contains two rows, sorted by fill % ascending, with `Subgroups` empty.
+
+- [ ] **Step 2: Extend implementation** — group shifts by `shift.Rota.Team.ParentTeam ?? shift.Rota.Team` (aka "department"). For each group compute totals + per-period `PeriodStaffing`. Order rows by fill % ascending (ties by name).
+
+- [ ] **Step 3: Run** — Expected: PASS.
+
+### Task 2.7: Department rows — with subteams
+
+- [ ] **Step 1: Add test**:
+  - Parent team "Infrastructure", subteams "Power" (child of Infrastructure) and "Plumbing" (child of Infrastructure)
+  - 1 rota on Infrastructure (direct) with 2 shifts
+  - 1 rota on Power with 2 shifts
+  - 1 rota on Plumbing with 2 shifts, low fill rate
+  - Assert: one department row "Infrastructure" with `Subgroups.Count == 3`: first row is "Direct" (IsDirect=true) pinned top, then Plumbing (lowest fill %), then Power. Each subgroup's TotalShifts = 2. Aggregate assertion: sum(subgroup.TotalShifts) == department.TotalShifts; same for FilledShifts and Build/Event/Strike components.
+
+- [ ] **Step 2: Extend service implementation** — after grouping by department, check whether any shift in the group belongs to a subteam (`rota.Team.ParentTeamId != null`). If yes, build `Subgroups`:
+  - Per-subteam subgroup: sum over shifts where `rota.TeamId == subteamId`, use `rota.Team.Name`
+  - "Direct" subgroup: sum over shifts where `rota.TeamId == departmentId` (if any)
+  - Sort subgroups by fill % ascending, pin `IsDirect == true` to top
+  - Else set `Subgroups = []`
+
+- [ ] **Step 3: Run** — Expected: PASS.
+
+- [ ] **Step 4: Add aggregate-invariant test**
+
+```csharp
+[Fact]
+public async Task GetDashboardOverviewAsync_SubgroupsSumToDepartment()
+{
+    // Arrange: department with subteams, mixed fill rates
+    // Assert: for each department with subgroups, totals and per-period counters sum exactly
+}
+```
+
+- [ ] **Step 5: Run, commit**
+
+```bash
+git add tests/Humans.Application.Tests/Services/ShiftDashboardMetricsTests.cs \
+        src/Humans.Infrastructure/Services/ShiftManagementService.cs
+git commit -m "Department subgroup aggregation with subteam unfolding"
+```
+
+### Task 2.8: Stale-pending test
+
+- [ ] **Step 1: Add test** — pending signup created exactly 3 days ago → not stale; 3 days + 1 minute → stale; confirmed with old createdAt → never stale.
+
+- [ ] **Step 2: Run, adjust if needed, commit.**
+
+### Task 2.9: Implement `GetCoordinatorActivityAsync`
+
+- [ ] **Step 1: Add tests**:
+  - Team with zero pending signups excluded
+  - Team with multiple coordinators lists all
+  - Rows sorted by oldest coordinator `LastLoginAt` first (nulls first), ties by team name
+
+- [ ] **Step 2: Implement** — query pending signup counts per team (reuse `GetPendingShiftSignupCountsByTeamAsync`), filter teams with ≥1, load `TeamMembers.Where(tm => tm.Role == Coordinator)` with user, project to `CoordinatorActivityRow`. Cache with key `dashboard-coordinator-activity:{eventId}`, 5-min sliding.
+
+- [ ] **Step 3: Run, commit**
+
+```bash
+git add …
+git commit -m "Coordinator activity dashboard query with staleness ordering"
+```
+
+### Task 2.10: Implement `GetDashboardTrendsAsync`
+
+- [ ] **Step 1: Add tests**:
+  - Empty event with 7-day window → 7 points, all zero
+  - One signup today → `NewSignups` = 1 on today's bucket, zero on prior days
+  - Window boundaries: `Last30Days` returns exactly 30 points ending today (inclusive)
+  - `TrendWindow.All` uses `EventSettings.CreatedAt` date as start
+
+- [ ] **Step 2: Implement** — resolve start date from window + event TZ, generate list of `LocalDate`s, query three counts grouped by day in `EventSettings.TimeZoneId`, zero-fill missing days. Cache with key `dashboard-trends:{eventId}:{window}`, 5-min sliding.
+
+- [ ] **Step 3: Run, commit**
+
+```bash
+git add …
+git commit -m "Dashboard trends query with zero-filled buckets"
+```
+
+### Task 2.11: Cache invalidation on signup mutations
+
+- [ ] **Step 1: Locate `ShiftSignupService` methods that create / change state** (`CreateSignupAsync`, `ConfirmSignupAsync`, etc.). Identify every place a signup row is inserted or status-transitioned.
+
+- [ ] **Step 2: Inject `IMemoryCache`** if not already; add a private helper `InvalidateDashboardCaches(Guid eventSettingsId)` that removes `dashboard-overview:{id}` and `dashboard-coordinator-activity:{id}`. Call after successful save in each mutator.
+
+- [ ] **Step 3: Run full test suite** — `dotnet test Humans.slnx`. Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add …
+git commit -m "Invalidate dashboard caches on shift-signup mutations"
+```
+
+---
+
+## Chunk 3: ViewModel + Controller
+
+### Task 3.1: Extend `ShiftDashboardViewModel`
+
+**Files:**
+- Modify: `src/Humans.Web/Models/ShiftViewModels.cs`
+
+- [ ] **Step 1: Add properties** to `ShiftDashboardViewModel`:
+
+```csharp
+public DashboardOverview? Overview { get; set; }
+public List<CoordinatorActivityRow> CoordinatorActivity { get; set; } = [];
+public List<DashboardTrendPoint> Trends { get; set; } = [];
+public TrendWindow TrendWindow { get; set; } = TrendWindow.Last30Days;
+```
+
+Add `using Humans.Application.DTOs; using Humans.Application.Enums;` at the top.
+
+### Task 3.2: Update controller
+
+**Files:**
+- Modify: `src/Humans.Web/Controllers/ShiftDashboardController.cs`
+
+- [ ] **Step 1: Add `trendWindow` param**, default `Last30Days`. Parse from query string.
+
+- [ ] **Step 2: Call the new service methods in parallel** (`Task.WhenAll` over the three). Populate `Overview`, `CoordinatorActivity`, `Trends`, `TrendWindow` on the view model.
+
+- [ ] **Step 3: Build** — `dotnet build`. Commit:
+
+```bash
+git add src/Humans.Web/Models/ShiftViewModels.cs \
+        src/Humans.Web/Controllers/ShiftDashboardController.cs
+git commit -m "Wire dashboard controller to new overview/activity/trends methods"
+```
+
+---
+
+## Chunk 4: Views (overview, departments, coordinator activity, trends)
+
+### Task 4.1: Overview counters partial
+
+**Files:**
+- Create: `src/Humans.Web/Views/ShiftDashboard/_OverviewCounters.cshtml`
+
+- [ ] **Step 1: Write partial** — accepts `DashboardOverview` as model. Five Bootstrap cards in a responsive grid (`row g-3`). Each card shows value + label + sub-line. Ticket-holders-engaged card gets `border-primary` emphasis and the sub-line "N humans haven't signed up" (uses "humans" per CLAUDE.md). Stale-pending card gets `border-warning` when count > 0. Shifts-filled card adds three period chips coloured by threshold (≥80% green, 60–79% amber, <60% red).
+
+### Task 4.2: Departments table partial
+
+**Files:**
+- Create: `src/Humans.Web/Views/ShiftDashboard/_DepartmentsTable.cshtml`
+
+- [ ] **Step 1: Write partial** — accepts `IReadOnlyList<DepartmentStaffingRow>`. Table with columns: department · total · filled · % · slots remaining · chevron. Each row has `data-bs-toggle="collapse" data-bs-target="#dept-<id>"`. Hidden row below shows:
+  - If `row.Subgroups.Any()`: render inner table with one row per subgroup, columns: name (with "Direct" badge if `IsDirect`) · total · filled · % · slots · [Build / Event / Strike compact chips].
+  - Else: render three rows (Build / Event / Strike) with total + filled + %.
+- Period chips formatted as `@((int)Math.Round(100.0 * p.Filled / Math.Max(1, p.Total)))%` with same threshold colours as the overview.
+
+### Task 4.3: Coordinator activity partial
+
+**Files:**
+- Create: `src/Humans.Web/Views/ShiftDashboard/_CoordinatorActivity.cshtml`
+
+- [ ] **Step 1: Write partial** — accepts `IReadOnlyList<CoordinatorActivityRow>`. Table with columns: team · coordinators (comma-separated names) · last login (relative; red if > 7 days or null) · pending count. Hide entire card if list empty (`@if (Model.Any()) { ... }`).
+
+### Task 4.4: Trends chart partial
+
+**Files:**
+- Create: `src/Humans.Web/Views/ShiftDashboard/_TrendsChart.cshtml`
+
+- [ ] **Step 1: Write partial** — accepts a tuple `(IReadOnlyList<DashboardTrendPoint> Points, TrendWindow Window)`. Render a `<canvas id="dashboardTrendsChart">` and a window-toggle `<div>` with four `<a asp-action="Index" asp-route-trendWindow="...">` buttons. Each button gets `btn btn-outline-secondary` or `btn btn-primary active` depending on current window.
+
+- [ ] **Step 2: Chart.js init script** at the bottom of the partial inside `<script>`. Three datasets: new signups, new ticket sales, DAU. Tooltip callback explains DAU limitation.
+
+### Task 4.5: Wire partials into `Index.cshtml`
+
+**Files:**
+- Modify: `src/Humans.Web/Views/ShiftDashboard/Index.cshtml`
+
+- [ ] **Step 1: Insert partials** between the filter bar and the existing staffing charts:
+
+```razor
+@if (Model.Overview is not null)
+{
+    @await Html.PartialAsync("_OverviewCounters", Model.Overview)
+    @await Html.PartialAsync("_DepartmentsTable", Model.Overview.Departments)
+}
+@await Html.PartialAsync("_CoordinatorActivity", Model.CoordinatorActivity)
+@await Html.PartialAsync("_TrendsChart", (Model.Trends, Model.TrendWindow))
+```
+
+- [ ] **Step 2: Run site locally** — `dotnet run --project src/Humans.Web`. Visit dashboard, verify markup renders without JS errors (empty state acceptable pre-seed). Stop the dev server.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/Humans.Web/Views/ShiftDashboard/
+git commit -m "Render dashboard overview, departments, activity, trends partials"
+```
+
+### Task 4.6: Add localization strings
+
+**Files:**
+- Modify: `src/Humans.Web/Resources/SharedResource.resx` + `.es.resx`, `.de.resx`, `.fr.resx`, `.it.resx`, `.ca.resx`
+
+- [ ] **Step 1: Add keys** for each user-facing string added to the partials (e.g. `ShiftDash_Overview_ShiftsFilled`, `ShiftDash_Overview_TicketHoldersEngaged`, `ShiftDash_Overview_StalePending`, `ShiftDash_Departments_Title`, `ShiftDash_Coordinators_Title`, `ShiftDash_Trends_Title`, window labels). Use "humans" not "users/members/volunteers"; "humans" stays English in every locale.
+
+- [ ] **Step 2: Rebuild, commit**
+
+```bash
+git add src/Humans.Web/Resources/
+git commit -m "Add i18n strings for dashboard panels"
+```
+
+---
+
+## Chunk 5: Seeder + dev endpoint
+
+### Task 5.1: Write `DevelopmentDashboardSeeder`
+
+**Files:**
+- Create: `src/Humans.Web/Infrastructure/DevelopmentDashboardSeeder.cs`
+
+- [ ] **Step 1: Class shell with `HumansDbContext` + `IClock` + `UserManager<User>` + logger injection.** Add `public async Task<DashboardSeedResult> SeedAsync(CancellationToken ct)`.
+
+- [ ] **Step 2: Idempotency guard** — look for `EventSettings.Name == "Seeded Nowhere 2026 (dev)"`. If exists, return early with a message.
+
+- [ ] **Step 3: Create `EventSettings`** — `GateOpeningDate = today + 60 days`, `BuildStartOffset = -14`, `EventEndOffset = 6`, `StrikeEndOffset = 9`, `IsActive = true`, `Name = "Seeded Nowhere 2026 (dev)"`.
+
+- [ ] **Step 4: Create 6 parent teams** (Gate, Infrastructure, Kitchen, Medics, Rangers, DPW) if missing.
+
+- [ ] **Step 5: Create Infrastructure's two subteams** — Power + Plumbing (`ParentTeamId = Infrastructure.Id`).
+
+- [ ] **Step 6: Create rotas** — 3 per parent (one per period) + 1 per Infrastructure subteam (Event period on Power, Event period on Plumbing).
+
+- [ ] **Step 7: Create shifts** — 8–12 per rota, mixed `MinVolunteers` / `MaxVolunteers` (2–8) and `DurationHours` (2–8).
+
+- [ ] **Step 8: Create ~400 users** with profiles. ~300 with matched paid `TicketOrder`, ~30 ticket-less with profile, ~70 baseline.
+
+- [ ] **Step 9: Assign coordinators** — Infrastructure gets 2 coordinators with `LastLoginAt = now - 9 days`; other departments' coordinators within 48h.
+
+- [ ] **Step 10: Create signups** — Gate/Kitchen ≥85% confirmed, Strike rotas ~20% confirmed, Power subteam ~85%, Plumbing subteam ~40%, ~15 pending older than 3 days, a handful of Bailed / Refused.
+
+- [ ] **Step 11: Spread `LastLoginAt` across 30 days** for DAU shape.
+
+- [ ] **Step 12: SaveChangesAsync; return result record.**
+
+### Task 5.2: Register seeder + add controller endpoint
+
+**Files:**
+- Modify: `src/Humans.Web/Program.cs`
+- Modify: `src/Humans.Web/Controllers/DevSeedController.cs`
+
+- [ ] **Step 1: `builder.Services.AddScoped<DevelopmentDashboardSeeder>();`** in Program.cs.
+
+- [ ] **Step 2: Add action**:
+
+```csharp
+[Authorize(Policy = PolicyNames.ShiftDashboardAccess)]
+[HttpPost("dashboard")]
+[ValidateAntiForgeryToken]
+public async Task<IActionResult> SeedDashboard(CancellationToken ct)
+{
+    if (!_environment.IsDevelopment()) return NotFound();
+    if (!IsDevAuthEnabled()) return NotFound();
+    var (error, user) = await RequireCurrentUserAsync();
+    if (error is not null) return error;
+
+    var seeder = _serviceProvider.GetRequiredService<DevelopmentDashboardSeeder>();
+    var result = await seeder.SeedAsync(ct);
+    SetSuccess($"Dashboard seed complete: {result}");
+    return RedirectToAction("Index", "ShiftDashboard");
+}
+```
+
+Extract a `IsDevAuthEnabled()` helper that mirrors the config check used by `IsDevSeedEnabled` but is callable alongside the stricter `IsDevelopment()` gate.
+
+- [ ] **Step 3: Add a seed button** on `/Shifts/Dashboard` visible only when `env.IsDevelopment()` (pass a flag via ViewData). Form POSTs to `/dev/seed/dashboard`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Humans.Web/Infrastructure/DevelopmentDashboardSeeder.cs \
+        src/Humans.Web/Controllers/DevSeedController.cs \
+        src/Humans.Web/Program.cs \
+        src/Humans.Web/Views/ShiftDashboard/Index.cshtml
+git commit -m "Add DevelopmentDashboardSeeder and /dev/seed/dashboard endpoint"
+```
+
+---
+
+## Chunk 6: Docs + manual verification
+
+### Task 6.1: Update feature doc
+
+**Files:**
+- Modify: `docs/features/25-shift-management.md`
+
+- [ ] **Step 1: Append a "Coordinator Dashboard" section** with: purpose, metric definitions, subgroup rules, authorization, caching notes.
+
+### Task 6.2: Update section invariants
+
+**Files:**
+- Modify: `docs/sections/Shifts.md`
+
+- [ ] **Step 1: Add invariants**:
+  - "All dashboard methods on `IShiftManagementService` require `ShiftDashboardAccess` policy at the controller; the service itself is auth-free per design rules."
+  - "`DevelopmentDashboardSeeder` is gated to `IsDevelopment()` only; QA/preview/prod cannot run it."
+
+### Task 6.3: Commit docs
+
+- [ ] **Step 1:**
+
+```bash
+git add docs/features/25-shift-management.md docs/sections/Shifts.md
+git commit -m "Document coordinator dashboard feature and section invariants"
+```
+
+### Task 6.4: Manual verification
+
+- [ ] **Step 1: Launch** — `dotnet run --project src/Humans.Web`.
+
+- [ ] **Step 2: Dev-login as Admin.**
+
+- [ ] **Step 3: Click seed button** on `/Shifts/Dashboard`.
+
+- [ ] **Step 4: Verify**:
+  - Five counter cards populated (non-zero)
+  - Infrastructure's row visible; expand shows "Direct" + Plumbing (top, low %) + Power
+  - Gate row expands into three period rows
+  - Coordinator activity row for Infrastructure shows red 9-days-ago
+  - Trend chart populated; toggling 7/30/90/All updates the chart
+  - Non-coordinator login gets 403 on the page
+
+- [ ] **Step 5: Check build + tests final time** — `dotnet build Humans.slnx && dotnet test Humans.slnx`. Expected: all PASS, no new warnings.
+
+---
+
+## Execution handoff
+
+Plan complete. This session executes the plan directly using superpowers:executing-plans (single-session batched execution with TDD discipline).

--- a/docs/superpowers/specs/2026-04-19-volunteer-coordinator-dashboard-design.md
+++ b/docs/superpowers/specs/2026-04-19-volunteer-coordinator-dashboard-design.md
@@ -1,0 +1,309 @@
+# Volunteer Coordinator Dashboard — Design
+
+**Date:** 2026-04-19
+**Status:** Draft
+**Owner:** Frank
+**Scope:** Extend `/Shifts/Dashboard` with ticket-aware engagement counters, a per-department staffing table with per-period drill-down, a coordinator activity table, and a trend chart. Ship as a single PR. Include a local-only seed endpoint for manual verification.
+
+## 1. Purpose & audience
+
+The Volunteer Coordinator (plus Admin / NoInfoAdmin, per the existing `ShiftDashboardAccess` policy) is responsible for making sure every department's shifts get filled and that enough volunteers actually show up. The existing `/Shifts/Dashboard` surfaces urgent shifts and staffing charts, but it does not answer the coordinator's weekly questions:
+
+- How close are we to fully staffing each period (Build / Event / Strike) across the org?
+- Which ticket holders have not yet signed up — i.e., who should we reach out to?
+- Are team coordinators actually logging in to approve pending signups?
+- Do our engagement efforts (newsletters, announcements) actually move signups?
+
+This dashboard extends the existing page with new panels that answer those questions directly.
+
+## 2. Scope
+
+**In scope (single PR):**
+
+- New Overview panel with five counter cards
+- New Departments table (all parent departments in the event, sorted by lowest % filled first) with expandable rows that unfold either subteams (when the department has subteam rotas) or per-period breakdown (when it does not)
+- New Coordinator activity table (only teams with ≥1 pending signup, sorted by staleness)
+- New Trends line chart (daily shift signups, daily ticket sales, daily active users) with a 7/30/90/all window toggle
+- New `DevelopmentDashboardSeeder` and `POST /dev/seed/dashboard` endpoint, gated to `ASPNETCORE_ENVIRONMENT=Development` only
+- Unit tests for the new service methods
+- Feature-doc update in `docs/features/25-shift-management.md`
+- Section invariant update in `docs/sections/Shifts.md`
+
+**Out of scope (explicit non-goals):**
+
+- No-show rate and bail rate (deferred — user requested for later)
+- Per-event comparison / multi-event analytics
+- Historical DAU beyond the most-recent login (would require an event log — out of scope)
+- Hours-committed / over-committed-volunteer views
+- Tag-coverage breakdown
+- Configurable thresholds for stale-pending (hard-coded to 3 days)
+- Per-coordinator drill-through pages
+- CSV export
+
+## 3. Architecture
+
+Clean Architecture, same layering as the rest of the app.
+
+### 3.1 New / modified files
+
+| Layer | File | Change |
+|---|---|---|
+| Application | `src/Humans.Application/DTOs/DashboardOverview.cs` | New record |
+| Application | `src/Humans.Application/DTOs/DepartmentStaffingRow.cs` | New record |
+| Application | `src/Humans.Application/DTOs/CoordinatorActivityRow.cs` | New record |
+| Application | `src/Humans.Application/DTOs/DashboardTrendPoint.cs` | New record |
+| Application | `src/Humans.Application/Interfaces/IShiftManagementService.cs` | Add 3 methods |
+| Infrastructure | `src/Humans.Infrastructure/Services/ShiftManagementService.cs` | Implement 3 methods + cache invalidation on signup mutations |
+| Web | `src/Humans.Web/Models/ShiftViewModels.cs` | Extend `ShiftDashboardViewModel` |
+| Web | `src/Humans.Web/Controllers/ShiftDashboardController.cs` | Call new service methods, accept `?trendWindow=` query param |
+| Web | `src/Humans.Web/Views/ShiftDashboard/Index.cshtml` | Render new panels above existing content |
+| Web | `src/Humans.Web/Views/ShiftDashboard/_OverviewCounters.cshtml` | New partial |
+| Web | `src/Humans.Web/Views/ShiftDashboard/_DepartmentsTable.cshtml` | New partial |
+| Web | `src/Humans.Web/Views/ShiftDashboard/_CoordinatorActivity.cshtml` | New partial |
+| Web | `src/Humans.Web/Views/ShiftDashboard/_TrendsChart.cshtml` | New partial |
+| Web | `src/Humans.Web/Controllers/DevSeedController.cs` | Add `SeedDashboard` action with stricter gate |
+| Web | `src/Humans.Web/Infrastructure/DevelopmentDashboardSeeder.cs` | New seeder class |
+| Tests | `tests/Humans.Application.Tests/Services/ShiftDashboardMetricsTests.cs` | New test file |
+| Docs | `docs/features/25-shift-management.md` | Append "Coordinator Dashboard" section |
+| Docs | `docs/sections/Shifts.md` | New invariant: dashboard methods require `ShiftDashboardAccess` policy |
+
+### 3.2 Service contract
+
+New methods on `IShiftManagementService`:
+
+```csharp
+Task<DashboardOverview> GetDashboardOverviewAsync(Guid eventSettingsId);
+Task<IReadOnlyList<CoordinatorActivityRow>> GetCoordinatorActivityAsync(Guid eventSettingsId);
+Task<IReadOnlyList<DashboardTrendPoint>> GetDashboardTrendsAsync(Guid eventSettingsId, TrendWindow window);
+```
+
+New enum:
+
+```csharp
+public enum TrendWindow { Last7Days, Last30Days, Last90Days, All }
+```
+
+### 3.3 DTO shapes
+
+```csharp
+public record DashboardOverview(
+    int TotalShifts,
+    int FilledShifts,
+    PeriodBreakdown PeriodFillRates,
+    int TicketHolderCount,
+    int TicketHoldersEngaged,
+    int NonTicketSignups,
+    int StalePendingCount,
+    IReadOnlyList<DepartmentStaffingRow> Departments);
+
+public record PeriodBreakdown(double BuildPct, double EventPct, double StrikePct);
+
+public record DepartmentStaffingRow(
+    Guid DepartmentId,
+    string DepartmentName,
+    int TotalShifts,
+    int FilledShifts,
+    int SlotsRemaining,
+    PeriodStaffing Build,
+    PeriodStaffing Event,
+    PeriodStaffing Strike,
+    IReadOnlyList<SubgroupStaffingRow> Subgroups);
+
+public record SubgroupStaffingRow(
+    Guid? TeamId,
+    string Name,
+    bool IsDirect,
+    int TotalShifts,
+    int FilledShifts,
+    int SlotsRemaining,
+    PeriodStaffing Build,
+    PeriodStaffing Event,
+    PeriodStaffing Strike);
+
+public record PeriodStaffing(int Total, int Filled, int SlotsRemaining);
+
+public record CoordinatorActivityRow(
+    Guid TeamId,
+    string TeamName,
+    IReadOnlyList<CoordinatorLogin> Coordinators,
+    int PendingSignupCount);
+
+public record CoordinatorLogin(Guid UserId, string DisplayName, Instant? LastLoginAt);
+
+public record DashboardTrendPoint(
+    LocalDate Date,
+    int NewSignups,
+    int NewTicketSales,
+    int DistinctLogins);
+```
+
+## 4. Metric definitions (authoritative)
+
+These definitions are load-bearing — the unit tests pin them down and the implementation must match.
+
+- **Event scope.** All counts and tables are scoped to a single `EventSettings` (the one the existing dashboard already resolves).
+- **Shift inclusion filter.** A shift is included iff `!shift.AdminOnly` **and** `shift.Rota.IsVisibleToVolunteers`. This matches the existing browse-surface definition so the dashboard reflects what volunteers actually see.
+- **Filled shift.** `COUNT(confirmed signups) >= shift.MinVolunteers`. Confirmed = `SignupStatus.Confirmed`. Pending signups are *not* counted toward filled.
+- **Ticket holder.** A `User` with at least one `TicketOrder` where `PaymentStatus = Paid` and `MatchedUserId = user.Id`. Multiple orders for the same user still count as one ticket holder.
+- **Engaged ticket holder.** Ticket holder with ≥1 `ShiftSignup` in the event (any status except `Cancelled`).
+- **Non-ticket signup.** User with ≥1 `ShiftSignup` in the event (any status except `Cancelled`) AND zero paid `TicketOrder`s matched to them.
+- **Stale pending.** `ShiftSignup` where `Status = Pending` and `CreatedAt < now - 3 days` and the shift belongs to the event.
+- **Coordinator.** A `TeamMember` with `Role = Coordinator` on the team. A team may have multiple coordinators.
+- **Coordinator activity row inclusion.** A team appears iff it has ≥1 pending signup on a shift in the event. Teams with zero pending are hidden (they do not need attention). Rows sort by oldest coordinator `LastLoginAt` first, breaking ties by team name.
+- **Period.** Uses the existing `Shift.GetShiftPeriod(EventSettings)` function, which returns `ShiftPeriod.Build`, `.Event`, or `.Strike` based on `DayOffset` vs `GateOpeningDate`, `EventEndOffset`, `StrikeEndOffset`.
+- **Department.** A *department* is a top-level team (`ParentTeamId == null`). Rotas attached directly to a department contribute to the department row. Rotas attached to a subteam (`ParentTeamId == department.Id`) also contribute to the parent department row but are additionally surfaced as subgroups.
+- **Subgroup inclusion.** A department shows subgroup rows iff at least one of its subteams has ≥1 rota in the event. The subgroup list contains one row per subteam-with-rotas plus a "Direct" row for the department's own direct rotas (if any). If no subteam has rotas, `Subgroups` is empty and the UI falls back to per-period expansion.
+- **Subgroup ordering.** Sort subgroups by fill % ascending; ties broken by name. The "Direct" subgroup, if present, is pinned at the top regardless of its fill %.
+- **Subgroup totals.** A subgroup's `TotalShifts` / `FilledShifts` / `SlotsRemaining` / `PeriodStaffing` values sum to the parent department's aggregate (invariant asserted by tests).
+- **Trend buckets.** Days are local dates in `EventSettings.TimeZoneId`. A bucket exists for every day in the window even if counts are 0.
+  - **NewSignups:** count of `ShiftSignup` rows created that day for shifts in this event.
+  - **NewTicketSales:** count of `TicketOrder` rows with `PurchasedAt` that day, `PaymentStatus = Paid`. Not filtered by `VendorEventId` in v1 — we treat any paid order in the window as a ticket sale signal. (Future multi-event may need to scope this.)
+  - **DistinctLogins (DAU).** Count of users whose `LastLoginAt` falls on that day. **Limitation:** `User.LastLoginAt` holds only the *most recent* login per user, so buckets older than ~24h will undercount as users log in again. This is documented in the chart legend tooltip. Acceptable for v1; a proper daily-active metric would need a login-event log which is out of scope.
+
+## 5. Caching & performance
+
+At ~500-user scale every query is trivially fast, but the trend query GROUPs by day across months of data so it is the worst offender.
+
+- `IMemoryCache` with 5-minute sliding TTL.
+- Cache keys:
+  - `dashboard-overview:{eventId}`
+  - `dashboard-coordinator-activity:{eventId}`
+  - `dashboard-trends:{eventId}:{window}`
+- On any `ShiftSignup` create / state transition, invalidate overview + coordinator-activity keys for the event. Trend key is cheaper to leave stale — new signups only matter for today's bucket, which recomputes on the next TTL expiry.
+- No concurrency tokens, no row versioning (per CLAUDE.md rules).
+
+## 6. UI layout
+
+Dashboard view (`/Shifts/Dashboard`) renders, top to bottom:
+
+1. **Overview counters** — 5 cards in a responsive grid:
+   - *Shifts filled* — `312 / 487 (64%)` plus three period chips (Build / Event / Strike) color-coded by threshold (≥80% green, 60–79% amber, <60% red).
+   - *Ticket holders* — raw count.
+   - *Ticket holders engaged* — `X / Y (Z%)` with sub-line `"N ticket holders haven't signed up"`. Visually emphasised as the primary outreach metric.
+   - *Non-ticket signups* — count, sub-line `"signed up without a ticket (yet)"`.
+   - *Stale pending* — count, sub-line `"pending > 3 days"`.
+2. **Departments** — table sorted by lowest fill % first. Each main row shows department · total · filled · % · slots remaining. A chevron toggles an expanded area:
+   - If the department has one or more subteams with ≥1 rota, the expansion shows **one row per subgroup** (the department's own direct rotas as a "Direct" row, if any, plus one row per subteam). Each subgroup row shows name · total · filled · % · slots remaining · compact Build/Event/Strike % chips.
+   - If the department has no subteam rotas, the expansion shows the original three period rows (Build / Event / Strike) with their own totals/%.
+   - Subgroups are sorted lowest fill % first; the "Direct" row (if present) is always pinned to the top.
+   - Expand state is client-side only (no persistence).
+3. **Coordinator activity** — table of teams with ≥1 pending signup. Columns: team · coordinator names · last login relative time · pending count. Logins older than 7 days render red.
+4. **Trends** — Chart.js line chart with three series (new signups, new ticket sales, DAU) and a window toggle (7 / 30 / 90 / all). Default window = 30.
+5. **Existing panels** — urgent shifts, staffing by day, staffing hours by priority — unchanged, below the new content.
+
+Bootstrap 5.3 for layout, Chart.js 4.5 for the trend chart (already CDN-loaded in `_Layout.cshtml`). No new third-party dependencies.
+
+### 6.1 Text & i18n
+
+All user-facing text uses **"humans"** not "users"/"members" (per CLAUDE.md). New strings go into `SharedResource.resx` plus each locale file (`.es.resx`, `.de.resx`, `.fr.resx`, `.it.resx`, `.ca.resx`). "Humans" stays untranslated across all locales.
+
+### 6.2 Nav
+
+No new top-nav link is required — the existing "Shifts Dashboard" access path continues to serve. This satisfies the "no orphan pages" rule.
+
+### 6.3 Authorization
+
+Unchanged from current state: `[Authorize(Policy = PolicyNames.ShiftDashboardAccess)]` on the controller action → Admin, NoInfoAdmin, VolunteerCoordinator only.
+
+## 7. Seed data (`DevelopmentDashboardSeeder`)
+
+New endpoint: `POST /dev/seed/dashboard` on `DevSeedController`.
+
+**Gate — stricter than existing `/dev/seed/*`:**
+
+```csharp
+if (!_environment.IsDevelopment()) return NotFound();
+if (!DevAuthEnabled) return NotFound();
+```
+
+Rationale: the existing endpoints run on any non-production env with DevAuth enabled (so QA + preview envs can seed budget data). The dashboard seed is explicitly local-only — `IsDevelopment()` is true only when `ASPNETCORE_ENVIRONMENT=Development`, which is the default for `dotnet run` and is not set on QA / preview / prod.
+
+**Produced data (idempotent):**
+
+- One `EventSettings` if none exists; otherwise use the current one. Gate opening 60 days in the future.
+- 6 parent teams if missing: Gate, Infrastructure, Kitchen, Medics, Rangers, DPW.
+- Subteams under Infrastructure: *Power* and *Plumbing* (exercises subteam unfolding). Other departments remain flat to exercise the per-period fallback expansion.
+- 3 rotas per parent team — one per period, tagged + prioritised realistically.
+- Infrastructure subteams each get 1–2 rotas of their own (in addition to Infrastructure's own direct rotas), so the parent row has a "Direct" subgroup plus two subteam subgroups.
+- 8–12 shifts per rota with varied `MinVolunteers` / `MaxVolunteers` (2–8) and `Duration` (2–8h).
+- ~400 `User`s with profiles:
+  - ~300 with a paid `TicketOrder` matched.
+  - ~30 without a ticket but with a profile (the "intend to attend" cohort).
+  - ~70 with neither ticket nor signups (outreach-candidate baseline).
+- Coordinators assigned — Infrastructure's two coordinators get `LastLoginAt` 9 days ago (exercises the red staleness warning); the rest within the last 48h.
+- `ShiftSignup`s:
+  - Gate & Kitchen land ≥85% Confirmed.
+  - Strike-period rotas stay around 20% Confirmed.
+  - Infrastructure/Power subteam lands ~85% Confirmed; Infrastructure/Plumbing subteam around 40% Confirmed (so subteam rows sort with Plumbing at the top of the expansion).
+  - ~15 Pending signups older than 3 days (fires the stale-pending counter).
+  - A few Bailed / Refused to exercise filters.
+- `LastLoginAt` spread across the last 30 days for DAU shape.
+
+**Idempotency marker:** the seeder sets `EventSettings.Name = "Seeded Nowhere 2026 (dev)"` and inspects it on re-run; if present, the operation is a no-op that returns a message.
+
+**Teardown:** no dedicated endpoint. Local devs drop and recreate the database when they want a clean slate.
+
+## 8. Testing
+
+### 8.1 Unit tests (`ShiftDashboardMetricsTests`)
+
+EF in-memory DB, same shape as the existing `ShiftUrgencyTests`. Cover:
+
+- Counter totals including edge cases: zero shifts, zero signups, zero ticket holders
+- Filled-shift threshold: `MinVolunteers - 1` confirmed → not filled; `MinVolunteers` confirmed → filled; `MinVolunteers + 1` confirmed → still filled
+- Period breakdown: shifts split correctly across Build / Event / Strike using `DayOffset` boundaries from `EventSettings`
+- Ticket-holder classification: user with paid order = ticket holder; user with only refunded order = not; user with multiple paid orders counts once
+- Engaged-ticket-holder: ticket holder with `Cancelled`-only signups is *not* engaged
+- Non-ticket-signup: user with signups but no paid order counted; user with signups and a paid order not counted
+- Stale-pending: signup created exactly 3 days ago → not stale; 3 days + 1 minute → stale; status = Confirmed → never stale regardless of age
+- Coordinator activity: team with zero pending signups excluded; team with multiple coordinators lists all; row ordering by oldest login first
+- Trend bucketing: zero-count days present in the range; window boundaries inclusive on start, exclusive on end+1; trend respects `EventSettings.TimeZoneId`
+- TrendWindow.All uses event creation date as the start
+- Subgroup computation: department with zero subteam rotas yields empty `Subgroups`; department with subteam rotas + direct rotas yields one "Direct" row plus one row per subteam with rotas; subteam with no rotas is omitted
+- Subgroup aggregation invariant: sum of subgroup `TotalShifts`, `FilledShifts`, `SlotsRemaining`, and per-period counters equals the parent department's totals
+- Subgroup ordering: "Direct" pinned top; remaining rows sorted by fill % ascending with name tiebreak
+
+### 8.2 Manual test plan (included in PR description)
+
+1. `dotnet run --project src/Humans.Web` against a clean dev DB.
+2. Log in as Admin via dev login.
+3. `curl -X POST http://localhost:5xxx/dev/seed/dashboard` (with antiforgery) or click the seed button.
+4. Visit `/Shifts/Dashboard`:
+   - Verify 5 counter cards render with non-zero values matching seeder expectations.
+   - Verify Infrastructure's strike column is the lowest % (designed-in).
+   - Click Infrastructure row — subgroup rows appear: a "Direct" row plus Power and Plumbing subteam rows, with Plumbing at the top (lowest fill %).
+   - Click Gate row (no subteams) — three period rows appear (Build / Event / Strike), confirming the fallback expansion.
+   - Verify Coordinator activity shows Infrastructure with red "9 days ago".
+   - Toggle trend window 7 / 30 / 90 / all — chart updates without errors.
+5. Log out, log in as a plain volunteer — verify `/Shifts/Dashboard` returns 403 / NotFound.
+6. Rebuild with `ASPNETCORE_ENVIRONMENT=Production` locally and verify `POST /dev/seed/dashboard` returns 404.
+7. Screenshots of final state attached to PR.
+
+### 8.3 Automated verification before commit
+
+- `dotnet build Humans.slnx` passes with no new warnings.
+- `dotnet test Humans.slnx` passes.
+- No new EF migration files appear in the diff (sanity check).
+
+## 9. Risks & open questions
+
+- **DAU accuracy.** `LastLoginAt` only captures the most recent login, so historical days undercount. Documented in the chart tooltip; acceptable for v1.
+- **Ticket order event scoping.** `TicketOrder.VendorEventId` exists but is not enforced in v1 — we treat any paid order as a ticket. If the nonprofit starts selling tickets for multiple events concurrently, the "ticket holders" count will conflate them. Out of scope; flagged for future work.
+- **Performance edge case.** A ~10,000-signup event with a 90-day trend window would GROUP BY up to 90 buckets across ~10k rows. Still sub-second in Postgres at this scale, but if the org ever grows past current expectations, consider materialising a daily-stats table.
+- **Team hierarchy.** Dashboard rows are parent departments. Subteams with rotas surface inside the expansion of their parent's row (see §4 "Subgroup inclusion"). Only one level of hierarchy exists in the data model (`Team.ParentTeamId` is at most one hop deep), so the expansion is flat — no recursive nesting.
+
+## 10. Git plan
+
+- Branch: `feat/volunteer-coordinator-dashboard` off `origin/main` (peter's fork).
+- Single PR to peter's `main`. Coolify opens a preview env at `{pr_id}.n.burn.camp` with dev login enabled.
+- PR description links this spec.
+- Squash merge on approval.
+- Production promotion handled later as a batched rebase-merge to `upstream/main`.
+
+## 11. Follow-ups (not this PR)
+
+- No-show rate + bail rate counters
+- Per-coordinator drill-through page
+- Cross-event comparison
+- Tag-coverage panel
+- CSV export of the outreach-candidate list (ticket holders with no signup)

--- a/src/Humans.Application/DTOs/DashboardOverview.cs
+++ b/src/Humans.Application/DTOs/DashboardOverview.cs
@@ -1,0 +1,53 @@
+using NodaTime;
+
+namespace Humans.Application.DTOs;
+
+public record DashboardOverview(
+    int TotalShifts,
+    int FilledShifts,
+    PeriodBreakdown PeriodFillRates,
+    int TicketHolderCount,
+    int TicketHoldersEngaged,
+    int NonTicketSignups,
+    int StalePendingCount,
+    IReadOnlyList<DepartmentStaffingRow> Departments);
+
+public record PeriodBreakdown(double BuildPct, double EventPct, double StrikePct);
+
+public record DepartmentStaffingRow(
+    Guid DepartmentId,
+    string DepartmentName,
+    int TotalShifts,
+    int FilledShifts,
+    int SlotsRemaining,
+    PeriodStaffing Build,
+    PeriodStaffing Event,
+    PeriodStaffing Strike,
+    IReadOnlyList<SubgroupStaffingRow> Subgroups);
+
+public record SubgroupStaffingRow(
+    Guid? TeamId,
+    string Name,
+    bool IsDirect,
+    int TotalShifts,
+    int FilledShifts,
+    int SlotsRemaining,
+    PeriodStaffing Build,
+    PeriodStaffing Event,
+    PeriodStaffing Strike);
+
+public record PeriodStaffing(int Total, int Filled, int SlotsRemaining);
+
+public record CoordinatorActivityRow(
+    Guid TeamId,
+    string TeamName,
+    IReadOnlyList<CoordinatorLogin> Coordinators,
+    int PendingSignupCount);
+
+public record CoordinatorLogin(Guid UserId, string DisplayName, Instant? LastLoginAt);
+
+public record DashboardTrendPoint(
+    LocalDate Date,
+    int NewSignups,
+    int NewTicketSales,
+    int DistinctLogins);

--- a/src/Humans.Application/DTOs/DashboardOverview.cs
+++ b/src/Humans.Application/DTOs/DashboardOverview.cs
@@ -42,7 +42,9 @@ public record CoordinatorActivityRow(
     Guid TeamId,
     string TeamName,
     IReadOnlyList<CoordinatorLogin> Coordinators,
-    int PendingSignupCount);
+    int PendingSignupCount,
+    int AggregatePendingCount,
+    IReadOnlyList<CoordinatorActivityRow> Subgroups);
 
 public record CoordinatorLogin(Guid UserId, string DisplayName, Instant? LastLoginAt);
 

--- a/src/Humans.Application/Enums/TrendWindow.cs
+++ b/src/Humans.Application/Enums/TrendWindow.cs
@@ -1,0 +1,9 @@
+namespace Humans.Application.Enums;
+
+public enum TrendWindow
+{
+    Last7Days,
+    Last30Days,
+    Last90Days,
+    All
+}

--- a/src/Humans.Application/Interfaces/IShiftManagementService.cs
+++ b/src/Humans.Application/Interfaces/IShiftManagementService.cs
@@ -1,3 +1,5 @@
+using Humans.Application.DTOs;
+using Humans.Application.Enums;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using NodaTime;
@@ -198,6 +200,23 @@ public interface IShiftManagementService
     /// </summary>
     Task<IReadOnlyList<(Guid TeamId, string TeamName)>> GetDepartmentsWithRotasAsync(
         Guid eventSettingsId);
+
+    // === Coordinator Dashboard ===
+
+    /// <summary>
+    /// Gets the full coordinator-dashboard overview (counters + per-department staffing rows with subgroup drill-down).
+    /// </summary>
+    Task<DashboardOverview> GetDashboardOverviewAsync(Guid eventSettingsId);
+
+    /// <summary>
+    /// Gets per-team coordinator activity, scoped to teams with at least one pending signup.
+    /// </summary>
+    Task<IReadOnlyList<CoordinatorActivityRow>> GetCoordinatorActivityAsync(Guid eventSettingsId);
+
+    /// <summary>
+    /// Gets daily trend points (signups, ticket sales, distinct logins) for the window.
+    /// </summary>
+    Task<IReadOnlyList<DashboardTrendPoint>> GetDashboardTrendsAsync(Guid eventSettingsId, TrendWindow window);
 
     // === Shift Tags ===
 

--- a/src/Humans.Application/Interfaces/IShiftManagementService.cs
+++ b/src/Humans.Application/Interfaces/IShiftManagementService.cs
@@ -151,7 +151,7 @@ public interface IShiftManagementService
     /// </summary>
     Task<IReadOnlyList<UrgentShift>> GetUrgentShiftsAsync(
         Guid eventSettingsId, int? limit = null,
-        Guid? departmentId = null, LocalDate? date = null);
+        Guid? departmentId = null, LocalDate? date = null, ShiftPeriod? period = null);
 
     /// <summary>
     /// Gets all active shifts for browse page, with optional filtering. Includes full shifts.
@@ -174,14 +174,14 @@ public interface IShiftManagementService
     /// Gets per-day staffing data for all periods (set-up, event, strike).
     /// </summary>
     Task<IReadOnlyList<DailyStaffingData>> GetStaffingDataAsync(
-        Guid eventSettingsId, Guid? departmentId = null);
+        Guid eventSettingsId, Guid? departmentId = null, ShiftPeriod? period = null);
 
     /// <summary>
     /// Gets per-day staffing hours across all periods, grouped by shift priority.
     /// Hours = shift duration × MaxVolunteers. All-day shifts count as 8 hours per slot.
     /// </summary>
     Task<IReadOnlyList<DailyStaffingHours>> GetStaffingHoursAsync(
-        Guid eventSettingsId, Guid? departmentId = null);
+        Guid eventSettingsId, Guid? departmentId = null, ShiftPeriod? period = null);
 
     /// <summary>
     /// Gets shifts summary for a department. Returns null if no rotas.
@@ -206,17 +206,21 @@ public interface IShiftManagementService
     /// <summary>
     /// Gets the full coordinator-dashboard overview (counters + per-department staffing rows with subgroup drill-down).
     /// </summary>
-    Task<DashboardOverview> GetDashboardOverviewAsync(Guid eventSettingsId);
+    Task<DashboardOverview> GetDashboardOverviewAsync(Guid eventSettingsId, ShiftPeriod? period = null);
 
     /// <summary>
     /// Gets per-team coordinator activity, scoped to teams with at least one pending signup.
+    /// When <paramref name="period"/> is non-null, only signups on shifts in that period count.
     /// </summary>
-    Task<IReadOnlyList<CoordinatorActivityRow>> GetCoordinatorActivityAsync(Guid eventSettingsId);
+    Task<IReadOnlyList<CoordinatorActivityRow>> GetCoordinatorActivityAsync(Guid eventSettingsId, ShiftPeriod? period = null);
 
     /// <summary>
     /// Gets daily trend points (signups, ticket sales, distinct logins) for the window.
+    /// Ticket sales and logins are unaffected by <paramref name="period"/>; the signups
+    /// series is scoped to shifts in that period when non-null.
     /// </summary>
-    Task<IReadOnlyList<DashboardTrendPoint>> GetDashboardTrendsAsync(Guid eventSettingsId, TrendWindow window);
+    Task<IReadOnlyList<DashboardTrendPoint>> GetDashboardTrendsAsync(
+        Guid eventSettingsId, TrendWindow window, ShiftPeriod? period = null);
 
     // === Shift Tags ===
 

--- a/src/Humans.Application/Interfaces/ITeamService.cs
+++ b/src/Humans.Application/Interfaces/ITeamService.cs
@@ -112,6 +112,14 @@ public record AdminTeamListResult(
     int TotalCount);
 
 /// <summary>
+/// Flat projection of an active coordinator row — the user who holds the
+/// Coordinator membership role on a specific team. Used by cross-section
+/// callers (shift dashboard) that need per-team coordinator lists without
+/// joining across the Teams-owned tables themselves.
+/// </summary>
+public record TeamCoordinatorRef(Guid TeamId, Guid UserId);
+
+/// <summary>
 /// Service for managing teams and team membership.
 /// </summary>
 public interface ITeamService
@@ -499,6 +507,54 @@ public interface ITeamService
     /// </summary>
     Task EnqueueGoogleResyncForUserTeamsAsync(
         Guid userId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Loads the Team rows for the requested IDs <b>and</b> any referenced parent
+    /// teams, so the caller can resolve the "department" (parent or self) for each
+    /// team via dictionary lookups without navigating <c>team.ParentTeam</c>. Used
+    /// by the shift coordinator dashboard to stitch department rows in memory after
+    /// moving off a cross-domain <c>.Include(Rota).ThenInclude(Team).ThenInclude(ParentTeam)</c>
+    /// chain. Returned teams are not active-filtered — shifts/rotas may still
+    /// reference deactivated teams and the caller still needs the name.
+    /// </summary>
+    Task<IReadOnlyDictionary<Guid, Team>> GetByIdsWithParentsAsync(
+        IReadOnlyCollection<Guid> teamIds,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns one row per active (<see cref="TeamMember.LeftAt"/> is null) coordinator
+    /// across the requested teams. Used by the shift coordinator dashboard to look up
+    /// coordinators for teams with pending signups without reading the TeamMembers table.
+    /// </summary>
+    Task<IReadOnlyList<TeamCoordinatorRef>> GetActiveCoordinatorsForTeamsAsync(
+        IReadOnlyCollection<Guid> teamIds,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Adds a team member with an explicit <paramref name="role"/> and <paramref name="joinedAt"/>
+    /// timestamp, without emitting audit entries, outbox events, or user-facing emails. This is
+    /// a narrow seed/migration-only path; production membership changes must go through
+    /// <see cref="AddMemberToTeamAsync"/>, <see cref="ApproveJoinRequestAsync"/>, or the role
+    /// assignment APIs. Throws if the user is already an active member of the team.
+    /// </summary>
+    Task<TeamMember> AddSeededMemberAsync(
+        Guid teamId,
+        Guid userId,
+        TeamMemberRole role,
+        Instant joinedAt,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Hard-deletes every team whose <see cref="Team.Name"/> ends with
+    /// <paramref name="nameSuffix"/>, along with its <see cref="TeamMember"/> rows and
+    /// <see cref="TeamJoinRequest"/> rows. Narrow seed/test-only cleanup path that
+    /// bypasses <see cref="DeleteTeamAsync"/>'s soft-delete semantics so a subsequent
+    /// reseed can reuse the same slugs without collisions. Returns the number of teams
+    /// deleted.
+    /// </summary>
+    Task<int> HardDeleteSeededTeamsAsync(
+        string nameSuffix,
+        CancellationToken cancellationToken = default);
 
     // ==========================================================================
     // Cache Helpers

--- a/src/Humans.Application/Interfaces/ITicketQueryService.cs
+++ b/src/Humans.Application/Interfaces/ITicketQueryService.cs
@@ -139,6 +139,24 @@ public interface ITicketQueryService
     /// so GDPR exports stay stable after the service-ownership refactor.
     /// </summary>
     Task<UserTicketExportData> GetUserTicketExportDataAsync(Guid userId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns the distinct set of matched user IDs across paid ticket orders.
+    /// Used by the shift coordinator dashboard to compute ticket-holder engagement
+    /// counters without reading the tickets table directly.
+    /// </summary>
+    Task<IReadOnlyCollection<Guid>> GetMatchedUserIdsForPaidOrdersAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns the <c>PurchasedAt</c> timestamp of every paid ticket order that falls
+    /// within the half-open window <c>[fromInclusive, toExclusive)</c>. Used by the
+    /// shift coordinator dashboard to chart daily ticket sales without reading the
+    /// tickets table directly.
+    /// </summary>
+    Task<IReadOnlyList<Instant>> GetPaidOrderDatesInWindowAsync(
+        Instant fromInclusive,
+        Instant toExclusive,
+        CancellationToken ct = default);
 }
 
 /// <summary>

--- a/src/Humans.Application/Interfaces/IUserService.cs
+++ b/src/Humans.Application/Interfaces/IUserService.cs
@@ -116,4 +116,15 @@ public interface IUserService
     /// Ordered by CreatedAt descending.
     /// </summary>
     Task<IReadOnlyList<User>> GetContactUsersAsync(string? search, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns the <c>LastLoginAt</c> timestamp of every user whose last login falls
+    /// within the half-open window <c>[fromInclusive, toExclusive)</c>. Used by the
+    /// shift coordinator dashboard to chart distinct logins by day without reading
+    /// the users table directly.
+    /// </summary>
+    Task<IReadOnlyList<Instant>> GetLoginTimestampsInWindowAsync(
+        Instant fromInclusive,
+        Instant toExclusive,
+        CancellationToken ct = default);
 }

--- a/src/Humans.Infrastructure/Services/ShiftManagementService.cs
+++ b/src/Humans.Infrastructure/Services/ShiftManagementService.cs
@@ -1,3 +1,5 @@
+using Humans.Application.DTOs;
+using Humans.Application.Enums;
 using Humans.Application.Interfaces;
 using Humans.Application;
 using Humans.Domain.Constants;
@@ -867,6 +869,345 @@ public class ShiftManagementService : IShiftManagementService
             .ToListAsync();
 
         return teams.Select(x => (x.Id, x.Name)).ToList();
+    }
+
+    // ============================================================
+    // Coordinator Dashboard
+    // ============================================================
+
+    private static readonly TimeSpan DashboardCacheTtl = TimeSpan.FromMinutes(5);
+
+    internal static string OverviewCacheKey(Guid eventId) => $"dashboard-overview:{eventId}";
+    internal static string CoordinatorActivityCacheKey(Guid eventId) => $"dashboard-coordinator-activity:{eventId}";
+    internal static string TrendsCacheKey(Guid eventId, TrendWindow window) => $"dashboard-trends:{eventId}:{window}";
+
+    public async Task<DashboardOverview> GetDashboardOverviewAsync(Guid eventSettingsId)
+    {
+        var cached = await _cache.GetOrCreateAsync(OverviewCacheKey(eventSettingsId), async entry =>
+        {
+            entry.SlidingExpiration = DashboardCacheTtl;
+            return await ComputeDashboardOverviewAsync(eventSettingsId);
+        });
+        return cached!;
+    }
+
+    private async Task<DashboardOverview> ComputeDashboardOverviewAsync(Guid eventSettingsId)
+    {
+        var es = await _dbContext.EventSettings.AsNoTracking()
+            .FirstOrDefaultAsync(e => e.Id == eventSettingsId);
+        if (es is null)
+            return EmptyOverview();
+
+        var shifts = await _dbContext.Shifts.AsNoTracking()
+            .Include(s => s.Rota).ThenInclude(r => r.Team).ThenInclude(t => t.ParentTeam)
+            .Where(s => s.Rota.EventSettingsId == eventSettingsId
+                        && !s.AdminOnly
+                        && s.Rota.IsVisibleToVolunteers)
+            .ToListAsync();
+
+        var shiftIds = shifts.Select(s => s.Id).ToList();
+
+        var confirmedCounts = await _dbContext.ShiftSignups.AsNoTracking()
+            .Where(su => shiftIds.Contains(su.ShiftId) && su.Status == SignupStatus.Confirmed)
+            .GroupBy(su => su.ShiftId)
+            .Select(g => new { ShiftId = g.Key, Count = g.Count() })
+            .ToDictionaryAsync(x => x.ShiftId, x => x.Count);
+
+        int ConfirmedOn(Guid shiftId) => confirmedCounts.TryGetValue(shiftId, out var c) ? c : 0;
+        bool IsFilled(Shift s) => ConfirmedOn(s.Id) >= s.MinVolunteers;
+
+        var totalShifts = shifts.Count;
+        var filledShifts = shifts.Count(IsFilled);
+
+        PeriodBreakdown periodFillRates;
+        {
+            var perPeriod = shifts
+                .GroupBy(s => s.GetShiftPeriod(es))
+                .ToDictionary(g => g.Key, g => (Total: g.Count(), Filled: g.Count(IsFilled)));
+            periodFillRates = new PeriodBreakdown(
+                Pct(perPeriod, ShiftPeriod.Build),
+                Pct(perPeriod, ShiftPeriod.Event),
+                Pct(perPeriod, ShiftPeriod.Strike));
+        }
+
+        var ticketHolderIds = await _dbContext.TicketOrders.AsNoTracking()
+            .Where(o => o.PaymentStatus == TicketPaymentStatus.Paid && o.MatchedUserId != null)
+            .Select(o => o.MatchedUserId!.Value)
+            .Distinct()
+            .ToListAsync();
+        var ticketHolders = ticketHolderIds.ToHashSet();
+
+        var engagedUserIds = await _dbContext.ShiftSignups.AsNoTracking()
+            .Where(su => shiftIds.Contains(su.ShiftId) && su.Status != SignupStatus.Cancelled)
+            .Select(su => su.UserId)
+            .Distinct()
+            .ToListAsync();
+        var engaged = engagedUserIds.ToHashSet();
+
+        var ticketHoldersEngaged = engaged.Count(u => ticketHolders.Contains(u));
+        var nonTicketSignups = engaged.Count(u => !ticketHolders.Contains(u));
+
+        var staleThreshold = _clock.GetCurrentInstant().Minus(Duration.FromDays(3));
+        var stalePendingCount = await _dbContext.ShiftSignups.AsNoTracking()
+            .CountAsync(su => shiftIds.Contains(su.ShiftId)
+                              && su.Status == SignupStatus.Pending
+                              && su.CreatedAt < staleThreshold);
+
+        var departments = BuildDepartmentRows(shifts, confirmedCounts, es);
+
+        return new DashboardOverview(
+            totalShifts, filledShifts, periodFillRates,
+            ticketHolders.Count, ticketHoldersEngaged, nonTicketSignups, stalePendingCount,
+            departments);
+
+        static double Pct(Dictionary<ShiftPeriod, (int Total, int Filled)> perPeriod, ShiftPeriod p) =>
+            perPeriod.TryGetValue(p, out var v) && v.Total > 0
+                ? 100.0 * v.Filled / v.Total
+                : 0d;
+    }
+
+    private static DashboardOverview EmptyOverview() => new(
+        0, 0, new PeriodBreakdown(0, 0, 0), 0, 0, 0, 0, Array.Empty<DepartmentStaffingRow>());
+
+    private static List<DepartmentStaffingRow> BuildDepartmentRows(
+        List<Shift> shifts,
+        Dictionary<Guid, int> confirmedCounts,
+        EventSettings es)
+    {
+        // Group by department (parent team if exists, else own team).
+        var groups = shifts
+            .GroupBy(s => s.Rota.Team.ParentTeam ?? s.Rota.Team)
+            .ToList();
+
+        var rows = new List<DepartmentStaffingRow>();
+        foreach (var g in groups)
+        {
+            var dept = g.Key;
+            var deptShifts = g.ToList();
+            var agg = AggregateShifts(deptShifts, confirmedCounts, es);
+
+            // Subgroups: any shift belongs to a subteam?
+            var subgroups = new List<SubgroupStaffingRow>();
+            var anySubteam = deptShifts.Any(s => s.Rota.Team.ParentTeamId != null);
+            if (anySubteam)
+            {
+                // Per-subteam subgroups.
+                var subteamGroups = deptShifts
+                    .Where(s => s.Rota.Team.ParentTeamId != null)
+                    .GroupBy(s => s.Rota.Team);
+                foreach (var sg in subteamGroups)
+                {
+                    var sAgg = AggregateShifts(sg.ToList(), confirmedCounts, es);
+                    subgroups.Add(new SubgroupStaffingRow(
+                        sg.Key.Id, sg.Key.Name, IsDirect: false,
+                        sAgg.Total, sAgg.Filled, sAgg.Remaining,
+                        sAgg.Build, sAgg.Event, sAgg.Strike));
+                }
+
+                // "Direct" row for department's own rotas (if any).
+                var directShifts = deptShifts.Where(s => s.Rota.TeamId == dept.Id).ToList();
+                if (directShifts.Count > 0)
+                {
+                    var dAgg = AggregateShifts(directShifts, confirmedCounts, es);
+                    subgroups.Insert(0, new SubgroupStaffingRow(
+                        dept.Id, "Direct", IsDirect: true,
+                        dAgg.Total, dAgg.Filled, dAgg.Remaining,
+                        dAgg.Build, dAgg.Event, dAgg.Strike));
+                }
+
+                // Sort: Direct pinned top; rest by fill % ascending, ties by name.
+                subgroups = subgroups
+                    .OrderByDescending(r => r.IsDirect)
+                    .ThenBy(r => r.TotalShifts == 0 ? 0 : 100.0 * r.FilledShifts / r.TotalShifts)
+                    .ThenBy(r => r.Name, StringComparer.Ordinal)
+                    .ToList();
+            }
+
+            rows.Add(new DepartmentStaffingRow(
+                dept.Id, dept.Name,
+                agg.Total, agg.Filled, agg.Remaining,
+                agg.Build, agg.Event, agg.Strike,
+                subgroups));
+        }
+
+        return rows
+            .OrderBy(r => r.TotalShifts == 0 ? 0 : 100.0 * r.FilledShifts / r.TotalShifts)
+            .ThenBy(r => r.DepartmentName, StringComparer.Ordinal)
+            .ToList();
+    }
+
+    private static (int Total, int Filled, int Remaining, PeriodStaffing Build, PeriodStaffing Event, PeriodStaffing Strike)
+        AggregateShifts(List<Shift> shifts, Dictionary<Guid, int> confirmedCounts, EventSettings es)
+    {
+        int total = shifts.Count;
+        int filled = 0;
+        int remaining = 0;
+        var periodAgg = new Dictionary<ShiftPeriod, (int Total, int Filled, int Remaining)>
+        {
+            [ShiftPeriod.Build] = (0, 0, 0),
+            [ShiftPeriod.Event] = (0, 0, 0),
+            [ShiftPeriod.Strike] = (0, 0, 0),
+        };
+
+        foreach (var s in shifts)
+        {
+            var confirmed = confirmedCounts.TryGetValue(s.Id, out var c) ? c : 0;
+            var isFilled = confirmed >= s.MinVolunteers;
+            var slotsLeft = Math.Max(0, s.MaxVolunteers - confirmed);
+
+            if (isFilled) filled++;
+            remaining += slotsLeft;
+
+            var p = s.GetShiftPeriod(es);
+            var cur = periodAgg[p];
+            periodAgg[p] = (cur.Total + 1, cur.Filled + (isFilled ? 1 : 0), cur.Remaining + slotsLeft);
+        }
+
+        PeriodStaffing ToStaffing(ShiftPeriod p)
+        {
+            var v = periodAgg[p];
+            return new PeriodStaffing(v.Total, v.Filled, v.Remaining);
+        }
+
+        return (total, filled, remaining, ToStaffing(ShiftPeriod.Build), ToStaffing(ShiftPeriod.Event), ToStaffing(ShiftPeriod.Strike));
+    }
+
+    public async Task<IReadOnlyList<CoordinatorActivityRow>> GetCoordinatorActivityAsync(Guid eventSettingsId)
+    {
+        var cached = await _cache.GetOrCreateAsync(CoordinatorActivityCacheKey(eventSettingsId), async entry =>
+        {
+            entry.SlidingExpiration = DashboardCacheTtl;
+            return await ComputeCoordinatorActivityAsync(eventSettingsId);
+        });
+        return cached!;
+    }
+
+    private async Task<IReadOnlyList<CoordinatorActivityRow>> ComputeCoordinatorActivityAsync(Guid eventSettingsId)
+    {
+        // Pending signup counts per team (via rota.TeamId). We intentionally don't dedupe by SignupBlockId here —
+        // this count is the raw number of pending shift-signups that need attention, which matches the UX.
+        var pendingCounts = await (
+            from rota in _dbContext.Rotas
+            where rota.EventSettingsId == eventSettingsId
+            join shift in _dbContext.Shifts on rota.Id equals shift.RotaId
+            join signup in _dbContext.ShiftSignups on shift.Id equals signup.ShiftId
+            where signup.Status == SignupStatus.Pending
+            group signup by rota.TeamId into g
+            select new { TeamId = g.Key, Count = g.Count() }
+        ).ToDictionaryAsync(x => x.TeamId, x => x.Count);
+
+        if (pendingCounts.Count == 0)
+            return Array.Empty<CoordinatorActivityRow>();
+
+        var teamIds = pendingCounts.Keys.ToList();
+
+        var rawRows = await _dbContext.Teams.AsNoTracking()
+            .Where(t => teamIds.Contains(t.Id))
+            .Select(t => new
+            {
+                t.Id,
+                t.Name,
+                Coordinators = t.Members
+                    .Where(m => m.LeftAt == null && m.Role == TeamMemberRole.Coordinator)
+                    .Select(m => new { m.UserId, m.User.DisplayName, m.User.LastLoginAt })
+                    .ToList()
+            })
+            .ToListAsync();
+
+        return rawRows
+            .Select(t =>
+            {
+                var coords = t.Coordinators
+                    .Select(c => new CoordinatorLogin(c.UserId, c.DisplayName, c.LastLoginAt))
+                    .OrderBy(c => c.LastLoginAt ?? Instant.MinValue)
+                    .ToList();
+                return new CoordinatorActivityRow(
+                    t.Id, t.Name, coords, pendingCounts[t.Id]);
+            })
+            .OrderBy(r => r.Coordinators.Select(c => c.LastLoginAt ?? Instant.MinValue).DefaultIfEmpty(Instant.MinValue).Min())
+            .ThenBy(r => r.TeamName, StringComparer.Ordinal)
+            .ToList();
+    }
+
+    public async Task<IReadOnlyList<DashboardTrendPoint>> GetDashboardTrendsAsync(Guid eventSettingsId, TrendWindow window)
+    {
+        var cached = await _cache.GetOrCreateAsync(TrendsCacheKey(eventSettingsId, window), async entry =>
+        {
+            entry.SlidingExpiration = DashboardCacheTtl;
+            return await ComputeDashboardTrendsAsync(eventSettingsId, window);
+        });
+        return cached!;
+    }
+
+    private async Task<IReadOnlyList<DashboardTrendPoint>> ComputeDashboardTrendsAsync(Guid eventSettingsId, TrendWindow window)
+    {
+        var es = await _dbContext.EventSettings.AsNoTracking()
+            .FirstOrDefaultAsync(e => e.Id == eventSettingsId);
+        if (es is null) return Array.Empty<DashboardTrendPoint>();
+
+        var tz = DateTimeZoneProviders.Tzdb.GetZoneOrNull(es.TimeZoneId) ?? DateTimeZone.Utc;
+        var now = _clock.GetCurrentInstant();
+        var today = now.InZone(tz).Date;
+
+        LocalDate start = window switch
+        {
+            TrendWindow.Last7Days => today.PlusDays(-6),
+            TrendWindow.Last30Days => today.PlusDays(-29),
+            TrendWindow.Last90Days => today.PlusDays(-89),
+            TrendWindow.All => es.CreatedAt.InZone(tz).Date,
+            _ => today.PlusDays(-29),
+        };
+
+        if (start > today) start = today;
+
+        var startInstant = start.AtStartOfDayInZone(tz).ToInstant();
+        var endInstant = today.PlusDays(1).AtStartOfDayInZone(tz).ToInstant();
+
+        // Signups created in window, scoped to this event's shifts.
+        var signupsInWindow = await (
+            from su in _dbContext.ShiftSignups.AsNoTracking()
+            join sh in _dbContext.Shifts.AsNoTracking() on su.ShiftId equals sh.Id
+            join r in _dbContext.Rotas.AsNoTracking() on sh.RotaId equals r.Id
+            where r.EventSettingsId == eventSettingsId
+                  && su.CreatedAt >= startInstant
+                  && su.CreatedAt < endInstant
+            select su.CreatedAt
+        ).ToListAsync();
+
+        var ticketsInWindow = await _dbContext.TicketOrders.AsNoTracking()
+            .Where(o => o.PaymentStatus == TicketPaymentStatus.Paid
+                        && o.PurchasedAt >= startInstant
+                        && o.PurchasedAt < endInstant)
+            .Select(o => o.PurchasedAt)
+            .ToListAsync();
+
+        var loginsInWindow = await _dbContext.Users.AsNoTracking()
+            .Where(u => u.LastLoginAt != null
+                        && u.LastLoginAt >= startInstant
+                        && u.LastLoginAt < endInstant)
+            .Select(u => u.LastLoginAt!.Value)
+            .ToListAsync();
+
+        LocalDate ToLocalDate(Instant i) => i.InZone(tz).Date;
+
+        var signupsByDay = signupsInWindow.GroupBy(ToLocalDate).ToDictionary(g => g.Key, g => g.Count());
+        var ticketsByDay = ticketsInWindow.GroupBy(ToLocalDate).ToDictionary(g => g.Key, g => g.Count());
+        var loginsByDay = loginsInWindow.Select(ToLocalDate).Distinct().ToHashSet();
+        // DistinctLogins as daily count = each user counted at most once on their LastLoginAt day; that's what we have.
+        var loginCountsByDay = loginsInWindow
+            .GroupBy(i => ToLocalDate(i))
+            .ToDictionary(g => g.Key, g => g.Count());
+
+        var points = new List<DashboardTrendPoint>();
+        for (var d = start; d <= today; d = d.PlusDays(1))
+        {
+            points.Add(new DashboardTrendPoint(
+                d,
+                signupsByDay.TryGetValue(d, out var s) ? s : 0,
+                ticketsByDay.TryGetValue(d, out var t) ? t : 0,
+                loginCountsByDay.TryGetValue(d, out var l) ? l : 0));
+        }
+        return points;
     }
 
     // ============================================================

--- a/src/Humans.Infrastructure/Services/ShiftManagementService.cs
+++ b/src/Humans.Infrastructure/Services/ShiftManagementService.cs
@@ -1088,8 +1088,8 @@ public class ShiftManagementService : IShiftManagementService
 
     private async Task<IReadOnlyList<CoordinatorActivityRow>> ComputeCoordinatorActivityAsync(Guid eventSettingsId)
     {
-        // Pending signup counts per team (via rota.TeamId). We intentionally don't dedupe by SignupBlockId here —
-        // this count is the raw number of pending shift-signups that need attention, which matches the UX.
+        // Pending signup counts per team (via rota.TeamId). Not deduped by SignupBlockId —
+        // this count is the raw number of pending shift-signups that need attention.
         var pendingCounts = await (
             from rota in _dbContext.Rotas
             where rota.EventSettingsId == eventSettingsId
@@ -1103,34 +1103,93 @@ public class ShiftManagementService : IShiftManagementService
         if (pendingCounts.Count == 0)
             return Array.Empty<CoordinatorActivityRow>();
 
-        var teamIds = pendingCounts.Keys.ToList();
+        // Load the full team hierarchy so we can build the tree and include ancestors
+        // of any team that has pending (a parent with no pending of its own but pending
+        // subteams still needs to appear as the top-level row).
+        var teamMeta = await _dbContext.Teams.AsNoTracking()
+            .Select(t => new { t.Id, t.Name, t.ParentTeamId })
+            .ToDictionaryAsync(t => t.Id);
 
-        var rawRows = await _dbContext.Teams.AsNoTracking()
-            .Where(t => teamIds.Contains(t.Id))
-            .Select(t => new
+        var relevantTeamIds = new HashSet<Guid>(pendingCounts.Keys);
+        foreach (var id in pendingCounts.Keys.ToList())
+        {
+            var current = teamMeta.GetValueOrDefault(id);
+            while (current?.ParentTeamId is Guid parentId && teamMeta.ContainsKey(parentId))
             {
-                t.Id,
-                t.Name,
-                Coordinators = t.Members
-                    .Where(m => m.LeftAt == null && m.Role == TeamMemberRole.Coordinator)
-                    .Select(m => new { m.UserId, m.User.DisplayName, m.User.LastLoginAt })
-                    .ToList()
-            })
+                if (!relevantTeamIds.Add(parentId))
+                    break;
+                current = teamMeta[parentId];
+            }
+        }
+
+        // Coordinators per relevant team.
+        var coordsRaw = await _dbContext.TeamMembers.AsNoTracking()
+            .Where(m => relevantTeamIds.Contains(m.TeamId)
+                        && m.LeftAt == null
+                        && m.Role == TeamMemberRole.Coordinator)
+            .Select(m => new { m.TeamId, m.UserId, m.User.DisplayName, m.User.LastLoginAt })
             .ToListAsync();
 
-        return rawRows
-            .Select(t =>
-            {
-                var coords = t.Coordinators
-                    .Select(c => new CoordinatorLogin(c.UserId, c.DisplayName, c.LastLoginAt))
+        var coordsByTeam = coordsRaw
+            .GroupBy(c => c.TeamId)
+            .ToDictionary(
+                g => g.Key,
+                g => (IReadOnlyList<CoordinatorLogin>)g
+                    .Select(c => new CoordinatorLogin(c.UserId, c.DisplayName ?? string.Empty, c.LastLoginAt))
                     .OrderBy(c => c.LastLoginAt ?? Instant.MinValue)
-                    .ToList();
-                return new CoordinatorActivityRow(
-                    t.Id, t.Name, coords, pendingCounts[t.Id]);
-            })
-            .OrderBy(r => r.Coordinators.Select(c => c.LastLoginAt ?? Instant.MinValue).DefaultIfEmpty(Instant.MinValue).Min())
+                    .ToList());
+
+        // Build recursive rows.
+        CoordinatorActivityRow BuildRow(Guid teamId)
+        {
+            var t = teamMeta[teamId];
+            var ownPending = pendingCounts.GetValueOrDefault(teamId, 0);
+            var coords = coordsByTeam.GetValueOrDefault(teamId, Array.Empty<CoordinatorLogin>());
+
+            var childIds = relevantTeamIds
+                .Where(id => teamMeta[id].ParentTeamId == teamId);
+
+            var subgroups = childIds
+                .Select(BuildRow)
+                .OrderBy(SubtreeOldestLogin)
+                .ThenBy(r => r.TeamName, StringComparer.Ordinal)
+                .ToList();
+
+            var aggregate = ownPending + subgroups.Sum(s => s.AggregatePendingCount);
+            return new CoordinatorActivityRow(teamId, t.Name, coords, ownPending, aggregate, subgroups);
+        }
+
+        // Root teams: no parent, or parent not in the relevant set (defensive — shouldn't happen).
+        var rootIds = relevantTeamIds
+            .Where(id =>
+            {
+                var t = teamMeta[id];
+                return !t.ParentTeamId.HasValue || !relevantTeamIds.Contains(t.ParentTeamId.Value);
+            });
+
+        return rootIds
+            .Select(BuildRow)
+            .Where(r => r.AggregatePendingCount > 0)
+            .OrderBy(SubtreeOldestLogin)
             .ThenBy(r => r.TeamName, StringComparer.Ordinal)
             .ToList();
+
+        static Instant SubtreeOldestLogin(CoordinatorActivityRow row)
+        {
+            var oldest = Instant.MaxValue;
+            var found = false;
+            void Walk(CoordinatorActivityRow r)
+            {
+                foreach (var c in r.Coordinators)
+                {
+                    var lv = c.LastLoginAt ?? Instant.MinValue;
+                    if (!found || lv < oldest) { oldest = lv; found = true; }
+                }
+                foreach (var sub in r.Subgroups) Walk(sub);
+            }
+            Walk(row);
+            return found ? oldest : Instant.MinValue;
+        }
     }
 
     public async Task<IReadOnlyList<DashboardTrendPoint>> GetDashboardTrendsAsync(Guid eventSettingsId, TrendWindow window)

--- a/src/Humans.Infrastructure/Services/ShiftManagementService.cs
+++ b/src/Humans.Infrastructure/Services/ShiftManagementService.cs
@@ -1232,6 +1232,7 @@ public class ShiftManagementService : IShiftManagementService
                 foreach (var sub in r.Subgroups) Walk(sub);
             }
             Walk(row);
+            // No coordinators in subtree: return MinValue so this row sorts first (needs coordinator attention).
             return found ? oldest : Instant.MinValue;
         }
     }
@@ -1312,7 +1313,6 @@ public class ShiftManagementService : IShiftManagementService
 
         var signupsByDay = signupsInWindow.GroupBy(ToLocalDate).ToDictionary(g => g.Key, g => g.Count());
         var ticketsByDay = ticketsInWindow.GroupBy(ToLocalDate).ToDictionary(g => g.Key, g => g.Count());
-        var loginsByDay = loginsInWindow.Select(ToLocalDate).Distinct().ToHashSet();
         // DistinctLogins as daily count = each user counted at most once on their LastLoginAt day; that's what we have.
         var loginCountsByDay = loginsInWindow
             .GroupBy(i => ToLocalDate(i))

--- a/src/Humans.Infrastructure/Services/ShiftManagementService.cs
+++ b/src/Humans.Infrastructure/Services/ShiftManagementService.cs
@@ -40,6 +40,13 @@ public class ShiftManagementService : IShiftManagementService
     // Lazy-resolved to break circular dependency: TeamService → IShiftManagementService → ITeamService
     private ITeamService TeamService => _serviceProvider.GetRequiredService<ITeamService>();
 
+    // Resolved on demand so this class stays construction-cheap in tests and avoids
+    // forcing the (heavy) ticket/user services as hard ctor dependencies. These are
+    // only used by the coordinator dashboard compute methods, which already live
+    // behind a 5-minute sliding cache.
+    private ITicketQueryService TicketQueryService => _serviceProvider.GetRequiredService<ITicketQueryService>();
+    private IUserService UserService => _serviceProvider.GetRequiredService<IUserService>();
+
     public ShiftManagementService(
         HumansDbContext dbContext,
         IAuditLogService auditLogService,
@@ -917,8 +924,10 @@ public class ShiftManagementService : IShiftManagementService
         if (es is null)
             return EmptyOverview();
 
+        // Load shifts with just their Rota (same Shifts-owned domain) — no cross-domain
+        // Team/ParentTeam includes. We resolve team metadata via ITeamService below.
         var allShifts = await _dbContext.Shifts.AsNoTracking()
-            .Include(s => s.Rota).ThenInclude(r => r.Team).ThenInclude(t => t.ParentTeam)
+            .Include(s => s.Rota)
             .Where(s => s.Rota.EventSettingsId == eventSettingsId
                         && !s.AdminOnly
                         && s.Rota.IsVisibleToVolunteers)
@@ -953,12 +962,8 @@ public class ShiftManagementService : IShiftManagementService
                 Pct(perPeriod, ShiftPeriod.Strike));
         }
 
-        var ticketHolderIds = await _dbContext.TicketOrders.AsNoTracking()
-            .Where(o => o.PaymentStatus == TicketPaymentStatus.Paid && o.MatchedUserId != null)
-            .Select(o => o.MatchedUserId!.Value)
-            .Distinct()
-            .ToListAsync();
-        var ticketHolders = ticketHolderIds.ToHashSet();
+        var ticketHolderIds = await TicketQueryService.GetMatchedUserIdsForPaidOrdersAsync();
+        var ticketHolders = ticketHolderIds as HashSet<Guid> ?? ticketHolderIds.ToHashSet();
 
         var engagedUserIds = await _dbContext.ShiftSignups.AsNoTracking()
             .Where(su => shiftIds.Contains(su.ShiftId) && su.Status != SignupStatus.Cancelled)
@@ -976,7 +981,15 @@ public class ShiftManagementService : IShiftManagementService
                               && su.Status == SignupStatus.Pending
                               && su.CreatedAt < staleThreshold);
 
-        var departments = BuildDepartmentRows(shifts, confirmedCounts, es);
+        // Pull the teams referenced by our loaded rotas (plus their parents) via
+        // ITeamService so we never navigate across domains.
+        var teamIdsOnRotas = shifts
+            .Select(s => s.Rota.TeamId)
+            .Distinct()
+            .ToList();
+        var teamLookup = await TeamService.GetByIdsWithParentsAsync(teamIdsOnRotas);
+
+        var departments = BuildDepartmentRows(shifts, confirmedCounts, es, teamLookup);
 
         return new DashboardOverview(
             totalShifts, filledShifts, periodFillRates,
@@ -995,49 +1008,62 @@ public class ShiftManagementService : IShiftManagementService
     private static List<DepartmentStaffingRow> BuildDepartmentRows(
         List<Shift> shifts,
         Dictionary<Guid, int> confirmedCounts,
-        EventSettings es)
+        EventSettings es,
+        IReadOnlyDictionary<Guid, Team> teamLookup)
     {
-        // Helper: resolve department (parent team if any, else own team) from a shift.
-        static Team DeptOf(Shift s) => s.Rota.Team.ParentTeam ?? s.Rota.Team;
+        // Helper: resolve the department ID (parent team if any, else own team) for a shift.
+        // We defer to teamLookup so we never navigate the cross-domain .Team/.ParentTeam
+        // properties — the shift loader only includes the Rota (a Shifts-owned entity).
+        Guid DeptIdOf(Shift s)
+        {
+            if (!teamLookup.TryGetValue(s.Rota.TeamId, out var team))
+                return s.Rota.TeamId; // Team row vanished — fall back to the rota's team id.
+            return team.ParentTeamId ?? team.Id;
+        }
 
-        // Group by department ID (Team instances may differ across includes; grouping by identity is incorrect).
+        string NameOf(Guid teamId) =>
+            teamLookup.TryGetValue(teamId, out var t) ? t.Name : string.Empty;
+
+        // Group by department ID.
         var groups = shifts
-            .GroupBy(s => DeptOf(s).Id)
+            .GroupBy(DeptIdOf)
             .ToList();
 
         var rows = new List<DepartmentStaffingRow>();
         foreach (var g in groups)
         {
             var deptShifts = g.ToList();
-            var dept = DeptOf(deptShifts[0]);
+            var deptId = g.Key;
+            var deptName = NameOf(deptId);
             var agg = AggregateShifts(deptShifts, confirmedCounts, es);
 
             // Subgroups: any shift belongs to a subteam?
             var subgroups = new List<SubgroupStaffingRow>();
-            var anySubteam = deptShifts.Any(s => s.Rota.Team.ParentTeamId != null);
+            var anySubteam = deptShifts.Any(s =>
+                teamLookup.TryGetValue(s.Rota.TeamId, out var t) && t.ParentTeamId != null);
             if (anySubteam)
             {
-                // Per-subteam subgroups (group by team ID for stable identity across EF-include instances).
+                // Per-subteam subgroups (group by team ID for stable identity).
                 var subteamGroups = deptShifts
-                    .Where(s => s.Rota.Team.ParentTeamId != null)
-                    .GroupBy(s => s.Rota.Team.Id);
+                    .Where(s => teamLookup.TryGetValue(s.Rota.TeamId, out var t) && t.ParentTeamId != null)
+                    .GroupBy(s => s.Rota.TeamId);
                 foreach (var sg in subteamGroups)
                 {
-                    var sTeam = sg.First().Rota.Team;
+                    var sTeamId = sg.Key;
                     var sAgg = AggregateShifts(sg.ToList(), confirmedCounts, es);
                     subgroups.Add(new SubgroupStaffingRow(
-                        sTeam.Id, sTeam.Name, IsDirect: false,
+                        sTeamId, NameOf(sTeamId), IsDirect: false,
                         sAgg.Total, sAgg.Filled, sAgg.Remaining,
                         sAgg.Build, sAgg.Event, sAgg.Strike));
                 }
 
                 // "Direct" row for department's own rotas (if any).
-                var directShifts = deptShifts.Where(s => s.Rota.TeamId == dept.Id).ToList();
+                var directShifts = deptShifts.Where(s => s.Rota.TeamId == deptId).ToList();
                 if (directShifts.Count > 0)
                 {
                     var dAgg = AggregateShifts(directShifts, confirmedCounts, es);
                     subgroups.Insert(0, new SubgroupStaffingRow(
-                        dept.Id, "Direct", IsDirect: true,
+                        deptId, "Direct", IsDirect: true,
                         dAgg.Total, dAgg.Filled, dAgg.Remaining,
                         dAgg.Build, dAgg.Event, dAgg.Strike));
                 }
@@ -1051,7 +1077,7 @@ public class ShiftManagementService : IShiftManagementService
             }
 
             rows.Add(new DepartmentStaffingRow(
-                dept.Id, dept.Name,
+                deptId, deptName,
                 agg.Total, agg.Filled, agg.Remaining,
                 agg.Build, agg.Event, agg.Strike,
                 subgroups));
@@ -1147,12 +1173,29 @@ public class ShiftManagementService : IShiftManagementService
         if (pendingCounts.Count == 0)
             return Array.Empty<CoordinatorActivityRow>();
 
-        // Load the full team hierarchy so we can build the tree and include ancestors
-        // of any team that has pending (a parent with no pending of its own but pending
-        // subteams still needs to appear as the top-level row).
-        var teamMeta = await _dbContext.Teams.AsNoTracking()
-            .Select(t => new { t.Id, t.Name, t.ParentTeamId })
-            .ToDictionaryAsync(t => t.Id);
+        // Load team metadata for pending teams and walk up through parents until we
+        // have every ancestor in our working set. We request teams in passes because
+        // ITeamService.GetByIdsWithParentsAsync includes one level of parents; deeper
+        // chains (shouldn't exist today — CreateTeamAsync enforces a single nesting
+        // level — but we defend against it) iterate until fixed-point.
+        var teamMeta = new Dictionary<Guid, Team>();
+        var pendingFetch = pendingCounts.Keys.ToHashSet();
+        while (pendingFetch.Count > 0)
+        {
+            var toFetch = pendingFetch.Where(id => !teamMeta.ContainsKey(id)).ToList();
+            if (toFetch.Count == 0) break;
+
+            var fetched = await TeamService.GetByIdsWithParentsAsync(toFetch);
+            foreach (var kvp in fetched)
+            {
+                teamMeta[kvp.Key] = kvp.Value;
+            }
+
+            pendingFetch = fetched.Values
+                .Where(t => t.ParentTeamId.HasValue && !teamMeta.ContainsKey(t.ParentTeamId.Value))
+                .Select(t => t.ParentTeamId!.Value)
+                .ToHashSet();
+        }
 
         var relevantTeamIds = new HashSet<Guid>(pendingCounts.Keys);
         foreach (var id in pendingCounts.Keys.ToList())
@@ -1166,20 +1209,26 @@ public class ShiftManagementService : IShiftManagementService
             }
         }
 
-        // Coordinators per relevant team.
-        var coordsRaw = await _dbContext.TeamMembers.AsNoTracking()
-            .Where(m => relevantTeamIds.Contains(m.TeamId)
-                        && m.LeftAt == null
-                        && m.Role == TeamMemberRole.Coordinator)
-            .Select(m => new { m.TeamId, m.UserId, m.User.DisplayName, m.User.LastLoginAt })
-            .ToListAsync();
+        // Coordinators per relevant team (Teams domain — via ITeamService).
+        var coordsRaw = await TeamService.GetActiveCoordinatorsForTeamsAsync(relevantTeamIds.ToList());
+        var coordinatorUserIds = coordsRaw.Select(c => c.UserId).Distinct().ToList();
+
+        // User info (DisplayName + LastLoginAt) — via IUserService.
+        var userLookup = await UserService.GetByIdsAsync(coordinatorUserIds);
 
         var coordsByTeam = coordsRaw
             .GroupBy(c => c.TeamId)
             .ToDictionary(
                 g => g.Key,
                 g => (IReadOnlyList<CoordinatorLogin>)g
-                    .Select(c => new CoordinatorLogin(c.UserId, c.DisplayName ?? string.Empty, c.LastLoginAt))
+                    .Select(c =>
+                    {
+                        userLookup.TryGetValue(c.UserId, out var user);
+                        return new CoordinatorLogin(
+                            c.UserId,
+                            user?.DisplayName ?? string.Empty,
+                            user?.LastLoginAt);
+                    })
                     .OrderBy(c => c.LastLoginAt ?? Instant.MinValue)
                     .ToList());
 
@@ -1295,19 +1344,9 @@ public class ShiftManagementService : IShiftManagementService
 
         var signupsInWindow = await signupsQuery.Select(x => x.CreatedAt).ToListAsync();
 
-        var ticketsInWindow = await _dbContext.TicketOrders.AsNoTracking()
-            .Where(o => o.PaymentStatus == TicketPaymentStatus.Paid
-                        && o.PurchasedAt >= startInstant
-                        && o.PurchasedAt < endInstant)
-            .Select(o => o.PurchasedAt)
-            .ToListAsync();
-
-        var loginsInWindow = await _dbContext.Users.AsNoTracking()
-            .Where(u => u.LastLoginAt != null
-                        && u.LastLoginAt >= startInstant
-                        && u.LastLoginAt < endInstant)
-            .Select(u => u.LastLoginAt!.Value)
-            .ToListAsync();
+        // Cross-domain reads routed through the owning service interfaces.
+        var ticketsInWindow = await TicketQueryService.GetPaidOrderDatesInWindowAsync(startInstant, endInstant);
+        var loginsInWindow = await UserService.GetLoginTimestampsInWindowAsync(startInstant, endInstant);
 
         LocalDate ToLocalDate(Instant i) => i.InZone(tz).Date;
 

--- a/src/Humans.Infrastructure/Services/ShiftManagementService.cs
+++ b/src/Humans.Infrastructure/Services/ShiftManagementService.cs
@@ -479,7 +479,7 @@ public class ShiftManagementService : IShiftManagementService
 
     public async Task<IReadOnlyList<UrgentShift>> GetUrgentShiftsAsync(
         Guid eventSettingsId, int? limit = null,
-        Guid? departmentId = null, LocalDate? date = null)
+        Guid? departmentId = null, LocalDate? date = null, ShiftPeriod? period = null)
     {
         var es = await _dbContext.EventSettings.AsNoTracking()
             .FirstOrDefaultAsync(e => e.Id == eventSettingsId);
@@ -494,6 +494,15 @@ public class ShiftManagementService : IShiftManagementService
 
         if (departmentId.HasValue)
             query = query.Where(s => s.Rota.TeamId == departmentId.Value);
+
+        var eventEndOffset = es.EventEndOffset;
+        query = period switch
+        {
+            ShiftPeriod.Build => query.Where(s => s.DayOffset < 0),
+            ShiftPeriod.Event => query.Where(s => s.DayOffset >= 0 && s.DayOffset <= eventEndOffset),
+            ShiftPeriod.Strike => query.Where(s => s.DayOffset > eventEndOffset),
+            _ => query,
+        };
 
         if (date.HasValue)
         {
@@ -668,7 +677,7 @@ public class ShiftManagementService : IShiftManagementService
     // ============================================================
 
     public async Task<IReadOnlyList<DailyStaffingData>> GetStaffingDataAsync(
-        Guid eventSettingsId, Guid? departmentId = null)
+        Guid eventSettingsId, Guid? departmentId = null, ShiftPeriod? period = null)
     {
         var es = await _dbContext.EventSettings.AsNoTracking()
             .FirstOrDefaultAsync(e => e.Id == eventSettingsId);
@@ -676,11 +685,15 @@ public class ShiftManagementService : IShiftManagementService
 
         var tz = DateTimeZoneProviders.Tzdb[es.TimeZoneId];
 
-        // All periods: Build [BuildStartOffset..-1], Event [0..EventEndOffset], Strike [EventEndOffset+1..StrikeEndOffset]
+        // Day offsets in the requested period (all if null):
+        //   Build [BuildStartOffset..-1], Event [0..EventEndOffset], Strike [EventEndOffset+1..StrikeEndOffset]
         var dayOffsets = new List<int>();
-        for (var d = es.BuildStartOffset; d < 0; d++) dayOffsets.Add(d);
-        for (var d = 0; d <= es.EventEndOffset; d++) dayOffsets.Add(d);
-        for (var d = es.EventEndOffset + 1; d <= es.StrikeEndOffset; d++) dayOffsets.Add(d);
+        if (period is null or ShiftPeriod.Build)
+            for (var d = es.BuildStartOffset; d < 0; d++) dayOffsets.Add(d);
+        if (period is null or ShiftPeriod.Event)
+            for (var d = 0; d <= es.EventEndOffset; d++) dayOffsets.Add(d);
+        if (period is null or ShiftPeriod.Strike)
+            for (var d = es.EventEndOffset + 1; d <= es.StrikeEndOffset; d++) dayOffsets.Add(d);
 
         if (dayOffsets.Count == 0) return [];
 
@@ -701,7 +714,7 @@ public class ShiftManagementService : IShiftManagementService
             var dayDate = es.GateOpeningDate.PlusDays(dayOffset);
             var dayStart = dayDate.AtStartOfDayInZone(tz).ToInstant();
             var dayEnd = dayDate.PlusDays(1).AtStartOfDayInZone(tz).ToInstant();
-            var period = dayOffset < 0 ? "Set-up" : dayOffset <= es.EventEndOffset ? "Event" : "Strike";
+            var periodLabel = dayOffset < 0 ? "Set-up" : dayOffset <= es.EventEndOffset ? "Event" : "Strike";
             var dateLabel = dayDate.DayOfWeek.ToString()[..3] + " " + dayDate.ToString("MMM d", null);
 
             var overlapping = shifts.Where(s =>
@@ -717,14 +730,14 @@ public class ShiftManagementService : IShiftManagementService
                 .SelectMany(s => s.ShiftSignups)
                 .Count(su => su.Status == SignupStatus.Confirmed);
 
-            results.Add(new DailyStaffingData(dayOffset, dateLabel, confirmedCount, totalSlots, minSlots, period));
+            results.Add(new DailyStaffingData(dayOffset, dateLabel, confirmedCount, totalSlots, minSlots, periodLabel));
         }
 
         return results;
     }
 
     public async Task<IReadOnlyList<DailyStaffingHours>> GetStaffingHoursAsync(
-        Guid eventSettingsId, Guid? departmentId = null)
+        Guid eventSettingsId, Guid? departmentId = null, ShiftPeriod? period = null)
     {
         var es = await _dbContext.EventSettings.AsNoTracking()
             .FirstOrDefaultAsync(e => e.Id == eventSettingsId);
@@ -733,9 +746,12 @@ public class ShiftManagementService : IShiftManagementService
         var tz = DateTimeZoneProviders.Tzdb[es.TimeZoneId];
 
         var dayOffsets = new List<int>();
-        for (var d = es.BuildStartOffset; d < 0; d++) dayOffsets.Add(d);
-        for (var d = 0; d <= es.EventEndOffset; d++) dayOffsets.Add(d);
-        for (var d = es.EventEndOffset + 1; d <= es.StrikeEndOffset; d++) dayOffsets.Add(d);
+        if (period is null or ShiftPeriod.Build)
+            for (var d = es.BuildStartOffset; d < 0; d++) dayOffsets.Add(d);
+        if (period is null or ShiftPeriod.Event)
+            for (var d = 0; d <= es.EventEndOffset; d++) dayOffsets.Add(d);
+        if (period is null or ShiftPeriod.Strike)
+            for (var d = es.EventEndOffset + 1; d <= es.StrikeEndOffset; d++) dayOffsets.Add(d);
 
         if (dayOffsets.Count == 0) return [];
 
@@ -877,33 +893,40 @@ public class ShiftManagementService : IShiftManagementService
 
     private static readonly TimeSpan DashboardCacheTtl = TimeSpan.FromMinutes(5);
 
-    internal static string OverviewCacheKey(Guid eventId) => $"dashboard-overview:{eventId}";
-    internal static string CoordinatorActivityCacheKey(Guid eventId) => $"dashboard-coordinator-activity:{eventId}";
-    internal static string TrendsCacheKey(Guid eventId, TrendWindow window) => $"dashboard-trends:{eventId}:{window}";
+    internal static string OverviewCacheKey(Guid eventId, ShiftPeriod? period) =>
+        $"dashboard-overview:{eventId}:{period?.ToString() ?? "all"}";
+    internal static string CoordinatorActivityCacheKey(Guid eventId, ShiftPeriod? period) =>
+        $"dashboard-coordinator-activity:{eventId}:{period?.ToString() ?? "all"}";
+    internal static string TrendsCacheKey(Guid eventId, TrendWindow window, ShiftPeriod? period) =>
+        $"dashboard-trends:{eventId}:{window}:{period?.ToString() ?? "all"}";
 
-    public async Task<DashboardOverview> GetDashboardOverviewAsync(Guid eventSettingsId)
+    public async Task<DashboardOverview> GetDashboardOverviewAsync(Guid eventSettingsId, ShiftPeriod? period = null)
     {
-        var cached = await _cache.GetOrCreateAsync(OverviewCacheKey(eventSettingsId), async entry =>
+        var cached = await _cache.GetOrCreateAsync(OverviewCacheKey(eventSettingsId, period), async entry =>
         {
             entry.SlidingExpiration = DashboardCacheTtl;
-            return await ComputeDashboardOverviewAsync(eventSettingsId);
+            return await ComputeDashboardOverviewAsync(eventSettingsId, period);
         });
         return cached!;
     }
 
-    private async Task<DashboardOverview> ComputeDashboardOverviewAsync(Guid eventSettingsId)
+    private async Task<DashboardOverview> ComputeDashboardOverviewAsync(Guid eventSettingsId, ShiftPeriod? period)
     {
         var es = await _dbContext.EventSettings.AsNoTracking()
             .FirstOrDefaultAsync(e => e.Id == eventSettingsId);
         if (es is null)
             return EmptyOverview();
 
-        var shifts = await _dbContext.Shifts.AsNoTracking()
+        var allShifts = await _dbContext.Shifts.AsNoTracking()
             .Include(s => s.Rota).ThenInclude(r => r.Team).ThenInclude(t => t.ParentTeam)
             .Where(s => s.Rota.EventSettingsId == eventSettingsId
                         && !s.AdminOnly
                         && s.Rota.IsVisibleToVolunteers)
             .ToListAsync();
+
+        var shifts = period is null
+            ? allShifts
+            : allShifts.Where(s => s.GetShiftPeriod(es) == period.Value).ToList();
 
         var shiftIds = shifts.Select(s => s.Id).ToList();
 
@@ -1076,29 +1099,50 @@ public class ShiftManagementService : IShiftManagementService
         return (total, filled, remaining, ToStaffing(ShiftPeriod.Build), ToStaffing(ShiftPeriod.Event), ToStaffing(ShiftPeriod.Strike));
     }
 
-    public async Task<IReadOnlyList<CoordinatorActivityRow>> GetCoordinatorActivityAsync(Guid eventSettingsId)
+    public async Task<IReadOnlyList<CoordinatorActivityRow>> GetCoordinatorActivityAsync(Guid eventSettingsId, ShiftPeriod? period = null)
     {
-        var cached = await _cache.GetOrCreateAsync(CoordinatorActivityCacheKey(eventSettingsId), async entry =>
+        var cached = await _cache.GetOrCreateAsync(CoordinatorActivityCacheKey(eventSettingsId, period), async entry =>
         {
             entry.SlidingExpiration = DashboardCacheTtl;
-            return await ComputeCoordinatorActivityAsync(eventSettingsId);
+            return await ComputeCoordinatorActivityAsync(eventSettingsId, period);
         });
         return cached!;
     }
 
-    private async Task<IReadOnlyList<CoordinatorActivityRow>> ComputeCoordinatorActivityAsync(Guid eventSettingsId)
+    private async Task<IReadOnlyList<CoordinatorActivityRow>> ComputeCoordinatorActivityAsync(Guid eventSettingsId, ShiftPeriod? period)
     {
+        // Need EventEndOffset for period filtering via DayOffset at the DB level.
+        int eventEndOffset = 0;
+        if (period is not null)
+        {
+            var es = await _dbContext.EventSettings.AsNoTracking()
+                .FirstOrDefaultAsync(e => e.Id == eventSettingsId);
+            if (es is null) return Array.Empty<CoordinatorActivityRow>();
+            eventEndOffset = es.EventEndOffset;
+        }
+
         // Pending signup counts per team (via rota.TeamId). Not deduped by SignupBlockId —
         // this count is the raw number of pending shift-signups that need attention.
-        var pendingCounts = await (
+        var pendingQuery =
             from rota in _dbContext.Rotas
             where rota.EventSettingsId == eventSettingsId
             join shift in _dbContext.Shifts on rota.Id equals shift.RotaId
             join signup in _dbContext.ShiftSignups on shift.Id equals signup.ShiftId
             where signup.Status == SignupStatus.Pending
-            group signup by rota.TeamId into g
-            select new { TeamId = g.Key, Count = g.Count() }
-        ).ToDictionaryAsync(x => x.TeamId, x => x.Count);
+            select new { rota.TeamId, shift.DayOffset };
+
+        pendingQuery = period switch
+        {
+            ShiftPeriod.Build => pendingQuery.Where(x => x.DayOffset < 0),
+            ShiftPeriod.Event => pendingQuery.Where(x => x.DayOffset >= 0 && x.DayOffset <= eventEndOffset),
+            ShiftPeriod.Strike => pendingQuery.Where(x => x.DayOffset > eventEndOffset),
+            _ => pendingQuery,
+        };
+
+        var pendingCounts = await pendingQuery
+            .GroupBy(x => x.TeamId)
+            .Select(g => new { TeamId = g.Key, Count = g.Count() })
+            .ToDictionaryAsync(x => x.TeamId, x => x.Count);
 
         if (pendingCounts.Count == 0)
             return Array.Empty<CoordinatorActivityRow>();
@@ -1192,17 +1236,19 @@ public class ShiftManagementService : IShiftManagementService
         }
     }
 
-    public async Task<IReadOnlyList<DashboardTrendPoint>> GetDashboardTrendsAsync(Guid eventSettingsId, TrendWindow window)
+    public async Task<IReadOnlyList<DashboardTrendPoint>> GetDashboardTrendsAsync(
+        Guid eventSettingsId, TrendWindow window, ShiftPeriod? period = null)
     {
-        var cached = await _cache.GetOrCreateAsync(TrendsCacheKey(eventSettingsId, window), async entry =>
+        var cached = await _cache.GetOrCreateAsync(TrendsCacheKey(eventSettingsId, window, period), async entry =>
         {
             entry.SlidingExpiration = DashboardCacheTtl;
-            return await ComputeDashboardTrendsAsync(eventSettingsId, window);
+            return await ComputeDashboardTrendsAsync(eventSettingsId, window, period);
         });
         return cached!;
     }
 
-    private async Task<IReadOnlyList<DashboardTrendPoint>> ComputeDashboardTrendsAsync(Guid eventSettingsId, TrendWindow window)
+    private async Task<IReadOnlyList<DashboardTrendPoint>> ComputeDashboardTrendsAsync(
+        Guid eventSettingsId, TrendWindow window, ShiftPeriod? period)
     {
         var es = await _dbContext.EventSettings.AsNoTracking()
             .FirstOrDefaultAsync(e => e.Id == eventSettingsId);
@@ -1226,16 +1272,27 @@ public class ShiftManagementService : IShiftManagementService
         var startInstant = start.AtStartOfDayInZone(tz).ToInstant();
         var endInstant = today.PlusDays(1).AtStartOfDayInZone(tz).ToInstant();
 
-        // Signups created in window, scoped to this event's shifts.
-        var signupsInWindow = await (
+        // Signups created in window, scoped to this event's shifts. Period filter applies
+        // only to this series — ticket sales and logins are event-wide, not period-specific.
+        var eventEndOffset = es.EventEndOffset;
+        var signupsQuery =
             from su in _dbContext.ShiftSignups.AsNoTracking()
             join sh in _dbContext.Shifts.AsNoTracking() on su.ShiftId equals sh.Id
             join r in _dbContext.Rotas.AsNoTracking() on sh.RotaId equals r.Id
             where r.EventSettingsId == eventSettingsId
                   && su.CreatedAt >= startInstant
                   && su.CreatedAt < endInstant
-            select su.CreatedAt
-        ).ToListAsync();
+            select new { su.CreatedAt, sh.DayOffset };
+
+        signupsQuery = period switch
+        {
+            ShiftPeriod.Build => signupsQuery.Where(x => x.DayOffset < 0),
+            ShiftPeriod.Event => signupsQuery.Where(x => x.DayOffset >= 0 && x.DayOffset <= eventEndOffset),
+            ShiftPeriod.Strike => signupsQuery.Where(x => x.DayOffset > eventEndOffset),
+            _ => signupsQuery,
+        };
+
+        var signupsInWindow = await signupsQuery.Select(x => x.CreatedAt).ToListAsync();
 
         var ticketsInWindow = await _dbContext.TicketOrders.AsNoTracking()
             .Where(o => o.PaymentStatus == TicketPaymentStatus.Paid

--- a/src/Humans.Infrastructure/Services/ShiftManagementService.cs
+++ b/src/Humans.Infrastructure/Services/ShiftManagementService.cs
@@ -974,16 +974,19 @@ public class ShiftManagementService : IShiftManagementService
         Dictionary<Guid, int> confirmedCounts,
         EventSettings es)
     {
-        // Group by department (parent team if exists, else own team).
+        // Helper: resolve department (parent team if any, else own team) from a shift.
+        static Team DeptOf(Shift s) => s.Rota.Team.ParentTeam ?? s.Rota.Team;
+
+        // Group by department ID (Team instances may differ across includes; grouping by identity is incorrect).
         var groups = shifts
-            .GroupBy(s => s.Rota.Team.ParentTeam ?? s.Rota.Team)
+            .GroupBy(s => DeptOf(s).Id)
             .ToList();
 
         var rows = new List<DepartmentStaffingRow>();
         foreach (var g in groups)
         {
-            var dept = g.Key;
             var deptShifts = g.ToList();
+            var dept = DeptOf(deptShifts[0]);
             var agg = AggregateShifts(deptShifts, confirmedCounts, es);
 
             // Subgroups: any shift belongs to a subteam?
@@ -991,15 +994,16 @@ public class ShiftManagementService : IShiftManagementService
             var anySubteam = deptShifts.Any(s => s.Rota.Team.ParentTeamId != null);
             if (anySubteam)
             {
-                // Per-subteam subgroups.
+                // Per-subteam subgroups (group by team ID for stable identity across EF-include instances).
                 var subteamGroups = deptShifts
                     .Where(s => s.Rota.Team.ParentTeamId != null)
-                    .GroupBy(s => s.Rota.Team);
+                    .GroupBy(s => s.Rota.Team.Id);
                 foreach (var sg in subteamGroups)
                 {
+                    var sTeam = sg.First().Rota.Team;
                     var sAgg = AggregateShifts(sg.ToList(), confirmedCounts, es);
                     subgroups.Add(new SubgroupStaffingRow(
-                        sg.Key.Id, sg.Key.Name, IsDirect: false,
+                        sTeam.Id, sTeam.Name, IsDirect: false,
                         sAgg.Total, sAgg.Filled, sAgg.Remaining,
                         sAgg.Build, sAgg.Event, sAgg.Strike));
                 }

--- a/src/Humans.Infrastructure/Services/ShiftManagementService.cs
+++ b/src/Humans.Infrastructure/Services/ShiftManagementService.cs
@@ -1147,15 +1147,17 @@ public class ShiftManagementService : IShiftManagementService
             eventEndOffset = es.EventEndOffset;
         }
 
-        // Pending signup counts per team (via rota.TeamId). Not deduped by SignupBlockId —
-        // this count is the raw number of pending shift-signups that need attention.
+        // Pending signup counts per team (via rota.TeamId). Deduped by SignupBlockId so a
+        // multi-day range signup (one volunteer request spanning N days, N pending rows
+        // sharing one block id) counts as one actionable item — matching SignupBlockId ?? Id
+        // treatment elsewhere in the service and in DashboardService.
         var pendingQuery =
             from rota in _dbContext.Rotas
             where rota.EventSettingsId == eventSettingsId
             join shift in _dbContext.Shifts on rota.Id equals shift.RotaId
             join signup in _dbContext.ShiftSignups on shift.Id equals signup.ShiftId
             where signup.Status == SignupStatus.Pending
-            select new { rota.TeamId, shift.DayOffset };
+            select new { rota.TeamId, shift.DayOffset, BlockKey = signup.SignupBlockId ?? signup.Id };
 
         pendingQuery = period switch
         {
@@ -1166,6 +1168,8 @@ public class ShiftManagementService : IShiftManagementService
         };
 
         var pendingCounts = await pendingQuery
+            .Select(x => new { x.TeamId, x.BlockKey })
+            .Distinct()
             .GroupBy(x => x.TeamId)
             .Select(g => new { TeamId = g.Key, Count = g.Count() })
             .ToDictionaryAsync(x => x.TeamId, x => x.Count);

--- a/src/Humans.Infrastructure/Services/TeamService.cs
+++ b/src/Humans.Infrastructure/Services/TeamService.cs
@@ -2187,6 +2187,148 @@ public class TeamService : ITeamService, IUserDataContributor
             .ToListAsync(cancellationToken);
     }
 
+    public async Task<IReadOnlyDictionary<Guid, Team>> GetByIdsWithParentsAsync(
+        IReadOnlyCollection<Guid> teamIds,
+        CancellationToken cancellationToken = default)
+    {
+        if (teamIds.Count == 0)
+        {
+            return new Dictionary<Guid, Team>();
+        }
+
+        // First pass: load the requested teams. We need them as tracked-free entities
+        // for read-only stitching at the caller.
+        var requested = await _dbContext.Teams
+            .AsNoTracking()
+            .Where(t => teamIds.Contains(t.Id))
+            .ToListAsync(cancellationToken);
+
+        // Second pass: load any parents that aren't already in the requested set.
+        var parentIds = requested
+            .Where(t => t.ParentTeamId.HasValue)
+            .Select(t => t.ParentTeamId!.Value)
+            .Distinct()
+            .Where(id => !teamIds.Contains(id))
+            .ToList();
+
+        var parents = parentIds.Count == 0
+            ? new List<Team>()
+            : await _dbContext.Teams
+                .AsNoTracking()
+                .Where(t => parentIds.Contains(t.Id))
+                .ToListAsync(cancellationToken);
+
+        var dict = new Dictionary<Guid, Team>(requested.Count + parents.Count);
+        foreach (var t in requested) dict[t.Id] = t;
+        foreach (var t in parents) dict[t.Id] = t;
+        return dict;
+    }
+
+    public async Task<IReadOnlyList<TeamCoordinatorRef>> GetActiveCoordinatorsForTeamsAsync(
+        IReadOnlyCollection<Guid> teamIds,
+        CancellationToken cancellationToken = default)
+    {
+        if (teamIds.Count == 0)
+        {
+            return Array.Empty<TeamCoordinatorRef>();
+        }
+
+        return await _dbContext.TeamMembers
+            .AsNoTracking()
+            .Where(tm => teamIds.Contains(tm.TeamId)
+                         && tm.LeftAt == null
+                         && tm.Role == TeamMemberRole.Coordinator)
+            .Select(tm => new TeamCoordinatorRef(tm.TeamId, tm.UserId))
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task<TeamMember> AddSeededMemberAsync(
+        Guid teamId,
+        Guid userId,
+        TeamMemberRole role,
+        Instant joinedAt,
+        CancellationToken cancellationToken = default)
+    {
+        var team = await _dbContext.Teams.FindAsync(new object[] { teamId }, cancellationToken)
+            ?? throw new InvalidOperationException($"Team {teamId} not found");
+
+        if (team.IsSystemTeam)
+        {
+            throw new InvalidOperationException("AddSeededMemberAsync cannot target system teams");
+        }
+
+        var existing = await _dbContext.TeamMembers
+            .AsNoTracking()
+            .FirstOrDefaultAsync(tm => tm.TeamId == teamId && tm.UserId == userId && tm.LeftAt == null, cancellationToken);
+        if (existing is not null)
+        {
+            throw new InvalidOperationException("User is already a member of this team");
+        }
+
+        var member = new TeamMember
+        {
+            Id = Guid.NewGuid(),
+            TeamId = teamId,
+            UserId = userId,
+            Role = role,
+            JoinedAt = joinedAt,
+        };
+
+        _dbContext.TeamMembers.Add(member);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        // Keep the cached team view in sync so subsequent reads see the seeded member.
+        var addedUser = await _dbContext.Users.FindAsync(new object[] { userId }, cancellationToken);
+        if (addedUser is not null)
+        {
+            AddMemberToTeamCache(teamId, new CachedTeamMember(
+                member.Id, userId, addedUser.DisplayName, addedUser.ProfilePictureUrl, role, joinedAt));
+        }
+
+        return member;
+    }
+
+    public async Task<int> HardDeleteSeededTeamsAsync(
+        string nameSuffix,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrEmpty(nameSuffix))
+        {
+            throw new ArgumentException("nameSuffix must be a non-empty marker", nameof(nameSuffix));
+        }
+
+        var targetTeams = await _dbContext.Teams
+            .Where(t => t.Name.EndsWith(nameSuffix))
+            .ToListAsync(cancellationToken);
+
+        if (targetTeams.Count == 0)
+        {
+            return 0;
+        }
+
+        var teamIds = targetTeams.Select(t => t.Id).ToList();
+
+        // Clear dependent rows first (TeamMembers, TeamJoinRequests). Callers are responsible
+        // for cleaning up any cross-domain references (shift rotas, etc.) before this runs.
+        await _dbContext.TeamMembers
+            .Where(tm => teamIds.Contains(tm.TeamId))
+            .ExecuteDeleteAsync(cancellationToken);
+
+        await _dbContext.TeamJoinRequests
+            .Where(r => teamIds.Contains(r.TeamId))
+            .ExecuteDeleteAsync(cancellationToken);
+
+        _dbContext.Teams.RemoveRange(targetTeams);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        foreach (var id in teamIds)
+        {
+            RemoveCachedTeam(id);
+        }
+
+        return targetTeams.Count;
+    }
+
     // ==========================================================================
     // Team Cache
     // ==========================================================================

--- a/src/Humans.Infrastructure/Services/TicketQueryService.cs
+++ b/src/Humans.Infrastructure/Services/TicketQueryService.cs
@@ -975,6 +975,32 @@ public class TicketQueryService : ITicketQueryService, IUserDataContributor
         return new UserTicketExportData(orders, attendees);
     }
 
+    public async Task<IReadOnlyCollection<Guid>> GetMatchedUserIdsForPaidOrdersAsync(CancellationToken ct = default)
+    {
+        var ids = await _dbContext.TicketOrders
+            .AsNoTracking()
+            .Where(o => o.PaymentStatus == TicketPaymentStatus.Paid && o.MatchedUserId != null)
+            .Select(o => o.MatchedUserId!.Value)
+            .Distinct()
+            .ToListAsync(ct);
+
+        return ids;
+    }
+
+    public async Task<IReadOnlyList<Instant>> GetPaidOrderDatesInWindowAsync(
+        Instant fromInclusive,
+        Instant toExclusive,
+        CancellationToken ct = default)
+    {
+        return await _dbContext.TicketOrders
+            .AsNoTracking()
+            .Where(o => o.PaymentStatus == TicketPaymentStatus.Paid
+                        && o.PurchasedAt >= fromInclusive
+                        && o.PurchasedAt < toExclusive)
+            .Select(o => o.PurchasedAt)
+            .ToListAsync(ct);
+    }
+
     private static bool HasSearchTerm([NotNullWhen(true)] string? value, int minLength = 2) =>
         !string.IsNullOrWhiteSpace(value) && value.Trim().Length >= minLength;
 

--- a/src/Humans.Infrastructure/Services/UserService.cs
+++ b/src/Humans.Infrastructure/Services/UserService.cs
@@ -196,6 +196,20 @@ public class UserService : IUserService, IUserDataContributor
         // Note: caller is responsible for SaveChangesAsync (batch context)
     }
 
+    public async Task<IReadOnlyList<Instant>> GetLoginTimestampsInWindowAsync(
+        Instant fromInclusive,
+        Instant toExclusive,
+        CancellationToken ct = default)
+    {
+        return await _dbContext.Users
+            .AsNoTracking()
+            .Where(u => u.LastLoginAt != null
+                        && u.LastLoginAt >= fromInclusive
+                        && u.LastLoginAt < toExclusive)
+            .Select(u => u.LastLoginAt!.Value)
+            .ToListAsync(ct);
+    }
+
     public async Task<int> BackfillParticipationsAsync(int year, List<(Guid UserId, ParticipationStatus Status)> entries, CancellationToken ct = default)
     {
         var existing = await _dbContext.EventParticipations

--- a/src/Humans.Web/Controllers/DevSeedController.cs
+++ b/src/Humans.Web/Controllers/DevSeedController.cs
@@ -81,7 +81,7 @@ public class DevSeedController : HumansControllerBase
     [Authorize(Policy = PolicyNames.ShiftDashboardAccess)]
     [HttpPost("dashboard")]
     [ValidateAntiForgeryToken]
-    public async Task<IActionResult> SeedDashboard(CancellationToken cancellationToken)
+    public async Task<IActionResult> SeedDashboard(bool reset, CancellationToken cancellationToken)
     {
         // Stricter than IsDevSeedEnabled: dashboard seed runs only on local Development
         // (ASPNETCORE_ENVIRONMENT=Development), never on QA / preview / prod.
@@ -99,14 +99,25 @@ public class DevSeedController : HumansControllerBase
         try
         {
             var seeder = _serviceProvider.GetRequiredService<DevelopmentDashboardSeeder>();
+
+            DashboardResetResult? resetResult = null;
+            if (reset)
+            {
+                resetResult = await seeder.ResetAsync(cancellationToken);
+            }
+
             var result = await seeder.SeedAsync(cancellationToken);
+
             if (result.AlreadySeeded)
             {
-                SetSuccess("Dashboard demo data already present — no changes.");
+                SetSuccess("Dashboard demo data already present — no changes. Pass ?reset=true to reseed.");
             }
             else
             {
-                SetSuccess($"Dashboard demo seeded: {result.TeamsCreated} teams, {result.UsersCreated} humans, {result.ShiftsCreated} shifts, {result.SignupsCreated} signups, {result.TicketOrdersCreated} ticket orders.");
+                var resetNote = resetResult is null
+                    ? ""
+                    : $"Reset removed {resetResult.EventsDeleted} events, {resetResult.TeamsDeleted} teams, {resetResult.UsersDeleted} humans, {resetResult.TicketOrdersDeleted} ticket orders. ";
+                SetSuccess($"{resetNote}Dashboard demo seeded: {result.TeamsCreated} teams, {result.UsersCreated} humans, {result.ShiftsCreated} shifts, {result.SignupsCreated} signups, {result.TicketOrdersCreated} ticket orders.");
             }
         }
         catch (Exception ex)

--- a/src/Humans.Web/Controllers/DevSeedController.cs
+++ b/src/Humans.Web/Controllers/DevSeedController.cs
@@ -116,8 +116,8 @@ public class DevSeedController : HumansControllerBase
             {
                 var resetNote = resetResult is null
                     ? ""
-                    : $"Reset removed {resetResult.EventsDeleted} events, {resetResult.TeamsDeleted} teams, {resetResult.UsersDeleted} humans, {resetResult.TicketOrdersDeleted} ticket orders. ";
-                SetSuccess($"{resetNote}Dashboard demo seeded: {result.TeamsCreated} teams, {result.UsersCreated} humans, {result.ShiftsCreated} shifts, {result.SignupsCreated} signups, {result.TicketOrdersCreated} ticket orders.");
+                    : $"Reset removed {resetResult.EventsDeleted} events, {resetResult.TeamsDeleted} teams, {resetResult.UsersDeleted} humans. ";
+                SetSuccess($"{resetNote}Dashboard demo seeded: {result.TeamsCreated} teams, {result.UsersCreated} humans, {result.ShiftsCreated} shifts, {result.SignupsCreated} signups.");
             }
         }
         catch (Exception ex)

--- a/src/Humans.Web/Controllers/DevSeedController.cs
+++ b/src/Humans.Web/Controllers/DevSeedController.cs
@@ -77,4 +77,44 @@ public class DevSeedController : HumansControllerBase
         return _configuration.GetSettingValue(
             _configRegistry, "DevAuth:Enabled", "Development", defaultValue: false);
     }
+
+    [Authorize(Policy = PolicyNames.ShiftDashboardAccess)]
+    [HttpPost("dashboard")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> SeedDashboard(CancellationToken cancellationToken)
+    {
+        // Stricter than IsDevSeedEnabled: dashboard seed runs only on local Development
+        // (ASPNETCORE_ENVIRONMENT=Development), never on QA / preview / prod.
+        if (!_environment.IsDevelopment() || !IsDevSeedEnabled())
+        {
+            return NotFound();
+        }
+
+        var (errorResult, _) = await RequireCurrentUserAsync();
+        if (errorResult is not null)
+        {
+            return errorResult;
+        }
+
+        try
+        {
+            var seeder = _serviceProvider.GetRequiredService<DevelopmentDashboardSeeder>();
+            var result = await seeder.SeedAsync(cancellationToken);
+            if (result.AlreadySeeded)
+            {
+                SetSuccess("Dashboard demo data already present — no changes.");
+            }
+            else
+            {
+                SetSuccess($"Dashboard demo seeded: {result.TeamsCreated} teams, {result.UsersCreated} humans, {result.ShiftsCreated} shifts, {result.SignupsCreated} signups, {result.TicketOrdersCreated} ticket orders.");
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to seed dashboard demo data.");
+            SetError("Dashboard seeding failed. Check logs for details.");
+        }
+
+        return Redirect("/Shifts/Dashboard");
+    }
 }

--- a/src/Humans.Web/Controllers/ShiftDashboardController.cs
+++ b/src/Humans.Web/Controllers/ShiftDashboardController.cs
@@ -1,3 +1,4 @@
+using Humans.Application.Enums;
 using Humans.Application.Interfaces;
 using Humans.Domain.Constants;
 using Humans.Domain.Entities;
@@ -21,6 +22,7 @@ public class ShiftDashboardController : HumansControllerBase
     private readonly IShiftSignupService _signupService;
     private readonly IGeneralAvailabilityService _availabilityService;
     private readonly UserManager<User> _userManager;
+    private readonly IWebHostEnvironment _environment;
     private readonly ILogger<ShiftDashboardController> _logger;
 
     public ShiftDashboardController(
@@ -28,6 +30,7 @@ public class ShiftDashboardController : HumansControllerBase
         IShiftSignupService signupService,
         IGeneralAvailabilityService availabilityService,
         UserManager<User> userManager,
+        IWebHostEnvironment environment,
         ILogger<ShiftDashboardController> logger)
         : base(userManager)
     {
@@ -35,11 +38,12 @@ public class ShiftDashboardController : HumansControllerBase
         _signupService = signupService;
         _availabilityService = availabilityService;
         _userManager = userManager;
+        _environment = environment;
         _logger = logger;
     }
 
     [HttpGet("")]
-    public async Task<IActionResult> Index(Guid? departmentId, Guid? rotaId, string? date)
+    public async Task<IActionResult> Index(Guid? departmentId, Guid? rotaId, string? date, TrendWindow? trendWindow)
     {
         var es = await _shiftMgmt.GetActiveAsync();
         if (es is null)
@@ -56,11 +60,17 @@ public class ShiftDashboardController : HumansControllerBase
                 filterDate = parseResult.Value;
         }
 
+        var window = trendWindow ?? TrendWindow.Last30Days;
+
+        // Sequential awaits — shared scoped DbContext is not safe for concurrent queries.
         var shifts = await _shiftMgmt.GetUrgentShiftsAsync(es.Id, limit: null, departmentId, filterDate);
         var staffingData = await _shiftMgmt.GetStaffingDataAsync(es.Id, departmentId);
         var staffingHours = await _shiftMgmt.GetStaffingHoursAsync(es.Id, departmentId);
-
+        var overview = await _shiftMgmt.GetDashboardOverviewAsync(es.Id);
+        var coordinatorActivity = await _shiftMgmt.GetCoordinatorActivityAsync(es.Id);
+        var trends = await _shiftMgmt.GetDashboardTrendsAsync(es.Id, window);
         var deptTuples = await _shiftMgmt.GetDepartmentsWithRotasAsync(es.Id);
+
         var departments = deptTuples.Select(d => new DepartmentOption
         {
             TeamId = d.TeamId,
@@ -76,7 +86,12 @@ public class ShiftDashboardController : HumansControllerBase
             SelectedDate = date,
             EventSettings = es,
             StaffingData = staffingData.ToList(),
-            StaffingHours = staffingHours.ToList()
+            StaffingHours = staffingHours.ToList(),
+            Overview = overview,
+            CoordinatorActivity = coordinatorActivity,
+            Trends = trends,
+            TrendWindow = window,
+            IsDevelopment = _environment.IsDevelopment(),
         };
 
         return View(model);

--- a/src/Humans.Web/Controllers/ShiftDashboardController.cs
+++ b/src/Humans.Web/Controllers/ShiftDashboardController.cs
@@ -74,7 +74,9 @@ public class ShiftDashboardController : HumansControllerBase
         var staffingHours = await _shiftMgmt.GetStaffingHoursAsync(es.Id, departmentId, period);
         var overview = await _shiftMgmt.GetDashboardOverviewAsync(es.Id, period);
         var coordinatorActivity = await _shiftMgmt.GetCoordinatorActivityAsync(es.Id, period);
-        var trends = await _shiftMgmt.GetDashboardTrendsAsync(es.Id, window, period);
+        // Always fetch the full history; the partial slices client-side on window toggle
+        // so the user doesn't incur a full page reload to change the trend range.
+        var trends = await _shiftMgmt.GetDashboardTrendsAsync(es.Id, TrendWindow.All, period);
         var deptTuples = await _shiftMgmt.GetDepartmentsWithRotasAsync(es.Id);
 
         var departments = deptTuples.Select(d => new DepartmentOption

--- a/src/Humans.Web/Controllers/ShiftDashboardController.cs
+++ b/src/Humans.Web/Controllers/ShiftDashboardController.cs
@@ -2,6 +2,7 @@ using Humans.Application.Enums;
 using Humans.Application.Interfaces;
 using Humans.Domain.Constants;
 using Humans.Domain.Entities;
+using Humans.Domain.Enums;
 using Humans.Web.Authorization;
 using Humans.Web.Extensions;
 using Humans.Web.Helpers;
@@ -43,7 +44,12 @@ public class ShiftDashboardController : HumansControllerBase
     }
 
     [HttpGet("")]
-    public async Task<IActionResult> Index(Guid? departmentId, Guid? rotaId, string? date, TrendWindow? trendWindow)
+    public async Task<IActionResult> Index(
+        Guid? departmentId,
+        Guid? rotaId,
+        string? date,
+        TrendWindow? trendWindow,
+        ShiftPeriod? period)
     {
         var es = await _shiftMgmt.GetActiveAsync();
         if (es is null)
@@ -63,12 +69,12 @@ public class ShiftDashboardController : HumansControllerBase
         var window = trendWindow ?? TrendWindow.Last30Days;
 
         // Sequential awaits — shared scoped DbContext is not safe for concurrent queries.
-        var shifts = await _shiftMgmt.GetUrgentShiftsAsync(es.Id, limit: null, departmentId, filterDate);
-        var staffingData = await _shiftMgmt.GetStaffingDataAsync(es.Id, departmentId);
-        var staffingHours = await _shiftMgmt.GetStaffingHoursAsync(es.Id, departmentId);
-        var overview = await _shiftMgmt.GetDashboardOverviewAsync(es.Id);
-        var coordinatorActivity = await _shiftMgmt.GetCoordinatorActivityAsync(es.Id);
-        var trends = await _shiftMgmt.GetDashboardTrendsAsync(es.Id, window);
+        var shifts = await _shiftMgmt.GetUrgentShiftsAsync(es.Id, limit: null, departmentId, filterDate, period);
+        var staffingData = await _shiftMgmt.GetStaffingDataAsync(es.Id, departmentId, period);
+        var staffingHours = await _shiftMgmt.GetStaffingHoursAsync(es.Id, departmentId, period);
+        var overview = await _shiftMgmt.GetDashboardOverviewAsync(es.Id, period);
+        var coordinatorActivity = await _shiftMgmt.GetCoordinatorActivityAsync(es.Id, period);
+        var trends = await _shiftMgmt.GetDashboardTrendsAsync(es.Id, window, period);
         var deptTuples = await _shiftMgmt.GetDepartmentsWithRotasAsync(es.Id);
 
         var departments = deptTuples.Select(d => new DepartmentOption
@@ -84,6 +90,7 @@ public class ShiftDashboardController : HumansControllerBase
             SelectedDepartmentId = departmentId,
             SelectedRotaId = rotaId,
             SelectedDate = date,
+            SelectedPeriod = period,
             EventSettings = es,
             StaffingData = staffingData.ToList(),
             StaffingHours = staffingHours.ToList(),

--- a/src/Humans.Web/Infrastructure/DevelopmentDashboardSeeder.cs
+++ b/src/Humans.Web/Infrastructure/DevelopmentDashboardSeeder.cs
@@ -15,6 +15,12 @@ public sealed record DashboardSeedResult(
     int SignupsCreated,
     int TicketOrdersCreated);
 
+public sealed record DashboardResetResult(
+    int EventsDeleted,
+    int TeamsDeleted,
+    int UsersDeleted,
+    int TicketOrdersDeleted);
+
 /// <summary>
 /// Seeds deterministic-ish demo data for the volunteer coordinator dashboard.
 /// Gated to IsDevelopment() only by the calling controller. Not safe to run in QA/prod.
@@ -376,6 +382,71 @@ public sealed class DevelopmentDashboardSeeder
             ShiftsCreated: shifts.Count,
             SignupsCreated: signupsCreated,
             TicketOrdersCreated: ticketOrdersCreated);
+    }
+
+    /// <summary>
+    /// Deletes all data previously created by <see cref="SeedAsync"/>: the seeded
+    /// event (with cascading rotas/shifts/signups), dev teams (slug prefix "dev-"),
+    /// dev users (email pattern "dev-human-*@seed.local"), and their DEV-* ticket
+    /// orders. Safe to call on a DB where no seed has ever run.
+    /// </summary>
+    public async Task<DashboardResetResult> ResetAsync(CancellationToken cancellationToken)
+    {
+        // Order matters: delete rows that reference others first to avoid FK violations
+        // on databases without ON DELETE CASCADE configured for every edge.
+        var devUserEmails = await _dbContext.Users
+            .Where(u => u.Email != null && u.Email.EndsWith("@seed.local") && u.Email.StartsWith("dev-human-"))
+            .Select(u => u.Id)
+            .ToListAsync(cancellationToken);
+
+        var devTeamIds = await _dbContext.Teams
+            .Where(t => t.Slug.StartsWith("dev-"))
+            .Select(t => t.Id)
+            .ToListAsync(cancellationToken);
+
+        var seededEventIds = await _dbContext.EventSettings
+            .Where(e => e.EventName == SeededEventName)
+            .Select(e => e.Id)
+            .ToListAsync(cancellationToken);
+
+        // Signups reference Users + Shifts; delete first.
+        await _dbContext.ShiftSignups
+            .Where(s => devUserEmails.Contains(s.UserId) || s.Shift.Rota.Team.Slug.StartsWith("dev-"))
+            .ExecuteDeleteAsync(cancellationToken);
+
+        await _dbContext.Shifts
+            .Where(s => s.Rota.Team.Slug.StartsWith("dev-"))
+            .ExecuteDeleteAsync(cancellationToken);
+
+        await _dbContext.Rotas
+            .Where(r => r.Team.Slug.StartsWith("dev-") || seededEventIds.Contains(r.EventSettingsId))
+            .ExecuteDeleteAsync(cancellationToken);
+
+        await _dbContext.TeamMembers
+            .Where(tm => devTeamIds.Contains(tm.TeamId) || devUserEmails.Contains(tm.UserId))
+            .ExecuteDeleteAsync(cancellationToken);
+
+        var ticketsDeleted = await _dbContext.TicketOrders
+            .Where(t => t.VendorOrderId.StartsWith("DEV-") || (t.MatchedUserId != null && devUserEmails.Contains(t.MatchedUserId.Value)))
+            .ExecuteDeleteAsync(cancellationToken);
+
+        var usersDeleted = await _dbContext.Users
+            .Where(u => devUserEmails.Contains(u.Id))
+            .ExecuteDeleteAsync(cancellationToken);
+
+        var teamsDeleted = await _dbContext.Teams
+            .Where(t => t.Slug.StartsWith("dev-"))
+            .ExecuteDeleteAsync(cancellationToken);
+
+        var eventsDeleted = await _dbContext.EventSettings
+            .Where(e => e.EventName == SeededEventName)
+            .ExecuteDeleteAsync(cancellationToken);
+
+        _logger.LogInformation(
+            "Dashboard seed reset complete: {Events} events, {Teams} teams, {Users} users, {Tickets} ticket orders deleted.",
+            eventsDeleted, teamsDeleted, usersDeleted, ticketsDeleted);
+
+        return new DashboardResetResult(eventsDeleted, teamsDeleted, usersDeleted, ticketsDeleted);
     }
 
     private static string SlugFor(string name)

--- a/src/Humans.Web/Infrastructure/DevelopmentDashboardSeeder.cs
+++ b/src/Humans.Web/Infrastructure/DevelopmentDashboardSeeder.cs
@@ -1,0 +1,344 @@
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using Humans.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using NodaTime;
+
+namespace Humans.Web.Infrastructure;
+
+public sealed record DashboardSeedResult(
+    bool AlreadySeeded,
+    int TeamsCreated,
+    int UsersCreated,
+    int ShiftsCreated,
+    int SignupsCreated,
+    int TicketOrdersCreated);
+
+/// <summary>
+/// Seeds deterministic-ish demo data for the volunteer coordinator dashboard.
+/// Gated to IsDevelopment() only by the calling controller. Not safe to run in QA/prod.
+/// </summary>
+public sealed class DevelopmentDashboardSeeder
+{
+    private const string SeededEventName = "Seeded Nowhere 2026 (dev)";
+
+    private static readonly string[] ParentTeamNames =
+        ["Gate", "Infrastructure", "Kitchen", "Medics", "Rangers", "DPW"];
+
+    private static readonly string[] InfrastructureSubteamNames = ["Power", "Plumbing"];
+
+    // A deterministic RNG so reruns on a clean DB produce the same-ish shape.
+    private readonly Random _rng = new(42);
+
+    private readonly HumansDbContext _dbContext;
+    private readonly IClock _clock;
+    private readonly ILogger<DevelopmentDashboardSeeder> _logger;
+
+    public DevelopmentDashboardSeeder(
+        HumansDbContext dbContext,
+        IClock clock,
+        ILogger<DevelopmentDashboardSeeder> logger)
+    {
+        _dbContext = dbContext;
+        _clock = clock;
+        _logger = logger;
+    }
+
+    public async Task<DashboardSeedResult> SeedAsync(CancellationToken cancellationToken)
+    {
+        var existing = await _dbContext.EventSettings
+            .FirstOrDefaultAsync(e => e.EventName == SeededEventName, cancellationToken);
+        if (existing is not null)
+        {
+            _logger.LogInformation("Dashboard seed already applied (event '{EventName}' exists).", SeededEventName);
+            return new DashboardSeedResult(AlreadySeeded: true, 0, 0, 0, 0, 0);
+        }
+
+        var now = _clock.GetCurrentInstant();
+        var todayUtc = now.InUtc().Date;
+
+        // Deactivate any existing active event so ours becomes the one resolved by GetActiveAsync.
+        var existingActive = await _dbContext.EventSettings
+            .Where(e => e.IsActive)
+            .ToListAsync(cancellationToken);
+        foreach (var e in existingActive)
+        {
+            e.IsActive = false;
+            e.UpdatedAt = now;
+        }
+
+        var es = new EventSettings
+        {
+            Id = Guid.NewGuid(),
+            EventName = SeededEventName,
+            Year = todayUtc.Year,
+            TimeZoneId = "Europe/Madrid",
+            GateOpeningDate = todayUtc.PlusDays(60),
+            BuildStartOffset = -14,
+            EventEndOffset = 6,
+            StrikeEndOffset = 9,
+            IsActive = true,
+            CreatedAt = now.Minus(Duration.FromDays(30)),
+            UpdatedAt = now,
+        };
+        _dbContext.EventSettings.Add(es);
+
+        var teamsCreated = 0;
+        var parentTeams = new Dictionary<string, Team>(StringComparer.Ordinal);
+        foreach (var name in ParentTeamNames)
+        {
+            var t = new Team
+            {
+                Id = Guid.NewGuid(),
+                Name = $"{name} (dev)",
+                Slug = $"dev-{name.ToLowerInvariant()}",
+                IsActive = true,
+                CreatedAt = now,
+                UpdatedAt = now,
+            };
+            parentTeams[name] = t;
+            _dbContext.Teams.Add(t);
+            teamsCreated++;
+        }
+
+        var subteams = new Dictionary<string, Team>(StringComparer.Ordinal);
+        foreach (var name in InfrastructureSubteamNames)
+        {
+            var t = new Team
+            {
+                Id = Guid.NewGuid(),
+                Name = $"{name} (dev)",
+                Slug = $"dev-{name.ToLowerInvariant()}",
+                IsActive = true,
+                ParentTeamId = parentTeams["Infrastructure"].Id,
+                CreatedAt = now,
+                UpdatedAt = now,
+            };
+            subteams[name] = t;
+            _dbContext.Teams.Add(t);
+            teamsCreated++;
+        }
+
+        // Rotas: one per period per parent team, plus Event-period rotas on each Infrastructure subteam.
+        var rotaConfigs = new List<(Team Team, RotaPeriod Period, string Label, double ConfirmedRate)>();
+        foreach (var parent in parentTeams.Values)
+        {
+            var isWellStaffed = parent.Name.StartsWith("Gate", StringComparison.Ordinal)
+                             || parent.Name.StartsWith("Kitchen", StringComparison.Ordinal);
+            rotaConfigs.Add((parent, RotaPeriod.Build, "Build", isWellStaffed ? 0.85 : 0.55));
+            rotaConfigs.Add((parent, RotaPeriod.Event, "Event", isWellStaffed ? 0.9 : 0.6));
+            rotaConfigs.Add((parent, RotaPeriod.Strike, "Strike", 0.2));
+        }
+        rotaConfigs.Add((subteams["Power"], RotaPeriod.Event, "Event", 0.85));
+        rotaConfigs.Add((subteams["Plumbing"], RotaPeriod.Event, "Event", 0.4));
+
+        var allRotas = new List<(Rota Rota, double ConfirmedRate)>();
+        foreach (var (team, period, label, confirmedRate) in rotaConfigs)
+        {
+            var rota = new Rota
+            {
+                Id = Guid.NewGuid(),
+                TeamId = team.Id,
+                EventSettingsId = es.Id,
+                Name = $"{team.Name} - {label}",
+                Priority = ShiftPriority.Normal,
+                Policy = SignupPolicy.RequireApproval,
+                Period = period,
+                IsVisibleToVolunteers = true,
+                CreatedAt = now,
+                UpdatedAt = now,
+            };
+            _dbContext.Rotas.Add(rota);
+            allRotas.Add((rota, confirmedRate));
+        }
+
+        // Shifts: 8–12 per rota with varied min/max/duration and day offsets by period.
+        var shifts = new List<(Shift Shift, double ConfirmedRate)>();
+        foreach (var (rota, rate) in allRotas)
+        {
+            var count = _rng.Next(8, 13);
+            for (var i = 0; i < count; i++)
+            {
+                var dayOffset = rota.Period switch
+                {
+                    RotaPeriod.Build => _rng.Next(-14, 0),
+                    RotaPeriod.Event => _rng.Next(0, 7),
+                    RotaPeriod.Strike => _rng.Next(7, 10),
+                    _ => 0,
+                };
+                var min = _rng.Next(2, 6);
+                var max = min + _rng.Next(1, 4);
+                var isAllDay = rota.Period != RotaPeriod.Event;
+                var shift = new Shift
+                {
+                    Id = Guid.NewGuid(),
+                    RotaId = rota.Id,
+                    DayOffset = dayOffset,
+                    StartTime = isAllDay ? new LocalTime(0, 0) : new LocalTime(_rng.Next(8, 20), 0),
+                    Duration = isAllDay
+                        ? Duration.FromHours(24)
+                        : Duration.FromHours(_rng.Next(2, 9)),
+                    MinVolunteers = min,
+                    MaxVolunteers = max,
+                    IsAllDay = isAllDay,
+                    CreatedAt = now,
+                    UpdatedAt = now,
+                };
+                _dbContext.Shifts.Add(shift);
+                shifts.Add((shift, rate));
+            }
+        }
+
+        // Users: keep the cohort small (~120) — large enough to show activity, small enough to keep the dev seed fast.
+        var totalUsers = 120;
+        var ticketHolderCount = 90;
+
+        var users = new List<User>();
+        var ticketOrdersCreated = 0;
+        for (var i = 0; i < totalUsers; i++)
+        {
+            var display = $"Dev Human {i:D3}";
+            var email = $"dev-human-{i:D3}@seed.local";
+            var createdAt = now.Minus(Duration.FromDays(_rng.Next(30, 400)));
+            var lastLoginDaysAgo = _rng.Next(0, 30);
+            var user = new User
+            {
+                Id = Guid.NewGuid(),
+                UserName = email,
+                NormalizedUserName = email.ToUpperInvariant(),
+                Email = email,
+                NormalizedEmail = email.ToUpperInvariant(),
+                EmailConfirmed = true,
+                DisplayName = display,
+                SecurityStamp = Guid.NewGuid().ToString("N"),
+                CreatedAt = createdAt,
+                LastLoginAt = now.Minus(Duration.FromDays(lastLoginDaysAgo)).Minus(Duration.FromHours(_rng.Next(0, 23))),
+            };
+            users.Add(user);
+            _dbContext.Users.Add(user);
+
+            if (i < ticketHolderCount)
+            {
+                _dbContext.TicketOrders.Add(new TicketOrder
+                {
+                    Id = Guid.NewGuid(),
+                    VendorOrderId = $"DEV-{i:D4}",
+                    BuyerName = display,
+                    BuyerEmail = email,
+                    MatchedUserId = user.Id,
+                    TotalAmount = 80m,
+                    Currency = "EUR",
+                    PaymentStatus = TicketPaymentStatus.Paid,
+                    VendorEventId = "dev-vendor-event",
+                    PurchasedAt = now.Minus(Duration.FromDays(_rng.Next(0, 45))),
+                    SyncedAt = now,
+                });
+                ticketOrdersCreated++;
+            }
+        }
+
+        // Coordinators: 2 per parent team. Infrastructure coords logged in 9 days ago (stale).
+        foreach (var parent in parentTeams.Values)
+        {
+            var isInfrastructure = parent.Name.StartsWith("Infrastructure", StringComparison.Ordinal);
+            var coordLastLogin = isInfrastructure
+                ? now.Minus(Duration.FromDays(9))
+                : now.Minus(Duration.FromHours(_rng.Next(1, 48)));
+
+            for (var i = 0; i < 2; i++)
+            {
+                var coord = users[_rng.Next(users.Count)];
+                coord.LastLoginAt = coordLastLogin;
+                _dbContext.TeamMembers.Add(new TeamMember
+                {
+                    Id = Guid.NewGuid(),
+                    TeamId = parent.Id,
+                    UserId = coord.Id,
+                    Role = TeamMemberRole.Coordinator,
+                    JoinedAt = now.Minus(Duration.FromDays(60)),
+                });
+            }
+        }
+
+        // Signups: rate-driven Confirmed vs Pending, plus a few Bailed / Refused, and some stale Pending.
+        var signupsCreated = 0;
+        var pickedSignups = new HashSet<(Guid ShiftId, Guid UserId)>();
+        foreach (var (shift, rate) in shifts)
+        {
+            var targetConfirmed = (int)Math.Round(shift.MaxVolunteers * rate);
+            for (var i = 0; i < targetConfirmed && i < shift.MaxVolunteers; i++)
+            {
+                var user = users[_rng.Next(users.Count)];
+                var key = (shift.Id, user.Id);
+                if (!pickedSignups.Add(key)) continue;
+                _dbContext.ShiftSignups.Add(new ShiftSignup
+                {
+                    Id = Guid.NewGuid(),
+                    ShiftId = shift.Id,
+                    UserId = user.Id,
+                    Status = SignupStatus.Confirmed,
+                    CreatedAt = now.Minus(Duration.FromDays(_rng.Next(0, 20))),
+                    UpdatedAt = now,
+                });
+                signupsCreated++;
+            }
+
+            // A couple of pending per shift to create visible pending load.
+            for (var i = 0; i < 2; i++)
+            {
+                var user = users[_rng.Next(users.Count)];
+                var key = (shift.Id, user.Id);
+                if (!pickedSignups.Add(key)) continue;
+                // Some of these are stale (>3 days old).
+                var createdDaysAgo = _rng.Next(0, 8);
+                _dbContext.ShiftSignups.Add(new ShiftSignup
+                {
+                    Id = Guid.NewGuid(),
+                    ShiftId = shift.Id,
+                    UserId = user.Id,
+                    Status = SignupStatus.Pending,
+                    CreatedAt = now.Minus(Duration.FromDays(createdDaysAgo)),
+                    UpdatedAt = now,
+                });
+                signupsCreated++;
+            }
+        }
+
+        // A few Bailed / Refused to exercise filters.
+        for (var i = 0; i < 8 && i < shifts.Count; i++)
+        {
+            var (shift, _) = shifts[_rng.Next(shifts.Count)];
+            var user = users[_rng.Next(users.Count)];
+            var key = (shift.Id, user.Id);
+            if (!pickedSignups.Add(key)) continue;
+            _dbContext.ShiftSignups.Add(new ShiftSignup
+            {
+                Id = Guid.NewGuid(),
+                ShiftId = shift.Id,
+                UserId = user.Id,
+                Status = i % 2 == 0 ? SignupStatus.Bailed : SignupStatus.Refused,
+                CreatedAt = now.Minus(Duration.FromDays(_rng.Next(1, 10))),
+                UpdatedAt = now,
+                ReviewedAt = now,
+                ReviewedByUserId = users[0].Id,
+                StatusReason = "Seeded for demo",
+            });
+            signupsCreated++;
+        }
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        _logger.LogInformation(
+            "Dashboard seed complete: {Teams} teams, {Users} users, {Shifts} shifts, {Signups} signups, {Tickets} ticket orders.",
+            teamsCreated, users.Count, shifts.Count, signupsCreated, ticketOrdersCreated);
+
+        return new DashboardSeedResult(
+            AlreadySeeded: false,
+            TeamsCreated: teamsCreated,
+            UsersCreated: users.Count,
+            ShiftsCreated: shifts.Count,
+            SignupsCreated: signupsCreated,
+            TicketOrdersCreated: ticketOrdersCreated);
+    }
+}

--- a/src/Humans.Web/Infrastructure/DevelopmentDashboardSeeder.cs
+++ b/src/Humans.Web/Infrastructure/DevelopmentDashboardSeeder.cs
@@ -23,10 +23,29 @@ public sealed class DevelopmentDashboardSeeder
 {
     private const string SeededEventName = "Seeded Nowhere 2026 (dev)";
 
+    // Match real, non-hidden parent departments from the production Teams list
+    // so the dashboard seed reflects terminology the coordinators actually use.
     private static readonly string[] ParentTeamNames =
-        ["Gate", "Infrastructure", "Kitchen", "Medics", "Rangers", "DPW"];
+    [
+        "Gate",
+        "Infrastructure",
+        "Participant Wellness",
+        "Ice and Water",
+        "Site Operations",
+        "Production & Logistics",
+        "Werkhaus/Barrio",
+        "Power",
+    ];
 
-    private static readonly string[] InfrastructureSubteamNames = ["Power", "Plumbing"];
+    // Subteams chosen to exercise the department-expand UI:
+    //   - Participant Wellness has 3 subteams + "Direct" row (wide expand).
+    //   - Ice and Water has 2 subteams.
+    //   - Other parents have none (exercise the per-period row path).
+    private static readonly (string Parent, string[] Subteams)[] Subteams =
+    [
+        ("Participant Wellness", ["Consent", "Welfare", "Ohana House"]),
+        ("Ice and Water", ["Ice Ice Baby", "Icemakers"]),
+    ];
 
     // A deterministic RNG so reruns on a clean DB produce the same-ish shape.
     private readonly Random _rng = new(42);
@@ -92,7 +111,7 @@ public sealed class DevelopmentDashboardSeeder
             {
                 Id = Guid.NewGuid(),
                 Name = $"{name} (dev)",
-                Slug = $"dev-{name.ToLowerInvariant()}",
+                Slug = SlugFor(name),
                 IsActive = true,
                 CreatedAt = now,
                 UpdatedAt = now,
@@ -103,35 +122,52 @@ public sealed class DevelopmentDashboardSeeder
         }
 
         var subteams = new Dictionary<string, Team>(StringComparer.Ordinal);
-        foreach (var name in InfrastructureSubteamNames)
+        foreach (var (parentName, subNames) in Subteams)
         {
-            var t = new Team
+            foreach (var subName in subNames)
             {
-                Id = Guid.NewGuid(),
-                Name = $"{name} (dev)",
-                Slug = $"dev-{name.ToLowerInvariant()}",
-                IsActive = true,
-                ParentTeamId = parentTeams["Infrastructure"].Id,
-                CreatedAt = now,
-                UpdatedAt = now,
-            };
-            subteams[name] = t;
-            _dbContext.Teams.Add(t);
-            teamsCreated++;
+                var t = new Team
+                {
+                    Id = Guid.NewGuid(),
+                    Name = $"{subName} (dev)",
+                    Slug = SlugFor(subName),
+                    IsActive = true,
+                    ParentTeamId = parentTeams[parentName].Id,
+                    CreatedAt = now,
+                    UpdatedAt = now,
+                };
+                subteams[subName] = t;
+                _dbContext.Teams.Add(t);
+                teamsCreated++;
+            }
         }
 
-        // Rotas: one per period per parent team, plus Event-period rotas on each Infrastructure subteam.
+        // Rotas: one per period per parent team, plus Event-period rotas on each subteam.
+        // Subteam fill rates are tuned to produce a mix of low/mid/high % chips in the expand view.
+        var subteamRates = new Dictionary<string, double>(StringComparer.Ordinal)
+        {
+            // Participant Wellness: one low (drives the red chip), one mid, one high.
+            ["Consent"] = 0.3,
+            ["Welfare"] = 0.6,
+            ["Ohana House"] = 0.85,
+            // Ice and Water: one mid, one high.
+            ["Ice Ice Baby"] = 0.55,
+            ["Icemakers"] = 0.9,
+        };
+
         var rotaConfigs = new List<(Team Team, RotaPeriod Period, string Label, double ConfirmedRate)>();
         foreach (var parent in parentTeams.Values)
         {
             var isWellStaffed = parent.Name.StartsWith("Gate", StringComparison.Ordinal)
-                             || parent.Name.StartsWith("Kitchen", StringComparison.Ordinal);
+                             || parent.Name.StartsWith("Site Operations", StringComparison.Ordinal);
             rotaConfigs.Add((parent, RotaPeriod.Build, "Build", isWellStaffed ? 0.85 : 0.55));
             rotaConfigs.Add((parent, RotaPeriod.Event, "Event", isWellStaffed ? 0.9 : 0.6));
             rotaConfigs.Add((parent, RotaPeriod.Strike, "Strike", 0.2));
         }
-        rotaConfigs.Add((subteams["Power"], RotaPeriod.Event, "Event", 0.85));
-        rotaConfigs.Add((subteams["Plumbing"], RotaPeriod.Event, "Event", 0.4));
+        foreach (var (subName, rate) in subteamRates)
+        {
+            rotaConfigs.Add((subteams[subName], RotaPeriod.Event, "Event", rate));
+        }
 
         var allRotas = new List<(Rota Rota, double ConfirmedRate)>();
         foreach (var (team, period, label, confirmedRate) in rotaConfigs)
@@ -340,5 +376,26 @@ public sealed class DevelopmentDashboardSeeder
             ShiftsCreated: shifts.Count,
             SignupsCreated: signupsCreated,
             TicketOrdersCreated: ticketOrdersCreated);
+    }
+
+    private static string SlugFor(string name)
+    {
+        var lower = name.ToLowerInvariant();
+        var sb = new System.Text.StringBuilder("dev-", lower.Length + 4);
+        var lastDash = true;
+        foreach (var ch in lower)
+        {
+            if (ch is >= 'a' and <= 'z' or >= '0' and <= '9')
+            {
+                sb.Append(ch);
+                lastDash = false;
+            }
+            else if (!lastDash)
+            {
+                sb.Append('-');
+                lastDash = true;
+            }
+        }
+        return sb.ToString().TrimEnd('-');
     }
 }

--- a/src/Humans.Web/Infrastructure/DevelopmentDashboardSeeder.cs
+++ b/src/Humans.Web/Infrastructure/DevelopmentDashboardSeeder.cs
@@ -27,7 +27,7 @@ public sealed record DashboardResetResult(
 /// </summary>
 public sealed class DevelopmentDashboardSeeder
 {
-    private const string SeededEventName = "Seeded Nowhere 2026 (dev)";
+    private const string SeededEventName = "Seeded Elsewhere 2026 (dev)";
 
     // Match real, non-hidden parent departments from the production Teams list
     // so the dashboard seed reflects terminology the coordinators actually use.

--- a/src/Humans.Web/Infrastructure/DevelopmentDashboardSeeder.cs
+++ b/src/Humans.Web/Infrastructure/DevelopmentDashboardSeeder.cs
@@ -201,7 +201,7 @@ public sealed class DevelopmentDashboardSeeder
             var display = $"Dev Human {i:D3}";
             var email = $"dev-human-{i:D3}@seed.local";
             var createdAt = now.Minus(Duration.FromDays(_rng.Next(30, 400)));
-            var lastLoginDaysAgo = _rng.Next(0, 30);
+            var lastLoginDaysAgo = _rng.Next(0, 85);
             var user = new User
             {
                 Id = Guid.NewGuid(),
@@ -231,7 +231,7 @@ public sealed class DevelopmentDashboardSeeder
                     Currency = "EUR",
                     PaymentStatus = TicketPaymentStatus.Paid,
                     VendorEventId = "dev-vendor-event",
-                    PurchasedAt = now.Minus(Duration.FromDays(_rng.Next(0, 45))),
+                    PurchasedAt = now.Minus(Duration.FromDays(_rng.Next(0, 85))),
                     SyncedAt = now,
                 });
                 ticketOrdersCreated++;
@@ -278,7 +278,7 @@ public sealed class DevelopmentDashboardSeeder
                     ShiftId = shift.Id,
                     UserId = user.Id,
                     Status = SignupStatus.Confirmed,
-                    CreatedAt = now.Minus(Duration.FromDays(_rng.Next(0, 20))),
+                    CreatedAt = now.Minus(Duration.FromDays(_rng.Next(0, 85))),
                     UpdatedAt = now,
                 });
                 signupsCreated++;

--- a/src/Humans.Web/Infrastructure/DevelopmentDashboardSeeder.cs
+++ b/src/Humans.Web/Infrastructure/DevelopmentDashboardSeeder.cs
@@ -1,6 +1,8 @@
+using Humans.Application.Interfaces;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Humans.Infrastructure.Data;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using NodaTime;
@@ -12,22 +14,30 @@ public sealed record DashboardSeedResult(
     int TeamsCreated,
     int UsersCreated,
     int ShiftsCreated,
-    int SignupsCreated,
-    int TicketOrdersCreated);
+    int SignupsCreated);
 
 public sealed record DashboardResetResult(
     int EventsDeleted,
     int TeamsDeleted,
-    int UsersDeleted,
-    int TicketOrdersDeleted);
+    int UsersDeleted);
 
 /// <summary>
 /// Seeds deterministic-ish demo data for the volunteer coordinator dashboard.
 /// Gated to IsDevelopment() only by the calling controller. Not safe to run in QA/prod.
+///
+/// Cross-domain writes (Users, Teams, TeamMembers) go through the owning services:
+/// <see cref="UserManager{TUser}"/> for Users and <see cref="ITeamService"/> for
+/// Teams/TeamMembers. Shifts-owned tables (EventSettings, Rotas, Shifts, ShiftSignups)
+/// are written directly via <see cref="HumansDbContext"/> because this seeder IS the
+/// Shifts-test-data setup — the same ownership the <see cref="ShiftManagementService"/>
+/// holds in production.
 /// </summary>
 public sealed class DevelopmentDashboardSeeder
 {
     private const string SeededEventName = "Seeded Elsewhere 2026 (dev)";
+    private const string DevTeamNameSuffix = " (dev)";
+    private const string DevUserEmailSuffix = "@seed.local";
+    private const string DevUserEmailPrefix = "dev-human-";
 
     // Match real, non-hidden parent departments from the production Teams list
     // so the dashboard seed reflects terminology the coordinators actually use.
@@ -57,15 +67,21 @@ public sealed class DevelopmentDashboardSeeder
     private readonly Random _rng = new(42);
 
     private readonly HumansDbContext _dbContext;
+    private readonly ITeamService _teamService;
+    private readonly UserManager<User> _userManager;
     private readonly IClock _clock;
     private readonly ILogger<DevelopmentDashboardSeeder> _logger;
 
     public DevelopmentDashboardSeeder(
         HumansDbContext dbContext,
+        ITeamService teamService,
+        UserManager<User> userManager,
         IClock clock,
         ILogger<DevelopmentDashboardSeeder> logger)
     {
         _dbContext = dbContext;
+        _teamService = teamService;
+        _userManager = userManager;
         _clock = clock;
         _logger = logger;
     }
@@ -77,13 +93,14 @@ public sealed class DevelopmentDashboardSeeder
         if (existing is not null)
         {
             _logger.LogInformation("Dashboard seed already applied (event '{EventName}' exists).", SeededEventName);
-            return new DashboardSeedResult(AlreadySeeded: true, 0, 0, 0, 0, 0);
+            return new DashboardSeedResult(AlreadySeeded: true, 0, 0, 0, 0);
         }
 
         var now = _clock.GetCurrentInstant();
         var todayUtc = now.InUtc().Date;
 
         // Deactivate any existing active event so ours becomes the one resolved by GetActiveAsync.
+        // EventSettings is Shifts-owned — the service's direct-write path.
         var existingActive = await _dbContext.EventSettings
             .Where(e => e.IsActive)
             .ToListAsync(cancellationToken);
@@ -108,22 +125,20 @@ public sealed class DevelopmentDashboardSeeder
             UpdatedAt = now,
         };
         _dbContext.EventSettings.Add(es);
+        await _dbContext.SaveChangesAsync(cancellationToken);
 
+        // Teams: create parents, then subteams. Goes through ITeamService so slug
+        // generation, validation, and cache seeding match production.
         var teamsCreated = 0;
         var parentTeams = new Dictionary<string, Team>(StringComparer.Ordinal);
         foreach (var name in ParentTeamNames)
         {
-            var t = new Team
-            {
-                Id = Guid.NewGuid(),
-                Name = $"{name} (dev)",
-                Slug = SlugFor(name),
-                IsActive = true,
-                CreatedAt = now,
-                UpdatedAt = now,
-            };
-            parentTeams[name] = t;
-            _dbContext.Teams.Add(t);
+            var created = await _teamService.CreateTeamAsync(
+                $"{name}{DevTeamNameSuffix}",
+                description: null,
+                requiresApproval: true,
+                cancellationToken: cancellationToken);
+            parentTeams[name] = created;
             teamsCreated++;
         }
 
@@ -132,18 +147,13 @@ public sealed class DevelopmentDashboardSeeder
         {
             foreach (var subName in subNames)
             {
-                var t = new Team
-                {
-                    Id = Guid.NewGuid(),
-                    Name = $"{subName} (dev)",
-                    Slug = SlugFor(subName),
-                    IsActive = true,
-                    ParentTeamId = parentTeams[parentName].Id,
-                    CreatedAt = now,
-                    UpdatedAt = now,
-                };
-                subteams[subName] = t;
-                _dbContext.Teams.Add(t);
+                var created = await _teamService.CreateTeamAsync(
+                    $"{subName}{DevTeamNameSuffix}",
+                    description: null,
+                    requiresApproval: true,
+                    parentTeamId: parentTeams[parentName].Id,
+                    cancellationToken: cancellationToken);
+                subteams[subName] = created;
                 teamsCreated++;
             }
         }
@@ -232,55 +242,44 @@ public sealed class DevelopmentDashboardSeeder
             }
         }
 
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
         // Users: keep the cohort small (~120) — large enough to show activity, small enough to keep the dev seed fast.
+        // Users are an Identity-framework concern; we create them via UserManager, the
+        // standard pattern for framework-owned types. Passwords are intentionally omitted
+        // — these accounts are never logged into; they exist purely as dashboard data.
         var totalUsers = 120;
-        var ticketHolderCount = 90;
 
         var users = new List<User>();
-        var ticketOrdersCreated = 0;
         for (var i = 0; i < totalUsers; i++)
         {
             var display = $"Dev Human {i:D3}";
-            var email = $"dev-human-{i:D3}@seed.local";
+            var email = $"{DevUserEmailPrefix}{i:D3}{DevUserEmailSuffix}";
             var createdAt = now.Minus(Duration.FromDays(_rng.Next(30, 400)));
             var lastLoginDaysAgo = _rng.Next(0, 85);
             var user = new User
             {
-                Id = Guid.NewGuid(),
                 UserName = email,
-                NormalizedUserName = email.ToUpperInvariant(),
                 Email = email,
-                NormalizedEmail = email.ToUpperInvariant(),
                 EmailConfirmed = true,
                 DisplayName = display,
-                SecurityStamp = Guid.NewGuid().ToString("N"),
                 CreatedAt = createdAt,
                 LastLoginAt = now.Minus(Duration.FromDays(lastLoginDaysAgo)).Minus(Duration.FromHours(_rng.Next(0, 23))),
             };
-            users.Add(user);
-            _dbContext.Users.Add(user);
 
-            if (i < ticketHolderCount)
+            var createResult = await _userManager.CreateAsync(user);
+            if (!createResult.Succeeded)
             {
-                _dbContext.TicketOrders.Add(new TicketOrder
-                {
-                    Id = Guid.NewGuid(),
-                    VendorOrderId = $"DEV-{i:D4}",
-                    BuyerName = display,
-                    BuyerEmail = email,
-                    MatchedUserId = user.Id,
-                    TotalAmount = 80m,
-                    Currency = "EUR",
-                    PaymentStatus = TicketPaymentStatus.Paid,
-                    VendorEventId = "dev-vendor-event",
-                    PurchasedAt = now.Minus(Duration.FromDays(_rng.Next(0, 85))),
-                    SyncedAt = now,
-                });
-                ticketOrdersCreated++;
+                throw new InvalidOperationException(
+                    $"Failed to create seeded dev user '{email}': {string.Join(", ", createResult.Errors.Select(e => e.Description))}");
             }
+
+            users.Add(user);
         }
 
-        // Coordinators: 2 per parent team. Infrastructure coords logged in 9 days ago (stale).
+        // Coordinators: 2 per parent team, routed via ITeamService.AddSeededMemberAsync so
+        // we never touch TeamMembers directly. Infrastructure coords logged in 9 days ago
+        // (stale) to drive the red chip on the dashboard.
         foreach (var parent in parentTeams.Values)
         {
             var isInfrastructure = parent.Name.StartsWith("Infrastructure", StringComparison.Ordinal);
@@ -292,14 +291,24 @@ public sealed class DevelopmentDashboardSeeder
             {
                 var coord = users[_rng.Next(users.Count)];
                 coord.LastLoginAt = coordLastLogin;
-                _dbContext.TeamMembers.Add(new TeamMember
+                var updateResult = await _userManager.UpdateAsync(coord);
+                if (!updateResult.Succeeded)
                 {
-                    Id = Guid.NewGuid(),
-                    TeamId = parent.Id,
-                    UserId = coord.Id,
-                    Role = TeamMemberRole.Coordinator,
-                    JoinedAt = now.Minus(Duration.FromDays(60)),
-                });
+                    throw new InvalidOperationException(
+                        $"Failed to update LastLoginAt for seeded coord '{coord.Email}': {string.Join(", ", updateResult.Errors.Select(e => e.Description))}");
+                }
+
+                try
+                {
+                    await _teamService.AddSeededMemberAsync(
+                        parent.Id, coord.Id, TeamMemberRole.Coordinator, now.Minus(Duration.FromDays(60)),
+                        cancellationToken);
+                }
+                catch (InvalidOperationException)
+                {
+                    // The RNG may pick the same user as a coord for multiple teams or twice for
+                    // the same team; ignore duplicate membership (it's just demo data).
+                }
             }
         }
 
@@ -372,101 +381,125 @@ public sealed class DevelopmentDashboardSeeder
         await _dbContext.SaveChangesAsync(cancellationToken);
 
         _logger.LogInformation(
-            "Dashboard seed complete: {Teams} teams, {Users} users, {Shifts} shifts, {Signups} signups, {Tickets} ticket orders.",
-            teamsCreated, users.Count, shifts.Count, signupsCreated, ticketOrdersCreated);
+            "Dashboard seed complete: {Teams} teams, {Users} users, {Shifts} shifts, {Signups} signups.",
+            teamsCreated, users.Count, shifts.Count, signupsCreated);
 
         return new DashboardSeedResult(
             AlreadySeeded: false,
             TeamsCreated: teamsCreated,
             UsersCreated: users.Count,
             ShiftsCreated: shifts.Count,
-            SignupsCreated: signupsCreated,
-            TicketOrdersCreated: ticketOrdersCreated);
+            SignupsCreated: signupsCreated);
     }
 
     /// <summary>
     /// Deletes all data previously created by <see cref="SeedAsync"/>: the seeded
-    /// event (with cascading rotas/shifts/signups), dev teams (slug prefix "dev-"),
-    /// dev users (email pattern "dev-human-*@seed.local"), and their DEV-* ticket
-    /// orders. Safe to call on a DB where no seed has ever run.
+    /// event (with its rotas/shifts/signups), dev teams (name suffix "<c> (dev)</c>"),
+    /// and dev users (email pattern <c>dev-human-*@seed.local</c>). Safe to call on
+    /// a DB where no seed has ever run.
+    ///
+    /// Users go through <see cref="UserManager{TUser}"/>; Teams go through
+    /// <see cref="ITeamService.HardDeleteSeededTeamsAsync"/>. Shifts-owned tables
+    /// are emptied directly — this seeder IS the owning test fixture.
     /// </summary>
     public async Task<DashboardResetResult> ResetAsync(CancellationToken cancellationToken)
     {
-        // Order matters: delete rows that reference others first to avoid FK violations
-        // on databases without ON DELETE CASCADE configured for every edge.
-        var devUserEmails = await _dbContext.Users
-            .Where(u => u.Email != null && u.Email.EndsWith("@seed.local") && u.Email.StartsWith("dev-human-"))
-            .Select(u => u.Id)
-            .ToListAsync(cancellationToken);
-
-        var devTeamIds = await _dbContext.Teams
-            .Where(t => t.Slug.StartsWith("dev-"))
-            .Select(t => t.Id)
-            .ToListAsync(cancellationToken);
-
+        // Order matters: clear Shifts-owned dependents that reference Users/Teams/Events
+        // first so downstream deletions don't trip FK constraints.
         var seededEventIds = await _dbContext.EventSettings
             .Where(e => e.EventName == SeededEventName)
             .Select(e => e.Id)
             .ToListAsync(cancellationToken);
 
-        // Signups reference Users + Shifts; delete first.
-        await _dbContext.ShiftSignups
-            .Where(s => devUserEmails.Contains(s.UserId) || s.Shift.Rota.Team.Slug.StartsWith("dev-"))
-            .ExecuteDeleteAsync(cancellationToken);
+        // Dev users — looked up via UserManager's query surface (framework-owned).
+        var devUserIds = await _userManager.Users
+            .Where(u => u.Email != null
+                        && u.Email.EndsWith(DevUserEmailSuffix)
+                        && u.Email.StartsWith(DevUserEmailPrefix))
+            .Select(u => u.Id)
+            .ToListAsync(cancellationToken);
 
-        await _dbContext.Shifts
-            .Where(s => s.Rota.Team.Slug.StartsWith("dev-"))
-            .ExecuteDeleteAsync(cancellationToken);
-
-        await _dbContext.Rotas
-            .Where(r => r.Team.Slug.StartsWith("dev-") || seededEventIds.Contains(r.EventSettingsId))
-            .ExecuteDeleteAsync(cancellationToken);
-
-        await _dbContext.TeamMembers
-            .Where(tm => devTeamIds.Contains(tm.TeamId) || devUserEmails.Contains(tm.UserId))
-            .ExecuteDeleteAsync(cancellationToken);
-
-        var ticketsDeleted = await _dbContext.TicketOrders
-            .Where(t => t.VendorOrderId.StartsWith("DEV-") || (t.MatchedUserId != null && devUserEmails.Contains(t.MatchedUserId.Value)))
-            .ExecuteDeleteAsync(cancellationToken);
-
-        var usersDeleted = await _dbContext.Users
-            .Where(u => devUserEmails.Contains(u.Id))
-            .ExecuteDeleteAsync(cancellationToken);
-
-        var teamsDeleted = await _dbContext.Teams
-            .Where(t => t.Slug.StartsWith("dev-"))
-            .ExecuteDeleteAsync(cancellationToken);
-
-        var eventsDeleted = await _dbContext.EventSettings
-            .Where(e => e.EventName == SeededEventName)
-            .ExecuteDeleteAsync(cancellationToken);
-
-        _logger.LogInformation(
-            "Dashboard seed reset complete: {Events} events, {Teams} teams, {Users} users, {Tickets} ticket orders deleted.",
-            eventsDeleted, teamsDeleted, usersDeleted, ticketsDeleted);
-
-        return new DashboardResetResult(eventsDeleted, teamsDeleted, usersDeleted, ticketsDeleted);
-    }
-
-    private static string SlugFor(string name)
-    {
-        var lower = name.ToLowerInvariant();
-        var sb = new System.Text.StringBuilder("dev-", lower.Length + 4);
-        var lastDash = true;
-        foreach (var ch in lower)
+        // Rotas created by the seeder live under the seeded event IDs; remove their
+        // shifts + signups first. All three tables are Shifts-owned, so direct
+        // ExecuteDeleteAsync is fine here.
+        if (seededEventIds.Count > 0)
         {
-            if (ch is >= 'a' and <= 'z' or >= '0' and <= '9')
+            var rotaIds = await _dbContext.Rotas
+                .Where(r => seededEventIds.Contains(r.EventSettingsId))
+                .Select(r => r.Id)
+                .ToListAsync(cancellationToken);
+
+            if (rotaIds.Count > 0)
             {
-                sb.Append(ch);
-                lastDash = false;
-            }
-            else if (!lastDash)
-            {
-                sb.Append('-');
-                lastDash = true;
+                var shiftIds = await _dbContext.Shifts
+                    .Where(s => rotaIds.Contains(s.RotaId))
+                    .Select(s => s.Id)
+                    .ToListAsync(cancellationToken);
+
+                if (shiftIds.Count > 0)
+                {
+                    await _dbContext.ShiftSignups
+                        .Where(s => shiftIds.Contains(s.ShiftId))
+                        .ExecuteDeleteAsync(cancellationToken);
+
+                    await _dbContext.Shifts
+                        .Where(s => shiftIds.Contains(s.Id))
+                        .ExecuteDeleteAsync(cancellationToken);
+                }
+
+                await _dbContext.Rotas
+                    .Where(r => rotaIds.Contains(r.Id))
+                    .ExecuteDeleteAsync(cancellationToken);
             }
         }
-        return sb.ToString().TrimEnd('-');
+
+        // Also clear any remaining signups that reference dev users — they might belong to
+        // non-seeded rotas (e.g., after a partially replayed seed). Shifts-owned, direct OK.
+        if (devUserIds.Count > 0)
+        {
+            await _dbContext.ShiftSignups
+                .Where(s => devUserIds.Contains(s.UserId))
+                .ExecuteDeleteAsync(cancellationToken);
+        }
+
+        // Teams (and their TeamMembers + TeamJoinRequests): routed via ITeamService.
+        var teamsDeleted = await _teamService.HardDeleteSeededTeamsAsync(DevTeamNameSuffix, cancellationToken);
+
+        // Users: routed via UserManager.
+        var usersDeleted = 0;
+        if (devUserIds.Count > 0)
+        {
+            // Load each user and delete — UserManager takes entity references, not IDs.
+            // At ~120 users this is fine; it's dev-only teardown.
+            foreach (var userId in devUserIds)
+            {
+                var user = await _userManager.FindByIdAsync(userId.ToString());
+                if (user is null) continue;
+                var deleteResult = await _userManager.DeleteAsync(user);
+                if (!deleteResult.Succeeded)
+                {
+                    _logger.LogWarning(
+                        "Failed to delete seeded dev user {UserId} during reset: {Errors}",
+                        userId, string.Join(", ", deleteResult.Errors.Select(e => e.Description)));
+                    continue;
+                }
+                usersDeleted++;
+            }
+        }
+
+        // Events last: Shifts-owned, direct OK.
+        var eventsDeleted = 0;
+        if (seededEventIds.Count > 0)
+        {
+            eventsDeleted = await _dbContext.EventSettings
+                .Where(e => seededEventIds.Contains(e.Id))
+                .ExecuteDeleteAsync(cancellationToken);
+        }
+
+        _logger.LogInformation(
+            "Dashboard seed reset complete: {Events} events, {Teams} teams, {Users} users deleted.",
+            eventsDeleted, teamsDeleted, usersDeleted);
+
+        return new DashboardResetResult(eventsDeleted, teamsDeleted, usersDeleted);
     }
 }

--- a/src/Humans.Web/Models/ShiftViewModels.cs
+++ b/src/Humans.Web/Models/ShiftViewModels.cs
@@ -407,6 +407,7 @@ public class ShiftDashboardViewModel
     public Guid? SelectedDepartmentId { get; set; }
     public Guid? SelectedRotaId { get; set; }
     public string? SelectedDate { get; set; }
+    public ShiftPeriod? SelectedPeriod { get; set; }
     public EventSettings EventSettings { get; set; } = null!;
     public List<DailyStaffingData> StaffingData { get; set; } = [];
     public List<DailyStaffingHours> StaffingHours { get; set; } = [];

--- a/src/Humans.Web/Models/ShiftViewModels.cs
+++ b/src/Humans.Web/Models/ShiftViewModels.cs
@@ -1,4 +1,6 @@
 using System.ComponentModel.DataAnnotations;
+using Humans.Application.DTOs;
+using Humans.Application.Enums;
 using Humans.Application.Interfaces;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
@@ -408,6 +410,12 @@ public class ShiftDashboardViewModel
     public EventSettings EventSettings { get; set; } = null!;
     public List<DailyStaffingData> StaffingData { get; set; } = [];
     public List<DailyStaffingHours> StaffingHours { get; set; } = [];
+
+    public DashboardOverview? Overview { get; set; }
+    public IReadOnlyList<CoordinatorActivityRow> CoordinatorActivity { get; set; } = Array.Empty<CoordinatorActivityRow>();
+    public IReadOnlyList<DashboardTrendPoint> Trends { get; set; } = Array.Empty<DashboardTrendPoint>();
+    public TrendWindow TrendWindow { get; set; } = TrendWindow.Last30Days;
+    public bool IsDevelopment { get; set; }
 }
 
 public class VolunteerSearchResult

--- a/src/Humans.Web/Program.cs
+++ b/src/Humans.Web/Program.cs
@@ -82,6 +82,7 @@ builder.Services.AddSingleton<IClock>(SystemClock.Instance);
 if (!builder.Environment.IsProduction())
 {
     builder.Services.AddScoped<DevelopmentBudgetSeeder>();
+    builder.Services.AddScoped<DevelopmentDashboardSeeder>();
 }
 
 // Configure JSON options with NodaTime support

--- a/src/Humans.Web/Resources/SharedResource.ca.resx
+++ b/src/Humans.Web/Resources/SharedResource.ca.resx
@@ -1700,6 +1700,8 @@
   <data name="ShiftDash_Overview_NonTicketSubline" xml:space="preserve"><value>apuntats sense entrada (encara)</value></data>
   <data name="ShiftDash_Overview_StalePending" xml:space="preserve"><value>Pendents antics</value></data>
   <data name="ShiftDash_Overview_StaleSubline" xml:space="preserve"><value>pendents &gt; 3 dies</value></data>
+  <data name="Common_NotAvailable" xml:space="preserve"><value>N/D</value></data>
+  <data name="ShiftDash_Overview_TicketData_Hidden" xml:space="preserve"><value>dades d'entrades encara no compartides</value></data>
 
   <data name="ShiftDash_PeriodFilter_Label" xml:space="preserve"><value>Mostrant:</value></data>
   <data name="ShiftDash_PeriodFilter_All" xml:space="preserve"><value>Tot</value></data>

--- a/src/Humans.Web/Resources/SharedResource.ca.resx
+++ b/src/Humans.Web/Resources/SharedResource.ca.resx
@@ -1691,4 +1691,46 @@
   <data name="Privacy_ComplaintBody" xml:space="preserve"><value>Si no estàs satisfet amb la nostra resposta, tens dret a presentar una reclamació davant l'Agència Espanyola de Protecció de Dades (AEPD) a {0}.</value><comment>{0} = AEPD URL</comment></data>
 
 
+  <data name="ShiftDash_Overview_ShiftsFilled" xml:space="preserve"><value>Torns coberts</value></data>
+  <data name="ShiftDash_Overview_TicketHolders" xml:space="preserve"><value>Amb entrada</value></data>
+  <data name="ShiftDash_Overview_TicketHoldersSubline" xml:space="preserve"><value>humans que han pagat</value></data>
+  <data name="ShiftDash_Overview_TicketHoldersEngaged" xml:space="preserve"><value>Amb entrada i apuntats</value></data>
+  <data name="ShiftDash_Overview_EngagedSubline" xml:space="preserve"><value>{0} humans no s'han apuntat</value><comment>{0} = count</comment></data>
+  <data name="ShiftDash_Overview_NonTicketSignups" xml:space="preserve"><value>Apuntats sense entrada</value></data>
+  <data name="ShiftDash_Overview_NonTicketSubline" xml:space="preserve"><value>apuntats sense entrada (encara)</value></data>
+  <data name="ShiftDash_Overview_StalePending" xml:space="preserve"><value>Pendents antics</value></data>
+  <data name="ShiftDash_Overview_StaleSubline" xml:space="preserve"><value>pendents &gt; 3 dies</value></data>
+
+  <data name="ShiftDash_Departments_Title" xml:space="preserve"><value>Departaments</value></data>
+  <data name="ShiftDash_Departments_SortNote" xml:space="preserve"><value>ordenats pel % més baix cobert primer</value></data>
+  <data name="ShiftDash_Departments_Col_Department" xml:space="preserve"><value>Departament</value></data>
+  <data name="ShiftDash_Departments_Col_Total" xml:space="preserve"><value>Total</value></data>
+  <data name="ShiftDash_Departments_Col_Filled" xml:space="preserve"><value>Coberts</value></data>
+  <data name="ShiftDash_Departments_Col_Pct" xml:space="preserve"><value>%</value></data>
+  <data name="ShiftDash_Departments_Col_SlotsRemaining" xml:space="preserve"><value>Places lliures</value></data>
+  <data name="ShiftDash_Departments_Col_Period" xml:space="preserve"><value>Període</value></data>
+  <data name="ShiftDash_Departments_Direct" xml:space="preserve"><value>Directe</value></data>
+
+  <data name="ShiftDash_Coordinators_Title" xml:space="preserve"><value>Activitat dels coordinadors</value></data>
+  <data name="ShiftDash_Coordinators_Subtitle" xml:space="preserve"><value>equips amb pendents, inici de sessió més antic primer</value></data>
+  <data name="ShiftDash_Coordinators_Col_Team" xml:space="preserve"><value>Equip</value></data>
+  <data name="ShiftDash_Coordinators_Col_Coordinators" xml:space="preserve"><value>Coordinadors</value></data>
+  <data name="ShiftDash_Coordinators_Col_OldestLogin" xml:space="preserve"><value>Inici més antic</value></data>
+  <data name="ShiftDash_Coordinators_Col_Pending" xml:space="preserve"><value>Pendents</value></data>
+  <data name="ShiftDash_Coordinators_NoCoordinators" xml:space="preserve"><value>sense coordinadors</value></data>
+  <data name="ShiftDash_Coordinators_Never" xml:space="preserve"><value>mai</value></data>
+  <data name="ShiftDash_Coordinators_MinutesAgo" xml:space="preserve"><value>fa {0} min</value><comment>{0} = minutes</comment></data>
+  <data name="ShiftDash_Coordinators_HoursAgo" xml:space="preserve"><value>fa {0} h</value><comment>{0} = hours</comment></data>
+  <data name="ShiftDash_Coordinators_DaysAgo" xml:space="preserve"><value>fa {0} d</value><comment>{0} = days</comment></data>
+
+  <data name="ShiftDash_Trends_Title" xml:space="preserve"><value>Tendències</value></data>
+  <data name="ShiftDash_Trends_Window_7d" xml:space="preserve"><value>7d</value></data>
+  <data name="ShiftDash_Trends_Window_30d" xml:space="preserve"><value>30d</value></data>
+  <data name="ShiftDash_Trends_Window_90d" xml:space="preserve"><value>90d</value></data>
+  <data name="ShiftDash_Trends_Window_All" xml:space="preserve"><value>Tot</value></data>
+  <data name="ShiftDash_Trends_NewSignups" xml:space="preserve"><value>Noves inscripcions</value></data>
+  <data name="ShiftDash_Trends_NewTicketSales" xml:space="preserve"><value>Noves entrades venudes</value></data>
+  <data name="ShiftDash_Trends_DAU" xml:space="preserve"><value>Inicis de sessió únics (DAU)</value></data>
+  <data name="ShiftDash_Trends_DAUNote" xml:space="preserve"><value>Només es desa l'últim inici per human — els períodes antics estan infrarrepresentats.</value></data>
+
 </root>

--- a/src/Humans.Web/Resources/SharedResource.ca.resx
+++ b/src/Humans.Web/Resources/SharedResource.ca.resx
@@ -1722,6 +1722,7 @@
   <data name="ShiftDash_Coordinators_MinutesAgo" xml:space="preserve"><value>fa {0} min</value><comment>{0} = minutes</comment></data>
   <data name="ShiftDash_Coordinators_HoursAgo" xml:space="preserve"><value>fa {0} h</value><comment>{0} = hours</comment></data>
   <data name="ShiftDash_Coordinators_DaysAgo" xml:space="preserve"><value>fa {0} d</value><comment>{0} = days</comment></data>
+  <data name="ShiftDash_Coordinators_DirectPending" xml:space="preserve"><value>{0} directes</value><comment>{0} = pending count at this team level only</comment></data>
 
   <data name="ShiftDash_Trends_Title" xml:space="preserve"><value>Tendències</value></data>
   <data name="ShiftDash_Trends_Window_7d" xml:space="preserve"><value>7d</value></data>

--- a/src/Humans.Web/Resources/SharedResource.ca.resx
+++ b/src/Humans.Web/Resources/SharedResource.ca.resx
@@ -1694,7 +1694,7 @@
   <data name="ShiftDash_Overview_ShiftsFilled" xml:space="preserve"><value>Torns coberts</value></data>
   <data name="ShiftDash_Overview_TicketHolders" xml:space="preserve"><value>Amb entrada</value></data>
   <data name="ShiftDash_Overview_TicketHoldersSubline" xml:space="preserve"><value>humans que han pagat</value></data>
-  <data name="ShiftDash_Overview_TicketHoldersEngaged" xml:space="preserve"><value>Amb entrada i apuntats</value></data>
+  <data name="ShiftDash_Overview_TicketHoldersEngaged" xml:space="preserve"><value>Voluntaris amb entrada</value></data>
   <data name="ShiftDash_Overview_EngagedSubline" xml:space="preserve"><value>{0} humans no s'han apuntat</value><comment>{0} = count</comment></data>
   <data name="ShiftDash_Overview_NonTicketSignups" xml:space="preserve"><value>Apuntats sense entrada</value></data>
   <data name="ShiftDash_Overview_NonTicketSubline" xml:space="preserve"><value>apuntats sense entrada (encara)</value></data>

--- a/src/Humans.Web/Resources/SharedResource.ca.resx
+++ b/src/Humans.Web/Resources/SharedResource.ca.resx
@@ -1694,7 +1694,7 @@
   <data name="ShiftDash_Overview_ShiftsFilled" xml:space="preserve"><value>Torns coberts</value></data>
   <data name="ShiftDash_Overview_TicketHolders" xml:space="preserve"><value>Amb entrada</value></data>
   <data name="ShiftDash_Overview_TicketHoldersSubline" xml:space="preserve"><value>humans que han pagat</value></data>
-  <data name="ShiftDash_Overview_TicketHoldersEngaged" xml:space="preserve"><value>Voluntaris amb entrada</value></data>
+  <data name="ShiftDash_Overview_TicketHoldersEngaged" xml:space="preserve"><value>Ticket holding humans</value></data>
   <data name="ShiftDash_Overview_EngagedSubline" xml:space="preserve"><value>{0} humans no s'han apuntat</value><comment>{0} = count</comment></data>
   <data name="ShiftDash_Overview_NonTicketSignups" xml:space="preserve"><value>Apuntats sense entrada</value></data>
   <data name="ShiftDash_Overview_NonTicketSubline" xml:space="preserve"><value>apuntats sense entrada (encara)</value></data>
@@ -1723,7 +1723,6 @@
   <data name="ShiftDash_Coordinators_Subtitle" xml:space="preserve"><value>equips amb pendents, inici de sessió més antic primer</value></data>
   <data name="ShiftDash_Coordinators_Col_Team" xml:space="preserve"><value>Equip</value></data>
   <data name="ShiftDash_Coordinators_Col_Coordinators" xml:space="preserve"><value>Coordinadors</value></data>
-  <data name="ShiftDash_Coordinators_Col_OldestLogin" xml:space="preserve"><value>Inici més antic</value></data>
   <data name="ShiftDash_Coordinators_Col_Pending" xml:space="preserve"><value>Pendents</value></data>
   <data name="ShiftDash_Coordinators_NoCoordinators" xml:space="preserve"><value>sense coordinadors</value></data>
   <data name="ShiftDash_Coordinators_Never" xml:space="preserve"><value>mai</value></data>
@@ -1741,5 +1740,9 @@
   <data name="ShiftDash_Trends_NewTicketSales" xml:space="preserve"><value>Noves entrades venudes</value></data>
   <data name="ShiftDash_Trends_DAU" xml:space="preserve"><value>Inicis de sessió únics (DAU)</value></data>
   <data name="ShiftDash_Trends_DAUNote" xml:space="preserve"><value>Només es desa l'últim inici per human — els períodes antics estan infrarrepresentats.</value></data>
+  <data name="ShiftDash_Status_OnTrack" xml:space="preserve"><value>En curs</value></data>
+  <data name="ShiftDash_Status_AtRisk" xml:space="preserve"><value>En risc</value></data>
+  <data name="ShiftDash_Status_BelowTarget" xml:space="preserve"><value>Per sota de l'objectiu</value></data>
+  <data name="ShiftDash_Coordinators_StaleLabel" xml:space="preserve"><value>Inactiu més de 7 dies</value></data>
 
 </root>

--- a/src/Humans.Web/Resources/SharedResource.ca.resx
+++ b/src/Humans.Web/Resources/SharedResource.ca.resx
@@ -1701,6 +1701,12 @@
   <data name="ShiftDash_Overview_StalePending" xml:space="preserve"><value>Pendents antics</value></data>
   <data name="ShiftDash_Overview_StaleSubline" xml:space="preserve"><value>pendents &gt; 3 dies</value></data>
 
+  <data name="ShiftDash_PeriodFilter_Label" xml:space="preserve"><value>Mostrant:</value></data>
+  <data name="ShiftDash_PeriodFilter_All" xml:space="preserve"><value>Tot</value></data>
+  <data name="ShiftDash_PeriodFilter_BuildDays" xml:space="preserve"><value>Dies de muntatge</value></data>
+  <data name="ShiftDash_PeriodFilter_EventShifts" xml:space="preserve"><value>Torns d'esdeveniment</value></data>
+  <data name="ShiftDash_PeriodFilter_Strike" xml:space="preserve"><value>Desmuntatge</value></data>
+
   <data name="ShiftDash_Departments_Title" xml:space="preserve"><value>Departaments</value></data>
   <data name="ShiftDash_Departments_SortNote" xml:space="preserve"><value>ordenats pel % més baix cobert primer</value></data>
   <data name="ShiftDash_Departments_Col_Department" xml:space="preserve"><value>Departament</value></data>

--- a/src/Humans.Web/Resources/SharedResource.de.resx
+++ b/src/Humans.Web/Resources/SharedResource.de.resx
@@ -1689,4 +1689,46 @@
   <data name="Privacy_ComplaintBody" xml:space="preserve"><value>Wenn du mit unserer Antwort nicht zufrieden bist, hast du das Recht, eine Beschwerde bei der Spanischen Datenschutzbehörde (AEPD) unter {0} einzureichen.</value><comment>{0} = AEPD URL</comment></data>
 
 
+  <data name="ShiftDash_Overview_ShiftsFilled" xml:space="preserve"><value>Besetzte Schichten</value></data>
+  <data name="ShiftDash_Overview_TicketHolders" xml:space="preserve"><value>Ticketinhaber</value></data>
+  <data name="ShiftDash_Overview_TicketHoldersSubline" xml:space="preserve"><value>humans, die bezahlt haben</value></data>
+  <data name="ShiftDash_Overview_TicketHoldersEngaged" xml:space="preserve"><value>Ticketinhaber engagiert</value></data>
+  <data name="ShiftDash_Overview_EngagedSubline" xml:space="preserve"><value>{0} humans haben sich noch nicht eingetragen</value><comment>{0} = count</comment></data>
+  <data name="ShiftDash_Overview_NonTicketSignups" xml:space="preserve"><value>Eintragungen ohne Ticket</value></data>
+  <data name="ShiftDash_Overview_NonTicketSubline" xml:space="preserve"><value>eingetragen, noch ohne Ticket</value></data>
+  <data name="ShiftDash_Overview_StalePending" xml:space="preserve"><value>Alte offene</value></data>
+  <data name="ShiftDash_Overview_StaleSubline" xml:space="preserve"><value>offen &gt; 3 Tage</value></data>
+
+  <data name="ShiftDash_Departments_Title" xml:space="preserve"><value>Abteilungen</value></data>
+  <data name="ShiftDash_Departments_SortNote" xml:space="preserve"><value>sortiert nach niedrigster Füllquote zuerst</value></data>
+  <data name="ShiftDash_Departments_Col_Department" xml:space="preserve"><value>Abteilung</value></data>
+  <data name="ShiftDash_Departments_Col_Total" xml:space="preserve"><value>Gesamt</value></data>
+  <data name="ShiftDash_Departments_Col_Filled" xml:space="preserve"><value>Besetzt</value></data>
+  <data name="ShiftDash_Departments_Col_Pct" xml:space="preserve"><value>%</value></data>
+  <data name="ShiftDash_Departments_Col_SlotsRemaining" xml:space="preserve"><value>Freie Plätze</value></data>
+  <data name="ShiftDash_Departments_Col_Period" xml:space="preserve"><value>Phase</value></data>
+  <data name="ShiftDash_Departments_Direct" xml:space="preserve"><value>Direkt</value></data>
+
+  <data name="ShiftDash_Coordinators_Title" xml:space="preserve"><value>Koordinator-Aktivität</value></data>
+  <data name="ShiftDash_Coordinators_Subtitle" xml:space="preserve"><value>Teams mit offenen Eintragungen, ältester Login zuerst</value></data>
+  <data name="ShiftDash_Coordinators_Col_Team" xml:space="preserve"><value>Team</value></data>
+  <data name="ShiftDash_Coordinators_Col_Coordinators" xml:space="preserve"><value>Koordinatoren</value></data>
+  <data name="ShiftDash_Coordinators_Col_OldestLogin" xml:space="preserve"><value>Ältester Login</value></data>
+  <data name="ShiftDash_Coordinators_Col_Pending" xml:space="preserve"><value>Offen</value></data>
+  <data name="ShiftDash_Coordinators_NoCoordinators" xml:space="preserve"><value>keine Koordinatoren</value></data>
+  <data name="ShiftDash_Coordinators_Never" xml:space="preserve"><value>nie</value></data>
+  <data name="ShiftDash_Coordinators_MinutesAgo" xml:space="preserve"><value>vor {0} Min.</value><comment>{0} = minutes</comment></data>
+  <data name="ShiftDash_Coordinators_HoursAgo" xml:space="preserve"><value>vor {0} Std.</value><comment>{0} = hours</comment></data>
+  <data name="ShiftDash_Coordinators_DaysAgo" xml:space="preserve"><value>vor {0} T.</value><comment>{0} = days</comment></data>
+
+  <data name="ShiftDash_Trends_Title" xml:space="preserve"><value>Trends</value></data>
+  <data name="ShiftDash_Trends_Window_7d" xml:space="preserve"><value>7T</value></data>
+  <data name="ShiftDash_Trends_Window_30d" xml:space="preserve"><value>30T</value></data>
+  <data name="ShiftDash_Trends_Window_90d" xml:space="preserve"><value>90T</value></data>
+  <data name="ShiftDash_Trends_Window_All" xml:space="preserve"><value>Alle</value></data>
+  <data name="ShiftDash_Trends_NewSignups" xml:space="preserve"><value>Neue Eintragungen</value></data>
+  <data name="ShiftDash_Trends_NewTicketSales" xml:space="preserve"><value>Neue Ticketverkäufe</value></data>
+  <data name="ShiftDash_Trends_DAU" xml:space="preserve"><value>Einzigartige Logins (DAU)</value></data>
+  <data name="ShiftDash_Trends_DAUNote" xml:space="preserve"><value>Nur der letzte Login pro human wird gespeichert — ältere Zeiträume sind untererfasst.</value></data>
+
 </root>

--- a/src/Humans.Web/Resources/SharedResource.de.resx
+++ b/src/Humans.Web/Resources/SharedResource.de.resx
@@ -1720,6 +1720,7 @@
   <data name="ShiftDash_Coordinators_MinutesAgo" xml:space="preserve"><value>vor {0} Min.</value><comment>{0} = minutes</comment></data>
   <data name="ShiftDash_Coordinators_HoursAgo" xml:space="preserve"><value>vor {0} Std.</value><comment>{0} = hours</comment></data>
   <data name="ShiftDash_Coordinators_DaysAgo" xml:space="preserve"><value>vor {0} T.</value><comment>{0} = days</comment></data>
+  <data name="ShiftDash_Coordinators_DirectPending" xml:space="preserve"><value>{0} direkt</value><comment>{0} = pending count at this team level only</comment></data>
 
   <data name="ShiftDash_Trends_Title" xml:space="preserve"><value>Trends</value></data>
   <data name="ShiftDash_Trends_Window_7d" xml:space="preserve"><value>7T</value></data>

--- a/src/Humans.Web/Resources/SharedResource.de.resx
+++ b/src/Humans.Web/Resources/SharedResource.de.resx
@@ -1692,7 +1692,7 @@
   <data name="ShiftDash_Overview_ShiftsFilled" xml:space="preserve"><value>Besetzte Schichten</value></data>
   <data name="ShiftDash_Overview_TicketHolders" xml:space="preserve"><value>Ticketinhaber</value></data>
   <data name="ShiftDash_Overview_TicketHoldersSubline" xml:space="preserve"><value>humans, die bezahlt haben</value></data>
-  <data name="ShiftDash_Overview_TicketHoldersEngaged" xml:space="preserve"><value>Ticketinhaber engagiert</value></data>
+  <data name="ShiftDash_Overview_TicketHoldersEngaged" xml:space="preserve"><value>Freiwillige mit Ticket</value></data>
   <data name="ShiftDash_Overview_EngagedSubline" xml:space="preserve"><value>{0} humans haben sich noch nicht eingetragen</value><comment>{0} = count</comment></data>
   <data name="ShiftDash_Overview_NonTicketSignups" xml:space="preserve"><value>Eintragungen ohne Ticket</value></data>
   <data name="ShiftDash_Overview_NonTicketSubline" xml:space="preserve"><value>eingetragen, noch ohne Ticket</value></data>

--- a/src/Humans.Web/Resources/SharedResource.de.resx
+++ b/src/Humans.Web/Resources/SharedResource.de.resx
@@ -1692,7 +1692,7 @@
   <data name="ShiftDash_Overview_ShiftsFilled" xml:space="preserve"><value>Besetzte Schichten</value></data>
   <data name="ShiftDash_Overview_TicketHolders" xml:space="preserve"><value>Ticketinhaber</value></data>
   <data name="ShiftDash_Overview_TicketHoldersSubline" xml:space="preserve"><value>humans, die bezahlt haben</value></data>
-  <data name="ShiftDash_Overview_TicketHoldersEngaged" xml:space="preserve"><value>Freiwillige mit Ticket</value></data>
+  <data name="ShiftDash_Overview_TicketHoldersEngaged" xml:space="preserve"><value>Ticket holding humans</value></data>
   <data name="ShiftDash_Overview_EngagedSubline" xml:space="preserve"><value>{0} humans haben sich noch nicht eingetragen</value><comment>{0} = count</comment></data>
   <data name="ShiftDash_Overview_NonTicketSignups" xml:space="preserve"><value>Eintragungen ohne Ticket</value></data>
   <data name="ShiftDash_Overview_NonTicketSubline" xml:space="preserve"><value>eingetragen, noch ohne Ticket</value></data>
@@ -1721,7 +1721,6 @@
   <data name="ShiftDash_Coordinators_Subtitle" xml:space="preserve"><value>Teams mit offenen Eintragungen, ältester Login zuerst</value></data>
   <data name="ShiftDash_Coordinators_Col_Team" xml:space="preserve"><value>Team</value></data>
   <data name="ShiftDash_Coordinators_Col_Coordinators" xml:space="preserve"><value>Koordinatoren</value></data>
-  <data name="ShiftDash_Coordinators_Col_OldestLogin" xml:space="preserve"><value>Ältester Login</value></data>
   <data name="ShiftDash_Coordinators_Col_Pending" xml:space="preserve"><value>Offen</value></data>
   <data name="ShiftDash_Coordinators_NoCoordinators" xml:space="preserve"><value>keine Koordinatoren</value></data>
   <data name="ShiftDash_Coordinators_Never" xml:space="preserve"><value>nie</value></data>
@@ -1739,5 +1738,9 @@
   <data name="ShiftDash_Trends_NewTicketSales" xml:space="preserve"><value>Neue Ticketverkäufe</value></data>
   <data name="ShiftDash_Trends_DAU" xml:space="preserve"><value>Einzigartige Logins (DAU)</value></data>
   <data name="ShiftDash_Trends_DAUNote" xml:space="preserve"><value>Nur der letzte Login pro human wird gespeichert — ältere Zeiträume sind untererfasst.</value></data>
+  <data name="ShiftDash_Status_OnTrack" xml:space="preserve"><value>Im Plan</value></data>
+  <data name="ShiftDash_Status_AtRisk" xml:space="preserve"><value>Gefährdet</value></data>
+  <data name="ShiftDash_Status_BelowTarget" xml:space="preserve"><value>Unter Ziel</value></data>
+  <data name="ShiftDash_Coordinators_StaleLabel" xml:space="preserve"><value>Über 7 Tage inaktiv</value></data>
 
 </root>

--- a/src/Humans.Web/Resources/SharedResource.de.resx
+++ b/src/Humans.Web/Resources/SharedResource.de.resx
@@ -1698,6 +1698,8 @@
   <data name="ShiftDash_Overview_NonTicketSubline" xml:space="preserve"><value>eingetragen, noch ohne Ticket</value></data>
   <data name="ShiftDash_Overview_StalePending" xml:space="preserve"><value>Alte offene</value></data>
   <data name="ShiftDash_Overview_StaleSubline" xml:space="preserve"><value>offen &gt; 3 Tage</value></data>
+  <data name="Common_NotAvailable" xml:space="preserve"><value>k. A.</value></data>
+  <data name="ShiftDash_Overview_TicketData_Hidden" xml:space="preserve"><value>Ticketdaten noch nicht freigegeben</value></data>
 
   <data name="ShiftDash_PeriodFilter_Label" xml:space="preserve"><value>Anzeige:</value></data>
   <data name="ShiftDash_PeriodFilter_All" xml:space="preserve"><value>Alle</value></data>

--- a/src/Humans.Web/Resources/SharedResource.de.resx
+++ b/src/Humans.Web/Resources/SharedResource.de.resx
@@ -1699,6 +1699,12 @@
   <data name="ShiftDash_Overview_StalePending" xml:space="preserve"><value>Alte offene</value></data>
   <data name="ShiftDash_Overview_StaleSubline" xml:space="preserve"><value>offen &gt; 3 Tage</value></data>
 
+  <data name="ShiftDash_PeriodFilter_Label" xml:space="preserve"><value>Anzeige:</value></data>
+  <data name="ShiftDash_PeriodFilter_All" xml:space="preserve"><value>Alle</value></data>
+  <data name="ShiftDash_PeriodFilter_BuildDays" xml:space="preserve"><value>Aufbau-Tage</value></data>
+  <data name="ShiftDash_PeriodFilter_EventShifts" xml:space="preserve"><value>Veranstaltungsschichten</value></data>
+  <data name="ShiftDash_PeriodFilter_Strike" xml:space="preserve"><value>Abbau</value></data>
+
   <data name="ShiftDash_Departments_Title" xml:space="preserve"><value>Abteilungen</value></data>
   <data name="ShiftDash_Departments_SortNote" xml:space="preserve"><value>sortiert nach niedrigster Füllquote zuerst</value></data>
   <data name="ShiftDash_Departments_Col_Department" xml:space="preserve"><value>Abteilung</value></data>

--- a/src/Humans.Web/Resources/SharedResource.es.resx
+++ b/src/Humans.Web/Resources/SharedResource.es.resx
@@ -1694,7 +1694,7 @@
   <data name="ShiftDash_Overview_ShiftsFilled" xml:space="preserve"><value>Turnos cubiertos</value></data>
   <data name="ShiftDash_Overview_TicketHolders" xml:space="preserve"><value>Con entrada</value></data>
   <data name="ShiftDash_Overview_TicketHoldersSubline" xml:space="preserve"><value>humans que han pagado</value></data>
-  <data name="ShiftDash_Overview_TicketHoldersEngaged" xml:space="preserve"><value>Voluntarios con entrada</value></data>
+  <data name="ShiftDash_Overview_TicketHoldersEngaged" xml:space="preserve"><value>Ticket holding humans</value></data>
   <data name="ShiftDash_Overview_EngagedSubline" xml:space="preserve"><value>{0} humans no se han apuntado</value><comment>{0} = count</comment></data>
   <data name="ShiftDash_Overview_NonTicketSignups" xml:space="preserve"><value>Apuntados sin entrada</value></data>
   <data name="ShiftDash_Overview_NonTicketSubline" xml:space="preserve"><value>apuntados sin entrada (aún)</value></data>
@@ -1723,7 +1723,6 @@
   <data name="ShiftDash_Coordinators_Subtitle" xml:space="preserve"><value>equipos con pendientes, inicio de sesión más antiguo primero</value></data>
   <data name="ShiftDash_Coordinators_Col_Team" xml:space="preserve"><value>Equipo</value></data>
   <data name="ShiftDash_Coordinators_Col_Coordinators" xml:space="preserve"><value>Coordinadores</value></data>
-  <data name="ShiftDash_Coordinators_Col_OldestLogin" xml:space="preserve"><value>Inicio más antiguo</value></data>
   <data name="ShiftDash_Coordinators_Col_Pending" xml:space="preserve"><value>Pendientes</value></data>
   <data name="ShiftDash_Coordinators_NoCoordinators" xml:space="preserve"><value>sin coordinadores</value></data>
   <data name="ShiftDash_Coordinators_Never" xml:space="preserve"><value>nunca</value></data>
@@ -1741,5 +1740,9 @@
   <data name="ShiftDash_Trends_NewTicketSales" xml:space="preserve"><value>Nuevas entradas vendidas</value></data>
   <data name="ShiftDash_Trends_DAU" xml:space="preserve"><value>Inicios de sesión únicos (DAU)</value></data>
   <data name="ShiftDash_Trends_DAUNote" xml:space="preserve"><value>Solo se guarda el último inicio por human — los periodos antiguos están infrarrepresentados.</value></data>
+  <data name="ShiftDash_Status_OnTrack" xml:space="preserve"><value>En camino</value></data>
+  <data name="ShiftDash_Status_AtRisk" xml:space="preserve"><value>En riesgo</value></data>
+  <data name="ShiftDash_Status_BelowTarget" xml:space="preserve"><value>Por debajo del objetivo</value></data>
+  <data name="ShiftDash_Coordinators_StaleLabel" xml:space="preserve"><value>Inactivo más de 7 días</value></data>
 
 </root>

--- a/src/Humans.Web/Resources/SharedResource.es.resx
+++ b/src/Humans.Web/Resources/SharedResource.es.resx
@@ -1694,7 +1694,7 @@
   <data name="ShiftDash_Overview_ShiftsFilled" xml:space="preserve"><value>Turnos cubiertos</value></data>
   <data name="ShiftDash_Overview_TicketHolders" xml:space="preserve"><value>Con entrada</value></data>
   <data name="ShiftDash_Overview_TicketHoldersSubline" xml:space="preserve"><value>humans que han pagado</value></data>
-  <data name="ShiftDash_Overview_TicketHoldersEngaged" xml:space="preserve"><value>Con entrada y apuntados</value></data>
+  <data name="ShiftDash_Overview_TicketHoldersEngaged" xml:space="preserve"><value>Voluntarios con entrada</value></data>
   <data name="ShiftDash_Overview_EngagedSubline" xml:space="preserve"><value>{0} humans no se han apuntado</value><comment>{0} = count</comment></data>
   <data name="ShiftDash_Overview_NonTicketSignups" xml:space="preserve"><value>Apuntados sin entrada</value></data>
   <data name="ShiftDash_Overview_NonTicketSubline" xml:space="preserve"><value>apuntados sin entrada (aún)</value></data>

--- a/src/Humans.Web/Resources/SharedResource.es.resx
+++ b/src/Humans.Web/Resources/SharedResource.es.resx
@@ -1701,6 +1701,12 @@
   <data name="ShiftDash_Overview_StalePending" xml:space="preserve"><value>Pendientes antiguos</value></data>
   <data name="ShiftDash_Overview_StaleSubline" xml:space="preserve"><value>pendientes &gt; 3 días</value></data>
 
+  <data name="ShiftDash_PeriodFilter_Label" xml:space="preserve"><value>Mostrando:</value></data>
+  <data name="ShiftDash_PeriodFilter_All" xml:space="preserve"><value>Todo</value></data>
+  <data name="ShiftDash_PeriodFilter_BuildDays" xml:space="preserve"><value>Días de montaje</value></data>
+  <data name="ShiftDash_PeriodFilter_EventShifts" xml:space="preserve"><value>Turnos de evento</value></data>
+  <data name="ShiftDash_PeriodFilter_Strike" xml:space="preserve"><value>Desmontaje</value></data>
+
   <data name="ShiftDash_Departments_Title" xml:space="preserve"><value>Departamentos</value></data>
   <data name="ShiftDash_Departments_SortNote" xml:space="preserve"><value>ordenados por menor % cubierto primero</value></data>
   <data name="ShiftDash_Departments_Col_Department" xml:space="preserve"><value>Departamento</value></data>

--- a/src/Humans.Web/Resources/SharedResource.es.resx
+++ b/src/Humans.Web/Resources/SharedResource.es.resx
@@ -1700,6 +1700,8 @@
   <data name="ShiftDash_Overview_NonTicketSubline" xml:space="preserve"><value>apuntados sin entrada (aún)</value></data>
   <data name="ShiftDash_Overview_StalePending" xml:space="preserve"><value>Pendientes antiguos</value></data>
   <data name="ShiftDash_Overview_StaleSubline" xml:space="preserve"><value>pendientes &gt; 3 días</value></data>
+  <data name="Common_NotAvailable" xml:space="preserve"><value>N/D</value></data>
+  <data name="ShiftDash_Overview_TicketData_Hidden" xml:space="preserve"><value>datos de entradas aún no compartidos</value></data>
 
   <data name="ShiftDash_PeriodFilter_Label" xml:space="preserve"><value>Mostrando:</value></data>
   <data name="ShiftDash_PeriodFilter_All" xml:space="preserve"><value>Todo</value></data>

--- a/src/Humans.Web/Resources/SharedResource.es.resx
+++ b/src/Humans.Web/Resources/SharedResource.es.resx
@@ -1691,4 +1691,46 @@
   <data name="Privacy_ComplaintBody" xml:space="preserve"><value>Si no estás satisfecho con nuestra respuesta, tienes derecho a presentar una reclamación ante la Agencia Española de Protección de Datos (AEPD) en {0}.</value><comment>{0} = AEPD URL</comment></data>
 
 
+  <data name="ShiftDash_Overview_ShiftsFilled" xml:space="preserve"><value>Turnos cubiertos</value></data>
+  <data name="ShiftDash_Overview_TicketHolders" xml:space="preserve"><value>Con entrada</value></data>
+  <data name="ShiftDash_Overview_TicketHoldersSubline" xml:space="preserve"><value>humans que han pagado</value></data>
+  <data name="ShiftDash_Overview_TicketHoldersEngaged" xml:space="preserve"><value>Con entrada y apuntados</value></data>
+  <data name="ShiftDash_Overview_EngagedSubline" xml:space="preserve"><value>{0} humans no se han apuntado</value><comment>{0} = count</comment></data>
+  <data name="ShiftDash_Overview_NonTicketSignups" xml:space="preserve"><value>Apuntados sin entrada</value></data>
+  <data name="ShiftDash_Overview_NonTicketSubline" xml:space="preserve"><value>apuntados sin entrada (aún)</value></data>
+  <data name="ShiftDash_Overview_StalePending" xml:space="preserve"><value>Pendientes antiguos</value></data>
+  <data name="ShiftDash_Overview_StaleSubline" xml:space="preserve"><value>pendientes &gt; 3 días</value></data>
+
+  <data name="ShiftDash_Departments_Title" xml:space="preserve"><value>Departamentos</value></data>
+  <data name="ShiftDash_Departments_SortNote" xml:space="preserve"><value>ordenados por menor % cubierto primero</value></data>
+  <data name="ShiftDash_Departments_Col_Department" xml:space="preserve"><value>Departamento</value></data>
+  <data name="ShiftDash_Departments_Col_Total" xml:space="preserve"><value>Total</value></data>
+  <data name="ShiftDash_Departments_Col_Filled" xml:space="preserve"><value>Cubiertos</value></data>
+  <data name="ShiftDash_Departments_Col_Pct" xml:space="preserve"><value>%</value></data>
+  <data name="ShiftDash_Departments_Col_SlotsRemaining" xml:space="preserve"><value>Plazas libres</value></data>
+  <data name="ShiftDash_Departments_Col_Period" xml:space="preserve"><value>Periodo</value></data>
+  <data name="ShiftDash_Departments_Direct" xml:space="preserve"><value>Directo</value></data>
+
+  <data name="ShiftDash_Coordinators_Title" xml:space="preserve"><value>Actividad de coordinadores</value></data>
+  <data name="ShiftDash_Coordinators_Subtitle" xml:space="preserve"><value>equipos con pendientes, inicio de sesión más antiguo primero</value></data>
+  <data name="ShiftDash_Coordinators_Col_Team" xml:space="preserve"><value>Equipo</value></data>
+  <data name="ShiftDash_Coordinators_Col_Coordinators" xml:space="preserve"><value>Coordinadores</value></data>
+  <data name="ShiftDash_Coordinators_Col_OldestLogin" xml:space="preserve"><value>Inicio más antiguo</value></data>
+  <data name="ShiftDash_Coordinators_Col_Pending" xml:space="preserve"><value>Pendientes</value></data>
+  <data name="ShiftDash_Coordinators_NoCoordinators" xml:space="preserve"><value>sin coordinadores</value></data>
+  <data name="ShiftDash_Coordinators_Never" xml:space="preserve"><value>nunca</value></data>
+  <data name="ShiftDash_Coordinators_MinutesAgo" xml:space="preserve"><value>hace {0} min</value><comment>{0} = minutes</comment></data>
+  <data name="ShiftDash_Coordinators_HoursAgo" xml:space="preserve"><value>hace {0} h</value><comment>{0} = hours</comment></data>
+  <data name="ShiftDash_Coordinators_DaysAgo" xml:space="preserve"><value>hace {0} d</value><comment>{0} = days</comment></data>
+
+  <data name="ShiftDash_Trends_Title" xml:space="preserve"><value>Tendencias</value></data>
+  <data name="ShiftDash_Trends_Window_7d" xml:space="preserve"><value>7d</value></data>
+  <data name="ShiftDash_Trends_Window_30d" xml:space="preserve"><value>30d</value></data>
+  <data name="ShiftDash_Trends_Window_90d" xml:space="preserve"><value>90d</value></data>
+  <data name="ShiftDash_Trends_Window_All" xml:space="preserve"><value>Todo</value></data>
+  <data name="ShiftDash_Trends_NewSignups" xml:space="preserve"><value>Nuevas inscripciones</value></data>
+  <data name="ShiftDash_Trends_NewTicketSales" xml:space="preserve"><value>Nuevas entradas vendidas</value></data>
+  <data name="ShiftDash_Trends_DAU" xml:space="preserve"><value>Inicios de sesión únicos (DAU)</value></data>
+  <data name="ShiftDash_Trends_DAUNote" xml:space="preserve"><value>Solo se guarda el último inicio por human — los periodos antiguos están infrarrepresentados.</value></data>
+
 </root>

--- a/src/Humans.Web/Resources/SharedResource.es.resx
+++ b/src/Humans.Web/Resources/SharedResource.es.resx
@@ -1722,6 +1722,7 @@
   <data name="ShiftDash_Coordinators_MinutesAgo" xml:space="preserve"><value>hace {0} min</value><comment>{0} = minutes</comment></data>
   <data name="ShiftDash_Coordinators_HoursAgo" xml:space="preserve"><value>hace {0} h</value><comment>{0} = hours</comment></data>
   <data name="ShiftDash_Coordinators_DaysAgo" xml:space="preserve"><value>hace {0} d</value><comment>{0} = days</comment></data>
+  <data name="ShiftDash_Coordinators_DirectPending" xml:space="preserve"><value>{0} directos</value><comment>{0} = pending count at this team level only</comment></data>
 
   <data name="ShiftDash_Trends_Title" xml:space="preserve"><value>Tendencias</value></data>
   <data name="ShiftDash_Trends_Window_7d" xml:space="preserve"><value>7d</value></data>

--- a/src/Humans.Web/Resources/SharedResource.fr.resx
+++ b/src/Humans.Web/Resources/SharedResource.fr.resx
@@ -1689,4 +1689,46 @@
   <data name="Privacy_ComplaintBody" xml:space="preserve"><value>Si vous n'êtes pas satisfait de notre réponse, vous avez le droit de déposer une plainte auprès de l'Agence Espagnole de Protection des Données (AEPD) à {0}.</value><comment>{0} = AEPD URL</comment></data>
 
 
+  <data name="ShiftDash_Overview_ShiftsFilled" xml:space="preserve"><value>Quarts remplis</value></data>
+  <data name="ShiftDash_Overview_TicketHolders" xml:space="preserve"><value>Détenteurs de billets</value></data>
+  <data name="ShiftDash_Overview_TicketHoldersSubline" xml:space="preserve"><value>humans qui ont payé</value></data>
+  <data name="ShiftDash_Overview_TicketHoldersEngaged" xml:space="preserve"><value>Détenteurs de billets engagés</value></data>
+  <data name="ShiftDash_Overview_EngagedSubline" xml:space="preserve"><value>{0} humans ne se sont pas inscrits</value><comment>{0} = count</comment></data>
+  <data name="ShiftDash_Overview_NonTicketSignups" xml:space="preserve"><value>Inscriptions sans billet</value></data>
+  <data name="ShiftDash_Overview_NonTicketSubline" xml:space="preserve"><value>inscrits sans billet (pour l'instant)</value></data>
+  <data name="ShiftDash_Overview_StalePending" xml:space="preserve"><value>En attente anciens</value></data>
+  <data name="ShiftDash_Overview_StaleSubline" xml:space="preserve"><value>en attente &gt; 3 jours</value></data>
+
+  <data name="ShiftDash_Departments_Title" xml:space="preserve"><value>Départements</value></data>
+  <data name="ShiftDash_Departments_SortNote" xml:space="preserve"><value>triés par % de remplissage le plus bas en premier</value></data>
+  <data name="ShiftDash_Departments_Col_Department" xml:space="preserve"><value>Département</value></data>
+  <data name="ShiftDash_Departments_Col_Total" xml:space="preserve"><value>Total</value></data>
+  <data name="ShiftDash_Departments_Col_Filled" xml:space="preserve"><value>Remplis</value></data>
+  <data name="ShiftDash_Departments_Col_Pct" xml:space="preserve"><value>%</value></data>
+  <data name="ShiftDash_Departments_Col_SlotsRemaining" xml:space="preserve"><value>Places restantes</value></data>
+  <data name="ShiftDash_Departments_Col_Period" xml:space="preserve"><value>Période</value></data>
+  <data name="ShiftDash_Departments_Direct" xml:space="preserve"><value>Direct</value></data>
+
+  <data name="ShiftDash_Coordinators_Title" xml:space="preserve"><value>Activité des coordinateurs</value></data>
+  <data name="ShiftDash_Coordinators_Subtitle" xml:space="preserve"><value>équipes avec inscriptions en attente, connexion la plus ancienne d'abord</value></data>
+  <data name="ShiftDash_Coordinators_Col_Team" xml:space="preserve"><value>Équipe</value></data>
+  <data name="ShiftDash_Coordinators_Col_Coordinators" xml:space="preserve"><value>Coordinateurs</value></data>
+  <data name="ShiftDash_Coordinators_Col_OldestLogin" xml:space="preserve"><value>Connexion la plus ancienne</value></data>
+  <data name="ShiftDash_Coordinators_Col_Pending" xml:space="preserve"><value>En attente</value></data>
+  <data name="ShiftDash_Coordinators_NoCoordinators" xml:space="preserve"><value>pas de coordinateurs</value></data>
+  <data name="ShiftDash_Coordinators_Never" xml:space="preserve"><value>jamais</value></data>
+  <data name="ShiftDash_Coordinators_MinutesAgo" xml:space="preserve"><value>il y a {0} min</value><comment>{0} = minutes</comment></data>
+  <data name="ShiftDash_Coordinators_HoursAgo" xml:space="preserve"><value>il y a {0} h</value><comment>{0} = hours</comment></data>
+  <data name="ShiftDash_Coordinators_DaysAgo" xml:space="preserve"><value>il y a {0} j</value><comment>{0} = days</comment></data>
+
+  <data name="ShiftDash_Trends_Title" xml:space="preserve"><value>Tendances</value></data>
+  <data name="ShiftDash_Trends_Window_7d" xml:space="preserve"><value>7j</value></data>
+  <data name="ShiftDash_Trends_Window_30d" xml:space="preserve"><value>30j</value></data>
+  <data name="ShiftDash_Trends_Window_90d" xml:space="preserve"><value>90j</value></data>
+  <data name="ShiftDash_Trends_Window_All" xml:space="preserve"><value>Tout</value></data>
+  <data name="ShiftDash_Trends_NewSignups" xml:space="preserve"><value>Nouvelles inscriptions</value></data>
+  <data name="ShiftDash_Trends_NewTicketSales" xml:space="preserve"><value>Nouvelles ventes de billets</value></data>
+  <data name="ShiftDash_Trends_DAU" xml:space="preserve"><value>Connexions uniques (DAU)</value></data>
+  <data name="ShiftDash_Trends_DAUNote" xml:space="preserve"><value>Seule la dernière connexion par human est stockée — les périodes anciennes sont sous-comptées.</value></data>
+
 </root>

--- a/src/Humans.Web/Resources/SharedResource.fr.resx
+++ b/src/Humans.Web/Resources/SharedResource.fr.resx
@@ -1720,6 +1720,7 @@
   <data name="ShiftDash_Coordinators_MinutesAgo" xml:space="preserve"><value>il y a {0} min</value><comment>{0} = minutes</comment></data>
   <data name="ShiftDash_Coordinators_HoursAgo" xml:space="preserve"><value>il y a {0} h</value><comment>{0} = hours</comment></data>
   <data name="ShiftDash_Coordinators_DaysAgo" xml:space="preserve"><value>il y a {0} j</value><comment>{0} = days</comment></data>
+  <data name="ShiftDash_Coordinators_DirectPending" xml:space="preserve"><value>{0} directs</value><comment>{0} = pending count at this team level only</comment></data>
 
   <data name="ShiftDash_Trends_Title" xml:space="preserve"><value>Tendances</value></data>
   <data name="ShiftDash_Trends_Window_7d" xml:space="preserve"><value>7j</value></data>

--- a/src/Humans.Web/Resources/SharedResource.fr.resx
+++ b/src/Humans.Web/Resources/SharedResource.fr.resx
@@ -1699,6 +1699,12 @@
   <data name="ShiftDash_Overview_StalePending" xml:space="preserve"><value>En attente anciens</value></data>
   <data name="ShiftDash_Overview_StaleSubline" xml:space="preserve"><value>en attente &gt; 3 jours</value></data>
 
+  <data name="ShiftDash_PeriodFilter_Label" xml:space="preserve"><value>Affichage :</value></data>
+  <data name="ShiftDash_PeriodFilter_All" xml:space="preserve"><value>Tout</value></data>
+  <data name="ShiftDash_PeriodFilter_BuildDays" xml:space="preserve"><value>Jours de montage</value></data>
+  <data name="ShiftDash_PeriodFilter_EventShifts" xml:space="preserve"><value>Quarts de l'événement</value></data>
+  <data name="ShiftDash_PeriodFilter_Strike" xml:space="preserve"><value>Démontage</value></data>
+
   <data name="ShiftDash_Departments_Title" xml:space="preserve"><value>Départements</value></data>
   <data name="ShiftDash_Departments_SortNote" xml:space="preserve"><value>triés par % de remplissage le plus bas en premier</value></data>
   <data name="ShiftDash_Departments_Col_Department" xml:space="preserve"><value>Département</value></data>

--- a/src/Humans.Web/Resources/SharedResource.fr.resx
+++ b/src/Humans.Web/Resources/SharedResource.fr.resx
@@ -1692,7 +1692,7 @@
   <data name="ShiftDash_Overview_ShiftsFilled" xml:space="preserve"><value>Quarts remplis</value></data>
   <data name="ShiftDash_Overview_TicketHolders" xml:space="preserve"><value>Détenteurs de billets</value></data>
   <data name="ShiftDash_Overview_TicketHoldersSubline" xml:space="preserve"><value>humans qui ont payé</value></data>
-  <data name="ShiftDash_Overview_TicketHoldersEngaged" xml:space="preserve"><value>Détenteurs de billets engagés</value></data>
+  <data name="ShiftDash_Overview_TicketHoldersEngaged" xml:space="preserve"><value>Bénévoles avec billet</value></data>
   <data name="ShiftDash_Overview_EngagedSubline" xml:space="preserve"><value>{0} humans ne se sont pas inscrits</value><comment>{0} = count</comment></data>
   <data name="ShiftDash_Overview_NonTicketSignups" xml:space="preserve"><value>Inscriptions sans billet</value></data>
   <data name="ShiftDash_Overview_NonTicketSubline" xml:space="preserve"><value>inscrits sans billet (pour l'instant)</value></data>

--- a/src/Humans.Web/Resources/SharedResource.fr.resx
+++ b/src/Humans.Web/Resources/SharedResource.fr.resx
@@ -1692,7 +1692,7 @@
   <data name="ShiftDash_Overview_ShiftsFilled" xml:space="preserve"><value>Quarts remplis</value></data>
   <data name="ShiftDash_Overview_TicketHolders" xml:space="preserve"><value>Détenteurs de billets</value></data>
   <data name="ShiftDash_Overview_TicketHoldersSubline" xml:space="preserve"><value>humans qui ont payé</value></data>
-  <data name="ShiftDash_Overview_TicketHoldersEngaged" xml:space="preserve"><value>Bénévoles avec billet</value></data>
+  <data name="ShiftDash_Overview_TicketHoldersEngaged" xml:space="preserve"><value>Ticket holding humans</value></data>
   <data name="ShiftDash_Overview_EngagedSubline" xml:space="preserve"><value>{0} humans ne se sont pas inscrits</value><comment>{0} = count</comment></data>
   <data name="ShiftDash_Overview_NonTicketSignups" xml:space="preserve"><value>Inscriptions sans billet</value></data>
   <data name="ShiftDash_Overview_NonTicketSubline" xml:space="preserve"><value>inscrits sans billet (pour l'instant)</value></data>
@@ -1721,7 +1721,6 @@
   <data name="ShiftDash_Coordinators_Subtitle" xml:space="preserve"><value>équipes avec inscriptions en attente, connexion la plus ancienne d'abord</value></data>
   <data name="ShiftDash_Coordinators_Col_Team" xml:space="preserve"><value>Équipe</value></data>
   <data name="ShiftDash_Coordinators_Col_Coordinators" xml:space="preserve"><value>Coordinateurs</value></data>
-  <data name="ShiftDash_Coordinators_Col_OldestLogin" xml:space="preserve"><value>Connexion la plus ancienne</value></data>
   <data name="ShiftDash_Coordinators_Col_Pending" xml:space="preserve"><value>En attente</value></data>
   <data name="ShiftDash_Coordinators_NoCoordinators" xml:space="preserve"><value>pas de coordinateurs</value></data>
   <data name="ShiftDash_Coordinators_Never" xml:space="preserve"><value>jamais</value></data>
@@ -1739,5 +1738,9 @@
   <data name="ShiftDash_Trends_NewTicketSales" xml:space="preserve"><value>Nouvelles ventes de billets</value></data>
   <data name="ShiftDash_Trends_DAU" xml:space="preserve"><value>Connexions uniques (DAU)</value></data>
   <data name="ShiftDash_Trends_DAUNote" xml:space="preserve"><value>Seule la dernière connexion par human est stockée — les périodes anciennes sont sous-comptées.</value></data>
+  <data name="ShiftDash_Status_OnTrack" xml:space="preserve"><value>En bonne voie</value></data>
+  <data name="ShiftDash_Status_AtRisk" xml:space="preserve"><value>À risque</value></data>
+  <data name="ShiftDash_Status_BelowTarget" xml:space="preserve"><value>En dessous de l'objectif</value></data>
+  <data name="ShiftDash_Coordinators_StaleLabel" xml:space="preserve"><value>Inactif depuis plus de 7 jours</value></data>
 
 </root>

--- a/src/Humans.Web/Resources/SharedResource.fr.resx
+++ b/src/Humans.Web/Resources/SharedResource.fr.resx
@@ -1698,6 +1698,8 @@
   <data name="ShiftDash_Overview_NonTicketSubline" xml:space="preserve"><value>inscrits sans billet (pour l'instant)</value></data>
   <data name="ShiftDash_Overview_StalePending" xml:space="preserve"><value>En attente anciens</value></data>
   <data name="ShiftDash_Overview_StaleSubline" xml:space="preserve"><value>en attente &gt; 3 jours</value></data>
+  <data name="Common_NotAvailable" xml:space="preserve"><value>N/D</value></data>
+  <data name="ShiftDash_Overview_TicketData_Hidden" xml:space="preserve"><value>données billetterie non encore partagées</value></data>
 
   <data name="ShiftDash_PeriodFilter_Label" xml:space="preserve"><value>Affichage :</value></data>
   <data name="ShiftDash_PeriodFilter_All" xml:space="preserve"><value>Tout</value></data>

--- a/src/Humans.Web/Resources/SharedResource.it.resx
+++ b/src/Humans.Web/Resources/SharedResource.it.resx
@@ -1692,7 +1692,7 @@
   <data name="ShiftDash_Overview_ShiftsFilled" xml:space="preserve"><value>Turni coperti</value></data>
   <data name="ShiftDash_Overview_TicketHolders" xml:space="preserve"><value>Con biglietto</value></data>
   <data name="ShiftDash_Overview_TicketHoldersSubline" xml:space="preserve"><value>humans che hanno pagato</value></data>
-  <data name="ShiftDash_Overview_TicketHoldersEngaged" xml:space="preserve"><value>Con biglietto e iscritti</value></data>
+  <data name="ShiftDash_Overview_TicketHoldersEngaged" xml:space="preserve"><value>Volontari con biglietto</value></data>
   <data name="ShiftDash_Overview_EngagedSubline" xml:space="preserve"><value>{0} humans non si sono iscritti</value><comment>{0} = count</comment></data>
   <data name="ShiftDash_Overview_NonTicketSignups" xml:space="preserve"><value>Iscritti senza biglietto</value></data>
   <data name="ShiftDash_Overview_NonTicketSubline" xml:space="preserve"><value>iscritti senza biglietto (ancora)</value></data>

--- a/src/Humans.Web/Resources/SharedResource.it.resx
+++ b/src/Humans.Web/Resources/SharedResource.it.resx
@@ -1698,6 +1698,8 @@
   <data name="ShiftDash_Overview_NonTicketSubline" xml:space="preserve"><value>iscritti senza biglietto (ancora)</value></data>
   <data name="ShiftDash_Overview_StalePending" xml:space="preserve"><value>In sospeso da tempo</value></data>
   <data name="ShiftDash_Overview_StaleSubline" xml:space="preserve"><value>in sospeso &gt; 3 giorni</value></data>
+  <data name="Common_NotAvailable" xml:space="preserve"><value>N/D</value></data>
+  <data name="ShiftDash_Overview_TicketData_Hidden" xml:space="preserve"><value>dati biglietti non ancora condivisi</value></data>
 
   <data name="ShiftDash_PeriodFilter_Label" xml:space="preserve"><value>Visualizzazione:</value></data>
   <data name="ShiftDash_PeriodFilter_All" xml:space="preserve"><value>Tutto</value></data>

--- a/src/Humans.Web/Resources/SharedResource.it.resx
+++ b/src/Humans.Web/Resources/SharedResource.it.resx
@@ -1720,6 +1720,7 @@
   <data name="ShiftDash_Coordinators_MinutesAgo" xml:space="preserve"><value>{0} min fa</value><comment>{0} = minutes</comment></data>
   <data name="ShiftDash_Coordinators_HoursAgo" xml:space="preserve"><value>{0} h fa</value><comment>{0} = hours</comment></data>
   <data name="ShiftDash_Coordinators_DaysAgo" xml:space="preserve"><value>{0} g fa</value><comment>{0} = days</comment></data>
+  <data name="ShiftDash_Coordinators_DirectPending" xml:space="preserve"><value>{0} diretti</value><comment>{0} = pending count at this team level only</comment></data>
 
   <data name="ShiftDash_Trends_Title" xml:space="preserve"><value>Tendenze</value></data>
   <data name="ShiftDash_Trends_Window_7d" xml:space="preserve"><value>7g</value></data>

--- a/src/Humans.Web/Resources/SharedResource.it.resx
+++ b/src/Humans.Web/Resources/SharedResource.it.resx
@@ -1692,7 +1692,7 @@
   <data name="ShiftDash_Overview_ShiftsFilled" xml:space="preserve"><value>Turni coperti</value></data>
   <data name="ShiftDash_Overview_TicketHolders" xml:space="preserve"><value>Con biglietto</value></data>
   <data name="ShiftDash_Overview_TicketHoldersSubline" xml:space="preserve"><value>humans che hanno pagato</value></data>
-  <data name="ShiftDash_Overview_TicketHoldersEngaged" xml:space="preserve"><value>Volontari con biglietto</value></data>
+  <data name="ShiftDash_Overview_TicketHoldersEngaged" xml:space="preserve"><value>Ticket holding humans</value></data>
   <data name="ShiftDash_Overview_EngagedSubline" xml:space="preserve"><value>{0} humans non si sono iscritti</value><comment>{0} = count</comment></data>
   <data name="ShiftDash_Overview_NonTicketSignups" xml:space="preserve"><value>Iscritti senza biglietto</value></data>
   <data name="ShiftDash_Overview_NonTicketSubline" xml:space="preserve"><value>iscritti senza biglietto (ancora)</value></data>
@@ -1721,7 +1721,6 @@
   <data name="ShiftDash_Coordinators_Subtitle" xml:space="preserve"><value>team con iscrizioni in sospeso, accesso più vecchio prima</value></data>
   <data name="ShiftDash_Coordinators_Col_Team" xml:space="preserve"><value>Team</value></data>
   <data name="ShiftDash_Coordinators_Col_Coordinators" xml:space="preserve"><value>Coordinatori</value></data>
-  <data name="ShiftDash_Coordinators_Col_OldestLogin" xml:space="preserve"><value>Accesso più vecchio</value></data>
   <data name="ShiftDash_Coordinators_Col_Pending" xml:space="preserve"><value>In sospeso</value></data>
   <data name="ShiftDash_Coordinators_NoCoordinators" xml:space="preserve"><value>nessun coordinatore</value></data>
   <data name="ShiftDash_Coordinators_Never" xml:space="preserve"><value>mai</value></data>
@@ -1739,5 +1738,9 @@
   <data name="ShiftDash_Trends_NewTicketSales" xml:space="preserve"><value>Nuove vendite di biglietti</value></data>
   <data name="ShiftDash_Trends_DAU" xml:space="preserve"><value>Accessi unici (DAU)</value></data>
   <data name="ShiftDash_Trends_DAUNote" xml:space="preserve"><value>Viene salvato solo l'ultimo accesso per human — i periodi più vecchi sono sottostimati.</value></data>
+  <data name="ShiftDash_Status_OnTrack" xml:space="preserve"><value>In linea</value></data>
+  <data name="ShiftDash_Status_AtRisk" xml:space="preserve"><value>A rischio</value></data>
+  <data name="ShiftDash_Status_BelowTarget" xml:space="preserve"><value>Sotto obiettivo</value></data>
+  <data name="ShiftDash_Coordinators_StaleLabel" xml:space="preserve"><value>Inattivo da più di 7 giorni</value></data>
 
 </root>

--- a/src/Humans.Web/Resources/SharedResource.it.resx
+++ b/src/Humans.Web/Resources/SharedResource.it.resx
@@ -1699,6 +1699,12 @@
   <data name="ShiftDash_Overview_StalePending" xml:space="preserve"><value>In sospeso da tempo</value></data>
   <data name="ShiftDash_Overview_StaleSubline" xml:space="preserve"><value>in sospeso &gt; 3 giorni</value></data>
 
+  <data name="ShiftDash_PeriodFilter_Label" xml:space="preserve"><value>Visualizzazione:</value></data>
+  <data name="ShiftDash_PeriodFilter_All" xml:space="preserve"><value>Tutto</value></data>
+  <data name="ShiftDash_PeriodFilter_BuildDays" xml:space="preserve"><value>Giorni di montaggio</value></data>
+  <data name="ShiftDash_PeriodFilter_EventShifts" xml:space="preserve"><value>Turni dell'evento</value></data>
+  <data name="ShiftDash_PeriodFilter_Strike" xml:space="preserve"><value>Smontaggio</value></data>
+
   <data name="ShiftDash_Departments_Title" xml:space="preserve"><value>Dipartimenti</value></data>
   <data name="ShiftDash_Departments_SortNote" xml:space="preserve"><value>ordinati per % più basso di copertura</value></data>
   <data name="ShiftDash_Departments_Col_Department" xml:space="preserve"><value>Dipartimento</value></data>

--- a/src/Humans.Web/Resources/SharedResource.it.resx
+++ b/src/Humans.Web/Resources/SharedResource.it.resx
@@ -1689,4 +1689,46 @@
   <data name="Privacy_ComplaintBody" xml:space="preserve"><value>Se non sei soddisfatto della nostra risposta, hai il diritto di presentare un reclamo all'Agenzia Spagnola per la Protezione dei Dati (AEPD) a {0}.</value><comment>{0} = AEPD URL</comment></data>
 
 
+  <data name="ShiftDash_Overview_ShiftsFilled" xml:space="preserve"><value>Turni coperti</value></data>
+  <data name="ShiftDash_Overview_TicketHolders" xml:space="preserve"><value>Con biglietto</value></data>
+  <data name="ShiftDash_Overview_TicketHoldersSubline" xml:space="preserve"><value>humans che hanno pagato</value></data>
+  <data name="ShiftDash_Overview_TicketHoldersEngaged" xml:space="preserve"><value>Con biglietto e iscritti</value></data>
+  <data name="ShiftDash_Overview_EngagedSubline" xml:space="preserve"><value>{0} humans non si sono iscritti</value><comment>{0} = count</comment></data>
+  <data name="ShiftDash_Overview_NonTicketSignups" xml:space="preserve"><value>Iscritti senza biglietto</value></data>
+  <data name="ShiftDash_Overview_NonTicketSubline" xml:space="preserve"><value>iscritti senza biglietto (ancora)</value></data>
+  <data name="ShiftDash_Overview_StalePending" xml:space="preserve"><value>In sospeso da tempo</value></data>
+  <data name="ShiftDash_Overview_StaleSubline" xml:space="preserve"><value>in sospeso &gt; 3 giorni</value></data>
+
+  <data name="ShiftDash_Departments_Title" xml:space="preserve"><value>Dipartimenti</value></data>
+  <data name="ShiftDash_Departments_SortNote" xml:space="preserve"><value>ordinati per % più basso di copertura</value></data>
+  <data name="ShiftDash_Departments_Col_Department" xml:space="preserve"><value>Dipartimento</value></data>
+  <data name="ShiftDash_Departments_Col_Total" xml:space="preserve"><value>Totale</value></data>
+  <data name="ShiftDash_Departments_Col_Filled" xml:space="preserve"><value>Coperti</value></data>
+  <data name="ShiftDash_Departments_Col_Pct" xml:space="preserve"><value>%</value></data>
+  <data name="ShiftDash_Departments_Col_SlotsRemaining" xml:space="preserve"><value>Posti liberi</value></data>
+  <data name="ShiftDash_Departments_Col_Period" xml:space="preserve"><value>Periodo</value></data>
+  <data name="ShiftDash_Departments_Direct" xml:space="preserve"><value>Diretto</value></data>
+
+  <data name="ShiftDash_Coordinators_Title" xml:space="preserve"><value>Attività dei coordinatori</value></data>
+  <data name="ShiftDash_Coordinators_Subtitle" xml:space="preserve"><value>team con iscrizioni in sospeso, accesso più vecchio prima</value></data>
+  <data name="ShiftDash_Coordinators_Col_Team" xml:space="preserve"><value>Team</value></data>
+  <data name="ShiftDash_Coordinators_Col_Coordinators" xml:space="preserve"><value>Coordinatori</value></data>
+  <data name="ShiftDash_Coordinators_Col_OldestLogin" xml:space="preserve"><value>Accesso più vecchio</value></data>
+  <data name="ShiftDash_Coordinators_Col_Pending" xml:space="preserve"><value>In sospeso</value></data>
+  <data name="ShiftDash_Coordinators_NoCoordinators" xml:space="preserve"><value>nessun coordinatore</value></data>
+  <data name="ShiftDash_Coordinators_Never" xml:space="preserve"><value>mai</value></data>
+  <data name="ShiftDash_Coordinators_MinutesAgo" xml:space="preserve"><value>{0} min fa</value><comment>{0} = minutes</comment></data>
+  <data name="ShiftDash_Coordinators_HoursAgo" xml:space="preserve"><value>{0} h fa</value><comment>{0} = hours</comment></data>
+  <data name="ShiftDash_Coordinators_DaysAgo" xml:space="preserve"><value>{0} g fa</value><comment>{0} = days</comment></data>
+
+  <data name="ShiftDash_Trends_Title" xml:space="preserve"><value>Tendenze</value></data>
+  <data name="ShiftDash_Trends_Window_7d" xml:space="preserve"><value>7g</value></data>
+  <data name="ShiftDash_Trends_Window_30d" xml:space="preserve"><value>30g</value></data>
+  <data name="ShiftDash_Trends_Window_90d" xml:space="preserve"><value>90g</value></data>
+  <data name="ShiftDash_Trends_Window_All" xml:space="preserve"><value>Tutto</value></data>
+  <data name="ShiftDash_Trends_NewSignups" xml:space="preserve"><value>Nuove iscrizioni</value></data>
+  <data name="ShiftDash_Trends_NewTicketSales" xml:space="preserve"><value>Nuove vendite di biglietti</value></data>
+  <data name="ShiftDash_Trends_DAU" xml:space="preserve"><value>Accessi unici (DAU)</value></data>
+  <data name="ShiftDash_Trends_DAUNote" xml:space="preserve"><value>Viene salvato solo l'ultimo accesso per human — i periodi più vecchi sono sottostimati.</value></data>
+
 </root>

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -1740,6 +1740,7 @@
   <data name="ShiftDash_Coordinators_MinutesAgo" xml:space="preserve"><value>{0} min ago</value><comment>{0} = minutes</comment></data>
   <data name="ShiftDash_Coordinators_HoursAgo" xml:space="preserve"><value>{0} h ago</value><comment>{0} = hours</comment></data>
   <data name="ShiftDash_Coordinators_DaysAgo" xml:space="preserve"><value>{0} d ago</value><comment>{0} = days</comment></data>
+  <data name="ShiftDash_Coordinators_DirectPending" xml:space="preserve"><value>{0} direct</value><comment>{0} = pending count at this team level only</comment></data>
 
   <data name="ShiftDash_Trends_Title" xml:space="preserve"><value>Trends</value></data>
   <data name="ShiftDash_Trends_Window_7d" xml:space="preserve"><value>7d</value></data>

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -1719,6 +1719,12 @@
   <data name="ShiftDash_Overview_StalePending" xml:space="preserve"><value>Stale pending</value></data>
   <data name="ShiftDash_Overview_StaleSubline" xml:space="preserve"><value>pending &gt; 3 days</value></data>
 
+  <data name="ShiftDash_PeriodFilter_Label" xml:space="preserve"><value>Showing:</value></data>
+  <data name="ShiftDash_PeriodFilter_All" xml:space="preserve"><value>All</value></data>
+  <data name="ShiftDash_PeriodFilter_BuildDays" xml:space="preserve"><value>Build days</value></data>
+  <data name="ShiftDash_PeriodFilter_EventShifts" xml:space="preserve"><value>Event-time shifts</value></data>
+  <data name="ShiftDash_PeriodFilter_Strike" xml:space="preserve"><value>Strike</value></data>
+
   <data name="ShiftDash_Departments_Title" xml:space="preserve"><value>Departments</value></data>
   <data name="ShiftDash_Departments_SortNote" xml:space="preserve"><value>sorted by lowest fill % first</value></data>
   <data name="ShiftDash_Departments_Col_Department" xml:space="preserve"><value>Department</value></data>

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -1709,4 +1709,46 @@
   <data name="Privacy_ComplaintBody" xml:space="preserve"><value>If you are not satisfied with our response, you have the right to lodge a complaint with the Spanish Data Protection Agency (AEPD) at {0}.</value><comment>{0} = AEPD URL</comment></data>
 
 
+  <data name="ShiftDash_Overview_ShiftsFilled" xml:space="preserve"><value>Shifts filled</value></data>
+  <data name="ShiftDash_Overview_TicketHolders" xml:space="preserve"><value>Ticket holders</value></data>
+  <data name="ShiftDash_Overview_TicketHoldersSubline" xml:space="preserve"><value>humans who have paid</value></data>
+  <data name="ShiftDash_Overview_TicketHoldersEngaged" xml:space="preserve"><value>Ticket holders engaged</value></data>
+  <data name="ShiftDash_Overview_EngagedSubline" xml:space="preserve"><value>{0} humans haven't signed up</value><comment>{0} = count</comment></data>
+  <data name="ShiftDash_Overview_NonTicketSignups" xml:space="preserve"><value>Non-ticket signups</value></data>
+  <data name="ShiftDash_Overview_NonTicketSubline" xml:space="preserve"><value>signed up without a ticket (yet)</value></data>
+  <data name="ShiftDash_Overview_StalePending" xml:space="preserve"><value>Stale pending</value></data>
+  <data name="ShiftDash_Overview_StaleSubline" xml:space="preserve"><value>pending &gt; 3 days</value></data>
+
+  <data name="ShiftDash_Departments_Title" xml:space="preserve"><value>Departments</value></data>
+  <data name="ShiftDash_Departments_SortNote" xml:space="preserve"><value>sorted by lowest fill % first</value></data>
+  <data name="ShiftDash_Departments_Col_Department" xml:space="preserve"><value>Department</value></data>
+  <data name="ShiftDash_Departments_Col_Total" xml:space="preserve"><value>Total</value></data>
+  <data name="ShiftDash_Departments_Col_Filled" xml:space="preserve"><value>Filled</value></data>
+  <data name="ShiftDash_Departments_Col_Pct" xml:space="preserve"><value>%</value></data>
+  <data name="ShiftDash_Departments_Col_SlotsRemaining" xml:space="preserve"><value>Slots remaining</value></data>
+  <data name="ShiftDash_Departments_Col_Period" xml:space="preserve"><value>Period</value></data>
+  <data name="ShiftDash_Departments_Direct" xml:space="preserve"><value>Direct</value></data>
+
+  <data name="ShiftDash_Coordinators_Title" xml:space="preserve"><value>Coordinator activity</value></data>
+  <data name="ShiftDash_Coordinators_Subtitle" xml:space="preserve"><value>teams with pending signups, oldest login first</value></data>
+  <data name="ShiftDash_Coordinators_Col_Team" xml:space="preserve"><value>Team</value></data>
+  <data name="ShiftDash_Coordinators_Col_Coordinators" xml:space="preserve"><value>Coordinators</value></data>
+  <data name="ShiftDash_Coordinators_Col_OldestLogin" xml:space="preserve"><value>Oldest login</value></data>
+  <data name="ShiftDash_Coordinators_Col_Pending" xml:space="preserve"><value>Pending</value></data>
+  <data name="ShiftDash_Coordinators_NoCoordinators" xml:space="preserve"><value>no coordinators</value></data>
+  <data name="ShiftDash_Coordinators_Never" xml:space="preserve"><value>never</value></data>
+  <data name="ShiftDash_Coordinators_MinutesAgo" xml:space="preserve"><value>{0} min ago</value><comment>{0} = minutes</comment></data>
+  <data name="ShiftDash_Coordinators_HoursAgo" xml:space="preserve"><value>{0} h ago</value><comment>{0} = hours</comment></data>
+  <data name="ShiftDash_Coordinators_DaysAgo" xml:space="preserve"><value>{0} d ago</value><comment>{0} = days</comment></data>
+
+  <data name="ShiftDash_Trends_Title" xml:space="preserve"><value>Trends</value></data>
+  <data name="ShiftDash_Trends_Window_7d" xml:space="preserve"><value>7d</value></data>
+  <data name="ShiftDash_Trends_Window_30d" xml:space="preserve"><value>30d</value></data>
+  <data name="ShiftDash_Trends_Window_90d" xml:space="preserve"><value>90d</value></data>
+  <data name="ShiftDash_Trends_Window_All" xml:space="preserve"><value>All</value></data>
+  <data name="ShiftDash_Trends_NewSignups" xml:space="preserve"><value>New signups</value></data>
+  <data name="ShiftDash_Trends_NewTicketSales" xml:space="preserve"><value>New ticket sales</value></data>
+  <data name="ShiftDash_Trends_DAU" xml:space="preserve"><value>Distinct logins (DAU)</value></data>
+  <data name="ShiftDash_Trends_DAUNote" xml:space="preserve"><value>Only last login per human is stored — older buckets undercount.</value></data>
+
 </root>

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -1712,7 +1712,7 @@
   <data name="ShiftDash_Overview_ShiftsFilled" xml:space="preserve"><value>Shifts filled</value></data>
   <data name="ShiftDash_Overview_TicketHolders" xml:space="preserve"><value>Ticket holders</value></data>
   <data name="ShiftDash_Overview_TicketHoldersSubline" xml:space="preserve"><value>humans who have paid</value></data>
-  <data name="ShiftDash_Overview_TicketHoldersEngaged" xml:space="preserve"><value>Ticket holders engaged</value></data>
+  <data name="ShiftDash_Overview_TicketHoldersEngaged" xml:space="preserve"><value>Ticket holding volunteers</value></data>
   <data name="ShiftDash_Overview_EngagedSubline" xml:space="preserve"><value>{0} humans haven't signed up</value><comment>{0} = count</comment></data>
   <data name="ShiftDash_Overview_NonTicketSignups" xml:space="preserve"><value>Non-ticket signups</value></data>
   <data name="ShiftDash_Overview_NonTicketSubline" xml:space="preserve"><value>signed up without a ticket (yet)</value></data>

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -1712,7 +1712,7 @@
   <data name="ShiftDash_Overview_ShiftsFilled" xml:space="preserve"><value>Shifts filled</value></data>
   <data name="ShiftDash_Overview_TicketHolders" xml:space="preserve"><value>Ticket holders</value></data>
   <data name="ShiftDash_Overview_TicketHoldersSubline" xml:space="preserve"><value>humans who have paid</value></data>
-  <data name="ShiftDash_Overview_TicketHoldersEngaged" xml:space="preserve"><value>Ticket holding volunteers</value></data>
+  <data name="ShiftDash_Overview_TicketHoldersEngaged" xml:space="preserve"><value>Ticket holding humans</value></data>
   <data name="ShiftDash_Overview_EngagedSubline" xml:space="preserve"><value>{0} humans haven't signed up</value><comment>{0} = count</comment></data>
   <data name="ShiftDash_Overview_NonTicketSignups" xml:space="preserve"><value>Non-ticket signups</value></data>
   <data name="ShiftDash_Overview_NonTicketSubline" xml:space="preserve"><value>signed up without a ticket (yet)</value></data>
@@ -1741,7 +1741,6 @@
   <data name="ShiftDash_Coordinators_Subtitle" xml:space="preserve"><value>teams with pending signups, oldest login first</value></data>
   <data name="ShiftDash_Coordinators_Col_Team" xml:space="preserve"><value>Team</value></data>
   <data name="ShiftDash_Coordinators_Col_Coordinators" xml:space="preserve"><value>Coordinators</value></data>
-  <data name="ShiftDash_Coordinators_Col_OldestLogin" xml:space="preserve"><value>Oldest login</value></data>
   <data name="ShiftDash_Coordinators_Col_Pending" xml:space="preserve"><value>Pending</value></data>
   <data name="ShiftDash_Coordinators_NoCoordinators" xml:space="preserve"><value>no coordinators</value></data>
   <data name="ShiftDash_Coordinators_Never" xml:space="preserve"><value>never</value></data>
@@ -1759,5 +1758,9 @@
   <data name="ShiftDash_Trends_NewTicketSales" xml:space="preserve"><value>New ticket sales</value></data>
   <data name="ShiftDash_Trends_DAU" xml:space="preserve"><value>Distinct logins (DAU)</value></data>
   <data name="ShiftDash_Trends_DAUNote" xml:space="preserve"><value>Only last login per human is stored — older buckets undercount.</value></data>
+  <data name="ShiftDash_Status_OnTrack" xml:space="preserve"><value>On track</value></data>
+  <data name="ShiftDash_Status_AtRisk" xml:space="preserve"><value>At risk</value></data>
+  <data name="ShiftDash_Status_BelowTarget" xml:space="preserve"><value>Below target</value></data>
+  <data name="ShiftDash_Coordinators_StaleLabel" xml:space="preserve"><value>Inactive over 7 days</value></data>
 
 </root>

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -1718,6 +1718,8 @@
   <data name="ShiftDash_Overview_NonTicketSubline" xml:space="preserve"><value>signed up without a ticket (yet)</value></data>
   <data name="ShiftDash_Overview_StalePending" xml:space="preserve"><value>Stale pending</value></data>
   <data name="ShiftDash_Overview_StaleSubline" xml:space="preserve"><value>pending &gt; 3 days</value></data>
+  <data name="Common_NotAvailable" xml:space="preserve"><value>N/A</value></data>
+  <data name="ShiftDash_Overview_TicketData_Hidden" xml:space="preserve"><value>ticket data not yet shared</value></data>
 
   <data name="ShiftDash_PeriodFilter_Label" xml:space="preserve"><value>Showing:</value></data>
   <data name="ShiftDash_PeriodFilter_All" xml:space="preserve"><value>All</value></data>

--- a/src/Humans.Web/Views/Shared/_StaffingChart.cshtml
+++ b/src/Humans.Web/Views/Shared/_StaffingChart.cshtml
@@ -55,6 +55,32 @@
             return chartDanger;
         });
 
+        var pctLabelsPlugin = {
+            id: 'pctLabels',
+            afterDatasetsDraw: function(chart) {
+                var ctx = chart.ctx;
+                var confMeta = chart.getDatasetMeta(0);
+                var remMeta = chart.getDatasetMeta(1);
+                var confData = chart.data.datasets[0].data;
+                var remData = chart.data.datasets[1].data;
+                ctx.save();
+                ctx.font = '600 11px system-ui, -apple-system, sans-serif';
+                ctx.fillStyle = cv('--bs-body-color') || '#333';
+                ctx.textAlign = 'center';
+                ctx.textBaseline = 'bottom';
+                confMeta.data.forEach(function(_, i) {
+                    var conf = confData[i];
+                    var rem = remData[i];
+                    var total = conf + rem;
+                    if (total === 0) return;
+                    var pct = Math.round(100 * conf / total);
+                    var topBar = remMeta.data[i];
+                    ctx.fillText(pct + '%', topBar.x, topBar.y - 4);
+                });
+                ctx.restore();
+            }
+        };
+
         new Chart(document.getElementById('@chartKey'), {
             type: 'bar',
             data: {
@@ -67,15 +93,29 @@
             },
             options: {
                 responsive: true,
+                layout: { padding: { top: 20 } },
                 scales: { x: { stacked: true }, y: { stacked: true, beginAtZero: true } },
+                interaction: { mode: 'index', intersect: false },
                 plugins: {
                     tooltip: {
                         callbacks: {
-                            afterTitle: function(items) { return data[items[0].dataIndex].period; }
+                            afterTitle: function(items) { return data[items[0].dataIndex].period; },
+                            footer: function(items) {
+                                var conf = 0, rem = 0;
+                                items.forEach(function(item) {
+                                    if (item.dataset.label === 'Confirmed') conf = item.parsed.y;
+                                    else if (item.dataset.label === 'Remaining') rem = item.parsed.y;
+                                });
+                                var total = conf + rem;
+                                if (total === 0) return '';
+                                var pct = Math.round(100 * conf / total);
+                                return 'Total: ' + total + ' (' + pct + '% confirmed)';
+                            }
                         }
                     }
                 }
-            }
+            },
+            plugins: [pctLabelsPlugin]
         });
     };
         </text>

--- a/src/Humans.Web/Views/Shared/_StaffingChart.cshtml
+++ b/src/Humans.Web/Views/Shared/_StaffingChart.cshtml
@@ -131,7 +131,7 @@
             <div class="card mb-4">
                 <div class="card-header"><h6 class="mb-0">@group.Key Staffing</h6></div>
                 <div class="card-body">
-                    <canvas id="@chartKey" height="100"></canvas>
+                    <canvas id="@chartKey" height="100" role="img" aria-label="@(group.Key) Staffing"></canvas>
                 </div>
             </div>
         }

--- a/src/Humans.Web/Views/ShiftDashboard/Index.cshtml
+++ b/src/Humans.Web/Views/ShiftDashboard/Index.cshtml
@@ -17,10 +17,27 @@
 
     <div class="d-flex justify-content-between align-items-center mb-3">
         <h2>@Localizer["ShiftDash_Title"]</h2>
-        <span class="badge bg-secondary fs-6">@string.Format(Localizer["ShiftDash_ShiftsCount"].Value, Model.Shifts.Count)</span>
+        <div class="d-flex gap-2 align-items-center">
+            @if (Model.IsDevelopment)
+            {
+                <form method="post" action="/dev/seed/dashboard" class="d-inline">
+                    @Html.AntiForgeryToken()
+                    <button type="submit" class="btn btn-sm btn-outline-warning">Seed dashboard (dev)</button>
+                </form>
+            }
+            <span class="badge bg-secondary fs-6">@string.Format(Localizer["ShiftDash_ShiftsCount"].Value, Model.Shifts.Count)</span>
+        </div>
     </div>
 
     <vc:temp-data-alerts />
+
+    @if (Model.Overview is not null)
+    {
+        @await Html.PartialAsync("_OverviewCounters", Model.Overview)
+        @await Html.PartialAsync("_DepartmentsTable", Model.Overview.Departments)
+    }
+    @await Html.PartialAsync("_CoordinatorActivity", Model.CoordinatorActivity)
+    @await Html.PartialAsync("_TrendsChart", (Model.Trends, Model.TrendWindow))
 
     @* Filter bar *@
     <div class="card mb-4">

--- a/src/Humans.Web/Views/ShiftDashboard/Index.cshtml
+++ b/src/Humans.Web/Views/ShiftDashboard/Index.cshtml
@@ -24,6 +24,10 @@
                     @Html.AntiForgeryToken()
                     <button type="submit" class="btn btn-sm btn-outline-warning">Seed dashboard (dev)</button>
                 </form>
+                <form method="post" action="/dev/seed/dashboard?reset=true" class="d-inline">
+                    @Html.AntiForgeryToken()
+                    <button type="submit" class="btn btn-sm btn-outline-danger">Reset &amp; reseed (dev)</button>
+                </form>
             }
             <span class="badge bg-secondary fs-6">@string.Format(Localizer["ShiftDash_ShiftsCount"].Value, Model.Shifts.Count)</span>
         </div>

--- a/src/Humans.Web/Views/ShiftDashboard/Index.cshtml
+++ b/src/Humans.Web/Views/ShiftDashboard/Index.cshtml
@@ -1,10 +1,15 @@
 @model Humans.Web.Models.ShiftDashboardViewModel
+@using Humans.Application.Enums
+@using Humans.Domain.Enums
 @using Humans.Web.Controllers
 
 @{
     ViewData["Title"] = Localizer["ShiftDash_Title"].Value;
     var searchUrl = Url.Action(nameof(ShiftDashboardController.SearchVolunteers), "ShiftDashboard");
     var voluntellUrl = Url.Action(nameof(ShiftDashboardController.Voluntell), "ShiftDashboard");
+
+    string PeriodBtnClass(ShiftPeriod? p) =>
+        Model.SelectedPeriod == p ? "btn btn-primary active" : "btn btn-outline-secondary";
 }
 
 <div class="container py-4">
@@ -35,18 +40,61 @@
 
     <vc:temp-data-alerts />
 
+    <div class="card mb-4">
+        <div class="card-body py-2 d-flex align-items-center flex-wrap gap-2">
+            <span class="text-muted small me-2">@Localizer["ShiftDash_PeriodFilter_Label"]</span>
+            <div class="btn-group btn-group-sm" role="group">
+                <a asp-action="Index"
+                   asp-route-departmentId="@Model.SelectedDepartmentId"
+                   asp-route-rotaId="@Model.SelectedRotaId"
+                   asp-route-date="@Model.SelectedDate"
+                   asp-route-trendWindow="@Model.TrendWindow"
+                   class="@PeriodBtnClass(null)">@Localizer["ShiftDash_PeriodFilter_All"]</a>
+                <a asp-action="Index"
+                   asp-route-departmentId="@Model.SelectedDepartmentId"
+                   asp-route-rotaId="@Model.SelectedRotaId"
+                   asp-route-date="@Model.SelectedDate"
+                   asp-route-trendWindow="@Model.TrendWindow"
+                   asp-route-period="@ShiftPeriod.Build"
+                   class="@PeriodBtnClass(ShiftPeriod.Build)">@Localizer["ShiftDash_PeriodFilter_BuildDays"]</a>
+                <a asp-action="Index"
+                   asp-route-departmentId="@Model.SelectedDepartmentId"
+                   asp-route-rotaId="@Model.SelectedRotaId"
+                   asp-route-date="@Model.SelectedDate"
+                   asp-route-trendWindow="@Model.TrendWindow"
+                   asp-route-period="@ShiftPeriod.Event"
+                   class="@PeriodBtnClass(ShiftPeriod.Event)">@Localizer["ShiftDash_PeriodFilter_EventShifts"]</a>
+                <a asp-action="Index"
+                   asp-route-departmentId="@Model.SelectedDepartmentId"
+                   asp-route-rotaId="@Model.SelectedRotaId"
+                   asp-route-date="@Model.SelectedDate"
+                   asp-route-trendWindow="@Model.TrendWindow"
+                   asp-route-period="@ShiftPeriod.Strike"
+                   class="@PeriodBtnClass(ShiftPeriod.Strike)">@Localizer["ShiftDash_PeriodFilter_Strike"]</a>
+            </div>
+        </div>
+    </div>
+
     @if (Model.Overview is not null)
     {
         @await Html.PartialAsync("_OverviewCounters", Model.Overview)
         @await Html.PartialAsync("_DepartmentsTable", Model.Overview.Departments)
     }
     @await Html.PartialAsync("_CoordinatorActivity", Model.CoordinatorActivity)
-    @await Html.PartialAsync("_TrendsChart", (Model.Trends, Model.TrendWindow))
+    @await Html.PartialAsync("_TrendsChart", (Model.Trends, Model.TrendWindow, Model.SelectedPeriod))
 
     @* Filter bar *@
     <div class="card mb-4">
         <div class="card-body">
             <form method="get" class="row g-2 align-items-end">
+                @if (Model.SelectedPeriod.HasValue)
+                {
+                    <input type="hidden" name="period" value="@Model.SelectedPeriod.Value" />
+                }
+                @if (Model.TrendWindow != TrendWindow.Last30Days)
+                {
+                    <input type="hidden" name="trendWindow" value="@Model.TrendWindow" />
+                }
                 <div class="col-md-3">
                     <label class="form-label">@Localizer["ShiftDash_Date"]</label>
                     <input type="date" name="date" value="@Model.SelectedDate" class="form-control" />

--- a/src/Humans.Web/Views/ShiftDashboard/Index.cshtml
+++ b/src/Humans.Web/Views/ShiftDashboard/Index.cshtml
@@ -29,8 +29,9 @@
                     @Html.AntiForgeryToken()
                     <button type="submit" class="btn btn-sm btn-outline-warning">Seed dashboard (dev)</button>
                 </form>
-                <form method="post" action="/dev/seed/dashboard?reset=true" class="d-inline">
+                <form method="post" action="/dev/seed/dashboard" class="d-inline">
                     @Html.AntiForgeryToken()
+                    <input type="hidden" name="reset" value="true" />
                     <button type="submit" class="btn btn-sm btn-outline-danger">Reset &amp; reseed (dev)</button>
                 </form>
             }

--- a/src/Humans.Web/Views/ShiftDashboard/_CoordinatorActivity.cshtml
+++ b/src/Humans.Web/Views/ShiftDashboard/_CoordinatorActivity.cshtml
@@ -47,7 +47,8 @@
                     <tr role="@(hasSubgroups ? "button" : null)"
                         data-bs-toggle="@(hasSubgroups ? "collapse" : null)"
                         data-bs-target="@(hasSubgroups ? "#" + rowId : null)"
-                        aria-expanded="false">
+                        aria-expanded="false"
+                        aria-controls="@(hasSubgroups ? rowId : null)">
                         <td class="text-muted">
                             @if (hasSubgroups)
                             {
@@ -69,7 +70,7 @@
                                         <li>
                                             <span class="fw-semibold">@c.DisplayName</span>
                                             <span class="text-muted"> · </span>
-                                            <span class="@(stale ? "text-danger fw-semibold" : "text-muted")">@RelativeTime(c.LastLoginAt)</span>
+                                            <span class="@(stale ? "text-danger fw-semibold" : "text-muted")">@RelativeTime(c.LastLoginAt)@if (stale) {<span class="visually-hidden"> — @Localizer["ShiftDash_Coordinators_StaleLabel"]</span>}</span>
                                         </li>
                                     }
                                 </ul>
@@ -110,7 +111,7 @@
                                                                 <li>
                                                                     <span class="fw-semibold">@c.DisplayName</span>
                                                                     <span class="text-muted"> · </span>
-                                                                    <span class="@(stale ? "text-danger fw-semibold" : "text-muted")">@RelativeTime(c.LastLoginAt)</span>
+                                                                    <span class="@(stale ? "text-danger fw-semibold" : "text-muted")">@RelativeTime(c.LastLoginAt)@if (stale) {<span class="visually-hidden"> — @Localizer["ShiftDash_Coordinators_StaleLabel"]</span>}</span>
                                                                 </li>
                                                             }
                                                         </ul>

--- a/src/Humans.Web/Views/ShiftDashboard/_CoordinatorActivity.cshtml
+++ b/src/Humans.Web/Views/ShiftDashboard/_CoordinatorActivity.cshtml
@@ -15,6 +15,8 @@
             : string.Format(Localizer["ShiftDash_Coordinators_HoursAgo"].Value, (int)diff.TotalHours);
         return string.Format(Localizer["ShiftDash_Coordinators_DaysAgo"].Value, (int)diff.TotalDays);
     }
+
+    bool IsStale(Instant? t) => t is null || (now - t.Value).TotalDays > 7;
 }
 
 @if (Model.Count == 0)
@@ -31,37 +33,99 @@
         <table class="table table-sm align-middle mb-0">
             <thead class="table-light">
                 <tr>
+                    <th style="width: 2rem;"></th>
                     <th>@Localizer["ShiftDash_Coordinators_Col_Team"]</th>
                     <th>@Localizer["ShiftDash_Coordinators_Col_Coordinators"]</th>
-                    <th>@Localizer["ShiftDash_Coordinators_Col_OldestLogin"]</th>
                     <th class="text-end">@Localizer["ShiftDash_Coordinators_Col_Pending"]</th>
                 </tr>
             </thead>
             <tbody>
                 @foreach (var row in Model)
                 {
-                    var oldest = row.Coordinators.Count == 0
-                        ? (Instant?)null
-                        : row.Coordinators.Min(c => c.LastLoginAt ?? Instant.MinValue);
-                    if (oldest == Instant.MinValue) oldest = null;
-                    var stale = oldest is null || (now - oldest.Value).TotalDays > 7;
-                    <tr>
-                        <td>@row.TeamName</td>
+                    var rowId = "coord-" + row.TeamId.ToString("N");
+                    var hasSubgroups = row.Subgroups.Count > 0;
+                    <tr role="@(hasSubgroups ? "button" : null)"
+                        data-bs-toggle="@(hasSubgroups ? "collapse" : null)"
+                        data-bs-target="@(hasSubgroups ? "#" + rowId : null)"
+                        aria-expanded="false">
+                        <td class="text-muted">
+                            @if (hasSubgroups)
+                            {
+                                <i class="bi bi-chevron-right"></i>
+                            }
+                        </td>
+                        <td class="fw-semibold">@row.TeamName</td>
                         <td>
                             @if (row.Coordinators.Count == 0)
                             {
-                                <span class="text-muted fst-italic">@Localizer["ShiftDash_Coordinators_NoCoordinators"]</span>
+                                <span class="text-muted fst-italic small">@Localizer["ShiftDash_Coordinators_NoCoordinators"]</span>
                             }
                             else
                             {
-                                @string.Join(", ", row.Coordinators.Select(c => c.DisplayName))
+                                <ul class="list-unstyled mb-0 small">
+                                    @foreach (var c in row.Coordinators)
+                                    {
+                                        var stale = IsStale(c.LastLoginAt);
+                                        <li>
+                                            <span class="fw-semibold">@c.DisplayName</span>
+                                            <span class="text-muted"> · </span>
+                                            <span class="@(stale ? "text-danger fw-semibold" : "text-muted")">@RelativeTime(c.LastLoginAt)</span>
+                                        </li>
+                                    }
+                                </ul>
                             }
                         </td>
-                        <td class="@(stale ? "text-danger fw-semibold" : "")">
-                            @RelativeTime(oldest)
+                        <td class="text-end">
+                            <span class="badge bg-warning text-dark">@row.AggregatePendingCount</span>
+                            @if (hasSubgroups && row.PendingSignupCount != row.AggregatePendingCount)
+                            {
+                                <div class="text-muted small">
+                                    @string.Format(Localizer["ShiftDash_Coordinators_DirectPending"].Value, row.PendingSignupCount)
+                                </div>
+                            }
                         </td>
-                        <td class="text-end"><span class="badge bg-warning text-dark">@row.PendingSignupCount</span></td>
                     </tr>
+                    @if (hasSubgroups)
+                    {
+                        <tr class="collapse" id="@rowId">
+                            <td></td>
+                            <td colspan="3" class="bg-light">
+                                <table class="table table-sm mb-0">
+                                    <tbody>
+                                        @foreach (var sub in row.Subgroups)
+                                        {
+                                            <tr>
+                                                <td style="width: 30%;">@sub.TeamName</td>
+                                                <td>
+                                                    @if (sub.Coordinators.Count == 0)
+                                                    {
+                                                        <span class="text-muted fst-italic small">@Localizer["ShiftDash_Coordinators_NoCoordinators"]</span>
+                                                    }
+                                                    else
+                                                    {
+                                                        <ul class="list-unstyled mb-0 small">
+                                                            @foreach (var c in sub.Coordinators)
+                                                            {
+                                                                var stale = IsStale(c.LastLoginAt);
+                                                                <li>
+                                                                    <span class="fw-semibold">@c.DisplayName</span>
+                                                                    <span class="text-muted"> · </span>
+                                                                    <span class="@(stale ? "text-danger fw-semibold" : "text-muted")">@RelativeTime(c.LastLoginAt)</span>
+                                                                </li>
+                                                            }
+                                                        </ul>
+                                                    }
+                                                </td>
+                                                <td class="text-end" style="width: 6rem;">
+                                                    <span class="badge bg-warning text-dark">@sub.AggregatePendingCount</span>
+                                                </td>
+                                            </tr>
+                                        }
+                                    </tbody>
+                                </table>
+                            </td>
+                        </tr>
+                    }
                 }
             </tbody>
         </table>

--- a/src/Humans.Web/Views/ShiftDashboard/_CoordinatorActivity.cshtml
+++ b/src/Humans.Web/Views/ShiftDashboard/_CoordinatorActivity.cshtml
@@ -1,0 +1,69 @@
+@using Humans.Application.DTOs
+@using NodaTime
+@model IReadOnlyList<CoordinatorActivityRow>
+@inject IClock Clock
+
+@{
+    var now = Clock.GetCurrentInstant();
+
+    static string RelativeTime(Instant? t, Instant now)
+    {
+        if (t is null) return "never";
+        var diff = now - t.Value;
+        if (diff.TotalDays < 1) return diff.TotalHours < 1
+            ? $"{(int)Math.Max(1, diff.TotalMinutes)} min ago"
+            : $"{(int)diff.TotalHours} h ago";
+        return $"{(int)diff.TotalDays} d ago";
+    }
+}
+
+@if (Model.Count == 0)
+{
+    return;
+}
+
+<div class="card mb-4">
+    <div class="card-header d-flex justify-content-between align-items-center">
+        <strong>Coordinator activity</strong>
+        <span class="text-muted small">teams with pending signups, oldest login first</span>
+    </div>
+    <div class="table-responsive">
+        <table class="table table-sm align-middle mb-0">
+            <thead class="table-light">
+                <tr>
+                    <th>Team</th>
+                    <th>Coordinators</th>
+                    <th>Oldest login</th>
+                    <th class="text-end">Pending</th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach (var row in Model)
+                {
+                    var oldest = row.Coordinators.Count == 0
+                        ? (Instant?)null
+                        : row.Coordinators.Min(c => c.LastLoginAt ?? Instant.MinValue);
+                    if (oldest == Instant.MinValue) oldest = null;
+                    var stale = oldest is null || (now - oldest.Value).TotalDays > 7;
+                    <tr>
+                        <td>@row.TeamName</td>
+                        <td>
+                            @if (row.Coordinators.Count == 0)
+                            {
+                                <span class="text-muted fst-italic">no coordinators</span>
+                            }
+                            else
+                            {
+                                @string.Join(", ", row.Coordinators.Select(c => c.DisplayName))
+                            }
+                        </td>
+                        <td class="@(stale ? "text-danger fw-semibold" : "")">
+                            @RelativeTime(oldest, now)
+                        </td>
+                        <td class="text-end"><span class="badge bg-warning text-dark">@row.PendingSignupCount</span></td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+    </div>
+</div>

--- a/src/Humans.Web/Views/ShiftDashboard/_CoordinatorActivity.cshtml
+++ b/src/Humans.Web/Views/ShiftDashboard/_CoordinatorActivity.cshtml
@@ -6,14 +6,14 @@
 @{
     var now = Clock.GetCurrentInstant();
 
-    static string RelativeTime(Instant? t, Instant now)
+    string RelativeTime(Instant? t)
     {
-        if (t is null) return "never";
+        if (t is null) return Localizer["ShiftDash_Coordinators_Never"].Value;
         var diff = now - t.Value;
         if (diff.TotalDays < 1) return diff.TotalHours < 1
-            ? $"{(int)Math.Max(1, diff.TotalMinutes)} min ago"
-            : $"{(int)diff.TotalHours} h ago";
-        return $"{(int)diff.TotalDays} d ago";
+            ? string.Format(Localizer["ShiftDash_Coordinators_MinutesAgo"].Value, (int)Math.Max(1, diff.TotalMinutes))
+            : string.Format(Localizer["ShiftDash_Coordinators_HoursAgo"].Value, (int)diff.TotalHours);
+        return string.Format(Localizer["ShiftDash_Coordinators_DaysAgo"].Value, (int)diff.TotalDays);
     }
 }
 
@@ -24,17 +24,17 @@
 
 <div class="card mb-4">
     <div class="card-header d-flex justify-content-between align-items-center">
-        <strong>Coordinator activity</strong>
-        <span class="text-muted small">teams with pending signups, oldest login first</span>
+        <strong>@Localizer["ShiftDash_Coordinators_Title"]</strong>
+        <span class="text-muted small">@Localizer["ShiftDash_Coordinators_Subtitle"]</span>
     </div>
     <div class="table-responsive">
         <table class="table table-sm align-middle mb-0">
             <thead class="table-light">
                 <tr>
-                    <th>Team</th>
-                    <th>Coordinators</th>
-                    <th>Oldest login</th>
-                    <th class="text-end">Pending</th>
+                    <th>@Localizer["ShiftDash_Coordinators_Col_Team"]</th>
+                    <th>@Localizer["ShiftDash_Coordinators_Col_Coordinators"]</th>
+                    <th>@Localizer["ShiftDash_Coordinators_Col_OldestLogin"]</th>
+                    <th class="text-end">@Localizer["ShiftDash_Coordinators_Col_Pending"]</th>
                 </tr>
             </thead>
             <tbody>
@@ -50,7 +50,7 @@
                         <td>
                             @if (row.Coordinators.Count == 0)
                             {
-                                <span class="text-muted fst-italic">no coordinators</span>
+                                <span class="text-muted fst-italic">@Localizer["ShiftDash_Coordinators_NoCoordinators"]</span>
                             }
                             else
                             {
@@ -58,7 +58,7 @@
                             }
                         </td>
                         <td class="@(stale ? "text-danger fw-semibold" : "")">
-                            @RelativeTime(oldest, now)
+                            @RelativeTime(oldest)
                         </td>
                         <td class="text-end"><span class="badge bg-warning text-dark">@row.PendingSignupCount</span></td>
                     </tr>

--- a/src/Humans.Web/Views/ShiftDashboard/_DepartmentsTable.cshtml
+++ b/src/Humans.Web/Views/ShiftDashboard/_DepartmentsTable.cshtml
@@ -1,0 +1,120 @@
+@using Humans.Application.DTOs
+@model IReadOnlyList<DepartmentStaffingRow>
+
+@{
+    static string PctClass(double pct) =>
+        pct >= 80 ? "bg-success" : pct >= 60 ? "bg-warning text-dark" : "bg-danger";
+
+    static double Pct(int filled, int total) => total == 0 ? 0 : 100.0 * filled / total;
+}
+
+@if (Model.Count == 0)
+{
+    return;
+}
+
+<div class="card mb-4">
+    <div class="card-header d-flex justify-content-between align-items-center">
+        <strong>Departments</strong>
+        <span class="text-muted small">sorted by lowest fill % first</span>
+    </div>
+    <div class="table-responsive">
+        <table class="table table-sm align-middle mb-0">
+            <thead class="table-light">
+                <tr>
+                    <th></th>
+                    <th>Department</th>
+                    <th class="text-end">Total</th>
+                    <th class="text-end">Filled</th>
+                    <th class="text-end">%</th>
+                    <th class="text-end">Slots remaining</th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach (var row in Model)
+                {
+                    var rowId = "dept-" + row.DepartmentId.ToString("N");
+                    var pct = Pct(row.FilledShifts, row.TotalShifts);
+                    <tr role="button" data-bs-toggle="collapse" data-bs-target="#@rowId" aria-expanded="false">
+                        <td class="text-muted"><i class="bi bi-chevron-right"></i></td>
+                        <td>@row.DepartmentName</td>
+                        <td class="text-end">@row.TotalShifts</td>
+                        <td class="text-end">@row.FilledShifts</td>
+                        <td class="text-end"><span class="badge @PctClass(pct)">@pct.ToString("0")%</span></td>
+                        <td class="text-end">@row.SlotsRemaining</td>
+                    </tr>
+                    <tr class="collapse" id="@rowId">
+                        <td colspan="6" class="bg-light">
+                            @if (row.Subgroups.Count > 0)
+                            {
+                                <table class="table table-sm mb-0">
+                                    <thead>
+                                        <tr>
+                                            <th></th>
+                                            <th class="text-end">Total</th>
+                                            <th class="text-end">Filled</th>
+                                            <th class="text-end">%</th>
+                                            <th class="text-end">Slots remaining</th>
+                                            <th class="text-end">Build</th>
+                                            <th class="text-end">Event</th>
+                                            <th class="text-end">Strike</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        @foreach (var sub in row.Subgroups)
+                                        {
+                                            var sPct = Pct(sub.FilledShifts, sub.TotalShifts);
+                                            <tr>
+                                                <td>
+                                                    @if (sub.IsDirect)
+                                                    {
+                                                        <span class="badge bg-secondary me-1">Direct</span>
+                                                    }
+                                                    @sub.Name
+                                                </td>
+                                                <td class="text-end">@sub.TotalShifts</td>
+                                                <td class="text-end">@sub.FilledShifts</td>
+                                                <td class="text-end"><span class="badge @PctClass(sPct)">@sPct.ToString("0")%</span></td>
+                                                <td class="text-end">@sub.SlotsRemaining</td>
+                                                <td class="text-end"><span class="badge @PctClass(Pct(sub.Build.Filled, sub.Build.Total))">@Pct(sub.Build.Filled, sub.Build.Total).ToString("0")%</span></td>
+                                                <td class="text-end"><span class="badge @PctClass(Pct(sub.Event.Filled, sub.Event.Total))">@Pct(sub.Event.Filled, sub.Event.Total).ToString("0")%</span></td>
+                                                <td class="text-end"><span class="badge @PctClass(Pct(sub.Strike.Filled, sub.Strike.Total))">@Pct(sub.Strike.Filled, sub.Strike.Total).ToString("0")%</span></td>
+                                            </tr>
+                                        }
+                                    </tbody>
+                                </table>
+                            }
+                            else
+                            {
+                                <table class="table table-sm mb-0">
+                                    <thead>
+                                        <tr>
+                                            <th>Period</th>
+                                            <th class="text-end">Total</th>
+                                            <th class="text-end">Filled</th>
+                                            <th class="text-end">%</th>
+                                            <th class="text-end">Slots remaining</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        @foreach (var (label, p) in new[] { ("Build", row.Build), ("Event", row.Event), ("Strike", row.Strike) })
+                                        {
+                                            var pPct = Pct(p.Filled, p.Total);
+                                            <tr>
+                                                <td>@label</td>
+                                                <td class="text-end">@p.Total</td>
+                                                <td class="text-end">@p.Filled</td>
+                                                <td class="text-end"><span class="badge @PctClass(pPct)">@pPct.ToString("0")%</span></td>
+                                                <td class="text-end">@p.SlotsRemaining</td>
+                                            </tr>
+                                        }
+                                    </tbody>
+                                </table>
+                            }
+                        </td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+    </div>
+</div>

--- a/src/Humans.Web/Views/ShiftDashboard/_DepartmentsTable.cshtml
+++ b/src/Humans.Web/Views/ShiftDashboard/_DepartmentsTable.cshtml
@@ -6,6 +6,11 @@
         pct >= 80 ? "bg-success" : pct >= 60 ? "bg-warning text-dark" : "bg-danger";
 
     static double Pct(int filled, int total) => total == 0 ? 0 : 100.0 * filled / total;
+
+    string PctStatusLabel(double pct) =>
+        pct >= 80 ? Localizer["ShiftDash_Status_OnTrack"].Value
+        : pct >= 60 ? Localizer["ShiftDash_Status_AtRisk"].Value
+        : Localizer["ShiftDash_Status_BelowTarget"].Value;
 }
 
 @if (Model.Count == 0)
@@ -35,12 +40,12 @@
                 {
                     var rowId = "dept-" + row.DepartmentId.ToString("N");
                     var pct = Pct(row.FilledShifts, row.TotalShifts);
-                    <tr role="button" data-bs-toggle="collapse" data-bs-target="#@rowId" aria-expanded="false">
+                    <tr role="button" data-bs-toggle="collapse" data-bs-target="#@rowId" aria-expanded="false" aria-controls="@rowId">
                         <td class="text-muted"><i class="bi bi-chevron-right"></i></td>
                         <td>@row.DepartmentName</td>
                         <td class="text-end">@row.TotalShifts</td>
                         <td class="text-end">@row.FilledShifts</td>
-                        <td class="text-end"><span class="badge @PctClass(pct)">@pct.ToString("0")%</span></td>
+                        <td class="text-end"><span class="badge @PctClass(pct)">@pct.ToString("0")% <span class="visually-hidden">@PctStatusLabel(pct)</span></span></td>
                         <td class="text-end">@row.SlotsRemaining</td>
                     </tr>
                     <tr class="collapse" id="@rowId">
@@ -74,11 +79,11 @@
                                                 </td>
                                                 <td class="text-end">@sub.TotalShifts</td>
                                                 <td class="text-end">@sub.FilledShifts</td>
-                                                <td class="text-end"><span class="badge @PctClass(sPct)">@sPct.ToString("0")%</span></td>
+                                                <td class="text-end"><span class="badge @PctClass(sPct)">@sPct.ToString("0")% <span class="visually-hidden">@PctStatusLabel(sPct)</span></span></td>
                                                 <td class="text-end">@sub.SlotsRemaining</td>
-                                                <td class="text-end"><span class="badge @PctClass(Pct(sub.Build.Filled, sub.Build.Total))">@Pct(sub.Build.Filled, sub.Build.Total).ToString("0")%</span></td>
-                                                <td class="text-end"><span class="badge @PctClass(Pct(sub.Event.Filled, sub.Event.Total))">@Pct(sub.Event.Filled, sub.Event.Total).ToString("0")%</span></td>
-                                                <td class="text-end"><span class="badge @PctClass(Pct(sub.Strike.Filled, sub.Strike.Total))">@Pct(sub.Strike.Filled, sub.Strike.Total).ToString("0")%</span></td>
+                                                <td class="text-end"><span class="badge @PctClass(Pct(sub.Build.Filled, sub.Build.Total))">@Pct(sub.Build.Filled, sub.Build.Total).ToString("0")% <span class="visually-hidden">@PctStatusLabel(Pct(sub.Build.Filled, sub.Build.Total))</span></span></td>
+                                                <td class="text-end"><span class="badge @PctClass(Pct(sub.Event.Filled, sub.Event.Total))">@Pct(sub.Event.Filled, sub.Event.Total).ToString("0")% <span class="visually-hidden">@PctStatusLabel(Pct(sub.Event.Filled, sub.Event.Total))</span></span></td>
+                                                <td class="text-end"><span class="badge @PctClass(Pct(sub.Strike.Filled, sub.Strike.Total))">@Pct(sub.Strike.Filled, sub.Strike.Total).ToString("0")% <span class="visually-hidden">@PctStatusLabel(Pct(sub.Strike.Filled, sub.Strike.Total))</span></span></td>
                                             </tr>
                                         }
                                     </tbody>
@@ -107,7 +112,7 @@
                                                 <td>@label</td>
                                                 <td class="text-end">@p.Total</td>
                                                 <td class="text-end">@p.Filled</td>
-                                                <td class="text-end"><span class="badge @PctClass(pPct)">@pPct.ToString("0")%</span></td>
+                                                <td class="text-end"><span class="badge @PctClass(pPct)">@pPct.ToString("0")% <span class="visually-hidden">@PctStatusLabel(pPct)</span></span></td>
                                                 <td class="text-end">@p.SlotsRemaining</td>
                                             </tr>
                                         }

--- a/src/Humans.Web/Views/ShiftDashboard/_DepartmentsTable.cshtml
+++ b/src/Humans.Web/Views/ShiftDashboard/_DepartmentsTable.cshtml
@@ -15,19 +15,19 @@
 
 <div class="card mb-4">
     <div class="card-header d-flex justify-content-between align-items-center">
-        <strong>Departments</strong>
-        <span class="text-muted small">sorted by lowest fill % first</span>
+        <strong>@Localizer["ShiftDash_Departments_Title"]</strong>
+        <span class="text-muted small">@Localizer["ShiftDash_Departments_SortNote"]</span>
     </div>
     <div class="table-responsive">
         <table class="table table-sm align-middle mb-0">
             <thead class="table-light">
                 <tr>
                     <th></th>
-                    <th>Department</th>
-                    <th class="text-end">Total</th>
-                    <th class="text-end">Filled</th>
-                    <th class="text-end">%</th>
-                    <th class="text-end">Slots remaining</th>
+                    <th>@Localizer["ShiftDash_Departments_Col_Department"]</th>
+                    <th class="text-end">@Localizer["ShiftDash_Departments_Col_Total"]</th>
+                    <th class="text-end">@Localizer["ShiftDash_Departments_Col_Filled"]</th>
+                    <th class="text-end">@Localizer["ShiftDash_Departments_Col_Pct"]</th>
+                    <th class="text-end">@Localizer["ShiftDash_Departments_Col_SlotsRemaining"]</th>
                 </tr>
             </thead>
             <tbody>
@@ -51,13 +51,13 @@
                                     <thead>
                                         <tr>
                                             <th></th>
-                                            <th class="text-end">Total</th>
-                                            <th class="text-end">Filled</th>
-                                            <th class="text-end">%</th>
-                                            <th class="text-end">Slots remaining</th>
-                                            <th class="text-end">Build</th>
-                                            <th class="text-end">Event</th>
-                                            <th class="text-end">Strike</th>
+                                            <th class="text-end">@Localizer["ShiftDash_Departments_Col_Total"]</th>
+                                            <th class="text-end">@Localizer["ShiftDash_Departments_Col_Filled"]</th>
+                                            <th class="text-end">@Localizer["ShiftDash_Departments_Col_Pct"]</th>
+                                            <th class="text-end">@Localizer["ShiftDash_Departments_Col_SlotsRemaining"]</th>
+                                            <th class="text-end">@Localizer["Shifts_SetUp"]</th>
+                                            <th class="text-end">@Localizer["Shifts_Event"]</th>
+                                            <th class="text-end">@Localizer["Shifts_Strike"]</th>
                                         </tr>
                                     </thead>
                                     <tbody>
@@ -68,7 +68,7 @@
                                                 <td>
                                                     @if (sub.IsDirect)
                                                     {
-                                                        <span class="badge bg-secondary me-1">Direct</span>
+                                                        <span class="badge bg-secondary me-1">@Localizer["ShiftDash_Departments_Direct"]</span>
                                                     }
                                                     @sub.Name
                                                 </td>
@@ -89,15 +89,18 @@
                                 <table class="table table-sm mb-0">
                                     <thead>
                                         <tr>
-                                            <th>Period</th>
-                                            <th class="text-end">Total</th>
-                                            <th class="text-end">Filled</th>
-                                            <th class="text-end">%</th>
-                                            <th class="text-end">Slots remaining</th>
+                                            <th>@Localizer["ShiftDash_Departments_Col_Period"]</th>
+                                            <th class="text-end">@Localizer["ShiftDash_Departments_Col_Total"]</th>
+                                            <th class="text-end">@Localizer["ShiftDash_Departments_Col_Filled"]</th>
+                                            <th class="text-end">@Localizer["ShiftDash_Departments_Col_Pct"]</th>
+                                            <th class="text-end">@Localizer["ShiftDash_Departments_Col_SlotsRemaining"]</th>
                                         </tr>
                                     </thead>
                                     <tbody>
-                                        @foreach (var (label, p) in new[] { ("Build", row.Build), ("Event", row.Event), ("Strike", row.Strike) })
+                                        @foreach (var (label, p) in new[] {
+                                            (Localizer["Shifts_SetUp"].Value, row.Build),
+                                            (Localizer["Shifts_Event"].Value, row.Event),
+                                            (Localizer["Shifts_Strike"].Value, row.Strike) })
                                         {
                                             var pPct = Pct(p.Filled, p.Total);
                                             <tr>

--- a/src/Humans.Web/Views/ShiftDashboard/_OverviewCounters.cshtml
+++ b/src/Humans.Web/Views/ShiftDashboard/_OverviewCounters.cshtml
@@ -1,0 +1,63 @@
+@using Humans.Application.DTOs
+@model DashboardOverview
+
+@{
+    static string PctClass(double pct) =>
+        pct >= 80 ? "bg-success" : pct >= 60 ? "bg-warning text-dark" : "bg-danger";
+
+    var filledPct = Model.TotalShifts == 0 ? 0 : 100.0 * Model.FilledShifts / Model.TotalShifts;
+    var engagedPct = Model.TicketHolderCount == 0 ? 0 : 100.0 * Model.TicketHoldersEngaged / Model.TicketHolderCount;
+    var unreached = Math.Max(0, Model.TicketHolderCount - Model.TicketHoldersEngaged);
+}
+
+<div class="row g-3 mb-4">
+    <div class="col-md-4 col-lg">
+        <div class="card h-100">
+            <div class="card-body">
+                <div class="text-muted small text-uppercase">Shifts filled</div>
+                <div class="fs-3 fw-bold">@Model.FilledShifts <span class="text-muted fs-6">/ @Model.TotalShifts (@filledPct.ToString("0")%)</span></div>
+                <div class="mt-2">
+                    <span class="badge @PctClass(Model.PeriodFillRates.BuildPct) me-1">Build @Model.PeriodFillRates.BuildPct.ToString("0")%</span>
+                    <span class="badge @PctClass(Model.PeriodFillRates.EventPct) me-1">Event @Model.PeriodFillRates.EventPct.ToString("0")%</span>
+                    <span class="badge @PctClass(Model.PeriodFillRates.StrikePct)">Strike @Model.PeriodFillRates.StrikePct.ToString("0")%</span>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-4 col-lg">
+        <div class="card h-100">
+            <div class="card-body">
+                <div class="text-muted small text-uppercase">Ticket holders</div>
+                <div class="fs-3 fw-bold">@Model.TicketHolderCount</div>
+                <div class="text-muted small">humans who have paid</div>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-4 col-lg">
+        <div class="card h-100 border-primary">
+            <div class="card-body">
+                <div class="text-muted small text-uppercase">Ticket holders engaged</div>
+                <div class="fs-3 fw-bold">@Model.TicketHoldersEngaged <span class="text-muted fs-6">/ @Model.TicketHolderCount (@engagedPct.ToString("0")%)</span></div>
+                <div class="text-muted small">@unreached humans haven't signed up</div>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-4 col-lg">
+        <div class="card h-100">
+            <div class="card-body">
+                <div class="text-muted small text-uppercase">Non-ticket signups</div>
+                <div class="fs-3 fw-bold">@Model.NonTicketSignups</div>
+                <div class="text-muted small">signed up without a ticket (yet)</div>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-4 col-lg">
+        <div class="card h-100 @(Model.StalePendingCount > 0 ? "border-warning" : "")">
+            <div class="card-body">
+                <div class="text-muted small text-uppercase">Stale pending</div>
+                <div class="fs-3 fw-bold">@Model.StalePendingCount</div>
+                <div class="text-muted small">pending &gt; 3 days</div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/Humans.Web/Views/ShiftDashboard/_OverviewCounters.cshtml
+++ b/src/Humans.Web/Views/ShiftDashboard/_OverviewCounters.cshtml
@@ -5,6 +5,11 @@
     static string PctClass(double pct) =>
         pct >= 80 ? "bg-success" : pct >= 60 ? "bg-warning text-dark" : "bg-danger";
 
+    string PctStatusLabel(double pct) =>
+        pct >= 80 ? Localizer["ShiftDash_Status_OnTrack"].Value
+        : pct >= 60 ? Localizer["ShiftDash_Status_AtRisk"].Value
+        : Localizer["ShiftDash_Status_BelowTarget"].Value;
+
     var filledPct = Model.TotalShifts == 0 ? 0 : 100.0 * Model.FilledShifts / Model.TotalShifts;
     var engagedPct = Model.TicketHolderCount == 0 ? 0 : 100.0 * Model.TicketHoldersEngaged / Model.TicketHolderCount;
     var unreached = Math.Max(0, Model.TicketHolderCount - Model.TicketHoldersEngaged);
@@ -21,9 +26,9 @@
                 <div class="text-muted small text-uppercase">@Localizer["ShiftDash_Overview_ShiftsFilled"]</div>
                 <div class="fs-3 fw-bold">@Model.FilledShifts <span class="text-muted fs-6">/ @Model.TotalShifts (@filledPct.ToString("0")%)</span></div>
                 <div class="mt-2">
-                    <span class="badge @PctClass(Model.PeriodFillRates.BuildPct) me-1">@Localizer["Shifts_SetUp"] @Model.PeriodFillRates.BuildPct.ToString("0")%</span>
-                    <span class="badge @PctClass(Model.PeriodFillRates.EventPct) me-1">@Localizer["Shifts_Event"] @Model.PeriodFillRates.EventPct.ToString("0")%</span>
-                    <span class="badge @PctClass(Model.PeriodFillRates.StrikePct)">@Localizer["Shifts_Strike"] @Model.PeriodFillRates.StrikePct.ToString("0")%</span>
+                    <span class="badge @PctClass(Model.PeriodFillRates.BuildPct) me-1">@Localizer["Shifts_SetUp"] @Model.PeriodFillRates.BuildPct.ToString("0")% <span class="visually-hidden">@PctStatusLabel(Model.PeriodFillRates.BuildPct)</span></span>
+                    <span class="badge @PctClass(Model.PeriodFillRates.EventPct) me-1">@Localizer["Shifts_Event"] @Model.PeriodFillRates.EventPct.ToString("0")% <span class="visually-hidden">@PctStatusLabel(Model.PeriodFillRates.EventPct)</span></span>
+                    <span class="badge @PctClass(Model.PeriodFillRates.StrikePct)">@Localizer["Shifts_Strike"] @Model.PeriodFillRates.StrikePct.ToString("0")% <span class="visually-hidden">@PctStatusLabel(Model.PeriodFillRates.StrikePct)</span></span>
                 </div>
             </div>
         </div>

--- a/src/Humans.Web/Views/ShiftDashboard/_OverviewCounters.cshtml
+++ b/src/Humans.Web/Views/ShiftDashboard/_OverviewCounters.cshtml
@@ -14,12 +14,12 @@
     <div class="col-md-4 col-lg">
         <div class="card h-100">
             <div class="card-body">
-                <div class="text-muted small text-uppercase">Shifts filled</div>
+                <div class="text-muted small text-uppercase">@Localizer["ShiftDash_Overview_ShiftsFilled"]</div>
                 <div class="fs-3 fw-bold">@Model.FilledShifts <span class="text-muted fs-6">/ @Model.TotalShifts (@filledPct.ToString("0")%)</span></div>
                 <div class="mt-2">
-                    <span class="badge @PctClass(Model.PeriodFillRates.BuildPct) me-1">Build @Model.PeriodFillRates.BuildPct.ToString("0")%</span>
-                    <span class="badge @PctClass(Model.PeriodFillRates.EventPct) me-1">Event @Model.PeriodFillRates.EventPct.ToString("0")%</span>
-                    <span class="badge @PctClass(Model.PeriodFillRates.StrikePct)">Strike @Model.PeriodFillRates.StrikePct.ToString("0")%</span>
+                    <span class="badge @PctClass(Model.PeriodFillRates.BuildPct) me-1">@Localizer["Shifts_SetUp"] @Model.PeriodFillRates.BuildPct.ToString("0")%</span>
+                    <span class="badge @PctClass(Model.PeriodFillRates.EventPct) me-1">@Localizer["Shifts_Event"] @Model.PeriodFillRates.EventPct.ToString("0")%</span>
+                    <span class="badge @PctClass(Model.PeriodFillRates.StrikePct)">@Localizer["Shifts_Strike"] @Model.PeriodFillRates.StrikePct.ToString("0")%</span>
                 </div>
             </div>
         </div>
@@ -27,36 +27,36 @@
     <div class="col-md-4 col-lg">
         <div class="card h-100">
             <div class="card-body">
-                <div class="text-muted small text-uppercase">Ticket holders</div>
+                <div class="text-muted small text-uppercase">@Localizer["ShiftDash_Overview_TicketHolders"]</div>
                 <div class="fs-3 fw-bold">@Model.TicketHolderCount</div>
-                <div class="text-muted small">humans who have paid</div>
+                <div class="text-muted small">@Localizer["ShiftDash_Overview_TicketHoldersSubline"]</div>
             </div>
         </div>
     </div>
     <div class="col-md-4 col-lg">
         <div class="card h-100 border-primary">
             <div class="card-body">
-                <div class="text-muted small text-uppercase">Ticket holders engaged</div>
+                <div class="text-muted small text-uppercase">@Localizer["ShiftDash_Overview_TicketHoldersEngaged"]</div>
                 <div class="fs-3 fw-bold">@Model.TicketHoldersEngaged <span class="text-muted fs-6">/ @Model.TicketHolderCount (@engagedPct.ToString("0")%)</span></div>
-                <div class="text-muted small">@unreached humans haven't signed up</div>
+                <div class="text-muted small">@string.Format(Localizer["ShiftDash_Overview_EngagedSubline"].Value, unreached)</div>
             </div>
         </div>
     </div>
     <div class="col-md-4 col-lg">
         <div class="card h-100">
             <div class="card-body">
-                <div class="text-muted small text-uppercase">Non-ticket signups</div>
+                <div class="text-muted small text-uppercase">@Localizer["ShiftDash_Overview_NonTicketSignups"]</div>
                 <div class="fs-3 fw-bold">@Model.NonTicketSignups</div>
-                <div class="text-muted small">signed up without a ticket (yet)</div>
+                <div class="text-muted small">@Localizer["ShiftDash_Overview_NonTicketSubline"]</div>
             </div>
         </div>
     </div>
     <div class="col-md-4 col-lg">
         <div class="card h-100 @(Model.StalePendingCount > 0 ? "border-warning" : "")">
             <div class="card-body">
-                <div class="text-muted small text-uppercase">Stale pending</div>
+                <div class="text-muted small text-uppercase">@Localizer["ShiftDash_Overview_StalePending"]</div>
                 <div class="fs-3 fw-bold">@Model.StalePendingCount</div>
-                <div class="text-muted small">pending &gt; 3 days</div>
+                <div class="text-muted small">@Localizer["ShiftDash_Overview_StaleSubline"]</div>
             </div>
         </div>
     </div>

--- a/src/Humans.Web/Views/ShiftDashboard/_OverviewCounters.cshtml
+++ b/src/Humans.Web/Views/ShiftDashboard/_OverviewCounters.cshtml
@@ -8,6 +8,10 @@
     var filledPct = Model.TotalShifts == 0 ? 0 : 100.0 * Model.FilledShifts / Model.TotalShifts;
     var engagedPct = Model.TicketHolderCount == 0 ? 0 : 100.0 * Model.TicketHoldersEngaged / Model.TicketHolderCount;
     var unreached = Math.Max(0, Model.TicketHolderCount - Model.TicketHoldersEngaged);
+
+    // TEMP: ticket figures are not shareable yet. Flip to true once ticket data is publishable.
+    // The underlying DashboardOverview still computes them (see ShiftManagementService).
+    var showTicketData = false;
 }
 
 <div class="row g-3 mb-4">
@@ -28,17 +32,33 @@
         <div class="card h-100">
             <div class="card-body">
                 <div class="text-muted small text-uppercase">@Localizer["ShiftDash_Overview_TicketHolders"]</div>
-                <div class="fs-3 fw-bold">@Model.TicketHolderCount</div>
-                <div class="text-muted small">@Localizer["ShiftDash_Overview_TicketHoldersSubline"]</div>
+                @if (showTicketData)
+                {
+                    <div class="fs-3 fw-bold">@Model.TicketHolderCount</div>
+                    <div class="text-muted small">@Localizer["ShiftDash_Overview_TicketHoldersSubline"]</div>
+                }
+                else
+                {
+                    <div class="fs-3 fw-bold text-muted">@Localizer["Common_NotAvailable"]</div>
+                    <div class="text-muted small">@Localizer["ShiftDash_Overview_TicketData_Hidden"]</div>
+                }
             </div>
         </div>
     </div>
     <div class="col-md-4 col-lg">
-        <div class="card h-100 border-primary">
+        <div class="card h-100 @(showTicketData ? "border-primary" : "")">
             <div class="card-body">
                 <div class="text-muted small text-uppercase">@Localizer["ShiftDash_Overview_TicketHoldersEngaged"]</div>
-                <div class="fs-3 fw-bold">@Model.TicketHoldersEngaged <span class="text-muted fs-6">/ @Model.TicketHolderCount (@engagedPct.ToString("0")%)</span></div>
-                <div class="text-muted small">@string.Format(Localizer["ShiftDash_Overview_EngagedSubline"].Value, unreached)</div>
+                @if (showTicketData)
+                {
+                    <div class="fs-3 fw-bold">@Model.TicketHoldersEngaged <span class="text-muted fs-6">/ @Model.TicketHolderCount (@engagedPct.ToString("0")%)</span></div>
+                    <div class="text-muted small">@string.Format(Localizer["ShiftDash_Overview_EngagedSubline"].Value, unreached)</div>
+                }
+                else
+                {
+                    <div class="fs-3 fw-bold text-muted">@Localizer["Common_NotAvailable"]</div>
+                    <div class="text-muted small">@Localizer["ShiftDash_Overview_TicketData_Hidden"]</div>
+                }
             </div>
         </div>
     </div>
@@ -46,8 +66,16 @@
         <div class="card h-100">
             <div class="card-body">
                 <div class="text-muted small text-uppercase">@Localizer["ShiftDash_Overview_NonTicketSignups"]</div>
-                <div class="fs-3 fw-bold">@Model.NonTicketSignups</div>
-                <div class="text-muted small">@Localizer["ShiftDash_Overview_NonTicketSubline"]</div>
+                @if (showTicketData)
+                {
+                    <div class="fs-3 fw-bold">@Model.NonTicketSignups</div>
+                    <div class="text-muted small">@Localizer["ShiftDash_Overview_NonTicketSubline"]</div>
+                }
+                else
+                {
+                    <div class="fs-3 fw-bold text-muted">@Localizer["Common_NotAvailable"]</div>
+                    <div class="text-muted small">@Localizer["ShiftDash_Overview_TicketData_Hidden"]</div>
+                }
             </div>
         </div>
     </div>

--- a/src/Humans.Web/Views/ShiftDashboard/_TrendsChart.cshtml
+++ b/src/Humans.Web/Views/ShiftDashboard/_TrendsChart.cshtml
@@ -21,10 +21,10 @@
 
     string Label(TrendWindow w) => w switch
     {
-        TrendWindow.Last7Days => "7d",
-        TrendWindow.Last30Days => "30d",
-        TrendWindow.Last90Days => "90d",
-        TrendWindow.All => "All",
+        TrendWindow.Last7Days => Localizer["ShiftDash_Trends_Window_7d"].Value,
+        TrendWindow.Last30Days => Localizer["ShiftDash_Trends_Window_30d"].Value,
+        TrendWindow.Last90Days => Localizer["ShiftDash_Trends_Window_90d"].Value,
+        TrendWindow.All => Localizer["ShiftDash_Trends_Window_All"].Value,
         _ => w.ToString(),
     };
 
@@ -50,7 +50,7 @@
         </div>
     </div>
     <div class="card-body">
-        <canvas id="dashboardTrendsChart" height="90"></canvas>
+        <canvas id="dashboardTrendsChart" height="90" role="img" aria-label="@Localizer["ShiftDash_Trends_Title"]"></canvas>
     </div>
 </div>
 

--- a/src/Humans.Web/Views/ShiftDashboard/_TrendsChart.cshtml
+++ b/src/Humans.Web/Views/ShiftDashboard/_TrendsChart.cshtml
@@ -7,7 +7,7 @@
 
 @{
     var points = Model.Points;
-    var window = Model.Window;
+    var initialWindow = Model.Window;
     var period = Model.Period;
 
     var labelPattern = LocalDatePattern.Iso;
@@ -17,14 +17,14 @@
     var logins = points.Select(p => p.DistinctLogins).ToArray();
 
     string ButtonClass(TrendWindow w) =>
-        w == window ? "btn btn-primary active" : "btn btn-outline-secondary";
+        w == initialWindow ? "btn btn-primary active" : "btn btn-outline-secondary";
 
     string Label(TrendWindow w) => w switch
     {
-        TrendWindow.Last7Days => Localizer["ShiftDash_Trends_Window_7d"].Value,
-        TrendWindow.Last30Days => Localizer["ShiftDash_Trends_Window_30d"].Value,
-        TrendWindow.Last90Days => Localizer["ShiftDash_Trends_Window_90d"].Value,
-        TrendWindow.All => Localizer["ShiftDash_Trends_Window_All"].Value,
+        TrendWindow.Last7Days => "7d",
+        TrendWindow.Last30Days => "30d",
+        TrendWindow.Last90Days => "90d",
+        TrendWindow.All => "All",
         _ => w.ToString(),
     };
 
@@ -37,10 +37,11 @@
 <div class="card mb-4">
     <div class="card-header d-flex justify-content-between align-items-center">
         <strong>@Localizer["ShiftDash_Trends_Title"]</strong>
-        <div class="btn-group btn-group-sm" role="group">
+        <div class="btn-group btn-group-sm" role="group" id="dashboardTrendsWindow">
             @foreach (var w in new[] { TrendWindow.Last7Days, TrendWindow.Last30Days, TrendWindow.Last90Days, TrendWindow.All })
             {
-                <a asp-action="Index" asp-route-trendWindow="@w" asp-route-period="@period" class="@ButtonClass(w)">@Label(w)</a>
+                <a asp-action="Index" asp-route-trendWindow="@w" asp-route-period="@period"
+                   class="@ButtonClass(w)" data-trends-window="@w">@Label(w)</a>
             }
         </div>
     </div>
@@ -51,26 +52,53 @@
 
 <script>
 (function () {
-    var labels = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(labels));
-    var signups = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(signups));
-    var tickets = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(tickets));
-    var logins = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(logins));
+    var allLabels = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(labels));
+    var allSignups = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(signups));
+    var allTickets = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(tickets));
+    var allLogins = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(logins));
     var newSignupsLabel = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(newSignupsLabel));
     var newTicketsLabel = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(newTicketsLabel));
     var dauLabel = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(dauLabel));
     var dauNote = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(dauNote));
+    var initialWindow = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(initialWindow.ToString()));
 
-    function renderDashboardTrendsChart() {
+    var chartInstance = null;
+
+    function sliceForWindow(win) {
+        var n;
+        if (win === 'Last7Days') n = 7;
+        else if (win === 'Last30Days') n = 30;
+        else if (win === 'Last90Days') n = 90;
+        else n = allLabels.length;
+        var start = Math.max(0, allLabels.length - n);
+        return {
+            labels: allLabels.slice(start),
+            signups: allSignups.slice(start),
+            tickets: allTickets.slice(start),
+            logins: allLogins.slice(start)
+        };
+    }
+
+    function renderChart(win) {
         var ctx = document.getElementById('dashboardTrendsChart');
         if (!ctx || typeof Chart === 'undefined') return;
-        new Chart(ctx, {
+        var sliced = sliceForWindow(win);
+        if (chartInstance) {
+            chartInstance.data.labels = sliced.labels;
+            chartInstance.data.datasets[0].data = sliced.signups;
+            chartInstance.data.datasets[1].data = sliced.tickets;
+            chartInstance.data.datasets[2].data = sliced.logins;
+            chartInstance.update();
+            return;
+        }
+        chartInstance = new Chart(ctx, {
             type: 'line',
             data: {
-                labels: labels,
+                labels: sliced.labels,
                 datasets: [
-                    { label: newSignupsLabel, data: signups, borderColor: '#0d6efd', backgroundColor: 'rgba(13,110,253,0.1)', tension: 0.25 },
-                    { label: newTicketsLabel, data: tickets, borderColor: '#198754', backgroundColor: 'rgba(25,135,84,0.1)', tension: 0.25 },
-                    { label: dauLabel, data: logins, borderColor: '#6c757d', backgroundColor: 'rgba(108,117,125,0.1)', tension: 0.25, borderDash: [4, 4] }
+                    { label: newSignupsLabel, data: sliced.signups, borderColor: '#0d6efd', backgroundColor: 'rgba(13,110,253,0.1)', tension: 0.25 },
+                    { label: newTicketsLabel, data: sliced.tickets, borderColor: '#198754', backgroundColor: 'rgba(25,135,84,0.1)', tension: 0.25 },
+                    { label: dauLabel, data: sliced.logins, borderColor: '#6c757d', backgroundColor: 'rgba(108,117,125,0.1)', tension: 0.25, borderDash: [4, 4] }
                 ]
             },
             options: {
@@ -81,9 +109,7 @@
                     tooltip: {
                         callbacks: {
                             afterLabel: function (c) {
-                                if (c.dataset.label === dauLabel) {
-                                    return dauNote;
-                                }
+                                if (c.dataset.label === dauLabel) return dauNote;
                                 return null;
                             }
                         }
@@ -96,26 +122,53 @@
         });
     }
 
+    function wireButtons() {
+        var group = document.getElementById('dashboardTrendsWindow');
+        if (!group) return;
+        var buttons = group.querySelectorAll('[data-trends-window]');
+        buttons.forEach(function (btn) {
+            btn.addEventListener('click', function (e) {
+                e.preventDefault();
+                var win = btn.getAttribute('data-trends-window');
+                buttons.forEach(function (b) {
+                    b.classList.remove('btn-primary', 'active');
+                    b.classList.add('btn-outline-secondary');
+                });
+                btn.classList.remove('btn-outline-secondary');
+                btn.classList.add('btn-primary', 'active');
+                renderChart(win);
+                try {
+                    var url = new URL(window.location.href);
+                    url.searchParams.set('trendWindow', win);
+                    history.replaceState({}, '', url.toString());
+                } catch (_) { /* ignore */ }
+            });
+        });
+    }
+
+    function bootstrap() {
+        wireButtons();
+        renderChart(initialWindow);
+    }
+
     if (typeof Chart === 'undefined') {
-        // Chart.js may already be getting loaded by sibling partials.
-        // Poll briefly, otherwise inject our own script tag.
         var tries = 0;
         var iv = setInterval(function () {
             if (typeof Chart !== 'undefined') {
                 clearInterval(iv);
-                renderDashboardTrendsChart();
+                bootstrap();
             } else if (++tries > 50) {
                 clearInterval(iv);
                 var s = document.createElement('script');
                 s.src = 'https://cdn.jsdelivr.net/npm/chart.js@4.5.1/dist/chart.umd.min.js';
                 s.integrity = 'sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ';
                 s.crossOrigin = 'anonymous';
-                s.onload = renderDashboardTrendsChart;
+                s.onload = bootstrap;
                 document.head.appendChild(s);
             }
         }, 100);
     } else {
-        renderDashboardTrendsChart();
+        bootstrap();
     }
 })();
 </script>

--- a/src/Humans.Web/Views/ShiftDashboard/_TrendsChart.cshtml
+++ b/src/Humans.Web/Views/ShiftDashboard/_TrendsChart.cshtml
@@ -32,6 +32,10 @@
     var newTicketsLabel = Localizer["ShiftDash_Trends_NewTicketSales"].Value;
     var dauLabel = Localizer["ShiftDash_Trends_DAU"].Value;
     var dauNote = Localizer["ShiftDash_Trends_DAUNote"].Value;
+
+    // TEMP: ticket figures are not shareable yet. Flip to true once ticket data is publishable.
+    // The underlying trend series still computes new-ticket-sales in ShiftManagementService.
+    var showTicketData = false;
 }
 
 <div class="card mb-4">
@@ -61,6 +65,7 @@
     var dauLabel = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(dauLabel));
     var dauNote = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(dauNote));
     var initialWindow = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(initialWindow.ToString()));
+    var showTicketData = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(showTicketData));
 
     var chartInstance = null;
 
@@ -86,20 +91,28 @@
         if (chartInstance) {
             chartInstance.data.labels = sliced.labels;
             chartInstance.data.datasets[0].data = sliced.signups;
-            chartInstance.data.datasets[1].data = sliced.tickets;
-            chartInstance.data.datasets[2].data = sliced.logins;
+            if (showTicketData) {
+                chartInstance.data.datasets[1].data = sliced.tickets;
+                chartInstance.data.datasets[2].data = sliced.logins;
+            } else {
+                chartInstance.data.datasets[1].data = sliced.logins;
+            }
             chartInstance.update();
             return;
+        }
+        var datasets = [
+            { label: newSignupsLabel, data: sliced.signups, borderColor: '#0d6efd', backgroundColor: 'rgba(13,110,253,0.1)', tension: 0.25 },
+            { label: dauLabel, data: sliced.logins, borderColor: '#6c757d', backgroundColor: 'rgba(108,117,125,0.1)', tension: 0.25, borderDash: [4, 4] }
+        ];
+        if (showTicketData) {
+            // Keep the tickets series wiring in place for when ticket data is shareable again.
+            datasets.splice(1, 0, { label: newTicketsLabel, data: sliced.tickets, borderColor: '#198754', backgroundColor: 'rgba(25,135,84,0.1)', tension: 0.25 });
         }
         chartInstance = new Chart(ctx, {
             type: 'line',
             data: {
                 labels: sliced.labels,
-                datasets: [
-                    { label: newSignupsLabel, data: sliced.signups, borderColor: '#0d6efd', backgroundColor: 'rgba(13,110,253,0.1)', tension: 0.25 },
-                    { label: newTicketsLabel, data: sliced.tickets, borderColor: '#198754', backgroundColor: 'rgba(25,135,84,0.1)', tension: 0.25 },
-                    { label: dauLabel, data: sliced.logins, borderColor: '#6c757d', backgroundColor: 'rgba(108,117,125,0.1)', tension: 0.25, borderDash: [4, 4] }
-                ]
+                datasets: datasets
             },
             options: {
                 responsive: true,

--- a/src/Humans.Web/Views/ShiftDashboard/_TrendsChart.cshtml
+++ b/src/Humans.Web/Views/ShiftDashboard/_TrendsChart.cshtml
@@ -1,12 +1,14 @@
 @using Humans.Application.DTOs
 @using Humans.Application.Enums
+@using Humans.Domain.Enums
 @using NodaTime
 @using NodaTime.Text
-@model (IReadOnlyList<DashboardTrendPoint> Points, TrendWindow Window)
+@model (IReadOnlyList<DashboardTrendPoint> Points, TrendWindow Window, ShiftPeriod? Period)
 
 @{
     var points = Model.Points;
     var window = Model.Window;
+    var period = Model.Period;
 
     var labelPattern = LocalDatePattern.Iso;
     var labels = points.Select(p => labelPattern.Format(p.Date)).ToArray();
@@ -38,7 +40,7 @@
         <div class="btn-group btn-group-sm" role="group">
             @foreach (var w in new[] { TrendWindow.Last7Days, TrendWindow.Last30Days, TrendWindow.Last90Days, TrendWindow.All })
             {
-                <a asp-action="Index" asp-route-trendWindow="@w" class="@ButtonClass(w)">@Label(w)</a>
+                <a asp-action="Index" asp-route-trendWindow="@w" asp-route-period="@period" class="@ButtonClass(w)">@Label(w)</a>
             }
         </div>
     </div>

--- a/src/Humans.Web/Views/ShiftDashboard/_TrendsChart.cshtml
+++ b/src/Humans.Web/Views/ShiftDashboard/_TrendsChart.cshtml
@@ -44,44 +44,67 @@
 
 <script>
 (function () {
-    const labels = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(labels));
-    const signups = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(signups));
-    const tickets = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(tickets));
-    const logins = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(logins));
+    var labels = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(labels));
+    var signups = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(signups));
+    var tickets = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(tickets));
+    var logins = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(logins));
 
-    const ctx = document.getElementById('dashboardTrendsChart');
-    if (!ctx || typeof Chart === 'undefined') return;
-
-    new Chart(ctx, {
-        type: 'line',
-        data: {
-            labels,
-            datasets: [
-                { label: 'New signups', data: signups, borderColor: '#0d6efd', backgroundColor: 'rgba(13,110,253,0.1)', tension: 0.25 },
-                { label: 'New ticket sales', data: tickets, borderColor: '#198754', backgroundColor: 'rgba(25,135,84,0.1)', tension: 0.25 },
-                { label: 'Distinct logins (DAU)', data: logins, borderColor: '#6c757d', backgroundColor: 'rgba(108,117,125,0.1)', tension: 0.25, borderDash: [4, 4] },
-            ]
-        },
-        options: {
-            responsive: true,
-            interaction: { mode: 'index', intersect: false },
-            plugins: {
-                legend: { position: 'bottom' },
-                tooltip: {
-                    callbacks: {
-                        afterLabel: function (ctx) {
-                            if (ctx.dataset.label === 'Distinct logins (DAU)') {
-                                return 'Only last login per human is stored — older buckets undercount.';
+    function renderDashboardTrendsChart() {
+        var ctx = document.getElementById('dashboardTrendsChart');
+        if (!ctx || typeof Chart === 'undefined') return;
+        new Chart(ctx, {
+            type: 'line',
+            data: {
+                labels: labels,
+                datasets: [
+                    { label: 'New signups', data: signups, borderColor: '#0d6efd', backgroundColor: 'rgba(13,110,253,0.1)', tension: 0.25 },
+                    { label: 'New ticket sales', data: tickets, borderColor: '#198754', backgroundColor: 'rgba(25,135,84,0.1)', tension: 0.25 },
+                    { label: 'Distinct logins (DAU)', data: logins, borderColor: '#6c757d', backgroundColor: 'rgba(108,117,125,0.1)', tension: 0.25, borderDash: [4, 4] }
+                ]
+            },
+            options: {
+                responsive: true,
+                interaction: { mode: 'index', intersect: false },
+                plugins: {
+                    legend: { position: 'bottom' },
+                    tooltip: {
+                        callbacks: {
+                            afterLabel: function (c) {
+                                if (c.dataset.label === 'Distinct logins (DAU)') {
+                                    return 'Only last login per human is stored — older buckets undercount.';
+                                }
+                                return null;
                             }
-                            return null;
                         }
                     }
+                },
+                scales: {
+                    y: { beginAtZero: true, ticks: { precision: 0 } }
                 }
-            },
-            scales: {
-                y: { beginAtZero: true, ticks: { precision: 0 } }
             }
-        }
-    });
+        });
+    }
+
+    if (typeof Chart === 'undefined') {
+        // Chart.js may already be getting loaded by sibling partials.
+        // Poll briefly, otherwise inject our own script tag.
+        var tries = 0;
+        var iv = setInterval(function () {
+            if (typeof Chart !== 'undefined') {
+                clearInterval(iv);
+                renderDashboardTrendsChart();
+            } else if (++tries > 50) {
+                clearInterval(iv);
+                var s = document.createElement('script');
+                s.src = 'https://cdn.jsdelivr.net/npm/chart.js@4.5.1/dist/chart.umd.min.js';
+                s.integrity = 'sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ';
+                s.crossOrigin = 'anonymous';
+                s.onload = renderDashboardTrendsChart;
+                document.head.appendChild(s);
+            }
+        }, 100);
+    } else {
+        renderDashboardTrendsChart();
+    }
 })();
 </script>

--- a/src/Humans.Web/Views/ShiftDashboard/_TrendsChart.cshtml
+++ b/src/Humans.Web/Views/ShiftDashboard/_TrendsChart.cshtml
@@ -19,17 +19,22 @@
 
     string Label(TrendWindow w) => w switch
     {
-        TrendWindow.Last7Days => "7d",
-        TrendWindow.Last30Days => "30d",
-        TrendWindow.Last90Days => "90d",
-        TrendWindow.All => "All",
+        TrendWindow.Last7Days => Localizer["ShiftDash_Trends_Window_7d"].Value,
+        TrendWindow.Last30Days => Localizer["ShiftDash_Trends_Window_30d"].Value,
+        TrendWindow.Last90Days => Localizer["ShiftDash_Trends_Window_90d"].Value,
+        TrendWindow.All => Localizer["ShiftDash_Trends_Window_All"].Value,
         _ => w.ToString(),
     };
+
+    var newSignupsLabel = Localizer["ShiftDash_Trends_NewSignups"].Value;
+    var newTicketsLabel = Localizer["ShiftDash_Trends_NewTicketSales"].Value;
+    var dauLabel = Localizer["ShiftDash_Trends_DAU"].Value;
+    var dauNote = Localizer["ShiftDash_Trends_DAUNote"].Value;
 }
 
 <div class="card mb-4">
     <div class="card-header d-flex justify-content-between align-items-center">
-        <strong>Trends</strong>
+        <strong>@Localizer["ShiftDash_Trends_Title"]</strong>
         <div class="btn-group btn-group-sm" role="group">
             @foreach (var w in new[] { TrendWindow.Last7Days, TrendWindow.Last30Days, TrendWindow.Last90Days, TrendWindow.All })
             {
@@ -48,6 +53,10 @@
     var signups = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(signups));
     var tickets = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(tickets));
     var logins = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(logins));
+    var newSignupsLabel = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(newSignupsLabel));
+    var newTicketsLabel = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(newTicketsLabel));
+    var dauLabel = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(dauLabel));
+    var dauNote = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(dauNote));
 
     function renderDashboardTrendsChart() {
         var ctx = document.getElementById('dashboardTrendsChart');
@@ -57,9 +66,9 @@
             data: {
                 labels: labels,
                 datasets: [
-                    { label: 'New signups', data: signups, borderColor: '#0d6efd', backgroundColor: 'rgba(13,110,253,0.1)', tension: 0.25 },
-                    { label: 'New ticket sales', data: tickets, borderColor: '#198754', backgroundColor: 'rgba(25,135,84,0.1)', tension: 0.25 },
-                    { label: 'Distinct logins (DAU)', data: logins, borderColor: '#6c757d', backgroundColor: 'rgba(108,117,125,0.1)', tension: 0.25, borderDash: [4, 4] }
+                    { label: newSignupsLabel, data: signups, borderColor: '#0d6efd', backgroundColor: 'rgba(13,110,253,0.1)', tension: 0.25 },
+                    { label: newTicketsLabel, data: tickets, borderColor: '#198754', backgroundColor: 'rgba(25,135,84,0.1)', tension: 0.25 },
+                    { label: dauLabel, data: logins, borderColor: '#6c757d', backgroundColor: 'rgba(108,117,125,0.1)', tension: 0.25, borderDash: [4, 4] }
                 ]
             },
             options: {
@@ -70,8 +79,8 @@
                     tooltip: {
                         callbacks: {
                             afterLabel: function (c) {
-                                if (c.dataset.label === 'Distinct logins (DAU)') {
-                                    return 'Only last login per human is stored — older buckets undercount.';
+                                if (c.dataset.label === dauLabel) {
+                                    return dauNote;
                                 }
                                 return null;
                             }

--- a/src/Humans.Web/Views/ShiftDashboard/_TrendsChart.cshtml
+++ b/src/Humans.Web/Views/ShiftDashboard/_TrendsChart.cshtml
@@ -1,0 +1,87 @@
+@using Humans.Application.DTOs
+@using Humans.Application.Enums
+@using NodaTime
+@using NodaTime.Text
+@model (IReadOnlyList<DashboardTrendPoint> Points, TrendWindow Window)
+
+@{
+    var points = Model.Points;
+    var window = Model.Window;
+
+    var labelPattern = LocalDatePattern.Iso;
+    var labels = points.Select(p => labelPattern.Format(p.Date)).ToArray();
+    var signups = points.Select(p => p.NewSignups).ToArray();
+    var tickets = points.Select(p => p.NewTicketSales).ToArray();
+    var logins = points.Select(p => p.DistinctLogins).ToArray();
+
+    string ButtonClass(TrendWindow w) =>
+        w == window ? "btn btn-primary active" : "btn btn-outline-secondary";
+
+    string Label(TrendWindow w) => w switch
+    {
+        TrendWindow.Last7Days => "7d",
+        TrendWindow.Last30Days => "30d",
+        TrendWindow.Last90Days => "90d",
+        TrendWindow.All => "All",
+        _ => w.ToString(),
+    };
+}
+
+<div class="card mb-4">
+    <div class="card-header d-flex justify-content-between align-items-center">
+        <strong>Trends</strong>
+        <div class="btn-group btn-group-sm" role="group">
+            @foreach (var w in new[] { TrendWindow.Last7Days, TrendWindow.Last30Days, TrendWindow.Last90Days, TrendWindow.All })
+            {
+                <a asp-action="Index" asp-route-trendWindow="@w" class="@ButtonClass(w)">@Label(w)</a>
+            }
+        </div>
+    </div>
+    <div class="card-body">
+        <canvas id="dashboardTrendsChart" height="90"></canvas>
+    </div>
+</div>
+
+<script>
+(function () {
+    const labels = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(labels));
+    const signups = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(signups));
+    const tickets = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(tickets));
+    const logins = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(logins));
+
+    const ctx = document.getElementById('dashboardTrendsChart');
+    if (!ctx || typeof Chart === 'undefined') return;
+
+    new Chart(ctx, {
+        type: 'line',
+        data: {
+            labels,
+            datasets: [
+                { label: 'New signups', data: signups, borderColor: '#0d6efd', backgroundColor: 'rgba(13,110,253,0.1)', tension: 0.25 },
+                { label: 'New ticket sales', data: tickets, borderColor: '#198754', backgroundColor: 'rgba(25,135,84,0.1)', tension: 0.25 },
+                { label: 'Distinct logins (DAU)', data: logins, borderColor: '#6c757d', backgroundColor: 'rgba(108,117,125,0.1)', tension: 0.25, borderDash: [4, 4] },
+            ]
+        },
+        options: {
+            responsive: true,
+            interaction: { mode: 'index', intersect: false },
+            plugins: {
+                legend: { position: 'bottom' },
+                tooltip: {
+                    callbacks: {
+                        afterLabel: function (ctx) {
+                            if (ctx.dataset.label === 'Distinct logins (DAU)') {
+                                return 'Only last login per human is stored — older buckets undercount.';
+                            }
+                            return null;
+                        }
+                    }
+                }
+            },
+            scales: {
+                y: { beginAtZero: true, ticks: { precision: 0 } }
+            }
+        }
+    });
+})();
+</script>

--- a/tests/Humans.Application.Tests/Services/ShiftDashboardMetricsTests.cs
+++ b/tests/Humans.Application.Tests/Services/ShiftDashboardMetricsTests.cs
@@ -1,0 +1,557 @@
+using AwesomeAssertions;
+using Humans.Application.Enums;
+using Humans.Application.Interfaces;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using Humans.Infrastructure.Data;
+using Humans.Infrastructure.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging.Abstractions;
+using NodaTime;
+using NodaTime.Testing;
+using NSubstitute;
+using Xunit;
+
+namespace Humans.Application.Tests.Services;
+
+public class ShiftDashboardMetricsTests : IDisposable
+{
+    private static readonly Instant TestNow = Instant.FromUtc(2026, 7, 1, 12, 0);
+
+    private readonly HumansDbContext _dbContext;
+    private readonly ShiftManagementService _service;
+    private readonly FakeClock _clock = new(TestNow);
+
+    public ShiftDashboardMetricsTests()
+    {
+        var options = new DbContextOptionsBuilder<HumansDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        _dbContext = new HumansDbContext(options);
+
+        var serviceProvider = Substitute.For<IServiceProvider>();
+        serviceProvider.GetService(typeof(ITeamService)).Returns(Substitute.For<ITeamService>());
+
+        _service = new ShiftManagementService(
+            _dbContext,
+            Substitute.For<IAuditLogService>(),
+            Substitute.For<IRoleAssignmentService>(),
+            serviceProvider,
+            new MemoryCache(new MemoryCacheOptions()),
+            _clock,
+            NullLogger<ShiftManagementService>.Instance);
+    }
+
+    public void Dispose()
+    {
+        _dbContext.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public async Task GetDashboardOverview_EmptyDatabase_ReturnsZeroCounters()
+    {
+        var es = await SeedEventAsync();
+
+        var result = await _service.GetDashboardOverviewAsync(es.Id);
+
+        result.TotalShifts.Should().Be(0);
+        result.FilledShifts.Should().Be(0);
+        result.TicketHolderCount.Should().Be(0);
+        result.TicketHoldersEngaged.Should().Be(0);
+        result.NonTicketSignups.Should().Be(0);
+        result.StalePendingCount.Should().Be(0);
+        result.Departments.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetDashboardOverview_MinVolunteersMinusOne_NotFilled()
+    {
+        var es = await SeedEventAsync();
+        var team = await SeedTeamAsync("Gate");
+        var rota = await SeedRotaAsync(team, es, RotaPeriod.Event);
+        var shift = await SeedShiftAsync(rota, dayOffset: 2, min: 3, max: 5);
+        await SeedSignupsAsync(shift, SignupStatus.Confirmed, count: 2);
+
+        var result = await _service.GetDashboardOverviewAsync(es.Id);
+
+        result.TotalShifts.Should().Be(1);
+        result.FilledShifts.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task GetDashboardOverview_MinVolunteersExactly_Filled()
+    {
+        var es = await SeedEventAsync();
+        var team = await SeedTeamAsync("Gate");
+        var rota = await SeedRotaAsync(team, es, RotaPeriod.Event);
+        var shift = await SeedShiftAsync(rota, dayOffset: 2, min: 3, max: 5);
+        await SeedSignupsAsync(shift, SignupStatus.Confirmed, count: 3);
+
+        var result = await _service.GetDashboardOverviewAsync(es.Id);
+
+        result.FilledShifts.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task GetDashboardOverview_PendingSignupsDoNotCountAsFilled()
+    {
+        var es = await SeedEventAsync();
+        var team = await SeedTeamAsync("Gate");
+        var rota = await SeedRotaAsync(team, es, RotaPeriod.Event);
+        var shift = await SeedShiftAsync(rota, dayOffset: 2, min: 2, max: 5);
+        await SeedSignupsAsync(shift, SignupStatus.Pending, count: 5);
+
+        var result = await _service.GetDashboardOverviewAsync(es.Id);
+
+        result.FilledShifts.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task GetDashboardOverview_AdminOnlyAndHiddenRotaShiftsExcluded()
+    {
+        var es = await SeedEventAsync();
+        var team = await SeedTeamAsync("Gate");
+        var visibleRota = await SeedRotaAsync(team, es, RotaPeriod.Event);
+        var hiddenRota = await SeedRotaAsync(team, es, RotaPeriod.Event, isVisible: false);
+        await SeedShiftAsync(visibleRota, dayOffset: 2, min: 2, max: 5);
+        await SeedShiftAsync(visibleRota, dayOffset: 3, min: 2, max: 5, adminOnly: true);
+        await SeedShiftAsync(hiddenRota, dayOffset: 4, min: 2, max: 5);
+
+        var result = await _service.GetDashboardOverviewAsync(es.Id);
+
+        result.TotalShifts.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task GetDashboardOverview_TicketHolderAndEngagementCounters()
+    {
+        var es = await SeedEventAsync();
+        var team = await SeedTeamAsync("Gate");
+        var rota = await SeedRotaAsync(team, es, RotaPeriod.Event);
+        var shift = await SeedShiftAsync(rota, dayOffset: 2, min: 1, max: 5);
+
+        var engagedTicketHolder = await SeedUserAsync("A");
+        var disengagedTicketHolder = await SeedUserAsync("B");
+        var refundedUser = await SeedUserAsync("C");
+        var nonTicketSignupUser = await SeedUserAsync("D");
+        var cancelledOnlyTicketHolder = await SeedUserAsync("E");
+
+        await SeedTicketOrderAsync(engagedTicketHolder.Id, TicketPaymentStatus.Paid);
+        await SeedTicketOrderAsync(engagedTicketHolder.Id, TicketPaymentStatus.Paid); // duplicate — counts once
+        await SeedTicketOrderAsync(disengagedTicketHolder.Id, TicketPaymentStatus.Paid);
+        await SeedTicketOrderAsync(refundedUser.Id, TicketPaymentStatus.Refunded);
+        await SeedTicketOrderAsync(cancelledOnlyTicketHolder.Id, TicketPaymentStatus.Paid);
+
+        await SeedOneSignupAsync(shift, engagedTicketHolder.Id, SignupStatus.Confirmed);
+        await SeedOneSignupAsync(shift, nonTicketSignupUser.Id, SignupStatus.Pending);
+        await SeedOneSignupAsync(shift, cancelledOnlyTicketHolder.Id, SignupStatus.Cancelled);
+
+        var result = await _service.GetDashboardOverviewAsync(es.Id);
+
+        result.TicketHolderCount.Should().Be(3); // engaged, disengaged, cancelled-only
+        result.TicketHoldersEngaged.Should().Be(1); // only A
+        result.NonTicketSignups.Should().Be(1); // only D
+    }
+
+    [Fact]
+    public async Task GetDashboardOverview_StalePending_ThresholdExact3Days_NotStale()
+    {
+        var es = await SeedEventAsync();
+        var team = await SeedTeamAsync("Gate");
+        var rota = await SeedRotaAsync(team, es, RotaPeriod.Event);
+        var shift = await SeedShiftAsync(rota, dayOffset: 2, min: 1, max: 5);
+        var user = await SeedUserAsync("U");
+
+        var signup = new ShiftSignup
+        {
+            Id = Guid.NewGuid(),
+            ShiftId = shift.Id,
+            UserId = user.Id,
+            Status = SignupStatus.Pending,
+            CreatedAt = TestNow.Minus(Duration.FromDays(3)),
+            UpdatedAt = TestNow,
+        };
+        _dbContext.ShiftSignups.Add(signup);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _service.GetDashboardOverviewAsync(es.Id);
+
+        result.StalePendingCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task GetDashboardOverview_StalePending_JustPastThreshold_CountsAsStale()
+    {
+        var es = await SeedEventAsync();
+        var team = await SeedTeamAsync("Gate");
+        var rota = await SeedRotaAsync(team, es, RotaPeriod.Event);
+        var shift = await SeedShiftAsync(rota, dayOffset: 2, min: 1, max: 5);
+        var user = await SeedUserAsync("U");
+
+        var signup = new ShiftSignup
+        {
+            Id = Guid.NewGuid(),
+            ShiftId = shift.Id,
+            UserId = user.Id,
+            Status = SignupStatus.Pending,
+            CreatedAt = TestNow.Minus(Duration.FromDays(3)).Minus(Duration.FromMinutes(1)),
+            UpdatedAt = TestNow,
+        };
+        _dbContext.ShiftSignups.Add(signup);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _service.GetDashboardOverviewAsync(es.Id);
+
+        result.StalePendingCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task GetDashboardOverview_NoSubteamRotas_DepartmentSubgroupsEmpty()
+    {
+        var es = await SeedEventAsync();
+        var gate = await SeedTeamAsync("Gate");
+        var rota = await SeedRotaAsync(gate, es, RotaPeriod.Event);
+        await SeedShiftAsync(rota, dayOffset: 2, min: 1, max: 5);
+
+        var result = await _service.GetDashboardOverviewAsync(es.Id);
+
+        result.Departments.Should().HaveCount(1);
+        result.Departments[0].Subgroups.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetDashboardOverview_WithSubteamRotas_ProducesSubgroupsWithDirectPinned()
+    {
+        var es = await SeedEventAsync();
+        var infra = await SeedTeamAsync("Infrastructure");
+        var power = await SeedTeamAsync("Power", parentId: infra.Id);
+        var plumbing = await SeedTeamAsync("Plumbing", parentId: infra.Id);
+
+        var infraDirect = await SeedRotaAsync(infra, es, RotaPeriod.Event);
+        var powerRota = await SeedRotaAsync(power, es, RotaPeriod.Event);
+        var plumbingRota = await SeedRotaAsync(plumbing, es, RotaPeriod.Event);
+
+        // Infrastructure direct: 2 shifts, 1 filled.
+        var d1 = await SeedShiftAsync(infraDirect, dayOffset: 1, min: 1, max: 3);
+        var d2 = await SeedShiftAsync(infraDirect, dayOffset: 2, min: 1, max: 3);
+        await SeedSignupsAsync(d1, SignupStatus.Confirmed, count: 1);
+
+        // Power: 2 shifts, both filled (high fill %).
+        var p1 = await SeedShiftAsync(powerRota, dayOffset: 1, min: 1, max: 3);
+        var p2 = await SeedShiftAsync(powerRota, dayOffset: 2, min: 1, max: 3);
+        await SeedSignupsAsync(p1, SignupStatus.Confirmed, count: 2);
+        await SeedSignupsAsync(p2, SignupStatus.Confirmed, count: 2);
+
+        // Plumbing: 2 shifts, 0 filled (lowest fill %).
+        await SeedShiftAsync(plumbingRota, dayOffset: 1, min: 1, max: 3);
+        await SeedShiftAsync(plumbingRota, dayOffset: 2, min: 1, max: 3);
+
+        var result = await _service.GetDashboardOverviewAsync(es.Id);
+
+        var infraRow = result.Departments.Single(d => string.Equals(d.DepartmentName, "Infrastructure", StringComparison.Ordinal));
+        infraRow.TotalShifts.Should().Be(6);
+        infraRow.FilledShifts.Should().Be(3); // 1 direct + 2 power
+        infraRow.Subgroups.Should().HaveCount(3);
+
+        // "Direct" pinned first regardless of fill %.
+        infraRow.Subgroups[0].IsDirect.Should().BeTrue();
+        infraRow.Subgroups[0].Name.Should().Be("Direct");
+
+        // Remaining: Plumbing before Power (lower fill %).
+        infraRow.Subgroups[1].Name.Should().Be("Plumbing");
+        infraRow.Subgroups[2].Name.Should().Be("Power");
+
+        // Invariant: subgroup totals sum to department totals.
+        infraRow.Subgroups.Sum(s => s.TotalShifts).Should().Be(infraRow.TotalShifts);
+        infraRow.Subgroups.Sum(s => s.FilledShifts).Should().Be(infraRow.FilledShifts);
+        infraRow.Subgroups.Sum(s => s.SlotsRemaining).Should().Be(infraRow.SlotsRemaining);
+        infraRow.Subgroups.Sum(s => s.Event.Total).Should().Be(infraRow.Event.Total);
+        infraRow.Subgroups.Sum(s => s.Event.Filled).Should().Be(infraRow.Event.Filled);
+    }
+
+    [Fact]
+    public async Task GetDashboardOverview_DepartmentsSortedByLowestFillPercentFirst()
+    {
+        var es = await SeedEventAsync();
+        var gate = await SeedTeamAsync("Gate");
+        var kitchen = await SeedTeamAsync("Kitchen");
+
+        // Gate: fully filled.
+        var gateRota = await SeedRotaAsync(gate, es, RotaPeriod.Event);
+        var gs = await SeedShiftAsync(gateRota, dayOffset: 1, min: 1, max: 3);
+        await SeedSignupsAsync(gs, SignupStatus.Confirmed, count: 1);
+
+        // Kitchen: not filled.
+        var kitchenRota = await SeedRotaAsync(kitchen, es, RotaPeriod.Event);
+        await SeedShiftAsync(kitchenRota, dayOffset: 1, min: 1, max: 3);
+
+        var result = await _service.GetDashboardOverviewAsync(es.Id);
+
+        result.Departments.Should().HaveCount(2);
+        result.Departments[0].DepartmentName.Should().Be("Kitchen"); // 0% fill comes first
+        result.Departments[1].DepartmentName.Should().Be("Gate");
+    }
+
+    [Fact]
+    public async Task GetCoordinatorActivity_TeamsWithoutPendingExcluded()
+    {
+        var es = await SeedEventAsync();
+        var gate = await SeedTeamAsync("Gate");
+        var kitchen = await SeedTeamAsync("Kitchen");
+
+        var gateRota = await SeedRotaAsync(gate, es, RotaPeriod.Event);
+        var gs = await SeedShiftAsync(gateRota, dayOffset: 1, min: 1, max: 3);
+
+        var coord = await SeedUserAsync("coord", TestNow.Minus(Duration.FromDays(2)));
+        await SeedCoordinatorAsync(gate, coord);
+
+        // Pending on Gate, not Kitchen.
+        await SeedSignupsAsync(gs, SignupStatus.Pending, count: 1);
+
+        var kitchenRota = await SeedRotaAsync(kitchen, es, RotaPeriod.Event);
+        var ks = await SeedShiftAsync(kitchenRota, dayOffset: 1, min: 1, max: 3);
+        await SeedSignupsAsync(ks, SignupStatus.Confirmed, count: 1);
+
+        var result = await _service.GetCoordinatorActivityAsync(es.Id);
+
+        result.Should().HaveCount(1);
+        result[0].TeamName.Should().Be("Gate");
+        result[0].PendingSignupCount.Should().Be(1);
+        result[0].Coordinators.Should().HaveCount(1);
+        result[0].Coordinators[0].DisplayName.Should().Be("coord");
+    }
+
+    [Fact]
+    public async Task GetCoordinatorActivity_SortsByOldestLoginFirst()
+    {
+        var es = await SeedEventAsync();
+        var teamA = await SeedTeamAsync("A");
+        var teamB = await SeedTeamAsync("B");
+
+        var rotaA = await SeedRotaAsync(teamA, es, RotaPeriod.Event);
+        var shiftA = await SeedShiftAsync(rotaA, dayOffset: 1, min: 1, max: 3);
+        await SeedSignupsAsync(shiftA, SignupStatus.Pending, count: 1);
+
+        var rotaB = await SeedRotaAsync(teamB, es, RotaPeriod.Event);
+        var shiftB = await SeedShiftAsync(rotaB, dayOffset: 1, min: 1, max: 3);
+        await SeedSignupsAsync(shiftB, SignupStatus.Pending, count: 1);
+
+        // A has a recent login; B has an old login → B should come first.
+        var coordA = await SeedUserAsync("a-coord", TestNow.Minus(Duration.FromHours(1)));
+        var coordB = await SeedUserAsync("b-coord", TestNow.Minus(Duration.FromDays(20)));
+        await SeedCoordinatorAsync(teamA, coordA);
+        await SeedCoordinatorAsync(teamB, coordB);
+
+        var result = await _service.GetCoordinatorActivityAsync(es.Id);
+
+        result.Should().HaveCount(2);
+        result[0].TeamName.Should().Be("B");
+        result[1].TeamName.Should().Be("A");
+    }
+
+    [Fact]
+    public async Task GetDashboardTrends_SevenDayWindow_ReturnsSevenPointsEndingToday()
+    {
+        var es = await SeedEventAsync();
+
+        var result = await _service.GetDashboardTrendsAsync(es.Id, TrendWindow.Last7Days);
+
+        result.Should().HaveCount(7);
+        var today = TestNow.InUtc().Date;
+        result[^1].Date.Should().Be(today);
+        result[0].Date.Should().Be(today.PlusDays(-6));
+        result.Should().OnlyContain(p => p.NewSignups == 0 && p.NewTicketSales == 0 && p.DistinctLogins == 0);
+    }
+
+    [Fact]
+    public async Task GetDashboardTrends_CountsSignupsInToday()
+    {
+        var es = await SeedEventAsync();
+        var team = await SeedTeamAsync("T");
+        var rota = await SeedRotaAsync(team, es, RotaPeriod.Event);
+        var shift = await SeedShiftAsync(rota, dayOffset: 1, min: 1, max: 3);
+        var user = await SeedUserAsync("u");
+
+        _dbContext.ShiftSignups.Add(new ShiftSignup
+        {
+            Id = Guid.NewGuid(),
+            ShiftId = shift.Id,
+            UserId = user.Id,
+            Status = SignupStatus.Pending,
+            CreatedAt = TestNow,
+            UpdatedAt = TestNow,
+        });
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _service.GetDashboardTrendsAsync(es.Id, TrendWindow.Last7Days);
+
+        result[^1].NewSignups.Should().Be(1);
+        result.Take(6).Should().OnlyContain(p => p.NewSignups == 0);
+    }
+
+    // ================================================================
+    // Seeding helpers.
+    // ================================================================
+
+    private async Task<EventSettings> SeedEventAsync()
+    {
+        var es = new EventSettings
+        {
+            Id = Guid.NewGuid(),
+            EventName = "Test Event",
+            Year = 2026,
+            TimeZoneId = "UTC",
+            GateOpeningDate = new LocalDate(2026, 8, 1),
+            BuildStartOffset = -14,
+            EventEndOffset = 6,
+            StrikeEndOffset = 9,
+            IsActive = true,
+            CreatedAt = TestNow.Minus(Duration.FromDays(60)),
+            UpdatedAt = TestNow,
+        };
+        _dbContext.EventSettings.Add(es);
+        await _dbContext.SaveChangesAsync();
+        return es;
+    }
+
+    private async Task<Team> SeedTeamAsync(string name, Guid? parentId = null)
+    {
+        var team = new Team
+        {
+            Id = Guid.NewGuid(),
+            Name = name,
+            Slug = name.ToLowerInvariant(),
+            IsActive = true,
+            ParentTeamId = parentId,
+            CreatedAt = TestNow,
+            UpdatedAt = TestNow,
+        };
+        _dbContext.Teams.Add(team);
+        await _dbContext.SaveChangesAsync();
+        return team;
+    }
+
+    private async Task<Rota> SeedRotaAsync(Team team, EventSettings es, RotaPeriod period, bool isVisible = true)
+    {
+        var rota = new Rota
+        {
+            Id = Guid.NewGuid(),
+            TeamId = team.Id,
+            EventSettingsId = es.Id,
+            Name = $"{team.Name} {period}",
+            Priority = ShiftPriority.Normal,
+            Policy = SignupPolicy.Public,
+            Period = period,
+            IsVisibleToVolunteers = isVisible,
+            CreatedAt = TestNow,
+            UpdatedAt = TestNow,
+        };
+        _dbContext.Rotas.Add(rota);
+        await _dbContext.SaveChangesAsync();
+        return rota;
+    }
+
+    private async Task<Shift> SeedShiftAsync(Rota rota, int dayOffset, int min, int max, bool adminOnly = false)
+    {
+        var shift = new Shift
+        {
+            Id = Guid.NewGuid(),
+            RotaId = rota.Id,
+            DayOffset = dayOffset,
+            StartTime = new LocalTime(9, 0),
+            Duration = Duration.FromHours(4),
+            MinVolunteers = min,
+            MaxVolunteers = max,
+            AdminOnly = adminOnly,
+            CreatedAt = TestNow,
+            UpdatedAt = TestNow,
+        };
+        _dbContext.Shifts.Add(shift);
+        await _dbContext.SaveChangesAsync();
+        return shift;
+    }
+
+    private async Task<User> SeedUserAsync(string displayName, Instant? lastLogin = null)
+    {
+        var user = new User
+        {
+            Id = Guid.NewGuid(),
+            UserName = $"{displayName}@test",
+            NormalizedUserName = $"{displayName.ToUpperInvariant()}@TEST",
+            Email = $"{displayName}@test",
+            NormalizedEmail = $"{displayName.ToUpperInvariant()}@TEST",
+            DisplayName = displayName,
+            LastLoginAt = lastLogin,
+            SecurityStamp = Guid.NewGuid().ToString(),
+            CreatedAt = TestNow,
+        };
+        _dbContext.Users.Add(user);
+        await _dbContext.SaveChangesAsync();
+        return user;
+    }
+
+    private async Task SeedSignupsAsync(Shift shift, SignupStatus status, int count)
+    {
+        for (var i = 0; i < count; i++)
+        {
+            var user = await SeedUserAsync($"u-{shift.Id:N}-{i}");
+            _dbContext.ShiftSignups.Add(new ShiftSignup
+            {
+                Id = Guid.NewGuid(),
+                ShiftId = shift.Id,
+                UserId = user.Id,
+                Status = status,
+                CreatedAt = TestNow.Minus(Duration.FromHours(1)),
+                UpdatedAt = TestNow,
+            });
+        }
+        await _dbContext.SaveChangesAsync();
+    }
+
+    private async Task SeedOneSignupAsync(Shift shift, Guid userId, SignupStatus status)
+    {
+        _dbContext.ShiftSignups.Add(new ShiftSignup
+        {
+            Id = Guid.NewGuid(),
+            ShiftId = shift.Id,
+            UserId = userId,
+            Status = status,
+            CreatedAt = TestNow.Minus(Duration.FromHours(1)),
+            UpdatedAt = TestNow,
+        });
+        await _dbContext.SaveChangesAsync();
+    }
+
+    private async Task SeedTicketOrderAsync(Guid userId, TicketPaymentStatus status)
+    {
+        _dbContext.TicketOrders.Add(new TicketOrder
+        {
+            Id = Guid.NewGuid(),
+            VendorOrderId = Guid.NewGuid().ToString("N"),
+            BuyerName = "Buyer",
+            BuyerEmail = $"{userId:N}@buyer.test",
+            MatchedUserId = userId,
+            PaymentStatus = status,
+            Currency = "EUR",
+            VendorEventId = "v1",
+            PurchasedAt = TestNow.Minus(Duration.FromDays(10)),
+            SyncedAt = TestNow,
+        });
+        await _dbContext.SaveChangesAsync();
+    }
+
+    private async Task SeedCoordinatorAsync(Team team, User user)
+    {
+        _dbContext.TeamMembers.Add(new TeamMember
+        {
+            Id = Guid.NewGuid(),
+            TeamId = team.Id,
+            UserId = user.Id,
+            Role = TeamMemberRole.Coordinator,
+            JoinedAt = TestNow.Minus(Duration.FromDays(30)),
+        });
+        await _dbContext.SaveChangesAsync();
+    }
+}

--- a/tests/Humans.Application.Tests/Services/ShiftDashboardMetricsTests.cs
+++ b/tests/Humans.Application.Tests/Services/ShiftDashboardMetricsTests.cs
@@ -330,6 +330,43 @@ public class ShiftDashboardMetricsTests : IDisposable
     }
 
     [Fact]
+    public async Task GetCoordinatorActivity_RangeSignup_CountsAsOneBlockNotOneRowPerDay()
+    {
+        var es = await SeedEventAsync();
+        var build = await SeedTeamAsync("Build");
+
+        var buildRota = await SeedRotaAsync(build, es, RotaPeriod.Build);
+
+        // A 5-day range signup — five pending shift-signups sharing one SignupBlockId.
+        var volunteer = await SeedUserAsync("v", TestNow);
+        var blockId = Guid.NewGuid();
+        for (var day = -5; day <= -1; day++)
+        {
+            var shift = await SeedShiftAsync(buildRota, dayOffset: day, min: 1, max: 3);
+            _dbContext.ShiftSignups.Add(new ShiftSignup
+            {
+                Id = Guid.NewGuid(),
+                ShiftId = shift.Id,
+                UserId = volunteer.Id,
+                SignupBlockId = blockId,
+                Status = SignupStatus.Pending,
+                CreatedAt = TestNow.Minus(Duration.FromHours(1)),
+                UpdatedAt = TestNow,
+            });
+        }
+        await _dbContext.SaveChangesAsync();
+
+        var coord = await SeedUserAsync("coord", TestNow.Minus(Duration.FromDays(2)));
+        await SeedCoordinatorAsync(build, coord);
+
+        var result = await _service.GetCoordinatorActivityAsync(es.Id);
+
+        result.Should().HaveCount(1);
+        result[0].TeamName.Should().Be("Build");
+        result[0].PendingSignupCount.Should().Be(1);
+    }
+
+    [Fact]
     public async Task GetCoordinatorActivity_SortsByOldestLoginFirst()
     {
         var es = await SeedEventAsync();

--- a/tests/Humans.Application.Tests/Services/ShiftDashboardMetricsTests.cs
+++ b/tests/Humans.Application.Tests/Services/ShiftDashboardMetricsTests.cs
@@ -30,8 +30,14 @@ public class ShiftDashboardMetricsTests : IDisposable
             .Options;
         _dbContext = new HumansDbContext(options);
 
+        // The dashboard compute methods now reach cross-domain data through
+        // ITicketQueryService / ITeamService / IUserService. Wire thin fakes that
+        // read from the same in-memory DbContext so existing DbContext-based
+        // test seed helpers still drive the scenarios end-to-end.
         var serviceProvider = Substitute.For<IServiceProvider>();
-        serviceProvider.GetService(typeof(ITeamService)).Returns(Substitute.For<ITeamService>());
+        serviceProvider.GetService(typeof(ITeamService)).Returns(new FakeTeamService(_dbContext));
+        serviceProvider.GetService(typeof(ITicketQueryService)).Returns(new FakeTicketQueryService(_dbContext));
+        serviceProvider.GetService(typeof(IUserService)).Returns(new FakeUserService(_dbContext));
 
         _service = new ShiftManagementService(
             _dbContext,
@@ -553,5 +559,185 @@ public class ShiftDashboardMetricsTests : IDisposable
             JoinedAt = TestNow.Minus(Duration.FromDays(30)),
         });
         await _dbContext.SaveChangesAsync();
+    }
+
+    // ================================================================
+    // Thin fakes for cross-domain service interfaces. Each method covers
+    // only the narrow surface used by ShiftManagementService's dashboard
+    // compute paths. All reads go through the same in-memory DbContext
+    // so the test seed helpers (_dbContext.*.Add) drive results end-to-end.
+    // ================================================================
+
+    private sealed class FakeTicketQueryService : ITicketQueryService
+    {
+        private readonly HumansDbContext _db;
+        public FakeTicketQueryService(HumansDbContext db) => _db = db;
+
+        public async Task<IReadOnlyCollection<Guid>> GetMatchedUserIdsForPaidOrdersAsync(CancellationToken ct = default)
+        {
+            return await _db.TicketOrders
+                .Where(o => o.PaymentStatus == Humans.Domain.Enums.TicketPaymentStatus.Paid && o.MatchedUserId != null)
+                .Select(o => o.MatchedUserId!.Value)
+                .Distinct()
+                .ToListAsync(ct);
+        }
+
+        public async Task<IReadOnlyList<Instant>> GetPaidOrderDatesInWindowAsync(Instant fromInclusive, Instant toExclusive, CancellationToken ct = default)
+        {
+            return await _db.TicketOrders
+                .Where(o => o.PaymentStatus == Humans.Domain.Enums.TicketPaymentStatus.Paid
+                            && o.PurchasedAt >= fromInclusive
+                            && o.PurchasedAt < toExclusive)
+                .Select(o => o.PurchasedAt)
+                .ToListAsync(ct);
+        }
+
+        // Members below are unused by the dashboard compute paths under test.
+        public Task<int> GetUserTicketCountAsync(Guid userId) => throw new NotSupportedException();
+        public Task<HashSet<Guid>> GetUserIdsWithTicketsAsync() => throw new NotSupportedException();
+        public Task<HashSet<Guid>> GetAllMatchedUserIdsAsync() => throw new NotSupportedException();
+        public Task<Humans.Application.DTOs.TicketDashboardStats> GetDashboardStatsAsync() => throw new NotSupportedException();
+        public Task<decimal> GetGrossTicketRevenueAsync() => throw new NotSupportedException();
+        public Task<Humans.Application.DTOs.BreakEvenResult> CalculateBreakEvenAsync(int ticketsSold, decimal grossRevenue, string currency, bool canAccessFinance, int fallbackTarget) => throw new NotSupportedException();
+        public Task<Humans.Application.DTOs.TicketSalesAggregates> GetSalesAggregatesAsync() => throw new NotSupportedException();
+        public Task<List<string>> GetAvailableTicketTypesAsync() => throw new NotSupportedException();
+        public Task<Humans.Application.DTOs.CodeTrackingData> GetCodeTrackingDataAsync(string? search) => throw new NotSupportedException();
+        public Task<Humans.Application.DTOs.OrdersPageResult> GetOrdersPageAsync(string? search, string sortBy, bool sortDesc, int page, int pageSize, string? filterPaymentStatus, string? filterTicketType, bool? filterMatched) => throw new NotSupportedException();
+        public Task<Humans.Application.DTOs.AttendeesPageResult> GetAttendeesPageAsync(string? search, string sortBy, bool sortDesc, int page, int pageSize, string? filterTicketType, string? filterStatus, bool? filterMatched, string? filterOrderId) => throw new NotSupportedException();
+        public Task<Humans.Application.DTOs.WhoHasntBoughtResult> GetWhoHasntBoughtAsync(string? search, string? filterTeam, string? filterTier, string? filterTicketStatus, int page, int pageSize) => throw new NotSupportedException();
+        public Task<List<Humans.Application.DTOs.AttendeeExportRow>> GetAttendeeExportDataAsync() => throw new NotSupportedException();
+        public Task<List<Humans.Application.DTOs.OrderExportRow>> GetOrderExportDataAsync() => throw new NotSupportedException();
+        public Task<bool> HasTicketAttendeeMatchAsync(Guid userId) => throw new NotSupportedException();
+        public Task<List<UserTicketOrderSummary>> GetUserTicketOrderSummariesAsync(Guid userId) => throw new NotSupportedException();
+        public Task<bool> HasCurrentEventTicketAsync(Guid userId, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task<UserTicketExportData> GetUserTicketExportDataAsync(Guid userId, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task<Instant?> GetPostEventHoldDateAsync(CancellationToken ct = default) => throw new NotSupportedException();
+    }
+
+    private sealed class FakeUserService : IUserService
+    {
+        private readonly HumansDbContext _db;
+        public FakeUserService(HumansDbContext db) => _db = db;
+
+        public async Task<User?> GetByIdAsync(Guid userId, CancellationToken ct = default)
+            => await _db.Users.FirstOrDefaultAsync(u => u.Id == userId, ct);
+
+        public async Task<IReadOnlyDictionary<Guid, User>> GetByIdsAsync(IReadOnlyCollection<Guid> userIds, CancellationToken ct = default)
+        {
+            if (userIds.Count == 0) return new Dictionary<Guid, User>();
+            var users = await _db.Users.Where(u => userIds.Contains(u.Id)).ToListAsync(ct);
+            return users.ToDictionary(u => u.Id);
+        }
+
+        public async Task<IReadOnlyList<Instant>> GetLoginTimestampsInWindowAsync(Instant fromInclusive, Instant toExclusive, CancellationToken ct = default)
+        {
+            return await _db.Users
+                .Where(u => u.LastLoginAt != null && u.LastLoginAt >= fromInclusive && u.LastLoginAt < toExclusive)
+                .Select(u => u.LastLoginAt!.Value)
+                .ToListAsync(ct);
+        }
+
+        // Members below are unused by the dashboard compute paths under test.
+        public Task<Humans.Domain.Entities.EventParticipation?> GetParticipationAsync(Guid userId, int year, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task<List<Humans.Domain.Entities.EventParticipation>> GetAllParticipationsForYearAsync(int year, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task<Humans.Domain.Entities.EventParticipation> DeclareNotAttendingAsync(Guid userId, int year, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task<bool> UndoNotAttendingAsync(Guid userId, int year, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task SetParticipationFromTicketSyncAsync(Guid userId, int year, Humans.Domain.Enums.ParticipationStatus status, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task RemoveTicketSyncParticipationAsync(Guid userId, int year, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task<int> BackfillParticipationsAsync(int year, List<(Guid UserId, Humans.Domain.Enums.ParticipationStatus Status)> entries, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task<IReadOnlyList<User>> GetAllUsersAsync(CancellationToken ct = default) => throw new NotSupportedException();
+        public Task<bool> TrySetGoogleEmailAsync(Guid userId, string email, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task UpdateDisplayNameAsync(Guid userId, string displayName, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task<bool> SetDeletionPendingAsync(Guid userId, Instant requestedAt, Instant scheduledFor, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task<bool> ClearDeletionAsync(Guid userId, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task<User?> GetByEmailOrAlternateAsync(string email, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task<IReadOnlyList<User>> GetContactUsersAsync(string? search, CancellationToken ct = default) => throw new NotSupportedException();
+    }
+
+    private sealed class FakeTeamService : ITeamService
+    {
+        private readonly HumansDbContext _db;
+        public FakeTeamService(HumansDbContext db) => _db = db;
+
+        public async Task<IReadOnlyDictionary<Guid, Team>> GetByIdsWithParentsAsync(IReadOnlyCollection<Guid> teamIds, CancellationToken cancellationToken = default)
+        {
+            if (teamIds.Count == 0) return new Dictionary<Guid, Team>();
+            var requested = await _db.Teams.Where(t => teamIds.Contains(t.Id)).ToListAsync(cancellationToken);
+            var parentIds = requested
+                .Where(t => t.ParentTeamId.HasValue)
+                .Select(t => t.ParentTeamId!.Value)
+                .Where(id => !teamIds.Contains(id))
+                .Distinct()
+                .ToList();
+            var parents = parentIds.Count == 0
+                ? new List<Team>()
+                : await _db.Teams.Where(t => parentIds.Contains(t.Id)).ToListAsync(cancellationToken);
+            var dict = new Dictionary<Guid, Team>();
+            foreach (var t in requested) dict[t.Id] = t;
+            foreach (var t in parents) dict[t.Id] = t;
+            return dict;
+        }
+
+        public async Task<IReadOnlyList<TeamCoordinatorRef>> GetActiveCoordinatorsForTeamsAsync(IReadOnlyCollection<Guid> teamIds, CancellationToken cancellationToken = default)
+        {
+            if (teamIds.Count == 0) return Array.Empty<TeamCoordinatorRef>();
+            return await _db.TeamMembers
+                .Where(m => teamIds.Contains(m.TeamId) && m.LeftAt == null && m.Role == TeamMemberRole.Coordinator)
+                .Select(m => new TeamCoordinatorRef(m.TeamId, m.UserId))
+                .ToListAsync(cancellationToken);
+        }
+
+        // Members below are unused by the dashboard compute paths under test.
+        public Task<Team> CreateTeamAsync(string name, string? description, bool requiresApproval, Guid? parentTeamId = null, string? googleGroupPrefix = null, bool isHidden = false, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<Team?> GetTeamBySlugAsync(string slug, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<Team?> GetTeamByIdAsync(Guid teamId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<IReadOnlyDictionary<Guid, string>> GetTeamNamesByIdsAsync(IReadOnlyCollection<Guid> teamIds, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<IReadOnlyList<Team>> GetAllTeamsAsync(CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<IReadOnlyList<Team>> GetUserCreatedTeamsAsync(CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<TeamDirectoryResult> GetTeamDirectoryAsync(Guid? userId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<TeamDetailResult?> GetTeamDetailAsync(string slug, Guid? userId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<IReadOnlyList<TeamMember>> GetUserTeamsAsync(Guid userId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<IReadOnlyList<MyTeamMembershipSummary>> GetMyTeamMembershipsAsync(Guid userId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<Team> UpdateTeamAsync(Guid teamId, string name, string? description, bool requiresApproval, bool isActive, Guid? parentTeamId = null, string? googleGroupPrefix = null, string? customSlug = null, bool? hasBudget = null, bool? isHidden = null, bool? isSensitive = null, bool? isPromotedToDirectory = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task DeleteTeamAsync(Guid teamId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<TeamJoinRequest> RequestToJoinTeamAsync(Guid teamId, Guid userId, string? message, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<TeamMember> JoinTeamDirectlyAsync(Guid teamId, Guid userId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<bool> LeaveTeamAsync(Guid teamId, Guid userId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task WithdrawJoinRequestAsync(Guid requestId, Guid userId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<TeamMember> ApproveJoinRequestAsync(Guid requestId, Guid approverUserId, string? notes, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task RejectJoinRequestAsync(Guid requestId, Guid approverUserId, string reason, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<IReadOnlyList<TeamJoinRequest>> GetPendingRequestsForApproverAsync(Guid approverUserId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<IReadOnlyList<TeamJoinRequest>> GetPendingRequestsForTeamAsync(Guid teamId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<TeamJoinRequest?> GetUserPendingRequestAsync(Guid teamId, Guid userId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<bool> CanUserApproveRequestsForTeamAsync(Guid teamId, Guid userId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<bool> IsUserMemberOfTeamAsync(Guid teamId, Guid userId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<bool> IsUserCoordinatorOfTeamAsync(Guid teamId, Guid userId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<bool> RemoveMemberAsync(Guid teamId, Guid userId, Guid actorUserId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<IReadOnlyList<TeamMember>> GetTeamMembersAsync(Guid teamId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<IReadOnlyDictionary<Guid, int>> GetPendingRequestCountsByTeamIdsAsync(IEnumerable<Guid> teamIds, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<IReadOnlyDictionary<Guid, string>> GetManagementRoleNamesByTeamIdsAsync(IEnumerable<Guid> teamIds, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<IReadOnlyDictionary<Guid, List<string>>> GetNonSystemTeamNamesByUserIdsAsync(IEnumerable<Guid> userIds, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<IReadOnlyList<TeamOptionDto>> GetActiveTeamOptionsAsync(CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<(IReadOnlyList<Team> Items, int TotalCount)> GetAllTeamsForAdminAsync(int page, int pageSize, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<AdminTeamListResult> GetAdminTeamListAsync(int page, int pageSize, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<IReadOnlyList<TeamRosterSlotSummary>> GetRosterAsync(string? priority, string? status, string? period, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<TeamMember> AddMemberToTeamAsync(Guid teamId, Guid targetUserId, Guid actorUserId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task UpdateTeamPageContentAsync(Guid teamId, string? pageContent, List<Humans.Domain.ValueObjects.CallToAction> callsToAction, bool isPublicPage, bool showCoordinatorsOnPublicPage, Guid updatedByUserId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<TeamRoleDefinition> CreateRoleDefinitionAsync(Guid teamId, string name, string? description, int slotCount, List<Humans.Domain.Enums.SlotPriority> priorities, int sortOrder, Humans.Domain.Enums.RolePeriod period, Guid actorUserId, bool isPublic = true, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<TeamRoleDefinition> UpdateRoleDefinitionAsync(Guid roleDefinitionId, string name, string? description, int slotCount, List<Humans.Domain.Enums.SlotPriority> priorities, int sortOrder, bool isManagement, Humans.Domain.Enums.RolePeriod period, Guid actorUserId, bool isPublic = true, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task DeleteRoleDefinitionAsync(Guid roleDefinitionId, Guid actorUserId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task SetRoleIsManagementAsync(Guid roleDefinitionId, bool isManagement, Guid actorUserId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<IReadOnlyList<TeamRoleDefinition>> GetRoleDefinitionsAsync(Guid teamId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<IReadOnlyList<TeamRoleDefinition>> GetAllRoleDefinitionsAsync(CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<TeamRoleAssignment> AssignToRoleAsync(Guid roleDefinitionId, Guid targetUserId, Guid actorUserId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task UnassignFromRoleAsync(Guid roleDefinitionId, Guid teamMemberId, Guid actorUserId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<IReadOnlyList<Guid>> GetUserCoordinatedTeamIdsAsync(Guid userId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<IReadOnlyList<Guid>> GetCoordinatorUserIdsAsync(Guid teamId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<TeamMember> AddSeededMemberAsync(Guid teamId, Guid userId, TeamMemberRole role, Instant joinedAt, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<int> HardDeleteSeededTeamsAsync(string nameSuffix, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public void RemoveMemberFromAllTeamsCache(Guid userId) => throw new NotSupportedException();
+        public Task<IReadOnlyList<string>> GetActiveTeamNamesForUserAsync(Guid userId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task EnqueueGoogleResyncForUserTeamsAsync(Guid userId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<int> RevokeAllMembershipsAsync(Guid userId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
     }
 }


### PR DESCRIPTION
## Summary
- Adds `/Shifts/Dashboard` — overview counters, departments table with subgroup drill-down, per-team coordinator activity (per-coordinator last-login, aggregated subteam pending), trends chart with client-side window toggle
- Top-level period filter (All / Build days / Event-time shifts / Strike) scopes every metric on the page
- Staffing chart tooltip shows confirmed + remaining + total together; % confirmed label on each bar
- Development-only seed button with reset/reseed at `/dev/seed/dashboard`; seeds use real department names (Gate, Infrastructure, Participant Wellness → Consent/Welfare/Ohana House, Ice and Water → Ice Ice Baby/Icemakers, Site Operations, Production & Logistics, Werkhaus/Barrio, Power)
- Ticket figures temporarily render "N/A · ticket data not yet shared" (pipeline intact — flip `showTicketData` in two partials to re-enable)
- Auth: `[Authorize(Policy = PolicyNames.ShiftDashboardAccess)]` → Admin, NoInfoAdmin, VolunteerCoordinator. Dev seeder gated to `IWebHostEnvironment.IsDevelopment()`.
- Caching: 5-minute sliding TTL per (event, period) combination. Known gap: signup mutations don't invalidate the cache yet (tracked as a follow-up — counters lag up to 5 min after state changes).

## Test plan
- [ ] `/Shifts/Dashboard` loads as Admin, NoInfoAdmin, VolunteerCoordinator; 403 for other roles
- [ ] Period filter toggle re-scopes overview / departments / coordinator activity / trends / staffing charts
- [ ] Trend-window toggle (7d/30d/90d/All) switches instantly without page reload; URL updates
- [ ] Departments table expands: subteam parents show Direct + subgroups; others show Set-up/Event/Strike rows
- [ ] Coordinator activity shows each coordinator with individual last-login (red when > 7d); parent rows aggregate subteam pending
- [ ] Staffing chart tooltip shows "Total: N (X% confirmed)" on hover; % label above each bar
- [ ] Ticket cards show "N/A" in all locales (en/es/ca/de/fr/it)
- [ ] `dotnet test Humans.slnx` passes — includes 15 new `ShiftDashboardMetricsTests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)