### PR TITLE
Add Reset Password button to Accounts admin (#518)

### DIFF
--- a/src/Humans.Web/Resources/SharedResource.ca.resx
+++ b/src/Humans.Web/Resources/SharedResource.ca.resx
@@ -849,6 +849,13 @@
   <data name="AdminAddRole_NotesPlaceholder" xml:space="preserve"><value>Motiu de la assignació</value></data>
 
   <!-- ======================== -->
+  <!-- Google Accounts View     -->
+  <!-- ======================== -->
+  <data name="GoogleAccounts_Actions" xml:space="preserve"><value>Accions</value></data>
+  <data name="GoogleAccounts_ResetPassword" xml:space="preserve"><value>Restableix contrasenya</value></data>
+  <data name="GoogleAccounts_ResetPasswordConfirm" xml:space="preserve"><value>Restablir la contrasenya de {0}? Es generar&#xE0; una nova contrasenya temporal i es mostrar&#xE0; a la pantalla. L'usuari l'haur&#xE0; de canviar la propera vegada que iniciï sessi&#xF3;.</value><comment>{0} = email</comment></data>
+
+  <!-- ======================== -->
   <!-- Google Sync View         -->
   <!-- ======================== -->
   <data name="GoogleSync_SyncNow" xml:space="preserve"><value>Sincronitza ara</value></data>

--- a/src/Humans.Web/Resources/SharedResource.ca.resx
+++ b/src/Humans.Web/Resources/SharedResource.ca.resx
@@ -853,7 +853,7 @@
   <!-- ======================== -->
   <data name="GoogleAccounts_Actions" xml:space="preserve"><value>Accions</value></data>
   <data name="GoogleAccounts_ResetPassword" xml:space="preserve"><value>Restableix contrasenya</value></data>
-  <data name="GoogleAccounts_ResetPasswordConfirm" xml:space="preserve"><value>Restablir la contrasenya de {0}? Es generar&#xE0; una nova contrasenya temporal i es mostrar&#xE0; a la pantalla. L'usuari l'haur&#xE0; de canviar la propera vegada que iniciï sessi&#xF3;.</value><comment>{0} = email</comment></data>
+  <data name="GoogleAccounts_ResetPasswordConfirm" xml:space="preserve"><value>Restablir la contrasenya de {0}? Es generar&#xE0; una nova contrasenya temporal i es mostrar&#xE0; a la pantalla. El human l'haur&#xE0; de canviar en el proper inici de sessi&#xF3;.</value><comment>{0} = email</comment></data>
 
   <!-- ======================== -->
   <!-- Google Sync View         -->

--- a/src/Humans.Web/Resources/SharedResource.de.resx
+++ b/src/Humans.Web/Resources/SharedResource.de.resx
@@ -848,7 +848,7 @@
   <!-- ======================== -->
   <data name="GoogleAccounts_Actions" xml:space="preserve"><value>Aktionen</value></data>
   <data name="GoogleAccounts_ResetPassword" xml:space="preserve"><value>Passwort zur&#xFC;cksetzen</value></data>
-  <data name="GoogleAccounts_ResetPasswordConfirm" xml:space="preserve"><value>Passwort f&#xFC;r {0} zur&#xFC;cksetzen? Ein neues tempor&#xE4;res Passwort wird erzeugt und auf dem Bildschirm angezeigt. Der Nutzer muss es bei der n&#xE4;chsten Anmeldung &#xE4;ndern.</value><comment>{0} = email</comment></data>
+  <data name="GoogleAccounts_ResetPasswordConfirm" xml:space="preserve"><value>Passwort f&#xFC;r {0} zur&#xFC;cksetzen? Ein neues tempor&#xE4;res Passwort wird erzeugt und auf dem Bildschirm angezeigt. Der Human muss es bei der n&#xE4;chsten Anmeldung &#xE4;ndern.</value><comment>{0} = email</comment></data>
 
   <!-- ======================== -->
   <!-- Google Sync View         -->

--- a/src/Humans.Web/Resources/SharedResource.de.resx
+++ b/src/Humans.Web/Resources/SharedResource.de.resx
@@ -844,6 +844,13 @@
   <data name="AdminAddRole_NotesPlaceholder" xml:space="preserve"><value>Grund der Zuweisung</value></data>
 
   <!-- ======================== -->
+  <!-- Google Accounts View     -->
+  <!-- ======================== -->
+  <data name="GoogleAccounts_Actions" xml:space="preserve"><value>Aktionen</value></data>
+  <data name="GoogleAccounts_ResetPassword" xml:space="preserve"><value>Passwort zur&#xFC;cksetzen</value></data>
+  <data name="GoogleAccounts_ResetPasswordConfirm" xml:space="preserve"><value>Passwort f&#xFC;r {0} zur&#xFC;cksetzen? Ein neues tempor&#xE4;res Passwort wird erzeugt und auf dem Bildschirm angezeigt. Der Nutzer muss es bei der n&#xE4;chsten Anmeldung &#xE4;ndern.</value><comment>{0} = email</comment></data>
+
+  <!-- ======================== -->
   <!-- Google Sync View         -->
   <!-- ======================== -->
   <data name="GoogleSync_SyncNow" xml:space="preserve"><value>Jetzt synchronisieren</value></data>

--- a/src/Humans.Web/Resources/SharedResource.es.resx
+++ b/src/Humans.Web/Resources/SharedResource.es.resx
@@ -849,6 +849,13 @@
   <data name="AdminAddRole_NotesPlaceholder" xml:space="preserve"><value>Motivo de la asignaci&#xF3;n</value></data>
 
   <!-- ======================== -->
+  <!-- Google Accounts View     -->
+  <!-- ======================== -->
+  <data name="GoogleAccounts_Actions" xml:space="preserve"><value>Acciones</value></data>
+  <data name="GoogleAccounts_ResetPassword" xml:space="preserve"><value>Restablecer contrase&#xF1;a</value></data>
+  <data name="GoogleAccounts_ResetPasswordConfirm" xml:space="preserve"><value>&#xBF;Restablecer la contrase&#xF1;a de {0}? Se generar&#xE1; una contrase&#xF1;a temporal nueva y se mostrar&#xE1; en pantalla. El usuario deber&#xE1; cambiarla al iniciar sesi&#xF3;n.</value><comment>{0} = email</comment></data>
+
+  <!-- ======================== -->
   <!-- Google Sync View         -->
   <!-- ======================== -->
   <data name="GoogleSync_SyncNow" xml:space="preserve"><value>Sincronizar ahora</value></data>

--- a/src/Humans.Web/Resources/SharedResource.es.resx
+++ b/src/Humans.Web/Resources/SharedResource.es.resx
@@ -853,7 +853,7 @@
   <!-- ======================== -->
   <data name="GoogleAccounts_Actions" xml:space="preserve"><value>Acciones</value></data>
   <data name="GoogleAccounts_ResetPassword" xml:space="preserve"><value>Restablecer contrase&#xF1;a</value></data>
-  <data name="GoogleAccounts_ResetPasswordConfirm" xml:space="preserve"><value>&#xBF;Restablecer la contrase&#xF1;a de {0}? Se generar&#xE1; una contrase&#xF1;a temporal nueva y se mostrar&#xE1; en pantalla. El usuario deber&#xE1; cambiarla al iniciar sesi&#xF3;n.</value><comment>{0} = email</comment></data>
+  <data name="GoogleAccounts_ResetPasswordConfirm" xml:space="preserve"><value>&#xBF;Restablecer la contrase&#xF1;a de {0}? Se generar&#xE1; una nueva contrase&#xF1;a temporal y se mostrar&#xE1; en pantalla. El human deber&#xE1; cambiarla en el pr&#xF3;ximo inicio de sesi&#xF3;n.</value><comment>{0} = email</comment></data>
 
   <!-- ======================== -->
   <!-- Google Sync View         -->

--- a/src/Humans.Web/Resources/SharedResource.fr.resx
+++ b/src/Humans.Web/Resources/SharedResource.fr.resx
@@ -848,7 +848,7 @@
   <!-- ======================== -->
   <data name="GoogleAccounts_Actions" xml:space="preserve"><value>Actions</value></data>
   <data name="GoogleAccounts_ResetPassword" xml:space="preserve"><value>R&#xE9;initialiser le mot de passe</value></data>
-  <data name="GoogleAccounts_ResetPasswordConfirm" xml:space="preserve"><value>R&#xE9;initialiser le mot de passe pour {0}&#xA0;? Un nouveau mot de passe temporaire sera g&#xE9;n&#xE9;r&#xE9; et affich&#xE9; &#xE0; l'&#xE9;cran. L'utilisateur devra le changer &#xE0; la prochaine connexion.</value><comment>{0} = email</comment></data>
+  <data name="GoogleAccounts_ResetPasswordConfirm" xml:space="preserve"><value>R&#xE9;initialiser le mot de passe pour {0}&#xA0;? Un nouveau mot de passe temporaire sera g&#xE9;n&#xE9;r&#xE9; et affich&#xE9; &#xE0; l'&#xE9;cran. Le human devra le changer &#xE0; sa prochaine connexion.</value><comment>{0} = email</comment></data>
 
   <!-- ======================== -->
   <!-- Google Sync View         -->

--- a/src/Humans.Web/Resources/SharedResource.fr.resx
+++ b/src/Humans.Web/Resources/SharedResource.fr.resx
@@ -844,6 +844,13 @@
   <data name="AdminAddRole_NotesPlaceholder" xml:space="preserve"><value>Motif de l'attribution</value></data>
 
   <!-- ======================== -->
+  <!-- Google Accounts View     -->
+  <!-- ======================== -->
+  <data name="GoogleAccounts_Actions" xml:space="preserve"><value>Actions</value></data>
+  <data name="GoogleAccounts_ResetPassword" xml:space="preserve"><value>R&#xE9;initialiser le mot de passe</value></data>
+  <data name="GoogleAccounts_ResetPasswordConfirm" xml:space="preserve"><value>R&#xE9;initialiser le mot de passe pour {0}&#xA0;? Un nouveau mot de passe temporaire sera g&#xE9;n&#xE9;r&#xE9; et affich&#xE9; &#xE0; l'&#xE9;cran. L'utilisateur devra le changer &#xE0; la prochaine connexion.</value><comment>{0} = email</comment></data>
+
+  <!-- ======================== -->
   <!-- Google Sync View         -->
   <!-- ======================== -->
   <data name="GoogleSync_SyncNow" xml:space="preserve"><value>Synchroniser maintenant</value></data>

--- a/src/Humans.Web/Resources/SharedResource.it.resx
+++ b/src/Humans.Web/Resources/SharedResource.it.resx
@@ -848,7 +848,7 @@
   <!-- ======================== -->
   <data name="GoogleAccounts_Actions" xml:space="preserve"><value>Azioni</value></data>
   <data name="GoogleAccounts_ResetPassword" xml:space="preserve"><value>Reimposta password</value></data>
-  <data name="GoogleAccounts_ResetPasswordConfirm" xml:space="preserve"><value>Reimpostare la password di {0}? Verr&#xE0; generata una nuova password temporanea e mostrata sullo schermo. L'utente dovr&#xE0; cambiarla al prossimo accesso.</value><comment>{0} = email</comment></data>
+  <data name="GoogleAccounts_ResetPasswordConfirm" xml:space="preserve"><value>Reimpostare la password di {0}? Verr&#xE0; generata una nuova password temporanea e mostrata sullo schermo. Il human dovr&#xE0; cambiarla al prossimo accesso.</value><comment>{0} = email</comment></data>
 
   <!-- ======================== -->
   <!-- Google Sync View         -->

--- a/src/Humans.Web/Resources/SharedResource.it.resx
+++ b/src/Humans.Web/Resources/SharedResource.it.resx
@@ -844,6 +844,13 @@
   <data name="AdminAddRole_NotesPlaceholder" xml:space="preserve"><value>Motivo dell'assegnazione</value></data>
 
   <!-- ======================== -->
+  <!-- Google Accounts View     -->
+  <!-- ======================== -->
+  <data name="GoogleAccounts_Actions" xml:space="preserve"><value>Azioni</value></data>
+  <data name="GoogleAccounts_ResetPassword" xml:space="preserve"><value>Reimposta password</value></data>
+  <data name="GoogleAccounts_ResetPasswordConfirm" xml:space="preserve"><value>Reimpostare la password di {0}? Verr&#xE0; generata una nuova password temporanea e mostrata sullo schermo. L'utente dovr&#xE0; cambiarla al prossimo accesso.</value><comment>{0} = email</comment></data>
+
+  <!-- ======================== -->
   <!-- Google Sync View         -->
   <!-- ======================== -->
   <data name="GoogleSync_SyncNow" xml:space="preserve"><value>Sincronizza ora</value></data>

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -865,7 +865,7 @@
   <!-- ======================== -->
   <data name="GoogleAccounts_Actions" xml:space="preserve"><value>Actions</value></data>
   <data name="GoogleAccounts_ResetPassword" xml:space="preserve"><value>Reset password</value></data>
-  <data name="GoogleAccounts_ResetPasswordConfirm" xml:space="preserve"><value>Reset password for {0}? A new temporary password will be generated and shown on screen. The user must change it at next sign-in.</value><comment>{0} = email</comment></data>
+  <data name="GoogleAccounts_ResetPasswordConfirm" xml:space="preserve"><value>Reset password for {0}? A new temporary password will be generated and shown on screen. The human must change it at next sign-in.</value><comment>{0} = email</comment></data>
 
   <!-- ======================== -->
   <!-- Google Sync View         -->

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -861,6 +861,13 @@
   <data name="AdminAddRole_NotesPlaceholder" xml:space="preserve"><value>Reason for assignment</value></data>
 
   <!-- ======================== -->
+  <!-- Google Accounts View     -->
+  <!-- ======================== -->
+  <data name="GoogleAccounts_Actions" xml:space="preserve"><value>Actions</value></data>
+  <data name="GoogleAccounts_ResetPassword" xml:space="preserve"><value>Reset password</value></data>
+  <data name="GoogleAccounts_ResetPasswordConfirm" xml:space="preserve"><value>Reset password for {0}? A new temporary password will be generated and shown on screen. The user must change it at next sign-in.</value><comment>{0} = email</comment></data>
+
+  <!-- ======================== -->
   <!-- Google Sync View         -->
   <!-- ======================== -->
   <data name="GoogleSync_SyncNow" xml:space="preserve"><value>Sync Now</value></data>

--- a/src/Humans.Web/Views/Google/Accounts.cshtml
+++ b/src/Humans.Web/Views/Google/Accounts.cshtml
@@ -205,15 +205,6 @@
 
 @section Scripts {
     <script>
-        // Confirm before posting a password reset
-        document.querySelectorAll('.reset-password-form').forEach(function (form) {
-            form.addEventListener('submit', function (e) {
-                if (!confirm(form.dataset.confirm)) {
-                    e.preventDefault();
-                }
-            });
-        });
-
         // Sync the _HumanSearchInput hidden value to the form's userId field on submit
         document.querySelectorAll('.link-form').forEach(function (form) {
             form.addEventListener('submit', function (e) {

--- a/src/Humans.Web/Views/Google/Accounts.cshtml
+++ b/src/Humans.Web/Views/Google/Accounts.cshtml
@@ -123,6 +123,7 @@
                         <th>Status</th>
                         <th>Created</th>
                         <th>Last Login</th>
+                        <th class="text-end">@Localizer["GoogleAccounts_Actions"]</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -180,6 +181,20 @@
                                     <span class="text-muted">Never</span>
                                 }
                             </td>
+                            <td class="text-end">
+                                @if (!account.IsSuspended)
+                                {
+                                    <form asp-action="ResetPassword" method="post" class="d-inline reset-password-form"
+                                          data-email="@account.PrimaryEmail"
+                                          data-confirm="@string.Format(Localizer["GoogleAccounts_ResetPasswordConfirm"].Value, account.PrimaryEmail)">
+                                        @Html.AntiForgeryToken()
+                                        <input type="hidden" name="email" value="@account.PrimaryEmail" />
+                                        <button type="submit" class="btn btn-outline-warning btn-sm">
+                                            <i class="fa-solid fa-key me-1"></i>@Localizer["GoogleAccounts_ResetPassword"]
+                                        </button>
+                                    </form>
+                                }
+                            </td>
                         </tr>
                     }
                 </tbody>
@@ -190,6 +205,15 @@
 
 @section Scripts {
     <script>
+        // Confirm before posting a password reset
+        document.querySelectorAll('.reset-password-form').forEach(function (form) {
+            form.addEventListener('submit', function (e) {
+                if (!confirm(form.dataset.confirm)) {
+                    e.preventDefault();
+                }
+            });
+        });
+
         // Sync the _HumanSearchInput hidden value to the form's userId field on submit
         document.querySelectorAll('.link-form').forEach(function (form) {
             form.addEventListener('submit', function (e) {


### PR DESCRIPTION
## Summary
- Adds an **Actions** column to `Views/Google/Accounts.cshtml` with a **Reset Password** button for active (non-suspended) accounts.
- Button posts to the existing `POST /Google/Accounts/ResetPassword` endpoint with `{ email }` + antiforgery token.
- JS confirm dialog warns before reset and clarifies the generated temporary password will be shown on screen and must be changed at next sign-in.
- Localized across en/es/ca/de/fr/it.

## Why
`GoogleController.ResetPassword` has existed since the admin service landed but was not reachable from any admin UI. Issue #518.

## Security / Auth
- The `Accounts` GET action is already `[Authorize(Policy = PolicyNames.AdminOnly)]`, so only admins see this view and the new button inherits that gate.
- The `ResetPassword` POST is also `[Authorize(Policy = PolicyNames.AdminOnly)]` and `[ValidateAntiForgeryToken]`.

## Test plan
- [ ] Deploy to preview.
- [ ] Sign in as an admin → /Google/Accounts → see the new Actions column.
- [ ] Click **Reset password** on an active account → confirm dialog appears with email.
- [ ] Cancel → no network call.
- [ ] Confirm → success flash shows the generated temporary password.
- [ ] Suspended account shows no button.
- [ ] Try another locale (es / ca / de / fr / it) → button + confirm text localize.

Closes #518