### PR TITLE
issue-642: catch OperationCanceledException in profile/home reads

### DIFF
--- a/src/Humans.Web/Controllers/HomeController.cs
+++ b/src/Humans.Web/Controllers/HomeController.cs
@@ -41,6 +41,21 @@ public class HomeController : HumansControllerBase
 
     public async Task<IActionResult> Index(CancellationToken cancellationToken)
     {
+        try
+        {
+            return await IndexCore(cancellationToken);
+        }
+        catch (OperationCanceledException) when (HttpContext.RequestAborted.IsCancellationRequested)
+        {
+            // Client aborted the request mid-read. Don't surface as 500/Error;
+            // log at Warning without the exception object.
+            _logger.LogWarning("Request aborted while rendering home dashboard");
+            return new EmptyResult();
+        }
+    }
+
+    private async Task<IActionResult> IndexCore(CancellationToken cancellationToken)
+    {
         if (!User.Identity?.IsAuthenticated ?? true)
         {
             return View();

--- a/src/Humans.Web/Controllers/ProfileController.cs
+++ b/src/Humans.Web/Controllers/ProfileController.cs
@@ -1381,13 +1381,24 @@ public class ProfileController : HumansControllerBase
         // store directly — IProfileService owns the FS-first / DB-fallback /
         // migrate-on-read orchestration AND the anonymization gate (issue
         // nobodies-collective/Humans#527).
-        var result = await _profileService.GetProfilePictureAsync(id, ct);
-        if (result is null)
+        try
         {
-            return NotFound();
-        }
+            var result = await _profileService.GetProfilePictureAsync(id, ct);
+            if (result is null)
+            {
+                return NotFound();
+            }
 
-        return File(result.Value.Data, result.Value.ContentType);
+            return File(result.Value.Data, result.Value.ContentType);
+        }
+        catch (OperationCanceledException) when (HttpContext.RequestAborted.IsCancellationRequested)
+        {
+            // Client aborted the request mid-read. Don't surface as 500/Error;
+            // log at Warning without the exception object so the prod log viewer
+            // still sees the event but the stack-trace noise is dropped.
+            _logger.LogWarning("Request aborted while reading profile picture for {ProfileId}", id);
+            return new EmptyResult();
+        }
     }
 
     [HttpPost("Me/ImportGooglePhoto")]
@@ -1584,33 +1595,43 @@ public class ProfileController : HumansControllerBase
     [HttpGet("{id:guid}/Popover")]
     public async Task<IActionResult> Popover(Guid id, CancellationToken ct)
     {
-        var profile = await _profileService.GetProfileAsync(id, ct);
-        if (profile is null) return NotFound();
-
-        var popoverUser = await _userService.GetByIdAsync(id, ct);
-        var teams = await _teamService.GetActiveTeamNamesForUserAsync(id, ct);
-
-        var effectivePictureUrl = profile.HasCustomProfilePicture
-            ? Url.Action(nameof(Picture), "Profile",
-                new { id = profile.Id, v = profile.UpdatedAt.ToUnixTimeTicks() })
-            : popoverUser?.ProfilePictureUrl;
-
-        var vm = new ProfileSummaryViewModel
+        try
         {
-            UserId = id,
-            DisplayName = popoverUser?.DisplayName ?? "Unknown",
-            Email = popoverUser?.Email,
-            ProfilePictureUrl = effectivePictureUrl,
-            MembershipTier = profile.MembershipTier.ToString(),
-            MembershipStatus = profile.IsSuspended ? "Suspended"
-                : profile.IsApproved ? "Active" : "Pending",
-            City = profile.City,
-            CountryCode = profile.CountryCode,
-            IsSuspended = profile.IsSuspended,
-            Teams = teams.ToList()
-        };
+            var profile = await _profileService.GetProfileAsync(id, ct);
+            if (profile is null) return NotFound();
 
-        return PartialView("_HumanPopover", vm);
+            var popoverUser = await _userService.GetByIdAsync(id, ct);
+            var teams = await _teamService.GetActiveTeamNamesForUserAsync(id, ct);
+
+            var effectivePictureUrl = profile.HasCustomProfilePicture
+                ? Url.Action(nameof(Picture), "Profile",
+                    new { id = profile.Id, v = profile.UpdatedAt.ToUnixTimeTicks() })
+                : popoverUser?.ProfilePictureUrl;
+
+            var vm = new ProfileSummaryViewModel
+            {
+                UserId = id,
+                DisplayName = popoverUser?.DisplayName ?? "Unknown",
+                Email = popoverUser?.Email,
+                ProfilePictureUrl = effectivePictureUrl,
+                MembershipTier = profile.MembershipTier.ToString(),
+                MembershipStatus = profile.IsSuspended ? "Suspended"
+                    : profile.IsApproved ? "Active" : "Pending",
+                City = profile.City,
+                CountryCode = profile.CountryCode,
+                IsSuspended = profile.IsSuspended,
+                Teams = teams.ToList()
+            };
+
+            return PartialView("_HumanPopover", vm);
+        }
+        catch (OperationCanceledException) when (HttpContext.RequestAborted.IsCancellationRequested)
+        {
+            // Client aborted the request mid-read. Don't surface as 500/Error;
+            // log at Warning without the exception object.
+            _logger.LogWarning("Request aborted while loading popover for {ProfileId}", id);
+            return new EmptyResult();
+        }
     }
 
     [HttpGet("{id:guid}/SendMessage")]


### PR DESCRIPTION
Closes nobodies-collective/Humans#642

## Summary

Aborted requests to `GET /Profile/Picture`, `GET /Profile/{id}/Popover`, and `GET /` were surfacing in production logs as 500 Errors with full Npgsql/EF stack traces, because EF binds queries to `HttpContext.RequestAborted` and `OperationCanceledException` propagates up to the framework. ~64 such occurrences in a recent buffer, vast majority on `/Profile/Picture`.

## Changes

- `ProfileController.Picture`, `ProfileController.Popover`: wrap action body in try/catch on `OperationCanceledException` filtered by `HttpContext.RequestAborted.IsCancellationRequested`. Return `EmptyResult`. Log at `LogWarning` with structured `{ProfileId}` and **no exception object** (drops the stack-trace noise but keeps the event visible in the prod log viewer).
- `HomeController.Index`: same treatment via a thin wrapper that delegates to `IndexCore`. Avoided refactoring the action body further.

Real (non-cancellation) DB errors still propagate to the Error channel — only client-aborted reads short-circuit.

## Acceptance criteria

- [x] Aborted picture requests no longer return 500 / hit Error channel
- [x] Warning has structured props and no Exception arg
- [x] `/` and `/Profile/{id}/Popover` get the same handling
- [x] Real DB errors still log at Error