### PR TITLE
fix: split conflated user-not-found-or-no-email Google provisioning warning

### DIFF
--- a/src/Humans.Application/Services/GoogleIntegration/GoogleWorkspaceSyncService.cs
+++ b/src/Humans.Application/Services/GoogleIntegration/GoogleWorkspaceSyncService.cs
@@ -556,7 +556,14 @@ public sealed class GoogleWorkspaceSyncService : IGoogleSyncService
                 .FirstOrDefault();
         if (googleEmail is null)
         {
-            _logger.LogWarning("User {UserId} not found or has no email", userId);
+            if (user is null)
+            {
+                _logger.LogWarning("Skipped Google provisioning for {UserId}: user no longer exists (likely deleted between outbox enqueue and dequeue)", userId);
+            }
+            else
+            {
+                _logger.LogWarning("Skipped Google provisioning for {UserId}: user exists but has no verified email", userId);
+            }
             return;
         }
 


### PR DESCRIPTION
Splits the single `LogWarning("User {UserId} not found or has no email")` in `AddUserToTeamResourcesAsync` into two distinct warnings so log triage can distinguish:

- **User row no longer exists** — race between outbox enqueue and dequeue (expected, low priority)
- **User exists but has no verified email** — real anomaly worth investigating

Uses the existing `usersById` dictionary (already loaded via `GetByIdsWithEmailsAsync`) to determine which case applies — no extra DB hit on the happy path.

Both calls remain at Warning, neither passes an exception arg.

Closes nobodies-collective/Humans#623