### PR TITLE
§15 Part 1: Google Workspace — migrate GoogleWorkspaceUserService to Application layer

### DIFF
--- a/src/Humans.Application/Interfaces/IWorkspaceUserDirectoryClient.cs
+++ b/src/Humans.Application/Interfaces/IWorkspaceUserDirectoryClient.cs
@@ -1,0 +1,60 @@
+namespace Humans.Application.Interfaces;
+
+/// <summary>
+/// Narrow connector over the Google Workspace Admin SDK (Directory API)
+/// scoped to the @nobodies.team user-account operations performed by
+/// <see cref="IGoogleWorkspaceUserService"/>. Implementations live in
+/// <c>Humans.Infrastructure</c> (real Google-backed implementation for
+/// production, stub for dev without service-account credentials). The
+/// Application-layer service depends only on this interface so the
+/// <c>Humans.Application</c> project stays free of <c>Google.Apis.*</c>
+/// imports inside business logic.
+/// </summary>
+public interface IWorkspaceUserDirectoryClient
+{
+    /// <summary>
+    /// Lists every @nobodies.team account in the configured Workspace domain,
+    /// pagination handled internally. Returns shape-neutral DTOs so callers
+    /// never see Google SDK types.
+    /// </summary>
+    Task<IReadOnlyList<WorkspaceUserAccount>> ListAccountsAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Looks up a single account by its primary email address. Returns
+    /// <c>null</c> when no account exists.
+    /// </summary>
+    Task<WorkspaceUserAccount?> GetAccountAsync(string primaryEmail, CancellationToken ct = default);
+
+    /// <summary>
+    /// Provisions a new @nobodies.team account with the given names and
+    /// temporary password. When <paramref name="recoveryEmail"/> is provided
+    /// and is not itself a @nobodies.team address, the connector records it
+    /// on the account for password recovery.
+    /// </summary>
+    Task<WorkspaceUserAccount> ProvisionAccountAsync(
+        string primaryEmail,
+        string firstName,
+        string lastName,
+        string temporaryPassword,
+        string? recoveryEmail,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Sets <c>Suspended=true</c> on the account identified by
+    /// <paramref name="primaryEmail"/>.
+    /// </summary>
+    Task SuspendAccountAsync(string primaryEmail, CancellationToken ct = default);
+
+    /// <summary>
+    /// Sets <c>Suspended=false</c> on the account identified by
+    /// <paramref name="primaryEmail"/>.
+    /// </summary>
+    Task ReactivateAccountAsync(string primaryEmail, CancellationToken ct = default);
+
+    /// <summary>
+    /// Resets the password for the account identified by
+    /// <paramref name="primaryEmail"/>. The account is flagged to require a
+    /// password change at next login.
+    /// </summary>
+    Task ResetPasswordAsync(string primaryEmail, string newPassword, CancellationToken ct = default);
+}

--- a/src/Humans.Application/Services/GoogleIntegration/GoogleWorkspaceUserService.cs
+++ b/src/Humans.Application/Services/GoogleIntegration/GoogleWorkspaceUserService.cs
@@ -1,0 +1,84 @@
+using Microsoft.Extensions.Logging;
+using Humans.Application.Interfaces;
+
+namespace Humans.Application.Services.GoogleIntegration;
+
+/// <summary>
+/// Manages @nobodies.team user accounts via the Google Workspace Admin SDK
+/// (Directory API), going through <see cref="IWorkspaceUserDirectoryClient"/>
+/// so the Application project stays free of <c>Google.Apis.*</c> imports.
+/// Migrated to the §15 pattern as part of issue #554 (Google Integration).
+/// </summary>
+public sealed class GoogleWorkspaceUserService : IGoogleWorkspaceUserService
+{
+    private readonly IWorkspaceUserDirectoryClient _client;
+    private readonly ILogger<GoogleWorkspaceUserService> _logger;
+
+    public GoogleWorkspaceUserService(
+        IWorkspaceUserDirectoryClient client,
+        ILogger<GoogleWorkspaceUserService> logger)
+    {
+        _client = client;
+        _logger = logger;
+    }
+
+    public async Task<IReadOnlyList<WorkspaceUserAccount>> ListAccountsAsync(
+        CancellationToken ct = default)
+    {
+        var accounts = await _client.ListAccountsAsync(ct);
+        _logger.LogInformation("Listed {Count} workspace accounts", accounts.Count);
+        return accounts;
+    }
+
+    public async Task<WorkspaceUserAccount> ProvisionAccountAsync(
+        string primaryEmail,
+        string firstName,
+        string lastName,
+        string temporaryPassword,
+        string? recoveryEmail = null,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(lastName))
+            throw new InvalidOperationException(
+                $"Cannot provision account for {primaryEmail}: FamilyName is required but was empty. The user must have a last name in their profile.");
+
+        var created = await _client.ProvisionAccountAsync(
+            primaryEmail, firstName, lastName, temporaryPassword, recoveryEmail, ct);
+
+        _logger.LogInformation(
+            "Provisioned workspace account: {Email} (recovery: {Recovery})",
+            primaryEmail, recoveryEmail ?? "none");
+
+        return created;
+    }
+
+    public async Task SuspendAccountAsync(string primaryEmail, CancellationToken ct = default)
+    {
+        await _client.SuspendAccountAsync(primaryEmail, ct);
+        _logger.LogInformation("Suspended workspace account: {Email}", primaryEmail);
+    }
+
+    public async Task ReactivateAccountAsync(string primaryEmail, CancellationToken ct = default)
+    {
+        await _client.ReactivateAccountAsync(primaryEmail, ct);
+        _logger.LogInformation("Reactivated workspace account: {Email}", primaryEmail);
+    }
+
+    public async Task ResetPasswordAsync(
+        string primaryEmail, string newPassword, CancellationToken ct = default)
+    {
+        await _client.ResetPasswordAsync(primaryEmail, newPassword, ct);
+        _logger.LogInformation("Reset password for workspace account: {Email}", primaryEmail);
+    }
+
+    public async Task<WorkspaceUserAccount?> GetAccountAsync(
+        string primaryEmail, CancellationToken ct = default)
+    {
+        var account = await _client.GetAccountAsync(primaryEmail, ct);
+        if (account is null)
+        {
+            _logger.LogDebug("Workspace account not found for email {Email}", primaryEmail);
+        }
+        return account;
+    }
+}

