### PR TITLE
Fix Attendees pagination overflow and add multi-ticket buyer filter

### DIFF
--- a/src/Humans.Application/Interfaces/Repositories/ITicketRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/ITicketRepository.cs
@@ -241,6 +241,7 @@ public interface ITicketRepository
         TicketAttendeeStatus? filterStatus,
         bool? filterMatched,
         string? filterOrderId,
+        bool filterMultipleTickets,
         CancellationToken ct = default);
 
     Task<IReadOnlyList<AttendeeExportRow>> GetAttendeeExportDataAsync(CancellationToken ct = default);

--- a/src/Humans.Application/Interfaces/Tickets/ITicketQueryService.cs
+++ b/src/Humans.Application/Interfaces/Tickets/ITicketQueryService.cs
@@ -86,7 +86,8 @@ public interface ITicketQueryService
     Task<AttendeesPageResult> GetAttendeesPageAsync(
         string? search, string sortBy, bool sortDesc,
         int page, int pageSize,
-        string? filterTicketType, string? filterStatus, bool? filterMatched, string? filterOrderId);
+        string? filterTicketType, string? filterStatus, bool? filterMatched, string? filterOrderId,
+        bool filterMultipleTickets = false);
 
     /// <summary>
     /// Get data for the "who hasn't bought" page: all active humans with ticket match status,

--- a/src/Humans.Application/Services/Tickets/TicketQueryService.cs
+++ b/src/Humans.Application/Services/Tickets/TicketQueryService.cs
@@ -470,7 +470,8 @@ public sealed class TicketQueryService : ITicketQueryService, IUserDataContribut
     public async Task<AttendeesPageResult> GetAttendeesPageAsync(
         string? search, string sortBy, bool sortDesc,
         int page, int pageSize,
-        string? filterTicketType, string? filterStatus, bool? filterMatched, string? filterOrderId)
+        string? filterTicketType, string? filterStatus, bool? filterMatched, string? filterOrderId,
+        bool filterMultipleTickets = false)
     {
         TicketAttendeeStatus? parsedStatus = null;
         if (!string.IsNullOrEmpty(filterStatus) &&
@@ -481,7 +482,7 @@ public sealed class TicketQueryService : ITicketQueryService, IUserDataContribut
 
         var (rawRows, totalCount) = await _ticketRepository.GetAttendeesPageAsync(
             search, sortBy, sortDesc, page, pageSize,
-            filterTicketType, parsedStatus, filterMatched, filterOrderId);
+            filterTicketType, parsedStatus, filterMatched, filterOrderId, filterMultipleTickets);
 
         var rows = await HydrateAttendeeMatchedUserNamesAsync(rawRows);
         return new AttendeesPageResult { Rows = rows, TotalCount = totalCount };

--- a/src/Humans.Infrastructure/Repositories/Tickets/TicketRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Tickets/TicketRepository.cs
@@ -678,6 +678,7 @@ public sealed class TicketRepository : ITicketRepository
         TicketAttendeeStatus? filterStatus,
         bool? filterMatched,
         string? filterOrderId,
+        bool filterMultipleTickets,
         CancellationToken ct = default)
     {
         await using var ctx = await _factory.CreateDbContextAsync(ct);
@@ -706,6 +707,27 @@ public sealed class TicketRepository : ITicketRepository
             query = query.Where(a => a.MatchedUserId != null);
         else if (filterMatched == false)
             query = query.Where(a => a.MatchedUserId == null);
+
+        if (filterMultipleTickets)
+        {
+            var dupMatchedIds = ctx.TicketAttendees
+                .Where(a => a.MatchedUserId != null)
+                .GroupBy(a => a.MatchedUserId!.Value)
+                .Where(g => g.Count() > 1)
+                .Select(g => g.Key);
+
+#pragma warning disable MA0011 // EF LINQ: ToLower() translates to SQL lower()
+            var dupEmails = ctx.TicketAttendees
+                .Where(a => a.MatchedUserId == null && a.AttendeeEmail != null)
+                .GroupBy(a => a.AttendeeEmail!.ToLower())
+                .Where(g => g.Count() > 1)
+                .Select(g => g.Key);
+
+            query = query.Where(a =>
+                (a.MatchedUserId != null && dupMatchedIds.Contains(a.MatchedUserId!.Value)) ||
+                (a.MatchedUserId == null && a.AttendeeEmail != null && dupEmails.Contains(a.AttendeeEmail.ToLower())));
+#pragma warning restore MA0011
+        }
 
         var totalCount = await query.CountAsync(ct);
 

--- a/src/Humans.Web/Controllers/TicketController.cs
+++ b/src/Humans.Web/Controllers/TicketController.cs
@@ -213,13 +213,14 @@ public class TicketController : HumansControllerBase
         string? search, string sortBy = "name", bool sortDesc = false,
         int page = 1, int pageSize = 25,
         string? filterTicketType = null, string? filterStatus = null,
-        bool? filterMatched = null, string? filterOrderId = null)
+        bool? filterMatched = null, string? filterOrderId = null,
+        bool filterMultipleTickets = false)
     {
         pageSize = pageSize.ClampPageSize();
 
         var result = await _ticketQueryService.GetAttendeesPageAsync(
             search, sortBy, sortDesc, page, pageSize,
-            filterTicketType, filterStatus, filterMatched, filterOrderId);
+            filterTicketType, filterStatus, filterMatched, filterOrderId, filterMultipleTickets);
 
         var model = new TicketAttendeesViewModel
         {
@@ -252,6 +253,7 @@ public class TicketController : HumansControllerBase
             FilterStatus = filterStatus,
             FilterMatched = filterMatched,
             FilterOrderId = filterOrderId,
+            FilterMultipleTickets = filterMultipleTickets,
             AvailableTicketTypes = await _ticketQueryService.GetAvailableTicketTypesAsync(),
         };
 

