### PR TITLE
fix: suppress cookie banner in e2e helper (#587)

### DIFF
--- a/tests/e2e/helpers/auth.ts
+++ b/tests/e2e/helpers/auth.ts
@@ -2,7 +2,27 @@ import { type Page, type APIResponse, expect } from '@playwright/test';
 
 const NAV_SELECTOR = '[data-testid="user-nav"], .navbar .dropdown:has(.profile-dropdown-menu)';
 
+/**
+ * Pre-seed the cookie-consent cookie so the banner never renders during tests.
+ * The banner (<div id="cookieConsent">) otherwise intercepts clicks on page
+ * elements (e.g. #nextBtn in the shift-preference wizard) and causes flaky
+ * failures. Mirrors the name/value/sameSite set by wwwroot/js/site.js when a
+ * user clicks "Accept".
+ */
+async function seedCookieConsent(page: Page): Promise<void> {
+  const targetUrl = process.env.BASE_URL || 'https://humans.n.burn.camp';
+  await page.context().addCookies([
+    {
+      name: 'cookieConsent',
+      value: 'accepted',
+      url: targetUrl,
+      sameSite: 'Lax',
+    },
+  ]);
+}
+
 async function loginAs(page: Page, slug: string): Promise<void> {
+  await seedCookieConsent(page);
   await page.goto(`/dev/login/${slug}`, { waitUntil: 'domcontentloaded' });
   await page.waitForSelector(NAV_SELECTOR);
 }


### PR DESCRIPTION
Closes nobodies-collective/Humans#587

## Summary

Pre-seed the `cookieConsent=accepted` cookie on the browser context in the Playwright login helper so the cookie-consent banner never renders during tests. The banner's full-width footer div was intercepting clicks on `#nextBtn` in the shift-preference wizard and caused three deterministic failures in `tests/e2e/tests/shift-preferences.spec.ts`.

The cookie name/value/sameSite mirror what `wwwroot/js/site.js` writes when a user clicks "Accept", so from the app's perspective it looks like the browser session already dismissed the banner.

## Change

- `tests/e2e/helpers/auth.ts`: new `seedCookieConsent(page)` helper invoked from `loginAs(...)` before the first `page.goto(...)`.

Test-only change; no change to cookie-banner behaviour in the app itself.

## Test plan

- [ ] `npx playwright test tests/shift-preferences.spec.ts` against `humans.n.burn.camp` — all 5 tests pass without retries
- [ ] Rest of the e2e suite still passes