### PR TITLE
Auto Consent Check via LLM + hold list (closes #485)

### DIFF
--- a/docs/features/auto-consent-check.md
+++ b/docs/features/auto-consent-check.md
@@ -1,0 +1,124 @@
+# Auto Consent Check (LLM-backed)
+
+## Business Context
+
+The Consent Check is the final step of the standard onboarding pipeline: after a new human has completed their profile and signed all required legal documents, a Consent Coordinator reviews the profile before the human is auto-approved as a Volunteer. In practice the overwhelming majority of these reviews are rubber-stamps — the legal name looks like a real name and nothing about the profile is concerning. The Consent Coordinator's real value is catching the rare case that *isn't* routine (profanity, impersonation, a specific individual that needs human attention).
+
+This feature automates the rubber-stamp cases with an LLM and keeps the manual-review queue clear for the interesting ones. It ONLY ever approves — it never flags, never rejects, never downgrades any profile. If the model isn't confident, or the API is unavailable, or anything else goes wrong, the entry is left exactly where it was and a human reviews it as before.
+
+## Scope — what the job does / doesn't do
+
+**Does:**
+- Polls the Consent Check = Pending queue every 15 minutes.
+- For each entry, asks Claude Haiku two questions: does the legal name look like a real human name, and does it match any entry on the admin-maintained hold list?
+- If the answer to both is "clean" (plausible real name AND no hold-list match), clears the consent check on behalf of the system — audit action `ConsentCheckAutoCleared`, actor recorded as the job name, `ConsentCheckedByUserId` left null.
+- Continues the normal post-clear flow: `IsApproved = true`, nav/notification cache invalidation, `IFullProfileInvalidator` refresh, Volunteers team sync, Colaborador/Asociado sync if relevant.
+- Audits every decision (cleared or skipped) with the model id and the LLM's stated reason.
+
+**Does NOT:**
+- Flag profiles. The manual flag path (`IOnboardingService.FlagConsentCheckAsync`) is still the only way a profile ends up in the Flagged bucket.
+- Reject profiles. Rejection remains a Board/Admin action.
+- Call the LLM if the kill switch is set to `None`.
+- Touch profiles in any state other than `ConsentCheckStatus = Pending, IsApproved = false, RejectedAt = null`.
+- Persist any human text from the LLM in a user-facing field. The reason is stored only in the internal `ConsentCheckNotes` (admin-visible) and in the audit log.
+
+## Third-Party Processing Disclosure (GDPR)
+
+The LLM assistant sends the human's **legal name** (first + last) and the full admin-maintained hold list to Anthropic's Claude API. Anthropic acts as a **third-party processor** for the purpose of evaluating the name. No other personal data is transmitted — not email, not city, not IP, not profile picture, not contact fields.
+
+Per Anthropic's current published policy, API requests are not used to train models by default and are retained only for a short abuse-monitoring window. Operators deploying this system are responsible for confirming the up-to-date processor terms match their data-protection agreements with humans (Article 28 GDPR). If this disclosure is unacceptable, set `SyncServiceType.AutoConsentCheck` to `None` at `/Google/SyncSettings` — the job will skip without any outbound traffic and the manual Consent Check flow continues as before.
+
+## Workflow
+
+```
+Every 15 min (cron */15)
+    │
+    ▼
+AutoConsentCheckJob
+    │
+    ├── Kill switch: SyncMode.None → log + exit
+    │
+    ├── Load pending userIds: IOnboardingService.GetPendingConsentCheckUserIdsAsync
+    ├── Load hold list:       IConsentHoldListService.ListAsync
+    ├── Batch-load profiles:  IProfileService.GetByUserIdsAsync
+    │
+    ▼ for each pending user
+    │
+    ├── legalName = FirstName + ' ' + LastName
+    ├── verdict = IConsentCheckAssistant.EvaluateAsync(legalName, holdList)
+    │       ↓ HTTP POST https://api.anthropic.com/v1/messages
+    │       ↓ model: claude-haiku-4-5 (configurable)
+    │       ↓ 10s timeout, 1 retry on 5xx / 429 / timeout
+    │       ↓ parse strict JSON: { plausible_real_name, hold_list_match, reason }
+    │
+    ├── if PlausibleRealName && !HoldListMatch:
+    │       IOnboardingService.AutoClearConsentCheckAsync
+    │           → sets Cleared + IsApproved=true, audit ConsentCheckAutoCleared
+    │           → triggers Volunteers team sync
+    │
+    └── else (or any exception):
+            audit ConsentCheckAutoSkipped with the reason + model id
+            leave entry in the manual queue
+```
+
+## Data Model
+
+### `ConsentHoldListEntry` (table `consent_hold_list`)
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `Id` | `int` (auto-inc PK) | |
+| `Entry` | `string` required, max 500 | Free-form name/alias text. |
+| `Note` | `string?` max 2000 | Admin-only context about why this entry exists. |
+| `AddedByUserId` | `Guid` | FK to `users`, `OnDelete: Restrict`. |
+| `AddedAt` | `NodaTime.Instant` | |
+
+### Audit entries
+
+| Action | Written by | Actor |
+|--------|-----------|-------|
+| `ConsentHoldListEntryAdded` | `ConsentHoldListService.AddAsync` | Admin user |
+| `ConsentHoldListEntryRemoved` | `ConsentHoldListService.DeleteAsync` | Admin user |
+| `ConsentCheckAutoCleared` | `OnboardingService.AutoClearConsentCheckAsync` | `AutoConsentCheckJob` (job name, no actor) |
+| `ConsentCheckAutoSkipped` | `AutoConsentCheckJob` (direct) | `AutoConsentCheckJob` |
+
+## Configuration
+
+| Key | Meaning |
+|-----|---------|
+| `Anthropic:ApiKey` (env `Anthropic__ApiKey`) | Anthropic API key. Required for the assistant; without it calls throw and every run skips. Treat as a secret. |
+| `Anthropic:Model` | Optional. Defaults to `claude-haiku-4-5`. Override for canary testing of newer Haiku versions. |
+| `SyncServiceType.AutoConsentCheck` at `/Google/SyncSettings` | Kill switch. `None` = job exits immediately. Anything else (e.g. `AddOnly`, `AddAndRemove`) = enabled. The Add/Remove semantics are meaningless for this service; any non-None value is treated as "on". |
+
+The Admin Configuration page (`/Admin/Configuration`) shows whether `Anthropic:ApiKey` is set. The key is marked sensitive and never displayed.
+
+## Admin UI
+
+- `/Admin/ConsentHoldList` — list, add, remove hold-list entries. Admin-only. Linked from `/Admin` (Admin Tools landing page).
+
+## Failure modes
+
+| Failure | Behaviour |
+|---------|-----------|
+| API key missing | `EvaluateAsync` throws; job logs warning and skips the entry; no outbound traffic. |
+| HTTP 5xx / 429 | One retry; if still failing, skip the entry. Audit `ConsentCheckAutoSkipped` not written (we only audit LLM-returned verdicts, not transport errors — the job logs them). |
+| HTTP 4xx | No retry. Skip the entry with a logged warning. |
+| Timeout (10s) | One retry. If still timing out, skip the entry. |
+| Malformed JSON in response | Skip the entry with a logged warning. |
+| LLM returns `plausible_real_name = false` | Skip, audit `ConsentCheckAutoSkipped`. Manual reviewer handles it. |
+| LLM returns `hold_list_match = true` | Skip, audit `ConsentCheckAutoSkipped`. Manual reviewer handles it. |
+| `AutoClearConsentCheckAsync` returns non-success | Skip with a logged warning (e.g. profile was rejected or cleared between queue fetch and approval). |
+
+## Open design notes / deferrals
+
+- **No per-run cost cap.** At our scale (target ~500 humans total, ~a few new signups per week) and Haiku pricing, the unconstrained cost is negligible. If traffic rises, a simple per-run ceiling should go in the job before the LLM loop. TODO tracked in the PR description.
+- **Retroactive backlog.** On first deploy, the job will pick up every Pending entry that already exists. This is intentional — the backlog is exactly the workload the feature is meant to reduce.
+- **Hold list seeding.** The list starts empty. Admins add entries as specific situations arise.
+- **No standalone metric counter.** The existing `IHumansMetrics.RecordJobRun("auto_consent_check", ...)` covers job-level success/failure. Per-verdict counters can be added later if the auto-clear rate becomes a thing to tune.
+
+## Related Features
+
+- `docs/features/16-onboarding-pipeline.md` — the broader onboarding flow this fits into.
+- `docs/features/17-coordinator-roles.md` — ConsentCoordinator role whose workload this reduces.
+- `docs/sections/onboarding.md` — section invariants, triggers, negative rules.
+- `docs/features/12-audit-log.md` — where the four new AuditAction values land.

--- a/docs/sections/Onboarding.md
+++ b/docs/sections/Onboarding.md
@@ -34,6 +34,8 @@ The only onboarding-specific value type is the narrow `IOnboardingEligibilityQue
 - OAuth login checks verified UserEmails, unverified UserEmails, and User.Email before creating a new account — preventing duplicate accounts when the same email exists on another user in any form.
 - `OnboardingService` depends only on interfaces (plus `IClock`) — no `DbContext`, `IDbContextFactory`, `DbSet<T>`, `IMemoryCache`, `IFullProfileInvalidator`, or repository. Enforced by `OnboardingArchitectureTests`.
 - The DI cycle between `OnboardingService` and `ProfileService` / `ConsentService` is broken by the narrow `IOnboardingEligibilityQuery` interface (`SetConsentCheckPendingIfEligibleAsync(userId, ct)`). `OnboardingService` implements it; Profile and Consent depend on it instead of the full `IOnboardingService`.
+- **Consent Check auto-approval:** An LLM-backed job (`AutoConsentCheckJob`, every 15 min) may auto-approve Consent Check = Pending profiles. The job ONLY approves — it never flags, never rejects, never sets a profile to Flagged. A failure (LLM error / timeout) leaves the entry in the manual queue for a human Consent Coordinator. See `docs/features/auto-consent-check.md`.
+- **Consent Hold List invariant:** Entries on the admin-maintained hold list (`/Admin/ConsentHoldList`) suppress auto-approval for names that match. A hold-list match does NOT block manual approval — a human coordinator can still approve. The list is never shown to non-admin users.
 
 ## Negative Access Rules
 
@@ -49,6 +51,7 @@ The only onboarding-specific value type is the narrow `IOnboardingEligibilityQue
 - When a legal document is signed: the system checks if the profile is also approved. If both conditions are met, the human is added to the Volunteers team.
 - When a consent check is flagged: onboarding is blocked. Board or Admin must review.
 - When a signup is rejected: the rejection reason and timestamp are recorded on the profile. The human is notified.
+- When `AutoConsentCheckJob` runs and `SyncServiceType.AutoConsentCheck` is not `None`: every Pending consent-check profile is evaluated by the LLM. Clean verdicts (`PlausibleRealName && !HoldListMatch`) trigger `IOnboardingService.AutoClearConsentCheckAsync`, which has the same effect as a human clear except the audit action is `ConsentCheckAutoCleared` and `ConsentCheckedByUserId` is left null. Every non-clear verdict and every LLM failure is audited as `ConsentCheckAutoSkipped` and leaves the entry in the manual queue.
 
 ## Cross-Section Dependencies
 

--- a/src/Humans.Application/DTOs/ConsentCheckVerdict.cs
+++ b/src/Humans.Application/DTOs/ConsentCheckVerdict.cs
@@ -1,0 +1,30 @@
+namespace Humans.Application.DTOs;
+
+/// <summary>
+/// Result of an LLM-based Consent Check evaluation. The LLM is asked to answer
+/// two yes/no questions: does the legal name look like a plausible real name,
+/// and does it match any entry on the hold list. The job uses both answers to
+/// decide whether to auto-approve the pending onboarding review.
+/// </summary>
+/// <param name="PlausibleRealName">
+/// True if the legal name looks like a plausible real human name (not an obvious
+/// placeholder, not profane, not a celebrity / historical figure, etc.).
+/// </param>
+/// <param name="HoldListMatch">
+/// True if the legal name matches any entry on the supplied hold list (fuzzy
+/// match, case-insensitive, tolerant of accent/ordering differences).
+/// </param>
+/// <param name="Reason">
+/// Short explanation the LLM provided. Stored verbatim in the audit log so a
+/// human reviewer can understand why the auto-approval did or did not fire.
+/// </param>
+/// <param name="ModelId">
+/// The model identifier reported by the API (e.g. "claude-haiku-4-5-20251001").
+/// Captured in the audit trail to make retroactive quality analysis possible
+/// when Anthropic releases new Haiku versions.
+/// </param>
+public sealed record ConsentCheckVerdict(
+    bool PlausibleRealName,
+    bool HoldListMatch,
+    string Reason,
+    string ModelId);

--- a/src/Humans.Application/Interfaces/IConsentCheckAssistant.cs
+++ b/src/Humans.Application/Interfaces/IConsentCheckAssistant.cs
@@ -1,0 +1,26 @@
+using Humans.Application.DTOs;
+
+namespace Humans.Application.Interfaces;
+
+/// <summary>
+/// LLM-backed assistant that evaluates whether a pending Consent Check entry
+/// is safe to auto-approve. Implementations call an external service (Anthropic)
+/// and therefore MUST enforce a short timeout and a single retry. Failures
+/// (timeout, HTTP error, malformed JSON) are surfaced as exceptions so the
+/// calling job can skip the entry and leave it in the manual queue.
+/// </summary>
+public interface IConsentCheckAssistant
+{
+    /// <summary>
+    /// Ask the LLM to evaluate a single human's legal name.
+    /// </summary>
+    /// <param name="legalName">The human's legal first + last name (from Profile).</param>
+    /// <param name="holdList">Admin-maintained list of names/aliases to flag.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A <see cref="ConsentCheckVerdict"/>.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when the API is not configured.</exception>
+    Task<ConsentCheckVerdict> EvaluateAsync(
+        string legalName,
+        IReadOnlyList<string> holdList,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Humans.Application/Interfaces/IConsentHoldListService.cs
+++ b/src/Humans.Application/Interfaces/IConsentHoldListService.cs
@@ -1,0 +1,20 @@
+using Humans.Domain.Entities;
+
+namespace Humans.Application.Interfaces;
+
+/// <summary>
+/// Admin-only CRUD over the Consent Hold List. Entries on the hold list are
+/// consulted by the auto Consent Check job — a name match blocks auto-approval
+/// and leaves the entry in the manual review queue. See docs/features/auto-consent-check.md.
+/// </summary>
+public interface IConsentHoldListService
+{
+    /// <summary>Returns all hold-list entries ordered by most recently added first.</summary>
+    Task<IReadOnlyList<ConsentHoldListEntry>> ListAsync(CancellationToken ct = default);
+
+    /// <summary>Adds a new hold-list entry. Writes an audit log entry.</summary>
+    Task<ConsentHoldListEntry> AddAsync(string entry, string? note, Guid addedByUserId, CancellationToken ct = default);
+
+    /// <summary>Removes a hold-list entry by id. Writes an audit log entry. No-op if the entry doesn't exist.</summary>
+    Task DeleteAsync(int id, Guid actingUserId, CancellationToken ct = default);
+}

--- a/src/Humans.Application/Interfaces/Onboarding/IOnboardingService.cs
+++ b/src/Humans.Application/Interfaces/Onboarding/IOnboardingService.cs
@@ -21,6 +21,17 @@ public interface IOnboardingService : IOnboardingEligibilityQuery
     Task<OnboardingResult> FlagConsentCheckAsync(
         Guid userId, Guid reviewerId, string? notes, CancellationToken ct = default);
 
+    /// <summary>
+    /// Auto-clear a pending consent check on behalf of the system (no human reviewer).
+    /// Used by <c>AutoConsentCheckJob</c> after the LLM assistant gives a clean verdict.
+    /// Same semantics as <see cref="ClearConsentCheckAsync"/> (IsApproved=true, cache
+    /// eviction, Volunteers team sync) but audited as
+    /// <see cref="Humans.Domain.Enums.AuditAction.ConsentCheckAutoCleared"/> with the
+    /// job name as the actor, and no ConsentCheckedByUserId set.
+    /// </summary>
+    Task<OnboardingResult> AutoClearConsentCheckAsync(
+        Guid userId, string reason, string modelId, CancellationToken ct = default);
+
     // --- Board vote ---
     Task<bool> HasBoardVotesAsync(Guid applicationId, CancellationToken ct = default);
     Task<OnboardingResult> CastBoardVoteAsync(
@@ -39,6 +50,12 @@ public interface IOnboardingService : IOnboardingEligibilityQuery
         Guid userId, Guid adminId, string? notes, CancellationToken ct = default);
     Task<OnboardingResult> UnsuspendAsync(
         Guid userId, Guid adminId, CancellationToken ct = default);
+
+    /// <summary>
+    /// UserIds of profiles currently sitting in the Consent Check = Pending bucket
+    /// (not yet cleared, not flagged, not rejected). Used by AutoConsentCheckJob.
+    /// </summary>
+    Task<IReadOnlyList<Guid>> GetPendingConsentCheckUserIdsAsync(CancellationToken ct = default);
 
     // --- Badge counts ---
     /// <summary>

--- a/src/Humans.Application/Interfaces/Profiles/IProfileService.cs
+++ b/src/Humans.Application/Interfaces/Profiles/IProfileService.cs
@@ -158,6 +158,25 @@ public interface IProfileService
         Guid userId, Guid reviewerId, string? notes, CancellationToken ct = default);
 
     /// <summary>
+    /// Auto-clear a pending consent check on behalf of the system (no human reviewer).
+    /// Mirrors <see cref="ClearConsentCheckAsync"/> in side effects (IsApproved=true,
+    /// status=Cleared) but leaves <c>ConsentCheckedByUserId</c> null and audits as
+    /// <see cref="Humans.Domain.Enums.AuditAction.ConsentCheckAutoCleared"/> with
+    /// <paramref name="actorName"/> as the actor. Only succeeds when the profile
+    /// is currently in <see cref="ConsentCheckStatus.Pending"/>.
+    /// Error keys: <c>NotFound</c>, <c>AlreadyRejected</c>, <c>NotPending</c>.
+    /// </summary>
+    Task<OnboardingResult> AutoClearConsentCheckAsync(
+        Guid userId, string reason, string modelId, string actorName, CancellationToken ct = default);
+
+    /// <summary>
+    /// User ids of profiles currently sitting in the Consent Check = Pending
+    /// bucket (not yet cleared, not flagged, not rejected). Used by
+    /// <c>AutoConsentCheckJob</c> to enumerate the queue.
+    /// </summary>
+    Task<IReadOnlyList<Guid>> GetPendingConsentCheckUserIdsAsync(CancellationToken ct = default);
+
+    /// <summary>
     /// Rejects a signup (records rejection reason, sets RejectedAt).
     /// Error keys: <c>NotFound</c>, <c>AlreadyRejected</c>.
     /// </summary>

--- a/src/Humans.Application/Interfaces/Repositories/IProfileRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/IProfileRepository.cs
@@ -94,6 +94,14 @@ public interface IProfileRepository
     Task<int> GetReviewableCountAsync(CancellationToken ct = default);
 
     /// <summary>
+    /// Returns user ids of profiles whose <c>ConsentCheckStatus</c> is
+    /// <c>Pending</c> and whose profile is not approved and not rejected.
+    /// Ordered by <c>CreatedAt</c> ascending. Used by the auto-consent-check
+    /// job to enumerate the manual review queue.
+    /// </summary>
+    Task<IReadOnlyList<Guid>> GetPendingConsentCheckUserIdsAsync(CancellationToken ct = default);
+
+    /// <summary>
     /// Returns the user ids of every approved, non-suspended profile. Used
     /// by the admin dashboard to compute active-user aggregates without
     /// loading the full Profile graph.

--- a/src/Humans.Application/Services/Onboarding/OnboardingService.cs
+++ b/src/Humans.Application/Services/Onboarding/OnboardingService.cs
@@ -168,6 +168,36 @@ public sealed class OnboardingService : IOnboardingService
         return result;
     }
 
+    public async Task<OnboardingResult> AutoClearConsentCheckAsync(
+        Guid userId, string reason, string modelId, CancellationToken ct = default)
+    {
+        // Profile mutation + cache invalidation owned by ProfileService/decorator.
+        // Audit log actor is the job name (no human reviewer for system clears).
+        var result = await _profileService.AutoClearConsentCheckAsync(
+            userId, reason, modelId, "AutoConsentCheckJob", ct);
+        if (!result.Success)
+            return result;
+
+        // Sync Volunteers team membership (adds to team if consents are also complete)
+        await _syncJob.SyncVolunteersMembershipForUserAsync(userId, CancellationToken.None);
+
+        // If user already has approved tier applications, sync those teams too.
+        var approvedTiers = await _applicationDecisionService.GetApprovedTiersForUserAsync(userId, ct);
+
+        foreach (var tier in approvedTiers)
+        {
+            if (tier == MembershipTier.Colaborador)
+                await _syncJob.SyncColaboradorsMembershipForUserAsync(userId, CancellationToken.None);
+            else if (tier == MembershipTier.Asociado)
+                await _syncJob.SyncAsociadosMembershipForUserAsync(userId, CancellationToken.None);
+        }
+
+        return result;
+    }
+
+    public Task<IReadOnlyList<Guid>> GetPendingConsentCheckUserIdsAsync(CancellationToken ct = default) =>
+        _profileService.GetPendingConsentCheckUserIdsAsync(ct);
+
     // ==========================================================================
     // Board vote
     // ==========================================================================

--- a/src/Humans.Application/Services/Profile/ProfileService.cs
+++ b/src/Humans.Application/Services/Profile/ProfileService.cs
@@ -882,6 +882,46 @@ public sealed class ProfileService : IProfileService, IUserDataContributor
         return new OnboardingResult(true);
     }
 
