### PR TITLE
Stop rendering Google avatars; add "Import my Google photo" button

### DIFF
--- a/docs/features/14-profile-pictures-birthdays.md
+++ b/docs/features/14-profile-pictures-birthdays.md
@@ -2,24 +2,24 @@
 
 ## Business Context
 
-Members need a way to personalize their profiles beyond the Google OAuth avatar. Custom profile pictures make team pages more personal and help members recognize each other. The birthday calendar fosters community by letting members see upcoming birthdays within the organization.
+Humans need a way to personalize their profiles. Custom profile pictures make team pages more personal and help humans recognize each other. The birthday calendar fosters community by letting humans see upcoming birthdays within the organization. Google OAuth avatars are no longer rendered anywhere in the UI — they are only used as a one-time seed when a human chooses to import their Google photo as a custom picture (see US-14.5).
 
 ## User Stories
 
 ### US-14.1: Upload Profile Picture
-**As a** member
+**As a** human
 **I want to** upload a custom profile picture
-**So that** I can personalize my profile beyond my Google avatar
+**So that** I can personalize my profile
 
 **Acceptance Criteria:**
-- Can upload JPEG, PNG, or WebP images (max 2MB)
-- Custom picture takes precedence over Google OAuth avatar
-- Can remove custom picture to revert to Google avatar
+- Can upload JPEG, PNG, WebP, or HEIC images (max 20MB; large images are auto-resized)
+- The custom picture is rendered everywhere a profile picture is shown
+- Can remove the custom picture; profile then falls back to the initial-letter placeholder
 - Picture is shown on profile page, team detail pages, and birthday calendar
 - Picture served via dedicated endpoint with 1-hour cache
 
 ### US-14.2: View Team Photo Gallery
-**As a** member
+**As a** human
 **I want to** see profile pictures of all team members on the team detail page
 **So that** I can put faces to names
 
@@ -27,8 +27,8 @@ Members need a way to personalize their profiles beyond the Google OAuth avatar.
 - Team detail page shows members in a grid layout with profile pictures
 - Leads shown first with larger photos (80x80) and primary border
 - Regular members shown with standard photos (64x64)
-- Placeholder initials shown for members without pictures
-- Both custom and Google avatar pictures are displayed
+- Placeholder initials shown for members without a custom picture
+- Only custom uploaded pictures are rendered (Google avatars are never shown directly)
 
 ### US-14.3: Set Date of Birth
 **As a** member
@@ -43,17 +43,31 @@ Members need a way to personalize their profiles beyond the Google OAuth avatar.
 - Field is optional
 
 ### US-14.4: View Birthday Calendar
-**As a** member
+**As a** human
 **I want to** see upcoming birthdays by month
 **So that** I can celebrate with my teammates
 
 **Acceptance Criteria:**
 - Monthly view with navigation between months
 - Shows profile picture, display name, day of month, and team memberships
-- Only shows members who have set their date of birth
+- Only shows humans who have set their birthday
 - Accessible from Teams index page
 - Privacy note explaining visibility rules
 - System teams excluded from team name display
+
+### US-14.5: Import Google Photo as Profile Picture
+**As a** human signed in via Google
+**I want to** copy my Google account photo as my profile picture with one click
+**So that** I don't have to download and re-upload it manually
+
+**Acceptance Criteria:**
+- "Import my Google photo" button is shown on the profile edit page only when:
+  - The human signed in with Google and an avatar URL was captured at sign-in
+  - The human does not already have a custom profile picture
+- Clicking the button server-side fetches the Google avatar, resizes it, and stores it as the custom profile picture
+- The fetch is restricted to `https://*.googleusercontent.com` (SSRF guard); any other host is refused with an error message
+- After import, the photo is treated like any uploaded picture and can be removed/replaced normally
+- Errors (network, format, size, untrusted host) surface as friendly TempData error messages and never throw to the user
 
 ## Data Model
 
@@ -79,6 +93,7 @@ Profile pictures are stored as `bytea` in PostgreSQL. This is appropriate for th
 | Route | Method | Description |
 |-------|--------|-------------|
 | `GET /Profile/Picture/{id}` | GET | Serve profile picture (anonymous, cached 1hr) |
+| `POST /Profile/Me/ImportGooglePhoto` | POST | Import the signed-in user's Google avatar as their custom picture (anti-forgery; SSRF-guarded to `*.googleusercontent.com`) |
 | `GET /Teams/Birthdays` | GET | Birthday calendar (current month) |
 | `GET /Teams/Birthdays?month=N` | GET | Birthday calendar for specific month |
 
@@ -110,12 +125,14 @@ Profile pictures are stored as `bytea` in PostgreSQL. This is appropriate for th
 
 ## Picture Priority
 
-Custom uploaded picture always takes precedence over Google OAuth avatar. This is implemented via the `EffectiveProfilePictureUrl` computed property on both `ProfileViewModel` and `TeamMemberViewModel`:
+Only the custom uploaded picture is rendered in the UI. Google OAuth avatar URLs are never displayed directly — humans without a custom picture get the initial-letter placeholder. The Google avatar URL is retained on the User entity solely as the source for the optional one-click import flow (US-14.5).
+
+This is implemented via the `EffectiveProfilePictureUrl` computed property on both `ProfileViewModel` and `TeamMemberViewModel`:
 
 ```
 EffectiveProfilePictureUrl = HasCustomProfilePicture
     ? CustomProfilePictureUrl   (→ /Profile/Picture/{id})
-    : ProfilePictureUrl         (→ Google avatar URL)
+    : null                       (→ initial-letter placeholder)
 ```
 
 ## Privacy Model
@@ -128,13 +145,27 @@ EffectiveProfilePictureUrl = HasCustomProfilePicture
 
 ## Localization
 
-All UI strings are localized in 5 languages: EN, ES, DE, FR, IT. Keys include:
+All UI strings are localized in 6 languages: EN, ES, CA, DE, FR, IT. Keys include:
 - `Profile_ProfilePicture`, `Profile_DateOfBirth`
 - `Profile_PictureTooLarge`, `Profile_PictureInvalidFormat`
-- `ProfileEdit_GoogleAvatar`, `ProfileEdit_PictureHelp`, `ProfileEdit_RemovePicture`
+- `ProfileEdit_PictureHelp`, `ProfileEdit_RemovePicture`
 - `ProfileEdit_DateOfBirthHelp`
 - `TeamDetail_TeamLeads`
 - `Birthdays_Title`, `Birthdays_Count`, `Birthdays_None`, `Birthdays_Privacy`
+
+### Import-Google-photo flow (US-14.5)
+
+| Key | Where | Purpose |
+|-----|-------|---------|
+| `ProfileEdit_ImportGooglePhoto` | Edit page | Button label |
+| `ProfileEdit_ImportGooglePhotoHelp` | Edit page | Help text under the button |
+| `Profile_ImportGooglePhoto_Success` | TempData | Import succeeded |
+| `Profile_ImportGooglePhoto_Unavailable` | TempData | No Google login or no captured avatar |
+| `Profile_ImportGooglePhoto_NoProfile` | TempData | Profile not yet provisioned |
+| `Profile_ImportGooglePhoto_AlreadyHasCustom` | TempData | Already has a custom picture |
+| `Profile_ImportGooglePhoto_FetchFailed` | TempData | Network / HTTP / timeout failure |
+| `Profile_ImportGooglePhoto_InvalidFormat` | TempData | Unsupported content type or unprocessable bytes |
+| `Profile_ImportGooglePhoto_NotGoogleUrl` | TempData | SSRF guard: stored URL is not on `*.googleusercontent.com` |
 
 ## Related Features
 

--- a/src/Humans.Application/Interfaces/Profiles/IProfileService.cs
+++ b/src/Humans.Application/Interfaces/Profiles/IProfileService.cs
@@ -46,6 +46,15 @@ public interface IProfileService
     Task<(Profile? Profile, bool IsTierLocked, MemberApplication? PendingApplication)>
         GetProfileEditDataAsync(Guid userId, CancellationToken ct = default);
     Task<(byte[]? Data, string? ContentType)> GetProfilePictureAsync(Guid profileId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Persists a new custom profile picture for the user's profile. No-op (logs a
+    /// warning) if the user has no profile yet. Invalidates the FullProfile cache
+    /// entry via the caching decorator. Callers are responsible for validating and
+    /// resizing the image before calling.
+    /// </summary>
+    Task SetProfilePictureAsync(Guid userId, byte[] pictureData, string contentType, CancellationToken ct = default);
+
     Task<Guid> SaveProfileAsync(Guid userId, string displayName, ProfileSaveRequest request, string language, CancellationToken ct = default);
     Task<OnboardingResult> RequestDeletionAsync(Guid userId, CancellationToken ct = default);
     Task<OnboardingResult> CancelDeletionAsync(Guid userId, CancellationToken ct = default);

--- a/src/Humans.Application/Services/Profile/ProfileService.cs
+++ b/src/Humans.Application/Services/Profile/ProfileService.cs
@@ -129,6 +129,34 @@ public sealed class ProfileService : IProfileService, IUserDataContributor
         // Store update handled by CachingProfileService decorator
     }
 
+    public async Task SetProfilePictureAsync(
+        Guid userId, byte[] pictureData, string contentType, CancellationToken ct = default)
+    {
+        if (pictureData.Length == 0)
+        {
+            throw new ArgumentException("Picture data must not be empty", nameof(pictureData));
+        }
+        if (string.IsNullOrWhiteSpace(contentType))
+        {
+            throw new ArgumentException("Content type must not be empty", nameof(contentType));
+        }
+
+        var profile = await _profileRepository.GetByUserIdAsync(userId, ct);
+        if (profile is null)
+        {
+            _logger.LogWarning(
+                "Cannot set profile picture for user {UserId} — no profile exists", userId);
+            return;
+        }
+
+        profile.ProfilePictureData = pictureData;
+        profile.ProfilePictureContentType = contentType;
+        profile.UpdatedAt = _clock.GetCurrentInstant();
+        await _profileRepository.UpdateAsync(profile, ct);
+
+        // FullProfile cache invalidation handled by CachingProfileService decorator.
+    }
+
     public async Task<(Domain.Entities.Profile? Profile, MemberApplication? LatestApplication, int PendingConsentCount)>
         GetProfileIndexDataAsync(Guid userId, CancellationToken ct = default)
     {

--- a/src/Humans.Infrastructure/Services/Profiles/CachingProfileService.cs
+++ b/src/Humans.Infrastructure/Services/Profiles/CachingProfileService.cs
@@ -389,6 +389,15 @@ public sealed class CachingProfileService : IProfileService, IFullProfileInvalid
         await RefreshEntryAsync(userId, ct);
     }
 
