### PR TITLE
issue-632: user-facing /Agent/Conversation/{id} transcript view

### DIFF
--- a/docs/features/40-agent-section.md
+++ b/docs/features/40-agent-section.md
@@ -20,7 +20,7 @@ As a **signed-in human** I want to **review my previous agent conversations** so
 
 **Acceptance:**
 - `GET /Agent/Conversations` lists the user's conversations with `StartedAt`, `LastMessageAt`, `MessageCount`.
-- `GET /Agent/Conversations/{id}` shows the transcript. No user-initiated delete endpoint — retention purges old conversations on the daily schedule.
+- `GET /Agent/Conversation/{id}` (singular) shows the transcript. No user-initiated delete endpoint — retention purges old conversations on the daily schedule. The plural-form `/Agent/Conversations/{id}` is the admin diagnostic view (see US-40.3).
 
 ### US-40.3 — Admin reviews agent behavior
 As an **Admin** I want to **see all agent conversations and refusals** so that **I can spot-check quality and feed corrections back into docs**.

--- a/docs/sections/Agent.md
+++ b/docs/sections/Agent.md
@@ -59,8 +59,8 @@ Per-user message and token counters live in the Singleton `IAgentRateLimitStore`
 
 | Actor | Capability |
 |---|---|
-| Authenticated human | Send messages, read own history at `/Agent/Conversations` |
-| Admin | Configure settings, view all conversations at `/Agent/Conversations` (Human column + filters), disable globally |
+| Authenticated human | Send messages, read own history at `/Agent/Conversations`, drill into a single transcript at `/Agent/Conversation/{id}` (issue #632 — own conversations only; cross-user → 404) |
+| Admin | Configure settings, view all conversations at `/Agent/Conversations` (Human column + filters), drill into the diagnostic view at `/Agent/Conversations/{id}` (token counts, tool-call args, prompt preview), disable globally |
 | Anyone else (anonymous) | Widget not rendered; endpoints return 401 |
 
 ## Invariants

--- a/src/Humans.Application/Interfaces/IAgentService.cs
+++ b/src/Humans.Application/Interfaces/IAgentService.cs
@@ -18,6 +18,18 @@ public interface IAgentService : IUserDataContributor
     Task<Humans.Domain.Entities.AgentConversation?> GetConversationForUserAsync(
         Guid userId, Guid conversationId, CancellationToken cancellationToken);
 
+    /// <summary>
+    /// User-facing detail bundle for <c>/Agent/Conversation/{id}</c> (issue
+    /// #632). Returns the conversation (messages eagerly loaded) plus the
+    /// user-context tail as it would be built right now, so the viewer can
+    /// render a "what the agent sees about you currently" panel. Returns
+    /// null if the conversation does not exist or is not owned by
+    /// <paramref name="userId"/> — callers should 404, not 403, so the
+    /// existence of someone else's conversation is not leaked.
+    /// </summary>
+    Task<AgentMyConversationView?> GetMyConversationAsync(
+        Guid userId, Guid conversationId, CancellationToken cancellationToken);
+
     /// <summary>Admin-only listing of all conversations across users (for /Agent/Admin/Conversations).</summary>
     Task<IReadOnlyList<Humans.Domain.Entities.AgentConversation>> ListAllConversationsForAdminAsync(
         bool refusalsOnly, bool handoffsOnly, Guid? userId, int take, int skip,

--- a/src/Humans.Application/Models/AgentMyConversationView.cs
+++ b/src/Humans.Application/Models/AgentMyConversationView.cs
@@ -1,0 +1,16 @@
+using Humans.Domain.Entities;
+
+namespace Humans.Application.Models;
+
+/// <summary>
+/// User-facing transcript of the calling user's own agent conversation
+/// (issue #632). Bundles the persisted <see cref="AgentConversation"/> with the
+/// user-context tail as it would be built *right now*, so the viewer at
+/// <c>/Agent/Conversation/{id}</c> can render a "this is what the agent sees
+/// about you currently" panel alongside the historical messages. The tail is
+/// not snapshotted per turn today — see Agent.md "Open question" — so this
+/// record carries the live regenerated value with a UI caveat.
+/// </summary>
+public sealed record AgentMyConversationView(
+    AgentConversation Conversation,
+    string CurrentUserContextTail);

--- a/src/Humans.Application/Services/Agent/AgentService.cs
+++ b/src/Humans.Application/Services/Agent/AgentService.cs
@@ -265,6 +265,24 @@ public sealed class AgentService : IAgentService, IUserDataContributor
         return conv is not null && conv.UserId == userId ? conv : null;
     }
 
+    public async Task<AgentMyConversationView?> GetMyConversationAsync(
+        Guid userId, Guid conversationId, CancellationToken ct)
+    {
+        var conv = await _repo.GetConversationByIdAsync(conversationId, ct);
+        // Mismatched ownership and "doesn't exist" must look the same to the
+        // caller (Agent.md invariant 7) — both return null so the controller
+        // can 404 without leaking existence of someone else's conversation.
+        if (conv is null || conv.UserId != userId) return null;
+
+        // Tail is regenerated from the live snapshot. It may differ from what
+        // the model actually saw at the time of any historical turn — the
+        // view surfaces this caveat to the user. Persisting per-turn snapshots
+        // is tracked in Agent.md "Open question".
+        var snapshot = await _snapshots.LoadAsync(userId, ct);
+        var tail = _assembler.BuildUserContextTail(snapshot);
+        return new AgentMyConversationView(conv, tail);
+    }
+
     public Task<IReadOnlyList<AgentConversation>> ListAllConversationsForAdminAsync(
         bool refusalsOnly, bool handoffsOnly, Guid? userId, int take, int skip,
         CancellationToken ct) =>

--- a/src/Humans.Web/Controllers/AgentController.cs
+++ b/src/Humans.Web/Controllers/AgentController.cs
@@ -101,6 +101,21 @@ public class AgentController : HumansControllerBase
         return View(new AgentConversationsViewModel(listRows, IsAdminView: isAdmin));
     }
 
