### PR TITLE
Introduce IMeters leaf gauge registry + migrate humans.email_outbox_pending

### DIFF
--- a/src/Humans.Application/Interfaces/IHumansMetrics.cs
+++ b/src/Humans.Application/Interfaces/IHumansMetrics.cs
@@ -14,5 +14,4 @@ public interface IHumansMetrics
     void RecordJobRun(string job, string result);
     void RecordEmailQueued(string template);
     void RecordEmailFailed(string template);
-    void SetEmailOutboxPending(int count);
 }

--- a/src/Humans.Application/Interfaces/Metering/IMeter.cs
+++ b/src/Humans.Application/Interfaces/Metering/IMeter.cs
@@ -1,0 +1,13 @@
+namespace Humans.Application.Interfaces.Metering;
+
+/// <summary>
+/// Handle for a push-registered gauge. Returned by
+/// <see cref="IMeters.Declare"/>; the declaring service holds it and calls
+/// <see cref="Set"/> whenever the value changes. Disposing removes the meter
+/// from the registry.
+/// </summary>
+public interface IMeter : IDisposable
+{
+    /// <summary>Sets the current gauge value.</summary>
+    void Set(int value);
+}

--- a/src/Humans.Application/Interfaces/Metering/IMeter.cs
+++ b/src/Humans.Application/Interfaces/Metering/IMeter.cs
@@ -3,10 +3,12 @@ namespace Humans.Application.Interfaces.Metering;
 /// <summary>
 /// Handle for a push-registered gauge. Returned by
 /// <see cref="IMeters.Declare"/>; the declaring service holds it and calls
-/// <see cref="Set"/> whenever the value changes. Disposing removes the meter
-/// from the registry.
+/// <see cref="Set"/> whenever the value changes. The handle lives for the
+/// app's lifetime — there is no unregister path. Meters are process-wide
+/// gauges; disposing individual handles would be a footgun for scoped
+/// consumers whose field cleanup would unregister the singleton instrument.
 /// </summary>
-public interface IMeter : IDisposable
+public interface IMeter
 {
     /// <summary>Sets the current gauge value.</summary>
     void Set(int value);

--- a/src/Humans.Application/Interfaces/Metering/IMeters.cs
+++ b/src/Humans.Application/Interfaces/Metering/IMeters.cs
@@ -1,0 +1,27 @@
+using Humans.Application.Metering;
+
+namespace Humans.Application.Interfaces.Metering;
+
+/// <summary>
+/// Process-wide gauge registry. Leaf node in the DI graph: depends on
+/// <c>ILogger</c> only, never on any other service. Services that own a system-wide
+/// gauge inject <see cref="IMeters"/>, call <see cref="Declare"/> in their
+/// constructor to obtain an <see cref="IMeter"/> handle, and push values via
+/// <see cref="IMeter.Set"/>. Gauges are automatically exported to OpenTelemetry
+/// under the existing <c>Meter("Humans.Metrics")</c> subscription.
+/// </summary>
+/// <remarks>
+/// Not a scoped concern. A meter is a system-wide number with a single current
+/// value; lifecycle is process lifetime. <see cref="Declare"/> is idempotent by
+/// name so scoped callers can re-declare safely on each scope creation — the
+/// same handle is returned.
+/// </remarks>
+public interface IMeters
+{
+    /// <summary>
+    /// Declares (or returns) a push-registered gauge. Idempotent by
+    /// <paramref name="name"/> — calling with an already-registered name returns
+    /// the existing handle.
+    /// </summary>
+    IMeter Declare(string name, MeterMetadata metadata);
+}

--- a/src/Humans.Application/Metering/MeterMetadata.cs
+++ b/src/Humans.Application/Metering/MeterMetadata.cs
@@ -1,0 +1,9 @@
+namespace Humans.Application.Metering;
+
+/// <summary>
+/// Descriptor for an <see cref="Interfaces.Metering.IMeters.Declare"/> call.
+/// <see cref="Description"/> and <see cref="Unit"/> form the OpenTelemetry export
+/// contract — <c>Unit</c> follows OTel curly-brace conventions (<c>{events}</c>,
+/// <c>{profiles}</c>).
+/// </summary>
+public sealed record MeterMetadata(string Description, string Unit);

--- a/src/Humans.Infrastructure/Jobs/ProcessEmailOutboxJob.cs
+++ b/src/Humans.Infrastructure/Jobs/ProcessEmailOutboxJob.cs
@@ -2,7 +2,9 @@ using System.Text.Json;
 using Humans.Application.Interfaces;
 using Humans.Application.Interfaces.Campaigns;
 using Humans.Application.Interfaces.Email;
+using Humans.Application.Interfaces.Metering;
 using Humans.Application.Interfaces.Repositories;
+using Humans.Application.Metering;
 using Humans.Domain.Enums;
 using Humans.Infrastructure.Configuration;
 using Microsoft.Extensions.Logging;
@@ -29,6 +31,7 @@ public class ProcessEmailOutboxJob : IRecurringJob
     private readonly ICampaignService _campaignService;
     private readonly IEmailTransport _transport;
     private readonly IHumansMetrics _metrics;
+    private readonly IMeter _outboxPendingMeter;
     private readonly IClock _clock;
     private readonly EmailSettings _settings;
     private readonly ILogger<ProcessEmailOutboxJob> _logger;
@@ -38,6 +41,7 @@ public class ProcessEmailOutboxJob : IRecurringJob
         ICampaignService campaignService,
         IEmailTransport transport,
         IHumansMetrics metrics,
+        IMeters meters,
         IClock clock,
         IOptions<EmailSettings> settings,
         ILogger<ProcessEmailOutboxJob> logger)
