### PR TITLE
§15 Part 1 Calendar: migrate CalendarService to Application layer

### DIFF
--- a/docs/architecture/design-rules.md
+++ b/docs/architecture/design-rules.md
@@ -251,6 +251,7 @@ Each section's service owns these tables. Cross-service access goes through the 
 | **Team Resources** | `TeamResourceService` | `google_resources` |
 | **Google Integration** | `GoogleSyncService`, `GoogleAdminService`, `GoogleWorkspaceUserService`, `DriveActivityMonitorService`, `SyncSettingsService`, `EmailProvisioningService` | `sync_service_settings` |
 | **Email** | `EmailOutboxService`, `EmailService` | `email_outbox_messages` |
+| **Calendar** | `CalendarService` | `calendar_events`, `calendar_event_exceptions` |
 | **Feedback** | `FeedbackService` | `feedback_reports`, `feedback_messages` |
 | **Notifications** | `NotificationService`, `NotificationInboxService` | *(in-memory / transient)* |
 | **Audit** | `AuditLogService` | `audit_log_entries` |
@@ -577,7 +578,7 @@ Old names that no longer exist: `CachedProfile`, `IProfileStore`, `ProfileStore`
 
 ### 15i. Known Current Violations (as of 2026-04-23)
 
-- **4 business services** still live in `Humans.Infrastructure/Services/` and inject `HumansDbContext` directly: `TeamService`, `GoogleWorkspaceSyncService`, `CalendarService`, `HumansMetricsService`. All other files in that folder are connectors, stubs, or renderers that correctly stay in Infrastructure. Target: 0. Migration progress by section:
+- **3 business services** still live in `Humans.Infrastructure/Services/` and inject `HumansDbContext` directly: `TeamService`, `GoogleWorkspaceSyncService`, `HumansMetricsService`. All other files in that folder are connectors, stubs, or renderers that correctly stay in Infrastructure. Target: 0. Migration progress by section:
   - **Governance** — migrated 2026-04-15 in PR #503.
   - **Profiles** — fully migrated 2026-04-20 in PR #235 — `ProfileService`, `ContactFieldService`, `ContactService`, `UserEmailService`, `CommunicationPreferenceService` now live in `Humans.Application.Services.Profile`. (`VolunteerHistoryService` was folded into `ProfileService`/`IProfileRepository`; it no longer exists as a separate service.)
   - **User** — migrated 2026-04-21 in PR #243 — `UserService` now lives in `Humans.Application.Services.Users`, goes through `IUserRepository`, and invalidates `IFullProfileInvalidator` on writes that change FullProfile-visible fields. **No caching decorator** was added for the User section: User is ~500 rows with no hot bulk-read path, so a dict cache isn't warranted (same rationale as Governance's decorator removal in #242). Option A is documented in `docs/superpowers/specs/2026-04-21-issue-511-user-migration.md`.
