### PR TITLE
fix: bump Microsoft packages 10.0.6 → 10.0.7 to patch GHSA-9mv3-2cwr-p262

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,13 +8,13 @@
     <PackageVersion Include="HtmlSanitizer" Version="9.0.892" />
     <PackageVersion Include="Ical.Net" Version="5.2.1" />
     <PackageVersion Include="Markdig" Version="1.1.2" />
-    <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.Google" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.Google" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
     <!-- Database -->
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime" Version="10.0.1" />
     <!-- NodaTime -->
@@ -56,13 +56,13 @@
     <PackageVersion Include="Serilog.Sinks.OpenTelemetry" Version="4.2.0" />
     <!-- Image Processing -->
     <PackageVersion Include="Magick.NET-Q8-AnyCPU" Version="14.12.0" />
-    <!-- Transitive pin: patches GHSA-37gx-xxp4-5rgx / GHSA-w3x6-4m5h-cxqf in 10.0.5 -->
-    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.6" />
+    <!-- Transitive pin: patches GHSA-37gx-xxp4-5rgx / GHSA-w3x6-4m5h-cxqf / GHSA-9mv3-2cwr-p262 -->
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.7" />
     <!-- Localization -->
-    <PackageVersion Include="Microsoft.Extensions.Localization" Version="10.0.6" />
-    <!-- Data Protection -->
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.Localization" Version="10.0.7" />
+    <!-- Data Protection: 10.0.7 patches GHSA-9mv3-2cwr-p262 -->
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="10.0.7" />
     <!-- Health Checks -->
     <PackageVersion Include="AspNetCore.HealthChecks.NpgSql" Version="9.0.0" />
     <PackageVersion Include="AspNetCore.HealthChecks.Hangfire" Version="9.0.0" />


### PR DESCRIPTION
This morning, I got 
```
Humans/src/Humans.Infrastructure/Humans.Infrastructure.csproj :
error NU1903: Warning As Error: Package 'Microsoft.AspNetCore.DataProtection' 10.0.6
has a known high severity vulnerability,
https://github.com/advisories/GHSA-9mv3-2cwr-p262
```
when I tried to run the project, due to a new CVE.

Here is the fix:

## Summary

- Bumps all `Microsoft.*` packages from `10.0.6` to `10.0.7` in `Directory.Packages.props`
- Patches high-severity vulnerability [GHSA-9mv3-2cwr-p262](https://github.com/advisories/GHSA-9mv3-2cwr-p262) in `Microsoft.AspNetCore.DataProtection`
- Updates the `System.Security.Cryptography.Xml` transitive pin to `10.0.7` to satisfy the new dependency requirement

## Test plan

- [ ] `dotnet build Humans.slnx` passes with no vulnerability warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)