### PR TITLE
feat(store): camp-lead order UX — /Store browse, order CRUD, balance

### DIFF
--- a/src/Humans.Application/Interfaces/Repositories/IStoreRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/IStoreRepository.cs
@@ -32,6 +32,13 @@ public interface IStoreRepository
     // Products
     Task<IReadOnlyList<StoreProduct>> GetActiveProductsForYearAsync(int year, CancellationToken ct = default);
     Task<StoreProduct?> GetProductByIdAsync(Guid productId, CancellationToken ct = default);
+    /// <summary>
+    /// Resolves product display names for the given ids regardless of whether
+    /// the product is currently active or belongs to the active year. Used by
+    /// order-mapping code so issued/historical lines render with their actual
+    /// product name even after the product has been deactivated.
+    /// </summary>
+    Task<IReadOnlyDictionary<Guid, string>> GetProductNamesByIdsAsync(IReadOnlyCollection<Guid> ids, CancellationToken ct = default);
     Task AddProductAsync(StoreProduct product, CancellationToken ct = default);
     Task UpdateProductAsync(StoreProduct product, CancellationToken ct = default);
 

--- a/src/Humans.Application/Interfaces/Repositories/IStoreRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/IStoreRepository.cs
@@ -1,6 +1,20 @@
 using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using NodaTime;
 
 namespace Humans.Application.Interfaces.Repositories;
+
+/// <summary>
+/// Materialized view of a <see cref="StoreOrderLine"/> together with the parent
+/// order's state and camp season and the product's order deadline. Returned by
+/// <see cref="IStoreRepository.GetLineWithOrderAndProductAsync"/>.
+/// </summary>
+public record StoreLineContext(
+    Guid LineId,
+    Guid OrderId,
+    Guid CampSeasonId,
+    StoreOrderState OrderState,
+    LocalDate ProductOrderableUntil);
 
 /// <summary>
 /// Repository for the Store section's tables: <c>store_products</c>,
@@ -32,6 +46,13 @@ public interface IStoreRepository
     // Lines
     Task AddLineAsync(StoreOrderLine line, CancellationToken ct = default);
     Task RemoveLineAsync(Guid lineId, CancellationToken ct = default);
+    /// <summary>
+    /// Returns the line plus its parent order's <see cref="StoreOrder.State"/> and
+    /// <see cref="StoreOrder.CampSeasonId"/> and the product's
+    /// <see cref="StoreProduct.OrderableUntil"/> deadline. Used by RemoveLineAsync
+    /// to enforce the same gate as AddLine without three round trips.
+    /// </summary>
+    Task<StoreLineContext?> GetLineWithOrderAndProductAsync(Guid lineId, CancellationToken ct = default);
 
     // Payments
     Task AddPaymentAsync(StorePayment payment, CancellationToken ct = default);

--- a/src/Humans.Application/Services/Store/BalanceCalculator.cs
+++ b/src/Humans.Application/Services/Store/BalanceCalculator.cs
@@ -4,31 +4,44 @@ namespace Humans.Application.Services.Store;
 
 public static class BalanceCalculator
 {
+    public record LineTotals(
+        Guid LineId,
+        decimal SubtotalEur,
+        decimal VatEur,
+        decimal DepositEur,
+        decimal TotalEur);
+
     public record Result(
         decimal LinesSubtotalEur,
         decimal VatTotalEur,
         decimal DepositTotalEur,
         decimal PaymentsTotalEur,
-        decimal BalanceEur);
+        decimal BalanceEur,
+        IReadOnlyList<LineTotals> Lines);
 
     public static Result Compute(StoreOrder order)
     {
         decimal subtotal = 0m;
         decimal vat = 0m;
         decimal deposits = 0m;
+        var lineTotals = new List<LineTotals>(order.Lines.Count);
 
         foreach (var line in order.Lines)
         {
             var lineSubtotal = line.Qty * line.UnitPriceSnapshot;
+            var lineVat = Math.Round(lineSubtotal * line.VatRateSnapshot / 100m, 2, MidpointRounding.AwayFromZero);
+            var lineDeposit = line.DepositAmountSnapshot is { } deposit ? line.Qty * deposit : 0m;
+            var lineTotal = lineSubtotal + lineVat + lineDeposit;
+
             subtotal += lineSubtotal;
-            vat += Math.Round(lineSubtotal * line.VatRateSnapshot / 100m, 2, MidpointRounding.AwayFromZero);
-            if (line.DepositAmountSnapshot is { } deposit)
-                deposits += line.Qty * deposit;
+            vat += lineVat;
+            deposits += lineDeposit;
+            lineTotals.Add(new LineTotals(line.Id, lineSubtotal, lineVat, lineDeposit, lineTotal));
         }
 
         var payments = order.Payments.Sum(p => p.AmountEur);
         var balance = subtotal + vat + deposits - payments;
 
-        return new Result(subtotal, vat, deposits, payments, balance);
+        return new Result(subtotal, vat, deposits, payments, balance, lineTotals);
     }
 }

--- a/src/Humans.Application/Services/Store/BalanceCalculator.cs
+++ b/src/Humans.Application/Services/Store/BalanceCalculator.cs
@@ -1,0 +1,34 @@
+using Humans.Domain.Entities;
+
+namespace Humans.Application.Services.Store;
+
+public static class BalanceCalculator
+{
+    public record Result(
+        decimal LinesSubtotalEur,
+        decimal VatTotalEur,
+        decimal DepositTotalEur,
+        decimal PaymentsTotalEur,
+        decimal BalanceEur);
+
+    public static Result Compute(StoreOrder order)
+    {
+        decimal subtotal = 0m;
+        decimal vat = 0m;
+        decimal deposits = 0m;
+
+        foreach (var line in order.Lines)
+        {
+            var lineSubtotal = line.Qty * line.UnitPriceSnapshot;
+            subtotal += lineSubtotal;
+            vat += Math.Round(lineSubtotal * line.VatRateSnapshot / 100m, 2, MidpointRounding.AwayFromZero);
+            if (line.DepositAmountSnapshot is { } deposit)
+                deposits += line.Qty * deposit;
+        }
+
+        var payments = order.Payments.Sum(p => p.AmountEur);
+        var balance = subtotal + vat + deposits - payments;
+
+        return new Result(subtotal, vat, deposits, payments, balance);
+    }
+}

--- a/src/Humans.Application/Services/Store/Dtos/OrderLineDto.cs
+++ b/src/Humans.Application/Services/Store/Dtos/OrderLineDto.cs
@@ -11,4 +11,8 @@ public record OrderLineDto(
     decimal UnitPriceSnapshot,
     decimal VatRateSnapshot,
     decimal? DepositAmountSnapshot,
-    Instant AddedAt);
+    Instant AddedAt,
+    decimal SubtotalEur,
+    decimal VatEur,
+    decimal DepositEur,
+    decimal TotalEur);

