### PR TITLE
Add fill rate bars to shift rows

### DIFF
--- a/src/Humans.Web/Controllers/ShiftsController.cs
+++ b/src/Humans.Web/Controllers/ShiftsController.cs
@@ -44,7 +44,7 @@ public class ShiftsController : HumansControllerBase
     }
 
     [HttpGet("")]
-    public async Task<IActionResult> Index(Guid? departmentId, string? fromDate, string? toDate, string? period, bool showFull = false, [FromQuery(Name = "tags")] List<Guid>? tagIds = null)
+    public async Task<IActionResult> Index(Guid? departmentId, string? fromDate, string? toDate, string? period, bool showFull = false, [FromQuery(Name = "tags")] List<Guid>? tagIds = null, string? sort = null)
     {
         var (currentUserNotFound, user) = await ResolveCurrentUserOrChallengeAsync();
         if (currentUserNotFound is not null)
@@ -104,6 +104,46 @@ public class ShiftsController : HumansControllerBase
         var shiftTeamIds = filteredShifts.Select(u => u.Shift.Rota.TeamId).Distinct().ToList();
         var teamLookup = await _teamService.GetByIdsWithParentsAsync(shiftTeamIds);
 
+        // Map UrgentShift → ShiftDisplayItem (shared by both sort modes)
+        ShiftDisplayItem MapToDisplayItem(UrgentShift u)
+        {
+            var (start, end, shiftPeriod) = _shiftMgmt.ResolveShiftTimes(u.Shift, es);
+            return new ShiftDisplayItem
+            {
+                Shift = u.Shift,
+                AbsoluteStart = start,
+                AbsoluteEnd = end,
+                Period = shiftPeriod,
+                ConfirmedCount = u.ConfirmedCount,
+                RemainingSlots = u.RemainingSlots,
+                UrgencyScore = u.UrgencyScore,
+                Signups = u.Signups
+                    .Select(s => new ShiftSignupInfo(
+                        s.UserId, s.DisplayName, s.Status,
+                        s.HasProfilePicture ? $"/Profile/Picture?id={s.UserId}" : null))
+                    .ToList()
+            };
+        }
+
+        RotaShiftGroup BuildRotaGroup(IGrouping<Guid, UrgentShift> rotaGroup, string? deptName = null, string? deptSlug = null)
+        {
+            var rota = rotaGroup.OrderBy(x => x.Shift.Id).First().Shift.Rota;
+            var shifts = rotaGroup
+                .Select(MapToDisplayItem)
+                .OrderBy(s => s.AbsoluteStart)
+                .ToList();
+            return new RotaShiftGroup
+            {
+                Rota = rota,
+                Shifts = shifts,
+                DepartmentName = deptName,
+                DepartmentSlug = deptSlug,
+                MaxUrgencyScore = shifts.Count > 0 ? shifts.Max(s => s.UrgencyScore) : 0,
+                TotalConfirmed = shifts.Sum(s => s.ConfirmedCount),
+                TotalSlots = shifts.Sum(s => s.Shift.MaxVolunteers)
+            };
+        }
+
         // Group by department → rota → shift
         var departments = filteredShifts
             .GroupBy(u => u.Shift.Rota.TeamId)
@@ -111,48 +151,30 @@ public class ShiftsController : HumansControllerBase
             {
                 var firstShift = deptGroup.OrderBy(x => x.Shift.Id).First().Shift;
                 var team = teamLookup.TryGetValue(firstShift.Rota.TeamId, out var t) ? t : null;
+                var deptName = team?.Name ?? string.Empty;
+                var deptSlug = team?.Slug ?? string.Empty;
                 return new DepartmentShiftGroup
                 {
                     TeamId = firstShift.Rota.TeamId,
-                    TeamName = team?.Name ?? string.Empty,
-                    TeamSlug = team?.Slug ?? string.Empty,
+                    TeamName = deptName,
+                    TeamSlug = deptSlug,
                     Rotas = deptGroup
                         .GroupBy(u => u.Shift.RotaId)
-                        .Select(rotaGroup =>
-                        {
-                            var rota = rotaGroup.OrderBy(x => x.Shift.Id).First().Shift.Rota;
-                            return new RotaShiftGroup
-                            {
-                                Rota = rota,
-                                Shifts = rotaGroup
-                                    .Select(u =>
-                                    {
-                                        var (start, end, shiftPeriod) = _shiftMgmt.ResolveShiftTimes(u.Shift, es);
-                                        return new ShiftDisplayItem
-                                        {
-                                            Shift = u.Shift,
-                                            AbsoluteStart = start,
-                                            AbsoluteEnd = end,
-                                            Period = shiftPeriod,
-                                            ConfirmedCount = u.ConfirmedCount,
-                                            RemainingSlots = u.RemainingSlots,
-                                            Signups = u.Signups
-                                                .Select(s => new ShiftSignupInfo(
-                                                    s.UserId, s.DisplayName, s.Status,
-                                                    s.HasProfilePicture ? $"/Profile/Picture?id={s.UserId}" : null))
-                                                .ToList()
-                                        };
-                                    })
-                                    .OrderBy(s => s.AbsoluteStart)
-                                    .ToList()
-                            };
-                        })
+                        .Select(rg => BuildRotaGroup(rg, deptName, deptSlug))
                         .OrderBy(r => r.Rota.Name, StringComparer.Ordinal)
                         .ToList()
                 };
             })
             .OrderBy(d => d.TeamName, StringComparer.Ordinal)
             .ToList();
+
+        // Build urgency-ranked flat rota list (used when sort=urgency)
+        var isUrgencySort = string.Equals(sort, "urgency", StringComparison.OrdinalIgnoreCase);
+        var urgencyRankedRotas = isUrgencySort
+            ? departments.SelectMany(d => d.Rotas)
+                .OrderByDescending(r => r.MaxUrgencyScore)
+                .ToList()
+            : [];
 
         // Get department list for filter dropdown — if already unfiltered, reuse data
         List<DepartmentOption> allDepartments;
@@ -187,6 +209,8 @@ public class ShiftsController : HumansControllerBase
             Departments = departments,
             AllDepartments = allDepartments,
             ShowSignups = isPrivileged,
+            Sort = isUrgencySort ? "urgency" : null,
+            UrgencyRankedRotas = urgencyRankedRotas,
             AllTags = allTags.ToList(),
             FilterTagIds = activeTagFilter,
             UserPreferredTagIds = userPreferredTags.Select(t => t.Id).ToHashSet()
@@ -247,13 +271,14 @@ public class ShiftsController : HumansControllerBase
         return RedirectToAction(nameof(Index), BuildFilterRouteValues(departmentId, fromDate, toDate, period, tagIds));
     }
 
-    private static RouteValueDictionary BuildFilterRouteValues(Guid? departmentId, string? fromDate, string? toDate, string? period, List<Guid>? tagIds)
+    private static RouteValueDictionary BuildFilterRouteValues(Guid? departmentId, string? fromDate, string? toDate, string? period, List<Guid>? tagIds, string? sort = null)
     {
         var rv = new RouteValueDictionary();
         if (departmentId.HasValue) rv["departmentId"] = departmentId.Value;
         if (!string.IsNullOrEmpty(fromDate)) rv["fromDate"] = fromDate;
         if (!string.IsNullOrEmpty(toDate)) rv["toDate"] = toDate;
         if (!string.IsNullOrEmpty(period)) rv["period"] = period;
+        if (!string.IsNullOrEmpty(sort)) rv["sort"] = sort;
         if (tagIds is { Count: > 0 })
             for (var i = 0; i < tagIds.Count; i++)
                 rv[$"tags[{i}]"] = tagIds[i];

--- a/src/Humans.Web/Models/ShiftViewModels.cs
+++ b/src/Humans.Web/Models/ShiftViewModels.cs
@@ -146,6 +146,16 @@ public class ShiftBrowseViewModel
     public bool ShowSignups { get; set; }
 
     /// <summary>
+    /// Current sort mode: "urgency" for most-needed-first, null/empty for default by-department grouping.
+    /// </summary>
+    public string? Sort { get; set; }
+
+    /// <summary>
+    /// Flat list of rotas sorted by urgency score (populated only when Sort == "urgency").
+    /// </summary>
+    public List<RotaShiftGroup> UrgencyRankedRotas { get; set; } = [];
+
+    /// <summary>
     /// All available tags for the filter UI.
     /// </summary>
     public List<ShiftTag> AllTags { get; set; } = [];
@@ -179,6 +189,21 @@ public class RotaShiftGroup
 {
     public Rota Rota { get; set; } = null!;
     public List<ShiftDisplayItem> Shifts { get; set; } = [];
+
+    /// <summary>Department name, populated for urgency-sorted view where rotas are shown flat.</summary>
+    public string? DepartmentName { get; set; }
+
+    /// <summary>Department slug for linking, populated for urgency-sorted view.</summary>
+    public string? DepartmentSlug { get; set; }
+
+    /// <summary>Highest urgency score among shifts in this rota (for sorting).</summary>
+    public double MaxUrgencyScore { get; set; }
+
+    /// <summary>Total confirmed signups across all shifts in this rota.</summary>
+    public int TotalConfirmed { get; set; }
+
+    /// <summary>Total max volunteer slots across all shifts in this rota.</summary>
+    public int TotalSlots { get; set; }
 }
 
 public record ShiftSignupInfo(Guid UserId, string DisplayName, SignupStatus Status, string? ProfilePictureUrl);
@@ -191,6 +216,7 @@ public class ShiftDisplayItem
     public ShiftPeriod Period { get; set; }
     public int ConfirmedCount { get; set; }
     public int RemainingSlots { get; set; }
+    public double UrgencyScore { get; set; }
     public IReadOnlyList<ShiftSignupInfo> Signups { get; set; } = [];
 }
 

