### PR TITLE
issue-664: warn on /Profile/Emails that merge isn't ticket transfer

### DIFF
--- a/src/Humans.Web/Resources/SharedResource.ca.resx
+++ b/src/Humans.Web/Resources/SharedResource.ca.resx
@@ -1359,6 +1359,8 @@
   <data name="Emails_ManageEmails" xml:space="preserve"><value>Adreces de correu</value></data>
   <data name="Emails_ManageEmailsHelp" xml:space="preserve"><value>Afegeix adreces de correu addicionals, controla notificacions i estableix la visibilitat del perfil.</value></data>
   <data name="Emails_ManageLater" xml:space="preserve"><value>Pots afegir i gestionar adreces de correu addicionals des del teu perfil després de completar la configuració.</value></data>
+  <data name="Emails_MergeWarningBody" xml:space="preserve"><value>La fusió de comptes serveix per combinar dos comptes que pertanyen a la mateixa persona (per exemple, un correu antic i un de nou, tots dos teus). No és una manera de compartir o transferir entrades, reserves o altres elements entre dues persones diferents. La transferència d'entrades entre humans és una funció separada, properament.</value></data>
+  <data name="Emails_MergeWarningTitle" xml:space="preserve"><value>Fusionar comptes?</value></data>
   <data name="Emails_ResendCooldown" xml:space="preserve"><value>Pots sol·licitar un correu de verificació nou d’aquí a {0} minut(s).</value></data>
   <data name="Emails_SendVerification" xml:space="preserve"><value>Envia correu de verificació</value></data>
   <data name="Emails_Title" xml:space="preserve"><value>Adreces de correu</value></data>

--- a/src/Humans.Web/Resources/SharedResource.de.resx
+++ b/src/Humans.Web/Resources/SharedResource.de.resx
@@ -1344,6 +1344,8 @@
   <data name="Emails_ManageEmails" xml:space="preserve"><value>E-Mail-Adressen</value></data>
   <data name="Emails_ManageEmailsHelp" xml:space="preserve"><value>Weitere E-Mail-Adressen hinzufügen, Benachrichtigungen steuern und Profilsichtbarkeit einstellen.</value></data>
   <data name="Emails_ManageLater" xml:space="preserve"><value>Du kannst nach Abschluss der Einrichtung weitere E-Mail-Adressen in deinem Profil hinzufügen und verwalten.</value></data>
+  <data name="Emails_MergeWarningBody" xml:space="preserve"><value>Das Zusammenführen von Konten dient dazu, zwei Konten zu kombinieren, die derselben Person gehören (zum Beispiel eine alte und eine neue E-Mail-Adresse, die beide dir gehören). Es ist kein Weg, Tickets, Buchungen oder andere Elemente zwischen zwei verschiedenen Personen zu teilen oder zu übertragen. Die Ticket-Übertragung zwischen Menschen ist eine separate Funktion und wird in Kürze verfügbar sein.</value></data>
+  <data name="Emails_MergeWarningTitle" xml:space="preserve"><value>Konten zusammenführen?</value></data>
   <data name="Emails_ResendCooldown" xml:space="preserve"><value>Du kannst in {0} Minute(n) eine neue Bestätigungs-E-Mail anfordern.</value></data>
   <data name="Emails_SendVerification" xml:space="preserve"><value>Bestätigungs-E-Mail senden</value></data>
   <data name="Emails_Title" xml:space="preserve"><value>E-Mail-Adressen</value></data>

--- a/src/Humans.Web/Resources/SharedResource.es.resx
+++ b/src/Humans.Web/Resources/SharedResource.es.resx
@@ -1359,6 +1359,8 @@
   <data name="Emails_ManageEmails" xml:space="preserve"><value>Direcciones de correo</value></data>
   <data name="Emails_ManageEmailsHelp" xml:space="preserve"><value>Agregar direcciones de correo adicionales, controlar notificaciones y establecer la visibilidad del perfil.</value></data>
   <data name="Emails_ManageLater" xml:space="preserve"><value>Puedes agregar y gestionar direcciones de correo adicionales desde tu perfil después de completar la configuración.</value></data>
+  <data name="Emails_MergeWarningBody" xml:space="preserve"><value>La fusión de cuentas sirve para combinar dos cuentas que pertenecen a la misma persona (por ejemplo, un correo antiguo y uno nuevo, ambos tuyos). No es una forma de compartir o transferir entradas, reservas u otros elementos entre dos personas distintas. La transferencia de entradas entre humanos es una función aparte, próximamente.</value></data>
+  <data name="Emails_MergeWarningTitle" xml:space="preserve"><value>¿Fusionar cuentas?</value></data>
   <data name="Emails_ResendCooldown" xml:space="preserve"><value>Puedes solicitar un nuevo correo de verificación en {0} minuto(s).</value></data>
   <data name="Emails_SendVerification" xml:space="preserve"><value>Enviar correo de verificación</value></data>
   <data name="Emails_Title" xml:space="preserve"><value>Direcciones de correo</value></data>

--- a/src/Humans.Web/Resources/SharedResource.fr.resx
+++ b/src/Humans.Web/Resources/SharedResource.fr.resx
@@ -1344,6 +1344,8 @@
   <data name="Emails_ManageEmails" xml:space="preserve"><value>Adresses e-mail</value></data>
   <data name="Emails_ManageEmailsHelp" xml:space="preserve"><value>Ajouter des adresses e-mail supplémentaires, gérer les notifications et définir la visibilité du profil.</value></data>
   <data name="Emails_ManageLater" xml:space="preserve"><value>Vous pourrez ajouter et gérer des adresses e-mail supplémentaires depuis votre profil après avoir terminé la configuration.</value></data>
