### PR TITLE
Flip Campaign/Feedback/RoleAssignment repos to §15b Singleton + IDbContextFactory

### DIFF
--- a/src/Humans.Application/Interfaces/Repositories/ICampaignRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/ICampaignRepository.cs
@@ -23,13 +23,14 @@ public interface ICampaignRepository
     Task<Campaign?> GetByIdAsync(Guid id, CancellationToken ct = default);
 
     /// <summary>
-    /// Find a campaign for update — no navigation. Returns a tracked entity.
+    /// Load a campaign for update via <see cref="UpdateCampaignAsync"/> —
+    /// no navigation. Returns a detached entity.
     /// </summary>
     Task<Campaign?> FindForMutationAsync(Guid id, CancellationToken ct = default);
 
     /// <summary>
-    /// Find a campaign for update with its codes loaded (used during
-    /// activation and code import).
+    /// Load a campaign for update with its codes loaded (used during
+    /// activation and code import). Returns a detached entity.
     /// </summary>
     Task<Campaign?> FindForMutationWithCodesAsync(Guid id, CancellationToken ct = default);
 
@@ -55,15 +56,25 @@ public interface ICampaignRepository
     Task<IReadOnlyList<CampaignCodeTrackingGrantRow>> GetCodeTrackingGrantRowsAsync(
         CancellationToken ct = default);
 
-    /// <summary>Stage a new campaign in the change tracker.</summary>
-    void AddCampaign(Campaign campaign);
+    /// <summary>Persists a new campaign. Commits immediately.</summary>
+    Task AddCampaignAsync(Campaign campaign, CancellationToken ct = default);
+
+    /// <summary>
+    /// Persists changes to a mutated campaign (obtained via
+    /// <see cref="FindForMutationAsync"/> or <see cref="FindForMutationWithCodesAsync"/>).
+    /// Commits immediately.
+    /// </summary>
+    Task UpdateCampaignAsync(Campaign campaign, CancellationToken ct = default);
 
     // ==========================================================================
     // Campaign Codes
     // ==========================================================================
 
-    /// <summary>Stage a new campaign code in the change tracker.</summary>
-    void AddCampaignCode(CampaignCode code);
+    /// <summary>
+    /// Persists a batch of new campaign codes atomically. No-op when the list
+    /// is empty.
+    /// </summary>
+    Task AddCampaignCodesAsync(IReadOnlyList<CampaignCode> codes, CancellationToken ct = default);
 
     /// <summary>
     /// Returns available codes (not yet granted) for a campaign, ordered by
@@ -144,12 +155,6 @@ public interface ICampaignRepository
     Task<IReadOnlyList<GrantExportRow>> GetGrantsForUserExportAsync(
         Guid userId, CancellationToken ct = default);
 
-    // ==========================================================================
-    // Unit-of-work
-    // ==========================================================================
-
-    /// <summary>Commit staged changes in the change tracker.</summary>
-    Task SaveChangesAsync(CancellationToken ct = default);
 }
 
 /// <summary>

--- a/src/Humans.Application/Interfaces/Repositories/IFeedbackRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/IFeedbackRepository.cs
@@ -16,9 +16,9 @@ namespace Humans.Application.Interfaces.Repositories;
 /// stitch display data from <c>IUserService</c>, <c>IUserEmailService</c>, and
 /// <c>ITeamService</c>.
 ///
-/// Feedback is admin-review-only and low-traffic, so the repository uses the
-/// Scoped + <c>HumansDbContext</c> pattern (like <c>ApplicationRepository</c>)
-/// rather than the Singleton + <c>IDbContextFactory</c> pattern.
+/// Feedback is admin-review-only and low-traffic. The repository uses the
+/// Singleton + <c>IDbContextFactory</c> pattern so each method owns its own
+/// <c>HumansDbContext</c> lifetime.
 /// </remarks>
 public interface IFeedbackRepository
 {
@@ -35,8 +35,9 @@ public interface IFeedbackRepository
     Task<FeedbackReport?> GetByIdAsync(Guid id, CancellationToken ct = default);
 
     /// <summary>
-    /// Loads a tracked feedback report for mutation (no navigation included).
-    /// Returns null if not found.
+    /// Loads a feedback report by id (no navigation included) for mutation
+    /// via <see cref="SaveTrackedReportAsync"/> or
+    /// <see cref="AddMessageAndSaveReportAsync"/>. Returns null if not found.
     /// </summary>
     Task<FeedbackReport?> FindForMutationAsync(Guid id, CancellationToken ct = default);
 

--- a/src/Humans.Application/Interfaces/Repositories/IRoleAssignmentRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/IRoleAssignmentRepository.cs
@@ -13,9 +13,8 @@ namespace Humans.Application.Interfaces.Repositories;
 /// in the Application layer stitch display data from <c>IUserService</c>.
 ///
 /// Auth is low-traffic (handful of admin writes per month, a few reads per
-/// day), so the repository uses the Scoped + <c>HumansDbContext</c> pattern
-/// (like <c>ApplicationRepository</c>) rather than the Singleton +
-/// <c>IDbContextFactory</c> pattern.
+/// day). The repository uses the Singleton + <c>IDbContextFactory</c> pattern
+/// so each method owns its own <c>HumansDbContext</c> lifetime.
 /// </remarks>
 public interface IRoleAssignmentRepository
 {
@@ -24,8 +23,9 @@ public interface IRoleAssignmentRepository
     // ==========================================================================
 
     /// <summary>
-    /// Loads a single role assignment by id, tracked for mutation. Cross-domain
-    /// navs are NOT populated. Returns null if the assignment does not exist.
+    /// Loads a single role assignment by id for mutation via
+    /// <see cref="UpdateAsync"/>. Cross-domain navs are NOT populated.
+    /// Returns null if the assignment does not exist.
     /// </summary>
     Task<RoleAssignment?> FindForMutationAsync(Guid assignmentId, CancellationToken ct = default);
 
@@ -107,8 +107,9 @@ public interface IRoleAssignmentRepository
         CancellationToken ct = default);
 
     /// <summary>
-    /// All currently-active assignments for the user, tracked for mutation.
-    /// Used by <c>RevokeAllActiveAsync</c> to stamp <c>ValidTo</c> on each.
+    /// All currently-active assignments for the user for mutation via
+    /// <see cref="UpdateManyAsync"/>. Used by <c>RevokeAllActiveAsync</c> to
+    /// stamp <c>ValidTo</c> on each.
     /// </summary>
     Task<IReadOnlyList<RoleAssignment>> GetActiveForUserForMutationAsync(
         Guid userId,
@@ -134,8 +135,15 @@ public interface IRoleAssignmentRepository
     Task AddAsync(RoleAssignment assignment, CancellationToken ct = default);
 
     /// <summary>
-    /// Persists changes to a tracked assignment (obtained via
-    /// <see cref="FindForMutationAsync"/> or <see cref="GetActiveForUserForMutationAsync"/>).
+    /// Persists changes to a mutated assignment (obtained via
+    /// <see cref="FindForMutationAsync"/>). Commits immediately.
     /// </summary>
-    Task SaveTrackedAsync(CancellationToken ct = default);
+    Task UpdateAsync(RoleAssignment assignment, CancellationToken ct = default);
+
+    /// <summary>
+    /// Persists changes to a list of mutated assignments (obtained via
+    /// <see cref="GetActiveForUserForMutationAsync"/>). Commits all in one
+    /// transaction. No-op when the list is empty.
+    /// </summary>
+    Task UpdateManyAsync(IReadOnlyList<RoleAssignment> assignments, CancellationToken ct = default);
 }

--- a/src/Humans.Application/Services/Auth/RoleAssignmentService.cs
+++ b/src/Humans.Application/Services/Auth/RoleAssignmentService.cs
@@ -188,7 +188,7 @@ public sealed class RoleAssignmentService : IRoleAssignmentService, IUserDataCon
                 : $"{roleAssignment.Notes} | Ended: {notes}";
         }
 
