### PR TITLE
§15 Part 1: Tickets — migrate TicketSyncService domain side to Application layer

### DIFF
--- a/docs/architecture/design-rules.md
+++ b/docs/architecture/design-rules.md
@@ -577,7 +577,7 @@ Old names that no longer exist: `CachedProfile`, `IProfileStore`, `ProfileStore`
 
 ### 15i. Known Current Violations (as of 2026-04-22)
 
-- **~24 services** still live in `Humans.Infrastructure/Services/` and inject `HumansDbContext` directly. Target: 0. Migration progress by section:
+- **~25 services** still live in `Humans.Infrastructure/Services/` and inject `HumansDbContext` directly. Target: 0. Migration progress by section:
   - **Governance** — migrated 2026-04-15 in PR #503.
   - **Profiles** — fully migrated 2026-04-20 in PR #235 — `ProfileService`, `ContactFieldService`, `ContactService`, `UserEmailService`, `CommunicationPreferenceService` now live in `Humans.Application.Services.Profile`. (`VolunteerHistoryService` was folded into `ProfileService`/`IProfileRepository`; it no longer exists as a separate service.)
   - **User** — migrated 2026-04-21 in PR #243 — `UserService` now lives in `Humans.Application.Services.Users`, goes through `IUserRepository`, and invalidates `IFullProfileInvalidator` on writes that change FullProfile-visible fields. **No caching decorator** was added for the User section: User is ~500 rows with no hot bulk-read path, so a dict cache isn't warranted (same rationale as Governance's decorator removal in #242). Option A is documented in `docs/superpowers/specs/2026-04-21-issue-511-user-migration.md`.
@@ -590,8 +590,7 @@ Old names that no longer exist: `CachedProfile`, `IProfileStore`, `ProfileStore`
   - **Feedback** — migrated 2026-04-22 in issue #549 — `FeedbackService` now lives in `Humans.Application.Services.Feedback`, goes through `IFeedbackRepository`, and resolves reporter / assignee / resolver display names + effective email via `IUserService`, `IUserEmailService.GetNotificationTargetEmailsAsync`, and `ITeamService.GetTeamNamesByIdsAsync`. Cross-domain `.Include()` chains on `FeedbackReport.User`, `.ResolvedByUser`, `.AssignedToUser`, `.AssignedToTeam`, and `FeedbackMessage.SenderUser` are gone from the service (4→0). Navs are `[Obsolete]`-marked and populated in-memory by the service (§6b "in-memory join") so controllers and views continue to read `report.User.DisplayName` etc. under `#pragma warning disable CS0618`. Nav-strip follow-up lands as part of the wider User-entity nav cleanup. No caching decorator — Feedback is admin-review-only and low-traffic.
   - **Auth** — migrated 2026-04-22 in issue #551 — `RoleAssignmentService` and `MagicLinkService` now live in `Humans.Application.Services.Auth`. `RoleAssignmentService` goes through `IRoleAssignmentRepository`, stitches assignee / creator display names via `IUserService`, and invalidates the per-user claims cache via `IRoleAssignmentClaimsCacheInvalidator` + the nav-badge cache via `INavBadgeCacheInvalidator`. `MagicLinkService` owns no tables; verified-email lookup routes through `IUserEmailService.FindVerifiedEmailWithUserAsync`, and Data-Protection / URL / replay / signup-cooldown state sits behind Infrastructure-side `IMagicLinkUrlBuilder` + `IMagicLinkRateLimiter` (same shape as `CommunicationPreferenceService` + `IUnsubscribeTokenProvider`). Cross-domain navs on `RoleAssignment` (`User`, `CreatedByUser`) are `[Obsolete]`-marked and populated in-memory; controllers + the two daily-digest jobs that still read them do so under `#pragma warning disable CS0618`. No caching decorator — Auth writes are rare (handful of admin events per month).
   - **Teams (partial)** — `TeamPageService` migrated 2026-04-22 under umbrella #540 (sub-task #540b) — it now lives in `Humans.Application.Services.Teams` and owns no tables (pure composer over `ITeamService`, `IProfileService`, `ITeamResourceService`, `IShiftManagementService`, `IUserService`). A new `IShiftManagementService.GetTeamIdsWithShiftsInEventAsync` method replaced the direct `Rotas`/`Shifts` query. `TeamService` (2,698 LOC), `TeamResourceService` (883 LOC), and `StubTeamResourceService` (368 LOC) remain in `Humans.Infrastructure/Services/` pending sub-tasks #540a and #540c.
-  - **Tickets (partial — domain-persistence side)** — `TicketSyncService` migrated 2026-04-22 in PR #545c (umbrella #545) — now lives in `Humans.Application.Services.Tickets`, goes through the newly introduced `ITicketRepository` for all DB access, delegates vendor I/O to the existing `ITicketVendorService` connector (still Infrastructure: `TicketTailorService` / `StubTicketVendorService`), routes `event_participations` writes through `IUserService`, and routes `EventSettings` reads through `IShiftManagementService`. **No caching decorator** — TicketSync runs on a 15-minute Hangfire schedule, not request-path. `TicketQueryService` and the Ticket Tailor connector migration (domain-side vendor client extraction) remain outstanding (#545a, #555). `TicketingBudgetService` migration landed separately in PR #545b.
-- **~19 cross-domain `.Include()` calls** across **~11 services**. Biggest offenders: `OnboardingService` (7), `GoogleWorkspaceSyncService` (4). Target: 0.
+- **~20 cross-domain `.Include()` calls** across **~12 services**. Biggest offenders: `OnboardingService` (7), `GoogleWorkspaceSyncService` (4). Target: 0.
   - Includes fully removed from the service layer in these sections:
     - Profile
     - Governance
@@ -601,9 +600,8 @@ Old names that no longer exist: `CachedProfile`, `IProfileStore`, `ProfileStore`
     - Feedback
     - Auth
     - Teams (TeamPageService only — `TeamService` and `TeamResourceService` still in Infrastructure)
-    - Tickets (TicketSyncService only — `TicketQueryService` still in Infrastructure)
   - **User section's PR #243 landed the Application-layer move but deferred the nav-strip** — cross-domain nav reads via `user.UserEmails`, `user.Profile`, `user.TeamMemberships`, `user.GetEffectiveEmail()` still exist in `TicketQueryService`, `TeamService`, `GoogleWorkspaceSyncService`, `SendBoardDailyDigestJob`, `SyncLegalDocumentsJob`, `SystemTeamSyncJob`, `SuspendNonCompliantMembersJob`, `ProfileController`. Tracked as a follow-up.
-- **15 repositories** exist today. Target: one per domain (~20 total):
+- **14 repositories** exist today. Target: one per domain (~20 total):
   - `ApplicationRepository`
   - `ProfileRepository`
   - `ContactFieldRepository`
@@ -618,7 +616,6 @@ Old names that no longer exist: `CachedProfile`, `IProfileStore`, `ProfileStore`
   - `EmailOutboxRepository`
   - `FeedbackRepository`
   - `RoleAssignmentRepository`
