### PR TITLE
issue-646: follow merge-fold redirect in Google sync provisioning

### DIFF
--- a/src/Humans.Application/Services/GoogleIntegration/GoogleWorkspaceSyncService.cs
+++ b/src/Humans.Application/Services/GoogleIntegration/GoogleWorkspaceSyncService.cs
@@ -644,14 +644,17 @@ public sealed class GoogleWorkspaceSyncService : IGoogleSyncService
         // after. The team_members row was re-FK'd to the target, and the
         // source's UserEmails were also re-FK'd, so a lookup against the
         // source returns "no verified email" even though the target has one.
-        // Follow MergedToUserId so the provisioning runs against the target.
-        if (user is { MergedToUserId: { } targetUserId })
+        // Follow the MergedToUserId chain to the terminal target — A→B→C
+        // possible if B was later merged into C.
+        var hops = 0;
+        while (user is { MergedToUserId: { } targetUserId } && hops < 16)
         {
             _logger.LogInformation(
                 "Following merge-fold redirect for AddUserToTeamResources: source {SourceUserId} → target {TargetUserId} (team {TeamId})",
                 userId, targetUserId, teamId);
             userId = targetUserId;
             user = await _userService.GetByIdAsync(userId, cancellationToken);
+            hops++;
         }
 
         var userEmails = user is null
@@ -774,14 +777,17 @@ public sealed class GoogleWorkspaceSyncService : IGoogleSyncService
         }
 
         // Merge-fold redirect (issue peterdrier/Humans#646): if the caller
-        // passed a folded source id, follow MergedToUserId so restoration
-        // runs against the target — team_members were re-FK'd at merge time.
-        if (user.MergedToUserId is { } targetUserId)
+        // passed a folded source id, follow the MergedToUserId chain to the
+        // terminal target — A→B→C possible if B was later merged into C.
+        var hops = 0;
+        while (user is { MergedToUserId: { } targetUserId } && hops < 16)
         {
             _logger.LogInformation(
                 "Following merge-fold redirect for RestoreUserToAllTeams: source {SourceUserId} → target {TargetUserId}",
                 userId, targetUserId);
             userId = targetUserId;
+            user = await _userService.GetByIdAsync(userId, cancellationToken);
+            hops++;
         }
 
         var memberships = await _teamService.GetUserTeamsAsync(userId, cancellationToken);

--- a/src/Humans.Application/Services/GoogleIntegration/GoogleWorkspaceSyncService.cs
+++ b/src/Humans.Application/Services/GoogleIntegration/GoogleWorkspaceSyncService.cs
@@ -657,6 +657,13 @@ public sealed class GoogleWorkspaceSyncService : IGoogleSyncService
             hops++;
         }
 
+        if (hops >= 16 && user is { MergedToUserId: not null })
+        {
+            _logger.LogWarning(
+                "Merge-fold chain exceeded 16 hops for user {UserId} on team {TeamId}; provisioning against intermediate node",
+                userId, teamId);
+        }
+
         var userEmails = user is null
             ? (IReadOnlyList<UserEmail>)Array.Empty<UserEmail>()
             : await _userEmailService.GetEntitiesByUserIdAsync(userId, cancellationToken);
@@ -788,6 +795,21 @@ public sealed class GoogleWorkspaceSyncService : IGoogleSyncService
             userId = targetUserId;
             user = await _userService.GetByIdAsync(userId, cancellationToken);
             hops++;
+        }
+
+        if (user is null)
+        {
+            _logger.LogWarning(
+                "RestoreUserToAllTeams: terminal merge target {UserId} not found after following redirect chain",
+                userId);
+            return;
+        }
+
+        if (hops >= 16 && user.MergedToUserId is not null)
+        {
+            _logger.LogWarning(
+                "Merge-fold chain exceeded 16 hops for user {UserId} on RestoreUserToAllTeams; provisioning against intermediate node",
+                userId);
         }
 
         var memberships = await _teamService.GetUserTeamsAsync(userId, cancellationToken);

--- a/src/Humans.Application/Services/GoogleIntegration/GoogleWorkspaceSyncService.cs
+++ b/src/Humans.Application/Services/GoogleIntegration/GoogleWorkspaceSyncService.cs
@@ -637,6 +637,23 @@ public sealed class GoogleWorkspaceSyncService : IGoogleSyncService
         // service (design-rules §2c) instead of traversing user.UserEmails
         // cross-domain.
         var user = await _userService.GetByIdAsync(userId, cancellationToken);
+
+        // Merge-fold redirect (issue peterdrier/Humans#646): if the source
+        // user has been folded into a target via AccountMergeService, the
+        // outbox event was enqueued before the merge but is being dequeued
+        // after. The team_members row was re-FK'd to the target, and the
+        // source's UserEmails were also re-FK'd, so a lookup against the
+        // source returns "no verified email" even though the target has one.
+        // Follow MergedToUserId so the provisioning runs against the target.
+        if (user is { MergedToUserId: { } targetUserId })
+        {
+            _logger.LogInformation(
+                "Following merge-fold redirect for AddUserToTeamResources: source {SourceUserId} → target {TargetUserId} (team {TeamId})",
+                userId, targetUserId, teamId);
+            userId = targetUserId;
+            user = await _userService.GetByIdAsync(userId, cancellationToken);
+        }
+
         var userEmails = user is null
             ? (IReadOnlyList<UserEmail>)Array.Empty<UserEmail>()
             : await _userEmailService.GetEntitiesByUserIdAsync(userId, cancellationToken);
