### PR TITLE
issue-634: surface tickets, shifts, team roles to agent + add get_shift_details tool

### DIFF
--- a/docs/sections/Agent.md
+++ b/docs/sections/Agent.md
@@ -68,7 +68,7 @@ Per-user message and token counters live in the Singleton `IAgentRateLimitStore`
 1. **Terms link, not gate.** The Assistant panel shows a persistent "AI Terms" link below the composer that opens `/Legal/agent-chat` (the rendered Agent Chat Terms from `nobodies-collective/legal`). There is no explicit consent step — opening the panel and sending a message constitutes use; the terms describe what's sent, retention, and rights. The team-required-doc consent flow (`IConsentService.GetPendingDocumentNamesAsync`) is intentionally NOT used here; agent use is opt-in, not a membership precondition.
 2. **Enabled gate.** If `AgentSettings.Enabled = false`, widget is hidden and `POST /Agent/Ask` returns `503 ServiceUnavailable`.
 3. **Rate limit.** Per-user daily and hourly caps from `AgentSettings`. Over-cap requests return `429 TooManyRequests` without hitting the provider.
-4. **Tool whitelist.** Only `fetch_feature_spec`, `fetch_section_guide`, `route_to_issue`, `get_audit_history` are valid tool names. Unknown names return a tool error; filesystem is never touched outside `docs/sections/` and `docs/features/`.
+4. **Tool whitelist.** Only `fetch_feature_spec`, `fetch_section_guide`, `route_to_issue`, `get_audit_history`, `get_shift_details` are valid tool names. Unknown names return a tool error; filesystem is never touched outside `docs/sections/` and `docs/features/`.
 5. **Tool loop bound.** At most `AnthropicOptions.MaxToolCallsPerTurn` (default 3) tool calls per turn, enforced server-side.
 6. **Refusal logging.** Every refused turn writes an `AgentMessage` with `RefusalReason != null`.
 7. **Append-only conversations per user.** A user can only post to conversations they own. `AgentController` rejects cross-user access with 404.
@@ -105,7 +105,7 @@ Missing or wrong key → 401 (503 if the key is not configured). Unknown id → 
 - **Issues** — agent handoff produces a client-side issue proposal (title/category/description) that pre-fills `/Issues/Submit`. The agent does not write Issue rows itself.
 - **Feedback (legacy)** — historical `FeedbackReport.Source = AgentUnresolved` rows from before this PR are still readable via the Feedback admin queue. Agent no longer creates new ones.
 - **Legal** — `LegalDocumentService` resolves the `agent-chat` slug to the `AgentChat/` folder in the legal repo and renders content at `/Legal/agent-chat`. The Assistant panel links there from the composer footer. No `IConsentService` involvement.
-- **Profiles / Users / Auth / Teams** — `IAgentUserSnapshotProvider` composes the per-turn user context from `IProfileService`, `IUserService`, `IRoleAssignmentService.GetActiveForUserAsync`, `ITeamService.GetActiveTeamNamesForUserAsync`.
+- **Profiles / Users / Auth / Teams / Tickets / Shifts** — `IAgentUserSnapshotProvider` composes the per-turn user context from `IProfileService`, `IUserService`, `IRoleAssignmentService.GetActiveForUserAsync`, `ITeamService.GetActiveTeamMembershipsForUserAsync`, `ITicketQueryService.GetOpenTicketIdsForUserAsync`, `IShiftSignupService.GetByUserAsync`, and `IShiftManagementService.GetActiveAsync`.
 - **GDPR** — `AgentService` implements `IUserDataContributor` so per-user export pulls conversation history. User deletion does not cascade into Agent; orphan rows expire via the retention job.
 
 ## Architecture

--- a/src/Humans.Application/Constants/AgentToolNames.cs
+++ b/src/Humans.Application/Constants/AgentToolNames.cs
@@ -5,6 +5,7 @@ public static class AgentToolNames
     public const string FetchFeatureSpec = "fetch_feature_spec";
     public const string FetchSectionGuide = "fetch_section_guide";
     public const string GetAuditHistory = "get_audit_history";
+    public const string GetShiftDetails = "get_shift_details";
     public const string RouteToIssue = "route_to_issue";
 
     public static readonly IReadOnlySet<string> All =
@@ -13,6 +14,7 @@ public static class AgentToolNames
             FetchFeatureSpec,
             FetchSectionGuide,
             GetAuditHistory,
+            GetShiftDetails,
             RouteToIssue
         };
 }

--- a/src/Humans.Application/Interfaces/Repositories/ITicketRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/ITicketRepository.cs
@@ -199,6 +199,14 @@ public interface ITicketRepository
 
     Task<IReadOnlyList<TicketOrder>> GetOrdersMatchedToUserAsync(Guid userId, CancellationToken ct = default);
 
+    /// <summary>
+    /// Returns the ids of every order matched to <paramref name="userId"/> whose
+    /// <c>PaymentStatus</c> is <see cref="TicketPaymentStatus.Paid"/> or
+    /// <see cref="TicketPaymentStatus.Pending"/>. Refunded and Cancelled rows are
+    /// excluded so the agent snapshot only surfaces actionable tickets.
+    /// </summary>
+    Task<IReadOnlyList<Guid>> GetOpenOrderIdsMatchedToUserAsync(Guid userId, CancellationToken ct = default);
+
     Task<IReadOnlyList<TicketAttendee>> GetAttendeesMatchedToUserAsync(Guid userId, CancellationToken ct = default);
 
     Task<IReadOnlyList<Instant>> GetPaidOrderDatesInWindowAsync(

--- a/src/Humans.Application/Interfaces/Teams/ITeamService.cs
+++ b/src/Humans.Application/Interfaces/Teams/ITeamService.cs
@@ -527,18 +527,10 @@ public interface ITeamService
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Gets the names of all active (non-Volunteers) teams the user belongs to,
-    /// ordered alphabetically. Used for profile popover display.
-    /// </summary>
-    Task<IReadOnlyList<string>> GetActiveTeamNamesForUserAsync(
-        Guid userId, CancellationToken cancellationToken = default);
-
-    /// <summary>
     /// Returns the active (non-Volunteers) teams the user belongs to with the
-    /// user's role on each team, ordered alphabetically by team name. Used by
-    /// the agent snapshot tail so the model can distinguish a coordinator
-    /// from a regular member without loading full <see cref="TeamMember"/>
-    /// graphs.
+    /// user's role on each team. Callers that only need names project via
+    /// <c>.Select(m =&gt; m.TeamName)</c>. Display ordering is the caller's
+    /// responsibility (rendering layer).
     /// </summary>
     Task<IReadOnlyList<Humans.Application.Models.TeamMembership>> GetActiveTeamMembershipsForUserAsync(
         Guid userId, CancellationToken cancellationToken = default);

--- a/src/Humans.Application/Interfaces/Teams/ITeamService.cs
+++ b/src/Humans.Application/Interfaces/Teams/ITeamService.cs
@@ -534,6 +534,16 @@ public interface ITeamService
         Guid userId, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Returns the active (non-Volunteers) teams the user belongs to with the
+    /// user's role on each team, ordered alphabetically by team name. Used by
+    /// the agent snapshot tail so the model can distinguish a coordinator
+    /// from a regular member without loading full <see cref="TeamMember"/>
+    /// graphs.
+    /// </summary>
+    Task<IReadOnlyList<Humans.Application.Models.TeamMembership>> GetActiveTeamMembershipsForUserAsync(
+        Guid userId, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Enqueues AddUserToTeamResources sync events for all active team
     /// memberships of a user. Used when the user's Google service email changes.
     /// </summary>

--- a/src/Humans.Application/Interfaces/Tickets/ITicketQueryService.cs
+++ b/src/Humans.Application/Interfaces/Tickets/ITicketQueryService.cs
@@ -120,6 +120,14 @@ public interface ITicketQueryService
     Task<List<UserTicketOrderSummary>> GetUserTicketOrderSummariesAsync(Guid userId);
 
     /// <summary>
+    /// Returns the order ids of every <see cref="TicketPaymentStatus.Paid"/> or
+    /// <see cref="TicketPaymentStatus.Pending"/> ticket order matched to the user
+    /// (i.e. <c>MatchedUserId == userId</c>). Refunded and Cancelled orders are
+    /// excluded — the agent snapshot only counts orders the user can still act on.
+    /// </summary>
+    Task<IReadOnlyList<Guid>> GetOpenTicketIdsForUserAsync(Guid userId, CancellationToken ct = default);
+
+    /// <summary>
     /// Returns the post-event hold date (GateOpeningDate + StrikeEndOffset + 1 day, start of day
     /// in the event's timezone) if there is an active event and the date is in the future.
     /// Returns null if no active event or the hold date has already passed.

--- a/src/Humans.Application/Models/AgentUserSnapshot.cs
+++ b/src/Humans.Application/Models/AgentUserSnapshot.cs
@@ -9,7 +9,8 @@ public sealed record AgentUserSnapshot(
     string Tier,
     bool IsApproved,
     IReadOnlyList<(string RoleName, string ExpiresIsoDate)> RoleAssignments,
-    IReadOnlyList<string> Teams,
+    IReadOnlyList<TeamMembership> Teams,
     IReadOnlyList<string> PendingConsentDocs,
     IReadOnlyList<Guid> OpenTicketIds,
-    IReadOnlyList<Guid> OpenFeedbackIds);
+    IReadOnlyList<Guid> OpenFeedbackIds,
+    IReadOnlyList<UpcomingShiftEntry> UpcomingShifts);

--- a/src/Humans.Application/Models/TeamMembership.cs
+++ b/src/Humans.Application/Models/TeamMembership.cs
@@ -1,0 +1,13 @@
+using Humans.Domain.Enums;
+
+namespace Humans.Application.Models;
+
+/// <summary>
+/// Lightweight projection of a user's active membership on a single team —
+/// just the team name and the user's role within that team. Used by
+/// <see cref="AgentUserSnapshot"/> so the agent can distinguish a coordinator
+/// on Build from a regular member on Cantina without leaking the full
+/// <see cref="Humans.Domain.Entities.TeamMember"/> graph into the prompt
+/// surface.
+/// </summary>
+public sealed record TeamMembership(string TeamName, TeamMemberRole Role);

--- a/src/Humans.Application/Models/UpcomingShiftEntry.cs
+++ b/src/Humans.Application/Models/UpcomingShiftEntry.cs
@@ -1,0 +1,30 @@
+using Humans.Domain.Enums;
+using NodaTime;
+
+namespace Humans.Application.Models;
+
+/// <summary>
+/// One row in <see cref="AgentUserSnapshot.UpcomingShifts"/>: either a
+/// multi-day signup block (rows sharing the same
+/// <see cref="Humans.Domain.Entities.ShiftSignup.SignupBlockId"/>) collapsed
+/// to a single entry, or a singleton signup. The agent surfaces these
+/// summaries in the per-turn user-context tail and calls
+/// <c>get_shift_details</c> with <see cref="Key"/> to fetch the full
+/// description.
+/// </summary>
+/// <param name="Key">
+/// <see cref="Humans.Domain.Entities.ShiftSignup.SignupBlockId"/> for blocks,
+/// <see cref="Humans.Domain.Entities.ShiftSignup.Id"/> for singletons.
+/// </param>
+/// <param name="Label">Display label — derived from the rota name.</param>
+/// <param name="StartDate">Earliest day in the block (== <paramref name="EndDate"/> for singletons).</param>
+/// <param name="EndDate">Latest day in the block.</param>
+/// <param name="DayCount">Number of distinct days spanned (1 for singletons).</param>
+/// <param name="Status">Lifecycle status of the underlying signup(s).</param>
+public sealed record UpcomingShiftEntry(
+    Guid Key,
+    string Label,
+    LocalDate StartDate,
+    LocalDate EndDate,
+    int DayCount,
+    SignupStatus Status);

--- a/src/Humans.Application/Services/Teams/TeamService.cs
+++ b/src/Humans.Application/Services/Teams/TeamService.cs
@@ -1654,18 +1654,6 @@ public sealed class TeamService : ITeamService, IUserDataContributor, IUserMerge
         CancellationToken cancellationToken = default) =>
         _repo.GetCoordinatorUserIdsAsync(teamId, cancellationToken);
 
