### PR TITLE
UX: Align volunteer dashboard with guest dashboard design language

### DIFF
--- a/src/Humans.Web/Resources/SharedResource.ca.resx
+++ b/src/Humans.Web/Resources/SharedResource.ca.resx
@@ -47,6 +47,7 @@
   <data name="Common_Submit" xml:space="preserve"><value>Envia</value></data>
   <data name="Common_NotProvided" xml:space="preserve"><value>No proporcionat</value></data>
   <data name="Common_Error" xml:space="preserve"><value>Alguna cosa ha anat malament. Si us plau, torna-ho a provar més tard.</value></data>
+  <data name="Common_Unknown" xml:space="preserve"><value>Desconegut</value></data>
 
   <!-- ======================== -->
   <!-- Navigation (_Layout)     -->
@@ -172,6 +173,8 @@
   <data name="Dashboard_Subtitle" xml:space="preserve"><value>Això és el que passa.</value></data>
   <data name="Dashboard_AgreementSingular" xml:space="preserve"><value>acord per revisar</value></data>
   <data name="Dashboard_AgreementPlural" xml:space="preserve"><value>acords per revisar</value></data>
+  <data name="Dashboard_SlotsSingular" xml:space="preserve"><value>plaça</value></data>
+  <data name="Dashboard_SlotsPlural" xml:space="preserve"><value>places</value></data>
   <data name="Dashboard_GetInvolved" xml:space="preserve"><value>Participa</value></data>
   <data name="Dashboard_GetInvolvedSubtitle" xml:space="preserve"><value>Això no es munta sol.</value></data>
   <data name="Dashboard_ShiftsDescription" xml:space="preserve"><value>Mira què cal fer i apunta't.</value></data>

--- a/src/Humans.Web/Resources/SharedResource.ca.resx
+++ b/src/Humans.Web/Resources/SharedResource.ca.resx
@@ -169,6 +169,33 @@
   <data name="Dashboard_RejectedMessage" xml:space="preserve"><value>El teu registre ha estat revisat i no va ser aprovat. Si tens preguntes, contacta amb l'equip d'administració.</value></data>
   <data name="Dashboard_RejectionReason" xml:space="preserve"><value>Motiu</value></data>
 
+  <data name="Dashboard_Subtitle" xml:space="preserve"><value>Això és el que passa.</value></data>
+  <data name="Dashboard_AgreementSingular" xml:space="preserve"><value>acord per revisar</value></data>
+  <data name="Dashboard_AgreementPlural" xml:space="preserve"><value>acords per revisar</value></data>
+  <data name="Dashboard_GetInvolved" xml:space="preserve"><value>Participa</value></data>
+  <data name="Dashboard_GetInvolvedSubtitle" xml:space="preserve"><value>Això no es munta sol.</value></data>
+  <data name="Dashboard_ShiftsDescription" xml:space="preserve"><value>Mira què cal fer i apunta't.</value></data>
+  <data name="Dashboard_TeamsDescription" xml:space="preserve"><value>Troba la teva gent. O fes-te la gent d'algú.</value></data>
+  <data name="Dashboard_CampsDescription" xml:space="preserve"><value>Els barris que fan que Elsewhere sembli casa.</value></data>
+  <data name="Dashboard_YourStuff" xml:space="preserve"><value>Les teves coses</value></data>
+  <data name="Dashboard_YourStuffSubtitle" xml:space="preserve"><value>Perfil, acords, i el que és només teu.</value></data>
+  <data name="Dashboard_ProfileCardDescription" xml:space="preserve"><value>Actualitza la teva info, foto, i tot això.</value></data>
+  <data name="Dashboard_ConsentsCardDescription" xml:space="preserve"><value>El paperassa de ser human.</value></data>
+  <data name="Dashboard_PrivacyCard" xml:space="preserve"><value>Privacitat</value></data>
+  <data name="Dashboard_PrivacyCardDescription" xml:space="preserve"><value>Controla el que els altres poden veure de tu.</value></data>
+  <data name="Dashboard_GovernanceCardDescription" xml:space="preserve"><value>Assemblees, eleccions, i el seriós.</value></data>
+  <data name="Dashboard_TicketNotConfigured" xml:space="preserve"><value>La info d'entrades encara no està disponible. Paciència.</value></data>
+  <data name="Dashboard_TicketConfirmed" xml:space="preserve"><value>Hi ets. Entrada llesta.</value></data>
+  <data name="Dashboard_TicketCount" xml:space="preserve"><value>Tens {0} entrades</value><comment>{0} = ticket count</comment></data>
+  <data name="Dashboard_NotAttending" xml:space="preserve"><value>No véns aquest any.</value></data>
+  <data name="Dashboard_NotAttendingHint" xml:space="preserve"><value>Has canviat d'opinió? Sense judici.</value></data>
+  <data name="Dashboard_UndoNotAttending" xml:space="preserve"><value>Bé, potser sí que hi vaig</value></data>
+  <data name="Dashboard_TicketMissing" xml:space="preserve"><value>Encara sense entrada</value></data>
+  <data name="Dashboard_TicketMissingHint" xml:space="preserve"><value>No en veiem cap vinculada al teu compte.</value></data>
+  <data name="Dashboard_BuyTicket" xml:space="preserve"><value>Aconsegueix la teva entrada</value></data>
+  <data name="Dashboard_DifferentEmail" xml:space="preserve"><value>Has comprat amb un altre email?</value></data>
+  <data name="Dashboard_DeclareNotAttending" xml:space="preserve"><value>No hi vaig aquest any</value></data>
+
   <!-- Guest Dashboard -->
   <data name="Guest_Greeting" xml:space="preserve"><value>Hola, {0}.</value></data>
   <data name="Guest_Subtitle" xml:space="preserve"><value>Benvingut/da a Humans &#x2014; on Nobodies Collective gestiona tot per a Elsewhere.</value></data>

--- a/src/Humans.Web/Resources/SharedResource.de.resx
+++ b/src/Humans.Web/Resources/SharedResource.de.resx
@@ -47,6 +47,7 @@
   <data name="Common_Submit" xml:space="preserve"><value>Absenden</value></data>
   <data name="Common_NotProvided" xml:space="preserve"><value>Nicht angegeben</value></data>
   <data name="Common_Error" xml:space="preserve"><value>Etwas ist schiefgelaufen. Bitte versuche es später erneut.</value></data>
+  <data name="Common_Unknown" xml:space="preserve"><value>Unbekannt</value></data>
 
   <!-- ======================== -->
   <!-- Navigation (_Layout)     -->
@@ -172,6 +173,8 @@
   <data name="Dashboard_Subtitle" xml:space="preserve"><value>Das ist gerade los.</value></data>
   <data name="Dashboard_AgreementSingular" xml:space="preserve"><value>Vereinbarung zu prüfen</value></data>
   <data name="Dashboard_AgreementPlural" xml:space="preserve"><value>Vereinbarungen zu prüfen</value></data>
+  <data name="Dashboard_SlotsSingular" xml:space="preserve"><value>Platz</value></data>
+  <data name="Dashboard_SlotsPlural" xml:space="preserve"><value>Plätze</value></data>
   <data name="Dashboard_GetInvolved" xml:space="preserve"><value>Mach mit</value></data>
   <data name="Dashboard_GetInvolvedSubtitle" xml:space="preserve"><value>Das baut sich nicht von allein.</value></data>
   <data name="Dashboard_ShiftsDescription" xml:space="preserve"><value>Schau was ansteht und trag dich ein.</value></data>

--- a/src/Humans.Web/Resources/SharedResource.de.resx
+++ b/src/Humans.Web/Resources/SharedResource.de.resx
@@ -169,6 +169,33 @@
   <data name="Dashboard_RejectedMessage" xml:space="preserve"><value>Ihre Anmeldung wurde gepr&#xFC;ft und nicht genehmigt. Bei Fragen wenden Sie sich bitte an das Admin-Team.</value></data>
   <data name="Dashboard_RejectionReason" xml:space="preserve"><value>Grund</value></data>
 
