### PR TITLE
refactor(camps): drop duplicate camp/user fetches on Details views

### DIFF
--- a/src/Humans.Application/Interfaces/Camps/ICampService.cs
+++ b/src/Humans.Application/Interfaces/Camps/ICampService.cs
@@ -80,9 +80,7 @@ public interface ICampService
     Task RemoveHistoricalNameAsync(Guid historicalNameId, CancellationToken cancellationToken = default);
 
     // Cross-service queries (used by CityPlanningService)
-    Task<SoundZone?> GetCampSeasonSoundZoneAsync(Guid campSeasonId, CancellationToken cancellationToken = default);
-    Task<string?> GetCampSeasonNameAsync(Guid campSeasonId, CancellationToken cancellationToken = default);
-    Task<CampSeasonInfo?> GetCampSeasonInfoAsync(Guid campSeasonId, CancellationToken cancellationToken = default);
+    Task<CampSeason?> GetCampSeasonByIdAsync(Guid campSeasonId, CancellationToken cancellationToken = default);
     Task<IReadOnlyDictionary<Guid, CampSeasonDisplayData>> GetCampSeasonDisplayDataForYearAsync(int year, CancellationToken cancellationToken = default);
     Task<IReadOnlyList<CampSeasonBrief>> GetCampSeasonBriefsForYearAsync(int year, CancellationToken cancellationToken = default);
     Task<Guid?> GetCampLeadSeasonIdForYearAsync(Guid userId, int year, CancellationToken cancellationToken = default);
@@ -109,111 +107,56 @@ public interface ICampService
     // Camp membership per season (issue nobodies-collective#488)
     // ==========================================================================
 
-    /// <summary>
-    /// Human requests to join a camp for the currently-open season. No-op if
-    /// an active or pending row already exists — the existing row's id is
-    /// returned with an <c>Already*</c> outcome. Handles concurrent duplicate
-    /// submissions idempotently.
-    /// </summary>
+    /// <summary>Idempotent — returns existing row's id with an <c>Already*</c> outcome if one exists.</summary>
     Task<CampMemberRequestResult> RequestCampMembershipAsync(
         Guid campId, Guid userId, CancellationToken cancellationToken = default);
 
-    /// <summary>
-    /// Lead / CampAdmin approves a pending request. Scoped to the authorizing
-    /// camp: throws if the membership's season belongs to a different camp.
-    /// Sends <c>CampMembershipApproved</c> notification to the requester.
-    /// </summary>
+    /// <summary>Throws if the membership's season belongs to a different camp than <paramref name="scopedCampId"/>.</summary>
     Task ApproveCampMemberAsync(
         Guid scopedCampId, Guid campMemberId, Guid approvedByUserId,
         CancellationToken cancellationToken = default);
 
-    /// <summary>
-    /// Lead / CampAdmin rejects a pending request. Scoped to the authorizing
-    /// camp: throws if the membership's season belongs to a different camp.
-    /// Sends <c>CampMembershipRejected</c> notification to the requester.
-    /// </summary>
+    /// <summary>Throws if the membership's season belongs to a different camp than <paramref name="scopedCampId"/>.</summary>
     Task RejectCampMemberAsync(
         Guid scopedCampId, Guid campMemberId, Guid rejectedByUserId,
         CancellationToken cancellationToken = default);
 
-    /// <summary>
-    /// Lead / CampAdmin removes an active member. Scoped to the authorizing camp.
-    /// </summary>
+    /// <summary>Throws if the membership's season belongs to a different camp than <paramref name="scopedCampId"/>.</summary>
     Task RemoveCampMemberAsync(
         Guid scopedCampId, Guid campMemberId, Guid removedByUserId,
         CancellationToken cancellationToken = default);
 
-    /// <summary>
-    /// Lead-driven add: creates a CampMember with Status=Active directly, bypassing
-    /// the request/approve flow. Used by the "Add active member" button on the camp Edit
-    /// page. Idempotent — if an Active membership already exists, returns its id without
-    /// auditing again. Authorization is the caller's responsibility (CampOperationRequirement.Manage).
-    /// </summary>
+    /// <summary>Bypasses the request/approve flow. Idempotent. Caller authorizes.</summary>
     Task<Guid> AddCampMemberAsLeadAsync(Guid campSeasonId, Guid userId, Guid actorUserId, CancellationToken cancellationToken = default);
 
-    /// <summary>
-    /// Human withdraws their own pending request. Scoped to the caller's user id.
-    /// </summary>
+    /// <summary>Throws if <paramref name="userId"/> is not the row's owner.</summary>
     Task WithdrawCampMembershipRequestAsync(
         Guid campMemberId, Guid userId, CancellationToken cancellationToken = default);
 
-    /// <summary>
-    /// Human leaves their own active membership. Scoped to the caller's user id.
-    /// </summary>
+    /// <summary>Throws if <paramref name="userId"/> is not the row's owner.</summary>
     Task LeaveCampAsync(
         Guid campMemberId, Guid userId, CancellationToken cancellationToken = default);
 
-    /// <summary>
-    /// Gets the current user's membership state for a camp's open-season
-    /// (or <c>NoOpenSeason</c> if the camp has no Active/Full season this year).
-    /// </summary>
+    /// <summary>Returns <c>NoOpenSeason</c> if no Active/Full season exists for the public year.</summary>
     Task<CampMembershipState> GetMembershipStateForCampAsync(
         Guid campId, Guid userId, CancellationToken cancellationToken = default);
 
-    /// <summary>
-    /// Lists Pending + Active members for a given camp season, stitched with
-    /// display names via <c>IUserService</c>. Privileged view (no authorization
-    /// inside — caller must gate).
-    /// </summary>
+    /// <summary>Privileged — caller must authorize.</summary>
     Task<CampMemberListData> GetCampMembersAsync(
         Guid campSeasonId, CancellationToken cancellationToken = default);
 
-    /// <summary>
-    /// Returns the raw <see cref="CampMember"/> rows (Active + Pending) for a
-    /// given camp season — no display-name stitching, no lead union. Used by
-    /// the Camp Edit page to build the per-camp roles picker (which needs
-    /// CampMember.Id and UserId for active members only). Privileged view
-    /// (no authorization inside — caller must gate).
-    /// </summary>
+    /// <summary>Raw rows (no display-name stitching, no lead union). Privileged — caller must authorize.</summary>
     Task<IReadOnlyList<CampMember>> GetSeasonMembersAsync(
         Guid campSeasonId, CancellationToken cancellationToken = default);
 
-    /// <summary>
-    /// Lists Active/Pending memberships for a human, grouped by year. Used for
-    /// the human's own profile dashboard (MyCamps).
-    /// </summary>
     Task<IReadOnlyList<CampMembershipSummary>> GetCampMembershipsForUserAsync(
         Guid userId, CancellationToken cancellationToken = default);
 
