### PR TITLE
issue-663: extract IHttpContextAccessor session read out of OnboardingWidgetState

### DIFF
--- a/src/Humans.Application/Interfaces/Onboarding/IOnboardingWidgetSessionState.cs
+++ b/src/Humans.Application/Interfaces/Onboarding/IOnboardingWidgetSessionState.cs
@@ -1,0 +1,14 @@
+namespace Humans.Application.Interfaces.Onboarding;
+
+/// <summary>
+/// Per-request session-derived state consumed by <see cref="IOnboardingWidgetState"/>.
+/// Implemented in the Web layer so that the Application layer never references HTTP types.
+/// </summary>
+public interface IOnboardingWidgetSessionState
+{
+    /// <summary>
+    /// True when the user clicked "Not right now" on the Shifts step in this session.
+    /// Set by <c>/OnboardingWidget/Skip</c>; consumed when computing the current step.
+    /// </summary>
+    bool ShiftSkipActive { get; }
+}

--- a/src/Humans.Application/Services/Onboarding/OnboardingWidgetState.cs
+++ b/src/Humans.Application/Services/Onboarding/OnboardingWidgetState.cs
@@ -4,21 +4,17 @@ using Humans.Application.Interfaces.Onboarding;
 using Humans.Application.Interfaces.Profiles;
 using Humans.Application.Interfaces.Shifts;
 using Humans.Domain.Constants;
-using Microsoft.AspNetCore.Http;
 
 namespace Humans.Application.Services.Onboarding;
 
 public class OnboardingWidgetState : IOnboardingWidgetState
 {
-    /// <summary>Session key set by `/OnboardingWidget/Skip` and read here.</summary>
-    public const string ShiftSkipSessionKey = "OnboardingShiftSkip";
-
     private readonly IProfileService _profile;
     private readonly IShiftSignupService _signups;
     private readonly IMembershipCalculator _membership;
     private readonly IShiftManagementService _shiftMgmt;
     private readonly IConsentService _consents;
-    private readonly IHttpContextAccessor _http;
+    private readonly IOnboardingWidgetSessionState _session;
 
     public OnboardingWidgetState(
         IProfileService profile,
@@ -26,14 +22,14 @@ public class OnboardingWidgetState : IOnboardingWidgetState
         IMembershipCalculator membership,
         IShiftManagementService shiftMgmt,
         IConsentService consents,
-        IHttpContextAccessor http)
+        IOnboardingWidgetSessionState session)
     {
         _profile = profile;
         _signups = signups;
         _membership = membership;
         _shiftMgmt = shiftMgmt;
         _consents = consents;
-        _http = http;
+        _session = session;
     }
 
     public async Task<OnboardingWidgetStep> GetCurrentStepAsync(Guid userId, CancellationToken ct = default)
@@ -55,10 +51,7 @@ public class OnboardingWidgetState : IOnboardingWidgetState
         if (requiredRows.Any(r => r.Signed))
             return OnboardingWidgetStep.Consents;
 
-        var hasSkip = string.Equals(
-            _http.HttpContext?.Session.GetString(ShiftSkipSessionKey),
-            "true",
-            StringComparison.Ordinal);
+        var hasSkip = _session.ShiftSkipActive;
 
         var activeEvent = await _shiftMgmt.GetActiveAsync();
         var hasCurrentEventSignup = false;

--- a/src/Humans.Web/Controllers/OnboardingWidgetController.cs
+++ b/src/Humans.Web/Controllers/OnboardingWidgetController.cs
@@ -4,11 +4,11 @@ using Humans.Application.Interfaces.Consent;
 using Humans.Application.Interfaces.Onboarding;
 using Humans.Application.Interfaces.Profiles;
 using Humans.Application.Interfaces.Shifts;
-using Humans.Application.Services.Onboarding;
 using Humans.Domain.Constants;
 using Humans.Domain.Entities;
 using Humans.Web.Models;
 using Humans.Web.Models.OnboardingWidget;
+using Humans.Web.Services.Onboarding;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
@@ -170,7 +170,7 @@ public class OnboardingWidgetController : HumansControllerBase
     [ValidateAntiForgeryToken]
     public IActionResult Skip(CancellationToken ct)
     {
-        HttpContext.Session.SetString(OnboardingWidgetState.ShiftSkipSessionKey, "true");
+        HttpContext.Session.SetString(HttpOnboardingWidgetSessionState.ShiftSkipSessionKey, "true");
         return RedirectToAction(nameof(Consents));
     }
 