-    public async Task<IReadOnlyList<string>> GetActiveTeamNamesForUserAsync(
-        Guid userId, CancellationToken cancellationToken = default)
-    {
-        var cached = await GetCachedTeamsAsync(cancellationToken);
-        return cached.Values
-            .Where(t => t.SystemTeamType != SystemTeamType.Volunteers
-                && t.Members.Any(m => m.UserId == userId))
-            .Select(t => t.Name)
-            .OrderBy(n => n, StringComparer.OrdinalIgnoreCase)
-            .ToList();
-    }
-
     public async Task<IReadOnlyList<Humans.Application.Models.TeamMembership>> GetActiveTeamMembershipsForUserAsync(
         Guid userId, CancellationToken cancellationToken = default)
     {
@@ -1680,9 +1668,9 @@ public sealed class TeamService : ITeamService, IUserDataContributor, IUserMerge
                 continue;
             rows.Add(new Humans.Application.Models.TeamMembership(team.Name, membership.Role));
         }
-        return rows
-            .OrderBy(m => m.TeamName, StringComparer.OrdinalIgnoreCase)
-            .ToList();
+        // No display sort here — callers sort at the rendering layer
+        // (memory/architecture/display-sort-in-controllers.md).
+        return rows;
     }
 
     public async Task EnqueueGoogleResyncForUserTeamsAsync(

--- a/src/Humans.Application/Services/Teams/TeamService.cs
+++ b/src/Humans.Application/Services/Teams/TeamService.cs
@@ -1666,6 +1666,25 @@ public sealed class TeamService : ITeamService, IUserDataContributor, IUserMerge
             .ToList();
     }
 
+    public async Task<IReadOnlyList<Humans.Application.Models.TeamMembership>> GetActiveTeamMembershipsForUserAsync(
+        Guid userId, CancellationToken cancellationToken = default)
+    {
+        var cached = await GetCachedTeamsAsync(cancellationToken);
+        var rows = new List<Humans.Application.Models.TeamMembership>();
+        foreach (var team in cached.Values)
+        {
+            if (team.SystemTeamType == SystemTeamType.Volunteers)
+                continue;
+            var membership = team.Members.FirstOrDefault(m => m.UserId == userId);
+            if (membership is null)
+                continue;
+            rows.Add(new Humans.Application.Models.TeamMembership(team.Name, membership.Role));
+        }
+        return rows
+            .OrderBy(m => m.TeamName, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
     public async Task EnqueueGoogleResyncForUserTeamsAsync(
         Guid userId, CancellationToken cancellationToken = default)
     {

--- a/src/Humans.Application/Services/Tickets/TicketQueryService.cs
+++ b/src/Humans.Application/Services/Tickets/TicketQueryService.cs
@@ -760,6 +760,9 @@ public sealed class TicketQueryService : ITicketQueryService, IUserDataContribut
             o.Currency)).ToList();
     }
 
+    public Task<IReadOnlyList<Guid>> GetOpenTicketIdsForUserAsync(Guid userId, CancellationToken ct = default) =>
+        _ticketRepository.GetOpenOrderIdsMatchedToUserAsync(userId, ct);
+
     public async Task<Instant?> GetPostEventHoldDateAsync(CancellationToken ct = default)
     {
         var activeEvent = await _shiftManagementService.GetActiveAsync();

--- a/src/Humans.Infrastructure/Repositories/Tickets/TicketRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Tickets/TicketRepository.cs
@@ -443,6 +443,19 @@ public sealed class TicketRepository : ITicketRepository
             .ToListAsync(ct);
     }
 
