### PR TITLE
Fix info button accessibility

### DIFF
--- a/src/Humans.Web/wwwroot/css/site.css
+++ b/src/Humans.Web/wwwroot/css/site.css
@@ -461,6 +461,42 @@ h5, .h5 { font-size: 1.1rem; }
     color: var(--h-text-on-dark);
 }
 
+.btn-info {
+    background-color: var(--h-blue-muted);
+    border-color: var(--h-blue-muted);
+    color: var(--h-text-on-dark);
+    border-radius: var(--h-radius);
+    font-weight: 700;
+}
+
+.btn-info:hover {
+    background-color: #4a6977;
+    border-color: #4a6977;
+    color: var(--h-text-on-dark);
+}
+
+.btn-outline-info {
+    border-color: var(--h-blue-muted);
+    color: var(--h-blue-muted);
+    border-radius: var(--h-radius);
+    font-weight: 700;
+    transition: all 0.2s ease;
+}
+
+.btn-outline-info:hover {
+    background-color: var(--h-blue-muted);
+    border-color: var(--h-blue-muted);
+    color: var(--h-text-on-dark);
+}
+
+.btn-outline-info:focus,
+.btn-outline-info.active,
+.btn-outline-info:active {
+    background-color: var(--h-blue-muted);
+    border-color: var(--h-blue-muted);
+    color: var(--h-text-on-dark);
+}
+
 .btn-outline-dark {
     border-color: var(--h-aged-ink);
     color: var(--h-aged-ink);


### PR DESCRIPTION
## Summary
- Override btn-outline-info and btn-info with the muted blue from the design system
- Adds hover, focus, and active states for outline variant
- Fixes all info-colored buttons across the app with one CSS change

## Test plan
- [ ] Check period tabs on /Shifts (Set-up button uses btn-info/btn-outline-info)
- [ ] Check status badges and buttons on admin pages
- [ ] Verify hover state changes to filled blue with white text

🤖 Generated with [Claude Code](https://claude.com/claude-code)