### PR TITLE
issue-641: move Camp members/roles management to dedicated /Edit/Members page

### DIFF
--- a/docs/features/20-camps.md
+++ b/docs/features/20-camps.md
@@ -166,7 +166,7 @@ Nobodies Collective organizes camping areas ("barrios") at Nowhere and related e
 
 **Acceptance Criteria:**
 - CampAdmin can create, edit, deactivate, and reactivate role definitions at `/Camps/Admin/Roles`. Deactivated definitions are hidden from new-assignment UI but historical assignments stay intact.
-- Per-camp role assignments live on the Camp Edit page (`/Camps/{slug}/Edit`), one card per active role definition, ordered by `SortOrder`. Each card renders one row per slot up to `SlotCount`; filled slots show the assigned human plus an unassign button, empty slots show a `_HumanSearchInput` typeahead picker (search-as-you-type, name + burner name only via `?scope=name`).
+- Per-camp role assignments live on the Camp Members page (`/Camps/{slug}/Edit/Members`), one card per active role definition, ordered by `SortOrder`. Each card renders one row per slot up to `SlotCount`; filled slots show the assigned human plus an unassign button, empty slots show a `_HumanSearchInput` typeahead picker (search-as-you-type, name + burner name only via `?scope=name`).
 - The picker excludes humans already filling the same role from its suggestions (`ExcludeUserIds`), so leads can't accidentally re-assign the same human.
 - Assigning a role: the picker posts to `/Camps/{slug}/Roles/AssignByUser` which adds the picked human as a CampMember (Active) if they're not already one and assigns the role in one step (`ICampService.AddMemberAndAssignRoleAsync`). Audited as `CampMemberAddedByLead` for the membership add. The legacy `/Roles/Assign` endpoint (taking a `campMemberId`) remains available for callers that already have a member id.
 - Service still rejects with `MemberNotActive` / `MemberSeasonMismatch` if a stale member id is submitted to the legacy endpoint, and with `AlreadyHoldsRole` if the same human is re-submitted before the page refreshes.
@@ -185,11 +185,11 @@ Nobodies Collective organizes camping areas ("barrios") at Nowhere and related e
 **Acceptance Criteria:**
 - On a camp's detail page, an authenticated human with no existing membership sees a "Request to join for {year}" button (only when the camp has an Active or Full season for the public year).
 - Authenticated humans who are already a **lead** of the camp see a "You are a lead for {year}" info alert instead of the request button — leads are part of the camp by definition and shouldn't be prompted to request membership.
-- The Actions card on a camp lead's detail view labels the edit link as "Edit Barrio / Assign roles" so leads understand the same page covers role management; non-leads still see the plain "Edit Barrio" label.
+- The Actions card on a camp lead's detail view labels the edit link as "Edit Barrio / Assign roles" so leads understand role management is one click away (the link goes to `/Edit`, which links through to `/Edit/Members` for role assignments and pending-request review); non-leads still see the plain "Edit Barrio" label.
 - Copy on the request card explicitly states that this does NOT join you to the camp — do that through the camp's own process first.
 - A pending request can be withdrawn by the requester; an active membership can be left by the member.
 - Membership state (Pending / Active) is never rendered on anonymous views.
-- Leads and CampAdmin see pending requests on the camp edit page with Approve / Reject buttons, and active members with a Remove button.
+- Leads and CampAdmin see pending requests on the camp Members page (`/Camps/{slug}/Edit/Members`) with Approve / Reject buttons, and active members with a Remove button.
 - Approve / Reject mutations are scoped to the authorizing camp — a lead of camp A cannot mutate camp B's memberships by submitting a crafted member id.
 - Concurrent duplicate "request" submissions resolve idempotently — the second one returns the winning row instead of a 500.
 - When a season is rejected or withdrawn, pending requesters receive a notification. Pending rows are left as-is (so if the season is later reactivated, the request is still live).
@@ -460,8 +460,9 @@ Transitions:
 | `GET /Camps/{slug}/Season/{year}` | Camp detail for specific season |
 | `GET /Camps/Register` | Registration form |
 | `POST /Camps/Register` | Submit registration |
-| `GET /Camps/{slug}/Edit` | Edit form |
+| `GET /Camps/{slug}/Edit` | Edit form (camp metadata only — links to Members for role/membership management) |
 | `POST /Camps/{slug}/Edit` | Submit edits |
+| `GET /Camps/{slug}/Edit/Members` | Members + roles management (pending requests, active members, role assignments) |
 | `POST /Camps/{slug}/OptIn/{year}` | Opt-in to season |
 | `POST /Camps/{slug}/Leads/Add` | Add co-lead |
 | `POST /Camps/{slug}/Leads/Remove/{leadId}` | Remove lead |