+  <data name="Dashboard_Subtitle" xml:space="preserve"><value>Das ist gerade los.</value></data>
+  <data name="Dashboard_AgreementSingular" xml:space="preserve"><value>Vereinbarung zu prüfen</value></data>
+  <data name="Dashboard_AgreementPlural" xml:space="preserve"><value>Vereinbarungen zu prüfen</value></data>
+  <data name="Dashboard_GetInvolved" xml:space="preserve"><value>Mach mit</value></data>
+  <data name="Dashboard_GetInvolvedSubtitle" xml:space="preserve"><value>Das baut sich nicht von allein.</value></data>
+  <data name="Dashboard_ShiftsDescription" xml:space="preserve"><value>Schau was ansteht und trag dich ein.</value></data>
+  <data name="Dashboard_TeamsDescription" xml:space="preserve"><value>Finde deine Leute. Oder werde die Leute von jemand anderem.</value></data>
+  <data name="Dashboard_CampsDescription" xml:space="preserve"><value>Die Nachbarschaften, die Elsewhere wie zuhause fühlen lassen.</value></data>
+  <data name="Dashboard_YourStuff" xml:space="preserve"><value>Dein Kram</value></data>
+  <data name="Dashboard_YourStuffSubtitle" xml:space="preserve"><value>Profil, Vereinbarungen, und was nur dir gehört.</value></data>
+  <data name="Dashboard_ProfileCardDescription" xml:space="preserve"><value>Aktualisiere deine Infos, Foto, und so.</value></data>
+  <data name="Dashboard_ConsentsCardDescription" xml:space="preserve"><value>Der Papierkram des Human-Seins.</value></data>
+  <data name="Dashboard_PrivacyCard" xml:space="preserve"><value>Privatsphäre</value></data>
+  <data name="Dashboard_PrivacyCardDescription" xml:space="preserve"><value>Kontrolliere, was andere über dich sehen.</value></data>
+  <data name="Dashboard_GovernanceCardDescription" xml:space="preserve"><value>Versammlungen, Wahlen, und das Ernste.</value></data>
+  <data name="Dashboard_TicketNotConfigured" xml:space="preserve"><value>Ticket-Info ist noch nicht verfügbar. Geduld.</value></data>
+  <data name="Dashboard_TicketConfirmed" xml:space="preserve"><value>Du bist drin. Ticket erledigt.</value></data>
+  <data name="Dashboard_TicketCount" xml:space="preserve"><value>Du hast {0} Tickets</value><comment>{0} = ticket count</comment></data>
+  <data name="Dashboard_NotAttending" xml:space="preserve"><value>Kommst dieses Jahr nicht.</value></data>
+  <data name="Dashboard_NotAttendingHint" xml:space="preserve"><value>Meinung geändert? Kein Urteil.</value></data>
+  <data name="Dashboard_UndoNotAttending" xml:space="preserve"><value>Doch, vielleicht komme ich</value></data>
+  <data name="Dashboard_TicketMissing" xml:space="preserve"><value>Noch kein Ticket</value></data>
+  <data name="Dashboard_TicketMissingHint" xml:space="preserve"><value>Wir sehen keins mit deinem Konto verknüpft.</value></data>
+  <data name="Dashboard_BuyTicket" xml:space="preserve"><value>Hol dir dein Ticket</value></data>
+  <data name="Dashboard_DifferentEmail" xml:space="preserve"><value>Mit anderer Email gekauft?</value></data>
+  <data name="Dashboard_DeclareNotAttending" xml:space="preserve"><value>Komme dieses Jahr nicht</value></data>
+
   <!-- Guest Dashboard -->
   <data name="Guest_Greeting" xml:space="preserve"><value>Hey, {0}.</value></data>
   <data name="Guest_Subtitle" xml:space="preserve"><value>Willkommen bei Humans &#x2014; wo Nobodies Collective alles f&#xFC;r Elsewhere verwaltet.</value></data>

--- a/src/Humans.Web/Resources/SharedResource.es.resx
+++ b/src/Humans.Web/Resources/SharedResource.es.resx
@@ -47,6 +47,7 @@
   <data name="Common_Submit" xml:space="preserve"><value>Enviar</value></data>
   <data name="Common_NotProvided" xml:space="preserve"><value>No proporcionado</value></data>
   <data name="Common_Error" xml:space="preserve"><value>Algo salió mal. Por favor, inténtalo de nuevo más tarde.</value></data>
+  <data name="Common_Unknown" xml:space="preserve"><value>Desconocido</value></data>
 
   <!-- ======================== -->
   <!-- Navigation (_Layout)     -->
@@ -172,6 +173,8 @@
   <data name="Dashboard_Subtitle" xml:space="preserve"><value>Esto es lo que pasa.</value></data>
   <data name="Dashboard_AgreementSingular" xml:space="preserve"><value>acuerdo por revisar</value></data>
   <data name="Dashboard_AgreementPlural" xml:space="preserve"><value>acuerdos por revisar</value></data>
+  <data name="Dashboard_SlotsSingular" xml:space="preserve"><value>plaza</value></data>
+  <data name="Dashboard_SlotsPlural" xml:space="preserve"><value>plazas</value></data>
   <data name="Dashboard_GetInvolved" xml:space="preserve"><value>Participa</value></data>
   <data name="Dashboard_GetInvolvedSubtitle" xml:space="preserve"><value>Esto no se monta solo.</value></data>
   <data name="Dashboard_ShiftsDescription" xml:space="preserve"><value>Mira qué hace falta y apúntate.</value></data>

--- a/src/Humans.Web/Resources/SharedResource.es.resx
+++ b/src/Humans.Web/Resources/SharedResource.es.resx
@@ -169,6 +169,33 @@
   <data name="Dashboard_RejectedMessage" xml:space="preserve"><value>Su registro ha sido revisado y no fue aprobado. Si tiene preguntas, contacte al equipo de administraci&#xF3;n.</value></data>
   <data name="Dashboard_RejectionReason" xml:space="preserve"><value>Motivo</value></data>
 
+  <data name="Dashboard_Subtitle" xml:space="preserve"><value>Esto es lo que pasa.</value></data>
+  <data name="Dashboard_AgreementSingular" xml:space="preserve"><value>acuerdo por revisar</value></data>
+  <data name="Dashboard_AgreementPlural" xml:space="preserve"><value>acuerdos por revisar</value></data>
+  <data name="Dashboard_GetInvolved" xml:space="preserve"><value>Participa</value></data>
+  <data name="Dashboard_GetInvolvedSubtitle" xml:space="preserve"><value>Esto no se monta solo.</value></data>
+  <data name="Dashboard_ShiftsDescription" xml:space="preserve"><value>Mira qué hace falta y apúntate.</value></data>
+  <data name="Dashboard_TeamsDescription" xml:space="preserve"><value>Encuentra a tu gente. O conviértete en la gente de alguien.</value></data>
+  <data name="Dashboard_CampsDescription" xml:space="preserve"><value>Los barrios que hacen que Elsewhere se sienta como casa.</value></data>
+  <data name="Dashboard_YourStuff" xml:space="preserve"><value>Tus cosas</value></data>
+  <data name="Dashboard_YourStuffSubtitle" xml:space="preserve"><value>Perfil, acuerdos, y lo que es solo tuyo.</value></data>
+  <data name="Dashboard_ProfileCardDescription" xml:space="preserve"><value>Actualiza tu info, foto, y todo eso.</value></data>
+  <data name="Dashboard_ConsentsCardDescription" xml:space="preserve"><value>El papeleo de ser human.</value></data>
+  <data name="Dashboard_PrivacyCard" xml:space="preserve"><value>Privacidad</value></data>
+  <data name="Dashboard_PrivacyCardDescription" xml:space="preserve"><value>Controla lo que otros pueden ver de ti.</value></data>
+  <data name="Dashboard_GovernanceCardDescription" xml:space="preserve"><value>Asambleas, elecciones, y lo serio.</value></data>
+  <data name="Dashboard_TicketNotConfigured" xml:space="preserve"><value>La info de entradas aún no está disponible. Paciencia.</value></data>
+  <data name="Dashboard_TicketConfirmed" xml:space="preserve"><value>Estás dentro. Entrada lista.</value></data>
+  <data name="Dashboard_TicketCount" xml:space="preserve"><value>Tienes {0} entradas</value><comment>{0} = ticket count</comment></data>
+  <data name="Dashboard_NotAttending" xml:space="preserve"><value>No vienes este año.</value></data>
+  <data name="Dashboard_NotAttendingHint" xml:space="preserve"><value>¿Has cambiado de opinión? Sin juicio.</value></data>
+  <data name="Dashboard_UndoNotAttending" xml:space="preserve"><value>Bueno, igual sí voy</value></data>
+  <data name="Dashboard_TicketMissing" xml:space="preserve"><value>Aún sin entrada</value></data>
+  <data name="Dashboard_TicketMissingHint" xml:space="preserve"><value>No vemos ninguna vinculada a tu cuenta.</value></data>
+  <data name="Dashboard_BuyTicket" xml:space="preserve"><value>Consigue tu entrada</value></data>
+  <data name="Dashboard_DifferentEmail" xml:space="preserve"><value>¿Compraste con otro email?</value></data>
+  <data name="Dashboard_DeclareNotAttending" xml:space="preserve"><value>No voy este año</value></data>
+
   <!-- Guest Dashboard -->
   <data name="Guest_Greeting" xml:space="preserve"><value>Hola, {0}.</value></data>
   <data name="Guest_Subtitle" xml:space="preserve"><value>Bienvenido/a a Humans &#x2014; donde Nobodies Collective gestiona todo para Elsewhere.</value></data>

