### PR TITLE
feat: map distance measuring tool

### DIFF
--- a/docs/features/38-city-planning.md
+++ b/docs/features/38-city-planning.md
@@ -41,6 +41,7 @@ City Planning gives camps a collaborative, real-time tool to stake out and refin
 - **US-38.11: Admin — Upload/Delete Official Zones** — Read-only named overlay (dark gray, labeled); each Feature requires a `name` property; download/delete supported
 - **US-38.12: Admin — Export All Placements** — Download all polygons as a GeoJSON FeatureCollection
 - **US-38.13: Admin — Add Polygon on Behalf of a Camp** — Place a polygon for any unmapped camp season via admin dropdown
+- **US-38.14: Distance Measuring Tool** — Any authenticated user can toggle a two-point ruler from the top-right card. First click drops a point and starts a live rubber-band line with a distance label that follows the cursor; second click locks the measurement; a third click starts a new one. Distance shows as `NNN m` under 1 km and `N.NN km` at or above. Escape or re-clicking the button exits and clears all measure layers. Entering measure mode while editing exits edit mode first; while measuring, camp polygon clicks are suppressed. Measure layers render above all camp/draw layers.
 
 ## Data Model
 
@@ -95,6 +96,7 @@ The map page is a full-screen MapLibre GL JS map with a vanilla ES module fronte
 | `edit.js` | Edit mode lifecycle, draw event handlers, popup, history offcanvas |
 | `signalr.js` | SignalR connection, cursor broadcast, polygon update handler |
 | `config.js` | Server-rendered config values read from DOM data attributes |
+| `measure.js` | Distance measuring tool — sources/layers, click state machine, rubber-band preview |
 
 **State flow:**
 1. Page loads → `GET /api/city-planning/state` fetches settings + all polygons

--- a/src/Humans.Web/Resources/SharedResource.ca.resx
+++ b/src/Humans.Web/Resources/SharedResource.ca.resx
@@ -1425,7 +1425,7 @@
   <data name="CityPlanning_AddABarrioOption" xml:space="preserve"><value>Afegir un barrio…</value></data>
   <data name="CityPlanning_SaveButton" xml:space="preserve"><value>Desar</value></data>
   <data name="CityPlanning_HistoryButton" xml:space="preserve"><value>Historial</value></data>
-  <data name="CityPlanning_MeasureButton" xml:space="preserve"><value>Measure</value></data>
+  <data name="CityPlanning_MeasureButton" xml:space="preserve"><value>Mesurar</value></data>
   <data name="CityPlanning_AdminLink" xml:space="preserve"><value>Admin</value></data>
   <data name="CityPlanning_GoToPlacementMap" xml:space="preserve"><value>Anar al mapa de col·locació</value></data>
   <data name="CityPlanning_Admin_Title" xml:space="preserve"><value>Admin del Mapa de Barrios</value></data>

--- a/src/Humans.Web/Resources/SharedResource.ca.resx
+++ b/src/Humans.Web/Resources/SharedResource.ca.resx
@@ -1425,6 +1425,7 @@
   <data name="CityPlanning_AddABarrioOption" xml:space="preserve"><value>Afegir un barrio…</value></data>
   <data name="CityPlanning_SaveButton" xml:space="preserve"><value>Desar</value></data>
   <data name="CityPlanning_HistoryButton" xml:space="preserve"><value>Historial</value></data>
+  <data name="CityPlanning_MeasureButton" xml:space="preserve"><value>Measure</value></data>
   <data name="CityPlanning_AdminLink" xml:space="preserve"><value>Admin</value></data>
   <data name="CityPlanning_GoToPlacementMap" xml:space="preserve"><value>Anar al mapa de col·locació</value></data>
   <data name="CityPlanning_Admin_Title" xml:space="preserve"><value>Admin del Mapa de Barrios</value></data>

--- a/src/Humans.Web/Resources/SharedResource.de.resx
+++ b/src/Humans.Web/Resources/SharedResource.de.resx
@@ -1423,6 +1423,7 @@
   <data name="CityPlanning_AddABarrioOption" xml:space="preserve"><value>Barrio hinzufügen…</value></data>
   <data name="CityPlanning_SaveButton" xml:space="preserve"><value>Speichern</value></data>
   <data name="CityPlanning_HistoryButton" xml:space="preserve"><value>Verlauf</value></data>
