### PR TITLE
Fix /Admin sidebar nav unreachable items on mobile

### DIFF
--- a/src/Humans.Web/Views/Shared/_Layout.cshtml
+++ b/src/Humans.Web/Views/Shared/_Layout.cshtml
@@ -26,7 +26,7 @@
 </head>
 <body>
     <header>
-        <nav class="navbar navbar-expand-sm navbar-dark mb-3">
+        <nav class="navbar navbar-expand-lg navbar-dark mb-3">
             <div class="container">
                 @{
                     string? buildHashTooltip = null;
@@ -69,7 +69,7 @@
                 <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target=".navbar-collapse">
                     <span class="navbar-toggler-icon"></span>
                 </button>
-                <div class="navbar-collapse collapse d-sm-inline-flex justify-content-between">
+                <div class="navbar-collapse collapse d-lg-inline-flex justify-content-between">
                     @{
                         var isAuthenticated = User.Identity?.IsAuthenticated == true;
                         var hasProfile = User.HasClaim(

--- a/src/Humans.Web/wwwroot/css/admin-shell.css
+++ b/src/Humans.Web/wwwroot/css/admin-shell.css
@@ -458,7 +458,9 @@ body.admin-shell .split-panels {
 }
 
 /* Below 768px the sidebar collapses into a horizontal scroll strip beneath
-   the topbar — no offcanvas/hamburger. */
+   the topbar — no offcanvas/hamburger. Edge-fade gradients indicate when
+   items are off-screen; site.js toggles data-scroll-start/end on .sidebar
+   to show/hide the gradients and scrolls the active item into view. */
 @media (max-width: 767.98px) {
     body.admin-shell .app-shell { grid-template-columns: 1fr; }
     body.admin-shell .stats { grid-template-columns: 1fr; }
@@ -472,7 +474,12 @@ body.admin-shell .split-panels {
     body.admin-shell .m-nav .exit-admin { padding: 6px 8px; }
     body.admin-shell .m-nav .avatar { width: 28px; height: 28px; font-size: 0.74rem; }
 
-    body.admin-shell .sidebar { padding: 0; border-right: 0; border-bottom: 1px solid rgba(255,245,221,0.1); }
+    body.admin-shell .sidebar {
+        padding: 0;
+        border-right: 0;
+        border-bottom: 1px solid rgba(255,245,221,0.1);
+        position: relative;
+    }
     body.admin-shell .sidebar-scroll {
         flex-direction: row;
         align-items: center;
@@ -480,6 +487,9 @@ body.admin-shell .split-panels {
         padding: 0 8px;
         overflow-x: auto;
         scrollbar-width: none;
+        -webkit-overflow-scrolling: touch;
+        overscroll-behavior-x: contain;
+        scroll-behavior: smooth;
     }
     body.admin-shell .sidebar-scroll::-webkit-scrollbar { display: none; }
     body.admin-shell .sidebar h4 { display: none; }
@@ -498,4 +508,32 @@ body.admin-shell .split-panels {
         background: transparent;
     }
     body.admin-shell .sidebar .pill { font-size: 0.6rem; padding: 1px 6px; }
+
+    /* Edge-fade affordances. The overlay is over .sidebar (which has the
+       same bg as the strip), so fading from transparent to --h-aged-ink
+       creates a clean reveal/conceal of off-screen items. JS toggles the
+       data-scroll-start/end attributes; default state shows the right fade
+       (since pages typically load scrolled to the start). */
+    body.admin-shell .sidebar::before,
+    body.admin-shell .sidebar::after {
+        content: '';
+        position: absolute;
+        top: 0;
+        bottom: 1px; /* don't cover the bottom border */
+        width: 32px;
+        pointer-events: none;
+        z-index: 1;
+        opacity: 0;
+        transition: opacity 0.15s ease;
+    }
+    body.admin-shell .sidebar::before {
+        left: 0;
+        background: linear-gradient(to right, var(--h-aged-ink), rgba(28,24,20,0));
+    }
+    body.admin-shell .sidebar::after {
+        right: 0;
+        background: linear-gradient(to left, var(--h-aged-ink), rgba(28,24,20,0));
+    }
+    body.admin-shell .sidebar[data-scroll-start="false"]::before { opacity: 1; }
+    body.admin-shell .sidebar[data-scroll-end="false"]::after { opacity: 1; }
 }

--- a/src/Humans.Web/wwwroot/css/admin-shell.css
+++ b/src/Humans.Web/wwwroot/css/admin-shell.css
@@ -490,6 +490,7 @@ body.admin-shell .split-panels {
         -webkit-overflow-scrolling: touch;
         overscroll-behavior-x: contain;
         scroll-behavior: smooth;
+        cursor: grab;
     }
     body.admin-shell .sidebar-scroll::-webkit-scrollbar { display: none; }
     body.admin-shell .sidebar h4 { display: none; }

--- a/src/Humans.Web/wwwroot/css/admin-shell.css
+++ b/src/Humans.Web/wwwroot/css/admin-shell.css
@@ -462,7 +462,11 @@ body.admin-shell .split-panels {
    items are off-screen; site.js toggles data-scroll-start/end on .sidebar
    to show/hide the gradients and scrolls the active item into view. */
 @media (max-width: 767.98px) {
-    body.admin-shell .app-shell { grid-template-columns: 1fr; }
+    /* minmax(0, 1fr) instead of 1fr — without min:0, the grid column
+       sizes to the auto-min-content of .sidebar-scroll's flex children
+       (which have flex-shrink:0), so the column expands past the viewport
+       and the inner overflow:auto never triggers. */
+    body.admin-shell .app-shell { grid-template-columns: minmax(0, 1fr); }
     body.admin-shell .stats { grid-template-columns: 1fr; }
     body.admin-shell .split-panels { grid-template-columns: 1fr; }
 
@@ -479,6 +483,8 @@ body.admin-shell .split-panels {
         border-right: 0;
         border-bottom: 1px solid rgba(255,245,221,0.1);
         position: relative;
+        min-width: 0;
+        overflow: hidden;
     }
     body.admin-shell .sidebar-scroll {
         flex-direction: row;

--- a/src/Humans.Web/wwwroot/js/site.js
+++ b/src/Humans.Web/wwwroot/js/site.js
@@ -314,6 +314,51 @@ function showToast(message, type) {
     scroll.addEventListener('scroll', update, { passive: true });
     window.addEventListener('resize', update);
 
+    // Mouse drag-to-scroll. Native overflow-x:auto handles touch panning on
+    // real phones, but a mouse on desktop (or DevTools mobile emulation
+    // without touch sim) can't drag-scroll without JS. Threshold is 5px so
+    // a tiny jitter during a click doesn't suppress navigation.
+    var dragStartX = 0;
+    var dragStartScroll = 0;
+    var dragMoved = 0;
+    var dragging = false;
+
+    scroll.addEventListener('mousedown', function (e) {
+        if (e.button !== 0) return;
+        dragging = true;
+        dragStartX = e.pageX;
+        dragStartScroll = scroll.scrollLeft;
+        dragMoved = 0;
+        scroll.style.cursor = 'grabbing';
+        scroll.style.userSelect = 'none';
+    });
+
+    document.addEventListener('mousemove', function (e) {
+        if (!dragging) return;
+        var dx = e.pageX - dragStartX;
+        if (Math.abs(dx) > Math.abs(dragMoved)) dragMoved = dx;
+        scroll.scrollLeft = dragStartScroll - dx;
+    });
+
+    function endDrag() {
+        if (!dragging) return;
+        dragging = false;
+        scroll.style.cursor = '';
+        scroll.style.userSelect = '';
+    }
+    document.addEventListener('mouseup', endDrag);
+    scroll.addEventListener('mouseleave', endDrag);
+
+    // Suppress the click that follows a real drag, so dragging across a
+    // nav link doesn't accidentally navigate.
+    scroll.addEventListener('click', function (e) {
+        if (Math.abs(dragMoved) > 5) {
+            e.preventDefault();
+            e.stopPropagation();
+            dragMoved = 0;
+        }
+    }, true);
+
     // On mobile (horizontal strip), bring the active item into view if it's
     // off-screen so users land on the right item without manual scrolling.
     var horizontal = window.matchMedia('(max-width: 767.98px)');

--- a/src/Humans.Web/wwwroot/js/site.js
+++ b/src/Humans.Web/wwwroot/js/site.js
@@ -294,3 +294,37 @@ function showToast(message, type) {
         }
     }, true);
 })();
+
+// Admin sidebar mobile scroll affordances — toggles data-scroll-start/end
+// on the .sidebar so admin-shell.css can show/hide the edge fades, and
+// scrolls the active nav item into view on load when the strip overflows.
+(function () {
+    var sidebar = document.querySelector('body.admin-shell .sidebar');
+    if (!sidebar) return;
+    var scroll = sidebar.querySelector('.sidebar-scroll');
+    if (!scroll) return;
+
+    function update() {
+        var atStart = scroll.scrollLeft <= 1;
+        var atEnd = scroll.scrollLeft + scroll.clientWidth >= scroll.scrollWidth - 1;
+        sidebar.dataset.scrollStart = atStart ? 'true' : 'false';
+        sidebar.dataset.scrollEnd = atEnd ? 'true' : 'false';
+    }
+
+    scroll.addEventListener('scroll', update, { passive: true });
+    window.addEventListener('resize', update);
+
+    // On mobile (horizontal strip), bring the active item into view if it's
+    // off-screen so users land on the right item without manual scrolling.
+    var horizontal = window.matchMedia('(max-width: 767.98px)');
+    if (horizontal.matches) {
+        var active = scroll.querySelector('a.active');
+        if (active) {
+            var prev = scroll.style.scrollBehavior;
+            scroll.style.scrollBehavior = 'auto';
+            active.scrollIntoView({ inline: 'center', block: 'nearest' });
+            scroll.style.scrollBehavior = prev;
+        }
+    }
+    update();
+})();


### PR DESCRIPTION
Closes nobodies-collective/Humans#625.

## Summary
- Add right/left edge-fade gradient affordances to the admin sidebar's mobile horizontal scroll strip so users can see when items extend past the viewport edge.
- Auto-scroll the active nav item into view on page load when the strip overflows, so users land on the right item without manual scrolling.
- Add smooth touch scrolling (`-webkit-overflow-scrolling: touch`, `overscroll-behavior-x: contain`, `scroll-behavior: smooth`).
- JS toggles `data-scroll-start` / `data-scroll-end` on `.sidebar`; CSS shows each fade only when there's content past that edge. No change on desktop (≥768px) — the strip layout is mobile-only.

## Files
- `src/Humans.Web/wwwroot/css/admin-shell.css` — mobile media query: position `.sidebar` relative, `::before`/`::after` edge fades, smooth scroll properties on `.sidebar-scroll`.
- `src/Humans.Web/wwwroot/js/site.js` — small IIFE that updates the data attributes on scroll/resize and scrolls the active item into view at mobile width.

## Test plan
- [ ] On preview env (`{pr_id}.n.burn.camp`), open `/Admin/*` on a phone-width viewport (or DevTools device emulation ≤767.98px) and confirm:
  - [ ] A right-edge fade is visible when the nav has more items than fit.
  - [ ] Touch/trackpad horizontal-scrolling reveals the off-screen items.
  - [ ] Once scrolled, a left-edge fade appears; once at the right edge, the right fade disappears.
  - [ ] Loading a page whose active item is off-screen automatically centers that item in the strip.
- [ ] Desktop (≥768px) sidebar remains vertical and unchanged.
- [ ] iOS Safari and Android Chrome touch scrolling feels smooth.