--- a/src/Humans.Application/Services/Store/StoreService.cs
+++ b/src/Humans.Application/Services/Store/StoreService.cs
@@ -210,10 +210,16 @@ public class StoreService : IStoreService
     private static OrderDto MapOrder(StoreOrder o, IReadOnlyDictionary<Guid, string> productNames)
     {
         var balance = BalanceCalculator.Compute(o);
-        var lines = o.Lines.Select(l => new OrderLineDto(
-            l.Id, l.OrderId, l.ProductId,
-            productNames.GetValueOrDefault(l.ProductId, "(unknown product)"),
-            l.Qty, l.UnitPriceSnapshot, l.VatRateSnapshot, l.DepositAmountSnapshot, l.AddedAt)).ToList();
+        var totalsByLine = balance.Lines.ToDictionary(t => t.LineId);
+        var lines = o.Lines.Select(l =>
+        {
+            var t = totalsByLine[l.Id];
+            return new OrderLineDto(
+                l.Id, l.OrderId, l.ProductId,
+                productNames.GetValueOrDefault(l.ProductId, "(unknown product)"),
+                l.Qty, l.UnitPriceSnapshot, l.VatRateSnapshot, l.DepositAmountSnapshot, l.AddedAt,
+                t.SubtotalEur, t.VatEur, t.DepositEur, t.TotalEur);
+        }).ToList();
 
         return new OrderDto(
             o.Id, o.CampSeasonId, o.Label, o.State,

--- a/src/Humans.Application/Services/Store/StoreService.cs
+++ b/src/Humans.Application/Services/Store/StoreService.cs
@@ -58,8 +58,8 @@ public class StoreService : IStoreService
     public async Task<IReadOnlyList<OrderDto>> GetOrdersForCampSeasonAsync(Guid campSeasonId, CancellationToken ct = default)
     {
         var orders = await _repo.GetOrdersForCampSeasonAsync(campSeasonId, ct);
-        var products = await _repo.GetActiveProductsForYearAsync(DateTime.UtcNow.Year, ct);
-        var productNames = products.ToDictionary(p => p.Id, p => p.Name);
+        var productIds = orders.SelectMany(o => o.Lines).Select(l => l.ProductId).Distinct().ToList();
+        var productNames = await _repo.GetProductNamesByIdsAsync(productIds, ct);
         return orders.Select(o => MapOrder(o, productNames)).ToList();
     }
 
@@ -67,8 +67,8 @@ public class StoreService : IStoreService
     {
         var o = await _repo.GetOrderWithLinesAndPaymentsAsync(orderId, ct);
         if (o is null) return null;
-        var products = await _repo.GetActiveProductsForYearAsync(DateTime.UtcNow.Year, ct);
-        var productNames = products.ToDictionary(p => p.Id, p => p.Name);
+        var productIds = o.Lines.Select(l => l.ProductId).Distinct().ToList();
+        var productNames = await _repo.GetProductNamesByIdsAsync(productIds, ct);
         return MapOrder(o, productNames);
     }
 

--- a/src/Humans.Application/Services/Store/StoreService.cs
+++ b/src/Humans.Application/Services/Store/StoreService.cs
@@ -73,20 +73,118 @@ public class StoreService : IStoreService
     }
 
     // ==========================================================================
-    // Orders (write — Phase 2.4)
+    // Orders (write)
     // ==========================================================================
 
-    public Task<Guid> CreateOrderAsync(Guid campSeasonId, string? label, Guid actorUserId, CancellationToken ct = default)
-        => throw new NotSupportedException("Phase 2.4");
+    public async Task<Guid> CreateOrderAsync(Guid campSeasonId, string? label, Guid actorUserId, CancellationToken ct = default)
+    {
+        var now = _clock.GetCurrentInstant();
+        var order = new StoreOrder
+        {
+            Id = Guid.NewGuid(),
+            CampSeasonId = campSeasonId,
+            Label = label,
+            State = StoreOrderState.Open,
+            CreatedAt = now,
+            UpdatedAt = now
+        };
+        await _repo.AddOrderAsync(order, ct);
+        await _audit.LogAsync(
+            AuditAction.StoreOrderCreated, nameof(StoreOrder), order.Id,
+            $"Created store order for camp season {campSeasonId}" +
+            (string.IsNullOrWhiteSpace(label) ? string.Empty : $" — '{label}'"),
+            actorUserId);
+        return order.Id;
+    }
 
-    public Task AddLineAsync(Guid orderId, Guid productId, int qty, Guid actorUserId, CancellationToken ct = default)
-        => throw new NotSupportedException("Phase 2.4");
+    public async Task AddLineAsync(Guid orderId, Guid productId, int qty, Guid actorUserId, CancellationToken ct = default)
+    {
+        if (qty <= 0)
+            throw new ArgumentException("Qty must be positive", nameof(qty));
 
-    public Task RemoveLineAsync(Guid lineId, Guid actorUserId, CancellationToken ct = default)
-        => throw new NotSupportedException("Phase 2.4");
+        var order = await _repo.GetOrderByIdAsync(orderId, ct)
+            ?? throw new InvalidOperationException($"Order {orderId} not found");
 
-    public Task UpdateCounterpartyAsync(Guid orderId, OrderCounterpartyInput input, Guid actorUserId, CancellationToken ct = default)
-        => throw new NotSupportedException("Phase 2.4");
+        if (order.State != StoreOrderState.Open)
+            throw new InvalidOperationException("Cannot add lines to an issued order");
+
+        var product = await _repo.GetProductByIdAsync(productId, ct)
+            ?? throw new InvalidOperationException($"Product {productId} not found");
+
+        var today = await TodayInEventZoneAsync();
+        if (today > product.OrderableUntil)
+            throw new InvalidOperationException(
+                $"Product '{product.Name}' order deadline ({product.OrderableUntil}) has passed");
+
+        var line = new StoreOrderLine
+        {
+            Id = Guid.NewGuid(),
+            OrderId = order.Id,
+            ProductId = product.Id,
+            Qty = qty,
+            UnitPriceSnapshot = product.UnitPriceEur,
+            VatRateSnapshot = product.VatRatePercent,
+            DepositAmountSnapshot = product.DepositAmountEur,
+            AddedAt = _clock.GetCurrentInstant(),
+            AddedByUserId = actorUserId
+        };
+        await _repo.AddLineAsync(line, ct);
+        await _audit.LogAsync(
+            AuditAction.StoreLineAdded, nameof(StoreOrderLine), line.Id,
+            $"Added {qty} × '{product.Name}' to order {order.Id}",
+            actorUserId, order.Id, nameof(StoreOrder));
+    }
+
+    public async Task RemoveLineAsync(Guid lineId, Guid actorUserId, CancellationToken ct = default)
+    {
+        var ctx = await _repo.GetLineWithOrderAndProductAsync(lineId, ct)
+            ?? throw new InvalidOperationException($"Line {lineId} not found");
+
+        if (ctx.OrderState != StoreOrderState.Open)
+            throw new InvalidOperationException("Cannot remove lines from an issued order");
+
+        var today = await TodayInEventZoneAsync();
+        if (today > ctx.ProductOrderableUntil)
+            throw new InvalidOperationException(
+                $"Line's product order deadline ({ctx.ProductOrderableUntil}) has passed");
+
+        await _repo.RemoveLineAsync(lineId, ct);
+        await _audit.LogAsync(
+            AuditAction.StoreLineRemoved, nameof(StoreOrderLine), lineId,
+            $"Removed line {lineId} from order {ctx.OrderId}",
+            actorUserId, ctx.OrderId, nameof(StoreOrder));
+    }
+
+    public async Task UpdateCounterpartyAsync(Guid orderId, OrderCounterpartyInput input, Guid actorUserId, CancellationToken ct = default)
+    {
+        var order = await _repo.GetOrderByIdAsync(orderId, ct)
+            ?? throw new InvalidOperationException($"Order {orderId} not found");
+
+        if (order.State != StoreOrderState.Open)
+            throw new InvalidOperationException("Cannot edit counterparty on an issued order");
+
+        order.CounterpartyName = input.Name;
+        order.CounterpartyVatId = input.VatId;
+        order.CounterpartyAddress = input.Address;
+        order.CounterpartyCountryCode = input.CountryCode;
+        order.CounterpartyEmail = input.Email;
+        order.UpdatedAt = _clock.GetCurrentInstant();
+
+        await _repo.UpdateOrderAsync(order, ct);
+        await _audit.LogAsync(
+            AuditAction.StoreCounterpartyEdited, nameof(StoreOrder), orderId,
+            $"Updated counterparty on order {orderId}",
+            actorUserId);
+    }
+
+    private async Task<LocalDate> TodayInEventZoneAsync()
+    {
+        var activeEvent = await _shifts.GetActiveAsync();
+        var tz = activeEvent is null
+            ? DateTimeZone.Utc
+            : DateTimeZoneProviders.Tzdb.GetZoneOrNull(activeEvent.TimeZoneId) ?? DateTimeZone.Utc;
+        return _clock.GetCurrentInstant().InZone(tz).Date;
+    }
 
     // ==========================================================================
     // Payments / invoices / summary (Phase 5+)

--- a/src/Humans.Application/Services/Store/StoreService.cs
+++ b/src/Humans.Application/Services/Store/StoreService.cs
@@ -1,18 +1,46 @@
+using Humans.Application.Interfaces.AuditLog;
 using Humans.Application.Interfaces.Repositories;
+using Humans.Application.Interfaces.Shifts;
 using Humans.Application.Interfaces.Store;
 using Humans.Application.Services.Store.Dtos;
+using Humans.Domain.Entities;
 using Humans.Domain.Enums;
+using NodaTime;
 
 namespace Humans.Application.Services.Store;
 
 public class StoreService : IStoreService
 {
     private readonly IStoreRepository _repo;
+    private readonly IAuditLogService _audit;
+    private readonly IClock _clock;
+    private readonly IShiftManagementService _shifts;
 
-    public StoreService(IStoreRepository repo) => _repo = repo;
+    public StoreService(
+        IStoreRepository repo,
+        IAuditLogService audit,
+        IClock clock,
+        IShiftManagementService shifts)
+    {
+        _repo = repo;
+        _audit = audit;
+        _clock = clock;
+        _shifts = shifts;
+    }
 
-    public Task<IReadOnlyList<ProductDto>> GetActiveCatalogAsync(int year, CancellationToken ct = default)
-        => throw new NotSupportedException("Phase 2");
+    // ==========================================================================
+    // Catalog (read)
+    // ==========================================================================
+
+    public async Task<IReadOnlyList<ProductDto>> GetActiveCatalogAsync(int year, CancellationToken ct = default)
+    {
+        var products = await _repo.GetActiveProductsForYearAsync(year, ct);
+        return products.Select(MapProduct).ToList();
+    }
+
+    // ==========================================================================
+    // Catalog (write — Phase 3)
+    // ==========================================================================
 
     public Task<Guid> CreateProductAsync(ProductDto draft, Guid actorUserId, CancellationToken ct = default)
         => throw new NotSupportedException("Phase 3");
@@ -23,23 +51,46 @@ public class StoreService : IStoreService
     public Task DeactivateProductAsync(Guid productId, Guid actorUserId, CancellationToken ct = default)
         => throw new NotSupportedException("Phase 3");
 
-    public Task<IReadOnlyList<OrderDto>> GetOrdersForCampSeasonAsync(Guid campSeasonId, CancellationToken ct = default)
-        => throw new NotSupportedException("Phase 2");
+    // ==========================================================================
+    // Orders (read)
+    // ==========================================================================
 
-    public Task<OrderDto?> GetOrderAsync(Guid orderId, CancellationToken ct = default)
-        => throw new NotSupportedException("Phase 2");
+    public async Task<IReadOnlyList<OrderDto>> GetOrdersForCampSeasonAsync(Guid campSeasonId, CancellationToken ct = default)
+    {
+        var orders = await _repo.GetOrdersForCampSeasonAsync(campSeasonId, ct);
+        var products = await _repo.GetActiveProductsForYearAsync(DateTime.UtcNow.Year, ct);
+        var productNames = products.ToDictionary(p => p.Id, p => p.Name);
+        return orders.Select(o => MapOrder(o, productNames)).ToList();
+    }
+
+    public async Task<OrderDto?> GetOrderAsync(Guid orderId, CancellationToken ct = default)
+    {
+        var o = await _repo.GetOrderWithLinesAndPaymentsAsync(orderId, ct);
+        if (o is null) return null;
+        var products = await _repo.GetActiveProductsForYearAsync(DateTime.UtcNow.Year, ct);
+        var productNames = products.ToDictionary(p => p.Id, p => p.Name);
+        return MapOrder(o, productNames);
+    }
+
+    // ==========================================================================
+    // Orders (write — Phase 2.4)
+    // ==========================================================================
 
     public Task<Guid> CreateOrderAsync(Guid campSeasonId, string? label, Guid actorUserId, CancellationToken ct = default)
-        => throw new NotSupportedException("Phase 2");
+        => throw new NotSupportedException("Phase 2.4");
 
     public Task AddLineAsync(Guid orderId, Guid productId, int qty, Guid actorUserId, CancellationToken ct = default)
-        => throw new NotSupportedException("Phase 2");
+        => throw new NotSupportedException("Phase 2.4");
 
     public Task RemoveLineAsync(Guid lineId, Guid actorUserId, CancellationToken ct = default)
-        => throw new NotSupportedException("Phase 2");
+        => throw new NotSupportedException("Phase 2.4");
 
     public Task UpdateCounterpartyAsync(Guid orderId, OrderCounterpartyInput input, Guid actorUserId, CancellationToken ct = default)
-        => throw new NotSupportedException("Phase 2");
+        => throw new NotSupportedException("Phase 2.4");
+
+    // ==========================================================================
+    // Payments / invoices / summary (Phase 5+)
+    // ==========================================================================
 
     public Task RecordManualPaymentAsync(Guid orderId, decimal amountEur, StorePaymentMethod method, string? externalRef, string? notes, Guid actorUserId, CancellationToken ct = default)
         => throw new NotSupportedException("Phase 5");
@@ -49,4 +100,29 @@ public class StoreService : IStoreService
 
     public Task<IReadOnlyList<OrderSummaryDto>> GetAllOrderSummariesAsync(int year, CancellationToken ct = default)
         => throw new NotSupportedException("Phase 5");
+
+    // ==========================================================================
+    // Mapping
+    // ==========================================================================
+
+    private static ProductDto MapProduct(StoreProduct p) =>
+        new(p.Id, p.Year, p.Name, p.Description, p.UnitPriceEur, p.VatRatePercent,
+            p.DepositAmountEur, p.OrderableUntil, p.IsActive);
+
+    private static OrderDto MapOrder(StoreOrder o, IReadOnlyDictionary<Guid, string> productNames)
+    {
+        var balance = BalanceCalculator.Compute(o);
+        var lines = o.Lines.Select(l => new OrderLineDto(
+            l.Id, l.OrderId, l.ProductId,
+            productNames.GetValueOrDefault(l.ProductId, "(unknown product)"),
+            l.Qty, l.UnitPriceSnapshot, l.VatRateSnapshot, l.DepositAmountSnapshot, l.AddedAt)).ToList();
+
+        return new OrderDto(
+            o.Id, o.CampSeasonId, o.Label, o.State,
+            o.CounterpartyName, o.CounterpartyVatId, o.CounterpartyAddress, o.CounterpartyCountryCode, o.CounterpartyEmail,
+            o.IssuedInvoiceId,
+            lines,
+            balance.LinesSubtotalEur, balance.VatTotalEur, balance.DepositTotalEur,
+            balance.PaymentsTotalEur, balance.BalanceEur);
+    }
 }

--- a/src/Humans.Domain/Enums/AuditAction.cs
+++ b/src/Humans.Domain/Enums/AuditAction.cs
@@ -94,4 +94,8 @@ public enum AuditAction
     CampRoleAssigned,
     CampRoleUnassigned,
     AccountPurged,
+    StoreOrderCreated,
+    StoreLineAdded,
+    StoreLineRemoved,
+    StoreCounterpartyEdited,
 }

