### PR TITLE
fix: grant fileOrganizer (not writer) on linked Drive resources so team members can move/delete files

### DIFF
--- a/src/Humans.Application/Interfaces/Teams/ITeamResourceService.cs
+++ b/src/Humans.Application/Interfaces/Teams/ITeamResourceService.cs
@@ -85,19 +85,19 @@ public interface ITeamResourceService
     /// Links an existing Google Drive folder to a team by URL.
     /// The folder must be pre-shared with the service account as Editor.
     /// </summary>
-    Task<LinkResourceResult> LinkDriveFolderAsync(Guid teamId, string folderUrl, DrivePermissionLevel permissionLevel = DrivePermissionLevel.Contributor, CancellationToken ct = default);
+    Task<LinkResourceResult> LinkDriveFolderAsync(Guid teamId, string folderUrl, DrivePermissionLevel permissionLevel = DrivePermissionLevel.ContentManager, CancellationToken ct = default);
 
     /// <summary>
     /// Links an existing Google Drive file (Sheet, Doc, etc.) to a team by URL.
     /// The file must be on a Shared Drive pre-shared with the service account.
     /// </summary>
-    Task<LinkResourceResult> LinkDriveFileAsync(Guid teamId, string fileUrl, DrivePermissionLevel permissionLevel = DrivePermissionLevel.Contributor, CancellationToken ct = default);
+    Task<LinkResourceResult> LinkDriveFileAsync(Guid teamId, string fileUrl, DrivePermissionLevel permissionLevel = DrivePermissionLevel.ContentManager, CancellationToken ct = default);
 
     /// <summary>
     /// Links a Google Drive resource (folder or file) to a team by URL.
     /// Automatically detects the resource type from the URL and routes accordingly.
     /// </summary>
-    Task<LinkResourceResult> LinkDriveResourceAsync(Guid teamId, string url, DrivePermissionLevel permissionLevel = DrivePermissionLevel.Contributor, CancellationToken ct = default);
+    Task<LinkResourceResult> LinkDriveResourceAsync(Guid teamId, string url, DrivePermissionLevel permissionLevel = DrivePermissionLevel.ContentManager, CancellationToken ct = default);
 
     /// <summary>
     /// Links an existing Google Group to a team by email address.

--- a/src/Humans.Application/Services/GoogleIntegration/GoogleWorkspaceSyncService.cs
+++ b/src/Humans.Application/Services/GoogleIntegration/GoogleWorkspaceSyncService.cs
@@ -1216,7 +1216,7 @@ public sealed class GoogleWorkspaceSyncService : IGoogleSyncService
                 {
                     try
                     {
-                        var memberLevel = ParseApiRole(member.ExpectedRole) ?? DrivePermissionLevel.Contributor;
+                        var memberLevel = ParseApiRole(member.ExpectedRole) ?? DrivePermissionLevel.ContentManager;
                         await AddUserToDriveAsync(primary, member.Email, memberLevel, cancellationToken);
                     }
                     catch (Exception ex)
@@ -2008,7 +2008,7 @@ public sealed class GoogleWorkspaceSyncService : IGoogleSyncService
         var userTeams = await _teamService.GetUserTeamsAsync(userId, cancellationToken);
         var userTeamIds = userTeams.Where(tm => tm.LeftAt is null).Select(tm => tm.TeamId).ToHashSet();
         if (userTeamIds.Count == 0)
-            return DrivePermissionLevel.Contributor;
+            return DrivePermissionLevel.ContentManager;
 
         // Which of those teams have an active resource with this Google id?
         var resourcesByTeam = await _resourceRepository.GetActiveByTeamIdsAsync(userTeamIds.ToList(), cancellationToken);
@@ -2019,7 +2019,7 @@ public sealed class GoogleWorkspaceSyncService : IGoogleSyncService
             .Select(r => r.DrivePermissionLevel)
             .ToList();
 
-        return levels.Count == 0 ? DrivePermissionLevel.Contributor : levels.Max();
+        return levels.Count == 0 ? DrivePermissionLevel.ContentManager : levels.Max();
     }
 
     /// <summary>

