### PR TITLE
Invert NotificationMeterProvider — push model (nobodies-collective/Humans#581)

### DIFF
--- a/docs/sections/Governance.md
+++ b/docs/sections/Governance.md
@@ -65,4 +65,4 @@ Governance runs on a plain repository + Scoped service — **no caching decorato
 
 ### Known incoming violations (other sections reading Governance tables)
 
-`OnboardingService`, `SendBoardDailyDigestJob`, `SendAdminDailyDigestJob`, `TermRenewalReminderJob`, `SystemTeamSyncJob`, and `NotificationMeterProvider` still read governance-owned tables directly for dashboard-counting and batch jobs. Those uses are allowed until the sections owning those services migrate to call `IApplicationDecisionService` / `IApplicationRepository` instead.
+`OnboardingService`, `SendBoardDailyDigestJob`, `SendAdminDailyDigestJob`, `TermRenewalReminderJob`, and `SystemTeamSyncJob` still read governance-owned tables directly for dashboard-counting and batch jobs. Those uses are allowed until the sections owning those services migrate to call `IApplicationDecisionService` / `IApplicationRepository` instead. Issue nobodies-collective/Humans#581 inverted the old pull-model `NotificationMeterProvider` to a push-model registry; Governance's own `BoardVotingMeterContributor` now lives in this section and calls `IApplicationDecisionService` directly.

--- a/src/Humans.Application/Interfaces/Notifications/INotificationMeterContributor.cs
+++ b/src/Humans.Application/Interfaces/Notifications/INotificationMeterContributor.cs
@@ -1,0 +1,76 @@
+using System.Security.Claims;
+using Humans.Application.DTOs;
+
+namespace Humans.Application.Interfaces.Notifications;
+
+/// <summary>
+/// Cache scope for a notification meter count.
+/// </summary>
+public enum NotificationMeterScope
+{
+    /// <summary>
+    /// Count is a cross-user aggregate (e.g. total applications pending). Shared
+    /// across all users; visibility filtered by role.
+    /// </summary>
+    Global,
+
+    /// <summary>
+    /// Count depends on the identity of the viewing user (e.g. applications this
+    /// board member has not yet voted on).
+    /// </summary>
+    PerUser,
+}
+
+/// <summary>
+/// A single notification meter contributed by an owning section. Sections register
+/// one contributor per meter via their DI extension; <see cref="INotificationMeterProvider"/>
+/// aggregates them into the navbar badge list with no section knowledge of its own.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the push-model replacement for the pre-§15 pull model where
+/// <see cref="INotificationMeterProvider"/> knew every section explicitly. Each section
+/// owns its meter: label, icon/action URL, priority, role visibility, and the count
+/// query (routed through the section's own service — no direct DB access).
+/// </para>
+/// <para>
+/// Global-scoped contributors must compute a user-agnostic count. The provider caches
+/// global meter results in a cross-user bundle (2-minute TTL) under
+/// <c>CacheKeys.NotificationMeters</c>, and the <see cref="user"/> argument to
+/// <see cref="BuildMeterAsync"/> is a sentinel empty principal for these. Per-user
+/// contributors receive the real principal and are invoked on every request — they
+/// self-cache if caching is desired.
+/// </para>
+/// </remarks>
+public interface INotificationMeterContributor
+{
+    /// <summary>
+    /// Stable identifier used in the global-meter cache dictionary and in diagnostic
+    /// logs. Must be unique across all registered contributors.
+    /// </summary>
+    string Key { get; }
+
+    /// <summary>
+    /// Whether this meter's count is a cross-user aggregate (<see cref="NotificationMeterScope.Global"/>)
+    /// or per-user (<see cref="NotificationMeterScope.PerUser"/>).
+    /// </summary>
+    NotificationMeterScope Scope { get; }
+
+    /// <summary>
+    /// Cheap synchronous role gate. Evaluated before <see cref="BuildMeterAsync"/> so
+    /// count queries are skipped entirely for users who would not see the meter.
+    /// </summary>
+    bool IsVisibleTo(ClaimsPrincipal user);
+
+    /// <summary>
+    /// Computes the meter. Returns <see langword="null"/> when the count is zero or
+    /// there is otherwise nothing to display. Only invoked when
+    /// <see cref="IsVisibleTo"/> returned <see langword="true"/>.
+    /// </summary>
+    /// <param name="user">
+    /// The viewing user for <see cref="NotificationMeterScope.PerUser"/>-scoped contributors.
+    /// For <see cref="NotificationMeterScope.Global"/> contributors this is a sentinel
+    /// empty principal — global contributors must produce a user-agnostic count.
+    /// </param>
+    Task<NotificationMeter?> BuildMeterAsync(ClaimsPrincipal user, CancellationToken cancellationToken);
+}

--- a/src/Humans.Application/Services/GoogleIntegration/FailedGoogleSyncMeterContributor.cs
+++ b/src/Humans.Application/Services/GoogleIntegration/FailedGoogleSyncMeterContributor.cs
@@ -1,0 +1,43 @@
+using System.Security.Claims;
+using Humans.Application.DTOs;
+using Humans.Application.Interfaces.GoogleIntegration;
+using Humans.Application.Interfaces.Notifications;
+using Humans.Domain.Constants;
+
+namespace Humans.Application.Services.GoogleIntegration;
+
+/// <summary>
+/// Meter: number of failed Google sync outbox events. Registered by the Google
+/// Integration section (which owns the <c>google_sync_outbox_events</c> table) per
+/// the push-model design in issue nobodies-collective/Humans#581.
+/// </summary>
+public sealed class FailedGoogleSyncMeterContributor : INotificationMeterContributor
+{
+    private readonly IGoogleSyncService _googleSyncService;
+
+    public FailedGoogleSyncMeterContributor(IGoogleSyncService googleSyncService)
+    {
+        _googleSyncService = googleSyncService;
+    }
+
+    public string Key => "FailedGoogleSync";
+
+    public NotificationMeterScope Scope => NotificationMeterScope.Global;
+
+    public bool IsVisibleTo(ClaimsPrincipal user) => user.IsInRole(RoleNames.Admin);
+
+    public async Task<NotificationMeter?> BuildMeterAsync(
+        ClaimsPrincipal user, CancellationToken cancellationToken)
+    {
+        var count = await _googleSyncService.GetFailedSyncEventCountAsync(cancellationToken);
+        if (count <= 0) return null;
+
+        return new NotificationMeter
+        {
+            Title = "Failed Google sync events",
+            Count = count,
+            ActionUrl = "/Google/Sync",
+            Priority = 7,
+        };
+    }
+}

--- a/src/Humans.Application/Services/Governance/BoardVotingMeterContributor.cs
+++ b/src/Humans.Application/Services/Governance/BoardVotingMeterContributor.cs
@@ -1,0 +1,67 @@
+using System.Security.Claims;
+using Humans.Application.DTOs;
+using Humans.Application.Interfaces.Governance;
+using Humans.Application.Interfaces.Notifications;
+using Humans.Domain.Constants;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Humans.Application.Services.Governance;
+
+/// <summary>
+/// Per-user meter: applications pending this board member's vote. Registered by the
+/// Governance section (which owns the <c>applications</c> and <c>board_votes</c>
+/// tables) per the push-model design in issue nobodies-collective/Humans#581.
+/// </summary>
+/// <remarks>
+/// Self-caches per user under <see cref="CacheKeys.VotingBadge"/> with a 2-minute TTL.
+/// The same cache key is read by <c>NavBadgesViewComponent</c> — keeping it unchanged
+/// preserves shared cache warmth between the navbar badge and the notifications meter.
+/// Invalidated by <see cref="IVotingBadgeCacheInvalidator"/> on vote submission.
+/// </remarks>
+public sealed class BoardVotingMeterContributor : INotificationMeterContributor
+{
+    private static readonly TimeSpan CacheDuration = TimeSpan.FromMinutes(2);
+
+    private readonly IApplicationDecisionService _applicationDecisionService;
+    private readonly IMemoryCache _cache;
+
+    public BoardVotingMeterContributor(
+        IApplicationDecisionService applicationDecisionService,
+        IMemoryCache cache)
+    {
+        _applicationDecisionService = applicationDecisionService;
+        _cache = cache;
+    }
+
+    public string Key => "BoardVoting";
+
+    public NotificationMeterScope Scope => NotificationMeterScope.PerUser;
+
+    public bool IsVisibleTo(ClaimsPrincipal user) => user.IsInRole(RoleNames.Board);
+
+    public async Task<NotificationMeter?> BuildMeterAsync(
+        ClaimsPrincipal user, CancellationToken cancellationToken)
+    {
+        var userIdClaim = user.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (!Guid.TryParse(userIdClaim, out var boardMemberUserId))
+            return null;
+
+        var cacheKey = CacheKeys.VotingBadge(boardMemberUserId);
+        var count = await _cache.GetOrCreateAsync(cacheKey, async entry =>
+        {
+            entry.AbsoluteExpirationRelativeToNow = CacheDuration;
+            return await _applicationDecisionService
+                .GetUnvotedApplicationCountAsync(boardMemberUserId, cancellationToken);
+        });
+
+        if (count <= 0) return null;
+
+        return new NotificationMeter
+        {
+            Title = "Applications pending your vote",
+            Count = count,
+            ActionUrl = "/OnboardingReview/BoardVoting",
+            Priority = 9,
+        };
+    }
+}

--- a/src/Humans.Application/Services/Notifications/NotificationMeterProvider.cs
+++ b/src/Humans.Application/Services/Notifications/NotificationMeterProvider.cs
@@ -1,13 +1,6 @@
 using System.Security.Claims;
 using Humans.Application.DTOs;
-using Humans.Application.Interfaces.GoogleIntegration;
-using Humans.Application.Interfaces.Governance;
 using Humans.Application.Interfaces.Notifications;
-using Humans.Application.Interfaces.Profiles;
-using Humans.Application.Interfaces.Teams;
-using Humans.Application.Interfaces.Tickets;
-using Humans.Application.Interfaces.Users;
-using Humans.Domain.Constants;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 
@@ -15,59 +8,53 @@ namespace Humans.Application.Services.Notifications;
 
 /// <summary>
 /// Application-layer implementation of <see cref="INotificationMeterProvider"/>.
-/// Provides live counter meters for admin/coordinator work queues. Counts
-/// are computed by calling into each owning section service
-/// (<see cref="IProfileService"/>, <see cref="IUserService"/>,
-/// <see cref="IGoogleSyncService"/>, <see cref="ITeamService"/>,
-/// <see cref="ITicketSyncService"/>, <see cref="IApplicationDecisionService"/>)
-/// and cached for ~2 minutes. No direct DB access.
+/// Pure aggregation + caching: discovers registered
+/// <see cref="INotificationMeterContributor"/>s via DI, filters by per-user role
+/// visibility, and collects their meters. Knows nothing about individual sections.
 /// </summary>
 /// <remarks>
 /// <para>
-/// This service replaces the pre-§15 <c>NotificationMeterProvider</c> that
-/// read <c>profiles</c>, <c>users</c>, <c>google_sync_outbox_events</c>,
-/// <c>team_join_requests</c>, <c>ticket_sync_states</c>, and
-/// <c>applications</c> directly. Per design-rules §2c the Notifications
-/// section owns <c>notifications</c>/<c>notification_recipients</c> only —
-/// every other table is reached through its owning section's public
-/// service interface.
+/// This service is the push-model registry for the admin/coordinator navbar work-queue
+/// badges. Each section registers one or more <see cref="INotificationMeterContributor"/>
+/// instances via its DI extension (issue nobodies-collective/Humans#581). The provider
+/// itself has zero knowledge of <c>IProfileService</c>, <c>IUserService</c>,
+/// <c>IGoogleSyncService</c>, <c>ITeamService</c>, <c>ITicketSyncService</c>, or
+/// <c>IApplicationDecisionService</c>.
 /// </para>
 /// <para>
-/// The meter counts cache (<see cref="CacheKeys.NotificationMeters"/>) is a
-/// short-TTL request-acceleration cache appropriate for <see cref="IMemoryCache"/>
-/// per §15i. Writes elsewhere invalidate it via
-/// <see cref="INotificationMeterCacheInvalidator"/>.
+/// Global-scoped contributors are cached as a cross-user bundle under
+/// <see cref="CacheKeys.NotificationMeters"/> with a 2-minute TTL (§15i request-
+/// acceleration cache). Writes elsewhere invalidate the bundle via
+/// <see cref="INotificationMeterCacheInvalidator"/>. Per-user contributors are invoked
+/// each request and self-cache if desired (e.g. board voting badge uses
+/// <see cref="CacheKeys.VotingBadge"/>).
+/// </para>
+/// <para>
+/// A failing contributor is isolated: it is logged and its meter is omitted for that
+/// request, without affecting other sections' meters in the same call.
 /// </para>
 /// </remarks>
 public sealed class NotificationMeterProvider : INotificationMeterProvider
 {
     private static readonly TimeSpan CacheDuration = TimeSpan.FromMinutes(2);
 
-    private readonly IProfileService _profileService;
-    private readonly IUserService _userService;
-    private readonly IGoogleSyncService _googleSyncService;
-    private readonly ITeamService _teamService;
-    private readonly ITicketSyncService _ticketSyncService;
-    private readonly IApplicationDecisionService _applicationDecisionService;
+    /// <summary>
+    /// Sentinel principal passed to <see cref="INotificationMeterContributor.BuildMeterAsync"/>
+    /// for <see cref="NotificationMeterScope.Global"/> contributors. Global contributors
+    /// must not read any identity claim off this value — its contents are undefined.
+    /// </summary>
+    private static readonly ClaimsPrincipal GlobalScopePrincipal = new();
+
+    private readonly IEnumerable<INotificationMeterContributor> _contributors;
     private readonly IMemoryCache _cache;
     private readonly ILogger<NotificationMeterProvider> _logger;
 
     public NotificationMeterProvider(
-        IProfileService profileService,
-        IUserService userService,
-        IGoogleSyncService googleSyncService,
-        ITeamService teamService,
-        ITicketSyncService ticketSyncService,
-        IApplicationDecisionService applicationDecisionService,
+        IEnumerable<INotificationMeterContributor> contributors,
         IMemoryCache cache,
         ILogger<NotificationMeterProvider> logger)
     {
-        _profileService = profileService;
-        _userService = userService;
-        _googleSyncService = googleSyncService;
-        _teamService = teamService;
-        _ticketSyncService = ticketSyncService;
-        _applicationDecisionService = applicationDecisionService;
+        _contributors = contributors;
         _cache = cache;
         _logger = logger;
     }
@@ -75,180 +62,109 @@ public sealed class NotificationMeterProvider : INotificationMeterProvider
     public async Task<IReadOnlyList<NotificationMeter>> GetMetersForUserAsync(
         ClaimsPrincipal user, CancellationToken cancellationToken = default)
     {
-        var counts = await GetCachedCountsAsync(cancellationToken);
-        var meters = new List<NotificationMeter>();
+        ArgumentNullException.ThrowIfNull(user);
 
-        var isAdmin = user.IsInRole(RoleNames.Admin);
-        var isBoard = user.IsInRole(RoleNames.Board);
-        var isVolunteerCoordinator = user.IsInRole(RoleNames.VolunteerCoordinator);
-        var isConsentCoordinator = user.IsInRole(RoleNames.ConsentCoordinator);
+        var visible = _contributors.Where(c => c.IsVisibleTo(user)).ToList();
+        if (visible.Count == 0)
+            return [];
 
-        // Consent reviews pending — Consent Coordinator
-        if (isConsentCoordinator && counts.ConsentReviewsPending > 0)
+        // Global contributors are resolved from a shared cross-user cache bundle.
+        // The cache entry holds the last-computed meter (possibly null) for each
+        // global contributor key; per-user role visibility is re-applied above, so
+        // two users with different roles share the same cached counts.
+        Dictionary<string, NotificationMeter?>? globalBundle = null;
+        if (visible.Any(c => c.Scope == NotificationMeterScope.Global))
+            globalBundle = await GetCachedGlobalBundleAsync(cancellationToken);
+
+        var perUserTasks = visible
+            .Where(c => c.Scope == NotificationMeterScope.PerUser)
+            .Select(c => BuildPerUserMeterAsync(c, user, cancellationToken))
+            .ToList();
+        var perUserResults = await Task.WhenAll(perUserTasks);
+
+        var result = new List<NotificationMeter>(visible.Count);
+
+        if (globalBundle is not null)
         {
-            meters.Add(new NotificationMeter
+            foreach (var contributor in visible.Where(c => c.Scope == NotificationMeterScope.Global))
             {
-                Title = "Consent reviews pending",
-                Count = counts.ConsentReviewsPending,
-                ActionUrl = "/OnboardingReview",
-                Priority = 10,
-            });
-        }
-
-        // Applications pending board vote — Board (per-user count)
-        if (isBoard)
-        {
-            var userIdClaim = user.FindFirstValue(ClaimTypes.NameIdentifier);
-            if (Guid.TryParse(userIdClaim, out var boardMemberUserId))
-            {
-                var pendingVoteCount = await GetPerUserVotingCountAsync(boardMemberUserId, cancellationToken);
-                if (pendingVoteCount > 0)
-                {
-                    meters.Add(new NotificationMeter
-                    {
-                        Title = "Applications pending your vote",
-                        Count = pendingVoteCount,
-                        ActionUrl = "/OnboardingReview/BoardVoting",
-                        Priority = 9,
-                    });
-                }
+                if (globalBundle.TryGetValue(contributor.Key, out var meter) && meter is not null)
+                    result.Add(meter);
             }
         }
 
-        // Pending account deletions — Admin
-        if (isAdmin && counts.PendingDeletions > 0)
+        foreach (var meter in perUserResults)
         {
-            meters.Add(new NotificationMeter
-            {
-                Title = "Pending account deletions",
-                Count = counts.PendingDeletions,
-                ActionUrl = "/Profile/Admin?filter=deleting&sort=name&dir=asc",
-                Priority = 8,
-            });
+            if (meter is not null)
+                result.Add(meter);
         }
 
-        // Failed Google sync events — Admin
-        if (isAdmin && counts.FailedSyncEvents > 0)
-        {
-            meters.Add(new NotificationMeter
-            {
-                Title = "Failed Google sync events",
-                Count = counts.FailedSyncEvents,
-                ActionUrl = "/Google/Sync",
-                Priority = 7,
-            });
-        }
-
-        // Onboarding profiles pending — Board / Volunteer Coordinator
-        if ((isBoard || isVolunteerCoordinator) && counts.OnboardingPending > 0)
-        {
-            meters.Add(new NotificationMeter
-            {
-                Title = "Onboarding profiles pending",
-                Count = counts.OnboardingPending,
-                ActionUrl = "/OnboardingReview",
-                Priority = 6,
-            });
-        }
-
-        // Team join requests pending — Admin (visible to admins since coordinators
-        // see their own team's requests on the team page)
-        if (isAdmin && counts.TeamJoinRequestsPending > 0)
-        {
-            meters.Add(new NotificationMeter
-            {
-                Title = "Team join requests pending",
-                Count = counts.TeamJoinRequestsPending,
-                ActionUrl = "/Teams/Summary",
-                Priority = 5,
-            });
-        }
-
-        // Ticket sync error — Admin
-        if (isAdmin && counts.TicketSyncError)
-        {
-            meters.Add(new NotificationMeter
-            {
-                Title = "Ticket sync error",
-                Count = 1,
-                ActionUrl = "/Tickets",
-                Priority = 4,
-            });
-        }
-
-        return meters;
+        return result;
     }
 
-    private async Task<MeterCounts> GetCachedCountsAsync(CancellationToken cancellationToken)
+    private async Task<Dictionary<string, NotificationMeter?>> GetCachedGlobalBundleAsync(
+        CancellationToken cancellationToken)
     {
-        var counts = await _cache.GetOrCreateAsync(CacheKeys.NotificationMeters, async entry =>
+        var bundle = await _cache.GetOrCreateAsync(CacheKeys.NotificationMeters, async entry =>
         {
             entry.AbsoluteExpirationRelativeToNow = CacheDuration;
-
-            try
-            {
-                return await ComputeCountsAsync(cancellationToken);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Failed to compute notification meter counts");
-                return new MeterCounts();
-            }
+            return await ComputeGlobalBundleAsync(cancellationToken);
         });
 
-        return counts!;
+        return bundle!;
     }
 
-    private async Task<int> GetPerUserVotingCountAsync(Guid boardMemberUserId, CancellationToken cancellationToken)
+    private async Task<Dictionary<string, NotificationMeter?>> ComputeGlobalBundleAsync(
+        CancellationToken cancellationToken)
     {
-        var cacheKey = CacheKeys.VotingBadge(boardMemberUserId);
-        return await _cache.GetOrCreateAsync(cacheKey, async entry =>
+        var globalContributors = _contributors
+            .Where(c => c.Scope == NotificationMeterScope.Global)
+            .ToList();
+
+        var tasks = globalContributors
+            .Select(c => BuildGlobalMeterAsync(c, cancellationToken))
+            .ToList();
+
+        var results = await Task.WhenAll(tasks);
+
+        var bundle = new Dictionary<string, NotificationMeter?>(StringComparer.Ordinal);
+        foreach (var (key, meter) in results)
+            bundle[key] = meter;
+        return bundle;
+    }
+
+    private async Task<(string Key, NotificationMeter? Meter)> BuildGlobalMeterAsync(
+        INotificationMeterContributor contributor, CancellationToken cancellationToken)
+    {
+        try
         {
-            entry.AbsoluteExpirationRelativeToNow = CacheDuration;
-            return await _applicationDecisionService
-                .GetUnvotedApplicationCountAsync(boardMemberUserId, cancellationToken);
-        });
-    }
-
-    private async Task<MeterCounts> ComputeCountsAsync(CancellationToken cancellationToken)
-    {
-        var consentReviewsPending = await _profileService.GetConsentReviewPendingCountAsync(cancellationToken);
-
-        var pendingDeletions = await _userService.GetPendingDeletionCountAsync(cancellationToken);
-
-        var failedSyncEvents = await _googleSyncService.GetFailedSyncEventCountAsync(cancellationToken);
-
-        // Onboarding profiles pending excludes consent-review items, matching
-        // the board digest "still onboarding" queue semantics.
-        var totalNotApproved = await _profileService
-            .GetNotApprovedAndNotSuspendedCountAsync(cancellationToken);
-        var onboardingPending = totalNotApproved - consentReviewsPending;
-        if (onboardingPending < 0)
-            onboardingPending = 0;
-
-        var teamJoinRequestsPending = await _teamService
-            .GetTotalPendingJoinRequestCountAsync(cancellationToken);
-
-        var ticketSyncError = await _ticketSyncService.IsInErrorStateAsync(cancellationToken);
-
-        return new MeterCounts
+            var meter = await contributor.BuildMeterAsync(GlobalScopePrincipal, cancellationToken);
+            return (contributor.Key, meter);
+        }
+        catch (Exception ex)
         {
-            ConsentReviewsPending = consentReviewsPending,
-            PendingDeletions = pendingDeletions,
-            FailedSyncEvents = failedSyncEvents,
-            OnboardingPending = onboardingPending,
-            TeamJoinRequestsPending = teamJoinRequestsPending,
-            TicketSyncError = ticketSyncError,
-        };
+            _logger.LogError(
+                ex,
+                "Notification meter contributor {Key} (global) failed; meter omitted this cycle",
+                contributor.Key);
+            return (contributor.Key, null);
+        }
     }
 
-    private sealed class MeterCounts
+    private async Task<NotificationMeter?> BuildPerUserMeterAsync(
+        INotificationMeterContributor contributor, ClaimsPrincipal user, CancellationToken cancellationToken)
     {
-        public int ConsentReviewsPending { get; init; }
-        public int PendingDeletions { get; init; }
-        public int FailedSyncEvents { get; init; }
-        public int OnboardingPending { get; init; }
-        public int TeamJoinRequestsPending { get; init; }
-        public bool TicketSyncError { get; init; }
+        try
+        {
+            return await contributor.BuildMeterAsync(user, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(
+                ex,
+                "Notification meter contributor {Key} (per-user) failed; meter omitted this request",
+                contributor.Key);
+            return null;
+        }
     }
 }

--- a/src/Humans.Application/Services/Profile/ConsentReviewsPendingMeterContributor.cs
+++ b/src/Humans.Application/Services/Profile/ConsentReviewsPendingMeterContributor.cs
@@ -1,0 +1,44 @@
+using System.Security.Claims;
+using Humans.Application.DTOs;
+using Humans.Application.Interfaces.Notifications;
+using Humans.Application.Interfaces.Profiles;
+using Humans.Domain.Constants;
+
+namespace Humans.Application.Services.Profile;
+
+/// <summary>
+/// Meter: number of profiles awaiting a Consent Coordinator review. Registered by
+/// the Profile section (which owns the <c>profiles</c> table) per the push-model
+/// design in issue nobodies-collective/Humans#581.
+/// </summary>
+public sealed class ConsentReviewsPendingMeterContributor : INotificationMeterContributor
+{
+    private readonly IProfileService _profileService;
+
+    public ConsentReviewsPendingMeterContributor(IProfileService profileService)
+    {
+        _profileService = profileService;
+    }
+
+    public string Key => "ConsentReviewsPending";
+
+    public NotificationMeterScope Scope => NotificationMeterScope.Global;
+
+    public bool IsVisibleTo(ClaimsPrincipal user) =>
+        user.IsInRole(RoleNames.ConsentCoordinator);
+
+    public async Task<NotificationMeter?> BuildMeterAsync(
+        ClaimsPrincipal user, CancellationToken cancellationToken)
+    {
+        var count = await _profileService.GetConsentReviewPendingCountAsync(cancellationToken);
+        if (count <= 0) return null;
+
+        return new NotificationMeter
+        {
+            Title = "Consent reviews pending",
+            Count = count,
+            ActionUrl = "/OnboardingReview",
+            Priority = 10,
+        };
+    }
+}

--- a/src/Humans.Application/Services/Profile/OnboardingPendingMeterContributor.cs
+++ b/src/Humans.Application/Services/Profile/OnboardingPendingMeterContributor.cs
@@ -1,0 +1,50 @@
+using System.Security.Claims;
+using Humans.Application.DTOs;
+using Humans.Application.Interfaces.Notifications;
+using Humans.Application.Interfaces.Profiles;
+using Humans.Domain.Constants;
+
+namespace Humans.Application.Services.Profile;
+
+/// <summary>
+/// Meter: number of profiles in the onboarding queue excluding those in consent
+/// review. Matches the board-digest "still onboarding" semantics — count is
+/// <c>totalNotApproved - consentReviewsPending</c>, clamped at zero. Registered by
+/// the Profile section per the push-model design in issue nobodies-collective/Humans#581.
+/// </summary>
+public sealed class OnboardingPendingMeterContributor : INotificationMeterContributor
+{
+    private readonly IProfileService _profileService;
+
+    public OnboardingPendingMeterContributor(IProfileService profileService)
+    {
+        _profileService = profileService;
+    }
+
+    public string Key => "OnboardingPending";
+
+    public NotificationMeterScope Scope => NotificationMeterScope.Global;
+
+    public bool IsVisibleTo(ClaimsPrincipal user) =>
+        user.IsInRole(RoleNames.Board) || user.IsInRole(RoleNames.VolunteerCoordinator);
+
+    public async Task<NotificationMeter?> BuildMeterAsync(
+        ClaimsPrincipal user, CancellationToken cancellationToken)
+    {
+        var totalNotApproved =
+            await _profileService.GetNotApprovedAndNotSuspendedCountAsync(cancellationToken);
+        var consentReviewsPending =
+            await _profileService.GetConsentReviewPendingCountAsync(cancellationToken);
+
+        var count = totalNotApproved - consentReviewsPending;
+        if (count <= 0) return null;
+
+        return new NotificationMeter
+        {
+            Title = "Onboarding profiles pending",
+            Count = count,
+            ActionUrl = "/OnboardingReview",
+            Priority = 6,
+        };
+    }
+}

--- a/src/Humans.Application/Services/Teams/TeamJoinRequestsPendingMeterContributor.cs
+++ b/src/Humans.Application/Services/Teams/TeamJoinRequestsPendingMeterContributor.cs
@@ -1,0 +1,47 @@
+using System.Security.Claims;
+using Humans.Application.DTOs;
+using Humans.Application.Interfaces.Notifications;
+using Humans.Application.Interfaces.Teams;
+using Humans.Domain.Constants;
+
+namespace Humans.Application.Services.Teams;
+
+/// <summary>
+/// Meter: number of pending team join requests across all teams. Registered by the
+/// Teams section (which owns the <c>team_join_requests</c> table) per the push-model
+/// design in issue nobodies-collective/Humans#581.
+/// </summary>
+/// <remarks>
+/// Coordinators see per-team join requests on the team page directly; this admin-wide
+/// meter intentionally shows only to global Admins.
+/// </remarks>
+public sealed class TeamJoinRequestsPendingMeterContributor : INotificationMeterContributor
+{
+    private readonly ITeamService _teamService;
+
+    public TeamJoinRequestsPendingMeterContributor(ITeamService teamService)
+    {
+        _teamService = teamService;
+    }
+
+    public string Key => "TeamJoinRequestsPending";
+
+    public NotificationMeterScope Scope => NotificationMeterScope.Global;
+
+    public bool IsVisibleTo(ClaimsPrincipal user) => user.IsInRole(RoleNames.Admin);
+
+    public async Task<NotificationMeter?> BuildMeterAsync(
+        ClaimsPrincipal user, CancellationToken cancellationToken)
+    {
+        var count = await _teamService.GetTotalPendingJoinRequestCountAsync(cancellationToken);
+        if (count <= 0) return null;
+
+        return new NotificationMeter
+        {
+            Title = "Team join requests pending",
+            Count = count,
+            ActionUrl = "/Teams/Summary",
+            Priority = 5,
+        };
+    }
+}

--- a/src/Humans.Application/Services/Tickets/TicketSyncErrorMeterContributor.cs
+++ b/src/Humans.Application/Services/Tickets/TicketSyncErrorMeterContributor.cs
@@ -1,0 +1,43 @@
+using System.Security.Claims;
+using Humans.Application.DTOs;
+using Humans.Application.Interfaces.Notifications;
+using Humans.Application.Interfaces.Tickets;
+using Humans.Domain.Constants;
+
+namespace Humans.Application.Services.Tickets;
+
+/// <summary>
+/// Meter: ticket sync error flag. Registered by the Tickets section (which owns the
+/// <c>ticket_sync_states</c> table) per the push-model design in issue
+/// nobodies-collective/Humans#581.
+/// </summary>
+public sealed class TicketSyncErrorMeterContributor : INotificationMeterContributor
+{
+    private readonly ITicketSyncService _ticketSyncService;
+
+    public TicketSyncErrorMeterContributor(ITicketSyncService ticketSyncService)
+    {
+        _ticketSyncService = ticketSyncService;
+    }
+
+    public string Key => "TicketSyncError";
+
+    public NotificationMeterScope Scope => NotificationMeterScope.Global;
+
+    public bool IsVisibleTo(ClaimsPrincipal user) => user.IsInRole(RoleNames.Admin);
+
+    public async Task<NotificationMeter?> BuildMeterAsync(
+        ClaimsPrincipal user, CancellationToken cancellationToken)
+    {
+        var inError = await _ticketSyncService.IsInErrorStateAsync(cancellationToken);
+        if (!inError) return null;
+
+        return new NotificationMeter
+        {
+            Title = "Ticket sync error",
+            Count = 1,
+            ActionUrl = "/Tickets",
+            Priority = 4,
+        };
+    }
+}

--- a/src/Humans.Application/Services/Users/PendingDeletionsMeterContributor.cs
+++ b/src/Humans.Application/Services/Users/PendingDeletionsMeterContributor.cs
@@ -1,0 +1,43 @@
+using System.Security.Claims;
+using Humans.Application.DTOs;
+using Humans.Application.Interfaces.Notifications;
+using Humans.Application.Interfaces.Users;
+using Humans.Domain.Constants;
+
+namespace Humans.Application.Services.Users;
+
+/// <summary>
+/// Meter: number of users pending account deletion. Registered by the Users section
+/// (which owns the <c>users</c> table) per the push-model design in issue
+/// nobodies-collective/Humans#581.
+/// </summary>
+public sealed class PendingDeletionsMeterContributor : INotificationMeterContributor
+{
+    private readonly IUserService _userService;
+
+    public PendingDeletionsMeterContributor(IUserService userService)
+    {
+        _userService = userService;
+    }
+
+    public string Key => "PendingDeletions";
+
+    public NotificationMeterScope Scope => NotificationMeterScope.Global;
+
+    public bool IsVisibleTo(ClaimsPrincipal user) => user.IsInRole(RoleNames.Admin);
+
+    public async Task<NotificationMeter?> BuildMeterAsync(
+        ClaimsPrincipal user, CancellationToken cancellationToken)
+    {
+        var count = await _userService.GetPendingDeletionCountAsync(cancellationToken);
+        if (count <= 0) return null;
+
+        return new NotificationMeter
+        {
+            Title = "Pending account deletions",
+            Count = count,
+            ActionUrl = "/Profile/Admin?filter=deleting&sort=name&dir=asc",
+            Priority = 8,
+        };
+    }
+}

--- a/src/Humans.Web/Extensions/Infrastructure/GoogleWorkspaceInfrastructureExtensions.cs
+++ b/src/Humans.Web/Extensions/Infrastructure/GoogleWorkspaceInfrastructureExtensions.cs
@@ -1,10 +1,12 @@
 using Humans.Application.Configuration;
+using Humans.Application.Interfaces.Notifications;
 using Humans.Application.Interfaces.Repositories;
 using Humans.Application.Services.Teams;
 using Humans.Infrastructure.Configuration;
 using Humans.Infrastructure.Jobs;
 using Humans.Infrastructure.Services;
 using Humans.Infrastructure.Services.GoogleWorkspace;
+using FailedGoogleSyncMeterContributor = Humans.Application.Services.GoogleIntegration.FailedGoogleSyncMeterContributor;
 using GoogleWorkspaceUserService = Humans.Application.Services.GoogleIntegration.GoogleWorkspaceUserService;
 using GoogleDriveActivityMonitorService = Humans.Application.Services.GoogleIntegration.DriveActivityMonitorService;
 using GoogleAdminService = Humans.Application.Services.GoogleIntegration.GoogleAdminService;
@@ -116,6 +118,12 @@ internal static class GoogleWorkspaceInfrastructureExtensions
         services.AddScoped<GoogleResourceReconciliationJob>();
         services.AddScoped<DriveActivityMonitorJob>();
         services.AddScoped<ProcessGoogleSyncOutboxJob>();
+
+        // Notification meter contributor owned by this section (push-model per
+        // issue nobodies-collective/Humans#581). Registered here rather than in
+        // a section extension because Google Integration's DI surface lives in
+        // the Infrastructure extensions file.
+        services.AddScoped<INotificationMeterContributor, FailedGoogleSyncMeterContributor>();
 
         return services;
     }