-    /// <summary>
-    /// Total number of Pending membership requests across all camps where the
-    /// user is an active lead. Used by the notification meter to show a single
-    /// "N people want to join your camp" counter instead of emitting a stored
-    /// notification per request.
-    /// </summary>
     Task<int> GetPendingMembershipCountForLeadAsync(
         Guid userId, CancellationToken cancellationToken = default);
 
-    /// <summary>
-    /// Returns the season + status + user of a camp member, or null if not found.
-    /// Used by ICampRoleService to enforce the active-member-in-correct-season precondition.
-    /// </summary>
     Task<CampMemberLookup?> GetCampMemberStatusAsync(Guid campMemberId, CancellationToken ct = default);
 
-    /// <summary>
-    /// Returns (CampId, CampName, CampSlug, CampSeasonId) tuples for every camp that has
-    /// any season in the given year. Used by the camp role compliance report.
-    /// </summary>
     Task<IReadOnlyList<(Guid CampId, string CampName, string CampSlug, Guid CampSeasonId)>>
         GetCampSeasonsForComplianceAsync(int year, CancellationToken ct = default);
 }
@@ -451,18 +394,6 @@ public record CampPlacementSummary(
     string Status,
     string? ElectricalGrid);
 
-/// <summary>
-/// Core camp season info for cross-service lookups (CampId + Year).
-/// </summary>
-public record CampSeasonInfo(Guid CampSeasonId, Guid CampId, int Year);
-
-/// <summary>
-/// Display data for camp seasons: name, camp slug, and sound zone.
-/// Used by CityPlanningService for polygon display/export.
-/// </summary>
 public record CampSeasonDisplayData(string Name, string CampSlug, SoundZone? SoundZone, SpaceSize? SpaceRequirement);
 
-/// <summary>
-/// Lightweight camp season summary (ID, name, camp slug) for listing.
-/// </summary>
 public record CampSeasonBrief(Guid CampSeasonId, string Name, string CampSlug, SpaceSize? SpaceRequirement);

--- a/src/Humans.Application/Interfaces/Camps/ICampService.cs
+++ b/src/Humans.Application/Interfaces/Camps/ICampService.cs
@@ -30,6 +30,11 @@ public interface ICampService
         int? preferredYear = null,
         bool fallbackToLatestSeason = true,
         CancellationToken cancellationToken = default);
+    Task<CampDetailData?> BuildCampDetailDataAsync(
+        Camp camp,
+        int? preferredYear = null,
+        bool fallbackToLatestSeason = true,
+        CancellationToken cancellationToken = default);
     Task<CampEditData?> GetCampEditDataAsync(
         Guid campId,
         int? preferredYear = null,

--- a/src/Humans.Application/Interfaces/Camps/ICampService.cs
+++ b/src/Humans.Application/Interfaces/Camps/ICampService.cs
@@ -44,7 +44,6 @@ public interface ICampService
         CampDirectoryFilter? filter = null,
         CancellationToken cancellationToken = default);
     Task<List<Camp>> GetCampsForYearAsync(int year, CancellationToken cancellationToken = default);
-    Task<List<Camp>> GetAllCampsForYearAsync(int year, CancellationToken cancellationToken = default);
     Task<IReadOnlyList<CampPublicSummary>> GetCampPublicSummariesForYearAsync(int year, CancellationToken cancellationToken = default);
     Task<IReadOnlyList<CampPlacementSummary>> GetCampPlacementSummariesForYearAsync(int year, CancellationToken cancellationToken = default);
     Task<CampSettings> GetSettingsAsync(CancellationToken cancellationToken = default);

--- a/src/Humans.Application/Interfaces/Repositories/ICampRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/ICampRepository.cs
@@ -199,21 +199,8 @@ public interface ICampRepository
     // Cross-service queries (CampSeason by id)
     // ==========================================================================
 
-    /// <summary>
-    /// Returns the sound zone of the given season, read-only.
-    /// </summary>
-    Task<SoundZone?> GetSeasonSoundZoneAsync(Guid campSeasonId, CancellationToken ct = default);
-
-    /// <summary>
-    /// Returns the name of the given season, read-only.
-    /// </summary>
-    Task<string?> GetSeasonNameAsync(Guid campSeasonId, CancellationToken ct = default);
-
-    /// <summary>
-    /// Returns core (CampSeasonId, CampId, Year) info, read-only.
-    /// </summary>
-    Task<(Guid CampSeasonId, Guid CampId, int Year)?> GetSeasonInfoAsync(
-        Guid campSeasonId, CancellationToken ct = default);
+    /// <summary>Read-only fetch by id; null if not found.</summary>
+    Task<CampSeason?> GetSeasonByIdAsync(Guid campSeasonId, CancellationToken ct = default);
 
     /// <summary>
     /// Returns a tuple-shaped dictionary keyed by season id for seasons in the

--- a/src/Humans.Application/Interfaces/Repositories/ICampRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/ICampRepository.cs
@@ -39,15 +39,9 @@ public interface ICampRepository
     Task<Camp?> GetByIdAsync(Guid campId, CancellationToken ct = default);
 
     /// <summary>
-    /// Returns camps whose seasons for the year have status Active or Full,
-    /// with seasons (year-filtered), images (sort-ordered), and historical
-    /// names included. Read-only.
-    /// </summary>
-    Task<IReadOnlyList<Camp>> GetPublicCampsForYearAsync(int year, CancellationToken ct = default);
-
-    /// <summary>
     /// Returns every camp that has any season for the year, with seasons
-    /// (year-filtered), images and historical names included. Admin-only.
+    /// (year-filtered), images and historical names included. Read-only.
+    /// Caller-side filter via <c>Camp.IsPublic</c> for the public subset.
     /// </summary>
     Task<IReadOnlyList<Camp>> GetAllCampsForYearAsync(int year, CancellationToken ct = default);
 

--- a/src/Humans.Application/Interfaces/Repositories/ICampRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/ICampRepository.cs
@@ -41,7 +41,7 @@ public interface ICampRepository
     /// <summary>
     /// Returns every camp that has any season for the year, with seasons
     /// (year-filtered), images and historical names included. Read-only.
-    /// Caller-side filter via <c>Camp.IsPublic</c> for the public subset.
+    /// Caller-side filter via <c>Camp.HasPublicSeasonForYear(year)</c> for the public subset.
     /// </summary>
     Task<IReadOnlyList<Camp>> GetAllCampsForYearAsync(int year, CancellationToken ct = default);
 

--- a/src/Humans.Application/Services/Camps/CampRoleService.cs
+++ b/src/Humans.Application/Services/Camps/CampRoleService.cs
@@ -216,7 +216,7 @@ public sealed class CampRoleService : ICampRoleService
         var inserted = await _repo.AddAssignmentAsync(assignment, ct);
         if (!inserted)
         {
-            // I5 fix — repo translated the unique-index race
+            // Repo translated the unique-index race.
             return AssignCampRoleOutcome.AlreadyHoldsRole;
         }
 

