### PR TITLE
§15 Part 1 Google-writing jobs: route SystemTeamSyncJob + SuspendNonCompliantMembersJob through service interfaces (completes #570)

### DIFF
--- a/src/Humans.Application/Interfaces/Caching/IActiveTeamsCacheInvalidator.cs
+++ b/src/Humans.Application/Interfaces/Caching/IActiveTeamsCacheInvalidator.cs
@@ -1,0 +1,19 @@
+namespace Humans.Application.Interfaces.Caching;
+
+/// <summary>
+/// Cross-cutting invalidator for the <c>CacheKeys.ActiveTeams</c> in-memory
+/// team directory cache owned by the Teams section. Background jobs and other
+/// services that change team membership outside of <c>ITeamService</c>'s own
+/// write paths inject this and call <see cref="Invalidate"/> after their own
+/// writes — they never touch <see cref="Microsoft.Extensions.Caching.Memory.IMemoryCache"/>
+/// directly. Added during the Google-writing Hangfire-jobs migration (issue
+/// #570) so <c>SystemTeamSyncJob</c> can drop its direct cache dependency.
+/// </summary>
+public interface IActiveTeamsCacheInvalidator
+{
+    /// <summary>
+    /// Evicts the active-teams master cache entry so the next read repopulates
+    /// from the database via <c>ITeamService</c>.
+    /// </summary>
+    void Invalidate();
+}

--- a/src/Humans.Application/Interfaces/Governance/IApplicationDecisionService.cs
+++ b/src/Humans.Application/Interfaces/Governance/IApplicationDecisionService.cs
@@ -218,6 +218,41 @@ public interface IApplicationDecisionService
         Guid boardMemberUserId,
         IReadOnlyCollection<Guid> applicationIds,
         CancellationToken ct = default);
+
+    // ==========================================================================
+    // System team sync support (issue #570 — §15 Google-writing jobs)
+    // ==========================================================================
+
+    /// <summary>
+    /// Returns the distinct user ids whose Approved application for
+    /// <paramref name="tier"/> still has an active term on
+    /// <paramref name="today"/> (<c>TermExpiresAt</c> is null or on/after
+    /// <paramref name="today"/>). Used by <c>SystemTeamSyncJob.SyncTierTeamAsync</c>
+    /// so the job never reads <c>applications</c> directly (design-rules §2c).
+    /// </summary>
+    Task<IReadOnlyList<Guid>> GetActiveApprovedTierUserIdsAsync(
+        MembershipTier tier, LocalDate today, CancellationToken ct = default);
+
+    /// <summary>
+    /// Does <paramref name="userId"/> have an Approved application for
+    /// <paramref name="tier"/> whose term is still active on
+    /// <paramref name="today"/>? Used by
+    /// <c>SystemTeamSyncJob.SyncTierMembershipForUserAsync</c>.
+    /// </summary>
+    Task<bool> HasActiveApprovedTierAsync(
+        Guid userId, MembershipTier tier, LocalDate today, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns the per-user "other active tier" map: for each user with an
+    /// Approved application for a non-<paramref name="excludeTier"/>
+    /// non-Volunteer tier that is still active on <paramref name="today"/>,
+    /// returns the tier. Each user maps to a single entry (the first Approved
+    /// row found); callers use this to decide whether a tier-downgrade
+    /// should land at Volunteer or at the alternate tier. Used by
+    /// <c>SystemTeamSyncJob.SyncTierTeamAsync</c>.
+    /// </summary>
+    Task<IReadOnlyDictionary<Guid, MembershipTier>> GetOtherActiveTierAssignmentsAsync(
+        MembershipTier excludeTier, LocalDate today, CancellationToken ct = default);
 }
 
 public record ApplicationDecisionResult(bool Success, string? ErrorKey = null, Guid? ApplicationId = null);

--- a/src/Humans.Application/Interfaces/Profiles/IProfileService.cs
+++ b/src/Humans.Application/Interfaces/Profiles/IProfileService.cs
@@ -226,4 +226,25 @@ public interface IProfileService
         IReadOnlyCollection<Guid> userIds,
         Instant now,
         CancellationToken ct = default);
+
+    /// <summary>
+    /// For every profile whose <see cref="Profile.MembershipTier"/> equals
+    /// <paramref name="currentTier"/> and whose <c>UserId</c> is NOT in
+    /// <paramref name="userIdsToKeep"/>, downgrade the tier to the value
+    /// supplied by <paramref name="fallbackTierByUser"/> (falling back to
+    /// <see cref="MembershipTier.Volunteer"/> when the user is absent from
+    /// the map). Stamps <see cref="Profile.UpdatedAt"/> to
+    /// <paramref name="now"/> and persists in a single save. Returns a list
+    /// of (UserId, NewTier) tuples so the caller can emit audit entries
+    /// without a second round-trip. Used by
+    /// <c>SystemTeamSyncJob.SyncTierTeamAsync</c> so the job does not write
+    /// to <c>profiles</c> directly (design-rules §2c).
+    /// </summary>
+    Task<IReadOnlyList<(Guid UserId, MembershipTier NewTier)>>
+        DowngradeTierForExpiredAsync(
+            MembershipTier currentTier,
+            IReadOnlyCollection<Guid> userIdsToKeep,
+            IReadOnlyDictionary<Guid, MembershipTier> fallbackTierByUser,
+            Instant now,
+            CancellationToken ct = default);
 }

--- a/src/Humans.Application/Interfaces/Profiles/IProfileService.cs
+++ b/src/Humans.Application/Interfaces/Profiles/IProfileService.cs
@@ -206,4 +206,24 @@ public interface IProfileService
     /// <see cref="Users.IUserService.AnonymizeExpiredAccountAsync"/>.
     /// </summary>
     Task<bool> AnonymizeExpiredProfileAsync(Guid userId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Sets <see cref="Profile.IsSuspended"/> to true and stamps
+    /// <see cref="Profile.UpdatedAt"/> for users whose consent grace period has
+    /// expired. Unlike <see cref="SuspendAsync"/>, this variant does not
+    /// require an admin actor, skip-list already-suspended profiles (so the
+    /// caller can pre-filter with the returned set), and does not write an
+    /// audit log entry — the caller is expected to emit the
+    /// <see cref="Humans.Domain.Enums.AuditAction.MemberSuspended"/> entry
+    /// itself so it can include job-specific context.
+    /// Returns the set of user ids whose profile was actually mutated (i.e.
+    /// those who had a profile and were not already suspended).
+    /// No-op (absent from the returned set) for users without a profile or
+    /// already suspended. Used by the SuspendNonCompliantMembersJob so the
+    /// Profile section owns the write (design-rules §2c).
+    /// </summary>
+    Task<IReadOnlySet<Guid>> SuspendForMissingConsentAsync(
+        IReadOnlyCollection<Guid> userIds,
+        Instant now,
+        CancellationToken ct = default);
 }

--- a/src/Humans.Application/Interfaces/Repositories/IApplicationRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/IApplicationRepository.cs
@@ -205,6 +205,35 @@ public interface IApplicationRepository
     /// </summary>
     Task MarkRenewalReminderSentAsync(
         Guid applicationId, Instant sentAt, CancellationToken ct = default);
+
+    // ==========================================================================
+    // System team sync support (issue #570 — §15 Google-writing jobs)
+    // ==========================================================================
+
+    /// <summary>
+    /// Returns the distinct user ids of every Approved application for
+    /// <paramref name="tier"/> whose term is still active on
+    /// <paramref name="today"/> (<c>TermExpiresAt</c> is null or on/after
+    /// <paramref name="today"/>).
+    /// </summary>
+    Task<IReadOnlyList<Guid>> GetActiveApprovedTierUserIdsAsync(
+        MembershipTier tier, LocalDate today, CancellationToken ct = default);
+
+    /// <summary>
+    /// Does the user have an Approved application for <paramref name="tier"/>
+    /// whose term is still active on <paramref name="today"/>?
+    /// </summary>
+    Task<bool> HasActiveApprovedTierAsync(
+        Guid userId, MembershipTier tier, LocalDate today, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns per-user active-approved non-Volunteer tier assignments
+    /// excluding <paramref name="excludeTier"/>. Each entry is the first
+    /// (UserId, MembershipTier) row encountered. Used by the system team
+    /// sync's tier-downgrade calculation.
+    /// </summary>
+    Task<IReadOnlyDictionary<Guid, MembershipTier>> GetOtherActiveTierAssignmentsAsync(
+        MembershipTier excludeTier, LocalDate today, CancellationToken ct = default);
 }
 
 /// <summary>

--- a/src/Humans.Application/Interfaces/Repositories/IProfileRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/IProfileRepository.cs
@@ -1,4 +1,5 @@
 using Humans.Domain.Entities;
+using Humans.Domain.Enums;
 using Humans.Application;
 using NodaTime;
 
@@ -177,6 +178,24 @@ public interface IProfileRepository
         IReadOnlyCollection<Guid> userIds,
         Instant now,
         CancellationToken ct = default);
+
+    /// <summary>
+    /// For every profile whose <see cref="Profile.MembershipTier"/> equals
+    /// <paramref name="currentTier"/> and whose <c>UserId</c> is NOT in
+    /// <paramref name="userIdsToKeep"/>, downgrades the tier to the value
+    /// supplied by <paramref name="fallbackTierByUser"/> (defaulting to
+    /// <see cref="MembershipTier.Volunteer"/> when the user is absent).
+    /// Stamps <see cref="Profile.UpdatedAt"/> and persists. Returns a list
+    /// of (UserId, NewTier) tuples for audit logging. Used by the system
+    /// team sync's tier-downgrade pass.
+    /// </summary>
+    Task<IReadOnlyList<(Guid UserId, MembershipTier NewTier)>>
+        DowngradeTierForExpiredAsync(
+            MembershipTier currentTier,
+            IReadOnlyCollection<Guid> userIdsToKeep,
+            IReadOnlyDictionary<Guid, MembershipTier> fallbackTierByUser,
+            Instant now,
+            CancellationToken ct = default);
 
     /// <summary>
     /// Reconciles the CV-entry collection for the given profile with the

--- a/src/Humans.Application/Interfaces/Repositories/IProfileRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/IProfileRepository.cs
@@ -1,5 +1,6 @@
 using Humans.Domain.Entities;
 using Humans.Application;
+using NodaTime;
 
 namespace Humans.Application.Interfaces.Repositories;
 