-  - `TicketRepository`
 - **0 stores** exist today. `IApplicationStore` was retired when Governance dropped its caching layer (issue #533). Target: replaced by §15 `ConcurrentDictionary`-in-decorator where a cache is warranted; no separate store type.
 - **1 caching decorator** exists today (`CachingProfileService` — §15 pattern). Governance, User, and Camps sections operate without one. Target: every migrated section that needs caching uses the §15 pattern. Not every section needs caching.
 - **Inline `IMemoryCache.GetOrCreateAsync`** still scattered across services for non-profile caches (nav badge, notification meter, role-assignment claims, shift auth, camps-for-year, camp settings). These are short-TTL request-acceleration caches, not canonical domain data caches, and are appropriate for `IMemoryCache`. Canonical domain data caches (full entity projections) must use the §15 pattern.

--- a/docs/architecture/design-rules.md
+++ b/docs/architecture/design-rules.md
@@ -577,7 +577,7 @@ Old names that no longer exist: `CachedProfile`, `IProfileStore`, `ProfileStore`
 
 ### 15i. Known Current Violations (as of 2026-04-22)
 
-- **~25 services** still live in `Humans.Infrastructure/Services/` and inject `HumansDbContext` directly. Target: 0. Migration progress by section:
+- **~24 services** still live in `Humans.Infrastructure/Services/` and inject `HumansDbContext` directly. Target: 0. Migration progress by section:
   - **Governance** — migrated 2026-04-15 in PR #503.
   - **Profiles** — fully migrated 2026-04-20 in PR #235 — `ProfileService`, `ContactFieldService`, `ContactService`, `UserEmailService`, `CommunicationPreferenceService` now live in `Humans.Application.Services.Profile`. (`VolunteerHistoryService` was folded into `ProfileService`/`IProfileRepository`; it no longer exists as a separate service.)
   - **User** — migrated 2026-04-21 in PR #243 — `UserService` now lives in `Humans.Application.Services.Users`, goes through `IUserRepository`, and invalidates `IFullProfileInvalidator` on writes that change FullProfile-visible fields. **No caching decorator** was added for the User section: User is ~500 rows with no hot bulk-read path, so a dict cache isn't warranted (same rationale as Governance's decorator removal in #242). Option A is documented in `docs/superpowers/specs/2026-04-21-issue-511-user-migration.md`.
@@ -590,7 +590,8 @@ Old names that no longer exist: `CachedProfile`, `IProfileStore`, `ProfileStore`
   - **Feedback** — migrated 2026-04-22 in issue #549 — `FeedbackService` now lives in `Humans.Application.Services.Feedback`, goes through `IFeedbackRepository`, and resolves reporter / assignee / resolver display names + effective email via `IUserService`, `IUserEmailService.GetNotificationTargetEmailsAsync`, and `ITeamService.GetTeamNamesByIdsAsync`. Cross-domain `.Include()` chains on `FeedbackReport.User`, `.ResolvedByUser`, `.AssignedToUser`, `.AssignedToTeam`, and `FeedbackMessage.SenderUser` are gone from the service (4→0). Navs are `[Obsolete]`-marked and populated in-memory by the service (§6b "in-memory join") so controllers and views continue to read `report.User.DisplayName` etc. under `#pragma warning disable CS0618`. Nav-strip follow-up lands as part of the wider User-entity nav cleanup. No caching decorator — Feedback is admin-review-only and low-traffic.
   - **Auth** — migrated 2026-04-22 in issue #551 — `RoleAssignmentService` and `MagicLinkService` now live in `Humans.Application.Services.Auth`. `RoleAssignmentService` goes through `IRoleAssignmentRepository`, stitches assignee / creator display names via `IUserService`, and invalidates the per-user claims cache via `IRoleAssignmentClaimsCacheInvalidator` + the nav-badge cache via `INavBadgeCacheInvalidator`. `MagicLinkService` owns no tables; verified-email lookup routes through `IUserEmailService.FindVerifiedEmailWithUserAsync`, and Data-Protection / URL / replay / signup-cooldown state sits behind Infrastructure-side `IMagicLinkUrlBuilder` + `IMagicLinkRateLimiter` (same shape as `CommunicationPreferenceService` + `IUnsubscribeTokenProvider`). Cross-domain navs on `RoleAssignment` (`User`, `CreatedByUser`) are `[Obsolete]`-marked and populated in-memory; controllers + the two daily-digest jobs that still read them do so under `#pragma warning disable CS0618`. No caching decorator — Auth writes are rare (handful of admin events per month).
   - **Teams (partial)** — `TeamPageService` migrated 2026-04-22 under umbrella #540 (sub-task #540b) — it now lives in `Humans.Application.Services.Teams` and owns no tables (pure composer over `ITeamService`, `IProfileService`, `ITeamResourceService`, `IShiftManagementService`, `IUserService`). A new `IShiftManagementService.GetTeamIdsWithShiftsInEventAsync` method replaced the direct `Rotas`/`Shifts` query. `TeamService` (2,698 LOC), `TeamResourceService` (883 LOC), and `StubTeamResourceService` (368 LOC) remain in `Humans.Infrastructure/Services/` pending sub-tasks #540a and #540c.
-- **~20 cross-domain `.Include()` calls** across **~12 services**. Biggest offenders: `OnboardingService` (7), `GoogleWorkspaceSyncService` (4). Target: 0.
+  - **Tickets (partial — domain-persistence side)** — `TicketSyncService` migrated 2026-04-22 in PR #545c (umbrella #545) — now lives in `Humans.Application.Services.Tickets`, goes through the newly introduced `ITicketRepository` for all DB access, delegates vendor I/O to the existing `ITicketVendorService` connector (still Infrastructure: `TicketTailorService` / `StubTicketVendorService`), routes `event_participations` writes through `IUserService`, and routes `EventSettings` reads through `IShiftManagementService`. **No caching decorator** — TicketSync runs on a 15-minute Hangfire schedule, not request-path. `TicketQueryService` and the Ticket Tailor connector migration (domain-side vendor client extraction) remain outstanding (#545a, #555). `TicketingBudgetService` migration landed separately in PR #545b.
+- **~19 cross-domain `.Include()` calls** across **~11 services**. Biggest offenders: `OnboardingService` (7), `GoogleWorkspaceSyncService` (4). Target: 0.
   - Includes fully removed from the service layer in these sections:
     - Profile
     - Governance
@@ -600,8 +601,9 @@ Old names that no longer exist: `CachedProfile`, `IProfileStore`, `ProfileStore`
     - Feedback
     - Auth
     - Teams (TeamPageService only — `TeamService` and `TeamResourceService` still in Infrastructure)
+    - Tickets (TicketSyncService only — `TicketQueryService` still in Infrastructure)
   - **User section's PR #243 landed the Application-layer move but deferred the nav-strip** — cross-domain nav reads via `user.UserEmails`, `user.Profile`, `user.TeamMemberships`, `user.GetEffectiveEmail()` still exist in `TicketQueryService`, `TeamService`, `GoogleWorkspaceSyncService`, `SendBoardDailyDigestJob`, `SyncLegalDocumentsJob`, `SystemTeamSyncJob`, `SuspendNonCompliantMembersJob`, `ProfileController`. Tracked as a follow-up.
-- **14 repositories** exist today. Target: one per domain (~20 total):
+- **15 repositories** exist today. Target: one per domain (~20 total):
   - `ApplicationRepository`
   - `ProfileRepository`
   - `ContactFieldRepository`
@@ -616,6 +618,7 @@ Old names that no longer exist: `CachedProfile`, `IProfileStore`, `ProfileStore`
   - `EmailOutboxRepository`
   - `FeedbackRepository`
   - `RoleAssignmentRepository`
+  - `TicketRepository`
 - **0 stores** exist today. `IApplicationStore` was retired when Governance dropped its caching layer (issue #533). Target: replaced by §15 `ConcurrentDictionary`-in-decorator where a cache is warranted; no separate store type.
 - **1 caching decorator** exists today (`CachingProfileService` — §15 pattern). Governance, User, and Camps sections operate without one. Target: every migrated section that needs caching uses the §15 pattern. Not every section needs caching.
 - **Inline `IMemoryCache.GetOrCreateAsync`** still scattered across services for non-profile caches (nav badge, notification meter, role-assignment claims, shift auth, camps-for-year, camp settings). These are short-TTL request-acceleration caches, not canonical domain data caches, and are appropriate for `IMemoryCache`. Canonical domain data caches (full entity projections) must use the §15 pattern.

--- a/docs/sections/Tickets.md
+++ b/docs/sections/Tickets.md
@@ -76,8 +76,8 @@ Observed in this section's service code as of 2026-04-15:
   - `TicketQueryService.cs:569` — `_dbContext.Users` (Users/Identity section)
   - `TicketQueryService.cs:584` — `_dbContext.EventSettings` (Shifts section)
   - `TicketQueryService.cs:588` — `_dbContext.EventParticipations` (Shifts section)
-  - `TicketSyncService.cs:440` — `_dbContext.EventSettings` (Shifts section)
-  - `TicketSyncService.cs:449,481` — `_dbContext.EventParticipations` (Shifts section)
+  - ~~`TicketSyncService.cs:440` — `_dbContext.EventSettings` (Shifts section)~~ **Resolved in PR #545c (2026-04-22):** active-event lookup now routes through `IShiftManagementService.GetActiveAsync()`.
+  - ~~`TicketSyncService.cs:449,481` — `_dbContext.EventParticipations` (Shifts section)~~ **Resolved in PR #545c (2026-04-22):** participation reads/writes now route through `IUserService` (User section owns `event_participations` per PR #243).
 - **Within-section cross-service direct DbContext reads:**
   - `TicketingBudgetService.cs:44` — reads `_dbContext.TicketOrders` directly. From Tickets' perspective this is a Budget-owned service reaching into Tickets tables; should go through `ITicketRepository` / `ITicketQueryService`. (From Budget's perspective this is a cross-section read into Tickets.)
 - **Inline `IMemoryCache` usage in service methods:**
@@ -93,7 +93,7 @@ Observed in this section's service code as of 2026-04-15:
 Until this section is migrated end-to-end, when touching its code:
 
 - When touching `TicketQueryService` user-matching code (around lines 569-572, 697-699, 767-769), do not add new `.Include(... MatchedUser ...)` or new traversals off `User`. Fetch via `IUserService` / `IProfileService` and project into Ticket DTOs in-memory by `MatchedUserId`.
-- When touching participation/event logic in `TicketQueryService.cs:584-588` or `TicketSyncService.cs:440,449,481`, route through a Shifts-owned interface (`IEventSettingsService` / `IEventParticipationService`) rather than adding more `_dbContext.EventSettings` / `_dbContext.EventParticipations` reads.
+- When touching participation/event logic in `TicketQueryService.cs:584-588`, route through a Shifts-owned interface (`IEventSettingsService` / `IEventParticipationService`) rather than adding more `_dbContext.EventSettings` / `_dbContext.EventParticipations` reads. (`TicketSyncService` already routes these through `IShiftManagementService` / `IUserService` as of PR #545c.)
 - When touching code tracking (`TicketQueryService.GetCodeTrackingDataAsync`, ~line 337), do not deepen the `Campaign` / `Grants` / `User` include chain; call `ICampaignService` for campaign + grant data and correlate with local ticket orders in memory.
 - When touching cache logic around ticket counts (`TicketQueryService.cs:38-42,81,132-133`), keep cache calls confined to this service — do not push `IMemoryCache` into controllers or view components — and prefer adding to `CacheKeys.InvalidateTicketCaches()` over sprinkling new `_cache.Remove` sites, so the eventual caching decorator has a single seam to replace.
 - When touching `TicketingBudgetService.cs:44`, do not add further direct reads of `ticket_orders` / `ticket_attendees`; expose what Budget needs as a method on `ITicketQueryService` and call that instead.

--- a/src/Humans.Application/Configuration/TicketVendorSettings.cs
+++ b/src/Humans.Application/Configuration/TicketVendorSettings.cs
@@ -1,0 +1,33 @@
+namespace Humans.Application.Configuration;
+
+/// <summary>
+/// Configuration for the ticket vendor integration.
+/// Non-sensitive values (EventId, Provider, SyncIntervalMinutes, BreakEvenTarget)
+/// come from appsettings <c>TicketVendor</c> section. The API key is populated
+/// from the <c>TICKET_VENDOR_API_KEY</c> environment variable at DI registration
+/// time (see <c>InfrastructureServiceCollectionExtensions</c>) and is not stored
+/// in appsettings.
+/// </summary>
+/// <remarks>
+/// Lives in <c>Humans.Application.Configuration</c> rather than
+/// <c>Humans.Infrastructure</c> so the Application-layer
+/// <c>TicketSyncService</c> can consume <c>IsConfigured</c> / <c>EventId</c>
+/// without reaching into Infrastructure. The TicketTailor HTTP client and stub
+/// vendor service (both Infrastructure) consume it via the same
+/// <c>IOptions&lt;TicketVendorSettings&gt;</c> binding.
+/// </remarks>
+public class TicketVendorSettings
+{
+    public const string SectionName = "TicketVendor";
+
+    public string Provider { get; set; } = "TicketTailor";
+    public string EventId { get; set; } = string.Empty;
+    public int SyncIntervalMinutes { get; set; } = 15;
+    public int BreakEvenTarget { get; set; }
+
+    /// <summary>API key — populated from TICKET_VENDOR_API_KEY env var at DI registration time.
+    /// Not stored in appsettings (sensitive). Accessible in settings for testability.</summary>
+    public string ApiKey { get; set; } = string.Empty;
+
+    public bool IsConfigured => !string.IsNullOrEmpty(EventId) && !string.IsNullOrEmpty(ApiKey);
+}

--- a/src/Humans.Application/DTOs/TicketSyncDtos.cs
+++ b/src/Humans.Application/DTOs/TicketSyncDtos.cs
@@ -1,0 +1,26 @@
+using Humans.Domain.Enums;
+using NodaTime;
+
+namespace Humans.Application.DTOs;
+
+/// <summary>
+/// A single user email entry, shaped for building the
+/// email → userId lookup that <see cref="Humans.Application.Services.Tickets.TicketSyncService"/>
+/// uses to match vendor buyer/attendee emails to users.
+/// Read-only projection owned by <c>ITicketRepository</c>.
+/// </summary>
+public record UserEmailLookupEntry(string Email, Guid UserId, bool IsOAuth);
+
+/// <summary>
+/// An attendee row projected for the event-participation reconciliation pass.
+/// Only includes attendees with a non-null <c>MatchedUserId</c>, scoped to a
+/// single vendor event (matching <see cref="TicketSyncService"/> behavior).
+/// </summary>
+public record MatchedAttendeeRow(Guid MatchedUserId, TicketAttendeeStatus Status);
+
+/// <summary>
+/// A discount-code projection row used to build
+/// <see cref="DiscountCodeRedemption"/> entries that feed
+/// <c>ICampaignService.MarkGrantsRedeemedAsync</c>.
+/// </summary>
+public record OrderDiscountCodeRow(string Code, Instant PurchasedAt);

--- a/src/Humans.Application/Interfaces/Repositories/ITicketRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/ITicketRepository.cs
@@ -1,0 +1,170 @@
+using Humans.Application.DTOs;
+using Humans.Domain.Entities;
+
+namespace Humans.Application.Interfaces.Repositories;
+
+/// <summary>
+/// Repository for the Tickets section's canonical tables
+/// (<c>ticket_orders</c>, <c>ticket_attendees</c>, <c>ticket_sync_states</c>).
+/// Owned by <see cref="Humans.Application.Services.Tickets.TicketSyncService"/>
+/// — the only non-test code path that writes to these tables.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Narrow shape: exposes only the operations the Application-layer
+/// <c>TicketSyncService</c> needs. Business rules (VAT computation, OAuth
+/// tie-breaking, status parsing) stay in the service; this interface just
+/// loads and persists. Every method opens its own short-lived
+/// <c>HumansDbContext</c> via <c>IDbContextFactory</c> and disposes it before
+/// returning — returned entities are therefore detached (<c>AsNoTracking</c>);
+/// callers mutate them in memory and pass them back to the matching write
+/// method.
+/// </para>
+/// <para>
+/// <b>Relation to <c>ITicketingBudgetRepository</c>:</b> Intentionally
+/// distinct. That repository is a narrow read-only shape for the
+/// Tickets→Budget bridge (<c>TicketingBudgetService</c>). Merging the two
+/// would couple TicketSync's write surface to Budget's read surface — two
+/// things that evolve on very different cadences.
+/// </para>
+/// </remarks>
+public interface ITicketRepository
+{
+    // ── TicketSyncState (singleton row, Id == 1) ─────────────────────────────
+
+    /// <summary>
+    /// Returns the sync-state singleton row (Id == 1), read-only.
+    /// Returns null if the seed row is missing — callers should treat this as
+    /// a configuration error.
+    /// </summary>
+    Task<TicketSyncState?> GetSyncStateAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Persists the in-memory state of the sync-state singleton row.
+    /// Attaches the entity and marks it modified. If the row does not yet
+    /// exist, it is inserted instead.
+    /// </summary>
+    Task PersistSyncStateAsync(TicketSyncState state, CancellationToken ct = default);
+
+    /// <summary>
+    /// Clears <c>LastSyncAt</c> on the singleton row to force a full resync
+    /// on the next sync cycle. No-op if the row does not exist.
+    /// </summary>
+    Task ResetSyncStateLastSyncAsync(CancellationToken ct = default);
+
+    // ── Email lookup (cross-section projection over user_emails) ─────────────
+
+    /// <summary>
+    /// Returns every row of <c>user_emails</c> projected to the three fields
+    /// needed to build the email → userId lookup. Read-only; ordering is
+    /// unspecified — the service performs grouping and OAuth tie-breaking in
+    /// memory.
+    /// </summary>
+    /// <remarks>
+    /// This projection is narrow (three columns) and non-mutating, so reading
+    /// it from the Tickets repository does not violate table ownership — the
+    /// Profile section's owning service (<c>IUserEmailService</c>) does not
+    /// expose a shape that fits bulk email-matching. If TicketSync ever needs
+    /// to <i>write</i> user-email data, it must go through
+    /// <c>IUserEmailService</c> instead.
+    /// </remarks>
+    Task<IReadOnlyList<UserEmailLookupEntry>> GetAllUserEmailLookupEntriesAsync(
+        CancellationToken ct = default);
+
+    // ── TicketOrder reads (all detached / AsNoTracking) ──────────────────────
+
+    /// <summary>
+    /// Returns detached <see cref="TicketOrder"/> entities keyed by
+    /// <c>VendorOrderId</c> for the given set of vendor ids. Callers mutate
+    /// these in memory and pass them back to <see cref="UpsertOrdersAsync"/>.
+    /// </summary>
+    Task<IReadOnlyDictionary<string, TicketOrder>> GetOrdersByVendorIdsAsync(
+        IReadOnlyCollection<string> vendorOrderIds,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns detached <see cref="TicketAttendee"/> entities keyed by
+    /// <c>VendorTicketId</c> for the given set of vendor ticket ids. Callers
+    /// mutate these in memory and pass them back to
+    /// <see cref="UpsertAttendeesAsync"/>.
+    /// </summary>
+    Task<IReadOnlyDictionary<string, TicketAttendee>> GetAttendeesByVendorIdsAsync(
+        IReadOnlyCollection<string> vendorTicketIds,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns <c>(VendorOrderId, Id)</c> pairs for every order in the database
+    /// — used by the attendee-upsert pass to resolve parent-order FKs without
+    /// re-querying per ticket.
+    /// </summary>
+    Task<IReadOnlyDictionary<string, Guid>> GetOrderIdsByVendorIdAsync(
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns all orders with <c>StripePaymentIntentId != null</c> and
+    /// <c>StripeFee == null</c>, detached. Callers fill in fee/payment-method
+    /// data and save via <see cref="UpsertOrdersAsync"/>.
+    /// </summary>
+    Task<IReadOnlyList<TicketOrder>> GetOrdersNeedingStripeEnrichmentAsync(
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns all orders with their attendees eagerly loaded (same aggregate
+    /// — not a cross-section include). Detached. Used by the VAT-computation
+    /// pass which writes <c>VatAmount</c> back on each order.
+    /// </summary>
+    Task<IReadOnlyList<TicketOrder>> GetAllOrdersWithAttendeesAsync(
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns discount-code rows for every order with a non-null
+    /// <c>DiscountCode</c>. Read-only.
+    /// </summary>
+    Task<IReadOnlyList<OrderDiscountCodeRow>> GetOrderDiscountCodesAsync(
+        CancellationToken ct = default);
+
+    // ── TicketAttendee reads ─────────────────────────────────────────────────
+
+    /// <summary>
+    /// Returns matched-attendee rows (MatchedUserId non-null) for a single
+    /// vendor event. Read-only projection used by the event-participation
+    /// reconciliation pass.
+    /// </summary>
+    Task<IReadOnlyList<MatchedAttendeeRow>> GetMatchedAttendeesForEventAsync(
+        string vendorEventId,
+        CancellationToken ct = default);
+
+    // ── TicketOrder / TicketAttendee writes ──────────────────────────────────
+
+    /// <summary>
+    /// Upserts the given orders — existing rows (matched by
+    /// <c>VendorOrderId</c>) are updated, the rest are inserted — in a single
+    /// <c>SaveChanges</c>.
+    /// </summary>
+    Task UpsertOrdersAsync(IReadOnlyList<TicketOrder> orders, CancellationToken ct = default);
+
+    /// <summary>
+    /// Upserts the given attendees — existing rows (matched by
+    /// <c>VendorTicketId</c>) are updated, the rest are inserted — in a single
+    /// <c>SaveChanges</c>.
+    /// </summary>
+    Task UpsertAttendeesAsync(IReadOnlyList<TicketAttendee> attendees, CancellationToken ct = default);
+
+    /// <summary>
+    /// Persists <c>VatAmount</c> updates for the given orders in a single
+    /// <c>SaveChanges</c>. Only the VAT column is written — other mutations
+    /// on the entities are ignored.
+    /// </summary>
+    Task UpdateOrderVatAmountsAsync(
+        IReadOnlyList<(Guid OrderId, decimal VatAmount)> updates,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Persists Stripe-enrichment updates (<c>PaymentMethod</c>,
+    /// <c>PaymentMethodDetail</c>, <c>StripeFee</c>, <c>ApplicationFee</c>) for
+    /// the given orders in a single <c>SaveChanges</c>.
+    /// </summary>
+    Task UpdateOrderStripeEnrichmentAsync(
+        IReadOnlyList<TicketOrder> orders,
+        CancellationToken ct = default);
+}

--- a/src/Humans.Application/Services/Tickets/TicketSyncService.cs
+++ b/src/Humans.Application/Services/Tickets/TicketSyncService.cs
@@ -1,23 +1,49 @@
+using Humans.Application;
+using Humans.Application.Configuration;
 using Humans.Application.DTOs;
 using Humans.Application.Extensions;
 using Humans.Application.Interfaces;
-using Humans.Application;
+using Humans.Application.Interfaces.Repositories;
 using Humans.Domain.Constants;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Humans.Domain.Helpers;
-using Humans.Infrastructure.Data;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NodaTime;
 
-namespace Humans.Infrastructure.Services;
+namespace Humans.Application.Services.Tickets;
 
-public class TicketSyncService : ITicketSyncService
+/// <summary>
+/// Application-layer implementation of <see cref="ITicketSyncService"/>.
+/// Owns domain-persistence for the Tickets section's sync pipeline: upsert
+/// vendor orders and attendees into <c>ticket_orders</c>/<c>ticket_attendees</c>,
+/// match buyers and attendees to users by email, compute VAT, enrich with
+/// Stripe fee data, and reconcile event participation.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Split vs Ticket Tailor connector (per PR #545c / umbrella #545):</b>
+/// This service never calls the vendor API directly — it delegates to
+/// <see cref="ITicketVendorService"/>, whose implementation
+/// (<c>TicketTailorService</c> or <c>StubTicketVendorService</c>) stays in
+/// Infrastructure as the HTTP/vendor connector. All DB access goes through
+/// <see cref="ITicketRepository"/> — this type never imports
+/// <c>Microsoft.EntityFrameworkCore</c>, enforced by
+/// <c>Humans.Application.csproj</c>'s reference graph.
+/// </para>
+/// <para>
+/// <b>Cross-section calls.</b> <c>event_participations</c> writes route
+/// through <see cref="IUserService"/> (per the User section's PR #243 — the
+/// User section owns that table). <c>EventSettings</c> reads route through
+/// <see cref="IShiftManagementService"/>. <c>CampaignGrants</c> redemption
+/// updates route through <see cref="ICampaignService"/>.
+/// </para>
+/// </remarks>
+public sealed class TicketSyncService : ITicketSyncService
 {
-    private readonly HumansDbContext _dbContext;
+    private readonly ITicketRepository _ticketRepository;
     private readonly ITicketVendorService _vendorService;
     private readonly IStripeService _stripeService;
     private readonly IClock _clock;
@@ -25,10 +51,11 @@ public class TicketSyncService : ITicketSyncService
     private readonly IMemoryCache _cache;
     private readonly IUserService _userService;
     private readonly ICampaignService _campaignService;
+    private readonly IShiftManagementService _shiftManagementService;
     private readonly ILogger<TicketSyncService> _logger;
 
     public TicketSyncService(
-        HumansDbContext dbContext,
+        ITicketRepository ticketRepository,
         ITicketVendorService vendorService,
         IStripeService stripeService,
         IClock clock,
@@ -36,9 +63,10 @@ public class TicketSyncService : ITicketSyncService
         ILogger<TicketSyncService> logger,
         IMemoryCache cache,
         IUserService userService,
-        ICampaignService campaignService)
+        ICampaignService campaignService,
+        IShiftManagementService shiftManagementService)
     {
-        _dbContext = dbContext;
+        _ticketRepository = ticketRepository;
         _vendorService = vendorService;
         _stripeService = stripeService;
         _clock = clock;
@@ -46,6 +74,7 @@ public class TicketSyncService : ITicketSyncService
         _cache = cache;
         _userService = userService;
         _campaignService = campaignService;
+        _shiftManagementService = shiftManagementService;
         _logger = logger;
     }
 
@@ -59,7 +88,7 @@ public class TicketSyncService : ITicketSyncService
 
         var eventId = _settings.EventId;
 
-        var syncState = await _dbContext.TicketSyncStates.FindAsync([1], ct)
+        var syncState = await _ticketRepository.GetSyncStateAsync(ct)
             ?? throw new InvalidOperationException("TicketSyncState seed row missing");
 
         var now = _clock.GetCurrentInstant();
@@ -67,66 +96,80 @@ public class TicketSyncService : ITicketSyncService
         syncState.SyncStatus = TicketSyncStatus.Running;
         syncState.StatusChangedAt = now;
         syncState.VendorEventId = eventId;
-        await _dbContext.SaveChangesAsync(ct);
+        await _ticketRepository.PersistSyncStateAsync(syncState, ct);
 
         try
         {
             var orders = await _vendorService.GetOrdersAsync(syncState.LastSyncAt, eventId, ct);
             var tickets = await _vendorService.GetIssuedTicketsAsync(syncState.LastSyncAt, eventId, ct);
 
-            // Build email → UserId lookup from UserEmails table
+            // Build email → UserId lookup from UserEmails table.
             var emailLookup = await BuildEmailLookupAsync(ct);
 
-            var ordersSynced = 0;
-            var attendeesSynced = 0;
-            var ordersMatched = 0;
-            var attendeesMatched = 0;
+            // Build entity list for orders — existing rows keep their Id so the repo
+            // upsert recognises them; new rows get a freshly-minted Guid.
+            var existingOrdersByVendorId = await _ticketRepository
+                .GetOrdersByVendorIdsAsync(orders.Select(o => o.VendorOrderId).ToList(), ct);
 
-            foreach (var orderDto in orders)
+            var ordersToUpsert = new List<TicketOrder>(orders.Count);
+            var ordersMatched = 0;
+            foreach (var dto in orders)
             {
-                var order = await UpsertOrderAsync(orderDto, eventId, emailLookup, now, ct);
-                ordersSynced++;
+                var order = BuildOrderEntity(dto, eventId, emailLookup, now,
+                    existingOrdersByVendorId.GetValueOrDefault(dto.VendorOrderId));
+                ordersToUpsert.Add(order);
                 if (order.MatchedUserId.HasValue)
                     ordersMatched++;
             }
 
-            // IMPORTANT: Save orders before processing attendees so that
-            // UpsertAttendeeAsync can find parent orders via DB query.
-            // Without this, newly added orders are only in the Change Tracker
-            // and FirstOrDefaultAsync won't see them.
-            await _dbContext.SaveChangesAsync(ct);
+            await _ticketRepository.UpsertOrdersAsync(ordersToUpsert, ct);
+            var ordersSynced = ordersToUpsert.Count;
 
-            // Enrich orders with Stripe fee/payment method data
+            // Enrich orders with Stripe fee/payment method data.
             await EnrichOrdersWithStripeDataAsync(ct);
 
-            // Sync all tickets (not grouped by order — we match by VendorTicketId)
-            foreach (var ticketDto in tickets)
+            // Build attendee entities. Parent orders must exist by now (just upserted).
+            var orderIdByVendorId = await _ticketRepository.GetOrderIdsByVendorIdAsync(ct);
+            var existingAttendeesByVendorId = await _ticketRepository
+                .GetAttendeesByVendorIdsAsync(tickets.Select(t => t.VendorTicketId).ToList(), ct);
+
+            var attendeesToUpsert = new List<TicketAttendee>(tickets.Count);
+            var attendeesMatched = 0;
+            foreach (var dto in tickets)
             {
-                var attendee = await UpsertAttendeeAsync(ticketDto, eventId, emailLookup, now, ct);
-                if (attendee is null) continue; // Skipped — parent order not found
-                attendeesSynced++;
+                if (!orderIdByVendorId.TryGetValue(dto.VendorOrderId, out var parentOrderId))
+                {
+                    _logger.LogWarning(
+                        "Attendee {VendorTicketId} references unknown order {VendorOrderId}, skipping",
+                        dto.VendorTicketId, dto.VendorOrderId);
+                    continue;
+                }
+
+                var attendee = BuildAttendeeEntity(dto, eventId, emailLookup, now, parentOrderId,
+                    existingAttendeesByVendorId.GetValueOrDefault(dto.VendorTicketId));
+                attendeesToUpsert.Add(attendee);
                 if (attendee.MatchedUserId.HasValue)
                     attendeesMatched++;
             }
 
-            await _dbContext.SaveChangesAsync(ct);
+            await _ticketRepository.UpsertAttendeesAsync(attendeesToUpsert, ct);
+            var attendeesSynced = attendeesToUpsert.Count;
 
-            // Compute VAT for all orders using VIP split logic on attendee prices
+            // Compute VAT for all orders using VIP split logic on attendee prices.
             await ComputeVatForOrdersAsync(ct);
-            await _dbContext.SaveChangesAsync(ct);
 
-            // Match discount codes to campaign grants
+            // Match discount codes to campaign grants.
             var codesRedeemed = await MatchDiscountCodesAsync(ct);
 
-            // Sync event participation records
+            // Sync event participation records.
             await SyncEventParticipationsAsync(ct);
 
-            // Update sync state
+            // Update sync state.
             syncState.SyncStatus = TicketSyncStatus.Idle;
             syncState.StatusChangedAt = _clock.GetCurrentInstant();
             syncState.LastSyncAt = now;
             syncState.LastError = null;
-            await _dbContext.SaveChangesAsync(ct);
+            await _ticketRepository.PersistSyncStateAsync(syncState, ct);
 
             // Invalidate all ticket-related caches after successful sync.
             _cache.Remove(CacheKeys.TicketEventSummary(eventId));
@@ -153,7 +196,7 @@ public class TicketSyncService : ITicketSyncService
 
             syncState.SyncStatus = TicketSyncStatus.Idle;
             syncState.StatusChangedAt = _clock.GetCurrentInstant();
-            await _dbContext.SaveChangesAsync(CancellationToken.None);
+            await _ticketRepository.PersistSyncStateAsync(syncState, CancellationToken.None);
 
             return new TicketSyncResult(0, 0, 0, 0, 0);
         }
@@ -164,27 +207,32 @@ public class TicketSyncService : ITicketSyncService
             syncState.SyncStatus = TicketSyncStatus.Error;
             syncState.StatusChangedAt = _clock.GetCurrentInstant();
             syncState.LastError = ex.Message;
-            await _dbContext.SaveChangesAsync(CancellationToken.None);
+            await _ticketRepository.PersistSyncStateAsync(syncState, CancellationToken.None);
 
             throw;
         }
     }
 
+    public async Task ResetSyncStateForFullResyncAsync()
+    {
+        await _ticketRepository.ResetSyncStateLastSyncAsync();
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
     private async Task<Dictionary<string, Guid>> BuildEmailLookupAsync(CancellationToken ct)
     {
-        // Match against ALL user emails (OAuth, verified, unverified)
+        // Match against ALL user emails (OAuth, verified, unverified).
         // Normalize for comparison so gmail/googlemail aliases resolve to the same human.
-        // If multiple users share same email, prefer the one where it's the OAuth email
-        var userEmails = await _dbContext.Set<UserEmail>()
-            .Select(ue => new { ue.Email, ue.UserId, ue.IsOAuth })
-            .ToListAsync(ct);
+        // If multiple users share same email, prefer the one where it's the OAuth email.
+        var entries = await _ticketRepository.GetAllUserEmailLookupEntriesAsync(ct);
 
         var lookup = new Dictionary<string, Guid>(NormalizingEmailComparer.Instance);
-        var grouped = userEmails.GroupBy(e => e.Email, NormalizingEmailComparer.Instance);
+        var grouped = entries.GroupBy(e => e.Email, NormalizingEmailComparer.Instance);
         foreach (var group in grouped)
         {
-            var entries = group.ToList();
-            var distinctUserIds = entries.Select(e => e.UserId).Distinct().ToList();
+            var groupEntries = group.ToList();
+            var distinctUserIds = groupEntries.Select(e => e.UserId).Distinct().ToList();
 
             if (distinctUserIds.Count == 1)
             {
@@ -192,15 +240,16 @@ public class TicketSyncService : ITicketSyncService
             }
             else
             {
-                // Multiple users share this email — prefer OAuth
-                var oauthEntry = entries.FirstOrDefault(e => e.IsOAuth);
+                // Multiple users share this email — prefer OAuth.
+                var oauthEntry = groupEntries.FirstOrDefault(e => e.IsOAuth);
                 if (oauthEntry is not null)
                 {
                     lookup[group.Key] = oauthEntry.UserId;
                 }
                 else
                 {
-                    _logger.LogWarning("Email {Email} shared by {Count} users with no OAuth owner, leaving unmatched",
+                    _logger.LogWarning(
+                        "Email {Email} shared by {Count} users with no OAuth owner, leaving unmatched",
                         group.Key, distinctUserIds.Count);
                 }
             }
@@ -209,34 +258,20 @@ public class TicketSyncService : ITicketSyncService
         return lookup;
     }
 
-    private async Task<TicketOrder> UpsertOrderAsync(
-        VendorOrderDto dto, string eventId,
-        Dictionary<string, Guid> emailLookup, Instant now,
-        CancellationToken ct)
+    private TicketOrder BuildOrderEntity(
+        VendorOrderDto dto,
+        string eventId,
+        Dictionary<string, Guid> emailLookup,
+        Instant now,
+        TicketOrder? existing)
     {
-        var existing = await _dbContext.TicketOrders
-            .FirstOrDefaultAsync(o => o.VendorOrderId == dto.VendorOrderId, ct);
+        var id = existing?.Id ?? Guid.NewGuid();
 
-        if (existing is not null)
+        // Preserve Stripe-enrichment fields on existing rows (they're filled in
+        // by a separate pass and the vendor DTO doesn't carry them).
+        return new TicketOrder
         {
-            existing.BuyerName = dto.BuyerName;
-            existing.BuyerEmail = dto.BuyerEmail;
-            existing.TotalAmount = dto.TotalAmount;
-            existing.Currency = dto.Currency;
-            existing.DiscountCode = dto.DiscountCode;
-            existing.PaymentStatus = ParsePaymentStatus(dto.PaymentStatus);
-            existing.VendorDashboardUrl = dto.VendorDashboardUrl;
-            existing.SyncedAt = now;
-            existing.MatchedUserId = LookupUserId(emailLookup, dto.BuyerEmail);
-            existing.StripePaymentIntentId = dto.StripePaymentIntentId;
-            existing.DiscountAmount = dto.DiscountAmount;
-            existing.DonationAmount = dto.DonationAmount;
-            return existing;
-        }
-
-        var order = new TicketOrder
-        {
-            Id = Guid.NewGuid(),
+            Id = id,
             VendorOrderId = dto.VendorOrderId,
             BuyerName = dto.BuyerName,
             BuyerEmail = dto.BuyerEmail,
@@ -252,52 +287,34 @@ public class TicketSyncService : ITicketSyncService
             StripePaymentIntentId = dto.StripePaymentIntentId,
             DiscountAmount = dto.DiscountAmount,
             DonationAmount = dto.DonationAmount,
+            // Stripe enrichment + VAT are computed in later passes; preserve any
+            // prior values so the upsert doesn't stomp them back to null/0.
+            PaymentMethod = existing?.PaymentMethod,
+            PaymentMethodDetail = existing?.PaymentMethodDetail,
+            StripeFee = existing?.StripeFee,
+            ApplicationFee = existing?.ApplicationFee,
+            VatAmount = existing?.VatAmount ?? 0m,
         };
-
-        _dbContext.TicketOrders.Add(order);
-        return order;
     }
 
-    private async Task<TicketAttendee?> UpsertAttendeeAsync(
-        VendorTicketDto dto, string eventId,
-        Dictionary<string, Guid> emailLookup, Instant now,
-        CancellationToken ct)
+    private TicketAttendee BuildAttendeeEntity(
+        VendorTicketDto dto,
+        string eventId,
+        Dictionary<string, Guid> emailLookup,
+        Instant now,
+        Guid parentOrderId,
+        TicketAttendee? existing)
     {
-        var existing = await _dbContext.TicketAttendees
-            .FirstOrDefaultAsync(a => a.VendorTicketId == dto.VendorTicketId, ct);
-
-        Guid? matchedUserId = dto.AttendeeEmail is not null
+        var id = existing?.Id ?? Guid.NewGuid();
+        var matchedUserId = dto.AttendeeEmail is not null
             ? LookupUserId(emailLookup, dto.AttendeeEmail)
             : null;
 
-        if (existing is not null)
+        return new TicketAttendee
         {
-            existing.AttendeeName = dto.AttendeeName;
-            existing.AttendeeEmail = dto.AttendeeEmail;
-            existing.TicketTypeName = dto.TicketTypeName;
-            existing.Price = dto.Price;
-            existing.Status = ParseAttendeeStatus(dto.Status);
-            existing.SyncedAt = now;
-            existing.MatchedUserId = matchedUserId;
-            return existing;
-        }
-
-        // Resolve parent order FK via VendorOrderId from the ticket DTO
-        var parentOrder = await _dbContext.TicketOrders
-            .FirstOrDefaultAsync(o => o.VendorOrderId == dto.VendorOrderId, ct);
-
-        if (parentOrder is null)
-        {
-            _logger.LogWarning("Attendee {VendorTicketId} references unknown order {VendorOrderId}, skipping",
-                dto.VendorTicketId, dto.VendorOrderId);
-            return null;
-        }
-
-        var attendee = new TicketAttendee
-        {
-            Id = Guid.NewGuid(),
+            Id = id,
             VendorTicketId = dto.VendorTicketId,
-            TicketOrderId = parentOrder.Id,
+            TicketOrderId = parentOrderId,
             AttendeeName = dto.AttendeeName,
             AttendeeEmail = dto.AttendeeEmail,
             TicketTypeName = dto.TicketTypeName,
@@ -307,22 +324,15 @@ public class TicketSyncService : ITicketSyncService
             SyncedAt = now,
             MatchedUserId = matchedUserId,
         };
-
-        _dbContext.TicketAttendees.Add(attendee);
-        return attendee;
     }
 
     private async Task<int> MatchDiscountCodesAsync(CancellationToken ct)
     {
-        var ordersWithCodes = await _dbContext.TicketOrders
-            .Where(o => o.DiscountCode != null)
-            .Select(o => new { Code = o.DiscountCode!, o.PurchasedAt })
-            .ToListAsync(ct);
+        var rows = await _ticketRepository.GetOrderDiscountCodesAsync(ct);
+        if (rows.Count == 0) return 0;
 
-        if (ordersWithCodes.Count == 0) return 0;
-
-        var redemptions = ordersWithCodes
-            .Select(o => new DiscountCodeRedemption(o.Code, o.PurchasedAt))
+        var redemptions = rows
+            .Select(r => new DiscountCodeRedemption(r.Code, r.PurchasedAt))
             .ToList();
 
         // Delegate to CampaignService — CampaignGrants is owned by the Campaigns section.
@@ -337,15 +347,14 @@ public class TicketSyncService : ITicketSyncService
             return;
         }
 
-        // Find orders that have a Stripe PI but no fee data yet
-        var ordersToEnrich = await _dbContext.TicketOrders
-            .Where(o => o.StripePaymentIntentId != null && o.StripeFee == null)
-            .ToListAsync(ct);
+        var ordersToEnrich = await _ticketRepository
+            .GetOrdersNeedingStripeEnrichmentAsync(ct);
 
         if (ordersToEnrich.Count == 0) return;
 
         _logger.LogInformation("Enriching {Count} orders with Stripe fee data", ordersToEnrich.Count);
 
+        var updated = new List<TicketOrder>(ordersToEnrich.Count);
         foreach (var order in ordersToEnrich)
         {
             try
@@ -357,15 +366,17 @@ public class TicketSyncService : ITicketSyncService
                 order.PaymentMethodDetail = details.PaymentMethodDetail;
                 order.StripeFee = details.StripeFee;
                 order.ApplicationFee = details.ApplicationFee;
+                updated.Add(order);
             }
             catch (Exception ex)
             {
-                _logger.LogWarning(ex, "Failed to fetch Stripe data for order {OrderId} (PI: {PaymentIntentId})",
+                _logger.LogWarning(ex,
+                    "Failed to fetch Stripe data for order {OrderId} (PI: {PaymentIntentId})",
                     order.VendorOrderId, order.StripePaymentIntentId);
             }
         }
 
-        await _dbContext.SaveChangesAsync(ct);
+        await _ticketRepository.UpdateOrderStripeEnrichmentAsync(updated, ct);
     }
 
     /// <summary>
@@ -376,14 +387,12 @@ public class TicketSyncService : ITicketSyncService
     /// </summary>
     private async Task ComputeVatForOrdersAsync(CancellationToken ct)
     {
-        var orders = await _dbContext.TicketOrders
-            .Include(o => o.Attendees)
-            .ToListAsync(ct);
+        var orders = await _ticketRepository.GetAllOrdersWithAttendeesAsync(ct);
+        var updates = orders
+            .Select(o => (o.Id, VatAmount: ComputeOrderVat(o)))
+            .ToList();
 
-        foreach (var order in orders)
-        {
-            order.VatAmount = ComputeOrderVat(order);
-        }
+        await _ticketRepository.UpdateOrderVatAmountsAsync(updates, ct);
     }
 
     /// <summary>
@@ -419,16 +428,6 @@ public class TicketSyncService : ITicketSyncService
     private static bool IsRevenueAttendee(TicketAttendee attendee) =>
         attendee.Status == TicketAttendeeStatus.Valid || attendee.Status == TicketAttendeeStatus.CheckedIn;
 
-    public async Task ResetSyncStateForFullResyncAsync()
-    {
-        var syncState = await _dbContext.TicketSyncStates.FindAsync(1);
-        if (syncState is not null)
-        {
-            syncState.LastSyncAt = null;
-            await _dbContext.SaveChangesAsync();
-        }
-    }
-
     /// <summary>
     /// Derive EventParticipation records from current ticket data.
     /// For each matched user: 1+ valid tickets → Ticketed, any checked-in → Attended.
@@ -436,29 +435,24 @@ public class TicketSyncService : ITicketSyncService
     /// </summary>
     private async Task SyncEventParticipationsAsync(CancellationToken ct)
     {
-        // Determine the event year from EventSettings
-        var activeEvent = await _dbContext.EventSettings
-            .FirstOrDefaultAsync(e => e.IsActive, ct);
-
+        var activeEvent = await _shiftManagementService.GetActiveAsync();
         if (activeEvent is null || activeEvent.Year == 0)
             return;
 
         var year = activeEvent.Year;
 
-        // Get attendees matched to users for the active vendor event only
-        var matchedAttendees = await _dbContext.TicketAttendees
-            .Where(a => a.MatchedUserId != null && a.VendorEventId == _settings.EventId)
-            .Select(a => new { a.MatchedUserId, a.Status })
-            .ToListAsync(ct);
+        // Get matched attendees for the active vendor event only.
+        var matchedAttendees = await _ticketRepository
+            .GetMatchedAttendeesForEventAsync(_settings.EventId, ct);
 
-        // Group by user
+        // Group by user.
         var userTicketStatuses = matchedAttendees
-            .GroupBy(a => a.MatchedUserId!.Value)
+            .GroupBy(a => a.MatchedUserId)
             .ToDictionary(
                 g => g.Key,
                 g => g.Select(a => a.Status).ToList());
 
-        // Process users with tickets
+        // Process users with tickets.
         foreach (var (userId, statuses) in userTicketStatuses)
         {
             var hasCheckedIn = statuses.Any(s => s == TicketAttendeeStatus.CheckedIn);
@@ -468,33 +462,33 @@ public class TicketSyncService : ITicketSyncService
             if (hasCheckedIn)
             {
                 await _userService.SetParticipationFromTicketSyncAsync(
-                    userId, year, ParticipationStatus.Attended);
+                    userId, year, ParticipationStatus.Attended, ct);
             }
             else if (hasValidTicket)
             {
                 await _userService.SetParticipationFromTicketSyncAsync(
-                    userId, year, ParticipationStatus.Ticketed);
+                    userId, year, ParticipationStatus.Ticketed, ct);
             }
         }
 
-        // Handle users who previously had tickets but no longer do
-        var existingTicketSyncParticipations = await _dbContext.EventParticipations
-            .Where(ep => ep.Year == year
-                && ep.Source == ParticipationSource.TicketSync
-                && ep.Status == ParticipationStatus.Ticketed)
-            .ToListAsync(ct);
+        // Handle users who previously had tickets but no longer do. Pull all
+        // participation records for the year and filter to TicketSync+Ticketed
+        // in memory — at ~500 users this is cheap and avoids adding a tightly
+        // scoped read method to IUserService.
+        var allParticipations = await _userService.GetAllParticipationsForYearAsync(year, ct);
+        var stalePreviousTicketed = allParticipations
+            .Where(ep => ep.Source == ParticipationSource.TicketSync
+                && ep.Status == ParticipationStatus.Ticketed);
 
-        foreach (var ep in existingTicketSyncParticipations)
+        foreach (var ep in stalePreviousTicketed)
         {
-            if (!userTicketStatuses.ContainsKey(ep.UserId) ||
-                !userTicketStatuses[ep.UserId].Any(s =>
+            if (!userTicketStatuses.TryGetValue(ep.UserId, out var statuses) ||
+                !statuses.Any(s =>
                     s == TicketAttendeeStatus.Valid || s == TicketAttendeeStatus.CheckedIn))
             {
-                await _userService.RemoveTicketSyncParticipationAsync(ep.UserId, year);
+                await _userService.RemoveTicketSyncParticipationAsync(ep.UserId, year, ct);
             }
         }
-
-        await _dbContext.SaveChangesAsync(ct);
     }
 
     private static Guid? LookupUserId(Dictionary<string, Guid> lookup, string? email) =>

--- a/src/Humans.Infrastructure/Jobs/TicketSyncJob.cs
+++ b/src/Humans.Infrastructure/Jobs/TicketSyncJob.cs
@@ -1,6 +1,6 @@
 using Hangfire;
+using Humans.Application.Configuration;
 using Humans.Application.Interfaces;
-using Humans.Infrastructure.Services;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 

--- a/src/Humans.Infrastructure/Repositories/TicketRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/TicketRepository.cs
@@ -1,0 +1,292 @@
+using Humans.Application.DTOs;
+using Humans.Application.Interfaces.Repositories;
+using Humans.Domain.Entities;
+using Humans.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace Humans.Infrastructure.Repositories;
+
+/// <summary>
+/// EF-backed implementation of <see cref="ITicketRepository"/>. The only
+/// non-test file that writes to <c>ticket_orders</c>, <c>ticket_attendees</c>,
+/// and <c>ticket_sync_states</c> after the TicketSyncService migration lands
+/// (per PR #545c / umbrella #545).
+/// </summary>
+/// <remarks>
+/// Uses <see cref="IDbContextFactory{TContext}"/> so the repository can be
+/// registered as Singleton while <c>HumansDbContext</c> remains short-lived
+/// per method — same pattern as <c>ProfileRepository</c>, <c>UserRepository</c>,
+/// and <c>TicketingBudgetRepository</c> (design-rules §15b).
+/// </remarks>
+public sealed class TicketRepository : ITicketRepository
+{
+    private readonly IDbContextFactory<HumansDbContext> _factory;
+
+    public TicketRepository(IDbContextFactory<HumansDbContext> factory)
+    {
+        _factory = factory;
+    }
+
+    // ── TicketSyncState ──────────────────────────────────────────────────────
+
+    public async Task<TicketSyncState?> GetSyncStateAsync(CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        return await ctx.TicketSyncStates
+            .AsNoTracking()
+            .FirstOrDefaultAsync(s => s.Id == 1, ct);
+    }
+
+    public async Task PersistSyncStateAsync(TicketSyncState state, CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        var existing = await ctx.TicketSyncStates.FirstOrDefaultAsync(s => s.Id == state.Id, ct);
+        if (existing is null)
+        {
+            ctx.TicketSyncStates.Add(state);
+        }
+        else
+        {
+            ctx.Entry(existing).CurrentValues.SetValues(state);
+        }
+        await ctx.SaveChangesAsync(ct);
+    }
+
+    public async Task ResetSyncStateLastSyncAsync(CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        var syncState = await ctx.TicketSyncStates.FindAsync([1], ct);
+        if (syncState is null) return;
+        syncState.LastSyncAt = null;
+        await ctx.SaveChangesAsync(ct);
+    }
+
+    // ── User email lookup ────────────────────────────────────────────────────
+
+    public async Task<IReadOnlyList<UserEmailLookupEntry>> GetAllUserEmailLookupEntriesAsync(
+        CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        return await ctx.Set<UserEmail>()
+            .AsNoTracking()
+            .Select(ue => new UserEmailLookupEntry(ue.Email, ue.UserId, ue.IsOAuth))
+            .ToListAsync(ct);
+    }
+
+    // ── TicketOrder reads (detached) ─────────────────────────────────────────
+
+    public async Task<IReadOnlyDictionary<string, TicketOrder>> GetOrdersByVendorIdsAsync(
+        IReadOnlyCollection<string> vendorOrderIds,
+        CancellationToken ct = default)
+    {
+        if (vendorOrderIds.Count == 0)
+            return new Dictionary<string, TicketOrder>(StringComparer.Ordinal);
+
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        var ids = vendorOrderIds.ToList();
+        var orders = await ctx.TicketOrders
+            .AsNoTracking()
+            .Where(o => ids.Contains(o.VendorOrderId))
+            .ToListAsync(ct);
+        return orders.ToDictionary(o => o.VendorOrderId, StringComparer.Ordinal);
+    }
+
+    public async Task<IReadOnlyDictionary<string, TicketAttendee>> GetAttendeesByVendorIdsAsync(
+        IReadOnlyCollection<string> vendorTicketIds,
+        CancellationToken ct = default)
+    {
+        if (vendorTicketIds.Count == 0)
+            return new Dictionary<string, TicketAttendee>(StringComparer.Ordinal);
+
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        var ids = vendorTicketIds.ToList();
+        var attendees = await ctx.TicketAttendees
+            .AsNoTracking()
+            .Where(a => ids.Contains(a.VendorTicketId))
+            .ToListAsync(ct);
+        return attendees.ToDictionary(a => a.VendorTicketId, StringComparer.Ordinal);
+    }
+
+    public async Task<IReadOnlyDictionary<string, Guid>> GetOrderIdsByVendorIdAsync(
+        CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        var rows = await ctx.TicketOrders
+            .AsNoTracking()
+            .Select(o => new { o.VendorOrderId, o.Id })
+            .ToListAsync(ct);
+        return rows.ToDictionary(r => r.VendorOrderId, r => r.Id, StringComparer.Ordinal);
+    }
+
+    public async Task<IReadOnlyList<TicketOrder>> GetOrdersNeedingStripeEnrichmentAsync(
+        CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        return await ctx.TicketOrders
+            .AsNoTracking()
+            .Where(o => o.StripePaymentIntentId != null && o.StripeFee == null)
+            .ToListAsync(ct);
+    }
+
+    public async Task<IReadOnlyList<TicketOrder>> GetAllOrdersWithAttendeesAsync(
+        CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        return await ctx.TicketOrders
+            .AsNoTracking()
+            .Include(o => o.Attendees)
+            .ToListAsync(ct);
+    }
+
+    public async Task<IReadOnlyList<OrderDiscountCodeRow>> GetOrderDiscountCodesAsync(
+        CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        return await ctx.TicketOrders
+            .AsNoTracking()
+            .Where(o => o.DiscountCode != null)
+            .Select(o => new OrderDiscountCodeRow(o.DiscountCode!, o.PurchasedAt))
+            .ToListAsync(ct);
+    }
+
+    // ── TicketAttendee reads (detached) ──────────────────────────────────────
+
+    public async Task<IReadOnlyList<MatchedAttendeeRow>> GetMatchedAttendeesForEventAsync(
+        string vendorEventId,
+        CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        return await ctx.TicketAttendees
+            .AsNoTracking()
+            .Where(a => a.MatchedUserId != null && a.VendorEventId == vendorEventId)
+            .Select(a => new MatchedAttendeeRow(a.MatchedUserId!.Value, a.Status))
+            .ToListAsync(ct);
+    }
+
+    // ── TicketOrder / TicketAttendee writes ──────────────────────────────────
+
+    public async Task UpsertOrdersAsync(
+        IReadOnlyList<TicketOrder> orders,
+        CancellationToken ct = default)
+    {
+        if (orders.Count == 0) return;
+
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        var vendorIds = orders.Select(o => o.VendorOrderId).ToList();
+        var existing = await ctx.TicketOrders
+            .Where(o => vendorIds.Contains(o.VendorOrderId))
+            .ToDictionaryAsync(o => o.VendorOrderId, StringComparer.Ordinal, ct);
+
+        foreach (var order in orders)
+        {
+            if (existing.TryGetValue(order.VendorOrderId, out var tracked))
+            {
+                // Copy mutable fields (Id, VendorOrderId are init-only).
+                tracked.BuyerName = order.BuyerName;
+                tracked.BuyerEmail = order.BuyerEmail;
+                tracked.TotalAmount = order.TotalAmount;
+                tracked.Currency = order.Currency;
+                tracked.DiscountCode = order.DiscountCode;
+                tracked.PaymentStatus = order.PaymentStatus;
+                tracked.VendorEventId = order.VendorEventId;
+                tracked.VendorDashboardUrl = order.VendorDashboardUrl;
+                tracked.PurchasedAt = order.PurchasedAt;
+                tracked.SyncedAt = order.SyncedAt;
+                tracked.MatchedUserId = order.MatchedUserId;
+                tracked.StripePaymentIntentId = order.StripePaymentIntentId;
+                tracked.DiscountAmount = order.DiscountAmount;
+                tracked.DonationAmount = order.DonationAmount;
+            }
+            else
+            {
+                ctx.TicketOrders.Add(order);
+            }
+        }
+
+        await ctx.SaveChangesAsync(ct);
+    }
+
+    public async Task UpsertAttendeesAsync(
+        IReadOnlyList<TicketAttendee> attendees,
+        CancellationToken ct = default)
+    {
+        if (attendees.Count == 0) return;
+
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        var vendorIds = attendees.Select(a => a.VendorTicketId).ToList();
+        var existing = await ctx.TicketAttendees
+            .Where(a => vendorIds.Contains(a.VendorTicketId))
+            .ToDictionaryAsync(a => a.VendorTicketId, StringComparer.Ordinal, ct);
+
+        foreach (var attendee in attendees)
+        {
+            if (existing.TryGetValue(attendee.VendorTicketId, out var tracked))
+            {
+                tracked.AttendeeName = attendee.AttendeeName;
+                tracked.AttendeeEmail = attendee.AttendeeEmail;
+                tracked.TicketTypeName = attendee.TicketTypeName;
+                tracked.Price = attendee.Price;
+                tracked.Status = attendee.Status;
+                tracked.VendorEventId = attendee.VendorEventId;
+                tracked.SyncedAt = attendee.SyncedAt;
+                tracked.MatchedUserId = attendee.MatchedUserId;
+                // TicketOrderId is init-only on existing rows; don't reparent.
+            }
+            else
+            {
+                ctx.TicketAttendees.Add(attendee);
+            }
+        }
+
+        await ctx.SaveChangesAsync(ct);
+    }
+
+    public async Task UpdateOrderVatAmountsAsync(
+        IReadOnlyList<(Guid OrderId, decimal VatAmount)> updates,
+        CancellationToken ct = default)
+    {
+        if (updates.Count == 0) return;
+
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        var ids = updates.Select(u => u.OrderId).ToList();
+        var tracked = await ctx.TicketOrders
+            .Where(o => ids.Contains(o.Id))
+            .ToDictionaryAsync(o => o.Id, ct);
+
+        foreach (var (orderId, vat) in updates)
+        {
+            if (tracked.TryGetValue(orderId, out var order))
+            {
+                order.VatAmount = vat;
+            }
+        }
+
+        await ctx.SaveChangesAsync(ct);
+    }
+
+    public async Task UpdateOrderStripeEnrichmentAsync(
+        IReadOnlyList<TicketOrder> orders,
+        CancellationToken ct = default)
+    {
+        if (orders.Count == 0) return;
+
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        var ids = orders.Select(o => o.Id).ToList();
+        var tracked = await ctx.TicketOrders
+            .Where(o => ids.Contains(o.Id))
+            .ToDictionaryAsync(o => o.Id, ct);
+
+        foreach (var order in orders)
+        {
+            if (tracked.TryGetValue(order.Id, out var t))
+            {
+                t.PaymentMethod = order.PaymentMethod;
+                t.PaymentMethodDetail = order.PaymentMethodDetail;
+                t.StripeFee = order.StripeFee;
+                t.ApplicationFee = order.ApplicationFee;
+            }
+        }
+
+        await ctx.SaveChangesAsync(ct);
+    }
+}

--- a/src/Humans.Infrastructure/Services/TicketTailorService.cs
+++ b/src/Humans.Infrastructure/Services/TicketTailorService.cs
@@ -4,6 +4,7 @@ using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Humans.Application;
+using Humans.Application.Configuration;
 using Humans.Application.DTOs;
 using Humans.Application.Interfaces;
 using Microsoft.Extensions.Caching.Memory;
@@ -12,21 +13,6 @@ using Microsoft.Extensions.Options;
 using NodaTime;
 
 namespace Humans.Infrastructure.Services;
-
-public class TicketVendorSettings
-{
-    public const string SectionName = "TicketVendor";
-
-    public string Provider { get; set; } = "TicketTailor";
-    public string EventId { get; set; } = string.Empty;
-    public int SyncIntervalMinutes { get; set; } = 15;
-    public int BreakEvenTarget { get; set; }
-    /// <summary>API key — populated from TICKET_VENDOR_API_KEY env var at DI registration time.
-    /// Not stored in appsettings (sensitive). Accessible in settings for testability.</summary>
-    public string ApiKey { get; set; } = string.Empty;
-
-    public bool IsConfigured => !string.IsNullOrEmpty(EventId) && !string.IsNullOrEmpty(ApiKey);
-}
 
 /// <summary>
 /// TicketTailor API client implementing the vendor-agnostic interface.

--- a/src/Humans.Web/Controllers/TicketController.cs
+++ b/src/Humans.Web/Controllers/TicketController.cs
@@ -1,4 +1,5 @@
 using Hangfire;
+using Humans.Application.Configuration;
 using Humans.Application.Interfaces;
 using Humans.Domain.Constants;
 using Humans.Domain.Entities;

--- a/src/Humans.Web/Extensions/Infrastructure/TicketVendorInfrastructureExtensions.cs
+++ b/src/Humans.Web/Extensions/Infrastructure/TicketVendorInfrastructureExtensions.cs
@@ -1,5 +1,5 @@
+using Humans.Application.Configuration;
 using Humans.Application.Interfaces;
-using Humans.Infrastructure.Configuration;
 using Humans.Infrastructure.Services;
 
 namespace Humans.Web.Extensions.Infrastructure;

--- a/src/Humans.Web/Extensions/Sections/TicketsSectionExtensions.cs
+++ b/src/Humans.Web/Extensions/Sections/TicketsSectionExtensions.cs
@@ -1,7 +1,10 @@
 using Humans.Application.Interfaces;
 using Humans.Application.Interfaces.Gdpr;
+using Humans.Application.Interfaces.Repositories;
 using Humans.Infrastructure.Jobs;
+using Humans.Infrastructure.Repositories;
 using Humans.Infrastructure.Services;
+using TicketsTicketSyncService = Humans.Application.Services.Tickets.TicketSyncService;
 
 namespace Humans.Web.Extensions.Sections;
 
@@ -9,7 +12,12 @@ internal static class TicketsSectionExtensions
 {
     internal static IServiceCollection AddTicketsSection(this IServiceCollection services)
     {
-        services.AddScoped<ITicketSyncService, TicketSyncService>();
+        // TicketSyncService (§15 Part 1 — Tickets domain-persistence, issue #545c)
+        // Application-layer service goes through ITicketRepository for all DB access
+        // and consumes ITicketVendorService (Infrastructure connector) for vendor API calls.
+        // Repository is Singleton (IDbContextFactory-based) per design-rules §15b.
+        services.AddSingleton<ITicketRepository, TicketRepository>();
+        services.AddScoped<ITicketSyncService, TicketsTicketSyncService>();
 
         services.AddScoped<TicketQueryService>();
         services.AddScoped<ITicketQueryService>(sp => sp.GetRequiredService<TicketQueryService>());

--- a/tests/Humans.Application.Tests/Architecture/TicketSyncArchitectureTests.cs
+++ b/tests/Humans.Application.Tests/Architecture/TicketSyncArchitectureTests.cs
@@ -1,0 +1,136 @@
+using AwesomeAssertions;
+using Humans.Application.Interfaces;
+using Humans.Application.Interfaces.Repositories;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+using TicketSyncService = Humans.Application.Services.Tickets.TicketSyncService;
+
+namespace Humans.Application.Tests.Architecture;
+
+/// <summary>
+/// Architecture tests enforcing the §15 repository pattern for
+/// <see cref="TicketSyncService"/> — domain-persistence side migrated in
+/// PR #545c (umbrella #545).
+///
+/// <para>
+/// The Ticket Tailor API / webhook side remains in <c>Humans.Infrastructure</c>
+/// as a vendor connector (<c>ITicketVendorService</c> →
+/// <c>TicketTailorService</c> / <c>StubTicketVendorService</c>). These tests
+/// pin the domain-persistence side's shape: Application-layer service, no
+/// DbContext, all DB access via <c>ITicketRepository</c>, and cross-section
+/// reads/writes routed through the owning services (not a second repo).
+/// </para>
+/// </summary>
+public class TicketSyncArchitectureTests
+{
+    // ── TicketSyncService ────────────────────────────────────────────────────
+
+    [Fact]
+    public void TicketSyncService_LivesInHumansApplicationServicesTicketsNamespace()
+    {
+        typeof(TicketSyncService).Namespace
+            .Should().Be("Humans.Application.Services.Tickets",
+                because: "services with business logic live in Humans.Application per design-rules §2b, organized by section");
+    }
+
+    [Fact]
+    public void TicketSyncService_HasNoDbContextConstructorParameter()
+    {
+        var ctor = typeof(TicketSyncService).GetConstructors().Single();
+        ctor.GetParameters()
+            .Should().NotContain(
+                p => typeof(DbContext).IsAssignableFrom(p.ParameterType),
+                because: "services in Humans.Application must never take DbContext — use ITicketRepository instead (design-rules §3)");
+    }
+
+    [Fact]
+    public void TicketSyncService_TakesRepository()
+    {
+        var ctor = typeof(TicketSyncService).GetConstructors().Single();
+        var paramTypes = ctor.GetParameters().Select(p => p.ParameterType).ToList();
+
+        paramTypes.Should().Contain(typeof(ITicketRepository),
+            because: "TicketSyncService's DB access must go through ITicketRepository (design-rules §3)");
+    }
+
+    [Fact]
+    public void TicketSyncService_TakesVendorConnectorInterface()
+    {
+        var ctor = typeof(TicketSyncService).GetConstructors().Single();
+        var paramTypes = ctor.GetParameters().Select(p => p.ParameterType).ToList();
+
+        paramTypes.Should().Contain(typeof(ITicketVendorService),
+            because: "Ticket Tailor API calls are the connector's job — the sync service delegates all vendor I/O to ITicketVendorService (Infrastructure-backed)");
+    }
+
+    [Fact]
+    public void TicketSyncService_TakesUserServiceForEventParticipationWrites()
+    {
+        var ctor = typeof(TicketSyncService).GetConstructors().Single();
+        var paramTypes = ctor.GetParameters().Select(p => p.ParameterType).ToList();
+
+        paramTypes.Should().Contain(typeof(IUserService),
+            because: "event_participations is User-section-owned per PR #243; TicketSync must route participation writes through IUserService (design-rules §8, §9)");
+    }
+
+    [Fact]
+    public void TicketSyncService_TakesCampaignServiceForGrantRedemption()
+    {
+        var ctor = typeof(TicketSyncService).GetConstructors().Single();
+        var paramTypes = ctor.GetParameters().Select(p => p.ParameterType).ToList();
+
+        paramTypes.Should().Contain(typeof(ICampaignService),
+            because: "campaign_grants is Campaigns-section-owned; redemption writes route through ICampaignService (design-rules §8, §9)");
+    }
+
+    [Fact]
+    public void TicketSyncService_TakesShiftManagementServiceForActiveEventLookup()
+    {
+        var ctor = typeof(TicketSyncService).GetConstructors().Single();
+        var paramTypes = ctor.GetParameters().Select(p => p.ParameterType).ToList();
+
+        paramTypes.Should().Contain(typeof(IShiftManagementService),
+            because: "event_settings is Shifts-section-owned; active-event reads route through IShiftManagementService rather than a direct DbContext read (design-rules §8, §9)");
+    }
+
+    [Fact]
+    public void TicketSyncService_ConstructorTakesNoStoreType()
+    {
+        var ctor = typeof(TicketSyncService).GetConstructors().Single();
+        var storeParam = ctor.GetParameters()
+            .FirstOrDefault(p => (p.ParameterType.Namespace ?? string.Empty)
+                .StartsWith("Humans.Application.Interfaces.Stores", StringComparison.Ordinal));
+
+        storeParam.Should().BeNull(
+            because: "Application services must not depend on store abstractions (design-rules §15); the Tickets section's §15 migration does not use a store");
+    }
+
+    // ── ITicketRepository ────────────────────────────────────────────────────
+
+    [Fact]
+    public void ITicketRepository_LivesInApplicationInterfacesRepositoriesNamespace()
+    {
+        typeof(ITicketRepository).Namespace
+            .Should().Be("Humans.Application.Interfaces.Repositories",
+                because: "repository interfaces live in Humans.Application.Interfaces.Repositories per design-rules §3");
+    }
+
+    [Fact]
+    public void TicketRepository_IsSealed()
+    {
+        // Mirrors ProfileRepository/UserRepository — repository implementations
+        // are terminal; no subclass should extend or override the EF-backed
+        // data access.
+        var repoType = typeof(Humans.Infrastructure.Repositories.TicketRepository);
+
+        repoType.IsSealed.Should().BeTrue(
+            because: "repository implementations are sealed to prevent ad-hoc extension; any new behavior belongs on the interface");
+    }
+
+    [Fact]
+    public void TicketRepository_ImplementsITicketRepository()
+    {
+        typeof(ITicketRepository).IsAssignableFrom(typeof(Humans.Infrastructure.Repositories.TicketRepository))
+            .Should().BeTrue();
+    }
+}

--- a/tests/Humans.Application.Tests/Repositories/TicketRepositoryTests.cs
+++ b/tests/Humans.Application.Tests/Repositories/TicketRepositoryTests.cs
@@ -1,0 +1,248 @@
+using AwesomeAssertions;
+using Humans.Application.Tests.Infrastructure;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using Humans.Infrastructure.Data;
+using Humans.Infrastructure.Repositories;
+using Microsoft.EntityFrameworkCore;
+using NodaTime;
+using NodaTime.Testing;
+using Xunit;
+
+namespace Humans.Application.Tests.Repositories;
+
+public sealed class TicketRepositoryTests : IDisposable
+{
+    private readonly HumansDbContext _dbContext;
+    private readonly FakeClock _clock;
+    private readonly TicketRepository _repo;
+
+    public TicketRepositoryTests()
+    {
+        var options = new DbContextOptionsBuilder<HumansDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        _dbContext = new HumansDbContext(options);
+        _clock = new FakeClock(Instant.FromUtc(2026, 3, 1, 12, 0));
+        _repo = new TicketRepository(new TestDbContextFactory(options));
+
+        _dbContext.TicketSyncStates.Add(new TicketSyncState
+        {
+            Id = 1,
+            SyncStatus = TicketSyncStatus.Idle,
+            VendorEventId = string.Empty,
+        });
+        _dbContext.SaveChanges();
+    }
+
+    public void Dispose()
+    {
+        _dbContext.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    // ── GetSyncStateAsync / PersistSyncStateAsync ────────────────────────────
+
+    [Fact]
+    public async Task GetSyncStateAsync_ReturnsSingletonRow()
+    {
+        var state = await _repo.GetSyncStateAsync();
+
+        state.Should().NotBeNull();
+        state!.Id.Should().Be(1);
+        state.SyncStatus.Should().Be(TicketSyncStatus.Idle);
+    }
+
+    [Fact]
+    public async Task PersistSyncStateAsync_UpdatesExistingSingleton()
+    {
+        var state = (await _repo.GetSyncStateAsync())!;
+        state.SyncStatus = TicketSyncStatus.Running;
+        state.LastError = "boom";
+        state.StatusChangedAt = _clock.GetCurrentInstant();
+
+        await _repo.PersistSyncStateAsync(state);
+
+        var reloaded = await _dbContext.TicketSyncStates.AsNoTracking().FirstAsync(s => s.Id == 1);
+        reloaded.SyncStatus.Should().Be(TicketSyncStatus.Running);
+        reloaded.LastError.Should().Be("boom");
+    }
+
+    [Fact]
+    public async Task ResetSyncStateLastSyncAsync_ClearsLastSyncAt()
+    {
+        var state = (await _repo.GetSyncStateAsync())!;
+        state.LastSyncAt = _clock.GetCurrentInstant();
+        await _repo.PersistSyncStateAsync(state);
+
+        await _repo.ResetSyncStateLastSyncAsync();
+
+        var reloaded = await _dbContext.TicketSyncStates.AsNoTracking().FirstAsync(s => s.Id == 1);
+        reloaded.LastSyncAt.Should().BeNull();
+    }
+
+    // ── UpsertOrdersAsync ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task UpsertOrdersAsync_InsertsNewRowsAndUpdatesExisting()
+    {
+        var existing = new TicketOrder
+        {
+            Id = Guid.NewGuid(),
+            VendorOrderId = "ord_existing",
+            BuyerName = "Old Name",
+            BuyerEmail = "old@example.com",
+            TotalAmount = 10m,
+            Currency = "EUR",
+            PaymentStatus = TicketPaymentStatus.Paid,
+            VendorEventId = "ev_1",
+            PurchasedAt = _clock.GetCurrentInstant(),
+            SyncedAt = _clock.GetCurrentInstant(),
+        };
+        _dbContext.TicketOrders.Add(existing);
+        await _dbContext.SaveChangesAsync();
+
+        var updatedExisting = new TicketOrder
+        {
+            Id = existing.Id,
+            VendorOrderId = "ord_existing",
+            BuyerName = "New Name",
+            BuyerEmail = "new@example.com",
+            TotalAmount = 99m,
+            Currency = "EUR",
+            PaymentStatus = TicketPaymentStatus.Paid,
+            VendorEventId = "ev_1",
+            PurchasedAt = _clock.GetCurrentInstant(),
+            SyncedAt = _clock.GetCurrentInstant(),
+        };
+        var brandNew = new TicketOrder
+        {
+            Id = Guid.NewGuid(),
+            VendorOrderId = "ord_new",
+            BuyerName = "Brand New",
+            BuyerEmail = "new@example.com",
+            TotalAmount = 50m,
+            Currency = "EUR",
+            PaymentStatus = TicketPaymentStatus.Pending,
+            VendorEventId = "ev_1",
+            PurchasedAt = _clock.GetCurrentInstant(),
+            SyncedAt = _clock.GetCurrentInstant(),
+        };
+
+        await _repo.UpsertOrdersAsync(new List<TicketOrder> { updatedExisting, brandNew });
+
+        var rows = await _dbContext.TicketOrders.AsNoTracking()
+            .OrderBy(o => o.VendorOrderId).ToListAsync();
+        rows.Should().HaveCount(2);
+        rows[0].VendorOrderId.Should().Be("ord_existing");
+        rows[0].BuyerName.Should().Be("New Name");
+        rows[0].TotalAmount.Should().Be(99m);
+        rows[1].VendorOrderId.Should().Be("ord_new");
+    }
+
+    // ── GetAllUserEmailLookupEntriesAsync ────────────────────────────────────
+
+    [Fact]
+    public async Task GetAllUserEmailLookupEntriesAsync_ReturnsOneEntryPerRow()
+    {
+        var user = new User
+        {
+            Id = Guid.NewGuid(),
+            UserName = "u@x.com",
+            Email = "u@x.com",
+            DisplayName = "U",
+        };
+        _dbContext.Users.Add(user);
+        _dbContext.UserEmails.Add(new UserEmail
+        {
+            Id = Guid.NewGuid(),
+            UserId = user.Id,
+            Email = "primary@example.com",
+            IsOAuth = true,
+            IsVerified = true,
+            CreatedAt = _clock.GetCurrentInstant(),
+            UpdatedAt = _clock.GetCurrentInstant(),
+        });
+        _dbContext.UserEmails.Add(new UserEmail
+        {
+            Id = Guid.NewGuid(),
+            UserId = user.Id,
+            Email = "alt@example.com",
+            IsOAuth = false,
+            IsVerified = false,
+            CreatedAt = _clock.GetCurrentInstant(),
+            UpdatedAt = _clock.GetCurrentInstant(),
+        });
+        await _dbContext.SaveChangesAsync();
+
+        var entries = await _repo.GetAllUserEmailLookupEntriesAsync();
+
+        entries.Should().HaveCount(2);
+        entries.Should().Contain(e => e.Email == "primary@example.com" && e.IsOAuth);
+        entries.Should().Contain(e => e.Email == "alt@example.com" && !e.IsOAuth);
+    }
+
+    // ── GetMatchedAttendeesForEventAsync ─────────────────────────────────────
+
+    [Fact]
+    public async Task GetMatchedAttendeesForEventAsync_FiltersToEventAndMatchedOnly()
+    {
+        var orderId = Guid.NewGuid();
+        var order = new TicketOrder
+        {
+            Id = orderId,
+            VendorOrderId = "ord_1",
+            VendorEventId = "ev_a",
+            BuyerEmail = "b@e.com",
+            BuyerName = "B",
+            Currency = "EUR",
+            PaymentStatus = TicketPaymentStatus.Paid,
+            PurchasedAt = _clock.GetCurrentInstant(),
+            SyncedAt = _clock.GetCurrentInstant(),
+        };
+        _dbContext.TicketOrders.Add(order);
+
+        var matchedUserId = Guid.NewGuid();
+
+        _dbContext.TicketAttendees.Add(new TicketAttendee
+        {
+            Id = Guid.NewGuid(),
+            VendorTicketId = "tk_matched_a",
+            TicketOrderId = orderId,
+            AttendeeName = "Matched A",
+            VendorEventId = "ev_a",
+            Status = TicketAttendeeStatus.Valid,
+            MatchedUserId = matchedUserId,
+            SyncedAt = _clock.GetCurrentInstant(),
+        });
+        _dbContext.TicketAttendees.Add(new TicketAttendee
+        {
+            Id = Guid.NewGuid(),
+            VendorTicketId = "tk_matched_b",
+            TicketOrderId = orderId,
+            AttendeeName = "Matched B (other event)",
+            VendorEventId = "ev_b",
+            Status = TicketAttendeeStatus.Valid,
+            MatchedUserId = Guid.NewGuid(),
+            SyncedAt = _clock.GetCurrentInstant(),
+        });
+        _dbContext.TicketAttendees.Add(new TicketAttendee
+        {
+            Id = Guid.NewGuid(),
+            VendorTicketId = "tk_unmatched",
+            TicketOrderId = orderId,
+            AttendeeName = "Unmatched",
+            VendorEventId = "ev_a",
+            Status = TicketAttendeeStatus.Valid,
+            MatchedUserId = null,
+            SyncedAt = _clock.GetCurrentInstant(),
+        });
+        await _dbContext.SaveChangesAsync();
+
+        var rows = await _repo.GetMatchedAttendeesForEventAsync("ev_a");
+
+        rows.Should().ContainSingle();
+        rows[0].MatchedUserId.Should().Be(matchedUserId);
+        rows[0].Status.Should().Be(TicketAttendeeStatus.Valid);
+    }
+}

--- a/tests/Humans.Application.Tests/Services/TicketSyncServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/TicketSyncServiceTests.cs
@@ -1,10 +1,14 @@
 using AwesomeAssertions;
+using Humans.Application.Configuration;
 using Humans.Application.DTOs;
 using Humans.Application.Interfaces;
+using Humans.Application.Interfaces.Repositories;
+using Humans.Application.Services.Tickets;
+using Humans.Application.Tests.Infrastructure;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Humans.Infrastructure.Data;
-using Humans.Infrastructure.Services;
+using Humans.Infrastructure.Repositories;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -20,10 +24,14 @@ namespace Humans.Application.Tests.Services;
 public class TicketSyncServiceTests : IDisposable
 {
     private readonly HumansDbContext _dbContext;
+    private readonly TestDbContextFactory _factory;
     private readonly FakeClock _clock;
     private readonly ITicketVendorService _vendorService;
     private readonly IStripeService _stripeService;
     private readonly ICampaignService _campaignService;
+    private readonly IUserService _userService;
+    private readonly IShiftManagementService _shiftManagementService;
+    private readonly ITicketRepository _ticketRepository;
     private readonly TicketSyncService _service;
 
     public TicketSyncServiceTests()
@@ -32,7 +40,8 @@ public class TicketSyncServiceTests : IDisposable
             .UseInMemoryDatabase(Guid.NewGuid().ToString())
             .Options;
 
-        _dbContext = new HumansDbContext(options);
+        _factory = new TestDbContextFactory(options);
+        _dbContext = _factory.CreateDbContext();
         _clock = new FakeClock(Instant.FromUtc(2026, 3, 1, 12, 0));
         _vendorService = Substitute.For<ITicketVendorService>();
 
@@ -44,18 +53,25 @@ public class TicketSyncServiceTests : IDisposable
         });
 
         _stripeService = Substitute.For<IStripeService>();
-        var userService = Substitute.For<IUserService>();
+        _userService = Substitute.For<IUserService>();
+        _userService.GetAllParticipationsForYearAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(new List<EventParticipation>());
         _campaignService = Substitute.For<ICampaignService>();
+        _shiftManagementService = Substitute.For<IShiftManagementService>();
+
+        _ticketRepository = new TicketRepository(_factory);
+
         _service = new TicketSyncService(
-            _dbContext,
+            _ticketRepository,
             _vendorService,
             _stripeService,
             _clock,
             settings,
             NullLogger<TicketSyncService>.Instance,
             new MemoryCache(new MemoryCacheOptions()),
-            userService,
-            _campaignService);
+            _userService,
+            _campaignService,
+            _shiftManagementService);
 
         // Seed the singleton TicketSyncState row
         _dbContext.TicketSyncStates.Add(new TicketSyncState
@@ -218,8 +234,9 @@ public class TicketSyncServiceTests : IDisposable
         var result = await _service.SyncOrdersAndAttendeesAsync();
 
         result.OrdersSynced.Should().Be(0);
-        var syncState = await _dbContext.TicketSyncStates.FindAsync(1);
-        syncState!.SyncStatus.Should().Be(TicketSyncStatus.Idle);
+        var syncState = await _dbContext.TicketSyncStates.AsNoTracking()
+            .FirstAsync(s => s.Id == 1);
+        syncState.SyncStatus.Should().Be(TicketSyncStatus.Idle);
         syncState.LastError.Should().BeNull();
     }
 
@@ -233,8 +250,9 @@ public class TicketSyncServiceTests : IDisposable
 
         await act.Should().ThrowAsync<HttpRequestException>();
 
-        var syncState = await _dbContext.TicketSyncStates.FindAsync(1);
-        syncState!.SyncStatus.Should().Be(TicketSyncStatus.Error);
+        var syncState = await _dbContext.TicketSyncStates.AsNoTracking()
+            .FirstAsync(s => s.Id == 1);
+        syncState.SyncStatus.Should().Be(TicketSyncStatus.Error);
         syncState.LastError.Should().Be("Unauthorized");
     }
 
@@ -254,7 +272,7 @@ public class TicketSyncServiceTests : IDisposable
         });
 
         var service = new TicketSyncService(
-            _dbContext,
+            _ticketRepository,
             _vendorService,
             _stripeService,
             _clock,
@@ -262,7 +280,8 @@ public class TicketSyncServiceTests : IDisposable
             NullLogger<TicketSyncService>.Instance,
             new MemoryCache(new MemoryCacheOptions()),
             Substitute.For<IUserService>(),
-            Substitute.For<ICampaignService>());
+            Substitute.For<ICampaignService>(),
+            Substitute.For<IShiftManagementService>());
 
         var result = await service.SyncOrdersAndAttendeesAsync();
 
@@ -403,8 +422,9 @@ public class TicketSyncServiceTests : IDisposable
         dbAttendees.Should().Be(700);
 
         // Sync state should be Idle after success
-        var syncState = await _dbContext.TicketSyncStates.FindAsync(1);
-        syncState!.SyncStatus.Should().Be(TicketSyncStatus.Idle);
+        var syncState = await _dbContext.TicketSyncStates.AsNoTracking()
+            .FirstAsync(s => s.Id == 1);
+        syncState.SyncStatus.Should().Be(TicketSyncStatus.Idle);
         syncState.LastSyncAt.Should().NotBeNull();
     }
 

--- a/tests/Humans.Application.Tests/Services/TicketTailorServiceCachingTests.cs
+++ b/tests/Humans.Application.Tests/Services/TicketTailorServiceCachingTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Text.Json;
 using AwesomeAssertions;
+using Humans.Application.Configuration;
 using Humans.Infrastructure.Services;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging.Abstractions;

--- a/tests/Humans.Application.Tests/Services/TicketTailorServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/TicketTailorServiceTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Text.Json;
 using AwesomeAssertions;
+using Humans.Application.Configuration;
 using Humans.Infrastructure.Services;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging.Abstractions;


### PR DESCRIPTION
Part of nobodies-collective/Humans#545 — TicketSyncService domain-persistence side only. Ticket Tailor API/webhook connector side remains in Infrastructure (migrates in batch 11 #555). TicketingBudgetService already shipped as PR #272.

## Summary

Migrates the domain-persistence side of `TicketSyncService` to the Application layer per design-rules §15. All DB access now flows through the new `ITicketRepository`. The Ticket Tailor vendor API side (`ITicketVendorService` → `TicketTailorService` / `StubTicketVendorService`) stays in Infrastructure unchanged — it's a separate connector migration (#555).

### Split boundary

- **Moved to Application (this PR):** upsert of `TicketOrder` / `TicketAttendee`, sync-state management, email→userId matching, VAT compute, Stripe enrichment loop, discount-code → `ICampaignService` fan-out, event-participation reconciliation.
- **Stayed in Infrastructure (deferred to #555):** HTTP calls into Ticket Tailor, webhook ingestion, vendor JSON deserialization.

### Cross-section routing (no direct DB reads of non-Ticket tables)

- `EventSettings` (Shifts) → `IShiftManagementService.GetActiveAsync()`.
- `EventParticipations` (User — per #243) → `IUserService.SetParticipationFromTicketSync…`, `RemoveTicketSyncParticipation…`, `GetAllParticipationsForYearAsync`.
- `CampaignGrants` (Campaigns) → `ICampaignService.MarkGrantsRedeemedAsync` (already in place; preserved).
- `UserEmail` reads for email lookup kept narrow: `ITicketRepository.GetAllUserEmailLookupEntriesAsync` projects just `(Email, UserId, IsOAuth)`; IUserEmailService doesn't expose a bulk-email-matching shape, and this is read-only.

### Participation methods on UserRepository/UserService

Left in place (no move). Per the task spec, matching #545a (not yet landed) is noted: since #545a has not landed, `UpsertParticipationAsync` / `RemoveParticipationAsync` / `BackfillParticipationsAsync` stay on `IUserRepository`. Revisit when #545a lands if Tickets wants to co-own these methods.

### Repository shape

`ITicketRepository` is the Tickets-section-wide repo (distinct from the narrow `ITicketingBudgetRepository` in PR #272 — different caller, different cadence). Singleton via `IDbContextFactory`. No decorator — TicketSync runs on a 15-minute Hangfire schedule, not request-path.

### Warning-free build, all Application/Domain tests pass

- `dotnet build -v quiet` → 0 warnings, 0 errors.
- `tests/Humans.Application.Tests` → 1080 passed (includes 11 TicketSync service tests, 11 architecture tests, 6 new repo tests).
- `tests/Humans.Domain.Tests` → 116 passed.
- Integration tests require Docker (Testcontainers) — not runnable on this machine; unrelated to this PR.
- `reforge injected HumansDbContext` no longer lists TicketSyncService.
- `reforge dbset-usage Humans.Application.Services.Tickets.TicketSyncService` → 0.
- `dotnet ef migrations add VerifyTicketSync` produced empty Up/Down — discarded.

## Test plan

- [ ] CI green on peter's fork
- [ ] QA ticket sync run (Hangfire 15-minute or manual trigger from `/Ticket`) imports orders + attendees and updates sync state
- [ ] `/Ticket/SalesAggregates` still renders (no behavior change, just DI rewiring)
- [ ] Backfill / reset-for-full-resync button on Ticket admin UI still works (exercises `ResetSyncStateForFullResyncAsync`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)