### PR TITLE
UX: Declutter home dashboard sidebar

### DIFF
--- a/src/Humans.Web/Resources/SharedResource.ca.resx
+++ b/src/Humans.Web/Resources/SharedResource.ca.resx
@@ -163,6 +163,8 @@
   <data name="Dashboard_LastLogin" xml:space="preserve"><value>Últim accés</value></data>
   <data name="Dashboard_QuickLinks" xml:space="preserve"><value>Accesos ràpids</value></data>
   <data name="Dashboard_ManageConsents" xml:space="preserve"><value>Revisar acords</value></data>
+  <data name="Dashboard_PendingAgreementsSingular" xml:space="preserve"><value>{0} acord per revisar</value></data>
+  <data name="Dashboard_PendingAgreementsPlural" xml:space="preserve"><value>{0} acords per revisar</value></data>
   <data name="Dashboard_RejectedTitle" xml:space="preserve"><value>Registre rebutjat</value></data>
   <data name="Dashboard_RejectedMessage" xml:space="preserve"><value>El teu registre ha estat revisat i no va ser aprovat. Si tens preguntes, contacta amb l'equip d'administració.</value></data>
   <data name="Dashboard_RejectionReason" xml:space="preserve"><value>Motiu</value></data>

--- a/src/Humans.Web/Resources/SharedResource.de.resx
+++ b/src/Humans.Web/Resources/SharedResource.de.resx
@@ -163,6 +163,8 @@
   <data name="Dashboard_LastLogin" xml:space="preserve"><value>Letzte Anmeldung</value></data>
   <data name="Dashboard_QuickLinks" xml:space="preserve"><value>Schnellzugriff</value></data>
   <data name="Dashboard_ManageConsents" xml:space="preserve"><value>Vereinbarungen prüfen</value></data>
+  <data name="Dashboard_PendingAgreementsSingular" xml:space="preserve"><value>{0} Vereinbarung zu prüfen</value></data>
+  <data name="Dashboard_PendingAgreementsPlural" xml:space="preserve"><value>{0} Vereinbarungen zu prüfen</value></data>
   <data name="Dashboard_RejectedTitle" xml:space="preserve"><value>Anmeldung abgelehnt</value></data>
   <data name="Dashboard_RejectedMessage" xml:space="preserve"><value>Ihre Anmeldung wurde gepr&#xFC;ft und nicht genehmigt. Bei Fragen wenden Sie sich bitte an das Admin-Team.</value></data>
   <data name="Dashboard_RejectionReason" xml:space="preserve"><value>Grund</value></data>

--- a/src/Humans.Web/Resources/SharedResource.es.resx
+++ b/src/Humans.Web/Resources/SharedResource.es.resx
@@ -163,6 +163,8 @@
   <data name="Dashboard_LastLogin" xml:space="preserve"><value>&#xDA;ltimo acceso</value></data>
   <data name="Dashboard_QuickLinks" xml:space="preserve"><value>Accesos r&#xE1;pidos</value></data>
   <data name="Dashboard_ManageConsents" xml:space="preserve"><value>Revisar acuerdos</value></data>
+  <data name="Dashboard_PendingAgreementsSingular" xml:space="preserve"><value>{0} acuerdo por revisar</value></data>
+  <data name="Dashboard_PendingAgreementsPlural" xml:space="preserve"><value>{0} acuerdos por revisar</value></data>
   <data name="Dashboard_RejectedTitle" xml:space="preserve"><value>Registro rechazado</value></data>
   <data name="Dashboard_RejectedMessage" xml:space="preserve"><value>Su registro ha sido revisado y no fue aprobado. Si tiene preguntas, contacte al equipo de administraci&#xF3;n.</value></data>
   <data name="Dashboard_RejectionReason" xml:space="preserve"><value>Motivo</value></data>

--- a/src/Humans.Web/Resources/SharedResource.fr.resx
+++ b/src/Humans.Web/Resources/SharedResource.fr.resx
@@ -163,6 +163,8 @@
   <data name="Dashboard_LastLogin" xml:space="preserve"><value>Derni&#xE8;re connexion</value></data>
   <data name="Dashboard_QuickLinks" xml:space="preserve"><value>Acc&#xE8;s rapides</value></data>
   <data name="Dashboard_ManageConsents" xml:space="preserve"><value>Consulter les accords</value></data>