+    public async Task<OnboardingResult> AutoClearConsentCheckAsync(
+        Guid userId, string reason, string modelId, string actorName, CancellationToken ct = default)
+    {
+        var profile = await _profileRepository.GetByUserIdAsync(userId, ct);
+        if (profile is null)
+            return new OnboardingResult(false, "NotFound");
+
+        if (profile.RejectedAt is not null)
+            return new OnboardingResult(false, "AlreadyRejected");
+
+        if (profile.ConsentCheckStatus is not ConsentCheckStatus.Pending)
+            return new OnboardingResult(false, "NotPending");
+
+        var now = _clock.GetCurrentInstant();
+
+        profile.ConsentCheckStatus = ConsentCheckStatus.Cleared;
+        profile.ConsentCheckAt = now;
+        // No ConsentCheckedByUserId — the system (LLM) cleared this, not a human reviewer.
+        profile.ConsentCheckedByUserId = null;
+        profile.ConsentCheckNotes = $"Auto-approved by {modelId}: {reason}";
+        profile.IsApproved = true;
+        profile.UpdatedAt = now;
+
+        await _profileRepository.UpdateAsync(profile, ct);
+
+        await _auditLogService.LogAsync(
+            AuditAction.ConsentCheckAutoCleared, nameof(Domain.Entities.Profile), userId,
+            $"Consent check auto-cleared by {modelId}: {reason}",
+            actorName);
+
+        _logger.LogInformation(
+            "Consent check auto-cleared for user {UserId} by model {ModelId}: {Reason}",
+            userId, modelId, reason);
+
+        return new OnboardingResult(true);
+    }
+
+    public Task<IReadOnlyList<Guid>> GetPendingConsentCheckUserIdsAsync(CancellationToken ct = default) =>
+        _profileRepository.GetPendingConsentCheckUserIdsAsync(ct);
+
     public async Task<OnboardingResult> RejectSignupAsync(
         Guid userId, Guid reviewerId, string? reason, CancellationToken ct = default)
     {

--- a/src/Humans.Domain/Entities/ConsentHoldListEntry.cs
+++ b/src/Humans.Domain/Entities/ConsentHoldListEntry.cs
@@ -1,0 +1,39 @@
+using NodaTime;
+
+namespace Humans.Domain.Entities;
+
+/// <summary>
+/// An entry on the Consent Hold List. If a pending human's legal name matches
+/// one of these entries (per the LLM auto-approval job), the human is NOT
+/// auto-approved and must be reviewed by a Consent Coordinator manually.
+/// Admin-only CRUD.
+/// </summary>
+public class ConsentHoldListEntry
+{
+    /// <summary>
+    /// Auto-increment primary key.
+    /// </summary>
+    public int Id { get; init; }
+
+    /// <summary>
+    /// Free-form name / alias text to match against incoming legal names.
+    /// Case-insensitive match semantics are handled by the LLM, not by SQL.
+    /// </summary>
+    public string Entry { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Optional admin note explaining why this entry is on the list.
+    /// Never shown to humans (non-admin) — internal only.
+    /// </summary>
+    public string? Note { get; set; }
+
+    /// <summary>
+    /// FK to the User (AspNetUsers) that added this entry.
+    /// </summary>
+    public Guid AddedByUserId { get; init; }
+
+    /// <summary>
+    /// When this entry was added.
+    /// </summary>
+    public Instant AddedAt { get; init; }
+}

--- a/src/Humans.Domain/Enums/AuditAction.cs
+++ b/src/Humans.Domain/Enums/AuditAction.cs
@@ -86,4 +86,8 @@ public enum AuditAction
     CampMemberWithdrawn,
     CampMemberLeft,
     CampMemberRemoved,
+    ConsentHoldListEntryAdded,
+    ConsentHoldListEntryRemoved,
+    ConsentCheckAutoCleared,
+    ConsentCheckAutoSkipped,
 }

--- a/src/Humans.Domain/Enums/SyncServiceType.cs
+++ b/src/Humans.Domain/Enums/SyncServiceType.cs
@@ -7,5 +7,10 @@ public enum SyncServiceType
 {
     GoogleDrive = 0,
     GoogleGroups = 1,
-    Discord = 2
+    Discord = 2,
+    /// <summary>
+    /// LLM-powered auto-approval of the Consent Check onboarding review step.
+    /// <see cref="SyncMode.None"/> means disabled; anything else means enabled.
+    /// </summary>
+    AutoConsentCheck = 3,
 }

--- a/src/Humans.Infrastructure/Data/Configurations/ConsentHoldListEntryConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/ConsentHoldListEntryConfiguration.cs
@@ -1,0 +1,34 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Humans.Domain.Entities;
+
+namespace Humans.Infrastructure.Data.Configurations;
+
+public class ConsentHoldListEntryConfiguration : IEntityTypeConfiguration<ConsentHoldListEntry>
+{
+    public void Configure(EntityTypeBuilder<ConsentHoldListEntry> builder)
+    {
+        builder.ToTable("consent_hold_list");
+
+        builder.HasKey(e => e.Id);
+
+        builder.Property(e => e.Entry)
+            .IsRequired()
+            .HasMaxLength(500);
+
+        builder.Property(e => e.Note)
+            .HasMaxLength(2000);
+
+        builder.Property(e => e.AddedByUserId)
+            .IsRequired();
+
+        builder.Property(e => e.AddedAt)
+            .IsRequired();
+
+        // FK-only to User — no nav property on the User side.
+        builder.HasOne<User>()
+            .WithMany()
+            .HasForeignKey(e => e.AddedByUserId)
+            .OnDelete(DeleteBehavior.Restrict);
+    }
+}

--- a/src/Humans.Infrastructure/Data/Configurations/SyncServiceSettingsConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/SyncServiceSettingsConfiguration.cs
@@ -60,6 +60,13 @@ public class SyncServiceSettingsConfiguration : IEntityTypeConfiguration<SyncSer
                 ServiceType = SyncServiceType.Discord,
                 SyncMode = SyncMode.None,
                 UpdatedAt = SeedTimestamp,
+            },
+            new
+            {
+                Id = Guid.Parse("00000000-0000-0000-0002-000000000004"),
+                ServiceType = SyncServiceType.AutoConsentCheck,
+                SyncMode = SyncMode.None,
+                UpdatedAt = SeedTimestamp,
             });
     }
 }