--- a/src/Humans.Infrastructure/Repositories/Store/StoreRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Store/StoreRepository.cs
@@ -93,7 +93,7 @@ public sealed class StoreRepository : IStoreRepository
     public async Task<StoreOrder?> GetOrderWithLinesAndPaymentsAsync(Guid orderId, CancellationToken ct = default)
     {
         await using var ctx = await _factory.CreateDbContextAsync(ct);
-        return await ctx.StoreOrders
+        return await ctx.StoreOrders.AsNoTracking()
             .Include(o => o.Lines)
             .Include(o => o.Payments)
             .FirstOrDefaultAsync(o => o.Id == orderId, ct);

--- a/src/Humans.Infrastructure/Repositories/Store/StoreRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Store/StoreRepository.cs
@@ -45,6 +45,17 @@ public sealed class StoreRepository : IStoreRepository
         return await ctx.StoreProducts.FirstOrDefaultAsync(p => p.Id == productId, ct);
     }
 
+    public async Task<IReadOnlyDictionary<Guid, string>> GetProductNamesByIdsAsync(IReadOnlyCollection<Guid> ids, CancellationToken ct = default)
+    {
+        if (ids.Count == 0) return new Dictionary<Guid, string>();
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        var rows = await ctx.StoreProducts.AsNoTracking()
+            .Where(p => ids.Contains(p.Id))
+            .Select(p => new { p.Id, p.Name })
+            .ToListAsync(ct);
+        return rows.ToDictionary(r => r.Id, r => r.Name);
+    }
+
     public async Task AddProductAsync(StoreProduct product, CancellationToken ct = default)
     {
         await using var ctx = await _factory.CreateDbContextAsync(ct);

--- a/src/Humans.Infrastructure/Repositories/Store/StoreRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Store/StoreRepository.cs
@@ -131,6 +131,22 @@ public sealed class StoreRepository : IStoreRepository
         await ctx.SaveChangesAsync(ct);
     }
 
+    public async Task<StoreLineContext?> GetLineWithOrderAndProductAsync(Guid lineId, CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        var row = await ctx.StoreOrderLines.AsNoTracking()
+            .Where(l => l.Id == lineId)
+            .Join(ctx.StoreOrders.AsNoTracking(),
+                l => l.OrderId, o => o.Id,
+                (l, o) => new { Line = l, Order = o })
+            .Join(ctx.StoreProducts.AsNoTracking(),
+                lo => lo.Line.ProductId, p => p.Id,
+                (lo, p) => new StoreLineContext(
+                    lo.Line.Id, lo.Order.Id, lo.Order.CampSeasonId, lo.Order.State, p.OrderableUntil))
+            .FirstOrDefaultAsync(ct);
+        return row;
+    }
+
     // ==========================================================================
     // Payments
     // ==========================================================================

--- a/src/Humans.Web/Authorization/AuthorizationPolicyExtensions.cs
+++ b/src/Humans.Web/Authorization/AuthorizationPolicyExtensions.cs
@@ -22,6 +22,7 @@ public static class AuthorizationPolicyExtensions
         // Resource-based authorization handlers (scoped — they depend on scoped services)
         services.AddScoped<IAuthorizationHandler, BudgetAuthorizationHandler>();
         services.AddScoped<IAuthorizationHandler, CampAuthorizationHandler>();
+        services.AddScoped<IAuthorizationHandler, StoreOrderAuthorizationHandler>();
         services.AddScoped<IAuthorizationHandler, TeamAuthorizationHandler>();
 
         // Service-layer enforcement handlers (singleton — no scoped dependencies)

--- a/src/Humans.Web/Authorization/Requirements/StoreOrderAuthorizationHandler.cs
+++ b/src/Humans.Web/Authorization/Requirements/StoreOrderAuthorizationHandler.cs
@@ -1,0 +1,48 @@
+using System.Security.Claims;
+using Humans.Application.Interfaces.Camps;
+using Humans.Application.Services.Store.Dtos;
+using Microsoft.AspNetCore.Authorization;
+
+namespace Humans.Web.Authorization.Requirements;
+
+/// <summary>
+/// Resource-based authorization handler for Store order operations.
+///
+/// Authorization logic:
+/// - Admin or FinanceAdmin: allow any operation on any order
+/// - Camp lead of the camp that owns the order's CampSeason: allow any operation
+/// - Everyone else: deny
+/// </summary>
+public class StoreOrderAuthorizationHandler : AuthorizationHandler<StoreOrderOperationRequirement, OrderDto>
+{
+    private readonly ICampService _campService;
+
+    public StoreOrderAuthorizationHandler(ICampService campService)
+    {
+        _campService = campService;
+    }
+
+    protected override async Task HandleRequirementAsync(
+        AuthorizationHandlerContext context,
+        StoreOrderOperationRequirement requirement,
+        OrderDto resource)
+    {
+        if (RoleChecks.IsFinanceAdmin(context.User))
+        {
+            context.Succeed(requirement);
+            return;
+        }
+
+        var userIdClaim = context.User.FindFirst(ClaimTypes.NameIdentifier);
+        if (userIdClaim is null || !Guid.TryParse(userIdClaim.Value, out var userId))
+            return;
+
+        var season = await _campService.GetCampSeasonByIdAsync(resource.CampSeasonId);
+        if (season is null) return;
+
+        if (await _campService.IsUserCampLeadAsync(userId, season.CampId))
+        {
+            context.Succeed(requirement);
+        }
+    }
+}

--- a/src/Humans.Web/Authorization/Requirements/StoreOrderAuthorizationHandler.cs
+++ b/src/Humans.Web/Authorization/Requirements/StoreOrderAuthorizationHandler.cs
@@ -8,12 +8,14 @@ namespace Humans.Web.Authorization.Requirements;
 /// <summary>
 /// Resource-based authorization handler for Store order operations.
 ///
-/// Authorization logic:
-/// - Admin or FinanceAdmin: allow any operation on any order
-/// - Camp lead of the camp that owns the order's CampSeason: allow any operation
+/// Authorization logic (applies to both <see cref="OrderDto"/> resources for
+/// View/AddLine/RemoveLine/EditCounterparty and <see cref="StoreOrderCreateContext"/>
+/// resources for Create):
+/// - Admin or FinanceAdmin: allow any operation
+/// - Camp lead/co-lead of the camp owning the resource's CampSeason: allow
 /// - Everyone else: deny
 /// </summary>
-public class StoreOrderAuthorizationHandler : AuthorizationHandler<StoreOrderOperationRequirement, OrderDto>
+public class StoreOrderAuthorizationHandler : IAuthorizationHandler
 {
     private readonly ICampService _campService;
 
@@ -22,14 +24,25 @@ public class StoreOrderAuthorizationHandler : AuthorizationHandler<StoreOrderOpe
         _campService = campService;
     }
 
-    protected override async Task HandleRequirementAsync(
-        AuthorizationHandlerContext context,
-        StoreOrderOperationRequirement requirement,
-        OrderDto resource)
+    public async Task HandleAsync(AuthorizationHandlerContext context)
     {
+        // Only react to our own requirement type.
+        var pending = context.PendingRequirements
+            .OfType<StoreOrderOperationRequirement>()
+            .ToList();
+        if (pending.Count == 0) return;
+
+        var campSeasonId = context.Resource switch
+        {
+            OrderDto order => order.CampSeasonId,
+            StoreOrderCreateContext create => create.CampSeasonId,
+            _ => (Guid?)null
+        };
+        if (campSeasonId is null) return;
+
         if (RoleChecks.IsFinanceAdmin(context.User))
         {
-            context.Succeed(requirement);
+            foreach (var req in pending) context.Succeed(req);
             return;
         }
 
@@ -37,12 +50,12 @@ public class StoreOrderAuthorizationHandler : AuthorizationHandler<StoreOrderOpe
         if (userIdClaim is null || !Guid.TryParse(userIdClaim.Value, out var userId))
             return;
 
-        var season = await _campService.GetCampSeasonByIdAsync(resource.CampSeasonId);
+        var season = await _campService.GetCampSeasonByIdAsync(campSeasonId.Value);
         if (season is null) return;
 
         if (await _campService.IsUserCampLeadAsync(userId, season.CampId))
         {
-            context.Succeed(requirement);
+            foreach (var req in pending) context.Succeed(req);
         }
     }
 }

--- a/src/Humans.Web/Authorization/Requirements/StoreOrderOperationRequirement.cs
+++ b/src/Humans.Web/Authorization/Requirements/StoreOrderOperationRequirement.cs
@@ -10,6 +10,7 @@ namespace Humans.Web.Authorization.Requirements;
 public sealed class StoreOrderOperationRequirement : IAuthorizationRequirement
 {
     public static readonly StoreOrderOperationRequirement View = new(nameof(View));
+    public static readonly StoreOrderOperationRequirement Create = new(nameof(Create));
     public static readonly StoreOrderOperationRequirement AddLine = new(nameof(AddLine));
     public static readonly StoreOrderOperationRequirement RemoveLine = new(nameof(RemoveLine));
     public static readonly StoreOrderOperationRequirement EditCounterparty = new(nameof(EditCounterparty));
@@ -21,3 +22,10 @@ public sealed class StoreOrderOperationRequirement : IAuthorizationRequirement
         OperationName = operationName;
     }
 }
+
+/// <summary>
+/// Resource passed to <see cref="StoreOrderAuthorizationHandler"/> when
+/// authorizing a Create-order operation. There is no <c>StoreOrder</c> yet, so
+/// the camp-lead check is rooted at the target <c>CampSeason</c>.
+/// </summary>
+public sealed record StoreOrderCreateContext(Guid CampSeasonId);

