### PR TITLE
issue-665: consolidate IProfileService search methods onto SearchProfilesAsync(predicate)

### DIFF
--- a/docs/architecture/design-rules.md
+++ b/docs/architecture/design-rules.md
@@ -535,9 +535,9 @@ var inner = scope.ServiceProvider.GetRequiredKeyedService<IProfileService>(Inner
 
 **Writes:** delegate to the inner service, then call `RefreshEntryAsync(userId, ct)`. `RefreshEntryAsync` reloads directly from repositories, re-stitches the `FullProfile`, and upserts the dict. If the profile or user no longer exists, the dict entry is removed.
 
-**Warming:** eager at startup. `FullProfileWarmupHostedService` (registered via `AddHostedService`) calls `CachingProfileService.WarmAllAsync` during host start, enumerating all users and populating `_byUserId` before the app takes traffic. Bulk reads (`GetBirthdayProfilesAsync`, `GetApprovedProfilesWithLocationAsync`, `GetFilteredHumansAsync`, `SearchApprovedUsersAsync`) then read the warm dict directly — no runtime gate, no fully-warm flag. If warmup fails (e.g., DB unreachable at startup) the hosted service logs at Error and the host continues to start; individual per-user reads will lazy-populate the dict via `GetFullProfileAsync`. Warmup is an optimization, not a correctness requirement.
+**Warming:** eager at startup. `FullProfileWarmupHostedService` (registered via `AddHostedService`) calls `CachingProfileService.WarmAllAsync` during host start, enumerating all users and populating `_byUserId` before the app takes traffic. Bulk reads (`GetBirthdayProfilesAsync`, `GetApprovedProfilesWithLocationAsync`, `GetFilteredHumansAsync`, `SearchProfilesAsync`) then read the warm dict directly — no runtime gate, no fully-warm flag. If warmup fails (e.g., DB unreachable at startup) the hosted service logs at Error and the host continues to start; individual per-user reads will lazy-populate the dict via `GetFullProfileAsync`. Warmup is an optimization, not a correctness requirement.
 
-**Static helpers:** methods like `GetBirthdayProfilesAsync` and `SearchApprovedUsersAsync` are served synchronously from `_byUserId.Values` via `ProfileService.GetBirthdayProfilesFromSnapshot` / `ProfileService.SearchApprovedUsersFromSnapshot` — no inner call, no scope.
+**Static helpers:** methods like `GetBirthdayProfilesAsync` and `SearchProfilesAsync` are served synchronously from `_byUserId.Values` via `ProfileService.GetBirthdayProfilesFromSnapshot` / `ProfileService.SearchProfilesFromSnapshot` — no inner call, no scope.
 
 DI registration for the decorator:
 

--- a/src/Humans.Application/DTOs/ProfileSearchResults.cs
+++ b/src/Humans.Application/DTOs/ProfileSearchResults.cs
@@ -1,7 +1,5 @@
 namespace Humans.Application.DTOs;
 
-public record UserSearchResult(Guid UserId, string DisplayName, string Email);
-
 public record HumanSearchResult(
     Guid UserId,
     string DisplayName,
@@ -9,6 +7,8 @@ public record HumanSearchResult(
     string? City,
     string? Bio,
     string? ContributionInterests,
+    string? Pronouns,
+    string? PrimaryEmail,
     string? ProfilePictureUrl,
     bool HasCustomPicture,
     Guid ProfileId,

--- a/src/Humans.Application/Interfaces/Profiles/IProfileService.cs
+++ b/src/Humans.Application/Interfaces/Profiles/IProfileService.cs
@@ -128,17 +128,15 @@ public interface IProfileService : IUserMerge
 
     Task<AdminHumanDetailData?> GetAdminHumanDetailAsync(Guid userId, CancellationToken ct = default);
 
-    Task<IReadOnlyList<UserSearchResult>> SearchApprovedUsersAsync(string query, CancellationToken ct = default);
-
-    Task<IReadOnlyList<HumanSearchResult>> SearchHumansAsync(string query, CancellationToken ct = default);
-
     /// <summary>
-    /// Narrowed variant of <see cref="SearchHumansAsync"/> that matches only on
-    /// display name (first/last) and burner name. Used by the typeahead picker
-    /// where a tighter, less noisy result list is what callers want; the full
-    /// search page (bio / city / interests / CV) keeps using the broad method.
+    /// Predicate-based search over approved, non-suspended profiles. The caller
+    /// supplies the exact match condition; results are ordered by display name
+    /// and capped at 50. <see cref="HumanSearchResult.MatchField"/> and
+    /// <see cref="HumanSearchResult.MatchSnippet"/> are null because the caller
+    /// already knows what it filtered for.
     /// </summary>
-    Task<IReadOnlyList<HumanSearchResult>> SearchHumansByNameAsync(string query, CancellationToken ct = default);
+    Task<IReadOnlyList<HumanSearchResult>> SearchProfilesAsync(
+        Func<FullProfile, bool> predicate, CancellationToken ct = default);
 
     /// <summary>
     /// Reconciles the user's CV entries (volunteer history) with the provided set.

--- a/src/Humans.Application/Services/Profile/HumanSearchMatcher.cs
+++ b/src/Humans.Application/Services/Profile/HumanSearchMatcher.cs
@@ -1,0 +1,51 @@
+using Humans.Application.DTOs;
+
+namespace Humans.Application.Services.Profile;
+
+/// <summary>
+/// Caller-side helper for the broad-search UI: given a query and a
+/// <see cref="HumanSearchResult"/> returned from
+/// <c>IProfileService.SearchProfilesAsync</c>, determines which field matched
+/// (display name, burner name, city, interests, bio, pronouns) and a short
+/// snippet for free-text fields.
+/// </summary>
+/// <remarks>
+/// Match precedence is display-name-wins, mirroring the legacy
+/// <c>SearchHumansAsync</c> behaviour. CV-only matches are not detected here
+/// because <see cref="HumanSearchResult"/> does not carry CV entries; the
+/// broad search predicate still surfaces the row, the badge just won't
+/// label it as a CV match.
+/// </remarks>
+public static class HumanSearchMatcher
+{
+    public static (string? Field, string? Snippet) DetermineMatch(HumanSearchResult r, string query)
+    {
+        if (r.DisplayName.Contains(query, StringComparison.OrdinalIgnoreCase))
+            return ("Name", null);
+        if (r.BurnerName?.Contains(query, StringComparison.OrdinalIgnoreCase) == true)
+            return ("Burner Name", null);
+        if (r.City?.Contains(query, StringComparison.OrdinalIgnoreCase) == true)
+            return ("City", r.City);
+        if (r.ContributionInterests?.Contains(query, StringComparison.OrdinalIgnoreCase) == true)
+            return ("Interests", GetSnippet(r.ContributionInterests, query));
+        if (r.Bio?.Contains(query, StringComparison.OrdinalIgnoreCase) == true)
+            return ("Bio", GetSnippet(r.Bio, query));
+        if (r.Pronouns?.Contains(query, StringComparison.OrdinalIgnoreCase) == true)
+            return ("Pronouns", r.Pronouns);
+
+        return (null, null);
+    }
+
+    private static string GetSnippet(string text, string query, int contextChars = 60)
+    {
+        var index = text.IndexOf(query, StringComparison.OrdinalIgnoreCase);
+        if (index < 0) return text.Length <= contextChars * 2 ? text : text[..(contextChars * 2)] + "...";
+
+        var start = Math.Max(0, index - contextChars);
+        var end = Math.Min(text.Length, index + query.Length + contextChars);
+        var snippet = text[start..end];
+        if (start > 0) snippet = "..." + snippet;
+        if (end < text.Length) snippet += "...";
+        return snippet;
+    }
+}

--- a/src/Humans.Application/Services/Profile/ProfileSearchPredicates.cs
+++ b/src/Humans.Application/Services/Profile/ProfileSearchPredicates.cs
@@ -1,0 +1,45 @@
+namespace Humans.Application.Services.Profile;
+
+/// <summary>
+/// Reusable <see cref="FullProfile"/> predicates for the consolidated
+/// <c>IProfileService.SearchProfilesAsync</c> surface. Keeps the per-caller
+/// match conditions in one place so controllers stay slim and the
+/// "broad-match across bio / city / interests / pronouns / CV" definition
+/// can change in exactly one location.
+/// </summary>
+public static class ProfileSearchPredicates
+{
+    /// <summary>
+    /// Display name + burner name match. Used by the typeahead picker
+    /// (<c>scope=name</c>) and recipient-lookup callers.
+    /// </summary>
+    public static Func<FullProfile, bool> ByName(string query) =>
+        p =>
+            p.DisplayName.Contains(query, StringComparison.OrdinalIgnoreCase) ||
+            (p.BurnerName?.Contains(query, StringComparison.OrdinalIgnoreCase) ?? false);
+
+    /// <summary>
+    /// Broad match across all indexed profile fields plus CV entries.
+    /// Equivalent to the legacy <c>SearchHumansAsync</c> match set.
+    /// </summary>
+    public static Func<FullProfile, bool> Broad(string query) =>
+        p =>
+            p.DisplayName.Contains(query, StringComparison.OrdinalIgnoreCase) ||
+            (p.BurnerName?.Contains(query, StringComparison.OrdinalIgnoreCase) ?? false) ||
+            (p.City?.Contains(query, StringComparison.OrdinalIgnoreCase) ?? false) ||
+            (p.Bio?.Contains(query, StringComparison.OrdinalIgnoreCase) ?? false) ||
+            (p.ContributionInterests?.Contains(query, StringComparison.OrdinalIgnoreCase) ?? false) ||
+            (p.Pronouns?.Contains(query, StringComparison.OrdinalIgnoreCase) ?? false) ||
+            p.CVEntries.Any(v =>
+                v.EventName.Contains(query, StringComparison.OrdinalIgnoreCase) ||
+                (v.Description?.Contains(query, StringComparison.OrdinalIgnoreCase) ?? false));
+
+    /// <summary>
+    /// Display name + primary email match. Used by the team-admin user picker
+    /// (members are looked up by either their visible name or their email).
+    /// </summary>
+    public static Func<FullProfile, bool> ByNameOrPrimaryEmail(string query) =>
+        p =>
+            p.DisplayName.Contains(query, StringComparison.OrdinalIgnoreCase) ||
+            (p.PrimaryEmail?.Contains(query, StringComparison.OrdinalIgnoreCase) ?? false);
+}

--- a/src/Humans.Application/Services/Profile/ProfileService.cs
+++ b/src/Humans.Application/Services/Profile/ProfileService.cs
@@ -756,90 +756,34 @@ public sealed class ProfileService : IProfileService, IUserDataContributor, IUse
         return (true, 0, null);
     }
 
-    public async Task<IReadOnlyList<UserSearchResult>> SearchApprovedUsersAsync(string query, CancellationToken ct = default)
+    public async Task<IReadOnlyList<HumanSearchResult>> SearchProfilesAsync(
+        Func<FullProfile, bool> predicate, CancellationToken ct = default)
     {
         var snapshot = await BuildFullProfileSnapshotAsync(ct);
-        return SearchApprovedUsersFromSnapshot(snapshot, query);
-    }
-
-    public async Task<IReadOnlyList<HumanSearchResult>> SearchHumansAsync(string query, CancellationToken ct = default)
-    {
-        var snapshot = await BuildFullProfileSnapshotAsync(ct);
-        return SearchHumansFromSnapshot(snapshot, query);
-    }
-
-    public async Task<IReadOnlyList<HumanSearchResult>> SearchHumansByNameAsync(string query, CancellationToken ct = default)
-    {
-        var snapshot = await BuildFullProfileSnapshotAsync(ct);
-        return SearchHumansByNameFromSnapshot(snapshot, query);
+        return SearchProfilesFromSnapshot(snapshot, predicate);
     }
 
     /// <summary>
-    /// Searches all approved, non-suspended profiles from a pre-built <see cref="FullProfile"/>
-    /// snapshot for users whose display name or notification email contains <paramref name="query"/>.
-    /// Called by <c>CachingProfileService</c> with its private dict snapshot.
+    /// Predicate-based search over a pre-built <see cref="FullProfile"/>
+    /// snapshot. Always filters to approved + non-suspended, ordered by display
+    /// name, capped at 50. Called by <c>CachingProfileService</c> with its
+    /// private dict snapshot. <see cref="HumanSearchResult.MatchField"/> and
+    /// <see cref="HumanSearchResult.MatchSnippet"/> are null — the caller
+    /// already knows what it filtered for.
     /// </summary>
-    public static IReadOnlyList<UserSearchResult> SearchApprovedUsersFromSnapshot(
-        IEnumerable<FullProfile> snapshot, string query)
+    public static IReadOnlyList<HumanSearchResult> SearchProfilesFromSnapshot(
+        IEnumerable<FullProfile> snapshot, Func<FullProfile, bool> predicate)
     {
         return snapshot
             .Where(p => p.IsApproved && !p.IsSuspended)
-            .Where(p =>
-                p.DisplayName.Contains(query, StringComparison.OrdinalIgnoreCase) ||
-                (p.NotificationEmail?.Contains(query, StringComparison.OrdinalIgnoreCase) ?? false))
-            .OrderBy(p => p.DisplayName, StringComparer.OrdinalIgnoreCase)
-            .Take(20)
-            .Select(p => new UserSearchResult(p.UserId, p.DisplayName, p.NotificationEmail ?? ""))
-            .ToList();
-    }
-
-    /// <summary>
-    /// Searches all approved, non-suspended profiles from a pre-built <see cref="FullProfile"/>
-    /// snapshot for those matching <paramref name="query"/> on any indexed field.
-    /// Called by <c>CachingProfileService</c> with its private dict snapshot.
-    /// </summary>
-    public static IReadOnlyList<HumanSearchResult> SearchHumansFromSnapshot(
-        IEnumerable<FullProfile> snapshot, string query)
-    {
-        var results = new List<HumanSearchResult>();
-
-        foreach (var p in snapshot.Where(p => p.IsApproved && !p.IsSuspended))
-        {
-            var (matchField, matchSnippet) = DetermineMatchFromCache(p, query);
-            if (matchField is null) continue;
-
-            results.Add(new HumanSearchResult(
-                p.UserId, p.DisplayName, p.BurnerName, p.City, p.Bio, p.ContributionInterests,
-                p.ProfilePictureUrl, p.HasCustomPicture, p.ProfileId, p.UpdatedAtTicks,
-                matchField, matchSnippet));
-        }
-
-        return results
-            .OrderBy(r => r.DisplayName, StringComparer.OrdinalIgnoreCase)
-            .Take(50)
-            .ToList();
-    }
-
-    /// <summary>
-    /// Narrowed snapshot search for the typeahead picker — matches DisplayName
-    /// (covers first + last) and BurnerName only. Skips bio / city / interests /
-    /// pronouns / CV so callers like the camp role picker get a tight result list.
-    /// </summary>
-    public static IReadOnlyList<HumanSearchResult> SearchHumansByNameFromSnapshot(
-        IEnumerable<FullProfile> snapshot, string query)
-    {
-        return snapshot
-            .Where(p => p.IsApproved && !p.IsSuspended)
-            .Where(p =>
-                p.DisplayName.Contains(query, StringComparison.OrdinalIgnoreCase) ||
-                (p.BurnerName?.Contains(query, StringComparison.OrdinalIgnoreCase) ?? false))
+            .Where(predicate)
             .OrderBy(p => p.DisplayName, StringComparer.OrdinalIgnoreCase)
             .Take(50)
             .Select(p => new HumanSearchResult(
                 p.UserId, p.DisplayName, p.BurnerName, p.City, p.Bio, p.ContributionInterests,
+                p.Pronouns, p.PrimaryEmail,
                 p.ProfilePictureUrl, p.HasCustomPicture, p.ProfileId, p.UpdatedAtTicks,
-                p.DisplayName.Contains(query, StringComparison.OrdinalIgnoreCase) ? "Name" : "Burner Name",
-                null))
+                MatchField: null, MatchSnippet: null))
             .ToList();
     }
 