--- a/src/Humans.Web/Resources/SharedResource.fr.resx
+++ b/src/Humans.Web/Resources/SharedResource.fr.resx
@@ -47,6 +47,7 @@
   <data name="Common_Submit" xml:space="preserve"><value>Envoyer</value></data>
   <data name="Common_NotProvided" xml:space="preserve"><value>Non renseign&#xE9;</value></data>
   <data name="Common_Error" xml:space="preserve"><value>Une erreur est survenue. Veuillez réessayer plus tard.</value></data>
+  <data name="Common_Unknown" xml:space="preserve"><value>Inconnu</value></data>
 
   <!-- ======================== -->
   <!-- Navigation (_Layout)     -->
@@ -172,6 +173,8 @@
   <data name="Dashboard_Subtitle" xml:space="preserve"><value>Voilà ce qui se passe.</value></data>
   <data name="Dashboard_AgreementSingular" xml:space="preserve"><value>accord à revoir</value></data>
   <data name="Dashboard_AgreementPlural" xml:space="preserve"><value>accords à revoir</value></data>
+  <data name="Dashboard_SlotsSingular" xml:space="preserve"><value>place</value></data>
+  <data name="Dashboard_SlotsPlural" xml:space="preserve"><value>places</value></data>
   <data name="Dashboard_GetInvolved" xml:space="preserve"><value>Participe</value></data>
   <data name="Dashboard_GetInvolvedSubtitle" xml:space="preserve"><value>Ça ne se construit pas tout seul.</value></data>
   <data name="Dashboard_ShiftsDescription" xml:space="preserve"><value>Regarde ce qu'il faut faire et inscris-toi.</value></data>

--- a/src/Humans.Web/Resources/SharedResource.fr.resx
+++ b/src/Humans.Web/Resources/SharedResource.fr.resx
@@ -169,6 +169,33 @@
   <data name="Dashboard_RejectedMessage" xml:space="preserve"><value>Votre inscription a &#xE9;t&#xE9; examin&#xE9;e et n'a pas &#xE9;t&#xE9; approuv&#xE9;e. Si vous avez des questions, veuillez contacter l'&#xE9;quipe d'administration.</value></data>
   <data name="Dashboard_RejectionReason" xml:space="preserve"><value>Motif</value></data>
 
+  <data name="Dashboard_Subtitle" xml:space="preserve"><value>Voilà ce qui se passe.</value></data>
+  <data name="Dashboard_AgreementSingular" xml:space="preserve"><value>accord à revoir</value></data>
+  <data name="Dashboard_AgreementPlural" xml:space="preserve"><value>accords à revoir</value></data>
+  <data name="Dashboard_GetInvolved" xml:space="preserve"><value>Participe</value></data>
+  <data name="Dashboard_GetInvolvedSubtitle" xml:space="preserve"><value>Ça ne se construit pas tout seul.</value></data>
+  <data name="Dashboard_ShiftsDescription" xml:space="preserve"><value>Regarde ce qu'il faut faire et inscris-toi.</value></data>
+  <data name="Dashboard_TeamsDescription" xml:space="preserve"><value>Trouve tes gens. Ou deviens les gens de quelqu'un.</value></data>
+  <data name="Dashboard_CampsDescription" xml:space="preserve"><value>Les quartiers qui font qu'Elsewhere se sent comme chez soi.</value></data>
+  <data name="Dashboard_YourStuff" xml:space="preserve"><value>Tes affaires</value></data>
+  <data name="Dashboard_YourStuffSubtitle" xml:space="preserve"><value>Profil, accords, et ce qui n'appartient qu'à toi.</value></data>
+  <data name="Dashboard_ProfileCardDescription" xml:space="preserve"><value>Mets à jour tes infos, photo, et tout ça.</value></data>
+  <data name="Dashboard_ConsentsCardDescription" xml:space="preserve"><value>La paperasse d'être human.</value></data>
+  <data name="Dashboard_PrivacyCard" xml:space="preserve"><value>Vie privée</value></data>
+  <data name="Dashboard_PrivacyCardDescription" xml:space="preserve"><value>Contrôle ce que les autres voient de toi.</value></data>
+  <data name="Dashboard_GovernanceCardDescription" xml:space="preserve"><value>Assemblées, élections, et le sérieux.</value></data>
+  <data name="Dashboard_TicketNotConfigured" xml:space="preserve"><value>Les infos billets ne sont pas encore dispo. Patience.</value></data>
+  <data name="Dashboard_TicketConfirmed" xml:space="preserve"><value>T'es dedans. Billet réglé.</value></data>
+  <data name="Dashboard_TicketCount" xml:space="preserve"><value>Tu as {0} billets</value><comment>{0} = ticket count</comment></data>
+  <data name="Dashboard_NotAttending" xml:space="preserve"><value>Tu ne viens pas cette année.</value></data>
+  <data name="Dashboard_NotAttendingHint" xml:space="preserve"><value>Tu as changé d'avis ? Aucun jugement.</value></data>
+  <data name="Dashboard_UndoNotAttending" xml:space="preserve"><value>En fait, je viens peut-être</value></data>
+  <data name="Dashboard_TicketMissing" xml:space="preserve"><value>Pas encore de billet</value></data>
+  <data name="Dashboard_TicketMissingHint" xml:space="preserve"><value>On n'en voit pas lié à ton compte.</value></data>
+  <data name="Dashboard_BuyTicket" xml:space="preserve"><value>Prends ton billet</value></data>
+  <data name="Dashboard_DifferentEmail" xml:space="preserve"><value>Acheté avec un autre email ?</value></data>
+  <data name="Dashboard_DeclareNotAttending" xml:space="preserve"><value>Je ne viens pas cette année</value></data>
+
   <!-- Guest Dashboard -->
   <data name="Guest_Greeting" xml:space="preserve"><value>Salut, {0}.</value></data>
   <data name="Guest_Subtitle" xml:space="preserve"><value>Bienvenue sur Humans &#x2014; o&#xF9; Nobodies Collective g&#xE8;re tout pour Elsewhere.</value></data>

--- a/src/Humans.Web/Resources/SharedResource.it.resx
+++ b/src/Humans.Web/Resources/SharedResource.it.resx
@@ -169,6 +169,33 @@
   <data name="Dashboard_RejectedMessage" xml:space="preserve"><value>La Sua registrazione &#xE8; stata esaminata e non &#xE8; stata approvata. Per domande, contatti il team di amministrazione.</value></data>
   <data name="Dashboard_RejectionReason" xml:space="preserve"><value>Motivo</value></data>
 
+  <data name="Dashboard_Subtitle" xml:space="preserve"><value>Ecco cosa succede.</value></data>
+  <data name="Dashboard_AgreementSingular" xml:space="preserve"><value>accordo da rivedere</value></data>
+  <data name="Dashboard_AgreementPlural" xml:space="preserve"><value>accordi da rivedere</value></data>
+  <data name="Dashboard_GetInvolved" xml:space="preserve"><value>Partecipa</value></data>
+  <data name="Dashboard_GetInvolvedSubtitle" xml:space="preserve"><value>Non si costruisce da solo.</value></data>
+  <data name="Dashboard_ShiftsDescription" xml:space="preserve"><value>Guarda cosa serve e iscriviti.</value></data>
+  <data name="Dashboard_TeamsDescription" xml:space="preserve"><value>Trova la tua gente. O diventa la gente di qualcuno.</value></data>
+  <data name="Dashboard_CampsDescription" xml:space="preserve"><value>I quartieri che fanno sentire Elsewhere come casa.</value></data>
+  <data name="Dashboard_YourStuff" xml:space="preserve"><value>Le tue cose</value></data>
+  <data name="Dashboard_YourStuffSubtitle" xml:space="preserve"><value>Profilo, accordi, e le cose che sono solo tue.</value></data>
+  <data name="Dashboard_ProfileCardDescription" xml:space="preserve"><value>Aggiorna le tue info, foto, e tutto il resto.</value></data>
+  <data name="Dashboard_ConsentsCardDescription" xml:space="preserve"><value>La burocrazia dell'essere human.</value></data>
+  <data name="Dashboard_PrivacyCard" xml:space="preserve"><value>Privacy</value></data>
+  <data name="Dashboard_PrivacyCardDescription" xml:space="preserve"><value>Controlla cosa possono vedere gli altri di te.</value></data>
+  <data name="Dashboard_GovernanceCardDescription" xml:space="preserve"><value>Assemblee, elezioni, e le cose serie.</value></data>
+  <data name="Dashboard_TicketNotConfigured" xml:space="preserve"><value>Le info sui biglietti non sono ancora disponibili. Pazienza.</value></data>
+  <data name="Dashboard_TicketConfirmed" xml:space="preserve"><value>Ci sei. Biglietto fatto.</value></data>
+  <data name="Dashboard_TicketCount" xml:space="preserve"><value>Hai {0} biglietti</value><comment>{0} = ticket count</comment></data>
+  <data name="Dashboard_NotAttending" xml:space="preserve"><value>Non vieni quest'anno.</value></data>
+  <data name="Dashboard_NotAttendingHint" xml:space="preserve"><value>Hai cambiato idea? Nessun giudizio.</value></data>
+  <data name="Dashboard_UndoNotAttending" xml:space="preserve"><value>In realtà, forse vengo</value></data>
+  <data name="Dashboard_TicketMissing" xml:space="preserve"><value>Ancora nessun biglietto</value></data>
+  <data name="Dashboard_TicketMissingHint" xml:space="preserve"><value>Non ne vediamo nessuno collegato al tuo account.</value></data>
+  <data name="Dashboard_BuyTicket" xml:space="preserve"><value>Prendi il tuo biglietto</value></data>
+  <data name="Dashboard_DifferentEmail" xml:space="preserve"><value>Comprato con un'altra email?</value></data>
+  <data name="Dashboard_DeclareNotAttending" xml:space="preserve"><value>Non vengo quest'anno</value></data>
+
   <!-- Guest Dashboard -->
   <data name="Guest_Greeting" xml:space="preserve"><value>Ciao, {0}.</value></data>
   <data name="Guest_Subtitle" xml:space="preserve"><value>Benvenuto/a su Humans &#x2014; dove Nobodies Collective gestisce tutto per Elsewhere.</value></data>