--- a/src/Humans.Web/Authorization/Requirements/StoreOrderOperationRequirement.cs
+++ b/src/Humans.Web/Authorization/Requirements/StoreOrderOperationRequirement.cs
@@ -1,0 +1,23 @@
+using Microsoft.AspNetCore.Authorization;
+
+namespace Humans.Web.Authorization.Requirements;
+
+/// <summary>
+/// Resource-based authorization requirement for Store order operations.
+/// Used with IAuthorizationService.AuthorizeAsync(User, order, requirement)
+/// where the resource is a StoreOrder.
+/// </summary>
+public sealed class StoreOrderOperationRequirement : IAuthorizationRequirement
+{
+    public static readonly StoreOrderOperationRequirement View = new(nameof(View));
+    public static readonly StoreOrderOperationRequirement AddLine = new(nameof(AddLine));
+    public static readonly StoreOrderOperationRequirement RemoveLine = new(nameof(RemoveLine));
+    public static readonly StoreOrderOperationRequirement EditCounterparty = new(nameof(EditCounterparty));
+
+    public string OperationName { get; }
+
+    private StoreOrderOperationRequirement(string operationName)
+    {
+        OperationName = operationName;
+    }
+}

--- a/src/Humans.Web/Controllers/StoreController.cs
+++ b/src/Humans.Web/Controllers/StoreController.cs
@@ -114,9 +114,11 @@ public class StoreController : HumansControllerBase
         var season = await _campService.GetCampSeasonByIdAsync(campSeasonId, ct);
         if (season is null) return NotFound();
 
-        var isPrivileged = User.IsInRole(RoleNames.Admin) || User.IsInRole(RoleNames.FinanceAdmin);
-        if (!isPrivileged && !await _campService.IsUserCampLeadAsync(user.Id, season.CampId, ct))
-            return Forbid();
+        var auth = await _authService.AuthorizeAsync(
+            User,
+            new StoreOrderCreateContext(campSeasonId),
+            StoreOrderOperationRequirement.Create);
+        if (!auth.Succeeded) return Forbid();
 
         var newId = await _storeService.CreateOrderAsync(campSeasonId, label, user.Id, ct);
         SetSuccess("Order created.");