@@ -1234,45 +1178,4 @@ public sealed class ProfileService : IProfileService, IUserDataContributor, IUse
         CancellationToken ct) =>
         _profileRepository.ReassignSubAggregatesToUserAsync(sourceUserId, targetUserId, updatedAt, ct);
 
-    // ==========================================================================
-    // Helpers
-    // ==========================================================================
-
-    private static (string? Field, string? Snippet) DetermineMatchFromCache(FullProfile p, string query)
-    {
-        if (p.DisplayName.Contains(query, StringComparison.OrdinalIgnoreCase))
-            return ("Name", null);
-        if (p.BurnerName?.Contains(query, StringComparison.OrdinalIgnoreCase) == true)
-            return ("Burner Name", null);
-        if (p.City?.Contains(query, StringComparison.OrdinalIgnoreCase) == true)
-            return ("City", p.City);
-        if (p.ContributionInterests?.Contains(query, StringComparison.OrdinalIgnoreCase) == true)
-            return ("Interests", GetSnippet(p.ContributionInterests, query));
-        if (p.Bio?.Contains(query, StringComparison.OrdinalIgnoreCase) == true)
-            return ("Bio", GetSnippet(p.Bio, query));
-        if (p.Pronouns?.Contains(query, StringComparison.OrdinalIgnoreCase) == true)
-            return ("Pronouns", p.Pronouns);
-
-        foreach (var v in p.CVEntries)
-        {
-            if (v.EventName.Contains(query, StringComparison.OrdinalIgnoreCase) ||
-                v.Description?.Contains(query, StringComparison.OrdinalIgnoreCase) == true)
-                return ("Burner CV", v.EventName);
-        }
-
-        return (null, null);
-    }
-
-    private static string GetSnippet(string text, string query, int contextChars = 60)
-    {
-        var index = text.IndexOf(query, StringComparison.OrdinalIgnoreCase);
-        if (index < 0) return text.Length <= contextChars * 2 ? text : text[..(contextChars * 2)] + "...";
-
-        var start = Math.Max(0, index - contextChars);
-        var end = Math.Min(text.Length, index + query.Length + contextChars);
-        var snippet = text[start..end];
-        if (start > 0) snippet = "..." + snippet;
-        if (end < text.Length) snippet += "...";
-        return snippet;
-    }
 }

