### PR TITLE
issue-647: include rejected email in 'Rejected email add' warnings

### DIFF
--- a/src/Humans.Web/Controllers/ProfileController.cs
+++ b/src/Humans.Web/Controllers/ProfileController.cs
@@ -612,7 +612,9 @@ public class ProfileController : HumansControllerBase
         }
         catch (ValidationException ex)
         {
-            _logger.LogWarning("Rejected email add for user {UserId}: {Reason}", user.Id, ex.Message);
+            _logger.LogWarning(
+                "Rejected email add for user {UserId} ({Email}): {Reason}",
+                user.Id, model.NewEmail, ex.Message);
             ModelState.AddModelError(nameof(model.NewEmail), ex.Message);
             return View(nameof(Emails), await BuildEmailsViewModelAsync(user));
         }
@@ -1033,7 +1035,10 @@ public class ProfileController : HumansControllerBase
         }
         catch (Exception ex) when (ex is ValidationException or InvalidOperationException)
         {
-            _logger.LogWarning(ex, "Admin failed to add email for user {UserId}: {Reason}", id, ex.Message);
+            _logger.LogWarning(
+                ex,
+                "Admin failed to add email for user {UserId} ({Email}): {Reason}",
+                id, email, ex.Message);
             SetError(ex.Message);
         }
 

--- a/src/Humans.Web/Controllers/ProfileController.cs
+++ b/src/Humans.Web/Controllers/ProfileController.cs
@@ -1036,7 +1036,6 @@ public class ProfileController : HumansControllerBase
         catch (Exception ex) when (ex is ValidationException or InvalidOperationException)
         {
             _logger.LogWarning(
-                ex,
                 "Admin failed to add email for user {UserId} ({Email}): {Reason}",
                 id, email, ex.Message);
             SetError(ex.Message);


### PR DESCRIPTION
Closes nobodies-collective/Humans#647

## Summary
Self-add and admin-add `ValidationException` catches in `ProfileController` logged user ID and reason but omitted the rejected email — leaving support unable to identify which email collided. Adds `{Email}` as a structured property on both warning calls.

- Self-add (line 615) — no exception arg per spec
- Admin-add (line 1036) — keeps existing exception arg (consistent with the rest of admin email-mutation logs in this file)

## Test plan
- [ ] Trigger a rejected self-add → log line contains the rejected email as a structured property
- [ ] Trigger a rejected admin-add → same