### PR TITLE
UX: Redesign shifts browse header with tabs and phase cards

### DIFF
--- a/src/Humans.Web/Controllers/ShiftsController.cs
+++ b/src/Humans.Web/Controllers/ShiftsController.cs
@@ -44,7 +44,7 @@ public class ShiftsController : HumansControllerBase
     }
 
     [HttpGet("")]
-    public async Task<IActionResult> Index(Guid? departmentId, string? fromDate, string? toDate, string? period, bool showFull = false, [FromQuery(Name = "tags")] List<Guid>? tagIds = null, string? sort = null)
+    public async Task<IActionResult> Index(Guid? departmentId, string? fromDate, string? toDate, string? period, bool showFull = false, [FromQuery(Name = "tags")] List<Guid>? tagIds = null, string? sort = null, [FromQuery(Name = "periods")] List<string>? periods = null)
     {
         var (currentUserNotFound, user) = await ResolveCurrentUserOrChallengeAsync();
         if (currentUserNotFound is not null)
@@ -79,12 +79,40 @@ public class ShiftsController : HumansControllerBase
         if ((!string.IsNullOrEmpty(fromDate) || !string.IsNullOrEmpty(toDate)) && !string.IsNullOrEmpty(period))
             period = null;
 
-        // Apply period filter — compute date boundaries from EventSettings offsets
-        if (!string.IsNullOrEmpty(period) && Enum.TryParse<ShiftPeriod>(period, true, out var parsedPeriod))
+        // Multiselect period support: if specific periods are provided, compute the union date range.
+        // When all 3 are selected (or none), treat as "no filter" — same as legacy single-period "All".
+        var activePeriods = (periods ?? [])
+            .Where(p => Enum.TryParse<ShiftPeriod>(p, true, out _))
+            .Select(p => Enum.Parse<ShiftPeriod>(p, true))
+            .Distinct()
+            .ToList();
+        var allPeriodsSelected = activePeriods.Count == 3 ||
+            (activePeriods.Count == 0 && string.IsNullOrEmpty(period));
+
+        // Legacy single-period param: fold into activePeriods for unified handling
+        if (activePeriods.Count == 0 && !string.IsNullOrEmpty(period) &&
+            Enum.TryParse<ShiftPeriod>(period, true, out var parsedPeriod))
         {
-            var (periodFrom, periodTo) = GetPeriodDateRange(es, parsedPeriod);
-            filterFromDate ??= periodFrom;
-            filterToDate ??= periodTo;
+            activePeriods = [parsedPeriod];
+        }
+
+        // Apply period filter — for single contiguous period, use date range query.
+        // For multi-period or non-contiguous, fetch all and post-filter by shift period.
+        var postFilterByPeriod = false;
+        if (activePeriods.Count > 0 && !allPeriodsSelected)
+        {
+            if (activePeriods.Count == 1)
+            {
+                // Single period: use efficient date range query
+                var (periodFrom, periodTo) = GetPeriodDateRange(es, activePeriods[0]);
+                filterFromDate ??= periodFrom;
+                filterToDate ??= periodTo;
+            }
+            else
+            {
+                // Multiple non-contiguous periods (e.g., Build + Strike): fetch all, filter after
+                postFilterByPeriod = true;
+            }
         }
 
         // Build the browse view — show all active shifts, hide AdminOnly from regular volunteers.
@@ -95,11 +123,16 @@ public class ShiftsController : HumansControllerBase
             includeAdminOnly: isPrivileged, includeSignups: true,
             includeHidden: isPrivileged);
 
+        // Post-filter by period when multiple non-contiguous periods are selected (e.g., Build + Strike)
+        var periodFilteredShifts = postFilterByPeriod
+            ? urgentShifts.Where(u => activePeriods.Contains(u.Shift.GetShiftPeriod(es))).ToList()
+            : (IReadOnlyList<UrgentShift>)urgentShifts;
+
         // Apply tag filter — keep only shifts whose rota has at least one of the selected tags
         var activeTagFilter = tagIds?.Where(id => id != Guid.Empty).ToList() ?? [];
         var filteredShifts = activeTagFilter.Count > 0
-            ? urgentShifts.Where(u => u.Shift.Rota.Tags.Any(t => activeTagFilter.Contains(t.Id))).ToList()
-            : urgentShifts;
+            ? periodFilteredShifts.Where(u => u.Shift.Rota.Tags.Any(t => activeTagFilter.Contains(t.Id))).ToList()
+            : periodFilteredShifts;
 
         // Resolve team name/slug cross-section (Shifts doesn't own Team data).
         var shiftTeamIds = filteredShifts.Select(u => u.Shift.Rota.TeamId).Distinct().ToList();
@@ -170,8 +203,8 @@ public class ShiftsController : HumansControllerBase
             .OrderBy(d => d.TeamName, StringComparer.Ordinal)
             .ToList();
 
-        // Build urgency-ranked flat rota list (used when sort=urgency)
-        var isUrgencySort = string.Equals(sort, "urgency", StringComparison.OrdinalIgnoreCase);
+        // Build urgency-ranked flat rota list — default sort is now "urgency" (most needed first)
+        var isUrgencySort = !string.Equals(sort, "department", StringComparison.OrdinalIgnoreCase);
         var urgencyRankedRotas = isUrgencySort
             ? departments.SelectMany(d => d.Rotas)
                 .OrderByDescending(r => r.MaxUrgencyScore)
@@ -205,6 +238,7 @@ public class ShiftsController : HumansControllerBase
             FilterFromDate = fromDate,
             FilterToDate = toDate,
             FilterPeriod = period,
+            FilterPeriods = activePeriods.Select(p => p.ToString()).ToList(),
             ShowFullShifts = showFull,
             UserSignupShiftIds = userSignupShiftIds,
             UserSignupStatuses = userSignupStatuses,
@@ -213,11 +247,12 @@ public class ShiftsController : HumansControllerBase
             // Temporarily public — signups list visible to all browsers. Keep the isPrivileged
             // computation in place so we can flip back to `ShowSignups = isPrivileged` if folks object.
             ShowSignups = true,
-            Sort = isUrgencySort ? "urgency" : null,
+            Sort = isUrgencySort ? "urgency" : "department",
             UrgencyRankedRotas = urgencyRankedRotas,
             AllTags = allTags.ToList(),
             FilterTagIds = activeTagFilter,
-            UserPreferredTagIds = userPreferredTags.Select(t => t.Id).ToHashSet()
+            UserPreferredTagIds = userPreferredTags.Select(t => t.Id).ToHashSet(),
+            MySignupCount = userSignups.Count(s => s.Status is SignupStatus.Confirmed or SignupStatus.Pending)
         };
 
         return View(model);
@@ -275,7 +310,7 @@ public class ShiftsController : HumansControllerBase
         return RedirectToAction(nameof(Index), BuildFilterRouteValues(departmentId, fromDate, toDate, period, tagIds));
     }
 
-    private static RouteValueDictionary BuildFilterRouteValues(Guid? departmentId, string? fromDate, string? toDate, string? period, List<Guid>? tagIds, string? sort = null)
+    private static RouteValueDictionary BuildFilterRouteValues(Guid? departmentId, string? fromDate, string? toDate, string? period, List<Guid>? tagIds, string? sort = null, List<string>? periods = null)
     {
         var rv = new RouteValueDictionary();
         if (departmentId.HasValue) rv["departmentId"] = departmentId.Value;
@@ -286,6 +321,9 @@ public class ShiftsController : HumansControllerBase
         if (tagIds is { Count: > 0 })
             for (var i = 0; i < tagIds.Count; i++)
                 rv[$"tags[{i}]"] = tagIds[i];
+        if (periods is { Count: > 0 })
+            for (var i = 0; i < periods.Count; i++)
+                rv[$"periods[{i}]"] = periods[i];
         return rv;
     }
 

