### PR TITLE
ci: verify EF migration chain is linear

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,19 @@ jobs:
       # test host for 8+ minutes before this guard existed.
       run: dotnet test Humans.slnx --no-build --configuration Release --verbosity quiet --blame-hang-timeout 2m --logger "trx;LogFileName=test-results.trx" --logger "console;verbosity=minimal" --filter "FullyQualifiedName!~Integration"
 
+    - name: Verify EF migration chain is linear
+      # Catches migration forks (two migrations claiming the same parent) and
+      # snapshot drift (HumansDbContextModelSnapshot.cs out of sync with the
+      # current DbContext model). Exits non-zero if the snapshot doesn't match
+      # the live model — which is exactly what happens when two branches each
+      # add a migration off the same tip and one merges before the other.
+      run: |
+        dotnet tool install --global dotnet-ef --version 10.0.*
+        dotnet ef migrations has-pending-model-changes \
+          --project src/Humans.Infrastructure \
+          --startup-project src/Humans.Web \
+          --no-build --configuration Release
+
     - name: Upload test results
       uses: actions/upload-artifact@v4
       if: always()


### PR DESCRIPTION
## Summary

Adds Layer 1 of EF migration chain verification to `build.yml`: `dotnet ef migrations has-pending-model-changes`. Exits non-zero if `HumansDbContextModelSnapshot.cs` doesn't match the live DbContext model — which is exactly what happens when two branches each add a migration off the same parent and one merges before the other (the surviving snapshot disagrees with the merged model state).

Catches:
- snapshot hand-edits / forgotten regenerations
- migration-fork pattern (\`A → B + A → C\` instead of \`A → B → C\`)

Does NOT catch (these need Layer 2):
- migrations that are linear at the model level but break against real-world data shapes
- ordering issues that only surface during `dotnet ef database update`

Layer 2 (apply-from-scratch on a throwaway Postgres) is intentionally not in this PR — it'll go in a separate job targeting a self-hosted Windows runner when one is available.

## Test plan

- [x] Verified locally: `dotnet ef migrations has-pending-model-changes` against current main exits 0 with "No changes have been made to the model since the last migration."
- [ ] CI passes on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)