--- a/src/Humans.Web/Resources/SharedResource.ca.resx
+++ b/src/Humans.Web/Resources/SharedResource.ca.resx
@@ -1641,6 +1641,10 @@
   <data name="Shifts_SortUrgencyHint" xml:space="preserve"><value>Els torns que necessiten gent primer</value></data>
   <data name="Shifts_SortDeptHint" xml:space="preserve"><value>Agrupar torns per departament</value></data>
   <data name="Shifts_SlotsFilled" xml:space="preserve"><value>places cobertes</value></data>
+  <data name="Shifts_RotaSingular" xml:space="preserve"><value>torn</value></data>
+  <data name="Shifts_RotaPlural" xml:space="preserve"><value>torns</value></data>
+  <data name="Shifts_ShiftSingular" xml:space="preserve"><value>franja</value></data>
+  <data name="Shifts_ShiftPlural" xml:space="preserve"><value>franges</value></data>
   <data name="Shifts_SignUpButton" xml:space="preserve"><value>Inscriure's</value></data>
   <data name="Shifts_BrowsingClosed" xml:space="preserve"><value>L'exploració de torns encara no està oberta. Torna més tard!</value></data>
   <data name="Shifts_NoActiveEvent" xml:space="preserve"><value>No hi ha cap esdeveniment actiu configurat. Un administrador ha de configurar els ajustos de l'esdeveniment primer.</value></data>

--- a/src/Humans.Web/Resources/SharedResource.ca.resx
+++ b/src/Humans.Web/Resources/SharedResource.ca.resx
@@ -1636,6 +1636,11 @@
   <data name="Shifts_AllPhases" xml:space="preserve"><value>Totes les fases</value></data>
   <data name="Shifts_HiddenBadge" xml:space="preserve"><value>Ocult</value></data>
   <data name="Shifts_MatchesPrefs" xml:space="preserve"><value>Coincideix amb les teves preferències</value></data>
+  <data name="Shifts_SortUrgency" xml:space="preserve"><value>On m&#233;s calen</value></data>
+  <data name="Shifts_SortDept" xml:space="preserve"><value>Per departament</value></data>
+  <data name="Shifts_SortUrgencyHint" xml:space="preserve"><value>Els torns que necessiten gent primer</value></data>
+  <data name="Shifts_SortDeptHint" xml:space="preserve"><value>Agrupar torns per departament</value></data>
+  <data name="Shifts_SlotsFilled" xml:space="preserve"><value>places cobertes</value></data>
   <data name="Shifts_SignUpButton" xml:space="preserve"><value>Inscriure's</value></data>
   <data name="Shifts_BrowsingClosed" xml:space="preserve"><value>L'exploració de torns encara no està oberta. Torna més tard!</value></data>
   <data name="Shifts_NoActiveEvent" xml:space="preserve"><value>No hi ha cap esdeveniment actiu configurat. Un administrador ha de configurar els ajustos de l'esdeveniment primer.</value></data>

--- a/src/Humans.Web/Resources/SharedResource.de.resx
+++ b/src/Humans.Web/Resources/SharedResource.de.resx
@@ -1634,6 +1634,11 @@
   <data name="Shifts_AllPhases" xml:space="preserve"><value>Alle Phasen</value></data>
   <data name="Shifts_HiddenBadge" xml:space="preserve"><value>Versteckt</value></data>
   <data name="Shifts_MatchesPrefs" xml:space="preserve"><value>Passt zu deinen Präferenzen</value></data>
+  <data name="Shifts_SortUrgency" xml:space="preserve"><value>Am dringendsten</value></data>
+  <data name="Shifts_SortDept" xml:space="preserve"><value>Nach Abteilung</value></data>
+  <data name="Shifts_SortUrgencyHint" xml:space="preserve"><value>Schichten, die am meisten Leute brauchen, zuerst</value></data>
+  <data name="Shifts_SortDeptHint" xml:space="preserve"><value>Schichten nach Abteilung gruppieren</value></data>
+  <data name="Shifts_SlotsFilled" xml:space="preserve"><value>Pl&#228;tze besetzt</value></data>
   <data name="Shifts_SignUpButton" xml:space="preserve"><value>Anmelden</value></data>
   <data name="Shifts_BrowsingClosed" xml:space="preserve"><value>Schichten-Übersicht ist noch nicht geöffnet. Schau später wieder!</value></data>
   <data name="Shifts_NoActiveEvent" xml:space="preserve"><value>Kein aktives Event konfiguriert. Ein Admin muss zuerst die Event-Einstellungen einrichten.</value></data>

--- a/src/Humans.Web/Resources/SharedResource.de.resx
+++ b/src/Humans.Web/Resources/SharedResource.de.resx
@@ -1639,6 +1639,10 @@
   <data name="Shifts_SortUrgencyHint" xml:space="preserve"><value>Schichten, die am meisten Leute brauchen, zuerst</value></data>
   <data name="Shifts_SortDeptHint" xml:space="preserve"><value>Schichten nach Abteilung gruppieren</value></data>
   <data name="Shifts_SlotsFilled" xml:space="preserve"><value>Pl&#228;tze besetzt</value></data>
+  <data name="Shifts_RotaSingular" xml:space="preserve"><value>Dienstplan</value></data>
+  <data name="Shifts_RotaPlural" xml:space="preserve"><value>Dienstpl&#228;ne</value></data>
+  <data name="Shifts_ShiftSingular" xml:space="preserve"><value>Schicht</value></data>
+  <data name="Shifts_ShiftPlural" xml:space="preserve"><value>Schichten</value></data>
   <data name="Shifts_SignUpButton" xml:space="preserve"><value>Anmelden</value></data>
   <data name="Shifts_BrowsingClosed" xml:space="preserve"><value>Schichten-Übersicht ist noch nicht geöffnet. Schau später wieder!</value></data>
   <data name="Shifts_NoActiveEvent" xml:space="preserve"><value>Kein aktives Event konfiguriert. Ein Admin muss zuerst die Event-Einstellungen einrichten.</value></data>

--- a/src/Humans.Web/Resources/SharedResource.es.resx
+++ b/src/Humans.Web/Resources/SharedResource.es.resx
@@ -1641,6 +1641,10 @@
   <data name="Shifts_SortUrgencyHint" xml:space="preserve"><value>Los turnos que necesitan gente primero</value></data>
   <data name="Shifts_SortDeptHint" xml:space="preserve"><value>Agrupar turnos por departamento</value></data>
   <data name="Shifts_SlotsFilled" xml:space="preserve"><value>plazas cubiertas</value></data>
+  <data name="Shifts_RotaSingular" xml:space="preserve"><value>turno</value></data>
+  <data name="Shifts_RotaPlural" xml:space="preserve"><value>turnos</value></data>
+  <data name="Shifts_ShiftSingular" xml:space="preserve"><value>franja</value></data>
+  <data name="Shifts_ShiftPlural" xml:space="preserve"><value>franjas</value></data>
   <data name="Shifts_SignUpButton" xml:space="preserve"><value>Inscribirse</value></data>
   <data name="Shifts_BrowsingClosed" xml:space="preserve"><value>La exploración de turnos aún no está abierta. ¡Vuelve más tarde!</value></data>
   <data name="Shifts_NoActiveEvent" xml:space="preserve"><value>No hay ningún evento activo configurado. Un administrador debe configurar los ajustes del evento primero.</value></data>

--- a/src/Humans.Web/Resources/SharedResource.es.resx
+++ b/src/Humans.Web/Resources/SharedResource.es.resx
@@ -1636,6 +1636,11 @@
   <data name="Shifts_AllPhases" xml:space="preserve"><value>Todas las fases</value></data>
   <data name="Shifts_HiddenBadge" xml:space="preserve"><value>Oculto</value></data>
   <data name="Shifts_MatchesPrefs" xml:space="preserve"><value>Coincide con tus preferencias</value></data>