--- a/src/Humans.Infrastructure/Services/GoogleWorkspace/StubWorkspaceUserDirectoryClient.cs
+++ b/src/Humans.Infrastructure/Services/GoogleWorkspace/StubWorkspaceUserDirectoryClient.cs
@@ -1,18 +1,22 @@
 using Microsoft.Extensions.Logging;
 using Humans.Application.Interfaces;
 
-namespace Humans.Infrastructure.Services;
+namespace Humans.Infrastructure.Services.GoogleWorkspace;
 
 /// <summary>
-/// Stub implementation for development environments without Google Admin SDK credentials.
-/// Returns fake data so the admin UI can be developed and tested locally.
+/// Stub implementation of <see cref="IWorkspaceUserDirectoryClient"/> for
+/// development environments without Google Admin SDK credentials. Returns
+/// fake data so the admin UI and higher-level workflows can be developed
+/// and tested locally. Per the §15 connector pattern, the real
+/// <see cref="Humans.Application.Services.GoogleIntegration.GoogleWorkspaceUserService"/>
+/// runs against this stub — there is no "stub service" variant.
 /// </summary>
-public class StubGoogleWorkspaceUserService : IGoogleWorkspaceUserService
+public sealed class StubWorkspaceUserDirectoryClient : IWorkspaceUserDirectoryClient
 {
-    private readonly ILogger<StubGoogleWorkspaceUserService> _logger;
+    private readonly ILogger<StubWorkspaceUserDirectoryClient> _logger;
     private readonly List<WorkspaceUserAccount> _accounts;
 
-    public StubGoogleWorkspaceUserService(ILogger<StubGoogleWorkspaceUserService> logger)
+    public StubWorkspaceUserDirectoryClient(ILogger<StubWorkspaceUserDirectoryClient> logger)
     {
         _logger = logger;
         _accounts =
@@ -35,13 +39,24 @@ public class StubGoogleWorkspaceUserService : IGoogleWorkspaceUserService
         return Task.FromResult<IReadOnlyList<WorkspaceUserAccount>>(_accounts.AsReadOnly());
     }
 
+    public Task<WorkspaceUserAccount?> GetAccountAsync(string primaryEmail, CancellationToken ct = default)
+    {
+        var account = _accounts.FirstOrDefault(a =>
+            string.Equals(a.PrimaryEmail, primaryEmail, StringComparison.OrdinalIgnoreCase));
+        return Task.FromResult(account);
+    }
+
     public Task<WorkspaceUserAccount> ProvisionAccountAsync(
-        string primaryEmail, string firstName, string lastName,
-        string temporaryPassword, string? recoveryEmail = null, CancellationToken ct = default)
+        string primaryEmail,
+        string firstName,
+        string lastName,
+        string temporaryPassword,
+        string? recoveryEmail,
+        CancellationToken ct = default)
     {
         _logger.LogInformation("[Stub] Provisioned fake account: {Email}", primaryEmail);
-        var account = new WorkspaceUserAccount(primaryEmail, firstName, lastName, false,
-            DateTime.UtcNow, null);
+        var account = new WorkspaceUserAccount(
+            primaryEmail, firstName, lastName, false, DateTime.UtcNow, null);
         _accounts.Add(account);
         return Task.FromResult(account);
     }