+  <data name="Dashboard_PendingAgreementsSingular" xml:space="preserve"><value>{0} accord à consulter</value></data>
+  <data name="Dashboard_PendingAgreementsPlural" xml:space="preserve"><value>{0} accords à consulter</value></data>
   <data name="Dashboard_RejectedTitle" xml:space="preserve"><value>Inscription refus&#xE9;e</value></data>
   <data name="Dashboard_RejectedMessage" xml:space="preserve"><value>Votre inscription a &#xE9;t&#xE9; examin&#xE9;e et n'a pas &#xE9;t&#xE9; approuv&#xE9;e. Si vous avez des questions, veuillez contacter l'&#xE9;quipe d'administration.</value></data>
   <data name="Dashboard_RejectionReason" xml:space="preserve"><value>Motif</value></data>

--- a/src/Humans.Web/Resources/SharedResource.it.resx
+++ b/src/Humans.Web/Resources/SharedResource.it.resx
@@ -163,6 +163,8 @@
   <data name="Dashboard_LastLogin" xml:space="preserve"><value>Ultimo accesso</value></data>
   <data name="Dashboard_QuickLinks" xml:space="preserve"><value>Link rapidi</value></data>
   <data name="Dashboard_ManageConsents" xml:space="preserve"><value>Esamina accordi</value></data>
+  <data name="Dashboard_PendingAgreementsSingular" xml:space="preserve"><value>{0} accordo da esaminare</value></data>
+  <data name="Dashboard_PendingAgreementsPlural" xml:space="preserve"><value>{0} accordi da esaminare</value></data>
   <data name="Dashboard_RejectedTitle" xml:space="preserve"><value>Registrazione rifiutata</value></data>
   <data name="Dashboard_RejectedMessage" xml:space="preserve"><value>La Sua registrazione &#xE8; stata esaminata e non &#xE8; stata approvata. Per domande, contatti il team di amministrazione.</value></data>
   <data name="Dashboard_RejectionReason" xml:space="preserve"><value>Motivo</value></data>

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -163,6 +163,8 @@
   <data name="Dashboard_LastLogin" xml:space="preserve"><value>Last Login</value></data>
   <data name="Dashboard_QuickLinks" xml:space="preserve"><value>Quick Links</value></data>
   <data name="Dashboard_ManageConsents" xml:space="preserve"><value>Review Agreements</value></data>
+  <data name="Dashboard_PendingAgreementsSingular" xml:space="preserve"><value>{0} agreement to review</value><comment>{0} = pending consent count (singular)</comment></data>
+  <data name="Dashboard_PendingAgreementsPlural" xml:space="preserve"><value>{0} agreements to review</value><comment>{0} = pending consent count (plural)</comment></data>
   <data name="Dashboard_RejectedTitle" xml:space="preserve"><value>Signup Rejected</value></data>
   <data name="Dashboard_RejectedMessage" xml:space="preserve"><value>Your signup has been reviewed and was not approved. If you have questions, please contact the admin team.</value></data>
   <data name="Dashboard_RejectionReason" xml:space="preserve"><value>Reason</value></data>

--- a/src/Humans.Web/Views/Home/Dashboard.cshtml
+++ b/src/Humans.Web/Views/Home/Dashboard.cshtml
@@ -10,7 +10,13 @@
                             size="64"
                             css-class="me-3" />
             <div>
-                <h1 class="mb-0">@Html.Raw(string.Format(Localizer["Dashboard_Welcome"].Value, Html.Encode(Model.DisplayName)))</h1>
+                <h1 class="mb-0">
+                    @Html.Raw(string.Format(Localizer["Dashboard_Welcome"].Value, Html.Encode(Model.DisplayName)))
+                    @if (Model.MembershipTier != MembershipTier.Volunteer)
+                    {
+                        <span class="badge bg-primary ms-2 align-middle" style="font-size: 0.4em; vertical-align: middle;">@Model.MembershipTier</span>
+                    }
+                </h1>
             </div>
         </div>
     </div>
@@ -170,34 +176,6 @@
                 </div>
             }
 
-            <div class="card mb-4">
-                <div class="card-header">@Localizer["Nav_Governance"]</div>
-                <div class="card-body">
-                    @if (Model.LatestApplicationStatus != null)
-                    {
-                        <div class="d-flex justify-content-between align-items-center">
-                            <div>
-                                <strong>@Localizer["Dashboard_LatestApplication"]</strong>
-                                @if (Model.LatestApplicationTier.HasValue)
-                                {
-                                    <span class="badge bg-info me-1">@Model.LatestApplicationTier.Value</span>
-                                }
-                                <span class="badge @Model.LatestApplicationStatus.GetBadgeClass()">@Localizer["ApplicationStatus_" + Model.LatestApplicationStatus.ToString()]</span>
-                            </div>
-                            <small class="text-muted">@Model.LatestApplicationDate?.ToDisplayDate()</small>
-                        </div>
-                        <div class="mt-2">
-                            <a asp-controller="Application" asp-action="Index">@Localizer["Dashboard_ViewApplicationHistory"]</a>
-                        </div>
-                    }
-                    else
-                    {
-                        <p class="text-muted mb-2">@Localizer["Dashboard_GovernanceDescription"]</p>
-                        <p class="text-muted mb-3"><small>@Localizer["Dashboard_GovernanceOptional"]</small></p>
-                        <a asp-controller="Application" asp-action="Index" class="btn btn-sm btn-outline-secondary">@Localizer["Dashboard_LearnMore"]</a>
-                    }
-                </div>
-            </div>
         }
     </div>
 