+  <data name="Emails_MergeWarningBody" xml:space="preserve"><value>La fusion de comptes sert à combiner deux comptes appartenant à la même personne (par exemple, un ancien et un nouvel e-mail, tous deux les vôtres). Ce n'est pas un moyen de partager ou de transférer des billets, des réservations ou d'autres éléments entre deux personnes différentes. Le transfert de billets entre humains est une fonctionnalité distincte, bientôt disponible.</value></data>
+  <data name="Emails_MergeWarningTitle" xml:space="preserve"><value>Fusionner des comptes ?</value></data>
   <data name="Emails_ResendCooldown" xml:space="preserve"><value>Vous pourrez demander un nouvel e-mail de vérification dans {0} minute(s).</value></data>
   <data name="Emails_SendVerification" xml:space="preserve"><value>Envoyer un e-mail de vérification</value></data>
   <data name="Emails_Title" xml:space="preserve"><value>Adresses e-mail</value></data>

--- a/src/Humans.Web/Resources/SharedResource.it.resx
+++ b/src/Humans.Web/Resources/SharedResource.it.resx
@@ -1344,6 +1344,8 @@
   <data name="Emails_ManageEmails" xml:space="preserve"><value>Indirizzi e-mail</value></data>
   <data name="Emails_ManageEmailsHelp" xml:space="preserve"><value>Aggiungi indirizzi e-mail aggiuntivi, gestisci le notifiche e imposta la visibilità del profilo.</value></data>
   <data name="Emails_ManageLater" xml:space="preserve"><value>Puoi aggiungere e gestire indirizzi e-mail aggiuntivi dal tuo profilo dopo aver completato la configurazione.</value></data>
+  <data name="Emails_MergeWarningBody" xml:space="preserve"><value>L'unione degli account serve a combinare due account che appartengono alla stessa persona (per esempio, una vecchia e una nuova e-mail, entrambe tue). Non è un modo per condividere o trasferire biglietti, prenotazioni o altri elementi tra due persone diverse. Il trasferimento di biglietti tra umani è una funzionalità separata, in arrivo a breve.</value></data>
+  <data name="Emails_MergeWarningTitle" xml:space="preserve"><value>Unire account?</value></data>
   <data name="Emails_ResendCooldown" xml:space="preserve"><value>Puoi richiedere una nuova e-mail di verifica tra {0} minuto/i.</value></data>
   <data name="Emails_SendVerification" xml:space="preserve"><value>Invia e-mail di verifica</value></data>
   <data name="Emails_Title" xml:space="preserve"><value>Indirizzi e-mail</value></data>

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -359,6 +359,8 @@
   <data name="Emails_Description" xml:space="preserve"><value>Manage your email addresses. Your sign-in email is always included. Add additional emails, set which one receives notifications, and control profile visibility.</value></data>
   <data name="Emails_YourEmails" xml:space="preserve"><value>Your Email Addresses</value></data>
   <data name="Emails_AddNew" xml:space="preserve"><value>Add Email Address</value></data>
+  <data name="Emails_MergeWarningTitle" xml:space="preserve"><value>Merging accounts?</value></data>
+  <data name="Emails_MergeWarningBody" xml:space="preserve"><value>Account merge is for combining two accounts that belong to the same person (for example, an old email and a new email that are both yours). It is not a way to share or transfer tickets, bookings, or other items between two different people. Ticket transfer between humans is a separate feature, coming soon.</value></data>
   <data name="Emails_VerificationWillBeSent" xml:space="preserve"><value>A verification email will be sent to this address.</value></data>
   <data name="Emails_SendVerification" xml:space="preserve"><value>Send Verification Email</value></data>
   <data name="Emails_ResendCooldown" xml:space="preserve"><value>You can request a new verification email in {0} minute(s).</value><comment>{0} = minutes remaining</comment></data>

--- a/src/Humans.Web/Views/Profile/Emails.cshtml
+++ b/src/Humans.Web/Views/Profile/Emails.cshtml
@@ -299,6 +299,16 @@
                 <h5 class="mb-0">@Localizer["Emails_AddNew"]</h5>
             </div>
             <div class="card-body">
+                @if (!Model.IsAdminContext)
+                {
+                    <div class="alert alert-info d-flex align-items-start mb-3">
+                        <i class="fa-solid fa-circle-info me-2 fs-4"></i>
+                        <div>
+                            <strong>@Localizer["Emails_MergeWarningTitle"]</strong>
+                            <div>@Localizer["Emails_MergeWarningBody"]</div>
+                        </div>
+                    </div>
+                }
                 <form asp-action="@(Model.IsAdminContext ? "AdminAddEmail" : "AddEmail")"
                       asp-route-id="@(Model.IsAdminContext ? Model.TargetUserId : (Guid?)null)"
                       method="post">


### PR DESCRIPTION
Closes #664

## Summary
- Adds an info alert inside the **Add Email** card on `/Profile/Emails` (non-admin only) clarifying that account merge is for combining two accounts belonging to the same person, NOT a way to share or transfer tickets between two different people.
- References that ticket transfer between humans is a separate feature (coming via #382).
- New resx keys `Emails_MergeWarningTitle` / `Emails_MergeWarningBody`, localized in en, es, ca, de, fr, it.

## Why
Users were attempting to merge their account with a partner's account in a failed attempt to transfer event tickets, generating merge requests admins had to reject.

## Test plan
- [ ] Visit `/Profile/Emails` as a normal user → info banner with "Merging accounts?" appears above the Add Email form.
- [ ] Visit `/Profile/AdminEmails/{id}` as admin → banner does NOT appear.
- [ ] Switch language (es/ca/de/fr/it) → banner copy localized.