### PR TITLE
Add /welcome page for post-ticket-purchase landing

### DIFF
--- a/docs/features/24-ticket-vendor-integration.md
+++ b/docs/features/24-ticket-vendor-integration.md
@@ -1,6 +1,8 @@
 <!-- freshness:triggers
   src/Humans.Application/Services/Tickets/**
   src/Humans.Web/Controllers/TicketController.cs
+  src/Humans.Web/Controllers/WelcomeController.cs
+  src/Humans.Web/Views/Welcome/**
   src/Humans.Domain/Entities/TicketOrder.cs
   src/Humans.Domain/Entities/TicketAttendee.cs
   src/Humans.Domain/Entities/TicketSyncState.cs
@@ -75,6 +77,18 @@ Tickets priced above 315 EUR (the VIP threshold, `TicketConstants.VipThresholdEu
 | `/Tickets/GateList` | Stub for June implementation |
 | `/Tickets/WhoHasntBought` | Active humans without ticket purchases |
 | `/Tickets/SalesAggregates` | Weekly (Mon–Sun) and quarterly (Spanish tax Q1–Q4) aggregate reports with real VAT/donation data |
+| `/Welcome` | Public post-purchase landing — TicketTailor redirect target, sign-in CTA → `/Shifts` |
+
+## Post-Purchase Landing (`/Welcome`)
+
+Public, anonymous-accessible page used as the redirect target after a buyer completes checkout on TicketTailor. Explains shift participation in the org's voice and routes the buyer toward signing in / claiming shifts.
+
+- **Route**: `/Welcome` (`WelcomeController`, `[AllowAnonymous]`)
+- **Active-member shortcut**: authenticated users with the `ActiveMember` claim are redirected straight to `/Shifts` — they don't need the explainer
+- **CTA**: links to `/Account/Login?returnUrl=/Shifts` so post-login lands on the shifts board
+- **Localization**: `Welcome_*` strings in `SharedResource.{en,es,ca,de,fr,it}.resx`
+
+The TicketTailor "after checkout" redirect URL points at this route.
 
 ## Dashboard Widgets
 

--- a/src/Humans.Web/Controllers/WelcomeController.cs
+++ b/src/Humans.Web/Controllers/WelcomeController.cs
@@ -6,7 +6,7 @@ namespace Humans.Web.Controllers;
 [AllowAnonymous]
 public class WelcomeController : Controller
 {
-    [HttpGet("/welcome")]
+    [HttpGet("/Welcome")]
     public IActionResult Index()
     {
         // If user is already authenticated and an active member,

--- a/src/Humans.Web/Controllers/WelcomeController.cs
+++ b/src/Humans.Web/Controllers/WelcomeController.cs
@@ -1,0 +1,28 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Humans.Web.Controllers;
+
+[AllowAnonymous]
+public class WelcomeController : Controller
+{
+    [HttpGet("/welcome")]
+    public IActionResult Index()
+    {
+        // If user is already authenticated and an active member,
+        // skip the welcome page and go straight to shifts.
+        if (User.Identity?.IsAuthenticated ?? false)
+        {
+            var isActive = User.HasClaim(
+                Authorization.RoleAssignmentClaimsTransformation.ActiveMemberClaimType,
+                Authorization.RoleAssignmentClaimsTransformation.ActiveClaimValue);
+
+            if (isActive)
+            {
+                return Redirect("/Shifts");
+            }
+        }
+
+        return View();
+    }
+}

--- a/src/Humans.Web/Resources/SharedResource.ca.resx
+++ b/src/Humans.Web/Resources/SharedResource.ca.resx
@@ -1987,4 +1987,14 @@
   <data name="Issue_Section_Updated" xml:space="preserve"><value>Secció actualitzada.</value></data>
   <data name="Issue_GitHub_Linked" xml:space="preserve"><value>Vinculada amb GitHub.</value></data>
 
+  <data name="Welcome_Title" xml:space="preserve"><value>Benvinguda</value></data>
+  <data name="Welcome_Heading" xml:space="preserve"><value>Ja hi ets.</value></data>
+  <data name="Welcome_Subtitle" xml:space="preserve"><value>La teva entrada per a Elsewhere 2026 està confirmada.</value></data>
+  <data name="Welcome_ShiftsTitle" xml:space="preserve"><value>Ara fem que això passi entre tots.</value></data>
+  <data name="Welcome_ShiftsBody" xml:space="preserve"><value>Elsewhere no és un festival on véns — és un que ajudes a construir. Cada human tria torns: muntatge abans, operació durant i desmuntatge després.</value></data>
+  <data name="Welcome_ShiftsBody2" xml:space="preserve"><value>Per veure els torns i apuntar-t'hi, necessites un compte a Humans. Només porta un parell de minuts.</value></data>
+  <data name="Welcome_CTA" xml:space="preserve"><value>Inicia sessió o crea un compte</value></data>
+  <data name="Welcome_Footer" xml:space="preserve"><value>Ja tens compte? El mateix botó — inicia sessió i arribaràs directament als torns.</value></data>
+  <data name="Welcome_Contact" xml:space="preserve"><value>Preguntes? Escriu-nos a</value></data>
+
 </root>

--- a/src/Humans.Web/Resources/SharedResource.de.resx
+++ b/src/Humans.Web/Resources/SharedResource.de.resx
@@ -1985,4 +1985,14 @@
   <data name="Issue_Section_Updated" xml:space="preserve"><value>Bereich aktualisiert.</value></data>
   <data name="Issue_GitHub_Linked" xml:space="preserve"><value>Mit GitHub verknüpft.</value></data>
 
+  <data name="Welcome_Title" xml:space="preserve"><value>Willkommen</value></data>
+  <data name="Welcome_Heading" xml:space="preserve"><value>Du bist dabei.</value></data>
+  <data name="Welcome_Subtitle" xml:space="preserve"><value>Dein Ticket für Elsewhere 2026 ist bestätigt.</value></data>
+  <data name="Welcome_ShiftsTitle" xml:space="preserve"><value>Jetzt machen wir das gemeinsam möglich.</value></data>
+  <data name="Welcome_ShiftsBody" xml:space="preserve"><value>Elsewhere ist kein Festival, zu dem du einfach kommst — es ist eines, das du mitaufbaust. Jeder human wählt Schichten: Aufbau vorher, Betrieb währenddessen und Abbau danach.</value></data>
+  <data name="Welcome_ShiftsBody2" xml:space="preserve"><value>Um Schichten zu sehen und dich anzumelden, brauchst du ein Humans-Konto. Das dauert nur ein paar Minuten.</value></data>
+  <data name="Welcome_CTA" xml:space="preserve"><value>Anmelden oder Konto erstellen</value></data>
+  <data name="Welcome_Footer" xml:space="preserve"><value>Schon ein Konto? Gleicher Button — melde dich an und du landest direkt bei den Schichten.</value></data>
+  <data name="Welcome_Contact" xml:space="preserve"><value>Fragen? Schreib uns an</value></data>
+
 </root>

--- a/src/Humans.Web/Resources/SharedResource.es.resx
+++ b/src/Humans.Web/Resources/SharedResource.es.resx
@@ -2011,4 +2011,14 @@
   <data name="Issue_Section_Updated" xml:space="preserve"><value>Sección actualizada.</value></data>
   <data name="Issue_GitHub_Linked" xml:space="preserve"><value>Vinculada con GitHub.</value></data>
 
+  <data name="Welcome_Title" xml:space="preserve"><value>Bienvenida</value></data>
+  <data name="Welcome_Heading" xml:space="preserve"><value>Ya estás dentro.</value></data>
+  <data name="Welcome_Subtitle" xml:space="preserve"><value>Tu entrada para Elsewhere 2026 está confirmada.</value></data>
+  <data name="Welcome_ShiftsTitle" xml:space="preserve"><value>Ahora vamos a hacer que esto pase entre todos.</value></data>
+  <data name="Welcome_ShiftsBody" xml:space="preserve"><value>Elsewhere no es un festival al que vienes — es uno que ayudas a construir. Cada human elige turnos: montaje antes, operación durante y desmontaje después.</value></data>
+  <data name="Welcome_ShiftsBody2" xml:space="preserve"><value>Para ver los turnos y apuntarte, necesitas una cuenta en Humans. Solo lleva un par de minutos.</value></data>
+  <data name="Welcome_CTA" xml:space="preserve"><value>Iniciar sesión o crear cuenta</value></data>
+  <data name="Welcome_Footer" xml:space="preserve"><value>¿Ya tienes cuenta? El mismo botón — inicia sesión y llegarás directamente a los turnos.</value></data>
+  <data name="Welcome_Contact" xml:space="preserve"><value>¿Preguntas? Escríbenos a</value></data>
+
 </root>

--- a/src/Humans.Web/Resources/SharedResource.fr.resx
+++ b/src/Humans.Web/Resources/SharedResource.fr.resx
@@ -1985,4 +1985,14 @@
   <data name="Issue_Section_Updated" xml:space="preserve"><value>Section mise à jour.</value></data>
   <data name="Issue_GitHub_Linked" xml:space="preserve"><value>Lié à GitHub.</value></data>
 
+  <data name="Welcome_Title" xml:space="preserve"><value>Bienvenue</value></data>
+  <data name="Welcome_Heading" xml:space="preserve"><value>C'est bon, t'es dedans.</value></data>
+  <data name="Welcome_Subtitle" xml:space="preserve"><value>Ton billet pour Elsewhere 2026 est confirmé.</value></data>
+  <data name="Welcome_ShiftsTitle" xml:space="preserve"><value>Maintenant, on fait ça ensemble.</value></data>
+  <data name="Welcome_ShiftsBody" xml:space="preserve"><value>Elsewhere, c'est pas un festival où tu viens — c'est un que tu aides à construire. Chaque human choisit des créneaux : montage avant, opération pendant et démontage après.</value></data>
+  <data name="Welcome_ShiftsBody2" xml:space="preserve"><value>Pour voir les créneaux et t'inscrire, il te faut un compte Humans. Ça prend juste quelques minutes.</value></data>
+  <data name="Welcome_CTA" xml:space="preserve"><value>Se connecter ou créer un compte</value></data>
+  <data name="Welcome_Footer" xml:space="preserve"><value>Déjà un compte ? Même bouton — connecte-toi et tu arrives directement sur les créneaux.</value></data>
+  <data name="Welcome_Contact" xml:space="preserve"><value>Des questions ? Écris-nous à</value></data>
+
 </root>

--- a/src/Humans.Web/Resources/SharedResource.it.resx
+++ b/src/Humans.Web/Resources/SharedResource.it.resx
@@ -1985,4 +1985,14 @@
   <data name="Issue_Section_Updated" xml:space="preserve"><value>Sezione aggiornata.</value></data>
   <data name="Issue_GitHub_Linked" xml:space="preserve"><value>Collegata a GitHub.</value></data>
 
+  <data name="Welcome_Title" xml:space="preserve"><value>Benvenuto/a</value></data>
+  <data name="Welcome_Heading" xml:space="preserve"><value>Ci sei.</value></data>
+  <data name="Welcome_Subtitle" xml:space="preserve"><value>Il tuo biglietto per Elsewhere 2026 è confermato.</value></data>
+  <data name="Welcome_ShiftsTitle" xml:space="preserve"><value>Ora facciamo succedere tutto insieme.</value></data>
+  <data name="Welcome_ShiftsBody" xml:space="preserve"><value>Elsewhere non è un festival a cui partecipi — è uno che aiuti a costruire. Ogni human sceglie i turni: allestimento prima, operazione durante e smontaggio dopo.</value></data>
+  <data name="Welcome_ShiftsBody2" xml:space="preserve"><value>Per vedere i turni e iscriverti, ti serve un account Humans. Ci vogliono solo un paio di minuti.</value></data>
+  <data name="Welcome_CTA" xml:space="preserve"><value>Accedi o crea un account</value></data>
+  <data name="Welcome_Footer" xml:space="preserve"><value>Hai già un account? Stesso pulsante — accedi e arrivi direttamente ai turni.</value></data>
+  <data name="Welcome_Contact" xml:space="preserve"><value>Domande? Scrivici a</value></data>
+
 </root>

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -2029,4 +2029,14 @@
   <data name="Issue_Section_Updated" xml:space="preserve"><value>Section updated.</value></data>
   <data name="Issue_GitHub_Linked" xml:space="preserve"><value>Linked to GitHub.</value></data>
 
+  <data name="Welcome_Title" xml:space="preserve"><value>Welcome</value></data>
+  <data name="Welcome_Heading" xml:space="preserve"><value>You're in.</value></data>
+  <data name="Welcome_Subtitle" xml:space="preserve"><value>Your ticket for Elsewhere 2026 is confirmed.</value></data>
+  <data name="Welcome_ShiftsTitle" xml:space="preserve"><value>Now let's make this thing happen together.</value></data>
+  <data name="Welcome_ShiftsBody" xml:space="preserve"><value>Elsewhere isn't a festival you show up to — it's one you help build. Every human picks shifts: setting up before, keeping things running during, and taking it all down after.</value></data>
+  <data name="Welcome_ShiftsBody2" xml:space="preserve"><value>To browse and sign up for shifts, you need a Humans account. It takes a couple of minutes.</value></data>
+  <data name="Welcome_CTA" xml:space="preserve"><value>Sign in or create account</value></data>
+  <data name="Welcome_Footer" xml:space="preserve"><value>Already have an account? Same button — sign in and you'll land straight on the shifts page.</value></data>
+  <data name="Welcome_Contact" xml:space="preserve"><value>Questions? Reach us at</value></data>
+
 </root>

--- a/src/Humans.Web/Views/Welcome/Index.cshtml
+++ b/src/Humans.Web/Views/Welcome/Index.cshtml
@@ -1,6 +1,7 @@
 @{
     ViewData["Title"] = Localizer["Welcome_Title"].Value;
-    var loginUrl = Url.Action("Login", "Account", new { returnUrl = "/Shifts" });
+    var shiftsUrl = Url.Action("Index", "Shifts");
+    var loginUrl = Url.Action("Login", "Account", new { returnUrl = shiftsUrl });
 }
 
 <div class="row justify-content-center">

--- a/src/Humans.Web/Views/Welcome/Index.cshtml
+++ b/src/Humans.Web/Views/Welcome/Index.cshtml
@@ -1,0 +1,38 @@
+@{
+    ViewData["Title"] = Localizer["Welcome_Title"].Value;
+    var loginUrl = Url.Action("Login", "Account", new { returnUrl = "/Shifts" });
+}
+
+<div class="row justify-content-center">
+    <div class="col-md-8 col-lg-6">
+
+        <section class="welcome-hero text-center">
+            <div class="welcome-checkmark">
+                <i class="fa-solid fa-circle-check"></i>
+            </div>
+            <h1 class="welcome-heading">@Localizer["Welcome_Heading"]</h1>
+            <p class="welcome-subtitle">@Localizer["Welcome_Subtitle"]</p>
+        </section>
+
+        <div class="welcome-shifts-card">
+            <h2 class="welcome-shifts-title">@Localizer["Welcome_ShiftsTitle"]</h2>
+            <p class="welcome-shifts-body">@Localizer["Welcome_ShiftsBody"]</p>
+            <p class="welcome-shifts-body">@Localizer["Welcome_ShiftsBody2"]</p>
+        </div>
+
+        <div class="text-center mb-3">
+            <a href="@loginUrl" class="btn btn-primary btn-lg welcome-cta">
+                <i class="fa-solid fa-right-to-bracket me-2"></i>@Localizer["Welcome_CTA"]
+            </a>
+        </div>
+
+        <p class="welcome-footer text-center">@Localizer["Welcome_Footer"]</p>
+
+        <div class="welcome-contact text-center">
+            <p>@Localizer["Welcome_Contact"]
+                <a href="mailto:hola@nobodies.team">hola@nobodies.team</a>
+            </p>
+        </div>
+
+    </div>
+</div>

--- a/src/Humans.Web/wwwroot/css/site.css
+++ b/src/Humans.Web/wwwroot/css/site.css
@@ -920,6 +920,107 @@ a:hover {
     }
 }
 
+/* --- Welcome / Thank You page (post-ticket-purchase landing) --- */
+.welcome-hero {
+    padding: 3rem 1rem 1.5rem;
+}
+
+.welcome-checkmark {
+    font-size: 3rem;
+    color: var(--h-sage);
+    margin-bottom: 0.75rem;
+}
+
+.welcome-heading {
+    font-family: var(--h-font-display);
+    font-size: 2.2rem;
+    color: var(--h-aged-ink);
+    margin-bottom: 0.5rem;
+}
+
+.welcome-subtitle {
+    font-size: 1.1rem;
+    color: var(--h-sepia);
+    margin-bottom: 0;
+}
+
+.welcome-shifts-card {
+    background-color: var(--h-parchment-light);
+    border: 1px solid var(--h-border-light);
+    border-radius: 0.5rem;
+    padding: 1.5rem 1.75rem;
+    margin-bottom: 1.75rem;
+}
+
+.welcome-shifts-title {
+    font-family: var(--h-font-display);
+    font-size: 1.3rem;
+    font-weight: 600;
+    color: var(--h-aged-ink);
+    margin-bottom: 0.75rem;
+}
+
+.welcome-shifts-body {
+    font-size: 0.95rem;
+    color: var(--h-sepia);
+    line-height: 1.7;
+    margin-bottom: 0.75rem;
+}
+
+.welcome-shifts-body:last-child {
+    margin-bottom: 0;
+}
+
+.welcome-cta {
+    background-color: var(--h-sage);
+    border-color: var(--h-sage);
+    color: #fff;
+    padding: 0.6rem 2rem;
+    font-size: 1rem;
+}
+
+.welcome-cta:hover {
+    background-color: var(--h-sage-dark);
+    border-color: var(--h-sage-dark);
+    color: #fff;
+}
+
+.welcome-footer {
+    font-size: 0.85rem;
+    color: var(--h-sepia-light);
+    margin-bottom: 2rem;
+}
+
+.welcome-contact {
+    border-top: 1px solid var(--h-border-light);
+    padding-top: 1rem;
+    margin-bottom: 2rem;
+}
+
+.welcome-contact p {
+    font-size: 0.85rem;
+    color: var(--h-sepia-light);
+    margin-bottom: 0;
+}
+
+.welcome-contact a {
+    color: var(--h-blue-muted);
+}
+
+@media (max-width: 767.98px) {
+    .welcome-hero {
+        padding: 2rem 0.5rem 1rem;
+    }
+
+    .welcome-heading {
+        font-size: 1.8rem;
+    }
+
+    .welcome-shifts-card {
+        padding: 1.25rem;
+    }
+}
+
 /* --- Decorative rule — used as section separator --- */
 hr {
     border-color: var(--h-border);


### PR DESCRIPTION
## Summary
- Public page at /welcome for TicketTailor redirect after ticket purchase
- Explains shift participation in Nobodies voice, CTA links to sign-in with returnUrl=/Shifts
- Active members who hit /welcome skip straight to /Shifts
- Localized across all 6 locales

## Test plan
- Visit /welcome while logged out — see thank-you page with sign-in CTA
- Visit /welcome while logged in as active member — redirected to /Shifts
- Visit /welcome while logged in as profileless user — see thank-you page
- Click CTA — lands on login page, after sign-in redirects to /Shifts
- Check all 6 locales render correctly

🤖 Generated with Claude