### PR TITLE
issue-656: attribute /Admin/Logs entries to the logged-in user

### DIFF
--- a/src/Humans.Infrastructure/Logging/CurrentUserEnricher.cs
+++ b/src/Humans.Infrastructure/Logging/CurrentUserEnricher.cs
@@ -14,16 +14,22 @@ namespace Humans.Infrastructure.Logging;
 /// </summary>
 public sealed class CurrentUserEnricher : ILogEventEnricher
 {
-    private readonly IHttpContextAccessor? _httpContextAccessor;
+    public const string UserIdProperty = "UserId";
+
+    private readonly IHttpContextAccessor? _explicitAccessor;
+    private readonly bool _useExplicit;
 
     /// <summary>
     /// Default constructor used by Serilog's <c>.Enrich.With&lt;T&gt;()</c> activator.
-    /// Resolves <see cref="IHttpContextAccessor"/> lazily via the static accessor seeded at
-    /// app startup. Out-of-request and pre-startup emissions yield a null <c>UserId</c>.
+    /// Resolves <see cref="IHttpContextAccessor"/> lazily via <see cref="StaticAccessor"/>
+    /// on each enrich call — Serilog instantiates the enricher when the logger is built,
+    /// which happens before <c>builder.Build()</c> runs and seeds <see cref="StaticAccessor"/>,
+    /// so the static must be read at enrich time, not captured in the ctor.
     /// </summary>
     public CurrentUserEnricher()
     {
-        _httpContextAccessor = StaticAccessor;
+        _explicitAccessor = null;
+        _useExplicit = false;
     }
 
     /// <summary>
@@ -32,7 +38,8 @@ public sealed class CurrentUserEnricher : ILogEventEnricher
     /// </summary>
     public CurrentUserEnricher(IHttpContextAccessor? httpContextAccessor)
     {
-        _httpContextAccessor = httpContextAccessor;
+        _explicitAccessor = httpContextAccessor;
+        _useExplicit = true;
     }
 
     /// <summary>
@@ -46,12 +53,35 @@ public sealed class CurrentUserEnricher : ILogEventEnricher
     {
         var userId = TryGetUserId();
         var value = userId.HasValue ? (object)userId.Value : null!;
-        logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty("UserId", value));
+        logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty(UserIdProperty, value));
+    }
+
+    /// <summary>
+    /// Reads the <c>UserId</c> property off a <see cref="LogEvent"/>, accepting both
+    /// <see cref="Guid"/> and string-form scalars (Serilog's destructurer may pick either
+    /// depending on how the value was attached). Centralized so log consumers
+    /// (admin views, log API) don't duplicate the extraction.
+    /// </summary>
+    public static Guid? ExtractFromEvent(LogEvent logEvent)
+    {
+        if (!logEvent.Properties.TryGetValue(UserIdProperty, out var prop))
+            return null;
+
+        if (prop is not ScalarValue scalar || scalar.Value is null)
+            return null;
+
+        return scalar.Value switch
+        {
+            Guid g => g,
+            string s when Guid.TryParse(s, out var parsed) => parsed,
+            _ => null,
+        };
     }
 
     private Guid? TryGetUserId()
     {
-        var httpContext = _httpContextAccessor?.HttpContext;
+        var accessor = _useExplicit ? _explicitAccessor : StaticAccessor;
+        var httpContext = accessor?.HttpContext;
         if (httpContext is null)
             return null;
 

--- a/src/Humans.Infrastructure/Logging/CurrentUserEnricher.cs
+++ b/src/Humans.Infrastructure/Logging/CurrentUserEnricher.cs
@@ -1,0 +1,73 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace Humans.Infrastructure.Logging;
+
+/// <summary>
+/// Serilog enricher that attaches the current authenticated user's id (<c>UserId</c>)
+/// to every log event. Reads the principal from <see cref="IHttpContextAccessor"/>.
+/// Out-of-request emissions (background jobs, startup) result in a null <c>UserId</c>
+/// so log consumers can clearly attribute events to a specific user — or not.
+/// Pattern follows <see cref="PiiRedactionEnricher"/>.
+/// </summary>
+public sealed class CurrentUserEnricher : ILogEventEnricher
+{
+    private readonly IHttpContextAccessor? _httpContextAccessor;
+
+    /// <summary>
+    /// Default constructor used by Serilog's <c>.Enrich.With&lt;T&gt;()</c> activator.
+    /// Resolves <see cref="IHttpContextAccessor"/> lazily via the static accessor seeded at
+    /// app startup. Out-of-request and pre-startup emissions yield a null <c>UserId</c>.
+    /// </summary>
+    public CurrentUserEnricher()
+    {
+        _httpContextAccessor = StaticAccessor;
+    }
+
+    /// <summary>
+    /// Test/DI-friendly constructor. Pass <c>null</c> to simulate no <see cref="HttpContext"/>
+    /// being available at all (e.g. during background jobs).
+    /// </summary>
+    public CurrentUserEnricher(IHttpContextAccessor? httpContextAccessor)
+    {
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    /// <summary>
+    /// Static accessor seeded at startup so the parameterless ctor (used by Serilog's
+    /// activator) can find the request <see cref="HttpContext"/>. Set once in <c>Program.cs</c>
+    /// after <c>AddHttpContextAccessor</c>; unset only in tests.
+    /// </summary>
+    public static IHttpContextAccessor? StaticAccessor { get; set; }
+
+    public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
+    {
+        var userId = TryGetUserId();
+        var value = userId.HasValue ? (object)userId.Value : null!;
+        logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty("UserId", value));
+    }
+
+    private Guid? TryGetUserId()
+    {
+        var httpContext = _httpContextAccessor?.HttpContext;
+        if (httpContext is null)
+            return null;
+
+        // Reading the principal off ASP.NET's HttpContext (not a domain entity nav).
+        // Pragma scoped to silence the cross-domain-nav-reads ratchet, whose textual
+        // heuristic otherwise matches this access by property name.
+#pragma warning disable CS0618
+        var user = httpContext.User;
+#pragma warning restore CS0618
+        if (user?.Identity is null || !user.Identity.IsAuthenticated)
+            return null;
+
+        var claim = user.FindFirst(ClaimTypes.NameIdentifier);
+        if (claim is null || !Guid.TryParse(claim.Value, out var userId))
+            return null;
+
+        return userId;
+    }
+}

--- a/src/Humans.Web/Controllers/LogApiController.cs
+++ b/src/Humans.Web/Controllers/LogApiController.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Mvc;
+using Humans.Infrastructure.Logging;
 using Humans.Web.Filters;
 using Humans.Web.Infrastructure;
 using Serilog.Events;
@@ -45,25 +46,9 @@ public class LogApiController : ControllerBase
             Level = e.Level.ToString(),
             Message = e.RenderMessage(),
             Exception = e.Exception?.ToString(),
-            UserId = ExtractUserId(e),
+            UserId = CurrentUserEnricher.ExtractFromEvent(e),
         });
 
         return Ok(result);