@@ -64,13 +79,6 @@ public class StubGoogleWorkspaceUserService : IGoogleWorkspaceUserService
     {
         _logger.LogInformation("[Stub] Reset password for fake account: {Email}", primaryEmail);
         return Task.CompletedTask;
-    }
-
-    public Task<WorkspaceUserAccount?> GetAccountAsync(string primaryEmail, CancellationToken ct = default)
-    {
-        var account = _accounts.FirstOrDefault(a =>
-            string.Equals(a.PrimaryEmail, primaryEmail, StringComparison.OrdinalIgnoreCase));
-        return Task.FromResult(account);
     }
 
     private void ReplaceAccount(string email, Func<WorkspaceUserAccount, WorkspaceUserAccount> transform)

--- a/src/Humans.Infrastructure/Services/GoogleWorkspace/WorkspaceUserDirectoryClient.cs
+++ b/src/Humans.Infrastructure/Services/GoogleWorkspace/WorkspaceUserDirectoryClient.cs
@@ -2,30 +2,26 @@ using Google.Apis.Admin.Directory.directory_v1;
 using Google.Apis.Admin.Directory.directory_v1.Data;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Humans.Application.Interfaces;
 using Humans.Infrastructure.Configuration;
 
-namespace Humans.Infrastructure.Services;
+namespace Humans.Infrastructure.Services.GoogleWorkspace;
 
 /// <summary>
-/// Manages @nobodies.team user accounts via Google Workspace Admin SDK (Directory API).
-/// The service account authenticates as itself (no delegation or impersonation)
-/// and must be assigned the User Management Admin role in Google Workspace Admin Console.
+/// Real Google-backed implementation of <see cref="IWorkspaceUserDirectoryClient"/>.
+/// Talks to the Google Workspace Admin SDK (Directory API) using the configured
+/// service account. This is the only file that imports <c>Google.Apis.*</c> for
+/// user-account management; the Application-layer service never sees SDK types.
 /// </summary>
-public class GoogleWorkspaceUserService : IGoogleWorkspaceUserService
+public sealed class WorkspaceUserDirectoryClient : IWorkspaceUserDirectoryClient
 {
     private readonly GoogleWorkspaceSettings _settings;
-    private readonly ILogger<GoogleWorkspaceUserService> _logger;
     private DirectoryService? _directoryService;
 
-    public GoogleWorkspaceUserService(
-        IOptions<GoogleWorkspaceSettings> settings,
-        ILogger<GoogleWorkspaceUserService> logger)
+    public WorkspaceUserDirectoryClient(IOptions<GoogleWorkspaceSettings> settings)
     {
         _settings = settings.Value;
-        _logger = logger;
     }
 
     private async Task<DirectoryService> GetDirectoryServiceAsync()
@@ -99,8 +95,24 @@ public class GoogleWorkspaceUserService : IGoogleWorkspaceUserService
             pageToken = response.NextPageToken;
         } while (!string.IsNullOrEmpty(pageToken));
 
