### PR TITLE
fix(audit-log): attribute shift signup entries to actor and subject

### DIFF
--- a/docs/features/12-audit-log.md
+++ b/docs/features/12-audit-log.md
@@ -207,11 +207,7 @@ Displays the 50 most recent audit entries affecting a user, queried by:
 - `EntityType = 'User' AND EntityId = @userId` (direct entries)
 - `RelatedEntityId = @userId` (related entries, e.g., team membership changes)
 
-Each entry shows:
-- Description (bold)
-- Badge: "System" (info) for job-generated entries, "Admin" (secondary) for human-initiated entries
-- Actor name: resolved at render time from ActorUserId via batch lookup
-- Timestamp (right-aligned)
+Each entry renders structurally as: `[timestamp] — [actor] [verb] [subject] in [team] — [description]`. Verbs are mapped per `AuditAction` in `AuditLogViewComponent.GetActionVerb`; a self-form (`GetActionSelfVerb`) is used when actor == subject to avoid dangling prepositions. Actor and subject are resolved as clickable `<human-link>` from `UserDisplayNames` (batch-loaded). Unmapped actions fall back to a rough `[actor] · [ActionName] · [subject] — [description]` form so attribution is never lost.
 
 ## Authorization
 

--- a/src/Humans.Application/Services/Shifts/ShiftSignupService.cs
+++ b/src/Humans.Application/Services/Shifts/ShiftSignupService.cs
@@ -148,7 +148,7 @@ public sealed class ShiftSignupService : IShiftSignupService, IUserDataContribut
         {
             await _auditLogService.LogAsync(
                 AuditAction.ShiftSignupConfirmed, nameof(ShiftSignup), signup.Id,
-                $"shift '{shift.Rota.Name}' (self-signup)",
+                $"shift '{shift.Rota.Name}'",
                 userId,
                 userId, nameof(User));
 

--- a/src/Humans.Application/Services/Shifts/ShiftSignupService.cs
+++ b/src/Humans.Application/Services/Shifts/ShiftSignupService.cs
@@ -148,8 +148,9 @@ public sealed class ShiftSignupService : IShiftSignupService, IUserDataContribut
         {
             await _auditLogService.LogAsync(
                 AuditAction.ShiftSignupConfirmed, nameof(ShiftSignup), signup.Id,
-                $"Auto-confirmed signup for shift '{shift.Rota.Name}'",
-                userId);
+                $"shift '{shift.Rota.Name}' (self-signup)",
+                userId,
+                userId, nameof(User));
 
             await DispatchSignupChangeNotificationAsync(signup, shift,
                 $"New confirmed signup for '{shift.Rota.Name}' on day {shift.DayOffset}.");
@@ -202,8 +203,9 @@ public sealed class ShiftSignupService : IShiftSignupService, IUserDataContribut
 
         await _auditLogService.LogAsync(
             AuditAction.ShiftSignupConfirmed, nameof(ShiftSignup), signup.Id,
-            $"Approved signup for shift '{signup.Shift.Rota.Name}'",
-            reviewerUserId);
+            $"shift '{signup.Shift.Rota.Name}'",
+            reviewerUserId,
+            signup.UserId, nameof(User));
 
         await DispatchSignupChangeNotificationAsync(signup, signup.Shift,
             $"Signup approved for '{signup.Shift.Rota.Name}' on day {signup.Shift.DayOffset}.");
@@ -222,8 +224,9 @@ public sealed class ShiftSignupService : IShiftSignupService, IUserDataContribut
 
         await _auditLogService.LogAsync(
             AuditAction.ShiftSignupRefused, nameof(ShiftSignup), signup.Id,
-            $"Refused signup for shift '{signup.Shift.Rota.Name}'" + (reason is not null ? $": {reason}" : ""),
-            reviewerUserId);
+            $"shift '{signup.Shift.Rota.Name}'" + (reason is not null ? $": {reason}" : ""),
+            reviewerUserId,
+            signup.UserId, nameof(User));
 
         await DispatchSignupChangeNotificationAsync(signup, signup.Shift,
             $"Signup refused for '{signup.Shift.Rota.Name}' on day {signup.Shift.DayOffset}.");