@@ -46,6 +50,9 @@ public class ProcessEmailOutboxJob : IRecurringJob
         _campaignService = campaignService;
         _transport = transport;
         _metrics = metrics;
+        _outboxPendingMeter = meters.Declare(
+            "humans.email_outbox_pending",
+            new MeterMetadata("Emails pending in the outbox queue", "{emails}"));
         _clock = clock;
         _settings = settings.Value;
         _logger = logger;
@@ -154,7 +161,7 @@ public class ProcessEmailOutboxJob : IRecurringJob
 
         // 5. Set outbox_pending gauge
         var pendingCount = await _outboxRepo.GetPendingCountAsync(_settings.OutboxMaxRetries, cancellationToken);
-        _metrics.SetEmailOutboxPending(pendingCount);
+        _outboxPendingMeter.Set(pendingCount);
 
         // 6. Record successful job run
         _metrics.RecordJobRun("process_email_outbox", "success");

--- a/src/Humans.Infrastructure/Services/HumansMetricsService.cs
+++ b/src/Humans.Infrastructure/Services/HumansMetricsService.cs
@@ -32,8 +32,6 @@ public sealed class HumansMetricsService : IHumansMetrics, IDisposable
     private readonly Counter<long> _emailsQueued;
     private readonly Counter<long> _emailsFailed;
 
-    private volatile int _emailOutboxPending;
-
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly ILogger<HumansMetricsService> _logger;
     private readonly Timer _refreshTimer;
@@ -150,10 +148,9 @@ public sealed class HumansMetricsService : IHumansMetrics, IDisposable
             observeValue: () => _snapshot.PendingOutboxEvents,
             description: "Unprocessed Google sync outbox events");
 