--- a/src/Humans.Application/Services/Camps/CampService.cs
+++ b/src/Humans.Application/Services/Camps/CampService.cs
@@ -110,7 +110,6 @@ public sealed class CampService : ICampService, IUserDataContributor
             throw new InvalidOperationException($"The name '{name}' generates a reserved slug.");
         }
 
-        // Ensure unique slug
         var baseSlug = slug;
         var suffix = 2;
         while (await _repo.SlugExistsAsync(slug, cancellationToken))
@@ -613,20 +612,17 @@ public sealed class CampService : ICampService, IUserDataContributor
     public async Task<CampSeason> OptInToSeasonAsync(
         Guid campId, int year, CancellationToken cancellationToken = default)
     {
-        // Verify season is open
         var settings = await GetSettingsAsync(cancellationToken);
         if (!settings.OpenSeasons.Contains(year))
         {
             throw new InvalidOperationException($"Season {year} is not open for registration.");
         }
 
-        // Check no existing season for this year
         if (await _repo.SeasonExistsAsync(campId, year, cancellationToken))
         {
             throw new InvalidOperationException($"Camp already has a season for {year}.");
         }
 
-        // Copy from most recent season
         var previousSeason = await _repo.GetLatestSeasonAsync(campId, cancellationToken)
             ?? throw new InvalidOperationException("No previous season to copy from.");
 
@@ -1111,22 +1107,9 @@ public sealed class CampService : ICampService, IUserDataContributor
     // Cross-service queries (used by CityPlanningService)
     // ==========================================================================
 
-    public Task<SoundZone?> GetCampSeasonSoundZoneAsync(
+    public Task<CampSeason?> GetCampSeasonByIdAsync(
         Guid campSeasonId, CancellationToken cancellationToken = default) =>
-        _repo.GetSeasonSoundZoneAsync(campSeasonId, cancellationToken);
-
-    public Task<string?> GetCampSeasonNameAsync(
-        Guid campSeasonId, CancellationToken cancellationToken = default) =>
-        _repo.GetSeasonNameAsync(campSeasonId, cancellationToken);
-
-    public async Task<CampSeasonInfo?> GetCampSeasonInfoAsync(
-        Guid campSeasonId, CancellationToken cancellationToken = default)
-    {
-        var info = await _repo.GetSeasonInfoAsync(campSeasonId, cancellationToken);
-        return info is null
-            ? null
-            : new CampSeasonInfo(info.Value.CampSeasonId, info.Value.CampId, info.Value.Year);
-    }
+        _repo.GetSeasonByIdAsync(campSeasonId, cancellationToken);
 
     public async Task<IReadOnlyDictionary<Guid, CampSeasonDisplayData>> GetCampSeasonDisplayDataForYearAsync(
         int year, CancellationToken cancellationToken = default)
@@ -1704,12 +1687,8 @@ public sealed class CampService : ICampService, IUserDataContributor
     public async Task<CampMemberListData> GetCampMembersAsync(
         Guid campSeasonId, CancellationToken cancellationToken = default)
     {
-        var infoOpt = await _repo.GetSeasonInfoAsync(campSeasonId, cancellationToken);
-        if (infoOpt is null)
-        {
-            throw new InvalidOperationException("Season not found.");
-        }
-        var info = infoOpt.Value;
+        var season = await _repo.GetSeasonByIdAsync(campSeasonId, cancellationToken)
+            ?? throw new InvalidOperationException("Season not found.");
 
         var members = await _repo.GetSeasonMembersAsync(campSeasonId, cancellationToken);
 
@@ -1721,7 +1700,7 @@ public sealed class CampService : ICampService, IUserDataContributor
         // the CampLead concept into role assignments on CampMember — when that
         // lands, delete this whole union block and drop `IsLead` from the
         // CampMemberRow record.
-        var camp = await _repo.GetByIdAsync(info.CampId, cancellationToken);
+        var camp = await _repo.GetByIdAsync(season.CampId, cancellationToken);
         var activeLeads = camp?.Leads.Where(l => l.LeftAt is null).ToList() ?? new List<CampLead>();
         var leadUserIds = activeLeads.Select(l => l.UserId).ToHashSet();
 
@@ -1769,7 +1748,7 @@ public sealed class CampService : ICampService, IUserDataContributor
             .ThenBy(r => r.DisplayName, StringComparer.OrdinalIgnoreCase)
             .ToList();
 
-        return new CampMemberListData(campSeasonId, info.Year, pending, active);
+        return new CampMemberListData(campSeasonId, season.Year, pending, active);
     }
 
     public Task<IReadOnlyList<CampMember>> GetSeasonMembersAsync(

--- a/src/Humans.Application/Services/Camps/CampService.cs
+++ b/src/Humans.Application/Services/Camps/CampService.cs
@@ -194,6 +194,15 @@ public sealed class CampService : ICampService, IUserDataContributor
             return null;
         }
 
+        return await BuildCampDetailDataAsync(camp, preferredYear, fallbackToLatestSeason, cancellationToken);
+    }
+
+    public async Task<CampDetailData?> BuildCampDetailDataAsync(
+        Camp camp,
+        int? preferredYear = null,
+        bool fallbackToLatestSeason = true,
+        CancellationToken cancellationToken = default)
+    {
         var targetYear = preferredYear;
         if (!targetYear.HasValue)
         {

--- a/src/Humans.Application/Services/Camps/CampService.cs
+++ b/src/Humans.Application/Services/Camps/CampService.cs
@@ -287,7 +287,7 @@ public sealed class CampService : ICampService, IUserDataContributor
         var camps = await GetCampsForYearAsync(year, cancellationToken);
 
         var cards = ApplyCampDirectoryFilter(
-            camps.Where(c => c.IsPublic).Select(camp => CreateCampDirectoryCard(camp, year)),
+            camps.Where(c => c.HasPublicSeasonForYear(year)).Select(camp => CreateCampDirectoryCard(camp, year)),
             filter)
             .OrderBy(card => card.Name, StringComparer.OrdinalIgnoreCase)
             .ToList();
@@ -342,7 +342,7 @@ public sealed class CampService : ICampService, IUserDataContributor
         var camps = await GetCampsForYearAsync(year, cancellationToken);
 
         return camps
-            .Where(c => c.IsPublic)
+            .Where(c => c.HasPublicSeasonForYear(year))
             .Select(camp => CreateCampPublicSummary(camp, year))
             .OrderBy(camp => camp.Name, StringComparer.OrdinalIgnoreCase)
             .ToList();
@@ -355,7 +355,7 @@ public sealed class CampService : ICampService, IUserDataContributor
         var camps = await GetCampsForYearAsync(year, cancellationToken);
 
         return camps
-            .Where(c => c.IsPublic)
+            .Where(c => c.HasPublicSeasonForYear(year))
             .Select(camp => CreateCampPlacementSummary(camp, year))
             .Where(summary => summary is not null)
             .Select(summary => summary!)

--- a/src/Humans.Application/Services/Camps/CampService.cs
+++ b/src/Humans.Application/Services/Camps/CampService.cs
@@ -287,7 +287,7 @@ public sealed class CampService : ICampService, IUserDataContributor
         var camps = await GetCampsForYearAsync(year, cancellationToken);
 
         var cards = ApplyCampDirectoryFilter(
-            camps.Select(camp => CreateCampDirectoryCard(camp, year)),
+            camps.Where(c => c.IsPublic).Select(camp => CreateCampDirectoryCard(camp, year)),
             filter)
             .OrderBy(card => card.Name, StringComparer.OrdinalIgnoreCase)
             .ToList();
@@ -319,23 +319,16 @@ public sealed class CampService : ICampService, IUserDataContributor
             async entry =>
             {
                 entry.AbsoluteExpirationRelativeToNow = CampsForYearCacheTtl;
-                return await _repo.GetPublicCampsForYearAsync(year, cancellationToken);
+                return await _repo.GetAllCampsForYearAsync(year, cancellationToken);
             });
 
         return cached is null ? new List<Camp>() : cached.ToList();
     }
 
-    public async Task<List<Camp>> GetAllCampsForYearAsync(
-        int year, CancellationToken cancellationToken = default)
-    {
-        var camps = await _repo.GetAllCampsForYearAsync(year, cancellationToken);
-        return camps.ToList();
-    }
-
     public async Task<IReadOnlyList<(Guid CampId, string CampName, string CampSlug, Guid CampSeasonId)>>
         GetCampSeasonsForComplianceAsync(int year, CancellationToken cancellationToken = default)
     {
-        var camps = await _repo.GetAllCampsForYearAsync(year, cancellationToken);
+        var camps = await GetCampsForYearAsync(year, cancellationToken);
         // Camp.Name lives on CampSeason, not Camp — pull s.Name not c.Name (deviation
         // from plan; reflects actual schema where the canonical name is per-season).
         return camps.SelectMany(c => c.Seasons.Where(s => s.Year == year).Select(s =>
@@ -349,6 +342,7 @@ public sealed class CampService : ICampService, IUserDataContributor
         var camps = await GetCampsForYearAsync(year, cancellationToken);
 
         return camps
+            .Where(c => c.IsPublic)
             .Select(camp => CreateCampPublicSummary(camp, year))
             .OrderBy(camp => camp.Name, StringComparer.OrdinalIgnoreCase)
             .ToList();
@@ -361,6 +355,7 @@ public sealed class CampService : ICampService, IUserDataContributor
         var camps = await GetCampsForYearAsync(year, cancellationToken);
 
         return camps
+            .Where(c => c.IsPublic)
             .Select(camp => CreateCampPlacementSummary(camp, year))
             .Where(summary => summary is not null)
             .Select(summary => summary!)

--- a/src/Humans.Application/Services/CityPlanning/CityPlanningService.cs
+++ b/src/Humans.Application/Services/CityPlanning/CityPlanningService.cs
@@ -204,11 +204,11 @@ public sealed class CityPlanningService : ICityPlanningService
         var settings = await GetSettingsAsync(cancellationToken);
         if (!settings.IsPlacementOpen) return false;
 
-        var campSeasonInfo = await _campService.GetCampSeasonInfoAsync(campSeasonId, cancellationToken);
-        if (campSeasonInfo is null) return false;
-        if (campSeasonInfo.Year != settings.Year) return false;
+        var season = await _campService.GetCampSeasonByIdAsync(campSeasonId, cancellationToken);
+        if (season is null) return false;
+        if (season.Year != settings.Year) return false;
 
-        return await _campService.IsUserCampLeadAsync(userId, campSeasonInfo.CampId, cancellationToken);
+        return await _campService.IsUserCampLeadAsync(userId, season.CampId, cancellationToken);
     }
 
     // ==========================================================================

--- a/src/Humans.Domain/Entities/Camp.cs
+++ b/src/Humans.Domain/Entities/Camp.cs
@@ -27,8 +27,7 @@ public class Camp
     public ICollection<CampHistoricalName> HistoricalNames { get; set; } = new List<CampHistoricalName>();
     public ICollection<CampImage> Images { get; set; } = new List<CampImage>();
 
-    // Assumes Seasons is loaded already filtered to a single year — true for
-    // every callsite (repo's year-based loaders include Seasons.Where(s => s.Year == year)).
-    public bool IsPublic =>
-        Seasons.Any(s => s.Status == CampSeasonStatus.Active || s.Status == CampSeasonStatus.Full);
+    public bool HasPublicSeasonForYear(int year) =>
+        Seasons.Any(s => s.Year == year &&
+            (s.Status == CampSeasonStatus.Active || s.Status == CampSeasonStatus.Full));
 }

--- a/src/Humans.Domain/Entities/Camp.cs
+++ b/src/Humans.Domain/Entities/Camp.cs
@@ -1,3 +1,4 @@
+using Humans.Domain.Enums;
 using Humans.Domain.ValueObjects;
 using NodaTime;
 
@@ -25,4 +26,9 @@ public class Camp
     public ICollection<CampLead> Leads { get; set; } = new List<CampLead>();
     public ICollection<CampHistoricalName> HistoricalNames { get; set; } = new List<CampHistoricalName>();
     public ICollection<CampImage> Images { get; set; } = new List<CampImage>();
+
+    // Assumes Seasons is loaded already filtered to a single year — true for
+    // every callsite (repo's year-based loaders include Seasons.Where(s => s.Year == year)).
+    public bool IsPublic =>
+        Seasons.Any(s => s.Status == CampSeasonStatus.Active || s.Status == CampSeasonStatus.Full);
 }

--- a/src/Humans.Infrastructure/Repositories/Camps/CampRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Camps/CampRepository.cs
@@ -56,21 +56,6 @@ public sealed class CampRepository : ICampRepository
             .FirstOrDefaultAsync(b => b.Id == campId, ct);
     }
 
