### PR TITLE
Quiet OperationCanceledException in dashboard (#535)

### DIFF
--- a/src/Humans.Application/Services/Dashboard/DashboardService.cs
+++ b/src/Humans.Application/Services/Dashboard/DashboardService.cs
@@ -210,10 +210,6 @@ public class DashboardService : IDashboardService
                 participationStatus = participation?.Status;
             }
         }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-        {
-            throw;
-        }
         catch (OperationCanceledException ex)
         {
             _logger.LogWarning("Dashboard participation load cancelled for user {UserId}: {Reason}", userId, ex.Message);

--- a/src/Humans.Application/Services/Dashboard/DashboardService.cs
+++ b/src/Humans.Application/Services/Dashboard/DashboardService.cs
@@ -210,6 +210,14 @@ public class DashboardService : IDashboardService
                 participationStatus = participation?.Status;
             }
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (OperationCanceledException ex)
+        {
+            _logger.LogWarning("Dashboard participation load cancelled for user {UserId}: {Reason}", userId, ex.Message);
+        }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to load participation status for user {UserId}", userId);


### PR DESCRIPTION
## Summary
- Catches `OperationCanceledException` in `DashboardService.GetMemberDashboardAsync`'s participation-load try block.
- Re-throws when the caller's `CancellationToken` is cancelled (preserves cooperative cancellation).
- Otherwise logs at Warning with structured `{Reason}` and no exception object, matching the #497/#499/#500 pattern.

## Why
An `OperationCanceledException` was surfacing as a LogError with full stack when the user navigated away mid-load. Follows the established pattern for quieting expected OCEs without losing log signal.

## Test plan
- [ ] Deploy to QA.
- [ ] Navigate to dashboard, immediately hit back — confirm no Error-level log with OCE stack.
- [ ] Confirm a Warning with `Dashboard participation load cancelled for user ...` appears instead.
- [ ] Regular dashboard loads still populate participation status.

Closes #535