### PR TITLE
Add in-app Guide section (#531)

### DIFF
--- a/docs/features/39-in-app-guide.md
+++ b/docs/features/39-in-app-guide.md
@@ -1,0 +1,75 @@
+# 39 — In-App Guide
+
+## Business context
+
+The Humans app has a comprehensive end-user guide under `docs/guide/` (17
+files covering every section of the app). Before this feature, humans read
+it on GitHub — one click away from the app itself. Embedding the guide at
+`/Guide` makes it immediately available from the nav bar and lets links
+inside the guide navigate in-app to the pages they describe.
+
+GitHub remains the authoring source: guide changes go through pull-request
+review (no in-app CMS). The app pulls the current content from
+`nobodies-collective/Humans:main:docs/guide/` on demand, caches it in
+memory, and re-renders it for each request with role-aware filtering.
+
+## User stories
+
+- As a volunteer, I can click "Guide" in the nav bar and read a
+  human-friendly explanation of the parts of the app I use, with in-app
+  links that take me directly to the right page.
+- As a team coordinator, I see coordinator-specific sections in the guide
+  that explain the management features I have access to.
+- As a domain admin (e.g. TeamsAdmin), I see admin guidance for my domain
+  but not for domains I don't manage.
+- As an admin, I can click "Refresh from GitHub" after merging a guide
+  change, without waiting for the app to redeploy.
+
+## Data model
+
+None. The feature is stateless relative to the database: all content is
+cached in-memory from GitHub. No migrations, no new tables.
+
+## Workflows
+
+### Reading a guide page
+
+1. Human navigates to `/Guide/<Page>`.
+2. `GuideRoleResolver` builds a `GuideRoleContext` from claims +
+   `TeamMember` check.
+3. `GuideContentService` returns the fully rendered HTML for the page,
+   fetching and rendering the 17 files on cache miss.
+4. `GuideFilter` strips role-scoped `<div>` blocks the user can't see.
+5. Filtered HTML rendered inside `_GuideLayout.cshtml` with sidebar.
+
+### Refreshing from GitHub (Admin)
+
+1. Admin submits `POST /Guide/Refresh` (CSRF-protected).
+2. `GuideContentService.RefreshAllAsync` re-fetches all 17 files and
+   re-renders; existing cache entries are overwritten.
+3. Admin is redirected back to `/Guide` with a status flash.
+
+## Authorization
+
+- `GET /Guide` / `GET /Guide/{name}` — `[AllowAnonymous]`. Role filtering
+  applied server-side; anonymous users see Volunteer sections only.
+- `POST /Guide/Refresh` — `[Authorize(Policy = PolicyNames.AdminOnly)]`.
+
+## Role filtering rules
+
+See `docs/superpowers/specs/2026-04-21-in-app-guide-design.md` §Role
+filtering for the authoritative rules (per-block visibility, within-file
+superset, parenthetical parsing).
+
+## Related features
+
+- Legal documents (feature 04) use a similar GitHub-sync pattern but with
+  DB persistence and versioning. Guide content has no such requirement
+  and is memory-only.
+
+## Out of scope for v1
+
+- Localization (English-only for now).
+- Glossary-term hover tooltips.
+- Scheduled background refresh (TTL + manual refresh cover the cases).
+- In-app markdown editing.

--- a/docs/guide/Budget.md
+++ b/docs/guide/Budget.md
@@ -59,7 +59,7 @@ Every edit is audit-logged. You cannot change the category's allocated amount or
 
 Each category shows budget vs actual with the unallocated remainder. Auto-generated line items (weekly ticket-sales rollups, for example) are marked **Auto** on a lighter row — don't edit those by hand; they are overwritten on the next sync.
 
-## As a Board member / Admin
+## As a Board member / Admin (Finance Admin)
 
 (assumes Coordinator knowledge)
 

--- a/docs/guide/CityPlanning.md
+++ b/docs/guide/CityPlanning.md
@@ -34,7 +34,7 @@ If you are a **Camp Lead** and placement is open, you also get tools to place an
 
 You can only edit your own camp's polygon, and only while placement is open. To change it after placement closes, ask a map admin.
 
-## As a Board member / Admin (City Planning Admin)
+## As a Board member / Admin (Camp Admin)
 
 Map admin access is held by **Camp Admin**, **[Admin](Glossary.md#admin)**, and members of the **City Planning team** (slug `city-planning`). Map admins act on any polygon at any time — the placement-open restriction doesn't apply to you.
 

--- a/docs/guide/Feedback.md
+++ b/docs/guide/Feedback.md
@@ -28,7 +28,7 @@ Open **My Feedback** from your profile dropdown, or go to `/Feedback`. You see y
 
 When an admin posts a message on one of your reports, you receive an email in your preferred language with the reply and a direct link back to the report.
 
-## As a Board member / Admin
+## As a Board member / Admin (Feedback Admin)
 
 The capabilities below require the **FeedbackAdmin** or **Admin** role. FeedbackAdmin is scoped to feedback triage only — it does not grant any other admin power.
 

--- a/docs/guide/Onboarding.md
+++ b/docs/guide/Onboarding.md
@@ -57,7 +57,7 @@ If you hold the **Consent Coordinator** role, your work in onboarding is reviewi
 
 If you hold the **Volunteer Coordinator** role, you have read-only access to the same queue so you can assist new humans, but you cannot clear, flag, or reject.
 
-## As a Board member / Admin
+## As a Board member / Admin (Human Admin)
 
 Board members and Admins can do everything a Consent Coordinator can, plus:
 

--- a/docs/guide/Profiles.md
+++ b/docs/guide/Profiles.md
@@ -75,7 +75,7 @@ Go to `/Profile/Me/Privacy` and choose Download My Data. You get a JSON file con
 
 Also on `/Profile/Me/Privacy`. Requesting deletion revokes your team memberships and role assignments immediately and starts a 30-day grace period during which you can still log in and cancel. After 30 days your personal data is anonymised automatically in the background. Google permissions are removed through the normal sync cycle once your team memberships end.
 
-## As a Board member / Admin
+## As a Board member / Admin (Human Admin)
 
 ### View any profile in full
 

--- a/docs/guide/Shifts.md
+++ b/docs/guide/Shifts.md
@@ -66,7 +66,7 @@ There's a hard cap on how many people are on site during set-up and pre-event. E
 
 Reach Volunteer Coordination at [volunteers@nobodies.team](mailto:volunteers@nobodies.team) (Frank, Nurse, Hardcastle).
 
-## As a Board member / Admin
+## As a Board member / Admin (NoInfo Admin)
 
 Admins get the site-wide shift view and can approve, refuse, bail, or voluntell across any department. **NoInfoAdmin** has the same signup powers but can't create or edit rotas and shifts. **VolunteerCoordinator** has full coordinator capabilities across every department.
 

--- a/docs/guide/Teams.md
+++ b/docs/guide/Teams.md
@@ -110,7 +110,7 @@ Three roles handle volunteer coordination across every department. Reach all thr
 
 In many departments it's the sub-team leads — not the top-level coordinator — who manage day-to-day shifts. Example: in Creativity, shifts are managed by Kunsthaus and MoN leads, not the Creativity coordinator. The system is being updated to reflect this properly. In the meantime, if a sub-team lead needs shift management permissions, ask Frank to escalate their access to TeamAdmin.
 
-## As a Board member / Admin
+## As a Board member / Admin (Teams Admin)
 
 (assumes Coordinator knowledge)
 

--- a/docs/sections/Guide.md
+++ b/docs/sections/Guide.md
@@ -16,7 +16,7 @@
 | Role | Visibility |
 |------|------------|
 | Anonymous | View Volunteer-scoped blocks only; cannot trigger refresh |
-| Volunteer (human + not coordinator) | View Volunteer + Coordinator (filtered) blocks; cannot trigger refresh |
+| Any authenticated human | View Volunteer-scoped content |
 | Team coordinator (TeamMember.Role == Coordinator) | Additionally view Coordinator-scoped blocks |
 | Domain admin (*Admin or *Coordinator system role named in a parenthetical) | Additionally view blocks whose parenthetical names their role, on those specific files |
 | Admin, Board | View all blocks on all pages |

--- a/docs/sections/Guide.md
+++ b/docs/sections/Guide.md
@@ -1,0 +1,55 @@
+# Guide — Section Invariants
+
+## Concepts
+
+- A **guide page** is one markdown file under `docs/guide/` in the Humans
+  repo, rendered at `/Guide/<FileStem>`.
+- A **role-scoped block** is a `## As a …` heading and the content under
+  it, wrapped in `<div data-guide-role="…" data-guide-roles="…">` by the
+  renderer and optionally stripped at request time by `GuideFilter`.
+- A **parenthetical** is text in parens after `## As a …` (e.g. `## As a
+  Board member / Admin (Teams Admin)`) that specifies which domain admin
+  role sees that block.
+
+## Actors & Roles
+
+| Role | Visibility |
+|------|------------|
+| Anonymous | View Volunteer-scoped blocks only; cannot trigger refresh |
+| Volunteer (human + not coordinator) | View Volunteer + Coordinator (filtered) blocks; cannot trigger refresh |
+| Team coordinator (TeamMember.Role == Coordinator) | Additionally view Coordinator-scoped blocks |
+| Domain admin (*Admin or *Coordinator system role named in a parenthetical) | Additionally view blocks whose parenthetical names their role, on those specific files |
+| Admin, Board | View all blocks on all pages |
+| Admin | Trigger `POST /Guide/Refresh` |
+
+## Invariants
+
+- All content above the first `## As a …` heading in a file is always
+  visible regardless of role.
+- All content at or below a non-`As a …` `## ` heading (e.g.
+  `## Related sections`) is always visible.
+- Anonymous users only see Volunteer-scoped blocks. They never see
+  Coordinator or Board/Admin blocks.
+- Guide content is the 17 files in `docs/guide/` on the current branch;
+  nothing is authored in-app.
+- Cache key is `guide:<FileStem>`. TTL is sliding, configured via
+  `Guide:CacheTtlHours` (default 6).
+- Only the `GuideContentService` reads or writes the `guide:*` cache
+  entries. No other service touches guide content.
+
+## Triggers
+
+- First `GET /Guide/*` after cold start → full refresh of all 17 cache
+  entries.
+- `POST /Guide/Refresh` (Admin) → clears and repopulates all entries.
+- GitHub fetch failure on warm cache → stale content served; warning
+  logged; TTL preserved.
+- GitHub fetch failure on cold cache → `GuideContentUnavailableException`
+  bubbles; controller renders `Unavailable.cshtml`.
+
+## Cross-Section Dependencies
+
+- Reads `TeamMember.Role` to resolve the `IsTeamCoordinator` flag for the
+  current user (see `Teams` section).
+- Reads `User.IsInRole` claims for the `SystemRoles` set (see `Admin`
+  section for role assignments).

--- a/src/Humans.Application/Constants/GuideFiles.cs
+++ b/src/Humans.Application/Constants/GuideFiles.cs
@@ -1,0 +1,47 @@
+namespace Humans.Application.Constants;
+
+/// <summary>
+/// The set of markdown files rendered at /Guide/{stem}. Order mirrors docs/guide/README.md.
+/// </summary>
+public static class GuideFiles
+{
+    public const string Readme = "README";
+    public const string GettingStarted = "GettingStarted";
+    public const string Glossary = "Glossary";
+
+    public static readonly IReadOnlyList<string> Sections =
+    [
+        "Profiles",
+        "Onboarding",
+        "LegalAndConsent",
+        "Teams",
+        "Shifts",
+        "Tickets",
+        "Camps",
+        "Email",
+        "Campaigns",
+        "Feedback",
+        "Governance",
+        "Budget",
+        "CityPlanning",
+        "GoogleIntegration",
+        "Admin"
+    ];
+
+    public static readonly IReadOnlySet<string> All = BuildAll();
+
+    private static IReadOnlySet<string> BuildAll()
+    {
+        var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            Readme,
+            GettingStarted,
+            Glossary
+        };
+        foreach (var section in Sections)
+        {
+            set.Add(section);
+        }
+        return set;
+    }
+}

--- a/src/Humans.Application/Interfaces/IGuideContentService.cs
+++ b/src/Humans.Application/Interfaces/IGuideContentService.cs
@@ -1,0 +1,36 @@
+namespace Humans.Application.Interfaces;
+
+/// <summary>
+/// Public façade for retrieving rendered guide pages. Owns the memory cache.
+/// </summary>
+public interface IGuideContentService
+{
+    /// <summary>
+    /// Returns the rendered, role-annotated HTML for a guide file. Triggers a
+    /// full refresh if the cache is cold. Throws <see cref="GuideContentUnavailableException"/>
+    /// when GitHub is unreachable and no stale content is available.
+    /// </summary>
+    Task<string> GetRenderedAsync(string fileStem, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Evicts all cached entries and re-fetches every known guide file from GitHub.
+    /// </summary>
+    Task RefreshAllAsync(CancellationToken cancellationToken = default);
+}
+
+public sealed class GuideContentUnavailableException : Exception
+{
+    public GuideContentUnavailableException()
+    {
+    }
+
+    public GuideContentUnavailableException(string message)
+        : base(message)
+    {
+    }
+
+    public GuideContentUnavailableException(string message, Exception? innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/src/Humans.Application/Interfaces/IGuideContentSource.cs
+++ b/src/Humans.Application/Interfaces/IGuideContentSource.cs
@@ -1,0 +1,12 @@
+namespace Humans.Application.Interfaces;
+
+/// <summary>
+/// Abstracts the GitHub fetch so GuideContentService is testable without network.
+/// </summary>
+public interface IGuideContentSource
+{
+    /// <summary>
+    /// Fetches the raw markdown for one guide file by stem (e.g. "Profiles" → Profiles.md).
+    /// </summary>
+    Task<string> GetMarkdownAsync(string fileStem, CancellationToken cancellationToken = default);
+}

--- a/src/Humans.Application/Interfaces/IGuideRenderer.cs
+++ b/src/Humans.Application/Interfaces/IGuideRenderer.cs
@@ -1,0 +1,10 @@
+namespace Humans.Application.Interfaces;
+
+/// <summary>
+/// Renders guide markdown to HTML with role-section div wrappers and rewritten
+/// links/images. Pure function of (markdown, file stem) — safe to cache the output.
+/// </summary>
+public interface IGuideRenderer
+{
+    string Render(string markdown, string fileStem);
+}

--- a/src/Humans.Application/Interfaces/IGuideRoleResolver.cs
+++ b/src/Humans.Application/Interfaces/IGuideRoleResolver.cs
@@ -1,0 +1,13 @@
+using System.Security.Claims;
+using Humans.Application.Models;
+
+namespace Humans.Application.Interfaces;
+
+/// <summary>
+/// Builds a <see cref="GuideRoleContext"/> for the current user: reads system roles
+/// from claims and checks the database for any active team-coordinator assignment.
+/// </summary>
+public interface IGuideRoleResolver
+{
+    Task<GuideRoleContext> ResolveAsync(ClaimsPrincipal user, CancellationToken cancellationToken = default);
+}

--- a/src/Humans.Application/Models/GuideRoleContext.cs
+++ b/src/Humans.Application/Models/GuideRoleContext.cs
@@ -1,0 +1,10 @@
+namespace Humans.Application.Models;
+
+public sealed record GuideRoleContext(
+    bool IsAuthenticated,
+    bool IsTeamCoordinator,
+    IReadOnlySet<string> SystemRoles)
+{
+    public static readonly GuideRoleContext Anonymous =
+        new(false, false, new HashSet<string>(StringComparer.Ordinal));
+}

--- a/src/Humans.Application/Services/GuideFilter.cs
+++ b/src/Humans.Application/Services/GuideFilter.cs
@@ -11,6 +11,10 @@ namespace Humans.Application.Services;
 /// </summary>
 public static class GuideFilter
 {
+    /// <summary>
+    /// Regex that matches the innermost &lt;/div&gt; (non-greedy .*?), which is safe because
+    /// guide markdown is PR-reviewed and does not contain nested &lt;div&gt;s.
+    /// </summary>
     private static readonly Regex BlockPattern = new(
         """<div\s+data-guide-role="(?<role>[^"]+)"\s+data-guide-roles="(?<roles>[^"]*)"\s*>(?<body>.*?)</div>""",
         RegexOptions.Compiled | RegexOptions.Singleline,

--- a/src/Humans.Application/Services/GuideFilter.cs
+++ b/src/Humans.Application/Services/GuideFilter.cs
@@ -1,0 +1,91 @@
+using System.Text.RegularExpressions;
+using Humans.Application.Models;
+using Humans.Domain.Constants;
+
+namespace Humans.Application.Services;
+
+/// <summary>
+/// Strips role-scoped blocks the current user is not entitled to see. Operates on the
+/// HTML produced by <c>GuideRenderer</c> (with &lt;div data-guide-role&gt; wrappers).
+/// Pure function — returns the filtered HTML.
+/// </summary>
+public static class GuideFilter
+{
+    private static readonly Regex BlockPattern = new(
+        """<div\s+data-guide-role="(?<role>[^"]+)"\s+data-guide-roles="(?<roles>[^"]*)"\s*>(?<body>.*?)</div>""",
+        RegexOptions.Compiled | RegexOptions.Singleline,
+        TimeSpan.FromSeconds(1));
+
+    public static string Apply(string html, GuideRoleContext context)
+    {
+        ArgumentNullException.ThrowIfNull(html);
+        ArgumentNullException.ThrowIfNull(context);
+
+        // Two-pass: first pass decides each block's visibility; second pass applies the
+        // within-file Coordinator superset (Coordinator inherits from Board/Admin).
+        var fileSeesBoardAdmin = false;
+        var matches = BlockPattern.Matches(html).ToList();
+
+        foreach (Match match in matches)
+        {
+            var role = match.Groups["role"].Value;
+            var roles = match.Groups["roles"].Value;
+            if (role.Equals("boardadmin", StringComparison.Ordinal) &&
+                IsVisible(role, roles, context))
+            {
+                fileSeesBoardAdmin = true;
+                break;
+            }
+        }
+
+        return BlockPattern.Replace(html, match =>
+        {
+            var role = match.Groups["role"].Value;
+            var roles = match.Groups["roles"].Value;
+
+            var visible = IsVisible(role, roles, context);
+            if (!visible && role.Equals("coordinator", StringComparison.Ordinal) && fileSeesBoardAdmin)
+            {
+                visible = true;
+            }
+
+            return visible ? match.Value : string.Empty;
+        });
+    }
+
+    private static bool IsVisible(string role, string rolesAttr, GuideRoleContext context)
+    {
+        var parenthetical = string.IsNullOrEmpty(rolesAttr)
+            ? []
+            : (IReadOnlyList<string>)rolesAttr.Split(',', StringSplitOptions.RemoveEmptyEntries);
+
+        return role switch
+        {
+            "volunteer" => true,
+            "coordinator" => IsCoordinatorVisible(parenthetical, context),
+            "boardadmin" => IsBoardAdminVisible(parenthetical, context),
+            _ => false
+        };
+    }
+
+    private static bool IsCoordinatorVisible(IReadOnlyList<string> paren, GuideRoleContext ctx)
+    {
+        if (ctx.IsTeamCoordinator) return true;
+        if (ctx.SystemRoles.Contains(RoleNames.Board) || ctx.SystemRoles.Contains(RoleNames.Admin)) return true;
+        foreach (var role in paren)
+        {
+            if (ctx.SystemRoles.Contains(role)) return true;
+        }
+        return false;
+    }
+
+    private static bool IsBoardAdminVisible(IReadOnlyList<string> paren, GuideRoleContext ctx)
+    {
+        if (ctx.SystemRoles.Contains(RoleNames.Board) || ctx.SystemRoles.Contains(RoleNames.Admin)) return true;
+        foreach (var role in paren)
+        {
+            if (ctx.SystemRoles.Contains(role)) return true;
+        }
+        return false;
+    }
+}

--- a/src/Humans.Application/Services/GuideRolePrivilegeMap.cs
+++ b/src/Humans.Application/Services/GuideRolePrivilegeMap.cs
@@ -1,0 +1,61 @@
+using System.Diagnostics.CodeAnalysis;
+using Humans.Domain.Constants;
+
+namespace Humans.Application.Services;
+
+/// <summary>
+/// Maps display names that appear in guide-heading parentheticals (e.g. "Camp Admin",
+/// "Consent Coordinator") to the system role constants defined in <see cref="RoleNames"/>.
+/// </summary>
+public static class GuideRolePrivilegeMap
+{
+    private static readonly IReadOnlyDictionary<string, string> DisplayToRole =
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Admin"] = RoleNames.Admin,
+            ["Board"] = RoleNames.Board,
+            ["Teams Admin"] = RoleNames.TeamsAdmin,
+            ["Camp Admin"] = RoleNames.CampAdmin,
+            ["Ticket Admin"] = RoleNames.TicketAdmin,
+            ["NoInfo Admin"] = RoleNames.NoInfoAdmin,
+            ["No Info Admin"] = RoleNames.NoInfoAdmin,
+            ["Feedback Admin"] = RoleNames.FeedbackAdmin,
+            ["Human Admin"] = RoleNames.HumanAdmin,
+            ["Finance Admin"] = RoleNames.FinanceAdmin,
+            ["Consent Coordinator"] = RoleNames.ConsentCoordinator,
+            ["Volunteer Coordinator"] = RoleNames.VolunteerCoordinator
+        };
+
+    public static bool TryResolve(string displayName, [NotNullWhen(true)] out string? systemRole)
+    {
+        if (string.IsNullOrWhiteSpace(displayName))
+        {
+            systemRole = null;
+            return false;
+        }
+
+        return DisplayToRole.TryGetValue(displayName.Trim(), out systemRole);
+    }
+
+    /// <summary>
+    /// Parses a guide-heading parenthetical like "Camp Admin, Finance Admin" into the
+    /// matching system-role constants. Unknown tokens are skipped (not thrown).
+    /// </summary>
+    public static IReadOnlyList<string> ParseParenthetical(string? paren)
+    {
+        if (string.IsNullOrWhiteSpace(paren))
+        {
+            return [];
+        }
+
+        var result = new List<string>();
+        foreach (var token in paren.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (TryResolve(token, out var role))
+            {
+                result.Add(role);
+            }
+        }
+        return result;
+    }
+}

--- a/src/Humans.Infrastructure/Configuration/GuideSettings.cs
+++ b/src/Humans.Infrastructure/Configuration/GuideSettings.cs
@@ -1,0 +1,34 @@
+namespace Humans.Infrastructure.Configuration;
+
+/// <summary>
+/// Configuration for the in-app Guide section. Source location and cache behaviour.
+/// </summary>
+public class GuideSettings
+{
+    public const string SectionName = "Guide";
+
+    /// <summary>GitHub owner (defaults to nobodies-collective).</summary>
+    public string Owner { get; set; } = "nobodies-collective";
+
+    /// <summary>GitHub repository (defaults to Humans).</summary>
+    public string Repository { get; set; } = "Humans";
+
+    /// <summary>Branch to read guide content from.</summary>
+    public string Branch { get; set; } = "main";
+
+    /// <summary>Folder inside the repo that contains the guide markdown files.</summary>
+    public string FolderPath { get; set; } = "docs/guide";
+
+    /// <summary>Cache TTL in hours for rendered guide pages. Sliding expiration.</summary>
+    public int CacheTtlHours { get; set; } = 6;
+
+    /// <summary>Optional personal access token. Falls back to GitHubSettings.AccessToken if empty.</summary>
+    public string? AccessToken { get; set; }
+
+    /// <summary>
+    /// Returns the raw.githubusercontent.com URL prefix for image references inside
+    /// guide content: "https://raw.githubusercontent.com/{Owner}/{Repository}/{Branch}/{FolderPath}/".
+    /// </summary>
+    public string RawContentBaseUrl =>
+        $"https://raw.githubusercontent.com/{Owner}/{Repository}/{Branch}/{FolderPath.TrimEnd('/')}/";
+}

--- a/src/Humans.Infrastructure/Services/GitHubGuideContentSource.cs
+++ b/src/Humans.Infrastructure/Services/GitHubGuideContentSource.cs
@@ -1,0 +1,50 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Octokit;
+using Humans.Application.Interfaces;
+using Humans.Infrastructure.Configuration;
+
+namespace Humans.Infrastructure.Services;
+
+public sealed class GitHubGuideContentSource : IGuideContentSource
+{
+    private readonly IOptions<GuideSettings> _guideSettings;
+    private readonly IOptions<GitHubSettings> _gitHubSettings;
+    private readonly GitHubClient _client;
+    private readonly ILogger<GitHubGuideContentSource> _logger;
+
+    public GitHubGuideContentSource(
+        IOptions<GuideSettings> guideSettings,
+        IOptions<GitHubSettings> gitHubSettings,
+        ILogger<GitHubGuideContentSource> logger)
+    {
+        _guideSettings = guideSettings;
+        _gitHubSettings = gitHubSettings;
+        _logger = logger;
+
+        _client = new GitHubClient(new ProductHeaderValue("NobodiesHumansGuide"));
+        var token = guideSettings.Value.AccessToken ?? gitHubSettings.Value.AccessToken;
+        if (!string.IsNullOrEmpty(token))
+        {
+            _client.Credentials = new Credentials(token);
+        }
+    }
+
+    public async Task<string> GetMarkdownAsync(string fileStem, CancellationToken cancellationToken = default)
+    {
+        var settings = _guideSettings.Value;
+        var path = $"{settings.FolderPath.TrimEnd('/')}/{fileStem}.md";
+
+        _logger.LogDebug(
+            "Fetching guide file {Path} from {Owner}/{Repository}@{Branch}",
+            path, settings.Owner, settings.Repository, settings.Branch);
+
+        var rawBytes = await _client.Repository.Content.GetRawContentByRef(
+            settings.Owner,
+            settings.Repository,
+            path,
+            settings.Branch);
+
+        return System.Text.Encoding.UTF8.GetString(rawBytes);
+    }
+}

--- a/src/Humans.Infrastructure/Services/GitHubGuideContentSource.cs
+++ b/src/Humans.Infrastructure/Services/GitHubGuideContentSource.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Octokit;
+using Humans.Application.Configuration;
 using Humans.Application.Interfaces;
 using Humans.Infrastructure.Configuration;
 
@@ -23,7 +24,10 @@ public sealed class GitHubGuideContentSource : IGuideContentSource
         _logger = logger;
 
         _client = new GitHubClient(new ProductHeaderValue("NobodiesHumansGuide"));
-        var token = guideSettings.Value.AccessToken ?? gitHubSettings.Value.AccessToken;
+        // Empty string from env-var wiring is treated the same as null — fall back to GitHubSettings.
+        var token = string.IsNullOrEmpty(guideSettings.Value.AccessToken)
+            ? gitHubSettings.Value.AccessToken
+            : guideSettings.Value.AccessToken;
         if (!string.IsNullOrEmpty(token))
         {
             _client.Credentials = new Credentials(token);

--- a/src/Humans.Infrastructure/Services/GuideContentService.cs
+++ b/src/Humans.Infrastructure/Services/GuideContentService.cs
@@ -1,0 +1,119 @@
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Humans.Application.Constants;
+using Humans.Application.Interfaces;
+using Humans.Infrastructure.Configuration;
+
+namespace Humans.Infrastructure.Services;
+
+public sealed class GuideContentService : IGuideContentService
+{
+    private const string CacheKeyPrefix = "guide:";
+
+    private readonly IGuideContentSource _source;
+    private readonly IGuideRenderer _renderer;
+    private readonly IMemoryCache _cache;
+    private readonly IOptions<GuideSettings> _settings;
+    private readonly ILogger<GuideContentService> _logger;
+    private readonly SemaphoreSlim _refreshLock = new(1, 1);
+
+    public GuideContentService(
+        IGuideContentSource source,
+        IGuideRenderer renderer,
+        IMemoryCache cache,
+        IOptions<GuideSettings> settings,
+        ILogger<GuideContentService> logger)
+    {
+        _source = source;
+        _renderer = renderer;
+        _cache = cache;
+        _settings = settings;
+        _logger = logger;
+    }
+
+    public async Task<string> GetRenderedAsync(string fileStem, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(fileStem);
+
+        var canonical = GuideFiles.All.FirstOrDefault(s => s.Equals(fileStem, StringComparison.OrdinalIgnoreCase))
+            ?? throw new FileNotFoundException($"Guide file '{fileStem}' is not in the known set.");
+
+        if (_cache.TryGetValue(CacheKey(canonical), out string? cached) && cached is not null)
+        {
+            return cached;
+        }
+
+        await PopulateAsync(isRefresh: false, cancellationToken);
+
+        if (_cache.TryGetValue(CacheKey(canonical), out string? afterPopulate) && afterPopulate is not null)
+        {
+            return afterPopulate;
+        }
+
+        throw new GuideContentUnavailableException(
+            $"Guide content '{canonical}' is not currently available.");
+    }
+
+    public Task RefreshAllAsync(CancellationToken cancellationToken = default) =>
+        PopulateAsync(isRefresh: true, cancellationToken);
+
+    private async Task PopulateAsync(bool isRefresh, CancellationToken cancellationToken)
+    {
+        await _refreshLock.WaitAsync(cancellationToken);
+        try
+        {
+            var hasStale = GuideFiles.All.Any(s => _cache.TryGetValue(CacheKey(s), out string? _));
+
+            var settings = _settings.Value;
+            var ttl = TimeSpan.FromHours(Math.Max(1, settings.CacheTtlHours));
+            var anyFailures = false;
+            var newEntries = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var stem in GuideFiles.All)
+            {
+                try
+                {
+                    var markdown = await _source.GetMarkdownAsync(stem, cancellationToken);
+                    var html = _renderer.Render(markdown, stem);
+                    newEntries[stem] = html;
+                }
+                catch (Exception ex)
+                {
+                    anyFailures = true;
+                    _logger.LogWarning(ex,
+                        "Failed to fetch or render guide file {FileStem}; {Outcome}",
+                        stem,
+                        hasStale ? "keeping stale cached copy" : "no stale copy available");
+                }
+            }
+
+            if (!hasStale && newEntries.Count == 0)
+            {
+                throw new GuideContentUnavailableException(
+                    "Guide content is unavailable and the cache is cold.");
+            }
+
+            foreach (var (stem, html) in newEntries)
+            {
+                _cache.Set(CacheKey(stem), html, new MemoryCacheEntryOptions
+                {
+                    SlidingExpiration = ttl
+                });
+            }
+
+            if (anyFailures)
+            {
+                _logger.LogWarning(
+                    "Guide refresh completed with failures (isRefresh={IsRefresh}); stale entries retained.",
+                    isRefresh);
+            }
+        }
+        finally
+        {
+            _refreshLock.Release();
+        }
+    }
+
+    private static string CacheKey(string stem) => CacheKeyPrefix + stem;
+}

--- a/src/Humans.Infrastructure/Services/GuideHtmlPostprocessor.cs
+++ b/src/Humans.Infrastructure/Services/GuideHtmlPostprocessor.cs
@@ -20,6 +20,14 @@ public sealed class GuideHtmlPostprocessor
         RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture,
         TimeSpan.FromMilliseconds(500));
 
+    // Matches <code>/route/path</code> spans where the content is a concrete app path:
+    // starts with "/", contains no "{" (so route templates like /Profile/{id} are left
+    // alone), no whitespace, no "#" or "?". These spans get wrapped in an <a href>.
+    private static readonly Regex AppPathCodePattern = new(
+        """<code>(?<path>/[^\s<>{}#?]+)</code>""",
+        RegexOptions.Compiled | RegexOptions.ExplicitCapture,
+        TimeSpan.FromMilliseconds(500));
+
     public string Rewrite(string html, GuideSettings settings, IReadOnlySet<string> knownFileStems)
     {
         ArgumentNullException.ThrowIfNull(html);
@@ -54,6 +62,12 @@ public sealed class GuideHtmlPostprocessor
 
             var rewritten = RewriteImgSrc(url, rawBase, guideFolder);
             return $"<img {before}src=\"{rewritten}\"{after}>";
+        });
+
+        html = AppPathCodePattern.Replace(html, match =>
+        {
+            var path = match.Groups["path"].Value;
+            return $"""<a href="{path}" class="guide-app-path"><code>{path}</code></a>""";
         });
 
         return html;

--- a/src/Humans.Infrastructure/Services/GuideHtmlPostprocessor.cs
+++ b/src/Humans.Infrastructure/Services/GuideHtmlPostprocessor.cs
@@ -1,0 +1,157 @@
+using System.Text.RegularExpressions;
+using Humans.Infrastructure.Configuration;
+
+namespace Humans.Infrastructure.Services;
+
+/// <summary>
+/// Rewrites &lt;a href&gt; and &lt;img src&gt; attributes in rendered guide HTML so sibling
+/// .md links become in-app routes, external/parent-relative links open in a new tab,
+/// and image references resolve to raw.githubusercontent.com.
+/// </summary>
+public sealed class GuideHtmlPostprocessor
+{
+    private static readonly Regex HrefPattern = new(
+        """<a\s+(?<before>[^>]*?)href="(?<url>[^"]+)"(?<rest>[^>]*)>""",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture,
+        TimeSpan.FromMilliseconds(500));
+
+    private static readonly Regex ImgPattern = new(
+        """<img\s+(?<before>[^>]*?)src="(?<url>[^"]+)"(?<rest>[^>]*)>""",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture,
+        TimeSpan.FromMilliseconds(500));
+
+    public string Rewrite(string html, GuideSettings settings, IReadOnlySet<string> knownFileStems)
+    {
+        ArgumentNullException.ThrowIfNull(html);
+        ArgumentNullException.ThrowIfNull(settings);
+        ArgumentNullException.ThrowIfNull(knownFileStems);
+
+        var githubRepoBlobBase =
+            $"https://github.com/{settings.Owner}/{settings.Repository}/blob/{settings.Branch}/";
+        var rawBase = settings.RawContentBaseUrl;
+        var guideFolder = settings.FolderPath.TrimEnd('/') + "/";
+
+        html = HrefPattern.Replace(html, match =>
+        {
+            var before = match.Groups["before"].Value;
+            var url = match.Groups["url"].Value;
+            var after = match.Groups["rest"].Value;
+
+            var rewritten = RewriteHref(url, knownFileStems, githubRepoBlobBase, guideFolder);
+            if (rewritten.IsExternal && !after.Contains("target=", StringComparison.OrdinalIgnoreCase))
+            {
+                after = $" target=\"_blank\" rel=\"noopener\"{after}";
+            }
+
+            return $"<a {before}href=\"{rewritten.Href}\"{after}>";
+        });
+
+        html = ImgPattern.Replace(html, match =>
+        {
+            var before = match.Groups["before"].Value;
+            var url = match.Groups["url"].Value;
+            var after = match.Groups["rest"].Value;
+
+            var rewritten = RewriteImgSrc(url, rawBase, guideFolder);
+            return $"<img {before}src=\"{rewritten}\"{after}>";
+        });
+
+        return html;
+    }
+
+    private static (string Href, bool IsExternal) RewriteHref(
+        string url,
+        IReadOnlySet<string> knownStems,
+        string githubRepoBlobBase,
+        string guideFolder)
+    {
+        if (url.StartsWith("http://", StringComparison.OrdinalIgnoreCase) ||
+            url.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+        {
+            return (url, true);
+        }
+
+        if (url.StartsWith("mailto:", StringComparison.OrdinalIgnoreCase))
+        {
+            return (url, false);
+        }
+
+        if (url.StartsWith('/'))
+        {
+            return (url, false);
+        }
+
+        if (url.StartsWith("../", StringComparison.Ordinal))
+        {
+            var resolved = ResolveParentRelative(url, guideFolder);
+            return ($"{githubRepoBlobBase}{resolved}", true);
+        }
+
+        var (path, fragment) = SplitFragment(url);
+
+        if (path.EndsWith(".md", StringComparison.OrdinalIgnoreCase))
+        {
+            var stem = path[..^3];
+            var known = knownStems.FirstOrDefault(s => s.Equals(stem, StringComparison.OrdinalIgnoreCase));
+            if (known is not null)
+            {
+                var href = fragment is null ? $"/Guide/{known}" : $"/Guide/{known}#{fragment}";
+                return (href, false);
+            }
+
+            var blobUrl = $"{githubRepoBlobBase}{guideFolder}{path}";
+            if (fragment is not null)
+            {
+                blobUrl = $"{blobUrl}#{fragment}";
+            }
+            return (blobUrl, true);
+        }
+
+        return (url, false);
+    }
+
+    private static string RewriteImgSrc(string url, string rawBase, string guideFolder)
+    {
+        if (url.StartsWith("http://", StringComparison.OrdinalIgnoreCase) ||
+            url.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+        {
+            return url;
+        }
+
+        var trimmed = url.TrimStart('/');
+        if (trimmed.StartsWith(guideFolder, StringComparison.OrdinalIgnoreCase))
+        {
+            trimmed = trimmed[guideFolder.Length..];
+        }
+
+        return rawBase + trimmed;
+    }
+
+    private static string ResolveParentRelative(string url, string guideFolder)
+    {
+        var segments = guideFolder.Trim('/').Split('/', StringSplitOptions.RemoveEmptyEntries).ToList();
+
+        var remainder = url;
+        while (remainder.StartsWith("../", StringComparison.Ordinal))
+        {
+            if (segments.Count > 0)
+            {
+                segments.RemoveAt(segments.Count - 1);
+            }
+            remainder = remainder[3..];
+        }
+
+        segments.Add(remainder);
+        return string.Join('/', segments);
+    }
+
+    private static (string Path, string? Fragment) SplitFragment(string url)
+    {
+        var hashIndex = url.IndexOf('#');
+        if (hashIndex < 0)
+        {
+            return (url, null);
+        }
+        return (url[..hashIndex], url[(hashIndex + 1)..]);
+    }
+}

--- a/src/Humans.Infrastructure/Services/GuideMarkdownPreprocessor.cs
+++ b/src/Humans.Infrastructure/Services/GuideMarkdownPreprocessor.cs
@@ -1,0 +1,120 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using Humans.Application.Services;
+
+namespace Humans.Infrastructure.Services;
+
+/// <summary>
+/// Wraps each "## As a …" block in a raw HTML div carrying role metadata so the
+/// rendered HTML can be role-filtered per request. Blocks end at the next "## " heading
+/// or EOF.
+/// </summary>
+public sealed class GuideMarkdownPreprocessor
+{
+    private static readonly Regex RoleHeading = new(
+        @"^##\s+As\s+an?\s+(?:\[)?(?<head>Volunteer|Coordinator|Board)[^\n]*?(?:\((?<paren>[^)]+)\))?\s*$",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled,
+        TimeSpan.FromMilliseconds(250));
+
+    private static readonly Regex AnyH2 = new(
+        @"^##\s+",
+        RegexOptions.Compiled,
+        TimeSpan.FromMilliseconds(100));
+
+    public string Wrap(string markdown)
+    {
+        ArgumentNullException.ThrowIfNull(markdown);
+
+        var lines = markdown.Split('\n');
+        var output = new StringBuilder(markdown.Length + 256);
+        var inBlock = false;
+
+        for (var i = 0; i < lines.Length; i++)
+        {
+            var rawLine = lines[i];
+            var line = rawLine.EndsWith('\r') ? rawLine[..^1] : rawLine;
+
+            var roleMatch = RoleHeading.Match(line);
+            if (roleMatch.Success)
+            {
+                if (inBlock)
+                {
+                    AppendDivClose(output);
+                }
+
+                var head = roleMatch.Groups["head"].Value.ToLowerInvariant() switch
+                {
+                    "volunteer" => "volunteer",
+                    "coordinator" => "coordinator",
+                    "board" => "boardadmin",
+                    _ => "volunteer"
+                };
+
+                var parenContent = roleMatch.Groups["paren"].Success
+                    ? roleMatch.Groups["paren"].Value
+                    : null;
+                var roles = GuideRolePrivilegeMap.ParseParenthetical(parenContent);
+                var rolesAttr = string.Join(",", roles);
+
+                // Emit the heading with the parenthetical stripped, since the role
+                // information is now carried by the wrapping div's data attributes.
+                var headingLine = roleMatch.Groups["paren"].Success
+                    ? StripParenthetical(rawLine)
+                    : rawLine;
+
+                output.Append('\n');
+                output.Append($"<div data-guide-role=\"{head}\" data-guide-roles=\"{rolesAttr}\">");
+                output.Append('\n');
+                output.Append('\n');
+                output.Append(headingLine);
+                output.Append('\n');
+                inBlock = true;
+                continue;
+            }
+
+            if (inBlock && AnyH2.IsMatch(line))
+            {
+                AppendDivClose(output);
+                inBlock = false;
+            }
+
+            output.Append(rawLine);
+            if (i < lines.Length - 1)
+            {
+                output.Append('\n');
+            }
+        }
+
+        if (inBlock)
+        {
+            AppendDivClose(output);
+        }
+
+        return output.ToString();
+    }
+
+    private static void AppendDivClose(StringBuilder sb)
+    {
+        sb.Append('\n');
+        sb.Append("</div>");
+        sb.Append('\n');
+        sb.Append('\n');
+    }
+
+    private static string StripParenthetical(string line)
+    {
+        var open = line.IndexOf('(');
+        if (open < 0)
+        {
+            return line;
+        }
+        var close = line.IndexOf(')', open + 1);
+        if (close < 0)
+        {
+            return line;
+        }
+        var before = line[..open].TrimEnd();
+        var after = line[(close + 1)..];
+        return before + after;
+    }
+}

--- a/src/Humans.Infrastructure/Services/GuideMarkdownPreprocessor.cs
+++ b/src/Humans.Infrastructure/Services/GuideMarkdownPreprocessor.cs
@@ -56,17 +56,11 @@ public sealed class GuideMarkdownPreprocessor
                 var roles = GuideRolePrivilegeMap.ParseParenthetical(parenContent);
                 var rolesAttr = string.Join(",", roles);
 
-                // Emit the heading with the parenthetical stripped, since the role
-                // information is now carried by the wrapping div's data attributes.
-                var headingLine = roleMatch.Groups["paren"].Success
-                    ? StripParenthetical(rawLine)
-                    : rawLine;
-
                 output.Append('\n');
                 output.Append($"<div data-guide-role=\"{head}\" data-guide-roles=\"{rolesAttr}\">");
                 output.Append('\n');
                 output.Append('\n');
-                output.Append(headingLine);
+                output.Append(rawLine);
                 output.Append('\n');
                 inBlock = true;
                 continue;
@@ -99,22 +93,5 @@ public sealed class GuideMarkdownPreprocessor
         sb.Append("</div>");
         sb.Append('\n');
         sb.Append('\n');
-    }
-
-    private static string StripParenthetical(string line)
-    {
-        var open = line.IndexOf('(');
-        if (open < 0)
-        {
-            return line;
-        }
-        var close = line.IndexOf(')', open + 1);
-        if (close < 0)
-        {
-            return line;
-        }
-        var before = line[..open].TrimEnd();
-        var after = line[(close + 1)..];
-        return before + after;
     }
 }

--- a/src/Humans.Infrastructure/Services/GuideRenderer.cs
+++ b/src/Humans.Infrastructure/Services/GuideRenderer.cs
@@ -1,0 +1,38 @@
+using Markdig;
+using Microsoft.Extensions.Options;
+using Humans.Application.Constants;
+using Humans.Application.Interfaces;
+using Humans.Infrastructure.Configuration;
+
+namespace Humans.Infrastructure.Services;
+
+public sealed class GuideRenderer : IGuideRenderer
+{
+    private static readonly MarkdownPipeline Pipeline = new MarkdownPipelineBuilder()
+        .UseAdvancedExtensions()
+        .Build();
+
+    private readonly IOptions<GuideSettings> _settings;
+    private readonly GuideMarkdownPreprocessor _preprocessor;
+    private readonly GuideHtmlPostprocessor _postprocessor;
+
+    public GuideRenderer(
+        IOptions<GuideSettings> settings,
+        GuideMarkdownPreprocessor preprocessor,
+        GuideHtmlPostprocessor postprocessor)
+    {
+        _settings = settings;
+        _preprocessor = preprocessor;
+        _postprocessor = postprocessor;
+    }
+
+    public string Render(string markdown, string fileStem)
+    {
+        ArgumentNullException.ThrowIfNull(markdown);
+        ArgumentException.ThrowIfNullOrWhiteSpace(fileStem);
+
+        var wrapped = _preprocessor.Wrap(markdown);
+        var rendered = Markdown.ToHtml(wrapped, Pipeline);
+        return _postprocessor.Rewrite(rendered, _settings.Value, GuideFiles.All);
+    }
+}

--- a/src/Humans.Infrastructure/Services/GuideRoleResolver.cs
+++ b/src/Humans.Infrastructure/Services/GuideRoleResolver.cs
@@ -1,0 +1,71 @@
+using System.Security.Claims;
+using Microsoft.EntityFrameworkCore;
+using Humans.Application.Interfaces;
+using Humans.Application.Models;
+using Humans.Domain.Constants;
+using Humans.Domain.Enums;
+using Humans.Infrastructure.Data;
+
+namespace Humans.Infrastructure.Services;
+
+public sealed class GuideRoleResolver : IGuideRoleResolver
+{
+    private static readonly IReadOnlyList<string> KnownRoles =
+    [
+        RoleNames.Admin,
+        RoleNames.Board,
+        RoleNames.TeamsAdmin,
+        RoleNames.CampAdmin,
+        RoleNames.TicketAdmin,
+        RoleNames.NoInfoAdmin,
+        RoleNames.FeedbackAdmin,
+        RoleNames.HumanAdmin,
+        RoleNames.FinanceAdmin,
+        RoleNames.ConsentCoordinator,
+        RoleNames.VolunteerCoordinator
+    ];
+
+    private readonly HumansDbContext _db;
+
+    public GuideRoleResolver(HumansDbContext db)
+    {
+        _db = db;
+    }
+
+    public async Task<GuideRoleContext> ResolveAsync(ClaimsPrincipal user, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(user);
+
+        if (user.Identity is null || !user.Identity.IsAuthenticated)
+        {
+            return GuideRoleContext.Anonymous;
+        }
+
+        var systemRoles = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var role in KnownRoles)
+        {
+            if (user.IsInRole(role))
+            {
+                systemRoles.Add(role);
+            }
+        }
+
+        var userIdClaim = user.FindFirstValue(ClaimTypes.NameIdentifier);
+        var isCoordinator = false;
+        if (Guid.TryParse(userIdClaim, out var userId))
+        {
+            isCoordinator = await _db.TeamMembers
+                .AsNoTracking()
+                .AnyAsync(
+                    tm => tm.UserId == userId
+                          && tm.Role == TeamMemberRole.Coordinator
+                          && tm.LeftAt == null,
+                    cancellationToken);
+        }
+
+        return new GuideRoleContext(
+            IsAuthenticated: true,
+            IsTeamCoordinator: isCoordinator,
+            SystemRoles: systemRoles);
+    }
+}

--- a/src/Humans.Web/Controllers/GuideController.cs
+++ b/src/Humans.Web/Controllers/GuideController.cs
@@ -55,6 +55,7 @@ public class GuideController : Controller
 
         if (canonical is null)
         {
+            Response.StatusCode = StatusCodes.Status404NotFound;
             return View("NotFound", BuildSidebar(null));
         }
 
@@ -65,6 +66,7 @@ public class GuideController : Controller
         }
         catch (GuideContentUnavailableException)
         {
+            Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
             return View("Unavailable", BuildSidebar(canonical));
         }
 

--- a/src/Humans.Web/Controllers/GuideController.cs
+++ b/src/Humans.Web/Controllers/GuideController.cs
@@ -1,0 +1,112 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Mvc;
+using Humans.Application.Constants;
+using Humans.Application.Interfaces;
+using Humans.Application.Services;
+using Humans.Web.Authorization;
+using Humans.Web.Models;
+
+namespace Humans.Web.Controllers;
+
+[Route("Guide")]
+public class GuideController : Controller
+{
+    private readonly IGuideContentService _content;
+    private readonly IGuideRoleResolver _roles;
+
+    public GuideController(IGuideContentService content, IGuideRoleResolver roles)
+    {
+        _content = content;
+        _roles = roles;
+    }
+
+    [HttpGet("")]
+    [AllowAnonymous]
+    public Task<IActionResult> Index(CancellationToken cancellationToken) =>
+        RenderAsync(GuideFiles.Readme, cancellationToken);
+
+    [HttpGet("{name}")]
+    [AllowAnonymous]
+    public Task<IActionResult> Document(string name, CancellationToken cancellationToken) =>
+        RenderAsync(name, cancellationToken);
+
+    [HttpPost("Refresh")]
+    [Authorize(Policy = PolicyNames.AdminOnly)]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Refresh(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _content.RefreshAllAsync(cancellationToken);
+            TempData["GuideRefreshStatus"] = "Guide refreshed from GitHub.";
+        }
+        catch (GuideContentUnavailableException ex)
+        {
+            TempData["GuideRefreshStatus"] = $"Refresh failed: {ex.Message}";
+        }
+        return RedirectToAction(nameof(Index));
+    }
+
+    private async Task<IActionResult> RenderAsync(string requestedStem, CancellationToken cancellationToken)
+    {
+        var canonical = GuideFiles.All.FirstOrDefault(s =>
+            s.Equals(requestedStem, StringComparison.OrdinalIgnoreCase));
+
+        if (canonical is null)
+        {
+            return View("NotFound", BuildSidebar(null));
+        }
+
+        string rendered;
+        try
+        {
+            rendered = await _content.GetRenderedAsync(canonical, cancellationToken);
+        }
+        catch (GuideContentUnavailableException)
+        {
+            return View("Unavailable", BuildSidebar(canonical));
+        }
+
+        var roleContext = await _roles.ResolveAsync(User, cancellationToken);
+        var filtered = GuideFilter.Apply(rendered, roleContext);
+
+        var viewModel = new GuideViewModel
+        {
+            Title = DisplayName(canonical),
+            Html = new HtmlString(filtered),
+            Sidebar = BuildSidebar(canonical),
+            FileStem = canonical
+        };
+
+        ViewData["Title"] = viewModel.Title;
+        return View(canonical.Equals(GuideFiles.Readme, StringComparison.OrdinalIgnoreCase)
+            ? "Index"
+            : "Document", viewModel);
+    }
+
+    private static GuideSidebarModel BuildSidebar(string? activeStem)
+    {
+        var entries = new List<GuideSidebarEntry>
+        {
+            new(GuideFiles.GettingStarted, "Getting Started", "Start here")
+        };
+        foreach (var section in GuideFiles.Sections)
+        {
+            entries.Add(new GuideSidebarEntry(section, DisplayName(section), "Section guides"));
+        }
+        entries.Add(new GuideSidebarEntry(GuideFiles.Glossary, "Glossary", "Appendix"));
+        return new GuideSidebarModel { Entries = entries, ActiveStem = activeStem };
+    }
+
+    private static string DisplayName(string stem) => stem switch
+    {
+        GuideFiles.Readme => "Guide",
+        GuideFiles.GettingStarted => "Getting Started",
+        GuideFiles.Glossary => "Glossary",
+        "LegalAndConsent" => "Legal & Consent",
+        "CityPlanning" => "City Planning",
+        "GoogleIntegration" => "Google Integration",
+        _ => stem
+    };
+}

