### PR TITLE
fix: include shift date in voluntold audit messages

### DIFF
--- a/src/Humans.Application/Services/Shifts/ShiftSignupService.cs
+++ b/src/Humans.Application/Services/Shifts/ShiftSignupService.cs
@@ -315,7 +315,7 @@ public sealed class ShiftSignupService : IShiftSignupService, IUserDataContribut
 
         await _auditLogService.LogAsync(
             AuditAction.ShiftSignupVoluntold, nameof(ShiftSignup), signup.Id,
-            $"shift '{shift.Rota.Name}'",
+            $"shift '{shift.Rota.Name}' on {FormatShiftDate(es.GateOpeningDate.PlusDays(shift.DayOffset))}",
             enrollerUserId,
             userId, nameof(User));
 
@@ -442,7 +442,7 @@ public sealed class ShiftSignupService : IShiftSignupService, IUserDataContribut
         {
             await _auditLogService.LogAsync(
                 AuditAction.ShiftSignupVoluntold, nameof(ShiftSignup), auditedSignup.Id,
-                $"'{rota.Name}' day {dayOffset} (range)",
+                $"'{rota.Name}' on {FormatShiftDate(es.GateOpeningDate.PlusDays(dayOffset))} (range)",
                 enrollerUserId,
                 userId, nameof(User));
         }


### PR DESCRIPTION
## Summary
- Voluntold audit entries previously read `shift 'X'` (single) or `'X' day {N} (range)` — unreadable a few months later.
- Now use the existing `FormatShiftDate` helper so they read e.g. `shift 'Cantina Early Crew' on Mon Jun 15` and `'Cantina Early Crew' on Mon Jun 15 (range)`.

## Test plan
- [ ] Voluntell a single shift; confirm the audit entry shows the shift date.
- [ ] Voluntell a range; confirm each per-shift audit entry shows its date instead of `day {N}`.