### PR TITLE
[codex] Add bulk approval to onboarding review queue

### DIFF
--- a/docs/features/16-onboarding-pipeline.md
+++ b/docs/features/16-onboarding-pipeline.md
@@ -165,6 +165,7 @@ The default Volunteer flow uses the **onboarding widget** (Names → Shifts → 
 - **Clear**: ConsentCheckStatus = Cleared, IsApproved = true
   - If all legal docs also signed → Volunteers team → ActiveMember
   - If legal docs still pending → admission deferred until docs are signed
+- **Bulk Clear**: Coordinators can multi-select rows that have a legal name and clear them in one action. The server re-checks each selection against the live queue and only clears those that are still pending and still have a legal name; users no longer eligible (already cleared, profile rejected, legal name went blank) are silently skipped and surfaced in the flash message as "Approved X of Y selected".
 - **Flag**: ConsentCheckStatus = Flagged with notes → access blocked, can be resolved later
 
 `IsApproved = true` is set on clearance even if legal docs are incomplete — it marks profile review approval, not full activation. The Volunteers team membership is the true activation gate, and `SyncVolunteersMembershipForUserAsync` independently checks both `IsApproved` AND `HasAllRequiredConsents`.

--- a/src/Humans.Application/Interfaces/Onboarding/IOnboardingService.cs
+++ b/src/Humans.Application/Interfaces/Onboarding/IOnboardingService.cs
@@ -6,6 +6,7 @@ using MemberApplication = Humans.Domain.Entities.Application;
 namespace Humans.Application.Interfaces.Onboarding;
 
 public record OnboardingResult(bool Success, string? ErrorKey = null);
+public record BulkOnboardingResult(int ApprovedCount);
 
 public interface IOnboardingService : IOnboardingEligibilityQuery
 {
@@ -18,6 +19,8 @@ public interface IOnboardingService : IOnboardingEligibilityQuery
     // --- Consent check mutations ---
     Task<OnboardingResult> ClearConsentCheckAsync(
         Guid userId, Guid reviewerId, string? notes, CancellationToken ct = default);
+    Task<BulkOnboardingResult> BulkClearConsentChecksAsync(
+        IReadOnlyCollection<Guid> userIds, Guid reviewerId, CancellationToken ct = default);
     Task<OnboardingResult> FlagConsentCheckAsync(
         Guid userId, Guid reviewerId, string? notes, CancellationToken ct = default);
 

--- a/src/Humans.Application/Services/Onboarding/OnboardingService.cs
+++ b/src/Humans.Application/Services/Onboarding/OnboardingService.cs
@@ -177,7 +177,16 @@ public sealed class OnboardingService : IOnboardingService
         {
             var result = await ClearConsentCheckAsync(userId, reviewerId, notes: null, ct);
             if (result.Success)
+            {
                 approved++;
+            }
+            else
+            {
+                _logger.LogWarning(
+                    "BulkClearConsentChecks: skipped user {UserId}: {ErrorKey}",
+                    userId,
+                    result.ErrorKey);
+            }
         }
 
         return new BulkOnboardingResult(approved);

--- a/src/Humans.Application/Services/Onboarding/OnboardingService.cs
+++ b/src/Humans.Application/Services/Onboarding/OnboardingService.cs
@@ -158,6 +158,31 @@ public sealed class OnboardingService : IOnboardingService
         return result;
     }
 
+    public async Task<BulkOnboardingResult> BulkClearConsentChecksAsync(
+        IReadOnlyCollection<Guid> userIds, Guid reviewerId, CancellationToken ct = default)
+    {
+        if (userIds.Count == 0)
+            return new BulkOnboardingResult(0);
+
+        var selected = userIds.ToHashSet();
+        var data = await GetReviewQueueAsync(ct);
+        var eligibleUserIds = data.Pending
+            .Concat(data.Flagged)
+            .Where(p => selected.Contains(p.UserId) && !string.IsNullOrWhiteSpace(p.FullName))
+            .Select(p => p.UserId)
+            .ToList();
+
+        var approved = 0;
+        foreach (var userId in eligibleUserIds)
+        {
+            var result = await ClearConsentCheckAsync(userId, reviewerId, notes: null, ct);
+            if (result.Success)
+                approved++;
+        }
+
+        return new BulkOnboardingResult(approved);
+    }
+
     public async Task<OnboardingResult> FlagConsentCheckAsync(
         Guid userId, Guid reviewerId, string? notes, CancellationToken ct = default)
     {

--- a/src/Humans.Web/Controllers/OnboardingReviewController.cs
+++ b/src/Humans.Web/Controllers/OnboardingReviewController.cs
@@ -141,39 +141,11 @@ public class OnboardingReviewController : HumansControllerBase
         if (currentUser is null)
             return NotFound();
 
-        if (selectedUserIds.Count == 0)
-        {
-            SetInfo("No humans selected.");
-            return RedirectToAction(nameof(Index));
-        }
-
         try
         {
-            var selected = selectedUserIds.ToHashSet();
-            var data = await _onboardingService.GetReviewQueueAsync(ct);
-            var eligibleUserIds = data.Pending
-                .Concat(data.Flagged)
-                .Where(p => selected.Contains(p.UserId) && !string.IsNullOrWhiteSpace(p.FullName))
-                .Select(p => p.UserId)
-                .ToList();
-
-            var approved = 0;
-            foreach (var userId in eligibleUserIds)
-            {
-                var result = await _onboardingService.ClearConsentCheckAsync(
-                    userId, currentUser.Id, notes: null, ct);
-                if (result.Success)
-                    approved++;
-            }
-
-            if (approved == 0)
-            {
-                SetInfo("No selected humans were approved.");
-            }
-            else
-            {
-                SetSuccess($"Approved {approved} selected human{(approved == 1 ? "" : "s")}.");
-            }
+            var result = await _onboardingService.BulkClearConsentChecksAsync(
+                selectedUserIds, currentUser.Id, ct);
+            SetBulkClearResultMessage(result);
         }
         catch (Exception ex)
         {
@@ -182,6 +154,18 @@ public class OnboardingReviewController : HumansControllerBase
         }
 
         return RedirectToAction(nameof(Index));
+    }
+
+    private void SetBulkClearResultMessage(BulkOnboardingResult result)
+    {
+        if (result.ApprovedCount == 0)
+        {
+            SetInfo("No selected humans were approved.");
+        }
+        else
+        {
+            SetSuccess($"Approved {result.ApprovedCount} selected human{(result.ApprovedCount == 1 ? "" : "s")}.");
+        }
     }
 
     [HttpPost("{userId:guid}/Flag")]

--- a/src/Humans.Web/Controllers/OnboardingReviewController.cs
+++ b/src/Humans.Web/Controllers/OnboardingReviewController.cs
@@ -132,6 +132,58 @@ public class OnboardingReviewController : HumansControllerBase
         return RedirectToAction(nameof(Index));
     }
 