+  <data name="Shifts_SortUrgency" xml:space="preserve"><value>Donde m&#225;s falta hacen</value></data>
+  <data name="Shifts_SortDept" xml:space="preserve"><value>Por departamento</value></data>
+  <data name="Shifts_SortUrgencyHint" xml:space="preserve"><value>Los turnos que necesitan gente primero</value></data>
+  <data name="Shifts_SortDeptHint" xml:space="preserve"><value>Agrupar turnos por departamento</value></data>
+  <data name="Shifts_SlotsFilled" xml:space="preserve"><value>plazas cubiertas</value></data>
   <data name="Shifts_SignUpButton" xml:space="preserve"><value>Inscribirse</value></data>
   <data name="Shifts_BrowsingClosed" xml:space="preserve"><value>La exploración de turnos aún no está abierta. ¡Vuelve más tarde!</value></data>
   <data name="Shifts_NoActiveEvent" xml:space="preserve"><value>No hay ningún evento activo configurado. Un administrador debe configurar los ajustes del evento primero.</value></data>

--- a/src/Humans.Web/Resources/SharedResource.fr.resx
+++ b/src/Humans.Web/Resources/SharedResource.fr.resx
@@ -1634,6 +1634,11 @@
   <data name="Shifts_AllPhases" xml:space="preserve"><value>Toutes les phases</value></data>
   <data name="Shifts_HiddenBadge" xml:space="preserve"><value>Masqué</value></data>
   <data name="Shifts_MatchesPrefs" xml:space="preserve"><value>Correspond à vos préférences</value></data>
+  <data name="Shifts_SortUrgency" xml:space="preserve"><value>Les plus urgents</value></data>
+  <data name="Shifts_SortDept" xml:space="preserve"><value>Par d&#233;partement</value></data>
+  <data name="Shifts_SortUrgencyHint" xml:space="preserve"><value>Les cr&#233;neaux qui ont le plus besoin de monde en premier</value></data>
+  <data name="Shifts_SortDeptHint" xml:space="preserve"><value>Regrouper les cr&#233;neaux par d&#233;partement</value></data>
+  <data name="Shifts_SlotsFilled" xml:space="preserve"><value>places pourvu</value></data>
   <data name="Shifts_SignUpButton" xml:space="preserve"><value>S'inscrire</value></data>
   <data name="Shifts_BrowsingClosed" xml:space="preserve"><value>La navigation des quarts n'est pas encore ouverte. Revenez plus tard !</value></data>
   <data name="Shifts_NoActiveEvent" xml:space="preserve"><value>Aucun événement actif configuré. Un administrateur doit d'abord configurer les paramètres de l'événement.</value></data>

--- a/src/Humans.Web/Resources/SharedResource.fr.resx
+++ b/src/Humans.Web/Resources/SharedResource.fr.resx
@@ -1639,6 +1639,10 @@
   <data name="Shifts_SortUrgencyHint" xml:space="preserve"><value>Les cr&#233;neaux qui ont le plus besoin de monde en premier</value></data>
   <data name="Shifts_SortDeptHint" xml:space="preserve"><value>Regrouper les cr&#233;neaux par d&#233;partement</value></data>
   <data name="Shifts_SlotsFilled" xml:space="preserve"><value>places pourvu</value></data>
+  <data name="Shifts_RotaSingular" xml:space="preserve"><value>roulement</value></data>
+  <data name="Shifts_RotaPlural" xml:space="preserve"><value>roulements</value></data>
+  <data name="Shifts_ShiftSingular" xml:space="preserve"><value>cr&#233;neau</value></data>
+  <data name="Shifts_ShiftPlural" xml:space="preserve"><value>cr&#233;neaux</value></data>
   <data name="Shifts_SignUpButton" xml:space="preserve"><value>S'inscrire</value></data>
   <data name="Shifts_BrowsingClosed" xml:space="preserve"><value>La navigation des quarts n'est pas encore ouverte. Revenez plus tard !</value></data>
   <data name="Shifts_NoActiveEvent" xml:space="preserve"><value>Aucun événement actif configuré. Un administrateur doit d'abord configurer les paramètres de l'événement.</value></data>

--- a/src/Humans.Web/Resources/SharedResource.it.resx
+++ b/src/Humans.Web/Resources/SharedResource.it.resx
@@ -1634,6 +1634,11 @@
   <data name="Shifts_AllPhases" xml:space="preserve"><value>Tutte le fasi</value></data>
   <data name="Shifts_HiddenBadge" xml:space="preserve"><value>Nascosto</value></data>
   <data name="Shifts_MatchesPrefs" xml:space="preserve"><value>Corrisponde alle tue preferenze</value></data>
+  <data name="Shifts_SortUrgency" xml:space="preserve"><value>Pi&#249; urgenti</value></data>
+  <data name="Shifts_SortDept" xml:space="preserve"><value>Per reparto</value></data>
+  <data name="Shifts_SortUrgencyHint" xml:space="preserve"><value>I turni che hanno pi&#249; bisogno di persone per primi</value></data>
+  <data name="Shifts_SortDeptHint" xml:space="preserve"><value>Raggruppa i turni per reparto</value></data>
+  <data name="Shifts_SlotsFilled" xml:space="preserve"><value>posti occupati</value></data>
   <data name="Shifts_SignUpButton" xml:space="preserve"><value>Iscriviti</value></data>
   <data name="Shifts_BrowsingClosed" xml:space="preserve"><value>La consultazione dei turni non è ancora aperta. Torna più tardi!</value></data>
   <data name="Shifts_NoActiveEvent" xml:space="preserve"><value>Nessun evento attivo configurato. Un amministratore deve prima configurare le impostazioni dell'evento.</value></data>

--- a/src/Humans.Web/Resources/SharedResource.it.resx
+++ b/src/Humans.Web/Resources/SharedResource.it.resx
@@ -1639,6 +1639,10 @@
   <data name="Shifts_SortUrgencyHint" xml:space="preserve"><value>I turni che hanno pi&#249; bisogno di persone per primi</value></data>
   <data name="Shifts_SortDeptHint" xml:space="preserve"><value>Raggruppa i turni per reparto</value></data>
   <data name="Shifts_SlotsFilled" xml:space="preserve"><value>posti occupati</value></data>
+  <data name="Shifts_RotaSingular" xml:space="preserve"><value>turno</value></data>
+  <data name="Shifts_RotaPlural" xml:space="preserve"><value>turni</value></data>
+  <data name="Shifts_ShiftSingular" xml:space="preserve"><value>fascia</value></data>
+  <data name="Shifts_ShiftPlural" xml:space="preserve"><value>fasce</value></data>
   <data name="Shifts_SignUpButton" xml:space="preserve"><value>Iscriviti</value></data>
   <data name="Shifts_BrowsingClosed" xml:space="preserve"><value>La consultazione dei turni non è ancora aperta. Torna più tardi!</value></data>
   <data name="Shifts_NoActiveEvent" xml:space="preserve"><value>Nessun evento attivo configurato. Un amministratore deve prima configurare le impostazioni dell'evento.</value></data>

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -1653,6 +1653,11 @@
   <data name="Shifts_AllPhases" xml:space="preserve"><value>All Phases</value></data>
   <data name="Shifts_HiddenBadge" xml:space="preserve"><value>Hidden</value></data>
   <data name="Shifts_MatchesPrefs" xml:space="preserve"><value>Matches your preferences</value></data>
+  <data name="Shifts_SortUrgency" xml:space="preserve"><value>Most needed</value></data>
+  <data name="Shifts_SortDept" xml:space="preserve"><value>By department</value></data>
+  <data name="Shifts_SortUrgencyHint" xml:space="preserve"><value>Show shifts that need people the most, first</value></data>
+  <data name="Shifts_SortDeptHint" xml:space="preserve"><value>Group shifts by department</value></data>
+  <data name="Shifts_SlotsFilled" xml:space="preserve"><value>slots filled</value></data>
   <data name="Shifts_SignUpButton" xml:space="preserve"><value>Sign Up</value></data>
   <data name="Shifts_BrowsingClosed" xml:space="preserve"><value>Shift browsing is not yet open. Check back later!</value></data>
   <data name="Shifts_NoActiveEvent" xml:space="preserve"><value>No active event is configured. An admin needs to set up event settings first.</value></data>

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -1658,6 +1658,10 @@
   <data name="Shifts_SortUrgencyHint" xml:space="preserve"><value>Show shifts that need people the most, first</value></data>
   <data name="Shifts_SortDeptHint" xml:space="preserve"><value>Group shifts by department</value></data>
   <data name="Shifts_SlotsFilled" xml:space="preserve"><value>slots filled</value></data>
