### PR TITLE
Reject @nobodies.team provisioning when prefix is in use by another human (#501)

### DIFF
--- a/src/Humans.Infrastructure/Services/EmailProvisioningService.cs
+++ b/src/Humans.Infrastructure/Services/EmailProvisioningService.cs
@@ -67,6 +67,36 @@ public class EmailProvisioningService : IEmailProvisioningService
 
         try
         {
+            // Check DB first: reject if the address is already tied to another human in our system.
+            // Must run BEFORE the Workspace existence check so a stale/deleted Workspace account
+            // cannot silently "move" the identity off its current human.
+            var conflictingEmailUserId = await _dbContext.UserEmails
+                .Where(ue => string.Equals(ue.Email, fullEmail, StringComparison.OrdinalIgnoreCase))
+                .Select(ue => (Guid?)ue.UserId)
+                .FirstOrDefaultAsync();
+            if (conflictingEmailUserId is not null && conflictingEmailUserId != userId)
+            {
+                _logger.LogWarning(
+                    "Provisioning rejected: {Email} is already linked to user {ConflictUserId} (requested for {UserId})",
+                    fullEmail, conflictingEmailUserId, userId);
+                return new EmailProvisioningResult(false, fullEmail,
+                    ErrorMessage: $"{fullEmail} is already in use by another human.");
+            }
+
+            var conflictingGoogleEmailUserId = await _dbContext.Users
+                .Where(u => u.GoogleEmail != null
+                    && string.Equals(u.GoogleEmail, fullEmail, StringComparison.OrdinalIgnoreCase))
+                .Select(u => (Guid?)u.Id)
+                .FirstOrDefaultAsync();
+            if (conflictingGoogleEmailUserId is not null && conflictingGoogleEmailUserId != userId)
+            {
+                _logger.LogWarning(
+                    "Provisioning rejected: {Email} is already set as GoogleEmail for user {ConflictUserId} (requested for {UserId})",
+                    fullEmail, conflictingGoogleEmailUserId, userId);
+                return new EmailProvisioningResult(false, fullEmail,
+                    ErrorMessage: $"{fullEmail} is already in use by another human.");
+            }
+
             // Check if account already exists in Google Workspace
             var existing = await _workspaceUserService.GetAccountAsync(fullEmail);
             if (existing is not null)

--- a/src/Humans.Infrastructure/Services/EmailProvisioningService.cs
+++ b/src/Humans.Infrastructure/Services/EmailProvisioningService.cs
@@ -70,11 +70,15 @@ public class EmailProvisioningService : IEmailProvisioningService
             // Check DB first: reject if the address is already tied to another human in our system.
             // Must run BEFORE the Workspace existence check so a stale/deleted Workspace account
             // cannot silently "move" the identity off its current human.
+            //
+            // Filter UserId != userId inside the query (not after FirstOrDefault) so duplicate
+            // rows with mixed case or historical drift can't mask a real cross-user conflict.
             var conflictingEmailUserId = await _dbContext.UserEmails
-                .Where(ue => string.Equals(ue.Email, fullEmail, StringComparison.OrdinalIgnoreCase))
+                .Where(ue => string.Equals(ue.Email, fullEmail, StringComparison.OrdinalIgnoreCase)
+                    && ue.UserId != userId)
                 .Select(ue => (Guid?)ue.UserId)
                 .FirstOrDefaultAsync();
-            if (conflictingEmailUserId is not null && conflictingEmailUserId != userId)
+            if (conflictingEmailUserId is not null)
             {
                 _logger.LogWarning(
                     "Provisioning rejected: {Email} is already linked to user {ConflictUserId} (requested for {UserId})",
@@ -85,16 +89,34 @@ public class EmailProvisioningService : IEmailProvisioningService
 
             var conflictingGoogleEmailUserId = await _dbContext.Users
                 .Where(u => u.GoogleEmail != null
-                    && string.Equals(u.GoogleEmail, fullEmail, StringComparison.OrdinalIgnoreCase))
+                    && string.Equals(u.GoogleEmail, fullEmail, StringComparison.OrdinalIgnoreCase)
+                    && u.Id != userId)
                 .Select(u => (Guid?)u.Id)
                 .FirstOrDefaultAsync();
-            if (conflictingGoogleEmailUserId is not null && conflictingGoogleEmailUserId != userId)
+            if (conflictingGoogleEmailUserId is not null)
             {
                 _logger.LogWarning(
                     "Provisioning rejected: {Email} is already set as GoogleEmail for user {ConflictUserId} (requested for {UserId})",
                     fullEmail, conflictingGoogleEmailUserId, userId);
                 return new EmailProvisioningResult(false, fullEmail,
                     ErrorMessage: $"{fullEmail} is already in use by another human.");
+            }
+
+            // Reject if the prefix collides with a team's Google Group. Team groups
+            // live on the same domain (@nobodies.team), so a user account with the
+            // same address would cause mail-routing chaos and break group membership.
+            var conflictingTeamName = await _dbContext.Teams
+                .Where(t => t.GoogleGroupPrefix != null
+                    && string.Equals(t.GoogleGroupPrefix, sanitizedPrefix, StringComparison.OrdinalIgnoreCase))
+                .Select(t => t.Name)
+                .FirstOrDefaultAsync();
+            if (conflictingTeamName is not null)
+            {
+                _logger.LogWarning(
+                    "Provisioning rejected: {Email} is the Google Group address for team '{TeamName}' (requested for {UserId})",
+                    fullEmail, conflictingTeamName, userId);
+                return new EmailProvisioningResult(false, fullEmail,
+                    ErrorMessage: $"{fullEmail} is the Google Group address for team \"{conflictingTeamName}\" and cannot be used as a personal account.");
             }
 
             // Check if account already exists in Google Workspace

--- a/src/Humans.Infrastructure/Services/GoogleAdminService.cs
+++ b/src/Humans.Infrastructure/Services/GoogleAdminService.cs
@@ -134,7 +134,8 @@ public class GoogleAdminService : IGoogleAdminService
         Guid actorUserId,
         CancellationToken ct = default)
     {
-        var fullEmail = $"{emailPrefix.Trim().ToLowerInvariant()}@{NobodiesTeamDomain}";
+        var normalizedPrefix = emailPrefix.Trim().ToLowerInvariant();
+        var fullEmail = $"{normalizedPrefix}@{NobodiesTeamDomain}";
 
         // Check DB first: reject if the address is already tied to any human in our system.
         // Must run BEFORE the Workspace existence check so a stale/deleted Workspace account
@@ -160,6 +161,23 @@ public class GoogleAdminService : IGoogleAdminService
                 fullEmail);
             return new WorkspaceAccountActionResult(false,
                 ErrorMessage: $"{fullEmail} is already in use by another human.");
+        }
+
+        // Reject if the prefix collides with a team's Google Group. Team groups live on
+        // the same domain (@nobodies.team), so provisioning a user account with the same
+        // address would cause mail-routing chaos and break group membership.
+        var conflictingTeamName = await _dbContext.Teams
+            .Where(t => t.GoogleGroupPrefix != null
+                && string.Equals(t.GoogleGroupPrefix, normalizedPrefix, StringComparison.OrdinalIgnoreCase))
+            .Select(t => t.Name)
+            .FirstOrDefaultAsync(ct);
+        if (conflictingTeamName is not null)
+        {
+            _logger.LogWarning(
+                "Standalone provisioning rejected: {Email} is the Google Group address for team '{TeamName}'",
+                fullEmail, conflictingTeamName);
+            return new WorkspaceAccountActionResult(false,
+                ErrorMessage: $"{fullEmail} is the Google Group address for team \"{conflictingTeamName}\" and cannot be used as a personal account.");
         }
 
         // Check if account already exists

--- a/src/Humans.Infrastructure/Services/GoogleAdminService.cs
+++ b/src/Humans.Infrastructure/Services/GoogleAdminService.cs
@@ -136,12 +136,38 @@ public class GoogleAdminService : IGoogleAdminService
     {
         var fullEmail = $"{emailPrefix.Trim().ToLowerInvariant()}@{NobodiesTeamDomain}";
 
+        // Check DB first: reject if the address is already tied to any human in our system.
+        // Must run BEFORE the Workspace existence check so a stale/deleted Workspace account
+        // cannot silently "move" the identity off its current human.
+        var emailInUse = await _dbContext.UserEmails
+            .AnyAsync(ue => string.Equals(ue.Email, fullEmail, StringComparison.OrdinalIgnoreCase), ct);
+        if (emailInUse)
+        {
+            _logger.LogWarning(
+                "Standalone provisioning rejected: {Email} is already linked to a human",
+                fullEmail);
+            return new WorkspaceAccountActionResult(false,
+                ErrorMessage: $"{fullEmail} is already in use by another human.");
+        }
+
+        var googleEmailInUse = await _dbContext.Users
+            .AnyAsync(u => u.GoogleEmail != null
+                && string.Equals(u.GoogleEmail, fullEmail, StringComparison.OrdinalIgnoreCase), ct);
+        if (googleEmailInUse)
+        {
+            _logger.LogWarning(
+                "Standalone provisioning rejected: {Email} is already set as GoogleEmail for a human",
+                fullEmail);
+            return new WorkspaceAccountActionResult(false,
+                ErrorMessage: $"{fullEmail} is already in use by another human.");
+        }
+
         // Check if account already exists
         var existing = await _workspaceUserService.GetAccountAsync(fullEmail, ct);
         if (existing is not null)
         {
             return new WorkspaceAccountActionResult(false,
-                ErrorMessage: $"Account {fullEmail} already exists.");
+                ErrorMessage: $"Account {fullEmail} already exists in Google Workspace.");
         }
 
         try

--- a/tests/Humans.Application.Tests/Services/EmailProvisioningServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/EmailProvisioningServiceTests.cs
@@ -204,6 +204,94 @@ public class EmailProvisioningServiceTests
     }
 
     [Fact]
