### PR TITLE
feat(api): add isConfirmedForYear flag to /api/barrios/{year} (#578)

### DIFF
--- a/src/Humans.Application/Interfaces/Camps/ICampService.cs
+++ b/src/Humans.Application/Interfaces/Camps/ICampService.cs
@@ -247,7 +247,8 @@ public record CampPublicSummary(
     int TimesAtNowhere,
     bool IsSwissCamp,
     IReadOnlyList<CampLink>? Links,
-    string? WebOrSocialUrl);
+    string? WebOrSocialUrl,
+    bool IsConfirmedForYear);
 
 public record CampPlacementSummary(
     Guid Id,

--- a/src/Humans.Application/Services/Camps/CampService.cs
+++ b/src/Humans.Application/Services/Camps/CampService.cs
@@ -525,6 +525,7 @@ public sealed class CampService : ICampService, IUserDataContributor
     {
         var season = camp.Seasons.FirstOrDefault(s => s.Year == year);
         var firstImage = camp.Images.OrderBy(i => i.SortOrder).FirstOrDefault();
+        var status = season?.Status ?? CampSeasonStatus.Pending;
 
         return new CampPublicSummary(
             camp.Id,
@@ -537,11 +538,12 @@ public sealed class CampService : ICampService, IUserDataContributor
             (season?.AcceptingMembers ?? YesNoMaybe.No).ToString(),
             (season?.KidsWelcome ?? YesNoMaybe.No).ToString(),
             season?.SoundZone?.ToString(),
-            (season?.Status ?? CampSeasonStatus.Pending).ToString(),
+            status.ToString(),
             camp.TimesAtNowhere,
             camp.IsSwissCamp,
             camp.Links,
-            camp.WebOrSocialUrl);
+            camp.WebOrSocialUrl,
+            status is CampSeasonStatus.Active or CampSeasonStatus.Full);
     }
 
     private static CampPlacementSummary? CreateCampPlacementSummary(Camp camp, int year)


### PR DESCRIPTION
Closes nobodies-collective/Humans#578

## Summary

Adds an `isConfirmedForYear: boolean` field to the public `CampPublicSummary` DTO exposed at `/api/barrios/{year}` (and `/api/camps/{year}`). Semantics: `true` iff the camp season for the requested year is in `Active` or `Full` state — i.e. a barrio admin has approved the season.

## Scope caveat — what this does and doesn't do

**Does:** gives website consumers a single stable boolean to filter on without string-matching `status`. Forward-compatible: if we ever loosen the query to surface `Pending` seasons to admin callers, consumers that filter on `isConfirmedForYear === true` keep working.

**Does not:** introduce a distinct "lead-re-confirmed-for-year" signal separate from season status. The Gallo Group / 2026 case from the issue — a camp that was admin-approved but isn't actually attending — will still show as confirmed until someone flips the season to `Withdrawn`. That's a data fix, not an API change.

If we want lead-driven yearly re-confirmation (so camps have to positively opt in each year, and stale approvals don't pollute the public feed), that needs a new `ConfirmedAt` field on `CampSeason` + a lead-facing UI — a separate, larger issue. Happy to file one if it's wanted.

## Changes

- `ICampService.cs` — `CampPublicSummary` gains `bool IsConfirmedForYear` at the end of the positional record.
- `CampService.CreateCampPublicSummary` — populates it as `status is CampSeasonStatus.Active or CampSeasonStatus.Full`.

Existing consumers (tests, the /Barrios view, `/api/camps/...`) access fields by property name, not positionally, so no other call sites break.

## Test plan

- [ ] `dotnet build Humans.slnx -v quiet` — clean (verified locally).
- [ ] `dotnet test Humans.slnx -v quiet` — no regressions in CampServiceTests.
- [ ] After deploy: `curl https://humans.n.burn.camp/api/barrios/2026 | jq '.[0]'` shows `isConfirmedForYear: true`.
- [ ] Pairs with #577 (CORS); once both land, nobodies.team website can drop its static `barrios-data.json` snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)