### PR TITLE
§15 Part 1: Tickets — migrate TicketingBudgetService to Application layer

### DIFF
--- a/docs/sections/Budget.md
+++ b/docs/sections/Budget.md
@@ -76,7 +76,7 @@ Observed in this section's service code as of 2026-04-15:
   - `BudgetService.cs:922` — `_dbContext.TeamMembers` in `GetEffectiveCoordinatorTeamIdsAsync` (Teams section)
   - `BudgetService.cs:930` — `_dbContext.Set<TeamRoleAssignment>()` with deep `.TeamMember` / `.TeamRoleDefinition.Team` nav traversal in `GetEffectiveCoordinatorTeamIdsAsync` (Teams section)
   - `BudgetService.cs:945` — `_dbContext.Teams.Where(t => t.ParentTeamId != null ...)` for child-team expansion (Teams section)
-  - `TicketingBudgetService.cs:44` — `_dbContext.TicketOrders` (Tickets section)
+  - ~~`TicketingBudgetService.cs:44` — `_dbContext.TicketOrders` (Tickets section)~~ **Resolved in PR #545b (2026-04-22):** `TicketingBudgetService` moved to `Humans.Application.Services.Tickets` and now reads paid orders via the Tickets-owned `ITicketingBudgetRepository`. Budget no longer has a code path that reads Tickets tables directly.
 - **Within-section cross-service direct DbContext reads:** None found.
 - **Inline `IMemoryCache` usage in service methods:** None found.
 - **Cross-domain nav properties on this section's entities:**

--- a/docs/sections/Tickets.md
+++ b/docs/sections/Tickets.md
@@ -79,7 +79,7 @@ Observed in this section's service code as of 2026-04-15:
   - `TicketSyncService.cs:440` — `_dbContext.EventSettings` (Shifts section)
   - `TicketSyncService.cs:449,481` — `_dbContext.EventParticipations` (Shifts section)
 - **Within-section cross-service direct DbContext reads:**
-  - `TicketingBudgetService.cs:44` — reads `_dbContext.TicketOrders` directly. From Tickets' perspective this is a Budget-owned service reaching into Tickets tables; should go through `ITicketRepository` / `ITicketQueryService`. (From Budget's perspective this is a cross-section read into Tickets.)
+  - ~~`TicketingBudgetService.cs:44` — reads `_dbContext.TicketOrders` directly.~~ **Resolved in PR #545b (2026-04-22):** `TicketingBudgetService` was migrated to `Humans.Application.Services.Tickets` and now reads paid orders through the narrow `ITicketingBudgetRepository` (Tickets-side). No cross-section DbContext reads remain on the Budget→Tickets bridge.
 - **Inline `IMemoryCache` usage in service methods:**
   - `TicketQueryService.cs:38,42` — direct `_cache.TryGetExistingValue` / `_cache.Set` around ticket counts
   - `TicketQueryService.cs:81` — `_cache.GetOrCreateAsync(CacheKeys.UserIdsWithTickets, ...)`
@@ -96,4 +96,4 @@ Until this section is migrated end-to-end, when touching its code:
 - When touching participation/event logic in `TicketQueryService.cs:584-588` or `TicketSyncService.cs:440,449,481`, route through a Shifts-owned interface (`IEventSettingsService` / `IEventParticipationService`) rather than adding more `_dbContext.EventSettings` / `_dbContext.EventParticipations` reads.
 - When touching code tracking (`TicketQueryService.GetCodeTrackingDataAsync`, ~line 337), do not deepen the `Campaign` / `Grants` / `User` include chain; call `ICampaignService` for campaign + grant data and correlate with local ticket orders in memory.
 - When touching cache logic around ticket counts (`TicketQueryService.cs:38-42,81,132-133`), keep cache calls confined to this service — do not push `IMemoryCache` into controllers or view components — and prefer adding to `CacheKeys.InvalidateTicketCaches()` over sprinkling new `_cache.Remove` sites, so the eventual caching decorator has a single seam to replace.
-- When touching `TicketingBudgetService.cs:44`, do not add further direct reads of `ticket_orders` / `ticket_attendees`; expose what Budget needs as a method on `ITicketQueryService` and call that instead.
+- When extending `TicketingBudgetService`, add new Tickets-side read methods to `ITicketingBudgetRepository` (narrow, Tickets-owned) rather than reaching into `HumansDbContext`. Projection/line-item writes remain Budget-owned and must route through `IBudgetService`.

--- a/src/Humans.Application/DTOs/TicketingBudgetDtos.cs
+++ b/src/Humans.Application/DTOs/TicketingBudgetDtos.cs
@@ -30,3 +30,17 @@ public record TicketingWeeklyActuals(
     decimal Revenue,
     decimal StripeFees,
     decimal TicketTailorFees);