--- a/src/Humans.Web/Extensions/Sections/GovernanceSectionExtensions.cs
+++ b/src/Humans.Web/Extensions/Sections/GovernanceSectionExtensions.cs
@@ -1,6 +1,7 @@
 using Humans.Application.Interfaces.Caching;
 using Humans.Application.Interfaces.Gdpr;
 using Humans.Application.Interfaces.Governance;
+using Humans.Application.Interfaces.Notifications;
 using Humans.Application.Interfaces.Onboarding;
 using Humans.Application.Interfaces.Repositories;
 using Humans.Infrastructure.Caching;
@@ -8,6 +9,7 @@ using Humans.Infrastructure.Jobs;
 using Humans.Infrastructure.Repositories.Governance;
 using Humans.Infrastructure.Services;
 using GovernanceApplicationDecisionService = Humans.Application.Services.Governance.ApplicationDecisionService;
+using GovernanceBoardVotingMeterContributor = Humans.Application.Services.Governance.BoardVotingMeterContributor;
 using OnboardingOrchestratorService = Humans.Application.Services.Onboarding.OnboardingService;
 
 namespace Humans.Web.Extensions.Sections;
@@ -40,6 +42,12 @@ internal static class GovernanceSectionExtensions
         services.AddScoped<IOnboardingEligibilityQuery>(sp => sp.GetRequiredService<OnboardingOrchestratorService>());
 
         services.AddScoped<TermRenewalReminderJob>();
