### PR TITLE
§15 Part 1 Jobs: route 7 non-Google Hangfire jobs through service interfaces (partial of #570)

### DIFF
--- a/src/Humans.Application/Interfaces/AuditLog/IAuditLogService.cs
+++ b/src/Humans.Application/Interfaces/AuditLog/IAuditLogService.cs
@@ -92,6 +92,20 @@ public interface IAuditLogService
     /// Batch-loads team names and slugs for a set of team IDs.
     /// </summary>
     Task<Dictionary<Guid, (string Name, string Slug)>> GetTeamNamesAsync(IReadOnlyList<Guid> teamIds, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns the distinct entity ids for audit entries whose
+    /// <see cref="AuditLogEntry.Action"/> matches <paramref name="action"/>
+    /// and whose <see cref="AuditLogEntry.OccurredAt"/> falls inside the
+    /// half-open window <c>[windowStart, windowEnd)</c>. Used by the Board
+    /// daily digest to enumerate approvals without reading
+    /// <c>audit_log_entries</c> directly (design-rules §2c).
+    /// </summary>
+    Task<IReadOnlyList<Guid>> GetEntityIdsForActionInWindowAsync(
+        NodaTime.Instant windowStart,
+        NodaTime.Instant windowEnd,
+        AuditAction action,
+        CancellationToken ct = default);
 }
 
 /// <summary>

--- a/src/Humans.Application/Interfaces/Campaigns/ICampaignService.cs
+++ b/src/Humans.Application/Interfaces/Campaigns/ICampaignService.cs
@@ -73,4 +73,17 @@ public interface ICampaignService
     /// ticket orders separately.
     /// </summary>
     Task<CampaignCodeTrackingData> GetCodeTrackingAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Updates a campaign grant's denormalized email delivery status
+    /// (<c>LatestEmailStatus</c>) and timestamp (<c>LatestEmailAt</c>).
+    /// Returns <c>true</c> if the grant was found and updated. Used by the
+    /// email outbox processor so the job can record Sent/Failed without
+    /// touching <c>campaign_grants</c> directly (design-rules §2c).
+    /// </summary>
+    Task<bool> UpdateGrantEmailStatusAsync(
+        Guid grantId,
+        Humans.Domain.Enums.EmailOutboxStatus status,
+        Instant latestEmailAt,
+        CancellationToken ct = default);
 }

--- a/src/Humans.Application/Interfaces/Governance/IApplicationDecisionService.cs
+++ b/src/Humans.Application/Interfaces/Governance/IApplicationDecisionService.cs
@@ -164,6 +164,60 @@ public interface IApplicationDecisionService
     /// admin dashboard.
     /// </summary>
     Task<int> GetPendingApplicationCountAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns every <see cref="ApplicationStatus.Approved"/> application
+    /// whose <c>TermExpiresAt</c> falls between <paramref name="today"/>
+    /// (inclusive) and <paramref name="reminderThreshold"/> (inclusive) and
+    /// whose <c>RenewalReminderSentAt</c> is still null. Used by the term
+    /// renewal reminder job so it can enumerate candidates without reading
+    /// <c>applications</c> directly (design-rules §2c).
+    /// </summary>
+    Task<IReadOnlyList<MemberApplication>> GetExpiringApplicationsNeedingReminderAsync(
+        LocalDate today, LocalDate reminderThreshold, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns the distinct (UserId, MembershipTier) pairs that currently
+    /// have a <see cref="ApplicationStatus.Submitted"/> application. Used by
+    /// the term renewal reminder job to exclude users who have already filed
+    /// a renewal.
+    /// </summary>
+    Task<IReadOnlySet<(Guid UserId, MembershipTier Tier)>> GetPendingApplicationUserTiersAsync(
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Stamps <c>Application.RenewalReminderSentAt</c> to
+    /// <paramref name="sentAt"/>. No-op if the application does not exist.
+    /// Used by the term renewal reminder job so it never writes to
+    /// <c>applications</c> directly.
+    /// </summary>
+    Task MarkRenewalReminderSentAsync(
+        Guid applicationId, Instant sentAt, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns every <see cref="ApplicationStatus.Approved"/> application
+    /// resolved within the half-open window
+    /// <c>[windowStart, windowEnd)</c>. Used by the Board daily digest.
+    /// </summary>
+    Task<IReadOnlyList<MemberApplication>> GetApprovedInWindowAsync(
+        Instant windowStart, Instant windowEnd, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns the ids of every <see cref="ApplicationStatus.Submitted"/>
+    /// application. Used by the Board daily digest.
+    /// </summary>
+    Task<IReadOnlyList<Guid>> GetSubmittedApplicationIdsAsync(
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns the count of applications in <paramref name="applicationIds"/>
+    /// that the given board member has NOT yet voted on. Used by the Board
+    /// daily digest per-member queue size.
+    /// </summary>
+    Task<int> GetUnvotedCountForBoardMemberAmongApplicationsAsync(
+        Guid boardMemberUserId,
+        IReadOnlyCollection<Guid> applicationIds,
+        CancellationToken ct = default);
 }
 
 public record ApplicationDecisionResult(bool Success, string? ErrorKey = null, Guid? ApplicationId = null);

--- a/src/Humans.Application/Interfaces/Profiles/IProfileService.cs
+++ b/src/Humans.Application/Interfaces/Profiles/IProfileService.cs
@@ -193,4 +193,17 @@ public interface IProfileService
     /// cache refresh.
     /// </summary>
     Task<bool> SetConsentCheckPendingAsync(Guid userId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Anonymizes the personal fields of the user's profile for GDPR
+    /// expiry-based deletion: clears first/last name → "Deleted"/"User",
+    /// burner name → empty, and blanks every optional demographic /
+    /// emergency-contact / admin-note / contribution-interest field. Also
+    /// removes every <c>ContactField</c> and <c>VolunteerHistoryEntry</c> row
+    /// owned by the profile in the same save. No-op if the user has no
+    /// profile. Returns <c>true</c> if a profile was anonymized. Used by the
+    /// account deletion job via
+    /// <see cref="Users.IUserService.AnonymizeExpiredAccountAsync"/>.
+    /// </summary>
+    Task<bool> AnonymizeExpiredProfileAsync(Guid userId, CancellationToken ct = default);
 }

--- a/src/Humans.Application/Interfaces/Repositories/IApplicationRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/IApplicationRepository.cs
@@ -154,6 +154,57 @@ public interface IApplicationRepository
     /// application block. All counts exclude <see cref="ApplicationStatus.Withdrawn"/>.
     /// </summary>
     Task<ApplicationAdminStats> GetAdminStatsAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns every Approved application whose <c>TermExpiresAt</c> falls
+    /// between <paramref name="today"/> (inclusive) and
+    /// <paramref name="reminderThreshold"/> (inclusive) and whose
+    /// <c>RenewalReminderSentAt</c> is still null. Read-only.
+    /// </summary>
+    Task<IReadOnlyList<MemberApplication>> GetExpiringApplicationsNeedingReminderAsync(
+        LocalDate today, LocalDate reminderThreshold, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns the distinct <c>(UserId, MembershipTier)</c> pairs across
+    /// every Submitted application. Used by the term renewal reminder
+    /// to suppress renewals for users who already have a pending application.
+    /// </summary>
+    Task<IReadOnlySet<(Guid UserId, MembershipTier Tier)>> GetPendingApplicationUserTiersAsync(
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns Approved applications that have been resolved within
+    /// the half-open window <c>[windowStart, windowEnd)</c>, ordered by
+    /// <see cref="MembershipTier"/> then <c>ResolvedAt</c>. Used by the
+    /// Board daily digest.
+    /// </summary>
+    Task<IReadOnlyList<MemberApplication>> GetApprovedInWindowAsync(
+        Instant windowStart, Instant windowEnd, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns every Submitted application id. Used by the Board daily
+    /// digest to compute per-member unvoted counts without re-loading the
+    /// full application set.
+    /// </summary>
+    Task<IReadOnlyList<Guid>> GetSubmittedApplicationIdsAsync(
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns the number of applications from <paramref name="applicationIds"/>
+    /// that the given board member has NOT yet voted on. Used by the Board
+    /// daily digest to render the per-member queue size.
+    /// </summary>
+    Task<int> GetUnvotedCountForBoardMemberAmongApplicationsAsync(
+        Guid boardMemberUserId,
+        IReadOnlyCollection<Guid> applicationIds,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Stamps <c>Application.RenewalReminderSentAt</c> to
+    /// <paramref name="sentAt"/>. No-op if the application does not exist.
+    /// </summary>
+    Task MarkRenewalReminderSentAsync(
+        Guid applicationId, Instant sentAt, CancellationToken ct = default);
 }
 
 /// <summary>

--- a/src/Humans.Application/Interfaces/Repositories/IAuditLogRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/IAuditLogRepository.cs
@@ -108,4 +108,16 @@ public interface IAuditLogRepository
     /// </summary>
     Task<Dictionary<Guid, (string Name, string Slug)>> GetTeamNamesAsync(
         IReadOnlyList<Guid> teamIds, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns the distinct entity ids of audit rows whose
+    /// <see cref="AuditLogEntry.Action"/> matches <paramref name="action"/>
+    /// and whose <see cref="AuditLogEntry.OccurredAt"/> falls inside the
+    /// half-open window <c>[windowStart, windowEnd)</c>. Read-only.
+    /// </summary>
+    Task<IReadOnlyList<Guid>> GetEntityIdsForActionInWindowAsync(
+        NodaTime.Instant windowStart,
+        NodaTime.Instant windowEnd,
+        AuditAction action,
+        CancellationToken ct = default);
 }

--- a/src/Humans.Application/Interfaces/Repositories/IProfileRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/IProfileRepository.cs
@@ -151,6 +151,20 @@ public interface IProfileRepository
     Task<bool> AnonymizeForMergeByUserIdAsync(Guid userId, CancellationToken ct = default);
 
     /// <summary>
+    /// Same set of writes as <see cref="AnonymizeForMergeByUserIdAsync"/>,
+    /// but labels the anonymized row as <c>"Deleted User"</c> instead of
+    /// <c>"Merged User"</c>. Used by the expired-deletion job path so the
+    /// post-anonymization audit log, profile view, etc. identify the record
+    /// as a GDPR-erasure outcome rather than an account merge.
+    /// </summary>
+    /// <remarks>
+    /// No-op if the user has no profile. Returns true when a profile existed
+    /// and was anonymized. Language rows (<see cref="ProfileLanguage"/>) are
+    /// intentionally left as-is; they are not personally identifying.
+    /// </remarks>
+    Task<bool> AnonymizeForDeletionByUserIdAsync(Guid userId, CancellationToken ct = default);
+
+    /// <summary>
     /// Reconciles the CV-entry collection for the given profile with the
     /// provided set, keyed by <see cref="CVEntry.Id"/>:
     /// <list type="bullet">

--- a/src/Humans.Application/Interfaces/Repositories/IShiftManagementRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/IShiftManagementRepository.cs
@@ -342,4 +342,13 @@ public interface IShiftManagementRepository
 
     Task UpdateVolunteerEventProfileAsync(
         VolunteerEventProfile profile, CancellationToken ct = default);
+
+    /// <summary>
+    /// Deletes every <c>VolunteerEventProfile</c> row belonging to
+    /// <paramref name="userId"/>. Returns the number of rows removed. Used by
+    /// the account anonymization flow so the Shifts section owns
+    /// <c>volunteer_event_profiles</c> writes (design-rules §2c).
+    /// </summary>
+    Task<int> DeleteVolunteerEventProfilesForUserAsync(
+        Guid userId, CancellationToken ct = default);
 }

--- a/src/Humans.Application/Interfaces/Repositories/IShiftSignupRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/IShiftSignupRepository.cs
@@ -221,4 +221,14 @@ public interface IShiftSignupRepository
     /// calls made in the same request.
     /// </summary>
     Task SaveChangesAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Cancels every <c>Confirmed</c> or <c>Pending</c> signup belonging to
+    /// <paramref name="userId"/>, stamping the supplied <paramref name="reason"/>
+    /// and persisting in one <c>SaveChangesAsync</c> call. Returns the id and
+    /// shift id of each signup that was cancelled so the caller can emit
+    /// per-signup audit entries.
+    /// </summary>
+    Task<IReadOnlyList<(Guid SignupId, Guid ShiftId)>> CancelActiveSignupsForUserAsync(
+        Guid userId, string reason, CancellationToken ct = default);
 }

--- a/src/Humans.Application/Interfaces/Repositories/ITeamRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/ITeamRepository.cs
@@ -383,6 +383,14 @@ public interface ITeamRepository
     /// <summary>Total pending join requests across all teams.</summary>
     Task<int> GetTotalPendingCountAsync(CancellationToken ct = default);
 
+    /// <summary>
+    /// Distinct user ids of every active (<see cref="TeamMember.LeftAt"/> is null)
+    /// <see cref="TeamMemberRole.Coordinator"/> on a non-system team
+    /// (<see cref="Team.SystemTeamType"/> == <see cref="SystemTeamType.None"/>).
+    /// </summary>
+    Task<IReadOnlyList<Guid>> GetActiveNonSystemTeamCoordinatorUserIdsAsync(
+        CancellationToken ct = default);
+
     /// <summary>Inserts a new join request.</summary>
     Task AddRequestAsync(TeamJoinRequest request, CancellationToken ct = default);
 

--- a/src/Humans.Application/Interfaces/Repositories/IUserRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/IUserRepository.cs
@@ -209,6 +209,41 @@ public interface IUserRepository
     /// </summary>
     Task<int> GetPendingDeletionCountAsync(CancellationToken ct = default);
 
+    /// <summary>
+    /// Sets <c>User.LastConsentReminderSentAt</c> to <paramref name="sentAt"/>.
+    /// No-op if the user does not exist.
+    /// </summary>
+    Task SetLastConsentReminderSentAsync(
+        Guid userId, Instant sentAt, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns the count of users whose <c>GoogleEmailStatus</c> equals
+    /// <see cref="GoogleEmailStatus.Rejected"/>. Used by the admin digest.
+    /// </summary>
+    Task<int> GetRejectedGoogleEmailCountAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns the ids of every user whose <c>DeletionScheduledFor</c> is at
+    /// or before <paramref name="now"/> and whose <c>DeletionEligibleAfter</c>
+    /// is either null or at or before <paramref name="now"/>. Used by the
+    /// account deletion job to enumerate expired candidates.
+    /// </summary>
+    Task<IReadOnlyList<Guid>> GetAccountsDueForAnonymizationAsync(
+        Instant now, CancellationToken ct = default);
+
+    /// <summary>
+    /// Applies the identity-level fields of the GDPR expiry anonymization in
+    /// one atomic save: renames the user to <c>Deleted User</c> + sentinel
+    /// email, removes every <c>UserEmail</c> row, clears phone/picture/iCal
+    /// token, clears all deletion fields, sets the security stamp, and
+    /// permanently locks out the account. Returns a small summary of the
+    /// prior identity (effective email, display name, preferred language) or
+    /// <c>null</c> if the user does not exist. Used by the account deletion
+    /// job via <see cref="AnonymizeExpiredAccountAsync"/>.
+    /// </summary>
+    Task<ExpiredDeletionAnonymizationResult?> ApplyExpiredDeletionAnonymizationAsync(
+        Guid userId, CancellationToken ct = default);
+
     // ==========================================================================
     // Reads — EventParticipation
     // ==========================================================================
@@ -274,3 +309,20 @@ public interface IUserRepository
         IReadOnlyList<(Guid UserId, ParticipationStatus Status)> entries,
         CancellationToken ct = default);
 }
+
+/// <summary>
+/// Slice returned from <see cref="IUserRepository.ApplyExpiredDeletionAnonymizationAsync"/>
+/// so the service layer can send the confirmation email and log audit entries
+/// without re-loading the (now anonymized) user.
+/// </summary>
+/// <param name="OriginalEmail">
+/// The effective email on the account before anonymization (preferring the
+/// verified notification-target <c>UserEmail</c> row, falling back to
+/// <c>User.Email</c>). May be null when the account never had an email.
+/// </param>
+/// <param name="OriginalDisplayName">Display name on the user before the write.</param>
+/// <param name="PreferredLanguage">Preferred language on the user before the write.</param>
+public record ExpiredDeletionAnonymizationResult(
+    string? OriginalEmail,
+    string OriginalDisplayName,
+    string PreferredLanguage);

--- a/src/Humans.Application/Interfaces/Repositories/IUserRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/IUserRepository.cs
@@ -37,6 +37,15 @@ public interface IUserRepository
         CancellationToken ct = default);
 
     /// <summary>
+    /// Same as <see cref="GetByIdsAsync"/> but includes each user's
+    /// <see cref="User.UserEmails"/> collection so callers can resolve
+    /// <see cref="User.GetEffectiveEmail"/> correctly. Read-only (AsNoTracking).
+    /// </summary>
+    Task<IReadOnlyDictionary<Guid, User>> GetByIdsWithEmailsAsync(
+        IReadOnlyCollection<Guid> userIds,
+        CancellationToken ct = default);
+
+    /// <summary>
     /// Loads every user, read-only (AsNoTracking). Used by admin list views
     /// that must include profileless users. Trivial at ~500-user scale.
     /// </summary>

--- a/src/Humans.Application/Interfaces/Shifts/IShiftManagementService.cs
+++ b/src/Humans.Application/Interfaces/Shifts/IShiftManagementService.cs
@@ -290,6 +290,15 @@ public interface IShiftManagementService
     /// Gets a user's shift profile. Medical data included only when includeMedical=true.
     /// </summary>
     Task<VolunteerEventProfile?> GetShiftProfileAsync(Guid userId, bool includeMedical);
+
+    /// <summary>
+    /// Deletes every <c>VolunteerEventProfile</c> row owned by
+    /// <paramref name="userId"/>. Returns the number of rows removed. Used by
+    /// the account anonymization flow so the job does not write to
+    /// <c>volunteer_event_profiles</c> directly (design-rules §2c).
+    /// </summary>
+    Task<int> DeleteShiftProfilesForUserAsync(
+        Guid userId, CancellationToken ct = default);
 }
 
 /// <summary>

--- a/src/Humans.Application/Interfaces/Shifts/IShiftSignupService.cs
+++ b/src/Humans.Application/Interfaces/Shifts/IShiftSignupService.cs
@@ -104,6 +104,17 @@ public interface IShiftSignupService
     /// </summary>
     Task<(HashSet<Guid> ShiftIds, Dictionary<Guid, SignupStatus> Statuses)> GetActiveSignupStatusesAsync(
         Guid userId, Guid eventSettingsId);
+
+    /// <summary>
+    /// Cancels every Confirmed or Pending signup owned by
+    /// <paramref name="userId"/> with the supplied <paramref name="reason"/>,
+    /// in one atomic save. Returns the id + shift id of each signup that was
+    /// cancelled so callers (account deletion job) can emit per-signup audit
+    /// entries. Used by the account anonymization flow so the job does not
+    /// write to <c>shift_signups</c> directly (design-rules §2c).
+    /// </summary>
+    Task<IReadOnlyList<(Guid SignupId, Guid ShiftId)>> CancelActiveSignupsForUserAsync(
+        Guid userId, string reason, CancellationToken ct = default);
 }
 
 /// <summary>

--- a/src/Humans.Application/Interfaces/Teams/ITeamService.cs
+++ b/src/Humans.Application/Interfaces/Teams/ITeamService.cs
@@ -666,4 +666,15 @@ public interface ITeamService
     /// directly (design-rules §2c).
     /// </summary>
     Task<int> GetTotalPendingJoinRequestCountAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns the distinct user ids of every active
+    /// (<see cref="TeamMember.LeftAt"/> is null)
+    /// <see cref="TeamMemberRole.Coordinator"/> on a non-system team.
+    /// Used by the Admin daily digest to compute pending-consent counts
+    /// for team coordinators without reading
+    /// <c>team_members</c> directly (design-rules §2c).
+    /// </summary>
+    Task<IReadOnlyList<Guid>> GetActiveNonSystemTeamCoordinatorUserIdsAsync(
+        CancellationToken cancellationToken = default);
 }

--- a/src/Humans.Application/Interfaces/Tickets/ITicketSyncService.cs
+++ b/src/Humans.Application/Interfaces/Tickets/ITicketSyncService.cs
@@ -26,7 +26,21 @@ public interface ITicketSyncService
     /// section read <c>ticket_sync_states</c> directly (design-rules §2c).
     /// </summary>
     Task<bool> IsInErrorStateAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns the current error state plus the most recent error message
+    /// recorded on the singleton ticket sync state row. <see cref="ErrorMessage"/>
+    /// is null unless <see cref="InError"/> is true. Used by the Admin daily
+    /// digest so the digest can render the specific failure message without
+    /// reading <c>ticket_sync_states</c> directly (design-rules §2c).
+    /// </summary>
+    Task<TicketSyncErrorStatus> GetErrorStatusAsync(CancellationToken ct = default);
 }
