### PR TITLE
Surface shift-tag preferences on Edit Profile page

### DIFF
--- a/src/Humans.Web/Controllers/ProfileController.cs
+++ b/src/Humans.Web/Controllers/ProfileController.cs
@@ -317,7 +317,11 @@ public class ProfileController : HumansControllerBase
         // Shift tag preferences — surfaced on Edit Profile so users can pick what
         // kinds of volunteer work they want without bouncing to /Shifts. Without
         // this surface the profile completion bar sticks at 95%.
-        var allShiftTags = await _shiftMgmt.GetTagsAsync();
+        // Sort at presentation layer (memory/architecture/display-sort-in-controllers.md);
+        // GetTagsAsync returns DB-insertion order.
+        var allShiftTags = (await _shiftMgmt.GetTagsAsync())
+            .OrderBy(t => t.Name, StringComparer.OrdinalIgnoreCase)
+            .ToList();
         var preferredShiftTags = await _shiftMgmt.GetVolunteerTagPreferencesAsync(user.Id);
 
         var hasCustomPicture = profile?.HasCustomProfilePicture == true;
@@ -413,7 +417,9 @@ public class ProfileController : HumansControllerBase
     {
         // Shift-tag catalog isn't posted back — repopulate up front so every
         // validation-failure `View(model)` path in this action still renders the picker.
-        model.AllShiftTags = await _shiftMgmt.GetTagsAsync();
+        model.AllShiftTags = (await _shiftMgmt.GetTagsAsync())
+            .OrderBy(t => t.Name, StringComparer.OrdinalIgnoreCase)
+            .ToList();
 
         if (!ModelState.IsValid)
         {

--- a/src/Humans.Web/Controllers/ProfileController.cs
+++ b/src/Humans.Web/Controllers/ProfileController.cs
@@ -314,6 +314,12 @@ public class ProfileController : HumansControllerBase
             ? await _profileService.GetProfileLanguagesAsync(profile.Id, ct)
             : (IReadOnlyList<ProfileLanguage>)[];
 
+        // Shift tag preferences — surfaced on Edit Profile so users can pick what
+        // kinds of volunteer work they want without bouncing to /Shifts. Without
+        // this surface the profile completion bar sticks at 95%.
+        var allShiftTags = await _shiftMgmt.GetTagsAsync();
+        var preferredShiftTags = await _shiftMgmt.GetVolunteerTagPreferencesAsync(user.Id);
+
         var hasCustomPicture = profile?.HasCustomProfilePicture == true;
 
         // Initial setup = no profile or not yet approved (onboarding)
@@ -392,7 +398,9 @@ public class ProfileController : HumansControllerBase
                 Id = pl.Id,
                 LanguageCode = pl.LanguageCode,
                 Proficiency = pl.Proficiency
-            }).ToList()
+            }).ToList(),
+            AllShiftTags = allShiftTags,
+            EditableShiftTagIds = preferredShiftTags.Select(t => t.Id).ToList()
         };
 
         ViewData["GoogleMapsApiKey"] = _configuration.GetRequiredSetting(_configRegistry, "GoogleMaps:ApiKey", "Google Maps", isSensitive: true);
