### PR TITLE
UX: Calendar grid availability picker

### DIFF
--- a/src/Humans.Web/Resources/SharedResource.ca.resx
+++ b/src/Humans.Web/Resources/SharedResource.ca.resx
@@ -1698,6 +1698,7 @@
   <data name="Shifts_GeneralAvailability" xml:space="preserve"><value>Disponibilitat general</value></data>
   <data name="Shifts_AvailabilityHelp" xml:space="preserve"><value>Marca els dies que estàs disponible per ajudar. Els coordinadors poden veure qui està disponible en assignar torns.</value></data>
   <data name="Shifts_SaveAvailability" xml:space="preserve"><value>Desar disponibilitat</value></data>
+  <data name="Shifts_DaysSelected" xml:space="preserve"><value>dies seleccionats</value></data>
   <data name="Shifts_SlotsFull" xml:space="preserve"><value>Alguns dies encara necessiten ajuda, però totes les places disponibles estan completes. Torna més tard per si s'obren places.</value></data>
 
   <data name="ShiftDash_Title" xml:space="preserve"><value>Tauler de torns</value></data>

--- a/src/Humans.Web/Resources/SharedResource.de.resx
+++ b/src/Humans.Web/Resources/SharedResource.de.resx
@@ -1696,6 +1696,7 @@
   <data name="Shifts_GeneralAvailability" xml:space="preserve"><value>Allgemeine Verfügbarkeit</value></data>
   <data name="Shifts_AvailabilityHelp" xml:space="preserve"><value>Markiere, an welchen Tagen du helfen kannst. Koordinatoren können sehen, wer verfügbar ist.</value></data>
   <data name="Shifts_SaveAvailability" xml:space="preserve"><value>Verfügbarkeit speichern</value></data>
+  <data name="Shifts_DaysSelected" xml:space="preserve"><value>Tage ausgewählt</value></data>
   <data name="Shifts_SlotsFull" xml:space="preserve"><value>Einige Tage brauchen noch Hilfe, aber alle verfügbaren Plätze sind derzeit belegt. Schau später noch einmal vorbei, falls Plätze frei werden.</value></data>
 
   <data name="ShiftDash_Title" xml:space="preserve"><value>Schicht-Dashboard</value></data>

--- a/src/Humans.Web/Resources/SharedResource.es.resx
+++ b/src/Humans.Web/Resources/SharedResource.es.resx
@@ -1698,6 +1698,7 @@
   <data name="Shifts_GeneralAvailability" xml:space="preserve"><value>Disponibilidad general</value></data>
   <data name="Shifts_AvailabilityHelp" xml:space="preserve"><value>Marca los días que estás disponible para ayudar. Los coordinadores pueden ver quién está disponible al asignar turnos.</value></data>
   <data name="Shifts_SaveAvailability" xml:space="preserve"><value>Guardar disponibilidad</value></data>
+  <data name="Shifts_DaysSelected" xml:space="preserve"><value>días seleccionados</value></data>
   <data name="Shifts_SlotsFull" xml:space="preserve"><value>Algunos días aún necesitan ayuda, pero todos los turnos disponibles están completos. Vuelve más tarde por si se abren plazas.</value></data>
 
   <data name="ShiftDash_Title" xml:space="preserve"><value>Panel de turnos</value></data>

--- a/src/Humans.Web/Resources/SharedResource.fr.resx
+++ b/src/Humans.Web/Resources/SharedResource.fr.resx
@@ -1696,6 +1696,7 @@
   <data name="Shifts_GeneralAvailability" xml:space="preserve"><value>Disponibilité générale</value></data>
   <data name="Shifts_AvailabilityHelp" xml:space="preserve"><value>Indiquez les jours où vous êtes disponible. Les coordinateurs peuvent voir qui est disponible lors de l'attribution des quarts.</value></data>
   <data name="Shifts_SaveAvailability" xml:space="preserve"><value>Enregistrer la disponibilité</value></data>
+  <data name="Shifts_DaysSelected" xml:space="preserve"><value>jours sélectionnés</value></data>
   <data name="Shifts_SlotsFull" xml:space="preserve"><value>Certains jours ont encore besoin d'aide, mais tous les créneaux disponibles sont complets. Reviens plus tard au cas où des places se libèrent.</value></data>
 
   <data name="ShiftDash_Title" xml:space="preserve"><value>Tableau de bord des quarts</value></data>

