### PR TITLE
docs: 2026-04-23 tech debt cleanup plan (post-§15 Part 1)

### DIFF
--- a/docs/architecture/tech-debt-2026-04-23.md
+++ b/docs/architecture/tech-debt-2026-04-23.md
@@ -1,0 +1,145 @@
+# Tech Debt Cleanup Plan — 2026-04-23
+
+Post-§15-Part-1 audit and action plan.
+
+Baseline: `origin/main` at `fc51fcc2` (Notifications §15 migration via #267, all §15 Part 1 PRs merged to peter's fork).
+
+## Pending promotion to upstream
+
+These upstream issues are done in `origin/main` but won't close until the next `upstream/main` promotion. Listed here so the audit reads against the true completion state, not the upstream snapshot:
+
+**§15 Part 1 sections — done**: #542 Camps, #543 City Planning, #544 Budget, #546 Campaigns, #547 Legal, #548 Email, #549 Feedback, #550 Notifications, #551 Auth, #552 Audit Log, #553 Onboarding, #555 Tickets Tailor connector, #556 Stripe, #557 AccountMerge+DuplicateAccount, #558 User AccountProvisioning+Unsubscribe, #559 MembershipCalculator.
+
+**§15 Part 1 sections — partial**: #540 Teams (TeamPageService #270 ✓, TeamResourceService #274 ✓, `TeamService` core remains), #541 Shifts (ShiftManagement #275 ✓, ShiftSignup #276 ✓, GeneralAvailability #269 ✓, residual cross-domain `.Include()` in `ShiftSignupRepository` remains), #545 Tickets (TicketingBudget #272 ✓, TicketSync #277 ✓, TicketQuery #278 ✓ — verify nothing else open), #554 Google Workspace connector (4 sub-services done, `GoogleWorkspaceSyncService` core + bridge/repository remain).
+
+**Non-§15 — done**: #501 Nobodies email prefix check, #518 Admin Reset Password button, #534 Browse Shifts CTA, #536 SignalR rate-limiter exclusion.
+
+## Audit findings
+
+### Critical
+
+**Services still in `Humans.Infrastructure/Services/` injecting `HumansDbContext`**
+
+- `src/Humans.Infrastructure/Services/TeamService.cs:25` — 2,698 LOC, ~50 cross-domain `.Include(…User)` chains. Tracked by #540 (partial).
+- `src/Humans.Infrastructure/Services/GoogleWorkspaceSyncService.cs:29` — injects `DbContext` AND `IDbContextFactory` (mixed). 10+ cross-domain `.Include()` at lines 200, 223, 296, 318, 325–327, 330, 548, 680, 936, 1091, 1116, 1368–1373. Tracked by #554 (partial).
+- `src/Humans.Infrastructure/Services/CalendarService.cs:20` — **not in §15i migration list**. `.Include(e => e.OwningTeam)` at :44 is a §6 violation. Also owns `calendar_events`, missing from the §8 table-ownership map.
+
+**Cross-domain nav reads without `#pragma warning disable CS0618`** — either silent CS0618 spew or fragile to tree-shake:
+
+- `src/Humans.Infrastructure/Services/GoogleWorkspaceSyncService.cs:682–683, 1147–1149, 1482–1493` — `tm.User.GoogleEmailStatus`, `.DisplayName`, `.ProfilePictureUrl`, `.GetGoogleServiceEmail()`. No file-level pragma; relies on include.
+- `src/Humans.Infrastructure/Jobs/SystemTeamSyncJob.cs:130, 134, 157, 161` — `member.User.DisplayName` logged directly.
+- `src/Humans.Infrastructure/Services/TeamService.cs:422, 468, 1468, 2547–2548, 2644–2646` — `m.User.DisplayName`/`.Email`/`.ProfilePictureUrl`. No pragma.
+
+**Repository pattern inconsistency** — 6 repos use old Scoped + `HumansDbContext`; 20 use §15 Singleton + `IDbContextFactory`. These were shipped with §15 migrations that closed as done:
+
+- `src/Humans.Infrastructure/Repositories/BudgetRepository.cs:18` (closed by #544)
+- `src/Humans.Infrastructure/Repositories/CampaignRepository.cs:19` (closed by #546)
+- `src/Humans.Infrastructure/Repositories/FeedbackRepository.cs:18` (closed by #549)
+- `src/Humans.Infrastructure/Repositories/RoleAssignmentRepository.cs:18` (closed by #551)
+- `src/Humans.Infrastructure/Repositories/ApplicationRepository.cs:19` (Governance — acceptable per #533 "no decorator" decision)
+- `src/Humans.Infrastructure/Repositories/ShiftSignupRepository.cs:25` (pending Shifts umbrella #541 final cleanup)
+
+**§15i documentation drift** — `docs/architecture/design-rules.md`:
+
+- `:580` — "~25 services still in `Humans.Infrastructure/Services/`" → reality is **4** business services (Team, GoogleWorkspaceSync, Calendar, HumansMetrics). Rest are connectors/stubs.
+- `:604` — "14 repositories exist today" → reality is **26**.
+- `:592` — "`TeamResourceService` remains in Infrastructure pending #540c" → moved to Application (PR #274).
+- `:586` — "`TicketingBudgetService` remains in Infrastructure … migrates in issue #545" → moved to Application (PR #272).
+- `:593` — "~20 cross-domain `.Include()` calls across ~12 services" → Application layer is now clean (only doc-comments); remaining includes concentrated in Team + GoogleWorkspaceSync.
+
+### Important
+
+**Jobs injecting `HumansDbContext` directly** (§2c violation — should route through service interfaces):
+
+- `src/Humans.Infrastructure/Jobs/ProcessAccountDeletionsJob.cs:29`
+- `src/Humans.Infrastructure/Jobs/ProcessEmailOutboxJob.cs:37` — self-documents the reason at :118 ("DbContext until Campaigns §15 lands" — Campaigns is now landed)
+- `src/Humans.Infrastructure/Jobs/ProcessGoogleSyncOutboxJob.cs:34`
+- `src/Humans.Infrastructure/Jobs/SendAdminDailyDigestJob.cs:30` (file-wide pragma at :14)
+- `src/Humans.Infrastructure/Jobs/SendBoardDailyDigestJob.cs:65–75` — pragma at :13 notes it as §15h follow-up
+- `src/Humans.Infrastructure/Jobs/SendReConsentReminderJob.cs:25`
+- `src/Humans.Infrastructure/Jobs/SuspendNonCompliantMembersJob.cs:32`
+- `src/Humans.Infrastructure/Jobs/SyncLegalDocumentsJob.cs:23`
+- `src/Humans.Infrastructure/Jobs/SystemTeamSyncJob.cs:39`
+- `src/Humans.Infrastructure/Jobs/TermRenewalReminderJob.cs:23`
+
+**Controllers with direct `HumansDbContext`** (§2a; already tracked at §15i:638):
+
+- `src/Humans.Web/Controllers/AdminController.cs:26`
+- `src/Humans.Web/Controllers/ProfileController.cs` (also `IMemoryCache` at :59)
+- `src/Humans.Web/Controllers/GoogleController.cs` (also `IMemoryCache` at :26)
+- `src/Humans.Web/Controllers/DevLoginController.cs:57` (dev-only — low)
+
+**Repositories exposing `SaveChangesAsync`** (§3 anti-pattern; auto-save per method):
+
+- `src/Humans.Infrastructure/Repositories/BudgetRepository.cs:298` — method literally named `SaveChangesAsync`
+- `src/Humans.Infrastructure/Repositories/ApplicationRepository.cs:76, 82, 88, 171`
+- `src/Humans.Infrastructure/Repositories/CampaignRepository.cs:210, 216, 232, 308`
+- `src/Humans.Infrastructure/Repositories/RoleAssignmentRepository.cs:178, 184`
+
+**View components and jobs injecting `IMemoryCache` directly**:
+
+- `src/Humans.Web/ViewComponents/NavBadgesViewComponent.cs:13` — documented 2-min TTL
+- `src/Humans.Web/ViewComponents/NobodiesEmailBadgeViewComponent.cs:10`
+- `src/Humans.Web/ViewComponents/NotificationBellViewComponent.cs:13`
+- `src/Humans.Infrastructure/Jobs/SystemTeamSyncJob.cs:34, 167` — `InvalidateActiveTeams()`; route through an `IActiveTeamsCacheInvalidator` interface instead
+- `src/Humans.Infrastructure/Jobs/ProcessAccountDeletionsJob.cs:24`
+- `src/Humans.Infrastructure/Jobs/SuspendNonCompliantMembersJob.cs:27`
+
+**Composer services in Infrastructure that don't need a repository** — trivial Application moves:
+
+- `src/Humans.Infrastructure/Services/DashboardService.cs:19` — pure composer over `IProfileService`/`IShiftManagementService`/`ITicketQueryService`/`IUserService`
+- `src/Humans.Infrastructure/Services/CampContactService.cs:12` — injects only `IEmailService`/`IAuditLogService`/`IMemoryCache`
+
+**Residual cross-domain `.Include()` in a repository** (pending Shifts umbrella #541):
+
+- `src/Humans.Infrastructure/Repositories/ShiftSignupRepository.cs:98, 108` — `.Include(d => d.User)`, `.Include(s => s.ReviewedByUser)`. Source comments already acknowledge "§15 follow-up".
+
+**Time-sensitive deprecation**:
+
+- `src/Humans.Web/Controllers/HumanRedirectController.cs:11` — `[Obsolete("Temporary redirect shim. Remove after 2026-05-01.")]`. 8 days away — decide delete vs extend now.
+
+### Nice-to-have
+
+**Tracked in-source follow-ups to reconcile into tickets**:
+
+- `src/Humans.Infrastructure/Repositories/BudgetRepository.cs:153` — "keep the `Include` until that PR lands" (BudgetLineItem.ResponsibleTeam strip)
+- `src/Humans.Infrastructure/Jobs/SendBoardDailyDigestJob.cs:13` and `SendAdminDailyDigestJob.cs:13` — both tagged as §15h touch-and-clean
+
+**Pragma-wrapping ceremony** — consider consolidating `#pragma warning disable CS0618` around stitching methods into a helper (`NavStitching.Suppress`) to reduce noise in `ShiftManagementService.cs:301, 319, 346, 496`; `RoleAssignmentService.cs:284`; `FeedbackService.cs:470`.
+
+**EF configuration pragmas are legitimate** — these are the only way to configure `[Obsolete]` navs for EF, keep until the navs are stripped:
+
+- `src/Humans.Infrastructure/Data/Configurations/BudgetAuditLogConfiguration.cs:21`, `BudgetCategoryConfiguration.cs:21`, `CampaignConfiguration.cs:24`, `CampaignGrantConfiguration.cs:33`, `UserConfiguration.cs:43`, `FeedbackReportConfiguration.cs:55`, `FeedbackMessageConfiguration.cs:29`, `RoleAssignmentConfiguration.cs:36`
+
+**Clean sweeps that came up empty** (pleasant surprises):
+
+- Duplicate-method survey — no near-duplicates like the #267 `GetUnvotedApplicationCountAsync` / `GetPendingVoteCountForBoardMemberAsync` dedupe. Clean.
+- Orphan-type survey — no `CachedProfile` / `IProfileStore` / `ProfileStore` / `IApplicationStore` / `IVolunteerHistoryService` / `ProfileStoreWarmupHostedService` references anywhere in `src/` or `tests/`.
+
+**Stale line-number citations** — `docs/sections/Teams.md:92–100` cites `TeamService` violations by line numbers that have drifted. Refresh after TeamService migration lands.
+
+## Action plan — 9 items, in execution order
+
+1. **§15i doc refresh** — new issue. Fix the four inaccurate counts/claims in `design-rules.md` §15i and the §8 table-ownership map (add `calendar_events`). Load-bearing because other tickets reference the §15i state.
+2. **Repository pattern uniformity** — new issue. Flip Budget / Campaigns / Feedback / Auth repositories from Scoped + `HumansDbContext` to §15b canonical Singleton + `IDbContextFactory`. Small, mechanical, 4 sub-tasks in one PR.
+3. **Pragma-strip remaining unwrapped `[Obsolete]` nav reads** — new issue. Either pragma-wrap now as a holding action, or stitch in-memory. Target: `TeamService`, `GoogleWorkspaceSyncService`, `SystemTeamSyncJob`. Decide the stitch-vs-pragma policy once, apply uniformly.
+4. **Low-hanging Application moves** — new issue. `DashboardService` + `CampContactService`. Pure composers; no repository extraction needed. Single session.
+5. **`TeamService` migration** — extend **#540**. TeamPageService and TeamResourceService done (#270, #274); `TeamService` core is the last piece. Adds `ITeamRepository`, moves 2,698 LOC to Application, eliminates ~50 cross-domain `.Include()`. Decorator decision (Option A vs §15-cache) goes in the PR.
+6. **`GoogleWorkspaceSyncService` migration** — extend **#554**. Four sub-services done (#284, #286, #287, #288); `GoogleWorkspaceSyncService` + bridge/repository is the last piece. Migrate to Application, extract `IGoogleDirectoryClient` / `IGoogleGroupClient` bridges, and `IGoogleResourceRepository` for the `google_resources` + `google_sync_outbox_events` tables.
+7. **`CalendarService` migration** — new issue. Add `calendar_events` to §8 table-ownership map, extract `ICalendarRepository`, move `CalendarService` to Application, strip `.Include(e => e.OwningTeam)` in favor of `ITeamService.GetByIdsAsync`.
+8. **Jobs → service-interface routing** — new issue. Route all `Humans.Infrastructure/Jobs/*` through section service interfaces instead of direct `HumansDbContext`. ~10 jobs. Closes the §2c drift. Can be done incrementally.
+9. **`HumanRedirectController` shim** — new issue, time-sensitive. Decide delete vs extend before 2026-05-01 (8 days from today).
+
+## Methodology (for session replay)
+
+Audit ran against `sprint/2026-04-21/issue-550` worktree at HEAD `0d1524e1` (PR #267 — last §15 Part 1 merge-candidate; now merged to `origin/main` as `fc51fcc2`).
+
+Five background agents, parallel:
+
+1. Services still in `Humans.Infrastructure/Services/` + repository DI-registration consistency
+2. Cross-domain `.Include()` chains + duplicate methods + `#pragma warning disable CS0618` sites
+3. `[Obsolete]` nav property read sites + `IMemoryCache` usage from controllers/view-components/jobs
+4. `docs/architecture/design-rules.md` §15i drift + orphaned types
+5. TODO/HACK markers + defensive try/catches + dead code
+
+Two agents used the wrong path (main-repo checkout instead of worktree); findings reconciled against direct file listings of the issue-550 worktree.

--- a/docs/architecture/tech-debt-2026-04-23.md
+++ b/docs/architecture/tech-debt-2026-04-23.md
@@ -120,15 +120,15 @@ These upstream issues are done in `origin/main` but won't close until the next `
 
 ## Action plan — 9 items, in execution order
 
-1. **§15i doc refresh** — new issue. Fix the four inaccurate counts/claims in `design-rules.md` §15i and the §8 table-ownership map (add `calendar_events`). Load-bearing because other tickets reference the §15i state.
-2. **Repository pattern uniformity** — new issue. Flip Budget / Campaigns / Feedback / Auth repositories from Scoped + `HumansDbContext` to §15b canonical Singleton + `IDbContextFactory`. Small, mechanical, 4 sub-tasks in one PR.
-3. **Pragma-strip remaining unwrapped `[Obsolete]` nav reads** — new issue. Either pragma-wrap now as a holding action, or stitch in-memory. Target: `TeamService`, `GoogleWorkspaceSyncService`, `SystemTeamSyncJob`. Decide the stitch-vs-pragma policy once, apply uniformly.
-4. **Low-hanging Application moves** — new issue. `DashboardService` + `CampContactService`. Pure composers; no repository extraction needed. Single session.
-5. **`TeamService` migration** — extend **#540**. TeamPageService and TeamResourceService done (#270, #274); `TeamService` core is the last piece. Adds `ITeamRepository`, moves 2,698 LOC to Application, eliminates ~50 cross-domain `.Include()`. Decorator decision (Option A vs §15-cache) goes in the PR.
-6. **`GoogleWorkspaceSyncService` migration** — extend **#554**. Four sub-services done (#284, #286, #287, #288); `GoogleWorkspaceSyncService` + bridge/repository is the last piece. Migrate to Application, extract `IGoogleDirectoryClient` / `IGoogleGroupClient` bridges, and `IGoogleResourceRepository` for the `google_resources` + `google_sync_outbox_events` tables.
-7. **`CalendarService` migration** — new issue. Add `calendar_events` to §8 table-ownership map, extract `ICalendarRepository`, move `CalendarService` to Application, strip `.Include(e => e.OwningTeam)` in favor of `ITeamService.GetByIdsAsync`.
-8. **Jobs → service-interface routing** — new issue. Route all `Humans.Infrastructure/Jobs/*` through section service interfaces instead of direct `HumansDbContext`. ~10 jobs. Closes the §2c drift. Can be done incrementally.
-9. **`HumanRedirectController` shim** — new issue, time-sensitive. Decide delete vs extend before 2026-05-01 (8 days from today).
+1. **§15i doc refresh** — #565. Fix the four inaccurate counts/claims in `design-rules.md` §15i and the §8 table-ownership map (add `calendar_events`). Load-bearing because other tickets reference the §15i state.
+2. **Repository pattern uniformity** — #566. Flip Budget / Campaigns / Feedback / Auth repositories from Scoped + `HumansDbContext` to §15b canonical Singleton + `IDbContextFactory`. Small, mechanical, 4 sub-tasks in one PR.
+3. **Pragma-strip remaining unwrapped `[Obsolete]` nav reads** — #567. Either pragma-wrap now as a holding action, or stitch in-memory. Target: `TeamService`, `GoogleWorkspaceSyncService`, `SystemTeamSyncJob`. Decide the stitch-vs-pragma policy once, apply uniformly.
+4. **Low-hanging Application moves** — #568. `DashboardService` + `CampContactService`. Pure composers; no repository extraction needed. Single session.
+5. **`TeamService` migration** — extends **#540** (existing umbrella). TeamPageService (#270) and TeamResourceService (#274) done; `TeamService` core is the last piece. Adds `ITeamRepository`, moves 2,698 LOC to Application, eliminates ~50 cross-domain `.Include()`. Decorator decision (Option A vs §15-cache) goes in the PR.
+6. **`GoogleWorkspaceSyncService` migration** — extends **#554** (existing umbrella). Four sub-services done (#284, #286, #287, #288); `GoogleWorkspaceSyncService` + bridge/repository is the last piece. Migrate to Application, extract `IGoogleDirectoryClient` / `IGoogleGroupClient` bridges, and `IGoogleResourceRepository` for the `google_resources` + `google_sync_outbox_events` tables.
+7. **`CalendarService` migration** — #569. Add `calendar_events` to §8 table-ownership map, extract `ICalendarRepository`, move `CalendarService` to Application, strip `.Include(e => e.OwningTeam)` in favor of `ITeamService.GetByIdsAsync`.
+8. **Jobs → service-interface routing** — #570. Route all `Humans.Infrastructure/Jobs/*` through section service interfaces instead of direct `HumansDbContext`. ~10 jobs. Closes the §2c drift. Can be done incrementally.
+9. **`HumanRedirectController` shim** — #571, time-sensitive. Decide delete vs extend before 2026-05-01 (8 days from today).
 
 ## Methodology (for session replay)
 


### PR DESCRIPTION
## Summary

- Parallel-agent audit of the codebase against design-rules.md §15 after PR #267 (Notifications) merged
- Prioritized findings list (Critical / Important / Nice-to-have) with file:line citations
- 9-item action plan in execution order — 7 new issues + extensions to #540 and #554

## Context

Runs the audit against `origin/main` (at `fc51fcc2`), not `upstream/main` — upstream is ~42 commits behind and doesn't yet reflect the 15+ §15 Part 1 sections that shipped this sprint. The "Pending promotion to upstream" section lists every issue that is effectively done in origin but still open on nobodies-collective/Humans, so reviewers don't double-count.

## Notable corrections to §15i

- Claims "~25 services in Infrastructure/Services" → actual is 4 business services
- Claims "14 repositories" → actual is 26
- Lists TeamResourceService / TicketingBudgetService as unmigrated → both already moved
- `calendar_events` is missing from the §8 table-ownership map

## What this PR is / isn't

**Is**: the cleanup roadmap for today's session.
**Isn't**: code changes. The 9 issues created alongside this PR are the executable units.

## Test plan

- [ ] Plan doc renders cleanly on GitHub
- [ ] All 9 action items have corresponding issues/extensions tracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)