### PR TITLE
feat(email-oauth-pr5): unsubscribe footer coverage + token-driven UpdateSource

### DIFF
--- a/docs/features/communication-preferences.md
+++ b/docs/features/communication-preferences.md
@@ -47,7 +47,7 @@ When a user opts out of Facilitated Messages, the "Send Message" button is hidde
 - `OptedOut` (bool) — true = user does NOT receive email for this category
 - `InboxEnabled` (bool) — true = user receives in-app alerts for this category
 - `UpdatedAt` (Instant) — when preference was last changed
-- `UpdateSource` (string) — how it was set: "Profile", "MagicLink", "OneClick", "Default", "DataMigration"
+- `UpdateSource` (string) — how it was set: "Profile" (signed-in profile UI), "Guest" (signed-in Guest dashboard, profileless), "MagicLink" (anonymous unsubscribe-token endpoints), "OneClick" (RFC 8058 List-Unsubscribe), "Default" (lazy seed), "DataMigration"
 
 **Enum:** `MessageCategory` — stored as string in DB
 - Active: System, CampaignCodes, FacilitatedMessages, Ticketing, VolunteerUpdates, TeamUpdates, Governance, Marketing

--- a/docs/sections/Profiles.md
+++ b/docs/sections/Profiles.md
@@ -195,7 +195,7 @@ Per-user, per-category email opt-in/opt-out preferences. One row per user per ca
 | OptedOut | bool | true = user opted out of email for this category |
 | InboxEnabled | bool | Default true; when false, informational in-app notifications for this category are suppressed (actionable notifications always show) |
 | UpdatedAt | Instant | Last change |
-| UpdateSource | string (100) | "Profile", "MagicLink", "OneClick", "Default", "DataMigration" |
+| UpdateSource | string (100) | "Profile" (signed-in profile UI), "Guest" (signed-in Guest dashboard, profileless), "MagicLink" (anonymous unsubscribe-token endpoints), "OneClick" (RFC 8058 List-Unsubscribe), "Default" (lazy seed), "DataMigration" |
 
 **Unique constraint:** `(UserId, Category)`. **Indexes:** `UserId`.
 

--- a/memory/INDEX.md
+++ b/memory/INDEX.md
@@ -53,6 +53,7 @@ Atomic rules. Fetch the body when the description's trigger matches your task. S
 - [`search-endpoint-response-shape`](code/search-endpoint-response-shape.md) — search/autocomplete endpoints return typed DTOs/records, not anonymous objects
 - [`string-comparisons-explicit`](code/string-comparisons-explicit.md) — `StringComparison.Ordinal`/`OrdinalIgnoreCase`; user search uses shared `Humans.Web.Extensions` helpers
 - [`time-parsing-standardization`](code/time-parsing-standardization.md) — `TryParseInvariantTimeOnly`/`TryParseInvariantLocalTime` from `TimeParsingExtensions`
+- [`update-source-attribution`](code/update-source-attribution.md) — `CommunicationPreference.UpdateSource` must reflect actor (signed-in/anon) + channel; don't conflate `Guest` (session) with `MagicLink` (token)
 - [`view-components-vs-partials`](code/view-components-vs-partials.md) — View Component when it fetches its own data; Partial View when parent already has the model
 - [`viewcomponent-no-cache`](code/viewcomponent-no-cache.md) — view components must NOT inject `IMemoryCache`; the owning service exposes a cached accessor
 

--- a/memory/code/update-source-attribution.md
+++ b/memory/code/update-source-attribution.md
@@ -1,0 +1,29 @@
+---
+name: UpdateSource attribution — distinguish actor + channel
+description: When writing CommunicationPreference (or any audited preference write), `UpdateSource` must reflect how the user reached the endpoint — token-driven anonymous vs. session-driven, and which UI. Don't conflate "Guest" with "MagicLink".
+---
+
+When a controller writes a `CommunicationPreference` via `ICommunicationPreferenceService.UpdatePreferenceAsync`, the `source` parameter must reflect both the **actor** (signed-in vs. anonymous) and the **channel** (which UI/endpoint). Don't use one label for two channels.
+
+**The current vocabulary** (also documented in [`docs/sections/Profiles.md`](../../docs/sections/Profiles.md) and [`docs/features/communication-preferences.md`](../../docs/features/communication-preferences.md)):
+
+| Source | Actor | Channel |
+|---|---|---|
+| `"Profile"` | Signed-in user with a Profile | `/Profile/Me/CommunicationPreferences` |
+| `"Guest"` | Signed-in profileless user | `/Guest/CommunicationPreferences` |
+| `"MagicLink"` | Anonymous, valid unsubscribe token | `/Guest/CommunicationPreferences/Update?utoken=…` |
+| `"OneClick"` | Anonymous, RFC 8058 List-Unsubscribe-Post | `/Unsubscribe/OneClick` |
+| `"Default"` | (none — lazy seed by `GetPreferencesAsync`) | first read |
+| `"DataMigration"` | Backfill | one-shot data migration |
+
+**Why:** GDPR / CAN-SPAM audit defensibility. The audit-log description literally embeds the source (`"{Category} opted out via {source}"`). When a user disputes "I never unsubscribed", we need to tell whether it came from their authenticated session, a magic-link in their inbox (proves they had inbox access), or one-click from an MUA — those are different evidentiary stories. Conflating them destroys the signal.
+
+The token-driven `"MagicLink"` value also matters because it's the only path that doesn't require an account session, so it's the one most likely to be challenged. PR #387 split `"Guest"` into `"Guest"` (session) + `"MagicLink"` (token) for exactly this reason.
+
+**How to apply:**
+
+- `GuestController.ResolveUserIdOrTokenAsync` returns `(UserId, TokenCategory, FromToken)`. The `FromToken` bool is the source of truth — `fromToken ? "MagicLink" : "Guest"` in `UpdatePreference`. Don't second-guess it from `utoken != null` (the session path can run with a stale `utoken` query param too).
+- Adding a new endpoint that writes preferences? Pick a new source label that names the channel, OR reuse an existing one only if the actor + channel are identical to that label's owner.
+- Tests that assert `UpdateSource` must POST values that **differ from the seeded default** for the chosen category — the service early-returns on idempotent updates and the row stays at `"Default"`. `MessageCategory.VolunteerUpdates` (default `OptedOut=false`) flipped via `emailEnabled=false` is the canonical assertion shape; see `tests/Humans.Integration.Tests/Controllers/UnsubscribeFlowTests.cs`.
+
+**Related:** [`docs/sections/Profiles.md`](../../docs/sections/Profiles.md) (CommunicationPreference table), [`docs/features/communication-preferences.md`](../../docs/features/communication-preferences.md).

