### PR TITLE
issue-669: fix unescaped JS string in French phone-hint translation

### DIFF
--- a/src/Humans.Web/Views/Profile/Edit.cshtml
+++ b/src/Humans.Web/Views/Profile/Edit.cshtml
@@ -693,8 +693,8 @@
             }
 
             const phoneTypes = ['Phone', 'WhatsApp'];
-            const phonePlaceholder = '@Html.Raw(Localizer["Validation_PhonePlaceholder"].Value)';
-            const phoneTitle = '@Html.Raw(Localizer["Validation_PhoneHint"].Value)';
+            const phonePlaceholder = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Localizer["Validation_PhonePlaceholder"].Value));
+            const phoneTitle = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Localizer["Validation_PhoneHint"].Value));
             const defaultPlaceholder = 'Enter contact info';
 
             function applyPhoneValidation(valueInput, isPhone) {


### PR DESCRIPTION
## Summary

- French `Validation_PhoneHint` contains an apostrophe (`l'indicatif`), which broke the surrounding JS single-quoted literal in `Profile/Edit.cshtml` and killed the entire `<script>` block. Fully blocked French users from adding contact fields, languages, or Burner CV entries.
- Switched the two localized JS string assignments to `System.Text.Json.JsonSerializer.Serialize`, which emits properly escaped JSON literals (also valid JS literals). Now any current or future translation can contain apostrophes, double-quotes, backslashes, or newlines without breaking parsing.

Reported and root-caused by @valentin-consulting — they pinpointed the exact file/line.

## Resource audit

Checked all 6 locales (default, ca, de, es, fr, it) for `Validation_PhoneHint` and `Validation_PhonePlaceholder`. Only French currently triggered the bug, but the fix removes the class of issue entirely.

## Test plan

- [ ] On `/Profile/Me/Edit` with French selected, the page no longer throws `Uncaught SyntaxError: Unexpected identifier 'indicatif'`
- [ ] "Ajouter un champ de contact", "Ajouter une langue", and "Ajouter une entrée" buttons all work
- [ ] Phone-type contact fields show the localized French title attribute correctly
- [ ] Spot-check Spanish, Catalan, German, Italian — all locales still render the script block without errors

Closes #669