--- a/src/Humans.Web/Controllers/StoreController.cs
+++ b/src/Humans.Web/Controllers/StoreController.cs
@@ -1,0 +1,218 @@
+using Humans.Application.Interfaces.Camps;
+using Humans.Application.Interfaces.Shifts;
+using Humans.Application.Interfaces.Store;
+using Humans.Application.Services.Store.Dtos;
+using Humans.Domain.Constants;
+using Humans.Domain.Entities;
+using Humans.Web.Authorization;
+using Humans.Web.Authorization.Requirements;
+using Humans.Web.Models;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Humans.Web.Controllers;
+
+[Authorize]
+[Route("Store")]
+public class StoreController : HumansControllerBase
+{
+    private readonly IStoreService _storeService;
+    private readonly ICampService _campService;
+    private readonly IShiftManagementService _shifts;
+    private readonly IAuthorizationService _authService;
+    private readonly ILogger<StoreController> _logger;
+
+    public StoreController(
+        IStoreService storeService,
+        ICampService campService,
+        IShiftManagementService shifts,
+        IAuthorizationService authService,
+        UserManager<User> userManager,
+        ILogger<StoreController> logger)
+        : base(userManager)
+    {
+        _storeService = storeService;
+        _campService = campService;
+        _shifts = shifts;
+        _authService = authService;
+        _logger = logger;
+    }
+
+    [HttpGet("")]
+    public async Task<IActionResult> Index(CancellationToken ct)
+    {
+        var (errorResult, user) = await RequireCurrentUserAsync();
+        if (errorResult is not null) return errorResult;
+
+        var year = await ResolveActiveYearAsync();
+        var catalog = await _storeService.GetActiveCatalogAsync(year, ct);
+
+        var isPrivilegedReader = User.IsInRole(RoleNames.Admin)
+            || User.IsInRole(RoleNames.FinanceAdmin)
+            || User.IsInRole(RoleNames.StoreAdmin);
+
+        var leadCamps = await _campService.GetCampsByLeadUserIdAsync(user.Id, ct);
+        var sections = new List<StoreCampSeasonOrders>();
+        foreach (var camp in leadCamps)
+        {
+            var season = camp.Seasons.FirstOrDefault(s => s.Year == year);
+            if (season is null) continue;
+            var orders = await _storeService.GetOrdersForCampSeasonAsync(season.Id, ct);
+            sections.Add(new StoreCampSeasonOrders(season.Id, season.Name, year, orders));
+        }
+
+        if (sections.Count == 0 && !isPrivilegedReader)
+        {
+            SetInfo("You don't lead any camps this year, so there are no Store orders to manage.");
+        }
+
+        var model = new StoreIndexViewModel
+        {
+            Year = year,
+            Catalog = catalog,
+            CampSeasons = sections
+        };
+        return View(model);
+    }
+
+    [HttpGet("Order/{id:guid}")]
+    public async Task<IActionResult> Order(Guid id, CancellationToken ct)
+    {
+        var (errorResult, _) = await RequireCurrentUserAsync();
+        if (errorResult is not null) return errorResult;
+
+        var order = await _storeService.GetOrderAsync(id, ct);
+        if (order is null) return NotFound();
+
+        var view = await _authService.AuthorizeAsync(User, order, StoreOrderOperationRequirement.View);
+        if (!view.Succeeded) return Forbid();
+
+        var year = await ResolveActiveYearAsync();
+        var catalog = await _storeService.GetActiveCatalogAsync(year, ct);
+        var season = await _campService.GetCampSeasonByIdAsync(order.CampSeasonId, ct);
+
+        var canEdit = (await _authService.AuthorizeAsync(User, order, StoreOrderOperationRequirement.AddLine)).Succeeded;
+
+        var model = new StoreOrderViewModel
+        {
+            Order = order,
+            Catalog = catalog,
+            CampName = season?.Name ?? "(unknown camp)",
+            CanEdit = canEdit
+        };
+        return View(model);
+    }
+
+    [HttpPost("Order/Create/{campSeasonId:guid}")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Create(Guid campSeasonId, string? label, CancellationToken ct)
+    {
+        var (errorResult, user) = await RequireCurrentUserAsync();
+        if (errorResult is not null) return errorResult;
+
+        var season = await _campService.GetCampSeasonByIdAsync(campSeasonId, ct);
+        if (season is null) return NotFound();
+
+        var isPrivileged = User.IsInRole(RoleNames.Admin) || User.IsInRole(RoleNames.FinanceAdmin);
+        if (!isPrivileged && !await _campService.IsUserCampLeadAsync(user.Id, season.CampId, ct))
+            return Forbid();
+
+        var newId = await _storeService.CreateOrderAsync(campSeasonId, label, user.Id, ct);
+        SetSuccess("Order created.");
+        return RedirectToAction(nameof(Order), new { id = newId });
+    }
+
+    [HttpPost("Order/{id:guid}/AddLine")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> AddLine(Guid id, Guid productId, int qty, CancellationToken ct)
+    {
+        var (errorResult, user) = await RequireCurrentUserAsync();
+        if (errorResult is not null) return errorResult;
+
+        var order = await _storeService.GetOrderAsync(id, ct);
+        if (order is null) return NotFound();
+
+        var auth = await _authService.AuthorizeAsync(User, order, StoreOrderOperationRequirement.AddLine);
+        if (!auth.Succeeded) return Forbid();
+
+        try
+        {
+            await _storeService.AddLineAsync(id, productId, qty, user.Id, ct);
+            SetSuccess("Line added.");
+        }
+        catch (ArgumentException ex)
+        {
+            SetError(ex.Message);
+            return RedirectToAction(nameof(Order), new { id });
+        }
+        catch (InvalidOperationException ex)
+        {
+            _logger.LogInformation(ex, "AddLine rejected for order {OrderId}", id);
+            SetError(ex.Message);
+            return RedirectToAction(nameof(Order), new { id });
+        }
+        return RedirectToAction(nameof(Order), new { id });
+    }
+
+    [HttpPost("Order/{id:guid}/RemoveLine")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> RemoveLine(Guid id, Guid lineId, CancellationToken ct)
+    {
+        var (errorResult, user) = await RequireCurrentUserAsync();
+        if (errorResult is not null) return errorResult;
+
+        var order = await _storeService.GetOrderAsync(id, ct);
+        if (order is null) return NotFound();
+
+        var auth = await _authService.AuthorizeAsync(User, order, StoreOrderOperationRequirement.RemoveLine);
+        if (!auth.Succeeded) return Forbid();
+
+        try
+        {
+            await _storeService.RemoveLineAsync(lineId, user.Id, ct);
+            SetSuccess("Line removed.");
+        }
+        catch (InvalidOperationException ex)
+        {
+            _logger.LogInformation(ex, "RemoveLine rejected for line {LineId}", lineId);
+            SetError(ex.Message);
+        }
+        return RedirectToAction(nameof(Order), new { id });
+    }
+
+    [HttpPost("Order/{id:guid}/UpdateCounterparty")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> UpdateCounterparty(
+        Guid id,
+        OrderCounterpartyInput input,
+        CancellationToken ct)
+    {
+        var (errorResult, user) = await RequireCurrentUserAsync();
+        if (errorResult is not null) return errorResult;
+
+        var order = await _storeService.GetOrderAsync(id, ct);
+        if (order is null) return NotFound();
+
+        var auth = await _authService.AuthorizeAsync(User, order, StoreOrderOperationRequirement.EditCounterparty);
+        if (!auth.Succeeded) return Forbid();
+
+        try
+        {
+            await _storeService.UpdateCounterpartyAsync(id, input, user.Id, ct);
+            SetSuccess("Counterparty updated.");
+        }
+        catch (InvalidOperationException ex)
+        {
+            _logger.LogInformation(ex, "UpdateCounterparty rejected for order {OrderId}", id);
+            SetError(ex.Message);
+        }
+        return RedirectToAction(nameof(Order), new { id });
+    }
+
+    private async Task<int> ResolveActiveYearAsync()
+    {
+        var activeEvent = await _shifts.GetActiveAsync();
+        return activeEvent?.Year > 0 ? activeEvent.Year : DateTime.UtcNow.Year;
+    }
+}

--- a/src/Humans.Web/Models/StoreIndexViewModel.cs
+++ b/src/Humans.Web/Models/StoreIndexViewModel.cs
@@ -1,0 +1,24 @@
+using Humans.Application.Services.Store.Dtos;
+
+namespace Humans.Web.Models;
+
+public sealed class StoreIndexViewModel
+{
+    public int Year { get; init; }
+    public IReadOnlyList<ProductDto> Catalog { get; init; } = [];
+    public IReadOnlyList<StoreCampSeasonOrders> CampSeasons { get; init; } = [];
+}
+
+public sealed record StoreCampSeasonOrders(
+    Guid CampSeasonId,
+    string CampName,
+    int Year,
+    IReadOnlyList<OrderDto> Orders);
+
+public sealed class StoreOrderViewModel
+{
+    public OrderDto Order { get; init; } = null!;
+    public IReadOnlyList<ProductDto> Catalog { get; init; } = [];
+    public string CampName { get; init; } = string.Empty;
+    public bool CanEdit { get; init; }
+}

--- a/src/Humans.Web/Views/Shared/_Layout.cshtml
+++ b/src/Humans.Web/Views/Shared/_Layout.cshtml
@@ -92,6 +92,9 @@
                         <li class="nav-item">
                             <a class="nav-link" asp-area="" asp-controller="Camp" asp-action="Index">@Localizer["Camp_Plural"]</a>
                         </li>
+                        <li class="nav-item" authorize-policy="IsActiveMember">
+                            <a class="nav-link" asp-area="" asp-controller="Store" asp-action="Index">Store</a>
+                        </li>
                         <li class="nav-item">
                             <a class="nav-link" asp-area="" asp-controller="Team" asp-action="Index">@Localizer["Nav_Teams"]</a>
                         </li>

--- a/src/Humans.Web/Views/Store/Index.cshtml
+++ b/src/Humans.Web/Views/Store/Index.cshtml
@@ -40,7 +40,7 @@ else
                             <tr>
                                 <th>Label</th>
                                 <th>State</th>
-                                <th class="text-end">Lines total</th>
+                                <th class="text-end">Lines + VAT</th>
                                 <th class="text-end">Deposits</th>
                                 <th class="text-end">Balance</th>
                                 <th></th>

--- a/src/Humans.Web/Views/Store/Index.cshtml
+++ b/src/Humans.Web/Views/Store/Index.cshtml
@@ -1,0 +1,107 @@
+@model Humans.Web.Models.StoreIndexViewModel
+@{
+    ViewData["Title"] = "Store";
+}
+
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <h1 class="mb-0">Store</h1>
+    <span class="badge bg-secondary fs-6">@Model.Year</span>
+</div>
+
+<vc:temp-data-alerts />
+
+@if (!Model.CampSeasons.Any())
+{
+    <div class="alert alert-info">
+        You don't lead any camps with an active season this year. The catalog
+        below is read-only.
+    </div>
+}
+else
+{
+    @foreach (var campSection in Model.CampSeasons)
+    {
+        <div class="card mb-4">
+            <div class="card-header d-flex justify-content-between align-items-center">
+                <h2 class="h5 mb-0">@campSection.CampName</h2>
+                <form asp-action="Create" asp-route-campSeasonId="@campSection.CampSeasonId"
+                      method="post" class="d-flex gap-2 align-items-center mb-0">
+                    @Html.AntiForgeryToken()
+                    <input type="text" name="label" class="form-control form-control-sm"
+                           placeholder="Label (optional)" maxlength="120" />
+                    <button type="submit" class="btn btn-sm btn-primary">Start order</button>
+                </form>
+            </div>
+            <div class="card-body p-0">
+                @if (campSection.Orders.Any())
+                {
+                    <table class="table table-sm mb-0">
+                        <thead>
+                            <tr>
+                                <th>Label</th>
+                                <th>State</th>
+                                <th class="text-end">Lines total</th>
+                                <th class="text-end">Deposits</th>
+                                <th class="text-end">Balance</th>
+                                <th></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach (var order in campSection.Orders)
+                            {
+                                <tr>
+                                    <td>@(string.IsNullOrWhiteSpace(order.Label) ? "(no label)" : order.Label)</td>
+                                    <td><span class="badge bg-secondary">@order.State</span></td>
+                                    <td class="text-end">&euro;@((order.LinesSubtotalEur + order.VatTotalEur).ToString("N2"))</td>
+                                    <td class="text-end">&euro;@order.DepositTotalEur.ToString("N2")</td>
+                                    <td class="text-end fw-bold">&euro;@order.BalanceEur.ToString("N2")</td>
+                                    <td class="text-end">
+                                        <a asp-action="Order" asp-route-id="@order.Id" class="btn btn-sm btn-outline-primary">Open</a>
+                                    </td>
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
+                }
+                else
+                {
+                    <div class="p-3 text-muted">No orders yet.</div>
+                }
+            </div>
+        </div>
+    }
+}
+
+<h2 class="h4 mb-3">Catalog (@Model.Year)</h2>
+@if (!Model.Catalog.Any())
+{
+    <div class="alert alert-secondary">No products are active for @Model.Year.</div>
+}
+else
+{
+    <table class="table">
+        <thead>
+            <tr>
+                <th>Name</th>
+                <th>Description</th>
+                <th class="text-end">Unit price</th>
+                <th class="text-end">VAT</th>
+                <th class="text-end">Deposit</th>
+                <th>Order by</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (var product in Model.Catalog)
+            {
+                <tr>
+                    <td>@product.Name</td>
+                    <td>@product.Description</td>
+                    <td class="text-end">&euro;@product.UnitPriceEur.ToString("N2")</td>
+                    <td class="text-end">@product.VatRatePercent.ToString("0.##")%</td>
+                    <td class="text-end">@(product.DepositAmountEur.HasValue ? $"€{product.DepositAmountEur.Value:N2}" : "—")</td>
+                    <td>@product.OrderableUntil</td>
+                </tr>
+            }
+        </tbody>
+    </table>
+}

--- a/src/Humans.Web/Views/Store/Order.cshtml
+++ b/src/Humans.Web/Views/Store/Order.cshtml
@@ -1,0 +1,172 @@
+@model Humans.Web.Models.StoreOrderViewModel
+@{
+    ViewData["Title"] = $"Store order — {Model.CampName}";
+    var order = Model.Order;
+}
+
+<nav aria-label="breadcrumb" class="mb-3">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a asp-action="Index">Store</a></li>
+        <li class="breadcrumb-item">@Model.CampName</li>
+        <li class="breadcrumb-item active">@(string.IsNullOrWhiteSpace(order.Label) ? "Order" : order.Label)</li>
+    </ol>
+</nav>
+
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <h1 class="mb-0">@(string.IsNullOrWhiteSpace(order.Label) ? "Store order" : order.Label)</h1>
+    <span class="badge bg-secondary fs-6">@order.State</span>
+</div>
+
+<vc:temp-data-alerts />
+
+<div class="row mb-4">
+    <div class="col-md-3">
+        <div class="card text-center">
+            <div class="card-body">
+                <h6 class="card-subtitle mb-2 text-muted">Lines subtotal</h6>
+                <h4 class="card-title mb-0">&euro;@order.LinesSubtotalEur.ToString("N2")</h4>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-3">
+        <div class="card text-center">
+            <div class="card-body">
+                <h6 class="card-subtitle mb-2 text-muted">VAT</h6>
+                <h4 class="card-title mb-0">&euro;@order.VatTotalEur.ToString("N2")</h4>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-3">
+        <div class="card text-center">
+            <div class="card-body">
+                <h6 class="card-subtitle mb-2 text-muted">Deposits</h6>
+                <h4 class="card-title mb-0">&euro;@order.DepositTotalEur.ToString("N2")</h4>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-3">
+        <div class="card text-center bg-light">
+            <div class="card-body">
+                <h6 class="card-subtitle mb-2 text-muted">Balance owed</h6>
+                <h4 class="card-title mb-0 fw-bold">&euro;@order.BalanceEur.ToString("N2")</h4>
+            </div>
+        </div>
+    </div>
+</div>
+
+<h2 class="h4 mb-3">Lines</h2>
+@if (order.Lines.Any())
+{
+    <table class="table">
+        <thead>
+            <tr>
+                <th>Product</th>
+                <th class="text-end">Qty</th>
+                <th class="text-end">Unit price</th>
+                <th class="text-end">VAT %</th>
+                <th class="text-end">Deposit</th>
+                <th class="text-end">Line total (incl. VAT &amp; deposit)</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (var line in order.Lines)
+            {
+                var lineSubtotal = line.Qty * line.UnitPriceSnapshot;
+                var lineVat = Math.Round(lineSubtotal * line.VatRateSnapshot / 100m, 2, MidpointRounding.AwayFromZero);
+                var lineDeposit = (line.DepositAmountSnapshot ?? 0m) * line.Qty;
+                var lineTotal = lineSubtotal + lineVat + lineDeposit;
+                <tr>
+                    <td>@line.ProductName</td>
+                    <td class="text-end">@line.Qty</td>
+                    <td class="text-end">&euro;@line.UnitPriceSnapshot.ToString("N2")</td>
+                    <td class="text-end">@line.VatRateSnapshot.ToString("0.##")%</td>
+                    <td class="text-end">@(line.DepositAmountSnapshot.HasValue ? $"€{(line.DepositAmountSnapshot.Value * line.Qty):N2}" : "—")</td>
+                    <td class="text-end">&euro;@lineTotal.ToString("N2")</td>
+                    <td class="text-end">
+                        @if (Model.CanEdit)
+                        {
+                            <form asp-action="RemoveLine" asp-route-id="@order.Id" method="post" class="d-inline">
+                                @Html.AntiForgeryToken()
+                                <input type="hidden" name="lineId" value="@line.Id" />
+                                <button type="submit" class="btn btn-sm btn-outline-danger"
+                                        onclick="return confirm('Remove this line?');">Remove</button>
+                            </form>
+                        }
+                    </td>
+                </tr>
+            }
+        </tbody>
+    </table>
+}
+else
+{
+    <div class="alert alert-secondary">No lines on this order yet.</div>
+}
+
+@if (Model.CanEdit)
+{
+    <h2 class="h4 mb-3">Add line</h2>
+    <form asp-action="AddLine" asp-route-id="@order.Id" method="post" class="row g-2 mb-4">
+        @Html.AntiForgeryToken()
+        <div class="col-md-7">
+            <select name="productId" class="form-select" required>
+                <option value="">Choose a product…</option>
+                @foreach (var product in Model.Catalog)
+                {
+                    <option value="@product.Id">@product.Name — &euro;@product.UnitPriceEur.ToString("N2") (deadline @product.OrderableUntil)</option>
+                }
+            </select>
+        </div>
+        <div class="col-md-2">
+            <input type="number" name="qty" class="form-control" min="1" value="1" required />
+        </div>
+        <div class="col-md-3">
+            <button type="submit" class="btn btn-primary w-100">Add line</button>
+        </div>
+    </form>
+}
+
+<h2 class="h4 mb-3">Counterparty (for invoice)</h2>
+@if (Model.CanEdit)
+{
+    <form asp-action="UpdateCounterparty" asp-route-id="@order.Id" method="post" class="row g-3 mb-4">
+        @Html.AntiForgeryToken()
+        <div class="col-md-6">
+            <label class="form-label">Name</label>
+            <input type="text" name="Name" class="form-control" value="@order.CounterpartyName" />
+        </div>
+        <div class="col-md-6">
+            <label class="form-label">VAT / NIF / CIF</label>
+            <input type="text" name="VatId" class="form-control" value="@order.CounterpartyVatId" />
+        </div>
+        <div class="col-md-12">
+            <label class="form-label">Address</label>
+            <input type="text" name="Address" class="form-control" value="@order.CounterpartyAddress" />
+        </div>
+        <div class="col-md-2">
+            <label class="form-label">Country</label>
+            <input type="text" name="CountryCode" class="form-control" maxlength="2" value="@order.CounterpartyCountryCode" />
+        </div>
+        <div class="col-md-6">
+            <label class="form-label">Email</label>
+            <input type="email" name="Email" class="form-control" value="@order.CounterpartyEmail" />
+        </div>
+        <div class="col-md-12">
+            <button type="submit" class="btn btn-primary">Save counterparty</button>
+        </div>
+    </form>
+}
+else
+{
+    <dl class="row">
+        <dt class="col-sm-3">Name</dt><dd class="col-sm-9">@order.CounterpartyName</dd>
+        <dt class="col-sm-3">VAT / NIF / CIF</dt><dd class="col-sm-9">@order.CounterpartyVatId</dd>
+        <dt class="col-sm-3">Address</dt><dd class="col-sm-9">@order.CounterpartyAddress</dd>
+        <dt class="col-sm-3">Country</dt><dd class="col-sm-9">@order.CounterpartyCountryCode</dd>
+        <dt class="col-sm-3">Email</dt><dd class="col-sm-9">@order.CounterpartyEmail</dd>
+    </dl>
+}
+
+<h2 class="h4 mb-3">Payments</h2>
+<p class="text-muted">Payments are recorded by Finance Admin. None are visible on this order yet.</p>

--- a/src/Humans.Web/Views/Store/Order.cshtml
+++ b/src/Humans.Web/Views/Store/Order.cshtml
@@ -72,17 +72,13 @@
         <tbody>
             @foreach (var line in order.Lines)
             {
-                var lineSubtotal = line.Qty * line.UnitPriceSnapshot;
-                var lineVat = Math.Round(lineSubtotal * line.VatRateSnapshot / 100m, 2, MidpointRounding.AwayFromZero);
-                var lineDeposit = (line.DepositAmountSnapshot ?? 0m) * line.Qty;
-                var lineTotal = lineSubtotal + lineVat + lineDeposit;
                 <tr>
                     <td>@line.ProductName</td>
                     <td class="text-end">@line.Qty</td>
                     <td class="text-end">&euro;@line.UnitPriceSnapshot.ToString("N2")</td>
                     <td class="text-end">@line.VatRateSnapshot.ToString("0.##")%</td>
-                    <td class="text-end">@(line.DepositAmountSnapshot.HasValue ? $"€{(line.DepositAmountSnapshot.Value * line.Qty):N2}" : "—")</td>
-                    <td class="text-end">&euro;@lineTotal.ToString("N2")</td>
+                    <td class="text-end">@(line.DepositAmountSnapshot.HasValue ? $"€{line.DepositEur:N2}" : "—")</td>
+                    <td class="text-end">&euro;@line.TotalEur.ToString("N2")</td>
                     <td class="text-end">
                         @if (Model.CanEdit)
                         {
@@ -169,4 +165,4 @@ else
 }
 
 <h2 class="h4 mb-3">Payments</h2>
-<p class="text-muted">Payments are recorded by Finance Admin. None are visible on this order yet.</p>
+<p class="text-muted">Payments are recorded by the finance team. None are visible on this order yet.</p>

--- a/tests/Humans.Application.Tests/Services/Store/BalanceCalculatorTests.cs
+++ b/tests/Humans.Application.Tests/Services/Store/BalanceCalculatorTests.cs
@@ -1,0 +1,79 @@
+using AwesomeAssertions;
+using Humans.Application.Services.Store;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using Xunit;
+
+namespace Humans.Application.Tests.Services.Store;
+
+public class BalanceCalculatorTests
+{
+    [HumansFact]
+    public void Empty_order_has_zero_balance()
+    {
+        var order = new StoreOrder();
+        var result = BalanceCalculator.Compute(order);
+        result.LinesSubtotalEur.Should().Be(0);
+        result.VatTotalEur.Should().Be(0);
+        result.DepositTotalEur.Should().Be(0);
+        result.PaymentsTotalEur.Should().Be(0);
+        result.BalanceEur.Should().Be(0);
+    }
+
+    [HumansFact]
+    public void Single_line_with_21_percent_vat()
+    {
+        var order = new StoreOrder
+        {
+            Lines = new List<StoreOrderLine>
+            {
+                new() { Qty = 2, UnitPriceSnapshot = 50m, VatRateSnapshot = 21m }
+            }
+        };
+
+        var r = BalanceCalculator.Compute(order);
+        r.LinesSubtotalEur.Should().Be(100m);
+        r.VatTotalEur.Should().Be(21m);
+        r.DepositTotalEur.Should().Be(0m);
+        r.BalanceEur.Should().Be(121m);
+    }
+
+    [HumansFact]
+    public void Deposit_lines_excluded_from_vat_added_to_total()
+    {
+        var order = new StoreOrder
+        {
+            Lines = new List<StoreOrderLine>
+            {
+                new() { Qty = 1, UnitPriceSnapshot = 30m, VatRateSnapshot = 21m, DepositAmountSnapshot = 100m }
+            }
+        };
+
+        var r = BalanceCalculator.Compute(order);
+        r.LinesSubtotalEur.Should().Be(30m);
+        r.VatTotalEur.Should().Be(6.30m);
+        r.DepositTotalEur.Should().Be(100m);
+        r.BalanceEur.Should().Be(136.30m);
+    }
+
+    [HumansFact]
+    public void Payments_reduce_balance_negative_payment_treated_as_refund()
+    {
+        var order = new StoreOrder
+        {
+            Lines = new List<StoreOrderLine>
+            {
+                new() { Qty = 1, UnitPriceSnapshot = 100m, VatRateSnapshot = 21m }
+            },
+            Payments = new List<StorePayment>
+            {
+                new() { AmountEur = 50m, Method = StorePaymentMethod.Stripe },
+                new() { AmountEur = -10m, Method = StorePaymentMethod.Manual }
+            }
+        };
+
+        var r = BalanceCalculator.Compute(order);
+        r.PaymentsTotalEur.Should().Be(40m);
+        r.BalanceEur.Should().Be(81m);
+    }
+}

--- a/tests/Humans.Application.Tests/Services/Store/BalanceCalculatorTests.cs
+++ b/tests/Humans.Application.Tests/Services/Store/BalanceCalculatorTests.cs
@@ -18,16 +18,18 @@ public class BalanceCalculatorTests
         result.DepositTotalEur.Should().Be(0);
         result.PaymentsTotalEur.Should().Be(0);
         result.BalanceEur.Should().Be(0);
+        result.Lines.Should().BeEmpty();
     }
 
     [HumansFact]
     public void Single_line_with_21_percent_vat()
     {
+        var lineId = Guid.NewGuid();
         var order = new StoreOrder
         {
             Lines = new List<StoreOrderLine>
             {
-                new() { Qty = 2, UnitPriceSnapshot = 50m, VatRateSnapshot = 21m }
+                new() { Id = lineId, Qty = 2, UnitPriceSnapshot = 50m, VatRateSnapshot = 21m }
             }
         };
 
@@ -36,16 +38,19 @@ public class BalanceCalculatorTests
         r.VatTotalEur.Should().Be(21m);
         r.DepositTotalEur.Should().Be(0m);
         r.BalanceEur.Should().Be(121m);
+        r.Lines.Should().ContainSingle().Which.Should().Be(
+            new BalanceCalculator.LineTotals(lineId, 100m, 21m, 0m, 121m));
     }
 
     [HumansFact]
     public void Deposit_lines_excluded_from_vat_added_to_total()
     {
+        var lineId = Guid.NewGuid();
         var order = new StoreOrder
         {
             Lines = new List<StoreOrderLine>
             {
-                new() { Qty = 1, UnitPriceSnapshot = 30m, VatRateSnapshot = 21m, DepositAmountSnapshot = 100m }
+                new() { Id = lineId, Qty = 1, UnitPriceSnapshot = 30m, VatRateSnapshot = 21m, DepositAmountSnapshot = 100m }
             }
         };
 
@@ -54,16 +59,19 @@ public class BalanceCalculatorTests
         r.VatTotalEur.Should().Be(6.30m);
         r.DepositTotalEur.Should().Be(100m);
         r.BalanceEur.Should().Be(136.30m);
+        r.Lines.Should().ContainSingle().Which.Should().Be(
+            new BalanceCalculator.LineTotals(lineId, 30m, 6.30m, 100m, 136.30m));
     }
 
     [HumansFact]
     public void Payments_reduce_balance_negative_payment_treated_as_refund()
     {
+        var lineId = Guid.NewGuid();
         var order = new StoreOrder
         {
             Lines = new List<StoreOrderLine>
             {
-                new() { Qty = 1, UnitPriceSnapshot = 100m, VatRateSnapshot = 21m }
+                new() { Id = lineId, Qty = 1, UnitPriceSnapshot = 100m, VatRateSnapshot = 21m }
             },
             Payments = new List<StorePayment>
             {
@@ -75,5 +83,7 @@ public class BalanceCalculatorTests
         var r = BalanceCalculator.Compute(order);
         r.PaymentsTotalEur.Should().Be(40m);
         r.BalanceEur.Should().Be(81m);
+        r.Lines.Should().ContainSingle().Which.Should().Be(
+            new BalanceCalculator.LineTotals(lineId, 100m, 21m, 0m, 121m));
     }
 }

--- a/tests/Humans.Application.Tests/Services/Store/StoreServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Store/StoreServiceTests.cs
@@ -1,0 +1,161 @@
+using AwesomeAssertions;
+using Humans.Application.Interfaces.AuditLog;
+using Humans.Application.Interfaces.Repositories;
+using Humans.Application.Interfaces.Shifts;
+using Humans.Application.Services.Store;
+using Humans.Application.Services.Store.Dtos;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using NodaTime;
+using NodaTime.Testing;
+using NSubstitute;
+using Xunit;
+
+namespace Humans.Application.Tests.Services.Store;
+
+public class StoreServiceTests
+{
+    private readonly IStoreRepository _repo = Substitute.For<IStoreRepository>();
+    private readonly IAuditLogService _audit = Substitute.For<IAuditLogService>();
+    private readonly IShiftManagementService _shifts = Substitute.For<IShiftManagementService>();
+    private readonly FakeClock _clock = new(Instant.FromUtc(2026, 3, 14, 12, 0));
+    private readonly StoreService _service;
+
+    public StoreServiceTests()
+    {
+        _shifts.GetActiveAsync().Returns(new EventSettings
+        {
+            Year = 2026,
+            TimeZoneId = "Europe/Madrid"
+        });
+        _service = new StoreService(_repo, _audit, _clock, _shifts);
+    }
+
+    // ==========================================================================
+    // Read paths (Task 2.3)
+    // ==========================================================================
+
+    [HumansFact]
+    public async Task GetActiveCatalogAsync_returns_empty_for_empty_catalog()
+    {
+        _repo.GetActiveProductsForYearAsync(2026, Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<StoreProduct>());
+
+        var result = await _service.GetActiveCatalogAsync(2026);
+
+        result.Should().BeEmpty();
+    }
+
+    [HumansFact]
+    public async Task GetActiveCatalogAsync_maps_products_to_dtos()
+    {
+        var p = MakeProduct(name: "Tent", price: 50m, vat: 21m, deposit: 100m);
+        _repo.GetActiveProductsForYearAsync(2026, Arg.Any<CancellationToken>())
+            .Returns(new[] { p });
+
+        var result = await _service.GetActiveCatalogAsync(2026);
+
+        result.Should().HaveCount(1);
+        result[0].Name.Should().Be("Tent");
+        result[0].UnitPriceEur.Should().Be(50m);
+        result[0].VatRatePercent.Should().Be(21m);
+        result[0].DepositAmountEur.Should().Be(100m);
+    }
+
+    [HumansFact]
+    public async Task GetOrdersForCampSeasonAsync_maps_orders_with_balance()
+    {
+        var product = MakeProduct(name: "Tent", price: 50m, vat: 21m);
+        var campSeasonId = Guid.NewGuid();
+        var orderId = Guid.NewGuid();
+        var order = new StoreOrder
+        {
+            Id = orderId,
+            CampSeasonId = campSeasonId,
+            State = StoreOrderState.Open,
+            Lines = new List<StoreOrderLine>
+            {
+                new() { Id = Guid.NewGuid(), OrderId = orderId, ProductId = product.Id, Qty = 2,
+                        UnitPriceSnapshot = 50m, VatRateSnapshot = 21m }
+            }
+        };
+        _repo.GetOrdersForCampSeasonAsync(campSeasonId, Arg.Any<CancellationToken>())
+            .Returns(new[] { order });
+        _repo.GetActiveProductsForYearAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(new[] { product });
+
+        var result = await _service.GetOrdersForCampSeasonAsync(campSeasonId);
+
+        result.Should().HaveCount(1);
+        result[0].LinesSubtotalEur.Should().Be(100m);
+        result[0].VatTotalEur.Should().Be(21m);
+        result[0].BalanceEur.Should().Be(121m);
+        result[0].Lines[0].ProductName.Should().Be("Tent");
+    }
+
+    [HumansFact]
+    public async Task GetOrderAsync_returns_null_when_missing()
+    {
+        _repo.GetOrderWithLinesAndPaymentsAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns((StoreOrder?)null);
+
+        var result = await _service.GetOrderAsync(Guid.NewGuid());
+
+        result.Should().BeNull();
+    }
+
+    [HumansFact]
+    public async Task GetOrderAsync_maps_order_with_balance()
+    {
+        var product = MakeProduct(name: "Tent", price: 50m, vat: 21m);
+        var orderId = Guid.NewGuid();
+        var order = new StoreOrder
+        {
+            Id = orderId,
+            CampSeasonId = Guid.NewGuid(),
+            State = StoreOrderState.Open,
+            Lines = new List<StoreOrderLine>
+            {
+                new() { Id = Guid.NewGuid(), OrderId = orderId, ProductId = product.Id, Qty = 1,
+                        UnitPriceSnapshot = 50m, VatRateSnapshot = 21m }
+            }
+        };
+        _repo.GetOrderWithLinesAndPaymentsAsync(orderId, Arg.Any<CancellationToken>()).Returns(order);
+        _repo.GetActiveProductsForYearAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(new[] { product });
+
+        var result = await _service.GetOrderAsync(orderId);
+
+        result.Should().NotBeNull();
+        result!.BalanceEur.Should().Be(60.50m);
+        result.Lines[0].ProductName.Should().Be("Tent");
+    }
+
+    // ==========================================================================
+    // Helpers
+    // ==========================================================================
+
+    private static StoreProduct MakeProduct(
+        string name = "Test product",
+        decimal price = 10m,
+        decimal vat = 21m,
+        decimal? deposit = null,
+        LocalDate? orderableUntil = null,
+        int year = 2026)
+    {
+        return new StoreProduct
+        {
+            Id = Guid.NewGuid(),
+            Year = year,
+            Name = name,
+            Description = string.Empty,
+            UnitPriceEur = price,
+            VatRatePercent = vat,
+            DepositAmountEur = deposit,
+            OrderableUntil = orderableUntil ?? new LocalDate(2026, 12, 31),
+            IsActive = true,
+            CreatedAt = Instant.FromUtc(2026, 1, 1, 0, 0),
+            UpdatedAt = Instant.FromUtc(2026, 1, 1, 0, 0)
+        };
+    }
+}

--- a/tests/Humans.Application.Tests/Services/Store/StoreServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Store/StoreServiceTests.cs
@@ -81,8 +81,8 @@ public class StoreServiceTests
         };
         _repo.GetOrdersForCampSeasonAsync(campSeasonId, Arg.Any<CancellationToken>())
             .Returns(new[] { order });
-        _repo.GetActiveProductsForYearAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
-            .Returns(new[] { product });
+        _repo.GetProductNamesByIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<Guid, string> { [product.Id] = product.Name });
 
         var result = await _service.GetOrdersForCampSeasonAsync(campSeasonId);
 
@@ -121,8 +121,8 @@ public class StoreServiceTests
             }
         };
         _repo.GetOrderWithLinesAndPaymentsAsync(orderId, Arg.Any<CancellationToken>()).Returns(order);
-        _repo.GetActiveProductsForYearAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
-            .Returns(new[] { product });
+        _repo.GetProductNamesByIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<Guid, string> { [product.Id] = product.Name });
 
         var result = await _service.GetOrderAsync(orderId);
 

--- a/tests/Humans.Application.Tests/Services/Store/StoreServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Store/StoreServiceTests.cs
@@ -132,6 +132,189 @@ public class StoreServiceTests
     }
 
     // ==========================================================================
