### PR TITLE
issue-604: e2e admin shell + sidebar coverage

### DIFF
--- a/docs/sections/admin-shell.md
+++ b/docs/sections/admin-shell.md
@@ -19,23 +19,23 @@ The admin shell applies to all routes under `/Admin`. The `AdminLayout.cshtml` l
 
 ## Actors & Roles
 
+Sidebar groups: Operations, Members, Money, Governance, Integrations, Agent, People data, Diagnostics (and Dev — env-gated to `!IsProduction()`). Source of truth is `AdminNavTree.cs`; the per-role expected items below are pinned by `tests/e2e/tests/admin-shell.spec.ts` (`sidebarMatrix`).
+
 | Actor | Capabilities |
 |-------|--------------|
-| Admin | Full access to all sidebar groups and items |
-| Board | Access to Governance and Users sidebar groups |
-| HumanAdmin | Access to Users, Profiles, and Onboarding sidebar groups |
-| FinanceAdmin | Access to Budget sidebar group |
-| TicketAdmin | Access to Tickets sidebar group |
-| TeamsAdmin | Access to Teams sidebar group |
-| CampAdmin | Access to Camps sidebar group |
-| FeedbackAdmin | Access to Feedback sidebar group |
-| NoInfoAdmin | Access to Users sidebar group (read-only admin view) |
-| VolunteerCoordinator | Access to Onboarding review queue sidebar item |
-| ConsentCoordinator | Access to Onboarding consent review sidebar item |
+| Admin | Full access — every group and every item |
+| Board | Operations (Tickets, Scanner), Members (Humans, Review), Governance (Voting, Board) |
+| HumanAdmin | Members (Humans) |
+| TicketAdmin | Operations (Tickets, Scanner) |
+| FinanceAdmin | Money (Finance, Store catalog) |
+| StoreAdmin | Money (Store catalog) |
+| ConsentCoordinator | Members (Review) |
+| VolunteerCoordinator | Members (Review) |
+| TeamsAdmin / CampAdmin / FeedbackAdmin / NoInfoAdmin | Reach the `/Admin` dashboard (member of `AnyAdminRole`) but have no sidebar items in the current tree — they act via the dashboard tiles and any direct links from member-facing pages |
 
 ## Invariants
 
-- The `Admin` top-nav link is visible only to users who hold at least one admin-shaped role (enforced by `PolicyNames.AdminOnly` on the `[Authorize]` attribute on the `AdminController` base or area filter).
+- The `Admin` top-nav link and the `/Admin` dashboard are gated by `PolicyNames.AnyAdminRole` (12 roles: Admin, Board, HumanAdmin, TeamsAdmin, CampAdmin, TicketAdmin, FeedbackAdmin, FinanceAdmin, StoreAdmin, NoInfoAdmin, VolunteerCoordinator, ConsentCoordinator). Other actions on `AdminController` remain `PolicyNames.AdminOnly`.
 - Sidebar items are filtered per-item by `IAuthorizationService.AuthorizeAsync`; an item the current user cannot access does not appear in the rendered HTML.
 - Sidebar groups whose entire visible-item list is empty do not render.
 - The admin shell adds no new authorization policies; it reuses existing `PolicyNames.*` constants defined in the Auth section.
@@ -43,7 +43,7 @@ The admin shell applies to all routes under `/Admin`. The `AdminLayout.cshtml` l
 
 ## Negative Access Rules
 
-- A user with no admin-shaped role **cannot** reach any `/Admin` route — existing `[Authorize(Policy = PolicyNames.AdminOnly)]` enforcement applies at the controller/area level before the shell renders.
+- A user with no admin-shaped role **cannot** reach the `/Admin` dashboard — `[Authorize(Policy = PolicyNames.AnyAdminRole)]` on `AdminController.Index` rejects them before the shell renders. Non-Index actions are individually gated, most by `PolicyNames.AdminOnly`.
 - An admin-role user **cannot** see sidebar items they are not authorized for — items are individually gated, not globally shown.
 
 ## Triggers

