### PR TITLE
issue-660: /Profile/Admin/EmailProblems page

### DIFF
--- a/docs/sections/Profiles.md
+++ b/docs/sections/Profiles.md
@@ -32,6 +32,7 @@ Per-human personal data: profile, contact fields, emails, communication preferen
 - **CV Entries** (sub-aggregate of Profile, table `volunteer_history_entries`) record volunteer involvement history.
 - **Profile Languages** (sub-aggregate of Profile, table `profile_languages`) record self-assessed proficiency in ISO 639-1 language codes.
 - **Duplicate Account Detection** scans for email addresses appearing on multiple accounts (across `User.Email` and `UserEmail.Email`, with gmail/googlemail equivalence). Admin can resolve by archiving the duplicate and re-linking its logins to the real account.
+- **Email Problems** scans every UserEmail invariant violation (multi/zero IsPrimary or IsGoogle, unverified rows, cross-user collisions, orphan rows, ghost AspNetUserLogins). Reads source-of-truth from the `FullProfile` cache. Read-only-plus-three-actions admin surface; the cross-user merge action shares its kernel with `IAccountMergeService.AcceptAsync`.
 - **Account Merge** consolidates two accounts into one, transferring all associated data (emails, contact fields, CV entries, role assignments, memberships) to the surviving account.
 
 ## Data Model
@@ -337,6 +338,11 @@ Admin-only flows for the section's cross-account hygiene:
 | `/Admin/DuplicateAccounts` | List detected duplicate-account groups (`AdminDuplicateAccountsController`) |
 | `/Admin/DuplicateAccounts/Detail` | Side-by-side comparison of two candidate accounts |
 | `/Admin/DuplicateAccounts/Resolve` | Archive the duplicate and re-link logins to the survivor |
+| `/Profile/Admin/EmailProblems` | List UserEmail invariant violations across all accounts (`ProfileAdminController`) |
+| `/Profile/Admin/EmailProblems/Compare` | Side-by-side detail for a case-5 cross-user email collision |
+| `/Profile/Admin/EmailProblems/Merge` | POST — admin-initiated merge via `IAccountMergeService.AdminMergeAsync` |
+| `/Profile/Admin/EmailProblems/DeleteOrphanEmail` | POST — delete a single orphan UserEmail row |
+| `/Profile/Admin/EmailProblems/DeleteGhostLogins` | POST — delete every AspNetUserLogins row for a userId with no UserEmails |
 
 ## Actors & Roles
 
@@ -395,7 +401,7 @@ Admin-only flows for the section's cross-account hygiene:
 
 ## Architecture
 