@@ -163,6 +164,19 @@ public interface IProfileRepository
     /// intentionally left as-is; they are not personally identifying.
     /// </remarks>
     Task<bool> AnonymizeForDeletionByUserIdAsync(Guid userId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Sets <see cref="Profile.IsSuspended"/> to true and stamps
+    /// <see cref="Profile.UpdatedAt"/> for every profile whose <c>UserId</c>
+    /// is in <paramref name="userIds"/> and that is not already suspended.
+    /// Persists in a single SaveChanges and returns the set of user ids
+    /// whose profile was actually mutated. Used by the non-compliant
+    /// suspension job — the caller writes the audit log separately.
+    /// </summary>
+    Task<IReadOnlySet<Guid>> SuspendManyAsync(
+        IReadOnlyCollection<Guid> userIds,
+        Instant now,
+        CancellationToken ct = default);
 
     /// <summary>
     /// Reconciles the CV-entry collection for the given profile with the

--- a/src/Humans.Application/Interfaces/Repositories/ITeamRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/ITeamRepository.cs
@@ -586,4 +586,77 @@ public interface ITeamRepository
     /// </summary>
     Task<IReadOnlyList<TeamJoinRequest>> GetAllJoinRequestsForUserAsync(
         Guid userId, CancellationToken ct = default);
+
+    // ==========================================================================
+    // System team sync support (issue #570 — §15 Google-writing jobs)
+    //
+    // Narrow repository methods used exclusively by the Teams-section service
+    // methods that back SystemTeamSyncJob. Every mutation commits in its own
+    // DbContext so the Singleton+IDbContextFactory contract is preserved.
+    // ==========================================================================
+
+    /// <summary>
+    /// Load the system team whose <see cref="Team.SystemTeamType"/> matches
+    /// <paramref name="type"/> along with its active
+    /// (<see cref="TeamMember.LeftAt"/> is null) members. Detached. Returns
+    /// null if no team of that system type exists.
+    /// </summary>
+    Task<Team?> GetSystemTeamWithActiveMembersAsync(
+        SystemTeamType type, CancellationToken ct = default);
+
+    /// <summary>
+    /// Load every active (<see cref="TeamMember.LeftAt"/> is null) team
+    /// membership along with its <see cref="TeamMember.RoleAssignments"/>
+    /// and each assignment's <see cref="TeamRoleAssignment.TeamRoleDefinition"/>.
+    /// Also hydrates <see cref="TeamMember.Team"/> so the caller can read the
+    /// team's <see cref="Team.SystemTeamType"/> without a second query.
+    /// Detached. Used by <c>SystemTeamSyncJob.ReconcileCoordinatorRolesAsync</c>
+    /// to decide promote / demote sets in memory.
+    /// </summary>
+    Task<IReadOnlyList<TeamMember>> GetActiveMembershipsForRoleReconciliationAsync(
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Applies a bulk list of <see cref="TeamMember.Role"/> changes in one save.
+    /// Ignores team-member ids that are no longer active. Used by
+    /// <c>SystemTeamSyncJob.ReconcileCoordinatorRolesAsync</c> so the job
+    /// does not write to <c>team_members</c> directly.
+    /// </summary>
+    Task<int> ApplyMemberRoleChangesAsync(
+        IReadOnlyCollection<(Guid TeamMemberId, TeamMemberRole Role)> changes,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns the distinct user ids of every active coordinator on a
+    /// non-system department team (<see cref="Team.ParentTeamId"/> is null).
+    /// Sub-team managers are excluded. Used by the Coordinators system-team
+    /// sync to determine membership eligibility.
+    /// </summary>
+    Task<IReadOnlyList<Guid>> GetActiveDepartmentCoordinatorUserIdsAsync(
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Does the user currently hold <see cref="TeamMemberRole.Coordinator"/>
+    /// on any active department team (<see cref="Team.ParentTeamId"/> is null)?
+    /// Used by <c>SystemTeamSyncJob.SyncCoordinatorsMembershipForUserAsync</c>.
+    /// </summary>
+    Task<bool> IsActiveDepartmentCoordinatorAsync(
+        Guid userId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Applies a bulk system-team membership reconciliation in a single save:
+    /// inserts a new <see cref="TeamMember"/> with <c>Role=Member</c> +
+    /// <c>JoinedAt=now</c> for each id in <paramref name="userIdsToAdd"/>,
+    /// and for each id in <paramref name="userIdsToRemove"/>, sets
+    /// <see cref="TeamMember.LeftAt"/> on the single active membership and
+    /// cascade-deletes any <see cref="TeamRoleAssignment"/> rows attached to
+    /// that membership. Bumps <see cref="Team.UpdatedAt"/> if at least one
+    /// change lands. Returns true if any writes occurred.
+    /// </summary>
+    Task<bool> ApplySystemTeamMembershipDeltaAsync(
+        Guid teamId,
+        IReadOnlyCollection<Guid> userIdsToAdd,
+        IReadOnlyCollection<Guid> userIdsToRemove,
+        Instant now,
+        CancellationToken ct = default);
 }

--- a/src/Humans.Application/Interfaces/Repositories/IUserRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/IUserRepository.cs
@@ -329,6 +329,17 @@ public interface IUserRepository
         int year,
         IReadOnlyList<(Guid UserId, ParticipationStatus Status)> entries,
         CancellationToken ct = default);
+
+    /// <summary>
+    /// For each user whose <see cref="User.GoogleEmail"/> is currently null
+    /// but who has a verified <see cref="UserEmail"/> row whose address ends
+    /// in <c>@nobodies.team</c>, set <c>User.GoogleEmail</c> to that verified
+    /// address. Persists in a single save. Returns one descriptor per
+    /// mutated user so the caller can emit audit entries without reloading.
+    /// Used by the system team sync's backfill pass.
+    /// </summary>
+    Task<IReadOnlyList<(Guid UserId, string DisplayName, string GoogleEmail)>>
+        BackfillNobodiesTeamGoogleEmailsAsync(CancellationToken ct = default);
 }
 
 /// <summary>

--- a/src/Humans.Application/Interfaces/Teams/ITeamService.cs
+++ b/src/Humans.Application/Interfaces/Teams/ITeamService.cs
@@ -702,4 +702,76 @@ public interface ITeamService
     Task<IReadOnlyList<TeamMember>> GetActiveChildMembersByParentIdsAsync(
         IReadOnlyCollection<Guid> parentTeamIds,
         CancellationToken cancellationToken = default);
+
+    // ==========================================================================
+    // System team sync support (issue #570 — §15 Google-writing jobs)
+    //
+    // Narrow read/write methods used exclusively by SystemTeamSyncJob so the
+    // job can drop its HumansDbContext dependency. Each mutation commits in
+    // its own repository-owned unit of work; the caller fan-outs Google sync
+    // calls externally.
+    // ==========================================================================
+
+    /// <summary>
+    /// Loads the system team whose <see cref="Team.SystemTeamType"/> equals
+    /// <paramref name="type"/>, with active members hydrated. Returns null
+    /// when no team is configured for that system type.
+    /// </summary>
+    Task<Team?> GetSystemTeamWithActiveMembersAsync(
+        SystemTeamType type, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Loads every active membership with enough role-assignment / role-
+    /// definition / team context to decide coordinator promotion and
+    /// demotion in-memory. Used by <c>SystemTeamSyncJob.ReconcileCoordinatorRolesAsync</c>.
+    /// </summary>
+    Task<IReadOnlyList<TeamMember>> GetActiveMembershipsForRoleReconciliationAsync(
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Applies a bulk list of <see cref="TeamMember.Role"/> changes (promote
+    /// to Coordinator / demote to Member) in a single save. Invalidates the
+    /// ActiveTeams cache if any change is applied. Returns the number of
+    /// memberships updated.
+    /// </summary>
+    Task<int> ApplyMemberRoleChangesAsync(
+        IReadOnlyCollection<(Guid TeamMemberId, TeamMemberRole Role)> changes,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns the distinct user ids of every active coordinator on a
+    /// non-system department team (<c>ParentTeamId</c> is null). Sub-team
+    /// managers are excluded.
+    /// </summary>
+    Task<IReadOnlyList<Guid>> GetActiveDepartmentCoordinatorUserIdsAsync(
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Is the user a coordinator on any active department team
+    /// (<c>ParentTeamId</c> is null)?
+    /// </summary>
+    Task<bool> IsActiveDepartmentCoordinatorAsync(
+        Guid userId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Applies a system-team membership reconciliation in a single save:
+    /// inserts new <see cref="TeamMember"/> rows for <paramref name="userIdsToAdd"/>
+    /// with <see cref="TeamMemberRole.Member"/> + <c>JoinedAt=now</c>, and
+    /// soft-removes the active memberships for <paramref name="userIdsToRemove"/>
+    /// by stamping <see cref="TeamMember.LeftAt"/> and cascade-deleting any
+    /// attached <see cref="TeamRoleAssignment"/> rows. Bumps
+    /// <see cref="Team.UpdatedAt"/> and invalidates the ActiveTeams cache
+    /// when at least one change lands. Returns true when any writes occur.
+    /// </summary>
+    /// <remarks>
+    /// The caller is expected to fan out Google-sync calls
+    /// (<c>AddUserToTeamResourcesAsync</c> / <c>RemoveUserFromTeamResourcesAsync</c>)
+    /// and audit entries per user after this method returns.
+    /// </remarks>
+    Task<bool> ApplySystemTeamMembershipDeltaAsync(
+        Guid teamId,
+        IReadOnlyCollection<Guid> userIdsToAdd,
+        IReadOnlyCollection<Guid> userIdsToRemove,
+        Instant now,
+        CancellationToken cancellationToken = default);
 }

--- a/src/Humans.Application/Interfaces/Users/IUserService.cs
+++ b/src/Humans.Application/Interfaces/Users/IUserService.cs
@@ -279,6 +279,17 @@ public interface IUserService
     /// </summary>
     Task<AnonymizedAccountSummary?> AnonymizeExpiredAccountAsync(
         Guid userId, Instant now, CancellationToken ct = default);
+
+    /// <summary>
+    /// For every user whose <see cref="User.GoogleEmail"/> is null but who has
+    /// a verified <c>@nobodies.team</c> <see cref="UserEmail"/> row, sets
+    /// <see cref="User.GoogleEmail"/> to that verified address. Persists all
+    /// changes in a single save and returns the list of backfill descriptors
+    /// (UserId, DisplayName, NewGoogleEmail) so the caller can emit audit
+    /// entries. Used by <c>SystemTeamSyncJob.BackfillGoogleEmailsAsync</c>.
+    /// </summary>
+    Task<IReadOnlyList<(Guid UserId, string DisplayName, string GoogleEmail)>>
+        BackfillNobodiesTeamGoogleEmailsAsync(CancellationToken ct = default);
 }
 
 /// <summary>

--- a/src/Humans.Application/Services/Governance/ApplicationDecisionService.cs
+++ b/src/Humans.Application/Services/Governance/ApplicationDecisionService.cs
@@ -660,6 +660,18 @@ public sealed class ApplicationDecisionService : IApplicationDecisionService, IU
         _repository.GetUnvotedCountForBoardMemberAmongApplicationsAsync(
             boardMemberUserId, applicationIds, ct);
 
+    public Task<IReadOnlyList<Guid>> GetActiveApprovedTierUserIdsAsync(
+        MembershipTier tier, LocalDate today, CancellationToken ct = default) =>
+        _repository.GetActiveApprovedTierUserIdsAsync(tier, today, ct);
+
+    public Task<bool> HasActiveApprovedTierAsync(
+        Guid userId, MembershipTier tier, LocalDate today, CancellationToken ct = default) =>
+        _repository.HasActiveApprovedTierAsync(userId, tier, today, ct);
+
+    public Task<IReadOnlyDictionary<Guid, MembershipTier>> GetOtherActiveTierAssignmentsAsync(
+        MembershipTier excludeTier, LocalDate today, CancellationToken ct = default) =>
+        _repository.GetOtherActiveTierAssignmentsAsync(excludeTier, today, ct);
+
     public async Task UpdateDraftApplicationAsync(
         Guid applicationId, MembershipTier tier, string motivation,
         string? additionalInfo, string? significantContribution, string? roleUnderstanding,

--- a/src/Humans.Application/Services/Profile/ProfileService.cs
+++ b/src/Humans.Application/Services/Profile/ProfileService.cs
@@ -1000,6 +1000,12 @@ public sealed class ProfileService : IProfileService, IUserDataContributor
     public Task<bool> AnonymizeExpiredProfileAsync(Guid userId, CancellationToken ct = default) =>
         _profileRepository.AnonymizeForDeletionByUserIdAsync(userId, ct);
 
+    public Task<IReadOnlySet<Guid>> SuspendForMissingConsentAsync(
+        IReadOnlyCollection<Guid> userIds,
+        Instant now,
+        CancellationToken ct = default) =>
+        _profileRepository.SuspendManyAsync(userIds, now, ct);
+
     // ==========================================================================
     // Helpers
     // ==========================================================================

--- a/src/Humans.Application/Services/Profile/ProfileService.cs
+++ b/src/Humans.Application/Services/Profile/ProfileService.cs
@@ -1006,6 +1006,16 @@ public sealed class ProfileService : IProfileService, IUserDataContributor
         CancellationToken ct = default) =>
         _profileRepository.SuspendManyAsync(userIds, now, ct);
 
+    public Task<IReadOnlyList<(Guid UserId, MembershipTier NewTier)>>
+        DowngradeTierForExpiredAsync(
+            MembershipTier currentTier,
+            IReadOnlyCollection<Guid> userIdsToKeep,
+            IReadOnlyDictionary<Guid, MembershipTier> fallbackTierByUser,
+            Instant now,
+            CancellationToken ct = default) =>
+        _profileRepository.DowngradeTierForExpiredAsync(
+            currentTier, userIdsToKeep, fallbackTierByUser, now, ct);
+
     // ==========================================================================
     // Helpers
     // ==========================================================================

--- a/src/Humans.Application/Services/Teams/TeamService.cs
+++ b/src/Humans.Application/Services/Teams/TeamService.cs
@@ -2297,4 +2297,57 @@ public sealed class TeamService : ITeamService, IUserDataContributor
         if (name.Length > 100)
             throw new InvalidOperationException("Role name cannot exceed 100 characters");
     }
+
+    // ==========================================================================
+    // System team sync support (issue #570 — §15 Google-writing jobs)
+    // ==========================================================================
+
+    public Task<Team?> GetSystemTeamWithActiveMembersAsync(
+        SystemTeamType type, CancellationToken cancellationToken = default) =>
+        _repo.GetSystemTeamWithActiveMembersAsync(type, cancellationToken);
+
+    public Task<IReadOnlyList<TeamMember>> GetActiveMembershipsForRoleReconciliationAsync(
+        CancellationToken cancellationToken = default) =>
+        _repo.GetActiveMembershipsForRoleReconciliationAsync(cancellationToken);
+
+    public async Task<int> ApplyMemberRoleChangesAsync(
+        IReadOnlyCollection<(Guid TeamMemberId, TeamMemberRole Role)> changes,
+        CancellationToken cancellationToken = default)
+    {
+        if (changes.Count == 0)
+            return 0;
+        var updated = await _repo.ApplyMemberRoleChangesAsync(changes, cancellationToken);
+        if (updated > 0)
+        {
+            InvalidateActiveTeamsCache();
+        }
+        return updated;
+    }
+
+    public Task<IReadOnlyList<Guid>> GetActiveDepartmentCoordinatorUserIdsAsync(
+        CancellationToken cancellationToken = default) =>
+        _repo.GetActiveDepartmentCoordinatorUserIdsAsync(cancellationToken);
+
+    public Task<bool> IsActiveDepartmentCoordinatorAsync(
+        Guid userId, CancellationToken cancellationToken = default) =>
+        _repo.IsActiveDepartmentCoordinatorAsync(userId, cancellationToken);
+
+    public async Task<bool> ApplySystemTeamMembershipDeltaAsync(
+        Guid teamId,
+        IReadOnlyCollection<Guid> userIdsToAdd,
+        IReadOnlyCollection<Guid> userIdsToRemove,
+        Instant now,
+        CancellationToken cancellationToken = default)
+    {
+        var changed = await _repo.ApplySystemTeamMembershipDeltaAsync(
+            teamId, userIdsToAdd, userIdsToRemove, now, cancellationToken);
+        if (changed)
+        {
+            // The in-service CachedTeam projection is rebuilt lazily on next
+            // read; invalidate it so downstream directory / coordinator
+            // queries reflect the post-sync membership.
+            InvalidateActiveTeamsCache();
+        }
+        return changed;
+    }
 }

--- a/src/Humans.Application/Services/Users/UserService.cs
+++ b/src/Humans.Application/Services/Users/UserService.cs
@@ -414,4 +414,8 @@ public sealed class UserService : IUserService, IUserDataContributor
 
         return null;
     }
+
+    public Task<IReadOnlyList<(Guid UserId, string DisplayName, string GoogleEmail)>>
+        BackfillNobodiesTeamGoogleEmailsAsync(CancellationToken ct = default) =>
+        _repo.BackfillNobodiesTeamGoogleEmailsAsync(ct);
 }

--- a/src/Humans.Infrastructure/Caching/MemoryCacheInvalidators.cs
+++ b/src/Humans.Infrastructure/Caching/MemoryCacheInvalidators.cs
@@ -39,3 +39,10 @@ public sealed class RoleAssignmentClaimsCacheInvalidator : IRoleAssignmentClaims
     public RoleAssignmentClaimsCacheInvalidator(IMemoryCache cache) => _cache = cache;
     public void Invalidate(Guid userId) => _cache.InvalidateRoleAssignmentClaims(userId);
 }
+
+public sealed class ActiveTeamsCacheInvalidator : IActiveTeamsCacheInvalidator
+{
+    private readonly IMemoryCache _cache;
+    public ActiveTeamsCacheInvalidator(IMemoryCache cache) => _cache = cache;
+    public void Invalidate() => _cache.InvalidateActiveTeams();
+}

--- a/src/Humans.Infrastructure/Jobs/SuspendNonCompliantMembersJob.cs
+++ b/src/Humans.Infrastructure/Jobs/SuspendNonCompliantMembersJob.cs
@@ -1,19 +1,18 @@
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using NodaTime;
-using Humans.Application.Extensions;
 using Humans.Application.Interfaces;
-using Humans.Domain.Entities;
-using Humans.Domain.Enums;
-using Humans.Infrastructure.Data;
 using Humans.Application.Interfaces.AuditLog;
+using Humans.Application.Interfaces.Caching;
 using Humans.Application.Interfaces.Email;
 using Humans.Application.Interfaces.GoogleIntegration;
-using Humans.Application.Interfaces.Teams;
-using Humans.Application.Interfaces.Notifications;
 using Humans.Application.Interfaces.Governance;
+using Humans.Application.Interfaces.Notifications;
 using Humans.Application.Interfaces.Profiles;
+using Humans.Application.Interfaces.Shifts;
+using Humans.Application.Interfaces.Teams;
+using Humans.Application.Interfaces.Users;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
 
 namespace Humans.Infrastructure.Jobs;
 
@@ -21,44 +20,61 @@ namespace Humans.Infrastructure.Jobs;
 /// Background job that suspends members who haven't re-consented to required documents
 /// after the grace period has expired.
 /// </summary>
+/// <remarks>
+/// All reads/writes fan out through section services
+/// (<see cref="IUserService"/>, <see cref="IProfileService"/>,
+/// <see cref="ITeamService"/>, <see cref="IGoogleSyncService"/>) so the job
+/// never touches <see cref="Humans.Infrastructure.Data.HumansDbContext"/>
+/// directly (design-rules §2c). Cross-cutting cache invalidation routes
+/// through invalidator interfaces
+/// (<see cref="IFullProfileInvalidator"/>,
+/// <see cref="IRoleAssignmentClaimsCacheInvalidator"/>,
+/// <see cref="IShiftAuthorizationInvalidator"/>) rather than IMemoryCache.
+/// </remarks>
 public class SuspendNonCompliantMembersJob : IRecurringJob
 {
-    private readonly HumansDbContext _dbContext;
+    private readonly IUserService _userService;
+    private readonly IProfileService _profileService;
+    private readonly ITeamService _teamService;
     private readonly IMembershipCalculator _membershipCalculator;
     private readonly IEmailService _emailService;
     private readonly INotificationService _notificationService;
     private readonly IGoogleSyncService _googleSyncService;
     private readonly IAuditLogService _auditLogService;
     private readonly IFullProfileInvalidator _fullProfileInvalidator;
-    private readonly ITeamService _teamService;
-    private readonly IMemoryCache _cache;
+    private readonly IRoleAssignmentClaimsCacheInvalidator _roleAssignmentClaimsInvalidator;
+    private readonly IShiftAuthorizationInvalidator _shiftAuthorizationInvalidator;
     private readonly IHumansMetrics _metrics;
     private readonly ILogger<SuspendNonCompliantMembersJob> _logger;
     private readonly IClock _clock;
 
     public SuspendNonCompliantMembersJob(
-        HumansDbContext dbContext,
+        IUserService userService,
+        IProfileService profileService,
+        ITeamService teamService,
         IMembershipCalculator membershipCalculator,
         IEmailService emailService,
         INotificationService notificationService,
         IGoogleSyncService googleSyncService,
         IAuditLogService auditLogService,
         IFullProfileInvalidator fullProfileInvalidator,
-        ITeamService teamService,
-        IMemoryCache cache,
+        IRoleAssignmentClaimsCacheInvalidator roleAssignmentClaimsInvalidator,
+        IShiftAuthorizationInvalidator shiftAuthorizationInvalidator,
         IHumansMetrics metrics,
         ILogger<SuspendNonCompliantMembersJob> logger,
         IClock clock)
     {
-        _dbContext = dbContext;
+        _userService = userService;
+        _profileService = profileService;
+        _teamService = teamService;
         _membershipCalculator = membershipCalculator;
         _emailService = emailService;
         _notificationService = notificationService;
         _googleSyncService = googleSyncService;
         _auditLogService = auditLogService;
         _fullProfileInvalidator = fullProfileInvalidator;
-        _teamService = teamService;
-        _cache = cache;
+        _roleAssignmentClaimsInvalidator = roleAssignmentClaimsInvalidator;
+        _shiftAuthorizationInvalidator = shiftAuthorizationInvalidator;
         _metrics = metrics;
         _logger = logger;
         _clock = clock;
@@ -85,49 +101,57 @@ public class SuspendNonCompliantMembersJob : IRecurringJob
                 return;
             }
 
-            // Batch load all users with profiles and their team memberships (tracked for persistence)
-            var users = await _dbContext.Users
-                .Include(u => u.Profile)
-                    .ThenInclude(p => p!.VolunteerHistory)
-                .Include(u => u.UserEmails)
-                .Include(u => u.TeamMemberships.Where(tm => tm.LeftAt == null))
-                .Where(u => usersToSuspend.Contains(u.Id))
-                .ToListAsync(cancellationToken);
-
             var now = _clock.GetCurrentInstant();
-            var suspendedCount = 0;
-            var suspendedUserIds = new List<Guid>();
 
-            foreach (var user in users)
+            // Apply the suspension write through IProfileService — returns the
+            // subset of user ids whose profile was actually mutated (skips
+            // already-suspended / profileless users).
+            var suspendedIds = await _profileService
+                .SuspendForMissingConsentAsync(usersToSuspend, now, cancellationToken);
+
+            if (suspendedIds.Count == 0)
             {
-                if (user.Profile is null)
+                _metrics.RecordJobRun("suspend_noncompliant_members", "success");
+                _logger.LogInformation(
+                    "Completed non-compliant member check, no eligible users to suspend");
+                return;
+            }
+
+            // Fan out user + email hydration for notifications, and team membership
+            // lookup for Google-sync cleanup.
+            var usersById = await _userService
+                .GetByIdsWithEmailsAsync(suspendedIds, cancellationToken);
+
+            foreach (var userId in suspendedIds)
+            {
+                if (!usersById.TryGetValue(userId, out var user))
                 {
+                    _logger.LogWarning(
+                        "Suspended user {UserId} not found in user lookup — skipping downstream side effects",
+                        userId);
                     continue;
                 }
 
-                // Skip users who are already suspended — avoids re-sending notifications
-                if (user.Profile.IsSuspended)
-                {
-                    continue;
-                }
-
-                // 1. Set suspended flag on profile
-                user.Profile.IsSuspended = true;
-                user.Profile.UpdatedAt = now;
-
-                // 2. Send email notification
+                // 1. Send email notification
                 var effectiveEmail = user.GetEffectiveEmail();
                 if (effectiveEmail is not null)
                 {
-                    await _emailService.SendAccessSuspendedAsync(
-                        effectiveEmail,
-                        user.DisplayName,
-                        "Missing required document consent (grace period expired)",
-                        user.PreferredLanguage,
-                        cancellationToken);
+                    try
+                    {
+                        await _emailService.SendAccessSuspendedAsync(
+                            effectiveEmail,
+                            user.DisplayName,
+                            "Missing required document consent (grace period expired)",
+                            user.PreferredLanguage,
+                            cancellationToken);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, "Failed to send suspension email for user {UserId}", user.Id);
+                    }
                 }
 
-                // 2b. Send in-app notification (best-effort)
+                // 2. Send in-app notification (best-effort)
                 try
                 {
                     await _notificationService.SendAsync(
@@ -146,8 +170,9 @@ public class SuspendNonCompliantMembersJob : IRecurringJob
                     _logger.LogError(ex, "Failed to dispatch AccessSuspended notification for user {UserId}", user.Id);
                 }
 
-                // 3. Remove from all team resources (Google Drive/Groups)
-                foreach (var membership in user.TeamMemberships)
+                // 3. Remove from all team resources (Google Drive/Groups) via ITeamService lookup.
+                var memberships = await _teamService.GetUserTeamsAsync(user.Id, cancellationToken);
+                foreach (var membership in memberships)
                 {
                     try
                     {
@@ -164,36 +189,27 @@ public class SuspendNonCompliantMembersJob : IRecurringJob
                 }
 
                 _logger.LogWarning(
-                    "User {UserId} ({Email}) suspended and removed from {Count} teams",
-                    user.Id, effectiveEmail, user.TeamMemberships.Count);
+                    "User {UserId} ({Email}) suspended and flagged for removal from {Count} teams",
+                    user.Id, effectiveEmail, memberships.Count);
 
                 _metrics.RecordMemberSuspended("job");
-                suspendedCount++;
-                suspendedUserIds.Add(user.Id);
-            }
 
-            if (suspendedCount > 0)
-            {
-                await _dbContext.SaveChangesAsync(cancellationToken);
+                // 4. Audit log + cross-cutting cache invalidation.
+                await _auditLogService.LogAsync(
+                    AuditAction.MemberSuspended, nameof(User), user.Id,
+                    $"{user.DisplayName} suspended for missing required document consent (grace period expired)",
+                    nameof(SuspendNonCompliantMembersJob));
 
-                foreach (var suspendedUser in users.Where(u => suspendedUserIds.Contains(u.Id)))
-                {
-                    await _auditLogService.LogAsync(
-                        AuditAction.MemberSuspended, nameof(User), suspendedUser.Id,
-                        $"{suspendedUser.DisplayName} suspended for missing required document consent (grace period expired)",
-                        nameof(SuspendNonCompliantMembersJob));
-
-                    await _fullProfileInvalidator.InvalidateAsync(suspendedUser.Id, cancellationToken);
-                    _cache.InvalidateRoleAssignmentClaims(suspendedUser.Id);
-                    _cache.InvalidateShiftAuthorization(suspendedUser.Id);
-                    _teamService.RemoveMemberFromAllTeamsCache(suspendedUser.Id);
-                }
+                await _fullProfileInvalidator.InvalidateAsync(user.Id, cancellationToken);
+                _roleAssignmentClaimsInvalidator.Invalidate(user.Id);
+                _shiftAuthorizationInvalidator.Invalidate(user.Id);
+                _teamService.RemoveMemberFromAllTeamsCache(user.Id);
             }
 
             _metrics.RecordJobRun("suspend_noncompliant_members", "success");
             _logger.LogInformation(
                 "Completed non-compliant member check, suspended {Count} members",
-                suspendedCount);
+                suspendedIds.Count);
         }
         catch (Exception ex)
         {

--- a/src/Humans.Infrastructure/Jobs/SystemTeamSyncJob.cs
+++ b/src/Humans.Infrastructure/Jobs/SystemTeamSyncJob.cs
@@ -29,32 +29,30 @@ namespace Humans.Infrastructure.Jobs;
 /// <see cref="IRoleAssignmentService"/>, <see cref="ITeamResourceService"/>,
 /// <see cref="ICampRepository"/>) so the job never touches
 /// <see cref="Humans.Infrastructure.Data.HumansDbContext"/> directly
-/// (design-rules §2c). Cross-cutting cache invalidation routes through
-/// invalidator interfaces
-/// (<see cref="IActiveTeamsCacheInvalidator"/>,
-/// <see cref="IRoleAssignmentClaimsCacheInvalidator"/>) rather than
-/// IMemoryCache.
+/// (design-rules §2c). Cross-cutting cache invalidation that crosses a
+/// section boundary (claims principal refresh) routes through
+/// <see cref="IRoleAssignmentClaimsCacheInvalidator"/> rather than
+/// IMemoryCache; the ActiveTeams cache is owned and invalidated by
+/// <see cref="ITeamService"/> itself on every mutating write.
 /// </remarks>
 public class SystemTeamSyncJob : ISystemTeamSync
 {
     private readonly ITeamService _teamService;
     private readonly IUserService _userService;
-    private readonly IProfileService _profileService;
-    private readonly IApplicationDecisionService _applicationDecisionService;
-    private readonly IRoleAssignmentService _roleAssignmentService;
-    private readonly ITeamResourceService _teamResourceService;
     private readonly ICampRepository _campRepository;
-    // IMembershipCalculator is resolved lazily via IServiceProvider to break a
-    // DI cycle: TeamService and RoleAssignmentService inject ISystemTeamSync,
-    // and MembershipCalculator (transitively, via IMembershipQuery) depends on
-    // those same services. All calls below happen after DI has finished
-    // building the graph, so deferring the lookup is safe — same pattern
-    // MembershipCalculator uses for IConsentService.
+    // IApplicationDecisionService, IRoleAssignmentService, IProfileService,
+    // ITeamResourceService, and IMembershipCalculator are resolved lazily via
+    // IServiceProvider to break DI cycles: ApplicationDecisionService and
+    // RoleAssignmentService inject ISystemTeamSync directly, ProfileService
+    // injects both, TeamResourceService injects IRoleAssignmentService, and
+    // MembershipCalculator (via IMembershipQuery) depends on them. Direct
+    // ctor injection here would form an unresolvable cycle. All calls below
+    // happen after DI has finished building the graph, so deferring the
+    // lookup is safe — same pattern MembershipCalculator uses for IConsentService.
     private readonly IServiceProvider _serviceProvider;
     private readonly IGoogleSyncService _googleSyncService;
     private readonly IAuditLogService _auditLogService;
     private readonly IEmailService _emailService;
-    private readonly IActiveTeamsCacheInvalidator _activeTeamsInvalidator;
     private readonly IRoleAssignmentClaimsCacheInvalidator _roleAssignmentClaimsInvalidator;
     private readonly IHumansMetrics _metrics;
     private readonly ILogger<SystemTeamSyncJob> _logger;
@@ -63,16 +61,11 @@ public class SystemTeamSyncJob : ISystemTeamSync
     public SystemTeamSyncJob(
         ITeamService teamService,
         IUserService userService,
-        IProfileService profileService,
-        IApplicationDecisionService applicationDecisionService,
-        IRoleAssignmentService roleAssignmentService,
-        ITeamResourceService teamResourceService,
         ICampRepository campRepository,
         IServiceProvider serviceProvider,
         IGoogleSyncService googleSyncService,
         IAuditLogService auditLogService,
         IEmailService emailService,
-        IActiveTeamsCacheInvalidator activeTeamsInvalidator,
         IRoleAssignmentClaimsCacheInvalidator roleAssignmentClaimsInvalidator,
         IHumansMetrics metrics,
         ILogger<SystemTeamSyncJob> logger,
@@ -80,21 +73,28 @@ public class SystemTeamSyncJob : ISystemTeamSync
     {
         _teamService = teamService;
         _userService = userService;
-        _profileService = profileService;
-        _applicationDecisionService = applicationDecisionService;
-        _roleAssignmentService = roleAssignmentService;
-        _teamResourceService = teamResourceService;
         _campRepository = campRepository;
         _serviceProvider = serviceProvider;
         _googleSyncService = googleSyncService;
         _auditLogService = auditLogService;
         _emailService = emailService;
-        _activeTeamsInvalidator = activeTeamsInvalidator;
         _roleAssignmentClaimsInvalidator = roleAssignmentClaimsInvalidator;
         _metrics = metrics;
         _logger = logger;
         _clock = clock;
     }
+
+    private IApplicationDecisionService ApplicationDecisionService =>
+        _serviceProvider.GetRequiredService<IApplicationDecisionService>();
+
+    private IRoleAssignmentService RoleAssignmentService =>
+        _serviceProvider.GetRequiredService<IRoleAssignmentService>();
+
+    private IProfileService ProfileService =>
+        _serviceProvider.GetRequiredService<IProfileService>();
+
+    private ITeamResourceService TeamResourceService =>
+        _serviceProvider.GetRequiredService<ITeamResourceService>();
 
     private IMembershipCalculator MembershipCalculator =>
         _serviceProvider.GetRequiredService<IMembershipCalculator>();
@@ -233,7 +233,7 @@ public class SystemTeamSyncJob : ISystemTeamSync
         }
 
         // All users with profiles that are approved and not suspended.
-        var allApprovedIds = await _profileService.GetActiveApprovedUserIdsAsync(cancellationToken);
+        var allApprovedIds = await ProfileService.GetActiveApprovedUserIdsAsync(cancellationToken);
 
         // Use shared partition to determine eligibility (Active = approved +
         // not suspended + all consents signed).
@@ -292,7 +292,7 @@ public class SystemTeamSyncJob : ISystemTeamSync
         }
 
         // Users with active Board role assignment (service reads the clock).
-        var boardMemberIds = await _roleAssignmentService.GetActiveUserIdsInRoleAsync(
+        var boardMemberIds = await RoleAssignmentService.GetActiveUserIdsInRoleAsync(
             RoleNames.Board, cancellationToken);
 
         // Additionally filter by Board-team-required consents.
@@ -333,11 +333,11 @@ public class SystemTeamSyncJob : ISystemTeamSync
 
         var today = _clock.GetCurrentInstant().InUtc().Date;
 
-        var applicationUserIds = await _applicationDecisionService
+        var applicationUserIds = await ApplicationDecisionService
             .GetActiveApprovedTierUserIdsAsync(tier, today, cancellationToken);
 
         // Filter by profile status to match per-user sync behavior.
-        var allApprovedIds = await _profileService.GetActiveApprovedUserIdsAsync(cancellationToken);
+        var allApprovedIds = await ProfileService.GetActiveApprovedUserIdsAsync(cancellationToken);
         var approvedSet = allApprovedIds.ToHashSet();
         var userIds = applicationUserIds.Where(approvedSet.Contains).ToList();
 
@@ -350,10 +350,10 @@ public class SystemTeamSyncJob : ISystemTeamSync
         // Volunteer, check if the user holds an active application for the
         // OTHER higher tier.
         var todayInstant = _clock.GetCurrentInstant();
-        var otherTierByUser = await _applicationDecisionService
+        var otherTierByUser = await ApplicationDecisionService
             .GetOtherActiveTierAssignmentsAsync(tier, today, cancellationToken);
 
-        var downgrades = await _profileService.DowngradeTierForExpiredAsync(
+        var downgrades = await ProfileService.DowngradeTierForExpiredAsync(
             tier, applicationUserIds, otherTierByUser, todayInstant, cancellationToken);
 
         if (downgrades.Count > 0)
@@ -391,7 +391,7 @@ public class SystemTeamSyncJob : ISystemTeamSync
             return;
         }
 
-        var profiles = await _profileService.GetByUserIdsAsync([userId], cancellationToken);
+        var profiles = await ProfileService.GetByUserIdsAsync([userId], cancellationToken);
         profiles.TryGetValue(userId, out var profile);
 
         var isEligible = profile is { IsApproved: true, IsSuspended: false }
@@ -447,10 +447,10 @@ public class SystemTeamSyncJob : ISystemTeamSync
 
         var today = _clock.GetCurrentInstant().InUtc().Date;
 
-        var hasApprovedApp = await _applicationDecisionService
+        var hasApprovedApp = await ApplicationDecisionService
             .HasActiveApprovedTierAsync(userId, tier, today, cancellationToken);
 
-        var profiles = await _profileService.GetByUserIdsAsync([userId], cancellationToken);
+        var profiles = await ProfileService.GetByUserIdsAsync([userId], cancellationToken);
         profiles.TryGetValue(userId, out var profile);
 
         var isEligible = hasApprovedApp
@@ -630,7 +630,7 @@ public class SystemTeamSyncJob : ISystemTeamSync
         // Send "added to team" emails for newly added members (skip hidden teams).
         if (toAdd.Count > 0 && !team.IsHidden)
         {
-            var resources = await _teamResourceService.GetTeamResourcesAsync(team.Id, cancellationToken);
+            var resources = await TeamResourceService.GetTeamResourcesAsync(team.Id, cancellationToken);
             var resourceTuples = resources.Select(r => (r.Name, r.Url)).ToList();
 
             var addedUsersWithEmails = await _userService

--- a/src/Humans.Infrastructure/Jobs/SystemTeamSyncJob.cs
+++ b/src/Humans.Infrastructure/Jobs/SystemTeamSyncJob.cs
@@ -1,36 +1,48 @@
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NodaTime;
-using Humans.Application.Extensions;
-using Humans.Application.Interfaces;
-using Humans.Application.Interfaces.Repositories;
-using Humans.Domain.Constants;
-using Humans.Domain.Entities;
-using Humans.Domain.Enums;
 using Humans.Application.DTOs;
-using Humans.Infrastructure.Data;
+using Humans.Application.Interfaces;
 using Humans.Application.Interfaces.AuditLog;
+using Humans.Application.Interfaces.Auth;
+using Humans.Application.Interfaces.Caching;
 using Humans.Application.Interfaces.Email;
 using Humans.Application.Interfaces.GoogleIntegration;
 using Humans.Application.Interfaces.Governance;
-
-// Cross-domain nav reads (TeamMember.User, TeamJoinRequest.User, etc.) are
-// scheduled for removal per design-rules §6c, but SystemTeamSyncJob still
-// lives in Infrastructure and reads TeamMember.User directly (§15i — Google
-// Workspace / SystemTeamSync row). This file-wide pragma is cleared when the
-// job migrates to Application alongside the User-entity nav strip.
-#pragma warning disable CS0618
+using Humans.Application.Interfaces.Profiles;
+using Humans.Application.Interfaces.Repositories;
+using Humans.Application.Interfaces.Teams;
+using Humans.Application.Interfaces.Users;
+using Humans.Domain.Constants;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
 
 namespace Humans.Infrastructure.Jobs;
 
 /// <summary>
 /// Background job that syncs membership for system-managed teams.
 /// </summary>
+/// <remarks>
+/// All reads/writes fan out through section services
+/// (<see cref="ITeamService"/>, <see cref="IUserService"/>,
+/// <see cref="IProfileService"/>, <see cref="IApplicationDecisionService"/>,
+/// <see cref="IRoleAssignmentService"/>, <see cref="ITeamResourceService"/>,
+/// <see cref="ICampRepository"/>) so the job never touches
+/// <see cref="Humans.Infrastructure.Data.HumansDbContext"/> directly
+/// (design-rules §2c). Cross-cutting cache invalidation routes through
+/// invalidator interfaces
+/// (<see cref="IActiveTeamsCacheInvalidator"/>,
+/// <see cref="IRoleAssignmentClaimsCacheInvalidator"/>) rather than
+/// IMemoryCache.
+/// </remarks>
 public class SystemTeamSyncJob : ISystemTeamSync
 {
-    private readonly HumansDbContext _dbContext;
+    private readonly ITeamService _teamService;
+    private readonly IUserService _userService;
+    private readonly IProfileService _profileService;
+    private readonly IApplicationDecisionService _applicationDecisionService;
+    private readonly IRoleAssignmentService _roleAssignmentService;
+    private readonly ITeamResourceService _teamResourceService;
     private readonly ICampRepository _campRepository;
     // IMembershipCalculator is resolved lazily via IServiceProvider to break a
     // DI cycle: TeamService and RoleAssignmentService inject ISystemTeamSync,
@@ -42,30 +54,43 @@ public class SystemTeamSyncJob : ISystemTeamSync
     private readonly IGoogleSyncService _googleSyncService;
     private readonly IAuditLogService _auditLogService;
     private readonly IEmailService _emailService;
-    private readonly IMemoryCache _cache;
+    private readonly IActiveTeamsCacheInvalidator _activeTeamsInvalidator;
+    private readonly IRoleAssignmentClaimsCacheInvalidator _roleAssignmentClaimsInvalidator;
     private readonly IHumansMetrics _metrics;
     private readonly ILogger<SystemTeamSyncJob> _logger;
     private readonly IClock _clock;
 
     public SystemTeamSyncJob(
-        HumansDbContext dbContext,
+        ITeamService teamService,
+        IUserService userService,
+        IProfileService profileService,
+        IApplicationDecisionService applicationDecisionService,
+        IRoleAssignmentService roleAssignmentService,
+        ITeamResourceService teamResourceService,
         ICampRepository campRepository,
         IServiceProvider serviceProvider,
         IGoogleSyncService googleSyncService,
         IAuditLogService auditLogService,
         IEmailService emailService,
-        IMemoryCache cache,
+        IActiveTeamsCacheInvalidator activeTeamsInvalidator,
+        IRoleAssignmentClaimsCacheInvalidator roleAssignmentClaimsInvalidator,
         IHumansMetrics metrics,
         ILogger<SystemTeamSyncJob> logger,
         IClock clock)
     {
-        _dbContext = dbContext;
+        _teamService = teamService;
+        _userService = userService;
+        _profileService = profileService;
+        _applicationDecisionService = applicationDecisionService;
+        _roleAssignmentService = roleAssignmentService;
+        _teamResourceService = teamResourceService;
         _campRepository = campRepository;
         _serviceProvider = serviceProvider;
         _googleSyncService = googleSyncService;
         _auditLogService = auditLogService;
         _emailService = emailService;
-        _cache = cache;
+        _activeTeamsInvalidator = activeTeamsInvalidator;
+        _roleAssignmentClaimsInvalidator = roleAssignmentClaimsInvalidator;
         _metrics = metrics;
         _logger = logger;
         _clock = clock;
@@ -84,9 +109,12 @@ public class SystemTeamSyncJob : ISystemTeamSync
 
         try
         {
-            // These run sequentially because they share the same DbContext instance,
-            // which is not thread-safe. Parallelizing with Task.WhenAll would require
-            // IServiceScopeFactory to create separate DbContext instances per task.
+            // These run sequentially to match the pre-migration behavior where
+            // every step shared a single DbContext. Now each step calls
+            // section services that own their own unit-of-work — the
+            // sequential ordering still matters for downstream audit/notification
+            // semantics (e.g. coordinator reconciliation must land before the
+            // Coordinators-team sync).
             await SyncVolunteersTeamAsync(report, cancellationToken);
             await ReconcileCoordinatorRolesAsync(report, cancellationToken);
             await SyncCoordinatorsTeamAsync(report, cancellationToken);
@@ -119,64 +147,69 @@ public class SystemTeamSyncJob : ISystemTeamSync
         _logger.LogDebug("Reconciling coordinator roles with IsManagement assignments");
         var step = new SyncStepResult("Coordinator Role Reconciliation");
 
-        // Find all active team members who are assigned to an IsManagement role but have Role = Member
-        var shouldBeCoordinator = await _dbContext.TeamMembers
-            .Include(tm => tm.User)
-            .Include(tm => tm.RoleAssignments)
-                .ThenInclude(ra => ra.TeamRoleDefinition)
+        // Load active memberships with role assignments + role definitions +
+        // team metadata so we can decide promote / demote in memory without
+        // touching DbContext.
+        var memberships = await _teamService
+            .GetActiveMembershipsForRoleReconciliationAsync(cancellationToken);
+
+        var shouldBeCoordinator = memberships
             .Where(tm =>
-                tm.LeftAt == null &&
                 tm.Role == TeamMemberRole.Member &&
                 tm.RoleAssignments.Any(ra => ra.TeamRoleDefinition.IsManagement))
-            .ToListAsync(cancellationToken);
+            .ToList();
 
-        foreach (var member in shouldBeCoordinator)
-        {
-            member.Role = TeamMemberRole.Coordinator;
-            var teamName = await _dbContext.Teams
-                .Where(t => t.Id == member.TeamId)
-                .Select(t => t.Name)
-                .FirstOrDefaultAsync(cancellationToken) ?? "Unknown";
-
-            step.Fixed(member.UserId, member.User.DisplayName, $"Promoted to Coordinator on {teamName}");
-
-            _logger.LogInformation(
-                "Reconciled {UserName} to Coordinator on team {TeamId} (had IsManagement role assignment)",
-                member.User.DisplayName, member.TeamId);
-        }
-
-        // Find all active team members who have Role = Coordinator but no IsManagement role assignment
-        var shouldBeMember = await _dbContext.TeamMembers
-            .Include(tm => tm.User)
-            .Include(tm => tm.RoleAssignments)
-                .ThenInclude(ra => ra.TeamRoleDefinition)
+        var shouldBeMember = memberships
             .Where(tm =>
-                tm.LeftAt == null &&
                 tm.Role == TeamMemberRole.Coordinator &&
                 tm.Team.SystemTeamType == SystemTeamType.None &&
                 !tm.RoleAssignments.Any(ra => ra.TeamRoleDefinition.IsManagement))
-            .ToListAsync(cancellationToken);
+            .ToList();
+
+        if (shouldBeCoordinator.Count == 0 && shouldBeMember.Count == 0)
+        {
+            report?.Steps.Add(step);
+            return;
+        }
+
+        // Stitch user display names for step-result audit output.
+        var affectedUserIds = shouldBeCoordinator.Select(tm => tm.UserId)
+            .Concat(shouldBeMember.Select(tm => tm.UserId))
+            .Distinct()
+            .ToList();
+        var userNamesById = await _userService.GetByIdsAsync(affectedUserIds, cancellationToken);
+
+        var changes = new List<(Guid TeamMemberId, TeamMemberRole Role)>(
+            shouldBeCoordinator.Count + shouldBeMember.Count);
+
+        foreach (var member in shouldBeCoordinator)
+        {
+            changes.Add((member.Id, TeamMemberRole.Coordinator));
+            var userName = userNamesById.TryGetValue(member.UserId, out var u)
+                ? u.DisplayName : member.UserId.ToString();
+            var teamName = member.Team.Name;
+            step.Fixed(member.UserId, userName, $"Promoted to Coordinator on {teamName}");
+            _logger.LogInformation(
+                "Reconciled {UserName} to Coordinator on team {TeamId} (had IsManagement role assignment)",
+                userName, member.TeamId);
+        }
 
         foreach (var member in shouldBeMember)
         {
-            member.Role = TeamMemberRole.Member;
-            var teamName = await _dbContext.Teams
-                .Where(t => t.Id == member.TeamId)
-                .Select(t => t.Name)
-                .FirstOrDefaultAsync(cancellationToken) ?? "Unknown";
-
-            step.Fixed(member.UserId, member.User.DisplayName, $"Demoted to Member on {teamName} (no IsManagement role)");
-
+            changes.Add((member.Id, TeamMemberRole.Member));
+            var userName = userNamesById.TryGetValue(member.UserId, out var u)
+                ? u.DisplayName : member.UserId.ToString();
+            var teamName = member.Team.Name;
+            step.Fixed(member.UserId, userName, $"Demoted to Member on {teamName} (no IsManagement role)");
             _logger.LogInformation(
                 "Reconciled {UserName} to Member on team {TeamId} (no IsManagement role assignment)",
-                member.User.DisplayName, member.TeamId);
+                userName, member.TeamId);
         }
 
-        if (shouldBeCoordinator.Count > 0 || shouldBeMember.Count > 0)
-        {
-            await _dbContext.SaveChangesAsync(cancellationToken);
-            _cache.InvalidateActiveTeams();
-        }
+        // Apply all role changes in a single save through the Teams section.
+        // The service invalidates the ActiveTeams cache when at least one
+        // change lands, so no direct cache call here.
+        await _teamService.ApplyMemberRoleChangesAsync(changes, cancellationToken);
 
         report?.Steps.Add(step);
     }
@@ -190,7 +223,8 @@ public class SystemTeamSyncJob : ISystemTeamSync
         _logger.LogDebug("Syncing Volunteers team");
         var step = new SyncStepResult("Volunteers");
 
-        var team = await GetSystemTeamAsync(SystemTeamType.Volunteers, cancellationToken);
+        var team = await _teamService.GetSystemTeamWithActiveMembersAsync(
+            SystemTeamType.Volunteers, cancellationToken);
         if (team is null)
         {
             _logger.LogWarning("Volunteers system team not found");
@@ -198,14 +232,11 @@ public class SystemTeamSyncJob : ISystemTeamSync
             return;
         }
 
-        // Get all users with profiles that are approved and not suspended
-        var allApprovedIds = await _dbContext.Profiles
-            .AsNoTracking()
-            .Where(p => p.IsApproved && !p.IsSuspended)
-            .Select(p => p.UserId)
-            .ToListAsync(cancellationToken);
+        // All users with profiles that are approved and not suspended.
+        var allApprovedIds = await _profileService.GetActiveApprovedUserIdsAsync(cancellationToken);
 
-        // Use shared partition to determine eligibility (Active = approved + not suspended + all consents signed)
+        // Use shared partition to determine eligibility (Active = approved +
+        // not suspended + all consents signed).
         var partition = await MembershipCalculator.PartitionUsersAsync(allApprovedIds, cancellationToken);
         var eligibleUserIds = partition.Active.ToList();
 
@@ -222,7 +253,8 @@ public class SystemTeamSyncJob : ISystemTeamSync
         _logger.LogDebug("Syncing Coordinators team");
         var step = new SyncStepResult("Coordinators");
 
-        var team = await GetSystemTeamAsync(SystemTeamType.Coordinators, cancellationToken);
+        var team = await _teamService.GetSystemTeamWithActiveMembersAsync(
+            SystemTeamType.Coordinators, cancellationToken);
         if (team is null)
         {
             _logger.LogWarning("Coordinators system team not found");
@@ -230,19 +262,10 @@ public class SystemTeamSyncJob : ISystemTeamSync
             return;
         }
 
-        // Get all current department coordinators (sub-team managers are excluded)
-        var leadUserIds = await _dbContext.TeamMembers
-            .AsNoTracking()
-            .Where(tm =>
-                tm.LeftAt == null &&
-                tm.Role == TeamMemberRole.Coordinator &&
-                tm.Team.SystemTeamType == SystemTeamType.None &&
-                tm.Team.ParentTeamId == null) // Only department coordinators, not sub-team managers
-            .Select(tm => tm.UserId)
-            .Distinct()
-            .ToListAsync(cancellationToken);
+        // Department-level coordinators only (sub-team managers excluded).
+        var leadUserIds = await _teamService.GetActiveDepartmentCoordinatorUserIdsAsync(cancellationToken);
 
-        // Additionally filter by Coordinators-team-required consents
+        // Additionally filter by Coordinators-team-required consents.
         var eligibleSet = await MembershipCalculator.GetUsersWithAllRequiredConsentsForTeamAsync(
             leadUserIds, SystemTeamIds.Coordinators, cancellationToken);
 
@@ -259,7 +282,8 @@ public class SystemTeamSyncJob : ISystemTeamSync
         _logger.LogDebug("Syncing Board team");
         var step = new SyncStepResult("Board");
 
-        var team = await GetSystemTeamAsync(SystemTeamType.Board, cancellationToken);
+        var team = await _teamService.GetSystemTeamWithActiveMembersAsync(
+            SystemTeamType.Board, cancellationToken);
         if (team is null)
         {
             _logger.LogWarning("Board system team not found");
@@ -267,20 +291,11 @@ public class SystemTeamSyncJob : ISystemTeamSync
             return;
         }
 
-        var now = _clock.GetCurrentInstant();
+        // Users with active Board role assignment (service reads the clock).
+        var boardMemberIds = await _roleAssignmentService.GetActiveUserIdsInRoleAsync(
+            RoleNames.Board, cancellationToken);
 
-        // Get all users with active Board role assignment
-        var boardMemberIds = await _dbContext.RoleAssignments
-            .AsNoTracking()
-            .Where(ra =>
-                ra.RoleName == RoleNames.Board &&
-                ra.ValidFrom <= now &&
-                (ra.ValidTo == null || ra.ValidTo > now))
-            .Select(ra => ra.UserId)
-            .Distinct()
-            .ToListAsync(cancellationToken);
-
-        // Additionally filter by Board-team-required consents
+        // Additionally filter by Board-team-required consents.
         var eligibleSet = await MembershipCalculator.GetUsersWithAllRequiredConsentsForTeamAsync(
             boardMemberIds, SystemTeamIds.Board, cancellationToken);
 
@@ -308,7 +323,7 @@ public class SystemTeamSyncJob : ISystemTeamSync
         _logger.LogDebug("Syncing {TeamType} team", teamType);
         var step = new SyncStepResult(teamType.ToString());
 
-        var team = await GetSystemTeamAsync(teamType, cancellationToken);
+        var team = await _teamService.GetSystemTeamWithActiveMembersAsync(teamType, cancellationToken);
         if (team is null)
         {
             _logger.LogWarning("{TeamType} system team not found", teamType);
@@ -318,78 +333,43 @@ public class SystemTeamSyncJob : ISystemTeamSync
 
         var today = _clock.GetCurrentInstant().InUtc().Date;
 
-        var applicationUserIds = await _dbContext.Applications
-            .AsNoTracking()
-            .Where(a => a.Status == ApplicationStatus.Approved
-                && a.MembershipTier == tier
-                && (a.TermExpiresAt == null || a.TermExpiresAt >= today))
-            .Select(a => a.UserId)
-            .Distinct()
-            .ToListAsync(cancellationToken);
+        var applicationUserIds = await _applicationDecisionService
+            .GetActiveApprovedTierUserIdsAsync(tier, today, cancellationToken);
 
-        // Filter by profile status to match per-user sync behavior
-        var userIds = await _dbContext.Profiles
-            .AsNoTracking()
-            .Where(p => applicationUserIds.Contains(p.UserId) && p.IsApproved && !p.IsSuspended)
-            .Select(p => p.UserId)
-            .ToListAsync(cancellationToken);
+        // Filter by profile status to match per-user sync behavior.
+        var allApprovedIds = await _profileService.GetActiveApprovedUserIdsAsync(cancellationToken);
+        var approvedSet = allApprovedIds.ToHashSet();
+        var userIds = applicationUserIds.Where(approvedSet.Contains).ToList();
 
         var eligibleSet = await MembershipCalculator.GetUsersWithAllRequiredConsentsForTeamAsync(
             userIds, teamId, cancellationToken);
         var eligibleUserIds = eligibleSet.ToList();
 
-        // Downgrade Profile.MembershipTier for users who no longer have an active approved application for this tier.
-        // Before downgrading to Volunteer, check if the user holds an active application for the OTHER higher tier.
+        // Downgrade Profile.MembershipTier for users who no longer have an
+        // active approved application for this tier. Before downgrading to
+        // Volunteer, check if the user holds an active application for the
+        // OTHER higher tier.
         var todayInstant = _clock.GetCurrentInstant();
-        var usersWithOtherActiveTier = await _dbContext.Applications
-            .AsNoTracking()
-            .Where(a => a.Status == ApplicationStatus.Approved
-                && a.MembershipTier != tier
-                && a.MembershipTier != MembershipTier.Volunteer
-                && (a.TermExpiresAt == null || a.TermExpiresAt >= today))
-            .Select(a => new { a.UserId, a.MembershipTier })
-            .ToListAsync(cancellationToken);
-        var otherTierByUser = usersWithOtherActiveTier
-            .GroupBy(a => a.UserId)
-            .ToDictionary(g => g.Key, g => g.First().MembershipTier);
+        var otherTierByUser = await _applicationDecisionService
+            .GetOtherActiveTierAssignmentsAsync(tier, today, cancellationToken);
 
-        var toDowngrade = await _dbContext.Profiles
-            .Where(p => p.MembershipTier == tier && !applicationUserIds.Contains(p.UserId))
-            .ToListAsync(cancellationToken);
+        var downgrades = await _profileService.DowngradeTierForExpiredAsync(
+            tier, applicationUserIds, otherTierByUser, todayInstant, cancellationToken);
 
-        // Batch-load users for display names in audit log
-        var downgradeUserIds = toDowngrade.Select(p => p.UserId).ToList();
-        var downgradeUsersById = downgradeUserIds.Count > 0
-            ? await _dbContext.Users.AsNoTracking()
-                .Where(u => downgradeUserIds.Contains(u.Id))
-                .ToDictionaryAsync(u => u.Id, cancellationToken)
-            : new Dictionary<Guid, User>();
-
-        var downgradeAudits = new List<(Guid UserId, MembershipTier NewTier, string DisplayName)>();
-        foreach (var profile in toDowngrade)
+        if (downgrades.Count > 0)
         {
-            var newTier = otherTierByUser.TryGetValue(profile.UserId, out var otherTier)
-                ? otherTier
-                : MembershipTier.Volunteer;
-            profile.MembershipTier = newTier;
-            profile.UpdatedAt = todayInstant;
+            var downgradeUserIds = downgrades.Select(d => d.UserId).ToList();
+            var downgradeUsersById = await _userService.GetByIdsAsync(downgradeUserIds, cancellationToken);
 
-            var displayName = downgradeUsersById.TryGetValue(profile.UserId, out var u)
-                ? u.DisplayName : "Unknown";
-            downgradeAudits.Add((profile.UserId, newTier, displayName));
-        }
-
-        if (toDowngrade.Count > 0)
-        {
-            await _dbContext.SaveChangesAsync(cancellationToken);
-
-            foreach (var (auditUserId, newTier, displayName) in downgradeAudits)
+            foreach (var (downgradeUserId, newTier) in downgrades)
             {
+                var displayName = downgradeUsersById.TryGetValue(downgradeUserId, out var u)
+                    ? u.DisplayName : "Unknown";
                 await _auditLogService.LogAsync(
-                    AuditAction.TierDowngraded, nameof(Profile), auditUserId,
+                    AuditAction.TierDowngraded, nameof(Profile), downgradeUserId,
                     $"Membership tier changed to {newTier} for {displayName} due to {tier} term expiry",
                     nameof(SystemTeamSyncJob),
-                    relatedEntityId: auditUserId, relatedEntityType: nameof(User));
+                    relatedEntityId: downgradeUserId, relatedEntityType: nameof(User));
             }
         }
 
@@ -403,16 +383,16 @@ public class SystemTeamSyncJob : ISystemTeamSync
     /// </summary>
     public async Task SyncVolunteersMembershipForUserAsync(Guid userId, CancellationToken cancellationToken = default)
     {
-        var team = await GetSystemTeamAsync(SystemTeamType.Volunteers, cancellationToken);
+        var team = await _teamService.GetSystemTeamWithActiveMembersAsync(
+            SystemTeamType.Volunteers, cancellationToken);
         if (team is null)
         {
             _logger.LogWarning("Volunteers system team not found");
             return;
         }
 
-        var profile = await _dbContext.Profiles
-            .AsNoTracking()
-            .FirstOrDefaultAsync(p => p.UserId == userId, cancellationToken);
+        var profiles = await _profileService.GetByUserIdsAsync([userId], cancellationToken);
+        profiles.TryGetValue(userId, out var profile);
 
         var isEligible = profile is { IsApproved: true, IsSuspended: false }
             && await MembershipCalculator.HasAllRequiredConsentsForTeamAsync(userId, SystemTeamIds.Volunteers, cancellationToken);
@@ -428,23 +408,15 @@ public class SystemTeamSyncJob : ISystemTeamSync
     /// </summary>
     public async Task SyncCoordinatorsMembershipForUserAsync(Guid userId, CancellationToken cancellationToken = default)
     {
-        var team = await GetSystemTeamAsync(SystemTeamType.Coordinators, cancellationToken);
+        var team = await _teamService.GetSystemTeamWithActiveMembersAsync(
+            SystemTeamType.Coordinators, cancellationToken);
         if (team is null)
         {
             _logger.LogWarning("Coordinators system team not found");
             return;
         }
 
-        // Check if user is currently Coordinator of any department (sub-team managers excluded)
-        var isCoordinatorAnywhere = await _dbContext.TeamMembers
-            .AsNoTracking()
-            .AnyAsync(tm =>
-                tm.UserId == userId &&
-                tm.LeftAt == null &&
-                tm.Role == TeamMemberRole.Coordinator &&
-                tm.Team.SystemTeamType == SystemTeamType.None &&
-                tm.Team.ParentTeamId == null, // Only department coordinators
-                cancellationToken);
+        var isCoordinatorAnywhere = await _teamService.IsActiveDepartmentCoordinatorAsync(userId, cancellationToken);
 
         var isEligible = isCoordinatorAnywhere
             && await MembershipCalculator.HasAllRequiredConsentsForTeamAsync(userId, SystemTeamIds.Coordinators, cancellationToken);
@@ -466,7 +438,7 @@ public class SystemTeamSyncJob : ISystemTeamSync
     private async Task SyncTierMembershipForUserAsync(Guid userId, MembershipTier tier,
         SystemTeamType teamType, Guid teamId, CancellationToken cancellationToken)
     {
-        var team = await GetSystemTeamAsync(teamType, cancellationToken);
+        var team = await _teamService.GetSystemTeamWithActiveMembersAsync(teamType, cancellationToken);
         if (team is null)
         {
             _logger.LogWarning("{TeamType} system team not found", teamType);
@@ -475,18 +447,11 @@ public class SystemTeamSyncJob : ISystemTeamSync
 
         var today = _clock.GetCurrentInstant().InUtc().Date;
 
-        var hasApprovedApp = await _dbContext.Applications
-            .AsNoTracking()
-            .AnyAsync(a =>
-                a.UserId == userId &&
-                a.Status == ApplicationStatus.Approved &&
-                a.MembershipTier == tier &&
-                (a.TermExpiresAt == null || a.TermExpiresAt >= today),
-                cancellationToken);
+        var hasApprovedApp = await _applicationDecisionService
+            .HasActiveApprovedTierAsync(userId, tier, today, cancellationToken);
 
-        var profile = await _dbContext.Profiles
-            .AsNoTracking()
-            .FirstOrDefaultAsync(p => p.UserId == userId, cancellationToken);
+        var profiles = await _profileService.GetByUserIdsAsync([userId], cancellationToken);
+        profiles.TryGetValue(userId, out var profile);
 
         var isEligible = hasApprovedApp
             && profile is { IsApproved: true, IsSuspended: false }
@@ -505,7 +470,8 @@ public class SystemTeamSyncJob : ISystemTeamSync
         _logger.LogDebug("Syncing Barrio Leads team");
         var step = new SyncStepResult("Barrio Leads");
 
-        var team = await GetSystemTeamAsync(SystemTeamType.BarrioLeads, cancellationToken);
+        var team = await _teamService.GetSystemTeamWithActiveMembersAsync(
+            SystemTeamType.BarrioLeads, cancellationToken);
         if (team is null)
         {
             _logger.LogWarning("Barrio Leads system team not found");
@@ -526,7 +492,8 @@ public class SystemTeamSyncJob : ISystemTeamSync
     /// </summary>
     public async Task SyncBarrioLeadsMembershipForUserAsync(Guid userId, CancellationToken cancellationToken = default)
     {
-        var team = await GetSystemTeamAsync(SystemTeamType.BarrioLeads, cancellationToken);
+        var team = await _teamService.GetSystemTeamWithActiveMembersAsync(
+            SystemTeamType.BarrioLeads, cancellationToken);
         if (team is null)
         {
             _logger.LogWarning("Barrio Leads system team not found");
@@ -535,19 +502,14 @@ public class SystemTeamSyncJob : ISystemTeamSync
 
         var isLeadAnywhere = await _campRepository.IsLeadAnywhereAsync(userId, cancellationToken);
 
-        // Idempotency guard: if the user should be a member and already has an active
-        // team_members row, do nothing. This avoids unique-index violations
-        // (IX_team_members_active_unique) on the Barrio Leads team when the user is
-        // registering another camp and already has an active membership from a
-        // previous registration. Checks against the database directly rather than the
-        // filtered Include collection to be robust against any tracker staleness.
+        // Idempotency guard: if the user should be a member and already has an
+        // active team_members row, do nothing. This avoids unique-index
+        // violations (IX_team_members_active_unique) on the Barrio Leads team
+        // when the user is registering another camp and already has an active
+        // membership from a previous registration.
         if (isLeadAnywhere)
         {
-            var alreadyActive = await _dbContext.TeamMembers
-                .AsNoTracking()
-                .AnyAsync(
-                    tm => tm.TeamId == team.Id && tm.UserId == userId && tm.LeftAt == null,
-                    cancellationToken);
+            var alreadyActive = team.Members.Any(m => m.UserId == userId && m.LeftAt == null);
             if (alreadyActive)
             {
                 return;
@@ -566,45 +528,15 @@ public class SystemTeamSyncJob : ISystemTeamSync
     {
         var step = new SyncStepResult("Google Email Backfill");
 
-        var usersToFix = await _dbContext.Users
-            .Where(u => u.GoogleEmail == null
-                && _dbContext.UserEmails.Any(ue =>
-                    ue.UserId == u.Id
-                    && ue.IsVerified
-                    && EF.Functions.ILike(ue.Email, "%@nobodies.team")))
-            .ToListAsync(cancellationToken);
-
-        foreach (var user in usersToFix)
+        var backfilled = await _userService.BackfillNobodiesTeamGoogleEmailsAsync(cancellationToken);
+        foreach (var (userId, displayName, googleEmail) in backfilled)
         {
-            var nobodiesEmail = await _dbContext.UserEmails
-                .Where(ue => ue.UserId == user.Id
-                    && ue.IsVerified
-                    && EF.Functions.ILike(ue.Email, "%@nobodies.team"))
-                .Select(ue => ue.Email)
-                .FirstOrDefaultAsync(cancellationToken);
-
-            if (nobodiesEmail is not null)
-            {
-                user.GoogleEmail = nobodiesEmail;
-                step.Fixed(user.Id, user.DisplayName, $"Set GoogleEmail to {nobodiesEmail}");
-                _logger.LogInformation("Backfilled GoogleEmail for {User} to {Email}",
-                    user.DisplayName, nobodiesEmail);
-            }
-        }
-
-        if (usersToFix.Count > 0)
-        {
-            await _dbContext.SaveChangesAsync(cancellationToken);
+            step.Fixed(userId, displayName, $"Set GoogleEmail to {googleEmail}");
+            _logger.LogInformation(
+                "Backfilled GoogleEmail for {User} to {Email}", displayName, googleEmail);
         }
 
         report?.Steps.Add(step);
-    }
-
-    private async Task<Team?> GetSystemTeamAsync(SystemTeamType systemTeamType, CancellationToken cancellationToken)
-    {
-        return await _dbContext.Teams
-            .Include(t => t.Members.Where(m => m.LeftAt == null))
-            .FirstOrDefaultAsync(t => t.SystemTeamType == systemTeamType, cancellationToken);
     }
 
     private async Task SyncTeamMembershipAsync(Team team, List<Guid> eligibleUserIds,
@@ -617,40 +549,39 @@ public class SystemTeamSyncJob : ISystemTeamSync
 
         var eligibleSet = eligibleUserIds.ToHashSet();
 
-        // When syncing a single user, only evaluate that user (don't remove others)
-        var scopeIds = singleUserSync.HasValue ? new HashSet<Guid> { singleUserSync.Value } : currentMemberIds.Union(eligibleSet).ToHashSet();
+        // When syncing a single user, only evaluate that user (don't remove others).
+        var scopeIds = singleUserSync.HasValue
+            ? new HashSet<Guid> { singleUserSync.Value }
+            : currentMemberIds.Union(eligibleSet).ToHashSet();
 
-        // Users to add (in eligible but not current members)
+        // Users to add (in eligible but not current members).
         var toAdd = scopeIds.Where(id => eligibleSet.Contains(id) && !currentMemberIds.Contains(id)).ToList();
 
-        // Users to remove (current members but not in eligible)
+        // Users to remove (current members but not in eligible).
         var toRemove = scopeIds.Where(id => currentMemberIds.Contains(id) && !eligibleSet.Contains(id)).ToList();
+
+        if (toAdd.Count == 0 && toRemove.Count == 0)
+            return;
 
         var now = _clock.GetCurrentInstant();
 
-        // Batch-load display names for affected users (single query)
+        // Batch-load display names for affected users via IUserService.
         var affectedUserIds = toAdd.Concat(toRemove).ToList();
-        var userNames = affectedUserIds.Count > 0
-            ? await _dbContext.Users
-                .AsNoTracking()
-                .Where(u => affectedUserIds.Contains(u.Id))
-                .ToDictionaryAsync(u => u.Id, u => u.DisplayName, cancellationToken)
-            : new Dictionary<Guid, string>();
+        var usersById = await _userService.GetByIdsAsync(affectedUserIds, cancellationToken);
+        var userNames = usersById.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.DisplayName);
 
-        // Add new members
+        // Apply the bulk membership delta in a single save through the Teams
+        // section (also cascades TeamRoleAssignment deletes on soft-remove and
+        // invalidates the ActiveTeams cache).
+        await _teamService.ApplySystemTeamMembershipDeltaAsync(
+            team.Id, toAdd, toRemove, now, cancellationToken);
+
+        // Fan out Google sync adds per user — the call stays outside the
+        // Teams section so sync-service failures don't tear down the DB
+        // write (which is the behavior the pre-migration job had).
         var addedAudits = new List<(Guid UserId, string UserName)>();
         foreach (var userId in toAdd)
         {
-            var member = new TeamMember
-            {
-                Id = Guid.NewGuid(),
-                TeamId = team.Id,
-                UserId = userId,
-                Role = TeamMemberRole.Member,
-                JoinedAt = now
-            };
-            _dbContext.TeamMembers.Add(member);
-
             var userName = userNames.GetValueOrDefault(userId, userId.ToString());
             step?.Added(userId, userName);
             addedAudits.Add((userId, userName));
@@ -658,81 +589,63 @@ public class SystemTeamSyncJob : ISystemTeamSync
             await _googleSyncService.AddUserToTeamResourcesAsync(team.Id, userId, cancellationToken);
         }
 
-        // Remove members who are no longer eligible
+        // Fan out Google sync removes per user.
         var removedAudits = new List<(Guid UserId, string UserName)>();
         foreach (var userId in toRemove)
         {
-            var member = team.Members.FirstOrDefault(m => m.UserId == userId && m.LeftAt is null);
-            if (member is not null)
-            {
-                // Clean up role slot assignments before ending membership
-                var roleAssignments = await _dbContext.Set<TeamRoleAssignment>()
-                    .Where(a => a.TeamMemberId == member.Id)
-                    .ToListAsync(cancellationToken);
-                _dbContext.Set<TeamRoleAssignment>().RemoveRange(roleAssignments);
+            var userName = userNames.GetValueOrDefault(userId, userId.ToString());
+            step?.Removed(userId, userName);
+            removedAudits.Add((userId, userName));
 
-                member.LeftAt = now;
-
-                var userName = userNames.GetValueOrDefault(userId, userId.ToString());
-                step?.Removed(userId, userName);
-                removedAudits.Add((userId, userName));
-
-                await _googleSyncService.RemoveUserFromTeamResourcesAsync(team.Id, userId, cancellationToken);
-            }
+            await _googleSyncService.RemoveUserFromTeamResourcesAsync(team.Id, userId, cancellationToken);
         }
 
-        if (toAdd.Count > 0 || toRemove.Count > 0)
+        foreach (var (auditUserId, userName) in addedAudits)
         {
-            team.UpdatedAt = now;
-            await _dbContext.SaveChangesAsync(cancellationToken);
-
-            foreach (var (auditUserId, userName) in addedAudits)
-            {
-                await _auditLogService.LogAsync(
-                    AuditAction.TeamMemberAdded, nameof(Team), team.Id,
-                    $"{userName} added to {team.Name} by system sync",
-                    nameof(SystemTeamSyncJob),
-                    relatedEntityId: auditUserId, relatedEntityType: nameof(User));
-            }
-
-            foreach (var (auditUserId, userName) in removedAudits)
-            {
-                await _auditLogService.LogAsync(
-                    AuditAction.TeamMemberRemoved, nameof(Team), team.Id,
-                    $"{userName} removed from {team.Name} by system sync",
-                    nameof(SystemTeamSyncJob),
-                    relatedEntityId: auditUserId, relatedEntityType: nameof(User));
-            }
-
-            // Invalidate team cache — sync job runs infrequently, cache rebuilds on next access
-            _cache.InvalidateActiveTeams();
-            InvalidateUserCachesForSystemTeamMembershipChanges(team.SystemTeamType, affectedUserIds);
-
-            _logger.LogInformation(
-                "Synced {TeamName} team: added {AddCount}, removed {RemoveCount}",
-                team.Name, toAdd.Count, toRemove.Count);
+            await _auditLogService.LogAsync(
+                AuditAction.TeamMemberAdded, nameof(Team), team.Id,
+                $"{userName} added to {team.Name} by system sync",
+                nameof(SystemTeamSyncJob),
+                relatedEntityId: auditUserId, relatedEntityType: nameof(User));
         }
 
-        // Send "added to team" emails for newly added members (skip hidden teams)
+        foreach (var (auditUserId, userName) in removedAudits)
+        {
+            await _auditLogService.LogAsync(
+                AuditAction.TeamMemberRemoved, nameof(Team), team.Id,
+                $"{userName} removed from {team.Name} by system sync",
+                nameof(SystemTeamSyncJob),
+                relatedEntityId: auditUserId, relatedEntityType: nameof(User));
+        }
+
+        // Invalidate per-user role-assignment-claim caches for Volunteers
+        // changes so the sidebar claims transform refreshes before the 60s
+        // TTL elapses (matches pre-migration behavior).
+        InvalidateUserCachesForSystemTeamMembershipChanges(team.SystemTeamType, affectedUserIds);
+
+        _logger.LogInformation(
+            "Synced {TeamName} team: added {AddCount}, removed {RemoveCount}",
+            team.Name, toAdd.Count, toRemove.Count);
+
+        // Send "added to team" emails for newly added members (skip hidden teams).
         if (toAdd.Count > 0 && !team.IsHidden)
         {
-            var resources = await _dbContext.GoogleResources
-                .AsNoTracking()
-                .Where(gr => gr.TeamId == team.Id && gr.IsActive)
-                .Select(gr => new { gr.Name, gr.Url })
-                .ToListAsync(cancellationToken);
+            var resources = await _teamResourceService.GetTeamResourcesAsync(team.Id, cancellationToken);
             var resourceTuples = resources.Select(r => (r.Name, r.Url)).ToList();
 
-            var addedUsers = await _dbContext.Users
-                .Include(u => u.UserEmails)
-                .Where(u => toAdd.Contains(u.Id))
-                .ToListAsync(cancellationToken);
+            var addedUsersWithEmails = await _userService
+                .GetByIdsWithEmailsAsync(toAdd, cancellationToken);
 
-            foreach (var user in addedUsers)
+            foreach (var userId in toAdd)
             {
+                if (!addedUsersWithEmails.TryGetValue(userId, out var user))
+                    continue;
+
                 try
                 {
+#pragma warning disable CS0618 // User.GetEffectiveEmail() cross-domain nav — covered by §15i follow-up.
                     var email = user.GetEffectiveEmail() ?? user.Email!;
+#pragma warning restore CS0618
                     await _emailService.SendAddedToTeamAsync(
                         email, user.DisplayName, team.Name, team.Slug,
                         resourceTuples, user.PreferredLanguage, cancellationToken);
@@ -757,7 +670,7 @@ public class SystemTeamSyncJob : ISystemTeamSync
 
         foreach (var userId in userIds)
         {
-            _cache.InvalidateRoleAssignmentClaims(userId);
+            _roleAssignmentClaimsInvalidator.Invalidate(userId);
         }
     }
 }

--- a/src/Humans.Infrastructure/Repositories/Governance/ApplicationRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Governance/ApplicationRepository.cs
@@ -304,4 +304,43 @@ public sealed class ApplicationRepository : IApplicationRepository
         app.RenewalReminderSentAt = sentAt;
         await _dbContext.SaveChangesAsync(ct);
     }
+
+    public async Task<IReadOnlyList<Guid>> GetActiveApprovedTierUserIdsAsync(
+        MembershipTier tier, LocalDate today, CancellationToken ct = default) =>
+        await _dbContext.Applications
+            .AsNoTracking()
+            .Where(a => a.Status == ApplicationStatus.Approved
+                && a.MembershipTier == tier
+                && (a.TermExpiresAt == null || a.TermExpiresAt >= today))
+            .Select(a => a.UserId)
+            .Distinct()
+            .ToListAsync(ct);
+
+    public Task<bool> HasActiveApprovedTierAsync(
+        Guid userId, MembershipTier tier, LocalDate today, CancellationToken ct = default) =>
+        _dbContext.Applications
+            .AsNoTracking()
+            .AnyAsync(a =>
+                a.UserId == userId &&
+                a.Status == ApplicationStatus.Approved &&
+                a.MembershipTier == tier &&
+                (a.TermExpiresAt == null || a.TermExpiresAt >= today),
+                ct);
+
+    public async Task<IReadOnlyDictionary<Guid, MembershipTier>> GetOtherActiveTierAssignmentsAsync(
+        MembershipTier excludeTier, LocalDate today, CancellationToken ct = default)
+    {
+        var rows = await _dbContext.Applications
+            .AsNoTracking()
+            .Where(a => a.Status == ApplicationStatus.Approved
+                && a.MembershipTier != excludeTier
+                && a.MembershipTier != MembershipTier.Volunteer
+                && (a.TermExpiresAt == null || a.TermExpiresAt >= today))
+            .Select(a => new { a.UserId, a.MembershipTier })
+            .ToListAsync(ct);
+
+        return rows
+            .GroupBy(r => r.UserId)
+            .ToDictionary(g => g.Key, g => g.First().MembershipTier);
+    }
 }

--- a/src/Humans.Infrastructure/Repositories/Profiles/ProfileRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Profiles/ProfileRepository.cs
@@ -252,6 +252,39 @@ public sealed class ProfileRepository : IProfileRepository
         return profiles.Select(p => p.UserId).ToHashSet();
     }
 
+    public async Task<IReadOnlyList<(Guid UserId, MembershipTier NewTier)>>
+        DowngradeTierForExpiredAsync(
+            MembershipTier currentTier,
+            IReadOnlyCollection<Guid> userIdsToKeep,
+            IReadOnlyDictionary<Guid, MembershipTier> fallbackTierByUser,
+            Instant now,
+            CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        var keepList = userIdsToKeep is IList<Guid> list ? list : userIdsToKeep.ToList();
+        var profiles = await ctx.Profiles
+            .Where(p => p.MembershipTier == currentTier && !keepList.Contains(p.UserId))
+            .ToListAsync(ct);
+
+        var result = new List<(Guid UserId, MembershipTier NewTier)>(profiles.Count);
+        foreach (var profile in profiles)
+        {
+            var newTier = fallbackTierByUser.TryGetValue(profile.UserId, out var other)
+                ? other
+                : MembershipTier.Volunteer;
+            profile.MembershipTier = newTier;
+            profile.UpdatedAt = now;
+            result.Add((profile.UserId, newTier));
+        }
+
+        if (profiles.Count > 0)
+        {
+            await ctx.SaveChangesAsync(ct);
+        }
+
+        return result;
+    }
+
     private async Task<bool> AnonymizeProfileInternalAsync(
         Guid userId, string firstName, string lastName, CancellationToken ct)
     {

--- a/src/Humans.Infrastructure/Repositories/Profiles/ProfileRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Profiles/ProfileRepository.cs
@@ -224,6 +224,34 @@ public sealed class ProfileRepository : IProfileRepository
     public Task<bool> AnonymizeForDeletionByUserIdAsync(Guid userId, CancellationToken ct = default) =>
         AnonymizeProfileInternalAsync(userId, "Deleted", "User", ct);
 
+    public async Task<IReadOnlySet<Guid>> SuspendManyAsync(
+        IReadOnlyCollection<Guid> userIds,
+        Instant now,
+        CancellationToken ct = default)
+    {
+        if (userIds.Count == 0)
+            return new HashSet<Guid>();
+
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        var userIdList = userIds is IList<Guid> list ? list : userIds.ToList();
+        var profiles = await ctx.Profiles
+            .Where(p => userIdList.Contains(p.UserId) && !p.IsSuspended)
+            .ToListAsync(ct);
+
+        foreach (var profile in profiles)
+        {
+            profile.IsSuspended = true;
+            profile.UpdatedAt = now;
+        }
+
+        if (profiles.Count > 0)
+        {
+            await ctx.SaveChangesAsync(ct);
+        }
+
+        return profiles.Select(p => p.UserId).ToHashSet();
+    }
+
     private async Task<bool> AnonymizeProfileInternalAsync(
         Guid userId, string firstName, string lastName, CancellationToken ct)
     {

--- a/src/Humans.Infrastructure/Repositories/Teams/TeamRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Teams/TeamRepository.cs
@@ -1254,4 +1254,154 @@ public sealed class TeamRepository : ITeamRepository
             .OrderByDescending(tjr => tjr.RequestedAt)
             .ToListAsync(ct);
     }
+
+    // ==========================================================================
+    // System team sync support (issue #570 — §15 Google-writing jobs)
+    // ==========================================================================
+
+    public async Task<Team?> GetSystemTeamWithActiveMembersAsync(
+        SystemTeamType type, CancellationToken ct = default)
+    {
+        await using var db = await _factory.CreateDbContextAsync(ct);
+        return await db.Teams
+            .AsNoTracking()
+            .Include(t => t.Members.Where(m => m.LeftAt == null))
+            .FirstOrDefaultAsync(t => t.SystemTeamType == type, ct);
+    }
+
+    public async Task<IReadOnlyList<TeamMember>> GetActiveMembershipsForRoleReconciliationAsync(
+        CancellationToken ct = default)
+    {
+        await using var db = await _factory.CreateDbContextAsync(ct);
+        return await db.TeamMembers
+            .AsNoTracking()
+            .Include(tm => tm.Team)
+            .Include(tm => tm.RoleAssignments)
+                .ThenInclude(ra => ra.TeamRoleDefinition)
+            .Where(tm => tm.LeftAt == null)
+            .ToListAsync(ct);
+    }
+
+    public async Task<int> ApplyMemberRoleChangesAsync(
+        IReadOnlyCollection<(Guid TeamMemberId, TeamMemberRole Role)> changes,
+        CancellationToken ct = default)
+    {
+        if (changes.Count == 0)
+            return 0;
+
+        await using var db = await _factory.CreateDbContextAsync(ct);
+        var ids = changes.Select(c => c.TeamMemberId).ToList();
+        var members = await db.TeamMembers
+            .Where(tm => ids.Contains(tm.Id) && tm.LeftAt == null)
+            .ToListAsync(ct);
+
+        var targetRoleById = changes.ToDictionary(c => c.TeamMemberId, c => c.Role);
+
+        var updated = 0;
+        foreach (var member in members)
+        {
+            if (targetRoleById.TryGetValue(member.Id, out var newRole) && member.Role != newRole)
+            {
+                member.Role = newRole;
+                updated++;
+            }
+        }
+
+        if (updated > 0)
+        {
+            await db.SaveChangesAsync(ct);
+        }
+
+        return updated;
+    }
+
+    public async Task<IReadOnlyList<Guid>> GetActiveDepartmentCoordinatorUserIdsAsync(
+        CancellationToken ct = default)
+    {
+        await using var db = await _factory.CreateDbContextAsync(ct);
+        return await db.TeamMembers
+            .AsNoTracking()
+            .Where(tm =>
+                tm.LeftAt == null &&
+                tm.Role == TeamMemberRole.Coordinator &&
+                tm.Team.SystemTeamType == SystemTeamType.None &&
+                tm.Team.ParentTeamId == null)
+            .Select(tm => tm.UserId)
+            .Distinct()
+            .ToListAsync(ct);
+    }
+
+    public async Task<bool> IsActiveDepartmentCoordinatorAsync(
+        Guid userId, CancellationToken ct = default)
+    {
+        await using var db = await _factory.CreateDbContextAsync(ct);
+        return await db.TeamMembers
+            .AsNoTracking()
+            .AnyAsync(tm =>
+                tm.UserId == userId &&
+                tm.LeftAt == null &&
+                tm.Role == TeamMemberRole.Coordinator &&
+                tm.Team.SystemTeamType == SystemTeamType.None &&
+                tm.Team.ParentTeamId == null,
+                ct);
+    }
+
+    public async Task<bool> ApplySystemTeamMembershipDeltaAsync(
+        Guid teamId,
+        IReadOnlyCollection<Guid> userIdsToAdd,
+        IReadOnlyCollection<Guid> userIdsToRemove,
+        Instant now,
+        CancellationToken ct = default)
+    {
+        if (userIdsToAdd.Count == 0 && userIdsToRemove.Count == 0)
+            return false;
+
+        await using var db = await _factory.CreateDbContextAsync(ct);
+
+        // Inserts
+        foreach (var userId in userIdsToAdd)
+        {
+            db.TeamMembers.Add(new TeamMember
+            {
+                Id = Guid.NewGuid(),
+                TeamId = teamId,
+                UserId = userId,
+                Role = TeamMemberRole.Member,
+                JoinedAt = now,
+            });
+        }
+
+        // Soft-removes: load active memberships for the users being removed,
+        // also eager-load their TeamRoleAssignments so EF cascades the delete.
+        if (userIdsToRemove.Count > 0)
+        {
+            var removeIds = userIdsToRemove is IList<Guid> list
+                ? list
+                : userIdsToRemove.ToList();
+            var members = await db.TeamMembers
+                .Include(tm => tm.RoleAssignments)
+                .Where(tm => tm.TeamId == teamId && tm.LeftAt == null && removeIds.Contains(tm.UserId))
+                .ToListAsync(ct);
+
+            foreach (var member in members)
+            {
+                // Clean up role slot assignments before ending the membership.
+                if (member.RoleAssignments.Count > 0)
+                {
+                    db.Set<TeamRoleAssignment>().RemoveRange(member.RoleAssignments);
+                }
+                member.LeftAt = now;
+            }
+        }
+
+        // Bump Team.UpdatedAt so the cached projection refresh picks up the change.
+        var team = await db.Teams.FirstOrDefaultAsync(t => t.Id == teamId, ct);
+        if (team is not null)
+        {
+            team.UpdatedAt = now;
+        }
+
+        await db.SaveChangesAsync(ct);
+        return true;
+    }
 }

--- a/src/Humans.Infrastructure/Repositories/Users/UserRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Users/UserRepository.cs
@@ -669,4 +669,43 @@ public sealed class UserRepository : IUserRepository
         await ctx.SaveChangesAsync(ct);
         return count;
     }
+
+    public async Task<IReadOnlyList<(Guid UserId, string DisplayName, string GoogleEmail)>>
+        BackfillNobodiesTeamGoogleEmailsAsync(CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+
+        var usersToFix = await ctx.Users
+            .Where(u => u.GoogleEmail == null
+                && ctx.UserEmails.Any(ue =>
+                    ue.UserId == u.Id
+                    && ue.IsVerified
+                    && EF.Functions.ILike(ue.Email, "%@nobodies.team")))
+            .ToListAsync(ct);
+
+        var result = new List<(Guid UserId, string DisplayName, string GoogleEmail)>(usersToFix.Count);
+
+        foreach (var user in usersToFix)
+        {
+            var nobodiesEmail = await ctx.UserEmails
+                .Where(ue => ue.UserId == user.Id
+                    && ue.IsVerified
+                    && EF.Functions.ILike(ue.Email, "%@nobodies.team"))
+                .Select(ue => ue.Email)
+                .FirstOrDefaultAsync(ct);
+
+            if (nobodiesEmail is not null)
+            {
+                user.GoogleEmail = nobodiesEmail;
+                result.Add((user.Id, user.DisplayName, nobodiesEmail));
+            }
+        }
+
+        if (result.Count > 0)
+        {
+            await ctx.SaveChangesAsync(ct);
+        }
+
+        return result;
+    }
 }

--- a/src/Humans.Infrastructure/Services/Profiles/CachingProfileService.cs
+++ b/src/Humans.Infrastructure/Services/Profiles/CachingProfileService.cs
@@ -587,4 +587,22 @@ public sealed class CachingProfileService : IProfileService, IFullProfileInvalid
         }
         return anonymized;
     }
+
+    public async Task<IReadOnlySet<Guid>> SuspendForMissingConsentAsync(
+        IReadOnlyCollection<Guid> userIds,
+        Instant now,
+        CancellationToken ct = default)
+    {
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        var inner = scope.ServiceProvider.GetRequiredKeyedService<IProfileService>(InnerServiceKey);
+        var suspendedIds = await inner.SuspendForMissingConsentAsync(userIds, now, ct);
+        // IsSuspended is part of the FullProfile projection — refresh the
+        // cache entry for every user that was actually mutated so downstream
+        // readers see the suspended view immediately.
+        foreach (var userId in suspendedIds)
+        {
+            await RefreshEntryAsync(userId, ct);
+        }
+        return suspendedIds;
+    }
 }

--- a/src/Humans.Infrastructure/Services/Profiles/CachingProfileService.cs
+++ b/src/Humans.Infrastructure/Services/Profiles/CachingProfileService.cs
@@ -605,4 +605,25 @@ public sealed class CachingProfileService : IProfileService, IFullProfileInvalid
         }
         return suspendedIds;
     }
+
+    public async Task<IReadOnlyList<(Guid UserId, MembershipTier NewTier)>>
+        DowngradeTierForExpiredAsync(
+            MembershipTier currentTier,
+            IReadOnlyCollection<Guid> userIdsToKeep,
+            IReadOnlyDictionary<Guid, MembershipTier> fallbackTierByUser,
+            Instant now,
+            CancellationToken ct = default)
+    {
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        var inner = scope.ServiceProvider.GetRequiredKeyedService<IProfileService>(InnerServiceKey);
+        var downgrades = await inner.DowngradeTierForExpiredAsync(
+            currentTier, userIdsToKeep, fallbackTierByUser, now, ct);
+        // MembershipTier is part of the FullProfile projection — refresh the
+        // cache entry for every downgraded user.
+        foreach (var (userId, _) in downgrades)
+        {
+            await RefreshEntryAsync(userId, ct);
+        }
+        return downgrades;
+    }
 }

--- a/src/Humans.Web/Extensions/Sections/TeamsSectionExtensions.cs
+++ b/src/Humans.Web/Extensions/Sections/TeamsSectionExtensions.cs
@@ -1,7 +1,9 @@
+using Humans.Application.Interfaces.Caching;
 using Humans.Application.Interfaces.Gdpr;
 using Humans.Application.Interfaces.GoogleIntegration;
 using Humans.Application.Interfaces.Repositories;
 using Humans.Application.Interfaces.Teams;
+using Humans.Infrastructure.Caching;
 using Humans.Infrastructure.Jobs;
 using Humans.Infrastructure.Repositories.Teams;
 using TeamsTeamPageService = Humans.Application.Services.Teams.TeamPageService;
@@ -36,6 +38,12 @@ internal static class TeamsSectionExtensions
         services.AddScoped<IUserDataContributor>(sp => sp.GetRequiredService<TeamsTeamService>());
 
         services.AddScoped<ITeamPageService, TeamsTeamPageService>();
+
+        // Cross-cutting invalidator for the ActiveTeams cache entry (§15
+        // design-rules). Registered alongside the Teams section — Teams
+        // owns the cache, external callers (e.g. SystemTeamSyncJob) inject
+        // IActiveTeamsCacheInvalidator rather than IMemoryCache.
+        services.AddScoped<IActiveTeamsCacheInvalidator, ActiveTeamsCacheInvalidator>();
 
         services.AddScoped<ISystemTeamSync, SystemTeamSyncJob>();
 

--- a/tests/Humans.Application.Tests/Jobs/SuspendNonCompliantMembersJobTests.cs
+++ b/tests/Humans.Application.Tests/Jobs/SuspendNonCompliantMembersJobTests.cs
@@ -1,6 +1,4 @@
 using AwesomeAssertions;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NodaTime;
@@ -8,31 +6,35 @@ using NodaTime.Testing;
 using NSubstitute;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
-using Humans.Infrastructure.Data;
 using Humans.Infrastructure.Jobs;
 using Humans.Infrastructure.Services;
 using Xunit;
 using Humans.Application.Interfaces.AuditLog;
+using Humans.Application.Interfaces.Caching;
 using Humans.Application.Interfaces.Email;
 using Humans.Application.Interfaces.GoogleIntegration;
 using Humans.Application.Interfaces.Teams;
 using Humans.Application.Interfaces.Notifications;
 using Humans.Application.Interfaces.Governance;
 using Humans.Application.Interfaces.Profiles;
+using Humans.Application.Interfaces.Shifts;
+using Humans.Application.Interfaces.Users;
 
 namespace Humans.Application.Tests.Jobs;
 
 public class SuspendNonCompliantMembersJobTests : IDisposable
 {
-    private readonly HumansDbContext _dbContext;
+    private readonly IUserService _userService;
+    private readonly IProfileService _profileService;
+    private readonly ITeamService _teamService;
     private readonly IMembershipCalculator _membershipCalculator;
     private readonly IEmailService _emailService;
     private readonly INotificationService _notificationService;
     private readonly IGoogleSyncService _googleSyncService;
     private readonly IAuditLogService _auditLogService;
     private readonly IFullProfileInvalidator _fullProfileInvalidator;
-    private readonly ITeamService _teamService;
-    private readonly IMemoryCache _cache;
+    private readonly IRoleAssignmentClaimsCacheInvalidator _roleAssignmentClaimsInvalidator;
+    private readonly IShiftAuthorizationInvalidator _shiftAuthorizationInvalidator;
     private readonly HumansMetricsService _metrics;
     private readonly FakeClock _clock;
     private readonly SuspendNonCompliantMembersJob _job;
@@ -41,35 +43,37 @@ public class SuspendNonCompliantMembersJobTests : IDisposable
 
     public SuspendNonCompliantMembersJobTests()
     {
-        var options = new DbContextOptionsBuilder<HumansDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-
-        _dbContext = new HumansDbContext(options);
+        _userService = Substitute.For<IUserService>();
+        _profileService = Substitute.For<IProfileService>();
+        _teamService = Substitute.For<ITeamService>();
         _membershipCalculator = Substitute.For<IMembershipCalculator>();
         _emailService = Substitute.For<IEmailService>();
         _notificationService = Substitute.For<INotificationService>();
         _googleSyncService = Substitute.For<IGoogleSyncService>();
         _auditLogService = Substitute.For<IAuditLogService>();
         _fullProfileInvalidator = Substitute.For<IFullProfileInvalidator>();
-        _teamService = Substitute.For<ITeamService>();
-        _cache = new MemoryCache(new MemoryCacheOptions());
+        _roleAssignmentClaimsInvalidator = Substitute.For<IRoleAssignmentClaimsCacheInvalidator>();
+        _shiftAuthorizationInvalidator = Substitute.For<IShiftAuthorizationInvalidator>();
         _clock = new FakeClock(Now);
         _metrics = new HumansMetricsService(
             Substitute.For<IServiceScopeFactory>(),
             Substitute.For<ILogger<HumansMetricsService>>());
         var logger = Substitute.For<ILogger<SuspendNonCompliantMembersJob>>();
 
+        // Default: ITeamService.GetUserTeamsAsync returns empty list so tests
+        // that don't care about team fan-out don't need to stub it.
+        _teamService.GetUserTeamsAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<TeamMember>());
+
         _job = new SuspendNonCompliantMembersJob(
-            _dbContext, _membershipCalculator, _emailService,
-            _notificationService, _googleSyncService, _auditLogService,
-            _fullProfileInvalidator, _teamService, _cache, _metrics, logger, _clock);
+            _userService, _profileService, _teamService, _membershipCalculator,
+            _emailService, _notificationService, _googleSyncService, _auditLogService,
+            _fullProfileInvalidator, _roleAssignmentClaimsInvalidator,
+            _shiftAuthorizationInvalidator, _metrics, logger, _clock);
     }
 
     public void Dispose()
     {
-        _dbContext.Dispose();
-        _cache.Dispose();
         _metrics.Dispose();
         GC.SuppressFinalize(this);
     }
@@ -77,15 +81,17 @@ public class SuspendNonCompliantMembersJobTests : IDisposable
     [Fact]
     public async Task ExecuteAsync_SuspendsNonCompliantUser()
     {
-        var user = await SeedUserWithProfile();
+        var user = SetupUser();
         _membershipCalculator.GetUsersRequiringStatusUpdateAsync(Arg.Any<CancellationToken>())
             .Returns(new List<Guid> { user.Id });
+        StubSuspendSucceeds([user.Id]);
 
         await _job.ExecuteAsync();
 
-        var updated = await _dbContext.Users.Include(u => u.Profile).SingleAsync();
-        updated.Profile!.IsSuspended.Should().BeTrue();
-        updated.Profile.UpdatedAt.Should().Be(Now);
+        await _profileService.Received(1).SuspendForMissingConsentAsync(
+            Arg.Is<IReadOnlyCollection<Guid>>(ids => ids.Contains(user.Id)),
+            Now,
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -96,6 +102,9 @@ public class SuspendNonCompliantMembersJobTests : IDisposable
 
         await _job.ExecuteAsync();
 
+        await _profileService.DidNotReceive().SuspendForMissingConsentAsync(
+            Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<Instant>(), Arg.Any<CancellationToken>());
+
         await _emailService.DidNotReceive().SendAccessSuspendedAsync(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
             Arg.Any<string?>(), Arg.Any<CancellationToken>());
@@ -104,9 +113,16 @@ public class SuspendNonCompliantMembersJobTests : IDisposable
     [Fact]
     public async Task ExecuteAsync_SkipsAlreadySuspendedUsers()
     {
-        var user = await SeedUserWithProfile(isSuspended: true);
+        // Profile service reports zero mutations — job should not send email.
+        var user = SetupUser();
         _membershipCalculator.GetUsersRequiringStatusUpdateAsync(Arg.Any<CancellationToken>())
             .Returns(new List<Guid> { user.Id });
+
+        _profileService.SuspendForMissingConsentAsync(
+            Arg.Any<IReadOnlyCollection<Guid>>(),
+            Arg.Any<Instant>(),
+            Arg.Any<CancellationToken>())
+            .Returns((IReadOnlySet<Guid>)new HashSet<Guid>());
 
         await _job.ExecuteAsync();
 
@@ -116,37 +132,44 @@ public class SuspendNonCompliantMembersJobTests : IDisposable
     }
 
     [Fact]
-    public async Task ExecuteAsync_SkipsUsersWithoutProfile()
+    public async Task ExecuteAsync_SkipsUsersMissingFromUserLookup()
     {
         var userId = Guid.NewGuid();
-        _dbContext.Users.Add(new User
-        {
-            Id = userId,
-            UserName = "noprofile",
-            NormalizedUserName = "NOPROFILE",
-            Email = "noprofile@example.com",
-            NormalizedEmail = "NOPROFILE@EXAMPLE.COM",
-            DisplayName = "No Profile",
-            PreferredLanguage = "en"
-        });
-        await _dbContext.SaveChangesAsync();
-
         _membershipCalculator.GetUsersRequiringStatusUpdateAsync(Arg.Any<CancellationToken>())
             .Returns(new List<Guid> { userId });
+
+        // Profile service says it suspended the user, but user service returns
+        // an empty lookup — job should not emit email/notification/audit.
+        _profileService.SuspendForMissingConsentAsync(
+            Arg.Any<IReadOnlyCollection<Guid>>(),
+            Arg.Any<Instant>(),
+            Arg.Any<CancellationToken>())
+            .Returns((IReadOnlySet<Guid>)new HashSet<Guid> { userId });
+
+        _userService.GetByIdsWithEmailsAsync(
+            Arg.Any<IReadOnlyCollection<Guid>>(),
+            Arg.Any<CancellationToken>())
+            .Returns((IReadOnlyDictionary<Guid, User>)new Dictionary<Guid, User>());
 
         await _job.ExecuteAsync();
 
         await _emailService.DidNotReceive().SendAccessSuspendedAsync(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
             Arg.Any<string?>(), Arg.Any<CancellationToken>());
+
+        await _auditLogService.DidNotReceive().LogAsync(
+            Arg.Any<AuditAction>(), Arg.Any<string>(), Arg.Any<Guid>(),
+            Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<Guid?>(), Arg.Any<string?>());
     }
 
     [Fact]
     public async Task ExecuteAsync_SendsSuspensionEmail()
     {
-        var user = await SeedUserWithProfile();
+        var user = SetupUser();
         _membershipCalculator.GetUsersRequiringStatusUpdateAsync(Arg.Any<CancellationToken>())
             .Returns(new List<Guid> { user.Id });
+        StubSuspendSucceeds([user.Id]);
 
         await _job.ExecuteAsync();
 
@@ -161,9 +184,10 @@ public class SuspendNonCompliantMembersJobTests : IDisposable
     [Fact]
     public async Task ExecuteAsync_SendsInAppNotification()
     {
-        var user = await SeedUserWithProfile();
+        var user = SetupUser();
         _membershipCalculator.GetUsersRequiringStatusUpdateAsync(Arg.Any<CancellationToken>())
             .Returns(new List<Guid> { user.Id });
+        StubSuspendSucceeds([user.Id]);
 
         await _job.ExecuteAsync();
 
@@ -183,41 +207,38 @@ public class SuspendNonCompliantMembersJobTests : IDisposable
     [Fact]
     public async Task ExecuteAsync_RemovesFromTeamResources()
     {
-        var user = await SeedUserWithProfile();
-        var team = new Team
-        {
-            Id = Guid.NewGuid(),
-            Name = "Test Team",
-            Slug = "test-team",
-            CreatedAt = Now - Duration.FromDays(100)
-        };
-        _dbContext.Teams.Add(team);
-
-        _dbContext.TeamMembers.Add(new TeamMember
-        {
-            Id = Guid.NewGuid(),
-            TeamId = team.Id,
-            UserId = user.Id,
-            JoinedAt = Now - Duration.FromDays(50),
-            LeftAt = null
-        });
-        await _dbContext.SaveChangesAsync();
+        var user = SetupUser();
+        var teamId = Guid.NewGuid();
+        _teamService.GetUserTeamsAsync(user.Id, Arg.Any<CancellationToken>())
+            .Returns(new List<TeamMember>
+            {
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    TeamId = teamId,
+                    UserId = user.Id,
+                    JoinedAt = Now - Duration.FromDays(50),
+                    LeftAt = null,
+                },
+            });
 
         _membershipCalculator.GetUsersRequiringStatusUpdateAsync(Arg.Any<CancellationToken>())
             .Returns(new List<Guid> { user.Id });
+        StubSuspendSucceeds([user.Id]);
 
         await _job.ExecuteAsync();
 
         await _googleSyncService.Received(1).RemoveUserFromTeamResourcesAsync(
-            team.Id, user.Id, Arg.Any<CancellationToken>());
+            teamId, user.Id, Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task ExecuteAsync_LogsAuditEntry()
     {
-        var user = await SeedUserWithProfile();
+        var user = SetupUser();
         _membershipCalculator.GetUsersRequiringStatusUpdateAsync(Arg.Any<CancellationToken>())
             .Returns(new List<Guid> { user.Id });
+        StubSuspendSucceeds([user.Id]);
 
         await _job.ExecuteAsync();
 
@@ -234,55 +255,60 @@ public class SuspendNonCompliantMembersJobTests : IDisposable
     [Fact]
     public async Task ExecuteAsync_InvalidatesCaches()
     {
-        var user = await SeedUserWithProfile();
+        var user = SetupUser();
         _membershipCalculator.GetUsersRequiringStatusUpdateAsync(Arg.Any<CancellationToken>())
             .Returns(new List<Guid> { user.Id });
+        StubSuspendSucceeds([user.Id]);
 
         await _job.ExecuteAsync();
 
         await _fullProfileInvalidator.Received(1).InvalidateAsync(user.Id, Arg.Any<CancellationToken>());
+        _roleAssignmentClaimsInvalidator.Received(1).Invalidate(user.Id);
+        _shiftAuthorizationInvalidator.Received(1).Invalidate(user.Id);
         _teamService.Received(1).RemoveMemberFromAllTeamsCache(user.Id);
     }
 
     [Fact]
     public async Task ExecuteAsync_ContinuesWhenGoogleSyncFails()
     {
-        var user = await SeedUserWithProfile();
-        var team = new Team
-        {
-            Id = Guid.NewGuid(),
-            Name = "Test Team",
-            Slug = "test-team",
-            CreatedAt = Now - Duration.FromDays(100)
-        };
-        _dbContext.Teams.Add(team);
-
-        _dbContext.TeamMembers.Add(new TeamMember
-        {
-            Id = Guid.NewGuid(),
-            TeamId = team.Id,
-            UserId = user.Id,
-            JoinedAt = Now - Duration.FromDays(50),
-            LeftAt = null
-        });
-        await _dbContext.SaveChangesAsync();
+        var user = SetupUser();
+        var teamId = Guid.NewGuid();
+        _teamService.GetUserTeamsAsync(user.Id, Arg.Any<CancellationToken>())
+            .Returns(new List<TeamMember>
+            {
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    TeamId = teamId,
+                    UserId = user.Id,
+                    JoinedAt = Now - Duration.FromDays(50),
+                    LeftAt = null,
+                },
+            });
 
         _membershipCalculator.GetUsersRequiringStatusUpdateAsync(Arg.Any<CancellationToken>())
             .Returns(new List<Guid> { user.Id });
+        StubSuspendSucceeds([user.Id]);
 
         _googleSyncService.RemoveUserFromTeamResourcesAsync(
             Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromException(new InvalidOperationException("Google API error")));
 
-        // Should not throw — Google sync failures are caught and logged
+        // Should not throw — Google sync failures are caught and logged.
         await _job.ExecuteAsync();
 
-        // User should still be suspended despite Google sync failure
-        var updated = await _dbContext.Users.Include(u => u.Profile).SingleAsync();
-        updated.Profile!.IsSuspended.Should().BeTrue();
+        // Audit entry should still be written despite Google failure.
+        await _auditLogService.Received(1).LogAsync(
+            AuditAction.MemberSuspended, nameof(User), user.Id,
+            Arg.Any<string>(), nameof(SuspendNonCompliantMembersJob),
+            Arg.Any<Guid?>(), Arg.Any<string?>());
     }
 
-    private async Task<User> SeedUserWithProfile(bool isSuspended = false)
+    // ------------------------------------------------------------------
+    // Helpers
+    // ------------------------------------------------------------------
+
+    private User SetupUser()
     {
         var userId = Guid.NewGuid();
         var user = new User
@@ -294,20 +320,25 @@ public class SuspendNonCompliantMembersJobTests : IDisposable
             NormalizedEmail = "TEST@EXAMPLE.COM",
             DisplayName = "Test User",
             PreferredLanguage = "en",
-            Profile = new Profile
-            {
-                Id = Guid.NewGuid(),
-                UserId = userId,
-                FirstName = "Test",
-                LastName = "User",
-                BurnerName = "Tester",
-                IsSuspended = isSuspended,
-                UpdatedAt = Now - Duration.FromDays(10)
-            }
         };
 
-        _dbContext.Users.Add(user);
-        await _dbContext.SaveChangesAsync();
+        _userService.GetByIdsWithEmailsAsync(
+            Arg.Is<IReadOnlyCollection<Guid>>(ids => ids.Contains(userId)),
+            Arg.Any<CancellationToken>())
+            .Returns((IReadOnlyDictionary<Guid, User>)new Dictionary<Guid, User>
+            {
+                [userId] = user,
+            });
+
         return user;
+    }
+
+    private void StubSuspendSucceeds(IReadOnlyCollection<Guid> suspendedIds)
+    {
+        _profileService.SuspendForMissingConsentAsync(
+            Arg.Any<IReadOnlyCollection<Guid>>(),
+            Arg.Any<Instant>(),
+            Arg.Any<CancellationToken>())
+            .Returns((IReadOnlySet<Guid>)suspendedIds.ToHashSet());
     }
 }

--- a/tests/Humans.Application.Tests/Services/AccountProvisioningServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/AccountProvisioningServiceTests.cs
@@ -208,6 +208,9 @@ public class AccountProvisioningServiceTests
             throw new NotSupportedException();
         public Task<ExpiredDeletionAnonymizationResult?> ApplyExpiredDeletionAnonymizationAsync(Guid userId, CancellationToken ct = default) =>
             throw new NotSupportedException();
+        public Task<IReadOnlyList<(Guid UserId, string DisplayName, string GoogleEmail)>>
+            BackfillNobodiesTeamGoogleEmailsAsync(CancellationToken ct = default) =>
+            throw new NotSupportedException();
     }
 
     private sealed class FakeUserEmailRepository : IUserEmailRepository

--- a/tests/Humans.Application.Tests/Services/ShiftDashboardMetricsTests.cs
+++ b/tests/Humans.Application.Tests/Services/ShiftDashboardMetricsTests.cs
@@ -718,6 +718,7 @@ public class ShiftDashboardMetricsTests : IDisposable
         public Task<int> GetRejectedGoogleEmailCountAsync(CancellationToken ct = default) => throw new NotSupportedException();
         public Task<IReadOnlyList<Guid>> GetAccountsDueForAnonymizationAsync(Instant now, CancellationToken ct = default) => throw new NotSupportedException();
         public Task<AnonymizedAccountSummary?> AnonymizeExpiredAccountAsync(Guid userId, Instant now, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task<IReadOnlyList<(Guid UserId, string DisplayName, string GoogleEmail)>> BackfillNobodiesTeamGoogleEmailsAsync(CancellationToken ct = default) => throw new NotSupportedException();
     }
 
     private sealed class FakeTeamService : ITeamService
@@ -817,5 +818,11 @@ public class ShiftDashboardMetricsTests : IDisposable
         public Task<IReadOnlyList<Guid>> GetActiveNonSystemTeamCoordinatorUserIdsAsync(CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<IReadOnlyList<TeamMember>> GetActiveMembersForTeamsAsync(IReadOnlyCollection<Guid> teamIds, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<IReadOnlyList<TeamMember>> GetActiveChildMembersByParentIdsAsync(IReadOnlyCollection<Guid> parentTeamIds, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<Team?> GetSystemTeamWithActiveMembersAsync(SystemTeamType type, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<IReadOnlyList<TeamMember>> GetActiveMembershipsForRoleReconciliationAsync(CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<int> ApplyMemberRoleChangesAsync(IReadOnlyCollection<(Guid TeamMemberId, TeamMemberRole Role)> changes, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<IReadOnlyList<Guid>> GetActiveDepartmentCoordinatorUserIdsAsync(CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<bool> IsActiveDepartmentCoordinatorAsync(Guid userId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<bool> ApplySystemTeamMembershipDeltaAsync(Guid teamId, IReadOnlyCollection<Guid> userIdsToAdd, IReadOnlyCollection<Guid> userIdsToRemove, Instant now, CancellationToken cancellationToken = default) => throw new NotSupportedException();
     }
 }

--- a/tests/Humans.Application.Tests/Services/SystemTeamSyncJobBarrioLeadsTests.cs
+++ b/tests/Humans.Application.Tests/Services/SystemTeamSyncJobBarrioLeadsTests.cs
@@ -1,17 +1,18 @@
 using AwesomeAssertions;
 using Humans.Application.Interfaces;
 using Humans.Application.Interfaces.AuditLog;
+using Humans.Application.Interfaces.Auth;
+using Humans.Application.Interfaces.Caching;
 using Humans.Application.Interfaces.Email;
 using Humans.Application.Interfaces.GoogleIntegration;
 using Humans.Application.Interfaces.Governance;
-using Humans.Application.Tests.Infrastructure;
+using Humans.Application.Interfaces.Profiles;
+using Humans.Application.Interfaces.Repositories;
+using Humans.Application.Interfaces.Teams;
+using Humans.Application.Interfaces.Users;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
-using Humans.Infrastructure.Data;
 using Humans.Infrastructure.Jobs;
-using Humans.Infrastructure.Repositories.Camps;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
@@ -26,131 +27,57 @@ namespace Humans.Application.Tests.Services;
 /// Covers #498: duplicate camp registration for a user who is already an active member of the
 /// Barrio Leads system team must not violate IX_team_members_active_unique.
 /// </summary>
-public class SystemTeamSyncJobBarrioLeadsTests : IDisposable
+/// <remarks>
+/// Rewritten for the §15 Google-writing jobs migration (issue #570): the job no
+/// longer owns a <c>HumansDbContext</c>, so the test coordinates through the
+/// <see cref="ITeamService"/> / <see cref="ICampRepository"/> seams. The
+/// Barrio Leads system team's <see cref="Team.Members"/> collection is stubbed
+/// so the job's idempotency guard can see the existing active membership
+/// without reading the DB directly.
+/// </remarks>
+public class SystemTeamSyncJobBarrioLeadsTests
 {
-    private readonly HumansDbContext _dbContext;
-    private readonly FakeClock _clock;
-    private readonly SystemTeamSyncJob _job;
-    private readonly IMemoryCache _cache = new MemoryCache(new MemoryCacheOptions());
+    private readonly FakeClock _clock = new(Instant.FromUtc(2026, 4, 15, 12, 0));
+    private readonly ITeamService _teamService = Substitute.For<ITeamService>();
+    private readonly IUserService _userService = Substitute.For<IUserService>();
+    private readonly IProfileService _profileService = Substitute.For<IProfileService>();
+    private readonly IApplicationDecisionService _applicationDecisionService = Substitute.For<IApplicationDecisionService>();
+    private readonly IRoleAssignmentService _roleAssignmentService = Substitute.For<IRoleAssignmentService>();
+    private readonly ITeamResourceService _teamResourceService = Substitute.For<ITeamResourceService>();
+    private readonly ICampRepository _campRepository = Substitute.For<ICampRepository>();
+    private readonly IGoogleSyncService _googleSyncService = Substitute.For<IGoogleSyncService>();
+    private readonly IAuditLogService _auditLogService = Substitute.For<IAuditLogService>();
+    private readonly IEmailService _emailService = Substitute.For<IEmailService>();
+    private readonly IActiveTeamsCacheInvalidator _activeTeamsInvalidator = Substitute.For<IActiveTeamsCacheInvalidator>();
+    private readonly IRoleAssignmentClaimsCacheInvalidator _roleAssignmentClaimsInvalidator = Substitute.For<IRoleAssignmentClaimsCacheInvalidator>();
+    private readonly IHumansMetrics _metrics = Substitute.For<IHumansMetrics>();
 
-    public SystemTeamSyncJobBarrioLeadsTests()
+    private SystemTeamSyncJob CreateJob()
     {
-        var options = new DbContextOptionsBuilder<HumansDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-        _dbContext = new HumansDbContext(options);
-        _clock = new FakeClock(Instant.FromUtc(2026, 4, 15, 12, 0));
-
-        var factory = new TestDbContextFactory(options);
-        var campRepo = new CampRepository(factory);
-
         var services = new ServiceCollection();
         services.AddSingleton(Substitute.For<IMembershipCalculator>());
         var provider = services.BuildServiceProvider();
 
-        _job = new SystemTeamSyncJob(
-            _dbContext,
-            campRepo,
+        return new SystemTeamSyncJob(
+            _teamService,
+            _userService,
+            _profileService,
+            _applicationDecisionService,
+            _roleAssignmentService,
+            _teamResourceService,
+            _campRepository,
             provider,
-            Substitute.For<IGoogleSyncService>(),
-            Substitute.For<IAuditLogService>(),
-            Substitute.For<IEmailService>(),
-            _cache,
-            Substitute.For<IHumansMetrics>(),
+            _googleSyncService,
+            _auditLogService,
+            _emailService,
+            _activeTeamsInvalidator,
+            _roleAssignmentClaimsInvalidator,
+            _metrics,
             NullLogger<SystemTeamSyncJob>.Instance,
             _clock);
     }
 
-    public void Dispose()
-    {
-        _cache.Dispose();
-        _dbContext.Dispose();
-        GC.SuppressFinalize(this);
-    }
-
-    [Fact]
-    public async Task SyncBarrioLeadsMembershipForUserAsync_UserAlreadyActiveMember_IsNoOp()
-    {
-        // Arrange: user is lead of one camp and already has an active team_members row
-        // for the Barrio Leads system team (as they would after registering a first camp).
-        var userId = Guid.NewGuid();
-        var team = await SeedBarrioLeadsTeamAsync();
-        var camp1 = await SeedCampAsync("camp-one");
-        var camp2 = await SeedCampAsync("camp-two");
-
-        _dbContext.CampLeads.Add(new CampLead
-        {
-            Id = Guid.NewGuid(),
-            CampId = camp1.Id,
-            UserId = userId,
-            Role = CampLeadRole.CoLead,
-            JoinedAt = _clock.GetCurrentInstant()
-        });
-        _dbContext.TeamMembers.Add(new TeamMember
-        {
-            Id = Guid.NewGuid(),
-            TeamId = team.Id,
-            UserId = userId,
-            Role = TeamMemberRole.Member,
-            JoinedAt = _clock.GetCurrentInstant()
-        });
-        await _dbContext.SaveChangesAsync();
-
-        // Simulate a second camp registration: add another CampLead row, then call sync.
-        _dbContext.CampLeads.Add(new CampLead
-        {
-            Id = Guid.NewGuid(),
-            CampId = camp2.Id,
-            UserId = userId,
-            Role = CampLeadRole.CoLead,
-            JoinedAt = _clock.GetCurrentInstant()
-        });
-        await _dbContext.SaveChangesAsync();
-
-        // Act + Assert: should NOT throw (previously failed with unique-index violation)
-        // and there should still be exactly one active membership after sync.
-        var act = async () => await _job.SyncBarrioLeadsMembershipForUserAsync(userId);
-        await act.Should().NotThrowAsync();
-
-        var activeRows = await _dbContext.TeamMembers
-            .Where(tm => tm.TeamId == team.Id && tm.UserId == userId && tm.LeftAt == null)
-            .CountAsync();
-        activeRows.Should().Be(1);
-    }
-
-    [Fact]
-    public async Task SyncBarrioLeadsMembershipForUserAsync_UserBecomesLead_AddsMembership()
-    {
-        // Arrange: team exists, user has a new CampLead but no TeamMember row yet.
-        var userId = Guid.NewGuid();
-        var team = await SeedBarrioLeadsTeamAsync();
-        var camp = await SeedCampAsync("new-camp");
-
-        _dbContext.CampLeads.Add(new CampLead
-        {
-            Id = Guid.NewGuid(),
-            CampId = camp.Id,
-            UserId = userId,
-            Role = CampLeadRole.CoLead,
-            JoinedAt = _clock.GetCurrentInstant()
-        });
-        await _dbContext.SaveChangesAsync();
-
-        // Act
-        await _job.SyncBarrioLeadsMembershipForUserAsync(userId);
-
-        // Assert: single active membership created.
-        var activeRows = await _dbContext.TeamMembers
-            .Where(tm => tm.TeamId == team.Id && tm.UserId == userId && tm.LeftAt == null)
-            .CountAsync();
-        activeRows.Should().Be(1);
-    }
-
-    // ------------------------------------------------------------------
-    // Seed helpers
-    // ------------------------------------------------------------------
-
-    private async Task<Team> SeedBarrioLeadsTeamAsync()
+    private Team StubBarrioLeadsTeam(IEnumerable<TeamMember>? activeMembers = null)
     {
         var team = new Team
         {
@@ -162,26 +89,79 @@ public class SystemTeamSyncJobBarrioLeadsTests : IDisposable
             IsActive = true,
             IsHidden = true,
             CreatedAt = _clock.GetCurrentInstant(),
-            UpdatedAt = _clock.GetCurrentInstant()
+            UpdatedAt = _clock.GetCurrentInstant(),
         };
-        _dbContext.Teams.Add(team);
-        await _dbContext.SaveChangesAsync();
+        if (activeMembers is not null)
+        {
+            foreach (var m in activeMembers)
+            {
+                team.Members.Add(m);
+            }
+        }
+        _teamService.GetSystemTeamWithActiveMembersAsync(
+            SystemTeamType.BarrioLeads, Arg.Any<CancellationToken>())
+            .Returns(team);
         return team;
     }
 
-    private async Task<Camp> SeedCampAsync(string slug)
+    [Fact]
+    public async Task SyncBarrioLeadsMembershipForUserAsync_UserAlreadyActiveMember_IsNoOp()
     {
-        var camp = new Camp
-        {
-            Id = Guid.NewGuid(),
-            Slug = slug,
-            ContactEmail = $"{slug}@example.com",
-            ContactPhone = "+34600000000",
-            CreatedAt = _clock.GetCurrentInstant(),
-            UpdatedAt = _clock.GetCurrentInstant()
-        };
-        _dbContext.Camps.Add(camp);
-        await _dbContext.SaveChangesAsync();
-        return camp;
+        // User is already an active member of Barrio Leads and is still a
+        // lead of at least one camp — the guard in the job should short-circuit.
+        var userId = Guid.NewGuid();
+        var team = StubBarrioLeadsTeam(
+            [
+                new TeamMember
+                {
+                    Id = Guid.NewGuid(),
+                    UserId = userId,
+                    Role = TeamMemberRole.Member,
+                    JoinedAt = _clock.GetCurrentInstant(),
+                    LeftAt = null,
+                },
+            ]);
+        _campRepository.IsLeadAnywhereAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        var job = CreateJob();
+
+        // Act + Assert: should not throw and must not call the membership
+        // delta apply path (otherwise a duplicate insert would surface).
+        var act = async () => await job.SyncBarrioLeadsMembershipForUserAsync(userId);
+        await act.Should().NotThrowAsync();
+
+        await _teamService.DidNotReceive().ApplySystemTeamMembershipDeltaAsync(
+            Arg.Any<Guid>(),
+            Arg.Any<IReadOnlyCollection<Guid>>(),
+            Arg.Any<IReadOnlyCollection<Guid>>(),
+            Arg.Any<Instant>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SyncBarrioLeadsMembershipForUserAsync_UserBecomesLead_AddsMembership()
+    {
+        // User is a new lead but not yet a team member — the job should
+        // enqueue the add via the bulk-delta service call.
+        var userId = Guid.NewGuid();
+        var team = StubBarrioLeadsTeam();
+        _campRepository.IsLeadAnywhereAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        _userService.GetByIdsAsync(
+            Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns((IReadOnlyDictionary<Guid, User>)new Dictionary<Guid, User>());
+
+        var job = CreateJob();
+
+        await job.SyncBarrioLeadsMembershipForUserAsync(userId);
+
+        await _teamService.Received(1).ApplySystemTeamMembershipDeltaAsync(
+            team.Id,
+            Arg.Is<IReadOnlyCollection<Guid>>(ids => ids.Contains(userId)),
+            Arg.Is<IReadOnlyCollection<Guid>>(ids => ids.Count == 0),
+            Arg.Any<Instant>(),
+            Arg.Any<CancellationToken>());
     }
 }

--- a/tests/Humans.Application.Tests/Services/SystemTeamSyncJobBarrioLeadsTests.cs
+++ b/tests/Humans.Application.Tests/Services/SystemTeamSyncJobBarrioLeadsTests.cs
@@ -40,15 +40,10 @@ public class SystemTeamSyncJobBarrioLeadsTests
     private readonly FakeClock _clock = new(Instant.FromUtc(2026, 4, 15, 12, 0));
     private readonly ITeamService _teamService = Substitute.For<ITeamService>();
     private readonly IUserService _userService = Substitute.For<IUserService>();
-    private readonly IProfileService _profileService = Substitute.For<IProfileService>();
-    private readonly IApplicationDecisionService _applicationDecisionService = Substitute.For<IApplicationDecisionService>();
-    private readonly IRoleAssignmentService _roleAssignmentService = Substitute.For<IRoleAssignmentService>();
-    private readonly ITeamResourceService _teamResourceService = Substitute.For<ITeamResourceService>();
     private readonly ICampRepository _campRepository = Substitute.For<ICampRepository>();
     private readonly IGoogleSyncService _googleSyncService = Substitute.For<IGoogleSyncService>();
     private readonly IAuditLogService _auditLogService = Substitute.For<IAuditLogService>();
     private readonly IEmailService _emailService = Substitute.For<IEmailService>();
-    private readonly IActiveTeamsCacheInvalidator _activeTeamsInvalidator = Substitute.For<IActiveTeamsCacheInvalidator>();
     private readonly IRoleAssignmentClaimsCacheInvalidator _roleAssignmentClaimsInvalidator = Substitute.For<IRoleAssignmentClaimsCacheInvalidator>();
     private readonly IHumansMetrics _metrics = Substitute.For<IHumansMetrics>();
 
@@ -61,16 +56,11 @@ public class SystemTeamSyncJobBarrioLeadsTests
         return new SystemTeamSyncJob(
             _teamService,
             _userService,
-            _profileService,
-            _applicationDecisionService,
-            _roleAssignmentService,
-            _teamResourceService,
             _campRepository,
             provider,
             _googleSyncService,
             _auditLogService,
             _emailService,
-            _activeTeamsInvalidator,
             _roleAssignmentClaimsInvalidator,
             _metrics,
             NullLogger<SystemTeamSyncJob>.Instance,


### PR DESCRIPTION
## Summary

Completes the Google-writing slice of the Hangfire-jobs §15 migration
(issue #570) that was deferred from Lane 3 (peterdrier/Humans#303)
because the two remaining jobs depended on the \`GoogleWorkspaceSyncService\`
Application-layer migration that landed in peterdrier/Humans#304.

Both \`SystemTeamSyncJob\` and \`SuspendNonCompliantMembersJob\` now drop
\`HumansDbContext\` / \`IDbContextFactory<HumansDbContext>\` and \`IMemoryCache\`
completely; every read and write fans out through section services, and
cross-cutting cache invalidation routes through invalidator interfaces.

## Why

- **Design-rules §2c**: jobs must own no tables; DB access must go
  through the owning section's service.
- **§15i Google Workspace row**: the last two jobs still holding direct
  DbContext handles were blocked on \`GoogleWorkspaceSyncService\` moving
  to Application first (landed in #304). With that in place, this PR
  clears the row.
- **Cache ownership**: \`IMemoryCache\` injections in jobs violate
  \"cache ownership follows data ownership\" — every invalidation is now
  a domain-specific invalidator signal instead.

## What changed

### New cross-cutting invalidator

- \`IActiveTeamsCacheInvalidator\` (owned by Teams section,
  \`Humans.Application/Interfaces/Caching/\`) — exposes the ActiveTeams
  cache eviction as a cross-cutting signal. Implementation in
  \`Humans.Infrastructure/Caching/MemoryCacheInvalidators.cs\`.

### SuspendNonCompliantMembersJob

- Injects \`IUserService\` / \`IProfileService\` / \`ITeamService\`
  instead of \`HumansDbContext\`.
- New \`IProfileService.SuspendForMissingConsentAsync\` (backed by
  \`IProfileRepository.SuspendManyAsync\`) owns the
  \`Profile.IsSuspended = true\` + \`UpdatedAt\` bulk write and returns
  the set of user ids actually mutated. The caching decorator refreshes
  \`FullProfile\` for each mutated user.
- \`IUserService.GetByIdsWithEmailsAsync\` hydrates email + display
  name + language for notifications.
- \`ITeamService.GetUserTeamsAsync\` replaces the
  \`User.TeamMemberships\` Include chain for the Google-sync remove
  fan-out.
- Invalidators: \`IFullProfileInvalidator\`,
  \`IRoleAssignmentClaimsCacheInvalidator\`,
  \`IShiftAuthorizationInvalidator\` (all existing); plus the existing
  \`ITeamService.RemoveMemberFromAllTeamsCache\` for the Teams cache.

### SystemTeamSyncJob

Injects section services + invalidators instead of \`HumansDbContext\` +
\`IMemoryCache\`. Added service methods (all additive, no signature
changes to existing methods):

- \`ITeamService.GetSystemTeamWithActiveMembersAsync\`
- \`ITeamService.GetActiveMembershipsForRoleReconciliationAsync\`
- \`ITeamService.ApplyMemberRoleChangesAsync\`
- \`ITeamService.GetActiveDepartmentCoordinatorUserIdsAsync\`
- \`ITeamService.IsActiveDepartmentCoordinatorAsync\`
- \`ITeamService.ApplySystemTeamMembershipDeltaAsync\` (bulk add/remove
  in a single save, cascades TeamRoleAssignment cleanup, bumps
  \`Team.UpdatedAt\`, invalidates the ActiveTeams cache)
- \`IApplicationDecisionService.GetActiveApprovedTierUserIdsAsync\`
- \`IApplicationDecisionService.HasActiveApprovedTierAsync\`
- \`IApplicationDecisionService.GetOtherActiveTierAssignmentsAsync\`
- \`IProfileService.DowngradeTierForExpiredAsync\` (caching decorator
  refreshes FullProfile for each downgraded user)
- \`IUserService.BackfillNobodiesTeamGoogleEmailsAsync\`

The Google sync fan-out
(\`AddUserToTeamResourcesAsync\` / \`RemoveUserFromTeamResourcesAsync\`)
stays outside the Teams section — same behavior the pre-migration
job had: per-user failures don't tear down the DB write.

The file-wide \`#pragma warning disable CS0618\` block is removed; the
only remaining cross-domain nav (\`User.GetEffectiveEmail\` in the
added-to-team email path) is now narrowed to a two-line pragma.

### Parallel-agent conflict awareness

A sibling agent is simultaneously refactoring \`ProcessGoogleSyncOutboxJob\`
+ \`GoogleController\` + \`TeamService.EnqueueGoogleSyncAsync\` on another
branch (issue #576). This PR's \`TeamService\` edits are **purely additive** —
six new methods appended in a dedicated \"System team sync support\" section
near the end of the class / interface. No renames, no signature changes
to existing methods. Rebase conflicts should be trivial.

## Test plan

- [x] \`dotnet build Humans.slnx -v quiet\` — clean
- [x] \`dotnet test tests/Humans.Domain.Tests -v quiet\` — 116 passed
- [x] \`dotnet test tests/Humans.Application.Tests -v quiet\` — 1585 passed
- [ ] Preview-environment sanity check: hourly \`SystemTeamSync\` + the
      daily \`SuspendNonCompliantMembers\` run should show no new errors
      after deploy.

## References

- Completes the Google-writing slice of #570 deferred from
  peterdrier/Humans#303.
- Depends on: peterdrier/Humans#304 (GoogleWorkspaceSyncService Application migration).
- Precedent: peterdrier/Humans#303 (Lane 3 non-Google jobs — same style).

🤖 Generated with [Claude Code](https://claude.com/claude-code)