-    }
-
-    private static Guid? ExtractUserId(LogEvent logEvent)
-    {
-        if (!logEvent.Properties.TryGetValue("UserId", out var prop))
-            return null;
-
-        if (prop is not ScalarValue scalar || scalar.Value is null)
-            return null;
-
-        return scalar.Value switch
-        {
-            Guid g => g,
-            string s when Guid.TryParse(s, out var parsed) => parsed,
-            _ => null,
-        };
     }
 }

--- a/src/Humans.Web/Controllers/LogApiController.cs
+++ b/src/Humans.Web/Controllers/LogApiController.cs
@@ -44,9 +44,26 @@ public class LogApiController : ControllerBase
             Timestamp = e.Timestamp.UtcDateTime,
             Level = e.Level.ToString(),
             Message = e.RenderMessage(),
-            Exception = e.Exception?.ToString()
+            Exception = e.Exception?.ToString(),
+            UserId = ExtractUserId(e),
         });
 
         return Ok(result);
+    }
+
+    private static Guid? ExtractUserId(LogEvent logEvent)
+    {
+        if (!logEvent.Properties.TryGetValue("UserId", out var prop))
+            return null;
+
+        if (prop is not ScalarValue scalar || scalar.Value is null)
+            return null;
+
+        return scalar.Value switch
+        {
+            Guid g => g,
+            string s when Guid.TryParse(s, out var parsed) => parsed,
+            _ => null,
+        };
     }
 }

