### PR TITLE
fix: skip Stripe enrichment for placeholder '--' PaymentIntent and quiet noisy stack trace

### DIFF
--- a/src/Humans.Application/Services/Tickets/TicketSyncService.cs
+++ b/src/Humans.Application/Services/Tickets/TicketSyncService.cs
@@ -373,9 +373,17 @@ public sealed class TicketSyncService : ITicketSyncService, IUserMerge
         var updated = new List<TicketOrder>(ordersToEnrich.Count);
         foreach (var order in ordersToEnrich)
         {
+            // Belt-and-suspenders: skip placeholder PaymentIntent ids the
+            // repository filter should already exclude.
+            if (string.IsNullOrEmpty(order.StripePaymentIntentId)
+                || string.Equals(order.StripePaymentIntentId, "--", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
             try
             {
-                var details = await _stripeService.GetPaymentDetailsAsync(order.StripePaymentIntentId!, ct);
+                var details = await _stripeService.GetPaymentDetailsAsync(order.StripePaymentIntentId, ct);
                 if (details is null) continue;
 
                 order.PaymentMethod = details.PaymentMethod;
@@ -386,9 +394,9 @@ public sealed class TicketSyncService : ITicketSyncService, IUserMerge
             }
             catch (Exception ex)
             {
-                _logger.LogWarning(ex,
-                    "Failed to fetch Stripe data for order {OrderId} (PI: {PaymentIntentId})",
-                    order.VendorOrderId, order.StripePaymentIntentId);
+                _logger.LogWarning(
+                    "Failed to fetch Stripe data for order {OrderId} (PI: {PaymentIntentId}): {Reason}",
+                    order.VendorOrderId, order.StripePaymentIntentId, ex.Message);
             }
         }
 

--- a/src/Humans.Infrastructure/Repositories/Tickets/TicketRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Tickets/TicketRepository.cs
@@ -128,7 +128,9 @@ public sealed class TicketRepository : ITicketRepository
         await using var ctx = await _factory.CreateDbContextAsync(ct);
         return await ctx.TicketOrders
             .AsNoTracking()
-            .Where(o => o.StripePaymentIntentId != null && o.StripeFee == null)
+            .Where(o => o.StripePaymentIntentId != null
+                        && o.StripePaymentIntentId != "--"
+                        && o.StripeFee == null)
             .ToListAsync(ct);
     }
 


### PR DESCRIPTION
Two related changes to suppress noisy Stripe enrichment failures for orders that were imported with a placeholder `'--'` PaymentIntent id:

1. **Repository filter** — `TicketRepository.GetOrdersNeedingStripeEnrichmentAsync` now excludes orders whose `StripePaymentIntentId` equals `'--'` so they never reach the Stripe call.
2. **Service-side belt-and-suspenders** — `TicketSyncService.EnrichOrdersWithStripeDataAsync` skips the same orders defensively before calling Stripe.
3. **Quieter exception log** — the catch around the Stripe call now logs at Warning **without** the exception object, using `ex.Message` as a structured `{Reason}` instead of dumping a full stack trace into logs for what's typically a recoverable enrichment miss.

Closes nobodies-collective/Humans#620