@@ -595,6 +596,7 @@ Old names that no longer exist: `CachedProfile`, `IProfileStore`, `ProfileStore`
   - **Shifts (partial, #541)** — `ShiftManagementService`, `ShiftSignupService`, and `GeneralAvailabilityService` now live in `Humans.Application.Services.Shifts`, going through `IShiftManagementRepository`, `IShiftSignupRepository`, and `IGeneralAvailabilityRepository`. §15 NEW-B (ShiftAuthorization cache invalidation on profile mutation) remains open — tracked in issue #541.
   - **Tickets (partial, #545)** — `TicketQueryService`, `TicketSyncService`, and `TicketingBudgetService` now live in `Humans.Application.Services.Tickets`, going through `ITicketRepository` and `ITicketingBudgetRepository`. The Ticket Tailor API side of `TicketSyncService` is structurally separated via the `ITicketVendorService` connector (PR #277). Pending upstream promotion to nobodies-collective/Humans.
   - **Google Workspace (partial, #554)** — `GoogleAdminService`, `GoogleWorkspaceUserService`, `DriveActivityMonitorService`, `SyncSettingsService`, and `EmailProvisioningService` migrated in PR #267 (issue #289) and now live in `Humans.Application.Services.GoogleIntegration`. `GoogleWorkspaceSyncService` remains in `Humans.Infrastructure/Services/` (still injects `HumansDbContext` and `IDbContextFactory<HumansDbContext>` directly, plus imports `Google.Apis.*` SDK namespaces). **Part 1 of #554 (2026-04-23):** `IGoogleSyncOutboxRepository` extracted — `google_sync_outbox_events` now has a dedicated repository for the count queries used by `NotificationMeterProvider`, `HumansMetricsService`, `SendAdminDailyDigestJob`, and the notification-meter path in `GoogleWorkspaceSyncService.GetFailedSyncEventCountAsync`. **Part 2 (remaining):** split the Google SDK surface into bridges (`IGoogleDirectoryClient`, `IGoogleDriveClient`, `IGoogleGroupsClient`, `IGoogleGroupSettingsClient`); strip `HumansDbContext`/`IDbContextFactory` from `GoogleWorkspaceSyncService`; route cross-domain reads (`TeamMembers.Include(User)`, `Users`, `UserEmails`, `Teams`) through sibling service interfaces; move the service to `Humans.Application.Services.GoogleIntegration`. This is the largest remaining §15 migration in the codebase.
+  - **Calendar** — migrated 2026-04-23 for issue #569 — `CalendarService` now lives in `Humans.Application.Services.Calendar`, goes through `ICalendarRepository`, and routes owning-team display names through `ITeamService.GetTeamNamesByIdsAsync` (§6b in-memory join). Cross-domain `.Include(e => e.OwningTeam)` is gone; `CalendarEvent.OwningTeam` nav is `[Obsolete]`-marked and the EF configuration references it under `#pragma warning disable CS0618` to keep the FK + cascade behavior wired. **No caching decorator** — short-TTL `IMemoryCache` (`calendar:active-events`) stays in-service per §15f. The `calendar_events` / `calendar_event_exceptions` tables are now listed under a new **Calendar** row in §8.
 - **Cross-domain `.Include()` calls** remain concentrated in `TeamService` and `GoogleWorkspaceSyncService` (both still in Infrastructure). The Application layer is clean — 0 `.Include()` calls across all Application-layer services. Target: 0 everywhere.
   - Includes fully removed from the service layer in these sections:
     - Profile
@@ -610,12 +612,14 @@ Old names that no longer exist: `CachedProfile`, `IProfileStore`, `ProfileStore`
     - Shifts
     - Tickets
     - Google Workspace (all Application-layer services; `GoogleWorkspaceSyncService` in Infrastructure still has includes)
+    - Calendar
   - **User section's PR #243 landed the Application-layer move but deferred the nav-strip** — cross-domain nav reads via `user.UserEmails`, `user.Profile`, `user.TeamMemberships`, `user.GetEffectiveEmail()` still exist in `TeamService`, `GoogleWorkspaceSyncService`, `SendBoardDailyDigestJob`, `SyncLegalDocumentsJob`, `SystemTeamSyncJob`, `SuspendNonCompliantMembersJob`, `ProfileController`. Tracked as a follow-up.
-- **27 repositories** exist today. Target: one per domain (~20 total, some sections need two):
+- **28 repositories** exist today. Target: one per domain (~20 total, some sections need two):
   - `AccountMergeRepository`
   - `ApplicationRepository`
   - `AuditLogRepository`
   - `BudgetRepository`
+  - `CalendarRepository`
   - `CampaignRepository`
   - `CampRepository`
   - `CityPlanningRepository`

--- a/src/Humans.Application/Humans.Application.csproj
+++ b/src/Humans.Application/Humans.Application.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Ical.Net" />
     <PackageReference Include="NodaTime" />
   </ItemGroup>
 

--- a/src/Humans.Application/Interfaces/Repositories/ICalendarRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/ICalendarRepository.cs
@@ -1,0 +1,111 @@
+using Humans.Domain.Entities;
+using NodaTime;
+
+namespace Humans.Application.Interfaces.Repositories;
+
+/// <summary>
+/// Repository for the Calendar section's <c>calendar_events</c> and
+/// <c>calendar_event_exceptions</c> tables. The only non-test file that
+/// touches <c>DbContext.CalendarEvents</c> / <c>DbContext.CalendarEventExceptions</c>
+/// after the Calendar §15 migration (issue #569) lands.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Entities-in / entities-out per design-rules §3. Read methods are
+/// <c>AsNoTracking</c>. Mutating methods load tracked entities and save
+/// changes atomically inside a single
+/// <see cref="Microsoft.EntityFrameworkCore.IDbContextFactory{TContext}"/>-owned
+/// context so callers never have to reason about the EF context lifetime.
+/// </para>
+/// <para>
+/// Cross-domain navigation (<c>CalendarEvent.OwningTeam</c>) is never
+/// <c>Include</c>-ed; the application service stitches team display names
+/// via <see cref="Teams.ITeamService"/> per design-rules §6.
+/// </para>
+/// </remarks>
+public interface ICalendarRepository
+{
+    // ==========================================================================
+    // Reads
+    // ==========================================================================
+
+    /// <summary>
+    /// Returns calendar events whose window overlaps with
+    /// <c>[from, to]</c> — i.e. events that start before <paramref name="to"/>
+    /// and whose recurrence end (or <c>null</c>, meaning open-ended) is on or
+    /// after <paramref name="from"/>. Optionally filtered by team.
+    /// Exceptions are loaded eagerly. Soft-deleted rows are filtered via the
+    /// global query filter. Read-only (<c>AsNoTracking</c>). The
+    /// <c>OwningTeam</c> navigation is not loaded — the caller stitches team
+    /// names via <see cref="Teams.ITeamService"/>.
+    /// </summary>
+    Task<IReadOnlyList<CalendarEvent>> GetEventsInWindowAsync(
+        Instant from,
+        Instant to,
+        Guid? teamId,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Loads a single <see cref="CalendarEvent"/> by id, with its
+    /// <c>Exceptions</c> collection included. Returns <c>null</c> if not
+    /// found or soft-deleted. Read-only (<c>AsNoTracking</c>). The
+    /// <c>OwningTeam</c> navigation is not loaded.
+    /// </summary>
+    Task<CalendarEvent?> GetEventByIdAsync(Guid id, CancellationToken ct = default);
+
+    // ==========================================================================
+    // Writes — CalendarEvent
+    // ==========================================================================
+
+    /// <summary>
+    /// Inserts a new <see cref="CalendarEvent"/>. The caller is responsible for
+    /// validating the entity first.
+    /// </summary>
+    Task AddAsync(CalendarEvent ev, CancellationToken ct = default);
+
+    /// <summary>
+    /// Loads the event for mutation, applies <paramref name="mutate"/>, and
+    /// saves. Returns <c>false</c> (without calling the mutator) when the
+    /// event does not exist or is soft-deleted. The mutator is called against
+    /// the tracked entity so changes are persisted on <c>SaveChanges</c>.
+    /// </summary>
+    Task<bool> UpdateAsync(
+        Guid id,
+        Action<CalendarEvent> mutate,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Soft-deletes the event by stamping <c>DeletedAt</c> and
+    /// <c>UpdatedAt</c> with <paramref name="deletedAt"/>. Returns the
+    /// event's <c>OwningTeamId</c> and previous <c>Title</c> so the caller
+    /// can write an audit-log entry without re-loading. Returns <c>null</c>
+    /// when the event does not exist or is already soft-deleted.
+    /// </summary>
+    Task<(Guid OwningTeamId, string Title)?> SoftDeleteAsync(
+        Guid id,
+        Instant deletedAt,
+        CancellationToken ct = default);
+
+    // ==========================================================================
+    // Writes — CalendarEventException (per-occurrence override / cancellation)
+    // ==========================================================================
+
+    /// <summary>
+    /// Upserts the exception row for
+    /// <c>(<paramref name="eventId"/>, <paramref name="originalOccurrenceStartUtc"/>)</c>.
+    /// When no row exists, a new one is created using <paramref name="createdByUserId"/>
+    /// and <paramref name="now"/> for audit stamps. When a row exists, only
+    /// <c>UpdatedAt</c> is refreshed. The caller's <paramref name="apply"/>
+    /// delegate mutates the exception (cancel flag and/or override fields)
+    /// and is invoked after audit-stamp bookkeeping. Returns <c>true</c> on
+    /// success. Validation is the caller's responsibility (via
+    /// <see cref="CalendarEventException.Validate"/>).
+    /// </summary>
+    Task UpsertExceptionAsync(
+        Guid eventId,
+        Instant originalOccurrenceStartUtc,
+        Guid createdByUserId,
+        Instant now,
+        Action<CalendarEventException> apply,
+        CancellationToken ct = default);
+}

--- a/src/Humans.Application/Services/Calendar/CalendarService.cs
+++ b/src/Humans.Application/Services/Calendar/CalendarService.cs
@@ -1,37 +1,61 @@
 using Humans.Application.DTOs.Calendar;
 using Humans.Application.Interfaces.AuditLog;
 using Humans.Application.Interfaces.Calendar;
+using Humans.Application.Interfaces.Repositories;
+using Humans.Application.Interfaces.Teams;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
-using Humans.Infrastructure.Data;
 using Ical.Net.DataTypes;
 using Ical.Net.Evaluation;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using NodaTime;
 using IcalEvent = Ical.Net.CalendarComponents.CalendarEvent;
 
-namespace Humans.Infrastructure.Services;
+namespace Humans.Application.Services.Calendar;
 
-public class CalendarService : ICalendarService
+/// <summary>
+/// Application-layer implementation of <see cref="ICalendarService"/>. Goes
+/// through <see cref="ICalendarRepository"/> for all data access — this type
+/// never imports <c>Microsoft.EntityFrameworkCore</c>, enforced by
+/// <c>Humans.Application.csproj</c>'s reference graph (design-rules §2b).
+/// </summary>
+/// <remarks>
+/// Cross-section interactions:
+/// <list type="bullet">
+///   <item><see cref="ITeamService"/> — resolves owning-team display names
+///     for the occurrence projection that previously loaded them via the
+///     <c>CalendarEvent.OwningTeam</c> cross-domain nav (design-rules §6b
+///     "in-memory join").</item>
+///   <item><see cref="IAuditLogService"/> — create / update / delete /
+///     occurrence-cancel / occurrence-override mutations are audited.</item>
+/// </list>
+/// Caching: the short-TTL <see cref="IMemoryCache"/> entry
+/// <c>calendar:active-events</c> is a request-acceleration marker rather
+/// than a canonical domain projection, so §15 transparent-cache rules do
+/// not apply (design-rules §15f). It stays in-service per the §569 scope.
+/// </remarks>
+public sealed class CalendarService : ICalendarService
 {
     private const string CacheKeyActiveEvents = "calendar:active-events";
 
-    private readonly HumansDbContext _db;
+    private readonly ICalendarRepository _repo;
+    private readonly ITeamService _teamService;
     private readonly IMemoryCache _cache;
     private readonly IClock _clock;
     private readonly IAuditLogService _audit;
     private readonly ILogger<CalendarService> _logger;
 
     public CalendarService(
-        HumansDbContext db,
+        ICalendarRepository repo,
+        ITeamService teamService,
         IMemoryCache cache,
         IClock clock,
         IAuditLogService audit,
         ILogger<CalendarService> logger)
     {
-        _db = db;
+        _repo = repo;
+        _teamService = teamService;
         _cache = cache;
         _clock = clock;
         _audit = audit;
@@ -41,22 +65,23 @@ public class CalendarService : ICalendarService
     public async Task<IReadOnlyList<CalendarOccurrence>> GetOccurrencesInWindowAsync(
         Instant from, Instant to, Guid? teamId = null, CancellationToken ct = default)
     {
-        var query = _db.CalendarEvents
-            .Include(e => e.OwningTeam)
-            .Include(e => e.Exceptions)
-            .AsQueryable();
+        var events = await _repo.GetEventsInWindowAsync(from, to, teamId, ct);
 
-        query = query.Where(e => e.StartUtc <= to
-            && (e.RecurrenceUntilUtc == null || e.RecurrenceUntilUtc >= from));
+        // In-memory join (§6b): resolve owning-team display names up front
+        // via ITeamService instead of .Include(e => e.OwningTeam).
+        var teamIds = events.Select(e => e.OwningTeamId).Distinct().ToList();
+        var teamNames = teamIds.Count == 0
+            ? (IReadOnlyDictionary<Guid, string>)new Dictionary<Guid, string>()
+            : await _teamService.GetTeamNamesByIdsAsync(teamIds, ct);
 
-        if (teamId is { } t)
-            query = query.Where(e => e.OwningTeamId == t);
-
-        var events = await query.ToListAsync(ct);
         var results = new List<CalendarOccurrence>();
 
         foreach (var e in events)
         {
+            var owningTeamName = teamNames.TryGetValue(e.OwningTeamId, out var name)
+                ? name
+                : string.Empty;
+
             if (string.IsNullOrWhiteSpace(e.RecurrenceRule))
             {
                 // Half-open window [from, to): event overlaps when end > from AND start < to.
@@ -73,7 +98,7 @@ public class CalendarService : ICalendarService
                     Location: e.Location,
                     LocationUrl: e.LocationUrl,
                     OwningTeamId: e.OwningTeamId,
-                    OwningTeamName: e.OwningTeam.Name,
+                    OwningTeamName: owningTeamName,
                     IsRecurring: false,
                     OriginalOccurrenceStartUtc: null));
             }
@@ -122,7 +147,7 @@ public class CalendarService : ICalendarService
                         Location: e.Location,
                         LocationUrl: e.LocationUrl,
                         OwningTeamId: e.OwningTeamId,
-                        OwningTeamName: e.OwningTeam.Name,
+                        OwningTeamName: owningTeamName,
                         IsRecurring: true,
                         OriginalOccurrenceStartUtc: startInstant));
                 }
@@ -178,6 +203,10 @@ public class CalendarService : ICalendarService
         // materialized them, so the override loop above didn't see them either).
         foreach (var ev in events)
         {
+            var owningTeamName = teamNames.TryGetValue(ev.OwningTeamId, out var name)
+                ? name
+                : string.Empty;
+
             foreach (var ex in ev.Exceptions)
             {
                 if (handledExceptionKeys.Contains((ev.Id, ex.OriginalOccurrenceStartUtc))) continue;
@@ -201,7 +230,7 @@ public class CalendarService : ICalendarService
                     Location: ex.OverrideLocation ?? ev.Location,
                     LocationUrl: ex.OverrideLocationUrl ?? ev.LocationUrl,
                     OwningTeamId: ev.OwningTeamId,
-                    OwningTeamName: ev.OwningTeam.Name,
+                    OwningTeamName: owningTeamName,
                     IsRecurring: true,
                     OriginalOccurrenceStartUtc: ex.OriginalOccurrenceStartUtc));
             }
@@ -210,13 +239,8 @@ public class CalendarService : ICalendarService
         return finalResults.OrderBy(o => o.OccurrenceStartUtc).ToList();
     }
 
-    public async Task<CalendarEvent?> GetEventByIdAsync(Guid id, CancellationToken ct = default)
-    {
-        return await _db.CalendarEvents
-            .Include(e => e.OwningTeam)
-            .Include(e => e.Exceptions)
-            .FirstOrDefaultAsync(e => e.Id == id, ct);
-    }
+    public Task<CalendarEvent?> GetEventByIdAsync(Guid id, CancellationToken ct = default) =>
+        _repo.GetEventByIdAsync(id, ct);
 
     public async Task<CalendarEvent> CreateEventAsync(CreateCalendarEventDto dto, Guid createdByUserId, CancellationToken ct = default)
     {
@@ -245,8 +269,7 @@ public class CalendarService : ICalendarService
         if (errors.Count > 0)
             throw new InvalidOperationException("CalendarEvent is invalid: " + string.Join("; ", errors));
 
-        _db.CalendarEvents.Add(ev);
-        await _db.SaveChangesAsync(ct);
+        await _repo.AddAsync(ev, ct);
 
         await _audit.LogAsync(
             AuditAction.CalendarEventCreated, nameof(CalendarEvent), ev.Id,
@@ -337,52 +360,55 @@ public class CalendarService : ICalendarService
 
     public async Task<CalendarEvent> UpdateEventAsync(Guid id, UpdateCalendarEventDto dto, Guid updatedByUserId, CancellationToken ct = default)
     {
-        var ev = await _db.CalendarEvents.FirstOrDefaultAsync(e => e.Id == id, ct)
-            ?? throw new InvalidOperationException($"CalendarEvent {id} not found.");
+        var now = _clock.GetCurrentInstant();
+        CalendarEvent? mutated = null;
 
-        ev.Title = dto.Title;
-        ev.Description = dto.Description;
-        ev.Location = dto.Location;
-        ev.LocationUrl = dto.LocationUrl;
-        ev.OwningTeamId = dto.OwningTeamId;
-        ev.StartUtc = dto.StartUtc;
-        ev.EndUtc = dto.EndUtc;
-        ev.IsAllDay = dto.IsAllDay;
-        ev.RecurrenceRule = dto.RecurrenceRule;
-        ev.RecurrenceTimezone = dto.RecurrenceTimezone;
-        ev.RecurrenceUntilUtc = ComputeRecurrenceUntilUtc(dto.RecurrenceRule, dto.RecurrenceTimezone, dto.StartUtc, dto.EndUtc);
-        ev.UpdatedAt = _clock.GetCurrentInstant();
+        var found = await _repo.UpdateAsync(id, ev =>
+        {
+            ev.Title = dto.Title;
+            ev.Description = dto.Description;
+            ev.Location = dto.Location;
+            ev.LocationUrl = dto.LocationUrl;
+            ev.OwningTeamId = dto.OwningTeamId;
+            ev.StartUtc = dto.StartUtc;
+            ev.EndUtc = dto.EndUtc;
+            ev.IsAllDay = dto.IsAllDay;
+            ev.RecurrenceRule = dto.RecurrenceRule;
+            ev.RecurrenceTimezone = dto.RecurrenceTimezone;
+            ev.RecurrenceUntilUtc = ComputeRecurrenceUntilUtc(dto.RecurrenceRule, dto.RecurrenceTimezone, dto.StartUtc, dto.EndUtc);
+            ev.UpdatedAt = now;
 
-        var errors = ev.Validate();
-        if (errors.Count > 0)
-            throw new InvalidOperationException("CalendarEvent is invalid: " + string.Join("; ", errors));
+            var errors = ev.Validate();
+            if (errors.Count > 0)
+                throw new InvalidOperationException("CalendarEvent is invalid: " + string.Join("; ", errors));
 
-        await _db.SaveChangesAsync(ct);
+            mutated = ev;
+        }, ct);
+
+        if (!found || mutated is null)
+            throw new InvalidOperationException($"CalendarEvent {id} not found.");
 
         await _audit.LogAsync(
-            AuditAction.CalendarEventUpdated, nameof(CalendarEvent), ev.Id,
-            $"Updated calendar event '{ev.Title}'",
+            AuditAction.CalendarEventUpdated, nameof(CalendarEvent), mutated.Id,
+            $"Updated calendar event '{mutated.Title}'",
             updatedByUserId,
-            relatedEntityId: ev.OwningTeamId, relatedEntityType: nameof(Team));
+            relatedEntityId: mutated.OwningTeamId, relatedEntityType: nameof(Team));
 
         InvalidateCache();
-        return ev;
+        return mutated;
     }
 
     public async Task DeleteEventAsync(Guid id, Guid deletedByUserId, CancellationToken ct = default)
     {
-        var ev = await _db.CalendarEvents.FirstOrDefaultAsync(e => e.Id == id, ct);
-        if (ev is null) return;
-        ev.DeletedAt = _clock.GetCurrentInstant();
-        ev.UpdatedAt = ev.DeletedAt.Value;
-
-        await _db.SaveChangesAsync(ct);
+        var now = _clock.GetCurrentInstant();
+        var result = await _repo.SoftDeleteAsync(id, now, ct);
+        if (result is null) return;
 
         await _audit.LogAsync(
-            AuditAction.CalendarEventDeleted, nameof(CalendarEvent), ev.Id,
-            $"Deleted calendar event '{ev.Title}'",
+            AuditAction.CalendarEventDeleted, nameof(CalendarEvent), id,
+            $"Deleted calendar event '{result.Value.Title}'",
             deletedByUserId,
-            relatedEntityId: ev.OwningTeamId, relatedEntityType: nameof(Team));
+            relatedEntityId: result.Value.OwningTeamId, relatedEntityType: nameof(Team));
 
         InvalidateCache();
     }
@@ -420,36 +446,15 @@ public class CalendarService : ICalendarService
         AuditAction auditAction, string auditDescription,
         CancellationToken ct)
     {
-        var existing = await _db.CalendarEventExceptions
-            .FirstOrDefaultAsync(x => x.EventId == eventId && x.OriginalOccurrenceStartUtc == originalUtc, ct);
-
         var now = _clock.GetCurrentInstant();
 
-        if (existing is null)
-        {
-            existing = new CalendarEventException
-            {
-                Id = Guid.NewGuid(),
-                EventId = eventId,
-                OriginalOccurrenceStartUtc = originalUtc,
-                CreatedByUserId = userId,
-                CreatedAt = now,
-                UpdatedAt = now,
-            };
-            _db.CalendarEventExceptions.Add(existing);
-        }
-        else
-        {
-            existing.UpdatedAt = now;
-        }
-
-        apply(existing);
-
-        var errors = existing.Validate();
-        if (errors.Count > 0)
-            throw new InvalidOperationException("Exception is invalid: " + string.Join("; ", errors));
-
-        await _db.SaveChangesAsync(ct);
+        await _repo.UpsertExceptionAsync(
+            eventId,
+            originalUtc,
+            createdByUserId: userId,
+            now: now,
+            apply: apply,
+            ct: ct);
 
         await _audit.LogAsync(
             auditAction, nameof(CalendarEvent), eventId,

--- a/src/Humans.Domain/Entities/CalendarEvent.cs
+++ b/src/Humans.Domain/Entities/CalendarEvent.cs
@@ -13,6 +13,15 @@ public class CalendarEvent
     public string? Location { get; set; }
     public string? LocationUrl { get; set; }
     public Guid OwningTeamId { get; set; }
+
+    /// <summary>
+    /// Cross-domain navigation to the owning <see cref="Team"/>. Kept so that
+    /// the EF configuration can still declare the FK + cascade behavior, but
+    /// the Application-layer <c>CalendarService</c> stitches team display
+    /// names via <see cref="Team"/> lookups through <c>ITeamService</c>
+    /// rather than <c>.Include()</c>-ing this nav (design-rules §6).
+    /// </summary>
+    [Obsolete("Cross-domain nav — resolve via ITeamService.GetByIdsAsync instead of navigating CalendarEvent.OwningTeam. See design-rules §6c.")]
     public Team OwningTeam { get; set; } = null!;
     public Instant StartUtc { get; set; }
     public Instant? EndUtc { get; set; }

--- a/src/Humans.Infrastructure/Data/Configurations/Calendar/CalendarEventConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/Calendar/CalendarEventConfiguration.cs
@@ -19,10 +19,16 @@ public class CalendarEventConfiguration : IEntityTypeConfiguration<CalendarEvent
         b.Property(e => e.RecurrenceTimezone).HasMaxLength(100);
         b.Property(e => e.OwningTeamId).IsRequired();
 
+        // EF needs the nav ref to configure the cross-section FK + cascade
+        // behavior. The nav itself is [Obsolete] for the Application layer
+        // (design-rules §6c) — suppress the obsolete warning only for this
+        // wiring block.
+#pragma warning disable CS0618
         b.HasOne(e => e.OwningTeam)
          .WithMany()
          .HasForeignKey(e => e.OwningTeamId)
          .OnDelete(DeleteBehavior.Restrict);
+#pragma warning restore CS0618
 
         b.HasMany(e => e.Exceptions)
          .WithOne(x => x.Event)

--- a/src/Humans.Infrastructure/Repositories/Calendar/CalendarRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Calendar/CalendarRepository.cs
@@ -1,0 +1,157 @@
+using Humans.Application.Interfaces.Repositories;
+using Humans.Domain.Entities;
+using Humans.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+using NodaTime;
+
+namespace Humans.Infrastructure.Repositories.Calendar;
+
+/// <summary>
+/// EF-backed implementation of <see cref="ICalendarRepository"/>. The only
+/// non-test file that touches the Calendar-owned DbSets
+/// (<c>CalendarEvents</c>, <c>CalendarEventExceptions</c>) after the Calendar
+/// §15 migration (issue #569) lands. Uses
+/// <see cref="IDbContextFactory{TContext}"/> so the repository can be
+/// registered as Singleton while <c>HumansDbContext</c> remains Scoped.
+/// Cross-domain navigation (<c>CalendarEvent.OwningTeam</c>) is never
+/// <c>Include</c>-ed; the service stitches team names via
+/// <see cref="Application.Interfaces.Teams.ITeamService"/>.
+/// </summary>
+public sealed class CalendarRepository : ICalendarRepository
+{
+    private readonly IDbContextFactory<HumansDbContext> _factory;
+
+    public CalendarRepository(IDbContextFactory<HumansDbContext> factory)
+    {
+        _factory = factory;
+    }
+
+    // ==========================================================================
+    // Reads
+    // ==========================================================================
+
+    public async Task<IReadOnlyList<CalendarEvent>> GetEventsInWindowAsync(
+        Instant from,
+        Instant to,
+        Guid? teamId,
+        CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+
+        var query = ctx.CalendarEvents
+            .AsNoTracking()
+            .Include(e => e.Exceptions)
+            .Where(e => e.StartUtc <= to
+                && (e.RecurrenceUntilUtc == null || e.RecurrenceUntilUtc >= from));
+
+        if (teamId is { } t)
+        {
+            query = query.Where(e => e.OwningTeamId == t);
+        }
+
+        return await query.ToListAsync(ct);
+    }
+
+    public async Task<CalendarEvent?> GetEventByIdAsync(Guid id, CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        return await ctx.CalendarEvents
+            .AsNoTracking()
+            .Include(e => e.Exceptions)
+            .FirstOrDefaultAsync(e => e.Id == id, ct);
+    }
+
+    // ==========================================================================
+    // Writes — CalendarEvent
+    // ==========================================================================
+
+    public async Task AddAsync(CalendarEvent ev, CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        ctx.CalendarEvents.Add(ev);
+        await ctx.SaveChangesAsync(ct);
+    }
+
+    public async Task<bool> UpdateAsync(
+        Guid id,
+        Action<CalendarEvent> mutate,
+        CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        var ev = await ctx.CalendarEvents.FirstOrDefaultAsync(e => e.Id == id, ct);
+        if (ev is null)
+        {
+            return false;
+        }
+
+        mutate(ev);
+        await ctx.SaveChangesAsync(ct);
+        return true;
+    }
+
+    public async Task<(Guid OwningTeamId, string Title)?> SoftDeleteAsync(
+        Guid id,
+        Instant deletedAt,
+        CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        var ev = await ctx.CalendarEvents.FirstOrDefaultAsync(e => e.Id == id, ct);
+        if (ev is null)
+        {
+            return null;
+        }
+
+        ev.DeletedAt = deletedAt;
+        ev.UpdatedAt = deletedAt;
+        await ctx.SaveChangesAsync(ct);
+        return (ev.OwningTeamId, ev.Title);
+    }
+
+    // ==========================================================================
+    // Writes — CalendarEventException
+    // ==========================================================================
+
+    public async Task UpsertExceptionAsync(
+        Guid eventId,
+        Instant originalOccurrenceStartUtc,
+        Guid createdByUserId,
+        Instant now,
+        Action<CalendarEventException> apply,
+        CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+
+        var existing = await ctx.CalendarEventExceptions
+            .FirstOrDefaultAsync(
+                x => x.EventId == eventId && x.OriginalOccurrenceStartUtc == originalOccurrenceStartUtc,
+                ct);
+
+        if (existing is null)
+        {
+            existing = new CalendarEventException
+            {
+                Id = Guid.NewGuid(),
+                EventId = eventId,
+                OriginalOccurrenceStartUtc = originalOccurrenceStartUtc,
+                CreatedByUserId = createdByUserId,
+                CreatedAt = now,
+                UpdatedAt = now,
+            };
+            ctx.CalendarEventExceptions.Add(existing);
+        }
+        else
+        {
+            existing.UpdatedAt = now;
+        }
+
+        apply(existing);
+
+        var errors = existing.Validate();
+        if (errors.Count > 0)
+        {
+            throw new InvalidOperationException("Exception is invalid: " + string.Join("; ", errors));
+        }
+
+        await ctx.SaveChangesAsync(ct);
+    }
+}

--- a/src/Humans.Web/Controllers/CalendarController.cs
+++ b/src/Humans.Web/Controllers/CalendarController.cs
@@ -155,8 +155,13 @@ public class CalendarController : HumansControllerBase
             .Take(5)
             .ToList();
 
+        // Owning-team name resolved via ITeamService per design-rules §6b —
+        // CalendarEvent.OwningTeam nav is [Obsolete] and no longer .Include()d.
+        var owningTeam = await _teams.GetTeamByIdAsync(ev.OwningTeamId, ct);
+        var owningTeamName = owningTeam?.Name ?? string.Empty;
+
         // Any authenticated human can edit; changes are audited.
-        return View(new CalendarEventViewModel(ev, upcoming, CanEdit: true, zone.Id));
+        return View(new CalendarEventViewModel(ev, owningTeamName, upcoming, CanEdit: true, zone.Id));
     }
 
     [HttpGet("Event/Create")]

--- a/src/Humans.Web/Controllers/CalendarController.cs
+++ b/src/Humans.Web/Controllers/CalendarController.cs
@@ -157,8 +157,12 @@ public class CalendarController : HumansControllerBase
 
         // Owning-team name resolved via ITeamService per design-rules §6b —
         // CalendarEvent.OwningTeam nav is [Obsolete] and no longer .Include()d.
-        var owningTeam = await _teams.GetTeamByIdAsync(ev.OwningTeamId, ct);
-        var owningTeamName = owningTeam?.Name ?? string.Empty;
+        // Use the lightweight name-only lookup so we don't hydrate the entire
+        // team aggregate (members + users) just to render a display string.
+        var teamNames = await _teams.GetTeamNamesByIdsAsync([ev.OwningTeamId], ct);
+        var owningTeamName = teamNames.TryGetValue(ev.OwningTeamId, out var name)
+            ? name
+            : string.Empty;
 
         // Any authenticated human can edit; changes are audited.
         return View(new CalendarEventViewModel(ev, owningTeamName, upcoming, CanEdit: true, zone.Id));

--- a/src/Humans.Web/Extensions/InfrastructureServiceCollectionExtensions.cs
+++ b/src/Humans.Web/Extensions/InfrastructureServiceCollectionExtensions.cs
@@ -31,6 +31,7 @@ public static class InfrastructureServiceCollectionExtensions
         services.AddCityPlanningSection(configuration);
         services.AddBudgetSection();
         services.AddShiftsSection();
+        services.AddCalendarSection();
         services.AddTicketsSection();
         services.AddFeedbackSection();
         services.AddNotificationsSection();

--- a/src/Humans.Web/Extensions/Sections/CalendarSectionExtensions.cs
+++ b/src/Humans.Web/Extensions/Sections/CalendarSectionExtensions.cs
@@ -1,0 +1,21 @@
+using Humans.Application.Interfaces.Calendar;
+using Humans.Application.Interfaces.Repositories;
+using Humans.Infrastructure.Repositories.Calendar;
+using CalendarCalendarService = Humans.Application.Services.Calendar.CalendarService;
+
+namespace Humans.Web.Extensions.Sections;
+
+internal static class CalendarSectionExtensions
+{
+    internal static IServiceCollection AddCalendarSection(this IServiceCollection services)
+    {
+        // Calendar section — §15 repository pattern (issue #569).
+        // Repository is Singleton (IDbContextFactory-based). Service is Scoped
+        // so it can pull per-request ITeamService / IAuditLogService / IClock.
+        // No caching decorator — short-TTL IMemoryCache stays in-service per §15f.
+        services.AddSingleton<ICalendarRepository, CalendarRepository>();
+        services.AddScoped<ICalendarService, CalendarCalendarService>();
+
+        return services;
+    }
+}

--- a/src/Humans.Web/Extensions/Sections/ShiftsSectionExtensions.cs
+++ b/src/Humans.Web/Extensions/Sections/ShiftsSectionExtensions.cs
@@ -1,10 +1,8 @@
 using Humans.Application.Interfaces.Gdpr;
 using Humans.Application.Interfaces.Repositories;
-using Humans.Infrastructure.Services;
 using ShiftsShiftManagementService = Humans.Application.Services.Shifts.ShiftManagementService;
 using ShiftsShiftSignupService = Humans.Application.Services.Shifts.ShiftSignupService;
 using ShiftsGeneralAvailabilityService = Humans.Application.Services.Shifts.GeneralAvailabilityService;
-using Humans.Application.Interfaces.Calendar;
 using Humans.Application.Interfaces.Shifts;
 using Humans.Infrastructure.Repositories.Shifts;
 
@@ -40,8 +38,6 @@ internal static class ShiftsSectionExtensions
         // same rationale as Users/#243 and Audit Log/#552).
         services.AddSingleton<IGeneralAvailabilityRepository, GeneralAvailabilityRepository>();
         services.AddScoped<IGeneralAvailabilityService, ShiftsGeneralAvailabilityService>();
-
-        services.AddScoped<ICalendarService, CalendarService>();
 
         return services;
     }

--- a/src/Humans.Web/Models/Calendar/CalendarEventViewModel.cs
+++ b/src/Humans.Web/Models/Calendar/CalendarEventViewModel.cs
@@ -5,6 +5,7 @@ namespace Humans.Web.Models.Calendar;
 
 public sealed record CalendarEventViewModel(
     CalendarEvent Event,
+    string OwningTeamName,
     IReadOnlyList<CalendarOccurrence> UpcomingOccurrences,
     bool CanEdit,
     string ViewerTimezoneLabel);

--- a/src/Humans.Web/Views/Calendar/Event.cshtml
+++ b/src/Humans.Web/Views/Calendar/Event.cshtml
@@ -12,7 +12,7 @@
         <div>
             <h1 class="h3 mb-0">@Model.Event.Title</h1>
             <p class="text-muted mb-0">
-                <a asp-action="Team" asp-route-teamId="@Model.Event.OwningTeamId">@Model.Event.OwningTeam.Name</a>
+                <a asp-action="Team" asp-route-teamId="@Model.Event.OwningTeamId">@Model.OwningTeamName</a>
             </p>
         </div>
         @if (Model.CanEdit)

--- a/tests/Humans.Application.Tests/Architecture/CalendarArchitectureTests.cs
+++ b/tests/Humans.Application.Tests/Architecture/CalendarArchitectureTests.cs
@@ -1,0 +1,132 @@
+using AwesomeAssertions;
+using Humans.Application.Interfaces.Calendar;
+using Humans.Application.Interfaces.Repositories;
+using Humans.Application.Interfaces.Teams;
+using Humans.Infrastructure.Repositories.Calendar;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+using CalendarService = Humans.Application.Services.Calendar.CalendarService;
+
+namespace Humans.Application.Tests.Architecture;
+
+/// <summary>
+/// Architecture tests enforcing the §15 repository pattern for the Calendar
+/// section — migrated per issue #569. Pins the invariants:
+/// <c>CalendarService</c> lives in Application, goes through
+/// <see cref="ICalendarRepository"/>, never injects <c>DbContext</c>, and
+/// resolves owning-team display names via <see cref="ITeamService"/> rather
+/// than the <c>CalendarEvent.OwningTeam</c> cross-domain nav. Calendar did
+/// not get a caching decorator — short-TTL <c>IMemoryCache</c> stays
+/// in-service per design-rules §15f.
+/// </summary>
+public class CalendarArchitectureTests
+{
+    // ── CalendarService ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void CalendarService_LivesInHumansApplicationServicesCalendarNamespace()
+    {
+        typeof(CalendarService).Namespace
+            .Should().Be("Humans.Application.Services.Calendar",
+                because: "services with business logic live in Humans.Application per design-rules §2b, organized by section");
+    }
+
+    [Fact]
+    public void CalendarService_HasNoDbContextConstructorParameter()
+    {
+        var ctor = typeof(CalendarService).GetConstructors().Single();
+        ctor.GetParameters()
+            .Should().NotContain(
+                p => typeof(DbContext).IsAssignableFrom(p.ParameterType),
+                because: "services in Humans.Application must never take DbContext — use ICalendarRepository instead (design-rules §3)");
+    }
+
+    [Fact]
+    public void CalendarService_DoesNotImportMicrosoftEntityFrameworkCore()
+    {
+        // The Application project reference graph structurally prevents this —
+        // but pin the intent with a compile-time assertion on the assembly's
+        // referenced assemblies so the test fails loudly if someone adds a
+        // transitive EF reference to Humans.Application.
+        var appAssembly = typeof(CalendarService).Assembly;
+        appAssembly.GetReferencedAssemblies()
+            .Should().NotContain(
+                a => a.Name == "Microsoft.EntityFrameworkCore",
+                because: "Humans.Application.csproj must not reference EF (design-rules §1)");
+    }
+
+    [Fact]
+    public void CalendarService_TakesRepository()
+    {
+        var ctor = typeof(CalendarService).GetConstructors().Single();
+        var paramTypes = ctor.GetParameters().Select(p => p.ParameterType).ToList();
+
+        paramTypes.Should().Contain(typeof(ICalendarRepository));
+    }
+
+    [Fact]
+    public void CalendarService_TakesTeamService()
+    {
+        var ctor = typeof(CalendarService).GetConstructors().Single();
+        var paramTypes = ctor.GetParameters().Select(p => p.ParameterType).ToList();
+
+        paramTypes.Should().Contain(typeof(ITeamService),
+            because: "owning-team display names are resolved via ITeamService cross-section (design-rules §6b, §9); CalendarEvent.OwningTeam nav is [Obsolete]");
+    }
+
+    [Fact]
+    public void CalendarService_ConstructorTakesNoStoreType()
+    {
+        var ctor = typeof(CalendarService).GetConstructors().Single();
+        var storeParam = ctor.GetParameters()
+            .FirstOrDefault(p => (p.ParameterType.Namespace ?? string.Empty)
+                .StartsWith("Humans.Application.Interfaces.Stores", StringComparison.Ordinal));
+
+        storeParam.Should().BeNull(
+            because: "Calendar §15 migration does not use a store — short-TTL IMemoryCache in-service is sufficient (§15f)");
+    }
+
+    // ── ICalendarRepository ──────────────────────────────────────────────────
+
+    [Fact]
+    public void ICalendarRepository_LivesInApplicationInterfacesRepositoriesNamespace()
+    {
+        typeof(ICalendarRepository).Namespace
+            .Should().Be("Humans.Application.Interfaces.Repositories",
+                because: "repository interfaces live in Humans.Application.Interfaces.Repositories per design-rules §3");
+    }
+
+    [Fact]
+    public void CalendarRepository_IsSealed()
+    {
+        var repoType = typeof(CalendarRepository);
+
+        repoType.IsSealed.Should().BeTrue(
+            because: "repository implementations are sealed to prevent ad-hoc extension; any new behavior belongs on the interface");
+    }
+
+    // ── CalendarEvent ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void CalendarEvent_OwningTeamNavIsObsolete()
+    {
+        var navProperty = typeof(Humans.Domain.Entities.CalendarEvent)
+            .GetProperty("OwningTeam");
+
+        navProperty.Should().NotBeNull(
+            because: "EF configuration still needs the nav reference to declare FK + cascade behavior");
+
+        navProperty!.GetCustomAttributes(typeof(ObsoleteAttribute), inherit: false)
+            .Should().NotBeEmpty(
+                because: "CalendarEvent.OwningTeam is a cross-domain nav into the Teams section; resolve via ITeamService instead (design-rules §6c)");
+    }
+
+    [Fact]
+    public void CalendarEvent_KeepsOwningTeamIdForeignKey()
+    {
+        typeof(Humans.Domain.Entities.CalendarEvent)
+            .GetProperty("OwningTeamId")
+            .Should().NotBeNull(
+                because: "FK stays — only the navigation property is [Obsolete]");
+    }
+}

--- a/tests/Humans.Application.Tests/Repositories/CalendarRepositoryTests.cs
+++ b/tests/Humans.Application.Tests/Repositories/CalendarRepositoryTests.cs
@@ -1,0 +1,320 @@
+using AwesomeAssertions;
+using Humans.Application.Tests.Infrastructure;
+using Humans.Domain.Entities;
+using Humans.Infrastructure.Data;
+using Humans.Infrastructure.Repositories.Calendar;
+using Microsoft.EntityFrameworkCore;
+using NodaTime;
+using Xunit;
+
+namespace Humans.Application.Tests.Repositories;
+
+/// <summary>
+/// Repository tests for <see cref="CalendarRepository"/> — verify the EF-backed
+/// implementation reads/writes <c>calendar_events</c> and
+/// <c>calendar_event_exceptions</c> correctly through
+/// <see cref="IDbContextFactory{HumansDbContext}"/>, with no cross-domain
+/// <c>.Include()</c>.
+/// </summary>
+public sealed class CalendarRepositoryTests : IDisposable
+{
+    private readonly HumansDbContext _dbContext;
+    private readonly CalendarRepository _repo;
+
+    public CalendarRepositoryTests()
+    {
+        var options = new DbContextOptionsBuilder<HumansDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        _dbContext = new HumansDbContext(options);
+        _repo = new CalendarRepository(new TestDbContextFactory(options));
+    }
+
+    public void Dispose()
+    {
+        _dbContext.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    // ==========================================================================
+    // AddAsync / GetEventByIdAsync
+    // ==========================================================================
+
+    [Fact]
+    public async Task AddAsync_PersistsEvent()
+    {
+        var ev = BuildEvent();
+        await _repo.AddAsync(ev);
+
+        var persisted = await _dbContext.CalendarEvents.AsNoTracking().SingleAsync();
+        persisted.Id.Should().Be(ev.Id);
+        persisted.Title.Should().Be(ev.Title);
+    }
+
+    [Fact]
+    public async Task GetEventByIdAsync_ReturnsEventWithExceptions()
+    {
+        var ev = BuildEvent();
+        await _repo.AddAsync(ev);
+
+        await _repo.UpsertExceptionAsync(
+            ev.Id,
+            ev.StartUtc,
+            createdByUserId: Guid.NewGuid(),
+            now: Instant.FromUtc(2026, 4, 10, 0, 0),
+            apply: x => x.IsCancelled = true);
+
+        var fetched = await _repo.GetEventByIdAsync(ev.Id);
+        fetched.Should().NotBeNull();
+        fetched!.Exceptions.Should().ContainSingle(x => x.IsCancelled);
+    }
+
+    [Fact]
+    public async Task GetEventByIdAsync_ReturnsNullForMissingId()
+    {
+        var fetched = await _repo.GetEventByIdAsync(Guid.NewGuid());
+        fetched.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetEventByIdAsync_DoesNotLoadOwningTeamNav()
+    {
+        var ev = BuildEvent();
+        await _repo.AddAsync(ev);
+
+        var fetched = await _repo.GetEventByIdAsync(ev.Id);
+        fetched.Should().NotBeNull();
+#pragma warning disable CS0618 // accessing the [Obsolete] nav intentionally in the assertion
+        fetched!.OwningTeam.Should().BeNull(
+            because: "CalendarRepository must not .Include(OwningTeam) — cross-domain nav resolved via ITeamService (design-rules §6c)");
+#pragma warning restore CS0618
+    }
+
+    [Fact]
+    public async Task GetEventByIdAsync_HidesSoftDeleted()
+    {
+        var ev = BuildEvent();
+        await _repo.AddAsync(ev);
+
+        await _repo.SoftDeleteAsync(ev.Id, Instant.FromUtc(2026, 4, 10, 0, 0));
+
+        var fetched = await _repo.GetEventByIdAsync(ev.Id);
+        fetched.Should().BeNull();
+    }
+
+    // ==========================================================================
+    // GetEventsInWindowAsync
+    // ==========================================================================
+
+    [Fact]
+    public async Task GetEventsInWindowAsync_FiltersByOverlap()
+    {
+        var inside = BuildEvent(
+            start: Instant.FromUtc(2026, 6, 15, 17, 0),
+            end: Instant.FromUtc(2026, 6, 15, 18, 0));
+        var outside = BuildEvent(
+            start: Instant.FromUtc(2027, 1, 1, 0, 0),
+            end: Instant.FromUtc(2027, 1, 1, 1, 0));
+
+        await _repo.AddAsync(inside);
+        await _repo.AddAsync(outside);
+
+        var events = await _repo.GetEventsInWindowAsync(
+            from: Instant.FromUtc(2026, 6, 1, 0, 0),
+            to: Instant.FromUtc(2026, 7, 1, 0, 0),
+            teamId: null);
+
+        events.Should().ContainSingle(e => e.Id == inside.Id);
+        events.Should().NotContain(e => e.Id == outside.Id);
+    }
+
+    [Fact]
+    public async Task GetEventsInWindowAsync_FiltersByTeam()
+    {
+        var teamA = Guid.NewGuid();
+        var teamB = Guid.NewGuid();
+
+        var a = BuildEvent(teamId: teamA);
+        var b = BuildEvent(teamId: teamB);
+
+        await _repo.AddAsync(a);
+        await _repo.AddAsync(b);
+
+        var events = await _repo.GetEventsInWindowAsync(
+            from: Instant.FromUtc(2026, 1, 1, 0, 0),
+            to: Instant.FromUtc(2027, 1, 1, 0, 0),
+            teamId: teamA);
+
+        events.Should().ContainSingle(e => e.Id == a.Id);
+        events.Should().NotContain(e => e.Id == b.Id);
+    }
+
+    [Fact]
+    public async Task GetEventsInWindowAsync_IncludesExceptions()
+    {
+        var ev = BuildEvent();
+        await _repo.AddAsync(ev);
+
+        await _repo.UpsertExceptionAsync(
+            ev.Id,
+            ev.StartUtc,
+            createdByUserId: Guid.NewGuid(),
+            now: Instant.FromUtc(2026, 4, 10, 0, 0),
+            apply: x => x.IsCancelled = true);
+
+        var events = await _repo.GetEventsInWindowAsync(
+            from: Instant.FromUtc(2026, 1, 1, 0, 0),
+            to: Instant.FromUtc(2027, 1, 1, 0, 0),
+            teamId: null);
+
+        events.Should().ContainSingle();
+        events[0].Exceptions.Should().ContainSingle(x => x.IsCancelled);
+    }
+
+    // ==========================================================================
+    // UpdateAsync
+    // ==========================================================================
+
+    [Fact]
+    public async Task UpdateAsync_MutatesTrackedEntity()
+    {
+        var ev = BuildEvent();
+        await _repo.AddAsync(ev);
+
+        var updated = await _repo.UpdateAsync(ev.Id, e =>
+        {
+            e.Title = "Updated title";
+            e.UpdatedAt = Instant.FromUtc(2026, 4, 10, 0, 0);
+        });
+
+        updated.Should().BeTrue();
+        var persisted = await _repo.GetEventByIdAsync(ev.Id);
+        persisted.Should().NotBeNull();
+        persisted!.Title.Should().Be("Updated title");
+    }
+
+    [Fact]
+    public async Task UpdateAsync_ReturnsFalseForMissingId()
+    {
+        var updated = await _repo.UpdateAsync(Guid.NewGuid(), _ => { });
+        updated.Should().BeFalse();
+    }
+
+    // ==========================================================================
+    // SoftDeleteAsync
+    // ==========================================================================
+
+    [Fact]
+    public async Task SoftDeleteAsync_ReturnsTeamIdAndTitleAndStampsDeletedAt()
+    {
+        var ev = BuildEvent();
+        await _repo.AddAsync(ev);
+
+        var now = Instant.FromUtc(2026, 4, 10, 0, 0);
+        var result = await _repo.SoftDeleteAsync(ev.Id, now);
+
+        result.Should().NotBeNull();
+        result!.Value.OwningTeamId.Should().Be(ev.OwningTeamId);
+        result.Value.Title.Should().Be(ev.Title);
+
+        var deletedRow = await _dbContext.CalendarEvents
+            .IgnoreQueryFilters()
+            .AsNoTracking()
+            .SingleAsync(e => e.Id == ev.Id);
+        deletedRow.DeletedAt.Should().Be(now);
+    }
+
+    [Fact]
+    public async Task SoftDeleteAsync_ReturnsNullForMissingId()
+    {
+        var result = await _repo.SoftDeleteAsync(Guid.NewGuid(), Instant.FromUtc(2026, 4, 10, 0, 0));
+        result.Should().BeNull();
+    }
+
+    // ==========================================================================
+    // UpsertExceptionAsync
+    // ==========================================================================
+
+    [Fact]
+    public async Task UpsertExceptionAsync_InsertsNewRowWhenMissing()
+    {
+        var ev = BuildEvent();
+        await _repo.AddAsync(ev);
+
+        await _repo.UpsertExceptionAsync(
+            ev.Id,
+            ev.StartUtc,
+            createdByUserId: Guid.NewGuid(),
+            now: Instant.FromUtc(2026, 4, 10, 0, 0),
+            apply: x => x.IsCancelled = true);
+
+        var exceptions = await _dbContext.CalendarEventExceptions.AsNoTracking().ToListAsync();
+        exceptions.Should().ContainSingle();
+        exceptions[0].IsCancelled.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task UpsertExceptionAsync_UpdatesExistingRowWhenPresent()
+    {
+        var ev = BuildEvent();
+        await _repo.AddAsync(ev);
+
+        await _repo.UpsertExceptionAsync(
+            ev.Id,
+            ev.StartUtc,
+            createdByUserId: Guid.NewGuid(),
+            now: Instant.FromUtc(2026, 4, 10, 0, 0),
+            apply: x => x.IsCancelled = true);
+
+        await _repo.UpsertExceptionAsync(
+            ev.Id,
+            ev.StartUtc,
+            createdByUserId: Guid.NewGuid(),
+            now: Instant.FromUtc(2026, 4, 11, 0, 0),
+            apply: x =>
+            {
+                x.IsCancelled = false;
+                x.OverrideTitle = "Overridden";
+            });
+
+        var exceptions = await _dbContext.CalendarEventExceptions.AsNoTracking().ToListAsync();
+        exceptions.Should().ContainSingle(x =>
+            !x.IsCancelled && x.OverrideTitle == "Overridden");
+    }
+
+    [Fact]
+    public async Task UpsertExceptionAsync_ThrowsWhenNeitherCancelledNorOverridden()
+    {
+        var ev = BuildEvent();
+        await _repo.AddAsync(ev);
+
+        var act = () => _repo.UpsertExceptionAsync(
+            ev.Id,
+            ev.StartUtc,
+            createdByUserId: Guid.NewGuid(),
+            now: Instant.FromUtc(2026, 4, 10, 0, 0),
+            apply: _ => { });
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    // ==========================================================================
+    // Helpers
+    // ==========================================================================
+
+    private static CalendarEvent BuildEvent(
+        Guid? teamId = null,
+        Instant? start = null,
+        Instant? end = null) => new()
+        {
+            Id = Guid.NewGuid(),
+            Title = "Test event",
+            OwningTeamId = teamId ?? Guid.NewGuid(),
+            StartUtc = start ?? Instant.FromUtc(2026, 6, 15, 17, 0),
+            EndUtc = end ?? Instant.FromUtc(2026, 6, 15, 18, 0),
+            IsAllDay = false,
+            CreatedByUserId = Guid.NewGuid(),
+            CreatedAt = Instant.FromUtc(2026, 4, 1, 12, 0),
+            UpdatedAt = Instant.FromUtc(2026, 4, 1, 12, 0),
+        };
+}

--- a/tests/Humans.Application.Tests/Services/Gdpr/GdprExportDependencyInjectionTests.cs
+++ b/tests/Humans.Application.Tests/Services/Gdpr/GdprExportDependencyInjectionTests.cs
@@ -105,7 +105,7 @@ public class GdprExportDependencyInjectionTests
         // still holds most of them, and Humans.Application is the new target
         // location per the repository/store/decorator migration — the first
         // such move is ApplicationDecisionService (Governance, PR #503).
-        var infrastructureAssembly = typeof(CalendarService).Assembly;
+        var infrastructureAssembly = typeof(TeamService).Assembly;
         var applicationAssembly = typeof(ApplicationDecisionService).Assembly;
 
         var foundContributors = new[] { infrastructureAssembly, applicationAssembly }


### PR DESCRIPTION
Migrates `CalendarService` from `Humans.Infrastructure/Services/` to `Humans.Application/Services/Calendar/` following the §15 repository pattern. Extracts `ICalendarRepository` (Singleton + `IDbContextFactory`) for the `calendar_events` and `calendar_event_exceptions` tables, strips the cross-domain `.Include(e => e.OwningTeam)` in favor of an in-memory join via `ITeamService.GetTeamNamesByIdsAsync` (§6b), marks `CalendarEvent.OwningTeam` `[Obsolete]`, and wires a dedicated `CalendarSectionExtensions` DI file.

Implements nobodies-collective/Humans#569

## Acceptance checklist

- [x] `dotnet build Humans.slnx -v quiet` clean — 0 warnings, 0 errors.
- [x] `dotnet test Humans.slnx -v quiet` all pass — 116 Domain + 1485 Application (25 new) + 32 Integration, 3 skipped (unrelated, pre-existing).
- [x] `reforge injected HumansDbContext` does not list `CalendarService` — grep confirms empty.
- [x] `reforge dbset-usage Humans.Application.Services.Calendar.CalendarService` returns 0 — confirmed.
- [x] `dotnet ef migrations add VerifyCalendar` produces empty Up/Down — confirmed, migration removed.
- [x] §8 table-ownership map updated — added **Calendar** row with `calendar_events` + `calendar_event_exceptions`. `calendar_events` was not previously in §8 (checked — #565 had not added it), so this PR is the first to list it; no duplication or shuffle.

## Section §8 row status

`calendar_events` was **not** present in §8 before this PR (verified). Added in this PR under a new **Calendar** row; no overlap with #565.

## Evidence

- Interface: `src/Humans.Application/Interfaces/Repositories/ICalendarRepository.cs`
- Repository: `src/Humans.Infrastructure/Repositories/Calendar/CalendarRepository.cs` (Singleton, `IDbContextFactory<HumansDbContext>`)
- Service: `src/Humans.Application/Services/Calendar/CalendarService.cs` (Scoped, no EF imports, short-TTL `IMemoryCache` in-service per §15f)
- DI: `src/Humans.Web/Extensions/Sections/CalendarSectionExtensions.cs` + registration in `InfrastructureServiceCollectionExtensions`
- Nav strip: `src/Humans.Domain/Entities/CalendarEvent.cs` — `OwningTeam` marked `[Obsolete]`; EF config keeps FK/cascade under `#pragma warning disable CS0618`
- View-model reshape: `CalendarEventViewModel` now carries `OwningTeamName`; controller resolves via `ITeamService.GetTeamByIdAsync` before rendering
- Tests: `CalendarArchitectureTests`, `CalendarRepositoryTests` (16 new tests total)

## Decorator recommendation

**No.** Calendar is low-traffic (community event listing). Same rationale as Governance / User / Camps. Short-TTL `IMemoryCache` (`calendar:active-events`) stays in-service per §15f.

## Smoke targets

- `/Calendar` list + filter-by-team + `/Calendar/List` + `/Calendar/Agenda`
- `/Calendar/Event/{id}` detail page (verify `OwningTeamName` still renders as the team link)
- `/Calendar/Event/Create` + `/Calendar/Event/{id}/Edit` + `/Calendar/Event/{id}/Delete`
- Occurrence cancel + override (`/Calendar/Event/{id}/Occurrence/{start}/Cancel` and `.../Edit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)