### PR TITLE
Admin: add verified user_emails row directly (recovery path)

### DIFF
--- a/src/Humans.Application/Interfaces/Profiles/IUserEmailService.cs
+++ b/src/Humans.Application/Interfaces/Profiles/IUserEmailService.cs
@@ -119,9 +119,10 @@ public interface IUserEmailService : IApplicationService
     /// <summary>
     /// Adds a verified email directly (admin provisioning/linking — no verification flow needed).
     /// If the email is @nobodies.team, it's automatically set as the notification target.
-    /// Skips if the email already exists for this user.
+    /// Idempotent: if the email already exists for this user, skips the insert
+    /// and returns <c>false</c>. Returns <c>true</c> when a row was actually inserted.
     /// </summary>
-    Task AddVerifiedEmailAsync(
+    Task<bool> AddVerifiedEmailAsync(
         Guid userId,
         string email,
         CancellationToken cancellationToken = default);

--- a/src/Humans.Application/Services/Profile/UserEmailService.cs
+++ b/src/Humans.Application/Services/Profile/UserEmailService.cs
@@ -406,14 +406,14 @@ public sealed class UserEmailService : IUserEmailService, IUserMerge
             mergedFromUserId, mergedToUserId, now, ct);
     }
 
-    public async Task AddVerifiedEmailAsync(
+    public async Task<bool> AddVerifiedEmailAsync(
         Guid userId, string email, CancellationToken cancellationToken = default)
     {
         var normalizedEmail = EmailNormalization.NormalizeForComparison(email);
         var alternateEmail = GetAlternateComparableEmail(normalizedEmail);
 
         if (await _repository.ExistsForUserAsync(userId, normalizedEmail, alternateEmail, cancellationToken))
-            return;
+            return false;
 
         var now = _clock.GetCurrentInstant();
 
@@ -436,6 +436,7 @@ public sealed class UserEmailService : IUserEmailService, IUserMerge
         // so the @nobodies.team row wins automatically without a separate
         // _userService.TrySetGoogleEmailAsync write.
         await AddRowWithInvariantsAsync(userEmail, cancellationToken);
+        return true;
     }
 
     [Obsolete("Issue nobodies-collective/Humans#687: User.GoogleEmail is being deprecated. UserEmailService.EnsureGoogleInvariantAsync now stamps IsGoogle on the canonical row whenever a UserEmail is added; no separate backfill is needed. Method body is now a no-op.")]

--- a/src/Humans.Web/Controllers/ProfileController.cs
+++ b/src/Humans.Web/Controllers/ProfileController.cs
@@ -1307,6 +1307,53 @@ public class ProfileController : HumansControllerBase
         return RedirectToAction(nameof(AdminEmails), new { id });
     }
 
+    // Admin-only recovery path: directly insert an already-verified UserEmail
+    // row without sending a verification email. Use when an admin needs to
+    // restore a row that was deleted in error (or otherwise re-attach a known
+    // address to the user without a round-trip to their mailbox).
+    [HttpPost("{id:guid}/Admin/Emails/AddVerified")]
+    [Authorize(Policy = PolicyNames.AdminOnly)]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> AdminAddVerifiedEmail(Guid id, string email, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(email))
+        {
+            SetError(_localizer["Profile_EnterEmail"].Value);
+            return RedirectToAction(nameof(AdminEmails), new { id });
+        }
+
+        var actor = await GetCurrentUserAsync();
+        if (actor is null)
+            return Forbid();
+
+        var targetUser = await FindUserByIdAsync(id);
+        if (targetUser is null)
+            return NotFound();
+
+        try
+        {
+            await _userEmailService.AddVerifiedEmailAsync(id, email.Trim(), ct);
+            _cache.InvalidateNobodiesTeamEmails();
+
+            await _auditLogService.LogAsync(
+                AuditAction.UserEmailAdded,
+                nameof(User), id,
+                $"Admin added pre-verified email {email.Trim()} for user {id} (no verification flow)",
+                actor.Id);
+
+            SetSuccess($"Verified email {email.Trim()} added.");
+        }
+        catch (Exception ex) when (ex is ValidationException or InvalidOperationException)
+        {
+            _logger.LogWarning(
+                "Admin failed to add verified email for user {UserId} ({Email}): {Reason}",
+                id, email, ex.Message);
+            SetError(ex.Message);
+        }
+
+        return RedirectToAction(nameof(AdminEmails), new { id });
+    }
+
     [HttpPost("{id:guid}/Admin/Emails/Verify")]
     [Authorize(Policy = PolicyNames.AdminOnly)]
     [ValidateAntiForgeryToken]