--- a/docs/sections/Camps.md
+++ b/docs/sections/Camps.md
@@ -163,7 +163,8 @@ Three controllers serve this section. The MVC URL surface is dual-routed under `
 | `/Camps/{slug}` | `CampController` | Camp detail (current season, leads, images, history) |
 | `/Camps/{slug}/Season/{year}` | `CampController` | Past-season detail |
 | `/Camps/{slug}/Contact` | `CampController` | Facilitated message to camp leads |
-| `/Camps/{slug}/Edit` | `CampController` | Lead-only edit of season copy / images / leads |
+| `/Camps/{slug}/Edit` | `CampController` | Lead-only edit of season copy / images / leads (links through to Members for role/membership management) |
+| `/Camps/{slug}/Edit/Members` | `CampController.Members` | Lead-only members + roles management (pending requests, active members, role assignments) |
 | `/Camps/Register` | `CampController` | New camp registration |
 | `/Camps/{slug}/OptIn/{year}`, `.../Withdraw/{seasonId}`, `.../Rejoin/{seasonId}` | `CampController` | Per-season participation toggles |
 | `/Camps/{slug}/Leads/*` | `CampController` | Lead add/remove |

--- a/memory/product/humans-terminology.md
+++ b/memory/product/humans-terminology.md
@@ -15,3 +15,4 @@ It applies across all locales (the word "humans" is kept in English even in es/d
 - Even in es/de/fr/it `.resx` files, "humans" stays in English; don't translate to "miembros", "freiwillige", etc.
 - Internal code (`User`, `IUserService`, `humans` table — wait, the table IS named for users; entity is `User`) is fine as-is.
 - "Volunteer" is OK only when specifically referring to the **Volunteer** role/team (the Spanish `Volunteers` team, the volunteer-vs-Colaborador-vs-Asociado tier distinction).
+- "Member" / "Camp member" is OK in the **Camps** context — `CampMember` is a real domain concept (a person's active participation in a specific camp/year), and "Camp Members" reads accurately for the per-camp roster UI. Don't apply the humans-replacement here.

--- a/src/Humans.Web/Controllers/CampController.cs
+++ b/src/Humans.Web/Controllers/CampController.cs
@@ -412,6 +412,34 @@ public class CampController : HumansCampControllerBase
         return View(viewModel);
     }
 
+    [Authorize]
+    [HttpGet("{slug}/Edit/Members")]
+    public async Task<IActionResult> Members(string slug, int? year, CancellationToken ct)
+    {
+        var (errorResult, _, camp) = await ResolveCampManagementAsync(slug);
+        if (errorResult is not null)
+        {
+            return errorResult;
+        }
+
+        var editData = await _campService.GetCampEditDataAsync(camp.Id, year);
+        if (editData is null)
+        {
+            SetError("No season found for this camp.");
+            return RedirectToAction(nameof(Details), new { slug });
+        }
+
+        var viewModel = MapToEditViewModel(editData);
+        await PopulateEditMembersAsync(viewModel);
+
+        var openSeason = camp.Seasons.FirstOrDefault(s => s.Status == CampSeasonStatus.Active);
+        viewModel.RolesPanel = openSeason is null
+            ? null
+            : await BuildRolesPanelAsync(camp.Slug, openSeason.Id, canManage: true, ct);
+
+        return View(viewModel);
+    }
+
     private async Task<CampRolesPanelViewModel> BuildRolesPanelAsync(
         string campSlug, Guid campSeasonId, bool canManage, CancellationToken ct)
     {
@@ -647,7 +675,7 @@ public class CampController : HumansCampControllerBase
         if (userId == Guid.Empty)
         {
             SetError("Please search and select a human first.");
-            return RedirectToAction(nameof(Edit), new { slug });
+            return RedirectToAction(nameof(Members), new { slug });
         }
 
         try
@@ -661,7 +689,7 @@ public class CampController : HumansCampControllerBase
             SetError(ex.Message);
         }
 
-        return RedirectToAction(nameof(Edit), new { slug });
+        return RedirectToAction(nameof(Members), new { slug });
     }
 
     [Authorize]
@@ -686,7 +714,7 @@ public class CampController : HumansCampControllerBase
             SetError(ex.Message);
         }
 
-        return RedirectToAction(nameof(Edit), new { slug });
+        return RedirectToAction(nameof(Members), new { slug });
     }
 
 
@@ -949,7 +977,7 @@ public class CampController : HumansCampControllerBase
             SetError(ex.Message);
         }
 
-        return RedirectToAction(nameof(Edit), new { slug });
+        return RedirectToAction(nameof(Members), new { slug });
     }
 
     [Authorize]
@@ -971,7 +999,7 @@ public class CampController : HumansCampControllerBase
             SetError(ex.Message);
         }
 
-        return RedirectToAction(nameof(Edit), new { slug });
+        return RedirectToAction(nameof(Members), new { slug });
     }
 
     [Authorize]
@@ -993,7 +1021,7 @@ public class CampController : HumansCampControllerBase
             SetError(ex.Message);
         }
 
-        return RedirectToAction(nameof(Edit), new { slug });
+        return RedirectToAction(nameof(Members), new { slug });
     }
 
     [Authorize]
@@ -1007,14 +1035,14 @@ public class CampController : HumansCampControllerBase
         if (userId == Guid.Empty)
         {
             SetError("Please search and select a human first.");
-            return RedirectToAction(nameof(Edit), new { slug });
+            return RedirectToAction(nameof(Members), new { slug });
         }
 
         var openSeason = camp.Seasons.FirstOrDefault(s => s.Status == CampSeasonStatus.Active);
         if (openSeason is null)
         {
             SetError("No active season for this camp.");
-            return RedirectToAction(nameof(Edit), new { slug });
+            return RedirectToAction(nameof(Members), new { slug });
         }
 
         try
@@ -1028,7 +1056,7 @@ public class CampController : HumansCampControllerBase
             SetError("Failed to add human to camp.");
         }
 
-        return RedirectToAction(nameof(Edit), new { slug });
+        return RedirectToAction(nameof(Members), new { slug });
     }
 
     // ======================================================================
@@ -1047,7 +1075,7 @@ public class CampController : HumansCampControllerBase
         if (openSeason is null)
         {
             SetError("No active season for this camp.");
-            return RedirectToAction(nameof(Edit), new { slug });
+            return RedirectToAction(nameof(Members), new { slug });
         }
 
         var outcome = await _campRoleService.AssignAsync(openSeason.Id, roleDefinitionId, campMemberId, user.Id, ct);
@@ -1074,7 +1102,7 @@ public class CampController : HumansCampControllerBase
             SetError(message);
         }
 
-        return RedirectToAction(nameof(Edit), new { slug });
+        return RedirectToAction(nameof(Members), new { slug });
     }
 
     /// <summary>
@@ -1094,14 +1122,14 @@ public class CampController : HumansCampControllerBase
         if (userId == Guid.Empty)
         {
             SetError("Please search and select a human first.");
-            return RedirectToAction(nameof(Edit), new { slug });
+            return RedirectToAction(nameof(Members), new { slug });
         }
 
         var openSeason = camp.Seasons.FirstOrDefault(s => s.Status == CampSeasonStatus.Active);
         if (openSeason is null)
         {
             SetError("No active season for this camp.");
-            return RedirectToAction(nameof(Edit), new { slug });
+            return RedirectToAction(nameof(Members), new { slug });
         }
 
         AssignCampRoleOutcome outcome;
@@ -1114,7 +1142,7 @@ public class CampController : HumansCampControllerBase
         {
             _logger.LogError(ex, "AssignRoleByUser failed for camp {CampSlug}, user {UserId}.", slug, userId);
             SetError("Failed to assign role.");
-            return RedirectToAction(nameof(Edit), new { slug });
+            return RedirectToAction(nameof(Members), new { slug });
         }
 
         var message = outcome switch
@@ -1140,7 +1168,7 @@ public class CampController : HumansCampControllerBase
             SetError(message);
         }
 
-        return RedirectToAction(nameof(Edit), new { slug });
+        return RedirectToAction(nameof(Members), new { slug });
     }
 
     [Authorize]
@@ -1172,7 +1200,7 @@ public class CampController : HumansCampControllerBase
             SetError("Assignment not found.");
         }
 
-        return RedirectToAction(nameof(Edit), new { slug });
+        return RedirectToAction(nameof(Members), new { slug });
     }
 
     // ======================================================================

--- a/src/Humans.Web/Controllers/CampController.cs
+++ b/src/Humans.Web/Controllers/CampController.cs
@@ -399,15 +399,6 @@ public class CampController : HumansCampControllerBase
         }
 
         var viewModel = MapToEditViewModel(editData);
-        await PopulateEditMembersAsync(viewModel);
-
-        // Build per-camp roles panel against the camp's open season (if any).
-        // canManage is implicitly true here: ResolveCampManagementAsync already
-        // returned Forbid for callers without CampOperationRequirement.Manage.
-        var openSeason = camp.Seasons.FirstOrDefault(s => s.Status == CampSeasonStatus.Active);
-        viewModel.RolesPanel = openSeason is null
-            ? null
-            : await BuildRolesPanelAsync(camp.Slug, openSeason.Id, canManage: true, ct);
 
         return View(viewModel);
     }

--- a/src/Humans.Web/Views/Camp/Edit.cshtml
+++ b/src/Humans.Web/Views/Camp/Edit.cshtml
@@ -251,6 +251,21 @@
     </div>
 
     <div class="col-md-4">
+        @* Members & Roles — moved to dedicated page (issue nobodies-collective#641) *@
+        <div class="card mb-4">
+            <div class="card-header">
+                <i class="fa-solid fa-users-gear me-1"></i> Members & Roles
+            </div>
+            <div class="card-body">
+                <p class="card-text small text-muted mb-3">
+                    Manage active members, roles, leads, and pending join requests.
+                </p>
+                <a asp-action="Members" asp-route-slug="@Model.Slug" class="btn btn-primary">
+                    <i class="fa-solid fa-users-gear me-1"></i> Open members & roles
+                </a>
+            </div>
+        </div>
+
         <div class="card mb-4">
             <div class="card-header">
                 <i class="fa-solid fa-cart-shopping me-1"></i> Store
@@ -262,151 +277,6 @@
                 <a asp-controller="Store" asp-action="Index" class="btn btn-primary">
                     <i class="fa-solid fa-cart-shopping me-1"></i> Open store
                 </a>
-            </div>
-        </div>
-
-        @* Add active member (issue nobodies-collective#489) *@
-        @if (Model.RolesPanel is not null && Model.RolesPanel.CanManage)
-        {
-            <div class="card mb-4">
-                <div class="card-header">
-                    <i class="fa-solid fa-user-plus me-1"></i> Add active member
-                </div>
-                <div class="card-body">
-                    <form asp-action="AddMember" asp-route-slug="@Model.Slug" method="post" class="input-group">
-                        @Html.AntiForgeryToken()
-                        <partial name="_HumanSearchInput" view-data='@(new ViewDataDictionary(ViewData) {
-                            { "FieldName", "userId" },
-                            { "Scope", "name" }
-                        })' />
-                        <button type="submit" class="btn btn-outline-success" title="Add active member">
-                            <i class="fa-solid fa-user-plus"></i>
-                        </button>
-                    </form>
-                    <div class="form-text">Search by name. The human is added to the camp's open season as Active.</div>
-                </div>
-            </div>
-        }
-
-        @* Per-camp roles panel (issue nobodies-collective#489) *@
-        @if (Model.RolesPanel is not null)
-        {
-            <div class="card mb-4">
-                <div class="card-header">
-                    <i class="fa-solid fa-list-check me-1"></i> Roles (@Model.Year)
-                </div>
-                <div class="card-body">
-                    @if (Model.RolesPanel.Rows.Count == 0)
-                    {
-                        <p class="text-muted small mb-0">
-                            No camp roles defined yet.
-                            @if (Model.RolesPanel.CanManage)
-                            {
-                                <text>CampAdmin can add them at <a asp-controller="CampAdmin" asp-action="Roles">Camp roles</a>.</text>
-                            }
-                        </p>
-                    }
-                    else
-                    {
-                        @foreach (var role in Model.RolesPanel.Rows)
-                        {
-                            var assignedMemberIds = role.FilledSlots.Select(s => s.CampMemberId).ToHashSet();
-                            <div class="mb-3">
-                                <h6 class="mb-1">
-                                    @role.Name
-                                    @if (role.MinimumRequired > 0)
-                                    {
-                                        <span class="badge bg-secondary">required</span>
-                                    }
-                                    <small class="text-muted">@role.CurrentCount / @role.SlotCount filled</small>
-                                    @if (role.OverCapacity)
-                                    {
-                                        <span class="badge bg-warning text-dark" title="More assignments than the configured slot count.">Over capacity</span>
-                                    }
-                                </h6>
-                                @if (!string.IsNullOrWhiteSpace(role.Description))
-                                {
-                                    <div class="text-muted small mb-2">@Html.SanitizedMarkdown(role.Description)</div>
-                                }
-
-                                @* Filled slots — render in service-supplied order (AssignedAt) *@
-                                @foreach (var slot in role.FilledSlots)
-                                {
-                                    <div class="d-flex justify-content-between align-items-center gap-2 mb-1">
-                                        <human-link user-id="@slot.UserId" display-name="@slot.DisplayName" show-popover="true" />
-                                        @if (Model.RolesPanel.CanManage)
-                                        {
-                                            <form asp-action="UnassignRole" asp-route-slug="@Model.Slug" asp-route-assignmentId="@slot.AssignmentId" method="post" class="d-inline">
-                                                @Html.AntiForgeryToken()
-                                                <button type="submit" class="btn btn-sm btn-outline-danger" title="Remove this assignment" data-confirm="Remove this assignment?">
-                                                    <i class="fa-solid fa-xmark"></i>
-                                                </button>
-                                            </form>
-                                        }
-                                    </div>
-                                }
-
-                                @* Empty slots — search + assign (adds the human to the camp if not already a member). *@
-                                @if (Model.RolesPanel.CanManage)
-                                {
-                                    var alreadyInRole = role.FilledSlots.Select(s => s.UserId).ToList();
-                                    @for (var i = 0; i < role.EmptySlotCount; i++)
-                                    {
-                                        <form asp-action="AssignRoleByUser" asp-route-slug="@Model.Slug" method="post" class="d-flex gap-2 mb-1">
-                                            @Html.AntiForgeryToken()
-                                            <input type="hidden" name="roleDefinitionId" value="@role.DefinitionId" />
-                                            <partial name="_HumanSearchInput" view-data='@(new ViewDataDictionary(ViewData) {
-                                                { "FieldName", "userId" },
-                                                { "InstanceKey", $"role-{role.DefinitionId:N}-slot-{i}" },
-                                                { "Placeholder", "Search humans…" },
-                                                { "ExcludeUserIds", alreadyInRole },
-                                                { "Scope", "name" }
-                                            })' />
-                                            <button class="btn btn-sm btn-outline-primary" type="submit" title="Assign — adds to camp if not yet a member">
-                                                <i class="fa-solid fa-check"></i>
-                                            </button>
-                                        </form>
-                                    }
-                                }
-                            </div>
-                        }
-                    }
-                </div>
-            </div>
-        }
-
-        @* Lead Management *@
-        <div class="card mb-4">
-            <div class="card-header">
-                <i class="fa-solid fa-user-shield me-1"></i> Leads
-            </div>
-            <ul class="list-group list-group-flush">
-                @foreach (var lead in Model.Leads)
-                {
-                    <li class="list-group-item d-flex justify-content-between align-items-center">
-                        <human-link user-id="@lead.UserId" display-name="@lead.DisplayName" />
-                        @if (Model.Leads.Count > 1)
-                        {
-                            <form asp-action="RemoveLead" asp-route-slug="@Model.Slug" asp-route-leadId="@lead.LeadId" method="post" class="d-inline">
-                                @Html.AntiForgeryToken()
-                                <button type="submit" class="btn btn-sm btn-outline-danger" title="Remove lead"
-                                        data-confirm="Remove @lead.DisplayName as a lead?">
-                                    <i class="fa-solid fa-user-minus"></i>
-                                </button>
-                            </form>
-                        }
-                    </li>
-                }
-            </ul>
-            <div class="card-body">
-                <form asp-action="AddLead" asp-route-slug="@Model.Slug" method="post" class="input-group">
-                    @Html.AntiForgeryToken()
-                    <partial name="_HumanSearchInput" view-data='@(new ViewDataDictionary(ViewData) { { "FieldName", "userId" } })' />
-                    <button type="submit" class="btn btn-outline-success" title="Add lead">
-                        <i class="fa-solid fa-user-plus"></i>
-                    </button>
-                </form>
-                <div class="form-text">Search by name to find the new lead.</div>
             </div>
         </div>
 
@@ -535,85 +405,6 @@
             </div>
         </div>
 
-        @* Per-season membership (pending requests + active members) *@
-        <div class="card mb-4">
-            <div class="card-header">
-                <i class="fa-solid fa-users-gear me-1"></i> Humans this season (@Model.Year)
-            </div>
-            <div class="card-body p-0">
-                <div class="px-3 py-2">
-                    <strong class="text-muted small">Pending requests (@Model.PendingMembers.Count)</strong>
-                </div>
-                @if (Model.PendingMembers.Count == 0)
-                {
-                    <div class="px-3 pb-2 text-muted small fst-italic">No pending requests.</div>
-                }
-                else
-                {
-                    <ul class="list-group list-group-flush">
-                        @foreach (var pending in Model.PendingMembers)
-                        {
-                            <li class="list-group-item d-flex justify-content-between align-items-center gap-2">
-                                <human-link user-id="@pending.UserId" display-name="@pending.DisplayName" show-popover="true" />
-                                <div class="d-flex gap-2">
-                                    <form asp-action="ApproveMembership" asp-route-slug="@Model.Slug" asp-route-campMemberId="@pending.CampMemberId" method="post" class="d-inline">
-                                        @Html.AntiForgeryToken()
-                                        <button type="submit" class="btn btn-sm btn-outline-success" title="Approve">
-                                            <i class="fa-solid fa-check"></i>
-                                        </button>
-                                    </form>
-                                    <form asp-action="RejectMembership" asp-route-slug="@Model.Slug" asp-route-campMemberId="@pending.CampMemberId" method="post" class="d-inline">
-                                        @Html.AntiForgeryToken()
-                                        <button type="submit" class="btn btn-sm btn-outline-danger" title="Reject" data-confirm="Reject this request?">
-                                            <i class="fa-solid fa-xmark"></i>
-                                        </button>
-                                    </form>
-                                </div>
-                            </li>
-                        }
-                    </ul>
-                }
-
-                <div class="px-3 pt-3 pb-2">
-                    <strong class="text-muted small">Active humans (@Model.ActiveMembers.Count)</strong>
-                </div>
-                @if (Model.ActiveMembers.Count == 0)
-                {
-                    <div class="px-3 pb-2 text-muted small fst-italic">No humans yet.</div>
-                }
-                else
-                {
-                    <ul class="list-group list-group-flush">
-                        @foreach (var active in Model.ActiveMembers)
-                        {
-                            <li class="list-group-item d-flex justify-content-between align-items-center gap-2">
-                                <div class="d-flex align-items-center gap-2">
-                                    <human-link user-id="@active.UserId" display-name="@active.DisplayName" show-popover="true" />
-                                    @if (active.IsLead)
-                                    {
-                                        <span class="badge bg-info text-dark" title="Camp lead">Lead</span>
-                                    }
-                                </div>
-                                @if (!active.IsLead && active.CampMemberId != Guid.Empty)
-                                {
-                                    <form asp-action="RemoveMembership" asp-route-slug="@Model.Slug" asp-route-campMemberId="@active.CampMemberId" method="post" class="d-inline">
-                                        @Html.AntiForgeryToken()
-                                        <button type="submit" class="btn btn-sm btn-outline-danger" title="Remove" data-confirm="Remove this human?">
-                                            <i class="fa-solid fa-user-minus"></i>
-                                        </button>
-                                    </form>
-                                }
-                            </li>
-                        }
-                    </ul>
-                }
-                <div class="card-body border-top">
-                    <small class="text-muted">
-                        This is a post-hoc record so the app knows who's in which camp. Approving here does <strong>not</strong> admit someone to your camp — that's done through your camp's own process.
-                    </small>
-                </div>
-            </div>
-        </div>
     </div>
 </div>
 

--- a/src/Humans.Web/Views/Camp/Edit.cshtml
+++ b/src/Humans.Web/Views/Camp/Edit.cshtml
@@ -251,17 +251,17 @@
     </div>
 
     <div class="col-md-4">
-        @* Members & Roles — moved to dedicated page (issue nobodies-collective#641) *@
+        @* Humans & Roles — moved to dedicated page (issue nobodies-collective#641) *@
         <div class="card mb-4">
             <div class="card-header">
-                <i class="fa-solid fa-users-gear me-1"></i> Members & Roles
+                <i class="fa-solid fa-users-gear me-1"></i> Humans & Roles
             </div>
             <div class="card-body">
                 <p class="card-text small text-muted mb-3">
-                    Manage active members, roles, leads, and pending join requests.
+                    Manage active humans, roles, leads, and pending join requests.
                 </p>
                 <a asp-action="Members" asp-route-slug="@Model.Slug" class="btn btn-primary">
-                    <i class="fa-solid fa-users-gear me-1"></i> Open members & roles
+                    <i class="fa-solid fa-users-gear me-1"></i> Open humans & roles
                 </a>
             </div>
         </div>

--- a/src/Humans.Web/Views/Camp/Edit.cshtml
+++ b/src/Humans.Web/Views/Camp/Edit.cshtml
@@ -251,17 +251,17 @@
     </div>
 
     <div class="col-md-4">
-        @* Humans & Roles — moved to dedicated page (issue nobodies-collective#641) *@
+        @* Members & Roles — moved to dedicated page (issue nobodies-collective#641) *@
         <div class="card mb-4">
             <div class="card-header">
-                <i class="fa-solid fa-users-gear me-1"></i> Humans & Roles
+                <i class="fa-solid fa-users-gear me-1"></i> Members & Roles
             </div>
             <div class="card-body">
                 <p class="card-text small text-muted mb-3">
-                    Manage active humans, roles, leads, and pending join requests.
+                    Manage active members, roles, leads, and pending join requests.
                 </p>
                 <a asp-action="Members" asp-route-slug="@Model.Slug" class="btn btn-primary">
-                    <i class="fa-solid fa-users-gear me-1"></i> Open humans & roles
+                    <i class="fa-solid fa-users-gear me-1"></i> Open members & roles
                 </a>
             </div>
         </div>

--- a/src/Humans.Web/Views/Camp/Members.cshtml
+++ b/src/Humans.Web/Views/Camp/Members.cshtml
@@ -1,6 +1,6 @@
 @model Humans.Web.Models.CampEditViewModel
 @{
-    ViewData["Title"] = $"Members & Roles — {Model.Name}";
+    ViewData["Title"] = $"Humans & Roles — {Model.Name}";
 }
 
 <nav aria-label="breadcrumb">
@@ -8,11 +8,11 @@
         <li class="breadcrumb-item"><a asp-action="Index">@Localizer["Camp_Plural"]</a></li>
         <li class="breadcrumb-item"><a asp-action="Details" asp-route-slug="@Model.Slug">@Model.Name</a></li>
         <li class="breadcrumb-item"><a asp-action="Edit" asp-route-slug="@Model.Slug">Edit</a></li>
-        <li class="breadcrumb-item active" aria-current="page">Members</li>
+        <li class="breadcrumb-item active" aria-current="page">Humans</li>
     </ol>
 </nav>
 
-<h1 class="mb-4">Members &amp; Roles — @Model.Name <small class="text-muted">(@Model.Year)</small></h1>
+<h1 class="mb-4">Humans &amp; Roles — @Model.Name <small class="text-muted">(@Model.Year)</small></h1>
 
 <vc:temp-data-alerts />
 

--- a/src/Humans.Web/Views/Camp/Members.cshtml
+++ b/src/Humans.Web/Views/Camp/Members.cshtml
@@ -41,7 +41,6 @@
                     {
                         @foreach (var role in Model.RolesPanel.Rows)
                         {
-                            var assignedMemberIds = role.FilledSlots.Select(s => s.CampMemberId).ToHashSet();
                             <div class="mb-3">
                                 <h6 class="mb-1">
                                     @role.Name

--- a/src/Humans.Web/Views/Camp/Members.cshtml
+++ b/src/Humans.Web/Views/Camp/Members.cshtml
@@ -1,0 +1,249 @@
+@model Humans.Web.Models.CampEditViewModel
+@{
+    ViewData["Title"] = $"Members & Roles — {Model.Name}";
+}
+
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a asp-action="Index">@Localizer["Camp_Plural"]</a></li>
+        <li class="breadcrumb-item"><a asp-action="Details" asp-route-slug="@Model.Slug">@Model.Name</a></li>
+        <li class="breadcrumb-item"><a asp-action="Edit" asp-route-slug="@Model.Slug">Edit</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Members</li>
+    </ol>
+</nav>
+
+<h1 class="mb-4">Members &amp; Roles — @Model.Name <small class="text-muted">(@Model.Year)</small></h1>
+
+<vc:temp-data-alerts />
+
+<div class="row">
+    @* Wide column — Roles panel needs the horizontal space. *@
+    <div class="col-md-8">
+        @* Per-camp roles panel (issue nobodies-collective#489) *@
+        @if (Model.RolesPanel is not null)
+        {
+            <div class="card mb-4">
+                <div class="card-header">
+                    <i class="fa-solid fa-list-check me-1"></i> Roles (@Model.Year)
+                </div>
+                <div class="card-body">
+                    @if (Model.RolesPanel.Rows.Count == 0)
+                    {
+                        <p class="text-muted small mb-0">
+                            No camp roles defined yet.
+                            @if (Model.RolesPanel.CanManage)
+                            {
+                                <text>CampAdmin can add them at <a asp-controller="CampAdmin" asp-action="Roles">Camp roles</a>.</text>
+                            }
+                        </p>
+                    }
+                    else
+                    {
+                        @foreach (var role in Model.RolesPanel.Rows)
+                        {
+                            var assignedMemberIds = role.FilledSlots.Select(s => s.CampMemberId).ToHashSet();
+                            <div class="mb-3">
+                                <h6 class="mb-1">
+                                    @role.Name
+                                    @if (role.MinimumRequired > 0)
+                                    {
+                                        <span class="badge bg-secondary">required</span>
+                                    }
+                                    <small class="text-muted">@role.CurrentCount / @role.SlotCount filled</small>
+                                    @if (role.OverCapacity)
+                                    {
+                                        <span class="badge bg-warning text-dark" title="More assignments than the configured slot count.">Over capacity</span>
+                                    }
+                                </h6>
+                                @if (!string.IsNullOrWhiteSpace(role.Description))
+                                {
+                                    <div class="text-muted small mb-2">@Html.SanitizedMarkdown(role.Description)</div>
+                                }
+
+                                @* Filled slots — render in service-supplied order (AssignedAt) *@
+                                @foreach (var slot in role.FilledSlots)
+                                {
+                                    <div class="d-flex justify-content-between align-items-center gap-2 mb-1">
+                                        <human-link user-id="@slot.UserId" display-name="@slot.DisplayName" show-popover="true" />
+                                        @if (Model.RolesPanel.CanManage)
+                                        {
+                                            <form asp-action="UnassignRole" asp-route-slug="@Model.Slug" asp-route-assignmentId="@slot.AssignmentId" method="post" class="d-inline">
+                                                @Html.AntiForgeryToken()
+                                                <button type="submit" class="btn btn-sm btn-outline-danger" title="Remove this assignment" data-confirm="Remove this assignment?">
+                                                    <i class="fa-solid fa-xmark"></i>
+                                                </button>
+                                            </form>
+                                        }
+                                    </div>
+                                }
+
+                                @* Empty slots — search + assign (adds the human to the camp if not already a member). *@
+                                @if (Model.RolesPanel.CanManage)
+                                {
+                                    var alreadyInRole = role.FilledSlots.Select(s => s.UserId).ToList();
+                                    @for (var i = 0; i < role.EmptySlotCount; i++)
+                                    {
+                                        <form asp-action="AssignRoleByUser" asp-route-slug="@Model.Slug" method="post" class="d-flex gap-2 mb-1">
+                                            @Html.AntiForgeryToken()
+                                            <input type="hidden" name="roleDefinitionId" value="@role.DefinitionId" />
+                                            <partial name="_HumanSearchInput" view-data='@(new ViewDataDictionary(ViewData) {
+                                                { "FieldName", "userId" },
+                                                { "InstanceKey", $"role-{role.DefinitionId:N}-slot-{i}" },
+                                                { "Placeholder", "Search humans…" },
+                                                { "ExcludeUserIds", alreadyInRole },
+                                                { "Scope", "name" }
+                                            })' />
+                                            <button class="btn btn-sm btn-outline-primary" type="submit" title="Assign — adds to camp if not yet a member">
+                                                <i class="fa-solid fa-check"></i>
+                                            </button>
+                                        </form>
+                                    }
+                                }
+                            </div>
+                        }
+                    }
+                </div>
+            </div>
+        }
+
+        @* Per-season membership (pending requests + active members) *@
+        <div class="card mb-4">
+            <div class="card-header">
+                <i class="fa-solid fa-users-gear me-1"></i> Humans this season (@Model.Year)
+            </div>
+            <div class="card-body p-0">
+                <div class="px-3 py-2">
+                    <strong class="text-muted small">Pending requests (@Model.PendingMembers.Count)</strong>
+                </div>
+                @if (Model.PendingMembers.Count == 0)
+                {
+                    <div class="px-3 pb-2 text-muted small fst-italic">No pending requests.</div>
+                }
+                else
+                {
+                    <ul class="list-group list-group-flush">
+                        @foreach (var pending in Model.PendingMembers)
+                        {
+                            <li class="list-group-item d-flex justify-content-between align-items-center gap-2">
+                                <human-link user-id="@pending.UserId" display-name="@pending.DisplayName" show-popover="true" />
+                                <div class="d-flex gap-2">
+                                    <form asp-action="ApproveMembership" asp-route-slug="@Model.Slug" asp-route-campMemberId="@pending.CampMemberId" method="post" class="d-inline">
+                                        @Html.AntiForgeryToken()
+                                        <button type="submit" class="btn btn-sm btn-outline-success" title="Approve">
+                                            <i class="fa-solid fa-check"></i>
+                                        </button>
+                                    </form>
+                                    <form asp-action="RejectMembership" asp-route-slug="@Model.Slug" asp-route-campMemberId="@pending.CampMemberId" method="post" class="d-inline">
+                                        @Html.AntiForgeryToken()
+                                        <button type="submit" class="btn btn-sm btn-outline-danger" title="Reject" data-confirm="Reject this request?">
+                                            <i class="fa-solid fa-xmark"></i>
+                                        </button>
+                                    </form>
+                                </div>
+                            </li>
+                        }
+                    </ul>
+                }
+
+                <div class="px-3 pt-3 pb-2">
+                    <strong class="text-muted small">Active humans (@Model.ActiveMembers.Count)</strong>
+                </div>
+                @if (Model.ActiveMembers.Count == 0)
+                {
+                    <div class="px-3 pb-2 text-muted small fst-italic">No humans yet.</div>
+                }
+                else
+                {
+                    <ul class="list-group list-group-flush">
+                        @foreach (var active in Model.ActiveMembers)
+                        {
+                            <li class="list-group-item d-flex justify-content-between align-items-center gap-2">
+                                <div class="d-flex align-items-center gap-2">
+                                    <human-link user-id="@active.UserId" display-name="@active.DisplayName" show-popover="true" />
+                                    @if (active.IsLead)
+                                    {
+                                        <span class="badge bg-info text-dark" title="Camp lead">Lead</span>
+                                    }
+                                </div>
+                                @if (!active.IsLead && active.CampMemberId != Guid.Empty)
+                                {
+                                    <form asp-action="RemoveMembership" asp-route-slug="@Model.Slug" asp-route-campMemberId="@active.CampMemberId" method="post" class="d-inline">
+                                        @Html.AntiForgeryToken()
+                                        <button type="submit" class="btn btn-sm btn-outline-danger" title="Remove" data-confirm="Remove this human?">
+                                            <i class="fa-solid fa-user-minus"></i>
+                                        </button>
+                                    </form>
+                                }
+                            </li>
+                        }
+                    </ul>
+                }
+                <div class="card-body border-top">
+                    <small class="text-muted">
+                        This is a post-hoc record so the app knows who's in which camp. Approving here does <strong>not</strong> admit someone to your camp — that's done through your camp's own process.
+                    </small>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="col-md-4">
+        @* Add active member (issue nobodies-collective#489) *@
+        @if (Model.RolesPanel is not null && Model.RolesPanel.CanManage)
+        {
+            <div class="card mb-4">
+                <div class="card-header">
+                    <i class="fa-solid fa-user-plus me-1"></i> Add active member
+                </div>
+                <div class="card-body">
+                    <form asp-action="AddMember" asp-route-slug="@Model.Slug" method="post" class="input-group">
+                        @Html.AntiForgeryToken()
+                        <partial name="_HumanSearchInput" view-data='@(new ViewDataDictionary(ViewData) {
+                            { "FieldName", "userId" },
+                            { "Scope", "name" }
+                        })' />
+                        <button type="submit" class="btn btn-outline-success" title="Add active member">
+                            <i class="fa-solid fa-user-plus"></i>
+                        </button>
+                    </form>
+                    <div class="form-text">Search by name. The human is added to the camp's open season as Active.</div>
+                </div>
+            </div>
+        }
+
+        @* Lead Management *@
+        <div class="card mb-4">
+            <div class="card-header">
+                <i class="fa-solid fa-user-shield me-1"></i> Leads
+            </div>
+            <ul class="list-group list-group-flush">
+                @foreach (var lead in Model.Leads)
+                {
+                    <li class="list-group-item d-flex justify-content-between align-items-center">
+                        <human-link user-id="@lead.UserId" display-name="@lead.DisplayName" />
+                        @if (Model.Leads.Count > 1)
+                        {
+                            <form asp-action="RemoveLead" asp-route-slug="@Model.Slug" asp-route-leadId="@lead.LeadId" method="post" class="d-inline">
+                                @Html.AntiForgeryToken()
+                                <button type="submit" class="btn btn-sm btn-outline-danger" title="Remove lead"
+                                        data-confirm="Remove @lead.DisplayName as a lead?">
+                                    <i class="fa-solid fa-user-minus"></i>
+                                </button>
+                            </form>
+                        }
+                    </li>
+                }
+            </ul>
+            <div class="card-body">
+                <form asp-action="AddLead" asp-route-slug="@Model.Slug" method="post" class="input-group">
+                    @Html.AntiForgeryToken()
+                    <partial name="_HumanSearchInput" view-data='@(new ViewDataDictionary(ViewData) { { "FieldName", "userId" } })' />
+                    <button type="submit" class="btn btn-outline-success" title="Add lead">
+                        <i class="fa-solid fa-user-plus"></i>
+                    </button>
+                </form>
+                <div class="form-text">Search by name to find the new lead.</div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/Humans.Web/Views/Camp/Members.cshtml
+++ b/src/Humans.Web/Views/Camp/Members.cshtml
@@ -1,6 +1,6 @@
 @model Humans.Web.Models.CampEditViewModel
 @{
-    ViewData["Title"] = $"Humans & Roles — {Model.Name}";
+    ViewData["Title"] = $"Members & Roles — {Model.Name}";
 }
 
 <nav aria-label="breadcrumb">
@@ -8,11 +8,11 @@
         <li class="breadcrumb-item"><a asp-action="Index">@Localizer["Camp_Plural"]</a></li>
         <li class="breadcrumb-item"><a asp-action="Details" asp-route-slug="@Model.Slug">@Model.Name</a></li>
         <li class="breadcrumb-item"><a asp-action="Edit" asp-route-slug="@Model.Slug">Edit</a></li>
-        <li class="breadcrumb-item active" aria-current="page">Humans</li>
+        <li class="breadcrumb-item active" aria-current="page">Members</li>
     </ol>
 </nav>
 
-<h1 class="mb-4">Humans &amp; Roles — @Model.Name <small class="text-muted">(@Model.Year)</small></h1>
+<h1 class="mb-4">Members &amp; Roles — @Model.Name <small class="text-muted">(@Model.Year)</small></h1>
 
 <vc:temp-data-alerts />
 

--- a/tests/Humans.Application.Tests/Architecture/Baselines/NoBusinessLogicInControllers.baseline.txt
+++ b/tests/Humans.Application.Tests/Architecture/Baselines/NoBusinessLogicInControllers.baseline.txt
@@ -27,7 +27,6 @@ src/Humans.Web/Controllers/CampController.cs:AssignRole/4
 src/Humans.Web/Controllers/CampController.cs:AssignRoleByUser/4
 src/Humans.Web/Controllers/CampController.cs:Contact/2
 src/Humans.Web/Controllers/CampController.cs:Edit/2
-src/Humans.Web/Controllers/CampController.cs:Edit/3
 src/Humans.Web/Controllers/CampController.cs:LeaveMembership/2
 src/Humans.Web/Controllers/CampController.cs:Register/1
 src/Humans.Web/Controllers/CampController.cs:RequestMembership/1


### PR DESCRIPTION
## Summary

- Adds new `CampController.Members(slug)` action + `Views/Camp/Members.cshtml` view, reachable at `/Barrios/{slug}/Edit/Members`.
- Moves the four membership cards (Add active member, Roles, Leads, Humans this season) off the cramped `col-md-4` right column on `Edit.cshtml` and onto the new Members page, with the Roles panel now in a wide `col-md-8` column.
- Replaces the moved cards on `Edit.cshtml` with a single "Members & Roles" link card at the top of the right column.
- Member, lead, and role POST handlers now redirect back to Members (where those actions originate). Image and historical-name handlers still redirect to Edit.
- Authorization unchanged — Members uses the same `ResolveCampManagementAsync` gate as Edit.
- Breadcrumb on Members: Camps → {Camp Name} → Edit → Members.

Closes nobodies-collective/Humans#641

## Test plan

- [ ] `/Barrios/{slug}/Edit` shows a single "Members & Roles" card linking to the new page; Images and Historical Names cards still present.
- [ ] `/Barrios/{slug}/Edit/Members` renders Roles panel wide, Add active member / Leads alongside, Humans this season below.
- [ ] Add lead / remove lead / approve / reject / remove member / add member / assign role / unassign role round-trip back to Members with the correct flash message.
- [ ] Non-managers (no `CampOperationRequirement.Manage`) get Forbid on `/Edit/Members` just like `/Edit`.
- [ ] Breadcrumb back-links work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)