### PR TITLE
Invert HumansMetricsService — push model (nobodies-collective/Humans#580)

### DIFF
--- a/docs/sections/Onboarding.md
+++ b/docs/sections/Onboarding.md
@@ -66,7 +66,7 @@ Onboarding is a pure orchestrator and owns no tables. It lives in
 - `IRoleAssignmentService` — cross-section Board-member resolution (`GetActiveUserIdsInRoleAsync`). Used from within `IApplicationDecisionService.GetBoardVotingDashboardAsync`.
 - `ISystemTeamSync` — Volunteers/Colaboradors/Asociados system team membership sync.
 - `IMembershipCalculator` — consent-check eligibility + admin-dashboard partition.
-- `IEmailService` / `INotificationService` / `INotificationInboxService` / `IHumansMetrics` / `ILogger` — cross-cutting concerns.
+- `IEmailService` / `INotificationService` / `INotificationInboxService` / `IOnboardingMetrics` / `ILogger` — cross-cutting concerns. `IOnboardingMetrics` is the Onboarding section's push-model metrics surface (issue nobodies-collective/Humans#580); `IHumansMetrics` no longer carries Record methods.
 
 The **DI cycle between `OnboardingService` and `ProfileService`/`ConsentService`** is broken by extracting the narrow `IOnboardingEligibilityQuery` interface (`SetConsentCheckPendingIfEligibleAsync(userId, ct)`). `OnboardingService` implements it; `ProfileService` and `ConsentService` depend on it instead of the full `IOnboardingService`.
 

--- a/src/Humans.Application/Interfaces/Auth/IRoleAssignmentService.cs
+++ b/src/Humans.Application/Interfaces/Auth/IRoleAssignmentService.cs
@@ -84,4 +84,13 @@ public interface IRoleAssignmentService
     /// </summary>
     Task<IReadOnlyList<Guid>> GetActiveUserIdsInRoleAsync(
         string roleName, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns the count of active role assignments grouped by role. Used by
+    /// the metrics gauge <c>humans.role_assignments_active</c> so the metrics
+    /// contributor does not read <c>role_assignments</c> directly
+    /// (design-rules §2c).
+    /// </summary>
+    Task<IReadOnlyList<(string Role, int Count)>> GetActiveCountsByRoleAsync(
+        CancellationToken ct = default);
 }

--- a/src/Humans.Application/Interfaces/Consent/IConsentMetrics.cs
+++ b/src/Humans.Application/Interfaces/Consent/IConsentMetrics.cs
@@ -1,0 +1,13 @@
+namespace Humans.Application.Interfaces.Consent;
+
+/// <summary>
+/// Consent section's metrics surface (issue nobodies-collective/Humans#580).
+/// </summary>
+public interface IConsentMetrics
+{
+    /// <summary>
+    /// Increments <c>humans.consents_given_total</c>. Called by
+    /// <c>ConsentService</c> on every successful consent-record INSERT.
+    /// </summary>
+    void RecordConsentGiven();
+}

--- a/src/Humans.Application/Interfaces/Email/IEmailMetrics.cs
+++ b/src/Humans.Application/Interfaces/Email/IEmailMetrics.cs
@@ -1,0 +1,34 @@
+namespace Humans.Application.Interfaces.Email;
+
+/// <summary>
+/// Email section's metrics surface (issue nobodies-collective/Humans#580).
+/// Call sites inject this interface directly; counter names live with the
+/// implementation rather than the cross-cutting <c>IHumansMetrics</c>.
+/// </summary>
+public interface IEmailMetrics
+{
+    /// <summary>
+    /// Increments <c>humans.emails_sent_total</c> with <c>template</c> tag.
+    /// Called by SMTP and outbox-processing paths after a successful send.
+    /// </summary>
+    void RecordSent(string template);
+
+    /// <summary>
+    /// Increments <c>humans.email_queued_total</c> with <c>template</c> tag.
+    /// Called by the outbox-queue writer when a new message is enqueued.
+    /// </summary>
+    void RecordQueued(string template);
+
+    /// <summary>
+    /// Increments <c>humans.email_failed_total</c> with <c>template</c> tag.
+    /// Called by the outbox processor when a send fails permanently.
+    /// </summary>
+    void RecordFailed(string template);
+
+    /// <summary>
+    /// Pushes the current outbox-pending count into the
+    /// <c>humans.email_outbox_pending</c> gauge. Written by the outbox
+    /// processor after each sweep.
+    /// </summary>
+    void SetOutboxPending(int count);
+}

--- a/src/Humans.Application/Interfaces/GoogleIntegration/IGoogleSyncMetrics.cs
+++ b/src/Humans.Application/Interfaces/GoogleIntegration/IGoogleSyncMetrics.cs
@@ -1,0 +1,14 @@
+namespace Humans.Application.Interfaces.GoogleIntegration;
+
+/// <summary>
+/// Google Integration section's metrics surface (issue nobodies-collective/Humans#580).
+/// </summary>
+public interface IGoogleSyncMetrics
+{
+    /// <summary>
+    /// Increments <c>humans.sync_operations_total</c> with the <c>result</c>
+    /// tag ("success", "failure", "permanent_failure"). Called by the
+    /// outbox-processor job after each batched operation.
+    /// </summary>
+    void RecordSyncOperation(string result);
+}

--- a/src/Humans.Application/Interfaces/Governance/IApplicationMetrics.cs
+++ b/src/Humans.Application/Interfaces/Governance/IApplicationMetrics.cs
@@ -1,0 +1,15 @@
+namespace Humans.Application.Interfaces.Governance;
+
+/// <summary>
+/// Governance section's metrics surface for tier-application processing
+/// (issue nobodies-collective/Humans#580).
+/// </summary>
+public interface IApplicationMetrics
+{
+    /// <summary>
+    /// Increments <c>humans.applications_processed_total</c> with the
+    /// <c>action</c> tag ("approved", "rejected", "withdrawn"). Called by
+    /// <c>ApplicationDecisionService</c> after each finalise action.
+    /// </summary>
+    void RecordApplicationProcessed(string action);
+}

--- a/src/Humans.Application/Interfaces/IHumansMetrics.cs
+++ b/src/Humans.Application/Interfaces/IHumansMetrics.cs
@@ -1,18 +1,82 @@
+using System.Diagnostics.Metrics;
+
 namespace Humans.Application.Interfaces;
 
 /// <summary>
-/// Records Prometheus metrics for business operations.
+/// Registration surface for application-level OpenTelemetry counters and gauges.
+/// Owns the singleton <c>Humans.Metrics</c> <see cref="Meter"/> and the 60-second
+/// gauge-snapshot refresh tick; has zero section knowledge.
 /// </summary>
+/// <remarks>
+/// <para>
+/// Sections register their own counters and gauges through this interface via
+/// <see cref="IMetricsContributor"/> — see issue nobodies-collective/Humans#580.
+/// Counter instances are returned to the caller so the owning section can
+/// increment them directly at the emission site; the pre-#580
+/// <c>RecordEmailSent</c>/<c>RecordJobRun</c>/etc. methods on this interface
+/// are gone and call sites now own their own <see cref="Counter{T}"/> references.
+/// </para>
+/// <para>
+/// Gauge callbacks read from section-owned in-memory state; the section's
+/// registered <see cref="RegisterGaugeRefresher"/> callback is invoked every
+/// ~60 seconds on the snapshot tick to refresh that state from its owning data
+/// source. A failing refresh callback is logged and isolated — one section's
+/// exception cannot blank another section's gauges.
+/// </para>
+/// </remarks>
 public interface IHumansMetrics
 {
-    void RecordEmailSent(string template);
-    void RecordConsentGiven();
-    void RecordMemberSuspended(string source);
-    void RecordVolunteerApproved();
-    void RecordSyncOperation(string result);
-    void RecordApplicationProcessed(string action);
-    void RecordJobRun(string job, string result);
-    void RecordEmailQueued(string template);
-    void RecordEmailFailed(string template);
-    void SetEmailOutboxPending(int count);
+    /// <summary>
+    /// Creates a counter on the <c>Humans.Metrics</c> meter and returns the
+    /// instance. The caller owns the returned <see cref="Counter{T}"/> and calls
+    /// <c>Add</c> directly; the metrics registry has no knowledge of counter
+    /// names or tags.
+    /// </summary>
+    Counter<T> CreateCounter<T>(string name, string? description = null) where T : struct;
+
+    /// <summary>
+    /// Registers a single-value observable gauge. <paramref name="observeValue"/>
+    /// is invoked by the OTel scrape pipeline and must read from section-owned
+    /// in-memory state — do not perform I/O in the callback.
+    /// </summary>
+    void CreateObservableGauge<T>(string name, Func<T> observeValue, string? description = null) where T : struct;
+
+    /// <summary>
+    /// Registers a multi-measurement observable gauge (emits multiple tagged
+    /// values per scrape — used for <c>status</c>-tagged or <c>role</c>-tagged
+    /// dimensions). <paramref name="observeValues"/> must read from section-owned
+    /// in-memory state; do not perform I/O in the callback.
+    /// </summary>
+    void CreateObservableGauge<T>(
+        string name,
+        Func<IEnumerable<Measurement<T>>> observeValues,
+        string? description = null) where T : struct;
+
+    /// <summary>
+    /// Registers a refresh callback invoked every ~60 seconds on the snapshot
+    /// tick. The callback is responsible for re-reading the section's data (via
+    /// its own repository/service inside a scope obtained from
+    /// <see cref="IServiceScopeFactory"/>) and updating the in-memory state that
+    /// its gauge callbacks read from. Per-callback try/catch in the registry
+    /// isolates failures.
+    /// </summary>
+    void RegisterGaugeRefresher(Func<CancellationToken, Task> refresher);
+}
+
+/// <summary>
+/// Sections implement <see cref="IMetricsContributor"/> to participate in the
+/// push-model metrics registration (issue nobodies-collective/Humans#580). The
+/// registry eagerly resolves every registered contributor at startup and calls
+/// <see cref="Initialize"/> exactly once, passing the shared
+/// <see cref="IHumansMetrics"/> registration surface.
+/// </summary>
+public interface IMetricsContributor
+{
+    /// <summary>
+    /// Called once at application startup. The contributor creates its counters
+    /// and gauges on <paramref name="metrics"/>, stores the returned
+    /// <see cref="Counter{T}"/> references on its own fields, and registers any
+    /// gauge refresh callbacks via <see cref="IHumansMetrics.RegisterGaugeRefresher"/>.
+    /// </summary>
+    void Initialize(IHumansMetrics metrics);
 }

--- a/src/Humans.Application/Interfaces/IJobRunMetrics.cs
+++ b/src/Humans.Application/Interfaces/IJobRunMetrics.cs
@@ -1,0 +1,21 @@
+namespace Humans.Application.Interfaces;
+
+/// <summary>
+/// Cross-cutting metrics surface for background job runs. Every Hangfire job
+/// records a success/failure outcome through this interface after each execution
+/// (issue nobodies-collective/Humans#580).
+/// </summary>
+/// <remarks>
+/// This does not belong to any single section — <c>humans.job_runs_total</c> is
+/// emitted from every job in <c>Humans.Infrastructure/Jobs/</c>. The contributor
+/// implementation lives in <c>Humans.Infrastructure</c> alongside the jobs that
+/// consume it.
+/// </remarks>
+public interface IJobRunMetrics
+{
+    /// <summary>
+    /// Increments <c>humans.job_runs_total</c> with <c>job</c> and
+    /// <c>result</c> tags (result = "success" / "failure" / "skipped").
+    /// </summary>
+    void RecordJobRun(string job, string result);
+}

--- a/src/Humans.Application/Interfaces/Onboarding/IOnboardingMetrics.cs
+++ b/src/Humans.Application/Interfaces/Onboarding/IOnboardingMetrics.cs
@@ -1,0 +1,19 @@
+namespace Humans.Application.Interfaces.Onboarding;
+
+/// <summary>
+/// Onboarding section's metrics surface (issue nobodies-collective/Humans#580).
+/// </summary>
+public interface IOnboardingMetrics
+{
+    /// <summary>
+    /// Increments <c>humans.volunteers_approved_total</c>. Called when a
+    /// volunteer is auto-approved after consent coordinator clearance.
+    /// </summary>
+    void RecordVolunteerApproved();
+
+    /// <summary>
+    /// Increments <c>humans.members_suspended_total</c> with <c>source</c>
+    /// tag ("admin", "job", ...). Called on every membership suspension.
+    /// </summary>
+    void RecordMemberSuspended(string source);
+}

--- a/src/Humans.Application/Interfaces/Profiles/IProfileService.cs
+++ b/src/Humans.Application/Interfaces/Profiles/IProfileService.cs
@@ -84,6 +84,17 @@ public interface IProfileService
     /// </summary>
     Task<int> GetNotApprovedAndNotSuspendedCountAsync(CancellationToken ct = default);
 
+    /// <summary>
+    /// Returns aggregate profile status counts:
+    /// <c>Approved</c> = IsApproved &amp;&amp; !IsSuspended;
+    /// <c>Suspended</c> = IsSuspended;
+    /// <c>Pending</c> = !IsApproved &amp;&amp; !IsSuspended.
+    /// Used by the metrics contributor for <c>humans.humans_total</c> /
+    /// <c>humans.pending_volunteers</c> so Profiles' gauge refresher does not
+    /// touch the <c>profiles</c> table directly (design-rules §2c).
+    /// </summary>
+    Task<ProfileStatusCounts> GetProfileStatusCountsAsync(CancellationToken ct = default);
+
     Task<IReadOnlyList<(Guid ProfileId, Guid UserId, long UpdatedAtTicks)>>
         GetCustomPictureInfoByUserIdsAsync(IEnumerable<Guid> userIds, CancellationToken ct = default);
 
@@ -248,3 +259,10 @@ public interface IProfileService
             Instant now,
             CancellationToken ct = default);
 }
+
+/// <summary>
+/// Aggregate profile status counts, returned by
+/// <see cref="IProfileService.GetProfileStatusCountsAsync"/>.
+/// </summary>
+[System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Auto)]
+public readonly record struct ProfileStatusCounts(int Approved, int Suspended, int Pending);

--- a/src/Humans.Application/Interfaces/Repositories/IProfileRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/IProfileRepository.cs
@@ -112,6 +112,12 @@ public interface IProfileRepository
     Task<int> GetNotApprovedAndNotSuspendedCountAsync(CancellationToken ct = default);
 
     /// <summary>
+    /// Returns aggregate profile status counts (Approved, Suspended, Pending).
+    /// Single query so the metrics gauge refresher avoids three round-trips.
+    /// </summary>
+    Task<(int Approved, int Suspended, int Pending)> GetStatusCountsAsync(CancellationToken ct = default);
+
+    /// <summary>
     /// Returns the languages for a profile, ordered by proficiency descending
     /// then language code. Read-only.
     /// </summary>

--- a/src/Humans.Application/Interfaces/Repositories/IRoleAssignmentRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/IRoleAssignmentRepository.cs
@@ -125,6 +125,14 @@ public interface IRoleAssignmentRepository
         Instant now,
         CancellationToken ct = default);
 
+    /// <summary>
+    /// Returns the count of active assignments grouped by <c>RoleName</c> at
+    /// <paramref name="now"/>. Used by the metrics contributor for the
+    /// <c>humans.role_assignments_active</c> gauge.
+    /// </summary>
+    Task<IReadOnlyList<(string Role, int Count)>> GetActiveCountsByRoleAsync(
+        Instant now, CancellationToken ct = default);
+
     // ==========================================================================
     // Writes
     // ==========================================================================

--- a/src/Humans.Application/Services/Auth/AuthMetricsContributor.cs
+++ b/src/Humans.Application/Services/Auth/AuthMetricsContributor.cs
@@ -1,0 +1,50 @@
+using System.Diagnostics.Metrics;
+using Humans.Application.Interfaces;
+using Humans.Application.Interfaces.Auth;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Humans.Application.Services.Auth;
+
+/// <summary>
+/// Auth section's push-model metrics contributor (issue nobodies-collective/Humans#580).
+/// Gauge-only. Owns <c>humans.role_assignments_active</c> (tagged by role).
+/// </summary>
+public sealed class AuthMetricsContributor : IMetricsContributor
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+
+    private IReadOnlyList<(string Role, int Count)> _snapshot = Array.Empty<(string, int)>();
+
+    public AuthMetricsContributor(IServiceScopeFactory scopeFactory)
+    {
+        _scopeFactory = scopeFactory;
+    }
+
+    public void Initialize(IHumansMetrics metrics)
+    {
+        metrics.CreateObservableGauge<int>(
+            "humans.role_assignments_active",
+            observeValues: ObserveRoleAssignments,
+            description: "Active role assignments by role");
+
+        metrics.RegisterGaugeRefresher(RefreshAsync);
+    }
+
+    private IEnumerable<Measurement<int>> ObserveRoleAssignments()
+    {
+        // Read the volatile reference once per scrape so the snapshot cannot
+        // flip mid-enumeration.
+        var snapshot = _snapshot;
+        foreach (var (role, count) in snapshot)
+        {
+            yield return new Measurement<int>(count, new KeyValuePair<string, object?>("role", role));
+        }
+    }
+
+    private async Task RefreshAsync(CancellationToken cancellationToken)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var roleAssignmentService = scope.ServiceProvider.GetRequiredService<IRoleAssignmentService>();
+        _snapshot = await roleAssignmentService.GetActiveCountsByRoleAsync(cancellationToken);
+    }
+}