@@ -255,8 +258,9 @@ public sealed class ShiftSignupService : IShiftSignupService, IUserDataContribut
 
         await _auditLogService.LogAsync(
             AuditAction.ShiftSignupBailed, nameof(ShiftSignup), signup.Id,
-            $"Bailed from shift '{signup.Shift.Rota.Name}'" + (reason is not null ? $": {reason}" : ""),
-            actorUserId);
+            $"shift '{signup.Shift.Rota.Name}'" + (reason is not null ? $": {reason}" : ""),
+            actorUserId,
+            signup.UserId, nameof(User));
 
         await DispatchSignupChangeNotificationAsync(signup, signup.Shift,
             $"Volunteer bailed from '{signup.Shift.Rota.Name}' on day {signup.Shift.DayOffset}.");
@@ -310,7 +314,7 @@ public sealed class ShiftSignupService : IShiftSignupService, IUserDataContribut
 
         await _auditLogService.LogAsync(
             AuditAction.ShiftSignupVoluntold, nameof(ShiftSignup), signup.Id,
-            $"Voluntold for shift '{shift.Rota.Name}'",
+            $"shift '{shift.Rota.Name}'",
             enrollerUserId,
             userId, nameof(User));
 
@@ -437,7 +441,7 @@ public sealed class ShiftSignupService : IShiftSignupService, IUserDataContribut
         {
             await _auditLogService.LogAsync(
                 AuditAction.ShiftSignupVoluntold, nameof(ShiftSignup), auditedSignup.Id,
-                $"Voluntold range for '{rota.Name}' day {dayOffset} (block {blockId})",
+                $"'{rota.Name}' day {dayOffset} (range, block {blockId})",
                 enrollerUserId,
                 userId, nameof(User));
         }
@@ -483,8 +487,9 @@ public sealed class ShiftSignupService : IShiftSignupService, IUserDataContribut
 
         await _auditLogService.LogAsync(
             AuditAction.ShiftSignupNoShow, nameof(ShiftSignup), signup.Id,
-            $"Marked no-show for shift '{signup.Shift.Rota.Name}'",
-            reviewerUserId);
+            $"shift '{signup.Shift.Rota.Name}'",
+            reviewerUserId,
+            signup.UserId, nameof(User));
 
         return SignupResult.Ok(signup);
     }
@@ -503,9 +508,10 @@ public sealed class ShiftSignupService : IShiftSignupService, IUserDataContribut
 
         await _auditLogService.LogAsync(
             AuditAction.ShiftSignupCancelled, nameof(ShiftSignup), signup.Id,
-            $"Removed from shift '{signup.Shift.Rota.Name}'" +
+            $"shift '{signup.Shift.Rota.Name}'" +
             (reason is not null ? $": {reason}" : ""),
-            removedByUserId);
+            removedByUserId,
+            signup.UserId, nameof(User));
 
         await DispatchSignupChangeNotificationAsync(signup, signup.Shift,
             $"Removed from '{signup.Shift.Rota.Name}' on day {signup.Shift.DayOffset}.");
@@ -666,8 +672,9 @@ public sealed class ShiftSignupService : IShiftSignupService, IUserDataContribut
                 await _auditLogService.LogAsync(
                     AuditAction.ShiftSignupConfirmed,
                     nameof(ShiftSignup), auditedSignup.Id,
-                    $"Range signup for '{rota.Name}' day {dayOffset} (block {blockId})",
-                    userId);
+                    $"'{rota.Name}' day {dayOffset} (range self-signup, block {blockId})",
+                    userId,
+                    userId, nameof(User));
             }
 
             await DispatchSignupChangeNotificationAsync(lastSignup!, availableShifts[^1], rota,
@@ -743,8 +750,9 @@ public sealed class ShiftSignupService : IShiftSignupService, IUserDataContribut
                 {
                     await _auditLogService.LogAsync(
                         AuditAction.ShiftSignupRefused, nameof(ShiftSignup), skipped.Id,
-                        $"Auto-refused (at capacity) for shift '{skipped.Shift.Rota.Name}' day {skipped.Shift.DayOffset} (block {signupBlockId})",
-                        reviewerUserId);
+                        $"shift '{skipped.Shift.Rota.Name}' day {skipped.Shift.DayOffset} (auto-refused, at capacity, block {signupBlockId})",
+                        reviewerUserId,
+                        skipped.UserId, nameof(User));
                 }
             }
             return SignupResult.Fail("Cannot approve: all shifts in this range are at capacity.");
