### PR TITLE
§15 Part 1: Google Workspace — migrate GoogleAdminService to Application layer

### DIFF
--- a/src/Humans.Application/Interfaces/ITeamService.cs
+++ b/src/Humans.Application/Interfaces/ITeamService.cs
@@ -370,6 +370,27 @@ public interface ITeamService
     Task<IReadOnlyList<TeamOptionDto>> GetActiveTeamOptionsAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Sets <c>Team.GoogleGroupPrefix</c> to <paramref name="prefix"/> (may be
+    /// null to clear) and persists the change. Returns the previous prefix so
+    /// callers can revert on downstream-service failure. Returns (<c>false</c>,
+    /// <c>null</c>) if the team does not exist. Narrow alternative to
+    /// <see cref="UpdateTeamAsync"/> for flows that only need to touch the
+    /// Google-group wiring.
+    /// </summary>
+    Task<(bool Updated, string? PreviousPrefix)> SetGoogleGroupPrefixAsync(
+        Guid teamId, string? prefix, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns the name of the team whose <c>GoogleGroupPrefix</c> matches
+    /// <paramref name="prefix"/> (case-insensitive), or null if no team uses that
+    /// prefix. Used by Google-admin flows to detect collisions between a
+    /// proposed standalone account address and an existing team group address
+    /// before mutating Workspace state.
+    /// </summary>
+    Task<string?> GetTeamNameByGoogleGroupPrefixAsync(
+        string prefix, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Gets all teams for admin list with active member counts and pending request counts.
     /// </summary>
     Task<(IReadOnlyList<Team> Items, int TotalCount)> GetAllTeamsForAdminAsync(

--- a/src/Humans.Application/Interfaces/ITeamService.cs
+++ b/src/Humans.Application/Interfaces/ITeamService.cs
@@ -381,16 +381,6 @@ public interface ITeamService
         Guid teamId, string? prefix, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Returns the name of the team whose <c>GoogleGroupPrefix</c> matches
-    /// <paramref name="prefix"/> (case-insensitive), or null if no team uses that
-    /// prefix. Used by Google-admin flows to detect collisions between a
-    /// proposed standalone account address and an existing team group address
-    /// before mutating Workspace state.
-    /// </summary>
-    Task<string?> GetTeamNameByGoogleGroupPrefixAsync(
-        string prefix, CancellationToken cancellationToken = default);
-
-    /// <summary>
     /// Gets all teams for admin list with active member counts and pending request counts.
     /// </summary>
     Task<(IReadOnlyList<Team> Items, int TotalCount)> GetAllTeamsForAdminAsync(

--- a/src/Humans.Application/Interfaces/IUserEmailService.cs
+++ b/src/Humans.Application/Interfaces/IUserEmailService.cs
@@ -153,6 +153,7 @@ public interface IUserEmailService
         IEnumerable<Guid> userIds,
         CancellationToken cancellationToken = default);
 
+    /// <summary>
     /// Resolves the notification-target email for each requested user. The
     /// result is <c>UserEmail.Email</c> where <c>IsNotificationTarget</c> is
     /// true and the email is verified, falling back to <c>User.Email</c> when

--- a/src/Humans.Application/Interfaces/IUserEmailService.cs
+++ b/src/Humans.Application/Interfaces/IUserEmailService.cs
@@ -1,5 +1,6 @@
 using Humans.Application.DTOs;
 using Humans.Domain.Enums;
+using NodaTime;
 
 namespace Humans.Application.Interfaces;
 
@@ -152,7 +153,6 @@ public interface IUserEmailService
         IEnumerable<Guid> userIds,
         CancellationToken cancellationToken = default);
 
-    /// <summary>
     /// Resolves the notification-target email for each requested user. The
     /// result is <c>UserEmail.Email</c> where <c>IsNotificationTarget</c> is
     /// true and the email is verified, falling back to <c>User.Email</c> when
@@ -218,4 +218,45 @@ public interface IUserEmailService
         string email,
         Guid excludeUserId,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns true when any <see cref="Humans.Domain.Entities.UserEmail"/> row
+    /// exists whose <c>Email</c> matches <paramref name="email"/> case-insensitively,
+    /// irrespective of user. Used by admin account-linking flows to reject duplicate
+    /// links before mutating state.
+    /// </summary>
+    Task<bool> IsEmailLinkedToAnyUserAsync(
+        string email, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Rewrites the user's <see cref="Humans.Domain.Entities.UserEmail"/> row
+    /// whose address matches <paramref name="oldEmail"/> (case-insensitive) to
+    /// <paramref name="newEmail"/> and stamps <c>UpdatedAt</c>. Used by the
+    /// admin rename-fix flow. No-op if the user has no matching row.
+    /// </summary>
+    Task RewriteEmailAddressAsync(
+        Guid userId, string oldEmail, string newEmail,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns every <see cref="UserEmailMatch"/> whose address matches one of
+    /// <paramref name="emails"/> (case-insensitive). Used by the Google admin
+    /// workspace-accounts list to match Google-side accounts to humans without
+    /// loading the full <c>user_emails</c> table.
+    /// </summary>
+    Task<IReadOnlyList<UserEmailMatch>> MatchByEmailsAsync(
+        IReadOnlyCollection<string> emails,
+        CancellationToken cancellationToken = default);
 }
+
+/// <summary>
+/// Narrow projection describing a <see cref="Humans.Domain.Entities.UserEmail"/>
+/// row used by admin cross-section matching. Avoids leaking the full entity
+/// outside the owning section.
+/// </summary>
+public record UserEmailMatch(
+    string Email,
+    Guid UserId,
+    bool IsNotificationTarget,
+    bool IsVerified,
+    Instant UpdatedAt);

--- a/src/Humans.Application/Interfaces/IUserService.cs
+++ b/src/Humans.Application/Interfaces/IUserService.cs
@@ -95,6 +95,17 @@ public interface IUserService
     Task<bool> SetGoogleEmailAsync(Guid userId, string email, CancellationToken ct = default);
 
     /// <summary>
+    /// Rewrites <c>User.Email</c>, <c>User.UserName</c>, and their normalized
+    /// counterparts to <paramref name="newEmail"/>. If the user has an
+    /// OAuth-sourced <see cref="Humans.Domain.Entities.UserEmail"/> row, it is
+    /// rewritten to match so login continues to succeed against the new email.
+    /// Invalidates the Profile cache on success. Returns the previous email on
+    /// success, or (<c>false</c>, <c>null</c>) if the user does not exist.
+    /// </summary>
+    Task<(bool Updated, string? OldEmail)> ApplyEmailBackfillAsync(
+        Guid userId, string newEmail, CancellationToken ct = default);
+
+    /// <summary>
     /// Updates <c>User.DisplayName</c>. No-op if the user does not exist.
     /// </summary>
     Task UpdateDisplayNameAsync(Guid userId, string displayName, CancellationToken ct = default);

--- a/src/Humans.Application/Interfaces/Repositories/IUserEmailRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/IUserEmailRepository.cs
@@ -1,6 +1,7 @@
 using Humans.Application.DTOs;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
+using NodaTime;
 
 namespace Humans.Application.Interfaces.Repositories;
 
@@ -103,6 +104,22 @@ public interface IUserEmailRepository
     Task<bool> RemoveByIdAsync(Guid emailId, CancellationToken ct = default);
 
     /// <summary>
+    /// Returns every <see cref="UserEmail"/> row whose <c>Email</c> matches one
+    /// of <paramref name="emails"/> (case-insensitive). Read-only (AsNoTracking).
+    /// Used by the Google admin workspace-accounts list to match Google-side
+    /// accounts to human records without loading the full table.
+    /// </summary>
+    Task<IReadOnlyList<UserEmail>> GetByEmailsAsync(
+        IReadOnlyCollection<string> emails, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns true when any <see cref="UserEmail"/> row exists with
+    /// <c>Email</c> equal to <paramref name="email"/> (case-insensitive),
+    /// irrespective of user. Used by admin account-linking flows.
+    /// </summary>
+    Task<bool> AnyWithEmailAsync(string email, CancellationToken ct = default);
+
+    /// <summary>
     /// Returns a mapping of userId → verified notification-target email for all users
     /// that have one. If a user has multiple verified notification-target emails,
     /// one is picked arbitrarily.
@@ -161,6 +178,25 @@ public interface IUserEmailRepository
     /// </summary>
     Task<Guid?> GetOtherUserIdHavingEmailAsync(
         string email, Guid excludeUserId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Rewrites the <c>Email</c> of the user's OAuth-sourced <see cref="UserEmail"/>
+    /// row (if one exists) to <paramref name="newEmail"/>. Used by the admin
+    /// email-backfill workflow. Returns true when a row was updated. No-op if the
+    /// user has no OAuth email row.
+    /// </summary>
+    Task<bool> RewriteOAuthEmailAsync(Guid userId, string newEmail, CancellationToken ct = default);
+
+    /// <summary>
+    /// Rewrites the <c>Email</c> of the user's existing <see cref="UserEmail"/> row
+    /// (case-insensitive match on <paramref name="oldEmail"/>) to
+    /// <paramref name="newEmail"/> and stamps <c>UpdatedAt</c> with
+    /// <paramref name="updatedAt"/>. Used by the admin rename-fix flow. Returns
+    /// true when a row was updated. No-op if no matching row exists.
+    /// </summary>
+    Task<bool> RewriteEmailAddressAsync(
+        Guid userId, string oldEmail, string newEmail, Instant updatedAt,
+        CancellationToken ct = default);
 
     Task AddAsync(UserEmail email, CancellationToken ct = default);
     Task RemoveAsync(UserEmail email, CancellationToken ct = default);

--- a/src/Humans.Application/Interfaces/Repositories/IUserRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/IUserRepository.cs
@@ -110,6 +110,17 @@ public interface IUserRepository
     Task<bool> SetGoogleEmailAsync(Guid userId, string email, CancellationToken ct = default);
 
     /// <summary>
+    /// Rewrites <c>User.Email</c>, <c>User.UserName</c>, <c>User.NormalizedEmail</c>,
+    /// and <c>User.NormalizedUserName</c> to the given <paramref name="newEmail"/>.
+    /// Used by the admin email-backfill workflow to repair OAuth identity after a
+    /// provider-side email change. Returns the previous <c>Email</c> value (may be
+    /// null) so callers can log the transition, or <c>(false, null)</c> if the user
+    /// does not exist.
+    /// </summary>
+    Task<(bool Updated, string? OldEmail)> RewritePrimaryEmailAsync(
+        Guid userId, string newEmail, CancellationToken ct = default);
+
+    /// <summary>
     /// Sets the deletion-pending fields on a user (<c>DeletionRequestedAt</c>,
     /// <c>DeletionScheduledFor</c>). Returns false if the user does not exist.
     /// </summary>

--- a/src/Humans.Application/Services/GoogleIntegration/GoogleAdminService.cs
+++ b/src/Humans.Application/Services/GoogleIntegration/GoogleAdminService.cs
@@ -61,11 +61,26 @@ public sealed class GoogleAdminService : IGoogleAdminService
             // we just listed — much cheaper than loading the entire user_emails table.
             var accountEmails = accounts.Select(a => a.PrimaryEmail).ToList();
             var matches = await _userEmailService.MatchByEmailsAsync(accountEmails, ct);
-            var matchByEmail = matches.ToDictionary(
-                m => m.Email, StringComparer.OrdinalIgnoreCase);
+
+            // user_emails allows a verified + unverified row for the same
+            // address, so MatchByEmailsAsync can return multiple hits per
+            // email. Collapse to one winner per address: prefer verified
+            // rows, then the most recently updated, then a stable UserId
+            // tie-breaker. Using ToDictionary directly would throw on the
+            // duplicate key and fail the whole workspace-accounts view.
+            var matchByEmail = matches
+                .GroupBy(m => m.Email, StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(
+                    g => g.Key,
+                    g => g
+                        .OrderByDescending(m => m.IsVerified)
+                        .ThenByDescending(m => m.UpdatedAt)
+                        .ThenBy(m => m.UserId)
+                        .First(),
+                    StringComparer.OrdinalIgnoreCase);
 
             // Batch-load users for matched emails
-            var matchedUserIds = matches.Select(m => m.UserId).Distinct().ToList();
+            var matchedUserIds = matchByEmail.Values.Select(m => m.UserId).Distinct().ToList();
             var usersById = matchedUserIds.Count == 0
                 ? new Dictionary<Guid, User>()
                 : (await _userService.GetByIdsAsync(matchedUserIds, ct))

--- a/src/Humans.Application/Services/GoogleIntegration/GoogleAdminService.cs
+++ b/src/Humans.Application/Services/GoogleIntegration/GoogleAdminService.cs
@@ -4,47 +4,49 @@ using Humans.Application.Interfaces;
 using Humans.Domain.Constants;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
-using Humans.Infrastructure.Data;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using NodaTime;
 
-namespace Humans.Infrastructure.Services;
+namespace Humans.Application.Services.GoogleIntegration;
 
 /// <summary>
-/// Service for Google Workspace admin operations:
-/// workspace account management, group linking, email backfill, account linking.
+/// Application-layer service for Google Workspace admin operations:
+/// workspace account management, group linking, email backfill, account
+/// linking. Migrated to the §15 pattern as part of issue #554 — no DbContext
+/// dependency; all cross-section data access routes through the owning
+/// services (<see cref="IUserService"/>, <see cref="IUserEmailService"/>,
+/// <see cref="ITeamService"/>, <see cref="ITeamResourceService"/>).
 /// </summary>
-public class GoogleAdminService : IGoogleAdminService
+public sealed class GoogleAdminService : IGoogleAdminService
 {
-    private readonly HumansDbContext _dbContext;
     private readonly IGoogleWorkspaceUserService _workspaceUserService;
     private readonly IGoogleSyncService _googleSyncService;
+    private readonly ITeamService _teamService;
     private readonly ITeamResourceService _teamResourceService;
+    private readonly IUserService _userService;
     private readonly IUserEmailService _userEmailService;
     private readonly IAuditLogService _auditLogService;
-    private readonly IClock _clock;
     private readonly ILogger<GoogleAdminService> _logger;
 
     private const string NobodiesTeamDomain = "nobodies.team";
 
     public GoogleAdminService(
-        HumansDbContext dbContext,
         IGoogleWorkspaceUserService workspaceUserService,
         IGoogleSyncService googleSyncService,
+        ITeamService teamService,
         ITeamResourceService teamResourceService,
+        IUserService userService,
         IUserEmailService userEmailService,
         IAuditLogService auditLogService,
-        IClock clock,
         ILogger<GoogleAdminService> logger)
     {
-        _dbContext = dbContext;
         _workspaceUserService = workspaceUserService;
         _googleSyncService = googleSyncService;
+        _teamService = teamService;
         _teamResourceService = teamResourceService;
+        _userService = userService;
         _userEmailService = userEmailService;
         _auditLogService = auditLogService;
-        _clock = clock;
         _logger = logger;
     }
 
@@ -55,36 +57,36 @@ public class GoogleAdminService : IGoogleAdminService
         {
             var accounts = await _workspaceUserService.ListAccountsAsync(ct);
 
-            // Load all user emails to match accounts to humans
-            var allUserEmails = await _dbContext.UserEmails
-                .AsNoTracking()
-                .ToListAsync(ct);
+            // Match only against emails that correspond to Google-side accounts
+            // we just listed — much cheaper than loading the entire user_emails table.
+            var accountEmails = accounts.Select(a => a.PrimaryEmail).ToList();
+            var matches = await _userEmailService.MatchByEmailsAsync(accountEmails, ct);
+            var matchByEmail = matches.ToDictionary(
+                m => m.Email, StringComparer.OrdinalIgnoreCase);
 
             // Batch-load users for matched emails
-            var matchedUserIds = allUserEmails.Select(ue => ue.UserId).Distinct().ToList();
-            var usersById = await _dbContext.Users
-                .AsNoTracking()
-                .Where(u => matchedUserIds.Contains(u.Id))
-                .ToDictionaryAsync(u => u.Id, ct);
+            var matchedUserIds = matches.Select(m => m.UserId).Distinct().ToList();
+            var usersById = matchedUserIds.Count == 0
+                ? new Dictionary<Guid, User>()
+                : (await _userService.GetByIdsAsync(matchedUserIds, ct))
+                    .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
 
             var accountInfos = new List<WorkspaceAccountInfo>();
             var notPrimaryCount = 0;
 
             foreach (var account in accounts)
             {
-                var matchedEmail = allUserEmails.FirstOrDefault(ue =>
-                    string.Equals(ue.Email, account.PrimaryEmail, StringComparison.OrdinalIgnoreCase));
-
-                var isUsedAsPrimary = matchedEmail is { IsNotificationTarget: true };
+                matchByEmail.TryGetValue(account.PrimaryEmail, out var matched);
+                var isUsedAsPrimary = matched is { IsNotificationTarget: true };
 
                 // Count accounts that exist in the system but are not used as primary
-                if (matchedEmail is not null && !isUsedAsPrimary)
+                if (matched is not null && !isUsedAsPrimary)
                 {
                     notPrimaryCount++;
                 }
 
-                var matchedUser = matchedEmail is not null
-                    ? usersById.GetValueOrDefault(matchedEmail.UserId)
+                var matchedUser = matched is not null
+                    ? usersById.GetValueOrDefault(matched.UserId)
                     : null;
 
                 accountInfos.Add(new WorkspaceAccountInfo(
@@ -94,7 +96,7 @@ public class GoogleAdminService : IGoogleAdminService
                     IsSuspended: account.IsSuspended,
                     CreationTime: account.CreationTime,
                     LastLoginTime: account.LastLoginTime,
-                    MatchedUserId: matchedEmail?.UserId,
+                    MatchedUserId: matched?.UserId,
                     MatchedDisplayName: matchedUser?.DisplayName,
                     IsUsedAsPrimary: isUsedAsPrimary));
             }
@@ -140,8 +142,7 @@ public class GoogleAdminService : IGoogleAdminService
         // Check DB first: reject if the address is already tied to any human in our system.
         // Must run BEFORE the Workspace existence check so a stale/deleted Workspace account
         // cannot silently "move" the identity off its current human.
-        var emailInUse = await _dbContext.UserEmails
-            .AnyAsync(ue => string.Equals(ue.Email, fullEmail, StringComparison.OrdinalIgnoreCase), ct);
+        var emailInUse = await _userEmailService.IsEmailLinkedToAnyUserAsync(fullEmail, ct);
         if (emailInUse)
         {
             _logger.LogWarning(
@@ -151,10 +152,10 @@ public class GoogleAdminService : IGoogleAdminService
                 ErrorMessage: $"{fullEmail} is already in use by another human.");
         }
 
-        var googleEmailInUse = await _dbContext.Users
-            .AnyAsync(u => u.GoogleEmail != null
-                && string.Equals(u.GoogleEmail, fullEmail, StringComparison.OrdinalIgnoreCase), ct);
-        if (googleEmailInUse)
+        // Also reject if the address is set as a User.GoogleEmail (or User.Email) — the
+        // user_emails check covers verified/linked rows, this covers the User row itself.
+        var existingUser = await _userService.GetByEmailOrAlternateAsync(fullEmail, ct);
+        if (existingUser is not null)
         {
             _logger.LogWarning(
                 "Standalone provisioning rejected: {Email} is already set as GoogleEmail for a human",
@@ -166,11 +167,8 @@ public class GoogleAdminService : IGoogleAdminService
         // Reject if the prefix collides with a team's Google Group. Team groups live on
         // the same domain (@nobodies.team), so provisioning a user account with the same
         // address would cause mail-routing chaos and break group membership.
-        var conflictingTeamName = await _dbContext.Teams
-            .Where(t => t.GoogleGroupPrefix != null
-                && string.Equals(t.GoogleGroupPrefix, normalizedPrefix, StringComparison.OrdinalIgnoreCase))
-            .Select(t => t.Name)
-            .FirstOrDefaultAsync(ct);
+        var conflictingTeamName = await _teamService.GetTeamNameByGoogleGroupPrefixAsync(
+            normalizedPrefix, ct);
         if (conflictingTeamName is not null)
         {
             _logger.LogWarning(
@@ -195,8 +193,8 @@ public class GoogleAdminService : IGoogleAdminService
             await _workspaceUserService.ProvisionAccountAsync(
                 fullEmail, firstName.Trim(), lastName.Trim(), tempPassword, ct: ct);
 
-            await _dbContext.SaveChangesAsync(ct);
-
+            // Audit AFTER Google API success — business "save" here is the Workspace-side
+            // provision. No local DB write happens in this flow.
             await _auditLogService.LogAsync(
                 AuditAction.WorkspaceAccountProvisioned,
                 "WorkspaceAccount", Guid.Empty,
@@ -223,8 +221,8 @@ public class GoogleAdminService : IGoogleAdminService
         {
             await _workspaceUserService.SuspendAccountAsync(email, ct);
 
-            await _dbContext.SaveChangesAsync(ct);
-
+            // Audit AFTER Google API success — the "business save" here is the
+            // Workspace-side suspend. No local DB write happens in this flow.
             await _auditLogService.LogAsync(
                 AuditAction.WorkspaceAccountSuspended,
                 "WorkspaceAccount", Guid.Empty,
@@ -250,8 +248,8 @@ public class GoogleAdminService : IGoogleAdminService
         {
             await _workspaceUserService.ReactivateAccountAsync(email, ct);
 
-            await _dbContext.SaveChangesAsync(ct);
-
+            // Audit AFTER Google API success — the "business save" here is the
+            // Workspace-side reactivate. No local DB write happens in this flow.
             await _auditLogService.LogAsync(
                 AuditAction.WorkspaceAccountReactivated,
                 "WorkspaceAccount", Guid.Empty,
@@ -278,8 +276,8 @@ public class GoogleAdminService : IGoogleAdminService
             var newPassword = PasswordGenerator.GenerateTemporary();
             await _workspaceUserService.ResetPasswordAsync(email, newPassword, ct);
 
-            await _dbContext.SaveChangesAsync(ct);
-
+            // Audit AFTER Google API success — the "business save" here is the
+            // Workspace-side password reset. No local DB write happens in this flow.
             await _auditLogService.LogAsync(
                 AuditAction.WorkspaceAccountPasswordReset,
                 "WorkspaceAccount", Guid.Empty,
@@ -305,63 +303,36 @@ public class GoogleAdminService : IGoogleAdminService
     {
         try
         {
-            var user = await _dbContext.Users.FindAsync([userId], ct);
+            var user = await _userService.GetByIdAsync(userId, ct);
             if (user is null)
             {
                 return new WorkspaceAccountActionResult(false,
                     ErrorMessage: "Human not found.");
             }
 
-            // Check not already linked
-            var alreadyLinked = await _dbContext.UserEmails
-                .AnyAsync(ue => EF.Functions.ILike(ue.Email, email), ct);
+            // Check not already linked (case-insensitive, any user)
+            var alreadyLinked = await _userEmailService.IsEmailLinkedToAnyUserAsync(email, ct);
             if (alreadyLinked)
             {
                 return new WorkspaceAccountActionResult(false,
                     ErrorMessage: $"{email} is already linked to a human.");
             }
 
-            // Add as verified email (also sets notification target for @nobodies.team)
+            // Add as verified email (also sets notification target for @nobodies.team).
+            // Self-persists via IUserEmailRepository.
             await _userEmailService.AddVerifiedEmailAsync(userId, email, ct);
 
-            // Auto-set as Google service email and reset sync state
-            user.GoogleEmail = email;
-            user.GoogleEmailStatus = GoogleEmailStatus.Unknown;
-            await _dbContext.SaveChangesAsync(ct);
+            // Auto-set as Google service email and reset sync state (also invalidates
+            // FullProfile). Self-persists via IUserRepository.
+            await _userService.SetGoogleEmailAsync(userId, email, ct);
 
-            // Enqueue re-sync for all current team memberships
-            var memberships = await _dbContext.TeamMembers
-                .Where(tm => tm.UserId == userId && tm.LeftAt == null)
-                .Select(tm => new { tm.Id, tm.TeamId })
-                .ToListAsync(ct);
+            // Enqueue re-sync for all current team memberships — delegated to the
+            // Teams-owning service so google_sync_outbox_events writes stay
+            // colocated with the rest of the outbox flow. Self-persists.
+            await _teamService.EnqueueGoogleResyncForUserTeamsAsync(userId, ct);
 
-            var now = _clock.GetCurrentInstant();
-            foreach (var membership in memberships)
-            {
-                var dedupeKey = $"{membership.Id}:{GoogleSyncOutboxEventTypes.AddUserToTeamResources}:link:{now}";
-                _dbContext.GoogleSyncOutboxEvents.Add(new GoogleSyncOutboxEvent
-                {
-                    Id = Guid.NewGuid(),
-                    EventType = GoogleSyncOutboxEventTypes.AddUserToTeamResources,
-                    TeamId = membership.TeamId,
-                    UserId = userId,
-                    OccurredAt = now,
-                    DeduplicationKey = dedupeKey
-                });
-            }
-
-            if (memberships.Count > 0)
-            {
-                await _dbContext.SaveChangesAsync(ct);
-                _logger.LogInformation(
-                    "Enqueued {Count} re-sync events for user {UserId} after admin email link",
-                    memberships.Count, userId);
-            }
-
-            await _dbContext.SaveChangesAsync(ct);
-
-            // Audit AFTER every SaveChangesAsync in this method — a failing trailing
-            // save would otherwise leave a phantom "linked" audit row.
+            // Audit AFTER every business write completes so a failing upstream call
+            // never leaves a phantom "linked" audit row.
             await _auditLogService.LogAsync(
                 AuditAction.WorkspaceAccountLinked,
                 "WorkspaceAccount", userId,
@@ -394,28 +365,13 @@ public class GoogleAdminService : IGoogleAdminService
 
             try
             {
-                var user = await _dbContext.Users
-                    .Include(u => u.UserEmails)
-                    .FirstOrDefaultAsync(u => u.Id == userId, ct);
+                var (wasUpdated, oldEmail) = await _userService.ApplyEmailBackfillAsync(
+                    userId, googleEmail, ct);
 
-                if (user is null)
+                if (!wasUpdated)
                 {
                     errors.Add($"User {userId} not found.");
                     continue;
-                }
-
-                var oldEmail = user.Email;
-
-                user.Email = googleEmail;
-                user.UserName = googleEmail;
-                user.NormalizedEmail = googleEmail.ToUpperInvariant();
-                user.NormalizedUserName = googleEmail.ToUpperInvariant();
-
-                // Update OAuth UserEmail record if it exists
-                var oauthEmail = user.UserEmails.FirstOrDefault(e => e.IsOAuth);
-                if (oauthEmail is not null)
-                {
-                    oauthEmail.Email = googleEmail;
                 }
 
                 _logger.LogInformation(
@@ -431,9 +387,6 @@ public class GoogleAdminService : IGoogleAdminService
             }
         }
 
-        if (updated > 0)
-            await _dbContext.SaveChangesAsync(ct);
-
         return new EmailBackfillActionResult(updated, errors);
     }
 
@@ -443,34 +396,35 @@ public class GoogleAdminService : IGoogleAdminService
     {
         try
         {
-            var team = await _dbContext.Teams.FindAsync([teamId], ct);
-            if (team is null)
+            var normalizedPrefix = groupPrefix.Trim().ToLowerInvariant();
+            var (updated, previousPrefix) = await _teamService.SetGoogleGroupPrefixAsync(
+                teamId, normalizedPrefix, ct);
+            if (!updated)
             {
                 return new GroupLinkActionResult(false, ErrorMessage: "Team not found.");
             }
 
-            var normalizedPrefix = groupPrefix.Trim().ToLowerInvariant();
-            var previousPrefix = team.GoogleGroupPrefix;
-            team.GoogleGroupPrefix = normalizedPrefix;
+            // Re-fetch for downstream messaging (name).
+            var team = await _teamService.GetTeamByIdAsync(teamId, ct);
+            var teamName = team?.Name ?? teamId.ToString();
 
-            var linkResult = await _googleSyncService.EnsureTeamGroupAsync(teamId);
+            var linkResult = await _googleSyncService.EnsureTeamGroupAsync(teamId, cancellationToken: ct);
             if (linkResult.RequiresConfirmation)
             {
-                await _dbContext.SaveChangesAsync(ct);
                 return new GroupLinkActionResult(true,
-                    InfoMessage: $"Linked group for team \"{team.Name}\". Note: {linkResult.WarningMessage}");
+                    InfoMessage: $"Linked group for team \"{teamName}\". Note: {linkResult.WarningMessage}");
             }
 
             if (linkResult.ErrorMessage is not null)
             {
-                team.GoogleGroupPrefix = previousPrefix;
+                // Revert the prefix on downstream-service failure.
+                await _teamService.SetGoogleGroupPrefixAsync(teamId, previousPrefix, ct);
                 return new GroupLinkActionResult(false,
                     ErrorMessage: $"Could not link group: {linkResult.ErrorMessage}");
             }
 
-            await _dbContext.SaveChangesAsync(ct);
             return new GroupLinkActionResult(true,
-                Message: $"Successfully linked {normalizedPrefix}@nobodies.team to team \"{team.Name}\".");
+                Message: $"Successfully linked {normalizedPrefix}@nobodies.team to team \"{teamName}\".");
         }
         catch (Exception ex)
         {
@@ -483,11 +437,10 @@ public class GoogleAdminService : IGoogleAdminService
     public async Task<IReadOnlyList<TeamSummary>> GetActiveTeamsAsync(
         CancellationToken ct = default)
     {
-        return await _dbContext.Teams
-            .Where(t => t.IsActive)
-            .OrderBy(t => t.Name)
-            .Select(t => new TeamSummary(t.Id, t.Name))
-            .ToListAsync(ct);
+        var options = await _teamService.GetActiveTeamOptionsAsync(ct);
+        return options
+            .Select(o => new TeamSummary(o.Id, o.Name))
+            .ToList();
     }
 
     public async Task<EmailRenameDetectionResult> DetectEmailRenamesAsync(
@@ -495,30 +448,29 @@ public class GoogleAdminService : IGoogleAdminService
     {
         try
         {
-            // Load all users with a @nobodies.team GoogleEmail
-            var usersWithGoogleEmail = await _dbContext.Users
-                .AsNoTracking()
-                .Where(u => u.GoogleEmail != null)
-                .Select(u => new { u.Id, u.DisplayName, u.GoogleEmail })
-                .ToListAsync(ct);
+            // Load all users, then filter to those with a @nobodies.team GoogleEmail.
+            var allUsers = await _userService.GetAllUsersAsync(ct);
 
-            var nobodiesUsers = usersWithGoogleEmail
-                .Where(u => u.GoogleEmail!.EndsWith($"@{NobodiesTeamDomain}", StringComparison.OrdinalIgnoreCase))
+            var nobodiesUsers = allUsers
+                .Where(u => u.GoogleEmail is not null &&
+                    u.GoogleEmail.EndsWith($"@{NobodiesTeamDomain}", StringComparison.OrdinalIgnoreCase))
+                .Select(u => new { u.Id, u.DisplayName, u.GoogleEmail })
                 .ToList();
 
             // Load resource counts per team for affected resource calculation
             var teamResourceCounts = await _teamResourceService.GetActiveResourceCountsByTeamAsync(ct);
 
-            // Load active team memberships per user
-            var userTeamIds = await _dbContext.TeamMembers
-                .Where(tm => tm.LeftAt == null)
-                .Where(tm => nobodiesUsers.Select(u => u.Id).Contains(tm.UserId))
-                .Select(tm => new { tm.UserId, tm.TeamId })
-                .ToListAsync(ct);
-
-            var userTeamLookup = userTeamIds
-                .GroupBy(x => x.UserId)
-                .ToDictionary(g => g.Key, g => g.Select(x => x.TeamId).ToList());
+            // Active team memberships per user — delegated to ITeamService so we
+            // never read team_members directly from here.
+            var userTeamNameLookup = new Dictionary<Guid, IReadOnlyList<Guid>>();
+            foreach (var u in nobodiesUsers)
+            {
+                var memberships = await _teamService.GetUserTeamsAsync(u.Id, ct);
+                userTeamNameLookup[u.Id] = memberships
+                    .Where(m => m.LeftAt == null)
+                    .Select(m => m.TeamId)
+                    .ToList();
+            }
 
             var renames = new List<EmailRenameInfo>();
 
@@ -538,7 +490,7 @@ public class GoogleAdminService : IGoogleAdminService
                     {
                         // Email was renamed
                         var affectedResources = 0;
-                        if (userTeamLookup.TryGetValue(user.Id, out var teamIds))
+                        if (userTeamNameLookup.TryGetValue(user.Id, out var teamIds))
                         {
                             affectedResources = teamIds.Sum(tid =>
                                 teamResourceCounts.TryGetValue(tid, out var count) ? count : 0);
@@ -584,10 +536,7 @@ public class GoogleAdminService : IGoogleAdminService
     {
         try
         {
-            var user = await _dbContext.Users
-                .Include(u => u.UserEmails)
-                .FirstOrDefaultAsync(u => u.Id == userId, ct);
-
+            var user = await _userService.GetByIdAsync(userId, ct);
             if (user is null)
             {
                 return new EmailRenameFixResult(false, ErrorMessage: "Human not found.");
@@ -601,25 +550,24 @@ public class GoogleAdminService : IGoogleAdminService
             }
 
             // Update User.GoogleEmail and reset sync status so reconciliation resumes
-            user.GoogleEmail = newEmail;
-            user.GoogleEmailStatus = GoogleEmailStatus.Unknown;
-
-            // Update the corresponding UserEmail record if one exists for the old email
-            var oldUserEmail = user.UserEmails.FirstOrDefault(ue =>
-                string.Equals(ue.Email, oldEmail, StringComparison.OrdinalIgnoreCase));
-
-            if (oldUserEmail is not null)
+            var updated = await _userService.SetGoogleEmailAsync(userId, newEmail, ct);
+            if (!updated)
             {
-                oldUserEmail.Email = newEmail;
-                oldUserEmail.UpdatedAt = _clock.GetCurrentInstant();
+                return new EmailRenameFixResult(false,
+                    ErrorMessage: "Human not found during update.");
             }
+
+            // Update the corresponding UserEmail row if one exists for the old email —
+            // delegated to the owning section so no user_emails writes happen here.
+            // Self-persists via IUserEmailRepository.
+            await _userEmailService.RewriteEmailAddressAsync(userId, oldEmail, newEmail, ct);
 
             _logger.LogInformation(
                 "Admin {AdminId} fixing email rename for user {UserId}: '{OldEmail}' -> '{NewEmail}'",
                 actorUserId, userId, oldEmail, newEmail);
 
-            await _dbContext.SaveChangesAsync(ct);
-
+            // Audit AFTER every business write completes so a failing upstream call
+            // never leaves a phantom rename audit row.
             await _auditLogService.LogAsync(
                 AuditAction.GoogleEmailRenamed,
                 "User", userId,

--- a/src/Humans.Application/Services/GoogleIntegration/GoogleAdminService.cs
+++ b/src/Humans.Application/Services/GoogleIntegration/GoogleAdminService.cs
@@ -409,35 +409,53 @@ public sealed class GoogleAdminService : IGoogleAdminService
         Guid teamId, string groupPrefix,
         CancellationToken ct = default)
     {
+        var normalizedPrefix = groupPrefix.Trim().ToLowerInvariant();
+
+        (bool updated, string? previousPrefix) setResult;
         try
         {
-            var normalizedPrefix = groupPrefix.Trim().ToLowerInvariant();
-            var (updated, previousPrefix) = await _teamService.SetGoogleGroupPrefixAsync(
+            setResult = await _teamService.SetGoogleGroupPrefixAsync(
                 teamId, normalizedPrefix, ct);
-            if (!updated)
-            {
-                return new GroupLinkActionResult(false, ErrorMessage: "Team not found.");
-            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to link group {GroupPrefix} to team {TeamId}", groupPrefix, teamId);
+            return new GroupLinkActionResult(false,
+                ErrorMessage: $"Failed to link group: {ex.Message}");
+        }
 
-            // Re-fetch for downstream messaging (name).
+        if (!setResult.updated)
+        {
+            return new GroupLinkActionResult(false, ErrorMessage: "Team not found.");
+        }
+
+        // Track whether the prefix write is "committed" (the Google side either
+        // confirmed the group or deferred to a RequiresConfirmation warning the
+        // admin has been told about). If we exit without committing — including
+        // via a thrown exception from EnsureTeamGroupAsync — the finally block
+        // rolls the prefix back so the DB doesn't claim a mapping that Google
+        // never actually got.
+        var committed = false;
+        try
+        {
             var team = await _teamService.GetTeamByIdAsync(teamId, ct);
             var teamName = team?.Name ?? teamId.ToString();
 
             var linkResult = await _googleSyncService.EnsureTeamGroupAsync(teamId, cancellationToken: ct);
             if (linkResult.RequiresConfirmation)
             {
+                committed = true;
                 return new GroupLinkActionResult(true,
                     InfoMessage: $"Linked group for team \"{teamName}\". Note: {linkResult.WarningMessage}");
             }
 
             if (linkResult.ErrorMessage is not null)
             {
-                // Revert the prefix on downstream-service failure.
-                await _teamService.SetGoogleGroupPrefixAsync(teamId, previousPrefix, ct);
                 return new GroupLinkActionResult(false,
                     ErrorMessage: $"Could not link group: {linkResult.ErrorMessage}");
             }
 
+            committed = true;
             return new GroupLinkActionResult(true,
                 Message: $"Successfully linked {normalizedPrefix}@nobodies.team to team \"{teamName}\".");
         }
@@ -446,6 +464,22 @@ public sealed class GoogleAdminService : IGoogleAdminService
             _logger.LogError(ex, "Failed to link group {GroupPrefix} to team {TeamId}", groupPrefix, teamId);
             return new GroupLinkActionResult(false,
                 ErrorMessage: $"Failed to link group: {ex.Message}");
+        }
+        finally
+        {
+            if (!committed)
+            {
+                try
+                {
+                    await _teamService.SetGoogleGroupPrefixAsync(teamId, setResult.previousPrefix, ct);
+                }
+                catch (Exception revertEx)
+                {
+                    _logger.LogError(revertEx,
+                        "Failed to revert GoogleGroupPrefix for team {TeamId} after failed link (prefix remains {Prefix})",
+                        teamId, normalizedPrefix);
+                }
+            }
         }
     }
 

--- a/src/Humans.Application/Services/GoogleIntegration/GoogleAdminService.cs
+++ b/src/Humans.Application/Services/GoogleIntegration/GoogleAdminService.cs
@@ -169,7 +169,7 @@ public sealed class GoogleAdminService : IGoogleAdminService
         // address would cause mail-routing chaos and break group membership.
         var conflictingTeamName = await _teamService.GetTeamNameByGoogleGroupPrefixAsync(
             normalizedPrefix, ct);
-        if (conflictingTeamName is not null)
+        if (!string.IsNullOrEmpty(conflictingTeamName))
         {
             _logger.LogWarning(
                 "Standalone provisioning rejected: {Email} is the Google Group address for team '{TeamName}'",

--- a/src/Humans.Application/Services/Profile/UserEmailService.cs
+++ b/src/Humans.Application/Services/Profile/UserEmailService.cs
@@ -473,6 +473,29 @@ public sealed class UserEmailService : IUserEmailService
         string email, Guid excludeUserId, CancellationToken cancellationToken = default)
         => _repository.GetOtherUserIdHavingEmailAsync(email, excludeUserId, cancellationToken);
 
+    public Task<bool> IsEmailLinkedToAnyUserAsync(
+        string email, CancellationToken cancellationToken = default) =>
+        _repository.AnyWithEmailAsync(email, cancellationToken);
+
+    public async Task RewriteEmailAddressAsync(
+        Guid userId, string oldEmail, string newEmail,
+        CancellationToken cancellationToken = default)
+    {
+        await _repository.RewriteEmailAddressAsync(
+            userId, oldEmail, newEmail, _clock.GetCurrentInstant(), cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<UserEmailMatch>> MatchByEmailsAsync(
+        IReadOnlyCollection<string> emails, CancellationToken cancellationToken = default)
+    {
+        var rows = await _repository.GetByEmailsAsync(emails, cancellationToken);
+        return rows
+            .Select(r => new UserEmailMatch(
+                r.Email, r.UserId, r.IsNotificationTarget, r.IsVerified, r.UpdatedAt))
+            .ToList();
+    }
+
+
     private static List<ContactFieldVisibility> GetAllowedVisibilities(ContactFieldVisibility accessLevel) =>
         accessLevel switch
         {

--- a/src/Humans.Application/Services/Users/UserService.cs
+++ b/src/Humans.Application/Services/Users/UserService.cs
@@ -31,13 +31,17 @@ public sealed class UserService : IUserService, IUserDataContributor
     private readonly IClock _clock;
     private readonly ILogger<UserService> _logger;
 
+    private readonly IUserEmailRepository _userEmailRepo;
+
     public UserService(
         IUserRepository repo,
+        IUserEmailRepository userEmailRepo,
         IFullProfileInvalidator fullProfileInvalidator,
         IClock clock,
         ILogger<UserService> logger)
     {
         _repo = repo;
+        _userEmailRepo = userEmailRepo;
         _fullProfileInvalidator = fullProfileInvalidator;
         _clock = clock;
         _logger = logger;
@@ -93,6 +97,20 @@ public sealed class UserService : IUserService, IUserDataContributor
         if (set)
             await _fullProfileInvalidator.InvalidateAsync(userId, ct);
         return set;
+    }
+
+    public async Task<(bool Updated, string? OldEmail)> ApplyEmailBackfillAsync(
+        Guid userId, string newEmail, CancellationToken ct = default)
+    {
+        var (updated, oldEmail) = await _repo.RewritePrimaryEmailAsync(userId, newEmail, ct);
+        if (!updated)
+            return (false, null);
+
+        // Keep the OAuth UserEmail row in lock-step so login against the new
+        // provider email continues to succeed (no-op if none exists).
+        await _userEmailRepo.RewriteOAuthEmailAsync(userId, newEmail, ct);
+        await _fullProfileInvalidator.InvalidateAsync(userId, ct);
+        return (true, oldEmail);
     }
 
     public async Task UpdateDisplayNameAsync(Guid userId, string displayName, CancellationToken ct = default)

--- a/src/Humans.Infrastructure/Repositories/UserEmailRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/UserEmailRepository.cs
@@ -197,10 +197,20 @@ public sealed class UserEmailRepository : IUserEmailRepository
 
     public async Task<bool> AnyWithEmailAsync(string email, CancellationToken ct = default)
     {
+        // Escape '_' and '%' in the input so ILIKE treats them as literals,
+        // otherwise the collision check can report false positives
+        // (e.g. john_doe@... matching johnXdoe@...).
+        var escaped = EscapeLikePattern(email);
         await using var ctx = await _factory.CreateDbContextAsync(ct);
         return await ctx.UserEmails
-            .AnyAsync(ue => EF.Functions.ILike(ue.Email, email), ct);
+            .AnyAsync(ue => EF.Functions.ILike(ue.Email, escaped, "\\"), ct);
     }
+
+    private static string EscapeLikePattern(string value)
+        => value
+            .Replace("\\", "\\\\")
+            .Replace("%", "\\%")
+            .Replace("_", "\\_");
 
     public async Task<Dictionary<Guid, string>> GetAllNotificationTargetEmailsAsync(
         CancellationToken ct = default)

--- a/src/Humans.Infrastructure/Repositories/UserEmailRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/UserEmailRepository.cs
@@ -248,17 +248,6 @@ public sealed class UserEmailRepository : IUserEmailRepository
             .ToListAsync(ct);
     }
 
-    /// <summary>
-    /// Escapes LIKE/ILIKE wildcard metacharacters so a literal match is
-    /// performed. Must be used with an explicit escape clause, e.g.
-    /// <c>EF.Functions.ILike(x, pattern, "\\")</c>.
-    /// </summary>
-    private static string EscapeLikePattern(string value)
-        => value
-            .Replace("\\", "\\\\")
-            .Replace("%", "\\%")
-            .Replace("_", "\\_");
-
     public async Task<string?> GetVerifiedEmailAddressAsync(
         Guid userId, Guid emailId, CancellationToken ct = default)
     {

--- a/src/Humans.Infrastructure/Repositories/UserEmailRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/UserEmailRepository.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using NodaTime;
 using Humans.Application.DTOs;
 using Humans.Application.Interfaces.Repositories;
 using Humans.Domain.Entities;
@@ -174,6 +175,33 @@ public sealed class UserEmailRepository : IUserEmailRepository
         return true;
     }
 
+    public async Task<IReadOnlyList<UserEmail>> GetByEmailsAsync(
+        IReadOnlyCollection<string> emails, CancellationToken ct = default)
+    {
+        if (emails.Count == 0)
+            return [];
+
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        // Lower-case both sides for a case-insensitive IN comparison.
+        // UserEmail.Email is a plain text column; explicit invariant lowering
+        // keeps the translation provider-neutral. The .NET-side LINQ to Entities
+        // suppression (MA0011) is fine — we already normalize on save.
+#pragma warning disable MA0011 // Use a CultureInfo overload — EF translates ToLower to Postgres lower()
+        var lowered = emails.Select(e => e.ToLowerInvariant()).ToArray();
+        return await ctx.UserEmails
+            .AsNoTracking()
+            .Where(ue => lowered.Contains(ue.Email.ToLower()))
+            .ToListAsync(ct);
+#pragma warning restore MA0011
+    }
+
+    public async Task<bool> AnyWithEmailAsync(string email, CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        return await ctx.UserEmails
+            .AnyAsync(ue => EF.Functions.ILike(ue.Email, email), ct);
+    }
+
     public async Task<Dictionary<Guid, string>> GetAllNotificationTargetEmailsAsync(
         CancellationToken ct = default)
     {
@@ -257,6 +285,37 @@ public sealed class UserEmailRepository : IUserEmailRepository
             .Where(ue => EF.Functions.ILike(ue.Email, escaped, "\\") && ue.UserId != excludeUserId)
             .Select(ue => (Guid?)ue.UserId)
             .FirstOrDefaultAsync(ct);
+    }
+
+    public async Task<bool> RewriteOAuthEmailAsync(
+        Guid userId, string newEmail, CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        var oauth = await ctx.UserEmails
+            .FirstOrDefaultAsync(e => e.UserId == userId && e.IsOAuth, ct);
+        if (oauth is null)
+            return false;
+
+        oauth.Email = newEmail;
+        await ctx.SaveChangesAsync(ct);
+        return true;
+    }
+
+    public async Task<bool> RewriteEmailAddressAsync(
+        Guid userId, string oldEmail, string newEmail, Instant updatedAt,
+        CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        var row = await ctx.UserEmails
+            .FirstOrDefaultAsync(e => e.UserId == userId &&
+                EF.Functions.ILike(e.Email, oldEmail), ct);
+        if (row is null)
+            return false;
+
+        row.Email = newEmail;
+        row.UpdatedAt = updatedAt;
+        await ctx.SaveChangesAsync(ct);
+        return true;
     }
 
     public async Task AddAsync(UserEmail email, CancellationToken ct = default)

--- a/src/Humans.Infrastructure/Repositories/UserRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/UserRepository.cs
@@ -197,8 +197,26 @@ public sealed class UserRepository : IUserRepository
             return false;
 
         user.GoogleEmail = email;
+        user.GoogleEmailStatus = GoogleEmailStatus.Unknown;
         await ctx.SaveChangesAsync(ct);
         return true;
+    }
+
+    public async Task<(bool Updated, string? OldEmail)> RewritePrimaryEmailAsync(
+        Guid userId, string newEmail, CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        var user = await ctx.Users.FindAsync([userId], ct);
+        if (user is null)
+            return (false, null);
+
+        var oldEmail = user.Email;
+        user.Email = newEmail;
+        user.UserName = newEmail;
+        user.NormalizedEmail = newEmail.ToUpperInvariant();
+        user.NormalizedUserName = newEmail.ToUpperInvariant();
+        await ctx.SaveChangesAsync(ct);
+        return (true, oldEmail);
     }
 
     public async Task<bool> SetDeletionPendingAsync(

--- a/src/Humans.Infrastructure/Services/TeamService.cs
+++ b/src/Humans.Infrastructure/Services/TeamService.cs
@@ -316,11 +316,11 @@ public class TeamService : ITeamService, IUserDataContributor
         if (string.IsNullOrWhiteSpace(prefix))
             return null;
 
-        var normalized = prefix.Trim().ToLowerInvariant();
+        var normalized = prefix.Trim();
         return await _dbContext.Teams
             .AsNoTracking()
             .Where(t => t.GoogleGroupPrefix != null
-                && t.GoogleGroupPrefix.ToLower() == normalized)
+                && EF.Functions.ILike(t.GoogleGroupPrefix, normalized))
             .Select(t => t.Name)
             .FirstOrDefaultAsync(cancellationToken);
     }

--- a/src/Humans.Infrastructure/Services/TeamService.cs
+++ b/src/Humans.Infrastructure/Services/TeamService.cs
@@ -316,14 +316,23 @@ public class TeamService : ITeamService, IUserDataContributor
         if (string.IsNullOrWhiteSpace(prefix))
             return null;
 
-        var normalized = prefix.Trim();
+        // Case-insensitive exact match: use ILIKE with an explicit escape so
+        // literal '_' / '%' in the prefix don't act as wildcards and match an
+        // unrelated team.
+        var escaped = EscapeLikePattern(prefix.Trim());
         return await _dbContext.Teams
             .AsNoTracking()
             .Where(t => t.GoogleGroupPrefix != null
-                && EF.Functions.ILike(t.GoogleGroupPrefix, normalized))
+                && EF.Functions.ILike(t.GoogleGroupPrefix, escaped, "\\"))
             .Select(t => t.Name)
             .FirstOrDefaultAsync(cancellationToken);
     }
+
+    private static string EscapeLikePattern(string value)
+        => value
+            .Replace("\\", "\\\\")
+            .Replace("%", "\\%")
+            .Replace("_", "\\_");
 
     public async Task<TeamDirectoryResult> GetTeamDirectoryAsync(
         Guid? userId,

--- a/src/Humans.Infrastructure/Services/TeamService.cs
+++ b/src/Humans.Infrastructure/Services/TeamService.cs
@@ -178,20 +178,6 @@ public class TeamService : ITeamService, IUserDataContributor
             .FirstOrDefaultAsync(t => t.Id == teamId, cancellationToken);
     }
 
-    public async Task<string?> GetTeamNameByGoogleGroupPrefixAsync(
-        string googleGroupPrefix, CancellationToken cancellationToken = default)
-    {
-        if (string.IsNullOrEmpty(googleGroupPrefix))
-            return null;
-
-        return await _dbContext.Teams
-            .AsNoTracking()
-            .Where(t => t.GoogleGroupPrefix != null
-                        && EF.Functions.ILike(t.GoogleGroupPrefix, googleGroupPrefix))
-            .Select(t => t.Name)
-            .FirstOrDefaultAsync(cancellationToken);
-    }
-
     public async Task<IReadOnlyDictionary<Guid, string>> GetTeamNamesByIdsAsync(
         IReadOnlyCollection<Guid> teamIds,
         CancellationToken cancellationToken = default)

--- a/src/Humans.Infrastructure/Services/TeamService.cs
+++ b/src/Humans.Infrastructure/Services/TeamService.cs
@@ -296,6 +296,35 @@ public class TeamService : ITeamService, IUserDataContributor
         return teamIds;
     }
 
+    public async Task<(bool Updated, string? PreviousPrefix)> SetGoogleGroupPrefixAsync(
+        Guid teamId, string? prefix, CancellationToken cancellationToken = default)
+    {
+        var team = await _dbContext.Teams.FindAsync([teamId], cancellationToken);
+        if (team is null)
+            return (false, null);
+
+        var previous = team.GoogleGroupPrefix;
+        team.GoogleGroupPrefix = prefix;
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        _cache.InvalidateActiveTeams();
+        return (true, previous);
+    }
+
+    public async Task<string?> GetTeamNameByGoogleGroupPrefixAsync(
+        string prefix, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(prefix))
+            return null;
+
+        var normalized = prefix.Trim().ToLowerInvariant();
+        return await _dbContext.Teams
+            .AsNoTracking()
+            .Where(t => t.GoogleGroupPrefix != null
+                && t.GoogleGroupPrefix.ToLower() == normalized)
+            .Select(t => t.Name)
+            .FirstOrDefaultAsync(cancellationToken);
+    }
+
     public async Task<TeamDirectoryResult> GetTeamDirectoryAsync(
         Guid? userId,
         CancellationToken cancellationToken = default)

--- a/src/Humans.Web/Extensions/Infrastructure/GoogleWorkspaceInfrastructureExtensions.cs
+++ b/src/Humans.Web/Extensions/Infrastructure/GoogleWorkspaceInfrastructureExtensions.cs
@@ -8,6 +8,7 @@ using Humans.Infrastructure.Services;
 using Humans.Infrastructure.Services.GoogleWorkspace;
 using GoogleWorkspaceUserService = Humans.Application.Services.GoogleIntegration.GoogleWorkspaceUserService;
 using GoogleDriveActivityMonitorService = Humans.Application.Services.GoogleIntegration.DriveActivityMonitorService;
+using GoogleAdminService = Humans.Application.Services.GoogleIntegration.GoogleAdminService;
 
 namespace Humans.Web.Extensions.Infrastructure;
 

--- a/tests/Humans.Application.Tests/Architecture/GoogleAdminArchitectureTests.cs
+++ b/tests/Humans.Application.Tests/Architecture/GoogleAdminArchitectureTests.cs
@@ -1,0 +1,93 @@
+using AwesomeAssertions;
+using Humans.Application.Interfaces;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+using GoogleAdminService = Humans.Application.Services.GoogleIntegration.GoogleAdminService;
+
+namespace Humans.Application.Tests.Architecture;
+
+/// <summary>
+/// Architecture tests enforcing the §15 pattern for the Google Integration
+/// section's <see cref="GoogleAdminService"/> — migrated under issue #554
+/// (split from the umbrella PR into an isolated sub-task). The service now
+/// lives in <c>Humans.Application.Services.GoogleIntegration</c> and routes
+/// all cross-section data access through the owning service interfaces
+/// (<see cref="IUserService"/>, <see cref="IUserEmailService"/>,
+/// <see cref="ITeamService"/>, <see cref="ITeamResourceService"/>). These
+/// tests are the compile-time guarantee that the service never reaches back
+/// into EF Core or another section's tables.
+/// </summary>
+public class GoogleAdminArchitectureTests
+{
+    // ── GoogleAdminService ───────────────────────────────────────────────────
+
+    [Fact]
+    public void GoogleAdminService_LivesInHumansApplicationServicesGoogleIntegrationNamespace()
+    {
+        typeof(GoogleAdminService).Namespace
+            .Should().Be("Humans.Application.Services.GoogleIntegration",
+                because: "services with business logic live in Humans.Application per design-rules §2b, organized by section");
+    }
+
+    [Fact]
+    public void GoogleAdminService_HasNoDbContextConstructorParameter()
+    {
+        var ctor = typeof(GoogleAdminService).GetConstructors().Single();
+        ctor.GetParameters()
+            .Should().NotContain(
+                p => typeof(DbContext).IsAssignableFrom(p.ParameterType),
+                because: "services in Humans.Application must never take DbContext (design-rules §3) — the Google Integration service routes through owning service interfaces");
+    }
+
+    [Fact]
+    public void GoogleAdminService_HasNoDbContextFactoryConstructorParameter()
+    {
+        var ctor = typeof(GoogleAdminService).GetConstructors().Single();
+        var factoryParam = ctor.GetParameters()
+            .FirstOrDefault(p =>
+                p.ParameterType.IsGenericType &&
+                p.ParameterType.GetGenericTypeDefinition() == typeof(IDbContextFactory<>));
+
+        factoryParam.Should().BeNull(
+            because: "IDbContextFactory belongs behind the repository boundary, not in an Application-layer service");
+    }
+
+    [Fact]
+    public void GoogleAdminService_RoutesCrossSectionDataThroughOwningServices()
+    {
+        var ctor = typeof(GoogleAdminService).GetConstructors().Single();
+        var paramTypes = ctor.GetParameters().Select(p => p.ParameterType).ToHashSet();
+
+        // Google Integration owns no user/team/email tables — every cross-section
+        // read routes through the owning service interface per design-rules §9.
+        paramTypes.Should().Contain(typeof(IUserService),
+            because: "cross-section user lookups go through IUserService, not IUserRepository");
+        paramTypes.Should().Contain(typeof(IUserEmailService),
+            because: "cross-section UserEmail lookups go through IUserEmailService");
+        paramTypes.Should().Contain(typeof(ITeamService),
+            because: "cross-section Team reads and the google_sync_outbox_events write path go through ITeamService");
+        paramTypes.Should().Contain(typeof(IGoogleWorkspaceUserService),
+            because: "Google Admin SDK calls go through IGoogleWorkspaceUserService (PR #287 connector), not this service");
+    }
+
+    [Fact]
+    public void GoogleAdminService_IsSealed()
+    {
+        typeof(GoogleAdminService).IsSealed.Should().BeTrue(
+            because: "service implementations are sealed to prevent ad-hoc extension; any new behavior belongs on the interface");
+    }
+
+    [Fact]
+    public void GoogleAdminService_DoesNotReferenceGoogleSdkTypes()
+    {
+        // Paranoid guard: the service's assembly must not pull Google.Apis.*
+        // references indirectly. Google SDK calls live behind IGoogleWorkspaceUserService
+        // (which itself delegates to IWorkspaceUserDirectoryClient in Infrastructure).
+        var assembly = typeof(GoogleAdminService).Assembly;
+        var referenced = assembly.GetReferencedAssemblies();
+        referenced
+            .Should().NotContain(
+                a => (a.Name ?? string.Empty).StartsWith("Google.Apis", StringComparison.Ordinal),
+                because: "Humans.Application must stay free of Google SDK references");
+    }
+}

--- a/tests/Humans.Application.Tests/Services/AccountProvisioningServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/AccountProvisioningServiceTests.cs
@@ -179,6 +179,8 @@ public class AccountProvisioningServiceTests
             throw new NotSupportedException();
         public Task<bool> SetGoogleEmailAsync(Guid userId, string email, CancellationToken ct = default) =>
             throw new NotSupportedException();
+        public Task<(bool Updated, string? OldEmail)> RewritePrimaryEmailAsync(Guid userId, string newEmail, CancellationToken ct = default) =>
+            throw new NotSupportedException();
     }
 
     private sealed class FakeUserEmailRepository : IUserEmailRepository
@@ -256,6 +258,16 @@ public class AccountProvisioningServiceTests
             throw new NotSupportedException();
         public Task<Guid?> GetOtherUserIdHavingEmailAsync(
             string email, Guid excludeUserId, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+        public Task<IReadOnlyList<UserEmail>> GetByEmailsAsync(
+            IReadOnlyCollection<string> emails, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+        public Task<bool> AnyWithEmailAsync(string email, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+        public Task<bool> RewriteOAuthEmailAsync(Guid userId, string newEmail, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+        public Task<bool> RewriteEmailAddressAsync(
+            Guid userId, string oldEmail, string newEmail, Instant now, CancellationToken ct = default) =>
             throw new NotSupportedException();
     }
 

--- a/tests/Humans.Application.Tests/Services/GoogleAdminServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/GoogleAdminServiceTests.cs
@@ -73,7 +73,12 @@ public class GoogleAdminServiceTests
 
         _userEmailService.MatchByEmailsAsync(Arg.Any<IReadOnlyCollection<string>>(), Arg.Any<CancellationToken>())
             .Returns([
-                new UserEmailMatch("alice@nobodies.team", userId, IsNotificationTarget: true)
+                new UserEmailMatch(
+                    "alice@nobodies.team",
+                    userId,
+                    IsNotificationTarget: true,
+                    IsVerified: true,
+                    UpdatedAt: NodaTime.SystemClock.Instance.GetCurrentInstant())
             ]);
 
         _userService.GetByIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
@@ -95,6 +100,52 @@ public class GoogleAdminServiceTests
             string.Equals(a.PrimaryEmail, "alice@nobodies.team", StringComparison.OrdinalIgnoreCase));
         alice.MatchedUserId.Should().Be(userId);
         alice.IsUsedAsPrimary.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task GetWorkspaceAccountListAsync_PicksVerifiedWinner_WhenDuplicateEmailMatches()
+    {
+        // user_emails may hold both a verified and unverified row for the
+        // same address. MatchByEmailsAsync surfaces both; the service must
+        // collapse them rather than throw on the duplicate key.
+        var verifiedUserId = Guid.NewGuid();
+        var unverifiedUserId = Guid.NewGuid();
+        var now = NodaTime.SystemClock.Instance.GetCurrentInstant();
+
+        _workspaceUserService.ListAccountsAsync(Arg.Any<CancellationToken>())
+            .Returns([
+                new WorkspaceUserAccount("dup@nobodies.team", "Dup", "User", false,
+                    DateTime.UtcNow, null),
+            ]);
+
+        _userEmailService.MatchByEmailsAsync(Arg.Any<IReadOnlyCollection<string>>(), Arg.Any<CancellationToken>())
+            .Returns([
+                // Unverified row is newer but must lose to the verified row.
+                new UserEmailMatch(
+                    "dup@nobodies.team", unverifiedUserId,
+                    IsNotificationTarget: false,
+                    IsVerified: false,
+                    UpdatedAt: now),
+                new UserEmailMatch(
+                    "dup@nobodies.team", verifiedUserId,
+                    IsNotificationTarget: true,
+                    IsVerified: true,
+                    UpdatedAt: now - NodaTime.Duration.FromHours(1)),
+            ]);
+
+        _userService.GetByIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<Guid, User>
+            {
+                [verifiedUserId] = new User { Id = verifiedUserId, DisplayName = "Verified User" }
+            });
+
+        var result = await _service.GetWorkspaceAccountListAsync();
+
+        result.ErrorMessage.Should().BeNull();
+        result.TotalAccounts.Should().Be(1);
+        var dup = result.Accounts.Single();
+        dup.MatchedUserId.Should().Be(verifiedUserId);
+        dup.IsUsedAsPrimary.Should().BeTrue();
     }
 
     [Fact]

--- a/tests/Humans.Application.Tests/Services/GoogleAdminServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/GoogleAdminServiceTests.cs
@@ -1,60 +1,60 @@
 using AwesomeAssertions;
+using Humans.Application.DTOs;
 using Humans.Application.Interfaces;
 using Humans.Domain.Entities;
-using Humans.Infrastructure.Data;
-using Humans.Infrastructure.Services;
-using Microsoft.EntityFrameworkCore;
+using Humans.Domain.Enums;
 using Microsoft.Extensions.Logging.Abstractions;
-using NodaTime;
-using NodaTime.Testing;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Xunit;
+using GoogleAdminService = Humans.Application.Services.GoogleIntegration.GoogleAdminService;
 
 namespace Humans.Application.Tests.Services;
 
-public class GoogleAdminServiceTests : IDisposable
+/// <summary>
+/// Unit tests for the migrated Google Integration
+/// <see cref="GoogleAdminService"/>. After the §15 migration the service has
+/// no DbContext dependency — cross-section data access goes through
+/// <see cref="IUserService"/>, <see cref="IUserEmailService"/>,
+/// <see cref="ITeamService"/>, and <see cref="ITeamResourceService"/>. These
+/// tests pin down both the Google Workspace orchestration contract and the
+/// owning-service delegation boundary.
+/// </summary>
+public class GoogleAdminServiceTests
 {
-    private readonly HumansDbContext _dbContext;
     private readonly IGoogleWorkspaceUserService _workspaceUserService;
     private readonly IGoogleSyncService _googleSyncService;
+    private readonly ITeamService _teamService;
+    private readonly ITeamResourceService _teamResourceService;
+    private readonly IUserService _userService;
     private readonly IUserEmailService _userEmailService;
     private readonly IAuditLogService _auditLogService;
     private readonly GoogleAdminService _service;
 
     private readonly Guid _actorUserId = Guid.NewGuid();
 
-
     public GoogleAdminServiceTests()
     {
-        var options = new DbContextOptionsBuilder<HumansDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-
-        _dbContext = new HumansDbContext(options);
         _workspaceUserService = Substitute.For<IGoogleWorkspaceUserService>();
         _googleSyncService = Substitute.For<IGoogleSyncService>();
+        _teamService = Substitute.For<ITeamService>();
+        _teamResourceService = Substitute.For<ITeamResourceService>();
+        _userService = Substitute.For<IUserService>();
         _userEmailService = Substitute.For<IUserEmailService>();
         _auditLogService = Substitute.For<IAuditLogService>();
-        var teamResourceService = Substitute.For<ITeamResourceService>();
-        teamResourceService.GetActiveResourceCountsByTeamAsync(Arg.Any<CancellationToken>())
+
+        _teamResourceService.GetActiveResourceCountsByTeamAsync(Arg.Any<CancellationToken>())
             .Returns(new Dictionary<Guid, int>());
 
         _service = new GoogleAdminService(
-            _dbContext,
             _workspaceUserService,
             _googleSyncService,
-            teamResourceService,
+            _teamService,
+            _teamResourceService,
+            _userService,
             _userEmailService,
             _auditLogService,
-            new FakeClock(Instant.FromUtc(2026, 1, 1, 0, 0)),
             NullLogger<GoogleAdminService>.Instance);
-    }
-
-    public void Dispose()
-    {
-        _dbContext.Dispose();
-        GC.SuppressFinalize(this);
     }
 
     // --- GetWorkspaceAccountListAsync ---
@@ -63,18 +63,6 @@ public class GoogleAdminServiceTests : IDisposable
     public async Task GetWorkspaceAccountListAsync_ReturnsAccountsWithMatchedUsers()
     {
         var userId = Guid.NewGuid();
-        var user = new User { Id = userId, Email = "test@example.com", DisplayName = "Test User" };
-        _dbContext.Users.Add(user);
-        _dbContext.UserEmails.Add(new UserEmail
-        {
-            Id = Guid.NewGuid(),
-            UserId = userId,
-            Email = "alice@nobodies.team",
-            IsVerified = true,
-            IsNotificationTarget = true,
-        });
-        await _dbContext.SaveChangesAsync();
-
         _workspaceUserService.ListAccountsAsync(Arg.Any<CancellationToken>())
             .Returns([
                 new WorkspaceUserAccount("alice@nobodies.team", "Alice", "Smith", false,
@@ -82,6 +70,17 @@ public class GoogleAdminServiceTests : IDisposable
                 new WorkspaceUserAccount("bob@nobodies.team", "Bob", "Jones", true,
                     DateTime.UtcNow, null),
             ]);
+
+        _userEmailService.MatchByEmailsAsync(Arg.Any<IReadOnlyCollection<string>>(), Arg.Any<CancellationToken>())
+            .Returns([
+                new UserEmailMatch("alice@nobodies.team", userId, IsNotificationTarget: true)
+            ]);
+
+        _userService.GetByIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<Guid, User>
+            {
+                [userId] = new User { Id = userId, DisplayName = "Test User" }
+            });
 
         var result = await _service.GetWorkspaceAccountListAsync();
 
@@ -102,7 +101,7 @@ public class GoogleAdminServiceTests : IDisposable
     public async Task GetWorkspaceAccountListAsync_ReturnsErrorOnException()
     {
         _workspaceUserService.ListAccountsAsync(Arg.Any<CancellationToken>())
-            .ThrowsAsync(new Exception("Google API error"));
+            .ThrowsAsync(new InvalidOperationException("Google API error"));
 
         var result = await _service.GetWorkspaceAccountListAsync();
 
@@ -131,7 +130,7 @@ public class GoogleAdminServiceTests : IDisposable
         result.Message.Should().Contain("test@nobodies.team");
 
         await _auditLogService.Received(1).LogAsync(
-            Arg.Any<Domain.Enums.AuditAction>(),
+            Arg.Any<AuditAction>(),
             Arg.Any<string>(), Arg.Any<Guid>(),
             Arg.Any<string>(), _actorUserId,
             Arg.Any<Guid?>(), Arg.Any<string?>());
@@ -154,16 +153,9 @@ public class GoogleAdminServiceTests : IDisposable
     [Fact]
     public async Task ProvisionStandaloneAccountAsync_RejectsWhenPrefixInUseByUserEmail()
     {
-        var ownerId = Guid.NewGuid();
-        _dbContext.Users.Add(new User { Id = ownerId, Email = "x@example.com", DisplayName = "X" });
-        _dbContext.UserEmails.Add(new UserEmail
-        {
-            Id = Guid.NewGuid(),
-            UserId = ownerId,
-            Email = "test@nobodies.team",
-            IsVerified = true,
-        });
-        await _dbContext.SaveChangesAsync();
+        _userEmailService.IsEmailLinkedToAnyUserAsync(
+                "test@nobodies.team", Arg.Any<CancellationToken>())
+            .Returns(true);
 
         var result = await _service.ProvisionStandaloneAccountAsync(
             "test", "Test", "User", _actorUserId);
@@ -188,14 +180,18 @@ public class GoogleAdminServiceTests : IDisposable
     public async Task ProvisionStandaloneAccountAsync_RejectsWhenPrefixInUseByGoogleEmail()
     {
         var ownerId = Guid.NewGuid();
-        _dbContext.Users.Add(new User
-        {
-            Id = ownerId,
-            Email = "x@example.com",
-            DisplayName = "X",
-            GoogleEmail = "test@nobodies.team",
-        });
-        await _dbContext.SaveChangesAsync();
+        _userEmailService.IsEmailLinkedToAnyUserAsync(
+                Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(false);
+        _userService.GetByEmailOrAlternateAsync(
+                "test@nobodies.team", Arg.Any<CancellationToken>())
+            .Returns(new User
+            {
+                Id = ownerId,
+                Email = "x@example.com",
+                DisplayName = "X",
+                GoogleEmail = "test@nobodies.team",
+            });
 
         var result = await _service.ProvisionStandaloneAccountAsync(
             "test", "Test", "User", _actorUserId);
@@ -213,15 +209,15 @@ public class GoogleAdminServiceTests : IDisposable
     [Fact]
     public async Task ProvisionStandaloneAccountAsync_RejectsWhenPrefixCollidesWithTeamGoogleGroup()
     {
-        _dbContext.Teams.Add(new Team
-        {
-            Id = Guid.NewGuid(),
-            Name = "Communications",
-            Slug = "communications",
-            IsActive = true,
-            GoogleGroupPrefix = "comms",
-        });
-        await _dbContext.SaveChangesAsync();
+        _userEmailService.IsEmailLinkedToAnyUserAsync(
+                Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(false);
+        _userService.GetByEmailOrAlternateAsync(
+                Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns((User?)null);
+        _teamService.GetTeamNameByGoogleGroupPrefixAsync(
+                "comms", Arg.Any<CancellationToken>())
+            .Returns("Communications");
 
         var result = await _service.ProvisionStandaloneAccountAsync(
             "comms", "Any", "Name", _actorUserId);
@@ -256,7 +252,7 @@ public class GoogleAdminServiceTests : IDisposable
     public async Task SuspendAccountAsync_ReturnsErrorOnFailure()
     {
         _workspaceUserService.SuspendAccountAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .ThrowsAsync(new Exception("API error"));
+            .ThrowsAsync(new InvalidOperationException("API error"));
 
         var result = await _service.SuspendAccountAsync(
             "test@nobodies.team", _actorUserId);
@@ -302,9 +298,12 @@ public class GoogleAdminServiceTests : IDisposable
     public async Task LinkAccountAsync_LinksEmailAndSetsGoogleEmail()
     {
         var userId = Guid.NewGuid();
-        var user = new User { Id = userId, Email = "test@example.com", DisplayName = "Test User" };
-        _dbContext.Users.Add(user);
-        await _dbContext.SaveChangesAsync();
+        _userService.GetByIdAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(new User { Id = userId, DisplayName = "Test User" });
+        _userEmailService.IsEmailLinkedToAnyUserAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(false);
+        _userService.SetGoogleEmailAsync(userId, "alice@nobodies.team", Arg.Any<CancellationToken>())
+            .Returns(true);
 
         var result = await _service.LinkAccountAsync(
             "alice@nobodies.team", userId, _actorUserId);
@@ -312,17 +311,25 @@ public class GoogleAdminServiceTests : IDisposable
         result.Success.Should().BeTrue();
         result.Message.Should().Contain("Linked");
 
-        // Verify GoogleEmail was set
-        var updatedUser = await _dbContext.Users.FindAsync(userId);
-        updatedUser!.GoogleEmail.Should().Be("alice@nobodies.team");
-
         await _userEmailService.Received(1)
             .AddVerifiedEmailAsync(userId, "alice@nobodies.team", Arg.Any<CancellationToken>());
+        await _userService.Received(1)
+            .SetGoogleEmailAsync(userId, "alice@nobodies.team", Arg.Any<CancellationToken>());
+        await _teamService.Received(1)
+            .EnqueueGoogleResyncForUserTeamsAsync(userId, Arg.Any<CancellationToken>());
+        await _auditLogService.Received(1).LogAsync(
+            AuditAction.WorkspaceAccountLinked,
+            "WorkspaceAccount", userId,
+            Arg.Any<string>(), _actorUserId,
+            Arg.Any<Guid?>(), Arg.Any<string?>());
     }
 
     [Fact]
     public async Task LinkAccountAsync_ReturnsErrorIfUserNotFound()
     {
+        _userService.GetByIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns((User?)null);
+
         var result = await _service.LinkAccountAsync(
             "alice@nobodies.team", Guid.NewGuid(), _actorUserId);
 
@@ -333,25 +340,21 @@ public class GoogleAdminServiceTests : IDisposable
     [Fact]
     public async Task LinkAccountAsync_ReturnsErrorIfEmailConflict()
     {
-        // Note: ILike is not supported by in-memory provider, so this exercises
-        // the error path. The real duplicate check works on PostgreSQL.
         var userId = Guid.NewGuid();
-        var user = new User { Id = userId, Email = "test@example.com", DisplayName = "Test" };
-        _dbContext.Users.Add(user);
-        _dbContext.UserEmails.Add(new UserEmail
-        {
-            Id = Guid.NewGuid(),
-            UserId = userId,
-            Email = "alice@nobodies.team",
-            IsVerified = true,
-        });
-        await _dbContext.SaveChangesAsync();
+        _userService.GetByIdAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(new User { Id = userId, DisplayName = "Test" });
+        _userEmailService.IsEmailLinkedToAnyUserAsync(
+                "alice@nobodies.team", Arg.Any<CancellationToken>())
+            .Returns(true);
 
         var result = await _service.LinkAccountAsync(
             "alice@nobodies.team", userId, _actorUserId);
 
         result.Success.Should().BeFalse();
-        result.ErrorMessage.Should().NotBeNullOrEmpty();
+        result.ErrorMessage.Should().Contain("already linked");
+
+        await _userEmailService.DidNotReceive()
+            .AddVerifiedEmailAsync(Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
     // --- ApplyEmailBackfillAsync ---
@@ -360,24 +363,8 @@ public class GoogleAdminServiceTests : IDisposable
     public async Task ApplyEmailBackfillAsync_UpdatesEmailsAndReturnsCount()
     {
         var userId = Guid.NewGuid();
-        var user = new User
-        {
-            Id = userId,
-            Email = "old@example.com",
-            UserName = "old@example.com",
-            NormalizedEmail = "OLD@EXAMPLE.COM",
-            NormalizedUserName = "OLD@EXAMPLE.COM",
-            DisplayName = "Test",
-        };
-        _dbContext.Users.Add(user);
-        _dbContext.UserEmails.Add(new UserEmail
-        {
-            Id = Guid.NewGuid(),
-            UserId = userId,
-            Email = "old@example.com",
-            IsOAuth = true,
-        });
-        await _dbContext.SaveChangesAsync();
+        _userService.ApplyEmailBackfillAsync(userId, "new@example.com", Arg.Any<CancellationToken>())
+            .Returns((true, "old@example.com"));
 
         var corrections = new Dictionary<string, string>(StringComparer.Ordinal)
         {
@@ -389,24 +376,40 @@ public class GoogleAdminServiceTests : IDisposable
 
         result.UpdatedCount.Should().Be(1);
         result.Errors.Should().BeEmpty();
-
-        var updatedUser = await _dbContext.Users.FindAsync(userId);
-        updatedUser!.Email.Should().Be("new@example.com");
-        updatedUser.NormalizedEmail.Should().Be("NEW@EXAMPLE.COM");
+        await _userService.Received(1).ApplyEmailBackfillAsync(
+            userId, "new@example.com", Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task ApplyEmailBackfillAsync_SkipsUsersWithNoCorrection()
     {
         var userId = Guid.NewGuid();
-        var user = new User { Id = userId, Email = "test@example.com", DisplayName = "Test" };
-        _dbContext.Users.Add(user);
-        await _dbContext.SaveChangesAsync();
 
         var result = await _service.ApplyEmailBackfillAsync(
             [userId], new Dictionary<string, string>(StringComparer.Ordinal), _actorUserId);
 
         result.UpdatedCount.Should().Be(0);
+        await _userService.DidNotReceive().ApplyEmailBackfillAsync(
+            Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ApplyEmailBackfillAsync_RecordsErrorWhenUserMissing()
+    {
+        var userId = Guid.NewGuid();
+        _userService.ApplyEmailBackfillAsync(userId, "new@example.com", Arg.Any<CancellationToken>())
+            .Returns((false, (string?)null));
+
+        var corrections = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            { userId.ToString(), "new@example.com" }
+        };
+
+        var result = await _service.ApplyEmailBackfillAsync(
+            [userId], corrections, _actorUserId);
+
+        result.UpdatedCount.Should().Be(0);
+        result.Errors.Should().ContainSingle().Which.Should().Contain("not found");
     }
 
     // --- LinkGroupToTeamAsync ---
@@ -415,25 +418,28 @@ public class GoogleAdminServiceTests : IDisposable
     public async Task LinkGroupToTeamAsync_LinksGroupAndSaves()
     {
         var teamId = Guid.NewGuid();
-        var team = new Team { Id = teamId, Name = "Test Team", IsActive = true, Slug = "test-team" };
-        _dbContext.Teams.Add(team);
-        await _dbContext.SaveChangesAsync();
-
+        _teamService.SetGoogleGroupPrefixAsync(teamId, "test-team", Arg.Any<CancellationToken>())
+            .Returns((true, (string?)null));
+        _teamService.GetTeamByIdAsync(teamId, Arg.Any<CancellationToken>())
+            .Returns(new Team { Id = teamId, Name = "Test Team", IsActive = true, Slug = "test-team" });
         _googleSyncService.EnsureTeamGroupAsync(teamId, false, Arg.Any<CancellationToken>())
-            .Returns(DTOs.GroupLinkResult.Ok());
+            .Returns(GroupLinkResult.Ok());
 
         var result = await _service.LinkGroupToTeamAsync(teamId, "test-team");
 
         result.Success.Should().BeTrue();
         result.Message.Should().Contain("test-team@nobodies.team");
 
-        var updatedTeam = await _dbContext.Teams.FindAsync(teamId);
-        updatedTeam!.GoogleGroupPrefix.Should().Be("test-team");
+        await _teamService.Received(1).SetGoogleGroupPrefixAsync(
+            teamId, "test-team", Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task LinkGroupToTeamAsync_ReturnsErrorIfTeamNotFound()
     {
+        _teamService.SetGoogleGroupPrefixAsync(Arg.Any<Guid>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns((false, (string?)null));
+
         var result = await _service.LinkGroupToTeamAsync(Guid.NewGuid(), "prefix");
 
         result.Success.Should().BeFalse();
@@ -444,24 +450,21 @@ public class GoogleAdminServiceTests : IDisposable
     public async Task LinkGroupToTeamAsync_RevertsOnError()
     {
         var teamId = Guid.NewGuid();
-        var team = new Team
-        {
-            Id = teamId,
-            Name = "Test Team",
-            IsActive = true,
-            Slug = "test-team",
-            GoogleGroupPrefix = "old-prefix"
-        };
-        _dbContext.Teams.Add(team);
-        await _dbContext.SaveChangesAsync();
-
+        _teamService.SetGoogleGroupPrefixAsync(teamId, "new-prefix", Arg.Any<CancellationToken>())
+            .Returns((true, "old-prefix"));
+        _teamService.GetTeamByIdAsync(teamId, Arg.Any<CancellationToken>())
+            .Returns(new Team { Id = teamId, Name = "Test Team", IsActive = true, Slug = "test-team" });
         _googleSyncService.EnsureTeamGroupAsync(teamId, false, Arg.Any<CancellationToken>())
-            .Returns(DTOs.GroupLinkResult.Error("Failed to create group"));
+            .Returns(GroupLinkResult.Error("Failed to create group"));
 
         var result = await _service.LinkGroupToTeamAsync(teamId, "new-prefix");
 
         result.Success.Should().BeFalse();
         result.ErrorMessage.Should().Contain("Failed to create group");
+
+        // Revert call — first SetGoogleGroupPrefixAsync with the new prefix, then with the previous.
+        await _teamService.Received(1).SetGoogleGroupPrefixAsync(
+            teamId, "old-prefix", Arg.Any<CancellationToken>());
     }
 
     // --- GetActiveTeamsAsync ---
@@ -469,12 +472,11 @@ public class GoogleAdminServiceTests : IDisposable
     [Fact]
     public async Task GetActiveTeamsAsync_ReturnsOnlyActiveTeamsOrdered()
     {
-        await _dbContext.Teams.AddRangeAsync(
-            new Team { Id = Guid.NewGuid(), Name = "Zebra", IsActive = true, Slug = "zebra" },
-            new Team { Id = Guid.NewGuid(), Name = "Alpha", IsActive = true, Slug = "alpha" },
-            new Team { Id = Guid.NewGuid(), Name = "Inactive", IsActive = false, Slug = "inactive" }
-        );
-        await _dbContext.SaveChangesAsync();
+        _teamService.GetActiveTeamOptionsAsync(Arg.Any<CancellationToken>())
+            .Returns([
+                new TeamOptionDto(Guid.NewGuid(), "Alpha"),
+                new TeamOptionDto(Guid.NewGuid(), "Zebra")
+            ]);
 
         var result = await _service.GetActiveTeamsAsync();
 

--- a/tests/Humans.Application.Tests/Services/OnboardingServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/OnboardingServiceTests.cs
@@ -48,8 +48,10 @@ public class OnboardingServiceTests : IDisposable
         // stitched user reads in OnboardingService's BoardVoting methods
         // resolve to the seeded users without extra mocking.
         var userRepo = new UserRepository(new TestDbContextFactory(options));
+        var userEmailRepo = new UserEmailRepository(new TestDbContextFactory(options));
         var userService = new UsersUserService(
-            userRepo, _fullProfileInvalidator, _clock, NullLogger<UsersUserService>.Instance);
+            userRepo, userEmailRepo, _fullProfileInvalidator, _clock,
+            NullLogger<UsersUserService>.Instance);
         _service = new OnboardingService(
             _dbContext, userService, _auditLogService, _emailService, _notificationService,
             _notificationInboxService, _syncJob,

--- a/tests/Humans.Application.Tests/Services/ShiftDashboardMetricsTests.cs
+++ b/tests/Humans.Application.Tests/Services/ShiftDashboardMetricsTests.cs
@@ -765,7 +765,6 @@ public class ShiftDashboardMetricsTests : IDisposable
         public Task<IReadOnlyDictionary<Guid, List<string>>> GetNonSystemTeamNamesByUserIdsAsync(IEnumerable<Guid> userIds, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<IReadOnlyList<TeamOptionDto>> GetActiveTeamOptionsAsync(CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<(bool Updated, string? PreviousPrefix)> SetGoogleGroupPrefixAsync(Guid teamId, string? prefix, CancellationToken cancellationToken = default) => throw new NotSupportedException();
-        public Task<string?> GetTeamNameByGoogleGroupPrefixAsync(string prefix, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<(IReadOnlyList<Team> Items, int TotalCount)> GetAllTeamsForAdminAsync(int page, int pageSize, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<AdminTeamListResult> GetAdminTeamListAsync(int page, int pageSize, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<IReadOnlyList<TeamRosterSlotSummary>> GetRosterAsync(string? priority, string? status, string? period, CancellationToken cancellationToken = default) => throw new NotSupportedException();

--- a/tests/Humans.Application.Tests/Services/ShiftDashboardMetricsTests.cs
+++ b/tests/Humans.Application.Tests/Services/ShiftDashboardMetricsTests.cs
@@ -765,6 +765,7 @@ public class ShiftDashboardMetricsTests : IDisposable
         public Task<IReadOnlyDictionary<Guid, List<string>>> GetNonSystemTeamNamesByUserIdsAsync(IEnumerable<Guid> userIds, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<IReadOnlyList<TeamOptionDto>> GetActiveTeamOptionsAsync(CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<(bool Updated, string? PreviousPrefix)> SetGoogleGroupPrefixAsync(Guid teamId, string? prefix, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<string?> GetTeamNameByGoogleGroupPrefixAsync(string prefix, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<(IReadOnlyList<Team> Items, int TotalCount)> GetAllTeamsForAdminAsync(int page, int pageSize, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<AdminTeamListResult> GetAdminTeamListAsync(int page, int pageSize, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<IReadOnlyList<TeamRosterSlotSummary>> GetRosterAsync(string? priority, string? status, string? period, CancellationToken cancellationToken = default) => throw new NotSupportedException();

--- a/tests/Humans.Application.Tests/Services/ShiftDashboardMetricsTests.cs
+++ b/tests/Humans.Application.Tests/Services/ShiftDashboardMetricsTests.cs
@@ -690,6 +690,7 @@ public class ShiftDashboardMetricsTests : IDisposable
         public Task<IReadOnlyList<User>> GetAllUsersAsync(CancellationToken ct = default) => throw new NotSupportedException();
         public Task<bool> TrySetGoogleEmailAsync(Guid userId, string email, CancellationToken ct = default) => throw new NotSupportedException();
         public Task<bool> SetGoogleEmailAsync(Guid userId, string email, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task<(bool Updated, string? OldEmail)> ApplyEmailBackfillAsync(Guid userId, string newEmail, CancellationToken ct = default) => throw new NotSupportedException();
         public Task UpdateDisplayNameAsync(Guid userId, string displayName, CancellationToken ct = default) => throw new NotSupportedException();
         public Task<bool> SetDeletionPendingAsync(Guid userId, Instant requestedAt, Instant scheduledFor, CancellationToken ct = default) => throw new NotSupportedException();
         public Task<bool> ClearDeletionAsync(Guid userId, CancellationToken ct = default) => throw new NotSupportedException();
@@ -763,6 +764,7 @@ public class ShiftDashboardMetricsTests : IDisposable
         public Task<IReadOnlyDictionary<Guid, string>> GetManagementRoleNamesByTeamIdsAsync(IEnumerable<Guid> teamIds, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<IReadOnlyDictionary<Guid, List<string>>> GetNonSystemTeamNamesByUserIdsAsync(IEnumerable<Guid> userIds, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<IReadOnlyList<TeamOptionDto>> GetActiveTeamOptionsAsync(CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<(bool Updated, string? PreviousPrefix)> SetGoogleGroupPrefixAsync(Guid teamId, string? prefix, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<(IReadOnlyList<Team> Items, int TotalCount)> GetAllTeamsForAdminAsync(int page, int pageSize, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<AdminTeamListResult> GetAdminTeamListAsync(int page, int pageSize, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<IReadOnlyList<TeamRosterSlotSummary>> GetRosterAsync(string? priority, string? status, string? period, CancellationToken cancellationToken = default) => throw new NotSupportedException();


### PR DESCRIPTION
Part of nobodies-collective/Humans#554 — GoogleAdminService split-off. Siblings: #284, #286, #287, #554-driveactivity in flight.

## Summary

- Move `GoogleAdminService` (~589 LOC) from `Humans.Infrastructure/Services/` to `Humans.Application/Services/GoogleIntegration/` per the §15 pattern.
- Remove all direct `HumansDbContext` access. The service owns no DB tables; cross-section data routes through owning service interfaces.
- Delegate `google_sync_outbox_events` writes to `ITeamService.EnqueueGoogleResyncForUserTeamsAsync` so the outbox flow stays colocated with the rest of the team membership sync path.
- Reuse `IGoogleWorkspaceUserService` (introduced by PR #287 for Google Admin SDK access) — no new connector interface needed.

## Owning-service surfaces added

- `IUserService.SetGoogleEmailAsync` / `ApplyEmailBackfillAsync`
- `IUserEmailService.IsEmailLinkedToAnyUserAsync` / `MatchByEmailsAsync` / `RewriteEmailAddressAsync`
- `ITeamService.SetGoogleGroupPrefixAsync`
- Repo-layer: `IUserRepository.SetGoogleEmailAsync` / `RewritePrimaryEmailAsync`; `IUserEmailRepository.RewriteOAuthEmailAsync` / `RewriteEmailAddressAsync` / `AnyWithEmailAsync` / `GetByEmailsAsync`.

## Tests

- `GoogleAdminServiceTests` rewritten against mocked service interfaces (NSubstitute, no in-memory DbContext needed).
- New `GoogleAdminArchitectureTests` enforces §15 placement, no `DbContext` / `IDbContextFactory` parameters, `sealed` class, no `Google.Apis.*` references in `Humans.Application`.
- `UserService` constructor now takes `IUserEmailRepository` for the backfill flow — touched `OnboardingServiceTests` and `ShiftDashboardMetricsTests` fakes accordingly.

## Verification

- `dotnet build Humans.slnx -v quiet` — clean, 0 warnings.
- `dotnet test` — Application tests 1070/1070 pass (Integration tests require Docker, skipped locally).
- `reforge injected HumansDbContext` no longer lists `GoogleAdminService`.
- `reforge dbset-usage Humans.Application.Services.GoogleIntegration.GoogleAdminService` returns 0.
- `dotnet ef migrations add VerifyGoogleAdmin` produced an empty `Up`/`Down` — discarded.
- `docs/architecture/design-rules.md` §15i updated with the partial Google Integration migration and the remaining deferred services.

## Known overlap with PR #251

PR #251 (`#501` provisioning guard) is still OPEN on `origin/main` and touches `GoogleAdminService.ProvisionStandaloneAccountAsync` with DB-first duplicate checks. This PR is based on `origin/main` (pre-#251); the two PRs will need to be landed in order with the later rebased on top. The guard logic translates cleanly onto the new service surface (`IUserEmailService.IsEmailLinkedToAnyUserAsync`, `IUserService.GetByEmailOrAlternateAsync`) — no contract change needed.

## Test plan

- [ ] CI green on peterdrier/Humans preview env
- [ ] Manual smoke in preview: workspace accounts list renders with matched users
- [ ] Manual smoke: link a @nobodies.team account to a human → `User.GoogleEmail` set, resync events enqueued
- [ ] Manual smoke: detect & fix an email rename → `User.GoogleEmail` + `UserEmail.Email` both updated
- [ ] Manual smoke: link a Google Group prefix to a team → prefix persisted, group ensured