--- a/src/Humans.Web/Controllers/ProfileController.cs
+++ b/src/Humans.Web/Controllers/ProfileController.cs
@@ -1332,16 +1332,23 @@ public class ProfileController : HumansControllerBase
 
         try
         {
-            await _userEmailService.AddVerifiedEmailAsync(id, email.Trim(), ct);
-            _cache.InvalidateNobodiesTeamEmails();
+            var inserted = await _userEmailService.AddVerifiedEmailAsync(id, email.Trim(), ct);
+            if (inserted)
+            {
+                _cache.InvalidateNobodiesTeamEmails();
 
-            await _auditLogService.LogAsync(
-                AuditAction.UserEmailAdded,
-                nameof(User), id,
-                $"Admin added pre-verified email {email.Trim()} for user {id} (no verification flow)",
-                actor.Id);
+                await _auditLogService.LogAsync(
+                    AuditAction.UserEmailAdded,
+                    nameof(User), id,
+                    $"Admin added pre-verified email {email.Trim()} for user {id} (no verification flow)",
+                    actor.Id);
 
-            SetSuccess($"Verified email {email.Trim()} added.");
+                SetSuccess($"Verified email {email.Trim()} added.");
+            }
+            else
+            {
+                SetInfo($"Email {email.Trim()} already exists on this user — no change.");
+            }
         }
         catch (Exception ex) when (ex is ValidationException or InvalidOperationException)
         {

--- a/src/Humans.Web/Views/Profile/Emails.cshtml
+++ b/src/Humans.Web/Views/Profile/Emails.cshtml
@@ -347,10 +347,10 @@
         @* self-heal on next OAuth sign-in via ReconcileOAuthIdentityAsync.   *@
         @if (Model.IsAdminContext)
         {
-            <div class="card mb-4" id="external-logins">
-                <div class="card-header">
-                    <h5 class="mb-0">AspNetUserLogins</h5>
-                    <small class="text-muted">Authoritative store for OAuth identity. The <code>UserEmail</code> provider tag above is a per-row pointer; this is the truth.</small>
+            <div class="card mb-4 border-danger" id="external-logins">
+                <div class="card-header bg-danger text-white">
+                    <h5 class="mb-0"><i class="fa-solid fa-user-shield me-1"></i>AspNetUserLogins <small class="ms-2 opacity-75">(Admin only)</small></h5>
+                    <small class="text-white-50">Authoritative store for OAuth identity. The <code>UserEmail</code> provider tag above is a per-row pointer; this is the truth.</small>
                 </div>
                 <div class="card-body p-0">
                     @if (!Model.ExternalLogins.Any())
@@ -399,10 +399,10 @@
 
             @* Admin-only raw UserEmail dump — every column verbatim. *@
             @* Diagnostic surface; no formatting, no actions. *@
-            <div class="card mb-4" id="raw-user-emails">
-                <div class="card-header">
-                    <h5 class="mb-0">Raw <code>user_emails</code> rows</h5>
-                    <small class="text-muted">Every column verbatim. Admin diagnostic.</small>
+            <div class="card mb-4 border-danger" id="raw-user-emails">
+                <div class="card-header bg-danger text-white">
+                    <h5 class="mb-0"><i class="fa-solid fa-user-shield me-1"></i>Raw <code>user_emails</code> rows <small class="ms-2 opacity-75">(Admin only)</small></h5>
+                    <small class="text-white-50">Every column verbatim. Admin diagnostic.</small>
                 </div>
                 <div class="card-body p-0">
                     @if (!Model.RawUserEmails.Any())
@@ -451,6 +451,34 @@
                             </table>
                         </div>
                     }
+                </div>
+            </div>
+
+            @* Admin-only recovery: insert an already-verified UserEmail row    *@
+            @* directly, no verification email. Use when a row was deleted in   *@
+            @* error and the address is already known-good. Bypasses the legacy *@
+            @* "this is already your sign-in email" check that blocks the       *@
+            @* normal Add flow when User.Email still holds the address.         *@
+            <div class="card mb-4 border-danger" id="admin-add-verified">
+                <div class="card-header bg-danger text-white">
+                    <h5 class="mb-0"><i class="fa-solid fa-user-shield me-1"></i>Add verified email directly <small class="ms-2 opacity-75">(Admin only)</small></h5>
+                    <small class="text-white-50">Inserts a verified <code>user_emails</code> row with no verification flow. Use to restore a row deleted in error.</small>
+                </div>
+                <div class="card-body">
+                    <form asp-action="AdminAddVerifiedEmail"
+                          asp-route-id="@Model.TargetUserId"
+                          method="post"
+                          data-confirm="Insert a verified user_emails row for this address? No verification email will be sent.">
+                        @Html.AntiForgeryToken()
+                        <div class="mb-3">
+                            <label class="form-label" for="admin-add-verified-email-input">Email address</label>
+                            <input id="admin-add-verified-email-input" class="form-control" type="email" name="email"
+                                   placeholder="you@example.com" required />
+                        </div>
+                        <button type="submit" class="btn btn-danger">
+                            <i class="fa-solid fa-plus me-1"></i>Insert verified row
+                        </button>
+                    </form>
                 </div>
             </div>
         }

