### PR TITLE
docs(camps): add Routing section to invariants doc

### DIFF
--- a/docs/sections/Camps.md
+++ b/docs/sections/Camps.md
@@ -155,7 +155,7 @@ All stored as strings via `HasConversion<string>()`. `Vibes` stored as jsonb arr
 
 ## Routing
 
-Three controllers serve this section, and the URL surface is dual-routed: every path is reachable under `/Camps/*` (English) and `/Barrios/*` (Spanish). This is the only sanctioned URL alias in the codebase — no other section may add aliases.
+Three controllers serve this section. The MVC URL surface is dual-routed under `/Camps/*` (English) and `/Barrios/*` (Spanish); the API surface is dual-routed under `/api/camps/*` and `/api/barrios/*`. The dual-route alias is governed by an invariant below — no other section may add aliases.
 
 | Route | Controller | Purpose |
 |-------|------------|---------|
@@ -179,7 +179,7 @@ Three controllers serve this section, and the URL surface is dual-routed: every 
 | `/api/camps/{year}` | `CampApiController` | Year directory JSON |
 | `/api/camps/{year}/placement` | `CampApiController` | Placement-data JSON |
 
-Admin pages live under `/Camps/Admin/*` (per `architecture_no_admin_url_section` — never `/Admin/Camps/*`).
+Admin pages live under `/Camps/Admin/*` — never `/Admin/Camps/*` (per `docs/architecture/design-rules.md` § "Admin is not a section": `/Admin/*` is a nav holder for actions whose services live in their owning sections).
 
 ## Actors & Roles
 
@@ -208,6 +208,7 @@ Admin pages live under `/Camps/Admin/*` (per `architecture_no_admin_url_section`
 - All role-assignment data is private (no anonymous render). The public Camp Details page does not expose role assignments.
 - Leave/Withdraw/Remove cascades clear role assignments via `ICampRoleService.RemoveAllForMemberAsync` before the soft-delete. Hard-delete of a `CampMember` row cascades through the FK directly.
 - Camp Lead authz remains on the `CampLead` entity until the follow-up issue retires it. The "Camp Lead" role is **not** a `CampRoleDefinition` row in this PR.
+- The `/Camps ↔ /Barrios` and `/api/camps ↔ /api/barrios` dual-route aliases are the **only sanctioned URL aliases in the codebase**. No other section may add URL aliases without explicit owner approval.
 
 ## Negative Access Rules
 

--- a/docs/sections/Camps.md
+++ b/docs/sections/Camps.md
@@ -153,6 +153,34 @@ Aggregate-local navs: `CampRoleAssignment.CampSeason`, `CampRoleAssignment.Defin
 
 All stored as strings via `HasConversion<string>()`. `Vibes` stored as jsonb array.
 
+## Routing
+
+Three controllers serve this section, and the URL surface is dual-routed: every path is reachable under `/Camps/*` (English) and `/Barrios/*` (Spanish). This is the only sanctioned URL alias in the codebase — no other section may add aliases.
+
+| Route | Controller | Purpose |
+|-------|------------|---------|
+| `/Camps` | `CampController` | Public directory |
+| `/Camps/{slug}` | `CampController` | Camp detail (current season, leads, images, history) |
+| `/Camps/{slug}/Season/{year}` | `CampController` | Past-season detail |
+| `/Camps/{slug}/Contact` | `CampController` | Facilitated message to camp leads |
+| `/Camps/{slug}/Edit` | `CampController` | Lead-only edit of season copy / images / leads |
+| `/Camps/Register` | `CampController` | New camp registration |
+| `/Camps/{slug}/OptIn/{year}`, `.../Withdraw/{seasonId}`, `.../Rejoin/{seasonId}` | `CampController` | Per-season participation toggles |
+| `/Camps/{slug}/Leads/*` | `CampController` | Lead add/remove |
+| `/Camps/{slug}/Members/*` | `CampController` | Member request/approve/reject/remove/leave |
+| `/Camps/{slug}/Roles/*` | `CampController` | Per-camp role assignment/unassignment |
+| `/Camps/{slug}/Images/*` | `CampController` | Image upload/delete/reorder |
+| `/Camps/{slug}/HistoricalNames/*` | `CampController` | Historical-name add/remove |
+| `/Camps/Admin` | `CampAdminController` | CampAdmin-only directory + season management |
+| `/Camps/Admin/Roles/*` | `CampAdminController` | `CampRoleDefinition` CRUD |
+| `/Camps/Admin/Compliance` | `CampAdminController` | Per-season role compliance report |
+| `/Camps/Admin/Export` | `CampAdminController` | CSV export |
+| `/Camps/Admin/{Approve,Reject,OpenSeason,CloseSeason,SetPublicYear,SetNameLockDate,Reactivate,UpdateRegistrationInfo,Delete}/...` | `CampAdminController` | Season lifecycle actions |
+| `/api/camps/{year}` | `CampApiController` | Year directory JSON |
+| `/api/camps/{year}/placement` | `CampApiController` | Placement-data JSON |
+
+Admin pages live under `/Camps/Admin/*` (per `architecture_no_admin_url_section` — never `/Admin/Camps/*`).
+
 ## Actors & Roles
 
 | Actor | Capabilities |


### PR DESCRIPTION
## Summary

- Adds the `## Routing` heading to `docs/sections/Camps.md`, between Data Model and Actors & Roles per `SECTION-TEMPLATE.md`.
- Documents all three controllers (`CampController`, `CampAdminController`, `CampApiController`) and the sanctioned `/Camps`↔`/Barrios` dual-route pattern in one place.
- Calls out the `architecture_no_admin_url_section` rule for `/Camps/Admin/*`.

## Why

Surfaced by the new `/section-align` skill (peterdrier#cc01af0d) running its Phase 0 inventory against Camps as the gold-standard reference. The template marks `## Routing` optional, but specifies it should be included when "multiple controllers serve one section" or "URL-to-controller mapping is non-obvious" — both true for Camps.

## Test plan

- [ ] Reads cleanly against current code (routes verified against `Camp{,Admin,Api}Controller.cs` action attributes)
- [ ] No code changes — docs-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)