+
+        // Notification meter contributor owned by this section (push-model per
+        // issue nobodies-collective/Humans#581). Per-user scope; self-caches
+        // under CacheKeys.VotingBadge(userId) which is also read by
+        // NavBadgesViewComponent so cache warmth is shared.
+        services.AddScoped<INotificationMeterContributor, GovernanceBoardVotingMeterContributor>();
 
         return services;
     }

--- a/src/Humans.Web/Extensions/Sections/ProfileSectionExtensions.cs
+++ b/src/Humans.Web/Extensions/Sections/ProfileSectionExtensions.cs
@@ -1,6 +1,8 @@
 using Humans.Application.Interfaces.Caching;
 using Humans.Application.Interfaces.Gdpr;
+using Humans.Application.Interfaces.Notifications;
 using Humans.Application.Interfaces.Repositories;
+using Humans.Application.Services.Profile;
 using Humans.Infrastructure.Caching;
 using Humans.Infrastructure.HostedServices;
 using Humans.Infrastructure.Services;
@@ -88,6 +90,12 @@ internal static class ProfileSectionExtensions
         // in lazily per user. Failures are logged and swallowed; lazy population
         // still works.
         services.AddHostedService<FullProfileWarmupHostedService>();
+
+        // Notification meter contributors owned by this section (push-model per
+        // issue nobodies-collective/Humans#581). The cross-section provider in
+        // Notifications consumes IEnumerable<INotificationMeterContributor>.
+        services.AddScoped<INotificationMeterContributor, ConsentReviewsPendingMeterContributor>();
+        services.AddScoped<INotificationMeterContributor, OnboardingPendingMeterContributor>();
 
         return services;
     }

