### PR TITLE
feat: select multiple points at once with a rectangle in barrio placement

### DIFF
--- a/docs/superpowers/plans/2026-04-26-city-planning-marquee-selection.md
+++ b/docs/superpowers/plans/2026-04-26-city-planning-marquee-selection.md
@@ -1,0 +1,233 @@
+# City Planning Marquee Vertex Selection — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add drag-to-select rectangle selection of polygon vertices in the CityPlanning map editor, complementing the existing Shift+click single-vertex selection.
+
+**Architecture:** A custom MapboxDraw mode (`MarqueeDirectSelectMode`) spreads `direct_select` and overrides four event handlers to intercept drag-on-empty-space, render a dashed rectangle overlay, and update vertex selection on release. The mode is registered at MapboxDraw initialisation time, replacing the built-in `direct_select` key — no other files change.
+
+**Tech Stack:** Vanilla ES module JS, MapboxDraw v1.5.1 custom mode API, MapLibre GL JS v5 (`map.project()`, `map.dragPan`).
+
+---
+
+## File Map
+
+| Action | Path | Responsibility |
+|---|---|---|
+| Create | `src/Humans.Web/wwwroot/js/city-planning/marquee-direct-select.js` | Custom MapboxDraw mode + helpers |
+| Modify | `src/Humans.Web/wwwroot/js/city-planning/main.js` | Import and register the custom mode |
+
+---
+
+### Task 1: Create `marquee-direct-select.js`
+
+**Files:**
+- Create: `src/Humans.Web/wwwroot/js/city-planning/marquee-direct-select.js`
+
+This file has no dependencies beyond the globally available `MapboxDraw`. It exports a single object `MarqueeDirectSelectMode`.
+
+- [ ] **Step 1: Create the file with the complete implementation**
+
+```js
+// src/Humans.Web/wwwroot/js/city-planning/marquee-direct-select.js
+const DirectSelectMode = MapboxDraw.modes.direct_select;
+
+function createMarqueeEl(container) {
+    const el = document.createElement('div');
+    el.style.cssText = 'position:absolute;pointer-events:none;border:2px dashed #ffffff;background:rgba(255,255,255,0.15);box-sizing:border-box;z-index:100;';
+    container.appendChild(el);
+    return el;
+}
+
+function updateMarqueeEl(el, start, cur) {
+    el.style.left   = Math.min(start.x, cur.x) + 'px';
+    el.style.top    = Math.min(start.y, cur.y) + 'px';
+    el.style.width  = Math.abs(cur.x - start.x) + 'px';
+    el.style.height = Math.abs(cur.y - start.y) + 'px';
+}
+
+function selectVerticesInRect(mode, state, rect) {
+    const coords    = state.feature.coordinates[0];
+    const featureId = state.featureId;
+    const newSelected = [];
+
+    // Skip last coord — it's the closing duplicate of the first vertex
+    for (let i = 0; i < coords.length - 1; i++) {
+        const pt = mode.map.project(coords[i]);
+        if (pt.x >= rect.minX && pt.x <= rect.maxX && pt.y >= rect.minY && pt.y <= rect.maxY) {
+            newSelected.push({ feature_id: featureId, coord_path: `0.${i}` });
+        }
+    }
+
+    let combined = state.marqueeShift
+        ? [...state.selectedCoordPaths.map(p => ({ feature_id: featureId, coord_path: p })), ...newSelected]
+        : newSelected;
+
+    // Deduplicate (Shift can produce overlaps)
+    const seen = new Set();
+    combined = combined.filter(c => {
+        if (seen.has(c.coord_path)) return false;
+        seen.add(c.coord_path);
+        return true;
+    });
+
+    mode.setSelectedCoordinates(combined);
+    state.selectedCoordPaths = combined.map(c => c.coord_path);
+}
+
+export const MarqueeDirectSelectMode = {
+    ...DirectSelectMode,
+
+    onMouseDown(state, e) {
+        const meta = e.featureTarget?.properties?.meta;
+        if (meta === 'vertex' || meta === 'midpoint') {
+            return DirectSelectMode.onMouseDown.call(this, state, e);
+        }
+        state.marqueeStart = e.point;   // container-relative pixels
+        state.marqueeShift = e.originalEvent.shiftKey;
+        state.isMarquee    = false;
+        state.marqueeEl    = null;
+        this.map.dragPan.disable();
+    },
+
+    onDrag(state, e) {
+        if (!state.marqueeStart) {
+            return DirectSelectMode.onDrag.call(this, state, e);
+        }
+        const cur = e.point;
+        if (!state.isMarquee &&
+            Math.abs(cur.x - state.marqueeStart.x) < 4 &&
+            Math.abs(cur.y - state.marqueeStart.y) < 4) return;
+
+        state.isMarquee = true;
+        if (!state.marqueeEl) state.marqueeEl = createMarqueeEl(this.map.getContainer());
+        updateMarqueeEl(state.marqueeEl, state.marqueeStart, cur);
+    },
+
+    onMouseUp(state, e) {
+        if (!state.marqueeStart) {
+            return DirectSelectMode.onMouseUp.call(this, state, e);
+        }
+        this.map.dragPan.enable();
+
+        if (state.isMarquee) {
+            const end = e.point;
+            selectVerticesInRect(this, state, {
+                minX: Math.min(state.marqueeStart.x, end.x),
+                maxX: Math.max(state.marqueeStart.x, end.x),
+                minY: Math.min(state.marqueeStart.y, end.y),
+                maxY: Math.max(state.marqueeStart.y, end.y),
+            });
+            if (state.marqueeEl) state.marqueeEl.remove();
+        } else {
+            // Near-zero drag = click: preserve existing click-on-empty behaviour
+            DirectSelectMode.onMouseUp.call(this, state, e);
+        }
+
+        state.marqueeStart = null;
+        state.isMarquee    = false;
+        state.marqueeEl    = null;
+    },
+
+    onStop(state) {
+        // Guard: clean up if user exits edit mode mid-drag
+        this.map.dragPan.enable();
+        if (state.marqueeEl) { state.marqueeEl.remove(); state.marqueeEl = null; }
+        return DirectSelectMode.onStop.call(this, state);
+    },
+};
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/Humans.Web/wwwroot/js/city-planning/marquee-direct-select.js
+git commit -m "feat: add MarqueeDirectSelectMode for rectangle vertex selection (nobodies-collective#523)"
+```
+
+---
+
+### Task 2: Register the custom mode in `main.js`
+
+**Files:**
+- Modify: `src/Humans.Web/wwwroot/js/city-planning/main.js`
+
+Two changes: add the import at the top, add the `modes` option to `new MapboxDraw(...)`.
+
+- [ ] **Step 1: Add the import**
+
+At the top of `main.js`, after the existing imports, add:
+
+```js
+import { MarqueeDirectSelectMode } from './marquee-direct-select.js';
+```
+
+- [ ] **Step 2: Register the mode**
+
+Change the existing `new MapboxDraw(...)` call (currently line 23) from:
+
+```js
+appState.draw = new MapboxDraw({ displayControlsDefault: false, styles: DRAW_STYLES });
+```
+
+to:
+
+```js
+appState.draw = new MapboxDraw({
+    displayControlsDefault: false,
+    styles: DRAW_STYLES,
+    modes: { ...MapboxDraw.modes, direct_select: MarqueeDirectSelectMode },
+});
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/Humans.Web/wwwroot/js/city-planning/main.js
+git commit -m "feat: register MarqueeDirectSelectMode as direct_select (nobodies-collective#523)"
+```
+
+---
+
+### Task 3: Manual smoke test
+
+Start the app and navigate to the CityPlanning map.
+
+```bash
+dotnet run --project src/Humans.Web
+```
+
+Open a browser at `https://localhost:5001/CityPlanning` (or whatever the local port is).
+
+- [ ] **Basic marquee draw:**
+  1. Click an existing polygon to open its popup, click Edit.
+  2. Click and drag on empty map space — a white dashed rectangle should appear while dragging.
+  3. Release — all vertices inside the rectangle should turn highlighted (selected state).
+
+- [ ] **Replace selection (no Shift):**
+  1. Shift+click a vertex to select it.
+  2. Drag a marquee over a different set of vertices.
+  3. Release — only the marquee vertices are selected; the previously selected vertex is deselected.
+
+- [ ] **Additive selection (with Shift):**
+  1. Shift+click one vertex to select it.
+  2. Hold Shift, drag a marquee over other vertices.
+  3. Release — all of the previously selected vertex plus the marquee vertices are selected.
+
+- [ ] **Near-zero drag (click on empty space):**
+  1. Click (don't drag) on empty map space.
+  2. Existing MapboxDraw behaviour should be preserved: vertices deselect and mode returns to simple_select (polygon popup closed).
+
+- [ ] **Mid-drag escape (edit mode exit):**
+  1. Start a marquee drag.
+  2. While still dragging, click the Cancel button.
+  3. The marquee rectangle should disappear cleanly and map panning should work normally after.
+
+- [ ] **Map panning not broken:**
+  1. After any marquee selection, verify the map can still be panned by clicking and dragging normally.
+
+- [ ] **Existing Shift+click still works:**
+  1. Shift+click individual vertices — should still add/remove from selection as before.
+
+- [ ] **Vertex drag still works:**
+  1. Click and drag a vertex — it should still move correctly (marquee should not interfere).

--- a/docs/superpowers/specs/2026-04-26-city-planning-marquee-selection-design.md
+++ b/docs/superpowers/specs/2026-04-26-city-planning-marquee-selection-design.md
@@ -1,0 +1,79 @@
+# City Planning Map — Marquee Vertex Selection
+
+**Date:** 2026-04-26
+**Feature:** Rectangular marquee selection of polygon vertices in the CityPlanning map editor
+
+## Context
+
+The polygon editor in CityPlanning uses MapboxDraw in `direct_select` mode. Users can already select multiple vertices with Shift+click, but this is cumbersome when vertices are dense. This feature adds drag-to-select: holding and dragging on empty map space draws a selection rectangle; releasing selects all vertices inside it.
+
+## Behaviour
+
+- **Trigger:** mousedown on empty map space (no vertex or midpoint under cursor) followed by a drag of more than 4px in either axis.
+- **Visual feedback:** a dashed white rectangle (`border: 2px dashed #ffffff`, `background: rgba(255,255,255,0.15)`) is rendered as a `position:absolute` div inside the map container while dragging.
+- **Selection on release:**
+  - Without Shift: the vertices inside the rectangle become the new selection (replaces any existing selection).
+  - With Shift (held at the moment of mousedown): the vertices inside the rectangle are unioned with the existing selection.
+- **Near-zero drag (< 4px):** treated as a click; existing click-on-empty-space behaviour (deselect all, return to simple_select) is preserved by delegating to the parent mode.
+- **Complements** existing Shift+click single-vertex selection; both methods remain available.
+
+## Architecture
+
+### New file: `wwwroot/js/city-planning/marquee-direct-select.js`
+
+Exports `MarqueeDirectSelectMode`, an object that spreads `MapboxDraw.modes.direct_select` and overrides four handlers:
+
+| Handler | Behaviour |
+|---|---|
+| `onMouseDown` | If target is vertex/midpoint → delegate to parent. Otherwise record `state.marqueeStart = e.point`, `state.marqueeShift = e.originalEvent.shiftKey`, disable `map.dragPan`. |
+| `onDrag` | If no `state.marqueeStart` → delegate to parent (vertex/feature drag). Otherwise update the marquee div once the 4px threshold is crossed; lazily create the div on first threshold crossing. |
+| `onMouseUp` | If no `state.marqueeStart` → delegate to parent. Re-enable `dragPan`. If `state.isMarquee`, compute selection and remove div. If not (click), delegate `onMouseUp` to parent. Clear all marquee state. |
+| `onStop` | Re-enable `dragPan`, remove marquee div if present, delegate to parent. Guards against exiting edit mode mid-drag. |
+
+### Modified file: `wwwroot/js/city-planning/main.js`
+
+Import `MarqueeDirectSelectMode` and register it when initialising MapboxDraw:
+
+```js
+import { MarqueeDirectSelectMode } from './marquee-direct-select.js';
+
+appState.draw = new MapboxDraw({
+    displayControlsDefault: false,
+    styles: DRAW_STYLES,
+    modes: { ...MapboxDraw.modes, direct_select: MarqueeDirectSelectMode },
+});
+```
+
+`edit.js` is unchanged — it already calls `draw.changeMode('direct_select', ...)`.
+
+## Vertex Selection Logic
+
+On mouse-up with a valid marquee rectangle:
+
+1. Build pixel rect: `{ minX, maxX, minY, maxY }` from `state.marqueeStart` and `e.point`.
+2. Iterate `state.feature.coordinates[0]`, skipping the last coordinate (closing duplicate).
+3. For each coordinate at index `i`, project with `map.project([lng, lat])` → `{x, y}`.
+4. If within rect, add `{ feature_id: state.featureId, coord_path: "0.i" }` to `newSelected`.
+5. Apply Shift logic:
+   - Shift: union `state.selectedCoordPaths.map(p => ({ feature_id, coord_path: p }))` with `newSelected`, deduplicated by `coord_path`.
+   - No Shift: use `newSelected` directly.
+6. Call `mode.setSelectedCoordinates(combined)` and set `state.selectedCoordPaths = combined.map(c => c.coord_path)`.
+
+## Marquee Div
+
+```
+position: absolute
+pointer-events: none
+border: 2px dashed #ffffff
+background: rgba(255, 255, 255, 0.15)
+box-sizing: border-box
+z-index: 100
+```
+
+Positioned and sized using container-relative pixel coordinates (`e.point`) on every `onDrag` call. Removed on `onMouseUp` or `onStop`.
+
+## Out of Scope
+
+- Deselection via marquee (drawing a rect to deselect vertices inside it).
+- Support for polygons with holes (inner rings); the editor only handles the outer ring `coordinates[0]`.
+- Any changes to the save/load/history flow.

--- a/src/Humans.Web/Resources/SharedResource.ca.resx
+++ b/src/Humans.Web/Resources/SharedResource.ca.resx
@@ -1470,6 +1470,7 @@
   <data name="CityPlanning_Help_Adjusting_Reposition" xml:space="preserve"><value>Arrossega tota la forma per reposicionar-la</value></data>
   <data name="CityPlanning_Help_Adjusting_AddVertex" xml:space="preserve"><value>Fes clic al punt mig d'un costat (on es mostra la longitud en metres) per afegir una nova cantonada</value></data>
   <data name="CityPlanning_Help_Adjusting_DeleteVertex" xml:space="preserve"><value>Fes clic en un punt per seleccionar-lo (es torna taronja), després prem Delete o Backspace per eliminar-lo</value></data>
+  <data name="CityPlanning_Help_Adjusting_MultiSelect" xml:space="preserve"><value>Mantén Majúscules i fes clic als punts per seleccionar-ne diversos alhora, o fes clic i arrossega en un espai buit per dibuixar un rectangle de selecció</value></data>
   <data name="CityPlanning_Help_Adjusting_Area" xml:space="preserve"><value>La superfície en m² es mostra al centre i s'actualitza en editar</value></data>
   <data name="CityPlanning_Help_SavingTitle" xml:space="preserve"><value>Desar &amp; editar més tard</value></data>
   <data name="CityPlanning_Help_SavingBody" xml:space="preserve"><value>Satisfet? Prem Save. Després, fes clic al teu barrio al mapa per veure la mida, i Edit per tornar al mode d'edició. Cada desat crea una entrada a l'historial — usa el botó History per navegar i restaurar versions anteriors. Sense estrès, no pots trencar res!</value></data>

--- a/src/Humans.Web/Resources/SharedResource.de.resx
+++ b/src/Humans.Web/Resources/SharedResource.de.resx
@@ -1468,6 +1468,7 @@
   <data name="CityPlanning_Help_Adjusting_Reposition" xml:space="preserve"><value>Ziehe die gesamte Form, um sie neu zu positionieren</value></data>
   <data name="CityPlanning_Help_Adjusting_AddVertex" xml:space="preserve"><value>Klicke auf den Mittelpunkt einer Kante (wo die Länge in Metern angezeigt wird), um eine neue Ecke hinzuzufügen</value></data>
   <data name="CityPlanning_Help_Adjusting_DeleteVertex" xml:space="preserve"><value>Klicke auf einen Punkt, um ihn auszuwählen (er wird orange), dann drücke Delete oder Backspace, um ihn zu entfernen</value></data>
+  <data name="CityPlanning_Help_Adjusting_MultiSelect" xml:space="preserve"><value>Halte Shift gedrückt und klicke Punkte an, um mehrere auf einmal auszuwählen, oder klicke und ziehe auf einer leeren Fläche, um ein Auswahlrechteck zu zeichnen</value></data>
   <data name="CityPlanning_Help_Adjusting_Area" xml:space="preserve"><value>Die Fläche in m² wird in der Mitte angezeigt und aktualisiert sich beim Bearbeiten</value></data>
   <data name="CityPlanning_Help_SavingTitle" xml:space="preserve"><value>Speichern &amp; später bearbeiten</value></data>
   <data name="CityPlanning_Help_SavingBody" xml:space="preserve"><value>Zufrieden? Klicke auf Save. Danach klicke auf dein Barrio auf der Karte, um die Größe zu sehen, dann Edit, um in den Bearbeitungsmodus zurückzukehren. Jedes Speichern erstellt einen Verlaufseintrag — nutze die Schaltfläche History, um frühere Versionen zu durchsuchen und wiederherzustellen. Kein Stress, du kannst nichts kaputtmachen!</value></data>

--- a/src/Humans.Web/Resources/SharedResource.es.resx
+++ b/src/Humans.Web/Resources/SharedResource.es.resx
@@ -1470,6 +1470,7 @@
   <data name="CityPlanning_Help_Adjusting_Reposition" xml:space="preserve"><value>Arrastra toda la forma para reposicionarla</value></data>
   <data name="CityPlanning_Help_Adjusting_AddVertex" xml:space="preserve"><value>Haz clic en el punto medio de un borde (donde se muestra la longitud en metros) para añadir una nueva esquina</value></data>
   <data name="CityPlanning_Help_Adjusting_DeleteVertex" xml:space="preserve"><value>Haz clic en un punto para seleccionarlo (se pone naranja), luego pulsa Delete o Backspace para eliminarlo</value></data>
+  <data name="CityPlanning_Help_Adjusting_MultiSelect" xml:space="preserve"><value>Mantén Shift y haz clic en puntos para seleccionar varios a la vez, o haz clic y arrastra en un espacio vacío para dibujar un rectángulo de selección</value></data>
   <data name="CityPlanning_Help_Adjusting_Area" xml:space="preserve"><value>El área en m² se muestra en el centro y se actualiza al editar</value></data>
   <data name="CityPlanning_Help_SavingTitle" xml:space="preserve"><value>Guardar y editar después</value></data>
   <data name="CityPlanning_Help_SavingBody" xml:space="preserve"><value>¿Satisfecho? Dale a Save. Después, haz clic en tu barrio en el mapa para ver su tamaño, luego Edit para volver al modo edición. Cada guardado crea una entrada en el historial — usa el botón History para ver y restaurar versiones anteriores: haz clic en el botón de vista previa para mostrarla y guarda la que quieras restaurar. ¡Sin estrés, no puedes romper nada!</value></data>

--- a/src/Humans.Web/Resources/SharedResource.fr.resx
+++ b/src/Humans.Web/Resources/SharedResource.fr.resx
@@ -1468,6 +1468,7 @@
   <data name="CityPlanning_Help_Adjusting_Reposition" xml:space="preserve"><value>Fais glisser toute la forme pour la repositionner</value></data>
   <data name="CityPlanning_Help_Adjusting_AddVertex" xml:space="preserve"><value>Clique sur le milieu d'un bord (où la longueur en mètres est affichée) pour ajouter un nouveau coin</value></data>
   <data name="CityPlanning_Help_Adjusting_DeleteVertex" xml:space="preserve"><value>Clique sur un point pour le sélectionner (il devient orange), puis appuie sur Delete ou Backspace pour le supprimer</value></data>
+  <data name="CityPlanning_Help_Adjusting_MultiSelect" xml:space="preserve"><value>Maintiens Shift et clique sur des points pour en sélectionner plusieurs à la fois, ou clique et fais glisser dans un espace vide pour dessiner un rectangle de sélection</value></data>
   <data name="CityPlanning_Help_Adjusting_Area" xml:space="preserve"><value>La surface en m² est affichée au centre et se met à jour lors de l'édition</value></data>
   <data name="CityPlanning_Help_SavingTitle" xml:space="preserve"><value>Enregistrer &amp; modifier plus tard</value></data>
   <data name="CityPlanning_Help_SavingBody" xml:space="preserve"><value>Content du résultat ? Clique sur Save. Ensuite, clique sur ton barrio sur la carte pour voir sa surface, puis Edit pour revenir en mode édition. Chaque sauvegarde crée une entrée dans l'historique — utilise le bouton History pour parcourir et restaurer une version précédente. Pas de stress, tu ne peux rien casser !</value></data>

--- a/src/Humans.Web/Resources/SharedResource.it.resx
+++ b/src/Humans.Web/Resources/SharedResource.it.resx
@@ -1468,6 +1468,7 @@
   <data name="CityPlanning_Help_Adjusting_Reposition" xml:space="preserve"><value>Trascina l'intera forma per riposizionarla</value></data>
   <data name="CityPlanning_Help_Adjusting_AddVertex" xml:space="preserve"><value>Clicca sul punto medio di un lato (dove è mostrata la lunghezza in metri) per aggiungere un nuovo angolo</value></data>
   <data name="CityPlanning_Help_Adjusting_DeleteVertex" xml:space="preserve"><value>Clicca su un punto per selezionarlo (diventa arancione), poi premi Delete o Backspace per rimuoverlo</value></data>
+  <data name="CityPlanning_Help_Adjusting_MultiSelect" xml:space="preserve"><value>Tieni premuto Shift e clicca sui punti per selezionarne più di uno, oppure clicca e trascina su uno spazio vuoto per disegnare un rettangolo di selezione</value></data>
   <data name="CityPlanning_Help_Adjusting_Area" xml:space="preserve"><value>La superficie in m² è mostrata al centro e si aggiorna durante la modifica</value></data>
   <data name="CityPlanning_Help_SavingTitle" xml:space="preserve"><value>Salvare &amp; modificare in seguito</value></data>
   <data name="CityPlanning_Help_SavingBody" xml:space="preserve"><value>Soddisfatto? Clicca Save. Poi clicca sul tuo barrio sulla mappa per vederne la dimensione, poi Edit per tornare in modalità modifica. Ogni salvataggio crea una voce nella cronologia — usa il pulsante History per sfogliare e ripristinare versioni precedenti. Nessuno stress, non puoi rompere nulla!</value></data>

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -1487,6 +1487,7 @@
   <data name="CityPlanning_Help_Adjusting_Reposition" xml:space="preserve"><value>Drag the whole shape to reposition it</value></data>
   <data name="CityPlanning_Help_Adjusting_AddVertex" xml:space="preserve"><value>Click the midpoint of an edge (where the length in metres is shown) to add a new corner</value></data>
   <data name="CityPlanning_Help_Adjusting_DeleteVertex" xml:space="preserve"><value>Click a point to select it (it turns orange), then press Delete or Backspace to remove it</value></data>
+  <data name="CityPlanning_Help_Adjusting_MultiSelect" xml:space="preserve"><value>Hold Shift and click points to select multiple at once, or click and drag on empty space to draw a selection rectangle</value></data>
   <data name="CityPlanning_Help_Adjusting_Area" xml:space="preserve"><value>The area in m² is shown in the centre and updates as you edit</value></data>
   <data name="CityPlanning_Help_SavingTitle" xml:space="preserve"><value>Saving &amp; editing later</value></data>
   <data name="CityPlanning_Help_SavingBody" xml:space="preserve"><value>Happy with it? Hit Save. Afterwards, click your barrio on the map to see its size, then Edit to jump back into edit mode. Every save creates a history entry — use the History button to browse and restore any previous version: hit the preview button to show the version, and then save the one you want to restore. No stress, you can't break anything!</value></data>

--- a/src/Humans.Web/Views/CityPlanning/_PlacementHelpModal.cshtml
+++ b/src/Humans.Web/Views/CityPlanning/_PlacementHelpModal.cshtml
@@ -56,6 +56,7 @@
                                     <li>@Localizer["CityPlanning_Help_Adjusting_Reposition"]</li>
                                     <li>@Localizer["CityPlanning_Help_Adjusting_AddVertex"]</li>
                                     <li>@Localizer["CityPlanning_Help_Adjusting_DeleteVertex"]</li>
+                                    <li>@Localizer["CityPlanning_Help_Adjusting_MultiSelect"]</li>
                                     <li>@Localizer["CityPlanning_Help_Adjusting_Area"]</li>
                                 </ul>
                             </div>

--- a/src/Humans.Web/wwwroot/js/city-planning/main.js
+++ b/src/Humans.Web/wwwroot/js/city-planning/main.js
@@ -8,6 +8,7 @@ import {
     setEditingControlsVisible, updateAddMyBarrioVisibility,
 } from './edit.js';
 import { initSignalR } from './signalr.js';
+import { MarqueeDirectSelectMode } from './marquee-direct-select.js';
 
 async function init() {
     appState.map = new maplibregl.Map({
@@ -20,7 +21,11 @@ async function init() {
         bounds: CONFIG.MAP_BOUNDS,
     });
 
-    appState.draw = new MapboxDraw({ displayControlsDefault: false, styles: DRAW_STYLES });
+    appState.draw = new MapboxDraw({
+        displayControlsDefault: false,
+        styles: DRAW_STYLES,
+        modes: { ...MapboxDraw.modes, direct_select: MarqueeDirectSelectMode },
+    });
     appState.map.addControl(appState.draw);
 
     appState.map.on('draw.create', onDrawChange);

--- a/src/Humans.Web/wwwroot/js/city-planning/marquee-direct-select.js
+++ b/src/Humans.Web/wwwroot/js/city-planning/marquee-direct-select.js
@@ -1,0 +1,106 @@
+const DirectSelectMode = MapboxDraw.modes.direct_select;
+
+function createMarqueeEl(container) {
+    const el = document.createElement('div');
+    el.style.cssText = 'position:absolute;pointer-events:none;border:2px dashed #ffffff;background:rgba(255,255,255,0.15);box-sizing:border-box;z-index:100;';
+    container.appendChild(el);
+    return el;
+}
+
+function updateMarqueeEl(el, start, cur) {
+    el.style.left   = Math.min(start.x, cur.x) + 'px';
+    el.style.top    = Math.min(start.y, cur.y) + 'px';
+    el.style.width  = Math.abs(cur.x - start.x) + 'px';
+    el.style.height = Math.abs(cur.y - start.y) + 'px';
+}
+
+function selectVerticesInRect(mode, state, rect) {
+    const coords    = state.feature.coordinates[0];
+    const featureId = state.featureId;
+    const newSelected = [];
+
+    // Skip last coord — it's the closing duplicate of the first vertex
+    for (let i = 0; i < coords.length - 1; i++) {
+        const pt = mode.map.project(coords[i]);
+        if (pt.x >= rect.minX && pt.x <= rect.maxX && pt.y >= rect.minY && pt.y <= rect.maxY) {
+            newSelected.push({ feature_id: featureId, coord_path: `0.${i}` });
+        }
+    }
+
+    let combined = state.marqueeShift
+        ? [...state.selectedCoordPaths.map(p => ({ feature_id: featureId, coord_path: p })), ...newSelected]
+        : newSelected;
+
+    // Deduplicate (Shift can produce overlaps)
+    const seen = new Set();
+    combined = combined.filter(c => {
+        if (seen.has(c.coord_path)) return false;
+        seen.add(c.coord_path);
+        return true;
+    });
+
+    mode.setSelectedCoordinates(combined);
+    state.selectedCoordPaths = combined.map(c => c.coord_path);
+}
+
+export const MarqueeDirectSelectMode = {
+    ...DirectSelectMode,
+
+    onMouseDown(state, e) {
+        const meta = e.featureTarget?.properties?.meta;
+        if (meta === 'vertex' || meta === 'midpoint') {
+            return DirectSelectMode.onMouseDown.call(this, state, e);
+        }
+        state.marqueeStart = e.point;   // container-relative pixels
+        state.marqueeShift = e.originalEvent.shiftKey;
+        state.isMarquee    = false;
+        state.marqueeEl    = null;
+        this.map.dragPan.disable();
+    },
+
+    onDrag(state, e) {
+        if (!state.marqueeStart) {
+            return DirectSelectMode.onDrag.call(this, state, e);
+        }
+        const cur = e.point;
+        if (!state.isMarquee &&
+            Math.abs(cur.x - state.marqueeStart.x) < 4 &&
+            Math.abs(cur.y - state.marqueeStart.y) < 4) return;
+
+        state.isMarquee = true;
+        if (!state.marqueeEl) state.marqueeEl = createMarqueeEl(this.map.getContainer());
+        updateMarqueeEl(state.marqueeEl, state.marqueeStart, cur);
+    },
+
+    onMouseUp(state, e) {
+        if (!state.marqueeStart) {
+            return DirectSelectMode.onMouseUp.call(this, state, e);
+        }
+        this.map.dragPan.enable();
+
+        if (state.isMarquee) {
+            const end = e.point;
+            selectVerticesInRect(this, state, {
+                minX: Math.min(state.marqueeStart.x, end.x),
+                maxX: Math.max(state.marqueeStart.x, end.x),
+                minY: Math.min(state.marqueeStart.y, end.y),
+                maxY: Math.max(state.marqueeStart.y, end.y),
+            });
+            if (state.marqueeEl) state.marqueeEl.remove();
+        } else {
+            // Near-zero drag = click: preserve existing click-on-empty behaviour
+            DirectSelectMode.onMouseUp.call(this, state, e);
+        }
+
+        state.marqueeStart = null;
+        state.isMarquee    = false;
+        state.marqueeEl    = null;
+    },
+
+    onStop(state) {
+        // Guard: clean up if user exits edit mode mid-drag
+        this.map.dragPan.enable();
+        if (state.marqueeEl) { state.marqueeEl.remove(); state.marqueeEl = null; }
+        return DirectSelectMode.onStop.call(this, state);
+    },
+};

--- a/src/Humans.Web/wwwroot/js/city-planning/marquee-direct-select.js
+++ b/src/Humans.Web/wwwroot/js/city-planning/marquee-direct-select.js
@@ -15,6 +15,7 @@ function updateMarqueeEl(el, start, cur) {
 }
 
 function selectVerticesInRect(mode, state, rect) {
+    if (!Array.isArray(state.feature?.coordinates?.[0])) return;
     const coords    = state.feature.coordinates[0];
     const featureId = state.featureId;
     const newSelected = [];
@@ -28,7 +29,7 @@ function selectVerticesInRect(mode, state, rect) {
     }
 
     let combined = state.marqueeShift
-        ? [...state.selectedCoordPaths.map(p => ({ feature_id: featureId, coord_path: p })), ...newSelected]
+        ? [...(state.selectedCoordPaths ?? []).map(p => ({ feature_id: featureId, coord_path: p })), ...newSelected]
         : newSelected;
 
     // Deduplicate (Shift can produce overlaps)
@@ -47,6 +48,7 @@ export const MarqueeDirectSelectMode = {
     ...DirectSelectMode,
 
     onMouseDown(state, e) {
+        if (e.originalEvent.button !== 0) return;
         const meta = e.featureTarget?.properties?.meta;
         if (meta === 'vertex' || meta === 'midpoint') {
             return DirectSelectMode.onMouseDown.call(this, state, e);
@@ -86,7 +88,7 @@ export const MarqueeDirectSelectMode = {
                 minY: Math.min(state.marqueeStart.y, end.y),
                 maxY: Math.max(state.marqueeStart.y, end.y),
             });
-            if (state.marqueeEl) state.marqueeEl.remove();
+            state.marqueeEl?.remove();
         } else {
             // Near-zero drag = click: preserve existing click-on-empty behaviour
             DirectSelectMode.onMouseUp.call(this, state, e);

--- a/src/Humans.Web/wwwroot/js/city-planning/marquee-direct-select.js
+++ b/src/Humans.Web/wwwroot/js/city-planning/marquee-direct-select.js
@@ -15,8 +15,9 @@ function updateMarqueeEl(el, start, cur) {
 }
 
 function selectVerticesInRect(mode, state, rect) {
-    if (!Array.isArray(state.feature?.coordinates?.[0])) return;
-    const coords    = state.feature.coordinates[0];
+    const freshFeature = mode.getFeature(state.featureId);
+    if (!Array.isArray(freshFeature?.coordinates?.[0])) return;
+    const coords    = freshFeature.coordinates[0];
     const featureId = state.featureId;
     const newSelected = [];
 

--- a/src/Humans.Web/wwwroot/js/city-planning/marquee-direct-select.js
+++ b/src/Humans.Web/wwwroot/js/city-planning/marquee-direct-select.js
@@ -50,8 +50,11 @@ export const MarqueeDirectSelectMode = {
 
     onMouseDown(state, e) {
         if (e.originalEvent.button !== 0) return;
+        // Defensive: clear any orphaned marquee element from a drag released outside the map
+        if (state.marqueeEl) { state.marqueeEl.remove(); state.marqueeEl = null; }
         const meta = e.featureTarget?.properties?.meta;
-        if (meta === 'vertex' || meta === 'midpoint') {
+        // Delegate to parent for vertex/midpoint (existing select) and feature (whole-polygon drag)
+        if (meta === 'vertex' || meta === 'midpoint' || meta === 'feature') {
             return DirectSelectMode.onMouseDown.call(this, state, e);
         }
         state.marqueeStart = e.point;   // container-relative pixels
@@ -59,6 +62,19 @@ export const MarqueeDirectSelectMode = {
         state.isMarquee    = false;
         state.marqueeEl    = null;
         this.map.dragPan.disable();
+
+        // MapboxDraw only dispatches mouseup on the canvas. Catch releases outside
+        // the map so dragPan is re-enabled and the marquee element doesn't leak.
+        const map = this.map;
+        const onWindowMouseUp = () => {
+            document.removeEventListener('mouseup', onWindowMouseUp);
+            if (!state.marqueeStart) return; // onMouseUp already ran
+            map.dragPan.enable();
+            if (state.marqueeEl) { state.marqueeEl.remove(); state.marqueeEl = null; }
+            state.marqueeStart = null;
+            state.isMarquee    = false;
+        };
+        document.addEventListener('mouseup', onWindowMouseUp);
     },
 
     onDrag(state, e) {


### PR DESCRIPTION
Now that city planning will be able to import more complex geoJSON polygons for barrios, with a lot of points, it'll become difficult to edit them without a tool to select many points at the same time and drag or delete them.
This PRs implements that: while selecting points, one can draw a rectangle to select a set of points. The Shift key toggles adding to the selection versus replacing it.
<img width="1072" height="977" alt="image" src="https://github.com/user-attachments/assets/d13508f5-8a2c-4107-9c30-4d4c05498455" />


## Summary
- Adds drag-to-select rectangle selection of polygon vertices in the CityPlanning map editor
- White dashed rectangle appears while dragging on empty map space; vertices inside are selected on release
- Shift held at drag start adds to existing selection instead of replacing it

## Implementation
- New `MarqueeDirectSelectMode` in `marquee-direct-select.js` extends MapboxDraw's `direct_select` by overriding `onMouseDown`/`onDrag`/`onMouseUp`/`onStop`
- Registered as the `direct_select` mode at MapboxDraw init time — no other files changed
- Right/middle-click guarded, non-Polygon geometry guarded, feature always refreshed from draw context to pick up newly added midpoint vertices

## Test Plan
- [ ] Drag on empty map space while editing a polygon → white dashed rectangle appears → vertices inside get selected on release
- [ ] No Shift: marquee replaces existing selection
- [ ] Shift held at drag start: marquee adds to existing selection
- [ ] Click (no drag) on empty space → existing deselect behaviour preserved
- [ ] Vertices added via midpoint click are selectable by marquee
- [ ] Map panning works normally after marquee
- [ ] Existing Shift+click and vertex drag unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)