--- a/src/Humans.Application/Services/Profile/ProfileService.cs
+++ b/src/Humans.Application/Services/Profile/ProfileService.cs
@@ -765,10 +765,13 @@ public sealed class ProfileService : IProfileService, IUserDataContributor, IUse
 
     /// <summary>
     /// Predicate-based search over a pre-built <see cref="FullProfile"/>
-    /// snapshot. Always filters to approved + non-suspended, ordered by display
-    /// name, capped at 50. Called by <c>CachingProfileService</c> with its
-    /// private dict snapshot. <see cref="HumanSearchResult.MatchField"/> and
-    /// <see cref="HumanSearchResult.MatchSnippet"/> are null — the caller
+    /// snapshot. Filters to approved + non-suspended and applies the predicate.
+    /// Returns matches in unspecified order; callers are responsible for any
+    /// display ordering and result cap (the appropriate cap depends on the
+    /// caller's downstream filtering — e.g. team-admin pages exclude existing
+    /// members before taking 10). Called by <c>CachingProfileService</c> with
+    /// its private dict snapshot. <see cref="HumanSearchResult.MatchField"/>
+    /// and <see cref="HumanSearchResult.MatchSnippet"/> are null — the caller
     /// already knows what it filtered for.
     /// </summary>
     public static IReadOnlyList<HumanSearchResult> SearchProfilesFromSnapshot(
@@ -777,8 +780,6 @@ public sealed class ProfileService : IProfileService, IUserDataContributor, IUse
         return snapshot
             .Where(p => p.IsApproved && !p.IsSuspended)
             .Where(predicate)
-            .OrderBy(p => p.DisplayName, StringComparer.OrdinalIgnoreCase)
-            .Take(50)
             .Select(p => new HumanSearchResult(
                 p.UserId, p.DisplayName, p.BurnerName, p.City, p.Bio, p.ContributionInterests,
                 p.Pronouns, p.PrimaryEmail,

--- a/src/Humans.Infrastructure/HostedServices/FullProfileWarmupHostedService.cs
+++ b/src/Humans.Infrastructure/HostedServices/FullProfileWarmupHostedService.cs
@@ -11,7 +11,7 @@ namespace Humans.Infrastructure.HostedServices;
 /// (<see cref="CachingProfileService.GetBirthdayProfilesAsync"/>,
 /// <see cref="CachingProfileService.GetApprovedProfilesWithLocationAsync"/>,
 /// <see cref="CachingProfileService.GetFilteredHumansAsync"/>,
-/// <see cref="CachingProfileService.SearchApprovedUsersAsync"/>) return
+/// <see cref="CachingProfileService.SearchProfilesAsync"/>) return
 /// complete results immediately after deploy rather than filling in lazily
 /// as each user is accessed.
 /// </summary>

--- a/src/Humans.Infrastructure/Services/Profiles/CachingProfileService.cs
+++ b/src/Humans.Infrastructure/Services/Profiles/CachingProfileService.cs
@@ -226,7 +226,7 @@ public sealed class CachingProfileService : IProfileService, IFullProfileInvalid
     /// (<see cref="GetBirthdayProfilesAsync"/>,
     /// <see cref="GetApprovedProfilesWithLocationAsync"/>,
     /// <see cref="GetFilteredHumansAsync"/>,
-    /// <see cref="SearchApprovedUsersAsync"/>) return complete results immediately
+    /// <see cref="SearchProfilesAsync"/>) return complete results immediately
     /// after deploy rather than filling in lazily as each user is accessed.
     /// </summary>
     /// <remarks>
@@ -391,25 +391,11 @@ public sealed class CachingProfileService : IProfileService, IFullProfileInvalid
         return await inner.GetEmailCooldownInfoAsync(pendingEmailId, ct);
     }
 
-    public Task<IReadOnlyList<UserSearchResult>> SearchApprovedUsersAsync(
-        string query, CancellationToken ct = default)
+    public Task<IReadOnlyList<HumanSearchResult>> SearchProfilesAsync(
+        Func<FullProfile, bool> predicate, CancellationToken ct = default)
     {
         return Task.FromResult(
-            ProfilesProfileService.SearchApprovedUsersFromSnapshot(_byUserId.Values, query));
-    }
-
-    public Task<IReadOnlyList<HumanSearchResult>> SearchHumansAsync(
-        string query, CancellationToken ct = default)
-    {
-        return Task.FromResult(
-            ProfilesProfileService.SearchHumansFromSnapshot(_byUserId.Values, query));
-    }
-
-    public Task<IReadOnlyList<HumanSearchResult>> SearchHumansByNameAsync(
-        string query, CancellationToken ct = default)
-    {
-        return Task.FromResult(
-            ProfilesProfileService.SearchHumansByNameFromSnapshot(_byUserId.Values, query));
+            ProfilesProfileService.SearchProfilesFromSnapshot(_byUserId.Values, predicate));
     }
 
     public async Task<IReadOnlyList<ProfileLanguage>> GetProfileLanguagesAsync(

--- a/src/Humans.Web/Controllers/ProfileApiController.cs
+++ b/src/Humans.Web/Controllers/ProfileApiController.cs
@@ -33,6 +33,7 @@ public class ProfileApiController : ControllerBase
         var results = await _profileService.SearchProfilesAsync(predicate);
 
         return Ok(results
+            .OrderBy(r => r.DisplayName, StringComparer.OrdinalIgnoreCase)
             .Take(10)
             .Select(r => r.ToHumanLookupSearchResult()));
     }

--- a/src/Humans.Web/Controllers/ProfileApiController.cs
+++ b/src/Humans.Web/Controllers/ProfileApiController.cs
@@ -1,4 +1,5 @@
 using Humans.Application.Interfaces.Profiles;
+using Humans.Application.Services.Profile;
 using Humans.Web.Extensions;
 using Humans.Web.Models;
 using Microsoft.AspNetCore.Authorization;
@@ -25,10 +26,11 @@ public class ProfileApiController : ControllerBase
             return Ok(Array.Empty<HumanLookupSearchResult>());
 
         // scope=name → narrowed match on display name + burner name only.
-        // anything else (default) → broad match across bio / city / interests / CV / etc.
-        var results = string.Equals(scope, "name", StringComparison.OrdinalIgnoreCase)
-            ? await _profileService.SearchHumansByNameAsync(q)
-            : await _profileService.SearchHumansAsync(q);
+        // anything else (default) → broad match across bio / city / interests / CV / pronouns.
+        var predicate = string.Equals(scope, "name", StringComparison.OrdinalIgnoreCase)
+            ? ProfileSearchPredicates.ByName(q)
+            : ProfileSearchPredicates.Broad(q);
+        var results = await _profileService.SearchProfilesAsync(predicate);
 
         return Ok(results
             .Take(10)

--- a/src/Humans.Web/Controllers/ProfileController.cs
+++ b/src/Humans.Web/Controllers/ProfileController.cs
@@ -28,6 +28,7 @@ using Humans.Application.Interfaces.AuditLog;
 using Humans.Application.Interfaces.Campaigns;
 using Humans.Application.Interfaces.Email;
 using Humans.Application.Interfaces.Shifts;
+using Humans.Application.Services.Profile;
 using Humans.Application.Interfaces.Teams;
 using Humans.Application.Interfaces.Tickets;
 using Humans.Application.Interfaces.Users;
@@ -1934,10 +1935,11 @@ public class ProfileController : HumansControllerBase
             return View(viewModel);
         }
 
-        var results = await _profileService.SearchHumansAsync(q, ct);
+        var results = await _profileService.SearchProfilesAsync(
+            ProfileSearchPredicates.Broad(q), ct);
 
         viewModel.Results = results
-            .Select(r => r.ToHumanSearchViewModel(Url))
+            .Select(r => r.ToHumanSearchViewModel(Url, q))
             .ToList();
 
         return View(viewModel);

--- a/src/Humans.Web/Controllers/ProfileController.cs
+++ b/src/Humans.Web/Controllers/ProfileController.cs
@@ -1939,6 +1939,8 @@ public class ProfileController : HumansControllerBase
             ProfileSearchPredicates.Broad(q), ct);
 
         viewModel.Results = results