-        _logger.LogInformation("Listed {Count} @{Domain} accounts", accounts.Count, _settings.Domain);
         return accounts;
+    }
+
+    public async Task<WorkspaceUserAccount?> GetAccountAsync(
+        string primaryEmail, CancellationToken ct = default)
+    {
+        // Users.Get() returns 403 for our service account, but Users.List() with
+        // a query filter works. Use that to check if an account exists.
+        var service = await GetDirectoryServiceAsync();
+
+        var request = service.Users.List();
+        request.Domain = _settings.Domain;
+        request.Query = $"email={primaryEmail}";
+        request.MaxResults = 1;
+
+        var response = await request.ExecuteAsync(ct);
+        var user = response.UsersValue?.FirstOrDefault();
+        return user is null ? null : MapToAccount(user);
     }
 
     public async Task<WorkspaceUserAccount> ProvisionAccountAsync(
@@ -108,14 +120,10 @@ public class GoogleWorkspaceUserService : IGoogleWorkspaceUserService
         string firstName,
         string lastName,
         string temporaryPassword,
-        string? recoveryEmail = null,
+        string? recoveryEmail,
         CancellationToken ct = default)
     {
         var service = await GetDirectoryServiceAsync();
-
-        if (string.IsNullOrWhiteSpace(lastName))
-            throw new InvalidOperationException(
-                $"Cannot provision account for {primaryEmail}: FamilyName is required but was empty. The user must have a last name in their profile.");
 
         var newUser = new User
         {
@@ -138,70 +146,33 @@ public class GoogleWorkspaceUserService : IGoogleWorkspaceUserService
         }
 
         var created = await service.Users.Insert(newUser).ExecuteAsync(ct);
-        _logger.LogInformation("Provisioned @{Domain} account: {Email} (recovery: {Recovery})",
-            _settings.Domain, primaryEmail, recoveryEmail ?? "none");
-
         return MapToAccount(created);
     }
 
     public async Task SuspendAccountAsync(string primaryEmail, CancellationToken ct = default)
     {
         var service = await GetDirectoryServiceAsync();
-
         var update = new User { Suspended = true };
         await service.Users.Update(update, primaryEmail).ExecuteAsync(ct);
-
-        _logger.LogInformation("Suspended @{Domain} account: {Email}", _settings.Domain, primaryEmail);
     }
 
     public async Task ReactivateAccountAsync(string primaryEmail, CancellationToken ct = default)
     {
         var service = await GetDirectoryServiceAsync();
-
         var update = new User { Suspended = false };
         await service.Users.Update(update, primaryEmail).ExecuteAsync(ct);
-
-        _logger.LogInformation("Reactivated @{Domain} account: {Email}", _settings.Domain, primaryEmail);
     }
 
     public async Task ResetPasswordAsync(
         string primaryEmail, string newPassword, CancellationToken ct = default)
     {
         var service = await GetDirectoryServiceAsync();
-
         var update = new User
         {
             Password = newPassword,
             ChangePasswordAtNextLogin = true
         };
         await service.Users.Update(update, primaryEmail).ExecuteAsync(ct);
-
-        _logger.LogInformation("Reset password for @{Domain} account: {Email}",
-            _settings.Domain, primaryEmail);
-    }
-
-    public async Task<WorkspaceUserAccount?> GetAccountAsync(
-        string primaryEmail, CancellationToken ct = default)
-    {
-        // Users.Get() returns 403 for our service account, but Users.List() with
-        // a query filter works. Use that to check if an account exists.
-        var service = await GetDirectoryServiceAsync();
-
-        var request = service.Users.List();
-        request.Domain = _settings.Domain;
-        request.Query = $"email={primaryEmail}";
-        request.MaxResults = 1;
-
-        var response = await request.ExecuteAsync(ct);
-        var user = response.UsersValue?.FirstOrDefault();
-
-        if (user is null)
-        {
-            _logger.LogDebug("Workspace account not found for email {Email}", primaryEmail);
-            return null;
-        }
-
-        return MapToAccount(user);
     }
 
     private static WorkspaceUserAccount MapToAccount(User user)