+    [HttpPost("BulkClear")]
+    [ValidateAntiForgeryToken]
+    [Authorize(Policy = PolicyNames.ConsentCoordinatorBoardOrAdmin)]
+    public async Task<IActionResult> BulkClear([FromForm] List<Guid> selectedUserIds, CancellationToken ct)
+    {
+        var currentUser = await GetCurrentUserAsync();
+        if (currentUser is null)
+            return NotFound();
+
+        if (selectedUserIds.Count == 0)
+        {
+            SetInfo("No humans selected.");
+            return RedirectToAction(nameof(Index));
+        }
+
+        try
+        {
+            var selected = selectedUserIds.ToHashSet();
+            var data = await _onboardingService.GetReviewQueueAsync(ct);
+            var eligibleUserIds = data.Pending
+                .Concat(data.Flagged)
+                .Where(p => selected.Contains(p.UserId) && !string.IsNullOrWhiteSpace(p.FullName))
+                .Select(p => p.UserId)
+                .ToList();
+
+            var approved = 0;
+            foreach (var userId in eligibleUserIds)
+            {
+                var result = await _onboardingService.ClearConsentCheckAsync(
+                    userId, currentUser.Id, notes: null, ct);
+                if (result.Success)
+                    approved++;
+            }
+
+            if (approved == 0)
+            {
+                SetInfo("No selected humans were approved.");
+            }
+            else
+            {
+                SetSuccess($"Approved {approved} selected human{(approved == 1 ? "" : "s")}.");
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to bulk clear consent checks for selected users");
+            SetError(_localizer["Common_Error"].Value);
+        }
+
+        return RedirectToAction(nameof(Index));
+    }
+
     [HttpPost("{userId:guid}/Flag")]
     [ValidateAntiForgeryToken]
     [Authorize(Policy = PolicyNames.ConsentCoordinatorBoardOrAdmin)]

--- a/src/Humans.Web/Controllers/OnboardingReviewController.cs
+++ b/src/Humans.Web/Controllers/OnboardingReviewController.cs
@@ -145,26 +145,34 @@ public class OnboardingReviewController : HumansControllerBase
         {
             var result = await _onboardingService.BulkClearConsentChecksAsync(
                 selectedUserIds, currentUser.Id, ct);
-            SetBulkClearResultMessage(result);
+            SetBulkClearResultMessage(result, selectedUserIds.Count);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to bulk clear consent checks for selected users");
+            _logger.LogError(
+                ex,
+                "Failed to bulk clear consent checks for {Count} users: {UserIds}",
+                selectedUserIds.Count,
+                selectedUserIds);
             SetError(_localizer["Common_Error"].Value);
         }
 
         return RedirectToAction(nameof(Index));
     }
 
-    private void SetBulkClearResultMessage(BulkOnboardingResult result)
+    private void SetBulkClearResultMessage(BulkOnboardingResult result, int selectedCount)
     {
         if (result.ApprovedCount == 0)
         {
-            SetInfo("No selected humans were approved.");
+            SetInfo(_localizer["OnboardingReview_BulkClearedNone"].Value);
+        }
+        else if (result.ApprovedCount < selectedCount)
+        {
+            SetSuccess(_localizer["OnboardingReview_BulkClearedPartial", result.ApprovedCount, selectedCount].Value);
         }
         else
         {
-            SetSuccess($"Approved {result.ApprovedCount} selected human{(result.ApprovedCount == 1 ? "" : "s")}.");
+            SetSuccess(_localizer["OnboardingReview_BulkCleared", result.ApprovedCount].Value);
         }
     }
 