--- a/src/Humans.Web/Program.cs
+++ b/src/Humans.Web/Program.cs
@@ -46,6 +46,7 @@ var logConfig = new LoggerConfiguration()
     .Enrich.FromLogContext()
     .Enrich.WithProperty("Application", "Humans.Web")
     .Enrich.With<PiiRedactionEnricher>()
+    .Enrich.With<CurrentUserEnricher>()
     .WriteTo.Console()
     .WriteTo.Sink(InMemoryLogSink.Instance, LogEventLevel.Warning);
 
@@ -526,6 +527,11 @@ var app = builder.Build();
 // Initialize timezone-aware display extensions with IHttpContextAccessor
 // so all Instant.ToDisplay*() calls automatically use the user's session timezone.
 DateTimeDisplayExtensions.Initialize(app.Services.GetRequiredService<IHttpContextAccessor>());
+
+// Seed the Serilog CurrentUserEnricher with the request-scoped HttpContextAccessor.
+// Done here (post-Build) so the parameterless enricher activator can read the current
+// principal off the ambient HttpContext on every log emission.
+CurrentUserEnricher.StaticAccessor = app.Services.GetRequiredService<IHttpContextAccessor>();
 
 // Eagerly resolve IHumansMetrics so the background gauge-refresh timer starts
 // immediately — otherwise observable gauges emit nothing until first injection.

--- a/src/Humans.Web/Views/Admin/Logs.cshtml
+++ b/src/Humans.Web/Views/Admin/Logs.cshtml
@@ -1,8 +1,21 @@
 @model IReadOnlyList<Serilog.Events.LogEvent>
+@using Serilog.Events
 @{
     ViewData["Title"] = "Application Logs";
     var lifetimeCounts = ViewBag.LifetimeCounts as IReadOnlyDictionary<Serilog.Events.LogEventLevel, long>
         ?? new Dictionary<Serilog.Events.LogEventLevel, long>();
+
+    Guid? ExtractUserId(LogEvent evt)
+    {
+        if (!evt.Properties.TryGetValue("UserId", out var prop)) return null;
+        if (prop is not ScalarValue scalar || scalar.Value is null) return null;
+        return scalar.Value switch
+        {
+            Guid g => g,
+            string s when Guid.TryParse(s, out var parsed) => parsed,
+            _ => null,
+        };
+    }
 }
 
 <div class="container-fluid px-4">
@@ -51,6 +64,7 @@
                     <tr>
                         <th style="width: 160px;">Timestamp (UTC)</th>
                         <th style="width: 80px;">Level</th>
+                        <th style="width: 160px;">User</th>
                         <th>Message</th>
                     </tr>
                 </thead>
@@ -64,9 +78,20 @@
                             Serilog.Events.LogEventLevel.Warning => "table-warning",
                             _ => ""
                         };
+                        var evtUserId = ExtractUserId(evt);
                         <tr class="@levelClass">
                             <td class="text-nowrap">@evt.Timestamp.UtcDateTime.ToAuditTimestamp()</td>
                             <td>@evt.Level</td>
+                            <td>
+                                @if (evtUserId.HasValue)
+                                {
+                                    <human-link user-id="@evtUserId.Value"></human-link>
+                                }
+                                else
+                                {
+                                    <span class="text-muted">—</span>
+                                }
+                            </td>
                             <td>
                                 @evt.RenderMessage()
                                 @if (evt.Exception != null)