--- a/src/Humans.Web/Extensions/Infrastructure/GoogleWorkspaceInfrastructureExtensions.cs
+++ b/src/Humans.Web/Extensions/Infrastructure/GoogleWorkspaceInfrastructureExtensions.cs
@@ -2,6 +2,8 @@ using Humans.Application.Interfaces;
 using Humans.Infrastructure.Configuration;
 using Humans.Infrastructure.Jobs;
 using Humans.Infrastructure.Services;
+using Humans.Infrastructure.Services.GoogleWorkspace;
+using GoogleWorkspaceUserService = Humans.Application.Services.GoogleIntegration.GoogleWorkspaceUserService;
 
 namespace Humans.Web.Extensions.Infrastructure;
 
@@ -25,6 +27,11 @@ internal static class GoogleWorkspaceInfrastructureExtensions
             services.AddScoped<ITeamResourceService, TeamResourceService>();
             services.AddScoped<IDriveActivityMonitorService, DriveActivityMonitorService>();
 
+            // Google Integration §15 migration (issue #554) — workspace users.
+            // Application-layer service depends only on the shape-neutral
+            // IWorkspaceUserDirectoryClient connector; the real and stub
+            // implementations live in Humans.Infrastructure.
+            services.AddScoped<IWorkspaceUserDirectoryClient, WorkspaceUserDirectoryClient>();
             services.AddScoped<IGoogleWorkspaceUserService, GoogleWorkspaceUserService>();
         }
         else if (environment.IsProduction())
@@ -38,7 +45,9 @@ internal static class GoogleWorkspaceInfrastructureExtensions
             services.AddScoped<IGoogleSyncService, StubGoogleSyncService>();
             services.AddScoped<ITeamResourceService, StubTeamResourceService>();
             services.AddScoped<IDriveActivityMonitorService, StubDriveActivityMonitorService>();
-            services.AddScoped<IGoogleWorkspaceUserService, StubGoogleWorkspaceUserService>();
+
+            services.AddScoped<IWorkspaceUserDirectoryClient, StubWorkspaceUserDirectoryClient>();
+            services.AddScoped<IGoogleWorkspaceUserService, GoogleWorkspaceUserService>();
         }
 
         services.AddScoped<IGoogleAdminService, GoogleAdminService>();