--- a/src/Humans.Web/Resources/SharedResource.it.resx
+++ b/src/Humans.Web/Resources/SharedResource.it.resx
@@ -47,6 +47,7 @@
   <data name="Common_Submit" xml:space="preserve"><value>Invia</value></data>
   <data name="Common_NotProvided" xml:space="preserve"><value>Non fornito</value></data>
   <data name="Common_Error" xml:space="preserve"><value>Qualcosa è andato storto. Riprova più tardi.</value></data>
+  <data name="Common_Unknown" xml:space="preserve"><value>Sconosciuto</value></data>
 
   <!-- ======================== -->
   <!-- Navigation (_Layout)     -->
@@ -172,6 +173,8 @@
   <data name="Dashboard_Subtitle" xml:space="preserve"><value>Ecco cosa succede.</value></data>
   <data name="Dashboard_AgreementSingular" xml:space="preserve"><value>accordo da rivedere</value></data>
   <data name="Dashboard_AgreementPlural" xml:space="preserve"><value>accordi da rivedere</value></data>
+  <data name="Dashboard_SlotsSingular" xml:space="preserve"><value>posto</value></data>
+  <data name="Dashboard_SlotsPlural" xml:space="preserve"><value>posti</value></data>
   <data name="Dashboard_GetInvolved" xml:space="preserve"><value>Partecipa</value></data>
   <data name="Dashboard_GetInvolvedSubtitle" xml:space="preserve"><value>Non si costruisce da solo.</value></data>
   <data name="Dashboard_ShiftsDescription" xml:space="preserve"><value>Guarda cosa serve e iscriviti.</value></data>

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -47,6 +47,7 @@
   <data name="Common_Submit" xml:space="preserve"><value>Submit</value></data>
   <data name="Common_NotProvided" xml:space="preserve"><value>Not provided</value></data>
   <data name="Common_Error" xml:space="preserve"><value>Something went wrong. Please try again later.</value></data>
+  <data name="Common_Unknown" xml:space="preserve"><value>Unknown</value></data>
 
   <!-- ======================== -->
   <!-- Navigation (_Layout)     -->
@@ -171,6 +172,8 @@
   <data name="Dashboard_Subtitle" xml:space="preserve"><value>Here's what's happening.</value></data>
   <data name="Dashboard_AgreementSingular" xml:space="preserve"><value>agreement to review</value></data>
   <data name="Dashboard_AgreementPlural" xml:space="preserve"><value>agreements to review</value></data>
+  <data name="Dashboard_SlotsSingular" xml:space="preserve"><value>slot</value></data>
+  <data name="Dashboard_SlotsPlural" xml:space="preserve"><value>slots</value></data>
   <data name="Dashboard_GetInvolved" xml:space="preserve"><value>Get involved</value></data>
   <data name="Dashboard_GetInvolvedSubtitle" xml:space="preserve"><value>This thing doesn't build itself.</value></data>
   <data name="Dashboard_ShiftsDescription" xml:space="preserve"><value>See what needs doing and sign up.</value></data>

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -168,6 +168,32 @@
   <data name="Dashboard_RejectedTitle" xml:space="preserve"><value>Signup Rejected</value></data>
   <data name="Dashboard_RejectedMessage" xml:space="preserve"><value>Your signup has been reviewed and was not approved. If you have questions, please contact the admin team.</value></data>
   <data name="Dashboard_RejectionReason" xml:space="preserve"><value>Reason</value></data>
+  <data name="Dashboard_Subtitle" xml:space="preserve"><value>Here's what's happening.</value></data>
+  <data name="Dashboard_AgreementSingular" xml:space="preserve"><value>agreement to review</value></data>
+  <data name="Dashboard_AgreementPlural" xml:space="preserve"><value>agreements to review</value></data>
+  <data name="Dashboard_GetInvolved" xml:space="preserve"><value>Get involved</value></data>
+  <data name="Dashboard_GetInvolvedSubtitle" xml:space="preserve"><value>This thing doesn't build itself.</value></data>
+  <data name="Dashboard_ShiftsDescription" xml:space="preserve"><value>See what needs doing and sign up.</value></data>
+  <data name="Dashboard_TeamsDescription" xml:space="preserve"><value>Find your people. Or become someone else's people.</value></data>
+  <data name="Dashboard_CampsDescription" xml:space="preserve"><value>The neighbourhoods that make Elsewhere feel like home.</value></data>
+  <data name="Dashboard_YourStuff" xml:space="preserve"><value>Your stuff</value></data>
+  <data name="Dashboard_YourStuffSubtitle" xml:space="preserve"><value>Profile, agreements, and the bits that are just yours.</value></data>
+  <data name="Dashboard_ProfileCardDescription" xml:space="preserve"><value>Update your info, photo, and all that.</value></data>
+  <data name="Dashboard_ConsentsCardDescription" xml:space="preserve"><value>The paperwork side of being a human.</value></data>
+  <data name="Dashboard_PrivacyCard" xml:space="preserve"><value>Privacy</value></data>
+  <data name="Dashboard_PrivacyCardDescription" xml:space="preserve"><value>Control what others can see about you.</value></data>
+  <data name="Dashboard_GovernanceCardDescription" xml:space="preserve"><value>Assemblies, elections, and the serious stuff.</value></data>
+  <data name="Dashboard_TicketNotConfigured" xml:space="preserve"><value>Ticket info isn't available yet. Hang tight.</value></data>
+  <data name="Dashboard_TicketConfirmed" xml:space="preserve"><value>You're in. Ticket sorted.</value></data>
+  <data name="Dashboard_TicketCount" xml:space="preserve"><value>You have {0} tickets</value><comment>{0} = ticket count</comment></data>
+  <data name="Dashboard_NotAttending" xml:space="preserve"><value>Not coming this year.</value></data>
+  <data name="Dashboard_NotAttendingHint" xml:space="preserve"><value>Changed your mind? No judgment.</value></data>
+  <data name="Dashboard_UndoNotAttending" xml:space="preserve"><value>Actually, I might come</value></data>
+  <data name="Dashboard_TicketMissing" xml:space="preserve"><value>No ticket yet</value></data>
+  <data name="Dashboard_TicketMissingHint" xml:space="preserve"><value>We don't see one linked to your account.</value></data>
+  <data name="Dashboard_BuyTicket" xml:space="preserve"><value>Get your ticket</value></data>
+  <data name="Dashboard_DifferentEmail" xml:space="preserve"><value>Bought on a different email?</value></data>
+  <data name="Dashboard_DeclareNotAttending" xml:space="preserve"><value>Not coming this year</value></data>
 
   <!-- Guest Dashboard -->
   <data name="Guest_Greeting" xml:space="preserve"><value>Hey, {0}.</value></data>

--- a/src/Humans.Web/Views/Home/Dashboard.cshtml
+++ b/src/Humans.Web/Views/Home/Dashboard.cshtml
@@ -3,203 +3,175 @@
     ViewData["Title"] = Localizer["Dashboard_Title"].Value;
 }
 
-<div class="row mb-4">
-    <div class="col">
+@* ─── Header ─── *@
+<div class="row justify-content-center mb-4">
+    <div class="col-lg-8">
         <div class="d-flex align-items-center">
             <vc:user-avatar user-id="@Model.UserId"
                             size="64"
                             css-class="me-3" />
             <div>
-                <h1 class="mb-0">
+                <h1 class="mb-1">
                     @Html.Raw(string.Format(Localizer["Dashboard_Welcome"].Value, Html.Encode(Model.DisplayName)))
                     @if (Model.MembershipTier != MembershipTier.Volunteer)
                     {
                         <span class="badge bg-primary ms-2 align-middle" style="font-size: 0.4em; vertical-align: middle;">@Model.MembershipTier</span>
                     }
                 </h1>