+    public async Task ProvisionNobodiesEmailAsync_RejectsWhenTargetAlsoHasRowForSameEmail()
+    {
+        // Regression for the FirstOrDefault-then-compare bug: if the target user
+        // has a row for the same email AND another user also has one, the original
+        // code could return the target's row and miss the cross-user conflict.
+        // Filtering UserId != userId inside the query is deterministic.
+        var f = BuildFixture();
+        using var _ = f.DbContext;
+
+        var ownerId = Guid.NewGuid();
+        var targetId = Guid.NewGuid();
+
+        f.DbContext.Users.Add(new User
+        {
+            Id = ownerId, Email = "owner@example.com", DisplayName = "Owner",
+            Profile = new Profile { FirstName = "Owner", LastName = "One" },
+        });
+        f.DbContext.Users.Add(new User
+        {
+            Id = targetId, Email = "target@example.com", DisplayName = "Target",
+            Profile = new Profile { FirstName = "Target", LastName = "Two" },
+        });
+        // Target's row goes in FIRST so it's more likely to be returned by FirstOrDefault
+        f.DbContext.UserEmails.Add(new UserEmail
+        {
+            Id = Guid.NewGuid(),
+            UserId = targetId,
+            Email = "alice@nobodies.team",
+            IsVerified = true,
+        });
+        f.DbContext.UserEmails.Add(new UserEmail
+        {
+            Id = Guid.NewGuid(),
+            UserId = ownerId,
+            Email = "alice@nobodies.team",
+            IsVerified = true,
+        });
+        await f.DbContext.SaveChangesAsync();
+
+        var result = await f.Service.ProvisionNobodiesEmailAsync(targetId, "alice", targetId);
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("already in use by another human");
+
+        await f.WorkspaceUserService.DidNotReceive().ProvisionAccountAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ProvisionNobodiesEmailAsync_RejectsWhenPrefixCollidesWithTeamGoogleGroup()
+    {
+        var f = BuildFixture();
+        using var _ = f.DbContext;
+
+        var userId = Guid.NewGuid();
+        f.DbContext.Users.Add(new User
+        {
+            Id = userId, Email = "person@example.com", DisplayName = "Person",
+            Profile = new Profile { FirstName = "Person", LastName = "Test" },
+        });
+        f.DbContext.Teams.Add(new Team
+        {
+            Id = Guid.NewGuid(),
+            Name = "Communications",
+            Slug = "communications",
+            IsActive = true,
+            GoogleGroupPrefix = "comms",
+        });
+        await f.DbContext.SaveChangesAsync();
+
+        var result = await f.Service.ProvisionNobodiesEmailAsync(userId, "comms", userId);
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("Google Group");
+        result.ErrorMessage.Should().Contain("Communications");
+
+        // No Workspace call, no DB mutation
+        await f.WorkspaceUserService.DidNotReceive().GetAccountAsync(
+            Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await f.WorkspaceUserService.DidNotReceive().ProvisionAccountAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
+        await f.UserEmailService.DidNotReceive().AddVerifiedEmailAsync(
+            Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task ProvisionNobodiesEmailAsync_AllowsWhenPrefixIsFree()
     {
         var f = BuildFixture();

--- a/tests/Humans.Application.Tests/Services/EmailProvisioningServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/EmailProvisioningServiceTests.cs
@@ -128,12 +128,16 @@ public class EmailProvisioningServiceTests
 
         f.DbContext.Users.Add(new User
         {
-            Id = ownerId, Email = "owner@example.com", DisplayName = "Owner",
+            Id = ownerId,
+            Email = "owner@example.com",
+            DisplayName = "Owner",
             Profile = new Profile { FirstName = "Owner", LastName = "One" },
         });
         f.DbContext.Users.Add(new User
         {
-            Id = targetId, Email = "target@example.com", DisplayName = "Target",
+            Id = targetId,
+            Email = "target@example.com",
+            DisplayName = "Target",
             Profile = new Profile { FirstName = "Target", LastName = "Two" },
         });
         f.DbContext.UserEmails.Add(new UserEmail
@@ -175,13 +179,17 @@ public class EmailProvisioningServiceTests
 
         f.DbContext.Users.Add(new User
         {
-            Id = ownerId, Email = "owner@example.com", DisplayName = "Owner",
+            Id = ownerId,
+            Email = "owner@example.com",
+            DisplayName = "Owner",
             GoogleEmail = "alice@nobodies.team",
             Profile = new Profile { FirstName = "Owner", LastName = "One" },
         });
         f.DbContext.Users.Add(new User
         {
-            Id = targetId, Email = "target@example.com", DisplayName = "Target",
+            Id = targetId,
+            Email = "target@example.com",
+            DisplayName = "Target",
             Profile = new Profile { FirstName = "Target", LastName = "Two" },
         });
         await f.DbContext.SaveChangesAsync();
@@ -218,12 +226,16 @@ public class EmailProvisioningServiceTests
 
         f.DbContext.Users.Add(new User
         {
-            Id = ownerId, Email = "owner@example.com", DisplayName = "Owner",
+            Id = ownerId,
+            Email = "owner@example.com",
+            DisplayName = "Owner",
             Profile = new Profile { FirstName = "Owner", LastName = "One" },
         });
         f.DbContext.Users.Add(new User
         {
-            Id = targetId, Email = "target@example.com", DisplayName = "Target",
+            Id = targetId,
+            Email = "target@example.com",
+            DisplayName = "Target",
             Profile = new Profile { FirstName = "Target", LastName = "Two" },
         });
         // Target's row goes in FIRST so it's more likely to be returned by FirstOrDefault
@@ -262,7 +274,9 @@ public class EmailProvisioningServiceTests
         var userId = Guid.NewGuid();
         f.DbContext.Users.Add(new User
         {
-            Id = userId, Email = "person@example.com", DisplayName = "Person",
+            Id = userId,
+            Email = "person@example.com",
+            DisplayName = "Person",
             Profile = new Profile { FirstName = "Person", LastName = "Test" },
         });
         f.DbContext.Teams.Add(new Team
@@ -300,7 +314,9 @@ public class EmailProvisioningServiceTests
         var userId = Guid.NewGuid();
         f.DbContext.Users.Add(new User
         {
-            Id = userId, Email = "person@example.com", DisplayName = "Person",
+            Id = userId,
+            Email = "person@example.com",
+            DisplayName = "Person",
             Profile = new Profile { FirstName = "Person", LastName = "Test" },
         });
         await f.DbContext.SaveChangesAsync();

--- a/tests/Humans.Application.Tests/Services/EmailProvisioningServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/EmailProvisioningServiceTests.cs
@@ -1,5 +1,12 @@
 using AwesomeAssertions;
+using Humans.Application.Interfaces;
+using Humans.Domain.Entities;
+using Humans.Infrastructure.Data;
 using Humans.Infrastructure.Services;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
 using Xunit;
 
 namespace Humans.Application.Tests.Services;
@@ -71,5 +78,164 @@ public class EmailProvisioningServiceTests
     public void SanitizeEmailPrefix_ReturnsNullForEmbeddedControlCharacters()
     {
         EmailProvisioningService.SanitizeEmailPrefix("te\tst").Should().BeNull();
+    }
+
+    // --- ProvisionNobodiesEmailAsync: DB conflict checks ---
+    // These tests verify that provisioning rejects prefixes already in use
+    // by another human in our system BEFORE calling Workspace or writing DB.
+
+    private sealed record ProvisioningFixture(
+        EmailProvisioningService Service,
+        HumansDbContext DbContext,
+        IGoogleWorkspaceUserService WorkspaceUserService,
+        IUserEmailService UserEmailService,
+        IEmailService EmailService,
+        INotificationService NotificationService,
+        IAuditLogService AuditLogService);
+
+    private static ProvisioningFixture BuildFixture()
+    {
+        var options = new DbContextOptionsBuilder<HumansDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        var db = new HumansDbContext(options);
+
+        var store = Substitute.For<IUserStore<User>>();
+        var userManager = Substitute.For<UserManager<User>>(
+            store, null, null, null, null, null, null, null, null);
+
+        var workspace = Substitute.For<IGoogleWorkspaceUserService>();
+        var userEmail = Substitute.For<IUserEmailService>();
+        var email = Substitute.For<IEmailService>();
+        var notify = Substitute.For<INotificationService>();
+        var audit = Substitute.For<IAuditLogService>();
+
+        var service = new EmailProvisioningService(
+            db, userManager, workspace, userEmail, email, notify, audit,
+            NullLogger<EmailProvisioningService>.Instance);
+
+        return new ProvisioningFixture(service, db, workspace, userEmail, email, notify, audit);
+    }
+
+    [Fact]
+    public async Task ProvisionNobodiesEmailAsync_RejectsWhenEmailBelongsToAnotherUserEmail()
+    {
+        var f = BuildFixture();
+        using var _ = f.DbContext;
+
+        var ownerId = Guid.NewGuid();
+        var targetId = Guid.NewGuid();
+
+        f.DbContext.Users.Add(new User
+        {
+            Id = ownerId, Email = "owner@example.com", DisplayName = "Owner",
+            Profile = new Profile { FirstName = "Owner", LastName = "One" },
+        });
+        f.DbContext.Users.Add(new User
+        {
+            Id = targetId, Email = "target@example.com", DisplayName = "Target",
+            Profile = new Profile { FirstName = "Target", LastName = "Two" },
+        });
+        f.DbContext.UserEmails.Add(new UserEmail
+        {
+            Id = Guid.NewGuid(),
+            UserId = ownerId,
+            Email = "alice@nobodies.team",
+            IsVerified = true,
+        });
+        await f.DbContext.SaveChangesAsync();
+
+        var result = await f.Service.ProvisionNobodiesEmailAsync(targetId, "alice", targetId);
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("already in use by another human");
+
+        // No Workspace call, no DB mutation
+        await f.WorkspaceUserService.DidNotReceive().GetAccountAsync(
+            Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await f.WorkspaceUserService.DidNotReceive().ProvisionAccountAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
+        await f.UserEmailService.DidNotReceive().AddVerifiedEmailAsync(
+            Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+
+        // Target's GoogleEmail was NOT mutated
+        var target = await f.DbContext.Users.FindAsync(targetId);
+        target!.GoogleEmail.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ProvisionNobodiesEmailAsync_RejectsWhenEmailBelongsToAnotherGoogleEmail()
+    {
+        var f = BuildFixture();
+        using var _ = f.DbContext;
+
+        var ownerId = Guid.NewGuid();
+        var targetId = Guid.NewGuid();
+
+        f.DbContext.Users.Add(new User
+        {
+            Id = ownerId, Email = "owner@example.com", DisplayName = "Owner",
+            GoogleEmail = "alice@nobodies.team",
+            Profile = new Profile { FirstName = "Owner", LastName = "One" },
+        });
+        f.DbContext.Users.Add(new User
+        {
+            Id = targetId, Email = "target@example.com", DisplayName = "Target",
+            Profile = new Profile { FirstName = "Target", LastName = "Two" },
+        });
+        await f.DbContext.SaveChangesAsync();
+
+        var result = await f.Service.ProvisionNobodiesEmailAsync(targetId, "alice", targetId);
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("already in use by another human");
+
+        await f.WorkspaceUserService.DidNotReceive().GetAccountAsync(
+            Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await f.WorkspaceUserService.DidNotReceive().ProvisionAccountAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
+        await f.UserEmailService.DidNotReceive().AddVerifiedEmailAsync(
+            Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+
+        var target = await f.DbContext.Users.FindAsync(targetId);
+        target!.GoogleEmail.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ProvisionNobodiesEmailAsync_AllowsWhenPrefixIsFree()
+    {
+        var f = BuildFixture();
+        using var _ = f.DbContext;
+
+        var userId = Guid.NewGuid();
+        f.DbContext.Users.Add(new User
+        {
+            Id = userId, Email = "person@example.com", DisplayName = "Person",
+            Profile = new Profile { FirstName = "Person", LastName = "Test" },
+        });
+        await f.DbContext.SaveChangesAsync();
+
+        f.WorkspaceUserService.GetAccountAsync(
+                Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns((WorkspaceUserAccount?)null);
+        f.WorkspaceUserService.ProvisionAccountAsync(
+                Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+                Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(new WorkspaceUserAccount(
+                "bob@nobodies.team", "Person", "Test", false,
+                DateTime.UtcNow, null));
+
+        var result = await f.Service.ProvisionNobodiesEmailAsync(userId, "bob", userId);
+
+        result.Success.Should().BeTrue();
+        result.FullEmail.Should().Be("bob@nobodies.team");
+
+        await f.WorkspaceUserService.Received(1).ProvisionAccountAsync(
+            "bob@nobodies.team", "Person", "Test",
+            Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
+        await f.UserEmailService.Received(1).AddVerifiedEmailAsync(
+            userId, "bob@nobodies.team", Arg.Any<CancellationToken>());
     }
 }

--- a/tests/Humans.Application.Tests/Services/GoogleAdminServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/GoogleAdminServiceTests.cs
@@ -210,6 +210,33 @@ public class GoogleAdminServiceTests : IDisposable
             Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
     }
 
+    [Fact]
+    public async Task ProvisionStandaloneAccountAsync_RejectsWhenPrefixCollidesWithTeamGoogleGroup()
+    {
+        _dbContext.Teams.Add(new Team
+        {
+            Id = Guid.NewGuid(),
+            Name = "Communications",
+            Slug = "communications",
+            IsActive = true,
+            GoogleGroupPrefix = "comms",
+        });
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _service.ProvisionStandaloneAccountAsync(
+            "comms", "Any", "Name", _actorUserId);
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("Google Group");
+        result.ErrorMessage.Should().Contain("Communications");
+
+        await _workspaceUserService.DidNotReceive().GetAccountAsync(
+            Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await _workspaceUserService.DidNotReceive().ProvisionAccountAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
+    }
+
     // --- SuspendAccountAsync ---
 
     [Fact]

--- a/tests/Humans.Application.Tests/Services/GoogleAdminServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/GoogleAdminServiceTests.cs
@@ -148,7 +148,66 @@ public class GoogleAdminServiceTests : IDisposable
             "test", "Test", "User", _actorUserId);
 
         result.Success.Should().BeFalse();
-        result.ErrorMessage.Should().Contain("already exists");
+        result.ErrorMessage.Should().Contain("already exists in Google Workspace");
+    }
+
+    [Fact]
+    public async Task ProvisionStandaloneAccountAsync_RejectsWhenPrefixInUseByUserEmail()
+    {
+        var ownerId = Guid.NewGuid();
+        _dbContext.Users.Add(new User { Id = ownerId, Email = "x@example.com", DisplayName = "X" });
+        _dbContext.UserEmails.Add(new UserEmail
+        {
+            Id = Guid.NewGuid(),
+            UserId = ownerId,
+            Email = "test@nobodies.team",
+            IsVerified = true,
+        });
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _service.ProvisionStandaloneAccountAsync(
+            "test", "Test", "User", _actorUserId);
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("already in use by another human");
+
+        // No Workspace calls, no audit write
+        await _workspaceUserService.DidNotReceive().GetAccountAsync(
+            Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await _workspaceUserService.DidNotReceive().ProvisionAccountAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
+        await _auditLogService.DidNotReceive().LogAsync(
+            Arg.Any<Domain.Enums.AuditAction>(),
+            Arg.Any<string>(), Arg.Any<Guid>(),
+            Arg.Any<string>(), Arg.Any<Guid>(),
+            Arg.Any<Guid?>(), Arg.Any<string?>());
+    }
+
+    [Fact]
+    public async Task ProvisionStandaloneAccountAsync_RejectsWhenPrefixInUseByGoogleEmail()
+    {
+        var ownerId = Guid.NewGuid();
+        _dbContext.Users.Add(new User
+        {
+            Id = ownerId,
+            Email = "x@example.com",
+            DisplayName = "X",
+            GoogleEmail = "test@nobodies.team",
+        });
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _service.ProvisionStandaloneAccountAsync(
+            "test", "Test", "User", _actorUserId);
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("already in use by another human");
+
+        await _workspaceUserService.DidNotReceive().GetAccountAsync(
+            Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await _workspaceUserService.DidNotReceive().ProvisionAccountAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
     }
 
     // --- SuspendAccountAsync ---


### PR DESCRIPTION
## Summary

Both provisioning entry points — `EmailProvisioningService.ProvisionNobodiesEmailAsync` (per-human flow via Human Detail / GoogleController / TeamAdminController) and `GoogleAdminService.ProvisionStandaloneAccountAsync` (Admin Workspace Accounts flow) — checked whether the prefix existed in Google Workspace but never checked whether it was already attached to another user in our database. If the Workspace-side check returned null (stale cache, account deleted/suspended in Workspace, etc.), provisioning proceeded and silently "moved" the identity off its current human.

## Changes

- Add DB-first duplicate checks that run **before** any Workspace call or DB write:
  - `user_emails` lookup (case-insensitive) for any row belonging to another user
  - `Users.GoogleEmail` lookup (case-insensitive) for any row belonging to another user
- Distinct error messages: "already in use by another human" (DB conflict) vs "already exists in Google Workspace" (Workspace conflict)
- Log a warning on rejection so operators can see why provisioning stopped
- Unit tests cover both conflict paths and the happy path for each method

No `GoogleSyncOutboxEvent`, `User.GoogleEmail` mutation, or `user_emails` row is written on the conflict paths.

Part of nobodies-collective/Humans#501

## Test plan

- [x] `dotnet build Humans.slnx -v quiet` — clean
- [x] `dotnet test` — 1068 Application tests pass (Integration tests skipped locally, require Docker)
- [x] New tests pass:
  - `ProvisionNobodiesEmailAsync_RejectsWhenEmailBelongsToAnotherUserEmail`
  - `ProvisionNobodiesEmailAsync_RejectsWhenEmailBelongsToAnotherGoogleEmail`
  - `ProvisionNobodiesEmailAsync_AllowsWhenPrefixIsFree`
  - `ProvisionStandaloneAccountAsync_RejectsWhenPrefixInUseByUserEmail`
  - `ProvisionStandaloneAccountAsync_RejectsWhenPrefixInUseByGoogleEmail`
- [ ] Manual smoke in QA/preview: attempt to provision `foo@nobodies.team` for human B when it's already linked to human A — expect reject with clear error