### PR TITLE
fix: bump OpenTelemetry packages 1.15.2 → 1.15.3 to patch GHSA-g94r-2vxg-569j / GHSA-mr8r-92fq-pj8p

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -42,9 +42,9 @@
     <!-- Resilience -->
     <PackageVersion Include="Polly" Version="8.6.6" />
     <!-- Observability -->
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.2" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.15.0-beta.1" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.2" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.15.0-beta.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />

--- a/src/Humans.Web/Views/About/Index.cshtml
+++ b/src/Humans.Web/Views/About/Index.cshtml
@@ -277,7 +277,7 @@
                 <tr>
                     <td>Observability</td>
                     <td><a href="https://www.nuget.org/packages/OpenTelemetry.Exporter.OpenTelemetryProtocol" target="_blank" rel="noopener noreferrer">OpenTelemetry.Exporter.OpenTelemetryProtocol</a></td>
-                    <td>1.15.2</td>
+                    <td>1.15.3</td>
                     <td>Apache-2.0</td>
                 </tr>
                 <tr>
@@ -289,7 +289,7 @@
                 <tr>
                     <td>Observability</td>
                     <td><a href="https://www.nuget.org/packages/OpenTelemetry.Extensions.Hosting" target="_blank" rel="noopener noreferrer">OpenTelemetry.Extensions.Hosting</a></td>
-                    <td>1.15.2</td>
+                    <td>1.15.3</td>
                     <td>Apache-2.0</td>
                 </tr>
                 <tr>


### PR DESCRIPTION
## Summary

Bumps OpenTelemetry packages to patch two moderate-severity NuGet vulnerability advisories that are currently breaking CI (restore fails with `NU1902: Warning As Error`).

- `OpenTelemetry.Exporter.OpenTelemetryProtocol`: 1.15.2 → 1.15.3
- `OpenTelemetry.Extensions.Hosting`: 1.15.2 → 1.15.3

The `OpenTelemetry.Api` transitive pulls up to 1.15.3 via these bumps, which closes the first advisory as well.

## Advisories patched

- [GHSA-g94r-2vxg-569j](https://github.com/advisories/GHSA-g94r-2vxg-569j) — Excessive memory allocation when parsing OpenTelemetry propagation headers (`OpenTelemetry.Api`, transitive; fixed in 1.15.3)
- [GHSA-mr8r-92fq-pj8p](https://github.com/advisories/GHSA-mr8r-92fq-pj8p) — Unbounded `grpc-status-details-bin` parsing in OTLP/gRPC retry handling (`OpenTelemetry.Exporter.OpenTelemetryProtocol`; fixed in 1.15.3)

Also updates `About/Index.cshtml` to match.

## Test plan

- [x] `dotnet restore Humans.slnx` succeeds with no NU1902 errors
- [x] `dotnet build Humans.slnx` succeeds (0 warnings, 0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)