### PR TITLE
Move DashboardService + CampContactService to Humans.Application

### DIFF
--- a/src/Humans.Application/Services/Camps/CampContactService.cs
+++ b/src/Humans.Application/Services/Camps/CampContactService.cs
@@ -7,7 +7,7 @@ using Humans.Domain.Enums;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 
-namespace Humans.Infrastructure.Services;
+namespace Humans.Application.Services.Camps;
 
 public class CampContactService : ICampContactService
 {

--- a/src/Humans.Application/Services/Dashboard/DashboardService.cs
+++ b/src/Humans.Application/Services/Dashboard/DashboardService.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.Options;
 using NodaTime;
 using MemberApplication = Humans.Domain.Entities.Application;
 
-namespace Humans.Infrastructure.Services;
+namespace Humans.Application.Services.Dashboard;
 
 /// <summary>
 /// Orchestrates the member dashboard snapshot. Pulls from several owning services

--- a/src/Humans.Web/Extensions/Sections/CampsSectionExtensions.cs
+++ b/src/Humans.Web/Extensions/Sections/CampsSectionExtensions.cs
@@ -3,6 +3,7 @@ using Humans.Application.Interfaces.Gdpr;
 using Humans.Application.Interfaces.Repositories;
 using Humans.Infrastructure.Repositories;
 using Humans.Infrastructure.Services;
+using CampsCampContactService = Humans.Application.Services.Camps.CampContactService;
 using CampsCampService = Humans.Application.Services.Camps.CampService;
 
 namespace Humans.Web.Extensions.Sections;
@@ -18,7 +19,7 @@ internal static class CampsSectionExtensions
         services.AddScoped<ICampService>(sp => sp.GetRequiredService<CampsCampService>());
         services.AddScoped<IUserDataContributor>(sp => sp.GetRequiredService<CampsCampService>());
 
-        services.AddScoped<ICampContactService, CampContactService>();
+        services.AddScoped<ICampContactService, CampsCampContactService>();
 
         return services;
     }

--- a/src/Humans.Web/Extensions/Sections/UsersSectionExtensions.cs
+++ b/src/Humans.Web/Extensions/Sections/UsersSectionExtensions.cs
@@ -2,7 +2,7 @@ using Humans.Application.Interfaces;
 using Humans.Application.Interfaces.Gdpr;
 using Humans.Application.Interfaces.Repositories;
 using Humans.Infrastructure.Repositories;
-using Humans.Infrastructure.Services;
+using DashboardDashboardService = Humans.Application.Services.Dashboard.DashboardService;
 using GovernanceMembershipCalculator = Humans.Application.Services.Governance.MembershipCalculator;
 using GovernanceMembershipQuery = Humans.Application.Services.Governance.MembershipQuery;
 using UsersUserService = Humans.Application.Services.Users.UserService;
@@ -29,7 +29,7 @@ internal static class UsersSectionExtensions
         // Only MembershipCalculator depends on the query adapter.
         services.AddScoped<IMembershipQuery, GovernanceMembershipQuery>();
         services.AddScoped<IMembershipCalculator, GovernanceMembershipCalculator>();
-        services.AddScoped<IDashboardService, DashboardService>();
+        services.AddScoped<IDashboardService, DashboardDashboardService>();
 
         return services;
     }

--- a/tests/Humans.Application.Tests/Services/CampContactServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/CampContactServiceTests.cs
@@ -1,6 +1,6 @@
 using AwesomeAssertions;
 using Humans.Application.Interfaces;
-using Humans.Infrastructure.Services;
+using Humans.Application.Services.Camps;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;


### PR DESCRIPTION
Closes #568

Part of peterdrier/Humans#292 wave 1. Relocates two pure-composer services (no DbContext, no repositories) from Infrastructure to Application, closing §2b violations. No behavior change.