+    public async Task SetProfilePictureAsync(
+        Guid userId, byte[] pictureData, string contentType, CancellationToken ct = default)
+    {
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        var inner = scope.ServiceProvider.GetRequiredKeyedService<IProfileService>(InnerServiceKey);
+        await inner.SetProfilePictureAsync(userId, pictureData, contentType, ct);
+        await RefreshEntryAsync(userId, ct);
+    }
+
     public async Task<Guid> SaveProfileAsync(
         Guid userId, string displayName, ProfileSaveRequest request, string language,
         CancellationToken ct = default)

--- a/src/Humans.Web/Controllers/AboutController.cs
+++ b/src/Humans.Web/Controllers/AboutController.cs
@@ -56,10 +56,10 @@ public class AboutController : HumansControllerBase
             var (assignments, _) = await _roleAssignmentService.GetFilteredAsync(
                 roleFilter: null, activeOnly: true, page: 1, pageSize: 500, now);
 
-            // Resolve effective profile picture URLs (custom uploads take priority over Google avatars)
+            // Resolve effective profile picture URLs (custom uploads only — see issue #532).
             var effectiveUrls = await ProfilePictureUrlHelper.BuildEffectiveUrlsAsync(
                 _profileService, Url,
-                assignments.Select(ra => (ra.UserId, ra.User.ProfilePictureUrl)));
+                assignments.Select(ra => ra.UserId));
 
             // Define role display order and metadata
             var roleDefinitions = StaffViewModel.GetRoleDefinitions();

--- a/src/Humans.Web/Controllers/AccountController.cs
+++ b/src/Humans.Web/Controllers/AccountController.cs
@@ -67,6 +67,19 @@ public class AccountController : Controller
             return RedirectToAction(nameof(Login), new { returnUrl, error = "oauth" });
         }
 
+        // Log once per sign-in whether the Google avatar URL was provided. We capture the
+        // URL on User.ProfilePictureUrl but never render it — see issue #532 and the
+        // "Import my Google photo" button on /Profile/Edit.
+        var googlePictureClaim = info.Principal.FindFirstValue("urn:google:picture");
+        if (!string.IsNullOrEmpty(googlePictureClaim))
+        {
+            _logger.LogInformation("Google avatar URL captured for {Provider} sign-in", info.LoginProvider);
+        }
+        else
+        {
+            _logger.LogInformation("Google avatar URL not captured for {Provider} sign-in (claim missing)", info.LoginProvider);
+        }
+
         // Sign in the user with this external login provider if the user already has a login
         var result = await _signInManager.ExternalLoginSignInAsync(
             info.LoginProvider,

--- a/src/Humans.Web/Controllers/ProfileController.cs
+++ b/src/Humans.Web/Controllers/ProfileController.cs
@@ -1060,12 +1060,26 @@ public class ProfileController : HumansControllerBase
             return RedirectToAction(nameof(Edit));
         }
 
