### PR TITLE
§15 Part 1: Tickets — formalize Ticket Tailor connector boundary (#555)

### DIFF
--- a/tests/Humans.Application.Tests/Architecture/TicketVendorArchitectureTests.cs
+++ b/tests/Humans.Application.Tests/Architecture/TicketVendorArchitectureTests.cs
@@ -1,0 +1,193 @@
+using System.Reflection;
+using AwesomeAssertions;
+using Humans.Application.Interfaces;
+using Xunit;
+
+namespace Humans.Application.Tests.Architecture;
+
+/// <summary>
+/// Architecture tests enforcing the connector boundary for the Ticket Tailor
+/// integration (issue #555 — §15 Part 1). <c>ITicketVendorService</c> is the
+/// Application-layer port; <c>TicketTailorService</c> and
+/// <c>StubTicketVendorService</c> are Infrastructure adapters. The interface
+/// must never leak HTTP-client or vendor-SDK types across the boundary — its
+/// entire signature set (parameters, return types) must be expressible in
+/// Application-layer terms (Application DTOs, primitives, NodaTime, BCL
+/// collections).
+///
+/// <para>
+/// These tests fail loudly if a future change drags the interface back into
+/// <c>Humans.Infrastructure</c>, adds a parameter/return type from an HTTP or
+/// vendor-SDK namespace, or accidentally references a type from
+/// <c>Humans.Infrastructure</c> inside the Application project.
+/// </para>
+/// </summary>
+public class TicketVendorArchitectureTests
+{
+    // Namespaces that indicate an HTTP-client or vendor-SDK type leaking into
+    // the Application-layer interface. Matching is prefix-based; add more
+    // here if a new vendor library shows up.
+    private static readonly string[] ForbiddenNamespacePrefixes =
+    [
+        "System.Net.Http",
+        "TicketTailor",
+        "Humans.Infrastructure",
+    ];
+
+    [Fact]
+    public void ITicketVendorService_LivesInApplicationInterfacesNamespace()
+    {
+        typeof(ITicketVendorService).Namespace
+            .Should().Be("Humans.Application.Interfaces",
+                because: "the vendor-agnostic port lives in the Application layer; HTTP/SDK adapters are Infrastructure (design-rules §1, §15)");
+    }
+
+    [Fact]
+    public void ITicketVendorService_IsDeclaredInApplicationAssembly()
+    {
+        typeof(ITicketVendorService).Assembly.GetName().Name
+            .Should().Be("Humans.Application",
+                because: "the port must be compiled into Humans.Application so Application-layer consumers can reference it without an Infrastructure dependency");
+    }
+
+    [Fact]
+    public void HumansApplicationAssembly_HasNoReferenceToInfrastructureOrVendorSdk()
+    {
+        var applicationAssembly = typeof(ITicketVendorService).Assembly;
+
+        var referenced = applicationAssembly.GetReferencedAssemblies()
+            .Select(a => a.Name ?? string.Empty)
+            .ToList();
+
+        referenced.Should().NotContain(
+            name => name.StartsWith("Humans.Infrastructure", StringComparison.Ordinal),
+            because: "Humans.Application must not depend on Humans.Infrastructure — the connector pattern inverts this dependency");
+
+        referenced.Should().NotContain(
+            name => name.StartsWith("TicketTailor", StringComparison.Ordinal),
+            because: "Humans.Application must not reference the TicketTailor SDK; HTTP I/O is Infrastructure's concern");
+    }
+
+    [Fact]
+    public void ITicketVendorService_ExposesNoForbiddenTypesInSignatures()
+    {
+        var offenders = new List<string>();
+
+        foreach (var method in typeof(ITicketVendorService).GetMethods())
+        {
+            CheckType(method.ReturnType, $"{method.Name} return");
+
+            foreach (var parameter in method.GetParameters())
+            {
+                CheckType(parameter.ParameterType, $"{method.Name}({parameter.Name})");
+            }
+        }
+
+        offenders.Should().BeEmpty(
+            because: "ITicketVendorService must expose only Application-layer DTOs, primitives, NodaTime, and BCL collection types in its signatures (design-rules §15 connector pattern); offenders: "
+                     + string.Join(", ", offenders));
+
+        void CheckType(Type type, string location)
+        {
+            foreach (var probed in EnumerateTypes(type))
+            {
+                var ns = probed.Namespace ?? string.Empty;
+                if (ForbiddenNamespacePrefixes.Any(p => ns.StartsWith(p, StringComparison.Ordinal)))
+                {
+                    offenders.Add($"{location}: {probed.FullName}");
+                }
+            }
+        }
+
+        // Walk generic arguments so we catch forbidden types inside
+        // Task<IReadOnlyList<...>>, IEnumerable<...>, etc.
+        static IEnumerable<Type> EnumerateTypes(Type type)
+        {
+            yield return type;
+            if (type.IsGenericType)
+            {
+                foreach (var arg in type.GetGenericArguments())
+                {
+                    foreach (var inner in EnumerateTypes(arg))
+                        yield return inner;
+                }
+            }
+        }
+    }
+
+    [Fact]
+    public void ITicketVendorService_AllDtoTypesLiveInApplicationDtos()
+    {
+        // Every non-BCL, non-NodaTime, non-primitive type surfaced by the
+        // interface must live in Humans.Application.DTOs (the
+        // Application-layer vendor-agnostic shape).
+        var offenders = new List<string>();
+
+        foreach (var method in typeof(ITicketVendorService).GetMethods())
+        {
+            Inspect(method.ReturnType, $"{method.Name} return");
+            foreach (var p in method.GetParameters())
+                Inspect(p.ParameterType, $"{method.Name}({p.Name})");
+        }
+
+        offenders.Should().BeEmpty(
+            because: "custom types surfaced by ITicketVendorService must live in Humans.Application.DTOs (Application-layer vendor-agnostic DTOs); offenders: "
+                     + string.Join(", ", offenders));
+
+        void Inspect(Type type, string location)
+        {
+            foreach (var probed in Walk(type))
+            {
+                var ns = probed.Namespace ?? string.Empty;
+
+                // BCL, System.*, NodaTime, primitives — fine.
+                if (probed.IsPrimitive) continue;
+                if (probed == typeof(void) || probed == typeof(string)) continue;
+                if (ns.StartsWith("System", StringComparison.Ordinal)) continue;
+                if (ns.StartsWith("NodaTime", StringComparison.Ordinal)) continue;
+
+                // Types declared by this assembly must live in the DTOs namespace.
+                if (probed.Assembly == typeof(ITicketVendorService).Assembly &&
+                    !string.Equals(ns, "Humans.Application.DTOs", StringComparison.Ordinal))
+                {
+                    offenders.Add($"{location}: {probed.FullName} (namespace {ns})");
+                }
+            }
+        }
+
+        static IEnumerable<Type> Walk(Type type)
+        {
+            yield return type;
+            if (type.IsGenericType)
+            {
+                foreach (var arg in type.GetGenericArguments())
+                    foreach (var inner in Walk(arg))
+                        yield return inner;
+            }
+        }
+    }
+
+    [Fact]
+    public void TicketTailorService_LivesInHumansInfrastructureServicesNamespace()
+    {
+        var infra = Assembly.Load("Humans.Infrastructure");
+        var impl = infra.GetExportedTypes()
+            .Single(t => string.Equals(t.Name, "TicketTailorService", StringComparison.Ordinal)
+                         && typeof(ITicketVendorService).IsAssignableFrom(t));
+
+        impl.Namespace.Should().Be("Humans.Infrastructure.Services",
+            because: "the HTTP-backed adapter must stay in Infrastructure — it owns HttpClient, JSON parsing, and TicketTailor-specific response shapes (design-rules §1, §15 connector)");
+    }
+
+    [Fact]
+    public void StubTicketVendorService_LivesInHumansInfrastructureServicesNamespace()
+    {
+        var infra = Assembly.Load("Humans.Infrastructure");
+        var impl = infra.GetExportedTypes()
+            .Single(t => string.Equals(t.Name, "StubTicketVendorService", StringComparison.Ordinal)
+                         && typeof(ITicketVendorService).IsAssignableFrom(t));
+
+        impl.Namespace.Should().Be("Humans.Infrastructure.Services",
+            because: "the dev-time stub adapter is an Infrastructure concern (DI registration swaps prod HTTP impl for it); it is not an Application-layer interface variant");
+    }
+}

--- a/tests/Humans.Application.Tests/Architecture/TicketVendorArchitectureTests.cs
+++ b/tests/Humans.Application.Tests/Architecture/TicketVendorArchitectureTests.cs
@@ -118,9 +118,11 @@ public class TicketVendorArchitectureTests
     [Fact]
     public void ITicketVendorService_AllDtoTypesLiveInApplicationDtos()
     {
-        // Every non-BCL, non-NodaTime, non-primitive type surfaced by the
-        // interface must live in Humans.Application.DTOs (the
-        // Application-layer vendor-agnostic shape).
+        // Strict allowlist: every type surfaced by the interface must be a
+        // primitive, void/string, System.*, NodaTime.*, or live in
+        // Humans.Application.DTOs. Anything else — Humans.Domain entities,
+        // Humans.Infrastructure types, vendor SDKs, etc. — is a boundary
+        // leak and an offender, regardless of which assembly it lives in.
         var offenders = new List<string>();
 
         foreach (var method in typeof(ITicketVendorService).GetMethods())
@@ -140,18 +142,13 @@ public class TicketVendorArchitectureTests
             {
                 var ns = probed.Namespace ?? string.Empty;
 
-                // BCL, System.*, NodaTime, primitives — fine.
                 if (probed.IsPrimitive) continue;
                 if (probed == typeof(void) || probed == typeof(string)) continue;
                 if (ns.StartsWith("System", StringComparison.Ordinal)) continue;
                 if (ns.StartsWith("NodaTime", StringComparison.Ordinal)) continue;
+                if (string.Equals(ns, "Humans.Application.DTOs", StringComparison.Ordinal)) continue;
 
-                // Types declared by this assembly must live in the DTOs namespace.
-                if (probed.Assembly == typeof(ITicketVendorService).Assembly &&
-                    !string.Equals(ns, "Humans.Application.DTOs", StringComparison.Ordinal))
-                {
-                    offenders.Add($"{location}: {probed.FullName} (namespace {ns})");
-                }
+                offenders.Add($"{location}: {probed.FullName} (namespace {ns})");
             }
         }
 


### PR DESCRIPTION
Part of nobodies-collective/Humans#555 — Ticket Tailor connector formalization. TicketSyncService domain side already shipped as PR #277.

## Summary

Formalizes the Ticket Tailor vendor integration as a proper Application-layer connector (design-rules §15). `ITicketVendorService` (and its DTOs `VendorOrderDto`, `VendorTicketDto`, `VendorEventSummaryDto`, `DiscountCodeSpec`, `DiscountCodeStatusDto`, `DiscountType`) already live in `Humans.Application`; `TicketTailorService` (HTTP/JSON) and `StubTicketVendorService` (dev-time) are Infrastructure adapters. This PR locks that boundary in with architecture tests and updates `docs/architecture/design-rules.md` §15i.

### Scope

**In scope (this PR):**
- Architecture test (`TicketVendorArchitectureTests`, 7 tests) enforcing the connector boundary — interface location, assembly, DTO-only signatures, no HTTP/SDK leakage through generics, adapter namespace.
- `design-rules.md` §15i note on the Tickets connector formalization.

**Out of scope (covered by other PRs):**
- TicketSyncService domain-persistence migration → PR #277 (§545c).
- TicketQueryService / TicketingBudgetService migrations → separate.

### Acceptance

- [x] Build clean — 0 warnings, 0 errors (`dotnet build Humans.slnx -v quiet`)
- [x] Tests pass — **1070/1070** Application.Tests (includes 7 new architecture tests), **116/116** Domain.Tests
- [x] `reforge injected HumansDbContext` — `TicketTailorService` / `StubTicketVendorService` not listed
- [x] `ITicketVendorService` lives in `Humans.Application.Interfaces`
- [x] Application-layer `ITicketVendorService` has no HTTP-client or Tailor SDK imports (architecture test asserts this across all method signatures, walking through generic type arguments)
- [x] `docs/architecture/design-rules.md` §15i updated

### Notes

`TicketVendorSettings` (currently at `Humans.Infrastructure.Services/TicketTailorService.cs`) intentionally stays put in this PR — its lift into `Humans.Application.Configuration` is part of PR #277's scope (the TicketSyncService domain-side migration), since that's the service that gains a clean dependency on the Options type from the Application layer.

## Test plan

- [ ] CI green on peter's fork
- [ ] QA ticket sync continues to work (no behavior change — interface and impls already exist)

🤖 Generated with [Claude Code](https://claude.com/claude-code)