### PR TITLE
issue-633: render markdown in agent chat + admin conversation view

### DIFF
--- a/src/Humans.Web/Views/Admin/Agent/ConversationDetail.cshtml
+++ b/src/Humans.Web/Views/Admin/Agent/ConversationDetail.cshtml
@@ -38,7 +38,14 @@
                 <span class="text-muted small">@msg.CreatedAt.ToAuditTimestamp() UTC</span>
             </div>
             <div class="card-body">
-                <p class="mb-1" style="white-space: pre-wrap;">@msg.Content</p>
+                @if (msg.Role == Humans.Domain.Enums.AgentRole.Assistant)
+                {
+                    <div class="agent-assistant-content mb-1">@Html.SanitizedMarkdown(msg.Content)</div>
+                }
+                else
+                {
+                    <p class="mb-1" style="white-space: pre-wrap;">@msg.Content</p>
+                }
                 @if (!string.IsNullOrEmpty(msg.RefusalReason))
                 {
                     <div class="alert alert-warning mt-2 mb-0 py-1">Refusal: @msg.RefusalReason</div>

--- a/src/Humans.Web/Views/Shared/Components/AgentWidget/Default.cshtml
+++ b/src/Humans.Web/Views/Shared/Components/AgentWidget/Default.cshtml
@@ -46,4 +46,10 @@
 </div>
 
 <link rel="stylesheet" href="~/css/agent.css" asp-append-version="true" />
+<script src="https://cdn.jsdelivr.net/npm/marked@14.1.4/marked.min.js"
+        integrity="sha384-lqPzN0kmFw9t2syAMwVPM4VbAyqsz/lPyYWbb2Xt6nSPM0WPNrpSWCUBgdcAdgnC"
+        crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/dompurify@3.1.7/dist/purify.min.js"
+        integrity="sha384-XQqX/4yiUGu+oyr87jvWzRuqBUK/adrY0DunhL+tID9m/9dwSpV8h9Fk/Sg6ifVQ"
+        crossorigin="anonymous"></script>
 <script src="~/js/agent/widget.js" asp-append-version="true"></script>

--- a/src/Humans.Web/wwwroot/js/agent/widget.js
+++ b/src/Humans.Web/wwwroot/js/agent/widget.js
@@ -11,6 +11,52 @@
 
     let currentConversationId = null;
 
+    // Configure marked with GFM + breaks (single newlines render as <br>),
+    // matching how Anthropic models tend to write.
+    if (typeof marked !== 'undefined') {
+        marked.setOptions({ breaks: true, gfm: true });
+    }
+
+    // Force <a> tags to safe defaults for external URLs (target=_blank,
+    // rel=noopener noreferrer); same-tab + no rel for internal /-prefixed paths.
+    if (typeof DOMPurify !== 'undefined') {
+        DOMPurify.addHook('afterSanitizeAttributes', function (node) {
+            if (node.tagName === 'A' && node.hasAttribute('href')) {
+                const href = node.getAttribute('href');
+                if (href && !href.startsWith('/')) {
+                    node.setAttribute('target', '_blank');
+                    node.setAttribute('rel', 'noopener noreferrer');
+                } else {
+                    node.removeAttribute('target');
+                    node.removeAttribute('rel');
+                }
+            }
+        });
+    }
+
+    // Allowed tags for sanitized markdown output (forbid img, iframe, script,
+    // event handlers — DOMPurify defaults already strip those, but we are
+    // explicit about the allow-list).
+    const PURIFY_CONFIG = {
+        ALLOWED_TAGS: [
+            'p', 'br', 'hr',
+            'ul', 'ol', 'li',
+            'strong', 'em', 'code', 'pre', 'blockquote',
+            'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+            'a',
+            'table', 'thead', 'tbody', 'tr', 'th', 'td'
+        ],
+        ALLOWED_ATTR: ['href', 'target', 'rel']
+    };
+
+    function renderMarkdown(raw) {
+        if (typeof marked === 'undefined' || typeof DOMPurify === 'undefined') {
+            return null;
+        }
+        const html = marked.parse(raw);
+        return DOMPurify.sanitize(html, PURIFY_CONFIG);
+    }
+
     launcher.addEventListener('click', function () {
         panel.style.display = panel.style.display === 'none' ? 'block' : 'none';
     });
@@ -25,6 +71,10 @@
 
         appendMessage('user', message);
         const bubble = appendMessage('assistant', '');
+        // Track raw accumulated markdown per assistant bubble so we can
+        // re-parse + sanitize on each delta. innerHTML write below is safe
+        // ONLY because DOMPurify gates it.
+        bubble.dataset.rawMarkdown = '';
 
         try {
             const resp = await fetch('/Agent/Ask', {
@@ -71,10 +121,19 @@
         if (!data) return;
         const parsed = JSON.parse(data);
         if (event === 'text' && parsed.textDelta) {
-            bubble.textContent += parsed.textDelta;
+            bubble.dataset.rawMarkdown = (bubble.dataset.rawMarkdown || '') + parsed.textDelta;
+            const sanitized = renderMarkdown(bubble.dataset.rawMarkdown);
+            if (sanitized !== null) {
+                // Safe: sanitized is the output of DOMPurify.sanitize.
+                bubble.innerHTML = sanitized;
+            } else {
+                // Fallback if marked/DOMPurify failed to load — keep streaming as text.
+                bubble.textContent = bubble.dataset.rawMarkdown;
+            }
             messagesEl.scrollTop = messagesEl.scrollHeight;
         } else if (event === 'final' && parsed.finalizer) {
             const reason = parsed.finalizer.stopReason;
+            // Final-frame placeholders are trusted strings — render as plain text.
             if (reason === 'disabled') bubble.textContent = '(The agent is currently disabled.)';
             if (reason === 'rate_limited') bubble.textContent = '(Daily limit reached — try again tomorrow.)';
             // Capture the conversation id from the first successful turn so the


### PR DESCRIPTION
Closes nobodies-collective/Humans#633
Supersedes nobodies-collective/Humans#630

## Summary

- **Live agent panel** (`widget.js`): buffer raw markdown per assistant bubble; on each SSE delta, re-parse with `marked` and sanitize with `DOMPurify`, then `bubble.innerHTML = sanitized` (safe because gated by DOMPurify). `afterSanitizeAttributes` hook forces `target="_blank" rel="noopener noreferrer"` for external `<a>`, same-tab no rel for internal `/`-paths.
- **Final-frame placeholders** (`disabled`, `rate_limited`, network error, status error) keep `bubble.textContent` — trusted strings.
- **Admin conversation view** (`Views/Admin/Agent/ConversationDetail.cshtml`): assistant messages render via `@Html.SanitizedMarkdown(msg.Content)`; user messages stay escaped pre-wrap text; tool-call panels unchanged.
- **Pinned + SRI**: `marked@14.1.4` and `dompurify@3.1.7` loaded from `cdn.jsdelivr.net` with `sha384` integrity hashes. CSP unmodified (existing `cdn.jsdelivr.net` allow-list covers both libs).
- **Allow-list** (DOMPurify config): standard formatting tags + tables + anchors; img/iframe/script/event handlers excluded.
- `Views/Agent/Conversation.cshtml` is planned in #632 and does not yet exist on `main`; skipped per spec.

## Test plan

- [ ] Visual smoke: ask agent a question whose answer uses bold + bullets + a link; bold/lists render, link opens in new tab with `rel=noopener noreferrer`.
- [ ] Streaming: half-arrived `**bo` shows as text mid-stream; reflows to bolded once closing `**` arrives.
- [ ] XSS: agent reply containing `<script>alert(1)</script>` and `<img src=x onerror=alert(1)>` renders inert (no script run).
- [ ] User messages render as plain escaped text.
- [ ] Final-frame placeholders unaffected (test via disabled / rate-limited paths).
- [ ] `/Admin/Agent/Conversations/{id}` renders assistant content as markdown; user content as pre-wrap text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)