+
+/// <summary>
+/// A single paid ticket order summary — the primitive shape the
+/// <c>ITicketingBudgetRepository</c> returns so <c>TicketingBudgetService</c>
+/// can do the ISO-week bucketing in memory without holding EF types. The
+/// <c>TicketCount</c> is pre-computed server-side from the order's attendees
+/// (Valid + CheckedIn only).
+/// </summary>
+public record PaidTicketOrderSummary(
+    Instant PurchasedAt,
+    decimal TotalAmount,
+    decimal? StripeFee,
+    decimal? ApplicationFee,
+    int TicketCount);

--- a/src/Humans.Application/Interfaces/Repositories/ITicketingBudgetRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/ITicketingBudgetRepository.cs
@@ -1,0 +1,39 @@
+using Humans.Application.DTOs;
+
+namespace Humans.Application.Interfaces.Repositories;
+
+/// <summary>
+/// Narrow repository owned by <see cref="Humans.Application.Services.Tickets.TicketingBudgetService"/>.
+/// Exposes only the ticket-sales shape that the Tickets→Budget bridge needs —
+/// paid orders with pre-counted valid/checked-in attendees — so the service can
+/// bucket them into ISO weeks in memory without taking a direct dependency on
+/// <c>DbContext</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Separate from the (pending) broader <c>ITicketRepository</c> that
+/// <c>TicketQueryService</c> and <c>TicketSyncService</c> will adopt in the
+/// follow-up sub-tasks (#545a and #545c). Keeping this interface narrow avoids
+/// stepping on that larger surface while TicketingBudgetService migrates on its
+/// own timeline as the Tickets→Budget bridge.
+/// </para>
+/// <para>
+/// Table ownership per design-rules §8: <c>ticket_orders</c>/<c>ticket_attendees</c>
+/// are Tickets-section-owned. This repository is a Tickets-owned read gateway
+/// used by the in-section bridge service (TicketingBudgetService co-owns Tickets
+/// tables). <c>ticketing_projections</c> remains Budget-owned and flows through
+/// <c>IBudgetService</c> — unchanged by this migration.
+/// </para>
+/// </remarks>
+public interface ITicketingBudgetRepository
+{
+    /// <summary>
+    /// Returns one summary row per ticket order whose
+    /// <c>PaymentStatus == TicketPaymentStatus.Paid</c>, with <c>TicketCount</c>
+    /// pre-computed server-side as the number of attendees with
+    /// <c>Status</c> equal to <c>Valid</c> or <c>CheckedIn</c>. Read-only
+    /// (AsNoTracking). Ordering is unspecified — the caller groups by ISO week.
+    /// </summary>
+    Task<IReadOnlyList<PaidTicketOrderSummary>> GetPaidOrderSummariesAsync(
+        CancellationToken ct = default);
+}

--- a/src/Humans.Application/Services/Tickets/TicketingBudgetService.cs
+++ b/src/Humans.Application/Services/Tickets/TicketingBudgetService.cs
@@ -1,35 +1,49 @@
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Logging;
-using NodaTime;
 using Humans.Application.DTOs;
 using Humans.Application.Interfaces;
+using Humans.Application.Interfaces.Repositories;
 using Humans.Domain.Entities;
-using Humans.Domain.Enums;
-using Humans.Infrastructure.Data;
+using Microsoft.Extensions.Logging;
+using NodaTime;
 
-namespace Humans.Infrastructure.Services;
+namespace Humans.Application.Services.Tickets;
 
 /// <summary>
-/// Orchestrator between ticket sales data (owned by the Tickets section) and the
-/// ticketing budget group (owned by the Budget section). Queries TicketOrders —
-/// which this service co-owns as part of the Tickets section — aggregates them
-/// into completed ISO weeks, and delegates all BudgetLineItem / TicketingProjection
-/// mutations to <see cref="IBudgetService"/>.
+/// Application-layer implementation of <see cref="ITicketingBudgetService"/>.
+/// Bridges the Tickets section (ticket_orders / ticket_attendees) into the
+/// Budget section (budget_line_items / ticketing_projections). Goes through
+/// <see cref="ITicketingBudgetRepository"/> for ticket reads and delegates all
+/// Budget-owned mutations to <see cref="IBudgetService"/> — this type never
+/// imports <c>Microsoft.EntityFrameworkCore</c>, enforced by
+/// <c>Humans.Application.csproj</c>'s reference graph.
 /// </summary>