+            .OrderBy(r => r.DisplayName, StringComparer.OrdinalIgnoreCase)
+            .Take(50)
             .Select(r => r.ToHumanSearchViewModel(Url, q))
             .ToList();
 

--- a/src/Humans.Web/Controllers/TeamAdminController.cs
+++ b/src/Humans.Web/Controllers/TeamAdminController.cs
@@ -413,6 +413,7 @@ public class TeamAdminController : HumansTeamControllerBase
 
         var filtered = results
             .Where(r => !existingMemberIds.Contains(r.UserId))
+            .OrderBy(r => r.DisplayName, StringComparer.OrdinalIgnoreCase)
             .Take(10)
             .Select(r => r.ToApprovedUserSearchResult())
             .ToList();
@@ -1060,6 +1061,7 @@ public class TeamAdminController : HumansTeamControllerBase
             ProfileSearchPredicates.ByNameOrPrimaryEmail(q));
         var nonMembers = allResults
             .Where(r => !teamMemberUserIds.Contains(r.UserId))
+            .OrderBy(r => r.DisplayName, StringComparer.OrdinalIgnoreCase)
             .Take(10 - matchingTeamMembers.Count)
             .Select(r => new RoleAssignmentSearchResult(r.UserId, r.DisplayName, r.PrimaryEmail ?? "", false))
             .ToList();