--- a/src/Humans.Application/Services/Auth/RoleAssignmentService.cs
+++ b/src/Humans.Application/Services/Auth/RoleAssignmentService.cs
@@ -251,6 +251,10 @@ public sealed class RoleAssignmentService : IRoleAssignmentService, IUserDataCon
         string roleName, CancellationToken ct = default) =>
         _repository.GetActiveUserIdsInRoleAsync(roleName, _clock.GetCurrentInstant(), ct);
 
+    public Task<IReadOnlyList<(string Role, int Count)>> GetActiveCountsByRoleAsync(
+        CancellationToken ct = default) =>
+        _repository.GetActiveCountsByRoleAsync(_clock.GetCurrentInstant(), ct);
+
     public async Task<int> RevokeAllActiveAsync(Guid userId, CancellationToken ct = default)
     {
         var now = _clock.GetCurrentInstant();

--- a/src/Humans.Application/Services/Consent/ConsentMetricsContributor.cs
+++ b/src/Humans.Application/Services/Consent/ConsentMetricsContributor.cs
@@ -1,0 +1,68 @@
+using System.Diagnostics.Metrics;
+using Humans.Application.Interfaces;
+using Humans.Application.Interfaces.Consent;
+using Humans.Application.Interfaces.Governance;
+using Humans.Application.Interfaces.Users;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Humans.Application.Services.Consent;
+
+/// <summary>
+/// Consent section's push-model metrics contributor (issue nobodies-collective/Humans#580).
+/// Owns <c>humans.consents_given_total</c> and the two consent-related gauges
+/// <c>humans.pending_consents</c> / <c>humans.consent_deadline_approaching</c>,
+/// both of which are sourced from <see cref="IMembershipCalculator"/>.
+/// </summary>
+/// <remarks>
+/// Singleton so the counter reference and snapshot state persist across scopes.
+/// The gauge refresher opens a scope each tick to resolve the scoped
+/// <see cref="IMembershipCalculator"/> and <see cref="IUserService"/> safely.
+/// </remarks>
+public sealed class ConsentMetricsContributor : IConsentMetrics, IMetricsContributor
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+
+    private Counter<long> _consentsGiven = null!;
+    private volatile int _pendingConsents;
+    private volatile int _consentDeadlineApproaching;
+
+    public ConsentMetricsContributor(IServiceScopeFactory scopeFactory)
+    {
+        _scopeFactory = scopeFactory;
+    }
+
+    public void Initialize(IHumansMetrics metrics)
+    {
+        _consentsGiven = metrics.CreateCounter<long>(
+            "humans.consents_given_total",
+            description: "Total consent records created");
+
+        metrics.CreateObservableGauge<int>(
+            "humans.pending_consents",
+            observeValue: () => _pendingConsents,
+            description: "Users missing required consents");
+
+        metrics.CreateObservableGauge<int>(
+            "humans.consent_deadline_approaching",
+            observeValue: () => _consentDeadlineApproaching,
+            description: "Users past grace period not yet suspended");
+
+        metrics.RegisterGaugeRefresher(RefreshAsync);
+    }
+
+    public void RecordConsentGiven() => _consentsGiven.Add(1);
+
+    private async Task RefreshAsync(CancellationToken cancellationToken)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var membershipCalc = scope.ServiceProvider.GetRequiredService<IMembershipCalculator>();
+        var userService = scope.ServiceProvider.GetRequiredService<IUserService>();
+
+        var allUserIds = await userService.GetAllUserIdsAsync(cancellationToken);
+        var usersWithAllConsents = await membershipCalc.GetUsersWithAllRequiredConsentsAsync(allUserIds);
+        _pendingConsents = allUserIds.Count - usersWithAllConsents.Count;
+
+        var usersRequiringUpdate = await membershipCalc.GetUsersRequiringStatusUpdateAsync();
+        _consentDeadlineApproaching = usersRequiringUpdate.Count;
+    }
+}

--- a/src/Humans.Application/Services/Consent/ConsentService.cs
+++ b/src/Humans.Application/Services/Consent/ConsentService.cs
@@ -53,7 +53,7 @@ public sealed class ConsentService : IConsentService, IUserDataContributor
     private readonly ISystemTeamSync _syncJob;
     private readonly IProfileService _profileService;
     private readonly IServiceProvider _serviceProvider;
-    private readonly IHumansMetrics _metrics;
+    private readonly IConsentMetrics _metrics;
     private readonly IClock _clock;
     private readonly ILogger<ConsentService> _logger;
 
@@ -65,7 +65,7 @@ public sealed class ConsentService : IConsentService, IUserDataContributor
         ISystemTeamSync syncJob,
         IProfileService profileService,
         IServiceProvider serviceProvider,
-        IHumansMetrics metrics,
+        IConsentMetrics metrics,
         IClock clock,
         ILogger<ConsentService> logger)
     {

--- a/src/Humans.Application/Services/Email/EmailMetricsContributor.cs
+++ b/src/Humans.Application/Services/Email/EmailMetricsContributor.cs
@@ -1,0 +1,49 @@
+using System.Diagnostics.Metrics;
+using Humans.Application.Interfaces;
+using Humans.Application.Interfaces.Email;
+
+namespace Humans.Application.Services.Email;
+
+/// <summary>
+/// Email section's push-model metrics contributor (issue nobodies-collective/Humans#580).
+/// Owns the <c>humans.emails_sent_total</c>, <c>humans.email_queued_total</c>,
+/// <c>humans.email_failed_total</c> counters and the
+/// <c>humans.email_outbox_pending</c> gauge. Registered as a Singleton so the
+/// <see cref="Counter{T}"/> references and pending-count state persist across scopes.
+/// </summary>
+public sealed class EmailMetricsContributor : IEmailMetrics, IMetricsContributor
+{
+    private Counter<long> _sent = null!;
+    private Counter<long> _queued = null!;
+    private Counter<long> _failed = null!;
+    private volatile int _outboxPending;
+
+    public void Initialize(IHumansMetrics metrics)
+    {
+        _sent = metrics.CreateCounter<long>(
+            "humans.emails_sent_total",
+            description: "Total emails sent");
+        _queued = metrics.CreateCounter<long>(
+            "humans.email_queued_total",
+            description: "Total emails queued for sending");
+        _failed = metrics.CreateCounter<long>(
+            "humans.email_failed_total",
+            description: "Total email send failures");
+
+        metrics.CreateObservableGauge<int>(
+            "humans.email_outbox_pending",
+            observeValue: () => _outboxPending,
+            description: "Emails pending in the outbox queue");
+    }
+
+    public void RecordSent(string template) =>
+        _sent.Add(1, new KeyValuePair<string, object?>("template", template));
+
+    public void RecordQueued(string template) =>
+        _queued.Add(1, new KeyValuePair<string, object?>("template", template));
+
+    public void RecordFailed(string template) =>
+        _failed.Add(1, new KeyValuePair<string, object?>("template", template));
+
+    public void SetOutboxPending(int count) => _outboxPending = count;
+}

--- a/src/Humans.Application/Services/Email/OutboxEmailService.cs
+++ b/src/Humans.Application/Services/Email/OutboxEmailService.cs
@@ -1,7 +1,6 @@
 using System.Globalization;
 using System.Text.Json;
 using Humans.Application.DTOs;
-using Humans.Application.Interfaces;
 using Humans.Application.Interfaces.Email;
 using Humans.Application.Interfaces.Profiles;
 using Humans.Application.Interfaces.Repositories;
@@ -32,7 +31,7 @@ public sealed class OutboxEmailService : IEmailService
     private readonly IEmailRenderer _renderer;
     private readonly IEmailBodyComposer _bodyComposer;
     private readonly IImmediateOutboxProcessor _immediateProcessor;
-    private readonly IHumansMetrics _metrics;
+    private readonly IEmailMetrics _metrics;
     private readonly IClock _clock;
     private readonly ICommunicationPreferenceService _commPrefService;
     private readonly ILogger<OutboxEmailService> _logger;
@@ -43,7 +42,7 @@ public sealed class OutboxEmailService : IEmailService
         IEmailRenderer renderer,
         IEmailBodyComposer bodyComposer,
         IImmediateOutboxProcessor immediateProcessor,
-        IHumansMetrics metrics,
+        IEmailMetrics metrics,
         IClock clock,
         ICommunicationPreferenceService commPrefService,
         ILogger<OutboxEmailService> logger)
@@ -362,7 +361,7 @@ public sealed class OutboxEmailService : IEmailService
 
         await _outboxRepo.AddAsync(message, cancellationToken);
 
-        _metrics.RecordEmailQueued("campaign_code");
+        _metrics.RecordQueued("campaign_code");
         _logger.LogInformation(
             "Campaign code email queued for grant {GrantId} to {Recipient}",
             request.CampaignGrantId, request.RecipientEmail);
@@ -425,7 +424,7 @@ public sealed class OutboxEmailService : IEmailService
 
         await _outboxRepo.AddAsync(message, cancellationToken);
 
-        _metrics.RecordEmailQueued(templateName);
+        _metrics.RecordQueued(templateName);
         _logger.LogInformation("Email queued: {TemplateName} to {Recipient}", templateName, recipientEmail);
 
         if (triggerImmediate)

--- a/src/Humans.Application/Services/GoogleIntegration/GoogleIntegrationMetricsContributor.cs
+++ b/src/Humans.Application/Services/GoogleIntegration/GoogleIntegrationMetricsContributor.cs
@@ -1,0 +1,60 @@
+using System.Diagnostics.Metrics;
+using Humans.Application.Interfaces;
+using Humans.Application.Interfaces.GoogleIntegration;
+using Humans.Application.Interfaces.Repositories;
+using Humans.Application.Interfaces.Teams;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Humans.Application.Services.GoogleIntegration;
+
+/// <summary>
+/// Google Integration section's push-model metrics contributor (issue nobodies-collective/Humans#580).
+/// Owns the <c>humans.sync_operations_total</c> counter plus two gauges:
+/// <c>humans.google_sync_outbox_pending</c> and <c>humans.google_resources</c>.
+/// </summary>
+public sealed class GoogleIntegrationMetricsContributor : IGoogleSyncMetrics, IMetricsContributor
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+
+    private Counter<long> _syncOperations = null!;
+    private volatile int _pendingOutboxEvents;
+    private volatile int _googleResources;
+
+    public GoogleIntegrationMetricsContributor(IServiceScopeFactory scopeFactory)
+    {
+        _scopeFactory = scopeFactory;
+    }
+
+    public void Initialize(IHumansMetrics metrics)
+    {
+        _syncOperations = metrics.CreateCounter<long>(
+            "humans.sync_operations_total",
+            description: "Total Google sync operations");
+
+        metrics.CreateObservableGauge<int>(
+            "humans.google_sync_outbox_pending",
+            observeValue: () => _pendingOutboxEvents,
+            description: "Unprocessed Google sync outbox events");
+
+        metrics.CreateObservableGauge<int>(
+            "humans.google_resources",
+            observeValue: () => _googleResources,
+            description: "Total Google resources");
+
+        metrics.RegisterGaugeRefresher(RefreshAsync);
+    }
+
+    public void RecordSyncOperation(string result) =>
+        _syncOperations.Add(1, new KeyValuePair<string, object?>("result", result));
+
+    private async Task RefreshAsync(CancellationToken cancellationToken)
+    {
+        using var scope = _scopeFactory.CreateScope();
+
+        var outboxRepo = scope.ServiceProvider.GetRequiredService<IGoogleSyncOutboxRepository>();
+        _pendingOutboxEvents = await outboxRepo.CountPendingAsync(cancellationToken);
+
+        var teamResourceService = scope.ServiceProvider.GetRequiredService<ITeamResourceService>();
+        _googleResources = await teamResourceService.GetResourceCountAsync(cancellationToken);
+    }
+}

--- a/src/Humans.Application/Services/Governance/ApplicationDecisionService.cs
+++ b/src/Humans.Application/Services/Governance/ApplicationDecisionService.cs
@@ -44,7 +44,7 @@ public sealed class ApplicationDecisionService : IApplicationDecisionService, IU
     private readonly IEmailService _emailService;
     private readonly INotificationService _notificationService;
     private readonly ISystemTeamSync _syncJob;
-    private readonly IHumansMetrics _metrics;
+    private readonly IApplicationMetrics _metrics;
     private readonly INavBadgeCacheInvalidator _navBadge;
     private readonly INotificationMeterCacheInvalidator _notificationMeter;
     private readonly IVotingBadgeCacheInvalidator _votingBadge;
@@ -60,7 +60,7 @@ public sealed class ApplicationDecisionService : IApplicationDecisionService, IU
         IEmailService emailService,
         INotificationService notificationService,
         ISystemTeamSync syncJob,
-        IHumansMetrics metrics,
+        IApplicationMetrics metrics,
         INavBadgeCacheInvalidator navBadge,
         INotificationMeterCacheInvalidator notificationMeter,
         IVotingBadgeCacheInvalidator votingBadge,

--- a/src/Humans.Application/Services/Governance/GovernanceMetricsContributor.cs
+++ b/src/Humans.Application/Services/Governance/GovernanceMetricsContributor.cs
@@ -1,0 +1,67 @@
+using System.Diagnostics.Metrics;
+using Humans.Application.Interfaces;
+using Humans.Application.Interfaces.Governance;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Humans.Application.Services.Governance;
+
+/// <summary>
+/// Governance section's push-model metrics contributor (issue nobodies-collective/Humans#580).
+/// Owns the <c>humans.applications_processed_total</c> counter plus two gauges:
+/// <c>humans.asociados</c> (approved-application count) and
+/// <c>humans.applications_pending</c> (pending-by-status count).
+/// </summary>
+public sealed class GovernanceMetricsContributor : IApplicationMetrics, IMetricsContributor
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+
+    private Counter<long> _applicationsProcessed = null!;
+    private volatile int _asociados;
+    private volatile int _applicationsSubmitted;
+
+    public GovernanceMetricsContributor(IServiceScopeFactory scopeFactory)
+    {
+        _scopeFactory = scopeFactory;
+    }
+
+    public void Initialize(IHumansMetrics metrics)
+    {
+        _applicationsProcessed = metrics.CreateCounter<long>(
+            "humans.applications_processed_total",
+            description: "Total asociado applications processed");
+
+        metrics.CreateObservableGauge<int>(
+            "humans.asociados",
+            observeValue: () => _asociados,
+            description: "Approved asociado members");
+
+        metrics.CreateObservableGauge<int>(
+            "humans.applications_pending",
+            observeValues: ObserveApplicationsPending,
+            description: "Pending applications by status");
+
+        metrics.RegisterGaugeRefresher(RefreshAsync);
+    }
+
+    public void RecordApplicationProcessed(string action) =>
+        _applicationsProcessed.Add(1, new KeyValuePair<string, object?>("action", action));
+
+    private IEnumerable<Measurement<int>> ObserveApplicationsPending()
+    {
+        yield return new Measurement<int>(
+            _applicationsSubmitted,
+            new KeyValuePair<string, object?>("status", "submitted"));
+    }
+
+    private async Task RefreshAsync(CancellationToken cancellationToken)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var decisionService = scope.ServiceProvider.GetRequiredService<IApplicationDecisionService>();
+
+        // GetAdminStatsAsync returns Approved + pending counts; reusing it avoids
+        // duplicating count queries.
+        var stats = await decisionService.GetAdminStatsAsync(cancellationToken);
+        _asociados = stats.Approved;
+        _applicationsSubmitted = await decisionService.GetPendingApplicationCountAsync(cancellationToken);
+    }
+}