--- a/src/Humans.Web/Extensions/Sections/TeamsSectionExtensions.cs
+++ b/src/Humans.Web/Extensions/Sections/TeamsSectionExtensions.cs
@@ -1,11 +1,13 @@
 using Humans.Application.Interfaces.Caching;
 using Humans.Application.Interfaces.Gdpr;
 using Humans.Application.Interfaces.GoogleIntegration;
+using Humans.Application.Interfaces.Notifications;
 using Humans.Application.Interfaces.Repositories;
 using Humans.Application.Interfaces.Teams;
 using Humans.Infrastructure.Caching;
 using Humans.Infrastructure.Jobs;
 using Humans.Infrastructure.Repositories.Teams;
+using TeamsTeamJoinRequestsPendingMeterContributor = Humans.Application.Services.Teams.TeamJoinRequestsPendingMeterContributor;
 using TeamsTeamPageService = Humans.Application.Services.Teams.TeamPageService;
 using TeamsTeamService = Humans.Application.Services.Teams.TeamService;
 
@@ -46,6 +48,10 @@ internal static class TeamsSectionExtensions
         services.AddScoped<IActiveTeamsCacheInvalidator, ActiveTeamsCacheInvalidator>();
 
         services.AddScoped<ISystemTeamSync, SystemTeamSyncJob>();