--- a/src/Humans.Infrastructure/Data/HumansDbContext.cs
+++ b/src/Humans.Infrastructure/Data/HumansDbContext.cs
@@ -82,6 +82,7 @@ public class HumansDbContext : IdentityDbContext<User, IdentityRole<Guid>, Guid>
     public DbSet<NotificationRecipient> NotificationRecipients => Set<NotificationRecipient>();
     public DbSet<ProfileLanguage> ProfileLanguages => Set<ProfileLanguage>();
     public DbSet<EventParticipation> EventParticipations => Set<EventParticipation>();
+    public DbSet<ConsentHoldListEntry> ConsentHoldListEntries => Set<ConsentHoldListEntry>();
 
     protected override void OnModelCreating(ModelBuilder builder)
     {

--- a/src/Humans.Infrastructure/Jobs/AutoConsentCheckJob.cs
+++ b/src/Humans.Infrastructure/Jobs/AutoConsentCheckJob.cs
@@ -1,0 +1,221 @@
+using Microsoft.Extensions.Logging;
+using NodaTime;
+using Humans.Application.DTOs;
+using Humans.Application.Interfaces;
+using Humans.Application.Interfaces.AuditLog;
+using Humans.Application.Interfaces.GoogleIntegration;
+using Humans.Application.Interfaces.Onboarding;
+using Humans.Application.Interfaces.Profiles;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using Humans.Infrastructure.Data;
+
+namespace Humans.Infrastructure.Jobs;
+
+/// <summary>
+/// Hangfire job: for every human sitting in the Consent Check = Pending bucket,
+/// ask the LLM whether their legal name (a) looks like a plausible real name and
+/// (b) matches the admin-maintained hold list. If both checks pass, auto-clear the
+/// consent check on their behalf. Otherwise, leave the entry in the manual review
+/// queue untouched — a human Consent Coordinator will look at it.
+///
+/// Only ever APPROVES. Never flags, never rejects. Failures (LLM timeout, API
+/// error, malformed response) leave the entry in the queue.
+///
+/// Kill switch: set <see cref="SyncServiceType.AutoConsentCheck"/> to
+/// <see cref="SyncMode.None"/> at /Google/SyncSettings (the shared admin
+/// SyncSettings page) to disable without redeploying.
+/// </summary>
+public class AutoConsentCheckJob : IRecurringJob
+{
+    private readonly IOnboardingService _onboardingService;
+    private readonly IConsentHoldListService _holdListService;
+    private readonly IConsentCheckAssistant _assistant;
+    private readonly IProfileService _profileService;
+    private readonly IAuditLogService _auditLogService;
+    private readonly ISyncSettingsService _syncSettingsService;
+    private readonly HumansDbContext _dbContext;
+    private readonly IHumansMetrics _metrics;
+    private readonly IClock _clock;
+    private readonly ILogger<AutoConsentCheckJob> _logger;
+
+    public AutoConsentCheckJob(
+        IOnboardingService onboardingService,
+        IConsentHoldListService holdListService,
+        IConsentCheckAssistant assistant,
+        IProfileService profileService,
+        IAuditLogService auditLogService,
+        ISyncSettingsService syncSettingsService,
+        HumansDbContext dbContext,
+        IHumansMetrics metrics,
+        IClock clock,
+        ILogger<AutoConsentCheckJob> logger)
+    {
+        _onboardingService = onboardingService;
+        _holdListService = holdListService;
+        _assistant = assistant;
+        _profileService = profileService;
+        _auditLogService = auditLogService;
+        _syncSettingsService = syncSettingsService;
+        _dbContext = dbContext;
+        _metrics = metrics;
+        _clock = clock;
+        _logger = logger;
+    }
+
+    public async Task ExecuteAsync(CancellationToken cancellationToken = default)
+    {
+        var mode = await _syncSettingsService.GetModeAsync(SyncServiceType.AutoConsentCheck, cancellationToken);
+        if (mode == SyncMode.None)
+        {
+            _logger.LogInformation(
+                "AutoConsentCheckJob skipped: SyncServiceType.AutoConsentCheck is set to None");
+            _metrics.RecordJobRun("auto_consent_check", "skipped");
+            return;
+        }
+
+        _logger.LogInformation("Starting AutoConsentCheckJob at {Time}", _clock.GetCurrentInstant());
+
+        IReadOnlyList<Guid> pendingUserIds;
+        try
+        {
+            pendingUserIds = await _onboardingService.GetPendingConsentCheckUserIdsAsync(cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _metrics.RecordJobRun("auto_consent_check", "failure");
+            _logger.LogError(ex, "AutoConsentCheckJob: failed to load pending consent-check queue");
+            throw;
+        }
+
+        if (pendingUserIds.Count == 0)
+        {
+            _logger.LogInformation("AutoConsentCheckJob: no pending consent-check entries to evaluate");
+            _metrics.RecordJobRun("auto_consent_check", "success");
+            return;
+        }
+
+        IReadOnlyList<ConsentHoldListEntry> holdListEntries;
+        try
+        {
+            holdListEntries = await _holdListService.ListAsync(cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _metrics.RecordJobRun("auto_consent_check", "failure");
+            _logger.LogError(ex, "AutoConsentCheckJob: failed to load hold list");
+            throw;
+        }
+
+        var holdList = holdListEntries
+            .Select(e => e.Entry)
+            .ToList();
+
+        var profilesByUserId = await _profileService.GetByUserIdsAsync(pendingUserIds, cancellationToken);
+
+        var approvedCount = 0;
+        var skippedCount = 0;
+
+        foreach (var userId in pendingUserIds)
+        {
+            if (cancellationToken.IsCancellationRequested) break;
+
+            if (!profilesByUserId.TryGetValue(userId, out var profile) || profile is null)
+            {
+                _logger.LogWarning(
+                    "AutoConsentCheckJob: profile not found for user {UserId} (skipped)", userId);
+                skippedCount++;
+                continue;
+            }
+
+            var legalName = $"{profile.FirstName} {profile.LastName}".Trim();
+            if (string.IsNullOrWhiteSpace(legalName))
+            {
+                _logger.LogInformation(
+                    "AutoConsentCheckJob: skipping user {UserId} — legal name is empty", userId);
+                await SafeLogSkipAsync(userId, "(no legal name on profile)", modelId: "n/a", cancellationToken);
+                skippedCount++;
+                continue;
+            }
+
+            ConsentCheckVerdict verdict;
+            try
+            {
+                verdict = await _assistant.EvaluateAsync(legalName, holdList, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                // Any LLM failure leaves the entry untouched — human reviewer handles it.
+                _logger.LogWarning(
+                    ex, "AutoConsentCheckJob: LLM evaluation failed for user {UserId}; leaving in manual queue",
+                    userId);
+                skippedCount++;
+                continue;
+            }
+
+            if (verdict.PlausibleRealName && !verdict.HoldListMatch)
+            {
+                var result = await _onboardingService.AutoClearConsentCheckAsync(
+                    userId, verdict.Reason, verdict.ModelId, cancellationToken);
+                if (result.Success)
+                {
+                    _logger.LogInformation(
+                        "AutoConsentCheckJob: auto-cleared user {UserId} (model {ModelId}): {Reason}",
+                        userId, verdict.ModelId, verdict.Reason);
+                    approvedCount++;
+                }
+                else
+                {
+                    _logger.LogWarning(
+                        "AutoConsentCheckJob: AutoClearConsentCheckAsync for user {UserId} returned {ErrorKey}",
+                        userId, result.ErrorKey);
+                    skippedCount++;
+                }
+            }
+            else
+            {
+                var reasonLabel = BuildSkipReason(verdict);
+                _logger.LogInformation(
+                    "AutoConsentCheckJob: skipping user {UserId} ({Reason}, model {ModelId})",
+                    userId, reasonLabel, verdict.ModelId);
+                await SafeLogSkipAsync(userId, reasonLabel, verdict.ModelId, cancellationToken);
+                skippedCount++;
+            }
+        }
+
+        _metrics.RecordJobRun("auto_consent_check", "success");
+        _logger.LogInformation(
+            "AutoConsentCheckJob finished: approved={Approved}, skipped={Skipped}, total={Total}",
+            approvedCount, skippedCount, pendingUserIds.Count);
+    }
+
+    private async Task SafeLogSkipAsync(Guid userId, string reason, string modelId, CancellationToken ct)
+    {
+        try
+        {
+            // IAuditLogService.LogAsync queues to the DbContext but does not save —
+            // skips don't mutate Profile state, so we save audit-only writes here.
+            await _auditLogService.LogAsync(
+                AuditAction.ConsentCheckAutoSkipped,
+                nameof(Profile),
+                userId,
+                $"Auto consent-check skipped by {modelId}: {reason}",
+                nameof(AutoConsentCheckJob));
+            await _dbContext.SaveChangesAsync(ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "AutoConsentCheckJob: failed to write skip-audit entry for user {UserId}", userId);
+        }
+    }
+
+    private static string BuildSkipReason(ConsentCheckVerdict verdict)
+    {
+        var parts = new List<string>(2);
+        if (!verdict.PlausibleRealName) parts.Add("name not plausible");
+        if (verdict.HoldListMatch) parts.Add("hold-list match");
+        var label = parts.Count == 0 ? "no-op" : string.Join(" + ", parts);
+        return string.IsNullOrWhiteSpace(verdict.Reason) ? label : $"{label}: {verdict.Reason}";
+    }
+}

--- a/src/Humans.Infrastructure/Migrations/20260426113817_AddConsentHoldList.Designer.cs
+++ b/src/Humans.Infrastructure/Migrations/20260426113817_AddConsentHoldList.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Humans.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Humans.Infrastructure.Migrations
 {
     [DbContext(typeof(HumansDbContext))]
-    partial class HumansDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260426113817_AddConsentHoldList")]
+    partial class AddConsentHoldList
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Humans.Infrastructure/Migrations/20260426113817_AddConsentHoldList.cs
+++ b/src/Humans.Infrastructure/Migrations/20260426113817_AddConsentHoldList.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NodaTime;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace Humans.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddConsentHoldList : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "consent_hold_list",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    Entry = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: false),
+                    Note = table.Column<string>(type: "character varying(2000)", maxLength: 2000, nullable: true),
+                    AddedByUserId = table.Column<Guid>(type: "uuid", nullable: false),
+                    AddedAt = table.Column<Instant>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_consent_hold_list", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_consent_hold_list_users_AddedByUserId",
+                        column: x => x.AddedByUserId,
+                        principalTable: "users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.InsertData(
+                table: "sync_service_settings",
+                columns: new[] { "Id", "ServiceType", "SyncMode", "UpdatedAt", "UpdatedByUserId" },
+                values: new object[] { new Guid("00000000-0000-0000-0002-000000000004"), "AutoConsentCheck", "None", NodaTime.Instant.FromUnixTimeTicks(17730144000000000L), null });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_consent_hold_list_AddedByUserId",
+                table: "consent_hold_list",
+                column: "AddedByUserId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "consent_hold_list");
+
+            migrationBuilder.DeleteData(
+                table: "sync_service_settings",
+                keyColumn: "Id",
+                keyValue: new Guid("00000000-0000-0000-0002-000000000004"));
+        }
+    }
+}