+  <data name="CityPlanning_MeasureButton" xml:space="preserve"><value>Measure</value></data>
   <data name="CityPlanning_AdminLink" xml:space="preserve"><value>Admin</value></data>
   <data name="CityPlanning_GoToPlacementMap" xml:space="preserve"><value>Zur Platzierungskarte</value></data>
   <data name="CityPlanning_Admin_Title" xml:space="preserve"><value>Barrio-Karte Admin</value></data>

--- a/src/Humans.Web/Resources/SharedResource.de.resx
+++ b/src/Humans.Web/Resources/SharedResource.de.resx
@@ -1423,7 +1423,7 @@
   <data name="CityPlanning_AddABarrioOption" xml:space="preserve"><value>Barrio hinzufügen…</value></data>
   <data name="CityPlanning_SaveButton" xml:space="preserve"><value>Speichern</value></data>
   <data name="CityPlanning_HistoryButton" xml:space="preserve"><value>Verlauf</value></data>
-  <data name="CityPlanning_MeasureButton" xml:space="preserve"><value>Measure</value></data>
+  <data name="CityPlanning_MeasureButton" xml:space="preserve"><value>Messen</value></data>
   <data name="CityPlanning_AdminLink" xml:space="preserve"><value>Admin</value></data>
   <data name="CityPlanning_GoToPlacementMap" xml:space="preserve"><value>Zur Platzierungskarte</value></data>
   <data name="CityPlanning_Admin_Title" xml:space="preserve"><value>Barrio-Karte Admin</value></data>

--- a/src/Humans.Web/Resources/SharedResource.es.resx
+++ b/src/Humans.Web/Resources/SharedResource.es.resx
@@ -1425,6 +1425,7 @@
   <data name="CityPlanning_AddABarrioOption" xml:space="preserve"><value>Añadir un barrio…</value></data>
   <data name="CityPlanning_SaveButton" xml:space="preserve"><value>Guardar</value></data>
   <data name="CityPlanning_HistoryButton" xml:space="preserve"><value>Historial</value></data>
+  <data name="CityPlanning_MeasureButton" xml:space="preserve"><value>Measure</value></data>
   <data name="CityPlanning_AdminLink" xml:space="preserve"><value>Admin</value></data>
   <data name="CityPlanning_GoToPlacementMap" xml:space="preserve"><value>Ir al mapa de colocación</value></data>
   <data name="CityPlanning_Admin_Title" xml:space="preserve"><value>Admin del Mapa de Barrios</value></data>

--- a/src/Humans.Web/Resources/SharedResource.es.resx
+++ b/src/Humans.Web/Resources/SharedResource.es.resx
@@ -1425,7 +1425,7 @@
   <data name="CityPlanning_AddABarrioOption" xml:space="preserve"><value>Añadir un barrio…</value></data>
   <data name="CityPlanning_SaveButton" xml:space="preserve"><value>Guardar</value></data>
   <data name="CityPlanning_HistoryButton" xml:space="preserve"><value>Historial</value></data>
-  <data name="CityPlanning_MeasureButton" xml:space="preserve"><value>Measure</value></data>
+  <data name="CityPlanning_MeasureButton" xml:space="preserve"><value>Medir</value></data>
   <data name="CityPlanning_AdminLink" xml:space="preserve"><value>Admin</value></data>
   <data name="CityPlanning_GoToPlacementMap" xml:space="preserve"><value>Ir al mapa de colocación</value></data>
   <data name="CityPlanning_Admin_Title" xml:space="preserve"><value>Admin del Mapa de Barrios</value></data>

--- a/src/Humans.Web/Resources/SharedResource.fr.resx
+++ b/src/Humans.Web/Resources/SharedResource.fr.resx
@@ -1423,6 +1423,7 @@
   <data name="CityPlanning_AddABarrioOption" xml:space="preserve"><value>Ajouter un barrio…</value></data>
   <data name="CityPlanning_SaveButton" xml:space="preserve"><value>Enregistrer</value></data>
   <data name="CityPlanning_HistoryButton" xml:space="preserve"><value>Historique</value></data>