+
+/// <summary>
+/// Ticket sync error state shape used by the Admin daily digest.
+/// </summary>
+public record TicketSyncErrorStatus(bool InError, string? ErrorMessage);
 
 /// <summary>Summary of a sync operation.</summary>
 public record TicketSyncResult(

--- a/src/Humans.Application/Interfaces/Users/IUserService.cs
+++ b/src/Humans.Application/Interfaces/Users/IUserService.cs
@@ -192,4 +192,78 @@ public interface IUserService
     /// table directly (design-rules §2c).
     /// </summary>
     Task<int> GetPendingDeletionCountAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Sets <c>User.LastConsentReminderSentAt</c> to <paramref name="sentAt"/>.
+    /// No-op if the user does not exist. Used by the re-consent reminder job
+    /// so it does not write to the Users table directly (design-rules §2c).
+    /// </summary>
+    Task SetLastConsentReminderSentAsync(
+        Guid userId, Instant sentAt, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns the count of users whose <see cref="User.GoogleEmailStatus"/>
+    /// equals <see cref="Humans.Domain.Enums.GoogleEmailStatus.Rejected"/>.
+    /// Used by the admin daily digest so the job does not read the users
+    /// table directly (design-rules §2c).
+    /// </summary>
+    Task<int> GetRejectedGoogleEmailCountAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns the user ids of every account with <c>DeletionScheduledFor</c>
+    /// in the past (or equal to <paramref name="now"/>) and with
+    /// <c>DeletionEligibleAfter</c> either null or already elapsed. Used by
+    /// the account deletion job to enumerate candidates without reading the
+    /// Users table directly (design-rules §2c).
+    /// </summary>
+    Task<IReadOnlyList<Guid>> GetAccountsDueForAnonymizationAsync(
+        Instant now, CancellationToken ct = default);
+
+    /// <summary>
+    /// Anonymizes the identity portion of a user whose 30-day deletion grace
+    /// period has expired: display name, username, email fields, profile
+    /// picture, phone number, deletion fields, security stamp, iCal token,
+    /// and lockout are all cleared or replaced with sentinels. Removes
+    /// <c>UserEmail</c> rows, ends active team memberships (via
+    /// <see cref="Teams.ITeamService.RevokeAllMembershipsAsync"/>) and active
+    /// governance role assignments, anonymizes the profile (via
+    /// <see cref="Profiles.IProfileService"/>), removes contact fields,
+    /// volunteer history, volunteer event profiles (via
+    /// <see cref="Shifts.IShiftManagementService"/>) and cancels active shift
+    /// signups (via <see cref="Shifts.IShiftSignupService"/>). Returns an
+    /// <see cref="AnonymizedAccountSummary"/> describing the prior identity,
+    /// the user's preferred language, and the ids of any shift signups that
+    /// were cancelled, or null if the user does not exist. Invalidates the
+    /// FullProfile cache, role-assignment claims, shift-authorization, and
+    /// the Teams member cache.
+    /// </summary>
+    Task<AnonymizedAccountSummary?> AnonymizeExpiredAccountAsync(
+        Guid userId, Instant now, CancellationToken ct = default);
 }
+
+/// <summary>
+/// Summary returned from <see cref="IUserService.AnonymizeExpiredAccountAsync"/>
+/// so the caller (account deletion job) can send a confirmation email and
+/// write the corresponding audit log entries without re-loading the
+/// anonymized row.
+/// </summary>
+/// <param name="OriginalEmail">
+/// The effective email on the account before anonymization. May be null
+/// when the account never had an email set.
+/// </param>
+/// <param name="OriginalDisplayName">
+/// The display name on the account before anonymization.
+/// </param>
+/// <param name="PreferredLanguage">
+/// The user's preferred language, used to render the confirmation email.
+/// </param>
+/// <param name="CancelledSignupIds">
+/// The id of each shift signup that was cancelled as part of the
+/// anonymization, paired with the shift it belonged to. Used by the caller
+/// to emit per-signup audit entries.
+/// </param>
+public record AnonymizedAccountSummary(
+    string? OriginalEmail,
+    string OriginalDisplayName,
+    string PreferredLanguage,
+    IReadOnlyList<(Guid SignupId, Guid ShiftId)> CancelledSignupIds);

--- a/src/Humans.Application/Interfaces/Users/IUserService.cs
+++ b/src/Humans.Application/Interfaces/Users/IUserService.cs
@@ -28,6 +28,19 @@ public interface IUserService
         CancellationToken ct = default);
 
     /// <summary>
+    /// Same as <see cref="GetByIdsAsync"/> but also hydrates each user's
+    /// <see cref="User.UserEmails"/> collection so callers can resolve
+    /// <see cref="User.GetEffectiveEmail"/> (the verified notification-target
+    /// address) without a second round-trip. Used by notification-sending
+    /// jobs (digests, re-consent reminder, term renewal) so the correct
+    /// recipient is picked instead of silently falling back to
+    /// <see cref="User.Email"/>.
+    /// </summary>
+    Task<IReadOnlyDictionary<Guid, User>> GetByIdsWithEmailsAsync(
+        IReadOnlyCollection<Guid> userIds,
+        CancellationToken ct = default);
+
+    /// <summary>
     /// Get the participation record for a user in a given year. Returns null if no record exists.
     /// </summary>
     Task<EventParticipation?> GetParticipationAsync(Guid userId, int year, CancellationToken ct = default);

--- a/src/Humans.Application/Services/AuditLog/AuditLogService.cs
+++ b/src/Humans.Application/Services/AuditLog/AuditLogService.cs
@@ -261,4 +261,11 @@ public sealed class AuditLogService : IAuditLogService, IUserDataContributor
 
         return [new UserDataSlice(GdprExportSections.AuditLog, shaped)];
     }
+
+    public Task<IReadOnlyList<Guid>> GetEntityIdsForActionInWindowAsync(
+        NodaTime.Instant windowStart,
+        NodaTime.Instant windowEnd,
+        AuditAction action,
+        CancellationToken ct = default) =>
+        _repo.GetEntityIdsForActionInWindowAsync(windowStart, windowEnd, action, ct);
 }

--- a/src/Humans.Application/Services/Campaigns/CampaignService.cs
+++ b/src/Humans.Application/Services/Campaigns/CampaignService.cs
@@ -657,4 +657,11 @@ public sealed class CampaignService : ICampaignService, IUserDataContributor
 
         return [new UserDataSlice(GdprExportSections.CampaignGrants, shaped)];
     }
+
+    public Task<bool> UpdateGrantEmailStatusAsync(
+        Guid grantId,
+        EmailOutboxStatus status,
+        Instant latestEmailAt,
+        CancellationToken ct = default) =>
+        _repository.UpdateGrantStatusAsync(grantId, status, latestEmailAt, ct);
 }

--- a/src/Humans.Application/Services/Governance/ApplicationDecisionService.cs
+++ b/src/Humans.Application/Services/Governance/ApplicationDecisionService.cs
@@ -633,6 +633,33 @@ public sealed class ApplicationDecisionService : IApplicationDecisionService, IU
     public Task<int> GetPendingApplicationCountAsync(CancellationToken ct = default) =>
         _repository.CountByStatusAsync(ApplicationStatus.Submitted, ct);
 
+    public Task<IReadOnlyList<MemberApplication>> GetExpiringApplicationsNeedingReminderAsync(
+        LocalDate today, LocalDate reminderThreshold, CancellationToken ct = default) =>
+        _repository.GetExpiringApplicationsNeedingReminderAsync(today, reminderThreshold, ct);
+
+    public Task<IReadOnlySet<(Guid UserId, MembershipTier Tier)>> GetPendingApplicationUserTiersAsync(
+        CancellationToken ct = default) =>
+        _repository.GetPendingApplicationUserTiersAsync(ct);
+
+    public Task MarkRenewalReminderSentAsync(
+        Guid applicationId, Instant sentAt, CancellationToken ct = default) =>
+        _repository.MarkRenewalReminderSentAsync(applicationId, sentAt, ct);
+
+    public Task<IReadOnlyList<MemberApplication>> GetApprovedInWindowAsync(
+        Instant windowStart, Instant windowEnd, CancellationToken ct = default) =>
+        _repository.GetApprovedInWindowAsync(windowStart, windowEnd, ct);
+
+    public Task<IReadOnlyList<Guid>> GetSubmittedApplicationIdsAsync(
+        CancellationToken ct = default) =>
+        _repository.GetSubmittedApplicationIdsAsync(ct);
+
+    public Task<int> GetUnvotedCountForBoardMemberAmongApplicationsAsync(
+        Guid boardMemberUserId,
+        IReadOnlyCollection<Guid> applicationIds,
+        CancellationToken ct = default) =>
+        _repository.GetUnvotedCountForBoardMemberAmongApplicationsAsync(
+            boardMemberUserId, applicationIds, ct);
+
     public async Task UpdateDraftApplicationAsync(
         Guid applicationId, MembershipTier tier, string motivation,
         string? additionalInfo, string? significantContribution, string? roleUnderstanding,

--- a/src/Humans.Application/Services/Profile/ProfileService.cs
+++ b/src/Humans.Application/Services/Profile/ProfileService.cs
@@ -997,6 +997,9 @@ public sealed class ProfileService : IProfileService, IUserDataContributor
         return true;
     }
 
+    public Task<bool> AnonymizeExpiredProfileAsync(Guid userId, CancellationToken ct = default) =>
+        _profileRepository.AnonymizeForDeletionByUserIdAsync(userId, ct);
+
     // ==========================================================================
     // Helpers
     // ==========================================================================

--- a/src/Humans.Application/Services/Shifts/ShiftManagementService.cs
+++ b/src/Humans.Application/Services/Shifts/ShiftManagementService.cs
@@ -1396,4 +1396,8 @@ public sealed class ShiftManagementService : IShiftManagementService, IShiftAuth
 
         return profile;
     }
+
+    public Task<int> DeleteShiftProfilesForUserAsync(
+        Guid userId, CancellationToken ct = default) =>
+        _repo.DeleteVolunteerEventProfilesForUserAsync(userId, ct);
 }

--- a/src/Humans.Application/Services/Shifts/ShiftSignupService.cs
+++ b/src/Humans.Application/Services/Shifts/ShiftSignupService.cs
@@ -1068,4 +1068,8 @@ public sealed class ShiftSignupService : IShiftSignupService, IUserDataContribut
 
         return [signupSlice, vepSlice, availabilitySlice, tagPreferenceSlice];
     }
+
+    public Task<IReadOnlyList<(Guid SignupId, Guid ShiftId)>> CancelActiveSignupsForUserAsync(
+        Guid userId, string reason, CancellationToken ct = default) =>
+        _repo.CancelActiveSignupsForUserAsync(userId, reason, ct);
 }

--- a/src/Humans.Application/Services/Teams/TeamService.cs
+++ b/src/Humans.Application/Services/Teams/TeamService.cs
@@ -1759,6 +1759,10 @@ public sealed class TeamService : ITeamService, IUserDataContributor
     public Task<int> GetTotalPendingJoinRequestCountAsync(CancellationToken cancellationToken = default) =>
         _repo.GetTotalPendingCountAsync(cancellationToken);
 
+    public Task<IReadOnlyList<Guid>> GetActiveNonSystemTeamCoordinatorUserIdsAsync(
+        CancellationToken cancellationToken = default) =>
+        _repo.GetActiveNonSystemTeamCoordinatorUserIdsAsync(cancellationToken);
+
     public Task<IReadOnlyDictionary<Guid, string>> GetManagementRoleNamesByTeamIdsAsync(
         IEnumerable<Guid> teamIds,
         CancellationToken cancellationToken = default) =>

--- a/src/Humans.Application/Services/Tickets/TicketSyncService.cs
+++ b/src/Humans.Application/Services/Tickets/TicketSyncService.cs
@@ -438,6 +438,13 @@ public sealed class TicketSyncService : ITicketSyncService
         return syncState?.SyncStatus == TicketSyncStatus.Error;
     }
 
+    public async Task<TicketSyncErrorStatus> GetErrorStatusAsync(CancellationToken ct = default)
+    {
+        var syncState = await _ticketRepository.GetSyncStateAsync(ct);
+        var inError = syncState?.SyncStatus == TicketSyncStatus.Error;
+        return new TicketSyncErrorStatus(inError, inError ? syncState?.LastError : null);
+    }
+
     /// <summary>
     /// Derive EventParticipation records from current ticket data.
     /// For each matched user: 1+ valid tickets → Ticketed, any checked-in → Attended.

--- a/src/Humans.Application/Services/Users/UserService.cs
+++ b/src/Humans.Application/Services/Users/UserService.cs
@@ -1,12 +1,16 @@
 using Humans.Application.Extensions;
+using Humans.Application.Interfaces.Auth;
+using Humans.Application.Interfaces.Caching;
 using Humans.Application.Interfaces.Gdpr;
 using Humans.Application.Interfaces.Profiles;
 using Humans.Application.Interfaces.Repositories;
+using Humans.Application.Interfaces.Shifts;
 using Humans.Application.Interfaces.Teams;
 using Humans.Application.Interfaces.Users;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Humans.Domain.Helpers;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NodaTime;
 
@@ -31,16 +35,30 @@ public sealed class UserService : IUserService, IUserDataContributor
     private readonly IUserRepository _repo;
     private readonly IFullProfileInvalidator _fullProfileInvalidator;
     private readonly ITeamService _teamService;
+    private readonly IServiceProvider _serviceProvider;
+    private readonly IRoleAssignmentClaimsCacheInvalidator _roleAssignmentClaimsInvalidator;
+    private readonly IShiftAuthorizationInvalidator _shiftAuthorizationInvalidator;
     private readonly IClock _clock;
     private readonly ILogger<UserService> _logger;
 
     private readonly IUserEmailRepository _userEmailRepo;
+
+    // Lazy-resolved to avoid construction-time cycles with sections that
+    // already inject IUserService themselves (IProfileService, etc.). Used
+    // only by the expired-deletion anonymization path.
+    private IProfileService ProfileService => _serviceProvider.GetRequiredService<IProfileService>();
+    private IRoleAssignmentService RoleAssignmentService => _serviceProvider.GetRequiredService<IRoleAssignmentService>();
+    private IShiftSignupService ShiftSignupService => _serviceProvider.GetRequiredService<IShiftSignupService>();
+    private IShiftManagementService ShiftManagementService => _serviceProvider.GetRequiredService<IShiftManagementService>();
 
     public UserService(
         IUserRepository repo,
         IUserEmailRepository userEmailRepo,
         IFullProfileInvalidator fullProfileInvalidator,
         ITeamService teamService,
+        IServiceProvider serviceProvider,
+        IRoleAssignmentClaimsCacheInvalidator roleAssignmentClaimsInvalidator,
+        IShiftAuthorizationInvalidator shiftAuthorizationInvalidator,
         IClock clock,
         ILogger<UserService> logger)
     {
@@ -48,6 +66,9 @@ public sealed class UserService : IUserService, IUserDataContributor
         _userEmailRepo = userEmailRepo;
         _fullProfileInvalidator = fullProfileInvalidator;
         _teamService = teamService;
+        _serviceProvider = serviceProvider;
+        _roleAssignmentClaimsInvalidator = roleAssignmentClaimsInvalidator;
+        _shiftAuthorizationInvalidator = shiftAuthorizationInvalidator;
         _clock = clock;
         _logger = logger;
     }
@@ -117,6 +138,13 @@ public sealed class UserService : IUserService, IUserDataContributor
     public Task<int> GetPendingDeletionCountAsync(CancellationToken ct = default) =>
         _repo.GetPendingDeletionCountAsync(ct);
 
+    public Task<int> GetRejectedGoogleEmailCountAsync(CancellationToken ct = default) =>
+        _repo.GetRejectedGoogleEmailCountAsync(ct);
+
+    public Task<IReadOnlyList<Guid>> GetAccountsDueForAnonymizationAsync(
+        Instant now, CancellationToken ct = default) =>
+        _repo.GetAccountsDueForAnonymizationAsync(now, ct);
+
     // ==========================================================================
     // User writes
     // ==========================================================================
@@ -164,6 +192,47 @@ public sealed class UserService : IUserService, IUserDataContributor
 
     public Task<bool> ClearDeletionAsync(Guid userId, CancellationToken ct = default) =>
         _repo.ClearDeletionAsync(userId, ct);
+
+    public Task SetLastConsentReminderSentAsync(
+        Guid userId, Instant sentAt, CancellationToken ct = default) =>
+        _repo.SetLastConsentReminderSentAsync(userId, sentAt, ct);
+
+    public async Task<AnonymizedAccountSummary?> AnonymizeExpiredAccountAsync(
+        Guid userId, Instant now, CancellationToken ct = default)
+    {
+        // 1. Anonymize identity + UserEmails on the User aggregate.
+        var identity = await _repo.ApplyExpiredDeletionAnonymizationAsync(userId, ct);
+        if (identity is null)
+            return null;
+
+        // 2. End team memberships and team role slot assignments.
+        await _teamService.RevokeAllMembershipsAsync(userId, ct);
+
+        // 3. End active governance role assignments.
+        await RoleAssignmentService.RevokeAllActiveAsync(userId, ct);
+
+        // 4. Anonymize the profile + remove contact fields + volunteer history.
+        await ProfileService.AnonymizeExpiredProfileAsync(userId, ct);
+
+        // 5. Cancel active shift signups (returns ids for per-signup audit log).
+        var cancelledSignupIds = await ShiftSignupService.CancelActiveSignupsForUserAsync(
+            userId, "Account deletion", ct);
+
+        // 6. Delete the user's VolunteerEventProfile row(s).
+        await ShiftManagementService.DeleteShiftProfilesForUserAsync(userId, ct);
+
+        // 7. Invalidate cross-cutting caches that key off the user.
+        await _fullProfileInvalidator.InvalidateAsync(userId, ct);
+        _teamService.RemoveMemberFromAllTeamsCache(userId);
+        _roleAssignmentClaimsInvalidator.Invalidate(userId);
+        _shiftAuthorizationInvalidator.Invalidate(userId);
+
+        return new AnonymizedAccountSummary(
+            identity.OriginalEmail,
+            identity.OriginalDisplayName,
+            identity.PreferredLanguage,
+            cancelledSignupIds);
+    }
 
     // ==========================================================================
     // EventParticipation reads

--- a/src/Humans.Application/Services/Users/UserService.cs
+++ b/src/Humans.Application/Services/Users/UserService.cs
@@ -84,6 +84,10 @@ public sealed class UserService : IUserService, IUserDataContributor
         IReadOnlyCollection<Guid> userIds, CancellationToken ct = default) =>
         _repo.GetByIdsAsync(userIds, ct);
 