@@ -756,16 +764,18 @@ public sealed class ShiftSignupService : IShiftSignupService, IUserDataContribut
         {
             await _auditLogService.LogAsync(
                 AuditAction.ShiftSignupConfirmed, nameof(ShiftSignup), approvedSignup.Id,
-                $"Range approved for shift '{approvedSignup.Shift.Rota.Name}' day {approvedSignup.Shift.DayOffset} (block {signupBlockId})",
-                reviewerUserId);
+                $"shift '{approvedSignup.Shift.Rota.Name}' day {approvedSignup.Shift.DayOffset} (range, block {signupBlockId})",
+                reviewerUserId,
+                approvedSignup.UserId, nameof(User));
         }
 
         foreach (var skipped in skippedAtCapacity)
         {
             await _auditLogService.LogAsync(
                 AuditAction.ShiftSignupRefused, nameof(ShiftSignup), skipped.Id,
-                $"Auto-refused (at capacity) for shift '{skipped.Shift.Rota.Name}' day {skipped.Shift.DayOffset} (block {signupBlockId})",
-                reviewerUserId);
+                $"shift '{skipped.Shift.Rota.Name}' day {skipped.Shift.DayOffset} (auto-refused, at capacity, block {signupBlockId})",
+                reviewerUserId,
+                skipped.UserId, nameof(User));
         }
 
         await DispatchSignupChangeNotificationAsync(approved[0], approved[0].Shift,
@@ -792,9 +802,10 @@ public sealed class ShiftSignupService : IShiftSignupService, IUserDataContribut
         {
             await _auditLogService.LogAsync(
                 AuditAction.ShiftSignupRefused, nameof(ShiftSignup), signup.Id,
-                $"Range refused for shift '{signup.Shift.Rota.Name}' day {signup.Shift.DayOffset} (block {signupBlockId})" +
+                $"shift '{signup.Shift.Rota.Name}' day {signup.Shift.DayOffset} (range, block {signupBlockId})" +
                 (reason is not null ? $": {reason}" : ""),
-                reviewerUserId);
+                reviewerUserId,
+                signup.UserId, nameof(User));
         }
 
         await DispatchSignupChangeNotificationAsync(signups[0], signups[0].Shift,
@@ -833,9 +844,10 @@ public sealed class ShiftSignupService : IShiftSignupService, IUserDataContribut
         {
             await _auditLogService.LogAsync(
                 AuditAction.ShiftSignupBailed, nameof(ShiftSignup), signup.Id,
-                $"Range bail from '{signup.Shift.Rota.Name}' day {signup.Shift.DayOffset} (block {signupBlockId})" +
+                $"shift '{signup.Shift.Rota.Name}' day {signup.Shift.DayOffset} (range, block {signupBlockId})" +
                 (reason is not null ? $": {reason}" : ""),
-                actorUserId);
+                actorUserId,
+                signup.UserId, nameof(User));
         }
 
         await DispatchSignupChangeNotificationAsync(firstSignup, firstSignup.Shift,

--- a/src/Humans.Application/Services/Shifts/ShiftSignupService.cs
+++ b/src/Humans.Application/Services/Shifts/ShiftSignupService.cs
@@ -441,7 +441,7 @@ public sealed class ShiftSignupService : IShiftSignupService, IUserDataContribut
         {
             await _auditLogService.LogAsync(
                 AuditAction.ShiftSignupVoluntold, nameof(ShiftSignup), auditedSignup.Id,
-                $"'{rota.Name}' day {dayOffset} (range, block {blockId})",
+                $"'{rota.Name}' day {dayOffset} (range)",
                 enrollerUserId,
                 userId, nameof(User));
         }
@@ -672,7 +672,7 @@ public sealed class ShiftSignupService : IShiftSignupService, IUserDataContribut
                 await _auditLogService.LogAsync(
                     AuditAction.ShiftSignupConfirmed,
                     nameof(ShiftSignup), auditedSignup.Id,
-                    $"'{rota.Name}' day {dayOffset} (range self-signup, block {blockId})",
+                    $"'{rota.Name}' day {dayOffset} (range)",
                     userId,
                     userId, nameof(User));
             }