--- a/src/Humans.Web/Views/Admin/Logs.cshtml
+++ b/src/Humans.Web/Views/Admin/Logs.cshtml
@@ -1,21 +1,10 @@
 @model IReadOnlyList<Serilog.Events.LogEvent>
+@using Humans.Infrastructure.Logging
 @using Serilog.Events
 @{
     ViewData["Title"] = "Application Logs";
     var lifetimeCounts = ViewBag.LifetimeCounts as IReadOnlyDictionary<Serilog.Events.LogEventLevel, long>
         ?? new Dictionary<Serilog.Events.LogEventLevel, long>();
-
-    Guid? ExtractUserId(LogEvent evt)
-    {
-        if (!evt.Properties.TryGetValue("UserId", out var prop)) return null;
-        if (prop is not ScalarValue scalar || scalar.Value is null) return null;
-        return scalar.Value switch
-        {
-            Guid g => g,
-            string s when Guid.TryParse(s, out var parsed) => parsed,
-            _ => null,
-        };
-    }
 }
 
 <div class="container-fluid px-4">
@@ -78,7 +67,7 @@
                             Serilog.Events.LogEventLevel.Warning => "table-warning",
                             _ => ""
                         };
-                        var evtUserId = ExtractUserId(evt);
+                        var evtUserId = CurrentUserEnricher.ExtractFromEvent(evt);
                         <tr class="@levelClass">
                             <td class="text-nowrap">@evt.Timestamp.UtcDateTime.ToAuditTimestamp()</td>
                             <td>@evt.Level</td>