+        // SSRF guard: only fetch from Google's avatar host. The URL came from a
+        // Google OAuth claim, but we don't trust the stored value blindly — refuse
+        // anything that isn't HTTPS and on a *.googleusercontent.com host.
+        if (!Uri.TryCreate(user.ProfilePictureUrl, UriKind.Absolute, out var pictureUri)
+            || !string.Equals(pictureUri.Scheme, Uri.UriSchemeHttps
+, StringComparison.Ordinal) || !pictureUri.Host.EndsWith(".googleusercontent.com", StringComparison.OrdinalIgnoreCase))
+        {
+            _logger.LogWarning(
+                "Refusing to import Google photo for user {UserId}: URL is not a trusted Google host",
+                user.Id);
+            SetError(_localizer["Profile_ImportGooglePhoto_NotGoogleUrl"].Value);
+            return RedirectToAction(nameof(Edit));
+        }
+
         byte[] rawBytes;
         string fetchedContentType;
         try
         {
             var httpClient = _httpClientFactory.CreateClient(GoogleAvatarHttpClientName);
-            using var response = await httpClient.GetAsync(user.ProfilePictureUrl, ct);
+            using var response = await httpClient.GetAsync(pictureUri, ct);
             if (!response.IsSuccessStatusCode)
             {
                 _logger.LogWarning(

--- a/src/Humans.Web/Controllers/ProfileController.cs
+++ b/src/Humans.Web/Controllers/ProfileController.cs
@@ -69,8 +69,11 @@ public class ProfileController : HumansControllerBase
     private readonly IClock _clock;
     private readonly IAuthorizationService _authorizationService;
     private readonly IUserService _userService;
+    private readonly IHttpClientFactory _httpClientFactory;
 
     private const int MaxProfilePictureUploadBytes = 20 * 1024 * 1024; // 20MB upload limit
+    private const int MaxGooglePhotoDownloadBytes = 20 * 1024 * 1024; // 20MB hard ceiling for Google avatar fetch
+    private const string GoogleAvatarHttpClientName = "GoogleAvatar";
     private static readonly HashSet<string> AllowedImageContentTypes = new(StringComparer.OrdinalIgnoreCase)
     {
         "image/jpeg",
@@ -117,7 +120,8 @@ public class ProfileController : HumansControllerBase
         IMemoryCache cache,
         IClock clock,
         IAuthorizationService authorizationService,
-        IUserService userService)
+        IUserService userService,
+        IHttpClientFactory httpClientFactory)
         : base(userManager)
     {
         _userManager = userManager;
@@ -144,6 +148,7 @@ public class ProfileController : HumansControllerBase
         _clock = clock;
         _authorizationService = authorizationService;
         _userService = userService;
+        _httpClientFactory = httpClientFactory;
     }
 
     // ─── Own Profile (Me) ────────────────────────────────────────────
@@ -215,6 +220,16 @@ public class ProfileController : HumansControllerBase
         // ?preview=true forces initial-setup mode for testing
         var isInitialSetup = profile is null || !profile.IsApproved || preview;
 
+        // "Import my Google photo" button is only offered when the user signed in with
+        // Google, we captured an avatar URL at sign-in, and they don't yet have a custom
+        // upload. We intentionally don't surface a replace flow here (see issue #532).
+        var externalLogins = await UserManager.GetLoginsAsync(user);
+        var hasGoogleLogin = externalLogins.Any(l =>
+            string.Equals(l.LoginProvider, "Google", StringComparison.OrdinalIgnoreCase));
+        var canImportGooglePicture = hasGoogleLogin
+            && !hasCustomPicture
+            && !string.IsNullOrEmpty(user.ProfilePictureUrl);
+
         var viewModel = new ProfileViewModel
         {
             Id = profile?.Id ?? Guid.Empty,
@@ -226,6 +241,7 @@ public class ProfileController : HumansControllerBase
             CustomProfilePictureUrl = hasCustomPicture
                 ? Url.Action(nameof(Picture), new { id = profile!.Id, v = profile.UpdatedAt.ToUnixTimeTicks() })
                 : null,
+            CanImportGooglePicture = canImportGooglePicture,
             BurnerName = profile?.BurnerName ?? user.DisplayName,
             FirstName = profile?.FirstName ?? string.Empty,
             LastName = profile?.LastName ?? string.Empty,
@@ -1009,6 +1025,100 @@ public class ProfileController : HumansControllerBase
             return NotFound();
 
         return File(data, contentType);
+    }
+
+    [HttpPost("Me/ImportGooglePhoto")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> ImportGooglePhoto(CancellationToken ct)
+    {
+        var user = await GetCurrentUserAsync();
+        if (user is null)
+        {
+            return NotFound();
+        }
+
+        // Eligibility: must have a Google login, must have a captured avatar URL, and
+        // must NOT already have a custom picture (no replacement flow in this PR).
+        var externalLogins = await UserManager.GetLoginsAsync(user);
+        var hasGoogleLogin = externalLogins.Any(l =>
+            string.Equals(l.LoginProvider, "Google", StringComparison.OrdinalIgnoreCase));
+        if (!hasGoogleLogin || string.IsNullOrEmpty(user.ProfilePictureUrl))
+        {
+            SetError(_localizer["Profile_ImportGooglePhoto_Unavailable"].Value);
+            return RedirectToAction(nameof(Edit));
+        }
+
+        var profile = await _profileService.GetProfileAsync(user.Id, ct);
+        if (profile is null)
+        {
+            SetError(_localizer["Profile_ImportGooglePhoto_NoProfile"].Value);
+            return RedirectToAction(nameof(Edit));
+        }
+        if (profile.HasCustomProfilePicture)
+        {
+            SetError(_localizer["Profile_ImportGooglePhoto_AlreadyHasCustom"].Value);
+            return RedirectToAction(nameof(Edit));
+        }
+
+        byte[] rawBytes;
+        string fetchedContentType;
+        try
+        {
+            var httpClient = _httpClientFactory.CreateClient(GoogleAvatarHttpClientName);
+            using var response = await httpClient.GetAsync(user.ProfilePictureUrl, ct);
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning(
+                    "Google avatar fetch for user {UserId} returned {StatusCode}",
+                    user.Id, (int)response.StatusCode);
+                SetError(_localizer["Profile_ImportGooglePhoto_FetchFailed"].Value);
+                return RedirectToAction(nameof(Edit));
+            }
+
+            fetchedContentType = response.Content.Headers.ContentType?.MediaType ?? string.Empty;
+            if (!AllowedImageContentTypes.Contains(fetchedContentType))
+            {
+                _logger.LogWarning(
+                    "Google avatar for user {UserId} returned unsupported content type {ContentType}",
+                    user.Id, fetchedContentType);
+                SetError(_localizer["Profile_ImportGooglePhoto_InvalidFormat"].Value);
+                return RedirectToAction(nameof(Edit));
+            }
+
+            rawBytes = await response.Content.ReadAsByteArrayAsync(ct);
+            if (rawBytes.Length == 0 || rawBytes.Length > MaxGooglePhotoDownloadBytes)
+            {
+                _logger.LogWarning(
+                    "Google avatar for user {UserId} had invalid size {Bytes}", user.Id, rawBytes.Length);
+                SetError(_localizer["Profile_ImportGooglePhoto_FetchFailed"].Value);
+                return RedirectToAction(nameof(Edit));
+            }
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogWarning(ex, "Google avatar fetch failed for user {UserId}", user.Id);
+            SetError(_localizer["Profile_ImportGooglePhoto_FetchFailed"].Value);
+            return RedirectToAction(nameof(Edit));
+        }
+        catch (TaskCanceledException ex) when (!ct.IsCancellationRequested)
+        {
+            _logger.LogWarning(ex, "Google avatar fetch timed out for user {UserId}", user.Id);
+            SetError(_localizer["Profile_ImportGooglePhoto_FetchFailed"].Value);
+            return RedirectToAction(nameof(Edit));
+        }
+
+        var resized = Helpers.ProfilePictureProcessor.ResizeProfilePicture(rawBytes, _logger);
+        if (resized is null)
+        {
+            SetError(_localizer["Profile_ImportGooglePhoto_InvalidFormat"].Value);
+            return RedirectToAction(nameof(Edit));
+        }
+
+        await _profileService.SetProfilePictureAsync(user.Id, resized.Value.Data, resized.Value.ContentType, ct);
+
+        _logger.LogInformation("Imported Google avatar for user {UserId}", user.Id);
+        SetSuccess(_localizer["Profile_ImportGooglePhoto_Success"].Value);
+        return RedirectToAction(nameof(Edit));
     }
 
     // ─── View Another Profile ────────────────────────────────────────

--- a/src/Humans.Web/Controllers/TeamController.cs
+++ b/src/Humans.Web/Controllers/TeamController.cs
@@ -206,7 +206,8 @@ public class TeamController : HumansControllerBase
                         {
                             UserId = cm.UserId,
                             DisplayName = cm.User.DisplayName,
-                            ProfilePictureUrl = cm.User.ProfilePictureUrl,
+                            // Populated below via ProfilePictureUrlHelper (custom uploads only).
+                            ProfilePictureUrl = null,
                             ChildTeamName = child.Name,
                             ChildTeamSlug = child.Slug,
                             IsCoordinator = true,
@@ -221,7 +222,8 @@ public class TeamController : HumansControllerBase
                     {
                         UserId = cm.UserId,
                         DisplayName = cm.User.DisplayName,
-                        ProfilePictureUrl = cm.User.ProfilePictureUrl,
+                        // Populated below via ProfilePictureUrlHelper (custom uploads only).
+                        ProfilePictureUrl = null,
                         ChildTeamName = child.Name,
                         ChildTeamSlug = child.Slug,
                         IsCoordinator = isCoordinator,
@@ -239,7 +241,7 @@ public class TeamController : HumansControllerBase
             {
                 var effectiveUrls = await ProfilePictureUrlHelper.BuildEffectiveUrlsAsync(
                     _profileService, Url,
-                    allChildUserEntries.Select(m => (m.UserId, m.ProfilePictureUrl)));
+                    allChildUserEntries.Select(m => m.UserId));
 
                 foreach (var member in allChildUserEntries)
                 {
@@ -345,7 +347,7 @@ public class TeamController : HumansControllerBase
 
         var effectiveUrls = await ProfilePictureUrlHelper.BuildEffectiveUrlsAsync(
             _profileService, Url,
-            profilesWithBirthdays.Select(p => (p.UserId, p.ProfilePictureUrl)));
+            profilesWithBirthdays.Select(p => p.UserId));
 
         var viewModel = new BirthdayCalendarViewModel
         {
@@ -397,7 +399,7 @@ public class TeamController : HumansControllerBase
 
         var effectiveUrls = await ProfilePictureUrlHelper.BuildEffectiveUrlsAsync(
             _profileService, Url,
-            profiles.Select(p => (p.UserId, p.ProfilePictureUrl)));
+            profiles.Select(p => p.UserId));
 
         var markers = profiles.Select(p => new MapMarkerViewModel
         {

--- a/src/Humans.Web/Helpers/ProfilePictureUrlHelper.cs
+++ b/src/Humans.Web/Helpers/ProfilePictureUrlHelper.cs
@@ -5,31 +5,42 @@ using Humans.Application.Interfaces.Profiles;
 namespace Humans.Web.Helpers;
 
 /// <summary>
-/// Resolves effective profile picture URLs (custom upload takes priority over Google avatar).
-/// Centralizes the pattern used across Map, Birthdays, Team Details, etc.
+/// Resolves effective profile picture URLs for a set of users. Returns only the
+/// custom-upload URL when present; otherwise the dictionary value is null and callers
+/// are expected to render the initial-letter placeholder.
 /// </summary>
+/// <remarks>
+/// Google avatar URLs (<see cref="Humans.Domain.Entities.User.ProfilePictureUrl"/>) are
+/// intentionally not considered here — see issue #532. They're captured at sign-in but
+/// not used for rendering, because Google restricts hotlinking and the URLs frequently
+/// fail to load. Users who want their Google photo must import it via the
+/// "Import my Google photo" button on <c>/Profile/Edit</c>.
+/// </remarks>
 public static class ProfilePictureUrlHelper
 {
     /// <summary>
-    /// Builds a dictionary mapping UserId → effective profile picture URL
-    /// for a set of users, resolving custom uploads vs Google avatars.
+    /// Builds a dictionary mapping UserId → custom profile picture URL, or null when the
+    /// user has no custom upload.
     /// </summary>
     public static async Task<Dictionary<Guid, string?>> BuildEffectiveUrlsAsync(
         IProfileService profileService,
         IUrlHelper urlHelper,
-        IEnumerable<(Guid UserId, string? GoogleProfilePictureUrl)> users,
+        IEnumerable<Guid> userIds,
         CancellationToken ct = default)
     {
-        var userList = users.DistinctBy(u => u.UserId).ToList();
-        var userIds = userList.Select(u => u.UserId).ToList();
+        var idList = userIds.Distinct().ToList();
+        if (idList.Count == 0)
+        {
+            return new Dictionary<Guid, string?>();
+        }
 
-        var customPictures = await profileService.GetCustomPictureInfoByUserIdsAsync(userIds, ct);
+        var customPictures = await profileService.GetCustomPictureInfoByUserIdsAsync(idList, ct);
         var customByUserId = customPictures.ToDictionary(
             p => p.UserId,
             p => urlHelper.Action(nameof(ProfileController.Picture), "Profile", new { id = p.ProfileId, v = p.UpdatedAtTicks }));
 
-        return userList.ToDictionary(
-            u => u.UserId,
-            u => customByUserId.TryGetValue(u.UserId, out var customUrl) ? customUrl : u.GoogleProfilePictureUrl);
+        return idList.ToDictionary(
+            id => id,
+            id => customByUserId.TryGetValue(id, out var customUrl) ? customUrl : null);
     }
 }

--- a/src/Humans.Web/Models/ProfileViewModel.cs
+++ b/src/Humans.Web/Models/ProfileViewModel.cs
@@ -24,6 +24,13 @@ public class ProfileViewModel
     /// </summary>
     public string? CustomProfilePictureUrl { get; set; }
 
+    /// <summary>
+    /// True when the user can import a photo from Google — they signed in with Google,
+    /// we captured an avatar URL on <see cref="Humans.Domain.Entities.User.ProfilePictureUrl"/>,
+    /// and they don't yet have a custom uploaded picture. See issue #532.
+    /// </summary>
+    public bool CanImportGooglePicture { get; set; }
+
     [Required]
     [StringLength(100)]
     [Display(Name = "Burner Name")]

--- a/src/Humans.Web/Program.cs
+++ b/src/Humans.Web/Program.cs
@@ -243,6 +243,14 @@ builder.Services.AddHumansAuthorizationPolicies();
 builder.Services.AddHttpContextAccessor();
 builder.Services.AddTransient<Microsoft.AspNetCore.Authentication.IClaimsTransformation, RoleAssignmentClaimsTransformation>();
 
+// Named HttpClient used by /Profile/Me/ImportGooglePhoto to fetch the signed-in user's
+// Google avatar once on demand. Short timeout — if Google is slow we surface an error
+// rather than keeping the request hanging.
+builder.Services.AddHttpClient("GoogleAvatar", client =>
+{
+    client.Timeout = TimeSpan.FromSeconds(10);
+});
+
 // Configure Hangfire
 builder.Services.AddHangfire((sp, config) =>
 {

--- a/src/Humans.Web/Resources/SharedResource.ca.resx
+++ b/src/Humans.Web/Resources/SharedResource.ca.resx
@@ -921,7 +921,6 @@
   <data name="Profile_DateOfBirth" xml:space="preserve"><value>Aniversari</value></data>
   <data name="Profile_PictureTooLarge" xml:space="preserve"><value>La foto de perfil ha de ser inferior a 20MB.</value></data>
   <data name="Profile_PictureInvalidFormat" xml:space="preserve"><value>La foto de perfil ha d'estar en format JPEG, PNG, WebP o HEIC.</value></data>
-  <data name="ProfileEdit_GoogleAvatar" xml:space="preserve"><value>(avatar de Google)</value></data>
   <data name="ProfileEdit_PictureHelp" xml:space="preserve"><value>Puja una imatge JPEG, PNG, WebP o HEIC (màx. 20MB). Les imatges grans es redimensionen automàticament.</value></data>
   <data name="ProfileEdit_RemovePicture" xml:space="preserve"><value>Elimina foto personalitzada</value></data>
   <data name="ProfileEdit_ImportGooglePhoto" xml:space="preserve"><value>Importa la meva foto de Google</value></data>
@@ -932,6 +931,7 @@
   <data name="Profile_ImportGooglePhoto_AlreadyHasCustom" xml:space="preserve"><value>Ja tens una foto de perfil personalitzada. Elimina-la primer per importar la teva foto de Google.</value></data>
   <data name="Profile_ImportGooglePhoto_FetchFailed" xml:space="preserve"><value>No hem pogut obtenir la teva foto de Google. Prova-ho més tard o puja'n una directament.</value></data>
   <data name="Profile_ImportGooglePhoto_InvalidFormat" xml:space="preserve"><value>No s'ha pogut processar la teva foto de Google: format no admès o resposta incorrecta.</value></data>
+  <data name="Profile_ImportGooglePhoto_NotGoogleUrl" xml:space="preserve"><value>No hem pogut importar la teva foto de Google: la URL de l'avatar emmagatzemat no sembla una adreça de Google. Puja'n una directament.</value></data>
   <data name="ProfileEdit_DateOfBirthHelp" xml:space="preserve"><value>Només visible per a tu i la junta directiva. S'utilitza per al calendari d'aniversaris.</value></data>
   <data name="TeamDetail_TeamCoordinators" xml:space="preserve"><value>Coordinadors</value></data>
 

--- a/src/Humans.Web/Resources/SharedResource.ca.resx
+++ b/src/Humans.Web/Resources/SharedResource.ca.resx
@@ -922,8 +922,16 @@
   <data name="Profile_PictureTooLarge" xml:space="preserve"><value>La foto de perfil ha de ser inferior a 20MB.</value></data>
   <data name="Profile_PictureInvalidFormat" xml:space="preserve"><value>La foto de perfil ha d'estar en format JPEG, PNG, WebP o HEIC.</value></data>
   <data name="ProfileEdit_GoogleAvatar" xml:space="preserve"><value>(avatar de Google)</value></data>
-  <data name="ProfileEdit_PictureHelp" xml:space="preserve"><value>Puja una imatge JPEG, PNG, WebP o HEIC (màx. 20MB). Les imatges grans es redimensionen automàticament. Això substitueix el teu avatar de Google.</value></data>
-  <data name="ProfileEdit_RemovePicture" xml:space="preserve"><value>Elimina foto personalitzada (tornar a l'avatar de Google)</value></data>
+  <data name="ProfileEdit_PictureHelp" xml:space="preserve"><value>Puja una imatge JPEG, PNG, WebP o HEIC (màx. 20MB). Les imatges grans es redimensionen automàticament.</value></data>
+  <data name="ProfileEdit_RemovePicture" xml:space="preserve"><value>Elimina foto personalitzada</value></data>
+  <data name="ProfileEdit_ImportGooglePhoto" xml:space="preserve"><value>Importa la meva foto de Google</value></data>
+  <data name="ProfileEdit_ImportGooglePhotoHelp" xml:space="preserve"><value>Copia la foto del teu compte de Google com a foto de perfil. Podràs reemplaçar-la més endavant pujant-ne una de nova.</value></data>
+  <data name="Profile_ImportGooglePhoto_Success" xml:space="preserve"><value>La teva foto de Google s'ha importat com a foto de perfil.</value></data>
+  <data name="Profile_ImportGooglePhoto_Unavailable" xml:space="preserve"><value>No podem importar una foto de Google: el teu compte no està vinculat a Google o no es va capturar cap avatar en iniciar sessió.</value></data>
+  <data name="Profile_ImportGooglePhoto_NoProfile" xml:space="preserve"><value>Acaba de configurar el teu perfil primer i després podràs importar la teva foto de Google.</value></data>
+  <data name="Profile_ImportGooglePhoto_AlreadyHasCustom" xml:space="preserve"><value>Ja tens una foto de perfil personalitzada. Elimina-la primer per importar la teva foto de Google.</value></data>
+  <data name="Profile_ImportGooglePhoto_FetchFailed" xml:space="preserve"><value>No hem pogut obtenir la teva foto de Google. Prova-ho més tard o puja'n una directament.</value></data>
+  <data name="Profile_ImportGooglePhoto_InvalidFormat" xml:space="preserve"><value>No s'ha pogut processar la teva foto de Google: format no admès o resposta incorrecta.</value></data>
   <data name="ProfileEdit_DateOfBirthHelp" xml:space="preserve"><value>Només visible per a tu i la junta directiva. S'utilitza per al calendari d'aniversaris.</value></data>
   <data name="TeamDetail_TeamCoordinators" xml:space="preserve"><value>Coordinadors</value></data>
 

--- a/src/Humans.Web/Resources/SharedResource.de.resx
+++ b/src/Humans.Web/Resources/SharedResource.de.resx
@@ -917,8 +917,16 @@
   <data name="Profile_PictureTooLarge" xml:space="preserve"><value>Das Profilbild darf maximal 20MB gro&#xDF; sein.</value></data>
   <data name="Profile_PictureInvalidFormat" xml:space="preserve"><value>Das Profilbild muss im JPEG-, PNG-, WebP- oder HEIC-Format sein.</value></data>
   <data name="ProfileEdit_GoogleAvatar" xml:space="preserve"><value>(Google-Avatar)</value></data>
-  <data name="ProfileEdit_PictureHelp" xml:space="preserve"><value>Laden Sie ein JPEG-, PNG-, WebP- oder HEIC-Bild hoch (max. 20MB). Gro&#xDF;e Bilder werden automatisch verkleinert. Dies ersetzt Ihren Google-Avatar.</value></data>
-  <data name="ProfileEdit_RemovePicture" xml:space="preserve"><value>Benutzerdefiniertes Bild entfernen (zum Google-Avatar zur&#xFC;ckkehren)</value></data>
+  <data name="ProfileEdit_PictureHelp" xml:space="preserve"><value>Laden Sie ein JPEG-, PNG-, WebP- oder HEIC-Bild hoch (max. 20MB). Gro&#xDF;e Bilder werden automatisch verkleinert.</value></data>
+  <data name="ProfileEdit_RemovePicture" xml:space="preserve"><value>Benutzerdefiniertes Bild entfernen</value></data>
+  <data name="ProfileEdit_ImportGooglePhoto" xml:space="preserve"><value>Mein Google-Foto importieren</value></data>
+  <data name="ProfileEdit_ImportGooglePhotoHelp" xml:space="preserve"><value>Kopiert das Foto aus deinem Google-Konto als Profilbild. Du kannst es sp&#xE4;ter durch ein neues Bild ersetzen.</value></data>
+  <data name="Profile_ImportGooglePhoto_Success" xml:space="preserve"><value>Dein Google-Foto wurde als Profilbild importiert.</value></data>
+  <data name="Profile_ImportGooglePhoto_Unavailable" xml:space="preserve"><value>Google-Foto kann nicht importiert werden: Dein Konto ist nicht mit Google verkn&#xFC;pft oder es wurde kein Avatar bei der Anmeldung erfasst.</value></data>
+  <data name="Profile_ImportGooglePhoto_NoProfile" xml:space="preserve"><value>Schlie&#xDF;e zuerst die Einrichtung deines Profils ab, dann kannst du dein Google-Foto importieren.</value></data>
+  <data name="Profile_ImportGooglePhoto_AlreadyHasCustom" xml:space="preserve"><value>Du hast bereits ein benutzerdefiniertes Profilbild. Entferne es zuerst, um dein Google-Foto zu importieren.</value></data>
+  <data name="Profile_ImportGooglePhoto_FetchFailed" xml:space="preserve"><value>Dein Google-Foto konnte nicht abgerufen werden. Versuche es sp&#xE4;ter erneut oder lade direkt eines hoch.</value></data>
+  <data name="Profile_ImportGooglePhoto_InvalidFormat" xml:space="preserve"><value>Dein Google-Foto konnte nicht verarbeitet werden: Nicht unterst&#xFC;tztes Format oder fehlerhafte Antwort von Google.</value></data>
   <data name="ProfileEdit_DateOfBirthHelp" xml:space="preserve"><value>Nur f&#xFC;r Sie und den Vorstand sichtbar. Wird f&#xFC;r den Geburtstagskalender verwendet.</value></data>
   <data name="TeamDetail_TeamCoordinators" xml:space="preserve"><value>Koordinatoren</value></data>
 

--- a/src/Humans.Web/Resources/SharedResource.de.resx
+++ b/src/Humans.Web/Resources/SharedResource.de.resx
@@ -916,7 +916,6 @@
   <data name="Profile_DateOfBirth" xml:space="preserve"><value>Geburtstag</value></data>
   <data name="Profile_PictureTooLarge" xml:space="preserve"><value>Das Profilbild darf maximal 20MB gro&#xDF; sein.</value></data>
   <data name="Profile_PictureInvalidFormat" xml:space="preserve"><value>Das Profilbild muss im JPEG-, PNG-, WebP- oder HEIC-Format sein.</value></data>
-  <data name="ProfileEdit_GoogleAvatar" xml:space="preserve"><value>(Google-Avatar)</value></data>
   <data name="ProfileEdit_PictureHelp" xml:space="preserve"><value>Laden Sie ein JPEG-, PNG-, WebP- oder HEIC-Bild hoch (max. 20MB). Gro&#xDF;e Bilder werden automatisch verkleinert.</value></data>
   <data name="ProfileEdit_RemovePicture" xml:space="preserve"><value>Benutzerdefiniertes Bild entfernen</value></data>
   <data name="ProfileEdit_ImportGooglePhoto" xml:space="preserve"><value>Mein Google-Foto importieren</value></data>
@@ -927,6 +926,7 @@
   <data name="Profile_ImportGooglePhoto_AlreadyHasCustom" xml:space="preserve"><value>Du hast bereits ein benutzerdefiniertes Profilbild. Entferne es zuerst, um dein Google-Foto zu importieren.</value></data>
   <data name="Profile_ImportGooglePhoto_FetchFailed" xml:space="preserve"><value>Dein Google-Foto konnte nicht abgerufen werden. Versuche es sp&#xE4;ter erneut oder lade direkt eines hoch.</value></data>
   <data name="Profile_ImportGooglePhoto_InvalidFormat" xml:space="preserve"><value>Dein Google-Foto konnte nicht verarbeitet werden: Nicht unterst&#xFC;tztes Format oder fehlerhafte Antwort von Google.</value></data>
+  <data name="Profile_ImportGooglePhoto_NotGoogleUrl" xml:space="preserve"><value>Dein Google-Foto konnte nicht importiert werden: Die gespeicherte Avatar-URL sieht nicht nach einer Google-Adresse aus. Bitte lade direkt ein Foto hoch.</value></data>
   <data name="ProfileEdit_DateOfBirthHelp" xml:space="preserve"><value>Nur f&#xFC;r Sie und den Vorstand sichtbar. Wird f&#xFC;r den Geburtstagskalender verwendet.</value></data>
   <data name="TeamDetail_TeamCoordinators" xml:space="preserve"><value>Koordinatoren</value></data>
 

--- a/src/Humans.Web/Resources/SharedResource.es.resx
+++ b/src/Humans.Web/Resources/SharedResource.es.resx
@@ -921,7 +921,6 @@
   <data name="Profile_DateOfBirth" xml:space="preserve"><value>Cumplea&#xF1;os</value></data>
   <data name="Profile_PictureTooLarge" xml:space="preserve"><value>La foto de perfil debe ser inferior a 20MB.</value></data>
   <data name="Profile_PictureInvalidFormat" xml:space="preserve"><value>La foto de perfil debe estar en formato JPEG, PNG, WebP o HEIC.</value></data>
-  <data name="ProfileEdit_GoogleAvatar" xml:space="preserve"><value>(avatar de Google)</value></data>
   <data name="ProfileEdit_PictureHelp" xml:space="preserve"><value>Suba una imagen JPEG, PNG, WebP o HEIC (m&#xE1;x. 20MB). Las im&#xE1;genes grandes se redimensionan autom&#xE1;ticamente.</value></data>
   <data name="ProfileEdit_RemovePicture" xml:space="preserve"><value>Eliminar foto personalizada</value></data>
   <data name="ProfileEdit_ImportGooglePhoto" xml:space="preserve"><value>Importar mi foto de Google</value></data>
@@ -932,6 +931,7 @@
   <data name="Profile_ImportGooglePhoto_AlreadyHasCustom" xml:space="preserve"><value>Ya tienes una foto de perfil personalizada. Elim&#xED;nala primero para importar tu foto de Google.</value></data>
   <data name="Profile_ImportGooglePhoto_FetchFailed" xml:space="preserve"><value>No pudimos obtener tu foto de Google. Int&#xE9;ntalo m&#xE1;s tarde o sube una directamente.</value></data>
   <data name="Profile_ImportGooglePhoto_InvalidFormat" xml:space="preserve"><value>No se pudo procesar tu foto de Google: formato no admitido o respuesta err&#xF3;nea.</value></data>
+  <data name="Profile_ImportGooglePhoto_NotGoogleUrl" xml:space="preserve"><value>No pudimos importar tu foto de Google: la URL del avatar guardado no parece ser una direcci&#xF3;n de Google. Sube una directamente.</value></data>
   <data name="ProfileEdit_DateOfBirthHelp" xml:space="preserve"><value>Solo visible para usted y la junta directiva. Se usa para el calendario de cumplea&#xF1;os.</value></data>
   <data name="TeamDetail_TeamCoordinators" xml:space="preserve"><value>Coordinadores</value></data>
 

--- a/src/Humans.Web/Resources/SharedResource.es.resx
+++ b/src/Humans.Web/Resources/SharedResource.es.resx
@@ -922,8 +922,16 @@
   <data name="Profile_PictureTooLarge" xml:space="preserve"><value>La foto de perfil debe ser inferior a 20MB.</value></data>
   <data name="Profile_PictureInvalidFormat" xml:space="preserve"><value>La foto de perfil debe estar en formato JPEG, PNG, WebP o HEIC.</value></data>
   <data name="ProfileEdit_GoogleAvatar" xml:space="preserve"><value>(avatar de Google)</value></data>
-  <data name="ProfileEdit_PictureHelp" xml:space="preserve"><value>Suba una imagen JPEG, PNG, WebP o HEIC (m&#xE1;x. 20MB). Las im&#xE1;genes grandes se redimensionan autom&#xE1;ticamente. Esto reemplaza su avatar de Google.</value></data>
-  <data name="ProfileEdit_RemovePicture" xml:space="preserve"><value>Eliminar foto personalizada (volver al avatar de Google)</value></data>
+  <data name="ProfileEdit_PictureHelp" xml:space="preserve"><value>Suba una imagen JPEG, PNG, WebP o HEIC (m&#xE1;x. 20MB). Las im&#xE1;genes grandes se redimensionan autom&#xE1;ticamente.</value></data>
+  <data name="ProfileEdit_RemovePicture" xml:space="preserve"><value>Eliminar foto personalizada</value></data>
+  <data name="ProfileEdit_ImportGooglePhoto" xml:space="preserve"><value>Importar mi foto de Google</value></data>
+  <data name="ProfileEdit_ImportGooglePhotoHelp" xml:space="preserve"><value>Copia la foto de tu cuenta de Google como foto de perfil. Podr&#xE1;s reemplazarla m&#xE1;s tarde subiendo una nueva.</value></data>
+  <data name="Profile_ImportGooglePhoto_Success" xml:space="preserve"><value>Tu foto de Google se ha importado como foto de perfil.</value></data>
+  <data name="Profile_ImportGooglePhoto_Unavailable" xml:space="preserve"><value>No podemos importar una foto de Google: tu cuenta no est&#xE1; vinculada a Google o no se captur&#xF3; un avatar al iniciar sesi&#xF3;n.</value></data>
+  <data name="Profile_ImportGooglePhoto_NoProfile" xml:space="preserve"><value>Termina de configurar tu perfil primero y luego podr&#xE1;s importar tu foto de Google.</value></data>
+  <data name="Profile_ImportGooglePhoto_AlreadyHasCustom" xml:space="preserve"><value>Ya tienes una foto de perfil personalizada. Elim&#xED;nala primero para importar tu foto de Google.</value></data>
+  <data name="Profile_ImportGooglePhoto_FetchFailed" xml:space="preserve"><value>No pudimos obtener tu foto de Google. Int&#xE9;ntalo m&#xE1;s tarde o sube una directamente.</value></data>
+  <data name="Profile_ImportGooglePhoto_InvalidFormat" xml:space="preserve"><value>No se pudo procesar tu foto de Google: formato no admitido o respuesta err&#xF3;nea.</value></data>
   <data name="ProfileEdit_DateOfBirthHelp" xml:space="preserve"><value>Solo visible para usted y la junta directiva. Se usa para el calendario de cumplea&#xF1;os.</value></data>
   <data name="TeamDetail_TeamCoordinators" xml:space="preserve"><value>Coordinadores</value></data>
 

--- a/src/Humans.Web/Resources/SharedResource.fr.resx
+++ b/src/Humans.Web/Resources/SharedResource.fr.resx
@@ -916,7 +916,6 @@
   <data name="Profile_DateOfBirth" xml:space="preserve"><value>Anniversaire</value></data>
   <data name="Profile_PictureTooLarge" xml:space="preserve"><value>La photo de profil doit faire moins de 20 Mo.</value></data>
   <data name="Profile_PictureInvalidFormat" xml:space="preserve"><value>La photo de profil doit &#xEA;tre au format JPEG, PNG, WebP ou HEIC.</value></data>
-  <data name="ProfileEdit_GoogleAvatar" xml:space="preserve"><value>(avatar Google)</value></data>
   <data name="ProfileEdit_PictureHelp" xml:space="preserve"><value>T&#xE9;l&#xE9;chargez une image JPEG, PNG, WebP ou HEIC (max. 20 Mo). Les grandes images sont redimensionn&#xE9;es automatiquement.</value></data>
   <data name="ProfileEdit_RemovePicture" xml:space="preserve"><value>Supprimer la photo personnalis&#xE9;e</value></data>
   <data name="ProfileEdit_ImportGooglePhoto" xml:space="preserve"><value>Importer ma photo Google</value></data>
@@ -927,6 +926,7 @@
   <data name="Profile_ImportGooglePhoto_AlreadyHasCustom" xml:space="preserve"><value>Tu as d&#xE9;j&#xE0; une photo de profil personnalis&#xE9;e. Supprime-la d'abord pour importer ta photo Google.</value></data>
   <data name="Profile_ImportGooglePhoto_FetchFailed" xml:space="preserve"><value>Impossible de r&#xE9;cup&#xE9;rer ta photo Google. R&#xE9;essaie plus tard ou t&#xE9;l&#xE9;charge-en une directement.</value></data>
   <data name="Profile_ImportGooglePhoto_InvalidFormat" xml:space="preserve"><value>Ta photo Google n'a pas pu &#xEA;tre trait&#xE9;e : format non pris en charge ou mauvaise r&#xE9;ponse de Google.</value></data>
+  <data name="Profile_ImportGooglePhoto_NotGoogleUrl" xml:space="preserve"><value>Impossible d'importer ta photo Google : l'URL de l'avatar enregistr&#xE9;e ne ressemble pas &#xE0; une adresse Google. T&#xE9;l&#xE9;charge-en une directement.</value></data>
   <data name="ProfileEdit_DateOfBirthHelp" xml:space="preserve"><value>Visible uniquement par vous et le conseil d'administration. Utilis&#xE9; pour le calendrier des anniversaires.</value></data>
   <data name="TeamDetail_TeamCoordinators" xml:space="preserve"><value>Coordinateurs</value></data>
 

--- a/src/Humans.Web/Resources/SharedResource.fr.resx
+++ b/src/Humans.Web/Resources/SharedResource.fr.resx
@@ -917,8 +917,16 @@
   <data name="Profile_PictureTooLarge" xml:space="preserve"><value>La photo de profil doit faire moins de 20 Mo.</value></data>
   <data name="Profile_PictureInvalidFormat" xml:space="preserve"><value>La photo de profil doit &#xEA;tre au format JPEG, PNG, WebP ou HEIC.</value></data>
   <data name="ProfileEdit_GoogleAvatar" xml:space="preserve"><value>(avatar Google)</value></data>
-  <data name="ProfileEdit_PictureHelp" xml:space="preserve"><value>T&#xE9;l&#xE9;chargez une image JPEG, PNG, WebP ou HEIC (max. 20 Mo). Les grandes images sont redimensionn&#xE9;es automatiquement. Ceci remplace votre avatar Google.</value></data>
-  <data name="ProfileEdit_RemovePicture" xml:space="preserve"><value>Supprimer la photo personnalis&#xE9;e (revenir &#xE0; l'avatar Google)</value></data>
+  <data name="ProfileEdit_PictureHelp" xml:space="preserve"><value>T&#xE9;l&#xE9;chargez une image JPEG, PNG, WebP ou HEIC (max. 20 Mo). Les grandes images sont redimensionn&#xE9;es automatiquement.</value></data>
+  <data name="ProfileEdit_RemovePicture" xml:space="preserve"><value>Supprimer la photo personnalis&#xE9;e</value></data>
+  <data name="ProfileEdit_ImportGooglePhoto" xml:space="preserve"><value>Importer ma photo Google</value></data>
+  <data name="ProfileEdit_ImportGooglePhotoHelp" xml:space="preserve"><value>Copie la photo de ton compte Google comme photo de profil. Tu pourras la remplacer plus tard en en t&#xE9;l&#xE9;chargeant une nouvelle.</value></data>
+  <data name="Profile_ImportGooglePhoto_Success" xml:space="preserve"><value>Ta photo Google a &#xE9;t&#xE9; import&#xE9;e comme photo de profil.</value></data>
+  <data name="Profile_ImportGooglePhoto_Unavailable" xml:space="preserve"><value>Nous ne pouvons pas importer une photo Google : ton compte n'est pas li&#xE9; &#xE0; Google ou aucun avatar n'a &#xE9;t&#xE9; captur&#xE9; &#xE0; la connexion.</value></data>
+  <data name="Profile_ImportGooglePhoto_NoProfile" xml:space="preserve"><value>Termine d'abord la configuration de ton profil, ensuite tu pourras importer ta photo Google.</value></data>
+  <data name="Profile_ImportGooglePhoto_AlreadyHasCustom" xml:space="preserve"><value>Tu as d&#xE9;j&#xE0; une photo de profil personnalis&#xE9;e. Supprime-la d'abord pour importer ta photo Google.</value></data>
+  <data name="Profile_ImportGooglePhoto_FetchFailed" xml:space="preserve"><value>Impossible de r&#xE9;cup&#xE9;rer ta photo Google. R&#xE9;essaie plus tard ou t&#xE9;l&#xE9;charge-en une directement.</value></data>
+  <data name="Profile_ImportGooglePhoto_InvalidFormat" xml:space="preserve"><value>Ta photo Google n'a pas pu &#xEA;tre trait&#xE9;e : format non pris en charge ou mauvaise r&#xE9;ponse de Google.</value></data>
   <data name="ProfileEdit_DateOfBirthHelp" xml:space="preserve"><value>Visible uniquement par vous et le conseil d'administration. Utilis&#xE9; pour le calendrier des anniversaires.</value></data>
   <data name="TeamDetail_TeamCoordinators" xml:space="preserve"><value>Coordinateurs</value></data>
 

--- a/src/Humans.Web/Resources/SharedResource.it.resx
+++ b/src/Humans.Web/Resources/SharedResource.it.resx
@@ -917,8 +917,16 @@
   <data name="Profile_PictureTooLarge" xml:space="preserve"><value>La foto del profilo deve essere inferiore a 20MB.</value></data>
   <data name="Profile_PictureInvalidFormat" xml:space="preserve"><value>La foto del profilo deve essere in formato JPEG, PNG, WebP o HEIC.</value></data>
   <data name="ProfileEdit_GoogleAvatar" xml:space="preserve"><value>(avatar di Google)</value></data>
-  <data name="ProfileEdit_PictureHelp" xml:space="preserve"><value>Carica un'immagine JPEG, PNG, WebP o HEIC (max 20MB). Le immagini grandi vengono ridimensionate automaticamente. Questo sostituisce il tuo avatar di Google.</value></data>
-  <data name="ProfileEdit_RemovePicture" xml:space="preserve"><value>Rimuovi foto personalizzata (torna all'avatar di Google)</value></data>
+  <data name="ProfileEdit_PictureHelp" xml:space="preserve"><value>Carica un'immagine JPEG, PNG, WebP o HEIC (max 20MB). Le immagini grandi vengono ridimensionate automaticamente.</value></data>
+  <data name="ProfileEdit_RemovePicture" xml:space="preserve"><value>Rimuovi foto personalizzata</value></data>
+  <data name="ProfileEdit_ImportGooglePhoto" xml:space="preserve"><value>Importa la mia foto di Google</value></data>
+  <data name="ProfileEdit_ImportGooglePhotoHelp" xml:space="preserve"><value>Copia la foto del tuo account Google come foto del profilo. Potrai sostituirla in seguito caricandone una nuova.</value></data>
+  <data name="Profile_ImportGooglePhoto_Success" xml:space="preserve"><value>La tua foto di Google &#xE8; stata importata come foto del profilo.</value></data>
+  <data name="Profile_ImportGooglePhoto_Unavailable" xml:space="preserve"><value>Non possiamo importare una foto di Google: il tuo account non &#xE8; collegato a Google o nessun avatar &#xE8; stato acquisito al momento dell'accesso.</value></data>
+  <data name="Profile_ImportGooglePhoto_NoProfile" xml:space="preserve"><value>Completa prima la configurazione del tuo profilo, poi potrai importare la tua foto di Google.</value></data>
+  <data name="Profile_ImportGooglePhoto_AlreadyHasCustom" xml:space="preserve"><value>Hai gi&#xE0; una foto profilo personalizzata. Rimuovila prima per importare la tua foto di Google.</value></data>
+  <data name="Profile_ImportGooglePhoto_FetchFailed" xml:space="preserve"><value>Non siamo riusciti a recuperare la tua foto di Google. Riprova pi&#xF9; tardi o caricane una direttamente.</value></data>
+  <data name="Profile_ImportGooglePhoto_InvalidFormat" xml:space="preserve"><value>La tua foto di Google non &#xE8; stata elaborata: formato non supportato o risposta errata da Google.</value></data>
   <data name="ProfileEdit_DateOfBirthHelp" xml:space="preserve"><value>Visibile solo a te e al consiglio. Utilizzato per il calendario dei compleanni.</value></data>
   <data name="TeamDetail_TeamCoordinators" xml:space="preserve"><value>Coordinatori</value></data>
 

--- a/src/Humans.Web/Resources/SharedResource.it.resx
+++ b/src/Humans.Web/Resources/SharedResource.it.resx
@@ -916,7 +916,6 @@
   <data name="Profile_DateOfBirth" xml:space="preserve"><value>Compleanno</value></data>
   <data name="Profile_PictureTooLarge" xml:space="preserve"><value>La foto del profilo deve essere inferiore a 20MB.</value></data>
   <data name="Profile_PictureInvalidFormat" xml:space="preserve"><value>La foto del profilo deve essere in formato JPEG, PNG, WebP o HEIC.</value></data>
-  <data name="ProfileEdit_GoogleAvatar" xml:space="preserve"><value>(avatar di Google)</value></data>
   <data name="ProfileEdit_PictureHelp" xml:space="preserve"><value>Carica un'immagine JPEG, PNG, WebP o HEIC (max 20MB). Le immagini grandi vengono ridimensionate automaticamente.</value></data>
   <data name="ProfileEdit_RemovePicture" xml:space="preserve"><value>Rimuovi foto personalizzata</value></data>
   <data name="ProfileEdit_ImportGooglePhoto" xml:space="preserve"><value>Importa la mia foto di Google</value></data>
@@ -927,6 +926,7 @@
   <data name="Profile_ImportGooglePhoto_AlreadyHasCustom" xml:space="preserve"><value>Hai gi&#xE0; una foto profilo personalizzata. Rimuovila prima per importare la tua foto di Google.</value></data>
   <data name="Profile_ImportGooglePhoto_FetchFailed" xml:space="preserve"><value>Non siamo riusciti a recuperare la tua foto di Google. Riprova pi&#xF9; tardi o caricane una direttamente.</value></data>
   <data name="Profile_ImportGooglePhoto_InvalidFormat" xml:space="preserve"><value>La tua foto di Google non &#xE8; stata elaborata: formato non supportato o risposta errata da Google.</value></data>
+  <data name="Profile_ImportGooglePhoto_NotGoogleUrl" xml:space="preserve"><value>Non &#xE8; stato possibile importare la tua foto di Google: l'URL dell'avatar memorizzato non sembra un indirizzo di Google. Caricane una direttamente.</value></data>
   <data name="ProfileEdit_DateOfBirthHelp" xml:space="preserve"><value>Visibile solo a te e al consiglio. Utilizzato per il calendario dei compleanni.</value></data>
   <data name="TeamDetail_TeamCoordinators" xml:space="preserve"><value>Coordinatori</value></data>
 

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -936,8 +936,16 @@
   <data name="Profile_PictureTooLarge" xml:space="preserve"><value>Profile picture must be under 20MB.</value></data>
   <data name="Profile_PictureInvalidFormat" xml:space="preserve"><value>Profile picture must be JPEG, PNG, WebP, or HEIC format.</value></data>
   <data name="ProfileEdit_GoogleAvatar" xml:space="preserve"><value>(Google avatar)</value></data>
-  <data name="ProfileEdit_PictureHelp" xml:space="preserve"><value>Upload a JPEG, PNG, WebP, or HEIC image (max 20MB). Large images are automatically resized. This replaces your Google avatar.</value></data>
-  <data name="ProfileEdit_RemovePicture" xml:space="preserve"><value>Remove custom picture (revert to Google avatar)</value></data>
+  <data name="ProfileEdit_PictureHelp" xml:space="preserve"><value>Upload a JPEG, PNG, WebP, or HEIC image (max 20MB). Large images are automatically resized.</value></data>
+  <data name="ProfileEdit_RemovePicture" xml:space="preserve"><value>Remove custom picture</value></data>
+  <data name="ProfileEdit_ImportGooglePhoto" xml:space="preserve"><value>Import my Google photo</value></data>
+  <data name="ProfileEdit_ImportGooglePhotoHelp" xml:space="preserve"><value>Copy the photo from your Google account as your profile picture. You can replace it later by uploading a new one.</value></data>
+  <data name="Profile_ImportGooglePhoto_Success" xml:space="preserve"><value>Your Google photo has been imported as your profile picture.</value></data>
+  <data name="Profile_ImportGooglePhoto_Unavailable" xml:space="preserve"><value>We can't import a Google photo — your account isn't linked to Google or no avatar was captured at sign-in.</value></data>
+  <data name="Profile_ImportGooglePhoto_NoProfile" xml:space="preserve"><value>Finish setting up your profile first, then you can import your Google photo.</value></data>
+  <data name="Profile_ImportGooglePhoto_AlreadyHasCustom" xml:space="preserve"><value>You already have a custom profile picture. Remove it first to import your Google photo.</value></data>
+  <data name="Profile_ImportGooglePhoto_FetchFailed" xml:space="preserve"><value>We couldn't fetch your Google photo. Please try again later or upload one directly.</value></data>
+  <data name="Profile_ImportGooglePhoto_InvalidFormat" xml:space="preserve"><value>Your Google photo couldn't be processed — unsupported format or bad response from Google.</value></data>
   <data name="ProfileEdit_DateOfBirthHelp" xml:space="preserve"><value>Only month and day are stored — we don't collect birth year.</value></data>
   <data name="Profile_Month" xml:space="preserve"><value>Month</value></data>
   <data name="Profile_Day" xml:space="preserve"><value>Day</value></data>

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -935,7 +935,6 @@
   <data name="Profile_DateOfBirth" xml:space="preserve"><value>Birthday</value></data>
   <data name="Profile_PictureTooLarge" xml:space="preserve"><value>Profile picture must be under 20MB.</value></data>
   <data name="Profile_PictureInvalidFormat" xml:space="preserve"><value>Profile picture must be JPEG, PNG, WebP, or HEIC format.</value></data>
-  <data name="ProfileEdit_GoogleAvatar" xml:space="preserve"><value>(Google avatar)</value></data>
   <data name="ProfileEdit_PictureHelp" xml:space="preserve"><value>Upload a JPEG, PNG, WebP, or HEIC image (max 20MB). Large images are automatically resized.</value></data>
   <data name="ProfileEdit_RemovePicture" xml:space="preserve"><value>Remove custom picture</value></data>
   <data name="ProfileEdit_ImportGooglePhoto" xml:space="preserve"><value>Import my Google photo</value></data>
@@ -946,6 +945,7 @@
   <data name="Profile_ImportGooglePhoto_AlreadyHasCustom" xml:space="preserve"><value>You already have a custom profile picture. Remove it first to import your Google photo.</value></data>
   <data name="Profile_ImportGooglePhoto_FetchFailed" xml:space="preserve"><value>We couldn't fetch your Google photo. Please try again later or upload one directly.</value></data>
   <data name="Profile_ImportGooglePhoto_InvalidFormat" xml:space="preserve"><value>Your Google photo couldn't be processed — unsupported format or bad response from Google.</value></data>
+  <data name="Profile_ImportGooglePhoto_NotGoogleUrl" xml:space="preserve"><value>We couldn't import your Google photo — the stored avatar URL doesn't look like a Google address. Please upload one directly instead.</value></data>
   <data name="ProfileEdit_DateOfBirthHelp" xml:space="preserve"><value>Only month and day are stored — we don't collect birth year.</value></data>
   <data name="Profile_Month" xml:space="preserve"><value>Month</value></data>
   <data name="Profile_Day" xml:space="preserve"><value>Day</value></data>

--- a/src/Humans.Web/TagHelpers/HumanLinkTagHelper.cs
+++ b/src/Humans.Web/TagHelpers/HumanLinkTagHelper.cs
@@ -1,4 +1,5 @@
 using System.Text.Encodings.Web;
+using Humans.Application.Interfaces.Profiles;
 using Humans.Application.Interfaces.Users;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
@@ -17,11 +18,16 @@ public class HumanLinkTagHelper : TagHelper
 {
     private readonly IUrlHelperFactory _urlHelperFactory;
     private readonly IUserService _userService;
+    private readonly IProfileService _profileService;
 
-    public HumanLinkTagHelper(IUrlHelperFactory urlHelperFactory, IUserService userService)
+    public HumanLinkTagHelper(
+        IUrlHelperFactory urlHelperFactory,
+        IUserService userService,
+        IProfileService profileService)
     {
         _urlHelperFactory = urlHelperFactory;
         _userService = userService;
+        _profileService = profileService;
     }
 
     [HtmlAttributeNotBound]
@@ -36,7 +42,12 @@ public class HumanLinkTagHelper : TagHelper
     [HtmlAttributeName("display-name")]
     public string DisplayName { get; set; } = "";
 
-    /// <summary>Profile picture URL (optional). If null, shows initial fallback.</summary>
+    /// <summary>
+    /// Profile picture URL. Deprecated — the tag helper now resolves the custom
+    /// profile picture URL internally from <see cref="IProfileService"/> by user id.
+    /// Passed values are ignored so that existing Google-avatar URLs threaded through
+    /// from view models never render (see issue #532). Retained for attribute-compat.
+    /// </summary>
     [HtmlAttributeName("profile-picture-url")]
     public string? ProfilePictureUrl { get; set; }
 
@@ -72,22 +83,40 @@ public class HumanLinkTagHelper : TagHelper
         if (output.TagName is null)
             return;
 
-        // Resolve display name and profile picture from cache when not explicitly provided
-        if (string.IsNullOrEmpty(DisplayName) && UserId != Guid.Empty)
+        // Resolve the effective profile picture URL from the Profile section (custom upload only).
+        // We ignore any inbound `profile-picture-url` value — many callers still thread Google
+        // avatar URLs through view models, which don't render reliably (see issue #532).
+        var urlHelper = _urlHelperFactory.GetUrlHelper(ViewContext);
+        string? resolvedPictureUrl = null;
+
+        if (UserId != Guid.Empty)
         {
-            var user = await _userService.GetByIdAsync(UserId);
-            if (user is not null)
+            var fullProfile = await _profileService.GetFullProfileAsync(UserId);
+            if (fullProfile is not null)
             {
-                DisplayName = user.DisplayName;
-                ProfilePictureUrl ??= user.ProfilePictureUrl;
+                if (string.IsNullOrEmpty(DisplayName))
+                {
+                    DisplayName = fullProfile.DisplayName;
+                }
+
+                if (fullProfile.HasCustomPicture && fullProfile.ProfileId != Guid.Empty)
+                {
+                    resolvedPictureUrl = urlHelper.Action(
+                        action: "Picture",
+                        controller: "Profile",
+                        values: new { id = fullProfile.ProfileId, v = fullProfile.UpdatedAtTicks });
+                }
             }
-            else
+            else if (string.IsNullOrEmpty(DisplayName))
             {
-                DisplayName = "Unknown";
+                // Fall back to the User row when the Profile isn't built yet (pre-onboarding).
+                var user = await _userService.GetByIdAsync(UserId);
+                DisplayName = user?.DisplayName ?? "Unknown";
             }
         }
 
-        var urlHelper = _urlHelperFactory.GetUrlHelper(ViewContext);
+        ProfilePictureUrl = resolvedPictureUrl;
+
         var href = Admin
             ? urlHelper.Action("AdminDetail", "Profile", new { id = UserId })
             : urlHelper.Action("ViewProfile", "Profile", new { id = UserId });

--- a/src/Humans.Web/ViewComponents/UserAvatarViewComponent.cs
+++ b/src/Humans.Web/ViewComponents/UserAvatarViewComponent.cs
@@ -10,9 +10,14 @@ namespace Humans.Web.ViewComponents;
 /// Renders a user's avatar by looking up all display data from the cached profile
 /// given only a user ID. Resolution precedence:
 /// 1. Custom uploaded picture (served via <c>/Profile/{profileId}/Picture</c>)
-/// 2. Google OAuth <c>User.ProfilePictureUrl</c>
-/// 3. Initial-letter fallback from the display name
+/// 2. Initial-letter fallback from the display name
 /// </summary>
+/// <remarks>
+/// Google OAuth avatar URLs are intentionally not used as a fallback — they frequently
+/// fail to load due to hotlink restrictions and format drift. Users who want their Google
+/// photo must import it once via the "Import my Google photo" button on <c>/Profile/Edit</c>.
+/// See issue #532.
+/// </remarks>
 public class UserAvatarViewComponent : ViewComponent
 {
     private readonly IProfileService _profileService;
@@ -46,11 +51,11 @@ public class UserAvatarViewComponent : ViewComponent
             }
             else if (IsCurrentUser(userId))
             {
-                // Onboarding/guest users have no Profile row yet. Fall back to the Google
-                // claims on the signed-in principal so their own avatar still renders in
-                // the nav and dashboard until a Profile is created.
+                // Onboarding/guest users have no Profile row yet. Use display name from the
+                // signed-in principal so the initial-letter placeholder still renders in the
+                // nav and dashboard until a Profile is created. No avatar URL until they
+                // upload a custom picture (or import their Google photo once the profile exists).
                 displayName = UserClaimsPrincipal.FindFirstValue(ClaimTypes.Name);
-                profilePictureUrl = UserClaimsPrincipal.FindFirstValue("urn:google:picture");
             }
         }
 
@@ -81,7 +86,8 @@ public class UserAvatarViewComponent : ViewComponent
                 values: new { id = fullProfile.ProfileId, v = fullProfile.UpdatedAtTicks });
         }
 
-        return fullProfile.ProfilePictureUrl;
+        // No Google URL fallback — see class-level remarks.
+        return null;
     }
 
     private bool IsCurrentUser(Guid userId)

--- a/src/Humans.Web/Views/Profile/Edit.cshtml
+++ b/src/Humans.Web/Views/Profile/Edit.cshtml
@@ -40,10 +40,6 @@
                         <div class="d-flex align-items-center gap-3 mb-2">
                             <vc:user-avatar user-id="@Model.UserId"
                                             size="80" />
-                            @if (!Model.HasCustomProfilePicture && !string.IsNullOrEmpty(Model.ProfilePictureUrl))
-                            {
-                                <span class="text-muted small">@Localizer["ProfileEdit_GoogleAvatar"]</span>
-                            }
                         </div>
                         <input type="file" asp-for="ProfilePictureUpload" class="form-control" accept="image/jpeg,image/png,image/webp,image/heic,image/heif,image/avif,.heic,.heif,.avif" />
                         <span asp-validation-for="ProfilePictureUpload" class="text-danger"></span>
@@ -56,6 +52,20 @@
                             </div>
                         }
                     </div>
+                    @if (Model.CanImportGooglePicture)
+                    {
+                        @* Submits to the sibling import form declared at the bottom of the
+                           view, using the HTML5 form attribute so we don't nest forms. *@
+                        <div class="mb-3">
+                            <button type="submit"
+                                    form="importGooglePhotoForm"
+                                    class="btn btn-outline-secondary btn-sm">
+                                <i class="fa-brands fa-google me-1"></i>
+                                @Localizer["ProfileEdit_ImportGooglePhoto"]
+                            </button>
+                            <div class="form-text">@Localizer["ProfileEdit_ImportGooglePhotoHelp"]</div>
+                        </div>
+                    }
 
                     <hr />
 
@@ -495,6 +505,14 @@
                 <button type="submit" class="btn btn-primary">@Localizer["Common_Save"]</button>
             </div>
         </form>
+
+        @* Sibling form targeted via the HTML5 form attribute on the Import button. Keeping
+           it out of the Edit form avoids form nesting and lets the import POST independently
+           (no profile fields shipped with the import click). *@
+        @if (Model.CanImportGooglePicture)
+        {
+            <form id="importGooglePhotoForm" asp-action="ImportGooglePhoto" method="post"></form>
+        }
     </div>
 </div>
 

--- a/tests/Humans.Application.Tests/Architecture/InterfaceMethodBudgetTests.cs
+++ b/tests/Humans.Application.Tests/Architecture/InterfaceMethodBudgetTests.cs
@@ -45,7 +45,7 @@ public class InterfaceMethodBudgetTests
         [typeof(ITeamService)] = 71,
         [typeof(ICampService)] = 53,
         [typeof(IShiftManagementService)] = 49,
-        // +1 for SetProfilePictureAsync (issue #532 — Google avatar import button needs a
+        // +1 for SetProfilePictureAsync (nobodies-collective/Humans#532 — Google avatar import button needs a
         // narrow service write that owns its own cache invalidation; controllers can't reach
         // the FullProfile cache directly).
         [typeof(IProfileService)] = 40,

--- a/tests/Humans.Application.Tests/Architecture/InterfaceMethodBudgetTests.cs
+++ b/tests/Humans.Application.Tests/Architecture/InterfaceMethodBudgetTests.cs
@@ -45,7 +45,10 @@ public class InterfaceMethodBudgetTests
         [typeof(ITeamService)] = 71,
         [typeof(ICampService)] = 53,
         [typeof(IShiftManagementService)] = 49,
-        [typeof(IProfileService)] = 39,
+        // +1 for SetProfilePictureAsync (issue #532 — Google avatar import button needs a
+        // narrow service write that owns its own cache invalidation; controllers can't reach
+        // the FullProfile cache directly).
+        [typeof(IProfileService)] = 40,
         [typeof(IUserService)] = 32,
     };
 

--- a/tests/Humans.Application.Tests/Helpers/ProfilePictureUrlHelperTests.cs
+++ b/tests/Humans.Application.Tests/Helpers/ProfilePictureUrlHelperTests.cs
@@ -1,0 +1,117 @@
+using AwesomeAssertions;
+using Humans.Application.Interfaces.Profiles;
+using Humans.Web.Helpers;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Routing;
+using NSubstitute;
+using Xunit;
+
+namespace Humans.Application.Tests.Helpers;
+
+/// <summary>
+/// Covers <see cref="ProfilePictureUrlHelper"/> in isolation. Issue #532: the helper must
+/// return custom-upload URLs or null, never Google avatar URLs.
+/// </summary>
+public class ProfilePictureUrlHelperTests
+{
+    [HumansFact]
+    public async Task BuildEffectiveUrlsAsync_EmptyInput_ReturnsEmptyDictionary()
+    {
+        var profileService = Substitute.For<IProfileService>();
+        var urlHelper = Substitute.For<IUrlHelper>();
+
+        var result = await ProfilePictureUrlHelper.BuildEffectiveUrlsAsync(
+            profileService, urlHelper, []);
+
+        result.Should().BeEmpty();
+
+        // No repository call should have fired — the helper short-circuits on empty input.
+        _ = profileService.DidNotReceiveWithAnyArgs().GetCustomPictureInfoByUserIdsAsync(
+            default!, default);
+    }
+
+    [HumansFact]
+    public async Task BuildEffectiveUrlsAsync_UserWithoutCustomPicture_ReturnsNull()
+    {
+        var userId = Guid.NewGuid();
+
+        var profileService = Substitute.For<IProfileService>();
+        profileService
+            .GetCustomPictureInfoByUserIdsAsync(Arg.Any<IEnumerable<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<(Guid ProfileId, Guid UserId, long UpdatedAtTicks)>>([]));
+
+        var urlHelper = Substitute.For<IUrlHelper>();
+
+        var result = await ProfilePictureUrlHelper.BuildEffectiveUrlsAsync(
+            profileService, urlHelper, [userId]);
+
+        result.Should().ContainKey(userId);
+        result[userId].Should().BeNull();
+    }
+
+    [HumansFact]
+    public async Task BuildEffectiveUrlsAsync_UserWithCustomPicture_ReturnsCustomUrl()
+    {
+        var userId = Guid.NewGuid();
+        var profileId = Guid.NewGuid();
+        const long updatedAtTicks = 123456L;
+        const string expectedUrl = "/Profile/Picture?id=profile-id&v=123456";
+
+        var profileService = Substitute.For<IProfileService>();
+        profileService
+            .GetCustomPictureInfoByUserIdsAsync(Arg.Any<IEnumerable<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<(Guid ProfileId, Guid UserId, long UpdatedAtTicks)>>(
+                [(profileId, userId, updatedAtTicks)]));
+
+        var urlHelper = Substitute.For<IUrlHelper>();
+        urlHelper.Action(Arg.Any<UrlActionContext>()).Returns(expectedUrl);
+
+        var result = await ProfilePictureUrlHelper.BuildEffectiveUrlsAsync(
+            profileService, urlHelper, [userId]);
+
+        result.Should().ContainKey(userId);
+        result[userId].Should().Be(expectedUrl);
+    }
+
+    [HumansFact]
+    public async Task BuildEffectiveUrlsAsync_MixedUsers_ReturnsUrlOrNullPerUser()
+    {
+        var userWithCustom = Guid.NewGuid();
+        var userWithoutCustom = Guid.NewGuid();
+        var profileId = Guid.NewGuid();
+
+        var profileService = Substitute.For<IProfileService>();
+        profileService
+            .GetCustomPictureInfoByUserIdsAsync(Arg.Any<IEnumerable<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<(Guid ProfileId, Guid UserId, long UpdatedAtTicks)>>(
+                [(profileId, userWithCustom, 42L)]));
+
+        var urlHelper = Substitute.For<IUrlHelper>();
+        urlHelper.Action(Arg.Any<UrlActionContext>()).Returns("/custom-url");
+
+        var result = await ProfilePictureUrlHelper.BuildEffectiveUrlsAsync(
+            profileService, urlHelper, [userWithCustom, userWithoutCustom]);
+
+        result[userWithCustom].Should().Be("/custom-url");
+        result[userWithoutCustom].Should().BeNull();
+    }
+
+    [HumansFact]
+    public async Task BuildEffectiveUrlsAsync_DuplicateUserIds_AreDeduplicated()
+    {
+        var userId = Guid.NewGuid();
+
+        var profileService = Substitute.For<IProfileService>();
+        profileService
+            .GetCustomPictureInfoByUserIdsAsync(Arg.Any<IEnumerable<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<(Guid ProfileId, Guid UserId, long UpdatedAtTicks)>>([]));
+
+        var urlHelper = Substitute.For<IUrlHelper>();
+
+        var result = await ProfilePictureUrlHelper.BuildEffectiveUrlsAsync(
+            profileService, urlHelper, [userId, userId, userId]);
+
+        result.Should().HaveCount(1);
+        result[userId].Should().BeNull();
+    }
+}


### PR DESCRIPTION
Closes nobodies-collective/Humans#532

## Summary

Google avatar URLs (`User.ProfilePictureUrl`) don't render reliably across views — Google restricts hotlinking and URL formats drift. This PR stops rendering them entirely and offers a one-time import button so users can copy their Google photo into the existing custom-upload pipeline.

## What changed

- **Helper** — `ProfilePictureUrlHelper.BuildEffectiveUrlsAsync` takes user IDs and returns custom-upload URL or null. Google URL parameter gone.
- **Avatar rendering** — `UserAvatarViewComponent` drops the Google fallback. `HumanLinkTagHelper` always resolves the URL internally via `IProfileService` (FullProfile dict cache) and ignores any passed `profile-picture-url` attribute, so views still threading Google URLs through view models render correctly without per-view edits.
- **Import action** — new `POST /Profile/Me/ImportGooglePhoto` fetches the Google URL via a named `HttpClient` (10s timeout), validates content type, resizes through the existing `ProfilePictureProcessor`, persists via a new `IProfileService.SetProfilePictureAsync` that invalidates the FullProfile cache through the decorator. Clear, localized error messages for fetch failure, bad format, already-has-custom, etc.
- **Edit view** — button is visible only when the user has a Google login, a captured avatar URL, and no custom picture. It lives in a sibling `<form>` targeted by the HTML5 `form="..."` attribute on the button, so no nested forms and no profile fields are POSTed with the import click.
- **Sign-in** — `AccountController.ExternalLoginCallback` logs once per sign-in whether the Google avatar URL was captured (not captured otherwise), for future debugging.
- **Localization** — new keys across all six `SharedResource.*.resx` files (en, es, ca, fr, de, it). Cleaned up the existing Picture help/remove copy that mentioned reverting to the Google avatar.
- **Tests** — `ProfilePictureUrlHelperTests` covers empty input, no-custom-picture, custom picture present, mixed users, and duplicate user ids.

## Test plan
- [ ] Sign in via Google, visit `/Profile/Me/Edit` — button is visible only when no custom picture exists.
- [ ] Click Import — photo downloads, resizes to JPEG, appears immediately as the avatar across the app.
- [ ] Upload a custom picture — button disappears.
- [ ] Remove the custom picture — button reappears (if still signed in via Google).
- [ ] Non-Google user (magic link only) — button is never shown.
- [ ] Network error from Google — user sees the fetch-failed message, no crash.

## Follow-up

Dropping the `User.ProfilePictureUrl` column entirely is a separate, isolated PR — this change leaves the column populated but unreferenced at render time, which is the minimum needed to fix the visible breakage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)