--- a/src/Humans.Application/Services/Email/OutboxEmailService.cs
+++ b/src/Humans.Application/Services/Email/OutboxEmailService.cs
@@ -68,7 +68,8 @@ public sealed class OutboxEmailService : IEmailService
         CancellationToken cancellationToken = default)
     {
         var content = _renderer.RenderApplicationApproved(userName, tier, culture);
-        await EnqueueAsync(userEmail, userName, content, "application_approved", cancellationToken);
+        await EnqueueAsync(userEmail, userName, content, "application_approved", cancellationToken,
+            category: MessageCategory.Governance);
     }
 
     /// <inheritdoc />
@@ -81,7 +82,8 @@ public sealed class OutboxEmailService : IEmailService
         CancellationToken cancellationToken = default)
     {
         var content = _renderer.RenderApplicationRejected(userName, tier, reason, culture);
-        await EnqueueAsync(userEmail, userName, content, "application_rejected", cancellationToken);
+        await EnqueueAsync(userEmail, userName, content, "application_rejected", cancellationToken,
+            category: MessageCategory.Governance);
     }
 
     /// <inheritdoc />
@@ -253,7 +255,8 @@ public sealed class OutboxEmailService : IEmailService
         CancellationToken cancellationToken = default)
     {
         var content = _renderer.RenderAdminDailyDigest(name, date, counts, culture);
-        await EnqueueAsync(email, name, content, "admin_daily_digest", cancellationToken);
+        await EnqueueAsync(email, name, content, "admin_daily_digest", cancellationToken,
+            category: MessageCategory.Governance);
     }
 
     /// <inheritdoc />

--- a/src/Humans.Web/Controllers/GuestController.cs
+++ b/src/Humans.Web/Controllers/GuestController.cs
@@ -82,12 +82,13 @@ public class GuestController : HumansControllerBase
     {
         try
         {
-            var userId = await ResolveUserIdOrTokenAsync(utoken);
+            var (userId, tokenCategory, _) = await ResolveUserIdOrTokenAsync(utoken);
             if (userId is null)
                 return Challenge();
 
             var model = await BuildCommunicationPreferencesViewModelAsync(userId.Value);
             model.UnsubscribeToken = utoken;
+            model.HighlightCategory = tokenCategory;
             return View(model);
         }
         catch (Exception ex)
@@ -107,15 +108,18 @@ public class GuestController : HumansControllerBase
     {
         try
         {
-            var userId = await ResolveUserIdOrTokenAsync(utoken);
+            var (userId, _, fromToken) = await ResolveUserIdOrTokenAsync(utoken);
             if (userId is null)
                 return Unauthorized();
 
             if (category.IsAlwaysOn())
                 return BadRequest("Cannot change always-on categories.");
 
+            // Anonymous token-driven updates are attributed to "MagicLink"; session-driven to "Guest".
+            var source = fromToken ? "MagicLink" : "Guest";
+
             await _commPrefService.UpdatePreferenceAsync(
-                userId.Value, category, optedOut: !emailEnabled, inboxEnabled: alertEnabled, "Guest");
+                userId.Value, category, optedOut: !emailEnabled, inboxEnabled: alertEnabled, source);
 
             return Ok();
         }
@@ -301,26 +305,32 @@ public class GuestController : HumansControllerBase
 
     /// <summary>
     /// Resolves the user ID from the current session, or falls back to an unsubscribe token.
-    /// Returns null if neither is available.
+    /// Returns <c>UserId = null</c> if neither is available. <c>FromToken</c> is true only
+    /// when the resolution came from a valid <paramref name="utoken"/>; callers use this to
+    /// distinguish anonymous magic-link-driven updates (<c>UpdateSource = "MagicLink"</c>) from
+    /// session-driven ones (<c>UpdateSource = "Guest"</c>). <c>TokenCategory</c> carries the
+    /// category encoded in the token so the GET path can pre-focus that row.
     /// </summary>
-    private async Task<Guid?> ResolveUserIdOrTokenAsync(string? utoken)
+    private async Task<(Guid? UserId, MessageCategory? TokenCategory, bool FromToken)> ResolveUserIdOrTokenAsync(string? utoken)
     {
         // Prefer authenticated session
         var user = await GetCurrentUserAsync();
         if (user is not null)
-            return user.Id;
+            return (user.Id, null, false);
 
         // Fall back to unsubscribe token
         if (string.IsNullOrEmpty(utoken))
-            return null;
+            return (null, null, false);
 
         var result = _commPrefService.ValidateUnsubscribeToken(utoken);
         if (result.Status != TokenValidationStatus.Valid)
-            return null;
+            return (null, null, false);
 
         // Verify user still exists
         var exists = await FindUserByIdAsync(result.UserId);
-        return exists is not null ? result.UserId : null;
+        return exists is not null
+            ? (result.UserId, result.Category, true)
+            : (null, null, false);
     }
 
     private async Task<CommunicationPreferencesViewModel> BuildCommunicationPreferencesViewModelAsync(Guid userId)

--- a/src/Humans.Web/Models/CommunicationPreferenceViewModels.cs
+++ b/src/Humans.Web/Models/CommunicationPreferenceViewModels.cs
@@ -11,6 +11,12 @@ public class CommunicationPreferencesViewModel
     /// The token must be included in AJAX update calls for authorization.
     /// </summary>
     public string? UnsubscribeToken { get; set; }
+
+    /// <summary>
+    /// Category encoded in the unsubscribe token, when present. Drives the one-click
+    /// "Unsubscribe from <category>" banner and pre-focuses that row in the matrix.
+    /// </summary>
+    public MessageCategory? HighlightCategory { get; set; }
 }
 
 public class CategoryPreferenceItem