--- a/src/Humans.Web/Extensions/Infrastructure/ConfigurationMetadataExtensions.cs
+++ b/src/Humans.Web/Extensions/Infrastructure/ConfigurationMetadataExtensions.cs
@@ -29,6 +29,14 @@ internal static class ConfigurationMetadataExtensions
             configuration.GetRequiredSetting(configRegistry, "GitHub:Repository", "GitHub");
             configuration.GetRequiredSetting(configRegistry, "GitHub:AccessToken", "GitHub", isSensitive: true);
 
+            // Guide settings
+            configuration.GetOptionalSetting(configRegistry, "Guide:Owner", "Guide");
+            configuration.GetOptionalSetting(configRegistry, "Guide:Repository", "Guide");
+            configuration.GetOptionalSetting(configRegistry, "Guide:Branch", "Guide");
+            configuration.GetOptionalSetting(configRegistry, "Guide:FolderPath", "Guide");
+            configuration.GetOptionalSetting(configRegistry, "Guide:CacheTtlHours", "Guide");
+            configuration.GetOptionalSetting(configRegistry, "Guide:AccessToken", "Guide", isSensitive: true);
+
             // Google Maps
             configuration.GetRequiredSetting(configRegistry, "GoogleMaps:ApiKey", "Google Maps", isSensitive: true);
 