--- a/src/Humans.Web/Controllers/TeamAdminController.cs
+++ b/src/Humans.Web/Controllers/TeamAdminController.cs
@@ -22,6 +22,7 @@ using Humans.Application.Interfaces.GoogleIntegration;
 using Humans.Application.Interfaces.Teams;
 using Humans.Application.Interfaces.Notifications;
 using Humans.Application.Interfaces.Profiles;
+using Humans.Application.Services.Profile;
 
 namespace Humans.Web.Controllers;
 
@@ -401,7 +402,8 @@ public class TeamAdminController : HumansTeamControllerBase
             return Json(Array.Empty<ApprovedUserSearchResult>());
         }
 
-        var results = await _profileService.SearchApprovedUsersAsync(q);
+        var results = await _profileService.SearchProfilesAsync(
+            ProfileSearchPredicates.ByNameOrPrimaryEmail(q));
 
         // Exclude existing team members
         var existingMemberIds = team.Members
@@ -1054,11 +1056,12 @@ public class TeamAdminController : HumansTeamControllerBase
             .ToList();
 
         // Also search all approved users for non-members
-        var allResults = await _profileService.SearchApprovedUsersAsync(q);
+        var allResults = await _profileService.SearchProfilesAsync(
+            ProfileSearchPredicates.ByNameOrPrimaryEmail(q));
         var nonMembers = allResults
             .Where(r => !teamMemberUserIds.Contains(r.UserId))
             .Take(10 - matchingTeamMembers.Count)
