### PR TITLE
feat(city-planning): GeoJSON polygon bulk import

### DIFF
--- a/docs/superpowers/plans/2026-04-25-city-planning-import.md
+++ b/docs/superpowers/plans/2026-04-25-city-planning-import.md
@@ -1,0 +1,452 @@
+# City Planning GeoJSON Import Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a GeoJSON polygon bulk-import card to the CityPlanning Admin page that lets map admins upload a file, preview matched/unmatched camps with before/after areas, confirm, and apply updates using the existing polygon save API.
+
+**Architecture:** The backend change is minimal — add an optional `Note` field to `SaveCampPolygonRequest` so the JS can tag imports with `"Imported YYYY-MM-DD HH:mm"`. All matching, area computation (Turf.js), and sequenced save calls happen client-side in a new `admin-import.js` script loaded only on the Admin page. A Bootstrap modal provides the preview UX before any writes are committed.
+
+**Tech Stack:** C# / ASP.NET Core MVC, Bootstrap 5 modal, Turf.js (already CDN-loaded on the map page; added to Admin page), vanilla JS ES module, CSRF via `RequestVerificationToken` header.
+
+---
+
+## Files
+
+| Action | File |
+|--------|------|
+| Modify | `src/Humans.Application/Interfaces/CitiPlanning/ICityPlanningService.cs` |
+| Modify | `src/Humans.Web/Controllers/CityPlanningApiController.cs` |
+| Modify | `src/Humans.Web/Views/CityPlanning/Admin.cshtml` |
+| Create | `src/Humans.Web/wwwroot/js/city-planning/admin-import.js` |
+
+---
+
+## Task 1: Create feature branch
+
+- [ ] **Step 1: Create and switch to branch**
+
+```bash
+git checkout -b feat/city-planning-import
+```
+
+- [ ] **Step 2: Verify**
+
+```bash
+git branch --show-current
+```
+
+Expected output: `feat/city-planning-import`
+
+---
+
+## Task 2: Add optional `Note` to `SaveCampPolygonRequest`
+
+The save endpoint currently ignores any note and always passes `"Saved"` to the service. This task exposes the `note` parameter that the service already supports.
+
+**Files:**
+- Modify: `src/Humans.Application/Interfaces/CitiPlanning/ICityPlanningService.cs:72`
+- Modify: `src/Humans.Web/Controllers/CityPlanningApiController.cs:104-106`
+
+- [ ] **Step 1: Add `Note` to the request record**
+
+In `src/Humans.Application/Interfaces/CitiPlanning/ICityPlanningService.cs`, change line 72:
+
+```csharp
+// Before:
+public record SaveCampPolygonRequest(string GeoJson, double AreaSqm);
+
+// After:
+public record SaveCampPolygonRequest(string GeoJson, double AreaSqm, string? Note = null);
+```
+
+- [ ] **Step 2: Pass the note through in the controller**
+
+In `src/Humans.Web/Controllers/CityPlanningApiController.cs`, change the `SaveCampPolygon` action (around line 104):
+
+```csharp
+// Before:
+var (polygon, _) = await _cityPlanningService.SaveCampPolygonAsync(
+    campSeasonId, request.GeoJson, request.AreaSqm, userId,
+    cancellationToken: cancellationToken);
+
+// After:
+var (polygon, _) = await _cityPlanningService.SaveCampPolygonAsync(
+    campSeasonId, request.GeoJson, request.AreaSqm, userId,
+    note: request.Note ?? "Saved",
+    cancellationToken: cancellationToken);
+```
+
+- [ ] **Step 3: Build**
+
+```bash
+dotnet build Humans.slnx
+```
+
+Expected: Build succeeded, 0 errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Humans.Application/Interfaces/CitiPlanning/ICityPlanningService.cs \
+        src/Humans.Web/Controllers/CityPlanningApiController.cs
+git commit -m "feat(city-planning): add optional Note field to SaveCampPolygonRequest"
+```
+
+---
+
+## Task 3: Create `admin-import.js`
+
+This standalone script handles the full import flow: file reading, fetching map state, matching features to camps, area computation, preview dialog, and sequenced PUT calls.
+
+**Files:**
+- Create: `src/Humans.Web/wwwroot/js/city-planning/admin-import.js`
+
+- [ ] **Step 1: Create the file with the matching and area computation logic**
+
+```javascript
+// admin-import.js — GeoJSON bulk import for the City Planning Admin page.
+// Depends on: turf (global), Bootstrap 5 modal (global).
+
+const fileInput   = document.getElementById('import-file-input');
+const previewBtn  = document.getElementById('import-preview-btn');
+const errorDiv    = document.getElementById('import-error');
+
+let pendingImport = null; // { matched: [{campSeasonId, campName, previousAreaSqm, newAreaSqm, geoJson}], unrecognized: [string] }
+
+function showError(msg) {
+    errorDiv.textContent = msg;
+    errorDiv.classList.remove('d-none');
+}
+
+function clearError() {
+    errorDiv.textContent = '';
+    errorDiv.classList.add('d-none');
+}
+
+function formatArea(sqm) {
+    if (sqm == null) return '—';
+    return Math.round(sqm).toLocaleString() + ' m²';
+}
+
+function buildCampLookup(state) {
+    const lookup = new Map(); // key: normalised name or slug → {campSeasonId, campName, currentAreaSqm}
+    for (const p of state.campPolygons ?? []) {
+        lookup.set(p.campName.toLowerCase(),  { campSeasonId: p.campSeasonId, campName: p.campName, currentAreaSqm: p.areaSqm });
+        lookup.set(p.campSlug.toLowerCase(),  { campSeasonId: p.campSeasonId, campName: p.campName, currentAreaSqm: p.areaSqm });
+    }
+    for (const s of state.campSeasonsWithoutPolygon ?? []) {
+        lookup.set(s.campName.toLowerCase(), { campSeasonId: s.campSeasonId, campName: s.campName, currentAreaSqm: null });
+        lookup.set(s.campSlug.toLowerCase(), { campSeasonId: s.campSeasonId, campName: s.campName, currentAreaSqm: null });
+    }
+    return lookup;
+}
+
+function matchFeatures(features, lookup) {
+    const matched = [];
+    const unrecognized = [];
+    const seenIds = new Set();
+
+    for (const feature of features) {
+        const props = feature.properties ?? {};
+        const name  = (props.campName ?? '').toLowerCase();
+        const slug  = (props.campSlug ?? '').toLowerCase();
+        const camp  = lookup.get(name) || lookup.get(slug);
+
+        if (!camp) {
+            unrecognized.push(props.campName || props.campSlug || '(unnamed feature)');
+            continue;
+        }
+        if (seenIds.has(camp.campSeasonId)) continue; // skip duplicates in file
+        seenIds.add(camp.campSeasonId);
+
+        const newAreaSqm = turf.area(feature);
+        matched.push({
+            campSeasonId:    camp.campSeasonId,
+            campName:        camp.campName,
+            previousAreaSqm: camp.currentAreaSqm,
+            newAreaSqm,
+            geoJson:         JSON.stringify(feature),
+        });
+    }
+
+    return { matched, unrecognized };
+}
+
+async function handlePreview() {
+    clearError();
+    const file = fileInput.files?.[0];
+    if (!file) { showError('Please select a GeoJSON file.'); return; }
+
+    let parsed;
+    try {
+        parsed = JSON.parse(await file.text());
+    } catch {
+        showError('Invalid file — not valid JSON.'); return;
+    }
+    if (parsed?.type !== 'FeatureCollection' || !Array.isArray(parsed.features)) {
+        showError('File must be a GeoJSON FeatureCollection.'); return;
+    }
+
+    let state;
+    try {
+        const resp = await fetch('/api/city-planning/state');
+        if (!resp.ok) throw new Error();
+        state = await resp.json();
+    } catch {
+        showError('Could not load camp list. Please try again.'); return;
+    }
+
+    const lookup = buildCampLookup(state);
+    const { matched, unrecognized } = matchFeatures(parsed.features, lookup);
+    pendingImport = { matched, unrecognized };
+
+    renderPreviewModal(matched, unrecognized);
+    bootstrap.Modal.getOrCreateInstance(document.getElementById('import-preview-modal')).show();
+}
+
+function renderPreviewModal(matched, unrecognized) {
+    const matchedBody  = document.getElementById('import-matched-body');
+    const unrecSection = document.getElementById('import-unrecognized-section');
+    const unrecList    = document.getElementById('import-unrecognized-list');
+    const confirmBtn   = document.getElementById('import-confirm-btn');
+
+    if (matched.length === 0) {
+        matchedBody.innerHTML = '<tr><td colspan="3" class="text-muted text-center">No camps matched.</td></tr>';
+        confirmBtn.disabled = true;
+    } else {
+        matchedBody.innerHTML = matched.map(m => `
+            <tr>
+                <td>${escHtml(m.campName)}</td>
+                <td class="text-end">${formatArea(m.previousAreaSqm)}</td>
+                <td class="text-end">${formatArea(m.newAreaSqm)}</td>
+            </tr>
+        `).join('');
+        confirmBtn.disabled = false;
+    }
+
+    if (unrecognized.length > 0) {
+        unrecList.innerHTML = unrecognized.map(n => `<li>${escHtml(n)}</li>`).join('');
+        unrecSection.classList.remove('d-none');
+    } else {
+        unrecSection.classList.add('d-none');
+    }
+}
+
+function escHtml(s) {
+    const d = document.createElement('div');
+    d.textContent = s;
+    return d.innerHTML;
+}
+
+async function handleConfirm() {
+    if (!pendingImport?.matched?.length) return;
+
+    const confirmBtn  = document.getElementById('import-confirm-btn');
+    const statusEl    = document.getElementById('import-status');
+    const token       = document.querySelector('input[name="__RequestVerificationToken"]').value;
+    const now         = new Date();
+    const noteDate    = now.toISOString().slice(0, 16).replace('T', ' '); // "YYYY-MM-DD HH:mm" UTC
+    const note        = `Imported ${noteDate}`;
+
+    confirmBtn.disabled = true;
+    statusEl.textContent = `Updating ${pendingImport.matched.length} polygon(s)…`;
+    statusEl.classList.remove('d-none');
+
+    let successCount = 0;
+    const failures   = [];
+
+    for (const item of pendingImport.matched) {
+        const resp = await fetch(`/api/city-planning/camp-polygons/${item.campSeasonId}`, {
+            method: 'PUT',
+            headers: {
+                'Content-Type': 'application/json',
+                'RequestVerificationToken': token,
+            },
+            body: JSON.stringify({ geoJson: item.geoJson, areaSqm: item.newAreaSqm, note }),
+        });
+        if (resp.ok) {
+            successCount++;
+        } else {
+            failures.push(item.campName);
+        }
+    }
+
+    bootstrap.Modal.getInstance(document.getElementById('import-preview-modal'))?.hide();
+
+    const resultDiv = document.getElementById('import-result');
+    if (failures.length === 0) {
+        resultDiv.className = 'alert alert-success mt-2';
+        resultDiv.textContent = `${successCount} polygon(s) updated.`;
+    } else {
+        resultDiv.className = 'alert alert-warning mt-2';
+        resultDiv.textContent = `${successCount} updated, ${failures.length} failed: ${failures.join(', ')}.`;
+    }
+    resultDiv.classList.remove('d-none');
+    pendingImport = null;
+    fileInput.value = '';
+}
+
+previewBtn?.addEventListener('click', handlePreview);
+document.getElementById('import-confirm-btn')?.addEventListener('click', handleConfirm);
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/Humans.Web/wwwroot/js/city-planning/admin-import.js
+git commit -m "feat(city-planning): add admin-import.js for GeoJSON bulk polygon import"
+```
+
+---
+
+## Task 4: Add Import card and modal to `Admin.cshtml`
+
+**Files:**
+- Modify: `src/Humans.Web/Views/CityPlanning/Admin.cshtml`
+
+- [ ] **Step 1: Add the Import card after the existing Export card**
+
+After the closing `</div>` of the Export card (line 188), add a new full-width column:
+
+```html
+        <!-- Import -->
+        <div class="col-12">
+            <div class="card">
+                <div class="card-header fw-semibold">
+                    <i class="fa-solid fa-file-import me-1"></i> Import polygons (@settings.Year)
+                </div>
+                <div class="card-body">
+                    <p class="mb-2">Upload a GeoJSON FeatureCollection to bulk-update camp polygons for @settings.Year. Features are matched by <code>campName</code> or <code>campSlug</code> property.</p>
+                    <div class="mb-3">
+                        <label class="form-label small fw-semibold">GeoJSON file</label>
+                        <input type="file" id="import-file-input" accept=".geojson,.json,application/geo+json" class="form-control form-control-sm" />
+                    </div>
+                    <button id="import-preview-btn" type="button" class="btn btn-primary btn-sm">
+                        <i class="fa-solid fa-eye me-1"></i> Preview import
+                    </button>
+                    <div id="import-error" class="text-danger small mt-2 d-none"></div>
+                    <div id="import-result" class="d-none mt-2"></div>
+                </div>
+            </div>
+        </div>
+```
+
+- [ ] **Step 2: Add the Bootstrap preview modal**
+
+Before the closing `</div>` of `<div class="container py-4">` (after all cards), add:
+
+```html
+<!-- Import preview modal -->
+<div class="modal fade" id="import-preview-modal" tabindex="-1" aria-labelledby="import-preview-modal-label" aria-hidden="true">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="import-preview-modal-label">
+                    <i class="fa-solid fa-file-import me-1"></i> Import preview
+                </h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <h6 class="mb-2">Will be updated</h6>
+                <table class="table table-sm table-bordered mb-3">
+                    <thead class="table-light">
+                        <tr>
+                            <th>Camp</th>
+                            <th class="text-end">Previous area</th>
+                            <th class="text-end">New area</th>
+                        </tr>
+                    </thead>
+                    <tbody id="import-matched-body"></tbody>
+                </table>
+
+                <div id="import-unrecognized-section" class="d-none">
+                    <h6 class="text-warning mb-1"><i class="fa-solid fa-triangle-exclamation me-1"></i> Unrecognized features (will be skipped)</h6>
+                    <ul id="import-unrecognized-list" class="small text-muted mb-0"></ul>
+                </div>
+
+                <div id="import-status" class="text-muted small mt-3 d-none"></div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary btn-sm" data-bs-dismiss="modal">Cancel</button>
+                <button type="button" id="import-confirm-btn" class="btn btn-primary btn-sm">
+                    <i class="fa-solid fa-check me-1"></i> Confirm import
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+```
+
+- [ ] **Step 3: Add Turf.js and the import script to the `@section Scripts` block**
+
+At the bottom of `Admin.cshtml`, add (or create) a `@section Scripts` block:
+
+```html
+@section Scripts {
+    <script src="https://unpkg.com/@@turf/turf@7.1.0/turf.min.js"></script>
+    <script src="~/js/city-planning/admin-import.js"></script>
+}
+```
+
+- [ ] **Step 4: Build**
+
+```bash
+dotnet build Humans.slnx
+```
+
+Expected: Build succeeded, 0 errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Humans.Web/Views/CityPlanning/Admin.cshtml
+git commit -m "feat(city-planning): add GeoJSON import card and preview modal to Admin page"
+```
+
+---
+
+## Task 5: Manual smoke test
+
+- [ ] **Step 1: Run the app**
+
+```bash
+dotnet run --project src/Humans.Web
+```
+
+- [ ] **Step 2: Navigate to `/CityPlanning/Admin` as a map admin**
+
+Verify the Import card appears below the Export card.
+
+- [ ] **Step 3: Test with the exported file**
+
+1. Download the current year's GeoJSON via the Export button.
+2. Upload it to the Import card and click **Preview import**.
+3. Verify the modal shows all camps with matching previous/new areas (they should be equal since it's a round-trip).
+4. Click **Confirm import** and verify the success banner appears.
+5. Navigate to `/CityPlanning` and open history for one of the updated camps — verify a `"Imported YYYY-MM-DD HH:mm"` entry appears, attributed to your user.
+
+- [ ] **Step 4: Test with an unrecognized feature**
+
+Manually edit the exported GeoJSON to rename one `campName` to something fake (e.g. `"Unknown Camp XYZ"`), then re-import. Verify the modal shows it in the "Unrecognized" list and the import still succeeds for the others.
+
+- [ ] **Step 5: Test error states**
+
+- Upload a plain text file → expect error banner "Invalid file — not valid JSON".
+- Upload valid JSON that is not a FeatureCollection (e.g. `{}`) → expect error "File must be a GeoJSON FeatureCollection".
+
+---
+
+## Task 6: Update spec to note completed endpoint fix, then push
+
+- [ ] **Step 1: Commit the spec fix (HTTP method correction already made)**
+
+```bash
+git add docs/superpowers/specs/2026-04-25-city-planning-import-design.md
+git commit -m "docs: correct save endpoint to PUT /api/city-planning/camp-polygons/{id} in import spec"
+```
+
+- [ ] **Step 2: Push the branch**
+
+```bash
+git push -u origin feat/city-planning-import
+```

--- a/docs/superpowers/specs/2026-04-25-city-planning-import-design.md
+++ b/docs/superpowers/specs/2026-04-25-city-planning-import-design.md
@@ -1,0 +1,145 @@
+# City Planning — GeoJSON Polygon Import
+
+**Date:** 2026-04-25
+**Section:** CityPlanning / Admin
+
+---
+
+## Context
+
+The CityPlanning Admin page already has an Export card that downloads all camp polygons for the current year as a GeoJSON FeatureCollection. This feature adds a symmetrical Import card that lets a map admin upload a GeoJSON file to bulk-update polygon geometries.
+
+---
+
+## Goals
+
+- Upload a GeoJSON file containing polygon features
+- Match each feature to a camp in the current settings year by `campName` or `campSlug` property (case-insensitive)
+- Compute area client-side using Turf.js before saving
+- Preview matched/unrecognized features — including old vs. new area — before committing
+- Save via the existing per-polygon save API (no new write logic)
+- Record each update in polygon history with note `"Imported YYYY-MM-DD HH:mm"` attributed to the importing user
+
+---
+
+## Out of Scope
+
+- Importing to a year other than the current settings year
+- Deleting polygons not present in the import file
+- Creating new camps from the import file
+- Server-side area computation (stays client-side with Turf.js)
+
+---
+
+## Architecture
+
+### Backend changes
+
+**1. `SaveCampPolygonRequest` — add optional `Note` field**
+
+```csharp
+public sealed record SaveCampPolygonRequest(string GeoJson, double AreaSqm, string? Note = null);
+```
+
+The service/repository already accepts a `note` parameter in `SavePolygonAndAppendHistoryAsync`. The controller passes `request.Note ?? "Saved"` through to the service.
+
+### No other backend changes
+
+No new endpoints needed. The import JS fetches `GET /api/city-planning/state` (the same call the map makes on load) at import time to get a fresh camp list. The response already contains:
+
+- `campPolygons[]` — camps with existing polygons: `{campSeasonId, campName, campSlug, areaSqm, ...}`
+- `campSeasonsWithoutPolygon[]` — camps with no polygon yet: `{campSeasonId, campName, campSlug}`
+
+Fetching at import time (rather than page load) ensures the list is always fresh.
+
+All polygon writes go through the existing `POST /api/city-planning/polygons/{campSeasonId}` endpoint with `note: "Imported YYYY-MM-DD"` set in the request body.
+
+---
+
+## Frontend
+
+### Admin page changes (`Admin.cshtml`)
+
+Add an **Import** card after the existing Export card. The card contains:
+
+- A file `<input type="file" accept=".geojson,application/geo+json">`
+- A disabled **Preview import** button, enabled once a valid file is selected
+- A result banner area (hidden until import completes)
+
+### JS flow (`wwwroot/js/city-planning/import.js`)
+
+**Phase 1 — File read & matching (on file select or "Preview" click):**
+
+1. Read file via `FileReader`
+2. Parse JSON; validate it is a GeoJSON FeatureCollection
+3. Fetch `GET /api/city-planning/state` to get a fresh camp list; build a lookup from both `campPolygons` and `campSeasonsWithoutPolygon`
+4. For each feature, attempt match against camp list:
+   - Compare `feature.properties.campName` (case-insensitive) to `campName`
+   - Fall back to `feature.properties.campSlug` (case-insensitive) to `campSlug`
+5. For matched features, compute area with `turf.area(feature)` (result in m²)
+6. Build two lists: **matched** (campSeasonId, campName, previousAreaSqm, newAreaSqm) and **unrecognized** (feature name or index)
+
+**Phase 2 — Preview dialog:**
+
+Show a Bootstrap modal with two sections:
+
+- **Will be updated** — table with columns: Camp name | Previous area | New area
+  - Previous area shows `—` if the camp has no existing polygon
+  - Areas formatted as `1,234 m²`
+- **Unrecognized features (will be skipped)** — shown only if non-empty; yellow/warning styling; lists the unrecognized feature names
+
+**Confirm** button submits. **Cancel** closes the modal.
+
+**Phase 3 — Import execution (on Confirm):**
+
+1. Disable Confirm button, show spinner + "Updating N polygons..."
+2. Iterate matched camps sequentially:
+   - `POST /api/city-planning/polygons/{campSeasonId}` with `{ geoJson, areaSqm, note: "Imported YYYY-MM-DD HH:mm" }` (UTC, formatted by JS at import time)
+3. On completion, close modal, show result banner on the Admin page:
+   - Success: "N polygons updated."
+   - Partial failure: "N updated, M failed." with a collapsible error list
+
+---
+
+## History Entries
+
+Each updated polygon receives a `CampPolygonHistory` entry:
+
+| Field | Value |
+|---|---|
+| `Note` | `"Imported 2026-04-25"` (ISO date of import) |
+| `ModifiedByUserId` | Authenticated admin user |
+| `ModifiedAt` | Server timestamp at save time |
+| `GeoJson` | New polygon geometry |
+| `AreaSqm` | Newly computed area |
+
+The `"Imported YYYY-MM-DD HH:mm"` note is visually distinct from `"Saved"` (map edit) and `"Restored from ..."` (restore) in the history panel.
+
+---
+
+## Error Handling
+
+| Scenario | Behaviour |
+|---|---|
+| File is not valid JSON | Show inline error: "Invalid file — not valid JSON" |
+| File is valid JSON but not a FeatureCollection | Show inline error: "File must be a GeoJSON FeatureCollection" |
+| No features match any camp | Show modal with empty "Will be updated" list and all features in "Unrecognized"; Confirm disabled |
+| Individual save API call fails | Mark that camp as failed; continue with remaining; show partial-failure banner |
+| `GET /api/city-planning/state` fetch fails | Show inline error: "Could not load camp list. Please try again." |
+
+---
+
+## Authorization
+
+- Import card is visible only to map admins (same condition as the Export card)
+- `GET /api/city-planning/state` is already authorized (requires login); admin-only data is filtered by the service
+- Individual polygon save calls are already guarded by the existing save endpoint's authorization
+
+---
+
+## Related
+
+- Export: `GET /api/city-planning/export.geojson`
+- Polygon save (reused as-is): `POST /api/city-planning/polygons/{campSeasonId}`
+- History: `CampPolygonHistory`, `SavePolygonAndAppendHistoryAsync`
+- Section invariants: `docs/sections/CityPlanning.md`

--- a/docs/superpowers/specs/2026-04-25-city-planning-import-design.md
+++ b/docs/superpowers/specs/2026-04-25-city-planning-import-design.md
@@ -52,7 +52,7 @@ No new endpoints needed. The import JS fetches `GET /api/city-planning/state` (t
 
 Fetching at import time (rather than page load) ensures the list is always fresh.
 
-All polygon writes go through the existing `PUT /api/city-planning/camp-polygons/{campSeasonId}` endpoint with `note: "Imported YYYY-MM-DD"` set in the request body.
+All polygon writes go through the existing `PUT /api/city-planning/camp-polygons/{campSeasonId}` endpoint with `note: "Imported YYYY-MM-DD HH:mm"` set in the request body.
 
 ---
 

--- a/docs/superpowers/specs/2026-04-25-city-planning-import-design.md
+++ b/docs/superpowers/specs/2026-04-25-city-planning-import-design.md
@@ -107,7 +107,7 @@ Each updated polygon receives a `CampPolygonHistory` entry:
 
 | Field | Value |
 |---|---|
-| `Note` | `"Imported 2026-04-25"` (ISO date of import) |
+| `Note` | `"Imported 2026-04-25 14:30"` (UTC, format `Imported YYYY-MM-DD HH:mm`) |
 | `ModifiedByUserId` | Authenticated admin user |
 | `ModifiedAt` | Server timestamp at save time |
 | `GeoJson` | New polygon geometry |

--- a/docs/superpowers/specs/2026-04-25-city-planning-import-design.md
+++ b/docs/superpowers/specs/2026-04-25-city-planning-import-design.md
@@ -52,7 +52,7 @@ No new endpoints needed. The import JS fetches `GET /api/city-planning/state` (t
 
 Fetching at import time (rather than page load) ensures the list is always fresh.
 
-All polygon writes go through the existing `POST /api/city-planning/polygons/{campSeasonId}` endpoint with `note: "Imported YYYY-MM-DD"` set in the request body.
+All polygon writes go through the existing `PUT /api/city-planning/camp-polygons/{campSeasonId}` endpoint with `note: "Imported YYYY-MM-DD"` set in the request body.
 
 ---
 
@@ -94,7 +94,7 @@ Show a Bootstrap modal with two sections:
 
 1. Disable Confirm button, show spinner + "Updating N polygons..."
 2. Iterate matched camps sequentially:
-   - `POST /api/city-planning/polygons/{campSeasonId}` with `{ geoJson, areaSqm, note: "Imported YYYY-MM-DD HH:mm" }` (UTC, formatted by JS at import time)
+   - `PUT /api/city-planning/camp-polygons/{campSeasonId}` with `{ geoJson, areaSqm, note: "Imported YYYY-MM-DD HH:mm" }` (UTC, formatted by JS at import time)
 3. On completion, close modal, show result banner on the Admin page:
    - Success: "N polygons updated."
    - Partial failure: "N updated, M failed." with a collapsible error list
@@ -140,6 +140,6 @@ The `"Imported YYYY-MM-DD HH:mm"` note is visually distinct from `"Saved"` (map 
 ## Related
 
 - Export: `GET /api/city-planning/export.geojson`
-- Polygon save (reused as-is): `POST /api/city-planning/polygons/{campSeasonId}`
+- Polygon save (reused as-is): `PUT /api/city-planning/camp-polygons/{campSeasonId}`
 - History: `CampPolygonHistory`, `SavePolygonAndAppendHistoryAsync`
 - Section invariants: `docs/sections/CityPlanning.md`

--- a/src/Humans.Application/Interfaces/CitiPlanning/ICityPlanningService.cs
+++ b/src/Humans.Application/Interfaces/CitiPlanning/ICityPlanningService.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel.DataAnnotations;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using NodaTime;
@@ -69,4 +70,7 @@ public record CampPolygonHistoryEntryDto(
     string Note,
     string GeoJson);
 
-public record SaveCampPolygonRequest(string GeoJson, double AreaSqm, string? Note = null);
+public record SaveCampPolygonRequest(
+    string GeoJson,
+    double AreaSqm,
+    [property: StringLength(512, ErrorMessage = "Note cannot exceed 512 characters")] string? Note = null);

--- a/src/Humans.Application/Interfaces/CitiPlanning/ICityPlanningService.cs
+++ b/src/Humans.Application/Interfaces/CitiPlanning/ICityPlanningService.cs
@@ -69,4 +69,4 @@ public record CampPolygonHistoryEntryDto(
     string Note,
     string GeoJson);
 
-public record SaveCampPolygonRequest(string GeoJson, double AreaSqm);
+public record SaveCampPolygonRequest(string GeoJson, double AreaSqm, string? Note = null);

--- a/src/Humans.Web/Controllers/CityPlanningApiController.cs
+++ b/src/Humans.Web/Controllers/CityPlanningApiController.cs
@@ -103,6 +103,7 @@ public class CityPlanningApiController : ControllerBase
 
         var (polygon, _) = await _cityPlanningService.SaveCampPolygonAsync(
             campSeasonId, request.GeoJson, request.AreaSqm, userId,
+            note: request.Note ?? "Saved",
             cancellationToken: cancellationToken);
 
         var soundZone = await _campService.GetCampSeasonSoundZoneAsync(campSeasonId, cancellationToken);

--- a/src/Humans.Web/Resources/SharedResource.ca.resx
+++ b/src/Humans.Web/Resources/SharedResource.ca.resx
@@ -1467,6 +1467,17 @@
   <data name="CityPlanning_Admin_ImportNewArea" xml:space="preserve"><value>Àrea nova</value></data>
   <data name="CityPlanning_Admin_ImportUnrecognized" xml:space="preserve"><value>Entitats no reconegudes (s'ometran)</value></data>
   <data name="CityPlanning_Admin_ImportConfirmBtn" xml:space="preserve"><value>Confirmar importació</value></data>
+  <data name="CityPlanning_Admin_ImportSelectFileError" xml:space="preserve"><value>Selecciona un fitxer GeoJSON.</value></data>
+  <data name="CityPlanning_Admin_ImportInvalidJsonError" xml:space="preserve"><value>Fitxer no vàlid — JSON no vàlid.</value></data>
+  <data name="CityPlanning_Admin_ImportNotFeatureCollectionError" xml:space="preserve"><value>El fitxer ha de ser una FeatureCollection GeoJSON.</value></data>
+  <data name="CityPlanning_Admin_ImportFetchStateError" xml:space="preserve"><value>No s'ha pogut carregar la llista de barrios. Torna-ho a provar.</value></data>
+  <data name="CityPlanning_Admin_ImportNoCampsMatched" xml:space="preserve"><value>Cap barrio coincideix.</value></data>
+  <data name="CityPlanning_Admin_ImportTokenMissingError" xml:space="preserve"><value>Manca el testimoni de seguretat. Torna a carregar la pàgina.</value></data>
+  <data name="CityPlanning_Admin_ImportFileTooLargeError" xml:space="preserve"><value>Fitxer massa gran (màx. 10 MB).</value></data>
+  <data name="CityPlanning_Admin_ImportNotPolygonSuffix" xml:space="preserve"><value>(no és un polígon)</value></data>
+  <data name="CityPlanning_Admin_ImportUpdating" xml:space="preserve"><value>Actualitzant {0} polígon(s)…</value></data>
+  <data name="CityPlanning_Admin_ImportSuccess" xml:space="preserve"><value>{0} polígon(s) actualitzat(s).</value></data>
+  <data name="CityPlanning_Admin_ImportPartialFailure" xml:space="preserve"><value>{0} actualitzat(s), {1} fallit(s): {2}.</value></data>
   <data name="CityPlanning_HistoryTitle" xml:space="preserve"><value>Historial de polígons</value></data>
   <data name="CityPlanning_Loading" xml:space="preserve"><value>Carregant…</value></data>
   <data name="CityPlanning_Help_WhenIsIt" xml:space="preserve"><value>Quan és?</value></data>

--- a/src/Humans.Web/Resources/SharedResource.ca.resx
+++ b/src/Humans.Web/Resources/SharedResource.ca.resx
@@ -1456,6 +1456,17 @@
   <data name="CityPlanning_Admin_ExportCard" xml:space="preserve"><value>Exportar</value></data>
   <data name="CityPlanning_Admin_ExportDescription" xml:space="preserve"><value>Descarregar tots els polígons de barrios de {0} com a GeoJSON FeatureCollection.</value></data>
   <data name="CityPlanning_Admin_DownloadGeoJson" xml:space="preserve"><value>Descarregar GeoJSON ({0})</value></data>
+  <data name="CityPlanning_Admin_ImportCard" xml:space="preserve"><value>Importar polígons</value></data>
+  <data name="CityPlanning_Admin_ImportDescription" xml:space="preserve"><value>Puja una FeatureCollection GeoJSON per actualitzar en bloc els polígons de barrios de {0}. Les entitats s'associen per la propietat campName o campSlug.</value></data>
+  <data name="CityPlanning_Admin_ImportFileLabel" xml:space="preserve"><value>Fitxer GeoJSON</value></data>
+  <data name="CityPlanning_Admin_ImportPreviewBtn" xml:space="preserve"><value>Vista prèvia</value></data>
+  <data name="CityPlanning_Admin_ImportModalTitle" xml:space="preserve"><value>Vista prèvia de la importació</value></data>
+  <data name="CityPlanning_Admin_ImportWillBeUpdated" xml:space="preserve"><value>S'actualitzaran</value></data>
+  <data name="CityPlanning_Admin_ImportCampHeader" xml:space="preserve"><value>Barrio</value></data>
+  <data name="CityPlanning_Admin_ImportPreviousArea" xml:space="preserve"><value>Àrea anterior</value></data>
+  <data name="CityPlanning_Admin_ImportNewArea" xml:space="preserve"><value>Àrea nova</value></data>
+  <data name="CityPlanning_Admin_ImportUnrecognized" xml:space="preserve"><value>Entitats no reconegudes (s'ometran)</value></data>
+  <data name="CityPlanning_Admin_ImportConfirmBtn" xml:space="preserve"><value>Confirmar importació</value></data>
   <data name="CityPlanning_HistoryTitle" xml:space="preserve"><value>Historial de polígons</value></data>
   <data name="CityPlanning_Loading" xml:space="preserve"><value>Carregant…</value></data>
   <data name="CityPlanning_Help_WhenIsIt" xml:space="preserve"><value>Quan és?</value></data>

--- a/src/Humans.Web/Resources/SharedResource.de.resx
+++ b/src/Humans.Web/Resources/SharedResource.de.resx
@@ -1454,6 +1454,17 @@
   <data name="CityPlanning_Admin_ExportCard" xml:space="preserve"><value>Exportieren</value></data>
   <data name="CityPlanning_Admin_ExportDescription" xml:space="preserve"><value>Alle Barrio-Polygone für {0} als GeoJSON FeatureCollection herunterladen.</value></data>
   <data name="CityPlanning_Admin_DownloadGeoJson" xml:space="preserve"><value>GeoJSON herunterladen ({0})</value></data>
+  <data name="CityPlanning_Admin_ImportCard" xml:space="preserve"><value>Polygone importieren</value></data>
+  <data name="CityPlanning_Admin_ImportDescription" xml:space="preserve"><value>Lade eine GeoJSON FeatureCollection hoch, um Barrio-Polygone für {0} zu aktualisieren. Features werden anhand der Eigenschaft campName oder campSlug zugeordnet.</value></data>
+  <data name="CityPlanning_Admin_ImportFileLabel" xml:space="preserve"><value>GeoJSON-Datei</value></data>
+  <data name="CityPlanning_Admin_ImportPreviewBtn" xml:space="preserve"><value>Vorschau</value></data>
+  <data name="CityPlanning_Admin_ImportModalTitle" xml:space="preserve"><value>Importvorschau</value></data>
+  <data name="CityPlanning_Admin_ImportWillBeUpdated" xml:space="preserve"><value>Werden aktualisiert</value></data>
+  <data name="CityPlanning_Admin_ImportCampHeader" xml:space="preserve"><value>Barrio</value></data>
+  <data name="CityPlanning_Admin_ImportPreviousArea" xml:space="preserve"><value>Bisherige Fläche</value></data>
+  <data name="CityPlanning_Admin_ImportNewArea" xml:space="preserve"><value>Neue Fläche</value></data>
+  <data name="CityPlanning_Admin_ImportUnrecognized" xml:space="preserve"><value>Nicht erkannte Features (werden übersprungen)</value></data>
+  <data name="CityPlanning_Admin_ImportConfirmBtn" xml:space="preserve"><value>Import bestätigen</value></data>
   <data name="CityPlanning_HistoryTitle" xml:space="preserve"><value>Polygon-Verlauf</value></data>
   <data name="CityPlanning_Loading" xml:space="preserve"><value>Wird geladen…</value></data>
   <data name="CityPlanning_Help_WhenIsIt" xml:space="preserve"><value>Wann ist es?</value></data>

--- a/src/Humans.Web/Resources/SharedResource.de.resx
+++ b/src/Humans.Web/Resources/SharedResource.de.resx
@@ -1465,6 +1465,17 @@
   <data name="CityPlanning_Admin_ImportNewArea" xml:space="preserve"><value>Neue Fläche</value></data>
   <data name="CityPlanning_Admin_ImportUnrecognized" xml:space="preserve"><value>Nicht erkannte Features (werden übersprungen)</value></data>
   <data name="CityPlanning_Admin_ImportConfirmBtn" xml:space="preserve"><value>Import bestätigen</value></data>
+  <data name="CityPlanning_Admin_ImportSelectFileError" xml:space="preserve"><value>Bitte wähle eine GeoJSON-Datei.</value></data>
+  <data name="CityPlanning_Admin_ImportInvalidJsonError" xml:space="preserve"><value>Ungültige Datei – kein gültiges JSON.</value></data>
+  <data name="CityPlanning_Admin_ImportNotFeatureCollectionError" xml:space="preserve"><value>Die Datei muss eine GeoJSON FeatureCollection sein.</value></data>
+  <data name="CityPlanning_Admin_ImportFetchStateError" xml:space="preserve"><value>Barrio-Liste konnte nicht geladen werden. Bitte versuche es erneut.</value></data>
+  <data name="CityPlanning_Admin_ImportNoCampsMatched" xml:space="preserve"><value>Keine Barrios zugeordnet.</value></data>
+  <data name="CityPlanning_Admin_ImportTokenMissingError" xml:space="preserve"><value>Sicherheits-Token fehlt. Bitte lade die Seite neu.</value></data>
+  <data name="CityPlanning_Admin_ImportFileTooLargeError" xml:space="preserve"><value>Datei ist zu groß (max. 10 MB).</value></data>
+  <data name="CityPlanning_Admin_ImportNotPolygonSuffix" xml:space="preserve"><value>(kein Polygon)</value></data>
+  <data name="CityPlanning_Admin_ImportUpdating" xml:space="preserve"><value>Aktualisiere {0} Polygon(e)…</value></data>
+  <data name="CityPlanning_Admin_ImportSuccess" xml:space="preserve"><value>{0} Polygon(e) aktualisiert.</value></data>
+  <data name="CityPlanning_Admin_ImportPartialFailure" xml:space="preserve"><value>{0} aktualisiert, {1} fehlgeschlagen: {2}.</value></data>
   <data name="CityPlanning_HistoryTitle" xml:space="preserve"><value>Polygon-Verlauf</value></data>
   <data name="CityPlanning_Loading" xml:space="preserve"><value>Wird geladen…</value></data>
   <data name="CityPlanning_Help_WhenIsIt" xml:space="preserve"><value>Wann ist es?</value></data>

--- a/src/Humans.Web/Resources/SharedResource.es.resx
+++ b/src/Humans.Web/Resources/SharedResource.es.resx
@@ -1456,6 +1456,17 @@
   <data name="CityPlanning_Admin_ExportCard" xml:space="preserve"><value>Exportar</value></data>
   <data name="CityPlanning_Admin_ExportDescription" xml:space="preserve"><value>Descargar todos los polígonos de barrios de {0} como GeoJSON FeatureCollection.</value></data>
   <data name="CityPlanning_Admin_DownloadGeoJson" xml:space="preserve"><value>Descargar GeoJSON ({0})</value></data>
+  <data name="CityPlanning_Admin_ImportCard" xml:space="preserve"><value>Importar polígonos</value></data>
+  <data name="CityPlanning_Admin_ImportDescription" xml:space="preserve"><value>Sube un GeoJSON FeatureCollection para actualizar en bloque los polígonos de barrios de {0}. Las entidades se emparejan por la propiedad campName o campSlug.</value></data>
+  <data name="CityPlanning_Admin_ImportFileLabel" xml:space="preserve"><value>Archivo GeoJSON</value></data>
+  <data name="CityPlanning_Admin_ImportPreviewBtn" xml:space="preserve"><value>Vista previa</value></data>
+  <data name="CityPlanning_Admin_ImportModalTitle" xml:space="preserve"><value>Vista previa de la importación</value></data>
+  <data name="CityPlanning_Admin_ImportWillBeUpdated" xml:space="preserve"><value>Se actualizarán</value></data>
+  <data name="CityPlanning_Admin_ImportCampHeader" xml:space="preserve"><value>Barrio</value></data>
+  <data name="CityPlanning_Admin_ImportPreviousArea" xml:space="preserve"><value>Área anterior</value></data>
+  <data name="CityPlanning_Admin_ImportNewArea" xml:space="preserve"><value>Área nueva</value></data>
+  <data name="CityPlanning_Admin_ImportUnrecognized" xml:space="preserve"><value>Entidades no reconocidas (se omitirán)</value></data>
+  <data name="CityPlanning_Admin_ImportConfirmBtn" xml:space="preserve"><value>Confirmar importación</value></data>
   <data name="CityPlanning_HistoryTitle" xml:space="preserve"><value>Historial de polígonos</value></data>
   <data name="CityPlanning_Loading" xml:space="preserve"><value>Cargando…</value></data>
   <data name="CityPlanning_Help_WhenIsIt" xml:space="preserve"><value>¿Cuándo es?</value></data>

--- a/src/Humans.Web/Resources/SharedResource.es.resx
+++ b/src/Humans.Web/Resources/SharedResource.es.resx
@@ -1467,6 +1467,17 @@
   <data name="CityPlanning_Admin_ImportNewArea" xml:space="preserve"><value>Área nueva</value></data>
   <data name="CityPlanning_Admin_ImportUnrecognized" xml:space="preserve"><value>Entidades no reconocidas (se omitirán)</value></data>
   <data name="CityPlanning_Admin_ImportConfirmBtn" xml:space="preserve"><value>Confirmar importación</value></data>
+  <data name="CityPlanning_Admin_ImportSelectFileError" xml:space="preserve"><value>Selecciona un archivo GeoJSON.</value></data>
+  <data name="CityPlanning_Admin_ImportInvalidJsonError" xml:space="preserve"><value>Archivo no válido: no es JSON válido.</value></data>
+  <data name="CityPlanning_Admin_ImportNotFeatureCollectionError" xml:space="preserve"><value>El archivo debe ser una FeatureCollection GeoJSON.</value></data>
+  <data name="CityPlanning_Admin_ImportFetchStateError" xml:space="preserve"><value>No se pudo cargar la lista de barrios. Inténtalo de nuevo.</value></data>
+  <data name="CityPlanning_Admin_ImportNoCampsMatched" xml:space="preserve"><value>Ningún barrio coincide.</value></data>
+  <data name="CityPlanning_Admin_ImportTokenMissingError" xml:space="preserve"><value>Falta el token de seguridad. Recarga la página.</value></data>
+  <data name="CityPlanning_Admin_ImportFileTooLargeError" xml:space="preserve"><value>El archivo es demasiado grande (máx. 10 MB).</value></data>
+  <data name="CityPlanning_Admin_ImportNotPolygonSuffix" xml:space="preserve"><value>(no es un polígono)</value></data>
+  <data name="CityPlanning_Admin_ImportUpdating" xml:space="preserve"><value>Actualizando {0} polígono(s)…</value></data>
+  <data name="CityPlanning_Admin_ImportSuccess" xml:space="preserve"><value>{0} polígono(s) actualizado(s).</value></data>
+  <data name="CityPlanning_Admin_ImportPartialFailure" xml:space="preserve"><value>{0} actualizado(s), {1} fallido(s): {2}.</value></data>
   <data name="CityPlanning_HistoryTitle" xml:space="preserve"><value>Historial de polígonos</value></data>
   <data name="CityPlanning_Loading" xml:space="preserve"><value>Cargando…</value></data>
   <data name="CityPlanning_Help_WhenIsIt" xml:space="preserve"><value>¿Cuándo es?</value></data>

--- a/src/Humans.Web/Resources/SharedResource.fr.resx
+++ b/src/Humans.Web/Resources/SharedResource.fr.resx
@@ -1465,6 +1465,17 @@
   <data name="CityPlanning_Admin_ImportNewArea" xml:space="preserve"><value>Nouvelle surface</value></data>
   <data name="CityPlanning_Admin_ImportUnrecognized" xml:space="preserve"><value>Entités non reconnues (seront ignorées)</value></data>
   <data name="CityPlanning_Admin_ImportConfirmBtn" xml:space="preserve"><value>Confirmer l'import</value></data>
+  <data name="CityPlanning_Admin_ImportSelectFileError" xml:space="preserve"><value>Veuillez sélectionner un fichier GeoJSON.</value></data>
+  <data name="CityPlanning_Admin_ImportInvalidJsonError" xml:space="preserve"><value>Fichier non valide — JSON non valide.</value></data>
+  <data name="CityPlanning_Admin_ImportNotFeatureCollectionError" xml:space="preserve"><value>Le fichier doit être une FeatureCollection GeoJSON.</value></data>
+  <data name="CityPlanning_Admin_ImportFetchStateError" xml:space="preserve"><value>Impossible de charger la liste des barrios. Veuillez réessayer.</value></data>
+  <data name="CityPlanning_Admin_ImportNoCampsMatched" xml:space="preserve"><value>Aucun barrio correspondant.</value></data>
+  <data name="CityPlanning_Admin_ImportTokenMissingError" xml:space="preserve"><value>Jeton de sécurité manquant. Veuillez actualiser la page.</value></data>
+  <data name="CityPlanning_Admin_ImportFileTooLargeError" xml:space="preserve"><value>Fichier trop volumineux (max. 10 Mo).</value></data>
+  <data name="CityPlanning_Admin_ImportNotPolygonSuffix" xml:space="preserve"><value>(pas un polygone)</value></data>
+  <data name="CityPlanning_Admin_ImportUpdating" xml:space="preserve"><value>Mise à jour de {0} polygone(s)…</value></data>
+  <data name="CityPlanning_Admin_ImportSuccess" xml:space="preserve"><value>{0} polygone(s) mis à jour.</value></data>
+  <data name="CityPlanning_Admin_ImportPartialFailure" xml:space="preserve"><value>{0} mis à jour, {1} en échec : {2}.</value></data>
   <data name="CityPlanning_HistoryTitle" xml:space="preserve"><value>Historique des polygones</value></data>
   <data name="CityPlanning_Loading" xml:space="preserve"><value>Chargement…</value></data>
   <data name="CityPlanning_Help_WhenIsIt" xml:space="preserve"><value>C'est quand ?</value></data>

--- a/src/Humans.Web/Resources/SharedResource.fr.resx
+++ b/src/Humans.Web/Resources/SharedResource.fr.resx
@@ -1454,6 +1454,17 @@
   <data name="CityPlanning_Admin_ExportCard" xml:space="preserve"><value>Exporter</value></data>
   <data name="CityPlanning_Admin_ExportDescription" xml:space="preserve"><value>Télécharger tous les polygones de barrios pour {0} en tant que GeoJSON FeatureCollection.</value></data>
   <data name="CityPlanning_Admin_DownloadGeoJson" xml:space="preserve"><value>Télécharger GeoJSON ({0})</value></data>
+  <data name="CityPlanning_Admin_ImportCard" xml:space="preserve"><value>Importer des polygones</value></data>
+  <data name="CityPlanning_Admin_ImportDescription" xml:space="preserve"><value>Téléversez une FeatureCollection GeoJSON pour mettre à jour en bloc les polygones des barrios pour {0}. Les entités sont associées par la propriété campName ou campSlug.</value></data>
+  <data name="CityPlanning_Admin_ImportFileLabel" xml:space="preserve"><value>Fichier GeoJSON</value></data>
+  <data name="CityPlanning_Admin_ImportPreviewBtn" xml:space="preserve"><value>Aperçu</value></data>
+  <data name="CityPlanning_Admin_ImportModalTitle" xml:space="preserve"><value>Aperçu de l'import</value></data>
+  <data name="CityPlanning_Admin_ImportWillBeUpdated" xml:space="preserve"><value>Seront mis à jour</value></data>
+  <data name="CityPlanning_Admin_ImportCampHeader" xml:space="preserve"><value>Barrio</value></data>
+  <data name="CityPlanning_Admin_ImportPreviousArea" xml:space="preserve"><value>Surface précédente</value></data>
+  <data name="CityPlanning_Admin_ImportNewArea" xml:space="preserve"><value>Nouvelle surface</value></data>
+  <data name="CityPlanning_Admin_ImportUnrecognized" xml:space="preserve"><value>Entités non reconnues (seront ignorées)</value></data>
+  <data name="CityPlanning_Admin_ImportConfirmBtn" xml:space="preserve"><value>Confirmer l'import</value></data>
   <data name="CityPlanning_HistoryTitle" xml:space="preserve"><value>Historique des polygones</value></data>
   <data name="CityPlanning_Loading" xml:space="preserve"><value>Chargement…</value></data>
   <data name="CityPlanning_Help_WhenIsIt" xml:space="preserve"><value>C'est quand ?</value></data>

--- a/src/Humans.Web/Resources/SharedResource.it.resx
+++ b/src/Humans.Web/Resources/SharedResource.it.resx
@@ -1454,6 +1454,17 @@
   <data name="CityPlanning_Admin_ExportCard" xml:space="preserve"><value>Esporta</value></data>
   <data name="CityPlanning_Admin_ExportDescription" xml:space="preserve"><value>Scarica tutti i poligoni dei barrios per {0} come GeoJSON FeatureCollection.</value></data>
   <data name="CityPlanning_Admin_DownloadGeoJson" xml:space="preserve"><value>Scarica GeoJSON ({0})</value></data>
+  <data name="CityPlanning_Admin_ImportCard" xml:space="preserve"><value>Importa poligoni</value></data>
+  <data name="CityPlanning_Admin_ImportDescription" xml:space="preserve"><value>Carica una FeatureCollection GeoJSON per aggiornare in blocco i poligoni dei barrio per {0}. Le feature vengono abbinate dalla proprietà campName o campSlug.</value></data>
+  <data name="CityPlanning_Admin_ImportFileLabel" xml:space="preserve"><value>File GeoJSON</value></data>
+  <data name="CityPlanning_Admin_ImportPreviewBtn" xml:space="preserve"><value>Anteprima</value></data>
+  <data name="CityPlanning_Admin_ImportModalTitle" xml:space="preserve"><value>Anteprima importazione</value></data>
+  <data name="CityPlanning_Admin_ImportWillBeUpdated" xml:space="preserve"><value>Verranno aggiornati</value></data>
+  <data name="CityPlanning_Admin_ImportCampHeader" xml:space="preserve"><value>Barrio</value></data>
+  <data name="CityPlanning_Admin_ImportPreviousArea" xml:space="preserve"><value>Area precedente</value></data>
+  <data name="CityPlanning_Admin_ImportNewArea" xml:space="preserve"><value>Nuova area</value></data>
+  <data name="CityPlanning_Admin_ImportUnrecognized" xml:space="preserve"><value>Feature non riconosciute (verranno saltate)</value></data>
+  <data name="CityPlanning_Admin_ImportConfirmBtn" xml:space="preserve"><value>Conferma importazione</value></data>
   <data name="CityPlanning_HistoryTitle" xml:space="preserve"><value>Cronologia poligoni</value></data>
   <data name="CityPlanning_Loading" xml:space="preserve"><value>Caricamento…</value></data>
   <data name="CityPlanning_Help_WhenIsIt" xml:space="preserve"><value>Quando si svolge?</value></data>

--- a/src/Humans.Web/Resources/SharedResource.it.resx
+++ b/src/Humans.Web/Resources/SharedResource.it.resx
@@ -1465,6 +1465,17 @@
   <data name="CityPlanning_Admin_ImportNewArea" xml:space="preserve"><value>Nuova area</value></data>
   <data name="CityPlanning_Admin_ImportUnrecognized" xml:space="preserve"><value>Feature non riconosciute (verranno saltate)</value></data>
   <data name="CityPlanning_Admin_ImportConfirmBtn" xml:space="preserve"><value>Conferma importazione</value></data>
+  <data name="CityPlanning_Admin_ImportSelectFileError" xml:space="preserve"><value>Seleziona un file GeoJSON.</value></data>
+  <data name="CityPlanning_Admin_ImportInvalidJsonError" xml:space="preserve"><value>File non valido — JSON non valido.</value></data>
+  <data name="CityPlanning_Admin_ImportNotFeatureCollectionError" xml:space="preserve"><value>Il file deve essere una FeatureCollection GeoJSON.</value></data>
+  <data name="CityPlanning_Admin_ImportFetchStateError" xml:space="preserve"><value>Impossibile caricare l'elenco dei barrio. Riprova.</value></data>
+  <data name="CityPlanning_Admin_ImportNoCampsMatched" xml:space="preserve"><value>Nessun barrio corrispondente.</value></data>
+  <data name="CityPlanning_Admin_ImportTokenMissingError" xml:space="preserve"><value>Token di sicurezza mancante. Aggiorna la pagina.</value></data>
+  <data name="CityPlanning_Admin_ImportFileTooLargeError" xml:space="preserve"><value>File troppo grande (max 10 MB).</value></data>
+  <data name="CityPlanning_Admin_ImportNotPolygonSuffix" xml:space="preserve"><value>(non è un poligono)</value></data>
+  <data name="CityPlanning_Admin_ImportUpdating" xml:space="preserve"><value>Aggiornamento di {0} poligono/i…</value></data>
+  <data name="CityPlanning_Admin_ImportSuccess" xml:space="preserve"><value>{0} poligono/i aggiornato/i.</value></data>
+  <data name="CityPlanning_Admin_ImportPartialFailure" xml:space="preserve"><value>{0} aggiornato/i, {1} non riuscito/i: {2}.</value></data>
   <data name="CityPlanning_HistoryTitle" xml:space="preserve"><value>Cronologia poligoni</value></data>
   <data name="CityPlanning_Loading" xml:space="preserve"><value>Caricamento…</value></data>
   <data name="CityPlanning_Help_WhenIsIt" xml:space="preserve"><value>Quando si svolge?</value></data>

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -1471,6 +1471,17 @@
   <data name="CityPlanning_Admin_ExportCard" xml:space="preserve"><value>Export</value></data>
   <data name="CityPlanning_Admin_ExportDescription" xml:space="preserve"><value>Download all camp polygons for {0} as a GeoJSON FeatureCollection.</value><comment>{0} = year</comment></data>
   <data name="CityPlanning_Admin_DownloadGeoJson" xml:space="preserve"><value>Download GeoJSON ({0})</value><comment>{0} = year</comment></data>
+  <data name="CityPlanning_Admin_ImportCard" xml:space="preserve"><value>Import polygons</value></data>
+  <data name="CityPlanning_Admin_ImportDescription" xml:space="preserve"><value>Upload a GeoJSON FeatureCollection to bulk-update camp polygons for {0}. Features are matched by campName or campSlug property.</value><comment>{0} = year</comment></data>
+  <data name="CityPlanning_Admin_ImportFileLabel" xml:space="preserve"><value>GeoJSON file</value></data>
+  <data name="CityPlanning_Admin_ImportPreviewBtn" xml:space="preserve"><value>Preview import</value></data>
+  <data name="CityPlanning_Admin_ImportModalTitle" xml:space="preserve"><value>Import preview</value></data>
+  <data name="CityPlanning_Admin_ImportWillBeUpdated" xml:space="preserve"><value>Will be updated</value></data>
+  <data name="CityPlanning_Admin_ImportCampHeader" xml:space="preserve"><value>Camp</value></data>
+  <data name="CityPlanning_Admin_ImportPreviousArea" xml:space="preserve"><value>Previous area</value></data>
+  <data name="CityPlanning_Admin_ImportNewArea" xml:space="preserve"><value>New area</value></data>
+  <data name="CityPlanning_Admin_ImportUnrecognized" xml:space="preserve"><value>Unrecognized features (will be skipped)</value></data>
+  <data name="CityPlanning_Admin_ImportConfirmBtn" xml:space="preserve"><value>Confirm import</value></data>
   <!-- History offcanvas -->
   <data name="CityPlanning_HistoryTitle" xml:space="preserve"><value>Polygon History</value></data>
   <data name="CityPlanning_Loading" xml:space="preserve"><value>Loading…</value></data>

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -1482,6 +1482,17 @@
   <data name="CityPlanning_Admin_ImportNewArea" xml:space="preserve"><value>New area</value></data>
   <data name="CityPlanning_Admin_ImportUnrecognized" xml:space="preserve"><value>Unrecognized features (will be skipped)</value></data>
   <data name="CityPlanning_Admin_ImportConfirmBtn" xml:space="preserve"><value>Confirm import</value></data>
+  <data name="CityPlanning_Admin_ImportSelectFileError" xml:space="preserve"><value>Please select a GeoJSON file.</value></data>
+  <data name="CityPlanning_Admin_ImportInvalidJsonError" xml:space="preserve"><value>Invalid file — not valid JSON.</value></data>
+  <data name="CityPlanning_Admin_ImportNotFeatureCollectionError" xml:space="preserve"><value>File must be a GeoJSON FeatureCollection.</value></data>
+  <data name="CityPlanning_Admin_ImportFetchStateError" xml:space="preserve"><value>Could not load camp list. Please try again.</value></data>
+  <data name="CityPlanning_Admin_ImportNoCampsMatched" xml:space="preserve"><value>No camps matched.</value></data>
+  <data name="CityPlanning_Admin_ImportTokenMissingError" xml:space="preserve"><value>Security token missing. Please refresh the page.</value></data>
+  <data name="CityPlanning_Admin_ImportFileTooLargeError" xml:space="preserve"><value>File is too large (max 10 MB).</value></data>
+  <data name="CityPlanning_Admin_ImportNotPolygonSuffix" xml:space="preserve"><value>(not a polygon)</value></data>
+  <data name="CityPlanning_Admin_ImportUpdating" xml:space="preserve"><value>Updating {0} polygon(s)…</value><comment>{0} = count</comment></data>
+  <data name="CityPlanning_Admin_ImportSuccess" xml:space="preserve"><value>{0} polygon(s) updated.</value><comment>{0} = success count</comment></data>
+  <data name="CityPlanning_Admin_ImportPartialFailure" xml:space="preserve"><value>{0} updated, {1} failed: {2}.</value><comment>{0} = success count, {1} = fail count, {2} = comma-separated camp names</comment></data>
   <!-- History offcanvas -->
   <data name="CityPlanning_HistoryTitle" xml:space="preserve"><value>Polygon History</value></data>
   <data name="CityPlanning_Loading" xml:space="preserve"><value>Loading…</value></data>

--- a/src/Humans.Web/Views/CityPlanning/Admin.cshtml
+++ b/src/Humans.Web/Views/CityPlanning/Admin.cshtml
@@ -191,16 +191,16 @@
         <div class="col-12">
             <div class="card">
                 <div class="card-header fw-semibold">
-                    <i class="fa-solid fa-file-import me-1"></i> Import polygons (@settings.Year)
+                    <i class="fa-solid fa-file-import me-1"></i> @Localizer["CityPlanning_Admin_ImportCard"] (@settings.Year)
                 </div>
                 <div class="card-body">
-                    <p class="mb-2">Upload a GeoJSON FeatureCollection to bulk-update camp polygons for @settings.Year. Features are matched by <code>campName</code> or <code>campSlug</code> property.</p>
+                    <p class="mb-2">@string.Format(Localizer["CityPlanning_Admin_ImportDescription"].Value, settings.Year)</p>
                     <div class="mb-3">
-                        <label class="form-label small fw-semibold">GeoJSON file</label>
+                        <label class="form-label small fw-semibold">@Localizer["CityPlanning_Admin_ImportFileLabel"]</label>
                         <input type="file" id="import-file-input" accept=".geojson,.json,application/geo+json" class="form-control form-control-sm" />
                     </div>
                     <button id="import-preview-btn" type="button" class="btn btn-primary btn-sm">
-                        <i class="fa-solid fa-eye me-1"></i> Preview import
+                        <i class="fa-solid fa-eye me-1"></i> @Localizer["CityPlanning_Admin_ImportPreviewBtn"]
                     </button>
                     <div id="import-error" class="text-danger small mt-2 d-none"></div>
                     <div id="import-result" class="d-none mt-2"></div>
@@ -216,34 +216,34 @@
         <div class="modal-content">
             <div class="modal-header">
                 <h5 class="modal-title" id="import-preview-modal-label">
-                    <i class="fa-solid fa-file-import me-1"></i> Import preview
+                    <i class="fa-solid fa-file-import me-1"></i> @Localizer["CityPlanning_Admin_ImportModalTitle"]
                 </h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
             <div class="modal-body">
-                <h6 class="mb-2">Will be updated</h6>
+                <h6 class="mb-2">@Localizer["CityPlanning_Admin_ImportWillBeUpdated"]</h6>
                 <table class="table table-sm table-bordered mb-3">
                     <thead class="table-light">
                         <tr>
-                            <th>Camp</th>
-                            <th class="text-end">Previous area</th>
-                            <th class="text-end">New area</th>
+                            <th>@Localizer["CityPlanning_Admin_ImportCampHeader"]</th>
+                            <th class="text-end">@Localizer["CityPlanning_Admin_ImportPreviousArea"]</th>
+                            <th class="text-end">@Localizer["CityPlanning_Admin_ImportNewArea"]</th>
                         </tr>
                     </thead>
                     <tbody id="import-matched-body"></tbody>
                 </table>
 
                 <div id="import-unrecognized-section" class="d-none">
-                    <h6 class="text-warning mb-1"><i class="fa-solid fa-triangle-exclamation me-1"></i> Unrecognized features (will be skipped)</h6>
+                    <h6 class="text-warning mb-1"><i class="fa-solid fa-triangle-exclamation me-1"></i> @Localizer["CityPlanning_Admin_ImportUnrecognized"]</h6>
                     <ul id="import-unrecognized-list" class="small text-muted mb-0"></ul>
                 </div>
 
                 <div id="import-status" class="text-muted small mt-3 d-none"></div>
             </div>
             <div class="modal-footer">
-                <button type="button" class="btn btn-secondary btn-sm" data-bs-dismiss="modal">Cancel</button>
+                <button type="button" class="btn btn-secondary btn-sm" data-bs-dismiss="modal">@Localizer["Common_Cancel"]</button>
                 <button type="button" id="import-confirm-btn" class="btn btn-primary btn-sm">
-                    <i class="fa-solid fa-check me-1"></i> Confirm import
+                    <i class="fa-solid fa-check me-1"></i> @Localizer["CityPlanning_Admin_ImportConfirmBtn"]
                 </button>
             </div>
         </div>

--- a/src/Humans.Web/Views/CityPlanning/Admin.cshtml
+++ b/src/Humans.Web/Views/CityPlanning/Admin.cshtml
@@ -204,6 +204,18 @@
                     </button>
                     <div id="import-error" class="text-danger small mt-2 d-none"></div>
                     <div id="import-result" class="d-none mt-2"></div>
+                    <div id="import-strings" class="d-none"
+                         data-select-file-error="@Localizer["CityPlanning_Admin_ImportSelectFileError"]"
+                         data-invalid-json-error="@Localizer["CityPlanning_Admin_ImportInvalidJsonError"]"
+                         data-not-feature-collection-error="@Localizer["CityPlanning_Admin_ImportNotFeatureCollectionError"]"
+                         data-fetch-state-error="@Localizer["CityPlanning_Admin_ImportFetchStateError"]"
+                         data-no-camps-matched="@Localizer["CityPlanning_Admin_ImportNoCampsMatched"]"
+                         data-token-missing-error="@Localizer["CityPlanning_Admin_ImportTokenMissingError"]"
+                         data-file-too-large-error="@Localizer["CityPlanning_Admin_ImportFileTooLargeError"]"
+                         data-not-polygon-suffix="@Localizer["CityPlanning_Admin_ImportNotPolygonSuffix"]"
+                         data-updating="@Localizer["CityPlanning_Admin_ImportUpdating"]"
+                         data-import-success="@Localizer["CityPlanning_Admin_ImportSuccess"]"
+                         data-import-partial-failure="@Localizer["CityPlanning_Admin_ImportPartialFailure"]"></div>
                 </div>
             </div>
         </div>

--- a/src/Humans.Web/Views/CityPlanning/Admin.cshtml
+++ b/src/Humans.Web/Views/CityPlanning/Admin.cshtml
@@ -186,5 +186,71 @@
                 </div>
             </div>
         </div>
+
+        <!-- Import -->
+        <div class="col-12">
+            <div class="card">
+                <div class="card-header fw-semibold">
+                    <i class="fa-solid fa-file-import me-1"></i> Import polygons (@settings.Year)
+                </div>
+                <div class="card-body">
+                    <p class="mb-2">Upload a GeoJSON FeatureCollection to bulk-update camp polygons for @settings.Year. Features are matched by <code>campName</code> or <code>campSlug</code> property.</p>
+                    <div class="mb-3">
+                        <label class="form-label small fw-semibold">GeoJSON file</label>
+                        <input type="file" id="import-file-input" accept=".geojson,.json,application/geo+json" class="form-control form-control-sm" />
+                    </div>
+                    <button id="import-preview-btn" type="button" class="btn btn-primary btn-sm">
+                        <i class="fa-solid fa-eye me-1"></i> Preview import
+                    </button>
+                    <div id="import-error" class="text-danger small mt-2 d-none"></div>
+                    <div id="import-result" class="d-none mt-2"></div>
+                </div>
+            </div>
+        </div>
     </div>
 </div>
+
+<!-- Import preview modal -->
+<div class="modal fade" id="import-preview-modal" tabindex="-1" aria-labelledby="import-preview-modal-label" aria-hidden="true">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="import-preview-modal-label">
+                    <i class="fa-solid fa-file-import me-1"></i> Import preview
+                </h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <h6 class="mb-2">Will be updated</h6>
+                <table class="table table-sm table-bordered mb-3">
+                    <thead class="table-light">
+                        <tr>
+                            <th>Camp</th>
+                            <th class="text-end">Previous area</th>
+                            <th class="text-end">New area</th>
+                        </tr>
+                    </thead>
+                    <tbody id="import-matched-body"></tbody>
+                </table>
+
+                <div id="import-unrecognized-section" class="d-none">
+                    <h6 class="text-warning mb-1"><i class="fa-solid fa-triangle-exclamation me-1"></i> Unrecognized features (will be skipped)</h6>
+                    <ul id="import-unrecognized-list" class="small text-muted mb-0"></ul>
+                </div>
+
+                <div id="import-status" class="text-muted small mt-3 d-none"></div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary btn-sm" data-bs-dismiss="modal">Cancel</button>
+                <button type="button" id="import-confirm-btn" class="btn btn-primary btn-sm">
+                    <i class="fa-solid fa-check me-1"></i> Confirm import
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+    <script src="https://unpkg.com/@@turf/turf@7.1.0/turf.min.js"></script>
+    <script src="~/js/city-planning/admin-import.js"></script>
+}

--- a/src/Humans.Web/wwwroot/js/city-planning/admin-import.js
+++ b/src/Humans.Web/wwwroot/js/city-planning/admin-import.js
@@ -103,6 +103,8 @@ function renderPreviewModal(matched, unrecognized) {
     const unrecSection = document.getElementById('import-unrecognized-section');
     const unrecList    = document.getElementById('import-unrecognized-list');
     const confirmBtn   = document.getElementById('import-confirm-btn');
+    const statusEl     = document.getElementById('import-status');
+    if (statusEl) { statusEl.textContent = ''; statusEl.classList.add('d-none'); }
 
     if (matched.length === 0) {
         matchedBody.innerHTML = '<tr><td colspan="3" class="text-muted text-center">No camps matched.</td></tr>';

--- a/src/Humans.Web/wwwroot/js/city-planning/admin-import.js
+++ b/src/Humans.Web/wwwroot/js/city-planning/admin-import.js
@@ -137,14 +137,18 @@ async function handleConfirm() {
 
     const confirmBtn  = document.getElementById('import-confirm-btn');
     const statusEl    = document.getElementById('import-status');
-    const token       = document.querySelector('input[name="__RequestVerificationToken"]').value;
+    const tokenEl = document.querySelector('input[name="__RequestVerificationToken"]');
+    if (!tokenEl) { showError('Security token missing. Please refresh the page.'); return; }
+    const token = tokenEl.value;
     const now         = new Date();
     const noteDate    = now.toISOString().slice(0, 16).replace('T', ' ');
     const note        = `Imported ${noteDate}`;
 
     confirmBtn.disabled = true;
-    statusEl.textContent = `Updating ${pendingImport.matched.length} polygon(s)…`;
-    statusEl.classList.remove('d-none');
+    if (statusEl) {
+        statusEl.textContent = `Updating ${pendingImport.matched.length} polygon(s)…`;
+        statusEl.classList.remove('d-none');
+    }
 
     let successCount = 0;
     const failures   = [];
@@ -168,14 +172,14 @@ async function handleConfirm() {
     bootstrap.Modal.getInstance(document.getElementById('import-preview-modal'))?.hide();
 
     const resultDiv = document.getElementById('import-result');
-    if (failures.length === 0) {
+    if (resultDiv && failures.length === 0) {
         resultDiv.className = 'alert alert-success mt-2';
         resultDiv.textContent = `${successCount} polygon(s) updated.`;
-    } else {
+    } else if (resultDiv) {
         resultDiv.className = 'alert alert-warning mt-2';
         resultDiv.textContent = `${successCount} updated, ${failures.length} failed: ${failures.join(', ')}.`;
     }
-    resultDiv.classList.remove('d-none');
+    resultDiv?.classList.remove('d-none');
     pendingImport = null;
     fileInput.value = '';
 }

--- a/src/Humans.Web/wwwroot/js/city-planning/admin-import.js
+++ b/src/Humans.Web/wwwroot/js/city-planning/admin-import.js
@@ -1,0 +1,184 @@
+// admin-import.js — GeoJSON bulk import for the City Planning Admin page.
+// Depends on: turf (global), Bootstrap 5 modal (global).
+
+const fileInput   = document.getElementById('import-file-input');
+const previewBtn  = document.getElementById('import-preview-btn');
+const errorDiv    = document.getElementById('import-error');
+
+let pendingImport = null;
+
+function showError(msg) {
+    errorDiv.textContent = msg;
+    errorDiv.classList.remove('d-none');
+}
+
+function clearError() {
+    errorDiv.textContent = '';
+    errorDiv.classList.add('d-none');
+}
+
+function formatArea(sqm) {
+    if (sqm == null) return '—';
+    return Math.round(sqm).toLocaleString() + ' m²';
+}
+
+function buildCampLookup(state) {
+    const lookup = new Map();
+    for (const p of state.campPolygons ?? []) {
+        lookup.set(p.campName.toLowerCase(),  { campSeasonId: p.campSeasonId, campName: p.campName, currentAreaSqm: p.areaSqm });
+        lookup.set(p.campSlug.toLowerCase(),  { campSeasonId: p.campSeasonId, campName: p.campName, currentAreaSqm: p.areaSqm });
+    }
+    for (const s of state.campSeasonsWithoutPolygon ?? []) {
+        lookup.set(s.campName.toLowerCase(), { campSeasonId: s.campSeasonId, campName: s.campName, currentAreaSqm: null });
+        lookup.set(s.campSlug.toLowerCase(), { campSeasonId: s.campSeasonId, campName: s.campName, currentAreaSqm: null });
+    }
+    return lookup;
+}
+
+function matchFeatures(features, lookup) {
+    const matched = [];
+    const unrecognized = [];
+    const seenIds = new Set();
+
+    for (const feature of features) {
+        const props = feature.properties ?? {};
+        const name  = (props.campName ?? '').toLowerCase();
+        const slug  = (props.campSlug ?? '').toLowerCase();
+        const camp  = lookup.get(name) || lookup.get(slug);
+
+        if (!camp) {
+            unrecognized.push(props.campName || props.campSlug || '(unnamed feature)');
+            continue;
+        }
+        if (seenIds.has(camp.campSeasonId)) continue;
+        seenIds.add(camp.campSeasonId);
+
+        const newAreaSqm = turf.area(feature);
+        matched.push({
+            campSeasonId:    camp.campSeasonId,
+            campName:        camp.campName,
+            previousAreaSqm: camp.currentAreaSqm,
+            newAreaSqm,
+            geoJson:         JSON.stringify(feature),
+        });
+    }
+
+    return { matched, unrecognized };
+}
+
+async function handlePreview() {
+    clearError();
+    const file = fileInput.files?.[0];
+    if (!file) { showError('Please select a GeoJSON file.'); return; }
+
+    let parsed;
+    try {
+        parsed = JSON.parse(await file.text());
+    } catch {
+        showError('Invalid file — not valid JSON.'); return;
+    }
+    if (parsed?.type !== 'FeatureCollection' || !Array.isArray(parsed.features)) {
+        showError('File must be a GeoJSON FeatureCollection.'); return;
+    }
+
+    let state;
+    try {
+        const resp = await fetch('/api/city-planning/state');
+        if (!resp.ok) throw new Error();
+        state = await resp.json();
+    } catch {
+        showError('Could not load camp list. Please try again.'); return;
+    }
+
+    const lookup = buildCampLookup(state);
+    const { matched, unrecognized } = matchFeatures(parsed.features, lookup);
+    pendingImport = { matched, unrecognized };
+
+    renderPreviewModal(matched, unrecognized);
+    bootstrap.Modal.getOrCreateInstance(document.getElementById('import-preview-modal')).show();
+}
+
+function renderPreviewModal(matched, unrecognized) {
+    const matchedBody  = document.getElementById('import-matched-body');
+    const unrecSection = document.getElementById('import-unrecognized-section');
+    const unrecList    = document.getElementById('import-unrecognized-list');
+    const confirmBtn   = document.getElementById('import-confirm-btn');
+
+    if (matched.length === 0) {
+        matchedBody.innerHTML = '<tr><td colspan="3" class="text-muted text-center">No camps matched.</td></tr>';
+        confirmBtn.disabled = true;
+    } else {
+        matchedBody.innerHTML = matched.map(m => `
+            <tr>
+                <td>${escHtml(m.campName)}</td>
+                <td class="text-end">${formatArea(m.previousAreaSqm)}</td>
+                <td class="text-end">${formatArea(m.newAreaSqm)}</td>
+            </tr>
+        `).join('');
+        confirmBtn.disabled = false;
+    }
+
+    if (unrecognized.length > 0) {
+        unrecList.innerHTML = unrecognized.map(n => `<li>${escHtml(n)}</li>`).join('');
+        unrecSection.classList.remove('d-none');
+    } else {
+        unrecSection.classList.add('d-none');
+    }
+}
+
+function escHtml(s) {
+    const d = document.createElement('div');
+    d.textContent = s;
+    return d.innerHTML;
+}
+
+async function handleConfirm() {
+    if (!pendingImport?.matched?.length) return;
+
+    const confirmBtn  = document.getElementById('import-confirm-btn');
+    const statusEl    = document.getElementById('import-status');
+    const token       = document.querySelector('input[name="__RequestVerificationToken"]').value;
+    const now         = new Date();
+    const noteDate    = now.toISOString().slice(0, 16).replace('T', ' ');
+    const note        = `Imported ${noteDate}`;
+
+    confirmBtn.disabled = true;
+    statusEl.textContent = `Updating ${pendingImport.matched.length} polygon(s)…`;
+    statusEl.classList.remove('d-none');
+
+    let successCount = 0;
+    const failures   = [];
+
+    for (const item of pendingImport.matched) {
+        const resp = await fetch(`/api/city-planning/camp-polygons/${item.campSeasonId}`, {
+            method: 'PUT',
+            headers: {
+                'Content-Type': 'application/json',
+                'RequestVerificationToken': token,
+            },
+            body: JSON.stringify({ geoJson: item.geoJson, areaSqm: item.newAreaSqm, note }),
+        });
+        if (resp.ok) {
+            successCount++;
+        } else {
+            failures.push(item.campName);
+        }
+    }
+
+    bootstrap.Modal.getInstance(document.getElementById('import-preview-modal'))?.hide();
+
+    const resultDiv = document.getElementById('import-result');
+    if (failures.length === 0) {
+        resultDiv.className = 'alert alert-success mt-2';
+        resultDiv.textContent = `${successCount} polygon(s) updated.`;
+    } else {
+        resultDiv.className = 'alert alert-warning mt-2';
+        resultDiv.textContent = `${successCount} updated, ${failures.length} failed: ${failures.join(', ')}.`;
+    }
+    resultDiv.classList.remove('d-none');
+    pendingImport = null;
+    fileInput.value = '';
+}
+
+previewBtn?.addEventListener('click', handlePreview);
+document.getElementById('import-confirm-btn')?.addEventListener('click', handleConfirm);

--- a/src/Humans.Web/wwwroot/js/city-planning/admin-import.js
+++ b/src/Humans.Web/wwwroot/js/city-planning/admin-import.js
@@ -1,9 +1,18 @@
 // admin-import.js — GeoJSON bulk import for the City Planning Admin page.
 // Depends on: turf (global), Bootstrap 5 modal (global).
 
+const MAX_FILE_BYTES = 10_000_000; // 10 MB
+
 const fileInput   = document.getElementById('import-file-input');
 const previewBtn  = document.getElementById('import-preview-btn');
 const errorDiv    = document.getElementById('import-error');
+const stringsEl   = document.getElementById('import-strings');
+
+const STRINGS = stringsEl?.dataset ?? {};
+function t(key, ...args) {
+    const s = STRINGS[key] ?? '';
+    return args.length === 0 ? s : s.replace(/\{(\d+)\}/g, (_, i) => args[+i]);
+}
 
 let pendingImport = null;
 
@@ -15,6 +24,15 @@ function showError(msg) {
 function clearError() {
     errorDiv.textContent = '';
     errorDiv.classList.add('d-none');
+}
+
+function showModalStatus(msg, isError = false) {
+    const statusEl = document.getElementById('import-status');
+    if (!statusEl) return;
+    statusEl.textContent = msg;
+    statusEl.classList.remove('d-none');
+    statusEl.classList.toggle('text-danger', isError);
+    statusEl.classList.toggle('text-muted', !isError);
 }
 
 function formatArea(sqm) {
@@ -39,18 +57,30 @@ function matchFeatures(features, lookup) {
     const matched = [];
     const unrecognized = [];
     const seenIds = new Set();
+    const notPolygonSuffix = t('notPolygonSuffix');
 
     for (const feature of features) {
         const props = feature.properties ?? {};
         const name  = (props.campName ?? '').toLowerCase();
         const slug  = (props.campSlug ?? '').toLowerCase();
         const camp  = lookup.get(name) || lookup.get(slug);
+        const label = props.campName || props.campSlug || '(unnamed feature)';
 
         if (!camp) {
-            unrecognized.push(props.campName || props.campSlug || '(unnamed feature)');
+            unrecognized.push(label);
             continue;
         }
-        if (seenIds.has(camp.campSeasonId)) continue;
+
+        const geomType = feature.geometry?.type;
+        if (geomType !== 'Polygon' && geomType !== 'MultiPolygon') {
+            unrecognized.push(notPolygonSuffix ? `${label} ${notPolygonSuffix}` : label);
+            continue;
+        }
+
+        if (seenIds.has(camp.campSeasonId)) {
+            console.warn('admin-import: duplicate match for', camp.campName, '— first feature wins, later duplicate skipped');
+            continue;
+        }
         seenIds.add(camp.campSeasonId);
 
         const newAreaSqm = turf.area(feature);
@@ -67,35 +97,47 @@ function matchFeatures(features, lookup) {
 }
 
 async function handlePreview() {
-    clearError();
-    const file = fileInput.files?.[0];
-    if (!file) { showError('Please select a GeoJSON file.'); return; }
-
-    let parsed;
+    if (!previewBtn) return;
+    previewBtn.disabled = true;
     try {
-        parsed = JSON.parse(await file.text());
-    } catch {
-        showError('Invalid file — not valid JSON.'); return;
-    }
-    if (parsed?.type !== 'FeatureCollection' || !Array.isArray(parsed.features)) {
-        showError('File must be a GeoJSON FeatureCollection.'); return;
-    }
+        clearError();
+        const file = fileInput.files?.[0];
+        if (!file) { showError(t('selectFileError')); return; }
+        if (file.size > MAX_FILE_BYTES) { showError(t('fileTooLargeError')); return; }
 
-    let state;
-    try {
-        const resp = await fetch('/api/city-planning/state');
-        if (!resp.ok) throw new Error();
-        state = await resp.json();
-    } catch {
-        showError('Could not load camp list. Please try again.'); return;
+        let parsed;
+        try {
+            parsed = JSON.parse(await file.text());
+        } catch (e) {
+            console.error('admin-import: failed to parse GeoJSON file', e);
+            showError(t('invalidJsonError'));
+            return;
+        }
+        if (parsed?.type !== 'FeatureCollection' || !Array.isArray(parsed.features)) {
+            showError(t('notFeatureCollectionError'));
+            return;
+        }
+
+        let state;
+        try {
+            const resp = await fetch('/api/city-planning/state');
+            if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+            state = await resp.json();
+        } catch (e) {
+            console.error('admin-import: failed to fetch /api/city-planning/state', e);
+            showError(t('fetchStateError'));
+            return;
+        }
+
+        const lookup = buildCampLookup(state);
+        const { matched, unrecognized } = matchFeatures(parsed.features, lookup);
+        pendingImport = { matched, unrecognized };
+
+        renderPreviewModal(matched, unrecognized);
+        bootstrap.Modal.getOrCreateInstance(document.getElementById('import-preview-modal')).show();
+    } finally {
+        previewBtn.disabled = false;
     }
-
-    const lookup = buildCampLookup(state);
-    const { matched, unrecognized } = matchFeatures(parsed.features, lookup);
-    pendingImport = { matched, unrecognized };
-
-    renderPreviewModal(matched, unrecognized);
-    bootstrap.Modal.getOrCreateInstance(document.getElementById('import-preview-modal')).show();
 }
 
 function renderPreviewModal(matched, unrecognized) {
@@ -104,10 +146,15 @@ function renderPreviewModal(matched, unrecognized) {
     const unrecList    = document.getElementById('import-unrecognized-list');
     const confirmBtn   = document.getElementById('import-confirm-btn');
     const statusEl     = document.getElementById('import-status');
-    if (statusEl) { statusEl.textContent = ''; statusEl.classList.add('d-none'); }
+    if (statusEl) {
+        statusEl.textContent = '';
+        statusEl.classList.add('d-none');
+        statusEl.classList.remove('text-danger');
+        statusEl.classList.add('text-muted');
+    }
 
     if (matched.length === 0) {
-        matchedBody.innerHTML = '<tr><td colspan="3" class="text-muted text-center">No camps matched.</td></tr>';
+        matchedBody.innerHTML = `<tr><td colspan="3" class="text-muted text-center">${escHtml(t('noCampsMatched'))}</td></tr>`;
         confirmBtn.disabled = true;
     } else {
         matchedBody.innerHTML = matched.map(m => `
@@ -137,38 +184,41 @@ function escHtml(s) {
 async function handleConfirm() {
     if (!pendingImport?.matched?.length) return;
 
-    const confirmBtn  = document.getElementById('import-confirm-btn');
-    const statusEl    = document.getElementById('import-status');
-    const tokenEl = document.querySelector('input[name="__RequestVerificationToken"]');
-    if (!tokenEl) { showError('Security token missing. Please refresh the page.'); return; }
-    const token = tokenEl.value;
-    const now         = new Date();
-    const noteDate    = now.toISOString().slice(0, 16).replace('T', ' ');
-    const note        = `Imported ${noteDate}`;
+    const confirmBtn = document.getElementById('import-confirm-btn');
+    const tokenEl    = document.querySelector('input[name="__RequestVerificationToken"]');
+    if (!tokenEl) {
+        showModalStatus(t('tokenMissingError'), true);
+        return;
+    }
+    const token    = tokenEl.value;
+    const now      = new Date();
+    const noteDate = now.toISOString().slice(0, 16).replace('T', ' ');
+    const note     = `Imported ${noteDate}`;
 
     confirmBtn.disabled = true;
-    if (statusEl) {
-        statusEl.textContent = `Updating ${pendingImport.matched.length} polygon(s)…`;
-        statusEl.classList.remove('d-none');
-    }
+    showModalStatus(t('updating', pendingImport.matched.length));
 
     let successCount = 0;
     const failures   = [];
 
-    for (const item of pendingImport.matched) {
-        const resp = await fetch(`/api/city-planning/camp-polygons/${item.campSeasonId}`, {
-            method: 'PUT',
-            headers: {
-                'Content-Type': 'application/json',
-                'RequestVerificationToken': token,
-            },
-            body: JSON.stringify({ geoJson: item.geoJson, areaSqm: item.newAreaSqm, note }),
-        });
-        if (resp.ok) {
-            successCount++;
-        } else {
-            failures.push(item.campName);
+    try {
+        for (const item of pendingImport.matched) {
+            const resp = await fetch(`/api/city-planning/camp-polygons/${item.campSeasonId}`, {
+                method: 'PUT',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'RequestVerificationToken': token,
+                },
+                body: JSON.stringify({ geoJson: item.geoJson, areaSqm: item.newAreaSqm, note }),
+            });
+            if (resp.ok) {
+                successCount++;
+            } else {
+                failures.push(item.campName);
+            }
         }
+    } finally {
+        confirmBtn.disabled = false;
     }
 
     bootstrap.Modal.getInstance(document.getElementById('import-preview-modal'))?.hide();
@@ -176,10 +226,10 @@ async function handleConfirm() {
     const resultDiv = document.getElementById('import-result');
     if (resultDiv && failures.length === 0) {
         resultDiv.className = 'alert alert-success mt-2';
-        resultDiv.textContent = `${successCount} polygon(s) updated.`;
+        resultDiv.textContent = t('importSuccess', successCount);
     } else if (resultDiv) {
         resultDiv.className = 'alert alert-warning mt-2';
-        resultDiv.textContent = `${successCount} updated, ${failures.length} failed: ${failures.join(', ')}.`;
+        resultDiv.textContent = t('importPartialFailure', successCount, failures.length, failures.join(', '));
     }
     resultDiv?.classList.remove('d-none');
     pendingImport = null;


### PR DESCRIPTION
City planning map designers need to work on the camp polygons in their won software, and re-upload the results to the map.

## Summary

- Adds an **Import** card to the CityPlanning Admin page for bulk-updating camp polygons from a GeoJSON FeatureCollection
- Client-side matching by `campName` or `campSlug` property (case-insensitive), area computation via Turf.js, and a preview modal showing old vs. new area per camp before committing
- Each imported polygon gets a history entry with note `"Imported YYYY-MM-DD HH:mm"` (UTC) attributed to the importing user
- Reuses the existing `PUT /api/city-planning/camp-polygons/{campSeasonId}` endpoint — only backend change is an optional `Note` field on `SaveCampPolygonRequest`
- All UI strings localized (en, es, de, fr, it, ca)

## Test Plan

- [ ] Navigate to `/CityPlanning/Admin` as a map admin — Import card appears below Export
- [ ] Export current year's GeoJSON, re-upload it → preview modal shows all camps with matching previous/new areas → confirm → success banner
- [ ] Check polygon history for one camp → entry with `"Imported YYYY-MM-DD HH:mm"` note
- [ ] Rename a `campName` in the file to something fake → modal shows it in "Unrecognized (will be skipped)"
- [ ] Upload a plain text file → inline error "Invalid file — not valid JSON"
- [ ] Upload `{}` → inline error "File must be a GeoJSON FeatureCollection"
- [ ] Open import dialog a second time → status text from previous import is cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)