@@ -750,7 +750,7 @@ public sealed class ShiftSignupService : IShiftSignupService, IUserDataContribut
                 {
                     await _auditLogService.LogAsync(
                         AuditAction.ShiftSignupRefused, nameof(ShiftSignup), skipped.Id,
-                        $"shift '{skipped.Shift.Rota.Name}' day {skipped.Shift.DayOffset} (auto-refused, at capacity, block {signupBlockId})",
+                        $"shift '{skipped.Shift.Rota.Name}' day {skipped.Shift.DayOffset} (auto-refused, at capacity)",
                         reviewerUserId,
                         skipped.UserId, nameof(User));
                 }
@@ -764,7 +764,7 @@ public sealed class ShiftSignupService : IShiftSignupService, IUserDataContribut
         {
             await _auditLogService.LogAsync(
                 AuditAction.ShiftSignupConfirmed, nameof(ShiftSignup), approvedSignup.Id,
-                $"shift '{approvedSignup.Shift.Rota.Name}' day {approvedSignup.Shift.DayOffset} (range, block {signupBlockId})",
+                $"shift '{approvedSignup.Shift.Rota.Name}' day {approvedSignup.Shift.DayOffset} (range)",
                 reviewerUserId,
                 approvedSignup.UserId, nameof(User));
         }
@@ -773,7 +773,7 @@ public sealed class ShiftSignupService : IShiftSignupService, IUserDataContribut
         {
             await _auditLogService.LogAsync(
                 AuditAction.ShiftSignupRefused, nameof(ShiftSignup), skipped.Id,
-                $"shift '{skipped.Shift.Rota.Name}' day {skipped.Shift.DayOffset} (auto-refused, at capacity, block {signupBlockId})",
+                $"shift '{skipped.Shift.Rota.Name}' day {skipped.Shift.DayOffset} (auto-refused, at capacity)",
                 reviewerUserId,
                 skipped.UserId, nameof(User));
         }
@@ -802,7 +802,7 @@ public sealed class ShiftSignupService : IShiftSignupService, IUserDataContribut
         {
             await _auditLogService.LogAsync(
                 AuditAction.ShiftSignupRefused, nameof(ShiftSignup), signup.Id,
-                $"shift '{signup.Shift.Rota.Name}' day {signup.Shift.DayOffset} (range, block {signupBlockId})" +
+                $"shift '{signup.Shift.Rota.Name}' day {signup.Shift.DayOffset} (range)" +
                 (reason is not null ? $": {reason}" : ""),
                 reviewerUserId,
                 signup.UserId, nameof(User));
@@ -844,7 +844,7 @@ public sealed class ShiftSignupService : IShiftSignupService, IUserDataContribut
         {
             await _auditLogService.LogAsync(
                 AuditAction.ShiftSignupBailed, nameof(ShiftSignup), signup.Id,
-                $"shift '{signup.Shift.Rota.Name}' day {signup.Shift.DayOffset} (range, block {signupBlockId})" +
+                $"shift '{signup.Shift.Rota.Name}' day {signup.Shift.DayOffset} (range)" +
                 (reason is not null ? $": {reason}" : ""),
                 actorUserId,
                 signup.UserId, nameof(User));

--- a/src/Humans.Web/ViewComponents/AuditLogViewComponent.cs
+++ b/src/Humans.Web/ViewComponents/AuditLogViewComponent.cs
@@ -109,6 +109,12 @@ public class AuditLogViewComponent : ViewComponent
         AuditAction.SignupRejected => "rejected signup for",
         AuditAction.TierApplicationApproved => "approved tier application for",
         AuditAction.TierApplicationRejected => "rejected tier application for",
+        AuditAction.ShiftSignupConfirmed => "confirmed signup for",
+        AuditAction.ShiftSignupRefused => "refused signup for",
+        AuditAction.ShiftSignupVoluntold => "voluntold",
+        AuditAction.ShiftSignupBailed => "bailed signup for",
+        AuditAction.ShiftSignupNoShow => "marked no-show for",
+        AuditAction.ShiftSignupCancelled => "removed signup for",
         _ => null
     };
 }

--- a/src/Humans.Web/ViewComponents/AuditLogViewComponent.cs
+++ b/src/Humans.Web/ViewComponents/AuditLogViewComponent.cs
@@ -112,23 +112,17 @@ public class AuditLogViewComponent : ViewComponent
         AuditAction.ShiftSignupConfirmed => "confirmed signup for",
         AuditAction.ShiftSignupRefused => "refused signup for",
         AuditAction.ShiftSignupVoluntold => "voluntold",