--- a/src/Humans.Web/Resources/SharedResource.ca.resx
+++ b/src/Humans.Web/Resources/SharedResource.ca.resx
@@ -1595,6 +1595,10 @@
   <data name="CommPrefs_Alert" xml:space="preserve"><value>Alerta</value></data>
   <data name="CommPrefs_BackToProfile" xml:space="preserve"><value>Tornar al perfil</value></data>
   <data name="CommPrefs_BackToDashboard" xml:space="preserve"><value>Tornar al tauler</value></data>
+  <data name="CommPrefs_OneClick_Prompt" xml:space="preserve"><value>Has fet clic en un enllaç per donar-te de baixa dels correus de {0}.</value></data>
+  <data name="CommPrefs_OneClick_Hint" xml:space="preserve"><value>Dóna't de baixa amb un sol clic, o ajusta els detalls a la matriu de sota.</value></data>
+  <data name="CommPrefs_OneClick_Button" xml:space="preserve"><value>Donar-se de baixa de {0}</value></data>
+  <data name="CommPrefs_OneClick_Done" xml:space="preserve"><value>T'has donat de baixa. Pots tornar a activar qualsevol categoria a sota.</value></data>
 
   <data name="Emails_Header_Email" xml:space="preserve"><value>Correu</value></data>
   <data name="Emails_Header_Status" xml:space="preserve"><value>Estat</value></data>

--- a/src/Humans.Web/Resources/SharedResource.de.resx
+++ b/src/Humans.Web/Resources/SharedResource.de.resx
@@ -1593,6 +1593,10 @@
   <data name="CommPrefs_Alert" xml:space="preserve"><value>Benachrichtigung</value></data>
   <data name="CommPrefs_BackToProfile" xml:space="preserve"><value>Zurück zum Profil</value></data>
   <data name="CommPrefs_BackToDashboard" xml:space="preserve"><value>Zurück zum Dashboard</value></data>
+  <data name="CommPrefs_OneClick_Prompt" xml:space="preserve"><value>Du hast auf einen Abmeldelink in {0}-E-Mails geklickt.</value></data>
+  <data name="CommPrefs_OneClick_Hint" xml:space="preserve"><value>Mit einem Klick abmelden oder die Matrix unten anpassen.</value></data>
+  <data name="CommPrefs_OneClick_Button" xml:space="preserve"><value>{0} abbestellen</value></data>
+  <data name="CommPrefs_OneClick_Done" xml:space="preserve"><value>Abgemeldet. Du kannst jede Kategorie unten wieder aktivieren.</value></data>
 
   <data name="Emails_Header_Email" xml:space="preserve"><value>E-Mail</value></data>
   <data name="Emails_Header_Status" xml:space="preserve"><value>Status</value></data>

--- a/src/Humans.Web/Resources/SharedResource.es.resx
+++ b/src/Humans.Web/Resources/SharedResource.es.resx
@@ -1595,6 +1595,10 @@
   <data name="CommPrefs_Alert" xml:space="preserve"><value>Alerta</value></data>
   <data name="CommPrefs_BackToProfile" xml:space="preserve"><value>Volver al perfil</value></data>
   <data name="CommPrefs_BackToDashboard" xml:space="preserve"><value>Volver al panel</value></data>
+  <data name="CommPrefs_OneClick_Prompt" xml:space="preserve"><value>Has hecho clic en un enlace para darte de baja de los correos de {0}.</value></data>
+  <data name="CommPrefs_OneClick_Hint" xml:space="preserve"><value>Date de baja con un solo clic, o ajusta los detalles en la matriz de abajo.</value></data>
+  <data name="CommPrefs_OneClick_Button" xml:space="preserve"><value>Darse de baja de {0}</value></data>
+  <data name="CommPrefs_OneClick_Done" xml:space="preserve"><value>Te has dado de baja. Puedes volver a activar cualquier categoría abajo.</value></data>
 
   <data name="Emails_Header_Email" xml:space="preserve"><value>Correo</value></data>
   <data name="Emails_Header_Status" xml:space="preserve"><value>Estado</value></data>

