### PR TITLE
hotfix: wire TicketTransfer interfaces into service-boundary ratchet

### DIFF
--- a/src/Humans.Application/Interfaces/Repositories/ITicketTransferRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/ITicketTransferRepository.cs
@@ -3,7 +3,7 @@ using Humans.Domain.Enums;
 
 namespace Humans.Application.Interfaces.Repositories;
 
-public interface ITicketTransferRepository
+public interface ITicketTransferRepository : IRepository
 {
     Task<TicketTransferRequest?> GetByIdAsync(Guid id, CancellationToken ct = default);
 

--- a/src/Humans.Application/Interfaces/Tickets/ITicketTransferService.cs
+++ b/src/Humans.Application/Interfaces/Tickets/ITicketTransferService.cs
@@ -1,9 +1,10 @@
 using Humans.Application.DTOs;
+using Humans.Application.Interfaces;
 using Humans.Domain.Enums;
 
 namespace Humans.Application.Interfaces.Tickets;
 
-public interface ITicketTransferService
+public interface ITicketTransferService : IApplicationService
 {
     /// <summary>
     /// Resolve Receiver candidates for a free-text query. Email queries

--- a/tests/Humans.Application.Tests/Architecture/Baselines/CrossSectionRepositoryInjection.baseline.txt
+++ b/tests/Humans.Application.Tests/Architecture/Baselines/CrossSectionRepositoryInjection.baseline.txt
@@ -2,6 +2,5 @@
 # New cross-section data access must go through the owning service boundary.
 Humans.Application.Services.Profile.DuplicateAccountService:IUserRepository
 Humans.Application.Services.GoogleIntegration.GoogleWorkspaceSyncService:IGoogleResourceRepository
-Humans.Application.Services.Users.AccountProvisioningService:IUserEmailRepository
 Humans.Application.Services.Users.UserEmailProviderBackfillService:IUserEmailRepository
 Humans.Application.Services.Users.UserService:IUserEmailRepository

--- a/tests/Humans.Application.Tests/Architecture/ServiceBoundaryArchitectureTests.cs
+++ b/tests/Humans.Application.Tests/Architecture/ServiceBoundaryArchitectureTests.cs
@@ -49,6 +49,7 @@ public class ServiceBoundaryArchitectureTests
             [typeof(ITeamRepository)] = "Teams",
             [typeof(ITicketingBudgetRepository)] = "Tickets",
             [typeof(ITicketRepository)] = "Tickets",
+            [typeof(ITicketTransferRepository)] = "Tickets",
             [typeof(IUserEmailRepository)] = "Profiles",
             [typeof(IUserRepository)] = "Users",
         };


### PR DESCRIPTION
## Summary

- `main` has been red on **Build and Test** since [`a47ff121`](https://github.com/peterdrier/Humans/commit/a47ff121) (PR #475, "Add service entity boundary ratchet"). The ratchet shipped without picking up the TicketTransfer surface that PR #472 introduced.
- This PR wires the TicketTransfer interfaces into the ratchet model: marker interfaces on the service + repository, and the repository's owning section.
- Also shrinks the cross-section-injection baseline by one entry that the ratchet now sees as no longer a violation (it demands stale entries be removed).

## Changes

- `ITicketTransferService : IApplicationService`
- `ITicketTransferRepository : IRepository`
- `RepositoryOwners` in `ServiceBoundaryArchitectureTests.cs` gains `[typeof(ITicketTransferRepository)] = "Tickets"`. With the entry in place, `TicketSyncService` and `TicketTransferService` injecting `ITicketTransferRepository` register as intra-section, not cross-section.
- `CrossSectionRepositoryInjection.baseline.txt` drops `Humans.Application.Services.Users.AccountProvisioningService:IUserEmailRepository`. The ratchet detected this as a "fixed" violation and refused to pass until the baseline shrinks to match.

## Test plan

- [x] `dotnet test tests/Humans.Application.Tests --filter "FullyQualifiedName~ServiceBoundaryArchitectureTests"` — all 6 tests pass.
- [x] `dotnet build Humans.slnx -v quiet` — clean.
- [x] `dotnet test Humans.slnx --no-build` (Application 2362, Domain 144, Web 24, no failures). Integration tests not run locally; CI covers them.

## Why this is a separate PR

Sister PR #470 (docs/feature-folder-reorg) also carries the marker fixes on its branch because it inherited the same red CI state via the GitHub PR-merge ref. Doing the map + baseline fix in #470 would require merging origin/main into a docs-reorg PR plus pulling in unrelated PRs (#465, #475, #476). This hotfix targets `main` directly so every open PR inherits the green state when it merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
