### PR TITLE
fix(user-emails): mark matched row verified when linking OAuth identity

### DIFF
--- a/src/Humans.Application/Services/Profile/UserEmailService.cs
+++ b/src/Humans.Application/Services/Profile/UserEmailService.cs
@@ -666,13 +666,20 @@ public sealed class UserEmailService : IUserEmailService
                 ?? throw new InvalidOperationException(
                     $"UserEmail row {match.Id} disappeared between read and mutate.");
 
+            // Successful OAuth proves ownership, so promote a previously-pending
+            // plain row to verified. Without this the row is stranded —
+            // VerifyEmailAsync filters on (Provider == null) and won't pick it up.
+            var wasPending = !tracked.IsVerified;
             tracked.Provider = provider;
             tracked.ProviderKey = providerKey;
+            tracked.IsVerified = true;
             tracked.UpdatedAt = now;
             await _repository.UpdateAsync(tracked, cancellationToken);
 
             rowId = tracked.Id;
-            description = $"Linked {provider} `{tracked.Email}` to user";
+            description = wasPending
+                ? $"Linked {provider} `{tracked.Email}` to user (verified via OAuth)"
+                : $"Linked {provider} `{tracked.Email}` to user";
         }
         else
         {

--- a/tests/Humans.Application.Tests/Services/UserEmailServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/UserEmailServiceTests.cs
@@ -589,6 +589,46 @@ public class UserEmailServiceTests
     }
 
     [HumansFact]
+    public async Task LinkAsync_MatchedPendingRow_MarksItVerified()
+    {
+        // Pending unverified plain row exists for the user (e.g. added via
+        // "Add email" but never verified). User then signs in via OAuth with the
+        // same address. LinkAsync attaches Provider/ProviderKey to that row and
+        // MUST also set IsVerified=true — successful OAuth proves ownership, and
+        // VerifyEmailAsync filters on (Provider == null), so leaving the row
+        // unverified strands it permanently.
+        var userId = Guid.NewGuid();
+        var actorId = Guid.NewGuid();
+        var rowId = Guid.NewGuid();
+        var pending = new UserEmail
+        {
+            Id = rowId,
+            UserId = userId,
+            Email = "match@example.com",
+            IsVerified = false,
+            IsPrimary = false,
+            Provider = null,
+            ProviderKey = null,
+            VerificationSentAt = _clock.GetCurrentInstant(),
+        };
+        _repository.GetByUserIdReadOnlyAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(new List<UserEmail> { pending });
+        _repository.GetByIdAndUserIdAsync(rowId, userId, Arg.Any<CancellationToken>())
+            .Returns(pending);
+        _repository.GetByUserIdForMutationAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(_ => new List<UserEmail> { pending });
+
+        var result = await _service.LinkAsync(
+            userId, "Google", "sub-pending", "Match@Example.com", actorId);
+
+        result.Should().BeTrue();
+        pending.IsVerified.Should().BeTrue();
+        pending.Provider.Should().Be("Google");
+        pending.ProviderKey.Should().Be("sub-pending");
+        pending.IsPrimary.Should().BeTrue();
+    }
+
+    [HumansFact]
     public async Task AddVerifiedEmailAsync_FirstRow_SetsIsPrimaryTrueEvenForGmail()
     {
         // Magic-link signup: a non-Workspace email (gmail) goes through


### PR DESCRIPTION
## Summary

Fixes a logic asymmetry in `UserEmailService.LinkAsync` surfaced by Codex on the upstream-promote PR (nobodies-collective/Humans#614, P1 finding on commit 16bb3efd from peterdrier/Humans#376).

The match-found branch was attaching `Provider`/`ProviderKey` to an existing row but **not** setting `IsVerified=true`. Combined with `VerifyEmailAsync`'s `(Provider == null)` filter, a previously-pending row got permanently stranded after OAuth link:
- couldn't be re-verified through the email-token flow (Provider != null)
- couldn't be promoted to primary (`SetPrimaryAsync` rejects unverified)
- effectively unusable as the notification target

The fresh-row branch already does the right thing (sets `IsVerified=true`); this brings the match branch into line. Successful OAuth completion is the proof.

Audit description distinguishes the pending-row promotion case so the state transition is visible in the trail.

## Test plan
- [x] New regression test `LinkAsync_MatchedPendingRow_MarksItVerified` fails before the fix, passes after
- [x] All 23 `UserEmailServiceTests` pass
- [x] Full `Humans.Application.Tests` suite green (1881/1881)
- [ ] Preview env smoke: add pending email → sign in via Google with same address → confirm row shows verified + primary in /Profile/Emails

🤖 Generated with [Claude Code](https://claude.com/claude-code)