+  <data name="Shifts_RotaSingular" xml:space="preserve"><value>rota</value></data>
+  <data name="Shifts_RotaPlural" xml:space="preserve"><value>rotas</value></data>
+  <data name="Shifts_ShiftSingular" xml:space="preserve"><value>shift</value></data>
+  <data name="Shifts_ShiftPlural" xml:space="preserve"><value>shifts</value></data>
   <data name="Shifts_SignUpButton" xml:space="preserve"><value>Sign Up</value></data>
   <data name="Shifts_BrowsingClosed" xml:space="preserve"><value>Shift browsing is not yet open. Check back later!</value></data>
   <data name="Shifts_NoActiveEvent" xml:space="preserve"><value>No active event is configured. An admin needs to set up event settings first.</value></data>

--- a/src/Humans.Web/Views/Shared/_BuildStrikeRotaTable.cshtml
+++ b/src/Humans.Web/Views/Shared/_BuildStrikeRotaTable.cshtml
@@ -86,9 +86,17 @@ else if (allDayShifts.All(s => s.RemainingSlots <= 0) && allDayShifts.Any(s => s
                             @rangeStart.ToDisplayShiftDate()–@rangeEnd.ToDisplayShiftDate()
                             <small class="text-muted">(@range.Count @Localizer["Shifts_Days"])</small>
                         </td>
-                        <td>
-                            <span class="@(anyUnderstaffed ? "text-danger fw-bold" : "")">@totalConfirmed</span>
-                            <small class="text-muted">/ @totalMax @Localizer["Shifts_Total"]</small>
+                        <td style="min-width: 120px;">
+                            @{
+                                var rangeFillPercent = totalMax > 0 ? (int)Math.Round(100.0 * totalConfirmed / totalMax) : 0;
+                                var rangeFillColor = rangeFillPercent >= 80 ? "bg-success" : rangeFillPercent >= 40 ? "bg-warning" : "bg-danger";
+                            }
+                            <div class="d-flex align-items-center gap-2">
+                                <div class="progress flex-grow-1" style="height: 6px;">
+                                    <div class="progress-bar @rangeFillColor" role="progressbar" style="width: @rangeFillPercent%;" aria-valuenow="@totalConfirmed" aria-valuemin="0" aria-valuemax="@totalMax"></div>
+                                </div>
+                                <small class="text-nowrap @(anyUnderstaffed ? "text-danger fw-bold" : "text-muted")">@totalConfirmed/@totalMax</small>
+                            </div>
                         </td>
                         <td>
                             @if (userSignedUpDays == range.Count)
@@ -119,9 +127,17 @@ else if (allDayShifts.All(s => s.RemainingSlots <= 0) && allDayShifts.Any(s => s
                         var understaffed = item.ConfirmedCount < item.Shift.MinVolunteers;
                         <tr class="d-none range-detail-@rangeKey @(isFull ? "table-secondary" : "")">
                             <td class="ps-4">@es.GateOpeningDate.PlusDays(item.Shift.DayOffset).ToDisplayShiftDate()</td>
-                            <td>
-                                <span class="@(understaffed ? "text-danger fw-bold" : "")">@item.ConfirmedCount</span>
-                                <small class="text-muted">/ @item.Shift.MaxVolunteers</small>
+                            <td style="min-width: 120px;">
+                                @{
+                                    var dayFillPercent = item.Shift.MaxVolunteers > 0 ? (int)Math.Round(100.0 * item.ConfirmedCount / item.Shift.MaxVolunteers) : 0;
+                                    var dayFillColor = dayFillPercent >= 80 ? "bg-success" : dayFillPercent >= 40 ? "bg-warning" : "bg-danger";
+                                }
+                                <div class="d-flex align-items-center gap-2">
+                                    <div class="progress flex-grow-1" style="height: 6px;">
+                                        <div class="progress-bar @dayFillColor" role="progressbar" style="width: @dayFillPercent%;" aria-valuenow="@item.ConfirmedCount" aria-valuemin="0" aria-valuemax="@item.Shift.MaxVolunteers"></div>
+                                    </div>
+                                    <small class="text-nowrap @(understaffed ? "text-danger fw-bold" : "text-muted")">@item.ConfirmedCount/@item.Shift.MaxVolunteers</small>
+                                </div>
                             </td>
                             <td>
                                 @if (Model.UserSignupShiftIds.Contains(item.Shift.Id))
@@ -170,9 +186,17 @@ else if (allDayShifts.All(s => s.RemainingSlots <= 0) && allDayShifts.Any(s => s
                     var understaffed = item.ConfirmedCount < item.Shift.MinVolunteers;
                     <tr class="@(isFull ? "table-secondary" : "")">
                         <td>@es.GateOpeningDate.PlusDays(item.Shift.DayOffset).ToDisplayShiftDate()</td>
-                        <td>
-                            <span class="@(understaffed ? "text-danger fw-bold" : "")">@item.ConfirmedCount</span>
-                            <small class="text-muted">/ @item.Shift.MaxVolunteers</small>
+                        <td style="min-width: 120px;">
+                            @{
+                                var singleFillPercent = item.Shift.MaxVolunteers > 0 ? (int)Math.Round(100.0 * item.ConfirmedCount / item.Shift.MaxVolunteers) : 0;
+                                var singleFillColor = singleFillPercent >= 80 ? "bg-success" : singleFillPercent >= 40 ? "bg-warning" : "bg-danger";
+                            }
+                            <div class="d-flex align-items-center gap-2">
+                                <div class="progress flex-grow-1" style="height: 6px;">
+                                    <div class="progress-bar @singleFillColor" role="progressbar" style="width: @singleFillPercent%;" aria-valuenow="@item.ConfirmedCount" aria-valuemin="0" aria-valuemax="@item.Shift.MaxVolunteers"></div>
+                                </div>
+                                <small class="text-nowrap @(understaffed ? "text-danger fw-bold" : "text-muted")">@item.ConfirmedCount/@item.Shift.MaxVolunteers</small>
+                            </div>
                         </td>
                         <td>
                             @if (Model.UserSignupShiftIds.Contains(item.Shift.Id))

--- a/src/Humans.Web/Views/Shared/_EventRotaTable.cshtml
+++ b/src/Humans.Web/Views/Shared/_EventRotaTable.cshtml
@@ -58,13 +58,17 @@
                     <td>@es.GateOpeningDate.PlusDays(shift.DayOffset).ToDisplayShiftDate()</td>
                     <td>@item.AbsoluteStart.ToDisplayTime(tz)</td>
                     <td>@(shift.IsAllDay ? Localizer["Shifts_FullDay"].Value : $"{shift.Duration.TotalHours}h")</td>
-                    <td>
-                        <span class="@(understaffed ? "text-danger fw-bold" : "")">@item.ConfirmedCount</span>
-                        <small class="text-muted">/ @shift.MinVolunteers–@shift.MaxVolunteers</small>
-                        @if (understaffed)
-                        {
-                            <span class="badge bg-warning text-dark">@Localizer["Shifts_NeedsHelp"]</span>
+                    <td style="min-width: 130px;">
+                        @{
+                            var fillPercent = shift.MaxVolunteers > 0 ? (int)Math.Round(100.0 * item.ConfirmedCount / shift.MaxVolunteers) : 0;
+                            var fillColor = fillPercent >= 80 ? "bg-success" : fillPercent >= 40 ? "bg-warning" : "bg-danger";
                         }
+                        <div class="d-flex align-items-center gap-2">
+                            <div class="progress flex-grow-1" style="height: 6px;">
+                                <div class="progress-bar @fillColor" role="progressbar" style="width: @fillPercent%;" aria-valuenow="@item.ConfirmedCount" aria-valuemin="0" aria-valuemax="@shift.MaxVolunteers"></div>
+                            </div>
+                            <small class="text-nowrap @(understaffed ? "text-danger fw-bold" : "text-muted")">@item.ConfirmedCount/@shift.MaxVolunteers</small>
+                        </div>
                     </td>
                     @if (Model.ShowSignups)
                     {

--- a/src/Humans.Web/Views/Shifts/Index.cshtml
+++ b/src/Humans.Web/Views/Shifts/Index.cshtml
@@ -3,6 +3,7 @@
 @{
     ViewData["Title"] = Localizer["Shifts_Title"].Value;
     var es = Model.EventSettings;
+    var isUrgencySort = string.Equals(Model.Sort, "urgency", StringComparison.OrdinalIgnoreCase);
 
     // Compute date picker bounds — tighten to active period's range
     var pickerMin = es.GateOpeningDate.PlusDays(es.BuildStartOffset);
@@ -17,6 +18,21 @@
             _ => (pickerMin, pickerMax)
         };
     }
+
+    // Build sort toggle URLs preserving all current filters
+    var sortBaseRoute = new Dictionary<string, string?>();
+    if (Model.FilterDepartmentId.HasValue)
+        sortBaseRoute["departmentId"] = Model.FilterDepartmentId.Value.ToString();
+    if (!string.IsNullOrEmpty(Model.FilterFromDate))
+        sortBaseRoute["fromDate"] = Model.FilterFromDate;
+    if (!string.IsNullOrEmpty(Model.FilterToDate))
+        sortBaseRoute["toDate"] = Model.FilterToDate;
+    if (!string.IsNullOrEmpty(Model.FilterPeriod))
+        sortBaseRoute["period"] = Model.FilterPeriod;
+    for (var i = 0; i < Model.FilterTagIds.Count; i++)
+        sortBaseRoute[$"tags[{i}]"] = Model.FilterTagIds[i].ToString();
+    var urgencySortRoute = new Dictionary<string, string?>(sortBaseRoute) { ["sort"] = "urgency" };
+    var deptSortRoute = new Dictionary<string, string?>(sortBaseRoute);
 }
 
 <div class="container py-4">
@@ -55,13 +71,14 @@
                    min="@pickerMin.ToString("yyyy-MM-dd", null)"
                    max="@pickerMax.ToString("yyyy-MM-dd", null)" />
         </div>
-        @if (Model.FilterDepartmentId.HasValue || !string.IsNullOrEmpty(Model.FilterFromDate) || !string.IsNullOrEmpty(Model.FilterToDate) || !string.IsNullOrEmpty(Model.FilterPeriod) || Model.FilterTagIds.Count > 0)
+        @if (Model.FilterDepartmentId.HasValue || !string.IsNullOrEmpty(Model.FilterFromDate) || !string.IsNullOrEmpty(Model.FilterToDate) || !string.IsNullOrEmpty(Model.FilterPeriod) || Model.FilterTagIds.Count > 0 || !string.IsNullOrEmpty(Model.Sort))
         {
             <div class="col-auto">
                 <a asp-action="Index" class="btn btn-sm btn-outline-secondary">@Localizer["Shifts_ClearFilters"]</a>
             </div>
         }
         <input type="hidden" name="period" value="@Model.FilterPeriod" />
+        <input type="hidden" name="sort" value="@Model.Sort" />
         @foreach (var tagId in Model.FilterTagIds)
         {
             <input type="hidden" name="tags" value="@tagId" />
@@ -70,15 +87,27 @@
     @{
         var activePeriod = Model.FilterPeriod ?? "";
     }
-    <div class="btn-group mb-3" role="group" aria-label="Period filter">
-        <a href="@Url.Action("Index", new { departmentId = Model.FilterDepartmentId, fromDate = Model.FilterFromDate, toDate = Model.FilterToDate })"
-           class="btn btn-sm @(string.IsNullOrEmpty(activePeriod) ? "btn-primary" : "btn-outline-primary")">@Localizer["Shifts_All"]</a>
-        <a href="@Url.Action("Index", new { departmentId = Model.FilterDepartmentId, period = "Build" })"
-           class="btn btn-sm @(activePeriod == "Build" ? "btn-info" : "btn-outline-info")">@Localizer["Shifts_SetUp"]</a>
-        <a href="@Url.Action("Index", new { departmentId = Model.FilterDepartmentId, period = "Event" })"
-           class="btn btn-sm @(activePeriod == "Event" ? "btn-success" : "btn-outline-success")">@Localizer["Shifts_Event"]</a>
-        <a href="@Url.Action("Index", new { departmentId = Model.FilterDepartmentId, period = "Strike" })"
-           class="btn btn-sm @(activePeriod == "Strike" ? "btn-secondary" : "btn-outline-secondary")">@Localizer["Shifts_Strike"]</a>
+    <div class="d-flex flex-wrap gap-3 mb-3 align-items-center">
+        <div class="btn-group" role="group" aria-label="Period filter">
+            <a href="@Url.Action("Index", new { departmentId = Model.FilterDepartmentId, fromDate = Model.FilterFromDate, toDate = Model.FilterToDate, sort = Model.Sort })"
+               class="btn btn-sm @(string.IsNullOrEmpty(activePeriod) ? "btn-primary" : "btn-outline-primary")">@Localizer["Shifts_All"]</a>
+            <a href="@Url.Action("Index", new { departmentId = Model.FilterDepartmentId, period = "Build", sort = Model.Sort })"
+               class="btn btn-sm @(activePeriod == "Build" ? "btn-info" : "btn-outline-info")">@Localizer["Shifts_SetUp"]</a>
+            <a href="@Url.Action("Index", new { departmentId = Model.FilterDepartmentId, period = "Event", sort = Model.Sort })"
+               class="btn btn-sm @(activePeriod == "Event" ? "btn-success" : "btn-outline-success")">@Localizer["Shifts_Event"]</a>
+            <a href="@Url.Action("Index", new { departmentId = Model.FilterDepartmentId, period = "Strike", sort = Model.Sort })"
+               class="btn btn-sm @(activePeriod == "Strike" ? "btn-secondary" : "btn-outline-secondary")">@Localizer["Shifts_Strike"]</a>
+        </div>
+        <div class="btn-group" role="group" aria-label="Sort order">
+            <a href="@Url.Action("Index", urgencySortRoute)"
+               class="btn btn-sm @(isUrgencySort ? "btn-warning" : "btn-outline-warning")" title="@Localizer["Shifts_SortUrgencyHint"]">
+                <i class="fa-solid fa-fire me-1"></i>@Localizer["Shifts_SortUrgency"]
+            </a>
+            <a href="@Url.Action("Index", deptSortRoute)"
+               class="btn btn-sm @(!isUrgencySort ? "btn-warning" : "btn-outline-warning")" title="@Localizer["Shifts_SortDeptHint"]">
+                <i class="fa-solid fa-building me-1"></i>@Localizer["Shifts_SortDept"]
+            </a>
+        </div>
     </div>
 
     @if (Model.AllTags.Count > 0)
@@ -101,6 +130,8 @@
                         routeValues["toDate"] = Model.FilterToDate;
                     if (!string.IsNullOrEmpty(Model.FilterPeriod))
                         routeValues["period"] = Model.FilterPeriod;
+                    if (!string.IsNullOrEmpty(Model.Sort))
+                        routeValues["sort"] = Model.Sort;
                     for (var i = 0; i < newTagIds.Count; i++)
                         routeValues[$"tags[{i}]"] = newTagIds[i].ToString();
                     @if (isActive)
@@ -175,8 +206,81 @@
     {
         <div class="alert alert-info">@Localizer["Shifts_NoShiftsAvailable"]</div>
     }
+    else if (isUrgencySort)
+    {
+        @* === Urgency-sorted flat view: rotas ranked by most needed === *@
+        @foreach (var rotaGroup in Model.UrgencyRankedRotas)
+        {
+            var rotaMatchesPreference = Model.UserPreferredTagIds.Count > 0
+                && rotaGroup.Rota.Tags.Any(t => Model.UserPreferredTagIds.Contains(t.Id));
+            var fillPercent = rotaGroup.TotalSlots > 0 ? (int)Math.Round(100.0 * rotaGroup.TotalConfirmed / rotaGroup.TotalSlots) : 0;
+            var fillColor = fillPercent >= 80 ? "bg-success" : fillPercent >= 40 ? "bg-warning" : "bg-danger";
+            var hasOpenSlots = rotaGroup.Shifts.Any(s => s.RemainingSlots > 0);
+
+            <div class="card mb-3 @(!hasOpenSlots ? "opacity-75" : "")">
+                <div class="card-body">
+                    <div class="d-flex justify-content-between align-items-start mb-1">
+                        <div>
+                            @await Html.PartialAsync("_RotaHeader", new RotaHeaderViewModel { Rota = rotaGroup.Rota, ShowPreferenceStar = rotaMatchesPreference })
+                            @if (!string.IsNullOrEmpty(rotaGroup.DepartmentName))
+                            {
+                                <small class="text-muted"><i class="fa-solid fa-building me-1"></i>@rotaGroup.DepartmentName</small>
+                            }
+                        </div>
+                        <div class="text-end" style="min-width: 140px;">
+                            <div class="d-flex align-items-center gap-2 mb-1">
+                                <div class="progress flex-grow-1" style="height: 8px;" title="@rotaGroup.TotalConfirmed / @rotaGroup.TotalSlots @Localizer["Shifts_SlotsFilled"]">
+                                    <div class="progress-bar @fillColor" role="progressbar" style="width: @fillPercent%;" aria-valuenow="@rotaGroup.TotalConfirmed" aria-valuemin="0" aria-valuemax="@rotaGroup.TotalSlots"></div>
+                                </div>
+                                <small class="text-muted text-nowrap">@rotaGroup.TotalConfirmed/@rotaGroup.TotalSlots</small>
+                            </div>
+                        </div>
+                    </div>
+
+                    @{
+                        var hasAllDayShifts = rotaGroup.Shifts.Any(s => s.Shift.IsAllDay);
+                        var hasTimedShifts = rotaGroup.Shifts.Any(s => !s.Shift.IsAllDay);
+                        var isBuildStrike = rotaGroup.Rota.Period != RotaPeriod.Event;
+                    }
+                    @if (isBuildStrike || hasAllDayShifts)
+                    {
+                        @await Html.PartialAsync("_BuildStrikeRotaTable", new BuildStrikeRotaTableViewModel
+                        {
+                            RotaGroup = rotaGroup,
+                            EventSettings = es,
+                            UserSignupShiftIds = Model.UserSignupShiftIds,
+                            ShowSignups = Model.ShowSignups,
+                            FilterDepartmentId = Model.FilterDepartmentId,
+                            FilterFromDate = Model.FilterFromDate,
+                            FilterToDate = Model.FilterToDate,
+                            FilterPeriod = Model.FilterPeriod,
+                            FilterTagIds = Model.FilterTagIds
+                        })
+                    }
+                    @if (!isBuildStrike || hasTimedShifts)
+                    {
+                        var timedShifts = isBuildStrike ? rotaGroup.Shifts.Where(s => !s.Shift.IsAllDay).ToList() : rotaGroup.Shifts.ToList();
+                        @await Html.PartialAsync("_EventRotaTable", new EventRotaTableViewModel
+                        {
+                            Shifts = timedShifts,
+                            EventSettings = es,
+                            UserSignupShiftIds = Model.UserSignupShiftIds,
+                            UserSignupStatuses = Model.UserSignupStatuses,
+                            ShowSignups = Model.ShowSignups,
+                            FilterDepartmentId = Model.FilterDepartmentId,
+                            FilterFromDate = Model.FilterFromDate,
+                            FilterToDate = Model.FilterToDate,
+                            FilterPeriod = Model.FilterPeriod,
+                            FilterTagIds = Model.FilterTagIds
+                        })
+                    }
+                </div>
+            </div>
+        }
+    }
     else
     {
+        @* === Default department-grouped view === *@
         @foreach (var dept in Model.Departments)
         {
             <div class="card mb-4">

--- a/src/Humans.Web/Views/Shifts/Index.cshtml
+++ b/src/Humans.Web/Views/Shifts/Index.cshtml
@@ -35,6 +35,14 @@
     var deptSortRoute = new Dictionary<string, string?>(sortBaseRoute);
 }
 
+<style>
+    .disclosure-chevron {
+        transition: transform 0.2s ease;
+    }
+    .disclosure-chevron.rotated {
+        transform: rotate(90deg);
+    }
+</style>
 <div class="container py-4">
     <div class="d-flex justify-content-between align-items-center mb-4">
         <h2>@Localizer["Shifts_BrowseTitle"]</h2>
@@ -216,64 +224,89 @@
             var fillPercent = rotaGroup.TotalSlots > 0 ? (int)Math.Round(100.0 * rotaGroup.TotalConfirmed / rotaGroup.TotalSlots) : 0;
             var fillColor = fillPercent >= 80 ? "bg-success" : fillPercent >= 40 ? "bg-warning" : "bg-danger";
             var hasOpenSlots = rotaGroup.Shifts.Any(s => s.RemainingSlots > 0);
+            var urgRotaId = $"urg-rota-{rotaGroup.Rota.Id:N}";
 
             <div class="card mb-3 @(!hasOpenSlots ? "opacity-75" : "")">
-                <div class="card-body">
-                    <div class="d-flex justify-content-between align-items-start mb-1">
-                        <div>
-                            @await Html.PartialAsync("_RotaHeader", new RotaHeaderViewModel { Rota = rotaGroup.Rota, ShowPreferenceStar = rotaMatchesPreference })
-                            @if (!string.IsNullOrEmpty(rotaGroup.DepartmentName))
-                            {
-                                <small class="text-muted"><i class="fa-solid fa-building me-1"></i>@rotaGroup.DepartmentName</small>
-                            }
-                        </div>
-                        <div class="text-end" style="min-width: 140px;">
-                            <div class="d-flex align-items-center gap-2 mb-1">
-                                <div class="progress flex-grow-1" style="height: 8px;" title="@rotaGroup.TotalConfirmed / @rotaGroup.TotalSlots @Localizer["Shifts_SlotsFilled"]">
-                                    <div class="progress-bar @fillColor" role="progressbar" style="width: @fillPercent%;" aria-valuenow="@rotaGroup.TotalConfirmed" aria-valuemin="0" aria-valuemax="@rotaGroup.TotalSlots"></div>
-                                </div>
-                                <small class="text-muted text-nowrap">@rotaGroup.TotalConfirmed/@rotaGroup.TotalSlots</small>
+                <div class="card-header py-2" role="button" data-bs-toggle="collapse" data-bs-target="#@urgRotaId" aria-expanded="false" aria-controls="@urgRotaId" style="cursor: pointer;">
+                    <div class="d-flex justify-content-between align-items-center">
+                        <div class="d-flex align-items-center gap-2">
+                            <i class="fa-solid fa-chevron-right fa-xs disclosure-chevron"></i>
+                            <div>
+                                <span class="fw-semibold">@rotaGroup.Rota.Name</span>
+                                @if (rotaMatchesPreference)
+                                {
+                                    <i class="fa-solid fa-star text-warning ms-1" title="@Localizer["Shifts_MatchesPrefs"].Value"></i>
+                                }
+                                @if (rotaGroup.Rota.Priority == ShiftPriority.Essential)
+                                {
+                                    <span class="badge bg-danger ms-1">@Localizer["Shifts_Essential"]</span>
+                                }
+                                else if (rotaGroup.Rota.Priority == ShiftPriority.Important)
+                                {
+                                    <span class="badge bg-warning text-dark ms-1">@Localizer["Shifts_Important"]</span>
+                                }
+                                @if (!string.IsNullOrEmpty(rotaGroup.DepartmentName))
+                                {
+                                    <br /><small class="text-muted"><i class="fa-solid fa-building me-1"></i>@rotaGroup.DepartmentName</small>
+                                }
                             </div>
                         </div>
+                        <div class="d-flex align-items-center gap-2" style="min-width: 160px;">
+                            <div class="progress flex-grow-1" style="height: 8px;" title="@rotaGroup.TotalConfirmed / @rotaGroup.TotalSlots @Localizer["Shifts_SlotsFilled"]">
+                                <div class="progress-bar @fillColor" role="progressbar" style="width: @fillPercent%;" aria-valuenow="@rotaGroup.TotalConfirmed" aria-valuemin="0" aria-valuemax="@rotaGroup.TotalSlots"></div>
+                            </div>
+                            <small class="text-muted text-nowrap">@rotaGroup.TotalConfirmed/@rotaGroup.TotalSlots</small>
+                        </div>
                     </div>
-
-                    @{
-                        var hasAllDayShifts = rotaGroup.Shifts.Any(s => s.Shift.IsAllDay);
-                        var hasTimedShifts = rotaGroup.Shifts.Any(s => !s.Shift.IsAllDay);
-                        var isBuildStrike = rotaGroup.Rota.Period != RotaPeriod.Event;
-                    }
-                    @if (isBuildStrike || hasAllDayShifts)
-                    {
-                        @await Html.PartialAsync("_BuildStrikeRotaTable", new BuildStrikeRotaTableViewModel
+                </div>
+                <div class="collapse" id="@urgRotaId">
+                    <div class="card-body pt-2">
+                        @if (!string.IsNullOrEmpty(rotaGroup.Rota.Description))
                         {
-                            RotaGroup = rotaGroup,
-                            EventSettings = es,
-                            UserSignupShiftIds = Model.UserSignupShiftIds,
-                            ShowSignups = Model.ShowSignups,
-                            FilterDepartmentId = Model.FilterDepartmentId,
-                            FilterFromDate = Model.FilterFromDate,
-                            FilterToDate = Model.FilterToDate,
-                            FilterPeriod = Model.FilterPeriod,
-                            FilterTagIds = Model.FilterTagIds
-                        })
-                    }
-                    @if (!isBuildStrike || hasTimedShifts)
-                    {
-                        var timedShifts = isBuildStrike ? rotaGroup.Shifts.Where(s => !s.Shift.IsAllDay).ToList() : rotaGroup.Shifts.ToList();
-                        @await Html.PartialAsync("_EventRotaTable", new EventRotaTableViewModel
+                            <div class="text-muted small mb-2">@Html.SanitizedMarkdown(rotaGroup.Rota.Description)</div>
+                        }
+                        @if (!string.IsNullOrEmpty(rotaGroup.Rota.PracticalInfo))
                         {
-                            Shifts = timedShifts,
-                            EventSettings = es,
-                            UserSignupShiftIds = Model.UserSignupShiftIds,
-                            UserSignupStatuses = Model.UserSignupStatuses,
-                            ShowSignups = Model.ShowSignups,
-                            FilterDepartmentId = Model.FilterDepartmentId,
-                            FilterFromDate = Model.FilterFromDate,
-                            FilterToDate = Model.FilterToDate,
-                            FilterPeriod = Model.FilterPeriod,
-                            FilterTagIds = Model.FilterTagIds
-                        })
-                    }
+                            <div class="text-muted small mb-2"><i class="fa-solid fa-circle-info me-1"></i>@Html.SanitizedMarkdown(rotaGroup.Rota.PracticalInfo)</div>
+                        }
+                        @{
+                            var hasAllDayShifts = rotaGroup.Shifts.Any(s => s.Shift.IsAllDay);
+                            var hasTimedShifts = rotaGroup.Shifts.Any(s => !s.Shift.IsAllDay);
+                            var isBuildStrike = rotaGroup.Rota.Period != RotaPeriod.Event;
+                        }
+                        @if (isBuildStrike || hasAllDayShifts)
+                        {
+                            @await Html.PartialAsync("_BuildStrikeRotaTable", new BuildStrikeRotaTableViewModel
+                            {
+                                RotaGroup = rotaGroup,
+                                EventSettings = es,
+                                UserSignupShiftIds = Model.UserSignupShiftIds,
+                                ShowSignups = Model.ShowSignups,
+                                FilterDepartmentId = Model.FilterDepartmentId,
+                                FilterFromDate = Model.FilterFromDate,
+                                FilterToDate = Model.FilterToDate,
+                                FilterPeriod = Model.FilterPeriod,
+                                FilterTagIds = Model.FilterTagIds
+                            })
+                        }
+                        @if (!isBuildStrike || hasTimedShifts)
+                        {
+                            var timedShifts = isBuildStrike ? rotaGroup.Shifts.Where(s => !s.Shift.IsAllDay).ToList() : rotaGroup.Shifts.ToList();
+                            @await Html.PartialAsync("_EventRotaTable", new EventRotaTableViewModel
+                            {
+                                Shifts = timedShifts,
+                                EventSettings = es,
+                                UserSignupShiftIds = Model.UserSignupShiftIds,
+                                UserSignupStatuses = Model.UserSignupStatuses,
+                                ShowSignups = Model.ShowSignups,
+                                FilterDepartmentId = Model.FilterDepartmentId,
+                                FilterFromDate = Model.FilterFromDate,
+                                FilterToDate = Model.FilterToDate,
+                                FilterPeriod = Model.FilterPeriod,
+                                FilterTagIds = Model.FilterTagIds
+                            })
+                        }
+                    </div>
                 </div>
             </div>
         }
@@ -281,82 +314,158 @@
     else
     {
         @* === Default department-grouped view === *@
+        var singleDept = Model.Departments.Count == 1;
+        var filteredToDept = Model.FilterDepartmentId.HasValue;
         @foreach (var dept in Model.Departments)
         {
-            <div class="card mb-4">
-                <div class="card-header">
-                    <h5 class="mb-0">@dept.TeamName</h5>
-                </div>
-                <div class="card-body">
-                    @{
-                        var rotasByPeriod = dept.Rotas
-                            .GroupBy(r => r.Rota.Period)
-                            .OrderBy(g => g.Key)
-                            .ToList();
-                    }
-                    @foreach (var periodGroup in rotasByPeriod)
-                    {
-                        var periodName = periodGroup.Key == RotaPeriod.Build ? Localizer["Shifts_SetUp"].Value
-                            : periodGroup.Key == RotaPeriod.Strike ? Localizer["Shifts_Strike"].Value
-                            : Localizer["Shifts_Event"].Value;
-                        <h5 class="mt-4 mb-2 border-bottom pb-1">
-                            <span class="badge @(periodGroup.Key == RotaPeriod.Build ? "bg-info" : periodGroup.Key == RotaPeriod.Strike ? "bg-secondary" : "bg-success") me-1">@periodName</span>
-                            @periodName
-                        </h5>
-                        var hasAvailable = periodGroup.Any(r => r.Shifts.Any(s => s.RemainingSlots > 0));
-                        @if (!hasAvailable)
-                        {
-                            <p class="text-muted fst-italic">@string.Format(Localizer["Shifts_AllShiftsFull"].Value, periodName.ToLowerInvariant())</p>
-                        }
-                        @foreach (var rotaGroup in periodGroup)
-                        {
-                            var hasAllDayShifts = rotaGroup.Shifts.Any(s => s.Shift.IsAllDay);
-                            var hasTimedShifts = rotaGroup.Shifts.Any(s => !s.Shift.IsAllDay);
-                            var isBuildStrike = rotaGroup.Rota.Period != RotaPeriod.Event;
-                            var rotaMatchesPreference = Model.UserPreferredTagIds.Count > 0
-                                && rotaGroup.Rota.Tags.Any(t => Model.UserPreferredTagIds.Contains(t.Id));
-                            @await Html.PartialAsync("_RotaHeader", new RotaHeaderViewModel { Rota = rotaGroup.Rota, ShowPreferenceStar = rotaMatchesPreference })
+            var deptId = $"dept-{dept.TeamId:N}";
+            var deptExpanded = singleDept || filteredToDept;
+            var deptTotalConfirmed = dept.Rotas.Sum(r => r.TotalConfirmed);
+            var deptTotalSlots = dept.Rotas.Sum(r => r.TotalSlots);
+            var deptFillPercent = deptTotalSlots > 0 ? (int)Math.Round(100.0 * deptTotalConfirmed / deptTotalSlots) : 0;
+            var deptFillColor = deptFillPercent >= 80 ? "bg-success" : deptFillPercent >= 40 ? "bg-warning" : "bg-danger";
+            var deptRotaCount = dept.Rotas.Count;
+            var deptShiftCount = dept.Rotas.Sum(r => r.Shifts.Count);
 
-                            @if (isBuildStrike || hasAllDayShifts)
+            <div class="card mb-3">
+                <div class="card-header py-2" role="button" data-bs-toggle="collapse" data-bs-target="#@deptId" aria-expanded="@(deptExpanded ? "true" : "false")" aria-controls="@deptId" style="cursor: pointer;">
+                    <div class="d-flex justify-content-between align-items-center">
+                        <div class="d-flex align-items-center gap-2">
+                            <i class="fa-solid fa-chevron-right fa-xs disclosure-chevron @(deptExpanded ? "rotated" : "")"></i>
+                            <h5 class="mb-0">@dept.TeamName</h5>
+                            <small class="text-muted">@deptRotaCount @(deptRotaCount == 1 ? Localizer["Shifts_RotaSingular"] : Localizer["Shifts_RotaPlural"])</small>
+                        </div>
+                        <div class="d-flex align-items-center gap-2" style="min-width: 160px;">
+                            <div class="progress flex-grow-1" style="height: 8px;" title="@deptTotalConfirmed / @deptTotalSlots @Localizer["Shifts_SlotsFilled"]">
+                                <div class="progress-bar @deptFillColor" role="progressbar" style="width: @deptFillPercent%;" aria-valuenow="@deptTotalConfirmed" aria-valuemin="0" aria-valuemax="@deptTotalSlots"></div>
+                            </div>
+                            <small class="text-muted text-nowrap">@deptTotalConfirmed/@deptTotalSlots</small>
+                        </div>
+                    </div>
+                </div>
+                <div class="collapse @(deptExpanded ? "show" : "")" id="@deptId">
+                    <div class="card-body pt-2">
+                        @{
+                            var rotasByPeriod = dept.Rotas
+                                .GroupBy(r => r.Rota.Period)
+                                .OrderBy(g => g.Key)
+                                .ToList();
+                        }
+                        @foreach (var periodGroup in rotasByPeriod)
+                        {
+                            var periodName = periodGroup.Key == RotaPeriod.Build ? Localizer["Shifts_SetUp"].Value
+                                : periodGroup.Key == RotaPeriod.Strike ? Localizer["Shifts_Strike"].Value
+                                : Localizer["Shifts_Event"].Value;
+                            <h6 class="mt-3 mb-2 text-muted text-uppercase" style="font-size: 0.75rem; letter-spacing: 0.05em;">
+                                <span class="badge @(periodGroup.Key == RotaPeriod.Build ? "bg-info" : periodGroup.Key == RotaPeriod.Strike ? "bg-secondary" : "bg-success") me-1">@periodName</span>
+                            </h6>
+                            @foreach (var rotaGroup in periodGroup)
                             {
-                                @await Html.PartialAsync("_BuildStrikeRotaTable", new BuildStrikeRotaTableViewModel
-                                {
-                                    RotaGroup = rotaGroup,
-                                    EventSettings = es,
-                                    UserSignupShiftIds = Model.UserSignupShiftIds,
-                                    ShowSignups = Model.ShowSignups,
-                                    FilterDepartmentId = Model.FilterDepartmentId,
-                                    FilterFromDate = Model.FilterFromDate,
-                                    FilterToDate = Model.FilterToDate,
-                                    FilterPeriod = Model.FilterPeriod,
-                                    FilterTagIds = Model.FilterTagIds
-                                })
-                            }
-                            @if (!isBuildStrike || hasTimedShifts)
-                            {
-                                var timedShifts = isBuildStrike ? rotaGroup.Shifts.Where(s => !s.Shift.IsAllDay).ToList() : rotaGroup.Shifts.ToList();
-                                @await Html.PartialAsync("_EventRotaTable", new EventRotaTableViewModel
-                                {
-                                    Shifts = timedShifts,
-                                    EventSettings = es,
-                                    UserSignupShiftIds = Model.UserSignupShiftIds,
-                                    UserSignupStatuses = Model.UserSignupStatuses,
-                                    ShowSignups = Model.ShowSignups,
-                                    FilterDepartmentId = Model.FilterDepartmentId,
-                                    FilterFromDate = Model.FilterFromDate,
-                                    FilterToDate = Model.FilterToDate,
-                                    FilterPeriod = Model.FilterPeriod,
-                                    FilterTagIds = Model.FilterTagIds
-                                })
+                                var rotaId = $"rota-{rotaGroup.Rota.Id:N}";
+                                var rotaMatchesPreference = Model.UserPreferredTagIds.Count > 0
+                                    && rotaGroup.Rota.Tags.Any(t => Model.UserPreferredTagIds.Contains(t.Id));
+                                var rotaFillPercent = rotaGroup.TotalSlots > 0 ? (int)Math.Round(100.0 * rotaGroup.TotalConfirmed / rotaGroup.TotalSlots) : 0;
+                                var rotaFillColor = rotaFillPercent >= 80 ? "bg-success" : rotaFillPercent >= 40 ? "bg-warning" : "bg-danger";
+                                var hasOpenSlots = rotaGroup.Shifts.Any(s => s.RemainingSlots > 0);
+
+                                <div class="card mb-2 @(!hasOpenSlots ? "opacity-75" : "")">
+                                    <div class="card-header py-2 bg-transparent" role="button" data-bs-toggle="collapse" data-bs-target="#@rotaId" aria-expanded="false" aria-controls="@rotaId" style="cursor: pointer;">
+                                        <div class="d-flex justify-content-between align-items-center">
+                                            <div class="d-flex align-items-center gap-2">
+                                                <i class="fa-solid fa-chevron-right fa-xs disclosure-chevron"></i>
+                                                <span class="fw-semibold">@rotaGroup.Rota.Name</span>
+                                                @if (rotaMatchesPreference)
+                                                {
+                                                    <i class="fa-solid fa-star text-warning" title="@Localizer["Shifts_MatchesPrefs"].Value"></i>
+                                                }
+                                                @if (rotaGroup.Rota.Priority == ShiftPriority.Essential)
+                                                {
+                                                    <span class="badge bg-danger">@Localizer["Shifts_Essential"]</span>
+                                                }
+                                                else if (rotaGroup.Rota.Priority == ShiftPriority.Important)
+                                                {
+                                                    <span class="badge bg-warning text-dark">@Localizer["Shifts_Important"]</span>
+                                                }
+                                                <small class="text-muted d-none d-md-inline">@rotaGroup.Shifts.Count @(rotaGroup.Shifts.Count == 1 ? Localizer["Shifts_ShiftSingular"] : Localizer["Shifts_ShiftPlural"])</small>
+                                            </div>
+                                            <div class="d-flex align-items-center gap-2" style="min-width: 120px;">
+                                                <div class="progress flex-grow-1" style="height: 6px;" title="@rotaGroup.TotalConfirmed / @rotaGroup.TotalSlots @Localizer["Shifts_SlotsFilled"]">
+                                                    <div class="progress-bar @rotaFillColor" role="progressbar" style="width: @rotaFillPercent%;" aria-valuenow="@rotaGroup.TotalConfirmed" aria-valuemin="0" aria-valuemax="@rotaGroup.TotalSlots"></div>
+                                                </div>
+                                                <small class="text-muted text-nowrap">@rotaGroup.TotalConfirmed/@rotaGroup.TotalSlots</small>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="collapse" id="@rotaId">
+                                        <div class="card-body pt-2">
+                                            @if (!string.IsNullOrEmpty(rotaGroup.Rota.Description))
+                                            {
+                                                <div class="text-muted small mb-2">@Html.SanitizedMarkdown(rotaGroup.Rota.Description)</div>
+                                            }
+                                            @if (!string.IsNullOrEmpty(rotaGroup.Rota.PracticalInfo))
+                                            {
+                                                <div class="text-muted small mb-2"><i class="fa-solid fa-circle-info me-1"></i>@Html.SanitizedMarkdown(rotaGroup.Rota.PracticalInfo)</div>
+                                            }
+                                            @{
+                                                var hasAllDayShifts = rotaGroup.Shifts.Any(s => s.Shift.IsAllDay);
+                                                var hasTimedShifts = rotaGroup.Shifts.Any(s => !s.Shift.IsAllDay);
+                                                var isBuildStrike = rotaGroup.Rota.Period != RotaPeriod.Event;
+                                            }
+                                            @if (isBuildStrike || hasAllDayShifts)
+                                            {
+                                                @await Html.PartialAsync("_BuildStrikeRotaTable", new BuildStrikeRotaTableViewModel
+                                                {
+                                                    RotaGroup = rotaGroup,
+                                                    EventSettings = es,
+                                                    UserSignupShiftIds = Model.UserSignupShiftIds,
+                                                    ShowSignups = Model.ShowSignups,
+                                                    FilterDepartmentId = Model.FilterDepartmentId,
+                                                    FilterFromDate = Model.FilterFromDate,
+                                                    FilterToDate = Model.FilterToDate,
+                                                    FilterPeriod = Model.FilterPeriod,
+                                                    FilterTagIds = Model.FilterTagIds
+                                                })
+                                            }
+                                            @if (!isBuildStrike || hasTimedShifts)
+                                            {
+                                                var timedShifts = isBuildStrike ? rotaGroup.Shifts.Where(s => !s.Shift.IsAllDay).ToList() : rotaGroup.Shifts.ToList();
+                                                @await Html.PartialAsync("_EventRotaTable", new EventRotaTableViewModel
+                                                {
+                                                    Shifts = timedShifts,
+                                                    EventSettings = es,
+                                                    UserSignupShiftIds = Model.UserSignupShiftIds,
+                                                    UserSignupStatuses = Model.UserSignupStatuses,
+                                                    ShowSignups = Model.ShowSignups,
+                                                    FilterDepartmentId = Model.FilterDepartmentId,
+                                                    FilterFromDate = Model.FilterFromDate,
+                                                    FilterToDate = Model.FilterToDate,
+                                                    FilterPeriod = Model.FilterPeriod,
+                                                    FilterTagIds = Model.FilterTagIds
+                                                })
+                                            }
+                                        </div>
+                                    </div>
+                                </div>
                             }
                         }
-                    }
+                    </div>
                 </div>
             </div>
         }
     }
 </div>
 <script>
+    // Rotate disclosure chevrons on Bootstrap collapse show/hide
+    document.querySelectorAll('[data-bs-toggle="collapse"]').forEach(function(trigger) {
+        var targetId = trigger.getAttribute('data-bs-target');
+        var target = document.querySelector(targetId);
+        if (!target) return;
+        var chevron = trigger.querySelector('.disclosure-chevron');
+        if (!chevron) return;
+        target.addEventListener('show.bs.collapse', function() { chevron.classList.add('rotated'); });
+        target.addEventListener('hide.bs.collapse', function() { chevron.classList.remove('rotated'); });
+    });
+
     // Expand/collapse compressed date ranges — must run after table HTML is rendered
     document.querySelectorAll('.shift-range-header').forEach(function(el) {
         el.addEventListener('click', function() {


### PR DESCRIPTION
## Summary
- Replaces plain text fill counts with colored progress bars in shift tables
- Red bar below 40% filled, yellow 40-79%, green 80%+
- Applied to both event shifts and build/strike day rows
- Understaffed counts still highlighted in red

**Depends on:** #337, #339

## Test plan
- [ ] Expand a rota and verify each shift row has a progress bar
- [ ] Check bar color: red for mostly empty, yellow for partial, green for nearly full
- [ ] Verify build/strike date ranges also show bars (both collapsed summary and expanded days)
- [ ] Full shifts should show a full green bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)