--- a/src/Humans.Web/Models/PagerViewModel.cs
+++ b/src/Humans.Web/Models/PagerViewModel.cs
@@ -1,0 +1,10 @@
+namespace Humans.Web.Models;
+
+public sealed class PagerViewModel
+{
+    public required int TotalPages { get; init; }
+    public required int CurrentPage { get; init; }
+    public required string Action { get; init; }
+    public string? Controller { get; init; }
+    public int Window { get; init; } = 2;
+}

--- a/src/Humans.Web/Models/PagerViewModel.cs
+++ b/src/Humans.Web/Models/PagerViewModel.cs
@@ -5,6 +5,5 @@ public sealed class PagerViewModel
     public required int TotalPages { get; init; }
     public required int CurrentPage { get; init; }
     public required string Action { get; init; }
-    public string? Controller { get; init; }
     public int Window { get; init; } = 2;
 }

--- a/src/Humans.Web/Models/TicketViewModels.cs
+++ b/src/Humans.Web/Models/TicketViewModels.cs
@@ -132,6 +132,7 @@ public class TicketAttendeesViewModel : PagedListViewModel
     public string? FilterStatus { get; set; }
     public bool? FilterMatched { get; set; }
     public string? FilterOrderId { get; set; }
+    public bool FilterMultipleTickets { get; set; }
     public List<string> AvailableTicketTypes { get; set; } = [];
 }
 

--- a/src/Humans.Web/Views/Shared/_Pager.cshtml
+++ b/src/Humans.Web/Views/Shared/_Pager.cshtml
@@ -33,7 +33,7 @@
 <nav aria-label="Pagination">
     <ul class="pagination">
         <li class="page-item @(current <= 1 ? "disabled" : "")">