@@ -654,11 +671,15 @@ public sealed class GoogleWorkspaceSyncService : IGoogleSyncService
         {
             if (user is null)
             {
-                _logger.LogWarning("Skipped Google provisioning for {UserId}: user no longer exists (likely deleted between outbox enqueue and dequeue)", userId);
+                _logger.LogWarning(
+                    "Skipped Google provisioning for {UserId} on team {TeamId}: user no longer exists (likely deleted between outbox enqueue and dequeue)",
+                    userId, teamId);
             }
             else
             {
-                _logger.LogWarning("Skipped Google provisioning for {UserId}: user exists but has no verified email", userId);
+                _logger.LogWarning(
+                    "Skipped Google provisioning for {UserId} on team {TeamId}: user exists but has no verified email",
+                    userId, teamId);
             }
             return;
         }
@@ -750,6 +771,17 @@ public sealed class GoogleWorkspaceSyncService : IGoogleSyncService
         {
             _logger.LogWarning("User {UserId} not found for access restoration", userId);
             return;
+        }
+
+        // Merge-fold redirect (issue peterdrier/Humans#646): if the caller
+        // passed a folded source id, follow MergedToUserId so restoration
+        // runs against the target — team_members were re-FK'd at merge time.
+        if (user.MergedToUserId is { } targetUserId)
+        {
+            _logger.LogInformation(
+                "Following merge-fold redirect for RestoreUserToAllTeams: source {SourceUserId} → target {TargetUserId}",
+                userId, targetUserId);
+            userId = targetUserId;
         }
 
         var memberships = await _teamService.GetUserTeamsAsync(userId, cancellationToken);


### PR DESCRIPTION
## Summary
- Investigates the production warning `User {guid} not found or has no email` that fired 4 times on 2026-05-04 for 4 distinct user GUIDs.
- Locates the call site as `GoogleWorkspaceSyncService.AddUserToTeamResourcesAsync` (the warning text was the pre-PR-#394 conflated form; #394 already split it into two more specific warnings).
- Adds the missing merge-fold redirection: if the user has been folded (`User.MergedToUserId` is set), follow the redirect to the target before reading emails or running provisioning.
- Adds `{TeamId}` to the skip warnings so future occurrences are debuggable from the log alone.

## Investigation findings

**Call site:** `src/Humans.Application/Services/GoogleIntegration/GoogleWorkspaceSyncService.cs::AddUserToTeamResourcesAsync`. The exact pre-fix text `"User {UserId} not found or has no email"` was renamed in commit `89641b57` (PR peterdrier/Humans#394, merged 2026-05-03 17:38 UTC) into:
- `"Skipped Google provisioning for {UserId}: user no longer exists ..."`
- `"Skipped Google provisioning for {UserId}: user exists but has no verified email"`

**Why the redirect was missing:** `AccountMergeService.AcceptAsync` re-FKs both `team_members` and `user_emails` from source → target, then tombstones the source `User` row with `MergedToUserId` set. A `GoogleSyncOutbox` event for `AddUserToTeamResources` enqueued before the merge but dequeued after would call `AddUserToTeamResourcesAsync(teamId, sourceUserId)`. The source row exists (tombstoned), but its `UserEmails` are now empty (re-FK'd to target). Result: `userEmails` is empty → `googleEmail` is null → fires the misleading "user exists but has no verified email" warning, even though the target has one.

**Fix:** At the top of `AddUserToTeamResourcesAsync` and `RestoreUserToAllTeamsAsync`, check `user.MergedToUserId`. If set, log an info-level redirect line and rebind `userId` to the target before continuing. The `team_members` rows were re-FK'd at merge time, so the subsequent group/Drive provisioning operates against the right account.

## Production GUID cross-check (still TODO — needs DB access)

| GUID | Time (UTC) | Hypothesis |
|------|------------|------------|
| `c53b8b2d-0749-43be-aa2e-fa9b6a79dcd6` | 2026-05-04T20:37 | Most likely a folded source whose outbox event dequeued post-merge — fixed by this PR. Otherwise a deleted user (legitimate skip). |
| `c525d9fc-29ee-4dd1-9293-bf3e5a17cf1e` | 2026-05-04T20:21 | Same. |
| `96bf06eb-0d20-43c0-9100-610de5fd7177` | 2026-05-04T17:40 | Same. |
| `14d7500f-557a-4c3c-b305-41a7de4e8d06` | 2026-05-04T14:52 | Same. |

The text in prod logs is the *pre-PR-#394* conflated text, so production was running a build older than `89641b57` at the time of those warnings (or the in-memory log buffer retained pre-deploy entries). Either way, those entries are now historical; the new warnings (with team context) plus the merge-fold redirect should cover both root causes going forward.

Recommend cross-checking these 4 GUIDs in production against `users.MergedToUserId` and `users.DeletionScheduledFor` to confirm the merge-fold hypothesis.

## Acceptance criteria
- [x] Call site identified and documented above.
- [x] Merge-fold redirection added (`user.MergedToUserId` followed when set).
- [x] Warning includes operation context (`{UserId}` + `{TeamId}` and the operation phrase "Skipped Google provisioning").
- [ ] 4 production GUIDs explained — pending DB cross-check (documented as needing manual verification above).

## Test plan
- [x] `dotnet build Humans.slnx -v quiet` — clean.
- [x] `dotnet format Humans.slnx --no-restore --verbosity quiet` — no diffs.
- [x] Targeted tests: `--filter "FullyQualifiedName~GoogleWorkspaceSync|FullyQualifiedName~ProcessGoogleSyncOutbox|FullyQualifiedName~AcceptAsync"` — 51/51 pass.
- [x] `--filter "FullyQualifiedName~GoogleIntegration|FullyQualifiedName~AccountMerge"` — 46/46 pass.
- [ ] Manual: verify in QA / preview that a merged source user's outbox event resolves to the target's email and provisions correctly.

Closes nobodies-collective/Humans#646