### PR TITLE
fix: add matching query filter to CalendarEventException

### DIFF
--- a/docs/sections/Calendar.md
+++ b/docs/sections/Calendar.md
@@ -51,7 +51,7 @@ A community-calendar event belonging to a team. May be a single event or a recur
 
 ### CalendarEventException
 
-Per-occurrence override or cancellation for a recurring `CalendarEvent`. Cascade-deletes with the parent event.
+Per-occurrence override or cancellation for a recurring `CalendarEvent`. Cascade-deletes with the parent event. Inherits the parent's soft-delete via a global EF query filter (`ex => ex.Event.DeletedAt == null`) — exception rows are excluded from all queries when their parent event is soft-deleted, matching `CalendarEvent`'s `DeletedAt` filter.
 
 **Table:** `calendar_event_exceptions`
 
@@ -94,7 +94,7 @@ The calendar is intentionally open: no resource-based authorization gates edit/d
 - `RecurrenceRule` and `RecurrenceTimezone` are set together, or neither is set (all-or-nothing invariant).
 - `RecurrenceTimezone` defaults to `"Europe/Madrid"` if not specified on a recurring event.
 - `RecurrenceUntilUtc` is the last instant the recurrence can possibly produce an occurrence (RRULE `UNTIL` if present, else the end of the `COUNT`-th occurrence computed via Ical.Net, else null for open-ended rules); used for indexable SQL window prefiltering.
-- Soft-delete via `DeletedAt` — a global EF Core query filter hides deleted events from all queries.
+- Soft-delete via `DeletedAt` — a global EF Core query filter hides deleted events from all queries. `CalendarEventException` carries a matching filter (`ex => ex.Event.DeletedAt == null`) so exception rows attached to a soft-deleted event are also hidden; repository writes that need to observe orphaned-by-soft-delete exceptions (e.g. `UpsertExceptionAsync`'s existence lookup, to avoid duplicate-insert against the unique index when the parent is soft-deleted between pre-check and upsert) call `IgnoreQueryFilters()` explicitly.
 - `CalendarEventException` rows cascade-delete with the parent event.
 - Unique index on `(EventId, OriginalOccurrenceStartUtc)` — prevents duplicate exceptions for the same occurrence.
 - Recurrence is expanded in-memory per-request against the event's `RecurrenceTimezone` using `Ical.Net` library (RFC 5545 compliant).

--- a/src/Humans.Infrastructure/Data/Configurations/Calendar/CalendarEventExceptionConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/Calendar/CalendarEventExceptionConfiguration.cs
@@ -18,5 +18,9 @@ public class CalendarEventExceptionConfiguration : IEntityTypeConfiguration<Cale
 
         b.HasIndex(x => new { x.EventId, x.OriginalOccurrenceStartUtc })
          .IsUnique();
+
+        // Match parent CalendarEvent's soft-delete filter so EF doesn't
+        // emit an advisory and orphan exception rows aren't returned.
+        b.HasQueryFilter(ex => ex.Event.DeletedAt == null);
     }
 }

--- a/src/Humans.Infrastructure/Repositories/Calendar/CalendarRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Calendar/CalendarRepository.cs
@@ -121,7 +121,13 @@ public sealed class CalendarRepository : ICalendarRepository
     {
         await using var ctx = await _factory.CreateDbContextAsync(ct);
 
+        // Bypass the soft-delete query filter on the existence lookup so that if
+        // the parent event was soft-deleted between the caller's pre-check and
+        // this upsert, an existing exception row for the same
+        // (EventId, OriginalOccurrenceStartUtc) is still found and updated
+        // instead of triggering a duplicate-insert against the unique index.
         var existing = await ctx.CalendarEventExceptions
+            .IgnoreQueryFilters()
             .FirstOrDefaultAsync(
                 x => x.EventId == eventId && x.OriginalOccurrenceStartUtc == originalOccurrenceStartUtc,
                 ct);


### PR DESCRIPTION
Adds `HasQueryFilter(ex => ex.Event.DeletedAt == null)` on `CalendarEventException` to mirror the parent `CalendarEvent` soft-delete filter.

This silences the EF advisory about mismatched query filters and ensures exception rows for soft-deleted parent events are not returned by EF queries.

Closes nobodies-collective/Humans#621