+                <p class="text-muted mb-0">@Localizer["Dashboard_Subtitle"]</p>
             </div>
         </div>
     </div>
 </div>
 
+@* ─── Rejection alert ─── *@
 @if (Model.IsRejected)
 {
-    <div class="alert alert-danger" role="alert">
-        <h5 class="alert-heading">@Localizer["Dashboard_RejectedTitle"]</h5>
-        <p class="mb-0">@Localizer["Dashboard_RejectedMessage"]</p>
-        @if (!string.IsNullOrEmpty(Model.RejectionReason))
-        {
-            <hr />
-            <p class="mb-0"><strong>@Localizer["Dashboard_RejectionReason"]:</strong> @Model.RejectionReason</p>
-        }
+    <div class="row justify-content-center mb-4">
+        <div class="col-lg-8">
+            <div class="alert alert-danger mb-0" role="alert">
+                <h5 class="alert-heading">@Localizer["Dashboard_RejectedTitle"]</h5>
+                <p class="mb-0">@Localizer["Dashboard_RejectedMessage"]</p>
+                @if (!string.IsNullOrEmpty(Model.RejectionReason))
+                {
+                    <hr />
+                    <p class="mb-0"><strong>@Localizer["Dashboard_RejectionReason"]:</strong> @Model.RejectionReason</p>
+                }
+            </div>
+        </div>
     </div>
 }
 
-<div class="row">
-    <div class="col-md-8">
+@* ─── Things to do (auto-hides when all complete) ─── *@
+<div class="row justify-content-center mb-4">
+    <div class="col-lg-8">
         <vc:things-to-do user-id="@Model.UserId"
                          is-volunteer-member="@Model.IsVolunteerMember"
                          has-shift-signups="@Model.HasShiftSignups" />
-
-        @{
-            var shiftCards = ViewData["ShiftCards"] as Humans.Web.Models.ShiftCardsViewModel;
-        }
-
-        @{
-            var hasUpcomingShifts = shiftCards?.NextShifts.Count > 0 || shiftCards?.PendingCount > 0;
-        }
-
-        @if (hasUpcomingShifts)
-        {
-            <vc:shift-signups user-id="@Model.UserId" view-mode="@ShiftSignupsViewMode.Self" />
-
-            @if (shiftCards?.UrgentShifts.Count > 0)
-            {
-                <div class="card mb-4">
-                    <div class="card-header">
-                        <h5 class="mb-0">Shifts Need Help</h5>
-                    </div>
-                    <div class="card-body">
-                        <ul class="list-unstyled mb-0">
-                            @foreach (var item in shiftCards.UrgentShifts)
-                            {
-                                <li class="mb-2">
-                                    <strong>@(item?.Shift?.Rota?.Name ?? "Unknown")</strong>
-                                    <span class="badge bg-danger">@(item?.RemainingSlots ?? 0) slots</span>
-                                    <br /><small class="text-muted">@(item?.DepartmentName ?? "")</small>
-                                </li>
-                            }
-                        </ul>
-                    </div>
-                    <div class="card-footer">
-                        <a asp-controller="Shifts" asp-action="Index" class="btn btn-sm btn-outline-success">Browse Shift Options</a>
-                    </div>
-                </div>
-            }
-        }
-        else if (Model.IsShiftBrowsingOpen && Model.IsVolunteerMember)
-        {
-            @* Guided shift discovery — shown when user has no upcoming shifts *@
-            <div class="card mb-4 border-primary">
-                <div class="card-header bg-primary text-white">
-                    <h5 class="mb-0"><i class="fa-solid fa-hand-holding-heart me-2"></i>@Localizer["GetInvolved_Title"] — @Model.EventName</h5>
-                </div>
-                <div class="card-body">
-                    <p>@Localizer["GetInvolved_Intro"]</p>
-
-                    <div class="row g-3 mb-3">
-                        <div class="col-md-4">
-                            <div class="border rounded p-3 h-100">
-                                <h6><span class="badge bg-info me-1">@Localizer["GetInvolved_Phase_Setup"]</span></h6>
-                                <small class="text-muted">@Localizer["GetInvolved_Phase_Setup_Desc"]</small>
-                            </div>
-                        </div>
-                        <div class="col-md-4">
-                            <div class="border rounded p-3 h-100">
-                                <h6><span class="badge bg-success me-1">@Localizer["GetInvolved_Phase_Event"]</span></h6>
-                                <small class="text-muted">@Localizer["GetInvolved_Phase_Event_Desc"]</small>
-                            </div>
-                        </div>
-                        <div class="col-md-4">
-                            <div class="border rounded p-3 h-100">
-                                <h6><span class="badge bg-secondary me-1">@Localizer["GetInvolved_Phase_Strike"]</span></h6>
-                                <small class="text-muted">@Localizer["GetInvolved_Phase_Strike_Desc"]</small>
-                            </div>
-                        </div>
-                    </div>
-
-                    @if (shiftCards?.UrgentShifts.Count > 0)
-                    {
-                        <h6 class="mt-3"><i class="fa-solid fa-fire text-danger me-1"></i>@Localizer["GetInvolved_UrgentShifts"]</h6>
-                        <ul class="list-unstyled mb-3">
-                            @foreach (var item in shiftCards.UrgentShifts)
-                            {
-                                <li class="d-flex justify-content-between align-items-center py-1">
-                                    <span>
-                                        <strong>@(item?.Shift?.Rota?.Name ?? "Unknown")</strong>
-                                        <small class="text-muted ms-1">@(item?.DepartmentName ?? "")</small>
-                                    </span>
-                                    <span class="badge bg-danger">@(item?.RemainingSlots ?? 0) slots open</span>
-                                </li>
-                            }
-                        </ul>
-                    }
-                </div>
-                <div class="card-footer d-flex gap-2">
-                    <a asp-controller="Shifts" asp-action="Index" class="btn btn-primary">
-                        <i class="fa-solid fa-calendar-alt me-1"></i>@Localizer["GetInvolved_BrowseAllShifts"]
-                    </a>
-                    <a asp-controller="Shifts" asp-action="Mine" class="btn btn-outline-secondary">
-                        <i class="fa-solid fa-clipboard-list me-1"></i>@Localizer["GetInvolved_MyShifts"]
-                    </a>
-                </div>
-            </div>
-        }
-
-        @if (Model.IsVolunteerMember)
-        {
-            @if (Model.MembershipTier != MembershipTier.Volunteer)
-            {
-                <div class="card mb-4">
-                    <div class="card-header">
-                        @Localizer["Dashboard_MembershipTier"]
-                        <span class="badge bg-primary ms-2">@Model.MembershipTier</span>
-                    </div>
-                    <div class="card-body">
-                        @if (Model.TermExpired)
-                        {
-                            <div class="alert alert-danger mb-2">
-                                <strong>@Localizer["Dashboard_TermExpired"]</strong>
-                            </div>
-                            <a asp-controller="Application" asp-action="Create" class="btn btn-sm btn-primary">@Localizer["Dashboard_RenewNow"]</a>
-                        }
-                        else if (Model.TermExpiresSoon)
-                        {
-                            <div class="alert alert-warning mb-2">
-                                @Html.Raw(string.Format(Localizer["Dashboard_TermExpiresSoon"].Value, Model.TermExpiresAt?.ToDisplayDate()))
-                            </div>
-                            <a asp-controller="Application" asp-action="Create" class="btn btn-sm btn-warning">@Localizer["Dashboard_RenewNow"]</a>
-                        }
-                        else if (Model.HasPendingApplication)
-                        {
-                            <p class="text-warning mb-2">@Localizer["Dashboard_TierApplicationPending"]</p>
-                        }
-                        else
-                        {
-                            <p class="text-success mb-2">@Localizer["Dashboard_TierActive"]</p>
-                        }
-                        @if (Model.TermExpiresAt.HasValue && !Model.TermExpired)
-                        {
-                            <p class="text-muted mb-0"><small>@Html.Raw(string.Format(Localizer["Dashboard_TermExpires"].Value, Model.TermExpiresAt.Value.ToDisplayDate()))</small></p>
-                        }
-                    </div>
-                </div>
-            }
-
-        }
     </div>
+</div>
 