--- a/src/Humans.Web/Extensions/Sections/GovernanceSectionExtensions.cs
+++ b/src/Humans.Web/Extensions/Sections/GovernanceSectionExtensions.cs
@@ -8,6 +8,7 @@ using Humans.Infrastructure.Caching;
 using Humans.Infrastructure.Jobs;
 using Humans.Infrastructure.Repositories.Governance;
 using Humans.Infrastructure.Services;
+using Humans.Web.Services.Onboarding;
 using GovernanceApplicationDecisionService = Humans.Application.Services.Governance.ApplicationDecisionService;
 using OnboardingOrchestratorService = Humans.Application.Services.Onboarding.OnboardingService;
 using OnboardingWidgetStateService = Humans.Application.Services.Onboarding.OnboardingWidgetState;
@@ -43,6 +44,7 @@ internal static class GovernanceSectionExtensions
         services.AddScoped<IOnboardingEligibilityQuery>(sp => sp.GetRequiredService<OnboardingOrchestratorService>());
 
         services.AddScoped<IOnboardingWidgetState, OnboardingWidgetStateService>();
+        services.AddScoped<IOnboardingWidgetSessionState, HttpOnboardingWidgetSessionState>();
 
         services.AddScoped<TermRenewalReminderJob>();
 

--- a/src/Humans.Web/Services/Onboarding/HttpOnboardingWidgetSessionState.cs
+++ b/src/Humans.Web/Services/Onboarding/HttpOnboardingWidgetSessionState.cs
@@ -1,0 +1,26 @@
+using Humans.Application.Interfaces.Onboarding;
+
+namespace Humans.Web.Services.Onboarding;
+
+/// <summary>
+/// Web-layer implementation of <see cref="IOnboardingWidgetSessionState"/>.
+/// Reads the per-session "shift skip" flag set by <c>OnboardingWidgetController.Skip</c>
+/// from <see cref="HttpContext.Session"/>, keeping HTTP types out of the Application layer.
+/// </summary>
+public sealed class HttpOnboardingWidgetSessionState : IOnboardingWidgetSessionState
+{
+    /// <summary>Session key set by <c>/OnboardingWidget/Skip</c> and read here.</summary>
+    public const string ShiftSkipSessionKey = "OnboardingShiftSkip";
+
+    private readonly IHttpContextAccessor _http;
+
+    public HttpOnboardingWidgetSessionState(IHttpContextAccessor http)
+    {
+        _http = http;
+    }
+
+    public bool ShiftSkipActive => string.Equals(
+        _http.HttpContext?.Session.GetString(ShiftSkipSessionKey),
+        "true",
+        StringComparison.Ordinal);
+}

--- a/tests/Humans.Application.Tests/Services/Onboarding/OnboardingWidgetStateTests.cs
+++ b/tests/Humans.Application.Tests/Services/Onboarding/OnboardingWidgetStateTests.cs
@@ -7,7 +7,6 @@ using Humans.Application.Services.Onboarding;
 using Humans.Domain.Constants;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
-using Microsoft.AspNetCore.Http;
 using NSubstitute;
 using Xunit;
 
@@ -20,14 +19,13 @@ public class OnboardingWidgetStateTests
     private readonly IMembershipCalculator _membership = Substitute.For<IMembershipCalculator>();
     private readonly IShiftManagementService _shiftMgmt = Substitute.For<IShiftManagementService>();
     private readonly IConsentService _consents = Substitute.For<IConsentService>();