--- a/src/Humans.Web/Resources/SharedResource.ca.resx
+++ b/src/Humans.Web/Resources/SharedResource.ca.resx
@@ -1024,6 +1024,7 @@
   <data name="OnboardingReview_BulkClearedNone" xml:space="preserve"><value>No s'ha aprovat cap persona seleccionada.</value></data>
   <data name="OnboardingReview_BulkCleared" xml:space="preserve"><value>S'han aprovat {0} persones seleccionades.</value></data>
   <data name="OnboardingReview_BulkClearedPartial" xml:space="preserve"><value>S'han aprovat {0} de {1} seleccionades — les altres ja no són elegibles.</value></data>
+  <data name="OnboardingReview_BulkClearButton" xml:space="preserve"><value>Aprova totes les seleccionades</value></data>
   <data name="OnboardingReview_Flagged" xml:space="preserve"><value>Persona marcada per a revisió addicional.</value></data>
   <data name="OnboardingReview_RejectButton" xml:space="preserve"><value>Rebutja el registre</value></data>
   <data name="OnboardingReview_RejectReasonPlaceholder" xml:space="preserve"><value>Motiu del rebuig...</value></data>

--- a/src/Humans.Web/Resources/SharedResource.ca.resx
+++ b/src/Humans.Web/Resources/SharedResource.ca.resx
@@ -1021,6 +1021,9 @@
   <data name="OnboardingReview_FlagConfirm" xml:space="preserve"><value>Això marcarà aquesta persona per a revisió addicional. Vols continuar?</value></data>
   <data name="OnboardingReview_AlreadyCleared" xml:space="preserve"><value>Aquesta persona ja ha estat aprovada.</value></data>
   <data name="OnboardingReview_Cleared" xml:space="preserve"><value>Revisió del perfil aprovada.</value></data>
+  <data name="OnboardingReview_BulkClearedNone" xml:space="preserve"><value>No s'ha aprovat cap persona seleccionada.</value></data>
+  <data name="OnboardingReview_BulkCleared" xml:space="preserve"><value>S'han aprovat {0} persones seleccionades.</value></data>
+  <data name="OnboardingReview_BulkClearedPartial" xml:space="preserve"><value>S'han aprovat {0} de {1} seleccionades — les altres ja no són elegibles.</value></data>
   <data name="OnboardingReview_Flagged" xml:space="preserve"><value>Persona marcada per a revisió addicional.</value></data>
   <data name="OnboardingReview_RejectButton" xml:space="preserve"><value>Rebutja el registre</value></data>
   <data name="OnboardingReview_RejectReasonPlaceholder" xml:space="preserve"><value>Motiu del rebuig...</value></data>

--- a/src/Humans.Web/Resources/SharedResource.de.resx
+++ b/src/Humans.Web/Resources/SharedResource.de.resx
@@ -1019,6 +1019,7 @@
   <data name="OnboardingReview_BulkClearedNone" xml:space="preserve"><value>Keine ausgew&#xE4;hlten Humans wurden freigegeben.</value></data>
   <data name="OnboardingReview_BulkCleared" xml:space="preserve"><value>{0} ausgew&#xE4;hlte Humans freigegeben.</value></data>
   <data name="OnboardingReview_BulkClearedPartial" xml:space="preserve"><value>{0} von {1} ausgew&#xE4;hlten freigegeben — die anderen sind nicht mehr berechtigt.</value></data>
+  <data name="OnboardingReview_BulkClearButton" xml:space="preserve"><value>Alle ausgew&#xE4;hlten freigeben</value></data>
   <data name="OnboardingReview_Flagged" xml:space="preserve"><value>Human zur weiteren Pr&#xFC;fung markiert.</value></data>
   <data name="OnboardingReview_RejectButton" xml:space="preserve"><value>Anmeldung ablehnen</value></data>
   <data name="OnboardingReview_RejectReasonPlaceholder" xml:space="preserve"><value>Ablehnungsgrund...</value></data>

--- a/src/Humans.Web/Resources/SharedResource.de.resx
+++ b/src/Humans.Web/Resources/SharedResource.de.resx
@@ -1016,6 +1016,9 @@
   <data name="OnboardingReview_FlagConfirm" xml:space="preserve"><value>Dieser Human wird zur weiteren Pr&#xFC;fung markiert. Fortfahren?</value></data>
   <data name="OnboardingReview_AlreadyCleared" xml:space="preserve"><value>Dieser Human wurde bereits freigegeben.</value></data>
   <data name="OnboardingReview_Cleared" xml:space="preserve"><value>Profil&#xFC;berpr&#xFC;fung freigegeben.</value></data>