--- a/src/Humans.Web/Controllers/ShiftsController.cs
+++ b/src/Humans.Web/Controllers/ShiftsController.cs
@@ -260,7 +260,7 @@ public class ShiftsController : HumansControllerBase
 
     [HttpPost("SignUp")]
     [ValidateAntiForgeryToken]
-    public async Task<IActionResult> SignUp(Guid shiftId, Guid? departmentId, string? fromDate, string? toDate, string? period, [FromForm(Name = "tags")] List<Guid>? tagIds)
+    public async Task<IActionResult> SignUp(Guid shiftId, Guid? departmentId, string? fromDate, string? toDate, string? period, [FromForm(Name = "tags")] List<Guid>? tagIds, [FromForm(Name = "periods")] List<string>? periods = null)
     {
         var (currentUserNotFound, user) = await ResolveCurrentUserOrChallengeAsync();
         if (currentUserNotFound is not null)
@@ -274,19 +274,19 @@ public class ShiftsController : HumansControllerBase
         if (!result.Success)
         {
             SetError(result.Error ?? "Shift signup failed.");
-            return RedirectToAction(nameof(Index), BuildFilterRouteValues(departmentId, fromDate, toDate, period, tagIds));
+            return RedirectToAction(nameof(Index), BuildFilterRouteValues(departmentId, fromDate, toDate, period, tagIds, periods: periods));
         }
 
         SetSuccess(result.Warning is not null
             ? $"Signed up successfully. Note: {result.Warning}"
             : "Signed up successfully!");
 
-        return RedirectToAction(nameof(Index), BuildFilterRouteValues(departmentId, fromDate, toDate, period, tagIds));
+        return RedirectToAction(nameof(Index), BuildFilterRouteValues(departmentId, fromDate, toDate, period, tagIds, periods: periods));
     }
 
     [HttpPost("SignUpRange")]
     [ValidateAntiForgeryToken]
-    public async Task<IActionResult> SignUpRange(Guid rotaId, int startDayOffset, int endDayOffset, Guid? departmentId, string? fromDate, string? toDate, string? period, [FromForm(Name = "tags")] List<Guid>? tagIds)
+    public async Task<IActionResult> SignUpRange(Guid rotaId, int startDayOffset, int endDayOffset, Guid? departmentId, string? fromDate, string? toDate, string? period, [FromForm(Name = "tags")] List<Guid>? tagIds, [FromForm(Name = "periods")] List<string>? periods = null)
     {
         var (currentUserNotFound, user) = await ResolveCurrentUserOrChallengeAsync();
         if (currentUserNotFound is not null)
@@ -300,14 +300,14 @@ public class ShiftsController : HumansControllerBase
         if (!result.Success)
         {
             SetError(result.Error ?? "Shift range signup failed.");
-            return RedirectToAction(nameof(Index), BuildFilterRouteValues(departmentId, fromDate, toDate, period, tagIds));
+            return RedirectToAction(nameof(Index), BuildFilterRouteValues(departmentId, fromDate, toDate, period, tagIds, periods: periods));
         }
 
         SetSuccess(result.Warning is not null
             ? $"Signed up for date range. Note: {result.Warning}"
             : "Signed up for date range!");
 
-        return RedirectToAction(nameof(Index), BuildFilterRouteValues(departmentId, fromDate, toDate, period, tagIds));
+        return RedirectToAction(nameof(Index), BuildFilterRouteValues(departmentId, fromDate, toDate, period, tagIds, periods: periods));
     }
 
     private static RouteValueDictionary BuildFilterRouteValues(Guid? departmentId, string? fromDate, string? toDate, string? period, List<Guid>? tagIds, string? sort = null, List<string>? periods = null)

--- a/src/Humans.Web/Models/ShiftViewModels.cs
+++ b/src/Humans.Web/Models/ShiftViewModels.cs
@@ -541,6 +541,7 @@ public class BuildStrikeRotaTableViewModel
     public string? FilterFromDate { get; set; }
     public string? FilterToDate { get; set; }
     public string? FilterPeriod { get; set; }
+    public List<string> FilterPeriods { get; set; } = [];
     public List<Guid> FilterTagIds { get; set; } = [];
 }
 
@@ -555,6 +556,7 @@ public class EventRotaTableViewModel
     public string? FilterFromDate { get; set; }
     public string? FilterToDate { get; set; }
     public string? FilterPeriod { get; set; }
+    public List<string> FilterPeriods { get; set; } = [];
     public List<Guid> FilterTagIds { get; set; } = [];
 }
 

--- a/src/Humans.Web/Models/ShiftViewModels.cs
+++ b/src/Humans.Web/Models/ShiftViewModels.cs
@@ -140,6 +140,13 @@ public class ShiftBrowseViewModel
     public string? FilterFromDate { get; set; }
     public string? FilterToDate { get; set; }
     public string? FilterPeriod { get; set; }
+
+    /// <summary>
+    /// Active period filters for multiselect phase cards (Build, Event, Strike).
+    /// When all three are selected (or none explicitly set), no period filtering is applied.
+    /// </summary>
+    public List<string> FilterPeriods { get; set; } = [];
+
     public bool ShowFullShifts { get; set; }
     public HashSet<Guid> UserSignupShiftIds { get; set; } = [];
     public Dictionary<Guid, SignupStatus> UserSignupStatuses { get; set; } = new();
@@ -169,6 +176,11 @@ public class ShiftBrowseViewModel
     /// Tag IDs the current volunteer has selected as preferences (for highlighting).
     /// </summary>
     public HashSet<Guid> UserPreferredTagIds { get; set; } = [];
+
+    /// <summary>
+    /// Count of the current user's active signups (confirmed + pending), shown as badge on "My Shifts" tab.
+    /// </summary>
+    public int MySignupCount { get; set; }
 }
 
 public class DepartmentOption

--- a/src/Humans.Web/Resources/SharedResource.ca.resx
+++ b/src/Humans.Web/Resources/SharedResource.ca.resx
@@ -1643,6 +1643,10 @@
   <data name="Shifts_SetPreferences" xml:space="preserve"><value>Configura les teves preferències</value></data>
   <data name="Shifts_PreferencesHelp" xml:space="preserve"><value>Selecciona etiquetes que coincideixin amb el treball que t'agrada. Els torns coincidents es ressaltaran amb una estrella.</value></data>
   <data name="Shifts_SavePreferences" xml:space="preserve"><value>Desar preferències</value></data>
+  <data name="Shifts_HeroTitle" xml:space="preserve"><value>Troba el teu torn perfecte</value></data>
+  <data name="Shifts_HeroSubtitle" xml:space="preserve"><value>Explora les opcions de voluntariat, filtra per fase o departament, i apunta't als torns que millor s'adaptin a tu.</value></data>
+  <data name="Shifts_LearnMore" xml:space="preserve"><value>Saber-ne més</value></data>
+  <data name="Shifts_EditPreferences" xml:space="preserve"><value>Editar preferències</value></data>
   <data name="Shifts_NotOpenYet" xml:space="preserve"><value>Els torns encara no estan oberts. Només coordinadors i administradors poden veure aquesta pàgina.</value></data>
   <data name="Shifts_NoShiftsAvailable" xml:space="preserve"><value>Encara no hi ha torns disponibles.</value></data>
   <data name="Shifts_AllShiftsFull" xml:space="preserve"><value>Tots els torns de {0} estan complets.</value><comment>{0} = period name</comment></data>