-            <a class="page-link" asp-action="@Model.Action" asp-controller="@Model.Controller" asp-all-route-data="@RouteFor(current - 1)">Previous</a>
+            <a class="page-link" asp-action="@Model.Action" asp-all-route-data="@RouteFor(current - 1)">Previous</a>
         </li>
         @foreach (var p in pages)
         {
@@ -44,12 +44,12 @@
             else
             {
                 <li class="page-item @(p == current ? "active" : "")">
-                    <a class="page-link" asp-action="@Model.Action" asp-controller="@Model.Controller" asp-all-route-data="@RouteFor(p)">@p</a>
+                    <a class="page-link" asp-action="@Model.Action" asp-all-route-data="@RouteFor(p)">@p</a>
                 </li>
             }
         }
         <li class="page-item @(current >= Model.TotalPages ? "disabled" : "")">
-            <a class="page-link" asp-action="@Model.Action" asp-controller="@Model.Controller" asp-all-route-data="@RouteFor(current + 1)">Next</a>
+            <a class="page-link" asp-action="@Model.Action" asp-all-route-data="@RouteFor(current + 1)">Next</a>
         </li>
     </ul>
 </nav>

--- a/src/Humans.Web/Views/Shared/_Pager.cshtml
+++ b/src/Humans.Web/Views/Shared/_Pager.cshtml
@@ -1,0 +1,55 @@
+@model Humans.Web.Models.PagerViewModel
+@{
+    if (Model.TotalPages <= 1) { return; }
+
+    var current = Math.Clamp(Model.CurrentPage, 1, Model.TotalPages);
+    var window = Math.Max(0, Model.Window);
+    var windowStart = Math.Max(2, current - window);
+    var windowEnd = Math.Min(Model.TotalPages - 1, current + window);
+
+    var pages = new List<int> { 1 };
+    if (windowStart > 2) { pages.Add(-1); }
+    for (var i = windowStart; i <= windowEnd; i++) { pages.Add(i); }
+    if (windowEnd < Model.TotalPages - 1) { pages.Add(-1); }
+    if (Model.TotalPages > 1) { pages.Add(Model.TotalPages); }
+
+    var baseRoute = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+    foreach (var pair in Context.Request.Query)
+    {
+        if (string.Equals(pair.Key, "page", StringComparison.OrdinalIgnoreCase)) { continue; }
+        baseRoute[pair.Key] = pair.Value.ToString();
+    }
+
+    Dictionary<string, string?> RouteFor(int page)
+    {
+        var dict = new Dictionary<string, string?>(baseRoute, StringComparer.OrdinalIgnoreCase)
+        {
+            ["page"] = page.ToString(System.Globalization.CultureInfo.InvariantCulture),
+        };
+        return dict;
+    }
+}
+
+<nav aria-label="Pagination">
+    <ul class="pagination">
+        <li class="page-item @(current <= 1 ? "disabled" : "")">
+            <a class="page-link" asp-action="@Model.Action" asp-controller="@Model.Controller" asp-all-route-data="@RouteFor(current - 1)">Previous</a>
+        </li>
+        @foreach (var p in pages)
+        {
+            if (p == -1)
+            {
+                <li class="page-item disabled"><span class="page-link">&hellip;</span></li>
+            }
+            else
+            {
+                <li class="page-item @(p == current ? "active" : "")">
+                    <a class="page-link" asp-action="@Model.Action" asp-controller="@Model.Controller" asp-all-route-data="@RouteFor(p)">@p</a>
+                </li>
+            }
+        }
+        <li class="page-item @(current >= Model.TotalPages ? "disabled" : "")">
+            <a class="page-link" asp-action="@Model.Action" asp-controller="@Model.Controller" asp-all-route-data="@RouteFor(current + 1)">Next</a>
+        </li>
+    </ul>
+</nav>

--- a/src/Humans.Web/Views/Ticket/Attendees.cshtml
+++ b/src/Humans.Web/Views/Ticket/Attendees.cshtml
@@ -36,6 +36,14 @@
                 <option value="false" selected="@(Model.FilterMatched == false ? "selected" : null)">Unmatched</option>
             </select>
         </div>