-        await _repository.SaveTrackedAsync(ct);
+        await _repository.UpdateAsync(roleAssignment, ct);
 
         await _auditLogService.LogAsync(
             AuditAction.RoleEnded, nameof(User), roleAssignment.UserId,
@@ -260,7 +260,7 @@ public sealed class RoleAssignmentService : IRoleAssignmentService, IUserDataCon
             role.ValidTo = now;
         }
 
-        await _repository.SaveTrackedAsync(ct);
+        await _repository.UpdateManyAsync(activeRoles, ct);
         _claimsInvalidator.Invalidate(userId);
 
         return activeRoles.Count;

--- a/src/Humans.Application/Services/Campaigns/CampaignService.cs
+++ b/src/Humans.Application/Services/Campaigns/CampaignService.cs
@@ -74,8 +74,7 @@ public sealed class CampaignService : ICampaignService, IUserDataContributor
             CreatedByUserId = createdByUserId
         };
 
-        _repository.AddCampaign(campaign);
-        await _repository.SaveChangesAsync(ct);
+        await _repository.AddCampaignAsync(campaign, ct);
 
         _logger.LogInformation("Campaign {CampaignId} created: {Title}", campaign.Id, title);
         return campaign;
@@ -111,7 +110,7 @@ public sealed class CampaignService : ICampaignService, IUserDataContributor
         campaign.EmailBodyTemplate = emailBodyTemplate.Trim();
         campaign.ReplyToAddress = string.IsNullOrWhiteSpace(replyToAddress) ? null : replyToAddress.Trim();
 
-        await _repository.SaveChangesAsync(ct);
+        await _repository.UpdateCampaignAsync(campaign, ct);
 
         _logger.LogInformation("Campaign {CampaignId} updated", id);
         return true;
@@ -182,6 +181,7 @@ public sealed class CampaignService : ICampaignService, IUserDataContributor
         var imported = 0;
         var skipped = 0;
         var maxOrder = campaign.Codes.Any() ? campaign.Codes.Max(c => c.ImportOrder) : 0;
+        var newCodes = new List<CampaignCode>();
 
         foreach (var code in codes)
         {
@@ -196,7 +196,7 @@ public sealed class CampaignService : ICampaignService, IUserDataContributor
             }
 
             maxOrder++;