+
+        // Notification meter contributor owned by this section (push-model per
+        // issue nobodies-collective/Humans#581).
+        services.AddScoped<INotificationMeterContributor, TeamsTeamJoinRequestsPendingMeterContributor>();
 
         return services;
     }

--- a/src/Humans.Web/Extensions/Sections/TicketsSectionExtensions.cs
+++ b/src/Humans.Web/Extensions/Sections/TicketsSectionExtensions.cs
@@ -1,7 +1,9 @@
 using Humans.Application.Interfaces.Gdpr;
+using Humans.Application.Interfaces.Notifications;
 using Humans.Application.Interfaces.Repositories;
 using Humans.Infrastructure.Jobs;
 using Humans.Infrastructure.Services;
+using TicketsTicketSyncErrorMeterContributor = Humans.Application.Services.Tickets.TicketSyncErrorMeterContributor;
 using TicketsTicketSyncService = Humans.Application.Services.Tickets.TicketSyncService;
 using TicketsTicketQueryService = Humans.Application.Services.Tickets.TicketQueryService;
 using Humans.Application.Interfaces.Tickets;
@@ -28,6 +30,10 @@ internal static class TicketsSectionExtensions
 
         services.AddScoped<TicketSyncJob>();
         services.AddScoped<TicketingBudgetSyncJob>();
+
+        // Notification meter contributor owned by this section (push-model per
+        // issue nobodies-collective/Humans#581).
+        services.AddScoped<INotificationMeterContributor, TicketsTicketSyncErrorMeterContributor>();
 
         return services;
     }

--- a/src/Humans.Web/Extensions/Sections/UsersSectionExtensions.cs
+++ b/src/Humans.Web/Extensions/Sections/UsersSectionExtensions.cs
@@ -1,8 +1,10 @@
 using Humans.Application.Interfaces.Dashboard;
 using Humans.Application.Interfaces.Gdpr;
 using Humans.Application.Interfaces.Governance;
+using Humans.Application.Interfaces.Notifications;
 using Humans.Application.Interfaces.Repositories;
 using Humans.Application.Interfaces.Users;
+using Humans.Application.Services.Users;
 using Humans.Infrastructure.Repositories.Users;
 using DashboardDashboardService = Humans.Application.Services.Dashboard.DashboardService;
 using GovernanceMembershipCalculator = Humans.Application.Services.Governance.MembershipCalculator;
