### PR TITLE
Add Scanner section with in-browser barcode decode (phase 1)

### DIFF
--- a/docs/architecture/design-rules.md
+++ b/docs/architecture/design-rules.md
@@ -248,6 +248,7 @@ Each section's service owns these tables. Cross-service access goes through the 
 | **Shifts** | `ShiftManagementService`, `ShiftSignupService`, `GeneralAvailabilityService` | `rotas`, `shifts`, `shift_signups`, `event_settings`, `general_availabilities`, `volunteer_event_profiles`, `shift_tags`, `volunteer_tag_preferences` |
 | **Budget** | `BudgetService` | `budget_years`, `budget_groups`, `budget_categories`, `budget_line_items`, `budget_audit_logs`, `ticketing_projections` |
 | **Tickets** | `TicketQueryService`, `TicketSyncService`, `TicketingBudgetService` | `ticket_orders`, `ticket_attendees`, `ticket_sync_states` |
+| **Scanner** | none (phase 1 is presentational) | none |
 | **Campaigns** | `CampaignService` | `campaigns`, `campaign_codes`, `campaign_grants` |
 | **Google Integration** | `GoogleSyncService`, `GoogleAdminService`, `GoogleWorkspaceSyncService`, `GoogleWorkspaceUserService`, `DriveActivityMonitorService`, `SyncSettingsService`, `EmailProvisioningService` | `sync_service_settings`, `google_sync_outbox_events` |
 | **Email** | `EmailOutboxService`, `OutboxEmailService`, `EmailService` | `email_outbox_messages`; owns `system_settings` key `email_outbox_paused` |

--- a/docs/features/scanner-barcode.md
+++ b/docs/features/scanner-barcode.md
@@ -1,0 +1,73 @@
+# Scanner — Barcode (Phase 1)
+
+## Business Context
+
+TicketTailor issues ticket stubs carrying a barcode. Staff who want to confirm what's actually encoded on a stub currently have to bounce to the TicketTailor UI — there's no in-app way to read those barcodes. This tool gives them one, using nothing but the device camera and the browser's own APIs.
+
+**Explicitly not a check-in tool.** Humans do not enter the event by having their ticket scanned here. Nothing is written server-side. This exists to prove the camera + decode plumbing end-to-end, so future work (API verification against TicketTailor, ticket lookup, future scanner tools) can layer on top without re-doing the front-end.
+
+Phase 1 stands up the section (`Scanner`) as its own top-level nav area because we expect future scanner tools to live there — ticket lookup, asset tags, etc. — and the role is cross-cutting, not Tickets-specific.
+
+## User Stories
+
+### US-S1.1: Decode a ticket barcode on my phone
+**As a** TicketAdmin (or Board/Admin)
+**I want to** point my phone camera at a TicketTailor ticket stub
+**So that** I can see what value the barcode encodes without opening the TicketTailor dashboard
+
+**Acceptance Criteria:**
+- Open `/Scanner/Barcode`, tap Scan, grant camera permission — the rear camera starts a live preview.
+- A TicketTailor QR (or CODE128, whichever the vendor uses) is decoded within a reasonable time.
+- The decoded value, format, and timestamp appear in a list below the preview, most recent on top.
+- Values that look like URLs render as clickable links; other values render verbatim.
+- Tapping Stop releases the camera stream (hard requirement — no stale indicator light).
+
+### US-S1.2: Works on a laptop too
+**As a** TicketAdmin
+**I want to** use the same tool from a laptop webcam
+**So that** I'm not blocked if my phone isn't handy
+
+**Acceptance Criteria:**
+- The same flow works on desktop Chrome/Edge/Safari with a webcam.
+- If the browser lacks `BarcodeDetector` (iOS Safari, older Chromium), the tool transparently falls back to `@zxing/browser` via CDN.
+- The fallback is logged in the browser console so troubleshooting has a signal.
+
+## Decode Path
+
+1. **Feature detect `window.BarcodeDetector`.** If available, use it directly — configured for QR, CODE128, CODE39, EAN-13/8, UPC-A/E, PDF417, Data Matrix.
+2. **Fallback:** dynamic-import `@zxing/browser@0.1.5` from `cdn.jsdelivr.net` (already allow-listed in CSP). Use `BrowserMultiFormatReader.decodeFromStream`.
+3. Either path appends `{format, value, timestamp}` to the on-page list. Duplicate hits within 1.5 s are deduped so scanning holds don't spam the list.
+
+## Scope & Non-Goals
+
+### In Scope (Phase 1)
+
+- New `ScannerController` with `/Scanner` index and `/Scanner/Barcode` tool, gated to `TicketAdminBoardOrAdmin`.
+- Nav entry in the main nav.
+- Camera start/stop with feature-detect + ZXing fallback.
+- Decoded list rendered in the page, client-side only.
+- Localized copy across all six supported locales.
+- Section invariant doc (`docs/sections/Scanner.md`) and this feature spec.
+
+### Out of Scope (explicitly, for phase 1)
+
+- Check-in / attendance marking. Humans do not enter the event by having their ticket scanned here.
+- TicketTailor API calls to validate a decoded barcode. That's a follow-on.
+- Server-side storage of scan history. The list in the page is client-side only; refresh clears it.
+- Batch scanning / roster lookup / matching a barcode to a `TicketAttendee` row.
+- Any future check-in flow — if that ever ships, it's a different tool from this one.
+
+## Implementation Notes
+
+- Camera access requires a secure context. Already satisfied in all Humans environments (QA, preview, production).
+- iOS Safari will only open the camera on a user gesture — the Scan button exists for this reason. The page copy doesn't assume auto-play.
+- Narrow mobile viewports: preview and controls are touch-friendly and do not depend on hover.
+- The `BarcodeDetector` formats list is broad, but the primary target is QR + CODE128 because those are what TicketTailor uses. Adding more formats doesn't cost anything at the API level.
+- CSP already allows `cdn.jsdelivr.net` in `script-src` and `connect-src`, so the ZXing fallback loads without CSP changes.
+
+## Follow-ups (Separate Issues)
+
+- TicketTailor API verification — given a decoded value, ask TicketTailor whether the ticket is valid, refunded, already checked in, etc.
+- Match decoded value to the local `TicketAttendee` row and show the human's details inline.
+- Offline mode / scan queue for poor-connectivity environments.
+- If a check-in flow is ever needed, it's a different tool from this one.

--- a/docs/sections/Scanner.md
+++ b/docs/sections/Scanner.md
@@ -37,6 +37,7 @@
 
 **Owning service:** none (no business logic at this scale — phase 1 is presentational).
 **Owned tables:** none.