--- a/src/Humans.Application/Services/Legal/LegalMetricsContributor.cs
+++ b/src/Humans.Application/Services/Legal/LegalMetricsContributor.cs
@@ -1,0 +1,41 @@
+using Humans.Application.Interfaces;
+using Humans.Application.Interfaces.Legal;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Humans.Application.Services.Legal;
+
+/// <summary>
+/// Legal section's push-model metrics contributor (issue nobodies-collective/Humans#580).
+/// Gauge-only. Owns <c>humans.legal_documents_active</c>.
+/// </summary>
+public sealed class LegalMetricsContributor : IMetricsContributor
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private volatile int _activeRequiredCount;
+
+    public LegalMetricsContributor(IServiceScopeFactory scopeFactory)
+    {
+        _scopeFactory = scopeFactory;
+    }
+
+    public void Initialize(IHumansMetrics metrics)
+    {
+        metrics.CreateObservableGauge<int>(
+            "humans.legal_documents_active",
+            observeValue: () => _activeRequiredCount,
+            description: "Active required legal documents");
+
+        metrics.RegisterGaugeRefresher(RefreshAsync);
+    }
+
+    private async Task RefreshAsync(CancellationToken cancellationToken)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var syncService = scope.ServiceProvider.GetRequiredService<ILegalDocumentSyncService>();
+
+        // Active documents include both Required and non-Required; filter in
+        // memory — the set is small (≈5 documents).
+        var activeDocs = await syncService.GetActiveDocumentsAsync(cancellationToken);
+        _activeRequiredCount = activeDocs.Count(d => d.IsRequired);
+    }
+}

--- a/src/Humans.Application/Services/Onboarding/OnboardingMetricsContributor.cs
+++ b/src/Humans.Application/Services/Onboarding/OnboardingMetricsContributor.cs
@@ -1,0 +1,30 @@
+using System.Diagnostics.Metrics;
+using Humans.Application.Interfaces;
+using Humans.Application.Interfaces.Onboarding;
+
+namespace Humans.Application.Services.Onboarding;
+
+/// <summary>
+/// Onboarding section's push-model metrics contributor (issue nobodies-collective/Humans#580).
+/// Counter-only; no gauges. Singleton so counter references persist across scopes.
+/// </summary>
+public sealed class OnboardingMetricsContributor : IOnboardingMetrics, IMetricsContributor
+{
+    private Counter<long> _volunteersApproved = null!;
+    private Counter<long> _membersSuspended = null!;
+
+    public void Initialize(IHumansMetrics metrics)
+    {
+        _volunteersApproved = metrics.CreateCounter<long>(
+            "humans.volunteers_approved_total",
+            description: "Total volunteers approved");
+        _membersSuspended = metrics.CreateCounter<long>(
+            "humans.members_suspended_total",
+            description: "Total member suspensions");
+    }
+
+    public void RecordVolunteerApproved() => _volunteersApproved.Add(1);
+
+    public void RecordMemberSuspended(string source) =>
+        _membersSuspended.Add(1, new KeyValuePair<string, object?>("source", source));
+}

--- a/src/Humans.Application/Services/Onboarding/OnboardingService.cs
+++ b/src/Humans.Application/Services/Onboarding/OnboardingService.cs
@@ -37,7 +37,7 @@ public sealed class OnboardingService : IOnboardingService
     private readonly INotificationInboxService _notificationInboxService;
     private readonly ISystemTeamSync _syncJob;
     private readonly IMembershipCalculator _membershipCalculator;
-    private readonly IHumansMetrics _metrics;
+    private readonly IOnboardingMetrics _metrics;
     private readonly ILogger<OnboardingService> _logger;
 
     public OnboardingService(
@@ -49,7 +49,7 @@ public sealed class OnboardingService : IOnboardingService
         INotificationInboxService notificationInboxService,
         ISystemTeamSync syncJob,
         IMembershipCalculator membershipCalculator,
-        IHumansMetrics metrics,
+        IOnboardingMetrics metrics,
         ILogger<OnboardingService> logger)
     {
         _profileService = profileService;

--- a/src/Humans.Application/Services/Profile/ProfileService.cs
+++ b/src/Humans.Application/Services/Profile/ProfileService.cs
@@ -390,6 +390,12 @@ public sealed class ProfileService : IProfileService, IUserDataContributor
     public Task<int> GetNotApprovedAndNotSuspendedCountAsync(CancellationToken ct = default) =>
         _profileRepository.GetNotApprovedAndNotSuspendedCountAsync(ct);
 
+    public async Task<ProfileStatusCounts> GetProfileStatusCountsAsync(CancellationToken ct = default)
+    {
+        var (approved, suspended, pending) = await _profileRepository.GetStatusCountsAsync(ct);
+        return new ProfileStatusCounts(approved, suspended, pending);
+    }
+
     public Task<IReadOnlyList<(Guid ProfileId, Guid UserId, long UpdatedAtTicks)>>
         GetCustomPictureInfoByUserIdsAsync(IEnumerable<Guid> userIds, CancellationToken ct = default) =>
         _profileRepository.GetCustomPictureInfoByUserIdsAsync(userIds, ct);

--- a/src/Humans.Application/Services/Profile/ProfilesMetricsContributor.cs
+++ b/src/Humans.Application/Services/Profile/ProfilesMetricsContributor.cs
@@ -1,0 +1,75 @@
+using System.Diagnostics.Metrics;
+using Humans.Application.Interfaces;
+using Humans.Application.Interfaces.Profiles;
+using Humans.Application.Interfaces.Users;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Humans.Application.Services.Profile;
+
+/// <summary>
+/// Profiles section's push-model metrics contributor (issue nobodies-collective/Humans#580).
+/// Gauge-only, no counters. Owns:
+/// <list type="bullet">
+///   <item><c>humans.humans_total</c> — by status (active/suspended/pending/inactive).</item>
+///   <item><c>humans.pending_volunteers</c> — pending onboarding profiles.</item>
+/// </list>
+/// "Inactive" is the set of users with no profile row; the contributor reads the
+/// total user count from <see cref="IUserService"/> and partitions the profile
+/// status via <see cref="IProfileService"/>. Both reads go through owning-section
+/// services — no direct DB access.
+/// </summary>
+public sealed class ProfilesMetricsContributor : IMetricsContributor
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+
+    private volatile int _activeCount;
+    private volatile int _suspendedCount;
+    private volatile int _pendingCount;
+    private volatile int _inactiveCount;
+
+    public ProfilesMetricsContributor(IServiceScopeFactory scopeFactory)
+    {
+        _scopeFactory = scopeFactory;
+    }
+
+    public void Initialize(IHumansMetrics metrics)
+    {
+        metrics.CreateObservableGauge<int>(
+            "humans.humans_total",
+            observeValues: ObserveHumansTotal,
+            description: "Total humans by status");
+
+        metrics.CreateObservableGauge<int>(
+            "humans.pending_volunteers",
+            observeValue: () => _pendingCount,
+            description: "Volunteers awaiting board approval");
+
+        metrics.RegisterGaugeRefresher(RefreshAsync);
+    }
+
+    private IEnumerable<Measurement<int>> ObserveHumansTotal()
+    {
+        yield return new Measurement<int>(_activeCount, new KeyValuePair<string, object?>("status", "active"));
+        yield return new Measurement<int>(_suspendedCount, new KeyValuePair<string, object?>("status", "suspended"));
+        yield return new Measurement<int>(_pendingCount, new KeyValuePair<string, object?>("status", "pending"));
+        yield return new Measurement<int>(_inactiveCount, new KeyValuePair<string, object?>("status", "inactive"));
+    }
+
+    private async Task RefreshAsync(CancellationToken cancellationToken)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var profileService = scope.ServiceProvider.GetRequiredService<IProfileService>();
+        var userService = scope.ServiceProvider.GetRequiredService<IUserService>();
+
+        var statusCounts = await profileService.GetProfileStatusCountsAsync(cancellationToken);
+        var allUserIds = await userService.GetAllUserIdsAsync(cancellationToken);
+
+        var totalProfiles = statusCounts.Approved + statusCounts.Suspended + statusCounts.Pending;
+
+        _activeCount = statusCounts.Approved;
+        _suspendedCount = statusCounts.Suspended;
+        _pendingCount = statusCounts.Pending;
+        // Inactive = users without a profile row.
+        _inactiveCount = Math.Max(0, allUserIds.Count - totalProfiles);
+    }
+}

--- a/src/Humans.Application/Services/Teams/TeamsMetricsContributor.cs
+++ b/src/Humans.Application/Services/Teams/TeamsMetricsContributor.cs
@@ -1,0 +1,66 @@
+using System.Diagnostics.Metrics;
+using Humans.Application.Interfaces;
+using Humans.Application.Interfaces.Teams;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Humans.Application.Services.Teams;
+
+/// <summary>
+/// Teams section's push-model metrics contributor (issue nobodies-collective/Humans#580).
+/// Gauge-only: <c>humans.teams</c> (by status) and
+/// <c>humans.team_join_requests_pending</c>. No counters owned by this section.
+/// </summary>
+public sealed class TeamsMetricsContributor : IMetricsContributor
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+
+    private volatile int _teamsActive;
+    private volatile int _teamsInactive;
+    private volatile int _teamJoinRequestsPending;
+
+    public TeamsMetricsContributor(IServiceScopeFactory scopeFactory)
+    {
+        _scopeFactory = scopeFactory;
+    }
+
+    public void Initialize(IHumansMetrics metrics)
+    {
+        metrics.CreateObservableGauge<int>(
+            "humans.teams",
+            observeValues: ObserveTeams,
+            description: "Teams by status");
+
+        metrics.CreateObservableGauge<int>(
+            "humans.team_join_requests_pending",
+            observeValue: () => _teamJoinRequestsPending,
+            description: "Pending team join requests");
+
+        metrics.RegisterGaugeRefresher(RefreshAsync);
+    }
+
+    private IEnumerable<Measurement<int>> ObserveTeams()
+    {
+        yield return new Measurement<int>(_teamsActive, new KeyValuePair<string, object?>("status", "active"));
+        yield return new Measurement<int>(_teamsInactive, new KeyValuePair<string, object?>("status", "inactive"));
+    }
+
+    private async Task RefreshAsync(CancellationToken cancellationToken)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var teamService = scope.ServiceProvider.GetRequiredService<ITeamService>();
+
+        var allTeams = await teamService.GetAllTeamsAsync(cancellationToken);
+        var active = 0;
+        var inactive = 0;
+        foreach (var team in allTeams)
+        {
+            if (team.IsActive) active++;
+            else inactive++;
+        }
+        _teamsActive = active;
+        _teamsInactive = inactive;
+
+        _teamJoinRequestsPending =
+            await teamService.GetTotalPendingJoinRequestCountAsync(cancellationToken);
+    }
+}

--- a/src/Humans.Application/Services/Users/UsersMetricsContributor.cs
+++ b/src/Humans.Application/Services/Users/UsersMetricsContributor.cs
@@ -1,0 +1,37 @@
+using Humans.Application.Interfaces;
+using Humans.Application.Interfaces.Users;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Humans.Application.Services.Users;
+
+/// <summary>
+/// Users section's push-model metrics contributor (issue nobodies-collective/Humans#580).
+/// Gauge-only, no counters. Owns <c>humans.pending_deletions</c>.
+/// </summary>
+public sealed class UsersMetricsContributor : IMetricsContributor
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private volatile int _pendingDeletions;
+
+    public UsersMetricsContributor(IServiceScopeFactory scopeFactory)
+    {
+        _scopeFactory = scopeFactory;
+    }
+
+    public void Initialize(IHumansMetrics metrics)
+    {
+        metrics.CreateObservableGauge<int>(
+            "humans.pending_deletions",
+            observeValue: () => _pendingDeletions,
+            description: "Accounts scheduled for deletion");
+
+        metrics.RegisterGaugeRefresher(RefreshAsync);
+    }
+
+    private async Task RefreshAsync(CancellationToken cancellationToken)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var userService = scope.ServiceProvider.GetRequiredService<IUserService>();
+        _pendingDeletions = await userService.GetPendingDeletionCountAsync(cancellationToken);
+    }
+}

--- a/src/Humans.Infrastructure/Jobs/CleanupEmailOutboxJob.cs
+++ b/src/Humans.Infrastructure/Jobs/CleanupEmailOutboxJob.cs
@@ -15,14 +15,14 @@ public class CleanupEmailOutboxJob : IRecurringJob
     private readonly IEmailOutboxRepository _outboxRepo;
     private readonly IClock _clock;
     private readonly EmailSettings _settings;
