### PR TITLE
issue-651: fix TOCTOU race in ProfileService.SaveProfileAsync

### DIFF
--- a/src/Humans.Application/Services/Profile/ProfileService.cs
+++ b/src/Humans.Application/Services/Profile/ProfileService.cs
@@ -295,7 +295,14 @@ public sealed class ProfileService : IProfileService, IUserDataContributor, IUse
             // populated (BurnerName/FirstName/LastName), giving the
             // ProfileService_UpdateProfileAsync_TransitionsStubToActive
             // behavior contract a single home.
-            profile = new Domain.Entities.Profile
+            //
+            // Issue #651: use the idempotent insert. If a concurrent caller
+            // wins the race against profiles.UserId's unique index, re-fetch
+            // the winner's row by UserId and apply this caller's field
+            // updates to that entity — otherwise UpdateAsync would attach a
+            // detached entity with a non-matching Id and silently update
+            // zero rows.
+            var newProfile = new Domain.Entities.Profile
             {
                 Id = Guid.NewGuid(),
                 UserId = userId,
@@ -303,7 +310,24 @@ public sealed class ProfileService : IProfileService, IUserDataContributor, IUse
                 UpdatedAt = now,
                 State = ProfileState.Stub,
             };
-            await _profileRepository.AddAsync(profile, ct);
+            var inserted = await _profileRepository.AddIfNotExistsByUserIdAsync(newProfile, ct);
+            if (inserted)
+            {
+                profile = newProfile;
+            }
+            else
+            {
+                profile = await _profileRepository.GetByUserIdAsync(userId, ct);
+                if (profile is null)
+                {
+                    // Should not happen — AddIfNotExistsByUserIdAsync returned
+                    // false because a row exists. Re-fetch one more time in
+                    // case of a transient repeatable-read; if still missing,
+                    // surface as an exception rather than silently dropping.
+                    throw new InvalidOperationException(
+                        $"AddIfNotExistsByUserIdAsync reported a duplicate for user {userId} but no profile row could be re-read.");
+                }
+            }
         }
 
         profile.BurnerName = request.BurnerName;

--- a/tests/Humans.Application.Tests/Services/ProfileServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/ProfileServiceTests.cs
@@ -1677,6 +1677,74 @@ public class ProfileServiceTests : IDisposable
         };
     }
 
