### PR TITLE
ci: auto-review fork PRs from trusted authors

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -10,22 +10,33 @@ name: Claude PR Review
 # between the two repos:
 #
 #   peterdrier/Humans
-#     Trigger: pull_request (same-repo PRs only).
-#     Auth:    OIDC → claude[bot] App token (default).
-#     Fork PRs to peterdrier/Humans are deliberately not reviewed; run
-#     `/pr-review <num>` locally instead.
+#     Trigger: pull_request for same-repo PRs (collaborator pushed branch
+#              directly to peterdrier/Humans), pull_request_target for
+#              fork PRs from trusted authors (OWNER/MEMBER/COLLABORATOR
+#              per GitHub's author_association). Random external forks
+#              are skipped — pull_request_target with a checkout of
+#              attacker-controlled code would be a "pwn-request" hole.
+#     Auth:    OIDC → claude[bot] App token on pull_request (default);
+#              workflow GITHUB_TOKEN on pull_request_target (see #713
+#              below).
 #
 #   nobodies-collective/Humans
 #     Trigger: pull_request_target, only when the head is peterdrier/Humans
 #              (the QA-promotion path). Random external forks are skipped —
-#              pull_request_target with a checkout of attacker-controlled
-#              code would be a "pwn-request" hole.
+#              same pwn-request reason.
 #     Auth:    Workflow GITHUB_TOKEN. Anthropic's OIDC → App-token exchange
 #              currently 401s on pull_request_target events
 #              (anthropics/claude-code-action#713); passing github_token
 #              tells the action to skip OIDC and post as github-actions[bot].
 #     Checkout: base ref (default), per the action's docs/security.md —
 #               do NOT check out the PR head into the workspace root.
+#
+# Why pull_request_target stays safe: the pwn-request hole only opens if
+# you `actions/checkout` the PR head and execute code from it (build,
+# test, install). This workflow checks out the BASE ref (default for
+# pull_request_target) and reads the PR diff via the GitHub API through
+# the action — fork code never runs locally. Do NOT add build/test steps
+# to this job.
 #
 # Setup (one-time, per repo):
 #   1. `claude setup-token` locally → copy the OAuth token.
@@ -46,6 +57,12 @@ jobs:
         (github.event_name == 'pull_request'
           && github.repository == 'peterdrier/Humans'
           && github.event.pull_request.head.repo.full_name == github.repository)
+        ||
+        (github.event_name == 'pull_request_target'
+          && github.repository == 'peterdrier/Humans'
+          && github.event.pull_request.head.repo.full_name != github.repository
+          && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
+                      github.event.pull_request.author_association))
         ||
         (github.event_name == 'pull_request_target'
           && github.repository == 'nobodies-collective/Humans'


### PR DESCRIPTION
## Summary

- Extends the `claude-review.yml` `if:` guard so `pull_request_target` events also run the auto-review when the PR head is on a fork **and** the author is `OWNER` / `MEMBER` / `COLLABORATOR` (per GitHub's `author_association`).
- Same-repo PR path is unchanged. `nobodies-collective/Humans` promotion path is unchanged.
- Header comment rewritten to document the new gate and the pwn-request reasoning (we never `actions/checkout` the PR head, never execute fork code locally).

## Why

Right now PRs from external collaborators' forks (e.g. `laugongim/Humans` → `peterdrier/Humans`) skip the workflow because the existing same-repo guard only fires when the branch is pushed directly to `peterdrier/Humans`. Adding someone as a collaborator should be enough to opt their PRs into the review without asking them to push to our base repo. `author_association` does that without a hardcoded fork list.

## Test plan

- [ ] Open a fresh PR from a collaborator's fork → `claude-review` job runs and posts a summary
- [ ] Open a PR from a non-collaborator fork → `claude-review` job is skipped
- [ ] Existing same-repo PR (e.g. `chore/...` branch on `peterdrier/Humans`) still runs `claude-review` once (no duplicate from the new clause, since `head.repo == base.repo` excludes it)
- [ ] Promote-to-prod PR (`peterdrier/Humans` → `nobodies-collective/Humans`) still runs review on the upstream side