### PR TITLE
issue-611: bind email verification to specific row Id, not FirstOrDefault

### DIFF
--- a/src/Humans.Application/DTOs/UserEmailDto.cs
+++ b/src/Humans.Application/DTOs/UserEmailDto.cs
@@ -33,9 +33,15 @@ public record UserEmailEditDto(
 /// <summary>
 /// Result of adding an email address.
 /// </summary>
+/// <param name="EmailId">The new <see cref="Domain.Entities.UserEmail"/> row's
+/// Id. The verification token is bound to this Id via the token's purpose
+/// suffix, so the verification URL must round-trip this Id back to
+/// <see cref="Humans.Application.Interfaces.Profiles.IUserEmailService.VerifyEmailAsync"/>
+/// to disambiguate when the same user has multiple pending plain rows
+/// (issue nobodies-collective/Humans#611).</param>
 /// <param name="Token">Verification token for building the confirmation URL.</param>
 /// <param name="IsConflict">True if the email is already verified on another account (merge flow).</param>
-public record AddEmailResult(string Token, bool IsConflict);
+public record AddEmailResult(Guid EmailId, string Token, bool IsConflict);
 
 /// <summary>
 /// Result of verifying an email address.

--- a/src/Humans.Application/Interfaces/Profiles/IUserEmailService.cs
+++ b/src/Humans.Application/Interfaces/Profiles/IUserEmailService.cs
@@ -36,13 +36,18 @@ public interface IUserEmailService
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Verifies an email address using a token.
-    /// If the email is already verified on another account, creates a merge request
-    /// instead of completing verification.
-    /// Returns a result indicating the email and whether a merge request was created.
+    /// Verifies an email address using a token. <paramref name="emailId"/>
+    /// identifies the specific pending row the verification link was issued
+    /// for — the token is bound to this row's Id via the token's purpose
+    /// suffix, so passing it here disambiguates when the same user has
+    /// multiple pending plain rows (issue nobodies-collective/Humans#611).
+    /// If the email is already verified on another account, creates a merge
+    /// request instead of completing verification. Returns a result
+    /// indicating the email and whether a merge request was created.
     /// </summary>
     Task<VerifyEmailResult> VerifyEmailAsync(
         Guid userId,
+        Guid emailId,
         string token,
         CancellationToken cancellationToken = default);
 

--- a/src/Humans.Application/Services/Profile/UserEmailService.cs
+++ b/src/Humans.Application/Services/Profile/UserEmailService.cs
@@ -156,27 +156,26 @@ public sealed class UserEmailService : IUserEmailService, IUserMerge
             TokenOptions.DefaultEmailProvider,
             $"{EmailVerificationTokenPurpose}:{userEmail.Id}");
 