--- a/src/Humans.Application/Services/GoogleIntegration/GoogleWorkspaceSyncService.cs
+++ b/src/Humans.Application/Services/GoogleIntegration/GoogleWorkspaceSyncService.cs
@@ -1216,7 +1216,7 @@ public sealed class GoogleWorkspaceSyncService : IGoogleSyncService
                 {
                     try
                     {
-                        var memberLevel = ParseApiRole(member.ExpectedRole) ?? DrivePermissionLevel.ContentManager;
+                        var memberLevel = ParseApiRole(member.ExpectedRole) ?? DrivePermissionLevel.Contributor;
                         await AddUserToDriveAsync(primary, member.Email, memberLevel, cancellationToken);
                     }
                     catch (Exception ex)
@@ -2008,7 +2008,7 @@ public sealed class GoogleWorkspaceSyncService : IGoogleSyncService
         var userTeams = await _teamService.GetUserTeamsAsync(userId, cancellationToken);
         var userTeamIds = userTeams.Where(tm => tm.LeftAt is null).Select(tm => tm.TeamId).ToHashSet();
         if (userTeamIds.Count == 0)
-            return DrivePermissionLevel.ContentManager;
+            return DrivePermissionLevel.Contributor;
 
         // Which of those teams have an active resource with this Google id?
         var resourcesByTeam = await _resourceRepository.GetActiveByTeamIdsAsync(userTeamIds.ToList(), cancellationToken);
@@ -2019,7 +2019,7 @@ public sealed class GoogleWorkspaceSyncService : IGoogleSyncService
             .Select(r => r.DrivePermissionLevel)
             .ToList();
 
-        return levels.Count == 0 ? DrivePermissionLevel.ContentManager : levels.Max();
+        return levels.Count == 0 ? DrivePermissionLevel.Contributor : levels.Max();
     }
 
     /// <summary>

--- a/src/Humans.Application/Services/Teams/TeamResourceService.cs
+++ b/src/Humans.Application/Services/Teams/TeamResourceService.cs
@@ -158,7 +158,7 @@ public sealed partial class TeamResourceService : ITeamResourceService
     public async Task<LinkResourceResult> LinkDriveFolderAsync(
         Guid teamId,
         string folderUrl,
-        DrivePermissionLevel permissionLevel = DrivePermissionLevel.Contributor,
+        DrivePermissionLevel permissionLevel = DrivePermissionLevel.ContentManager,
         CancellationToken ct = default)
     {
         var folderId = ParseDriveFolderId(folderUrl);
@@ -224,7 +224,7 @@ public sealed partial class TeamResourceService : ITeamResourceService
     public async Task<LinkResourceResult> LinkDriveFileAsync(
         Guid teamId,
         string fileUrl,
-        DrivePermissionLevel permissionLevel = DrivePermissionLevel.Contributor,
+        DrivePermissionLevel permissionLevel = DrivePermissionLevel.ContentManager,
         CancellationToken ct = default)
     {
         var fileId = ParseDriveFileId(fileUrl);
@@ -286,7 +286,7 @@ public sealed partial class TeamResourceService : ITeamResourceService
     public async Task<LinkResourceResult> LinkDriveResourceAsync(
         Guid teamId,
         string url,
-        DrivePermissionLevel permissionLevel = DrivePermissionLevel.Contributor,
+        DrivePermissionLevel permissionLevel = DrivePermissionLevel.ContentManager,
         CancellationToken ct = default)
     {
         if (ParseDriveFolderId(url) is not null)

--- a/src/Humans.Web/Models/TeamResourceViewModels.cs
+++ b/src/Humans.Web/Models/TeamResourceViewModels.cs
@@ -34,7 +34,7 @@ public class LinkDriveResourceModel
     [Required(ErrorMessage = "Please enter a Google Drive URL.")]
     public string ResourceUrl { get; set; } = string.Empty;
 
-    public DrivePermissionLevel PermissionLevel { get; set; } = DrivePermissionLevel.Contributor;
+    public DrivePermissionLevel PermissionLevel { get; set; } = DrivePermissionLevel.ContentManager;
 }
 
 public class LinkGroupModel


### PR DESCRIPTION
Bumps the default `DrivePermissionLevel` granted to team members on linked Drive resources from `Contributor` (`writer`) to `ContentManager` (`fileOrganizer`).

Why: `writer` blocks delete/move, which has been confusing for team members. `fileOrganizer` is the lowest Google Drive role that allows organizing (move, delete) within a Shared Drive — the right floor for trusted team members.

Changes:
- `LinkDriveResourceModel.PermissionLevel` default → `ContentManager`
- `ITeamResourceService.LinkDriveFolderAsync` / `LinkDriveFileAsync` / `LinkDriveResourceAsync` default param → `ContentManager`
- `TeamResourceService` impl signatures match
- `GoogleWorkspaceSyncService.ResolvePermissionLevelForUserAsync` fallbacks → `ContentManager`
- Reconciliation fallback when `ParseApiRole(member.ExpectedRole)` returns null → `ContentManager`

The `ContentManager → "fileOrganizer"` enum mapping was already in place (`DrivePermissionLevelExtensions.ToApiRole`).

**Existing resources do not auto-bump.** Existing `GoogleResource` rows keep their stored `DrivePermissionLevel` (mostly `Contributor`). Reconciliation re-applies the *resource's stored* level, not the new default — so already-linked resources will continue to grant `writer` until explicitly relinked / level updated. No separate admin button added per the issue acceptance.

Reporter: Anyall (2026-04-28). Feedback ID: `fb:0545bf5e` — Peter will follow up.

Closes nobodies-collective/Humans#616