-    private readonly IHttpContextAccessor _http = Substitute.For<IHttpContextAccessor>();
-    private readonly DefaultHttpContext _httpContext = new();
+    private readonly IOnboardingWidgetSessionState _session = Substitute.For<IOnboardingWidgetSessionState>();
 
     public OnboardingWidgetStateTests()
     {
-        _http.HttpContext.Returns(_httpContext);
-        // Session is provided by a no-op test session in the helper below.
-        _httpContext.Session = new TestSession();
+        // Default: no skip flag set (new user fresh through the widget). Individual
+        // tests override this when exercising the skip-active path.
+        _session.ShiftSkipActive.Returns(false);
         // Default: no signed required consents (new user). Individual tests
         // override this when exercising the returning-member path.
         _consents.GetRequiredConsentRowsForUserAsync(
@@ -36,7 +34,7 @@ public class OnboardingWidgetStateTests
     }
 
     private OnboardingWidgetState BuildSut() =>
-        new(_profile, _signups, _membership, _shiftMgmt, _consents, _http);
+        new(_profile, _signups, _membership, _shiftMgmt, _consents, _session);
 
     [HumansFact]
     public async Task ConsentsComplete_ShortCircuitsToComplete_EvenWithoutSignup()
@@ -95,7 +93,7 @@ public class OnboardingWidgetStateTests
             .Returns(new EventSettings { Id = eventId });
         _signups.GetActiveSignupStatusesAsync(userId, eventId)
             .Returns((new HashSet<Guid>(), new Dictionary<Guid, SignupStatus>()));
-        _httpContext.Session.SetString(OnboardingWidgetState.ShiftSkipSessionKey, "true");
+        _session.ShiftSkipActive.Returns(true);
 
         var step = await BuildSut().GetCurrentStepAsync(userId);
 
@@ -167,24 +165,5 @@ public class OnboardingWidgetStateTests
         var step = await BuildSut().GetCurrentStepAsync(userId);
 
         Assert.Equal(OnboardingWidgetStep.Shifts, step);
-    }
-
-    private sealed class TestSession : ISession
-    {
-        private readonly Dictionary<string, byte[]> _store = new(StringComparer.Ordinal);
-        public bool IsAvailable => true;
-        public string Id => "test";
-        public IEnumerable<string> Keys => _store.Keys;
-        public void Clear() => _store.Clear();
-        public Task CommitAsync(CancellationToken ct = default) => Task.CompletedTask;
-        public Task LoadAsync(CancellationToken ct = default) => Task.CompletedTask;
-        public void Remove(string key) => _store.Remove(key);
-        public void Set(string key, byte[] value) => _store[key] = value;
-        public bool TryGetValue(string key, out byte[] value)
-        {
-            if (_store.TryGetValue(key, out var v)) { value = v; return true; }
-            value = Array.Empty<byte>();
-            return false;
-        }
     }
 }

--- a/tests/Humans.Web.Tests/Controllers/OnboardingWidgetControllerShiftsTests.cs
+++ b/tests/Humans.Web.Tests/Controllers/OnboardingWidgetControllerShiftsTests.cs
@@ -3,11 +3,11 @@ using Humans.Application.Interfaces.Consent;
 using Humans.Application.Interfaces.Onboarding;
 using Humans.Application.Interfaces.Profiles;
 using Humans.Application.Interfaces.Shifts;
-using Humans.Application.Services.Onboarding;
 using Humans.Domain.Entities;
 using Humans.Testing;
 using Humans.Web.Constants;
 using Humans.Web.Controllers;
+using Humans.Web.Services.Onboarding;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
@@ -116,7 +116,7 @@ public class OnboardingWidgetControllerShiftsTests
 
         var redirect = Assert.IsType<RedirectToActionResult>(result);
         Assert.Equal(nameof(OnboardingWidgetController.Consents), redirect.ActionName);
-        Assert.Equal("true", _http.Session.GetString(OnboardingWidgetState.ShiftSkipSessionKey));
+        Assert.Equal("true", _http.Session.GetString(HttpOnboardingWidgetSessionState.ShiftSkipSessionKey));
     }
 
     private sealed class TestSession : ISession


### PR DESCRIPTION
## Summary

`OnboardingWidgetState` (Application layer) no longer references `Microsoft.AspNetCore.Http`. The "shift skip" session flag is read through a narrow `IOnboardingWidgetSessionState` interface, with a Web-layer implementation (`HttpOnboardingWidgetSessionState`) doing the actual `HttpContext.Session.GetString("OnboardingShiftSkip")` read.

The session-key constant moved to the Web-layer adapter alongside the writer (`OnboardingWidgetController.Skip`), so reader and writer live together in the layer that owns HTTP.

DI registration in `GovernanceSectionExtensions` adds the new interface mapping. Application-layer test now substitutes the new interface; the Web-layer Skip-action test imports the new constant location.

## Test plan

- [x] `dotnet build Humans.slnx -v quiet` clean
- [x] `dotnet format` clean
- [x] OnboardingWidget state + controller tests pass
- [x] No remaining `Microsoft.AspNetCore.Http` reference in `OnboardingWidgetState`

Closes nobodies-collective/Humans#663