+        <div class="col-md-auto">
+            <div class="form-check mt-2">
+                <input class="form-check-input" type="checkbox" name="filterMultipleTickets" value="true" id="filterMultipleTickets" checked="@(Model.FilterMultipleTickets ? "checked" : null)" />
+                <label class="form-check-label" for="filterMultipleTickets" title="Buyers (matched human or unmatched email) with more than one ticket">
+                    Buyers with &gt;1 ticket
+                </label>
+            </div>
+        </div>
         <div class="col-auto">
             <button type="submit" class="btn btn-primary"><i class="fa-solid fa-search"></i> Filter</button>
         </div>
@@ -51,12 +59,12 @@
         <table class="table table-sm table-hover">
             <thead>
                 <tr>
-                    <th><a asp-action="Attendees" asp-route-sortBy="name" asp-route-sortDesc="@(string.Equals(Model.SortBy, "name", StringComparison.OrdinalIgnoreCase) ? (!Model.SortDesc).ToString() : "false")" asp-route-search="@Model.Search" asp-route-pageSize="@Model.PageSize" asp-route-filterTicketType="@Model.FilterTicketType" asp-route-filterStatus="@Model.FilterStatus" asp-route-filterMatched="@Model.FilterMatched" asp-route-filterOrderId="@Model.FilterOrderId">Name</a></th>
+                    <th><a asp-action="Attendees" asp-route-sortBy="name" asp-route-sortDesc="@(string.Equals(Model.SortBy, "name", StringComparison.OrdinalIgnoreCase) ? (!Model.SortDesc).ToString() : "false")" asp-route-search="@Model.Search" asp-route-pageSize="@Model.PageSize" asp-route-filterTicketType="@Model.FilterTicketType" asp-route-filterStatus="@Model.FilterStatus" asp-route-filterMatched="@Model.FilterMatched" asp-route-filterOrderId="@Model.FilterOrderId" asp-route-filterMultipleTickets="@Model.FilterMultipleTickets">Name</a></th>
                     <th>Email</th>
-                    <th><a asp-action="Attendees" asp-route-sortBy="type" asp-route-sortDesc="@(string.Equals(Model.SortBy, "type", StringComparison.OrdinalIgnoreCase) ? (!Model.SortDesc).ToString() : "false")" asp-route-search="@Model.Search" asp-route-pageSize="@Model.PageSize" asp-route-filterTicketType="@Model.FilterTicketType" asp-route-filterStatus="@Model.FilterStatus" asp-route-filterMatched="@Model.FilterMatched" asp-route-filterOrderId="@Model.FilterOrderId">Ticket Type</a></th>
-                    <th><a asp-action="Attendees" asp-route-sortBy="price" asp-route-sortDesc="@(string.Equals(Model.SortBy, "price", StringComparison.OrdinalIgnoreCase) ? (!Model.SortDesc).ToString() : "true")" asp-route-search="@Model.Search" asp-route-pageSize="@Model.PageSize" asp-route-filterTicketType="@Model.FilterTicketType" asp-route-filterStatus="@Model.FilterStatus" asp-route-filterMatched="@Model.FilterMatched" asp-route-filterOrderId="@Model.FilterOrderId">Price</a></th>
+                    <th><a asp-action="Attendees" asp-route-sortBy="type" asp-route-sortDesc="@(string.Equals(Model.SortBy, "type", StringComparison.OrdinalIgnoreCase) ? (!Model.SortDesc).ToString() : "false")" asp-route-search="@Model.Search" asp-route-pageSize="@Model.PageSize" asp-route-filterTicketType="@Model.FilterTicketType" asp-route-filterStatus="@Model.FilterStatus" asp-route-filterMatched="@Model.FilterMatched" asp-route-filterOrderId="@Model.FilterOrderId" asp-route-filterMultipleTickets="@Model.FilterMultipleTickets">Ticket Type</a></th>
+                    <th><a asp-action="Attendees" asp-route-sortBy="price" asp-route-sortDesc="@(string.Equals(Model.SortBy, "price", StringComparison.OrdinalIgnoreCase) ? (!Model.SortDesc).ToString() : "true")" asp-route-search="@Model.Search" asp-route-pageSize="@Model.PageSize" asp-route-filterTicketType="@Model.FilterTicketType" asp-route-filterStatus="@Model.FilterStatus" asp-route-filterMatched="@Model.FilterMatched" asp-route-filterOrderId="@Model.FilterOrderId" asp-route-filterMultipleTickets="@Model.FilterMultipleTickets">Price</a></th>
                     <th>VIP Split</th>
