### PR TITLE
Exclude SignalR hubs from global rate limiter (#536)

### DIFF
--- a/src/Humans.Web/Program.cs
+++ b/src/Humans.Web/Program.cs
@@ -342,6 +342,12 @@ builder.Services.AddRateLimiter(options =>
         if (context.Request.Path.StartsWithSegments("/Profile/Picture", StringComparison.OrdinalIgnoreCase))
             return RateLimitPartition.GetNoLimiter(string.Empty);
 
+        // Exclude SignalR hubs — long-polling fallback sends one POST per invoke,
+        // which trivially exceeds the global 100/min cap during active use.
+        // SignalR manages its own backpressure; abuse is handled via auth on the hub.
+        if (context.Request.Path.StartsWithSegments("/hubs", StringComparison.OrdinalIgnoreCase))
+            return RateLimitPartition.GetNoLimiter(string.Empty);
+
         // Exclude local network — e2e tests and internal tooling run from 192.168.*
         var remoteIp = context.Connection.RemoteIpAddress?.ToString();
         if (remoteIp is not null && remoteIp.StartsWith("192.168.", StringComparison.Ordinal))


### PR DESCRIPTION
## Summary
- Adds `/hubs/*` exclusion to the global rate limiter in `Program.cs`, next to the existing `/favicon.ico` and `/Profile/Picture` exclusions.

## Why
Long-polling fallback sends one HTTP POST per invoke, and the City Planning cursor-update handler fires on every mouse-move. Production logs captured 114 POSTs to `/hubs/city-planning` from a single user in 19 minutes, all hitting the 100/min cap. SignalR handles its own backpressure; abuse is gated at hub auth.

## Test plan
- [ ] Deploy to QA; open City Planning map, move cursor continuously for 2+ minutes.
- [ ] Confirm no 429s appear in logs for `/hubs/city-planning`.
- [ ] Confirm scanner probes (`/phpinfo.php`, `.env`) still get rate-limited.
- [ ] Confirm favicon + profile pictures still bypass (unchanged paths).

Closes #536