### PR TITLE
issue-652: gate Reset+2FA behind 2SV-not-enrolled

### DIFF
--- a/docs/features/32-workspace-account-provisioning.md
+++ b/docs/features/32-workspace-account-provisioning.md
@@ -95,20 +95,21 @@ Nobodies Collective uses Google Workspace for organizational email (@nobodies.te
 ### US-32.7: Reset Password + Get 2FA (combined recovery)
 **As an** admin
 **I want to** reset the password AND grab one fresh backup verification code in a single action
-**So that** I can unblock a locked-out human regardless of their 2SV-enrollment state — they can sign in with the password + code, then enroll/re-enroll a real second factor
+**So that** I can unblock a locked-out human who has not yet enrolled in 2SV — they can sign in with the password + code, then enroll a real second factor
 
 **Acceptance Criteria:**
-- "Reset + 2FA" button per row, Admin-only, CSRF-protected, hidden for suspended accounts
+- "Reset + 2FA" button per row, Admin-only, CSRF-protected, hidden for suspended accounts **and for accounts already enrolled in 2-Step Verification** (the combined flow rotates backup codes destructively, so running it against a working 2FA setup would silently break it)
 - Confirm-before-post explains both will be shown once
 - Calls `IGoogleAdminService.ResetPasswordAndGenerate2FaAsync` which composes the existing password-reset + backup-codes flows; only the **first** code from the freshly-issued set is surfaced (the rest are unused — Google rotates the whole set destructively, but the admin only ever needs one)
 - Confirmed (2026-05-04) to work for accounts that have not yet completed 2SV enrollment
+- **Server-side gate**: `ResetPasswordAndGenerate2FaAsync` re-fetches live Directory state at the top of the method and refuses with a clear error when `IsEnrolledIn2Sv` is true. The refusal is independent of the UI — a hand-crafted POST to `Accounts/ResetPasswordAndGenerate2Fa` for an enrolled email also returns the error path (no password reset, no code rotation). Refusals are logged via `WorkspaceAccountResetBlockedFor2Sv` for audit / abuse-pattern detection. If an admin genuinely needs to rotate 2FA for an enrolled human, that's done in the Google Admin console.
 - Both credentials appear once in the same modal as the password-only flow, with copy-to-clipboard formatted as:
   ```
   pw: <temp password>
   2fa: <single backup code>
   ```
 - Modal text-content is cleared on close so browser back/refresh can't re-expose the secrets
-- Two audit entries recorded: `WorkspaceAccountPasswordReset` then `WorkspaceAccountBackupCodesGenerated`
+- Two audit entries recorded on the success path: `WorkspaceAccountPasswordReset` then `WorkspaceAccountBackupCodesGenerated`. The blocked-by-2SV path records `WorkspaceAccountResetBlockedFor2Sv` instead and performs no Workspace mutation.
 - Requires the `admin.directory.user.security` scope on the service account credential
 
 ## Account-Management Invariants

--- a/src/Humans.Application/Services/GoogleIntegration/GoogleAdminService.cs
+++ b/src/Humans.Application/Services/GoogleIntegration/GoogleAdminService.cs
@@ -406,6 +406,9 @@ public sealed class GoogleAdminService : IGoogleAdminService
 
         if (liveAccount is null)
         {
+            _logger.LogWarning(
+                "Reset+2FA refused for {Email}: account not found in Workspace Directory. Actor: {ActorUserId}.",
+                email, actorUserId);
             return new WorkspaceRecoveryCredentialsResult(
                 Success: false,
                 Email: email,
@@ -414,11 +417,29 @@ public sealed class GoogleAdminService : IGoogleAdminService
 
         if (liveAccount.IsEnrolledIn2Sv)
         {
-            await _auditLogService.LogAsync(
-                AuditAction.WorkspaceAccountResetBlockedFor2Sv,
-                "WorkspaceAccount", Guid.Empty,
-                $"Refused Reset+2FA for @{NobodiesTeamDomain} account {email}: already enrolled in 2-Step Verification",
-                actorUserId);
+            _logger.LogWarning(
+                "Reset+2FA refused for {Email}: already enrolled in 2-Step Verification. Actor: {ActorUserId}.",
+                email, actorUserId);
+
+            // Audit AFTER the refusal decision. If audit persistence throws,
+            // log Critical and still return the user-facing refusal — degrading
+            // gracefully on an audit-side outage matches the BackupCodesGenerated
+            // pattern below, and forcing a 500 here would mask a safe outcome
+            // (no Workspace mutation happened).
+            try
+            {
+                await _auditLogService.LogAsync(
+                    AuditAction.WorkspaceAccountResetBlockedFor2Sv,
+                    "WorkspaceAccount", Guid.Empty,
+                    $"Refused Reset+2FA for @{NobodiesTeamDomain} account {email}: already enrolled in 2-Step Verification",
+                    actorUserId);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogCritical(ex,
+                    "Audit-log write failed for Reset+2FA refusal on {Email} by actor {ActorUserId}. Refusal was still surfaced to the admin; reconcile audit trail manually.",
+                    email, actorUserId);
+            }
 
             return new WorkspaceRecoveryCredentialsResult(
                 Success: false,

--- a/src/Humans.Application/Services/GoogleIntegration/GoogleAdminService.cs
+++ b/src/Humans.Application/Services/GoogleIntegration/GoogleAdminService.cs
@@ -385,6 +385,47 @@ public sealed class GoogleAdminService : IGoogleAdminService
         string email, Guid actorUserId,
         CancellationToken ct = default)
     {
+        // Refuse if the account is already enrolled in 2-Step Verification.
+        // The combined flow rotates the backup-code set destructively, so
+        // running it against a properly-set-up account would silently break
+        // the human's working 2FA. Always re-check live Directory state — the
+        // UI hides the button, but a hand-crafted POST must hit the same gate.
+        WorkspaceUserAccount? liveAccount;
+        try
+        {
+            liveAccount = await _workspaceUserService.GetAccountAsync(email, ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to fetch live 2SV state for: {Email}", email);
+            return new WorkspaceRecoveryCredentialsResult(
+                Success: false,
+                Email: email,
+                ErrorMessage: $"Failed to verify 2FA enrollment for {email}. Aborted; no changes made.");
+        }
+
+        if (liveAccount is null)
+        {
+            return new WorkspaceRecoveryCredentialsResult(
+                Success: false,
+                Email: email,
+                ErrorMessage: $"Account {email} not found in Workspace Directory.");
+        }
+
+        if (liveAccount.IsEnrolledIn2Sv)
+        {
+            await _auditLogService.LogAsync(
+                AuditAction.WorkspaceAccountResetBlockedFor2Sv,
+                "WorkspaceAccount", Guid.Empty,
+                $"Refused Reset+2FA for @{NobodiesTeamDomain} account {email}: already enrolled in 2-Step Verification",
+                actorUserId);
+
+            return new WorkspaceRecoveryCredentialsResult(
+                Success: false,
+                Email: email,
+                ErrorMessage: $"{email} is already enrolled in 2FA. Reset+2FA is for locked-out humans only — use the plain Reset Password button, or rotate 2FA in the Google Admin console.");
+        }
+
         // Step 1: reset the password. Audit + return on failure — there's
         // no point grabbing a backup code if the human can't sign in anyway.
         var resetResult = await ResetPasswordAsync(email, actorUserId, ct);

--- a/src/Humans.Domain/Enums/AuditAction.cs
+++ b/src/Humans.Domain/Enums/AuditAction.cs
@@ -69,6 +69,7 @@ public enum AuditAction
     // Reserved — was wired briefly during PR #254 development. No code path
     // currently writes this value; do not remove (audit enum is positional).
     WorkspaceAccountBackupCodesInvalidated,
+    WorkspaceAccountResetBlockedFor2Sv,
     AccountMergeRequested,
     AccountMergeAccepted,
     AccountMergeRejected,

--- a/src/Humans.Web/Views/Google/Accounts.cshtml
+++ b/src/Humans.Web/Views/Google/Accounts.cshtml
@@ -248,16 +248,19 @@
                                                 <i class="fa-solid fa-key me-1"></i>@Localizer["GoogleAccounts_ResetPassword"]
                                             </button>
                                         </form>
-                                        <form asp-action="ResetPasswordAndGenerate2Fa" method="post" class="d-inline"
-                                              data-confirm="Reset password and issue a backup verification code for @account.PrimaryEmail? Both will be shown once. Any previously-issued backup codes will be invalidated.">
-                                            @Html.AntiForgeryToken()
-                                            <input type="hidden" name="email" value="@account.PrimaryEmail" />
-                                            <button type="submit" class="btn btn-outline-danger btn-sm"
-                                                    title="Reset the password AND issue one backup code — for locked-out humans (any 2FA state)"
-                                                    data-bs-toggle="tooltip">
-                                                <i class="fa-solid fa-key me-1"></i>Reset + 2FA
-                                            </button>
-                                        </form>
+                                        @if (!account.IsEnrolledIn2Sv)
+                                        {
+                                            <form asp-action="ResetPasswordAndGenerate2Fa" method="post" class="d-inline"
+                                                  data-confirm="Reset password and issue a backup verification code for @account.PrimaryEmail? Both will be shown once. Any previously-issued backup codes will be invalidated.">
+                                                @Html.AntiForgeryToken()
+                                                <input type="hidden" name="email" value="@account.PrimaryEmail" />
+                                                <button type="submit" class="btn btn-outline-danger btn-sm"
+                                                        title="Reset the password AND issue one backup code — for locked-out humans not yet enrolled in 2FA"
+                                                        data-bs-toggle="tooltip">
+                                                    <i class="fa-solid fa-key me-1"></i>Reset + 2FA
+                                                </button>
+                                            </form>
+                                        }
                                     </div>
                                 }
                             </td>

--- a/tests/Humans.Application.Tests/Services/GoogleAdminServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/GoogleAdminServiceTests.cs
@@ -51,6 +51,19 @@ public class GoogleAdminServiceTests
         _teamResourceService.GetActiveResourceCountsByTeamAsync(Arg.Any<CancellationToken>())
             .Returns(new Dictionary<Guid, int>());
 
+        // Default: Reset+2FA gate sees the account as not-yet-enrolled in 2SV,
+        // so the recovery flow runs end-to-end. Tests that need the enrolled
+        // path override this per-test.
+        _workspaceUserService.GetAccountAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(ci => new WorkspaceUserAccount(
+                PrimaryEmail: ci.ArgAt<string>(0),
+                FirstName: "Test",
+                LastName: "User",
+                IsSuspended: false,
+                CreationTime: DateTime.UtcNow,
+                LastLoginTime: null,
+                IsEnrolledIn2Sv: false));
+
         _service = new GoogleAdminService(
             _workspaceUserService,
             _googleSyncService,
@@ -546,6 +559,60 @@ public class GoogleAdminServiceTests
         result.TempPassword.Should().NotBeNullOrEmpty();
         result.BackupCode.Should().BeNull();
         result.Message.Should().Contain("Backup-code generation failed");
+    }
+
+    [HumansFact]
+    public async Task ResetPasswordAndGenerate2FaAsync_RefusesAndAuditsWhenAlreadyEnrolledIn2Sv()
+    {
+        // Live Directory state says the human already has 2-Step Verification.
+        // Running the combined flow would destructively rotate their working
+        // 2FA setup, so the service must refuse — even if the UI button was
+        // somehow bypassed by a hand-crafted POST.
+        _workspaceUserService.GetAccountAsync(
+                "alice@nobodies.team", Arg.Any<CancellationToken>())
+            .Returns(new WorkspaceUserAccount(
+                "alice@nobodies.team", "Alice", "Smith", IsSuspended: false,
+                CreationTime: DateTime.UtcNow, LastLoginTime: null,
+                IsEnrolledIn2Sv: true));
+
+        var result = await _service.ResetPasswordAndGenerate2FaAsync(
+            "alice@nobodies.team", _actorUserId);
+
+        result.Success.Should().BeFalse();
+        result.TempPassword.Should().BeNull();
+        result.BackupCode.Should().BeNull();
+        result.ErrorMessage.Should().Contain("already enrolled in 2FA");
+
+        // No password reset, no backup-code rotation.
+        await _workspaceUserService.DidNotReceive().ResetPasswordAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await _workspaceUserService.DidNotReceive().GenerateBackupCodesAsync(
+            Arg.Any<string>(), Arg.Any<CancellationToken>());
+
+        // Refusal is audited so the attempt shows up in the trail.
+        await _auditLogService.Received(1).LogAsync(
+            AuditAction.WorkspaceAccountResetBlockedFor2Sv,
+            "WorkspaceAccount", Guid.Empty,
+            Arg.Is<string>(s => s.Contains("alice@nobodies.team")),
+            _actorUserId,
+            Arg.Any<Guid?>(), Arg.Any<string?>());
+    }
+
+    [HumansFact]
+    public async Task ResetPasswordAndGenerate2FaAsync_ReturnsErrorWhenAccountNotFound()
+    {
+        _workspaceUserService.GetAccountAsync(
+                "ghost@nobodies.team", Arg.Any<CancellationToken>())
+            .Returns((WorkspaceUserAccount?)null);
+
+        var result = await _service.ResetPasswordAndGenerate2FaAsync(
+            "ghost@nobodies.team", _actorUserId);
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("not found");
+
+        await _workspaceUserService.DidNotReceive().ResetPasswordAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
     // --- LinkAccountAsync ---

--- a/tests/Humans.Application.Tests/Services/GoogleAdminServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/GoogleAdminServiceTests.cs
@@ -599,6 +599,37 @@ public class GoogleAdminServiceTests
     }
 
     [HumansFact]
+    public async Task ResetPasswordAndGenerate2FaAsync_StillRefusesWhenAuditWriteFailsOnEnrolledAccount()
+    {
+        // The 2SV refusal happens BEFORE any Workspace mutation, so an audit
+        // outage must not turn a safe refusal into a 500 — we surface the
+        // refusal regardless and log the audit failure as Critical.
+        _workspaceUserService.GetAccountAsync(
+                "alice@nobodies.team", Arg.Any<CancellationToken>())
+            .Returns(new WorkspaceUserAccount(
+                "alice@nobodies.team", "Alice", "Smith", IsSuspended: false,
+                CreationTime: DateTime.UtcNow, LastLoginTime: null,
+                IsEnrolledIn2Sv: true));
+        _auditLogService.LogAsync(
+                AuditAction.WorkspaceAccountResetBlockedFor2Sv,
+                Arg.Any<string>(), Arg.Any<Guid>(),
+                Arg.Any<string>(), Arg.Any<Guid>(),
+                Arg.Any<Guid?>(), Arg.Any<string?>())
+            .ThrowsAsync(new InvalidOperationException("Audit DB unavailable"));
+
+        var result = await _service.ResetPasswordAndGenerate2FaAsync(
+            "alice@nobodies.team", _actorUserId);
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("already enrolled in 2FA");
+
+        await _workspaceUserService.DidNotReceive().ResetPasswordAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await _workspaceUserService.DidNotReceive().GenerateBackupCodesAsync(
+            Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
     public async Task ResetPasswordAndGenerate2FaAsync_ReturnsErrorWhenAccountNotFound()
     {
         _workspaceUserService.GetAccountAsync(


### PR DESCRIPTION
Closes nobodies-collective/Humans#652.

## Summary
- Hide the "Reset + 2FA" button on `/Google/Accounts` rows where the human is already enrolled in 2-Step Verification.
- Refuse `ResetPasswordAndGenerate2FaAsync` server-side by re-fetching live Directory state — protects the endpoint against a hand-crafted POST that bypasses the UI.
- Audit the refusal via a new `AuditAction.WorkspaceAccountResetBlockedFor2Sv`.

## Why
The combined password-reset + backup-code-rotation flow is destructive: it invalidates any previously-issued backup codes, silently breaking a working 2FA setup. It is the right tool for locked-out humans who haven't yet enrolled in 2SV; it has no legitimate use against an already-enrolled account.

## Test plan
- [x] `dotnet build Humans.slnx -v quiet` — clean
- [x] `dotnet test Humans.slnx -v quiet` — Domain + Application tests pass (2120 in Application incl. 2 new tests covering the gate). Pre-existing integration-test timeouts are unrelated to this change.
- [ ] Smoke on the PR preview env at `/Google/Accounts`: rows with the green "2FA" badge show only the plain "Reset Password" button; rows with the warning "No 2FA" badge show both buttons.
- [ ] Hand-crafted POST to `/Google/Accounts/ResetPasswordAndGenerate2Fa` with an enrolled email returns the error path (no password reset, no code rotation, audit row written).

🤖 Generated with [Claude Code](https://claude.com/claude-code)