+  <data name="OnboardingReview_BulkClearedNone" xml:space="preserve"><value>Keine ausgew&#xE4;hlten Humans wurden freigegeben.</value></data>
+  <data name="OnboardingReview_BulkCleared" xml:space="preserve"><value>{0} ausgew&#xE4;hlte Humans freigegeben.</value></data>
+  <data name="OnboardingReview_BulkClearedPartial" xml:space="preserve"><value>{0} von {1} ausgew&#xE4;hlten freigegeben — die anderen sind nicht mehr berechtigt.</value></data>
   <data name="OnboardingReview_Flagged" xml:space="preserve"><value>Human zur weiteren Pr&#xFC;fung markiert.</value></data>
   <data name="OnboardingReview_RejectButton" xml:space="preserve"><value>Anmeldung ablehnen</value></data>
   <data name="OnboardingReview_RejectReasonPlaceholder" xml:space="preserve"><value>Ablehnungsgrund...</value></data>

--- a/src/Humans.Web/Resources/SharedResource.es.resx
+++ b/src/Humans.Web/Resources/SharedResource.es.resx
@@ -1024,6 +1024,7 @@
   <data name="OnboardingReview_BulkClearedNone" xml:space="preserve"><value>No se aprob&#xF3; ning&#xFA;n humano seleccionado.</value></data>
   <data name="OnboardingReview_BulkCleared" xml:space="preserve"><value>Se aprobaron {0} humanos seleccionados.</value></data>
   <data name="OnboardingReview_BulkClearedPartial" xml:space="preserve"><value>Se aprobaron {0} de {1} seleccionados — los dem&#xE1;s ya no son elegibles.</value></data>
+  <data name="OnboardingReview_BulkClearButton" xml:space="preserve"><value>Aprobar todos los seleccionados</value></data>
   <data name="OnboardingReview_Flagged" xml:space="preserve"><value>Humano marcado para revisi&#xF3;n adicional.</value></data>
   <data name="OnboardingReview_RejectButton" xml:space="preserve"><value>Rechazar registro</value></data>
   <data name="OnboardingReview_RejectReasonPlaceholder" xml:space="preserve"><value>Motivo del rechazo...</value></data>

--- a/src/Humans.Web/Resources/SharedResource.es.resx
+++ b/src/Humans.Web/Resources/SharedResource.es.resx
@@ -1021,6 +1021,9 @@
   <data name="OnboardingReview_FlagConfirm" xml:space="preserve"><value>Esto marcar&#xE1; a este humano para revisi&#xF3;n adicional. &#xBF;Continuar?</value></data>
   <data name="OnboardingReview_AlreadyCleared" xml:space="preserve"><value>Este humano ya ha sido aprobado.</value></data>
   <data name="OnboardingReview_Cleared" xml:space="preserve"><value>Revisi&#xF3;n de perfil aprobada.</value></data>
+  <data name="OnboardingReview_BulkClearedNone" xml:space="preserve"><value>No se aprob&#xF3; ning&#xFA;n humano seleccionado.</value></data>
+  <data name="OnboardingReview_BulkCleared" xml:space="preserve"><value>Se aprobaron {0} humanos seleccionados.</value></data>
+  <data name="OnboardingReview_BulkClearedPartial" xml:space="preserve"><value>Se aprobaron {0} de {1} seleccionados — los dem&#xE1;s ya no son elegibles.</value></data>
   <data name="OnboardingReview_Flagged" xml:space="preserve"><value>Humano marcado para revisi&#xF3;n adicional.</value></data>
   <data name="OnboardingReview_RejectButton" xml:space="preserve"><value>Rechazar registro</value></data>
   <data name="OnboardingReview_RejectReasonPlaceholder" xml:space="preserve"><value>Motivo del rechazo...</value></data>

--- a/src/Humans.Web/Resources/SharedResource.fr.resx
+++ b/src/Humans.Web/Resources/SharedResource.fr.resx
@@ -1019,6 +1019,7 @@
   <data name="OnboardingReview_BulkClearedNone" xml:space="preserve"><value>Aucun human s&#xE9;lectionn&#xE9; n'a &#xE9;t&#xE9; valid&#xE9;.</value></data>
   <data name="OnboardingReview_BulkCleared" xml:space="preserve"><value>{0} humans s&#xE9;lectionn&#xE9;s valid&#xE9;s.</value></data>
   <data name="OnboardingReview_BulkClearedPartial" xml:space="preserve"><value>{0} sur {1} s&#xE9;lectionn&#xE9;s valid&#xE9;s — les autres ne sont plus &#xE9;ligibles.</value></data>
+  <data name="OnboardingReview_BulkClearButton" xml:space="preserve"><value>Valider tous les s&#xE9;lectionn&#xE9;s</value></data>
   <data name="OnboardingReview_Flagged" xml:space="preserve"><value>Human signal&#xE9; pour examen compl&#xE9;mentaire.</value></data>
   <data name="OnboardingReview_RejectButton" xml:space="preserve"><value>Refuser l'inscription</value></data>
   <data name="OnboardingReview_RejectReasonPlaceholder" xml:space="preserve"><value>Motif du refus...</value></data>