-    private readonly IHumansMetrics _metrics;
+    private readonly IJobRunMetrics _metrics;
     private readonly ILogger<CleanupEmailOutboxJob> _logger;
 
     public CleanupEmailOutboxJob(
         IEmailOutboxRepository outboxRepo,
         IClock clock,
         IOptions<EmailSettings> settings,
-        IHumansMetrics metrics,
+        IJobRunMetrics metrics,
         ILogger<CleanupEmailOutboxJob> logger)
     {
         _outboxRepo = outboxRepo;

--- a/src/Humans.Infrastructure/Jobs/CleanupNotificationsJob.cs
+++ b/src/Humans.Infrastructure/Jobs/CleanupNotificationsJob.cs
@@ -18,13 +18,13 @@ public class CleanupNotificationsJob : IRecurringJob
 
     private readonly INotificationRepository _notificationRepository;
     private readonly IClock _clock;
-    private readonly IHumansMetrics _metrics;
+    private readonly IJobRunMetrics _metrics;
     private readonly ILogger<CleanupNotificationsJob> _logger;
 
     public CleanupNotificationsJob(
         INotificationRepository notificationRepository,
         IClock clock,
-        IHumansMetrics metrics,
+        IJobRunMetrics metrics,
         ILogger<CleanupNotificationsJob> logger)
     {
         _notificationRepository = notificationRepository;

--- a/src/Humans.Infrastructure/Jobs/DriveActivityMonitorJob.cs
+++ b/src/Humans.Infrastructure/Jobs/DriveActivityMonitorJob.cs
@@ -12,13 +12,13 @@ namespace Humans.Infrastructure.Jobs;
 public class DriveActivityMonitorJob : IRecurringJob
 {
     private readonly IDriveActivityMonitorService _monitorService;
-    private readonly IHumansMetrics _metrics;
+    private readonly IJobRunMetrics _metrics;
     private readonly ILogger<DriveActivityMonitorJob> _logger;
     private readonly IClock _clock;
 
     public DriveActivityMonitorJob(
         IDriveActivityMonitorService monitorService,
-        IHumansMetrics metrics,
+        IJobRunMetrics metrics,
         ILogger<DriveActivityMonitorJob> logger,
         IClock clock)
     {

--- a/src/Humans.Infrastructure/Jobs/GoogleResourceProvisionJob.cs
+++ b/src/Humans.Infrastructure/Jobs/GoogleResourceProvisionJob.cs
@@ -10,12 +10,12 @@ namespace Humans.Infrastructure.Jobs;
 public class GoogleResourceProvisionJob
 {
     private readonly IGoogleSyncService _googleService;
-    private readonly IHumansMetrics _metrics;
+    private readonly IJobRunMetrics _metrics;
     private readonly ILogger<GoogleResourceProvisionJob> _logger;
 
     public GoogleResourceProvisionJob(
         IGoogleSyncService googleService,
-        IHumansMetrics metrics,
+        IJobRunMetrics metrics,
         ILogger<GoogleResourceProvisionJob> logger)
     {
         _googleService = googleService;

--- a/src/Humans.Infrastructure/Jobs/GoogleResourceReconciliationJob.cs
+++ b/src/Humans.Infrastructure/Jobs/GoogleResourceReconciliationJob.cs
@@ -16,14 +16,14 @@ public class GoogleResourceReconciliationJob : IRecurringJob
 {
     private readonly IGoogleSyncService _googleSyncService;
     private readonly INotificationService _notificationService;
-    private readonly IHumansMetrics _metrics;
+    private readonly IJobRunMetrics _metrics;
     private readonly ILogger<GoogleResourceReconciliationJob> _logger;
     private readonly IClock _clock;
 
     public GoogleResourceReconciliationJob(
         IGoogleSyncService googleSyncService,
         INotificationService notificationService,
-        IHumansMetrics metrics,
+        IJobRunMetrics metrics,
         ILogger<GoogleResourceReconciliationJob> logger,
         IClock clock)
     {

--- a/src/Humans.Infrastructure/Jobs/ProcessAccountDeletionsJob.cs
+++ b/src/Humans.Infrastructure/Jobs/ProcessAccountDeletionsJob.cs
@@ -27,7 +27,7 @@ public class ProcessAccountDeletionsJob : IRecurringJob
     private readonly IUserService _userService;
     private readonly IEmailService _emailService;
     private readonly IAuditLogService _auditLogService;
-    private readonly IHumansMetrics _metrics;
+    private readonly IJobRunMetrics _metrics;
     private readonly ILogger<ProcessAccountDeletionsJob> _logger;
     private readonly IClock _clock;
 
@@ -35,7 +35,7 @@ public class ProcessAccountDeletionsJob : IRecurringJob
         IUserService userService,
         IEmailService emailService,
         IAuditLogService auditLogService,
-        IHumansMetrics metrics,
+        IJobRunMetrics metrics,
         ILogger<ProcessAccountDeletionsJob> logger,
         IClock clock)
     {

--- a/src/Humans.Infrastructure/Jobs/ProcessEmailOutboxJob.cs
+++ b/src/Humans.Infrastructure/Jobs/ProcessEmailOutboxJob.cs
@@ -28,7 +28,8 @@ public class ProcessEmailOutboxJob : IRecurringJob
     private readonly IEmailOutboxRepository _outboxRepo;
     private readonly ICampaignService _campaignService;
     private readonly IEmailTransport _transport;
-    private readonly IHumansMetrics _metrics;
+    private readonly IEmailMetrics _emailMetrics;
+    private readonly IJobRunMetrics _jobMetrics;
     private readonly IClock _clock;
     private readonly EmailSettings _settings;
     private readonly ILogger<ProcessEmailOutboxJob> _logger;
@@ -37,7 +38,8 @@ public class ProcessEmailOutboxJob : IRecurringJob
         IEmailOutboxRepository outboxRepo,
         ICampaignService campaignService,
         IEmailTransport transport,
-        IHumansMetrics metrics,
+        IEmailMetrics emailMetrics,
+        IJobRunMetrics jobMetrics,
         IClock clock,
         IOptions<EmailSettings> settings,
         ILogger<ProcessEmailOutboxJob> logger)
@@ -45,7 +47,8 @@ public class ProcessEmailOutboxJob : IRecurringJob
         _outboxRepo = outboxRepo;
         _campaignService = campaignService;
         _transport = transport;
-        _metrics = metrics;
+        _emailMetrics = emailMetrics;
+        _jobMetrics = jobMetrics;
         _clock = clock;
         _settings = settings.Value;
         _logger = logger;
@@ -110,7 +113,7 @@ public class ProcessEmailOutboxJob : IRecurringJob
 
                 // Success — mark as sent BEFORE throttle delay to avoid re-send on cancellation
                 await _outboxRepo.MarkSentAsync(message.Id, now, cancellationToken);
-                _metrics.RecordEmailSent(message.TemplateName);
+                _emailMetrics.RecordSent(message.TemplateName);
 
                 // Update campaign grant status if applicable — routed via
                 // ICampaignService so the Campaigns section owns campaign_grants.
@@ -131,7 +134,7 @@ public class ProcessEmailOutboxJob : IRecurringJob
                 // Failure
                 var nextRetryAt = now + Duration.FromMinutes((long)Math.Pow(2, message.RetryCount + 1));
                 await _outboxRepo.MarkFailedAsync(message.Id, now, ex.Message, nextRetryAt, cancellationToken);
-                _metrics.RecordEmailFailed(message.TemplateName);
+                _emailMetrics.RecordFailed(message.TemplateName);
 
                 // Update campaign grant status if applicable — routed via ICampaignService.
                 if (message.CampaignGrantId.HasValue)
@@ -154,9 +157,9 @@ public class ProcessEmailOutboxJob : IRecurringJob
 
         // 5. Set outbox_pending gauge
         var pendingCount = await _outboxRepo.GetPendingCountAsync(_settings.OutboxMaxRetries, cancellationToken);
-        _metrics.SetEmailOutboxPending(pendingCount);
+        _emailMetrics.SetOutboxPending(pendingCount);
 
         // 6. Record successful job run
-        _metrics.RecordJobRun("process_email_outbox", "success");
+        _jobMetrics.RecordJobRun("process_email_outbox", "success");
     }
 }

--- a/src/Humans.Infrastructure/Jobs/ProcessGoogleSyncOutboxJob.cs
+++ b/src/Humans.Infrastructure/Jobs/ProcessGoogleSyncOutboxJob.cs
@@ -43,7 +43,8 @@ public class ProcessGoogleSyncOutboxJob : IRecurringJob
     private readonly ITeamService _teamService;
     private readonly IGoogleSyncService _googleSyncService;
     private readonly INotificationService _notificationService;
-    private readonly IHumansMetrics _metrics;
+    private readonly IGoogleSyncMetrics _syncMetrics;
+    private readonly IJobRunMetrics _jobMetrics;
     private readonly IClock _clock;
     private readonly ILogger<ProcessGoogleSyncOutboxJob> _logger;
 
@@ -54,7 +55,8 @@ public class ProcessGoogleSyncOutboxJob : IRecurringJob
         ITeamService teamService,
         IGoogleSyncService googleSyncService,
         INotificationService notificationService,
-        IHumansMetrics metrics,
+        IGoogleSyncMetrics syncMetrics,
+        IJobRunMetrics jobMetrics,
         IClock clock,
         ILogger<ProcessGoogleSyncOutboxJob> logger)
     {
@@ -64,7 +66,8 @@ public class ProcessGoogleSyncOutboxJob : IRecurringJob
         _teamService = teamService;
         _googleSyncService = googleSyncService;
         _notificationService = notificationService;
-        _metrics = metrics;
+        _syncMetrics = syncMetrics;
+        _jobMetrics = jobMetrics;
         _clock = clock;
         _logger = logger;
     }
@@ -116,7 +119,7 @@ public class ProcessGoogleSyncOutboxJob : IRecurringJob
 
                     await _outboxRepository.MarkProcessedAsync(
                         outboxEvent.Id, _clock.GetCurrentInstant(), cancellationToken);
-                    _metrics.RecordSyncOperation("success");
+                    _syncMetrics.RecordSyncOperation("success");
 
                     // Only mark user as Valid when the event actually touched Google APIs
                     // (AddUserToTeamResources with linked resources). RemoveUserFromTeamResources
@@ -134,7 +137,7 @@ public class ProcessGoogleSyncOutboxJob : IRecurringJob
                 }
                 catch (Google.GoogleApiException ex) when (IsPermanentError(ex))
                 {
-                    _metrics.RecordSyncOperation("permanent_failure");
+                    _syncMetrics.RecordSyncOperation("permanent_failure");
 
                     await _outboxRepository.MarkPermanentlyFailedAsync(
                         outboxEvent.Id, _clock.GetCurrentInstant(), ex.Message, cancellationToken);
@@ -154,7 +157,7 @@ public class ProcessGoogleSyncOutboxJob : IRecurringJob
                 }
                 catch (Exception ex)
                 {
-                    _metrics.RecordSyncOperation("failure");
+                    _syncMetrics.RecordSyncOperation("failure");
 
                     var (exhausted, retryCount) = await _outboxRepository.IncrementRetryAsync(
                         outboxEvent.Id,
@@ -200,11 +203,11 @@ public class ProcessGoogleSyncOutboxJob : IRecurringJob
                 }
             }
 
-            _metrics.RecordJobRun("process_google_sync_outbox", "success");
+            _jobMetrics.RecordJobRun("process_google_sync_outbox", "success");
         }
         catch (Exception ex)
         {
-            _metrics.RecordJobRun("process_google_sync_outbox", "failure");
+            _jobMetrics.RecordJobRun("process_google_sync_outbox", "failure");
             _logger.LogError(ex, "Error processing Google sync outbox");
             throw;
         }

--- a/src/Humans.Infrastructure/Jobs/SendAdminDailyDigestJob.cs
+++ b/src/Humans.Infrastructure/Jobs/SendAdminDailyDigestJob.cs
@@ -39,7 +39,7 @@ public class SendAdminDailyDigestJob : IRecurringJob
     private readonly IGoogleSyncOutboxRepository _googleSyncOutboxRepository;
     private readonly IEmailService _emailService;
     private readonly IMembershipCalculator _membershipCalculator;
-    private readonly IHumansMetrics _metrics;
+    private readonly IJobRunMetrics _metrics;
     private readonly ILogger<SendAdminDailyDigestJob> _logger;
     private readonly IClock _clock;
 
@@ -53,7 +53,7 @@ public class SendAdminDailyDigestJob : IRecurringJob
         IGoogleSyncOutboxRepository googleSyncOutboxRepository,
         IEmailService emailService,
         IMembershipCalculator membershipCalculator,
-        IHumansMetrics metrics,
+        IJobRunMetrics metrics,
         ILogger<SendAdminDailyDigestJob> logger,
         IClock clock)
     {

--- a/src/Humans.Infrastructure/Jobs/SendBoardDailyDigestJob.cs
+++ b/src/Humans.Infrastructure/Jobs/SendBoardDailyDigestJob.cs
@@ -37,7 +37,7 @@ public class SendBoardDailyDigestJob : IRecurringJob
     private readonly IRoleAssignmentService _roleAssignmentService;
     private readonly IEmailService _emailService;
     private readonly IMembershipCalculator _membershipCalculator;
-    private readonly IHumansMetrics _metrics;
+    private readonly IJobRunMetrics _metrics;
     private readonly ILogger<SendBoardDailyDigestJob> _logger;
     private readonly IClock _clock;
 
@@ -50,7 +50,7 @@ public class SendBoardDailyDigestJob : IRecurringJob
         IRoleAssignmentService roleAssignmentService,
         IEmailService emailService,
         IMembershipCalculator membershipCalculator,
-        IHumansMetrics metrics,
+        IJobRunMetrics metrics,
         ILogger<SendBoardDailyDigestJob> logger,
         IClock clock)
     {

--- a/src/Humans.Infrastructure/Jobs/SendReConsentReminderJob.cs
+++ b/src/Humans.Infrastructure/Jobs/SendReConsentReminderJob.cs
@@ -28,7 +28,7 @@ public class SendReConsentReminderJob : IRecurringJob
     private readonly IUserService _userService;
     private readonly IEmailService _emailService;
     private readonly EmailSettings _emailSettings;
-    private readonly IHumansMetrics _metrics;
+    private readonly IJobRunMetrics _metrics;
     private readonly ILogger<SendReConsentReminderJob> _logger;
     private readonly IClock _clock;
 
@@ -38,7 +38,7 @@ public class SendReConsentReminderJob : IRecurringJob
         IUserService userService,
         IEmailService emailService,
         IOptions<EmailSettings> emailSettings,
-        IHumansMetrics metrics,
+        IJobRunMetrics metrics,
         ILogger<SendReConsentReminderJob> logger,
         IClock clock)
     {

--- a/src/Humans.Infrastructure/Jobs/SuspendNonCompliantMembersJob.cs
+++ b/src/Humans.Infrastructure/Jobs/SuspendNonCompliantMembersJob.cs
@@ -7,6 +7,7 @@ using Humans.Application.Interfaces.Email;
 using Humans.Application.Interfaces.GoogleIntegration;
 using Humans.Application.Interfaces.Governance;
 using Humans.Application.Interfaces.Notifications;
+using Humans.Application.Interfaces.Onboarding;
 using Humans.Application.Interfaces.Profiles;
 using Humans.Application.Interfaces.Shifts;
 using Humans.Application.Interfaces.Teams;
@@ -44,7 +45,8 @@ public class SuspendNonCompliantMembersJob : IRecurringJob
     private readonly IFullProfileInvalidator _fullProfileInvalidator;
     private readonly IRoleAssignmentClaimsCacheInvalidator _roleAssignmentClaimsInvalidator;
     private readonly IShiftAuthorizationInvalidator _shiftAuthorizationInvalidator;
-    private readonly IHumansMetrics _metrics;
+    private readonly IOnboardingMetrics _onboardingMetrics;
+    private readonly IJobRunMetrics _jobMetrics;
     private readonly ILogger<SuspendNonCompliantMembersJob> _logger;
     private readonly IClock _clock;
 
@@ -60,7 +62,8 @@ public class SuspendNonCompliantMembersJob : IRecurringJob
         IFullProfileInvalidator fullProfileInvalidator,
         IRoleAssignmentClaimsCacheInvalidator roleAssignmentClaimsInvalidator,
         IShiftAuthorizationInvalidator shiftAuthorizationInvalidator,
-        IHumansMetrics metrics,
+        IOnboardingMetrics onboardingMetrics,
+        IJobRunMetrics jobMetrics,
         ILogger<SuspendNonCompliantMembersJob> logger,
         IClock clock)
     {
@@ -75,7 +78,8 @@ public class SuspendNonCompliantMembersJob : IRecurringJob
         _fullProfileInvalidator = fullProfileInvalidator;
         _roleAssignmentClaimsInvalidator = roleAssignmentClaimsInvalidator;
         _shiftAuthorizationInvalidator = shiftAuthorizationInvalidator;
-        _metrics = metrics;
+        _onboardingMetrics = onboardingMetrics;
+        _jobMetrics = jobMetrics;
         _logger = logger;
         _clock = clock;
     }
@@ -111,7 +115,7 @@ public class SuspendNonCompliantMembersJob : IRecurringJob
 
             if (suspendedIds.Count == 0)
             {
-                _metrics.RecordJobRun("suspend_noncompliant_members", "success");
+                _jobMetrics.RecordJobRun("suspend_noncompliant_members", "success");
                 _logger.LogInformation(
                     "Completed non-compliant member check, no eligible users to suspend");
                 return;
@@ -192,7 +196,7 @@ public class SuspendNonCompliantMembersJob : IRecurringJob
                     "User {UserId} ({Email}) suspended and flagged for removal from {Count} teams",
                     user.Id, effectiveEmail, memberships.Count);
 
-                _metrics.RecordMemberSuspended("job");
+                _onboardingMetrics.RecordMemberSuspended("job");
 
                 // 4. Audit log + cross-cutting cache invalidation.
                 await _auditLogService.LogAsync(
@@ -206,14 +210,14 @@ public class SuspendNonCompliantMembersJob : IRecurringJob
                 _teamService.RemoveMemberFromAllTeamsCache(user.Id);
             }
 
-            _metrics.RecordJobRun("suspend_noncompliant_members", "success");
+            _jobMetrics.RecordJobRun("suspend_noncompliant_members", "success");
             _logger.LogInformation(
                 "Completed non-compliant member check, suspended {Count} members",
                 suspendedIds.Count);
         }
         catch (Exception ex)
         {
-            _metrics.RecordJobRun("suspend_noncompliant_members", "failure");
+            _jobMetrics.RecordJobRun("suspend_noncompliant_members", "failure");
             _logger.LogError(ex, "Error checking non-compliant members");
             throw;
         }

--- a/src/Humans.Infrastructure/Jobs/SyncLegalDocumentsJob.cs
+++ b/src/Humans.Infrastructure/Jobs/SyncLegalDocumentsJob.cs
@@ -27,7 +27,7 @@ public class SyncLegalDocumentsJob : IRecurringJob
     private readonly ITeamService _teamService;
     private readonly IUserService _userService;
     private readonly IConsentRepository _consentRepository;
-    private readonly IHumansMetrics _metrics;
+    private readonly IJobRunMetrics _metrics;
     private readonly ILogger<SyncLegalDocumentsJob> _logger;
     private readonly IClock _clock;
 
@@ -37,7 +37,7 @@ public class SyncLegalDocumentsJob : IRecurringJob
         ITeamService teamService,
         IUserService userService,
         IConsentRepository consentRepository,
-        IHumansMetrics metrics,
+        IJobRunMetrics metrics,
         ILogger<SyncLegalDocumentsJob> logger,
         IClock clock)
     {

--- a/src/Humans.Infrastructure/Jobs/SystemTeamSyncJob.cs
+++ b/src/Humans.Infrastructure/Jobs/SystemTeamSyncJob.cs
@@ -54,7 +54,7 @@ public class SystemTeamSyncJob : ISystemTeamSync
     private readonly IAuditLogService _auditLogService;
     private readonly IEmailService _emailService;
     private readonly IRoleAssignmentClaimsCacheInvalidator _roleAssignmentClaimsInvalidator;
-    private readonly IHumansMetrics _metrics;
+    private readonly IJobRunMetrics _metrics;
     private readonly ILogger<SystemTeamSyncJob> _logger;
     private readonly IClock _clock;
 
@@ -67,7 +67,7 @@ public class SystemTeamSyncJob : ISystemTeamSync
         IAuditLogService auditLogService,
         IEmailService emailService,
         IRoleAssignmentClaimsCacheInvalidator roleAssignmentClaimsInvalidator,
-        IHumansMetrics metrics,
+        IJobRunMetrics metrics,
         ILogger<SystemTeamSyncJob> logger,
         IClock clock)
     {

--- a/src/Humans.Infrastructure/Jobs/TermRenewalReminderJob.cs
+++ b/src/Humans.Infrastructure/Jobs/TermRenewalReminderJob.cs
@@ -28,7 +28,7 @@ public class TermRenewalReminderJob : IRecurringJob
     private readonly IUserService _userService;
     private readonly IEmailService _emailService;
     private readonly INotificationService _notificationService;
-    private readonly IHumansMetrics _metrics;
+    private readonly IJobRunMetrics _metrics;
     private readonly ILogger<TermRenewalReminderJob> _logger;
     private readonly IClock _clock;
 
@@ -39,7 +39,7 @@ public class TermRenewalReminderJob : IRecurringJob
         IUserService userService,
         IEmailService emailService,
         INotificationService notificationService,
-        IHumansMetrics metrics,
+        IJobRunMetrics metrics,
         ILogger<TermRenewalReminderJob> logger,
         IClock clock)
     {

--- a/src/Humans.Infrastructure/Repositories/Auth/RoleAssignmentRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Auth/RoleAssignmentRepository.cs
@@ -203,6 +203,20 @@ public sealed class RoleAssignmentRepository : IRoleAssignmentRepository
             .ToListAsync(ct);
     }
 