@@ -32,6 +34,10 @@ internal static class UsersSectionExtensions
         services.AddScoped<IMembershipQuery, GovernanceMembershipQuery>();
         services.AddScoped<IMembershipCalculator, GovernanceMembershipCalculator>();
         services.AddScoped<IDashboardService, DashboardDashboardService>();
+
+        // Notification meter contributor owned by this section (push-model per
+        // issue nobodies-collective/Humans#581).
+        services.AddScoped<INotificationMeterContributor, PendingDeletionsMeterContributor>();
 
         return services;
     }

--- a/tests/Humans.Application.Tests/Architecture/NotificationsArchitectureTests.cs
+++ b/tests/Humans.Application.Tests/Architecture/NotificationsArchitectureTests.cs
@@ -1,4 +1,5 @@
 using AwesomeAssertions;
+using Humans.Application.Interfaces.Notifications;
 using Humans.Application.Interfaces.Repositories;
 using Microsoft.EntityFrameworkCore;
 using Xunit;
@@ -121,36 +122,52 @@ public class NotificationsArchitectureTests
     }
 
     [Fact]
-    public void NotificationMeterProvider_TakesCrossSectionInterfaces()
+    public void NotificationMeterProvider_HasNoSectionServiceDependencies()
     {
-        // The meter provider computes badge counts by calling into each owning
-        // section service — IProfileService, IUserService, IGoogleSyncService,
-        // ITeamService, ITicketSyncService, IApplicationDecisionService — never
-        // reading the underlying tables directly.
+        // Push-model inversion (issue nobodies-collective/Humans#581): the
+        // provider is a pure registry/cache and must not depend on any section
+        // service. Sections register their own INotificationMeterContributor
+        // instances via section DI extensions; the provider consumes them
+        // through IEnumerable<INotificationMeterContributor> and knows nothing
+        // about individual sections.
         var ctor = typeof(NotificationMeterProvider).GetConstructors().Single();
         var paramTypeNames = ctor.GetParameters().Select(p => p.ParameterType.Name).ToList();
 
-        paramTypeNames.Should().Contain("IProfileService");
-        paramTypeNames.Should().Contain("IUserService");
-        paramTypeNames.Should().Contain("IGoogleSyncService");
-        paramTypeNames.Should().Contain("ITeamService");
-        paramTypeNames.Should().Contain("ITicketSyncService");
-        paramTypeNames.Should().Contain("IApplicationDecisionService");
+        paramTypeNames.Should().NotContain("IProfileService");
+        paramTypeNames.Should().NotContain("IUserService");
+        paramTypeNames.Should().NotContain("IGoogleSyncService");
+        paramTypeNames.Should().NotContain("ITeamService");
+        paramTypeNames.Should().NotContain("ITicketSyncService");
+        paramTypeNames.Should().NotContain("IApplicationDecisionService");
+    }
+
+    [Fact]
+    public void NotificationMeterProvider_ResolvesContributorsThroughEnumerableRegistry()
+    {
+        // The provider discovers meters by resolving every registered
+        // INotificationMeterContributor from DI (IEnumerable<T>). Any section
+        // can add a new meter purely by registering a contributor in its own
+        // DI extension; no changes to the provider are needed.
+        var ctor = typeof(NotificationMeterProvider).GetConstructors().Single();
+        var paramTypes = ctor.GetParameters().Select(p => p.ParameterType).ToList();
+
+        paramTypes.Should().Contain(typeof(IEnumerable<INotificationMeterContributor>),
+            because: "the push-model provider consumes contributors via IEnumerable<T> registry");
     }
 
     [Fact]
     public void NotificationMeterProvider_TakesNoRepositoryDependency()
     {
         // The meter provider does not own notifications/notification_recipients
-        // reads either — those stay with the inbox service. It is purely an
-        // aggregator across other sections' count methods.
+        // reads either — those stay with the inbox service. It is purely a
+        // registry/cache across other sections' contributors.
         var ctor = typeof(NotificationMeterProvider).GetConstructors().Single();
         var hasRepo = ctor.GetParameters()
             .Any(p => (p.ParameterType.Namespace ?? string.Empty)
                 .StartsWith("Humans.Application.Interfaces.Repositories", StringComparison.Ordinal));
 
         hasRepo.Should().BeFalse(
-            because: "the meter provider is a cross-section aggregator; it should not bypass any section's public service interface (design-rules §9)");
+            because: "the meter provider is a pure registry; it should not bypass any section's public service interface (design-rules §9)");
     }
 
     // ── INotificationRepository ──────────────────────────────────────────────

--- a/tests/Humans.Application.Tests/Services/NotificationMeterProviderTests.cs
+++ b/tests/Humans.Application.Tests/Services/NotificationMeterProviderTests.cs
@@ -1,44 +1,26 @@
 using System.Security.Claims;
 using AwesomeAssertions;
-using Humans.Application.Interfaces.GoogleIntegration;
-using Humans.Application.Interfaces.Governance;
-using Humans.Application.Interfaces.Profiles;
-using Humans.Application.Interfaces.Teams;
-using Humans.Application.Interfaces.Tickets;
-using Humans.Application.Interfaces.Users;
+using Humans.Application;
+using Humans.Application.DTOs;
+using Humans.Application.Interfaces.Notifications;
 using Humans.Domain.Constants;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging.Abstractions;
-using NSubstitute;
 using Xunit;
 using NotificationMeterProvider = Humans.Application.Services.Notifications.NotificationMeterProvider;
 
 namespace Humans.Application.Tests.Services;
 