--- a/src/Humans.Web/Resources/SharedResource.fr.resx
+++ b/src/Humans.Web/Resources/SharedResource.fr.resx
@@ -1016,6 +1016,9 @@
   <data name="OnboardingReview_FlagConfirm" xml:space="preserve"><value>Ce human sera signal&#xE9; pour examen compl&#xE9;mentaire. Continuer ?</value></data>
   <data name="OnboardingReview_AlreadyCleared" xml:space="preserve"><value>Ce human a d&#xE9;j&#xE0; &#xE9;t&#xE9; valid&#xE9;.</value></data>
   <data name="OnboardingReview_Cleared" xml:space="preserve"><value>R&#xE9;vision du profil valid&#xE9;e.</value></data>
+  <data name="OnboardingReview_BulkClearedNone" xml:space="preserve"><value>Aucun human s&#xE9;lectionn&#xE9; n'a &#xE9;t&#xE9; valid&#xE9;.</value></data>
+  <data name="OnboardingReview_BulkCleared" xml:space="preserve"><value>{0} humans s&#xE9;lectionn&#xE9;s valid&#xE9;s.</value></data>
+  <data name="OnboardingReview_BulkClearedPartial" xml:space="preserve"><value>{0} sur {1} s&#xE9;lectionn&#xE9;s valid&#xE9;s — les autres ne sont plus &#xE9;ligibles.</value></data>
   <data name="OnboardingReview_Flagged" xml:space="preserve"><value>Human signal&#xE9; pour examen compl&#xE9;mentaire.</value></data>
   <data name="OnboardingReview_RejectButton" xml:space="preserve"><value>Refuser l'inscription</value></data>
   <data name="OnboardingReview_RejectReasonPlaceholder" xml:space="preserve"><value>Motif du refus...</value></data>

--- a/src/Humans.Web/Resources/SharedResource.it.resx
+++ b/src/Humans.Web/Resources/SharedResource.it.resx
@@ -1019,6 +1019,7 @@
   <data name="OnboardingReview_BulkClearedNone" xml:space="preserve"><value>Nessun human selezionato &#xE8; stato approvato.</value></data>
   <data name="OnboardingReview_BulkCleared" xml:space="preserve"><value>Approvati {0} humans selezionati.</value></data>
   <data name="OnboardingReview_BulkClearedPartial" xml:space="preserve"><value>Approvati {0} di {1} selezionati — gli altri non sono pi&#xF9; idonei.</value></data>
+  <data name="OnboardingReview_BulkClearButton" xml:space="preserve"><value>Approva tutti i selezionati</value></data>
   <data name="OnboardingReview_Flagged" xml:space="preserve"><value>Human segnalato per ulteriore revisione.</value></data>
   <data name="OnboardingReview_RejectButton" xml:space="preserve"><value>Rifiuta registrazione</value></data>
   <data name="OnboardingReview_RejectReasonPlaceholder" xml:space="preserve"><value>Motivo del rifiuto...</value></data>

--- a/src/Humans.Web/Resources/SharedResource.it.resx
+++ b/src/Humans.Web/Resources/SharedResource.it.resx
@@ -1016,6 +1016,9 @@
   <data name="OnboardingReview_FlagConfirm" xml:space="preserve"><value>Questo human verr&#xE0; segnalato per ulteriore revisione. Continuare?</value></data>
   <data name="OnboardingReview_AlreadyCleared" xml:space="preserve"><value>Questo human &#xE8; gi&#xE0; stato approvato.</value></data>
   <data name="OnboardingReview_Cleared" xml:space="preserve"><value>Revisione del profilo approvata.</value></data>
+  <data name="OnboardingReview_BulkClearedNone" xml:space="preserve"><value>Nessun human selezionato &#xE8; stato approvato.</value></data>
+  <data name="OnboardingReview_BulkCleared" xml:space="preserve"><value>Approvati {0} humans selezionati.</value></data>
+  <data name="OnboardingReview_BulkClearedPartial" xml:space="preserve"><value>Approvati {0} di {1} selezionati — gli altri non sono pi&#xF9; idonei.</value></data>
   <data name="OnboardingReview_Flagged" xml:space="preserve"><value>Human segnalato per ulteriore revisione.</value></data>
   <data name="OnboardingReview_RejectButton" xml:space="preserve"><value>Rifiuta registrazione</value></data>
   <data name="OnboardingReview_RejectReasonPlaceholder" xml:space="preserve"><value>Motivo del rifiuto...</value></data>

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -1043,6 +1043,9 @@
   <data name="OnboardingReview_FlagConfirm" xml:space="preserve"><value>This will flag this human for further review. Continue?</value></data>
   <data name="OnboardingReview_AlreadyCleared" xml:space="preserve"><value>This human has already been cleared.</value></data>
   <data name="OnboardingReview_Cleared" xml:space="preserve"><value>Profile review cleared.</value></data>