--- a/src/Humans.Infrastructure/Repositories/Profiles/ProfileRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Profiles/ProfileRepository.cs
@@ -135,6 +135,19 @@ public sealed class ProfileRepository : IProfileRepository
             .CountAsync(p => !p.IsApproved && p.RejectedAt == null, ct);
     }
 
+    public async Task<IReadOnlyList<Guid>> GetPendingConsentCheckUserIdsAsync(CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        return await ctx.Profiles
+            .AsNoTracking()
+            .Where(p => p.ConsentCheckStatus == ConsentCheckStatus.Pending
+                && !p.IsApproved
+                && p.RejectedAt == null)
+            .OrderBy(p => p.CreatedAt)
+            .Select(p => p.UserId)
+            .ToListAsync(ct);
+    }
+
     public async Task<IReadOnlyList<Guid>> GetApprovedUserIdsAsync(CancellationToken ct = default)
     {
         await using var ctx = await _factory.CreateDbContextAsync(ct);

--- a/src/Humans.Infrastructure/Services/ConsentCheckAssistant.cs
+++ b/src/Humans.Infrastructure/Services/ConsentCheckAssistant.cs
@@ -1,0 +1,284 @@
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Humans.Application.DTOs;
+using Humans.Application.Interfaces;
+
+namespace Humans.Infrastructure.Services;
+
+/// <summary>
+/// Anthropic Claude Haiku client for the auto Consent Check job. Speaks to the
+/// Messages API directly over HTTP — no SDK dependency. Configured via
+/// <c>Anthropic:ApiKey</c> and (optionally) <c>Anthropic:Model</c>. Hard 10s
+/// timeout, one retry on transient failure, structured JSON response.
+/// </summary>
+public sealed class ConsentCheckAssistant : IConsentCheckAssistant
+{
+    private const string DefaultModel = "claude-haiku-4-5";
+    private const string AnthropicVersion = "2023-06-01";
+    private const string MessagesEndpoint = "https://api.anthropic.com/v1/messages";
+    private static readonly TimeSpan RequestTimeout = TimeSpan.FromSeconds(10);
+
+    private readonly HttpClient _httpClient;
+    private readonly IConfiguration _configuration;
+    private readonly ILogger<ConsentCheckAssistant> _logger;
+
+    public ConsentCheckAssistant(
+        HttpClient httpClient,
+        IConfiguration configuration,
+        ILogger<ConsentCheckAssistant> logger)
+    {
+        _httpClient = httpClient;
+        _configuration = configuration;
+        _logger = logger;
+    }
+
+    public async Task<ConsentCheckVerdict> EvaluateAsync(
+        string legalName,
+        IReadOnlyList<string> holdList,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(legalName))
+        {
+            throw new ArgumentException("Legal name is required.", nameof(legalName));
+        }
+
+        var apiKey = _configuration["Anthropic:ApiKey"];
+        if (string.IsNullOrWhiteSpace(apiKey))
+        {
+            throw new InvalidOperationException(
+                "Anthropic:ApiKey is not configured. Set Anthropic__ApiKey env var or user-secret.");
+        }
+
+        var model = _configuration["Anthropic:Model"];
+        if (string.IsNullOrWhiteSpace(model))
+        {
+            model = DefaultModel;
+        }
+
+        var requestPayload = BuildRequest(model, legalName, holdList);
+        var requestJson = JsonSerializer.Serialize(requestPayload);
+
+        // One retry on transient/network failure.
+        Exception? lastException = null;
+        for (var attempt = 1; attempt <= 2; attempt++)
+        {
+            using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            linkedCts.CancelAfter(RequestTimeout);
+
+            try
+            {
+                using var request = new HttpRequestMessage(HttpMethod.Post, MessagesEndpoint);
+                request.Content = new StringContent(requestJson, Encoding.UTF8, "application/json");
+                request.Headers.TryAddWithoutValidation("x-api-key", apiKey);
+                request.Headers.TryAddWithoutValidation("anthropic-version", AnthropicVersion);
+                request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+
+                using var response = await _httpClient.SendAsync(
+                    request, HttpCompletionOption.ResponseHeadersRead, linkedCts.Token);
+
+                var body = await response.Content.ReadAsStringAsync(linkedCts.Token);
+
+                if (!response.IsSuccessStatusCode)
+                {
+                    // 5xx and 429 get one retry; 4xx is terminal.
+                    var shouldRetry = attempt == 1 &&
+                        ((int)response.StatusCode >= 500 || (int)response.StatusCode == 429);
+                    _logger.LogWarning(
+                        "Anthropic API returned {Status} on attempt {Attempt}: {Body}",
+                        (int)response.StatusCode, attempt, Truncate(body, 500));
+                    if (!shouldRetry)
+                    {
+                        throw new InvalidOperationException(
+                            $"Anthropic API returned HTTP {(int)response.StatusCode}.");
+                    }
+                    continue;
+                }
+
+                return ParseResponse(body, model);
+            }
+            catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+            {
+                // Timeout (our linked token fired, not the caller's). Retry once.
+                lastException = new TimeoutException(
+                    $"Anthropic API call timed out after {RequestTimeout.TotalSeconds:F0}s.");
+                _logger.LogWarning(
+                    "Anthropic API call timed out on attempt {Attempt} after {Timeout}s",
+                    attempt, RequestTimeout.TotalSeconds);
+                if (attempt == 2) throw lastException;
+            }
+            catch (HttpRequestException ex)
+            {
+                lastException = ex;
+                _logger.LogWarning(
+                    ex, "Anthropic API transport error on attempt {Attempt}", attempt);
+                if (attempt == 2) throw;
+            }
+        }
+
+        // Unreachable, but keeps the compiler happy.
+        throw lastException ?? new InvalidOperationException("Anthropic API call failed.");
+    }
+
+    private static AnthropicRequest BuildRequest(
+        string model, string legalName, IReadOnlyList<string> holdList)
+    {
+        var systemPrompt =
+            "You are a safety classifier for a small volunteer-organisation signup flow. " +
+            "Given the 'legal_name' field a new signup has put on their profile, answer " +
+            "TWO yes/no questions as strict JSON:\n" +
+            "1. plausible_real_name: does this look like a plausible real human name? " +
+            "Reject obvious placeholders (asdf, test test, Mickey Mouse), profanity, " +
+            "empty strings, single characters, ALL-CAPS gibberish. Accept real-sounding " +
+            "names from any culture, including short ones, including ones with unusual " +
+            "capitalisation or accents. When uncertain, lean towards ACCEPT — a human " +
+            "coordinator will see anyone you reject.\n" +
+            "2. hold_list_match: does this name match ANY entry in the hold_list I give " +
+            "you? Match fuzzily — case-insensitive, tolerant of accent differences, " +
+            "tolerant of first/last ordering, tolerant of diminutives that clearly refer " +
+            "to the same person. If the hold list is empty, hold_list_match is always " +
+            "false.\n\n" +
+            "Respond with ONLY a single JSON object, no prose, no markdown fences:\n" +
+            "{\"plausible_real_name\": bool, \"hold_list_match\": bool, \"reason\": \"short explanation\"}";
+
+        var holdListText = holdList.Count == 0
+            ? "(empty)"
+            : string.Join("\n", holdList.Select(h => $"- {h}"));
+
+        var userPrompt =
+            $"legal_name: {legalName}\n\n" +
+            $"hold_list:\n{holdListText}";
+
+        return new AnthropicRequest(
+            Model: model,
+            MaxTokens: 256,
+            System: systemPrompt,
+            Messages: [new AnthropicMessage("user", userPrompt)]);
+    }
+
+    private ConsentCheckVerdict ParseResponse(string responseBody, string requestedModel)
+    {
+        AnthropicResponse? envelope;
+        try
+        {
+            envelope = JsonSerializer.Deserialize<AnthropicResponse>(responseBody);
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogWarning(
+                ex, "Failed to parse Anthropic response envelope: {Body}", Truncate(responseBody, 500));
+            throw new InvalidOperationException("Anthropic response was not valid JSON.", ex);
+        }
+
+        if (envelope is null || envelope.Content is null || envelope.Content.Count == 0)
+        {
+            throw new InvalidOperationException("Anthropic response had no content blocks.");
+        }
+
+        var textBlock = envelope.Content
+            .FirstOrDefault(c => string.Equals(c.Type, "text", StringComparison.Ordinal));
+        if (textBlock is null || string.IsNullOrWhiteSpace(textBlock.Text))
+        {
+            throw new InvalidOperationException("Anthropic response had no text block.");
+        }
+
+        var payloadText = ExtractJson(textBlock.Text);
+        VerdictPayload? payload;
+        try
+        {
+            payload = JsonSerializer.Deserialize<VerdictPayload>(payloadText);
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogWarning(
+                ex, "Anthropic text block was not valid verdict JSON: {Text}", Truncate(textBlock.Text, 500));
+            throw new InvalidOperationException(
+                "Anthropic response body was not valid verdict JSON.", ex);
+        }
+
+        if (payload is null)
+        {
+            throw new InvalidOperationException("Anthropic response deserialised to null verdict.");
+        }
+
+        var reportedModel = string.IsNullOrWhiteSpace(envelope.Model) ? requestedModel : envelope.Model;
+
+        return new ConsentCheckVerdict(
+            PlausibleRealName: payload.PlausibleRealName,
+            HoldListMatch: payload.HoldListMatch,
+            Reason: string.IsNullOrWhiteSpace(payload.Reason) ? "(no reason)" : payload.Reason.Trim(),
+            ModelId: reportedModel);
+    }
+
+    /// <summary>
+    /// Strips optional ``` fences that small models sometimes add even when asked not to.
+    /// </summary>
+    private static string ExtractJson(string text)
+    {
+        var trimmed = text.Trim();
+        if (trimmed.StartsWith("```", StringComparison.Ordinal))
+        {
+            // ```json\n...\n``` or ```\n...\n```
+            var firstNewline = trimmed.IndexOf('\n');
+            if (firstNewline > 0)
+            {
+                trimmed = trimmed[(firstNewline + 1)..];
+            }
+            var fenceEnd = trimmed.LastIndexOf("```", StringComparison.Ordinal);
+            if (fenceEnd >= 0)
+            {
+                trimmed = trimmed[..fenceEnd];
+            }
+            trimmed = trimmed.Trim();
+        }
+        return trimmed;
+    }
+
+    private static string Truncate(string value, int maxLength) =>
+        value.Length <= maxLength ? value : value[..maxLength] + "...";
+
+    // --- Wire types ---
+
+    private sealed record AnthropicRequest(
+        [property: JsonPropertyName("model")] string Model,
+        [property: JsonPropertyName("max_tokens")] int MaxTokens,
+        [property: JsonPropertyName("system")] string System,
+        [property: JsonPropertyName("messages")] IReadOnlyList<AnthropicMessage> Messages);
+
+    private sealed record AnthropicMessage(
+        [property: JsonPropertyName("role")] string Role,
+        [property: JsonPropertyName("content")] string Content);
+
+    private sealed class AnthropicResponse
+    {
+        [JsonPropertyName("model")]
+        public string? Model { get; set; }
+
+        [JsonPropertyName("content")]
+        public List<AnthropicContentBlock>? Content { get; set; }
+    }
+
+    private sealed class AnthropicContentBlock
+    {
+        [JsonPropertyName("type")]
+        public string? Type { get; set; }
+
+        [JsonPropertyName("text")]
+        public string? Text { get; set; }
+    }
+
+    private sealed class VerdictPayload
+    {
+        [JsonPropertyName("plausible_real_name")]
+        public bool PlausibleRealName { get; set; }
+
+        [JsonPropertyName("hold_list_match")]
+        public bool HoldListMatch { get; set; }
+
+        [JsonPropertyName("reason")]
+        public string? Reason { get; set; }
+    }
+}