+    // --- Issue #651: TOCTOU race on profiles.UserId unique index ---
+
+    /// <summary>
+    /// Issue #651: when two callers concurrently SaveProfile a userId with no
+    /// pre-existing profile row, both must complete without throwing and the
+    /// final row must reflect one consistent set of writes — not a silently
+    /// dropped UpdateAsync against a non-matching Id.
+    ///
+    /// Determinism is achieved with a fake repository that mimics Postgres'
+    /// 23505 semantics: the first AddIfNotExistsByUserIdAsync wins, every
+    /// subsequent call returns false (and does not insert), and
+    /// GetByUserIdAsync after a winning insert returns the winner's row.
+    /// </summary>
+    [HumansFact(Timeout = 10000)]
+    public async Task SaveProfileAsync_TwoConcurrentCallers_BothComplete_WithSingleConsistentRow()
+    {
+        var userId = Guid.NewGuid();
+        await SeedUserAsync(userId);
+
+        var fakeRepo = new RaceSimulatingProfileRepository();
+        var service = new ProfileService(
+            fakeRepo, _userService,
+            _userEmailRepository,
+            _contactFieldRepository, _communicationPreferenceRepository,
+            _onboardingService, _auditLogService,
+            _membershipCalculator, _consentService, _ticketQueryService,
+            _applicationDecisionService, _campaignService,
+            _roleAssignmentService, _accountDeletionService,
+            _fileStorage,
+            _clock,
+            NullLogger<ProfileService>.Instance);
+
+        var requestA = MakeRequest(burnerName: "Alice", firstName: "Alice", lastName: "Aaron");
+        var requestB = MakeRequest(burnerName: "Bob", firstName: "Bob", lastName: "Baker");
+
+        // Run on threadpool tasks so the two callers actually contend on the
+        // fakeRepo's lock. VSTHRD003 is suppressed because the tasks are
+        // started here on threadpool threads — no deadlock risk in test code.
+#pragma warning disable VSTHRD003 // Avoid awaiting foreign Tasks
+        var taskA = Task.Run(() => service.SaveProfileAsync(userId, "Alice Aaron", requestA, "en"));
+        var taskB = Task.Run(() => service.SaveProfileAsync(userId, "Bob Baker", requestB, "en"));
+
+        var act = async () => await Task.WhenAll(taskA, taskB);
+        await act.Should().NotThrowAsync();
+#pragma warning restore VSTHRD003
+
+        // Exactly one row exists for this userId.
+        fakeRepo.Profiles.Should().ContainSingle(p => p.UserId == userId);
+
+        // The surviving row's fields match one of the two callers — neither
+        // caller's update was silently dropped onto a detached entity.
+        var row = fakeRepo.Profiles.Single(p => p.UserId == userId);
+        var matchedA = string.Equals(row.BurnerName, "Alice", StringComparison.Ordinal)
+            && string.Equals(row.FirstName, "Alice", StringComparison.Ordinal)
+            && string.Equals(row.LastName, "Aaron", StringComparison.Ordinal);
+        var matchedB = string.Equals(row.BurnerName, "Bob", StringComparison.Ordinal)
+            && string.Equals(row.FirstName, "Bob", StringComparison.Ordinal)
+            && string.Equals(row.LastName, "Baker", StringComparison.Ordinal);
+        (matchedA || matchedB).Should().BeTrue(
+            "the final row must reflect one of the two parallel callers' writes");
+
+        // Exactly one insert succeeded; the other call observed the
+        // unique-violation no-op and re-fetched the winner.
+        fakeRepo.AddIfNotExistsTrueCount.Should().Be(1);
+        fakeRepo.AddIfNotExistsFalseCount.Should().Be(1);
+        fakeRepo.UpdateCallCount.Should().Be(2);
+    }
+
     [HumansFact]
     public async Task ContributeForUserAsync_EmitsIsOAuthKey_SourcedFromProviderColumn()
     {
@@ -1716,5 +1784,140 @@ public class ProfileServiceTests : IDisposable
         // renamed property — the GDPR export must keep emitting "IsNotificationTarget".
         json.Should().Contain("\"IsNotificationTarget\":true");
         json.Should().NotContain("\"IsPrimary\":");
+    }
+
+    /// <summary>
+    /// Race-simulating <see cref="IProfileRepository"/> for issue #651.
+    /// Mimics Postgres' <c>profiles.UserId</c> unique-index semantics:
+    /// the first <see cref="AddIfNotExistsByUserIdAsync"/> for a given UserId
+    /// wins; subsequent calls return false (no insert). <see cref="GetByUserIdAsync"/>
+    /// returns whatever the winner inserted, exposing the "race-loser must
+    /// re-fetch the winner's row" path that ProfileService.SaveProfileAsync
+    /// would otherwise stomp with a detached entity. Only the methods exercised
+    /// by SaveProfileAsync are implemented; the rest throw to surface
+    /// accidental coupling.
+    /// </summary>
+    private sealed class RaceSimulatingProfileRepository : IProfileRepository
+    {
+        private readonly Dictionary<Guid, Profile> _byUserId = new();
+        private readonly Lock _gate = new();
+
+        public int AddIfNotExistsTrueCount { get; private set; }
+        public int AddIfNotExistsFalseCount { get; private set; }
+        public int UpdateCallCount { get; private set; }
+        public IReadOnlyCollection<Profile> Profiles
+        {
+            get { lock (_gate) { return _byUserId.Values.ToList(); } }
+        }
+
+        public Task<Profile?> GetByUserIdAsync(Guid userId, CancellationToken ct = default)
+        {
+            lock (_gate)
+            {
+                return Task.FromResult(_byUserId.TryGetValue(userId, out var p) ? Clone(p) : null);
+            }
+        }
+
+        public Task<bool> AddIfNotExistsByUserIdAsync(Profile profile, CancellationToken ct = default)
+        {
+            lock (_gate)
+            {
+                if (_byUserId.ContainsKey(profile.UserId))
+                {
+                    AddIfNotExistsFalseCount++;
+                    return Task.FromResult(false);
+                }
+                _byUserId[profile.UserId] = Clone(profile);
+                AddIfNotExistsTrueCount++;
+                return Task.FromResult(true);
+            }
+        }
+
+        public Task UpdateAsync(Profile profile, CancellationToken ct = default)
+        {
+            lock (_gate)
+            {
+                UpdateCallCount++;
+                // Only persist the update if the row's Id matches the row we
+                // hold — exactly the contract a real EF UpdateAsync upholds via
+                // the primary key. This makes the bug from issue #651 visible:
+                // if SaveProfileAsync hands us a Profile with a freshly-generated
+                // (race-loser) Id rather than re-fetched from the winner's row,
+                // the update silently does nothing.
+                if (_byUserId.TryGetValue(profile.UserId, out var existing) &&
+                    existing.Id == profile.Id)
+                {
+                    _byUserId[profile.UserId] = Clone(profile);
+                }
+                return Task.CompletedTask;
+            }
+        }
+
+        public Task AddAsync(Profile profile, CancellationToken ct = default)
+            => throw new NotSupportedException("Issue #651: SaveProfileAsync should no longer call AddAsync.");
+
+        private static Profile Clone(Profile source) => new()
+        {
+            Id = source.Id,
+            UserId = source.UserId,
+            CreatedAt = source.CreatedAt,
+            UpdatedAt = source.UpdatedAt,
+            State = source.State,
+            BurnerName = source.BurnerName,
+            FirstName = source.FirstName,
+            LastName = source.LastName,
+            City = source.City,
+            CountryCode = source.CountryCode,
+            Latitude = source.Latitude,
+            Longitude = source.Longitude,
+            PlaceId = source.PlaceId,
+            Bio = source.Bio,
+            Pronouns = source.Pronouns,
+            ContributionInterests = source.ContributionInterests,
+            BoardNotes = source.BoardNotes,
+            EmergencyContactName = source.EmergencyContactName,
+            EmergencyContactPhone = source.EmergencyContactPhone,
+            EmergencyContactRelationship = source.EmergencyContactRelationship,
+            NoPriorBurnExperience = source.NoPriorBurnExperience,
+            DateOfBirth = source.DateOfBirth,
+            ProfilePictureData = source.ProfilePictureData,
+            ProfilePictureContentType = source.ProfilePictureContentType,
+            MembershipTier = source.MembershipTier,
+            IsApproved = source.IsApproved,
+            IsSuspended = source.IsSuspended,
+            ConsentCheckStatus = source.ConsentCheckStatus,
+            ConsentCheckAt = source.ConsentCheckAt,
+            ConsentCheckedByUserId = source.ConsentCheckedByUserId,
+            ConsentCheckNotes = source.ConsentCheckNotes,
+            AdminNotes = source.AdminNotes,
+            RejectedAt = source.RejectedAt,
+            RejectedByUserId = source.RejectedByUserId,
+            RejectionReason = source.RejectionReason,
+        };
+
+        // ----- Unused by the SaveProfile path; intentionally left throwing. -----
+        public Task<Profile?> GetByUserIdReadOnlyAsync(Guid userId, CancellationToken ct = default) => throw new NotSupportedException("RaceSimulatingProfileRepository only implements the SaveProfileAsync surface");
+        public Task<IReadOnlyDictionary<Guid, Profile>> GetByUserIdsAsync(IReadOnlyCollection<Guid> userIds, CancellationToken ct = default) => throw new NotSupportedException("RaceSimulatingProfileRepository only implements the SaveProfileAsync surface");
+        public Task<IReadOnlyList<Profile>> GetAllAsync(CancellationToken ct = default) => throw new NotSupportedException("RaceSimulatingProfileRepository only implements the SaveProfileAsync surface");
+        public Task<Guid?> GetOwnerUserIdAsync(Guid profileId, CancellationToken ct = default) => throw new NotSupportedException("RaceSimulatingProfileRepository only implements the SaveProfileAsync surface");
+        public Task<(byte[]? Data, string? ContentType)> GetProfilePictureDataAsync(Guid profileId, CancellationToken ct = default) => throw new NotSupportedException("RaceSimulatingProfileRepository only implements the SaveProfileAsync surface");
+        public Task<string?> GetProfilePictureContentTypeAsync(Guid profileId, CancellationToken ct = default) => throw new NotSupportedException("RaceSimulatingProfileRepository only implements the SaveProfileAsync surface");
+        public Task<IReadOnlyList<(Guid ProfileId, Guid UserId, long UpdatedAtTicks)>> GetCustomPictureInfoByUserIdsAsync(IEnumerable<Guid> userIds, CancellationToken ct = default) => throw new NotSupportedException("RaceSimulatingProfileRepository only implements the SaveProfileAsync surface");
+        public Task<(int ColaboradorCount, int AsociadoCount)> GetTierCountsAsync(CancellationToken ct = default) => throw new NotSupportedException("RaceSimulatingProfileRepository only implements the SaveProfileAsync surface");
+        public Task<IReadOnlyList<Guid>> GetActiveApprovedUserIdsAsync(CancellationToken ct = default) => throw new NotSupportedException("RaceSimulatingProfileRepository only implements the SaveProfileAsync surface");
+        public Task<IReadOnlyList<Profile>> GetReviewableAsync(CancellationToken ct = default) => throw new NotSupportedException("RaceSimulatingProfileRepository only implements the SaveProfileAsync surface");
+        public Task<int> GetReviewableCountAsync(CancellationToken ct = default) => throw new NotSupportedException("RaceSimulatingProfileRepository only implements the SaveProfileAsync surface");
+        public Task<IReadOnlyList<Guid>> GetApprovedUserIdsAsync(CancellationToken ct = default) => throw new NotSupportedException("RaceSimulatingProfileRepository only implements the SaveProfileAsync surface");
+        public Task<int> GetConsentReviewPendingCountAsync(CancellationToken ct = default) => throw new NotSupportedException("RaceSimulatingProfileRepository only implements the SaveProfileAsync surface");
+        public Task<int> GetNotApprovedAndNotSuspendedCountAsync(CancellationToken ct = default) => throw new NotSupportedException("RaceSimulatingProfileRepository only implements the SaveProfileAsync surface");
+        public Task<IReadOnlyList<ProfileLanguage>> GetLanguagesAsync(Guid profileId, CancellationToken ct = default) => throw new NotSupportedException("RaceSimulatingProfileRepository only implements the SaveProfileAsync surface");
+        public Task ReplaceLanguagesAsync(Guid profileId, IReadOnlyList<ProfileLanguage> languages, CancellationToken ct = default) => throw new NotSupportedException("RaceSimulatingProfileRepository only implements the SaveProfileAsync surface");
+        public Task<bool> AnonymizeForMergeByUserIdAsync(Guid userId, CancellationToken ct = default) => throw new NotSupportedException("RaceSimulatingProfileRepository only implements the SaveProfileAsync surface");
+        public Task<bool> AnonymizeForDeletionByUserIdAsync(Guid userId, CancellationToken ct = default) => throw new NotSupportedException("RaceSimulatingProfileRepository only implements the SaveProfileAsync surface");
+        public Task<IReadOnlySet<Guid>> SuspendManyAsync(IReadOnlyCollection<Guid> userIds, Instant now, CancellationToken ct = default) => throw new NotSupportedException("RaceSimulatingProfileRepository only implements the SaveProfileAsync surface");
+        public Task<IReadOnlyList<(Guid UserId, MembershipTier NewTier)>> DowngradeTierForExpiredAsync(MembershipTier currentTier, IReadOnlyCollection<Guid> userIdsToKeep, IReadOnlyDictionary<Guid, MembershipTier> fallbackTierByUser, Instant now, CancellationToken ct = default) => throw new NotSupportedException("RaceSimulatingProfileRepository only implements the SaveProfileAsync surface");
+        public Task<int> ReassignSubAggregatesToUserAsync(Guid sourceUserId, Guid targetUserId, Instant updatedAt, CancellationToken ct = default) => throw new NotSupportedException("RaceSimulatingProfileRepository only implements the SaveProfileAsync surface");
+        public Task ReconcileCVEntriesAsync(Guid profileId, IReadOnlyList<CVEntry> entries, CancellationToken ct = default) => throw new NotSupportedException("RaceSimulatingProfileRepository only implements the SaveProfileAsync surface");
+        public Task<bool> WriteBackStateIfNullAsync(Guid userId, ProfileState state, CancellationToken ct = default) => throw new NotSupportedException("RaceSimulatingProfileRepository only implements the SaveProfileAsync surface");
     }
 }


### PR DESCRIPTION
## Summary

Two concurrent first-time `SaveProfileAsync` calls for the same `userId` both passed the `GetByUserIdAsync` null check; the race-loser's `AddAsync` hit the `profiles.UserId` unique index and bubbled a 500. A naive swap to `AddIfNotExistsByUserIdAsync` would silently drop the loser's writes (UpdateAsync attaches an entity whose Id doesn't match the winner's row).

Fix: after `AddIfNotExistsByUserIdAsync` returns false, re-fetch the winner's row by `UserId` and apply the field updates to that entity.

## Test plan

- [x] New `SaveProfileAsync_TwoConcurrentCallers_BothComplete_WithSingleConsistentRow` asserts no exception, single row, surviving row matches one of the two callers (proving neither write was silently dropped)
- [x] Existing `ProfileService_UpdateProfileAsync_TransitionsStubToActive_WhenAllRequiredFieldsPopulated` and the broader `SaveProfileAsync_*` suite still pass
- [x] Build clean

Closes nobodies-collective/Humans#651