-        AuditAction.ShiftSignupBailed => "bailed signup for",
+        AuditAction.ShiftSignupBailed => "bailed",
         AuditAction.ShiftSignupNoShow => "marked no-show for",
         AuditAction.ShiftSignupCancelled => "removed signup for",
         _ => null
     };
 
-    /// <summary>
-    /// Self-form verb for actions where actor == subject. Avoids dangling
-    /// prepositions like "Frank confirmed signup for —" when the partial
-    /// suppresses the duplicate subject. Returns null to fall back to the
-    /// transitive form for actions where actor == subject is not a natural case.
-    /// </summary>
+    // Self-form: avoids dangling preposition when actor == subject (subject is suppressed in the view).
     public static string? GetActionSelfVerb(AuditAction action) => action switch
     {
         AuditAction.ShiftSignupConfirmed => "signed up for",
         AuditAction.ShiftSignupBailed => "bailed from",
-        AuditAction.ShiftSignupCancelled => "cancelled signup for",
         _ => null
     };
 }

--- a/src/Humans.Web/ViewComponents/AuditLogViewComponent.cs
+++ b/src/Humans.Web/ViewComponents/AuditLogViewComponent.cs
@@ -117,6 +117,20 @@ public class AuditLogViewComponent : ViewComponent
         AuditAction.ShiftSignupCancelled => "removed signup for",
         _ => null
     };
+
+    /// <summary>
+    /// Self-form verb for actions where actor == subject. Avoids dangling
+    /// prepositions like "Frank confirmed signup for —" when the partial
+    /// suppresses the duplicate subject. Returns null to fall back to the
+    /// transitive form for actions where actor == subject is not a natural case.
+    /// </summary>
+    public static string? GetActionSelfVerb(AuditAction action) => action switch
+    {
+        AuditAction.ShiftSignupConfirmed => "signed up for",
+        AuditAction.ShiftSignupBailed => "bailed from",
+        AuditAction.ShiftSignupCancelled => "cancelled signup for",
+        _ => null
+    };
 }
 
 public class AuditLogComponentViewModel

--- a/src/Humans.Web/ViewComponents/AuditLogViewComponent.cs
+++ b/src/Humans.Web/ViewComponents/AuditLogViewComponent.cs
@@ -125,6 +125,17 @@ public class AuditLogViewComponent : ViewComponent
         AuditAction.ShiftSignupBailed => "bailed from",
         _ => null
     };
+
+    // True when the action's description is written as a context tail (e.g. "shift 'X'") rather
+    // than a stand-alone sentence (e.g. "Joined Build Team directly"). Tail-style descriptions
+    // append cleanly after the structured verb+subject; sentence-style ones produce redundancy.
+    public static bool ShouldRenderDescriptionTail(AuditAction action) => action
+        is AuditAction.ShiftSignupConfirmed
+        or AuditAction.ShiftSignupRefused
+        or AuditAction.ShiftSignupVoluntold
+        or AuditAction.ShiftSignupBailed
+        or AuditAction.ShiftSignupNoShow
+        or AuditAction.ShiftSignupCancelled;
 }
 
 public class AuditLogComponentViewModel

--- a/src/Humans.Web/Views/Shared/Components/AuditLog/_Entry.cshtml
+++ b/src/Humans.Web/Views/Shared/Components/AuditLog/_Entry.cshtml
@@ -8,6 +8,13 @@
     var verb = AuditLogViewComponent.GetActionVerb(Model.Action);
     var selfVerb = AuditLogViewComponent.GetActionSelfVerb(Model.Action);
 
+    // Trims a dangling " for"/" to" preposition. Used when we can't render a
+    // subject (old rows pre-RelatedEntityId fix, or unmapped subject-less actions).
+    string TrimDanglingPreposition(string v)
+        => v.EndsWith(" for", StringComparison.Ordinal) ? v[..^4]
+         : v.EndsWith(" to", StringComparison.Ordinal) ? v[..^3]
+         : v;
+
     // Subject: the user being acted upon
     Guid? subjectId = Model.EntityType is "User" or "Profile" or "WorkspaceAccount"
         ? Model.EntityId
@@ -41,7 +48,17 @@
             <span class="text-muted">System</span>
         }
 