+    public Task<IReadOnlyDictionary<Guid, User>> GetByIdsWithEmailsAsync(
+        IReadOnlyCollection<Guid> userIds, CancellationToken ct = default) =>
+        _repo.GetByIdsWithEmailsAsync(userIds, ct);
+
     public Task<IReadOnlyList<User>> GetAllUsersAsync(CancellationToken ct = default) =>
         _repo.GetAllAsync(ct);
 
@@ -200,26 +204,55 @@ public sealed class UserService : IUserService, IUserDataContributor
     public async Task<AnonymizedAccountSummary?> AnonymizeExpiredAccountAsync(
         Guid userId, Instant now, CancellationToken ct = default)
     {
-        // 1. Anonymize identity + UserEmails on the User aggregate.
-        var identity = await _repo.ApplyExpiredDeletionAnonymizationAsync(userId, ct);
-        if (identity is null)
+        // Capture the identity slice BEFORE any writes so the caller can send
+        // the confirmation email / emit audit entries even if the User-aggregate
+        // anonymization (the final step) is the place that fails.
+        var user = await _repo.GetByIdAsync(userId, ct);
+        if (user is null)
             return null;
 
-        // 2. End team memberships and team role slot assignments.
+        var originalEmail = user.GetEffectiveEmail();
+        var originalDisplayName = user.DisplayName;
+        var preferredLanguage = user.PreferredLanguage;
+
+        // Do every cross-section cleanup FIRST, while the account is still
+        // marked for deletion. If any of these throws, the DeletionScheduledFor /
+        // DeletionEligibleAfter fields are still set, so tomorrow's job run
+        // retries the same user rather than silently leaving them in a
+        // half-anonymized state. Only when every cleanup has committed do we
+        // collapse the User identity (which is the step that clears the
+        // deletion markers).
+
+        // 1. End team memberships and team role slot assignments.
         await _teamService.RevokeAllMembershipsAsync(userId, ct);
 
-        // 3. End active governance role assignments.
+        // 2. End active governance role assignments.
         await RoleAssignmentService.RevokeAllActiveAsync(userId, ct);
 
-        // 4. Anonymize the profile + remove contact fields + volunteer history.
+        // 3. Anonymize the profile + remove contact fields + volunteer history.
         await ProfileService.AnonymizeExpiredProfileAsync(userId, ct);
 
-        // 5. Cancel active shift signups (returns ids for per-signup audit log).
+        // 4. Cancel active shift signups (returns ids for per-signup audit log).
         var cancelledSignupIds = await ShiftSignupService.CancelActiveSignupsForUserAsync(
             userId, "Account deletion", ct);
 
-        // 6. Delete the user's VolunteerEventProfile row(s).
+        // 5. Delete the user's VolunteerEventProfile row(s).
         await ShiftManagementService.DeleteShiftProfilesForUserAsync(userId, ct);
+
+        // 6. Finally, anonymize identity + remove UserEmails on the User
+        //    aggregate. This is the write that clears DeletionScheduledFor /
+        //    DeletionEligibleAfter — once this commits, the user falls off
+        //    tomorrow's candidate list.
+        var identity = await _repo.ApplyExpiredDeletionAnonymizationAsync(userId, ct);
+        if (identity is null)
+        {
+            // Can only happen if the user was deleted by another code path
+            // between the GetById above and now. Still return the captured
+            // pre-write slice so the caller can audit the cancelled signups
+            // / pre-existing identity.
+            return new AnonymizedAccountSummary(
+                originalEmail, originalDisplayName, preferredLanguage, cancelledSignupIds);
+        }
 
         // 7. Invalidate cross-cutting caches that key off the user.
         await _fullProfileInvalidator.InvalidateAsync(userId, ct);

--- a/src/Humans.Infrastructure/Jobs/ProcessAccountDeletionsJob.cs
+++ b/src/Humans.Infrastructure/Jobs/ProcessAccountDeletionsJob.cs
@@ -1,16 +1,11 @@
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
-using Humans.Application.Extensions;
 using NodaTime;
 using Humans.Application.Interfaces;
-using Humans.Domain.Entities;
-using Humans.Domain.Enums;
-using Humans.Infrastructure.Data;
 using Humans.Application.Interfaces.AuditLog;
 using Humans.Application.Interfaces.Email;
-using Humans.Application.Interfaces.Profiles;
-using Humans.Application.Interfaces.Teams;
+using Humans.Application.Interfaces.Users;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
 
 namespace Humans.Infrastructure.Jobs;
 
@@ -18,35 +13,35 @@ namespace Humans.Infrastructure.Jobs;
 /// Background job that processes scheduled account deletions.
 /// Runs daily to anonymize accounts where the 30-day grace period has expired.
 /// </summary>
+/// <remarks>
+/// Delegates the actual anonymization to
+/// <see cref="IUserService.AnonymizeExpiredAccountAsync"/> — the Users section
+/// owns the User aggregate and coordinates cross-section writes (profile,
+/// team memberships, role assignments, shift signups, volunteer event
+/// profiles) through their owning services. The job retains the loop +
+/// audit-log + confirmation-email orchestration so a per-user failure
+/// doesn't stop the run.
+/// </remarks>
 public class ProcessAccountDeletionsJob : IRecurringJob
 {
-    private readonly HumansDbContext _dbContext;
+    private readonly IUserService _userService;
     private readonly IEmailService _emailService;
     private readonly IAuditLogService _auditLogService;
-    private readonly IFullProfileInvalidator _fullProfileInvalidator;
-    private readonly ITeamService _teamService;
-    private readonly IMemoryCache _cache;
     private readonly IHumansMetrics _metrics;
     private readonly ILogger<ProcessAccountDeletionsJob> _logger;
     private readonly IClock _clock;
 
     public ProcessAccountDeletionsJob(
-        HumansDbContext dbContext,
+        IUserService userService,
         IEmailService emailService,
         IAuditLogService auditLogService,
-        IFullProfileInvalidator fullProfileInvalidator,
-        ITeamService teamService,
-        IMemoryCache cache,
         IHumansMetrics metrics,
         ILogger<ProcessAccountDeletionsJob> logger,
         IClock clock)
     {
-        _dbContext = dbContext;
+        _userService = userService;
         _emailService = emailService;
         _auditLogService = auditLogService;
-        _fullProfileInvalidator = fullProfileInvalidator;
-        _teamService = teamService;
-        _cache = cache;
         _metrics = metrics;
         _logger = logger;
         _clock = clock;
@@ -64,18 +59,9 @@ public class ProcessAccountDeletionsJob : IRecurringJob
 
         try
         {
-            // Find accounts where deletion is scheduled and both the grace period
-            // and any event hold (DeletionEligibleAfter) have passed
-            var usersToDelete = await _dbContext.Users
-                .Include(u => u.Profile)
-                .Include(u => u.UserEmails)
-                .Include(u => u.TeamMemberships)
-                .Include(u => u.RoleAssignments)
-                .Where(u => u.DeletionScheduledFor != null && u.DeletionScheduledFor <= now
-                    && (u.DeletionEligibleAfter == null || u.DeletionEligibleAfter <= now))
-                .ToListAsync(cancellationToken);
+            var dueUserIds = await _userService.GetAccountsDueForAnonymizationAsync(now, cancellationToken);
 
-            if (usersToDelete.Count == 0)
+            if (dueUserIds.Count == 0)
             {
                 _metrics.RecordJobRun("process_account_deletions", "success");
                 _logger.LogInformation("No accounts scheduled for deletion");
@@ -84,31 +70,33 @@ public class ProcessAccountDeletionsJob : IRecurringJob
 
             _logger.LogInformation(
                 "Found {Count} accounts to process for deletion",
-                usersToDelete.Count);
+                dueUserIds.Count);
 
-            var processedUserIds = new List<Guid>();
+            var processed = 0;
 
-            foreach (var user in usersToDelete)
+            foreach (var userId in dueUserIds)
             {
                 try
                 {
-                    // Capture email before anonymization for notification
-                    var originalEmail = user.GetEffectiveEmail();
-                    var originalName = user.DisplayName;
+                    var summary = await _userService.AnonymizeExpiredAccountAsync(
+                        userId, now, cancellationToken);
 
-                    var cancelledSignupIds = await AnonymizeUserAsync(user, now, cancellationToken);
-
-                    // Save atomically per user so a failure in one doesn't leave others
-                    // in a partially-persisted state
-                    await _dbContext.SaveChangesAsync(cancellationToken);
+                    if (summary is null)
+                    {
+                        // User disappeared between enumeration and anonymization.
+                        _logger.LogWarning(
+                            "Skipping account deletion for user {UserId} — no longer exists",
+                            userId);
+                        continue;
+                    }
 
                     // Audit AFTER the business save has succeeded, per design-rules §7a.
                     await _auditLogService.LogAsync(
-                        AuditAction.AccountAnonymized, nameof(User), user.Id,
-                        $"Account anonymized (was {originalName})",
+                        AuditAction.AccountAnonymized, nameof(User), userId,
+                        $"Account anonymized (was {summary.OriginalDisplayName})",
                         nameof(ProcessAccountDeletionsJob));
 
-                    foreach (var (signupId, shiftId) in cancelledSignupIds)
+                    foreach (var (signupId, shiftId) in summary.CancelledSignupIds)
                     {
                         await _auditLogService.LogAsync(
                             AuditAction.ShiftSignupCancelled, nameof(ShiftSignup), signupId,
@@ -116,50 +104,33 @@ public class ProcessAccountDeletionsJob : IRecurringJob
                             nameof(ProcessAccountDeletionsJob));
                     }
 
-                    processedUserIds.Add(user.Id);
-
-                    // Send confirmation to original email if we have it
-                    if (!string.IsNullOrEmpty(originalEmail))
+                    if (!string.IsNullOrEmpty(summary.OriginalEmail))
                     {
                         await _emailService.SendAccountDeletedAsync(
-                            originalEmail,
-                            originalName,
-                            user.PreferredLanguage,
+                            summary.OriginalEmail,
+                            summary.OriginalDisplayName,
+                            summary.PreferredLanguage,
                             cancellationToken);
                     }
 
+                    processed++;
+
                     _logger.LogInformation(
                         "Successfully anonymized account {UserId}",
-                        user.Id);
+                        userId);
                 }
                 catch (Exception ex)
                 {
                     _logger.LogError(ex,
-                        "Failed to process deletion for user {UserId}. Reverting tracked changes",
-                        user.Id);
-
-                    // Detach only modified/added/deleted entries from the failed user,
-                    // keeping remaining unchanged entities tracked for subsequent iterations
-                    foreach (var entry in _dbContext.ChangeTracker.Entries().ToList())
-                    {
-                        if (entry.State != EntityState.Unchanged)
-                            entry.State = EntityState.Detached;
-                    }
+                        "Failed to process deletion for user {UserId}",
+                        userId);
                 }
-            }
-
-            foreach (var userId in processedUserIds)
-            {
-                await _fullProfileInvalidator.InvalidateAsync(userId, cancellationToken);
-                _teamService.RemoveMemberFromAllTeamsCache(userId);
-                _cache.InvalidateRoleAssignmentClaims(userId);
-                _cache.InvalidateShiftAuthorization(userId);
             }
 
             _metrics.RecordJobRun("process_account_deletions", "success");
             _logger.LogInformation(
                 "Completed account deletion processing, processed {Count} accounts",
-                usersToDelete.Count);
+                processed);
         }
         catch (Exception ex)
         {
@@ -167,124 +138,5 @@ public class ProcessAccountDeletionsJob : IRecurringJob
             _logger.LogError(ex, "Error processing account deletions");
             throw;
         }
-    }
-
-    private async Task<List<(Guid SignupId, Guid ShiftId)>> AnonymizeUserAsync(
-        Domain.Entities.User user,
-        Instant now,
-        CancellationToken cancellationToken)
-    {
-        // Generate anonymized identifier
-        var anonymizedId = $"deleted-{user.Id:N}";
-
-        // Anonymize user record
-        user.DisplayName = "Deleted User";
-        user.Email = $"{anonymizedId}@deleted.local";
-        user.NormalizedEmail = user.Email.ToUpperInvariant();
-        user.UserName = anonymizedId;
-        user.NormalizedUserName = anonymizedId.ToUpperInvariant();
-        user.ProfilePictureUrl = null;
-        user.PhoneNumber = null;
-        user.PhoneNumberConfirmed = false;
-
-        // Remove all email addresses
-        _dbContext.UserEmails.RemoveRange(user.UserEmails);
-
-        // Clear deletion request fields (deletion is now complete)
-        user.DeletionRequestedAt = null;
-        user.DeletionScheduledFor = null;
-        user.DeletionEligibleAfter = null;
-
-        // Disable login
-        user.LockoutEnabled = true;
-        user.LockoutEnd = DateTimeOffset.MaxValue;
-        user.SecurityStamp = Guid.NewGuid().ToString();
-
-        // Anonymize profile if exists
-        if (user.Profile is not null)
-        {
-            user.Profile.FirstName = "Deleted";
-            user.Profile.LastName = "User";
-            user.Profile.BurnerName = string.Empty;
-            user.Profile.Bio = null;
-            user.Profile.City = null;
-            user.Profile.CountryCode = null;
-            user.Profile.Latitude = null;
-            user.Profile.Longitude = null;
-            user.Profile.PlaceId = null;
-            user.Profile.AdminNotes = null;
-            user.Profile.Pronouns = null;
-            user.Profile.DateOfBirth = null;
-            user.Profile.ProfilePictureData = null;
-            user.Profile.ProfilePictureContentType = null;
-            user.Profile.EmergencyContactName = null;
-            user.Profile.EmergencyContactPhone = null;
-            user.Profile.EmergencyContactRelationship = null;
-            user.Profile.ContributionInterests = null;
-            user.Profile.BoardNotes = null;
-        }
-
-        // Remove contact fields and volunteer history
-        if (user.Profile is not null)
-        {
-            var contactFields = await _dbContext.ContactFields
-                .Where(cf => cf.ProfileId == user.Profile.Id)
-                .ToListAsync(cancellationToken);
-            _dbContext.ContactFields.RemoveRange(contactFields);
-
-            var volunteerHistory = await _dbContext.VolunteerHistoryEntries
-                .Where(vh => vh.ProfileId == user.Profile.Id)
-                .ToListAsync(cancellationToken);
-            _dbContext.VolunteerHistoryEntries.RemoveRange(volunteerHistory);
-        }
-
-        // Remove role slot assignments for active memberships
-        var activeMemberIds = user.TeamMemberships.Where(m => m.LeftAt is null).Select(m => m.Id).ToList();
-        if (activeMemberIds.Count > 0)
-        {
-            var roleSlotAssignments = await _dbContext.Set<TeamRoleAssignment>()
-                .Where(a => activeMemberIds.Contains(a.TeamMemberId))
-                .ToListAsync(cancellationToken);
-            _dbContext.Set<TeamRoleAssignment>().RemoveRange(roleSlotAssignments);
-        }
-
-        // End team memberships (only active ones — may already be ended by RequestDeletion)
-        foreach (var membership in user.TeamMemberships.Where(m => m.LeftAt is null))
-        {
-            membership.LeftAt = now;
-        }
-
-        // End role assignments
-        foreach (var role in user.RoleAssignments.Where(r => r.ValidTo is null))
-        {
-            role.ValidTo = now;
-        }
-
-        // Cancel active duty signups
-        var activeSignups = await _dbContext.ShiftSignups
-            .Where(d => d.UserId == user.Id &&
-                        (d.Status == SignupStatus.Confirmed || d.Status == SignupStatus.Pending))
-            .ToListAsync(cancellationToken);
-
-        var cancelledSignupIds = new List<(Guid SignupId, Guid ShiftId)>();
-        foreach (var signup in activeSignups)
-        {
-            signup.Cancel(_clock, "Account deletion");
-            cancelledSignupIds.Add((signup.Id, signup.ShiftId));
-        }
-
-        // Clear iCal token
-        user.ICalToken = null;
-
-        // Delete volunteer event profiles
-        var eventProfiles = await _dbContext.Set<VolunteerEventProfile>()
-            .Where(p => p.UserId == user.Id)
-            .ToListAsync(cancellationToken);
-        _dbContext.Set<VolunteerEventProfile>().RemoveRange(eventProfiles);
-
-        // Note: We keep consent records and applications for GDPR audit trail
-        // These are already anonymized via the user record anonymization
-
-        return cancelledSignupIds;
     }
 }

--- a/src/Humans.Infrastructure/Jobs/ProcessEmailOutboxJob.cs
+++ b/src/Humans.Infrastructure/Jobs/ProcessEmailOutboxJob.cs
@@ -1,11 +1,10 @@
 using System.Text.Json;
 using Humans.Application.Interfaces;
+using Humans.Application.Interfaces.Campaigns;
 using Humans.Application.Interfaces.Email;
 using Humans.Application.Interfaces.Repositories;
 using Humans.Domain.Enums;
 using Humans.Infrastructure.Configuration;
-using Humans.Infrastructure.Data;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NodaTime;
@@ -18,17 +17,16 @@ namespace Humans.Infrastructure.Jobs;
 /// </summary>
 /// <remarks>
 /// The outbox reads/writes go through <see cref="IEmailOutboxRepository"/> so the