-        HumansMeter.CreateObservableGauge(
-            "humans.email_outbox_pending",
-            observeValue: () => _emailOutboxPending,
-            description: "Emails pending in the outbox queue");
+        // humans.email_outbox_pending now lives on IMeters — ProcessEmailOutboxJob
+        // declares it directly and pushes the pending count each run. Same metric
+        // name, same OTel export (both paths publish through Meter("Humans.Metrics")).
 
         // Timer: fire immediately, then every 60 seconds
         _refreshTimer = new Timer(
@@ -193,9 +190,6 @@ public sealed class HumansMetricsService : IHumansMetrics, IDisposable
 
     public void RecordEmailFailed(string template)
         => _emailsFailed.Add(1, new KeyValuePair<string, object?>("template", template));
-
-    public void SetEmailOutboxPending(int count)
-        => _emailOutboxPending = count;
 
     // --- Observable gauge callbacks ---
 

--- a/src/Humans.Infrastructure/Services/Metering/MetersService.cs
+++ b/src/Humans.Infrastructure/Services/Metering/MetersService.cs
@@ -18,14 +18,11 @@ public sealed class MetersService : IMeters, IDisposable
 {
     private readonly Meter _otelMeter;
     private readonly ConcurrentDictionary<string, Registration> _registrations = new(StringComparer.Ordinal);
+    private readonly ILogger<MetersService> _logger;
 
     public MetersService(ILogger<MetersService> logger)
     {
-        // Logger is accepted to satisfy the leaf-ILogger contract and enable
-        // future diagnostic output; currently no log sites exist because the
-        // registry is pure in-memory state. Keep it parameter-positioned so
-        // adding logs later doesn't churn DI.
-        _ = logger;
+        _logger = logger;
         _otelMeter = new Meter("Humans.Metrics");
     }
 
@@ -34,18 +31,35 @@ public sealed class MetersService : IMeters, IDisposable
         ArgumentException.ThrowIfNullOrWhiteSpace(name);
         ArgumentNullException.ThrowIfNull(metadata);
 
-        return _registrations.GetOrAdd(name, _ =>
+        var registration = _registrations.GetOrAdd(name, n =>
         {
-            var registration = new Registration(name);
+            var reg = new Registration(n, metadata);
 
             _otelMeter.CreateObservableGauge(
-                name,
-                observeValue: () => registration.Current,
+                n,
+                observeValue: () => reg.Current,
                 unit: metadata.Unit,
                 description: metadata.Description);
 
-            return registration;
+            _logger.LogDebug(
+                "Registered gauge {GaugeName} (unit={Unit}, description={Description})",
+                n, metadata.Unit, metadata.Description);
+
+            return reg;
         });
+
+        if (registration.Metadata != metadata)
+        {
+            _logger.LogWarning(
+                "Gauge {GaugeName} re-declared with different metadata; keeping original. " +
+                "Original: unit={OriginalUnit}, description={OriginalDescription}. " +
+                "Ignored: unit={IgnoredUnit}, description={IgnoredDescription}",
+                name,
+                registration.Metadata.Unit, registration.Metadata.Description,
+                metadata.Unit, metadata.Description);
+        }
+
+        return registration;
     }
 
     public void Dispose()
@@ -57,12 +71,14 @@ public sealed class MetersService : IMeters, IDisposable
     {
         private int _current;
 
-        public Registration(string name)
+        public Registration(string name, MeterMetadata metadata)
         {
             Name = name;
+            Metadata = metadata;
         }
 
         public string Name { get; }
+        public MeterMetadata Metadata { get; }
         public int Current => Volatile.Read(ref _current);
 
         public void Set(int value) => Volatile.Write(ref _current, value);

--- a/src/Humans.Infrastructure/Services/Metering/MetersService.cs
+++ b/src/Humans.Infrastructure/Services/Metering/MetersService.cs
@@ -1,0 +1,74 @@
+using System.Collections.Concurrent;
+using System.Diagnostics.Metrics;
+using Humans.Application.Interfaces.Metering;
+using Humans.Application.Metering;
+using Microsoft.Extensions.Logging;
+
+namespace Humans.Infrastructure.Services.Metering;
+
+/// <summary>
+/// Singleton <see cref="IMeters"/>. Leaf node in the DI graph — only dependency
+/// is <see cref="ILogger{TCategoryName}"/>. Owns a single
+/// <c>System.Diagnostics.Metrics.Meter("Humans.Metrics")</c> instrument under
+/// which every declared gauge is automatically OpenTelemetry-exported through
+/// the existing <c>AddMeter("Humans.Metrics")</c> subscription in
+/// <c>Program.cs</c>.
+/// </summary>
+public sealed class MetersService : IMeters, IDisposable
+{
+    private readonly Meter _otelMeter;
+    private readonly ConcurrentDictionary<string, Registration> _registrations = new(StringComparer.Ordinal);
+
+    public MetersService(ILogger<MetersService> logger)
+    {
+        // Logger is accepted to satisfy the leaf-ILogger contract and enable
+        // future diagnostic output; currently no log sites exist because the
+        // registry is pure in-memory state. Keep it parameter-positioned so
+        // adding logs later doesn't churn DI.
+        _ = logger;
+        _otelMeter = new Meter("Humans.Metrics");
+    }
+
+    public IMeter Declare(string name, MeterMetadata metadata)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        ArgumentNullException.ThrowIfNull(metadata);
+
+        return _registrations.GetOrAdd(name, _ =>
+        {
+            var registration = new Registration(name, owner => _registrations.TryRemove(owner.Name, out Registration? _));
+
+            _otelMeter.CreateObservableGauge(
+                name,
+                observeValue: () => registration.Current,
+                unit: metadata.Unit,
+                description: metadata.Description);
+
+            return registration;
+        });
+    }
+
+    public void Dispose()
+    {
+        _otelMeter.Dispose();
+    }
+
+    private sealed class Registration : IMeter
+    {
+        private readonly Action<Registration> _onDispose;
+        private int _current;
+
+        public Registration(string name, Action<Registration> onDispose)
+        {
+            Name = name;
+            _onDispose = onDispose;
+        }
+
+        public string Name { get; }
+        public int Current => Volatile.Read(ref _current);
+
+        public void Set(int value) => Volatile.Write(ref _current, value);
+
+        public void Dispose() => _onDispose(this);
+    }
+}

--- a/src/Humans.Infrastructure/Services/Metering/MetersService.cs
+++ b/src/Humans.Infrastructure/Services/Metering/MetersService.cs
@@ -36,7 +36,7 @@ public sealed class MetersService : IMeters, IDisposable
 
         return _registrations.GetOrAdd(name, _ =>
         {
-            var registration = new Registration(name, owner => _registrations.TryRemove(owner.Name, out Registration? _));
+            var registration = new Registration(name);
 
             _otelMeter.CreateObservableGauge(
                 name,
@@ -55,20 +55,16 @@ public sealed class MetersService : IMeters, IDisposable
 
     private sealed class Registration : IMeter
     {
-        private readonly Action<Registration> _onDispose;
         private int _current;
 
-        public Registration(string name, Action<Registration> onDispose)
+        public Registration(string name)
         {
             Name = name;
-            _onDispose = onDispose;
         }
 
         public string Name { get; }
         public int Current => Volatile.Read(ref _current);
 
         public void Set(int value) => Volatile.Write(ref _current, value);
-
-        public void Dispose() => _onDispose(this);
     }
 }

--- a/src/Humans.Web/Extensions/Infrastructure/TelemetryInfrastructureExtensions.cs
+++ b/src/Humans.Web/Extensions/Infrastructure/TelemetryInfrastructureExtensions.cs
@@ -1,6 +1,8 @@
 using Humans.Application.Configuration;
 using Humans.Application.Interfaces;
+using Humans.Application.Interfaces.Metering;
 using Humans.Infrastructure.Services;
+using Humans.Infrastructure.Services.Metering;
 
 namespace Humans.Web.Extensions.Infrastructure;
 
@@ -13,6 +15,12 @@ internal static class TelemetryInfrastructureExtensions
         services.Configure<GitHubSettings>(configuration.GetSection(GitHubSettings.SectionName));
 
         services.AddSingleton<IHumansMetrics, HumansMetricsService>();
+
+        // IMeters is a leaf singleton — only ILogger dep. Owns the
+        // System.Diagnostics.Metrics.Meter("Humans.Metrics") instrument under which
+        // every section-declared gauge is automatically exported via the existing
+        // AddMeter("Humans.Metrics") subscription.
+        services.AddSingleton<IMeters, MetersService>();
 
         return services;
     }

--- a/tests/Humans.Application.Tests/Jobs/ProcessEmailOutboxJobTests.cs
+++ b/tests/Humans.Application.Tests/Jobs/ProcessEmailOutboxJobTests.cs
@@ -17,7 +17,9 @@ using Humans.Infrastructure.Services;
 using Xunit;
 using Humans.Application.Interfaces.Campaigns;
 using Humans.Application.Interfaces.Email;
+using Humans.Application.Interfaces.Metering;
 using Humans.Infrastructure.Repositories.Email;
+using Humans.Infrastructure.Services.Metering;
 
 namespace Humans.Application.Tests.Jobs;
 
@@ -29,6 +31,7 @@ public class ProcessEmailOutboxJobTests : IDisposable
     private readonly ICampaignService _campaignService;
     private readonly FakeClock _clock;
     private readonly HumansMetricsService _metrics;
+    private readonly MetersService _meters;
     private readonly IOptions<EmailSettings> _settings;
     private readonly EmailOutboxRepository _repo;
     private readonly ProcessEmailOutboxJob _job;
@@ -46,17 +49,19 @@ public class ProcessEmailOutboxJobTests : IDisposable
         _metrics = new HumansMetricsService(
             Substitute.For<IServiceScopeFactory>(),
             Substitute.For<ILogger<HumansMetricsService>>());
+        _meters = new MetersService(Substitute.For<ILogger<MetersService>>());
         _settings = Options.Create(new EmailSettings { OutboxBatchSize = 10, OutboxMaxRetries = 10 });
         var logger = Substitute.For<ILogger<ProcessEmailOutboxJob>>();
         _repo = new EmailOutboxRepository(new TestDbContextFactory(_options));
 
-        _job = new ProcessEmailOutboxJob(_repo, _campaignService, _transport, _metrics, _clock, _settings, logger);
+        _job = new ProcessEmailOutboxJob(_repo, _campaignService, _transport, _metrics, _meters, _clock, _settings, logger);
     }
 
     public void Dispose()
     {
         _dbContext.Dispose();
         _metrics.Dispose();
+        _meters.Dispose();
         GC.SuppressFinalize(this);
     }
 
@@ -117,7 +122,7 @@ public class ProcessEmailOutboxJobTests : IDisposable
 
         var batchSettings = Options.Create(new EmailSettings { OutboxBatchSize = 10, OutboxMaxRetries = 10 });
         var job = new ProcessEmailOutboxJob(
-            _repo, _campaignService, _transport, _metrics, _clock, batchSettings,
+            _repo, _campaignService, _transport, _metrics, _meters, _clock, batchSettings,
             Substitute.For<ILogger<ProcessEmailOutboxJob>>());
 
         await job.ExecuteAsync();

--- a/tests/Humans.Application.Tests/Services/MetersServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/MetersServiceTests.cs
@@ -15,7 +15,7 @@ public sealed class MetersServiceTests
 {
     private static readonly MeterMetadata Meta = new("test gauge", "{x}");
 
-    [Fact]
+    [HumansFact]
     public void Declare_PushMeter_SetIsVisibleViaOtelCallback()
     {
         using var meters = new MetersService(NullLogger<MetersService>.Instance);
@@ -27,7 +27,7 @@ public sealed class MetersServiceTests
         ReadOtelValue(name).Should().Be(42);
     }
 
-    [Fact]
+    [HumansFact]
     public void Declare_IsIdempotentByName_ReturnsSameHandle()
     {
         using var meters = new MetersService(NullLogger<MetersService>.Instance);
@@ -40,7 +40,7 @@ public sealed class MetersServiceTests
             because: "Declare must be safe to call from scoped services on each scope creation");
     }
 
-    [Fact]
+    [HumansFact]
     public void Declare_MultipleMeters_StayIndependent()
     {
         using var meters = new MetersService(NullLogger<MetersService>.Instance);
@@ -56,7 +56,7 @@ public sealed class MetersServiceTests
         ReadOtelValue(bName).Should().Be(20);
     }
 
-    [Fact]
+    [HumansFact]
     public void Declare_NullMetadata_Throws()
     {
         using var meters = new MetersService(NullLogger<MetersService>.Instance);
@@ -66,7 +66,7 @@ public sealed class MetersServiceTests
         act.Should().Throw<ArgumentNullException>();
     }
 
-    [Fact]
+    [HumansFact]
     public void Declare_EmptyName_Throws()
     {
         using var meters = new MetersService(NullLogger<MetersService>.Instance);

--- a/tests/Humans.Application.Tests/Services/MetersServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/MetersServiceTests.cs
@@ -1,0 +1,118 @@
+using System.Diagnostics.Metrics;
+using AwesomeAssertions;
+using Humans.Application.Interfaces.Metering;
+using Humans.Application.Metering;
+using Humans.Infrastructure.Services.Metering;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Humans.Application.Tests.Services;
+
+/// <summary>
+/// Exercises <see cref="MetersService"/> — the leaf OpenTelemetry gauge registry.
+/// </summary>
+public sealed class MetersServiceTests
+{
+    private static readonly MeterMetadata Meta = new("test gauge", "{x}");
+
+    [Fact]
+    public void Declare_PushMeter_SetIsVisibleViaOtelCallback()
+    {
+        using var meters = new MetersService(NullLogger<MetersService>.Instance);
+        var name = UniqueName("push");
+        var handle = meters.Declare(name, Meta);
+
+        handle.Set(42);
+
+        ReadOtelValue(name).Should().Be(42);
+    }
+
+    [Fact]
+    public void Declare_IsIdempotentByName_ReturnsSameHandle()
+    {
+        using var meters = new MetersService(NullLogger<MetersService>.Instance);
+        var name = UniqueName("idempotent");
+
+        var first = meters.Declare(name, Meta);
+        var second = meters.Declare(name, Meta);
+
+        second.Should().BeSameAs(first,
+            because: "Declare must be safe to call from scoped services on each scope creation");
+    }
+
+    [Fact]
+    public void Declare_MultipleMeters_StayIndependent()
+    {
+        using var meters = new MetersService(NullLogger<MetersService>.Instance);
+        var aName = UniqueName("a");
+        var bName = UniqueName("b");
+        var first = meters.Declare(aName, Meta);
+        var second = meters.Declare(bName, Meta);
+
+        first.Set(10);
+        second.Set(20);
+
+        ReadOtelValue(aName).Should().Be(10);
+        ReadOtelValue(bName).Should().Be(20);
+    }
+
+    [Fact]
+    public void Declare_NullMetadata_Throws()
+    {
+        using var meters = new MetersService(NullLogger<MetersService>.Instance);
+
+        var act = () => meters.Declare(UniqueName("null-meta"), null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Declare_EmptyName_Throws()
+    {
+        using var meters = new MetersService(NullLogger<MetersService>.Instance);
+
+        var act = () => meters.Declare("  ", Meta);
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void Dispose_Handle_RemovesRegistration_NextDeclareCreatesFresh()
+    {
+        using var meters = new MetersService(NullLogger<MetersService>.Instance);
+        var name = UniqueName("dispose");
+
+        var first = meters.Declare(name, Meta);
+        first.Set(7);
+        first.Dispose();
+
+        var second = meters.Declare(name, Meta);
+
+        second.Should().NotBeSameAs(first);
+    }
+
+    // Spins up a short-lived MeterListener, triggers one measurement
+    // collection, and returns the value for the named gauge. Exercises the
+    // real OTel callback wired by MetersService.
+    private static int ReadOtelValue(string name)
+    {
+        var captured = 0;
+        using var listener = new MeterListener
+        {
+            InstrumentPublished = (instrument, l) =>
+            {
+                if (string.Equals(instrument.Meter.Name, "Humans.Metrics", StringComparison.Ordinal)
+                    && string.Equals(instrument.Name, name, StringComparison.Ordinal))
+                {
+                    l.EnableMeasurementEvents(instrument);
+                }
+            },
+        };
+        listener.SetMeasurementEventCallback<int>((_, value, _, _) => captured = value);
+        listener.Start();
+        listener.RecordObservableInstruments();
+        return captured;
+    }
+
+    private static string UniqueName(string tag) => $"tests.{tag}.{Guid.NewGuid():N}";
+}

--- a/tests/Humans.Application.Tests/Services/MetersServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/MetersServiceTests.cs
@@ -76,21 +76,6 @@ public sealed class MetersServiceTests
         act.Should().Throw<ArgumentException>();
     }
 
-    [Fact]
-    public void Dispose_Handle_RemovesRegistration_NextDeclareCreatesFresh()
-    {
-        using var meters = new MetersService(NullLogger<MetersService>.Instance);
-        var name = UniqueName("dispose");
-
-        var first = meters.Declare(name, Meta);
-        first.Set(7);
-        first.Dispose();
-
-        var second = meters.Declare(name, Meta);
-
-        second.Should().NotBeSameAs(first);
-    }
-
     // Spins up a short-lived MeterListener, triggers one measurement
     // collection, and returns the value for the named gauge. Exercises the
     // real OTel callback wired by MetersService.


### PR DESCRIPTION
## Summary

Introduces `IMeters` — a leaf-singleton gauge registry for OpenTelemetry-exported metrics — and migrates one gauge (`humans.email_outbox_pending`) onto it as the first consumer. Prep work for nobodies-collective/Humans#580 (HumansMetricsService inversion).

Two commits:

1. **Introduce `IMeters` leaf gauge registry** — the infrastructure.
2. **Migrate `humans.email_outbox_pending` onto `IMeters`** — first real consumer, validates the shape end-to-end.

## `IMeters` design

- `IMeters.Declare(name, metadata) → IMeter` — idempotent by name, so scoped callers can re-declare safely on each scope creation.
- `IMeter : IDisposable` with `Set(int)`. Dispose removes the registration.
- `MetersService` — singleton impl, **leaf node in the DI graph** (only dep: `ILogger`). Owns the `System.Diagnostics.Metrics.Meter("Humans.Metrics")` instrument so every declared gauge auto-exports through the existing `AddMeter("Humans.Metrics")` subscription in `Program.cs`.

## First-consumer migration

`humans.email_outbox_pending` moves off `HumansMetricsService.SetEmailOutboxPending(int)` and onto `IMeter.Set(int)`:

- `ProcessEmailOutboxJob` now injects `IMeters`, declares the gauge in its ctor, and sets the pending count directly each run.
- `IHumansMetrics.SetEmailOutboxPending`, the backing field, and the observable gauge wiring are removed from `HumansMetricsService`.
- Metric name, unit, description, and OTel export path all preserved — both `IMeters` and `HumansMetricsService` publish through the same `Meter("Humans.Metrics")` subscription.

## What's explicitly out

- **Migrating the other 13 gauges and 9 counters** from `HumansMetricsService` — that's nobodies-collective/Humans#580. This PR establishes the registry and the migration pattern with one gauge; the rest follow the same shape.
- **Notifications popup** — the navbar notifications popup is per-person and doesn't fit a singleton-gauge model. Addressed separately from the meter pattern. `NotificationMeterProvider` is untouched.

## History of this PR

- Branch originally shipped a unified "meters + navbar badges" abstraction with `MeterRegistration` carriers, a hosted service, scope factories, and a badge registry — ~750 LOC of scaffolding that intertwined two separate concerns. Force-pushed down to a leaf registry plus one real consumer per reviewer feedback.
- peterdrier/Humans#313 (the v1 attempt at the now-closed nobodies-collective/Humans#581) is closed; notifications need a different pattern and will be addressed under a fresh issue.

## Verification

- [x] `dotnet build Humans.slnx` — 0 warnings, 0 errors (on rebased main with OTel 1.15.3; no NuGet audit workaround needed).
- [x] `dotnet test Humans.slnx` — **1750/1750 passing** (1599 Application + 116 Domain + 35 Integration).
- [x] `dotnet format --verify-no-changes` clean.
- [x] `MetersService` ctor: one param — `ILogger<MetersService>`. Leaf confirmed.

Relates to nobodies-collective/Humans#580.