--- a/src/Humans.Web/Resources/SharedResource.de.resx
+++ b/src/Humans.Web/Resources/SharedResource.de.resx
@@ -1641,6 +1641,10 @@
   <data name="Shifts_SetPreferences" xml:space="preserve"><value>Präferenzen festlegen</value></data>
   <data name="Shifts_PreferencesHelp" xml:space="preserve"><value>Wähle Tags aus, die zur Art von Arbeit passen, die du magst. Passende Schichten werden mit einem Stern markiert.</value></data>
   <data name="Shifts_SavePreferences" xml:space="preserve"><value>Präferenzen speichern</value></data>
+  <data name="Shifts_HeroTitle" xml:space="preserve"><value>Finde deine perfekte Schicht</value></data>
+  <data name="Shifts_HeroSubtitle" xml:space="preserve"><value>Durchsuche die Freiwilligenoptionen, filtere nach Phase oder Abteilung und melde dich für Schichten an, die zu dir passen.</value></data>
+  <data name="Shifts_LearnMore" xml:space="preserve"><value>Mehr erfahren</value></data>
+  <data name="Shifts_EditPreferences" xml:space="preserve"><value>Einstellungen bearbeiten</value></data>
   <data name="Shifts_NotOpenYet" xml:space="preserve"><value>Schichten sind noch nicht geöffnet. Nur Koordinatoren und Admins können diese Seite sehen.</value></data>
   <data name="Shifts_NoShiftsAvailable" xml:space="preserve"><value>Noch keine Schichten verfügbar.</value></data>
   <data name="Shifts_AllShiftsFull" xml:space="preserve"><value>Alle {0}-Schichten sind voll.</value><comment>{0} = period name</comment></data>

--- a/src/Humans.Web/Resources/SharedResource.es.resx
+++ b/src/Humans.Web/Resources/SharedResource.es.resx
@@ -1643,6 +1643,10 @@
   <data name="Shifts_SetPreferences" xml:space="preserve"><value>Configura tus preferencias</value></data>
   <data name="Shifts_PreferencesHelp" xml:space="preserve"><value>Selecciona etiquetas que coincidan con el trabajo que te gusta. Los turnos coincidentes se resaltarán con una estrella.</value></data>
   <data name="Shifts_SavePreferences" xml:space="preserve"><value>Guardar preferencias</value></data>
+  <data name="Shifts_HeroTitle" xml:space="preserve"><value>Encuentra tu turno perfecto</value></data>
+  <data name="Shifts_HeroSubtitle" xml:space="preserve"><value>Explora las opciones de voluntariado, filtra por fase o departamento, y apúntate a los turnos que mejor se adapten a ti.</value></data>
+  <data name="Shifts_LearnMore" xml:space="preserve"><value>Saber más</value></data>
+  <data name="Shifts_EditPreferences" xml:space="preserve"><value>Editar preferencias</value></data>
   <data name="Shifts_NotOpenYet" xml:space="preserve"><value>Los turnos aún no están abiertos. Solo coordinadores y administradores pueden ver esta página.</value></data>
   <data name="Shifts_NoShiftsAvailable" xml:space="preserve"><value>Aún no hay turnos disponibles.</value></data>
   <data name="Shifts_AllShiftsFull" xml:space="preserve"><value>Todos los turnos de {0} están completos.</value><comment>{0} = period name</comment></data>

--- a/src/Humans.Web/Resources/SharedResource.fr.resx
+++ b/src/Humans.Web/Resources/SharedResource.fr.resx
@@ -1641,6 +1641,10 @@
   <data name="Shifts_SetPreferences" xml:space="preserve"><value>Définir vos préférences</value></data>
   <data name="Shifts_PreferencesHelp" xml:space="preserve"><value>Sélectionnez les tags correspondant au type de travail que vous aimez. Les quarts correspondants seront mis en valeur avec une étoile.</value></data>
   <data name="Shifts_SavePreferences" xml:space="preserve"><value>Enregistrer les préférences</value></data>
+  <data name="Shifts_HeroTitle" xml:space="preserve"><value>Trouve ton créneau idéal</value></data>
+  <data name="Shifts_HeroSubtitle" xml:space="preserve"><value>Explore les options de bénévolat, filtre par phase ou département, et inscris-toi aux créneaux qui te conviennent.</value></data>
+  <data name="Shifts_LearnMore" xml:space="preserve"><value>En savoir plus</value></data>
+  <data name="Shifts_EditPreferences" xml:space="preserve"><value>Modifier les préférences</value></data>
   <data name="Shifts_NotOpenYet" xml:space="preserve"><value>Les quarts ne sont pas encore ouverts. Seuls les coordinateurs et admins peuvent voir cette page.</value></data>
   <data name="Shifts_NoShiftsAvailable" xml:space="preserve"><value>Aucun quart disponible pour le moment.</value></data>
   <data name="Shifts_AllShiftsFull" xml:space="preserve"><value>Tous les quarts de {0} sont complets.</value><comment>{0} = period name</comment></data>

--- a/src/Humans.Web/Resources/SharedResource.it.resx
+++ b/src/Humans.Web/Resources/SharedResource.it.resx
@@ -1641,6 +1641,10 @@
   <data name="Shifts_SetPreferences" xml:space="preserve"><value>Imposta le tue preferenze</value></data>
   <data name="Shifts_PreferencesHelp" xml:space="preserve"><value>Seleziona i tag che corrispondono al tipo di lavoro che ti piace. I turni corrispondenti saranno evidenziati con una stella.</value></data>
   <data name="Shifts_SavePreferences" xml:space="preserve"><value>Salva preferenze</value></data>
+  <data name="Shifts_HeroTitle" xml:space="preserve"><value>Trova il tuo turno perfetto</value></data>
+  <data name="Shifts_HeroSubtitle" xml:space="preserve"><value>Esplora le opzioni di volontariato, filtra per fase o reparto e iscriviti ai turni più adatti a te.</value></data>
+  <data name="Shifts_LearnMore" xml:space="preserve"><value>Scopri di più</value></data>
+  <data name="Shifts_EditPreferences" xml:space="preserve"><value>Modifica preferenze</value></data>
   <data name="Shifts_NotOpenYet" xml:space="preserve"><value>I turni non sono ancora aperti. Solo coordinatori e admin possono vedere questa pagina.</value></data>
   <data name="Shifts_NoShiftsAvailable" xml:space="preserve"><value>Nessun turno disponibile al momento.</value></data>
   <data name="Shifts_AllShiftsFull" xml:space="preserve"><value>Tutti i turni di {0} sono completi.</value><comment>{0} = period name</comment></data>

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -1661,6 +1661,10 @@
   <data name="Shifts_SetPreferences" xml:space="preserve"><value>Set your preferences</value></data>
   <data name="Shifts_PreferencesHelp" xml:space="preserve"><value>Select tags that match the kind of work you enjoy. Matching shifts will be highlighted with a star.</value></data>
   <data name="Shifts_SavePreferences" xml:space="preserve"><value>Save Preferences</value></data>
+  <data name="Shifts_HeroTitle" xml:space="preserve"><value>Find your perfect shift</value></data>
+  <data name="Shifts_HeroSubtitle" xml:space="preserve"><value>Browse volunteer options, filter by phase or department, and sign up for the shifts that suit you best.</value></data>
+  <data name="Shifts_LearnMore" xml:space="preserve"><value>Learn more</value></data>
+  <data name="Shifts_EditPreferences" xml:space="preserve"><value>Edit preferences</value></data>
   <data name="Shifts_NotOpenYet" xml:space="preserve"><value>Shifts aren't open yet. Only coordinators and admins can see this page.</value></data>
   <data name="Shifts_NoShiftsAvailable" xml:space="preserve"><value>No shifts available yet.</value></data>
   <data name="Shifts_AllShiftsFull" xml:space="preserve"><value>All {0} shifts are full.</value><comment>{0} = period name</comment></data>

