### PR TITLE
feat(teams): split hidden teams into their own /Teams section (admins only)

### DIFF
--- a/src/Humans.Application/Interfaces/Teams/ITeamService.cs
+++ b/src/Humans.Application/Interfaces/Teams/ITeamService.cs
@@ -22,6 +22,7 @@ public record TeamDirectorySummary(
     string Slug,
     int MemberCount,
     bool IsSystemTeam,
+    bool IsHidden,
     bool RequiresApproval,
     bool IsPublicPage,
     bool IsCurrentUserMember,
@@ -37,7 +38,8 @@ public record TeamDirectoryResult(
     bool CanCreateTeam,
     IReadOnlyList<TeamDirectorySummary> MyTeams,
     IReadOnlyList<TeamDirectorySummary> Departments,
-    IReadOnlyList<TeamDirectorySummary> SystemTeams);
+    IReadOnlyList<TeamDirectorySummary> SystemTeams,
+    IReadOnlyList<TeamDirectorySummary> HiddenTeams);
 
 public record TeamDetailMemberSummary(
     Guid UserId,

--- a/src/Humans.Application/Services/Teams/TeamService.cs
+++ b/src/Humans.Application/Services/Teams/TeamService.cs
@@ -279,7 +279,8 @@ public sealed class TeamService : ITeamService, IUserDataContributor
                 CanCreateTeam: false,
                 MyTeams: [],
                 Departments: publicDepartments,
-                SystemTeams: []);
+                SystemTeams: [],
+                HiddenTeams: []);
         }
 
         var isBoardMember = await RoleAssignmentService.IsUserBoardMemberAsync(userId.Value, cancellationToken);
@@ -305,13 +306,18 @@ public sealed class TeamService : ITeamService, IUserDataContributor
             .ToList();
 
         var departments = summaries
-            .Where(t => !t.IsCurrentUserMember && !t.IsSystemTeam)
+            .Where(t => !t.IsCurrentUserMember && !t.IsSystemTeam && !t.IsHidden)
             .OrderBy(t => t.SortKey, StringComparer.OrdinalIgnoreCase)
             .ToList();
 
         var systemTeams = summaries
-            .Where(t => !t.IsCurrentUserMember && t.IsSystemTeam)
+            .Where(t => !t.IsCurrentUserMember && t.IsSystemTeam && !t.IsHidden)
             .OrderBy(t => t.Name, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        var hiddenTeams = summaries
+            .Where(t => !t.IsCurrentUserMember && t.IsHidden)
+            .OrderBy(t => t.SortKey, StringComparer.OrdinalIgnoreCase)
             .ToList();
 
         return new TeamDirectoryResult(
@@ -319,7 +325,8 @@ public sealed class TeamService : ITeamService, IUserDataContributor
             CanCreateTeam: canCreateTeam,
             MyTeams: myTeams,
             Departments: departments,
-            SystemTeams: systemTeams);
+            SystemTeams: systemTeams,
+            HiddenTeams: hiddenTeams);
     }
 
     public async Task<TeamDetailResult?> GetTeamDetailAsync(
@@ -2255,6 +2262,7 @@ public sealed class TeamService : ITeamService, IUserDataContributor
             team.Slug,
             team.Members.Count,
             team.IsSystemTeam,
+            team.IsHidden,
             team.RequiresApproval,
             team.IsPublicPage,
             isCurrentUserMember,

--- a/src/Humans.Web/Controllers/TeamController.cs
+++ b/src/Humans.Web/Controllers/TeamController.cs
@@ -91,6 +91,7 @@ public class TeamController : HumansControllerBase
             MyTeams = directory.MyTeams.Select(MapTeamSummary).ToList(),
             Departments = directory.Departments.Select(MapTeamSummary).ToList(),
             SystemTeams = directory.SystemTeams.Select(MapTeamSummary).ToList(),
+            HiddenTeams = directory.HiddenTeams.Select(MapTeamSummary).ToList(),
             CanCreateTeam = directory.CanCreateTeam,
             IsAuthenticated = directory.IsAuthenticated
         };