--- a/src/Humans.Web/Resources/SharedResource.fr.resx
+++ b/src/Humans.Web/Resources/SharedResource.fr.resx
@@ -1593,6 +1593,10 @@
   <data name="CommPrefs_Alert" xml:space="preserve"><value>Alerte</value></data>
   <data name="CommPrefs_BackToProfile" xml:space="preserve"><value>Retour au profil</value></data>
   <data name="CommPrefs_BackToDashboard" xml:space="preserve"><value>Retour au tableau de bord</value></data>
+  <data name="CommPrefs_OneClick_Prompt" xml:space="preserve"><value>Vous avez cliqué sur un lien de désabonnement dans les e-mails de {0}.</value></data>
+  <data name="CommPrefs_OneClick_Hint" xml:space="preserve"><value>Désabonnement en un clic, ou ajustez les détails dans la matrice ci-dessous.</value></data>
+  <data name="CommPrefs_OneClick_Button" xml:space="preserve"><value>Se désabonner de {0}</value></data>
+  <data name="CommPrefs_OneClick_Done" xml:space="preserve"><value>Désabonné. Vous pouvez réactiver n'importe quelle catégorie ci-dessous.</value></data>
 
   <data name="Emails_Header_Email" xml:space="preserve"><value>E-mail</value></data>
   <data name="Emails_Header_Status" xml:space="preserve"><value>Statut</value></data>

--- a/src/Humans.Web/Resources/SharedResource.it.resx
+++ b/src/Humans.Web/Resources/SharedResource.it.resx
@@ -1593,6 +1593,10 @@
   <data name="CommPrefs_Alert" xml:space="preserve"><value>Avviso</value></data>
   <data name="CommPrefs_BackToProfile" xml:space="preserve"><value>Torna al profilo</value></data>
   <data name="CommPrefs_BackToDashboard" xml:space="preserve"><value>Torna alla dashboard</value></data>
+  <data name="CommPrefs_OneClick_Prompt" xml:space="preserve"><value>Hai cliccato su un link di disiscrizione dalle email di {0}.</value></data>
+  <data name="CommPrefs_OneClick_Hint" xml:space="preserve"><value>Disiscriviti con un clic, oppure regola i dettagli nella matrice qui sotto.</value></data>
+  <data name="CommPrefs_OneClick_Button" xml:space="preserve"><value>Disiscriviti da {0}</value></data>
+  <data name="CommPrefs_OneClick_Done" xml:space="preserve"><value>Disiscritto. Puoi riattivare qualsiasi categoria qui sotto.</value></data>
 
   <data name="Emails_Header_Email" xml:space="preserve"><value>E-mail</value></data>
   <data name="Emails_Header_Status" xml:space="preserve"><value>Stato</value></data>

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -1630,6 +1630,10 @@
   <data name="CommPrefs_Alert" xml:space="preserve"><value>Alert</value></data>
   <data name="CommPrefs_BackToProfile" xml:space="preserve"><value>Back to Profile</value></data>
   <data name="CommPrefs_BackToDashboard" xml:space="preserve"><value>Back to Dashboard</value></data>
+  <data name="CommPrefs_OneClick_Prompt" xml:space="preserve"><value>You clicked an unsubscribe link from {0} emails.</value></data>
+  <data name="CommPrefs_OneClick_Hint" xml:space="preserve"><value>One-click unsubscribe, or fine-tune the matrix below.</value></data>
+  <data name="CommPrefs_OneClick_Button" xml:space="preserve"><value>Unsubscribe from {0}</value></data>
+  <data name="CommPrefs_OneClick_Done" xml:space="preserve"><value>Unsubscribed. You can re-enable any category below.</value></data>
 
   <data name="Emails_Header_Email" xml:space="preserve"><value>Email</value></data>
   <data name="Emails_Header_Status" xml:space="preserve"><value>Status</value></data>

--- a/src/Humans.Web/Views/Guest/CommunicationPreferences.cshtml
+++ b/src/Humans.Web/Views/Guest/CommunicationPreferences.cshtml
@@ -20,6 +20,24 @@
 
         <vc:temp-data-alerts />
 
+        @if (Model.HighlightCategory is { } highlight && !highlight.IsAlwaysOn())
+        {
+            var highlightName = highlight == MessageCategory.Ticketing
+                ? $"Ticketing — {DateTime.UtcNow.Year}"
+                : highlight.ToDisplayName();
+            <div id="oneClickBanner"
+                 class="alert alert-warning d-flex align-items-center justify-content-between gap-3 mb-4"
+                 data-category="@highlight">
+                <div>
+                    <strong>@string.Format(Localizer["CommPrefs_OneClick_Prompt"].Value, highlightName)</strong>
+                    <div class="form-text mb-0">@Localizer["CommPrefs_OneClick_Hint"]</div>
+                </div>
+                <button type="button" id="oneClickUnsubscribe" class="btn btn-warning text-nowrap">
+                    @string.Format(Localizer["CommPrefs_OneClick_Button"].Value, highlightName)
+                </button>
+            </div>
+        }
+
         <div class="card mb-4">
             <div class="table-responsive">
                 <table class="table table-hover mb-0 align-middle">