--- a/src/Humans.Infrastructure/Services/ConsentHoldListService.cs
+++ b/src/Humans.Infrastructure/Services/ConsentHoldListService.cs
@@ -1,0 +1,114 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using NodaTime;
+using Humans.Application.Interfaces;
+using Humans.Application.Interfaces.AuditLog;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using Humans.Infrastructure.Data;
+
+namespace Humans.Infrastructure.Services;
+
+/// <summary>
+/// Owns the <c>consent_hold_list</c> table. The AutoConsentCheckJob reads the
+/// entire list on each run and passes it to the LLM assistant; at our scale
+/// the list is expected to stay small (&lt; a few hundred entries) so no caching
+/// is needed.
+/// </summary>
+public class ConsentHoldListService : IConsentHoldListService
+{
+    private readonly HumansDbContext _dbContext;
+    private readonly IAuditLogService _auditLogService;
+    private readonly IClock _clock;
+    private readonly ILogger<ConsentHoldListService> _logger;
+
+    public ConsentHoldListService(
+        HumansDbContext dbContext,
+        IAuditLogService auditLogService,
+        IClock clock,
+        ILogger<ConsentHoldListService> logger)
+    {
+        _dbContext = dbContext;
+        _auditLogService = auditLogService;
+        _clock = clock;
+        _logger = logger;
+    }
+
+    public async Task<IReadOnlyList<ConsentHoldListEntry>> ListAsync(CancellationToken ct = default)
+    {
+        return await _dbContext.ConsentHoldListEntries
+            .AsNoTracking()
+            .OrderByDescending(e => e.AddedAt)
+            .ToListAsync(ct);
+    }
+
+    public async Task<ConsentHoldListEntry> AddAsync(
+        string entry, string? note, Guid addedByUserId, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(entry))
+        {
+            throw new ArgumentException("Entry text is required.", nameof(entry));
+        }
+
+        var trimmedEntry = entry.Trim();
+        var trimmedNote = string.IsNullOrWhiteSpace(note) ? null : note.Trim();
+
+        var newEntry = new ConsentHoldListEntry
+        {
+            Entry = trimmedEntry,
+            Note = trimmedNote,
+            AddedByUserId = addedByUserId,
+            AddedAt = _clock.GetCurrentInstant(),
+        };
+
+        _dbContext.ConsentHoldListEntries.Add(newEntry);
+
+        await _auditLogService.LogAsync(
+            AuditAction.ConsentHoldListEntryAdded,
+            nameof(ConsentHoldListEntry),
+            // Entity id isn't known yet (int auto-increment); use Guid.Empty
+            // placeholder for the GUID-typed audit FK. The description carries
+            // the actual text — which is what reviewers look at anyway.
+            Guid.Empty,
+            $"Added hold-list entry: {trimmedEntry}" +
+                (trimmedNote is null ? string.Empty : $" (note: {trimmedNote})"),
+            addedByUserId);
+
+        await _dbContext.SaveChangesAsync(ct);
+
+        _logger.LogInformation(
+            "Admin {AdminId} added hold-list entry {EntryId}: {Entry}",
+            addedByUserId, newEntry.Id, trimmedEntry);
+
+        return newEntry;
+    }
+
+    public async Task DeleteAsync(int id, Guid actingUserId, CancellationToken ct = default)
+    {
+        var entry = await _dbContext.ConsentHoldListEntries
+            .FirstOrDefaultAsync(e => e.Id == id, ct);
+        if (entry is null)
+        {
+            _logger.LogInformation(
+                "DeleteAsync called for non-existent hold-list entry {EntryId} by {ActorId}",
+                id, actingUserId);
+            return;
+        }
+
+        var removedText = entry.Entry;
+        _dbContext.ConsentHoldListEntries.Remove(entry);
+
+        await _auditLogService.LogAsync(
+            AuditAction.ConsentHoldListEntryRemoved,
+            nameof(ConsentHoldListEntry),
+            Guid.Empty,
+            $"Removed hold-list entry: {removedText}",
+            actingUserId);
+
+        await _dbContext.SaveChangesAsync(ct);
+
+        _logger.LogInformation(
+            "Admin {AdminId} removed hold-list entry {EntryId}: {Entry}",
+            actingUserId, id, removedText);
+    }
+}

