### PR TITLE
Integration test fixture: seed fully-onboarded persona (#573)

### DIFF
--- a/tests/Humans.Integration.Tests/Controllers/CalendarControllerTests.cs
+++ b/tests/Humans.Integration.Tests/Controllers/CalendarControllerTests.cs
@@ -18,32 +18,29 @@ public class CalendarControllerTests : IntegrationTestBase
         resp.StatusCode.Should().BeOneOf(HttpStatusCode.Redirect, HttpStatusCode.Found, HttpStatusCode.Unauthorized);
     }
 
-    [Fact(Skip = "Integration fixture needs fully-onboarded persona seeder — tracked in nobodies-collective/Humans#573. Bare dev-login personas hit the onboarding/consent gate and get 302'd off /Calendar.")]
+    [Fact]
     public async Task LoggedIn_Volunteer_can_GET_Calendar()
     {
-        // 1) Sign in as a bare volunteer via dev-login (sets auth cookie).
-        var loginResp = await Client.GetAsync("/dev/login/volunteer");
-        loginResp.StatusCode.Should().BeOneOf(HttpStatusCode.Redirect, HttpStatusCode.Found, HttpStatusCode.OK);
+        await Factory.SignInAsFullyOnboardedAsync(Client, DevPersona.Volunteer);
 
-        // 2) Hit the month view — should render 200.
         var resp = await Client.GetAsync("/Calendar");
         resp.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
-    [Fact(Skip = "Integration fixture needs fully-onboarded persona seeder — tracked in nobodies-collective/Humans#573.")]
+    [Fact]
     public async Task LoggedIn_Volunteer_can_GET_Create()
     {
         // Calendar editing is open to any authenticated human; changes are audited.
-        await Client.GetAsync("/dev/login/volunteer");
+        await Factory.SignInAsFullyOnboardedAsync(Client, DevPersona.Volunteer);
 
         var resp = await Client.GetAsync("/Calendar/Event/Create");
         resp.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
-    [Fact(Skip = "Integration fixture needs fully-onboarded persona seeder — tracked in nobodies-collective/Humans#573.")]
+    [Fact]
     public async Task LoggedIn_Admin_GET_Agenda_renders()
     {
-        await Client.GetAsync("/dev/login/admin");
+        await Factory.SignInAsFullyOnboardedAsync(Client, DevPersona.Admin);
 
         var resp = await Client.GetAsync("/Calendar/Agenda");
         resp.StatusCode.Should().Be(HttpStatusCode.OK);

--- a/tests/Humans.Integration.Tests/Infrastructure/HumansWebApplicationFactory.cs
+++ b/tests/Humans.Integration.Tests/Infrastructure/HumansWebApplicationFactory.cs
@@ -113,32 +113,39 @@ public class HumansWebApplicationFactory : WebApplicationFactory<Program>, IAsyn
         ArgumentNullException.ThrowIfNull(client);
         ArgumentException.ThrowIfNullOrEmpty(personaSlug);
 
+        // Normalize slug to lowercase: DevLoginController matches personas
+        // case-insensitively, but we query the seeded user below by the
+        // case-sensitive Postgres varchar email column. Mirror the email
+        // convention used by DevLoginController ($"dev-{slug}@localhost", all
+        // lowercase) so "Volunteer"/"ADMIN"/etc. still resolve.
+        var slug = personaSlug.ToLowerInvariant();
+
         // 1) Hit the dev-login endpoint. This seeds the User + Profile +
         //    RoleAssignments + TeamMembers for the persona (idempotent) and
         //    issues the Identity auth cookie on the 302 response. Cookies are
         //    captured by WebApplicationFactory's default CookieContainer even
         //    with AllowAutoRedirect=false.
-        var loginResp = await client.GetAsync($"/dev/login/{personaSlug}");
+        var loginResp = await client.GetAsync($"/dev/login/{slug}");
         if (loginResp.StatusCode is not (HttpStatusCode.Redirect
             or HttpStatusCode.Found
             or HttpStatusCode.OK))
         {
             throw new InvalidOperationException(
-                $"Dev login for persona '{personaSlug}' failed: {(int)loginResp.StatusCode} {loginResp.StatusCode}");
+                $"Dev login for persona '{slug}' failed: {(int)loginResp.StatusCode} {loginResp.StatusCode}");
         }
 
         // 2) Resolve the seeded user id by email convention used in DevLoginController.
         using var scope = Services.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<HumansDbContext>();
 
-        var email = $"dev-{personaSlug}@localhost";
+        var email = $"dev-{slug}@localhost";
         var user = await db.Users
             .AsNoTracking()
             .FirstOrDefaultAsync(u => u.Email == email)
             ?? throw new InvalidOperationException(
-                $"Persona '{personaSlug}' was not found after dev login (email {email}).");
+                $"Persona '{slug}' was not found after dev login (email {email}).");
 
-        // 3) Seed ConsentRecord for every published, required document version the
+        // 3) Seed ConsentRecord for every current required document version the
         //    user hasn't already consented to. ConsentRecord is append-only
         //    (DB triggers block UPDATE/DELETE) — INSERT is the only mutation
         //    allowed here.
@@ -149,14 +156,27 @@ public class HumansWebApplicationFactory : WebApplicationFactory<Program>, IAsyn
 
     private static async Task SeedMissingConsentsAsync(HumansDbContext db, Guid userId)
     {
-        var requiredVersions = await db.DocumentVersions
+        var now = SystemClock.Instance.GetCurrentInstant();
+
+        // Match LegalDocumentSyncService.GetRequiredVersionsAsync: one row per
+        // required+active document, picking the latest already-effective version
+        // (EffectiveFrom <= now). Seeding *every* version would give the user
+        // consent to future-effective docs and hide re-consent regressions.
+        var documentGroups = await db.DocumentVersions
             .AsNoTracking()
-            .Where(v => v.LegalDocument.IsRequired && v.LegalDocument.IsActive)
-            .Select(v => new { v.Id, CanonicalContent = v.Content })
+            .Where(v => v.LegalDocument.IsRequired
+                     && v.LegalDocument.IsActive
+                     && v.EffectiveFrom <= now)
+            .Select(v => new { v.Id, v.LegalDocumentId, v.EffectiveFrom, Content = v.Content })
             .ToListAsync();
 
-        if (requiredVersions.Count == 0)
+        if (documentGroups.Count == 0)
             return;
+
+        var currentVersions = documentGroups
+            .GroupBy(v => v.LegalDocumentId)
+            .Select(g => g.OrderByDescending(v => v.EffectiveFrom).First())
+            .ToList();
 
         var alreadyConsentedIds = await db.ConsentRecords
             .AsNoTracking()
@@ -165,15 +185,14 @@ public class HumansWebApplicationFactory : WebApplicationFactory<Program>, IAsyn
             .ToListAsync();
         var alreadyConsented = alreadyConsentedIds.ToHashSet();
 
-        var now = SystemClock.Instance.GetCurrentInstant();
-        foreach (var version in requiredVersions)
+        foreach (var version in currentVersions)
         {
             if (alreadyConsented.Contains(version.Id))
                 continue;
 
             // Mirror ConsentService.SubmitConsentAsync: hash the canonical ("es")
             // content so ContentHash matches what production would produce.
-            var canonical = version.CanonicalContent.GetValueOrDefault("es", string.Empty);
+            var canonical = version.Content.GetValueOrDefault("es", string.Empty);
             var contentHash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(canonical)))
                 .ToLowerInvariant();
 

--- a/tests/Humans.Integration.Tests/Infrastructure/HumansWebApplicationFactory.cs
+++ b/tests/Humans.Integration.Tests/Infrastructure/HumansWebApplicationFactory.cs
@@ -1,8 +1,17 @@
+using System.Net;
+using System.Net.Http;
+using System.Security.Cryptography;
+using System.Text;
+using Humans.Domain.Entities;
+using Humans.Infrastructure.Data;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using NodaTime;
 using NSubstitute;
 using Testcontainers.PostgreSql;
 using Xunit;
@@ -53,6 +62,15 @@ public class HumansWebApplicationFactory : WebApplicationFactory<Program>, IAsyn
                 services.Remove(emailDescriptor);
             services.AddScoped(_ => Substitute.For<IEmailService>());
 
+            // TestServer serves over http://localhost; production config sets
+            // CookieSecurePolicy.Always which would strip the auth cookie on
+            // insecure requests. Relax that for integration tests so the dev
+            // login flow actually establishes a session.
+            services.ConfigureApplicationCookie(options =>
+            {
+                options.Cookie.SecurePolicy = CookieSecurePolicy.SameAsRequest;
+            });
+
             RegisteredServices = services.ToList();
 
         });