-    <div class="col-md-4">
-        <div class="card mb-4">
-            <div class="card-header">
-                <i class="fa-solid fa-ticket me-1"></i> Your Ticket
+@* ─── Pending consents alert ─── *@
+@if (Model.PendingConsents > 0)
+{
+    <div class="row justify-content-center mb-4">
+        <div class="col-lg-8">
+            <div class="alert alert-warning d-flex align-items-center mb-0" role="alert">
+                <i class="fa-solid fa-file-signature me-2"></i>
+                <div>
+                    <a asp-controller="Consent" asp-action="Index" class="alert-link">
+                        @Model.PendingConsents @(Model.PendingConsents == 1 ? Localizer["Dashboard_AgreementSingular"].Value : Localizer["Dashboard_AgreementPlural"].Value)
+                    </a>
+                </div>
             </div>
+        </div>
+    </div>
+}
+
+@* ─── Term expiry warnings (Colaborador/Asociado) ─── *@
+@if (Model.IsVolunteerMember && Model.MembershipTier != MembershipTier.Volunteer)
+{
+    <div class="row justify-content-center mb-4">
+        <div class="col-lg-8">
+            @if (Model.TermExpired)
+            {
+                <div class="card border-0 shadow-sm">
+                    <div class="card-body d-flex align-items-center py-3">
+                        <div class="rounded-circle d-inline-flex align-items-center justify-content-center me-3"
+                             style="width: 40px; height: 40px; background: var(--h-alert-danger-bg); color: var(--h-rust); flex-shrink: 0;">
+                            <i class="fa-solid fa-clock"></i>
+                        </div>
+                        <div class="flex-grow-1">
+                            <strong>@Localizer["Dashboard_TermExpired"]</strong>
+                            <br /><small class="text-muted">@Localizer["Dashboard_MembershipTier"]: @Model.MembershipTier</small>
+                        </div>
+                        <a asp-controller="Application" asp-action="Create" class="btn btn-sm btn-primary ms-3">@Localizer["Dashboard_RenewNow"]</a>
+                    </div>
+                </div>
+            }
+            else if (Model.TermExpiresSoon)
+            {
+                <div class="card border-0 shadow-sm">
+                    <div class="card-body d-flex align-items-center py-3">
+                        <div class="rounded-circle d-inline-flex align-items-center justify-content-center me-3"
+                             style="width: 40px; height: 40px; background: var(--h-alert-warning-bg); color: var(--h-amber-dark); flex-shrink: 0;">
+                            <i class="fa-solid fa-clock"></i>
+                        </div>
+                        <div class="flex-grow-1">
+                            @Html.Raw(string.Format(Localizer["Dashboard_TermExpiresSoon"].Value, Model.TermExpiresAt?.ToDisplayDate()))
+                            <br /><small class="text-muted">@Localizer["Dashboard_MembershipTier"]: @Model.MembershipTier</small>
+                        </div>
+                        <a asp-controller="Application" asp-action="Create" class="btn btn-sm btn-warning ms-3">@Localizer["Dashboard_RenewNow"]</a>
+                    </div>
+                </div>
+            }
+            else if (Model.HasPendingApplication)
+            {
+                <div class="card border-0 shadow-sm">
+                    <div class="card-body d-flex align-items-center py-3">
+                        <div class="rounded-circle d-inline-flex align-items-center justify-content-center me-3"
+                             style="width: 40px; height: 40px; background: var(--h-alert-info-bg); color: var(--h-blue-muted); flex-shrink: 0;">
+                            <i class="fa-solid fa-hourglass-half"></i>
+                        </div>
+                        <div>
+                            <strong>@Localizer["Dashboard_TierApplicationPending"]</strong>
+                            <br /><small class="text-muted">@Localizer["Dashboard_MembershipTier"]: @Model.MembershipTier</small>
+                        </div>
+                    </div>
+                </div>
+            }
+            else
+            {
+                <div class="card border-0 shadow-sm">
+                    <div class="card-body d-flex align-items-center py-3">
+                        <div class="rounded-circle d-inline-flex align-items-center justify-content-center me-3"
+                             style="width: 40px; height: 40px; background: var(--h-alert-success-bg); color: var(--h-sage-dark); flex-shrink: 0;">
+                            <i class="fa-solid fa-circle-check"></i>
+                        </div>
+                        <div>
+                            <strong>@Localizer["Dashboard_TierActive"]</strong>
+                            <span class="badge bg-primary ms-2">@Model.MembershipTier</span>
+                            @if (Model.TermExpiresAt.HasValue)
+                            {
+                                <br /><small class="text-muted">@Html.Raw(string.Format(Localizer["Dashboard_TermExpires"].Value, Model.TermExpiresAt.Value.ToDisplayDate()))</small>
+                            }
+                        </div>
+                    </div>
+                </div>
+            }
+        </div>
+    </div>
+}
+
+@* ─── Ticket Status ─── *@
+<div class="row justify-content-center mb-5">
+    <div class="col-lg-8">
+        <div class="card border-0 shadow-sm">
             <div class="card-body">
                 @if (!Model.TicketsConfigured)
                 {
-                    <div class="alert alert-warning mb-0">
-                        <i class="fa-solid fa-triangle-exclamation me-1"></i> Ticket vendor not configured. Contact an admin.
+                    <div class="d-flex align-items-center">
+                        <div class="rounded-circle d-inline-flex align-items-center justify-content-center me-3"
+                             style="width: 40px; height: 40px; background: var(--h-alert-warning-bg); color: var(--h-amber-dark); flex-shrink: 0;">
+                            <i class="fa-solid fa-ticket"></i>
+                        </div>
+                        <div>
+                            <strong>@Localizer["Dashboard_TicketNotConfigured"]</strong>
+                        </div>
                     </div>
                 }
                 else if (Model.HasTicket)
                 {
                     <div class="d-flex align-items-center">
-                        <i class="fa-solid fa-circle-check text-success fs-3 me-3"></i>
+                        <div class="rounded-circle d-inline-flex align-items-center justify-content-center me-3"
+                             style="width: 40px; height: 40px; background: var(--h-alert-success-bg); color: var(--h-sage-dark); flex-shrink: 0;">
+                            <i class="fa-solid fa-ticket"></i>
+                        </div>
                         <div>
-                            <strong>Thanks for getting your ticket!</strong>
+                            <h5 class="mb-0">@Localizer["Dashboard_TicketConfirmed"]</h5>
                             @if (Model.UserTicketCount > 1)
                             {
-                                <br /><span class="text-muted">You have @Model.UserTicketCount tickets</span>
+                                <small class="text-muted">@string.Format(Localizer["Dashboard_TicketCount"].Value, Model.UserTicketCount)</small>
                             }
                         </div>
                     </div>
@@ -207,55 +179,284 @@
                 else if (Model.ParticipationStatus == ParticipationStatus.NotAttending)
                 {
                     <div class="d-flex align-items-center mb-3">
-                        <i class="fa-solid fa-circle-xmark text-secondary fs-3 me-3"></i>
+                        <div class="rounded-circle d-inline-flex align-items-center justify-content-center me-3"
+                             style="width: 40px; height: 40px; background: var(--h-parchment); color: var(--h-aged-ink); flex-shrink: 0;">
+                            <i class="fa-solid fa-ticket"></i>
+                        </div>
                         <div>
-                            <strong>You're marked as not attending this year.</strong>
-                            <br /><span class="text-muted">Changed your mind? You can undo this below.</span>
+                            <h5 class="mb-0">@Localizer["Dashboard_NotAttending"]</h5>
+                            <small class="text-muted">@Localizer["Dashboard_NotAttendingHint"]</small>
                         </div>
                     </div>
                     <form asp-action="UndoNotAttending" method="post">
                         @Html.AntiForgeryToken()
                         <button type="submit" class="btn btn-outline-primary btn-sm">
-                            <i class="fa-solid fa-rotate-left me-1"></i> Undo — I might attend
+                            <i class="fa-solid fa-rotate-left me-1"></i> @Localizer["Dashboard_UndoNotAttending"]
                         </button>
                     </form>
                 }
                 else
                 {
-                    <p class="mb-2">We don't see a ticket linked to your account yet.</p>
-                    <a href="@Model.TicketPurchaseUrl" target="_blank" rel="noopener" class="btn btn-primary">
-                        <i class="fa-solid fa-external-link-alt me-1"></i> Buy your ticket now
-                    </a>
-                    <p class="text-muted small mt-2 mb-0">Bought on a different email? <a href="/Profile/Me/Emails">Add it here</a></p>
+                    <div class="d-flex align-items-center mb-3">
+                        <div class="rounded-circle d-inline-flex align-items-center justify-content-center me-3"
+                             style="width: 40px; height: 40px; background: var(--h-alert-info-bg); color: var(--h-blue-muted); flex-shrink: 0;">
+                            <i class="fa-solid fa-ticket"></i>
+                        </div>
+                        <div>
+                            <h5 class="mb-0">@Localizer["Dashboard_TicketMissing"]</h5>
+                            <small class="text-muted">@Localizer["Dashboard_TicketMissingHint"]</small>
+                        </div>
+                    </div>
+                    <div class="d-flex flex-wrap gap-2 align-items-center">
+                        <a href="@Model.TicketPurchaseUrl" target="_blank" rel="noopener" class="btn btn-primary">
+                            <i class="fa-solid fa-external-link-alt me-1"></i> @Localizer["Dashboard_BuyTicket"]
+                        </a>
+                        <a asp-controller="Profile" asp-action="Emails" class="btn btn-outline-secondary btn-sm">@Localizer["Dashboard_DifferentEmail"]</a>
+                    </div>
                     @if (Model.EventYear.HasValue)
                     {
                         <hr />
                         <form asp-action="DeclareNotAttending" method="post">
                             @Html.AntiForgeryToken()
                             <button type="submit" class="btn btn-outline-secondary btn-sm">
-                                <i class="fa-solid fa-xmark me-1"></i> Not attending this year
+                                <i class="fa-solid fa-xmark me-1"></i> @Localizer["Dashboard_DeclareNotAttending"]
                             </button>
                         </form>
                     }
                 }
             </div>
         </div>
+    </div>
+</div>
 
-        @if (Model.IsVolunteerMember)
-        {
-            @await Component.InvokeAsync("MyGoogleResources")
-        }
+@{
+    var shiftCards = ViewData["ShiftCards"] as Humans.Web.Models.ShiftCardsViewModel;
+    var hasUpcomingShifts = shiftCards?.NextShifts.Count > 0 || shiftCards?.PendingCount > 0;
+}
 
-        @if (Model.PendingConsents > 0)
-        {
-            <div class="alert alert-warning d-flex align-items-center mb-4" role="alert">
-                <i class="fa-solid fa-file-signature me-2"></i>
-                <div>
-                    <a asp-controller="Consent" asp-action="Index" class="alert-link">
-                        @string.Format((Model.PendingConsents == 1 ? Localizer["Dashboard_PendingAgreementsSingular"] : Localizer["Dashboard_PendingAgreementsPlural"]).Value, Model.PendingConsents)
+@* ─── Your shifts (if signed up) ─── *@
+@if (hasUpcomingShifts)
+{
+    <div class="row justify-content-center mb-5">
+        <div class="col-lg-8">
+            <vc:shift-signups user-id="@Model.UserId" view-mode="@ShiftSignupsViewMode.Self" />
+
+            @if (shiftCards?.UrgentShifts.Count > 0)
+            {
+                <div class="card border-0 shadow-sm mt-3">
+                    <div class="card-body">
+                        <h6 class="mb-3"><i class="fa-solid fa-fire text-danger me-1"></i>@Localizer["GetInvolved_UrgentShifts"]</h6>
+                        <ul class="list-unstyled mb-2">
+                            @foreach (var item in shiftCards.UrgentShifts)
+                            {
+                                <li class="d-flex justify-content-between align-items-center py-1">
+                                    <span>
+                                        <strong>@(item?.Shift?.Rota?.Name ?? "Unknown")</strong>
+                                        <small class="text-muted ms-1">@(item?.DepartmentName ?? "")</small>
+                                    </span>
+                                    <span class="badge bg-danger">@(item?.RemainingSlots ?? 0) slots</span>
+                                </li>
+                            }
+                        </ul>
+                        <a asp-controller="Shifts" asp-action="Index" class="btn btn-sm btn-outline-success">@Localizer["GetInvolved_BrowseAllShifts"]</a>
+                    </div>
+                </div>
+            }
+        </div>
+    </div>
+}
+else if (Model.IsShiftBrowsingOpen && Model.IsVolunteerMember)
+{
+    @* ─── Guided shift discovery — no shifts yet ─── *@
+    <div class="row justify-content-center mb-5">
+        <div class="col-lg-8">
+            <div class="card border-0 shadow" style="background: var(--h-aged-ink); color: var(--h-parchment-light);">
+                <div class="card-body text-center py-5 px-4">
+                    <h2 class="display-6 fw-bold mb-3" style="color: var(--h-parchment-light);">
+                        <i class="fa-solid fa-hand-holding-heart me-2"></i>@Localizer["GetInvolved_Title"]
+                    </h2>
+                    <p class="mb-2" style="max-width: 520px; margin: 0 auto; line-height: 1.3; color: var(--h-parchment-light);">
+                        @Localizer["GetInvolved_Intro"]
+                    </p>
+
+                    <div class="row g-3 my-4 justify-content-center">
+                        <div class="col-sm-4">
+                            <div class="rounded p-3 h-100" style="background: rgba(255,255,255,0.08);">
+                                <h6 style="color: var(--h-gold);">@Localizer["GetInvolved_Phase_Setup"]</h6>
+                                <small style="color: var(--h-parchment-dark);">@Localizer["GetInvolved_Phase_Setup_Desc"]</small>
+                            </div>
+                        </div>
+                        <div class="col-sm-4">
+                            <div class="rounded p-3 h-100" style="background: rgba(255,255,255,0.08);">
+                                <h6 style="color: var(--h-gold);">@Localizer["GetInvolved_Phase_Event"]</h6>
+                                <small style="color: var(--h-parchment-dark);">@Localizer["GetInvolved_Phase_Event_Desc"]</small>
+                            </div>
+                        </div>
+                        <div class="col-sm-4">
+                            <div class="rounded p-3 h-100" style="background: rgba(255,255,255,0.08);">
+                                <h6 style="color: var(--h-gold);">@Localizer["GetInvolved_Phase_Strike"]</h6>
+                                <small style="color: var(--h-parchment-dark);">@Localizer["GetInvolved_Phase_Strike_Desc"]</small>
+                            </div>
+                        </div>
+                    </div>
+
+                    @if (shiftCards?.UrgentShifts.Count > 0)
+                    {
+                        <div class="text-start mb-3" style="max-width: 520px; margin: 0 auto;">
+                            <h6 style="color: var(--h-gold);"><i class="fa-solid fa-fire me-1"></i>@Localizer["GetInvolved_UrgentShifts"]</h6>
+                            <ul class="list-unstyled mb-0">
+                                @foreach (var item in shiftCards.UrgentShifts)
+                                {
+                                    <li class="d-flex justify-content-between align-items-center py-1" style="color: var(--h-parchment-light);">
+                                        <span>
+                                            <strong>@(item?.Shift?.Rota?.Name ?? "Unknown")</strong>
+                                            <small class="ms-1" style="color: var(--h-parchment-dark);">@(item?.DepartmentName ?? "")</small>
+                                        </span>
+                                        <span class="badge bg-danger">@(item?.RemainingSlots ?? 0) slots</span>
+                                    </li>
+                                }
+                            </ul>
+                        </div>
+                    }
+
+                    <div class="d-flex justify-content-center gap-2">
+                        <a asp-controller="Shifts" asp-action="Index" class="btn btn-lg px-4" style="background: var(--h-gold); color: var(--h-aged-ink); font-weight: 600;">
+                            <i class="fa-solid fa-calendar-alt me-1"></i>@Localizer["GetInvolved_BrowseAllShifts"]
+                        </a>
+                        <a asp-controller="Shifts" asp-action="Mine" class="btn btn-lg btn-outline-light px-4">
+                            <i class="fa-solid fa-clipboard-list me-1"></i>@Localizer["GetInvolved_MyShifts"]
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+}
+
+@* ─── Get involved ─── *@
+@if (Model.IsVolunteerMember)
+{
+    <div class="row justify-content-center mb-5">
+        <div class="col-lg-8">
+            <h5 class="text-muted mb-1">@Localizer["Dashboard_GetInvolved"]</h5>
+            <p class="text-muted small mb-3 guest-section-sub">@Localizer["Dashboard_GetInvolvedSubtitle"]</p>
+            <div class="row g-3">
+                <div class="col-sm-4">
+                    <a asp-controller="Shifts" asp-action="Index" class="card border-0 shadow-sm text-decoration-none h-100 guest-explore-card">
+                        <div class="card-body text-center py-4">
+                            <div class="rounded-circle d-inline-flex align-items-center justify-content-center mb-2"
+                                 style="width: 48px; height: 48px; background: var(--h-parchment); color: var(--h-aged-ink);">
+                                <i class="fa-solid fa-calendar-alt fa-lg"></i>
+                            </div>
+                            <div class="fw-semibold" style="color: var(--h-text);">@Localizer["Nav_Shifts"]</div>
+                            <small class="text-muted d-block mt-1" style="line-height: 1.3;">@Localizer["Dashboard_ShiftsDescription"]</small>
+                        </div>
+                    </a>
+                </div>
+                <div class="col-sm-4">
+                    <a asp-controller="Team" asp-action="Index" class="card border-0 shadow-sm text-decoration-none h-100 guest-explore-card">
+                        <div class="card-body text-center py-4">
+                            <div class="rounded-circle d-inline-flex align-items-center justify-content-center mb-2"
+                                 style="width: 48px; height: 48px; background: var(--h-parchment); color: var(--h-aged-ink);">
+                                <i class="fa-solid fa-people-group fa-lg"></i>
+                            </div>
+                            <div class="fw-semibold" style="color: var(--h-text);">@Localizer["Nav_Teams"]</div>
+                            <small class="text-muted d-block mt-1" style="line-height: 1.3;">@Localizer["Dashboard_TeamsDescription"]</small>
+                        </div>
+                    </a>
+                </div>
+                <div class="col-sm-4">
+                    <a asp-controller="Camp" asp-action="Index" class="card border-0 shadow-sm text-decoration-none h-100 guest-explore-card">
+                        <div class="card-body text-center py-4">
+                            <div class="rounded-circle d-inline-flex align-items-center justify-content-center mb-2"
+                                 style="width: 48px; height: 48px; background: var(--h-parchment); color: var(--h-aged-ink);">
+                                <i class="fa-solid fa-campground fa-lg"></i>
+                            </div>
+                            <div class="fw-semibold" style="color: var(--h-text);">@Localizer["Camp_Plural"]</div>
+                            <small class="text-muted d-block mt-1" style="line-height: 1.3;">@Localizer["Dashboard_CampsDescription"]</small>
+                        </div>
                     </a>
                 </div>
             </div>
-        }
+        </div>
+    </div>
+}
+
+@* ─── Your stuff ─── *@
+<div class="row justify-content-center mb-4">
+    <div class="col-lg-8">
+        <h5 class="text-muted mb-1">@Localizer["Dashboard_YourStuff"]</h5>
+        <p class="text-muted small mb-3 guest-section-sub">@Localizer["Dashboard_YourStuffSubtitle"]</p>
+        <div class="row g-3">
+            <div class="col-md-4">
+                <a asp-controller="Profile" asp-action="Edit" class="card border-0 shadow-sm text-decoration-none h-100 guest-explore-card">
+                    <div class="card-body d-flex align-items-center py-3">
+                        <div class="rounded-circle d-inline-flex align-items-center justify-content-center me-3"
+                             style="width: 40px; height: 40px; background: var(--h-parchment); color: var(--h-aged-ink); flex-shrink: 0;">
+                            <i class="fa-solid fa-user-pen"></i>
+                        </div>
+                        <div>
+                            <div class="fw-semibold" style="color: var(--h-text);">@Localizer["Dashboard_ProfileCard"]</div>
+                            <small class="text-muted d-block" style="line-height: 1.3;">@Localizer["Dashboard_ProfileCardDescription"]</small>
+                        </div>
+                    </div>
+                </a>
+            </div>
+            <div class="col-md-4">
+                <a asp-controller="Consent" asp-action="Index" class="card border-0 shadow-sm text-decoration-none h-100 guest-explore-card">
+                    <div class="card-body d-flex align-items-center py-3">
+                        <div class="rounded-circle d-inline-flex align-items-center justify-content-center me-3"
+                             style="width: 40px; height: 40px; background: var(--h-alert-info-bg); color: var(--h-blue-muted); flex-shrink: 0;">
+                            <i class="fa-solid fa-file-signature"></i>
+                        </div>
+                        <div>
+                            <div class="fw-semibold" style="color: var(--h-text);">@Localizer["Dashboard_ConsentsCard"]</div>
+                            <small class="text-muted d-block" style="line-height: 1.3;">@Localizer["Dashboard_ConsentsCardDescription"]</small>
+                        </div>
+                    </div>
+                </a>
+            </div>
+            <div class="col-md-4">
+                <a asp-controller="Profile" asp-action="Privacy" class="card border-0 shadow-sm text-decoration-none h-100 guest-explore-card">
+                    <div class="card-body d-flex align-items-center py-3">
+                        <div class="rounded-circle d-inline-flex align-items-center justify-content-center me-3"
+                             style="width: 40px; height: 40px; background: var(--h-alert-info-bg); color: var(--h-blue-muted); flex-shrink: 0;">
+                            <i class="fa-solid fa-shield-halved"></i>
+                        </div>
+                        <div>
+                            <div class="fw-semibold" style="color: var(--h-text);">@Localizer["Dashboard_PrivacyCard"]</div>
+                            <small class="text-muted d-block" style="line-height: 1.3;">@Localizer["Dashboard_PrivacyCardDescription"]</small>
+                        </div>
+                    </div>
+                </a>
+            </div>
+            @if (Model.IsVolunteerMember)
+            {
+                <div class="col-md-4">
+                    <a asp-controller="Application" asp-action="Index" class="card border-0 shadow-sm text-decoration-none h-100 guest-explore-card">
+                        <div class="card-body d-flex align-items-center py-3">
+                            <div class="rounded-circle d-inline-flex align-items-center justify-content-center me-3"
+                                 style="width: 40px; height: 40px; background: var(--h-parchment); color: var(--h-aged-ink); flex-shrink: 0;">
+                                <i class="fa-solid fa-landmark"></i>
+                            </div>
+                            <div>
+                                <div class="fw-semibold" style="color: var(--h-text);">@Localizer["Nav_Governance"]</div>
+                                <small class="text-muted d-block" style="line-height: 1.3;">@Localizer["Dashboard_GovernanceCardDescription"]</small>
+                            </div>
+                        </div>
+                    </a>
+                </div>
+            }
+        </div>
     </div>
 </div>
+
+@* ─── Google Resources (volunteer only) ─── *@
+@if (Model.IsVolunteerMember)
+{
+    <div class="row justify-content-center mb-4">
+        <div class="col-lg-8">
+            @await Component.InvokeAsync("MyGoogleResources")
+        </div>
+    </div>
+}

--- a/src/Humans.Web/Views/Home/Dashboard.cshtml
+++ b/src/Humans.Web/Views/Home/Dashboard.cshtml
@@ -251,10 +251,10 @@
                             {
                                 <li class="d-flex justify-content-between align-items-center py-1">
                                     <span>
-                                        <strong>@(item?.Shift?.Rota?.Name ?? "Unknown")</strong>
+                                        <strong>@(item?.Shift?.Rota?.Name ?? Localizer["Common_Unknown"].Value)</strong>
                                         <small class="text-muted ms-1">@(item?.DepartmentName ?? "")</small>
                                     </span>
-                                    <span class="badge bg-danger">@(item?.RemainingSlots ?? 0) slots</span>
+                                    <span class="badge bg-danger">@(item?.RemainingSlots ?? 0) @((item?.RemainingSlots ?? 0) == 1 ? Localizer["Dashboard_SlotsSingular"].Value : Localizer["Dashboard_SlotsPlural"].Value)</span>
                                 </li>
                             }
                         </ul>
@@ -309,10 +309,10 @@ else if (Model.IsShiftBrowsingOpen && Model.IsVolunteerMember)
                                 {
                                     <li class="d-flex justify-content-between align-items-center py-1" style="color: var(--h-parchment-light);">
                                         <span>
-                                            <strong>@(item?.Shift?.Rota?.Name ?? "Unknown")</strong>
+                                            <strong>@(item?.Shift?.Rota?.Name ?? Localizer["Common_Unknown"].Value)</strong>
                                             <small class="ms-1" style="color: var(--h-parchment-dark);">@(item?.DepartmentName ?? "")</small>
                                         </span>
-                                        <span class="badge bg-danger">@(item?.RemainingSlots ?? 0) slots</span>
+                                        <span class="badge bg-danger">@(item?.RemainingSlots ?? 0) @((item?.RemainingSlots ?? 0) == 1 ? Localizer["Dashboard_SlotsSingular"].Value : Localizer["Dashboard_SlotsPlural"].Value)</span>
                                     </li>
                                 }
                             </ul>


### PR DESCRIPTION
Rebases Laura's commit `e6e6e095` from nobodies-collective/Humans#245 onto current `peterdrier/Humans:main` (after #244 landed) so it can ride the QA preview environment before promotion to upstream.

## Summary
- Full volunteer Home Dashboard redesign to match guest dashboard visual language.
- Centered single-column layout replaces the 2-column sidebar.
- Card grids for "Get involved" (Shifts / Teams / Camps) and "Your stuff" (Profile / Agreements / Privacy / Governance) with icon circles and hover lift.
- Ticket card redesigned with icon-in-circle pattern, all 4 states localized.
- Shift discovery CTA uses the dark hero card style from the guest CTA.
- Tier badge inline in the header; term warnings as compact inline cards.
- 26 new localization keys added to all 6 locales (en, es, ca, fr, it, de).

## Rebase notes
Laura's branch was cut from the same base as #244, so the cherry-pick produced merge conflicts in `Dashboard.cshtml` (four hunks). Resolution took Laura's full redesign as `--theirs` since #245 is a complete restructure that supersedes the smaller #244 declutter.

After this merges, two orphan keys remain from #244 that can be cleaned up separately:
- `Dashboard_PendingAgreementsSingular` / `Dashboard_PendingAgreementsPlural` — Laura uses her own `Dashboard_AgreementSingular` / `Dashboard_AgreementPlural` instead.

## Test plan
- [ ] Log in as a volunteer — header, Things to do, Pending consents, Term card, Ticket card, Shift card, Get involved, Your stuff, Google Resources all render
- [ ] Ticket card in all four states: NotConfigured / Confirmed / NotAttending / Missing
- [ ] Shift discovery CTA shows when `IsShiftBrowsingOpen` and user has no upcoming shifts
- [ ] Switch locale (es/ca/fr/it/de) and verify every new string is translated
- [ ] Mobile responsive check (`col-md-4` → stacked)
- [ ] Rejected user sees the rejection alert only

Upstream PR: nobodies-collective/Humans#245