--- a/src/Humans.Infrastructure/Services/Profiles/CachingProfileService.cs
+++ b/src/Humans.Infrastructure/Services/Profiles/CachingProfileService.cs
@@ -496,6 +496,27 @@ public sealed class CachingProfileService : IProfileService, IFullProfileInvalid
         return result;
     }
 
+    public async Task<OnboardingResult> AutoClearConsentCheckAsync(
+        Guid userId, string reason, string modelId, string actorName, CancellationToken ct = default)
+    {
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        var inner = scope.ServiceProvider.GetRequiredKeyedService<IProfileService>(InnerServiceKey);
+        var navBadge = scope.ServiceProvider.GetRequiredService<INavBadgeCacheInvalidator>();
+        var notificationMeter = scope.ServiceProvider.GetRequiredService<INotificationMeterCacheInvalidator>();
+
+        var result = await inner.AutoClearConsentCheckAsync(userId, reason, modelId, actorName, ct);
+        if (result.Success)
+        {
+            navBadge.Invalidate();
+            notificationMeter.Invalidate();
+            await RefreshEntryAsync(userId, ct);
+        }
+        return result;
+    }
+
+    public Task<IReadOnlyList<Guid>> GetPendingConsentCheckUserIdsAsync(CancellationToken ct = default) =>
+        _profileRepository.GetPendingConsentCheckUserIdsAsync(ct);
+
     public async Task<OnboardingResult> RejectSignupAsync(
         Guid userId, Guid reviewerId, string? reason, CancellationToken ct = default)
     {

--- a/src/Humans.Web/Controllers/AdminConsentHoldListController.cs
+++ b/src/Humans.Web/Controllers/AdminConsentHoldListController.cs
@@ -1,0 +1,99 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Humans.Application.Interfaces;
+using Humans.Domain.Entities;
+using Humans.Web.Authorization;
+using Humans.Web.Models;
+
+namespace Humans.Web.Controllers;
+
+/// <summary>
+/// Admin-only CRUD over the Consent Hold List. The hold list is consulted by
+/// <see cref="Humans.Infrastructure.Jobs.AutoConsentCheckJob"/>: incoming legal
+/// names are checked against these entries and any match blocks the LLM's
+/// auto-approval. See docs/features/auto-consent-check.md.
+/// </summary>
+[Authorize(Policy = PolicyNames.AdminOnly)]
+[Route("Admin/ConsentHoldList")]
+public class AdminConsentHoldListController : HumansControllerBase
+{
+    private readonly IConsentHoldListService _holdListService;
+    private readonly ILogger<AdminConsentHoldListController> _logger;
+
+    public AdminConsentHoldListController(
+        UserManager<User> userManager,
+        IConsentHoldListService holdListService,
+        ILogger<AdminConsentHoldListController> logger)
+        : base(userManager)
+    {
+        _holdListService = holdListService;
+        _logger = logger;
+    }
+
+    [HttpGet("")]
+    public async Task<IActionResult> Index()
+    {
+        var entries = await _holdListService.ListAsync();
+        var viewModel = new ConsentHoldListViewModel
+        {
+            Entries = entries.Select(e => new ConsentHoldListEntryRow
+            {
+                Id = e.Id,
+                Entry = e.Entry,
+                Note = e.Note,
+                AddedAt = e.AddedAt.ToDateTimeUtc(),
+                AddedByUserId = e.AddedByUserId,
+            }).ToList(),
+        };
+        return View(viewModel);
+    }
+
+    [HttpPost("Add")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Add(string entry, string? note)
+    {
+        var (error, user) = await RequireCurrentUserAsync();
+        if (error is not null) return error;
+
+        if (string.IsNullOrWhiteSpace(entry))
+        {
+            SetError("Entry text is required.");
+            return RedirectToAction(nameof(Index));
+        }
+
+        try
+        {
+            await _holdListService.AddAsync(entry, note, user.Id);
+            SetSuccess("Hold list entry added.");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to add hold-list entry by admin {AdminId}", user.Id);
+            SetError($"Failed to add entry: {ex.Message}");
+        }
+
+        return RedirectToAction(nameof(Index));
+    }
+
+    [HttpPost("Delete")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Delete(int id)
+    {
+        var (error, user) = await RequireCurrentUserAsync();
+        if (error is not null) return error;
+
+        try
+        {
+            await _holdListService.DeleteAsync(id, user.Id);
+            SetSuccess("Hold list entry removed.");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to delete hold-list entry {Id} by admin {AdminId}", id, user.Id);
+            SetError($"Failed to remove entry: {ex.Message}");
+        }
+
+        return RedirectToAction(nameof(Index));
+    }
+}

--- a/src/Humans.Web/Controllers/GoogleController.cs
+++ b/src/Humans.Web/Controllers/GoogleController.cs
@@ -854,6 +854,7 @@ public class GoogleController : HumansControllerBase
         SyncServiceType.GoogleDrive => "Google Drive",
         SyncServiceType.GoogleGroups => "Google Groups",
         SyncServiceType.Discord => "Discord",
+        SyncServiceType.AutoConsentCheck => "Auto Consent Check (LLM)",
         _ => type.ToString()
     };
 }

--- a/src/Humans.Web/Extensions/InfrastructureServiceCollectionExtensions.cs
+++ b/src/Humans.Web/Extensions/InfrastructureServiceCollectionExtensions.cs
@@ -35,7 +35,7 @@ public static class InfrastructureServiceCollectionExtensions
         services.AddTicketsSection();
         services.AddFeedbackSection();
         services.AddNotificationsSection();
-        services.AddLegalAndConsentSection();
+        services.AddLegalAndConsentSection(configuration, configRegistry);
         services.AddCampaignsSection();
         services.AddAuditLogSection();
         services.AddGdprSection();

--- a/src/Humans.Web/Extensions/RecurringJobExtensions.cs
+++ b/src/Humans.Web/Extensions/RecurringJobExtensions.cs
@@ -75,6 +75,12 @@ public static class RecurringJobExtensions
             // Materialize ticket sales actuals into budget line items daily at 04:30.
             ("ticketing-budget-sync", () => RecurringJob.AddOrUpdate<TicketingBudgetSyncJob>(
                 "ticketing-budget-sync", job => job.ExecuteAsync(CancellationToken.None), "30 4 * * *")),
+
+            // Auto-approve rubber-stamp consent-check entries via LLM — every 15 min.
+            // Controlled by SyncServiceType.AutoConsentCheck at /Google/SyncSettings
+            // (set to None to disable). Only ever approves; flags/rejects never happen.
+            ("auto-consent-check", () => RecurringJob.AddOrUpdate<AutoConsentCheckJob>(
+                "auto-consent-check", job => job.ExecuteAsync(CancellationToken.None), "*/15 * * * *")),
         };
 
         foreach (var (id, register) in jobs)