--- a/src/Humans.Web/Views/Shared/_BuildStrikeRotaTable.cshtml
+++ b/src/Humans.Web/Views/Shared/_BuildStrikeRotaTable.cshtml
@@ -14,6 +14,7 @@
         @if (!string.IsNullOrEmpty(Model.FilterFromDate)) { <input type="hidden" name="fromDate" value="@Model.FilterFromDate" /> }
         @if (!string.IsNullOrEmpty(Model.FilterToDate)) { <input type="hidden" name="toDate" value="@Model.FilterToDate" /> }
         @if (!string.IsNullOrEmpty(Model.FilterPeriod)) { <input type="hidden" name="period" value="@Model.FilterPeriod" /> }
+        @foreach (var p in Model.FilterPeriods) { <input type="hidden" name="periods" value="@p" /> }
         @foreach (var tagId in Model.FilterTagIds) { <input type="hidden" name="tags" value="@tagId" /> }
         <div class="col-auto">
             <label class="form-label form-label-sm">@Localizer["Shifts_Start"]</label>

--- a/src/Humans.Web/Views/Shared/_EventRotaTable.cshtml
+++ b/src/Humans.Web/Views/Shared/_EventRotaTable.cshtml
@@ -105,6 +105,7 @@
                                 @if (!string.IsNullOrEmpty(Model.FilterFromDate)) { <input type="hidden" name="fromDate" value="@Model.FilterFromDate" /> }
                                 @if (!string.IsNullOrEmpty(Model.FilterToDate)) { <input type="hidden" name="toDate" value="@Model.FilterToDate" /> }
                                 @if (!string.IsNullOrEmpty(Model.FilterPeriod)) { <input type="hidden" name="period" value="@Model.FilterPeriod" /> }
+                                @foreach (var p in Model.FilterPeriods) { <input type="hidden" name="periods" value="@p" /> }
                                 @foreach (var tagId in Model.FilterTagIds) { <input type="hidden" name="tags" value="@tagId" /> }
                                 <button type="submit" class="btn btn-sm btn-success">@Localizer["Shifts_SignUpButton"]</button>
                             </form>

--- a/src/Humans.Web/Views/Shifts/Index.cshtml
+++ b/src/Humans.Web/Views/Shifts/Index.cshtml
@@ -58,13 +58,17 @@
             </li>
         </ul>
         <div class="d-flex gap-2">
-            <vc:access-matrix section="Shifts" />
+            @* Hide the info button but keep the modal in the DOM for the "Learn more" button *@
+            <span class="shifts-hidden-info-btn"><vc:access-matrix section="Shifts" /></span>
             <a asp-controller="ShiftDashboard" asp-action="Index" class="btn btn-outline-warning btn-sm" authorize-policy="ShiftDepartmentManager"><i class="fa-solid fa-gauge-high me-1"></i>Dashboard <i class="fa-solid fa-lock auth-lock-icon"></i></a>
             <a asp-action="Settings" class="btn btn-outline-secondary btn-sm" authorize-policy="AdminOnly"><i class="fa-solid fa-gear me-1"></i>Settings <i class="fa-solid fa-lock auth-lock-icon"></i></a>
         </div>
     </div>
 
-    <vc:temp-data-alerts />
+    @* Toast alerts — bottom-right, auto-dismiss *@
+    <div class="shifts-toast-container">
+        <vc:temp-data-alerts />
+    </div>
 
     @* === Hero Banner === *@
     <div class="shifts-hero-banner mb-4">
@@ -269,6 +273,14 @@
                 cb.checked = !cb.checked;
                 cb.dispatchEvent(new Event('change'));
             });
+        });
+
+        // Auto-dismiss toast alerts after 4 seconds
+        document.querySelectorAll('.shifts-toast-container .alert').forEach(function(alert) {
+            setTimeout(function() {
+                var bsAlert = bootstrap.Alert.getOrCreateInstance(alert);
+                bsAlert.close();
+            }, 4000);
         });
     </script>
 

--- a/src/Humans.Web/Views/Shifts/Index.cshtml
+++ b/src/Humans.Web/Views/Shifts/Index.cshtml
@@ -5,34 +5,31 @@
     var es = Model.EventSettings;
     var isUrgencySort = string.Equals(Model.Sort, "urgency", StringComparison.OrdinalIgnoreCase);
 
-    // Compute date picker bounds — tighten to active period's range
-    var pickerMin = es.GateOpeningDate.PlusDays(es.BuildStartOffset);
-    var pickerMax = es.GateOpeningDate.PlusDays(es.StrikeEndOffset);
-    if (!string.IsNullOrEmpty(Model.FilterPeriod) && Enum.TryParse<ShiftPeriod>(Model.FilterPeriod, true, out var activePeriodEnum))
-    {
-        (pickerMin, pickerMax) = activePeriodEnum switch
-        {
-            ShiftPeriod.Build => (es.GateOpeningDate.PlusDays(es.BuildStartOffset), es.GateOpeningDate.PlusDays(-1)),
-            ShiftPeriod.Event => (es.GateOpeningDate, es.GateOpeningDate.PlusDays(es.EventEndOffset)),
-            ShiftPeriod.Strike => (es.GateOpeningDate.PlusDays(es.EventEndOffset + 1), es.GateOpeningDate.PlusDays(es.StrikeEndOffset)),
-            _ => (pickerMin, pickerMax)
-        };
-    }
+    // Phase date ranges for display on cards
+    var buildFrom = es.GateOpeningDate.PlusDays(es.BuildStartOffset);
+    var buildTo = es.GateOpeningDate.PlusDays(-1);
+    var eventFrom = es.GateOpeningDate;
+    var eventTo = es.GateOpeningDate.PlusDays(es.EventEndOffset);
+    var strikeFrom = es.GateOpeningDate.PlusDays(es.EventEndOffset + 1);
+    var strikeTo = es.GateOpeningDate.PlusDays(es.StrikeEndOffset);
+
+    // Multiselect phase state: default all selected (= no filter)
+    var activePeriods = Model.FilterPeriods;
+    var isBuildActive = activePeriods.Count == 0 || activePeriods.Contains("Build", StringComparer.OrdinalIgnoreCase);
+    var isEventActive = activePeriods.Count == 0 || activePeriods.Contains("Event", StringComparer.OrdinalIgnoreCase);
+    var isStrikeActive = activePeriods.Count == 0 || activePeriods.Contains("Strike", StringComparer.OrdinalIgnoreCase);
+    var allPhasesActive = isBuildActive && isEventActive && isStrikeActive;
 
     // Build sort toggle URLs preserving all current filters
     var sortBaseRoute = new Dictionary<string, string?>();
     if (Model.FilterDepartmentId.HasValue)
         sortBaseRoute["departmentId"] = Model.FilterDepartmentId.Value.ToString();