+/// <summary>
+/// Covers the push-model inversion from issue nobodies-collective/Humans#581:
+/// <see cref="NotificationMeterProvider"/> discovers meters via registered
+/// <see cref="INotificationMeterContributor"/>s, filters by per-user role
+/// visibility, caches the global bundle for ~2 minutes, and isolates contributor
+/// failures so one section's exception cannot suppress another section's meter.
+/// </summary>
 public class NotificationMeterProviderTests : IDisposable
 {
-    private readonly IProfileService _profileService = Substitute.For<IProfileService>();
-    private readonly IUserService _userService = Substitute.For<IUserService>();
-    private readonly IGoogleSyncService _googleSyncService = Substitute.For<IGoogleSyncService>();
-    private readonly ITeamService _teamService = Substitute.For<ITeamService>();
-    private readonly ITicketSyncService _ticketSyncService = Substitute.For<ITicketSyncService>();
-    private readonly IApplicationDecisionService _applicationDecisionService = Substitute.For<IApplicationDecisionService>();
-    private readonly IMemoryCache _cache;
-    private readonly NotificationMeterProvider _provider;
-
-    public NotificationMeterProviderTests()
-    {
-        _cache = new MemoryCache(new MemoryCacheOptions());
-        _provider = new NotificationMeterProvider(
-            _profileService,
-            _userService,
-            _googleSyncService,
-            _teamService,
-            _ticketSyncService,
-            _applicationDecisionService,
-            _cache,
-            NullLogger<NotificationMeterProvider>.Instance);
-    }
+    private readonly IMemoryCache _cache = new MemoryCache(new MemoryCacheOptions());
 
     public void Dispose()
     {
@@ -47,97 +29,158 @@ public class NotificationMeterProviderTests : IDisposable
     }
 
     [Fact]
-    public async Task GetMetersForUserAsync_Board_OnboardingMeterExcludesConsentReviewItems()
+    public async Task GetMetersForUserAsync_Empty_WhenNoContributorsRegistered()
     {
-        // consentReviewsPending = 1, totalNotApproved = 2 → onboardingPending = 1
-        _profileService.GetConsentReviewPendingCountAsync(Arg.Any<CancellationToken>()).Returns(1);
-        _profileService.GetNotApprovedAndNotSuspendedCountAsync(Arg.Any<CancellationToken>()).Returns(2);
-        _userService.GetPendingDeletionCountAsync(Arg.Any<CancellationToken>()).Returns(0);
-        _googleSyncService.GetFailedSyncEventCountAsync(Arg.Any<CancellationToken>()).Returns(0);
-        _teamService.GetTotalPendingJoinRequestCountAsync(Arg.Any<CancellationToken>()).Returns(0);
-        _ticketSyncService.IsInErrorStateAsync(Arg.Any<CancellationToken>()).Returns(false);
-        _applicationDecisionService.GetUnvotedApplicationCountAsync(
-            Arg.Any<Guid>(), Arg.Any<CancellationToken>()).Returns(0);
-
-        var meters = await _provider.GetMetersForUserAsync(CreatePrincipal(RoleNames.Board));
-
-        var onboardingMeter = meters.Single(m =>
-            string.Equals(m.Title, "Onboarding profiles pending", StringComparison.Ordinal));
-        onboardingMeter.Count.Should().Be(1);
+        var provider = CreateProvider([]);
+        var meters = await provider.GetMetersForUserAsync(CreatePrincipal(RoleNames.Admin));
+        meters.Should().BeEmpty();
     }
 
     [Fact]
-    public async Task GetMetersForUserAsync_VolunteerCoordinator_SeesOnboardingMeter()
+    public async Task GetMetersForUserAsync_RespectsVisibility()
     {
-        _profileService.GetConsentReviewPendingCountAsync(Arg.Any<CancellationToken>()).Returns(0);
-        _profileService.GetNotApprovedAndNotSuspendedCountAsync(Arg.Any<CancellationToken>()).Returns(1);
-        _userService.GetPendingDeletionCountAsync(Arg.Any<CancellationToken>()).Returns(0);
-        _googleSyncService.GetFailedSyncEventCountAsync(Arg.Any<CancellationToken>()).Returns(0);
-        _teamService.GetTotalPendingJoinRequestCountAsync(Arg.Any<CancellationToken>()).Returns(0);
-        _ticketSyncService.IsInErrorStateAsync(Arg.Any<CancellationToken>()).Returns(false);
+        var admin = new StubContributor("admin-only", NotificationMeterScope.Global,
+            p => p.IsInRole(RoleNames.Admin),
+            new NotificationMeter { Title = "Admin meter", Count = 1, ActionUrl = "/a", Priority = 1 });
+        var board = new StubContributor("board-only", NotificationMeterScope.Global,
+            p => p.IsInRole(RoleNames.Board),
+            new NotificationMeter { Title = "Board meter", Count = 2, ActionUrl = "/b", Priority = 2 });
 
-        var meters = await _provider.GetMetersForUserAsync(CreatePrincipal(RoleNames.VolunteerCoordinator));
+        var provider = CreateProvider([admin, board]);
 
-        meters.Should().ContainSingle(m =>
-            string.Equals(m.Title, "Onboarding profiles pending", StringComparison.Ordinal) &&
-            string.Equals(m.ActionUrl, "/OnboardingReview", StringComparison.Ordinal));
+        var adminMeters = await provider.GetMetersForUserAsync(CreatePrincipal(RoleNames.Admin));
+        adminMeters.Should().ContainSingle().Which.Title.Should().Be("Admin meter");
+
+        var boardMeters = await provider.GetMetersForUserAsync(CreatePrincipal(RoleNames.Board));
+        boardMeters.Should().ContainSingle().Which.Title.Should().Be("Board meter");
+
+        var otherMeters = await provider.GetMetersForUserAsync(CreatePrincipal("Volunteer"));
+        otherMeters.Should().BeEmpty();
     }
 
     [Fact]
-    public async Task GetMetersForUserAsync_ConsentCoordinator_SeesConsentReviewsPending()
+    public async Task GetMetersForUserAsync_OmitsMetersReturningNull()
     {
-        _profileService.GetConsentReviewPendingCountAsync(Arg.Any<CancellationToken>()).Returns(3);
-        _profileService.GetNotApprovedAndNotSuspendedCountAsync(Arg.Any<CancellationToken>()).Returns(3);
-        _userService.GetPendingDeletionCountAsync(Arg.Any<CancellationToken>()).Returns(0);
-        _googleSyncService.GetFailedSyncEventCountAsync(Arg.Any<CancellationToken>()).Returns(0);
-        _teamService.GetTotalPendingJoinRequestCountAsync(Arg.Any<CancellationToken>()).Returns(0);
-        _ticketSyncService.IsInErrorStateAsync(Arg.Any<CancellationToken>()).Returns(false);
+        var visible = new StubContributor("v", NotificationMeterScope.Global,
+            _ => true,
+            new NotificationMeter { Title = "Keep", Count = 1, ActionUrl = "/k", Priority = 1 });
+        var nullMeter = new StubContributor("n", NotificationMeterScope.Global, _ => true, meter: null);
 
-        var meters = await _provider.GetMetersForUserAsync(CreatePrincipal(RoleNames.ConsentCoordinator));
+        var provider = CreateProvider([visible, nullMeter]);
+        var meters = await provider.GetMetersForUserAsync(CreatePrincipal(RoleNames.Admin));
 
-        meters.Should().ContainSingle(m =>
-            string.Equals(m.Title, "Consent reviews pending", StringComparison.Ordinal) &&
-            m.Count == 3);
+        meters.Should().ContainSingle().Which.Title.Should().Be("Keep");
     }
 
     [Fact]
-    public async Task GetMetersForUserAsync_Admin_SeesFailedSyncAndDeletionsAndTeamsAndTicketError()
+    public async Task GetMetersForUserAsync_FailingContributor_IsolatedFromOthers()
     {
-        _profileService.GetConsentReviewPendingCountAsync(Arg.Any<CancellationToken>()).Returns(0);
-        _profileService.GetNotApprovedAndNotSuspendedCountAsync(Arg.Any<CancellationToken>()).Returns(0);
-        _userService.GetPendingDeletionCountAsync(Arg.Any<CancellationToken>()).Returns(2);
-        _googleSyncService.GetFailedSyncEventCountAsync(Arg.Any<CancellationToken>()).Returns(5);
-        _teamService.GetTotalPendingJoinRequestCountAsync(Arg.Any<CancellationToken>()).Returns(7);
-        _ticketSyncService.IsInErrorStateAsync(Arg.Any<CancellationToken>()).Returns(true);
+        var good = new StubContributor("good", NotificationMeterScope.Global,
+            _ => true,
+            new NotificationMeter { Title = "Good", Count = 1, ActionUrl = "/g", Priority = 1 });
+        var bad = new StubContributor("bad", NotificationMeterScope.Global,
+            _ => true,
+            new InvalidOperationException("boom"));
 
-        var meters = await _provider.GetMetersForUserAsync(CreatePrincipal(RoleNames.Admin));
+        var provider = CreateProvider([good, bad]);
+        var meters = await provider.GetMetersForUserAsync(CreatePrincipal(RoleNames.Admin));
 
-        meters.Should().Contain(m => m.Title == "Pending account deletions" && m.Count == 2);
-        meters.Should().Contain(m => m.Title == "Failed Google sync events" && m.Count == 5);
-        meters.Should().Contain(m => m.Title == "Team join requests pending" && m.Count == 7);
-        meters.Should().Contain(m => m.Title == "Ticket sync error" && m.Count == 1);
+        meters.Should().ContainSingle().Which.Title.Should().Be("Good");
     }
 
     [Fact]
-    public async Task GetMetersForUserAsync_Board_PendingVoteMeter_UsesPerUserCount()
+    public async Task GetMetersForUserAsync_FailingPerUserContributor_IsolatedFromOthers()
     {
-        var boardUserId = Guid.NewGuid();
+        var badPerUser = new StubContributor("bad-user", NotificationMeterScope.PerUser,
+            _ => true,
+            new InvalidOperationException("boom"));
+        var goodGlobal = new StubContributor("good-global", NotificationMeterScope.Global,
+            _ => true,
+            new NotificationMeter { Title = "Good", Count = 1, ActionUrl = "/g", Priority = 1 });
 
-        _profileService.GetConsentReviewPendingCountAsync(Arg.Any<CancellationToken>()).Returns(0);
-        _profileService.GetNotApprovedAndNotSuspendedCountAsync(Arg.Any<CancellationToken>()).Returns(0);
-        _userService.GetPendingDeletionCountAsync(Arg.Any<CancellationToken>()).Returns(0);
-        _googleSyncService.GetFailedSyncEventCountAsync(Arg.Any<CancellationToken>()).Returns(0);
-        _teamService.GetTotalPendingJoinRequestCountAsync(Arg.Any<CancellationToken>()).Returns(0);
-        _ticketSyncService.IsInErrorStateAsync(Arg.Any<CancellationToken>()).Returns(false);
-        _applicationDecisionService.GetUnvotedApplicationCountAsync(
-            boardUserId, Arg.Any<CancellationToken>()).Returns(4);
+        var provider = CreateProvider([badPerUser, goodGlobal]);
+        var meters = await provider.GetMetersForUserAsync(CreatePrincipal(RoleNames.Admin));
 
-        var principal = CreatePrincipalWithId(boardUserId, RoleNames.Board);
-        var meters = await _provider.GetMetersForUserAsync(principal);
-
-        meters.Should().ContainSingle(m =>
-            m.Title == "Applications pending your vote" && m.Count == 4);
+        meters.Should().ContainSingle().Which.Title.Should().Be("Good");
     }
+
+    [Fact]
+    public async Task GetMetersForUserAsync_GlobalBundleCached_Within2Minutes()
+    {
+        var contributor = new StubContributor("c", NotificationMeterScope.Global,
+            _ => true,
+            new NotificationMeter { Title = "First", Count = 1, ActionUrl = "/x", Priority = 1 });
+
+        var provider = CreateProvider([contributor]);
+
+        var first = await provider.GetMetersForUserAsync(CreatePrincipal(RoleNames.Admin));
+        first.Should().ContainSingle().Which.Title.Should().Be("First");
+
+        // Flip the contributor's meter; without invalidation the cached bundle
+        // should still return the first value.
+        contributor.Meter = new NotificationMeter
+        { Title = "Second", Count = 2, ActionUrl = "/y", Priority = 1 };
+
+        var second = await provider.GetMetersForUserAsync(CreatePrincipal(RoleNames.Admin));
+        second.Should().ContainSingle().Which.Title.Should().Be("First");
+
+        contributor.InvocationCount.Should().Be(1, "global bundle is cached for 2 minutes");
+    }
+
+    [Fact]
+    public async Task GetMetersForUserAsync_GlobalBundle_InvalidatedBySharedInvalidator()
+    {
+        var contributor = new StubContributor("c", NotificationMeterScope.Global,
+            _ => true,
+            new NotificationMeter { Title = "First", Count = 1, ActionUrl = "/x", Priority = 1 });
+
+        var provider = CreateProvider([contributor]);
+        await provider.GetMetersForUserAsync(CreatePrincipal(RoleNames.Admin));
+
+        // Equivalent to INotificationMeterCacheInvalidator.Invalidate() — section
+        // writes clear the shared CacheKeys.NotificationMeters entry.
+        _cache.Remove(CacheKeys.NotificationMeters);
+
+        contributor.Meter = new NotificationMeter
+        { Title = "Second", Count = 2, ActionUrl = "/y", Priority = 1 };
+
+        var after = await provider.GetMetersForUserAsync(CreatePrincipal(RoleNames.Admin));
+        after.Should().ContainSingle().Which.Title.Should().Be("Second");
+        contributor.InvocationCount.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task GetMetersForUserAsync_PerUser_InvokedEveryRequest()
+    {
+        var contributor = new StubContributor("per-user", NotificationMeterScope.PerUser,
+            _ => true,
+            new NotificationMeter { Title = "Per user", Count = 1, ActionUrl = "/u", Priority = 1 });
+
+        var provider = CreateProvider([contributor]);
+
+        await provider.GetMetersForUserAsync(CreatePrincipal(RoleNames.Board));
+        await provider.GetMetersForUserAsync(CreatePrincipal(RoleNames.Board));
+
+        contributor.InvocationCount.Should().Be(2, "per-user contributors self-cache; provider does not share across calls");
+    }
+
+    [Fact]
+    public async Task GetMetersForUserAsync_InvisibleContributor_NotInvoked()
+    {
+        var invisible = new StubContributor("invisible", NotificationMeterScope.Global,
+            p => p.IsInRole(RoleNames.Board),
+            new NotificationMeter { Title = "Never", Count = 1, ActionUrl = "/z", Priority = 1 });
+
+        var provider = CreateProvider([invisible]);
+        var meters = await provider.GetMetersForUserAsync(CreatePrincipal("Volunteer"));
+
+        meters.Should().BeEmpty();
+        invisible.InvocationCount.Should().Be(0,
+            "not-visible contributors are filtered before the cache/build path runs");
+    }
+
+    private NotificationMeterProvider CreateProvider(IEnumerable<INotificationMeterContributor> contributors)
+        => new(contributors, _cache, NullLogger<NotificationMeterProvider>.Instance);
 
     private static ClaimsPrincipal CreatePrincipal(params string[] roles)
     {
@@ -146,11 +189,42 @@ public class NotificationMeterProviderTests : IDisposable
         return new ClaimsPrincipal(identity);
     }
 
-    private static ClaimsPrincipal CreatePrincipalWithId(Guid userId, params string[] roles)
+    private sealed class StubContributor : INotificationMeterContributor
     {
-        var claims = new List<Claim> { new(ClaimTypes.NameIdentifier, userId.ToString()) };
-        claims.AddRange(roles.Select(role => new Claim(ClaimTypes.Role, role)));
-        var identity = new ClaimsIdentity(claims, authenticationType: "Test");
-        return new ClaimsPrincipal(identity);
+        private readonly Func<ClaimsPrincipal, bool> _visibility;
+        private readonly Exception? _throw;
+
+        public StubContributor(string key, NotificationMeterScope scope,
+            Func<ClaimsPrincipal, bool> visibility, NotificationMeter? meter)
+        {
+            Key = key;
+            Scope = scope;
+            _visibility = visibility;
+            Meter = meter;
+        }
+
+        public StubContributor(string key, NotificationMeterScope scope,
+            Func<ClaimsPrincipal, bool> visibility, Exception toThrow)
+        {
+            Key = key;
+            Scope = scope;
+            _visibility = visibility;
+            _throw = toThrow;
+        }
+
+        public string Key { get; }
+        public NotificationMeterScope Scope { get; }
+        public NotificationMeter? Meter { get; set; }
+        public int InvocationCount { get; private set; }
+
+        public bool IsVisibleTo(ClaimsPrincipal user) => _visibility(user);
+
+        public Task<NotificationMeter?> BuildMeterAsync(ClaimsPrincipal user, CancellationToken cancellationToken)
+        {
+            InvocationCount++;
+            if (_throw is not null)
+                throw _throw;
+            return Task.FromResult(Meter);
+        }
     }
 }


### PR DESCRIPTION
## Summary

Flip `NotificationMeterProvider` from pull to push. The provider becomes a pure registry/cache with zero section knowledge; each section registers its own `INotificationMeterContributor` instances via its DI extension. Sections own their meters end-to-end: title, action URL, priority, role visibility, and the count query (routed through the section's own service — no direct DB access).

## Changes

- New interface `INotificationMeterContributor` (Application layer) with `Global` / `PerUser` scope and a cheap `IsVisibleTo(ClaimsPrincipal)` role gate.
- `NotificationMeterProvider` rewritten as a pure aggregator: resolves `IEnumerable<INotificationMeterContributor>` from DI, filters by visibility, invokes each in parallel with per-contributor try/catch, caches the global-scoped bundle at `CacheKeys.NotificationMeters` (2-minute TTL).
- Section ownership of the existing meters:
  - **Profile** → `ConsentReviewsPendingMeterContributor`, `OnboardingPendingMeterContributor`
  - **Users** → `PendingDeletionsMeterContributor`
  - **Google Integration** → `FailedGoogleSyncMeterContributor` (registered in `GoogleWorkspaceInfrastructureExtensions`)
  - **Teams** → `TeamJoinRequestsPendingMeterContributor`
  - **Tickets** → `TicketSyncErrorMeterContributor`
  - **Governance** → `BoardVotingMeterContributor` (per-user; self-caches under `CacheKeys.VotingBadge(userId)` so the existing `NavBadgesViewComponent` keeps cache warmth)
- Tests rewritten: `NotificationMeterProviderTests` covers registry semantics, visibility filtering, caching, invalidation, and per-contributor isolation. `NotificationsArchitectureTests` updated to enforce no section-service dependencies and `IEnumerable<INotificationMeterContributor>` registry.

## Verification

- [ ] Navbar / notifications popup badges for Admin role unchanged (Consent reviews, Onboarding, Pending deletions, Failed Google sync, Team join requests, Ticket sync error)
- [ ] Navbar badges for Board role unchanged (Applications pending your vote, Onboarding profiles pending)
- [ ] Navbar badges for Volunteer / Consent Coordinator roles unchanged
- [ ] `INotificationMeterCacheInvalidator.Invalidate()` on application decisions / team writes / profile changes still clears the global bundle
- [ ] `dotnet build` clean, `dotnet test` all green (1598 Application tests + 116 Domain + 35 Integration), `dotnet format --verify-no-changes` clean

## Hard requirement check

Per the issue spec: the inversion is of REGISTRATION LOCATION, not a feature change. No meter was added or removed. Meter titles, action URLs, priorities, and role-visibility rules are byte-for-byte identical to the pre-PR behaviour.

Closes nobodies-collective/Humans#581
Related: nobodies-collective/Humans#580 (sibling push-model inversion for HumansMetricsService)