+    // Write paths (Task 2.4)
+    // ==========================================================================
+
+    [HumansFact]
+    public async Task CreateOrderAsync_persists_open_order_with_now_timestamps_and_audits()
+    {
+        var campSeasonId = Guid.NewGuid();
+        var actor = Guid.NewGuid();
+        StoreOrder? captured = null;
+        await _repo.AddOrderAsync(Arg.Do<StoreOrder>(o => captured = o), Arg.Any<CancellationToken>());
+
+        var orderId = await _service.CreateOrderAsync(campSeasonId, "First order", actor);
+
+        captured.Should().NotBeNull();
+        captured!.Id.Should().Be(orderId);
+        captured.CampSeasonId.Should().Be(campSeasonId);
+        captured.Label.Should().Be("First order");
+        captured.State.Should().Be(StoreOrderState.Open);
+        captured.CreatedAt.Should().Be(_clock.GetCurrentInstant());
+        captured.UpdatedAt.Should().Be(_clock.GetCurrentInstant());
+
+        await _audit.Received(1).LogAsync(
+            AuditAction.StoreOrderCreated, nameof(StoreOrder), orderId,
+            Arg.Any<string>(), actor,
+            Arg.Any<Guid?>(), Arg.Any<string?>());
+    }
+
+    [HumansFact]
+    public async Task AddLineAsync_rejects_non_positive_qty()
+    {
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => _service.AddLineAsync(Guid.NewGuid(), Guid.NewGuid(), 0, Guid.NewGuid()));
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => _service.AddLineAsync(Guid.NewGuid(), Guid.NewGuid(), -3, Guid.NewGuid()));
+    }
+
+    [HumansFact]
+    public async Task AddLineAsync_rejects_when_order_not_open()
+    {
+        var orderId = Guid.NewGuid();
+        var productId = Guid.NewGuid();
+        _repo.GetOrderByIdAsync(orderId, Arg.Any<CancellationToken>())
+            .Returns(new StoreOrder { Id = orderId, State = StoreOrderState.InvoiceIssued });
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _service.AddLineAsync(orderId, productId, 1, Guid.NewGuid()));
+    }
+
+    [HumansFact]
+    public async Task AddLineAsync_rejects_after_orderable_until()
+    {
+        var orderId = Guid.NewGuid();
+        var product = MakeProduct(orderableUntil: new LocalDate(2026, 1, 1));
+        _repo.GetOrderByIdAsync(orderId, Arg.Any<CancellationToken>())
+            .Returns(new StoreOrder { Id = orderId, State = StoreOrderState.Open });
+        _repo.GetProductByIdAsync(product.Id, Arg.Any<CancellationToken>()).Returns(product);
+        // _clock = 2026-03-14, so 2026-01-01 is past.
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _service.AddLineAsync(orderId, product.Id, 1, Guid.NewGuid()));
+        ex.Message.Should().Contain("deadline");
+    }
+
+    [HumansFact]
+    public async Task AddLineAsync_snapshots_product_price_vat_deposit_and_audits()
+    {
+        var orderId = Guid.NewGuid();
+        var actor = Guid.NewGuid();
+        var product = MakeProduct(price: 75m, vat: 10m, deposit: 50m,
+            orderableUntil: new LocalDate(2026, 12, 31));
+        _repo.GetOrderByIdAsync(orderId, Arg.Any<CancellationToken>())
+            .Returns(new StoreOrder { Id = orderId, State = StoreOrderState.Open });
+        _repo.GetProductByIdAsync(product.Id, Arg.Any<CancellationToken>()).Returns(product);
+
+        StoreOrderLine? captured = null;
+        await _repo.AddLineAsync(Arg.Do<StoreOrderLine>(l => captured = l), Arg.Any<CancellationToken>());
+
+        await _service.AddLineAsync(orderId, product.Id, 3, actor);
+
+        captured.Should().NotBeNull();
+        captured!.OrderId.Should().Be(orderId);
+        captured.ProductId.Should().Be(product.Id);
+        captured.Qty.Should().Be(3);
+        captured.UnitPriceSnapshot.Should().Be(75m);
+        captured.VatRateSnapshot.Should().Be(10m);
+        captured.DepositAmountSnapshot.Should().Be(50m);
+        captured.AddedByUserId.Should().Be(actor);
+        captured.AddedAt.Should().Be(_clock.GetCurrentInstant());
+
+        await _audit.Received(1).LogAsync(
+            AuditAction.StoreLineAdded, nameof(StoreOrderLine), captured.Id,
+            Arg.Any<string>(), actor,
+            Arg.Any<Guid?>(), Arg.Any<string?>());
+    }
+
+    [HumansFact]
+    public async Task RemoveLineAsync_rejects_when_order_not_open()
+    {
+        var lineId = Guid.NewGuid();
+        _repo.GetLineWithOrderAndProductAsync(lineId, Arg.Any<CancellationToken>())
+            .Returns(new StoreLineContext(
+                lineId, Guid.NewGuid(), Guid.NewGuid(),
+                StoreOrderState.InvoiceIssued, new LocalDate(2026, 12, 31)));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _service.RemoveLineAsync(lineId, Guid.NewGuid()));
+    }
+
+    [HumansFact]
+    public async Task RemoveLineAsync_rejects_after_orderable_until()
+    {
+        var lineId = Guid.NewGuid();
+        _repo.GetLineWithOrderAndProductAsync(lineId, Arg.Any<CancellationToken>())
+            .Returns(new StoreLineContext(
+                lineId, Guid.NewGuid(), Guid.NewGuid(),
+                StoreOrderState.Open, new LocalDate(2026, 1, 1)));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _service.RemoveLineAsync(lineId, Guid.NewGuid()));
+    }
+
+    [HumansFact]
+    public async Task RemoveLineAsync_removes_and_audits()
+    {
+        var lineId = Guid.NewGuid();
+        var orderId = Guid.NewGuid();
+        var actor = Guid.NewGuid();
+        _repo.GetLineWithOrderAndProductAsync(lineId, Arg.Any<CancellationToken>())
+            .Returns(new StoreLineContext(
+                lineId, orderId, Guid.NewGuid(),
+                StoreOrderState.Open, new LocalDate(2026, 12, 31)));
+
+        await _service.RemoveLineAsync(lineId, actor);
+
+        await _repo.Received(1).RemoveLineAsync(lineId, Arg.Any<CancellationToken>());
+        await _audit.Received(1).LogAsync(
+            AuditAction.StoreLineRemoved, nameof(StoreOrderLine), lineId,
+            Arg.Any<string>(), actor,
+            Arg.Any<Guid?>(), Arg.Any<string?>());
+    }
+
+    [HumansFact]
+    public async Task UpdateCounterpartyAsync_rejects_when_order_not_open()
+    {
+        var orderId = Guid.NewGuid();
+        _repo.GetOrderByIdAsync(orderId, Arg.Any<CancellationToken>())
+            .Returns(new StoreOrder { Id = orderId, State = StoreOrderState.InvoiceIssued });
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _service.UpdateCounterpartyAsync(
+                orderId,
+                new OrderCounterpartyInput("X", null, null, null, null),
+                Guid.NewGuid()));
+    }
+
+    [HumansFact]
+    public async Task UpdateCounterpartyAsync_updates_fields_and_audits()
+    {
+        var orderId = Guid.NewGuid();
+        var actor = Guid.NewGuid();
+        var order = new StoreOrder { Id = orderId, State = StoreOrderState.Open };
+        _repo.GetOrderByIdAsync(orderId, Arg.Any<CancellationToken>()).Returns(order);
+
+        await _service.UpdateCounterpartyAsync(
+            orderId,
+            new OrderCounterpartyInput("Acme", "ESB12345678", "1 St", "ES", "ops@acme.test"),
+            actor);
+
+        order.CounterpartyName.Should().Be("Acme");
+        order.CounterpartyVatId.Should().Be("ESB12345678");
+        order.CounterpartyAddress.Should().Be("1 St");
+        order.CounterpartyCountryCode.Should().Be("ES");
+        order.CounterpartyEmail.Should().Be("ops@acme.test");
+        order.UpdatedAt.Should().Be(_clock.GetCurrentInstant());
+
+        await _repo.Received(1).UpdateOrderAsync(order, Arg.Any<CancellationToken>());
+        await _audit.Received(1).LogAsync(
+            AuditAction.StoreCounterpartyEdited, nameof(StoreOrder), orderId,
+            Arg.Any<string>(), actor,
+            Arg.Any<Guid?>(), Arg.Any<string?>());
+    }
+
+    // ==========================================================================
     // Helpers
     // ==========================================================================
 