@@ -35,7 +53,8 @@
                         {
                             var item = Model.Categories[i];
 
-                            <tr class="@(!item.EmailEditable ? "table-light" : "")">
+                            <tr class="@(!item.EmailEditable ? "table-light" : (Model.HighlightCategory == item.Category ? "table-warning" : ""))"
+                                data-category-row="@item.Category">
                                 <td>
                                     <div class="fw-semibold">@item.DisplayName</div>
                                     <div class="form-text mb-0">@item.Description</div>
@@ -138,6 +157,47 @@
             });
         });
     });
+
+    // One-click unsubscribe banner: fires the same UpdatePreference call with emailEnabled=false
+    // for the highlighted category, then collapses the banner and unchecks the matrix row.
+    var oneClickBtn = document.getElementById('oneClickUnsubscribe');
+    if (oneClickBtn) {
+        oneClickBtn.addEventListener('click', function () {
+            var banner = document.getElementById('oneClickBanner');
+            var category = banner.dataset.category;
+            var row = document.querySelector('[data-category-row="' + category + '"]');
+            var emailCb = row ? row.querySelector('[data-channel="email"]') : null;
+            var alertCb = row ? row.querySelector('[data-channel="alert"]') : null;
+
+            var body = new URLSearchParams();
+            body.append('category', category);
+            body.append('emailEnabled', 'false');
+            body.append('alertEnabled', alertCb ? alertCb.checked : true);
+            body.append('__RequestVerificationToken',
+                document.querySelector('input[name="__RequestVerificationToken"]').value);
+            @if (!string.IsNullOrEmpty(Model.UnsubscribeToken))
+            {
+                @:body.append('utoken', '@Html.Raw(Html.Encode(Model.UnsubscribeToken))');
+            }
+
+            oneClickBtn.disabled = true;
+            fetch('@Url.Action("UpdatePreference")', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                body: body.toString()
+            }).then(function (resp) {
+                if (!resp.ok) throw new Error(resp.statusText);
+                if (emailCb) emailCb.checked = false;
+                banner.classList.remove('alert-warning');
+                banner.classList.add('alert-success');
+                banner.innerHTML = '<strong>@Html.Raw(Html.Encode(Localizer["CommPrefs_OneClick_Done"].Value))</strong>';
+            }).catch(function () {
+                banner.classList.remove('alert-warning');
+                banner.classList.add('alert-danger');
+                oneClickBtn.disabled = false;
+            });
+        });
+    }
 </script>
 }
 