@@ -268,39 +246,16 @@
             @await Component.InvokeAsync("MyGoogleResources")
         }
 
-        <div class="card mb-4">
-            <div class="card-header">@Localizer["Dashboard_YourMembership"]</div>
-            <div class="card-body">
-                <dl class="row mb-0">
-                    <dt class="col-6">@Localizer["Dashboard_MemberSince"]</dt>
-                    <dd class="col-6">@Model.MemberSince.ToDisplayMonthYear()</dd>
-                    @if (Model.LastLogin.HasValue)
-                    {
-                        <dt class="col-6">@Localizer["Dashboard_LastLogin"]</dt>
-                        <dd class="col-6">@Model.LastLogin.Value.ToDisplayDayMonth()</dd>
-                    }
-                </dl>
+        @if (Model.PendingConsents > 0)
+        {
+            <div class="alert alert-warning d-flex align-items-center mb-4" role="alert">
+                <i class="fa-solid fa-file-signature me-2"></i>
+                <div>
+                    <a asp-controller="Consent" asp-action="Index" class="alert-link">
+                        @Model.PendingConsents @(Model.PendingConsents == 1 ? "agreement" : "agreements") to review
+                    </a>
+                </div>
             </div>
-        </div>
-
-        <div class="card">
-            <div class="card-header">@Localizer["Dashboard_QuickLinks"]</div>
-            <div class="list-group list-group-flush">
-                <a asp-controller="Profile" asp-action="Edit" class="list-group-item list-group-item-action">@Localizer["Common_EditProfile"]</a>
-                <a asp-controller="Consent" asp-action="Index" class="list-group-item list-group-item-action">
-                    @Localizer["Dashboard_ManageConsents"]
-                    @if (Model.PendingConsents > 0)
-                    {
-                        <span class="badge bg-warning float-end">@Model.PendingConsents</span>
-                    }
-                </a>
-                @if (Model.IsVolunteerMember)
-                {
-                    <a asp-controller="Team" asp-action="Index" class="list-group-item list-group-item-action">@Localizer["Nav_Teams"]</a>
-                    <a asp-controller="Application" asp-action="Index" class="list-group-item list-group-item-action">@Localizer["Nav_Governance"]</a>
-                }
-                <a asp-controller="Profile" asp-action="Privacy" class="list-group-item list-group-item-action">@Localizer["ProfilePrivacy_Title"]</a>
-            </div>
-        </div>
+        }
     </div>
 </div>

--- a/src/Humans.Web/Views/Home/Dashboard.cshtml
+++ b/src/Humans.Web/Views/Home/Dashboard.cshtml
@@ -252,7 +252,7 @@
                 <i class="fa-solid fa-file-signature me-2"></i>
                 <div>
                     <a asp-controller="Consent" asp-action="Index" class="alert-link">
-                        @Model.PendingConsents @(Model.PendingConsents == 1 ? "agreement" : "agreements") to review
+                        @string.Format((Model.PendingConsents == 1 ? Localizer["Dashboard_PendingAgreementsSingular"] : Localizer["Dashboard_PendingAgreementsPlural"]).Value, Model.PendingConsents)
                     </a>
                 </div>
             </div>


### PR DESCRIPTION
Lifts Laura's commit `62ed0f7a` from nobodies-collective/Humans#537 onto `peterdrier/Humans:main` so it can ride the QA preview environment before being promoted to production.

## Summary
- Single commit by Laura González Gimeno: trims the home dashboard sidebar.
- Only `src/Humans.Web/Views/Home/Dashboard.cshtml` changes (+17 / -62).

## Test plan
- [ ] Preview env spins up cleanly
- [ ] `/Home/Dashboard` renders correctly for a volunteer
- [ ] Sidebar sections visually match Laura's intent
- [ ] No regressions in dashboard links or navigation

Upstream PR: nobodies-collective/Humans#537