--- a/src/Humans.Web/Extensions/InfrastructureServiceCollectionExtensions.cs
+++ b/src/Humans.Web/Extensions/InfrastructureServiceCollectionExtensions.cs
@@ -40,6 +40,7 @@ public static class InfrastructureServiceCollectionExtensions
         services.AddAuditLogSection();
         services.AddGdprSection();
         services.AddAdminSection();
+        services.AddGuideSection(configuration);
 
         return services;
     }

--- a/src/Humans.Web/Extensions/Sections/GuideSectionExtensions.cs
+++ b/src/Humans.Web/Extensions/Sections/GuideSectionExtensions.cs
@@ -1,0 +1,25 @@
+using Humans.Application.Interfaces;
+using Humans.Infrastructure.Configuration;
+using Humans.Infrastructure.Services;
+
+namespace Humans.Web.Extensions.Sections;
+
+internal static class GuideSectionExtensions
+{
+    internal static IServiceCollection AddGuideSection(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        services.Configure<GuideSettings>(configuration.GetSection(GuideSettings.SectionName));
+
+        // Guide (in-app docs from GitHub, memory-cached, role-filtered)
+        services.AddSingleton<GuideMarkdownPreprocessor>();
+        services.AddSingleton<GuideHtmlPostprocessor>();
+        services.AddSingleton<IGuideRenderer, GuideRenderer>();
+        services.AddSingleton<IGuideContentSource, GitHubGuideContentSource>();
+        services.AddSingleton<IGuideContentService, GuideContentService>();
+        services.AddScoped<IGuideRoleResolver, GuideRoleResolver>();
+
+        return services;
+    }
+}

