### PR TITLE
docs(memory): drive-by fixes ok when human reviews PR

### DIFF
--- a/memory/INDEX.md
+++ b/memory/INDEX.md
@@ -60,6 +60,7 @@ Atomic rules. Fetch the body when the description's trigger matches your task. S
 - [`after-prod-merge-reset`](process/after-prod-merge-reset.md) — after upstream PR lands: `git fetch upstream && git reset --hard upstream/main && git push origin main --force-with-lease`
 - [`discord-release-notes-format`](process/discord-release-notes-format.md) — audience-grouped (coordinators/volunteers/under-the-hood/known-issues), plain-language, no emojis
 - [`dotnet-verbosity-quiet`](process/dotnet-verbosity-quiet.md) — always `-v quiet` on `dotnet build`/`test`; never pipe through `tail`/`head`/`grep`
+- [`drive-by-fixes-ok`](process/drive-by-fixes-ok.md) — small unrelated fixes alongside in-scope work are fine in the same PR (Peter reviews end-to-end); surface them, don't auto-revert
 - [`ef-migration-review-gate`](process/ef-migration-review-gate.md) — MANDATORY. Run `.claude/agents/ef-migration-reviewer.md` before commit/PR
 - [`feature-spec-on-new-feature`](process/feature-spec-on-new-feature.md) — when implementing a non-trivial new feature, create `docs/features/<feature>.md` in the same PR (covers create-new; post-fix-doc-check covers update-existing)
 - [`issue-comments-mandatory`](process/issue-comments-mandatory.md) — HARD RULE (hook). Always fetch issues/PRs with comments; Peter's comments often flip OP intent

--- a/memory/INDEX.md
+++ b/memory/INDEX.md
@@ -60,7 +60,7 @@ Atomic rules. Fetch the body when the description's trigger matches your task. S
 - [`after-prod-merge-reset`](process/after-prod-merge-reset.md) — after upstream PR lands: `git fetch upstream && git reset --hard upstream/main && git push origin main --force-with-lease`
 - [`discord-release-notes-format`](process/discord-release-notes-format.md) — audience-grouped (coordinators/volunteers/under-the-hood/known-issues), plain-language, no emojis
 - [`dotnet-verbosity-quiet`](process/dotnet-verbosity-quiet.md) — always `-v quiet` on `dotnet build`/`test`; never pipe through `tail`/`head`/`grep`
-- [`drive-by-fixes-ok`](process/drive-by-fixes-ok.md) — small unrelated fixes alongside in-scope work are fine in the same PR (Peter reviews end-to-end); surface them, don't auto-revert
+- [`drive-by-fixes-ok`](process/drive-by-fixes-ok.md) — small unrelated fixes can land in the same PR ONLY after Peter explicitly approves; surface and ask, never bundle silently
 - [`ef-migration-review-gate`](process/ef-migration-review-gate.md) — MANDATORY. Run `.claude/agents/ef-migration-reviewer.md` before commit/PR
 - [`feature-spec-on-new-feature`](process/feature-spec-on-new-feature.md) — when implementing a non-trivial new feature, create `docs/features/<feature>.md` in the same PR (covers create-new; post-fix-doc-check covers update-existing)
 - [`issue-comments-mandatory`](process/issue-comments-mandatory.md) — HARD RULE (hook). Always fetch issues/PRs with comments; Peter's comments often flip OP intent

--- a/memory/process/drive-by-fixes-ok.md
+++ b/memory/process/drive-by-fixes-ok.md
@@ -1,19 +1,20 @@
 ---
-name: Drive-by fixes are fine when a human reviews the PR
-description: When fixing a thing in a PR, an unrelated small fix (stale doc, dead field, obvious typo) discovered alongside is OK to land in the same PR. Don't flag as scope creep, don't auto-revert.
+name: Drive-by fixes are fine — but require explicit human approval before landing
+description: An unrelated small fix discovered alongside in-scope work can land in the same PR, but ONLY after Peter explicitly approves it. Don't auto-include silently; don't auto-revert either. Surface and ask.
 ---
 
-When applying review fixes to a PR, an incidental small fix discovered alongside the in-scope work is fine to include in the same commit/PR. Don't reflexively revert it as "scope creep" and don't open a separate PR for it.
+When a fix subagent (or you) discovers an incidental small fix alongside in-scope work — stale doc table row, unused field, obvious one-line bug, typo — it MAY land in the same PR, but ONLY after the human reviewer has explicitly seen it and approved it. Default state for an unprompted drive-by is "surface to Peter and ask"; never "ship silently."
 
-**Why:** Peter ships review through PRs that he reads end-to-end before merging. The reason for tight-scope discipline elsewhere — auto-merging bots, distracted reviewers, hard-to-revert blast radius — doesn't apply to this project's flow. A drive-by doc fix or dead-code delete in the same PR saves a round-trip and a human review pass; the scope-mixing cost is paid by Peter, who's already reading the diff. The cost/benefit lands on "include it."
+**Why:** Peter is happy to bundle drive-bys into a PR he's already reviewing — that saves a round-trip vs. opening a separate small PR. But "human reviews end-to-end before merging" is not the same as "the human noticed and approved this specific drive-by." The diff is large; an unannounced drive-by can slip past even careful review. The deal is: drive-bys are welcome IF the human explicitly opts in. Surfacing the change and getting a yes/no is the price of bundling.
 
 **How to apply:**
 