-public class TicketingBudgetService : ITicketingBudgetService
+/// <remarks>
+/// <para>
+/// <b>Section ownership.</b> <c>TicketingBudgetService</c> is a co-owner of the
+/// Tickets section, alongside <c>TicketQueryService</c> and
+/// <c>TicketSyncService</c> (both pending their own §15 migrations in
+/// sub-tasks #545a and #545c). It is the Tickets-owned gateway for feeding
+/// completed-week sales into Budget.
+/// </para>
+/// <para>
+/// <b>ticketing_projections ownership.</b> Remains Budget-owned per
+/// design-rules §8. All projection reads/writes route through
+/// <see cref="IBudgetService"/> — this service never touches that table.
+/// </para>
+/// </remarks>
+public sealed class TicketingBudgetService : ITicketingBudgetService
 {
-    private readonly HumansDbContext _dbContext;
+    private readonly ITicketingBudgetRepository _ticketRepo;
     private readonly IBudgetService _budgetService;
     private readonly IClock _clock;
     private readonly ILogger<TicketingBudgetService> _logger;
 
     public TicketingBudgetService(
-        HumansDbContext dbContext,
+        ITicketingBudgetRepository ticketRepo,
         IBudgetService budgetService,
         IClock clock,
         ILogger<TicketingBudgetService> logger)
     {
-        _dbContext = dbContext;
+        _ticketRepo = ticketRepo;
         _budgetService = budgetService;
         _clock = clock;
         _logger = logger;
@@ -39,30 +53,15 @@ public class TicketingBudgetService : ITicketingBudgetService
     {
         try
         {
-            // Read ticket sales (TicketOrders is co-owned by the Tickets section,
-            // of which this service is a member) and aggregate them per ISO week.
-            var orders = await _dbContext.TicketOrders
-                .Where(o => o.PaymentStatus == TicketPaymentStatus.Paid)
-                .Select(o => new
-                {
-                    o.PurchasedAt,
-                    o.TotalAmount,
-                    o.StripeFee,
-                    o.ApplicationFee,
-                    TicketCount = o.Attendees.Count(a =>
-                        a.Status == TicketAttendeeStatus.Valid || a.Status == TicketAttendeeStatus.CheckedIn)
-                })
-                .ToListAsync(ct);
+            // Read paid ticket sales through the narrow Tickets-owned repository.
+            // TicketCount is already pre-computed server-side (valid + checked-in only).
+            var orders = await _ticketRepo.GetPaidOrderSummariesAsync(ct);
 
             var today = _clock.GetCurrentInstant().InUtc().Date;
             var currentWeekMonday = GetIsoMonday(today);
 
             var weeklyActuals = orders
-                .GroupBy(o =>
-                {
-                    var date = o.PurchasedAt.InUtc().Date;
-                    return GetIsoMonday(date);
-                })
+                .GroupBy(o => GetIsoMonday(o.PurchasedAt.InUtc().Date))
                 .Where(g => g.Key < currentWeekMonday)
                 .OrderBy(g => g.Key)
                 .Select(g =>
@@ -114,9 +113,9 @@ public class TicketingBudgetService : ITicketingBudgetService
         return _budgetService.GetActualTicketsSold(ticketingGroup);
     }
 
+    // NodaTime IsoDayOfWeek: Monday=1, Sunday=7.
     private static LocalDate GetIsoMonday(LocalDate date)
     {
-        // NodaTime IsoDayOfWeek: Monday=1, Sunday=7
         var dayOfWeek = (int)date.DayOfWeek;
         return date.PlusDays(-(dayOfWeek - 1));
     }

--- a/src/Humans.Infrastructure/Repositories/TicketingBudgetRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/TicketingBudgetRepository.cs
@@ -1,0 +1,48 @@
+using Microsoft.EntityFrameworkCore;
+using Humans.Application.DTOs;
+using Humans.Application.Interfaces.Repositories;
+using Humans.Domain.Enums;
+using Humans.Infrastructure.Data;
+
+namespace Humans.Infrastructure.Repositories;
+
+/// <summary>
+/// EF-backed implementation of <see cref="ITicketingBudgetRepository"/>. The
+/// only non-test file that queries <c>ticket_orders</c>/<c>ticket_attendees</c>
+/// on behalf of the Tickets→Budget bridge after the TicketingBudgetService
+/// migration lands.
+/// </summary>
+/// <remarks>
+/// Uses <see cref="IDbContextFactory{TContext}"/> so the repository can be
+/// registered as Singleton while <c>HumansDbContext</c> itself remains a
+/// per-request, short-lived instance — the same pattern as the other §15
+/// repositories (Profile, User, etc., per design-rules §15b).
+/// </remarks>
+public sealed class TicketingBudgetRepository : ITicketingBudgetRepository
+{
+    private readonly IDbContextFactory<HumansDbContext> _factory;
+
+    public TicketingBudgetRepository(IDbContextFactory<HumansDbContext> factory)
+    {
+        _factory = factory;
+    }
+
+    public async Task<IReadOnlyList<PaidTicketOrderSummary>> GetPaidOrderSummariesAsync(
+        CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+
+        return await ctx.TicketOrders
+            .AsNoTracking()
+            .Where(o => o.PaymentStatus == TicketPaymentStatus.Paid)
+            .Select(o => new PaidTicketOrderSummary(
+                o.PurchasedAt,
+                o.TotalAmount,
+                o.StripeFee,
+                o.ApplicationFee,
+                o.Attendees.Count(a =>
+                    a.Status == TicketAttendeeStatus.Valid ||
+                    a.Status == TicketAttendeeStatus.CheckedIn)))
+            .ToListAsync(ct);
+    }
+}

--- a/src/Humans.Web/Extensions/Sections/BudgetSectionExtensions.cs
+++ b/src/Humans.Web/Extensions/Sections/BudgetSectionExtensions.cs
@@ -4,6 +4,7 @@ using Humans.Application.Interfaces.Repositories;
 using Humans.Infrastructure.Repositories;
 using Humans.Infrastructure.Services;
 using BudgetBudgetService = Humans.Application.Services.Budget.BudgetService;
+using TicketsTicketingBudgetService = Humans.Application.Services.Tickets.TicketingBudgetService;
 
 namespace Humans.Web.Extensions.Sections;
 
@@ -21,7 +22,12 @@ internal static class BudgetSectionExtensions
         services.AddScoped<IBudgetService>(sp => sp.GetRequiredService<BudgetBudgetService>());
         services.AddScoped<IUserDataContributor>(sp => sp.GetRequiredService<BudgetBudgetService>());
 
-        services.AddScoped<ITicketingBudgetService, TicketingBudgetService>();
+        // TicketingBudgetService (§15 Part 1 — Tickets bridge, issue #545)
+        // Application-layer service goes through the narrow ITicketingBudgetRepository
+        // for paid-order reads and delegates all Budget-owned mutations to IBudgetService.
+        // Repository is Singleton (IDbContextFactory-based) per design-rules §15b.
+        services.AddSingleton<ITicketingBudgetRepository, TicketingBudgetRepository>();
+        services.AddScoped<ITicketingBudgetService, TicketsTicketingBudgetService>();
 
         return services;
     }

--- a/tests/Humans.Application.Tests/Architecture/TicketingBudgetArchitectureTests.cs
+++ b/tests/Humans.Application.Tests/Architecture/TicketingBudgetArchitectureTests.cs
@@ -1,0 +1,108 @@
+using AwesomeAssertions;
+using Humans.Application.Interfaces;
+using Humans.Application.Interfaces.Repositories;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+using TicketingBudgetService = Humans.Application.Services.Tickets.TicketingBudgetService;
+
+namespace Humans.Application.Tests.Architecture;
+
+/// <summary>
+/// Architecture tests enforcing the §15 pattern for the Tickets→Budget bridge
+/// service — migrated in PR #545b (umbrella #545).
+///
+/// <para>
+/// <c>TicketingBudgetService</c> is a narrow bridge: reads paid ticket orders
+/// through <see cref="ITicketingBudgetRepository"/> and delegates all
+/// Budget-owned mutations (line items and projections) to
+/// <see cref="IBudgetService"/>. No caching decorator — it is called from a
+/// nightly batch job and a few admin-finance refresh buttons, nowhere close to
+/// justifying a decorator.
+/// </para>
+/// </summary>
+public class TicketingBudgetArchitectureTests
+{
+    // ── TicketingBudgetService ───────────────────────────────────────────────
+
+    [Fact]
+    public void TicketingBudgetService_LivesInHumansApplicationServicesTicketsNamespace()
+    {
+        typeof(TicketingBudgetService).Namespace
+            .Should().Be("Humans.Application.Services.Tickets",
+                because: "services with business logic live in Humans.Application per design-rules §2b, organized by section");
+    }
+
+    [Fact]
+    public void TicketingBudgetService_HasNoDbContextConstructorParameter()
+    {
+        var ctor = typeof(TicketingBudgetService).GetConstructors().Single();
+        ctor.GetParameters()
+            .Should().NotContain(
+                p => typeof(DbContext).IsAssignableFrom(p.ParameterType),
+                because: "services in Humans.Application must never take DbContext — use ITicketingBudgetRepository instead (design-rules §3)");
+    }
+
+    [Fact]
+    public void TicketingBudgetService_HasNoIMemoryCacheConstructorParameter()
+    {
+        var ctor = typeof(TicketingBudgetService).GetConstructors().Single();
+        var cachingParam = ctor.GetParameters()
+            .FirstOrDefault(p => (p.ParameterType.FullName ?? string.Empty)
+                .StartsWith("Microsoft.Extensions.Caching.Memory", StringComparison.Ordinal));
+
+        cachingParam.Should().BeNull(
+            because: "TicketingBudgetService is a batch-style bridge; no per-request caching is warranted (design-rules §15 + Governance/User precedent for decorator-less sections)");
+    }
+
+    [Fact]
+    public void TicketingBudgetService_TakesRepository()
+    {
+        var ctor = typeof(TicketingBudgetService).GetConstructors().Single();
+        var paramTypes = ctor.GetParameters().Select(p => p.ParameterType).ToList();
+
+        paramTypes.Should().Contain(typeof(ITicketingBudgetRepository));
+    }
+
+    [Fact]
+    public void TicketingBudgetService_TakesBudgetServiceForCrossSectionWrites()
+    {
+        var ctor = typeof(TicketingBudgetService).GetConstructors().Single();
+        var paramTypes = ctor.GetParameters().Select(p => p.ParameterType).ToList();
+
+        paramTypes.Should().Contain(typeof(IBudgetService),
+            because: "ticketing_projections and budget_line_items are Budget-owned; all mutations route through IBudgetService (design-rules §2c, §8)");
+    }
+
+    [Fact]
+    public void TicketingBudgetService_ConstructorTakesNoStoreType()
+    {
+        var ctor = typeof(TicketingBudgetService).GetConstructors().Single();
+        var storeParam = ctor.GetParameters()
+            .FirstOrDefault(p => (p.ParameterType.Namespace ?? string.Empty)
+                .StartsWith("Humans.Application.Interfaces.Stores", StringComparison.Ordinal));
+
+        storeParam.Should().BeNull(
+            because: "the store pattern is retired (design-rules §15); §15 sections use in-decorator ConcurrentDictionary when caching is warranted, or no cache at all");
+    }
+
+    // ── ITicketingBudgetRepository ───────────────────────────────────────────
+
+    [Fact]
+    public void ITicketingBudgetRepository_LivesInApplicationInterfacesRepositoriesNamespace()
+    {
+        typeof(ITicketingBudgetRepository).Namespace
+            .Should().Be("Humans.Application.Interfaces.Repositories",
+                because: "repository interfaces live in Humans.Application.Interfaces.Repositories per design-rules §3");
+    }
+
+    [Fact]
+    public void TicketingBudgetRepository_IsSealed()
+    {
+        // Mirrors ProfileRepository / UserRepository — repository implementations are terminal;
+        // no subclass should extend or override the EF-backed data access.
+        var repoType = typeof(Humans.Infrastructure.Repositories.TicketingBudgetRepository);
+
+        repoType.IsSealed.Should().BeTrue(
+            because: "repository implementations are sealed to prevent ad-hoc extension; any new behavior belongs on the interface");
+    }
+}

--- a/tests/Humans.Application.Tests/Repositories/TicketingBudgetRepositoryTests.cs
+++ b/tests/Humans.Application.Tests/Repositories/TicketingBudgetRepositoryTests.cs
@@ -1,0 +1,147 @@
+using AwesomeAssertions;
+using Humans.Application.Tests.Infrastructure;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using Humans.Infrastructure.Data;
+using Humans.Infrastructure.Repositories;
+using Microsoft.EntityFrameworkCore;
+using NodaTime;
+using Xunit;
+
+namespace Humans.Application.Tests.Repositories;
+
+public sealed class TicketingBudgetRepositoryTests : IDisposable
+{
+    private readonly HumansDbContext _dbContext;
+    private readonly TicketingBudgetRepository _repo;
+
+    public TicketingBudgetRepositoryTests()
+    {
+        var options = new DbContextOptionsBuilder<HumansDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        _dbContext = new HumansDbContext(options);
+        _repo = new TicketingBudgetRepository(new TestDbContextFactory(options));
+    }
+
+    public void Dispose()
+    {
+        _dbContext.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private async Task<TicketOrder> SeedOrderAsync(
+        TicketPaymentStatus status,
+        decimal total,
+        decimal? stripeFee,
+        decimal? applicationFee,
+        Instant purchasedAt,
+        TicketAttendeeStatus[] attendeeStatuses)
+    {
+        var order = new TicketOrder
+        {
+            Id = Guid.NewGuid(),
+            VendorOrderId = $"vo-{Guid.NewGuid():N}",
+            PaymentStatus = status,
+            TotalAmount = total,
+            StripeFee = stripeFee,
+            ApplicationFee = applicationFee,
+            PurchasedAt = purchasedAt,
+            SyncedAt = purchasedAt,
+        };
+        foreach (var s in attendeeStatuses)
+        {
+            order.Attendees.Add(new TicketAttendee
+            {
+                Id = Guid.NewGuid(),
+                VendorTicketId = $"vt-{Guid.NewGuid():N}",
+                TicketOrderId = order.Id,
+                Status = s,
+                SyncedAt = purchasedAt,
+            });
+        }
+        _dbContext.TicketOrders.Add(order);
+        await _dbContext.SaveChangesAsync();
+        return order;
+    }
+
+    // ==========================================================================
+    // GetPaidOrderSummariesAsync
+    // ==========================================================================
+
+    [Fact]
+    public async Task GetPaidOrderSummariesAsync_ReturnsEmpty_WhenNoOrders()
+    {
+        var result = await _repo.GetPaidOrderSummariesAsync();
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetPaidOrderSummariesAsync_ExcludesNonPaidOrders()
+    {
+        var purchasedAt = Instant.FromUtc(2026, 3, 1, 12, 0);
+        await SeedOrderAsync(TicketPaymentStatus.Paid, 50m, 1.5m, 0.5m, purchasedAt,
+            new[] { TicketAttendeeStatus.Valid });
+        await SeedOrderAsync(TicketPaymentStatus.Pending, 80m, 2m, 0.8m, purchasedAt,
+            new[] { TicketAttendeeStatus.Valid });
+        await SeedOrderAsync(TicketPaymentStatus.Refunded, 90m, 2m, 0.9m, purchasedAt,
+            new[] { TicketAttendeeStatus.Valid });
+        await SeedOrderAsync(TicketPaymentStatus.Cancelled, 100m, 0m, 0m, purchasedAt,
+            new[] { TicketAttendeeStatus.Void });
+
+        var result = await _repo.GetPaidOrderSummariesAsync();
+
+        result.Should().HaveCount(1);
+        result[0].TotalAmount.Should().Be(50m);
+    }
+
+    [Fact]
+    public async Task GetPaidOrderSummariesAsync_CountsOnlyValidAndCheckedInAttendees()
+    {
+        var purchasedAt = Instant.FromUtc(2026, 3, 1, 12, 0);
+        await SeedOrderAsync(TicketPaymentStatus.Paid, 200m, 6m, 2m, purchasedAt, new[]
+        {
+            TicketAttendeeStatus.Valid,      // counted
+            TicketAttendeeStatus.CheckedIn,  // counted
+            TicketAttendeeStatus.Void,       // excluded
+            TicketAttendeeStatus.Valid,      // counted
+            TicketAttendeeStatus.Void,       // excluded
+        });
+
+        var result = await _repo.GetPaidOrderSummariesAsync();
+
+        result.Should().ContainSingle();
+        result[0].TicketCount.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task GetPaidOrderSummariesAsync_ReturnsAllFieldsIncludingNullableFees()
+    {
+        var purchasedAt = Instant.FromUtc(2026, 3, 5, 10, 30);
+        await SeedOrderAsync(TicketPaymentStatus.Paid, 150m, stripeFee: null, applicationFee: null, purchasedAt,
+            new[] { TicketAttendeeStatus.Valid });
+
+        var result = await _repo.GetPaidOrderSummariesAsync();
+
+        result.Should().ContainSingle();
+        var summary = result[0];
+        summary.PurchasedAt.Should().Be(purchasedAt);
+        summary.TotalAmount.Should().Be(150m);
+        summary.StripeFee.Should().BeNull();
+        summary.ApplicationFee.Should().BeNull();
+        summary.TicketCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task GetPaidOrderSummariesAsync_ReturnsZeroTicketCount_WhenAllAttendeesVoid()
+    {
+        var purchasedAt = Instant.FromUtc(2026, 3, 1, 12, 0);
+        await SeedOrderAsync(TicketPaymentStatus.Paid, 50m, 1m, 0.3m, purchasedAt,
+            new[] { TicketAttendeeStatus.Void, TicketAttendeeStatus.Void });
+
+        var result = await _repo.GetPaidOrderSummariesAsync();
+
+        result.Should().ContainSingle();
+        result[0].TicketCount.Should().Be(0);
+    }
+}

--- a/tests/Humans.Application.Tests/Services/TicketingBudgetServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/TicketingBudgetServiceTests.cs
@@ -1,0 +1,177 @@
+using AwesomeAssertions;
+using Humans.Application.DTOs;
+using Humans.Application.Interfaces;
+using Humans.Application.Interfaces.Repositories;
+using Humans.Domain.Entities;
+using Microsoft.Extensions.Logging.Abstractions;
+using NodaTime;
+using NodaTime.Testing;
+using NSubstitute;
+using Xunit;
+using TicketingBudgetService = Humans.Application.Services.Tickets.TicketingBudgetService;
+
+namespace Humans.Application.Tests.Services;
+
+/// <summary>
+/// Unit tests for the Application-layer <see cref="TicketingBudgetService"/>.
+/// Covers the ISO-week bucketing, exclusion of the current (not-yet-complete)
+/// week, and delegation of Budget-owned mutations to <see cref="IBudgetService"/>.
+/// Repository reads are stubbed via NSubstitute; no DB involvement.
+/// </summary>
+public class TicketingBudgetServiceTests
+{
+    private readonly ITicketingBudgetRepository _repo = Substitute.For<ITicketingBudgetRepository>();
+    private readonly IBudgetService _budgetService = Substitute.For<IBudgetService>();
+    private readonly FakeClock _clock = new(Instant.FromUtc(2026, 3, 11, 9, 0)); // Wed 11 Mar 2026
+
+    private TicketingBudgetService CreateSut() =>
+        new(_repo, _budgetService, _clock, NullLogger<TicketingBudgetService>.Instance);
+
+    [Fact]
+    public async Task SyncActualsAsync_BucketsByIsoWeek_AndExcludesCurrentWeek()
+    {
+        // "Now" is Wed 2026-03-11 → current ISO-week Monday is 2026-03-09 (excluded).
+        // Two paid orders in the completed week of 2026-03-02 (Mon) .. 2026-03-08 (Sun),
+        // one order in the current (incomplete) week → must be excluded.
+        var inCompletedWeekA = Instant.FromUtc(2026, 3, 2, 8, 0);  // Mon
+        var inCompletedWeekB = Instant.FromUtc(2026, 3, 7, 22, 30); // Sat
+        var inCurrentWeek = Instant.FromUtc(2026, 3, 10, 7, 0);  // Tue (current week)
+
+        _repo.GetPaidOrderSummariesAsync(Arg.Any<CancellationToken>())
+            .Returns(new List<PaidTicketOrderSummary>
+            {
+                new(inCompletedWeekA, 100m, 2m, 1m, TicketCount: 2),
+                new(inCompletedWeekB, 50m, 1.5m, 0.5m, TicketCount: 1),
+                new(inCurrentWeek, 999m, 10m, 5m, TicketCount: 10),
+            });
+
+        List<TicketingWeeklyActuals>? capturedActuals = null;
+        _budgetService.SyncTicketingActualsAsync(
+                Arg.Any<Guid>(),
+                Arg.Do<IReadOnlyList<TicketingWeeklyActuals>>(a => capturedActuals = a.ToList()),
+                Arg.Any<CancellationToken>())
+            .Returns(1);
+
+        var sut = CreateSut();
+
+        var result = await sut.SyncActualsAsync(Guid.NewGuid());
+
+        result.Should().Be(1);
+        capturedActuals.Should().NotBeNull();
+        capturedActuals.Should().HaveCount(1, because: "only the Mar 2–8 week is complete");
+
+        var week = capturedActuals![0];
+        week.Monday.Should().Be(new LocalDate(2026, 3, 2));
+        week.Sunday.Should().Be(new LocalDate(2026, 3, 8));
+        week.TicketCount.Should().Be(3);
+        week.Revenue.Should().Be(150m);
+        week.StripeFees.Should().Be(3.5m);
+        week.TicketTailorFees.Should().Be(1.5m);
+    }
+
+    [Fact]
+    public async Task SyncActualsAsync_TreatsNullFeesAsZero()
+    {
+        var purchasedAt = Instant.FromUtc(2026, 3, 3, 10, 0); // inside completed week Mon 2 Mar
+        _repo.GetPaidOrderSummariesAsync(Arg.Any<CancellationToken>())
+            .Returns(new List<PaidTicketOrderSummary>
+            {
+                new(purchasedAt, 100m, StripeFee: null, ApplicationFee: null, TicketCount: 2),
+                new(purchasedAt,  50m, StripeFee: 1m,   ApplicationFee: 0.2m, TicketCount: 1),
+            });
+
+        List<TicketingWeeklyActuals>? capturedActuals = null;
+        _budgetService.SyncTicketingActualsAsync(
+                Arg.Any<Guid>(),
+                Arg.Do<IReadOnlyList<TicketingWeeklyActuals>>(a => capturedActuals = a.ToList()),
+                Arg.Any<CancellationToken>())
+            .Returns(2);
+
+        var sut = CreateSut();
+
+        await sut.SyncActualsAsync(Guid.NewGuid());
+
+        capturedActuals.Should().NotBeNull().And.ContainSingle();
+        capturedActuals![0].StripeFees.Should().Be(1m);
+        capturedActuals[0].TicketTailorFees.Should().Be(0.2m);
+        capturedActuals[0].Revenue.Should().Be(150m);
+    }
+
+    [Fact]
+    public async Task SyncActualsAsync_ProducesEmptyActuals_WhenNoCompletedWeeks()
+    {
+        // Only orders inside the current week: nothing should be synced.
+        var inCurrentWeek = Instant.FromUtc(2026, 3, 10, 12, 0);
+        _repo.GetPaidOrderSummariesAsync(Arg.Any<CancellationToken>())
+            .Returns(new List<PaidTicketOrderSummary>
+            {
+                new(inCurrentWeek, 75m, 2m, 0.5m, TicketCount: 1),
+            });
+
+        List<TicketingWeeklyActuals>? capturedActuals = null;
+        _budgetService.SyncTicketingActualsAsync(
+                Arg.Any<Guid>(),
+                Arg.Do<IReadOnlyList<TicketingWeeklyActuals>>(a => capturedActuals = a.ToList()),
+                Arg.Any<CancellationToken>())
+            .Returns(0);
+
+        var sut = CreateSut();
+
+        await sut.SyncActualsAsync(Guid.NewGuid());
+
+        capturedActuals.Should().NotBeNull().And.BeEmpty();
+    }
+
+    [Fact]
+    public async Task RefreshProjectionsAsync_DelegatesToBudgetService()
+    {
+        var yearId = Guid.NewGuid();
+        _budgetService.RefreshTicketingProjectionsAsync(yearId, Arg.Any<CancellationToken>())
+            .Returns(7);
+
+        var sut = CreateSut();
+
+        var result = await sut.RefreshProjectionsAsync(yearId);
+
+        result.Should().Be(7);
+        await _budgetService.Received(1).RefreshTicketingProjectionsAsync(yearId, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetProjectionsAsync_DelegatesToBudgetService()
+    {
+        var groupId = Guid.NewGuid();
+        IReadOnlyList<TicketingWeekProjection> expected =
+            new List<TicketingWeekProjection>
+            {
+                new()
+                {
+                    WeekLabel = "Apr 6–Apr 12",
+                    WeekStart = new LocalDate(2026, 4, 6),
+                    WeekEnd = new LocalDate(2026, 4, 12),
+                    ProjectedTickets = 10,
+                    ProjectedRevenue = 500m,
+                    ProjectedStripeFees = 10m,
+                    ProjectedTtFees = 5m,
+                }
+            };
+        _budgetService.GetTicketingProjectionEntriesAsync(groupId).Returns(expected);
+
+        var sut = CreateSut();
+
+        var result = await sut.GetProjectionsAsync(groupId);
+
+        result.Should().BeSameAs(expected);
+    }
+
+    [Fact]
+    public void GetActualTicketsSold_DelegatesToBudgetService()
+    {
+        var group = new BudgetGroup { Id = Guid.NewGuid(), Name = "Ticketing" };
+        _budgetService.GetActualTicketsSold(group).Returns(187);
+
+        var sut = CreateSut();
+
+        sut.GetActualTicketsSold(group).Should().Be(187);
+    }
+}


### PR DESCRIPTION
Part of nobodies-collective/Humans#545 — TicketingBudgetService migration only. TicketQueryService and TicketSyncService remain in separate sub-tasks (#545a, #545c).

## Scope

Migrates the Tickets→Budget bridge service (`TicketingBudgetService`) to the §15 repository pattern. This service is a thin orchestrator: it reads paid ticket orders from the Tickets side and delegates all `BudgetLineItem` / `TicketingProjection` mutations to `IBudgetService` on the Budget side.

`TicketQueryService` and `TicketSyncService` still live in `Humans.Infrastructure.Services` and inject `HumansDbContext` directly — out of scope here, tracked in sub-tasks #545a and #545c.

## Ownership decisions

- **`ticket_orders` / `ticket_attendees`** remain Tickets-owned. This PR adds a narrow Tickets-side repository (`ITicketingBudgetRepository`) rather than bolting reads onto the forthcoming `ITicketRepository` that #545a/c will design — that keeps the surface area tight and avoids stepping on the larger refactor.
- **`ticketing_projections`** remains Budget-owned per design-rules §8. All projection/line-item writes continue to route through `IBudgetService`. Nothing about that ownership changes in this PR.

## Changes

- Move `TicketingBudgetService` from `Humans.Infrastructure.Services` to `Humans.Application.Services.Tickets`. The service is `sealed`, takes `ITicketingBudgetRepository` + `IBudgetService`, and never imports `Microsoft.EntityFrameworkCore` (enforced by `Humans.Application.csproj`'s reference graph).
- Add narrow `ITicketingBudgetRepository` / `TicketingBudgetRepository`: a single `GetPaidOrderSummariesAsync` method that returns `PaidTicketOrderSummary` rows with `TicketCount` pre-computed server-side (Valid + CheckedIn attendees only). Repository is `Singleton` and uses `IDbContextFactory<HumansDbContext>` per §15b.
- Add `PaidTicketOrderSummary` DTO alongside `TicketingWeeklyActuals` in `Humans.Application.DTOs`.
- Register the repository (Singleton) and swap the `ITicketingBudgetService` alias to the new Application-layer type in `InfrastructureServiceCollectionExtensions`.
- Delete the old `Humans.Infrastructure/Services/TicketingBudgetService.cs`.

No caching decorator — the service is driven by a nightly batch job and a handful of admin-finance refresh buttons; a decorator would be pure overhead (same rationale Governance/User used).

## Tests

- `TicketingBudgetArchitectureTests` — namespace, no `DbContext` / `IMemoryCache` constructor params, takes `ITicketingBudgetRepository` + `IBudgetService`, sealed repository.
- `TicketingBudgetRepositoryTests` (in-memory EF) — Paid-only filter, Valid/CheckedIn attendee counting, nullable fee passthrough, void-only edge case.
- `TicketingBudgetServiceTests` — ISO-week bucketing, current-week exclusion, null-fee-as-zero summation, delegation of projections/line-items to `IBudgetService`.

## Verification

- ✅ `dotnet build Humans.slnx -v quiet` — 0 warnings, 0 errors.
- ✅ `dotnet test tests/Humans.Application.Tests/...` — 1082 passed, 0 failed.
- ✅ `reforge injected HumansDbContext` no longer lists `TicketingBudgetService`.
- ✅ `reforge dbset-usage Humans.Application.Services.Tickets.TicketingBudgetService` returns 0.
- ✅ `dotnet ef migrations add VerifyTicketingBudget` produced an empty Up/Down — discarded.

## Docs

- `docs/architecture/design-rules.md` §15i updated with the partial-Tickets row noting this migration and the pending `#545a`/`#545c` sub-tasks. Repository count incremented to 7.
- `docs/sections/Tickets.md` and `docs/sections/Budget.md` — struck out the resolved direct `_dbContext.TicketOrders` read and refreshed the touch-and-clean guidance.

## Test plan

- [ ] CI green on preview environment
- [ ] Smoke: Finance admin page loads budget summary with ticketing projections
- [ ] Smoke: "Sync ticketing actuals" admin button still materializes completed weeks
- [ ] Smoke: Hangfire `TicketingBudgetSyncJob` runs without errors