--- a/tests/Humans.Application.Tests/Architecture/GoogleWorkspaceUserArchitectureTests.cs
+++ b/tests/Humans.Application.Tests/Architecture/GoogleWorkspaceUserArchitectureTests.cs
@@ -1,0 +1,155 @@
+using System.Reflection;
+using AwesomeAssertions;
+using Humans.Application.Interfaces;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+using GoogleWorkspaceUserService = Humans.Application.Services.GoogleIntegration.GoogleWorkspaceUserService;
+
+namespace Humans.Application.Tests.Architecture;
+
+/// <summary>
+/// Architecture tests enforcing the §15 pattern for the Google Integration
+/// section's <see cref="GoogleWorkspaceUserService"/> — migrated under issue
+/// #554 (split from the umbrella PR into an isolated sub-task). The service
+/// now lives in <c>Humans.Application.Services.GoogleIntegration</c> and
+/// routes all Google SDK calls through
+/// <see cref="IWorkspaceUserDirectoryClient"/>. These tests are the compile-
+/// time guarantee that the connector boundary does not leak back into the
+/// Application project.
+/// </summary>
+public class GoogleWorkspaceUserArchitectureTests
+{
+    // ── GoogleWorkspaceUserService ───────────────────────────────────────────
+
+    [Fact]
+    public void GoogleWorkspaceUserService_LivesInHumansApplicationServicesGoogleIntegrationNamespace()
+    {
+        typeof(GoogleWorkspaceUserService).Namespace
+            .Should().Be("Humans.Application.Services.GoogleIntegration",
+                because: "services with business logic live in Humans.Application per design-rules §2b, organized by section");
+    }
+
+    [Fact]
+    public void GoogleWorkspaceUserService_HasNoDbContextConstructorParameter()
+    {
+        var ctor = typeof(GoogleWorkspaceUserService).GetConstructors().Single();
+        ctor.GetParameters()
+            .Should().NotContain(
+                p => typeof(DbContext).IsAssignableFrom(p.ParameterType),
+                because: "services in Humans.Application must never take DbContext (design-rules §3) — this service has no DB, only a connector");
+    }
+
+    [Fact]
+    public void GoogleWorkspaceUserService_HasNoDbContextFactoryConstructorParameter()
+    {
+        var ctor = typeof(GoogleWorkspaceUserService).GetConstructors().Single();
+        var factoryParam = ctor.GetParameters()
+            .FirstOrDefault(p =>
+                p.ParameterType.IsGenericType &&
+                p.ParameterType.GetGenericTypeDefinition() == typeof(IDbContextFactory<>));
+
+        factoryParam.Should().BeNull(
+            because: "IDbContextFactory belongs behind the repository boundary, not in an Application-layer service");
+    }
+
+    [Fact]
+    public void GoogleWorkspaceUserService_TakesConnectorClient()
+    {
+        var ctor = typeof(GoogleWorkspaceUserService).GetConstructors().Single();
+        var paramTypes = ctor.GetParameters().Select(p => p.ParameterType).ToList();
+
+        paramTypes.Should().Contain(typeof(IWorkspaceUserDirectoryClient),
+            because: "Google SDK calls go through the shape-neutral connector, not directly from the Application service");
+    }
+
+    [Fact]
+    public void GoogleWorkspaceUserService_IsSealed()
+    {
+        typeof(GoogleWorkspaceUserService).IsSealed.Should().BeTrue(
+            because: "service implementations are sealed to prevent ad-hoc extension; any new behavior belongs on the interface");
+    }
+
+    // ── Application assembly cleanliness ─────────────────────────────────────
+
+    [Fact]
+    public void HumansApplicationAssembly_HasNoGoogleApisReferences()
+    {
+        // The Application project must never transitively pull Google.Apis.*.
+        // Scanning referenced assemblies is the compile-time guarantee for this.
+        var applicationAssembly = typeof(IGoogleWorkspaceUserService).Assembly;
+        var referencedNames = applicationAssembly.GetReferencedAssemblies();
+
+        referencedNames
+            .Should().NotContain(
+                a => (a.Name ?? string.Empty).StartsWith("Google.Apis", StringComparison.Ordinal),
+                because: "Humans.Application must stay free of Google SDK references; Google API calls live behind IWorkspaceUserDirectoryClient in Humans.Infrastructure");
+    }
+
+    [Fact]
+    public void GoogleWorkspaceUserService_DoesNotReferenceGoogleSdkTypes()
+    {
+        // Paranoid double-check: the service's module should have no Google.Apis.*
+        // types in its metadata references. Catches cases where a stray `using`
+        // survives a mass-edit even if csproj doesn't add the package reference.
+        var module = typeof(GoogleWorkspaceUserService).Module;
+        var referencedTypes = module.GetTypes()
+            .SelectMany(t => new[] { t.BaseType }
+                .Concat(t.GetInterfaces())
+                .Concat(t.GetFields(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)
+                    .Select(f => f.FieldType))
+                .Concat(t.GetProperties(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)
+                    .Select(p => p.PropertyType)))
+            .Where(t => t is not null)
+            .Select(t => t!.Namespace ?? string.Empty);
+
+        referencedTypes
+            .Should().NotContain(
+                ns => ns.StartsWith("Google.Apis", StringComparison.Ordinal),
+                because: "the Application-layer service must not see any Google SDK types — they belong behind IWorkspaceUserDirectoryClient");
+    }
+
+    // ── IWorkspaceUserDirectoryClient ────────────────────────────────────────
+
+    [Fact]
+    public void IWorkspaceUserDirectoryClient_LivesInApplicationInterfacesNamespace()
+    {
+        typeof(IWorkspaceUserDirectoryClient).Namespace
+            .Should().Be("Humans.Application.Interfaces",
+                because: "connector interfaces live alongside other application interfaces per design-rules §2b");
+    }
+
+    [Fact]
+    public void IWorkspaceUserDirectoryClient_HasNoGoogleSdkTypesInSignatures()
+    {
+        // Every method parameter and return type must come from Humans.Application
+        // or the BCL — never Google.Apis.*. Enforces the "shape-neutral" contract.
+        var methods = typeof(IWorkspaceUserDirectoryClient).GetMethods();
+
+        foreach (var method in methods)
+        {
+            var types = new[] { method.ReturnType }
+                .Concat(method.GetParameters().Select(p => p.ParameterType))
+                .SelectMany(UnwrapGenericArgs);
+
+            foreach (var t in types)
+            {
+                (t.Namespace ?? string.Empty)
+                    .Should().NotStartWith("Google.Apis",
+                        because: $"{method.Name} leaks a Google SDK type through its signature; connector contracts must be shape-neutral");
+            }
+        }
+
+        static IEnumerable<Type> UnwrapGenericArgs(Type t)
+        {
+            yield return t;
+            if (t.IsGenericType)
+            {
+                foreach (var arg in t.GetGenericArguments())
+                {
+                    foreach (var inner in UnwrapGenericArgs(arg))
+                        yield return inner;
+                }
+            }
+        }
+    }
+}