+**Status:** (A) Migrated — pure presentational section, no repository needed (issue nobodies-collective/Humans#525, 2026-04-26)
 
 Controller lives at `src/Humans.Web/Controllers/ScannerController.cs`. Views under `src/Humans.Web/Views/Scanner/`. Client logic at `src/Humans.Web/wwwroot/js/scanner/barcode.js`.
 

--- a/docs/sections/Scanner.md
+++ b/docs/sections/Scanner.md
@@ -3,7 +3,7 @@
 ## Concepts
 
 - **Scanner** is a section for in-browser tools that read data from the device camera (or similar inputs in the future).
-- **Phase 1** (issue #525) ships a single tool: `/Scanner/Barcode`, which decodes QR codes and CODE128 barcodes using the browser's `BarcodeDetector` API, falling back to `@zxing/browser` via CDN.
+- **Phase 1** (issue nobodies-collective/Humans#525) ships a single tool: `/Scanner/Barcode`, which decodes QR codes and CODE128 barcodes using the browser's `BarcodeDetector` API, falling back to `@zxing/browser` via CDN.
 - **Not a check-in tool.** Scanning a ticket here does not mark anyone as arrived. Decoded values are displayed only and not sent to the server.
 - **No server-side state.** The section has no owned tables, no DTOs, no services. Decoding happens entirely in the browser; results live in the page and are discarded on navigation.
 

--- a/docs/sections/Scanner.md
+++ b/docs/sections/Scanner.md
@@ -1,0 +1,48 @@
+# Scanner — Section Invariants
+
+## Concepts
+
+- **Scanner** is a section for in-browser tools that read data from the device camera (or similar inputs in the future).
+- **Phase 1** (issue #525) ships a single tool: `/Scanner/Barcode`, which decodes QR codes and CODE128 barcodes using the browser's `BarcodeDetector` API, falling back to `@zxing/browser` via CDN.
+- **Not a check-in tool.** Scanning a ticket here does not mark anyone as arrived. Decoded values are displayed only and not sent to the server.
+- **No server-side state.** The section has no owned tables, no DTOs, no services. Decoding happens entirely in the browser; results live in the page and are discarded on navigation.
+
+## Actors & Roles
+
+| Actor | Capabilities |
+|-------|-------------|
+| TicketAdmin, Board, Admin | View the scanner section index and use the barcode tool |
+| Everyone else | No access — all scanner routes require `TicketAdminBoardOrAdmin` |
+
+## Invariants
+
+- All scanner routes require the `TicketAdminBoardOrAdmin` policy (`TicketAdmin`, `Board`, or `Admin`).
+- No scanner endpoint writes server-side state. No database tables are owned by this section.
+- The barcode tool is explicitly labelled as a test tool on screen. It is never used to mark tickets as checked-in or to authenticate entry.
+- Decoded barcode values do not leave the browser.
+- The stream is released (`MediaStreamTrack.stop()` on every track) when the user taps Stop or leaves the page (`pagehide`, `beforeunload`).
+
+## Triggers
+
+- When the user clicks **Scan** on `/Scanner/Barcode`, the browser prompts for camera permission and starts the rear-facing preview.
+- When a barcode is decoded, the tool appends a `{format, value, timestamp}` entry to the on-page list (most recent first). Duplicate hits within 1.5 s are suppressed.
+- When the user clicks **Stop** (or leaves the page), the camera stream is released.
+
+## Cross-Section Dependencies
+
+- **Tickets**: the barcode tool is gated behind the ticket-admin policy because its initial use case is reading TicketTailor ticket stubs. No runtime coupling — Scanner does not call any Tickets service or share any state with Tickets.
+- **Admin**: none beyond the shared `TicketAdminBoardOrAdmin` policy.
+
+## Architecture — Current vs Target
+
+**Owning service:** none (no business logic at this scale — phase 1 is presentational).
+**Owned tables:** none.
+
+Controller lives at `src/Humans.Web/Controllers/ScannerController.cs`. Views under `src/Humans.Web/Views/Scanner/`. Client logic at `src/Humans.Web/wwwroot/js/scanner/barcode.js`.
+
+If future scanner tools grow to need server-side verification (for example, calling a ticket vendor API to validate a decoded reference), that logic goes into a new `IScannerVerificationService` in `Humans.Application` and is consumed by the controller — the `ScannerController` remains a thin web-layer wrapper, and the client logic stays in `wwwroot/js/scanner/`.
+
+## Negative Access Rules
+
+- The barcode tool is **not** a check-in gateway. Do not wire it up to attendance records, `EventParticipation`, ticket check-in state, or anything that would mark a human as having entered the event.
+- No data from a decoded barcode is sent to the server in phase 1. If a future scanner tool needs a server round-trip, it must be a new tool with its own route and feature spec, not an extension of `/Scanner/Barcode`.

--- a/docs/sections/Scanner.md
+++ b/docs/sections/Scanner.md
@@ -22,6 +22,11 @@
 - Decoded barcode values do not leave the browser.
 - The stream is released (`MediaStreamTrack.stop()` on every track) when the user taps Stop or leaves the page (`pagehide`, `beforeunload`).
 
+## Negative Access Rules
+
+- The barcode tool is **not** a check-in gateway. Do not wire it up to attendance records, `EventParticipation`, ticket check-in state, or anything that would mark a human as having entered the event.
+- No data from a decoded barcode is sent to the server in phase 1. If a future scanner tool needs a server round-trip, it must be a new tool with its own route and feature spec, not an extension of `/Scanner/Barcode`.
+
 ## Triggers
 
 - When the user clicks **Scan** on `/Scanner/Barcode`, the browser prompts for camera permission and starts the rear-facing preview.
@@ -42,8 +47,3 @@
 Controller lives at `src/Humans.Web/Controllers/ScannerController.cs`. Views under `src/Humans.Web/Views/Scanner/`. Client logic at `src/Humans.Web/wwwroot/js/scanner/barcode.js`.
 
 If future scanner tools grow to need server-side verification (for example, calling a ticket vendor API to validate a decoded reference), that logic goes into a new `IScannerVerificationService` in `Humans.Application` and is consumed by the controller — the `ScannerController` remains a thin web-layer wrapper, and the client logic stays in `wwwroot/js/scanner/`.
-
-## Negative Access Rules
-
-- The barcode tool is **not** a check-in gateway. Do not wire it up to attendance records, `EventParticipation`, ticket check-in state, or anything that would mark a human as having entered the event.
-- No data from a decoded barcode is sent to the server in phase 1. If a future scanner tool needs a server round-trip, it must be a new tool with its own route and feature spec, not an extension of `/Scanner/Barcode`.

--- a/src/Humans.Web/Controllers/ScannerController.cs
+++ b/src/Humans.Web/Controllers/ScannerController.cs
@@ -1,0 +1,21 @@
+using Humans.Web.Authorization;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Humans.Web.Controllers;
+
+/// <summary>
+/// Scanner section — in-browser tools for decoding barcodes / QR codes / similar from the
+/// device camera. Phase 1 (issue #525) only ships the barcode decoder; later tools live at
+/// <c>/Scanner/{ToolName}</c>. Nothing on this section writes server-side state.
+/// </summary>
+[Authorize(Policy = PolicyNames.TicketAdminBoardOrAdmin)]
+[Route("Scanner")]
+public class ScannerController : Controller
+{
+    [HttpGet("")]
+    public IActionResult Index() => View();
+
+    [HttpGet("Barcode")]
+    public IActionResult Barcode() => View();
+}

--- a/src/Humans.Web/Controllers/ScannerController.cs
+++ b/src/Humans.Web/Controllers/ScannerController.cs
@@ -6,7 +6,7 @@ namespace Humans.Web.Controllers;
 
 /// <summary>
 /// Scanner section — in-browser tools for decoding barcodes / QR codes / similar from the
-/// device camera. Phase 1 (issue #525) only ships the barcode decoder; later tools live at
+/// device camera. Phase 1 (issue nobodies-collective/Humans#525) only ships the barcode decoder; later tools live at
 /// <c>/Scanner/{ToolName}</c>. Nothing on this section writes server-side state.
 /// </summary>
 [Authorize(Policy = PolicyNames.TicketAdminBoardOrAdmin)]

--- a/src/Humans.Web/Program.cs
+++ b/src/Humans.Web/Program.cs
@@ -570,7 +570,7 @@ app.Use(async (context, next) =>
     context.Response.Headers.Append("X-Frame-Options", "DENY");
     context.Response.Headers.Append("X-Content-Type-Options", "nosniff");
     context.Response.Headers.Append("Referrer-Policy", "strict-origin-when-cross-origin");
-    context.Response.Headers.Append("Permissions-Policy", "geolocation=(), microphone=(), camera=()");
+    context.Response.Headers.Append("Permissions-Policy", "geolocation=(), microphone=(), camera=(self)");
     await next();
 });
 

--- a/src/Humans.Web/Resources/SharedResource.ca.resx
+++ b/src/Humans.Web/Resources/SharedResource.ca.resx
@@ -1209,7 +1209,7 @@
   <data name="Nav_Board" xml:space="preserve"><value>Junta</value></data>
   <data name="Nav_Scanner" xml:space="preserve"><value>Escàner</value></data>
 
-  <!-- Scanner section (issue #525) -->
+  <!-- Scanner section (issue nobodies-collective/Humans#525) -->
   <data name="Scanner_Section" xml:space="preserve"><value>Escàner</value></data>
   <data name="Scanner_Index_Title" xml:space="preserve"><value>Eines d'escàner</value></data>
   <data name="Scanner_Index_Intro" xml:space="preserve"><value>Eines d'escàner al navegador. No s'envien dades al servidor — tot s'executa al teu dispositiu.</value></data>

--- a/src/Humans.Web/Resources/SharedResource.ca.resx
+++ b/src/Humans.Web/Resources/SharedResource.ca.resx
@@ -1207,6 +1207,30 @@
   <data name="Nav_Review" xml:space="preserve"><value>Revisió</value></data>
   <data name="Nav_Voting" xml:space="preserve"><value>Votació</value></data>
   <data name="Nav_Board" xml:space="preserve"><value>Junta</value></data>
+  <data name="Nav_Scanner" xml:space="preserve"><value>Escàner</value></data>
+
+  <!-- Scanner section (issue #525) -->
+  <data name="Scanner_Section" xml:space="preserve"><value>Escàner</value></data>
+  <data name="Scanner_Index_Title" xml:space="preserve"><value>Eines d'escàner</value></data>
+  <data name="Scanner_Index_Intro" xml:space="preserve"><value>Eines d'escàner al navegador. No s'envien dades al servidor — tot s'executa al teu dispositiu.</value></data>
+  <data name="Scanner_Barcode_Title" xml:space="preserve"><value>Escàner de codis de barres</value></data>
+  <data name="Scanner_Barcode_Open" xml:space="preserve"><value>Obre l'escàner</value></data>
+  <data name="Scanner_Barcode_CardBlurb" xml:space="preserve"><value>Decodifica codis QR i CODE128 amb la càmera del dispositiu.</value></data>
+  <data name="Scanner_Barcode_NotForCheckIn" xml:space="preserve"><value>Aquesta és una eina de prova — no s'usa per al check-in. Escanejar una entrada aquí no marca ningú com a entrat.</value></data>
+  <data name="Scanner_Barcode_Intro" xml:space="preserve"><value>Prem Escaneja per obrir la càmera, apunta-la al codi i el valor decodificat apareixerà a sota. No es desa res.</value></data>
+  <data name="Scanner_Barcode_Scan" xml:space="preserve"><value>Escaneja</value></data>
+  <data name="Scanner_Barcode_Stop" xml:space="preserve"><value>Atura</value></data>
+  <data name="Scanner_Barcode_VideoAria" xml:space="preserve"><value>Vista prèvia en directe de la càmera</value></data>
+  <data name="Scanner_Barcode_DecodedTitle" xml:space="preserve"><value>Codis decodificats</value></data>
+  <data name="Scanner_Barcode_DecodedHelp" xml:space="preserve"><value>El més recent a dalt. Aquesta llista es manté només al teu navegador i s'esborra en sortir.</value></data>
+  <data name="Scanner_Barcode_NoResultsYet" xml:space="preserve"><value>Encara no s'ha decodificat cap codi.</value></data>
+  <data name="Scanner_Barcode_Status_Starting" xml:space="preserve"><value>Iniciant càmera…</value></data>
+  <data name="Scanner_Barcode_Status_Running" xml:space="preserve"><value>Escanejant</value></data>
+  <data name="Scanner_Barcode_Status_Stopped" xml:space="preserve"><value>Aturat</value></data>
+  <data name="Scanner_Barcode_Path_Native" xml:space="preserve"><value>detector natiu</value></data>
+  <data name="Scanner_Barcode_Path_ZXing" xml:space="preserve"><value>fallback ZXing</value></data>
+  <data name="Scanner_Barcode_Error_Camera" xml:space="preserve"><value>No s'ha pogut accedir a la càmera. Assegura't d'haver donat permís i que la pàgina es serveix per HTTPS.</value></data>
+  <data name="Scanner_Barcode_Error_NoDecoder" xml:space="preserve"><value>El teu navegador no té descodificador integrat i la llibreria de fallback no s'ha carregat. Prova amb Chrome o Safari mòbil recents.</value></data>
 
   <!-- Team admin: add member -->
   <data name="TeamAdmin_AddMember" xml:space="preserve"><value>Afegeix membre</value></data>

--- a/src/Humans.Web/Resources/SharedResource.de.resx
+++ b/src/Humans.Web/Resources/SharedResource.de.resx
@@ -1202,6 +1202,30 @@
   <data name="Nav_Review" xml:space="preserve"><value>Überprüfung</value></data>
   <data name="Nav_Voting" xml:space="preserve"><value>Abstimmung</value></data>
   <data name="Nav_Board" xml:space="preserve"><value>Board</value></data>
+  <data name="Nav_Scanner" xml:space="preserve"><value>Scanner</value></data>
+
+  <!-- Scanner section (issue #525) -->
+  <data name="Scanner_Section" xml:space="preserve"><value>Scanner</value></data>
+  <data name="Scanner_Index_Title" xml:space="preserve"><value>Scanner-Tools</value></data>
+  <data name="Scanner_Index_Intro" xml:space="preserve"><value>Scanner-Tools im Browser. Es werden keine Daten an den Server gesendet — alles läuft auf deinem Gerät.</value></data>
+  <data name="Scanner_Barcode_Title" xml:space="preserve"><value>Barcode-Scanner</value></data>
+  <data name="Scanner_Barcode_Open" xml:space="preserve"><value>Scanner öffnen</value></data>
+  <data name="Scanner_Barcode_CardBlurb" xml:space="preserve"><value>Dekodiert QR-Codes und CODE128-Barcodes mit der Gerätekamera.</value></data>
+  <data name="Scanner_Barcode_NotForCheckIn" xml:space="preserve"><value>Dies ist ein Testwerkzeug — es wird nicht für den Check-in verwendet. Ein Ticket hier zu scannen markiert niemanden als angekommen.</value></data>
+  <data name="Scanner_Barcode_Intro" xml:space="preserve"><value>Tippe auf Scannen, um die Kamera zu öffnen, richte sie auf den Barcode, und der dekodierte Wert erscheint unten. Nichts wird gespeichert.</value></data>
+  <data name="Scanner_Barcode_Scan" xml:space="preserve"><value>Scannen</value></data>
+  <data name="Scanner_Barcode_Stop" xml:space="preserve"><value>Stopp</value></data>
+  <data name="Scanner_Barcode_VideoAria" xml:space="preserve"><value>Live-Kameravorschau</value></data>
+  <data name="Scanner_Barcode_DecodedTitle" xml:space="preserve"><value>Dekodierte Codes</value></data>
+  <data name="Scanner_Barcode_DecodedHelp" xml:space="preserve"><value>Neueste oben. Diese Liste bleibt nur in deinem Browser und wird beim Verlassen der Seite gelöscht.</value></data>
+  <data name="Scanner_Barcode_NoResultsYet" xml:space="preserve"><value>Noch keine Codes dekodiert.</value></data>
+  <data name="Scanner_Barcode_Status_Starting" xml:space="preserve"><value>Kamera wird gestartet…</value></data>
+  <data name="Scanner_Barcode_Status_Running" xml:space="preserve"><value>Scanne</value></data>
+  <data name="Scanner_Barcode_Status_Stopped" xml:space="preserve"><value>Gestoppt</value></data>
+  <data name="Scanner_Barcode_Path_Native" xml:space="preserve"><value>nativer Detektor</value></data>
+  <data name="Scanner_Barcode_Path_ZXing" xml:space="preserve"><value>ZXing-Fallback</value></data>
+  <data name="Scanner_Barcode_Error_Camera" xml:space="preserve"><value>Kein Zugriff auf die Kamera. Stelle sicher, dass du die Berechtigung erteilt hast und die Seite über HTTPS ausgeliefert wird.</value></data>
+  <data name="Scanner_Barcode_Error_NoDecoder" xml:space="preserve"><value>Dein Browser hat keinen eingebauten Dekodierer und die Fallback-Bibliothek konnte nicht geladen werden. Versuche es mit aktuellem Chrome oder Safari auf einem Mobilgerät.</value></data>
 
   <!-- Team admin: add member -->
   <data name="TeamAdmin_AddMember" xml:space="preserve"><value>Mitglied hinzuf&#xFC;gen</value></data>

--- a/src/Humans.Web/Resources/SharedResource.de.resx
+++ b/src/Humans.Web/Resources/SharedResource.de.resx
@@ -1204,7 +1204,7 @@
   <data name="Nav_Board" xml:space="preserve"><value>Board</value></data>
   <data name="Nav_Scanner" xml:space="preserve"><value>Scanner</value></data>
 
-  <!-- Scanner section (issue #525) -->
+  <!-- Scanner section (issue nobodies-collective/Humans#525) -->
   <data name="Scanner_Section" xml:space="preserve"><value>Scanner</value></data>
   <data name="Scanner_Index_Title" xml:space="preserve"><value>Scanner-Tools</value></data>
   <data name="Scanner_Index_Intro" xml:space="preserve"><value>Scanner-Tools im Browser. Es werden keine Daten an den Server gesendet — alles läuft auf deinem Gerät.</value></data>

--- a/src/Humans.Web/Resources/SharedResource.es.resx
+++ b/src/Humans.Web/Resources/SharedResource.es.resx
@@ -1207,6 +1207,30 @@
   <data name="Nav_Review" xml:space="preserve"><value>Revisión</value></data>
   <data name="Nav_Voting" xml:space="preserve"><value>Votación</value></data>
   <data name="Nav_Board" xml:space="preserve"><value>Board</value></data>
+  <data name="Nav_Scanner" xml:space="preserve"><value>Escáner</value></data>
+
+  <!-- Scanner section (issue #525) -->
+  <data name="Scanner_Section" xml:space="preserve"><value>Escáner</value></data>
+  <data name="Scanner_Index_Title" xml:space="preserve"><value>Herramientas de escáner</value></data>
+  <data name="Scanner_Index_Intro" xml:space="preserve"><value>Herramientas de escáner en el navegador. No se envían datos al servidor — todo se ejecuta en tu dispositivo.</value></data>
+  <data name="Scanner_Barcode_Title" xml:space="preserve"><value>Escáner de códigos de barras</value></data>
+  <data name="Scanner_Barcode_Open" xml:space="preserve"><value>Abrir escáner</value></data>
+  <data name="Scanner_Barcode_CardBlurb" xml:space="preserve"><value>Decodifica códigos QR y CODE128 usando la cámara del dispositivo.</value></data>
+  <data name="Scanner_Barcode_NotForCheckIn" xml:space="preserve"><value>Esta es una herramienta de prueba — no se usa para el check-in. Escanear una entrada aquí no marca a nadie como entrada.</value></data>
+  <data name="Scanner_Barcode_Intro" xml:space="preserve"><value>Pulsa Escanear para abrir la cámara, apúntala al código, y el valor decodificado aparecerá debajo. Nada se guarda.</value></data>
+  <data name="Scanner_Barcode_Scan" xml:space="preserve"><value>Escanear</value></data>
+  <data name="Scanner_Barcode_Stop" xml:space="preserve"><value>Detener</value></data>
+  <data name="Scanner_Barcode_VideoAria" xml:space="preserve"><value>Vista previa en vivo de la cámara</value></data>
+  <data name="Scanner_Barcode_DecodedTitle" xml:space="preserve"><value>Códigos decodificados</value></data>
+  <data name="Scanner_Barcode_DecodedHelp" xml:space="preserve"><value>El más reciente arriba. Esta lista se mantiene solo en tu navegador y se borra al salir de la página.</value></data>
+  <data name="Scanner_Barcode_NoResultsYet" xml:space="preserve"><value>Aún no se ha decodificado ningún código.</value></data>
+  <data name="Scanner_Barcode_Status_Starting" xml:space="preserve"><value>Iniciando cámara…</value></data>
+  <data name="Scanner_Barcode_Status_Running" xml:space="preserve"><value>Escaneando</value></data>
+  <data name="Scanner_Barcode_Status_Stopped" xml:space="preserve"><value>Detenido</value></data>
+  <data name="Scanner_Barcode_Path_Native" xml:space="preserve"><value>detector nativo</value></data>
+  <data name="Scanner_Barcode_Path_ZXing" xml:space="preserve"><value>fallback ZXing</value></data>
+  <data name="Scanner_Barcode_Error_Camera" xml:space="preserve"><value>No se pudo acceder a la cámara. Asegúrate de haber otorgado permiso y de que la página se sirva por HTTPS.</value></data>
+  <data name="Scanner_Barcode_Error_NoDecoder" xml:space="preserve"><value>Tu navegador no tiene decodificador integrado y la librería de fallback no se cargó. Prueba con Chrome o Safari móvil recientes.</value></data>
 
   <!-- Team admin: add member -->
   <data name="TeamAdmin_AddMember" xml:space="preserve"><value>Agregar miembro</value></data>

--- a/src/Humans.Web/Resources/SharedResource.es.resx
+++ b/src/Humans.Web/Resources/SharedResource.es.resx
@@ -1209,7 +1209,7 @@
   <data name="Nav_Board" xml:space="preserve"><value>Board</value></data>
   <data name="Nav_Scanner" xml:space="preserve"><value>Escáner</value></data>
 
-  <!-- Scanner section (issue #525) -->
+  <!-- Scanner section (issue nobodies-collective/Humans#525) -->
   <data name="Scanner_Section" xml:space="preserve"><value>Escáner</value></data>
   <data name="Scanner_Index_Title" xml:space="preserve"><value>Herramientas de escáner</value></data>
   <data name="Scanner_Index_Intro" xml:space="preserve"><value>Herramientas de escáner en el navegador. No se envían datos al servidor — todo se ejecuta en tu dispositivo.</value></data>

--- a/src/Humans.Web/Resources/SharedResource.fr.resx
+++ b/src/Humans.Web/Resources/SharedResource.fr.resx
@@ -1202,6 +1202,30 @@
   <data name="Nav_Review" xml:space="preserve"><value>Examen</value></data>
   <data name="Nav_Voting" xml:space="preserve"><value>Vote</value></data>
   <data name="Nav_Board" xml:space="preserve"><value>Board</value></data>
+  <data name="Nav_Scanner" xml:space="preserve"><value>Scanner</value></data>
+
+  <!-- Scanner section (issue #525) -->
+  <data name="Scanner_Section" xml:space="preserve"><value>Scanner</value></data>
+  <data name="Scanner_Index_Title" xml:space="preserve"><value>Outils de scanner</value></data>
+  <data name="Scanner_Index_Intro" xml:space="preserve"><value>Outils de scanner dans le navigateur. Aucune donnée n'est envoyée au serveur — tout s'exécute sur ton appareil.</value></data>
+  <data name="Scanner_Barcode_Title" xml:space="preserve"><value>Scanner de code-barres</value></data>
+  <data name="Scanner_Barcode_Open" xml:space="preserve"><value>Ouvrir le scanner</value></data>
+  <data name="Scanner_Barcode_CardBlurb" xml:space="preserve"><value>Décode les QR codes et les codes-barres CODE128 avec la caméra de l'appareil.</value></data>
+  <data name="Scanner_Barcode_NotForCheckIn" xml:space="preserve"><value>Ceci est un outil de test — il n'est pas utilisé pour le check-in. Scanner un billet ici ne marque personne comme arrivé.</value></data>
+  <data name="Scanner_Barcode_Intro" xml:space="preserve"><value>Appuie sur Scanner pour ouvrir la caméra, pointe-la vers le code, et la valeur décodée apparaîtra ci-dessous. Rien n'est enregistré.</value></data>
+  <data name="Scanner_Barcode_Scan" xml:space="preserve"><value>Scanner</value></data>
+  <data name="Scanner_Barcode_Stop" xml:space="preserve"><value>Arrêter</value></data>
+  <data name="Scanner_Barcode_VideoAria" xml:space="preserve"><value>Aperçu en direct de la caméra</value></data>
+  <data name="Scanner_Barcode_DecodedTitle" xml:space="preserve"><value>Codes décodés</value></data>
+  <data name="Scanner_Barcode_DecodedHelp" xml:space="preserve"><value>Le plus récent en haut. Cette liste reste uniquement dans ton navigateur et se vide en quittant la page.</value></data>
+  <data name="Scanner_Barcode_NoResultsYet" xml:space="preserve"><value>Aucun code décodé pour l'instant.</value></data>
+  <data name="Scanner_Barcode_Status_Starting" xml:space="preserve"><value>Démarrage de la caméra…</value></data>
+  <data name="Scanner_Barcode_Status_Running" xml:space="preserve"><value>Scanne en cours</value></data>
+  <data name="Scanner_Barcode_Status_Stopped" xml:space="preserve"><value>Arrêté</value></data>
+  <data name="Scanner_Barcode_Path_Native" xml:space="preserve"><value>détecteur natif</value></data>
+  <data name="Scanner_Barcode_Path_ZXing" xml:space="preserve"><value>repli ZXing</value></data>
+  <data name="Scanner_Barcode_Error_Camera" xml:space="preserve"><value>Impossible d'accéder à la caméra. Assure-toi d'avoir accordé la permission et que la page est servie en HTTPS.</value></data>
+  <data name="Scanner_Barcode_Error_NoDecoder" xml:space="preserve"><value>Ton navigateur n'a pas de décodeur intégré et la bibliothèque de repli n'a pas pu se charger. Essaye avec Chrome ou Safari mobile récents.</value></data>
 
   <!-- Team admin: add member -->
   <data name="TeamAdmin_AddMember" xml:space="preserve"><value>Ajouter un membre</value></data>

--- a/src/Humans.Web/Resources/SharedResource.fr.resx
+++ b/src/Humans.Web/Resources/SharedResource.fr.resx
@@ -1204,7 +1204,7 @@
   <data name="Nav_Board" xml:space="preserve"><value>Board</value></data>
   <data name="Nav_Scanner" xml:space="preserve"><value>Scanner</value></data>
 
-  <!-- Scanner section (issue #525) -->
+  <!-- Scanner section (issue nobodies-collective/Humans#525) -->
   <data name="Scanner_Section" xml:space="preserve"><value>Scanner</value></data>
   <data name="Scanner_Index_Title" xml:space="preserve"><value>Outils de scanner</value></data>
   <data name="Scanner_Index_Intro" xml:space="preserve"><value>Outils de scanner dans le navigateur. Aucune donnée n'est envoyée au serveur — tout s'exécute sur ton appareil.</value></data>

--- a/src/Humans.Web/Resources/SharedResource.it.resx
+++ b/src/Humans.Web/Resources/SharedResource.it.resx
@@ -1204,7 +1204,7 @@
   <data name="Nav_Board" xml:space="preserve"><value>Board</value></data>
   <data name="Nav_Scanner" xml:space="preserve"><value>Scanner</value></data>
 
-  <!-- Scanner section (issue #525) -->
+  <!-- Scanner section (issue nobodies-collective/Humans#525) -->
   <data name="Scanner_Section" xml:space="preserve"><value>Scanner</value></data>
   <data name="Scanner_Index_Title" xml:space="preserve"><value>Strumenti di scanner</value></data>
   <data name="Scanner_Index_Intro" xml:space="preserve"><value>Strumenti di scanner nel browser. Non si inviano dati al server — tutto gira sul tuo dispositivo.</value></data>

--- a/src/Humans.Web/Resources/SharedResource.it.resx
+++ b/src/Humans.Web/Resources/SharedResource.it.resx
@@ -1202,6 +1202,30 @@
   <data name="Nav_Review" xml:space="preserve"><value>Revisione</value></data>
   <data name="Nav_Voting" xml:space="preserve"><value>Votazione</value></data>
   <data name="Nav_Board" xml:space="preserve"><value>Board</value></data>
+  <data name="Nav_Scanner" xml:space="preserve"><value>Scanner</value></data>
+
+  <!-- Scanner section (issue #525) -->
+  <data name="Scanner_Section" xml:space="preserve"><value>Scanner</value></data>
+  <data name="Scanner_Index_Title" xml:space="preserve"><value>Strumenti di scanner</value></data>
+  <data name="Scanner_Index_Intro" xml:space="preserve"><value>Strumenti di scanner nel browser. Non si inviano dati al server — tutto gira sul tuo dispositivo.</value></data>
+  <data name="Scanner_Barcode_Title" xml:space="preserve"><value>Scanner di codici a barre</value></data>
+  <data name="Scanner_Barcode_Open" xml:space="preserve"><value>Apri scanner</value></data>
+  <data name="Scanner_Barcode_CardBlurb" xml:space="preserve"><value>Decodifica codici QR e CODE128 usando la fotocamera del dispositivo.</value></data>
+  <data name="Scanner_Barcode_NotForCheckIn" xml:space="preserve"><value>Questo è uno strumento di test — non si usa per il check-in. Scansionare un biglietto qui non segna nessuno come arrivato.</value></data>
+  <data name="Scanner_Barcode_Intro" xml:space="preserve"><value>Tocca Scansiona per aprire la fotocamera, puntala sul codice, e il valore decodificato apparirà sotto. Niente viene salvato.</value></data>
+  <data name="Scanner_Barcode_Scan" xml:space="preserve"><value>Scansiona</value></data>
+  <data name="Scanner_Barcode_Stop" xml:space="preserve"><value>Ferma</value></data>
+  <data name="Scanner_Barcode_VideoAria" xml:space="preserve"><value>Anteprima dal vivo della fotocamera</value></data>
+  <data name="Scanner_Barcode_DecodedTitle" xml:space="preserve"><value>Codici decodificati</value></data>
+  <data name="Scanner_Barcode_DecodedHelp" xml:space="preserve"><value>Il più recente in alto. Questa lista resta solo nel tuo browser e si cancella quando esci dalla pagina.</value></data>
+  <data name="Scanner_Barcode_NoResultsYet" xml:space="preserve"><value>Nessun codice decodificato.</value></data>
+  <data name="Scanner_Barcode_Status_Starting" xml:space="preserve"><value>Avvio fotocamera…</value></data>
+  <data name="Scanner_Barcode_Status_Running" xml:space="preserve"><value>Scansione</value></data>
+  <data name="Scanner_Barcode_Status_Stopped" xml:space="preserve"><value>Fermato</value></data>
+  <data name="Scanner_Barcode_Path_Native" xml:space="preserve"><value>decodificatore nativo</value></data>
+  <data name="Scanner_Barcode_Path_ZXing" xml:space="preserve"><value>fallback ZXing</value></data>
+  <data name="Scanner_Barcode_Error_Camera" xml:space="preserve"><value>Impossibile accedere alla fotocamera. Assicurati di aver concesso il permesso e che la pagina sia servita via HTTPS.</value></data>
+  <data name="Scanner_Barcode_Error_NoDecoder" xml:space="preserve"><value>Il tuo browser non ha un decodificatore integrato e la libreria di fallback non si è caricata. Prova con Chrome o Safari mobile recenti.</value></data>
 
   <!-- Team admin: add member -->
   <data name="TeamAdmin_AddMember" xml:space="preserve"><value>Aggiungi membro</value></data>

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -1235,6 +1235,30 @@
   <data name="Nav_Review" xml:space="preserve"><value>Review</value></data>
   <data name="Nav_Voting" xml:space="preserve"><value>Voting</value></data>
   <data name="Nav_Board" xml:space="preserve"><value>Board</value></data>
+  <data name="Nav_Scanner" xml:space="preserve"><value>Scanner</value></data>
+
+  <!-- Scanner section (issue #525) -->
+  <data name="Scanner_Section" xml:space="preserve"><value>Scanner</value></data>
+  <data name="Scanner_Index_Title" xml:space="preserve"><value>Scanner tools</value></data>
+  <data name="Scanner_Index_Intro" xml:space="preserve"><value>In-browser scanner tools. No data is sent to the server — everything runs on your device.</value></data>
+  <data name="Scanner_Barcode_Title" xml:space="preserve"><value>Barcode scanner</value></data>
+  <data name="Scanner_Barcode_Open" xml:space="preserve"><value>Open barcode scanner</value></data>
+  <data name="Scanner_Barcode_CardBlurb" xml:space="preserve"><value>Decode QR codes and CODE128 barcodes using the device camera.</value></data>
+  <data name="Scanner_Barcode_NotForCheckIn" xml:space="preserve"><value>This is a test tool — it is not used for check-in. Scanning a ticket here does not mark anyone as arrived.</value></data>
+  <data name="Scanner_Barcode_Intro" xml:space="preserve"><value>Tap Scan to open the camera, point it at a barcode, and the decoded value will appear below. Nothing is saved.</value></data>
+  <data name="Scanner_Barcode_Scan" xml:space="preserve"><value>Scan</value></data>
+  <data name="Scanner_Barcode_Stop" xml:space="preserve"><value>Stop</value></data>
+  <data name="Scanner_Barcode_VideoAria" xml:space="preserve"><value>Live camera preview</value></data>
+  <data name="Scanner_Barcode_DecodedTitle" xml:space="preserve"><value>Decoded barcodes</value></data>
+  <data name="Scanner_Barcode_DecodedHelp" xml:space="preserve"><value>Most recent on top. This list is kept in your browser only and cleared when you leave the page.</value></data>
+  <data name="Scanner_Barcode_NoResultsYet" xml:space="preserve"><value>No barcodes decoded yet.</value></data>
+  <data name="Scanner_Barcode_Status_Starting" xml:space="preserve"><value>Starting camera…</value></data>
+  <data name="Scanner_Barcode_Status_Running" xml:space="preserve"><value>Scanning</value></data>
+  <data name="Scanner_Barcode_Status_Stopped" xml:space="preserve"><value>Stopped</value></data>
+  <data name="Scanner_Barcode_Path_Native" xml:space="preserve"><value>native detector</value></data>
+  <data name="Scanner_Barcode_Path_ZXing" xml:space="preserve"><value>ZXing fallback</value></data>
+  <data name="Scanner_Barcode_Error_Camera" xml:space="preserve"><value>Couldn't access the camera. Make sure you've granted permission and that this page is served over HTTPS.</value></data>
+  <data name="Scanner_Barcode_Error_NoDecoder" xml:space="preserve"><value>Your browser doesn't have a built-in barcode decoder and the fallback library failed to load. Try a recent mobile Chrome or Safari.</value></data>
 
   <!-- Team admin: add member -->
   <data name="TeamAdmin_AddMember" xml:space="preserve"><value>Add Member</value></data>

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -1237,7 +1237,7 @@
   <data name="Nav_Board" xml:space="preserve"><value>Board</value></data>
   <data name="Nav_Scanner" xml:space="preserve"><value>Scanner</value></data>
 
-  <!-- Scanner section (issue #525) -->
+  <!-- Scanner section (issue nobodies-collective/Humans#525) -->
   <data name="Scanner_Section" xml:space="preserve"><value>Scanner</value></data>
   <data name="Scanner_Index_Title" xml:space="preserve"><value>Scanner tools</value></data>
   <data name="Scanner_Index_Intro" xml:space="preserve"><value>In-browser scanner tools. No data is sent to the server — everything runs on your device.</value></data>

--- a/src/Humans.Web/Views/About/Index.cshtml
+++ b/src/Humans.Web/Views/About/Index.cshtml
@@ -446,6 +446,11 @@
                     <td>4.x</td>
                     <td>MIT</td>
                 </tr>
+                <tr>
+                    <td><a href="https://github.com/zxing-js/browser" target="_blank" rel="noopener noreferrer">@@zxing/browser</a></td>
+                    <td>0.1.5</td>
+                    <td>MIT</td>
+                </tr>
             </tbody>
         </table>
     </div>

--- a/src/Humans.Web/Views/Scanner/Barcode.cshtml
+++ b/src/Humans.Web/Views/Scanner/Barcode.cshtml
@@ -1,0 +1,88 @@
+@{
+    ViewData["Title"] = Localizer["Scanner_Barcode_Title"].Value;
+}
+
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a asp-action="Index">@Localizer["Scanner_Section"]</a></li>
+        <li class="breadcrumb-item active" aria-current="page">@Localizer["Scanner_Barcode_Title"]</li>
+    </ol>
+</nav>
+
+<h1>@Localizer["Scanner_Barcode_Title"]</h1>
+
+<div class="alert alert-warning d-flex align-items-center" role="alert">
+    <i class="fa-solid fa-triangle-exclamation me-2" aria-hidden="true"></i>
+    <div>@Localizer["Scanner_Barcode_NotForCheckIn"]</div>
+</div>
+
+<p class="text-muted">@Localizer["Scanner_Barcode_Intro"]</p>
+
+<div class="row g-3">
+    <div class="col-lg-7">
+        <div class="card">
+            <div class="card-body">
+                <div class="d-flex gap-2 mb-3">
+                    <button type="button" class="btn btn-primary" id="scanner-start">
+                        <i class="fa-solid fa-play me-1" aria-hidden="true"></i>
+                        @Localizer["Scanner_Barcode_Scan"]
+                    </button>
+                    <button type="button" class="btn btn-outline-secondary" id="scanner-stop" disabled>
+                        <i class="fa-solid fa-stop me-1" aria-hidden="true"></i>
+                        @Localizer["Scanner_Barcode_Stop"]
+                    </button>
+                </div>
+
+                <div id="scanner-status" class="small text-muted mb-2" aria-live="polite"></div>
+
+                <video id="scanner-video"
+                       class="w-100 rounded border bg-dark"
+                       style="aspect-ratio: 4 / 3; object-fit: cover;"
+                       playsinline
+                       muted
+                       aria-label="@Localizer["Scanner_Barcode_VideoAria"]"></video>
+
+                <div id="scanner-error" class="alert alert-danger mt-3 d-none" role="alert"></div>
+            </div>
+        </div>
+    </div>
+
+    <div class="col-lg-5">
+        <div class="card">
+            <div class="card-body">
+                <h5 class="card-title">@Localizer["Scanner_Barcode_DecodedTitle"]</h5>
+                <p class="small text-muted">@Localizer["Scanner_Barcode_DecodedHelp"]</p>
+                <ul id="scanner-results" class="list-group list-group-flush">
+                    <li id="scanner-results-empty" class="list-group-item text-muted small">
+                        @Localizer["Scanner_Barcode_NoResultsYet"]
+                    </li>
+                </ul>
+            </div>
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+    <script nonce="@Context.Items["CspNonce"]" type="module">
+        import { initBarcodeScanner } from '@Url.Content("~/js/scanner/barcode.js")';
+
+        initBarcodeScanner({
+            startButton: document.getElementById('scanner-start'),
+            stopButton: document.getElementById('scanner-stop'),
+            video: document.getElementById('scanner-video'),
+            results: document.getElementById('scanner-results'),
+            resultsEmpty: document.getElementById('scanner-results-empty'),
+            status: document.getElementById('scanner-status'),
+            error: document.getElementById('scanner-error'),
+            labels: {
+                starting: '@Localizer["Scanner_Barcode_Status_Starting"]',
+                running: '@Localizer["Scanner_Barcode_Status_Running"]',
+                stopped: '@Localizer["Scanner_Barcode_Status_Stopped"]',
+                pathNative: '@Localizer["Scanner_Barcode_Path_Native"]',
+                pathZxing: '@Localizer["Scanner_Barcode_Path_ZXing"]',
+                errorCamera: '@Localizer["Scanner_Barcode_Error_Camera"]',
+                errorNoDecoder: '@Localizer["Scanner_Barcode_Error_NoDecoder"]'
+            }
+        });
+    </script>
+}

--- a/src/Humans.Web/Views/Scanner/Barcode.cshtml
+++ b/src/Humans.Web/Views/Scanner/Barcode.cshtml
@@ -75,13 +75,13 @@
             status: document.getElementById('scanner-status'),
             error: document.getElementById('scanner-error'),
             labels: {
-                starting: '@Localizer["Scanner_Barcode_Status_Starting"]',
-                running: '@Localizer["Scanner_Barcode_Status_Running"]',
-                stopped: '@Localizer["Scanner_Barcode_Status_Stopped"]',
-                pathNative: '@Localizer["Scanner_Barcode_Path_Native"]',
-                pathZxing: '@Localizer["Scanner_Barcode_Path_ZXing"]',
-                errorCamera: '@Localizer["Scanner_Barcode_Error_Camera"]',
-                errorNoDecoder: '@Localizer["Scanner_Barcode_Error_NoDecoder"]'
+                starting: @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Localizer["Scanner_Barcode_Status_Starting"].Value)),
+                running: @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Localizer["Scanner_Barcode_Status_Running"].Value)),
+                stopped: @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Localizer["Scanner_Barcode_Status_Stopped"].Value)),
+                pathNative: @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Localizer["Scanner_Barcode_Path_Native"].Value)),
+                pathZxing: @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Localizer["Scanner_Barcode_Path_ZXing"].Value)),
+                errorCamera: @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Localizer["Scanner_Barcode_Error_Camera"].Value)),
+                errorNoDecoder: @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Localizer["Scanner_Barcode_Error_NoDecoder"].Value))
             }
         });
     </script>

--- a/src/Humans.Web/Views/Scanner/Index.cshtml
+++ b/src/Humans.Web/Views/Scanner/Index.cshtml
@@ -1,0 +1,29 @@
+@{
+    ViewData["Title"] = Localizer["Scanner_Index_Title"].Value;
+}
+
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item active" aria-current="page">@Localizer["Scanner_Section"]</li>
+    </ol>
+</nav>
+
+<h1>@Localizer["Scanner_Section"]</h1>
+<p class="text-muted">@Localizer["Scanner_Index_Intro"]</p>
+
+<div class="row g-3">
+    <div class="col-md-6">
+        <div class="card h-100">
+            <div class="card-body">
+                <h5 class="card-title">
+                    <i class="fa-solid fa-barcode me-2"></i>
+                    @Localizer["Scanner_Barcode_Title"]
+                </h5>
+                <p class="card-text text-muted">@Localizer["Scanner_Barcode_CardBlurb"]</p>
+                <a class="btn btn-primary" asp-action="Barcode">
+                    @Localizer["Scanner_Barcode_Open"]
+                </a>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/Humans.Web/Views/Shared/_Layout.cshtml
+++ b/src/Humans.Web/Views/Shared/_Layout.cshtml
@@ -134,6 +134,9 @@
                         <li class="nav-item" authorize-policy="TicketAdminBoardOrAdmin">
                             <a class="nav-link nav-restricted" asp-area="" asp-controller="Ticket" asp-action="Index">Tickets</a>
                         </li>
+                        <li class="nav-item" authorize-policy="TicketAdminBoardOrAdmin">
+                            <a class="nav-link nav-restricted" asp-area="" asp-controller="Scanner" asp-action="Index">@Localizer["Nav_Scanner"]</a>
+                        </li>
                         <li class="nav-item" authorize-policy="IsActiveMember">
                             <a class="nav-link" asp-area="" asp-controller="Budget" asp-action="Summary">Budget</a>
                         </li>

--- a/src/Humans.Web/wwwroot/js/scanner/barcode.js
+++ b/src/Humans.Web/wwwroot/js/scanner/barcode.js
@@ -158,6 +158,7 @@ export function initBarcodeScanner(refs) {
             decodePath = 'zxing';
             setStatus(`${labels.running} (${labels.pathZxing})`);
             startZxing().catch((e) => {
+                if (!mediaStream) return; // user pressed Stop while CDN was loading
                 console.error('Scanner: zxing fallback also failed', e);
                 showError(labels.errorNoDecoder);
                 stop();

--- a/src/Humans.Web/wwwroot/js/scanner/barcode.js
+++ b/src/Humans.Web/wwwroot/js/scanner/barcode.js
@@ -119,6 +119,9 @@ export function initBarcodeScanner(refs) {
             await video.play();
         } catch (err) {
             console.warn('Scanner: video.play() rejected', err);
+            showError(labels.errorCamera);
+            await stop();
+            return;
         }
 
         stopButton.disabled = false;
@@ -182,7 +185,7 @@ export function initBarcodeScanner(refs) {
     }
 
     async function startZxing() {
-        const mod = await import(/* @vite-ignore */ ZXING_CDN_URL);
+        const mod = await import(ZXING_CDN_URL);
         const BrowserMultiFormatReader = mod.BrowserMultiFormatReader ?? mod.default?.BrowserMultiFormatReader;
         if (!BrowserMultiFormatReader) {
             throw new Error('BrowserMultiFormatReader not found in ZXing module export');
@@ -198,7 +201,7 @@ export function initBarcodeScanner(refs) {
         });
     }
 
-    async function stop() {
+    function stop() {
         if (nativeLoopHandle) {
             cancelAnimationFrame(nativeLoopHandle);
             nativeLoopHandle = null;

--- a/src/Humans.Web/wwwroot/js/scanner/barcode.js
+++ b/src/Humans.Web/wwwroot/js/scanner/barcode.js
@@ -1,0 +1,237 @@
+// Scanner section — phase 1 barcode decode.
+//
+// Feature-detects the native BarcodeDetector API (Chrome/Edge/most Android). Falls back
+// to @zxing/browser via CDN for iOS Safari and anywhere else the native API isn't shipped.
+// Everything runs in the browser — no server round trip, no state written.
+
+const ZXING_CDN_URL = 'https://cdn.jsdelivr.net/npm/@zxing/browser@0.1.5/+esm';
+const DEDUPE_WINDOW_MS = 1500;
+
+export function initBarcodeScanner(refs) {
+    const {
+        startButton,
+        stopButton,
+        video,
+        results,
+        resultsEmpty,
+        status,
+        error,
+        labels,
+    } = refs;
+
+    let mediaStream = null;
+    let nativeDetector = null;
+    let nativeLoopHandle = null;
+    let zxingReader = null;
+    let zxingControls = null;
+    let decodePath = null; // 'native' | 'zxing'
+    const recentHits = new Map(); // dedupe key → timestamp
+
+    function setStatus(message) {
+        status.textContent = message ?? '';
+    }
+
+    function showError(message) {
+        if (!message) {
+            error.classList.add('d-none');
+            error.textContent = '';
+            return;
+        }
+        error.textContent = message;
+        error.classList.remove('d-none');
+    }
+
+    function addResult(value, format) {
+        if (!value) return;
+
+        const dedupeKey = `${format}|${value}`;
+        const now = Date.now();
+        const previous = recentHits.get(dedupeKey);
+        if (previous && now - previous < DEDUPE_WINDOW_MS) {
+            return;
+        }
+        recentHits.set(dedupeKey, now);
+
+        if (resultsEmpty && !resultsEmpty.classList.contains('d-none')) {
+            resultsEmpty.classList.add('d-none');
+        }
+
+        const item = document.createElement('li');
+        item.className = 'list-group-item';
+
+        const formatBadge = document.createElement('span');
+        formatBadge.className = 'badge bg-secondary me-2';
+        formatBadge.textContent = format || 'UNKNOWN';
+
+        const timestamp = document.createElement('small');
+        timestamp.className = 'text-muted float-end';
+        timestamp.textContent = new Date().toLocaleTimeString();
+
+        const valueNode = renderValueNode(value);
+
+        item.appendChild(formatBadge);
+        item.appendChild(valueNode);
+        item.appendChild(timestamp);
+        results.insertBefore(item, results.firstChild);
+    }
+
+    function renderValueNode(value) {
+        let parsed;
+        try {
+            parsed = new URL(value);
+        } catch {
+            parsed = null;
+        }
+        if (parsed && (parsed.protocol === 'http:' || parsed.protocol === 'https:')) {
+            const anchor = document.createElement('a');
+            anchor.href = value;
+            anchor.textContent = value;
+            anchor.target = '_blank';
+            anchor.rel = 'noopener noreferrer';
+            return anchor;
+        }
+        const span = document.createElement('code');
+        span.className = 'text-break';
+        span.textContent = value;
+        return span;
+    }
+
+    async function start() {
+        showError(null);
+        setStatus(labels.starting);
+        startButton.disabled = true;
+
+        try {
+            mediaStream = await navigator.mediaDevices.getUserMedia({
+                video: { facingMode: 'environment' },
+                audio: false,
+            });
+        } catch (err) {
+            console.error('Scanner: camera access failed', err);
+            showError(labels.errorCamera);
+            setStatus(labels.stopped);
+            startButton.disabled = false;
+            return;
+        }
+
+        video.srcObject = mediaStream;
+        try {
+            await video.play();
+        } catch (err) {
+            console.warn('Scanner: video.play() rejected', err);
+        }
+
+        stopButton.disabled = false;
+
+        if ('BarcodeDetector' in window) {
+            decodePath = 'native';
+            console.info('Scanner: using native BarcodeDetector');
+            setStatus(`${labels.running} (${labels.pathNative})`);
+            startNativeLoop();
+            return;
+        }
+
+        decodePath = 'zxing';
+        console.info('Scanner: falling back to @zxing/browser via CDN');
+        setStatus(`${labels.running} (${labels.pathZxing})`);
+        try {
+            await startZxing();
+        } catch (err) {
+            console.error('Scanner: zxing bootstrap failed', err);
+            showError(labels.errorNoDecoder);
+            await stop();
+        }
+    }
+
+    function startNativeLoop() {
+        try {
+            nativeDetector = new window.BarcodeDetector({
+                formats: ['qr_code', 'code_128', 'code_39', 'ean_13', 'ean_8', 'upc_a', 'upc_e', 'pdf417', 'data_matrix'],
+            });
+        } catch (err) {
+            // Some browsers report BarcodeDetector but constructors fail for unsupported formats.
+            console.warn('Scanner: BarcodeDetector constructor failed, falling back to ZXing', err);
+            decodePath = 'zxing';
+            startZxing().catch((e) => {
+                console.error('Scanner: zxing fallback also failed', e);
+                showError(labels.errorNoDecoder);
+                stop();
+            });
+            return;
+        }
+
+        const scan = async () => {
+            if (!mediaStream) return;
+            try {
+                const codes = await nativeDetector.detect(video);
+                for (const code of codes) {
+                    addResult(code.rawValue, code.format?.toUpperCase?.() ?? 'UNKNOWN');
+                }
+            } catch (err) {
+                // Transient detect() failures are expected while the video warms up.
+                console.debug('Scanner: detect() transient error', err);
+            }
+            if (mediaStream) {
+                nativeLoopHandle = requestAnimationFrame(scan);
+            }
+        };
+
+        nativeLoopHandle = requestAnimationFrame(scan);
+    }
+
+    async function startZxing() {
+        const mod = await import(/* @vite-ignore */ ZXING_CDN_URL);
+        const BrowserMultiFormatReader = mod.BrowserMultiFormatReader ?? mod.default?.BrowserMultiFormatReader;
+        if (!BrowserMultiFormatReader) {
+            throw new Error('BrowserMultiFormatReader not found in ZXing module export');
+        }
+
+        zxingReader = new BrowserMultiFormatReader();
+        zxingControls = await zxingReader.decodeFromStream(mediaStream, video, (result, err) => {
+            if (result) {
+                const format = result.getBarcodeFormat?.()?.toString?.() ?? 'UNKNOWN';
+                addResult(result.getText(), format);
+            }
+            // err is a NotFoundException on every empty frame — ignore silently.
+        });
+    }
+
+    async function stop() {
+        if (nativeLoopHandle) {
+            cancelAnimationFrame(nativeLoopHandle);
+            nativeLoopHandle = null;
+        }
+        if (zxingControls) {
+            try {
+                zxingControls.stop();
+            } catch (err) {
+                console.debug('Scanner: zxing controls.stop error', err);
+            }
+            zxingControls = null;
+        }
+        if (zxingReader) {
+            try {
+                zxingReader.reset?.();
+            } catch (err) {
+                console.debug('Scanner: zxing reader.reset error', err);
+            }
+            zxingReader = null;
+        }
+        if (mediaStream) {
+            for (const track of mediaStream.getTracks()) {
+                try { track.stop(); } catch (err) { console.debug('Scanner: track.stop error', err); }
+            }
+            mediaStream = null;
+        }
+        video.srcObject = null;
+        setStatus(labels.stopped);
+        startButton.disabled = false;
+        stopButton.disabled = true;
+        decodePath = null;
+    }
+
+    startButton.addEventListener('click', start);
+    stopButton.addEventListener('click', stop);
+    window.addEventListener('pagehide', stop);
+    window.addEventListener('beforeunload', stop);
+}

--- a/src/Humans.Web/wwwroot/js/scanner/barcode.js
+++ b/src/Humans.Web/wwwroot/js/scanner/barcode.js
@@ -152,6 +152,7 @@ export function initBarcodeScanner(refs) {
             // Some browsers report BarcodeDetector but constructors fail for unsupported formats.
             console.warn('Scanner: BarcodeDetector constructor failed, falling back to ZXing', err);
             decodePath = 'zxing';
+            setStatus(`${labels.running} (${labels.pathZxing})`);
             startZxing().catch((e) => {
                 console.error('Scanner: zxing fallback also failed', e);
                 showError(labels.errorNoDecoder);

--- a/src/Humans.Web/wwwroot/js/scanner/barcode.js
+++ b/src/Humans.Web/wwwroot/js/scanner/barcode.js
@@ -137,6 +137,7 @@ export function initBarcodeScanner(refs) {
         try {
             await startZxing();
         } catch (err) {
+            if (!mediaStream) return; // user pressed Stop while CDN was loading
             console.error('Scanner: zxing bootstrap failed', err);
             showError(labels.errorNoDecoder);
             await stop();


### PR DESCRIPTION
Closes nobodies-collective/Humans#525

## Summary

Stands up a new top-level **Scanner** section with a single tool in phase 1: `/Scanner/Barcode`, which opens the device camera and decodes QR / CODE128 / similar formats in the browser. Purely presentational, purely client-side — no server state, no API calls, no check-in semantics. The page is explicitly labelled a test tool.

## What changed

- **Controller** — `ScannerController` gated to `PolicyNames.TicketAdminBoardOrAdmin` (TicketAdmin / Board / Admin). Two routes: `/Scanner` (index) and `/Scanner/Barcode` (the tool).
- **Views** — `Scanner/Index.cshtml` lists available scanner tools. `Scanner/Barcode.cshtml` renders Scan / Stop buttons, a live `<video>` preview, a decoded-result list, and a prominent "test tool — not for check-in" warning.
- **Client JS** — `wwwroot/js/scanner/barcode.js` feature-detects `BarcodeDetector` and falls back to `@zxing/browser@0.1.5` from `cdn.jsdelivr.net` (already allow-listed in the CSP). Duplicate decodes within 1.5 s are suppressed. Stop / `pagehide` / `beforeunload` all release the `MediaStream` tracks so the camera indicator doesn't linger.
- **Nav** — Scanner link next to Tickets, behind the same policy.
- **Localization** — new keys across all six `SharedResource.*.resx` files (en, es, ca, fr, de, it).
- **Docs** — `docs/sections/Scanner.md` (invariants) and `docs/features/scanner-barcode.md` (phase-1 spec with explicit in-scope / out-of-scope).

## Test plan
- [ ] Open `/Scanner` as TicketAdmin — the landing page lists the Barcode tool.
- [ ] Open `/Scanner/Barcode`, tap Scan, grant camera permission — rear camera preview starts (mobile) / webcam preview starts (desktop).
- [ ] Point the camera at a TicketTailor ticket QR — the decoded value and format appear in the list within a few seconds.
- [ ] Point at an arbitrary QR code or CODE128 barcode — decodes the same way.
- [ ] Tap Stop — the camera indicator turns off immediately. Navigate away — same.
- [ ] Load the page as a non-privileged user — denied (Forbid).
- [ ] Test on iOS Safari — falls back to ZXing (check console for "using @zxing/browser via CDN" log).
- [ ] Switch locale to es/ca/fr/de/it — all labels translated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)