-    if (!string.IsNullOrEmpty(Model.FilterFromDate))
-        sortBaseRoute["fromDate"] = Model.FilterFromDate;
-    if (!string.IsNullOrEmpty(Model.FilterToDate))
-        sortBaseRoute["toDate"] = Model.FilterToDate;
-    if (!string.IsNullOrEmpty(Model.FilterPeriod))
-        sortBaseRoute["period"] = Model.FilterPeriod;
-    for (var i = 0; i < Model.FilterTagIds.Count; i++)
-        sortBaseRoute[$"tags[{i}]"] = Model.FilterTagIds[i].ToString();
+    for (var si = 0; si < Model.FilterTagIds.Count; si++)
+        sortBaseRoute[$"tags[{si}]"] = Model.FilterTagIds[si].ToString();
+    for (var si = 0; si < activePeriods.Count; si++)
+        sortBaseRoute[$"periods[{si}]"] = activePeriods[si];
     var urgencySortRoute = new Dictionary<string, string?>(sortBaseRoute) { ["sort"] = "urgency" };
-    var deptSortRoute = new Dictionary<string, string?>(sortBaseRoute);
+    var deptSortRoute = new Dictionary<string, string?>(sortBaseRoute) { ["sort"] = "department" };
 }
 
 <style>
@@ -44,19 +41,86 @@
     }
 </style>
 <div class="container py-4">
-    <div class="d-flex justify-content-between align-items-center mb-4">
-        <h2>@Localizer["Shifts_BrowseTitle"]</h2>
+    @* === Tabs: Browse / My Shifts === *@
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <ul class="nav nav-tabs shifts-nav-tabs border-0" role="tablist">
+            <li class="nav-item">
+                <a class="nav-link active" href="#">@Localizer["Shifts_BrowseTitle"]</a>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link" asp-action="Mine">
+                    @Localizer["Shifts_MyShiftsTitle"]
+                    @if (Model.MySignupCount > 0)
+                    {
+                        <span class="badge bg-primary ms-1">@Model.MySignupCount</span>
+                    }
+                </a>
+            </li>
+        </ul>
         <div class="d-flex gap-2">
             <vc:access-matrix section="Shifts" />
-            <a asp-controller="ShiftDashboard" asp-action="Index" class="btn btn-outline-warning" authorize-policy="ShiftDepartmentManager"><i class="fa-solid fa-gauge-high me-1"></i>Dashboard <i class="fa-solid fa-lock auth-lock-icon"></i></a>
-            <a asp-action="Settings" class="btn btn-outline-secondary" authorize-policy="AdminOnly"><i class="fa-solid fa-gear me-1"></i>Settings <i class="fa-solid fa-lock auth-lock-icon"></i></a>
-            <a asp-action="Mine" class="btn btn-outline-primary">@Localizer["Shifts_MyShiftsTitle"]</a>
+            <a asp-controller="ShiftDashboard" asp-action="Index" class="btn btn-outline-warning btn-sm" authorize-policy="ShiftDepartmentManager"><i class="fa-solid fa-gauge-high me-1"></i>Dashboard <i class="fa-solid fa-lock auth-lock-icon"></i></a>
+            <a asp-action="Settings" class="btn btn-outline-secondary btn-sm" authorize-policy="AdminOnly"><i class="fa-solid fa-gear me-1"></i>Settings <i class="fa-solid fa-lock auth-lock-icon"></i></a>
         </div>
     </div>
 
     <vc:temp-data-alerts />
 
-    <form method="get" class="row g-2 mb-4 align-items-end">
+    @* === Hero Banner === *@
+    <div class="shifts-hero-banner mb-4">
+        <div class="d-flex align-items-center gap-3">
+            <div class="shifts-hero-icon">
+                <i class="fa-solid fa-handshake-angle fa-2x"></i>
+            </div>
+            <div>
+                <strong>@Localizer["Shifts_HeroTitle"]</strong>
+                <p class="mb-0 small text-muted">@Localizer["Shifts_HeroSubtitle"]</p>
+            </div>
+            <button type="button" class="btn btn-sm btn-outline-secondary ms-auto" data-bs-toggle="modal" data-bs-target="#sectionHelp-Shifts">
+                <i class="fa-solid fa-circle-info me-1"></i>@Localizer["Shifts_LearnMore"]
+            </button>
+        </div>
+    </div>
+
+    @* === Phase Multiselect Cards === *@
+    <div class="row g-2 mb-3">
+        <div class="col-md-4">
+            <div class="phase-card phase-card-build @(isBuildActive ? "phase-card-active" : "")" data-phase="Build">
+                <div class="form-check mb-0">
+                    <input class="form-check-input phase-check" type="checkbox" id="phase-build" value="Build" @(isBuildActive ? "checked" : "") />
+                    <label class="form-check-label" for="phase-build">
+                        <span class="fw-semibold">@Localizer["Shifts_SetUp"]</span>
+                        <br /><small class="text-muted">@buildFrom.ToDisplayShiftDate() — @buildTo.ToDisplayShiftDate()</small>
+                    </label>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-4">
+            <div class="phase-card phase-card-event @(isEventActive ? "phase-card-active" : "")" data-phase="Event">
+                <div class="form-check mb-0">
+                    <input class="form-check-input phase-check" type="checkbox" id="phase-event" value="Event" @(isEventActive ? "checked" : "") />
+                    <label class="form-check-label" for="phase-event">
+                        <span class="fw-semibold">@Localizer["Shifts_Event"]</span>
+                        <br /><small class="text-muted">@eventFrom.ToDisplayShiftDate() — @eventTo.ToDisplayShiftDate()</small>
+                    </label>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-4">
+            <div class="phase-card phase-card-strike @(isStrikeActive ? "phase-card-active" : "")" data-phase="Strike">
+                <div class="form-check mb-0">
+                    <input class="form-check-input phase-check" type="checkbox" id="phase-strike" value="Strike" @(isStrikeActive ? "checked" : "") />
+                    <label class="form-check-label" for="phase-strike">
+                        <span class="fw-semibold">@Localizer["Shifts_Strike"]</span>
+                        <br /><small class="text-muted">@strikeFrom.ToDisplayShiftDate() — @strikeTo.ToDisplayShiftDate()</small>
+                    </label>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    @* === Filters Row: Department + Sort === *@
+    <form method="get" id="shifts-filter-form" class="row g-2 mb-3 align-items-end">
         <div class="col-auto">
             <label class="form-label mb-1">@Localizer["Shifts_Department"]</label>
             <select name="departmentId" class="form-select form-select-sm">
@@ -68,56 +132,35 @@
             </select>
         </div>
         <div class="col-auto">
-            <label class="form-label mb-1">@Localizer["Shifts_From"]</label>
-            <input type="date" name="fromDate" class="form-control form-control-sm" value="@Model.FilterFromDate"
-                   min="@pickerMin.ToString("yyyy-MM-dd", null)"
-                   max="@pickerMax.ToString("yyyy-MM-dd", null)" />
+            <div class="btn-group" role="group" aria-label="Sort order">
+                <a href="@Url.Action("Index", urgencySortRoute)"
+                   class="btn btn-sm @(isUrgencySort ? "btn-warning" : "btn-outline-warning")" title="@Localizer["Shifts_SortUrgencyHint"]">
+                    <i class="fa-solid fa-fire me-1"></i>@Localizer["Shifts_SortUrgency"]
+                </a>
+                <a href="@Url.Action("Index", deptSortRoute)"
+                   class="btn btn-sm @(!isUrgencySort ? "btn-warning" : "btn-outline-warning")" title="@Localizer["Shifts_SortDeptHint"]">
+                    <i class="fa-solid fa-building me-1"></i>@Localizer["Shifts_SortDept"]
+                </a>
+            </div>
         </div>