-                    <th><a asp-action="Attendees" asp-route-sortBy="status" asp-route-sortDesc="@(string.Equals(Model.SortBy, "status", StringComparison.OrdinalIgnoreCase) ? (!Model.SortDesc).ToString() : "false")" asp-route-search="@Model.Search" asp-route-pageSize="@Model.PageSize" asp-route-filterTicketType="@Model.FilterTicketType" asp-route-filterStatus="@Model.FilterStatus" asp-route-filterMatched="@Model.FilterMatched" asp-route-filterOrderId="@Model.FilterOrderId">Status</a></th>
+                    <th><a asp-action="Attendees" asp-route-sortBy="status" asp-route-sortDesc="@(string.Equals(Model.SortBy, "status", StringComparison.OrdinalIgnoreCase) ? (!Model.SortDesc).ToString() : "false")" asp-route-search="@Model.Search" asp-route-pageSize="@Model.PageSize" asp-route-filterTicketType="@Model.FilterTicketType" asp-route-filterStatus="@Model.FilterStatus" asp-route-filterMatched="@Model.FilterMatched" asp-route-filterOrderId="@Model.FilterOrderId" asp-route-filterMultipleTickets="@Model.FilterMultipleTickets">Status</a></th>
                     <th>Matched Human</th>
                     <th>Order</th>
                 </tr>
@@ -123,24 +131,8 @@
         </table>
     </div>
 