-            _repository.AddCampaignCode(new CampaignCode
+            newCodes.Add(new CampaignCode
             {
                 Id = Guid.NewGuid(),
                 CampaignId = campaignId,
@@ -208,7 +208,7 @@ public sealed class CampaignService : ICampaignService, IUserDataContributor
             imported++;
         }
 
-        await _repository.SaveChangesAsync(ct);
+        await _repository.AddCampaignCodesAsync(newCodes, ct);
 
         _logger.LogInformation(
             "Campaign {CampaignId}: imported {Imported} codes, skipped {Skipped} duplicates",
@@ -223,11 +223,12 @@ public sealed class CampaignService : ICampaignService, IUserDataContributor
 
         var now = _clock.GetCurrentInstant();
         var maxOrder = campaign.Codes.Any() ? campaign.Codes.Max(c => c.ImportOrder) : 0;
+        var newCodes = new List<CampaignCode>(codes.Count);
 
         foreach (var code in codes)
         {
             maxOrder++;
-            _repository.AddCampaignCode(new CampaignCode
+            newCodes.Add(new CampaignCode
             {
                 Id = Guid.NewGuid(),
                 CampaignId = campaignId,
@@ -237,7 +238,7 @@ public sealed class CampaignService : ICampaignService, IUserDataContributor
             });
         }
 
-        await _repository.SaveChangesAsync(ct);
+        await _repository.AddCampaignCodesAsync(newCodes, ct);
 
         _logger.LogInformation(
             "Campaign {CampaignId}: imported {Count} vendor-generated codes",
@@ -263,7 +264,7 @@ public sealed class CampaignService : ICampaignService, IUserDataContributor
                 campaignId);
 
         campaign.Status = CampaignStatus.Active;
-        await _repository.SaveChangesAsync(ct);
+        await _repository.UpdateCampaignAsync(campaign, ct);
 
         _logger.LogInformation("Campaign {CampaignId} activated", campaignId);
     }
@@ -278,7 +279,7 @@ public sealed class CampaignService : ICampaignService, IUserDataContributor
                 $"Campaign {campaignId} must be in Active status to complete (current: {campaign.Status}).");
 
         campaign.Status = CampaignStatus.Completed;
-        await _repository.SaveChangesAsync(ct);
+        await _repository.UpdateCampaignAsync(campaign, ct);
 
         _logger.LogInformation("Campaign {CampaignId} completed", campaignId);
     }

--- a/src/Humans.Infrastructure/Repositories/CampaignRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/CampaignRepository.cs
@@ -13,14 +13,16 @@ namespace Humans.Infrastructure.Repositories;
 /// non-test file that touches <c>DbContext.Campaigns</c>,
 /// <c>DbContext.CampaignCodes</c>, or <c>DbContext.CampaignGrants</c> after
 /// the Campaigns migration lands.
+/// Uses <see cref="IDbContextFactory{TContext}"/> so the repository can be
+/// registered as Singleton while <c>HumansDbContext</c> remains Scoped.
 /// </summary>
 public sealed class CampaignRepository : ICampaignRepository
 {
-    private readonly HumansDbContext _dbContext;
+    private readonly IDbContextFactory<HumansDbContext> _factory;
 
-    public CampaignRepository(HumansDbContext dbContext)
+    public CampaignRepository(IDbContextFactory<HumansDbContext> factory)
     {
-        _dbContext = dbContext;
+        _factory = factory;
     }
 
     // ==========================================================================
@@ -32,28 +34,35 @@ public sealed class CampaignRepository : ICampaignRepository
         // Grants' User navigation is cross-domain and tagged obsolete in the
         // entity; we don't include it here. Consumers that need display names
         // for recipients resolve via IUserService keyed off CampaignGrant.UserId.
-        return await _dbContext.Campaigns
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        return await ctx.Campaigns
             .Include(c => c.Codes)
             .Include(c => c.Grants).ThenInclude(g => g.Code)
             .AsSplitQuery()
             .FirstOrDefaultAsync(c => c.Id == id, ct);
     }
 
-    public Task<Campaign?> FindForMutationAsync(Guid id, CancellationToken ct = default)
+    public async Task<Campaign?> FindForMutationAsync(Guid id, CancellationToken ct = default)
     {
-        return _dbContext.Campaigns.FirstOrDefaultAsync(c => c.Id == id, ct);
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        return await ctx.Campaigns
+            .AsNoTracking()
+            .FirstOrDefaultAsync(c => c.Id == id, ct);
     }
 
-    public Task<Campaign?> FindForMutationWithCodesAsync(Guid id, CancellationToken ct = default)
+    public async Task<Campaign?> FindForMutationWithCodesAsync(Guid id, CancellationToken ct = default)
     {
-        return _dbContext.Campaigns
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        return await ctx.Campaigns
+            .AsNoTracking()
             .Include(c => c.Codes)
             .FirstOrDefaultAsync(c => c.Id == id, ct);
     }
 
     public async Task<List<Campaign>> GetAllAsync(CancellationToken ct = default)
     {
-        return await _dbContext.Campaigns
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        return await ctx.Campaigns
             .Include(c => c.Codes)
             .Include(c => c.Grants)
             .AsSplitQuery()
@@ -64,7 +73,8 @@ public sealed class CampaignRepository : ICampaignRepository
     public async Task<IReadOnlyList<CampaignCodeTrackingSummaryRow>> GetCodeTrackingSummariesAsync(
         CancellationToken ct = default)
     {
-        return await _dbContext.Campaigns
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        return await ctx.Campaigns
             .AsNoTracking()
             .Where(c => c.Status == CampaignStatus.Active || c.Status == CampaignStatus.Completed)
             .OrderByDescending(c => c.CreatedAt)
@@ -77,7 +87,8 @@ public sealed class CampaignRepository : ICampaignRepository
     {
         // Projected flat rows — no cross-domain .Include on CampaignGrant.User;
         // recipient display names are resolved by the service via IUserService.
-        return await _dbContext.CampaignGrants
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        return await ctx.CampaignGrants
             .AsNoTracking()
             .Where(g => g.Campaign.Status == CampaignStatus.Active
                 || g.Campaign.Status == CampaignStatus.Completed)
@@ -92,20 +103,42 @@ public sealed class CampaignRepository : ICampaignRepository
             .ToListAsync(ct);
     }
 
-    public void AddCampaign(Campaign campaign) => _dbContext.Campaigns.Add(campaign);
+    public async Task AddCampaignAsync(Campaign campaign, CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        ctx.Campaigns.Add(campaign);
+        await ctx.SaveChangesAsync(ct);
+    }
+
+    public async Task UpdateCampaignAsync(Campaign campaign, CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        ctx.Attach(campaign);
+        ctx.Entry(campaign).State = EntityState.Modified;
+        await ctx.SaveChangesAsync(ct);
+    }
 
     // ==========================================================================
     // Campaign Codes
     // ==========================================================================
 
-    public void AddCampaignCode(CampaignCode code) => _dbContext.CampaignCodes.Add(code);
+    public async Task AddCampaignCodesAsync(IReadOnlyList<CampaignCode> codes, CancellationToken ct = default)
+    {
+        if (codes.Count == 0)
+            return;
+
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        ctx.CampaignCodes.AddRange(codes);
+        await ctx.SaveChangesAsync(ct);
+    }
 
     public async Task<IReadOnlyList<CampaignCode>> GetAvailableCodesAsync(
         Guid campaignId, int limit, CancellationToken ct = default)
     {
-        return await _dbContext.CampaignCodes
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        return await ctx.CampaignCodes
             .Where(c => c.CampaignId == campaignId
-                && !_dbContext.CampaignGrants.Any(g => g.CampaignCodeId == c.Id))
+                && !ctx.CampaignGrants.Any(g => g.CampaignCodeId == c.Id))
             .OrderBy(c => c.ImportOrder)
             .Take(limit)
             .ToListAsync(ct);
@@ -113,9 +146,10 @@ public sealed class CampaignRepository : ICampaignRepository
 
     public async Task<int> CountAvailableCodesAsync(Guid campaignId, CancellationToken ct = default)
     {
-        return await _dbContext.CampaignCodes
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        return await ctx.CampaignCodes
             .Where(c => c.CampaignId == campaignId
-                && !_dbContext.CampaignGrants.Any(g => g.CampaignCodeId == c.Id))
+                && !ctx.CampaignGrants.Any(g => g.CampaignCodeId == c.Id))
             .CountAsync(ct);
     }
 
@@ -126,7 +160,8 @@ public sealed class CampaignRepository : ICampaignRepository
     public async Task<IReadOnlyList<CampaignGrant>> GetActiveOrCompletedGrantsForUserAsync(
         Guid userId, CancellationToken ct = default)
     {
-        return await _dbContext.CampaignGrants
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        return await ctx.CampaignGrants
             .AsNoTracking()
             .Include(g => g.Campaign)
             .Include(g => g.Code)
@@ -139,7 +174,8 @@ public sealed class CampaignRepository : ICampaignRepository
     public async Task<IReadOnlyList<CampaignGrant>> GetAllGrantsForUserAsync(
         Guid userId, CancellationToken ct = default)
     {
-        return await _dbContext.CampaignGrants
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        return await ctx.CampaignGrants
             .AsNoTracking()
             .Include(g => g.Campaign)
             .Include(g => g.Code)
@@ -151,7 +187,8 @@ public sealed class CampaignRepository : ICampaignRepository
     public async Task<GrantWithSendContext?> GetGrantForResendAsync(
         Guid grantId, CancellationToken ct = default)
     {
-        return await _dbContext.CampaignGrants
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        return await ctx.CampaignGrants
             .AsNoTracking()
             .Where(g => g.Id == grantId)
             .Select(g => new GrantWithSendContext(
@@ -169,7 +206,8 @@ public sealed class CampaignRepository : ICampaignRepository
     public async Task<IReadOnlyList<GrantWithSendContext>> GetFailedGrantsForRetryAsync(
         Guid campaignId, CancellationToken ct = default)
     {
-        return await _dbContext.CampaignGrants
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        return await ctx.CampaignGrants
             .AsNoTracking()
             .Where(g => g.CampaignId == campaignId
                 && g.LatestEmailStatus == EmailOutboxStatus.Failed)
@@ -188,7 +226,8 @@ public sealed class CampaignRepository : ICampaignRepository
     public async Task<Guid?> GetCampaignIdForGrantAsync(
         Guid grantId, CancellationToken ct = default)
     {
-        return await _dbContext.CampaignGrants
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        return await ctx.CampaignGrants
             .AsNoTracking()
             .Where(g => g.Id == grantId)
             .Select(g => (Guid?)g.CampaignId)
@@ -198,7 +237,8 @@ public sealed class CampaignRepository : ICampaignRepository
     public async Task<HashSet<Guid>> GetAlreadyGrantedUserIdsAsync(
         Guid campaignId, CancellationToken ct = default)
     {
-        var list = await _dbContext.CampaignGrants
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        var list = await ctx.CampaignGrants
             .AsNoTracking()
             .Where(g => g.CampaignId == campaignId)
             .Select(g => g.UserId)
@@ -209,8 +249,9 @@ public sealed class CampaignRepository : ICampaignRepository
 
     public async Task AddGrantAndSaveAsync(CampaignGrant grant, CancellationToken ct = default)
     {
-        _dbContext.CampaignGrants.Add(grant);
-        await _dbContext.SaveChangesAsync(ct);
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        ctx.CampaignGrants.Add(grant);
+        await ctx.SaveChangesAsync(ct);
     }
 
     public async Task<bool> UpdateGrantStatusAsync(
@@ -219,13 +260,14 @@ public sealed class CampaignRepository : ICampaignRepository
         Instant latestEmailAt,
         CancellationToken ct = default)
     {
-        var grant = await _dbContext.CampaignGrants.FirstOrDefaultAsync(g => g.Id == grantId, ct);
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        var grant = await ctx.CampaignGrants.FirstOrDefaultAsync(g => g.Id == grantId, ct);
         if (grant is null)
             return false;
 
         grant.LatestEmailStatus = status;
         grant.LatestEmailAt = latestEmailAt;
-        await _dbContext.SaveChangesAsync(ct);
+        await ctx.SaveChangesAsync(ct);
         return true;
     }
 
@@ -244,9 +286,11 @@ public sealed class CampaignRepository : ICampaignRepository
         if (codeStrings.Count == 0)
             return 0;
 
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+
         // Load unredeemed grants on active/completed campaigns. Filter by code
         // in memory so the DB query stays simple and collation-independent.
-        var unredeemed = (await _dbContext.CampaignGrants
+        var unredeemed = (await ctx.CampaignGrants
             .Include(g => g.Code)
             .Include(g => g.Campaign)
             .Where(g => g.Code != null
@@ -280,7 +324,7 @@ public sealed class CampaignRepository : ICampaignRepository
         }
 
         if (redeemedCount > 0)
-            await _dbContext.SaveChangesAsync(ct);
+            await ctx.SaveChangesAsync(ct);
 
         return redeemedCount;
     }
@@ -288,7 +332,8 @@ public sealed class CampaignRepository : ICampaignRepository
     public async Task<IReadOnlyList<GrantExportRow>> GetGrantsForUserExportAsync(
         Guid userId, CancellationToken ct = default)
     {
-        return await _dbContext.CampaignGrants
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        return await ctx.CampaignGrants
             .AsNoTracking()
             .Where(cg => cg.UserId == userId)
             .OrderByDescending(cg => cg.AssignedAt)
@@ -300,11 +345,4 @@ public sealed class CampaignRepository : ICampaignRepository
                 cg.LatestEmailStatus))
             .ToListAsync(ct);
     }
-
-    // ==========================================================================
-    // Unit-of-work
-    // ==========================================================================
-
-    public Task SaveChangesAsync(CancellationToken ct = default) =>
-        _dbContext.SaveChangesAsync(ct);
 }

--- a/src/Humans.Infrastructure/Repositories/FeedbackRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/FeedbackRepository.cs
@@ -10,30 +10,38 @@ namespace Humans.Infrastructure.Repositories;
 /// EF-backed implementation of <see cref="IFeedbackRepository"/>. The only
 /// non-test file that touches <c>DbContext.FeedbackReports</c> or
 /// <c>DbContext.FeedbackMessages</c> after the Feedback migration lands.
-/// Uses the Scoped + <c>HumansDbContext</c> pattern because Feedback is
-/// admin-only and low-traffic (mirrors <see cref="ApplicationRepository"/>).
+/// Uses <see cref="IDbContextFactory{TContext}"/> so the repository can be
+/// registered as Singleton while <c>HumansDbContext</c> remains Scoped.
 /// </summary>
 public sealed class FeedbackRepository : IFeedbackRepository
 {
-    private readonly HumansDbContext _dbContext;
+    private readonly IDbContextFactory<HumansDbContext> _factory;
 
-    public FeedbackRepository(HumansDbContext dbContext)
+    public FeedbackRepository(IDbContextFactory<HumansDbContext> factory)
     {
-        _dbContext = dbContext;
+        _factory = factory;
     }
 
     // ==========================================================================
     // Reads
     // ==========================================================================
 
-    public async Task<FeedbackReport?> GetByIdAsync(Guid id, CancellationToken ct = default) =>
-        await _dbContext.FeedbackReports
+    public async Task<FeedbackReport?> GetByIdAsync(Guid id, CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        return await ctx.FeedbackReports
             .AsNoTracking()
             .Include(f => f.Messages.OrderBy(m => m.CreatedAt))
             .FirstOrDefaultAsync(f => f.Id == id, ct);
+    }
 
-    public async Task<FeedbackReport?> FindForMutationAsync(Guid id, CancellationToken ct = default) =>
-        await _dbContext.FeedbackReports.FindAsync([id], ct);
+    public async Task<FeedbackReport?> FindForMutationAsync(Guid id, CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        return await ctx.FeedbackReports
+            .AsNoTracking()
+            .FirstOrDefaultAsync(f => f.Id == id, ct);
+    }
 
     public async Task<IReadOnlyList<FeedbackReport>> GetListAsync(
         FeedbackStatus? status,
@@ -45,7 +53,8 @@ public sealed class FeedbackRepository : IFeedbackRepository
         int limit,
         CancellationToken ct = default)
     {
-        var query = _dbContext.FeedbackReports
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        var query = ctx.FeedbackReports
             .AsNoTracking()
             .Include(f => f.Messages)
             .AsQueryable();
@@ -75,26 +84,33 @@ public sealed class FeedbackRepository : IFeedbackRepository
     }
 
     public async Task<IReadOnlyList<FeedbackMessage>> GetMessagesAsync(
-        Guid reportId, CancellationToken ct = default) =>
-        await _dbContext.FeedbackMessages
+        Guid reportId, CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        return await ctx.FeedbackMessages
             .AsNoTracking()
             .Where(m => m.FeedbackReportId == reportId)
             .OrderBy(m => m.CreatedAt)
             .ToListAsync(ct);
+    }
 
-    public Task<int> GetActionableCountAsync(CancellationToken ct = default) =>
-        _dbContext.FeedbackReports
+    public async Task<int> GetActionableCountAsync(CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        return await ctx.FeedbackReports
             .Where(f => f.Status != FeedbackStatus.Resolved && f.Status != FeedbackStatus.WontFix)
             .CountAsync(f =>
                 (f.Status == FeedbackStatus.Open && f.LastAdminMessageAt == null) ||
                 (f.LastReporterMessageAt != null &&
                  (f.LastAdminMessageAt == null || f.LastReporterMessageAt > f.LastAdminMessageAt)),
                 ct);
+    }
 
     public async Task<IReadOnlyList<(Guid UserId, int Count)>> GetReporterCountsAsync(
         CancellationToken ct = default)
     {
-        var rows = await _dbContext.FeedbackReports
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        var rows = await ctx.FeedbackReports
             .AsNoTracking()
             .GroupBy(f => f.UserId)
             .Select(g => new { UserId = g.Key, Count = g.Count() })
@@ -104,13 +120,16 @@ public sealed class FeedbackRepository : IFeedbackRepository
     }
 
     public async Task<IReadOnlyList<FeedbackReport>> GetForUserExportAsync(
-        Guid userId, CancellationToken ct = default) =>
-        await _dbContext.FeedbackReports
+        Guid userId, CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        return await ctx.FeedbackReports
             .AsNoTracking()
             .Include(fr => fr.Messages)
             .Where(fr => fr.UserId == userId)
             .OrderByDescending(fr => fr.CreatedAt)
             .ToListAsync(ct);
+    }
 
     // ==========================================================================
     // Writes
@@ -118,18 +137,29 @@ public sealed class FeedbackRepository : IFeedbackRepository
 
     public async Task AddReportAsync(FeedbackReport report, CancellationToken ct = default)
     {
-        _dbContext.FeedbackReports.Add(report);
-        await _dbContext.SaveChangesAsync(ct);
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        ctx.FeedbackReports.Add(report);
+        await ctx.SaveChangesAsync(ct);
     }
 
-    public Task SaveTrackedReportAsync(FeedbackReport report, CancellationToken ct = default) =>
-        _dbContext.SaveChangesAsync(ct);
+    public async Task SaveTrackedReportAsync(FeedbackReport report, CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        ctx.Attach(report);
+        ctx.Entry(report).State = EntityState.Modified;
+        await ctx.SaveChangesAsync(ct);
+    }
 
     public async Task AddMessageAndSaveReportAsync(
         FeedbackMessage message, FeedbackReport report, CancellationToken ct = default)
     {
-        _dbContext.FeedbackMessages.Add(message);
-        // report is assumed tracked (fetched via FindForMutationAsync).
-        await _dbContext.SaveChangesAsync(ct);
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        // Attach the report (mutated by the caller) and mark it modified so
+        // timestamp/status fields are persisted in the same transaction as the
+        // new message.
+        ctx.Attach(report);
+        ctx.Entry(report).State = EntityState.Modified;
+        ctx.FeedbackMessages.Add(message);
+        await ctx.SaveChangesAsync(ct);
     }
 }

--- a/src/Humans.Infrastructure/Repositories/RoleAssignmentRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/RoleAssignmentRepository.cs
@@ -9,37 +9,48 @@ namespace Humans.Infrastructure.Repositories;
 /// <summary>
 /// EF-backed implementation of <see cref="IRoleAssignmentRepository"/>. The
 /// only non-test file that writes to <c>DbContext.RoleAssignments</c> after
-/// the Auth migration lands. Uses the Scoped + <c>HumansDbContext</c> pattern
-/// because Auth writes are rare (admin-driven) and low-traffic (mirrors
-/// <see cref="ApplicationRepository"/>).
+/// the Auth migration lands.
+/// Uses <see cref="IDbContextFactory{TContext}"/> so the repository can be
+/// registered as Singleton while <c>HumansDbContext</c> remains Scoped.
 /// </summary>
 public sealed class RoleAssignmentRepository : IRoleAssignmentRepository
 {
-    private readonly HumansDbContext _dbContext;
+    private readonly IDbContextFactory<HumansDbContext> _factory;
 
-    public RoleAssignmentRepository(HumansDbContext dbContext)
+    public RoleAssignmentRepository(IDbContextFactory<HumansDbContext> factory)
     {
-        _dbContext = dbContext;
+        _factory = factory;
     }
 
     // ==========================================================================
     // Reads
     // ==========================================================================
 
-    public Task<RoleAssignment?> FindForMutationAsync(Guid assignmentId, CancellationToken ct = default) =>
-        _dbContext.RoleAssignments.FirstOrDefaultAsync(ra => ra.Id == assignmentId, ct);
-
-    public Task<RoleAssignment?> GetByIdAsync(Guid assignmentId, CancellationToken ct = default) =>
-        _dbContext.RoleAssignments
+    public async Task<RoleAssignment?> FindForMutationAsync(Guid assignmentId, CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        return await ctx.RoleAssignments
             .AsNoTracking()
             .FirstOrDefaultAsync(ra => ra.Id == assignmentId, ct);
+    }
 
-    public async Task<IReadOnlyList<RoleAssignment>> GetByUserIdAsync(Guid userId, CancellationToken ct = default) =>
-        await _dbContext.RoleAssignments
+    public async Task<RoleAssignment?> GetByIdAsync(Guid assignmentId, CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        return await ctx.RoleAssignments
+            .AsNoTracking()
+            .FirstOrDefaultAsync(ra => ra.Id == assignmentId, ct);
+    }
+
+    public async Task<IReadOnlyList<RoleAssignment>> GetByUserIdAsync(Guid userId, CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        return await ctx.RoleAssignments
             .AsNoTracking()
             .Where(ra => ra.UserId == userId)
             .OrderByDescending(ra => ra.ValidFrom)
             .ToListAsync(ct);
+    }
 
     public async Task<(IReadOnlyList<RoleAssignment> Items, int TotalCount)> GetFilteredAsync(
         string? roleFilter,
@@ -49,7 +60,8 @@ public sealed class RoleAssignmentRepository : IRoleAssignmentRepository
         Instant now,
         CancellationToken ct = default)
     {
-        var query = _dbContext.RoleAssignments.AsNoTracking().AsQueryable();
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        var query = ctx.RoleAssignments.AsNoTracking().AsQueryable();
 
         if (!string.IsNullOrWhiteSpace(roleFilter))
         {
@@ -80,7 +92,8 @@ public sealed class RoleAssignmentRepository : IRoleAssignmentRepository
         Instant? validTo,
         CancellationToken ct = default)
     {
-        var query = _dbContext.RoleAssignments
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        var query = ctx.RoleAssignments
             .AsNoTracking()
             .Where(ra => ra.UserId == userId && ra.RoleName == roleName);
 
@@ -102,43 +115,54 @@ public sealed class RoleAssignmentRepository : IRoleAssignmentRepository
         return await query.AnyAsync(ct);
     }
 
-    public Task<bool> HasActiveRoleAsync(
+    public async Task<bool> HasActiveRoleAsync(
         Guid userId,
         string roleName,
         Instant now,
-        CancellationToken ct = default) =>
-        _dbContext.RoleAssignments.AnyAsync(
+        CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        return await ctx.RoleAssignments.AnyAsync(
             ra => ra.UserId == userId &&
                   ra.RoleName == roleName &&
                   ra.ValidFrom <= now &&
                   (ra.ValidTo == null || ra.ValidTo > now),
             ct);
+    }
 
-    public Task<bool> HasAnyActiveAssignmentAsync(
+    public async Task<bool> HasAnyActiveAssignmentAsync(
         Guid userId,
         Instant now,
-        CancellationToken ct = default) =>
-        _dbContext.RoleAssignments.AnyAsync(
+        CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        return await ctx.RoleAssignments.AnyAsync(
             ra => ra.UserId == userId &&
                   ra.ValidFrom <= now &&
                   (ra.ValidTo == null || ra.ValidTo > now),
             ct);
+    }
 
     public async Task<IReadOnlyList<Guid>> GetUserIdsWithActiveAssignmentsAsync(
         Instant now,
-        CancellationToken ct = default) =>
-        await _dbContext.RoleAssignments
+        CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        return await ctx.RoleAssignments
             .AsNoTracking()
             .Where(ra => ra.ValidFrom <= now && (ra.ValidTo == null || ra.ValidTo > now))
             .Select(ra => ra.UserId)
             .Distinct()
             .ToListAsync(ct);
+    }
 
     public async Task<IReadOnlyList<Guid>> GetActiveUserIdsForRoleAsync(
         string roleName,
         Instant now,
-        CancellationToken ct = default) =>
-        await _dbContext.RoleAssignments
+        CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        return await ctx.RoleAssignments
             .AsNoTracking()
             .Where(ra => ra.RoleName == roleName &&
                          ra.ValidFrom <= now &&
@@ -146,22 +170,29 @@ public sealed class RoleAssignmentRepository : IRoleAssignmentRepository
             .Select(ra => ra.UserId)
             .Distinct()
             .ToListAsync(ct);
+    }
 
     public async Task<IReadOnlyList<RoleAssignment>> GetActiveForUserForMutationAsync(
         Guid userId,
         Instant now,
-        CancellationToken ct = default) =>
-        await _dbContext.RoleAssignments
+        CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        return await ctx.RoleAssignments
+            .AsNoTracking()
             .Where(ra => ra.UserId == userId &&
                          ra.ValidFrom <= now &&
                          (ra.ValidTo == null || ra.ValidTo > now))
             .ToListAsync(ct);
+    }
 
     public async Task<IReadOnlyList<Guid>> GetActiveUserIdsInRoleAsync(
         string roleName,
         Instant now,
-        CancellationToken ct = default) =>
-        await _dbContext.RoleAssignments
+        CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        return await ctx.RoleAssignments
             .AsNoTracking()
             .Where(ra =>
                 ra.RoleName == roleName &&
@@ -170,6 +201,7 @@ public sealed class RoleAssignmentRepository : IRoleAssignmentRepository
             .Select(ra => ra.UserId)
             .Distinct()
             .ToListAsync(ct);
+    }
 
     // ==========================================================================
     // Writes
@@ -177,10 +209,30 @@ public sealed class RoleAssignmentRepository : IRoleAssignmentRepository
 
     public async Task AddAsync(RoleAssignment assignment, CancellationToken ct = default)
     {
-        _dbContext.RoleAssignments.Add(assignment);
-        await _dbContext.SaveChangesAsync(ct);
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        ctx.RoleAssignments.Add(assignment);
+        await ctx.SaveChangesAsync(ct);
     }
 
-    public Task SaveTrackedAsync(CancellationToken ct = default) =>
-        _dbContext.SaveChangesAsync(ct);
+    public async Task UpdateAsync(RoleAssignment assignment, CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        ctx.Attach(assignment);
+        ctx.Entry(assignment).State = EntityState.Modified;
+        await ctx.SaveChangesAsync(ct);
+    }
+
+    public async Task UpdateManyAsync(IReadOnlyList<RoleAssignment> assignments, CancellationToken ct = default)
+    {
+        if (assignments.Count == 0)
+            return;
+
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        foreach (var assignment in assignments)
+        {
+            ctx.Attach(assignment);
+            ctx.Entry(assignment).State = EntityState.Modified;
+        }
+        await ctx.SaveChangesAsync(ct);
+    }
 }

--- a/src/Humans.Web/Extensions/Sections/AuthSectionExtensions.cs
+++ b/src/Humans.Web/Extensions/Sections/AuthSectionExtensions.cs
@@ -14,10 +14,9 @@ internal static class AuthSectionExtensions
     internal static IServiceCollection AddAuthSection(this IServiceCollection services)
     {
         // Auth section (§15 migration, issue #551) — repository + Application-
-        // layer service, no caching decorator. Auth writes are rare (handful of
-        // admin events per month); same Scoped + DbContext repository pattern
-        // as Governance.
-        services.AddScoped<IRoleAssignmentRepository, RoleAssignmentRepository>();
+        // layer service, no caching decorator. Singleton + IDbContextFactory
+        // pattern (§15b) so the repository owns context lifetime.
+        services.AddSingleton<IRoleAssignmentRepository, RoleAssignmentRepository>();
         services.AddScoped<IRoleAssignmentClaimsCacheInvalidator, RoleAssignmentClaimsCacheInvalidator>();
 
         services.AddScoped<RoleAssignmentService>();

--- a/src/Humans.Web/Extensions/Sections/CampaignsSectionExtensions.cs
+++ b/src/Humans.Web/Extensions/Sections/CampaignsSectionExtensions.cs
@@ -11,8 +11,8 @@ internal static class CampaignsSectionExtensions
     internal static IServiceCollection AddCampaignsSection(this IServiceCollection services)
     {
         // Campaigns section — §15 repository pattern (issue #546).
-        // No caching decorator: campaigns are admin-only, infrequent mutations.
-        services.AddScoped<ICampaignRepository, CampaignRepository>();
+        // Singleton + IDbContextFactory pattern (§15b) so the repository owns context lifetime.
+        services.AddSingleton<ICampaignRepository, CampaignRepository>();
         services.AddScoped<CampaignsCampaignService>();
         services.AddScoped<ICampaignService>(sp => sp.GetRequiredService<CampaignsCampaignService>());
         services.AddScoped<IUserDataContributor>(sp => sp.GetRequiredService<CampaignsCampaignService>());

--- a/src/Humans.Web/Extensions/Sections/FeedbackSectionExtensions.cs
+++ b/src/Humans.Web/Extensions/Sections/FeedbackSectionExtensions.cs
@@ -13,9 +13,8 @@ internal static class FeedbackSectionExtensions
     internal static IServiceCollection AddFeedbackSection(this IServiceCollection services)
     {
         // Feedback section — §15 repository + Application-layer service, no caching decorator.
-        // Feedback is admin-review-only and low-traffic; same Scoped + DbContext repository
-        // pattern as Governance (issue #549).
-        services.AddScoped<IFeedbackRepository, FeedbackRepository>();
+        // Singleton + IDbContextFactory pattern (§15b) so the repository owns context lifetime.
+        services.AddSingleton<IFeedbackRepository, FeedbackRepository>();
         services.AddScoped<FeedbackApplicationService>();
         services.AddScoped<IFeedbackService>(sp => sp.GetRequiredService<FeedbackApplicationService>());
         services.AddScoped<IUserDataContributor>(sp => sp.GetRequiredService<FeedbackApplicationService>());

--- a/tests/Humans.Application.Tests/Repositories/FeedbackRepositoryTests.cs
+++ b/tests/Humans.Application.Tests/Repositories/FeedbackRepositoryTests.cs
@@ -1,4 +1,5 @@
 using AwesomeAssertions;
+using Humans.Application.Tests.Infrastructure;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Humans.Infrastructure.Data;
@@ -23,7 +24,7 @@ public sealed class FeedbackRepositoryTests : IDisposable
             .Options;
         _dbContext = new HumansDbContext(options);
         _clock = new FakeClock(Instant.FromUtc(2026, 3, 18, 12, 0));
-        _repo = new FeedbackRepository(_dbContext);
+        _repo = new FeedbackRepository(new TestDbContextFactory(options));
     }
 
     public void Dispose()

--- a/tests/Humans.Application.Tests/Repositories/RoleAssignmentRepositoryTests.cs
+++ b/tests/Humans.Application.Tests/Repositories/RoleAssignmentRepositoryTests.cs
@@ -1,4 +1,5 @@
 using AwesomeAssertions;
+using Humans.Application.Tests.Infrastructure;
 using Humans.Domain.Constants;
 using Humans.Domain.Entities;
 using Humans.Infrastructure.Data;
@@ -23,7 +24,7 @@ public class RoleAssignmentRepositoryTests : IDisposable
             .Options;
         _dbContext = new HumansDbContext(options);
         _clock = new FakeClock(Instant.FromUtc(2026, 4, 22, 12, 0));
-        _repo = new RoleAssignmentRepository(_dbContext);
+        _repo = new RoleAssignmentRepository(new TestDbContextFactory(options));
     }
 
     public void Dispose()
@@ -64,7 +65,7 @@ public class RoleAssignmentRepositoryTests : IDisposable
         var tracked = await _repo.FindForMutationAsync(assignment.Id);
         tracked.Should().NotBeNull();
         tracked!.ValidTo = _clock.GetCurrentInstant();
-        await _repo.SaveTrackedAsync();
+        await _repo.UpdateAsync(tracked);
 
         var reloaded = await _dbContext.RoleAssignments.AsNoTracking().FirstAsync(ra => ra.Id == assignment.Id);
         reloaded.ValidTo.Should().NotBeNull();
@@ -199,7 +200,7 @@ public class RoleAssignmentRepositoryTests : IDisposable
         {
             ra.ValidTo = now;
         }
-        await _repo.SaveTrackedAsync();
+        await _repo.UpdateManyAsync(result);
 
         var reloaded = await _dbContext.RoleAssignments.AsNoTracking().Where(r => r.UserId == userId).ToListAsync();
         reloaded.All(r => r.ValidTo.HasValue).Should().BeTrue();

--- a/tests/Humans.Application.Tests/Services/CampaignServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/CampaignServiceTests.cs
@@ -5,6 +5,7 @@ using NodaTime;
 using NodaTime.Testing;
 using NSubstitute;
 using Humans.Application.Interfaces;
+using Humans.Application.Tests.Infrastructure;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Humans.Infrastructure.Data;
@@ -33,7 +34,7 @@ public class CampaignServiceTests : IDisposable
         _dbContext = new HumansDbContext(options);
         _clock = new FakeClock(Instant.FromUtc(2026, 3, 1, 12, 0));
 
-        var repository = new CampaignRepository(_dbContext);
+        var repository = new CampaignRepository(new TestDbContextFactory(options));
         _teamService = Substitute.For<ITeamService>();
         _userService = Substitute.For<IUserService>();
         _userEmailService = Substitute.For<IUserEmailService>();
@@ -489,6 +490,7 @@ public class CampaignServiceTests : IDisposable
             Arg.Is<CampaignCodeEmailRequest>(r => r.CampaignGrantId == grant.Id),
             Arg.Any<CancellationToken>());
 
+        _dbContext.ChangeTracker.Clear();
         var updatedGrant = await _dbContext.CampaignGrants.FindAsync(grant.Id);
         updatedGrant!.LatestEmailStatus.Should().Be(EmailOutboxStatus.Queued);
     }
@@ -524,6 +526,7 @@ public class CampaignServiceTests : IDisposable
             Arg.Is<CampaignCodeEmailRequest>(r => r.CampaignGrantId == grants[0].Id),
             Arg.Any<CancellationToken>());
 
+        _dbContext.ChangeTracker.Clear();
         var retriedGrant = await _dbContext.CampaignGrants.FindAsync(grants[0].Id);
         retriedGrant!.LatestEmailStatus.Should().Be(EmailOutboxStatus.Queued);
     }
@@ -635,6 +638,7 @@ public class CampaignServiceTests : IDisposable
         };
         _dbContext.Campaigns.Add(campaign);
         await _dbContext.SaveChangesAsync();
+        _dbContext.ChangeTracker.Clear();
         return campaign;
     }
 
@@ -660,6 +664,7 @@ public class CampaignServiceTests : IDisposable
             });
         }
         await _dbContext.SaveChangesAsync();