@@ -106,6 +107,7 @@ public class TeamController : HumansControllerBase
         Slug = team.Slug,
         MemberCount = team.MemberCount,
         IsSystemTeam = team.IsSystemTeam,
+        IsHidden = team.IsHidden,
         RequiresApproval = team.RequiresApproval,
         IsPublicPage = team.IsPublicPage,
         IsCurrentUserMember = team.IsCurrentUserMember,

--- a/src/Humans.Web/Models/TeamViewModels.cs
+++ b/src/Humans.Web/Models/TeamViewModels.cs
@@ -15,6 +15,7 @@ public class TeamIndexViewModel
     public List<TeamSummaryViewModel> MyTeams { get; set; } = [];
     public List<TeamSummaryViewModel> Departments { get; set; } = [];
     public List<TeamSummaryViewModel> SystemTeams { get; set; } = [];
+    public List<TeamSummaryViewModel> HiddenTeams { get; set; } = [];
     public bool CanCreateTeam { get; set; }
     public bool IsAuthenticated { get; set; }
 }
@@ -27,6 +28,7 @@ public class TeamSummaryViewModel
     public string Slug { get; set; } = string.Empty;
     public int MemberCount { get; set; }
     public bool IsSystemTeam { get; set; }
+    public bool IsHidden { get; set; }
     public bool RequiresApproval { get; set; }
     public bool IsPublicPage { get; set; }
     public bool IsCurrentUserMember { get; set; }

--- a/src/Humans.Web/Views/Team/Index.cshtml
+++ b/src/Humans.Web/Views/Team/Index.cshtml
@@ -60,8 +60,23 @@
     @if (Model.SystemTeams.Any())
     {
         <h4 class="mb-3">System Teams</h4>
-        <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4">
+        <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4 mb-4">
             @foreach (var team in Model.SystemTeams)
+            {
+                @await Html.PartialAsync("_TeamCard", team)
+            }
+        </div>
+    }
+
+    @if (Model.HiddenTeams.Any())
+    {
+        <h4 class="mb-3">
+            Hidden Teams
+            <small class="text-muted fs-6">(visible to admins only)</small>
+            <i class="fa-solid fa-lock auth-lock-icon"></i>
+        </h4>
+        <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4">
+            @foreach (var team in Model.HiddenTeams)
             {
                 @await Html.PartialAsync("_TeamCard", team)
             }


### PR DESCRIPTION
Closes nobodies-collective/Humans#624

## Summary
- Hidden teams used to interleave into Departments and System Teams for Board / Admin / Teams-Admin viewers, with no signal that the team was only visible because of an elevated role.
- Hidden teams (excluding ones the viewer belongs to) now bucket into a separate **Hidden Teams (visible to admins only)** section rendered below System Teams.
- Single bucket per team: a hidden team the viewer belongs to still shows under My Teams; otherwise it shows under Hidden Teams. Never duplicated, never in Departments / System Teams.
- Section is rendered only when non-empty, so non-privileged viewers see no change anywhere on the page.

## Implementation
- `TeamDirectoryResult` gains `HiddenTeams`; `TeamDirectorySummary` gains `IsHidden`.
- `TeamService.GetTeamDirectoryAsync` excludes hidden from Departments/SystemTeams and partitions them into the new bucket.
- `TeamIndexViewModel.HiddenTeams` + `TeamSummaryViewModel.IsHidden` mirror the DTO change.
- New section in `Views/Team/Index.cshtml` reuses `_TeamCard.cshtml`.

## Test plan
- [ ] As an Admin / Board / Teams-Admin: visit `/Teams`; hidden teams appear under a "Hidden Teams" section below System Teams, not interleaved.
- [ ] As a non-admin volunteer: visit `/Teams`; no Hidden Teams section is rendered.
- [ ] An admin who is also a member of a hidden team: that team appears under My Teams (only) — not duplicated under Hidden Teams.
- [ ] A team that is both `IsSystemTeam` and `IsHidden` shows under Hidden Teams only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)