--- a/src/Humans.Web/Resources/SharedResource.it.resx
+++ b/src/Humans.Web/Resources/SharedResource.it.resx
@@ -1696,6 +1696,7 @@
   <data name="Shifts_GeneralAvailability" xml:space="preserve"><value>Disponibilità generale</value></data>
   <data name="Shifts_AvailabilityHelp" xml:space="preserve"><value>Segna i giorni in cui sei disponibile. I coordinatori possono vedere chi è disponibile quando assegnano i turni.</value></data>
   <data name="Shifts_SaveAvailability" xml:space="preserve"><value>Salva disponibilità</value></data>
+  <data name="Shifts_DaysSelected" xml:space="preserve"><value>giorni selezionati</value></data>
   <data name="Shifts_SlotsFull" xml:space="preserve"><value>Alcuni giorni hanno ancora bisogno di aiuto, ma tutti i posti disponibili sono al completo. Riprova più tardi nel caso si liberino dei posti.</value></data>
 
   <data name="ShiftDash_Title" xml:space="preserve"><value>Dashboard turni</value></data>

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -1716,6 +1716,7 @@
   <data name="Shifts_GeneralAvailability" xml:space="preserve"><value>General Availability</value></data>
   <data name="Shifts_AvailabilityHelp" xml:space="preserve"><value>Mark which days you're available to help. Coordinators can see who's in the pool when assigning shifts.</value></data>
   <data name="Shifts_SaveAvailability" xml:space="preserve"><value>Save Availability</value></data>
+  <data name="Shifts_DaysSelected" xml:space="preserve"><value>days selected</value></data>
   <data name="Shifts_SlotsFull" xml:space="preserve"><value>Some days still need help but all available slots are currently full. Check back later in case spots open up.</value></data>
 
   <data name="ShiftDash_Title" xml:space="preserve"><value>Shift Dashboard</value></data>

--- a/src/Humans.Web/Views/Shifts/Mine.cshtml
+++ b/src/Humans.Web/Views/Shifts/Mine.cshtml
@@ -205,29 +205,69 @@
             <div class="alert alert-info">@Localizer["Shifts_NoSignups"] <a asp-action="Index">@Localizer["Shifts_BrowseAvailable"]</a>.</div>
         }
 
-        @* General Availability *@
+        @* General Availability — Calendar Grid *@
+        @{
+            var culture = System.Globalization.CultureInfo.CurrentUICulture;
+            var shortDays = culture.DateTimeFormat.AbbreviatedDayNames;
+            var monFirstDays = new[] { shortDays[1], shortDays[2], shortDays[3], shortDays[4], shortDays[5], shortDays[6], shortDays[0] };
+            int AvailLeadOffset(LocalDate d) => ((int)d.DayOfWeek + 6) % 7;
+
+            var phases = new List<(string Label, string BadgeClass, int StartOffset, int EndOffset)>
+            {
+                (Localizer["Shifts_SetUp"].Value, "bg-info", es.BuildStartOffset, -1),
+                (Localizer["Shifts_Event"].Value, "bg-success", 0, es.EventEndOffset),
+                (Localizer["Shifts_Strike"].Value, "bg-secondary", es.EventEndOffset + 1, es.StrikeEndOffset)
+            };
+        }
         <div class="card mb-4">
             <div class="card-header"><h5 class="mb-0">@Localizer["Shifts_GeneralAvailability"]</h5></div>
             <div class="card-body">
                 <p class="text-muted small">@Localizer["Shifts_AvailabilityHelp"]</p>
-                <form asp-action="SaveAvailability" method="post">
+                <form asp-action="SaveAvailability" method="post" id="availabilityForm">
                     @Html.AntiForgeryToken()
