### PR TITLE
nobodies-collective#658: bump /Admin/Logs in-memory sink capacity to 1000

### DIFF
--- a/src/Humans.Web/Controllers/AdminController.cs
+++ b/src/Humans.Web/Controllers/AdminController.cs
@@ -136,9 +136,9 @@ public class AdminController : HumansControllerBase
 
     [HttpGet("Logs")]
     [Authorize(Policy = PolicyNames.AdminOnly)]
-    public IActionResult Logs(int count = 200)
+    public IActionResult Logs(int count = 1000)
     {
-        count = Math.Clamp(count, 1, 200);
+        count = Math.Clamp(count, 1, 1000);
         var sink = Infrastructure.InMemoryLogSink.Instance;
         var events = sink.GetEvents(count);
         ViewBag.LifetimeCounts = sink.GetLifetimeCounts();

--- a/src/Humans.Web/Controllers/LogApiController.cs
+++ b/src/Humans.Web/Controllers/LogApiController.cs
@@ -15,7 +15,7 @@ public class LogApiController : ControllerBase
         [FromQuery] int count = 50,
         [FromQuery] string? minLevel = null)
     {
-        count = Math.Clamp(count, 1, 200);
+        count = Math.Clamp(count, 1, 1000);
 
         LogEventLevel? minLogLevel = null;
         if (minLevel is not null)
@@ -32,7 +32,7 @@ public class LogApiController : ControllerBase
                 return BadRequest(new { error = $"Invalid minLevel '{minLevel}'. Valid values: Warning, Error, Fatal" });
         }
 
-        var events = InMemoryLogSink.Instance.GetEvents(200);
+        var events = InMemoryLogSink.Instance.GetEvents(1000);
 
         if (minLogLevel.HasValue)
         {

--- a/src/Humans.Web/Infrastructure/InMemoryLogSink.cs
+++ b/src/Humans.Web/Infrastructure/InMemoryLogSink.cs
@@ -15,7 +15,7 @@ public sealed class InMemoryLogSink : ILogEventSink
     private readonly int _capacity;
     private readonly ConcurrentDictionary<LogEventLevel, long> _lifetimeCounts = new();
 
-    public InMemoryLogSink(int capacity = 200)
+    public InMemoryLogSink(int capacity = 1000)
     {
         _capacity = capacity;
     }
@@ -28,7 +28,7 @@ public sealed class InMemoryLogSink : ILogEventSink
             _events.TryDequeue(out _);
     }
 
-    public IReadOnlyList<LogEvent> GetEvents(int count = 200) =>
+    public IReadOnlyList<LogEvent> GetEvents(int count = 1000) =>
         _events.Reverse().Take(count).ToList();
 
     /// <summary>

--- a/src/Humans.Web/Views/Admin/Logs.cshtml
+++ b/src/Humans.Web/Views/Admin/Logs.cshtml
@@ -15,7 +15,7 @@
 
     <div class="d-flex justify-content-between align-items-center mb-3">
         <h1>Application Logs</h1>
-        <span class="text-muted">Showing @Model.Count of last 200 (in-memory buffer)</span>
+        <span class="text-muted">Showing @Model.Count of last 1000 (in-memory buffer)</span>
     </div>
 
     <div class="d-flex gap-3 mb-3 flex-wrap">


### PR DESCRIPTION
Closes nobodies-collective/Humans#658

## Summary
- `InMemoryLogSink` ring buffer capacity: 200 → 1000
- `InMemoryLogSink.GetEvents` default count: 200 → 1000
- `AdminController.Logs` query-param default + clamp: 200 → 1000
- `LogApiController` clamp + `GetEvents(...)` call: 200 → 1000
- `/Admin/Logs` view header text: "last 200" → "last 1000"

## Why
200 events fills quickly when sync jobs / batch operations are noisy, so older context is evicted before triage. At ~500 users on a single server with Warning+ only, the memory cost of 1000 events is negligible.

## Test plan
- [ ] Hit `/Admin/Logs` and `/Admin/Logs?count=1000`, confirm up to 1000 events render
- [ ] Hit `/api/logs?count=1000` (with API key), confirm up to 1000 events return
- [ ] Header reads "Showing N of last 1000 (in-memory buffer)"