### PR TITLE
issue-689: EmailProblems Case 9 — fix false-positives for Profile-less users

### DIFF
--- a/src/Humans.Application/Services/Profile/EmailProblemsService.cs
+++ b/src/Humans.Application/Services/Profile/EmailProblemsService.cs
@@ -1,6 +1,7 @@
 using Humans.Application.DTOs.EmailProblems;
 using Humans.Application.Interfaces.Profiles;
 using Humans.Application.Interfaces.Users;
+using Humans.Domain.Entities;
 using Humans.Domain.Helpers;
 using NodaTime;
 
@@ -114,18 +115,22 @@ public sealed class EmailProblemsService : IEmailProblemsService
         }
 
         // Case 9: legacy AspNetIdentity Email column populated but no matching
-        // verified UserEmail row exists. Pre-decoupling users whose row was
-        // never written when the spec switched. Detect via the raw column
-        // (IdentityEmailColumn) so the User.Email override's UserEmails-based
-        // resolution doesn't mask it.
+        // verified UserEmail row exists. Read user_emails directly by UserId —
+        // Profile-less users (mailing-list / ticketing imports) have a valid
+        // UserEmail row but no Profile aggregate, so the FullProfile path
+        // would false-positive them.
+        var emailsByUser = await _userEmailService.GetEntitiesByUserIdsAsync(
+            users.Select(u => u.Id).ToList(), ct);
+
         foreach (var u in users)
         {
             var legacy = u.IdentityEmailColumn;
             if (string.IsNullOrEmpty(legacy)) continue;
 
-            var profile = profiles.FirstOrDefault(p => p.UserId == u.Id);
-            var emails = profile?.AllUserEmails ?? Array.Empty<UserEmailSnapshot>();
-            var hasMatchingVerifiedRow = emails.Any(e =>
+            var userEmails = emailsByUser.TryGetValue(u.Id, out var list)
+                ? list
+                : (IReadOnlyList<UserEmail>)Array.Empty<UserEmail>();
+            var hasMatchingVerifiedRow = userEmails.Any(e =>
                 e.IsVerified && string.Equals(e.Email, legacy, StringComparison.OrdinalIgnoreCase));
             if (hasMatchingVerifiedRow) continue;
 
@@ -162,6 +167,9 @@ public sealed class EmailProblemsService : IEmailProblemsService
         CancellationToken ct = default)
     {
         var users = await _userService.GetAllUsersAsync(ct);
+        var emailsByUser = await _userEmailService.GetEntitiesByUserIdsAsync(
+            users.Select(u => u.Id).ToList(), ct);
+
         var backfilled = new List<(Guid, string)>();
 
         foreach (var u in users)
@@ -169,9 +177,10 @@ public sealed class EmailProblemsService : IEmailProblemsService
             var legacy = u.IdentityEmailColumn;
             if (string.IsNullOrEmpty(legacy)) continue;
 
-            var profile = await _profileService.GetFullProfileAsync(u.Id, ct);
-            var emails = profile?.AllUserEmails ?? Array.Empty<UserEmailSnapshot>();
-            if (emails.Any(e => e.IsVerified
+            var userEmails = emailsByUser.TryGetValue(u.Id, out var list)
+                ? list
+                : (IReadOnlyList<UserEmail>)Array.Empty<UserEmail>();
+            if (userEmails.Any(e => e.IsVerified
                 && string.Equals(e.Email, legacy, StringComparison.OrdinalIgnoreCase)))
                 continue;
 

--- a/tests/Humans.Application.Tests/Services/EmailProblemsServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/EmailProblemsServiceTests.cs
@@ -16,8 +16,25 @@ public class EmailProblemsServiceTests
     private readonly IUserService _userService = Substitute.For<IUserService>();
     private readonly FakeClock _clock = new(NodaTime.Instant.FromUtc(2026, 5, 5, 12, 0));
 
+    public EmailProblemsServiceTests()
+    {
+        _userEmailService.GetEntitiesByUserIdsAsync(
+                Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<Guid, IReadOnlyList<UserEmail>>());
+    }
+
     private EmailProblemsService Sut => new(
         _profileService, _userEmailService, _userService, _clock);
+
+    private void SetAllUserEmails(params UserEmail[] emails)
+    {
+        var grouped = emails
+            .GroupBy(e => e.UserId)
+            .ToDictionary(g => g.Key, g => (IReadOnlyList<UserEmail>)g.ToList());
+        _userEmailService.GetEntitiesByUserIdsAsync(
+                Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(grouped);
+    }
 
     private static FullProfile MakeProfile(Guid userId, params UserEmailSnapshot[] emails) =>
         new FullProfile(
@@ -304,11 +321,25 @@ public class EmailProblemsServiceTests
     {
         var users = pairs.Select(p => p.User).ToList();
         _userService.GetAllUsersAsync(Arg.Any<CancellationToken>()).Returns(users);
+        var grouped = new Dictionary<Guid, IReadOnlyList<UserEmail>>();
         foreach (var (u, profile) in pairs)
         {
             _profileService.GetFullProfileAsync(u.Id, Arg.Any<CancellationToken>())
                 .Returns(new ValueTask<FullProfile?>(profile));
+            var rows = profile.AllUserEmails.Select(s => new UserEmail
+            {
+                Id = s.Id,
+                UserId = u.Id,
+                Email = s.Email,
+                IsVerified = s.IsVerified,
+                IsPrimary = s.IsPrimary,
+                IsGoogle = s.IsGoogle
+            }).ToList();
+            if (rows.Count > 0) grouped[u.Id] = rows;
         }
+        _userEmailService.GetEntitiesByUserIdsAsync(
+                Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(grouped);
     }
 
     private static User MakeUser(Guid id, string? legacyEmail) =>
@@ -420,5 +451,75 @@ public class EmailProblemsServiceTests
         var result = await Sut.BackfillLegacyIdentityEmailsAsync();
 
         result.Should().BeEmpty();
+    }
+
+    [HumansFact]
+    public async Task DoesNotFlagLegacyEmail_WhenProfileLessUserHasMatchingVerifiedRow()
+    {
+        var userId = Guid.NewGuid();
+        var user = MakeUser(userId, "import@x.com");
+        _userService.GetAllUsersAsync(Arg.Any<CancellationToken>())
+            .Returns(new List<User> { user });
+        _profileService.GetFullProfileAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<FullProfile?>((FullProfile?)null));
+        SetAllUserEmails(new UserEmail
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            Email = "import@x.com",
+            IsVerified = true
+        });
+        SetOrphans();
+        SetGhosts();
+
+        var report = await Sut.ScanAsync();
+
+        report.Problems.Should().NotContain(p =>
+            p.Kind == EmailProblemKind.LegacyIdentityEmailNotInUserEmails);
+    }
+
+    [HumansFact]
+    public async Task DetectsLegacyEmail_WhenProfileLessUserHasNoMatchingRow()
+    {
+        var userId = Guid.NewGuid();
+        var user = MakeUser(userId, "legacy@x.com");
+        _userService.GetAllUsersAsync(Arg.Any<CancellationToken>())
+            .Returns(new List<User> { user });
+        _profileService.GetFullProfileAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<FullProfile?>((FullProfile?)null));
+        SetAllUserEmails();
+        SetOrphans();
+        SetGhosts();
+
+        var report = await Sut.ScanAsync();
+
+        report.Problems.Should().ContainSingle(p =>
+            p.Kind == EmailProblemKind.LegacyIdentityEmailNotInUserEmails
+            && p.UserId == userId
+            && p.Email == "legacy@x.com");
+    }
+
+    [HumansFact]
+    public async Task BackfillLegacyIdentityEmails_ProfileLessUserAlreadyMatched_SkipsUser()
+    {
+        var userId = Guid.NewGuid();
+        var user = MakeUser(userId, "import@x.com");
+        _userService.GetAllUsersAsync(Arg.Any<CancellationToken>())
+            .Returns(new List<User> { user });
+        _profileService.GetFullProfileAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<FullProfile?>((FullProfile?)null));
+        SetAllUserEmails(new UserEmail
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            Email = "import@x.com",
+            IsVerified = true
+        });
+
+        var result = await Sut.BackfillLegacyIdentityEmailsAsync();
+
+        result.Should().BeEmpty();
+        await _userEmailService.DidNotReceive().AddVerifiedEmailAsync(
+            Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 }


### PR DESCRIPTION
Fixes nobodies-collective/Humans#689.

## Summary

- Case 9 ("Legacy `User.Email` column not in `user_emails`") and `BackfillLegacyIdentityEmailsAsync` were reading `UserEmail` rows through `IProfileService.GetFullProfileAsync`, which short-circuits to `null` for users without a `Profile` (mailing-list / ticketing imports). They then fell back to an empty array and flagged users whose verified `UserEmail` row already matched their legacy `AspNetUsers.Email`.
- Switch both paths to `IUserEmailService.GetEntitiesByUserIdsAsync`, the existing section-service surface for cross-section bulk reads. Stays inside the `EmailProblemsService` architectural boundary (no new repository dependency — the architecture test still passes).
- Added Profile-less coverage for scan (matched + unmatched) and backfill (already-matched).

## Test plan

- [x] `dotnet build Humans.slnx -v quiet`
- [x] `dotnet test tests/Humans.Application.Tests -v quiet` — 2290/2290 pass, including `EmailProblemsService_DependsOnlyOnSectionServices_NotRepositories` and the new Profile-less cases
- [ ] QA: visit `/Profile/Admin/EmailProblems`, confirm Case 9 list no longer contains Profile-less imports whose verified `UserEmail` already matches `User.Email`

🤖 Generated with [Claude Code](https://claude.com/claude-code)