+  <data name="OnboardingReview_BulkClearedNone" xml:space="preserve"><value>No selected humans were approved.</value></data>
+  <data name="OnboardingReview_BulkCleared" xml:space="preserve"><value>Approved {0} selected humans.</value></data>
+  <data name="OnboardingReview_BulkClearedPartial" xml:space="preserve"><value>Approved {0} of {1} selected — the others are no longer eligible.</value></data>
   <data name="OnboardingReview_Flagged" xml:space="preserve"><value>Human flagged for further review.</value></data>
   <data name="OnboardingReview_RejectButton" xml:space="preserve"><value>Reject Signup</value></data>
   <data name="OnboardingReview_RejectReasonPlaceholder" xml:space="preserve"><value>Reason for rejection...</value></data>

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -1046,6 +1046,7 @@
   <data name="OnboardingReview_BulkClearedNone" xml:space="preserve"><value>No selected humans were approved.</value></data>
   <data name="OnboardingReview_BulkCleared" xml:space="preserve"><value>Approved {0} selected humans.</value></data>
   <data name="OnboardingReview_BulkClearedPartial" xml:space="preserve"><value>Approved {0} of {1} selected — the others are no longer eligible.</value></data>
+  <data name="OnboardingReview_BulkClearButton" xml:space="preserve"><value>Approve all selected</value></data>
   <data name="OnboardingReview_Flagged" xml:space="preserve"><value>Human flagged for further review.</value></data>
   <data name="OnboardingReview_RejectButton" xml:space="preserve"><value>Reject Signup</value></data>
   <data name="OnboardingReview_RejectReasonPlaceholder" xml:space="preserve"><value>Reason for rejection...</value></data>

--- a/src/Humans.Web/Views/OnboardingReview/Index.cshtml
+++ b/src/Humans.Web/Views/OnboardingReview/Index.cshtml
@@ -1,6 +1,9 @@
 @model Humans.Web.Models.OnboardingReviewIndexViewModel
 @{
     ViewData["Title"] = Localizer["OnboardingReview_Title"].Value;
+    var hasSelectableReviews = Model.PendingReviews
+        .Concat(Model.FlaggedReviews)
+        .Any(item => !string.IsNullOrWhiteSpace(item.LegalName));
 }
 
 <div class="d-flex justify-content-between align-items-center mb-4">
@@ -17,113 +20,153 @@
     </div>
 }
 
-@if (Model.PendingReviews.Count > 0)
+@if (Model.PendingReviews.Count > 0 || Model.FlaggedReviews.Count > 0)
 {
-    <h4 class="mt-4 mb-3">
-        @Localizer["OnboardingReview_PendingSection"]
-        <span class="badge bg-warning">@Model.PendingReviews.Count</span>
-    </h4>
-
-    <div class="list-group mb-4">
-        @foreach (var item in Model.PendingReviews)
+    <form asp-action="BulkClear" method="post">
+        @if (Model.PendingReviews.Count > 0)
         {
-            <div class="list-group-item">
-                <div class="d-flex justify-content-between align-items-center">
-                    <div class="d-flex align-items-center">
-                        <human-link user-id="@item.UserId" display-name="@item.DisplayName"
-                                    mode="Avatar" size="40" show-popover="false"
-                                    profile-picture-url="@item.ProfilePictureUrl" />
-                        <a asp-controller="Profile" asp-action="ViewProfile" asp-route-id="@item.UserId"
-                           class="ms-2 text-decoration-none text-reset"
-                           data-human-popover="true"
-                           data-user-id="@item.UserId">
-                            <span class="fw-semibold">@item.DisplayName</span>
-                            @if (!string.IsNullOrWhiteSpace(item.LegalName))
-                            {
-                                <span class="fw-normal text-muted"> - @item.LegalName</span>
-                            }
-                            else if (!string.IsNullOrWhiteSpace(item.Email))
-                            {
-                                <small class="text-muted"> @item.Email</small>
-                            }
-                        </a>
+            <h4 class="mt-4 mb-3">
+                @Localizer["OnboardingReview_PendingSection"]
+                <span class="badge bg-warning">@Model.PendingReviews.Count</span>
+            </h4>
+
+            <div class="list-group mb-4">
+                @foreach (var item in Model.PendingReviews)
+                {
+                    var hasLegalName = !string.IsNullOrWhiteSpace(item.LegalName);
+                    <div class="list-group-item">
+                        <div class="d-flex justify-content-between align-items-center">
+                            <div class="d-flex align-items-center">
+                                @if (hasLegalName)
+                                {
+                                    <input class="form-check-input me-3" type="checkbox" name="selectedUserIds"
+                                           value="@item.UserId" aria-label="Select @item.DisplayName" />
+                                }
+                                else
+                                {
+                                    <span class="form-check-input me-3 invisible" aria-hidden="true"></span>
+                                }
+                                <human-link user-id="@item.UserId" display-name="@item.DisplayName"
+                                            mode="Avatar" size="40" show-popover="false"
+                                            profile-picture-url="@item.ProfilePictureUrl" />
+                                <a asp-controller="Profile" asp-action="ViewProfile" asp-route-id="@item.UserId"
+                                   class="ms-2 text-decoration-none text-reset"
+                                   data-human-popover="true"
+                                   data-user-id="@item.UserId">
+                                    <span class="fw-semibold">@item.DisplayName</span>
+                                    @if (hasLegalName)
+                                    {
+                                        <span class="fw-normal text-muted"> - @item.LegalName</span>
+                                    }
+                                    else if (!string.IsNullOrWhiteSpace(item.Email))
+                                    {
+                                        <small class="text-muted"> @item.Email</small>
+                                    }
+                                </a>
+                            </div>
+                            <div class="text-end">
+                                @if (item.MembershipTier != MembershipTier.Volunteer)
+                                {
+                                    <span class="badge bg-info me-1">@item.MembershipTier</span>
+                                }
+                                @if (item.RequiredConsentCount > 0)
+                                {
+                                    var allSigned = item.ConsentCount >= item.RequiredConsentCount;
+                                    <span class="badge @(allSigned ? "bg-success" : "bg-secondary")">
+                                        <i class="fa-solid fa-file-signature me-1"></i>@item.ConsentCount/@item.RequiredConsentCount
+                                    </span>
+                                }
+                                <br />
+                                <small class="text-muted">@item.ProfileCreatedAt.ToDisplayDate()</small>
+                                <a asp-action="Detail" asp-route-userId="@item.UserId" class="btn btn-sm btn-outline-primary ms-2">
+                                    <i class="fa-solid fa-eye me-1"></i>Review
+                                </a>
+                            </div>
+                        </div>
                     </div>
-                    <div class="text-end">
-                        @if (item.MembershipTier != MembershipTier.Volunteer)
-                        {
-                            <span class="badge bg-info me-1">@item.MembershipTier</span>
-                        }
-                        @if (item.RequiredConsentCount > 0)
-                        {
-                            var allSigned = item.ConsentCount >= item.RequiredConsentCount;
-                            <span class="badge @(allSigned ? "bg-success" : "bg-secondary")">
-                                <i class="fa-solid fa-file-signature me-1"></i>@item.ConsentCount/@item.RequiredConsentCount
-                            </span>
-                        }
-                        <br />
-                        <small class="text-muted">@item.ProfileCreatedAt.ToDisplayDate()</small>
-                        <a asp-action="Detail" asp-route-userId="@item.UserId" class="btn btn-sm btn-outline-primary ms-2">
-                            <i class="fa-solid fa-eye me-1"></i>Review
-                        </a>
-                    </div>
-                </div>
+                }
             </div>
         }
-    </div>
-}
 