-            .Select(r => new RoleAssignmentSearchResult(r.UserId, r.DisplayName, r.Email, false))
+            .Select(r => new RoleAssignmentSearchResult(r.UserId, r.DisplayName, r.PrimaryEmail ?? "", false))
             .ToList();
 
         var combined = matchingTeamMembers.Concat(nonMembers).ToList();

--- a/src/Humans.Web/Extensions/HumanSearchMatcher.cs
+++ b/src/Humans.Web/Extensions/HumanSearchMatcher.cs
@@ -1,6 +1,6 @@
 using Humans.Application.DTOs;
 
-namespace Humans.Application.Services.Profile;
+namespace Humans.Web.Extensions;
 
 /// <summary>
 /// Caller-side helper for the broad-search UI: given a query and a

--- a/src/Humans.Web/Extensions/SearchResultMappingExtensions.cs
+++ b/src/Humans.Web/Extensions/SearchResultMappingExtensions.cs
@@ -1,5 +1,6 @@
 using Humans.Application.DTOs;
 using Humans.Application.Interfaces;
+using Humans.Application.Services.Profile;
 using Humans.Web.Controllers;
 using Humans.Web.Models;
 using Microsoft.AspNetCore.Mvc;
@@ -8,8 +9,17 @@ namespace Humans.Web.Extensions;
 
 public static class SearchResultMappingExtensions
 {
-    public static HumanSearchResultViewModel ToHumanSearchViewModel(this HumanSearchResult result, IUrlHelper url) =>
-        new()
+    /// <summary>
+    /// Maps a <see cref="HumanSearchResult"/> from <c>SearchProfilesAsync</c> to
+    /// the broad-search view model, computing <see cref="HumanSearchResultViewModel.MatchField"/>
+    /// and <see cref="HumanSearchResultViewModel.MatchSnippet"/> from the result fields
+    /// using the original query string.
+    /// </summary>
+    public static HumanSearchResultViewModel ToHumanSearchViewModel(
+        this HumanSearchResult result, IUrlHelper url, string query)
+    {
+        var (matchField, matchSnippet) = HumanSearchMatcher.DetermineMatch(result, query);
+        return new HumanSearchResultViewModel
         {
             UserId = result.UserId,
             DisplayName = result.DisplayName,
@@ -20,13 +30,14 @@ public static class SearchResultMappingExtensions
             EffectiveProfilePictureUrl = result.HasCustomPicture
                 ? url.Action(nameof(ProfileController.Picture), "Profile", new { id = result.ProfileId, v = result.UpdatedAtTicks })
                 : result.ProfilePictureUrl,
-            MatchField = result.MatchField,
-            MatchSnippet = result.MatchSnippet
+            MatchField = matchField,
+            MatchSnippet = matchSnippet
         };
+    }
 
     public static HumanLookupSearchResult ToHumanLookupSearchResult(this HumanSearchResult result) =>
         new(result.UserId, result.DisplayName, result.BurnerName);
 
-    public static ApprovedUserSearchResult ToApprovedUserSearchResult(this UserSearchResult result) =>
-        new(result.UserId, result.DisplayName, result.Email);
+    public static ApprovedUserSearchResult ToApprovedUserSearchResult(this HumanSearchResult result) =>
+        new(result.UserId, result.DisplayName, result.PrimaryEmail ?? "");
 }

