### PR TITLE
§15 Part 1: Legal & Consent — migrate ConsentService to Application layer

### DIFF
--- a/src/Humans.Application/Interfaces/ILegalDocumentSyncService.cs
+++ b/src/Humans.Application/Interfaces/ILegalDocumentSyncService.cs
@@ -58,4 +58,15 @@ public interface ILegalDocumentSyncService
     /// </summary>
     Task<IReadOnlyList<DocumentVersion>> GetRequiredDocumentVersionsForTeamAsync(
         Guid teamId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets every active+required legal document whose <c>TeamId</c> is in
+    /// <paramref name="teamIds"/>, with the <see cref="LegalDocument.Team"/>
+    /// and <see cref="LegalDocument.Versions"/> navigation properties
+    /// populated. Used by the consent dashboard to build the "documents per
+    /// team" grouping without crossing the section boundary into
+    /// <c>DbContext.LegalDocuments</c> from the Application layer.
+    /// </summary>
+    Task<IReadOnlyList<LegalDocument>> GetActiveRequiredDocumentsForTeamsAsync(
+        IReadOnlyCollection<Guid> teamIds, CancellationToken cancellationToken = default);
 }

--- a/src/Humans.Application/Interfaces/Repositories/IConsentRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/IConsentRepository.cs
@@ -1,0 +1,95 @@
+using Humans.Domain.Entities;
+
+namespace Humans.Application.Interfaces.Repositories;
+
+/// <summary>
+/// Repository for the Legal &amp; Consent section's <c>consent_records</c>
+/// table. The only non-test file that writes to <c>DbContext.ConsentRecords</c>
+/// after the ConsentService migration lands (issue #547).
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>consent_records</c> is append-only per design-rules §12 — only
+/// <see cref="AddAsync"/> is exposed; there are no <c>UpdateAsync</c>,
+/// <c>DeleteAsync</c>, or <c>RemoveAsync</c> methods. Database triggers
+/// additionally reject any UPDATE or DELETE at the storage layer, so even
+/// direct DbContext mutations from other code paths will fail at runtime.
+/// New state = new row.
+/// </para>
+/// <para>
+/// Uses <see cref="Microsoft.EntityFrameworkCore.IDbContextFactory{TContext}"/>
+/// so the repository can be registered as Singleton while
+/// <c>HumansDbContext</c> remains Scoped.
+/// </para>
+/// </remarks>
+public interface IConsentRepository
+{
+    // ==========================================================================
+    // Writes — append-only
+    // ==========================================================================
+
+    /// <summary>
+    /// Appends a new consent record. Persisted immediately (auto-saved).
+    /// This is the only write method; there are no updates or deletes.
+    /// </summary>
+    Task AddAsync(ConsentRecord record, CancellationToken ct = default);
+
+    // ==========================================================================
+    // Reads
+    // ==========================================================================
+
+    /// <summary>
+    /// Returns true if the user has an existing consent record for the given
+    /// document version.
+    /// </summary>
+    Task<bool> ExistsForUserAndVersionAsync(
+        Guid userId, Guid documentVersionId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Loads a consent record for the given user and document version, or
+    /// null if none exists. Read-only (AsNoTracking).
+    /// </summary>
+    Task<ConsentRecord?> GetByUserAndVersionAsync(
+        Guid userId, Guid documentVersionId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns every consent record for a user, ordered by <c>ConsentedAt</c>
+    /// descending. Includes the <see cref="ConsentRecord.DocumentVersion"/>
+    /// and nested <see cref="DocumentVersion.LegalDocument"/> navigation
+    /// properties so callers can render the document name and version without
+    /// further queries. Read-only (AsNoTracking).
+    /// </summary>
+    Task<IReadOnlyList<ConsentRecord>> GetAllForUserAsync(
+        Guid userId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns the count of consent records for a user.
+    /// </summary>
+    Task<int> GetCountForUserAsync(Guid userId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns the set of <c>DocumentVersionId</c> values that the user has
+    /// explicitly consented to.
+    /// </summary>
+    Task<IReadOnlySet<Guid>> GetExplicitlyConsentedVersionIdsAsync(
+        Guid userId, CancellationToken ct = default);
+
+    /// <summary>
+    /// For each input user id, returns the set of <c>DocumentVersionId</c>
+    /// values that user has explicitly consented to. Every input user id
+    /// appears in the result (empty set when the user has no explicit
+    /// consents).
+    /// </summary>
+    Task<IReadOnlyDictionary<Guid, IReadOnlySet<Guid>>> GetExplicitlyConsentedVersionIdsForUsersAsync(
+        IReadOnlyList<Guid> userIds, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns the <c>(UserId, DocumentVersionId)</c> pairs for the given set
+    /// of users and document versions. Used by the re-consent notification
+    /// job to find which users are missing consent to updated versions.
+    /// </summary>
+    Task<IReadOnlyList<(Guid UserId, Guid DocumentVersionId)>> GetPairsForUsersAndVersionsAsync(
+        IReadOnlyCollection<Guid> userIds,
+        IReadOnlyCollection<Guid> documentVersionIds,
+        CancellationToken ct = default);
+}

--- a/src/Humans.Application/Services/Consent/ConsentService.cs
+++ b/src/Humans.Application/Services/Consent/ConsentService.cs
@@ -1,47 +1,74 @@
 using System.Security.Cryptography;
 using System.Text;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using NodaTime;
 using Humans.Application.Extensions;
 using Humans.Application.Interfaces;
 using Humans.Application.Interfaces.Gdpr;
+using Humans.Application.Interfaces.Repositories;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
-using Humans.Infrastructure.Data;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NodaTime;
 
-namespace Humans.Infrastructure.Services;
+namespace Humans.Application.Services.Consent;
 
-public class ConsentService : IConsentService, IUserDataContributor
+/// <summary>
+/// Application-layer implementation of <see cref="IConsentService"/>. Goes
+/// through <see cref="IConsentRepository"/> for all consent-record access —
+/// this type never imports <c>Microsoft.EntityFrameworkCore</c>, enforced by
+/// <c>Humans.Application.csproj</c>'s reference graph.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>consent_records</c> is append-only per design-rules §12 — this service
+/// only appends records; there is no update or delete path.
+/// </para>
+/// <para>
+/// Cross-section dependencies are injected as service interfaces
+/// (<see cref="IOnboardingService"/>, <see cref="ILegalDocumentSyncService"/>,
+/// <see cref="ISystemTeamSync"/>, <see cref="INotificationInboxService"/>,
+/// <see cref="IProfileService"/>). Legal-document repository migration is
+/// tracked as sub-task #547a; until it lands, legal document data still
+/// flows through <see cref="ILegalDocumentSyncService"/>.
+/// </para>
+/// <para>
+/// Implements <see cref="IUserDataContributor"/> so the GDPR export
+/// orchestrator can assemble per-user consent slices without crossing the
+/// section boundary.
+/// </para>
+/// </remarks>
+public sealed class ConsentService : IConsentService, IUserDataContributor
 {
-    private readonly HumansDbContext _dbContext;
+    private readonly IConsentRepository _repo;
     private readonly IOnboardingService _onboardingService;
-    private readonly IServiceProvider _serviceProvider;
     private readonly ILegalDocumentSyncService _legalDocumentSyncService;
     private readonly INotificationInboxService _notificationInboxService;
     private readonly ISystemTeamSync _syncJob;
+    private readonly IProfileService _profileService;
+    private readonly IServiceProvider _serviceProvider;
     private readonly IHumansMetrics _metrics;
     private readonly IClock _clock;
     private readonly ILogger<ConsentService> _logger;
 
     public ConsentService(
-        HumansDbContext dbContext,
+        IConsentRepository repo,
         IOnboardingService onboardingService,
-        IServiceProvider serviceProvider,
         ILegalDocumentSyncService legalDocumentSyncService,
         INotificationInboxService notificationInboxService,
         ISystemTeamSync syncJob,
+        IProfileService profileService,
+        IServiceProvider serviceProvider,
         IHumansMetrics metrics,
         IClock clock,
         ILogger<ConsentService> logger)
     {
-        _dbContext = dbContext;
+        _repo = repo;
         _onboardingService = onboardingService;
-        _serviceProvider = serviceProvider;
         _legalDocumentSyncService = legalDocumentSyncService;
         _notificationInboxService = notificationInboxService;
         _syncJob = syncJob;
+        _profileService = profileService;
+        _serviceProvider = serviceProvider;
         _metrics = metrics;
         _clock = clock;
         _logger = logger;
@@ -56,18 +83,13 @@ public class ConsentService : IConsentService, IUserDataContributor
         var membershipCalculator = _serviceProvider.GetRequiredService<IMembershipCalculator>();
         var userTeamIds = await membershipCalculator.GetRequiredTeamIdsForUserAsync(userId, ct);
 
-        var documents = await _dbContext.LegalDocuments
-            .Where(d => d.IsActive && d.IsRequired && userTeamIds.Contains(d.TeamId))
-            .Include(d => d.Team)
-            .Include(d => d.Versions)
-            .ToListAsync(ct);
+        // Documents + Teams still flow through the legacy Legal document service
+        // because LegalDocumentService / AdminLegalDocumentService are scoped out
+        // of this migration (#547a). The document-listing surface lives on
+        // ILegalDocumentSyncService today.
+        var documents = await _legalDocumentSyncService.GetActiveRequiredDocumentsForTeamsAsync(userTeamIds, ct);
 
-        var userConsents = await _dbContext.ConsentRecords
-            .Where(c => c.UserId == userId)
-            .Include(c => c.DocumentVersion)
-            .ThenInclude(v => v.LegalDocument)
-            .OrderByDescending(c => c.ConsentedAt)
-            .ToListAsync(ct);
+        var userConsents = await _repo.GetAllForUserAsync(userId, ct);
 
         var groups = documents
             .GroupBy(d => d.TeamId)
@@ -93,7 +115,7 @@ public class ConsentService : IConsentService, IUserDataContributor
             })
             .ToList();
 
-        return (groups, userConsents);
+        return (groups, userConsents.ToList());
     }
 
     public async Task<(DocumentVersion? Version, ConsentRecord? ExistingConsent, string? UserFullName)>
@@ -104,12 +126,11 @@ public class ConsentService : IConsentService, IUserDataContributor
         if (version is null)
             return (null, null, null);
 
-        var consentRecord = await _dbContext.ConsentRecords
-            .FirstOrDefaultAsync(c => c.UserId == userId && c.DocumentVersionId == documentVersionId, ct);
+        var consentRecord = await _repo.GetByUserAndVersionAsync(userId, documentVersionId, ct);
 
-        var profile = await _dbContext.Profiles
-            .AsNoTracking()
-            .FirstOrDefaultAsync(p => p.UserId == userId, ct);
+        // Cross-section lookup: profile is owned by Profiles section. Route
+        // through IProfileService rather than querying _dbContext.Profiles.
+        var profile = await _profileService.GetProfileAsync(userId, ct);
 
         return (version, consentRecord, profile?.FullName);
     }
@@ -123,8 +144,7 @@ public class ConsentService : IConsentService, IUserDataContributor
         if (version is null)
             return new ConsentSubmitResult(false, ErrorKey: "NotFound");
 
-        var alreadyConsented = await _dbContext.ConsentRecords
-            .AnyAsync(c => c.UserId == userId && c.DocumentVersionId == documentVersionId, ct);
+        var alreadyConsented = await _repo.ExistsForUserAndVersionAsync(userId, documentVersionId, ct);
 
         if (alreadyConsented)
             return new ConsentSubmitResult(false, ErrorKey: "AlreadyConsented");
@@ -144,8 +164,7 @@ public class ConsentService : IConsentService, IUserDataContributor
             ExplicitConsent = explicitConsent
         };
 
-        _dbContext.ConsentRecords.Add(consentRecord);
-        await _dbContext.SaveChangesAsync(ct);
+        await _repo.AddAsync(consentRecord, ct);
         _metrics.RecordConsentGiven();
 
         _logger.LogInformation(
@@ -154,11 +173,11 @@ public class ConsentService : IConsentService, IUserDataContributor
 
         await _onboardingService.SetConsentCheckPendingIfEligibleAsync(userId, ct);
 
-        // Sync system team memberships (adds user if eligible + all consents done)
+        // Sync system team memberships (adds user if eligible + all consents done).
         await _syncJob.SyncVolunteersMembershipForUserAsync(userId);
         await _syncJob.SyncCoordinatorsMembershipForUserAsync(userId);
 
-        // Auto-resolve AccessSuspended notifications only once ALL required consents are complete
+        // Auto-resolve AccessSuspended notifications only once ALL required consents are complete.
         try
         {
             var membershipCalc = _serviceProvider.GetRequiredService<IMembershipCalculator>();
@@ -175,62 +194,20 @@ public class ConsentService : IConsentService, IUserDataContributor
         return new ConsentSubmitResult(true, DocumentName: version.LegalDocument.Name);
     }
 
-    public async Task<IReadOnlyList<ConsentRecord>> GetUserConsentRecordsAsync(
-        Guid userId, CancellationToken ct = default)
-    {
-        return await _dbContext.ConsentRecords
-            .AsNoTracking()
-            .Include(c => c.DocumentVersion)
-                .ThenInclude(v => v.LegalDocument)
-            .Where(c => c.UserId == userId)
-            .OrderByDescending(c => c.ConsentedAt)
-            .ToListAsync(ct);
-    }
+    public Task<IReadOnlyList<ConsentRecord>> GetUserConsentRecordsAsync(
+        Guid userId, CancellationToken ct = default) =>
+        _repo.GetAllForUserAsync(userId, ct);
 
-    public async Task<int> GetConsentRecordCountAsync(
-        Guid userId, CancellationToken ct = default)
-    {
-        return await _dbContext.ConsentRecords
-            .CountAsync(cr => cr.UserId == userId, ct);
-    }
+    public Task<int> GetConsentRecordCountAsync(Guid userId, CancellationToken ct = default) =>
+        _repo.GetCountForUserAsync(userId, ct);
 
-    public async Task<IReadOnlySet<Guid>> GetConsentedVersionIdsAsync(
-        Guid userId, CancellationToken ct = default)
-    {
-        var ids = await _dbContext.ConsentRecords
-            .AsNoTracking()
-            .Where(cr => cr.UserId == userId && cr.ExplicitConsent)
-            .Select(cr => cr.DocumentVersionId)
-            .ToListAsync(ct);
+    public Task<IReadOnlySet<Guid>> GetConsentedVersionIdsAsync(
+        Guid userId, CancellationToken ct = default) =>
+        _repo.GetExplicitlyConsentedVersionIdsAsync(userId, ct);
 
-        return ids.ToHashSet();
-    }
-
-    public async Task<IReadOnlyDictionary<Guid, IReadOnlySet<Guid>>> GetConsentMapForUsersAsync(
-        IReadOnlyList<Guid> userIds, CancellationToken ct = default)
-    {
-        if (userIds.Count == 0)
-        {
-            return new Dictionary<Guid, IReadOnlySet<Guid>>();
-        }
-
-        var consents = await _dbContext.ConsentRecords
-            .AsNoTracking()
-            .Where(cr => userIds.Contains(cr.UserId) && cr.ExplicitConsent)
-            .Select(cr => new { cr.UserId, cr.DocumentVersionId })
-            .ToListAsync(ct);
-
-        var result = userIds.ToDictionary(
-            id => id,
-            _ => (IReadOnlySet<Guid>)new HashSet<Guid>());
-
-        foreach (var consent in consents)
-        {
-            ((HashSet<Guid>)result[consent.UserId]).Add(consent.DocumentVersionId);
-        }
-
-        return result;
-    }
+    public Task<IReadOnlyDictionary<Guid, IReadOnlySet<Guid>>> GetConsentMapForUsersAsync(
+        IReadOnlyList<Guid> userIds, CancellationToken ct = default) =>
+        _repo.GetExplicitlyConsentedVersionIdsForUsersAsync(userIds, ct);
 
     private static string ComputeContentHash(string content)
     {
@@ -240,7 +217,7 @@ public class ConsentService : IConsentService, IUserDataContributor
 
     public async Task<IReadOnlyList<UserDataSlice>> ContributeForUserAsync(Guid userId, CancellationToken ct)
     {
-        var consents = await GetUserConsentRecordsAsync(userId, ct);
+        var consents = await _repo.GetAllForUserAsync(userId, ct);
 
         var shaped = consents.Select(c => new
         {

--- a/src/Humans.Infrastructure/Jobs/SyncLegalDocumentsJob.cs
+++ b/src/Humans.Infrastructure/Jobs/SyncLegalDocumentsJob.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using NodaTime;
 using Humans.Application.Interfaces;
+using Humans.Application.Interfaces.Repositories;
 using Humans.Infrastructure.Data;
 
 namespace Humans.Infrastructure.Jobs;
@@ -14,6 +15,7 @@ public class SyncLegalDocumentsJob : IRecurringJob
     private readonly ILegalDocumentSyncService _syncService;
     private readonly IEmailService _emailService;
     private readonly HumansDbContext _dbContext;
+    private readonly IConsentRepository _consentRepository;
     private readonly IHumansMetrics _metrics;
     private readonly ILogger<SyncLegalDocumentsJob> _logger;
     private readonly IClock _clock;
@@ -22,6 +24,7 @@ public class SyncLegalDocumentsJob : IRecurringJob
         ILegalDocumentSyncService syncService,
         IEmailService emailService,
         HumansDbContext dbContext,
+        IConsentRepository consentRepository,
         IHumansMetrics metrics,
         ILogger<SyncLegalDocumentsJob> logger,
         IClock clock)
@@ -29,6 +32,7 @@ public class SyncLegalDocumentsJob : IRecurringJob
         _syncService = syncService;
         _emailService = emailService;
         _dbContext = dbContext;
+        _consentRepository = consentRepository;
         _metrics = metrics;
         _logger = logger;
         _clock = clock;
@@ -101,13 +105,10 @@ public class SyncLegalDocumentsJob : IRecurringJob
             .Select(d => d.Versions.OrderByDescending(v => v.EffectiveFrom).First().Id)
             .ToList();
 
-        var consentsByUser = await _dbContext.ConsentRecords
-            .AsNoTracking()
-            .Where(cr => activeUserIds.Contains(cr.UserId) && updatedDocVersionIds.Contains(cr.DocumentVersionId))
-            .Select(cr => new { cr.UserId, cr.DocumentVersionId })
-            .ToListAsync(cancellationToken);
+        var consentPairs = await _consentRepository.GetPairsForUsersAndVersionsAsync(
+            activeUserIds, updatedDocVersionIds, cancellationToken);
 
-        var userConsents = consentsByUser
+        var userConsents = consentPairs
             .GroupBy(c => c.UserId)
             .ToDictionary(g => g.Key, g => g.Select(c => c.DocumentVersionId).ToHashSet());
 

--- a/src/Humans.Infrastructure/Repositories/ConsentRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/ConsentRepository.cs
@@ -1,0 +1,138 @@
+using Humans.Application.Interfaces.Repositories;
+using Humans.Domain.Entities;
+using Humans.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace Humans.Infrastructure.Repositories;
+
+/// <summary>
+/// EF-backed implementation of <see cref="IConsentRepository"/>. The only
+/// non-test file that touches <c>DbContext.ConsentRecords</c> after the
+/// ConsentService migration lands (issue #547). Uses
+/// <see cref="IDbContextFactory{TContext}"/> so the repository can be
+/// registered as Singleton while <c>HumansDbContext</c> remains Scoped.
+/// </summary>
+/// <remarks>
+/// <c>consent_records</c> is append-only per design-rules §12 — only
+/// <see cref="AddAsync"/> is exposed; there are no <c>UpdateAsync</c> or
+/// <c>DeleteAsync</c>. Database triggers reject any UPDATE/DELETE at the
+/// storage layer as a secondary defense.
+/// </remarks>
+public sealed class ConsentRepository : IConsentRepository
+{
+    private readonly IDbContextFactory<HumansDbContext> _factory;
+
+    public ConsentRepository(IDbContextFactory<HumansDbContext> factory)
+    {
+        _factory = factory;
+    }
+
+    // ==========================================================================
+    // Writes — append-only
+    // ==========================================================================
+
+    public async Task AddAsync(ConsentRecord record, CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        ctx.ConsentRecords.Add(record);
+        await ctx.SaveChangesAsync(ct);
+    }
+
+    // ==========================================================================
+    // Reads
+    // ==========================================================================
+
+    public async Task<bool> ExistsForUserAndVersionAsync(
+        Guid userId, Guid documentVersionId, CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        return await ctx.ConsentRecords
+            .AsNoTracking()
+            .AnyAsync(c => c.UserId == userId && c.DocumentVersionId == documentVersionId, ct);
+    }
+
+    public async Task<ConsentRecord?> GetByUserAndVersionAsync(
+        Guid userId, Guid documentVersionId, CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        return await ctx.ConsentRecords
+            .AsNoTracking()
+            .FirstOrDefaultAsync(c => c.UserId == userId && c.DocumentVersionId == documentVersionId, ct);
+    }
+
+    public async Task<IReadOnlyList<ConsentRecord>> GetAllForUserAsync(
+        Guid userId, CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        return await ctx.ConsentRecords
+            .AsNoTracking()
+            .Include(c => c.DocumentVersion)
+                .ThenInclude(v => v.LegalDocument)
+            .Where(c => c.UserId == userId)
+            .OrderByDescending(c => c.ConsentedAt)
+            .ToListAsync(ct);
+    }
+
+    public async Task<int> GetCountForUserAsync(Guid userId, CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        return await ctx.ConsentRecords
+            .CountAsync(c => c.UserId == userId, ct);
+    }
+
+    public async Task<IReadOnlySet<Guid>> GetExplicitlyConsentedVersionIdsAsync(
+        Guid userId, CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        var ids = await ctx.ConsentRecords
+            .AsNoTracking()
+            .Where(c => c.UserId == userId && c.ExplicitConsent)
+            .Select(c => c.DocumentVersionId)
+            .ToListAsync(ct);
+
+        return ids.ToHashSet();
+    }
+
+    public async Task<IReadOnlyDictionary<Guid, IReadOnlySet<Guid>>> GetExplicitlyConsentedVersionIdsForUsersAsync(
+        IReadOnlyList<Guid> userIds, CancellationToken ct = default)
+    {
+        var result = userIds.ToDictionary(
+            id => id,
+            _ => (IReadOnlySet<Guid>)new HashSet<Guid>());
+
+        if (userIds.Count == 0)
+            return result;
+
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        var pairs = await ctx.ConsentRecords
+            .AsNoTracking()
+            .Where(c => userIds.Contains(c.UserId) && c.ExplicitConsent)
+            .Select(c => new { c.UserId, c.DocumentVersionId })
+            .ToListAsync(ct);
+
+        foreach (var pair in pairs)
+        {
+            ((HashSet<Guid>)result[pair.UserId]).Add(pair.DocumentVersionId);
+        }
+
+        return result;
+    }
+
+    public async Task<IReadOnlyList<(Guid UserId, Guid DocumentVersionId)>> GetPairsForUsersAndVersionsAsync(
+        IReadOnlyCollection<Guid> userIds,
+        IReadOnlyCollection<Guid> documentVersionIds,
+        CancellationToken ct = default)
+    {
+        if (userIds.Count == 0 || documentVersionIds.Count == 0)
+            return [];
+
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        var pairs = await ctx.ConsentRecords
+            .AsNoTracking()
+            .Where(c => userIds.Contains(c.UserId) && documentVersionIds.Contains(c.DocumentVersionId))
+            .Select(c => new { c.UserId, c.DocumentVersionId })
+            .ToListAsync(ct);
+
+        return pairs.Select(p => (p.UserId, p.DocumentVersionId)).ToList();
+    }
+}

--- a/src/Humans.Infrastructure/Services/LegalDocumentSyncService.cs
+++ b/src/Humans.Infrastructure/Services/LegalDocumentSyncService.cs
@@ -204,6 +204,21 @@ public class LegalDocumentSyncService : ILegalDocumentSyncService
             .ToListAsync(cancellationToken);
     }
 
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<LegalDocument>> GetActiveRequiredDocumentsForTeamsAsync(
+        IReadOnlyCollection<Guid> teamIds, CancellationToken cancellationToken = default)
+    {
+        if (teamIds.Count == 0)
+            return [];
+
+        return await _dbContext.LegalDocuments
+            .AsNoTracking()
+            .Where(d => d.IsActive && d.IsRequired && teamIds.Contains(d.TeamId))
+            .Include(d => d.Team)
+            .Include(d => d.Versions)
+            .ToListAsync(cancellationToken);
+    }
+
     /// <summary>
     /// Syncs a single document from GitHub using folder-based discovery.
     /// </summary>

--- a/src/Humans.Web/Extensions/Sections/LegalAndConsentSectionExtensions.cs
+++ b/src/Humans.Web/Extensions/Sections/LegalAndConsentSectionExtensions.cs
@@ -1,7 +1,10 @@
 using Humans.Application.Interfaces;
 using Humans.Application.Interfaces.Gdpr;
+using Humans.Application.Interfaces.Repositories;
 using Humans.Infrastructure.Jobs;
+using Humans.Infrastructure.Repositories;
 using Humans.Infrastructure.Services;
+using ConsentConsentService = Humans.Application.Services.Consent.ConsentService;
 
 namespace Humans.Web.Extensions.Sections;
 
@@ -13,9 +16,16 @@ internal static class LegalAndConsentSectionExtensions
         services.AddScoped<IAdminLegalDocumentService, AdminLegalDocumentService>();
         services.AddScoped<ILegalDocumentService, LegalDocumentService>();
 
-        services.AddScoped<ConsentService>();
-        services.AddScoped<IConsentService>(sp => sp.GetRequiredService<ConsentService>());
-        services.AddScoped<IUserDataContributor>(sp => sp.GetRequiredService<ConsentService>());
+        // Legal & Consent section — ConsentService §15 repository pattern (issue #547).
+        // consent_records is append-only per design-rules §12 — the repository
+        // exposes only AddAsync + reads. No decorator: documents are few,
+        // consent records grow with history but reads are per-user.
+        // IConsentRepository is Singleton (IDbContextFactory-based) so the
+        // service can inject it directly.
+        services.AddSingleton<IConsentRepository, ConsentRepository>();
+        services.AddScoped<ConsentConsentService>();
+        services.AddScoped<IConsentService>(sp => sp.GetRequiredService<ConsentConsentService>());
+        services.AddScoped<IUserDataContributor>(sp => sp.GetRequiredService<ConsentConsentService>());
 
         services.AddScoped<SyncLegalDocumentsJob>();
         services.AddScoped<SendReConsentReminderJob>();

--- a/tests/Humans.Application.Tests/Architecture/ConsentArchitectureTests.cs
+++ b/tests/Humans.Application.Tests/Architecture/ConsentArchitectureTests.cs
@@ -1,0 +1,147 @@
+using System.Reflection;
+using AwesomeAssertions;
+using Humans.Application.Interfaces.Repositories;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+using ConsentService = Humans.Application.Services.Consent.ConsentService;
+
+namespace Humans.Application.Tests.Architecture;
+
+/// <summary>
+/// Architecture tests enforcing the §15 repository pattern for the Legal &amp;
+/// Consent section's <see cref="ConsentService"/> — migrated per issue #547.
+///
+/// <para>
+/// <c>consent_records</c> is append-only per design-rules §12 — the
+/// repository exposes only <c>AddAsync</c> for mutations; no
+/// <c>UpdateAsync</c>, <c>DeleteAsync</c>, or <c>RemoveAsync</c> surface is
+/// allowed. Database triggers additionally reject UPDATE/DELETE at the
+/// storage layer. The architecture test
+/// <see cref="IConsentRepository_HasNoUpdateOrDeleteOrRemoveMethods"/> pins
+/// the interface-level constraint.
+/// </para>
+///
+/// <para>
+/// This section's migration is <b>partial</b> as of #547b: <c>ConsentService</c>
+/// migrated to the Application layer; <c>LegalDocumentService</c>,
+/// <c>AdminLegalDocumentService</c>, and <c>LegalDocumentSyncService</c>
+/// remain in <c>Humans.Infrastructure/Services/</c> and are tracked as
+/// sub-task #547a.
+/// </para>
+/// </summary>
+public class ConsentArchitectureTests
+{
+    // ── ConsentService ───────────────────────────────────────────────────────
+
+    [Fact]
+    public void ConsentService_LivesInHumansApplicationServicesConsentNamespace()
+    {
+        typeof(ConsentService).Namespace
+            .Should().Be("Humans.Application.Services.Consent",
+                because: "services with business logic live in Humans.Application per design-rules §2b, organized by section");
+    }
+
+    [Fact]
+    public void ConsentService_HasNoDbContextConstructorParameter()
+    {
+        var ctor = typeof(ConsentService).GetConstructors().Single();
+        ctor.GetParameters()
+            .Should().NotContain(
+                p => typeof(DbContext).IsAssignableFrom(p.ParameterType),
+                because: "services in Humans.Application must never take DbContext — use IConsentRepository instead (design-rules §3)");
+    }
+
+    [Fact]
+    public void ConsentService_HasNoIMemoryCacheConstructorParameter()
+    {
+        var ctor = typeof(ConsentService).GetConstructors().Single();
+        var cachingParam = ctor.GetParameters()
+            .FirstOrDefault(p => (p.ParameterType.FullName ?? string.Empty)
+                .StartsWith("Microsoft.Extensions.Caching.Memory", StringComparison.Ordinal));
+
+        cachingParam.Should().BeNull(
+            because: "canonical Consent data is not IMemoryCache-backed; append-only semantics + per-user reads do not justify a decorator");
+    }
+
+    [Fact]
+    public void ConsentService_TakesRepository()
+    {
+        var ctor = typeof(ConsentService).GetConstructors().Single();
+        var paramTypes = ctor.GetParameters().Select(p => p.ParameterType).ToList();
+
+        paramTypes.Should().Contain(typeof(IConsentRepository));
+    }
+
+    [Fact]
+    public void ConsentService_ConstructorTakesNoStoreType()
+    {
+        var ctor = typeof(ConsentService).GetConstructors().Single();
+        var storeParam = ctor.GetParameters()
+            .FirstOrDefault(p => (p.ParameterType.Namespace ?? string.Empty)
+                .StartsWith("Humans.Application.Interfaces.Stores", StringComparison.Ordinal));
+
+        storeParam.Should().BeNull(
+            because: "Application services must not depend on store abstractions (design-rules §15); ConsentService has no cache layer at all");
+    }
+
+    // ── IConsentRepository ───────────────────────────────────────────────────
+
+    [Fact]
+    public void IConsentRepository_LivesInApplicationInterfacesRepositoriesNamespace()
+    {
+        typeof(IConsentRepository).Namespace
+            .Should().Be("Humans.Application.Interfaces.Repositories",
+                because: "repository interfaces live in Humans.Application.Interfaces.Repositories per design-rules §3");
+    }
+
+    [Fact]
+    public void ConsentRepository_IsSealed()
+    {
+        // Mirrors ProfileRepository / UserRepository / AuditLogRepository — repository implementations are terminal;
+        // no subclass should extend or override the EF-backed data access.
+        var repoType = typeof(Humans.Infrastructure.Repositories.ConsentRepository);
+
+        repoType.IsSealed.Should().BeTrue(
+            because: "repository implementations are sealed to prevent ad-hoc extension; any new behavior belongs on the interface");
+    }
+
+    /// <summary>
+    /// <c>consent_records</c> is append-only per design-rules §12 — database
+    /// triggers block UPDATE and DELETE, and the repository interface must
+    /// not expose any mutation surface beyond appending new records. This
+    /// test fails if a future refactor adds a method whose name implies
+    /// mutation of existing rows.
+    /// </summary>
+    [Fact]
+    public void IConsentRepository_HasNoUpdateOrDeleteOrRemoveMethods()
+    {
+        var methods = typeof(IConsentRepository)
+            .GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+
+        var mutationMethods = methods
+            .Where(m =>
+                m.Name.StartsWith("Update", StringComparison.Ordinal) ||
+                m.Name.StartsWith("Delete", StringComparison.Ordinal) ||
+                m.Name.StartsWith("Remove", StringComparison.Ordinal))
+            .Select(m => m.Name)
+            .ToList();
+
+        mutationMethods.Should().BeEmpty(
+            because: "consent_records is append-only per design-rules §12 — DB triggers reject UPDATE and DELETE; only AddAsync should exist. New state = new row.");
+    }
+
+    /// <summary>
+    /// Positive assertion: the repository must expose an <c>AddAsync</c>
+    /// method. Pins the append-only surface so removing the only write
+    /// primitive fails the suite immediately.
+    /// </summary>
+    [Fact]
+    public void IConsentRepository_HasAddAsyncMethod()
+    {
+        var addAsync = typeof(IConsentRepository)
+            .GetMethod("AddAsync", BindingFlags.Public | BindingFlags.Instance);
+
+        addAsync.Should().NotBeNull(
+            because: "append-only repositories must expose AddAsync as the sole mutation primitive");
+    }
+}

--- a/tests/Humans.Application.Tests/Repositories/ConsentRepositoryTests.cs
+++ b/tests/Humans.Application.Tests/Repositories/ConsentRepositoryTests.cs
@@ -1,0 +1,391 @@
+using AwesomeAssertions;
+using Humans.Application.Tests.Infrastructure;
+using Humans.Domain.Entities;
+using Humans.Infrastructure.Data;
+using Humans.Infrastructure.Repositories;
+using Microsoft.EntityFrameworkCore;
+using NodaTime;
+using NodaTime.Testing;
+using Xunit;
+
+namespace Humans.Application.Tests.Repositories;
+
+/// <summary>
+/// Integration tests for <see cref="ConsentRepository"/>. Covers the
+/// append-only write path and every read shape. Uses the shared
+/// <see cref="TestDbContextFactory"/> so the repository sees a fresh context
+/// per call while the test keeps one for seeding/verification.
+/// </summary>
+public sealed class ConsentRepositoryTests : IDisposable
+{
+    private readonly HumansDbContext _dbContext;
+    private readonly FakeClock _clock;
+    private readonly ConsentRepository _repo;
+
+    public ConsentRepositoryTests()
+    {
+        var options = new DbContextOptionsBuilder<HumansDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        _dbContext = new HumansDbContext(options);
+        _clock = new FakeClock(Instant.FromUtc(2026, 3, 1, 12, 0));
+        _repo = new ConsentRepository(new TestDbContextFactory(options));
+    }
+
+    public void Dispose()
+    {
+        _dbContext.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    // ==========================================================================
+    // AddAsync
+    // ==========================================================================
+
+    [Fact]
+    public async Task AddAsync_PersistsNewRecord()
+    {
+        var record = BuildRecord(Guid.NewGuid(), Guid.NewGuid());
+
+        await _repo.AddAsync(record);
+
+        var persisted = await _dbContext.ConsentRecords.AsNoTracking().FirstAsync();
+        persisted.Id.Should().Be(record.Id);
+        persisted.UserId.Should().Be(record.UserId);
+        persisted.DocumentVersionId.Should().Be(record.DocumentVersionId);
+    }
+
+    [Fact]
+    public async Task AddAsync_AutoSaves_PerCall()
+    {
+        // The old ConsentService added to a shared-scope DbContext and relied on
+        // the caller's SaveChangesAsync. The new repository auto-saves each call,
+        // so a subsequent read from a different context sees the row immediately.
+        var record = BuildRecord(Guid.NewGuid(), Guid.NewGuid());
+
+        await _repo.AddAsync(record);
+
+        var count = await _dbContext.ConsentRecords.CountAsync();
+        count.Should().Be(1);
+    }
+
+    // ==========================================================================
+    // ExistsForUserAndVersionAsync
+    // ==========================================================================
+
+    [Fact]
+    public async Task ExistsForUserAndVersionAsync_ReturnsTrue_WhenRecordExists()
+    {
+        var userId = Guid.NewGuid();
+        var versionId = Guid.NewGuid();
+        await _repo.AddAsync(BuildRecord(userId, versionId));
+
+        var exists = await _repo.ExistsForUserAndVersionAsync(userId, versionId);
+
+        exists.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ExistsForUserAndVersionAsync_ReturnsFalse_WhenNoRecord()
+    {
+        var exists = await _repo.ExistsForUserAndVersionAsync(Guid.NewGuid(), Guid.NewGuid());
+
+        exists.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ExistsForUserAndVersionAsync_ReturnsFalse_ForDifferentUser()
+    {
+        var versionId = Guid.NewGuid();
+        await _repo.AddAsync(BuildRecord(Guid.NewGuid(), versionId));
+
+        var exists = await _repo.ExistsForUserAndVersionAsync(Guid.NewGuid(), versionId);
+
+        exists.Should().BeFalse();
+    }
+
+    // ==========================================================================
+    // GetByUserAndVersionAsync
+    // ==========================================================================
+
+    [Fact]
+    public async Task GetByUserAndVersionAsync_ReturnsRecord_WhenExists()
+    {
+        var userId = Guid.NewGuid();
+        var versionId = Guid.NewGuid();
+        await _repo.AddAsync(BuildRecord(userId, versionId));
+
+        var record = await _repo.GetByUserAndVersionAsync(userId, versionId);
+
+        record.Should().NotBeNull();
+        record!.UserId.Should().Be(userId);
+        record.DocumentVersionId.Should().Be(versionId);
+    }
+
+    [Fact]
+    public async Task GetByUserAndVersionAsync_ReturnsNull_WhenMissing()
+    {
+        var record = await _repo.GetByUserAndVersionAsync(Guid.NewGuid(), Guid.NewGuid());
+
+        record.Should().BeNull();
+    }
+
+    // ==========================================================================
+    // GetAllForUserAsync
+    // ==========================================================================
+
+    [Fact]
+    public async Task GetAllForUserAsync_ReturnsOnlyThatUsersRecords_NewestFirst()
+    {
+        var userId = Guid.NewGuid();
+        var otherUserId = Guid.NewGuid();
+        var v1 = await SeedVersionAsync();
+        var v2 = await SeedVersionAsync();
+
+        var older = BuildRecord(userId, v1, consentedAt: _clock.GetCurrentInstant() - Duration.FromHours(2));
+        var newer = BuildRecord(userId, v2, consentedAt: _clock.GetCurrentInstant() - Duration.FromMinutes(10));
+        var otherUserRecord = BuildRecord(otherUserId, v1);
+
+        await _repo.AddAsync(older);
+        await _repo.AddAsync(newer);
+        await _repo.AddAsync(otherUserRecord);
+
+        var results = await _repo.GetAllForUserAsync(userId);
+
+        results.Should().HaveCount(2);
+        results[0].Id.Should().Be(newer.Id);
+        results[1].Id.Should().Be(older.Id);
+    }
+
+    [Fact]
+    public async Task GetAllForUserAsync_IncludesDocumentVersionAndLegalDocumentNavs()
+    {
+        var userId = Guid.NewGuid();
+        var versionId = await SeedVersionAsync("Privacy Policy");
+
+        await _repo.AddAsync(BuildRecord(userId, versionId));
+
+        var results = await _repo.GetAllForUserAsync(userId);
+
+        results.Should().HaveCount(1);
+        results[0].DocumentVersion.Should().NotBeNull();
+        results[0].DocumentVersion.LegalDocument.Should().NotBeNull();
+        results[0].DocumentVersion.LegalDocument.Name.Should().Be("Privacy Policy");
+    }
+
+    [Fact]
+    public async Task GetAllForUserAsync_ReturnsEmpty_WhenNoRecords()
+    {
+        var results = await _repo.GetAllForUserAsync(Guid.NewGuid());
+
+        results.Should().BeEmpty();
+    }
+
+    // ==========================================================================
+    // GetCountForUserAsync
+    // ==========================================================================
+
+    [Fact]
+    public async Task GetCountForUserAsync_ReturnsCount()
+    {
+        var userId = Guid.NewGuid();
+        await _repo.AddAsync(BuildRecord(userId, Guid.NewGuid()));
+        await _repo.AddAsync(BuildRecord(userId, Guid.NewGuid()));
+        await _repo.AddAsync(BuildRecord(Guid.NewGuid(), Guid.NewGuid())); // other user
+
+        var count = await _repo.GetCountForUserAsync(userId);
+
+        count.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task GetCountForUserAsync_ReturnsZero_WhenNoRecords()
+    {
+        var count = await _repo.GetCountForUserAsync(Guid.NewGuid());
+
+        count.Should().Be(0);
+    }
+
+    // ==========================================================================
+    // GetExplicitlyConsentedVersionIdsAsync
+    // ==========================================================================
+
+    [Fact]
+    public async Task GetExplicitlyConsentedVersionIdsAsync_ReturnsOnlyExplicitConsents()
+    {
+        var userId = Guid.NewGuid();
+        var explicitId = Guid.NewGuid();
+        var implicitId = Guid.NewGuid();
+        await _repo.AddAsync(BuildRecord(userId, explicitId, explicitConsent: true));
+        await _repo.AddAsync(BuildRecord(userId, implicitId, explicitConsent: false));
+
+        var ids = await _repo.GetExplicitlyConsentedVersionIdsAsync(userId);
+
+        ids.Should().HaveCount(1);
+        ids.Should().Contain(explicitId);
+        ids.Should().NotContain(implicitId);
+    }
+
+    [Fact]
+    public async Task GetExplicitlyConsentedVersionIdsAsync_ReturnsEmpty_WhenNone()
+    {
+        var ids = await _repo.GetExplicitlyConsentedVersionIdsAsync(Guid.NewGuid());
+
+        ids.Should().BeEmpty();
+    }
+
+    // ==========================================================================
+    // GetExplicitlyConsentedVersionIdsForUsersAsync
+    // ==========================================================================
+
+    [Fact]
+    public async Task GetExplicitlyConsentedVersionIdsForUsersAsync_EmptyInput_ReturnsEmpty()
+    {
+        var map = await _repo.GetExplicitlyConsentedVersionIdsForUsersAsync(Array.Empty<Guid>());
+
+        map.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetExplicitlyConsentedVersionIdsForUsersAsync_IncludesEveryInputUser()
+    {
+        // Every input user appears in the result, with an empty set when no consents.
+        var userWithConsents = Guid.NewGuid();
+        var userWithoutConsents = Guid.NewGuid();
+        var versionId = Guid.NewGuid();
+        await _repo.AddAsync(BuildRecord(userWithConsents, versionId, explicitConsent: true));
+
+        var map = await _repo.GetExplicitlyConsentedVersionIdsForUsersAsync(
+            new List<Guid> { userWithConsents, userWithoutConsents });
+
+        map.Should().ContainKey(userWithConsents);
+        map.Should().ContainKey(userWithoutConsents);
+        map[userWithConsents].Should().Contain(versionId);
+        map[userWithoutConsents].Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetExplicitlyConsentedVersionIdsForUsersAsync_ExcludesImplicitConsents()
+    {
+        var userId = Guid.NewGuid();
+        var explicitVersion = Guid.NewGuid();
+        var implicitVersion = Guid.NewGuid();
+        await _repo.AddAsync(BuildRecord(userId, explicitVersion, explicitConsent: true));
+        await _repo.AddAsync(BuildRecord(userId, implicitVersion, explicitConsent: false));
+
+        var map = await _repo.GetExplicitlyConsentedVersionIdsForUsersAsync(new List<Guid> { userId });
+
+        map[userId].Should().Contain(explicitVersion);
+        map[userId].Should().NotContain(implicitVersion);
+    }
+
+    // ==========================================================================
+    // GetPairsForUsersAndVersionsAsync
+    // ==========================================================================
+
+    [Fact]
+    public async Task GetPairsForUsersAndVersionsAsync_EmptyUsers_ReturnsEmpty()
+    {
+        var pairs = await _repo.GetPairsForUsersAndVersionsAsync(
+            Array.Empty<Guid>(), new[] { Guid.NewGuid() });
+
+        pairs.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetPairsForUsersAndVersionsAsync_EmptyVersions_ReturnsEmpty()
+    {
+        var pairs = await _repo.GetPairsForUsersAndVersionsAsync(
+            new[] { Guid.NewGuid() }, Array.Empty<Guid>());
+
+        pairs.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetPairsForUsersAndVersionsAsync_ReturnsOnlyMatchingPairs()
+    {
+        var userA = Guid.NewGuid();
+        var userB = Guid.NewGuid();
+        var versionX = Guid.NewGuid();
+        var versionY = Guid.NewGuid();
+        var versionOutside = Guid.NewGuid();
+
+        await _repo.AddAsync(BuildRecord(userA, versionX));
+        await _repo.AddAsync(BuildRecord(userA, versionY));
+        await _repo.AddAsync(BuildRecord(userB, versionX));
+        await _repo.AddAsync(BuildRecord(userA, versionOutside));
+        await _repo.AddAsync(BuildRecord(Guid.NewGuid(), versionX)); // different user
+
+        var pairs = await _repo.GetPairsForUsersAndVersionsAsync(
+            new[] { userA, userB }, new[] { versionX, versionY });
+
+        pairs.Should().HaveCount(3);
+        pairs.Should().Contain((userA, versionX));
+        pairs.Should().Contain((userA, versionY));
+        pairs.Should().Contain((userB, versionX));
+    }
+
+    // ==========================================================================
+    // Helpers
+    // ==========================================================================
+
+    private async Task<Guid> SeedVersionAsync(string documentName = "Doc")
+    {
+        var teamId = Guid.NewGuid();
+        var docId = Guid.NewGuid();
+        var versionId = Guid.NewGuid();
+        var now = _clock.GetCurrentInstant();
+
+        _dbContext.Teams.Add(new Team
+        {
+            Id = teamId,
+            Name = "Test Team",
+            Slug = "test-team",
+            IsActive = true,
+            CreatedAt = now,
+            UpdatedAt = now
+        });
+        _dbContext.LegalDocuments.Add(new LegalDocument
+        {
+            Id = docId,
+            Name = documentName,
+            TeamId = teamId,
+            IsActive = true,
+            IsRequired = true,
+            CurrentCommitSha = "abc",
+            CreatedAt = now,
+            LastSyncedAt = now
+        });
+        _dbContext.DocumentVersions.Add(new DocumentVersion
+        {
+            Id = versionId,
+            LegalDocumentId = docId,
+            VersionNumber = "v1",
+            CommitSha = "abc",
+            Content = new Dictionary<string, string>(StringComparer.Ordinal) { ["es"] = "text" },
+            EffectiveFrom = now,
+            CreatedAt = now
+        });
+        await _dbContext.SaveChangesAsync();
+        return versionId;
+    }
+
+    private ConsentRecord BuildRecord(
+        Guid userId,
+        Guid documentVersionId,
+        bool explicitConsent = true,
+        Instant? consentedAt = null)
+    {
+        return new ConsentRecord
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            DocumentVersionId = documentVersionId,
+            ConsentedAt = consentedAt ?? _clock.GetCurrentInstant(),
+            IpAddress = "127.0.0.1",
+            UserAgent = "test",
+            ContentHash = "hash",
+            ExplicitConsent = explicitConsent
+        };
+    }
+}

--- a/tests/Humans.Application.Tests/Services/AdminLegalDocumentServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/AdminLegalDocumentServiceTests.cs
@@ -203,5 +203,11 @@ public class AdminLegalDocumentServiceTests : IDisposable
         {
             return Task.FromResult<IReadOnlyList<DocumentVersion>>(Array.Empty<DocumentVersion>());
         }
+
+        public Task<IReadOnlyList<LegalDocument>> GetActiveRequiredDocumentsForTeamsAsync(
+            IReadOnlyCollection<Guid> teamIds, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult<IReadOnlyList<LegalDocument>>(Array.Empty<LegalDocument>());
+        }
     }
 }

--- a/tests/Humans.Application.Tests/Services/ConsentServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/ConsentServiceTests.cs
@@ -7,11 +7,13 @@ using NodaTime;
 using NodaTime.Testing;
 using NSubstitute;
 using Humans.Application.Interfaces;
+using Humans.Application.Tests.Infrastructure;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Humans.Infrastructure.Data;
-using Humans.Infrastructure.Services;
+using Humans.Infrastructure.Repositories;
 using Xunit;
+using ConsentService = Humans.Application.Services.Consent.ConsentService;
 
 namespace Humans.Application.Tests.Services;
 
@@ -25,6 +27,7 @@ public class ConsentServiceTests : IDisposable
     private readonly ILegalDocumentSyncService _legalDocumentSyncService = Substitute.For<ILegalDocumentSyncService>();
     private readonly INotificationInboxService _notificationInboxService = Substitute.For<INotificationInboxService>();
     private readonly ISystemTeamSync _syncJob = Substitute.For<ISystemTeamSync>();
+    private readonly IProfileService _profileService = Substitute.For<IProfileService>();
     private readonly IHumansMetrics _metrics = Substitute.For<IHumansMetrics>();
 
     public ConsentServiceTests()
@@ -45,10 +48,35 @@ public class ConsentServiceTests : IDisposable
                 .Include(v => v.LegalDocument)
                 .FirstOrDefaultAsync(v => v.Id == callInfo.ArgAt<Guid>(0)));
 
+        _legalDocumentSyncService
+            .GetActiveRequiredDocumentsForTeamsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(async callInfo =>
+            {
+                var teamIds = callInfo.ArgAt<IReadOnlyCollection<Guid>>(0);
+                if (teamIds.Count == 0)
+                    return (IReadOnlyList<LegalDocument>)Array.Empty<LegalDocument>();
+
+                return await _dbContext.LegalDocuments
+                    .AsNoTracking()
+                    .Where(d => d.IsActive && d.IsRequired && teamIds.Contains(d.TeamId))
+                    .Include(d => d.Team)
+                    .Include(d => d.Versions)
+                    .ToListAsync();
+            });
+
+        var factory = new TestDbContextFactory(options);
+        var consentRepository = new ConsentRepository(factory);
+
         _service = new ConsentService(
-            _dbContext, _onboardingService, serviceProvider,
+            consentRepository,
+            _onboardingService,
             _legalDocumentSyncService,
-            _notificationInboxService, _syncJob, _metrics, _clock,
+            _notificationInboxService,
+            _syncJob,
+            _profileService,
+            serviceProvider,
+            _metrics,
+            _clock,
             NullLogger<ConsentService>.Instance);
     }
 
@@ -384,7 +412,7 @@ public class ConsentServiceTests : IDisposable
         var versionId = Guid.NewGuid();
         SeedDocumentVersion(versionId, "Test Doc", new Dictionary<string, string>(StringComparer.Ordinal) { ["es"] = "text" });
         SeedConsentRecord(userId, versionId);
-        _dbContext.Profiles.Add(new Profile
+        var profile = new Profile
         {
             Id = Guid.NewGuid(),
             UserId = userId,
@@ -393,7 +421,8 @@ public class ConsentServiceTests : IDisposable
             LastName = "Doe",
             CreatedAt = _clock.GetCurrentInstant(),
             UpdatedAt = _clock.GetCurrentInstant()
-        });
+        };
+        _profileService.GetProfileAsync(userId, Arg.Any<CancellationToken>()).Returns(profile);
         await _dbContext.SaveChangesAsync();
 
         var (version, consent, fullName) = await _service.GetConsentReviewDetailAsync(versionId, userId);
@@ -410,7 +439,7 @@ public class ConsentServiceTests : IDisposable
         var userId = Guid.NewGuid();
         var versionId = Guid.NewGuid();
         SeedDocumentVersion(versionId, "Test Doc", new Dictionary<string, string>(StringComparer.Ordinal) { ["es"] = "text" });
-        _dbContext.Profiles.Add(new Profile
+        var profile = new Profile
         {
             Id = Guid.NewGuid(),
             UserId = userId,
@@ -419,7 +448,8 @@ public class ConsentServiceTests : IDisposable
             LastName = "Doe",
             CreatedAt = _clock.GetCurrentInstant(),
             UpdatedAt = _clock.GetCurrentInstant()
-        });
+        };
+        _profileService.GetProfileAsync(userId, Arg.Any<CancellationToken>()).Returns(profile);
         await _dbContext.SaveChangesAsync();
 
         var (version, consent, fullName) = await _service.GetConsentReviewDetailAsync(versionId, userId);
@@ -445,6 +475,7 @@ public class ConsentServiceTests : IDisposable
         var userId = Guid.NewGuid();
         var versionId = Guid.NewGuid();
         SeedDocumentVersion(versionId, "Test Doc", new Dictionary<string, string>(StringComparer.Ordinal) { ["es"] = "text" });
+        _profileService.GetProfileAsync(userId, Arg.Any<CancellationToken>()).Returns((Profile?)null);
 
         var (version, consent, fullName) = await _service.GetConsentReviewDetailAsync(versionId, userId);
 

--- a/tests/Humans.Application.Tests/Services/Gdpr/GdprExportDependencyInjectionTests.cs
+++ b/tests/Humans.Application.Tests/Services/Gdpr/GdprExportDependencyInjectionTests.cs
@@ -16,6 +16,7 @@ using AuditLogService = Humans.Application.Services.AuditLog.AuditLogService;
 using CampService = Humans.Application.Services.Camps.CampService;
 using FeedbackService = Humans.Application.Services.Feedback.FeedbackService;
 using RoleAssignmentService = Humans.Application.Services.Auth.RoleAssignmentService;
+using ConsentService = Humans.Application.Services.Consent.ConsentService;
 
 namespace Humans.Application.Tests.Services.Gdpr;
 


### PR DESCRIPTION
Part of nobodies-collective/Humans#547 — ConsentService migration only. LegalDocumentService, AdminLegalDocumentService, LegalDocumentSyncService remain in a separate sub-task (#547a).

## Summary

Migrates the `ConsentService` to the §15 repository pattern (services in `Humans.Application`, EF access through a narrow repository interface in `Humans.Infrastructure`).

`consent_records` is append-only per design-rules §12. The new `IConsentRepository` exposes only `AddAsync` plus read methods — no `UpdateAsync`, `DeleteAsync`, or `RemoveAsync` surface. DB triggers additionally block UPDATE/DELETE at the storage layer.

## Changes

**New:**
- `Humans.Application/Interfaces/Repositories/IConsentRepository.cs` — append-only write surface + reads
- `Humans.Infrastructure/Repositories/ConsentRepository.cs` — Singleton, `IDbContextFactory<HumansDbContext>`-based
- `Humans.Application/Services/Consent/ConsentService.cs` — moved from Infrastructure, no DbContext, no `IMemoryCache`, no store
- `tests/.../Architecture/ConsentArchitectureTests.cs` — pins the append-only invariant, namespace, no-DbContext, no-store, sealed repo
- `tests/.../Repositories/ConsentRepositoryTests.cs` — covers every read/write shape

**Modified:**
- `ILegalDocumentSyncService` / `LegalDocumentSyncService` — added narrow `GetActiveRequiredDocumentsForTeamsAsync` so ConsentService stops reading `_dbContext.LegalDocuments` directly
- `SyncLegalDocumentsJob` — uses `IConsentRepository` for the only surviving cross-section consent-record read
- DI wiring in `InfrastructureServiceCollectionExtensions` — Singleton repo + Scoped service
- `docs/architecture/design-rules.md` §15i — partial Legal & Consent migration row added, repo count updated to 7
- `ConsentServiceTests` / `GdprExportDependencyInjectionTests` / `AdminLegalDocumentServiceTests` — updated for the new type location and new fake-service method

**Deleted:**
- `Humans.Infrastructure/Services/ConsentService.cs` (moved via git rename)

## Cross-section dependencies (kept as service interfaces per spec)

- `IOnboardingService` — set consent-check pending after first required consent
- `ILegalDocumentSyncService` — legal document reads while #547a is pending
- `ISystemTeamSync` — volunteer/coordinator membership sync on consent submit
- `INotificationInboxService` — resolve AccessSuspended notifications
- `IProfileService` — replaces direct `_dbContext.Profiles` read in `GetConsentReviewDetailAsync`

## Out of scope (deferred)

- `LegalDocumentService`, `AdminLegalDocumentService`, `LegalDocumentSyncService` still inject `HumansDbContext` directly — tracked as sub-task #547a.
- Cross-domain nav strips on `ConsentRecord.User` / `ConsentRecord.DocumentVersion` are deferred until the full Legal section migrates (same deferral pattern used by PR #243 for User navs).

## Verification

- `dotnet build Humans.slnx -v quiet` — 0 warnings, 0 errors
- `dotnet test tests/Humans.Application.Tests/Humans.Application.Tests.csproj -v quiet` — 1092 passed (was 1063; +29 new)
- `reforge injected HumansDbContext` no longer lists `ConsentService` (only `SendReConsentReminderJob` remains from the original Legal & Consent surface, unrelated to this sub-task)
- `reforge dbset-usage Humans.Application.Services.Consent.ConsentService` → 0
- `dotnet ef migrations add VerifyConsent` produces empty `Up`/`Down` — discarded

## Test plan

- [ ] CI green on the PR
- [ ] Submit a consent in the preview environment and confirm the record persists, onboarding gate advances, and system team sync fires
- [ ] Confirm `/Consent` dashboard renders documents grouped by team with current-version + consent pairing
- [ ] Confirm the re-consent reminder job still finds users missing consent to updated versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)