--- a/src/Humans.Web/Views/Guest/CommunicationPreferences.cshtml
+++ b/src/Humans.Web/Views/Guest/CommunicationPreferences.cshtml
@@ -22,9 +22,10 @@
 
         @if (Model.HighlightCategory is { } highlight && !highlight.IsAlwaysOn())
         {
-            var highlightName = highlight == MessageCategory.Ticketing
-                ? $"Ticketing — {DateTime.UtcNow.Year}"
-                : highlight.ToDisplayName();
+            // Reuse the controller-built DisplayName (sourced from IClock for Ticketing year).
+            // Avoids a raw DateTime.UtcNow in the view — see memory/code/nodatime-for-dates.md.
+            var highlightName = Model.Categories.FirstOrDefault(c => c.Category == highlight)?.DisplayName
+                ?? highlight.ToDisplayName();
             <div id="oneClickBanner"
                  class="alert alert-warning d-flex align-items-center justify-content-between gap-3 mb-4"
                  data-category="@highlight">

--- a/tests/Humans.Application.Tests/Services/OutboxEmailServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/OutboxEmailServiceTests.cs
@@ -1,4 +1,5 @@
 using AwesomeAssertions;
+using Humans.Application.DTOs;
 using Humans.Application.Interfaces;
 using Humans.Application.Interfaces.Repositories;
 using Humans.Application.Services.Email;
@@ -236,6 +237,95 @@ public sealed class OutboxEmailServiceTests : IDisposable
         messages[0].RecipientEmail.Should().Be("dana@example.com");
         messages[0].TemplateName.Should().Be("added_to_team");
         messages[0].UserId.Should().Be(userId);
+    }
+
+    [HumansFact]
+    public async Task SendApplicationApprovedAsync_WhenOptedOutOfGovernance_DoesNotCreateOutboxRow()
+    {
+        var userId = Guid.NewGuid();
+        _userEmailService.GetUserIdByVerifiedEmailAsync("eve@example.com", Arg.Any<CancellationToken>())
+            .Returns(userId);
+        _commPrefService.IsOptedOutAsync(userId, MessageCategory.Governance, Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        _renderer.RenderApplicationApproved("Eve", MembershipTier.Colaborador, "en")
+            .Returns(new EmailContent("Approved!", "<p>Congrats</p>"));
+
+        await _service.SendApplicationApprovedAsync(
+            "eve@example.com", "Eve", MembershipTier.Colaborador, "en");
+
+        var messages = await _dbContext.EmailOutboxMessages.ToListAsync();
+        messages.Should().BeEmpty(
+            "ApplicationApproved is now Governance-categorized and must be suppressed when opted out.");
+    }
+
+    [HumansFact]
+    public async Task SendApplicationRejectedAsync_WhenOptedOutOfGovernance_DoesNotCreateOutboxRow()
+    {
+        var userId = Guid.NewGuid();
+        _userEmailService.GetUserIdByVerifiedEmailAsync("frank@example.com", Arg.Any<CancellationToken>())
+            .Returns(userId);
+        _commPrefService.IsOptedOutAsync(userId, MessageCategory.Governance, Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        _renderer.RenderApplicationRejected("Frank", MembershipTier.Asociado, "Insufficient tenure", "en")
+            .Returns(new EmailContent("Rejected", "<p>Sorry</p>"));
+
+        await _service.SendApplicationRejectedAsync(
+            "frank@example.com", "Frank", MembershipTier.Asociado, "Insufficient tenure", "en");
+
+        var messages = await _dbContext.EmailOutboxMessages.ToListAsync();
+        messages.Should().BeEmpty(
+            "ApplicationRejected is now Governance-categorized and must be suppressed when opted out.");
+    }
+
+    [HumansFact]
+    public async Task SendAdminDailyDigestAsync_WhenOptedOutOfGovernance_DoesNotCreateOutboxRow()
+    {
+        var userId = Guid.NewGuid();
+        _userEmailService.GetUserIdByVerifiedEmailAsync("admin@example.com", Arg.Any<CancellationToken>())
+            .Returns(userId);
+        _commPrefService.IsOptedOutAsync(userId, MessageCategory.Governance, Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        var counts = new AdminDigestCounts(0, 0, 0, 0, 0, 0, 0, 0, 0, false, null);
+        _renderer.RenderAdminDailyDigest("Admin", "2026-05-01", counts, "en")
+            .Returns(new EmailContent("Admin Digest", "<p>Today</p>"));
+
+        await _service.SendAdminDailyDigestAsync(
+            "admin@example.com", "Admin", "2026-05-01", counts, "en");
+
+        var messages = await _dbContext.EmailOutboxMessages.ToListAsync();
+        messages.Should().BeEmpty(
+            "AdminDailyDigest is now Governance-categorized and must be suppressed when opted out.");
+    }
+
+    [HumansFact]
+    public async Task SendApplicationApprovedAsync_WhenOptedIn_StampsUnsubscribeUrlIntoBody()
+    {
+        var userId = Guid.NewGuid();
+        _userEmailService.GetUserIdByVerifiedEmailAsync("grace@example.com", Arg.Any<CancellationToken>())
+            .Returns(userId);
+        _commPrefService.IsOptedOutAsync(userId, MessageCategory.Governance, Arg.Any<CancellationToken>())
+            .Returns(false);
+        _commPrefService.GenerateUnsubscribeHeaders(userId, MessageCategory.Governance)
+            .Returns(new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["List-Unsubscribe"] = "<https://example.com/u>",
+            });
+        _commPrefService.GenerateBrowserUnsubscribeUrl(userId, MessageCategory.Governance)
+            .Returns("https://example.com/Unsubscribe/abc");
+
+        _renderer.RenderApplicationApproved("Grace", MembershipTier.Colaborador, "en")
+            .Returns(new EmailContent("Approved!", "<p>Congrats Grace</p>"));
+
+        await _service.SendApplicationApprovedAsync(
+            "grace@example.com", "Grace", MembershipTier.Colaborador, "en");
+
+        var msg = await _dbContext.EmailOutboxMessages.SingleAsync();
+        msg.UserId.Should().Be(userId);
+        msg.ExtraHeaders.Should().NotBeNull("List-Unsubscribe headers must be stamped for Governance emails.");
+        _bodyComposer.Received().Compose(Arg.Any<string>(), "https://example.com/Unsubscribe/abc");
     }
 
     [HumansFact]

--- a/tests/Humans.Integration.Tests/Controllers/UnsubscribeFlowTests.cs
+++ b/tests/Humans.Integration.Tests/Controllers/UnsubscribeFlowTests.cs
@@ -1,0 +1,184 @@
+using System.Net;
+using System.Text.RegularExpressions;
+using AwesomeAssertions;
+using Humans.Application.Interfaces.Profiles;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using Humans.Infrastructure.Data;
+using Humans.Integration.Tests.Infrastructure;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using NodaTime;
+using Xunit;
+
+namespace Humans.Integration.Tests.Controllers;
+
+/// <summary>
+/// PR 5 of the email/OAuth decoupling sequence. Locks in the
+/// <c>UpdateSource</c> attribution split for <c>GuestController.UpdatePreference</c>:
+/// anonymous token-driven POSTs must record <c>"MagicLink"</c>, while
+/// session-driven POSTs must record <c>"Guest"</c>. The previous in-flight
+/// version of these tests went green on a no-op flip — the seed row already
+/// matched the POST body, so <see cref="ICommunicationPreferenceService.UpdatePreferenceAsync(Guid, MessageCategory, bool, bool, string, System.Threading.CancellationToken)"/>
+/// short-circuited as idempotent and the row stayed at <c>UpdateSource = "Default"</c>
+/// while the controller still returned 200 OK. The fix is to drive the POST
+/// against <see cref="MessageCategory.VolunteerUpdates"/> (default OptedOut=false)
+/// with <c>emailEnabled=false</c>, which forces an actual write.
+/// </summary>
+public class UnsubscribeFlowTests : IntegrationTestBase
+{
+    public UnsubscribeFlowTests(HumansWebApplicationFactory factory) : base(factory) { }
+
+    [HumansFact(Timeout = 30_000)]
+    public async Task TokenDriven_UpdatePreference_AttributesUpdateSourceToMagicLink()
+    {
+        // Seed a profileless user.
+        Guid userId;
+        await using (var scope = Factory.Services.CreateAsyncScope())
+        {
+            userId = await SeedBareUserAsync(scope, $"untoken-{Guid.NewGuid():N}@x.test");
+        }
+
+        // Generate an unsubscribe token for VolunteerUpdates (default OptedOut=false).
+        // POSTing emailEnabled=false flips OptedOut → true, so the service writes
+        // (instead of short-circuiting as idempotent and leaving the row at "Default").
+        string token;
+        await using (var scope = Factory.Services.CreateAsyncScope())
+        {
+            var commPrefService = scope.ServiceProvider.GetRequiredService<ICommunicationPreferenceService>();
+            token = commPrefService.GenerateUnsubscribeToken(userId, MessageCategory.VolunteerUpdates);
+        }
+
+        // Use the per-test-class anonymous client (no session cookie). The GET with
+        // utoken renders the page with an antiforgery field; the POST sends it back.
+        var (formToken, cookie) = await GetAntiforgeryAsync(
+            $"/Guest/CommunicationPreferences?utoken={Uri.EscapeDataString(token)}");
+
+        var resp = await PostFormWithAntiforgeryAsync(
+            "/Guest/CommunicationPreferences/Update",
+            formToken,
+            cookie,
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["category"] = MessageCategory.VolunteerUpdates.ToString(),
+                ["emailEnabled"] = "false",
+                ["alertEnabled"] = "true",
+                ["utoken"] = token,
+            });
+        resp.StatusCode.Should().Be(HttpStatusCode.OK,
+            $"the AJAX update endpoint returns 200 OK on success (got {(int)resp.StatusCode}).");
+
+        await using var assertScope = Factory.Services.CreateAsyncScope();
+        var db = assertScope.ServiceProvider.GetRequiredService<HumansDbContext>();
+        var pref = await db.Set<CommunicationPreference>()
+            .AsNoTracking()
+            .SingleAsync(p => p.UserId == userId && p.Category == MessageCategory.VolunteerUpdates);
+        pref.OptedOut.Should().BeTrue("emailEnabled=false maps to OptedOut=true.");
+        pref.UpdateSource.Should().Be("MagicLink",
+            "anonymous token-driven updates must be attributed to MagicLink, " +
+            "distinct from the seeded \"Default\" or session-driven \"Guest\".");
+    }
+
+    [HumansFact(Timeout = 30_000)]
+    public async Task SessionDriven_UpdatePreference_AttributesUpdateSourceToGuest()
+    {
+        // Sign in the per-test client. SignInAsFullyOnboardedAsync issues the
+        // Identity cookie on the same HttpClient/CookieContainer used below.
+        var userId = await Factory.SignInAsFullyOnboardedAsync(Client, DevPersona.Volunteer);
+
+        // No utoken → ResolveUserIdOrTokenAsync prefers the authenticated session,
+        // which produces fromToken=false and source="Guest".
+        var (formToken, cookie) = await GetAntiforgeryAsync("/Guest/CommunicationPreferences");
+
+        var resp = await PostFormWithAntiforgeryAsync(
+            "/Guest/CommunicationPreferences/Update",
+            formToken,
+            cookie,
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["category"] = MessageCategory.VolunteerUpdates.ToString(),
+                ["emailEnabled"] = "false",
+                ["alertEnabled"] = "true",
+            });
+        resp.StatusCode.Should().Be(HttpStatusCode.OK,
+            $"the AJAX update endpoint returns 200 OK on success (got {(int)resp.StatusCode}).");
+
+        await using var assertScope = Factory.Services.CreateAsyncScope();
+        var db = assertScope.ServiceProvider.GetRequiredService<HumansDbContext>();
+        var pref = await db.Set<CommunicationPreference>()
+            .AsNoTracking()
+            .SingleAsync(p => p.UserId == userId && p.Category == MessageCategory.VolunteerUpdates);
+        pref.OptedOut.Should().BeTrue("emailEnabled=false maps to OptedOut=true.");
+        pref.UpdateSource.Should().Be("Guest",
+            "session-driven updates must be attributed to Guest, distinct from MagicLink.");
+    }
+
+    // ---------------------------------------------------------------------
+    // Helpers — mirror EmailGridFlowTests.
+    // ---------------------------------------------------------------------
+
+    private static async Task<Guid> SeedBareUserAsync(IServiceScope scope, string email)
+    {
+        var um = scope.ServiceProvider.GetRequiredService<UserManager<User>>();
+        var user = new User
+        {
+            Id = Guid.NewGuid(),
+            DisplayName = "Seeded Human",
+            Email = email,
+            UserName = email,
+            CreatedAt = SystemClock.Instance.GetCurrentInstant(),
+        };
+        var result = await um.CreateAsync(user);
+        if (!result.Succeeded)
+            throw new InvalidOperationException("Failed to seed user: " +
+                string.Join("; ", result.Errors.Select(e => e.Description)));
+        return user.Id;
+    }
+
+    private async Task<(string FormToken, string Cookie)> GetAntiforgeryAsync(string url)
+    {
+        var resp = await Client.GetAsync(url);
+        resp.StatusCode.Should().Be(HttpStatusCode.OK,
+            $"GET {url} must render so we can harvest its antiforgery token (got {(int)resp.StatusCode}).");
+
+        var html = await resp.Content.ReadAsStringAsync();
+        var match = Regex.Match(
+            html,
+            @"name=""__RequestVerificationToken""[^>]*value=""(?<v>[^""]+)""",
+            RegexOptions.Singleline,
+            TimeSpan.FromSeconds(2));
+        if (!match.Success)
+            throw new InvalidOperationException(
+                $"No antiforgery token found in response from {url}.");
+        var formToken = match.Groups["v"].Value;
+
+        if (!resp.Headers.TryGetValues("Set-Cookie", out var setCookieValues))
+            throw new InvalidOperationException(
+                $"GET {url} did not emit any Set-Cookie headers (antiforgery cookie required).");
+
+        var antiforgeryCookie = setCookieValues
+            .Select(h => h.Split(';', 2)[0])
+            .FirstOrDefault(c => c.StartsWith(".AspNetCore.Antiforgery.", StringComparison.Ordinal))
+            ?? throw new InvalidOperationException(
+                "No .AspNetCore.Antiforgery.* cookie was set on the GET response.");
+
+        return (formToken, antiforgeryCookie);
+    }
+
+    private async Task<HttpResponseMessage> PostFormWithAntiforgeryAsync(
+        string url,
+        string formToken,
+        string antiforgeryCookie,
+        IDictionary<string, string> fields)
+    {
+        var withToken = new Dictionary<string, string>(fields, StringComparer.Ordinal)
+        {
+            ["__RequestVerificationToken"] = formToken,
+        };
+        using var content = new FormUrlEncodedContent(withToken);
+        using var req = new HttpRequestMessage(HttpMethod.Post, url) { Content = content };
+        req.Headers.TryAddWithoutValidation("Cookie", antiforgeryCookie);
+        return await Client.SendAsync(req);
+    }
+}


