### PR TITLE
issue-643: guard /Shifts/Bail against already-bailed signups

### DIFF
--- a/src/Humans.Application/Services/Shifts/ShiftSignupService.cs
+++ b/src/Humans.Application/Services/Shifts/ShiftSignupService.cs
@@ -242,9 +242,6 @@ public sealed class ShiftSignupService : IShiftSignupService, IUserDataContribut
         var signup = await _repo.GetByIdForMutationAsync(signupId);
         if (signup is null) return SignupResult.Fail("Signup not found.");
 
-        if (signup.Status == SignupStatus.Bailed)
-            return SignupResult.Fail("This signup has already been bailed.");
-
         var es = signup.Shift.Rota.EventSettings;
         var now = _clock.GetCurrentInstant();
         var isOwner = signup.UserId == actorUserId;
@@ -253,6 +250,12 @@ public sealed class ShiftSignupService : IShiftSignupService, IUserDataContribut
         // Authorization: must be signup owner or privileged (dept coordinator/NoInfoAdmin/Admin)
         if (!isOwner && !isPrivileged)
             return SignupResult.Fail("Not authorized to bail this signup.");
+
+        if (signup.Status == SignupStatus.Bailed)
+        {
+            _logger.LogWarning("Bail attempted on already-bailed signup {SignupId} by actor {ActorUserId}", signupId, actorUserId);
+            return SignupResult.Fail("This signup has already been bailed.");
+        }
 
         // EE freeze check for build shifts
         if (signup.Shift.IsEarlyEntry && es.EarlyEntryClose.HasValue && now >= es.EarlyEntryClose.Value && !isPrivileged)

--- a/src/Humans.Application/Services/Shifts/ShiftSignupService.cs
+++ b/src/Humans.Application/Services/Shifts/ShiftSignupService.cs
@@ -242,6 +242,9 @@ public sealed class ShiftSignupService : IShiftSignupService, IUserDataContribut
         var signup = await _repo.GetByIdForMutationAsync(signupId);
         if (signup is null) return SignupResult.Fail("Signup not found.");
 
+        if (signup.Status == SignupStatus.Bailed)
+            return SignupResult.Fail("This signup has already been bailed.");
+
         var es = signup.Shift.Rota.EventSettings;
         var now = _clock.GetCurrentInstant();
         var isOwner = signup.UserId == actorUserId;


### PR DESCRIPTION
Closes nobodies-collective/Humans#643

## Summary
Repeat calls to `POST /Shifts/Bail` for an already-`Bailed` signup (double-click, back-button replay, duplicate tab) returned 500 because the domain method throws `InvalidOperationException`. Adds an early `SignupResult.Fail("This signup has already been bailed.")` in `ShiftSignupService.BailAsync` so the controller redirects with friendly TempData instead.

Domain method `ShiftSignup.Bail` keeps its defensive throw — only the service-layer guard changes.

## Test plan
- [ ] Bail an already-bailed signup → friendly error TempData on redirect, not 500
- [ ] Bailing a Confirmed/Pending signup still works
- [ ] Error channel no longer logs `InvalidOperationException: Cannot bail signup in Bailed state`