-        <span>@(actorIsSubject && selfVerb != null ? selfVerb : verb)</span>
+        @* Pick verb form:
+           - actor==subject: selfVerb when defined (avoids dangling "for")
+           - subject missing (old rows pre-RelatedEntityId fix): selfVerb if defined,
+             else trim trailing preposition. Most subject-less ShiftSignup* old rows
+             are self-actions so selfVerb is the honest default. *@
+        var displayVerb =
+            actorIsSubject && selfVerb != null ? selfVerb :
+            !subjectId.HasValue && selfVerb != null ? selfVerb :
+            !subjectId.HasValue ? TrimDanglingPreposition(verb) :
+            verb;
+        <span>@displayVerb</span>
 
         @* Subject (skip if same as actor) *@
         @if (subjectId.HasValue && !actorIsSubject)

--- a/src/Humans.Web/Views/Shared/Components/AuditLog/_Entry.cshtml
+++ b/src/Humans.Web/Views/Shared/Components/AuditLog/_Entry.cshtml
@@ -6,6 +6,7 @@
     string GetName(Guid id) => userNames.TryGetValue(id, out var n) ? n : "Unknown";
 
     var verb = AuditLogViewComponent.GetActionVerb(Model.Action);
+    var selfVerb = AuditLogViewComponent.GetActionSelfVerb(Model.Action);
 
     // Subject: the user being acted upon
     Guid? subjectId = Model.EntityType is "User" or "Profile" or "WorkspaceAccount"
@@ -40,7 +41,7 @@
             <span class="text-muted">System</span>
         }
 
-        <span>@verb</span>
+        <span>@(actorIsSubject && selfVerb != null ? selfVerb : verb)</span>
 
         @* Subject (skip if same as actor) *@
         @if (subjectId.HasValue && !actorIsSubject)

--- a/src/Humans.Web/Views/Shared/Components/AuditLog/_Entry.cshtml
+++ b/src/Humans.Web/Views/Shared/Components/AuditLog/_Entry.cshtml
@@ -48,16 +48,12 @@
             <span class="text-muted">System</span>
         }
 
-        @* Pick verb form:
-           - actor==subject: selfVerb when defined (avoids dangling "for")
-           - subject missing (old rows pre-RelatedEntityId fix): selfVerb if defined,
-             else trim trailing preposition. Most subject-less ShiftSignup* old rows
-             are self-actions so selfVerb is the honest default. *@
-        var displayVerb =
-            actorIsSubject && selfVerb != null ? selfVerb :
-            !subjectId.HasValue && selfVerb != null ? selfVerb :
-            !subjectId.HasValue ? TrimDanglingPreposition(verb) :
-            verb;
+        @* When the view will not render a subject (actor==subject or subject unknown),
+           use selfVerb if defined, else trim a trailing preposition from the transitive verb. *@
+        var noVisibleSubject = actorIsSubject || !subjectId.HasValue;
+        var displayVerb = noVisibleSubject && selfVerb != null ? selfVerb
+                        : noVisibleSubject ? TrimDanglingPreposition(verb)
+                        : verb;
         <span>@displayVerb</span>
 
         @* Subject (skip if same as actor) *@

--- a/src/Humans.Web/Views/Shared/Components/AuditLog/_Entry.cshtml
+++ b/src/Humans.Web/Views/Shared/Components/AuditLog/_Entry.cshtml
@@ -69,8 +69,9 @@
             <a asp-controller="Team" asp-action="Details" asp-route-slug="@team.Slug" class="text-decoration-none">@team.Name</a>
         }
 
-        @* Description tail (context like shift name, reason) *@
-        @if (!string.IsNullOrWhiteSpace(Model.Description))
+        @* Description tail — only for actions whose descriptions are written as tails (e.g. ShiftSignup*).
+           Sentence-style descriptions (Team*, Role*, Member*) would render redundantly here. *@
+        @if (!string.IsNullOrWhiteSpace(Model.Description) && AuditLogViewComponent.ShouldRenderDescriptionTail(Model.Action))
         {
             <span class="text-muted">— @Model.Description</span>
         }

--- a/src/Humans.Web/Views/Shared/Components/AuditLog/_Entry.cshtml
+++ b/src/Humans.Web/Views/Shared/Components/AuditLog/_Entry.cshtml
@@ -25,7 +25,7 @@
     var actorIsSubject = Model.ActorUserId.HasValue && subjectId.HasValue && Model.ActorUserId.Value == subjectId.Value;
 }
 