-    <!-- Pagination -->
-    @if (Model.TotalPages > 1)
-    {
-        <nav>
-            <ul class="pagination">
-                <li class="page-item @(Model.Page <= 1 ? "disabled" : "")">
-                    <a class="page-link" asp-action="Attendees" asp-route-page="@(Model.Page - 1)" asp-route-search="@Model.Search" asp-route-sortBy="@Model.SortBy" asp-route-sortDesc="@Model.SortDesc" asp-route-pageSize="@Model.PageSize" asp-route-filterTicketType="@Model.FilterTicketType" asp-route-filterStatus="@Model.FilterStatus" asp-route-filterMatched="@Model.FilterMatched" asp-route-filterOrderId="@Model.FilterOrderId">Previous</a>
-                </li>
-                @for (var i = 1; i <= Model.TotalPages; i++)
-                {
-                    <li class="page-item @(i == Model.Page ? "active" : "")">
-                        <a class="page-link" asp-action="Attendees" asp-route-page="@i" asp-route-search="@Model.Search" asp-route-sortBy="@Model.SortBy" asp-route-sortDesc="@Model.SortDesc" asp-route-pageSize="@Model.PageSize" asp-route-filterTicketType="@Model.FilterTicketType" asp-route-filterStatus="@Model.FilterStatus" asp-route-filterMatched="@Model.FilterMatched" asp-route-filterOrderId="@Model.FilterOrderId">@i</a>
-                    </li>
-                }
-                <li class="page-item @(Model.Page >= Model.TotalPages ? "disabled" : "")">
-                    <a class="page-link" asp-action="Attendees" asp-route-page="@(Model.Page + 1)" asp-route-search="@Model.Search" asp-route-sortBy="@Model.SortBy" asp-route-sortDesc="@Model.SortDesc" asp-route-pageSize="@Model.PageSize" asp-route-filterTicketType="@Model.FilterTicketType" asp-route-filterStatus="@Model.FilterStatus" asp-route-filterMatched="@Model.FilterMatched" asp-route-filterOrderId="@Model.FilterOrderId">Next</a>
-                </li>
-            </ul>
-        </nav>
+    @{
+        var pagerModel = new PagerViewModel { TotalPages = Model.TotalPages, CurrentPage = Model.Page, Action = "Attendees" };
     }
+    <partial name="_Pager" model="pagerModel" />
 </div>

--- a/tests/Humans.Application.Tests/Services/ShiftDashboardMetricsTests.cs
+++ b/tests/Humans.Application.Tests/Services/ShiftDashboardMetricsTests.cs
@@ -948,7 +948,7 @@ public class ShiftDashboardMetricsTests : IDisposable
         public Task<List<string>> GetAvailableTicketTypesAsync() => throw new NotSupportedException();
         public Task<Humans.Application.DTOs.CodeTrackingData> GetCodeTrackingDataAsync(string? search) => throw new NotSupportedException();
         public Task<Humans.Application.DTOs.OrdersPageResult> GetOrdersPageAsync(string? search, string sortBy, bool sortDesc, int page, int pageSize, string? filterPaymentStatus, string? filterTicketType, bool? filterMatched) => throw new NotSupportedException();
-        public Task<Humans.Application.DTOs.AttendeesPageResult> GetAttendeesPageAsync(string? search, string sortBy, bool sortDesc, int page, int pageSize, string? filterTicketType, string? filterStatus, bool? filterMatched, string? filterOrderId) => throw new NotSupportedException();
+        public Task<Humans.Application.DTOs.AttendeesPageResult> GetAttendeesPageAsync(string? search, string sortBy, bool sortDesc, int page, int pageSize, string? filterTicketType, string? filterStatus, bool? filterMatched, string? filterOrderId, bool filterMultipleTickets = false) => throw new NotSupportedException();
         public Task<Humans.Application.DTOs.WhoHasntBoughtResult> GetWhoHasntBoughtAsync(string? search, string? filterTeam, string? filterTier, string? filterTicketStatus, int page, int pageSize) => throw new NotSupportedException();
         public Task<List<Humans.Application.DTOs.AttendeeExportRow>> GetAttendeeExportDataAsync() => throw new NotSupportedException();
         public Task<List<Humans.Application.DTOs.OrderExportRow>> GetOrderExportDataAsync() => throw new NotSupportedException();


### PR DESCRIPTION
## Summary

- Replace `/Tickets/Attendees` unbounded for-loop pager with a windowed `_Pager` partial (first, last, current ± 2, ellipsis). Partial is in `Views/Shared/` so other paged tables (`Orders`, `WhoHasntBought`, etc.) can adopt it incrementally.
- Add a **"Buyers with >1 ticket"** filter. Buyer identity = `MatchedUserId` when matched, else lowercased `AttendeeEmail`. Two duplicate-key subqueries ensure matched humans AND unmatched email-only buyers are both surfaced.

Closes nobodies-collective/Humans#593

## Test plan

- [ ] `/Tickets/Attendees` pager fits on one row regardless of total page count
- [ ] First/last buttons are always present; ellipses appear when there are gaps
- [ ] "Buyers with >1 ticket" filter shows matched humans with multiple tickets
- [ ] Same filter also shows unmatched buyers sharing an email address
- [ ] Filter combines correctly with search, ticket type, status, matched, and order filters
- [ ] Sort header links preserve the new filter state
- [ ] `dotnet build Humans.slnx` clean (modulo pre-existing NU1902/NU1904 advisories on DataProtection / OpenTelemetry — unrelated)
- [ ] `dotnet test` ticket suites pass (96/96 locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)