+        _dbContext.ChangeTracker.Clear();
         return campaign;
     }
 }

--- a/tests/Humans.Application.Tests/Services/FeedbackServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/FeedbackServiceTests.cs
@@ -93,7 +93,7 @@ public class FeedbackServiceTests : IDisposable
         _notificationService = Substitute.For<INotificationService>();
         _navBadge = Substitute.For<INavBadgeCacheInvalidator>();
 
-        _repository = new FeedbackRepository(_dbContext);
+        _repository = new FeedbackRepository(new TestDbContextFactory(options));
 
         _service = new FeedbackApplicationService(
             _repository, _userService, _userEmailService, _teamService,

--- a/tests/Humans.Application.Tests/Services/RoleAssignmentServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/RoleAssignmentServiceTests.cs
@@ -5,6 +5,7 @@ using NodaTime;
 using NodaTime.Testing;
 using Humans.Application;
 using Humans.Application.Interfaces;
+using Humans.Application.Tests.Infrastructure;
 using Humans.Application.Interfaces.Caching;
 using Humans.Application.Interfaces.Repositories;
 using Humans.Infrastructure.Data;
@@ -36,7 +37,7 @@ public class RoleAssignmentServiceTests : IDisposable
         _dbContext = new HumansDbContext(options);
         _clock = new FakeClock(Instant.FromUtc(2026, 2, 15, 15, 30));
 
-        _repository = new RoleAssignmentRepository(_dbContext);
+        _repository = new RoleAssignmentRepository(new TestDbContextFactory(options));
 
         _userService = Substitute.For<IUserService>();
         _userService

--- a/tests/Humans.Application.Tests/Services/TeamRoleServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/TeamRoleServiceTests.cs
@@ -35,7 +35,7 @@ public class TeamRoleServiceTests : IDisposable
         _clock = new FakeClock(Instant.FromUtc(2026, 3, 11, 12, 0));
         var cache = new Microsoft.Extensions.Caching.Memory.MemoryCache(new Microsoft.Extensions.Caching.Memory.MemoryCacheOptions());
         var roleAssignmentService = new RoleAssignmentService(
-            new RoleAssignmentRepository(_dbContext),
+            new RoleAssignmentRepository(new TestDbContextFactory(options)),
             Substitute.For<IUserService>(),
             Substitute.For<IAuditLogService>(),
             Substitute.For<INotificationEmitter>(),

--- a/tests/Humans.Application.Tests/Services/TeamServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/TeamServiceTests.cs
@@ -39,7 +39,7 @@ public class TeamServiceTests : IDisposable
         _dbContext = new HumansDbContext(options);
         _clock = new FakeClock(Instant.FromUtc(2026, 3, 1, 12, 0));
         _roleAssignmentService = new RoleAssignmentService(
-            new RoleAssignmentRepository(_dbContext),
+            new RoleAssignmentRepository(new TestDbContextFactory(options)),
             Substitute.For<IUserService>(),
             Substitute.For<IAuditLogService>(),
             Substitute.For<INotificationEmitter>(),


### PR DESCRIPTION
Partial fix for nobodies-collective/Humans#566. Budget deferred to nobodies-collective/Humans#572 (per-method contract redesign).

Normalizes three of the four §15b target repositories to Singleton + `IDbContextFactory<HumansDbContext>` — `BudgetRepository` is deferred.

### Changes
- **CampaignRepository, FeedbackRepository, RoleAssignmentRepository**: constructor + every method use `IDbContextFactory<HumansDbContext>`; each method owns its own context lifetime. DI flipped to `AddSingleton`.
- **Public `SaveChangesAsync` surface collapsed** on all three interfaces; mutators (`AddAsync` / `UpdateAsync` / `UpdateManyAsync` / `SaveTrackedReportAsync` / `AddCampaignCodesAsync` / etc.) self-save.
- `CampaignService` and `RoleAssignmentService` callers updated to the new auto-saving API.
- `ApplicationRepository` was already save-collapsed (all mutators self-save; no `SaveChangesAsync` on the public interface). No changes needed there.
- Test construction updated to wrap `HumansDbContext` in `TestDbContextFactory` per the §15b pattern. `ChangeTracker.Clear()` added in `CampaignServiceTests` seed helpers + verify reads to avoid stale-cache reads across separate contexts (factory-pattern gotcha).

### Not in scope (deferred)
- **BudgetRepository** → nobodies-collective/Humans#572. Its tracked-aggregate workflow (load for mutation → mutate in-memory → commit multi-entity transactions in one `SaveChanges`) is not a mechanical flip; needs per-method contract redesign to conform to §15b.
- **ApplicationRepository DI pattern** stays Scoped per #533 decision. Its public `SaveChangesAsync` surface was already collapsed.
- **ShiftSignupRepository** deferred to #541 cleanup.

### Verification
- `dotnet build Humans.slnx -v quiet` clean, no warnings.
- `dotnet test Humans.slnx -v quiet` — all affected tests green (Campaign/Feedback/RoleAssignment/TeamService/TeamRoleService). 3 pre-existing `CalendarControllerTests` failures on origin/main unchanged (verified independently — not introduced by this PR).

Part of peterdrier/Humans#292 wave 1.