-        <div class="col-auto">
-            <label class="form-label mb-1">@Localizer["Shifts_To"]</label>
-            <input type="date" name="toDate" class="form-control form-control-sm" value="@Model.FilterToDate"
-                   min="@pickerMin.ToString("yyyy-MM-dd", null)"
-                   max="@pickerMax.ToString("yyyy-MM-dd", null)" />
-        </div>
-        @if (Model.FilterDepartmentId.HasValue || !string.IsNullOrEmpty(Model.FilterFromDate) || !string.IsNullOrEmpty(Model.FilterToDate) || !string.IsNullOrEmpty(Model.FilterPeriod) || Model.FilterTagIds.Count > 0 || !string.IsNullOrEmpty(Model.Sort))
+        @if (Model.FilterDepartmentId.HasValue || activePeriods.Count > 0 && !allPhasesActive || Model.FilterTagIds.Count > 0 || Model.Sort == "department")
         {
             <div class="col-auto">
                 <a asp-action="Index" class="btn btn-sm btn-outline-secondary">@Localizer["Shifts_ClearFilters"]</a>
             </div>
         }
-        <input type="hidden" name="period" value="@Model.FilterPeriod" />
         <input type="hidden" name="sort" value="@Model.Sort" />
         @foreach (var tagId in Model.FilterTagIds)
         {
             <input type="hidden" name="tags" value="@tagId" />
         }
+        @foreach (var p in activePeriods)
+        {
+            <input type="hidden" name="periods" value="@p" />
+        }
     </form>
-    @{
-        var activePeriod = Model.FilterPeriod ?? "";
-    }
-    <div class="d-flex flex-wrap gap-3 mb-3 align-items-center">
-        <div class="btn-group" role="group" aria-label="Period filter">
-            <a href="@Url.Action("Index", new { departmentId = Model.FilterDepartmentId, fromDate = Model.FilterFromDate, toDate = Model.FilterToDate, sort = Model.Sort })"
-               class="btn btn-sm @(string.IsNullOrEmpty(activePeriod) ? "btn-primary" : "btn-outline-primary")">@Localizer["Shifts_All"]</a>
-            <a href="@Url.Action("Index", new { departmentId = Model.FilterDepartmentId, period = "Build", sort = Model.Sort })"
-               class="btn btn-sm @(activePeriod == "Build" ? "btn-info" : "btn-outline-info")">@Localizer["Shifts_SetUp"]</a>
-            <a href="@Url.Action("Index", new { departmentId = Model.FilterDepartmentId, period = "Event", sort = Model.Sort })"
-               class="btn btn-sm @(activePeriod == "Event" ? "btn-success" : "btn-outline-success")">@Localizer["Shifts_Event"]</a>
-            <a href="@Url.Action("Index", new { departmentId = Model.FilterDepartmentId, period = "Strike", sort = Model.Sort })"
-               class="btn btn-sm @(activePeriod == "Strike" ? "btn-secondary" : "btn-outline-secondary")">@Localizer["Shifts_Strike"]</a>
-        </div>
-        <div class="btn-group" role="group" aria-label="Sort order">
-            <a href="@Url.Action("Index", urgencySortRoute)"
-               class="btn btn-sm @(isUrgencySort ? "btn-warning" : "btn-outline-warning")" title="@Localizer["Shifts_SortUrgencyHint"]">
-                <i class="fa-solid fa-fire me-1"></i>@Localizer["Shifts_SortUrgency"]
-            </a>
-            <a href="@Url.Action("Index", deptSortRoute)"
-               class="btn btn-sm @(!isUrgencySort ? "btn-warning" : "btn-outline-warning")" title="@Localizer["Shifts_SortDeptHint"]">
-                <i class="fa-solid fa-building me-1"></i>@Localizer["Shifts_SortDept"]
-            </a>
-        </div>
-    </div>
 
+    @* === Tag Filters with Preferences as Defaults === *@
     @if (Model.AllTags.Count > 0)
     {
         <div class="mb-3">
@@ -126,81 +169,105 @@
                 @foreach (var tag in Model.AllTags)
                 {
                     var isActive = Model.FilterTagIds.Contains(tag.Id);
+                    var isPreferred = Model.UserPreferredTagIds.Contains(tag.Id);
                     var newTagIds = isActive
                         ? Model.FilterTagIds.Where(id => id != tag.Id).ToList()
                         : Model.FilterTagIds.Concat(new[] { tag.Id }).ToList();
                     var routeValues = new Dictionary<string, string?>();
                     if (Model.FilterDepartmentId.HasValue)
                         routeValues["departmentId"] = Model.FilterDepartmentId.Value.ToString();
-                    if (!string.IsNullOrEmpty(Model.FilterFromDate))
-                        routeValues["fromDate"] = Model.FilterFromDate;
-                    if (!string.IsNullOrEmpty(Model.FilterToDate))
-                        routeValues["toDate"] = Model.FilterToDate;
-                    if (!string.IsNullOrEmpty(Model.FilterPeriod))
-                        routeValues["period"] = Model.FilterPeriod;
                     if (!string.IsNullOrEmpty(Model.Sort))
                         routeValues["sort"] = Model.Sort;
                     for (var i = 0; i < newTagIds.Count; i++)
                         routeValues[$"tags[{i}]"] = newTagIds[i].ToString();
+                    for (var i = 0; i < activePeriods.Count; i++)
+                        routeValues[$"periods[{i}]"] = activePeriods[i];
                     @if (isActive)
                     {
                         <a href="@Url.Action("Index", routeValues)" class="btn btn-sm btn-primary">
+                            @if (isPreferred) { <i class="fa-solid fa-star me-1"></i> }
                             @tag.Name <i class="fa-solid fa-xmark ms-1"></i>
                         </a>
                     }
                     else
                     {
-                        <a href="@Url.Action("Index", routeValues)" class="btn btn-sm btn-outline-primary">
+                        <a href="@Url.Action("Index", routeValues)" class="btn btn-sm btn-outline-primary @(isPreferred ? "shift-tag-preferred" : "")">
+                            @if (isPreferred) { <i class="fa-solid fa-star me-1 text-warning"></i> }
                             @tag.Name
                         </a>
                     }
                 }
             </div>
-        </div>
-    }
-
-    @if (Model.AllTags.Count > 0)
-    {
-        <div class="mb-3">
-            <button class="btn btn-sm btn-outline-secondary" type="button" data-bs-toggle="collapse" data-bs-target="#tag-preferences-panel">
-                <i class="fa-solid fa-sliders me-1"></i>@Localizer["Shifts_SetPreferences"]
-                @if (Model.UserPreferredTagIds.Count > 0)
-                {
-                    <span class="badge bg-primary ms-1">@Model.UserPreferredTagIds.Count</span>
-                }
-            </button>
-            <div class="collapse @(Model.UserPreferredTagIds.Count == 0 ? "" : "")" id="tag-preferences-panel">
-                <div class="card card-body mt-2">
-                    <p class="small text-muted mb-2">@Localizer["Shifts_PreferencesHelp"] <i class="fa-solid fa-star text-warning"></i></p>
-                    <form asp-action="SaveTagPreferences" method="post">
-                        @Html.AntiForgeryToken()
-                        <div class="d-flex flex-wrap gap-2 mb-2">
-                            @foreach (var tag in Model.AllTags)
-                            {
-                                var isPreferred = Model.UserPreferredTagIds.Contains(tag.Id);
-                                <div class="form-check">
-                                    <input class="form-check-input" type="checkbox" name="tagIds" value="@tag.Id" id="pref-@tag.Id.ToString("N")"
-                                           @if (isPreferred) { <text>checked</text> } />
-                                    <label class="form-check-label" for="pref-@tag.Id.ToString("N")">@tag.Name</label>
-                                </div>
-                            }
-                        </div>
-                        <button type="submit" class="btn btn-sm btn-primary">@Localizer["Shifts_SavePreferences"]</button>
-                    </form>
+            <div class="mt-2">
+                <button class="btn btn-sm btn-link text-muted p-0" type="button" data-bs-toggle="collapse" data-bs-target="#tag-preferences-panel">
+                    <i class="fa-solid fa-sliders me-1"></i>@Localizer["Shifts_EditPreferences"]
+                </button>
+                <div class="collapse" id="tag-preferences-panel">
+                    <div class="card card-body mt-2">
+                        <p class="small text-muted mb-2">@Localizer["Shifts_PreferencesHelp"] <i class="fa-solid fa-star text-warning"></i></p>
+                        <form asp-action="SaveTagPreferences" method="post">
+                            @Html.AntiForgeryToken()
+                            <div class="d-flex flex-wrap gap-2 mb-2">
+                                @foreach (var tag in Model.AllTags)
+                                {
+                                    var isPreferred = Model.UserPreferredTagIds.Contains(tag.Id);
+                                    <div class="form-check">
+                                        <input class="form-check-input" type="checkbox" name="tagIds" value="@tag.Id" id="pref-@tag.Id.ToString("N")"
+                                               @if (isPreferred) { <text>checked</text> } />
+                                        <label class="form-check-label" for="pref-@tag.Id.ToString("N")">@tag.Name</label>
+                                    </div>
+                                }
+                            </div>
+                            <button type="submit" class="btn btn-sm btn-primary">@Localizer["Shifts_SavePreferences"]</button>
+                        </form>
+                    </div>
                 </div>
             </div>
         </div>
     }
 
     <script>