--- a/src/Humans.Web/Models/GuideSidebarModel.cs
+++ b/src/Humans.Web/Models/GuideSidebarModel.cs
@@ -1,0 +1,9 @@
+namespace Humans.Web.Models;
+
+public sealed record GuideSidebarEntry(string Stem, string DisplayName, string Group);
+
+public sealed class GuideSidebarModel
+{
+    public required IReadOnlyList<GuideSidebarEntry> Entries { get; init; }
+    public required string? ActiveStem { get; init; }
+}

--- a/src/Humans.Web/Models/GuideViewModel.cs
+++ b/src/Humans.Web/Models/GuideViewModel.cs
@@ -1,0 +1,11 @@
+using Microsoft.AspNetCore.Html;
+
+namespace Humans.Web.Models;
+
+public sealed class GuideViewModel
+{
+    public required string Title { get; init; }
+    public required HtmlString Html { get; init; }
+    public required GuideSidebarModel Sidebar { get; init; }
+    public required string? FileStem { get; init; }
+}

--- a/src/Humans.Web/Views/Guide/Document.cshtml
+++ b/src/Humans.Web/Views/Guide/Document.cshtml
@@ -1,0 +1,6 @@
+@model Humans.Web.Models.GuideViewModel
+@{
+    ViewData["Title"] = Model.Title;
+}
+
+@await Html.PartialAsync("_GuideLayout", Model)

--- a/src/Humans.Web/Views/Guide/Index.cshtml
+++ b/src/Humans.Web/Views/Guide/Index.cshtml
@@ -1,0 +1,8 @@
+@model Humans.Web.Models.GuideViewModel
+@{
+    ViewData["Title"] = Model.Title;
+}
+
+<h1 class="mb-4">Guide</h1>
+
+@await Html.PartialAsync("_GuideLayout", Model)

--- a/src/Humans.Web/Views/Guide/NotFound.cshtml
+++ b/src/Humans.Web/Views/Guide/NotFound.cshtml
@@ -1,0 +1,11 @@
+@model Humans.Web.Models.GuideSidebarModel
+@{
+    ViewData["Title"] = "Guide — Not found";
+}
+
+<div class="row">
+    <section class="col-md-9 offset-md-3">
+        <h1>Page not found</h1>
+        <p>That guide page does not exist. <a asp-controller="Guide" asp-action="Index">Return to the Guide home</a>.</p>
+    </section>
+</div>

--- a/src/Humans.Web/Views/Guide/Unavailable.cshtml
+++ b/src/Humans.Web/Views/Guide/Unavailable.cshtml
@@ -1,0 +1,11 @@
+@model Humans.Web.Models.GuideSidebarModel
+@{
+    ViewData["Title"] = "Guide — Temporarily unavailable";
+}
+
+<div class="row">
+    <section class="col-md-9 offset-md-3">
+        <h1>Guide temporarily unavailable</h1>
+        <p>We couldn't load the guide content right now. Please try again in a few minutes.</p>
+    </section>
+</div>

--- a/src/Humans.Web/Views/Shared/_GuideLayout.cshtml
+++ b/src/Humans.Web/Views/Shared/_GuideLayout.cshtml
@@ -1,0 +1,50 @@
+@model Humans.Web.Models.GuideViewModel
+
+<div class="row">
+    <aside class="col-md-3 mb-4">
+        <nav class="nav flex-column" aria-label="Guide navigation">
+            @foreach (var group in Model.Sidebar.Entries.GroupBy(e => e.Group))
+            {
+                <div class="text-uppercase text-muted small mt-3 mb-1">@group.Key</div>
+                @foreach (var entry in group)
+                {
+                    var active = string.Equals(entry.Stem, Model.Sidebar.ActiveStem, StringComparison.OrdinalIgnoreCase);
+                    <a class="nav-link @(active ? "active fw-bold" : "")"
+                       asp-controller="Guide" asp-action="Document" asp-route-name="@entry.Stem">
+                        @entry.DisplayName
+                    </a>
+                }
+            }
+        </nav>
+    </aside>
+    <section class="col-md-9">
+        @if (!string.IsNullOrEmpty(Model.FileStem) && !string.Equals(Model.FileStem, "README", StringComparison.OrdinalIgnoreCase))
+        {
+            <nav aria-label="breadcrumb">
+                <ol class="breadcrumb">
+                    <li class="breadcrumb-item"><a asp-controller="Guide" asp-action="Index">Guide</a></li>
+                    <li class="breadcrumb-item active" aria-current="page">@Model.Title</li>
+                </ol>
+            </nav>
+        }
+
+        @if (TempData["GuideRefreshStatus"] is string status)
+        {
+            <div class="alert alert-info">@status</div>
+        }
+
+        <article class="guide-content">
+            @Model.Html
+        </article>
+
+        @if (User.IsInRole(Humans.Domain.Constants.RoleNames.Admin))
+        {
+            <form asp-action="Refresh" method="post" class="mt-4">
+                @Html.AntiForgeryToken()
+                <button type="submit" class="btn btn-outline-secondary btn-sm">
+                    Refresh from GitHub
+                </button>
+            </form>
+        }
+    </section>
+</div>

--- a/tests/Humans.Application.Tests/Services/GuideContentServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/GuideContentServiceTests.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Options;
 using Humans.Application.Interfaces;
 using Humans.Infrastructure.Configuration;
 using Humans.Infrastructure.Services;
+using Humans.Testing;
 using Xunit;
 
 namespace Humans.Application.Tests.Services;
@@ -43,7 +44,7 @@ public class GuideContentServiceTests
             NullLogger<GuideContentService>.Instance);
     }
 
-    [Fact]
+    [HumansFact]
     public async Task GetRenderedAsync_FirstCall_FetchesFromSource()
     {
         var source = new FakeSource();
@@ -55,7 +56,7 @@ public class GuideContentServiceTests
         source.Calls.Should().BeGreaterThan(0);
     }
 
-    [Fact]
+    [HumansFact]
     public async Task GetRenderedAsync_SecondCall_ServedFromCache()
     {
         var source = new FakeSource();
@@ -68,7 +69,7 @@ public class GuideContentServiceTests
         source.Calls.Should().Be(callsAfterFirst);
     }
 
-    [Fact]
+    [HumansFact]
     public async Task RefreshAllAsync_ClearsAndRefetches()
     {
         var source = new FakeSource();
@@ -81,7 +82,7 @@ public class GuideContentServiceTests
         source.Calls.Should().BeGreaterThan(callsBefore);
     }
 