@@ -67,4 +85,130 @@ public class HumansWebApplicationFactory : WebApplicationFactory<Program>, IAsyn
     {
         await _postgres.DisposeAsync();
     }
+
+    /// <summary>
+    /// Signs the given <see cref="HttpClient"/> in as a fully-onboarded persona.
+    ///
+    /// "Fully onboarded" here matches what <see cref="Program"/>'s onboarding
+    /// pipeline treats as complete for route-level access:
+    /// <list type="bullet">
+    ///   <item>User + Profile exist (seeded by <c>/dev/login/{persona}</c>).</item>
+    ///   <item>Profile is approved and the consent-check is Cleared (seeded by the
+    ///     dev-login controller — the bare persona is already
+    ///     <c>IsApproved = true</c>, <c>ConsentCheckStatus = Cleared</c>).</item>
+    ///   <item>A <see cref="ConsentRecord"/> exists for every published
+    ///     <see cref="DocumentVersion"/> whose <see cref="LegalDocument"/> is
+    ///     active and required. Integration-test DBs are fresh and have no
+    ///     legal documents by default, so this is usually a no-op; tests that
+    ///     pre-seed legal docs are covered.</item>
+    /// </list>
+    /// </summary>
+    /// <returns>The persona's user id.</returns>
+    public Task<Guid> SignInAsFullyOnboardedAsync(HttpClient client, DevPersona persona) =>
+        SignInAsFullyOnboardedAsync(client, persona.Slug);
+
+    /// <inheritdoc cref="SignInAsFullyOnboardedAsync(HttpClient, DevPersona)"/>
+    public async Task<Guid> SignInAsFullyOnboardedAsync(HttpClient client, string personaSlug)
+    {
+        ArgumentNullException.ThrowIfNull(client);
+        ArgumentException.ThrowIfNullOrEmpty(personaSlug);
+
+        // 1) Hit the dev-login endpoint. This seeds the User + Profile +
+        //    RoleAssignments + TeamMembers for the persona (idempotent) and
+        //    issues the Identity auth cookie on the 302 response. Cookies are
+        //    captured by WebApplicationFactory's default CookieContainer even
+        //    with AllowAutoRedirect=false.
+        var loginResp = await client.GetAsync($"/dev/login/{personaSlug}");
+        if (loginResp.StatusCode is not (HttpStatusCode.Redirect
+            or HttpStatusCode.Found
+            or HttpStatusCode.OK))
+        {
+            throw new InvalidOperationException(
+                $"Dev login for persona '{personaSlug}' failed: {(int)loginResp.StatusCode} {loginResp.StatusCode}");
+        }
+
+        // 2) Resolve the seeded user id by email convention used in DevLoginController.
+        using var scope = Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<HumansDbContext>();
+
+        var email = $"dev-{personaSlug}@localhost";
+        var user = await db.Users
+            .AsNoTracking()
+            .FirstOrDefaultAsync(u => u.Email == email)
+            ?? throw new InvalidOperationException(
+                $"Persona '{personaSlug}' was not found after dev login (email {email}).");
+
+        // 3) Seed ConsentRecord for every published, required document version the
+        //    user hasn't already consented to. ConsentRecord is append-only
+        //    (DB triggers block UPDATE/DELETE) — INSERT is the only mutation
+        //    allowed here.
+        await SeedMissingConsentsAsync(db, user.Id);
+
+        return user.Id;
+    }
+
+    private static async Task SeedMissingConsentsAsync(HumansDbContext db, Guid userId)
+    {
+        var requiredVersions = await db.DocumentVersions
+            .AsNoTracking()
+            .Where(v => v.LegalDocument.IsRequired && v.LegalDocument.IsActive)
+            .Select(v => new { v.Id, CanonicalContent = v.Content })
+            .ToListAsync();
+
+        if (requiredVersions.Count == 0)
+            return;
+
+        var alreadyConsentedIds = await db.ConsentRecords
+            .AsNoTracking()
+            .Where(c => c.UserId == userId)
+            .Select(c => c.DocumentVersionId)
+            .ToListAsync();
+        var alreadyConsented = alreadyConsentedIds.ToHashSet();
+
+        var now = SystemClock.Instance.GetCurrentInstant();
+        foreach (var version in requiredVersions)
+        {
+            if (alreadyConsented.Contains(version.Id))
+                continue;
+
+            // Mirror ConsentService.SubmitConsentAsync: hash the canonical ("es")
+            // content so ContentHash matches what production would produce.
+            var canonical = version.CanonicalContent.GetValueOrDefault("es", string.Empty);
+            var contentHash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(canonical)))
+                .ToLowerInvariant();
+
+            db.ConsentRecords.Add(new ConsentRecord
+            {
+                Id = Guid.NewGuid(),
+                UserId = userId,
+                DocumentVersionId = version.Id,
+                ConsentedAt = now,
+                IpAddress = "127.0.0.1",
+                UserAgent = "integration-test-fixture",
+                ContentHash = contentHash,
+                ExplicitConsent = true
+            });
+        }
+
+        await db.SaveChangesAsync();
+    }
+}
+
+/// <summary>
+/// Named dev-login personas used by integration-test fixtures. The slug
+/// matches the route segment consumed by <c>DevLoginController.SignIn</c>.
+/// </summary>
+public sealed record DevPersona(string Slug)
+{
+    /// <summary>Bare volunteer: approved, consent-check cleared, Volunteers team.</summary>
+    public static readonly DevPersona Volunteer = new("volunteer");
+
+    /// <summary>Admin persona (RoleNames.Admin). Volunteers team + Admin role.</summary>
+    public static readonly DevPersona Admin = new("admin");
+
+    /// <summary>Board member persona (RoleNames.Board). Volunteers + Board teams.</summary>
+    public static readonly DevPersona Board = new("board");
+
+    /// <summary>Coordinator persona with a seeded test department and sub-team.</summary>
+    public static readonly DevPersona Coordinator = new("coordinator");
 }