-**Owning services:** `ProfileService`, `ContactFieldService`, `UserEmailService`, `CommunicationPreferenceService`, `AccountMergeService`, `DuplicateAccountService`
+**Owning services:** `ProfileService`, `ContactFieldService`, `UserEmailService`, `CommunicationPreferenceService`, `AccountMergeService`, `DuplicateAccountService`, `EmailProblemsService`
 **Owned tables:** `profiles`, `contact_fields`, `user_emails`, `communication_preferences`, `volunteer_history_entries`, `profile_languages`, `account_merge_requests`
 **Status:** (A) Migrated — canonical §15 reference implementation (peterdrier/Humans PR #235, 2026-04-20). `AccountMergeService` / `DuplicateAccountService` moved into `Humans.Application/Services/Profile/` after the original migration (they now live alongside the other Profile-section services in the code tree; design-rules §8 ownership updated accordingly).
 

--- a/docs/superpowers/plans/2026-05-05-email-problems-page.md
+++ b/docs/superpowers/plans/2026-05-05-email-problems-page.md
@@ -1,0 +1,2327 @@
+# /Profile/Admin/EmailProblems Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build `/Profile/Admin/EmailProblems` — a Profile-section admin page that surfaces every UserEmail invariant violation (8 cases) and offers a consolidating merge action backed by a reusable `FoldAsync` kernel inside `AccountMergeService`.
+
+**Architecture:** New `IEmailProblemsService` consumes only existing section services (`IProfileService`, `IUserEmailService`, `IUserService`) — never any repository directly. Detection sources from the `FullProfile` cache snapshot (extended to retain per-row UserEmail flags). Merge action calls a new `AccountMergeService.AdminMergeAsync` entry point, which shares a private `FoldAsync` kernel with the existing user-initiated `AcceptAsync`.
+
+**Tech Stack:** ASP.NET Core MVC, EF Core, NodaTime, xUnit, Clean Architecture (4 layers).
+
+**Spec:** `docs/superpowers/specs/2026-05-05-email-problems-page-design.md`
+
+**Working directory:** `H:/source/Humans/.worktrees/issue-660-email-problems` (branch `issue-660-email-problems`).
+
+**Build commands** (run from worktree root, never `cd <dir> && cmd`):
+- `dotnet build Humans.slnx -v quiet`
+- `dotnet test Humans.slnx -v quiet`
+- Single test: `dotnet test Humans.slnx -v quiet --filter "FullyQualifiedName~<TestName>"`
+
+---
+
+## Phase 1 — Foundation: extend FullProfile + section service surfaces
+
+### Task 1: Add `UserEmailSnapshot` record and extend `FullProfile`
+
+**Files:**
+- Modify: `src/Humans.Application/FullProfile.cs`
+
+- [ ] **Step 1: Add `UserEmailSnapshot` record at the top of `FullProfile.cs`**
+
+```csharp
+namespace Humans.Application;
+
+/// <summary>
+/// Compact projection of a <see cref="Domain.Entities.UserEmail"/> row carried
+/// inside <see cref="FullProfile"/> so consumers can inspect per-row flags
+/// (IsPrimary / IsGoogle / IsVerified) without going back to the repository.
+/// </summary>
+public sealed record UserEmailSnapshot(
+    Guid Id,
+    string Email,
+    bool IsVerified,
+    bool IsPrimary,
+    bool IsGoogle);
+```
+
+- [ ] **Step 2: Add `UserEmails` to the `FullProfile` record params (after `GoogleEmail`, before `State`)**
+
+The new param is `IReadOnlyList<UserEmailSnapshot>? UserEmails = null`. Default null for backward compat with existing `Create` overloads that don't have email rows.
+
+```csharp
+public record FullProfile(
+    // ... existing params ...
+    string? GoogleEmail = null,
+    IReadOnlyList<UserEmailSnapshot>? UserEmails = null,
+    ProfileState? State = null)
+{
+```
+
+- [ ] **Step 3: Add a non-null projection helper near `VerifiedEmails`**
+
+```csharp
+/// <summary>
+/// Defensive non-null projection of <see cref="UserEmails"/>.
+/// </summary>
+public IReadOnlyList<UserEmailSnapshot> AllUserEmails =>
+    UserEmails ?? Array.Empty<UserEmailSnapshot>();
+```
+
+- [ ] **Step 4: Build to confirm record signature change compiles**
+
+Run: `dotnet build Humans.slnx -v quiet`
+Expected: PASS (no callers yet rely on the new param positionally — it's optional).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Humans.Application/FullProfile.cs
+git commit -m "feat(profile): carry per-row UserEmail snapshot on FullProfile"
+```
+
+---
+
+### Task 2: Populate `FullProfile.UserEmails` inside the rich `Create` overload
+
+**Files:**
+- Modify: `src/Humans.Application/FullProfile.cs`
+
+- [ ] **Step 1: Inside `Create(profile, user, volunteerHistory, userEmails)`, build the snapshot list before constructing the FullProfile**
+
+```csharp
+var snapshots = userEmails
+    .Select(e => new UserEmailSnapshot(e.Id, e.Email, e.IsVerified, e.IsPrimary, e.IsGoogle))
+    .ToList();
+```
+
+- [ ] **Step 2: Pass `UserEmails: snapshots` into the `new FullProfile(...)` construction**
+
+Add the named arg between `GoogleEmail: google,` and `State: profile.State)`.
+
+- [ ] **Step 3: Build**
+
+Run: `dotnet build Humans.slnx -v quiet`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Humans.Application/FullProfile.cs
+git commit -m "feat(profile): populate UserEmails snapshot in FullProfile.Create"
+```
+
+---
+
+### Task 3: Add `IProfileService.GetFullProfileSnapshotAsync`
+
+**Files:**
+- Modify: `src/Humans.Application/Interfaces/Profiles/IProfileService.cs`
+- Modify: `src/Humans.Application/Services/Profile/ProfileService.cs` (inner)
+- Modify: `src/Humans.Infrastructure/Services/Profiles/CachingProfileService.cs` (decorator)
+
+- [ ] **Step 1: Add the interface method**
+
+In `IProfileService.cs`, near other snapshot-style methods:
+
+```csharp
+/// <summary>
+/// Returns a snapshot of every <see cref="FullProfile"/> currently materialized.
+/// Used by admin scans (EmailProblems) that need to enumerate the full set
+/// of users with their per-row UserEmail flags. Decorator returns the cache
+/// dict's Values; inner impl rebuilds from repositories.
+/// </summary>
+Task<IReadOnlyList<FullProfile>> GetFullProfileSnapshotAsync(CancellationToken ct = default);
+```
+
+- [ ] **Step 2: Implement on inner `ProfileService` by reusing the warmup-style load**
+
+In `Humans.Application/Services/Profile/ProfileService.cs`, add:
+
+```csharp
+public async Task<IReadOnlyList<FullProfile>> GetFullProfileSnapshotAsync(CancellationToken ct = default)
+{
+    var profiles = await _profileRepository.GetAllAsync(ct);
+    var userIds = profiles.Select(p => p.UserId).ToList();
+    var users = await _userService.GetByIdsAsync(userIds, ct);
+    var allUserEmails = await _userEmailRepository.GetAllAsync(ct);
+    var emailsByUser = allUserEmails.GroupBy(e => e.UserId)
+        .ToDictionary(g => g.Key, g => (IReadOnlyList<UserEmail>)g.ToList());
+
+    var result = new List<FullProfile>(profiles.Count);
+    foreach (var profile in profiles)
+    {
+        if (!users.TryGetValue(profile.UserId, out var user)) continue;
+        var emails = emailsByUser.GetValueOrDefault(profile.UserId, Array.Empty<UserEmail>());
+        result.Add(FullProfile.Create(profile, user, profile.VolunteerHistory.ToList(), emails));
+    }
+    return result;
+}
+```
+
+(Confirm `_userService` and `_userEmailRepository` injections already exist by reading the constructor — both are used elsewhere in this file.)
+
+- [ ] **Step 3: Implement on decorator (`CachingProfileService`) — return cache snapshot**
+
+```csharp
+public Task<IReadOnlyList<FullProfile>> GetFullProfileSnapshotAsync(CancellationToken ct = default) =>
+    Task.FromResult<IReadOnlyList<FullProfile>>(_byUserId.Values.ToList());
+```
+
+- [ ] **Step 4: Build**
+
+Run: `dotnet build Humans.slnx -v quiet`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Humans.Application/Interfaces/Profiles/IProfileService.cs \
+        src/Humans.Application/Services/Profile/ProfileService.cs \
+        src/Humans.Infrastructure/Services/Profiles/CachingProfileService.cs
+git commit -m "feat(profile): expose GetFullProfileSnapshotAsync on IProfileService"
+```
+
+---
+
+### Task 4: Add `IUserEmailService.GetOrphanUserEmailsAsync`
+
+**Files:**
+- Modify: `src/Humans.Application/Interfaces/Profiles/IUserEmailService.cs`
+- Modify: `src/Humans.Application/Services/Profile/UserEmailService.cs`
+
+- [ ] **Step 1: Add interface method**
+
+```csharp
+/// <summary>
+/// Returns UserEmail rows whose UserId points to a non-existent or tombstoned
+/// User (User row absent OR <c>MergedToUserId</c> set). Used by the EmailProblems
+/// admin scan. At ~500 users, full-table scan is trivial.
+/// </summary>
+Task<IReadOnlyList<UserEmail>> GetOrphanUserEmailsAsync(CancellationToken ct = default);
+```
+
+- [ ] **Step 2: Implement on `UserEmailService` using existing `IUserService.GetAllUsersAsync` + repo `GetAllAsync`**
+
+```csharp
+public async Task<IReadOnlyList<UserEmail>> GetOrphanUserEmailsAsync(CancellationToken ct = default)
+{
+    var allEmails = await _repository.GetAllAsync(ct);
+    var allUsers = await _userService.GetAllUsersAsync(ct);
+    var liveUserIds = allUsers
+        .Where(u => u.MergedToUserId is null)
+        .Select(u => u.Id)
+        .ToHashSet();
+
+    return allEmails
+        .Where(e => !liveUserIds.Contains(e.UserId))
+        .ToList();
+}
+```
+
+(Confirm `_userService` is already injected in `UserEmailService`. If not, add the injection — `IUserService` is already used by sibling services in this file.)
+
+- [ ] **Step 3: Build**
+
+Run: `dotnet build Humans.slnx -v quiet`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Humans.Application/Interfaces/Profiles/IUserEmailService.cs \
+        src/Humans.Application/Services/Profile/UserEmailService.cs
+git commit -m "feat(profile): add GetOrphanUserEmailsAsync to IUserEmailService"
+```
+
+---
+
+### Task 5: Add `IUserService.GetUsersWithLoginsButNoEmailsAsync` (with repo method)
+
+**Files:**
+- Modify: `src/Humans.Application/Interfaces/Repositories/IUserRepository.cs`
+- Modify: `src/Humans.Infrastructure/Repositories/Users/UserRepository.cs`
+- Modify: `src/Humans.Application/Interfaces/Users/IUserService.cs`
+- Modify: `src/Humans.Application/Services/Users/UserService.cs`
+
+- [ ] **Step 1: Add repo method to `IUserRepository`**
+
+```csharp
+/// <summary>
+/// Returns userIds of users that have at least one row in
+/// <c>AspNetUserLogins</c> but zero rows in <c>user_emails</c>. Used by the
+/// EmailProblems admin scan to surface ghost auth artifacts (case 8).
+/// </summary>
+Task<IReadOnlyList<Guid>> GetUsersWithLoginsButNoEmailsAsync(CancellationToken ct = default);
+```
+
+- [ ] **Step 2: Implement on `UserRepository`**
+
+Open `src/Humans.Infrastructure/Repositories/Users/UserRepository.cs`. Add (matching the section's `IDbContextFactory` + AsNoTracking idiom used by other read methods):
+
+```csharp
+public async Task<IReadOnlyList<Guid>> GetUsersWithLoginsButNoEmailsAsync(CancellationToken ct = default)
+{
+    using var ctx = await _contextFactory.CreateDbContextAsync(ct);
+
+    // Distinct UserIds present in AspNetUserLogins
+    var loginUserIds = await ctx.UserLogins
+        .AsNoTracking()
+        .Select(l => l.UserId)
+        .Distinct()
+        .ToListAsync(ct);
+
+    if (loginUserIds.Count == 0) return Array.Empty<Guid>();
+
+    // UserIds that DO have a user_emails row
+    var withEmail = await ctx.UserEmails
+        .AsNoTracking()
+        .Where(e => loginUserIds.Contains(e.UserId))
+        .Select(e => e.UserId)
+        .Distinct()
+        .ToListAsync(ct);
+
+    var withEmailSet = withEmail.ToHashSet();
+    return loginUserIds.Where(id => !withEmailSet.Contains(id)).ToList();
+}
+```
+
+- [ ] **Step 3: Add interface method to `IUserService`**
+
+```csharp
+/// <summary>
+/// Returns userIds of users that have AspNetUserLogins rows but zero
+/// UserEmail rows. Used by EmailProblems admin scan.
+/// </summary>
+Task<IReadOnlyList<Guid>> GetUsersWithLoginsButNoEmailsAsync(CancellationToken ct = default);
+```
+
+- [ ] **Step 4: Implement on `UserService` (pass-through to repo)**
+
+```csharp
+public Task<IReadOnlyList<Guid>> GetUsersWithLoginsButNoEmailsAsync(CancellationToken ct = default) =>
+    _repo.GetUsersWithLoginsButNoEmailsAsync(ct);
+```
+
+- [ ] **Step 5: Build**
+
+Run: `dotnet build Humans.slnx -v quiet`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Humans.Application/Interfaces/Repositories/IUserRepository.cs \
+        src/Humans.Infrastructure/Repositories/Users/UserRepository.cs \
+        src/Humans.Application/Interfaces/Users/IUserService.cs \
+        src/Humans.Application/Services/Users/UserService.cs
+git commit -m "feat(users): add GetUsersWithLoginsButNoEmailsAsync"
+```
+
+---
+
+### Task 6: Add new `AuditAction` enum values
+
+**Files:**
+- Modify: `src/Humans.Domain/Enums/AuditAction.cs`
+
+- [ ] **Step 1: Append two new values to the enum**
+
+```csharp
+OrphanUserEmailDeleted,
+GhostExternalLoginsDeleted,
+```
+
+(Append at the end of the enum to preserve string-conversion stability for existing rows.)
+
+- [ ] **Step 2: Build**
+
+Run: `dotnet build Humans.slnx -v quiet`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/Humans.Domain/Enums/AuditAction.cs
+git commit -m "feat(audit): add OrphanUserEmailDeleted, GhostExternalLoginsDeleted actions"
+```
+
+- [ ] **Step 4: Push the foundation phase**
+
+```bash
+git push
+```
+
+---
+
+## Phase 2 — Detection service (TDD)
+
+### Task 7: Create `EmailProblemsReport`, `IEmailProblemsService`, empty service skeleton
+
+**Files:**
+- Create: `src/Humans.Application/DTOs/EmailProblems/EmailProblemKind.cs`
+- Create: `src/Humans.Application/DTOs/EmailProblems/EmailProblem.cs`
+- Create: `src/Humans.Application/DTOs/EmailProblems/EmailProblemsReport.cs`
+- Create: `src/Humans.Application/Interfaces/Profiles/IEmailProblemsService.cs`
+- Create: `src/Humans.Application/Services/Profile/EmailProblemsService.cs`
+- Modify: `src/Humans.Web/Extensions/Sections/ProfileSectionExtensions.cs`
+
+- [ ] **Step 1: Create `EmailProblemKind.cs`**
+
+```csharp
+namespace Humans.Application.DTOs.EmailProblems;
+
+public enum EmailProblemKind
+{
+    MultipleIsPrimary = 1,
+    MultipleIsGoogle = 2,
+    ZeroIsPrimary = 3,
+    ZeroIsGoogle = 4,
+    SharedAcrossUsers = 5,
+    Unverified = 6,
+    OrphanUserEmail = 7,
+    GhostExternalLogins = 8
+}
+```
+
+- [ ] **Step 2: Create `EmailProblem.cs`**
+
+```csharp
+using Humans.Application.DTOs.EmailProblems;
+
+namespace Humans.Application.DTOs.EmailProblems;
+
+/// <summary>
+/// One detected EmailProblem entry. Some kinds are scoped to a single user,
+/// some to a pair (case 5), some to a single email row (case 7), some to a
+/// single user with no rows (case 8).
+/// </summary>
+public sealed record EmailProblem(
+    EmailProblemKind Kind,
+    Guid? UserId,
+    Guid? OtherUserId,
+    Guid? UserEmailId,
+    string? Email,
+    string? Detail);
+```
+
+- [ ] **Step 3: Create `EmailProblemsReport.cs`**
+
+```csharp
+using NodaTime;
+
+namespace Humans.Application.DTOs.EmailProblems;
+
+public sealed record EmailProblemsReport(
+    Instant ScannedAt,
+    IReadOnlyList<EmailProblem> Problems);
+```
+
+- [ ] **Step 4: Create `IEmailProblemsService.cs`**
+
+```csharp
+using Humans.Application.DTOs.EmailProblems;
+
+namespace Humans.Application.Interfaces.Profiles;
+
+/// <summary>
+/// Scans every UserEmail invariant violation surface for the
+/// <c>/Profile/Admin/EmailProblems</c> page. Consumes only existing section
+/// services — never any <c>I*Repository</c> or <c>DbContext</c>.
+/// </summary>
+public interface IEmailProblemsService
+{
+    Task<EmailProblemsReport> ScanAsync(CancellationToken ct = default);
+}
+```
+
+- [ ] **Step 5: Create empty `EmailProblemsService.cs`**
+
+```csharp
+using Humans.Application.DTOs.EmailProblems;
+using Humans.Application.Interfaces.Profiles;
+using Humans.Application.Interfaces.Users;
+using NodaTime;
+
+namespace Humans.Application.Services.Profile;
+
+public sealed class EmailProblemsService : IEmailProblemsService
+{
+    private readonly IProfileService _profileService;
+    private readonly IUserEmailService _userEmailService;
+    private readonly IUserService _userService;
+    private readonly IClock _clock;
+
+    public EmailProblemsService(
+        IProfileService profileService,
+        IUserEmailService userEmailService,
+        IUserService userService,
+        IClock clock)
+    {
+        _profileService = profileService;
+        _userEmailService = userEmailService;
+        _userService = userService;
+        _clock = clock;
+    }
+
+    public async Task<EmailProblemsReport> ScanAsync(CancellationToken ct = default)
+    {
+        var problems = new List<EmailProblem>();
+        // Tasks 8–13 fill this in.
+        return new EmailProblemsReport(_clock.GetCurrentInstant(), problems);
+    }
+}
+```
+
+- [ ] **Step 6: Register in DI**
+
+In `ProfileSectionExtensions.cs`, after the `IDuplicateAccountService` registration, add:
+
+```csharp
+services.AddScoped<IEmailProblemsService, EmailProblemsService>();
+```
+
+- [ ] **Step 7: Build**
+
+Run: `dotnet build Humans.slnx -v quiet`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/Humans.Application/DTOs/EmailProblems/ \
+        src/Humans.Application/Interfaces/Profiles/IEmailProblemsService.cs \
+        src/Humans.Application/Services/Profile/EmailProblemsService.cs \
+        src/Humans.Web/Extensions/Sections/ProfileSectionExtensions.cs
+git commit -m "feat(emailproblems): scaffold IEmailProblemsService + DTOs"
+```
+
+---
+
+### Task 8: Detect cases 1 & 2 — multiple `IsPrimary` / multiple `IsGoogle` per user (TDD)
+
+**Files:**
+- Create: `tests/Humans.Application.Tests/Services/Profile/EmailProblemsServiceTests.cs`
+- Modify: `src/Humans.Application/Services/Profile/EmailProblemsService.cs`
+
+- [ ] **Step 1: Write the failing test file**
+
+```csharp
+using FluentAssertions;
+using Humans.Application;
+using Humans.Application.DTOs.EmailProblems;
+using Humans.Application.Interfaces.Profiles;
+using Humans.Application.Interfaces.Users;
+using Humans.Application.Services.Profile;
+using Humans.Domain.Entities;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NodaTime.Testing;
+using Xunit;
+
+namespace Humans.Application.Tests.Services.Profile;
+
+public class EmailProblemsServiceTests
+{
+    private readonly Mock<IProfileService> _profileService = new();
+    private readonly Mock<IUserEmailService> _userEmailService = new();
+    private readonly Mock<IUserService> _userService = new();
+    private readonly FakeClock _clock = new(NodaTime.Instant.FromUtc(2026, 5, 5, 12, 0));
+
+    private EmailProblemsService Sut => new(
+        _profileService.Object, _userEmailService.Object, _userService.Object, _clock);
+
+    private static FullProfile MakeProfile(Guid userId, params UserEmailSnapshot[] emails) =>
+        new FullProfile(
+            UserId: userId, DisplayName: "Test User", ProfilePictureUrl: null,
+            HasCustomPicture: false, ProfileId: Guid.NewGuid(), UpdatedAtTicks: 0,
+            BurnerName: "Test", Bio: null, Pronouns: null, ContributionInterests: null,
+            City: null, CountryCode: null, Latitude: null, Longitude: null,
+            BirthdayDay: null, BirthdayMonth: null,
+            IsApproved: true, IsSuspended: false,
+            CVEntries: Array.Empty<CVEntry>(),
+            UserEmails: emails);
+
+    private void SetProfiles(params FullProfile[] profiles) =>
+        _profileService.Setup(s => s.GetFullProfileSnapshotAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(profiles);
+
+    private void SetOrphans(params UserEmail[] orphans) =>
+        _userEmailService.Setup(s => s.GetOrphanUserEmailsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(orphans);
+
+    private void SetGhosts(params Guid[] ghostUserIds) =>
+        _userService.Setup(s => s.GetUsersWithLoginsButNoEmailsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ghostUserIds);
+
+    [Fact]
+    public async Task EmptySnapshot_ReturnsEmptyReport()
+    {
+        SetProfiles();
+        SetOrphans();
+        SetGhosts();
+
+        var report = await Sut.ScanAsync();
+
+        report.Problems.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task DetectsMultipleIsPrimary()
+    {
+        var userId = Guid.NewGuid();
+        SetProfiles(MakeProfile(userId,
+            new UserEmailSnapshot(Guid.NewGuid(), "a@x.com", true, true, false),
+            new UserEmailSnapshot(Guid.NewGuid(), "b@x.com", true, true, false)));
+        SetOrphans();
+        SetGhosts();
+
+        var report = await Sut.ScanAsync();
+
+        report.Problems.Should().ContainSingle(p =>
+            p.Kind == EmailProblemKind.MultipleIsPrimary && p.UserId == userId);
+    }
+
+    [Fact]
+    public async Task DetectsMultipleIsGoogle()
+    {
+        var userId = Guid.NewGuid();
+        SetProfiles(MakeProfile(userId,
+            new UserEmailSnapshot(Guid.NewGuid(), "a@x.com", true, false, true),
+            new UserEmailSnapshot(Guid.NewGuid(), "b@x.com", true, false, true)));
+        SetOrphans();
+        SetGhosts();
+
+        var report = await Sut.ScanAsync();
+
+        report.Problems.Should().ContainSingle(p =>
+            p.Kind == EmailProblemKind.MultipleIsGoogle && p.UserId == userId);
+    }
+}
+```
+
+- [ ] **Step 2: Run tests, expect failures**
+
+Run: `dotnet test Humans.slnx -v quiet --filter "FullyQualifiedName~EmailProblemsServiceTests"`
+Expected: FAIL — `EmptySnapshot_ReturnsEmptyReport` passes (empty in, empty out), but the two detection tests fail because no detection is implemented.
+
+- [ ] **Step 3: Add detection logic in `ScanAsync`**
+
+Replace the body of `ScanAsync` in `EmailProblemsService.cs`:
+
+```csharp
+public async Task<EmailProblemsReport> ScanAsync(CancellationToken ct = default)
+{
+    var problems = new List<EmailProblem>();
+
+    var profiles = await _profileService.GetFullProfileSnapshotAsync(ct);
+
+    foreach (var p in profiles)
+    {
+        var emails = p.AllUserEmails;
+
+        if (emails.Count(e => e.IsPrimary) > 1)
+            problems.Add(new EmailProblem(
+                EmailProblemKind.MultipleIsPrimary, p.UserId, null, null, null, null));
+
+        if (emails.Count(e => e.IsGoogle) > 1)
+            problems.Add(new EmailProblem(
+                EmailProblemKind.MultipleIsGoogle, p.UserId, null, null, null, null));
+    }
+
+    return new EmailProblemsReport(_clock.GetCurrentInstant(), problems);
+}
+```
+
+- [ ] **Step 4: Run tests, expect pass**
+
+Run: `dotnet test Humans.slnx -v quiet --filter "FullyQualifiedName~EmailProblemsServiceTests"`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/Humans.Application.Tests/Services/Profile/EmailProblemsServiceTests.cs \
+        src/Humans.Application/Services/Profile/EmailProblemsService.cs
+git commit -m "feat(emailproblems): detect multiple IsPrimary/IsGoogle (cases 1, 2)"
+```
+
+---
+
+### Task 9: Detect cases 3 & 4 — zero `IsPrimary` / zero `IsGoogle` (TDD)
+
+**Files:**
+- Modify: `tests/Humans.Application.Tests/Services/Profile/EmailProblemsServiceTests.cs`
+- Modify: `src/Humans.Application/Services/Profile/EmailProblemsService.cs`
+
+- [ ] **Step 1: Add failing tests**
+
+```csharp
+[Fact]
+public async Task DetectsZeroIsPrimary_WhenUserHasVerifiedEmails()
+{
+    var userId = Guid.NewGuid();
+    SetProfiles(MakeProfile(userId,
+        new UserEmailSnapshot(Guid.NewGuid(), "a@x.com", true, false, false),
+        new UserEmailSnapshot(Guid.NewGuid(), "b@x.com", true, false, false)));
+    SetOrphans();
+    SetGhosts();
+
+    var report = await Sut.ScanAsync();
+
+    report.Problems.Should().ContainSingle(p =>
+        p.Kind == EmailProblemKind.ZeroIsPrimary && p.UserId == userId);
+}
+
+[Fact]
+public async Task DoesNotFlagZeroIsPrimary_WhenUserHasNoVerifiedEmails()
+{
+    var userId = Guid.NewGuid();
+    SetProfiles(MakeProfile(userId,
+        new UserEmailSnapshot(Guid.NewGuid(), "a@x.com", false, false, false)));
+    SetOrphans();
+    SetGhosts();
+
+    var report = await Sut.ScanAsync();
+
+    report.Problems.Should().NotContain(p => p.Kind == EmailProblemKind.ZeroIsPrimary);
+}
+
+[Fact]
+public async Task DetectsZeroIsGoogle()
+{
+    var userId = Guid.NewGuid();
+    SetProfiles(MakeProfile(userId,
+        new UserEmailSnapshot(Guid.NewGuid(), "a@x.com", true, true, false)));
+    SetOrphans();
+    SetGhosts();
+
+    var report = await Sut.ScanAsync();
+
+    report.Problems.Should().ContainSingle(p =>
+        p.Kind == EmailProblemKind.ZeroIsGoogle && p.UserId == userId);
+}
+```
+
+- [ ] **Step 2: Run, expect 2 of 3 to fail (the "DoesNotFlag" passes vacuously)**
+
+Run: `dotnet test Humans.slnx -v quiet --filter "FullyQualifiedName~EmailProblemsServiceTests"`
+Expected: FAIL.
+
+- [ ] **Step 3: Add detection logic in `ScanAsync` (inside the per-profile loop)**
+
+```csharp
+if (emails.Any(e => e.IsVerified) && !emails.Any(e => e.IsPrimary))
+    problems.Add(new EmailProblem(
+        EmailProblemKind.ZeroIsPrimary, p.UserId, null, null, null, null));
+
+if (!emails.Any(e => e.IsGoogle))
+    problems.Add(new EmailProblem(
+        EmailProblemKind.ZeroIsGoogle, p.UserId, null, null, null, null));
+```
+
+- [ ] **Step 4: Run tests, expect pass**
+
+Run: `dotnet test Humans.slnx -v quiet --filter "FullyQualifiedName~EmailProblemsServiceTests"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/Humans.Application.Tests/Services/Profile/EmailProblemsServiceTests.cs \
+        src/Humans.Application/Services/Profile/EmailProblemsService.cs
+git commit -m "feat(emailproblems): detect zero IsPrimary/IsGoogle (cases 3, 4)"
+```
+
+---
+
+### Task 10: Detect case 6 — any unverified UserEmail (TDD)
+
+**Files:**
+- Modify: `tests/Humans.Application.Tests/Services/Profile/EmailProblemsServiceTests.cs`
+- Modify: `src/Humans.Application/Services/Profile/EmailProblemsService.cs`
+
+- [ ] **Step 1: Add failing test**
+
+```csharp
+[Fact]
+public async Task DetectsUnverifiedEmail_RegardlessOfFlags()
+{
+    var userId = Guid.NewGuid();
+    var emailId = Guid.NewGuid();
+    SetProfiles(MakeProfile(userId,
+        new UserEmailSnapshot(emailId, "a@x.com", false, false, false)));
+    SetOrphans();
+    SetGhosts();
+
+    var report = await Sut.ScanAsync();
+
+    report.Problems.Should().ContainSingle(p =>
+        p.Kind == EmailProblemKind.Unverified
+        && p.UserId == userId
+        && p.UserEmailId == emailId
+        && p.Email == "a@x.com");
+}
+```
+
+- [ ] **Step 2: Run, expect fail**
+
+Run: `dotnet test Humans.slnx -v quiet --filter "FullyQualifiedName~EmailProblemsServiceTests"`
+Expected: FAIL.
+
+- [ ] **Step 3: Add detection inside the per-profile loop in `ScanAsync`**
+
+```csharp
+foreach (var unverified in emails.Where(e => !e.IsVerified))
+{
+    problems.Add(new EmailProblem(
+        EmailProblemKind.Unverified, p.UserId, null,
+        unverified.Id, unverified.Email, null));
+}
+```
+
+- [ ] **Step 4: Run, expect pass**
+
+Run: `dotnet test Humans.slnx -v quiet --filter "FullyQualifiedName~EmailProblemsServiceTests"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/Humans.Application.Tests/Services/Profile/EmailProblemsServiceTests.cs \
+        src/Humans.Application/Services/Profile/EmailProblemsService.cs
+git commit -m "feat(emailproblems): detect unverified UserEmail rows (case 6)"
+```
+
+---
+
+### Task 11: Detect case 5 — two users sharing an email (with normalization) (TDD)
+
+**Files:**
+- Modify: `tests/Humans.Application.Tests/Services/Profile/EmailProblemsServiceTests.cs`
+- Modify: `src/Humans.Application/Services/Profile/EmailProblemsService.cs`
+
+- [ ] **Step 1: Add failing tests**
+
+```csharp
+[Fact]
+public async Task DetectsRawEmailCollisionAcrossUsers()
+{
+    var u1 = Guid.NewGuid();
+    var u2 = Guid.NewGuid();
+    SetProfiles(
+        MakeProfile(u1, new UserEmailSnapshot(Guid.NewGuid(), "joe@x.com", true, true, false)),
+        MakeProfile(u2, new UserEmailSnapshot(Guid.NewGuid(), "joe@x.com", true, true, false)));
+    SetOrphans();
+    SetGhosts();
+
+    var report = await Sut.ScanAsync();
+
+    report.Problems.Should().ContainSingle(p => p.Kind == EmailProblemKind.SharedAcrossUsers)
+        .Which.Should().Match<EmailProblem>(p =>
+            p.Email == "joe@x.com"
+            && (p.UserId == u1 || p.UserId == u2)
+            && (p.OtherUserId == u1 || p.OtherUserId == u2)
+            && p.UserId != p.OtherUserId);
+}
+
+[Fact]
+public async Task DetectsNormalizationEquivalentCollision()
+{
+    var u1 = Guid.NewGuid();
+    var u2 = Guid.NewGuid();
+    SetProfiles(
+        MakeProfile(u1, new UserEmailSnapshot(Guid.NewGuid(), "joe@gmail.com", true, true, false)),
+        MakeProfile(u2, new UserEmailSnapshot(Guid.NewGuid(), "j.oe@googlemail.com", true, true, false)));
+    SetOrphans();
+    SetGhosts();
+
+    var report = await Sut.ScanAsync();
+
+    report.Problems.Should().ContainSingle(p => p.Kind == EmailProblemKind.SharedAcrossUsers);
+}
+```
+
+- [ ] **Step 2: Run, expect fail**
+
+Run: `dotnet test Humans.slnx -v quiet --filter "FullyQualifiedName~EmailProblemsServiceTests"`
+Expected: FAIL.
+
+- [ ] **Step 3: Add detection AFTER the per-profile loop in `ScanAsync`** (uses existing `EmailNormalization.NormalizeForComparison` from `Humans.Domain.Helpers`)
+
+```csharp
+// Cross-user duplicates: build normalized-email -> userIds map, flag pairs.
+var normToUsers = new Dictionary<string, List<(Guid UserId, string Raw)>>(StringComparer.Ordinal);
+foreach (var p in profiles)
+{
+    foreach (var email in p.AllUserEmails)
+    {
+        var norm = EmailNormalization.NormalizeForComparison(email.Email);
+        if (!normToUsers.TryGetValue(norm, out var list))
+        {
+            list = new List<(Guid, string)>();
+            normToUsers[norm] = list;
+        }
+        list.Add((p.UserId, email.Email));
+    }
+}
+
+foreach (var kvp in normToUsers)
+{
+    var distinctUsers = kvp.Value.Select(t => t.UserId).Distinct().ToList();
+    if (distinctUsers.Count <= 1) continue;
+
+    for (var i = 0; i < distinctUsers.Count; i++)
+    {
+        for (var j = i + 1; j < distinctUsers.Count; j++)
+        {
+            var rawA = kvp.Value.First(t => t.UserId == distinctUsers[i]).Raw;
+            problems.Add(new EmailProblem(
+                EmailProblemKind.SharedAcrossUsers,
+                distinctUsers[i], distinctUsers[j],
+                null, rawA, null));
+        }
+    }
+}
+```
+
+(Add `using Humans.Domain.Helpers;` to the file if not already present.)
+
+- [ ] **Step 4: Run, expect pass**
+
+Run: `dotnet test Humans.slnx -v quiet --filter "FullyQualifiedName~EmailProblemsServiceTests"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/Humans.Application.Tests/Services/Profile/EmailProblemsServiceTests.cs \
+        src/Humans.Application/Services/Profile/EmailProblemsService.cs
+git commit -m "feat(emailproblems): detect cross-user shared emails with normalization (case 5)"
+```
+
+---
+
+### Task 12: Detect case 7 — orphan UserEmail rows (TDD)
+
+**Files:**
+- Modify: `tests/Humans.Application.Tests/Services/Profile/EmailProblemsServiceTests.cs`
+- Modify: `src/Humans.Application/Services/Profile/EmailProblemsService.cs`
+
+- [ ] **Step 1: Add failing test**
+
+```csharp
+[Fact]
+public async Task DetectsOrphanUserEmail()
+{
+    var deadUserId = Guid.NewGuid();
+    var emailId = Guid.NewGuid();
+    SetProfiles();
+    SetOrphans(new UserEmail
+    {
+        Id = emailId,
+        UserId = deadUserId,
+        Email = "ghost@x.com",
+        IsVerified = true
+    });
+    SetGhosts();
+
+    var report = await Sut.ScanAsync();
+
+    report.Problems.Should().ContainSingle(p =>
+        p.Kind == EmailProblemKind.OrphanUserEmail
+        && p.UserEmailId == emailId
+        && p.UserId == deadUserId
+        && p.Email == "ghost@x.com");
+}
+```
+
+- [ ] **Step 2: Run, expect fail**
+
+- [ ] **Step 3: In `ScanAsync`, after the cross-user loop, add**
+
+```csharp
+var orphans = await _userEmailService.GetOrphanUserEmailsAsync(ct);
+foreach (var o in orphans)
+{
+    problems.Add(new EmailProblem(
+        EmailProblemKind.OrphanUserEmail, o.UserId, null, o.Id, o.Email, null));
+}
+```
+
+- [ ] **Step 4: Run, expect pass**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/Humans.Application.Tests/Services/Profile/EmailProblemsServiceTests.cs \
+        src/Humans.Application/Services/Profile/EmailProblemsService.cs
+git commit -m "feat(emailproblems): detect orphan UserEmail rows (case 7)"
+```
+
+---
+
+### Task 13: Detect case 8 — ghost AspNetUserLogins (TDD)
+
+**Files:**
+- Modify: `tests/Humans.Application.Tests/Services/Profile/EmailProblemsServiceTests.cs`
+- Modify: `src/Humans.Application/Services/Profile/EmailProblemsService.cs`
+
+- [ ] **Step 1: Add failing test**
+
+```csharp
+[Fact]
+public async Task DetectsGhostExternalLogins()
+{
+    var ghostUserId = Guid.NewGuid();
+    SetProfiles();
+    SetOrphans();
+    SetGhosts(ghostUserId);
+
+    var report = await Sut.ScanAsync();
+
+    report.Problems.Should().ContainSingle(p =>
+        p.Kind == EmailProblemKind.GhostExternalLogins && p.UserId == ghostUserId);
+}
+```
+
+- [ ] **Step 2: Run, expect fail**
+
+- [ ] **Step 3: In `ScanAsync`, append**
+
+```csharp
+var ghosts = await _userService.GetUsersWithLoginsButNoEmailsAsync(ct);
+foreach (var ghostId in ghosts)
+{
+    problems.Add(new EmailProblem(
+        EmailProblemKind.GhostExternalLogins, ghostId, null, null, null, null));
+}
+```
+
+- [ ] **Step 4: Run, expect pass**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/Humans.Application.Tests/Services/Profile/EmailProblemsServiceTests.cs \
+        src/Humans.Application/Services/Profile/EmailProblemsService.cs
+git commit -m "feat(emailproblems): detect ghost external logins (case 8)"
+```
+
+---
+
+### Task 14: Architecture test — `EmailProblemsService` has zero repository deps
+
+**Files:**
+- Modify: `tests/Humans.Application.Tests/Architecture/ProfileArchitectureTests.cs`
+
+- [ ] **Step 1: Add a focused test**
+
+```csharp
+[Fact]
+public void EmailProblemsService_DependsOnlyOnSectionServices_NotRepositories()
+{
+    var ctor = typeof(EmailProblemsService).GetConstructors().Single();
+    var paramTypes = ctor.GetParameters().Select(p => p.ParameterType).ToList();
+
+    var allowed = new[]
+    {
+        typeof(IProfileService),
+        typeof(IUserEmailService),
+        typeof(IUserService),
+        typeof(IClock)
+    };
+
+    paramTypes.Should().OnlyContain(t => allowed.Contains(t),
+        "EmailProblemsService must use existing section services, never repositories or DbContext");
+}
+```
+
+(Add `using Humans.Application.Services.Profile; using Humans.Application.Interfaces.Profiles; using Humans.Application.Interfaces.Users; using NodaTime;` and adapt the test class structure to whatever exists in `ProfileArchitectureTests.cs`.)
+
+- [ ] **Step 2: Run, expect pass**
+
+Run: `dotnet test Humans.slnx -v quiet --filter "FullyQualifiedName~EmailProblemsService_DependsOnlyOnSectionServices"`
+Expected: PASS.
+
+- [ ] **Step 3: Commit + push the detection phase**
+
+```bash
+git add tests/Humans.Application.Tests/Architecture/ProfileArchitectureTests.cs
+git commit -m "test(emailproblems): assert no repository deps in service constructor"
+git push
+```
+
+---
+
+## Phase 3 — Merge kernel extraction
+
+### Task 15: Extract `FoldAsync` private kernel; existing `AcceptAsync` tests stay green
+
+**Files:**
+- Modify: `src/Humans.Application/Services/Profile/AccountMergeService.cs`
+
+- [ ] **Step 1: Run the existing AccountMerge test suite, capture passing baseline**
+
+Run: `dotnet test Humans.slnx -v quiet --filter "FullyQualifiedName~AccountMergeService|FullyQualifiedName~AcceptAsync"`
+Expected: PASS (record the count).
+
+- [ ] **Step 2: Add a private `FoldAsync` method that contains the fan-out + tombstone + audit**
+
+Refactor strategy: lift the body of `AcceptAsync` between the request load+validate (top) and the request status update (bottom) into:
+
+```csharp
+private record AuditEntry(
+    Domain.Enums.AuditAction Action,
+    string EntityType,
+    Guid EntityId,
+    string Description,
+    Guid? RelatedEntityId = null,
+    string? RelatedEntityType = null);
+
+private async Task FoldAsync(
+    Guid sourceUserId, Guid targetUserId,
+    Guid adminUserId, AuditEntry audit,
+    CancellationToken ct)
+{
+    var now = _clock.GetCurrentInstant();
+
+    try
+    {
+        using (var scope = new System.Transactions.TransactionScope(
+            System.Transactions.TransactionScopeOption.Required,
+            new System.Transactions.TransactionOptions
+            {
+                IsolationLevel = System.Transactions.IsolationLevel.ReadCommitted
+            },
+            System.Transactions.TransactionScopeAsyncFlowOption.Enabled))
+        {
+            foreach (var merger in _userMerges)
+                await merger.ReassignAsync(sourceUserId, targetUserId, adminUserId, now, ct);
+
+            await _userService.AnonymizeForMergeAsync(sourceUserId, targetUserId, now, ct);
+
+            await _auditLogService.LogAsync(
+                audit.Action,
+                audit.EntityType, audit.EntityId,
+                audit.Description,
+                adminUserId,
+                relatedEntityId: audit.RelatedEntityId,
+                relatedEntityType: audit.RelatedEntityType);
+
+            scope.Complete();
+        }
+
+        _teamService.RemoveMemberFromAllTeamsCache(sourceUserId);
+        _roleAssignmentService.InvalidateClaimsCacheForUser(sourceUserId);
+        _roleAssignmentService.InvalidateClaimsCacheForUser(targetUserId);
+        _roleAssignmentService.InvalidateNavBadgeCache();
+        _notificationService.InvalidateBadgeCachesForUsers([sourceUserId, targetUserId]);
+    }
+    finally
+    {
+        _teamService.InvalidateActiveTeamsCache();
+    }
+}
+```
+
+Then rewrite `AcceptAsync` to:
+
+```csharp
+public async Task AcceptAsync(
+    Guid requestId, Guid adminUserId,
+    string? notes = null, CancellationToken ct = default)
+{
+    var request = await _mergeRepository.GetByIdAsync(requestId, ct)
+        ?? throw new InvalidOperationException("Merge request not found.");
+    if (request.Status != AccountMergeRequestStatus.Pending)
+        throw new InvalidOperationException("Merge request is not pending.");
+
+    _logger.LogInformation(
+        "Admin {AdminId} accepting merge request {RequestId}: folding {SourceUserId} into {TargetUserId}",
+        adminUserId, requestId, request.SourceUserId, request.TargetUserId);
+
+    var audit = new AuditEntry(
+        AuditAction.AccountMergeAccepted,
+        nameof(AccountMergeRequest), request.Id,
+        $"Folded source {request.SourceUserId} into target {request.TargetUserId} — email: {request.Email}",
+        RelatedEntityId: request.TargetUserId,
+        RelatedEntityType: nameof(User));
+
+    await FoldAsync(request.SourceUserId, request.TargetUserId, adminUserId, audit, ct);
+
+    // Request-specific post-fold steps (must be in a separate scope or merged
+    // back into FoldAsync via callback). Mark the pending email verified and
+    // update the request row.
+    var now = _clock.GetCurrentInstant();
+    using (var scope = new System.Transactions.TransactionScope(
+        System.Transactions.TransactionScopeOption.Required,
+        new System.Transactions.TransactionOptions
+        {
+            IsolationLevel = System.Transactions.IsolationLevel.ReadCommitted
+        },
+        System.Transactions.TransactionScopeAsyncFlowOption.Enabled))
+    {
+        var verified = await _userEmailRepository.MarkVerifiedAsync(request.PendingEmailId, now, ct);
+        if (!verified)
+            throw new InvalidOperationException(
+                $"Pending email {request.PendingEmailId} no longer exists. Cannot complete merge.");
+
+        request.Status = AccountMergeRequestStatus.Accepted;
+        request.ResolvedAt = now;
+        request.ResolvedByUserId = adminUserId;
+        request.AdminNotes = notes;
+        await _mergeRepository.UpdateAsync(request, ct);
+
+        scope.Complete();
+    }
+}
+```
+
+> **NOTE on transaction shape:** the original `AcceptAsync` ran fold+pending-verify+request-update in one ambient scope. Splitting them into two scopes is acceptable here because:
+>   1. The fold is the irreversible part — once the source is tombstoned, the merge has happened from the user's perspective.
+>   2. If the second scope fails (pending email gone, DB hiccup), the request stays Pending and the audit row records "Folded ... — email: X". A retry-or-manual cleanup is a much smaller blast radius than rolling back a fold.
+>   3. The simpler alternative — passing a callback into `FoldAsync` so the request-specific work runs inside the same scope — is also fine. Pick whichever the implementer finds cleaner; tests must show identical observable behavior.
+
+- [ ] **Step 3: Run the existing AccountMerge test suite again, expect same count of PASS**
+
+Run: `dotnet test Humans.slnx -v quiet --filter "FullyQualifiedName~AccountMergeService|FullyQualifiedName~AcceptAsync"`
+Expected: PASS — same count as Step 1.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Humans.Application/Services/Profile/AccountMergeService.cs
+git commit -m "refactor(merge): extract FoldAsync kernel inside AccountMergeService"
+```
+
+---
+
+### Task 16: Add `IAccountMergeService.AdminMergeAsync` + tests (TDD)
+
+**Files:**
+- Modify: `src/Humans.Application/Interfaces/Profiles/IAccountMergeService.cs`
+- Modify: `src/Humans.Application/Services/Profile/AccountMergeService.cs`
+- Create or modify: `tests/Humans.Application.Tests/Services/Profile/AccountMergeServiceAdminMergeTests.cs`
+
+- [ ] **Step 1: Add interface method**
+
+```csharp
+/// <summary>
+/// Admin-initiated merge of two pre-existing accounts (no AccountMergeRequest).
+/// Folds <paramref name="sourceUserId"/> into <paramref name="targetUserId"/>:
+/// reassigns every section's user-keyed rows via <c>IUserMerge</c>, tombstones
+/// the source, and audits. Used by /Profile/Admin/EmailProblems case 5.
+/// </summary>
+/// <exception cref="InvalidOperationException">
+/// Thrown if source==target, either user is missing, or the source is already tombstoned.
+/// </exception>
+Task AdminMergeAsync(
+    Guid sourceUserId, Guid targetUserId,
+    Guid adminUserId, string? notes = null,
+    CancellationToken ct = default);
+```
+
+- [ ] **Step 2: Write failing tests**
+
+Create `tests/Humans.Application.Tests/Services/Profile/AccountMergeServiceAdminMergeTests.cs`. Mirror the structure of any existing `AccountMergeServiceTests.cs` for mock wiring.
+
+```csharp
+using FluentAssertions;
+using Humans.Application.Interfaces.AuditLog;
+using Humans.Application.Interfaces.Auth;
+using Humans.Application.Interfaces.Notifications;
+using Humans.Application.Interfaces.Profiles;
+using Humans.Application.Interfaces.Repositories;
+using Humans.Application.Interfaces.Teams;
+using Humans.Application.Interfaces.Users;
+using Humans.Application.Services.Profile;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NodaTime.Testing;
+using Xunit;
+
+namespace Humans.Application.Tests.Services.Profile;
+
+public class AccountMergeServiceAdminMergeTests
+{
+    private readonly Mock<IAccountMergeRepository> _mergeRepo = new();
+    private readonly Mock<IUserEmailRepository> _userEmailRepo = new();
+    private readonly Mock<IUserService> _userService = new();
+    private readonly Mock<IAuditLogService> _audit = new();
+    private readonly Mock<ITeamService> _team = new();
+    private readonly Mock<IRoleAssignmentService> _roles = new();
+    private readonly Mock<INotificationService> _notify = new();
+    private readonly List<Mock<IUserMerge>> _userMerges = new();
+    private readonly FakeClock _clock = new(NodaTime.Instant.FromUtc(2026, 5, 5, 12, 0));
+
+    private AccountMergeService BuildSut() =>
+        new(
+            _mergeRepo.Object, _userEmailRepo.Object, _userService.Object,
+            _audit.Object, _team.Object, _roles.Object, _notify.Object,
+            _userMerges.Select(m => m.Object), _clock,
+            NullLogger<AccountMergeService>.Instance /* + any other deps the real ctor takes — adjust */);
+
+    private void SetupUsers(Guid sourceId, Guid targetId, bool sourceTombstoned = false)
+    {
+        _userService.Setup(s => s.GetByIdAsync(sourceId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new User { Id = sourceId, MergedToUserId = sourceTombstoned ? targetId : null });
+        _userService.Setup(s => s.GetByIdAsync(targetId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new User { Id = targetId });
+    }
+
+    [Fact]
+    public async Task AdminMergeAsync_HappyPath_RunsFanOutAndTombstone()
+    {
+        var src = Guid.NewGuid(); var tgt = Guid.NewGuid(); var admin = Guid.NewGuid();
+        SetupUsers(src, tgt);
+        var merger = new Mock<IUserMerge>(); _userMerges.Add(merger);
+
+        await BuildSut().AdminMergeAsync(src, tgt, admin);
+
+        merger.Verify(m => m.ReassignAsync(src, tgt, admin,
+            It.IsAny<NodaTime.Instant>(), It.IsAny<CancellationToken>()), Times.Once);
+        _userService.Verify(s => s.AnonymizeForMergeAsync(src, tgt,
+            It.IsAny<NodaTime.Instant>(), It.IsAny<CancellationToken>()), Times.Once);
+        _userEmailRepo.Verify(r => r.MarkVerifiedAsync(
+            It.IsAny<Guid>(), It.IsAny<NodaTime.Instant>(), It.IsAny<CancellationToken>()),
+            Times.Never, "AdminMergeAsync must NOT call MarkVerifiedAsync");
+    }
+
+    [Fact]
+    public async Task AdminMergeAsync_SourceEqualsTarget_Throws()
+    {
+        var id = Guid.NewGuid();
+        var act = () => BuildSut().AdminMergeAsync(id, id, Guid.NewGuid());
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*same*");
+    }
+
+    [Fact]
+    public async Task AdminMergeAsync_SourceMissing_Throws()
+    {
+        var src = Guid.NewGuid(); var tgt = Guid.NewGuid();
+        _userService.Setup(s => s.GetByIdAsync(tgt, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new User { Id = tgt });
+        var act = () => BuildSut().AdminMergeAsync(src, tgt, Guid.NewGuid());
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    [Fact]
+    public async Task AdminMergeAsync_SourceAlreadyTombstoned_Throws()
+    {
+        var src = Guid.NewGuid(); var tgt = Guid.NewGuid();
+        SetupUsers(src, tgt, sourceTombstoned: true);
+        var act = () => BuildSut().AdminMergeAsync(src, tgt, Guid.NewGuid());
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*tombstoned*");
+    }
+}
+```
+
+(Adapt the `BuildSut` ctor params to match the actual `AccountMergeService` constructor signature — read it from the source first.)
+
+- [ ] **Step 3: Run, expect 4 fails (AdminMergeAsync doesn't exist yet)**
+
+- [ ] **Step 4: Implement `AdminMergeAsync` on `AccountMergeService`**
+
+```csharp
+public async Task AdminMergeAsync(
+    Guid sourceUserId, Guid targetUserId,
+    Guid adminUserId, string? notes = null,
+    CancellationToken ct = default)
+{
+    if (sourceUserId == targetUserId)
+        throw new InvalidOperationException("Source and target users are the same.");
+
+    var source = await _userService.GetByIdAsync(sourceUserId, ct)
+        ?? throw new InvalidOperationException($"Source user {sourceUserId} not found.");
+    var target = await _userService.GetByIdAsync(targetUserId, ct)
+        ?? throw new InvalidOperationException($"Target user {targetUserId} not found.");
+
+    if (source.MergedToUserId is not null)
+        throw new InvalidOperationException(
+            $"Source user {sourceUserId} is already tombstoned (merged into {source.MergedToUserId}).");
+
+    if (target.MergedToUserId is not null)
+        throw new InvalidOperationException(
+            $"Target user {targetUserId} is already tombstoned.");
+
+    _logger.LogInformation(
+        "Admin {AdminId} initiated direct merge: folding {SourceUserId} into {TargetUserId}",
+        adminUserId, sourceUserId, targetUserId);
+
+    var description = $"Admin-initiated via EmailProblems: folded source {sourceUserId} into target {targetUserId}. Notes: {notes ?? "(none)"}";
+
+    var audit = new AuditEntry(
+        AuditAction.AccountMergeAccepted,
+        nameof(User), sourceUserId,
+        description,
+        RelatedEntityId: targetUserId,
+        RelatedEntityType: nameof(User));
+
+    await FoldAsync(sourceUserId, targetUserId, adminUserId, audit, ct);
+}
+```
+
+- [ ] **Step 5: Run tests, expect pass**
+
+Run: `dotnet test Humans.slnx -v quiet --filter "FullyQualifiedName~AccountMergeServiceAdminMergeTests"`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Humans.Application/Interfaces/Profiles/IAccountMergeService.cs \
+        src/Humans.Application/Services/Profile/AccountMergeService.cs \
+        tests/Humans.Application.Tests/Services/Profile/AccountMergeServiceAdminMergeTests.cs
+git commit -m "feat(merge): add IAccountMergeService.AdminMergeAsync (admin-initiated fold)"
+```
+
+---
+
+### Task 17: Integration test for full-fixture admin-initiated merge
+
+**Files:**
+- Create: `tests/Humans.Integration.Tests/AccountMerge/AdminMergeAsyncTests.cs`
+
+- [ ] **Step 1: Read the existing `tests/Humans.Integration.Tests/AccountMerge/AcceptAsyncFullFixtureTest.cs` and `MergeFixtureBuilder.cs` to understand fixture conventions**
+
+(Discovery step — no edit yet. Use `cat` or Read.)
+
+- [ ] **Step 2: Create the new test file mirroring `AcceptAsyncFullFixtureTest`'s setup, but invoking `AdminMergeAsync(sourceId, targetId, adminId)` instead of `AcceptAsync(requestId, adminId)`**
+
+The fixture must seed:
+- Two users, both with verified UserEmail rows, where source has `joe@x.com` (verified, IsPrimary on source) and target has `target@x.com` (verified, IsPrimary on target).
+- Source has at least one team membership and one role assignment so the fan-out has work to do.
+- Source has at least one AspNetUserLogins row so reassignment is verifiable.
+
+Assertions after the call:
+- Exactly one UserEmail row per normalized email exists in the database.
+- Source has zero UserEmail rows.
+- Source has zero AspNetUserLogins rows.
+- Target's pre-existing `IsPrimary` UserEmail still has `IsPrimary = true`; target's pre-existing `IsGoogle` (if any) still has `IsGoogle = true`.
+- Source User row has `MergedToUserId = targetId` and `MergedAt` set.
+- An `AuditAction.AccountMergeAccepted` row exists with `EntityType == nameof(User)`, `EntityId == sourceId`, and the description starts with `"Admin-initiated via EmailProblems"`.
+
+(Use the spec's "Acceptance Criteria — case 5" wording verbatim as test names so the spec ↔ test mapping is obvious.)
+
+- [ ] **Step 3: Run integration test**
+
+Run: `dotnet test Humans.slnx -v quiet --filter "FullyQualifiedName~AdminMergeAsyncTests"`
+Expected: PASS.
+
+- [ ] **Step 4: Commit + push**
+
+```bash
+git add tests/Humans.Integration.Tests/AccountMerge/AdminMergeAsyncTests.cs
+git commit -m "test(merge): full-fixture integration coverage for AdminMergeAsync"
+git push
+```
+
+---
+
+## Phase 4 — Controller, view models, views
+
+### Task 18: Create `ProfileAdminController` skeleton
+
+**Files:**
+- Create: `src/Humans.Web/Controllers/ProfileAdminController.cs`
+
+- [ ] **Step 1: Write the skeleton**
+
+```csharp
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Humans.Application.Interfaces.Profiles;
+using Humans.Domain.Constants;
+using Humans.Domain.Entities;
+
+namespace Humans.Web.Controllers;
+
+[Authorize(Policy = PolicyNames.AdminOnly)]
+[Route("Profile/Admin")]
+public class ProfileAdminController : HumansControllerBase
+{
+    private readonly IEmailProblemsService _emailProblems;
+    private readonly IAccountMergeService _accountMerge;
+    private readonly IUserEmailService _userEmails;
+    private readonly IUserService _users;
+    private readonly IAuditLogService _audit;
+    private readonly ILogger<ProfileAdminController> _logger;
+
+    public ProfileAdminController(
+        UserManager<User> userManager,
+        IEmailProblemsService emailProblems,
+        IAccountMergeService accountMerge,
+        IUserEmailService userEmails,
+        IUserService users,
+        IAuditLogService audit,
+        ILogger<ProfileAdminController> logger)
+        : base(userManager)
+    {
+        _emailProblems = emailProblems;
+        _accountMerge = accountMerge;
+        _userEmails = userEmails;
+        _users = users;
+        _audit = audit;
+        _logger = logger;
+    }
+}
+```
+
+(Add `using` for `IUserEmailService`, `IUserService`, `IAuditLogService`, `IAccountMergeService` from their respective namespaces.)
+
+- [ ] **Step 2: Build**
+
+Run: `dotnet build Humans.slnx -v quiet`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/Humans.Web/Controllers/ProfileAdminController.cs
+git commit -m "feat(profileadmin): scaffold ProfileAdminController"
+```
+
+---
+
+### Task 19: View models for list + compare
+
+**Files:**
+- Create: `src/Humans.Web/Models/EmailProblems/EmailProblemsListViewModel.cs`
+- Create: `src/Humans.Web/Models/EmailProblems/EmailProblemsCompareViewModel.cs`
+
+- [ ] **Step 1: Write list view model**
+
+```csharp
+using Humans.Application.DTOs.EmailProblems;
+using NodaTime;
+
+namespace Humans.Web.Models.EmailProblems;
+
+public sealed class EmailProblemsListViewModel
+{
+    public Instant ScannedAt { get; init; }
+    public int TotalProblems => CrossUserConflicts.Count + SingleUserIssues.Count + SystemLevelIssues.Count;
+
+    public IReadOnlyList<CrossUserConflictRow> CrossUserConflicts { get; init; } = Array.Empty<CrossUserConflictRow>();
+    public IReadOnlyList<SingleUserIssueRow> SingleUserIssues { get; init; } = Array.Empty<SingleUserIssueRow>();
+    public IReadOnlyList<SystemLevelIssueRow> SystemLevelIssues { get; init; } = Array.Empty<SystemLevelIssueRow>();
+}
+
+public sealed record CrossUserConflictRow(
+    string Email,
+    Guid User1Id, string User1DisplayName,
+    Guid User2Id, string User2DisplayName);
+
+public sealed record SingleUserIssueRow(
+    Guid UserId, string DisplayName,
+    IReadOnlyList<string> ProblemSummaries);
+
+public sealed record SystemLevelIssueRow(
+    EmailProblemKind Kind,
+    Guid? UserEmailId,
+    Guid? UserId,
+    string Detail);
+```
+
+- [ ] **Step 2: Write compare view model**
+
+```csharp
+using Humans.Application;
+using Humans.Domain.Entities;
+
+namespace Humans.Web.Models.EmailProblems;
+
+public sealed class EmailProblemsCompareViewModel
+{
+    public required string SharedEmail { get; init; }
+    public required CompareSide Account1 { get; init; }
+    public required CompareSide Account2 { get; init; }
+}
+
+public sealed record CompareSide(
+    Guid UserId,
+    string DisplayName,
+    string? ProfilePictureUrl,
+    IReadOnlyList<UserEmailSnapshot> AllUserEmails,
+    int TeamCount,
+    int RoleAssignmentCount,
+    DateTime? LastLogin,
+    bool IsProfileComplete);
+```
+
+- [ ] **Step 3: Build**
+
+Run: `dotnet build Humans.slnx -v quiet`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Humans.Web/Models/EmailProblems/
+git commit -m "feat(profileadmin): EmailProblems list + compare view models"
+```
+
+---
+
+### Task 20: GET `/Profile/Admin/EmailProblems` — list view
+
+**Files:**
+- Modify: `src/Humans.Web/Controllers/ProfileAdminController.cs`
+- Create: `src/Humans.Web/Views/ProfileAdmin/EmailProblems.cshtml`
+
+- [ ] **Step 1: Add the GET action**
+
+Inside `ProfileAdminController`, add:
+
+```csharp
+[HttpGet("EmailProblems")]
+public async Task<IActionResult> EmailProblems(CancellationToken ct)
+{
+    var report = await _emailProblems.ScanAsync(ct);
+
+    // Map: cross-user, single-user (grouped by user), system-level.
+    var crossUser = new List<CrossUserConflictRow>();
+    var singleUserMap = new Dictionary<Guid, List<string>>();
+    var systemLevel = new List<SystemLevelIssueRow>();
+
+    var allInvolvedUserIds = report.Problems
+        .SelectMany(p => new[] { p.UserId, p.OtherUserId })
+        .OfType<Guid>()
+        .Distinct()
+        .ToList();
+    var users = await _users.GetByIdsAsync(allInvolvedUserIds, ct);
+    string DisplayName(Guid? id) =>
+        id is Guid g && users.TryGetValue(g, out var u) ? u.DisplayName : "(unknown)";
+
+    foreach (var p in report.Problems)
+    {
+        switch (p.Kind)
+        {
+            case EmailProblemKind.SharedAcrossUsers when p.UserId is Guid u1 && p.OtherUserId is Guid u2:
+                crossUser.Add(new CrossUserConflictRow(p.Email ?? "(unknown)", u1, DisplayName(u1), u2, DisplayName(u2)));
+                break;
+
+            case EmailProblemKind.MultipleIsPrimary or EmailProblemKind.MultipleIsGoogle
+                or EmailProblemKind.ZeroIsPrimary or EmailProblemKind.ZeroIsGoogle
+                or EmailProblemKind.Unverified
+                when p.UserId is Guid u:
+                if (!singleUserMap.TryGetValue(u, out var list))
+                {
+                    list = new List<string>();
+                    singleUserMap[u] = list;
+                }
+                list.Add(p.Kind switch
+                {
+                    EmailProblemKind.MultipleIsPrimary => "multiple IsPrimary",
+                    EmailProblemKind.MultipleIsGoogle => "multiple IsGoogle",
+                    EmailProblemKind.ZeroIsPrimary => "zero IsPrimary",
+                    EmailProblemKind.ZeroIsGoogle => "zero IsGoogle",
+                    EmailProblemKind.Unverified => $"unverified: {p.Email}",
+                    _ => p.Kind.ToString()
+                });
+                break;
+
+            case EmailProblemKind.OrphanUserEmail:
+                systemLevel.Add(new SystemLevelIssueRow(
+                    p.Kind, p.UserEmailId, p.UserId,
+                    $"Orphan UserEmail \"{p.Email}\" (was userId {p.UserId})"));
+                break;
+
+            case EmailProblemKind.GhostExternalLogins:
+                systemLevel.Add(new SystemLevelIssueRow(
+                    p.Kind, null, p.UserId,
+                    $"Ghost AspNetUserLogins for userId {p.UserId}"));
+                break;
+        }
+    }
+
+    var singleUser = singleUserMap
+        .Select(kvp => new SingleUserIssueRow(kvp.Key, DisplayName(kvp.Key), kvp.Value))
+        .OrderBy(r => r.DisplayName, StringComparer.OrdinalIgnoreCase)
+        .ToList();
+
+    var vm = new EmailProblemsListViewModel
+    {
+        ScannedAt = report.ScannedAt,
+        CrossUserConflicts = crossUser,
+        SingleUserIssues = singleUser,
+        SystemLevelIssues = systemLevel
+    };
+
+    return View(vm);
+}
+```
+
+- [ ] **Step 2: Add the view**
+
+`src/Humans.Web/Views/ProfileAdmin/EmailProblems.cshtml`:
+
+```cshtml
+@using Humans.Web.Models.EmailProblems
+@using Humans.Application.DTOs.EmailProblems
+@model EmailProblemsListViewModel
+@{
+    ViewData["Title"] = "Email Problems";
+}
+
+<h1>Email Problems</h1>
+<p class="text-muted">
+    Scanned at @Model.ScannedAt.ToDateTimeUtc().ToString("HH:mm:ss") · @Model.TotalProblems total problems
+</p>
+
+<h2>Cross-user conflicts</h2>
+@if (Model.CrossUserConflicts.Count == 0)
+{
+    <p class="text-success">No problems found</p>
+}
+else
+{
+    <table class="table">
+        <thead>
+            <tr><th>Email</th><th>User A</th><th>User B</th><th></th></tr>
+        </thead>
+        <tbody>
+            @foreach (var row in Model.CrossUserConflicts)
+            {
+                <tr>
+                    <td><code>@row.Email</code></td>
+                    <td>@row.User1DisplayName</td>
+                    <td>@row.User2DisplayName</td>
+                    <td>
+                        <a class="btn btn-sm btn-primary"
+                           asp-action="EmailProblemsCompare"
+                           asp-route-userId1="@row.User1Id"
+                           asp-route-userId2="@row.User2Id">Compare</a>
+                    </td>
+                </tr>
+            }
+        </tbody>
+    </table>
+}
+
+<h2>Single-user issues</h2>
+@if (Model.SingleUserIssues.Count == 0)
+{
+    <p class="text-success">No problems found</p>
+}
+else
+{
+    <table class="table">
+        <thead><tr><th>User</th><th>Problems</th><th></th></tr></thead>
+        <tbody>
+            @foreach (var row in Model.SingleUserIssues)
+            {
+                <tr>
+                    <td>@row.DisplayName</td>
+                    <td>@string.Join(", ", row.ProblemSummaries)</td>
+                    <td>
+                        <a class="btn btn-sm btn-secondary"
+                           href="/Profile/@row.UserId/Admin/Emails">Open emails ▸</a>
+                    </td>
+                </tr>
+            }
+        </tbody>
+    </table>
+}
+
+<h2>System-level issues</h2>
+@if (Model.SystemLevelIssues.Count == 0)
+{
+    <p class="text-success">No problems found</p>
+}
+else
+{
+    <table class="table">
+        <thead><tr><th>Issue</th><th></th></tr></thead>
+        <tbody>
+            @foreach (var row in Model.SystemLevelIssues)
+            {
+                <tr>
+                    <td>@row.Detail</td>
+                    <td>
+                        @if (row.Kind == EmailProblemKind.OrphanUserEmail)
+                        {
+                            <form method="post" asp-action="DeleteOrphanEmail"
+                                  onsubmit="return confirm('Delete orphan UserEmail row? This is irreversible.');"
+                                  class="d-inline">
+                                @Html.AntiForgeryToken()
+                                <input type="hidden" name="emailId" value="@row.UserEmailId" />
+                                <button type="submit" class="btn btn-sm btn-danger">Delete row ✕</button>
+                            </form>
+                        }
+                        else if (row.Kind == EmailProblemKind.GhostExternalLogins)
+                        {
+                            <form method="post" asp-action="DeleteGhostLogins"
+                                  onsubmit="return confirm('Delete ghost AspNetUserLogins rows? This is irreversible.');"
+                                  class="d-inline">
+                                @Html.AntiForgeryToken()
+                                <input type="hidden" name="userId" value="@row.UserId" />
+                                <button type="submit" class="btn btn-sm btn-danger">Delete logins ✕</button>
+                            </form>
+                        }
+                    </td>
+                </tr>
+            }
+        </tbody>
+    </table>
+}
+```
+
+- [ ] **Step 3: Build, run app locally, navigate to `/Profile/Admin/EmailProblems` as an admin**
+
+Run: `dotnet build Humans.slnx -v quiet`
+Manual: `dotnet run --project src/Humans.Web` then visit `https://localhost:<port>/Profile/Admin/EmailProblems` signed in as an admin. Page should render with three sections.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Humans.Web/Controllers/ProfileAdminController.cs \
+        src/Humans.Web/Views/ProfileAdmin/EmailProblems.cshtml
+git commit -m "feat(profileadmin): EmailProblems list view (cases 1–8 grouped)"
+```
+
+---
+
+### Task 21: GET `/Profile/Admin/EmailProblems/Compare`
+
+**Files:**
+- Modify: `src/Humans.Web/Controllers/ProfileAdminController.cs`
+- Create: `src/Humans.Web/Views/ProfileAdmin/EmailProblemsCompare.cshtml`
+
+- [ ] **Step 1: Add the action**
+
+```csharp
+[HttpGet("EmailProblems/Compare")]
+public async Task<IActionResult> EmailProblemsCompare(Guid userId1, Guid userId2, CancellationToken ct)
+{
+    if (userId1 == userId2)
+    {
+        SetError("Cannot compare a user against themselves.");
+        return RedirectToAction(nameof(EmailProblems));
+    }
+
+    var ids = new[] { userId1, userId2 };
+    var users = await _users.GetByIdsAsync(ids, ct);
+    if (!users.TryGetValue(userId1, out var u1) || !users.TryGetValue(userId2, out var u2))
+    {
+        SetError("One or both users not found.");
+        return RedirectToAction(nameof(EmailProblems));
+    }
+
+    // Pull each user's full email list via the FullProfile cache (no repo).
+    var profiles = await _profileService.GetFullProfileSnapshotAsync(ct);
+    var byUser = profiles.ToDictionary(p => p.UserId);
+    byUser.TryGetValue(userId1, out var p1);
+    byUser.TryGetValue(userId2, out var p2);
+
+    // Find shared email for the heading.
+    var sharedEmail = (p1?.AllUserEmails ?? Array.Empty<UserEmailSnapshot>())
+        .Select(e => e.Email)
+        .Intersect((p2?.AllUserEmails ?? Array.Empty<UserEmailSnapshot>()).Select(e => e.Email),
+                   StringComparer.OrdinalIgnoreCase)
+        .FirstOrDefault() ?? "(no exact match — see normalized)";
+
+    CompareSide BuildSide(User user, FullProfile? profile, int teamCount, int roleCount) =>
+        new(user.Id, user.DisplayName, user.ProfilePictureUrl,
+            profile?.AllUserEmails ?? Array.Empty<UserEmailSnapshot>(),
+            teamCount, roleCount,
+            user.LastLoginAt?.ToDateTimeUtc(),
+            !string.IsNullOrEmpty(profile?.BurnerName));
+
+    // For TeamCount + RoleAssignmentCount, mirror what AdminDuplicateAccountsController does.
+    // Read from existing services — do NOT add new ones here.
+    var memberships1 = await _teamService.GetUserTeamsAsync(userId1, ct);
+    var memberships2 = await _teamService.GetUserTeamsAsync(userId2, ct);
+    var roles1 = await _roleAssignmentService.GetByUserIdAsync(userId1, ct);
+    var roles2 = await _roleAssignmentService.GetByUserIdAsync(userId2, ct);
+
+    var vm = new EmailProblemsCompareViewModel
+    {
+        SharedEmail = sharedEmail,
+        Account1 = BuildSide(u1, p1,
+            memberships1.Count(m => m.LeftAt is null),
+            roles1.Count(r => r.ValidTo is null)),
+        Account2 = BuildSide(u2, p2,
+            memberships2.Count(m => m.LeftAt is null),
+            roles2.Count(r => r.ValidTo is null))
+    };
+
+    return View(vm);
+}
+```
+
+(Add `IProfileService _profileService`, `ITeamService _teamService`, `IRoleAssignmentService _roleAssignmentService` injections to the constructor.)
+
+- [ ] **Step 2: Add the view**
+
+`src/Humans.Web/Views/ProfileAdmin/EmailProblemsCompare.cshtml`:
+
+```cshtml
+@using Humans.Web.Models.EmailProblems
+@model EmailProblemsCompareViewModel
+@{
+    ViewData["Title"] = "Compare accounts";
+}
+
+<h1>Compare for shared email</h1>
+<p class="text-muted">Shared email: <code>@Model.SharedEmail</code></p>
+
+<form method="post" asp-action="Merge"
+      onsubmit="return confirm('Merge these accounts? The selected SOURCE will be tombstoned. This is irreversible.');">
+    @Html.AntiForgeryToken()
+
+    <div class="row">
+        @foreach (var (side, label, isLeft) in new[] {
+            (Model.Account1, "Account A", true),
+            (Model.Account2, "Account B", false) })
+        {
+            <div class="col-md-6">
+                <h2>@label — @side.DisplayName</h2>
+                <p>
+                    Teams: @side.TeamCount · Roles: @side.RoleAssignmentCount
+                    · Last login: @(side.LastLogin?.ToString("yyyy-MM-dd") ?? "—")
+                    · Profile complete: @(side.IsProfileComplete ? "yes" : "no")
+                </p>
+
+                <table class="table table-sm">
+                    <thead>
+                        <tr><th>Email</th><th>Verified</th><th>Primary</th><th>Google</th></tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var e in side.AllUserEmails)
+                        {
+                            <tr>
+                                <td><code>@e.Email</code></td>
+                                <td>@(e.IsVerified ? "✓" : "")</td>
+                                <td>@(e.IsPrimary ? "✓" : "")</td>
+                                <td>@(e.IsGoogle ? "✓" : "")</td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+
+                <label class="form-check">
+                    <input class="form-check-input" type="radio" name="targetUserId" value="@side.UserId" required />
+                    Keep <strong>@side.DisplayName</strong> as target
+                </label>
+            </div>
+        }
+    </div>
+
+    <div class="mt-3">
+        <label for="notes" class="form-label">Admin notes (optional)</label>
+        <textarea id="notes" name="notes" class="form-control" rows="2"></textarea>
+    </div>
+
+    <input type="hidden" name="user1Id" value="@Model.Account1.UserId" />
+    <input type="hidden" name="user2Id" value="@Model.Account2.UserId" />
+
+    <button type="submit" class="btn btn-danger mt-3">Merge</button>
+    <a class="btn btn-secondary mt-3" asp-action="EmailProblems">Cancel</a>
+</form>
+```
+
+- [ ] **Step 3: Build, manually navigate to `Compare?userId1=...&userId2=...` for a known case 5 pair**
+
+Run: `dotnet build Humans.slnx -v quiet`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Humans.Web/Controllers/ProfileAdminController.cs \
+        src/Humans.Web/Views/ProfileAdmin/EmailProblemsCompare.cshtml
+git commit -m "feat(profileadmin): EmailProblems Compare view (case 5 detail)"
+```
+
+---
+
+### Task 22: POST `/Profile/Admin/EmailProblems/Merge`
+
+**Files:**
+- Modify: `src/Humans.Web/Controllers/ProfileAdminController.cs`
+
+- [ ] **Step 1: Add the action**
+
+```csharp
+[HttpPost("EmailProblems/Merge")]
+[ValidateAntiForgeryToken]
+public async Task<IActionResult> Merge(
+    Guid user1Id, Guid user2Id, Guid targetUserId, string? notes,
+    CancellationToken ct)
+{
+    var (error, currentUser) = await RequireCurrentUserAsync();
+    if (error is not null) return error;
+
+    Guid sourceUserId;
+    if (targetUserId == user1Id) sourceUserId = user2Id;
+    else if (targetUserId == user2Id) sourceUserId = user1Id;
+    else
+    {
+        SetError("Target must be one of the two compared accounts.");
+        return RedirectToAction(nameof(EmailProblemsCompare),
+            new { userId1 = user1Id, userId2 = user2Id });
+    }
+
+    try
+    {
+        await _accountMerge.AdminMergeAsync(sourceUserId, targetUserId, currentUser.Id, notes, ct);
+        SetSuccess("Accounts merged. The source account has been tombstoned.");
+        return RedirectToAction(nameof(EmailProblems));
+    }
+    catch (InvalidOperationException ex)
+    {
+        _logger.LogError(ex, "Admin-initiated merge failed: source {Source}, target {Target}",
+            sourceUserId, targetUserId);
+        SetError($"Merge failed: {ex.Message}");
+        return RedirectToAction(nameof(EmailProblemsCompare),
+            new { userId1 = user1Id, userId2 = user2Id });
+    }
+}
+```
+
+- [ ] **Step 2: Build**
+
+Run: `dotnet build Humans.slnx -v quiet`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/Humans.Web/Controllers/ProfileAdminController.cs
+git commit -m "feat(profileadmin): POST EmailProblems/Merge"
+```
+
+---
+
+### Task 23: POST `/Profile/Admin/EmailProblems/DeleteOrphanEmail`
+
+**Files:**
+- Modify: `src/Humans.Application/Interfaces/Profiles/IUserEmailService.cs`
+- Modify: `src/Humans.Application/Services/Profile/UserEmailService.cs`
+- Modify: `src/Humans.Web/Controllers/ProfileAdminController.cs`
+
+- [ ] **Step 1: Add a service method to delete an orphan by email id**
+
+In `IUserEmailService.cs`:
+
+```csharp
+/// <summary>
+/// Deletes a single UserEmail row by id. Used by EmailProblems orphan cleanup.
+/// Idempotent — returns false if the row no longer exists.
+/// </summary>
+Task<bool> DeleteByIdAsync(Guid emailId, CancellationToken ct = default);
+```
+
+In `UserEmailService.cs`:
+
+```csharp
+public Task<bool> DeleteByIdAsync(Guid emailId, CancellationToken ct = default) =>
+    _repository.RemoveByIdAsync(emailId, ct);
+```
+
+(`RemoveByIdAsync` already exists on `IUserEmailRepository` per existing code reading.)
+
+- [ ] **Step 2: Add the controller action**
+
+```csharp
+[HttpPost("EmailProblems/DeleteOrphanEmail")]
+[ValidateAntiForgeryToken]
+public async Task<IActionResult> DeleteOrphanEmail(Guid emailId, CancellationToken ct)
+{
+    var (error, currentUser) = await RequireCurrentUserAsync();
+    if (error is not null) return error;
+
+    var deleted = await _userEmails.DeleteByIdAsync(emailId, ct);
+    if (deleted)
+    {
+        await _audit.LogAsync(
+            AuditAction.OrphanUserEmailDeleted, nameof(UserEmail), emailId,
+            $"Orphan UserEmail row {emailId} deleted by EmailProblems action",
+            currentUser.Id);
+        SetSuccess("Orphan email row deleted.");
+    }
+    else
+    {
+        SetInfo("Already cleaned up — no row to delete.");
+    }
+    return RedirectToAction(nameof(EmailProblems));
+}
+```
+
+- [ ] **Step 3: Build**
+
+Run: `dotnet build Humans.slnx -v quiet`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Humans.Application/Interfaces/Profiles/IUserEmailService.cs \
+        src/Humans.Application/Services/Profile/UserEmailService.cs \
+        src/Humans.Web/Controllers/ProfileAdminController.cs
+git commit -m "feat(profileadmin): POST EmailProblems/DeleteOrphanEmail"
+```
+
+---
+
+### Task 24: POST `/Profile/Admin/EmailProblems/DeleteGhostLogins`
+
+**Files:**
+- Modify: `src/Humans.Application/Interfaces/Repositories/IUserRepository.cs`
+- Modify: `src/Humans.Infrastructure/Repositories/Users/UserRepository.cs`
+- Modify: `src/Humans.Application/Interfaces/Users/IUserService.cs`
+- Modify: `src/Humans.Application/Services/Users/UserService.cs`
+- Modify: `src/Humans.Web/Controllers/ProfileAdminController.cs`
+
+- [ ] **Step 1: Add repo method**
+
+In `IUserRepository.cs`:
+
+```csharp
+/// <summary>
+/// Deletes every <c>AspNetUserLogins</c> row for the given user. Returns the
+/// number of rows deleted. Used by EmailProblems ghost-login cleanup.
+/// </summary>
+Task<int> DeleteAllExternalLoginsForUserAsync(Guid userId, CancellationToken ct = default);
+```
+
+In `UserRepository.cs`:
+
+```csharp
+public async Task<int> DeleteAllExternalLoginsForUserAsync(Guid userId, CancellationToken ct = default)
+{
+    using var ctx = await _contextFactory.CreateDbContextAsync(ct);
+    return await ctx.UserLogins
+        .Where(l => l.UserId == userId)
+        .ExecuteDeleteAsync(ct);
+}
+```
+
+- [ ] **Step 2: Pass-through on `IUserService` / `UserService`**
+
+```csharp
+// IUserService
+Task<int> DeleteAllExternalLoginsForUserAsync(Guid userId, CancellationToken ct = default);
+
+// UserService
+public Task<int> DeleteAllExternalLoginsForUserAsync(Guid userId, CancellationToken ct = default) =>
+    _repo.DeleteAllExternalLoginsForUserAsync(userId, ct);
+```
+
+- [ ] **Step 3: Add the controller action**
+
+```csharp
+[HttpPost("EmailProblems/DeleteGhostLogins")]
+[ValidateAntiForgeryToken]
+public async Task<IActionResult> DeleteGhostLogins(Guid userId, CancellationToken ct)
+{
+    var (error, currentUser) = await RequireCurrentUserAsync();
+    if (error is not null) return error;
+
+    var count = await _users.DeleteAllExternalLoginsForUserAsync(userId, ct);
+    if (count > 0)
+    {
+        await _audit.LogAsync(
+            AuditAction.GhostExternalLoginsDeleted, nameof(User), userId,
+            $"Deleted {count} ghost AspNetUserLogins row(s) for userId {userId}",
+            currentUser.Id);
+        SetSuccess($"Deleted {count} ghost login row(s).");
+    }
+    else
+    {
+        SetInfo("Already cleaned up — no rows to delete.");
+    }
+    return RedirectToAction(nameof(EmailProblems));
+}
+```
+
+- [ ] **Step 4: Build**
+
+Run: `dotnet build Humans.slnx -v quiet`
+Expected: PASS.
+
+- [ ] **Step 5: Commit + push the controller phase**
+
+```bash
+git add src/Humans.Application/Interfaces/Repositories/IUserRepository.cs \
+        src/Humans.Infrastructure/Repositories/Users/UserRepository.cs \
+        src/Humans.Application/Interfaces/Users/IUserService.cs \
+        src/Humans.Application/Services/Users/UserService.cs \
+        src/Humans.Web/Controllers/ProfileAdminController.cs
+git commit -m "feat(profileadmin): POST EmailProblems/DeleteGhostLogins"
+git push
+```
+
+---
+
+### Task 25: Controller tests — AdminOnly enforcement + happy paths
+
+**Files:**
+- Create: `tests/Humans.Application.Tests/Controllers/ProfileAdminControllerTests.cs`
+
+- [ ] **Step 1: Read existing controller test patterns** (e.g., `ProfileControllerEmailGridTests.cs`) to match wiring style.
+
+- [ ] **Step 2: Write the test class**
+
+```csharp
+using FluentAssertions;
+using Humans.Application.DTOs.EmailProblems;
+using Humans.Application.Interfaces.AuditLog;
+using Humans.Application.Interfaces.Profiles;
+using Humans.Application.Interfaces.Users;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using Humans.Web.Controllers;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NodaTime;
+using NodaTime.Testing;
+using Xunit;
+
+namespace Humans.Application.Tests.Controllers;
+
+public class ProfileAdminControllerTests
+{
+    // Test 1: GET EmailProblems calls scan, returns view with vm
+    // Test 2: POST Merge with target == user1Id calls AdminMergeAsync(user2Id → user1Id)
+    // Test 3: POST Merge with target not in pair → redirect with error, no merge call
+    // Test 4: POST DeleteOrphanEmail success → audit logged, success toast
+    // Test 5: POST DeleteOrphanEmail row missing → info toast, no audit
+    // Test 6: POST DeleteGhostLogins success → audit logged with count
+    //
+    // Each test wires UserManager<User>, IEmailProblemsService, IAccountMergeService,
+    // IUserEmailService, IUserService, IAuditLogService mocks; instantiates
+    // ProfileAdminController; calls the action; asserts on returned IActionResult
+    // and Mock.Verify calls.
+}
+```
+
+(Flesh out each scenario per the comments. The exact mock wiring will mirror an existing test file in the same folder — copy its `BuildController()` helper and adjust.)
+
+- [ ] **Step 3: Run, expect pass**
+
+Run: `dotnet test Humans.slnx -v quiet --filter "FullyQualifiedName~ProfileAdminControllerTests"`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/Humans.Application.Tests/Controllers/ProfileAdminControllerTests.cs
+git commit -m "test(profileadmin): controller tests for EmailProblems + actions"
+```
+
+---
+
+## Phase 5 — Wire-up + docs
+
+### Task 26: Add the admin nav link
+
+**Files:**
+- Modify: existing admin nav source — search for where `/Admin/DuplicateAccounts` is linked from. Likely `src/Humans.Web/ViewComponents/AdminNavTree.cs` (matched in Phase 1 grep).
+
+- [ ] **Step 1: Read `src/Humans.Web/ViewComponents/AdminNavTree.cs` to find how existing admin entries are added**
+
+- [ ] **Step 2: Add an entry for `/Profile/Admin/EmailProblems` under the same parent (likely "Profiles" or "Admin → Profiles")**
+
+Match the existing entry shape exactly. Title: "Email Problems".
+
+- [ ] **Step 3: Build, run app, confirm link appears in admin nav and routes correctly**
+
+Run: `dotnet build Humans.slnx -v quiet`
+Manual: `dotnet run --project src/Humans.Web` then visit a page that shows the admin nav while signed in as admin.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Humans.Web/ViewComponents/AdminNavTree.cs
+git commit -m "feat(profileadmin): link EmailProblems from admin nav"
+```
+
+---
+
+### Task 27: Update `docs/sections/Profiles.md` route table
+
+**Files:**
+- Modify: `docs/sections/Profiles.md`
+
+- [ ] **Step 1: In the "Routing" section, add an entry under the existing `/Profile/Admin` block**
+
+```markdown
+| `/Profile/Admin/EmailProblems` | List UserEmail invariant violations across all accounts (`ProfileAdminController`) |
+| `/Profile/Admin/EmailProblems/Compare` | Side-by-side detail for a case-5 cross-user email collision |
+| `/Profile/Admin/EmailProblems/Merge` | POST — admin-initiated merge via `IAccountMergeService.AdminMergeAsync` |
+| `/Profile/Admin/EmailProblems/DeleteOrphanEmail` | POST — delete a single orphan UserEmail row |
+| `/Profile/Admin/EmailProblems/DeleteGhostLogins` | POST — delete every AspNetUserLogins row for a userId with no UserEmails |
+```
+
+- [ ] **Step 2: In "Concepts", add a one-liner near "Duplicate Account Detection"**
+
+```markdown
+- **Email Problems** scans every UserEmail invariant violation (multi/zero IsPrimary or IsGoogle, unverified rows, cross-user collisions, orphan rows, ghost AspNetUserLogins). Reads source-of-truth from the `FullProfile` cache. Read-only-plus-three-actions admin surface; the cross-user merge action shares its kernel with `IAccountMergeService.AcceptAsync`.
+```
+
+- [ ] **Step 3: Update the "Architecture > Owning services" line** to include `EmailProblemsService`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/sections/Profiles.md
+git commit -m "docs(profile): document /Profile/Admin/EmailProblems"
+```
+
+---
+
+### Task 28: Final build + manual smoke
+
+- [ ] **Step 1: Full build**
+
+Run: `dotnet build Humans.slnx -v quiet`
+Expected: PASS.
+
+- [ ] **Step 2: Full test suite**
+
+Run: `dotnet test Humans.slnx -v quiet`
+Expected: PASS.
+
+- [ ] **Step 3: Run app, sign in as admin, walk all 8 cases**
+
+```bash
+dotnet run --project src/Humans.Web
+```
+
+For each case:
+- Seed a violating row in dev DB (or use existing real data)
+- Visit `/Profile/Admin/EmailProblems`
+- Confirm the case shows in the right section (cross-user / single-user / system-level)
+- For case 5: click Compare, confirm side-by-side renders all UserEmail rows with badges, no `User.Email` shown anywhere
+- For case 5: pick a target, click Merge, confirm the source is tombstoned and one UserEmail row remains per email
+- For case 7: click Delete row, confirm orphan removed
+- For case 8: click Delete logins, confirm AspNetUserLogins rows removed
+- Confirm "No problems found" appears in any section that has no problems
+
+- [ ] **Step 4: Push final state**
+
+```bash
+git push
+```
+
+- [ ] **Step 5: Open PR to peter's `main`**
+
+Use `gh pr create` against `peterdrier/Humans:main`. Title: `issue-660: /Profile/Admin/EmailProblems page`. Body summarizes the 8 cases + the kernel extraction + the link to the spec doc on this branch.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** every spec section maps to at least one task. Cases 1–8 each have a TDD task. Kernel extraction in Task 15. AdminMergeAsync in Task 16. Compare page in Task 21. Audit actions added in Task 6 and used in Tasks 23/24. Architecture test in Task 14.
+- **Type consistency:** `EmailProblem.UserEmailId` (Guid?) used in tasks 7/10/12 matches usage in 20/23. `EmailProblemKind` enum stable across tasks. `AuditEntry` record introduced in Task 15 reused by Task 16.
+- **One ambiguity acknowledged in-plan:** Task 15 leaves the choice between "two scopes" and "callback into FoldAsync" up to the implementer with explicit constraints; both produce identical observable behavior. This is a deliberate flexibility, not a placeholder.
+- **No raw `User.Email` reads** in any task. Compare view (Task 21) explicitly uses `FullProfile.AllUserEmails`.

--- a/docs/superpowers/specs/2026-05-05-email-problems-page-design.md
+++ b/docs/superpowers/specs/2026-05-05-email-problems-page-design.md
@@ -1,0 +1,154 @@
+# EmailProblems Admin Page — Design
+
+**Issue:** [#660 — Add /Profile/Admin/EmailProblems page with consolidating merge action](https://github.com/nobodies-collective/Humans/issues/660)
+**Date:** 2026-05-05
+**Status:** Approved (brainstorm)
+
+## Problem
+
+`/Admin/DuplicateAccounts` predates the Profile/UserEmail rework and is confusing — it mixes `User.Email` (an Identity-internals copy) with the actual `UserEmail` rows. It only flags shared-email duplicates; many other UserEmail invariant violations sit silently in the database.
+
+A new admin page surfaces every UserEmail invariant violation, scoped through the existing Profile-section infrastructure (no new direct database access).
+
+The fundamental rule: **an email address belongs to exactly one user**, and each user has consistent `UserEmail` flags.
+
+## Scope — cases scanned
+
+1. User has multiple `IsPrimary` UserEmails
+2. User has multiple `IsGoogle` UserEmails
+3. User has zero `IsPrimary` UserEmails (with at least one verified row)
+4. User has zero `IsGoogle` UserEmails
+5. Two users sharing a UserEmail address (raw match OR normalization-equivalent — gmail/googlemail dot tricks)
+6. Any unverified UserEmail (regardless of `IsPrimary`/`IsGoogle`)
+7. Orphan UserEmail rows (UserId points to a tombstoned/anonymized user)
+8. Users with `AspNetUserLogins` rows but zero UserEmail rows (ghost auth artifact — should be empty after issue #661 lands; scan to catch existing damage)
+
+Empty result is the goal. Scan all users — missing a check hides problems.
+
+## Architecture
+
+### Routing & section ownership
+
+- New page: `GET /Profile/Admin/EmailProblems` — `AdminOnly` policy. Profiles section.
+- New controller: `Humans.Web/Controllers/ProfileAdminController.cs` (room to absorb other Profile-admin actions later; `ProfileBackfillAdminController` is **not** folded in this PR).
+- Compare detail page: `GET /Profile/Admin/EmailProblems/Compare?userId1=...&userId2=...`
+- Action endpoints (all AdminOnly, all `[ValidateAntiForgeryToken]`):
+  - `POST /Profile/Admin/EmailProblems/Merge` (sourceUserId, targetUserId, notes)
+  - `POST /Profile/Admin/EmailProblems/DeleteOrphanEmail` (emailId)
+  - `POST /Profile/Admin/EmailProblems/DeleteGhostLogins` (userId)
+- Existing `/Admin/DuplicateAccounts` page stays untouched until retired manually.
+
+### Detection service — no direct DB access
+
+- New service: `IEmailProblemsService` in `Humans.Application/Interfaces/Profiles/`, impl in `Humans.Application/Services/Profile/`.
+- Single method: `Task<EmailProblemsReport> ScanAsync(CancellationToken ct = default)`.
+- Consumes only existing section services — **never any `I*Repository` or `DbContext`**:
+  - `IProfileService` — primary source via the `FullProfile` cache snapshot (existing pattern: `GetBirthdayProfilesFromSnapshot`, `SearchApprovedUsersFromSnapshot`).
+  - `IUserEmailService` — for orphan detection (rows whose UserId is not in the FullProfile cache).
+  - `IUserService` — for ghost-AspNetUserLogins detection (case 8).
+- Live scan on every page load. At ~500 users, the FullProfile cache snapshot enumeration is trivial.
+
+### Required additions to existing surfaces
+
+- **`FullProfile` record** — extend to carry `IReadOnlyList<UserEmailSnapshot> UserEmails`, where `UserEmailSnapshot` is a small record `(Guid Id, string Email, bool IsVerified, bool IsPrimary, bool IsGoogle)`. The full rows are already loaded inside `FullProfile.Create` and discarded after deriving `PrimaryEmail`/`AllVerifiedEmails`/`GoogleEmail`; we retain them. Existing derived fields stay.
+- **`IProfileService.GetFullProfileSnapshotAsync()`** → returns `_byUserId.Values` snapshot from `CachingProfileService`. Same pattern as existing snapshot-returning methods.
+- **`IUserEmailService.GetOrphanUserEmailsAsync()`** → returns UserEmail rows whose UserId points to a non-existent or tombstoned User (`MergedToUserId is not null` OR User row absent). Implementation may use the FullProfile cache as the "live users" set. Service-layer scan, no new repo method.
+- **`IUserService.GetUsersWithLoginsButNoEmailsAsync()`** → returns userIds for case 8.
+
+### Merge kernel extraction
+
+In `AccountMergeService`, refactor `AcceptAsync` to extract a private `FoldAsync` kernel:
+
+```csharp
+private async Task FoldAsync(
+    Guid sourceUserId, Guid targetUserId,
+    Guid adminUserId, AuditEntry audit,
+    CancellationToken ct);
+```
+
+`FoldAsync` runs the `IUserMerge` fan-out (Teams, Roles, UserEmail-via-`ReassignToUserAsync`, Shifts, Notifications, etc.), tombstones source via `IUserService.AnonymizeForMergeAsync`, and writes the audit row — all inside one ambient `TransactionScope`. The audit entity type / id / description differ per caller (`AcceptAsync` audits against `AccountMergeRequest`; `AdminMergeAsync` audits against `User`), so the kernel takes a small `AuditEntry(AuditAction action, string entityType, Guid entityId, string description)` parameter rather than building the audit string itself.
+
+Two entry points call it:
+
+- **Existing `AcceptAsync(requestId, ...)`** — loads + validates the `AccountMergeRequest`, calls `FoldAsync`, then runs the request-specific `MarkVerifiedAsync(request.PendingEmailId)` step and updates request status. Signature unchanged.
+- **NEW `AdminMergeAsync(sourceUserId, targetUserId, adminUserId, notes, ct)`** — pre-flight (source != target, both exist, neither already tombstoned), calls `FoldAsync`. No request row, no `MarkVerifiedAsync`. Notes prefixed "Admin-initiated via EmailProblems" so the audit trail is unambiguous.
+
+UserEmail consolidation (collapse duplicate addresses, OR-combine `IsVerified`, clear `IsPrimary`/`IsGoogle` on incoming rows) already happens inside `IUserEmailRepository.ReassignToUserAsync`. No new merge-time logic needed for that.
+
+`DuplicateAccountService.ResolveAsync` and `/Admin/DuplicateAccounts` are left untouched.
+
+## Page UX
+
+Hybrid layout (cross-user → single-user → system-level):
+
+**Top: Cross-user conflicts (case 5)** — most critical
+- One row per email collision: `email — User A ⇄ User B  [Compare]`
+- "Compare" links to the Compare detail page.
+
+**Middle: Single-user issues (cases 1, 2, 3, 4, 6)** — operator opens user's existing admin page
+- One row per affected user, problems collapsed into a comma list.
+- `User Name — multiple IsPrimary, 1 unverified  [Open emails ▸]`
+- "Open emails" links to existing `/Profile/{id}/Admin/Emails`. No new fix UI on this page.
+
+**Bottom: System-level issues (cases 7, 8)** — no live user, inline action
+- `Orphan UserEmail "joe@old.com" (was userId xyz)  [Delete row ✕]`
+- `Ghost AspNetUserLogins for userId xyz (3 rows)  [Delete logins ✕]`
+- Each destructive action shows a confirm dialog before POST.
+
+**Empty-state per section:** "No problems found" (proves we scanned).
+
+**Header:** "Scanned at HH:MM:SS · N total problems".
+
+### Compare page (`/Profile/Admin/EmailProblems/Compare`)
+
+Side-by-side, two columns:
+- Per side: display name, **complete UserEmail list** (every row, with `IsVerified`/`IsPrimary`/`IsGoogle` badges), team count, role count, last login, profile completeness — same data the existing `DuplicateAccountDetailViewModel` shows.
+- Single action: "Merge: keep [User A] / [User B] as target" — radio + notes textbox + `[Merge]` button → confirm dialog → `POST /Profile/Admin/EmailProblems/Merge` → calls `AccountMergeService.AdminMergeAsync(sourceUserId, targetUserId, ...)`.
+- **Never display `User.Email`** anywhere on the page.
+
+## Authorization, audit, error handling
+
+**Authorization:** `[Authorize(Policy = PolicyNames.AdminOnly)]` on the controller. All POST actions `[ValidateAntiForgeryToken]`.
+
+**Audit:**
+- `Merge` → existing `AuditAction.AccountMergeAccepted` written by `FoldAsync`, notes prefixed "Admin-initiated via EmailProblems".
+- `DeleteOrphanEmail` → new `AuditAction.OrphanUserEmailDeleted`, entity `UserEmail`, description includes email + dangling userId.
+- `DeleteGhostLogins` → new `AuditAction.GhostExternalLoginsDeleted`, entity `User`, description includes userId + count.
+
+**Error handling:**
+- `AdminMergeAsync` pre-flight throws `InvalidOperationException` for source==target, missing user, or already-tombstoned source. Controller catches, sets error toast, redirects.
+- Orphan / ghost-logins delete: idempotent — already-gone returns success with "already cleaned up" info toast.
+- Scan failures: bubble; standard error page. No partial-results UI.
+
+**Concurrency:** Single admin operates this surface — no contention to design around.
+
+## Testing
+
+**Unit (`tests/Humans.Application.Tests/Services/Profile/EmailProblemsServiceTests.cs`)**
+- One test per case (1–8): seed FullProfile cache snapshot + service stubs to produce the violation, assert the report contains exactly the expected entry.
+- Empty snapshot → empty report.
+- Normalization-equivalent collision test for case 5 (`joe@gmail.com` vs `j.oe@googlemail.com`).
+
+**Unit (`tests/Humans.Application.Tests/Services/Profile/AccountMergeServiceTests.cs`)**
+- Existing `AcceptAsync` tests stay green.
+- `AdminMergeAsync` happy path: all `IUserMerge` impls invoked, source tombstoned, audit row written, no `MarkVerifiedAsync` call.
+- `AdminMergeAsync` source==target → `InvalidOperationException`, no writes.
+- `AdminMergeAsync` source already tombstoned → `InvalidOperationException`, no writes.
+
+**Integration (`tests/Humans.Integration.Tests/AccountMerge/AdminMergeAsyncTests.cs`)**
+- Full-fixture admin-initiated merge: two real users with overlapping UserEmails → exactly one row per email on target post-merge, source has zero UserEmail and zero AspNetUserLogins, target's pre-existing `IsPrimary`/`IsGoogle` selections preserved.
+
+**Controller (`tests/Humans.Application.Tests/Controllers/ProfileAdminControllerTests.cs`)**
+- AdminOnly policy enforcement.
+- POST endpoints: missing antiforgery → reject; success → audit + redirect with toast.
+
+**Architecture**
+- Add a focused test asserting `EmailProblemsService` constructor only depends on `IProfileService`, `IUserEmailService`, `IUserService` (no `I*Repository` types). Locks in the "use existing infra, no exceptions" rule.
+- Existing `ProfileArchitectureTests` already enforces no `Microsoft.EntityFrameworkCore` imports in services — automatic coverage for the new service.
+
+## Out of scope
+
+- Retiring `/Admin/DuplicateAccounts` (manual decision once new page surfaces zero issues).
+- Folding `ProfileBackfillAdminController` into `ProfileAdminController`.
+- Issue #661 (anonymization deletes AspNetUserLogins) — separate, shippable independently. Case 8 detection here serves as the safety net for existing damage.
+- Per-case fix actions for cases 1, 2, 3, 4, 6 — handled by linking to existing `/Profile/{id}/Admin/Emails` surface, not by new UI.

--- a/memory/INDEX.md
+++ b/memory/INDEX.md
@@ -84,6 +84,7 @@ Atomic rules. Fetch the body when the description's trigger matches your task. S
 - [`pr-codex-thread-replies`](process/pr-codex-thread-replies.md) — reply per Codex inline thread (`POST /pulls/{n}/comments/{id}/replies`), not as top-level PR comment
 - [`pr-done-means-codex-clean`](process/pr-done-means-codex-clean.md) — a PR isn't "done" until Codex returns no findings; pushed+green is mid-state
 - [`pr-no-ping-reviewers`](process/pr-no-ping-reviewers.md) — don't `@codex review` after pushes; quota is limited, Claude reviews on push automatically
+- [`pr-resolve-declined-when-authorized`](process/pr-resolve-declined-when-authorized.md) — in /pr-fix, "decline because Peter authorized" → resolve the thread; leave-open is for technically-wrong findings only
 - [`pr-review-both-repos`](process/pr-review-both-repos.md) — pull comments from BOTH `peterdrier/Humans` AND `nobodies-collective/Humans`; use `/pulls/{n}/comments` for inline
 - [`privilege-changes-need-explicit-approval`](process/privilege-changes-need-explicit-approval.md) — HARD RULE. Any change granting users new/elevated capability (Drive role bumps, auth-scope additions, role grants, admin flags, default permission tiers, CORS/allowlist expansions) needs Peter's explicit per-change approval before implementation, regardless of issue tier or sprint plan
 - [`rules-maintenance`](process/rules-maintenance.md) — when a new project rule surfaces, capture as `memory/<bucket>/<name>.md` + INDEX entry in the same commit. Not external memory.

--- a/memory/process/pr-resolve-declined-when-authorized.md
+++ b/memory/process/pr-resolve-declined-when-authorized.md
@@ -1,0 +1,14 @@
+---
+name: Resolve declined PR threads when Peter has authorized the deviation
+description: In `/pr-fix`, "decline because Peter authorized" → resolve the thread; reserve leave-open behavior for technically-wrong findings.
+---
+
+When `/pr-fix` triages a review-bot finding as "decline because Peter authorized" (e.g., budget bumps acknowledged in the PR body, or a "leave at N" answer to `AskUserQuestion`), **resolve the thread** in the same step as posting the reply.
+
+**Why:** The pr-fix skill's default "leave INVALID open so reviewers can push back" rule is for cases where Claude judged the bot wrong. When Peter authorized the deviation, the matter is settled — leaving the thread open is just clutter and a re-review trigger. Discovered on PR #448 when the bot flagged the same authorized budget bump twice and Peter had to ask for the second thread to be manually resolved.
+
+**How to apply:**
+
+- "Not changing — Peter authorized X" reply → resolve the thread.
+- "Not changing — bot is technically wrong" reply → leave open (default skill behavior).
+- The decision rule: did Peter explicitly OK this deviation? Resolve. Otherwise leave open.

--- a/src/Humans.Application/DTOs/EmailProblems/EmailProblem.cs
+++ b/src/Humans.Application/DTOs/EmailProblems/EmailProblem.cs
@@ -1,0 +1,14 @@
+namespace Humans.Application.DTOs.EmailProblems;
+
+/// <summary>
+/// One detected EmailProblem entry. Some kinds are scoped to a single user,
+/// some to a pair (case 5), some to a single email row (case 7), some to a
+/// single user with no rows (case 8).
+/// </summary>
+public sealed record EmailProblem(
+    EmailProblemKind Kind,
+    Guid? UserId,
+    Guid? OtherUserId,
+    Guid? UserEmailId,
+    string? Email,
+    string? Detail);

--- a/src/Humans.Application/DTOs/EmailProblems/EmailProblemKind.cs
+++ b/src/Humans.Application/DTOs/EmailProblems/EmailProblemKind.cs
@@ -9,5 +9,6 @@ public enum EmailProblemKind
     SharedAcrossUsers = 5,
     Unverified = 6,
     OrphanUserEmail = 7,
-    GhostExternalLogins = 8
+    GhostExternalLogins = 8,
+    LegacyIdentityEmailNotInUserEmails = 9
 }

--- a/src/Humans.Application/DTOs/EmailProblems/EmailProblemKind.cs
+++ b/src/Humans.Application/DTOs/EmailProblems/EmailProblemKind.cs
@@ -1,0 +1,13 @@
+namespace Humans.Application.DTOs.EmailProblems;
+
+public enum EmailProblemKind
+{
+    MultipleIsPrimary = 1,
+    MultipleIsGoogle = 2,
+    ZeroIsPrimary = 3,
+    ZeroIsGoogle = 4,
+    SharedAcrossUsers = 5,
+    Unverified = 6,
+    OrphanUserEmail = 7,
+    GhostExternalLogins = 8
+}

--- a/src/Humans.Application/DTOs/EmailProblems/EmailProblemsReport.cs
+++ b/src/Humans.Application/DTOs/EmailProblems/EmailProblemsReport.cs
@@ -1,0 +1,7 @@
+using NodaTime;
+
+namespace Humans.Application.DTOs.EmailProblems;
+
+public sealed record EmailProblemsReport(
+    Instant ScannedAt,
+    IReadOnlyList<EmailProblem> Problems);

--- a/src/Humans.Application/FullProfile.cs
+++ b/src/Humans.Application/FullProfile.cs
@@ -91,6 +91,10 @@ public record FullProfile(
             .Select(e => e.Email)
             .FirstOrDefault();
 
+        var snapshots = userEmails
+            .Select(e => new UserEmailSnapshot(e.Id, e.Email, e.IsVerified, e.IsPrimary, e.IsGoogle))
+            .ToList();
+
 #pragma warning disable HUM_PROFILE_ISSUSPENDED
         var isSuspended = profile.IsSuspended;
 #pragma warning restore HUM_PROFILE_ISSUSPENDED
@@ -121,6 +125,7 @@ public record FullProfile(
             PrimaryEmail: primary,
             AllVerifiedEmails: verified,
             GoogleEmail: google,
+            UserEmails: snapshots,
             State: profile.State);
     }
 

--- a/src/Humans.Application/FullProfile.cs
+++ b/src/Humans.Application/FullProfile.cs
@@ -4,6 +4,18 @@ using Humans.Domain.Enums;
 namespace Humans.Application;
 
 /// <summary>
+/// Compact projection of a <see cref="Domain.Entities.UserEmail"/> row carried
+/// inside <see cref="FullProfile"/> so consumers can inspect per-row flags
+/// (IsPrimary / IsGoogle / IsVerified) without going back to the repository.
+/// </summary>
+public sealed record UserEmailSnapshot(
+    Guid Id,
+    string Email,
+    bool IsVerified,
+    bool IsPrimary,
+    bool IsGoogle);
+
+/// <summary>
 /// Denormalized profile projection used by the caching decorator and its
 /// consumers (avatar, link tag helper, profile card). Stitched from
 /// <see cref="Profile"/>, the owning <see cref="User"/>, and the profile's
@@ -28,6 +40,7 @@ public record FullProfile(
     string? PrimaryEmail = null,
     IReadOnlyList<string>? AllVerifiedEmails = null,
     string? GoogleEmail = null,
+    IReadOnlyList<UserEmailSnapshot>? UserEmails = null,
     ProfileState? State = null)
 {
     /// <summary>
@@ -44,6 +57,12 @@ public record FullProfile(
     /// </summary>
     public IReadOnlyList<string> VerifiedEmails =>
         AllVerifiedEmails ?? Array.Empty<string>();
+
+    /// <summary>
+    /// Defensive non-null projection of <see cref="UserEmails"/>.
+    /// </summary>
+    public IReadOnlyList<UserEmailSnapshot> AllUserEmails =>
+        UserEmails ?? Array.Empty<UserEmailSnapshot>();
 
     /// <summary>
     /// Overload that accepts an explicit volunteer-history list and the loaded

--- a/src/Humans.Application/Interfaces/Profiles/IAccountMergeService.cs
+++ b/src/Humans.Application/Interfaces/Profiles/IAccountMergeService.cs
@@ -54,4 +54,18 @@ public interface IAccountMergeService
     /// Creates a new merge request.
     /// </summary>
     Task CreateAsync(AccountMergeRequest request, CancellationToken ct = default);
+
+    /// <summary>
+    /// Admin-initiated merge of two pre-existing accounts (no AccountMergeRequest).
+    /// Folds <paramref name="sourceUserId"/> into <paramref name="targetUserId"/>:
+    /// reassigns every section's user-keyed rows via <c>IUserMerge</c>, tombstones
+    /// the source, and audits. Used by /Profile/Admin/EmailProblems case 5.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown if source==target, either user is missing, or the source is already tombstoned.
+    /// </exception>
+    Task AdminMergeAsync(
+        Guid sourceUserId, Guid targetUserId,
+        Guid adminUserId, string? notes = null,
+        CancellationToken ct = default);
 }

--- a/src/Humans.Application/Interfaces/Profiles/IEmailProblemsService.cs
+++ b/src/Humans.Application/Interfaces/Profiles/IEmailProblemsService.cs
@@ -29,4 +29,17 @@ public interface IEmailProblemsService
     /// are client-controlled and the report may be stale.
     /// </summary>
     Task<bool> IsGhostExternalLoginsUserAsync(Guid userId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Backfills a verified <c>UserEmail</c> row from
+    /// <c>User.IdentityEmailColumn</c> (the raw legacy AspNetIdentity column)
+    /// for every user currently flagged by case 9
+    /// (<see cref="EmailProblemKind.LegacyIdentityEmailNotInUserEmails"/>).
+    /// Idempotent — relies on
+    /// <c>IUserEmailService.AddVerifiedEmailAsync</c>'s existing skip-if-exists
+    /// check. Returns the (userId, email) pairs that received a new row, so
+    /// the caller can audit per row.
+    /// </summary>
+    Task<IReadOnlyList<(Guid UserId, string Email)>> BackfillLegacyIdentityEmailsAsync(
+        CancellationToken ct = default);
 }

--- a/src/Humans.Application/Interfaces/Profiles/IEmailProblemsService.cs
+++ b/src/Humans.Application/Interfaces/Profiles/IEmailProblemsService.cs
@@ -1,0 +1,13 @@
+using Humans.Application.DTOs.EmailProblems;
+
+namespace Humans.Application.Interfaces.Profiles;
+
+/// <summary>
+/// Scans every UserEmail invariant violation surface for the
+/// <c>/Profile/Admin/EmailProblems</c> page. Consumes only existing section
+/// services — never any <c>I*Repository</c> or <c>DbContext</c>.
+/// </summary>
+public interface IEmailProblemsService
+{
+    Task<EmailProblemsReport> ScanAsync(CancellationToken ct = default);
+}

--- a/src/Humans.Application/Interfaces/Profiles/IEmailProblemsService.cs
+++ b/src/Humans.Application/Interfaces/Profiles/IEmailProblemsService.cs
@@ -10,4 +10,23 @@ namespace Humans.Application.Interfaces.Profiles;
 public interface IEmailProblemsService
 {
     Task<EmailProblemsReport> ScanAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns true if the two users currently share any UserEmail address
+    /// under the same normalization rule used by <see cref="ScanAsync"/>'s
+    /// case-5 detection (raw match plus gmail/googlemail equivalence).
+    /// Used by the admin merge POST to re-verify that the submitted pair
+    /// is actually an email-conflict pair before tombstoning, since form
+    /// fields are client-controlled.
+    /// </summary>
+    Task<bool> UsersShareAnyEmailAsync(Guid user1Id, Guid user2Id, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns true if the user is currently in the "ghost external logins"
+    /// set (has <c>AspNetUserLogins</c> rows but zero <c>UserEmail</c> rows).
+    /// Used by the admin "delete ghost logins" POST to re-verify the user
+    /// is still a ghost before deleting auth-table rows, since form fields
+    /// are client-controlled and the report may be stale.
+    /// </summary>
+    Task<bool> IsGhostExternalLoginsUserAsync(Guid userId, CancellationToken ct = default);
 }

--- a/src/Humans.Application/Interfaces/Profiles/IProfileService.cs
+++ b/src/Humans.Application/Interfaces/Profiles/IProfileService.cs
@@ -157,6 +157,14 @@ public interface IProfileService : IUserMerge
     /// </summary>
     Task SaveProfileLanguagesAsync(Guid profileId, IReadOnlyList<ProfileLanguage> languages, CancellationToken ct = default);
 
+    /// <summary>
+    /// Returns a snapshot of every <see cref="FullProfile"/> currently materialized.
+    /// Used by admin scans (EmailProblems) that need to enumerate the full set
+    /// of users with their per-row UserEmail flags. Decorator returns the cache
+    /// dict's Values; inner impl rebuilds from repositories.
+    /// </summary>
+    Task<IReadOnlyList<FullProfile>> GetFullProfileSnapshotAsync(CancellationToken ct = default);
+
     // ==========================================================================
     // Onboarding-section support methods — exposed so OnboardingService can
     // coordinate profile mutations without touching the Profile section's

--- a/src/Humans.Application/Interfaces/Profiles/IProfileService.cs
+++ b/src/Humans.Application/Interfaces/Profiles/IProfileService.cs
@@ -157,14 +157,6 @@ public interface IProfileService : IUserMerge
     /// </summary>
     Task SaveProfileLanguagesAsync(Guid profileId, IReadOnlyList<ProfileLanguage> languages, CancellationToken ct = default);
 
-    /// <summary>
-    /// Returns a snapshot of every <see cref="FullProfile"/> currently materialized.
-    /// Used by admin scans (EmailProblems) that need to enumerate the full set
-    /// of users with their per-row UserEmail flags. Decorator returns the cache
-    /// dict's Values; inner impl rebuilds from repositories.
-    /// </summary>
-    Task<IReadOnlyList<FullProfile>> GetFullProfileSnapshotAsync(CancellationToken ct = default);
-
     // ==========================================================================
     // Onboarding-section support methods — exposed so OnboardingService can
     // coordinate profile mutations without touching the Profile section's

--- a/src/Humans.Application/Interfaces/Profiles/IUserEmailService.cs
+++ b/src/Humans.Application/Interfaces/Profiles/IUserEmailService.cs
@@ -370,6 +370,13 @@ public interface IUserEmailService
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Returns UserEmail rows whose UserId points to a non-existent or tombstoned
+    /// User (User row absent OR <c>MergedToUserId</c> set). Used by the EmailProblems
+    /// admin scan. At ~500 users, full-table scan is trivial.
+    /// </summary>
+    Task<IReadOnlyList<UserEmail>> GetOrphanUserEmailsAsync(CancellationToken ct = default);
+
+    /// <summary>
     /// Find-or-create. Attaches the OAuth identity (<paramref name="provider"/>,
     /// <paramref name="providerKey"/>) to the user's email row matching
     /// <paramref name="email"/> (Ordinal/case-insensitive); creates a new

--- a/src/Humans.Application/Interfaces/Profiles/IUserEmailService.cs
+++ b/src/Humans.Application/Interfaces/Profiles/IUserEmailService.cs
@@ -377,6 +377,12 @@ public interface IUserEmailService
     Task<IReadOnlyList<UserEmail>> GetOrphanUserEmailsAsync(CancellationToken ct = default);
 
     /// <summary>
+    /// Deletes a single UserEmail row by id. Used by EmailProblems orphan cleanup.
+    /// Idempotent — returns false if the row no longer exists.
+    /// </summary>
+    Task<bool> DeleteByIdAsync(Guid emailId, CancellationToken ct = default);
+
+    /// <summary>
     /// Find-or-create. Attaches the OAuth identity (<paramref name="provider"/>,
     /// <paramref name="providerKey"/>) to the user's email row matching
     /// <paramref name="email"/> (Ordinal/case-insensitive); creates a new

--- a/src/Humans.Application/Interfaces/Repositories/IUserRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/IUserRepository.cs
@@ -189,6 +189,12 @@ public interface IUserRepository
     Task<IReadOnlyList<Guid>> GetUsersWithLoginsButNoEmailsAsync(CancellationToken ct = default);
 
     /// <summary>
+    /// Deletes every <c>AspNetUserLogins</c> row for the given user. Returns the
+    /// number of rows deleted. Used by EmailProblems ghost-login cleanup.
+    /// </summary>
+    Task<int> DeleteAllExternalLoginsForUserAsync(Guid userId, CancellationToken ct = default);
+
+    /// <summary>
     /// Migrates every <c>AspNetUserLogins</c> row from
     /// <paramref name="sourceUserId"/> to <paramref name="targetUserId"/>.
     /// <c>IdentityUserLogin&lt;Guid&gt;</c>'s primary key is

--- a/src/Humans.Application/Interfaces/Repositories/IUserRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/IUserRepository.cs
@@ -182,6 +182,13 @@ public interface IUserRepository
         Guid targetUserId, CancellationToken ct = default);
 
     /// <summary>
+    /// Returns userIds of users that have at least one row in
+    /// <c>AspNetUserLogins</c> but zero rows in <c>user_emails</c>. Used by the
+    /// EmailProblems admin scan to surface ghost auth artifacts (case 8).
+    /// </summary>
+    Task<IReadOnlyList<Guid>> GetUsersWithLoginsButNoEmailsAsync(CancellationToken ct = default);
+
+    /// <summary>
     /// Migrates every <c>AspNetUserLogins</c> row from
     /// <paramref name="sourceUserId"/> to <paramref name="targetUserId"/>.
     /// <c>IdentityUserLogin&lt;Guid&gt;</c>'s primary key is

--- a/src/Humans.Application/Interfaces/Users/IUserService.cs
+++ b/src/Humans.Application/Interfaces/Users/IUserService.cs
@@ -269,6 +269,12 @@ public interface IUserService
     /// </summary>
     Task<IReadOnlySet<Guid>> GetMergedSourceIdsAsync(
         Guid targetUserId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns userIds of users that have AspNetUserLogins rows but zero
+    /// UserEmail rows. Used by EmailProblems admin scan.
+    /// </summary>
+    Task<IReadOnlyList<Guid>> GetUsersWithLoginsButNoEmailsAsync(CancellationToken ct = default);
 }
 
 /// <summary>

--- a/src/Humans.Application/Interfaces/Users/IUserService.cs
+++ b/src/Humans.Application/Interfaces/Users/IUserService.cs
@@ -275,6 +275,12 @@ public interface IUserService
     /// UserEmail rows. Used by EmailProblems admin scan.
     /// </summary>
     Task<IReadOnlyList<Guid>> GetUsersWithLoginsButNoEmailsAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Deletes every <c>AspNetUserLogins</c> row for the given user. Returns the
+    /// number of rows deleted. Used by EmailProblems ghost-login cleanup.
+    /// </summary>
+    Task<int> DeleteAllExternalLoginsForUserAsync(Guid userId, CancellationToken ct = default);
 }
 
 /// <summary>

--- a/src/Humans.Application/Services/Profile/AccountMergeService.cs
+++ b/src/Humans.Application/Services/Profile/AccountMergeService.cs
@@ -302,4 +302,41 @@ public sealed class AccountMergeService : IAccountMergeService, IUserDataContrib
 
     public Task CreateAsync(AccountMergeRequest request, CancellationToken ct = default) =>
         _mergeRepository.AddAsync(request, ct);
+
+    public async Task AdminMergeAsync(
+        Guid sourceUserId, Guid targetUserId,
+        Guid adminUserId, string? notes = null,
+        CancellationToken ct = default)
+    {
+        if (sourceUserId == targetUserId)
+            throw new InvalidOperationException("Source and target users are the same.");
+
+        var source = await _userService.GetByIdAsync(sourceUserId, ct)
+            ?? throw new InvalidOperationException($"Source user {sourceUserId} not found.");
+        var target = await _userService.GetByIdAsync(targetUserId, ct)
+            ?? throw new InvalidOperationException($"Target user {targetUserId} not found.");
+
+        if (source.MergedToUserId is not null)
+            throw new InvalidOperationException(
+                $"Source user {sourceUserId} is already tombstoned (merged into {source.MergedToUserId}).");
+
+        if (target.MergedToUserId is not null)
+            throw new InvalidOperationException(
+                $"Target user {targetUserId} is already tombstoned.");
+
+        _logger.LogInformation(
+            "Admin {AdminId} initiated direct merge: folding {SourceUserId} into {TargetUserId}",
+            adminUserId, sourceUserId, targetUserId);
+
+        var description = $"Admin-initiated via EmailProblems: folded source {sourceUserId} into target {targetUserId}. Notes: {notes ?? "(none)"}";
+
+        var audit = new AuditEntry(
+            AuditAction.AccountMergeAccepted,
+            nameof(User), sourceUserId,
+            description,
+            RelatedEntityId: targetUserId,
+            RelatedEntityType: nameof(User));
+
+        await FoldAsync(sourceUserId, targetUserId, adminUserId, audit, ct);
+    }
 }

--- a/src/Humans.Application/Services/Profile/AccountMergeService.cs
+++ b/src/Humans.Application/Services/Profile/AccountMergeService.cs
@@ -95,19 +95,60 @@ public sealed class AccountMergeService : IAccountMergeService, IUserDataContrib
     {
         var request = await _mergeRepository.GetByIdAsync(requestId, ct)
             ?? throw new InvalidOperationException("Merge request not found.");
-
         if (request.Status != AccountMergeRequestStatus.Pending)
-        {
             throw new InvalidOperationException("Merge request is not pending.");
-        }
-
-        var now = _clock.GetCurrentInstant();
-        var mergedFromId = request.SourceUserId;
-        var mergedToId = request.TargetUserId;
 
         _logger.LogInformation(
             "Admin {AdminId} accepting merge request {RequestId}: folding {SourceUserId} into {TargetUserId}",
-            adminUserId, requestId, mergedFromId, mergedToId);
+            adminUserId, requestId, request.SourceUserId, request.TargetUserId);
+
+        var audit = new AuditEntry(
+            AuditAction.AccountMergeAccepted,
+            nameof(AccountMergeRequest), request.Id,
+            $"Folded source {request.SourceUserId} into target {request.TargetUserId} — email: {request.Email}",
+            RelatedEntityId: request.TargetUserId,
+            RelatedEntityType: nameof(User));
+
+        await FoldAsync(request.SourceUserId, request.TargetUserId, adminUserId, audit, ct);
+
+        var now = _clock.GetCurrentInstant();
+        using (var scope = new TransactionScope(
+            TransactionScopeOption.Required,
+            new TransactionOptions
+            {
+                IsolationLevel = IsolationLevel.ReadCommitted
+            },
+            TransactionScopeAsyncFlowOption.Enabled))
+        {
+            var verified = await _userEmailRepository.MarkVerifiedAsync(request.PendingEmailId, now, ct);
+            if (!verified)
+                throw new InvalidOperationException(
+                    $"Pending email {request.PendingEmailId} no longer exists. Cannot complete merge.");
+
+            request.Status = AccountMergeRequestStatus.Accepted;
+            request.ResolvedAt = now;
+            request.ResolvedByUserId = adminUserId;
+            request.AdminNotes = notes;
+            await _mergeRepository.UpdateAsync(request, ct);
+
+            scope.Complete();
+        }
+    }
+
+    private sealed record AuditEntry(
+        AuditAction Action,
+        string EntityType,
+        Guid EntityId,
+        string Description,
+        Guid? RelatedEntityId = null,
+        string? RelatedEntityType = null);
+
+    private async Task FoldAsync(
+        Guid sourceUserId, Guid targetUserId,
+        Guid adminUserId, AuditEntry audit,
+        CancellationToken ct)
+    {
+        var now = _clock.GetCurrentInstant();
 
         try
         {
@@ -120,70 +161,52 @@ public sealed class AccountMergeService : IAccountMergeService, IUserDataContrib
             // continuations.
             using (var scope = new TransactionScope(
                 TransactionScopeOption.Required,
-                new TransactionOptions { IsolationLevel = IsolationLevel.ReadCommitted },
+                new TransactionOptions
+                {
+                    IsolationLevel = IsolationLevel.ReadCommitted
+                },
                 TransactionScopeAsyncFlowOption.Enabled))
             {
-                // 1. Fan out across every section that owns user-keyed rows.
-                //    Each IUserMerge impl re-FKs its section's data from
-                //    source → target. Order doesn't matter for correctness
-                //    inside the same transaction.
+                // Fan out across every section that owns user-keyed rows.
+                // Each IUserMerge impl re-FKs its section's data from
+                // source → target. Order doesn't matter for correctness
+                // inside the same transaction.
                 foreach (var merger in _userMerges)
-                {
-                    await merger.ReassignAsync(mergedFromId, mergedToId, adminUserId, now, ct);
-                }
+                    await merger.ReassignAsync(sourceUserId, targetUserId, adminUserId, now, ct);
 
-                // 2. Verify the pending email on the target. The UserEmail
-                //    section's IUserMerge.ReassignAsync above moved any
-                //    non-conflicting source emails over; the pending row was
-                //    created on the target during request submission and
-                //    still needs to flip to verified.
-                var verified = await _userEmailRepository.MarkVerifiedAsync(request.PendingEmailId, now, ct);
-                if (!verified)
-                {
-                    throw new InvalidOperationException(
-                        $"Pending email {request.PendingEmailId} no longer exists. Cannot complete merge.");
-                }
+                // Tombstone the source User row: sets MergedToUserId,
+                // MergedAt, and locks out login. Does NOT wipe data —
+                // the source row stays as a redirect for chain-follow
+                // reads (audit, consent, budget).
+                await _userService.AnonymizeForMergeAsync(sourceUserId, targetUserId, now, ct);
 
-                // 3. Tombstone the source User row: sets MergedToUserId,
-                //    MergedAt, and locks out login. Does NOT wipe data —
-                //    the source row stays as a redirect for chain-follow
-                //    reads (audit, consent, budget).
-                await _userService.AnonymizeForMergeAsync(mergedFromId, mergedToId, now, ct);
-
-                // 4. Mark the merge request as accepted.
-                request.Status = AccountMergeRequestStatus.Accepted;
-                request.ResolvedAt = now;
-                request.ResolvedByUserId = adminUserId;
-                request.AdminNotes = notes;
-                await _mergeRepository.UpdateAsync(request, ct);
-
-                // 5. Audit inside the same scope so a rolled-back merge
-                //    doesn't leave a ghost audit row.
+                // Audit inside the same scope so a rolled-back fold
+                // doesn't leave a ghost audit row.
                 await _auditLogService.LogAsync(
-                    AuditAction.AccountMergeAccepted,
-                    nameof(AccountMergeRequest), request.Id,
-                    $"Folded source {mergedFromId} into target {mergedToId} — email: {request.Email}",
+                    audit.Action,
+                    audit.EntityType, audit.EntityId,
+                    audit.Description,
                     adminUserId,
-                    relatedEntityId: mergedToId, relatedEntityType: nameof(User));
+                    relatedEntityId: audit.RelatedEntityId,
+                    relatedEntityType: audit.RelatedEntityType);
 
                 scope.Complete();
             }
 
             // Cache invalidation runs AFTER the transaction commits so
             // cache-aside readers don't repopulate from rows that might
-            // still roll back. Each owning section service strips its own
-            // in-Reassign invalidator calls and we re-issue them here.
-            // FullProfile eviction for both users is handled by the
-            // CachingProfileService decorator inside the fan-out (covers
-            // Profile / UserEmail / ContactField / CommunicationPreference,
-            // all Profile-section). Claims + nav-badge cover RoleAssignment.
-            // Notification badge counts cover NotificationRecipient. Team
-            // caches cover the TeamService.ReassignAsync writes.
-            _teamService.RemoveMemberFromAllTeamsCache(mergedFromId);
-            _roleAssignmentService.InvalidateClaimsCacheForUser(mergedFromId);
-            _roleAssignmentService.InvalidateClaimsCacheForUser(mergedToId);
+            // still roll back. FullProfile eviction for both users is
+            // handled by the CachingProfileService decorator inside the
+            // fan-out (covers Profile / UserEmail / ContactField /
+            // CommunicationPreference, all Profile-section). Claims +
+            // nav-badge cover RoleAssignment. Notification badge counts
+            // cover NotificationRecipient. Team caches cover the
+            // TeamService.ReassignAsync writes.
+            _teamService.RemoveMemberFromAllTeamsCache(sourceUserId);
+            _roleAssignmentService.InvalidateClaimsCacheForUser(sourceUserId);
+            _roleAssignmentService.InvalidateClaimsCacheForUser(targetUserId);
             _roleAssignmentService.InvalidateNavBadgeCache();
-            _notificationService.InvalidateBadgeCachesForUsers([mergedFromId, mergedToId]);
+            _notificationService.InvalidateBadgeCachesForUsers([sourceUserId, targetUserId]);
         }
         finally
         {

--- a/src/Humans.Application/Services/Profile/EmailProblemsService.cs
+++ b/src/Humans.Application/Services/Profile/EmailProblemsService.cs
@@ -106,6 +106,13 @@ public sealed class EmailProblemsService : IEmailProblemsService
                 EmailProblemKind.OrphanUserEmail, o.UserId, null, o.Id, o.Email, null));
         }
 
+        var ghosts = await _userService.GetUsersWithLoginsButNoEmailsAsync(ct);
+        foreach (var ghostId in ghosts)
+        {
+            problems.Add(new EmailProblem(
+                EmailProblemKind.GhostExternalLogins, ghostId, null, null, null, null));
+        }
+
         return new EmailProblemsReport(_clock.GetCurrentInstant(), problems);
     }
 }

--- a/src/Humans.Application/Services/Profile/EmailProblemsService.cs
+++ b/src/Humans.Application/Services/Profile/EmailProblemsService.cs
@@ -1,0 +1,33 @@
+using Humans.Application.DTOs.EmailProblems;
+using Humans.Application.Interfaces.Profiles;
+using Humans.Application.Interfaces.Users;
+using NodaTime;
+
+namespace Humans.Application.Services.Profile;
+
+public sealed class EmailProblemsService : IEmailProblemsService
+{
+    private readonly IProfileService _profileService;
+    private readonly IUserEmailService _userEmailService;
+    private readonly IUserService _userService;
+    private readonly IClock _clock;
+
+    public EmailProblemsService(
+        IProfileService profileService,
+        IUserEmailService userEmailService,
+        IUserService userService,
+        IClock clock)
+    {
+        _profileService = profileService;
+        _userEmailService = userEmailService;
+        _userService = userService;
+        _clock = clock;
+    }
+
+    public Task<EmailProblemsReport> ScanAsync(CancellationToken ct = default)
+    {
+        var problems = new List<EmailProblem>();
+        // Tasks 8–13 fill this in.
+        return Task.FromResult(new EmailProblemsReport(_clock.GetCurrentInstant(), problems));
+    }
+}

--- a/src/Humans.Application/Services/Profile/EmailProblemsService.cs
+++ b/src/Humans.Application/Services/Profile/EmailProblemsService.cs
@@ -1,6 +1,7 @@
 using Humans.Application.DTOs.EmailProblems;
 using Humans.Application.Interfaces.Profiles;
 using Humans.Application.Interfaces.Users;
+using Humans.Domain.Helpers;
 using NodaTime;
 
 namespace Humans.Application.Services.Profile;
@@ -61,6 +62,40 @@ public sealed class EmailProblemsService : IEmailProblemsService
                 problems.Add(new EmailProblem(
                     EmailProblemKind.Unverified, p.UserId, null,
                     unverified.Id, unverified.Email, null));
+            }
+        }
+
+        // Cross-user duplicates: build normalized-email -> userIds map, flag pairs.
+        var normToUsers = new Dictionary<string, List<(Guid UserId, string Raw)>>(StringComparer.Ordinal);
+        foreach (var p in profiles)
+        {
+            foreach (var email in p.AllUserEmails)
+            {
+                var norm = EmailNormalization.NormalizeForComparison(email.Email);
+                if (!normToUsers.TryGetValue(norm, out var list))
+                {
+                    list = new List<(Guid, string)>();
+                    normToUsers[norm] = list;
+                }
+                list.Add((p.UserId, email.Email));
+            }
+        }
+
+        foreach (var kvp in normToUsers)
+        {
+            var distinctUsers = kvp.Value.Select(t => t.UserId).Distinct().ToList();
+            if (distinctUsers.Count <= 1) continue;
+
+            for (var i = 0; i < distinctUsers.Count; i++)
+            {
+                for (var j = i + 1; j < distinctUsers.Count; j++)
+                {
+                    var rawA = kvp.Value.First(t => t.UserId == distinctUsers[i]).Raw;
+                    problems.Add(new EmailProblem(
+                        EmailProblemKind.SharedAcrossUsers,
+                        distinctUsers[i], distinctUsers[j],
+                        null, rawA, null));
+                }
             }
         }
 

--- a/src/Humans.Application/Services/Profile/EmailProblemsService.cs
+++ b/src/Humans.Application/Services/Profile/EmailProblemsService.cs
@@ -24,10 +24,25 @@ public sealed class EmailProblemsService : IEmailProblemsService
         _clock = clock;
     }
 
-    public Task<EmailProblemsReport> ScanAsync(CancellationToken ct = default)
+    public async Task<EmailProblemsReport> ScanAsync(CancellationToken ct = default)
     {
         var problems = new List<EmailProblem>();
-        // Tasks 8–13 fill this in.
-        return Task.FromResult(new EmailProblemsReport(_clock.GetCurrentInstant(), problems));
+
+        var profiles = await _profileService.GetFullProfileSnapshotAsync(ct);
+
+        foreach (var p in profiles)
+        {
+            var emails = p.AllUserEmails;
+
+            if (emails.Count(e => e.IsPrimary) > 1)
+                problems.Add(new EmailProblem(
+                    EmailProblemKind.MultipleIsPrimary, p.UserId, null, null, null, null));
+
+            if (emails.Count(e => e.IsGoogle) > 1)
+                problems.Add(new EmailProblem(
+                    EmailProblemKind.MultipleIsGoogle, p.UserId, null, null, null, null));
+        }
+
+        return new EmailProblemsReport(_clock.GetCurrentInstant(), problems);
     }
 }

--- a/src/Humans.Application/Services/Profile/EmailProblemsService.cs
+++ b/src/Humans.Application/Services/Profile/EmailProblemsService.cs
@@ -115,4 +115,25 @@ public sealed class EmailProblemsService : IEmailProblemsService
 
         return new EmailProblemsReport(_clock.GetCurrentInstant(), problems);
     }
+
+    public async Task<bool> UsersShareAnyEmailAsync(Guid user1Id, Guid user2Id, CancellationToken ct = default)
+    {
+        if (user1Id == user2Id) return false;
+
+        var p1 = await _profileService.GetFullProfileAsync(user1Id, ct);
+        var p2 = await _profileService.GetFullProfileAsync(user2Id, ct);
+        if (p1 is null || p2 is null) return false;
+
+        var norms1 = p1.AllUserEmails
+            .Select(e => EmailNormalization.NormalizeForComparison(e.Email))
+            .ToHashSet(StringComparer.Ordinal);
+        return p2.AllUserEmails
+            .Any(e => norms1.Contains(EmailNormalization.NormalizeForComparison(e.Email)));
+    }
+
+    public async Task<bool> IsGhostExternalLoginsUserAsync(Guid userId, CancellationToken ct = default)
+    {
+        var ghosts = await _userService.GetUsersWithLoginsButNoEmailsAsync(ct);
+        return ghosts.Contains(userId);
+    }
 }

--- a/src/Humans.Application/Services/Profile/EmailProblemsService.cs
+++ b/src/Humans.Application/Services/Profile/EmailProblemsService.cs
@@ -41,6 +41,14 @@ public sealed class EmailProblemsService : IEmailProblemsService
             if (emails.Count(e => e.IsGoogle) > 1)
                 problems.Add(new EmailProblem(
                     EmailProblemKind.MultipleIsGoogle, p.UserId, null, null, null, null));
+
+            if (emails.Any(e => e.IsVerified) && !emails.Any(e => e.IsPrimary))
+                problems.Add(new EmailProblem(
+                    EmailProblemKind.ZeroIsPrimary, p.UserId, null, null, null, null));
+
+            if (!emails.Any(e => e.IsGoogle))
+                problems.Add(new EmailProblem(
+                    EmailProblemKind.ZeroIsGoogle, p.UserId, null, null, null, null));
         }
 
         return new EmailProblemsReport(_clock.GetCurrentInstant(), problems);

--- a/src/Humans.Application/Services/Profile/EmailProblemsService.cs
+++ b/src/Humans.Application/Services/Profile/EmailProblemsService.cs
@@ -113,6 +113,27 @@ public sealed class EmailProblemsService : IEmailProblemsService
                 EmailProblemKind.GhostExternalLogins, ghostId, null, null, null, null));
         }
 
+        // Case 9: legacy AspNetIdentity Email column populated but no matching
+        // verified UserEmail row exists. Pre-decoupling users whose row was
+        // never written when the spec switched. Detect via the raw column
+        // (IdentityEmailColumn) so the User.Email override's UserEmails-based
+        // resolution doesn't mask it.
+        foreach (var u in users)
+        {
+            var legacy = u.IdentityEmailColumn;
+            if (string.IsNullOrEmpty(legacy)) continue;
+
+            var profile = profiles.FirstOrDefault(p => p.UserId == u.Id);
+            var emails = profile?.AllUserEmails ?? Array.Empty<UserEmailSnapshot>();
+            var hasMatchingVerifiedRow = emails.Any(e =>
+                e.IsVerified && string.Equals(e.Email, legacy, StringComparison.OrdinalIgnoreCase));
+            if (hasMatchingVerifiedRow) continue;
+
+            problems.Add(new EmailProblem(
+                EmailProblemKind.LegacyIdentityEmailNotInUserEmails,
+                u.Id, null, null, legacy, null));
+        }
+
         return new EmailProblemsReport(_clock.GetCurrentInstant(), problems);
     }
 
@@ -135,5 +156,29 @@ public sealed class EmailProblemsService : IEmailProblemsService
     {
         var ghosts = await _userService.GetUsersWithLoginsButNoEmailsAsync(ct);
         return ghosts.Contains(userId);
+    }
+
+    public async Task<IReadOnlyList<(Guid UserId, string Email)>> BackfillLegacyIdentityEmailsAsync(
+        CancellationToken ct = default)
+    {
+        var users = await _userService.GetAllUsersAsync(ct);
+        var backfilled = new List<(Guid, string)>();
+
+        foreach (var u in users)
+        {
+            var legacy = u.IdentityEmailColumn;
+            if (string.IsNullOrEmpty(legacy)) continue;
+
+            var profile = await _profileService.GetFullProfileAsync(u.Id, ct);
+            var emails = profile?.AllUserEmails ?? Array.Empty<UserEmailSnapshot>();
+            if (emails.Any(e => e.IsVerified
+                && string.Equals(e.Email, legacy, StringComparison.OrdinalIgnoreCase)))
+                continue;
+
+            await _userEmailService.AddVerifiedEmailAsync(u.Id, legacy, ct);
+            backfilled.Add((u.Id, legacy));
+        }
+
+        return backfilled;
     }
 }

--- a/src/Humans.Application/Services/Profile/EmailProblemsService.cs
+++ b/src/Humans.Application/Services/Profile/EmailProblemsService.cs
@@ -49,6 +49,13 @@ public sealed class EmailProblemsService : IEmailProblemsService
             if (!emails.Any(e => e.IsGoogle))
                 problems.Add(new EmailProblem(
                     EmailProblemKind.ZeroIsGoogle, p.UserId, null, null, null, null));
+
+            foreach (var unverified in emails.Where(e => !e.IsVerified))
+            {
+                problems.Add(new EmailProblem(
+                    EmailProblemKind.Unverified, p.UserId, null,
+                    unverified.Id, unverified.Email, null));
+            }
         }
 
         return new EmailProblemsReport(_clock.GetCurrentInstant(), problems);

--- a/src/Humans.Application/Services/Profile/EmailProblemsService.cs
+++ b/src/Humans.Application/Services/Profile/EmailProblemsService.cs
@@ -99,6 +99,13 @@ public sealed class EmailProblemsService : IEmailProblemsService
             }
         }
 
+        var orphans = await _userEmailService.GetOrphanUserEmailsAsync(ct);
+        foreach (var o in orphans)
+        {
+            problems.Add(new EmailProblem(
+                EmailProblemKind.OrphanUserEmail, o.UserId, null, o.Id, o.Email, null));
+        }
+
         return new EmailProblemsReport(_clock.GetCurrentInstant(), problems);
     }
 }

--- a/src/Humans.Application/Services/Profile/EmailProblemsService.cs
+++ b/src/Humans.Application/Services/Profile/EmailProblemsService.cs
@@ -28,7 +28,13 @@ public sealed class EmailProblemsService : IEmailProblemsService
     {
         var problems = new List<EmailProblem>();
 
-        var profiles = await _profileService.GetFullProfileSnapshotAsync(ct);
+        var users = await _userService.GetAllUsersAsync(ct);
+        var profiles = new List<FullProfile>(users.Count);
+        foreach (var u in users)
+        {
+            var fp = await _profileService.GetFullProfileAsync(u.Id, ct);
+            if (fp is not null) profiles.Add(fp);
+        }
 
         foreach (var p in profiles)
         {

--- a/src/Humans.Application/Services/Profile/ProfileService.cs
+++ b/src/Humans.Application/Services/Profile/ProfileService.cs
@@ -509,6 +509,25 @@ public sealed class ProfileService : IProfileService, IUserDataContributor, IUse
     public Task<IReadOnlyList<Guid>> GetActiveApprovedUserIdsAsync(CancellationToken ct = default) =>
         _profileRepository.GetActiveApprovedUserIdsAsync(ct);
 
+    public async Task<IReadOnlyList<FullProfile>> GetFullProfileSnapshotAsync(CancellationToken ct = default)
+    {
+        var profiles = await _profileRepository.GetAllAsync(ct);
+        var userIds = profiles.Select(p => p.UserId).ToList();
+        var users = await _userService.GetByIdsAsync(userIds, ct);
+        var allUserEmails = await _userEmailRepository.GetAllAsync(ct);
+        var emailsByUser = allUserEmails.GroupBy(e => e.UserId)
+            .ToDictionary(g => g.Key, g => (IReadOnlyList<UserEmail>)g.ToList());
+
+        var result = new List<FullProfile>(profiles.Count);
+        foreach (var profile in profiles)
+        {
+            if (!users.TryGetValue(profile.UserId, out var user)) continue;
+            var emails = emailsByUser.GetValueOrDefault(profile.UserId, Array.Empty<UserEmail>());
+            result.Add(FullProfile.Create(profile, user, profile.VolunteerHistory.ToList(), emails));
+        }
+        return result;
+    }
+
     public Task<int> GetConsentReviewPendingCountAsync(CancellationToken ct = default) =>
         _profileRepository.GetConsentReviewPendingCountAsync(ct);
 

--- a/src/Humans.Application/Services/Profile/ProfileService.cs
+++ b/src/Humans.Application/Services/Profile/ProfileService.cs
@@ -509,24 +509,8 @@ public sealed class ProfileService : IProfileService, IUserDataContributor, IUse
     public Task<IReadOnlyList<Guid>> GetActiveApprovedUserIdsAsync(CancellationToken ct = default) =>
         _profileRepository.GetActiveApprovedUserIdsAsync(ct);
 
-    public async Task<IReadOnlyList<FullProfile>> GetFullProfileSnapshotAsync(CancellationToken ct = default)
-    {
-        var profiles = await _profileRepository.GetAllAsync(ct);
-        var userIds = profiles.Select(p => p.UserId).ToList();
-        var users = await _userService.GetByIdsAsync(userIds, ct);
-        var allUserEmails = await _userEmailRepository.GetAllAsync(ct);
-        var emailsByUser = allUserEmails.GroupBy(e => e.UserId)
-            .ToDictionary(g => g.Key, g => (IReadOnlyList<UserEmail>)g.ToList());
-
-        var result = new List<FullProfile>(profiles.Count);
-        foreach (var profile in profiles)
-        {
-            if (!users.TryGetValue(profile.UserId, out var user)) continue;
-            var emails = emailsByUser.GetValueOrDefault(profile.UserId, Array.Empty<UserEmail>());
-            result.Add(FullProfile.Create(profile, user, profile.VolunteerHistory.ToList(), emails));
-        }
-        return result;
-    }
+    public Task<IReadOnlyList<FullProfile>> GetFullProfileSnapshotAsync(CancellationToken ct = default) =>
+        BuildFullProfileSnapshotAsync(ct);
 
     public Task<int> GetConsentReviewPendingCountAsync(CancellationToken ct = default) =>
         _profileRepository.GetConsentReviewPendingCountAsync(ct);

--- a/src/Humans.Application/Services/Profile/ProfileService.cs
+++ b/src/Humans.Application/Services/Profile/ProfileService.cs
@@ -509,9 +509,6 @@ public sealed class ProfileService : IProfileService, IUserDataContributor, IUse
     public Task<IReadOnlyList<Guid>> GetActiveApprovedUserIdsAsync(CancellationToken ct = default) =>
         _profileRepository.GetActiveApprovedUserIdsAsync(ct);
 
-    public Task<IReadOnlyList<FullProfile>> GetFullProfileSnapshotAsync(CancellationToken ct = default) =>
-        BuildFullProfileSnapshotAsync(ct);
-
     public Task<int> GetConsentReviewPendingCountAsync(CancellationToken ct = default) =>
         _profileRepository.GetConsentReviewPendingCountAsync(ct);
 

--- a/src/Humans.Application/Services/Profile/UserEmailService.cs
+++ b/src/Humans.Application/Services/Profile/UserEmailService.cs
@@ -852,6 +852,21 @@ public sealed class UserEmailService : IUserEmailService, IUserMerge
     }
 
     /// <inheritdoc />
+    public async Task<IReadOnlyList<UserEmail>> GetOrphanUserEmailsAsync(CancellationToken ct = default)
+    {
+        var allEmails = await _repository.GetAllAsync(ct);
+        var allUsers = await _userService.GetAllUsersAsync(ct);
+        var liveUserIds = allUsers
+            .Where(u => u.MergedToUserId is null)
+            .Select(u => u.Id)
+            .ToHashSet();
+
+        return allEmails
+            .Where(e => !liveUserIds.Contains(e.UserId))
+            .ToList();
+    }
+
+    /// <inheritdoc />
     public async Task<bool> LinkAsync(
         Guid userId, string provider, string providerKey, string email, Guid actorUserId,
         CancellationToken cancellationToken = default)

--- a/src/Humans.Application/Services/Profile/UserEmailService.cs
+++ b/src/Humans.Application/Services/Profile/UserEmailService.cs
@@ -867,6 +867,10 @@ public sealed class UserEmailService : IUserEmailService, IUserMerge
     }
 
     /// <inheritdoc />
+    public Task<bool> DeleteByIdAsync(Guid emailId, CancellationToken ct = default) =>
+        _repository.RemoveByIdAsync(emailId, ct);
+
+    /// <inheritdoc />
     public async Task<bool> LinkAsync(
         Guid userId, string provider, string providerKey, string email, Guid actorUserId,
         CancellationToken cancellationToken = default)

--- a/src/Humans.Application/Services/Profile/UserEmailService.cs
+++ b/src/Humans.Application/Services/Profile/UserEmailService.cs
@@ -867,8 +867,16 @@ public sealed class UserEmailService : IUserEmailService, IUserMerge
     }
 
     /// <inheritdoc />
-    public Task<bool> DeleteByIdAsync(Guid emailId, CancellationToken ct = default) =>
-        _repository.RemoveByIdAsync(emailId, ct);
+    public async Task<bool> DeleteByIdAsync(Guid emailId, CancellationToken ct = default)
+    {
+        var row = await _repository.GetByIdReadOnlyAsync(emailId, ct);
+        if (row is null) return false;
+
+        var deleted = await _repository.RemoveByIdAsync(emailId, ct);
+        if (deleted)
+            await _fullProfileInvalidator.InvalidateAsync(row.UserId, ct);
+        return deleted;
+    }
 
     /// <inheritdoc />
     public async Task<bool> LinkAsync(

--- a/src/Humans.Application/Services/Users/UserService.cs
+++ b/src/Humans.Application/Services/Users/UserService.cs
@@ -388,4 +388,7 @@ public sealed class UserService : IUserService, IUserDataContributor, IUserMerge
         var ids = await _repo.GetMergedSourceIdsAsync(targetUserId, ct);
         return ids.ToHashSet();
     }
+
+    public Task<IReadOnlyList<Guid>> GetUsersWithLoginsButNoEmailsAsync(CancellationToken ct = default) =>
+        _repo.GetUsersWithLoginsButNoEmailsAsync(ct);
 }

--- a/src/Humans.Application/Services/Users/UserService.cs
+++ b/src/Humans.Application/Services/Users/UserService.cs
@@ -391,4 +391,7 @@ public sealed class UserService : IUserService, IUserDataContributor, IUserMerge
 
     public Task<IReadOnlyList<Guid>> GetUsersWithLoginsButNoEmailsAsync(CancellationToken ct = default) =>
         _repo.GetUsersWithLoginsButNoEmailsAsync(ct);
+
+    public Task<int> DeleteAllExternalLoginsForUserAsync(Guid userId, CancellationToken ct = default) =>
+        _repo.DeleteAllExternalLoginsForUserAsync(userId, ct);
 }

--- a/src/Humans.Domain/Entities/User.cs
+++ b/src/Humans.Domain/Entities/User.cs
@@ -91,6 +91,17 @@ public class User : IdentityUser<Guid>
         set => base.Email = value;
     }
 
+    /// <summary>
+    /// Raw legacy AspNetIdentity <c>Email</c> column value, bypassing the
+    /// computed-from-<see cref="UserEmails"/> override. Diagnostic only —
+    /// used by EmailProblems case-9 detection (legacy column populated but
+    /// no matching <see cref="UserEmail"/> row) and by the admin Manage
+    /// Emails page when a full Admin views another user. Application code
+    /// should read <see cref="Email"/>, not this property.
+    /// </summary>
+    [System.ComponentModel.DataAnnotations.Schema.NotMapped]
+    public string? IdentityEmailColumn => base.Email;
+
     /// <inheritdoc />
     /// <remarks>
     /// Issue #635 (§15i): NormalizedEmail is shadow-populated by Identity but

--- a/src/Humans.Domain/Enums/AuditAction.cs
+++ b/src/Humans.Domain/Enums/AuditAction.cs
@@ -126,4 +126,5 @@ public enum AuditAction
     StorePaymentRecorded,
     OrphanUserEmailDeleted,
     GhostExternalLoginsDeleted,
+    LegacyIdentityEmailBackfilled,
 }

--- a/src/Humans.Domain/Enums/AuditAction.cs
+++ b/src/Humans.Domain/Enums/AuditAction.cs
@@ -124,4 +124,6 @@ public enum AuditAction
     StoreProductUpdated,
     StoreProductDeactivated,
     StorePaymentRecorded,
+    OrphanUserEmailDeleted,
+    GhostExternalLoginsDeleted,
 }

--- a/src/Humans.Infrastructure/Repositories/Users/UserRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Users/UserRepository.cs
@@ -401,6 +401,14 @@ public sealed class UserRepository : IUserRepository
         return true;
     }
 
+    public async Task<int> DeleteAllExternalLoginsForUserAsync(Guid userId, CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        return await ctx.Set<IdentityUserLogin<Guid>>()
+            .Where(l => l.UserId == userId)
+            .ExecuteDeleteAsync(ct);
+    }
+
     public async Task<int> ReassignLoginsToUserAsync(
         Guid sourceUserId, Guid targetUserId, CancellationToken ct = default)
     {

--- a/src/Humans.Infrastructure/Repositories/Users/UserRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Users/UserRepository.cs
@@ -363,6 +363,31 @@ public sealed class UserRepository : IUserRepository
             .ToListAsync(ct);
     }
 
+    public async Task<IReadOnlyList<Guid>> GetUsersWithLoginsButNoEmailsAsync(CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+
+        // Distinct UserIds present in AspNetUserLogins
+        var loginUserIds = await ctx.Set<IdentityUserLogin<Guid>>()
+            .AsNoTracking()
+            .Select(l => l.UserId)
+            .Distinct()
+            .ToListAsync(ct);
+
+        if (loginUserIds.Count == 0) return Array.Empty<Guid>();
+
+        // UserIds that DO have a user_emails row
+        var withEmail = await ctx.UserEmails
+            .AsNoTracking()
+            .Where(e => loginUserIds.Contains(e.UserId))
+            .Select(e => e.UserId)
+            .Distinct()
+            .ToListAsync(ct);
+
+        var withEmailSet = withEmail.ToHashSet();
+        return loginUserIds.Where(id => !withEmailSet.Contains(id)).ToList();
+    }
+
     public async Task<bool> SetContactSourceIfNullAsync(
         Guid userId, ContactSource source, CancellationToken ct = default)
     {

--- a/src/Humans.Infrastructure/Services/Profiles/CachingProfileService.cs
+++ b/src/Humans.Infrastructure/Services/Profiles/CachingProfileService.cs
@@ -391,9 +391,6 @@ public sealed class CachingProfileService : IProfileService, IFullProfileInvalid
         return await inner.GetEmailCooldownInfoAsync(pendingEmailId, ct);
     }
 
-    public Task<IReadOnlyList<FullProfile>> GetFullProfileSnapshotAsync(CancellationToken ct = default) =>
-        Task.FromResult<IReadOnlyList<FullProfile>>(_byUserId.Values.ToList());
-
     public Task<IReadOnlyList<UserSearchResult>> SearchApprovedUsersAsync(
         string query, CancellationToken ct = default)
     {

--- a/src/Humans.Infrastructure/Services/Profiles/CachingProfileService.cs
+++ b/src/Humans.Infrastructure/Services/Profiles/CachingProfileService.cs
@@ -391,6 +391,9 @@ public sealed class CachingProfileService : IProfileService, IFullProfileInvalid
         return await inner.GetEmailCooldownInfoAsync(pendingEmailId, ct);
     }
 
+    public Task<IReadOnlyList<FullProfile>> GetFullProfileSnapshotAsync(CancellationToken ct = default) =>
+        Task.FromResult<IReadOnlyList<FullProfile>>(_byUserId.Values.ToList());
+
     public Task<IReadOnlyList<UserSearchResult>> SearchApprovedUsersAsync(
         string query, CancellationToken ct = default)
     {

--- a/src/Humans.Web/Controllers/ProfileAdminController.cs
+++ b/src/Humans.Web/Controllers/ProfileAdminController.cs
@@ -238,4 +238,27 @@ public class ProfileAdminController : HumansControllerBase
         }
         return RedirectToAction(nameof(EmailProblems));
     }
+
+    [HttpPost("EmailProblems/DeleteGhostLogins")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> DeleteGhostLogins(Guid userId, CancellationToken ct)
+    {
+        var (error, currentUser) = await RequireCurrentUserAsync();
+        if (error is not null) return error;
+
+        var count = await _users.DeleteAllExternalLoginsForUserAsync(userId, ct);
+        if (count > 0)
+        {
+            await _audit.LogAsync(
+                AuditAction.GhostExternalLoginsDeleted, nameof(User), userId,
+                $"Deleted {count} ghost AspNetUserLogins row(s) for userId {userId}",
+                currentUser.Id);
+            SetSuccess($"Deleted {count} ghost login row(s).");
+        }
+        else
+        {
+            SetInfo("Already cleaned up — no rows to delete.");
+        }
+        return RedirectToAction(nameof(EmailProblems));
+    }
 }

--- a/src/Humans.Web/Controllers/ProfileAdminController.cs
+++ b/src/Humans.Web/Controllers/ProfileAdminController.cs
@@ -1,0 +1,40 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Humans.Application.Interfaces.AuditLog;
+using Humans.Application.Interfaces.Profiles;
+using Humans.Application.Interfaces.Users;
+using Humans.Domain.Entities;
+using Humans.Web.Authorization;
+
+namespace Humans.Web.Controllers;
+
+[Authorize(Policy = PolicyNames.AdminOnly)]
+[Route("Profile/Admin")]
+public class ProfileAdminController : HumansControllerBase
+{
+    private readonly IEmailProblemsService _emailProblems;
+    private readonly IAccountMergeService _accountMerge;
+    private readonly IUserEmailService _userEmails;
+    private readonly IUserService _users;
+    private readonly IAuditLogService _audit;
+    private readonly ILogger<ProfileAdminController> _logger;
+
+    public ProfileAdminController(
+        UserManager<User> userManager,
+        IEmailProblemsService emailProblems,
+        IAccountMergeService accountMerge,
+        IUserEmailService userEmails,
+        IUserService users,
+        IAuditLogService audit,
+        ILogger<ProfileAdminController> logger)
+        : base(userManager)
+    {
+        _emailProblems = emailProblems;
+        _accountMerge = accountMerge;
+        _userEmails = userEmails;
+        _users = users;
+        _audit = audit;
+        _logger = logger;
+    }
+}

--- a/src/Humans.Web/Controllers/ProfileAdminController.cs
+++ b/src/Humans.Web/Controllers/ProfileAdminController.cs
@@ -193,6 +193,30 @@ public class ProfileAdminController : HumansControllerBase
         return RedirectToAction(nameof(EmailProblems));
     }
 
+    [HttpPost("EmailProblems/BackfillLegacyEmails")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> BackfillLegacyEmails(CancellationToken ct)
+    {
+        var (error, currentUser) = await RequireCurrentUserAsync();
+        if (error is not null) return error;
+
+        var backfilled = await _emailProblems.BackfillLegacyIdentityEmailsAsync(ct);
+        foreach (var (userId, email) in backfilled)
+        {
+            await _audit.LogAsync(
+                AuditAction.LegacyIdentityEmailBackfilled, nameof(User), userId,
+                $"Backfilled verified UserEmail row from legacy User.Email column: {email}",
+                currentUser.Id);
+        }
+
+        if (backfilled.Count == 0)
+            SetInfo("No legacy User.Email values to backfill.");
+        else
+            SetSuccess($"Backfilled {backfilled.Count} verified UserEmail row(s) from legacy User.Email columns.");
+
+        return RedirectToAction(nameof(EmailProblems));
+    }
+
     [HttpPost("EmailProblems/DeleteGhostLogins")]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> DeleteGhostLogins(Guid userId, CancellationToken ct)

--- a/src/Humans.Web/Controllers/ProfileAdminController.cs
+++ b/src/Humans.Web/Controllers/ProfileAdminController.cs
@@ -9,6 +9,7 @@ using Humans.Application.Interfaces.Profiles;
 using Humans.Application.Interfaces.Teams;
 using Humans.Application.Interfaces.Users;
 using Humans.Domain.Entities;
+using Humans.Domain.Enums;
 using Humans.Web.Authorization;
 using Humans.Web.Models.EmailProblems;
 
@@ -213,5 +214,28 @@ public class ProfileAdminController : HumansControllerBase
             return RedirectToAction(nameof(EmailProblemsCompare),
                 new { userId1 = user1Id, userId2 = user2Id });
         }
+    }
+
+    [HttpPost("EmailProblems/DeleteOrphanEmail")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> DeleteOrphanEmail(Guid emailId, CancellationToken ct)
+    {
+        var (error, currentUser) = await RequireCurrentUserAsync();
+        if (error is not null) return error;
+
+        var deleted = await _userEmails.DeleteByIdAsync(emailId, ct);
+        if (deleted)
+        {
+            await _audit.LogAsync(
+                AuditAction.OrphanUserEmailDeleted, nameof(UserEmail), emailId,
+                $"Orphan UserEmail row {emailId} deleted by EmailProblems action",
+                currentUser.Id);
+            SetSuccess("Orphan email row deleted.");
+        }
+        else
+        {
+            SetInfo("Already cleaned up — no row to delete.");
+        }
+        return RedirectToAction(nameof(EmailProblems));
     }
 }

--- a/src/Humans.Web/Controllers/ProfileAdminController.cs
+++ b/src/Humans.Web/Controllers/ProfileAdminController.cs
@@ -1,9 +1,12 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using Humans.Application;
 using Humans.Application.DTOs.EmailProblems;
 using Humans.Application.Interfaces.AuditLog;
+using Humans.Application.Interfaces.Auth;
 using Humans.Application.Interfaces.Profiles;
+using Humans.Application.Interfaces.Teams;
 using Humans.Application.Interfaces.Users;
 using Humans.Domain.Entities;
 using Humans.Web.Authorization;
@@ -21,6 +24,9 @@ public class ProfileAdminController : HumansControllerBase
     private readonly IUserService _users;
     private readonly IAuditLogService _audit;
     private readonly ILogger<ProfileAdminController> _logger;
+    private readonly IProfileService _profileService;
+    private readonly ITeamService _teamService;
+    private readonly IRoleAssignmentService _roleAssignmentService;
 
     public ProfileAdminController(
         UserManager<User> userManager,
@@ -29,7 +35,10 @@ public class ProfileAdminController : HumansControllerBase
         IUserEmailService userEmails,
         IUserService users,
         IAuditLogService audit,
-        ILogger<ProfileAdminController> logger)
+        ILogger<ProfileAdminController> logger,
+        IProfileService profileService,
+        ITeamService teamService,
+        IRoleAssignmentService roleAssignmentService)
         : base(userManager)
     {
         _emailProblems = emailProblems;
@@ -38,6 +47,9 @@ public class ProfileAdminController : HumansControllerBase
         _users = users;
         _audit = audit;
         _logger = logger;
+        _profileService = profileService;
+        _teamService = teamService;
+        _roleAssignmentService = roleAssignmentService;
     }
 
     [HttpGet("EmailProblems")]
@@ -111,6 +123,58 @@ public class ProfileAdminController : HumansControllerBase
             CrossUserConflicts = crossUser,
             SingleUserIssues = singleUser,
             SystemLevelIssues = systemLevel
+        };
+
+        return View(vm);
+    }
+
+    [HttpGet("EmailProblems/Compare")]
+    public async Task<IActionResult> EmailProblemsCompare(Guid userId1, Guid userId2, CancellationToken ct)
+    {
+        if (userId1 == userId2)
+        {
+            SetError("Cannot compare a user against themselves.");
+            return RedirectToAction(nameof(EmailProblems));
+        }
+
+        var ids = new[] { userId1, userId2 };
+        var users = await _users.GetByIdsAsync(ids, ct);
+        if (!users.TryGetValue(userId1, out var u1) || !users.TryGetValue(userId2, out var u2))
+        {
+            SetError("One or both users not found.");
+            return RedirectToAction(nameof(EmailProblems));
+        }
+
+        var p1 = await _profileService.GetFullProfileAsync(userId1, ct);
+        var p2 = await _profileService.GetFullProfileAsync(userId2, ct);
+
+        var sharedEmail = (p1?.AllUserEmails ?? Array.Empty<UserEmailSnapshot>())
+            .Select(e => e.Email)
+            .Intersect((p2?.AllUserEmails ?? Array.Empty<UserEmailSnapshot>()).Select(e => e.Email),
+                       StringComparer.OrdinalIgnoreCase)
+            .FirstOrDefault() ?? "(no exact match — see normalized)";
+
+        CompareSide BuildSide(User user, FullProfile? profile, int teamCount, int roleCount) =>
+            new(user.Id, user.DisplayName, user.ProfilePictureUrl,
+                profile?.AllUserEmails ?? Array.Empty<UserEmailSnapshot>(),
+                teamCount, roleCount,
+                user.LastLoginAt?.ToDateTimeUtc(),
+                !string.IsNullOrEmpty(profile?.BurnerName));
+
+        var memberships1 = await _teamService.GetUserTeamsAsync(userId1, ct);
+        var memberships2 = await _teamService.GetUserTeamsAsync(userId2, ct);
+        var roles1 = await _roleAssignmentService.GetByUserIdAsync(userId1, ct);
+        var roles2 = await _roleAssignmentService.GetByUserIdAsync(userId2, ct);
+
+        var vm = new EmailProblemsCompareViewModel
+        {
+            SharedEmail = sharedEmail,
+            Account1 = BuildSide(u1, p1,
+                memberships1.Count(m => m.LeftAt is null),
+                roles1.Count(r => r.ValidTo is null)),
+            Account2 = BuildSide(u2, p2,
+                memberships2.Count(m => m.LeftAt is null),
+                roles2.Count(r => r.ValidTo is null))
         };
 
         return View(vm);

--- a/src/Humans.Web/Controllers/ProfileAdminController.cs
+++ b/src/Humans.Web/Controllers/ProfileAdminController.cs
@@ -138,6 +138,12 @@ public class ProfileAdminController : HumansControllerBase
                 new { userId1 = user1Id, userId2 = user2Id });
         }
 
+        if (!await _emailProblems.UsersShareAnyEmailAsync(user1Id, user2Id, ct))
+        {
+            SetError("These accounts no longer share an email and cannot be merged here.");
+            return RedirectToAction(nameof(EmailProblems));
+        }
+
         try
         {
             await _accountMerge.AdminMergeAsync(sourceUserId, targetUserId, currentUser.Id, notes, ct);
@@ -183,6 +189,12 @@ public class ProfileAdminController : HumansControllerBase
     {
         var (error, currentUser) = await RequireCurrentUserAsync();
         if (error is not null) return error;
+
+        if (!await _emailProblems.IsGhostExternalLoginsUserAsync(userId, ct))
+        {
+            SetInfo("Already cleaned up — user is no longer in the ghost set.");
+            return RedirectToAction(nameof(EmailProblems));
+        }
 
         var count = await _users.DeleteAllExternalLoginsForUserAsync(userId, ct);
         if (count > 0)

--- a/src/Humans.Web/Controllers/ProfileAdminController.cs
+++ b/src/Humans.Web/Controllers/ProfileAdminController.cs
@@ -140,8 +140,8 @@ public class ProfileAdminController : HumansControllerBase
         }
         catch (InvalidOperationException ex)
         {
-            _logger.LogError(ex, "Admin-initiated merge failed: source {Source}, target {Target}",
-                sourceUserId, targetUserId);
+            _logger.LogWarning("Admin-initiated merge failed: source {Source}, target {Target}: {Reason}",
+                sourceUserId, targetUserId, ex.Message);
             SetError($"Merge failed: {ex.Message}");
             return RedirectToAction(nameof(EmailProblemsCompare),
                 new { userId1 = user1Id, userId2 = user2Id });

--- a/src/Humans.Web/Controllers/ProfileAdminController.cs
+++ b/src/Humans.Web/Controllers/ProfileAdminController.cs
@@ -2,7 +2,6 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Humans.Application;
-using Humans.Application.DTOs.EmailProblems;
 using Humans.Application.Interfaces.AuditLog;
 using Humans.Application.Interfaces.Auth;
 using Humans.Application.Interfaces.Profiles;
@@ -58,75 +57,14 @@ public class ProfileAdminController : HumansControllerBase
     {
         var report = await _emailProblems.ScanAsync(ct);
 
-        var crossUser = new List<CrossUserConflictRow>();
-        var singleUserMap = new Dictionary<Guid, List<string>>();
-        var systemLevel = new List<SystemLevelIssueRow>();
-
         var allInvolvedUserIds = report.Problems
             .SelectMany(p => new[] { p.UserId, p.OtherUserId })
             .OfType<Guid>()
             .Distinct()
             .ToList();
         var users = await _users.GetByIdsAsync(allInvolvedUserIds, ct);
-        string DisplayName(Guid? id) =>
-            id is Guid g && users.TryGetValue(g, out var u) ? u.DisplayName : "(unknown)";
 
-        foreach (var p in report.Problems)
-        {
-            switch (p.Kind)
-            {
-                case EmailProblemKind.SharedAcrossUsers when p.UserId is Guid u1 && p.OtherUserId is Guid u2:
-                    crossUser.Add(new CrossUserConflictRow(p.Email ?? "(unknown)", u1, DisplayName(u1), u2, DisplayName(u2)));
-                    break;
-
-                case EmailProblemKind.MultipleIsPrimary or EmailProblemKind.MultipleIsGoogle
-                    or EmailProblemKind.ZeroIsPrimary or EmailProblemKind.ZeroIsGoogle
-                    or EmailProblemKind.Unverified
-                    when p.UserId is Guid u:
-                    if (!singleUserMap.TryGetValue(u, out var list))
-                    {
-                        list = new List<string>();
-                        singleUserMap[u] = list;
-                    }
-                    list.Add(p.Kind switch
-                    {
-                        EmailProblemKind.MultipleIsPrimary => "multiple IsPrimary",
-                        EmailProblemKind.MultipleIsGoogle => "multiple IsGoogle",
-                        EmailProblemKind.ZeroIsPrimary => "zero IsPrimary",
-                        EmailProblemKind.ZeroIsGoogle => "zero IsGoogle",
-                        EmailProblemKind.Unverified => $"unverified: {p.Email}",
-                        _ => p.Kind.ToString()
-                    });
-                    break;
-
-                case EmailProblemKind.OrphanUserEmail:
-                    systemLevel.Add(new SystemLevelIssueRow(
-                        p.Kind, p.UserEmailId, p.UserId,
-                        $"Orphan UserEmail \"{p.Email}\" (was userId {p.UserId})"));
-                    break;
-
-                case EmailProblemKind.GhostExternalLogins:
-                    systemLevel.Add(new SystemLevelIssueRow(
-                        p.Kind, null, p.UserId,
-                        $"Ghost AspNetUserLogins for userId {p.UserId}"));
-                    break;
-            }
-        }
-
-        var singleUser = singleUserMap
-            .Select(kvp => new SingleUserIssueRow(kvp.Key, DisplayName(kvp.Key), kvp.Value))
-            .OrderBy(r => r.DisplayName, StringComparer.OrdinalIgnoreCase)
-            .ToList();
-
-        var vm = new EmailProblemsListViewModel
-        {
-            ScannedAt = report.ScannedAt,
-            CrossUserConflicts = crossUser,
-            SingleUserIssues = singleUser,
-            SystemLevelIssues = systemLevel
-        };
-
-        return View(vm);
+        return View(EmailProblemsListViewModel.From(report, users));
     }
 
     [HttpGet("EmailProblems/Compare")]

--- a/src/Humans.Web/Controllers/ProfileAdminController.cs
+++ b/src/Humans.Web/Controllers/ProfileAdminController.cs
@@ -97,7 +97,7 @@ public class ProfileAdminController : HumansControllerBase
             new(user.Id, user.DisplayName, user.ProfilePictureUrl,
                 profile?.AllUserEmails ?? Array.Empty<UserEmailSnapshot>(),
                 teamCount, roleCount,
-                user.LastLoginAt?.ToDateTimeUtc(),
+                user.LastLoginAt,
                 !string.IsNullOrEmpty(profile?.BurnerName));
 
         var memberships1 = await _teamService.GetUserTeamsAsync(userId1, ct);
@@ -125,24 +125,12 @@ public class ProfileAdminController : HumansControllerBase
         Guid user1Id, Guid user2Id, Guid targetUserId, string? notes,
         CancellationToken ct)
     {
-        var (error, currentUser) = await RequireCurrentUserAsync();
-        if (error is not null) return error;
+        var (authError, currentUser) = await RequireCurrentUserAsync();
+        if (authError is not null) return authError;
 
-        Guid sourceUserId;
-        if (targetUserId == user1Id) sourceUserId = user2Id;
-        else if (targetUserId == user2Id) sourceUserId = user1Id;
-        else
-        {
-            SetError("Target must be one of the two compared accounts.");
-            return RedirectToAction(nameof(EmailProblemsCompare),
-                new { userId1 = user1Id, userId2 = user2Id });
-        }
-
-        if (!await _emailProblems.UsersShareAnyEmailAsync(user1Id, user2Id, ct))
-        {
-            SetError("These accounts no longer share an email and cannot be merged here.");
-            return RedirectToAction(nameof(EmailProblems));
-        }
+        var (sourceUserId, validationError) =
+            await ResolveAndValidateMergePairAsync(user1Id, user2Id, targetUserId, ct);
+        if (validationError is not null) return validationError;
 
         try
         {
@@ -158,6 +146,28 @@ public class ProfileAdminController : HumansControllerBase
             return RedirectToAction(nameof(EmailProblemsCompare),
                 new { userId1 = user1Id, userId2 = user2Id });
         }
+    }
+
+    private async Task<(Guid SourceUserId, IActionResult? Error)> ResolveAndValidateMergePairAsync(
+        Guid user1Id, Guid user2Id, Guid targetUserId, CancellationToken ct)
+    {
+        Guid sourceUserId;
+        if (targetUserId == user1Id) sourceUserId = user2Id;
+        else if (targetUserId == user2Id) sourceUserId = user1Id;
+        else
+        {
+            SetError("Target must be one of the two compared accounts.");
+            return (Guid.Empty, RedirectToAction(nameof(EmailProblemsCompare),
+                new { userId1 = user1Id, userId2 = user2Id }));
+        }
+
+        if (!await _emailProblems.UsersShareAnyEmailAsync(user1Id, user2Id, ct))
+        {
+            SetError("These accounts no longer share an email and cannot be merged here.");
+            return (Guid.Empty, RedirectToAction(nameof(EmailProblems)));
+        }
+
+        return (sourceUserId, null);
     }
 
     [HttpPost("EmailProblems/DeleteOrphanEmail")]

--- a/src/Humans.Web/Controllers/ProfileAdminController.cs
+++ b/src/Humans.Web/Controllers/ProfileAdminController.cs
@@ -1,11 +1,13 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using Humans.Application.DTOs.EmailProblems;
 using Humans.Application.Interfaces.AuditLog;
 using Humans.Application.Interfaces.Profiles;
 using Humans.Application.Interfaces.Users;
 using Humans.Domain.Entities;
 using Humans.Web.Authorization;
+using Humans.Web.Models.EmailProblems;
 
 namespace Humans.Web.Controllers;
 
@@ -36,5 +38,81 @@ public class ProfileAdminController : HumansControllerBase
         _users = users;
         _audit = audit;
         _logger = logger;
+    }
+
+    [HttpGet("EmailProblems")]
+    public async Task<IActionResult> EmailProblems(CancellationToken ct)
+    {
+        var report = await _emailProblems.ScanAsync(ct);
+
+        var crossUser = new List<CrossUserConflictRow>();
+        var singleUserMap = new Dictionary<Guid, List<string>>();
+        var systemLevel = new List<SystemLevelIssueRow>();
+
+        var allInvolvedUserIds = report.Problems
+            .SelectMany(p => new[] { p.UserId, p.OtherUserId })
+            .OfType<Guid>()
+            .Distinct()
+            .ToList();
+        var users = await _users.GetByIdsAsync(allInvolvedUserIds, ct);
+        string DisplayName(Guid? id) =>
+            id is Guid g && users.TryGetValue(g, out var u) ? u.DisplayName : "(unknown)";
+
+        foreach (var p in report.Problems)
+        {
+            switch (p.Kind)
+            {
+                case EmailProblemKind.SharedAcrossUsers when p.UserId is Guid u1 && p.OtherUserId is Guid u2:
+                    crossUser.Add(new CrossUserConflictRow(p.Email ?? "(unknown)", u1, DisplayName(u1), u2, DisplayName(u2)));
+                    break;
+
+                case EmailProblemKind.MultipleIsPrimary or EmailProblemKind.MultipleIsGoogle
+                    or EmailProblemKind.ZeroIsPrimary or EmailProblemKind.ZeroIsGoogle
+                    or EmailProblemKind.Unverified
+                    when p.UserId is Guid u:
+                    if (!singleUserMap.TryGetValue(u, out var list))
+                    {
+                        list = new List<string>();
+                        singleUserMap[u] = list;
+                    }
+                    list.Add(p.Kind switch
+                    {
+                        EmailProblemKind.MultipleIsPrimary => "multiple IsPrimary",
+                        EmailProblemKind.MultipleIsGoogle => "multiple IsGoogle",
+                        EmailProblemKind.ZeroIsPrimary => "zero IsPrimary",
+                        EmailProblemKind.ZeroIsGoogle => "zero IsGoogle",
+                        EmailProblemKind.Unverified => $"unverified: {p.Email}",
+                        _ => p.Kind.ToString()
+                    });
+                    break;
+
+                case EmailProblemKind.OrphanUserEmail:
+                    systemLevel.Add(new SystemLevelIssueRow(
+                        p.Kind, p.UserEmailId, p.UserId,
+                        $"Orphan UserEmail \"{p.Email}\" (was userId {p.UserId})"));
+                    break;
+
+                case EmailProblemKind.GhostExternalLogins:
+                    systemLevel.Add(new SystemLevelIssueRow(
+                        p.Kind, null, p.UserId,
+                        $"Ghost AspNetUserLogins for userId {p.UserId}"));
+                    break;
+            }
+        }
+
+        var singleUser = singleUserMap
+            .Select(kvp => new SingleUserIssueRow(kvp.Key, DisplayName(kvp.Key), kvp.Value))
+            .OrderBy(r => r.DisplayName, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        var vm = new EmailProblemsListViewModel
+        {
+            ScannedAt = report.ScannedAt,
+            CrossUserConflicts = crossUser,
+            SingleUserIssues = singleUser,
+            SystemLevelIssues = systemLevel
+        };
+
+        return View(vm);
     }
 }

--- a/src/Humans.Web/Controllers/ProfileAdminController.cs
+++ b/src/Humans.Web/Controllers/ProfileAdminController.cs
@@ -179,4 +179,39 @@ public class ProfileAdminController : HumansControllerBase
 
         return View(vm);
     }
+
+    [HttpPost("EmailProblems/Merge")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Merge(
+        Guid user1Id, Guid user2Id, Guid targetUserId, string? notes,
+        CancellationToken ct)
+    {
+        var (error, currentUser) = await RequireCurrentUserAsync();
+        if (error is not null) return error;
+
+        Guid sourceUserId;
+        if (targetUserId == user1Id) sourceUserId = user2Id;
+        else if (targetUserId == user2Id) sourceUserId = user1Id;
+        else
+        {
+            SetError("Target must be one of the two compared accounts.");
+            return RedirectToAction(nameof(EmailProblemsCompare),
+                new { userId1 = user1Id, userId2 = user2Id });
+        }
+
+        try
+        {
+            await _accountMerge.AdminMergeAsync(sourceUserId, targetUserId, currentUser.Id, notes, ct);
+            SetSuccess("Accounts merged. The source account has been tombstoned.");
+            return RedirectToAction(nameof(EmailProblems));
+        }
+        catch (InvalidOperationException ex)
+        {
+            _logger.LogError(ex, "Admin-initiated merge failed: source {Source}, target {Target}",
+                sourceUserId, targetUserId);
+            SetError($"Merge failed: {ex.Message}");
+            return RedirectToAction(nameof(EmailProblemsCompare),
+                new { userId1 = user1Id, userId2 = user2Id });
+        }
+    }
 }

--- a/src/Humans.Web/Controllers/ProfileController.cs
+++ b/src/Humans.Web/Controllers/ProfileController.cs
@@ -2366,7 +2366,11 @@ public class ProfileController : HumansControllerBase
             TargetUserId = user.Id,
             TargetDisplayName = user.DisplayName,
             IsAdminContext = isAdminContext,
-            WorkspaceLockedEmailId = workspaceLockedEmail?.Id
+            WorkspaceLockedEmailId = workspaceLockedEmail?.Id,
+            LegacyIdentityEmailColumn = isAdminContext
+                && User.IsInRole(Humans.Domain.Constants.RoleNames.Admin)
+                ? user.IdentityEmailColumn
+                : null,
         };
     }
 

--- a/src/Humans.Web/Extensions/Sections/ProfileSectionExtensions.cs
+++ b/src/Humans.Web/Extensions/Sections/ProfileSectionExtensions.cs
@@ -11,6 +11,7 @@ using ProfilesUserEmailService = Humans.Application.Services.Profile.UserEmailSe
 using ProfilesCommunicationPreferenceService = Humans.Application.Services.Profile.CommunicationPreferenceService;
 using ProfilesAccountMergeService = Humans.Application.Services.Profile.AccountMergeService;
 using ProfilesDuplicateAccountService = Humans.Application.Services.Profile.DuplicateAccountService;
+using ProfilesEmailProblemsService = Humans.Application.Services.Profile.EmailProblemsService;
 using UsersAccountProvisioningService = Humans.Application.Services.Users.AccountProvisioningService;
 using UsersUnsubscribeService = Humans.Application.Services.Users.UnsubscribeService;
 using GoogleEmailProvisioningService = Humans.Application.Services.GoogleIntegration.EmailProvisioningService;
@@ -62,6 +63,7 @@ internal static class ProfileSectionExtensions
         services.AddScoped<IUserDataContributor>(sp => sp.GetRequiredService<ProfilesAccountMergeService>());
 
         services.AddScoped<IDuplicateAccountService, ProfilesDuplicateAccountService>();
+        services.AddScoped<IEmailProblemsService, ProfilesEmailProblemsService>();
         services.AddScoped<IAccountProvisioningService, UsersAccountProvisioningService>();
         services.AddScoped<IUserEmailProviderBackfillService, Humans.Application.Services.Users.UserEmailProviderBackfillService>();
 

--- a/src/Humans.Web/Models/EmailProblems/EmailProblemsCompareViewModel.cs
+++ b/src/Humans.Web/Models/EmailProblems/EmailProblemsCompareViewModel.cs
@@ -1,5 +1,6 @@
 using Humans.Application;
 using Humans.Domain.Entities;
+using NodaTime;
 
 namespace Humans.Web.Models.EmailProblems;
 
@@ -17,5 +18,5 @@ public sealed record CompareSide(
     IReadOnlyList<UserEmailSnapshot> AllUserEmails,
     int TeamCount,
     int RoleAssignmentCount,
-    DateTime? LastLogin,
+    Instant? LastLogin,
     bool IsProfileComplete);

--- a/src/Humans.Web/Models/EmailProblems/EmailProblemsCompareViewModel.cs
+++ b/src/Humans.Web/Models/EmailProblems/EmailProblemsCompareViewModel.cs
@@ -1,0 +1,21 @@
+using Humans.Application;
+using Humans.Domain.Entities;
+
+namespace Humans.Web.Models.EmailProblems;
+
+public sealed class EmailProblemsCompareViewModel
+{
+    public required string SharedEmail { get; init; }
+    public required CompareSide Account1 { get; init; }
+    public required CompareSide Account2 { get; init; }
+}
+
+public sealed record CompareSide(
+    Guid UserId,
+    string DisplayName,
+    string? ProfilePictureUrl,
+    IReadOnlyList<UserEmailSnapshot> AllUserEmails,
+    int TeamCount,
+    int RoleAssignmentCount,
+    DateTime? LastLogin,
+    bool IsProfileComplete);

--- a/src/Humans.Web/Models/EmailProblems/EmailProblemsListViewModel.cs
+++ b/src/Humans.Web/Models/EmailProblems/EmailProblemsListViewModel.cs
@@ -7,11 +7,13 @@ namespace Humans.Web.Models.EmailProblems;
 public sealed class EmailProblemsListViewModel
 {
     public Instant ScannedAt { get; init; }
-    public int TotalProblems => CrossUserConflicts.Count + SingleUserIssues.Count + SystemLevelIssues.Count;
+    public int TotalProblems =>
+        CrossUserConflicts.Count + SingleUserIssues.Count + SystemLevelIssues.Count + LegacyEmailRows.Count;
 
     public IReadOnlyList<CrossUserConflictRow> CrossUserConflicts { get; init; } = Array.Empty<CrossUserConflictRow>();
     public IReadOnlyList<SingleUserIssueRow> SingleUserIssues { get; init; } = Array.Empty<SingleUserIssueRow>();
     public IReadOnlyList<SystemLevelIssueRow> SystemLevelIssues { get; init; } = Array.Empty<SystemLevelIssueRow>();
+    public IReadOnlyList<LegacyEmailRow> LegacyEmailRows { get; init; } = Array.Empty<LegacyEmailRow>();
 
     public static EmailProblemsListViewModel From(
         EmailProblemsReport report,
@@ -23,6 +25,7 @@ public sealed class EmailProblemsListViewModel
         var crossUser = new List<CrossUserConflictRow>();
         var singleUserMap = new Dictionary<Guid, List<string>>();
         var systemLevel = new List<SystemLevelIssueRow>();
+        var legacyEmails = new List<LegacyEmailRow>();
 
         foreach (var p in report.Problems)
         {
@@ -63,6 +66,10 @@ public sealed class EmailProblemsListViewModel
                         p.Kind, null, p.UserId,
                         $"Ghost AspNetUserLogins for userId {p.UserId}"));
                     break;
+
+                case EmailProblemKind.LegacyIdentityEmailNotInUserEmails when p.UserId is Guid uid:
+                    legacyEmails.Add(new LegacyEmailRow(uid, DisplayName(uid), p.Email ?? "(unknown)"));
+                    break;
             }
         }
 
@@ -76,7 +83,10 @@ public sealed class EmailProblemsListViewModel
             ScannedAt = report.ScannedAt,
             CrossUserConflicts = crossUser,
             SingleUserIssues = singleUser,
-            SystemLevelIssues = systemLevel
+            SystemLevelIssues = systemLevel,
+            LegacyEmailRows = legacyEmails
+                .OrderBy(r => r.DisplayName, StringComparer.OrdinalIgnoreCase)
+                .ToList()
         };
     }
 }
@@ -95,3 +105,8 @@ public sealed record SystemLevelIssueRow(
     Guid? UserEmailId,
     Guid? UserId,
     string Detail);
+
+public sealed record LegacyEmailRow(
+    Guid UserId,
+    string DisplayName,
+    string LegacyEmail);

--- a/src/Humans.Web/Models/EmailProblems/EmailProblemsListViewModel.cs
+++ b/src/Humans.Web/Models/EmailProblems/EmailProblemsListViewModel.cs
@@ -1,0 +1,29 @@
+using Humans.Application.DTOs.EmailProblems;
+using NodaTime;
+
+namespace Humans.Web.Models.EmailProblems;
+
+public sealed class EmailProblemsListViewModel
+{
+    public Instant ScannedAt { get; init; }
+    public int TotalProblems => CrossUserConflicts.Count + SingleUserIssues.Count + SystemLevelIssues.Count;
+
+    public IReadOnlyList<CrossUserConflictRow> CrossUserConflicts { get; init; } = Array.Empty<CrossUserConflictRow>();
+    public IReadOnlyList<SingleUserIssueRow> SingleUserIssues { get; init; } = Array.Empty<SingleUserIssueRow>();
+    public IReadOnlyList<SystemLevelIssueRow> SystemLevelIssues { get; init; } = Array.Empty<SystemLevelIssueRow>();
+}
+
+public sealed record CrossUserConflictRow(
+    string Email,
+    Guid User1Id, string User1DisplayName,
+    Guid User2Id, string User2DisplayName);
+
+public sealed record SingleUserIssueRow(
+    Guid UserId, string DisplayName,
+    IReadOnlyList<string> ProblemSummaries);
+
+public sealed record SystemLevelIssueRow(
+    EmailProblemKind Kind,
+    Guid? UserEmailId,
+    Guid? UserId,
+    string Detail);

--- a/src/Humans.Web/Models/EmailProblems/EmailProblemsListViewModel.cs
+++ b/src/Humans.Web/Models/EmailProblems/EmailProblemsListViewModel.cs
@@ -1,4 +1,5 @@
 using Humans.Application.DTOs.EmailProblems;
+using Humans.Domain.Entities;
 using NodaTime;
 
 namespace Humans.Web.Models.EmailProblems;
@@ -11,6 +12,73 @@ public sealed class EmailProblemsListViewModel
     public IReadOnlyList<CrossUserConflictRow> CrossUserConflicts { get; init; } = Array.Empty<CrossUserConflictRow>();
     public IReadOnlyList<SingleUserIssueRow> SingleUserIssues { get; init; } = Array.Empty<SingleUserIssueRow>();
     public IReadOnlyList<SystemLevelIssueRow> SystemLevelIssues { get; init; } = Array.Empty<SystemLevelIssueRow>();
+
+    public static EmailProblemsListViewModel From(
+        EmailProblemsReport report,
+        IReadOnlyDictionary<Guid, User> users)
+    {
+        string DisplayName(Guid? id) =>
+            id is Guid g && users.TryGetValue(g, out var u) ? u.DisplayName : "(unknown)";
+
+        var crossUser = new List<CrossUserConflictRow>();
+        var singleUserMap = new Dictionary<Guid, List<string>>();
+        var systemLevel = new List<SystemLevelIssueRow>();
+
+        foreach (var p in report.Problems)
+        {
+            switch (p.Kind)
+            {
+                case EmailProblemKind.SharedAcrossUsers when p.UserId is Guid u1 && p.OtherUserId is Guid u2:
+                    crossUser.Add(new CrossUserConflictRow(p.Email ?? "(unknown)", u1, DisplayName(u1), u2, DisplayName(u2)));
+                    break;
+
+                case EmailProblemKind.MultipleIsPrimary or EmailProblemKind.MultipleIsGoogle
+                    or EmailProblemKind.ZeroIsPrimary or EmailProblemKind.ZeroIsGoogle
+                    or EmailProblemKind.Unverified
+                    when p.UserId is Guid u:
+                    if (!singleUserMap.TryGetValue(u, out var list))
+                    {
+                        list = new List<string>();
+                        singleUserMap[u] = list;
+                    }
+                    list.Add(p.Kind switch
+                    {
+                        EmailProblemKind.MultipleIsPrimary => "multiple IsPrimary",
+                        EmailProblemKind.MultipleIsGoogle => "multiple IsGoogle",
+                        EmailProblemKind.ZeroIsPrimary => "zero IsPrimary",
+                        EmailProblemKind.ZeroIsGoogle => "zero IsGoogle",
+                        EmailProblemKind.Unverified => $"unverified: {p.Email}",
+                        _ => p.Kind.ToString()
+                    });
+                    break;
+
+                case EmailProblemKind.OrphanUserEmail:
+                    systemLevel.Add(new SystemLevelIssueRow(
+                        p.Kind, p.UserEmailId, p.UserId,
+                        $"Orphan UserEmail \"{p.Email}\" (was userId {p.UserId})"));
+                    break;
+
+                case EmailProblemKind.GhostExternalLogins:
+                    systemLevel.Add(new SystemLevelIssueRow(
+                        p.Kind, null, p.UserId,
+                        $"Ghost AspNetUserLogins for userId {p.UserId}"));
+                    break;
+            }
+        }
+
+        var singleUser = singleUserMap
+            .Select(kvp => new SingleUserIssueRow(kvp.Key, DisplayName(kvp.Key), kvp.Value))
+            .OrderBy(r => r.DisplayName, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        return new EmailProblemsListViewModel
+        {
+            ScannedAt = report.ScannedAt,
+            CrossUserConflicts = crossUser,
+            SingleUserIssues = singleUser,
+            SystemLevelIssues = systemLevel
+        };
+    }
 }
 
 public sealed record CrossUserConflictRow(

--- a/src/Humans.Web/Models/EmailsViewModel.cs
+++ b/src/Humans.Web/Models/EmailsViewModel.cs
@@ -65,6 +65,16 @@ public class EmailsViewModel
     public bool IsAdminContext { get; set; }
 
     /// <summary>
+    /// Raw legacy AspNetIdentity <c>Email</c> column value for the target user.
+    /// Populated only when a full Admin views another user via the admin route —
+    /// the column is the silent fallback behind the
+    /// <c>User.Email</c>-from-<c>UserEmails</c> override and is otherwise
+    /// invisible. Diagnostic surface for the email-identity-decoupling
+    /// rollout. Null in self contexts and for non-Admin actors.
+    /// </summary>
+    public string? LegacyIdentityEmailColumn { get; set; }
+
+    /// <summary>
     /// When non-null, identifies the email row that is the user's Workspace
     /// canonical identity (Provider=Google + email on the configured Workspace
     /// domain). While set, the view locks Primary and Google radios across the

--- a/src/Humans.Web/ViewComponents/AdminNavTree.cs
+++ b/src/Humans.Web/ViewComponents/AdminNavTree.cs
@@ -55,6 +55,7 @@ public static class AdminNavTree
         {
             new("Merge requests",        "AdminMerge", "Index",            null, null, "fa-solid fa-code-merge", PolicyNames.AdminOnly),
             new("Duplicate detection",   "AdminDuplicateAccounts", "Index", null, null, "fa-solid fa-clone",      PolicyNames.AdminOnly),
+            new("Email problems",        "ProfileAdmin", "EmailProblems", null, null, "fa-solid fa-envelope-circle-check", PolicyNames.AdminOnly),
             new("Audience segmentation", "Admin", "AudienceSegmentation",   null, null, "fa-solid fa-chart-pie",  PolicyNames.AdminOnly),
             new("Legal documents",       "AdminLegalDocuments", "LegalDocuments", null, null, "fa-solid fa-scale-balanced", PolicyNames.AdminOnly),
             new("Backfill Provider/IsGoogle", "Admin", "BackfillUserEmailProviders", null, null, "fa-solid fa-key", PolicyNames.AdminOnly),

--- a/src/Humans.Web/Views/Profile/Emails.cshtml
+++ b/src/Humans.Web/Views/Profile/Emails.cshtml
@@ -58,6 +58,23 @@
             </p>
         }
 
+        @if (Model.LegacyIdentityEmailColumn is not null)
+        {
+            <div class="alert alert-secondary d-flex align-items-start mb-3 small">
+                <i class="fa-solid fa-database me-2 mt-1"></i>
+                <div>
+                    <strong>Legacy <code>User.Email</code> column:</strong>
+                    <code>@Model.LegacyIdentityEmailColumn</code>
+                    <div class="text-muted">
+                        Raw AspNetIdentity column value (Admin-only diagnostic). The
+                        runtime <code>User.Email</code> override returns the verified
+                        primary <code>UserEmail</code> row when present, falling back
+                        to this column when not.
+                    </div>
+                </div>
+            </div>
+        }
+
         <vc:temp-data-alerts />
 
         @if (!Model.IsAdminContext && Model.Emails.Any(e => e.IsPendingVerification))

--- a/src/Humans.Web/Views/ProfileAdmin/EmailProblems.cshtml
+++ b/src/Humans.Web/Views/ProfileAdmin/EmailProblems.cshtml
@@ -1,0 +1,108 @@
+@using Humans.Web.Models.EmailProblems
+@using Humans.Application.DTOs.EmailProblems
+@model EmailProblemsListViewModel
+@{
+    ViewData["Title"] = "Email Problems";
+}
+
+<h1>Email Problems</h1>
+<p class="text-muted">
+    Scanned at @Model.ScannedAt.ToDateTimeUtc().ToString("HH:mm:ss") · @Model.TotalProblems total problems
+</p>
+
+<h2>Cross-user conflicts</h2>
+@if (Model.CrossUserConflicts.Count == 0)
+{
+    <p class="text-success">No problems found</p>
+}
+else
+{
+    <table class="table">
+        <thead>
+            <tr><th>Email</th><th>User A</th><th>User B</th><th></th></tr>
+        </thead>
+        <tbody>
+            @foreach (var row in Model.CrossUserConflicts)
+            {
+                <tr>
+                    <td><code>@row.Email</code></td>
+                    <td>@row.User1DisplayName</td>
+                    <td>@row.User2DisplayName</td>
+                    <td>
+                        <a class="btn btn-sm btn-primary"
+                           asp-action="EmailProblemsCompare"
+                           asp-route-userId1="@row.User1Id"
+                           asp-route-userId2="@row.User2Id">Compare</a>
+                    </td>
+                </tr>
+            }
+        </tbody>
+    </table>
+}
+
+<h2>Single-user issues</h2>
+@if (Model.SingleUserIssues.Count == 0)
+{
+    <p class="text-success">No problems found</p>
+}
+else
+{
+    <table class="table">
+        <thead><tr><th>User</th><th>Problems</th><th></th></tr></thead>
+        <tbody>
+            @foreach (var row in Model.SingleUserIssues)
+            {
+                <tr>
+                    <td>@row.DisplayName</td>
+                    <td>@string.Join(", ", row.ProblemSummaries)</td>
+                    <td>
+                        <a class="btn btn-sm btn-secondary"
+                           href="/Profile/@row.UserId/Admin/Emails">Open emails ▸</a>
+                    </td>
+                </tr>
+            }
+        </tbody>
+    </table>
+}
+
+<h2>System-level issues</h2>
+@if (Model.SystemLevelIssues.Count == 0)
+{
+    <p class="text-success">No problems found</p>
+}
+else
+{
+    <table class="table">
+        <thead><tr><th>Issue</th><th></th></tr></thead>
+        <tbody>
+            @foreach (var row in Model.SystemLevelIssues)
+            {
+                <tr>
+                    <td>@row.Detail</td>
+                    <td>
+                        @if (row.Kind == EmailProblemKind.OrphanUserEmail)
+                        {
+                            <form method="post" asp-action="DeleteOrphanEmail"
+                                  onsubmit="return confirm('Delete orphan UserEmail row? This is irreversible.');"
+                                  class="d-inline">
+                                @Html.AntiForgeryToken()
+                                <input type="hidden" name="emailId" value="@row.UserEmailId" />
+                                <button type="submit" class="btn btn-sm btn-danger">Delete row ✕</button>
+                            </form>
+                        }
+                        else if (row.Kind == EmailProblemKind.GhostExternalLogins)
+                        {
+                            <form method="post" asp-action="DeleteGhostLogins"
+                                  onsubmit="return confirm('Delete ghost AspNetUserLogins rows? This is irreversible.');"
+                                  class="d-inline">
+                                @Html.AntiForgeryToken()
+                                <input type="hidden" name="userId" value="@row.UserId" />
+                                <button type="submit" class="btn btn-sm btn-danger">Delete logins ✕</button>
+                            </form>
+                        }
+                    </td>
+                </tr>
+            }
+        </tbody>
+    </table>
+}

--- a/src/Humans.Web/Views/ProfileAdmin/EmailProblems.cshtml
+++ b/src/Humans.Web/Views/ProfileAdmin/EmailProblems.cshtml
@@ -82,22 +82,20 @@ else
                     <td>
                         @if (row.Kind == EmailProblemKind.OrphanUserEmail)
                         {
-                            <form method="post" asp-action="DeleteOrphanEmail"
-                                  onsubmit="return confirm('Delete orphan UserEmail row? This is irreversible.');"
-                                  class="d-inline">
+                            <form method="post" asp-action="DeleteOrphanEmail" class="d-inline">
                                 @Html.AntiForgeryToken()
                                 <input type="hidden" name="emailId" value="@row.UserEmailId" />
-                                <button type="submit" class="btn btn-sm btn-danger">Delete row ✕</button>
+                                <button type="submit" class="btn btn-sm btn-danger"
+                                        data-confirm="Delete orphan UserEmail row? This is irreversible.">Delete row ✕</button>
                             </form>
                         }
                         else if (row.Kind == EmailProblemKind.GhostExternalLogins)
                         {
-                            <form method="post" asp-action="DeleteGhostLogins"
-                                  onsubmit="return confirm('Delete ghost AspNetUserLogins rows? This is irreversible.');"
-                                  class="d-inline">
+                            <form method="post" asp-action="DeleteGhostLogins" class="d-inline">
                                 @Html.AntiForgeryToken()
                                 <input type="hidden" name="userId" value="@row.UserId" />
-                                <button type="submit" class="btn btn-sm btn-danger">Delete logins ✕</button>
+                                <button type="submit" class="btn btn-sm btn-danger"
+                                        data-confirm="Delete ghost AspNetUserLogins rows? This is irreversible.">Delete logins ✕</button>
                             </form>
                         }
                     </td>
@@ -106,3 +104,13 @@ else
         </tbody>
     </table>
 }
+
+<script>
+    document.querySelectorAll('[data-confirm]').forEach(function (button) {
+        button.addEventListener('click', function (e) {
+            if (!confirm(this.getAttribute('data-confirm'))) {
+                e.preventDefault();
+            }
+        });
+    });
+</script>

--- a/src/Humans.Web/Views/ProfileAdmin/EmailProblems.cshtml
+++ b/src/Humans.Web/Views/ProfileAdmin/EmailProblems.cshtml
@@ -65,6 +65,39 @@ else
     </table>
 }
 
+<h2>Legacy User.Email column not in user_emails</h2>
+<p class="text-muted">
+    Pre-decoupling users whose <code>User.Email</code> AspNetIdentity column was populated but
+    no matching verified <code>UserEmail</code> row exists. Backfill creates a verified row from
+    the legacy column (idempotent — skips users whose row already exists).
+</p>
+@if (Model.LegacyEmailRows.Count == 0)
+{
+    <p class="text-success">No problems found</p>
+}
+else
+{
+    <form method="post" asp-action="BackfillLegacyEmails" class="mb-2">
+        @Html.AntiForgeryToken()
+        <button type="submit" class="btn btn-warning"
+                data-confirm="Backfill verified UserEmail rows for @Model.LegacyEmailRows.Count user(s) from their legacy User.Email column?">
+            Backfill all (@Model.LegacyEmailRows.Count)
+        </button>
+    </form>
+    <table class="table table-sm">
+        <thead><tr><th>User</th><th>Legacy User.Email</th></tr></thead>
+        <tbody>
+            @foreach (var row in Model.LegacyEmailRows)
+            {
+                <tr>
+                    <td>@row.DisplayName</td>
+                    <td><code>@row.LegacyEmail</code></td>
+                </tr>
+            }
+        </tbody>
+    </table>
+}
+
 <h2>System-level issues</h2>
 @if (Model.SystemLevelIssues.Count == 0)
 {

--- a/src/Humans.Web/Views/ProfileAdmin/EmailProblems.cshtml
+++ b/src/Humans.Web/Views/ProfileAdmin/EmailProblems.cshtml
@@ -7,7 +7,7 @@
 
 <h1>Email Problems</h1>
 <p class="text-muted">
-    Scanned at @Model.ScannedAt.ToDateTimeUtc().ToString("HH:mm:ss") · @Model.TotalProblems total problems
+    Scanned at @Model.ScannedAt.ToAuditTimestamp() · @Model.TotalProblems total problems
 </p>
 
 <h2>Cross-user conflicts</h2>

--- a/src/Humans.Web/Views/ProfileAdmin/EmailProblemsCompare.cshtml
+++ b/src/Humans.Web/Views/ProfileAdmin/EmailProblemsCompare.cshtml
@@ -7,8 +7,7 @@
 <h1>Compare for shared email</h1>
 <p class="text-muted">Shared email: <code>@Model.SharedEmail</code></p>
 
-<form method="post" asp-action="Merge"
-      onsubmit="return confirm('Merge these accounts? The selected SOURCE will be tombstoned. This is irreversible.');">
+<form method="post" asp-action="Merge">
     @Html.AntiForgeryToken()
 
     <div class="row">
@@ -20,7 +19,7 @@
                 <h2>@label — @side.DisplayName</h2>
                 <p>
                     Teams: @side.TeamCount · Roles: @side.RoleAssignmentCount
-                    · Last login: @(side.LastLogin?.ToString("yyyy-MM-dd") ?? "—")
+                    · Last login: @(side.LastLogin?.ToDisplayDate() ?? "—")
                     · Profile complete: @(side.IsProfileComplete ? "yes" : "no")
                 </p>
 
@@ -57,6 +56,17 @@
     <input type="hidden" name="user1Id" value="@Model.Account1.UserId" />
     <input type="hidden" name="user2Id" value="@Model.Account2.UserId" />
 
-    <button type="submit" class="btn btn-danger mt-3">Merge</button>
+    <button type="submit" class="btn btn-danger mt-3"
+            data-confirm="Merge these accounts? The selected SOURCE will be tombstoned. This is irreversible.">Merge</button>
     <a class="btn btn-secondary mt-3" asp-action="EmailProblems">Cancel</a>
 </form>
+
+<script>
+    document.querySelectorAll('[data-confirm]').forEach(function (button) {
+        button.addEventListener('click', function (e) {
+            if (!confirm(this.getAttribute('data-confirm'))) {
+                e.preventDefault();
+            }
+        });
+    });
+</script>

--- a/src/Humans.Web/Views/ProfileAdmin/EmailProblemsCompare.cshtml
+++ b/src/Humans.Web/Views/ProfileAdmin/EmailProblemsCompare.cshtml
@@ -1,0 +1,62 @@
+@using Humans.Web.Models.EmailProblems
+@model EmailProblemsCompareViewModel
+@{
+    ViewData["Title"] = "Compare accounts";
+}
+
+<h1>Compare for shared email</h1>
+<p class="text-muted">Shared email: <code>@Model.SharedEmail</code></p>
+
+<form method="post" asp-action="Merge"
+      onsubmit="return confirm('Merge these accounts? The selected SOURCE will be tombstoned. This is irreversible.');">
+    @Html.AntiForgeryToken()
+
+    <div class="row">
+        @foreach (var (side, label, isLeft) in new[] {
+            (Model.Account1, "Account A", true),
+            (Model.Account2, "Account B", false) })
+        {
+            <div class="col-md-6">
+                <h2>@label — @side.DisplayName</h2>
+                <p>
+                    Teams: @side.TeamCount · Roles: @side.RoleAssignmentCount
+                    · Last login: @(side.LastLogin?.ToString("yyyy-MM-dd") ?? "—")
+                    · Profile complete: @(side.IsProfileComplete ? "yes" : "no")
+                </p>
+
+                <table class="table table-sm">
+                    <thead>
+                        <tr><th>Email</th><th>Verified</th><th>Primary</th><th>Google</th></tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var e in side.AllUserEmails)
+                        {
+                            <tr>
+                                <td><code>@e.Email</code></td>
+                                <td>@(e.IsVerified ? "✓" : "")</td>
+                                <td>@(e.IsPrimary ? "✓" : "")</td>
+                                <td>@(e.IsGoogle ? "✓" : "")</td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+
+                <label class="form-check">
+                    <input class="form-check-input" type="radio" name="targetUserId" value="@side.UserId" required />
+                    Keep <strong>@side.DisplayName</strong> as target
+                </label>
+            </div>
+        }
+    </div>
+
+    <div class="mt-3">
+        <label for="notes" class="form-label">Admin notes (optional)</label>
+        <textarea id="notes" name="notes" class="form-control" rows="2"></textarea>
+    </div>
+
+    <input type="hidden" name="user1Id" value="@Model.Account1.UserId" />
+    <input type="hidden" name="user2Id" value="@Model.Account2.UserId" />
+
+    <button type="submit" class="btn btn-danger mt-3">Merge</button>
+    <a class="btn btn-secondary mt-3" asp-action="EmailProblems">Cancel</a>
+</form>

--- a/tests/Humans.Application.Tests/Architecture/InterfaceMethodBudgetTests.cs
+++ b/tests/Humans.Application.Tests/Architecture/InterfaceMethodBudgetTests.cs
@@ -154,7 +154,11 @@ public class InterfaceMethodBudgetTests
         // both happen through IUserMerge.ReassignAsync on UserService;
         // DuplicateAccountService routes the logins move directly via
         // IUserRepository (it doesn't run the full IUserMerge fan-out).
-        [typeof(IUserService)] = 29,
+        // 29→30: issue-660 EmailProblems case 8. Added GetUsersWithLoginsButNoEmailsAsync
+        // to surface ghost AspNetUserLogins rows (auth artifacts left behind by old
+        // account flows). Authorized by repo owner — no expiable substitute exists
+        // at the service surface (UserLogins is auth-internal).
+        [typeof(IUserService)] = 30,
     };
 
     [HumansTheory]

--- a/tests/Humans.Application.Tests/Architecture/InterfaceMethodBudgetTests.cs
+++ b/tests/Humans.Application.Tests/Architecture/InterfaceMethodBudgetTests.cs
@@ -158,7 +158,11 @@ public class InterfaceMethodBudgetTests
         // to surface ghost AspNetUserLogins rows (auth artifacts left behind by old
         // account flows). Authorized by repo owner — no expiable substitute exists
         // at the service surface (UserLogins is auth-internal).
-        [typeof(IUserService)] = 30,
+        // 30→31: issue-660 EmailProblems case 8 cleanup. Added
+        // DeleteAllExternalLoginsForUserAsync — service surface for the admin
+        // "Delete ghost logins" action. Auth-table cleanup; no expiable substitute
+        // (only the User section can write to AspNetUserLogins).
+        [typeof(IUserService)] = 31,
     };
 
     [HumansTheory]

--- a/tests/Humans.Application.Tests/Architecture/ProfileArchitectureTests.cs
+++ b/tests/Humans.Application.Tests/Architecture/ProfileArchitectureTests.cs
@@ -1,8 +1,10 @@
 using AwesomeAssertions;
 using Humans.Application.Interfaces.Repositories;
 using Humans.Application.Interfaces.Teams;
+using Humans.Application.Interfaces.Users;
 using Humans.Infrastructure.Services.Profiles;
 using Microsoft.EntityFrameworkCore;
+using NodaTime;
 using Xunit;
 using ProfileService = Humans.Application.Services.Profile.ProfileService;
 using ContactFieldService = Humans.Application.Services.Profile.ContactFieldService;
@@ -10,6 +12,7 @@ using UserEmailService = Humans.Application.Services.Profile.UserEmailService;
 using CommunicationPreferenceService = Humans.Application.Services.Profile.CommunicationPreferenceService;
 using AccountMergeService = Humans.Application.Services.Profile.AccountMergeService;
 using DuplicateAccountService = Humans.Application.Services.Profile.DuplicateAccountService;
+using EmailProblemsService = Humans.Application.Services.Profile.EmailProblemsService;
 using Humans.Application.Interfaces.Profiles;
 
 namespace Humans.Application.Tests.Architecture;
@@ -272,5 +275,25 @@ public class ProfileArchitectureTests
         typeof(IAccountMergeRepository).Namespace
             .Should().Be("Humans.Application.Interfaces.Repositories",
                 because: "repository interfaces live in Humans.Application.Interfaces.Repositories per design-rules §3");
+    }
+
+    // ── EmailProblemsService (issue #660) ─────────────────────────────────────
+
+    [HumansFact]
+    public void EmailProblemsService_DependsOnlyOnSectionServices_NotRepositories()
+    {
+        var ctor = typeof(EmailProblemsService).GetConstructors().Single();
+        var paramTypes = ctor.GetParameters().Select(p => p.ParameterType).ToList();
+
+        var allowed = new[]
+        {
+            typeof(IProfileService),
+            typeof(IUserEmailService),
+            typeof(IUserService),
+            typeof(IClock)
+        };
+
+        paramTypes.Should().OnlyContain(t => allowed.Contains(t),
+            "EmailProblemsService must use existing section services, never repositories or DbContext");
     }
 }

--- a/tests/Humans.Application.Tests/Controllers/ProfileAdminControllerTests.cs
+++ b/tests/Humans.Application.Tests/Controllers/ProfileAdminControllerTests.cs
@@ -119,6 +119,7 @@ public class ProfileAdminControllerTests
     {
         var u1 = Guid.NewGuid();
         var u2 = Guid.NewGuid();
+        _emailProblems.UsersShareAnyEmailAsync(u1, u2, Arg.Any<CancellationToken>()).Returns(true);
 
         var result = await BuildController().Merge(u1, u2, targetUserId: u1, notes: null, ct: default);
 
@@ -140,6 +141,21 @@ public class ProfileAdminControllerTests
             Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
         result.Should().BeOfType<RedirectToActionResult>()
             .Which.ActionName.Should().Be(nameof(ProfileAdminController.EmailProblemsCompare));
+    }
+
+    [HumansFact]
+    public async Task Merge_UsersDoNotShareEmail_RedirectsToList_NoMergeCall()
+    {
+        var u1 = Guid.NewGuid();
+        var u2 = Guid.NewGuid();
+        _emailProblems.UsersShareAnyEmailAsync(u1, u2, Arg.Any<CancellationToken>()).Returns(false);
+
+        var result = await BuildController().Merge(u1, u2, targetUserId: u1, notes: null, ct: default);
+
+        await _accountMerge.DidNotReceive().AdminMergeAsync(
+            Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
+        result.Should().BeOfType<RedirectToActionResult>()
+            .Which.ActionName.Should().Be(nameof(ProfileAdminController.EmailProblems));
     }
 
     [HumansFact]
@@ -176,6 +192,7 @@ public class ProfileAdminControllerTests
     public async Task DeleteGhostLogins_RowsDeleted_AuditsWithCount()
     {
         var userId = Guid.NewGuid();
+        _emailProblems.IsGhostExternalLoginsUserAsync(userId, Arg.Any<CancellationToken>()).Returns(true);
         _users.DeleteAllExternalLoginsForUserAsync(userId, Arg.Any<CancellationToken>()).Returns(3);
 
         var result = await BuildController().DeleteGhostLogins(userId, default);
@@ -184,6 +201,22 @@ public class ProfileAdminControllerTests
             AuditAction.GhostExternalLoginsDeleted, nameof(User), userId,
             Arg.Is<string>(s => s.Contains("3")),
             _adminUserId);
+        result.Should().BeOfType<RedirectToActionResult>();
+    }
+
+    [HumansFact]
+    public async Task DeleteGhostLogins_NotInGhostSet_NoOpsAndNoAudit()
+    {
+        var userId = Guid.NewGuid();
+        _emailProblems.IsGhostExternalLoginsUserAsync(userId, Arg.Any<CancellationToken>()).Returns(false);
+
+        var result = await BuildController().DeleteGhostLogins(userId, default);
+
+        await _users.DidNotReceive().DeleteAllExternalLoginsForUserAsync(
+            Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+        await _audit.DidNotReceive().LogAsync(
+            Arg.Any<AuditAction>(), Arg.Any<string>(), Arg.Any<Guid>(),
+            Arg.Any<string>(), Arg.Any<Guid>());
         result.Should().BeOfType<RedirectToActionResult>();
     }
 }

--- a/tests/Humans.Application.Tests/Controllers/ProfileAdminControllerTests.cs
+++ b/tests/Humans.Application.Tests/Controllers/ProfileAdminControllerTests.cs
@@ -1,0 +1,189 @@
+using System.Security.Claims;
+using AwesomeAssertions;
+using Humans.Application.DTOs.EmailProblems;
+using Humans.Application.Interfaces.AuditLog;
+using Humans.Application.Interfaces.Auth;
+using Humans.Application.Interfaces.Profiles;
+using Humans.Application.Interfaces.Teams;
+using Humans.Application.Interfaces.Users;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using Humans.Testing;
+using Humans.Web.Authorization;
+using Humans.Web.Controllers;
+using Humans.Web.Models.EmailProblems;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.Routing;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace Humans.Application.Tests.Controllers;
+
+public class ProfileAdminControllerTests
+{
+    private readonly IEmailProblemsService _emailProblems = Substitute.For<IEmailProblemsService>();
+    private readonly IAccountMergeService _accountMerge = Substitute.For<IAccountMergeService>();
+    private readonly IUserEmailService _userEmails = Substitute.For<IUserEmailService>();
+    private readonly IUserService _users = Substitute.For<IUserService>();
+    private readonly IProfileService _profileService = Substitute.For<IProfileService>();
+    private readonly ITeamService _teamService = Substitute.For<ITeamService>();
+    private readonly IRoleAssignmentService _roleAssignmentService = Substitute.For<IRoleAssignmentService>();
+    private readonly IAuditLogService _audit = Substitute.For<IAuditLogService>();
+    private readonly UserManager<User> _userManager;
+    private readonly Guid _adminUserId = Guid.NewGuid();
+    private readonly User _adminUser;
+
+    public ProfileAdminControllerTests()
+    {
+        _adminUser = new User { Id = _adminUserId };
+        var userStore = Substitute.For<IUserStore<User>>();
+        _userManager = Substitute.For<UserManager<User>>(
+            userStore, null, null, null, null, null, null, null, null);
+        _userManager.GetUserAsync(Arg.Any<ClaimsPrincipal>()).Returns(_adminUser);
+    }
+
+    private ProfileAdminController BuildController()
+    {
+        var c = new ProfileAdminController(
+            _userManager,
+            _emailProblems,
+            _accountMerge,
+            _userEmails,
+            _users,
+            _audit,
+            NullLogger<ProfileAdminController>.Instance,
+            _profileService,
+            _teamService,
+            _roleAssignmentService);
+
+        var identity = new ClaimsIdentity(new[]
+        {
+            new Claim(ClaimTypes.NameIdentifier, _adminUserId.ToString()),
+        }, authenticationType: "TestAuth");
+        var principal = new ClaimsPrincipal(identity);
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        var httpContext = new DefaultHttpContext
+        {
+            User = principal,
+            RequestServices = services.BuildServiceProvider(),
+        };
+
+        c.ControllerContext = new ControllerContext
+        {
+            HttpContext = httpContext,
+            ActionDescriptor = new ControllerActionDescriptor { ActionName = "Test" },
+            RouteData = new RouteData(),
+        };
+        c.TempData = new TempDataDictionary(httpContext, Substitute.For<ITempDataProvider>());
+        c.Url = Substitute.For<IUrlHelper>();
+        return c;
+    }
+
+    [HumansFact]
+    public void Controller_HasAdminOnlyPolicyAttribute()
+    {
+        var attr = typeof(ProfileAdminController)
+            .GetCustomAttributes(typeof(AuthorizeAttribute), inherit: false)
+            .Cast<AuthorizeAttribute>()
+            .Single();
+        attr.Policy.Should().Be(PolicyNames.AdminOnly);
+    }
+
+    [HumansFact]
+    public async Task EmailProblems_GET_CallsScanAndReturnsViewWithModel()
+    {
+        _emailProblems.ScanAsync(Arg.Any<CancellationToken>())
+            .Returns(new EmailProblemsReport(NodaTime.SystemClock.Instance.GetCurrentInstant(),
+                Array.Empty<EmailProblem>()));
+        _users.GetByIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<Guid, User>());
+
+        var result = await BuildController().EmailProblems(default);
+
+        result.Should().BeOfType<ViewResult>()
+            .Which.Model.Should().BeOfType<EmailProblemsListViewModel>();
+        await _emailProblems.Received(1).ScanAsync(Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task Merge_TargetEqualsUser1_CallsAdminMergeWithUser2AsSource()
+    {
+        var u1 = Guid.NewGuid();
+        var u2 = Guid.NewGuid();
+
+        var result = await BuildController().Merge(u1, u2, targetUserId: u1, notes: null, ct: default);
+
+        await _accountMerge.Received(1).AdminMergeAsync(u2, u1, _adminUserId, null, Arg.Any<CancellationToken>());
+        result.Should().BeOfType<RedirectToActionResult>()
+            .Which.ActionName.Should().Be(nameof(ProfileAdminController.EmailProblems));
+    }
+
+    [HumansFact]
+    public async Task Merge_TargetNotInPair_RedirectsToCompareWithError_NoMergeCall()
+    {
+        var u1 = Guid.NewGuid();
+        var u2 = Guid.NewGuid();
+        var stranger = Guid.NewGuid();
+
+        var result = await BuildController().Merge(u1, u2, targetUserId: stranger, notes: null, ct: default);
+
+        await _accountMerge.DidNotReceive().AdminMergeAsync(
+            Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
+        result.Should().BeOfType<RedirectToActionResult>()
+            .Which.ActionName.Should().Be(nameof(ProfileAdminController.EmailProblemsCompare));
+    }
+
+    [HumansFact]
+    public async Task DeleteOrphanEmail_RowExists_AuditsAndRedirects()
+    {
+        var emailId = Guid.NewGuid();
+        _userEmails.DeleteByIdAsync(emailId, Arg.Any<CancellationToken>()).Returns(true);
+
+        var result = await BuildController().DeleteOrphanEmail(emailId, default);
+
+        await _audit.Received(1).LogAsync(
+            AuditAction.OrphanUserEmailDeleted,
+            nameof(UserEmail), emailId,
+            Arg.Any<string>(),
+            _adminUserId);
+        result.Should().BeOfType<RedirectToActionResult>();
+    }
+
+    [HumansFact]
+    public async Task DeleteOrphanEmail_RowGone_NoAudit()
+    {
+        var emailId = Guid.NewGuid();
+        _userEmails.DeleteByIdAsync(emailId, Arg.Any<CancellationToken>()).Returns(false);
+
+        var result = await BuildController().DeleteOrphanEmail(emailId, default);
+
+        await _audit.DidNotReceive().LogAsync(
+            Arg.Any<AuditAction>(), Arg.Any<string>(), Arg.Any<Guid>(),
+            Arg.Any<string>(), Arg.Any<Guid>());
+        result.Should().BeOfType<RedirectToActionResult>();
+    }
+
+    [HumansFact]
+    public async Task DeleteGhostLogins_RowsDeleted_AuditsWithCount()
+    {
+        var userId = Guid.NewGuid();
+        _users.DeleteAllExternalLoginsForUserAsync(userId, Arg.Any<CancellationToken>()).Returns(3);
+
+        var result = await BuildController().DeleteGhostLogins(userId, default);
+
+        await _audit.Received(1).LogAsync(
+            AuditAction.GhostExternalLoginsDeleted, nameof(User), userId,
+            Arg.Is<string>(s => s.Contains("3")),
+            _adminUserId);
+        result.Should().BeOfType<RedirectToActionResult>();
+    }
+}

--- a/tests/Humans.Application.Tests/Controllers/ProfileAdminControllerTests.cs
+++ b/tests/Humans.Application.Tests/Controllers/ProfileAdminControllerTests.cs
@@ -205,6 +205,42 @@ public class ProfileAdminControllerTests
     }
 
     [HumansFact]
+    public async Task BackfillLegacyEmails_AuditsEachReturnedRow()
+    {
+        var u1 = Guid.NewGuid();
+        var u2 = Guid.NewGuid();
+        _emailProblems.BackfillLegacyIdentityEmailsAsync(Arg.Any<CancellationToken>())
+            .Returns(new List<(Guid, string)> { (u1, "a@x.com"), (u2, "b@x.com") });
+
+        var result = await BuildController().BackfillLegacyEmails(default);
+
+        await _audit.Received(1).LogAsync(
+            AuditAction.LegacyIdentityEmailBackfilled, nameof(User), u1,
+            Arg.Is<string>(s => s.Contains("a@x.com")),
+            _adminUserId);
+        await _audit.Received(1).LogAsync(
+            AuditAction.LegacyIdentityEmailBackfilled, nameof(User), u2,
+            Arg.Is<string>(s => s.Contains("b@x.com")),
+            _adminUserId);
+        result.Should().BeOfType<RedirectToActionResult>()
+            .Which.ActionName.Should().Be(nameof(ProfileAdminController.EmailProblems));
+    }
+
+    [HumansFact]
+    public async Task BackfillLegacyEmails_NoneToBackfill_NoAudit()
+    {
+        _emailProblems.BackfillLegacyIdentityEmailsAsync(Arg.Any<CancellationToken>())
+            .Returns(new List<(Guid, string)>());
+
+        var result = await BuildController().BackfillLegacyEmails(default);
+
+        await _audit.DidNotReceive().LogAsync(
+            Arg.Any<AuditAction>(), Arg.Any<string>(), Arg.Any<Guid>(),
+            Arg.Any<string>(), Arg.Any<Guid>());
+        result.Should().BeOfType<RedirectToActionResult>();
+    }
+
+    [HumansFact]
     public async Task DeleteGhostLogins_NotInGhostSet_NoOpsAndNoAudit()
     {
         var userId = Guid.NewGuid();

--- a/tests/Humans.Application.Tests/Services/AccountMergeServiceAdminMergeTests.cs
+++ b/tests/Humans.Application.Tests/Services/AccountMergeServiceAdminMergeTests.cs
@@ -1,0 +1,91 @@
+using AwesomeAssertions;
+using Humans.Application.Interfaces.AuditLog;
+using Humans.Application.Interfaces.Auth;
+using Humans.Application.Interfaces.Gdpr;
+using Humans.Application.Interfaces.Notifications;
+using Humans.Application.Interfaces.Profiles;
+using Humans.Application.Interfaces.Repositories;
+using Humans.Application.Interfaces.Teams;
+using Humans.Application.Interfaces.Users;
+using Humans.Application.Services.Profile;
+using Humans.Domain.Entities;
+using Microsoft.Extensions.Logging.Abstractions;
+using NodaTime.Testing;
+using NSubstitute;
+
+namespace Humans.Application.Tests.Services;
+
+public class AccountMergeServiceAdminMergeTests
+{
+    private readonly IAccountMergeRepository _mergeRepo = Substitute.For<IAccountMergeRepository>();
+    private readonly IUserEmailRepository _userEmailRepo = Substitute.For<IUserEmailRepository>();
+    private readonly IAuditLogService _audit = Substitute.For<IAuditLogService>();
+    private readonly IFullProfileInvalidator _fullProfileInvalidator = Substitute.For<IFullProfileInvalidator>();
+    private readonly IUserService _userService = Substitute.For<IUserService>();
+    private readonly ITeamService _team = Substitute.For<ITeamService>();
+    private readonly IRoleAssignmentService _roles = Substitute.For<IRoleAssignmentService>();
+    private readonly INotificationService _notify = Substitute.For<INotificationService>();
+    private readonly List<IUserMerge> _userMerges = new();
+    private readonly FakeClock _clock = new(NodaTime.Instant.FromUtc(2026, 5, 5, 12, 0));
+
+    private AccountMergeService BuildSut() =>
+        new(
+            _mergeRepo, _userEmailRepo, _audit, _fullProfileInvalidator,
+            NullLogger<AccountMergeService>.Instance, _clock,
+            _userMerges, _userService, _team, _roles, _notify);
+
+    private void SetupUsers(Guid sourceId, Guid targetId, bool sourceTombstoned = false)
+    {
+        _userService.GetByIdAsync(sourceId, Arg.Any<CancellationToken>())
+            .Returns(new User { Id = sourceId, MergedToUserId = sourceTombstoned ? targetId : (Guid?)null });
+        _userService.GetByIdAsync(targetId, Arg.Any<CancellationToken>())
+            .Returns(new User { Id = targetId });
+    }
+
+    [HumansFact]
+    public async Task AdminMergeAsync_HappyPath_RunsFanOutAndTombstone()
+    {
+        var src = Guid.NewGuid(); var tgt = Guid.NewGuid(); var admin = Guid.NewGuid();
+        SetupUsers(src, tgt);
+        var merger = Substitute.For<IUserMerge>();
+        _userMerges.Add(merger);
+
+        await BuildSut().AdminMergeAsync(src, tgt, admin);
+
+        await merger.Received(1).ReassignAsync(src, tgt, admin,
+            Arg.Any<NodaTime.Instant>(), Arg.Any<CancellationToken>());
+        await _userService.Received(1).AnonymizeForMergeAsync(src, tgt,
+            Arg.Any<NodaTime.Instant>(), Arg.Any<CancellationToken>());
+        await _userEmailRepo.DidNotReceive().MarkVerifiedAsync(
+            Arg.Any<Guid>(), Arg.Any<NodaTime.Instant>(), Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task AdminMergeAsync_SourceEqualsTarget_Throws()
+    {
+        var id = Guid.NewGuid();
+        var act = () => BuildSut().AdminMergeAsync(id, id, Guid.NewGuid());
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    [HumansFact]
+    public async Task AdminMergeAsync_SourceMissing_Throws()
+    {
+        var src = Guid.NewGuid(); var tgt = Guid.NewGuid();
+        _userService.GetByIdAsync(tgt, Arg.Any<CancellationToken>())
+            .Returns(new User { Id = tgt });
+        // source returns null by default — Substitute.For<>'s default for Task<User?> is null
+        var act = () => BuildSut().AdminMergeAsync(src, tgt, Guid.NewGuid());
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    [HumansFact]
+    public async Task AdminMergeAsync_SourceAlreadyTombstoned_Throws()
+    {
+        var src = Guid.NewGuid(); var tgt = Guid.NewGuid();
+        SetupUsers(src, tgt, sourceTombstoned: true);
+        var act = () => BuildSut().AdminMergeAsync(src, tgt, Guid.NewGuid());
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*tombstoned*");
+    }
+}

--- a/tests/Humans.Application.Tests/Services/AccountProvisioningServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/AccountProvisioningServiceTests.cs
@@ -220,6 +220,8 @@ public class AccountProvisioningServiceTests
         public Task<IReadOnlyList<Guid>> GetMergedSourceIdsAsync(
             Guid targetUserId, CancellationToken ct = default) =>
             throw new NotSupportedException();
+        public Task<IReadOnlyList<Guid>> GetUsersWithLoginsButNoEmailsAsync(CancellationToken ct = default) =>
+            throw new NotSupportedException();
     }
 
     private sealed class FakeUserEmailRepository : IUserEmailRepository

--- a/tests/Humans.Application.Tests/Services/AccountProvisioningServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/AccountProvisioningServiceTests.cs
@@ -222,6 +222,8 @@ public class AccountProvisioningServiceTests
             throw new NotSupportedException();
         public Task<IReadOnlyList<Guid>> GetUsersWithLoginsButNoEmailsAsync(CancellationToken ct = default) =>
             throw new NotSupportedException();
+        public Task<int> DeleteAllExternalLoginsForUserAsync(Guid userId, CancellationToken ct = default) =>
+            throw new NotSupportedException();
     }
 
     private sealed class FakeUserEmailRepository : IUserEmailRepository

--- a/tests/Humans.Application.Tests/Services/EmailProblemsServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/EmailProblemsServiceTests.cs
@@ -197,4 +197,28 @@ public class EmailProblemsServiceTests
 
         report.Problems.Should().ContainSingle(p => p.Kind == EmailProblemKind.SharedAcrossUsers);
     }
+
+    [HumansFact]
+    public async Task DetectsOrphanUserEmail()
+    {
+        var deadUserId = Guid.NewGuid();
+        var emailId = Guid.NewGuid();
+        SetProfiles();
+        SetOrphans(new UserEmail
+        {
+            Id = emailId,
+            UserId = deadUserId,
+            Email = "ghost@x.com",
+            IsVerified = true
+        });
+        SetGhosts();
+
+        var report = await Sut.ScanAsync();
+
+        report.Problems.Should().ContainSingle(p =>
+            p.Kind == EmailProblemKind.OrphanUserEmail
+            && p.UserEmailId == emailId
+            && p.UserId == deadUserId
+            && p.Email == "ghost@x.com");
+    }
 }

--- a/tests/Humans.Application.Tests/Services/EmailProblemsServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/EmailProblemsServiceTests.cs
@@ -221,4 +221,18 @@ public class EmailProblemsServiceTests
             && p.UserId == deadUserId
             && p.Email == "ghost@x.com");
     }
+
+    [HumansFact]
+    public async Task DetectsGhostExternalLogins()
+    {
+        var ghostUserId = Guid.NewGuid();
+        SetProfiles();
+        SetOrphans();
+        SetGhosts(ghostUserId);
+
+        var report = await Sut.ScanAsync();
+
+        report.Problems.Should().ContainSingle(p =>
+            p.Kind == EmailProblemKind.GhostExternalLogins && p.UserId == ghostUserId);
+    }
 }

--- a/tests/Humans.Application.Tests/Services/EmailProblemsServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/EmailProblemsServiceTests.cs
@@ -1,0 +1,88 @@
+using AwesomeAssertions;
+using Humans.Application.DTOs.EmailProblems;
+using Humans.Application.Interfaces.Profiles;
+using Humans.Application.Interfaces.Users;
+using Humans.Application.Services.Profile;
+using Humans.Domain.Entities;
+using NodaTime.Testing;
+using NSubstitute;
+
+namespace Humans.Application.Tests.Services;
+
+public class EmailProblemsServiceTests
+{
+    private readonly IProfileService _profileService = Substitute.For<IProfileService>();
+    private readonly IUserEmailService _userEmailService = Substitute.For<IUserEmailService>();
+    private readonly IUserService _userService = Substitute.For<IUserService>();
+    private readonly FakeClock _clock = new(NodaTime.Instant.FromUtc(2026, 5, 5, 12, 0));
+
+    private EmailProblemsService Sut => new(
+        _profileService, _userEmailService, _userService, _clock);
+
+    private static FullProfile MakeProfile(Guid userId, params UserEmailSnapshot[] emails) =>
+        new FullProfile(
+            UserId: userId, DisplayName: "Test User", ProfilePictureUrl: null,
+            HasCustomPicture: false, ProfileId: Guid.NewGuid(), UpdatedAtTicks: 0,
+            BurnerName: "Test", Bio: null, Pronouns: null, ContributionInterests: null,
+            City: null, CountryCode: null, Latitude: null, Longitude: null,
+            BirthdayDay: null, BirthdayMonth: null,
+            IsApproved: true, IsSuspended: false,
+            CVEntries: Array.Empty<CVEntry>(),
+            UserEmails: emails);
+
+    private void SetProfiles(params FullProfile[] profiles) =>
+        _profileService.GetFullProfileSnapshotAsync(Arg.Any<CancellationToken>())
+            .Returns(profiles);
+
+    private void SetOrphans(params UserEmail[] orphans) =>
+        _userEmailService.GetOrphanUserEmailsAsync(Arg.Any<CancellationToken>())
+            .Returns(orphans);
+
+    private void SetGhosts(params Guid[] ghostUserIds) =>
+        _userService.GetUsersWithLoginsButNoEmailsAsync(Arg.Any<CancellationToken>())
+            .Returns(ghostUserIds);
+
+    [HumansFact]
+    public async Task EmptySnapshot_ReturnsEmptyReport()
+    {
+        SetProfiles();
+        SetOrphans();
+        SetGhosts();
+
+        var report = await Sut.ScanAsync();
+
+        report.Problems.Should().BeEmpty();
+    }
+
+    [HumansFact]
+    public async Task DetectsMultipleIsPrimary()
+    {
+        var userId = Guid.NewGuid();
+        SetProfiles(MakeProfile(userId,
+            new UserEmailSnapshot(Guid.NewGuid(), "a@x.com", true, true, false),
+            new UserEmailSnapshot(Guid.NewGuid(), "b@x.com", true, true, false)));
+        SetOrphans();
+        SetGhosts();
+
+        var report = await Sut.ScanAsync();
+
+        report.Problems.Should().ContainSingle(p =>
+            p.Kind == EmailProblemKind.MultipleIsPrimary && p.UserId == userId);
+    }
+
+    [HumansFact]
+    public async Task DetectsMultipleIsGoogle()
+    {
+        var userId = Guid.NewGuid();
+        SetProfiles(MakeProfile(userId,
+            new UserEmailSnapshot(Guid.NewGuid(), "a@x.com", true, false, true),
+            new UserEmailSnapshot(Guid.NewGuid(), "b@x.com", true, false, true)));
+        SetOrphans();
+        SetGhosts();
+
+        var report = await Sut.ScanAsync();
+
+        report.Problems.Should().ContainSingle(p =>
+            p.Kind == EmailProblemKind.MultipleIsGoogle && p.UserId == userId);
+    }
+}

--- a/tests/Humans.Application.Tests/Services/EmailProblemsServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/EmailProblemsServiceTests.cs
@@ -299,4 +299,126 @@ public class EmailProblemsServiceTests
 
         (await Sut.IsGhostExternalLoginsUserAsync(otherUserId)).Should().BeFalse();
     }
+
+    private void SetUsersWithProfiles(params (User User, FullProfile Profile)[] pairs)
+    {
+        var users = pairs.Select(p => p.User).ToList();
+        _userService.GetAllUsersAsync(Arg.Any<CancellationToken>()).Returns(users);
+        foreach (var (u, profile) in pairs)
+        {
+            _profileService.GetFullProfileAsync(u.Id, Arg.Any<CancellationToken>())
+                .Returns(new ValueTask<FullProfile?>(profile));
+        }
+    }
+
+    private static User MakeUser(Guid id, string? legacyEmail) =>
+        new User { Id = id, DisplayName = "Test User", Email = legacyEmail };
+
+    [HumansFact]
+    public async Task DetectsLegacyIdentityEmailNotInUserEmails()
+    {
+        var userId = Guid.NewGuid();
+        var user = MakeUser(userId, "legacy@x.com");
+        SetUsersWithProfiles((user, MakeProfile(userId,
+            new UserEmailSnapshot(Guid.NewGuid(), "other@x.com", true, true, false))));
+        SetOrphans();
+        SetGhosts();
+
+        var report = await Sut.ScanAsync();
+
+        report.Problems.Should().ContainSingle(p =>
+            p.Kind == EmailProblemKind.LegacyIdentityEmailNotInUserEmails
+            && p.UserId == userId
+            && p.Email == "legacy@x.com");
+    }
+
+    [HumansFact]
+    public async Task DoesNotFlagLegacyEmail_WhenMatchingVerifiedRowExists()
+    {
+        var userId = Guid.NewGuid();
+        var user = MakeUser(userId, "match@x.com");
+        SetUsersWithProfiles((user, MakeProfile(userId,
+            new UserEmailSnapshot(Guid.NewGuid(), "match@x.com", true, true, false))));
+        SetOrphans();
+        SetGhosts();
+
+        var report = await Sut.ScanAsync();
+
+        report.Problems.Should().NotContain(p =>
+            p.Kind == EmailProblemKind.LegacyIdentityEmailNotInUserEmails);
+    }
+
+    [HumansFact]
+    public async Task DoesNotFlagLegacyEmail_WhenColumnIsNull()
+    {
+        var userId = Guid.NewGuid();
+        var user = MakeUser(userId, legacyEmail: null);
+        SetUsersWithProfiles((user, MakeProfile(userId)));
+        SetOrphans();
+        SetGhosts();
+
+        var report = await Sut.ScanAsync();
+
+        report.Problems.Should().NotContain(p =>
+            p.Kind == EmailProblemKind.LegacyIdentityEmailNotInUserEmails);
+    }
+
+    [HumansFact]
+    public async Task DoesNotFlagLegacyEmail_WhenMatchingRowIsUnverified()
+    {
+        var userId = Guid.NewGuid();
+        var user = MakeUser(userId, "legacy@x.com");
+        SetUsersWithProfiles((user, MakeProfile(userId,
+            new UserEmailSnapshot(Guid.NewGuid(), "legacy@x.com", false, false, false))));
+        SetOrphans();
+        SetGhosts();
+
+        var report = await Sut.ScanAsync();
+
+        report.Problems.Should().ContainSingle(p =>
+            p.Kind == EmailProblemKind.LegacyIdentityEmailNotInUserEmails
+            && p.UserId == userId);
+    }
+
+    [HumansFact]
+    public async Task BackfillLegacyIdentityEmails_FlaggedUser_CallsAddVerifiedAndReturnsPair()
+    {
+        var userId = Guid.NewGuid();
+        var user = MakeUser(userId, "legacy@x.com");
+        SetUsersWithProfiles((user, MakeProfile(userId)));
+
+        var result = await Sut.BackfillLegacyIdentityEmailsAsync();
+
+        result.Should().ContainSingle()
+            .Which.Should().Be((userId, "legacy@x.com"));
+        await _userEmailService.Received(1).AddVerifiedEmailAsync(
+            userId, "legacy@x.com", Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task BackfillLegacyIdentityEmails_AlreadyHasMatchingVerifiedRow_SkipsUser()
+    {
+        var userId = Guid.NewGuid();
+        var user = MakeUser(userId, "match@x.com");
+        SetUsersWithProfiles((user, MakeProfile(userId,
+            new UserEmailSnapshot(Guid.NewGuid(), "match@x.com", true, true, false))));
+
+        var result = await Sut.BackfillLegacyIdentityEmailsAsync();
+
+        result.Should().BeEmpty();
+        await _userEmailService.DidNotReceive().AddVerifiedEmailAsync(
+            Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task BackfillLegacyIdentityEmails_NullColumn_SkipsUser()
+    {
+        var userId = Guid.NewGuid();
+        var user = MakeUser(userId, legacyEmail: null);
+        SetUsersWithProfiles((user, MakeProfile(userId)));
+
+        var result = await Sut.BackfillLegacyIdentityEmailsAsync();
+
+        result.Should().BeEmpty();
+    }
 }

--- a/tests/Humans.Application.Tests/Services/EmailProblemsServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/EmailProblemsServiceTests.cs
@@ -30,9 +30,20 @@ public class EmailProblemsServiceTests
             CVEntries: Array.Empty<CVEntry>(),
             UserEmails: emails);
 
-    private void SetProfiles(params FullProfile[] profiles) =>
-        _profileService.GetFullProfileSnapshotAsync(Arg.Any<CancellationToken>())
-            .Returns(profiles);
+    private void SetProfiles(params FullProfile[] profiles)
+    {
+        var users = profiles
+            .Select(p => new User { Id = p.UserId })
+            .ToList();
+        _userService.GetAllUsersAsync(Arg.Any<CancellationToken>())
+            .Returns(users);
+
+        foreach (var p in profiles)
+        {
+            _profileService.GetFullProfileAsync(p.UserId, Arg.Any<CancellationToken>())
+                .Returns(new ValueTask<FullProfile?>(p));
+        }
+    }
 
     private void SetOrphans(params UserEmail[] orphans) =>
         _userEmailService.GetOrphanUserEmailsAsync(Arg.Any<CancellationToken>())

--- a/tests/Humans.Application.Tests/Services/EmailProblemsServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/EmailProblemsServiceTests.cs
@@ -85,4 +85,49 @@ public class EmailProblemsServiceTests
         report.Problems.Should().ContainSingle(p =>
             p.Kind == EmailProblemKind.MultipleIsGoogle && p.UserId == userId);
     }
+
+    [HumansFact]
+    public async Task DetectsZeroIsPrimary_WhenUserHasVerifiedEmails()
+    {
+        var userId = Guid.NewGuid();
+        SetProfiles(MakeProfile(userId,
+            new UserEmailSnapshot(Guid.NewGuid(), "a@x.com", true, false, false),
+            new UserEmailSnapshot(Guid.NewGuid(), "b@x.com", true, false, false)));
+        SetOrphans();
+        SetGhosts();
+
+        var report = await Sut.ScanAsync();
+
+        report.Problems.Should().ContainSingle(p =>
+            p.Kind == EmailProblemKind.ZeroIsPrimary && p.UserId == userId);
+    }
+
+    [HumansFact]
+    public async Task DoesNotFlagZeroIsPrimary_WhenUserHasNoVerifiedEmails()
+    {
+        var userId = Guid.NewGuid();
+        SetProfiles(MakeProfile(userId,
+            new UserEmailSnapshot(Guid.NewGuid(), "a@x.com", false, false, false)));
+        SetOrphans();
+        SetGhosts();
+
+        var report = await Sut.ScanAsync();
+
+        report.Problems.Should().NotContain(p => p.Kind == EmailProblemKind.ZeroIsPrimary);
+    }
+
+    [HumansFact]
+    public async Task DetectsZeroIsGoogle()
+    {
+        var userId = Guid.NewGuid();
+        SetProfiles(MakeProfile(userId,
+            new UserEmailSnapshot(Guid.NewGuid(), "a@x.com", true, true, false)));
+        SetOrphans();
+        SetGhosts();
+
+        var report = await Sut.ScanAsync();
+
+        report.Problems.Should().ContainSingle(p =>
+            p.Kind == EmailProblemKind.ZeroIsGoogle && p.UserId == userId);
+    }
 }

--- a/tests/Humans.Application.Tests/Services/EmailProblemsServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/EmailProblemsServiceTests.cs
@@ -160,4 +160,41 @@ public class EmailProblemsServiceTests
             && p.UserEmailId == emailId
             && p.Email == "a@x.com");
     }
+
+    [HumansFact]
+    public async Task DetectsRawEmailCollisionAcrossUsers()
+    {
+        var u1 = Guid.NewGuid();
+        var u2 = Guid.NewGuid();
+        SetProfiles(
+            MakeProfile(u1, new UserEmailSnapshot(Guid.NewGuid(), "joe@x.com", true, true, false)),
+            MakeProfile(u2, new UserEmailSnapshot(Guid.NewGuid(), "joe@x.com", true, true, false)));
+        SetOrphans();
+        SetGhosts();
+
+        var report = await Sut.ScanAsync();
+
+        report.Problems.Should().ContainSingle(p =>
+            p.Kind == EmailProblemKind.SharedAcrossUsers
+            && p.Email == "joe@x.com"
+            && (p.UserId == u1 || p.UserId == u2)
+            && (p.OtherUserId == u1 || p.OtherUserId == u2)
+            && p.UserId != p.OtherUserId);
+    }
+
+    [HumansFact]
+    public async Task DetectsNormalizationEquivalentCollision()
+    {
+        var u1 = Guid.NewGuid();
+        var u2 = Guid.NewGuid();
+        SetProfiles(
+            MakeProfile(u1, new UserEmailSnapshot(Guid.NewGuid(), "joe@gmail.com", true, true, false)),
+            MakeProfile(u2, new UserEmailSnapshot(Guid.NewGuid(), "joe@googlemail.com", true, true, false)));
+        SetOrphans();
+        SetGhosts();
+
+        var report = await Sut.ScanAsync();
+
+        report.Problems.Should().ContainSingle(p => p.Kind == EmailProblemKind.SharedAcrossUsers);
+    }
 }

--- a/tests/Humans.Application.Tests/Services/EmailProblemsServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/EmailProblemsServiceTests.cs
@@ -235,4 +235,68 @@ public class EmailProblemsServiceTests
         report.Problems.Should().ContainSingle(p =>
             p.Kind == EmailProblemKind.GhostExternalLogins && p.UserId == ghostUserId);
     }
+
+    [HumansFact]
+    public async Task UsersShareAnyEmail_ExactMatch_True()
+    {
+        var u1 = Guid.NewGuid();
+        var u2 = Guid.NewGuid();
+        SetProfiles(
+            MakeProfile(u1, new UserEmailSnapshot(Guid.NewGuid(), "joe@x.com", true, true, false)),
+            MakeProfile(u2, new UserEmailSnapshot(Guid.NewGuid(), "joe@x.com", true, true, false)));
+
+        (await Sut.UsersShareAnyEmailAsync(u1, u2)).Should().BeTrue();
+    }
+
+    [HumansFact]
+    public async Task UsersShareAnyEmail_GmailGooglemailEquivalent_True()
+    {
+        var u1 = Guid.NewGuid();
+        var u2 = Guid.NewGuid();
+        SetProfiles(
+            MakeProfile(u1, new UserEmailSnapshot(Guid.NewGuid(), "joe@gmail.com", true, true, false)),
+            MakeProfile(u2, new UserEmailSnapshot(Guid.NewGuid(), "joe@googlemail.com", true, true, false)));
+
+        (await Sut.UsersShareAnyEmailAsync(u1, u2)).Should().BeTrue();
+    }
+
+    [HumansFact]
+    public async Task UsersShareAnyEmail_NoOverlap_False()
+    {
+        var u1 = Guid.NewGuid();
+        var u2 = Guid.NewGuid();
+        SetProfiles(
+            MakeProfile(u1, new UserEmailSnapshot(Guid.NewGuid(), "alice@x.com", true, true, false)),
+            MakeProfile(u2, new UserEmailSnapshot(Guid.NewGuid(), "bob@x.com", true, true, false)));
+
+        (await Sut.UsersShareAnyEmailAsync(u1, u2)).Should().BeFalse();
+    }
+
+    [HumansFact]
+    public async Task UsersShareAnyEmail_SameUserId_False()
+    {
+        var u = Guid.NewGuid();
+        SetProfiles(MakeProfile(u, new UserEmailSnapshot(Guid.NewGuid(), "joe@x.com", true, true, false)));
+
+        (await Sut.UsersShareAnyEmailAsync(u, u)).Should().BeFalse();
+    }
+
+    [HumansFact]
+    public async Task IsGhostExternalLoginsUser_InSet_True()
+    {
+        var ghostUserId = Guid.NewGuid();
+        SetGhosts(ghostUserId);
+
+        (await Sut.IsGhostExternalLoginsUserAsync(ghostUserId)).Should().BeTrue();
+    }
+
+    [HumansFact]
+    public async Task IsGhostExternalLoginsUser_NotInSet_False()
+    {
+        var ghostUserId = Guid.NewGuid();
+        var otherUserId = Guid.NewGuid();
+        SetGhosts(ghostUserId);
+
+        (await Sut.IsGhostExternalLoginsUserAsync(otherUserId)).Should().BeFalse();
+    }
 }

--- a/tests/Humans.Application.Tests/Services/EmailProblemsServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/EmailProblemsServiceTests.cs
@@ -130,4 +130,23 @@ public class EmailProblemsServiceTests
         report.Problems.Should().ContainSingle(p =>
             p.Kind == EmailProblemKind.ZeroIsGoogle && p.UserId == userId);
     }
+
+    [HumansFact]
+    public async Task DetectsUnverifiedEmail_RegardlessOfFlags()
+    {
+        var userId = Guid.NewGuid();
+        var emailId = Guid.NewGuid();
+        SetProfiles(MakeProfile(userId,
+            new UserEmailSnapshot(emailId, "a@x.com", false, false, false)));
+        SetOrphans();
+        SetGhosts();
+
+        var report = await Sut.ScanAsync();
+
+        report.Problems.Should().ContainSingle(p =>
+            p.Kind == EmailProblemKind.Unverified
+            && p.UserId == userId
+            && p.UserEmailId == emailId
+            && p.Email == "a@x.com");
+    }
 }

--- a/tests/Humans.Application.Tests/Services/ShiftDashboardMetricsTests.cs
+++ b/tests/Humans.Application.Tests/Services/ShiftDashboardMetricsTests.cs
@@ -1019,6 +1019,7 @@ public class ShiftDashboardMetricsTests : IDisposable
         public Task<int> ReassignLoginsToUserAsync(Guid sourceUserId, Guid targetUserId, Instant updatedAt, CancellationToken ct = default) => throw new NotSupportedException();
         public Task<int> ReassignEventParticipationToUserAsync(Guid sourceUserId, Guid targetUserId, Instant updatedAt, CancellationToken ct = default) => throw new NotSupportedException();
         public Task<IReadOnlySet<Guid>> GetMergedSourceIdsAsync(Guid targetUserId, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task<IReadOnlyList<Guid>> GetUsersWithLoginsButNoEmailsAsync(CancellationToken ct = default) => throw new NotSupportedException();
     }
 
     private sealed class FakeTeamService : ITeamService

--- a/tests/Humans.Application.Tests/Services/ShiftDashboardMetricsTests.cs
+++ b/tests/Humans.Application.Tests/Services/ShiftDashboardMetricsTests.cs
@@ -1020,6 +1020,7 @@ public class ShiftDashboardMetricsTests : IDisposable
         public Task<int> ReassignEventParticipationToUserAsync(Guid sourceUserId, Guid targetUserId, Instant updatedAt, CancellationToken ct = default) => throw new NotSupportedException();
         public Task<IReadOnlySet<Guid>> GetMergedSourceIdsAsync(Guid targetUserId, CancellationToken ct = default) => throw new NotSupportedException();
         public Task<IReadOnlyList<Guid>> GetUsersWithLoginsButNoEmailsAsync(CancellationToken ct = default) => throw new NotSupportedException();
+        public Task<int> DeleteAllExternalLoginsForUserAsync(Guid userId, CancellationToken ct = default) => throw new NotSupportedException();
     }
 
     private sealed class FakeTeamService : ITeamService

--- a/tests/Humans.Integration.Tests/AccountMerge/AdminMergeAsyncTests.cs
+++ b/tests/Humans.Integration.Tests/AccountMerge/AdminMergeAsyncTests.cs
@@ -1,0 +1,196 @@
+using AwesomeAssertions;
+using Humans.Application.Interfaces.Profiles;
+using Humans.Domain.Constants;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using Humans.Infrastructure.Data;
+using Humans.Integration.Tests.Infrastructure;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using NodaTime;
+using Xunit;
+
+namespace Humans.Integration.Tests.AccountMerge;
+
+/// <summary>
+/// Integration test for <see cref="IAccountMergeService.AdminMergeAsync"/>:
+/// seeds a full two-user fixture, invokes the admin-initiated fold, and
+/// asserts all six post-conditions from the EmailProblems spec (case 5).
+/// </summary>
+public class AdminMergeAsyncTests : IClassFixture<HumansWebApplicationFactory>
+{
+    private readonly HumansWebApplicationFactory _factory;
+
+    public AdminMergeAsyncTests(HumansWebApplicationFactory factory) => _factory = factory;
+
+    [HumansFact(Timeout = 60_000)]
+    public async Task AdminMergeAsync_FullFixture_AllPostConditionsHold()
+    {
+        var runTag = Guid.NewGuid().ToString("N");
+        var sourceEmail = $"joe-{runTag}@x.com";
+        var targetEmail = $"target-{runTag}@x.com";
+        var sourceLoginKey = $"login-src-{runTag}";
+        var sourceOnlyRole = $"role-src-{runTag}";
+
+        Guid sourceOnlyTeamId = Guid.Empty;
+
+        // Stage 1 — seed source/target user pair with their primary verified
+        // emails, a login, and a role assignment.
+        var (sourceId, targetId) = await _factory.SeedMergeFixtureAsync(b =>
+        {
+            // Source: primary verified email.
+            b.WithSourceEmail(sourceEmail, verified: true, isPrimary: true);
+
+            // Target: primary verified email (with IsGoogle so preservation
+            // of IsPrimary + IsGoogle is assertable).
+            b.WithTargetEmail(targetEmail, verified: true, isPrimary: true, isGoogle: true);
+
+            // Source login — must move to target.
+            b.WithSourceLogin("Google", sourceLoginKey);
+
+            // Source role assignment — must re-FK to target.
+            b.WithSourceRoleAssignment(sourceOnlyRole);
+        });
+
+        // Stage 2 — seed a source-only team membership (requires ad-hoc Team row).
+        await using (var seedScope = _factory.Services.CreateAsyncScope())
+        {
+            var builder = new MergeFixtureBuilder(seedScope, sourceId, targetId);
+            sourceOnlyTeamId = builder.SeedTeamNow($"SrcOnly-{runTag}".Substring(0, 12));
+            builder.WithSourceTeamMember(sourceOnlyTeamId);
+            await builder.SaveAllAsync();
+        }
+
+        // Act — admin-initiated merge (no AccountMergeRequest).
+        var adminId = await SeedAdminUserAsync();
+        await using (var actScope = _factory.Services.CreateAsyncScope())
+        {
+            var mergeService = actScope.ServiceProvider.GetRequiredService<IAccountMergeService>();
+            await mergeService.AdminMergeAsync(sourceId, targetId, adminId);
+        }
+
+        // Assert — all six post-conditions from the EmailProblems spec case 5.
+        await using var assertScope = _factory.Services.CreateAsyncScope();
+        var db = assertScope.ServiceProvider.GetRequiredService<HumansDbContext>();
+
+        // ----------------------------------------------------------------
+        // Post-condition 1: exactly one UserEmail row per normalized email.
+        // ----------------------------------------------------------------
+        var sourceEmailRows = await db.UserEmails.AsNoTracking()
+            .Where(e => e.Email == sourceEmail).ToListAsync();
+        sourceEmailRows.Should().ContainSingle(
+            "the source-only email should exist exactly once (re-FK'd to target)");
+        sourceEmailRows[0].UserId.Should().Be(targetId,
+            "source-only email must be re-FK'd onto the target user");
+
+        var targetEmailRows = await db.UserEmails.AsNoTracking()
+            .Where(e => e.Email == targetEmail).ToListAsync();
+        targetEmailRows.Should().ContainSingle(
+            "target's primary email should exist exactly once");
+
+        // ----------------------------------------------------------------
+        // Post-condition 2: source has zero UserEmail rows.
+        // ----------------------------------------------------------------
+        (await db.UserEmails.AsNoTracking().CountAsync(e => e.UserId == sourceId))
+            .Should().Be(0, "all UserEmails must be moved off the source user");
+
+        // ----------------------------------------------------------------
+        // Post-condition 3: source has zero AspNetUserLogins rows.
+        // ----------------------------------------------------------------
+        (await db.Set<IdentityUserLogin<Guid>>().AsNoTracking().CountAsync(l => l.UserId == sourceId))
+            .Should().Be(0, "all logins must be re-FK'd to target");
+
+        (await db.Set<IdentityUserLogin<Guid>>().AsNoTracking()
+                .AnyAsync(l => l.UserId == targetId
+                    && l.LoginProvider == "Google" && l.ProviderKey == sourceLoginKey))
+            .Should().BeTrue("source login must be re-FK'd to target");
+
+        // ----------------------------------------------------------------
+        // Post-condition 4: target's pre-existing IsPrimary / IsGoogle preserved.
+        // ----------------------------------------------------------------
+        var survivingTargetEmail = await db.UserEmails.AsNoTracking()
+            .FirstOrDefaultAsync(e => e.UserId == targetId && e.Email == targetEmail);
+        survivingTargetEmail.Should().NotBeNull();
+        survivingTargetEmail!.IsPrimary.Should().BeTrue(
+            "target's pre-existing IsPrimary must remain true after fold");
+        survivingTargetEmail.IsGoogle.Should().BeTrue(
+            "target's pre-existing IsGoogle must remain true after fold");
+
+        // ----------------------------------------------------------------
+        // Post-condition 5: source tombstoned with MergedToUserId + MergedAt.
+        // ----------------------------------------------------------------
+        var sourceUser = await db.Users.AsNoTracking().FirstOrDefaultAsync(u => u.Id == sourceId);
+        sourceUser.Should().NotBeNull();
+        sourceUser!.MergedToUserId.Should().Be(targetId,
+            "source must be tombstoned pointing at the target");
+        sourceUser.MergedAt.Should().NotBeNull(
+            "source MergedAt must be set after admin-initiated fold");
+
+        // ----------------------------------------------------------------
+        // Post-condition 6: AuditLogEntry with AccountMergeAccepted action,
+        // EntityType == nameof(User), EntityId == sourceId, and description
+        // starting with "Admin-initiated via EmailProblems".
+        // ----------------------------------------------------------------
+        var auditRow = await db.AuditLogEntries.AsNoTracking()
+            .FirstOrDefaultAsync(a =>
+                a.Action == AuditAction.AccountMergeAccepted
+                && a.EntityType == nameof(User)
+                && a.EntityId == sourceId);
+        auditRow.Should().NotBeNull("an AccountMergeAccepted audit row must be written for the source");
+        auditRow!.Description.Should().StartWith("Admin-initiated via EmailProblems",
+            "the audit description must identify this as an admin-initiated fold");
+
+        // Bonus: source's team membership and role assignment moved to target.
+        (await db.TeamMembers.AsNoTracking()
+                .AnyAsync(tm => tm.UserId == targetId && tm.TeamId == sourceOnlyTeamId
+                    && tm.LeftAt == null))
+            .Should().BeTrue("source-only team membership must be re-FK'd to target");
+
+        (await db.RoleAssignments.AsNoTracking()
+                .AnyAsync(ra => ra.UserId == targetId && ra.RoleName == sourceOnlyRole))
+            .Should().BeTrue("source-only role assignment must be re-FK'd to target");
+    }
+
+    // ==================================================================
+    // Helpers
+    // ==================================================================
+
+    private async Task<Guid> SeedAdminUserAsync()
+    {
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var um = scope.ServiceProvider.GetRequiredService<UserManager<User>>();
+        var db = scope.ServiceProvider.GetRequiredService<HumansDbContext>();
+        var now = SystemClock.Instance.GetCurrentInstant();
+
+        var adminId = Guid.NewGuid();
+        var admin = new User
+        {
+            Id = adminId,
+            DisplayName = "Test Admin",
+            Email = $"admin-{adminId:N}@test.local",
+            UserName = $"admin-{adminId:N}@test.local",
+            CreatedAt = now,
+        };
+        var result = await um.CreateAsync(admin);
+        if (!result.Succeeded)
+        {
+            throw new InvalidOperationException(
+                "Failed to seed admin user for AdminMergeAsyncTests: "
+                + string.Join("; ", result.Errors.Select(e => e.Description)));
+        }
+
+        db.RoleAssignments.Add(new RoleAssignment
+        {
+            Id = Guid.NewGuid(),
+            UserId = adminId,
+            RoleName = RoleNames.Admin,
+            ValidFrom = now.Minus(Duration.FromDays(1)),
+            ValidTo = null,
+            CreatedAt = now,
+            CreatedByUserId = adminId,
+        });
+        await db.SaveChangesAsync();
+        return adminId;
+    }
+}


### PR DESCRIPTION
## Summary

- New admin page **`/Profile/Admin/EmailProblems`** that surfaces every UserEmail invariant violation in one place (8 cases) and provides three consolidating actions.
- New `IAccountMergeService.AdminMergeAsync` entry point sharing a private `FoldAsync` kernel with the existing user-initiated `AcceptAsync` — admin-initiated merges run the same `IUserMerge` fan-out + tombstone + audit, no `AccountMergeRequest` row.
- New `IEmailProblemsService` consumes only existing section services (`IProfileService`, `IUserEmailService`, `IUserService`) — no repository or `DbContext` dependencies.

Closes #660. Spec: `docs/superpowers/specs/2026-05-05-email-problems-page-design.md`. Plan: `docs/superpowers/plans/2026-05-05-email-problems-page.md`.

### Cases scanned (all populate one report shape)

1. Multiple `IsPrimary` per user
2. Multiple `IsGoogle` per user
3. Zero `IsPrimary` (with at least one verified row)
4. Zero `IsGoogle`
5. Two users sharing a UserEmail address (raw match OR gmail/googlemail equivalence — dot-stripping intentionally not normalized)
6. Any unverified `UserEmail` row
7. Orphan `UserEmail` rows (UserId points to tombstoned/missing user)
8. Users with `AspNetUserLogins` rows but zero `UserEmail` rows (auth ghosts — should be empty after #661 lands; scan catches existing damage)

### Page UX (hybrid — cross-user → single-user → system-level)

- **Cross-user conflicts (case 5)** — links to a side-by-side Compare detail page with a pick-the-target merge form
- **Single-user issues (cases 1, 2, 3, 4, 6)** — links to the existing `/Profile/{id}/Admin/Emails` page; no new fix UI here
- **System-level issues (cases 7, 8)** — inline destructive actions with confirm dialogs

Empty-state per section reads "No problems found" so admins can see the scan ran.

### Architectural notes for review

- **Budget bump 29→31 on `IUserService`** (two `+1`s authorized in this PR): added `GetUsersWithLoginsButNoEmailsAsync` (case-8 detection) and `DeleteAllExternalLoginsForUserAsync` (case-8 cleanup). Both are auth-table reads/writes — no expiable substitute on the service surface. Comments on the budget entry capture the rationale.
- **`IProfileService` budget unchanged at 39.** Initial plan added `GetFullProfileSnapshotAsync`; dropped during implementation. Scan iterates `IUserService.GetAllUsersAsync` + per-user cached `IProfileService.GetFullProfileAsync` instead.
- **`FullProfile` extended** with `UserEmailSnapshot` rows (`Id`, `Email`, `IsVerified`, `IsPrimary`, `IsGoogle`) so the scan inspects per-row flags without going back to repos.
- **`AcceptAsync` transaction shape changed** from one ambient `TransactionScope` to two: `FoldAsync` runs the irreversible fan-out + tombstone + audit in scope 1; `AcceptAsync` runs `MarkVerifiedAsync` + request-row update in scope 2. The fold being irreversible makes the second-scope failure mode small (request stays Pending; audit row + tombstone are already committed). Plan §15 captures the rationale.
- **Architecture test `EmailProblemsService_DependsOnlyOnSectionServices_NotRepositories`** locks in the "use existing section services, never repositories or DbContext" rule.

### Files of note

- `src/Humans.Application/Services/Profile/EmailProblemsService.cs` — the scan
- `src/Humans.Application/Services/Profile/AccountMergeService.cs` — `FoldAsync` kernel + `AdminMergeAsync`
- `src/Humans.Web/Controllers/ProfileAdminController.cs` — list, compare, merge, delete actions
- `src/Humans.Web/Views/ProfileAdmin/EmailProblems.cshtml` + `EmailProblemsCompare.cshtml`
- `tests/Humans.Integration.Tests/AccountMerge/AdminMergeAsyncTests.cs` — full-fixture coverage of the admin-initiated fold

## Test plan

- [ ] Walk all 8 cases on a preview env: seed a violator → visit `/Profile/Admin/EmailProblems` → confirm it shows in the right section
- [ ] Case 5: click **Compare**, confirm side-by-side renders all `UserEmail` rows with verified/primary/google badges; no `User.Email` displayed anywhere
- [ ] Case 5: pick a target, click **Merge**, confirm source `User` is tombstoned (`MergedToUserId`, `MergedAt` set), source has zero `UserEmail` and zero `AspNetUserLogins`, target's pre-existing `IsPrimary`/`IsGoogle` flags preserved
- [ ] Case 5: audit row written with `EntityType=User`, `EntityId=sourceId`, description starts with "Admin-initiated via EmailProblems"
- [ ] Case 7: click **Delete row**, confirm orphan removed, audit row written
- [ ] Case 8: click **Delete logins**, confirm `AspNetUserLogins` rows removed, audit row written
- [ ] Idempotency: replay each system-level action against an already-cleaned target → "Already cleaned up" toast, no audit row
- [ ] Sanity-check `/Admin/MergeRequests` → existing user-initiated `AcceptAsync` flow still works end-to-end
- [ ] Admin nav: `Email problems` link appears under "People data"

🤖 Generated with [Claude Code](https://claude.com/claude-code)