### PR TITLE
feat(api): enable CORS on /api/barrios for nobodies.team (#577)

### DIFF
--- a/src/Humans.Web/Controllers/CampApiController.cs
+++ b/src/Humans.Web/Controllers/CampApiController.cs
@@ -1,11 +1,13 @@
 using Humans.Application.Interfaces.Camps;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Humans.Web.Controllers;
 
 [AllowAnonymous]
 [ApiController]
+[EnableCors("BarriosPublic")]
 [Route("api/barrios")]
 [Route("api/camps")]
 public class CampApiController : ControllerBase

--- a/src/Humans.Web/Program.cs
+++ b/src/Humans.Web/Program.cs
@@ -422,6 +422,17 @@ builder.Services.AddSession(options =>
 // Configure Localization
 builder.Services.AddLocalization();
 
+// CORS — allow the public nobodies.team website to fetch /api/barrios
+builder.Services.AddCors(options =>
+{
+    options.AddPolicy("BarriosPublic", policy =>
+    {
+        policy.WithOrigins("https://nobodies.team", "https://www.nobodies.team")
+            .WithMethods("GET")
+            .WithHeaders("Content-Type", "Accept");
+    });
+});
+
 // Add Controllers with Views
 builder.Services.AddControllersWithViews(options =>
     {
@@ -572,6 +583,8 @@ app.Use(async (context, next) =>
 app.UseMiddleware<CspNonceMiddleware>();
 
 app.UseRouting();
+
+app.UseCors();
 
 // Rate limiting
 app.UseRateLimiter();


### PR DESCRIPTION
Closes nobodies-collective/Humans#577

## Summary

Adds a named `BarriosPublic` CORS policy allowing GET from `https://nobodies.team` and `https://www.nobodies.team` and applies it to `CampApiController` via `[EnableCors]`.

Unblocks website PR `nobodies-collective/website#26`, which currently ships a static `barrios-data.json` snapshot as a workaround.

## Changes

- `Program.cs` — register `AddCors` policy + `UseCors()` between `UseRouting()` and `UseAuthentication()` (canonical placement).
- `CampApiController.cs` — `[EnableCors("BarriosPublic")]` on the class. The attribute covers both `/api/barrios/*` and `/api/camps/*` since they share the controller; both are public read-only routes so exposing them to the website origin is safe.

Policy restricts methods to `GET` and request headers to `Content-Type`/`Accept`. No credentials are allowed (the endpoints are anonymous, so there's nothing credentialed to leak).

## Test plan

- [ ] `dotnet build Humans.slnx -v quiet` — clean (verified locally).
- [ ] After deploy, `curl -H "Origin: https://nobodies.team" -D - https://humans.n.burn.camp/api/barrios/2026 -o /dev/null` shows `access-control-allow-origin: https://nobodies.team`.
- [ ] Preflight: `curl -X OPTIONS -H "Origin: https://nobodies.team" -H "Access-Control-Request-Method: GET" -D - https://humans.n.burn.camp/api/barrios/2026` returns 204 with CORS headers.
- [ ] nobodies.team website can drop the static snapshot once this + #578 land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)