--- a/src/Humans.Web/Extensions/Sections/LegalAndConsentSectionExtensions.cs
+++ b/src/Humans.Web/Extensions/Sections/LegalAndConsentSectionExtensions.cs
@@ -1,3 +1,5 @@
+using Humans.Application.Configuration;
+using Humans.Application.Interfaces;
 using Humans.Application.Interfaces.Consent;
 using Humans.Application.Interfaces.Gdpr;
 using Humans.Application.Interfaces.Legal;
@@ -15,7 +17,10 @@ namespace Humans.Web.Extensions.Sections;
 
 internal static class LegalAndConsentSectionExtensions
 {
-    internal static IServiceCollection AddLegalAndConsentSection(this IServiceCollection services)
+    internal static IServiceCollection AddLegalAndConsentSection(
+        this IServiceCollection services,
+        IConfiguration configuration,
+        ConfigurationRegistry? configRegistry)
     {
         // Legal document section — §15 repository pattern (issue #547a).
         // ILegalDocumentRepository owns legal_documents + document_versions and
@@ -43,6 +48,25 @@ internal static class LegalAndConsentSectionExtensions
 
         services.AddScoped<SyncLegalDocumentsJob>();
         services.AddScoped<SendReConsentReminderJob>();
+
+        // Consent hold list — admin-only CRUD over the consent_hold_list table.
+        // Read by AutoConsentCheckJob to suppress LLM auto-approval for matching names.
+        services.AddScoped<IConsentHoldListService, ConsentHoldListService>();
+
+        // Anthropic-backed assistant for the AutoConsentCheckJob.
+        // API key read from IConfiguration["Anthropic:ApiKey"] (env var:
+        // Anthropic__ApiKey). See docs/features/auto-consent-check.md.
+        if (configRegistry is not null)
+        {
+            configuration.GetOptionalSetting(configRegistry, "Anthropic:ApiKey", "Anthropic",
+                isSensitive: true, importance: ConfigurationImportance.Recommended);
+            configuration.GetOptionalSetting(configRegistry, "Anthropic:Model", "Anthropic");
+        }
+        services.AddHttpClient<IConsentCheckAssistant, ConsentCheckAssistant>();
+
+        // Auto consent check job — Hangfire recurring job, registered alongside
+        // the other consent-section jobs. Scheduled by RecurringJobExtensions.
+        services.AddScoped<AutoConsentCheckJob>();
 
         return services;
     }

--- a/src/Humans.Web/Models/ConsentHoldListViewModel.cs
+++ b/src/Humans.Web/Models/ConsentHoldListViewModel.cs
@@ -1,0 +1,15 @@
+namespace Humans.Web.Models;
+
+public class ConsentHoldListViewModel
+{
+    public List<ConsentHoldListEntryRow> Entries { get; set; } = new();
+}
+
+public class ConsentHoldListEntryRow
+{
+    public int Id { get; set; }
+    public string Entry { get; set; } = string.Empty;
+    public string? Note { get; set; }
+    public DateTime AddedAt { get; set; }
+    public Guid AddedByUserId { get; set; }
+}

--- a/src/Humans.Web/Views/Admin/Index.cshtml
+++ b/src/Humans.Web/Views/Admin/Index.cshtml
@@ -60,6 +60,9 @@
                 <a asp-action="AudienceSegmentation" class="list-group-item list-group-item-action">
                     <i class="fa-solid fa-chart-pie me-2"></i>Audience Segmentation
                 </a>
+                <a asp-controller="AdminConsentHoldList" asp-action="Index" class="list-group-item list-group-item-action">
+                    <i class="fa-solid fa-shield-halved me-2"></i>Consent Hold List
+                </a>
             </div>
         </div>
 

--- a/src/Humans.Web/Views/AdminConsentHoldList/Index.cshtml
+++ b/src/Humans.Web/Views/AdminConsentHoldList/Index.cshtml
@@ -1,0 +1,111 @@
+@model Humans.Web.Models.ConsentHoldListViewModel
+@{
+    ViewData["Title"] = "Consent Hold List";
+}
+
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a asp-controller="Admin" asp-action="Index">Admin</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Consent Hold List</li>
+    </ol>
+</nav>
+
+<h1>Consent Hold List</h1>
+
+<vc:temp-data-alerts />
+
+<div class="card mb-4">
+    <div class="card-body">
+        <p class="text-muted mb-2">
+            The auto Consent Check job uses this list to suppress automatic approval.
+            If an incoming legal name matches any entry here (fuzzy, case-insensitive,
+            evaluated by the LLM), the human stays in the manual review queue for a
+            Consent Coordinator to look at. The job never auto-rejects — at worst a
+            match delays the approval until a human reviewer clears it.
+        </p>
+        <p class="text-muted mb-0">
+            Entries are free-form: real names, aliases, or whatever fragments are
+            worth matching. Entries are never shown to non-admin users.
+        </p>
+    </div>
+</div>
+
+<div class="card mb-4">
+    <div class="card-header">Add entry</div>
+    <div class="card-body">
+        <form asp-action="Add" method="post" class="row g-2">
+            @Html.AntiForgeryToken()
+            <div class="col-md-5">
+                <label for="entry" class="form-label">Name / alias</label>
+                <input type="text" id="entry" name="entry" class="form-control" maxlength="500" required />
+            </div>
+            <div class="col-md-5">
+                <label for="note" class="form-label">Note (optional)</label>
+                <input type="text" id="note" name="note" class="form-control" maxlength="2000" />
+            </div>
+            <div class="col-md-2 d-flex align-items-end">
+                <button type="submit" class="btn btn-primary w-100">Add</button>
+            </div>
+        </form>
+    </div>
+</div>
+
+<div class="card">
+    <div class="card-header d-flex justify-content-between align-items-center">
+        <strong>Current entries</strong>
+        <span class="badge bg-secondary">@Model.Entries.Count</span>
+    </div>
+    <div class="card-body p-0">
+        <table class="table table-hover mb-0 align-middle">
+            <thead>
+                <tr>
+                    <th>Entry</th>
+                    <th>Note</th>
+                    <th>Added</th>
+                    <th class="text-end">Actions</th>
+                </tr>
+            </thead>
+            <tbody>
+                @if (Model.Entries.Count == 0)
+                {
+                    <tr>
+                        <td colspan="4" class="text-center text-muted py-4">
+                            No entries. The list starts empty; add names as they come up.
+                        </td>
+                    </tr>
+                }
+                else
+                {
+                    @foreach (var row in Model.Entries)
+                    {
+                        <tr>
+                            <td><code>@row.Entry</code></td>
+                            <td>@(string.IsNullOrWhiteSpace(row.Note) ? "—" : row.Note)</td>
+                            <td>@row.AddedAt.ToDisplayCompactDateTime()</td>
+                            <td class="text-end">
+                                <form asp-action="Delete" method="post" class="d-inline">
+                                    @Html.AntiForgeryToken()
+                                    <input type="hidden" name="id" value="@row.Id" />
+                                    <button type="submit" class="btn btn-outline-danger btn-sm"
+                                            data-confirm="Remove this hold-list entry?">
+                                        Remove
+                                    </button>
+                                </form>
+                            </td>
+                        </tr>
+                    }
+                }
+            </tbody>
+        </table>
+    </div>
+</div>
+
+<script>
+    document.querySelectorAll('[data-confirm]').forEach(function (button) {
+        button.addEventListener('click', function (e) {
+            if (!confirm(this.getAttribute('data-confirm'))) {
+                e.preventDefault();
+            }
+        });
+    });
+</script>

--- a/tests/Humans.Application.Tests/Architecture/InterfaceMethodBudgetTests.cs
+++ b/tests/Humans.Application.Tests/Architecture/InterfaceMethodBudgetTests.cs
@@ -45,7 +45,7 @@ public class InterfaceMethodBudgetTests
         [typeof(ITeamService)] = 71,
         [typeof(ICampService)] = 53,
         [typeof(IShiftManagementService)] = 49,
-        [typeof(IProfileService)] = 39,
+        [typeof(IProfileService)] = 41,
         [typeof(IUserService)] = 32,
     };
 