--- a/tests/Humans.Integration.Tests/Controllers/StoreControllerTests.cs
+++ b/tests/Humans.Integration.Tests/Controllers/StoreControllerTests.cs
@@ -1,0 +1,124 @@
+using System.Net;
+using System.Net.Http;
+using AwesomeAssertions;
+using Humans.Domain.Entities;
+using Humans.Infrastructure.Data;
+using Humans.Integration.Tests.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using NodaTime;
+using Xunit;
+
+namespace Humans.Integration.Tests.Controllers;
+
+public class StoreControllerTests : IntegrationTestBase
+{
+    public StoreControllerTests(HumansWebApplicationFactory factory) : base(factory) { }
+
+    [HumansFact(Timeout = 30000)]
+    public async Task Anonymous_GET_Store_redirects_to_login()
+    {
+        var resp = await Client.GetAsync("/Store");
+        resp.StatusCode.Should().BeOneOf(HttpStatusCode.Redirect, HttpStatusCode.Found, HttpStatusCode.Unauthorized);
+    }
+
+    [HumansFact(Timeout = 30000)]
+    public async Task LoggedIn_camp_lead_can_GET_Store()
+    {
+        await Factory.SignInAsFullyOnboardedAsync(Client, new DevPersona("barrio-1-lead"));
+        var year = await SeedActiveProductAsync("Test product");
+
+        var resp = await Client.GetAsync("/Store");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadAsStringAsync();
+        body.Should().Contain("Test product");
+        body.Should().Contain(year.ToString(System.Globalization.CultureInfo.InvariantCulture));
+    }
+
+    [HumansFact(Timeout = 30000)]
+    public async Task Volunteer_GET_Store_returns_200_with_catalog_only()
+    {
+        await Factory.SignInAsFullyOnboardedAsync(Client, DevPersona.Volunteer);
+        await SeedActiveProductAsync("Volunteer-visible product");
+
+        var resp = await Client.GetAsync("/Store");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await resp.Content.ReadAsStringAsync();
+        body.Should().Contain("Volunteer-visible product");
+    }
+
+    [HumansFact(Timeout = 30000)]
+    public async Task Volunteer_cannot_create_order_against_someone_elses_camp_season()
+    {
+        // Make sure barrio-1's camp + season are seeded (lead persona seeds them).
+        using (var leadClient = Factory.CreateClient(new Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false
+        }))
+        {
+            await Factory.SignInAsFullyOnboardedAsync(leadClient, new DevPersona("barrio-1-lead"));
+        }
+
+        await Factory.SignInAsFullyOnboardedAsync(Client, DevPersona.Volunteer);
+        var seasonId = await GetBarrioOneCampSeasonIdAsync();
+        seasonId.Should().NotBe(Guid.Empty);
+
+        var resp = await Client.PostAsync(
+            $"/Store/Order/Create/{seasonId}",
+            BuildForm(("label", "should-not-create")));
+
+        // Anti-forgery / forbid produce non-2xx outcomes; assert it isn't a happy redirect to /Store/Order/{id}.
+        ((int)resp.StatusCode).Should().BeGreaterThanOrEqualTo(300);
+        if (resp.StatusCode == HttpStatusCode.Redirect || resp.StatusCode == HttpStatusCode.Found)
+        {
+            (resp.Headers.Location?.PathAndQuery ?? string.Empty)
+                .Should().NotContain("/Store/Order/");
+        }
+    }
+
+    private async Task<int> SeedActiveProductAsync(string name)
+    {
+        using var scope = Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<HumansDbContext>();
+        var year = (await db.CampSettings.FirstAsync()).PublicYear;
+
+        if (await db.StoreProducts.AnyAsync(p => p.Year == year && p.Name == name))
+            return year;
+
+        db.StoreProducts.Add(new StoreProduct
+        {
+            Id = Guid.NewGuid(),
+            Year = year,
+            Name = name,
+            Description = "Description for integration test",
+            UnitPriceEur = 25m,
+            VatRatePercent = 21m,
+            DepositAmountEur = null,
+            OrderableUntil = new LocalDate(year, 12, 31),
+            IsActive = true,
+            CreatedAt = SystemClock.Instance.GetCurrentInstant(),
+            UpdatedAt = SystemClock.Instance.GetCurrentInstant()
+        });
+        await db.SaveChangesAsync();
+        return year;
+    }
+
+    private async Task<Guid> GetBarrioOneCampSeasonIdAsync()
+    {
+        using var scope = Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<HumansDbContext>();
+        var year = (await db.CampSettings.FirstAsync()).PublicYear;
+        var season = await db.Set<CampSeason>()
+            .AsNoTracking()
+            .FirstOrDefaultAsync(s => s.Year == year && s.Camp.Slug == "barrio-1");
+        return season?.Id ?? Guid.Empty;
+    }
+
+    private static FormUrlEncodedContent BuildForm(params (string Key, string Value)[] fields)
+    {
+        return new FormUrlEncodedContent(fields.Select(f =>
+            new KeyValuePair<string, string>(f.Key, f.Value)));
+    }
+}