-        return new AddEmailResult(token, isConflict);
+        return new AddEmailResult(userEmail.Id, token, isConflict);
     }
 
     public async Task<VerifyEmailResult> VerifyEmailAsync(
-        Guid userId, string token, CancellationToken cancellationToken = default)
+        Guid userId, Guid emailId, string token, CancellationToken cancellationToken = default)
     {
         var user = await _userService.GetByIdAsync(userId, cancellationToken)
             ?? throw new InvalidOperationException("User not found.");
 
-        var userEmails = await _repository.GetByUserIdForMutationAsync(userId, cancellationToken);
-        // TODO(nobodies-collective#611): VerifyEmailAsync uses FirstOrDefault on
-        // (!IsVerified && Provider == null), which is ambiguous when multiple pending
-        // plain rows exist for the same user. The token IS bound to a specific row Id
-        // (purpose = "{EmailVerificationTokenPurpose}:{pendingEmail.Id}"), so a row
-        // mismatch causes token validation to fail against the wrong row, surfacing as
-        // a confusing user error even when the token is valid for ANOTHER pending row.
-        // Surfaced during PR 4 review (peterdrier/Humans#376) — AdminAddEmail amplifies
-        // the multi-pending-row scenario. Fix: load the row by the Id embedded in the
-        // token's purpose suffix, not via FirstOrDefault.
-        var pendingEmail = userEmails.FirstOrDefault(e => !e.IsVerified && e.Provider == null)
-            ?? throw new ValidationException("No email pending verification.");
+        // Issue nobodies-collective/Humans#611: load the specific pending row
+        // the verification link was issued for, not "any non-verified plain
+        // row". The token is bound to this row's Id via the purpose suffix
+        // ("{EmailVerificationTokenPurpose}:{emailId}"), so picking a
+        // different row would cause token validation to fail against the
+        // wrong row even when the token is valid.
+        var pendingEmail = await _repository.GetByIdAndUserIdAsync(emailId, userId, cancellationToken);
+        if (pendingEmail is null || pendingEmail.IsVerified || pendingEmail.Provider is not null)
+        {
+            throw new ValidationException("No email pending verification.");
+        }
 
         var isValid = await _userManager.VerifyUserTokenAsync(
             user,

--- a/src/Humans.Web/Controllers/ProfileController.cs
+++ b/src/Humans.Web/Controllers/ProfileController.cs
@@ -582,11 +582,12 @@ public class ProfileController : HumansControllerBase
         {
             var result = await _userEmailService.AddEmailAsync(user.Id, model.NewEmail);
 
-            // Build verification URL
+            // Build verification URL — emailId disambiguates when the user has
+            // multiple pending plain rows (issue nobodies-collective/Humans#611).
             var verificationUrl = Url.Action(
                 nameof(VerifyEmail),
                 "Profile",
-                new { userId = user.Id, token = HttpUtility.UrlEncode(result.Token) },
+                new { userId = user.Id, emailId = result.EmailId, token = HttpUtility.UrlEncode(result.Token) },
                 Request.Scheme);
 
             // Send verification email
@@ -624,9 +625,9 @@ public class ProfileController : HumansControllerBase
 
     [HttpGet("Me/Emails/Verify")]
     [AllowAnonymous]
-    public async Task<IActionResult> VerifyEmail(Guid userId, string token)
+    public async Task<IActionResult> VerifyEmail(Guid userId, Guid emailId, string token)
     {
-        if (string.IsNullOrEmpty(token))
+        if (string.IsNullOrEmpty(token) || emailId == Guid.Empty)
         {
             return VerifyEmailError(_localizer["Profile_InvalidVerificationLink"].Value);
         }
@@ -634,7 +635,7 @@ public class ProfileController : HumansControllerBase
         try
         {
             var decodedToken = HttpUtility.UrlDecode(token);
-            var result = await _userEmailService.VerifyEmailAsync(userId, decodedToken);
+            var result = await _userEmailService.VerifyEmailAsync(userId, emailId, decodedToken);
             _cache.InvalidateNobodiesTeamEmails();
 
             if (result.MergeRequestCreated)
@@ -1001,11 +1002,13 @@ public class ProfileController : HumansControllerBase
             // Verification email goes to the target user (the human whose row this is),
             // not to the admin. The admin can't verify on the user's behalf — that
             // defeats the purpose of verification. Mirrors the self AddEmail path.
-            // VerifyEmail still binds by query-string userId, so pass it explicitly.
+            // VerifyEmail still binds by query-string userId + emailId, so pass them
+            // explicitly. emailId disambiguates when the user has multiple pending
+            // plain rows (issue nobodies-collective/Humans#611).
             var verificationUrl = Url.Action(
                 nameof(VerifyEmail),
                 "Profile",
-                new { userId = id, token = HttpUtility.UrlEncode(result.Token) },
+                new { userId = id, emailId = result.EmailId, token = HttpUtility.UrlEncode(result.Token) },
                 Request.Scheme);
 
             await _emailService.SendEmailVerificationAsync(

--- a/tests/Humans.Application.Tests/Controllers/ProfileControllerEmailGridTests.cs
+++ b/tests/Humans.Application.Tests/Controllers/ProfileControllerEmailGridTests.cs
@@ -282,7 +282,7 @@ public class ProfileControllerEmailGridTests
         _userManager.FindByIdAsync(targetUserId.ToString())
             .Returns(new User { Id = targetUserId, DisplayName = "Target User", PreferredLanguage = "en" });
         _userEmailService.AddEmailAsync(targetUserId, newEmail, Arg.Any<CancellationToken>())
-            .Returns(new Humans.Application.DTOs.AddEmailResult("token", IsConflict: false));
+            .Returns(new Humans.Application.DTOs.AddEmailResult(Guid.NewGuid(), "token", IsConflict: false));
 
         var result = await _controller.AdminAddEmail(targetUserId, newEmail, CancellationToken.None);
 
@@ -300,7 +300,7 @@ public class ProfileControllerEmailGridTests
         _userManager.FindByIdAsync(targetUserId.ToString())
             .Returns(new User { Id = targetUserId, DisplayName = "Target User", PreferredLanguage = "en" });
         _userEmailService.AddEmailAsync(targetUserId, newEmail, Arg.Any<CancellationToken>())
-            .Returns(new Humans.Application.DTOs.AddEmailResult("token", IsConflict: false));
+            .Returns(new Humans.Application.DTOs.AddEmailResult(Guid.NewGuid(), "token", IsConflict: false));
 
         var result = await _controller.AdminAddEmail(targetUserId, newEmail, CancellationToken.None);
 
@@ -338,7 +338,7 @@ public class ProfileControllerEmailGridTests
         _userManager.FindByIdAsync(targetUserId.ToString())
             .Returns(new User { Id = targetUserId, DisplayName = "Target User", PreferredLanguage = "es" });
         _userEmailService.AddEmailAsync(targetUserId, newEmail, Arg.Any<CancellationToken>())
-            .Returns(new Humans.Application.DTOs.AddEmailResult(token, IsConflict: false));
+            .Returns(new Humans.Application.DTOs.AddEmailResult(Guid.NewGuid(), token, IsConflict: false));
 
         var result = await _controller.AdminAddEmail(targetUserId, newEmail, CancellationToken.None);
 

--- a/tests/Humans.Application.Tests/Services/UserEmailServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/UserEmailServiceTests.cs
@@ -814,4 +814,142 @@ public class UserEmailServiceTests
             Arg.Any<string>(), Arg.Any<Guid>(),
             Arg.Any<Guid?>(), Arg.Any<string?>());
     }
+
+    // ─── VerifyEmailAsync row-Id disambiguation — issue #611 ──────────────
+    // VerifyEmailAsync MUST load the pending row by the Id passed in (which
+    // matches the token's purpose suffix), not by `FirstOrDefault(!IsVerified
+    // && Provider == null)`. Otherwise a user with two pending plain rows
+    // gets a confusing "expired or invalid" error when verifying via a link
+    // that was actually issued for a different row.
+
+    [HumansFact]
+    public async Task VerifyEmailAsync_LoadsRowByEmailIdNotFirstPending()
+    {
+        var userId = Guid.NewGuid();
+        var rowAId = Guid.NewGuid();
+        var rowBId = Guid.NewGuid();
+        // Row A and row B are BOTH unverified plain rows for the same user.
+        // The verification link was issued for row B, so VerifyEmailAsync must
+        // pick row B by Id — not row A via FirstOrDefault.
+        var rowB = new UserEmail
+        {
+            Id = rowBId,
+            UserId = userId,
+            Email = "b@example.com",
+            IsVerified = false,
+            Provider = null,
+            VerificationSentAt = _clock.GetCurrentInstant(),
+        };
+
+        var user = new User { Id = userId, DisplayName = "U" };
+        _userService.GetByIdAsync(userId, Arg.Any<CancellationToken>()).Returns(user);
+        _repository.GetByIdAndUserIdAsync(rowBId, userId, Arg.Any<CancellationToken>())
+            .Returns(rowB);
+        _repository.GetByIdAndUserIdAsync(rowAId, userId, Arg.Any<CancellationToken>())
+            .Returns((UserEmail?)null);
+        _repository.GetConflictingVerifiedEmailAsync(
+                rowBId, Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns((UserEmail?)null);
+        _userManager.VerifyUserTokenAsync(
+                user, TokenOptions.DefaultEmailProvider,
+                $"UserEmailVerification:{rowBId}", "the-token-for-B")
+            .Returns(true);
+
+        var result = await _service.VerifyEmailAsync(userId, rowBId, "the-token-for-B");
+
+        result.MergeRequestCreated.Should().BeFalse();
+        result.Email.Should().Be("b@example.com");
+        rowB.IsVerified.Should().BeTrue();
+        // Row A was never loaded — VerifyEmailAsync must look up by the
+        // emailId argument, not enumerate the user's other pending rows.
+        await _repository.DidNotReceive().GetByIdAndUserIdAsync(
+            rowAId, userId, Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task VerifyEmailAsync_TokenForOtherRow_FailsWithoutVerifyingAnyRow()
+    {
+        // Token was issued for row A (purpose "...:rowAId"). The user clicks
+        // the link for row B (caller passes rowBId). The token is invalid for
+        // row B's purpose, so VerifyUserTokenAsync returns false and
+        // ValidationException surfaces — but neither row gets verified.
+        var userId = Guid.NewGuid();
+        var rowAId = Guid.NewGuid();
+        var rowBId = Guid.NewGuid();
+        var rowB = new UserEmail
+        {
+            Id = rowBId,
+            UserId = userId,
+            Email = "b@example.com",
+            IsVerified = false,
+            Provider = null,
+        };
+
+        var user = new User { Id = userId, DisplayName = "U" };
+        _userService.GetByIdAsync(userId, Arg.Any<CancellationToken>()).Returns(user);
+        _repository.GetByIdAndUserIdAsync(rowBId, userId, Arg.Any<CancellationToken>())
+            .Returns(rowB);
+        // Token from row A's link is NOT valid against row B's purpose suffix.
+        _userManager.VerifyUserTokenAsync(
+                user, TokenOptions.DefaultEmailProvider,
+                $"UserEmailVerification:{rowBId}", "token-issued-for-A")
+            .Returns(false);
+
+        var act = async () => await _service.VerifyEmailAsync(
+            userId, rowBId, "token-issued-for-A");
+
+        await act.Should().ThrowAsync<System.ComponentModel.DataAnnotations.ValidationException>();
+        rowB.IsVerified.Should().BeFalse();
+    }
+
+    [HumansFact]
+    public async Task VerifyEmailAsync_RowAlreadyVerified_ThrowsWithoutDoubleVerifying()
+    {
+        var userId = Guid.NewGuid();
+        var rowId = Guid.NewGuid();
+        var verified = new UserEmail
+        {
+            Id = rowId,
+            UserId = userId,
+            Email = "v@example.com",
+            IsVerified = true,
+            Provider = null,
+        };
+
+        var user = new User { Id = userId, DisplayName = "U" };
+        _userService.GetByIdAsync(userId, Arg.Any<CancellationToken>()).Returns(user);
+        _repository.GetByIdAndUserIdAsync(rowId, userId, Arg.Any<CancellationToken>())
+            .Returns(verified);
+
+        var act = async () => await _service.VerifyEmailAsync(userId, rowId, "any-token");
+
+        await act.Should().ThrowAsync<System.ComponentModel.DataAnnotations.ValidationException>();
+    }
+
+    [HumansFact]
+    public async Task VerifyEmailAsync_OAuthRow_Throws()
+    {
+        // Provider != null rows are tagged with an OAuth identity and verified
+        // via the OAuth callback — never via a plain verification link.
+        var userId = Guid.NewGuid();
+        var rowId = Guid.NewGuid();
+        var oauth = new UserEmail
+        {
+            Id = rowId,
+            UserId = userId,
+            Email = "oauth@example.com",
+            IsVerified = false,
+            Provider = "Google",
+            ProviderKey = "sub-x",
+        };
+
+        var user = new User { Id = userId, DisplayName = "U" };
+        _userService.GetByIdAsync(userId, Arg.Any<CancellationToken>()).Returns(user);
+        _repository.GetByIdAndUserIdAsync(rowId, userId, Arg.Any<CancellationToken>())
+            .Returns(oauth);
+
+        var act = async () => await _service.VerifyEmailAsync(userId, rowId, "any-token");
+
+        await act.Should().ThrowAsync<System.ComponentModel.DataAnnotations.ValidationException>();
+    }
 }

--- a/tests/Humans.Integration.Tests/Controllers/EmailGridFlowTests.cs
+++ b/tests/Humans.Integration.Tests/Controllers/EmailGridFlowTests.cs
@@ -58,7 +58,7 @@ public class EmailGridFlowTests : IntegrationTestBase
             addResult.IsConflict.Should().BeTrue(
                 "AddEmail must flag the conflict so the verification email warns the user.");
 
-            var verifyResult = await userEmailService.VerifyEmailAsync(userAId, addResult.Token);
+            var verifyResult = await userEmailService.VerifyEmailAsync(userAId, addResult.EmailId, addResult.Token);
             verifyResult.MergeRequestCreated.Should().BeTrue(
                 "the verify-time conflict path is what writes the merge request.");
         }
@@ -165,7 +165,7 @@ public class EmailGridFlowTests : IntegrationTestBase
             var addResult = await userEmailService.AddEmailAsync(targetUserId, sharedEmail);
             addResult.IsConflict.Should().BeTrue();
 
-            var verifyResult = await userEmailService.VerifyEmailAsync(targetUserId, addResult.Token);
+            var verifyResult = await userEmailService.VerifyEmailAsync(targetUserId, addResult.EmailId, addResult.Token);
             verifyResult.MergeRequestCreated.Should().BeTrue(
                 "even when an admin initiates the add, cross-user collisions must surface as merge requests, not silent folds.");
         }


### PR DESCRIPTION
Closes nobodies-collective/Humans#611

## Summary

`UserEmailService.VerifyEmailAsync` used `FirstOrDefault(e => !e.IsVerified && e.Provider == null)` to pick the pending row, but the verification token (`GenerateUserTokenAsync` purpose `\"UserEmailVerification:{userEmail.Id}\"`) is bound to a specific row Id. When a user has multiple pending plain rows — common after `AdminAddEmail` interleaves with a self-added pending row — `FirstOrDefault` could pick the wrong row and a valid token would surface as \"expired or invalid\" to the user.

## Changes

- **`AddEmailResult`** now carries the new row's `EmailId` alongside `Token`.
- **`IUserEmailService.VerifyEmailAsync`** takes `(userId, emailId, token)`. The implementation loads the row via `GetByIdAndUserIdAsync(emailId, userId)` and rejects already-verified or Provider-tagged rows.
- **`ProfileController.AddEmail` / `AdminAddEmail`** include `emailId` in the verification URL alongside `userId` and `token`.
- **`ProfileController.VerifyEmail`** accepts `emailId` as a query param and rejects empty Guids up front.

## Tests

- `VerifyEmailAsync_LoadsRowByEmailIdNotFirstPending` — two pending rows, link is issued for row B; verifies row B and never touches row A.
- `VerifyEmailAsync_TokenForOtherRow_FailsWithoutVerifyingAnyRow` — token generated for row A's purpose can't validate row B's purpose.
- `VerifyEmailAsync_RowAlreadyVerified_ThrowsWithoutDoubleVerifying`.
- `VerifyEmailAsync_OAuthRow_Throws` — Provider-tagged rows are out of scope for plain verification.
- Existing call sites in `ProfileControllerEmailGridTests` and `EmailGridFlowTests` updated for the new signatures.

## Acceptance

- [x] User with two unverified plain rows can verify each via its own link
- [x] Token from row A cannot validate row B
- [x] No regression on the typical single-pending-row flow