### PR TITLE
EmailProblems: render user names as <human-link>

### DIFF
--- a/src/Humans.Web/Views/ProfileAdmin/EmailProblems.cshtml
+++ b/src/Humans.Web/Views/ProfileAdmin/EmailProblems.cshtml
@@ -26,8 +26,8 @@ else
             {
                 <tr>
                     <td><code>@row.Email</code></td>
-                    <td>@row.User1DisplayName</td>
-                    <td>@row.User2DisplayName</td>
+                    <td><human-link user-id="@row.User1Id" display-name="@row.User1DisplayName" admin /></td>
+                    <td><human-link user-id="@row.User2Id" display-name="@row.User2DisplayName" admin /></td>
                     <td>
                         <a class="btn btn-sm btn-primary"
                            asp-action="EmailProblemsCompare"
@@ -53,7 +53,7 @@ else
             @foreach (var row in Model.SingleUserIssues)
             {
                 <tr>
-                    <td>@row.DisplayName</td>
+                    <td><human-link user-id="@row.UserId" display-name="@row.DisplayName" admin /></td>
                     <td>@string.Join(", ", row.ProblemSummaries)</td>
                     <td>
                         <a class="btn btn-sm btn-secondary"
@@ -90,7 +90,7 @@ else
             @foreach (var row in Model.LegacyEmailRows)
             {
                 <tr>
-                    <td>@row.DisplayName</td>
+                    <td><human-link user-id="@row.UserId" display-name="@row.DisplayName" admin /></td>
                     <td><code>@row.LegacyEmail</code></td>
                 </tr>
             }


### PR DESCRIPTION
## Summary
- Swap the four raw `@displayName` renders on `/Profile/Admin/EmailProblems` (cross-user conflicts × 2, single-user issues, legacy-email rows) to the `<human-link>` tag helper in `admin` mode.
- Each row already carried `UserId`, so this is purely a view-template change — no view-model or service touched.

## Test plan
- [ ] Open `/Profile/Admin/EmailProblems` on the preview env
- [ ] Verify cross-user rows show two clickable name links → admin profile
- [ ] Verify single-user and legacy-email rows show clickable names → admin profile
- [ ] Hover popover renders for each