+  <data name="CityPlanning_MeasureButton" xml:space="preserve"><value>Measure</value></data>
   <data name="CityPlanning_AdminLink" xml:space="preserve"><value>Admin</value></data>
   <data name="CityPlanning_GoToPlacementMap" xml:space="preserve"><value>Aller à la carte de placement</value></data>
   <data name="CityPlanning_Admin_Title" xml:space="preserve"><value>Admin Carte des Barrios</value></data>

--- a/src/Humans.Web/Resources/SharedResource.fr.resx
+++ b/src/Humans.Web/Resources/SharedResource.fr.resx
@@ -1423,7 +1423,7 @@
   <data name="CityPlanning_AddABarrioOption" xml:space="preserve"><value>Ajouter un barrio…</value></data>
   <data name="CityPlanning_SaveButton" xml:space="preserve"><value>Enregistrer</value></data>
   <data name="CityPlanning_HistoryButton" xml:space="preserve"><value>Historique</value></data>
-  <data name="CityPlanning_MeasureButton" xml:space="preserve"><value>Measure</value></data>
+  <data name="CityPlanning_MeasureButton" xml:space="preserve"><value>Mesurer</value></data>
   <data name="CityPlanning_AdminLink" xml:space="preserve"><value>Admin</value></data>
   <data name="CityPlanning_GoToPlacementMap" xml:space="preserve"><value>Aller à la carte de placement</value></data>
   <data name="CityPlanning_Admin_Title" xml:space="preserve"><value>Admin Carte des Barrios</value></data>

--- a/src/Humans.Web/Resources/SharedResource.it.resx
+++ b/src/Humans.Web/Resources/SharedResource.it.resx
@@ -1423,6 +1423,7 @@
   <data name="CityPlanning_AddABarrioOption" xml:space="preserve"><value>Aggiungi un barrio…</value></data>
   <data name="CityPlanning_SaveButton" xml:space="preserve"><value>Salva</value></data>
   <data name="CityPlanning_HistoryButton" xml:space="preserve"><value>Cronologia</value></data>
+  <data name="CityPlanning_MeasureButton" xml:space="preserve"><value>Measure</value></data>
   <data name="CityPlanning_AdminLink" xml:space="preserve"><value>Admin</value></data>
   <data name="CityPlanning_GoToPlacementMap" xml:space="preserve"><value>Vai alla mappa di posizionamento</value></data>
   <data name="CityPlanning_Admin_Title" xml:space="preserve"><value>Admin Mappa Barrios</value></data>

--- a/src/Humans.Web/Resources/SharedResource.it.resx
+++ b/src/Humans.Web/Resources/SharedResource.it.resx
@@ -1423,7 +1423,7 @@
   <data name="CityPlanning_AddABarrioOption" xml:space="preserve"><value>Aggiungi un barrio…</value></data>
   <data name="CityPlanning_SaveButton" xml:space="preserve"><value>Salva</value></data>
   <data name="CityPlanning_HistoryButton" xml:space="preserve"><value>Cronologia</value></data>
-  <data name="CityPlanning_MeasureButton" xml:space="preserve"><value>Measure</value></data>
+  <data name="CityPlanning_MeasureButton" xml:space="preserve"><value>Misurare</value></data>
   <data name="CityPlanning_AdminLink" xml:space="preserve"><value>Admin</value></data>
   <data name="CityPlanning_GoToPlacementMap" xml:space="preserve"><value>Vai alla mappa di posizionamento</value></data>
   <data name="CityPlanning_Admin_Title" xml:space="preserve"><value>Admin Mappa Barrios</value></data>

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -1439,6 +1439,7 @@
   <data name="CityPlanning_AddABarrioOption" xml:space="preserve"><value>Add a barrio…</value></data>
   <data name="CityPlanning_SaveButton" xml:space="preserve"><value>Save</value></data>
   <data name="CityPlanning_HistoryButton" xml:space="preserve"><value>History</value></data>
+  <data name="CityPlanning_MeasureButton" xml:space="preserve"><value>Measure</value></data>
   <data name="CityPlanning_AdminLink" xml:space="preserve"><value>Admin</value></data>
   <data name="CityPlanning_GoToPlacementMap" xml:space="preserve"><value>Go to placement map</value></data>
   <data name="CityPlanning_PlacementPhaseInfo" xml:space="preserve"><value>Placement phase info</value></data>

