### PR TITLE
fix: allow localhost / 127.0.0.1 dev origins for /api/barrios CORS

### DIFF
--- a/src/Humans.Web/Program.cs
+++ b/src/Humans.Web/Program.cs
@@ -440,12 +440,19 @@ builder.Services.AddSession(options =>
 // Configure Localization
 builder.Services.AddLocalization();
 
-// CORS — allow the public nobodies.team website to fetch /api/barrios
+// CORS — allow the public nobodies.team website to fetch /api/barrios.
+// Localhost / 127.0.0.1 (any port) are allowed so devs working on the
+// public site locally can hit the deployed barrios API.
 builder.Services.AddCors(options =>
 {
     options.AddPolicy("BarriosPublic", policy =>
     {
         policy.WithOrigins("https://nobodies.team", "https://www.nobodies.team")
+            .SetIsOriginAllowed(origin =>
+                origin.StartsWith("http://localhost:", StringComparison.Ordinal) ||
+                origin.StartsWith("http://127.0.0.1:", StringComparison.Ordinal) ||
+                string.Equals(origin, "https://nobodies.team", StringComparison.Ordinal) ||
+                string.Equals(origin, "https://www.nobodies.team", StringComparison.Ordinal))
             .WithMethods("GET")
             .WithHeaders("Content-Type", "Accept");
     });

--- a/src/Humans.Web/Program.cs
+++ b/src/Humans.Web/Program.cs
@@ -447,8 +447,10 @@ builder.Services.AddCors(options =>
 {
     options.AddPolicy("BarriosPublic", policy =>
     {
-        policy.WithOrigins("https://nobodies.team", "https://www.nobodies.team")
-            .SetIsOriginAllowed(origin =>
+        // SetIsOriginAllowed is the sole origin gate — when set, ASP.NET's
+        // CorsService ignores the WithOrigins list entirely, so the lambda
+        // must cover all four allowed origins (prod + localhost dev).
+        policy.SetIsOriginAllowed(origin =>
                 origin.StartsWith("http://localhost:", StringComparison.Ordinal) ||
                 origin.StartsWith("http://127.0.0.1:", StringComparison.Ordinal) ||
                 string.Equals(origin, "https://nobodies.team", StringComparison.Ordinal) ||


### PR DESCRIPTION
Extends the `BarriosPublic` CORS policy (added in PR #577 scoped to `https://nobodies.team`) to also allow `http://localhost:*` and `http://127.0.0.1:*` dev origins so devs working on the public site locally can hit the deployed barrios API.

Implementation: keep `WithOrigins` for the named production origins and add `SetIsOriginAllowed` for the prefix-matched dev origins (and the named origins, since EF/CORS evaluates the predicate when present). `AllowAnyOrigin` is intentionally not used — CORS surface stays narrow even though the data is public-read.

Scope is limited to the barrios policy; no global CORS surface change.

Ping @micho on merge — he asked.

Closes nobodies-collective/Humans#610