--- a/tests/Humans.Application.Tests/Infrastructure/Logging/CurrentUserEnricherTests.cs
+++ b/tests/Humans.Application.Tests/Infrastructure/Logging/CurrentUserEnricherTests.cs
@@ -1,0 +1,118 @@
+using System.Security.Claims;
+using AwesomeAssertions;
+using Humans.Infrastructure.Logging;
+using Humans.Testing;
+using Microsoft.AspNetCore.Http;
+using Serilog.Core;
+using Serilog.Events;
+using Serilog.Parsing;
+using Xunit;
+
+namespace Humans.Application.Tests.Infrastructure.Logging;
+
+public class CurrentUserEnricherTests
+{
+    [HumansFact]
+    public void Enrich_AuthenticatedUser_AttachesUserId()
+    {
+        var userId = Guid.NewGuid();
+        var accessor = new HttpContextAccessor
+        {
+            HttpContext = new DefaultHttpContext
+            {
+                User = BuildAuthenticatedPrincipal(userId)
+            }
+        };
+        var enricher = new CurrentUserEnricher(accessor);
+        var logEvent = CreateLogEvent();
+
+        enricher.Enrich(logEvent, new SimplePropertyFactory());
+
+        logEvent.Properties.Should().ContainKey("UserId");
+        var prop = logEvent.Properties["UserId"];
+        prop.Should().BeOfType<ScalarValue>();
+        ((ScalarValue)prop).Value.Should().Be(userId);
+    }
+
+    [HumansFact]
+    public void Enrich_AnonymousUser_AttachesNullUserId()
+    {
+        var accessor = new HttpContextAccessor
+        {
+            HttpContext = new DefaultHttpContext
+            {
+                User = new ClaimsPrincipal(new ClaimsIdentity()) // no auth scheme = unauthenticated
+            }
+        };
+        var enricher = new CurrentUserEnricher(accessor);
+        var logEvent = CreateLogEvent();
+
+        enricher.Enrich(logEvent, new SimplePropertyFactory());
+
+        logEvent.Properties.Should().ContainKey("UserId");
+        var prop = logEvent.Properties["UserId"];
+        ((ScalarValue)prop).Value.Should().BeNull();
+    }
+
+    [HumansFact]
+    public void Enrich_NoHttpContext_AttachesNullUserId()
+    {
+        // Simulates background jobs / startup emissions where no HttpContext is available.
+        var enricher = new CurrentUserEnricher(httpContextAccessor: null);
+        var logEvent = CreateLogEvent();
+
+        enricher.Enrich(logEvent, new SimplePropertyFactory());
+
+        logEvent.Properties.Should().ContainKey("UserId");
+        var prop = logEvent.Properties["UserId"];
+        ((ScalarValue)prop).Value.Should().BeNull();
+    }
+
+    [HumansFact]
+    public void Enrich_AccessorWithNullHttpContext_AttachesNullUserId()
+    {
+        var enricher = new CurrentUserEnricher(new HttpContextAccessor { HttpContext = null });
+        var logEvent = CreateLogEvent();
+
+        enricher.Enrich(logEvent, new SimplePropertyFactory());
+
+        ((ScalarValue)logEvent.Properties["UserId"]).Value.Should().BeNull();
+    }
+
+    [HumansFact]
+    public void Enrich_NameIdentifierNotAGuid_AttachesNullUserId()
+    {
+        var identity = new ClaimsIdentity(authenticationType: "TestAuth");
+        identity.AddClaim(new Claim(ClaimTypes.NameIdentifier, "not-a-guid"));
+        var accessor = new HttpContextAccessor
+        {
+            HttpContext = new DefaultHttpContext { User = new ClaimsPrincipal(identity) }
+        };
+        var enricher = new CurrentUserEnricher(accessor);
+        var logEvent = CreateLogEvent();
+
+        enricher.Enrich(logEvent, new SimplePropertyFactory());
+
+        ((ScalarValue)logEvent.Properties["UserId"]).Value.Should().BeNull();
+    }
+
+    private static ClaimsPrincipal BuildAuthenticatedPrincipal(Guid userId)
+    {
+        var identity = new ClaimsIdentity(authenticationType: "TestAuth");
+        identity.AddClaim(new Claim(ClaimTypes.NameIdentifier, userId.ToString()));
+        return new ClaimsPrincipal(identity);
+    }
+
+    private static LogEvent CreateLogEvent() => new(
+        timestamp: DateTimeOffset.UtcNow,
+        level: LogEventLevel.Information,
+        exception: null,
+        messageTemplate: new MessageTemplate("test", Array.Empty<MessageTemplateToken>()),
+        properties: Array.Empty<LogEventProperty>());
+
+    private sealed class SimplePropertyFactory : ILogEventPropertyFactory
+    {
+        public LogEventProperty CreateProperty(string name, object? value, bool destructureObjects = false)
+            => new(name, new ScalarValue(value));
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `CurrentUserEnricher` (Serilog) that reads the current principal from `IHttpContextAccessor` and attaches `UserId` to every log event. Out-of-request emissions (background jobs, startup) attach `null`.
- Wires the enricher into `Program.cs` next to the existing `PiiRedactionEnricher`. A static accessor on the enricher is seeded post-`builder.Build()` so Serilog's parameterless activator can resolve the request-scoped `HttpContext` on every emit.
- `/Admin/Logs` view renders the user via the existing `<human-link>` tag helper (clickable + hover card); anonymous/background entries render `—`.
- `/api/logs` JSON now includes `userId`.
- Unit tests cover authenticated, anonymous, no-`HttpContext`, null-`HttpContext`, and non-Guid `NameIdentifier` cases.

Closes nobodies-collective/Humans#656

## Test plan
- [ ] `dotnet build Humans.slnx -v quiet` clean
- [ ] `dotnet test ...CurrentUserEnricher` — 5 cases pass
- [ ] Architecture ratchet (`No_new_obsolete_nav_reads`) green
- [ ] Manual: visit `/Admin/Logs`, confirm user column shows clickable name on user-driven entries and `—` on background-job / startup entries
- [ ] Manual: hit `/api/logs` and confirm `userId` field present per entry