--- a/tests/Humans.Application.Tests/Services/GoogleWorkspaceUserServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/GoogleWorkspaceUserServiceTests.cs
@@ -1,0 +1,116 @@
+using AwesomeAssertions;
+using Humans.Application.Interfaces;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Xunit;
+using GoogleWorkspaceUserService = Humans.Application.Services.GoogleIntegration.GoogleWorkspaceUserService;
+
+namespace Humans.Application.Tests.Services;
+
+/// <summary>
+/// Unit tests for the migrated Google Integration
+/// <see cref="GoogleWorkspaceUserService"/>. The service is a thin orchestrator
+/// over <see cref="IWorkspaceUserDirectoryClient"/>; these tests pin down the
+/// dispatch contract (connector calls happen with the expected arguments) and
+/// the only piece of real behavior owned by the service — the
+/// <c>lastName</c> pre-flight guard from the pre-§15 implementation.
+/// </summary>
+public class GoogleWorkspaceUserServiceTests
+{
+    private readonly IWorkspaceUserDirectoryClient _client;
+    private readonly GoogleWorkspaceUserService _service;
+
+    public GoogleWorkspaceUserServiceTests()
+    {
+        _client = Substitute.For<IWorkspaceUserDirectoryClient>();
+        _service = new GoogleWorkspaceUserService(
+            _client, NullLogger<GoogleWorkspaceUserService>.Instance);
+    }
+
+    [Fact]
+    public async Task ListAccountsAsync_DelegatesToClient()
+    {
+        IReadOnlyList<WorkspaceUserAccount> expected =
+        [
+            new("a@nobodies.team", "A", "Alpha", false, DateTime.UtcNow, null)
+        ];
+        _client.ListAccountsAsync(Arg.Any<CancellationToken>()).Returns(expected);
+
+        var result = await _service.ListAccountsAsync();
+
+        result.Should().BeSameAs(expected);
+    }
+
+    [Fact]
+    public async Task GetAccountAsync_DelegatesToClient_AndReturnsNullWhenMissing()
+    {
+        _client.GetAccountAsync("missing@nobodies.team", Arg.Any<CancellationToken>())
+            .Returns((WorkspaceUserAccount?)null);
+
+        var result = await _service.GetAccountAsync("missing@nobodies.team");
+
+        result.Should().BeNull();
+        await _client.Received(1).GetAccountAsync("missing@nobodies.team", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ProvisionAccountAsync_ForwardsAllArguments()
+    {
+        var expected = new WorkspaceUserAccount(
+            "new@nobodies.team", "New", "User", false, DateTime.UtcNow, null);
+        _client.ProvisionAccountAsync(
+                "new@nobodies.team", "New", "User", "TempP@ss", "recover@example.com",
+                Arg.Any<CancellationToken>())
+            .Returns(expected);
+
+        var result = await _service.ProvisionAccountAsync(
+            "new@nobodies.team", "New", "User", "TempP@ss", "recover@example.com");
+
+        result.Should().BeSameAs(expected);
+        await _client.Received(1).ProvisionAccountAsync(
+            "new@nobodies.team", "New", "User", "TempP@ss", "recover@example.com",
+            Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(null)]
+    public async Task ProvisionAccountAsync_ThrowsWhenLastNameBlank(string? lastName)
+    {
+        var act = () => _service.ProvisionAccountAsync(
+            "new@nobodies.team", "First", lastName!, "pw");
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*FamilyName is required*");
+        await _client.DidNotReceiveWithAnyArgs().ProvisionAccountAsync(
+            default!, default!, default!, default!, default, default);
+    }
+
+    [Fact]
+    public async Task SuspendAccountAsync_DelegatesToClient()
+    {
+        await _service.SuspendAccountAsync("target@nobodies.team");
+
+        await _client.Received(1).SuspendAccountAsync(
+            "target@nobodies.team", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ReactivateAccountAsync_DelegatesToClient()
+    {
+        await _service.ReactivateAccountAsync("target@nobodies.team");
+
+        await _client.Received(1).ReactivateAccountAsync(
+            "target@nobodies.team", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ResetPasswordAsync_DelegatesToClient()
+    {
+        await _service.ResetPasswordAsync("target@nobodies.team", "NewP@ss");
+
+        await _client.Received(1).ResetPasswordAsync(
+            "target@nobodies.team", "NewP@ss", Arg.Any<CancellationToken>());
+    }
+}


### PR DESCRIPTION
Part of nobodies-collective/Humans#554 — GoogleWorkspaceUserService split-off. Sibling splits: PR #284 (SyncSettingsService), #554-emailprov in flight.

## Summary

- Move `GoogleWorkspaceUserService` from `Humans.Infrastructure/Services/` to `Humans.Application.Services.GoogleIntegration`. The service has no DB access (never did), so no repository was introduced; instead, Google SDK calls route through a new shape-neutral connector.
- New `IWorkspaceUserDirectoryClient` (in `Humans.Application.Interfaces`) exposes the 6 operations the service needs (list / get / provision / suspend / reactivate / reset). Implementations live in `Humans.Infrastructure/Services/GoogleWorkspace/`: `WorkspaceUserDirectoryClient` (real, wraps `Google.Apis.Admin.Directory`) and `StubWorkspaceUserDirectoryClient` (dev fake data).
- Follow PR #274's collapse pattern: one Application-layer service, two connector implementations. `StubGoogleWorkspaceUserService` is gone — dev mode is selected at the connector layer, which keeps the real service's entire code path exercised in dev.

## Design notes

- The connector returns the existing `WorkspaceUserAccount` DTO (already in Humans.Application), so consumers — `EmailProvisioningService`, `GoogleAdminService`, the admin UI — need no changes.
- `Humans.Application.csproj` has no Google package reference. Verified by reflection-based architecture test (`HumansApplicationAssembly_HasNoGoogleApisReferences`) plus a signature-scan over `IWorkspaceUserDirectoryClient` methods.
- The one piece of real business logic the service owns — the `lastName` pre-flight guard that rejects provisioning when `FamilyName` is empty — stays in the service and is covered by unit tests.

## Acceptance

- [x] Build clean, 0 warnings.
- [x] Application tests: 1081 pass (existing baseline) + 18 new (9 architecture + 9 service dispatch).
- [x] Integration tests: skipped locally (Docker unavailable on dev machine, same as PR #274); will run in CI.
- [x] `reforge injected HumansDbContext` — `GoogleWorkspaceUserService` no longer listed.
- [x] `reforge dbset-usage Humans.Application.Services.GoogleIntegration.GoogleWorkspaceUserService` returns 0.
- [x] `docs/architecture/design-rules.md` §15i updated (~33 → ~32 services, Google Integration status line added).

## Test plan

- [ ] QA: verify the `/Admin/WorkspaceAccounts` (or equivalent) page still lists accounts.
- [ ] QA: verify admin can provision, suspend, reactivate, and reset a @nobodies.team account.
- [ ] QA: verify the EmailProvisioningService 4-step flow still works end-to-end (it calls `GetAccountAsync` and `ProvisionAccountAsync`).
- [ ] Dev: verify stub mode (no service-account credentials) still returns the three fake accounts and that provisioning / suspend / reactivate against the stub behave correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)