--- a/src/Humans.Web/Views/Profile/Emails.cshtml
+++ b/src/Humans.Web/Views/Profile/Emails.cshtml
@@ -196,6 +196,12 @@
                                             </button>
                                         </form>
                                     }
+                                    else if (workspaceLocked && row.IsVerified)
+                                    {
+                                        @* Verified, but another row holds the Workspace lock — *@
+                                        @* don't claim "verify first", which is a lie.          *@
+                                        <span class="text-muted small" title="Locked by the Workspace email row">—</span>
+                                    }
                                     else
                                     {
                                         <span class="text-muted small">@Localizer["Emails_VerifyFirst"]</span>
@@ -241,6 +247,10 @@
                                                 @Localizer["EmailGrid_SetGoogle"]
                                             </button>
                                         </form>
+                                    }
+                                    else if (workspaceLocked && row.IsVerified)
+                                    {
+                                        <span class="text-muted small" title="Locked by the Workspace email row">—</span>
                                     }
                                     else
                                     {


### PR DESCRIPTION
## Summary
- New admin-only `POST /Profile/{id}/Admin/Emails/AddVerified` inserts a pre-verified `user_emails` row via `IUserEmailService.AddVerifiedEmailAsync`, bypassing the verification round-trip and the legacy "already your sign-in email" guard on the normal Add flow.
- Surfaced as a new card below the raw `user_emails` diagnostic on the admin Emails page (`/Profile/{id}/Admin/Emails`).
- The three admin-only cards on that page (AspNetUserLogins, raw `user_emails`, the new add-verified card) now share a red header to signal their elevated scope.

## Why
Recovery path: if an admin deletes a `user_emails` row in error, the normal Add flow rejects re-adding the same address because the legacy `User.Email` column still holds it ("This is already your sign-in email"). `AddVerifiedEmailAsync` only checks `user_emails`, so this card restores the row directly. AdminOnly policy + audit log entry (`UserEmailAdded` with an explicit "pre-verified, no verification flow" description).

## Test plan
- [ ] Sign in as admin
- [ ] Navigate to `/Profile/{userId}/Admin/Emails` for a user whose `user_emails` row was deleted but whose `AspNetUsers.Email` still holds the address
- [ ] Use the new red "Add verified email directly" card to re-insert the row
- [ ] Confirm the row appears in the grid and raw dump as verified
- [ ] Confirm an audit log entry was written