### PR TITLE
feat(store): foundation — entities, migration, role, service skeleton

### DIFF
--- a/docs/features/06-teams.md
+++ b/docs/features/06-teams.md
@@ -295,11 +295,11 @@ Teams are either **departments** (top-level, no parent) or **sub-teams** (have a
 
 | Team | Auto-Add Trigger | Auto-Remove Trigger |
 |------|------------------|---------------------|
-| **Volunteers** | Approved + all required consents signed | Missing consent, suspended, or approval revoked |
+| **Volunteers** | Profile + all required consents signed (no CC approval required) | Missing consent, suspended, CC-flagged, or rejected |
 | **Coordinators** | Become Coordinator of any team + team consents | No longer Coordinator anywhere |
 | **Board** | Active "Board" RoleAssignment + team consents | RoleAssignment expires |
 
-Volunteers team membership is the source of truth for "active volunteer" status. Both approval (`AdminController.ApproveVolunteer`) and consent completion (`ConsentController.Submit`) trigger an immediate single-user sync via `SyncVolunteersMembershipForUserAsync` -- the user doesn't wait for the scheduled job.
+Volunteers team membership is the source of truth for "active volunteer" status. Consent completion (`ConsentController.Submit`) triggers an immediate single-user sync via `SyncVolunteersMembershipForUserAsync` so the user doesn't wait for the scheduled job. CC approval (`ProfileController.ApproveVolunteer`) also fires a single-user sync as an audit-track no-op for users already admitted.
 
 ### System Team Properties
 - `RequiresApproval = false` (auto-managed)
@@ -314,9 +314,10 @@ Volunteers team membership is the source of truth for "active volunteer" status.
 SystemTeamSyncJob (scheduled hourly, currently disabled; also triggered inline):
 
   1. SyncVolunteersTeamAsync()
-     - Get all users where IsApproved = true AND !IsSuspended
+     - Get all users with a profile where !IsSuspended, ConsentCheckStatus != Flagged, RejectedAt is null
      - Filter to those with all required Volunteers-team consents
      - Add missing members, remove ineligible
+     - (Profile.IsApproved is the CC's audit annotation; not consulted here)
 
   2. SyncCoordinatorsTeamAsync()
      - Get all users with TeamMember.Role = Coordinator (non-system teams)

--- a/docs/features/08-background-jobs.md
+++ b/docs/features/08-background-jobs.md
@@ -171,17 +171,18 @@ See [Profiles — Account Deletion](02-profiles.md#account-deletion-right-to-era
 **Schedule**: Hourly (**CURRENTLY DISABLED** for scheduled runs — modifies Google permissions). Can be triggered manually from Admin dashboard via "Sync System Teams" button.
 
 **Inline Triggers**: In addition to the scheduled job, single-user sync is triggered immediately by:
-- `AdminController.ApproveVolunteer` — after setting `IsApproved = true`
-- `ConsentController.Submit` — after recording a consent
+- `ProfileController.ApproveVolunteer` — after a Consent Coordinator clears the consent check (audit annotation; admission may already have happened via consent submit)
+- `ConsentController.Submit` — after recording a consent (this is the path that admits a new human to Volunteers)
 
 Both call `SyncVolunteersMembershipForUserAsync(userId)`, which evaluates a single user without affecting other members.
 
 **Process**:
 ```
 1. SyncVolunteersTeamAsync()
-   - Eligible: Approved (IsApproved), non-suspended, with all required Volunteers-team consents
+   - Eligible: Has a profile, !IsSuspended, ConsentCheckStatus != Flagged, RejectedAt is null, with all required Volunteers-team consents
    - Add: New eligible users
-   - Remove: Users who lost eligibility
+   - Remove: Users who lost eligibility (suspended, flagged, rejected, or consent lapsed)
+   - (Profile.IsApproved is the CC audit annotation; not consulted)
 
 2. SyncCoordinatorsTeamAsync()
    - Eligible: Users who are Coordinator of any user-created team + Coordinators-team consents
@@ -201,7 +202,7 @@ Both call `SyncVolunteersMembershipForUserAsync(userId)`, which evaluates a sing
 **System Teams**:
 | Team | Eligibility Criteria |
 |------|---------------------|
-| Volunteers | IsApproved AND !IsSuspended AND HasAllRequiredConsentsForTeam(Volunteers) |
+| Volunteers | HasProfile AND !IsSuspended AND ConsentCheckStatus != Flagged AND RejectedAt is null AND HasAllRequiredConsentsForTeam(Volunteers) |
 | Coordinators | TeamMember.Role = Coordinator (non-system teams) AND HasAllRequiredConsentsForTeam(Coordinators) |
 | Board | RoleAssignment.RoleName = "Board" AND active AND HasAllRequiredConsentsForTeam(Board) |
 

--- a/docs/features/12-audit-log.md
+++ b/docs/features/12-audit-log.md
@@ -207,11 +207,7 @@ Displays the 50 most recent audit entries affecting a user, queried by:
 - `EntityType = 'User' AND EntityId = @userId` (direct entries)
 - `RelatedEntityId = @userId` (related entries, e.g., team membership changes)
 
-Each entry shows:
-- Description (bold)
-- Badge: "System" (info) for job-generated entries, "Admin" (secondary) for human-initiated entries
-- Actor name: resolved at render time from ActorUserId via batch lookup
-- Timestamp (right-aligned)
+Each entry renders structurally as: `[timestamp] — [actor] [verb] [subject] in [team] — [description]`. Verbs are mapped per `AuditAction` in `AuditLogViewComponent.GetActionVerb`; a self-form (`GetActionSelfVerb`) is used when actor == subject to avoid dangling prepositions. Actor and subject are resolved as clickable `<human-link>` from `UserDisplayNames` (batch-loaded). Unmapped actions fall back to a rough `[actor] · [ActionName] · [subject] — [description]` form so attribution is never lost.
 
 ## Authorization
 

--- a/docs/sections/LegalAndConsent.md
+++ b/docs/sections/LegalAndConsent.md
@@ -10,19 +10,19 @@
   src/Humans.Web/Controllers/AdminLegalDocumentsController.cs
 -->
 <!-- freshness:flag-on-change
-  ConsentRecord append-only DB-trigger invariant, document sync from GitHub, and consent-coordinator review gate — review when Legal/Consent services/entities/controllers change.
+  ConsentRecord append-only DB-trigger invariant, document sync from GitHub, and the Consent Coordinator review queue (audit-only, NOT a gate for Volunteers admission) — review when Legal/Consent services/entities/controllers change.
 -->
 
 # Legal & Consent — Section Invariants
 
-Legal documents synced from GitHub, per-version consent records (append-only), the Consent Coordinator review gate.
+Legal documents synced from GitHub, per-version consent records (append-only), the Consent Coordinator audit/review queue.
 
 ## Concepts
 
 - A **Legal Document** is a named, team-scoped document (e.g., "Privacy Policy", "Volunteer Agreement"). Documents on the Volunteers system team apply to every active human. Each document points at a folder in the configured GitHub repository and is synced from there by `LegalDocumentSyncService` / `SyncLegalDocumentsJob`.
 - A **Document Version** is a specific revision of a legal document with an `EffectiveFrom` instant and a multi-language `Content` dictionary keyed by language code (Spanish `"es"` is canonical/legally binding). When the GitHub commit SHA for the canonical file changes, the sync produces a new version; if `RequiresReConsent` is true, affected users are re-notified.
 - A **Consent Record** is an append-only audit entry linking a user to a specific document version with timestamp, IP, user-agent, content hash, and an `ExplicitConsent` flag. Consent records can never be updated or deleted — only new records can be inserted.
-- **Consent Check** is the safety gate in the onboarding pipeline. After a human signs all required documents, a Consent Coordinator reviews and either clears or flags the check.
+- **Consent Check** is an audit/annotation track maintained on the profile (`Profile.ConsentCheckStatus`). After a human signs all required documents, the status flips to `Pending` and the human appears in the Consent Coordinator review queue. CC actions (Clear / Flag / Reject) maintain the annotation but do NOT gate admission to the Volunteers team — admission is automatic once profile + consents are complete.
 - The **Statutes** page (`/Legal`) is a separate, anonymous read of the association's statutes pulled directly from GitHub by `LegalDocumentService` (with in-memory caching) — it does not go through the `legal_documents` table.
 
 ## Data Model
@@ -76,9 +76,9 @@ Cross-aggregate nav `ConsentRecord.DocumentVersion` — still declared and walke
 
 ## Triggers
 
-- When a human signs all required global documents: their consent check status transitions to Pending.
-- When a Consent Coordinator clears a consent check: the human is auto-approved as a Volunteer and added to the Volunteers system team.
-- When a Consent Coordinator flags a consent check: the human's Volunteer activation is blocked until Board or Admin review.
+- When a human signs all required global documents: their consent check status transitions to Pending AND `ISystemTeamSync.SyncVolunteersMembershipForUserAsync` admits them to the Volunteers system team. Admission does not depend on Consent Coordinator review.
+- When a Consent Coordinator clears a consent check: `Profile.IsApproved` is set to true and `ConsentCheckStatus = Cleared`. This is an audit annotation; the human is already a Volunteer.
+- When a Consent Coordinator flags a consent check: `Profile.IsApproved` is set to false, `ConsentCheckStatus = Flagged`, and `DeprovisionApprovalGatedSystemTeamsAsync` removes the user from Volunteers / Colaborador / Asociado teams. The Volunteers admission criteria explicitly exclude `ConsentCheckStatus == Flagged`, so the user stays out until Board or Admin resolves via `ProfileController.ApproveVolunteer`.
 - When a new document version is published: affected humans are notified to re-consent. A background job sends re-consent reminders.
 - A background job suspends humans who no longer have valid consents for required documents.
 

--- a/docs/sections/Onboarding.md
+++ b/docs/sections/Onboarding.md
@@ -20,10 +20,10 @@ Pure orchestrator over Profiles, Legal & Consent, Teams, and Governance. Owns no
 
 ## Concepts
 
-- **Onboarding** is the process a new human goes through to become an active Volunteer: sign up via Google OAuth, complete their profile, consent to all required legal documents, and pass a profile review by a Consent Coordinator. The last two steps can happen in any order.
+- **Onboarding** is the process a new human goes through to become an active Volunteer: sign up via Google OAuth, complete their profile, and consent to all required legal documents. Once both are done, admission to the Volunteers team is automatic — no Consent Coordinator approval is required for entry.
 - The **Membership Gate** restricts most of the application to active Volunteers. Humans still onboarding are limited to their profile, consent, feedback, legal documents, camps (public), and the home dashboard. All admin and coordinator roles bypass this gate entirely.
 - **Profileless accounts** are authenticated users with no Profile record (e.g., ticket holders, newsletter subscribers created by imports). They are redirected to the Guest dashboard instead of the Home dashboard and see a reduced nav: Guest Dashboard, Camps, Teams (public), Calendar, Legal. They can create a profile to enter the standard onboarding flow.
-- The **Profile Review** (consent check) and **Legal Document Signing** are independent, parallel tracks. A Consent Coordinator can clear the profile review before or after legal documents are signed. Admission to the Volunteers team only happens when both are complete.
+- The **Consent Coordinator review** (`Profile.ConsentCheckStatus`) is an audit/annotation track that runs in parallel with admission. When all required consents are signed, `ConsentCheckStatus` flips to `Pending` and the human appears in the CC review queue. CC actions (Clear / Flag / Reject) maintain the audit annotation and still flip `Profile.IsApproved`, but admission to the Volunteers team is decoupled from CC review — admission happens on profile-complete + consents-complete regardless of `IsApproved`.
 
 ## Data Model
 
@@ -43,9 +43,10 @@ The only onboarding-specific value type is the narrow `IOnboardingEligibilityQue
 
 ## Invariants
 
-- Onboarding steps: (1) complete profile, (2a) consent to all required global legal documents, (2b) profile review by a Consent Coordinator — these two can happen in any order, (3) auto-approval as Volunteer when both 2a and 2b are complete.
+- Onboarding steps: (1) complete profile, (2) consent to all required global legal documents, (3) automatic admission to the Volunteers system team. CC review of the consent check is an independent audit track that runs in parallel — it does not gate admission.
 - Volunteer onboarding is never blocked by tier applications — they are separate, parallel paths.
 - The ActiveMember status is derived from membership in the Volunteers system team.
+- Volunteers admission is `!IsSuspended && ConsentCheckStatus != Flagged && RejectedAt is null && HasAllRequiredConsentsForTeam(Volunteers)`. `Profile.IsApproved` is the CC's audit annotation and is NOT consulted for admission. The `Flagged` and `RejectedAt` exclusions preserve the CC's kick-out levers — `FlagConsentCheckAsync` and `RejectSignupAsync` set those fields before calling `DeprovisionApprovalGatedSystemTeamsAsync`, so the deprovision actually removes the user from Volunteers.
 - All admin and coordinator roles bypass the membership gate entirely — they can access the full application regardless of membership status.
 - OAuth login checks verified UserEmails, unverified UserEmails, and User.Email before creating a new account — preventing duplicate accounts when the same email exists on another user in any form.
 - `OnboardingService` depends only on interfaces (plus `IClock`) — no `DbContext`, `IDbContextFactory`, `DbSet<T>`, `IMemoryCache`, `IFullProfileInvalidator`, or repository. Enforced by `OnboardingArchitectureTests`.
@@ -60,9 +61,9 @@ The only onboarding-specific value type is the narrow `IOnboardingEligibilityQue
 
 ## Triggers
 
-- When a human completes their profile and signs all required documents: `OnboardingService.SetConsentCheckPendingIfEligibleAsync` flips `Profile.ConsentCheckStatus` to `Pending` (only if not already approved and `IMembershipCalculator.HasAllRequiredConsentsForTeamAsync(Volunteers)` returns true), and notifies the ConsentCoordinator role.
-- When a profile review is cleared: `Profile.IsApproved` is set to true and `ConsentCheckStatus = Cleared`. `ISystemTeamSync.SyncVolunteersMembershipForUserAsync` runs — it adds the user to the Volunteers system team only if `IsApproved && !IsSuspended && HasAllRequiredConsentsForTeam(Volunteers)` is true, so admission happens whenever the last condition is met (cleared first then last consent signed, or all consents signed first then cleared). If the user already has approved Colaborador/Asociado tiers, those team syncs run too. No email is sent on this auto-approval path.
-- When a legal document is signed: `ConsentService.SubmitConsentAsync` calls `SetConsentCheckPendingIfEligibleAsync` (flipping the consent check to Pending if all consents are now in) and `SyncVolunteersMembershipForUserAsync` (which admits the user iff `IsApproved` is also true).
+- When a human completes their profile and signs all required documents: `OnboardingService.SetConsentCheckPendingIfEligibleAsync` flips `Profile.ConsentCheckStatus` to `Pending` (only if not already approved and `IMembershipCalculator.HasAllRequiredConsentsForTeamAsync(Volunteers)` returns true), and notifies the ConsentCoordinator role. This is the audit/annotation track — admission to Volunteers happens automatically and does not depend on this flow.
+- When a legal document is signed: `ConsentService.SubmitConsentAsync` calls `SetConsentCheckPendingIfEligibleAsync` (flipping the consent check to Pending if all consents are now in) and `SyncVolunteersMembershipForUserAsync`, which admits the user to the Volunteers system team if `!IsSuspended && ConsentCheckStatus != Flagged && RejectedAt is null && HasAllRequiredConsentsForTeam(Volunteers)`. `Profile.IsApproved` is not consulted.
+- When a profile review is cleared by a CC: `Profile.IsApproved` is set to true and `ConsentCheckStatus = Cleared`. `ISystemTeamSync.SyncVolunteersMembershipForUserAsync` runs but is a no-op for admission if the user is already a Volunteer team member. No email is sent on this audit-track path.
 - When a consent check is flagged: `Profile.IsApproved` is set to false, `ConsentCheckStatus = Flagged`, and Volunteers / Colaborador / Asociado memberships are de-provisioned via `DeprovisionApprovalGatedSystemTeamsAsync`. Board or Admin must resolve via `ProfileController.ApproveVolunteer` (manual override).
 - When a signup is rejected: `Profile.RejectedAt`, `RejectionReason`, and `RejectedByUserId` are recorded; `IsApproved` is set to false; system team memberships are de-provisioned; a `SignupRejected` email and `ProfileRejected` notification are dispatched. (`Profile` has no `IsRejected` boolean — rejection is detected by `RejectedAt is not null`.)
 - When a Board+Admin manually `ApproveVolunteerAsync` (override path used after a flag is resolved): `IsApproved` is set to true, Volunteers team sync runs, and a `VolunteerApproved` notification ("Welcome! You have been approved") is dispatched.

--- a/docs/sections/Store.md
+++ b/docs/sections/Store.md
@@ -1,0 +1,228 @@
+<!-- freshness:triggers
+  src/Humans.Application/Services/Store/**
+  src/Humans.Application/Interfaces/Store/**
+  src/Humans.Application/Interfaces/Repositories/IStoreRepository.cs
+  src/Humans.Domain/Entities/Store*.cs
+  src/Humans.Domain/Enums/Store*.cs
+  src/Humans.Infrastructure/Data/Configurations/Store/**
+  src/Humans.Infrastructure/Repositories/Store/**
+  src/Humans.Web/Controllers/Store*.cs
+  src/Humans.Web/Authorization/Requirements/StoreOrder*.cs
+-->
+<!-- freshness:flag-on-change
+  Store catalog editing, order lifecycle, OrderableUntil gate, invoice issuance idempotency, treasury sync matching, and resource-based authorization — review when Store services/entities/controllers/auth handlers change.
+-->
+
+# Store — Section Invariants
+
+Per-camp catalog ordering, multi-method payments, and consolidated Holded factura issuance for Camp Lead purchases.
+
+## Concepts
+
+- A **Store Product** is a catalog item available to Camp Leads in a given event year (price, VAT rate, optional deposit, ordering deadline). Products are created and edited by StoreAdmin.
+- A **Store Order** is a Camp Lead's order against a `CampSeason`. Lifecycle: **Open** → **InvoiceIssued**. Multiple orders per `CampSeason` are allowed, distinguished by an optional `Label`.
+- A **Store Order Line** is a line on an order that snapshots the product's price, VAT, and deposit at the time the line was added — later catalog edits never mutate existing lines.
+- A **Store Payment** is a payment against an order, recorded with one of three methods (`Stripe`, `BankTransfer`, `Manual`). Negative amounts represent refunds.
+- A **Store Invoice** is the consolidated Holded factura issued for an order. One invoice per order, written once at issuance.
+- A **Store Treasury Sync State** is the singleton cursor row that the treasury-sync job uses to track its last successful Holded poll.
+
+## Data Model
+
+### StoreProduct
+
+Catalog item for a given event year.
+
+**Table:** `store_products`
+
+| Property | Type | Notes |
+|----------|------|-------|
+| Id | Guid | PK |
+| Year | int | Event year (plain int — no FK to CampSettings/CampSeason) |
+| Name | string(200) | Required |
+| Description | string(2000) | Required |
+| UnitPriceEur | numeric(12,2) | |
+| VatRatePercent | numeric(5,2) | |
+| DepositAmountEur | numeric(12,2)? | Optional per-unit deposit |
+| OrderableUntil | LocalDate | Add-line deadline |
+| IsActive | bool | Soft-deactivate |
+| CreatedAt | Instant | |
+| UpdatedAt | Instant | |
+
+**Indexes:** `(Year, IsActive)`.
+
+### StoreOrder
+
+A camp's order against a season.
+
+**Table:** `store_orders`
+
+| Property | Type | Notes |
+|----------|------|-------|
+| Id | Guid | PK |
+| CampSeasonId | Guid | FK only — no nav |
+| Label | string(100)? | Optional disambiguator within a season |
+| State | StoreOrderState (int) | Open or InvoiceIssued |
+| CounterpartyName / VatId / Address / CountryCode / Email | string? | Editable by Camp Lead while Open; FinanceAdmin always |
+| IssuedInvoiceId | Guid? | Set when invoice is issued |
+| CreatedAt / UpdatedAt | Instant | |
+
+**Indexes:** `CampSeasonId`, `State`.
+
+**Cross-section FKs:** `CampSeasonId` → `CampSeason` (Camps) — **FK only**, no navigation property.
+
+**Aggregate-local navs:** `StoreOrder.Lines`, `StoreOrder.Payments`.
+
+### StoreOrderLine
+
+**Table:** `store_order_lines`
+
+| Property | Type | Notes |
+|----------|------|-------|
+| Id | Guid | PK |
+| OrderId | Guid | FK to store_orders, cascade delete |
+| ProductId | Guid | FK only — no nav |
+| Qty | int | |
+| UnitPriceSnapshot | numeric(12,2) | Snapshot at add-time |
+| VatRateSnapshot | numeric(5,2) | Snapshot at add-time |
+| DepositAmountSnapshot | numeric(12,2)? | Snapshot at add-time |
+| AddedAt | Instant | |
+| AddedByUserId | Guid | FK only — no nav |
+
+**Indexes:** `OrderId`, `ProductId`.
+
+### StorePayment
+
+**Table:** `store_payments`
+
+| Property | Type | Notes |
+|----------|------|-------|
+| Id | Guid | PK |
+| OrderId | Guid | FK to store_orders, cascade delete |
+| AmountEur | numeric(12,2) | Signed — negative = refund |
+| Method | StorePaymentMethod (int) | Stripe / BankTransfer / Manual |
+| StripePaymentIntentId | string(200)? | Unique when present (filtered unique index) |
+| ExternalRef | string(200)? | e.g. Holded treasury entry id |
+| ReceivedAt | Instant | |
+| RecordedByUserId | Guid? | FK only — no nav |
+| Notes | string(1000)? | |
+
+**Indexes:** `OrderId`, unique-filtered `StripePaymentIntentId`.
+
+### StoreInvoice
+
+One per order; written once at issuance.
+
+**Table:** `store_invoices`
+
+| Property | Type | Notes |
+|----------|------|-------|
+| Id | Guid | PK |
+| OrderId | Guid | Unique |
+| HoldedDocId | string(100) | Unique |
+| HoldedDocNumber | string(50) | |
+| IssuedAt | Instant | |
+| IssuedByUserId | Guid | FK only — no nav |
+| RequestPayload | jsonb | Full Holded request body for audit |
+| ResponsePayload | jsonb | Full Holded response body for audit |
+
+**Indexes:** unique `OrderId`, unique `HoldedDocId`.
+
+### StoreTreasurySyncState
+
+Singleton cursor row (`Id = 1`).
+
+**Table:** `store_treasury_sync_state`
+
+| Property | Type | Notes |
+|----------|------|-------|
+| Id | int | Always 1 |
+| LastSyncAt | Instant? | Cursor for next poll |
+| SyncStatus | string(20) | Idle / Running / Error |
+| LastError | string(2000)? | Last error message |
+
+### StoreOrderState
+
+| Value | Int | Description |
+|-------|-----|-------------|
+| Open | 0 | Lines, counterparty, payments freely editable |
+| InvoiceIssued | 1 | Lines + counterparty frozen; payments continue |
+
+Stored as int via `HasConversion<int>()`.
+
+### StorePaymentMethod
+
+| Value | Int | Description |
+|-------|-----|-------------|
+| Stripe | 0 | From the Stripe webhook |
+| BankTransfer | 1 | From the Holded treasury sync job |
+| Manual | 2 | Manual entry by FinanceAdmin |
+
+Stored as int via `HasConversion<int>()`.
+
+## Routing
+
+- `/Store` — Camp Lead order browse + create + line edit.
+- `/Store/Order/{id}` — Camp Lead order detail (balance + Pay button).
+- `/Store/Admin/Catalog` — StoreAdmin catalog CRUD.
+- `/Store/Admin/Orders` — FinanceAdmin order ledger + payment entry + Issue Invoice.
+- `/Store/Summary` — FinanceAdmin per-camp + per-item summary.
+- `/Store/StripeWebhook` — anonymous endpoint for Stripe checkout-session events.
+
+## Actors & Roles
+
+| Actor | Capabilities |
+|-------|--------------|
+| Camp Lead | View / create orders for camp-seasons they lead. Add and remove lines while order is Open and the product's `OrderableUntil` has not passed. Edit counterparty fields while Open. Initiate Stripe checkout to pay. |
+| StoreAdmin | Manage the catalog (`/Store/Admin/Catalog`): create, edit, deactivate products. |
+| FinanceAdmin, Admin | All Camp Lead and StoreAdmin capabilities. Record manual payments (incl. refunds via negative amounts) regardless of order state. Issue invoice (single + Issue All). View `/Store/Summary`. Run treasury sync on demand. |
+
+## Invariants
+
+- An order follows the lifecycle: **Open → InvoiceIssued**. There is no return-to-Open transition.
+- Lines may only be added or removed while the order is `Open` AND `today <= Product.OrderableUntil` (enforced in `StoreService.AddLineAsync` / `RemoveLineAsync`).
+- Counterparty fields (Name, VAT id, Address, CountryCode, Email) are editable only while the order is `Open` (Camp Lead) or by FinanceAdmin/Admin always.
+- Line snapshots (`UnitPriceSnapshot`, `VatRateSnapshot`, `DepositAmountSnapshot`) are written at add-time and never recomputed — later catalog edits to `StoreProduct` do not propagate to existing lines.
+- Payments may be recorded regardless of order state — payments do not freeze on issuance.
+- Issuing an invoice is idempotent: re-issuing an order that already has `IssuedInvoiceId` set throws and does NOT call Holded.
+- Issue-invoice failure mid-flight leaves the order in `Open` state with no `StoreInvoice` row (atomic on success only).
+- A Stripe `checkout.session.completed` event with a known `humans_store_order_id` inserts at most one `StorePayment` per `StripePaymentIntentId` (filtered unique index + service-level dedup check).
+- The treasury sync job matches Holded entries to orders **best-effort** by exact `Order.Label` ↔ entry description; ambiguous matches (multiple orders share a Label) are skipped and logged.
+- Resource-based authorization per design-rules §11: `StoreOrderAuthorizationHandler` + `StoreOrderOperationRequirement` gate Camp Lead writes against the order's parent camp-season (Phase 2).
+
+## Negative Access Rules
+
+- A Camp Lead **cannot** add or remove lines after an order's first product `OrderableUntil` has passed (deadline is per-product, evaluated at write time).
+- A Camp Lead **cannot** edit lines or counterparty on an order in `InvoiceIssued` state.
+- A Camp Lead **cannot** view or edit orders for camp-seasons they do not lead (resource-based auth).
+- StoreAdmin **cannot** record payments, issue invoices, or view the order ledger — those are FinanceAdmin/Admin only.
+- Anyone other than FinanceAdmin/Admin **cannot** issue an invoice or run the treasury sync job manually.
+- Re-issuing an already-issued order **cannot** succeed — the second call throws and does not contact Holded.
+
+## Triggers
+
+- Every Order create, line add/remove, counterparty edit, payment record, and invoice issuance emits an audit log entry via `IAuditLogService` (Phases 2, 3, 5).
+- `IssueInvoiceAsync` calls `IHoldedClient.UpsertContactAsync` then `IHoldedClient.CreateInvoiceAsync`, then writes the `StoreInvoice` row and flips `StoreOrder.State = InvoiceIssued` in the same logical operation (Phase 5).
+- The Stripe webhook controller verifies the request signature with `STRIPE_WEBHOOK_SECRET` and inserts a `StorePayment(Method=Stripe)` for `checkout.session.completed` events (Phase 6).
+- `StoreTreasurySyncJob` (Hangfire recurring) polls `IHoldedClient.ListTreasuryEntriesAsync` from `StoreTreasurySyncState.LastSyncAt`, inserts `StorePayment(Method=BankTransfer)` for unambiguous Label matches, and advances the cursor (Phase 7).
+
+## Cross-Section Dependencies
+
+- **Camps:** `ICampService` for `CampSeason` lookups (camp name, lead resolution for resource-based auth).
+- **Auth/Roles:** `RoleNames.StoreAdmin` (this section), `RoleNames.FinanceAdmin`, `RoleNames.Admin`.
+- **Holded connector** (Infrastructure): `IHoldedClient` extended with `UpsertContactAsync`, `CreateInvoiceAsync`, `ListTreasuryEntriesAsync` in Phase 4.
+- **Stripe connector** (Infrastructure): `IStripeService.CreateCheckoutSessionAsync` added in Phase 6.
+- **Audit Log:** `IAuditLogService` for every mutation.
+
+## Architecture
+
+**Owning services:** `StoreService`
+**Owned tables:** `store_products`, `store_orders`, `store_order_lines`, `store_payments`, `store_invoices`, `store_treasury_sync_state`
+**Status:** (A) Migrated — new section, born §15-compliant (peterdrier/Humans store-foundation, 2026-04-30).
+
+- `StoreService` lives in `Humans.Application.Services.Store` and depends only on Application-layer abstractions.
+- `StoreRepository` (impl `Humans.Infrastructure/Repositories/Store/StoreRepository.cs`, §15b Singleton + `IDbContextFactory`) is the only file that touches Store tables via `DbContext`.
+- **Decorator decision — no caching decorator.** Store is admin / camp-lead only, low-traffic; same rationale as Budget / Governance.
+- **Cross-domain navs:** none. `CampSeasonId`, `ProductId`, `AddedByUserId`, `RecordedByUserId`, `IssuedByUserId` are all FK-only with no navigation property.
+- **Cross-section calls** route through `ICampService` (camp / camp-season lookups), `IAuditLogService`, `IHoldedClient`, `IStripeService`.
+
+Phase 1 ships entities, migration, role, service skeleton (methods throw `NotSupportedException` until later phases). Phases 2–7 progressively fill the surface; see `docs/superpowers/specs/2026-04-30-store-section-design.md` and `docs/superpowers/plans/2026-04-30-store-section.md`.

--- a/src/Humans.Application/Interfaces/Repositories/IStoreRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/IStoreRepository.cs
@@ -1,0 +1,46 @@
+using Humans.Domain.Entities;
+
+namespace Humans.Application.Interfaces.Repositories;
+
+/// <summary>
+/// Repository for the Store section's tables: <c>store_products</c>,
+/// <c>store_orders</c>, <c>store_order_lines</c>, <c>store_payments</c>,
+/// <c>store_invoices</c>, and <c>store_treasury_sync_state</c>. The only
+/// non-test file that writes to these DbSets.
+/// </summary>
+/// <remarks>
+/// Follows the §15b Singleton + <c>IDbContextFactory</c> pattern: every method
+/// opens its own short-lived <c>DbContext</c>, performs its work, and saves
+/// atomically within that context's lifetime.
+/// </remarks>
+public interface IStoreRepository
+{
+    // Products
+    Task<IReadOnlyList<StoreProduct>> GetActiveProductsForYearAsync(int year, CancellationToken ct = default);
+    Task<StoreProduct?> GetProductByIdAsync(Guid productId, CancellationToken ct = default);
+    Task AddProductAsync(StoreProduct product, CancellationToken ct = default);
+    Task UpdateProductAsync(StoreProduct product, CancellationToken ct = default);
+
+    // Orders
+    Task<IReadOnlyList<StoreOrder>> GetOrdersForCampSeasonAsync(Guid campSeasonId, CancellationToken ct = default);
+    Task<StoreOrder?> GetOrderByIdAsync(Guid orderId, CancellationToken ct = default);
+    Task<StoreOrder?> GetOrderWithLinesAndPaymentsAsync(Guid orderId, CancellationToken ct = default);
+    Task<IReadOnlyList<StoreOrder>> GetAllOrdersWithAggregatesAsync(int year, CancellationToken ct = default);
+    Task AddOrderAsync(StoreOrder order, CancellationToken ct = default);
+    Task UpdateOrderAsync(StoreOrder order, CancellationToken ct = default);
+
+    // Lines
+    Task AddLineAsync(StoreOrderLine line, CancellationToken ct = default);
+    Task RemoveLineAsync(Guid lineId, CancellationToken ct = default);
+
+    // Payments
+    Task AddPaymentAsync(StorePayment payment, CancellationToken ct = default);
+    Task<bool> StripePaymentIntentExistsAsync(string paymentIntentId, CancellationToken ct = default);
+
+    // Invoices
+    Task AddInvoiceAsync(StoreInvoice invoice, CancellationToken ct = default);
+
+    // Treasury sync state
+    Task<StoreTreasurySyncState> GetOrCreateTreasurySyncStateAsync(CancellationToken ct = default);
+    Task UpdateTreasurySyncStateAsync(StoreTreasurySyncState state, CancellationToken ct = default);
+}

--- a/src/Humans.Application/Interfaces/Repositories/IStoreRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/IStoreRepository.cs
@@ -25,7 +25,7 @@ public interface IStoreRepository
     Task<IReadOnlyList<StoreOrder>> GetOrdersForCampSeasonAsync(Guid campSeasonId, CancellationToken ct = default);
     Task<StoreOrder?> GetOrderByIdAsync(Guid orderId, CancellationToken ct = default);
     Task<StoreOrder?> GetOrderWithLinesAndPaymentsAsync(Guid orderId, CancellationToken ct = default);
-    Task<IReadOnlyList<StoreOrder>> GetAllOrdersWithAggregatesAsync(int year, CancellationToken ct = default);
+    Task<IReadOnlyList<StoreOrder>> GetAllOrdersAsync(CancellationToken ct = default);
     Task AddOrderAsync(StoreOrder order, CancellationToken ct = default);
     Task UpdateOrderAsync(StoreOrder order, CancellationToken ct = default);
 

--- a/src/Humans.Application/Interfaces/Store/IStoreService.cs
+++ b/src/Humans.Application/Interfaces/Store/IStoreService.cs
@@ -1,0 +1,41 @@
+using Humans.Application.Services.Store.Dtos;
+using Humans.Domain.Enums;
+
+namespace Humans.Application.Interfaces.Store;
+
+public interface IStoreService
+{
+    // Catalog (read)
+    Task<IReadOnlyList<ProductDto>> GetActiveCatalogAsync(int year, CancellationToken ct = default);
+
+    // Catalog (write — StoreAdmin)
+    Task<Guid> CreateProductAsync(ProductDto draft, Guid actorUserId, CancellationToken ct = default);
+    Task UpdateProductAsync(ProductDto draft, Guid actorUserId, CancellationToken ct = default);
+    Task DeactivateProductAsync(Guid productId, Guid actorUserId, CancellationToken ct = default);
+
+    // Orders (camp lead)
+    Task<IReadOnlyList<OrderDto>> GetOrdersForCampSeasonAsync(Guid campSeasonId, CancellationToken ct = default);
+    Task<OrderDto?> GetOrderAsync(Guid orderId, CancellationToken ct = default);
+    Task<Guid> CreateOrderAsync(Guid campSeasonId, string? label, Guid actorUserId, CancellationToken ct = default);
+    Task AddLineAsync(Guid orderId, Guid productId, int qty, Guid actorUserId, CancellationToken ct = default);
+    Task RemoveLineAsync(Guid lineId, Guid actorUserId, CancellationToken ct = default);
+
+    // Counterparty (camp lead pre-issuance, FinanceAdmin always)
+    Task UpdateCounterpartyAsync(Guid orderId, OrderCounterpartyInput input, Guid actorUserId, CancellationToken ct = default);
+
+    // Payments (FinanceAdmin)
+    Task RecordManualPaymentAsync(Guid orderId, decimal amountEur, StorePaymentMethod method, string? externalRef, string? notes, Guid actorUserId, CancellationToken ct = default);
+
+    // Invoice issuance (FinanceAdmin) — implemented in Phase 5
+    Task IssueInvoiceAsync(Guid orderId, Guid actorUserId, CancellationToken ct = default);
+
+    // Summary
+    Task<IReadOnlyList<OrderSummaryDto>> GetAllOrderSummariesAsync(int year, CancellationToken ct = default);
+}
+
+public record OrderCounterpartyInput(
+    string? Name,
+    string? VatId,
+    string? Address,
+    string? CountryCode,
+    string? Email);

--- a/src/Humans.Application/Interfaces/Store/IStoreService.cs
+++ b/src/Humans.Application/Interfaces/Store/IStoreService.cs
@@ -32,10 +32,3 @@ public interface IStoreService
     // Summary
     Task<IReadOnlyList<OrderSummaryDto>> GetAllOrderSummariesAsync(int year, CancellationToken ct = default);
 }
-
-public record OrderCounterpartyInput(
-    string? Name,
-    string? VatId,
-    string? Address,
-    string? CountryCode,
-    string? Email);

--- a/src/Humans.Application/Services/Shifts/ShiftSignupService.cs
+++ b/src/Humans.Application/Services/Shifts/ShiftSignupService.cs
@@ -148,8 +148,9 @@ public sealed class ShiftSignupService : IShiftSignupService, IUserDataContribut
         {
             await _auditLogService.LogAsync(
                 AuditAction.ShiftSignupConfirmed, nameof(ShiftSignup), signup.Id,
-                $"Auto-confirmed signup for shift '{shift.Rota.Name}'",
-                userId);
+                $"shift '{shift.Rota.Name}'",
+                userId,
+                userId, nameof(User));
 
             await DispatchSignupChangeNotificationAsync(signup, shift,
                 $"New confirmed signup for '{shift.Rota.Name}' on day {shift.DayOffset}.");
@@ -202,8 +203,9 @@ public sealed class ShiftSignupService : IShiftSignupService, IUserDataContribut
 
         await _auditLogService.LogAsync(
             AuditAction.ShiftSignupConfirmed, nameof(ShiftSignup), signup.Id,
-            $"Approved signup for shift '{signup.Shift.Rota.Name}'",
-            reviewerUserId);
+            $"shift '{signup.Shift.Rota.Name}'",
+            reviewerUserId,
+            signup.UserId, nameof(User));
 
         await DispatchSignupChangeNotificationAsync(signup, signup.Shift,
             $"Signup approved for '{signup.Shift.Rota.Name}' on day {signup.Shift.DayOffset}.");
@@ -222,8 +224,9 @@ public sealed class ShiftSignupService : IShiftSignupService, IUserDataContribut
 
         await _auditLogService.LogAsync(
             AuditAction.ShiftSignupRefused, nameof(ShiftSignup), signup.Id,
-            $"Refused signup for shift '{signup.Shift.Rota.Name}'" + (reason is not null ? $": {reason}" : ""),
-            reviewerUserId);
+            $"shift '{signup.Shift.Rota.Name}'" + (reason is not null ? $": {reason}" : ""),
+            reviewerUserId,
+            signup.UserId, nameof(User));
 
         await DispatchSignupChangeNotificationAsync(signup, signup.Shift,
             $"Signup refused for '{signup.Shift.Rota.Name}' on day {signup.Shift.DayOffset}.");
@@ -255,8 +258,9 @@ public sealed class ShiftSignupService : IShiftSignupService, IUserDataContribut
 
         await _auditLogService.LogAsync(
             AuditAction.ShiftSignupBailed, nameof(ShiftSignup), signup.Id,
-            $"Bailed from shift '{signup.Shift.Rota.Name}'" + (reason is not null ? $": {reason}" : ""),
-            actorUserId);
+            $"shift '{signup.Shift.Rota.Name}'" + (reason is not null ? $": {reason}" : ""),
+            actorUserId,
+            signup.UserId, nameof(User));
 
         await DispatchSignupChangeNotificationAsync(signup, signup.Shift,
             $"Volunteer bailed from '{signup.Shift.Rota.Name}' on day {signup.Shift.DayOffset}.");
@@ -310,7 +314,7 @@ public sealed class ShiftSignupService : IShiftSignupService, IUserDataContribut
 
         await _auditLogService.LogAsync(
             AuditAction.ShiftSignupVoluntold, nameof(ShiftSignup), signup.Id,
-            $"Voluntold for shift '{shift.Rota.Name}'",
+            $"shift '{shift.Rota.Name}'",
             enrollerUserId,
             userId, nameof(User));
 
@@ -437,7 +441,7 @@ public sealed class ShiftSignupService : IShiftSignupService, IUserDataContribut
         {
             await _auditLogService.LogAsync(
                 AuditAction.ShiftSignupVoluntold, nameof(ShiftSignup), auditedSignup.Id,
-                $"Voluntold range for '{rota.Name}' day {dayOffset} (block {blockId})",
+                $"'{rota.Name}' day {dayOffset} (range)",
                 enrollerUserId,
                 userId, nameof(User));
         }
@@ -483,8 +487,9 @@ public sealed class ShiftSignupService : IShiftSignupService, IUserDataContribut
 
         await _auditLogService.LogAsync(
             AuditAction.ShiftSignupNoShow, nameof(ShiftSignup), signup.Id,
-            $"Marked no-show for shift '{signup.Shift.Rota.Name}'",
-            reviewerUserId);
+            $"shift '{signup.Shift.Rota.Name}'",
+            reviewerUserId,
+            signup.UserId, nameof(User));
 
         return SignupResult.Ok(signup);
     }
@@ -503,9 +508,10 @@ public sealed class ShiftSignupService : IShiftSignupService, IUserDataContribut
 
         await _auditLogService.LogAsync(
             AuditAction.ShiftSignupCancelled, nameof(ShiftSignup), signup.Id,
-            $"Removed from shift '{signup.Shift.Rota.Name}'" +
+            $"shift '{signup.Shift.Rota.Name}'" +
             (reason is not null ? $": {reason}" : ""),
-            removedByUserId);
+            removedByUserId,
+            signup.UserId, nameof(User));
 
         await DispatchSignupChangeNotificationAsync(signup, signup.Shift,
             $"Removed from '{signup.Shift.Rota.Name}' on day {signup.Shift.DayOffset}.");
@@ -666,8 +672,9 @@ public sealed class ShiftSignupService : IShiftSignupService, IUserDataContribut
                 await _auditLogService.LogAsync(
                     AuditAction.ShiftSignupConfirmed,
                     nameof(ShiftSignup), auditedSignup.Id,
-                    $"Range signup for '{rota.Name}' day {dayOffset} (block {blockId})",
-                    userId);
+                    $"'{rota.Name}' day {dayOffset} (range)",
+                    userId,
+                    userId, nameof(User));
             }
 
             await DispatchSignupChangeNotificationAsync(lastSignup!, availableShifts[^1], rota,
@@ -743,8 +750,9 @@ public sealed class ShiftSignupService : IShiftSignupService, IUserDataContribut
                 {
                     await _auditLogService.LogAsync(
                         AuditAction.ShiftSignupRefused, nameof(ShiftSignup), skipped.Id,
-                        $"Auto-refused (at capacity) for shift '{skipped.Shift.Rota.Name}' day {skipped.Shift.DayOffset} (block {signupBlockId})",
-                        reviewerUserId);
+                        $"shift '{skipped.Shift.Rota.Name}' day {skipped.Shift.DayOffset} (auto-refused, at capacity)",
+                        reviewerUserId,
+                        skipped.UserId, nameof(User));
                 }
             }
             return SignupResult.Fail("Cannot approve: all shifts in this range are at capacity.");
@@ -756,16 +764,18 @@ public sealed class ShiftSignupService : IShiftSignupService, IUserDataContribut
         {
             await _auditLogService.LogAsync(
                 AuditAction.ShiftSignupConfirmed, nameof(ShiftSignup), approvedSignup.Id,
-                $"Range approved for shift '{approvedSignup.Shift.Rota.Name}' day {approvedSignup.Shift.DayOffset} (block {signupBlockId})",
-                reviewerUserId);
+                $"shift '{approvedSignup.Shift.Rota.Name}' day {approvedSignup.Shift.DayOffset} (range)",
+                reviewerUserId,
+                approvedSignup.UserId, nameof(User));
         }
 
         foreach (var skipped in skippedAtCapacity)
         {
             await _auditLogService.LogAsync(
                 AuditAction.ShiftSignupRefused, nameof(ShiftSignup), skipped.Id,
-                $"Auto-refused (at capacity) for shift '{skipped.Shift.Rota.Name}' day {skipped.Shift.DayOffset} (block {signupBlockId})",
-                reviewerUserId);
+                $"shift '{skipped.Shift.Rota.Name}' day {skipped.Shift.DayOffset} (auto-refused, at capacity)",
+                reviewerUserId,
+                skipped.UserId, nameof(User));
         }
 
         await DispatchSignupChangeNotificationAsync(approved[0], approved[0].Shift,
@@ -792,9 +802,10 @@ public sealed class ShiftSignupService : IShiftSignupService, IUserDataContribut
         {
             await _auditLogService.LogAsync(
                 AuditAction.ShiftSignupRefused, nameof(ShiftSignup), signup.Id,
-                $"Range refused for shift '{signup.Shift.Rota.Name}' day {signup.Shift.DayOffset} (block {signupBlockId})" +
+                $"shift '{signup.Shift.Rota.Name}' day {signup.Shift.DayOffset} (range)" +
                 (reason is not null ? $": {reason}" : ""),
-                reviewerUserId);
+                reviewerUserId,
+                signup.UserId, nameof(User));
         }
 
         await DispatchSignupChangeNotificationAsync(signups[0], signups[0].Shift,
@@ -833,9 +844,10 @@ public sealed class ShiftSignupService : IShiftSignupService, IUserDataContribut
         {
             await _auditLogService.LogAsync(
                 AuditAction.ShiftSignupBailed, nameof(ShiftSignup), signup.Id,
-                $"Range bail from '{signup.Shift.Rota.Name}' day {signup.Shift.DayOffset} (block {signupBlockId})" +
+                $"shift '{signup.Shift.Rota.Name}' day {signup.Shift.DayOffset} (range)" +
                 (reason is not null ? $": {reason}" : ""),
-                actorUserId);
+                actorUserId,
+                signup.UserId, nameof(User));
         }
 
         await DispatchSignupChangeNotificationAsync(firstSignup, firstSignup.Shift,

--- a/src/Humans.Application/Services/Store/Dtos/OrderCounterpartyInput.cs
+++ b/src/Humans.Application/Services/Store/Dtos/OrderCounterpartyInput.cs
@@ -1,0 +1,8 @@
+namespace Humans.Application.Services.Store.Dtos;
+
+public record OrderCounterpartyInput(
+    string? Name,
+    string? VatId,
+    string? Address,
+    string? CountryCode,
+    string? Email);

--- a/src/Humans.Application/Services/Store/Dtos/OrderDto.cs
+++ b/src/Humans.Application/Services/Store/Dtos/OrderDto.cs
@@ -1,0 +1,21 @@
+using Humans.Domain.Enums;
+
+namespace Humans.Application.Services.Store.Dtos;
+
+public record OrderDto(
+    Guid Id,
+    Guid CampSeasonId,
+    string? Label,
+    StoreOrderState State,
+    string? CounterpartyName,
+    string? CounterpartyVatId,
+    string? CounterpartyAddress,
+    string? CounterpartyCountryCode,
+    string? CounterpartyEmail,
+    Guid? IssuedInvoiceId,
+    IReadOnlyList<OrderLineDto> Lines,
+    decimal LinesSubtotalEur,
+    decimal VatTotalEur,
+    decimal DepositTotalEur,
+    decimal PaymentsTotalEur,
+    decimal BalanceEur);

--- a/src/Humans.Application/Services/Store/Dtos/OrderLineDto.cs
+++ b/src/Humans.Application/Services/Store/Dtos/OrderLineDto.cs
@@ -1,0 +1,14 @@
+using NodaTime;
+
+namespace Humans.Application.Services.Store.Dtos;
+
+public record OrderLineDto(
+    Guid Id,
+    Guid OrderId,
+    Guid ProductId,
+    string ProductName,
+    int Qty,
+    decimal UnitPriceSnapshot,
+    decimal VatRateSnapshot,
+    decimal? DepositAmountSnapshot,
+    Instant AddedAt);

--- a/src/Humans.Application/Services/Store/Dtos/OrderSummaryDto.cs
+++ b/src/Humans.Application/Services/Store/Dtos/OrderSummaryDto.cs
@@ -1,0 +1,13 @@
+using Humans.Domain.Enums;
+
+namespace Humans.Application.Services.Store.Dtos;
+
+public record OrderSummaryDto(
+    Guid OrderId,
+    Guid CampSeasonId,
+    string CampName,
+    string? Label,
+    StoreOrderState State,
+    decimal TotalDueEur,
+    decimal PaymentsTotalEur,
+    decimal BalanceEur);

--- a/src/Humans.Application/Services/Store/Dtos/ProductDto.cs
+++ b/src/Humans.Application/Services/Store/Dtos/ProductDto.cs
@@ -1,0 +1,14 @@
+using NodaTime;
+
+namespace Humans.Application.Services.Store.Dtos;
+
+public record ProductDto(
+    Guid Id,
+    int Year,
+    string Name,
+    string Description,
+    decimal UnitPriceEur,
+    decimal VatRatePercent,
+    decimal? DepositAmountEur,
+    LocalDate OrderableUntil,
+    bool IsActive);

--- a/src/Humans.Application/Services/Store/StoreService.cs
+++ b/src/Humans.Application/Services/Store/StoreService.cs
@@ -1,0 +1,52 @@
+using Humans.Application.Interfaces.Repositories;
+using Humans.Application.Interfaces.Store;
+using Humans.Application.Services.Store.Dtos;
+using Humans.Domain.Enums;
+
+namespace Humans.Application.Services.Store;
+
+public class StoreService : IStoreService
+{
+    private readonly IStoreRepository _repo;
+
+    public StoreService(IStoreRepository repo) => _repo = repo;
+
+    public Task<IReadOnlyList<ProductDto>> GetActiveCatalogAsync(int year, CancellationToken ct = default)
+        => throw new NotSupportedException("Phase 2");
+
+    public Task<Guid> CreateProductAsync(ProductDto draft, Guid actorUserId, CancellationToken ct = default)
+        => throw new NotSupportedException("Phase 3");
+
+    public Task UpdateProductAsync(ProductDto draft, Guid actorUserId, CancellationToken ct = default)
+        => throw new NotSupportedException("Phase 3");
+
+    public Task DeactivateProductAsync(Guid productId, Guid actorUserId, CancellationToken ct = default)
+        => throw new NotSupportedException("Phase 3");
+
+    public Task<IReadOnlyList<OrderDto>> GetOrdersForCampSeasonAsync(Guid campSeasonId, CancellationToken ct = default)
+        => throw new NotSupportedException("Phase 2");
+
+    public Task<OrderDto?> GetOrderAsync(Guid orderId, CancellationToken ct = default)
+        => throw new NotSupportedException("Phase 2");
+
+    public Task<Guid> CreateOrderAsync(Guid campSeasonId, string? label, Guid actorUserId, CancellationToken ct = default)
+        => throw new NotSupportedException("Phase 2");
+
+    public Task AddLineAsync(Guid orderId, Guid productId, int qty, Guid actorUserId, CancellationToken ct = default)
+        => throw new NotSupportedException("Phase 2");
+
+    public Task RemoveLineAsync(Guid lineId, Guid actorUserId, CancellationToken ct = default)
+        => throw new NotSupportedException("Phase 2");
+
+    public Task UpdateCounterpartyAsync(Guid orderId, OrderCounterpartyInput input, Guid actorUserId, CancellationToken ct = default)
+        => throw new NotSupportedException("Phase 2");
+
+    public Task RecordManualPaymentAsync(Guid orderId, decimal amountEur, StorePaymentMethod method, string? externalRef, string? notes, Guid actorUserId, CancellationToken ct = default)
+        => throw new NotSupportedException("Phase 5");
+
+    public Task IssueInvoiceAsync(Guid orderId, Guid actorUserId, CancellationToken ct = default)
+        => throw new NotSupportedException("Phase 5");
+
+    public Task<IReadOnlyList<OrderSummaryDto>> GetAllOrderSummariesAsync(int year, CancellationToken ct = default)
+        => throw new NotSupportedException("Phase 5");
+}

--- a/src/Humans.Domain/Constants/RoleNames.cs
+++ b/src/Humans.Domain/Constants/RoleNames.cs
@@ -70,6 +70,11 @@ public static class RoleNames
     public const string FinanceAdmin = "FinanceAdmin";
 
     /// <summary>
+    /// Store Administrator — manages the Store catalog (products, prices, VAT, deposits, deadlines).
+    /// </summary>
+    public const string StoreAdmin = "StoreAdmin";
+
+    /// <summary>
     /// Roles that Board and HumanAdmin are permitted to manage (assign/end).
     /// Used by both service-layer authorization and Web-layer role checks.
     /// </summary>
@@ -83,6 +88,7 @@ public static class RoleNames
         NoInfoAdmin,
         FeedbackAdmin,
         FinanceAdmin,
+        StoreAdmin,
         ConsentCoordinator,
         VolunteerCoordinator
     };

--- a/src/Humans.Domain/Entities/StoreInvoice.cs
+++ b/src/Humans.Domain/Entities/StoreInvoice.cs
@@ -1,0 +1,15 @@
+using NodaTime;
+
+namespace Humans.Domain.Entities;
+
+public class StoreInvoice
+{
+    public Guid Id { get; set; }
+    public Guid OrderId { get; set; }
+    public string HoldedDocId { get; set; } = string.Empty;
+    public string HoldedDocNumber { get; set; } = string.Empty;
+    public Instant IssuedAt { get; set; }
+    public Guid IssuedByUserId { get; set; }
+    public string RequestPayload { get; set; } = string.Empty;
+    public string ResponsePayload { get; set; } = string.Empty;
+}

--- a/src/Humans.Domain/Entities/StoreOrder.cs
+++ b/src/Humans.Domain/Entities/StoreOrder.cs
@@ -1,0 +1,26 @@
+using Humans.Domain.Enums;
+using NodaTime;
+
+namespace Humans.Domain.Entities;
+
+public class StoreOrder
+{
+    public Guid Id { get; set; }
+    public Guid CampSeasonId { get; set; }
+    public string? Label { get; set; }
+    public StoreOrderState State { get; set; } = StoreOrderState.Open;
+
+    public string? CounterpartyName { get; set; }
+    public string? CounterpartyVatId { get; set; }
+    public string? CounterpartyAddress { get; set; }
+    public string? CounterpartyCountryCode { get; set; }
+    public string? CounterpartyEmail { get; set; }
+
+    public Guid? IssuedInvoiceId { get; set; }
+
+    public Instant CreatedAt { get; set; }
+    public Instant UpdatedAt { get; set; }
+
+    public ICollection<StoreOrderLine> Lines { get; set; } = new List<StoreOrderLine>();
+    public ICollection<StorePayment> Payments { get; set; } = new List<StorePayment>();
+}

--- a/src/Humans.Domain/Entities/StoreOrderLine.cs
+++ b/src/Humans.Domain/Entities/StoreOrderLine.cs
@@ -1,0 +1,18 @@
+using NodaTime;
+
+namespace Humans.Domain.Entities;
+
+public class StoreOrderLine
+{
+    public Guid Id { get; set; }
+    public Guid OrderId { get; set; }
+    public Guid ProductId { get; set; }
+    public int Qty { get; set; }
+    public decimal UnitPriceSnapshot { get; set; }
+    public decimal VatRateSnapshot { get; set; }
+    public decimal? DepositAmountSnapshot { get; set; }
+    public Instant AddedAt { get; set; }
+    public Guid AddedByUserId { get; set; }
+
+    public StoreOrder? Order { get; set; }
+}

--- a/src/Humans.Domain/Entities/StorePayment.cs
+++ b/src/Humans.Domain/Entities/StorePayment.cs
@@ -1,0 +1,19 @@
+using Humans.Domain.Enums;
+using NodaTime;
+
+namespace Humans.Domain.Entities;
+
+public class StorePayment
+{
+    public Guid Id { get; set; }
+    public Guid OrderId { get; set; }
+    public decimal AmountEur { get; set; }
+    public StorePaymentMethod Method { get; set; }
+    public string? StripePaymentIntentId { get; set; }
+    public string? ExternalRef { get; set; }
+    public Instant ReceivedAt { get; set; }
+    public Guid? RecordedByUserId { get; set; }
+    public string? Notes { get; set; }
+
+    public StoreOrder? Order { get; set; }
+}

--- a/src/Humans.Domain/Entities/StoreProduct.cs
+++ b/src/Humans.Domain/Entities/StoreProduct.cs
@@ -1,0 +1,18 @@
+using NodaTime;
+
+namespace Humans.Domain.Entities;
+
+public class StoreProduct
+{
+    public Guid Id { get; set; }
+    public int Year { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public decimal UnitPriceEur { get; set; }
+    public decimal VatRatePercent { get; set; }
+    public decimal? DepositAmountEur { get; set; }
+    public LocalDate OrderableUntil { get; set; }
+    public bool IsActive { get; set; } = true;
+    public Instant CreatedAt { get; set; }
+    public Instant UpdatedAt { get; set; }
+}

--- a/src/Humans.Domain/Entities/StoreTreasurySyncState.cs
+++ b/src/Humans.Domain/Entities/StoreTreasurySyncState.cs
@@ -1,0 +1,11 @@
+using NodaTime;
+
+namespace Humans.Domain.Entities;
+
+public class StoreTreasurySyncState
+{
+    public int Id { get; set; } = 1;
+    public Instant? LastSyncAt { get; set; }
+    public string SyncStatus { get; set; } = "Idle";
+    public string? LastError { get; set; }
+}

--- a/src/Humans.Domain/Entities/StoreTreasurySyncState.cs
+++ b/src/Humans.Domain/Entities/StoreTreasurySyncState.cs
@@ -1,3 +1,4 @@
+using Humans.Domain.Enums;
 using NodaTime;
 
 namespace Humans.Domain.Entities;
@@ -6,6 +7,6 @@ public class StoreTreasurySyncState
 {
     public int Id { get; set; } = 1;
     public Instant? LastSyncAt { get; set; }
-    public string SyncStatus { get; set; } = "Idle";
+    public StoreTreasurySyncStatus SyncStatus { get; set; } = StoreTreasurySyncStatus.Idle;
     public string? LastError { get; set; }
 }

--- a/src/Humans.Domain/Enums/StoreOrderState.cs
+++ b/src/Humans.Domain/Enums/StoreOrderState.cs
@@ -1,0 +1,7 @@
+namespace Humans.Domain.Enums;
+
+public enum StoreOrderState
+{
+    Open = 0,
+    InvoiceIssued = 1
+}

--- a/src/Humans.Domain/Enums/StorePaymentMethod.cs
+++ b/src/Humans.Domain/Enums/StorePaymentMethod.cs
@@ -1,0 +1,8 @@
+namespace Humans.Domain.Enums;
+
+public enum StorePaymentMethod
+{
+    Stripe = 0,
+    BankTransfer = 1,
+    Manual = 2
+}

--- a/src/Humans.Domain/Enums/StoreTreasurySyncStatus.cs
+++ b/src/Humans.Domain/Enums/StoreTreasurySyncStatus.cs
@@ -1,0 +1,8 @@
+namespace Humans.Domain.Enums;
+
+public enum StoreTreasurySyncStatus
+{
+    Idle = 0,
+    Running = 1,
+    Failed = 2
+}

--- a/src/Humans.Infrastructure/Data/Configurations/Store/StoreInvoiceConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/Store/StoreInvoiceConfiguration.cs
@@ -1,0 +1,20 @@
+using Humans.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Humans.Infrastructure.Data.Configurations.Store;
+
+public class StoreInvoiceConfiguration : IEntityTypeConfiguration<StoreInvoice>
+{
+    public void Configure(EntityTypeBuilder<StoreInvoice> b)
+    {
+        b.ToTable("store_invoices");
+        b.HasKey(x => x.Id);
+        b.HasIndex(x => x.OrderId).IsUnique();
+        b.HasIndex(x => x.HoldedDocId).IsUnique();
+        b.Property(x => x.HoldedDocId).HasMaxLength(100);
+        b.Property(x => x.HoldedDocNumber).HasMaxLength(50);
+        b.Property(x => x.RequestPayload).HasColumnType("jsonb");
+        b.Property(x => x.ResponsePayload).HasColumnType("jsonb");
+    }
+}

--- a/src/Humans.Infrastructure/Data/Configurations/Store/StoreOrderConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/Store/StoreOrderConfiguration.cs
@@ -1,0 +1,25 @@
+using Humans.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Humans.Infrastructure.Data.Configurations.Store;
+
+public class StoreOrderConfiguration : IEntityTypeConfiguration<StoreOrder>
+{
+    public void Configure(EntityTypeBuilder<StoreOrder> b)
+    {
+        b.ToTable("store_orders");
+        b.HasKey(x => x.Id);
+        b.Property(x => x.Label).HasMaxLength(100);
+        b.Property(x => x.CounterpartyName).HasMaxLength(200);
+        b.Property(x => x.CounterpartyVatId).HasMaxLength(50);
+        b.Property(x => x.CounterpartyAddress).HasMaxLength(500);
+        b.Property(x => x.CounterpartyCountryCode).HasMaxLength(2);
+        b.Property(x => x.CounterpartyEmail).HasMaxLength(320);
+        b.Property(x => x.State).HasConversion<int>();
+        b.HasIndex(x => x.CampSeasonId);
+        b.HasIndex(x => x.State);
+        b.HasMany(x => x.Lines).WithOne(l => l.Order!).HasForeignKey(l => l.OrderId).OnDelete(DeleteBehavior.Cascade);
+        b.HasMany(x => x.Payments).WithOne(p => p.Order!).HasForeignKey(p => p.OrderId).OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/src/Humans.Infrastructure/Data/Configurations/Store/StoreOrderLineConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/Store/StoreOrderLineConfiguration.cs
@@ -1,0 +1,19 @@
+using Humans.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Humans.Infrastructure.Data.Configurations.Store;
+
+public class StoreOrderLineConfiguration : IEntityTypeConfiguration<StoreOrderLine>
+{
+    public void Configure(EntityTypeBuilder<StoreOrderLine> b)
+    {
+        b.ToTable("store_order_lines");
+        b.HasKey(x => x.Id);
+        b.Property(x => x.UnitPriceSnapshot).HasColumnType("numeric(12,2)");
+        b.Property(x => x.VatRateSnapshot).HasColumnType("numeric(5,2)");
+        b.Property(x => x.DepositAmountSnapshot).HasColumnType("numeric(12,2)");
+        b.HasIndex(x => x.OrderId);
+        b.HasIndex(x => x.ProductId);
+    }
+}

--- a/src/Humans.Infrastructure/Data/Configurations/Store/StorePaymentConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/Store/StorePaymentConfiguration.cs
@@ -1,0 +1,21 @@
+using Humans.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Humans.Infrastructure.Data.Configurations.Store;
+
+public class StorePaymentConfiguration : IEntityTypeConfiguration<StorePayment>
+{
+    public void Configure(EntityTypeBuilder<StorePayment> b)
+    {
+        b.ToTable("store_payments");
+        b.HasKey(x => x.Id);
+        b.Property(x => x.AmountEur).HasColumnType("numeric(12,2)");
+        b.Property(x => x.Method).HasConversion<int>();
+        b.Property(x => x.StripePaymentIntentId).HasMaxLength(200);
+        b.Property(x => x.ExternalRef).HasMaxLength(200);
+        b.Property(x => x.Notes).HasMaxLength(1000);
+        b.HasIndex(x => x.OrderId);
+        b.HasIndex(x => x.StripePaymentIntentId).IsUnique().HasFilter("\"StripePaymentIntentId\" IS NOT NULL");
+    }
+}

--- a/src/Humans.Infrastructure/Data/Configurations/Store/StoreProductConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/Store/StoreProductConfiguration.cs
@@ -1,0 +1,20 @@
+using Humans.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Humans.Infrastructure.Data.Configurations.Store;
+
+public class StoreProductConfiguration : IEntityTypeConfiguration<StoreProduct>
+{
+    public void Configure(EntityTypeBuilder<StoreProduct> b)
+    {
+        b.ToTable("store_products");
+        b.HasKey(x => x.Id);
+        b.Property(x => x.Name).HasMaxLength(200).IsRequired();
+        b.Property(x => x.Description).HasMaxLength(2000).IsRequired();
+        b.Property(x => x.UnitPriceEur).HasColumnType("numeric(12,2)");
+        b.Property(x => x.VatRatePercent).HasColumnType("numeric(5,2)");
+        b.Property(x => x.DepositAmountEur).HasColumnType("numeric(12,2)");
+        b.HasIndex(x => new { x.Year, x.IsActive });
+    }
+}

--- a/src/Humans.Infrastructure/Data/Configurations/Store/StoreTreasurySyncStateConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/Store/StoreTreasurySyncStateConfiguration.cs
@@ -10,7 +10,7 @@ public class StoreTreasurySyncStateConfiguration : IEntityTypeConfiguration<Stor
     {
         b.ToTable("store_treasury_sync_state");
         b.HasKey(x => x.Id);
-        b.Property(x => x.SyncStatus).HasMaxLength(20);
+        b.Property(x => x.SyncStatus).HasConversion<int>();
         b.Property(x => x.LastError).HasMaxLength(2000);
     }
 }

--- a/src/Humans.Infrastructure/Data/Configurations/Store/StoreTreasurySyncStateConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/Store/StoreTreasurySyncStateConfiguration.cs
@@ -1,0 +1,16 @@
+using Humans.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Humans.Infrastructure.Data.Configurations.Store;
+
+public class StoreTreasurySyncStateConfiguration : IEntityTypeConfiguration<StoreTreasurySyncState>
+{
+    public void Configure(EntityTypeBuilder<StoreTreasurySyncState> b)
+    {
+        b.ToTable("store_treasury_sync_state");
+        b.HasKey(x => x.Id);
+        b.Property(x => x.SyncStatus).HasMaxLength(20);
+        b.Property(x => x.LastError).HasMaxLength(2000);
+    }
+}

--- a/src/Humans.Infrastructure/Data/HumansDbContext.cs
+++ b/src/Humans.Infrastructure/Data/HumansDbContext.cs
@@ -84,6 +84,12 @@ public class HumansDbContext : IdentityDbContext<User, IdentityRole<Guid>, Guid>
     public DbSet<NotificationRecipient> NotificationRecipients => Set<NotificationRecipient>();
     public DbSet<ProfileLanguage> ProfileLanguages => Set<ProfileLanguage>();
     public DbSet<EventParticipation> EventParticipations => Set<EventParticipation>();
+    public DbSet<StoreProduct> StoreProducts => Set<StoreProduct>();
+    public DbSet<StoreOrder> StoreOrders => Set<StoreOrder>();
+    public DbSet<StoreOrderLine> StoreOrderLines => Set<StoreOrderLine>();
+    public DbSet<StorePayment> StorePayments => Set<StorePayment>();
+    public DbSet<StoreInvoice> StoreInvoices => Set<StoreInvoice>();
+    public DbSet<StoreTreasurySyncState> StoreTreasurySyncStates => Set<StoreTreasurySyncState>();
 
     protected override void OnModelCreating(ModelBuilder builder)
     {

--- a/src/Humans.Infrastructure/Jobs/SystemTeamSyncJob.cs
+++ b/src/Humans.Infrastructure/Jobs/SystemTeamSyncJob.cs
@@ -234,15 +234,26 @@ public class SystemTeamSyncJob : ISystemTeamSync
             return;
         }
 
-        // All users with profiles that are approved and not suspended.
-        var allApprovedIds = await ProfileService.GetActiveApprovedUserIdsAsync(cancellationToken);
+        // Volunteers admission no longer requires Profile.IsApproved (CC clearance) —
+        // any human with a profile, not suspended, not flagged, not rejected, and
+        // with all required consents signed is admitted. Profile.IsApproved is
+        // maintained as the CC's audit annotation but is not consulted here. The
+        // Flagged + RejectedAt exclusions preserve the CC's existing kick-out
+        // levers (FlagConsentCheckAsync and RejectSignupAsync set those fields
+        // before calling DeprovisionApprovalGatedSystemTeamsAsync).
+        var allUserIds = await _userService.GetAllUserIdsAsync(cancellationToken);
+        var profiles = await ProfileService.GetByUserIdsAsync(allUserIds, cancellationToken);
+        var candidateIds = allUserIds
+            .Where(id => profiles.TryGetValue(id, out var p)
+                && !p.IsSuspended
+                && p.ConsentCheckStatus != ConsentCheckStatus.Flagged
+                && p.RejectedAt is null)
+            .ToList();
 
-        // Use shared partition to determine eligibility (Active = approved +
-        // not suspended + all consents signed).
-        var partition = await MembershipCalculator.PartitionUsersAsync(allApprovedIds, cancellationToken);
-        var eligibleUserIds = partition.Active.ToList();
+        var eligibleSet = await MembershipCalculator.GetUsersWithAllRequiredConsentsForTeamAsync(
+            candidateIds, SystemTeamIds.Volunteers, cancellationToken);
 
-        await SyncTeamMembershipAsync(team, eligibleUserIds, cancellationToken, step: step);
+        await SyncTeamMembershipAsync(team, eligibleSet.ToList(), cancellationToken, step: step);
         report?.Steps.Add(step);
     }
 
@@ -396,7 +407,14 @@ public class SystemTeamSyncJob : ISystemTeamSync
         var profiles = await ProfileService.GetByUserIdsAsync([userId], cancellationToken);
         profiles.TryGetValue(userId, out var profile);
 
-        var isEligible = profile is { IsApproved: true, IsSuspended: false }
+        // Volunteers admission no longer requires Profile.IsApproved (CC clearance).
+        // Profile.IsApproved is tracked as the CC's audit annotation but is not
+        // consulted for team admission. Flagged consent checks and rejected
+        // signups remain excluded so DeprovisionApprovalGatedSystemTeamsAsync
+        // (called from FlagConsentCheckAsync / RejectSignupAsync after those
+        // mutations) actually removes the user from Volunteers.
+        var isEligible = profile is { IsSuspended: false, RejectedAt: null }
+            && profile.ConsentCheckStatus != ConsentCheckStatus.Flagged
             && await MembershipCalculator.HasAllRequiredConsentsForTeamAsync(userId, SystemTeamIds.Volunteers, cancellationToken);
 
         // Build a single-user eligible list and let the existing sync logic handle add/remove

--- a/src/Humans.Infrastructure/Migrations/20260430012549_AddStoreSection.Designer.cs
+++ b/src/Humans.Infrastructure/Migrations/20260430012549_AddStoreSection.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Humans.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Humans.Infrastructure.Migrations
 {
     [DbContext(typeof(HumansDbContext))]
-    partial class HumansDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260430012549_AddStoreSection")]
+    partial class AddStoreSection
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Humans.Infrastructure/Migrations/20260430012549_AddStoreSection.cs
+++ b/src/Humans.Infrastructure/Migrations/20260430012549_AddStoreSection.cs
@@ -1,0 +1,214 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NodaTime;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace Humans.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddStoreSection : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "store_invoices",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    OrderId = table.Column<Guid>(type: "uuid", nullable: false),
+                    HoldedDocId = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    HoldedDocNumber = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    IssuedAt = table.Column<Instant>(type: "timestamp with time zone", nullable: false),
+                    IssuedByUserId = table.Column<Guid>(type: "uuid", nullable: false),
+                    RequestPayload = table.Column<string>(type: "jsonb", nullable: false),
+                    ResponsePayload = table.Column<string>(type: "jsonb", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_store_invoices", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "store_orders",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    CampSeasonId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Label = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true),
+                    State = table.Column<int>(type: "integer", nullable: false),
+                    CounterpartyName = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                    CounterpartyVatId = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: true),
+                    CounterpartyAddress = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: true),
+                    CounterpartyCountryCode = table.Column<string>(type: "character varying(2)", maxLength: 2, nullable: true),
+                    CounterpartyEmail = table.Column<string>(type: "character varying(320)", maxLength: 320, nullable: true),
+                    IssuedInvoiceId = table.Column<Guid>(type: "uuid", nullable: true),
+                    CreatedAt = table.Column<Instant>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<Instant>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_store_orders", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "store_products",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Year = table.Column<int>(type: "integer", nullable: false),
+                    Name = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    Description = table.Column<string>(type: "character varying(2000)", maxLength: 2000, nullable: false),
+                    UnitPriceEur = table.Column<decimal>(type: "numeric(12,2)", nullable: false),
+                    VatRatePercent = table.Column<decimal>(type: "numeric(5,2)", nullable: false),
+                    DepositAmountEur = table.Column<decimal>(type: "numeric(12,2)", nullable: true),
+                    OrderableUntil = table.Column<LocalDate>(type: "date", nullable: false),
+                    IsActive = table.Column<bool>(type: "boolean", nullable: false),
+                    CreatedAt = table.Column<Instant>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<Instant>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_store_products", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "store_treasury_sync_state",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    LastSyncAt = table.Column<Instant>(type: "timestamp with time zone", nullable: true),
+                    SyncStatus = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false),
+                    LastError = table.Column<string>(type: "character varying(2000)", maxLength: 2000, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_store_treasury_sync_state", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "store_order_lines",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    OrderId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ProductId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Qty = table.Column<int>(type: "integer", nullable: false),
+                    UnitPriceSnapshot = table.Column<decimal>(type: "numeric(12,2)", nullable: false),
+                    VatRateSnapshot = table.Column<decimal>(type: "numeric(5,2)", nullable: false),
+                    DepositAmountSnapshot = table.Column<decimal>(type: "numeric(12,2)", nullable: true),
+                    AddedAt = table.Column<Instant>(type: "timestamp with time zone", nullable: false),
+                    AddedByUserId = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_store_order_lines", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_store_order_lines_store_orders_OrderId",
+                        column: x => x.OrderId,
+                        principalTable: "store_orders",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "store_payments",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    OrderId = table.Column<Guid>(type: "uuid", nullable: false),
+                    AmountEur = table.Column<decimal>(type: "numeric(12,2)", nullable: false),
+                    Method = table.Column<int>(type: "integer", nullable: false),
+                    StripePaymentIntentId = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                    ExternalRef = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                    ReceivedAt = table.Column<Instant>(type: "timestamp with time zone", nullable: false),
+                    RecordedByUserId = table.Column<Guid>(type: "uuid", nullable: true),
+                    Notes = table.Column<string>(type: "character varying(1000)", maxLength: 1000, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_store_payments", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_store_payments_store_orders_OrderId",
+                        column: x => x.OrderId,
+                        principalTable: "store_orders",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_store_invoices_HoldedDocId",
+                table: "store_invoices",
+                column: "HoldedDocId",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_store_invoices_OrderId",
+                table: "store_invoices",
+                column: "OrderId",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_store_order_lines_OrderId",
+                table: "store_order_lines",
+                column: "OrderId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_store_order_lines_ProductId",
+                table: "store_order_lines",
+                column: "ProductId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_store_orders_CampSeasonId",
+                table: "store_orders",
+                column: "CampSeasonId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_store_orders_State",
+                table: "store_orders",
+                column: "State");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_store_payments_OrderId",
+                table: "store_payments",
+                column: "OrderId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_store_payments_StripePaymentIntentId",
+                table: "store_payments",
+                column: "StripePaymentIntentId",
+                unique: true,
+                filter: "\"StripePaymentIntentId\" IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_store_products_Year_IsActive",
+                table: "store_products",
+                columns: new[] { "Year", "IsActive" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "store_invoices");
+
+            migrationBuilder.DropTable(
+                name: "store_order_lines");
+
+            migrationBuilder.DropTable(
+                name: "store_payments");
+
+            migrationBuilder.DropTable(
+                name: "store_products");
+
+            migrationBuilder.DropTable(
+                name: "store_treasury_sync_state");
+
+            migrationBuilder.DropTable(
+                name: "store_orders");
+        }
+    }
+}

--- a/src/Humans.Infrastructure/Migrations/20260430014508_AddStoreSection.Designer.cs
+++ b/src/Humans.Infrastructure/Migrations/20260430014508_AddStoreSection.Designer.cs
@@ -13,7 +13,7 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Humans.Infrastructure.Migrations
 {
     [DbContext(typeof(HumansDbContext))]
-    [Migration("20260430012549_AddStoreSection")]
+    [Migration("20260430014508_AddStoreSection")]
     partial class AddStoreSection
     {
         /// <inheritdoc />
@@ -2783,10 +2783,8 @@ namespace Humans.Infrastructure.Migrations
                     b.Property<Instant?>("LastSyncAt")
                         .HasColumnType("timestamp with time zone");
 
-                    b.Property<string>("SyncStatus")
-                        .IsRequired()
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
+                    b.Property<int>("SyncStatus")
+                        .HasColumnType("integer");
 
                     b.HasKey("Id");
 

--- a/src/Humans.Infrastructure/Migrations/20260430014508_AddStoreSection.cs
+++ b/src/Humans.Infrastructure/Migrations/20260430014508_AddStoreSection.cs
@@ -81,7 +81,7 @@ namespace Humans.Infrastructure.Migrations
                     Id = table.Column<int>(type: "integer", nullable: false)
                         .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
                     LastSyncAt = table.Column<Instant>(type: "timestamp with time zone", nullable: true),
-                    SyncStatus = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false),
+                    SyncStatus = table.Column<int>(type: "integer", nullable: false),
                     LastError = table.Column<string>(type: "character varying(2000)", maxLength: 2000, nullable: true)
                 },
                 constraints: table =>

--- a/src/Humans.Infrastructure/Migrations/HumansDbContextModelSnapshot.cs
+++ b/src/Humans.Infrastructure/Migrations/HumansDbContextModelSnapshot.cs
@@ -2780,10 +2780,8 @@ namespace Humans.Infrastructure.Migrations
                     b.Property<Instant?>("LastSyncAt")
                         .HasColumnType("timestamp with time zone");
 
-                    b.Property<string>("SyncStatus")
-                        .IsRequired()
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
+                    b.Property<int>("SyncStatus")
+                        .HasColumnType("integer");
 
                     b.HasKey("Id");
 

--- a/src/Humans.Infrastructure/Repositories/Store/StoreRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Store/StoreRepository.cs
@@ -1,0 +1,187 @@
+using Humans.Application.Interfaces.Repositories;
+using Humans.Domain.Entities;
+using Humans.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace Humans.Infrastructure.Repositories.Store;
+
+/// <summary>
+/// EF-backed implementation of <see cref="IStoreRepository"/>. The only
+/// non-test file that touches <c>DbContext.StoreProducts</c>,
+/// <c>DbContext.StoreOrders</c>, <c>DbContext.StoreOrderLines</c>,
+/// <c>DbContext.StorePayments</c>, <c>DbContext.StoreInvoices</c>, or
+/// <c>DbContext.StoreTreasurySyncStates</c>.
+/// </summary>
+/// <remarks>
+/// Follows design-rules §15b: registered as Singleton, injects
+/// <see cref="IDbContextFactory{TContext}"/>, and opens a fresh short-lived
+/// <see cref="HumansDbContext"/> per method.
+/// </remarks>
+public sealed class StoreRepository : IStoreRepository
+{
+    private readonly IDbContextFactory<HumansDbContext> _factory;
+
+    public StoreRepository(IDbContextFactory<HumansDbContext> factory)
+    {
+        _factory = factory;
+    }
+
+    // ==========================================================================
+    // Products
+    // ==========================================================================
+
+    public async Task<IReadOnlyList<StoreProduct>> GetActiveProductsForYearAsync(int year, CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        return await ctx.StoreProducts.AsNoTracking()
+            .Where(p => p.Year == year && p.IsActive)
+            .OrderBy(p => p.Name)
+            .ToListAsync(ct);
+    }
+
+    public async Task<StoreProduct?> GetProductByIdAsync(Guid productId, CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        return await ctx.StoreProducts.FirstOrDefaultAsync(p => p.Id == productId, ct);
+    }
+
+    public async Task AddProductAsync(StoreProduct product, CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        ctx.StoreProducts.Add(product);
+        await ctx.SaveChangesAsync(ct);
+    }
+
+    public async Task UpdateProductAsync(StoreProduct product, CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        ctx.StoreProducts.Update(product);
+        await ctx.SaveChangesAsync(ct);
+    }
+
+    // ==========================================================================
+    // Orders
+    // ==========================================================================
+
+    public async Task<IReadOnlyList<StoreOrder>> GetOrdersForCampSeasonAsync(Guid campSeasonId, CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        return await ctx.StoreOrders.AsNoTracking()
+            .Include(o => o.Lines)
+            .Include(o => o.Payments)
+            .Where(o => o.CampSeasonId == campSeasonId)
+            .ToListAsync(ct);
+    }
+
+    public async Task<StoreOrder?> GetOrderByIdAsync(Guid orderId, CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        return await ctx.StoreOrders.FirstOrDefaultAsync(o => o.Id == orderId, ct);
+    }
+
+    public async Task<StoreOrder?> GetOrderWithLinesAndPaymentsAsync(Guid orderId, CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        return await ctx.StoreOrders
+            .Include(o => o.Lines)
+            .Include(o => o.Payments)
+            .FirstOrDefaultAsync(o => o.Id == orderId, ct);
+    }
+
+    public async Task<IReadOnlyList<StoreOrder>> GetAllOrdersWithAggregatesAsync(int year, CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        // Year filter hop: Order has no Year directly; caller filters via product
+        // Year on lines. At ~500-user scale, returning all orders is fine.
+        return await ctx.StoreOrders.AsNoTracking()
+            .Include(o => o.Lines)
+            .Include(o => o.Payments)
+            .ToListAsync(ct);
+    }
+
+    public async Task AddOrderAsync(StoreOrder order, CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        ctx.StoreOrders.Add(order);
+        await ctx.SaveChangesAsync(ct);
+    }
+
+    public async Task UpdateOrderAsync(StoreOrder order, CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        ctx.StoreOrders.Update(order);
+        await ctx.SaveChangesAsync(ct);
+    }
+
+    // ==========================================================================
+    // Lines
+    // ==========================================================================
+
+    public async Task AddLineAsync(StoreOrderLine line, CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        ctx.StoreOrderLines.Add(line);
+        await ctx.SaveChangesAsync(ct);
+    }
+
+    public async Task RemoveLineAsync(Guid lineId, CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        var line = await ctx.StoreOrderLines.FirstOrDefaultAsync(l => l.Id == lineId, ct);
+        if (line is null) return;
+        ctx.StoreOrderLines.Remove(line);
+        await ctx.SaveChangesAsync(ct);
+    }
+
+    // ==========================================================================
+    // Payments
+    // ==========================================================================
+
+    public async Task AddPaymentAsync(StorePayment payment, CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        ctx.StorePayments.Add(payment);
+        await ctx.SaveChangesAsync(ct);
+    }
+
+    public async Task<bool> StripePaymentIntentExistsAsync(string paymentIntentId, CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        return await ctx.StorePayments.AnyAsync(p => p.StripePaymentIntentId == paymentIntentId, ct);
+    }
+
+    // ==========================================================================
+    // Invoices
+    // ==========================================================================
+
+    public async Task AddInvoiceAsync(StoreInvoice invoice, CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        ctx.StoreInvoices.Add(invoice);
+        await ctx.SaveChangesAsync(ct);
+    }
+
+    // ==========================================================================
+    // Treasury sync state
+    // ==========================================================================
+
+    public async Task<StoreTreasurySyncState> GetOrCreateTreasurySyncStateAsync(CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        var s = await ctx.StoreTreasurySyncStates.FirstOrDefaultAsync(x => x.Id == 1, ct);
+        if (s is null)
+        {
+            s = new StoreTreasurySyncState { Id = 1 };
+            ctx.StoreTreasurySyncStates.Add(s);
+            await ctx.SaveChangesAsync(ct);
+        }
+        return s;
+    }
+
+    public async Task UpdateTreasurySyncStateAsync(StoreTreasurySyncState state, CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        ctx.StoreTreasurySyncStates.Update(state);
+        await ctx.SaveChangesAsync(ct);
+    }
+}

--- a/src/Humans.Infrastructure/Repositories/Store/StoreRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Store/StoreRepository.cs
@@ -88,11 +88,9 @@ public sealed class StoreRepository : IStoreRepository
             .FirstOrDefaultAsync(o => o.Id == orderId, ct);
     }
 
-    public async Task<IReadOnlyList<StoreOrder>> GetAllOrdersWithAggregatesAsync(int year, CancellationToken ct = default)
+    public async Task<IReadOnlyList<StoreOrder>> GetAllOrdersAsync(CancellationToken ct = default)
     {
         await using var ctx = await _factory.CreateDbContextAsync(ct);
-        // Year filter hop: Order has no Year directly; caller filters via product
-        // Year on lines. At ~500-user scale, returning all orders is fine.
         return await ctx.StoreOrders.AsNoTracking()
             .Include(o => o.Lines)
             .Include(o => o.Payments)

--- a/src/Humans.Web/Extensions/InfrastructureServiceCollectionExtensions.cs
+++ b/src/Humans.Web/Extensions/InfrastructureServiceCollectionExtensions.cs
@@ -37,6 +37,7 @@ public static class InfrastructureServiceCollectionExtensions
         services.AddCampsSection();
         services.AddCityPlanningSection(configuration);
         services.AddBudgetSection();
+        services.AddStoreSection();
         services.AddShiftsSection();
         services.AddCalendarSection();
         services.AddTicketsSection();

--- a/src/Humans.Web/Extensions/Sections/StoreSectionExtensions.cs
+++ b/src/Humans.Web/Extensions/Sections/StoreSectionExtensions.cs
@@ -1,0 +1,20 @@
+using Humans.Application.Interfaces.Repositories;
+using Humans.Application.Interfaces.Store;
+using Humans.Application.Services.Store;
+using Humans.Infrastructure.Repositories.Store;
+
+namespace Humans.Web.Extensions.Sections;
+
+internal static class StoreSectionExtensions
+{
+    internal static IServiceCollection AddStoreSection(this IServiceCollection services)
+    {
+        // Store section — §15b repository pattern.
+        // StoreRepository uses IDbContextFactory<HumansDbContext> so it can be
+        // Singleton; every method opens its own short-lived DbContext.
+        services.AddSingleton<IStoreRepository, StoreRepository>();
+        services.AddScoped<IStoreService, StoreService>();
+
+        return services;
+    }
+}

--- a/src/Humans.Web/ViewComponents/AuditLogViewComponent.cs
+++ b/src/Humans.Web/ViewComponents/AuditLogViewComponent.cs
@@ -109,8 +109,33 @@ public class AuditLogViewComponent : ViewComponent
         AuditAction.SignupRejected => "rejected signup for",
         AuditAction.TierApplicationApproved => "approved tier application for",
         AuditAction.TierApplicationRejected => "rejected tier application for",
+        AuditAction.ShiftSignupConfirmed => "confirmed signup for",
+        AuditAction.ShiftSignupRefused => "refused signup for",
+        AuditAction.ShiftSignupVoluntold => "voluntold",
+        AuditAction.ShiftSignupBailed => "bailed",
+        AuditAction.ShiftSignupNoShow => "marked no-show for",
+        AuditAction.ShiftSignupCancelled => "removed signup for",
         _ => null
     };
+
+    // Self-form: avoids dangling preposition when actor == subject (subject is suppressed in the view).
+    public static string? GetActionSelfVerb(AuditAction action) => action switch
+    {
+        AuditAction.ShiftSignupConfirmed => "signed up for",
+        AuditAction.ShiftSignupBailed => "bailed from",
+        _ => null
+    };
+
+    // True when the action's description is written as a context tail (e.g. "shift 'X'") rather
+    // than a stand-alone sentence (e.g. "Joined Build Team directly"). Tail-style descriptions
+    // append cleanly after the structured verb+subject; sentence-style ones produce redundancy.
+    public static bool ShouldRenderDescriptionTail(AuditAction action) => action
+        is AuditAction.ShiftSignupConfirmed
+        or AuditAction.ShiftSignupRefused
+        or AuditAction.ShiftSignupVoluntold
+        or AuditAction.ShiftSignupBailed
+        or AuditAction.ShiftSignupNoShow
+        or AuditAction.ShiftSignupCancelled;
 }
 
 public class AuditLogComponentViewModel

--- a/src/Humans.Web/Views/Shared/Components/AuditLog/_Entry.cshtml
+++ b/src/Humans.Web/Views/Shared/Components/AuditLog/_Entry.cshtml
@@ -6,6 +6,14 @@
     string GetName(Guid id) => userNames.TryGetValue(id, out var n) ? n : "Unknown";
 
     var verb = AuditLogViewComponent.GetActionVerb(Model.Action);
+    var selfVerb = AuditLogViewComponent.GetActionSelfVerb(Model.Action);
+
+    // Trims a dangling " for"/" to" preposition. Used when we can't render a
+    // subject (old rows pre-RelatedEntityId fix, or unmapped subject-less actions).
+    string TrimDanglingPreposition(string v)
+        => v.EndsWith(" for", StringComparison.Ordinal) ? v[..^4]
+         : v.EndsWith(" to", StringComparison.Ordinal) ? v[..^3]
+         : v;
 
     // Subject: the user being acted upon
     Guid? subjectId = Model.EntityType is "User" or "Profile" or "WorkspaceAccount"
@@ -25,7 +33,7 @@
     var actorIsSubject = Model.ActorUserId.HasValue && subjectId.HasValue && Model.ActorUserId.Value == subjectId.Value;
 }
 
-<div class="d-flex align-items-baseline gap-1 small">
+<div class="d-flex align-items-baseline gap-1 small flex-wrap">
     <span class="text-muted text-nowrap">@Model.OccurredAt.ToAuditTimestamp()</span>
     <span class="text-muted">—</span>
     @if (verb != null)
@@ -40,7 +48,13 @@
             <span class="text-muted">System</span>
         }
 
-        <span>@verb</span>
+        @* When the view will not render a subject (actor==subject or subject unknown),
+           use selfVerb if defined, else trim a trailing preposition from the transitive verb. *@
+        var noVisibleSubject = actorIsSubject || !subjectId.HasValue;
+        var displayVerb = noVisibleSubject && selfVerb != null ? selfVerb
+                        : noVisibleSubject ? TrimDanglingPreposition(verb)
+                        : verb;
+        <span>@displayVerb</span>
 
         @* Subject (skip if same as actor) *@
         @if (subjectId.HasValue && !actorIsSubject)
@@ -54,9 +68,40 @@
             <span class="text-muted">in</span>
             <a asp-controller="Team" asp-action="Details" asp-route-slug="@team.Slug" class="text-decoration-none">@team.Name</a>
         }
+
+        @* Description tail — only for actions whose descriptions are written as tails (e.g. ShiftSignup*).
+           Sentence-style descriptions (Team*, Role*, Member*) would render redundantly here. *@
+        @if (!string.IsNullOrWhiteSpace(Model.Description) && AuditLogViewComponent.ShouldRenderDescriptionTail(Model.Action))
+        {
+            <span class="text-muted">— @Model.Description</span>
+        }
     }
     else
     {
-        <span>@Model.Description</span>
+        @* Unmapped action — render rough but fully attributed: actor · ActionName · subject · in team · "description" *@
+        @if (Model.ActorUserId.HasValue)
+        {
+            <human-link user-id="@Model.ActorUserId.Value" display-name="@GetName(Model.ActorUserId.Value)" mode="Text" />
+        }
+        else
+        {
+            <span class="text-muted">System</span>
+        }
+        <span class="text-muted">·</span>
+        <span>@Model.Action.ToString()</span>
+        @if (subjectId.HasValue && !actorIsSubject)
+        {
+            <span class="text-muted">·</span>
+            <human-link user-id="@subjectId.Value" display-name="@GetName(subjectId.Value)" mode="Text" />
+        }
+        @if (targetTeamId.HasValue && teamNames.TryGetValue(targetTeamId.Value, out var fallbackTeam))
+        {
+            <span class="text-muted">in</span>
+            <a asp-controller="Team" asp-action="Details" asp-route-slug="@fallbackTeam.Slug" class="text-decoration-none">@fallbackTeam.Name</a>
+        }
+        @if (!string.IsNullOrWhiteSpace(Model.Description))
+        {
+            <span class="text-muted">— @Model.Description</span>
+        }
     }
 </div>

--- a/tests/Humans.Application.Tests/Repositories/StoreRepositoryTests.cs
+++ b/tests/Humans.Application.Tests/Repositories/StoreRepositoryTests.cs
@@ -9,9 +9,8 @@ using Xunit;
 
 namespace Humans.Application.Tests.Repositories;
 
-public sealed class StoreRepositoryTests : IDisposable
+public sealed class StoreRepositoryTests
 {
-    private readonly HumansDbContext _dbContext;
     private readonly StoreRepository _repo;
 
     public StoreRepositoryTests()
@@ -19,14 +18,7 @@ public sealed class StoreRepositoryTests : IDisposable
         var options = new DbContextOptionsBuilder<HumansDbContext>()
             .UseInMemoryDatabase(Guid.NewGuid().ToString())
             .Options;
-        _dbContext = new HumansDbContext(options);
         _repo = new StoreRepository(new TestDbContextFactory(options));
-    }
-
-    public void Dispose()
-    {
-        _dbContext.Dispose();
-        GC.SuppressFinalize(this);
     }
 
     [HumansFact]

--- a/tests/Humans.Application.Tests/Repositories/StoreRepositoryTests.cs
+++ b/tests/Humans.Application.Tests/Repositories/StoreRepositoryTests.cs
@@ -1,0 +1,122 @@
+using AwesomeAssertions;
+using Humans.Application.Tests.Infrastructure;
+using Humans.Domain.Entities;
+using Humans.Infrastructure.Data;
+using Humans.Infrastructure.Repositories.Store;
+using Microsoft.EntityFrameworkCore;
+using NodaTime;
+using Xunit;
+
+namespace Humans.Application.Tests.Repositories;
+
+public sealed class StoreRepositoryTests : IDisposable
+{
+    private readonly HumansDbContext _dbContext;
+    private readonly StoreRepository _repo;
+
+    public StoreRepositoryTests()
+    {
+        var options = new DbContextOptionsBuilder<HumansDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        _dbContext = new HumansDbContext(options);
+        _repo = new StoreRepository(new TestDbContextFactory(options));
+    }
+
+    public void Dispose()
+    {
+        _dbContext.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    [HumansFact]
+    public async Task AddProductAsync_then_GetActiveProductsForYearAsync_round_trip()
+    {
+        var product = new StoreProduct
+        {
+            Id = Guid.NewGuid(),
+            Year = 2026,
+            Name = "Tent rental",
+            Description = "Rental of a 4-person tent for the event",
+            UnitPriceEur = 50m,
+            VatRatePercent = 21m,
+            DepositAmountEur = 100m,
+            OrderableUntil = new LocalDate(2026, 6, 1),
+            IsActive = true,
+            CreatedAt = Instant.FromUtc(2026, 3, 1, 12, 0),
+            UpdatedAt = Instant.FromUtc(2026, 3, 1, 12, 0)
+        };
+
+        await _repo.AddProductAsync(product);
+
+        var fetched = await _repo.GetActiveProductsForYearAsync(2026);
+        fetched.Should().HaveCount(1);
+        fetched[0].Id.Should().Be(product.Id);
+        fetched[0].Name.Should().Be("Tent rental");
+        fetched[0].UnitPriceEur.Should().Be(50m);
+        fetched[0].DepositAmountEur.Should().Be(100m);
+    }
+
+    [HumansFact]
+    public async Task GetActiveProductsForYearAsync_filters_by_year_and_active_flag()
+    {
+        await _repo.AddProductAsync(MakeProduct(year: 2026, isActive: true, name: "A"));
+        await _repo.AddProductAsync(MakeProduct(year: 2026, isActive: false, name: "B"));
+        await _repo.AddProductAsync(MakeProduct(year: 2025, isActive: true, name: "C"));
+
+        var results = await _repo.GetActiveProductsForYearAsync(2026);
+
+        results.Should().HaveCount(1);
+        results[0].Name.Should().Be("A");
+    }
+
+    [HumansFact]
+    public async Task GetOrCreateTreasurySyncStateAsync_creates_singleton_on_first_call()
+    {
+        var first = await _repo.GetOrCreateTreasurySyncStateAsync();
+        var second = await _repo.GetOrCreateTreasurySyncStateAsync();
+
+        first.Id.Should().Be(1);
+        second.Id.Should().Be(1);
+    }
+
+    [HumansFact]
+    public async Task AddOrderAsync_then_GetOrderWithLinesAndPaymentsAsync_round_trip()
+    {
+        var orderId = Guid.NewGuid();
+        var order = new StoreOrder
+        {
+            Id = orderId,
+            CampSeasonId = Guid.NewGuid(),
+            Label = "Lead's first order",
+            CreatedAt = Instant.FromUtc(2026, 3, 1, 12, 0),
+            UpdatedAt = Instant.FromUtc(2026, 3, 1, 12, 0)
+        };
+
+        await _repo.AddOrderAsync(order);
+
+        var fetched = await _repo.GetOrderWithLinesAndPaymentsAsync(orderId);
+        fetched.Should().NotBeNull();
+        fetched!.Id.Should().Be(orderId);
+        fetched.Label.Should().Be("Lead's first order");
+        fetched.Lines.Should().BeEmpty();
+        fetched.Payments.Should().BeEmpty();
+    }
+
+    private static StoreProduct MakeProduct(int year, bool isActive, string name)
+    {
+        return new StoreProduct
+        {
+            Id = Guid.NewGuid(),
+            Year = year,
+            Name = name,
+            Description = "desc",
+            UnitPriceEur = 10m,
+            VatRatePercent = 21m,
+            OrderableUntil = new LocalDate(year, 12, 31),
+            IsActive = isActive,
+            CreatedAt = Instant.FromUtc(year, 1, 1, 0, 0),
+            UpdatedAt = Instant.FromUtc(year, 1, 1, 0, 0)
+        };
+    }
+}

--- a/tests/Humans.Domain.Tests/Entities/StoreEntityDefaultsTests.cs
+++ b/tests/Humans.Domain.Tests/Entities/StoreEntityDefaultsTests.cs
@@ -5,7 +5,7 @@ using Xunit;
 
 namespace Humans.Domain.Tests.Entities;
 
-public class StoreOrderTests
+public class StoreEntityDefaultsTests
 {
     [HumansFact]
     public void New_order_defaults_to_open_state()
@@ -31,6 +31,6 @@ public class StoreOrderTests
         var s = new StoreTreasurySyncState();
 
         s.Id.Should().Be(1);
-        s.SyncStatus.Should().Be("Idle");
+        s.SyncStatus.Should().Be(StoreTreasurySyncStatus.Idle);
     }
 }

--- a/tests/Humans.Domain.Tests/Entities/StoreOrderTests.cs
+++ b/tests/Humans.Domain.Tests/Entities/StoreOrderTests.cs
@@ -1,0 +1,36 @@
+using AwesomeAssertions;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using Xunit;
+
+namespace Humans.Domain.Tests.Entities;
+
+public class StoreOrderTests
+{
+    [HumansFact]
+    public void New_order_defaults_to_open_state()
+    {
+        var o = new StoreOrder();
+
+        o.State.Should().Be(StoreOrderState.Open);
+        o.Lines.Should().BeEmpty();
+        o.Payments.Should().BeEmpty();
+    }
+
+    [HumansFact]
+    public void New_product_defaults_to_active()
+    {
+        var p = new StoreProduct();
+
+        p.IsActive.Should().BeTrue();
+    }
+
+    [HumansFact]
+    public void Treasury_sync_state_singleton_id_is_one()
+    {
+        var s = new StoreTreasurySyncState();
+
+        s.Id.Should().Be(1);
+        s.SyncStatus.Should().Be("Idle");
+    }
+}


### PR DESCRIPTION
Phase 1 of the /Store section per `docs/superpowers/specs/2026-04-30-store-section-design.md`.

## Summary

- 6 new entities: `StoreProduct`, `StoreOrder`, `StoreOrderLine`, `StorePayment`, `StoreInvoice`, `StoreTreasurySyncState`.
- 2 new enums: `StoreOrderState`, `StorePaymentMethod`.
- New `StoreAdmin` role (added to `BoardManageableRoles`).
- `IStoreService` + `IStoreRepository` (skeleton — service methods throw `NotSupportedException`, filled in Phases 2-7).
- `StoreRepository` is Singleton + `IDbContextFactory` (§15b), matching `BudgetRepository`.
- EF migration `AddStoreSection` (auto-generated, only Store tables).
- Section invariants doc at `docs/sections/Store.md` with `freshness:triggers` header (auto-walked by the `/freshness-sweep` skill — no per-file catalog entry needed).
- Smoke tests: domain entity defaults + repository round-trip (products, orders, treasury-sync singleton).

## Decisions baked in

- **Year handle:** plain `int Year` on `StoreProduct`. No FK to `CampSettings`/`CampSeason` — spec marked this deferred; plan locked the simplest interpretation.
- **Enum storage:** `int` via `HasConversion<int>()` per the plan's config code blocks.
- **Stripe PaymentIntent uniqueness:** filtered unique index (`StripePaymentIntentId IS NOT NULL`).
- **No caching decorator** — admin / camp-lead-only, low-traffic.
- **No cross-domain navigation properties** — `CampSeasonId`, `ProductId`, `*UserId` are FK-only.

## EF migration review

Reviewed inline against `.claude/agents/ef-migration-reviewer.md` checklist — no CRITICAL or WARNING issues:

- No `HasDefaultValue(false)` / sentinel traps.
- Migration is auto-generated, not hand-edited; namespace is `Humans.Infrastructure.Migrations`.
- All required strings have `IsRequired()`; decimals use `numeric(12,2)` / `numeric(5,2)`.
- FKs configured with `OnDelete: Cascade` for lines/payments under orders.
- DbSets declared; snake_case table names.

## Test plan

- [ ] CI green on peterdrier/Humans.
- [ ] Migration applies cleanly to preview DB.
- [ ] No new orphan pages (no UI yet — Phase 2 lands the Camp Lead UX).

🤖 Generated with [Claude Code](https://claude.com/claude-code)