-@if (Model.FlaggedReviews.Count > 0)
-{
-    <h4 class="mt-4 mb-3">
-        @Localizer["OnboardingReview_FlaggedSection"]
-        <span class="badge bg-danger">@Model.FlaggedReviews.Count</span>
-    </h4>
-
-    <div class="list-group mb-4">
-        @foreach (var item in Model.FlaggedReviews)
+        @if (Model.FlaggedReviews.Count > 0)
         {
-            <div class="list-group-item list-group-item-danger">
-                <div class="d-flex justify-content-between align-items-center">
-                    <div class="d-flex align-items-center">
-                        <human-link user-id="@item.UserId" display-name="@item.DisplayName"
-                                    mode="Avatar" size="40" show-popover="false"
-                                    profile-picture-url="@item.ProfilePictureUrl" />
-                        <a asp-controller="Profile" asp-action="ViewProfile" asp-route-id="@item.UserId"
-                           class="ms-2 text-decoration-none text-reset"
-                           data-human-popover="true"
-                           data-user-id="@item.UserId">
-                            <span class="fw-semibold">@item.DisplayName</span>
-                            @if (!string.IsNullOrWhiteSpace(item.LegalName))
-                            {
-                                <span class="fw-normal text-muted"> - @item.LegalName</span>
-                            }
-                            else if (!string.IsNullOrWhiteSpace(item.Email))
-                            {
-                                <small class="text-muted"> @item.Email</small>
-                            }
-                        </a>
+            <h4 class="mt-4 mb-3">
+                @Localizer["OnboardingReview_FlaggedSection"]
+                <span class="badge bg-danger">@Model.FlaggedReviews.Count</span>
+            </h4>
+
+            <div class="list-group mb-4">
+                @foreach (var item in Model.FlaggedReviews)
+                {
+                    var hasLegalName = !string.IsNullOrWhiteSpace(item.LegalName);
+                    <div class="list-group-item list-group-item-danger">
+                        <div class="d-flex justify-content-between align-items-center">
+                            <div class="d-flex align-items-center">
+                                @if (hasLegalName)
+                                {
+                                    <input class="form-check-input me-3" type="checkbox" name="selectedUserIds"
+                                           value="@item.UserId" aria-label="Select @item.DisplayName" />
+                                }
+                                else
+                                {
+                                    <span class="form-check-input me-3 invisible" aria-hidden="true"></span>
+                                }
+                                <human-link user-id="@item.UserId" display-name="@item.DisplayName"
+                                            mode="Avatar" size="40" show-popover="false"
+                                            profile-picture-url="@item.ProfilePictureUrl" />
+                                <a asp-controller="Profile" asp-action="ViewProfile" asp-route-id="@item.UserId"
+                                   class="ms-2 text-decoration-none text-reset"
+                                   data-human-popover="true"
+                                   data-user-id="@item.UserId">
+                                    <span class="fw-semibold">@item.DisplayName</span>
+                                    @if (hasLegalName)
+                                    {
+                                        <span class="fw-normal text-muted"> - @item.LegalName</span>
+                                    }
+                                    else if (!string.IsNullOrWhiteSpace(item.Email))
+                                    {
+                                        <small class="text-muted"> @item.Email</small>
+                                    }
+                                </a>
+                            </div>
+                            <div class="text-end">
+                                @if (item.MembershipTier != MembershipTier.Volunteer)
+                                {
+                                    <span class="badge bg-info me-1">@item.MembershipTier</span>
+                                }
+                                <span class="badge bg-danger">@Localizer["OnboardingReview_FlaggedBadge"]</span>
+                                @if (item.RequiredConsentCount > 0)
+                                {
+                                    var allSigned = item.ConsentCount >= item.RequiredConsentCount;
+                                    <span class="badge @(allSigned ? "bg-success" : "bg-secondary")">
+                                        <i class="fa-solid fa-file-signature me-1"></i>@item.ConsentCount/@item.RequiredConsentCount
+                                    </span>
+                                }
+                                <br />
+                                <small class="text-muted">@item.ProfileCreatedAt.ToDisplayDate()</small>
+                                <a asp-action="Detail" asp-route-userId="@item.UserId" class="btn btn-sm btn-outline-primary ms-2">
+                                    <i class="fa-solid fa-eye me-1"></i>Review
+                                </a>
+                            </div>
+                        </div>
                     </div>
-                    <div class="text-end">
-                        @if (item.MembershipTier != MembershipTier.Volunteer)
-                        {
-                            <span class="badge bg-info me-1">@item.MembershipTier</span>
-                        }
-                        <span class="badge bg-danger">@Localizer["OnboardingReview_FlaggedBadge"]</span>
-                        @if (item.RequiredConsentCount > 0)
-                        {
-                            var allSigned = item.ConsentCount >= item.RequiredConsentCount;
-                            <span class="badge @(allSigned ? "bg-success" : "bg-secondary")">
-                                <i class="fa-solid fa-file-signature me-1"></i>@item.ConsentCount/@item.RequiredConsentCount
-                            </span>
-                        }
-                        <br />
-                        <small class="text-muted">@item.ProfileCreatedAt.ToDisplayDate()</small>
-                        <a asp-action="Detail" asp-route-userId="@item.UserId" class="btn btn-sm btn-outline-primary ms-2">
-                            <i class="fa-solid fa-eye me-1"></i>Review
-                        </a>
-                    </div>
-                </div>
+                }
             </div>
         }
-    </div>
+
+        <div class="d-flex justify-content-end mb-4">
+            @if (hasSelectableReviews)
+            {
+                <button type="submit" class="btn btn-success">
+                    <i class="fa-solid fa-check me-1"></i>Approve all selected
+                </button>
+            }
+            else
+            {
+                <button type="submit" class="btn btn-success" disabled>
+                    <i class="fa-solid fa-check me-1"></i>Approve all selected
+                </button>
+            }
+        </div>
+    </form>
 }