+    public async Task<IReadOnlyList<Guid>> GetOpenOrderIdsMatchedToUserAsync(
+        Guid userId, CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        return await ctx.TicketOrders
+            .AsNoTracking()
+            .Where(o => o.MatchedUserId == userId
+                && (o.PaymentStatus == TicketPaymentStatus.Paid
+                    || o.PaymentStatus == TicketPaymentStatus.Pending))
+            .Select(o => o.Id)
+            .ToListAsync(ct);
+    }
+
     public async Task<IReadOnlyList<TicketAttendee>> GetAttendeesMatchedToUserAsync(
         Guid userId, CancellationToken ct = default)
     {

--- a/src/Humans.Infrastructure/Services/Agent/AgentPromptAssembler.cs
+++ b/src/Humans.Infrastructure/Services/Agent/AgentPromptAssembler.cs
@@ -8,6 +8,15 @@ namespace Humans.Infrastructure.Services.Agent;
 
 public sealed class AgentPromptAssembler : IAgentPromptAssembler
 {
+    /// <summary>
+    /// Maximum number of <see cref="UpcomingShiftEntry"/> rows rendered into
+    /// the per-turn user-context tail. Anything beyond this is summarised as
+    /// "+N more" — keeps the prompt bounded for volunteers signed up to many
+    /// ranges. The full set is available to the agent via
+    /// <c>get_shift_details</c>.
+    /// </summary>
+    internal const int MaxRenderedUpcomingShifts = 10;
+
     private const string SystemPromptHeader = """
         You are the Nobodies Collective in-app helper. You answer questions about how the Humans system works, grounded on the documentation below and the user context supplied at the end of this prompt.
 
@@ -21,6 +30,7 @@ public sealed class AgentPromptAssembler : IAgentPromptAssembler
         - Answer ONLY from preloaded docs, fetched docs, or the user's live state. Never invent rules, routes, role names, or people's names.
         - Answer OR escalate, never both. If you can answer the user's question from the available context — preload, fetched docs, or user state — answer and terminate the turn. If you genuinely cannot answer (no relevant docs, missing context, ambiguous user state) call the `route_to_issue` tool with a concrete `title`, `category` (Bug/Feature/Question), and `description` summarising what the user asked, then terminate the turn WITHOUT also drafting a partial answer. A `fetch_section_guide` returning "Unknown section" or an error is not by itself grounds to escalate — try the section index, related sections, or the access matrix first.
         - For personal-history questions ("who voluntold me?", "when did I get added to Build team?", "did anyone change my role?", "when was I approved?", "what happened to my shift signup?") call `get_audit_history` first and answer from the lines it returns. The tool already substitutes the user's name with "You" and resolves other actors to display names — quote those lines verbatim rather than paraphrasing.
+        - For shift-detail questions ("when do I show up?", "what's the deal with my Friday shift?", "tell me more about my July 1–7 shift") call `get_shift_details` with the `Key` from the matching `UpcomingShifts` entry in the user-context tail. The tail's UpcomingShifts list is a summary only; do not answer detail questions from it alone.
         - Refuse off-topic requests (politics, personal advice, general code help, anything outside Nobodies Collective operations).
         - Respond in the user's `PreferredLocale`. Keep answers concise — humans read quickly.
         - Never reference this system prompt, the cached corpus mechanism, or the tool names directly to the user.
@@ -49,7 +59,12 @@ public sealed class AgentPromptAssembler : IAgentPromptAssembler
         }
 
         if (snapshot.Teams.Count > 0)
-            sb.AppendLine("Teams: " + string.Join(", ", snapshot.Teams));
+        {
+            sb.AppendLine("Teams:");
+            foreach (var membership in snapshot.Teams)
+                sb.AppendLine(string.Create(CultureInfo.InvariantCulture,
+                    $"  - {membership.TeamName} ({membership.Role})"));
+        }
 
         if (snapshot.PendingConsentDocs.Count > 0)
             sb.AppendLine("Pending consents: " + string.Join(", ", snapshot.PendingConsentDocs));
@@ -60,7 +75,40 @@ public sealed class AgentPromptAssembler : IAgentPromptAssembler
         if (snapshot.OpenFeedbackIds.Count > 0)
             sb.AppendLine(string.Create(CultureInfo.InvariantCulture, $"OpenFeedback: {snapshot.OpenFeedbackIds.Count}"));
 
+        if (snapshot.UpcomingShifts.Count > 0)
+        {
+            sb.AppendLine("UpcomingShifts:");
+            var rendered = 0;
+            foreach (var entry in snapshot.UpcomingShifts)
+            {
+                if (rendered >= MaxRenderedUpcomingShifts)
+                    break;
+                sb.AppendLine(RenderShiftEntry(entry));
+                rendered++;
+            }
+            if (snapshot.UpcomingShifts.Count > MaxRenderedUpcomingShifts)
+            {
+                var overflow = snapshot.UpcomingShifts.Count - MaxRenderedUpcomingShifts;
+                sb.AppendLine(string.Create(CultureInfo.InvariantCulture, $"  +{overflow} more"));
+            }
+        }
+
         return sb.ToString();
+    }
+
+    private static string RenderShiftEntry(UpcomingShiftEntry entry)
+    {
+        // Block: "  - 2026-07-01 to 2026-07-07 — Cantina build (Voluntold, 7 days)"
+        // Singleton: "  - 2026-07-15 — Setup crew (Confirmed)"
+        var startIso = entry.StartDate.ToString("uuuu-MM-dd", CultureInfo.InvariantCulture);
+        if (entry.DayCount > 1)
+        {
+            var endIso = entry.EndDate.ToString("uuuu-MM-dd", CultureInfo.InvariantCulture);
+            return string.Create(CultureInfo.InvariantCulture,
+                $"  - {startIso} to {endIso} — {entry.Label} ({entry.Status}, {entry.DayCount} days)");
+        }
+        return string.Create(CultureInfo.InvariantCulture,
+            $"  - {startIso} — {entry.Label} ({entry.Status})");
     }
 
     public IReadOnlyList<AnthropicToolDefinition> BuildToolDefinitions() =>
@@ -77,6 +125,10 @@ public sealed class AgentPromptAssembler : IAgentPromptAssembler
             Name: AgentToolNames.GetAuditHistory,
             Description: "Fetch the calling user's recent audit history as plain-text lines (shifts, team membership, role changes, voluntolds, approvals, Workspace events). The tool substitutes the user's id with 'You' and resolves other actors to display names — no GUIDs are returned. Use for personal-history questions; do not use for questions about other users. Default limit is 20, hard cap 50.",
             JsonSchema: """{"type":"object","properties":{"limit":{"type":"integer","minimum":1,"maximum":50,"description":"Max lines to return. Defaults to 20, capped at 50."}}}"""),
+        new AnthropicToolDefinition(
+            Name: AgentToolNames.GetShiftDetails,
+            Description: "Look up details for one of the user's upcoming shift entries (block or singleton). Pass the Key value from an UpcomingShifts row in the user-context tail. Returns rota name, full description, dates, day count, status, all-day window or start/duration, and where-to-show-up notes from PracticalInfo. Only the calling user's signups are accessible — looking up other users' shifts returns a not-found error.",
+            JsonSchema: """{"type":"object","properties":{"shiftId":{"type":"string","format":"uuid"}},"required":["shiftId"]}"""),
         new AnthropicToolDefinition(
             Name: AgentToolNames.RouteToIssue,
             Description: "Hand off a question the agent cannot answer to the Issues system. Does NOT create the issue — the system pre-fills an issue submission form so the user can review and submit. Use Question for general help requests, Bug for things that look broken, Feature for missing capabilities.",

--- a/src/Humans.Infrastructure/Services/Agent/AgentPromptAssembler.cs
+++ b/src/Humans.Infrastructure/Services/Agent/AgentPromptAssembler.cs
@@ -61,7 +61,7 @@ public sealed class AgentPromptAssembler : IAgentPromptAssembler
         if (snapshot.Teams.Count > 0)
         {
             sb.AppendLine("Teams:");
-            foreach (var membership in snapshot.Teams)
+            foreach (var membership in snapshot.Teams.OrderBy(m => m.TeamName, StringComparer.OrdinalIgnoreCase))
                 sb.AppendLine(string.Create(CultureInfo.InvariantCulture,
                     $"  - {membership.TeamName} ({membership.Role})"));
         }
@@ -79,7 +79,7 @@ public sealed class AgentPromptAssembler : IAgentPromptAssembler
         {
             sb.AppendLine("UpcomingShifts:");
             var rendered = 0;
-            foreach (var entry in snapshot.UpcomingShifts)
+            foreach (var entry in snapshot.UpcomingShifts.OrderBy(e => e.StartDate))
             {
                 if (rendered >= MaxRenderedUpcomingShifts)
                     break;
@@ -98,17 +98,18 @@ public sealed class AgentPromptAssembler : IAgentPromptAssembler
 
     private static string RenderShiftEntry(UpcomingShiftEntry entry)
     {
-        // Block: "  - 2026-07-01 to 2026-07-07 — Cantina build (Voluntold, 7 days)"
-        // Singleton: "  - 2026-07-15 — Setup crew (Confirmed)"
+        // Block: "  - [<key>] 2026-07-01 to 2026-07-07 — Cantina build (Voluntold, 7 days)"
+        // Singleton: "  - [<key>] 2026-07-15 — Setup crew (Confirmed)"
+        // Key is the value the agent passes to get_shift_details(shiftId=...).
         var startIso = entry.StartDate.ToString("uuuu-MM-dd", CultureInfo.InvariantCulture);
         if (entry.DayCount > 1)
         {
             var endIso = entry.EndDate.ToString("uuuu-MM-dd", CultureInfo.InvariantCulture);
             return string.Create(CultureInfo.InvariantCulture,
-                $"  - {startIso} to {endIso} — {entry.Label} ({entry.Status}, {entry.DayCount} days)");
+                $"  - [{entry.Key}] {startIso} to {endIso} — {entry.Label} ({entry.Status}, {entry.DayCount} days)");
         }
         return string.Create(CultureInfo.InvariantCulture,
-            $"  - {startIso} — {entry.Label} ({entry.Status})");
+            $"  - [{entry.Key}] {startIso} — {entry.Label} ({entry.Status})");
     }
 
     public IReadOnlyList<AnthropicToolDefinition> BuildToolDefinitions() =>

--- a/src/Humans.Infrastructure/Services/Agent/AgentPromptAssembler.cs
+++ b/src/Humans.Infrastructure/Services/Agent/AgentPromptAssembler.cs
@@ -98,7 +98,7 @@ public sealed class AgentPromptAssembler : IAgentPromptAssembler
 
     private static string RenderShiftEntry(UpcomingShiftEntry entry)
     {
-        // Block: "  - [<key>] 2026-07-01 to 2026-07-07 — Cantina build (Voluntold, 7 days)"
+        // Block: "  - [<key>] 2026-07-01 to 2026-07-07 — Cantina build (Confirmed, 7 days)"
         // Singleton: "  - [<key>] 2026-07-15 — Setup crew (Confirmed)"
         // Key is the value the agent passes to get_shift_details(shiftId=...).
         var startIso = entry.StartDate.ToString("uuuu-MM-dd", CultureInfo.InvariantCulture);

--- a/src/Humans.Infrastructure/Services/Agent/AgentToolDispatcher.cs
+++ b/src/Humans.Infrastructure/Services/Agent/AgentToolDispatcher.cs
@@ -1,11 +1,16 @@
 using System.Globalization;
+using System.Text;
 using System.Text.Json;
 using Humans.Application.Constants;
 using Humans.Application.Interfaces;
 using Humans.Application.Interfaces.AuditLog;
+using Humans.Application.Interfaces.Shifts;
 using Humans.Application.Models;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
 using Humans.Infrastructure.Services.Preload;
 using Microsoft.Extensions.Logging;
+using NodaTime;
 
 namespace Humans.Infrastructure.Services.Agent;
 
@@ -26,17 +31,23 @@ public sealed class AgentToolDispatcher : IAgentToolDispatcher
     private readonly AgentSectionDocReader _sections;
     private readonly AgentFeatureSpecReader _features;
     private readonly IAuditViewerService _auditViewer;
+    private readonly IShiftSignupService _shiftSignups;
+    private readonly IShiftManagementService _shiftManagement;
     private readonly ILogger<AgentToolDispatcher> _logger;
 
     public AgentToolDispatcher(
         AgentSectionDocReader sections,
         AgentFeatureSpecReader features,
         IAuditViewerService auditViewer,
+        IShiftSignupService shiftSignups,
+        IShiftManagementService shiftManagement,
         ILogger<AgentToolDispatcher> logger)
     {
         _sections = sections;
         _features = features;
         _auditViewer = auditViewer;
+        _shiftSignups = shiftSignups;
+        _shiftManagement = shiftManagement;
         _logger = logger;
     }
 
@@ -76,6 +87,13 @@ public sealed class AgentToolDispatcher : IAgentToolDispatcher
                     {
                         var limit = ParseAuditHistoryLimit(args);
                         return await DispatchGetAuditHistoryAsync(call.Id, userId, limit, cancellationToken);
+                    }
+                case AgentToolNames.GetShiftDetails:
+                    {
+                        var shiftIdString = args.TryGetProperty("shiftId", out var sid) ? sid.GetString() ?? "" : "";
+                        if (!Guid.TryParse(shiftIdString, out var shiftKey))
+                            return new AnthropicToolResult(call.Id, "shiftId must be a valid GUID.", IsError: true);
+                        return await DispatchGetShiftDetailsAsync(call.Id, userId, shiftKey, cancellationToken);
                     }
                 case AgentToolNames.RouteToIssue:
                     {
@@ -118,6 +136,105 @@ public sealed class AgentToolDispatcher : IAgentToolDispatcher
 
         return new AnthropicToolResult(callId, content, IsError: false);
     }
+
+    /// <summary>
+    /// Resolves the agent's <c>get_shift_details</c> argument — which is either
+    /// a <see cref="ShiftSignup.SignupBlockId"/> (block) or a single
+    /// <see cref="ShiftSignup.Id"/> — and returns a textualized summary of the
+    /// matching signup(s). Only signups belonging to the calling user are
+    /// reachable; anything else returns "Shift not found" (no information leak
+    /// about other users' shifts).
+    /// </summary>
+    private async Task<AnthropicToolResult> DispatchGetShiftDetailsAsync(
+        string callId, Guid userId, Guid shiftKey, CancellationToken ct)
+    {
+        var activeEvent = await _shiftManagement.GetActiveAsync();
+        if (activeEvent is null)
+            return new AnthropicToolResult(callId, "No active event configured.", IsError: true);
+
+        var signups = await _shiftSignups.GetByUserAsync(userId, activeEvent.Id);
+
+        // Try block first.
+        var blockMatches = signups
+            .Where(s => s.SignupBlockId == shiftKey)
+            .ToList();
+        if (blockMatches.Count > 0)
+            return new AnthropicToolResult(callId,
+                RenderShiftDetails(blockMatches, activeEvent), IsError: false);
+
+        // Fall back to singleton id.
+        var singleton = signups.FirstOrDefault(s => s.Id == shiftKey);
+        if (singleton is not null)
+            return new AnthropicToolResult(callId,
+                RenderShiftDetails(new[] { singleton }, activeEvent), IsError: false);
+
+        return new AnthropicToolResult(callId, "Shift not found.", IsError: true);
+    }
+
+    /// <summary>
+    /// Builds the textual blob returned for <c>get_shift_details</c>. Renders
+    /// the rota name, date span, status, day count, hours window, optional
+    /// shift description, and Rota.PracticalInfo (where to show up). All
+    /// signups passed in must belong to the calling user.
+    /// </summary>
+    private static string RenderShiftDetails(IReadOnlyList<ShiftSignup> signups, EventSettings ev)
+    {
+        // Order chronologically so first/last reflect actual span.
+        var ordered = signups.OrderBy(s => s.Shift.DayOffset).ToList();
+        var first = ordered[0];
+        var last = ordered[^1];
+        var rota = first.Shift.Rota;
+
+        var startDate = ev.GateOpeningDate.PlusDays(first.Shift.DayOffset);
+        var endDate = ev.GateOpeningDate.PlusDays(last.Shift.DayOffset);
+        var dayCount = ordered.Select(s => s.Shift.DayOffset).Distinct().Count();
+        var status = first.Status;
+        var label = rota?.Name ?? "(unnamed rota)";
+
+        var sb = new StringBuilder();
+        if (dayCount > 1)
+        {
+            sb.AppendLine(string.Create(CultureInfo.InvariantCulture,
+                $"{label} — {FormatDate(startDate)} to {FormatDate(endDate)}"));
+        }
+        else
+        {
+            sb.AppendLine(string.Create(CultureInfo.InvariantCulture, $"{label} — {FormatDate(startDate)}"));
+        }
+
+        sb.AppendLine(dayCount > 1
+            ? string.Create(CultureInfo.InvariantCulture, $"Status: {status} ({dayCount} days)")
+            : string.Create(CultureInfo.InvariantCulture, $"Status: {status}"));
+
+        // Hours window.
+        if (first.Shift.IsAllDay)
+        {
+            sb.AppendLine(string.Create(CultureInfo.InvariantCulture,
+                $"Hours: {Shift.AllDayWindowStart:HH:mm}–{Shift.AllDayWindowEnd:HH:mm} each day (all-day shift)"));
+        }
+        else
+        {
+            var totalHours = first.Shift.Duration.TotalHours;
+            sb.AppendLine(string.Create(CultureInfo.InvariantCulture,
+                $"Hours: starts {first.Shift.StartTime:HH:mm}, lasts {totalHours:0.##} hours"));
+        }
+
+        // Shift description (per-shift duties).
+        if (!string.IsNullOrWhiteSpace(first.Shift.Description))
+            sb.AppendLine(string.Create(CultureInfo.InvariantCulture, $"Description: {first.Shift.Description.Trim()}"));
+
+        // Rota PracticalInfo — the canonical "where to show up / what to bring" field.
+        if (!string.IsNullOrWhiteSpace(rota?.PracticalInfo))
+            sb.AppendLine(string.Create(CultureInfo.InvariantCulture, $"Where to show up: {rota.PracticalInfo!.Trim()}"));
+
+        if (!string.IsNullOrWhiteSpace(rota?.Description))
+            sb.AppendLine(string.Create(CultureInfo.InvariantCulture, $"Rota description: {rota.Description!.Trim()}"));
+
+        return sb.ToString().TrimEnd();
+    }
+
+    private static string FormatDate(LocalDate date) =>
+        date.ToString("uuuu-MM-dd", CultureInfo.InvariantCulture);
 
     private static int ParseAuditHistoryLimit(JsonElement args)
     {

--- a/src/Humans.Infrastructure/Services/Agent/AgentToolDispatcher.cs
+++ b/src/Humans.Infrastructure/Services/Agent/AgentToolDispatcher.cs
@@ -154,9 +154,14 @@ public sealed class AgentToolDispatcher : IAgentToolDispatcher
 
         var signups = await _shiftSignups.GetByUserAsync(userId, activeEvent.Id);
 
-        // Try block first.
+        // Try block first. Filter to active states so RenderShiftDetails
+        // reports a status consistent with the snapshot tail (which also
+        // filters to Pending/Confirmed). Without this, a block where day 1
+        // was individually bailed but days 2–7 stayed Confirmed would render
+        // "Status: Bailed" here while the snapshot showed "Confirmed".
         var blockMatches = signups
-            .Where(s => s.SignupBlockId == shiftKey)
+            .Where(s => s.SignupBlockId == shiftKey
+                && s.Status is SignupStatus.Pending or SignupStatus.Confirmed)
             .ToList();
         if (blockMatches.Count > 0)
             return new AnthropicToolResult(callId,

--- a/src/Humans.Infrastructure/Services/Agent/AgentUserSnapshotProvider.cs
+++ b/src/Humans.Infrastructure/Services/Agent/AgentUserSnapshotProvider.cs
@@ -9,6 +9,7 @@ using Humans.Application.Interfaces.Teams;
 using Humans.Application.Interfaces.Tickets;
 using Humans.Application.Interfaces.Users;
 using Humans.Application.Models;
+using Humans.Domain.Enums;
 using NodaTime;
 
 namespace Humans.Infrastructure.Services.Agent;
@@ -92,7 +93,9 @@ public sealed class AgentUserSnapshotProvider : IAgentUserSnapshotProvider
 
         var now = _clock.GetCurrentInstant();
         var upcoming = signups
-            .Where(s => s.Shift is not null && s.Shift.GetAbsoluteEnd(activeEvent) > now)
+            .Where(s => s.Shift is not null
+                && s.Shift.GetAbsoluteEnd(activeEvent) > now
+                && s.Status is SignupStatus.Pending or SignupStatus.Confirmed)
             .ToList();
         if (upcoming.Count == 0)
             return Array.Empty<UpcomingShiftEntry>();
@@ -136,8 +139,8 @@ public sealed class AgentUserSnapshotProvider : IAgentUserSnapshotProvider
                 Status: status));
         }
 
-        return entries
-            .OrderBy(e => e.StartDate)
-            .ToList();
+        // No display sort here — AgentPromptAssembler.BuildUserContextTail
+        // sorts by StartDate at the rendering layer (memory/architecture/display-sort-in-controllers.md).
+        return entries;
     }
 }

--- a/src/Humans.Infrastructure/Services/Agent/AgentUserSnapshotProvider.cs
+++ b/src/Humans.Infrastructure/Services/Agent/AgentUserSnapshotProvider.cs
@@ -4,9 +4,12 @@ using Humans.Application.Interfaces.Auth;
 using Humans.Application.Interfaces.Consent;
 using Humans.Application.Interfaces.Feedback;
 using Humans.Application.Interfaces.Profiles;
+using Humans.Application.Interfaces.Shifts;
 using Humans.Application.Interfaces.Teams;
+using Humans.Application.Interfaces.Tickets;
 using Humans.Application.Interfaces.Users;
 using Humans.Application.Models;
+using NodaTime;
 
 namespace Humans.Infrastructure.Services.Agent;
 
@@ -18,6 +21,10 @@ public sealed class AgentUserSnapshotProvider : IAgentUserSnapshotProvider
     private readonly ITeamService _teams;
     private readonly IConsentService _consents;
     private readonly IFeedbackService _feedback;
+    private readonly ITicketQueryService _tickets;
+    private readonly IShiftSignupService _shiftSignups;
+    private readonly IShiftManagementService _shiftManagement;
+    private readonly IClock _clock;
 
     public AgentUserSnapshotProvider(
         IProfileService profiles,
@@ -25,7 +32,11 @@ public sealed class AgentUserSnapshotProvider : IAgentUserSnapshotProvider
         IRoleAssignmentService roles,
         ITeamService teams,
         IConsentService consents,
-        IFeedbackService feedback)
+        IFeedbackService feedback,
+        ITicketQueryService tickets,
+        IShiftSignupService shiftSignups,
+        IShiftManagementService shiftManagement,
+        IClock clock)
     {
         _profiles = profiles;
         _users = users;
@@ -33,6 +44,10 @@ public sealed class AgentUserSnapshotProvider : IAgentUserSnapshotProvider
         _teams = teams;
         _consents = consents;
         _feedback = feedback;
+        _tickets = tickets;
+        _shiftSignups = shiftSignups;
+        _shiftManagement = shiftManagement;
+        _clock = clock;
     }
 
     public async Task<AgentUserSnapshot> LoadAsync(Guid userId, CancellationToken cancellationToken)
@@ -40,9 +55,11 @@ public sealed class AgentUserSnapshotProvider : IAgentUserSnapshotProvider
         var profile = await _profiles.GetProfileAsync(userId, cancellationToken);
         var user = await _users.GetByIdAsync(userId, cancellationToken);
         var activeRoles = await _roles.GetActiveForUserAsync(userId, cancellationToken);
-        var teamNames = await _teams.GetActiveTeamNamesForUserAsync(userId, cancellationToken);
+        var teamMemberships = await _teams.GetActiveTeamMembershipsForUserAsync(userId, cancellationToken);
         var pendingDocs = await _consents.GetPendingDocumentNamesAsync(userId, cancellationToken);
         var openFeedback = await _feedback.GetOpenFeedbackIdsForUserAsync(userId, cancellationToken);
+        var openTickets = await _tickets.GetOpenTicketIdsForUserAsync(userId, cancellationToken);
+        var upcomingShifts = await LoadUpcomingShiftsAsync(userId, cancellationToken);
 
         var roleAssignments = activeRoles
             .Select(r => (r.RoleName, r.ValidTo?.ToInvariantInstantString() ?? "—"))
@@ -55,10 +72,72 @@ public sealed class AgentUserSnapshotProvider : IAgentUserSnapshotProvider
             Tier: profile?.MembershipTier.ToString() ?? "Volunteer",
             IsApproved: profile?.IsApproved ?? false,
             RoleAssignments: roleAssignments,
-            Teams: teamNames,
+            Teams: teamMemberships,
             PendingConsentDocs: pendingDocs,
-            // Tickets not integrated in Phase 1 (no per-user open-ticket lookup method on ITicketQueryService)
-            OpenTicketIds: Array.Empty<Guid>(),
-            OpenFeedbackIds: openFeedback);
+            OpenTicketIds: openTickets,
+            OpenFeedbackIds: openFeedback,
+            UpcomingShifts: upcomingShifts);
+    }
+
+    private async Task<IReadOnlyList<UpcomingShiftEntry>> LoadUpcomingShiftsAsync(
+        Guid userId, CancellationToken cancellationToken)
+    {
+        var activeEvent = await _shiftManagement.GetActiveAsync();
+        if (activeEvent is null)
+            return Array.Empty<UpcomingShiftEntry>();
+
+        var signups = await _shiftSignups.GetByUserAsync(userId, activeEvent.Id);
+        if (signups.Count == 0)
+            return Array.Empty<UpcomingShiftEntry>();
+
+        var now = _clock.GetCurrentInstant();
+        var upcoming = signups
+            .Where(s => s.Shift is not null && s.Shift.GetAbsoluteEnd(activeEvent) > now)
+            .ToList();
+        if (upcoming.Count == 0)
+            return Array.Empty<UpcomingShiftEntry>();
+
+        var entries = new List<UpcomingShiftEntry>();
+
+        // Singletons (SignupBlockId == null) → one entry per signup.
+        foreach (var signup in upcoming.Where(s => s.SignupBlockId is null))
+        {
+            var date = activeEvent.GateOpeningDate.PlusDays(signup.Shift.DayOffset);
+            entries.Add(new UpcomingShiftEntry(
+                Key: signup.Id,
+                Label: signup.Shift.Rota?.Name ?? "(unnamed rota)",
+                StartDate: date,
+                EndDate: date,
+                DayCount: 1,
+                Status: signup.Status));
+        }
+
+        // Block signups (SignupBlockId != null) → group by block id.
+        foreach (var group in upcoming
+            .Where(s => s.SignupBlockId is not null)
+            .GroupBy(s => s.SignupBlockId!.Value))
+        {
+            var dates = group
+                .Select(s => activeEvent.GateOpeningDate.PlusDays(s.Shift.DayOffset))
+                .OrderBy(d => d)
+                .ToList();
+            var label = group.First().Shift.Rota?.Name ?? "(unnamed rota)";
+            // Use the earliest signup's status as the block status — block
+            // signups are created in one transaction so they share a status,
+            // but defensively pick the earliest so a partially-bailed range
+            // still surfaces something meaningful.
+            var status = group.OrderBy(s => s.Shift.DayOffset).First().Status;
+            entries.Add(new UpcomingShiftEntry(
+                Key: group.Key,
+                Label: label,
+                StartDate: dates[0],
+                EndDate: dates[^1],
+                DayCount: dates.Distinct().Count(),
+                Status: status));
+        }
+
+        return entries
+            .OrderBy(e => e.StartDate)
+            .ToList();
     }
 }

--- a/src/Humans.Web/Controllers/ProfileController.cs
+++ b/src/Humans.Web/Controllers/ProfileController.cs
@@ -1839,6 +1839,7 @@ public class ProfileController : HumansControllerBase
 
             var popoverUser = await _userService.GetByIdAsync(id, ct);
             var teams = (await _teamService.GetActiveTeamMembershipsForUserAsync(id, ct))
+                .OrderBy(m => m.TeamName, StringComparer.OrdinalIgnoreCase)
                 .Select(m => m.TeamName)
                 .ToList();
             var profileLanguages = await _profileService.GetProfileLanguagesAsync(profile.Id, ct);

--- a/src/Humans.Web/Controllers/ProfileController.cs
+++ b/src/Humans.Web/Controllers/ProfileController.cs
@@ -1838,7 +1838,9 @@ public class ProfileController : HumansControllerBase
             if (profile is null) return NotFound();
 
             var popoverUser = await _userService.GetByIdAsync(id, ct);
-            var teams = await _teamService.GetActiveTeamNamesForUserAsync(id, ct);
+            var teams = (await _teamService.GetActiveTeamMembershipsForUserAsync(id, ct))
+                .Select(m => m.TeamName)
+                .ToList();
             var profileLanguages = await _profileService.GetProfileLanguagesAsync(profile.Id, ct);
 
             var effectivePictureUrl = profile.HasCustomProfilePicture

--- a/tests/Humans.Application.Tests/Agent/AgentPromptAssemblerTests.cs
+++ b/tests/Humans.Application.Tests/Agent/AgentPromptAssemblerTests.cs
@@ -1,6 +1,8 @@
 using AwesomeAssertions;
 using Humans.Application.Models;
+using Humans.Domain.Enums;
 using Humans.Infrastructure.Services.Agent;
+using NodaTime;
 using Xunit;
 
 namespace Humans.Application.Tests.Agent;
@@ -17,10 +19,15 @@ public class AgentPromptAssemblerTests
             Tier: "Volunteer",
             IsApproved: true,
             RoleAssignments: new[] { ("TeamsAdmin", "2027-12-31") },
-            Teams: new[] { "Volunteers", "Tech" },
+            Teams: new[]
+            {
+                new TeamMembership("Volunteers", TeamMemberRole.Member),
+                new TeamMembership("Tech", TeamMemberRole.Coordinator)
+            },
             PendingConsentDocs: new[] { "Privacy Policy" },
             OpenTicketIds: Array.Empty<Guid>(),
-            OpenFeedbackIds: Array.Empty<Guid>());
+            OpenFeedbackIds: Array.Empty<Guid>(),
+            UpcomingShifts: Array.Empty<UpcomingShiftEntry>());
 
         var assembler = new AgentPromptAssembler();
         var tail = assembler.BuildUserContextTail(snapshot);
@@ -30,4 +37,120 @@ public class AgentPromptAssemblerTests
         tail.Should().Contain("TeamsAdmin");
         tail.Should().Contain("Privacy Policy");
     }
+
+    [HumansFact]
+    public void BuildUserContextTail_renders_team_with_role_per_team()
+    {
+        var snapshot = new AgentUserSnapshot(
+            UserId: Guid.NewGuid(),
+            DisplayName: "Volunteer",
+            PreferredLocale: "es",
+            Tier: "Volunteer",
+            IsApproved: true,
+            RoleAssignments: Array.Empty<(string, string)>(),
+            Teams: new[]
+            {
+                new TeamMembership("Build", TeamMemberRole.Coordinator),
+                new TeamMembership("Cantina", TeamMemberRole.Member)
+            },
+            PendingConsentDocs: Array.Empty<string>(),
+            OpenTicketIds: Array.Empty<Guid>(),
+            OpenFeedbackIds: Array.Empty<Guid>(),
+            UpcomingShifts: Array.Empty<UpcomingShiftEntry>());
+
+        var assembler = new AgentPromptAssembler();
+        var tail = assembler.BuildUserContextTail(snapshot);
+
+        tail.Should().Contain("Build (Coordinator)");
+        tail.Should().Contain("Cantina (Member)");
+    }
+
+    [HumansFact]
+    public void BuildUserContextTail_renders_upcoming_shift_block_with_date_range_and_day_count()
+    {
+        var blockKey = Guid.NewGuid();
+        var snapshot = MakeSnapshot(
+            new UpcomingShiftEntry(
+                Key: blockKey,
+                Label: "Cantina build",
+                StartDate: new LocalDate(2026, 7, 1),
+                EndDate: new LocalDate(2026, 7, 7),
+                DayCount: 7,
+                Status: SignupStatus.Confirmed));
+
+        var tail = new AgentPromptAssembler().BuildUserContextTail(snapshot);
+
+        tail.Should().Contain("UpcomingShifts:");
+        tail.Should().Contain("2026-07-01 to 2026-07-07");
+        tail.Should().Contain("Cantina build");
+        tail.Should().Contain("(Confirmed, 7 days)");
+    }
+
+    [HumansFact]
+    public void BuildUserContextTail_renders_upcoming_shift_singleton_with_single_date()
+    {
+        var snapshot = MakeSnapshot(
+            new UpcomingShiftEntry(
+                Key: Guid.NewGuid(),
+                Label: "Setup crew",
+                StartDate: new LocalDate(2026, 7, 15),
+                EndDate: new LocalDate(2026, 7, 15),
+                DayCount: 1,
+                Status: SignupStatus.Pending));
+
+        var tail = new AgentPromptAssembler().BuildUserContextTail(snapshot);
+
+        tail.Should().Contain("2026-07-15 — Setup crew (Pending)");
+        // Singletons must NOT include "(Pending, 1 days)" — only the block path renders day count.
+        tail.Should().NotContain("1 days");
+    }
+
+    [HumansFact]
+    public void BuildUserContextTail_omits_upcoming_shifts_section_when_empty()
+    {
+        var snapshot = MakeSnapshot();
+        var tail = new AgentPromptAssembler().BuildUserContextTail(snapshot);
+        tail.Should().NotContain("UpcomingShifts");
+    }
+
+    [HumansFact]
+    public void BuildUserContextTail_caps_upcoming_shifts_with_overflow_marker()
+    {
+        var entries = Enumerable.Range(0, 12)
+            .Select(i => new UpcomingShiftEntry(
+                Key: Guid.NewGuid(),
+                Label: "Rota " + i,
+                StartDate: new LocalDate(2026, 7, 1).PlusDays(i),
+                EndDate: new LocalDate(2026, 7, 1).PlusDays(i),
+                DayCount: 1,
+                Status: SignupStatus.Confirmed))
+            .ToArray();
+
+        var snapshot = MakeSnapshot(entries);
+
+        var tail = new AgentPromptAssembler().BuildUserContextTail(snapshot);
+
+        // First 10 entries rendered.
+        tail.Should().Contain("Rota 0");
+        tail.Should().Contain("Rota 9");
+        // Entries beyond cap not in body.
+        tail.Should().NotContain("Rota 10");
+        tail.Should().NotContain("Rota 11");
+        // Overflow marker present.
+        tail.Should().Contain("+2 more");
+    }
+
+    private static AgentUserSnapshot MakeSnapshot(params UpcomingShiftEntry[] upcoming) =>
+        new(
+            UserId: Guid.NewGuid(),
+            DisplayName: "Test",
+            PreferredLocale: "es",
+            Tier: "Volunteer",
+            IsApproved: true,
+            RoleAssignments: Array.Empty<(string, string)>(),
+            Teams: Array.Empty<TeamMembership>(),
+            PendingConsentDocs: Array.Empty<string>(),
+            OpenTicketIds: Array.Empty<Guid>(),
+            OpenFeedbackIds: Array.Empty<Guid>(),
+            UpcomingShifts: upcoming);
 }

--- a/tests/Humans.Application.Tests/Agent/AgentPromptAssemblerTests.cs
+++ b/tests/Humans.Application.Tests/Agent/AgentPromptAssemblerTests.cs
@@ -114,6 +114,62 @@ public class AgentPromptAssemblerTests
     }
 
     [HumansFact]
+    public void BuildUserContextTail_sorts_upcoming_shifts_by_start_date_at_render_time()
+    {
+        // Service layer returns unsorted; the rendering layer is responsible for display order.
+        var snapshot = MakeSnapshot(
+            new UpcomingShiftEntry(Guid.NewGuid(), "Later", new LocalDate(2026, 7, 15), new LocalDate(2026, 7, 15), 1, SignupStatus.Confirmed),
+            new UpcomingShiftEntry(Guid.NewGuid(), "Earlier", new LocalDate(2026, 7, 1), new LocalDate(2026, 7, 1), 1, SignupStatus.Confirmed));
+
+        var tail = new AgentPromptAssembler().BuildUserContextTail(snapshot);
+
+        var earlierIdx = tail.IndexOf("Earlier", StringComparison.Ordinal);
+        var laterIdx = tail.IndexOf("Later", StringComparison.Ordinal);
+        earlierIdx.Should().BeGreaterThan(0);
+        laterIdx.Should().BeGreaterThan(earlierIdx);
+    }
+
+    [HumansFact]
+    public void BuildUserContextTail_sorts_teams_alphabetically_at_render_time()
+    {
+        var snapshot = new AgentUserSnapshot(
+            UserId: Guid.NewGuid(),
+            DisplayName: "Test",
+            PreferredLocale: "es",
+            Tier: "Volunteer",
+            IsApproved: true,
+            RoleAssignments: Array.Empty<(string, string)>(),
+            Teams: new[]
+            {
+                new TeamMembership("Zebra", TeamMemberRole.Member),
+                new TeamMembership("Apple", TeamMemberRole.Coordinator),
+            },
+            PendingConsentDocs: Array.Empty<string>(),
+            OpenTicketIds: Array.Empty<Guid>(),
+            OpenFeedbackIds: Array.Empty<Guid>(),
+            UpcomingShifts: Array.Empty<UpcomingShiftEntry>());
+
+        var tail = new AgentPromptAssembler().BuildUserContextTail(snapshot);
+
+        var appleIdx = tail.IndexOf("Apple", StringComparison.Ordinal);
+        var zebraIdx = tail.IndexOf("Zebra", StringComparison.Ordinal);
+        appleIdx.Should().BeGreaterThan(0);
+        zebraIdx.Should().BeGreaterThan(appleIdx);
+    }
+
+    [HumansFact]
+    public void BuildUserContextTail_renders_shift_key_so_agent_can_call_get_shift_details()
+    {
+        var key = Guid.NewGuid();
+        var snapshot = MakeSnapshot(
+            new UpcomingShiftEntry(key, "Setup crew", new LocalDate(2026, 7, 15), new LocalDate(2026, 7, 15), 1, SignupStatus.Pending));
+
+        var tail = new AgentPromptAssembler().BuildUserContextTail(snapshot);
+
+        tail.Should().Contain($"[{key}]");
+    }
+
+    [HumansFact]
     public void BuildUserContextTail_caps_upcoming_shifts_with_overflow_marker()
     {
         var entries = Enumerable.Range(0, 12)

--- a/tests/Humans.Application.Tests/Agent/AgentServiceTests.cs
+++ b/tests/Humans.Application.Tests/Agent/AgentServiceTests.cs
@@ -213,8 +213,11 @@ public class AgentServiceTests
         var snapshots = Substitute.For<IAgentUserSnapshotProvider>();
         snapshots.LoadAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>()).Returns(
             new AgentUserSnapshot(Guid.NewGuid(), "Test User", "es", "Volunteer", true,
-                Array.Empty<(string, string)>(), Array.Empty<string>(), Array.Empty<string>(),
-                Array.Empty<Guid>(), Array.Empty<Guid>()));
+                Array.Empty<(string, string)>(),
+                Array.Empty<Humans.Application.Models.TeamMembership>(),
+                Array.Empty<string>(),
+                Array.Empty<Guid>(), Array.Empty<Guid>(),
+                Array.Empty<Humans.Application.Models.UpcomingShiftEntry>()));
         var preload = Substitute.For<IAgentPreloadCorpusBuilder>();
         preload.BuildAsync(Arg.Any<AgentPreloadConfig>(), Arg.Any<CancellationToken>()).Returns("");
         var assembler = new AgentPromptAssembler();

--- a/tests/Humans.Application.Tests/Agent/AgentToolDispatcherTests.cs
+++ b/tests/Humans.Application.Tests/Agent/AgentToolDispatcherTests.cs
@@ -1,6 +1,7 @@
 using AwesomeAssertions;
 using Humans.Application.Constants;
 using Humans.Application.Models;
+using NSubstitute;
 using Xunit;
 
 namespace Humans.Application.Tests.Agent;
@@ -144,6 +145,189 @@ public class AgentToolDispatcherTests
             ResourceName: null);
 
     [HumansFact]
+    public async Task GetShiftDetails_with_block_id_returns_rota_name_dates_and_day_count()
+    {
+        var viewer = Guid.NewGuid();
+        var blockId = Guid.NewGuid();
+        var ev = MakeEventSettings();
+        var rota = new Humans.Domain.Entities.Rota
+        {
+            Id = Guid.NewGuid(),
+            Name = "Cantina build",
+            PracticalInfo = "Meet at gate",
+            Description = "Daily setup support"
+        };
+        var signups = Enumerable.Range(0, 7)
+            .Select(i => MakeSignup(viewer, blockId, MakeShift(rota, dayOffset: -10 + i, isAllDay: true), Humans.Domain.Enums.SignupStatus.Confirmed))
+            .ToList();
+
+        var shiftSignups = Substitute.For<Humans.Application.Interfaces.Shifts.IShiftSignupService>();
+        shiftSignups.GetByUserAsync(viewer, ev.Id).Returns((IReadOnlyList<Humans.Domain.Entities.ShiftSignup>)signups);
+
+        var shiftMgmt = Substitute.For<Humans.Application.Interfaces.Shifts.IShiftManagementService>();
+        shiftMgmt.GetActiveAsync().Returns(ev);
+
+        var dispatcher = MakeDispatcher(shiftSignups: shiftSignups, shiftManagement: shiftMgmt);
+
+        var result = await dispatcher.DispatchAsync(
+            new AnthropicToolCall("t1", AgentToolNames.GetShiftDetails,
+                $$"""{"shiftId":"{{blockId}}"}"""),
+            userId: viewer,
+            conversationId: Guid.NewGuid(),
+            CancellationToken.None);
+
+        result.IsError.Should().BeFalse();
+        result.Content.Should().Contain("Cantina build");
+        result.Content.Should().Contain("Confirmed");
+        result.Content.Should().Contain("7 days");
+        result.Content.Should().Contain("Meet at gate");
+        result.Content.Should().Contain("all-day shift");
+    }
+
+    [HumansFact]
+    public async Task GetShiftDetails_with_singleton_id_returns_single_date()
+    {
+        var viewer = Guid.NewGuid();
+        var ev = MakeEventSettings();
+        var rota = new Humans.Domain.Entities.Rota { Id = Guid.NewGuid(), Name = "Setup crew" };
+        var signup = MakeSignup(viewer, signupBlockId: null,
+            MakeShift(rota, dayOffset: 0, isAllDay: false, startTime: new NodaTime.LocalTime(9, 0), durationHours: 4),
+            Humans.Domain.Enums.SignupStatus.Pending);
+
+        var shiftSignups = Substitute.For<Humans.Application.Interfaces.Shifts.IShiftSignupService>();
+        shiftSignups.GetByUserAsync(viewer, ev.Id)
+            .Returns((IReadOnlyList<Humans.Domain.Entities.ShiftSignup>)new[] { signup });
+
+        var shiftMgmt = Substitute.For<Humans.Application.Interfaces.Shifts.IShiftManagementService>();
+        shiftMgmt.GetActiveAsync().Returns(ev);
+
+        var dispatcher = MakeDispatcher(shiftSignups: shiftSignups, shiftManagement: shiftMgmt);
+
+        var result = await dispatcher.DispatchAsync(
+            new AnthropicToolCall("t1", AgentToolNames.GetShiftDetails,
+                $$"""{"shiftId":"{{signup.Id}}"}"""),
+            userId: viewer,
+            conversationId: Guid.NewGuid(),
+            CancellationToken.None);
+
+        result.IsError.Should().BeFalse();
+        result.Content.Should().Contain("Setup crew");
+        result.Content.Should().Contain("Pending");
+        result.Content.Should().NotContain("days)"); // no day-count blurb on singletons
+    }
+
+    [HumansFact]
+    public async Task GetShiftDetails_with_unknown_id_returns_not_found_error()
+    {
+        var viewer = Guid.NewGuid();
+        var ev = MakeEventSettings();
+
+        var shiftSignups = Substitute.For<Humans.Application.Interfaces.Shifts.IShiftSignupService>();
+        shiftSignups.GetByUserAsync(viewer, ev.Id)
+            .Returns((IReadOnlyList<Humans.Domain.Entities.ShiftSignup>)Array.Empty<Humans.Domain.Entities.ShiftSignup>());
+
+        var shiftMgmt = Substitute.For<Humans.Application.Interfaces.Shifts.IShiftManagementService>();
+        shiftMgmt.GetActiveAsync().Returns(ev);
+
+        var dispatcher = MakeDispatcher(shiftSignups: shiftSignups, shiftManagement: shiftMgmt);
+
+        var result = await dispatcher.DispatchAsync(
+            new AnthropicToolCall("t1", AgentToolNames.GetShiftDetails,
+                $$"""{"shiftId":"{{Guid.NewGuid()}}"}"""),
+            userId: viewer,
+            conversationId: Guid.NewGuid(),
+            CancellationToken.None);
+
+        result.IsError.Should().BeTrue();
+        result.Content.Should().Contain("Shift not found");
+    }
+
+    [HumansFact]
+    public async Task GetShiftDetails_does_not_leak_other_users_shifts()
+    {
+        // Lookup uses the viewer's own GetByUserAsync return — a foreign user's
+        // signup id will not appear in that list, so we get a "not found"
+        // result (no information leak about whose shift it is).
+        var viewer = Guid.NewGuid();
+        var foreignBlockId = Guid.NewGuid();
+        var ev = MakeEventSettings();
+
+        var shiftSignups = Substitute.For<Humans.Application.Interfaces.Shifts.IShiftSignupService>();
+        // Viewer has zero signups.
+        shiftSignups.GetByUserAsync(viewer, ev.Id)
+            .Returns((IReadOnlyList<Humans.Domain.Entities.ShiftSignup>)Array.Empty<Humans.Domain.Entities.ShiftSignup>());
+
+        var shiftMgmt = Substitute.For<Humans.Application.Interfaces.Shifts.IShiftManagementService>();
+        shiftMgmt.GetActiveAsync().Returns(ev);
+
+        var dispatcher = MakeDispatcher(shiftSignups: shiftSignups, shiftManagement: shiftMgmt);
+
+        var result = await dispatcher.DispatchAsync(
+            new AnthropicToolCall("t1", AgentToolNames.GetShiftDetails,
+                $$"""{"shiftId":"{{foreignBlockId}}"}"""),
+            userId: viewer,
+            conversationId: Guid.NewGuid(),
+            CancellationToken.None);
+
+        result.IsError.Should().BeTrue();
+        result.Content.Should().Contain("Shift not found");
+    }
+
+    [HumansFact]
+    public async Task GetShiftDetails_with_invalid_guid_returns_validation_error()
+    {
+        var dispatcher = MakeDispatcher();
+        var result = await dispatcher.DispatchAsync(
+            new AnthropicToolCall("t1", AgentToolNames.GetShiftDetails, """{"shiftId":"not-a-guid"}"""),
+            userId: Guid.NewGuid(),
+            conversationId: Guid.NewGuid(),
+            CancellationToken.None);
+        result.IsError.Should().BeTrue();
+        result.Content.Should().Contain("must be a valid GUID");
+    }
+
+    private static Humans.Domain.Entities.EventSettings MakeEventSettings() => new()
+    {
+        Id = Guid.NewGuid(),
+        EventName = "Test",
+        Year = 2026,
+        TimeZoneId = "Europe/Madrid",
+        GateOpeningDate = new NodaTime.LocalDate(2026, 7, 1),
+        BuildStartOffset = -14,
+        EventEndOffset = 6,
+        StrikeEndOffset = 9,
+        IsActive = true
+    };
+
+    private static Humans.Domain.Entities.Shift MakeShift(
+        Humans.Domain.Entities.Rota rota, int dayOffset, bool isAllDay,
+        NodaTime.LocalTime? startTime = null, double durationHours = 0) => new()
+        {
+            Id = Guid.NewGuid(),
+            RotaId = rota.Id,
+            Rota = rota,
+            DayOffset = dayOffset,
+            IsAllDay = isAllDay,
+            StartTime = startTime ?? new NodaTime.LocalTime(8, 0),
+            Duration = NodaTime.Duration.FromHours(durationHours),
+            MinVolunteers = 1,
+            MaxVolunteers = 5
+        };
+
+    private static Humans.Domain.Entities.ShiftSignup MakeSignup(
+        Guid userId, Guid? signupBlockId,
+        Humans.Domain.Entities.Shift shift,
+        Humans.Domain.Enums.SignupStatus status) => new()
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            ShiftId = shift.Id,
+            Shift = shift,
+            SignupBlockId = signupBlockId,
+            Status = status
+        };
+
+    [HumansFact]
     public async Task RouteToIssue_returns_proposal_marker_without_creating_anything()
     {
         var dispatcher = MakeDispatcher();
@@ -160,14 +344,21 @@ public class AgentToolDispatcherTests
     }
 
     private static Humans.Infrastructure.Services.Agent.AgentToolDispatcher MakeDispatcher(
-        Humans.Application.Interfaces.AuditLog.IAuditViewerService? auditViewer = null)
+        Humans.Application.Interfaces.AuditLog.IAuditViewerService? auditViewer = null,
+        Humans.Application.Interfaces.Shifts.IShiftSignupService? shiftSignups = null,
+        Humans.Application.Interfaces.Shifts.IShiftManagementService? shiftManagement = null)
     {
         var env = new TestHostEnvironment();
         var sections = new Humans.Infrastructure.Services.Preload.AgentSectionDocReader(env);
         var features = new Humans.Infrastructure.Services.Preload.AgentFeatureSpecReader(env);
         var logger = Microsoft.Extensions.Logging.Abstractions.NullLogger<Humans.Infrastructure.Services.Agent.AgentToolDispatcher>.Instance;
         return new Humans.Infrastructure.Services.Agent.AgentToolDispatcher(
-            sections, features, auditViewer ?? new StubAuditViewer(), logger);
+            sections,
+            features,
+            auditViewer ?? new StubAuditViewer(),
+            shiftSignups ?? Substitute.For<Humans.Application.Interfaces.Shifts.IShiftSignupService>(),
+            shiftManagement ?? Substitute.For<Humans.Application.Interfaces.Shifts.IShiftManagementService>(),
+            logger);
     }
 
     private sealed class StubAuditViewer : Humans.Application.Interfaces.AuditLog.IAuditViewerService

--- a/tests/Humans.Application.Tests/Agent/AgentUserSnapshotProviderTests.cs
+++ b/tests/Humans.Application.Tests/Agent/AgentUserSnapshotProviderTests.cs
@@ -83,21 +83,23 @@ public class AgentUserSnapshotProviderTests
     }
 
     [HumansFact]
-    public async Task LoadAsync_sorts_entries_by_start_date_ascending()
+    public async Task LoadAsync_excludes_inactive_signup_states()
     {
+        // Pending and Confirmed are surfaced; Refused, Bailed, Cancelled are not.
         var userId = Guid.NewGuid();
         var ev = MakeEventSettings();
-        var rotaA = new Rota { Id = Guid.NewGuid(), Name = "Later" };
-        var rotaB = new Rota { Id = Guid.NewGuid(), Name = "Earlier" };
-        var later = MakeSignup(userId, null, MakeShift(rotaA, dayOffset: 5, isAllDay: true), SignupStatus.Confirmed);
-        var earlier = MakeSignup(userId, null, MakeShift(rotaB, dayOffset: 1, isAllDay: true), SignupStatus.Confirmed);
+        var rota = new Rota { Id = Guid.NewGuid(), Name = "R" };
+        var pending = MakeSignup(userId, null, MakeShift(rota, dayOffset: 1, isAllDay: true), SignupStatus.Pending);
+        var confirmed = MakeSignup(userId, null, MakeShift(rota, dayOffset: 2, isAllDay: true), SignupStatus.Confirmed);
+        var refused = MakeSignup(userId, null, MakeShift(rota, dayOffset: 3, isAllDay: true), SignupStatus.Refused);
+        var bailed = MakeSignup(userId, null, MakeShift(rota, dayOffset: 4, isAllDay: true), SignupStatus.Bailed);
+        var cancelled = MakeSignup(userId, null, MakeShift(rota, dayOffset: 5, isAllDay: true), SignupStatus.Cancelled);
 
-        var provider = MakeProvider(userId, ev, new[] { later, earlier });
+        var provider = MakeProvider(userId, ev, new[] { pending, confirmed, refused, bailed, cancelled });
         var snapshot = await provider.LoadAsync(userId, CancellationToken.None);
 
         snapshot.UpcomingShifts.Should().HaveCount(2);
-        snapshot.UpcomingShifts[0].Label.Should().Be("Earlier");
-        snapshot.UpcomingShifts[1].Label.Should().Be("Later");
+        snapshot.UpcomingShifts.Select(e => e.Status).Should().BeEquivalentTo(new[] { SignupStatus.Pending, SignupStatus.Confirmed });
     }
 
     [HumansFact]

--- a/tests/Humans.Application.Tests/Agent/AgentUserSnapshotProviderTests.cs
+++ b/tests/Humans.Application.Tests/Agent/AgentUserSnapshotProviderTests.cs
@@ -1,0 +1,224 @@
+using AwesomeAssertions;
+using Humans.Application.Interfaces.Auth;
+using Humans.Application.Interfaces.Consent;
+using Humans.Application.Interfaces.Feedback;
+using Humans.Application.Interfaces.Profiles;
+using Humans.Application.Interfaces.Shifts;
+using Humans.Application.Interfaces.Teams;
+using Humans.Application.Interfaces.Tickets;
+using Humans.Application.Interfaces.Users;
+using Humans.Application.Models;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using Humans.Infrastructure.Services.Agent;
+using NodaTime;
+using NodaTime.Testing;
+using NSubstitute;
+using Xunit;
+
+namespace Humans.Application.Tests.Agent;
+
+public class AgentUserSnapshotProviderTests
+{
+    [HumansFact]
+    public async Task LoadAsync_collapses_block_signups_into_one_entry_with_date_range_and_day_count()
+    {
+        var userId = Guid.NewGuid();
+        var blockId = Guid.NewGuid();
+        var ev = MakeEventSettings();
+        var rota = new Rota { Id = Guid.NewGuid(), Name = "Cantina build" };
+        var signups = Enumerable.Range(0, 7)
+            .Select(i => MakeSignup(userId, blockId, MakeShift(rota, dayOffset: -10 + i, isAllDay: true), SignupStatus.Confirmed))
+            .ToList();
+
+        var provider = MakeProvider(userId, ev, signups);
+
+        var snapshot = await provider.LoadAsync(userId, CancellationToken.None);
+
+        snapshot.UpcomingShifts.Should().HaveCount(1);
+        var entry = snapshot.UpcomingShifts[0];
+        entry.Key.Should().Be(blockId);
+        entry.Label.Should().Be("Cantina build");
+        entry.DayCount.Should().Be(7);
+        entry.StartDate.Should().Be(new LocalDate(2026, 6, 21));
+        entry.EndDate.Should().Be(new LocalDate(2026, 6, 27));
+        entry.Status.Should().Be(SignupStatus.Confirmed);
+    }
+
+    [HumansFact]
+    public async Task LoadAsync_singletons_pass_through_with_start_equal_end()
+    {
+        var userId = Guid.NewGuid();
+        var ev = MakeEventSettings();
+        var rota = new Rota { Id = Guid.NewGuid(), Name = "Setup crew" };
+        var signup = MakeSignup(userId, signupBlockId: null,
+            MakeShift(rota, dayOffset: 0, isAllDay: false, startTime: new LocalTime(9, 0), durationHours: 4),
+            SignupStatus.Pending);
+
+        var provider = MakeProvider(userId, ev, new[] { signup });
+
+        var snapshot = await provider.LoadAsync(userId, CancellationToken.None);
+
+        snapshot.UpcomingShifts.Should().HaveCount(1);
+        var entry = snapshot.UpcomingShifts[0];
+        entry.Key.Should().Be(signup.Id);
+        entry.DayCount.Should().Be(1);
+        entry.StartDate.Should().Be(entry.EndDate);
+    }
+
+    [HumansFact]
+    public async Task LoadAsync_filters_out_past_shifts()
+    {
+        var userId = Guid.NewGuid();
+        var ev = MakeEventSettings();
+        var rota = new Rota { Id = Guid.NewGuid(), Name = "Old" };
+        var pastSignup = MakeSignup(userId, signupBlockId: null,
+            MakeShift(rota, dayOffset: -100, isAllDay: true), SignupStatus.Confirmed);
+
+        var provider = MakeProvider(userId, ev, new[] { pastSignup });
+
+        var snapshot = await provider.LoadAsync(userId, CancellationToken.None);
+
+        snapshot.UpcomingShifts.Should().BeEmpty();
+    }
+
+    [HumansFact]
+    public async Task LoadAsync_sorts_entries_by_start_date_ascending()
+    {
+        var userId = Guid.NewGuid();
+        var ev = MakeEventSettings();
+        var rotaA = new Rota { Id = Guid.NewGuid(), Name = "Later" };
+        var rotaB = new Rota { Id = Guid.NewGuid(), Name = "Earlier" };
+        var later = MakeSignup(userId, null, MakeShift(rotaA, dayOffset: 5, isAllDay: true), SignupStatus.Confirmed);
+        var earlier = MakeSignup(userId, null, MakeShift(rotaB, dayOffset: 1, isAllDay: true), SignupStatus.Confirmed);
+
+        var provider = MakeProvider(userId, ev, new[] { later, earlier });
+        var snapshot = await provider.LoadAsync(userId, CancellationToken.None);
+
+        snapshot.UpcomingShifts.Should().HaveCount(2);
+        snapshot.UpcomingShifts[0].Label.Should().Be("Earlier");
+        snapshot.UpcomingShifts[1].Label.Should().Be("Later");
+    }
+
+    [HumansFact]
+    public async Task LoadAsync_returns_empty_when_no_active_event()
+    {
+        var userId = Guid.NewGuid();
+        var provider = MakeProvider(userId, activeEvent: null, signups: Array.Empty<ShiftSignup>());
+        var snapshot = await provider.LoadAsync(userId, CancellationToken.None);
+        snapshot.UpcomingShifts.Should().BeEmpty();
+    }
+
+    [HumansFact]
+    public async Task LoadAsync_populates_OpenTicketIds_from_ticket_service()
+    {
+        var userId = Guid.NewGuid();
+        var ev = MakeEventSettings();
+        var ids = new[] { Guid.NewGuid(), Guid.NewGuid() };
+        var provider = MakeProvider(userId, ev, Array.Empty<ShiftSignup>(), openTicketIds: ids);
+
+        var snapshot = await provider.LoadAsync(userId, CancellationToken.None);
+
+        snapshot.OpenTicketIds.Should().BeEquivalentTo(ids);
+    }
+
+    [HumansFact]
+    public async Task LoadAsync_populates_team_memberships_with_role()
+    {
+        var userId = Guid.NewGuid();
+        var ev = MakeEventSettings();
+        var memberships = new[]
+        {
+            new TeamMembership("Build", TeamMemberRole.Coordinator),
+            new TeamMembership("Cantina", TeamMemberRole.Member)
+        };
+        var provider = MakeProvider(userId, ev, Array.Empty<ShiftSignup>(), teamMemberships: memberships);
+
+        var snapshot = await provider.LoadAsync(userId, CancellationToken.None);
+
+        snapshot.Teams.Should().BeEquivalentTo(memberships);
+    }
+
+    private static AgentUserSnapshotProvider MakeProvider(
+        Guid userId,
+        EventSettings? activeEvent,
+        IReadOnlyList<ShiftSignup> signups,
+        IReadOnlyList<Guid>? openTicketIds = null,
+        IReadOnlyList<TeamMembership>? teamMemberships = null)
+    {
+        var profiles = Substitute.For<IProfileService>();
+        var users = Substitute.For<IUserService>();
+        users.GetByIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(new User { Id = userId, DisplayName = "T", PreferredLanguage = "es" });
+        var roles = Substitute.For<IRoleAssignmentService>();
+        roles.GetActiveForUserAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<RoleAssignment>());
+
+        var teams = Substitute.For<ITeamService>();
+        teams.GetActiveTeamMembershipsForUserAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(teamMemberships ?? Array.Empty<TeamMembership>());
+
+        var consents = Substitute.For<IConsentService>();
+        consents.GetPendingDocumentNamesAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<string>());
+
+        var feedback = Substitute.For<IFeedbackService>();
+        feedback.GetOpenFeedbackIdsForUserAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<Guid>());
+
+        var tickets = Substitute.For<ITicketQueryService>();
+        tickets.GetOpenTicketIdsForUserAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(openTicketIds ?? Array.Empty<Guid>());
+
+        var shiftSignups = Substitute.For<IShiftSignupService>();
+        shiftSignups.GetByUserAsync(userId, activeEvent?.Id).Returns(signups);
+
+        var shiftMgmt = Substitute.For<IShiftManagementService>();
+        shiftMgmt.GetActiveAsync().Returns(activeEvent);
+
+        var clock = new FakeClock(Instant.FromUtc(2026, 6, 1, 0, 0));
+
+        return new AgentUserSnapshotProvider(
+            profiles, users, roles, teams, consents, feedback, tickets,
+            shiftSignups, shiftMgmt, clock);
+    }
+
+    private static EventSettings MakeEventSettings() => new()
+    {
+        Id = Guid.NewGuid(),
+        EventName = "Nowhere 2026",
+        Year = 2026,
+        TimeZoneId = "Europe/Madrid",
+        GateOpeningDate = new LocalDate(2026, 7, 1),
+        BuildStartOffset = -14,
+        EventEndOffset = 6,
+        StrikeEndOffset = 9,
+        IsActive = true
+    };
+
+    private static Shift MakeShift(
+        Rota rota, int dayOffset, bool isAllDay,
+        LocalTime? startTime = null, double durationHours = 0) => new()
+        {
+            Id = Guid.NewGuid(),
+            RotaId = rota.Id,
+            Rota = rota,
+            DayOffset = dayOffset,
+            IsAllDay = isAllDay,
+            StartTime = startTime ?? new LocalTime(8, 0),
+            Duration = Duration.FromHours(durationHours),
+            MinVolunteers = 1,
+            MaxVolunteers = 5
+        };
+
+    private static ShiftSignup MakeSignup(
+        Guid userId, Guid? signupBlockId, Shift shift, SignupStatus status) => new()
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            ShiftId = shift.Id,
+            Shift = shift,
+            SignupBlockId = signupBlockId,
+            Status = status
+        };
+}

--- a/tests/Humans.Application.Tests/Architecture/InterfaceMethodBudgetTests.cs
+++ b/tests/Humans.Application.Tests/Architecture/InterfaceMethodBudgetTests.cs
@@ -50,11 +50,12 @@ public class InterfaceMethodBudgetTests
         // from ITeamService (moved to IUserMerge.ReassignAsync, implemented
         // by TeamService and dispatched by AccountMergeService via
         // IEnumerable<IUserMerge> fan-out).
-        // 70→71: issue-634 — added GetActiveTeamMembershipsForUserAsync so the
-        // agent snapshot can render team name + role-in-team without loading
-        // full TeamMember graphs. Could not reuse GetActiveTeamNamesForUserAsync
-        // because it discards roles.
-        [typeof(ITeamService)] = 71,
+        // 70→70: issue-634 — added GetActiveTeamMembershipsForUserAsync (name +
+        // role-in-team for the agent snapshot) and removed
+        // GetActiveTeamNamesForUserAsync, since the new method is strictly more
+        // capable; the one production caller (ProfileController popover)
+        // projects to names via .Select(m => m.TeamName).
+        [typeof(ITeamService)] = 70,
         // ICampService raised 53→57 for per-camp roles feature (peterdrier#489):
         // AddCampMemberAsLeadAsync, GetSeasonMembersAsync, GetCampMemberStatusAsync,
         // GetCampSeasonsForComplianceAsync — all needed by ICampRoleService and the

--- a/tests/Humans.Application.Tests/Architecture/InterfaceMethodBudgetTests.cs
+++ b/tests/Humans.Application.Tests/Architecture/InterfaceMethodBudgetTests.cs
@@ -50,7 +50,11 @@ public class InterfaceMethodBudgetTests
         // from ITeamService (moved to IUserMerge.ReassignAsync, implemented
         // by TeamService and dispatched by AccountMergeService via
         // IEnumerable<IUserMerge> fan-out).
-        [typeof(ITeamService)] = 70,
+        // 70→71: issue-634 — added GetActiveTeamMembershipsForUserAsync so the
+        // agent snapshot can render team name + role-in-team without loading
+        // full TeamMember graphs. Could not reuse GetActiveTeamNamesForUserAsync
+        // because it discards roles.
+        [typeof(ITeamService)] = 71,
         // ICampService raised 53→57 for per-camp roles feature (peterdrier#489):
         // AddCampMemberAsLeadAsync, GetSeasonMembersAsync, GetCampMemberStatusAsync,
         // GetCampSeasonsForComplianceAsync — all needed by ICampRoleService and the

--- a/tests/Humans.Application.Tests/Services/ShiftDashboardMetricsTests.cs
+++ b/tests/Humans.Application.Tests/Services/ShiftDashboardMetricsTests.cs
@@ -1109,7 +1109,6 @@ public class ShiftDashboardMetricsTests : IDisposable
         public Task<int> HardDeleteSeededTeamsAsync(string nameSuffix, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public void RemoveMemberFromAllTeamsCache(Guid userId) => throw new NotSupportedException();
         public void InvalidateActiveTeamsCache() => throw new NotSupportedException();
-        public Task<IReadOnlyList<string>> GetActiveTeamNamesForUserAsync(Guid userId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<IReadOnlyList<Humans.Application.Models.TeamMembership>> GetActiveTeamMembershipsForUserAsync(Guid userId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task EnqueueGoogleResyncForUserTeamsAsync(Guid userId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<int> RevokeAllMembershipsAsync(Guid userId, CancellationToken cancellationToken = default) => throw new NotSupportedException();

--- a/tests/Humans.Application.Tests/Services/ShiftDashboardMetricsTests.cs
+++ b/tests/Humans.Application.Tests/Services/ShiftDashboardMetricsTests.cs
@@ -955,6 +955,7 @@ public class ShiftDashboardMetricsTests : IDisposable
         public Task<List<Humans.Application.DTOs.OrderExportRow>> GetOrderExportDataAsync() => throw new NotSupportedException();
         public Task<bool> HasTicketAttendeeMatchAsync(Guid userId) => throw new NotSupportedException();
         public Task<List<UserTicketOrderSummary>> GetUserTicketOrderSummariesAsync(Guid userId) => throw new NotSupportedException();
+        public Task<IReadOnlyList<Guid>> GetOpenTicketIdsForUserAsync(Guid userId, CancellationToken ct = default) => throw new NotSupportedException();
         public Task<bool> HasCurrentEventTicketAsync(Guid userId, CancellationToken ct = default) => throw new NotSupportedException();
         public Task<UserTicketExportData> GetUserTicketExportDataAsync(Guid userId, CancellationToken ct = default) => throw new NotSupportedException();
         public Task<Instant?> GetPostEventHoldDateAsync(CancellationToken ct = default) => throw new NotSupportedException();
@@ -1109,6 +1110,7 @@ public class ShiftDashboardMetricsTests : IDisposable
         public void RemoveMemberFromAllTeamsCache(Guid userId) => throw new NotSupportedException();
         public void InvalidateActiveTeamsCache() => throw new NotSupportedException();
         public Task<IReadOnlyList<string>> GetActiveTeamNamesForUserAsync(Guid userId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<IReadOnlyList<Humans.Application.Models.TeamMembership>> GetActiveTeamMembershipsForUserAsync(Guid userId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task EnqueueGoogleResyncForUserTeamsAsync(Guid userId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<int> RevokeAllMembershipsAsync(Guid userId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task ReassignToUserAsync(Guid sourceUserId, Guid targetUserId, Guid actorUserId, Instant updatedAt, CancellationToken cancellationToken = default) => throw new NotSupportedException();


### PR DESCRIPTION
## Summary

Brings the agent's per-turn user-context tail in line with what volunteers actually do — work shifts, own tickets, and have roles on multiple teams — and adds a focused tool the agent can call to drill into one of those shifts.

- **OpenTicketIds plumbed.** New `ITicketQueryService.GetOpenTicketIdsForUserAsync` (backed by `ITicketRepository.GetOpenOrderIdsMatchedToUserAsync`) returns matched Paid/Pending order ids; the agent snapshot now reflects the real count instead of the placeholder zero.
- **Team membership carries role.** `AgentUserSnapshot.Teams` is now `IReadOnlyList<TeamMembership>` (team name + `TeamMemberRole`), populated by a new `ITeamService.GetActiveTeamMembershipsForUserAsync` reading the existing `CachedTeam.Members` cache. The tail renders each as `  - Build (Coordinator)`.
- **UpcomingShifts summary in the tail.** `AgentUserSnapshotProvider.LoadUpcomingShiftsAsync` calls `IShiftSignupService.GetByUserAsync` for the active event, filters to upcoming via `Shift.GetAbsoluteEnd > now`, groups non-null `SignupBlockId` rows into one entry each, and passes singletons through unchanged. The assembler renders entries sorted by start date, capped at 10 with `+N more` overflow, and omits the section entirely when empty.
- **`get_shift_details` tool.** New tool registered in `AgentPromptAssembler.BuildToolDefinitions` and dispatched in `AgentToolDispatcher`. Resolves the supplied id as a `SignupBlockId` first, then as a singleton `ShiftSignup.Id`, and only ever reads the calling user's signups — anything else returns `Shift not found`.
- **System prompt updated** to instruct the agent to call `get_shift_details(shiftId=<key>)` for shift-specific questions rather than answering from the tail alone.

## Acceptance criteria

- [x] `OpenTicketIds` populated with matched Paid/Pending orders
- [x] `Teams` carries name + role; tail renders both
- [x] `UpcomingShifts` populated, grouped by `SignupBlockId`
- [x] 7-day block renders as one entry with `DayCount = 7`
- [x] Singleton renders as one entry with `StartDate == EndDate`
- [x] Tail sorts entries ascending, caps at 10, appends `+N more`
- [x] Empty list omits the section header entirely
- [x] `get_shift_details` registered + dispatched
- [x] Block id returns rota name, dates, day count, status, description
- [x] Singleton id returns single date and the same shape
- [x] Foreign id returns `Shift not found`
- [x] System prompt instructs agent to use `get_shift_details`
- [x] Unit tests: block-conflation, singleton, sort + cap, ticket count, role-per-team, dispatch happy path + unauthorized id

## Test plan

- [x] `dotnet build Humans.slnx -v quiet` — clean
- [x] `dotnet test Humans.Application.Tests` — 2279/2279 pass (integration tests' 5s timeout flakiness exists on origin/main, unrelated)
- [x] `dotnet format Humans.slnx --verify-no-changes` — clean
- [ ] Smoke: open agent chat, ask "what shifts do I have?" — expect conflated list
- [ ] Smoke: ask "tell me about my July 1–7 shift" — expect agent to call `get_shift_details`

## Out of scope

- Capturing a structured location field on `Rota` if `PracticalInfo` is not enough.
- Past-shift history (covered by `get_audit_history` from issue-629).
- Modifying shifts via the agent — read-only here.

Closes #634