+        // Department dropdown auto-submit
         document.querySelectorAll('[name="departmentId"]').forEach(function(el) {
             el.addEventListener('change', function() { this.form.submit(); });
         });
-        document.querySelectorAll('[name="fromDate"], [name="toDate"]').forEach(function(el) {
-            el.addEventListener('change', function() {
-                // Dates take precedence — clear the period tab so results aren't constrained
-                this.form.querySelector('[name="period"]').value = '';
-                this.form.submit();
+
+        // Phase multiselect: toggle checkboxes and navigate
+        document.querySelectorAll('.phase-check').forEach(function(cb) {
+            cb.addEventListener('change', function() {
+                var checked = Array.from(document.querySelectorAll('.phase-check:checked')).map(function(c) { return c.value; });
+                // If all unchecked, re-select all (= no filter)
+                if (checked.length === 0) {
+                    document.querySelectorAll('.phase-check').forEach(function(c) { c.checked = true; });
+                    checked = ['Build', 'Event', 'Strike'];
+                }
+                // Build URL with current filters
+                var params = new URLSearchParams();
+                @if (Model.FilterDepartmentId.HasValue) {
+                    <text>params.set('departmentId', '@Model.FilterDepartmentId.Value');</text>
+                }
+                @if (!string.IsNullOrEmpty(Model.Sort)) {
+                    <text>params.set('sort', '@Model.Sort');</text>
+                }
+                // Only add periods if not all 3 are selected
+                if (checked.length < 3) {
+                    checked.forEach(function(p) { params.append('periods', p); });
+                }
+                @foreach (var tagId in Model.FilterTagIds) {
+                    <text>params.append('tags', '@tagId');</text>
+                }
+                var url = '@Url.Action("Index")' + '?' + params.toString();
+                window.location.href = url;
+            });
+        });
+
+        // Clicking on phase card toggles its checkbox
+        document.querySelectorAll('.phase-card').forEach(function(card) {
+            card.addEventListener('click', function(e) {
+                if (e.target.closest('.form-check-input')) return; // Let native checkbox handle
+                var cb = this.querySelector('.phase-check');
+                cb.checked = !cb.checked;
+                cb.dispatchEvent(new Event('change'));
             });
         });
     </script>

--- a/src/Humans.Web/Views/Shifts/Index.cshtml
+++ b/src/Humans.Web/Views/Shifts/Index.cshtml
@@ -44,11 +44,11 @@
     @* === Tabs: Browse / My Shifts === *@
     <div class="d-flex justify-content-between align-items-center mb-3">
         <ul class="nav nav-tabs shifts-nav-tabs border-0" role="tablist">
-            <li class="nav-item">
-                <a class="nav-link active" href="#">@Localizer["Shifts_BrowseTitle"]</a>
+            <li class="nav-item" role="presentation">
+                <a class="nav-link active" asp-action="Index" role="tab" aria-selected="true" aria-current="page">@Localizer["Shifts_BrowseTitle"]</a>
             </li>
-            <li class="nav-item">
-                <a class="nav-link" asp-action="Mine">
+            <li class="nav-item" role="presentation">
+                <a class="nav-link" asp-action="Mine" role="tab" aria-selected="false">
                     @Localizer["Shifts_MyShiftsTitle"]
                     @if (Model.MySignupCount > 0)
                     {
@@ -268,7 +268,8 @@
         // Clicking on phase card toggles its checkbox
         document.querySelectorAll('.phase-card').forEach(function(card) {
             card.addEventListener('click', function(e) {
-                if (e.target.closest('.form-check-input')) return; // Let native checkbox handle
+                // Let native checkbox/label behavior handle clicks on the input or its label
+                if (e.target.closest('.form-check-input, .form-check-label')) return;
                 var cb = this.querySelector('.phase-check');
                 cb.checked = !cb.checked;
                 cb.dispatchEvent(new Event('change'));
@@ -370,6 +371,7 @@
                                 FilterFromDate = Model.FilterFromDate,
                                 FilterToDate = Model.FilterToDate,
                                 FilterPeriod = Model.FilterPeriod,
+                                FilterPeriods = Model.FilterPeriods,
                                 FilterTagIds = Model.FilterTagIds
                             })
                         }
@@ -387,6 +389,7 @@
                                 FilterFromDate = Model.FilterFromDate,
                                 FilterToDate = Model.FilterToDate,
                                 FilterPeriod = Model.FilterPeriod,
+                                FilterPeriods = Model.FilterPeriods,
                                 FilterTagIds = Model.FilterTagIds
                             })
                         }
@@ -515,6 +518,7 @@
                                                     FilterFromDate = Model.FilterFromDate,
                                                     FilterToDate = Model.FilterToDate,
                                                     FilterPeriod = Model.FilterPeriod,
+                                                    FilterPeriods = Model.FilterPeriods,
                                                     FilterTagIds = Model.FilterTagIds
                                                 })
                                             }
@@ -532,6 +536,7 @@
                                                     FilterFromDate = Model.FilterFromDate,
                                                     FilterToDate = Model.FilterToDate,
                                                     FilterPeriod = Model.FilterPeriod,
+                                                    FilterPeriods = Model.FilterPeriods,
                                                     FilterTagIds = Model.FilterTagIds
                                                 })
                                             }

--- a/src/Humans.Web/Views/Shifts/Mine.cshtml
+++ b/src/Humans.Web/Views/Shifts/Mine.cshtml
@@ -33,16 +33,16 @@
 }
 
 <div class="container py-4">
-    <nav aria-label="breadcrumb">
-        <ol class="breadcrumb">
-            <li class="breadcrumb-item"><a asp-action="Index">Shifts</a></li>
-            <li class="breadcrumb-item active" aria-current="page">My Shifts</li>
-        </ol>
-    </nav>
-
-    <div class="d-flex justify-content-between align-items-center mb-4">
-        <h2>@Localizer["Shifts_MyShiftsTitle"]</h2>
-        <a asp-action="Index" class="btn btn-outline-primary">@Localizer["Shifts_BrowseTitle"]</a>
+    @* === Tabs: Browse / My Shifts === *@
+    <div class="mb-3">
+        <ul class="nav nav-tabs shifts-nav-tabs border-0" role="tablist">
+            <li class="nav-item">
+                <a class="nav-link" asp-action="Index">@Localizer["Shifts_BrowseTitle"]</a>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link active" href="#">@Localizer["Shifts_MyShiftsTitle"]</a>
+            </li>
+        </ul>
     </div>
 
     <vc:temp-data-alerts />

