### PR TITLE
Add Browse Shifts CTA on /Teams landing (#534)

### DIFF
--- a/src/Humans.Web/Resources/SharedResource.ca.resx
+++ b/src/Humans.Web/Resources/SharedResource.ca.resx
@@ -536,7 +536,7 @@
   <data name="Teams_System" xml:space="preserve"><value>Sistema</value></data>
 
   <!-- Vol/Teams landing: Browse Shifts CTA (#534) -->
-  <data name="VolTeams_BrowseShiftsBanner" xml:space="preserve"><value>Busques torns? Mira'ls tots aqu&#xED;, o tria un equip a sota per veure les seves rotacions.</value></data>
+  <data name="VolTeams_BrowseShiftsBanner" xml:space="preserve"><value>Busques torns? Mira'ls tots aqu&#xED;, o tria un equip a sota.</value></data>
   <data name="VolTeams_BrowseShiftsButton" xml:space="preserve"><value>Veure torns</value></data>
 
   <!-- Team Detail View -->

--- a/src/Humans.Web/Resources/SharedResource.ca.resx
+++ b/src/Humans.Web/Resources/SharedResource.ca.resx
@@ -535,6 +535,10 @@
   <data name="Teams_NoOtherTeams" xml:space="preserve"><value>No hi ha altres equips disponibles.</value></data>
   <data name="Teams_System" xml:space="preserve"><value>Sistema</value></data>
 
+  <!-- Vol/Teams landing: Browse Shifts CTA (#534) -->
+  <data name="VolTeams_BrowseShiftsBanner" xml:space="preserve"><value>Busques torns? Mira'ls tots aqu&#xED;, o tria un equip a sota per veure les seves rotacions.</value></data>
+  <data name="VolTeams_BrowseShiftsButton" xml:space="preserve"><value>Veure torns</value></data>
+
   <!-- Team Detail View -->
   <data name="TeamDetail_NoDescription" xml:space="preserve"><value>Sense descripció.</value></data>
   <data name="TeamDetail_SystemTeamInfo" xml:space="preserve"><value>Aquest és un equip gestionat pel sistema. La pertinença es sincronitza automàticament segons els criteris de {0}.</value><comment>{0} = system team type</comment></data>

--- a/src/Humans.Web/Resources/SharedResource.de.resx
+++ b/src/Humans.Web/Resources/SharedResource.de.resx
@@ -532,7 +532,7 @@
   <data name="Teams_System" xml:space="preserve"><value>System</value></data>
 
   <!-- Vol/Teams landing: Browse Shifts CTA (#534) -->
-  <data name="VolTeams_BrowseShiftsBanner" xml:space="preserve"><value>Suchst du Schichten? Sieh sie alle hier, oder w&#xE4;hle unten ein Team, um seine Rotas zu sehen.</value></data>
+  <data name="VolTeams_BrowseShiftsBanner" xml:space="preserve"><value>Suchst du Schichten? Sieh dir hier alle an, oder w&#xE4;hle unten ein Team.</value></data>
   <data name="VolTeams_BrowseShiftsButton" xml:space="preserve"><value>Schichten ansehen</value></data>
 
   <!-- Team Detail View -->

--- a/src/Humans.Web/Resources/SharedResource.de.resx
+++ b/src/Humans.Web/Resources/SharedResource.de.resx
@@ -531,6 +531,10 @@
   <data name="Teams_NoOtherTeams" xml:space="preserve"><value>Keine weiteren Teams verf&#xFC;gbar.</value></data>
   <data name="Teams_System" xml:space="preserve"><value>System</value></data>
 
+  <!-- Vol/Teams landing: Browse Shifts CTA (#534) -->
+  <data name="VolTeams_BrowseShiftsBanner" xml:space="preserve"><value>Suchst du Schichten? Sieh sie alle hier, oder w&#xE4;hle unten ein Team, um seine Rotas zu sehen.</value></data>
+  <data name="VolTeams_BrowseShiftsButton" xml:space="preserve"><value>Schichten ansehen</value></data>
+
   <!-- Team Detail View -->
   <data name="TeamDetail_NoDescription" xml:space="preserve"><value>Keine Beschreibung vorhanden.</value></data>
   <data name="TeamDetail_SystemTeamInfo" xml:space="preserve"><value>Dies ist ein systemverwaltetes Team. Die Mitgliedschaft wird automatisch anhand von {0}-Kriterien synchronisiert.</value><comment>{0} = system team type</comment></data>

--- a/src/Humans.Web/Resources/SharedResource.es.resx
+++ b/src/Humans.Web/Resources/SharedResource.es.resx
@@ -536,7 +536,7 @@
   <data name="Teams_System" xml:space="preserve"><value>Sistema</value></data>
 
   <!-- Vol/Teams landing: Browse Shifts CTA (#534) -->
-  <data name="VolTeams_BrowseShiftsBanner" xml:space="preserve"><value>&#xBF;Buscas turnos? M&#xED;ralos todos aqu&#xED;, o elige un equipo debajo para ver sus rotaciones.</value></data>
+  <data name="VolTeams_BrowseShiftsBanner" xml:space="preserve"><value>&#xBF;Buscas turnos? M&#xED;ralos todos aqu&#xED;, o elige un equipo abajo.</value></data>
   <data name="VolTeams_BrowseShiftsButton" xml:space="preserve"><value>Ver turnos</value></data>
 
   <!-- Team Detail View -->

--- a/src/Humans.Web/Resources/SharedResource.es.resx
+++ b/src/Humans.Web/Resources/SharedResource.es.resx
@@ -535,6 +535,10 @@
   <data name="Teams_NoOtherTeams" xml:space="preserve"><value>No hay otros equipos disponibles.</value></data>
   <data name="Teams_System" xml:space="preserve"><value>Sistema</value></data>
 
+  <!-- Vol/Teams landing: Browse Shifts CTA (#534) -->
+  <data name="VolTeams_BrowseShiftsBanner" xml:space="preserve"><value>&#xBF;Buscas turnos? M&#xED;ralos todos aqu&#xED;, o elige un equipo debajo para ver sus rotaciones.</value></data>
+  <data name="VolTeams_BrowseShiftsButton" xml:space="preserve"><value>Ver turnos</value></data>
+
   <!-- Team Detail View -->
   <data name="TeamDetail_NoDescription" xml:space="preserve"><value>Sin descripci&#xF3;n.</value></data>
   <data name="TeamDetail_SystemTeamInfo" xml:space="preserve"><value>Este es un equipo gestionado por el sistema. La membres&#xED;a se sincroniza autom&#xE1;ticamente seg&#xFA;n los criterios de {0}.</value><comment>{0} = system team type</comment></data>

--- a/src/Humans.Web/Resources/SharedResource.fr.resx
+++ b/src/Humans.Web/Resources/SharedResource.fr.resx
@@ -531,6 +531,10 @@
   <data name="Teams_NoOtherTeams" xml:space="preserve"><value>Aucune autre &#xE9;quipe disponible.</value></data>
   <data name="Teams_System" xml:space="preserve"><value>Syst&#xE8;me</value></data>
 
+  <!-- Vol/Teams landing: Browse Shifts CTA (#534) -->
+  <data name="VolTeams_BrowseShiftsBanner" xml:space="preserve"><value>Vous cherchez des cr&#xE9;neaux&#xA0;? Parcourez-les tous ici, ou choisissez une &#xE9;quipe ci-dessous pour voir ses rotations.</value></data>
+  <data name="VolTeams_BrowseShiftsButton" xml:space="preserve"><value>Voir les cr&#xE9;neaux</value></data>
+
   <!-- Team Detail View -->
   <data name="TeamDetail_NoDescription" xml:space="preserve"><value>Aucune description fournie.</value></data>
   <data name="TeamDetail_SystemTeamInfo" xml:space="preserve"><value>Ceci est une &#xE9;quipe g&#xE9;r&#xE9;e par le syst&#xE8;me. L'adh&#xE9;sion est automatiquement synchronis&#xE9;e selon les crit&#xE8;res de {0}.</value><comment>{0} = system team type</comment></data>

--- a/src/Humans.Web/Resources/SharedResource.fr.resx
+++ b/src/Humans.Web/Resources/SharedResource.fr.resx
@@ -532,7 +532,7 @@
   <data name="Teams_System" xml:space="preserve"><value>Syst&#xE8;me</value></data>
 
   <!-- Vol/Teams landing: Browse Shifts CTA (#534) -->
-  <data name="VolTeams_BrowseShiftsBanner" xml:space="preserve"><value>Vous cherchez des cr&#xE9;neaux&#xA0;? Parcourez-les tous ici, ou choisissez une &#xE9;quipe ci-dessous pour voir ses rotations.</value></data>
+  <data name="VolTeams_BrowseShiftsBanner" xml:space="preserve"><value>Vous cherchez des cr&#xE9;neaux&#xA0;? Parcourez-les tous ici, ou choisissez une &#xE9;quipe ci-dessous.</value></data>
   <data name="VolTeams_BrowseShiftsButton" xml:space="preserve"><value>Voir les cr&#xE9;neaux</value></data>
 
   <!-- Team Detail View -->

--- a/src/Humans.Web/Resources/SharedResource.it.resx
+++ b/src/Humans.Web/Resources/SharedResource.it.resx
@@ -531,6 +531,10 @@
   <data name="Teams_NoOtherTeams" xml:space="preserve"><value>Nessun altro team disponibile.</value></data>
   <data name="Teams_System" xml:space="preserve"><value>Sistema</value></data>
 
+  <!-- Vol/Teams landing: Browse Shifts CTA (#534) -->
+  <data name="VolTeams_BrowseShiftsBanner" xml:space="preserve"><value>Cerchi turni? Guardali tutti qui, o scegli una squadra qui sotto per vedere le sue rotazioni.</value></data>
+  <data name="VolTeams_BrowseShiftsButton" xml:space="preserve"><value>Vedi turni</value></data>
+
   <!-- Team Detail View -->
   <data name="TeamDetail_NoDescription" xml:space="preserve"><value>Nessuna descrizione fornita.</value></data>
   <data name="TeamDetail_SystemTeamInfo" xml:space="preserve"><value>Questo è un team gestito dal sistema. L'appartenenza viene sincronizzata automaticamente in base ai criteri {0}.</value><comment>{0} = system team type</comment></data>

--- a/src/Humans.Web/Resources/SharedResource.it.resx
+++ b/src/Humans.Web/Resources/SharedResource.it.resx
@@ -532,7 +532,7 @@
   <data name="Teams_System" xml:space="preserve"><value>Sistema</value></data>
 
   <!-- Vol/Teams landing: Browse Shifts CTA (#534) -->
-  <data name="VolTeams_BrowseShiftsBanner" xml:space="preserve"><value>Cerchi turni? Guardali tutti qui, o scegli una squadra qui sotto per vedere le sue rotazioni.</value></data>
+  <data name="VolTeams_BrowseShiftsBanner" xml:space="preserve"><value>Cerchi turni? Guardali tutti qui, o scegli una squadra qui sotto.</value></data>
   <data name="VolTeams_BrowseShiftsButton" xml:space="preserve"><value>Vedi turni</value></data>
 
   <!-- Team Detail View -->

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -547,6 +547,10 @@
   <data name="Teams_NoOtherTeams" xml:space="preserve"><value>No other teams available.</value></data>
   <data name="Teams_System" xml:space="preserve"><value>System</value></data>
 
+  <!-- Vol/Teams landing: Browse Shifts CTA (#534) -->
+  <data name="VolTeams_BrowseShiftsBanner" xml:space="preserve"><value>Looking for shifts? Browse them all here, or pick a team below to see its rotas.</value></data>
+  <data name="VolTeams_BrowseShiftsButton" xml:space="preserve"><value>Browse shifts</value></data>
+
   <!-- Team Detail View -->
   <data name="TeamDetail_NoDescription" xml:space="preserve"><value>No description provided.</value></data>
   <data name="TeamDetail_SystemTeamInfo" xml:space="preserve"><value>This is a system-managed team. Membership is automatically synchronized based on {0} criteria.</value><comment>{0} = system team type</comment></data>

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -548,7 +548,7 @@
   <data name="Teams_System" xml:space="preserve"><value>System</value></data>
 
   <!-- Vol/Teams landing: Browse Shifts CTA (#534) -->
-  <data name="VolTeams_BrowseShiftsBanner" xml:space="preserve"><value>Looking for shifts? Browse them all here, or pick a team below to see its rotas.</value></data>
+  <data name="VolTeams_BrowseShiftsBanner" xml:space="preserve"><value>Looking for shifts? Browse all of them here, or pick a team below.</value></data>
   <data name="VolTeams_BrowseShiftsButton" xml:space="preserve"><value>Browse shifts</value></data>
 
   <!-- Team Detail View -->

--- a/src/Humans.Web/Views/Vol/Teams.cshtml
+++ b/src/Humans.Web/Views/Vol/Teams.cshtml
@@ -7,6 +7,17 @@
 
 <vc:temp-data-alerts />
 
+<div class="alert alert-info d-flex flex-column flex-sm-row align-items-sm-center gap-2 mb-4" role="alert">
+    <div class="flex-grow-1">
+        <i class="fa-solid fa-circle-info me-1"></i>
+        @Localizer["VolTeams_BrowseShiftsBanner"]
+    </div>
+    <a asp-controller="Vol" asp-action="Shifts" class="btn btn-primary btn-sm flex-shrink-0">
+        <i class="fa-solid fa-list-check me-1"></i>
+        @Localizer["VolTeams_BrowseShiftsButton"]
+    </a>
+</div>
+
 @if (Model.Departments.Count == 0)
 {
     <div class="card">


### PR DESCRIPTION
## Summary
- Adds a localized info-banner CTA at the top of `Views/Vol/Teams.cshtml` linking directly to the shift browser (`Vol/Shifts`).
- Banner wraps on narrow viewports so both text and button remain visible without scrolling on mobile.
- New resx keys `VolTeams_BrowseShiftsBanner` and `VolTeams_BrowseShiftsButton` added across all six locales (en/es/ca/de/fr/it).

## Why
Feedback `fb:d96661e9` — iPhone Safari user on /Teams couldn't find shifts because the page had no direct route to the shift browser. The top-nav "Volunteer" entry is not always obvious to first-time visitors.

## Test plan
- [ ] Deploy to preview.
- [ ] Open /Teams on mobile, confirm CTA is visible above the fold.
- [ ] Click "Browse shifts" → lands on /Vol/Shifts.
- [ ] Switch language to es/ca/de/fr/it and confirm the banner text localizes.

Closes #534