-                    <div class="row row-cols-auto g-2 mb-3">
-                        @for (var d = es.BuildStartOffset; d <= es.StrikeEndOffset; d++)
-                        {
-                            var date = es.GateOpeningDate.PlusDays(d);
-                            var dateLabel = date.ToDisplayShiftDate();
-                            var isChecked = Model.AvailableDayOffsets.Contains(d);
-                            <div class="col">
-                                <div class="form-check">
-                                    <input type="checkbox" name="dayOffsets" value="@d" class="form-check-input"
-                                           id="avail-@d" checked="@(isChecked ? "checked" : null)" />
-                                    <label class="form-check-label small" for="avail-@d">@dateLabel</label>
-                                </div>
+                    @foreach (var phase in phases)
+                    {
+                        if (phase.StartOffset > es.StrikeEndOffset || phase.EndOffset < es.BuildStartOffset) { continue; }
+                        var phaseStart = es.GateOpeningDate.PlusDays(phase.StartOffset);
+                        var phaseEnd = es.GateOpeningDate.PlusDays(phase.EndOffset);
+                        <div class="mb-3">
+                            <div class="d-flex justify-content-between align-items-center mb-2">
+                                <span class="badge @phase.BadgeClass">@phase.Label</span>
+                                <small class="text-muted">@phaseStart.ToDisplayShiftDate() – @phaseEnd.ToDisplayShiftDate()</small>
                             </div>
-                        }
+                            <div class="avail-cal-grid">
+                                @foreach (var dayName in monFirstDays)
+                                {
+                                    <div class="avail-cal-head">@dayName</div>
+                                }
+                                @for (var i = 0; i < AvailLeadOffset(phaseStart); i++)
+                                {
+                                    <div class="avail-cal-day avail-cal-empty"></div>
+                                }
+                                @for (var d = phase.StartOffset; d <= phase.EndOffset; d++)
+                                {
+                                    var date = es.GateOpeningDate.PlusDays(d);
+                                    var isChecked = Model.AvailableDayOffsets.Contains(d);
+                                    var isWeekend = date.DayOfWeek == IsoDayOfWeek.Saturday || date.DayOfWeek == IsoDayOfWeek.Sunday;
+                                    var showMonth = d == phase.StartOffset || date.Day == 1;
+                                    <div class="avail-cal-day @(isWeekend ? "avail-cal-weekend" : "") @(isChecked ? "avail-cal-selected" : "")"
+                                         data-offset="@d" role="button" tabindex="0">
+                                        <input type="checkbox" name="dayOffsets" value="@d" class="d-none"
+                                               checked="@(isChecked ? "checked" : null)" />
+                                        <span class="avail-day-num">@date.Day</span>
+                                        @if (showMonth)
+                                        {
+                                            <span class="avail-day-month">@culture.DateTimeFormat.GetAbbreviatedMonthName(date.Month)</span>
+                                        }
+                                    </div>
+                                }
+                            </div>
+                        </div>
+                    }
+                    <div class="d-flex align-items-center gap-3 mt-2">
+                        <button type="submit" class="btn btn-sm btn-primary">@Localizer["Shifts_SaveAvailability"]</button>
+                        <small class="text-muted" id="availCount"></small>
                     </div>
-                    <button type="submit" class="btn btn-sm btn-primary">@Localizer["Shifts_SaveAvailability"]</button>
                 </form>
             </div>
         </div>
@@ -262,6 +302,39 @@
         copyBtn.addEventListener('click', function() {
             navigator.clipboard.writeText(document.getElementById('icalUrl').value);
         });
+    }
+
+    // Availability calendar grid — click to toggle
+    var form = document.getElementById('availabilityForm');
+    if (form) {
+        var days = form.querySelectorAll('.avail-cal-day:not(.avail-cal-empty)');
+        var countEl = document.getElementById('availCount');
+        var totalDays = days.length;
+
+        function updateCount() {
+            var selected = form.querySelectorAll('.avail-cal-selected').length;
+            if (countEl) {
+                countEl.textContent = selected + ' / ' + totalDays + ' @Localizer["Shifts_DaysSelected"].Value';
+            }
+        }
+
+        days.forEach(function(day) {
+            day.addEventListener('click', function() {
+                var cb = day.querySelector('input[type="checkbox"]');
+                if (!cb) return;
+                cb.checked = !cb.checked;
+                day.classList.toggle('avail-cal-selected', cb.checked);
+                updateCount();
+            });
+            day.addEventListener('keydown', function(e) {
+                if (e.key === ' ' || e.key === 'Enter') {
+                    e.preventDefault();
+                    day.click();
+                }
+            });
+        });
+
+        updateCount();
     }
 })();
 </script>

--- a/src/Humans.Web/Views/Shifts/Mine.cshtml
+++ b/src/Humans.Web/Views/Shifts/Mine.cshtml
@@ -206,19 +206,17 @@
         }
 
         @* General Availability — Calendar Grid *@