### PR DESCRIPTION
Closes nobodies-collective/Humans#485

## Summary

- Adds `AutoConsentCheckJob` (Hangfire, every 15 min) that asks Claude Haiku to rubber-stamp clean Consent Check entries in the onboarding review queue. The job only ever approves — never flags, never rejects. LLM failures leave the entry in the manual queue.
- Adds a `consent_hold_list` table + admin-only CRUD at `/Admin/ConsentHoldList`. Entries suppress auto-approval when the incoming legal name matches.
- Adds `SyncServiceType.AutoConsentCheck` as a kill switch at `/Google/SyncSettings` (None = disabled; any other value = enabled). No redeploy required.
- No SDK dependency — talks to the Messages API via `HttpClient` with a hard 10 s timeout and one retry. Configuration via `Anthropic:ApiKey` (env `Anthropic__ApiKey`); never in `appsettings.json`.

## Key design choices

- **`IOnboardingService.AutoClearConsentCheckAsync`** — a new system-actor method rather than overloading the existing `ClearConsentCheckAsync`. The existing method requires a `reviewerId` (Guid UserId) and writes it to `ConsentCheckedByUserId`; the system has no user to attribute. Same cache/Volunteers-sync side-effects as the human path, but the audit action is `ConsentCheckAutoCleared` and `ConsentCheckedByUserId` stays null. Slight deviation from \"route through `ClearConsentCheck`\" in the spec, chosen for audit clarity.
- **SyncSettings reuse** — `AutoConsentCheck` is added to `SyncServiceType` and appears alongside Google Drive / Groups / Discord on the existing `/Google/SyncSettings` page. The Add/Remove semantics don't map cleanly (the job doesn't add/remove anything), so the job treats any non-`None` mode as \"on\". This keeps the admin UX consistent (one place to disable automated work).
- **HTTP vs SDK** — direct HTTP keeps `Directory.Packages.props` clean and matches the project's existing external-integration patterns (Google, Stripe, Ticket vendor all have bespoke clients). The wire types are private records in `ConsentCheckAssistant`.
- **Hold-list service ownership** — `ConsentHoldListService` owns `consent_hold_list`; only the admin CRUD controller and `AutoConsentCheckJob` call it via the interface. No cross-service DB access.

## Defaults chosen (per spec's open questions)

- **Frequency**: every 15 min (cron `*/15 * * * *`).
- **Cost cap**: none. At ~500 users total and Haiku pricing, unconstrained cost is negligible. If traffic rises, a simple per-run ceiling belongs in the job before the LLM loop. TODO flagged in `docs/features/auto-consent-check.md`.
- **Kill switch**: yes, via `SyncServiceType.AutoConsentCheck` at `/Google/SyncSettings`.
- **Hold list seeding**: starts empty. Admin seeds as specific situations arise.
- **Retroactive backlog**: yes — first run processes every existing Pending entry.

## Test plan

- [ ] Set `Anthropic__ApiKey` in QA and flip `AutoConsentCheck` to `AddOnly` at `/Google/SyncSettings`
- [ ] Seed a Pending Consent Check via normal signup with a plausible name → next 15-min run should auto-clear, audit as `ConsentCheckAutoCleared`, `ConsentCheckedByUserId` NULL, reason populated in `ConsentCheckNotes`
- [ ] Seed a Pending with name \"asdf asdf\" → auto-skip, audit `ConsentCheckAutoSkipped`, entry stays Pending
- [ ] Add the plausible-name signup's surname to `/Admin/ConsentHoldList`, re-seed → auto-skip, audit reason mentions hold-list match
- [ ] Flip `AutoConsentCheck` back to `None` → job logs skip + exits, no HTTP traffic
- [ ] Unset `Anthropic__ApiKey`, flip to `AddOnly`, seed a Pending → job logs warning per entry, no auto-clear, no crash
- [ ] Trigger the job manually from `/hangfire` and verify logs for each of the above cases
- [ ] Hold-list CRUD: admin adds / removes entries, both audit entries appear in the audit log with the `ConsentHoldListEntry` entity type
- [ ] Non-admin hits `/Admin/ConsentHoldList` → 403 / redirect to login

## Migration review (self-check against `.claude/agents/ef-migration-reviewer.md`)

- No `HasDefaultValue(false)` on any bool (no bool properties on the new entity)
- `CreateTable` for `consent_hold_list` — all required columns present; no empty SET clauses
- Namespace `Humans.Infrastructure.Migrations` ✓
- No hand edits — exactly what `dotnet ef migrations add` generated
- Seed data on `sync_service_settings` adds the new `AutoConsentCheck` row, matching the existing three rows in shape
- New `DbSet<ConsentHoldListEntry> ConsentHoldListEntries` declared in `HumansDbContext`
- Table name `consent_hold_list` is snake_case
- FK to `users` configured with `OnDelete: Restrict`
- Snapshot includes the new entity

No CRITICAL issues.