@@ -403,6 +411,10 @@ public class ProfileController : HumansControllerBase
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> Edit(ProfileViewModel model)
     {
+        // Shift-tag catalog isn't posted back — repopulate up front so every
+        // validation-failure `View(model)` path in this action still renders the picker.
+        model.AllShiftTags = await _shiftMgmt.GetTagsAsync();
+
         if (!ModelState.IsValid)
         {
             ViewData["GoogleMapsApiKey"] = _configuration.GetRequiredSetting(_configRegistry, "GoogleMaps:ApiKey", "Google Maps", isSensitive: true);
@@ -672,6 +684,8 @@ public class ProfileController : HumansControllerBase
             .ToList();
 
         await _profileService.SaveProfileLanguagesAsync(profileId, newLanguages);
+
+        await _shiftMgmt.SetVolunteerTagPreferencesAsync(user.Id, model.EditableShiftTagIds);
 
         SetSuccess(_localizer["Profile_Updated"].Value);
         return RedirectToAction(nameof(Me));

--- a/src/Humans.Web/Models/ProfileViewModel.cs
+++ b/src/Humans.Web/Models/ProfileViewModel.cs
@@ -335,6 +335,17 @@ public class ProfileViewModel
     /// Languages for display (profile card).
     /// </summary>
     public IReadOnlyList<ProfileLanguageDisplayViewModel> Languages { get; set; } = [];
+
+    /// <summary>
+    /// All available shift tags (for the picker). Owner only.
+    /// </summary>
+    public IReadOnlyList<ShiftTag> AllShiftTags { get; set; } = [];
+
+    /// <summary>
+    /// IDs of shift tags the user has marked as preferred. Owner only.
+    /// Posted from the Edit form so the same submit saves preferences alongside the profile.
+    /// </summary>
+    public List<Guid> EditableShiftTagIds { get; set; } = [];
 }
 
 /// <summary>

--- a/src/Humans.Web/Views/Profile/Edit.cshtml
+++ b/src/Humans.Web/Views/Profile/Edit.cshtml
@@ -376,6 +376,26 @@
                         <span asp-validation-for="ContributionInterests" class="text-danger"></span>
                         <div class="form-text">@Localizer["ProfileEdit_ContributionInterestsHelp"]</div>
                     </div>
+
+                    @if (Model.AllShiftTags.Count > 0)
+                    {
+                        <hr />
+                        <div class="mb-3">
+                            <h6>@Localizer["Shifts_EditPreferences"]</h6>
+                            <p class="text-muted small mb-2">@Localizer["Shifts_PreferencesHelp"] <i class="fa-solid fa-star text-warning"></i></p>
+                            <div class="d-flex flex-wrap gap-3">
+                                @foreach (var tag in Model.AllShiftTags)
+                                {
+                                    var isPreferred = Model.EditableShiftTagIds.Contains(tag.Id);
+                                    <div class="form-check">
+                                        <input class="form-check-input" type="checkbox" name="EditableShiftTagIds" value="@tag.Id" id="prof-shift-tag-@tag.Id.ToString("N")"
+                                               @if (isPreferred) { <text>checked</text> } />
+                                        <label class="form-check-label" for="prof-shift-tag-@tag.Id.ToString("N")">@tag.Name</label>
+                                    </div>
+                                }
+                            </div>
+                        </div>
+                    }
                 </div>
             </div>
 

--- a/tests/Humans.Application.Tests/Controllers/ProfileControllerEditTests.cs
+++ b/tests/Humans.Application.Tests/Controllers/ProfileControllerEditTests.cs
@@ -60,6 +60,7 @@ public class ProfileControllerEditTests
     private readonly IApplicationDecisionService _applicationDecisionService =
         Substitute.For<IApplicationDecisionService>();
     private readonly IConfiguration _configuration = Substitute.For<IConfiguration>();
+    private readonly IShiftManagementService _shiftMgmt = Substitute.For<IShiftManagementService>();
     private readonly ProfileController _controller;
     private readonly Guid _userId = Guid.NewGuid();
 
@@ -97,7 +98,7 @@ public class ProfileControllerEditTests
             Substitute.For<IHumanLifecycleService>(),
             Substitute.For<IRoleAssignmentService>(),
             Substitute.For<IShiftSignupService>(),
-            Substitute.For<IShiftManagementService>(),
+            _shiftMgmt,
             Substitute.For<IGdprExportService>(),
             _configuration,
             new ConfigurationRegistry(),
@@ -244,6 +245,65 @@ public class ProfileControllerEditTests
             .UpdateDraftApplicationAsync(default, default, default!, default, default, default, default);
         await _applicationDecisionService.DidNotReceiveWithAnyArgs()
             .GetUserApplicationsAsync(default, default);
+    }
+
+    [HumansFact]
+    public async Task Edit_Post_WithShiftTagIds_CallsSetVolunteerTagPreferencesAsync()
+    {
+        _profileService.GetProfileAsync(_userId, Arg.Any<CancellationToken>()).Returns((Profile?)null);
+        _applicationDecisionService.GetUserApplicationsAsync(_userId, Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<MemberApplication>());
+
+        var tagId1 = Guid.NewGuid();
+        var tagId2 = Guid.NewGuid();
+        var model = MakeValidModel(MembershipTier.Volunteer);
+        model.EditableShiftTagIds = [tagId1, tagId2];
+
+        await _controller.Edit(model);
+
+        await _shiftMgmt.Received(1).SetVolunteerTagPreferencesAsync(
+            _userId,
+            Arg.Is<IReadOnlyList<Guid>>(ids => ids.Count == 2 && ids.Contains(tagId1) && ids.Contains(tagId2)));
+    }
+
+    [HumansFact]
+    public async Task Edit_Post_WithEmptyShiftTagIds_CallsSetVolunteerTagPreferencesAsyncWithEmptyList()
+    {
+        _profileService.GetProfileAsync(_userId, Arg.Any<CancellationToken>()).Returns((Profile?)null);
+        _applicationDecisionService.GetUserApplicationsAsync(_userId, Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<MemberApplication>());
+
+        var model = MakeValidModel(MembershipTier.Volunteer);
+        model.EditableShiftTagIds = [];
+
+        await _controller.Edit(model);
+
+        await _shiftMgmt.Received(1).SetVolunteerTagPreferencesAsync(
+            _userId,
+            Arg.Is<IReadOnlyList<Guid>>(ids => ids.Count == 0));
+    }
+
+    [HumansFact]
+    public async Task Edit_Post_ValidationFailure_RepopulatesAllShiftTagsAndDoesNotCallSetPreferences()
+    {
+        var tag1 = new ShiftTag { Id = Guid.NewGuid(), Name = "Heavy lifting" };
+        var tag2 = new ShiftTag { Id = Guid.NewGuid(), Name = "Working in the sun" };
+        _shiftMgmt.GetTagsAsync(Arg.Any<string?>())
+            .Returns(new List<ShiftTag> { tag1, tag2 });
+
+        // Force ModelState invalid before the action runs.
+        _controller.ModelState.AddModelError("BurnerName", "Required");
+
+        var model = MakeValidModel(MembershipTier.Volunteer);
+
+        var result = await _controller.Edit(model);
+
+        var viewResult = result.Should().BeOfType<ViewResult>().Subject;
+        var returnedModel = viewResult.Model.Should().BeOfType<ProfileViewModel>().Subject;
+        returnedModel.AllShiftTags.Should().HaveCountGreaterThan(0);
+
+        await _shiftMgmt.DidNotReceiveWithAnyArgs()
+            .SetVolunteerTagPreferencesAsync(default, default!);
     }
 
     private static ProfileViewModel MakeValidModel(


### PR DESCRIPTION
## Summary

- Adds the shift-tag checkbox grid to the Contributor section of `/Profile/Me/Edit` so users can declare what kinds of volunteer work they want **without bouncing to `/Shifts`**.
- Preferences save alongside the rest of the profile — no separate submit.
- Unblocks the dashboard "Complete your profile" widget from sticking at 95% when every other field is filled (the missing point came from `ProfileCompletion.cs` `hasShiftTagPreferences`).

## How

- `ProfileViewModel` gets `AllShiftTags` + `EditableShiftTagIds`.
- `ProfileController.Edit` GET loads the tag catalog and the user's current preferences inline (same pattern as Languages/CV/contact fields).
- `ProfileController.Edit` POST persists the picks via `IShiftManagementService.SetVolunteerTagPreferencesAsync` and repopulates the catalog upfront so every validation-failure re-render still shows the picker.
- View reuses the existing `Shifts_EditPreferences` / `Shifts_PreferencesHelp` localization keys.

## Test plan

- [x] Sign in as a non-admin user with a 95% complete profile, open `/Profile/Me/Edit`, scroll to the Contributor section.
- [x] Verify the "Edit preferences" block lists the same tags as `/Shifts` and pre-selects the user's current picks.
- [x] Tick at least one tag and save — confirm the dashboard widget hits 100%.
- [x] Edit again, untick everything, save — confirm the preferences clear (round-trip back to 95%).
- [ ] Trigger a validation error (e.g. invalid phone) and confirm the picker re-renders with the user's pending selections intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)