### PR DESCRIPTION
## Summary

Phase 2 of the /Store section. Stacks on store-foundation (peterdrier/Humans#371).

- Pure `BalanceCalculator` with VAT (rounded away-from-zero) + deposit + signed payments.
- `StoreService` read paths (catalog, orders by camp season, single order) + write paths (create order, add/remove line, update counterparty), all gated by `IClock` + `IShiftManagementService` for the "today in event time zone" check that enforces `StoreProduct.OrderableUntil`.
- Audit log emits via `IAuditLogService.LogAsync` (`StoreOrderCreated`, `StoreLineAdded`, `StoreLineRemoved`, `StoreCounterpartyEdited`).
- `StoreOrderAuthorizationHandler` resource-based auth (View/AddLine/RemoveLine/EditCounterparty over `OrderDto`); FinanceAdmin or camp-lead-of-the-camp succeeds.
- `StoreController` with the six routes the spec calls for. No `isPrivileged` booleans on the service surface.
- `Index` + `Order` Razor views; `/Store` nav link gated by `IsActiveMember`, placed between Camps and Teams (daily-traffic ordering).

## Notes

- `IStoreRepository` extended with `GetLineWithOrderAndProductAsync` so `RemoveLineAsync` can enforce both the state==Open rule and the product deadline in a single read. No budgeted interface raised; `ICampService` and `IShiftManagementService` are reused as-is.
- AuditAction enum gained four new entries (string-stored, no migration).
- Migration reviewer N/A — no schema changes in this PR.

## Test plan

- [x] `dotnet test --filter "FullyQualifiedName~Store"` — 29 + 44 + 4 = 77 green (Domain + Application + Integration).
- [x] Full suite: 1853 Application + 127 Domain green; 6 pre-existing integration failures unrelated to Store (Calendar/Teams/Health/SecurityHeader/Readiness).
- [ ] Manual: open /Store as a camp lead in the preview env, create an order, add a line, watch balance update.
- [ ] Manual: confirm /Store nav link visibility for an active volunteer (catalog only) and finance admin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)