-        @{
-            var culture = System.Globalization.CultureInfo.CurrentUICulture;
-            var shortDays = culture.DateTimeFormat.AbbreviatedDayNames;
-            var monFirstDays = new[] { shortDays[1], shortDays[2], shortDays[3], shortDays[4], shortDays[5], shortDays[6], shortDays[0] };
-            int AvailLeadOffset(LocalDate d) => ((int)d.DayOfWeek + 6) % 7;
+        var culture = System.Globalization.CultureInfo.CurrentUICulture;
+        var shortDays = culture.DateTimeFormat.AbbreviatedDayNames;
+        var monFirstDays = new[] { shortDays[1], shortDays[2], shortDays[3], shortDays[4], shortDays[5], shortDays[6], shortDays[0] };
+        int AvailLeadOffset(LocalDate d) => ((int)d.DayOfWeek + 6) % 7;
 
-            var phases = new List<(string Label, string BadgeClass, int StartOffset, int EndOffset)>
-            {
-                (Localizer["Shifts_SetUp"].Value, "bg-info", es.BuildStartOffset, -1),
-                (Localizer["Shifts_Event"].Value, "bg-success", 0, es.EventEndOffset),
-                (Localizer["Shifts_Strike"].Value, "bg-secondary", es.EventEndOffset + 1, es.StrikeEndOffset)
-            };
-        }
+        var phases = new List<(string Label, string BadgeClass, int StartOffset, int EndOffset)>
+        {
+            (Localizer["Shifts_SetUp"].Value, "bg-info", es.BuildStartOffset, -1),
+            (Localizer["Shifts_Event"].Value, "bg-success", 0, es.EventEndOffset),
+            (Localizer["Shifts_Strike"].Value, "bg-secondary", es.EventEndOffset + 1, es.StrikeEndOffset)
+        };
         <div class="card mb-4">
             <div class="card-header"><h5 class="mb-0">@Localizer["Shifts_GeneralAvailability"]</h5></div>
             <div class="card-body">

--- a/src/Humans.Web/wwwroot/css/site.css
+++ b/src/Humans.Web/wwwroot/css/site.css
@@ -1625,3 +1625,84 @@ tr[data-href] {
         padding: 0.0625rem 0.25rem;
     }
 }
+
+/* ==========================================================================
+   Availability Calendar Grid
+   ========================================================================== */
+
+.avail-cal-grid {
+    display: grid;
+    grid-template-columns: repeat(7, 1fr);
+    gap: 4px;
+}
+
+.avail-cal-head {
+    font-size: 0.7rem;
+    color: var(--h-muted-text);
+    text-align: center;
+    padding: 4px 0;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+}
+
+.avail-cal-day {
+    text-align: center;
+    padding: 6px 2px;
+    border-radius: var(--h-radius);
+    cursor: pointer;
+    border: 1px solid transparent;
+    transition: background-color 0.15s, border-color 0.15s;
+    user-select: none;
+}
+
+.avail-cal-day:hover {
+    background-color: var(--h-bg-hover);
+}
+
+.avail-cal-day:focus-visible {
+    outline: 2px solid var(--h-blue-muted);
+    outline-offset: 1px;
+}
+
+.avail-cal-empty {
+    visibility: hidden;
+}
+
+.avail-cal-weekend {
+    background-color: var(--h-bg-hover);
+}
+
+.avail-cal-selected {
+    background-color: var(--h-green-tint, #e8f5e9) !important;
+    border-color: var(--h-green-muted, #81c784);
+}
+
+.avail-day-num {
+    display: block;
+    font-size: 0.9rem;
+    font-weight: 500;
+    line-height: 1.3;
+}
+
+.avail-day-month {
+    display: block;
+    font-size: 0.65rem;
+    color: var(--h-muted-text);
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+}
+
+@media (max-width: 576px) {
+    .avail-cal-day {
+        padding: 4px 1px;
+    }
+
+    .avail-day-num {
+        font-size: 0.8rem;
+    }
+
+    .avail-day-month {
+        font-size: 0.6rem;
+    }
+}


### PR DESCRIPTION
## Summary
- Replace flat checkbox wall for general availability with a Mon–Sun calendar grid grouped by phase (set-up / event / strike)
- Weekend tinting, month labels, click-to-toggle cells, keyboard accessible, live day counter
- Fully localized across all 6 locales

## Test plan
- [ ] My Shifts page: availability calendar renders with correct dates and phases
- [ ] Clicking a day toggles green highlight and checkbox state
- [ ] Keyboard navigation (tab + space/enter) works
- [ ] Day counter updates on toggle
- [ ] Save preserves selections correctly
- [ ] Locales (es/ca/de/fr/it) show translated day names, months, phase labels
- [ ] Mobile: grid stays readable on narrow screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)