### PR TITLE
feat: build hash tooltip on logo for *Admin users

### DIFF
--- a/src/Humans.Web/Views/Shared/_Layout.cshtml
+++ b/src/Humans.Web/Views/Shared/_Layout.cshtml
@@ -28,10 +28,44 @@
     <header>
         <nav class="navbar navbar-expand-sm navbar-dark mb-3">
             <div class="container">
-                <a class="navbar-brand" asp-area="" asp-controller="Home" asp-action="Index">
-                    <img src="~/img/logo.svg" alt="" aria-hidden="true" />
-                    @Localizer["Nav_Brand"]
-                </a>
+                @{
+                    string? buildHashTooltip = null;
+                    if (User.IsInRole(Humans.Domain.Constants.RoleNames.Admin)
+                        || User.IsInRole(Humans.Domain.Constants.RoleNames.HumanAdmin)
+                        || User.IsInRole(Humans.Domain.Constants.RoleNames.TeamsAdmin)
+                        || User.IsInRole(Humans.Domain.Constants.RoleNames.CampAdmin)
+                        || User.IsInRole(Humans.Domain.Constants.RoleNames.TicketAdmin)
+                        || User.IsInRole(Humans.Domain.Constants.RoleNames.FeedbackAdmin)
+                        || User.IsInRole(Humans.Domain.Constants.RoleNames.FinanceAdmin)
+                        || User.IsInRole(Humans.Domain.Constants.RoleNames.NoInfoAdmin))
+                    {
+                        var brandAssembly = System.Reflection.Assembly.GetEntryAssembly()!;
+                        var brandAttr = (System.Reflection.AssemblyInformationalVersionAttribute?)
+                            Attribute.GetCustomAttribute(brandAssembly, typeof(System.Reflection.AssemblyInformationalVersionAttribute));
+                        var brandInfoVersion = brandAttr?.InformationalVersion ?? "";
+                        var brandPlusIndex = brandInfoVersion.IndexOf('+', StringComparison.Ordinal);
+                        var brandFullCommit = brandPlusIndex >= 0 ? brandInfoVersion[(brandPlusIndex + 1)..] : "";
+                        if (brandFullCommit.Length > 0)
+                        {
+                            buildHashTooltip = brandFullCommit.Length > 8 ? brandFullCommit[..8] : brandFullCommit;
+                        }
+                    }
+                }
+                @if (buildHashTooltip != null)
+                {
+                    <a class="navbar-brand" asp-area="" asp-controller="Home" asp-action="Index"
+                       data-bs-toggle="tooltip" data-bs-custom-class="build-hash-tooltip" title="@buildHashTooltip">
+                        <img src="~/img/logo.svg" alt="" aria-hidden="true" />
+                        @Localizer["Nav_Brand"]
+                    </a>
+                }
+                else
+                {
+                    <a class="navbar-brand" asp-area="" asp-controller="Home" asp-action="Index">
+                        <img src="~/img/logo.svg" alt="" aria-hidden="true" />
+                        @Localizer["Nav_Brand"]
+                    </a>
+                }
                 <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target=".navbar-collapse">
                     <span class="navbar-toggler-icon"></span>
                 </button>

--- a/src/Humans.Web/wwwroot/css/site.css
+++ b/src/Humans.Web/wwwroot/css/site.css
@@ -1499,3 +1499,11 @@ tr[data-href] {
 .guest-section-sub {
     line-height: 1.3;
 }
+
+/* ─── Build hash tooltip ─── */
+.build-hash-tooltip .tooltip-inner {
+    font-size: 2rem;
+    font-family: var(--bs-font-monospace, monospace);
+    max-width: none;
+}
+

--- a/src/Humans.Web/wwwroot/js/site.js
+++ b/src/Humans.Web/wwwroot/js/site.js
@@ -252,6 +252,14 @@ function showToast(message, type) {
     toastEl.addEventListener('hidden.bs.toast', function () { toastEl.remove(); });
 }
 
+// Initialize Bootstrap tooltips for any element with data-bs-toggle="tooltip"
+(function () {
+    if (typeof bootstrap === 'undefined' || !bootstrap.Tooltip) return;
+    document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(function (el) {
+        new bootstrap.Tooltip(el);
+    });
+})();
+
 // Human profile popover (lazy-loaded on first hover)
 (function () {
     var cache = {};


### PR DESCRIPTION
## Summary

- Hovering the navbar-brand logo shows the build hash (short SHA) in a Bootstrap tooltip
- Gated to any `*Admin` role: Admin, HumanAdmin, TeamsAdmin, CampAdmin, TicketAdmin, FeedbackAdmin, FinanceAdmin, NoInfoAdmin
- Tooltip text styled at 2rem, monospace; hash read server-side from `AssemblyInformationalVersionAttribute`

Implements nobodies-collective#589.

## Verification

Local build clean. Rendered HTML inspected against the running dev server:

| Persona | Result |
|---------|--------|
| Anonymous | clean `<a class="navbar-brand" href="/">` — no tooltip attrs |
| Volunteer | same — no tooltip |
| Board | same — no tooltip (governance role, not `*Admin`) |
| Admin | `data-bs-toggle="tooltip" data-bs-custom-class="build-hash-tooltip" title="8f6a2556"` |
| TeamsAdmin | same as Admin |

Couldn't drive a real browser from this session — visual hover behavior (tooltip appears, font-size 2rem, monospace) needs verification on the preview env.

## Test plan

- [ ] Preview env spins up cleanly
- [ ] Sign in as Admin, hover navbar logo: tooltip with the short SHA appears at 2rem
- [ ] Sign in as a non-admin (Volunteer / Board): no tooltip on hover
- [ ] Tooltip SHA matches `/api/version`'s `commit` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)