### PR TITLE
issue-640: move Store from top nav to Camp Edit page card

### DIFF
--- a/src/Humans.Web/Views/Camp/Edit.cshtml
+++ b/src/Humans.Web/Views/Camp/Edit.cshtml
@@ -251,6 +251,20 @@
     </div>
 
     <div class="col-md-4">
+        <div class="card mb-4">
+            <div class="card-header">
+                <i class="fa-solid fa-cart-shopping me-1"></i> Store
+            </div>
+            <div class="card-body">
+                <p class="card-text small text-muted mb-3">
+                    Place an order for this camp.
+                </p>
+                <a asp-controller="Store" asp-action="Index" class="btn btn-primary">
+                    <i class="fa-solid fa-cart-shopping me-1"></i> Open store
+                </a>
+            </div>
+        </div>
+
         @* Add active member (issue nobodies-collective#489) *@
         @if (Model.RolesPanel is not null && Model.RolesPanel.CanManage)
         {

--- a/src/Humans.Web/Views/Shared/_Layout.cshtml
+++ b/src/Humans.Web/Views/Shared/_Layout.cshtml
@@ -92,9 +92,6 @@
                         <li class="nav-item">
                             <a class="nav-link" asp-area="" asp-controller="Camp" asp-action="Index">@Localizer["Camp_Plural"]</a>
                         </li>
-                        <li class="nav-item" authorize-policy="IsActiveMember">
-                            <a class="nav-link" asp-area="" asp-controller="Store" asp-action="Index">Store</a>
-                        </li>
                         <li class="nav-item">
                             <a class="nav-link" asp-area="" asp-controller="Team" asp-action="Index">@Localizer["Nav_Teams"]</a>
                         </li>


### PR DESCRIPTION
Closes nobodies-collective/Humans#640

## Summary
Store is scoped to a camp — every order picks a camp. Surfacing it as a top-level nav for all active members is wrong placement. Camp leads already navigate via the edit page.

- Removes the Store `<li>` from `_Layout.cshtml`
- Adds a Store card at the top of the right column of `/Barrios/{slug}/Edit` with a primary "Open store" button linking to `StoreController.Index`
- No authorization changes — `IsActiveMember` gate on the controller is unchanged

## Test plan
- [ ] Visit `/Barrios/yes/Edit` (preview) — Store card present at top of right column, primary button links to `/Store`
- [ ] Top nav no longer shows Store link