--- a/src/Humans.Web/Views/CityPlanning/Index.cshtml
+++ b/src/Humans.Web/Views/CityPlanning/Index.cshtml
@@ -66,17 +66,21 @@
     }
 
     <!-- Top-right controls -->
-    <div class="position-absolute top-0 end-0 m-3 d-flex flex-row gap-2">
-        <button id="measure-btn" class="btn btn-outline-secondary btn-sm shadow-sm" title="Measure distance">
-            <i class="fa-solid fa-ruler me-1"></i> @Localizer["CityPlanning_MeasureButton"]
-        </button>
-        @if (isMapAdmin)
-        {
-        <a href="/CityPlanning/Admin" class="btn btn-outline-primary btn-sm shadow-sm">
-            <i class="fa fa-cog me-1"></i> @Localizer["CityPlanning_AdminLink"]
-        </a>
-        }
-        <vc:access-matrix section="CityPlanning" />
+    <div class="position-absolute top-0 end-0 m-3">
+        <div class="card shadow-sm">
+            <div class="card-body py-2 px-3 d-flex flex-column gap-1">
+                <button id="measure-btn" class="btn btn-outline-secondary btn-sm" title="Measure distance">
+                    <i class="fa-solid fa-ruler me-1"></i> @Localizer["CityPlanning_MeasureButton"]
+                </button>
+                @if (isMapAdmin)
+                {
+                <a href="/CityPlanning/Admin" class="btn btn-outline-primary btn-sm">
+                    <i class="fa fa-cog me-1"></i> @Localizer["CityPlanning_AdminLink"]
+                </a>
+                }
+                <vc:access-matrix section="CityPlanning" />
+            </div>
+        </div>
     </div>
 
     <!-- Toolbars -->

--- a/src/Humans.Web/Views/CityPlanning/Index.cshtml
+++ b/src/Humans.Web/Views/CityPlanning/Index.cshtml
@@ -65,26 +65,22 @@
     </div>
     }
 
-    <!-- Admin panel link + section help -->
-    <div class="position-absolute top-0 end-0 m-3 d-flex gap-2">
+    <!-- Top-right controls -->
+    <div class="position-absolute top-0 end-0 m-3 d-flex flex-row gap-2">
+        <button id="measure-btn" class="btn btn-outline-secondary btn-sm shadow-sm" title="Measure distance">
+            <i class="fa-solid fa-ruler me-1"></i> @Localizer["CityPlanning_MeasureButton"]
+        </button>
         @if (isMapAdmin)
         {
-            <a href="/CityPlanning/Admin" class="btn btn-outline-primary btn-sm shadow-sm">
-                <i class="fa fa-cog me-1"></i> @Localizer["CityPlanning_AdminLink"]
-            </a>
+        <a href="/CityPlanning/Admin" class="btn btn-outline-primary btn-sm shadow-sm">
+            <i class="fa fa-cog me-1"></i> @Localizer["CityPlanning_AdminLink"]
+        </a>
         }
         <vc:access-matrix section="CityPlanning" />
     </div>
 
     <!-- Toolbars -->
     <div class="position-absolute bottom-0 start-50 translate-middle-x mb-3 d-flex flex-row gap-2">