-    [Fact]
+    [HumansFact]
     public async Task GetRenderedAsync_UnknownFile_Throws()
     {
         var source = new FakeSource();
@@ -92,7 +93,7 @@ public class GuideContentServiceTests
         await act.Should().ThrowAsync<FileNotFoundException>();
     }
 
-    [Fact]
+    [HumansFact]
     public async Task GetRenderedAsync_ColdCacheGitHubFailure_ThrowsUnavailable()
     {
         var source = new FakeSource { FailFor = _ => new InvalidOperationException("network down") };
@@ -103,7 +104,7 @@ public class GuideContentServiceTests
         await act.Should().ThrowAsync<GuideContentUnavailableException>();
     }
 
-    [Fact]
+    [HumansFact]
     public async Task GetRenderedAsync_WarmCacheThenSourceFails_ServesStale()
     {
         var source = new FakeSource();

--- a/tests/Humans.Application.Tests/Services/GuideContentServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/GuideContentServiceTests.cs
@@ -1,0 +1,122 @@
+using AwesomeAssertions;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Humans.Application.Interfaces;
+using Humans.Infrastructure.Configuration;
+using Humans.Infrastructure.Services;
+using Xunit;
+
+namespace Humans.Application.Tests.Services;
+
+public class GuideContentServiceTests
+{
+    private sealed class FakeSource : IGuideContentSource
+    {
+        public int Calls { get; private set; }
+        public Func<string, string> MarkdownFor { get; set; } = stem => $"# {stem}\n\nContent.";
+        public Func<string, Exception?> FailFor { get; set; } = _ => null;
+
+        public Task<string> GetMarkdownAsync(string fileStem, CancellationToken cancellationToken = default)
+        {
+            Calls++;
+            var fail = FailFor(fileStem);
+            if (fail is not null) throw fail;
+            return Task.FromResult(MarkdownFor(fileStem));
+        }
+    }
+
+    private sealed class StubRenderer : IGuideRenderer
+    {
+        public string Render(string markdown, string fileStem) => $"[rendered:{fileStem}]";
+    }
+
+    private static GuideContentService CreateService(FakeSource source, out IMemoryCache cache)
+    {
+        cache = new MemoryCache(new MemoryCacheOptions());
+        var settings = Options.Create(new GuideSettings { CacheTtlHours = 6 });
+        return new GuideContentService(
+            source,
+            new StubRenderer(),
+            cache,
+            settings,
+            NullLogger<GuideContentService>.Instance);
+    }
+
+    [Fact]
+    public async Task GetRenderedAsync_FirstCall_FetchesFromSource()
+    {
+        var source = new FakeSource();
+        var service = CreateService(source, out _);
+
+        var html = await service.GetRenderedAsync("Profiles", CancellationToken.None);
+
+        html.Should().Be("[rendered:Profiles]");
+        source.Calls.Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public async Task GetRenderedAsync_SecondCall_ServedFromCache()
+    {
+        var source = new FakeSource();
+        var service = CreateService(source, out _);
+
+        await service.GetRenderedAsync("Profiles", CancellationToken.None);
+        var callsAfterFirst = source.Calls;
+        await service.GetRenderedAsync("Profiles", CancellationToken.None);
+
+        source.Calls.Should().Be(callsAfterFirst);
+    }
+
+    [Fact]
+    public async Task RefreshAllAsync_ClearsAndRefetches()
+    {
+        var source = new FakeSource();
+        var service = CreateService(source, out _);
+        await service.GetRenderedAsync("Profiles", CancellationToken.None);
+        var callsBefore = source.Calls;
+
+        await service.RefreshAllAsync(CancellationToken.None);
+
+        source.Calls.Should().BeGreaterThan(callsBefore);
+    }
+
+    [Fact]
+    public async Task GetRenderedAsync_UnknownFile_Throws()
+    {
+        var source = new FakeSource();
+        var service = CreateService(source, out _);
+
+        var act = async () => await service.GetRenderedAsync("DoesNotExist", CancellationToken.None);
+
+        await act.Should().ThrowAsync<FileNotFoundException>();
+    }
+
+    [Fact]
+    public async Task GetRenderedAsync_ColdCacheGitHubFailure_ThrowsUnavailable()
+    {
+        var source = new FakeSource { FailFor = _ => new InvalidOperationException("network down") };
+        var service = CreateService(source, out _);
+
+        var act = async () => await service.GetRenderedAsync("Profiles", CancellationToken.None);
+
+        await act.Should().ThrowAsync<GuideContentUnavailableException>();
+    }
+
+    [Fact]
+    public async Task GetRenderedAsync_WarmCacheThenSourceFails_ServesStale()
+    {
+        var source = new FakeSource();
+        var service = CreateService(source, out var cache);
+        await service.GetRenderedAsync("Profiles", CancellationToken.None);
+
+        // Simulate TTL-expired warm cache by clearing only the sentinel, leaving stale entries.
+        // Implementation detail: the service tracks a "populated" flag separately from entries.
+        source.FailFor = _ => new InvalidOperationException("flaky");
+        await service.RefreshAllAsync(CancellationToken.None); // should NOT throw — stale content present
+
+        var html = await service.GetRenderedAsync("Profiles", CancellationToken.None);
+
+        html.Should().Be("[rendered:Profiles]");
+    }
+}

--- a/tests/Humans.Application.Tests/Services/GuideFilterTests.cs
+++ b/tests/Humans.Application.Tests/Services/GuideFilterTests.cs
@@ -1,0 +1,148 @@
+using AwesomeAssertions;
+using Humans.Application.Models;
+using Humans.Application.Services;
+using Humans.Domain.Constants;
+using Xunit;
+
+namespace Humans.Application.Tests.Services;
+
+public class GuideFilterTests
+{
+    private const string Sample = """
+        <p>Intro, always visible.</p>
+        <div data-guide-role="volunteer" data-guide-roles="">
+          <h2>As a Volunteer</h2>
+          <p>Volunteer content.</p>
+        </div>
+        <div data-guide-role="coordinator" data-guide-roles="ConsentCoordinator">
+          <h2>As a Coordinator (Consent Coordinator)</h2>
+          <p>Coord content.</p>
+        </div>
+        <div data-guide-role="boardadmin" data-guide-roles="TeamsAdmin">
+          <h2>As a Board member / Admin (Teams Admin)</h2>
+          <p>Teams admin content.</p>
+        </div>
+        <h2>Related sections</h2>
+        <p>Always visible.</p>
+        """;
+
+    private static GuideRoleContext Roles(bool isCoord, params string[] systemRoles) =>
+        new(IsAuthenticated: true, IsTeamCoordinator: isCoord,
+            SystemRoles: new HashSet<string>(systemRoles, StringComparer.Ordinal));
+
+    [Fact]
+    public void Apply_Anonymous_KeepsOnlyVolunteerBlock()
+    {
+        var result = GuideFilter.Apply(Sample, GuideRoleContext.Anonymous);
+
+        result.Should().Contain("Volunteer content.");
+        result.Should().Contain("Intro, always visible.");
+        result.Should().Contain("Related sections");
+        result.Should().NotContain("Coord content.");
+        result.Should().NotContain("Teams admin content.");
+    }
+
+    [Fact]
+    public void Apply_PlainVolunteer_SameAsAnonymous()
+    {
+        var result = GuideFilter.Apply(Sample, Roles(isCoord: false));
+
+        result.Should().Contain("Volunteer content.");
+        result.Should().NotContain("Coord content.");
+        result.Should().NotContain("Teams admin content.");
+    }
+
+    [Fact]
+    public void Apply_TeamCoordinator_SeesVolunteerAndCoordinator()
+    {
+        var result = GuideFilter.Apply(Sample, Roles(isCoord: true));
+
+        result.Should().Contain("Volunteer content.");
+        result.Should().Contain("Coord content.");
+        result.Should().NotContain("Teams admin content.");
+    }
+
+    [Fact]
+    public void Apply_ConsentCoordinatorRoleOnly_SeesCoordinatorBlockByParenthetical()
+    {
+        var result = GuideFilter.Apply(Sample, Roles(isCoord: false, RoleNames.ConsentCoordinator));
+
+        result.Should().Contain("Coord content.");
+        result.Should().NotContain("Teams admin content.");
+    }
+
+    [Fact]
+    public void Apply_ConsentCoordinatorOnBareCoordinatorHeading_NotVisible()
+    {
+        const string bareCoord = """
+            <div data-guide-role="coordinator" data-guide-roles="">
+              <h2>As a Coordinator</h2>
+              <p>Bare coord content.</p>
+            </div>
+            """;
+
+        var result = GuideFilter.Apply(bareCoord, Roles(isCoord: false, RoleNames.ConsentCoordinator));
+
+        result.Should().NotContain("Bare coord content.");
+    }
+
+    [Fact]
+    public void Apply_TeamsAdmin_SeesCoordinatorAndBoardOnTeamsFile()
+    {
+        // Within-file superset: seeing Board/Admin via (Teams Admin) implies seeing Coordinator too.
+        var result = GuideFilter.Apply(Sample, Roles(isCoord: false, RoleNames.TeamsAdmin));
+
+        result.Should().Contain("Coord content.");
+        result.Should().Contain("Teams admin content.");
+    }
+
+    [Fact]
+    public void Apply_TeamsAdminOnTicketsFile_SeesNothingBeyondVolunteer()
+    {
+        const string ticketsLike = """
+            <div data-guide-role="volunteer" data-guide-roles="">V</div>
+            <div data-guide-role="coordinator" data-guide-roles="">C</div>
+            <div data-guide-role="boardadmin" data-guide-roles="TicketAdmin">BA</div>
+            """;
+
+        var result = GuideFilter.Apply(ticketsLike, Roles(isCoord: false, RoleNames.TeamsAdmin));
+
+        result.Should().Contain("V");
+        result.Should().NotContain(">C<");
+        result.Should().NotContain("BA");
+    }
+
+    [Fact]
+    public void Apply_Admin_SeesEverything()
+    {
+        var result = GuideFilter.Apply(Sample, Roles(isCoord: false, RoleNames.Admin));
+
+        result.Should().Contain("Volunteer content.");
+        result.Should().Contain("Coord content.");
+        result.Should().Contain("Teams admin content.");
+    }
+
+    [Fact]
+    public void Apply_Board_SeesAllBoardAdminBlocksRegardlessOfParenthetical()
+    {
+        const string mixed = """
+            <div data-guide-role="boardadmin" data-guide-roles="">Plain</div>
+            <div data-guide-role="boardadmin" data-guide-roles="CampAdmin">Camp-scoped</div>
+            """;
+
+        var result = GuideFilter.Apply(mixed, Roles(isCoord: false, RoleNames.Board));
+
+        result.Should().Contain("Plain");
+        result.Should().Contain("Camp-scoped");
+    }
+
+    [Fact]
+    public void Apply_NoRoleDivs_ReturnsUnchanged()
+    {
+        const string plain = "<p>Glossary entries.</p>";
+
+        var result = GuideFilter.Apply(plain, GuideRoleContext.Anonymous);
+
+        result.Should().Be(plain);
+    }
+}

--- a/tests/Humans.Application.Tests/Services/GuideFilterTests.cs
+++ b/tests/Humans.Application.Tests/Services/GuideFilterTests.cs
@@ -2,6 +2,7 @@ using AwesomeAssertions;
 using Humans.Application.Models;
 using Humans.Application.Services;
 using Humans.Domain.Constants;
+using Humans.Testing;
 using Xunit;
 
 namespace Humans.Application.Tests.Services;
@@ -30,7 +31,7 @@ public class GuideFilterTests
         new(IsAuthenticated: true, IsTeamCoordinator: isCoord,
             SystemRoles: new HashSet<string>(systemRoles, StringComparer.Ordinal));
 
-    [Fact]
+    [HumansFact]
     public void Apply_Anonymous_KeepsOnlyVolunteerBlock()
     {
         var result = GuideFilter.Apply(Sample, GuideRoleContext.Anonymous);
@@ -42,7 +43,7 @@ public class GuideFilterTests
         result.Should().NotContain("Teams admin content.");
     }
 
-    [Fact]
+    [HumansFact]
     public void Apply_PlainVolunteer_SameAsAnonymous()
     {
         var result = GuideFilter.Apply(Sample, Roles(isCoord: false));
@@ -52,7 +53,7 @@ public class GuideFilterTests
         result.Should().NotContain("Teams admin content.");
     }
 
-    [Fact]
+    [HumansFact]
     public void Apply_TeamCoordinator_SeesVolunteerAndCoordinator()
     {
         var result = GuideFilter.Apply(Sample, Roles(isCoord: true));
@@ -62,7 +63,7 @@ public class GuideFilterTests
         result.Should().NotContain("Teams admin content.");
     }
 
-    [Fact]
+    [HumansFact]
     public void Apply_ConsentCoordinatorRoleOnly_SeesCoordinatorBlockByParenthetical()
     {
         var result = GuideFilter.Apply(Sample, Roles(isCoord: false, RoleNames.ConsentCoordinator));
@@ -71,7 +72,7 @@ public class GuideFilterTests
         result.Should().NotContain("Teams admin content.");
     }
 
-    [Fact]
+    [HumansFact]
     public void Apply_ConsentCoordinatorOnBareCoordinatorHeading_NotVisible()
     {
         const string bareCoord = """
@@ -86,7 +87,7 @@ public class GuideFilterTests
         result.Should().NotContain("Bare coord content.");
     }
 
-    [Fact]
+    [HumansFact]
     public void Apply_TeamsAdmin_SeesCoordinatorAndBoardOnTeamsFile()
     {
         // Within-file superset: seeing Board/Admin via (Teams Admin) implies seeing Coordinator too.
@@ -96,7 +97,7 @@ public class GuideFilterTests
         result.Should().Contain("Teams admin content.");
     }
 
-    [Fact]
+    [HumansFact]
     public void Apply_TeamsAdminOnTicketsFile_SeesNothingBeyondVolunteer()
     {
         const string ticketsLike = """
@@ -112,7 +113,7 @@ public class GuideFilterTests
         result.Should().NotContain("BA");
     }
 
-    [Fact]
+    [HumansFact]
     public void Apply_Admin_SeesEverything()
     {
         var result = GuideFilter.Apply(Sample, Roles(isCoord: false, RoleNames.Admin));
@@ -122,7 +123,7 @@ public class GuideFilterTests
         result.Should().Contain("Teams admin content.");
     }
 
-    [Fact]
+    [HumansFact]
     public void Apply_Board_SeesAllBoardAdminBlocksRegardlessOfParenthetical()
     {
         const string mixed = """
@@ -136,7 +137,7 @@ public class GuideFilterTests
         result.Should().Contain("Camp-scoped");
     }
 
-    [Fact]
+    [HumansFact]
     public void Apply_NoRoleDivs_ReturnsUnchanged()
     {
         const string plain = "<p>Glossary entries.</p>";

--- a/tests/Humans.Application.Tests/Services/GuideHtmlPostprocessorTests.cs
+++ b/tests/Humans.Application.Tests/Services/GuideHtmlPostprocessorTests.cs
@@ -133,4 +133,48 @@ public class GuideHtmlPostprocessorTests
 
         result.Should().Contain("""src="https://cdn.example.com/x.png" """.Trim());
     }
+
+    [Fact]
+    public void Rewrite_InlineCodeAppPath_WrappedInAnchor()
+    {
+        const string html = "<p>Go to <code>/Profile/Me</code> to view your profile.</p>";
+
+        var result = Processor.Rewrite(html, Settings, GuideFiles.All);
+
+        result.Should().Contain("""<a href="/Profile/Me" class="guide-app-path"><code>/Profile/Me</code></a>""");
+    }
+
+    [Fact]
+    public void Rewrite_InlineCodeAppPathWithSegments_WrappedInAnchor()
+    {
+        const string html = "<code>/Profile/Me/Edit</code>";
+
+        var result = Processor.Rewrite(html, Settings, GuideFiles.All);
+
+        result.Should().Contain("""href="/Profile/Me/Edit" """.Trim());
+    }
+
+    [Fact]
+    public void Rewrite_InlineCodeRouteTemplate_LeftAsIs()
+    {
+        // Routes with "{id}" placeholders should NOT be linked — clicking /Profile/{id} would 404.
+        const string html = "<code>/Profile/{id}/Admin</code>";
+
+        var result = Processor.Rewrite(html, Settings, GuideFiles.All);
+
+        result.Should().NotContain("<a href=");
+        result.Should().Contain("<code>/Profile/{id}/Admin</code>");
+    }
+
+    [Fact]
+    public void Rewrite_InlineCodeNonPath_LeftAsIs()
+    {
+        // Not a path (doesn't start with "/") — it's a config key or a literal value.
+        const string html = "<p>Set <code>Guide:Owner</code> to your fork.</p>";
+
+        var result = Processor.Rewrite(html, Settings, GuideFiles.All);
+
+        result.Should().NotContain("<a href=");
+        result.Should().Contain("<code>Guide:Owner</code>");
+    }
 }

--- a/tests/Humans.Application.Tests/Services/GuideHtmlPostprocessorTests.cs
+++ b/tests/Humans.Application.Tests/Services/GuideHtmlPostprocessorTests.cs
@@ -2,6 +2,7 @@ using AwesomeAssertions;
 using Humans.Application.Constants;
 using Humans.Infrastructure.Configuration;
 using Humans.Infrastructure.Services;
+using Humans.Testing;
 using Xunit;
 
 namespace Humans.Application.Tests.Services;
@@ -18,7 +19,7 @@ public class GuideHtmlPostprocessorTests
 
     private static readonly GuideHtmlPostprocessor Processor = new();
 
-    [Fact]
+    [HumansFact]
     public void Rewrite_SiblingMdLink_BecomesGuideRoute()
     {
         const string html = """<a href="Profiles.md">Profiles</a>""";
@@ -28,7 +29,7 @@ public class GuideHtmlPostprocessorTests
         result.Should().Contain("""href="/Guide/Profiles" """.Trim());
     }
 
-    [Fact]
+    [HumansFact]
     public void Rewrite_SiblingMdWithFragment_PreservesFragment()
     {
         const string html = """<a href="Glossary.md#coordinator">Coordinator</a>""";
@@ -38,7 +39,7 @@ public class GuideHtmlPostprocessorTests
         result.Should().Contain("""href="/Guide/Glossary#coordinator" """.Trim());
     }
 
-    [Fact]
+    [HumansFact]
     public void Rewrite_SiblingMdCaseInsensitive_MatchesKnown()
     {
         const string html = """<a href="profiles.md">Profiles</a>""";
@@ -48,7 +49,7 @@ public class GuideHtmlPostprocessorTests
         result.Should().Contain("/Guide/Profiles");
     }
 
-    [Fact]
+    [HumansFact]
     public void Rewrite_UnknownSiblingMd_LeftAsExternal()
     {
         const string html = """<a href="NonExistent.md">Link</a>""";
@@ -60,7 +61,7 @@ public class GuideHtmlPostprocessorTests
         result.Should().Contain("target=\"_blank\"");
     }
 
-    [Fact]
+    [HumansFact]
     public void Rewrite_AppPathLink_LeftAsIs()
     {
         const string html = """<a href="/Profile/Me/Edit">Edit</a>""";
@@ -71,7 +72,7 @@ public class GuideHtmlPostprocessorTests
         result.Should().NotContain("target=\"_blank\"");
     }
 
-    [Fact]
+    [HumansFact]
     public void Rewrite_ExternalHttpLink_GetsNewTabAttrs()
     {
         const string html = """<a href="https://example.com/foo">x</a>""";
@@ -82,7 +83,7 @@ public class GuideHtmlPostprocessorTests
         result.Should().Contain("rel=\"noopener\"");
     }
 
-    [Fact]
+    [HumansFact]
     public void Rewrite_MailtoLink_LeftAsIs()
     {
         const string html = """<a href="mailto:a@b.com">a</a>""";
@@ -93,7 +94,7 @@ public class GuideHtmlPostprocessorTests
         result.Should().NotContain("target=\"_blank\"");
     }
 
-    [Fact]
+    [HumansFact]
     public void Rewrite_ParentRelativePath_BecomesGitHubBlobUrl()
     {
         const string html = """<a href="../sections/Teams.md">Section invariants</a>""";
@@ -104,7 +105,7 @@ public class GuideHtmlPostprocessorTests
         result.Should().Contain("target=\"_blank\"");
     }
 
-    [Fact]
+    [HumansFact]
     public void Rewrite_ImageShortPath_BecomesRawGitHubUrl()
     {
         const string html = """<img src="img/screenshot.png" alt="x" />""";
@@ -114,7 +115,7 @@ public class GuideHtmlPostprocessorTests
         result.Should().Contain("""src="https://raw.githubusercontent.com/nobodies-collective/Humans/main/docs/guide/img/screenshot.png" """.Trim());
     }
 
-    [Fact]
+    [HumansFact]
     public void Rewrite_ImageWithDocsGuidePrefix_AlsoRewritten()
     {
         const string html = """<img src="docs/guide/img/screenshot.png" alt="x" />""";
@@ -124,7 +125,7 @@ public class GuideHtmlPostprocessorTests
         result.Should().Contain("https://raw.githubusercontent.com/nobodies-collective/Humans/main/docs/guide/img/screenshot.png");
     }
 
-    [Fact]
+    [HumansFact]
     public void Rewrite_ImageAbsoluteUrl_LeftAsIs()
     {
         const string html = """<img src="https://cdn.example.com/x.png" alt="x" />""";
@@ -134,7 +135,7 @@ public class GuideHtmlPostprocessorTests
         result.Should().Contain("""src="https://cdn.example.com/x.png" """.Trim());
     }
 
-    [Fact]
+    [HumansFact]
     public void Rewrite_InlineCodeAppPath_WrappedInAnchor()
     {
         const string html = "<p>Go to <code>/Profile/Me</code> to view your profile.</p>";
@@ -144,7 +145,7 @@ public class GuideHtmlPostprocessorTests
         result.Should().Contain("""<a href="/Profile/Me" class="guide-app-path"><code>/Profile/Me</code></a>""");
     }
 
-    [Fact]
+    [HumansFact]
     public void Rewrite_InlineCodeAppPathWithSegments_WrappedInAnchor()
     {
         const string html = "<code>/Profile/Me/Edit</code>";
@@ -154,7 +155,7 @@ public class GuideHtmlPostprocessorTests
         result.Should().Contain("""href="/Profile/Me/Edit" """.Trim());
     }
 
-    [Fact]
+    [HumansFact]
     public void Rewrite_InlineCodeRouteTemplate_LeftAsIs()
     {
         // Routes with "{id}" placeholders should NOT be linked — clicking /Profile/{id} would 404.
@@ -166,7 +167,7 @@ public class GuideHtmlPostprocessorTests
         result.Should().Contain("<code>/Profile/{id}/Admin</code>");
     }
 
-    [Fact]
+    [HumansFact]
     public void Rewrite_InlineCodeNonPath_LeftAsIs()
     {
         // Not a path (doesn't start with "/") — it's a config key or a literal value.

--- a/tests/Humans.Application.Tests/Services/GuideHtmlPostprocessorTests.cs
+++ b/tests/Humans.Application.Tests/Services/GuideHtmlPostprocessorTests.cs
@@ -1,0 +1,136 @@
+using AwesomeAssertions;
+using Humans.Application.Constants;
+using Humans.Infrastructure.Configuration;
+using Humans.Infrastructure.Services;
+using Xunit;
+
+namespace Humans.Application.Tests.Services;
+
+public class GuideHtmlPostprocessorTests
+{
+    private static readonly GuideSettings Settings = new()
+    {
+        Owner = "nobodies-collective",
+        Repository = "Humans",
+        Branch = "main",
+        FolderPath = "docs/guide"
+    };
+
+    private static readonly GuideHtmlPostprocessor Processor = new();
+
+    [Fact]
+    public void Rewrite_SiblingMdLink_BecomesGuideRoute()
+    {
+        const string html = """<a href="Profiles.md">Profiles</a>""";
+
+        var result = Processor.Rewrite(html, Settings, GuideFiles.All);
+
+        result.Should().Contain("""href="/Guide/Profiles" """.Trim());
+    }
+
+    [Fact]
+    public void Rewrite_SiblingMdWithFragment_PreservesFragment()
+    {
+        const string html = """<a href="Glossary.md#coordinator">Coordinator</a>""";
+
+        var result = Processor.Rewrite(html, Settings, GuideFiles.All);
+
+        result.Should().Contain("""href="/Guide/Glossary#coordinator" """.Trim());
+    }
+
+    [Fact]
+    public void Rewrite_SiblingMdCaseInsensitive_MatchesKnown()
+    {
+        const string html = """<a href="profiles.md">Profiles</a>""";
+
+        var result = Processor.Rewrite(html, Settings, GuideFiles.All);
+
+        result.Should().Contain("/Guide/Profiles");
+    }
+
+    [Fact]
+    public void Rewrite_UnknownSiblingMd_LeftAsExternal()
+    {
+        const string html = """<a href="NonExistent.md">Link</a>""";
+
+        var result = Processor.Rewrite(html, Settings, GuideFiles.All);
+
+        // Unknown siblings fall through to external github.com URL.
+        result.Should().Contain("https://github.com/nobodies-collective/Humans/blob/main/docs/guide/NonExistent.md");
+        result.Should().Contain("target=\"_blank\"");
+    }
+
+    [Fact]
+    public void Rewrite_AppPathLink_LeftAsIs()
+    {
+        const string html = """<a href="/Profile/Me/Edit">Edit</a>""";
+
+        var result = Processor.Rewrite(html, Settings, GuideFiles.All);
+
+        result.Should().Contain("""href="/Profile/Me/Edit" """.Trim());
+        result.Should().NotContain("target=\"_blank\"");
+    }
+
+    [Fact]
+    public void Rewrite_ExternalHttpLink_GetsNewTabAttrs()
+    {
+        const string html = """<a href="https://example.com/foo">x</a>""";
+
+        var result = Processor.Rewrite(html, Settings, GuideFiles.All);
+
+        result.Should().Contain("target=\"_blank\"");
+        result.Should().Contain("rel=\"noopener\"");
+    }
+
+    [Fact]
+    public void Rewrite_MailtoLink_LeftAsIs()
+    {
+        const string html = """<a href="mailto:a@b.com">a</a>""";
+
+        var result = Processor.Rewrite(html, Settings, GuideFiles.All);
+
+        result.Should().Contain("""href="mailto:a@b.com" """.Trim());
+        result.Should().NotContain("target=\"_blank\"");
+    }
+
+    [Fact]
+    public void Rewrite_ParentRelativePath_BecomesGitHubBlobUrl()
+    {
+        const string html = """<a href="../sections/Teams.md">Section invariants</a>""";
+
+        var result = Processor.Rewrite(html, Settings, GuideFiles.All);
+
+        result.Should().Contain("https://github.com/nobodies-collective/Humans/blob/main/docs/sections/Teams.md");
+        result.Should().Contain("target=\"_blank\"");
+    }
+
+    [Fact]
+    public void Rewrite_ImageShortPath_BecomesRawGitHubUrl()
+    {
+        const string html = """<img src="img/screenshot.png" alt="x" />""";
+
+        var result = Processor.Rewrite(html, Settings, GuideFiles.All);
+
+        result.Should().Contain("""src="https://raw.githubusercontent.com/nobodies-collective/Humans/main/docs/guide/img/screenshot.png" """.Trim());
+    }
+
+    [Fact]
+    public void Rewrite_ImageWithDocsGuidePrefix_AlsoRewritten()
+    {
+        const string html = """<img src="docs/guide/img/screenshot.png" alt="x" />""";
+
+        var result = Processor.Rewrite(html, Settings, GuideFiles.All);
+
+        result.Should().Contain("https://raw.githubusercontent.com/nobodies-collective/Humans/main/docs/guide/img/screenshot.png");
+    }
+
+    [Fact]
+    public void Rewrite_ImageAbsoluteUrl_LeftAsIs()
+    {
+        const string html = """<img src="https://cdn.example.com/x.png" alt="x" />""";
+
+        var result = Processor.Rewrite(html, Settings, GuideFiles.All);
+
+        result.Should().Contain("""src="https://cdn.example.com/x.png" """.Trim());
+    }
+}

--- a/tests/Humans.Application.Tests/Services/GuideMarkdownPreprocessorTests.cs
+++ b/tests/Humans.Application.Tests/Services/GuideMarkdownPreprocessorTests.cs
@@ -1,5 +1,6 @@
 using AwesomeAssertions;
 using Humans.Infrastructure.Services;
+using Humans.Testing;
 using Xunit;
 
 namespace Humans.Application.Tests.Services;
@@ -8,7 +9,7 @@ public class GuideMarkdownPreprocessorTests
 {
     private static readonly GuideMarkdownPreprocessor Preprocessor = new();
 
-    [Fact]
+    [HumansFact]
     public void Wrap_VolunteerBlock_WrapsWithDivVolunteerRole()
     {
         const string input = """
@@ -32,7 +33,7 @@ public class GuideMarkdownPreprocessorTests
         result.Should().Contain("</div>");
     }
 
-    [Fact]
+    [HumansFact]
     public void Wrap_CoordinatorWithParenthetical_CapturesRoles()
     {
         const string input = """
@@ -48,7 +49,7 @@ public class GuideMarkdownPreprocessorTests
         result.Should().Contain("<div data-guide-role=\"coordinator\" data-guide-roles=\"ConsentCoordinator\">");
     }
 
-    [Fact]
+    [HumansFact]
     public void Wrap_BoardAdminWithParenthetical_CapturesSystemRole()
     {
         const string input = """
@@ -62,7 +63,7 @@ public class GuideMarkdownPreprocessorTests
         result.Should().Contain("<div data-guide-role=\"boardadmin\" data-guide-roles=\"CampAdmin\">");
     }
 
-    [Fact]
+    [HumansFact]
     public void Wrap_HeadingWithGlossaryLink_StillMatches()
     {
         const string input = """
@@ -76,7 +77,7 @@ public class GuideMarkdownPreprocessorTests
         result.Should().Contain("<div data-guide-role=\"volunteer\" data-guide-roles=\"\">");
     }
 
-    [Fact]
+    [HumansFact]
     public void Wrap_ClosesDivBeforeNextSectionHeading()
     {
         const string input = """
@@ -101,7 +102,7 @@ public class GuideMarkdownPreprocessorTests
         secondOpen.Should().BeGreaterThan(firstClose);
     }
 
-    [Fact]
+    [HumansFact]
     public void Wrap_ClosesDivAtRelatedSectionsHeading()
     {
         const string input = """
@@ -125,7 +126,7 @@ public class GuideMarkdownPreprocessorTests
         related.Should().BeGreaterThan(close);
     }
 
-    [Fact]
+    [HumansFact]
     public void Wrap_NoAsAHeadings_ReturnsInputUnchanged()
     {
         const string input = """
@@ -145,7 +146,7 @@ public class GuideMarkdownPreprocessorTests
         result.Should().Be(input);
     }
 
-    [Fact]
+    [HumansFact]
     public void Wrap_BlankLineBeforeAndAfterDiv_SoMarkdigRendersInner()
     {
         const string input = """
@@ -162,7 +163,7 @@ public class GuideMarkdownPreprocessorTests
         result.Should().Contain("\n\n<div data-guide-role=\"volunteer\"");
     }
 
-    [Fact]
+    [HumansFact]
     public void Wrap_ParentheticalWithUnknownToken_OmitsFromDataAttributeButKeepsHeading()
     {
         const string input = """
@@ -182,7 +183,7 @@ public class GuideMarkdownPreprocessorTests
         result.Should().Contain("## As a Board member / Admin (Camp Admin, Mystery Role)");
     }
 
-    [Fact]
+    [HumansFact]
     public void Wrap_HeadingWithGlossaryLinkAndRoleParenthetical_PreservesLink()
     {
         // Regression: the heading has a markdown link whose URL is parenthesised,

--- a/tests/Humans.Application.Tests/Services/GuideMarkdownPreprocessorTests.cs
+++ b/tests/Humans.Application.Tests/Services/GuideMarkdownPreprocessorTests.cs
@@ -1,0 +1,179 @@
+using AwesomeAssertions;
+using Humans.Infrastructure.Services;
+using Xunit;
+
+namespace Humans.Application.Tests.Services;
+
+public class GuideMarkdownPreprocessorTests
+{
+    private static readonly GuideMarkdownPreprocessor Preprocessor = new();
+
+    [Fact]
+    public void Wrap_VolunteerBlock_WrapsWithDivVolunteerRole()
+    {
+        const string input = """
+            # Profiles
+
+            ## What this section is for
+
+            Intro.
+
+            ## As a Volunteer
+
+            Do volunteer things.
+
+            ## Related sections
+            """;
+
+        var result = Preprocessor.Wrap(input);
+
+        result.Should().Contain("<div data-guide-role=\"volunteer\" data-guide-roles=\"\">");
+        result.Should().Contain("## As a Volunteer");
+        result.Should().Contain("</div>");
+    }
+
+    [Fact]
+    public void Wrap_CoordinatorWithParenthetical_CapturesRoles()
+    {
+        const string input = """
+            ## As a Coordinator (Consent Coordinator)
+
+            Do consent-coordinator things.
+
+            ## Related sections
+            """;
+
+        var result = Preprocessor.Wrap(input);
+
+        result.Should().Contain("<div data-guide-role=\"coordinator\" data-guide-roles=\"ConsentCoordinator\">");
+    }
+
+    [Fact]
+    public void Wrap_BoardAdminWithParenthetical_CapturesSystemRole()
+    {
+        const string input = """
+            ## As a Board member / Admin (Camp Admin)
+
+            Do camp admin things.
+            """;
+
+        var result = Preprocessor.Wrap(input);
+
+        result.Should().Contain("<div data-guide-role=\"boardadmin\" data-guide-roles=\"CampAdmin\">");
+    }
+
+    [Fact]
+    public void Wrap_HeadingWithGlossaryLink_StillMatches()
+    {
+        const string input = """
+            ## As a [Volunteer](Glossary.md#volunteer)
+
+            Content.
+            """;
+
+        var result = Preprocessor.Wrap(input);
+
+        result.Should().Contain("<div data-guide-role=\"volunteer\" data-guide-roles=\"\">");
+    }
+
+    [Fact]
+    public void Wrap_ClosesDivBeforeNextSectionHeading()
+    {
+        const string input = """
+            ## As a Volunteer
+
+            Volunteer stuff.
+
+            ## As a Coordinator
+
+            Coordinator stuff.
+            """;
+
+        var result = Preprocessor.Wrap(input);
+
+        // A closing div must appear before the next As-a heading's opening div.
+        var firstOpen = result.IndexOf("<div data-guide-role=\"volunteer\"", StringComparison.Ordinal);
+        var firstClose = result.IndexOf("</div>", firstOpen, StringComparison.Ordinal);
+        var secondOpen = result.IndexOf("<div data-guide-role=\"coordinator\"", StringComparison.Ordinal);
+
+        firstOpen.Should().BeGreaterThan(-1);
+        firstClose.Should().BeGreaterThan(firstOpen);
+        secondOpen.Should().BeGreaterThan(firstClose);
+    }
+
+    [Fact]
+    public void Wrap_ClosesDivAtRelatedSectionsHeading()
+    {
+        const string input = """
+            ## As a Volunteer
+
+            Content.
+
+            ## Related sections
+
+            See other stuff.
+            """;
+
+        var result = Preprocessor.Wrap(input);
+
+        var open = result.IndexOf("<div data-guide-role=\"volunteer\"", StringComparison.Ordinal);
+        var close = result.IndexOf("</div>", open, StringComparison.Ordinal);
+        var related = result.IndexOf("## Related sections", StringComparison.Ordinal);
+
+        open.Should().BeGreaterThan(-1);
+        close.Should().BeGreaterThan(open);
+        related.Should().BeGreaterThan(close);
+    }
+
+    [Fact]
+    public void Wrap_NoAsAHeadings_ReturnsInputUnchanged()
+    {
+        const string input = """
+            # Glossary
+
+            ## Admin
+
+            A human with full access.
+
+            ## Board
+
+            The governance body.
+            """;
+
+        var result = Preprocessor.Wrap(input);
+
+        result.Should().Be(input);
+    }
+
+    [Fact]
+    public void Wrap_BlankLineBeforeAndAfterDiv_SoMarkdigRendersInner()
+    {
+        const string input = """
+            Intro paragraph.
+
+            ## As a Volunteer
+
+            Content.
+            """;
+
+        var result = Preprocessor.Wrap(input);
+
+        // Markdig requires HTML block tags to be separated from inline markdown by blank lines.
+        result.Should().Contain("\n\n<div data-guide-role=\"volunteer\"");
+    }
+
+    [Fact]
+    public void Wrap_ParentheticalWithUnknownToken_OmitsUnknown()
+    {
+        const string input = """
+            ## As a Board member / Admin (Camp Admin, Mystery Role)
+
+            Content.
+            """;
+
+        var result = Preprocessor.Wrap(input);
+
+        result.Should().Contain("data-guide-roles=\"CampAdmin\"");
+        result.Should().NotContain("Mystery");
+    }
+}

--- a/tests/Humans.Application.Tests/Services/GuideMarkdownPreprocessorTests.cs
+++ b/tests/Humans.Application.Tests/Services/GuideMarkdownPreprocessorTests.cs
@@ -163,7 +163,7 @@ public class GuideMarkdownPreprocessorTests
     }
 
     [Fact]
-    public void Wrap_ParentheticalWithUnknownToken_OmitsUnknown()
+    public void Wrap_ParentheticalWithUnknownToken_OmitsFromDataAttributeButKeepsHeading()
     {
         const string input = """
             ## As a Board member / Admin (Camp Admin, Mystery Role)
@@ -173,7 +173,30 @@ public class GuideMarkdownPreprocessorTests
 
         var result = Preprocessor.Wrap(input);
 
+        // Unknown tokens must not appear in the data-guide-roles filter attribute.
         result.Should().Contain("data-guide-roles=\"CampAdmin\"");
-        result.Should().NotContain("Mystery");
+        result.Should().NotMatch("data-guide-roles=\"*Mystery*\"");
+
+        // The heading itself is passed through unchanged so that any markdown
+        // links inside it (e.g. "[Volunteer](Glossary.md#volunteer)") survive.
+        result.Should().Contain("## As a Board member / Admin (Camp Admin, Mystery Role)");
+    }
+
+    [Fact]
+    public void Wrap_HeadingWithGlossaryLinkAndRoleParenthetical_PreservesLink()
+    {
+        // Regression: the heading has a markdown link whose URL is parenthesised,
+        // and a trailing role parenthetical. The preprocessor must not mangle
+        // either — the link's URL must survive so Markdig can render it.
+        const string input = """
+            ## As a [Coordinator](Glossary.md#coordinator) (Camp Coordinator)
+
+            Content.
+            """;
+
+        var result = Preprocessor.Wrap(input);
+
+        result.Should().Contain("[Coordinator](Glossary.md#coordinator)");
+        result.Should().Contain("(Camp Coordinator)");
     }
 }

--- a/tests/Humans.Application.Tests/Services/GuideRendererTests.cs
+++ b/tests/Humans.Application.Tests/Services/GuideRendererTests.cs
@@ -2,6 +2,7 @@ using AwesomeAssertions;
 using Microsoft.Extensions.Options;
 using Humans.Infrastructure.Configuration;
 using Humans.Infrastructure.Services;
+using Humans.Testing;
 using Xunit;
 
 namespace Humans.Application.Tests.Services;
@@ -21,7 +22,7 @@ public class GuideRendererTests
         new GuideMarkdownPreprocessor(),
         new GuideHtmlPostprocessor());
 
-    [Fact]
+    [HumansFact]
     public void Render_RoleSection_WrappedWithDiv()
     {
         const string markdown = """
@@ -39,7 +40,7 @@ public class GuideRendererTests
         html.Should().Contain("<div data-guide-role=\"volunteer\"");
     }
 
-    [Fact]
+    [HumansFact]
     public void Render_SiblingMdLink_RewrittenToGuideRoute()
     {
         const string markdown = "See [Profiles](Profiles.md) for details.";
@@ -49,7 +50,7 @@ public class GuideRendererTests
         html.Should().Contain("/Guide/Profiles");
     }
 
-    [Fact]
+    [HumansFact]
     public void Render_ImageShortPath_RewrittenToRawUrl()
     {
         const string markdown = "![x](img/screenshot.png)";
@@ -59,7 +60,7 @@ public class GuideRendererTests
         html.Should().Contain("raw.githubusercontent.com/nobodies-collective/Humans/main/docs/guide/img/screenshot.png");
     }
 
-    [Fact]
+    [HumansFact]
     public void Render_ExternalLink_GetsBlankTarget()
     {
         const string markdown = "[ex](https://example.com)";
@@ -69,7 +70,7 @@ public class GuideRendererTests
         html.Should().Contain("target=\"_blank\"");
     }
 
-    [Fact]
+    [HumansFact]
     public void Render_AppPathLink_LeftAsIs()
     {
         const string markdown = "[Edit](/Profile/Me/Edit)";
@@ -80,7 +81,7 @@ public class GuideRendererTests
         html.Should().NotContain("target=\"_blank\"");
     }
 
-    [Fact]
+    [HumansFact]
     public void Render_GlossaryFile_NoRoleWrappers()
     {
         const string markdown = """

--- a/tests/Humans.Application.Tests/Services/GuideRendererTests.cs
+++ b/tests/Humans.Application.Tests/Services/GuideRendererTests.cs
@@ -1,0 +1,98 @@
+using AwesomeAssertions;
+using Microsoft.Extensions.Options;
+using Humans.Infrastructure.Configuration;
+using Humans.Infrastructure.Services;
+using Xunit;
+
+namespace Humans.Application.Tests.Services;
+
+public class GuideRendererTests
+{
+    private static readonly GuideSettings Settings = new()
+    {
+        Owner = "nobodies-collective",
+        Repository = "Humans",
+        Branch = "main",
+        FolderPath = "docs/guide"
+    };
+
+    private static GuideRenderer CreateRenderer() => new(
+        Options.Create(Settings),
+        new GuideMarkdownPreprocessor(),
+        new GuideHtmlPostprocessor());
+
+    [Fact]
+    public void Render_RoleSection_WrappedWithDiv()
+    {
+        const string markdown = """
+            # Profiles
+
+            Intro.
+
+            ## As a Volunteer
+
+            Do stuff.
+            """;
+
+        var html = CreateRenderer().Render(markdown, "Profiles");
+
+        html.Should().Contain("<div data-guide-role=\"volunteer\"");
+    }
+
+    [Fact]
+    public void Render_SiblingMdLink_RewrittenToGuideRoute()
+    {
+        const string markdown = "See [Profiles](Profiles.md) for details.";
+
+        var html = CreateRenderer().Render(markdown, "Teams");
+
+        html.Should().Contain("/Guide/Profiles");
+    }
+
+    [Fact]
+    public void Render_ImageShortPath_RewrittenToRawUrl()
+    {
+        const string markdown = "![x](img/screenshot.png)";
+
+        var html = CreateRenderer().Render(markdown, "Profiles");
+
+        html.Should().Contain("raw.githubusercontent.com/nobodies-collective/Humans/main/docs/guide/img/screenshot.png");
+    }
+
+    [Fact]
+    public void Render_ExternalLink_GetsBlankTarget()
+    {
+        const string markdown = "[ex](https://example.com)";
+
+        var html = CreateRenderer().Render(markdown, "Profiles");
+
+        html.Should().Contain("target=\"_blank\"");
+    }
+
+    [Fact]
+    public void Render_AppPathLink_LeftAsIs()
+    {
+        const string markdown = "[Edit](/Profile/Me/Edit)";
+
+        var html = CreateRenderer().Render(markdown, "Profiles");
+
+        html.Should().Contain("/Profile/Me/Edit");
+        html.Should().NotContain("target=\"_blank\"");
+    }
+
+    [Fact]
+    public void Render_GlossaryFile_NoRoleWrappers()
+    {
+        const string markdown = """
+            # Glossary
+
+            ## Admin
+
+            A human with full access.
+            """;
+
+        var html = CreateRenderer().Render(markdown, "Glossary");
+
+        html.Should().NotContain("data-guide-role");
+    }
+}

--- a/tests/Humans.Application.Tests/Services/GuideRolePrivilegeMapTests.cs
+++ b/tests/Humans.Application.Tests/Services/GuideRolePrivilegeMapTests.cs
@@ -1,0 +1,61 @@
+using AwesomeAssertions;
+using Humans.Application.Services;
+using Humans.Domain.Constants;
+using Xunit;
+
+namespace Humans.Application.Tests.Services;
+
+public class GuideRolePrivilegeMapTests
+{
+    [Theory]
+    [InlineData("Camp Admin", RoleNames.CampAdmin)]
+    [InlineData("camp admin", RoleNames.CampAdmin)]
+    [InlineData("Teams Admin", RoleNames.TeamsAdmin)]
+    [InlineData("NoInfo Admin", RoleNames.NoInfoAdmin)]
+    [InlineData("Human Admin", RoleNames.HumanAdmin)]
+    [InlineData("Finance Admin", RoleNames.FinanceAdmin)]
+    [InlineData("Feedback Admin", RoleNames.FeedbackAdmin)]
+    [InlineData("Ticket Admin", RoleNames.TicketAdmin)]
+    [InlineData("Consent Coordinator", RoleNames.ConsentCoordinator)]
+    [InlineData("Volunteer Coordinator", RoleNames.VolunteerCoordinator)]
+    public void TryResolve_KnownDisplayName_ReturnsSystemRole(string displayName, string expectedRole)
+    {
+        GuideRolePrivilegeMap.TryResolve(displayName, out var role).Should().BeTrue();
+        role.Should().Be(expectedRole);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("Unknown")]
+    [InlineData("Camp Coordinator")] // A team-coordinator, not a system role
+    public void TryResolve_UnknownOrEmpty_ReturnsFalse(string input)
+    {
+        GuideRolePrivilegeMap.TryResolve(input, out var role).Should().BeFalse();
+        role.Should().BeNull();
+    }
+
+    [Fact]
+    public void ParseParenthetical_MultipleCommaSeparated_ReturnsAll()
+    {
+        var result = GuideRolePrivilegeMap.ParseParenthetical("Camp Admin, Finance Admin");
+
+        result.Should().BeEquivalentTo([RoleNames.CampAdmin, RoleNames.FinanceAdmin]);
+    }
+
+    [Fact]
+    public void ParseParenthetical_UnknownTokensDropped()
+    {
+        var result = GuideRolePrivilegeMap.ParseParenthetical("Camp Admin, Gibberish");
+
+        result.Should().BeEquivalentTo([RoleNames.CampAdmin]);
+    }
+
+    [Fact]
+    public void ParseParenthetical_NullOrEmpty_ReturnsEmpty()
+    {
+        GuideRolePrivilegeMap.ParseParenthetical(null).Should().BeEmpty();
+        GuideRolePrivilegeMap.ParseParenthetical("").Should().BeEmpty();
+        GuideRolePrivilegeMap.ParseParenthetical("   ").Should().BeEmpty();
+    }
+}

--- a/tests/Humans.Application.Tests/Services/GuideRolePrivilegeMapTests.cs
+++ b/tests/Humans.Application.Tests/Services/GuideRolePrivilegeMapTests.cs
@@ -1,13 +1,14 @@
 using AwesomeAssertions;
 using Humans.Application.Services;
 using Humans.Domain.Constants;
+using Humans.Testing;
 using Xunit;
 
 namespace Humans.Application.Tests.Services;
 
 public class GuideRolePrivilegeMapTests
 {
-    [Theory]
+    [HumansTheory]
     [InlineData("Camp Admin", RoleNames.CampAdmin)]
     [InlineData("camp admin", RoleNames.CampAdmin)]
     [InlineData("Teams Admin", RoleNames.TeamsAdmin)]
@@ -24,7 +25,7 @@ public class GuideRolePrivilegeMapTests
         role.Should().Be(expectedRole);
     }
 
-    [Theory]
+    [HumansTheory]
     [InlineData("")]
     [InlineData("   ")]
     [InlineData("Unknown")]
@@ -35,7 +36,7 @@ public class GuideRolePrivilegeMapTests
         role.Should().BeNull();
     }
 
-    [Fact]
+    [HumansFact]
     public void ParseParenthetical_MultipleCommaSeparated_ReturnsAll()
     {
         var result = GuideRolePrivilegeMap.ParseParenthetical("Camp Admin, Finance Admin");
@@ -43,7 +44,7 @@ public class GuideRolePrivilegeMapTests
         result.Should().BeEquivalentTo([RoleNames.CampAdmin, RoleNames.FinanceAdmin]);
     }
 
-    [Fact]
+    [HumansFact]
     public void ParseParenthetical_UnknownTokensDropped()
     {
         var result = GuideRolePrivilegeMap.ParseParenthetical("Camp Admin, Gibberish");
@@ -51,7 +52,7 @@ public class GuideRolePrivilegeMapTests
         result.Should().BeEquivalentTo([RoleNames.CampAdmin]);
     }
 
-    [Fact]
+    [HumansFact]
     public void ParseParenthetical_NullOrEmpty_ReturnsEmpty()
     {
         GuideRolePrivilegeMap.ParseParenthetical(null).Should().BeEmpty();

--- a/tests/Humans.Application.Tests/Services/GuideRoleResolverTests.cs
+++ b/tests/Humans.Application.Tests/Services/GuideRoleResolverTests.cs
@@ -1,0 +1,169 @@
+using System.Security.Claims;
+using AwesomeAssertions;
+using Microsoft.EntityFrameworkCore;
+using NodaTime;
+using NodaTime.Testing;
+using Humans.Domain.Constants;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using Humans.Infrastructure.Data;
+using Humans.Infrastructure.Services;
+using Xunit;
+
+namespace Humans.Application.Tests.Services;
+
+public class GuideRoleResolverTests : IDisposable
+{
+    private readonly HumansDbContext _db;
+    private readonly FakeClock _clock = new(Instant.FromUtc(2026, 4, 21, 12, 0));
+
+    public GuideRoleResolverTests()
+    {
+        var options = new DbContextOptionsBuilder<HumansDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        _db = new HumansDbContext(options);
+    }
+
+    public void Dispose()
+    {
+        _db.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private ClaimsPrincipal PrincipalWithRoles(Guid? userId, params string[] roles)
+    {
+        var claims = new List<Claim>();
+        if (userId is not null)
+        {
+            claims.Add(new Claim(ClaimTypes.NameIdentifier, userId.Value.ToString()));
+        }
+        foreach (var role in roles)
+        {
+            claims.Add(new Claim(ClaimTypes.Role, role));
+        }
+        var identity = new ClaimsIdentity(claims, authenticationType: userId is null ? null : "test");
+        return new ClaimsPrincipal(identity);
+    }
+
+    [Fact]
+    public async Task Resolve_Anonymous_ReturnsAnonymousContext()
+    {
+        var resolver = new GuideRoleResolver(_db);
+
+        var result = await resolver.ResolveAsync(new ClaimsPrincipal(new ClaimsIdentity()));
+
+        result.IsAuthenticated.Should().BeFalse();
+        result.IsTeamCoordinator.Should().BeFalse();
+        result.SystemRoles.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Resolve_AuthWithAdminRole_ReportsSystemRoles()
+    {
+        var resolver = new GuideRoleResolver(_db);
+        var user = PrincipalWithRoles(Guid.NewGuid(), RoleNames.Admin, RoleNames.Board);
+
+        var result = await resolver.ResolveAsync(user);
+
+        result.IsAuthenticated.Should().BeTrue();
+        result.SystemRoles.Should().Contain([RoleNames.Admin, RoleNames.Board]);
+    }
+
+    [Fact]
+    public async Task Resolve_ActiveTeamCoordinator_IsTeamCoordinatorTrue()
+    {
+        var userId = Guid.NewGuid();
+        var teamId = Guid.NewGuid();
+        _db.Teams.Add(new Team
+        {
+            Id = teamId,
+            Name = "T",
+            Slug = "t",
+            IsActive = true,
+            CreatedAt = _clock.GetCurrentInstant(),
+            UpdatedAt = _clock.GetCurrentInstant()
+        });
+        _db.TeamMembers.Add(new TeamMember
+        {
+            Id = Guid.NewGuid(),
+            TeamId = teamId,
+            UserId = userId,
+            Role = TeamMemberRole.Coordinator,
+            JoinedAt = _clock.GetCurrentInstant()
+        });
+        await _db.SaveChangesAsync(CancellationToken.None);
+
+        var resolver = new GuideRoleResolver(_db);
+        var user = PrincipalWithRoles(userId);
+
+        var result = await resolver.ResolveAsync(user, CancellationToken.None);
+
+        result.IsTeamCoordinator.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Resolve_FormerTeamCoordinator_IsTeamCoordinatorFalse()
+    {
+        var userId = Guid.NewGuid();
+        var teamId = Guid.NewGuid();
+        _db.Teams.Add(new Team
+        {
+            Id = teamId,
+            Name = "T",
+            Slug = "t",
+            IsActive = true,
+            CreatedAt = _clock.GetCurrentInstant(),
+            UpdatedAt = _clock.GetCurrentInstant()
+        });
+        _db.TeamMembers.Add(new TeamMember
+        {
+            Id = Guid.NewGuid(),
+            TeamId = teamId,
+            UserId = userId,
+            Role = TeamMemberRole.Coordinator,
+            JoinedAt = _clock.GetCurrentInstant(),
+            LeftAt = _clock.GetCurrentInstant()
+        });
+        await _db.SaveChangesAsync(CancellationToken.None);
+
+        var resolver = new GuideRoleResolver(_db);
+        var user = PrincipalWithRoles(userId);
+
+        var result = await resolver.ResolveAsync(user, CancellationToken.None);
+
+        result.IsTeamCoordinator.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Resolve_MemberButNotCoordinator_IsTeamCoordinatorFalse()
+    {
+        var userId = Guid.NewGuid();
+        var teamId = Guid.NewGuid();
+        _db.Teams.Add(new Team
+        {
+            Id = teamId,
+            Name = "T",
+            Slug = "t",
+            IsActive = true,
+            CreatedAt = _clock.GetCurrentInstant(),
+            UpdatedAt = _clock.GetCurrentInstant()
+        });
+        _db.TeamMembers.Add(new TeamMember
+        {
+            Id = Guid.NewGuid(),
+            TeamId = teamId,
+            UserId = userId,
+            Role = TeamMemberRole.Member,
+            JoinedAt = _clock.GetCurrentInstant()
+        });
+        await _db.SaveChangesAsync(CancellationToken.None);
+
+        var resolver = new GuideRoleResolver(_db);
+        var user = PrincipalWithRoles(userId);
+
+        var result = await resolver.ResolveAsync(user, CancellationToken.None);
+
+        result.IsTeamCoordinator.Should().BeFalse();
+    }
+}

--- a/tests/Humans.Application.Tests/Services/GuideRoleResolverTests.cs
+++ b/tests/Humans.Application.Tests/Services/GuideRoleResolverTests.cs
@@ -8,6 +8,7 @@ using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Humans.Infrastructure.Data;
 using Humans.Infrastructure.Services;
+using Humans.Testing;
 using Xunit;
 
 namespace Humans.Application.Tests.Services;
@@ -46,7 +47,7 @@ public class GuideRoleResolverTests : IDisposable
         return new ClaimsPrincipal(identity);
     }
 
-    [Fact]
+    [HumansFact]
     public async Task Resolve_Anonymous_ReturnsAnonymousContext()
     {
         var resolver = new GuideRoleResolver(_db);
@@ -58,7 +59,7 @@ public class GuideRoleResolverTests : IDisposable
         result.SystemRoles.Should().BeEmpty();
     }
 
-    [Fact]
+    [HumansFact]
     public async Task Resolve_AuthWithAdminRole_ReportsSystemRoles()
     {
         var resolver = new GuideRoleResolver(_db);
@@ -70,7 +71,7 @@ public class GuideRoleResolverTests : IDisposable
         result.SystemRoles.Should().Contain([RoleNames.Admin, RoleNames.Board]);
     }
 
-    [Fact]
+    [HumansFact]
     public async Task Resolve_ActiveTeamCoordinator_IsTeamCoordinatorTrue()
     {
         var userId = Guid.NewGuid();
@@ -102,7 +103,7 @@ public class GuideRoleResolverTests : IDisposable
         result.IsTeamCoordinator.Should().BeTrue();
     }
 
-    [Fact]
+    [HumansFact]
     public async Task Resolve_FormerTeamCoordinator_IsTeamCoordinatorFalse()
     {
         var userId = Guid.NewGuid();
@@ -135,7 +136,7 @@ public class GuideRoleResolverTests : IDisposable
         result.IsTeamCoordinator.Should().BeFalse();
     }
 
-    [Fact]
+    [HumansFact]
     public async Task Resolve_MemberButNotCoordinator_IsTeamCoordinatorFalse()
     {
         var userId = Guid.NewGuid();


### PR DESCRIPTION
Closes #531.

## Summary

Renders `docs/guide/*.md` inside the app at `/Guide` with role-aware section filtering, link/image rewriting, and admin-triggered GitHub refresh. Memory-only cache, no DB.

## Architecture

- **`IGuideContentService`** (Infrastructure) — owns `IMemoryCache`, fetches all 17 files on cold start, serves stale on GitHub failure.
- **`IGuideRenderer`** — Markdig pipeline wrapped by `GuideMarkdownPreprocessor` (wraps `## As a …` blocks in role-annotated `<div>`s) and `GuideHtmlPostprocessor` (rewrites sibling `.md` links to `/Guide/…`, images to `raw.githubusercontent.com`, externals to new-tab).
- **`IGuideRoleResolver`** — claims + `TeamMember.Role == Coordinator` DB check → `GuideRoleContext`.
- **`GuideFilter`** (Application, pure) — strips role-blocks the viewer isn't entitled to; within-file Coordinator superset rule (TeamsAdmin on Teams.md sees both Coordinator and Board/Admin blocks; TeamsAdmin on Tickets.md sees only Volunteer).
- **`GuideController`** — `GET /Guide`, `GET /Guide/{name}` (AllowAnonymous, role filter applied), `POST /Guide/Refresh` (AdminOnly policy, CSRF).

## Key decisions (see `docs/superpowers/specs/2026-04-21-in-app-guide-design.md`)

- Memory-only cache (not DB-backed).
- Lazy load + 6h TTL + admin manual refresh (no scheduled Hangfire job).
- Role filter uses the `## As a …` heading + parenthetical convention already in the guide files. Parenthetical parser maps `Camp Admin` → `CampAdmin`, `Consent Coordinator` → `ConsentCoordinator`, etc.
- English-only in v1 (localization deferred).
- Glossary-term hover tooltips deferred.

## Content changes

Added domain-admin parentheticals to 6 guide files so the filter can scope Board/Admin blocks to the right role:

- `Teams.md` → `(Teams Admin)`
- `Profiles.md`, `Onboarding.md` → `(Human Admin)`
- `Shifts.md` → `(NoInfo Admin)`
- `Feedback.md` → `(Feedback Admin)`
- `Budget.md` → `(Finance Admin)`

## Test plan

**Unit tests (automated):** 64 new tests across 7 files; Application.Tests 1075/1075 passing; build clean, 0 warnings.

**Smoke test on preview (please verify):**

- [ ] Anonymous → `/` → click "Guide" in nav → README renders. Only Volunteer sections visible on pages like `/Guide/Profiles`.
- [ ] Plain Volunteer → same visibility as anonymous.
- [ ] Team coordinator (any `TeamMember.Role == Coordinator`) → Coordinator blocks now visible.
- [ ] `CampAdmin` → `/Guide/Camps` shows the Board/Admin block; `/Guide/Tickets` does not.
- [ ] `TeamsAdmin` → `/Guide/Teams` shows Coordinator AND Board/Admin blocks (within-file superset).
- [ ] `Admin` → all sections visible on every page. "Refresh from GitHub" button visible; click → flash message.
- [ ] Click a sibling `.md` link (e.g. Glossary anchor from Profiles) → navigates in-app, fragment preserved.
- [ ] Click an app-path link (e.g. `/Profile/Me/Edit`) → goes to real route.
- [ ] Click an external link → opens in new tab.
- [ ] Any images in guide content load from `raw.githubusercontent.com`.
- [ ] `/Guide/Nonexistent` returns 404 view (not 200).
- [ ] GitHub unreachable on cold cache → `/Guide` renders the Unavailable view with 503.

## Out of scope (tracked as follow-ups if needed)

- Localization of guide content and the nav link.
- Glossary-term hover tooltips.
- Scheduled daily Hangfire refresh.
- In-app markdown editing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)