### PR DESCRIPTION
## Summary

PR 5 of the email-and-OAuth decoupling sequence (parent: `docs/superpowers/specs/2026-04-27-email-and-oauth-decoupling-design.md`). Closes the gaps left after PRs 1–4 + #382.

The original spec called for a brand-new `PreferencesController` at `/preferences` with `MagicLinkService`-backed tokens. **Most of that is already shipped** (issues nobodies-collective#97 / #316 / #422 built it earlier). PR 5 collapses to three audit-and-fill closures:

### 1. Footer coverage — three templates were uncategorized

`OutboxEmailService.EnqueueAsync` injects the unsubscribe-link footer (and obeys the opt-out gate) only when a `MessageCategory` is passed. Three Send methods previously didn't pass one and silently sent footerless mail:

| Method | Now |
|---|---|
| `SendApplicationApprovedAsync` | `Governance` |
| `SendApplicationRejectedAsync` | `Governance` |
| `SendAdminDailyDigestAsync` | `Governance` |

(Aligned with `NotificationSourceMapping` and the existing `SendBoardDailyDigestAsync` / `SendTermRenewalReminderAsync` precedents.)

The other uncategorized methods — auth (magic link, verification, workspace credentials), security (account deletion, access suspended), and legal (re-consent) — are correctly footerless per spec line 173 (`MessageCategory != System` is the gate). Threading `MessageCategory.System` explicitly would be a no-op refactor; skipped.

### 2. UpdateSource drift — token-driven updates were attributed to "Guest"

`GuestController.UpdatePreference` previously passed `"Guest"` as `UpdateSource` for every update, regardless of whether the request was authorized by an authenticated session or by a `utoken`. Spec says token-driven updates record `"MagicLink"`.

Fix: `ResolveUserIdOrTokenAsync` now returns `(UserId, TokenCategory, FromToken)`. The controller maps `fromToken ? "MagicLink" : "Guest"`. Anonymous `utoken` updates → `"MagicLink"`; session updates → `"Guest"`.

### 3. Pre-focus from token — view ignored the token's category

When `/Guest/CommunicationPreferences?utoken=…` is loaded with a token that encodes a category, the view now:
- highlights the matching matrix row (`table-warning`)
- renders a one-click **"Unsubscribe from \<category\>"** banner above the matrix
- the banner button fires the same `UpdatePreference` AJAX with `emailEnabled=false`
- existing checkbox toggles still work for fine-tuning

## Out of scope (per discussion)

- **Token TTL** — stays at 90 days. Spec said `~1 year` but the justification was thin and 90d covers most realistic clicks; no external standard mandates either.
- **Token consolidation with `MagicLinkService`** — separate implementation; both work; pure refactor for no behavior change.
- **Renaming `UnsubscribeController` → `PreferencesController` / `/preferences`** — the existing surface is fine.

## Test plan

- [x] `dotnet build Humans.slnx -v quiet` clean
- [x] `dotnet test tests/Humans.Application.Tests` — 1888/1888 (4 new unit tests for the Governance-tagged templates: opt-out suppresses + opt-in stamps unsubscribe URL into the body composer)
- [x] `dotnet test tests/Humans.Application.Tests --filter ~CommunicationPreference|~Unsubscribe` — 23/23 (touched-surface unit coverage)
- [x] `dotnet test tests/Humans.Integration.Tests --filter ~Email|~Unsubscribe|~Communication` — 7/7 (touched-surface integration coverage)
- [x] `dotnet format Humans.slnx --verify-no-changes` clean
- [ ] Browser-verify on preview env: click an unsubscribe link in a Governance email → lands on the matrix with the Governance row highlighted + banner shown → one-click unsubscribe flips the checkbox and shows confirmation
- [ ] Browser-verify on preview env: from authenticated session, toggle a checkbox → DB row records `UpdateSource="Guest"` (existing behavior)

## Notes

- Localizer strings added in `SharedResource.resx` only (English). Translations to es/ca/de/fr/it can follow as a separate string-only PR.
- 7 integration tests fail on this branch but **all pre-existing flakies** flagged in #382 (`LoggedIn_Volunteer_can_GET_Calendar`, `ReadinessEndpoint_ReturnsResponse`, `LivenessEndpoint_ReturnsOk`, etc.). None touch the unsubscribe path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)