--- a/src/Humans.Web/Views/Shifts/Mine.cshtml
+++ b/src/Humans.Web/Views/Shifts/Mine.cshtml
@@ -36,11 +36,11 @@
     @* === Tabs: Browse / My Shifts === *@
     <div class="mb-3">
         <ul class="nav nav-tabs shifts-nav-tabs border-0" role="tablist">
-            <li class="nav-item">
-                <a class="nav-link" asp-action="Index">@Localizer["Shifts_BrowseTitle"]</a>
+            <li class="nav-item" role="presentation">
+                <a class="nav-link" asp-action="Index" role="tab" aria-selected="false">@Localizer["Shifts_BrowseTitle"]</a>
             </li>
-            <li class="nav-item">
-                <a class="nav-link active" href="#">@Localizer["Shifts_MyShiftsTitle"]</a>
+            <li class="nav-item" role="presentation">
+                <a class="nav-link active" asp-action="Mine" role="tab" aria-selected="true" aria-current="page">@Localizer["Shifts_MyShiftsTitle"]</a>
             </li>
         </ul>
     </div>

--- a/src/Humans.Web/wwwroot/css/site.css
+++ b/src/Humans.Web/wwwroot/css/site.css
@@ -1742,3 +1742,66 @@ tr[data-href] {
         font-size: 0.6rem;
     }
 }
+
+/* --- Shifts Header Redesign --- */
+
+/* Tabs — Renaissance style */
+.shifts-nav-tabs .nav-link {
+    color: var(--h-aged-ink-light);
+    border: none;
+    border-bottom: 2px solid transparent;
+    padding: 0.5rem 1rem;
+    font-family: 'Cormorant Garamond', serif;
+    font-size: 1.25rem;
+    font-weight: 600;
+}
+.shifts-nav-tabs .nav-link:hover {
+    color: var(--h-aged-ink);
+    border-bottom-color: var(--h-gold-light);
+}
+.shifts-nav-tabs .nav-link.active {
+    color: var(--h-aged-ink);
+    border-bottom-color: var(--h-gold);
+    background: transparent;
+}
+
+/* Hero Banner */
+.shifts-hero-banner {
+    background: var(--h-parchment-light, #faf3e6);
+    border: 1px solid var(--h-parchment-dark, #e8d4ab);
+    border-radius: 0.5rem;
+    padding: 1rem 1.25rem;
+}
+.shifts-hero-icon {
+    color: var(--h-gold, #c9a96e);
+}
+
+/* Phase Multiselect Cards */
+.phase-card {
+    border: 2px solid var(--h-parchment-dark, #e8d4ab);
+    border-radius: 0.5rem;
+    padding: 0.75rem 1rem;
+    cursor: pointer;
+    transition: border-color 0.2s, background-color 0.2s;
+    background: var(--h-warm-white, #fefaf3);
+}
+.phase-card:hover {
+    border-color: var(--h-gold-light, #d9c08e);
+}
+.phase-card-active.phase-card-build {
+    border-color: var(--bs-info, #0dcaf0);
+    background-color: rgba(13, 202, 240, 0.06);
+}
+.phase-card-active.phase-card-event {
+    border-color: var(--bs-success, #198754);
+    background-color: rgba(25, 135, 84, 0.06);
+}
+.phase-card-active.phase-card-strike {
+    border-color: var(--bs-secondary, #6c757d);
+    background-color: rgba(108, 117, 125, 0.06);
+}
+
+/* Tag preferred highlight */
+.shift-tag-preferred {
+    border-color: var(--h-gold-light, #d9c08e);
+}

--- a/src/Humans.Web/wwwroot/css/site.css
+++ b/src/Humans.Web/wwwroot/css/site.css
@@ -1789,16 +1789,52 @@ tr[data-href] {
     border-color: var(--h-gold-light, #d9c08e);
 }
 .phase-card-active.phase-card-build {
-    border-color: var(--bs-info, #0dcaf0);
-    background-color: rgba(13, 202, 240, 0.06);
+    border-color: var(--h-blue-muted, #5b7d8f);
+    background-color: rgba(91, 125, 143, 0.08);
 }
 .phase-card-active.phase-card-event {
-    border-color: var(--bs-success, #198754);
-    background-color: rgba(25, 135, 84, 0.06);
+    border-color: var(--h-sage, #6b8f71);
+    background-color: rgba(107, 143, 113, 0.08);
 }
 .phase-card-active.phase-card-strike {
-    border-color: var(--bs-secondary, #6c757d);
-    background-color: rgba(108, 117, 125, 0.06);
+    border-color: var(--h-sepia-light, #a69178);
+    background-color: rgba(166, 145, 120, 0.08);
+}
+
+/* Phase card checkbox colors — match the phase border */
+.phase-card-build .form-check-input:checked {
+    background-color: var(--h-blue-muted, #5b7d8f);
+    border-color: var(--h-blue-muted, #5b7d8f);
+}
+.phase-card-event .form-check-input:checked {
+    background-color: var(--h-sage, #6b8f71);
+    border-color: var(--h-sage, #6b8f71);
+}
+.phase-card-strike .form-check-input:checked {
+    background-color: var(--h-sepia-light, #a69178);
+    border-color: var(--h-sepia-light, #a69178);
+}
+
+/* Shifts toast — bottom-right, auto-dismiss */
+.shifts-toast-container {
+    position: fixed;
+    bottom: 1.5rem;
+    right: 1.5rem;
+    z-index: 1080;
+}
+.shifts-toast-container .alert {
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    min-width: 280px;
+    animation: shifts-toast-in 0.3s ease-out;
+}
+@keyframes shifts-toast-in {
+    from { opacity: 0; transform: translateY(1rem); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+/* Hide the info icon button but keep the modal markup accessible */
+.shifts-hidden-info-btn > button {
+    display: none;
 }
 
 /* Tag preferred highlight */


### PR DESCRIPTION
## Summary
- Replace page title + button with Browse/My Shifts nav-tabs (badge shows signup count)
- Add hero onboarding banner with "Learn more" linking to existing info modal
- Replace single-select period buttons + date pickers with multiselect phase cards (checkboxes, date ranges displayed)
- Default sort changed to "Most needed" instead of "By department"
- Tag pills show star icon for user-preferred tags, subtle "Edit preferences" link
- Controller supports new `periods` query param (multiselect) alongside legacy `period` param
- Localization keys added across all 6 locales (en/es/ca/de/fr/it)

## Test plan
- [ ] Browse page loads with tabs, hero banner, and 3 phase cards (all checked)
- [ ] Unchecking a phase card filters shifts correctly
- [ ] Unchecking all 3 re-selects all (no filter)
- [ ] Non-contiguous selection (e.g., Set-up + Strike) excludes Event shifts
- [ ] "My Shifts" tab navigates to Mine page with matching tabs
- [ ] Badge on "My Shifts" tab shows correct signup count
- [ ] "Learn more" opens the section help modal
- [ ] Default sort is "Most needed" (fire icon active)
- [ ] Tag pills with user preferences show star icon
- [ ] Department dropdown auto-submits
- [ ] "Clear filters" resets everything
- [ ] All 6 locales render new strings correctly
- [ ] Preview deploys and compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)