### PR DESCRIPTION
## Summary
- Adds `HumansWebApplicationFactory.SignInAsFullyOnboardedAsync(client, persona)` + `DevPersona` helper so integration tests can one-liner sign-in as a fully-onboarded persona.
- Inserts `ConsentRecord`s (append-only, respects the `consent_records` triggers) for every published, required `DocumentVersion` the user hasn't already consented to.
- Relaxes `CookieSecurePolicy` to `SameAsRequest` in `ConfigureTestServices`. Production pins it to `Always`; TestServer speaks plain `http://localhost`, so the Identity auth cookie was being stripped on every subsequent request — that was the actual reason the three Calendar tests were 302ing.
- Un-skips the three Calendar integration tests that tracked #573.

## What "fully onboarded" means here
Matches what `Program` treats as complete for authenticated route-level access:
1. User + Profile exist (seeded by `/dev/login/{persona}`).
2. Profile is approved and consent-check is `Cleared` (already set by `DevLoginController` for bare personas).
3. A `ConsentRecord` exists for every active+required `DocumentVersion`. Fresh test DBs have none, so this is typically a no-op — but the seeder is correct for fixtures that pre-seed legal documents.

## Surprise finding
The issue report framed this as "bare dev-login personas hit the onboarding/consent gate". That wasn't quite right — `DevLoginController` already seeds personas with `IsApproved=true`, `ConsentCheckStatus.Cleared`, and the `Volunteers` (+ role-specific) team memberships. The 302s were simply `Account/Login?ReturnUrl=/Calendar` because `CookieSecurePolicy.Always` was stripping the auth cookie on HTTP. So the seeder is still useful (clear intent in tests, and handles the consent case) but the cookie-policy override is the load-bearing fix.

## Test plan
- [x] `dotnet build Humans.slnx -v quiet` clean
- [x] `dotnet test Humans.slnx -v quiet` all pass (116 + 1527 + 35 = 1678, 0 skipped)
- [x] The 3 previously-skipped tests are now un-skipped and passing:
  - `LoggedIn_Volunteer_can_GET_Calendar`
  - `LoggedIn_Volunteer_can_GET_Create`
  - `LoggedIn_Admin_GET_Agenda_renders`

Closes nobodies-collective/Humans#573
Ref peterdrier/Humans#292