+    public async Task<IReadOnlyList<(string Role, int Count)>> GetActiveCountsByRoleAsync(
+        Instant now, CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        var rows = await ctx.RoleAssignments
+            .AsNoTracking()
+            .Where(ra => ra.ValidFrom <= now &&
+                         (ra.ValidTo == null || ra.ValidTo > now))
+            .GroupBy(ra => ra.RoleName)
+            .Select(g => new { Role = g.Key, Count = g.Count() })
+            .ToListAsync(ct);
+        return rows.Select(r => (r.Role, r.Count)).ToList();
+    }
+
     // ==========================================================================
     // Writes
     // ==========================================================================

--- a/src/Humans.Infrastructure/Repositories/Profiles/ProfileRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Profiles/ProfileRepository.cs
@@ -173,6 +173,26 @@ public sealed class ProfileRepository : IProfileRepository
             .CountAsync(p => !p.IsApproved && !p.IsSuspended, ct);
     }
 
+    public async Task<(int Approved, int Suspended, int Pending)> GetStatusCountsAsync(
+        CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        // Materialise (IsApproved, IsSuspended) once, partition in memory.
+        // At ~500-row scale the cost is trivial and saves three count queries.
+        var snapshot = await ctx.Profiles
+            .Select(p => new { p.IsApproved, p.IsSuspended })
+            .ToListAsync(ct);
+
+        int approved = 0, suspended = 0, pending = 0;
+        foreach (var row in snapshot)
+        {
+            if (row.IsSuspended) suspended++;
+            else if (row.IsApproved) approved++;
+            else pending++;
+        }
+        return (approved, suspended, pending);
+    }
+
     public async Task<IReadOnlyList<ProfileLanguage>> GetLanguagesAsync(
         Guid profileId, CancellationToken ct = default)
     {

--- a/src/Humans.Infrastructure/Services/HumansMetricsService.cs
+++ b/src/Humans.Infrastructure/Services/HumansMetricsService.cs
@@ -1,382 +1,138 @@
 using System.Diagnostics.Metrics;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using NodaTime;
 using Humans.Application.Interfaces;
-using Humans.Application.Interfaces.Repositories;
-using Humans.Domain.Enums;
-using Humans.Infrastructure.Data;
-using Humans.Application.Interfaces.Teams;
-using Humans.Application.Interfaces.Governance;
+using Microsoft.Extensions.Logging;
 
 namespace Humans.Infrastructure.Services;
 
 /// <summary>
-/// Singleton service that owns the "Humans.Metrics" meter and all application-level
-/// counters and observable gauges. Gauge values are refreshed every 60 seconds from
-/// the database via a background timer.
+/// Singleton that owns the <c>Humans.Metrics</c> <see cref="Meter"/>, the
+/// counter/gauge creation API, and the 60-second gauge-snapshot refresh tick.
 /// </summary>
+/// <remarks>
+/// <para>
+/// Pure infrastructure: after issue nobodies-collective/Humans#580 this service
+/// knows nothing about Teams, Applications, Users, or any other section. Sections
+/// register their own counters and gauges via <see cref="IMetricsContributor"/>
+/// — the contributors are resolved at construction and <see cref="IMetricsContributor.Initialize"/>
+/// is invoked exactly once per contributor with this service passed as the
+/// <see cref="IHumansMetrics"/> registration surface.
+/// </para>
+/// <para>
+/// The 60-second tick iterates over all section-registered refresh callbacks in
+/// parallel. Each callback is wrapped in its own try/catch so a single section's
+/// exception cannot blank other sections' gauges for that cycle — the error is
+/// logged and the next tick retries.
+/// </para>
+/// <para>
+/// This service stays in <c>Humans.Infrastructure</c> (like
+/// <c>IGoogleDriveClient</c>) because it legitimately owns process-wide OTel
+/// infrastructure — the <see cref="Meter"/> and <see cref="Timer"/> resources —
+/// and has no business logic of its own.
+/// </para>
+/// </remarks>
 public sealed class HumansMetricsService : IHumansMetrics, IDisposable
 {
     private static readonly Meter HumansMeter = new("Humans.Metrics");
+    private static readonly TimeSpan RefreshInterval = TimeSpan.FromSeconds(60);
 
-    // Counters
-    private readonly Counter<long> _emailsSent;
-    private readonly Counter<long> _consentsGiven;
-    private readonly Counter<long> _membersSuspended;
-    private readonly Counter<long> _volunteersApproved;
-    private readonly Counter<long> _syncOperations;
-    private readonly Counter<long> _applicationsProcessed;
-    private readonly Counter<long> _jobRuns;
-    private readonly Counter<long> _emailsQueued;
-    private readonly Counter<long> _emailsFailed;
-
-    private volatile int _emailOutboxPending;
-
-    private readonly IServiceScopeFactory _scopeFactory;
     private readonly ILogger<HumansMetricsService> _logger;
+    private readonly List<Func<CancellationToken, Task>> _refreshers = [];
     private readonly Timer _refreshTimer;
-
-    private volatile GaugeSnapshot _snapshot = GaugeSnapshot.Empty;
+    private readonly CancellationTokenSource _shutdownCts = new();
 
     public HumansMetricsService(
-        IServiceScopeFactory scopeFactory,
+        IEnumerable<IMetricsContributor> contributors,
         ILogger<HumansMetricsService> logger)
     {
-        _scopeFactory = scopeFactory;
         _logger = logger;
 
-        // Counters
-        _emailsSent = HumansMeter.CreateCounter<long>(
-            "humans.emails_sent_total",
-            description: "Total emails sent");
+        // Initialise every section's counters / gauges / refreshers BEFORE the
+        // first tick runs. Contributors are resolved eagerly (AddSingleton) so
+        // the DI container constructs them in time; the registry calls
+        // Initialize once on each, passing itself as the IHumansMetrics surface.
+        foreach (var contributor in contributors)
+        {
+            try
+            {
+                contributor.Initialize(this);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(
+                    ex,
+                    "Metrics contributor {Type} failed to Initialize; its counters/gauges will be missing",
+                    contributor.GetType().Name);
+            }
+        }
 
-        _consentsGiven = HumansMeter.CreateCounter<long>(
-            "humans.consents_given_total",
-            description: "Total consent records created");
-
-        _membersSuspended = HumansMeter.CreateCounter<long>(
-            "humans.members_suspended_total",
-            description: "Total member suspensions");
-
-        _volunteersApproved = HumansMeter.CreateCounter<long>(
-            "humans.volunteers_approved_total",
-            description: "Total volunteers approved");
-
-        _syncOperations = HumansMeter.CreateCounter<long>(
-            "humans.sync_operations_total",
-            description: "Total Google sync operations");
-
-        _applicationsProcessed = HumansMeter.CreateCounter<long>(
-            "humans.applications_processed_total",
-            description: "Total asociado applications processed");
-
-        _jobRuns = HumansMeter.CreateCounter<long>(
-            "humans.job_runs_total",
-            description: "Total background job runs");
-
-        _emailsQueued = HumansMeter.CreateCounter<long>(
-            "humans.email_queued_total",
-            description: "Total emails queued for sending");
-
-        _emailsFailed = HumansMeter.CreateCounter<long>(
-            "humans.email_failed_total",
-            description: "Total email send failures");
-
-        // Observable Gauges
-        HumansMeter.CreateObservableGauge(
-            "humans.humans_total",
-            observeValues: ObserveHumansTotal,
-            description: "Total humans by status");
-
-        HumansMeter.CreateObservableGauge(
-            "humans.pending_volunteers",
-            observeValue: () => _snapshot.PendingVolunteers,
-            description: "Volunteers awaiting board approval");
-
-        HumansMeter.CreateObservableGauge(
-            "humans.pending_consents",
-            observeValue: () => _snapshot.PendingConsents,
-            description: "Users missing required consents");
-
-        HumansMeter.CreateObservableGauge(
-            "humans.consent_deadline_approaching",
-            observeValue: () => _snapshot.ConsentDeadlineApproaching,
-            description: "Users past grace period not yet suspended");
-
-        HumansMeter.CreateObservableGauge(
-            "humans.pending_deletions",
-            observeValue: () => _snapshot.PendingDeletions,
-            description: "Accounts scheduled for deletion");
-
-        HumansMeter.CreateObservableGauge(
-            "humans.asociados",
-            observeValue: () => _snapshot.Asociados,
-            description: "Approved asociado members");
-
-        HumansMeter.CreateObservableGauge(
-            "humans.role_assignments_active",
-            observeValues: ObserveRoleAssignments,
-            description: "Active role assignments by role");
-
-        HumansMeter.CreateObservableGauge(
-            "humans.teams",
-            observeValues: ObserveTeams,
-            description: "Teams by status");
-
-        HumansMeter.CreateObservableGauge(
-            "humans.team_join_requests_pending",
-            observeValue: () => _snapshot.TeamJoinRequestsPending,
-            description: "Pending team join requests");
-
-        HumansMeter.CreateObservableGauge(
-            "humans.google_resources",
-            observeValue: () => _snapshot.GoogleResources,
-            description: "Total Google resources");
-
-        HumansMeter.CreateObservableGauge(
-            "humans.legal_documents_active",
-            observeValue: () => _snapshot.LegalDocumentsActive,
-            description: "Active required legal documents");
-
-        HumansMeter.CreateObservableGauge(
-            "humans.applications_pending",
-            observeValues: ObserveApplicationsPending,
-            description: "Pending applications by status");
-
-        HumansMeter.CreateObservableGauge(
-            "humans.google_sync_outbox_pending",
-            observeValue: () => _snapshot.PendingOutboxEvents,
-            description: "Unprocessed Google sync outbox events");
-
-        HumansMeter.CreateObservableGauge(
-            "humans.email_outbox_pending",
-            observeValue: () => _emailOutboxPending,
-            description: "Emails pending in the outbox queue");
-
-        // Timer: fire immediately, then every 60 seconds
+        // Fire the first refresh immediately (on the thread pool) and then every
+        // 60 seconds thereafter so gauges have fresh values on first scrape.
         _refreshTimer = new Timer(
-            callback: _ => _ = RefreshSnapshotAsync(),
+            callback: _ => _ = RunRefreshersAsync(),
             state: null,
             dueTime: TimeSpan.Zero,
-            period: TimeSpan.FromSeconds(60));
+            period: RefreshInterval);
     }
 
-    // --- Counter record methods ---
+    public Counter<T> CreateCounter<T>(string name, string? description = null) where T : struct =>
+        HumansMeter.CreateCounter<T>(name, description: description);
 
-    public void RecordEmailSent(string template)
-        => _emailsSent.Add(1, new KeyValuePair<string, object?>("template", template));
-
-    public void RecordConsentGiven()
-        => _consentsGiven.Add(1);
-
-    public void RecordMemberSuspended(string source)
-        => _membersSuspended.Add(1, new KeyValuePair<string, object?>("source", source));
-
-    public void RecordVolunteerApproved()
-        => _volunteersApproved.Add(1);
-
-    public void RecordSyncOperation(string result)
-        => _syncOperations.Add(1, new KeyValuePair<string, object?>("result", result));
-
-    public void RecordApplicationProcessed(string action)
-        => _applicationsProcessed.Add(1, new KeyValuePair<string, object?>("action", action));
-
-    public void RecordJobRun(string job, string result)
-        => _jobRuns.Add(1,
-            new KeyValuePair<string, object?>("job", job),
-            new KeyValuePair<string, object?>("result", result));
-
-    public void RecordEmailQueued(string template)
-        => _emailsQueued.Add(1, new KeyValuePair<string, object?>("template", template));
-
-    public void RecordEmailFailed(string template)
-        => _emailsFailed.Add(1, new KeyValuePair<string, object?>("template", template));
-
-    public void SetEmailOutboxPending(int count)
-        => _emailOutboxPending = count;
-
-    // --- Observable gauge callbacks ---
-
-    private IEnumerable<Measurement<int>> ObserveHumansTotal()
+    public void CreateObservableGauge<T>(string name, Func<T> observeValue, string? description = null)
+        where T : struct
     {
-        var s = _snapshot;
-        yield return new Measurement<int>(s.ActiveCount, new KeyValuePair<string, object?>("status", "active"));
-        yield return new Measurement<int>(s.SuspendedCount, new KeyValuePair<string, object?>("status", "suspended"));
-        yield return new Measurement<int>(s.PendingCount, new KeyValuePair<string, object?>("status", "pending"));
-        yield return new Measurement<int>(s.InactiveCount, new KeyValuePair<string, object?>("status", "inactive"));
+        HumansMeter.CreateObservableGauge<T>(
+            name,
+            observeValue: observeValue,
+            description: description);
     }
 
-    private IEnumerable<Measurement<int>> ObserveRoleAssignments()
+    public void CreateObservableGauge<T>(
+        string name,
+        Func<IEnumerable<Measurement<T>>> observeValues,
+        string? description = null) where T : struct
     {
-        foreach (var (role, count) in _snapshot.RoleAssignmentsByRole)
-        {
-            yield return new Measurement<int>(count, new KeyValuePair<string, object?>("role", role));
-        }
+        HumansMeter.CreateObservableGauge<T>(
+            name,
+            observeValues: observeValues,
+            description: description);
     }
 
-    private IEnumerable<Measurement<int>> ObserveTeams()
+    public void RegisterGaugeRefresher(Func<CancellationToken, Task> refresher)
     {
-        var s = _snapshot;
-        yield return new Measurement<int>(s.TeamsActive, new KeyValuePair<string, object?>("status", "active"));
-        yield return new Measurement<int>(s.TeamsInactive, new KeyValuePair<string, object?>("status", "inactive"));
+        ArgumentNullException.ThrowIfNull(refresher);
+        _refreshers.Add(refresher);
     }
 
-    private IEnumerable<Measurement<int>> ObserveApplicationsPending()
+    private async Task RunRefreshersAsync()
     {
-        var s = _snapshot;
-        yield return new Measurement<int>(s.ApplicationsSubmitted, new KeyValuePair<string, object?>("status", "submitted"));
+        // Per-refresher try/catch ensures one section's failure does not break
+        // other sections' gauges for the same tick. Run in parallel — at 500
+        // users scale the per-refresher DB work is tiny.
+        var ct = _shutdownCts.Token;
+        if (ct.IsCancellationRequested) return;
+
+        var tasks = _refreshers.Select(r => RunOneAsync(r, ct)).ToArray();
+        await Task.WhenAll(tasks);
     }
 
-    // --- Snapshot refresh ---
-
-    private async Task RefreshSnapshotAsync()
+    private async Task RunOneAsync(Func<CancellationToken, Task> refresher, CancellationToken ct)
     {
         try
         {
-            using var scope = _scopeFactory.CreateScope();
-            var db = scope.ServiceProvider.GetRequiredService<HumansDbContext>();
-            var membershipCalc = scope.ServiceProvider.GetRequiredService<IMembershipCalculator>();
-            var clock = scope.ServiceProvider.GetRequiredService<IClock>();
-            var now = clock.GetCurrentInstant();
-
-            // humans_total by status
-            var allUserIds = await db.Users.Select(u => u.Id).ToListAsync();
-            var profileData = await db.Profiles
-                .Select(p => new { p.UserId, p.IsApproved, p.IsSuspended })
-                .ToListAsync();
-
-            var profileLookup = profileData.ToDictionary(p => p.UserId);
-
-            int activeCount = 0, suspendedCount = 0, pendingCount = 0, inactiveCount = 0;
-            foreach (var userId in allUserIds)
-            {
-                if (profileLookup.TryGetValue(userId, out var p))
-                {
-                    if (p.IsSuspended) suspendedCount++;
-                    else if (!p.IsApproved) pendingCount++;
-                    else activeCount++;
-                }
-                else
-                {
-                    inactiveCount++;
-                }
-            }
-
-            // pending_consents
-            var usersWithAllConsents = await membershipCalc.GetUsersWithAllRequiredConsentsAsync(allUserIds);
-            var pendingConsents = allUserIds.Count - usersWithAllConsents.Count;
-
-            // consent_deadline_approaching
-            var usersRequiringUpdate = await membershipCalc.GetUsersRequiringStatusUpdateAsync();
-            var consentDeadlineApproaching = usersRequiringUpdate.Count;
-
-            // pending_deletions
-            var pendingDeletions = await db.Users.CountAsync(u => u.DeletionScheduledFor != null);
-
-            // asociados
-            var asociados = await db.Applications.CountAsync(a => a.Status == ApplicationStatus.Approved);
-
-            // role_assignments_active
-            var roleAssignments = await db.RoleAssignments
-                .Where(ra => ra.ValidFrom <= now && (ra.ValidTo == null || ra.ValidTo > now))
-                .GroupBy(ra => ra.RoleName)
-                .Select(g => new { Role = g.Key, Count = g.Count() })
-                .ToListAsync();
-
-            // teams
-            var teamsActive = await db.Teams.CountAsync(t => t.IsActive);
-            var teamsInactive = await db.Teams.CountAsync(t => !t.IsActive);
-
-            // team_join_requests_pending
-            var teamJoinRequestsPending = await db.TeamJoinRequests
-                .CountAsync(r => r.Status == TeamJoinRequestStatus.Pending);
-
-            // google_resources
-            var teamResourceService = scope.ServiceProvider.GetRequiredService<ITeamResourceService>();
-            var googleResources = await teamResourceService.GetResourceCountAsync();
-
-            // legal_documents_active
-            var legalDocumentsActive = await db.LegalDocuments
-                .CountAsync(d => d.IsActive && d.IsRequired);
-
-            // applications_pending
-            var applicationsSubmitted = await db.Applications
-                .CountAsync(a => a.Status == ApplicationStatus.Submitted);
-
-            // google_sync_outbox_pending — goes through the repository so this
-            // service doesn't read google_sync_outbox_events directly (issue #554
-            // Part 1, design-rules §2c).
-            var outboxRepo = scope.ServiceProvider.GetRequiredService<IGoogleSyncOutboxRepository>();
-            var pendingOutboxEvents = await outboxRepo.CountPendingAsync();
-
-            _snapshot = new GaugeSnapshot
-            {
-                ActiveCount = activeCount,
-                SuspendedCount = suspendedCount,
-                PendingCount = pendingCount,
-                InactiveCount = inactiveCount,
-                PendingVolunteers = pendingCount,
-                PendingConsents = pendingConsents,
-                ConsentDeadlineApproaching = consentDeadlineApproaching,
-                PendingDeletions = pendingDeletions,
-                Asociados = asociados,
-                RoleAssignmentsByRole = roleAssignments
-                    .Select(r => (r.Role, r.Count))
-                    .ToList(),
-                TeamsActive = teamsActive,
-                TeamsInactive = teamsInactive,
-                TeamJoinRequestsPending = teamJoinRequestsPending,
-                GoogleResources = googleResources,
-                LegalDocumentsActive = legalDocumentsActive,
-                ApplicationsSubmitted = applicationsSubmitted,
-                PendingOutboxEvents = pendingOutboxEvents
-            };
-
-            _logger.LogDebug("Metrics snapshot refreshed: {Active} active, {Suspended} suspended, {Pending} pending",
-                activeCount, suspendedCount, pendingCount);
+            await refresher(ct);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to refresh metrics snapshot");
+            _logger.LogError(
+                ex,
+                "Metrics gauge refresher failed on the snapshot tick; gauges for this contributor will retain their previous values until the next cycle");
         }
     }
 
     public void Dispose()
     {
+        _shutdownCts.Cancel();
         _refreshTimer.Dispose();
-    }
-
-    private sealed record GaugeSnapshot
-    {
-        public static readonly GaugeSnapshot Empty = new();
-
-        // humans_total
-        public int ActiveCount { get; init; }
-        public int SuspendedCount { get; init; }
-        public int PendingCount { get; init; }
-        public int InactiveCount { get; init; }
-
-        // Simple gauges
-        public int PendingVolunteers { get; init; }
-        public int PendingConsents { get; init; }
-        public int ConsentDeadlineApproaching { get; init; }
-        public int PendingDeletions { get; init; }
-        public int Asociados { get; init; }
-
-        // Role assignments grouped by role
-        public IReadOnlyList<(string Role, int Count)> RoleAssignmentsByRole { get; init; } = [];
-
-        // Teams
-        public int TeamsActive { get; init; }
-        public int TeamsInactive { get; init; }
-
-        // Other
-        public int TeamJoinRequestsPending { get; init; }
-        public int GoogleResources { get; init; }
-        public int LegalDocumentsActive { get; init; }
-        public int ApplicationsSubmitted { get; init; }
-        public int PendingOutboxEvents { get; init; }
+        _shutdownCts.Dispose();
     }
 }