-/// Email section's <c>email_outbox_messages</c> + <c>IsEmailSendingPaused</c> state
-/// is owned by a single repository per §15. The campaign-grant status update is
-/// a cross-section write (Campaigns section's <c>campaign_grants</c> table) and
-/// continues to use <see cref="HumansDbContext"/> directly — that cross-section
-/// write will move behind an <c>ICampaignService</c> surface when Campaigns
-/// completes its §15 migration.
+/// Email section's <c>email_outbox_messages</c> + <c>IsEmailSendingPaused</c>
+/// state is owned by a single repository per §15. Campaign grant status updates
+/// route through <see cref="ICampaignService"/> so the Campaigns section owns
+/// <c>campaign_grants</c> (design-rules §2c) — this job no longer touches
+/// <c>HumansDbContext</c> at all.
 /// </remarks>
 public class ProcessEmailOutboxJob : IRecurringJob
 {
-    private readonly HumansDbContext _dbContext;
     private readonly IEmailOutboxRepository _outboxRepo;
+    private readonly ICampaignService _campaignService;
     private readonly IEmailTransport _transport;
     private readonly IHumansMetrics _metrics;
     private readonly IClock _clock;
@@ -36,16 +34,16 @@ public class ProcessEmailOutboxJob : IRecurringJob
     private readonly ILogger<ProcessEmailOutboxJob> _logger;
 
     public ProcessEmailOutboxJob(
-        HumansDbContext dbContext,
         IEmailOutboxRepository outboxRepo,
+        ICampaignService campaignService,
         IEmailTransport transport,
         IHumansMetrics metrics,
         IClock clock,
         IOptions<EmailSettings> settings,
         ILogger<ProcessEmailOutboxJob> logger)
     {
-        _dbContext = dbContext;
         _outboxRepo = outboxRepo;
+        _campaignService = campaignService;
         _transport = transport;
         _metrics = metrics;
         _clock = clock;
@@ -114,19 +112,15 @@ public class ProcessEmailOutboxJob : IRecurringJob
                 await _outboxRepo.MarkSentAsync(message.Id, now, cancellationToken);
                 _metrics.RecordEmailSent(message.TemplateName);
 
-                // Update campaign grant status if applicable.
-                // Cross-section write into the Campaigns section; still direct on the
-                // DbContext until Campaigns §15 lands. Intentional and tracked.
+                // Update campaign grant status if applicable — routed via
+                // ICampaignService so the Campaigns section owns campaign_grants.
                 if (message.CampaignGrantId.HasValue)
                 {
-                    var grant = await _dbContext.CampaignGrants.FindAsync(
-                        new object[] { message.CampaignGrantId.Value }, cancellationToken);
-                    if (grant is not null)
-                    {
-                        grant.LatestEmailStatus = EmailOutboxStatus.Sent;
-                        grant.LatestEmailAt = now;
-                        await _dbContext.SaveChangesAsync(cancellationToken);
-                    }
+                    await _campaignService.UpdateGrantEmailStatusAsync(
+                        message.CampaignGrantId.Value,
+                        EmailOutboxStatus.Sent,
+                        now,
+                        cancellationToken);
                 }
 
                 // Throttle: 1 second delay between sends to avoid SMTP rate limits
@@ -139,17 +133,14 @@ public class ProcessEmailOutboxJob : IRecurringJob
                 await _outboxRepo.MarkFailedAsync(message.Id, now, ex.Message, nextRetryAt, cancellationToken);
                 _metrics.RecordEmailFailed(message.TemplateName);
 
-                // Update campaign grant status if applicable (cross-section write — see above)
+                // Update campaign grant status if applicable — routed via ICampaignService.
                 if (message.CampaignGrantId.HasValue)
                 {
-                    var grant = await _dbContext.CampaignGrants.FindAsync(
-                        new object[] { message.CampaignGrantId.Value }, cancellationToken);
-                    if (grant is not null)
-                    {
-                        grant.LatestEmailStatus = EmailOutboxStatus.Failed;
-                        grant.LatestEmailAt = now;
-                        await _dbContext.SaveChangesAsync(cancellationToken);
-                    }
+                    await _campaignService.UpdateGrantEmailStatusAsync(
+                        message.CampaignGrantId.Value,
+                        EmailOutboxStatus.Failed,
+                        now,
+                        cancellationToken);
                 }
 
                 _logger.LogError(

--- a/src/Humans.Infrastructure/Jobs/SendAdminDailyDigestJob.cs
+++ b/src/Humans.Infrastructure/Jobs/SendAdminDailyDigestJob.cs
@@ -1,50 +1,72 @@
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using NodaTime;
 using Humans.Application.DTOs;
 using Humans.Application.Extensions;
 using Humans.Application.Interfaces;
-using Humans.Application.Interfaces.Repositories;
-using Humans.Domain.Constants;
-using Humans.Domain.Enums;
-using Humans.Infrastructure.Data;
+using Humans.Application.Interfaces.Auth;
 using Humans.Application.Interfaces.Email;
 using Humans.Application.Interfaces.Governance;
-
-// RoleAssignment.User cross-domain nav is [Obsolete] (design-rules §6c). This job
-// still reads RoleAssignments directly; migration to IRoleAssignmentService +
-// IUserService.GetByIdsAsync is tracked as a §15h touch-and-clean follow-up.
-#pragma warning disable CS0618
+using Humans.Application.Interfaces.Profiles;
+using Humans.Application.Interfaces.Repositories;
+using Humans.Application.Interfaces.Teams;
+using Humans.Application.Interfaces.Tickets;
+using Humans.Application.Interfaces.Users;
+using Humans.Domain.Constants;
+using Humans.Domain.Enums;
 
 namespace Humans.Infrastructure.Jobs;
 
 /// <summary>
 /// Daily job that emails each Admin a digest of system health and pending actions.
 /// </summary>
+/// <remarks>
+/// All reads fan out through section services
+/// (<see cref="IUserService"/>, <see cref="IProfileService"/>,
+/// <see cref="ITeamService"/>, <see cref="IApplicationDecisionService"/>,
+/// <see cref="IRoleAssignmentService"/>, <see cref="ITicketSyncService"/>,
+/// <see cref="IGoogleSyncOutboxRepository"/>) so the job never touches
+/// <see cref="Humans.Infrastructure.Data.HumansDbContext"/> directly
+/// (design-rules §2c).
+/// </remarks>
 public class SendAdminDailyDigestJob : IRecurringJob
 {
-    private readonly HumansDbContext _dbContext;
+    private readonly IUserService _userService;
+    private readonly IProfileService _profileService;
+    private readonly ITeamService _teamService;
+    private readonly IApplicationDecisionService _applicationDecisionService;
+    private readonly IRoleAssignmentService _roleAssignmentService;
+    private readonly ITicketSyncService _ticketSyncService;
+    private readonly IGoogleSyncOutboxRepository _googleSyncOutboxRepository;
     private readonly IEmailService _emailService;
     private readonly IMembershipCalculator _membershipCalculator;
     private readonly IHumansMetrics _metrics;
-    private readonly IGoogleSyncOutboxRepository _googleSyncOutboxRepository;
     private readonly ILogger<SendAdminDailyDigestJob> _logger;
     private readonly IClock _clock;
 
     public SendAdminDailyDigestJob(
-        HumansDbContext dbContext,
+        IUserService userService,
+        IProfileService profileService,
+        ITeamService teamService,
+        IApplicationDecisionService applicationDecisionService,
+        IRoleAssignmentService roleAssignmentService,
+        ITicketSyncService ticketSyncService,
+        IGoogleSyncOutboxRepository googleSyncOutboxRepository,
         IEmailService emailService,
         IMembershipCalculator membershipCalculator,
         IHumansMetrics metrics,
-        IGoogleSyncOutboxRepository googleSyncOutboxRepository,
         ILogger<SendAdminDailyDigestJob> logger,
         IClock clock)
     {
-        _dbContext = dbContext;
+        _userService = userService;
+        _profileService = profileService;
+        _teamService = teamService;
+        _applicationDecisionService = applicationDecisionService;
+        _roleAssignmentService = roleAssignmentService;
+        _ticketSyncService = ticketSyncService;
+        _googleSyncOutboxRepository = googleSyncOutboxRepository;
         _emailService = emailService;
         _membershipCalculator = membershipCalculator;
         _metrics = metrics;
-        _googleSyncOutboxRepository = googleSyncOutboxRepository;
         _logger = logger;
         _clock = clock;
     }
@@ -59,61 +81,40 @@ public class SendAdminDailyDigestJob : IRecurringJob
 
         try
         {
-            // Pending deletions
-            var pendingDeletionsCount = await _dbContext.Users
-                .CountAsync(u => u.DeletionRequestedAt != null, cancellationToken);
-
-            // Pending consents
-            var allUserIds = await _dbContext.Users.Select(u => u.Id).ToListAsync(cancellationToken);
-            var usersWithAllConsents = await _membershipCalculator.GetUsersWithAllRequiredConsentsAsync(allUserIds, cancellationToken);
-
-            var leadUserIds = await _dbContext.TeamMembers
-                .Where(tm => tm.LeftAt == null && tm.Role == TeamMemberRole.Coordinator && tm.Team.SystemTeamType == SystemTeamType.None)
-                .Select(tm => tm.UserId)
-                .Distinct()
-                .ToListAsync(cancellationToken);
-            var leadsWithAllConsents = leadUserIds.Count > 0
-                ? await _membershipCalculator.GetUsersWithAllRequiredConsentsForTeamAsync(leadUserIds, SystemTeamIds.Coordinators, cancellationToken)
-                : new HashSet<Guid>();
-
-            var pendingConsentsCount = allUserIds.Count(id =>
-                !usersWithAllConsents.Contains(id) ||
-                (leadUserIds.Contains(id) && !leadsWithAllConsents.Contains(id)));
-
-            // Team join requests
-            var teamJoinRequestCount = await _dbContext.TeamJoinRequests
-                .CountAsync(r => r.Status == TeamJoinRequestStatus.Pending, cancellationToken);
-
-            // Onboarding review
-            var onboardingReviewCount = await _dbContext.Profiles
-                .CountAsync(p => p.ConsentCheckStatus != null
-                    && (p.ConsentCheckStatus == ConsentCheckStatus.Pending || p.ConsentCheckStatus == ConsentCheckStatus.Flagged)
-                    && p.RejectedAt == null, cancellationToken);
-
-            var totalNotApproved = await _dbContext.Profiles
-                .CountAsync(p => !p.IsApproved && !p.IsSuspended, cancellationToken);
+            // Pending deletions / consent reviews / onboarding / voting.
+            var pendingDeletionsCount = await _userService.GetPendingDeletionCountAsync(cancellationToken);
+            var onboardingReviewCount = await _profileService.GetConsentReviewPendingCountAsync(cancellationToken);
+            var totalNotApproved = await _profileService.GetNotApprovedAndNotSuspendedCountAsync(cancellationToken);
             var stillOnboardingCount = Math.Max(0, totalNotApproved - onboardingReviewCount);
+            var boardVotingTotal = await _applicationDecisionService.GetPendingApplicationCountAsync(cancellationToken);
+            var teamJoinRequestCount = await _teamService.GetTotalPendingJoinRequestCountAsync(cancellationToken);
 
-            // Board voting
-            var boardVotingTotal = await _dbContext.Applications
-                .CountAsync(a => a.Status == ApplicationStatus.Submitted, cancellationToken);
+            // Pending consents calculation — reuses the same inputs the Admin
+            // dashboard does so the numbers match.
+            var allUserIds = await _userService.GetAllUserIdsAsync(cancellationToken);
+            var allUserIdsList = allUserIds.ToList();
+            var usersWithAllConsents = await _membershipCalculator
+                .GetUsersWithAllRequiredConsentsAsync(allUserIdsList, cancellationToken);
 
-            // Stale Google sync outbox events (unprocessed with errors, excluding permanent failures).
-            // Routed through the repository so this job doesn't read google_sync_outbox_events
-            // directly (issue #554 Part 1, design-rules §2c).
+            var leadUserIds = await _teamService.GetActiveNonSystemTeamCoordinatorUserIdsAsync(cancellationToken);
+            var leadUserIdsList = leadUserIds.ToList();
+            var leadsWithAllConsents = leadUserIdsList.Count > 0
+                ? await _membershipCalculator.GetUsersWithAllRequiredConsentsForTeamAsync(
+                    leadUserIdsList, SystemTeamIds.Coordinators, cancellationToken)
+                : new HashSet<Guid>();
+            var leadSet = leadUserIdsList.ToHashSet();
+
+            var pendingConsentsCount = allUserIdsList.Count(id =>
+                !usersWithAllConsents.Contains(id) ||
+                (leadSet.Contains(id) && !leadsWithAllConsents.Contains(id)));
+
+            // Google sync outbox counts — already routed through the repo.
             var failedSyncEvents = await _googleSyncOutboxRepository.CountStaleAsync(cancellationToken);
-
-            // Permanent Google sync failures — count distinct users with rejected email status
-            var permanentSyncFailures = await _dbContext.Users
-                .CountAsync(u => u.GoogleEmailStatus == GoogleEmailStatus.Rejected, cancellationToken);
-
-            // Transient retries (still being retried, have errors but not permanent) — via repo.
             var transientSyncRetries = await _googleSyncOutboxRepository.CountTransientRetriesAsync(cancellationToken);
+            var permanentSyncFailures = await _userService.GetRejectedGoogleEmailCountAsync(cancellationToken);
 
-            // Ticket sync status
-            var ticketSyncState = await _dbContext.TicketSyncStates.FindAsync([1], cancellationToken);
-            var ticketSyncError = ticketSyncState?.SyncStatus == TicketSyncStatus.Error;
-            var ticketSyncErrorMessage = ticketSyncError ? ticketSyncState?.LastError : null;
+            // Ticket sync status — routed through ITicketSyncService.
+            var ticketSyncStatus = await _ticketSyncService.GetErrorStatusAsync(cancellationToken);
 
             var counts = new AdminDigestCounts(
                 pendingDeletionsCount,
@@ -125,15 +126,15 @@ public class SendAdminDailyDigestJob : IRecurringJob
                 failedSyncEvents,
                 permanentSyncFailures,
                 transientSyncRetries,
-                ticketSyncError,
-                ticketSyncErrorMessage);
+                ticketSyncStatus.InError,
+                ticketSyncStatus.ErrorMessage);
 
             // Skip if everything is clear
             var hasItems = pendingDeletionsCount > 0 || pendingConsentsCount > 0
                 || teamJoinRequestCount > 0 || onboardingReviewCount > 0
                 || stillOnboardingCount > 0 || boardVotingTotal > 0
                 || failedSyncEvents > 0 || permanentSyncFailures > 0
-                || transientSyncRetries > 0 || ticketSyncError;
+                || transientSyncRetries > 0 || ticketSyncStatus.InError;
 
             if (!hasItems)
             {
@@ -142,19 +143,13 @@ public class SendAdminDailyDigestJob : IRecurringJob
                 return;
             }
 
-            // Find active Admins
-            var admins = await _dbContext.RoleAssignments
-                .Include(ra => ra.User)
-                    .ThenInclude(u => u.UserEmails)
-                .Where(ra => ra.RoleName == RoleNames.Admin
-                    && ra.ValidFrom <= now
-                    && (ra.ValidTo == null || ra.ValidTo.Value > now))
-                .Select(ra => ra.User)
-                .Distinct()
-                .ToListAsync(cancellationToken);
+            // Resolve active Admin users via the role-assignment service.
+            var adminUserIds = await _roleAssignmentService.GetActiveUserIdsInRoleAsync(
+                RoleNames.Admin, cancellationToken);
+            var admins = await _userService.GetByIdsAsync(adminUserIds, cancellationToken);
 
             var sentCount = 0;
-            foreach (var admin in admins)
+            foreach (var admin in admins.Values)
             {
                 var email = admin.GetEffectiveEmail();
                 if (email is null)

--- a/src/Humans.Infrastructure/Jobs/SendAdminDailyDigestJob.cs
+++ b/src/Humans.Infrastructure/Jobs/SendAdminDailyDigestJob.cs
@@ -144,9 +144,12 @@ public class SendAdminDailyDigestJob : IRecurringJob
             }
 
             // Resolve active Admin users via the role-assignment service.
+            // Include UserEmails so GetEffectiveEmail picks the verified
+            // notification-target address instead of silently falling back
+            // to User.Email.
             var adminUserIds = await _roleAssignmentService.GetActiveUserIdsInRoleAsync(
                 RoleNames.Admin, cancellationToken);
-            var admins = await _userService.GetByIdsAsync(adminUserIds, cancellationToken);
+            var admins = await _userService.GetByIdsWithEmailsAsync(adminUserIds, cancellationToken);
 
             var sentCount = 0;
             foreach (var admin in admins.Values)

--- a/src/Humans.Infrastructure/Jobs/SendBoardDailyDigestJob.cs
+++ b/src/Humans.Infrastructure/Jobs/SendBoardDailyDigestJob.cs
@@ -174,9 +174,12 @@ public class SendBoardDailyDigestJob : IRecurringJob
                 : (IReadOnlyList<Guid>)Array.Empty<Guid>();
 
             // 5. Resolve active Board members via the role-assignment service.
+            // Include UserEmails so GetEffectiveEmail picks the verified
+            // notification-target address instead of silently falling back
+            // to User.Email.
             var boardUserIds = await _roleAssignmentService.GetActiveUserIdsInRoleAsync(
                 RoleNames.Board, cancellationToken);
-            var boardMembers = await _userService.GetByIdsAsync(boardUserIds, cancellationToken);
+            var boardMembers = await _userService.GetByIdsWithEmailsAsync(boardUserIds, cancellationToken);
 
             var sentCount = 0;
             foreach (var member in boardMembers.Values)

--- a/src/Humans.Infrastructure/Jobs/SendBoardDailyDigestJob.cs
+++ b/src/Humans.Infrastructure/Jobs/SendBoardDailyDigestJob.cs
@@ -1,29 +1,40 @@
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using NodaTime;
 using Humans.Application.DTOs;
 using Humans.Application.Extensions;
 using Humans.Application.Interfaces;
-using Humans.Domain.Constants;
-using Humans.Domain.Enums;
-using Humans.Infrastructure.Data;
+using Humans.Application.Interfaces.Auth;
+using Humans.Application.Interfaces.AuditLog;
 using Humans.Application.Interfaces.Email;
 using Humans.Application.Interfaces.Governance;
-
-// RoleAssignment.User cross-domain nav is [Obsolete] (design-rules §6c). This job
-// still reads RoleAssignments directly; migration to IRoleAssignmentService +
-// IUserService.GetByIdsAsync is tracked as a §15h touch-and-clean follow-up.
-#pragma warning disable CS0618
+using Humans.Application.Interfaces.Profiles;
+using Humans.Application.Interfaces.Teams;
+using Humans.Application.Interfaces.Users;
+using Humans.Domain.Constants;
+using Humans.Domain.Enums;
 
 namespace Humans.Infrastructure.Jobs;
 
 /// <summary>
-/// Nightly job that emails each Board member a summary of the previous UTC day's approvals
-/// plus outstanding items requiring attention.
+/// Nightly job that emails each Board member a summary of the previous UTC
+/// day's approvals plus outstanding items requiring attention.
 /// </summary>
+/// <remarks>
+/// All reads fan out through section services
+/// (<see cref="IAuditLogService"/>, <see cref="IApplicationDecisionService"/>,
+/// <see cref="IUserService"/>, <see cref="IProfileService"/>,
+/// <see cref="ITeamService"/>, <see cref="IRoleAssignmentService"/>) so the
+/// job never touches <see cref="Humans.Infrastructure.Data.HumansDbContext"/>
+/// directly (design-rules §2c).
+/// </remarks>
 public class SendBoardDailyDigestJob : IRecurringJob
 {
-    private readonly HumansDbContext _dbContext;
+    private readonly IAuditLogService _auditLogService;
+    private readonly IApplicationDecisionService _applicationDecisionService;
+    private readonly IUserService _userService;
+    private readonly IProfileService _profileService;
+    private readonly ITeamService _teamService;
+    private readonly IRoleAssignmentService _roleAssignmentService;
     private readonly IEmailService _emailService;
     private readonly IMembershipCalculator _membershipCalculator;
     private readonly IHumansMetrics _metrics;
@@ -31,14 +42,24 @@ public class SendBoardDailyDigestJob : IRecurringJob
     private readonly IClock _clock;
 
     public SendBoardDailyDigestJob(
-        HumansDbContext dbContext,
+        IAuditLogService auditLogService,
+        IApplicationDecisionService applicationDecisionService,
+        IUserService userService,
+        IProfileService profileService,
+        ITeamService teamService,
+        IRoleAssignmentService roleAssignmentService,
         IEmailService emailService,
         IMembershipCalculator membershipCalculator,
         IHumansMetrics metrics,
         ILogger<SendBoardDailyDigestJob> logger,
         IClock clock)
     {
-        _dbContext = dbContext;
+        _auditLogService = auditLogService;
+        _applicationDecisionService = applicationDecisionService;
+        _userService = userService;
+        _profileService = profileService;
+        _teamService = teamService;
+        _roleAssignmentService = roleAssignmentService;
         _emailService = emailService;
         _membershipCalculator = membershipCalculator;
         _metrics = metrics;
@@ -63,36 +84,25 @@ public class SendBoardDailyDigestJob : IRecurringJob
         {
             var groups = new List<BoardDigestTierGroup>();
 
-            // 1. Volunteer approvals — from audit log (VolunteerApproved action)
-            var volunteerUserIds = await _dbContext.AuditLogEntries
-                .Where(e => e.Action == AuditAction.VolunteerApproved
-                    && e.OccurredAt >= windowStart
-                    && e.OccurredAt < windowEnd)
-                .Select(e => e.EntityId)
-                .Distinct()
-                .ToListAsync(cancellationToken);
+            // 1. Volunteer approvals — routed via IAuditLogService.
+            var volunteerUserIds = await _auditLogService.GetEntityIdsForActionInWindowAsync(
+                windowStart, windowEnd, AuditAction.VolunteerApproved, cancellationToken);
 
             if (volunteerUserIds.Count > 0)
             {
-                var volunteerNames = await _dbContext.Users
-                    .Where(u => volunteerUserIds.Contains(u.Id))
+                var volunteerUsers = await _userService.GetByIdsAsync(volunteerUserIds, cancellationToken);
+                var volunteerNames = volunteerUsers.Values
                     .Select(u => u.DisplayName)
-                    .OrderBy(n => n)
-                    .ToListAsync(cancellationToken);
+                    .OrderBy(n => n, StringComparer.Ordinal)
+                    .ToList();
 
                 groups.Add(new BoardDigestTierGroup("Volunteer", volunteerNames));
             }
 
-            // 2. Tier application approvals (Colaborador/Asociado).
-            //    Application.User nav was stripped in the Governance migration —
-            //    fetch applicants separately and stitch DisplayName in memory.
-            var tierApprovals = await _dbContext.Applications
-                .Where(a => a.Status == ApplicationStatus.Approved
-                    && a.ResolvedAt != null
-                    && a.ResolvedAt.Value >= windowStart
-                    && a.ResolvedAt.Value < windowEnd)
-                .Select(a => new { a.MembershipTier, a.UserId })
-                .ToListAsync(cancellationToken);
+            // 2. Tier application approvals (Colaborador/Asociado) — routed via
+            //    IApplicationDecisionService.
+            var tierApprovals = await _applicationDecisionService.GetApprovedInWindowAsync(
+                windowStart, windowEnd, cancellationToken);
 
             if (tierApprovals.Count > 0)
             {
@@ -100,11 +110,7 @@ public class SendBoardDailyDigestJob : IRecurringJob
                     .Select(a => a.UserId)
                     .Distinct()
                     .ToList();
-                var approvedUsersById = await _dbContext.Users
-                    .AsNoTracking()
-                    .Where(u => approvedUserIds.Contains(u.Id))
-                    .Select(u => new { u.Id, u.DisplayName })
-                    .ToDictionaryAsync(u => u.Id, u => u.DisplayName, cancellationToken);
+                var approvedUsersById = await _userService.GetByIdsAsync(approvedUserIds, cancellationToken);
 
                 foreach (var tierGroup in tierApprovals
                     .GroupBy(a => a.MembershipTier)
@@ -112,104 +118,84 @@ public class SendBoardDailyDigestJob : IRecurringJob
                 {
                     var tierLabel = tierGroup.Key.ToString();
                     var names = tierGroup
-                        .Select(a => approvedUsersById.GetValueOrDefault(a.UserId) ?? string.Empty)
+                        .Select(a => approvedUsersById.TryGetValue(a.UserId, out var u) ? u.DisplayName : string.Empty)
                         .OrderBy(n => n, StringComparer.Ordinal)
                         .ToList();
                     groups.Add(new BoardDigestTierGroup(tierLabel, names));
                 }
             }
 
-            // 3. Compute shared outstanding counts
-            var onboardingReviewCount = await _dbContext.Profiles
-                .CountAsync(p => p.ConsentCheckStatus != null
-                    && (p.ConsentCheckStatus == ConsentCheckStatus.Pending || p.ConsentCheckStatus == ConsentCheckStatus.Flagged)
-                    && p.RejectedAt == null, cancellationToken);
-
-            var totalNotApproved = await _dbContext.Profiles
-                .CountAsync(p => !p.IsApproved && !p.IsSuspended, cancellationToken);
+            // 3. Compute shared outstanding counts via owning services.
+            var onboardingReviewCount = await _profileService.GetConsentReviewPendingCountAsync(cancellationToken);
+            var totalNotApproved = await _profileService.GetNotApprovedAndNotSuspendedCountAsync(cancellationToken);
             var stillOnboardingCount = totalNotApproved - onboardingReviewCount;
             if (stillOnboardingCount < 0) stillOnboardingCount = 0;
 
-            var boardVotingTotal = await _dbContext.Applications
-                .CountAsync(a => a.Status == ApplicationStatus.Submitted, cancellationToken);
+            var boardVotingTotal = await _applicationDecisionService.GetPendingApplicationCountAsync(cancellationToken);
+            var teamJoinRequestCount = await _teamService.GetTotalPendingJoinRequestCountAsync(cancellationToken);
 
-            var teamJoinRequestCount = await _dbContext.TeamJoinRequests
-                .CountAsync(r => r.Status == TeamJoinRequestStatus.Pending, cancellationToken);
+            // Pending consents (same logic as Admin digest).
+            var allUserIds = await _userService.GetAllUserIdsAsync(cancellationToken);
+            var allUserIdsList = allUserIds.ToList();
+            var usersWithAllConsents = await _membershipCalculator
+                .GetUsersWithAllRequiredConsentsAsync(allUserIdsList, cancellationToken);
 
-            // Pending consents (same logic as AdminController dashboard)
-            var allUserIds = await _dbContext.Users.Select(u => u.Id).ToListAsync(cancellationToken);
-            var usersWithAllConsents = await _membershipCalculator.GetUsersWithAllRequiredConsentsAsync(allUserIds, cancellationToken);
-
-            var leadUserIds = await _dbContext.TeamMembers
-                .Where(tm => tm.LeftAt == null && tm.Role == TeamMemberRole.Coordinator && tm.Team.SystemTeamType == SystemTeamType.None)
-                .Select(tm => tm.UserId)
-                .Distinct()
-                .ToListAsync(cancellationToken);
-            var leadsWithAllConsents = leadUserIds.Count > 0
-                ? await _membershipCalculator.GetUsersWithAllRequiredConsentsForTeamAsync(leadUserIds, SystemTeamIds.Coordinators, cancellationToken)
+            var leadUserIds = await _teamService.GetActiveNonSystemTeamCoordinatorUserIdsAsync(cancellationToken);
+            var leadUserIdsList = leadUserIds.ToList();
+            var leadsWithAllConsents = leadUserIdsList.Count > 0
+                ? await _membershipCalculator.GetUsersWithAllRequiredConsentsForTeamAsync(
+                    leadUserIdsList, SystemTeamIds.Coordinators, cancellationToken)
                 : new HashSet<Guid>();
+            var leadSet = leadUserIdsList.ToHashSet();
 
-            var pendingConsentsCount = allUserIds.Count(id =>
+            var pendingConsentsCount = allUserIdsList.Count(id =>
                 !usersWithAllConsents.Contains(id) ||
-                (leadUserIds.Contains(id) && !leadsWithAllConsents.Contains(id)));
+                (leadSet.Contains(id) && !leadsWithAllConsents.Contains(id)));
 
-            var pendingDeletionsCount = await _dbContext.Users
-                .CountAsync(u => u.DeletionRequestedAt != null, cancellationToken);
+            var pendingDeletionsCount = await _userService.GetPendingDeletionCountAsync(cancellationToken);
 
-            // Only skip if both no approvals AND all counts are zero
+            // Only skip if both no approvals AND all counts are zero.
             var hasOutstandingItems = onboardingReviewCount > 0 || stillOnboardingCount > 0
                 || boardVotingTotal > 0 || teamJoinRequestCount > 0
                 || pendingConsentsCount > 0 || pendingDeletionsCount > 0;
 
             if (groups.Count == 0 && !hasOutstandingItems)
             {
-                _logger.LogInformation("No approvals and no outstanding items on {Date}, skipping Board digest", dateLabel);
+                _logger.LogInformation(
+                    "No approvals and no outstanding items on {Date}, skipping Board digest",
+                    dateLabel);
                 _metrics.RecordJobRun("board_daily_digest", "skipped");
                 return;
             }
 
-            // 4. Submitted application IDs (for per-member vote count)
+            // 4. Submitted application ids (for per-member vote counts).
             var submittedApplicationIds = boardVotingTotal > 0
-                ? await _dbContext.Applications
-                    .Where(a => a.Status == ApplicationStatus.Submitted)
-                    .Select(a => a.Id)
-                    .ToListAsync(cancellationToken)
-                : new List<Guid>();
+                ? await _applicationDecisionService.GetSubmittedApplicationIdsAsync(cancellationToken)
+                : (IReadOnlyList<Guid>)Array.Empty<Guid>();
 
-            // 5. Find active Board members
-            var boardMembers = await _dbContext.RoleAssignments
-                .Include(ra => ra.User)
-                    .ThenInclude(u => u.UserEmails)
-                .Where(ra => ra.RoleName == RoleNames.Board
-                    && ra.ValidFrom <= now
-                    && (ra.ValidTo == null || ra.ValidTo.Value > now))
-                .Select(ra => ra.User)
-                .Distinct()
-                .ToListAsync(cancellationToken);
+            // 5. Resolve active Board members via the role-assignment service.
+            var boardUserIds = await _roleAssignmentService.GetActiveUserIdsInRoleAsync(
+                RoleNames.Board, cancellationToken);
+            var boardMembers = await _userService.GetByIdsAsync(boardUserIds, cancellationToken);
 
             var sentCount = 0;
-            foreach (var member in boardMembers)
+            foreach (var member in boardMembers.Values)
             {
                 var email = member.GetEffectiveEmail();
                 if (email is null)
                 {
-                    _logger.LogWarning("Board member {UserId} ({Name}) has no effective email, skipping digest",
+                    _logger.LogWarning(
+                        "Board member {UserId} ({Name}) has no effective email, skipping digest",
                         member.Id, member.DisplayName);
                     continue;
                 }
 
-                // Per-member: how many submitted applications this member hasn't voted on
-                var boardVotingYours = 0;
-                if (submittedApplicationIds.Count > 0)
-                {
-                    var votedAppIds = await _dbContext.BoardVotes
-                        .Where(v => v.BoardMemberUserId == member.Id
-                            && submittedApplicationIds.Contains(v.ApplicationId))
-                        .Select(v => v.ApplicationId)
-                        .ToListAsync(cancellationToken);
-
-                    boardVotingYours = submittedApplicationIds.Count - votedAppIds.Count;
-                }
+                // Per-member: how many submitted applications this member
+                // hasn't voted on.
+                var boardVotingYours = submittedApplicationIds.Count > 0
+                    ? await _applicationDecisionService.GetUnvotedCountForBoardMemberAmongApplicationsAsync(
+                        member.Id, submittedApplicationIds, cancellationToken)
+                    : 0;
 
                 var counts = new BoardDigestOutstandingCounts(
                     onboardingReviewCount,

--- a/src/Humans.Infrastructure/Jobs/SendReConsentReminderJob.cs
+++ b/src/Humans.Infrastructure/Jobs/SendReConsentReminderJob.cs
@@ -78,7 +78,7 @@ public class SendReConsentReminderJob : IRecurringJob
                 .ToList();
 
             var userIds = usersNeedingReminder.ToList();
-            var users = await _userService.GetByIdsAsync(userIds, cancellationToken);
+            var users = await _userService.GetByIdsWithEmailsAsync(userIds, cancellationToken);
 
             var now = _clock.GetCurrentInstant();
             var cooldown = Duration.FromDays(cooldownDays);

--- a/src/Humans.Infrastructure/Jobs/SendReConsentReminderJob.cs
+++ b/src/Humans.Infrastructure/Jobs/SendReConsentReminderJob.cs
@@ -1,24 +1,31 @@
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NodaTime;
+using Humans.Application.Extensions;
 using Humans.Application.Interfaces;
 using Humans.Infrastructure.Configuration;
-using Humans.Infrastructure.Data;
 using Humans.Application.Interfaces.Email;
 using Humans.Application.Interfaces.Legal;
 using Humans.Application.Interfaces.Governance;
+using Humans.Application.Interfaces.Users;
 
 namespace Humans.Infrastructure.Jobs;
 
 /// <summary>
 /// Background job that sends re-consent reminders to members.
 /// </summary>
+/// <remarks>
+/// Reads user display/email data via <see cref="IUserService"/> and persists
+/// <c>User.LastConsentReminderSentAt</c> through
+/// <see cref="IUserService.SetLastConsentReminderSentAsync"/>, so the job
+/// never touches <see cref="Humans.Infrastructure.Data.HumansDbContext"/>
+/// directly (design-rules §2c).
+/// </remarks>
 public class SendReConsentReminderJob : IRecurringJob
 {
-    private readonly HumansDbContext _dbContext;
     private readonly IMembershipCalculator _membershipCalculator;
     private readonly ILegalDocumentSyncService _legalDocService;
+    private readonly IUserService _userService;
     private readonly IEmailService _emailService;
     private readonly EmailSettings _emailSettings;
     private readonly IHumansMetrics _metrics;
@@ -26,18 +33,18 @@ public class SendReConsentReminderJob : IRecurringJob
     private readonly IClock _clock;
 
     public SendReConsentReminderJob(
-        HumansDbContext dbContext,
         IMembershipCalculator membershipCalculator,
         ILegalDocumentSyncService legalDocService,
+        IUserService userService,
         IEmailService emailService,
         IOptions<EmailSettings> emailSettings,
         IHumansMetrics metrics,
         ILogger<SendReConsentReminderJob> logger,
         IClock clock)
     {
-        _dbContext = dbContext;
         _membershipCalculator = membershipCalculator;
         _legalDocService = legalDocService;
+        _userService = userService;
         _emailService = emailService;
         _emailSettings = emailSettings.Value;
         _metrics = metrics;
@@ -71,10 +78,7 @@ public class SendReConsentReminderJob : IRecurringJob
                 .ToList();
 
             var userIds = usersNeedingReminder.ToList();
-            var users = await _dbContext.Users
-                .Include(u => u.UserEmails)
-                .Where(u => userIds.Contains(u.Id))
-                .ToDictionaryAsync(u => u.Id, cancellationToken);
+            var users = await _userService.GetByIdsAsync(userIds, cancellationToken);
 
             var now = _clock.GetCurrentInstant();
             var cooldown = Duration.FromDays(cooldownDays);
@@ -105,7 +109,7 @@ public class SendReConsentReminderJob : IRecurringJob
                         user.PreferredLanguage,
                         cancellationToken);
 
-                    user.LastConsentReminderSentAt = now;
+                    await _userService.SetLastConsentReminderSentAsync(userId, now, cancellationToken);
                     sentCount++;
 
                     _logger.LogInformation(
@@ -113,8 +117,6 @@ public class SendReConsentReminderJob : IRecurringJob
                         userId, effectiveEmail);
                 }
             }
-
-            await _dbContext.SaveChangesAsync(cancellationToken);
 
             _metrics.RecordJobRun("send_reconsent_reminder", "success");
             _logger.LogInformation(

--- a/src/Humans.Infrastructure/Jobs/SyncLegalDocumentsJob.cs
+++ b/src/Humans.Infrastructure/Jobs/SyncLegalDocumentsJob.cs
@@ -1,22 +1,31 @@
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using NodaTime;
+using Humans.Application.Extensions;
 using Humans.Application.Interfaces;
 using Humans.Application.Interfaces.Repositories;
-using Humans.Infrastructure.Data;
 using Humans.Application.Interfaces.Email;
 using Humans.Application.Interfaces.Legal;
+using Humans.Application.Interfaces.Teams;
+using Humans.Application.Interfaces.Users;
 
 namespace Humans.Infrastructure.Jobs;
 
 /// <summary>
 /// Background job that syncs legal documents from the GitHub repository.
 /// </summary>
+/// <remarks>
+/// Reads active team member user ids via <see cref="ITeamService"/> and user
+/// display data via <see cref="IUserService"/> so the job never touches
+/// <see cref="Humans.Infrastructure.Data.HumansDbContext"/> directly
+/// (design-rules §2c). Consent lookups remain on <see cref="IConsentRepository"/>
+/// which is already the Legal &amp; Consent section's owned repository.
+/// </remarks>
 public class SyncLegalDocumentsJob : IRecurringJob
 {
     private readonly ILegalDocumentSyncService _syncService;
     private readonly IEmailService _emailService;
-    private readonly HumansDbContext _dbContext;
+    private readonly ITeamService _teamService;
+    private readonly IUserService _userService;
     private readonly IConsentRepository _consentRepository;
     private readonly IHumansMetrics _metrics;
     private readonly ILogger<SyncLegalDocumentsJob> _logger;
@@ -25,7 +34,8 @@ public class SyncLegalDocumentsJob : IRecurringJob
     public SyncLegalDocumentsJob(
         ILegalDocumentSyncService syncService,
         IEmailService emailService,
-        HumansDbContext dbContext,
+        ITeamService teamService,
+        IUserService userService,
         IConsentRepository consentRepository,
         IHumansMetrics metrics,
         ILogger<SyncLegalDocumentsJob> logger,
@@ -33,7 +43,8 @@ public class SyncLegalDocumentsJob : IRecurringJob
     {
         _syncService = syncService;
         _emailService = emailService;
-        _dbContext = dbContext;
+        _teamService = teamService;
+        _userService = userService;
         _consentRepository = consentRepository;
         _metrics = metrics;
         _logger = logger;
@@ -87,13 +98,16 @@ public class SyncLegalDocumentsJob : IRecurringJob
         // Get unique team IDs for updated docs
         var teamIds = updatedDocs.Select(d => d.TeamId).Distinct().ToList();
 
-        // Get active team members for affected teams
-        var activeUserIds = await _dbContext.TeamMembers
-            .AsNoTracking()
-            .Where(tm => tm.LeftAt == null && teamIds.Contains(tm.TeamId))
-            .Select(tm => tm.UserId)
-            .Distinct()
-            .ToListAsync(cancellationToken);
+        // Get active team members for affected teams (union across teams, de-duped).
+        var activeUserIds = new HashSet<Guid>();
+        foreach (var teamId in teamIds)
+        {
+            var members = await _teamService.GetActiveMemberUserIdsAsync(teamId, cancellationToken);
+            foreach (var userId in members)
+            {
+                activeUserIds.Add(userId);
+            }
+        }
 
         if (activeUserIds.Count == 0)
         {
@@ -107,14 +121,15 @@ public class SyncLegalDocumentsJob : IRecurringJob
             .Select(d => d.Versions.OrderByDescending(v => v.EffectiveFrom).First().Id)
             .ToList();
 
+        var activeUserIdList = activeUserIds.ToList();
         var consentPairs = await _consentRepository.GetPairsForUsersAndVersionsAsync(
-            activeUserIds, updatedDocVersionIds, cancellationToken);
+            activeUserIdList, updatedDocVersionIds, cancellationToken);
 
         var userConsents = consentPairs
             .GroupBy(c => c.UserId)
             .ToDictionary(g => g.Key, g => g.Select(c => c.DocumentVersionId).ToHashSet());
 
-        var usersToNotify = activeUserIds
+        var usersToNotify = activeUserIdList
             .Where(userId => !userConsents.TryGetValue(userId, out var consented) ||
                              !updatedDocVersionIds.All(id => consented.Contains(id)))
             .ToList();
@@ -125,17 +140,19 @@ public class SyncLegalDocumentsJob : IRecurringJob
             return;
         }
 
-        // Batch load user entities for display names and emails
-        var users = await _dbContext.Users
-            .AsNoTracking()
-            .Where(u => usersToNotify.Contains(u.Id))
-            .ToListAsync(cancellationToken);
+        // Batch load user entities for display names and emails via IUserService
+        var users = await _userService.GetByIdsAsync(usersToNotify, cancellationToken);
 
         var documentNames = updatedDocs.Where(d => d.IsRequired).Select(d => d.Name).ToList();
         var notificationCount = 0;
 
-        foreach (var user in users)
+        foreach (var userId in usersToNotify)
         {
+            if (!users.TryGetValue(userId, out var user))
+            {
+                continue;
+            }
+
             var effectiveEmail = user.GetEffectiveEmail();
             if (effectiveEmail is null)
             {

--- a/src/Humans.Infrastructure/Jobs/SyncLegalDocumentsJob.cs
+++ b/src/Humans.Infrastructure/Jobs/SyncLegalDocumentsJob.cs
@@ -140,8 +140,10 @@ public class SyncLegalDocumentsJob : IRecurringJob
             return;
         }
 
-        // Batch load user entities for display names and emails via IUserService
-        var users = await _userService.GetByIdsAsync(usersToNotify, cancellationToken);
+        // Batch load user entities for display names and emails via
+        // IUserService. Use the -WithEmails variant so GetEffectiveEmail
+        // picks the verified notification-target address.
+        var users = await _userService.GetByIdsWithEmailsAsync(usersToNotify, cancellationToken);
 
         var documentNames = updatedDocs.Where(d => d.IsRequired).Select(d => d.Name).ToList();
         var notificationCount = 0;

--- a/src/Humans.Infrastructure/Jobs/TermRenewalReminderJob.cs
+++ b/src/Humans.Infrastructure/Jobs/TermRenewalReminderJob.cs
@@ -88,7 +88,7 @@ public class TermRenewalReminderJob : IRecurringJob
                 .ToList();
             var applicantsById = applicantIds.Count == 0
                 ? new Dictionary<Guid, Domain.Entities.User>()
-                : (await _userService.GetByIdsAsync(applicantIds, cancellationToken))
+                : (await _userService.GetByIdsWithEmailsAsync(applicantIds, cancellationToken))
                     .ToDictionary(kv => kv.Key, kv => kv.Value);
 
             var sentCount = 0;

--- a/src/Humans.Infrastructure/Jobs/TermRenewalReminderJob.cs
+++ b/src/Humans.Infrastructure/Jobs/TermRenewalReminderJob.cs
@@ -1,19 +1,31 @@
 using System.Globalization;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using NodaTime;
+using Humans.Application.Extensions;
 using Humans.Application.Interfaces;
-using Humans.Domain.Entities;
-using Humans.Domain.Enums;
-using Humans.Infrastructure.Data;
 using Humans.Application.Interfaces.Email;
+using Humans.Application.Interfaces.Governance;
 using Humans.Application.Interfaces.Notifications;
+using Humans.Application.Interfaces.Users;
+using Humans.Domain.Enums;
 
 namespace Humans.Infrastructure.Jobs;
 
+/// <summary>
+/// Nightly job that reminds approved members whose Colaborador / Asociado
+/// term expires within 90 days to submit a renewal application.
+/// </summary>
+/// <remarks>
+/// Reads Applications and marks <c>RenewalReminderSentAt</c> through
+/// <see cref="IApplicationDecisionService"/>, and stitches applicant display
+/// info via <see cref="IUserService"/>, so the job never touches
+/// <see cref="Humans.Infrastructure.Data.HumansDbContext"/> directly
+/// (design-rules §2c).
+/// </remarks>
 public class TermRenewalReminderJob : IRecurringJob
 {
-    private readonly HumansDbContext _dbContext;
+    private readonly IApplicationDecisionService _applicationDecisionService;
+    private readonly IUserService _userService;
     private readonly IEmailService _emailService;
     private readonly INotificationService _notificationService;
     private readonly IHumansMetrics _metrics;
@@ -23,14 +35,16 @@ public class TermRenewalReminderJob : IRecurringJob
     private const int ReminderDaysBeforeExpiry = 90;
 
     public TermRenewalReminderJob(
-        HumansDbContext dbContext,
+        IApplicationDecisionService applicationDecisionService,
+        IUserService userService,
         IEmailService emailService,
         INotificationService notificationService,
         IHumansMetrics metrics,
         ILogger<TermRenewalReminderJob> logger,
         IClock clock)
     {
-        _dbContext = dbContext;
+        _applicationDecisionService = applicationDecisionService;
+        _userService = userService;
         _emailService = emailService;
         _notificationService = notificationService;
         _metrics = metrics;
@@ -47,48 +61,38 @@ public class TermRenewalReminderJob : IRecurringJob
             var today = _clock.GetCurrentInstant().InUtc().Date;
             var reminderThreshold = today.PlusDays(ReminderDaysBeforeExpiry);
 
-            // Find approved applications with term expiring within 90 days that haven't had a reminder sent
-            var expiringApplications = await _dbContext.Applications
-                .Where(a =>
-                    a.Status == ApplicationStatus.Approved &&
-                    a.TermExpiresAt != null &&
-                    a.TermExpiresAt <= reminderThreshold &&
-                    a.TermExpiresAt >= today &&
-                    a.RenewalReminderSentAt == null)
-                .ToListAsync(cancellationToken);
+            // Find approved applications with term expiring within 90 days that
+            // haven't had a reminder sent yet.
+            var expiringApplications = await _applicationDecisionService
+                .GetExpiringApplicationsNeedingReminderAsync(today, reminderThreshold, cancellationToken);
 
-            // For each user, only consider the latest approved application per tier
-            // (a user might have multiple approved applications if they renewed before)
+            // For each user, only consider the latest approved application per
+            // tier (a user might have multiple approved applications if they
+            // renewed before).
             var latestPerUserTier = expiringApplications
                 .GroupBy(a => new { a.UserId, a.MembershipTier })
                 .Select(g => g.OrderByDescending(a => a.SubmittedAt).First())
                 .ToList();
 
-            // Exclude users who already have a pending renewal application for the same tier
-            var userTiersWithPending = await _dbContext.Applications
-                .Where(a =>
-                    a.Status == ApplicationStatus.Submitted)
-                .Select(a => new { a.UserId, a.MembershipTier })
-                .ToListAsync(cancellationToken);
+            // Exclude users who already have a pending renewal application for
+            // the same tier.
+            var pendingSet = await _applicationDecisionService
+                .GetPendingApplicationUserTiersAsync(cancellationToken);
 
-            var pendingSet = userTiersWithPending
-                .Select(x => (x.UserId, x.MembershipTier))
-                .ToHashSet();
-
-            // Stitch applicant user info in memory — Application.User cross-domain
-            // nav was stripped in the Governance migration (design-rules §6).
+            // Stitch applicant user info in memory — Application.User
+            // cross-domain nav was stripped in the Governance migration
+            // (design-rules §6).
             var applicantIds = latestPerUserTier
                 .Select(a => a.UserId)
                 .Distinct()
                 .ToList();
             var applicantsById = applicantIds.Count == 0
-                ? new Dictionary<Guid, User>()
-                : await _dbContext.Users
-                    .Include(u => u.UserEmails)
-                    .Where(u => applicantIds.Contains(u.Id))
-                    .ToDictionaryAsync(u => u.Id, cancellationToken);
+                ? new Dictionary<Guid, Domain.Entities.User>()
+                : (await _userService.GetByIdsAsync(applicantIds, cancellationToken))
+                    .ToDictionary(kv => kv.Key, kv => kv.Value);
 
             var sentCount = 0;
+            var now = _clock.GetCurrentInstant();
 
             foreach (var application in latestPerUserTier)
             {
@@ -127,14 +131,15 @@ public class TermRenewalReminderJob : IRecurringJob
                         applicant.PreferredLanguage,
                         cancellationToken);
 
-                    application.RenewalReminderSentAt = _clock.GetCurrentInstant();
+                    await _applicationDecisionService.MarkRenewalReminderSentAsync(
+                        application.Id, now, cancellationToken);
                     sentCount++;
 
                     _logger.LogInformation(
                         "Sent term renewal reminder to user {UserId} ({Email}) for {Tier} expiring {ExpiresAt}",
                         application.UserId, email, application.MembershipTier, application.TermExpiresAt);
 
-                    // Dispatch in-app notification alongside email
+                    // Dispatch in-app notification alongside email.
                     try
                     {
                         await _notificationService.SendAsync(
@@ -145,7 +150,7 @@ public class TermRenewalReminderJob : IRecurringJob
                             [application.UserId],
                             body: "Submit a renewal application to maintain your membership tier.",
                             actionUrl: "/Application",
-                            actionLabel: "Renew \u2192",
+                            actionLabel: "Renew →",
                             cancellationToken: cancellationToken);
                     }
                     catch (Exception notifEx)
@@ -161,11 +166,6 @@ public class TermRenewalReminderJob : IRecurringJob
                         "Failed to send term renewal reminder to user {UserId} for {Tier}",
                         application.UserId, application.MembershipTier);
                 }
-            }
-
-            if (sentCount > 0)
-            {
-                await _dbContext.SaveChangesAsync(cancellationToken);
             }
 
             _metrics.RecordJobRun("term_renewal_reminder", "success");

--- a/src/Humans.Infrastructure/Repositories/AuditLog/AuditLogRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/AuditLog/AuditLogRepository.cs
@@ -191,4 +191,21 @@ public sealed class AuditLogRepository : IAuditLogRepository
             .Where(t => teamIds.Contains(t.Id))
             .ToDictionaryAsync(t => t.Id, t => (t.Name, t.Slug), ct);
     }
+
+    public async Task<IReadOnlyList<Guid>> GetEntityIdsForActionInWindowAsync(
+        NodaTime.Instant windowStart,
+        NodaTime.Instant windowEnd,
+        AuditAction action,
+        CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        return await ctx.AuditLogEntries
+            .AsNoTracking()
+            .Where(e => e.Action == action
+                && e.OccurredAt >= windowStart
+                && e.OccurredAt < windowEnd)
+            .Select(e => e.EntityId)
+            .Distinct()
+            .ToListAsync(ct);
+    }
 }

--- a/src/Humans.Infrastructure/Repositories/Governance/ApplicationRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Governance/ApplicationRepository.cs
@@ -231,4 +231,77 @@ public sealed class ApplicationRepository : IApplicationRepository
             : new ApplicationAdminStats(
                 stats.Total, stats.Approved, stats.Rejected, stats.Colaborador, stats.Asociado);
     }
+
+    public async Task<IReadOnlyList<MemberApplication>> GetExpiringApplicationsNeedingReminderAsync(
+        LocalDate today, LocalDate reminderThreshold, CancellationToken ct = default) =>
+        await _dbContext.Applications
+            .AsNoTracking()
+            .Where(a =>
+                a.Status == ApplicationStatus.Approved &&
+                a.TermExpiresAt != null &&
+                a.TermExpiresAt <= reminderThreshold &&
+                a.TermExpiresAt >= today &&
+                a.RenewalReminderSentAt == null)
+            .ToListAsync(ct);
+
+    public async Task<IReadOnlySet<(Guid UserId, MembershipTier Tier)>> GetPendingApplicationUserTiersAsync(
+        CancellationToken ct = default)
+    {
+        var pairs = await _dbContext.Applications
+            .AsNoTracking()
+            .Where(a => a.Status == ApplicationStatus.Submitted)
+            .Select(a => new { a.UserId, a.MembershipTier })
+            .ToListAsync(ct);
+
+        return pairs
+            .Select(p => (p.UserId, p.MembershipTier))
+            .ToHashSet();
+    }
+
+    public async Task<IReadOnlyList<MemberApplication>> GetApprovedInWindowAsync(
+        Instant windowStart, Instant windowEnd, CancellationToken ct = default) =>
+        await _dbContext.Applications
+            .AsNoTracking()
+            .Where(a => a.Status == ApplicationStatus.Approved
+                && a.ResolvedAt != null
+                && a.ResolvedAt.Value >= windowStart
+                && a.ResolvedAt.Value < windowEnd)
+            .OrderBy(a => a.MembershipTier)
+            .ThenBy(a => a.ResolvedAt)
+            .ToListAsync(ct);
+
+    public async Task<IReadOnlyList<Guid>> GetSubmittedApplicationIdsAsync(
+        CancellationToken ct = default) =>
+        await _dbContext.Applications
+            .AsNoTracking()
+            .Where(a => a.Status == ApplicationStatus.Submitted)
+            .Select(a => a.Id)
+            .ToListAsync(ct);
+
+    public async Task<int> GetUnvotedCountForBoardMemberAmongApplicationsAsync(
+        Guid boardMemberUserId,
+        IReadOnlyCollection<Guid> applicationIds,
+        CancellationToken ct = default)
+    {
+        if (applicationIds.Count == 0)
+            return 0;
+
+        var votedCount = await _dbContext.BoardVotes
+            .AsNoTracking()
+            .CountAsync(v => v.BoardMemberUserId == boardMemberUserId
+                && applicationIds.Contains(v.ApplicationId), ct);
+
+        return applicationIds.Count - votedCount;
+    }
+
+    public async Task MarkRenewalReminderSentAsync(
+        Guid applicationId, Instant sentAt, CancellationToken ct = default)
+    {
+        var app = await _dbContext.Applications.FindAsync([applicationId], ct);
+        if (app is null)
+            return;
+
+        app.RenewalReminderSentAt = sentAt;
+        await _dbContext.SaveChangesAsync(ct);
+    }
 }

--- a/src/Humans.Infrastructure/Repositories/Profiles/ProfileRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Profiles/ProfileRepository.cs
@@ -218,7 +218,14 @@ public sealed class ProfileRepository : IProfileRepository
         await ctx.SaveChangesAsync(ct);
     }
 
-    public async Task<bool> AnonymizeForMergeByUserIdAsync(Guid userId, CancellationToken ct = default)
+    public Task<bool> AnonymizeForMergeByUserIdAsync(Guid userId, CancellationToken ct = default) =>
+        AnonymizeProfileInternalAsync(userId, "Merged", "User", ct);
+
+    public Task<bool> AnonymizeForDeletionByUserIdAsync(Guid userId, CancellationToken ct = default) =>
+        AnonymizeProfileInternalAsync(userId, "Deleted", "User", ct);
+
+    private async Task<bool> AnonymizeProfileInternalAsync(
+        Guid userId, string firstName, string lastName, CancellationToken ct)
     {
         await using var ctx = await _factory.CreateDbContextAsync(ct);
         var profile = await ctx.Profiles
@@ -227,8 +234,8 @@ public sealed class ProfileRepository : IProfileRepository
         if (profile is null)
             return false;
 
-        profile.FirstName = "Merged";
-        profile.LastName = "User";
+        profile.FirstName = firstName;
+        profile.LastName = lastName;
         profile.BurnerName = string.Empty;
         profile.Bio = null;
         profile.City = null;

--- a/src/Humans.Infrastructure/Repositories/Shifts/ShiftManagementRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Shifts/ShiftManagementRepository.cs
@@ -716,4 +716,20 @@ public sealed class ShiftManagementRepository : IShiftManagementRepository
         ctx.VolunteerEventProfiles.Update(profile);
         await ctx.SaveChangesAsync(ct);
     }
+
+    public async Task<int> DeleteVolunteerEventProfilesForUserAsync(
+        Guid userId, CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        var profiles = await ctx.VolunteerEventProfiles
+            .Where(p => p.UserId == userId)
+            .ToListAsync(ct);
+
+        if (profiles.Count == 0)
+            return 0;
+
+        ctx.VolunteerEventProfiles.RemoveRange(profiles);
+        await ctx.SaveChangesAsync(ct);
+        return profiles.Count;
+    }
 }

--- a/src/Humans.Infrastructure/Repositories/Shifts/ShiftSignupRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Shifts/ShiftSignupRepository.cs
@@ -5,6 +5,7 @@ using Humans.Infrastructure.Data;
 using Humans.Infrastructure.Repositories.Auth;
 using Humans.Infrastructure.Repositories.Governance;
 using Microsoft.EntityFrameworkCore;
+using NodaTime;
 
 namespace Humans.Infrastructure.Repositories.Shifts;
 
@@ -25,10 +26,12 @@ namespace Humans.Infrastructure.Repositories.Shifts;
 public sealed class ShiftSignupRepository : IShiftSignupRepository
 {
     private readonly HumansDbContext _dbContext;
+    private readonly IClock _clock;
 
-    public ShiftSignupRepository(HumansDbContext dbContext)
+    public ShiftSignupRepository(HumansDbContext dbContext, IClock clock)
     {
         _dbContext = dbContext;
+        _clock = clock;
     }
 
     // ============================================================
@@ -226,4 +229,27 @@ public sealed class ShiftSignupRepository : IShiftSignupRepository
     public void AddRange(IEnumerable<ShiftSignup> signups) => _dbContext.ShiftSignups.AddRange(signups);
 
     public Task SaveChangesAsync(CancellationToken ct = default) => _dbContext.SaveChangesAsync(ct);
+
+    public async Task<IReadOnlyList<(Guid SignupId, Guid ShiftId)>> CancelActiveSignupsForUserAsync(
+        Guid userId, string reason, CancellationToken ct = default)
+    {
+        var activeSignups = await _dbContext.ShiftSignups
+            .Where(d => d.UserId == userId &&
+                        (d.Status == SignupStatus.Confirmed || d.Status == SignupStatus.Pending))
+            .ToListAsync(ct);
+
+        if (activeSignups.Count == 0)
+            return Array.Empty<(Guid, Guid)>();
+
+        var cancelled = new List<(Guid SignupId, Guid ShiftId)>(activeSignups.Count);
+        foreach (var signup in activeSignups)
+        {
+            signup.Cancel(_clock, reason);
+            cancelled.Add((signup.Id, signup.ShiftId));
+        }
+
+        await _dbContext.SaveChangesAsync(ct);
+        return cancelled;
+    }
+
 }

--- a/src/Humans.Infrastructure/Repositories/Teams/TeamRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Teams/TeamRepository.cs
@@ -594,6 +594,20 @@ public sealed class TeamRepository : ITeamRepository
             .CountAsync(r => r.Status == TeamJoinRequestStatus.Pending, ct);
     }
 
+    public async Task<IReadOnlyList<Guid>> GetActiveNonSystemTeamCoordinatorUserIdsAsync(
+        CancellationToken ct = default)
+    {
+        await using var db = await _factory.CreateDbContextAsync(ct);
+        return await db.TeamMembers
+            .AsNoTracking()
+            .Where(tm => tm.LeftAt == null
+                && tm.Role == TeamMemberRole.Coordinator
+                && tm.Team.SystemTeamType == SystemTeamType.None)
+            .Select(tm => tm.UserId)
+            .Distinct()
+            .ToListAsync(ct);
+    }
+
     public async Task AddRequestAsync(TeamJoinRequest request, CancellationToken ct = default)
     {
         await using var db = await _factory.CreateDbContextAsync(ct);

--- a/src/Humans.Infrastructure/Repositories/Users/UserRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Users/UserRepository.cs
@@ -410,6 +410,89 @@ public sealed class UserRepository : IUserRepository
         return await ctx.Users.CountAsync(u => u.DeletionRequestedAt != null, ct);
     }
 
+    public async Task SetLastConsentReminderSentAsync(
+        Guid userId, Instant sentAt, CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        var user = await ctx.Users.FindAsync([userId], ct);
+        if (user is null)
+            return;
+
+        user.LastConsentReminderSentAt = sentAt;
+        await ctx.SaveChangesAsync(ct);
+    }
+
+    public async Task<int> GetRejectedGoogleEmailCountAsync(CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        return await ctx.Users.CountAsync(u => u.GoogleEmailStatus == GoogleEmailStatus.Rejected, ct);
+    }
+
+    public async Task<IReadOnlyList<Guid>> GetAccountsDueForAnonymizationAsync(
+        Instant now, CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        return await ctx.Users
+            .AsNoTracking()
+            .Where(u => u.DeletionScheduledFor != null
+                && u.DeletionScheduledFor <= now
+                && (u.DeletionEligibleAfter == null || u.DeletionEligibleAfter <= now))
+            .Select(u => u.Id)
+            .ToListAsync(ct);
+    }
+
+    public async Task<ExpiredDeletionAnonymizationResult?> ApplyExpiredDeletionAnonymizationAsync(
+        Guid userId, CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        var user = await ctx.Users
+            .Include(u => u.UserEmails)
+            .FirstOrDefaultAsync(u => u.Id == userId, ct);
+
+        if (user is null)
+            return null;
+
+        var originalEmail = user.GetEffectiveEmail();
+        var originalDisplayName = user.DisplayName;
+        var preferredLanguage = user.PreferredLanguage;
+
+        // Synthetic anonymized identifier derived from the user id so the
+        // collision surface for the sentinel email is zero (one per user).
+        var anonymizedId = $"deleted-{user.Id:N}";
+
+        user.DisplayName = "Deleted User";
+        user.Email = $"{anonymizedId}@deleted.local";
+        user.NormalizedEmail = user.Email.ToUpperInvariant();
+        user.UserName = anonymizedId;
+        user.NormalizedUserName = anonymizedId.ToUpperInvariant();
+        user.ProfilePictureUrl = null;
+        user.PhoneNumber = null;
+        user.PhoneNumberConfirmed = false;
+
+        // Remove all verified / unverified email addresses associated with the
+        // account so the unique index does not block future accounts from
+        // reusing the same addresses and so the anonymized row cannot be
+        // discovered by email lookup.
+        ctx.UserEmails.RemoveRange(user.UserEmails);
+
+        // Clear deletion request fields (deletion is now complete).
+        user.DeletionRequestedAt = null;
+        user.DeletionScheduledFor = null;
+        user.DeletionEligibleAfter = null;
+
+        // Permanently lock out the account.
+        user.LockoutEnabled = true;
+        user.LockoutEnd = DateTimeOffset.MaxValue;
+        user.SecurityStamp = Guid.NewGuid().ToString();
+
+        // Clear iCal token so old calendar feed URLs stop serving data.
+        user.ICalToken = null;
+
+        await ctx.SaveChangesAsync(ct);
+        return new ExpiredDeletionAnonymizationResult(
+            originalEmail, originalDisplayName, preferredLanguage);
+    }
+
     // ==========================================================================
     // Reads — EventParticipation
     // ==========================================================================

--- a/src/Humans.Infrastructure/Repositories/Users/UserRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Users/UserRepository.cs
@@ -51,6 +51,22 @@ public sealed class UserRepository : IUserRepository
         return list.ToDictionary(u => u.Id);
     }
 
+    public async Task<IReadOnlyDictionary<Guid, User>> GetByIdsWithEmailsAsync(
+        IReadOnlyCollection<Guid> userIds, CancellationToken ct = default)
+    {
+        if (userIds.Count == 0)
+            return new Dictionary<Guid, User>();
+
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        var list = await ctx.Users
+            .AsNoTracking()
+            .Include(u => u.UserEmails)
+            .Where(u => userIds.Contains(u.Id))
+            .ToListAsync(ct);
+
+        return list.ToDictionary(u => u.Id);
+    }
+
     public async Task<IReadOnlyList<User>> GetAllAsync(CancellationToken ct = default)
     {
         await using var ctx = await _factory.CreateDbContextAsync(ct);

--- a/src/Humans.Infrastructure/Services/Profiles/CachingProfileService.cs
+++ b/src/Humans.Infrastructure/Services/Profiles/CachingProfileService.cs
@@ -572,4 +572,19 @@ public sealed class CachingProfileService : IProfileService, IFullProfileInvalid
         }
         return set;
     }
+
+    public async Task<bool> AnonymizeExpiredProfileAsync(Guid userId, CancellationToken ct = default)
+    {
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        var inner = scope.ServiceProvider.GetRequiredKeyedService<IProfileService>(InnerServiceKey);
+        var anonymized = await inner.AnonymizeExpiredProfileAsync(userId, ct);
+        if (anonymized)
+        {
+            // The profile fields used by the FullProfile projection changed —
+            // refresh the cache entry so downstream readers see the anonymized
+            // view immediately.
+            await RefreshEntryAsync(userId, ct);
+        }
+        return anonymized;
+    }
 }

--- a/tests/Humans.Application.Tests/Jobs/ProcessAccountDeletionsJobTests.cs
+++ b/tests/Humans.Application.Tests/Jobs/ProcessAccountDeletionsJobTests.cs
@@ -1,32 +1,34 @@
 using AwesomeAssertions;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NodaTime;
 using NodaTime.Testing;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Humans.Application.Interfaces.AuditLog;
+using Humans.Application.Interfaces.Email;
+using Humans.Application.Interfaces.Users;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
-using Humans.Infrastructure.Data;
 using Humans.Infrastructure.Jobs;
 using Humans.Infrastructure.Services;
 using Xunit;
-using Humans.Application.Interfaces.AuditLog;
-using Humans.Application.Interfaces.Email;
-using Humans.Application.Interfaces.Profiles;
-using Humans.Application.Interfaces.Teams;
 
 namespace Humans.Application.Tests.Jobs;
 
+/// <summary>
+/// Unit tests for <see cref="ProcessAccountDeletionsJob"/> after §15: the
+/// job is now a thin coordinator that delegates candidate enumeration and
+/// anonymization to <see cref="IUserService"/>. These tests exercise that
+/// coordination — which users are enumerated, what audit entries are
+/// written, when the confirmation email fires, and error handling for a
+/// failing anonymization.
+/// </summary>
 public class ProcessAccountDeletionsJobTests : IDisposable
 {
-    private readonly HumansDbContext _dbContext;
+    private readonly IUserService _userService;
     private readonly IEmailService _emailService;
     private readonly IAuditLogService _auditLogService;
-    private readonly IFullProfileInvalidator _fullProfileInvalidator;
-    private readonly ITeamService _teamService;
-    private readonly IMemoryCache _cache;
     private readonly HumansMetricsService _metrics;
     private readonly FakeClock _clock;
     private readonly ProcessAccountDeletionsJob _job;
@@ -35,16 +37,9 @@ public class ProcessAccountDeletionsJobTests : IDisposable
 
     public ProcessAccountDeletionsJobTests()
     {
-        var options = new DbContextOptionsBuilder<HumansDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-
-        _dbContext = new HumansDbContext(options);
+        _userService = Substitute.For<IUserService>();
         _emailService = Substitute.For<IEmailService>();
         _auditLogService = Substitute.For<IAuditLogService>();
-        _fullProfileInvalidator = Substitute.For<IFullProfileInvalidator>();
-        _teamService = Substitute.For<ITeamService>();
-        _cache = new MemoryCache(new MemoryCacheOptions());
         _clock = new FakeClock(Now);
         _metrics = new HumansMetricsService(
             Substitute.For<IServiceScopeFactory>(),
@@ -52,369 +47,137 @@ public class ProcessAccountDeletionsJobTests : IDisposable
         var logger = Substitute.For<ILogger<ProcessAccountDeletionsJob>>();
 
         _job = new ProcessAccountDeletionsJob(
-            _dbContext, _emailService, _auditLogService,
-            _fullProfileInvalidator, _teamService, _cache, _metrics, logger, _clock);
+            _userService, _emailService, _auditLogService, _metrics, logger, _clock);
     }
 
     public void Dispose()
     {
-        _dbContext.Dispose();
-        _cache.Dispose();
         _metrics.Dispose();
         GC.SuppressFinalize(this);
     }
 
     [Fact]
-    public async Task ExecuteAsync_AnonymizesUserWhenGracePeriodExpired()
+    public async Task ExecuteAsync_NoDueAccounts_DoesNotCallAnonymize()
     {
-        var user = await SeedUserScheduledForDeletion(Now - Duration.FromDays(1));
+        _userService.GetAccountsDueForAnonymizationAsync(Now, Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<Guid>());
 
         await _job.ExecuteAsync();
 
-        var updated = await _dbContext.Users.Include(u => u.Profile).SingleAsync();
-        updated.DisplayName.Should().Be("Deleted User");
-        updated.Email.Should().StartWith("deleted-");
-        updated.Email.Should().EndWith("@deleted.local");
-        updated.ProfilePictureUrl.Should().BeNull();
-        updated.PhoneNumber.Should().BeNull();
-        updated.DeletionScheduledFor.Should().BeNull();
-        updated.DeletionRequestedAt.Should().BeNull();
-        updated.LockoutEnd.Should().Be(DateTimeOffset.MaxValue);
-        updated.Profile!.FirstName.Should().Be("Deleted");
-        updated.Profile.LastName.Should().Be("User");
-        updated.Profile.Bio.Should().BeNull();
-        updated.Profile.City.Should().BeNull();
+        await _userService.DidNotReceiveWithAnyArgs()
+            .AnonymizeExpiredAccountAsync(default, default, default);
+        await _emailService.DidNotReceiveWithAnyArgs().SendAccountDeletedAsync(
+            default!, default!, default, default);
     }
 
     [Fact]
-    public async Task ExecuteAsync_SkipsUserWhenGracePeriodNotExpired()
+    public async Task ExecuteAsync_AnonymizesAndLogsAndEmailsEachDueAccount()
     {
-        var user = await SeedUserScheduledForDeletion(Now + Duration.FromDays(5));
+        var userId = Guid.NewGuid();
+        var signupId = Guid.NewGuid();
+        var shiftId = Guid.NewGuid();
+
+        _userService.GetAccountsDueForAnonymizationAsync(Now, Arg.Any<CancellationToken>())
+            .Returns(new[] { userId });
+
+        _userService.AnonymizeExpiredAccountAsync(userId, Now, Arg.Any<CancellationToken>())
+            .Returns(new AnonymizedAccountSummary(
+                OriginalEmail: "test@example.com",
+                OriginalDisplayName: "Test User",
+                PreferredLanguage: "en",
+                CancelledSignupIds: new[] { (signupId, shiftId) }));
 
         await _job.ExecuteAsync();
 
-        var updated = await _dbContext.Users.SingleAsync();
-        updated.DisplayName.Should().Be("Test User");
-        updated.DeletionScheduledFor.Should().NotBeNull();
+        await _userService.Received(1).AnonymizeExpiredAccountAsync(
+            userId, Now, Arg.Any<CancellationToken>());
+
+        await _auditLogService.Received(1).LogAsync(
+            AuditAction.AccountAnonymized, nameof(User), userId,
+            Arg.Is<string>(s => s.Contains("Test User")),
+            nameof(ProcessAccountDeletionsJob),
+            Arg.Any<Guid?>(), Arg.Any<string?>());
+
+        await _auditLogService.Received(1).LogAsync(
+            AuditAction.ShiftSignupCancelled, nameof(ShiftSignup), signupId,
+            Arg.Is<string>(s => s.Contains(shiftId.ToString())),
+            nameof(ProcessAccountDeletionsJob),
+            Arg.Any<Guid?>(), Arg.Any<string?>());
+
+        await _emailService.Received(1).SendAccountDeletedAsync(
+            "test@example.com", "Test User", "en",
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
-    public async Task ExecuteAsync_SkipsUserWithFutureEventHold()
+    public async Task ExecuteAsync_NullSummary_SkipsAndContinues()
     {
-        // Grace period expired but event hold is still active
-        var user = await SeedUserScheduledForDeletion(
-            Now - Duration.FromDays(1),
-            deletionEligibleAfter: Now + Duration.FromDays(10));
+        var vanishedId = Guid.NewGuid();
+        var goodId = Guid.NewGuid();
 
-        await _job.ExecuteAsync();
+        _userService.GetAccountsDueForAnonymizationAsync(Now, Arg.Any<CancellationToken>())
+            .Returns(new[] { vanishedId, goodId });
 
-        var updated = await _dbContext.Users.SingleAsync();
-        updated.DisplayName.Should().Be("Test User");
-    }
-
-    [Fact]
-    public async Task ExecuteAsync_ProcessesUserWhenEventHoldExpired()
-    {
-        var user = await SeedUserScheduledForDeletion(
-            Now - Duration.FromDays(1),
-            deletionEligibleAfter: Now - Duration.FromDays(1));
-
-        await _job.ExecuteAsync();
-
-        var updated = await _dbContext.Users.SingleAsync();
-        updated.DisplayName.Should().Be("Deleted User");
-    }
-
-    [Fact]
-    public async Task ExecuteAsync_SendsConfirmationEmail()
-    {
-        var user = await SeedUserScheduledForDeletion(Now - Duration.FromDays(1));
+        _userService.AnonymizeExpiredAccountAsync(vanishedId, Now, Arg.Any<CancellationToken>())
+            .Returns((AnonymizedAccountSummary?)null);
+        _userService.AnonymizeExpiredAccountAsync(goodId, Now, Arg.Any<CancellationToken>())
+            .Returns(new AnonymizedAccountSummary(
+                "other@example.com", "Other User", "es",
+                Array.Empty<(Guid, Guid)>()));
 
         await _job.ExecuteAsync();
 
         await _emailService.Received(1).SendAccountDeletedAsync(
-            "test@example.com",
-            "Test User",
-            "en",
-            Arg.Any<CancellationToken>());
-    }
-
-    [Fact]
-    public async Task ExecuteAsync_LogsAuditEntry()
-    {
-        var user = await SeedUserScheduledForDeletion(Now - Duration.FromDays(1));
-
-        await _job.ExecuteAsync();
-
-        await _auditLogService.Received(1).LogAsync(
-            AuditAction.AccountAnonymized,
-            nameof(User),
-            user.Id,
-            Arg.Is<string>(s => s.Contains("Test User")),
-            nameof(ProcessAccountDeletionsJob),
-            Arg.Any<Guid?>(),
-            Arg.Any<string?>());
-    }
-
-    [Fact]
-    public async Task ExecuteAsync_RemovesContactFieldsAndVolunteerHistory()
-    {
-        var user = await SeedUserScheduledForDeletion(Now - Duration.FromDays(1));
-
-        // Seed contact fields
-        _dbContext.ContactFields.Add(new ContactField
-        {
-            Id = Guid.NewGuid(),
-            ProfileId = user.Profile!.Id,
-            FieldType = ContactFieldType.Phone,
-            Value = "+1234567890",
-            Visibility = ContactFieldVisibility.AllActiveProfiles
-        });
-
-        // Seed volunteer history
-        _dbContext.VolunteerHistoryEntries.Add(new VolunteerHistoryEntry
-        {
-            Id = Guid.NewGuid(),
-            ProfileId = user.Profile.Id,
-            EventName = "Test Event",
-            Description = "Testing"
-        });
-        await _dbContext.SaveChangesAsync();
-
-        await _job.ExecuteAsync();
-
-        var contactFields = await _dbContext.ContactFields
-            .Where(cf => cf.ProfileId == user.Profile.Id)
-            .CountAsync();
-        contactFields.Should().Be(0);
-
-        var historyEntries = await _dbContext.VolunteerHistoryEntries
-            .Where(vh => vh.ProfileId == user.Profile.Id)
-            .CountAsync();
-        historyEntries.Should().Be(0);
-    }
-
-    [Fact]
-    public async Task ExecuteAsync_EndsActiveTeamMemberships()
-    {
-        var user = await SeedUserScheduledForDeletion(Now - Duration.FromDays(1));
-
-        var team = new Team
-        {
-            Id = Guid.NewGuid(),
-            Name = "Test Team",
-            Slug = "test-team",
-            CreatedAt = Now - Duration.FromDays(100)
-        };
-        _dbContext.Teams.Add(team);
-
-        var membership = new TeamMember
-        {
-            Id = Guid.NewGuid(),
-            TeamId = team.Id,
-            UserId = user.Id,
-            JoinedAt = Now - Duration.FromDays(50),
-            LeftAt = null
-        };
-        _dbContext.TeamMembers.Add(membership);
-        await _dbContext.SaveChangesAsync();
-
-        // Re-read user so navigation property is populated
-        _dbContext.Entry(user).State = EntityState.Detached;
-
-        await _job.ExecuteAsync();
-
-        var updatedMembership = await _dbContext.TeamMembers.SingleAsync();
-        updatedMembership.LeftAt.Should().Be(Now);
-    }
-
-    [Fact]
-    public async Task ExecuteAsync_EndsActiveRoleAssignments()
-    {
-        var user = await SeedUserScheduledForDeletion(Now - Duration.FromDays(1));
-
-        var roleAssignment = new RoleAssignment
-        {
-            Id = Guid.NewGuid(),
-            UserId = user.Id,
-            RoleName = "Admin",
-            ValidFrom = Now - Duration.FromDays(30),
-            ValidTo = null,
-            CreatedByUserId = user.Id
-        };
-        _dbContext.RoleAssignments.Add(roleAssignment);
-        await _dbContext.SaveChangesAsync();
-
-        _dbContext.Entry(user).State = EntityState.Detached;
-
-        await _job.ExecuteAsync();
-
-        var updated = await _dbContext.RoleAssignments.SingleAsync();
-        updated.ValidTo.Should().Be(Now);
-    }
-
-    [Fact]
-    public async Task ExecuteAsync_CancelsActiveShiftSignups()
-    {
-        var user = await SeedUserScheduledForDeletion(Now - Duration.FromDays(1));
-
-        var shift = new Shift
-        {
-            Id = Guid.NewGuid(),
-            RotaId = Guid.NewGuid(),
-            StartTime = new LocalTime(10, 0),
-            Duration = Duration.FromHours(4),
-            MinVolunteers = 1,
-            MaxVolunteers = 10
-        };
-        _dbContext.Shifts.Add(shift);
-
-        var signup = new ShiftSignup
-        {
-            Id = Guid.NewGuid(),
-            ShiftId = shift.Id,
-            UserId = user.Id,
-            Status = SignupStatus.Confirmed
-        };
-        _dbContext.ShiftSignups.Add(signup);
-        await _dbContext.SaveChangesAsync();
-
-        _dbContext.Entry(user).State = EntityState.Detached;
-
-        await _job.ExecuteAsync();
-
-        var updatedSignup = await _dbContext.ShiftSignups.SingleAsync();
-        updatedSignup.Status.Should().Be(SignupStatus.Cancelled);
-        updatedSignup.StatusReason.Should().Be("Account deletion");
-    }
-
-    [Fact]
-    public async Task ExecuteAsync_RemovesUserEmails()
-    {
-        var user = await SeedUserScheduledForDeletion(Now - Duration.FromDays(1));
-
-        _dbContext.UserEmails.Add(new UserEmail
-        {
-            Id = Guid.NewGuid(),
-            UserId = user.Id,
-            Email = "secondary@example.com",
-            IsVerified = true,
-            IsNotificationTarget = false
-        });
-        await _dbContext.SaveChangesAsync();
-
-        _dbContext.Entry(user).State = EntityState.Detached;
-
-        await _job.ExecuteAsync();
-
-        var emailCount = await _dbContext.UserEmails.Where(e => e.UserId == user.Id).CountAsync();
-        emailCount.Should().Be(0);
-    }
-
-    [Fact]
-    public async Task ExecuteAsync_InvalidatesCaches()
-    {
-        var user = await SeedUserScheduledForDeletion(Now - Duration.FromDays(1));
-
-        await _job.ExecuteAsync();
-
-        await _fullProfileInvalidator.Received(1).InvalidateAsync(user.Id, Arg.Any<CancellationToken>());
-        _teamService.Received(1).RemoveMemberFromAllTeamsCache(user.Id);
-    }
-
-    [Fact]
-    public async Task ExecuteAsync_NoUsersToDelete_DoesNothing()
-    {
-        // No users in DB at all
-        await _job.ExecuteAsync();
-
+            "other@example.com", "Other User", "es", Arg.Any<CancellationToken>());
         await _emailService.DidNotReceive().SendAccountDeletedAsync(
-            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(),
-            Arg.Any<CancellationToken>());
+            Arg.Any<string>(), "Test User", Arg.Any<string?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_SkipsEmailWhenOriginalEmailIsNull()
+    {
+        var userId = Guid.NewGuid();
+        _userService.GetAccountsDueForAnonymizationAsync(Now, Arg.Any<CancellationToken>())
+            .Returns(new[] { userId });
+        _userService.AnonymizeExpiredAccountAsync(userId, Now, Arg.Any<CancellationToken>())
+            .Returns(new AnonymizedAccountSummary(
+                OriginalEmail: null,
+                OriginalDisplayName: "Orphan User",
+                PreferredLanguage: "en",
+                CancelledSignupIds: Array.Empty<(Guid, Guid)>()));
+
+        await _job.ExecuteAsync();
+
+        await _emailService.DidNotReceiveWithAnyArgs().SendAccountDeletedAsync(
+            default!, default!, default, default);
+
+        // Audit should still fire.
+        await _auditLogService.Received(1).LogAsync(
+            AuditAction.AccountAnonymized, nameof(User), userId,
+            Arg.Any<string>(), nameof(ProcessAccountDeletionsJob),
+            Arg.Any<Guid?>(), Arg.Any<string?>());
     }
 
     [Fact]
     public async Task ExecuteAsync_ContinuesProcessingAfterIndividualFailure()
     {
-        var user1 = await SeedUserScheduledForDeletion(Now - Duration.FromDays(1));
+        var user1 = Guid.NewGuid();
+        var user2 = Guid.NewGuid();
 
-        // Create a second user
-        var user2Id = Guid.NewGuid();
-        var user2 = new User
-        {
-            Id = user2Id,
-            UserName = "user2",
-            NormalizedUserName = "USER2",
-            Email = "user2@example.com",
-            NormalizedEmail = "USER2@EXAMPLE.COM",
-            DisplayName = "User Two",
-            DeletionRequestedAt = Now - Duration.FromDays(31),
-            DeletionScheduledFor = Now - Duration.FromDays(1),
-            PreferredLanguage = "en",
-            Profile = new Profile
-            {
-                Id = Guid.NewGuid(),
-                UserId = user2Id,
-                FirstName = "User",
-                LastName = "Two",
-                BurnerName = "UTwo"
-            }
-        };
-        _dbContext.Users.Add(user2);
-        await _dbContext.SaveChangesAsync();
+        _userService.GetAccountsDueForAnonymizationAsync(Now, Arg.Any<CancellationToken>())
+            .Returns(new[] { user1, user2 });
 
-        // Throw for user1's entity ID, succeed for everything else
-        var failEntityId = user1.Id;
-        _auditLogService.LogAsync(
-            Arg.Any<AuditAction>(), Arg.Any<string>(), Arg.Any<Guid>(),
-            Arg.Any<string>(), Arg.Any<string>(),
-            Arg.Any<Guid?>(), Arg.Any<string?>())
-            .Returns(callInfo =>
-            {
-                var entityId = callInfo.ArgAt<Guid>(2);
-                if (entityId == failEntityId)
-                    return Task.FromException(new InvalidOperationException("DB error"));
-                return Task.CompletedTask;
-            });
+        _userService.AnonymizeExpiredAccountAsync(user1, Now, Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("DB error"));
+        _userService.AnonymizeExpiredAccountAsync(user2, Now, Arg.Any<CancellationToken>())
+            .Returns(new AnonymizedAccountSummary(
+                "u2@example.com", "User Two", "en",
+                Array.Empty<(Guid, Guid)>()));
 
         await _job.ExecuteAsync();
 
-        // Second user should still be processed (anonymized)
-        var updatedUser2 = await _dbContext.Users.SingleAsync(u => u.Id == user2Id);
-        updatedUser2.DisplayName.Should().Be("Deleted User");
-    }
-
-    private async Task<User> SeedUserScheduledForDeletion(
-        Instant deletionScheduledFor,
-        Instant? deletionEligibleAfter = null)
-    {
-        var userId = Guid.NewGuid();
-        var user = new User
-        {
-            Id = userId,
-            UserName = "testuser",
-            NormalizedUserName = "TESTUSER",
-            Email = "test@example.com",
-            NormalizedEmail = "TEST@EXAMPLE.COM",
-            DisplayName = "Test User",
-            DeletionRequestedAt = deletionScheduledFor - Duration.FromDays(30),
-            DeletionScheduledFor = deletionScheduledFor,
-            DeletionEligibleAfter = deletionEligibleAfter,
-            PreferredLanguage = "en",
-            Profile = new Profile
-            {
-                Id = Guid.NewGuid(),
-                UserId = userId,
-                FirstName = "Test",
-                LastName = "User",
-                BurnerName = "Tester",
-                Bio = "A test bio",
-                City = "Madrid"
-            }
-        };
-
-        _dbContext.Users.Add(user);
-        await _dbContext.SaveChangesAsync();
-        return user;
+        // User 2 still gets its email/audit despite user 1 failing.
+        await _emailService.Received(1).SendAccountDeletedAsync(
+            "u2@example.com", "User Two", "en", Arg.Any<CancellationToken>());
     }
 }

--- a/tests/Humans.Application.Tests/Jobs/ProcessEmailOutboxJobTests.cs
+++ b/tests/Humans.Application.Tests/Jobs/ProcessEmailOutboxJobTests.cs
@@ -15,6 +15,7 @@ using Humans.Infrastructure.Data;
 using Humans.Infrastructure.Jobs;
 using Humans.Infrastructure.Services;
 using Xunit;
+using Humans.Application.Interfaces.Campaigns;
 using Humans.Application.Interfaces.Email;
 using Humans.Infrastructure.Repositories.Email;
 
@@ -25,6 +26,7 @@ public class ProcessEmailOutboxJobTests : IDisposable
     private readonly DbContextOptions<HumansDbContext> _options;
     private readonly HumansDbContext _dbContext;
     private readonly IEmailTransport _transport;
+    private readonly ICampaignService _campaignService;
     private readonly FakeClock _clock;
     private readonly HumansMetricsService _metrics;
     private readonly IOptions<EmailSettings> _settings;
@@ -39,6 +41,7 @@ public class ProcessEmailOutboxJobTests : IDisposable
 
         _dbContext = new HumansDbContext(_options);
         _transport = Substitute.For<IEmailTransport>();
+        _campaignService = Substitute.For<ICampaignService>();
         _clock = new FakeClock(Instant.FromUtc(2026, 3, 14, 12, 0));
         _metrics = new HumansMetricsService(
             Substitute.For<IServiceScopeFactory>(),
@@ -47,7 +50,7 @@ public class ProcessEmailOutboxJobTests : IDisposable
         var logger = Substitute.For<ILogger<ProcessEmailOutboxJob>>();
         _repo = new EmailOutboxRepository(new TestDbContextFactory(_options));
 
-        _job = new ProcessEmailOutboxJob(_dbContext, _repo, _transport, _metrics, _clock, _settings, logger);
+        _job = new ProcessEmailOutboxJob(_repo, _campaignService, _transport, _metrics, _clock, _settings, logger);
     }
 
     public void Dispose()
@@ -114,7 +117,7 @@ public class ProcessEmailOutboxJobTests : IDisposable
 
         var batchSettings = Options.Create(new EmailSettings { OutboxBatchSize = 10, OutboxMaxRetries = 10 });
         var job = new ProcessEmailOutboxJob(
-            _dbContext, _repo, _transport, _metrics, _clock, batchSettings,
+            _repo, _campaignService, _transport, _metrics, _clock, batchSettings,
             Substitute.For<ILogger<ProcessEmailOutboxJob>>());
 
         await job.ExecuteAsync();

--- a/tests/Humans.Application.Tests/Repositories/ShiftSignupRepositoryTests.cs
+++ b/tests/Humans.Application.Tests/Repositories/ShiftSignupRepositoryTests.cs
@@ -5,6 +5,7 @@ using Humans.Infrastructure.Data;
 using Humans.Infrastructure.Repositories.Shifts;
 using Microsoft.EntityFrameworkCore;
 using NodaTime;
+using NodaTime.Testing;
 using Xunit;
 
 namespace Humans.Application.Tests.Repositories;
@@ -28,7 +29,7 @@ public class ShiftSignupRepositoryTests : IDisposable
             .UseInMemoryDatabase(Guid.NewGuid().ToString())
             .Options;
         _dbContext = new HumansDbContext(options);
-        _repo = new ShiftSignupRepository(_dbContext);
+        _repo = new ShiftSignupRepository(_dbContext, new FakeClock(TestNow));
     }
 
     public void Dispose()

--- a/tests/Humans.Application.Tests/Services/AccountProvisioningServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/AccountProvisioningServiceTests.cs
@@ -67,6 +67,10 @@ file sealed class StubAuditLog : IAuditLogService
 
     public Task<Dictionary<Guid, (string Name, string Slug)>> GetTeamNamesAsync(IReadOnlyList<Guid> teamIds, CancellationToken ct = default) =>
         Task.FromResult(new Dictionary<Guid, (string Name, string Slug)>());
+
+    public Task<IReadOnlyList<Guid>> GetEntityIdsForActionInWindowAsync(
+        Instant windowStart, Instant windowEnd, AuditAction action, CancellationToken ct = default) =>
+        Task.FromResult((IReadOnlyList<Guid>)Array.Empty<Guid>());
 }
 
 /// <summary>

--- a/tests/Humans.Application.Tests/Services/AccountProvisioningServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/AccountProvisioningServiceTests.cs
@@ -136,6 +136,9 @@ public class AccountProvisioningServiceTests
         public Task<IReadOnlyDictionary<Guid, User>> GetByIdsAsync(
             IReadOnlyCollection<Guid> userIds, CancellationToken ct = default) =>
             throw new NotSupportedException();
+        public Task<IReadOnlyDictionary<Guid, User>> GetByIdsWithEmailsAsync(
+            IReadOnlyCollection<Guid> userIds, CancellationToken ct = default) =>
+            throw new NotSupportedException();
         public Task<IReadOnlyList<User>> GetAllAsync(CancellationToken ct = default) =>
             throw new NotSupportedException();
         public Task<User?> GetByNormalizedEmailAsync(string? normalizedEmail, CancellationToken ct = default) =>

--- a/tests/Humans.Application.Tests/Services/AccountProvisioningServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/AccountProvisioningServiceTests.cs
@@ -191,6 +191,14 @@ public class AccountProvisioningServiceTests
             throw new NotSupportedException();
         public Task<int> GetPendingDeletionCountAsync(CancellationToken ct = default) =>
             throw new NotSupportedException();
+        public Task SetLastConsentReminderSentAsync(Guid userId, Instant sentAt, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+        public Task<int> GetRejectedGoogleEmailCountAsync(CancellationToken ct = default) =>
+            throw new NotSupportedException();
+        public Task<IReadOnlyList<Guid>> GetAccountsDueForAnonymizationAsync(Instant now, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+        public Task<ExpiredDeletionAnonymizationResult?> ApplyExpiredDeletionAnonymizationAsync(Guid userId, CancellationToken ct = default) =>
+            throw new NotSupportedException();
     }
 
     private sealed class FakeUserEmailRepository : IUserEmailRepository

--- a/tests/Humans.Application.Tests/Services/CommunicationPreferenceServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/CommunicationPreferenceServiceTests.cs
@@ -71,6 +71,10 @@ file sealed class StubAuditLogService : IAuditLogService
 
     public Task<Dictionary<Guid, (string Name, string Slug)>> GetTeamNamesAsync(IReadOnlyList<Guid> teamIds, CancellationToken ct = default) =>
         Task.FromResult(new Dictionary<Guid, (string Name, string Slug)>());
+
+    public Task<IReadOnlyList<Guid>> GetEntityIdsForActionInWindowAsync(
+        NodaTime.Instant windowStart, NodaTime.Instant windowEnd, AuditAction action, CancellationToken ct = default) =>
+        Task.FromResult((IReadOnlyList<Guid>)Array.Empty<Guid>());
 }
 
 public class CommunicationPreferenceServiceTests : IDisposable

--- a/tests/Humans.Application.Tests/Services/ShiftDashboardMetricsTests.cs
+++ b/tests/Humans.Application.Tests/Services/ShiftDashboardMetricsTests.cs
@@ -705,6 +705,10 @@ public class ShiftDashboardMetricsTests : IDisposable
         public Task<IReadOnlyList<(string Language, int Count)>> GetLanguageDistributionForUserIdsAsync(IReadOnlyCollection<Guid> userIds, CancellationToken ct = default) => throw new NotSupportedException();
         public Task<(bool Purged, string? DisplayName)> PurgeAsync(Guid userId, CancellationToken ct = default) => throw new NotSupportedException();
         public Task<int> GetPendingDeletionCountAsync(CancellationToken ct = default) => throw new NotSupportedException();
+        public Task SetLastConsentReminderSentAsync(Guid userId, Instant sentAt, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task<int> GetRejectedGoogleEmailCountAsync(CancellationToken ct = default) => throw new NotSupportedException();
+        public Task<IReadOnlyList<Guid>> GetAccountsDueForAnonymizationAsync(Instant now, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task<AnonymizedAccountSummary?> AnonymizeExpiredAccountAsync(Guid userId, Instant now, CancellationToken ct = default) => throw new NotSupportedException();
     }
 
     private sealed class FakeTeamService : ITeamService

--- a/tests/Humans.Application.Tests/Services/ShiftDashboardMetricsTests.cs
+++ b/tests/Humans.Application.Tests/Services/ShiftDashboardMetricsTests.cs
@@ -805,5 +805,6 @@ public class ShiftDashboardMetricsTests : IDisposable
         public Task<IReadOnlyList<Guid>> GetActiveMemberUserIdsAsync(Guid teamId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<IReadOnlyDictionary<Guid, IReadOnlyList<string>>> GetActiveNonSystemTeamNamesByUserIdsAsync(IReadOnlyCollection<Guid> userIds, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<int> GetTotalPendingJoinRequestCountAsync(CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<IReadOnlyList<Guid>> GetActiveNonSystemTeamCoordinatorUserIdsAsync(CancellationToken cancellationToken = default) => throw new NotSupportedException();
     }
 }

--- a/tests/Humans.Application.Tests/Services/ShiftDashboardMetricsTests.cs
+++ b/tests/Humans.Application.Tests/Services/ShiftDashboardMetricsTests.cs
@@ -675,6 +675,13 @@ public class ShiftDashboardMetricsTests : IDisposable
             return users.ToDictionary(u => u.Id);
         }
 
+        public async Task<IReadOnlyDictionary<Guid, User>> GetByIdsWithEmailsAsync(IReadOnlyCollection<Guid> userIds, CancellationToken ct = default)
+        {
+            if (userIds.Count == 0) return new Dictionary<Guid, User>();
+            var users = await _db.Users.Include(u => u.UserEmails).Where(u => userIds.Contains(u.Id)).ToListAsync(ct);
+            return users.ToDictionary(u => u.Id);
+        }
+
         public async Task<IReadOnlyList<Instant>> GetLoginTimestampsInWindowAsync(Instant fromInclusive, Instant toExclusive, CancellationToken ct = default)
         {
             return await _db.Users

--- a/tests/Humans.Application.Tests/Services/ShiftSignupServiceEarlyEntryTests.cs
+++ b/tests/Humans.Application.Tests/Services/ShiftSignupServiceEarlyEntryTests.cs
@@ -59,7 +59,7 @@ public class ShiftSignupServiceEarlyEntryTests : IDisposable
             _clock,
             NullLogger<ShiftManagementService>.Instance);
 
-        _repo = new ShiftSignupRepository(_dbContext);
+        _repo = new ShiftSignupRepository(_dbContext, _clock);
         _service = new ShiftSignupService(
             _repo,
             _shiftMgmt,

--- a/tests/Humans.Application.Tests/Services/ShiftSignupServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/ShiftSignupServiceTests.cs
@@ -61,7 +61,7 @@ public class ShiftSignupServiceTests : IDisposable
             _clock,
             NullLogger<ShiftManagementService>.Instance);
 
-        _repo = new ShiftSignupRepository(_dbContext);
+        _repo = new ShiftSignupRepository(_dbContext, _clock);
         _service = new ShiftSignupService(
             _repo,
             _shiftMgmt,


### PR DESCRIPTION
## Summary

This is the **non-Google subset** of issue nobodies-collective/Humans#570 — migrates 7 Hangfire jobs off `HumansDbContext` / `IDbContextFactory<HumansDbContext>` / `IMemoryCache` and onto service interfaces, so each section's tables stay owned by its own service per design-rules §2c and §15.

**Jobs landed in this PR (7):**
- `ProcessAccountDeletionsJob` — full anonymization now lives in `IUserService.AnonymizeExpiredAccountAsync`, which dispatches to every owning service (Profile, Teams, RoleAssignments, Shifts) via a lazy `IServiceProvider` resolver. Cache invalidation (`IFullProfileInvalidator`, `IRoleAssignmentClaimsCacheInvalidator`, `IShiftAuthorizationInvalidator`, `ITeamService.RemoveMemberFromAllTeamsCache`) is the service's responsibility; the job no longer injects `IMemoryCache`.
- `ProcessEmailOutboxJob` — `CampaignGrant` status updates go through new `ICampaignService.UpdateGrantEmailStatusAsync`.
- `SendAdminDailyDigestJob` / `SendBoardDailyDigestJob` — every read fanned out through `IUserService`, `IProfileService`, `ITeamService`, `IApplicationDecisionService`, `IRoleAssignmentService`, `ITicketSyncService`, `IAuditLogService`, and the existing `IGoogleSyncOutboxRepository`. New audit-log method `GetEntityIdsForActionInWindowAsync` and ticket-sync `GetErrorStatusAsync` let the digests pull their specific slices without touching DbContext.
- `SendReConsentReminderJob` — User reads + `LastConsentReminderSentAt` writes via `IUserService`.
- `SyncLegalDocumentsJob` — team members via `ITeamService.GetActiveMemberUserIdsAsync`, users via `IUserService.GetByIdsAsync`; consent lookups already go through `IConsentRepository`.
- `TermRenewalReminderJob` — expiring/pending applications and the reminder-sent stamp via new `IApplicationDecisionService` methods; applicants stitched via `IUserService.GetByIdsAsync`.

**Deferred (3 — NOT in this PR):** `ProcessGoogleSyncOutboxJob`, `SystemTeamSyncJob`, `SuspendNonCompliantMembersJob`. Each writes to Google Workspace via `IGoogleSyncService`, whose shape is being reworked in the pending §15 Part 2b (nobodies-collective/Humans#575) Google migration. Rerouting them now would just churn the surface twice — we wait until #575 lands and fold them in then.

## New service surface (additive — no renames)

- `IUserService`: `GetAccountsDueForAnonymizationAsync`, `AnonymizeExpiredAccountAsync` (+ `AnonymizedAccountSummary` record), `GetRejectedGoogleEmailCountAsync`, `SetLastConsentReminderSentAsync`
- `IProfileService`: `AnonymizeExpiredProfileAsync` (uses a shared private helper with `AnonymizeForMergeByUserIdAsync`; label is the only diff)
- `IShiftSignupService`: `CancelActiveSignupsForUserAsync` (returns cancelled id/shift pairs for audit)
- `IShiftManagementService`: `DeleteShiftProfilesForUserAsync`
- `ITeamService`: `GetActiveNonSystemTeamCoordinatorUserIdsAsync`
- `IApplicationDecisionService`: `GetExpiringApplicationsNeedingReminderAsync`, `GetPendingApplicationUserTiersAsync`, `MarkRenewalReminderSentAsync`, `GetApprovedInWindowAsync`, `GetSubmittedApplicationIdsAsync`, `GetUnvotedCountForBoardMemberAmongApplicationsAsync`
- `IAuditLogService`: `GetEntityIdsForActionInWindowAsync`
- `ICampaignService`: `UpdateGrantEmailStatusAsync`
- `ITicketSyncService`: `GetErrorStatusAsync` (+ `TicketSyncErrorStatus` record)

Repository-side mirrors on `IUserRepository`, `IProfileRepository`, `IShiftSignupRepository`, `IShiftManagementRepository`, `ITeamRepository`, `IApplicationRepository`, `IAuditLogRepository`.

`ShiftSignupRepository` now takes `IClock` so it can call `ShiftSignup.Cancel(clock, reason)` atomically inside `CancelActiveSignupsForUserAsync`.

## Test plan

- [x] `dotnet build Humans.slnx -v quiet` — clean
- [x] `dotnet test Humans.slnx -v quiet` — 116 domain + 1518 application + 32 integration, all green
- [x] `ProcessAccountDeletionsJobTests` rewritten around the new service-coordination contract (service-level mocks replace the in-memory DbContext round-trip).
- [x] `ProcessEmailOutboxJobTests` updated for the new ctor signature + `ICampaignService` mock.
- [x] FakeUserRepository / FakeUserService / FakeTeamService / StubAuditLogService stubs in neighbouring tests updated for added interface members.
- [ ] Smoke: after merge, watch QA Hangfire dashboard for clean runs of the 7 jobs.

## Related

- Issue nobodies-collective/Humans#570 (§15 partial)
- Prior Part 1 PRs: peterdrier/Humans#297 (Google outbox), #298 (Budget), #299 (Calendar), #300 (Teams)
- Depends-on (for deferred 3): §15 Part 2b / nobodies-collective/Humans#575
- peterdrier/Humans#292 (§15 tracking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)