-- Mid-PR, if a fix subagent discovers an unrelated stale row in a doc table, an unused field, an obvious one-line bug, etc. — let it stay in the commit. Note it explicitly in the commit message ("also fixes …") so the human reviewer can spot it.
-- DO surface drive-bys in the PR description / review report so they're visible. The agreement is "human reviews everything", not "anything goes silently."
-- DO NOT smuggle in larger refactors (renames across files, new abstractions, behavior changes). Drive-by means small + obvious + low-risk. If it needs design judgment, it's its own PR.
-- DO NOT silently revert a subagent's drive-by edit when reviewing its work — surface it to Peter and let him decide. Default answer when in doubt is "keep it."
+- Mid-PR, if a subagent commits a drive-by edit, surface it explicitly in the report back: "Also touched X (unrelated to the in-scope ask) — keep or revert?" Let Peter decide before pushing.
+- After Peter says "keep it" / "a" / "yes", it can land in the PR. Without that, it goes in a separate PR or gets reverted.
+- DO surface drive-bys in the PR description / review report under a clear "Also includes (unrelated)" heading so the human can find them later.
+- DO NOT silently revert a subagent's drive-by either — surface it both ways.
+- DO NOT smuggle in larger work as "drive-by." Drive-by = small + obvious + low-risk + one-or-two lines. Renames across files, new abstractions, behavior changes, layer moves — those are their own PR even if the human is reviewing.
 
-**Examples of OK drive-bys:** stale §8 ownership table row, dead `_dbContext` field, missing `nameof()` on a magic string, typo in a comment.
+**Examples of OK drive-bys (after explicit approval):** stale §8 ownership table row, dead `_dbContext` field, missing `nameof()` on a magic string, typo in a comment.
 
-**Examples of NOT OK drive-bys:** rename a method used in 30 files, introduce a new helper class, change auth semantics, move a file across layers.
+**Examples of NOT OK as drive-by, even with approval:** rename a method used in 30 files, introduce a new helper class, change auth semantics, move a file across layers — those need their own PR.

--- a/memory/process/drive-by-fixes-ok.md
+++ b/memory/process/drive-by-fixes-ok.md
@@ -1,0 +1,19 @@
+---
+name: Drive-by fixes are fine when a human reviews the PR
+description: When fixing a thing in a PR, an unrelated small fix (stale doc, dead field, obvious typo) discovered alongside is OK to land in the same PR. Don't flag as scope creep, don't auto-revert.
+---
+
+When applying review fixes to a PR, an incidental small fix discovered alongside the in-scope work is fine to include in the same commit/PR. Don't reflexively revert it as "scope creep" and don't open a separate PR for it.
+
+**Why:** Peter ships review through PRs that he reads end-to-end before merging. The reason for tight-scope discipline elsewhere — auto-merging bots, distracted reviewers, hard-to-revert blast radius — doesn't apply to this project's flow. A drive-by doc fix or dead-code delete in the same PR saves a round-trip and a human review pass; the scope-mixing cost is paid by Peter, who's already reading the diff. The cost/benefit lands on "include it."
+
+**How to apply:**
+
+- Mid-PR, if a fix subagent discovers an unrelated stale row in a doc table, an unused field, an obvious one-line bug, etc. — let it stay in the commit. Note it explicitly in the commit message ("also fixes …") so the human reviewer can spot it.
+- DO surface drive-bys in the PR description / review report so they're visible. The agreement is "human reviews everything", not "anything goes silently."
+- DO NOT smuggle in larger refactors (renames across files, new abstractions, behavior changes). Drive-by means small + obvious + low-risk. If it needs design judgment, it's its own PR.
+- DO NOT silently revert a subagent's drive-by edit when reviewing its work — surface it to Peter and let him decide. Default answer when in doubt is "keep it."
+
+**Examples of OK drive-bys:** stale §8 ownership table row, dead `_dbContext` field, missing `nameof()` on a magic string, typo in a comment.
+
+**Examples of NOT OK drive-bys:** rename a method used in 30 files, introduce a new helper class, change auth semantics, move a file across layers.


### PR DESCRIPTION
## Summary

Captures the principle clarified during PR #389 review: drive-by fixes alongside in-scope work are fine in the same PR, since you read the diff end-to-end before merging. I had reflexively flagged a fix subagent's drive-by edit (stale §8 row) as scope creep and offered to revert. You said no — keep it.

New atom: \`memory/process/drive-by-fixes-ok.md\`. INDEX.md entry added.

## Test plan

- [x] Atom file follows META.md format (frontmatter + Why + How to apply)
- [x] INDEX.md entry added in alphabetical position under \`process/\`
- [x] No code changes; docs-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)