--- a/src/Humans.Infrastructure/Services/JobRunMetricsContributor.cs
+++ b/src/Humans.Infrastructure/Services/JobRunMetricsContributor.cs
@@ -1,0 +1,27 @@
+using System.Diagnostics.Metrics;
+using Humans.Application.Interfaces;
+
+namespace Humans.Infrastructure.Services;
+
+/// <summary>
+/// Cross-cutting metrics contributor for the <c>humans.job_runs_total</c>
+/// counter (issue nobodies-collective/Humans#580). Lives in Infrastructure
+/// alongside the Hangfire jobs that emit the metric.
+/// </summary>
+public sealed class JobRunMetricsContributor : IJobRunMetrics, IMetricsContributor
+{
+    private Counter<long> _jobRuns = null!;
+
+    public void Initialize(IHumansMetrics metrics)
+    {
+        _jobRuns = metrics.CreateCounter<long>(
+            "humans.job_runs_total",
+            description: "Total background job runs");
+    }
+
+    public void RecordJobRun(string job, string result) =>
+        _jobRuns.Add(
+            1,
+            new KeyValuePair<string, object?>("job", job),
+            new KeyValuePair<string, object?>("result", result));
+}

--- a/src/Humans.Infrastructure/Services/Profiles/CachingProfileService.cs
+++ b/src/Humans.Infrastructure/Services/Profiles/CachingProfileService.cs
@@ -276,6 +276,13 @@ public sealed class CachingProfileService : IProfileService, IFullProfileInvalid
         return await inner.GetNotApprovedAndNotSuspendedCountAsync(ct);
     }
 
+    public async Task<ProfileStatusCounts> GetProfileStatusCountsAsync(CancellationToken ct = default)
+    {
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        var inner = scope.ServiceProvider.GetRequiredKeyedService<IProfileService>(InnerServiceKey);
+        return await inner.GetProfileStatusCountsAsync(ct);
+    }
+
     public async Task<IReadOnlyList<(Guid ProfileId, Guid UserId, long UpdatedAtTicks)>>
         GetCustomPictureInfoByUserIdsAsync(IEnumerable<Guid> userIds, CancellationToken ct = default)
     {

--- a/src/Humans.Infrastructure/Services/SmtpEmailService.cs
+++ b/src/Humans.Infrastructure/Services/SmtpEmailService.cs
@@ -6,7 +6,6 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using MimeKit;
-using Humans.Application.Interfaces;
 using Humans.Infrastructure.Configuration;
 using Humans.Infrastructure.Helpers;
 using Humans.Application.Interfaces.Email;
@@ -20,14 +19,14 @@ namespace Humans.Infrastructure.Services;
 public class SmtpEmailService : IEmailService
 {
     private readonly EmailSettings _settings;
-    private readonly IHumansMetrics _metrics;
+    private readonly IEmailMetrics _metrics;
     private readonly ILogger<SmtpEmailService> _logger;
     private readonly IEmailRenderer _renderer;
     private readonly string _environmentName;
 
     public SmtpEmailService(
         IOptions<EmailSettings> settings,
-        IHumansMetrics metrics,
+        IEmailMetrics metrics,
         ILogger<SmtpEmailService> logger,
         IEmailRenderer renderer,
         IHostEnvironment hostEnvironment)
@@ -49,7 +48,7 @@ public class SmtpEmailService : IEmailService
     {
         var content = _renderer.RenderApplicationApproved(userName, tier, culture);
         await SendEmailAsync(userEmail, content.Subject, content.HtmlBody, cancellationToken);
-        _metrics.RecordEmailSent("application_approved");
+        _metrics.RecordSent("application_approved");
     }
 
     /// <inheritdoc />
@@ -63,7 +62,7 @@ public class SmtpEmailService : IEmailService
     {
         var content = _renderer.RenderApplicationRejected(userName, tier, reason, culture);
         await SendEmailAsync(userEmail, content.Subject, content.HtmlBody, cancellationToken);
-        _metrics.RecordEmailSent("application_rejected");
+        _metrics.RecordSent("application_rejected");
     }
 
     /// <inheritdoc />
@@ -88,7 +87,7 @@ public class SmtpEmailService : IEmailService
         var docs = documentNames.ToList();
         var content = _renderer.RenderReConsentsRequired(userName, docs, culture);
         await SendEmailAsync(userEmail, content.Subject, content.HtmlBody, cancellationToken);
-        _metrics.RecordEmailSent("reconsents_required");
+        _metrics.RecordSent("reconsents_required");
     }
 
     /// <inheritdoc />
@@ -103,7 +102,7 @@ public class SmtpEmailService : IEmailService
         var docs = documentNames.ToList();
         var content = _renderer.RenderReConsentReminder(userName, docs, daysRemaining, culture);
         await SendEmailAsync(userEmail, content.Subject, content.HtmlBody, cancellationToken);
-        _metrics.RecordEmailSent("reconsent_reminder");
+        _metrics.RecordSent("reconsent_reminder");
     }
 
     /// <inheritdoc />
@@ -115,7 +114,7 @@ public class SmtpEmailService : IEmailService
     {
         var content = _renderer.RenderWelcome(userName, culture);
         await SendEmailAsync(userEmail, content.Subject, content.HtmlBody, cancellationToken);
-        _metrics.RecordEmailSent("welcome");
+        _metrics.RecordSent("welcome");
     }
 
     /// <inheritdoc />
@@ -128,7 +127,7 @@ public class SmtpEmailService : IEmailService
     {
         var content = _renderer.RenderAccessSuspended(userName, reason, culture);
         await SendEmailAsync(userEmail, content.Subject, content.HtmlBody, cancellationToken);
-        _metrics.RecordEmailSent("access_suspended");
+        _metrics.RecordSent("access_suspended");
     }
 
     /// <inheritdoc />
@@ -142,7 +141,7 @@ public class SmtpEmailService : IEmailService
     {
         var content = _renderer.RenderEmailVerification(userName, toEmail, verificationUrl, isConflict, culture);
         await SendEmailAsync(toEmail, content.Subject, content.HtmlBody, cancellationToken);
-        _metrics.RecordEmailSent("email_verification");
+        _metrics.RecordSent("email_verification");
     }
 
     /// <inheritdoc />
@@ -156,7 +155,7 @@ public class SmtpEmailService : IEmailService
         var formattedDate = deletionDate.ToInvariantLongDate();
         var content = _renderer.RenderAccountDeletionRequested(userName, formattedDate, culture);
         await SendEmailAsync(userEmail, content.Subject, content.HtmlBody, cancellationToken);
-        _metrics.RecordEmailSent("deletion_requested");
+        _metrics.RecordSent("deletion_requested");
     }
 
     /// <inheritdoc />
@@ -168,7 +167,7 @@ public class SmtpEmailService : IEmailService
     {
         var content = _renderer.RenderAccountDeleted(userName, culture);
         await SendEmailAsync(userEmail, content.Subject, content.HtmlBody, cancellationToken);
-        _metrics.RecordEmailSent("account_deleted");
+        _metrics.RecordSent("account_deleted");
     }
 
     /// <inheritdoc />
@@ -184,7 +183,7 @@ public class SmtpEmailService : IEmailService
         var resourceList = resources.ToList();
         var content = _renderer.RenderAddedToTeam(userName, teamName, teamSlug, resourceList, culture);
         await SendEmailAsync(userEmail, content.Subject, content.HtmlBody, cancellationToken);
-        _metrics.RecordEmailSent("added_to_team");
+        _metrics.RecordSent("added_to_team");
     }
 
     /// <inheritdoc />
@@ -197,7 +196,7 @@ public class SmtpEmailService : IEmailService
     {
         var content = _renderer.RenderSignupRejected(userName, reason, culture);
         await SendEmailAsync(userEmail, content.Subject, content.HtmlBody, cancellationToken);
-        _metrics.RecordEmailSent("signup_rejected");
+        _metrics.RecordSent("signup_rejected");
     }
 
     /// <inheritdoc />
@@ -211,7 +210,7 @@ public class SmtpEmailService : IEmailService
     {
         var content = _renderer.RenderTermRenewalReminder(userName, tierName, expiresAt, culture);
         await SendEmailAsync(userEmail, content.Subject, content.HtmlBody, cancellationToken);
-        _metrics.RecordEmailSent("term_renewal_reminder");
+        _metrics.RecordSent("term_renewal_reminder");
     }
 
     /// <inheritdoc />
@@ -226,7 +225,7 @@ public class SmtpEmailService : IEmailService
     {
         var content = _renderer.RenderBoardDailyDigest(name, date, groups, outstandingCounts, culture);
         await SendEmailAsync(email, content.Subject, content.HtmlBody, cancellationToken);
-        _metrics.RecordEmailSent("board_daily_digest");
+        _metrics.RecordSent("board_daily_digest");
     }
 
     /// <inheritdoc />
@@ -240,7 +239,7 @@ public class SmtpEmailService : IEmailService
     {
         var content = _renderer.RenderAdminDailyDigest(name, date, counts, culture);
         await SendEmailAsync(email, content.Subject, content.HtmlBody, cancellationToken);
-        _metrics.RecordEmailSent("admin_daily_digest");
+        _metrics.RecordSent("admin_daily_digest");
     }
 
     /// <inheritdoc />
@@ -251,7 +250,7 @@ public class SmtpEmailService : IEmailService
     {
         var content = _renderer.RenderFeedbackResponse(userName, originalDescription, responseMessage, reportLink, culture);
         await SendEmailAsync(userEmail, content.Subject, content.HtmlBody, cancellationToken: cancellationToken);
-        _metrics.RecordEmailSent("feedback_response");
+        _metrics.RecordSent("feedback_response");
     }
 
     public async Task SendFacilitatedMessageAsync(
@@ -268,7 +267,7 @@ public class SmtpEmailService : IEmailService
             recipientName, senderName, messageText, includeContactInfo, senderEmail, culture);
         var replyTo = includeContactInfo ? senderEmail : null;
         await SendEmailAsync(recipientEmail, content.Subject, content.HtmlBody, cancellationToken, replyTo);