--- a/src/Humans.Web/Extensions/SearchResultMappingExtensions.cs
+++ b/src/Humans.Web/Extensions/SearchResultMappingExtensions.cs
@@ -1,6 +1,5 @@
 using Humans.Application.DTOs;
 using Humans.Application.Interfaces;
-using Humans.Application.Services.Profile;
 using Humans.Web.Controllers;
 using Humans.Web.Models;
 using Microsoft.AspNetCore.Mvc;

--- a/tests/Humans.Application.Tests/Architecture/InterfaceMethodBudgetTests.cs
+++ b/tests/Humans.Application.Tests/Architecture/InterfaceMethodBudgetTests.cs
@@ -119,7 +119,11 @@ public class InterfaceMethodBudgetTests
         // method's own interface comment said "At ~500-user scale this can
         // be a simple Count query — no caching required" — i.e. it never
         // earned its dedicated surface area).
-        [typeof(IProfileService)] = 39,
+        // 39→37: issue #665 — consolidate search surface onto
+        // SearchProfilesAsync(predicate). Removed three narrow methods
+        // (SearchHumansAsync, SearchHumansByNameAsync, SearchApprovedUsersAsync)
+        // and added SearchProfilesAsync. Net -2.
+        [typeof(IProfileService)] = 37,
         // -1 for GetContactUsersAsync removal (/Contacts surface deleted in PR 2 of
         // email-identity-decoupling — only ContactService called it).
         // 31→31: account-merge fold redesign Phase 3.4. Added 3 fold primitives

--- a/tests/Humans.Application.Tests/Services/ProfileServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/ProfileServiceTests.cs
@@ -1148,10 +1148,10 @@ public class ProfileServiceTests : IDisposable
         pendingEmailId.Should().BeNull();
     }
 
-    // --- Search (via static helpers, exercised directly since inner returns empty) ---
+    // --- Search (via static SearchProfilesFromSnapshot helper) ---
 
     [HumansFact]
-    public async Task SearchHumansAsync_MatchesByDisplayName()
+    public async Task SearchProfiles_MatchesByDisplayName()
     {
         var userId = Guid.NewGuid();
         await SeedUserAsync(userId, displayName: "Sparkle Phoenix");
@@ -1160,15 +1160,16 @@ public class ProfileServiceTests : IDisposable
         await _dbContext.SaveChangesAsync();
 
         var snapshot = new[] { MakeFullProfile(profile, userId) };
-        var results = ProfileService.SearchHumansFromSnapshot(snapshot, "Sparkle");
+        var results = ProfileService.SearchProfilesFromSnapshot(
+            snapshot,
+            p => p.DisplayName.Contains("Sparkle", StringComparison.OrdinalIgnoreCase));
 
         results.Should().HaveCount(1);
         results[0].UserId.Should().Be(userId);
-        results[0].MatchField.Should().Be("Name");
     }
 
     [HumansFact]
-    public async Task SearchHumansAsync_MatchesByCity()
+    public async Task SearchProfiles_MatchesByCity()
     {
         var userId = Guid.NewGuid();
         await SeedUserAsync(userId);
@@ -1178,14 +1179,16 @@ public class ProfileServiceTests : IDisposable
         await _dbContext.SaveChangesAsync();
 
         var snapshot = new[] { MakeFullProfile(profile, userId) };
-        var results = ProfileService.SearchHumansFromSnapshot(snapshot, "Barcelona");
+        var results = ProfileService.SearchProfilesFromSnapshot(
+            snapshot,
+            p => p.City?.Contains("Barcelona", StringComparison.OrdinalIgnoreCase) == true);
 
         results.Should().HaveCount(1);
-        results[0].MatchField.Should().Be("City");
+        results[0].City.Should().Be("Barcelona");
     }
 
     [HumansFact]
-    public async Task SearchHumansAsync_MatchesByBio()
+    public async Task SearchProfiles_MatchesByBio()
     {
         var userId = Guid.NewGuid();
         await SeedUserAsync(userId);
@@ -1195,15 +1198,16 @@ public class ProfileServiceTests : IDisposable
         await _dbContext.SaveChangesAsync();
 
         var snapshot = new[] { MakeFullProfile(profile, userId) };
-        var results = ProfileService.SearchHumansFromSnapshot(snapshot, "fire dancing");
+        var results = ProfileService.SearchProfilesFromSnapshot(
+            snapshot,
+            p => p.Bio?.Contains("fire dancing", StringComparison.OrdinalIgnoreCase) == true);
 
         results.Should().HaveCount(1);
-        results[0].MatchField.Should().Be("Bio");
-        results[0].MatchSnippet.Should().Contain("fire dancing");
+        results[0].Bio.Should().Contain("fire dancing");
     }
 
     [HumansFact]
-    public async Task SearchHumansAsync_ExcludesSuspended()
+    public async Task SearchProfiles_ExcludesSuspended()
     {
         var u1 = Guid.NewGuid();
         var u2 = Guid.NewGuid();
@@ -1217,14 +1221,16 @@ public class ProfileServiceTests : IDisposable
         await _dbContext.SaveChangesAsync();
 
         var snapshot = new[] { MakeFullProfile(p1, u1), MakeFullProfile(p2, u2) };
-        var results = ProfileService.SearchHumansFromSnapshot(snapshot, "Madrid");
+        var results = ProfileService.SearchProfilesFromSnapshot(
+            snapshot,
+            p => p.City?.Contains("Madrid", StringComparison.OrdinalIgnoreCase) == true);
 
         results.Should().HaveCount(1);
         results[0].UserId.Should().Be(u2);
     }
 
     [HumansFact]