+    [HttpGet("Conversation/{id:guid}")]
+    public async Task<IActionResult> Conversation(Guid id, CancellationToken cancellationToken)
+    {
+        var (missing, currentUser) = await RequireCurrentUserAsync();
+        if (missing is not null) return missing;
+
+        // Ownership mismatch returns 404 (not 403) per Agent.md invariant 7
+        // and the issue #632 spec — the existence of someone else's
+        // conversation must not be inferable from the response code.
+        var view = await _agent.GetMyConversationAsync(currentUser.Id, id, cancellationToken);
+        if (view is null) return NotFound();
+
+        return View(new AgentMyConversationViewModel(view.Conversation, view.CurrentUserContextTail));
+    }
+
     [HttpGet("Conversations/{id:guid}")]
     public async Task<IActionResult> ConversationDetail(Guid id, CancellationToken cancellationToken)
     {

--- a/src/Humans.Web/Models/Agent/AgentMyConversationViewModel.cs
+++ b/src/Humans.Web/Models/Agent/AgentMyConversationViewModel.cs
@@ -1,0 +1,16 @@
+using Humans.Domain.Entities;
+
+namespace Humans.Web.Models.Agent;
+
+/// <summary>
+/// Backs the user-facing transcript view at <c>/Agent/Conversation/{id}</c>
+/// (issue #632). The conversation is the calling user's own (ownership is
+/// enforced server-side; a mismatch returns 404 — see Agent.md invariant 7).
+/// <see cref="CurrentUserContextTail"/> is regenerated from the live snapshot
+/// for the "what the agent sees about you currently" card; it may differ
+/// from what the model saw at the time of any historical turn, so the view
+/// surfaces that caveat.
+/// </summary>
+public sealed record AgentMyConversationViewModel(
+    AgentConversation Conversation,
+    string CurrentUserContextTail);

--- a/src/Humans.Web/Resources/SharedResource.ca.resx
+++ b/src/Humans.Web/Resources/SharedResource.ca.resx
@@ -1819,6 +1819,16 @@
   <data name="Privacy_ComplaintBody" xml:space="preserve"><value>Si no estàs satisfet amb la nostra resposta, tens dret a presentar una reclamació davant l'Agència Espanyola de Protecció de Dades (AEPD) a {0}.</value><comment>{0} = AEPD URL</comment></data>
 
   <!-- Agent Widget -->
+  <data name="Agent_ConversationBackToHistory" xml:space="preserve"><value>Tornar a l'historial</value></data>
+  <data name="Agent_ConversationEmpty" xml:space="preserve"><value>No hi ha missatges en aquesta conversa.</value></data>
+  <data name="Agent_ConversationHandedOffToFeedback" xml:space="preserve"><value>Derivat a informe d'incidència</value></data>
+  <data name="Agent_ConversationRefusedLabel" xml:space="preserve"><value>L'assistent ha declinat respondre aquest torn.</value></data>
+  <data name="Agent_ConversationTitle" xml:space="preserve"><value>Conversa de l'assistent</value></data>
+  <data name="Agent_ConversationToolCallsSummary" xml:space="preserve"><value>{0} crida(es) a eines</value></data>
+  <data name="Agent_ConversationTranscript" xml:space="preserve"><value>Transcripció</value></data>
+  <data name="Agent_ContextCardCaveat" xml:space="preserve"><value>Aquest és el teu context actual. Si els teus rols o equips han canviat des d'aquesta conversa, l'assistent va veure una versió diferent en aquell moment.</value></data>
+  <data name="Agent_ContextCardEmpty" xml:space="preserve"><value>Actualment no s'envia cap context personal a l'assistent.</value></data>
+  <data name="Agent_ContextCardSummary" xml:space="preserve"><value>El teu context (tal com l'assistent et veu ara)</value></data>
   <data name="Agent_HistoryEmpty" xml:space="preserve"><value>Encara no hi ha converses.</value></data>
   <data name="Agent_HistoryLastMessage" xml:space="preserve"><value>Últim missatge</value></data>
   <data name="Agent_HistoryMessages" xml:space="preserve"><value>Missatges</value></data>

--- a/src/Humans.Web/Resources/SharedResource.de.resx
+++ b/src/Humans.Web/Resources/SharedResource.de.resx
@@ -1817,6 +1817,16 @@
   <data name="Privacy_ComplaintBody" xml:space="preserve"><value>Wenn du mit unserer Antwort nicht zufrieden bist, hast du das Recht, eine Beschwerde bei der Spanischen Datenschutzbehörde (AEPD) unter {0} einzureichen.</value><comment>{0} = AEPD URL</comment></data>
 
   <!-- Agent Widget -->
+  <data name="Agent_ConversationBackToHistory" xml:space="preserve"><value>Zurück zum Verlauf</value></data>
+  <data name="Agent_ConversationEmpty" xml:space="preserve"><value>Keine Nachrichten in diesem Gespräch.</value></data>
+  <data name="Agent_ConversationHandedOffToFeedback" xml:space="preserve"><value>An Feedback-Bericht weitergeleitet</value></data>
+  <data name="Agent_ConversationRefusedLabel" xml:space="preserve"><value>Der Assistent hat es abgelehnt, in dieser Runde zu antworten.</value></data>
+  <data name="Agent_ConversationTitle" xml:space="preserve"><value>Assistenten-Gespräch</value></data>
+  <data name="Agent_ConversationToolCallsSummary" xml:space="preserve"><value>{0} Werkzeugaufruf(e)</value></data>
+  <data name="Agent_ConversationTranscript" xml:space="preserve"><value>Transkript</value></data>
+  <data name="Agent_ContextCardCaveat" xml:space="preserve"><value>Dies ist dein aktueller Kontext. Wenn sich deine Rollen oder Teams seit diesem Gespräch geändert haben, sah der Assistent damals eine andere Version.</value></data>
+  <data name="Agent_ContextCardEmpty" xml:space="preserve"><value>Derzeit wird kein persönlicher Kontext an den Assistenten gesendet.</value></data>
+  <data name="Agent_ContextCardSummary" xml:space="preserve"><value>Dein Kontext (wie der Assistent dich jetzt sieht)</value></data>
   <data name="Agent_HistoryEmpty" xml:space="preserve"><value>Noch keine Gespräche.</value></data>
   <data name="Agent_HistoryLastMessage" xml:space="preserve"><value>Letzte Nachricht</value></data>
   <data name="Agent_HistoryMessages" xml:space="preserve"><value>Nachrichten</value></data>

--- a/src/Humans.Web/Resources/SharedResource.es.resx
+++ b/src/Humans.Web/Resources/SharedResource.es.resx
@@ -1819,6 +1819,16 @@
   <data name="Privacy_ComplaintBody" xml:space="preserve"><value>Si no estás satisfecho con nuestra respuesta, tienes derecho a presentar una reclamación ante la Agencia Española de Protección de Datos (AEPD) en {0}.</value><comment>{0} = AEPD URL</comment></data>
 
   <!-- Agent Widget -->
+  <data name="Agent_ConversationBackToHistory" xml:space="preserve"><value>Volver al historial</value></data>
+  <data name="Agent_ConversationEmpty" xml:space="preserve"><value>No hay mensajes en esta conversación.</value></data>
+  <data name="Agent_ConversationHandedOffToFeedback" xml:space="preserve"><value>Derivado a informe de incidencia</value></data>
+  <data name="Agent_ConversationRefusedLabel" xml:space="preserve"><value>El asistente declinó responder este turno.</value></data>
+  <data name="Agent_ConversationTitle" xml:space="preserve"><value>Conversación del asistente</value></data>
+  <data name="Agent_ConversationToolCallsSummary" xml:space="preserve"><value>{0} llamada(s) a herramientas</value></data>
+  <data name="Agent_ConversationTranscript" xml:space="preserve"><value>Transcripción</value></data>
+  <data name="Agent_ContextCardCaveat" xml:space="preserve"><value>Este es tu contexto actual. Si tus roles o equipos han cambiado desde esta conversación, el asistente vio una versión diferente en aquel momento.</value></data>
+  <data name="Agent_ContextCardEmpty" xml:space="preserve"><value>Actualmente no se envía ningún contexto personal al asistente.</value></data>
+  <data name="Agent_ContextCardSummary" xml:space="preserve"><value>Tu contexto (como el asistente te ve ahora)</value></data>
   <data name="Agent_HistoryEmpty" xml:space="preserve"><value>Aún no tienes conversaciones.</value></data>
   <data name="Agent_HistoryLastMessage" xml:space="preserve"><value>Último mensaje</value></data>
   <data name="Agent_HistoryMessages" xml:space="preserve"><value>Mensajes</value></data>

--- a/src/Humans.Web/Resources/SharedResource.fr.resx
+++ b/src/Humans.Web/Resources/SharedResource.fr.resx
@@ -1817,6 +1817,16 @@
   <data name="Privacy_ComplaintBody" xml:space="preserve"><value>Si vous n'êtes pas satisfait de notre réponse, vous avez le droit de déposer une plainte auprès de l'Agence Espagnole de Protection des Données (AEPD) à {0}.</value><comment>{0} = AEPD URL</comment></data>
 
   <!-- Agent Widget -->
+  <data name="Agent_ConversationBackToHistory" xml:space="preserve"><value>Retour à l'historique</value></data>
+  <data name="Agent_ConversationEmpty" xml:space="preserve"><value>Aucun message dans cette conversation.</value></data>
+  <data name="Agent_ConversationHandedOffToFeedback" xml:space="preserve"><value>Transféré vers un rapport de retour</value></data>
+  <data name="Agent_ConversationRefusedLabel" xml:space="preserve"><value>L'assistant a refusé de répondre à ce tour.</value></data>
+  <data name="Agent_ConversationTitle" xml:space="preserve"><value>Conversation avec l'assistant</value></data>
+  <data name="Agent_ConversationToolCallsSummary" xml:space="preserve"><value>{0} appel(s) d'outil</value></data>
+  <data name="Agent_ConversationTranscript" xml:space="preserve"><value>Transcription</value></data>
+  <data name="Agent_ContextCardCaveat" xml:space="preserve"><value>Ceci est votre contexte actuel. Si vos rôles ou équipes ont changé depuis cette conversation, l'assistant a vu une version différente à ce moment-là.</value></data>
+  <data name="Agent_ContextCardEmpty" xml:space="preserve"><value>Aucun contexte personnel n'est actuellement envoyé à l'assistant.</value></data>
+  <data name="Agent_ContextCardSummary" xml:space="preserve"><value>Votre contexte (tel que l'assistant vous voit maintenant)</value></data>
   <data name="Agent_HistoryEmpty" xml:space="preserve"><value>Aucune conversation.</value></data>
   <data name="Agent_HistoryLastMessage" xml:space="preserve"><value>Dernier message</value></data>
   <data name="Agent_HistoryMessages" xml:space="preserve"><value>Messages</value></data>

--- a/src/Humans.Web/Resources/SharedResource.it.resx
+++ b/src/Humans.Web/Resources/SharedResource.it.resx
@@ -1817,6 +1817,16 @@
   <data name="Privacy_ComplaintBody" xml:space="preserve"><value>Se non sei soddisfatto della nostra risposta, hai il diritto di presentare un reclamo all'Agenzia Spagnola per la Protezione dei Dati (AEPD) a {0}.</value><comment>{0} = AEPD URL</comment></data>
 
   <!-- Agent Widget -->
+  <data name="Agent_ConversationBackToHistory" xml:space="preserve"><value>Torna alla cronologia</value></data>
+  <data name="Agent_ConversationEmpty" xml:space="preserve"><value>Nessun messaggio in questa conversazione.</value></data>
+  <data name="Agent_ConversationHandedOffToFeedback" xml:space="preserve"><value>Trasferito a un rapporto di feedback</value></data>
+  <data name="Agent_ConversationRefusedLabel" xml:space="preserve"><value>L'assistente ha rifiutato di rispondere in questo turno.</value></data>
+  <data name="Agent_ConversationTitle" xml:space="preserve"><value>Conversazione con l'assistente</value></data>
+  <data name="Agent_ConversationToolCallsSummary" xml:space="preserve"><value>{0} chiamata(e) a strumento</value></data>
+  <data name="Agent_ConversationTranscript" xml:space="preserve"><value>Trascrizione</value></data>
+  <data name="Agent_ContextCardCaveat" xml:space="preserve"><value>Questo è il tuo contesto attuale. Se i tuoi ruoli o team sono cambiati da questa conversazione, l'assistente ha visto una versione diversa in quel momento.</value></data>
+  <data name="Agent_ContextCardEmpty" xml:space="preserve"><value>Attualmente non viene inviato alcun contesto personale all'assistente.</value></data>
+  <data name="Agent_ContextCardSummary" xml:space="preserve"><value>Il tuo contesto (come l'assistente ti vede ora)</value></data>
   <data name="Agent_HistoryEmpty" xml:space="preserve"><value>Nessuna conversazione.</value></data>
   <data name="Agent_HistoryLastMessage" xml:space="preserve"><value>Ultimo messaggio</value></data>
   <data name="Agent_HistoryMessages" xml:space="preserve"><value>Messaggi</value></data>

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -1363,6 +1363,16 @@
   <data name="Feedback_Error" xml:space="preserve"><value>Something went wrong submitting your feedback. Please try again.</value></data>
 
   <!-- Agent Widget -->
+  <data name="Agent_ConversationBackToHistory" xml:space="preserve"><value>Back to history</value></data>
+  <data name="Agent_ConversationEmpty" xml:space="preserve"><value>No messages in this conversation.</value></data>
+  <data name="Agent_ConversationHandedOffToFeedback" xml:space="preserve"><value>Handed off to feedback report</value></data>
+  <data name="Agent_ConversationRefusedLabel" xml:space="preserve"><value>The agent declined to answer this turn.</value></data>
+  <data name="Agent_ConversationTitle" xml:space="preserve"><value>Agent conversation</value></data>
+  <data name="Agent_ConversationToolCallsSummary" xml:space="preserve"><value>{0} tool call(s)</value></data>
+  <data name="Agent_ConversationTranscript" xml:space="preserve"><value>Transcript</value></data>
+  <data name="Agent_ContextCardCaveat" xml:space="preserve"><value>This is your current context. If your roles or teams have changed since this conversation, the agent saw a different version at the time.</value></data>
+  <data name="Agent_ContextCardEmpty" xml:space="preserve"><value>No personal context is currently being sent to the agent.</value></data>
+  <data name="Agent_ContextCardSummary" xml:space="preserve"><value>Your context (as the agent sees you now)</value></data>
   <data name="Agent_HistoryEmpty" xml:space="preserve"><value>No conversations yet.</value></data>
   <data name="Agent_HistoryLastMessage" xml:space="preserve"><value>Last message</value></data>
   <data name="Agent_HistoryMessages" xml:space="preserve"><value>Messages</value></data>

--- a/src/Humans.Web/Views/Agent/Conversation.cshtml
+++ b/src/Humans.Web/Views/Agent/Conversation.cshtml
@@ -1,0 +1,134 @@
+@using Humans.Web.Extensions
+@model Humans.Web.Models.Agent.AgentMyConversationViewModel
+@{
+    ViewData["Title"] = Localizer["Agent_ConversationTitle"].Value;
+    var conv = Model.Conversation;
+    var orderedMessages = conv.Messages.OrderBy(m => m.CreatedAt).ToList();
+}
+
+<link rel="stylesheet" href="~/css/agent.css" asp-append-version="true" />
+
+<div class="d-flex justify-content-between align-items-center mb-3">
+    <h2 class="mb-0">@ViewData["Title"]</h2>
+    <a asp-action="Conversations" class="btn btn-outline-secondary btn-sm">
+        @Localizer["Agent_ConversationBackToHistory"]
+    </a>
+</div>
+
+<dl class="row mb-3">
+    <dt class="col-sm-3">@Localizer["Agent_HistoryStarted"]</dt>
+    <dd class="col-sm-9">@conv.StartedAt.ToAuditTimestamp() UTC</dd>
+    <dt class="col-sm-3">@Localizer["Agent_HistoryLastMessage"]</dt>
+    <dd class="col-sm-9">@conv.LastMessageAt.ToAuditTimestamp() UTC</dd>
+    <dt class="col-sm-3">@Localizer["Agent_HistoryMessages"]</dt>
+    <dd class="col-sm-9">@conv.MessageCount</dd>
+</dl>
+
+<details class="mb-4 agent-context-card">
+    <summary class="fw-semibold">@Localizer["Agent_ContextCardSummary"]</summary>
+    <div class="alert alert-warning small mb-2 mt-2">@Localizer["Agent_ContextCardCaveat"]</div>
+    @if (!string.IsNullOrWhiteSpace(Model.CurrentUserContextTail))
+    {
+        <pre class="agent-context-body small">@Model.CurrentUserContextTail</pre>
+    }
+    else
+    {
+        <p class="text-muted small mb-0">@Localizer["Agent_ContextCardEmpty"]</p>
+    }
+</details>
+
+<h4>@Localizer["Agent_ConversationTranscript"]</h4>
+@if (orderedMessages.Count == 0)
+{
+    <p class="text-muted">@Localizer["Agent_ConversationEmpty"]</p>
+}
+else
+{
+    <div class="agent-transcript">
+        @foreach (var msg in orderedMessages)
+        {
+            var isUser = msg.Role == Humans.Domain.Enums.AgentRole.User;
+            var isAssistant = msg.Role == Humans.Domain.Enums.AgentRole.Assistant;
+            var isRefusal = !string.IsNullOrEmpty(msg.RefusalReason);
+
+            <div class="agent-transcript-row @(isUser ? "agent-transcript-row-user" : "agent-transcript-row-assistant")">
+                <div class="agent-msg @(isUser ? "agent-msg-user" : "agent-msg-assistant") @(isRefusal ? "agent-msg-refusal" : "")">
+                    @if (isAssistant && !isRefusal)
+                    {
+                        <div class="agent-assistant-content">@Html.SanitizedMarkdown(msg.Content)</div>
+                    }
+                    else if (isUser)
+                    {
+                        @* User content runs through SanitizedMarkdown so bare URLs get auto-linked
+                           (Markdig's UseAdvancedExtensions covers AutoLinks). The sanitizer strips
+                           any unsafe HTML the user might have typed. Once #630's dedicated linkifier
+                           lands this can be swapped over. *@
+                        <div class="agent-user-content">@Html.SanitizedMarkdown(msg.Content)</div>
+                    }
+                    else if (isRefusal)
+                    {
+                        <div class="agent-refusal text-muted small">
+                            <em>@Localizer["Agent_ConversationRefusedLabel"]</em>
+                            @if (!string.IsNullOrEmpty(msg.RefusalReason))
+                            {
+                                <span> — @msg.RefusalReason</span>
+                            }
+                        </div>
+                    }
+                    else
+                    {
+                        @* Tool / system roles aren't typically surfaced as separate bubbles in the
+                           historical transcript — assistant messages already carry their FetchedDocs
+                           summary inline below. Render their content plainly if any did get persisted. *@
+                        <div class="agent-msg-other small">@msg.Content</div>
+                    }
+
+                    @if (isAssistant && msg.HandedOffToFeedbackId.HasValue)
+                    {
+                        @* Legacy auto-created Feedback handoff. Conversations after #628 emit issue
+                           proposals client-side instead and never set this column, so the link only
+                           shows for historical rows. The user owns their conversation so they own
+                           the linked Feedback report — Feedback's own auth handles the redirect to
+                           login if their session has expired. *@
+                        <div class="agent-handoff small mt-2">
+                            <span aria-hidden="true">↪</span>
+                            @Localizer["Agent_ConversationHandedOffToFeedback"]:
+                            <a asp-controller="Feedback" asp-action="Detail"
+                               asp-route-id="@msg.HandedOffToFeedbackId">@msg.HandedOffToFeedbackId</a>
+                        </div>
+                    }
+
+                    @if (isAssistant && msg.FetchedDocs is { Length: > 0 })
+                    {
+                        @* Per #632 spec: collapse by default when there's more than one tool call;
+                           expand by default for a single call (the common case is small enough that
+                           an extra click would be noise). `open` is an HTML boolean attribute and
+                           must be conditionally emitted, never set to "False" — see code-review-rules. *@
+                        var toolSummary = string.Format(System.Globalization.CultureInfo.CurrentCulture,
+                            Localizer["Agent_ConversationToolCallsSummary"].Value,
+                            msg.FetchedDocs.Length);
+                        if (msg.FetchedDocs.Length == 1)
+                        {
+                            <details class="agent-tool-calls mt-2" open>
+                                <summary class="text-muted small">
+                                    <span aria-hidden="true">🔧</span> @toolSummary
+                                </summary>
+                                <partial name="_AgentToolCallsList" model="msg.FetchedDocs" />
+                            </details>
+                        }
+                        else
+                        {
+                            <details class="agent-tool-calls mt-2">
+                                <summary class="text-muted small">
+                                    <span aria-hidden="true">🔧</span> @toolSummary
+                                </summary>
+                                <partial name="_AgentToolCallsList" model="msg.FetchedDocs" />
+                            </details>
+                        }
+                    }
+                </div>
+                <div class="agent-msg-time small text-muted">@msg.CreatedAt.ToAuditMinuteTimestamp() UTC</div>
+            </div>
+        }
+    </div>
+}

--- a/src/Humans.Web/Views/Agent/Conversations.cshtml
+++ b/src/Humans.Web/Views/Agent/Conversations.cshtml
@@ -71,7 +71,17 @@ else
                     }
                     <td class="text-end">@conv.MessageCount</td>
                     <td class="text-nowrap">@conv.LastMessageAt.ToAuditMinuteTimestamp()</td>
-                    <td><a asp-action="ConversationDetail" asp-route-id="@conv.Id">View</a></td>
+                    @* Non-admin viewers go to the user-facing transcript (issue #632) which
+                       reuses the live-chat bubble style and surfaces the live user-context tail.
+                       Admins keep the existing token/tool-call diagnostic view. *@
+                    @if (Model.IsAdminView)
+                    {
+                        <td><a asp-action="ConversationDetail" asp-route-id="@conv.Id">View</a></td>
+                    }
+                    else
+                    {
+                        <td><a asp-action="Conversation" asp-route-id="@conv.Id">View</a></td>
+                    }
                 </tr>
             }
         </tbody>

--- a/src/Humans.Web/Views/Agent/_AgentToolCallsList.cshtml
+++ b/src/Humans.Web/Views/Agent/_AgentToolCallsList.cshtml
@@ -1,0 +1,21 @@
+@model string[]
+@*
+    Renders the list of tool-call entries (name + JSON args) under an assistant
+    message in the user-facing transcript at /Agent/Conversation/{id}. Each
+    entry in FetchedDocs is stored as "<toolName>:<jsonArgs>".
+*@
+<ul class="agent-tool-calls-list small mb-0 mt-1">
+    @foreach (var entry in Model)
+    {
+        var colon = entry.IndexOf(':');
+        var toolName = colon > 0 ? entry[..colon] : entry;
+        var toolArgs = colon > 0 ? entry[(colon + 1)..] : "";
+        <li>
+            <code>@toolName</code>
+            @if (!string.IsNullOrWhiteSpace(toolArgs))
+            {
+                <pre class="agent-tool-args">@toolArgs</pre>
+            }
+        </li>
+    }
+</ul>

--- a/src/Humans.Web/wwwroot/css/agent.css
+++ b/src/Humans.Web/wwwroot/css/agent.css
@@ -41,3 +41,80 @@
         max-width: calc(100vw - 32px);
     }
 }
+
+/* Transcript view (/Agent/Conversation/{id}) — issue #632. Styled to match
+   the live chat panel above so the user sees a familiar bubble layout. */
+.agent-transcript {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    max-width: 800px;
+}
+.agent-transcript-row {
+    display: flex;
+    flex-direction: column;
+    margin-bottom: 0.5rem;
+}
+.agent-transcript-row-user {
+    align-items: flex-end;
+}
+.agent-transcript-row-assistant {
+    align-items: flex-start;
+}
+.agent-transcript .agent-msg {
+    max-width: 90%;
+}
+.agent-transcript .agent-user-content p:last-child,
+.agent-transcript .agent-assistant-content p:last-child {
+    margin-bottom: 0;
+}
+/* Refusal bubbles dim into the page so the user can tell at a glance which
+   turns the agent declined to answer. */
+.agent-msg-refusal {
+    background: #f8f8f8 !important;
+    border: 1px dashed #ccc;
+    color: #555;
+}
+.agent-handoff {
+    border-top: 1px dotted #ccc;
+    padding-top: 0.4rem;
+    color: #444;
+}
+.agent-tool-calls summary {
+    cursor: pointer;
+}
+.agent-tool-calls-list {
+    list-style: none;
+    padding-left: 0.25rem;
+}
+.agent-tool-calls-list li {
+    margin-top: 0.25rem;
+}
+.agent-tool-args {
+    background: #fafafa;
+    border: 1px solid #eee;
+    border-radius: 4px;
+    padding: 0.25rem 0.4rem;
+    margin-top: 0.15rem;
+    margin-bottom: 0;
+    white-space: pre-wrap;
+    word-break: break-word;
+    font-size: 0.8em;
+}
+.agent-msg-time {
+    margin-top: 0.15rem;
+    padding: 0 0.5rem;
+}
+.agent-context-card > summary {
+    cursor: pointer;
+    padding: 0.4rem 0;
+}
+.agent-context-body {
+    background: #f8f9fa;
+    border: 1px solid #e9ecef;
+    border-radius: 4px;
+    padding: 0.5rem 0.75rem;
+    white-space: pre-wrap;
+    word-break: break-word;
+    margin-bottom: 0;
+}


### PR DESCRIPTION
## Summary

- New `GET /Agent/Conversation/{id:guid}` (singular) renders a user-facing transcript styled like the live chat panel — chronological bubbles, tool calls collapsed under the triggering assistant message, refusals dimmed with reason inline, legacy `HandedOffToFeedbackId` linked to the Feedback report.
- New `IAgentService.GetMyConversationAsync` wraps the repo + ownership assert; cross-user → 404 (not 403) per Agent.md invariant 7.
- Collapsible "Your context (as the agent sees you now)" card surfaces the live user-context tail with an explicit "as of now" caveat — per-turn snapshots tracked as the Agent.md open question.
- Non-admin rows on `Conversations.cshtml` now link to the new transcript view; admin rows continue to point at the existing diagnostic detail view.

## Test plan
- [ ] Have a conversation with the agent (incl. a tool call), then open `/Agent/Conversation/{your-id}` and confirm the bubbles, tool-call accordion, and context card render
- [ ] Visiting another user's conversation id returns 404 (verified by network tab — body should be the standard 404 page, not 403)
- [ ] Random/unknown guid → 404
- [ ] Refusal turn shows the muted/dashed style with reason inline
- [ ] If a legacy conversation has `HandedOffToFeedbackId`, the link resolves to `/Feedback/{id}`
- [ ] Bare URLs in messages auto-link (Markdig `UseAdvancedExtensions`)
- [ ] `Views/Agent/Conversations.cshtml` non-admin row link goes to the new singular route

Closes nobodies-collective/Humans#632