-        _metrics.RecordEmailSent("facilitated_message");
+        _metrics.RecordSent("facilitated_message");
     }
 
     public async Task SendMagicLinkLoginAsync(
@@ -277,7 +276,7 @@ public class SmtpEmailService : IEmailService
     {
         var content = _renderer.RenderMagicLinkLogin(displayName, magicLinkUrl, culture);
         await SendEmailAsync(toEmail, content.Subject, content.HtmlBody, ct);
-        _metrics.RecordEmailSent("magic_link_login");
+        _metrics.RecordSent("magic_link_login");
     }
 
     public async Task SendMagicLinkSignupAsync(
@@ -286,7 +285,7 @@ public class SmtpEmailService : IEmailService
     {
         var content = _renderer.RenderMagicLinkSignup(magicLinkUrl, culture);
         await SendEmailAsync(toEmail, content.Subject, content.HtmlBody, ct);
-        _metrics.RecordEmailSent("magic_link_signup");
+        _metrics.RecordSent("magic_link_signup");
     }
 
     public async Task SendWorkspaceCredentialsAsync(
@@ -295,7 +294,7 @@ public class SmtpEmailService : IEmailService
     {
         var content = _renderer.RenderWorkspaceCredentials(userName, workspaceEmail, tempPassword, culture);
         await SendEmailAsync(recoveryEmail, content.Subject, content.HtmlBody, cancellationToken);
-        _metrics.RecordEmailSent("workspace_credentials");
+        _metrics.RecordSent("workspace_credentials");
     }
 
     public async Task SendCampaignCodeAsync(CampaignCodeEmailRequest request, CancellationToken cancellationToken = default)
@@ -316,7 +315,7 @@ public class SmtpEmailService : IEmailService
             .Replace("{{Name}}", request.RecipientName, StringComparison.Ordinal);
 
         await SendEmailAsync(request.RecipientEmail, renderedSubject, renderedBody, cancellationToken, request.ReplyTo);
-        _metrics.RecordEmailSent("campaign_code");
+        _metrics.RecordSent("campaign_code");
     }
 
     private async Task SendEmailAsync(

--- a/src/Humans.Web/Extensions/Infrastructure/TelemetryInfrastructureExtensions.cs
+++ b/src/Humans.Web/Extensions/Infrastructure/TelemetryInfrastructureExtensions.cs
@@ -1,5 +1,20 @@
 using Humans.Application.Configuration;
 using Humans.Application.Interfaces;
+using Humans.Application.Interfaces.Consent;
+using Humans.Application.Interfaces.Email;
+using Humans.Application.Interfaces.Governance;
+using Humans.Application.Interfaces.GoogleIntegration;
+using Humans.Application.Interfaces.Onboarding;
+using Humans.Application.Services.Auth;
+using Humans.Application.Services.Consent;
+using Humans.Application.Services.Email;
+using Humans.Application.Services.Governance;
+using Humans.Application.Services.GoogleIntegration;
+using Humans.Application.Services.Legal;
+using Humans.Application.Services.Onboarding;
+using Humans.Application.Services.Profile;
+using Humans.Application.Services.Teams;
+using Humans.Application.Services.Users;
 using Humans.Infrastructure.Services;
 
 namespace Humans.Web.Extensions.Infrastructure;
@@ -12,6 +27,54 @@ internal static class TelemetryInfrastructureExtensions
     {
         services.Configure<GitHubSettings>(configuration.GetSection(GitHubSettings.SectionName));
 
+        // Push-model metrics registration (issue nobodies-collective/Humans#580).
+        // Each section's contributor is a Singleton so counter references and
+        // gauge backing state persist across scopes. The contributor is
+        // forwarded through both its section-specific metrics interface (so
+        // call sites inject a narrow surface) and the shared
+        // IMetricsContributor interface (so HumansMetricsService can iterate
+        // and Initialize them at startup).
+
+        // Email section — has an IEmailMetrics counter/gauge surface.
+        services.AddSingleton<EmailMetricsContributor>();
+        services.AddSingleton<IEmailMetrics>(sp => sp.GetRequiredService<EmailMetricsContributor>());
+        services.AddSingleton<IMetricsContributor>(sp => sp.GetRequiredService<EmailMetricsContributor>());
+
+        // Consent section — counter + two gauges.
+        services.AddSingleton<ConsentMetricsContributor>();
+        services.AddSingleton<IConsentMetrics>(sp => sp.GetRequiredService<ConsentMetricsContributor>());
+        services.AddSingleton<IMetricsContributor>(sp => sp.GetRequiredService<ConsentMetricsContributor>());
+
+        // Onboarding section — counter-only surface.
+        services.AddSingleton<OnboardingMetricsContributor>();
+        services.AddSingleton<IOnboardingMetrics>(sp => sp.GetRequiredService<OnboardingMetricsContributor>());
+        services.AddSingleton<IMetricsContributor>(sp => sp.GetRequiredService<OnboardingMetricsContributor>());
+
+        // Governance section — IApplicationMetrics counter + two gauges.
+        services.AddSingleton<GovernanceMetricsContributor>();
+        services.AddSingleton<IApplicationMetrics>(sp => sp.GetRequiredService<GovernanceMetricsContributor>());
+        services.AddSingleton<IMetricsContributor>(sp => sp.GetRequiredService<GovernanceMetricsContributor>());
+
+        // Google Integration — IGoogleSyncMetrics counter + two gauges.
+        services.AddSingleton<GoogleIntegrationMetricsContributor>();
+        services.AddSingleton<IGoogleSyncMetrics>(sp => sp.GetRequiredService<GoogleIntegrationMetricsContributor>());
+        services.AddSingleton<IMetricsContributor>(sp => sp.GetRequiredService<GoogleIntegrationMetricsContributor>());
+
+        // Cross-cutting job-run counter (all Hangfire jobs).
+        services.AddSingleton<JobRunMetricsContributor>();
+        services.AddSingleton<IJobRunMetrics>(sp => sp.GetRequiredService<JobRunMetricsContributor>());
+        services.AddSingleton<IMetricsContributor>(sp => sp.GetRequiredService<JobRunMetricsContributor>());
+
+        // Gauge-only contributors (no public section interface).
+        services.AddSingleton<IMetricsContributor, TeamsMetricsContributor>();
+        services.AddSingleton<IMetricsContributor, ProfilesMetricsContributor>();
+        services.AddSingleton<IMetricsContributor, UsersMetricsContributor>();
+        services.AddSingleton<IMetricsContributor, AuthMetricsContributor>();
+        services.AddSingleton<IMetricsContributor, LegalMetricsContributor>();
+
+        // Registry itself — Singleton so the Meter/Timer live for the app lifetime.
+        // Resolves IEnumerable<IMetricsContributor> from DI and invokes Initialize
+        // on each during construction.
         services.AddSingleton<IHumansMetrics, HumansMetricsService>();
 
         return services;

--- a/src/Humans.Web/Program.cs
+++ b/src/Humans.Web/Program.cs
@@ -461,8 +461,11 @@ var app = builder.Build();
 // so all Instant.ToDisplay*() calls automatically use the user's session timezone.
 DateTimeDisplayExtensions.Initialize(app.Services.GetRequiredService<IHttpContextAccessor>());
 
-// Eagerly resolve IHumansMetrics so the background gauge-refresh timer starts
-// immediately — otherwise observable gauges emit nothing until first injection.
+// Eagerly resolve IHumansMetrics so it runs every IMetricsContributor's
+// Initialize hook — counters and gauges are registered on the shared
+// Humans.Metrics meter during this call. The background gauge-refresh timer
+// also starts here; otherwise observable gauges emit nothing until first
+// injection.
 app.Services.GetRequiredService<IHumansMetrics>();
 
 // Localization diagnostic check

--- a/tests/Humans.Application.Tests/Jobs/CleanupEmailOutboxJobTests.cs
+++ b/tests/Humans.Application.Tests/Jobs/CleanupEmailOutboxJobTests.cs
@@ -1,11 +1,11 @@
 using AwesomeAssertions;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NodaTime;
 using NodaTime.Testing;
 using NSubstitute;
+using Humans.Application.Interfaces;
 using Humans.Application.Tests.Infrastructure;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
@@ -13,7 +13,6 @@ using Humans.Infrastructure.Configuration;
 using Humans.Infrastructure.Data;
 using Humans.Infrastructure.Jobs;
 using Humans.Infrastructure.Repositories.Email;
-using Humans.Infrastructure.Services;
 using Xunit;
 
 namespace Humans.Application.Tests.Jobs;
@@ -22,7 +21,7 @@ public class CleanupEmailOutboxJobTests : IDisposable
 {
     private readonly HumansDbContext _dbContext;
     private readonly FakeClock _clock;
-    private readonly HumansMetricsService _metrics;
+    private readonly IJobRunMetrics _metrics;
     private readonly CleanupEmailOutboxJob _job;
 
     // "Now" is 2026-03-14. With 150-day retention, cutoff is 2025-10-15.
@@ -36,9 +35,7 @@ public class CleanupEmailOutboxJobTests : IDisposable
 
         _dbContext = new HumansDbContext(options);
         _clock = new FakeClock(Now);
-        _metrics = new HumansMetricsService(
-            Substitute.For<IServiceScopeFactory>(),
-            Substitute.For<ILogger<HumansMetricsService>>());
+        _metrics = Substitute.For<IJobRunMetrics>();
         var logger = Substitute.For<ILogger<CleanupEmailOutboxJob>>();
         var settings = Options.Create(new EmailSettings { OutboxRetentionDays = 150 });
         var repo = new EmailOutboxRepository(new TestDbContextFactory(options));
@@ -49,7 +46,6 @@ public class CleanupEmailOutboxJobTests : IDisposable
     public void Dispose()
     {
         _dbContext.Dispose();
-        _metrics.Dispose();
         GC.SuppressFinalize(this);
     }
 

--- a/tests/Humans.Application.Tests/Jobs/CleanupNotificationsJobTests.cs
+++ b/tests/Humans.Application.Tests/Jobs/CleanupNotificationsJobTests.cs
@@ -1,14 +1,12 @@
 using AwesomeAssertions;
+using Humans.Application.Interfaces;
 using Humans.Application.Tests.Infrastructure;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Humans.Infrastructure.Data;
 using Humans.Infrastructure.Jobs;
 using Humans.Infrastructure.Repositories.Notifications;
-using Humans.Infrastructure.Services;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NodaTime.Testing;
@@ -32,9 +30,7 @@ public class CleanupNotificationsJobTests : IDisposable
         _dbContext = new HumansDbContext(options);
         _clock = new FakeClock(Instant.FromUtc(2026, 4, 10, 12, 0));
 
-        var metrics = new HumansMetricsService(
-            Substitute.For<IServiceScopeFactory>(),
-            Substitute.For<ILogger<HumansMetricsService>>());
+        var metrics = Substitute.For<IJobRunMetrics>();
         var repo = new NotificationRepository(new TestDbContextFactory(options));
         _job = new CleanupNotificationsJob(repo, _clock, metrics, NullLogger<CleanupNotificationsJob>.Instance);
     }

--- a/tests/Humans.Application.Tests/Jobs/GoogleResourceReconciliationJobTests.cs
+++ b/tests/Humans.Application.Tests/Jobs/GoogleResourceReconciliationJobTests.cs
@@ -1,13 +1,11 @@
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NodaTime.Testing;
 using NSubstitute;
 using Humans.Application.DTOs;
+using Humans.Application.Interfaces;
 using Humans.Domain.Enums;
 using Humans.Infrastructure.Jobs;
-using Humans.Infrastructure.Services;
 using Xunit;
 using Humans.Application.Interfaces.GoogleIntegration;
 using Humans.Application.Interfaces.Notifications;
@@ -18,16 +16,14 @@ public class GoogleResourceReconciliationJobTests : IDisposable
 {
     private readonly IGoogleSyncService _googleSyncService;
     private readonly FakeClock _clock;
-    private readonly HumansMetricsService _metrics;
+    private readonly IJobRunMetrics _metrics;
     private readonly GoogleResourceReconciliationJob _job;
 
     public GoogleResourceReconciliationJobTests()
     {
         _googleSyncService = Substitute.For<IGoogleSyncService>();
         _clock = new FakeClock(Instant.FromUtc(2026, 3, 9, 2, 0));
-        _metrics = new HumansMetricsService(
-            Substitute.For<IServiceScopeFactory>(),
-            Substitute.For<ILogger<HumansMetricsService>>());
+        _metrics = Substitute.For<IJobRunMetrics>();
 
         _job = new GoogleResourceReconciliationJob(
             _googleSyncService,
@@ -39,7 +35,6 @@ public class GoogleResourceReconciliationJobTests : IDisposable
 
     public void Dispose()
     {
-        _metrics.Dispose();
         GC.SuppressFinalize(this);
     }
 

--- a/tests/Humans.Application.Tests/Jobs/ProcessAccountDeletionsJobTests.cs
+++ b/tests/Humans.Application.Tests/Jobs/ProcessAccountDeletionsJobTests.cs
@@ -1,17 +1,16 @@
 using AwesomeAssertions;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NodaTime;
 using NodaTime.Testing;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
+using Humans.Application.Interfaces;
 using Humans.Application.Interfaces.AuditLog;
 using Humans.Application.Interfaces.Email;
 using Humans.Application.Interfaces.Users;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Humans.Infrastructure.Jobs;
-using Humans.Infrastructure.Services;
 using Xunit;
 
 namespace Humans.Application.Tests.Jobs;
@@ -29,7 +28,7 @@ public class ProcessAccountDeletionsJobTests : IDisposable
     private readonly IUserService _userService;
     private readonly IEmailService _emailService;
     private readonly IAuditLogService _auditLogService;
-    private readonly HumansMetricsService _metrics;
+    private readonly IJobRunMetrics _metrics;
     private readonly FakeClock _clock;
     private readonly ProcessAccountDeletionsJob _job;
 
@@ -41,9 +40,7 @@ public class ProcessAccountDeletionsJobTests : IDisposable
         _emailService = Substitute.For<IEmailService>();
         _auditLogService = Substitute.For<IAuditLogService>();
         _clock = new FakeClock(Now);
-        _metrics = new HumansMetricsService(
-            Substitute.For<IServiceScopeFactory>(),
-            Substitute.For<ILogger<HumansMetricsService>>());
+        _metrics = Substitute.For<IJobRunMetrics>();
         var logger = Substitute.For<ILogger<ProcessAccountDeletionsJob>>();
 
         _job = new ProcessAccountDeletionsJob(
@@ -52,7 +49,6 @@ public class ProcessAccountDeletionsJobTests : IDisposable
 
     public void Dispose()
     {
-        _metrics.Dispose();
         GC.SuppressFinalize(this);
     }
 

--- a/tests/Humans.Application.Tests/Jobs/ProcessEmailOutboxJobTests.cs
+++ b/tests/Humans.Application.Tests/Jobs/ProcessEmailOutboxJobTests.cs
@@ -1,19 +1,18 @@
 using AwesomeAssertions;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NodaTime;
 using NodaTime.Testing;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
+using Humans.Application.Interfaces;
 using Humans.Application.Tests.Infrastructure;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Humans.Infrastructure.Configuration;
 using Humans.Infrastructure.Data;
 using Humans.Infrastructure.Jobs;
-using Humans.Infrastructure.Services;
 using Xunit;
 using Humans.Application.Interfaces.Campaigns;
 using Humans.Application.Interfaces.Email;
@@ -28,7 +27,8 @@ public class ProcessEmailOutboxJobTests : IDisposable
     private readonly IEmailTransport _transport;
     private readonly ICampaignService _campaignService;
     private readonly FakeClock _clock;
-    private readonly HumansMetricsService _metrics;
+    private readonly IEmailMetrics _emailMetrics;
+    private readonly IJobRunMetrics _jobMetrics;
     private readonly IOptions<EmailSettings> _settings;
     private readonly EmailOutboxRepository _repo;
     private readonly ProcessEmailOutboxJob _job;
@@ -43,20 +43,19 @@ public class ProcessEmailOutboxJobTests : IDisposable
         _transport = Substitute.For<IEmailTransport>();
         _campaignService = Substitute.For<ICampaignService>();
         _clock = new FakeClock(Instant.FromUtc(2026, 3, 14, 12, 0));
-        _metrics = new HumansMetricsService(
-            Substitute.For<IServiceScopeFactory>(),
-            Substitute.For<ILogger<HumansMetricsService>>());
+        _emailMetrics = Substitute.For<IEmailMetrics>();
+        _jobMetrics = Substitute.For<IJobRunMetrics>();
         _settings = Options.Create(new EmailSettings { OutboxBatchSize = 10, OutboxMaxRetries = 10 });
         var logger = Substitute.For<ILogger<ProcessEmailOutboxJob>>();
         _repo = new EmailOutboxRepository(new TestDbContextFactory(_options));
 
-        _job = new ProcessEmailOutboxJob(_repo, _campaignService, _transport, _metrics, _clock, _settings, logger);
+        _job = new ProcessEmailOutboxJob(
+            _repo, _campaignService, _transport, _emailMetrics, _jobMetrics, _clock, _settings, logger);
     }
 
     public void Dispose()
     {
         _dbContext.Dispose();
-        _metrics.Dispose();
         GC.SuppressFinalize(this);
     }
 
@@ -117,7 +116,7 @@ public class ProcessEmailOutboxJobTests : IDisposable
 
         var batchSettings = Options.Create(new EmailSettings { OutboxBatchSize = 10, OutboxMaxRetries = 10 });
         var job = new ProcessEmailOutboxJob(
-            _repo, _campaignService, _transport, _metrics, _clock, batchSettings,
+            _repo, _campaignService, _transport, _emailMetrics, _jobMetrics, _clock, batchSettings,
             Substitute.For<ILogger<ProcessEmailOutboxJob>>());
 
         await job.ExecuteAsync();

--- a/tests/Humans.Application.Tests/Jobs/ProcessGoogleSyncOutboxJobTests.cs
+++ b/tests/Humans.Application.Tests/Jobs/ProcessGoogleSyncOutboxJobTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 using NodaTime;
 using NodaTime.Testing;
 using NSubstitute;
+using Humans.Application.Interfaces;
 using Humans.Application.Interfaces.GoogleIntegration;
 using Humans.Application.Interfaces.Notifications;
 using Humans.Application.Interfaces.Repositories;
@@ -15,8 +16,6 @@ using Humans.Domain.Enums;
 using Humans.Infrastructure.Data;
 using Humans.Infrastructure.Jobs;
 using Humans.Infrastructure.Repositories.GoogleIntegration;
-using Humans.Infrastructure.Services;
-using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace Humans.Application.Tests.Jobs;
@@ -31,7 +30,8 @@ public class ProcessGoogleSyncOutboxJobTests : IDisposable
     private readonly IGoogleSyncService _googleSyncService;
     private readonly INotificationService _notificationService;
     private readonly FakeClock _clock;
-    private readonly HumansMetricsService _metrics;
+    private readonly IGoogleSyncMetrics _syncMetrics;
+    private readonly IJobRunMetrics _jobMetrics;
     private readonly ProcessGoogleSyncOutboxJob _job;
 
     public ProcessGoogleSyncOutboxJobTests()
@@ -58,9 +58,8 @@ public class ProcessGoogleSyncOutboxJobTests : IDisposable
         _googleSyncService = Substitute.For<IGoogleSyncService>();
         _notificationService = Substitute.For<INotificationService>();
         _clock = new FakeClock(Instant.FromUtc(2026, 2, 15, 20, 0));
-        _metrics = new HumansMetricsService(
-            Substitute.For<IServiceScopeFactory>(),
-            Substitute.For<ILogger<HumansMetricsService>>());
+        _syncMetrics = Substitute.For<IGoogleSyncMetrics>();
+        _jobMetrics = Substitute.For<IJobRunMetrics>();
         var logger = Substitute.For<ILogger<ProcessGoogleSyncOutboxJob>>();
 
         _job = new ProcessGoogleSyncOutboxJob(
@@ -70,7 +69,8 @@ public class ProcessGoogleSyncOutboxJobTests : IDisposable
             _teamService,
             _googleSyncService,
             _notificationService,
-            _metrics,
+            _syncMetrics,
+            _jobMetrics,
             _clock,
             logger);
     }
@@ -78,7 +78,6 @@ public class ProcessGoogleSyncOutboxJobTests : IDisposable
     public void Dispose()
     {
         _dbContext.Dispose();
-        _metrics.Dispose();
         GC.SuppressFinalize(this);
     }
 

--- a/tests/Humans.Application.Tests/Jobs/SuspendNonCompliantMembersJobTests.cs
+++ b/tests/Humans.Application.Tests/Jobs/SuspendNonCompliantMembersJobTests.cs
@@ -1,18 +1,18 @@
 using AwesomeAssertions;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NodaTime;
 using NodaTime.Testing;
 using NSubstitute;
+using Humans.Application.Interfaces;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Humans.Infrastructure.Jobs;
-using Humans.Infrastructure.Services;
 using Xunit;
 using Humans.Application.Interfaces.AuditLog;
 using Humans.Application.Interfaces.Caching;
 using Humans.Application.Interfaces.Email;
 using Humans.Application.Interfaces.GoogleIntegration;
+using Humans.Application.Interfaces.Onboarding;
 using Humans.Application.Interfaces.Teams;
 using Humans.Application.Interfaces.Notifications;
 using Humans.Application.Interfaces.Governance;
@@ -35,7 +35,8 @@ public class SuspendNonCompliantMembersJobTests : IDisposable
     private readonly IFullProfileInvalidator _fullProfileInvalidator;
     private readonly IRoleAssignmentClaimsCacheInvalidator _roleAssignmentClaimsInvalidator;
     private readonly IShiftAuthorizationInvalidator _shiftAuthorizationInvalidator;
-    private readonly HumansMetricsService _metrics;
+    private readonly IOnboardingMetrics _onboardingMetrics;
+    private readonly IJobRunMetrics _jobMetrics;
     private readonly FakeClock _clock;
     private readonly SuspendNonCompliantMembersJob _job;
 
@@ -55,9 +56,8 @@ public class SuspendNonCompliantMembersJobTests : IDisposable
         _roleAssignmentClaimsInvalidator = Substitute.For<IRoleAssignmentClaimsCacheInvalidator>();
         _shiftAuthorizationInvalidator = Substitute.For<IShiftAuthorizationInvalidator>();
         _clock = new FakeClock(Now);
-        _metrics = new HumansMetricsService(
-            Substitute.For<IServiceScopeFactory>(),
-            Substitute.For<ILogger<HumansMetricsService>>());
+        _onboardingMetrics = Substitute.For<IOnboardingMetrics>();
+        _jobMetrics = Substitute.For<IJobRunMetrics>();
         var logger = Substitute.For<ILogger<SuspendNonCompliantMembersJob>>();
 
         // Default: ITeamService.GetUserTeamsAsync returns empty list so tests
@@ -69,12 +69,11 @@ public class SuspendNonCompliantMembersJobTests : IDisposable
             _userService, _profileService, _teamService, _membershipCalculator,
             _emailService, _notificationService, _googleSyncService, _auditLogService,
             _fullProfileInvalidator, _roleAssignmentClaimsInvalidator,
-            _shiftAuthorizationInvalidator, _metrics, logger, _clock);
+            _shiftAuthorizationInvalidator, _onboardingMetrics, _jobMetrics, logger, _clock);
     }
 
     public void Dispose()
     {
-        _metrics.Dispose();
         GC.SuppressFinalize(this);
     }
 

--- a/tests/Humans.Application.Tests/Services/ApplicationDecisionServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/ApplicationDecisionServiceTests.cs
@@ -36,7 +36,7 @@ public sealed class ApplicationDecisionServiceTests : IDisposable
     private readonly IEmailService _emailService = Substitute.For<IEmailService>();
     private readonly INotificationService _notificationService = Substitute.For<INotificationService>();
     private readonly ISystemTeamSync _syncJob = Substitute.For<ISystemTeamSync>();
-    private readonly IHumansMetrics _metrics = Substitute.For<IHumansMetrics>();
+    private readonly IApplicationMetrics _metrics = Substitute.For<IApplicationMetrics>();
     private readonly INavBadgeCacheInvalidator _navBadge = Substitute.For<INavBadgeCacheInvalidator>();
     private readonly INotificationMeterCacheInvalidator _notificationMeter = Substitute.For<INotificationMeterCacheInvalidator>();
     private readonly IVotingBadgeCacheInvalidator _votingBadge = Substitute.For<IVotingBadgeCacheInvalidator>();

--- a/tests/Humans.Application.Tests/Services/ConsentServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/ConsentServiceTests.cs
@@ -6,12 +6,12 @@ using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NodaTime.Testing;
 using NSubstitute;
-using Humans.Application.Interfaces;
 using Humans.Application.Tests.Infrastructure;
 using Humans.Domain.Entities;
 using Humans.Infrastructure.Data;
 using Xunit;
 using ConsentService = Humans.Application.Services.Consent.ConsentService;
+using Humans.Application.Interfaces.Consent;
 using Humans.Application.Interfaces.Legal;
 using Humans.Application.Interfaces.Onboarding;
 using Humans.Application.Interfaces.Notifications;
@@ -33,7 +33,7 @@ public class ConsentServiceTests : IDisposable
     private readonly INotificationInboxService _notificationInboxService = Substitute.For<INotificationInboxService>();
     private readonly ISystemTeamSync _syncJob = Substitute.For<ISystemTeamSync>();
     private readonly IProfileService _profileService = Substitute.For<IProfileService>();
-    private readonly IHumansMetrics _metrics = Substitute.For<IHumansMetrics>();
+    private readonly IConsentMetrics _metrics = Substitute.For<IConsentMetrics>();
 
     public ConsentServiceTests()
     {

--- a/tests/Humans.Application.Tests/Services/DependencyCycleResolutionTests.cs
+++ b/tests/Humans.Application.Tests/Services/DependencyCycleResolutionTests.cs
@@ -116,7 +116,7 @@ public class DependencyCycleResolutionTests
         services.AddScoped<IEmailRenderer>(_ => Substitute.For<IEmailRenderer>());
         services.AddScoped<IEmailBodyComposer>(_ => Substitute.For<IEmailBodyComposer>());
         services.AddScoped<IImmediateOutboxProcessor>(_ => Substitute.For<IImmediateOutboxProcessor>());
-        services.AddScoped<IHumansMetrics>(_ => Substitute.For<IHumansMetrics>());
+        services.AddScoped<IEmailMetrics>(_ => Substitute.For<IEmailMetrics>());
         services.AddScoped<ICommunicationPreferenceService>(_ => Substitute.For<ICommunicationPreferenceService>());
         services.AddScoped<NodaTime.IClock>(_ => Substitute.For<NodaTime.IClock>());
         services.AddScoped<UserManager<User>>(_ =>

--- a/tests/Humans.Application.Tests/Services/OutboxEmailServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/OutboxEmailServiceTests.cs
@@ -1,5 +1,4 @@
 using AwesomeAssertions;
-using Humans.Application.Interfaces;
 using Humans.Application.Interfaces.Repositories;
 using Humans.Application.Services.Email;
 using Humans.Domain.Entities;
@@ -34,7 +33,7 @@ public sealed class OutboxEmailServiceTests : IDisposable
     private readonly FakeClock _clock;
     private readonly OutboxEmailService _service;
     private readonly IEmailRenderer _renderer = Substitute.For<IEmailRenderer>();
-    private readonly IHumansMetrics _metrics = Substitute.For<IHumansMetrics>();
+    private readonly IEmailMetrics _metrics = Substitute.For<IEmailMetrics>();
     private readonly IImmediateOutboxProcessor _immediate = Substitute.For<IImmediateOutboxProcessor>();
     private readonly ICommunicationPreferenceService _commPrefService = Substitute.For<ICommunicationPreferenceService>();
     private readonly IUserEmailService _userEmailService = Substitute.For<IUserEmailService>();
@@ -104,7 +103,7 @@ public sealed class OutboxEmailServiceTests : IDisposable
 
         await _service.SendWelcomeEmailAsync("alice@example.com", "Alice", "en");
 
-        _metrics.Received(1).RecordEmailQueued("welcome");
+        _metrics.Received(1).RecordQueued("welcome");
     }
 
     [Fact]
@@ -168,7 +167,7 @@ public sealed class OutboxEmailServiceTests : IDisposable
         var msg = await _dbContext.EmailOutboxMessages.SingleAsync();
         msg.TemplateName.Should().Be("application_approved");
         msg.RecipientEmail.Should().Be("eve@example.com");
-        _metrics.Received(1).RecordEmailQueued("application_approved");
+        _metrics.Received(1).RecordQueued("application_approved");
     }
 
     [Fact]
@@ -271,6 +270,6 @@ public sealed class OutboxEmailServiceTests : IDisposable
         msg.CampaignGrantId.Should().Be(grantId);
         msg.ReplyTo.Should().Be("reply@example.com");
         msg.ExtraHeaders.Should().NotBeNull();
-        _metrics.Received(1).RecordEmailQueued("campaign_code");
+        _metrics.Received(1).RecordQueued("campaign_code");
     }
 }

--- a/tests/Humans.Application.Tests/Services/SystemTeamSyncJobBarrioLeadsTests.cs
+++ b/tests/Humans.Application.Tests/Services/SystemTeamSyncJobBarrioLeadsTests.cs
@@ -45,7 +45,7 @@ public class SystemTeamSyncJobBarrioLeadsTests
     private readonly IAuditLogService _auditLogService = Substitute.For<IAuditLogService>();
     private readonly IEmailService _emailService = Substitute.For<IEmailService>();
     private readonly IRoleAssignmentClaimsCacheInvalidator _roleAssignmentClaimsInvalidator = Substitute.For<IRoleAssignmentClaimsCacheInvalidator>();
-    private readonly IHumansMetrics _metrics = Substitute.For<IHumansMetrics>();
+    private readonly IJobRunMetrics _metrics = Substitute.For<IJobRunMetrics>();
 
     private SystemTeamSyncJob CreateJob()
     {


### PR DESCRIPTION
## Summary

Flip `HumansMetricsService` from pull to push. The service becomes pure infrastructure — owns the `Meter("Humans.Metrics")` singleton, counter/gauge creation API, and 60-second snapshot-refresh tick — with zero section knowledge. Sections own their metrics end-to-end.

Sibling inversion to nobodies-collective/Humans#581 (navbar notification meters). Same architectural pattern, larger surface: the `IMetricsContributor` / `Initialize(IHumansMetrics)` contract here plays the same role as `INotificationMeterContributor` there, but the metrics registry owns an OTel `Meter` + a background tick instead of a per-user cache. The two push-model hooks are intentionally distinct — metrics needs `Meter.Create*` calls at a specific time in app startup, before the first scrape — so they do NOT share a base interface.

## Changes

**Registration surface (Application layer):**
- `IHumansMetrics` — registration-only interface: `CreateCounter<T>`, `CreateObservableGauge` (single + multi-measurement), `RegisterGaugeRefresher`. All `RecordXxx` methods removed.
- `IMetricsContributor` — section hook. Each section's contributor implements `Initialize(IHumansMetrics)` to register its own counters and gauges.

**Narrow, section-owned metrics contracts (replace the old catch-all `IHumansMetrics.Record*`):**
- `IEmailMetrics` (Email) — `RecordSent`, `RecordQueued`, `RecordFailed`, `SetOutboxPending`
- `IConsentMetrics` (Consent) — `RecordConsentGiven`
- `IOnboardingMetrics` (Onboarding) — `RecordVolunteerApproved`, `RecordMemberSuspended`
- `IApplicationMetrics` (Governance) — `RecordApplicationProcessed`
- `IGoogleSyncMetrics` (Google Integration) — `RecordSyncOperation`
- `IJobRunMetrics` (Infrastructure — cross-cutting for every Hangfire job) — `RecordJobRun`

**Section contributors (each registered as a Singleton in `TelemetryInfrastructureExtensions`):**
- `Profiles` → `humans.humans_total` (by status), `humans.pending_volunteers`
- `Users` → `humans.pending_deletions`
- `Consent` → `humans.pending_consents`, `humans.consent_deadline_approaching`, `humans.consents_given_total`
- `Onboarding` → `humans.volunteers_approved_total`, `humans.members_suspended_total`
- `Governance` → `humans.asociados`, `humans.applications_pending`, `humans.applications_processed_total`
- `Auth` → `humans.role_assignments_active` (by role)
- `Teams` → `humans.teams` (by status), `humans.team_join_requests_pending`
- `Google Integration` → `humans.google_sync_outbox_pending`, `humans.google_resources`, `humans.sync_operations_total`
- `Email` → `humans.email_outbox_pending`, `humans.emails_sent_total`, `humans.email_queued_total`, `humans.email_failed_total`
- `Legal` → `humans.legal_documents_active`
- cross-cutting `JobRunMetricsContributor` → `humans.job_runs_total`

**Service method extensions** (needed so gauge refreshers never touch the DB directly):
- `IProfileService.GetProfileStatusCountsAsync` → `(Approved, Suspended, Pending)`. Single-query repository backing.
- `IRoleAssignmentService.GetActiveCountsByRoleAsync` + matching repository method.

**Call-site conversions** (~35 files migrated off `IHumansMetrics`):
- `SmtpEmailService`, `OutboxEmailService`, `ProcessEmailOutboxJob` → `IEmailMetrics`
- `ConsentService` → `IConsentMetrics`
- `OnboardingService`, `SuspendNonCompliantMembersJob` → `IOnboardingMetrics`
- `ApplicationDecisionService` → `IApplicationMetrics`
- `ProcessGoogleSyncOutboxJob` → `IGoogleSyncMetrics` + `IJobRunMetrics`
- Every Hangfire job that previously called `RecordJobRun` → `IJobRunMetrics`

## Hard requirement check — metric names + tags

Every pre-PR metric emits unchanged, with identical names, descriptions, and tag dimensions:

- Gauges: `humans.humans_total` (status), `humans.pending_volunteers`, `humans.pending_consents`, `humans.consent_deadline_approaching`, `humans.pending_deletions`, `humans.asociados`, `humans.role_assignments_active` (role), `humans.teams` (status), `humans.team_join_requests_pending`, `humans.google_resources`, `humans.legal_documents_active`, `humans.applications_pending` (status), `humans.google_sync_outbox_pending`, `humans.email_outbox_pending`.
- Counters: `humans.emails_sent_total` (template), `humans.consents_given_total`, `humans.members_suspended_total` (source), `humans.volunteers_approved_total`, `humans.sync_operations_total` (result), `humans.applications_processed_total` (action), `humans.job_runs_total` (job, result), `humans.email_queued_total` (template), `humans.email_failed_total` (template).

No metric was added. No metric was removed. No tag name or value was renamed.

## Isolation

`HumansMetricsService.RunOneAsync` wraps each refresher in a per-callback try/catch — one section's DB hiccup logs and leaves its gauges at their previous values for that cycle, without affecting other sections' scrapes.

## Verification

- [ ] Scrape `/metrics` before/after the deploy and diff — metric names + tag dimensions unchanged
- [ ] Admin dashboard counters that rely on `humans.*` series render identically
- [ ] `dotnet build` clean, `dotnet test` all green (116 Domain + 1593 Application + 35 Integration), `dotnet format --verify-no-changes` clean

Closes nobodies-collective/Humans#580
Related: nobodies-collective/Humans#581 (sibling push-model inversion for navbar notification meters)