### PR TITLE
fix(test): force TOCTOU interleaving in ProfileService race test

### DIFF
--- a/tests/Humans.Application.Tests/Services/ProfileServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/ProfileServiceTests.cs
@@ -1802,6 +1802,17 @@ public class ProfileServiceTests : IDisposable
         private readonly Dictionary<Guid, Profile> _byUserId = new();
         private readonly Lock _gate = new();
 
+        // Forces both concurrent SaveProfileAsync callers to observe the empty
+        // state on their first GetByUserIdAsync before either Add fires.
+        // Without this the scheduler sometimes lets one task fully complete
+        // before the other starts, so the TOCTOU interleaving the test exists
+        // to validate never actually happens and the AddIfNotExists==false
+        // assertion flakes. Subsequent Gets (e.g. the race-loser's re-fetch)
+        // bypass the barrier.
+        private readonly TaskCompletionSource _bothInitialGetsArrived =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private int _initialGetArrivals;
+
         public int AddIfNotExistsTrueCount { get; private set; }
         public int AddIfNotExistsFalseCount { get; private set; }
         public int UpdateCallCount { get; private set; }
@@ -1810,11 +1821,17 @@ public class ProfileServiceTests : IDisposable
             get { lock (_gate) { return _byUserId.Values.ToList(); } }
         }
 
-        public Task<Profile?> GetByUserIdAsync(Guid userId, CancellationToken ct = default)
+        public async Task<Profile?> GetByUserIdAsync(Guid userId, CancellationToken ct = default)
         {
+            if (!_bothInitialGetsArrived.Task.IsCompleted)
+            {
+                if (Interlocked.Increment(ref _initialGetArrivals) >= 2)
+                    _bothInitialGetsArrived.TrySetResult();
+                await _bothInitialGetsArrived.Task.WaitAsync(ct).ConfigureAwait(false);
+            }
             lock (_gate)
             {
-                return Task.FromResult(_byUserId.TryGetValue(userId, out var p) ? Clone(p) : null);
+                return _byUserId.TryGetValue(userId, out var p) ? Clone(p) : null;
             }
         }
 


### PR DESCRIPTION
## Summary
- The race test added in #434 (issue-651) flakes because nothing forces both `Task.Run` callers to overlap. On some scheduler runs, one task completes fully before the other starts, so the second caller sees the winner's row in `GetByUserIdAsync` and skips `Add` — making `AddIfNotExistsFalseCount.Should().Be(1)` fail with `0`.
- Add a `TaskCompletionSource` barrier in the fake repo's `GetByUserIdAsync` that releases only after both callers have arrived. Subsequent re-fetches (the race-loser's path) bypass the barrier. This deterministically reproduces the TOCTOU interleaving the test exists to validate.

Observed flaking on `main` (runs `25404859180`, `25404590593`) and on PR #436's CI even though #436 doesn't touch `ProfileService`.

## Test plan
- [x] `dotnet build tests/Humans.Application.Tests/Humans.Application.Tests.csproj` clean
- [x] Target test passes 5/5 iterations locally
- [ ] Full Application.Tests suite green on CI