-        <div class="card">
-            <div class="card-body py-2 px-3">
-                <button id="measure-btn" class="btn btn-outline-secondary btn-sm shadow" title="Measure distance">
-                    <i class="fa-solid fa-ruler me-1"></i> @Localizer["CityPlanning_MeasureButton"]
-                </button>
-            </div>
-        </div>
         @if (isPlacementOpen || isMapAdmin)
         {
         <div id="main-toolbar" class="card" style="@(showMainToolbar ? "" : "display:none")">

--- a/src/Humans.Web/Views/CityPlanning/Index.cshtml
+++ b/src/Humans.Web/Views/CityPlanning/Index.cshtml
@@ -78,6 +78,13 @@
 
     <!-- Toolbars -->
     <div class="position-absolute bottom-0 start-50 translate-middle-x mb-3 d-flex flex-row gap-2">
+        <div class="card">
+            <div class="card-body py-2 px-3">
+                <button id="measure-btn" class="btn btn-outline-secondary btn-sm shadow" title="Measure distance">
+                    <i class="fa-solid fa-ruler me-1"></i> @Localizer["CityPlanning_MeasureButton"]
+                </button>
+            </div>
+        </div>
         @if (isPlacementOpen || isMapAdmin)
         {
         <div id="main-toolbar" class="card" style="@(showMainToolbar ? "" : "display:none")">

--- a/src/Humans.Web/Views/CityPlanning/Index.cshtml
+++ b/src/Humans.Web/Views/CityPlanning/Index.cshtml
@@ -69,7 +69,7 @@
     <div class="position-absolute top-0 end-0 m-3">
         <div class="card shadow-sm">
             <div class="card-body py-2 px-3 d-flex flex-column gap-1">
-                <button id="measure-btn" class="btn btn-outline-secondary btn-sm" title="Measure distance">
+                <button id="measure-btn" class="btn btn-outline-secondary btn-sm" title="@Localizer["CityPlanning_MeasureButton"]" aria-pressed="false">
                     <i class="fa-solid fa-ruler me-1"></i> @Localizer["CityPlanning_MeasureButton"]
                 </button>
                 @if (isMapAdmin)

--- a/src/Humans.Web/wwwroot/js/city-planning/edit.js
+++ b/src/Humans.Web/wwwroot/js/city-planning/edit.js
@@ -29,7 +29,7 @@ function escHtml(s) {
 // --- Popup ---
 
 export function onCampPolygonClick(e) {
-    if (appState.activeCampSeasonId) return;
+    if (appState.activeCampSeasonId || appState.measuringActive) return;
     const props = e.features[0].properties;
     const campSeasonId = props.campSeasonId;
     const isOwn = props.campSeasonId === CONFIG.USER_CAMP_SEASON_ID;

--- a/src/Humans.Web/wwwroot/js/city-planning/layers.js
+++ b/src/Humans.Web/wwwroot/js/city-planning/layers.js
@@ -207,10 +207,10 @@ export function renderMap(onCampPolygonClick) {
 
   map.on('click', 'camp-polygons-fill', onCampPolygonClick);
   map.on('click', 'camp-polygons-fill-surprise', onCampPolygonClick);
-  map.on('mouseenter', 'camp-polygons-fill', () => { map.getCanvas().style.cursor = 'pointer'; });
-  map.on('mouseenter', 'camp-polygons-fill-surprise', () => { map.getCanvas().style.cursor = 'pointer'; });
-  map.on('mouseleave', 'camp-polygons-fill', () => { map.getCanvas().style.cursor = ''; });
-  map.on('mouseleave', 'camp-polygons-fill-surprise', () => { map.getCanvas().style.cursor = ''; });
+  map.on('mouseenter', 'camp-polygons-fill', () => { if (!appState.measuringActive) map.getCanvas().style.cursor = 'pointer'; });
+  map.on('mouseenter', 'camp-polygons-fill-surprise', () => { if (!appState.measuringActive) map.getCanvas().style.cursor = 'pointer'; });
+  map.on('mouseleave', 'camp-polygons-fill', () => { map.getCanvas().style.cursor = appState.measuringActive ? 'crosshair' : ''; });
+  map.on('mouseleave', 'camp-polygons-fill-surprise', () => { map.getCanvas().style.cursor = appState.measuringActive ? 'crosshair' : ''; });
 
   // Bring draw layers and warning overlays above our polygon layers
   map.getStyle().layers

--- a/src/Humans.Web/wwwroot/js/city-planning/layers.js
+++ b/src/Humans.Web/wwwroot/js/city-planning/layers.js
@@ -220,6 +220,10 @@ export function renderMap(onCampPolygonClick) {
   map.moveLayer('draw-warning-error');
   map.moveLayer('draw-edge-labels');
   map.moveLayer('draw-label');
+
+  // Bring measure layers above everything else
+  ['measure-line', 'measure-preview-line', 'measure-label', 'measure-points-stroke', 'measure-points']
+    .forEach(id => { if (map.getLayer(id)) map.moveLayer(id); });
 }
 
 export function setActivePolygonDim(campSeasonId) {

--- a/src/Humans.Web/wwwroot/js/city-planning/main.js
+++ b/src/Humans.Web/wwwroot/js/city-planning/main.js
@@ -9,6 +9,7 @@ import {
 } from './edit.js';
 import { initSignalR } from './signalr.js';
 import { MarqueeDirectSelectMode } from './marquee-direct-select.js';
+import { initMeasure, enterMeasureMode, exitMeasureMode } from './measure.js';
 
 async function init() {
     appState.map = new maplibregl.Map({
@@ -66,6 +67,8 @@ async function init() {
         paint: { 'fill-pattern': 'overlap-stripe-pattern' },
     });
 
+    initMeasure(map);
+
     appState.campMap = await (await fetch('/api/city-planning/state')).json();
     appState.limitZoneGeom = parseLimitZoneGeom(appState.campMap.limitZoneGeoJson);
     renderMap(onCampPolygonClick);
@@ -75,6 +78,10 @@ async function init() {
 
 // Global keydown: Delete/Backspace for vertex deletion when draw doesn't have focus
 document.addEventListener('keydown', e => {
+    if (e.key === 'Escape' && appState.measuringActive) {
+        exitMeasureMode();
+        return;
+    }
     if ((e.key === 'Delete' || e.key === 'Backspace') && appState.activeCampSeasonId) {
         e.preventDefault();
         const poly = appState.draw.getAll().features.find(f => f.geometry.type === 'Polygon');
@@ -128,6 +135,11 @@ document.getElementById('save-btn')?.addEventListener('click', async () => {
 document.getElementById('cancel-btn')?.addEventListener('click', () => {
     if (!confirm('Discard unsaved changes?')) return;
     exitEditMode();
+});
+
+document.getElementById('measure-btn')?.addEventListener('click', () => {
+    if (appState.measuringActive) exitMeasureMode();
+    else enterMeasureMode();
 });
 
 init();

--- a/src/Humans.Web/wwwroot/js/city-planning/measure.js
+++ b/src/Humans.Web/wwwroot/js/city-planning/measure.js
@@ -120,10 +120,14 @@ export function enterMeasureMode() {
     appState.measuringActive = true;
     firstPoint = null;
     secondPoint = null;
+    clearAll();
     appState.map.getCanvas().style.cursor = 'crosshair';
     appState.map.on('click', onMapClick);
 
-    document.getElementById('measure-btn').classList.replace('btn-outline-secondary', 'btn-warning');
+    const btn = document.getElementById('measure-btn');
+    btn.classList.remove('btn-outline-secondary');
+    btn.classList.add('btn-warning');
+    btn.setAttribute('aria-pressed', 'true');
 }
 
 export function exitMeasureMode() {
@@ -138,7 +142,10 @@ export function exitMeasureMode() {
     appState.measuringActive = false;
     appState.map.getCanvas().style.cursor = '';
 
-    document.getElementById('measure-btn').classList.replace('btn-warning', 'btn-outline-secondary');
+    const btn = document.getElementById('measure-btn');
+    btn.classList.remove('btn-warning');
+    btn.classList.add('btn-outline-secondary');
+    btn.setAttribute('aria-pressed', 'false');
 }
 
 export function initMeasure(map) {

--- a/src/Humans.Web/wwwroot/js/city-planning/measure.js
+++ b/src/Humans.Web/wwwroot/js/city-planning/measure.js
@@ -60,6 +60,7 @@ function clearAll() {
 let onMouseMove = null;
 
 function attachMouseMove() {
+    detachMouseMove();
     onMouseMove = e => {
         if (!firstPoint) return;
         const cursor = [e.lngLat.lng, e.lngLat.lat];
@@ -141,6 +142,7 @@ export function exitMeasureMode() {
 }
 
 export function initMeasure(map) {
+    if (typeof turf === 'undefined') throw new Error('measure.js requires turf.js to be loaded globally');
     map.addSource('measure-points',       { type: 'geojson', data: EMPTY_FC });
     map.addSource('measure-line',         { type: 'geojson', data: EMPTY_FC });
     map.addSource('measure-preview-line', { type: 'geojson', data: EMPTY_FC });

--- a/src/Humans.Web/wwwroot/js/city-planning/measure.js
+++ b/src/Humans.Web/wwwroot/js/city-planning/measure.js
@@ -1,0 +1,170 @@
+// Measuring tool: two-point distance with rubber-band preview.
+import { appState } from './state.js';
+import { exitEditMode } from './edit.js';
+
+const EMPTY_FC = { type: 'FeatureCollection', features: [] };
+
+let firstPoint = null;   // [lng, lat] or null
+let secondPoint = null;  // [lng, lat] or null
+
+function formatDistance(meters) {
+    if (meters >= 1000) return (meters / 1000).toFixed(2) + ' km';
+    return Math.round(meters) + ' m';
+}
+
+function midpoint(a, b) {
+    return [(a[0] + b[0]) / 2, (a[1] + b[1]) / 2];
+}
+
+function distanceLabel(a, b) {
+    const meters = turf.distance(turf.point(a), turf.point(b), { units: 'meters' });
+    return formatDistance(meters);
+}
+
+function setPoints(pts) {
+    appState.map.getSource('measure-points').setData({
+        type: 'FeatureCollection',
+        features: pts.map(p => ({ type: 'Feature', geometry: { type: 'Point', coordinates: p }, properties: {} })),
+    });
+}
+
+function setLine(a, b) {
+    appState.map.getSource('measure-line').setData({
+        type: 'FeatureCollection',
+        features: [{ type: 'Feature', geometry: { type: 'LineString', coordinates: [a, b] }, properties: {} }],
+    });
+}
+
+function setPreviewLine(a, b) {
+    appState.map.getSource('measure-preview-line').setData({
+        type: 'FeatureCollection',
+        features: [{ type: 'Feature', geometry: { type: 'LineString', coordinates: [a, b] }, properties: {} }],
+    });
+}
+
+function setLabel(pos, text) {
+    appState.map.getSource('measure-label').setData({
+        type: 'FeatureCollection',
+        features: [{ type: 'Feature', geometry: { type: 'Point', coordinates: pos }, properties: { label: text } }],
+    });
+}
+
+function clearAll() {
+    appState.map.getSource('measure-points').setData(EMPTY_FC);
+    appState.map.getSource('measure-line').setData(EMPTY_FC);
+    appState.map.getSource('measure-preview-line').setData(EMPTY_FC);
+    appState.map.getSource('measure-label').setData(EMPTY_FC);
+}
+
+// mousemove handler reference so we can remove it on exit
+let onMouseMove = null;
+
+function attachMouseMove() {
+    onMouseMove = e => {
+        if (!firstPoint) return;
+        const cursor = [e.lngLat.lng, e.lngLat.lat];
+        setPreviewLine(firstPoint, cursor);
+        const mid = midpoint(firstPoint, cursor);
+        setLabel(mid, distanceLabel(firstPoint, cursor));
+    };
+    appState.map.on('mousemove', onMouseMove);
+}
+
+function detachMouseMove() {
+    if (onMouseMove) {
+        appState.map.off('mousemove', onMouseMove);
+        onMouseMove = null;
+    }
+}
+
+function onMapClick(e) {
+    const coord = [e.lngLat.lng, e.lngLat.lat];
+
+    if (!firstPoint) {
+        // Place first point
+        firstPoint = coord;
+        secondPoint = null;
+        setPoints([firstPoint]);
+        appState.map.getSource('measure-line').setData(EMPTY_FC);
+        appState.map.getSource('measure-label').setData(EMPTY_FC);
+        attachMouseMove();
+        return;
+    }
+
+    if (!secondPoint) {
+        // Place second point — lock in measurement
+        secondPoint = coord;
+        setPoints([firstPoint, secondPoint]);
+        setLine(firstPoint, secondPoint);
+        const mid = midpoint(firstPoint, secondPoint);
+        setLabel(mid, distanceLabel(firstPoint, secondPoint));
+        appState.map.getSource('measure-preview-line').setData(EMPTY_FC);
+        detachMouseMove();
+        return;
+    }
+
+    // Third click: start a new measurement from this point
+    firstPoint = coord;
+    secondPoint = null;
+    setPoints([firstPoint]);
+    appState.map.getSource('measure-line').setData(EMPTY_FC);
+    appState.map.getSource('measure-label').setData(EMPTY_FC);
+    attachMouseMove();
+}
+
+export function enterMeasureMode() {
+    if (appState.measuringActive) return;
+    if (appState.activeCampSeasonId) exitEditMode();
+
+    appState.measuringActive = true;
+    firstPoint = null;
+    secondPoint = null;
+    appState.map.getCanvas().style.cursor = 'crosshair';
+    appState.map.on('click', onMapClick);
+
+    document.getElementById('measure-btn').classList.replace('btn-outline-secondary', 'btn-warning');
+}
+
+export function exitMeasureMode() {
+    if (!appState.measuringActive) return;
+
+    detachMouseMove();
+    appState.map.off('click', onMapClick);
+    clearAll();
+
+    firstPoint = null;
+    secondPoint = null;
+    appState.measuringActive = false;
+    appState.map.getCanvas().style.cursor = '';
+
+    document.getElementById('measure-btn').classList.replace('btn-warning', 'btn-outline-secondary');
+}
+
+export function initMeasure(map) {
+    map.addSource('measure-points',       { type: 'geojson', data: EMPTY_FC });
+    map.addSource('measure-line',         { type: 'geojson', data: EMPTY_FC });
+    map.addSource('measure-preview-line', { type: 'geojson', data: EMPTY_FC });
+    map.addSource('measure-label',        { type: 'geojson', data: EMPTY_FC });
+
+    map.addLayer({
+        id: 'measure-line', type: 'line', source: 'measure-line',
+        paint: { 'line-color': '#ff6600', 'line-width': 2, 'line-dasharray': [2, 2] },
+    });
+    map.addLayer({
+        id: 'measure-preview-line', type: 'line', source: 'measure-preview-line',
+        paint: { 'line-color': '#ff6600', 'line-width': 2, 'line-dasharray': [2, 2], 'line-opacity': 0.5 },
+    });
+    map.addLayer({
+        id: 'measure-label', type: 'symbol', source: 'measure-label',
+        layout: { 'text-field': ['get', 'label'], 'text-size': 13, 'text-anchor': 'center', 'text-allow-overlap': true },
+        paint: { 'text-color': '#000000', 'text-halo-color': '#ffffff', 'text-halo-width': 2 },
+    });
+    map.addLayer({
+        id: 'measure-points-stroke', type: 'circle', source: 'measure-points',
+        paint: { 'circle-radius': 10, 'circle-color': '#fff' },
+    });
+    map.addLayer({
+        id: 'measure-points', type: 'circle', source: 'measure-points',
+        paint: { 'circle-radius': 7, 'circle-color': '#ff6600' },
+    });
+}

--- a/src/Humans.Web/wwwroot/js/city-planning/state.js
+++ b/src/Humans.Web/wwwroot/js/city-planning/state.js
@@ -9,4 +9,5 @@ export const appState = {
     previewCampSeasonId: null,  // non-null while previewing a historical version
     remoteCursors:     {},
     currentPopup:      null,
+    measuringActive:   false,
 };


### PR DESCRIPTION
## Summary

A long-requested feature for the map ^^
<img width="655" height="579" alt="image" src="https://github.com/user-attachments/assets/d0f9c874-e8d1-4245-95ab-d5bacff8f2e8" />

- Adds a two-point rubber-band distance measuring tool to the CityPlanning map, available to all authenticated humans
- New `measure.js` module manages 4 MapLibre sources/layers and a click state machine: first click places a point, moving the mouse shows a live rubber-band line with a distance label, second click locks the measurement, third click starts a new one
- Measure button lives in a card in the top-right corner alongside the Admin link (stacked, with background for legibility)
- Measure layers are always rendered above camp polygons

## Details

- Distance shown as `NNN m` under 1 km, `N.NN km` above
- Escape or clicking the button again exits measure mode and clears all layers
- Entering measure mode while edit mode is active automatically exits edit mode
- Clicking camp polygons is suppressed while measuring
- Measure layers are re-raised to the top on every `renderMap` call (including SignalR-triggered re-renders)
- No backend changes

## Test plan

- [ ] "Measure" button visible in top-right card for all authenticated users (non-admins too)
- [ ] Click Measure → cursor crosshair, button turns orange
- [ ] Click map → orange dot; move mouse → dashed line + live distance label follows cursor
- [ ] Click second point → measurement locks in, preview clears
- [ ] Third click → resets to new first point
- [ ] Escape or button click → exits mode, all layers clear
- [ ] While measuring, clicking a camp polygon does nothing
- [ ] Entering measure mode while editing a polygon exits edit mode first
- [ ] Measure layers render above all camp polygons (including own barrio)

🤖 Generated with [Claude Code](https://claude.com/claude-code)