### PR TITLE
Add 2FA status and backup codes to Accounts admin

### DIFF
--- a/docs/features/32-workspace-account-provisioning.md
+++ b/docs/features/32-workspace-account-provisioning.md
@@ -9,7 +9,7 @@
   src/Humans.Infrastructure/Services/GoogleWorkspace/**
 -->
 <!-- freshness:flag-on-change
-  Provisioning step ordering, recovery email handling, credentials email template, admin/HumanAdmin authorization, or post-provisioning account management (2FA status, backup-code generation/invalidation, recovery-email visibility on `/Google/Accounts`) may have changed.
+  Provisioning step ordering, recovery email handling, credentials email template, admin/HumanAdmin authorization, or post-provisioning account management (2FA enrollment status, recovery-email visibility, password reset, combined Reset+2FA recovery flow on `/Google/Accounts`) may have changed.
 -->
 
 # Workspace Account Provisioning
@@ -79,40 +79,51 @@ Nobodies Collective uses Google Workspace for organizational email (@nobodies.te
 - Accounts with no recovery email show a yellow "None" badge with explanatory tooltip
 - Backed by `WorkspaceUserAccount.RecoveryEmail`, sourced from the Directory API `users.get` `recoveryEmail` field
 
-### US-32.6: Issue Backup Verification Codes
+### US-32.6: Reset Password (with one-shot delivery)
 **As an** admin
-**I want to** generate one-time backup codes for a @nobodies.team account from inside Humans
-**So that** I can recover locked-out humans without leaving the app
+**I want to** reset the password for a @nobodies.team account and see the new temporary password once
+**So that** I can hand it to a human who's lost access
 
 **Acceptance Criteria:**
-- "Generate" button per row, Admin-only, CSRF-protected, available for **both enrolled and unenrolled accounts**
-- Confirm-before-post copy adapts: "invalidates any previously issued codes" for enrolled accounts; "Google may reject this for never-enrolled accounts" for unenrolled
-- Calls Google Admin SDK `verificationCodes.generate` then `verificationCodes.list` to return the freshly issued set
-- Generated codes appear once in a modal with copy-to-clipboard and an "I've delivered these securely" acknowledgement gate; codes are cleared from the DOM on close so a refresh can't re-expose them (TempData single-use)
-- If the Google API rejects the call (e.g., for an account where Google requires prior enrollment), the admin sees a graceful flash error rather than a hung page
-- Audit trail recorded (`WorkspaceAccountBackupCodesGenerated`) — see invariant below on audit-vs-delivery ordering
+- "Reset Password" button per row, Admin-only, CSRF-protected, hidden for suspended accounts
+- Confirm-before-post explains the password will be shown once
+- Calls Google Admin SDK `users.update` with `password` + `changePasswordAtNextLogin: true`
+- New temp password appears once in a modal with copy-to-clipboard (clipboard format `pw: <password>`) and an "I've delivered these securely" acknowledgement gate
+- Modal text-content is cleared on close so browser back/refresh can't re-expose the password (TempData single-use)
+- Audit trail recorded (`WorkspaceAccountPasswordReset`)
+
+### US-32.7: Reset Password + Get 2FA (combined recovery)
+**As an** admin
+**I want to** reset the password AND grab one fresh backup verification code in a single action
+**So that** I can unblock a locked-out human regardless of their 2SV-enrollment state — they can sign in with the password + code, then enroll/re-enroll a real second factor
+
+**Acceptance Criteria:**
+- "Reset + 2FA" button per row, Admin-only, CSRF-protected, hidden for suspended accounts
+- Confirm-before-post explains both will be shown once
+- Calls `IGoogleAdminService.ResetPasswordAndGenerate2FaAsync` which composes the existing password-reset + backup-codes flows; only the **first** code from the freshly-issued set is surfaced (the rest are unused — Google rotates the whole set destructively, but the admin only ever needs one)
+- Confirmed (2026-05-04) to work for accounts that have not yet completed 2SV enrollment
+- Both credentials appear once in the same modal as the password-only flow, with copy-to-clipboard formatted as:
+  ```
+  pw: <temp password>
+  2fa: <single backup code>
+  ```
+- Modal text-content is cleared on close so browser back/refresh can't re-expose the secrets
+- Two audit entries recorded: `WorkspaceAccountPasswordReset` then `WorkspaceAccountBackupCodesGenerated`
 - Requires the `admin.directory.user.security` scope on the service account credential
-
-### US-32.7: Invalidate Backup Verification Codes
-**As an** admin
-**I want to** invalidate all backup codes for an account
-**So that** leaked codes can be revoked without issuing replacements
-
-**Acceptance Criteria:**
-- "Invalidate" button per row, Admin-only, CSRF-protected, **only available for enrolled accounts** (no codes to invalidate otherwise)
-- Confirm-before-post warns about immediate invalidation
-- Calls Google Admin SDK `verificationCodes.invalidate`
-- Audit trail recorded (`WorkspaceAccountBackupCodesInvalidated`)
 
 ## Account-Management Invariants
 
-### Backup-codes audit ordering
-`GenerateBackupCodesAsync` writes the audit entry **after** Google has rotated the codes and before returning them to the admin, with two safety guards:
+### Combined-recovery composition + partial-success handling
+`ResetPasswordAndGenerate2FaAsync` calls the underlying password-reset and backup-code-generation in sequence:
 
-1. **Empty-list guard** — if Google's `Generate` succeeds but the subsequent `List` returns 0 codes, no audit entry is written and the method returns `Success: false` with an explanatory message. We never record "generated 0 codes" in the audit log.
-2. **Audit-failure preservation** — if the audit `LogAsync` throws after Google has issued the new set, the codes are still returned to the admin (audit failure is logged at `LogCritical` for out-of-band reconciliation). Google has already invalidated the previously-issued set, so dropping the new codes would lock the human out — account recovery is real-time, audit reconciliation is operational.
+1. **Password-reset failure short-circuits** — if `ResetPasswordAsync` fails, the method returns `Success: false` and never attempts the backup-code call (no point handing out codes for an account the human still can't sign into).
+2. **Partial success on backup-code failure** — if the password reset succeeded but Google rejects the backup-code request, the method still returns `Success: true` with the temp password and `BackupCode: null`. Google rotates passwords destructively just like codes, so dropping the password to retry would lock the human out further. The admin sees "Password reset for X. Backup-code generation failed — deliver the password only and ask the human to re-attempt the 2FA request out-of-band."
 
-`InvalidateBackupCodesAsync` follows the standard audit-after-success pattern; an audit failure surfaces as `Success: false` and the admin is expected to retry (idempotent on the Google side).
+### Backup-codes audit-and-delivery ordering
+`GenerateBackupCodesAsync` (used standalone by the combined flow) writes its audit entry **after** Google has rotated the codes and before returning them, with two safety guards:
+
+1. **Empty-list guard** — if Google's `Generate` succeeds but the subsequent `List` returns 0 codes, no audit entry is written and the method returns `Success: false`. We never record "generated 0 codes" in the audit log.
+2. **Audit-failure preservation** — if the audit `LogAsync` throws after Google has issued the new set, the codes are still returned (audit failure is logged at `LogCritical` for out-of-band reconciliation). Google has already invalidated the previously-issued set, so dropping the new codes would lock the human out — account recovery is real-time, audit reconciliation is operational.
 
 ## Provisioning Flow
 
@@ -175,8 +186,8 @@ Ambiguous characters (0, O, l, 1, I) are excluded for readability.
 | Provision account | HumanAdmin, Admin |
 | Link existing account | Admin |
 | View `/Google/Accounts` (2FA status, recovery email, etc.) | Admin |
-| Generate backup codes | Admin |
-| Invalidate backup codes | Admin |
+| Reset password (one-shot delivery) | Admin |
+| Reset password + get 2FA backup code (combined recovery) | Admin |
 
 ## Routes
 
@@ -185,8 +196,8 @@ Ambiguous characters (0, O, l, 1, I) are excluded for readability.
 | `/Human/{id}/Admin` | GET | Human admin page (shows provisioning form) |
 | `/Human/{id}/Admin/ProvisionEmail` | POST | Provision and link @nobodies.team account |
 | `/Google/Accounts` | GET | List all @nobodies.team accounts with 2FA status, recovery email, link orphans (replaces the legacy `/Admin/Email` route) |
-| `/Google/Accounts/GenerateBackupCodes` | POST | Generate backup verification codes for an account |
-| `/Google/Accounts/InvalidateBackupCodes` | POST | Invalidate all backup verification codes for an account |
+| `/Google/Accounts/ResetPassword` | POST | Reset password — temp password shown once in a modal |
+| `/Google/Accounts/ResetPasswordAndGenerate2Fa` | POST | Reset password + issue one backup verification code — both shown once in the same modal |
 
 ## Service Interfaces
 
@@ -211,8 +222,9 @@ Task ReactivateAccountAsync(string email, CancellationToken ct);
 Task ResetPasswordAsync(string email, string newPassword, CancellationToken ct);
 
 // Backup verification codes (post-provisioning recovery surface)
+// Combined recovery composes ResetPasswordAsync + GenerateBackupCodesAsync
+// at the IGoogleAdminService layer (ResetPasswordAndGenerate2FaAsync).
 Task<IReadOnlyList<string>> GenerateBackupCodesAsync(string email, CancellationToken ct);
-Task InvalidateBackupCodesAsync(string email, CancellationToken ct);
 ```
 
 `WorkspaceUserAccount` carries the post-provisioning visibility fields used by the admin surface: `IsEnrolledIn2Sv` (from Directory API `isEnrolledIn2Sv`) and `RecoveryEmail` (from `recoveryEmail`).

--- a/docs/features/32-workspace-account-provisioning.md
+++ b/docs/features/32-workspace-account-provisioning.md
@@ -9,7 +9,7 @@
   src/Humans.Infrastructure/Services/GoogleWorkspace/**
 -->
 <!-- freshness:flag-on-change
-  Provisioning step ordering, recovery email handling, credentials email template, or admin/HumanAdmin authorization may have changed.
+  Provisioning step ordering, recovery email handling, credentials email template, admin/HumanAdmin authorization, or post-provisioning account management (2FA status, backup-code generation/invalidation, recovery-email visibility on `/Google/Accounts`) may have changed.
 -->
 
 # Workspace Account Provisioning
@@ -57,6 +57,62 @@ Nobodies Collective uses Google Workspace for organizational email (@nobodies.te
 - Linking creates a verified `UserEmail` and sets `GoogleEmail` on the user
 - Audit trail recorded (`WorkspaceAccountLinked`)
 - No credentials email sent (user already has access)
+
+### US-32.4: Surface 2FA Enrollment State
+**As an** admin
+**I want to** see which @nobodies.team accounts have completed 2-Step Verification enrollment
+**So that** I can spot broken accounts before the human reports being locked out
+
+**Acceptance Criteria:**
+- `/Google/Accounts` table shows a per-row 2FA chip: green "2FA ready" (enrolled) or red "2FA not set up" (unenrolled)
+- Summary counter at the top: "X accounts missing 2FA setup" — counts active unenrolled accounts only (suspended accounts are excluded since they can't sign in anyway)
+- Alert banner + client-side filter toggle to show only the unenrolled set
+- Backed by `WorkspaceUserAccount.IsEnrolledIn2Sv`, sourced from the Directory API `users.get` `isEnrolledIn2Sv` field
+
+### US-32.5: Surface Recovery Email
+**As an** admin
+**I want to** see the personal recovery email Google has on file for each account
+**So that** I can validate the recovery channel before the human is locked out
+
+**Acceptance Criteria:**
+- `/Google/Accounts` table shows a "Recovery Email" column per row
+- Accounts with no recovery email show a yellow "None" badge with explanatory tooltip
+- Backed by `WorkspaceUserAccount.RecoveryEmail`, sourced from the Directory API `users.get` `recoveryEmail` field
+
+### US-32.6: Issue Backup Verification Codes
+**As an** admin
+**I want to** generate one-time backup codes for a @nobodies.team account from inside Humans
+**So that** I can recover locked-out humans without leaving the app
+
+**Acceptance Criteria:**
+- "Generate" button per row, Admin-only, CSRF-protected, available for **both enrolled and unenrolled accounts**
+- Confirm-before-post copy adapts: "invalidates any previously issued codes" for enrolled accounts; "Google may reject this for never-enrolled accounts" for unenrolled
+- Calls Google Admin SDK `verificationCodes.generate` then `verificationCodes.list` to return the freshly issued set
+- Generated codes appear once in a modal with copy-to-clipboard and an "I've delivered these securely" acknowledgement gate; codes are cleared from the DOM on close so a refresh can't re-expose them (TempData single-use)
+- If the Google API rejects the call (e.g., for an account where Google requires prior enrollment), the admin sees a graceful flash error rather than a hung page
+- Audit trail recorded (`WorkspaceAccountBackupCodesGenerated`) — see invariant below on audit-vs-delivery ordering
+- Requires the `admin.directory.user.security` scope on the service account credential
+
+### US-32.7: Invalidate Backup Verification Codes
+**As an** admin
+**I want to** invalidate all backup codes for an account
+**So that** leaked codes can be revoked without issuing replacements
+
+**Acceptance Criteria:**
+- "Invalidate" button per row, Admin-only, CSRF-protected, **only available for enrolled accounts** (no codes to invalidate otherwise)
+- Confirm-before-post warns about immediate invalidation
+- Calls Google Admin SDK `verificationCodes.invalidate`
+- Audit trail recorded (`WorkspaceAccountBackupCodesInvalidated`)
+
+## Account-Management Invariants
+
+### Backup-codes audit ordering
+`GenerateBackupCodesAsync` writes the audit entry **after** Google has rotated the codes and before returning them to the admin, with two safety guards:
+
+1. **Empty-list guard** — if Google's `Generate` succeeds but the subsequent `List` returns 0 codes, no audit entry is written and the method returns `Success: false` with an explanatory message. We never record "generated 0 codes" in the audit log.
+2. **Audit-failure preservation** — if the audit `LogAsync` throws after Google has issued the new set, the codes are still returned to the admin (audit failure is logged at `LogCritical` for out-of-band reconciliation). Google has already invalidated the previously-issued set, so dropping the new codes would lock the human out — account recovery is real-time, audit reconciliation is operational.
+
+`InvalidateBackupCodesAsync` follows the standard audit-after-success pattern; an audit failure surfaces as `Success: false` and the admin is expected to retry (idempotent on the Google side).
 
 ## Provisioning Flow
 
@@ -118,6 +174,9 @@ Ambiguous characters (0, O, l, 1, I) are excluded for readability.
 |--------|---------------|
 | Provision account | HumanAdmin, Admin |
 | Link existing account | Admin |
+| View `/Google/Accounts` (2FA status, recovery email, etc.) | Admin |
+| Generate backup codes | Admin |
+| Invalidate backup codes | Admin |
 
 ## Routes
 
@@ -125,7 +184,9 @@ Ambiguous characters (0, O, l, 1, I) are excluded for readability.
 |-------|--------|--------|
 | `/Human/{id}/Admin` | GET | Human admin page (shows provisioning form) |
 | `/Human/{id}/Admin/ProvisionEmail` | POST | Provision and link @nobodies.team account |
-| `/Admin/Email` | GET | List all @nobodies.team accounts, link orphans |
+| `/Google/Accounts` | GET | List all @nobodies.team accounts with 2FA status, recovery email, link orphans (replaces the legacy `/Admin/Email` route) |
+| `/Google/Accounts/GenerateBackupCodes` | POST | Generate backup verification codes for an account |
+| `/Google/Accounts/InvalidateBackupCodes` | POST | Invalidate all backup verification codes for an account |
 
 ## Service Interfaces
 
@@ -144,8 +205,17 @@ Task<WorkspaceUserAccount?> GetAccountAsync(string email, CancellationToken ct);
 
 // Suspend/restore accounts
 Task SuspendAccountAsync(string email, CancellationToken ct);
-Task RestoreAccountAsync(string email, CancellationToken ct);
+Task ReactivateAccountAsync(string email, CancellationToken ct);
+
+// Reset password (admin-initiated)
+Task ResetPasswordAsync(string email, string newPassword, CancellationToken ct);
+
+// Backup verification codes (post-provisioning recovery surface)
+Task<IReadOnlyList<string>> GenerateBackupCodesAsync(string email, CancellationToken ct);
+Task InvalidateBackupCodesAsync(string email, CancellationToken ct);
 ```
+
+`WorkspaceUserAccount` carries the post-provisioning visibility fields used by the admin surface: `IsEnrolledIn2Sv` (from Directory API `isEnrolledIn2Sv`) and `RecoveryEmail` (from `recoveryEmail`).
 
 ### IEmailService (credentials notification)
 ```csharp

--- a/docs/sections/GoogleIntegration.md
+++ b/docs/sections/GoogleIntegration.md
@@ -67,7 +67,7 @@ Team-level resource linking stays at `/Teams/{slug}/Resources` in `TeamAdminCont
 
 | Actor | Capabilities |
 |-------|--------------|
-| Admin | Manage sync settings (per-service mode). Trigger manual syncs and execute sync actions. View reconciliation results. Check and remediate Google Group settings drift. Link unlinked groups to teams. Review and apply email backfill corrections. Manage @nobodies.team Workspace accounts (provision, suspend, reactivate, reset password, link). Provision per-human @nobodies.team email |
+| Admin | Manage sync settings (per-service mode). Trigger manual syncs and execute sync actions. View reconciliation results. Check and remediate Google Group settings drift. Link unlinked groups to teams. Review and apply email backfill corrections. Manage @nobodies.team Workspace accounts (provision, suspend, reactivate, reset password, link, generate/invalidate 2FA backup codes). Provision per-human @nobodies.team email |
 | TeamsAdmin, Board, Admin | View resource sync status dashboard. Link and unlink Google resources (Drive folders, Groups) to teams via `TeamAdminController`. View resource status. Trigger per-resource sync |
 | Coordinator | Link and unlink Google resources for their own department (via `TeamAdminController`). Trigger per-resource sync for their own department |
 | Board, Admin | View Drive activity anomaly check results. View sync audit logs |

--- a/docs/sections/GoogleIntegration.md
+++ b/docs/sections/GoogleIntegration.md
@@ -67,7 +67,7 @@ Team-level resource linking stays at `/Teams/{slug}/Resources` in `TeamAdminCont
 
 | Actor | Capabilities |
 |-------|--------------|
-| Admin | Manage sync settings (per-service mode). Trigger manual syncs and execute sync actions. View reconciliation results. Check and remediate Google Group settings drift. Link unlinked groups to teams. Review and apply email backfill corrections. Manage @nobodies.team Workspace accounts (provision, suspend, reactivate, reset password, link, generate/invalidate 2FA backup codes). Provision per-human @nobodies.team email |
+| Admin | Manage sync settings (per-service mode). Trigger manual syncs and execute sync actions. View reconciliation results. Check and remediate Google Group settings drift. Link unlinked groups to teams. Review and apply email backfill corrections. Manage @nobodies.team Workspace accounts (provision, suspend, reactivate, link, reset password, combined Reset + 2FA recovery for locked-out humans). Provision per-human @nobodies.team email |
 | TeamsAdmin, Board, Admin | View resource sync status dashboard. Link and unlink Google resources (Drive folders, Groups) to teams via `TeamAdminController`. View resource status. Trigger per-resource sync |
 | Coordinator | Link and unlink Google resources for their own department (via `TeamAdminController`). Trigger per-resource sync for their own department |
 | Board, Admin | View Drive activity anomaly check results. View sync audit logs |

--- a/src/Humans.Application/Interfaces/GoogleIntegration/IGoogleAdminService.cs
+++ b/src/Humans.Application/Interfaces/GoogleIntegration/IGoogleAdminService.cs
@@ -45,6 +45,22 @@ public interface IGoogleAdminService
         CancellationToken ct = default);
 
     /// <summary>
+    /// Generates a fresh set of backup verification codes for a @nobodies.team account.
+    /// Invalidates any previously issued codes. Writes an audit log entry.
+    /// </summary>
+    Task<WorkspaceBackupCodesResult> GenerateBackupCodesAsync(
+        string email, Guid actorUserId,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Invalidates all backup verification codes for a @nobodies.team account.
+    /// Writes an audit log entry.
+    /// </summary>
+    Task<WorkspaceAccountActionResult> InvalidateBackupCodesAsync(
+        string email, Guid actorUserId,
+        CancellationToken ct = default);
+
+    /// <summary>
     /// Links a @nobodies.team account to a user.
     /// </summary>
     Task<WorkspaceAccountActionResult> LinkAccountAsync(
@@ -100,6 +116,7 @@ public record WorkspaceAccountListResult(
     int LinkedAccounts,
     int UnlinkedAccounts,
     int NotPrimaryCount,
+    int MissingTwoFactorCount,
     string? ErrorMessage = null);
 
 /// <summary>
@@ -114,7 +131,8 @@ public record WorkspaceAccountInfo(
     DateTime? LastLoginTime,
     Guid? MatchedUserId,
     string? MatchedDisplayName,
-    bool IsUsedAsPrimary);
+    bool IsUsedAsPrimary,
+    bool IsEnrolledIn2Sv);
 
 /// <summary>
 /// Result of a workspace account action (provision, suspend, reactivate, reset, link).
@@ -124,6 +142,17 @@ public record WorkspaceAccountActionResult(
     string? Message = null,
     string? ErrorMessage = null,
     string? TemporaryPassword = null);
+
+/// <summary>
+/// Result of generating backup verification codes. Codes are returned once and
+/// must be delivered to the human immediately — they cannot be retrieved again.
+/// </summary>
+public record WorkspaceBackupCodesResult(
+    bool Success,
+    string? Email = null,
+    IReadOnlyList<string>? Codes = null,
+    string? Message = null,
+    string? ErrorMessage = null);
 
 /// <summary>
 /// Result of applying email backfill corrections.

--- a/src/Humans.Application/Interfaces/GoogleIntegration/IGoogleAdminService.cs
+++ b/src/Humans.Application/Interfaces/GoogleIntegration/IGoogleAdminService.cs
@@ -132,7 +132,8 @@ public record WorkspaceAccountInfo(
     Guid? MatchedUserId,
     string? MatchedDisplayName,
     bool IsUsedAsPrimary,
-    bool IsEnrolledIn2Sv);
+    bool IsEnrolledIn2Sv,
+    string? RecoveryEmail = null);
 
 /// <summary>
 /// Result of a workspace account action (provision, suspend, reactivate, reset, link).

--- a/src/Humans.Application/Interfaces/GoogleIntegration/IGoogleAdminService.cs
+++ b/src/Humans.Application/Interfaces/GoogleIntegration/IGoogleAdminService.cs
@@ -45,18 +45,13 @@ public interface IGoogleAdminService
         CancellationToken ct = default);
 
     /// <summary>
-    /// Generates a fresh set of backup verification codes for a @nobodies.team account.
-    /// Invalidates any previously issued codes. Writes an audit log entry.
+    /// Resets the password for a @nobodies.team account AND grabs a single
+    /// fresh backup verification code so the admin can hand both to a
+    /// locked-out human in one transaction (the user can sign in with the
+    /// temp password and the code regardless of 2FA-enrollment state).
+    /// Writes two audit entries (password reset + backup codes generated).
     /// </summary>
-    Task<WorkspaceBackupCodesResult> GenerateBackupCodesAsync(
-        string email, Guid actorUserId,
-        CancellationToken ct = default);
-
-    /// <summary>
-    /// Invalidates all backup verification codes for a @nobodies.team account.
-    /// Writes an audit log entry.
-    /// </summary>
-    Task<WorkspaceAccountActionResult> InvalidateBackupCodesAsync(
+    Task<WorkspaceRecoveryCredentialsResult> ResetPasswordAndGenerate2FaAsync(
         string email, Guid actorUserId,
         CancellationToken ct = default);
 
@@ -152,6 +147,19 @@ public record WorkspaceBackupCodesResult(
     bool Success,
     string? Email = null,
     IReadOnlyList<string>? Codes = null,
+    string? Message = null,
+    string? ErrorMessage = null);
+
+/// <summary>
+/// Result of the combined password-reset + single-backup-code recovery flow.
+/// Both fields are one-shot — they can never be retrieved again after
+/// the admin closes the modal.
+/// </summary>
+public record WorkspaceRecoveryCredentialsResult(
+    bool Success,
+    string? Email = null,
+    string? TempPassword = null,
+    string? BackupCode = null,
     string? Message = null,
     string? ErrorMessage = null);
 

--- a/src/Humans.Application/Interfaces/GoogleIntegration/IGoogleWorkspaceUserService.cs
+++ b/src/Humans.Application/Interfaces/GoogleIntegration/IGoogleWorkspaceUserService.cs
@@ -48,6 +48,26 @@ public interface IGoogleWorkspaceUserService
     /// Gets a single account's details.
     /// </summary>
     Task<WorkspaceUserAccount?> GetAccountAsync(string primaryEmail, CancellationToken ct = default);
+
+    /// <summary>
+    /// Generates a fresh set of backup verification codes for the account and returns them.
+    /// Google reissues the full set on generate — any previously issued codes are invalidated.
+    /// The account must be enrolled in 2-Step Verification for generated codes to be usable.
+    /// </summary>
+    /// <param name="primaryEmail">The @nobodies.team account to generate codes for.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The freshly issued backup codes (typically 10 codes).</returns>
+    Task<IReadOnlyList<string>> GenerateBackupCodesAsync(
+        string primaryEmail,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Invalidates all backup verification codes for the account. Use when codes may
+    /// have leaked or to revoke previously issued codes without issuing new ones.
+    /// </summary>
+    Task InvalidateBackupCodesAsync(
+        string primaryEmail,
+        CancellationToken ct = default);
 }
 
 /// <summary>
@@ -59,4 +79,5 @@ public record WorkspaceUserAccount(
     string LastName,
     bool IsSuspended,
     DateTime CreationTime,
-    DateTime? LastLoginTime);
+    DateTime? LastLoginTime,
+    bool IsEnrolledIn2Sv);

--- a/src/Humans.Application/Interfaces/GoogleIntegration/IGoogleWorkspaceUserService.cs
+++ b/src/Humans.Application/Interfaces/GoogleIntegration/IGoogleWorkspaceUserService.cs
@@ -52,20 +52,13 @@ public interface IGoogleWorkspaceUserService
     /// <summary>
     /// Generates a fresh set of backup verification codes for the account and returns them.
     /// Google reissues the full set on generate — any previously issued codes are invalidated.
-    /// The account must be enrolled in 2-Step Verification for generated codes to be usable.
+    /// Confirmed (2026-05-04) to work for accounts that have not yet enrolled in 2SV: the
+    /// admin can hand a single code + password to a locked-out human for first sign-in.
     /// </summary>
     /// <param name="primaryEmail">The @nobodies.team account to generate codes for.</param>
     /// <param name="ct">Cancellation token.</param>
-    /// <returns>The freshly issued backup codes (typically 10 codes).</returns>
+    /// <returns>The freshly issued backup codes (typically 10 codes; the recovery flow uses one).</returns>
     Task<IReadOnlyList<string>> GenerateBackupCodesAsync(
-        string primaryEmail,
-        CancellationToken ct = default);
-
-    /// <summary>
-    /// Invalidates all backup verification codes for the account. Use when codes may
-    /// have leaked or to revoke previously issued codes without issuing new ones.
-    /// </summary>
-    Task InvalidateBackupCodesAsync(
         string primaryEmail,
         CancellationToken ct = default);
 }

--- a/src/Humans.Application/Interfaces/GoogleIntegration/IGoogleWorkspaceUserService.cs
+++ b/src/Humans.Application/Interfaces/GoogleIntegration/IGoogleWorkspaceUserService.cs
@@ -73,6 +73,12 @@ public interface IGoogleWorkspaceUserService
 /// <summary>
 /// Represents a Google Workspace user account on @nobodies.team.
 /// </summary>
+/// <param name="RecoveryEmail">
+/// The personal recovery email Google has on file for the account. Surfaced
+/// to admins as a sanity check (so the recovery channel can be validated
+/// before the human is locked out). May be <c>null</c> if no recovery email
+/// is set.
+/// </param>
 public record WorkspaceUserAccount(
     string PrimaryEmail,
     string FirstName,
@@ -80,4 +86,5 @@ public record WorkspaceUserAccount(
     bool IsSuspended,
     DateTime CreationTime,
     DateTime? LastLoginTime,
-    bool IsEnrolledIn2Sv);
+    bool IsEnrolledIn2Sv,
+    string? RecoveryEmail = null);

--- a/src/Humans.Application/Interfaces/GoogleIntegration/IWorkspaceUserDirectoryClient.cs
+++ b/src/Humans.Application/Interfaces/GoogleIntegration/IWorkspaceUserDirectoryClient.cs
@@ -57,4 +57,16 @@ public interface IWorkspaceUserDirectoryClient
     /// password change at next login.
     /// </summary>
     Task ResetPasswordAsync(string primaryEmail, string newPassword, CancellationToken ct = default);
+
+    /// <summary>
+    /// Generates a fresh set of backup verification codes for the account and
+    /// returns them. Google always reissues the full set on generate — any
+    /// previously issued codes are invalidated.
+    /// </summary>
+    Task<IReadOnlyList<string>> GenerateBackupCodesAsync(string primaryEmail, CancellationToken ct = default);
+
+    /// <summary>
+    /// Invalidates all backup verification codes for the account.
+    /// </summary>
+    Task InvalidateBackupCodesAsync(string primaryEmail, CancellationToken ct = default);
 }

--- a/src/Humans.Application/Interfaces/GoogleIntegration/IWorkspaceUserDirectoryClient.cs
+++ b/src/Humans.Application/Interfaces/GoogleIntegration/IWorkspaceUserDirectoryClient.cs
@@ -64,9 +64,4 @@ public interface IWorkspaceUserDirectoryClient
     /// previously issued codes are invalidated.
     /// </summary>
     Task<IReadOnlyList<string>> GenerateBackupCodesAsync(string primaryEmail, CancellationToken ct = default);
-
-    /// <summary>
-    /// Invalidates all backup verification codes for the account.
-    /// </summary>
-    Task InvalidateBackupCodesAsync(string primaryEmail, CancellationToken ct = default);
 }

--- a/src/Humans.Application/Services/GoogleIntegration/GoogleAdminService.cs
+++ b/src/Humans.Application/Services/GoogleIntegration/GoogleAdminService.cs
@@ -117,7 +117,8 @@ public sealed class GoogleAdminService : IGoogleAdminService
                     LastLoginTime: account.LastLoginTime,
                     MatchedUserId: matched?.UserId,
                     MatchedDisplayName: matchedUser?.DisplayName,
-                    IsUsedAsPrimary: isUsedAsPrimary));
+                    IsUsedAsPrimary: isUsedAsPrimary,
+                    IsEnrolledIn2Sv: account.IsEnrolledIn2Sv));
             }
 
             var sorted = accountInfos
@@ -125,6 +126,9 @@ public sealed class GoogleAdminService : IGoogleAdminService
                 .ToList();
 
             var linkedCount = sorted.Count(a => a.MatchedUserId.HasValue);
+            // Missing-2FA only applies to accounts that can actually be used — suspended
+            // accounts can't sign in at all, so flagging their 2FA gap is noise.
+            var missingTwoFactorCount = sorted.Count(a => !a.IsSuspended && !a.IsEnrolledIn2Sv);
 
             return new WorkspaceAccountListResult(
                 Accounts: sorted,
@@ -133,7 +137,8 @@ public sealed class GoogleAdminService : IGoogleAdminService
                 SuspendedAccounts: sorted.Count(a => a.IsSuspended),
                 LinkedAccounts: linkedCount,
                 UnlinkedAccounts: sorted.Count - linkedCount,
-                NotPrimaryCount: notPrimaryCount);
+                NotPrimaryCount: notPrimaryCount,
+                MissingTwoFactorCount: missingTwoFactorCount);
         }
         catch (Exception ex)
         {
@@ -146,6 +151,7 @@ public sealed class GoogleAdminService : IGoogleAdminService
                 LinkedAccounts: 0,
                 UnlinkedAccounts: 0,
                 NotPrimaryCount: 0,
+                MissingTwoFactorCount: 0,
                 ErrorMessage: "Failed to load @nobodies.team accounts. Check the logs for details.");
         }
     }
@@ -312,6 +318,61 @@ public sealed class GoogleAdminService : IGoogleAdminService
             _logger.LogError(ex, "Failed to reset password for: {Email}", email);
             return new WorkspaceAccountActionResult(false,
                 ErrorMessage: $"Failed to reset password for {email}.");
+        }
+    }
+
+    public async Task<WorkspaceBackupCodesResult> GenerateBackupCodesAsync(
+        string email, Guid actorUserId,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            var codes = await _workspaceUserService.GenerateBackupCodesAsync(email, ct);
+
+            await _auditLogService.LogAsync(
+                AuditAction.WorkspaceAccountBackupCodesGenerated,
+                "WorkspaceAccount", Guid.Empty,
+                $"Generated {codes.Count} backup code(s) for @{NobodiesTeamDomain} account: {email}",
+                actorUserId);
+
+            return new WorkspaceBackupCodesResult(
+                Success: true,
+                Email: email,
+                Codes: codes,
+                Message: $"Generated {codes.Count} backup code(s) for {email}. Deliver them securely — they cannot be retrieved again.");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to generate backup codes for: {Email}", email);
+            return new WorkspaceBackupCodesResult(
+                Success: false,
+                Email: email,
+                ErrorMessage: $"Failed to generate backup codes for {email}. Check logs for details.");
+        }
+    }
+
+    public async Task<WorkspaceAccountActionResult> InvalidateBackupCodesAsync(
+        string email, Guid actorUserId,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            await _workspaceUserService.InvalidateBackupCodesAsync(email, ct);
+
+            await _auditLogService.LogAsync(
+                AuditAction.WorkspaceAccountBackupCodesInvalidated,
+                "WorkspaceAccount", Guid.Empty,
+                $"Invalidated backup codes for @{NobodiesTeamDomain} account: {email}",
+                actorUserId);
+
+            return new WorkspaceAccountActionResult(true,
+                Message: $"Backup codes invalidated for {email}.");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to invalidate backup codes for: {Email}", email);
+            return new WorkspaceAccountActionResult(false,
+                ErrorMessage: $"Failed to invalidate backup codes for {email}. Check logs for details.");
         }
     }
 

--- a/src/Humans.Application/Services/GoogleIntegration/GoogleAdminService.cs
+++ b/src/Humans.Application/Services/GoogleIntegration/GoogleAdminService.cs
@@ -325,21 +325,10 @@ public sealed class GoogleAdminService : IGoogleAdminService
         string email, Guid actorUserId,
         CancellationToken ct = default)
     {
+        IReadOnlyList<string> codes;
         try
         {
-            var codes = await _workspaceUserService.GenerateBackupCodesAsync(email, ct);
-
-            await _auditLogService.LogAsync(
-                AuditAction.WorkspaceAccountBackupCodesGenerated,
-                "WorkspaceAccount", Guid.Empty,
-                $"Generated {codes.Count} backup code(s) for @{NobodiesTeamDomain} account: {email}",
-                actorUserId);
-
-            return new WorkspaceBackupCodesResult(
-                Success: true,
-                Email: email,
-                Codes: codes,
-                Message: $"Generated {codes.Count} backup code(s) for {email}. Deliver them securely — they cannot be retrieved again.");
+            codes = await _workspaceUserService.GenerateBackupCodesAsync(email, ct);
         }
         catch (Exception ex)
         {
@@ -349,6 +338,46 @@ public sealed class GoogleAdminService : IGoogleAdminService
                 Email: email,
                 ErrorMessage: $"Failed to generate backup codes for {email}. Check logs for details.");
         }
+
+        if (codes.Count == 0)
+        {
+            // Generate succeeded but List returned 0 — API hiccup or race.
+            // No codes to deliver and nothing to audit; surface a clear failure
+            // instead of recording "Generated 0 backup codes" in the audit log.
+            _logger.LogWarning(
+                "Backup-code generation for {Email} returned 0 codes; nothing to deliver",
+                email);
+            return new WorkspaceBackupCodesResult(
+                Success: false,
+                Email: email,
+                ErrorMessage: $"Backup codes were generated for {email} but none were returned. Check logs and try again.");
+        }
+
+        // Audit AFTER the Workspace-side rotation succeeds. If audit persistence
+        // throws we must still hand the codes back: Google has already
+        // invalidated any previously-issued set, so dropping the new ones
+        // locks the human out. Surface the audit failure loudly via a critical
+        // log so it can be reconciled out-of-band.
+        try
+        {
+            await _auditLogService.LogAsync(
+                AuditAction.WorkspaceAccountBackupCodesGenerated,
+                "WorkspaceAccount", Guid.Empty,
+                $"Generated {codes.Count} backup code(s) for @{NobodiesTeamDomain} account: {email}",
+                actorUserId);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogCritical(ex,
+                "Audit-log write failed AFTER backup codes were generated for {Email} by actor {ActorUserId}. Codes were delivered; reconcile audit trail manually.",
+                email, actorUserId);
+        }
+
+        return new WorkspaceBackupCodesResult(
+            Success: true,
+            Email: email,
+            Codes: codes,
+            Message: $"Generated {codes.Count} backup code(s) for {email}. Deliver them securely — they cannot be retrieved again.");
     }
 
     public async Task<WorkspaceAccountActionResult> InvalidateBackupCodesAsync(

--- a/src/Humans.Application/Services/GoogleIntegration/GoogleAdminService.cs
+++ b/src/Humans.Application/Services/GoogleIntegration/GoogleAdminService.cs
@@ -322,7 +322,7 @@ public sealed class GoogleAdminService : IGoogleAdminService
         }
     }
 
-    public async Task<WorkspaceBackupCodesResult> GenerateBackupCodesAsync(
+    private async Task<WorkspaceBackupCodesResult> GenerateBackupCodesAsync(
         string email, Guid actorUserId,
         CancellationToken ct = default)
     {

--- a/src/Humans.Application/Services/GoogleIntegration/GoogleAdminService.cs
+++ b/src/Humans.Application/Services/GoogleIntegration/GoogleAdminService.cs
@@ -381,29 +381,46 @@ public sealed class GoogleAdminService : IGoogleAdminService
             Message: $"Generated {codes.Count} backup code(s) for {email}. Deliver them securely — they cannot be retrieved again.");
     }
 
-    public async Task<WorkspaceAccountActionResult> InvalidateBackupCodesAsync(
+    public async Task<WorkspaceRecoveryCredentialsResult> ResetPasswordAndGenerate2FaAsync(
         string email, Guid actorUserId,
         CancellationToken ct = default)
     {
-        try
+        // Step 1: reset the password. Audit + return on failure — there's
+        // no point grabbing a backup code if the human can't sign in anyway.
+        var resetResult = await ResetPasswordAsync(email, actorUserId, ct);
+        if (!resetResult.Success || resetResult.TemporaryPassword is null)
         {
-            await _workspaceUserService.InvalidateBackupCodesAsync(email, ct);
-
-            await _auditLogService.LogAsync(
-                AuditAction.WorkspaceAccountBackupCodesInvalidated,
-                "WorkspaceAccount", Guid.Empty,
-                $"Invalidated backup codes for @{NobodiesTeamDomain} account: {email}",
-                actorUserId);
-
-            return new WorkspaceAccountActionResult(true,
-                Message: $"Backup codes invalidated for {email}.");
+            return new WorkspaceRecoveryCredentialsResult(
+                Success: false,
+                Email: email,
+                ErrorMessage: resetResult.ErrorMessage
+                    ?? $"Failed to reset password for {email}. Check logs for details.");
         }
-        catch (Exception ex)
+
+        // Step 2: grab a backup code. If this fails, the password is still
+        // valid — return Success with just the password and an explanatory
+        // message so the admin can deliver what we have. (Google rotates
+        // codes destructively, so a partial success is better than re-asking
+        // the admin to start over.)
+        var codesResult = await GenerateBackupCodesAsync(email, actorUserId, ct);
+        if (!codesResult.Success || codesResult.Codes is not { Count: > 0 })
         {
-            _logger.LogError(ex, "Failed to invalidate backup codes for: {Email}", email);
-            return new WorkspaceAccountActionResult(false,
-                ErrorMessage: $"Failed to invalidate backup codes for {email}. Check logs for details.");
+            return new WorkspaceRecoveryCredentialsResult(
+                Success: true,
+                Email: email,
+                TempPassword: resetResult.TemporaryPassword,
+                BackupCode: null,
+                Message: $"Password reset for {email}. Backup-code generation failed — "
+                       + (codesResult.ErrorMessage
+                            ?? "deliver the password only and ask the human to re-attempt the 2FA request out-of-band."));
         }
+
+        return new WorkspaceRecoveryCredentialsResult(
+            Success: true,
+            Email: email,
+            TempPassword: resetResult.TemporaryPassword,
+            BackupCode: codesResult.Codes[0],
+            Message: $"Password reset and one backup code issued for {email}. Deliver both securely — neither can be retrieved again.");
     }
 
     public async Task<WorkspaceAccountActionResult> LinkAccountAsync(

--- a/src/Humans.Application/Services/GoogleIntegration/GoogleAdminService.cs
+++ b/src/Humans.Application/Services/GoogleIntegration/GoogleAdminService.cs
@@ -118,7 +118,8 @@ public sealed class GoogleAdminService : IGoogleAdminService
                     MatchedUserId: matched?.UserId,
                     MatchedDisplayName: matchedUser?.DisplayName,
                     IsUsedAsPrimary: isUsedAsPrimary,
-                    IsEnrolledIn2Sv: account.IsEnrolledIn2Sv));
+                    IsEnrolledIn2Sv: account.IsEnrolledIn2Sv,
+                    RecoveryEmail: account.RecoveryEmail));
             }
 
             var sorted = accountInfos

--- a/src/Humans.Application/Services/GoogleIntegration/GoogleWorkspaceUserService.cs
+++ b/src/Humans.Application/Services/GoogleIntegration/GoogleWorkspaceUserService.cs
@@ -81,4 +81,22 @@ public sealed class GoogleWorkspaceUserService : IGoogleWorkspaceUserService
         }
         return account;
     }
+
+    public async Task<IReadOnlyList<string>> GenerateBackupCodesAsync(
+        string primaryEmail, CancellationToken ct = default)
+    {
+        var codes = await _client.GenerateBackupCodesAsync(primaryEmail, ct);
+        _logger.LogInformation(
+            "Generated {Count} backup code(s) for workspace account: {Email}",
+            codes.Count, primaryEmail);
+        return codes;
+    }
+
+    public async Task InvalidateBackupCodesAsync(
+        string primaryEmail, CancellationToken ct = default)
+    {
+        await _client.InvalidateBackupCodesAsync(primaryEmail, ct);
+        _logger.LogInformation(
+            "Invalidated backup codes for workspace account: {Email}", primaryEmail);
+    }
 }

--- a/src/Humans.Application/Services/GoogleIntegration/GoogleWorkspaceUserService.cs
+++ b/src/Humans.Application/Services/GoogleIntegration/GoogleWorkspaceUserService.cs
@@ -92,11 +92,4 @@ public sealed class GoogleWorkspaceUserService : IGoogleWorkspaceUserService
         return codes;
     }
 
-    public async Task InvalidateBackupCodesAsync(
-        string primaryEmail, CancellationToken ct = default)
-    {
-        await _client.InvalidateBackupCodesAsync(primaryEmail, ct);
-        _logger.LogInformation(
-            "Invalidated backup codes for workspace account: {Email}", primaryEmail);
-    }
 }

--- a/src/Humans.Domain/Enums/AuditAction.cs
+++ b/src/Humans.Domain/Enums/AuditAction.cs
@@ -65,6 +65,8 @@ public enum AuditAction
     WorkspaceAccountReactivated,
     WorkspaceAccountPasswordReset,
     WorkspaceAccountLinked,
+    WorkspaceAccountBackupCodesGenerated,
+    WorkspaceAccountBackupCodesInvalidated,
     AccountMergeRequested,
     AccountMergeAccepted,
     AccountMergeRejected,

--- a/src/Humans.Domain/Enums/AuditAction.cs
+++ b/src/Humans.Domain/Enums/AuditAction.cs
@@ -66,6 +66,8 @@ public enum AuditAction
     WorkspaceAccountPasswordReset,
     WorkspaceAccountLinked,
     WorkspaceAccountBackupCodesGenerated,
+    // Reserved — was wired briefly during PR #254 development. No code path
+    // currently writes this value; do not remove (audit enum is positional).
     WorkspaceAccountBackupCodesInvalidated,
     AccountMergeRequested,
     AccountMergeAccepted,

--- a/src/Humans.Infrastructure/Services/GoogleWorkspace/StubWorkspaceUserDirectoryClient.cs
+++ b/src/Humans.Infrastructure/Services/GoogleWorkspace/StubWorkspaceUserDirectoryClient.cs
@@ -23,13 +23,16 @@ public sealed class StubWorkspaceUserDirectoryClient : IWorkspaceUserDirectoryCl
         [
             new WorkspaceUserAccount("alice@nobodies.team", "Alice", "Example", false,
                 new DateTime(2025, 1, 15, 0, 0, 0, DateTimeKind.Utc),
-                new DateTime(2026, 3, 18, 10, 0, 0, DateTimeKind.Utc)),
+                new DateTime(2026, 3, 18, 10, 0, 0, DateTimeKind.Utc),
+                IsEnrolledIn2Sv: true),
             new WorkspaceUserAccount("bob@nobodies.team", "Bob", "Test", false,
                 new DateTime(2025, 3, 1, 0, 0, 0, DateTimeKind.Utc),
-                new DateTime(2026, 3, 15, 14, 0, 0, DateTimeKind.Utc)),
+                new DateTime(2026, 3, 15, 14, 0, 0, DateTimeKind.Utc),
+                IsEnrolledIn2Sv: false),
             new WorkspaceUserAccount("carol@nobodies.team", "Carol", "Demo", true,
                 new DateTime(2025, 6, 10, 0, 0, 0, DateTimeKind.Utc),
-                null)
+                null,
+                IsEnrolledIn2Sv: false)
         ];
     }
 
@@ -56,7 +59,8 @@ public sealed class StubWorkspaceUserDirectoryClient : IWorkspaceUserDirectoryCl
     {
         _logger.LogInformation("[Stub] Provisioned fake account: {Email}", primaryEmail);
         var account = new WorkspaceUserAccount(
-            primaryEmail, firstName, lastName, false, DateTime.UtcNow, null);
+            primaryEmail, firstName, lastName, false, DateTime.UtcNow, null,
+            IsEnrolledIn2Sv: false);
         _accounts.Add(account);
         return Task.FromResult(account);
     }
@@ -78,6 +82,24 @@ public sealed class StubWorkspaceUserDirectoryClient : IWorkspaceUserDirectoryCl
     public Task ResetPasswordAsync(string primaryEmail, string newPassword, CancellationToken ct = default)
     {
         _logger.LogInformation("[Stub] Reset password for fake account: {Email}", primaryEmail);
+        return Task.CompletedTask;
+    }
+
+    public Task<IReadOnlyList<string>> GenerateBackupCodesAsync(string primaryEmail, CancellationToken ct = default)
+    {
+        _logger.LogInformation("[Stub] Generated backup codes for fake account: {Email}", primaryEmail);
+        // Return 10 placeholder codes for local development visibility.
+        IReadOnlyList<string> codes =
+        [
+            "1111-1111", "2222-2222", "3333-3333", "4444-4444", "5555-5555",
+            "6666-6666", "7777-7777", "8888-8888", "9999-9999", "0000-0000"
+        ];
+        return Task.FromResult(codes);
+    }
+
+    public Task InvalidateBackupCodesAsync(string primaryEmail, CancellationToken ct = default)
+    {
+        _logger.LogInformation("[Stub] Invalidated backup codes for fake account: {Email}", primaryEmail);
         return Task.CompletedTask;
     }
 

--- a/src/Humans.Infrastructure/Services/GoogleWorkspace/StubWorkspaceUserDirectoryClient.cs
+++ b/src/Humans.Infrastructure/Services/GoogleWorkspace/StubWorkspaceUserDirectoryClient.cs
@@ -101,12 +101,6 @@ public sealed class StubWorkspaceUserDirectoryClient : IWorkspaceUserDirectoryCl
         return Task.FromResult(codes);
     }
 
-    public Task InvalidateBackupCodesAsync(string primaryEmail, CancellationToken ct = default)
-    {
-        _logger.LogInformation("[Stub] Invalidated backup codes for fake account: {Email}", primaryEmail);
-        return Task.CompletedTask;
-    }
-
     private void ReplaceAccount(string email, Func<WorkspaceUserAccount, WorkspaceUserAccount> transform)
     {
         var index = _accounts.FindIndex(a =>

--- a/src/Humans.Infrastructure/Services/GoogleWorkspace/StubWorkspaceUserDirectoryClient.cs
+++ b/src/Humans.Infrastructure/Services/GoogleWorkspace/StubWorkspaceUserDirectoryClient.cs
@@ -24,15 +24,18 @@ public sealed class StubWorkspaceUserDirectoryClient : IWorkspaceUserDirectoryCl
             new WorkspaceUserAccount("alice@nobodies.team", "Alice", "Example", false,
                 new DateTime(2025, 1, 15, 0, 0, 0, DateTimeKind.Utc),
                 new DateTime(2026, 3, 18, 10, 0, 0, DateTimeKind.Utc),
-                IsEnrolledIn2Sv: true),
+                IsEnrolledIn2Sv: true,
+                RecoveryEmail: "alice.personal@example.com"),
             new WorkspaceUserAccount("bob@nobodies.team", "Bob", "Test", false,
                 new DateTime(2025, 3, 1, 0, 0, 0, DateTimeKind.Utc),
                 new DateTime(2026, 3, 15, 14, 0, 0, DateTimeKind.Utc),
-                IsEnrolledIn2Sv: false),
+                IsEnrolledIn2Sv: false,
+                RecoveryEmail: null),
             new WorkspaceUserAccount("carol@nobodies.team", "Carol", "Demo", true,
                 new DateTime(2025, 6, 10, 0, 0, 0, DateTimeKind.Utc),
                 null,
-                IsEnrolledIn2Sv: false)
+                IsEnrolledIn2Sv: false,
+                RecoveryEmail: "carol.personal@example.com")
         ];
     }
 
@@ -60,7 +63,8 @@ public sealed class StubWorkspaceUserDirectoryClient : IWorkspaceUserDirectoryCl
         _logger.LogInformation("[Stub] Provisioned fake account: {Email}", primaryEmail);
         var account = new WorkspaceUserAccount(
             primaryEmail, firstName, lastName, false, DateTime.UtcNow, null,
-            IsEnrolledIn2Sv: false);
+            IsEnrolledIn2Sv: false,
+            RecoveryEmail: recoveryEmail);
         _accounts.Add(account);
         return Task.FromResult(account);
     }

--- a/src/Humans.Infrastructure/Services/GoogleWorkspace/WorkspaceUserDirectoryClient.cs
+++ b/src/Humans.Infrastructure/Services/GoogleWorkspace/WorkspaceUserDirectoryClient.cs
@@ -63,7 +63,9 @@ public sealed class WorkspaceUserDirectoryClient : IWorkspaceUserDirectoryClient
                 "Google Workspace credentials not configured. Set ServiceAccountKeyPath or ServiceAccountKeyJson.");
         }
 
-        return credential.CreateScoped(DirectoryService.Scope.AdminDirectoryUser);
+        return credential.CreateScoped(
+            DirectoryService.Scope.AdminDirectoryUser,
+            DirectoryService.Scope.AdminDirectoryUserSecurity);
     }
 
     public async Task<IReadOnlyList<WorkspaceUserAccount>> ListAccountsAsync(
@@ -175,6 +177,33 @@ public sealed class WorkspaceUserDirectoryClient : IWorkspaceUserDirectoryClient
         await service.Users.Update(update, primaryEmail).ExecuteAsync(ct);
     }
 
+    public async Task<IReadOnlyList<string>> GenerateBackupCodesAsync(
+        string primaryEmail, CancellationToken ct = default)
+    {
+        var service = await GetDirectoryServiceAsync();
+
+        // Generate issues a fresh set of codes. Google always issues 10 codes and
+        // invalidates any previously issued set in the same call.
+        await service.VerificationCodes.Generate(primaryEmail).ExecuteAsync(ct);
+
+        // List returns the freshly generated codes so we can surface them to the admin.
+        var response = await service.VerificationCodes.List(primaryEmail).ExecuteAsync(ct);
+
+        var codes = response.Items?
+            .Select(c => c.VerificationCodeValue)
+            .Where(v => !string.IsNullOrEmpty(v))
+            .ToList() ?? [];
+
+        return codes;
+    }
+
+    public async Task InvalidateBackupCodesAsync(
+        string primaryEmail, CancellationToken ct = default)
+    {
+        var service = await GetDirectoryServiceAsync();
+        await service.VerificationCodes.Invalidate(primaryEmail).ExecuteAsync(ct);
+    }
+
     private static WorkspaceUserAccount MapToAccount(User user)
     {
         return new WorkspaceUserAccount(
@@ -187,6 +216,7 @@ public sealed class WorkspaceUserDirectoryClient : IWorkspaceUserDirectoryClient
                 : DateTime.MinValue,
             LastLoginTime: user.LastLoginTimeRaw is not null
                 ? DateTime.Parse(user.LastLoginTimeRaw, System.Globalization.CultureInfo.InvariantCulture)
-                : null);
+                : null,
+            IsEnrolledIn2Sv: user.IsEnrolledIn2Sv ?? false);
     }
 }

--- a/src/Humans.Infrastructure/Services/GoogleWorkspace/WorkspaceUserDirectoryClient.cs
+++ b/src/Humans.Infrastructure/Services/GoogleWorkspace/WorkspaceUserDirectoryClient.cs
@@ -197,13 +197,6 @@ public sealed class WorkspaceUserDirectoryClient : IWorkspaceUserDirectoryClient
         return codes;
     }
 
-    public async Task InvalidateBackupCodesAsync(
-        string primaryEmail, CancellationToken ct = default)
-    {
-        var service = await GetDirectoryServiceAsync();
-        await service.VerificationCodes.Invalidate(primaryEmail).ExecuteAsync(ct);
-    }
-
     private static WorkspaceUserAccount MapToAccount(User user)
     {
         return new WorkspaceUserAccount(

--- a/src/Humans.Infrastructure/Services/GoogleWorkspace/WorkspaceUserDirectoryClient.cs
+++ b/src/Humans.Infrastructure/Services/GoogleWorkspace/WorkspaceUserDirectoryClient.cs
@@ -217,6 +217,7 @@ public sealed class WorkspaceUserDirectoryClient : IWorkspaceUserDirectoryClient
             LastLoginTime: user.LastLoginTimeRaw is not null
                 ? DateTime.Parse(user.LastLoginTimeRaw, System.Globalization.CultureInfo.InvariantCulture)
                 : null,
-            IsEnrolledIn2Sv: user.IsEnrolledIn2Sv ?? false);
+            IsEnrolledIn2Sv: user.IsEnrolledIn2Sv ?? false,
+            RecoveryEmail: string.IsNullOrWhiteSpace(user.RecoveryEmail) ? null : user.RecoveryEmail);
     }
 }

--- a/src/Humans.Web/Constants/TempDataKeys.cs
+++ b/src/Humans.Web/Constants/TempDataKeys.cs
@@ -12,4 +12,5 @@ public static class TempDataKeys
     public const string GroupSettingsResult = "GroupSettingsResult";
     public const string EmailBackfillResult = "EmailBackfillResult";
     public const string EmailRenameResult = "EmailRenameResult";
+    public const string WorkspaceBackupCodes = "WorkspaceBackupCodes";
 }

--- a/src/Humans.Web/Constants/TempDataKeys.cs
+++ b/src/Humans.Web/Constants/TempDataKeys.cs
@@ -12,5 +12,5 @@ public static class TempDataKeys
     public const string GroupSettingsResult = "GroupSettingsResult";
     public const string EmailBackfillResult = "EmailBackfillResult";
     public const string EmailRenameResult = "EmailRenameResult";
-    public const string WorkspaceBackupCodes = "WorkspaceBackupCodes";
+    public const string WorkspaceRecoveryCredentials = "WorkspaceRecoveryCredentials";
 }

--- a/src/Humans.Web/Controllers/GoogleController.cs
+++ b/src/Humans.Web/Controllers/GoogleController.cs
@@ -587,15 +587,28 @@ public class GoogleController : HumansControllerBase
                 LastLoginTime = a.LastLoginTime,
                 MatchedUserId = a.MatchedUserId,
                 MatchedDisplayName = a.MatchedDisplayName,
-                IsUsedAsPrimary = a.IsUsedAsPrimary
+                IsUsedAsPrimary = a.IsUsedAsPrimary,
+                IsEnrolledIn2Sv = a.IsEnrolledIn2Sv
             }).ToList(),
             TotalAccounts = result.TotalAccounts,
             ActiveAccounts = result.ActiveAccounts,
             SuspendedAccounts = result.SuspendedAccounts,
             LinkedAccounts = result.LinkedAccounts,
             UnlinkedAccounts = result.UnlinkedAccounts,
-            NotPrimaryCount = result.NotPrimaryCount
+            NotPrimaryCount = result.NotPrimaryCount,
+            MissingTwoFactorCount = result.MissingTwoFactorCount
         };
+
+        // If a previous POST just generated backup codes, surface them once via a modal.
+        // TempData is single-use — once the page renders, the codes are gone.
+        if (TempData[TempDataKeys.WorkspaceBackupCodes] is string codesJson)
+        {
+            var codesVm = System.Text.Json.JsonSerializer.Deserialize<WorkspaceBackupCodesViewModel>(codesJson);
+            if (codesVm is not null)
+            {
+                ViewBag.GeneratedBackupCodes = codesVm;
+            }
+        }
 
         return View(model);
     }
@@ -691,6 +704,65 @@ public class GoogleController : HumansControllerBase
 
         var result = await _googleAdminService.ResetPasswordAsync(
             email, currentUser.Id);
+
+        if (result.Success)
+            SetSuccess(result.Message!);
+        else
+            SetError(result.ErrorMessage!);
+
+        return RedirectToAction(nameof(Accounts));
+    }
+
+    [HttpPost("Accounts/GenerateBackupCodes")]
+    [Authorize(Policy = PolicyNames.AdminOnly)]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> GenerateBackupCodes(string email)
+    {
+        if (string.IsNullOrWhiteSpace(email))
+        {
+            return BadRequest();
+        }
+
+        var currentUser = await GetCurrentUserAsync();
+        if (currentUser is null) return Unauthorized();
+
+        var result = await _googleAdminService.GenerateBackupCodesAsync(email, currentUser.Id);
+
+        if (result.Success && result.Codes is { Count: > 0 })
+        {
+            // Carry codes across the PRG redirect via TempData. Single-use so a refresh
+            // of the Accounts page after dismissing the modal doesn't re-expose them.
+            var codesVm = new WorkspaceBackupCodesViewModel
+            {
+                Email = result.Email ?? email,
+                Codes = result.Codes.ToList()
+            };
+            TempData[TempDataKeys.WorkspaceBackupCodes] =
+                System.Text.Json.JsonSerializer.Serialize(codesVm);
+            SetSuccess(result.Message ?? $"Generated {result.Codes.Count} backup code(s) for {email}.");
+        }
+        else
+        {
+            SetError(result.ErrorMessage ?? $"Failed to generate backup codes for {email}.");
+        }
+
+        return RedirectToAction(nameof(Accounts));
+    }
+
+    [HttpPost("Accounts/InvalidateBackupCodes")]
+    [Authorize(Policy = PolicyNames.AdminOnly)]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> InvalidateBackupCodes(string email)
+    {
+        if (string.IsNullOrWhiteSpace(email))
+        {
+            return BadRequest();
+        }
+
+        var currentUser = await GetCurrentUserAsync();
+        if (currentUser is null) return Unauthorized();
+
+        var result = await _googleAdminService.InvalidateBackupCodesAsync(email, currentUser.Id);
 
         if (result.Success)
             SetSuccess(result.Message!);

--- a/src/Humans.Web/Controllers/GoogleController.cs
+++ b/src/Humans.Web/Controllers/GoogleController.cs
@@ -600,14 +600,15 @@ public class GoogleController : HumansControllerBase
             MissingTwoFactorCount = result.MissingTwoFactorCount
         };
 
-        // If a previous POST just generated backup codes, surface them once via a modal.
-        // TempData is single-use — once the page renders, the codes are gone.
-        if (TempData[TempDataKeys.WorkspaceBackupCodes] is string codesJson)
+        // If a previous POST just issued recovery credentials (password reset
+        // ± a 2FA backup code), surface them once via a modal. TempData is
+        // single-use — once the page renders, the secrets are gone.
+        if (TempData[TempDataKeys.WorkspaceRecoveryCredentials] is string credsJson)
         {
-            var codesVm = System.Text.Json.JsonSerializer.Deserialize<WorkspaceBackupCodesViewModel>(codesJson);
-            if (codesVm is not null)
+            var credsVm = System.Text.Json.JsonSerializer.Deserialize<WorkspaceRecoveryCredentialsViewModel>(credsJson);
+            if (credsVm is not null)
             {
-                ViewBag.GeneratedBackupCodes = codesVm;
+                ViewBag.RecoveryCredentials = credsVm;
             }
         }
 
@@ -706,18 +707,28 @@ public class GoogleController : HumansControllerBase
         var result = await _googleAdminService.ResetPasswordAsync(
             email, currentUser.Id);
 
-        if (result.Success)
-            SetSuccess(result.Message!);
+        if (result.Success && !string.IsNullOrEmpty(result.TemporaryPassword))
+        {
+            CarryRecoveryCredentials(new WorkspaceRecoveryCredentialsViewModel
+            {
+                Email = email,
+                TempPassword = result.TemporaryPassword,
+                BackupCode = null
+            });
+            SetSuccess($"Password reset for {email}. Deliver the new password securely.");
+        }
         else
-            SetError(result.ErrorMessage!);
+        {
+            SetError(result.ErrorMessage ?? $"Failed to reset password for {email}.");
+        }
 
         return RedirectToAction(nameof(Accounts));
     }
 
-    [HttpPost("Accounts/GenerateBackupCodes")]
+    [HttpPost("Accounts/ResetPasswordAndGenerate2Fa")]
     [Authorize(Policy = PolicyNames.AdminOnly)]
     [ValidateAntiForgeryToken]
-    public async Task<IActionResult> GenerateBackupCodes(string email)
+    public async Task<IActionResult> ResetPasswordAndGenerate2Fa(string email)
     {
         if (string.IsNullOrWhiteSpace(email))
         {
@@ -727,50 +738,33 @@ public class GoogleController : HumansControllerBase
         var currentUser = await GetCurrentUserAsync();
         if (currentUser is null) return Unauthorized();
 
-        var result = await _googleAdminService.GenerateBackupCodesAsync(email, currentUser.Id);
+        var result = await _googleAdminService.ResetPasswordAndGenerate2FaAsync(
+            email, currentUser.Id);
 
-        if (result.Success && result.Codes is { Count: > 0 })
+        if (result.Success && !string.IsNullOrEmpty(result.TempPassword))
         {
-            // Carry codes across the PRG redirect via TempData. Single-use so a refresh
-            // of the Accounts page after dismissing the modal doesn't re-expose them.
-            var codesVm = new WorkspaceBackupCodesViewModel
+            CarryRecoveryCredentials(new WorkspaceRecoveryCredentialsViewModel
             {
                 Email = result.Email ?? email,
-                Codes = result.Codes.ToList()
-            };
-            TempData[TempDataKeys.WorkspaceBackupCodes] =
-                System.Text.Json.JsonSerializer.Serialize(codesVm);
-            SetSuccess(result.Message ?? $"Generated {result.Codes.Count} backup code(s) for {email}.");
+                TempPassword = result.TempPassword,
+                BackupCode = result.BackupCode
+            });
+            SetSuccess(result.Message ?? $"Recovery credentials issued for {email}. Deliver them securely.");
         }
         else
         {
-            SetError(result.ErrorMessage ?? $"Failed to generate backup codes for {email}.");
+            SetError(result.ErrorMessage ?? $"Failed to issue recovery credentials for {email}.");
         }
 
         return RedirectToAction(nameof(Accounts));
     }
 
-    [HttpPost("Accounts/InvalidateBackupCodes")]
-    [Authorize(Policy = PolicyNames.AdminOnly)]
-    [ValidateAntiForgeryToken]
-    public async Task<IActionResult> InvalidateBackupCodes(string email)
+    private void CarryRecoveryCredentials(WorkspaceRecoveryCredentialsViewModel vm)
     {
-        if (string.IsNullOrWhiteSpace(email))
-        {
-            return BadRequest();
-        }
-
-        var currentUser = await GetCurrentUserAsync();
-        if (currentUser is null) return Unauthorized();
-
-        var result = await _googleAdminService.InvalidateBackupCodesAsync(email, currentUser.Id);
-
-        if (result.Success)
-            SetSuccess(result.Message!);
-        else
-            SetError(result.ErrorMessage!);
-
-        return RedirectToAction(nameof(Accounts));
+        // Single-use across the PRG redirect — a refresh of /Google/Accounts
+        // after dismissing the modal cannot re-expose the secrets.
+        TempData[TempDataKeys.WorkspaceRecoveryCredentials] =
+            System.Text.Json.JsonSerializer.Serialize(vm);
     }
 
     [HttpPost("Accounts/Link")]

--- a/src/Humans.Web/Controllers/GoogleController.cs
+++ b/src/Humans.Web/Controllers/GoogleController.cs
@@ -588,7 +588,8 @@ public class GoogleController : HumansControllerBase
                 MatchedUserId = a.MatchedUserId,
                 MatchedDisplayName = a.MatchedDisplayName,
                 IsUsedAsPrimary = a.IsUsedAsPrimary,
-                IsEnrolledIn2Sv = a.IsEnrolledIn2Sv
+                IsEnrolledIn2Sv = a.IsEnrolledIn2Sv,
+                RecoveryEmail = a.RecoveryEmail
             }).ToList(),
             TotalAccounts = result.TotalAccounts,
             ActiveAccounts = result.ActiveAccounts,

--- a/src/Humans.Web/Controllers/GoogleController.cs
+++ b/src/Humans.Web/Controllers/GoogleController.cs
@@ -707,12 +707,12 @@ public class GoogleController : HumansControllerBase
         var result = await _googleAdminService.ResetPasswordAsync(
             email, currentUser.Id);
 
-        if (result.Success && !string.IsNullOrEmpty(result.TemporaryPassword))
+        if (result.Success)
         {
             CarryRecoveryCredentials(new WorkspaceRecoveryCredentialsViewModel
             {
                 Email = email,
-                TempPassword = result.TemporaryPassword,
+                TempPassword = result.TemporaryPassword!,
                 BackupCode = null
             });
             SetSuccess($"Password reset for {email}. Deliver the new password securely.");
@@ -749,7 +749,10 @@ public class GoogleController : HumansControllerBase
                 TempPassword = result.TempPassword,
                 BackupCode = result.BackupCode
             });
-            SetSuccess(result.Message ?? $"Recovery credentials issued for {email}. Deliver them securely.");
+            if (!string.IsNullOrEmpty(result.BackupCode))
+                SetSuccess(result.Message ?? $"Recovery credentials issued for {email}. Deliver them securely.");
+            else
+                SetError(result.Message ?? $"Password reset for {email}, but backup-code generation failed. Deliver the password and retry 2FA.");
         }
         else
         {

--- a/src/Humans.Web/Models/WorkspaceEmailViewModels.cs
+++ b/src/Humans.Web/Models/WorkspaceEmailViewModels.cs
@@ -12,6 +12,12 @@ public class WorkspaceEmailListViewModel
     public int LinkedAccounts { get; set; }
     public int UnlinkedAccounts { get; set; }
     public int NotPrimaryCount { get; set; }
+
+    /// <summary>
+    /// Count of active accounts that have not completed 2-Step Verification enrollment.
+    /// These accounts cannot sign in and need attention.
+    /// </summary>
+    public int MissingTwoFactorCount { get; set; }
 }
 
 /// <summary>
@@ -36,6 +42,22 @@ public class WorkspaceEmailAccountViewModel
     /// Whether the @nobodies.team email is being used as the notification target.
     /// </summary>
     public bool IsUsedAsPrimary { get; set; }
+
+    /// <summary>
+    /// Whether this account has completed 2-Step Verification enrollment.
+    /// Unenrolled accounts cannot sign in (2FA is enforced org-wide).
+    /// </summary>
+    public bool IsEnrolledIn2Sv { get; set; }
+}
+
+/// <summary>
+/// View model for the "codes generated" modal shown once after backup code generation.
+/// Codes are carried in TempData from GenerateBackupCodes POST → Accounts GET.
+/// </summary>
+public class WorkspaceBackupCodesViewModel
+{
+    public string Email { get; set; } = string.Empty;
+    public List<string> Codes { get; set; } = [];
 }
 
 /// <summary>

--- a/src/Humans.Web/Models/WorkspaceEmailViewModels.cs
+++ b/src/Humans.Web/Models/WorkspaceEmailViewModels.cs
@@ -58,13 +58,26 @@ public class WorkspaceEmailAccountViewModel
 }
 
 /// <summary>
-/// View model for the "codes generated" modal shown once after backup code generation.
-/// Codes are carried in TempData from GenerateBackupCodes POST → Accounts GET.
+/// One-shot recovery credentials shown to the admin in a modal after a
+/// password reset (and optionally a 2FA backup-code grab). Carried in
+/// TempData across the PRG redirect so a refresh after dismissal cannot
+/// re-expose the secret material.
 /// </summary>
-public class WorkspaceBackupCodesViewModel
+public class WorkspaceRecoveryCredentialsViewModel
 {
     public string Email { get; set; } = string.Empty;
-    public List<string> Codes { get; set; } = [];
+
+    /// <summary>
+    /// Freshly generated temporary password for the @nobodies.team account.
+    /// Always populated for both flows (reset-only and reset+2FA).
+    /// </summary>
+    public string TempPassword { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Single backup verification code, populated only when the admin
+    /// requested the combined "Reset + 2FA" flow. Null for password-only.
+    /// </summary>
+    public string? BackupCode { get; set; }
 }
 
 /// <summary>

--- a/src/Humans.Web/Models/WorkspaceEmailViewModels.cs
+++ b/src/Humans.Web/Models/WorkspaceEmailViewModels.cs
@@ -48,6 +48,13 @@ public class WorkspaceEmailAccountViewModel
     /// Unenrolled accounts cannot sign in (2FA is enforced org-wide).
     /// </summary>
     public bool IsEnrolledIn2Sv { get; set; }
+
+    /// <summary>
+    /// Personal recovery email Google has on file. Surfaced as a sanity
+    /// check so the recovery channel can be validated before lockout.
+    /// <c>null</c> when no recovery email is set.
+    /// </summary>
+    public string? RecoveryEmail { get; set; }
 }
 
 /// <summary>

--- a/src/Humans.Web/Views/Google/Accounts.cshtml
+++ b/src/Humans.Web/Views/Google/Accounts.cshtml
@@ -100,7 +100,30 @@
             </div>
         </div>
     </div>
+    <div class="col">
+        <div class="card text-center">
+            <div class="card-body py-2">
+                <h4 class="mb-0 @(Model.MissingTwoFactorCount > 0 ? "text-danger" : "text-success")">@Model.MissingTwoFactorCount</h4>
+                <small class="text-muted">Missing 2FA</small>
+            </div>
+        </div>
+    </div>
 </div>
+
+@if (Model.MissingTwoFactorCount > 0)
+{
+    <div class="alert alert-warning d-flex align-items-center justify-content-between mb-3" role="alert">
+        <div>
+            <i class="fa-solid fa-triangle-exclamation me-2"></i>
+            <strong>@Model.MissingTwoFactorCount</strong> account@(Model.MissingTwoFactorCount == 1 ? "" : "s") missing 2FA setup
+            — these accounts cannot sign in until enrollment is completed.
+        </div>
+        <div class="form-check form-switch mb-0">
+            <input class="form-check-input" type="checkbox" role="switch" id="filter-missing-2fa" />
+            <label class="form-check-label" for="filter-missing-2fa">Show only unenrolled</label>
+        </div>
+    </div>
+}
 
 @* Accounts list *@
 <div class="card">
@@ -114,15 +137,17 @@
         }
         else
         {
-            <table class="table table-hover mb-0">
+            <table class="table table-hover mb-0" id="accounts-table">
                 <thead>
                     <tr>
                         <th>Email</th>
                         <th>Name</th>
                         <th>Linked Human</th>
                         <th>Status</th>
+                        <th>2FA</th>
                         <th>Created</th>
                         <th>Last Login</th>
+                        <th>Backup Codes</th>
                         <th class="text-end">@Localizer["GoogleAccounts_Actions"]</th>
                     </tr>
                 </thead>
@@ -130,7 +155,9 @@
                     @for (var i = 0; i < Model.Accounts.Count; i++)
                     {
                         var account = Model.Accounts[i];
-                        <tr class="@(account.IsSuspended ? "table-secondary" : "")">
+                        <tr class="@(account.IsSuspended ? "table-secondary" : "")"
+                            data-is-enrolled-2sv="@(account.IsEnrolledIn2Sv ? "true" : "false")"
+                            data-is-suspended="@(account.IsSuspended ? "true" : "false")">
                             <td>
                                 <code>@account.PrimaryEmail</code>
                                 @if (account.MatchedUserId.HasValue && !account.IsUsedAsPrimary)
@@ -170,6 +197,20 @@
                                     <span class="badge bg-success">Active</span>
                                 }
                             </td>
+                            <td>
+                                @if (account.IsEnrolledIn2Sv)
+                                {
+                                    <span class="badge bg-success" title="2-Step Verification is enrolled on this account" data-bs-toggle="tooltip">
+                                        <i class="fa-solid fa-shield-halved me-1"></i>2FA ready
+                                    </span>
+                                }
+                                else
+                                {
+                                    <span class="badge bg-danger" title="Account has not completed 2FA enrollment — cannot sign in" data-bs-toggle="tooltip">
+                                        <i class="fa-solid fa-triangle-exclamation me-1"></i>2FA not set up
+                                    </span>
+                                }
+                            </td>
                             <td>@account.CreationTime.ToDisplayDate()</td>
                             <td>
                                 @if (account.LastLoginTime.HasValue)
@@ -180,6 +221,41 @@
                                 {
                                     <span class="text-muted">Never</span>
                                 }
+                            </td>
+                            <td>
+                                <div class="d-flex gap-1">
+                                    @if (account.IsEnrolledIn2Sv)
+                                    {
+                                        <form asp-action="GenerateBackupCodes" method="post" class="d-inline">
+                                            @Html.AntiForgeryToken()
+                                            <input type="hidden" name="email" value="@account.PrimaryEmail" />
+                                            <button type="submit" class="btn btn-outline-primary btn-sm"
+                                                    title="Generate a fresh set of backup verification codes for this account"
+                                                    data-bs-toggle="tooltip"
+                                                    data-confirm="Generate backup codes for @account.PrimaryEmail? This invalidates any previously issued codes.">
+                                                <i class="fa-solid fa-key me-1"></i>Generate
+                                            </button>
+                                        </form>
+                                        <form asp-action="InvalidateBackupCodes" method="post" class="d-inline">
+                                            @Html.AntiForgeryToken()
+                                            <input type="hidden" name="email" value="@account.PrimaryEmail" />
+                                            <button type="submit" class="btn btn-outline-danger btn-sm"
+                                                    title="Invalidate all existing backup codes (no new codes issued)"
+                                                    data-bs-toggle="tooltip"
+                                                    data-confirm="Invalidate all backup codes for @account.PrimaryEmail immediately? Use this if codes may have leaked.">
+                                                <i class="fa-solid fa-ban"></i>
+                                            </button>
+                                        </form>
+                                    }
+                                    else
+                                    {
+                                        <button type="button" class="btn btn-outline-secondary btn-sm" disabled
+                                                title="Backup codes require 2FA enrollment. The human must complete 2FA setup first."
+                                                data-bs-toggle="tooltip">
+                                            <i class="fa-solid fa-key me-1"></i>Generate
+                                        </button>
+                                    }
+                                </div>
                             </td>
                             <td class="text-end">
                                 @if (!account.IsSuspended)
@@ -203,6 +279,57 @@
     </div>
 </div>
 
+@{
+    var backupCodes = ViewBag.GeneratedBackupCodes as WorkspaceBackupCodesViewModel;
+}
+
+@if (backupCodes is not null && backupCodes.Codes.Count > 0)
+{
+    <div class="modal fade" id="backup-codes-modal" tabindex="-1" aria-labelledby="backup-codes-modal-label" aria-hidden="true"
+         data-bs-backdrop="static" data-bs-keyboard="false">
+        <div class="modal-dialog modal-dialog-centered">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="backup-codes-modal-label">
+                        <i class="fa-solid fa-key me-2"></i>Backup Codes for @backupCodes.Email
+                    </h5>
+                </div>
+                <div class="modal-body">
+                    <div class="alert alert-warning mb-3">
+                        <i class="fa-solid fa-triangle-exclamation me-1"></i>
+                        <strong>These codes replace any previously issued codes.</strong>
+                        Deliver them to <code>@backupCodes.Email</code> securely and do not store them —
+                        they cannot be retrieved again after you close this dialog.
+                    </div>
+
+                    <pre id="backup-codes-text" class="bg-light p-3 border rounded mb-3 small">@string.Join("\n", backupCodes.Codes)</pre>
+
+                    <button type="button" class="btn btn-outline-primary btn-sm" id="copy-backup-codes">
+                        <i class="fa-solid fa-copy me-1"></i>Copy all to clipboard
+                    </button>
+                    <span id="copy-backup-codes-feedback" class="text-success ms-2" style="display:none;">
+                        <i class="fa-solid fa-check me-1"></i>Copied
+                    </span>
+
+                    <hr />
+
+                    <div class="form-check">
+                        <input class="form-check-input" type="checkbox" id="ack-delivered" />
+                        <label class="form-check-label" for="ack-delivered">
+                            I've delivered these codes securely to the human
+                        </label>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-primary" id="close-backup-codes" data-bs-dismiss="modal" disabled>
+                        Close
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+}
+
 @section Scripts {
     <script>
         // Sync the _HumanSearchInput hidden value to the form's userId field on submit
@@ -219,5 +346,64 @@
                 }
             });
         });
+
+        // Filter toggle: show only accounts missing 2FA setup (active + unenrolled).
+        (function () {
+            var toggle = document.getElementById('filter-missing-2fa');
+            if (!toggle) return;
+            toggle.addEventListener('change', function () {
+                var onlyUnenrolled = toggle.checked;
+                document.querySelectorAll('#accounts-table tbody tr').forEach(function (row) {
+                    if (!onlyUnenrolled) {
+                        row.style.display = '';
+                        return;
+                    }
+                    var enrolled = row.getAttribute('data-is-enrolled-2sv') === 'true';
+                    var suspended = row.getAttribute('data-is-suspended') === 'true';
+                    // Hide enrolled rows and suspended rows (suspended accounts can't sign in either way)
+                    row.style.display = (!enrolled && !suspended) ? '' : 'none';
+                });
+            });
+        })();
+
+        // Backup codes modal: copy-to-clipboard, acknowledgement gate, and auto-show once.
+        (function () {
+            var modalEl = document.getElementById('backup-codes-modal');
+            if (!modalEl) return;
+
+            // Auto-show on load
+            var modal = new bootstrap.Modal(modalEl);
+            modal.show();
+
+            var ackCheckbox = document.getElementById('ack-delivered');
+            var closeBtn = document.getElementById('close-backup-codes');
+            if (ackCheckbox && closeBtn) {
+                ackCheckbox.addEventListener('change', function () {
+                    closeBtn.disabled = !ackCheckbox.checked;
+                });
+            }
+
+            var copyBtn = document.getElementById('copy-backup-codes');
+            var codesEl = document.getElementById('backup-codes-text');
+            var feedback = document.getElementById('copy-backup-codes-feedback');
+            if (copyBtn && codesEl) {
+                copyBtn.addEventListener('click', function () {
+                    var text = codesEl.textContent || '';
+                    if (navigator.clipboard && navigator.clipboard.writeText) {
+                        navigator.clipboard.writeText(text).then(function () {
+                            if (feedback) {
+                                feedback.style.display = 'inline';
+                                setTimeout(function () { feedback.style.display = 'none'; }, 2000);
+                            }
+                        });
+                    }
+                });
+            }
+
+            // On close, clear the codes from the DOM so browser back/refresh can't re-expose them.
+            modalEl.addEventListener('hidden.bs.modal', function () {
+                if (codesEl) codesEl.textContent = '';
+            });
+        })();
     </script>
 }

--- a/src/Humans.Web/Views/Google/Accounts.cshtml
+++ b/src/Humans.Web/Views/Google/Accounts.cshtml
@@ -148,7 +148,6 @@
                         <th>Recovery Email</th>
                         <th>Created</th>
                         <th>Last Login</th>
-                        <th>Backup Codes</th>
                         <th class="text-end">@Localizer["GoogleAccounts_Actions"]</th>
                     </tr>
                 </thead>
@@ -235,47 +234,31 @@
                                     <span class="text-muted">Never</span>
                                 }
                             </td>
-                            <td>
-                                <div class="d-flex gap-1">
-                                    <form asp-action="GenerateBackupCodes" method="post" class="d-inline">
-                                        @Html.AntiForgeryToken()
-                                        <input type="hidden" name="email" value="@account.PrimaryEmail" />
-                                        <button type="submit" class="btn btn-outline-primary btn-sm"
-                                                title="@(account.IsEnrolledIn2Sv ? "Generate a fresh set of backup verification codes (invalidates any previously issued set)" : "Generate backup codes so the human can complete first sign-in and enroll in 2FA")"
-                                                data-bs-toggle="tooltip"
-                                                data-confirm="@(account.IsEnrolledIn2Sv
-                                                    ? $"Generate backup codes for {account.PrimaryEmail}? This invalidates any previously issued codes."
-                                                    : $"Generate backup codes for {account.PrimaryEmail} to allow first sign-in? Google may reject this for never-enrolled accounts.")">
-                                            <i class="fa-solid fa-key me-1"></i>Generate
-                                        </button>
-                                    </form>
-                                    @if (account.IsEnrolledIn2Sv)
-                                    {
-                                        <form asp-action="InvalidateBackupCodes" method="post" class="d-inline">
-                                            @Html.AntiForgeryToken()
-                                            <input type="hidden" name="email" value="@account.PrimaryEmail" />
-                                            <button type="submit" class="btn btn-outline-danger btn-sm"
-                                                    title="Invalidate all existing backup codes (no new codes issued)"
-                                                    data-bs-toggle="tooltip"
-                                                    data-confirm="Invalidate all backup codes for @account.PrimaryEmail immediately? Use this if codes may have leaked.">
-                                                <i class="fa-solid fa-ban"></i>
-                                            </button>
-                                        </form>
-                                    }
-                                </div>
-                            </td>
                             <td class="text-end">
                                 @if (!account.IsSuspended)
                                 {
-                                    <form asp-action="ResetPassword" method="post" class="d-inline reset-password-form"
-                                          data-email="@account.PrimaryEmail"
-                                          data-confirm="@string.Format(Localizer["GoogleAccounts_ResetPasswordConfirm"].Value, account.PrimaryEmail)">
-                                        @Html.AntiForgeryToken()
-                                        <input type="hidden" name="email" value="@account.PrimaryEmail" />
-                                        <button type="submit" class="btn btn-outline-warning btn-sm">
-                                            <i class="fa-solid fa-key me-1"></i>@Localizer["GoogleAccounts_ResetPassword"]
-                                        </button>
-                                    </form>
+                                    <div class="d-inline-flex gap-1">
+                                        <form asp-action="ResetPassword" method="post" class="d-inline">
+                                            @Html.AntiForgeryToken()
+                                            <input type="hidden" name="email" value="@account.PrimaryEmail" />
+                                            <button type="submit" class="btn btn-outline-warning btn-sm"
+                                                    title="Issue a fresh temporary password — shown once after submit"
+                                                    data-bs-toggle="tooltip"
+                                                    data-confirm="Reset the password for @account.PrimaryEmail? The new temporary password will be shown once.">
+                                                <i class="fa-solid fa-key me-1"></i>@Localizer["GoogleAccounts_ResetPassword"]
+                                            </button>
+                                        </form>
+                                        <form asp-action="ResetPasswordAndGenerate2Fa" method="post" class="d-inline">
+                                            @Html.AntiForgeryToken()
+                                            <input type="hidden" name="email" value="@account.PrimaryEmail" />
+                                            <button type="submit" class="btn btn-outline-danger btn-sm"
+                                                    title="Reset the password AND issue one backup code — for locked-out humans (any 2FA state)"
+                                                    data-bs-toggle="tooltip"
+                                                    data-confirm="Reset password and issue a backup verification code for @account.PrimaryEmail? Both will be shown once.">
+                                                <i class="fa-solid fa-key me-1"></i>Reset + 2FA
+                                            </button>
+                                        </form>
+                                    </div>
                                 }
                             </td>
                         </tr>
@@ -287,34 +270,38 @@
 </div>
 
 @{
-    var backupCodes = ViewBag.GeneratedBackupCodes as WorkspaceBackupCodesViewModel;
+    var recoveryCreds = ViewBag.RecoveryCredentials as WorkspaceRecoveryCredentialsViewModel;
 }
 
-@if (backupCodes is not null && backupCodes.Codes.Count > 0)
+@if (recoveryCreds is not null && !string.IsNullOrEmpty(recoveryCreds.TempPassword))
 {
-    <div class="modal fade" id="backup-codes-modal" tabindex="-1" aria-labelledby="backup-codes-modal-label" aria-hidden="true"
+    var hasBackupCode = !string.IsNullOrEmpty(recoveryCreds.BackupCode);
+    var clipboardText = hasBackupCode
+        ? $"pw: {recoveryCreds.TempPassword}\n2fa: {recoveryCreds.BackupCode}"
+        : $"pw: {recoveryCreds.TempPassword}";
+    <div class="modal fade" id="recovery-credentials-modal" tabindex="-1" aria-labelledby="recovery-credentials-modal-label" aria-hidden="true"
          data-bs-backdrop="static" data-bs-keyboard="false">
         <div class="modal-dialog modal-dialog-centered">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title" id="backup-codes-modal-label">
-                        <i class="fa-solid fa-key me-2"></i>Backup Codes for @backupCodes.Email
+                    <h5 class="modal-title" id="recovery-credentials-modal-label">
+                        <i class="fa-solid fa-key me-2"></i>
+                        @(hasBackupCode ? "Recovery credentials" : "New password") for @recoveryCreds.Email
                     </h5>
                 </div>
                 <div class="modal-body">
                     <div class="alert alert-warning mb-3">
                         <i class="fa-solid fa-triangle-exclamation me-1"></i>
-                        <strong>These codes replace any previously issued codes.</strong>
-                        Deliver them to <code>@backupCodes.Email</code> securely and do not store them —
-                        they cannot be retrieved again after you close this dialog.
+                        <strong>One-shot delivery.</strong>
+                        Hand these to <code>@recoveryCreds.Email</code> securely — they cannot be retrieved again after you close this dialog.
                     </div>
 
-                    <pre id="backup-codes-text" class="bg-light p-3 border rounded mb-3 small">@string.Join("\n", backupCodes.Codes)</pre>
+                    <pre id="recovery-credentials-text" class="bg-light p-3 border rounded mb-3 small">@clipboardText</pre>
 
-                    <button type="button" class="btn btn-outline-primary btn-sm" id="copy-backup-codes">
-                        <i class="fa-solid fa-copy me-1"></i>Copy all to clipboard
+                    <button type="button" class="btn btn-outline-primary btn-sm" id="copy-recovery-credentials">
+                        <i class="fa-solid fa-copy me-1"></i>Copy to clipboard
                     </button>
-                    <span id="copy-backup-codes-feedback" class="text-success ms-2" style="display:none;">
+                    <span id="copy-recovery-credentials-feedback" class="text-success ms-2" style="display:none;">
                         <i class="fa-solid fa-check me-1"></i>Copied
                     </span>
 
@@ -323,12 +310,12 @@
                     <div class="form-check">
                         <input class="form-check-input" type="checkbox" id="ack-delivered" />
                         <label class="form-check-label" for="ack-delivered">
-                            I've delivered these codes securely to the human
+                            I've delivered these credentials securely to the human
                         </label>
                     </div>
                 </div>
                 <div class="modal-footer">
-                    <button type="button" class="btn btn-primary" id="close-backup-codes" data-bs-dismiss="modal" disabled>
+                    <button type="button" class="btn btn-primary" id="close-recovery-credentials" data-bs-dismiss="modal" disabled>
                         Close
                     </button>
                 </div>
@@ -373,9 +360,9 @@
             });
         })();
 
-        // Backup codes modal: copy-to-clipboard, acknowledgement gate, and auto-show once.
+        // Recovery-credentials modal: copy-to-clipboard, acknowledgement gate, and auto-show once.
         (function () {
-            var modalEl = document.getElementById('backup-codes-modal');
+            var modalEl = document.getElementById('recovery-credentials-modal');
             if (!modalEl) return;
 
             // Auto-show on load
@@ -383,19 +370,19 @@
             modal.show();
 
             var ackCheckbox = document.getElementById('ack-delivered');
-            var closeBtn = document.getElementById('close-backup-codes');
+            var closeBtn = document.getElementById('close-recovery-credentials');
             if (ackCheckbox && closeBtn) {
                 ackCheckbox.addEventListener('change', function () {
                     closeBtn.disabled = !ackCheckbox.checked;
                 });
             }
 
-            var copyBtn = document.getElementById('copy-backup-codes');
-            var codesEl = document.getElementById('backup-codes-text');
-            var feedback = document.getElementById('copy-backup-codes-feedback');
-            if (copyBtn && codesEl) {
+            var copyBtn = document.getElementById('copy-recovery-credentials');
+            var credsEl = document.getElementById('recovery-credentials-text');
+            var feedback = document.getElementById('copy-recovery-credentials-feedback');
+            if (copyBtn && credsEl) {
                 copyBtn.addEventListener('click', function () {
-                    var text = codesEl.textContent || '';
+                    var text = credsEl.textContent || '';
                     if (navigator.clipboard && navigator.clipboard.writeText) {
                         navigator.clipboard.writeText(text).then(function () {
                             if (feedback) {
@@ -407,9 +394,9 @@
                 });
             }
 
-            // On close, clear the codes from the DOM so browser back/refresh can't re-expose them.
+            // On close, clear the credentials from the DOM so browser back/refresh can't re-expose them.
             modalEl.addEventListener('hidden.bs.modal', function () {
-                if (codesEl) codesEl.textContent = '';
+                if (credsEl) credsEl.textContent = '';
             });
         })();
     </script>

--- a/src/Humans.Web/Views/Google/Accounts.cshtml
+++ b/src/Humans.Web/Views/Google/Accounts.cshtml
@@ -145,6 +145,7 @@
                         <th>Linked Human</th>
                         <th>Status</th>
                         <th>2FA</th>
+                        <th>Recovery Email</th>
                         <th>Created</th>
                         <th>Last Login</th>
                         <th>Backup Codes</th>
@@ -211,6 +212,18 @@
                                     </span>
                                 }
                             </td>
+                            <td>
+                                @if (!string.IsNullOrWhiteSpace(account.RecoveryEmail))
+                                {
+                                    <code class="small">@account.RecoveryEmail</code>
+                                }
+                                else
+                                {
+                                    <span class="badge bg-warning text-dark" title="No personal recovery email on file — recovery requires admin intervention" data-bs-toggle="tooltip">
+                                        <i class="fa-solid fa-triangle-exclamation me-1"></i>None
+                                    </span>
+                                }
+                            </td>
                             <td>@account.CreationTime.ToDisplayDate()</td>
                             <td>
                                 @if (account.LastLoginTime.HasValue)
@@ -224,18 +237,20 @@
                             </td>
                             <td>
                                 <div class="d-flex gap-1">
+                                    <form asp-action="GenerateBackupCodes" method="post" class="d-inline">
+                                        @Html.AntiForgeryToken()
+                                        <input type="hidden" name="email" value="@account.PrimaryEmail" />
+                                        <button type="submit" class="btn btn-outline-primary btn-sm"
+                                                title="@(account.IsEnrolledIn2Sv ? "Generate a fresh set of backup verification codes (invalidates any previously issued set)" : "Generate backup codes so the human can complete first sign-in and enroll in 2FA")"
+                                                data-bs-toggle="tooltip"
+                                                data-confirm="@(account.IsEnrolledIn2Sv
+                                                    ? $"Generate backup codes for {account.PrimaryEmail}? This invalidates any previously issued codes."
+                                                    : $"Generate backup codes for {account.PrimaryEmail} to allow first sign-in? Google may reject this for never-enrolled accounts.")">
+                                            <i class="fa-solid fa-key me-1"></i>Generate
+                                        </button>
+                                    </form>
                                     @if (account.IsEnrolledIn2Sv)
                                     {
-                                        <form asp-action="GenerateBackupCodes" method="post" class="d-inline">
-                                            @Html.AntiForgeryToken()
-                                            <input type="hidden" name="email" value="@account.PrimaryEmail" />
-                                            <button type="submit" class="btn btn-outline-primary btn-sm"
-                                                    title="Generate a fresh set of backup verification codes for this account"
-                                                    data-bs-toggle="tooltip"
-                                                    data-confirm="Generate backup codes for @account.PrimaryEmail? This invalidates any previously issued codes.">
-                                                <i class="fa-solid fa-key me-1"></i>Generate
-                                            </button>
-                                        </form>
                                         <form asp-action="InvalidateBackupCodes" method="post" class="d-inline">
                                             @Html.AntiForgeryToken()
                                             <input type="hidden" name="email" value="@account.PrimaryEmail" />
@@ -246,14 +261,6 @@
                                                 <i class="fa-solid fa-ban"></i>
                                             </button>
                                         </form>
-                                    }
-                                    else
-                                    {
-                                        <button type="button" class="btn btn-outline-secondary btn-sm" disabled
-                                                title="Backup codes require 2FA enrollment. The human must complete 2FA setup first."
-                                                data-bs-toggle="tooltip">
-                                            <i class="fa-solid fa-key me-1"></i>Generate
-                                        </button>
                                     }
                                 </div>
                             </td>

--- a/src/Humans.Web/Views/Google/Accounts.cshtml
+++ b/src/Humans.Web/Views/Google/Accounts.cshtml
@@ -238,23 +238,23 @@
                                 @if (!account.IsSuspended)
                                 {
                                     <div class="d-inline-flex gap-1">
-                                        <form asp-action="ResetPassword" method="post" class="d-inline">
+                                        <form asp-action="ResetPassword" method="post" class="d-inline"
+                                              data-confirm="Reset the password for @account.PrimaryEmail? The new temporary password will be shown once.">
                                             @Html.AntiForgeryToken()
                                             <input type="hidden" name="email" value="@account.PrimaryEmail" />
                                             <button type="submit" class="btn btn-outline-warning btn-sm"
                                                     title="Issue a fresh temporary password — shown once after submit"
-                                                    data-bs-toggle="tooltip"
-                                                    data-confirm="Reset the password for @account.PrimaryEmail? The new temporary password will be shown once.">
+                                                    data-bs-toggle="tooltip">
                                                 <i class="fa-solid fa-key me-1"></i>@Localizer["GoogleAccounts_ResetPassword"]
                                             </button>
                                         </form>
-                                        <form asp-action="ResetPasswordAndGenerate2Fa" method="post" class="d-inline">
+                                        <form asp-action="ResetPasswordAndGenerate2Fa" method="post" class="d-inline"
+                                              data-confirm="Reset password and issue a backup verification code for @account.PrimaryEmail? Both will be shown once. Any previously-issued backup codes will be invalidated.">
                                             @Html.AntiForgeryToken()
                                             <input type="hidden" name="email" value="@account.PrimaryEmail" />
                                             <button type="submit" class="btn btn-outline-danger btn-sm"
                                                     title="Reset the password AND issue one backup code — for locked-out humans (any 2FA state)"
-                                                    data-bs-toggle="tooltip"
-                                                    data-confirm="Reset password and issue a backup verification code for @account.PrimaryEmail? Both will be shown once.">
+                                                    data-bs-toggle="tooltip">
                                                 <i class="fa-solid fa-key me-1"></i>Reset + 2FA
                                             </button>
                                         </form>

--- a/tests/Humans.Application.Tests/Services/EmailProvisioningServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/EmailProvisioningServiceTests.cs
@@ -237,7 +237,7 @@ public class EmailProvisioningServiceTests
                 Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(new WorkspaceUserAccount(
                 "bob@nobodies.team", "Person", "Test", false,
-                DateTime.UtcNow, null));
+                DateTime.UtcNow, null, IsEnrolledIn2Sv: false));
 
         var result = await f.Service.ProvisionNobodiesEmailAsync(userId, "bob", userId);
 

--- a/tests/Humans.Application.Tests/Services/GoogleAdminServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/GoogleAdminServiceTests.cs
@@ -70,9 +70,9 @@ public class GoogleAdminServiceTests
         _workspaceUserService.ListAccountsAsync(Arg.Any<CancellationToken>())
             .Returns([
                 new WorkspaceUserAccount("alice@nobodies.team", "Alice", "Smith", false,
-                    DateTime.UtcNow, DateTime.UtcNow),
+                    DateTime.UtcNow, DateTime.UtcNow, IsEnrolledIn2Sv: true),
                 new WorkspaceUserAccount("bob@nobodies.team", "Bob", "Jones", true,
-                    DateTime.UtcNow, null),
+                    DateTime.UtcNow, null, IsEnrolledIn2Sv: false),
             ]);
 
         _userEmailService.MatchByEmailsAsync(Arg.Any<IReadOnlyCollection<string>>(), Arg.Any<CancellationToken>())
@@ -119,7 +119,7 @@ public class GoogleAdminServiceTests
         _workspaceUserService.ListAccountsAsync(Arg.Any<CancellationToken>())
             .Returns([
                 new WorkspaceUserAccount("dup@nobodies.team", "Dup", "User", false,
-                    DateTime.UtcNow, null),
+                    DateTime.UtcNow, null, IsEnrolledIn2Sv: false),
             ]);
 
         _userEmailService.MatchByEmailsAsync(Arg.Any<IReadOnlyCollection<string>>(), Arg.Any<CancellationToken>())
@@ -175,7 +175,7 @@ public class GoogleAdminServiceTests
                 Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
                 Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(new WorkspaceUserAccount("test@nobodies.team", "Test", "User", false,
-                DateTime.UtcNow, null));
+                DateTime.UtcNow, null, IsEnrolledIn2Sv: false));
 
         var result = await _service.ProvisionStandaloneAccountAsync(
             "test", "Test", "User", _actorUserId);
@@ -196,7 +196,7 @@ public class GoogleAdminServiceTests
     {
         _workspaceUserService.GetAccountAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(new WorkspaceUserAccount("test@nobodies.team", "Test", "User", false,
-                DateTime.UtcNow, null));
+                DateTime.UtcNow, null, IsEnrolledIn2Sv: false));
 
         var result = await _service.ProvisionStandaloneAccountAsync(
             "test", "Test", "User", _actorUserId);

--- a/tests/Humans.Application.Tests/Services/GoogleAdminServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/GoogleAdminServiceTests.cs
@@ -374,23 +374,24 @@ public class GoogleAdminServiceTests
             .ResetPasswordAsync("test@nobodies.team", Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
-    // --- GenerateBackupCodesAsync ---
+    // --- GenerateBackupCodesAsync (tested via ResetPasswordAndGenerate2FaAsync) ---
 
     [HumansFact]
     public async Task GenerateBackupCodesAsync_ReturnsCodesAndAuditsOnSuccess()
     {
+        // GenerateBackupCodesAsync is private; exercise it through the public combined method.
         IReadOnlyList<string> issued = ["aaaa-1111", "bbbb-2222", "cccc-3333"];
         _workspaceUserService.GenerateBackupCodesAsync(
                 "alice@nobodies.team", Arg.Any<CancellationToken>())
             .Returns(issued);
 
-        var result = await _service.GenerateBackupCodesAsync(
+        var result = await _service.ResetPasswordAndGenerate2FaAsync(
             "alice@nobodies.team", _actorUserId);
 
         result.Success.Should().BeTrue();
         result.Email.Should().Be("alice@nobodies.team");
-        result.Codes.Should().BeEquivalentTo(issued);
-        result.Message.Should().Contain("Generated 3 backup code(s)");
+        // The combined method exposes the first code as BackupCode.
+        result.BackupCode.Should().Be("aaaa-1111");
 
         await _auditLogService.Received(1).LogAsync(
             AuditAction.WorkspaceAccountBackupCodesGenerated,
@@ -409,12 +410,13 @@ public class GoogleAdminServiceTests
                 Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(Array.Empty<string>());
 
-        var result = await _service.GenerateBackupCodesAsync(
+        var result = await _service.ResetPasswordAndGenerate2FaAsync(
             "alice@nobodies.team", _actorUserId);
 
-        result.Success.Should().BeFalse();
-        result.Codes.Should().BeNull();
-        result.ErrorMessage.Should().Contain("none were returned");
+        // Combined method returns Success=true with password-only on backup-code failure.
+        result.Success.Should().BeTrue();
+        result.BackupCode.Should().BeNull();
+        result.Message.Should().Contain("none were returned");
 
         await _auditLogService.DidNotReceive().LogAsync(
             AuditAction.WorkspaceAccountBackupCodesGenerated,
@@ -430,15 +432,16 @@ public class GoogleAdminServiceTests
                 Arg.Any<string>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("Google API error"));
 
-        var result = await _service.GenerateBackupCodesAsync(
+        var result = await _service.ResetPasswordAndGenerate2FaAsync(
             "alice@nobodies.team", _actorUserId);
 
-        result.Success.Should().BeFalse();
-        result.Codes.Should().BeNull();
-        result.ErrorMessage.Should().Contain("Failed to generate backup codes");
+        // Combined method surfaces backup-code failure as Success=true, BackupCode=null.
+        result.Success.Should().BeTrue();
+        result.BackupCode.Should().BeNull();
+        result.Message.Should().Contain("Backup-code generation failed");
 
         await _auditLogService.DidNotReceive().LogAsync(
-            Arg.Any<AuditAction>(),
+            AuditAction.WorkspaceAccountBackupCodesGenerated,
             Arg.Any<string>(), Arg.Any<Guid>(),
             Arg.Any<string>(), Arg.Any<Guid>(),
             Arg.Any<Guid?>(), Arg.Any<string?>());
@@ -448,24 +451,26 @@ public class GoogleAdminServiceTests
     public async Task GenerateBackupCodesAsync_ReturnsCodesEvenWhenAuditWriteFails()
     {
         // Google has already invalidated the previously-issued set, so dropping
-        // the new codes locks the human out. The audit failure is logged loudly
-        // but the codes must still flow back to the admin.
+        // the new codes locks the human out. The audit failure for backup-code
+        // generation is logged loudly but the code must still flow back to the admin.
         IReadOnlyList<string> issued = ["aaaa-1111", "bbbb-2222"];
         _workspaceUserService.GenerateBackupCodesAsync(
                 Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(issued);
+        // Only fail the backup-codes audit; let the password-reset audit succeed
+        // so the combined method reaches the backup-code path.
         _auditLogService.LogAsync(
-                Arg.Any<AuditAction>(),
+                AuditAction.WorkspaceAccountBackupCodesGenerated,
                 Arg.Any<string>(), Arg.Any<Guid>(),
                 Arg.Any<string>(), Arg.Any<Guid>(),
                 Arg.Any<Guid?>(), Arg.Any<string?>())
             .ThrowsAsync(new InvalidOperationException("Audit DB unavailable"));
 
-        var result = await _service.GenerateBackupCodesAsync(
+        var result = await _service.ResetPasswordAndGenerate2FaAsync(
             "alice@nobodies.team", _actorUserId);
 
         result.Success.Should().BeTrue();
-        result.Codes.Should().BeEquivalentTo(issued);
+        result.BackupCode.Should().Be("aaaa-1111");
     }
 
     // --- ResetPasswordAndGenerate2FaAsync ---

--- a/tests/Humans.Application.Tests/Services/GoogleAdminServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/GoogleAdminServiceTests.cs
@@ -468,39 +468,78 @@ public class GoogleAdminServiceTests
         result.Codes.Should().BeEquivalentTo(issued);
     }
 
-    // --- InvalidateBackupCodesAsync ---
+    // --- ResetPasswordAndGenerate2FaAsync ---
 
     [HumansFact]
-    public async Task InvalidateBackupCodesAsync_InvalidatesAndAudits()
+    public async Task ResetPasswordAndGenerate2FaAsync_ReturnsBothCredentialsOnSuccess()
     {
-        var result = await _service.InvalidateBackupCodesAsync(
+        IReadOnlyList<string> issued = ["aaaa-1111", "bbbb-2222", "cccc-3333"];
+        _workspaceUserService.GenerateBackupCodesAsync(
+                "alice@nobodies.team", Arg.Any<CancellationToken>())
+            .Returns(issued);
+
+        var result = await _service.ResetPasswordAndGenerate2FaAsync(
             "alice@nobodies.team", _actorUserId);
 
         result.Success.Should().BeTrue();
-        result.Message.Should().Contain("invalidated");
+        result.Email.Should().Be("alice@nobodies.team");
+        result.TempPassword.Should().NotBeNullOrEmpty();
+        // The recovery flow uses one code, not the full set.
+        result.BackupCode.Should().Be("aaaa-1111");
 
-        await _workspaceUserService.Received(1)
-            .InvalidateBackupCodesAsync("alice@nobodies.team", Arg.Any<CancellationToken>());
+        await _workspaceUserService.Received(1).ResetPasswordAsync(
+            "alice@nobodies.team", Arg.Any<string>(), Arg.Any<CancellationToken>());
+
+        // Two audit entries — one for the password reset, one for the codes generation.
         await _auditLogService.Received(1).LogAsync(
-            AuditAction.WorkspaceAccountBackupCodesInvalidated,
+            AuditAction.WorkspaceAccountPasswordReset,
             "WorkspaceAccount", Guid.Empty,
-            Arg.Is<string>(s => s.Contains("alice@nobodies.team")),
-            _actorUserId,
+            Arg.Any<string>(), _actorUserId,
+            Arg.Any<Guid?>(), Arg.Any<string?>());
+        await _auditLogService.Received(1).LogAsync(
+            AuditAction.WorkspaceAccountBackupCodesGenerated,
+            "WorkspaceAccount", Guid.Empty,
+            Arg.Any<string>(), _actorUserId,
             Arg.Any<Guid?>(), Arg.Any<string?>());
     }
 
     [HumansFact]
-    public async Task InvalidateBackupCodesAsync_ReturnsErrorOnFailure()
+    public async Task ResetPasswordAndGenerate2FaAsync_ReturnsFailureWhenPasswordResetFails()
     {
-        _workspaceUserService.InvalidateBackupCodesAsync(
-                Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .ThrowsAsync(new InvalidOperationException("API error"));
+        _workspaceUserService.ResetPasswordAsync(
+                Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("Google API error"));
 
-        var result = await _service.InvalidateBackupCodesAsync(
+        var result = await _service.ResetPasswordAndGenerate2FaAsync(
             "alice@nobodies.team", _actorUserId);
 
         result.Success.Should().BeFalse();
-        result.ErrorMessage.Should().Contain("Failed to invalidate");
+        result.TempPassword.Should().BeNull();
+        result.BackupCode.Should().BeNull();
+        result.ErrorMessage.Should().Contain("Failed to reset password");
+
+        // Backup-code generation must NOT be attempted when password reset failed.
+        await _workspaceUserService.DidNotReceive().GenerateBackupCodesAsync(
+            Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task ResetPasswordAndGenerate2FaAsync_ReturnsPasswordOnlyWhenBackupCodesFail()
+    {
+        // Password reset succeeds, but Google rejects the backup-code request.
+        // The admin still gets the password — partial success is more useful
+        // than asking them to retry from scratch (Google has already rotated).
+        _workspaceUserService.GenerateBackupCodesAsync(
+                Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("Google API error"));
+
+        var result = await _service.ResetPasswordAndGenerate2FaAsync(
+            "alice@nobodies.team", _actorUserId);
+
+        result.Success.Should().BeTrue();
+        result.TempPassword.Should().NotBeNullOrEmpty();
+        result.BackupCode.Should().BeNull();
+        result.Message.Should().Contain("Backup-code generation failed");
     }
 
     // --- LinkAccountAsync ---

--- a/tests/Humans.Application.Tests/Services/GoogleAdminServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/GoogleAdminServiceTests.cs
@@ -70,9 +70,11 @@ public class GoogleAdminServiceTests
         _workspaceUserService.ListAccountsAsync(Arg.Any<CancellationToken>())
             .Returns([
                 new WorkspaceUserAccount("alice@nobodies.team", "Alice", "Smith", false,
-                    DateTime.UtcNow, DateTime.UtcNow, IsEnrolledIn2Sv: true),
+                    DateTime.UtcNow, DateTime.UtcNow, IsEnrolledIn2Sv: true,
+                    RecoveryEmail: "alice.personal@example.com"),
                 new WorkspaceUserAccount("bob@nobodies.team", "Bob", "Jones", true,
-                    DateTime.UtcNow, null, IsEnrolledIn2Sv: false),
+                    DateTime.UtcNow, null, IsEnrolledIn2Sv: false,
+                    RecoveryEmail: null),
             ]);
 
         _userEmailService.MatchByEmailsAsync(Arg.Any<IReadOnlyCollection<string>>(), Arg.Any<CancellationToken>())
@@ -107,6 +109,11 @@ public class GoogleAdminServiceTests
             string.Equals(a.PrimaryEmail, "alice@nobodies.team", StringComparison.OrdinalIgnoreCase));
         alice.MatchedUserId.Should().Be(userId);
         alice.IsUsedAsPrimary.Should().BeTrue();
+        alice.RecoveryEmail.Should().Be("alice.personal@example.com");
+
+        var bob = result.Accounts.Single(a =>
+            string.Equals(a.PrimaryEmail, "bob@nobodies.team", StringComparison.OrdinalIgnoreCase));
+        bob.RecoveryEmail.Should().BeNull();
     }
 
     [HumansFact]

--- a/tests/Humans.Application.Tests/Services/GoogleAdminServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/GoogleAdminServiceTests.cs
@@ -98,12 +98,33 @@ public class GoogleAdminServiceTests
         result.SuspendedAccounts.Should().Be(1);
         result.LinkedAccounts.Should().Be(1);
         result.UnlinkedAccounts.Should().Be(1);
+        // Bob is unenrolled but suspended — suspended accounts are excluded
+        // from the missing-2FA count by design (they can't sign in anyway).
+        result.MissingTwoFactorCount.Should().Be(0);
         result.ErrorMessage.Should().BeNull();
 
         var alice = result.Accounts.Single(a =>
             string.Equals(a.PrimaryEmail, "alice@nobodies.team", StringComparison.OrdinalIgnoreCase));
         alice.MatchedUserId.Should().Be(userId);
         alice.IsUsedAsPrimary.Should().BeTrue();
+    }
+
+    [HumansFact]
+    public async Task GetWorkspaceAccountListAsync_CountsActiveUnenrolledTowardMissingTwoFactor()
+    {
+        _workspaceUserService.ListAccountsAsync(Arg.Any<CancellationToken>())
+            .Returns([
+                new WorkspaceUserAccount("alice@nobodies.team", "Alice", "Smith", false,
+                    DateTime.UtcNow, DateTime.UtcNow, IsEnrolledIn2Sv: true),
+                new WorkspaceUserAccount("carol@nobodies.team", "Carol", "Doe", false,
+                    DateTime.UtcNow, null, IsEnrolledIn2Sv: false),
+                new WorkspaceUserAccount("bob@nobodies.team", "Bob", "Jones", true,
+                    DateTime.UtcNow, null, IsEnrolledIn2Sv: false),
+            ]);
+
+        var result = await _service.GetWorkspaceAccountListAsync();
+
+        result.MissingTwoFactorCount.Should().Be(1);
     }
 
     [HumansFact]
@@ -344,6 +365,135 @@ public class GoogleAdminServiceTests
 
         await _workspaceUserService.Received(1)
             .ResetPasswordAsync("test@nobodies.team", Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    // --- GenerateBackupCodesAsync ---
+
+    [HumansFact]
+    public async Task GenerateBackupCodesAsync_ReturnsCodesAndAuditsOnSuccess()
+    {
+        IReadOnlyList<string> issued = ["aaaa-1111", "bbbb-2222", "cccc-3333"];
+        _workspaceUserService.GenerateBackupCodesAsync(
+                "alice@nobodies.team", Arg.Any<CancellationToken>())
+            .Returns(issued);
+
+        var result = await _service.GenerateBackupCodesAsync(
+            "alice@nobodies.team", _actorUserId);
+
+        result.Success.Should().BeTrue();
+        result.Email.Should().Be("alice@nobodies.team");
+        result.Codes.Should().BeEquivalentTo(issued);
+        result.Message.Should().Contain("Generated 3 backup code(s)");
+
+        await _auditLogService.Received(1).LogAsync(
+            AuditAction.WorkspaceAccountBackupCodesGenerated,
+            "WorkspaceAccount", Guid.Empty,
+            Arg.Is<string>(s => s.Contains("alice@nobodies.team") && s.Contains("3 backup code")),
+            _actorUserId,
+            Arg.Any<Guid?>(), Arg.Any<string?>());
+    }
+
+    [HumansFact]
+    public async Task GenerateBackupCodesAsync_ReturnsFailureAndDoesNotAuditOnEmptyList()
+    {
+        // Generate succeeded on Google's side but List returned 0 — we
+        // must not write a misleading "generated 0 codes" audit entry.
+        _workspaceUserService.GenerateBackupCodesAsync(
+                Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<string>());
+
+        var result = await _service.GenerateBackupCodesAsync(
+            "alice@nobodies.team", _actorUserId);
+
+        result.Success.Should().BeFalse();
+        result.Codes.Should().BeNull();
+        result.ErrorMessage.Should().Contain("none were returned");
+
+        await _auditLogService.DidNotReceive().LogAsync(
+            AuditAction.WorkspaceAccountBackupCodesGenerated,
+            Arg.Any<string>(), Arg.Any<Guid>(),
+            Arg.Any<string>(), Arg.Any<Guid>(),
+            Arg.Any<Guid?>(), Arg.Any<string?>());
+    }
+
+    [HumansFact]
+    public async Task GenerateBackupCodesAsync_ReturnsErrorOnWorkspaceFailure()
+    {
+        _workspaceUserService.GenerateBackupCodesAsync(
+                Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("Google API error"));
+
+        var result = await _service.GenerateBackupCodesAsync(
+            "alice@nobodies.team", _actorUserId);
+
+        result.Success.Should().BeFalse();
+        result.Codes.Should().BeNull();
+        result.ErrorMessage.Should().Contain("Failed to generate backup codes");
+
+        await _auditLogService.DidNotReceive().LogAsync(
+            Arg.Any<AuditAction>(),
+            Arg.Any<string>(), Arg.Any<Guid>(),
+            Arg.Any<string>(), Arg.Any<Guid>(),
+            Arg.Any<Guid?>(), Arg.Any<string?>());
+    }
+
+    [HumansFact]
+    public async Task GenerateBackupCodesAsync_ReturnsCodesEvenWhenAuditWriteFails()
+    {
+        // Google has already invalidated the previously-issued set, so dropping
+        // the new codes locks the human out. The audit failure is logged loudly
+        // but the codes must still flow back to the admin.
+        IReadOnlyList<string> issued = ["aaaa-1111", "bbbb-2222"];
+        _workspaceUserService.GenerateBackupCodesAsync(
+                Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(issued);
+        _auditLogService.LogAsync(
+                Arg.Any<AuditAction>(),
+                Arg.Any<string>(), Arg.Any<Guid>(),
+                Arg.Any<string>(), Arg.Any<Guid>(),
+                Arg.Any<Guid?>(), Arg.Any<string?>())
+            .ThrowsAsync(new InvalidOperationException("Audit DB unavailable"));
+
+        var result = await _service.GenerateBackupCodesAsync(
+            "alice@nobodies.team", _actorUserId);
+
+        result.Success.Should().BeTrue();
+        result.Codes.Should().BeEquivalentTo(issued);
+    }
+
+    // --- InvalidateBackupCodesAsync ---
+
+    [HumansFact]
+    public async Task InvalidateBackupCodesAsync_InvalidatesAndAudits()
+    {
+        var result = await _service.InvalidateBackupCodesAsync(
+            "alice@nobodies.team", _actorUserId);
+
+        result.Success.Should().BeTrue();
+        result.Message.Should().Contain("invalidated");
+
+        await _workspaceUserService.Received(1)
+            .InvalidateBackupCodesAsync("alice@nobodies.team", Arg.Any<CancellationToken>());
+        await _auditLogService.Received(1).LogAsync(
+            AuditAction.WorkspaceAccountBackupCodesInvalidated,
+            "WorkspaceAccount", Guid.Empty,
+            Arg.Is<string>(s => s.Contains("alice@nobodies.team")),
+            _actorUserId,
+            Arg.Any<Guid?>(), Arg.Any<string?>());
+    }
+
+    [HumansFact]
+    public async Task InvalidateBackupCodesAsync_ReturnsErrorOnFailure()
+    {
+        _workspaceUserService.InvalidateBackupCodesAsync(
+                Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("API error"));
+
+        var result = await _service.InvalidateBackupCodesAsync(
+            "alice@nobodies.team", _actorUserId);
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("Failed to invalidate");
     }
 
     // --- LinkAccountAsync ---

--- a/tests/Humans.Application.Tests/Services/GoogleWorkspaceUserServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/GoogleWorkspaceUserServiceTests.cs
@@ -32,7 +32,7 @@ public class GoogleWorkspaceUserServiceTests
     {
         IReadOnlyList<WorkspaceUserAccount> expected =
         [
-            new("a@nobodies.team", "A", "Alpha", false, DateTime.UtcNow, null)
+            new("a@nobodies.team", "A", "Alpha", false, DateTime.UtcNow, null, IsEnrolledIn2Sv: false)
         ];
         _client.ListAccountsAsync(Arg.Any<CancellationToken>()).Returns(expected);
 
@@ -57,7 +57,7 @@ public class GoogleWorkspaceUserServiceTests
     public async Task ProvisionAccountAsync_ForwardsAllArguments()
     {
         var expected = new WorkspaceUserAccount(
-            "new@nobodies.team", "New", "User", false, DateTime.UtcNow, null);
+            "new@nobodies.team", "New", "User", false, DateTime.UtcNow, null, IsEnrolledIn2Sv: false);
         _client.ProvisionAccountAsync(
                 "new@nobodies.team", "New", "User", "TempP@ss", "recover@example.com",
                 Arg.Any<CancellationToken>())


### PR DESCRIPTION
Closes nobodies-collective/Humans#519

## Summary

`/Google/Accounts` admin page gains the recovery surface that lets admins unblock locked-out @nobodies.team humans without leaving Humans.

**Visibility on every row:**
- 2-Step Verification chip — green "2FA ready" or red "2FA not set up" — backed by Directory API `isEnrolledIn2Sv`
- Recovery email column (yellow "None" badge when unset) — backed by Directory API `recoveryEmail`
- Top-of-page "Missing 2FA" counter + alert banner + filter toggle for the active-unenrolled set (suspended accounts excluded — they can't sign in either way)

**Two recovery actions:**
- **Reset Password** — issues a fresh temp password, surfaces it once in a modal with copy-to-clipboard formatted `pw: <password>` and an "I've delivered these securely" gate
- **Reset + 2FA** — composes password-reset + a single backup verification code in one click. Confirmed working for unenrolled accounts in production. Clipboard format:
  ```
  pw: <temp password>
  2fa: <single backup code>
  ```

The old standalone "Generate / Invalidate backup codes" buttons (and the Backup Codes column) are gone — operationally we only ever needed one code at a time, and the admin always wants the password alongside it.

## Notes

- **Localization:** Per the repo's coding rule (`admin pages do not require localization`), new UI copy is in English only — consistent with the rest of `/Google/Accounts`.
- The stub directory client returns deterministic placeholder credentials so the modal flow is testable locally without Google credentials.
- No new DB migrations. `WorkspaceAccountBackupCodesInvalidated` is left in the audit enum (marked unused) so existing audit-log values don't shift.
- New scope: `admin.directory.user.security` — required by `verificationCodes.generate/list`.

## Test plan

- [ ] `/Google/Accounts` as Admin: 2FA chip visible per row, Recovery Email column populated (or "None" badge), summary counter matches active+unenrolled count, filter toggle narrows the list
- [ ] **Reset Password** on an active account: confirm dialog → modal opens with `pw: <generated>`, copy-to-clipboard works, Close gated on the acknowledgement checkbox, password clears from DOM after closing, single audit entry recorded
- [ ] **Reset + 2FA** on an enrolled account: confirm dialog → modal opens with both `pw:` and `2fa:` lines, copy-to-clipboard puts both into the clipboard, two audit entries recorded
- [ ] **Reset + 2FA** on an unenrolled account: same flow as above, codes are usable for first sign-in
- [ ] Reset / Reset + 2FA buttons hidden for suspended accounts
- [ ] Non-Admin cannot reach either POST endpoint (policy-gated)