--- a/src/Humans.Web/Views/OnboardingReview/Index.cshtml
+++ b/src/Humans.Web/Views/OnboardingReview/Index.cshtml
@@ -158,13 +158,13 @@
             @if (hasSelectableReviews)
             {
                 <button type="submit" class="btn btn-success">
-                    <i class="fa-solid fa-check me-1"></i>Approve all selected
+                    <i class="fa-solid fa-check me-1"></i>@Localizer["OnboardingReview_BulkClearButton"]
                 </button>
             }
             else
             {
                 <button type="submit" class="btn btn-success" disabled>
-                    <i class="fa-solid fa-check me-1"></i>Approve all selected
+                    <i class="fa-solid fa-check me-1"></i>@Localizer["OnboardingReview_BulkClearButton"]
                 </button>
             }
         </div>


### PR DESCRIPTION
Cherry-picked from upstream PR nobodies-collective/Humans#671 (author: @swombat) for QA preview on peter's fork.

## Summary
- Add selectable checkboxes before onboarding review queue avatars when an applicant has a legal name.
- Add invisible checkbox-sized spacers for rows without a legal name so avatars and names stay aligned while those rows remain unselectable.
- Add a green `Approve all selected` action at the bottom of the queue.
- Add a bulk clear endpoint that rechecks selected rows against the current review queue and only approves entries that still have a legal name.

## Dependency
Stacked on #446 (`[codex] Show legal names in onboarding review queue`). Until that lands, this PR includes its foundational commit in the diff.

## Validation
- `dotnet build Humans.slnx`
- Ran the local server at `http://localhost:7101` and loaded `/OnboardingReview` as the dev consent coordinator.
- Seeded local applicants with and without legal names; verified rows with legal names show checkboxes, rows without legal names show aligned invisible spacers, and the `Approve all selected` button renders.

---
Upstream PR: nobodies-collective/Humans#671