-<div class="d-flex align-items-baseline gap-1 small">
+<div class="d-flex align-items-baseline gap-1 small flex-wrap">
     <span class="text-muted text-nowrap">@Model.OccurredAt.ToAuditTimestamp()</span>
     <span class="text-muted">—</span>
     @if (verb != null)
@@ -54,9 +54,39 @@
             <span class="text-muted">in</span>
             <a asp-controller="Team" asp-action="Details" asp-route-slug="@team.Slug" class="text-decoration-none">@team.Name</a>
         }
+
+        @* Description tail (context like shift name, reason) *@
+        @if (!string.IsNullOrWhiteSpace(Model.Description))
+        {
+            <span class="text-muted">— @Model.Description</span>
+        }
     }
     else
     {
-        <span>@Model.Description</span>
+        @* Unmapped action — render rough but fully attributed: actor · ActionName · subject · in team · "description" *@
+        @if (Model.ActorUserId.HasValue)
+        {
+            <human-link user-id="@Model.ActorUserId.Value" display-name="@GetName(Model.ActorUserId.Value)" mode="Text" />
+        }
+        else
+        {
+            <span class="text-muted">System</span>
+        }
+        <span class="text-muted">·</span>
+        <span>@Model.Action.ToString()</span>
+        @if (subjectId.HasValue && !actorIsSubject)
+        {
+            <span class="text-muted">·</span>
+            <human-link user-id="@subjectId.Value" display-name="@GetName(subjectId.Value)" mode="Text" />
+        }
+        @if (targetTeamId.HasValue && teamNames.TryGetValue(targetTeamId.Value, out var fallbackTeam))
+        {
+            <span class="text-muted">in</span>
+            <a asp-controller="Team" asp-action="Details" asp-route-slug="@fallbackTeam.Slug" class="text-decoration-none">@fallbackTeam.Name</a>
+        }
+        @if (!string.IsNullOrWhiteSpace(Model.Description))
+        {
+            <span class="text-muted">— @Model.Description</span>
+        }
     }
 </div>


### PR DESCRIPTION
## Summary

The embedded audit log view component fell through to the unstructured description path for `ShiftSignup*` actions, hiding the actor entirely. Found while looking at a volunteer's audit history showing `Voluntold for shift 'LNT Set-up Crew'` with no indication of who did it.

Same rendering bug affects ~50 other unmapped actions (CampSeason*, CalendarEvent*, WorkspaceAccount*, etc.), so the fallback was tightened too.

## Changes

- **`AuditLogViewComponent.GetActionVerb`** — add the six `ShiftSignup` verbs so the structured `actor + verb + subject` path is used.
- **`ShiftSignupService`** — pass `signup.UserId` as `relatedEntity` on every audit call (only `Voluntell` did this before, so Approve/Refuse/Bail/NoShow/Cancel and their range variants had no Subject column on the global audit log either). Strip the verb-redundant prefix from descriptions, leaving just the context tail (`shift 'X'`, `shift 'X': reason`, `'rota' day N (range, block guid)`).
- **`_Entry.cshtml`**:
  - Mapped path now appends the description tail muted: `Frank voluntold Elia — shift 'LNT Set-up Crew'`.
  - Unmapped fallback renders `actor · ActionName · subject · in team · — description` instead of just dumping description-only. Rough but fully attributed for the ~50 actions still missing verb-mappings.

Old DB rows with the old descriptions still render correctly — they pick up the actor link they were missing, with the description tail trailing slightly redundantly (e.g. `Frank voluntold Elia — Voluntold for shift 'X'`). New rows render clean.

## Test plan

- [ ] Audit history on `/Profile/AdminDetail/{userId}` shows `Frank voluntold Elia — shift 'LNT Set-up Crew'` with both names as clickable human-links
- [ ] Self-signups still render without dup-name (`Frank confirmed signup — shift 'X' (self-signup)`)
- [ ] Bail by self renders without dup-name (`Frank bailed signup — shift 'X'`)
- [ ] Bail by coordinator renders both names (`Coordinator bailed signup Frank — shift 'X': reason`)
- [ ] Global audit log at `/Board/AuditLog` shows the volunteer in the Subject column for Approve/Refuse/Bail/NoShow/Cancel rows (was empty before)
- [ ] Unmapped actions like `CampSeasonApproved` now render with actor/subject/team in the embedded view component