--- a/tests/e2e/tests/admin-shell.spec.ts
+++ b/tests/e2e/tests/admin-shell.spec.ts
@@ -220,8 +220,10 @@ test.describe('Admin shell — chrome', () => {
     // Per src/Humans.Web/wwwroot/css/admin-shell.css the sub-768px design is a
     // horizontal scroll strip beneath the topbar (NOT a Bootstrap offcanvas).
     // We assert the shell still renders cleanly at narrow viewport.
-    await page.setViewportSize({ width: 480, height: 800 });
+    // Log in at desktop width first — the nav dropdown the auth helper waits
+    // for is collapsed behind the mobile hamburger at <768px.
     await loginAsAdmin(page);
+    await page.setViewportSize({ width: 480, height: 800 });
     await page.goto('/Admin');
 
     await expect(page.locator('aside.sidebar')).toBeVisible();

--- a/tests/e2e/tests/admin-shell.spec.ts
+++ b/tests/e2e/tests/admin-shell.spec.ts
@@ -61,7 +61,7 @@ const sidebarMatrix: SidebarExpectation[] = [
     login: loginAsBoard,
     groups: [
       { label: 'Operations', items: ['Tickets', 'Scanner'] },
-      { label: 'Members', items: ['Review'] },
+      { label: 'Members', items: ['Humans', 'Review'] },
       { label: 'Governance', items: ['Voting', 'Board'] },
     ],
   },
@@ -102,6 +102,9 @@ const sidebarMatrix: SidebarExpectation[] = [
   },
 ];
 
+// Note: 'Dev' is intentionally omitted — its items are env-gated
+// (!env.IsProduction()), so the group renders for admins in QA/Preview, and
+// the comment at the top of this file scopes us to role-based-policy items.
 const ALL_GROUP_LABELS = [
   'Operations',
   'Members',
@@ -111,7 +114,6 @@ const ALL_GROUP_LABELS = [
   'Agent',
   'People data',
   'Diagnostics',
-  'Dev',
 ];
 
 test.describe('Admin shell — sidebar visibility matrix', () => {
@@ -200,7 +202,11 @@ test.describe('Admin shell — maintenance + backfill pages', () => {
     await page.goto('/Admin/BackfillUserEmailProviders');
 
     expect(page.url()).toContain('/Admin/BackfillUserEmailProviders');
-    await expect(page.locator('form[action*="BackfillUserEmailProvidersRun"]')).toBeVisible();
+    // Form is asp-action="BackfillUserEmailProvidersRun" but that POST is
+    // attribute-routed as [HttpPost("BackfillUserEmailProviders")], so the
+    // rendered action attribute resolves to /Admin/BackfillUserEmailProviders.
+    await expect(page.locator('form[action*="BackfillUserEmailProviders"]')).toBeVisible();
+    await expect(page.locator('form button[type="submit"]', { hasText: 'Run backfill' })).toBeVisible();
 
     // Backfill is idempotent — re-running over already-backfilled rows is safe.
     const response = await postWithCsrf(page, '/Admin/BackfillUserEmailProviders', '');

--- a/tests/e2e/tests/admin-shell.spec.ts
+++ b/tests/e2e/tests/admin-shell.spec.ts
@@ -52,8 +52,8 @@ const sidebarMatrix: SidebarExpectation[] = [
       { label: 'Governance', items: ['Voting', 'Board'] },
       { label: 'Integrations', items: ['Google', 'Email preview', 'Email outbox', 'Campaigns', 'Workspace accounts'] },
       { label: 'Agent', items: ['Agent Config', 'Agent History'] },
-      { label: 'People data', items: ['Merge requests', 'Duplicate detection', 'Audience segmentation', 'Legal documents'] },
-      { label: 'Diagnostics', items: ['Logs', 'DB stats', 'Cache stats', 'Configuration', 'Maintenance', 'Hangfire', 'Health'] },
+      { label: 'People data', items: ['Merge requests', 'Duplicate detection', 'Audience segmentation', 'Legal documents', 'Backfill Provider/IsGoogle', 'Stub Profile Backfill'] },
+      { label: 'Diagnostics', items: ['Logs', 'DB stats', 'Cache stats', 'Configuration', 'Maintenance', 'Orphan signups', 'Hangfire', 'Health'] },
     ],
   },
   {

--- a/tests/e2e/tests/admin-shell.spec.ts
+++ b/tests/e2e/tests/admin-shell.spec.ts
@@ -1,0 +1,262 @@
+import { test, expect, type Page } from '@playwright/test';
+import {
+  loginAsAdmin,
+  loginAsBoard,
+  loginAsConsentCoordinator,
+  loginAsFinanceAdmin,
+  loginAsHumanAdmin,
+  loginAsTicketAdmin,
+  loginAsVolunteerCoordinator,
+  postWithCsrf,
+} from '../helpers/auth';
+
+/**
+ * Admin shell coverage (#604) — verifies the new sidebar-driven /Admin surface
+ * delivered by peterdrier/Humans#349.
+ *
+ * Source-of-truth for the sidebar group/item map is
+ * src/Humans.Web/ViewComponents/AdminNavTree.cs. Per-item policies determine
+ * which roles see which items; only role-based-policy items are asserted here
+ * (no environment-gated Dev items, no claim-dependent variants).
+ */
+
+// Role -> sidebar group labels expected to be present (groups whose items the
+// role can see at all). Items inside each group are asserted per-role below.
+//
+// Derived from AdminNavTree policies:
+//   Operations       — TicketAdminBoardOrAdmin (TicketAdmin / Admin / Board)
+//   Members.Humans   — HumanAdminBoardOrAdmin
+//   Members.Review   — ReviewQueueAccess (ConsentCoord / VolunteerCoord / Board / Admin)
+//   Money.Finance    — FinanceAdminOrAdmin
+//   Money.Store      — StoreCatalogAdmin (StoreAdmin / FinanceAdmin / Admin)
+//   Governance       — BoardOrAdmin
+//   Integrations,
+//   Agent,
+//   People data,
+//   Diagnostics,
+//   Dev              — AdminOnly
+interface SidebarExpectation {
+  name: string;
+  login: (page: Page) => Promise<void>;
+  groups: { label: string; items: string[] }[];
+}
+
+const sidebarMatrix: SidebarExpectation[] = [
+  {
+    name: 'admin',
+    login: loginAsAdmin,
+    groups: [
+      { label: 'Operations', items: ['Tickets', 'Scanner'] },
+      { label: 'Members', items: ['Humans', 'Review'] },
+      { label: 'Money', items: ['Finance', 'Store catalog'] },
+      { label: 'Governance', items: ['Voting', 'Board'] },
+      { label: 'Integrations', items: ['Google', 'Email preview', 'Email outbox', 'Campaigns', 'Workspace accounts'] },
+      { label: 'Agent', items: ['Agent Config', 'Agent History'] },
+      { label: 'People data', items: ['Merge requests', 'Duplicate detection', 'Audience segmentation', 'Legal documents'] },
+      { label: 'Diagnostics', items: ['Logs', 'DB stats', 'Cache stats', 'Configuration', 'Maintenance', 'Hangfire', 'Health'] },
+    ],
+  },
+  {
+    name: 'board',
+    login: loginAsBoard,
+    groups: [
+      { label: 'Operations', items: ['Tickets', 'Scanner'] },
+      { label: 'Members', items: ['Review'] },
+      { label: 'Governance', items: ['Voting', 'Board'] },
+    ],
+  },
+  {
+    name: 'humanAdmin',
+    login: loginAsHumanAdmin,
+    groups: [
+      { label: 'Members', items: ['Humans'] },
+    ],
+  },
+  {
+    name: 'ticketAdmin',
+    login: loginAsTicketAdmin,
+    groups: [
+      { label: 'Operations', items: ['Tickets', 'Scanner'] },
+    ],
+  },
+  {
+    name: 'consentCoordinator',
+    login: loginAsConsentCoordinator,
+    groups: [
+      { label: 'Members', items: ['Review'] },
+    ],
+  },
+  {
+    name: 'volunteerCoordinator',
+    login: loginAsVolunteerCoordinator,
+    groups: [
+      { label: 'Members', items: ['Review'] },
+    ],
+  },
+  {
+    name: 'financeAdmin',
+    login: loginAsFinanceAdmin,
+    groups: [
+      { label: 'Money', items: ['Finance', 'Store catalog'] },
+    ],
+  },
+];
+
+const ALL_GROUP_LABELS = [
+  'Operations',
+  'Members',
+  'Money',
+  'Governance',
+  'Integrations',
+  'Agent',
+  'People data',
+  'Diagnostics',
+  'Dev',
+];
+
+test.describe('Admin shell — sidebar visibility matrix', () => {
+  for (const role of sidebarMatrix) {
+    test(`${role.name}: sees expected sidebar groups + items`, async ({ page }) => {
+      await role.login(page);
+      await page.goto('/Admin');
+
+      const sidebar = page.locator('aside.sidebar');
+      await expect(sidebar).toBeVisible();
+
+      const expectedGroups = new Set(role.groups.map(g => g.label));
+
+      for (const group of role.groups) {
+        await expect(
+          sidebar.locator('h4', { hasText: new RegExp(`^${escapeRegex(group.label)}$`) }),
+          `${role.name} should see group '${group.label}'`,
+        ).toBeVisible();
+
+        for (const item of group.items) {
+          await expect(
+            sidebar.getByRole('link', { name: new RegExp(`^${escapeRegex(item)}\\b`) }),
+            `${role.name} should see item '${item}' in '${group.label}'`,
+          ).toBeVisible();
+        }
+      }
+
+      for (const label of ALL_GROUP_LABELS) {
+        if (expectedGroups.has(label)) continue;
+        await expect(
+          sidebar.locator('h4', { hasText: new RegExp(`^${escapeRegex(label)}$`) }),
+          `${role.name} should NOT see group '${label}'`,
+        ).not.toBeVisible();
+      }
+    });
+  }
+});
+
+test.describe('Admin shell — breadcrumb regression (controller-only-match bug, ddfdb6c1)', () => {
+  test('breadcrumb on /Admin/Logs shows Diagnostics / Logs', async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.goto('/Admin/Logs');
+
+    const crumb = page.locator('.crumb');
+    await expect(crumb).toContainText('Diagnostics');
+    await expect(crumb.locator('.here')).toHaveText('Logs');
+
+    // Regression: only the "Logs" sidebar link should be marked active, not
+    // every other item under controller=Admin.
+    const sidebar = page.locator('aside.sidebar');
+    const activeLinks = sidebar.locator('a.active');
+    await expect(activeLinks).toHaveCount(1);
+    await expect(activeLinks).toHaveText(/Logs/);
+  });
+
+  test('breadcrumb on /Admin/DbStats shows Diagnostics / DB stats', async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.goto('/Admin/DbStats');
+
+    const crumb = page.locator('.crumb');
+    await expect(crumb).toContainText('Diagnostics');
+    await expect(crumb.locator('.here')).toHaveText('DB stats');
+
+    const sidebar = page.locator('aside.sidebar');
+    const activeLinks = sidebar.locator('a.active');
+    await expect(activeLinks).toHaveCount(1);
+    await expect(activeLinks).toHaveText(/DB stats/);
+  });
+});
+
+test.describe('Admin shell — maintenance + backfill pages', () => {
+  test('/Admin/Maintenance loads with Clear Hangfire Locks form', async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.goto('/Admin/Maintenance');
+
+    expect(page.url()).toContain('/Admin/Maintenance');
+    await expect(page.locator('h1', { hasText: 'Maintenance' })).toBeVisible();
+
+    const form = page.locator('form[action*="ClearHangfireLocks"]');
+    await expect(form).toBeVisible();
+    await expect(form.locator('button[type="submit"]', { hasText: 'Clear Hangfire Locks' })).toBeVisible();
+  });
+
+  test('/Admin/BackfillUserEmailProviders GET loads, POST runs idempotently', async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.goto('/Admin/BackfillUserEmailProviders');
+
+    expect(page.url()).toContain('/Admin/BackfillUserEmailProviders');
+    await expect(page.locator('form[action*="BackfillUserEmailProvidersRun"]')).toBeVisible();
+
+    // Backfill is idempotent — re-running over already-backfilled rows is safe.
+    const response = await postWithCsrf(page, '/Admin/BackfillUserEmailProviders', '');
+    // Either redirected back to the page or rendered inline; both are non-error.
+    expect([200, 302]).toContain(response.status());
+  });
+});
+
+test.describe('Admin shell — chrome', () => {
+  test('mobile viewport (<768px) renders sidebar without breaking the shell', async ({ page }) => {
+    // Per src/Humans.Web/wwwroot/css/admin-shell.css the sub-768px design is a
+    // horizontal scroll strip beneath the topbar (NOT a Bootstrap offcanvas).
+    // We assert the shell still renders cleanly at narrow viewport.
+    await page.setViewportSize({ width: 480, height: 800 });
+    await loginAsAdmin(page);
+    await page.goto('/Admin');
+
+    await expect(page.locator('aside.sidebar')).toBeVisible();
+    await expect(page.locator('aside.sidebar .sidebar-scroll')).toBeVisible();
+    // Topbar exit-admin remains reachable.
+    await expect(page.locator('a.exit-admin')).toBeVisible();
+  });
+
+  test('exit-admin link navigates to member home', async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.goto('/Admin');
+
+    const exit = page.locator('a.exit-admin').first();
+    await expect(exit).toBeVisible();
+    await exit.click();
+    await page.waitForLoadState('domcontentloaded');
+
+    // Member home is /Home/Index (path "/"), and the admin shell is gone.
+    expect(new URL(page.url()).pathname).toMatch(/^\/(Home(\/Index)?)?$/i);
+    await expect(page.locator('body.admin-shell')).toHaveCount(0);
+  });
+
+  test('dashboard tiles render: active humans, shift coverage, open feedback, recent activity', async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.goto('/Admin');
+
+    // Tiles from _DashboardStats (active humans, shifts staffed, open feedback)
+    const stats = page.locator('.stats');
+    await expect(stats).toBeVisible();
+    await expect(stats.locator('.stat .label', { hasText: 'Active humans' })).toBeVisible();
+    await expect(stats.locator('.stat .label', { hasText: /Shifts staffed/ })).toBeVisible();
+    await expect(stats.locator('.stat .label', { hasText: 'Open feedback' })).toBeVisible();
+
+    // Shift coverage delta (drives the system-health-style summary line).
+    await expect(page.locator('.page-head .sub')).toContainText('shift coverage');
+
+    // Recent activity card (last 24h).
+    await expect(page.locator('.card-head h3', { hasText: 'Recent activity' })).toBeVisible();
+  });
+});
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/tests/e2e/tests/admin.spec.ts
+++ b/tests/e2e/tests/admin.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { loginAsAdmin, loginAsBoard, expectBlocked } from '../helpers/auth';
+import { loginAsAdmin, loginAsVolunteer, expectBlocked } from '../helpers/auth';
 
 test.describe('Admin (09-administration)', () => {
   test('US-9.1: admin dashboard loads with metrics cards', async ({ page }) => {
@@ -27,8 +27,11 @@ test.describe('Admin (09-administration)', () => {
     expect(page.url()).toContain('/Admin/Configuration');
   });
 
-  test('boundary: board member cannot access /Admin', async ({ page }) => {
-    await loginAsBoard(page);
+  test('boundary: volunteer cannot access /Admin', async ({ page }) => {
+    // Post #349 /Admin is gated by AnyAdminRole (composite of 12 admin-shaped
+    // roles, including Board), so Board members reach the dashboard. Volunteer
+    // is the closest non-admin role and the right boundary check.
+    await loginAsVolunteer(page);
     await expectBlocked(page, '/Admin');
   });
 });

--- a/tests/e2e/tests/nav-visibility.spec.ts
+++ b/tests/e2e/tests/nav-visibility.spec.ts
@@ -16,20 +16,19 @@ import {
 } from '../helpers/auth';
 
 /**
- * Nav visibility matrix — verifies that each role sees exactly the correct
- * policy-gated nav items. This is the primary e2e coverage for the
- * authorization policy foundation (PR #125 / #366).
+ * Top-nav visibility matrix — verifies that each role sees exactly the correct
+ * policy-gated items in the top navbar.
  *
- * Nav items gated by authorize-policy in _Layout.cshtml:
+ * Post peterdrier/Humans#349 the 9 dark-orange admin items were collapsed into
+ * a single composite-gated `Admin` link that opens the admin shell at `/Admin`.
+ * Only two top-nav items are role/policy gated:
+ *
  *   Volunteer  → ActiveMemberOrShiftAccess
- *   Review     → ReviewQueueAccess
- *   Voting     → BoardOrAdmin
- *   Board      → BoardOrAdmin
- *   Humans     → HumanAdminOnly
- *   Admin      → AdminOnly
- *   Google     → AdminOnly
- *   Tickets    → TicketAdminBoardOrAdmin
- *   Finance    → FinanceAdminOrAdmin
+ *   Admin      → AnyAdminRole (composite: Admin, Board, HumanAdmin, TeamsAdmin,
+ *                CampAdmin, TicketAdmin, FeedbackAdmin, FinanceAdmin, StoreAdmin,
+ *                NoInfoAdmin, VolunteerCoordinator, ConsentCoordinator)
+ *
+ * Sidebar coverage for items inside `/Admin` lives in admin-shell.spec.ts.
  *
  * Note on "Volunteer" (Shifts) visibility:
  * ActiveMemberOrShiftAccess succeeds via ActiveMember claim (Volunteers team
@@ -40,23 +39,16 @@ import {
  * always seeded into the Volunteers team.
  */
 
-type NavItem = 'volunteer' | 'review' | 'voting' | 'board' | 'humans' | 'admin' | 'google' | 'tickets' | 'finance';
+type NavItem = 'volunteer' | 'admin';
 
-const ALL_NAV_ITEMS: NavItem[] = ['volunteer', 'review', 'voting', 'board', 'humans', 'admin', 'google', 'tickets', 'finance'];
+const ALL_NAV_ITEMS: NavItem[] = ['volunteer', 'admin'];
 
 function getNavLocators(nav: Locator): Record<NavItem, Locator> {
   // Scope to ul.navbar-nav to exclude the navbar brand (also named "Humans")
   const items = nav.locator('ul.navbar-nav');
   return {
     volunteer: items.getByRole('link', { name: 'Volunteer', exact: true }),
-    review: items.getByRole('link', { name: /^Review/ }),
-    voting: items.getByRole('link', { name: /^Voting/ }),
-    board: items.getByRole('link', { name: 'Board', exact: true }),
-    humans: items.getByRole('link', { name: 'Humans', exact: true }),
     admin: items.getByRole('link', { name: 'Admin', exact: true }),
-    google: items.getByRole('link', { name: 'Google', exact: true }),
-    tickets: items.getByRole('link', { name: 'Tickets', exact: true }),
-    finance: items.getByRole('link', { name: 'Finance', exact: true }),
   };
 }
 
@@ -66,15 +58,18 @@ interface RoleTest {
   visible: NavItem[];
 }
 
-// "Volunteer" (Shifts) visibility by role path:
-//   ActiveMember claim: volunteer, coordinator (always in Volunteers team)
+// Volunteer (Shifts) visibility by role path:
+//   ActiveMember claim: volunteer, coordinator (always seeded into Volunteers team)
 //   IsTeamsAdminBoardOrAdmin: admin, board, teamsAdmin
 //   ShiftRoleChecks.CanAccessDashboard: admin, noInfoAdmin, volunteerCoordinator
 //
-// Roles without a role-based path (humanAdmin, campAdmin, ticketAdmin,
-// consentCoordinator, feedbackAdmin, financeAdmin) only see "Volunteer" if
-// they happen to have ActiveMember claim — which is environment-dependent.
-// We omit "volunteer" from their visible list to avoid flaky assertions.
+// Admin top-nav link visibility (AnyAdminRole composite):
+//   admin, board, humanAdmin, teamsAdmin, campAdmin, ticketAdmin, feedbackAdmin,
+//   financeAdmin, noInfoAdmin, volunteerCoordinator, consentCoordinator
+//   (StoreAdmin is in the policy but no dev login helper exists for it.)
+//
+// Roles without a role-based "Volunteer" path only see it if they happen to have
+// ActiveMember claim — environment-dependent, so we omit it from those expectations.
 const roles: RoleTest[] = [
   {
     name: 'volunteer',
@@ -89,68 +84,67 @@ const roles: RoleTest[] = [
   {
     name: 'admin',
     login: loginAsAdmin,
-    visible: ['volunteer', 'review', 'voting', 'board', 'admin', 'google', 'tickets', 'finance'],
-    // 'humans' is NOT visible — HumanAdminOnly requires HumanAdmin AND NOT Admin
+    visible: ['volunteer', 'admin'],
   },
   {
     name: 'board',
     login: loginAsBoard,
-    visible: ['volunteer', 'review', 'voting', 'board', 'tickets'],
+    visible: ['volunteer', 'admin'],
   },
   {
     name: 'humanAdmin',
     login: loginAsHumanAdmin,
-    visible: ['humans'],
+    visible: ['admin'],
   },
   {
     name: 'teamsAdmin',
     login: loginAsTeamsAdmin,
-    visible: ['volunteer'],
+    visible: ['volunteer', 'admin'],
   },
   {
     name: 'ticketAdmin',
     login: loginAsTicketAdmin,
-    visible: ['tickets'],
+    visible: ['admin'],
   },
   {
     name: 'campAdmin',
     login: loginAsCampAdmin,
-    visible: [],
+    visible: ['admin'],
   },
   {
     name: 'consentCoordinator',
     login: loginAsConsentCoordinator,
-    visible: ['review'],
+    visible: ['admin'],
   },
   {
     name: 'feedbackAdmin',
     login: loginAsFeedbackAdmin,
-    visible: [],
+    visible: ['admin'],
   },
   {
     name: 'noInfoAdmin',
     login: loginAsNoInfoAdmin,
-    visible: ['volunteer'],
+    visible: ['volunteer', 'admin'],
   },
   {
     name: 'financeAdmin',
     login: loginAsFinanceAdmin,
-    visible: ['finance'],
+    visible: ['admin'],
   },
   {
     name: 'volunteerCoordinator',
     login: loginAsVolunteerCoordinator,
-    visible: ['volunteer', 'review'],
+    visible: ['volunteer', 'admin'],
   },
 ];
 
-test.describe('Nav visibility matrix (#366)', () => {
+test.describe('Top-nav visibility matrix (#604)', () => {
   for (const role of roles) {
-    test(`${role.name}: sees correct nav items`, async ({ page }) => {
+    test(`${role.name}: sees correct top-nav items`, async ({ page }) => {
       await role.login(page);
       await page.goto('/');
 
-      const nav = page.locator('nav');
+      const nav = page.locator('nav').first();
       const locators = getNavLocators(nav);
       const hidden = ALL_NAV_ITEMS.filter(item => !role.visible.includes(item));
 


### PR DESCRIPTION
## Summary

Repairs the Playwright e2e suite after PR peterdrier/Humans#349 collapsed the
9 dark-orange admin items in the top nav into a single composite-gated `Admin`
link that opens an admin shell at `/Admin`.

- **`nav-visibility.spec.ts`** rewritten for the new 2-item gated top nav
  (`Volunteer` + `Admin`). Per-role expected visibility lists collapse to
  combinations of those two items.
- **`admin.spec.ts`** boundary check changed from Board to Volunteer. Post-#349
  `/Admin` is gated by `AnyAdminRole` (composite of 12 roles including Board),
  so Board now reaches the dashboard. Volunteer is the closest non-admin role.
- **`admin-shell.spec.ts`** (new) covers:
  - Sidebar group/item visibility matrix per role (scoped to `aside.sidebar`);
    source-of-truth is `AdminNavTree.cs`.
  - Breadcrumb regression for `/Admin/Logs` vs `/Admin/DbStats`
    (controller-only-match bug fixed in `ddfdb6c1`) — also asserts only one
    sidebar item is `.active`.
  - `/Admin/Maintenance` page + Clear Hangfire Locks form.
  - `/Admin/BackfillUserEmailProviders` GET + idempotent POST.
  - Narrow viewport (<768px) — sidebar collapses to a horizontal scroll strip
    per `admin-shell.css` (the implementation is **not** a Bootstrap offcanvas;
    test assertions match the actual implementation, not the issue's offcanvas
    wording).
  - Exit-admin link in topbar navigates back to member home.
  - Dashboard tiles render: active humans, shifts staffed, open feedback,
    recent activity. (No "system health" tile exists; that part of the issue
    text doesn't match the implementation, so I asserted what's actually
    there.)

No new helpers added in `tests/e2e/helpers/auth.ts` — uses existing
`loginAs*` helpers and `postWithCsrf`.

## Test plan

- [x] `dotnet build Humans.slnx -v quiet` — clean
- [x] `npx tsc --noEmit` in `tests/e2e/` — only the 2 pre-existing
  `process` / `Buffer` errors in `helpers/auth.ts` and `playwright.config.ts`
  remain; my new code adds no type errors
- [ ] Full Playwright suite green against a preview environment — verified by
  Peter at PR review time (no preview env available to this worker)

Refs nobodies-collective/Humans#604.