-    public async Task<IReadOnlyList<Camp>> GetPublicCampsForYearAsync(
-        int year, CancellationToken ct = default)
-    {
-        await using var ctx = await _factory.CreateDbContextAsync(ct);
-        return await ctx.Camps
-            .AsNoTracking()
-            .Include(b => b.Seasons.Where(s => s.Year == year &&
-                (s.Status == CampSeasonStatus.Active || s.Status == CampSeasonStatus.Full)))
-            .Include(b => b.Images.OrderBy(i => i.SortOrder))
-            .Include(b => b.HistoricalNames)
-            .Where(b => b.Seasons.Any(s => s.Year == year &&
-                (s.Status == CampSeasonStatus.Active || s.Status == CampSeasonStatus.Full)))
-            .ToListAsync(ct);
-    }
-
     public async Task<IReadOnlyList<Camp>> GetAllCampsForYearAsync(
         int year, CancellationToken ct = default)
     {

--- a/src/Humans.Infrastructure/Repositories/Camps/CampRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Camps/CampRepository.cs
@@ -363,39 +363,13 @@ public sealed class CampRepository : ICampRepository
     // Cross-service queries
     // ==========================================================================
 
-    public async Task<SoundZone?> GetSeasonSoundZoneAsync(
+    public async Task<CampSeason?> GetSeasonByIdAsync(
         Guid campSeasonId, CancellationToken ct = default)
     {
         await using var ctx = await _factory.CreateDbContextAsync(ct);
         return await ctx.CampSeasons
             .AsNoTracking()
-            .Where(s => s.Id == campSeasonId)
-            .Select(s => s.SoundZone)
-            .FirstOrDefaultAsync(ct);
-    }
-
-    public async Task<string?> GetSeasonNameAsync(
-        Guid campSeasonId, CancellationToken ct = default)
-    {
-        await using var ctx = await _factory.CreateDbContextAsync(ct);
-        return await ctx.CampSeasons
-            .AsNoTracking()
-            .Where(s => s.Id == campSeasonId)
-            .Select(s => s.Name)
-            .FirstOrDefaultAsync(ct);
-    }
-
-    public async Task<(Guid CampSeasonId, Guid CampId, int Year)?> GetSeasonInfoAsync(
-        Guid campSeasonId, CancellationToken ct = default)
-    {
-        await using var ctx = await _factory.CreateDbContextAsync(ct);
-        var row = await ctx.CampSeasons
-            .AsNoTracking()
-            .Where(s => s.Id == campSeasonId)
-            .Select(s => new { s.Id, s.CampId, s.Year })
-            .FirstOrDefaultAsync(ct);
-
-        return row is null ? null : (row.Id, row.CampId, row.Year);
+            .FirstOrDefaultAsync(s => s.Id == campSeasonId, ct);
     }
 
     public async Task<IReadOnlyDictionary<Guid, (string Name, string CampSlug, SoundZone? SoundZone, SpaceSize? SpaceRequirement)>>

--- a/src/Humans.Web/Controllers/CampAdminController.cs
+++ b/src/Humans.Web/Controllers/CampAdminController.cs
@@ -50,7 +50,7 @@ public class CampAdminController : HumansControllerBase
         {
             var settings = await _campService.GetSettingsAsync();
             var registrationInfo = await _cityPlanningService.GetRegistrationInfoAsync();
-            var allCamps = await _campService.GetAllCampsForYearAsync(settings.PublicYear);
+            var allCamps = await _campService.GetCampsForYearAsync(settings.PublicYear);
             var pendingSeasons = await _campService.GetPendingSeasonsAsync();
 
             var nameLockDates = settings.OpenSeasons.Count > 0

--- a/src/Humans.Web/Controllers/CampController.cs
+++ b/src/Humans.Web/Controllers/CampController.cs
@@ -119,17 +119,17 @@ public class CampController : HumansCampControllerBase
     [HttpGet("{slug}")]
     public async Task<IActionResult> Details(string slug, CancellationToken cancellationToken)
     {
-        var campDetail = await _campService.GetCampDetailAsync(slug, cancellationToken: cancellationToken);
-        if (campDetail is null)
-            return NotFound();
-
         var camp = await GetCampBySlugAsync(slug, cancellationToken);
         if (camp is null)
             return NotFound();
 
+        var campDetail = await _campService.BuildCampDetailDataAsync(camp, cancellationToken: cancellationToken);
+        if (campDetail is null)
+            return NotFound();
+
         var currentUser = User.Identity?.IsAuthenticated == true ? await GetCurrentUserAsync() : null;
         var (isLead, isCampAdmin) = await ResolveCampViewerStateAsync(camp, currentUser, cancellationToken);
-        var membership = await ResolveCurrentUserMembershipStateAsync(camp.Id);
+        var membership = await ResolveCurrentUserMembershipStateAsync(camp.Id, currentUser);
         await PopulateCityPlanningViewBagAsync(currentUser, cancellationToken);
 
         return View(MapCampDetailViewModel(campDetail, isLead, isCampAdmin, membership));
@@ -139,40 +139,34 @@ public class CampController : HumansCampControllerBase
     [HttpGet("{slug}/Season/{year:int}")]
     public async Task<IActionResult> SeasonDetails(string slug, int year, CancellationToken cancellationToken)
     {
-        var campDetail = await _campService.GetCampDetailAsync(
-            slug,
+        var camp = await GetCampBySlugAsync(slug, cancellationToken);
+        if (camp is null)
+            return NotFound();
+
+        var campDetail = await _campService.BuildCampDetailDataAsync(
+            camp,
             preferredYear: year,
             fallbackToLatestSeason: false,
             cancellationToken: cancellationToken);
         if (campDetail is null)
             return NotFound();
 
-        var camp = await GetCampBySlugAsync(slug, cancellationToken);
-        if (camp is null)
-            return NotFound();
-
         var currentUser = User.Identity?.IsAuthenticated == true ? await GetCurrentUserAsync() : null;
         var (isLead, isCampAdmin) = await ResolveCampViewerStateAsync(camp, currentUser, cancellationToken);
-        var membership = await ResolveCurrentUserMembershipStateAsync(camp.Id);
+        var membership = await ResolveCurrentUserMembershipStateAsync(camp.Id, currentUser);
         await PopulateCityPlanningViewBagAsync(currentUser, cancellationToken);
 
         return View(nameof(Details), MapCampDetailViewModel(campDetail, isLead, isCampAdmin, membership));
     }
 
-    private async Task<CampMembershipStateViewModel> ResolveCurrentUserMembershipStateAsync(Guid campId)
+    private async Task<CampMembershipStateViewModel> ResolveCurrentUserMembershipStateAsync(Guid campId, User? currentUser)
     {
-        if (User.Identity?.IsAuthenticated != true)
+        if (currentUser is null)
         {
             return new CampMembershipStateViewModel { Status = CampMemberStatusSummaryView.NoOpenSeason };
         }
 
-        var user = await GetCurrentUserAsync();
-        if (user is null)
-        {
-            return new CampMembershipStateViewModel { Status = CampMemberStatusSummaryView.NoOpenSeason };
-        }
-
-        var state = await _campService.GetMembershipStateForCampAsync(campId, user.Id);
+        var state = await _campService.GetMembershipStateForCampAsync(campId, currentUser.Id);
         var status = state.Status switch
         {
             CampMemberStatusSummary.Active => CampMemberStatusSummaryView.Active,

--- a/src/Humans.Web/Controllers/CityPlanningApiController.cs
+++ b/src/Humans.Web/Controllers/CityPlanningApiController.cs
@@ -106,9 +106,9 @@ public class CityPlanningApiController : ControllerBase
             note: request.Note ?? "Saved",
             cancellationToken: cancellationToken);
 
-        var soundZone = await _campService.GetCampSeasonSoundZoneAsync(campSeasonId, cancellationToken);
-        var soundZoneValue = soundZone.HasValue ? (int)soundZone.Value : -1;
-        var campName = await _campService.GetCampSeasonNameAsync(campSeasonId, cancellationToken) ?? string.Empty;
+        var season = await _campService.GetCampSeasonByIdAsync(campSeasonId, cancellationToken);
+        var soundZoneValue = season?.SoundZone is { } sz ? (int)sz : -1;
+        var campName = season?.Name ?? string.Empty;
         try
         {
             await _hubContext.Clients.All.SendAsync(
@@ -137,9 +137,9 @@ public class CityPlanningApiController : ControllerBase
         var (polygon, _) = await _cityPlanningService.RestoreCampPolygonVersionAsync(
             campSeasonId, historyId, userId, cancellationToken);
 
-        var soundZone = await _campService.GetCampSeasonSoundZoneAsync(campSeasonId, cancellationToken);
-        var soundZoneValue = soundZone.HasValue ? (int)soundZone.Value : -1;
-        var campName = await _campService.GetCampSeasonNameAsync(campSeasonId, cancellationToken) ?? string.Empty;
+        var season = await _campService.GetCampSeasonByIdAsync(campSeasonId, cancellationToken);
+        var soundZoneValue = season?.SoundZone is { } sz ? (int)sz : -1;
+        var campName = season?.Name ?? string.Empty;
         try
         {
             await _hubContext.Clients.All.SendAsync(

--- a/tests/Humans.Application.Tests/Architecture/InterfaceMethodBudgetTests.cs
+++ b/tests/Humans.Application.Tests/Architecture/InterfaceMethodBudgetTests.cs
@@ -47,7 +47,9 @@ public class InterfaceMethodBudgetTests
         // AddCampMemberAsLeadAsync, GetSeasonMembersAsync, GetCampMemberStatusAsync,
         // GetCampSeasonsForComplianceAsync — all needed by ICampRoleService and the
         // Camp Edit page roles panel.
-        [typeof(ICampService)] = 57,
+        // 57→56: simplify pass — added BuildCampDetailDataAsync, replaced 3 scoped
+        // CampSeason getters (SoundZone/Name/Info) with single GetCampSeasonByIdAsync.
+        [typeof(ICampService)] = 56,
         // +1: GetOverallCoverageAsync for admin dashboard shift-coverage tile (peterdrier#349).
         [typeof(IShiftManagementService)] = 50,
         // +1 for SetProfilePictureAsync (nobodies-collective/Humans#532 — Google avatar import button needs a

--- a/tests/Humans.Application.Tests/Architecture/InterfaceMethodBudgetTests.cs
+++ b/tests/Humans.Application.Tests/Architecture/InterfaceMethodBudgetTests.cs
@@ -11,27 +11,29 @@ using Xunit;
 namespace Humans.Application.Tests.Architecture;
 
 /// <summary>
-/// Method-count budget for major service interfaces. Each entry is a hard ceiling
-/// pinned at the count when the test was last updated. CI fails if any interface
-/// grows past its budget — adding a new method to a budgeted interface requires
-/// either deleting an existing one in the same PR (decrement-only ratchet) or
-/// raising the budget here with a one-line justification in the PR.
-///
-/// Why: the audit-surface skill keeps finding bloat that nobody noticed accruing
-/// because each PR only adds 1-2 methods. Without a tripwire, the only feedback
-/// loop is a periodic audit. This makes growth visible at the moment it happens.
+/// Method-count budget for major service interfaces. **Strict down-only
+/// ratchet for agents.** A PR that adds a method to a budgeted interface MUST
+/// remove another in the same PR; net delta over the PR is ≤ 0. Agents must
+/// not raise a number here for any reason — only the repo owner can authorize
+/// a raise, and only after explicit out-of-band discussion. The bloat this
+/// test exists to clean up was accrued one "this addition is justified, +1"
+/// PR at a time; agent justifications are precisely the failure mode.
 ///
 /// What's in scope: interfaces with a meaningful surface (≥10 methods) where
 /// growth would matter. Smaller interfaces aren't budgeted — adding the 3rd
 /// method to a 2-method interface isn't a smell.
 ///
 /// What to do when this fails:
-/// - If the new method is genuinely needed and you've already removed something:
-///   lower the budget here to match the new count.
-/// - If you can't remove anything but the addition is justified: raise the
-///   budget here, document why in the PR description, and consider whether the
-///   interface should be split (run /audit-surface).
-/// - Don't bypass the test. The point is to make growth deliberate.
+/// - You added a method without removing one. Remove one. Or replace the
+///   added method with a refinement of an existing signature so the count
+///   doesn't grow. Or split the interface (run /audit-surface).
+/// - You removed methods and the count dropped: lower the budget here to
+///   match the new count exactly. The Budgets_are_tight_and_not_padded test
+///   forbids headroom.
+/// - The interface genuinely needs to grow with no room to remove? STOP and
+///   ask the repo owner before raising. Do not raise on your own initiative
+///   under any circumstances. Do not pre-raise "to make room for later
+///   work." The expected default is split-or-shrink, not raise.
 /// </summary>
 public class InterfaceMethodBudgetTests
 {

--- a/tests/Humans.Application.Tests/Architecture/InterfaceMethodBudgetTests.cs
+++ b/tests/Humans.Application.Tests/Architecture/InterfaceMethodBudgetTests.cs
@@ -53,7 +53,9 @@ public class InterfaceMethodBudgetTests
         // Camp Edit page roles panel.
         // 57→56: simplify pass — added BuildCampDetailDataAsync, replaced 3 scoped
         // CampSeason getters (SoundZone/Name/Info) with single GetCampSeasonByIdAsync.
-        [typeof(ICampService)] = 56,
+        // 56→55: collapsed GetCampsForYearAsync + GetAllCampsForYearAsync into one
+        // method; callers filter via Camp.IsPublic predicate.
+        [typeof(ICampService)] = 55,
         // +1: GetOverallCoverageAsync for admin dashboard shift-coverage tile (peterdrier#349).
         [typeof(IShiftManagementService)] = 50,
         // +1 for SetProfilePictureAsync (nobodies-collective/Humans#532 — Google avatar import button needs a

--- a/tests/Humans.Application.Tests/Architecture/InterfaceMethodBudgetTests.cs
+++ b/tests/Humans.Application.Tests/Architecture/InterfaceMethodBudgetTests.cs
@@ -11,29 +11,31 @@ using Xunit;
 namespace Humans.Application.Tests.Architecture;
 
 /// <summary>
-/// Method-count budget for major service interfaces. **Strict down-only
-/// ratchet for agents.** A PR that adds a method to a budgeted interface MUST
-/// remove another in the same PR; net delta over the PR is ≤ 0. Agents must
-/// not raise a number here for any reason — only the repo owner can authorize
-/// a raise, and only after explicit out-of-band discussion. The bloat this
-/// test exists to clean up was accrued one "this addition is justified, +1"
-/// PR at a time; agent justifications are precisely the failure mode.
+/// Method-count budget for major service interfaces. This is a
+/// **consolidation ratchet** — the goal is for budgeted interfaces to get
+/// smaller over time, not stable, not redistributed.
 ///
-/// What's in scope: interfaces with a meaningful surface (≥10 methods) where
+/// Agent rules (strict):
+/// - No raises. Adding a method requires removing one from the SAME
+///   interface in the SAME PR. Net delta is ≤ 0.
+/// - No splits as a workaround. Don't extract a sub-interface to put methods
+///   under a fresh budget — that defeats the consolidation goal.
+/// - No "replace 2 methods with 1 broader bag-of-flags method" tricks. The
+///   count drops but the surface grows.
+/// - When net delta is negative, lower the budget number to match the new
+///   count exactly. Budgets_are_tight_and_not_padded forbids headroom.
+/// - Hit a wall? STOP and ask the repo owner. Only the owner authorizes
+///   raises, and only out-of-band — never preemptively in a PR.
+///
+/// Why: the audit-surface skill kept finding bloat that accrued one
+/// "this addition is justified, +1" PR at a time. Every raise had a
+/// justification. A split-it escape hatch redistributes the same surface
+/// across two budgets with fresh growth runway in each. The mechanism only
+/// works when agents cannot reach for either lever on their own initiative.
+///
+/// In scope: interfaces with a meaningful surface (≥10 methods) where
 /// growth would matter. Smaller interfaces aren't budgeted — adding the 3rd
 /// method to a 2-method interface isn't a smell.
-///
-/// What to do when this fails:
-/// - You added a method without removing one. Remove one. Or replace the
-///   added method with a refinement of an existing signature so the count
-///   doesn't grow. Or split the interface (run /audit-surface).
-/// - You removed methods and the count dropped: lower the budget here to
-///   match the new count exactly. The Budgets_are_tight_and_not_padded test
-///   forbids headroom.
-/// - The interface genuinely needs to grow with no room to remove? STOP and
-///   ask the repo owner before raising. Do not raise on your own initiative
-///   under any circumstances. Do not pre-raise "to make room for later
-///   work." The expected default is split-or-shrink, not raise.
 /// </summary>
 public class InterfaceMethodBudgetTests
 {

--- a/tests/Humans.Application.Tests/Repositories/CampRepositoryTests.cs
+++ b/tests/Humans.Application.Tests/Repositories/CampRepositoryTests.cs
@@ -171,11 +171,11 @@ public sealed class CampRepositoryTests : IDisposable
     }
 
     // ==========================================================================
-    // GetPublicCampsForYearAsync
+    // Camp.IsPublic predicate (caller-side filter on GetAllCampsForYearAsync)
     // ==========================================================================
 
     [HumansFact]
-    public async Task GetPublicCampsForYearAsync_ReturnsActiveAndFull_ExcludesPendingAndRejected()
+    public async Task GetAllCampsForYearAsync_WithIsPublicFilter_ReturnsActiveAndFull()
     {
         var activeCamp = await SeedCampAsync("active");
         await SeedSeasonAsync(activeCamp.Id, 2026, CampSeasonStatus.Active);
@@ -186,9 +186,9 @@ public sealed class CampRepositoryTests : IDisposable
         var pendingCamp = await SeedCampAsync("pending");
         await SeedSeasonAsync(pendingCamp.Id, 2026, CampSeasonStatus.Pending);
 
-        var result = await _repo.GetPublicCampsForYearAsync(2026);
+        var result = await _repo.GetAllCampsForYearAsync(2026);
 
-        result.Select(c => c.Slug).Should().BeEquivalentTo(["active", "full"]);
+        result.Where(c => c.IsPublic).Select(c => c.Slug).Should().BeEquivalentTo(["active", "full"]);
     }
 
     // ==========================================================================

--- a/tests/Humans.Application.Tests/Repositories/CampRepositoryTests.cs
+++ b/tests/Humans.Application.Tests/Repositories/CampRepositoryTests.cs
@@ -171,11 +171,11 @@ public sealed class CampRepositoryTests : IDisposable
     }
 
     // ==========================================================================
-    // Camp.IsPublic predicate (caller-side filter on GetAllCampsForYearAsync)
+    // Camp.HasPublicSeasonForYear predicate (caller-side filter on GetAllCampsForYearAsync)
     // ==========================================================================
 
     [HumansFact]
-    public async Task GetAllCampsForYearAsync_WithIsPublicFilter_ReturnsActiveAndFull()
+    public async Task GetAllCampsForYearAsync_WithHasPublicSeasonFilter_ReturnsActiveAndFull()
     {
         var activeCamp = await SeedCampAsync("active");
         await SeedSeasonAsync(activeCamp.Id, 2026, CampSeasonStatus.Active);
@@ -188,7 +188,8 @@ public sealed class CampRepositoryTests : IDisposable
 
         var result = await _repo.GetAllCampsForYearAsync(2026);
 
-        result.Where(c => c.IsPublic).Select(c => c.Slug).Should().BeEquivalentTo(["active", "full"]);
+        result.Where(c => c.HasPublicSeasonForYear(2026)).Select(c => c.Slug)
+            .Should().BeEquivalentTo(["active", "full"]);
     }
 
     // ==========================================================================

--- a/tests/Humans.Application.Tests/Services/CityPlanningServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/CityPlanningServiceTests.cs
@@ -201,8 +201,8 @@ public class CityPlanningServiceTests : IDisposable
         _teamService.GetTeamBySlugAsync("city-planning", Arg.Any<CancellationToken>())
             .Returns((Team?)null);
 
-        _campService.GetCampSeasonInfoAsync(campSeasonId, Arg.Any<CancellationToken>())
-            .Returns(new CampSeasonInfo(campSeasonId, campId, 2026));
+        _campService.GetCampSeasonByIdAsync(campSeasonId, Arg.Any<CancellationToken>())
+            .Returns(new CampSeason { Id = campSeasonId, CampId = campId, Year = 2026 });
         _campService.IsUserCampLeadAsync(userId, campId, Arg.Any<CancellationToken>())
             .Returns(true);
 
@@ -221,8 +221,8 @@ public class CityPlanningServiceTests : IDisposable
         _teamService.GetTeamBySlugAsync("city-planning", Arg.Any<CancellationToken>())
             .Returns((Team?)null);
 
-        _campService.GetCampSeasonInfoAsync(campSeasonId, Arg.Any<CancellationToken>())
-            .Returns(new CampSeasonInfo(campSeasonId, campId, 2026));
+        _campService.GetCampSeasonByIdAsync(campSeasonId, Arg.Any<CancellationToken>())
+            .Returns(new CampSeason { Id = campSeasonId, CampId = campId, Year = 2026 });
         _campService.IsUserCampLeadAsync(userId, campId, Arg.Any<CancellationToken>())
             .Returns(true);
 
@@ -241,8 +241,8 @@ public class CityPlanningServiceTests : IDisposable
         _teamService.GetTeamBySlugAsync("city-planning", Arg.Any<CancellationToken>())
             .Returns((Team?)null);
 
-        _campService.GetCampSeasonInfoAsync(campSeasonId, Arg.Any<CancellationToken>())
-            .Returns(new CampSeasonInfo(campSeasonId, campId, 2026));
+        _campService.GetCampSeasonByIdAsync(campSeasonId, Arg.Any<CancellationToken>())
+            .Returns(new CampSeason { Id = campSeasonId, CampId = campId, Year = 2026 });
         _campService.IsUserCampLeadAsync(userId, campId, Arg.Any<CancellationToken>())
             .Returns(false);
 
@@ -262,8 +262,8 @@ public class CityPlanningServiceTests : IDisposable
             .Returns((Team?)null);
 
         // Camp season is for 2027, but settings year is 2026
-        _campService.GetCampSeasonInfoAsync(campSeasonId, Arg.Any<CancellationToken>())
-            .Returns(new CampSeasonInfo(campSeasonId, campId, 2027));
+        _campService.GetCampSeasonByIdAsync(campSeasonId, Arg.Any<CancellationToken>())
+            .Returns(new CampSeason { Id = campSeasonId, CampId = campId, Year = 2027 });
 
         var result = await _sut.CanUserEditAsync(userId, campSeasonId);
         result.Should().BeFalse();


### PR DESCRIPTION
First pass of an ongoing per-section simplification process. Five commits, all surgical, no architectural changes. Net effect: less code, smaller interface surface, fewer DB round-trips on hot paths.

## Summary

**Hot-path fixes (commit 1):** `CampController.Details` / `SeasonDetails` were each issuing two redundant fetches per public view — `GetCampDetailAsync` re-loaded the same `Camp` by slug that the controller had already fetched for authorization, and `ResolveCurrentUserMembershipStateAsync` re-fetched the current `User` after the controller already had it. Now load once and pass through. Net per public detail page view: −1 DB SELECT, −1 `UserManager.GetUserAsync`.

**Interface consolidation (commits 2 + 5):** `ICampService` had grown a sprawl of single-property scalar getters where the existing entity-returning pattern (`GetCampBySlugAsync`, `GetCampByIdAsync`) would have done. Three scoped CampSeason getters (`GetCampSeasonSoundZoneAsync` / `GetCampSeasonNameAsync` / `GetCampSeasonInfoAsync`) collapse into one `GetCampSeasonByIdAsync` returning `CampSeason`; callers pluck the fields they need. `GetCampsForYearAsync` and `GetAllCampsForYearAsync` collapse into one method returning all camps for the year (cached); a new `Camp.IsPublic` instance property lets the 4 public-only callers filter via `.Where(c => c.IsPublic)`. CityPlanningApiController polygon save/restore paths drop from 2 round-trips to 1.

**Net `ICampService` surface: 57 → 55 methods.** Budget ratchet updated to match.

**Comment trims:** verbose XML docstrings on `ICampService` membership methods reduced to just the non-obvious WHY (cross-camp guards, ownership scoping, "caller authorizes" invariants). Trivial `// Ensure unique slug` / `// Verify season is open` narration deleted from `CampService`. The `// I5 fix —` task-reference prefix dropped.

**Ratchet docstring rewrite (commits 3 + 4):** `InterfaceMethodBudgetTests` is a consolidation mechanism, not paperwork-and-justification. Docstring rewritten to spell out three forbidden moves for agents:
- No raises, ever, on agent initiative.
- No splitting an interface to redistribute methods under a fresh budget.
- No "replace N methods with one bag-of-flags method" tricks.

The expected default for an interface that needs to grow is to actually shrink — and only the repo owner authorizes raises, only out-of-band.

## Test plan

- [x] `dotnet build Humans.slnx -v quiet` — clean
- [x] `dotnet test Humans.slnx -v quiet` — 1834/1834 Application, 124+1-skipped/124 Domain
- [x] Camps + CityPlanning subset: 180/180
- [x] Integration test failures on this branch are the same flaky environmental ones that fail on main (health endpoints, calendar, anonymous redirects); not regressions
- [ ] Smoke: `/Camps/{slug}` and `/Camps/{slug}/Season/{year}` render anonymous + authenticated
- [ ] Smoke: `/CityPlanning` polygon save/restore SignalR broadcast still includes correct sound zone + camp name
- [ ] Smoke: `/Admin/CampAdmin` admin dashboard lists all camps for the public year

## Deferred (future /simplify passes)

The three review agents surfaced these but I judged each out of scope for a tight first cut. Listed here so the trail isn't lost.

- **Cross-section image-validation duplication** (Camps/Feedback/Profile each redefine MIME whitelists + 10 MB limit). Belongs to a "shared utilities" pass.
- **`CreateCampAsync` 11-parameter sprawl.** Real, but introducing a DTO has cascading test changes; warrants its own PR.
- **`Lazy<ICampRoleService>` circular dependency** between `CampService` ↔ `CampRoleService`. Works; restructuring would be invasive.
- **`IsLead` synthesis in `GetCampMembersAsync`.** Section spec explicitly marks this as temporary until the camp-roles PR retires `CampLead`. Don't pre-empt.
- **`IsUserCampLeadAsync(userId, campId)` push to caller** — auth handler already has `Camp` loaded with `Leads` eager-included; could read `camp.Leads.Any(...)` directly. Held back at the repo owner's request because a related change is coming.
- **Soft-delete EF query filter for `CampLead.LeftAt`.** Global query filters propagate everywhere; risky scope creep.
- **Cache invalidation gap on `ChangeSeasonNameAsync` / `RejectSeasonAsync` / `WithdrawSeasonAsync`** for the lead-badge cache. Possibly a real bug — needs focused investigation, not a drive-by fix.
- **Stringly-typed enum-to-string in `CampPublicSummary` / `CampPlacementSummary`** — debatable; view layer might genuinely want strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)