### PR TITLE
Document interface consolidation tech debt rules

### DIFF
--- a/.codex/skills/humans-tech-debt/references/humans-tech-debt-rules.md
+++ b/.codex/skills/humans-tech-debt/references/humans-tech-debt-rules.md
@@ -87,6 +87,37 @@ Sections must not reach across each other's persistence:
 
 Prefer typed foreign-key queries and narrow projections over navigation-property graph loading. A slower but explicit service call boundary is better than a hidden cross-section join.
 
+## Interface Consolidation Rules
+
+Large interfaces should not grow one convenience method per caller. Prefer smaller, composable contracts.
+
+Bad pattern:
+
+- `GetActiveProfilesAsync()`
+- `GetSuspendedProfilesAsync()`
+- `GetProfilesForDashboardAsync()`
+- `GetRecentOrdersAsync()`
+- `GetTopTicketsAsync()`
+
+Better pattern, when the result set is safe to materialize and the shaping is screen-specific:
+
+- `GetProfilesAsync()` plus caller-side `.Where(p => p.IsActive)`
+- `GetProfilesAsync()` plus caller-side `.Where(p => p.IsSuspended)`
+- `GetProfilesAsync()` plus controller/view `.OrderBy(...).Take(20)`
+
+Start interface-consolidation passes with the largest interfaces and work down by method count. This gives the best payoff and catches the contracts most likely to accumulate AI-generated helper methods.
+
+Fixing strategy:
+
+- Rank `src/Humans.Application/Interfaces/**/*.cs` interfaces by public method count.
+- Inspect the largest interfaces first.
+- Find method families that differ only by status, filter, sort, window, dashboard, or screen.
+- Collapse them into one broader section-owned method when behavior remains clear and result size is safe.
+- Move screen-specific `.Where(...)`, `.OrderBy(...)`, `.Take(...)`, grouping, and dashboard shaping to controllers/views.
+- Update callers and tests in the same commit.
+
+Do not collapse methods that represent real domain concepts, authorization boundaries, operational queue semantics, expensive server-side queries that cannot safely materialize, or intentionally bounded search/tool APIs.
+
 ## Safety Checks
 
 - Verify every change preserves behavior except for the intended simplification.

--- a/.codex/tech-debt-prompt.md
+++ b/.codex/tech-debt-prompt.md
@@ -150,6 +150,47 @@ Do not mechanically remove every match. For each candidate, identify the owning 
 
 ---
 
+## Phase 0b: Interface Consolidation
+
+Run this after the cross-section DB-boundary pass, or in parallel only when it does not conflict with boundary work.
+
+**Problem:** AI-assisted refactors often grow interfaces by adding convenience methods for each caller:
+- `GetActiveProfilesAsync`
+- `GetSuspendedProfilesAsync`
+- `GetProfilesForDashboardAsync`
+- `GetRecentOrdersAsync`
+- `GetTopTicketsAsync`
+
+These methods feel easy locally, but they bloat service/repository contracts and encode presentation-specific filters, sorting, paging, and row limits into shared interfaces.
+
+**Fix:** Prefer fewer, more composable section-owned methods when the caller can safely shape the result:
+- `GetProfilesAsync()` plus `.Where(p => p.IsActive)`
+- `GetProfilesAsync()` plus `.Where(p => p.IsSuspended)`
+- `GetProfilesAsync()` plus controller/view `.OrderBy(...).Take(20)` for a dashboard
+
+Do not collapse methods that represent real domain/application concepts, authorization boundaries, expensive server-side queries that cannot be materialized safely, operational queue semantics, or intentionally bounded search/tool APIs.
+
+### Interface Consolidation Search Plan
+
+Start with the largest interfaces and work down by method count. This gives the best payoff and prevents the broadest contracts from growing unchecked.
+
+Suggested approach:
+- List `src/Humans.Application/Interfaces/**/*.cs` interfaces by public method count.
+- Inspect the largest interfaces first.
+- Look for method families that differ only by status/filter/sort/window/screen.
+- Replace them with one broader method plus caller-side LINQ when the result set is safely bounded and already section-owned.
+- Move screen-specific `.Where(...)`, `.OrderBy(...)`, `.Take(...)`, grouping, and dashboard shaping to controllers/views.
+- Keep reusable domain filtering in the owning service only when it has domain meaning beyond one screen.
+- Update all callers and tests in the same commit.
+
+Useful commands:
+- `rg -n "Task<|ValueTask<|IAsyncEnumerable<|IReadOnly|IEnumerable<|\\w+Async\\(" src/Humans.Application/Interfaces`
+- `rg --files src/Humans.Application/Interfaces | % { $p=$_; $c=(rg -n "\\w+Async\\(" $p | Measure-Object).Count; [pscustomobject]@{ Count=$c; Path=$p } } | Sort-Object Count -Descending`
+
+Commit each interface-consolidation slice separately. Do not combine broad interface churn with unrelated repository or section-boundary fixes.
+
+---
+
 ## Phase 1: Controller Pattern Consolidation
 
 ### Extract Repeated Controller Patterns


### PR DESCRIPTION
## Summary
- Add Phase 0b interface-consolidation guidance to the tech-debt prompt
- Add matching humans-tech-debt skill rules for ranking interfaces by method count and consolidating convenience Get* methods
- Preserve the existing layer-boundary wording from main

## Testing
- `git diff --check`