### PR TITLE
fix: codex findings on nobodies-collective#667 (OAuth linkage + negative page)

### DIFF
--- a/docs/sections/Profiles.md
+++ b/docs/sections/Profiles.md
@@ -173,11 +173,12 @@ Per-user email addresses (login, verified, notifications). Cross-domain nav `Use
 | UserId | Guid | FK → User (Cascade) — **FK only**, no nav |
 | Email | string (256) | Required |
 | IsVerified | bool | Required |
-| IsOAuth | bool | True for the OAuth login email; cannot be deleted |
-| IsNotificationTarget | bool | Exactly one verified email per user is the system-notification target |
+| Provider | string? (50) | OAuth provider that owns this row when the user signed in via OIDC ("Google" today; future Apple/Microsoft). Null when no OAuth identity is linked. Single-row-per-(Provider, ProviderKey) is service-enforced |
+| ProviderKey | string? (256) | OAuth subject/key (OIDC `sub`) for the linked identity. Stable across Google Workspace email renames; OAuth callback updates `Email` when claims diverge. Same-user merge in `UserEmailRepository.RewriteEmailAddressAsync` propagates `Provider`/`ProviderKey` to the surviving row to preserve OAuth linkage |
+| IsGoogle | bool | User-controlled flag for the canonical Google Workspace identity (used by Google sync and Workspace admin). At-most-one-true-per-UserId is service-enforced. **Never auto-derived** — set only via explicit user action in the Profile email grid |
+| IsPrimary | bool | Exactly one verified email per user is the system-notification target. Service-enforced via `EnsurePrimaryInvariantAsync`; column persists under legacy name `IsNotificationTarget` per `no-column-drops-for-decoupling.md` |
 | Visibility | ContactFieldVisibility? | Stored as string (max 50); null hides the email from profile view |
 | VerificationSentAt | Instant? | Last time a verification email was sent (rate limiting) |
-| DisplayOrder | int | Sort order in the UI |
 | CreatedAt / UpdatedAt | Instant | Maintained by `UserEmailService` |
 
 **Indexes:** `UserId`; **unique partial index** on `Email` filtered to `IsVerified = true` (Postgres `"IsVerified" = true`) — prevents email squatting across accounts.

--- a/src/Humans.Infrastructure/Repositories/Profiles/UserEmailRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Profiles/UserEmailRepository.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using NodaTime;
 using Humans.Application.DTOs;
 using Humans.Application.Interfaces.Repositories;
@@ -18,10 +19,14 @@ namespace Humans.Infrastructure.Repositories.Profiles;
 public sealed class UserEmailRepository : IUserEmailRepository
 {
     private readonly IDbContextFactory<HumansDbContext> _factory;
+    private readonly ILogger<UserEmailRepository> _logger;
 
-    public UserEmailRepository(IDbContextFactory<HumansDbContext> factory)
+    public UserEmailRepository(
+        IDbContextFactory<HumansDbContext> factory,
+        ILogger<UserEmailRepository> logger)
     {
         _factory = factory;
+        _logger = logger;
     }
 
     public async Task<IReadOnlyList<UserEmail>> GetByUserIdReadOnlyAsync(
@@ -428,6 +433,19 @@ public sealed class UserEmailRepository : IUserEmailRepository
         {
             conflictRow.Provider = sourceRow.Provider;
             conflictRow.ProviderKey = sourceRow.ProviderKey;
+        }
+        else if (sourceRow.Provider is not null && conflictRow.Provider is not null)
+        {
+            // Both rows carry an OAuth identity — same user holds two Provider
+            // rows (e.g., Google + future Apple). Deleting sourceRow drops its
+            // OAuth linkage; we cannot copy it onto conflictRow without
+            // clobbering conflictRow's existing identity. Log so the loss is
+            // visible — the caller has no signal in the return enum.
+            _logger.LogWarning(
+                "RewriteEmailAddressAsync: same-user merge dropping sourceRow OAuth identity " +
+                "(UserId={UserId}, sourceProvider={SourceProvider}, conflictProvider={ConflictProvider}). " +
+                "FindByProviderKeyAsync for the dropped (provider, key) will return null.",
+                userId, sourceRow.Provider, conflictRow.Provider);
         }
         conflictRow.UpdatedAt = updatedAt;
         await ctx.SaveChangesAsync(ct);

--- a/src/Humans.Infrastructure/Repositories/Profiles/UserEmailRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Profiles/UserEmailRepository.cs
@@ -413,11 +413,21 @@ public sealed class UserEmailRepository : IUserEmailRepository
         // source row was the only IsPrimary=true row — the "exactly one
         // verified IsPrimary per user" invariant is service-enforced (no DB
         // partial unique index) and would otherwise stay broken until some
-        // later repair path runs.
+        // later repair path runs. Also propagate Provider/ProviderKey: the
+        // OAuth rename detector finds sourceRow by (Provider, ProviderKey),
+        // so deleting it without copying the linkage would orphan the OAuth
+        // identity and break future FindByProviderKeyAsync lookups. IsGoogle
+        // is intentionally NOT propagated — it is user-controlled and must
+        // never be auto-derived.
         ctx.UserEmails.Remove(sourceRow);
         if (sourceRow.IsPrimary)
         {
             conflictRow.IsPrimary = true;
+        }
+        if (sourceRow.Provider is not null && conflictRow.Provider is null)
+        {
+            conflictRow.Provider = sourceRow.Provider;
+            conflictRow.ProviderKey = sourceRow.ProviderKey;
         }
         conflictRow.UpdatedAt = updatedAt;
         await ctx.SaveChangesAsync(ct);

--- a/src/Humans.Web/Controllers/AgentController.cs
+++ b/src/Humans.Web/Controllers/AgentController.cs
@@ -121,9 +121,12 @@ public class AgentController : HumansControllerBase
         CancellationToken ct)
     {
         const int adminPageSize = 25;
+        // Clamp negative page values from the URL — a negative offset would
+        // otherwise crash the EF paging call with a 500.
+        var safePage = page < 0 ? 0 : page;
         return isAdmin
             ? _agent.ListAllConversationsForAdminAsync(
-                refusalsOnly, handoffsOnly, userId, adminPageSize, page * adminPageSize, ct)
+                refusalsOnly, handoffsOnly, userId, adminPageSize, safePage * adminPageSize, ct)
             : _agent.GetHistoryAsync(currentUserId, take: 50, ct);
     }
 

--- a/tests/Humans.Application.Tests/Repositories/UserEmailRepositoryTests.cs
+++ b/tests/Humans.Application.Tests/Repositories/UserEmailRepositoryTests.cs
@@ -6,6 +6,7 @@ using Humans.Infrastructure.Repositories.Profiles;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.InMemory.Internal;
+using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using Xunit;
 
@@ -26,7 +27,9 @@ public sealed class UserEmailRepositoryTests : IDisposable
             .ConfigureWarnings(w => w.Ignore(InMemoryEventId.TransactionIgnoredWarning))
             .Options;
         _dbContext = new HumansDbContext(options);
-        _repo = new UserEmailRepository(new TestDbContextFactory(options));
+        _repo = new UserEmailRepository(
+            new TestDbContextFactory(options),
+            NullLogger<UserEmailRepository>.Instance);
     }
 
     public void Dispose()

--- a/tests/Humans.Application.Tests/Services/ProfileServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/ProfileServiceTests.cs
@@ -65,7 +65,7 @@ public class ProfileServiceTests : IDisposable
         // Real repositories backed by an IDbContextFactory wrapping the in-memory store.
         var factory = new Infrastructure.TestDbContextFactory(options);
         _profileRepository = new ProfileRepository(factory, _clock);
-        _userEmailRepository = new UserEmailRepository(factory);
+        _userEmailRepository = new UserEmailRepository(factory, NullLogger<UserEmailRepository>.Instance);
         _contactFieldRepository = new ContactFieldRepository(factory);
 
         _service = new ProfileService(


### PR DESCRIPTION
## Summary

Two issues Codex flagged post-merge on nobodies-collective/Humans#667.

**P1 — preserve OAuth provider metadata when merging same-user rows** (`UserEmailRepository.RewriteEmailAddressAsync`)
- Same-user collision path deletes `sourceRow` and previously only propagated `IsPrimary`.
- During OAuth rename detection, `sourceRow` is the row found by `(Provider, ProviderKey)` — deleting it without copying the linkage drops `Provider`/`ProviderKey`, breaking future `FindByProviderKeyAsync` lookups for that account.
- Fix: propagate `Provider`/`ProviderKey` from `sourceRow` to `conflictRow` before deletion when the source has them and the target does not. `IsGoogle` is intentionally NOT propagated — it is user-controlled and must never be auto-derived.

**P2 — clamp negative `page` in admin conversations** (`AgentController.LoadConversationsAsync`)
- `?page=-1` produced a negative SQL offset (`-1 * 25`), crashing the EF paging call with a 500.
- Fix: clamp `page` to `>= 0` before computing the offset.

## Test plan
- [x] `dotnet build Humans.slnx -v quiet` — clean
- [x] `dotnet test` for `UserEmail`/`AgentController`/`OAuthRename` filters — 80 passed
- [ ] Smoke `/Agent/Conversations?page=-1` on the preview env returns the first page (not 500)
- [ ] OAuth rename flow against preview env: rename a Google account when the user already has a verified row at the new address, verify the surviving row keeps `Provider`/`ProviderKey`

🤖 Generated with [Claude Code](https://claude.com/claude-code)