-    public async Task SearchHumansAsync_ExcludesUnapproved()
+    public async Task SearchProfiles_ExcludesUnapproved()
     {
         var u1 = Guid.NewGuid();
         var u2 = Guid.NewGuid();
@@ -1238,14 +1244,16 @@ public class ProfileServiceTests : IDisposable
         await _dbContext.SaveChangesAsync();
 
         var snapshot = new[] { MakeFullProfile(p1, u1), MakeFullProfile(p2, u2) };
-        var results = ProfileService.SearchHumansFromSnapshot(snapshot, "Madrid");
+        var results = ProfileService.SearchProfilesFromSnapshot(
+            snapshot,
+            p => p.City?.Contains("Madrid", StringComparison.OrdinalIgnoreCase) == true);
 
         results.Should().HaveCount(1);
         results[0].UserId.Should().Be(u2);
     }
 
     [HumansFact]
-    public async Task SearchHumansAsync_NoMatch_ReturnsEmpty()
+    public async Task SearchProfiles_NoMatch_ReturnsEmpty()
     {
         var userId = Guid.NewGuid();
         await SeedUserAsync(userId);
@@ -1254,7 +1262,9 @@ public class ProfileServiceTests : IDisposable
         await _dbContext.SaveChangesAsync();
 
         var snapshot = new[] { MakeFullProfile(profile, userId) };
-        var results = ProfileService.SearchHumansFromSnapshot(snapshot, "zzzznonexistent");
+        var results = ProfileService.SearchProfilesFromSnapshot(
+            snapshot,
+            p => p.DisplayName.Contains("zzzznonexistent", StringComparison.OrdinalIgnoreCase));
 
         results.Should().BeEmpty();
     }
@@ -1321,7 +1331,7 @@ public class ProfileServiceTests : IDisposable
     }
 
     [HumansFact]
-    public async Task SearchApprovedUsersAsync_BaseService_LoadsFromRepositoryAndFilters()
+    public async Task SearchProfilesAsync_BaseService_FiltersByDisplayName()
     {
         var u1 = Guid.NewGuid();
         var u2 = Guid.NewGuid();
@@ -1336,7 +1346,8 @@ public class ProfileServiceTests : IDisposable
         _userService.GetByIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
             .Returns(new Dictionary<Guid, User> { [u1] = user1, [u2] = user2 });
 
-        var result = await _service.SearchApprovedUsersAsync("Sparkle");
+        var result = await _service.SearchProfilesAsync(p =>
+            p.DisplayName.Contains("Sparkle", StringComparison.OrdinalIgnoreCase));
 
         result.Should().HaveCount(1);
         result[0].UserId.Should().Be(u1);
@@ -1344,7 +1355,7 @@ public class ProfileServiceTests : IDisposable
     }
 
     [HumansFact]
-    public async Task SearchHumansAsync_BaseService_LoadsFromRepositoryAndFilters()
+    public async Task SearchProfilesAsync_BaseService_FiltersByCity()
     {
         var u1 = Guid.NewGuid();
         var u2 = Guid.NewGuid();
@@ -1361,11 +1372,12 @@ public class ProfileServiceTests : IDisposable
         _userService.GetByIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
             .Returns(new Dictionary<Guid, User> { [u1] = user1, [u2] = user2 });
 
-        var result = await _service.SearchHumansAsync("Barcelona");
+        var result = await _service.SearchProfilesAsync(p =>
+            p.City?.Contains("Barcelona", StringComparison.OrdinalIgnoreCase) == true);
 
         result.Should().HaveCount(1);
         result[0].UserId.Should().Be(u1);
-        result[0].MatchField.Should().Be("City");
+        result[0].City.Should().Be("Barcelona");
     }
 
     [HumansFact]


### PR DESCRIPTION
## Summary

- Replace three narrow profile-search methods (`SearchHumansAsync`, `SearchHumansByNameAsync`, `SearchApprovedUsersAsync`) with one predicate variant `SearchProfilesAsync(Func<FullProfile, bool>)`. Reusable predicates live in `ProfileSearchPredicates` (`ByName` / `Broad` / `ByNameOrPrimaryEmail`).
- `HumanSearchResult` gains `PrimaryEmail` and `Pronouns` so callers project to caller-shaped DTOs without re-hitting the snapshot. `UserSearchResult` (Application DTO) is deleted with its sole consumer.
- Broad-search match-field/snippet computation moves caller-side via `HumanSearchMatcher.DetermineMatch`. CV-only matches surface but no longer get a "Burner CV" badge — explicitly authorized by the spec's "snippet generation" note.
- `IProfileService` budget: 39 → 37 (-3 narrow methods, +1 predicate).

## Test plan

- [x] `dotnet build Humans.slnx -v quiet` clean
- [x] `dotnet format` clean
- [x] All Humans.Application.Tests pass (2175/2175), including the bumped `InterfaceMethodBudgetTests` and migrated `SearchProfilesFromSnapshot` cases
- [x] Humans.Web.Tests pass (24/24)
- [x] Humans.Domain.Tests pass

Closes nobodies-collective/Humans#665