### PR TITLE
section-align skill: three-axis frame + first run (AuditLog Phase 0)

### DIFF
--- a/.claude/skills/reforge/SKILL.md
+++ b/.claude/skills/reforge/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: reforge
+description: Roslyn-powered semantic query CLI for C# solutions. Use when you need to find references, callers, implementations, dependencies, members, or trace call chains in a C# codebase — replaces multi-round grep/read cycles with single precise queries.
+---
+
+Run `reforge skill` to get the full usage guide:
+
+```bash
+reforge skill
+```
+
+Follow the output as your reference for which command to use and how to interpret results.
+
+For large solutions, start a hot server first to avoid the cold start tax:
+
+```bash
+reforge serve --solution path/to/Solution.slnx &
+```
+
+Then all subsequent `reforge` commands auto-relay to the server (~200ms instead of 3-20s).
+
+If the `reforge` binary is not on the PATH, ask the user for permission to install it via `dotnet tool install --global Reforge` (source: https://github.com/peterdrier/reforge) before proceeding.

--- a/.claude/skills/section-align/SKILL.md
+++ b/.claude/skills/section-align/SKILL.md
@@ -1,41 +1,71 @@
 ---
 name: section-align
-description: "Multi-phase orchestrator: inventory drift, rename surfaces, fix arch violations + review backlog, /simplify, polish docs — all in a push-and-bot-review loop. Use when a sizable PR landed, a section shows arch drift, or /pr-review returned a non-trivial violation list. Camps is the gold-standard reference."
+description: "Three-axis orchestrator: (1) clean section boundaries — naming, routes, views, ViewModels, DB ownership, cross-section access; (2) internal cohesion — no EF in service layer, caching in service only, proper interfaces, reusable ViewComponents, architecture-test coverage; (3) focused tests — grouped under the section, covering invariants/negatives/triggers, pruned of redundancy. Push-and-bot-review loop. Use when a sizable PR landed, a section shows arch drift, or /pr-review returned a non-trivial violation list. Camps is the gold-standard reference."
 argument-hint: "PR 374 | section EventGuide | section Camps --inventory-only"
 ---
 
 # Section Align
 
-A section is "aligned" when folders/namespaces/controllers/views/roles/routes/docs share one name; routes follow `/<Section>/*`, `/<Section>/Admin/*`, `/api/<section>/*`; services own their data; interfaces obey the budget ratchet; migrations are EF-auto-generated; and the invariant doc matches `SECTION-TEMPLATE.md`. **Camps is the reference.**
+## Purpose
+
+Drive one section of the Humans app to architectural alignment along three axes — boundary integrity, internal cohesion, test focus — through a phased PR that's pushed for bot review at each phase boundary. Surface follow-up /section-align targets for cross-section gaps the run discovers.
+
+## Vision
+
+Every section in the app is a self-contained vertical slice: one canonical name, its own data, public API others consume cleanly, current internal standards, and a focused test suite grouped with the section. Drift gets corrected one section at a time; new violations stand out instead of disappearing into noise.
+
+## Alignment definition
+
+A section is "aligned" when **all three axes hold**:
+
+**Axis 1 — boundary integrity.** The section has a single canonical name shared by folder, namespace, controller, views, ViewModels, route prefix, role suffix, invariant doc. Routes follow `/<Section>/*`, `/<Section>/Admin/*`, `/api/<section>/*`. No other section reads, writes, joins, or navigates EF into this section's tables. The section's controller, views folder, and ViewModels file exist under the section's name — *not* in `Views/Shared/`, `Models/AdminViewModels.cs`, or other sections' controllers.
+
+**Axis 2 — internal cohesion.** Services live in `Humans.Application.Services.<Section>/` and never import `Microsoft.EntityFrameworkCore` or take `DbContext`. Repositories are sealed, factory-based, registered Singleton. Caching lives in the service layer only (decorator or service-internal `IMemoryCache`), never in repos or controllers. Interfaces obey the budget ratchet. ViewComponents exist where the section's data is rendered on other sections' pages. Architecture tests pin each invariant. Migrations are EF-auto-generated.
+
+**Axis 3 — test focus.** Section-aligned tests live under one canonical location (`tests/Humans.Application.Tests/<Section>/` or `tests/Humans.Application.Tests/Services/<Section>/` — pick one, not both). Coverage maps to invariants, Negative Access Rules, and Triggers from the section doc — not to every method permutation. Redundant tests are pruned. Test maintenance cost matches test value. Tests assert observable behavior, not mock-graph internals.
+
+**Camps is the reference.**
+
+## Boundary-fix protocol
+
+When the inventory finds cross-section access (either direction), apply this protocol — **never just "fix the offending file" silently**, because that violates section ownership.
+
+- **We are the producer** (another section reads or writes our tables / navs into our entities): our job in THIS PR is to ensure the public API on our service satisfies the caller's need. Add the API if missing. Then flag the calling section as the next /section-align target — they own the call-site migration.
+- **We are the consumer** (we read or write into another section's tables / `.Include` across into another section's entity): flag the missing API on THEIR section. Don't fix it here. Document the gap, tolerate the current code (or fall back to a less-bad path), and surface the other section as the next /section-align target.
+
+Output every Phase 0 plan with an explicit **Follow-up /section-align targets** list naming each section that surfaced as needing its own pass.
 
 ## Input
 
 - `PR <n>` — inventory against diff; work on PR branch in a worktree.
-- `section <Name>` — resolves to `docs/sections/<Name>.md` + matching code; fresh branch off `main`.
+- `section <Name>` — resolves to `docs/sections/<Name>.md` + matching code; fresh branch off `origin/main`.
 - `<empty>` — ask which target.
 - `--inventory-only` — Phase 0 only.
 
 ## Stop conditions (check after Phase 0 — ask user before continuing)
 
-- Canonical name collides with an existing controller/service/folder.
+- Canonical name collides with an existing controller/service/folder in another section.
 - Cross-section DB fix would bump another section's budget by more than 1–2 methods.
 - Owning section of an entity is genuinely ambiguous (affects `design-rules.md §8`).
 - Invariant doc is missing more than half the `SECTION-TEMPLATE.md` shape.
 - PR branch has uncommitted work or open conflicts.
+- **Outbound API gap on a consumer-side fix** — we'd need a new public service method on another section to clean up our cross-domain read/write, and that section hasn't exposed one. Document, don't invent.
+
+**Do not treat section-doc-declared exceptions as closed questions.** When the doc says "served from two controllers — required because…", that's a description of current drift, not a sanction. Evaluate the exception against the convention; if the convention can hold, fix; if a true exception is needed, surface it for owner sign-off.
 
 Surface as: "I hit X. Decision needed: [A] / [B] / [C]."
 
 ## Phases
 
 ```
-Phase 0  Inventory → local/section-align-<target>.md; stop conditions; ask user
-Phase 1  Rename / surface alignment — Sonnet subagents; push; bot-review loop
-Phase 2  Fix arch violations + prior review items — Sonnet/Opus; push; bot-review loop
-Phase 3  /simplify pass — Opus; push; bot-review loop
-Phase 4  Doc polish — Opus; push; final review loop until merge-ready
+Phase 0  Inventory (both axes) → docs/plans/<YYYY-MM-DD>-section-align-<target>.md; stop conditions; ask user
+Phase 1  Surface alignment (axis 1) — create/move controllers, views, ViewModels, extensions, routes
+Phase 2  Fix arch violations + prior review items (both axes; boundary-fix protocol)
+Phase 3  /simplify pass — Opus; internal cohesion + interface trimming
+Phase 4  Doc polish — Opus; final review loop until merge-ready
 ```
 
-Sequential phases. Within a phase, parallel subagents up to **hard cap of 3** (`~/.claude-shared/shared/claude.md`). Escalate model: Sonnet for Phase 1 renames → Opus for Phases 2–4.
+Sequential phases. Within a phase, parallel subagents up to **hard cap of 3** (`~/.claude-shared/shared/claude.md`). Escalate model: Sonnet for Phase 1 mechanical work → Opus for Phases 2–4.
 
 ## Mode detection
 
@@ -49,66 +79,282 @@ Always use a worktree under `.worktrees/section-align-<target>/` (`feedback_alwa
 
 ---
 
-## Phase 0 — Inventory
+## Phase 0 — Inventory (two-axis)
 
-Output: `local/section-align-<target>.md`.
+Output: `docs/plans/<YYYY-MM-DD>-section-align-<target>.md`. Both axes always audited.
 
-**1. Section name consistency** — variants in use across folders/namespaces/controllers/views/roles/routes/docs. Propose canonical name. Flag collisions.
+### Axis 1 — boundary integrity
 
-**2. URL surface** — every route. Catch: `/Admin/<X>/*` paths (`architecture_no_admin_url_section`), non-Barrios↔Camps aliases (`feedback_no_url_aliases`), cross-section URL exposure, generic top-level controllers for section concerns.
+**A1.1 Section name consistency.** Variants across folders, namespaces, controllers, views, ViewModels, roles, routes, docs. Propose canonical name. Flag collisions.
 
-**3. Role surface** — domain-scoped roles need `*Admin` suffix (`feedback_admin_superset`). Exceptions only when semantics don't fit (e.g., `ConsentCoordinator`).
+**A1.2 Controller existence.** Does `src/Humans.Web/Controllers/<Section>Controller.cs` (or `<Section>AdminController.cs` / `<Section>ApiController.cs` if split) exist? If routes serving this section's data live on *other* sections' controllers (e.g. `BoardController` hosting `/Board/AuditLog`), that is drift. List each foreign route and propose the move.
 
-**4. Cross-section access**
+**A1.3 URL surface.** Every route serving this section's data. Catch:
+- Routes outside `/<Section>/*` or `/<Section>/Admin/*` or `/api/<section>/*`
+- `/Admin/<Section>/*` paths (`architecture_no_admin_url_section`)
+- Non-Barrios↔Camps aliases (`feedback_no_url_aliases`)
+- Generic top-level controllers hosting this section's concerns
+
+**A1.4 Views folder.** Does `src/Humans.Web/Views/<Section>/` exist? Section-owned page views in `Views/Shared/` (e.g. `Views/Shared/<Section>.cshtml`) are drift unless they are genuinely cross-section partials reused by widgets. ViewComponent partials at `Views/Shared/Components/<Section>/` are fine (and expected).
+
+**A1.5 ViewModel placement.** Section ViewModels in `Models/<Section>ViewModels.cs` or `Models/<Section>/`. Types parked in `Models/AdminViewModels.cs` or other grab-bag files = drift.
+
+**A1.6 Controller-base leak.** Search `HumansControllerBase` (or equivalent) for section-specific helper methods or ViewModels. Section names appearing in `protected` method names, parameter types, or return types = drift. Move into `<Section>Controller`.
+
+**A1.7 Extensions placement.** `src/Humans.Web/Extensions/Sections/<Section>SectionExtensions.cs` for DI wiring. Any `<Section>*.cs` in `Extensions/` root (not `Extensions/Sections/`) = drift.
+
+**A1.8 Role surface.** Domain-scoped roles need `*Admin` suffix (`feedback_admin_superset`). Exceptions only when semantics don't fit (e.g., `ConsentCoordinator`).
+
+**A1.9 INBOUND cross-section DB access (reads + writes).** Grep for any non-test file outside this section's repo touching this section's DbSets:
+
 ```bash
-git -C <worktree> grep -nE '_db\.(\w+)\.(Where|FirstOrDefault|FindAsync|ToListAsync)' src/Humans.Infrastructure/Repositories/<Section>/
+git grep -nE '_(db|context|ctx)\.(<TableA>|<TableB>)\.(Where|FirstOrDefault|Find|FindAsync|ToListAsync|Single|First|Count|Any|Add|AddRange|Update|Remove|Attach)\b' src/
+git grep -nE '\b(_db|_context|ctx)\.<TableA>\b' src/  # bare DbSet refs catch e.g. AddRange that the verb regex misses
 ```
-Cross-reference each `_db.X` against `design-rules.md §8`.
 
-**5. Controller → DbContext**
+For each hit: apply the **boundary-fix protocol (producer side)**. Do we expose the public API the caller actually needs? If yes, the caller's section becomes a /section-align follow-up target (they own the migration). If no, add the API in THIS PR's Phase 2 — *then* the caller becomes a follow-up target.
+
+**A1.10 INBOUND EF navigations.** Search other sections' entities for navigation properties pointing AT this section's entities:
+
 ```bash
-git -C <worktree> grep -nE 'HumansDbContext' src/Humans.Web/Controllers/
+git grep -nE 'public\s+<SectionEntity>\??\s+\w+\s*\{' src/Humans.Domain/Entities/
 ```
-Any hit violates Design Rule §2a.
 
-**6. Interface budget** — new interfaces ≥10 methods need an `InterfaceMethodBudgetTests.cs` entry. Flag any existing budgeted interface this work would push over budget.
+A nav from another section's entity to ours = a cross-domain coupling that breaks §6 if anyone `Include`s it.
 
-**7. Migrations** — hand-edited body or snapshot violates `architecture_no_hand_edited_migrations`.
+**A1.11 OUTBOUND cross-section access (this section reaches OUT).** Grep this section's repository for reads of other sections' DbSets or `.Include` across into other-section navs:
 
-**8. Section invariant doc** — present? name matches? follows `SECTION-TEMPLATE.md` shape? structural gaps?
+```bash
+git grep -nE '_(db|context|ctx)\.(<OtherSectionTableA>|<OtherSectionTableB>)' src/Humans.Infrastructure/Repositories/<Section>/
+git grep -nE '\.Include\([^)]+\)' src/Humans.Infrastructure/Repositories/<Section>/
+```
 
-**9. Open prior-review items (PR mode)**
+For each hit: apply the **boundary-fix protocol (consumer side)**. Does the other section expose a public service method that gives us what we need? If yes, switch (Phase 2). If no, document the API gap on their side, leave the current code in place, and flag their section as a follow-up /section-align target. **Do not add a method to their repo or service in this PR.**
+
+**A1.12 Controller → DbContext.** Any controller injecting `HumansDbContext` violates §2a. Hard violation; always Phase 2 fix.
+
+**A1.13 Migrations.** Hand-edited body or snapshot violates `architecture_no_hand_edited_migrations`. Intentional `migrationBuilder.Sql(...)` for triggers/seeds is allowed when named in the section doc.
+
+**A1.14 Section invariant doc shape.** Present? name matches? follows `SECTION-TEMPLATE.md`? structural gaps?
+
+**A1.15 Open prior-review items (PR mode).**
 ```bash
 gh pr view <n> --repo peterdrier/Humans --json comments,reviews
 gh api repos/peterdrier/Humans/pulls/<n>/comments
 ```
-List each unresolved comment with inline-comment ID. Also check `nobodies-collective/Humans` (`feedback_pr_review_both_repos`).
+Also check `nobodies-collective/Humans` (`feedback_pr_review_both_repos`). List each unresolved comment with inline-comment ID.
+
+### Axis 2 — internal cohesion
+
+**A2.1 EF leakage from service layer.** Grep this section's services for EF types and query operators:
+
+```bash
+git grep -nE '(Microsoft\.EntityFrameworkCore|IQueryable|DbContext|DbSet|\.Include\(|\.AsNoTracking|\.ToListAsync|\.FirstOrDefaultAsync|\.SaveChangesAsync)' src/Humans.Application/Services/<Section>/
+```
+
+Hits in `using` statements, ctor params, or method bodies = violation. Doc comments (`<see cref>`) are OK. Add `<Section>Service_HasNoDbContextConstructorParameter` arch test if missing.
+
+**A2.2 Caching placement.** Grep section's services + repos + controllers + view components:
+
+```bash
+git grep -nE '(IMemoryCache|MemoryCache|IDistributedCache|_cache\b)' src/Humans.Application/Services/<Section>/ src/Humans.Infrastructure/Repositories/<Section>/ src/Humans.Web/Controllers/<Section>*.cs src/Humans.Web/ViewComponents/<Section>*.cs
+```
+
+Caching belongs in the service layer **only** per §15 — either via a `Caching<Section>Service` decorator (Singleton, dict-backed) or service-internal `IMemoryCache` for short-TTL request acceleration. Never in repositories. Never in controllers. ViewComponents per `feedback_viewcomponent_no_cache`.
+
+**A2.3 DI lifetimes.** Read `Extensions/Sections/<Section>SectionExtensions.cs`. Verify:
+- Repository: Singleton, depends on `IDbContextFactory<HumansDbContext>`
+- Service: Scoped (or Singleton if stateless + factory-based dependencies)
+- Decorator (if present): Singleton
+- Cross-interface re-exports (e.g. `IUserDataContributor` → existing service): bound to the registered concrete
+
+**A2.4 Repository pattern.** `<Section>Repository`:
+- `sealed`
+- uses `IDbContextFactory<HumansDbContext>`
+- has no Update/Delete if entity is append-only (§12)
+- lives at `Infrastructure/Repositories/<Section>/`
+
+**A2.5 ViewComponent presence and reuse.** If this section's data appears on other sections' pages (audit history on profile pages, profile cards in directories, notification meters in nav), there should be a `<Section>ViewComponent` and partial views under `Views/Shared/Components/<Section>/`. Inverse check: section pages with inline rendering of "should-be-a-VC" content (10+ lines of Razor stitching this section's data into another section's view).
+
+Grep for invocations:
+```bash
+git grep -nE '<vc:<section-kebab>|Component\.InvokeAsync\("<Section>"' src/Humans.Web/Views/
+```
+
+**A2.6 Interface budget + segregation.** Count methods on each public interface. For each interface ≥10 methods, ensure `InterfaceMethodBudgetTests.Budgets` entry exists with current count. Beyond the budget number itself, flag:
+- Methods on the section's main service that exist only to be called by *another service within the same section* (UI plumbing leaking through the main interface — should be private or moved). Example: `IAuditLogService.GetUserDisplayNamesAsync` called only by `AuditViewerService`.
+- Multiple interfaces carrying overlapping read shapes (Service returns raw entity, ViewerService returns resolved record). Phase 3 candidate.
+- "Replace 2 methods with 1 broader bag-of-flags method" anti-pattern.
+
+**A2.7 Architecture test coverage.** For each service in the section, the section's `<Section>ArchitectureTests.cs` should pin:
+- Lives in `Humans.Application.Services.<Section>` namespace
+- No `DbContext` constructor parameter
+- No `IMemoryCache` constructor parameter (or has one, if caching is in-service)
+- Takes the section's repository
+- For append-only entities: repo has no Update/Delete/Remove methods
+- For sections that own DbSets: only `<Section>Repository` references `ctx.<SectionDbSet>` (Roslyn or reflection scan)
+
+List missing tests. Each missing test is a Phase 2 add.
+
+### Axis 3 — test focus
+
+**A3.1 Test folder placement.** Canonical layout for this codebase: **one folder per section, top-level**, holding service + repository + viewmodel tests for that section's classes.
+
+```
+tests/Humans.Application.Tests/<Section>/
+  <Section>ServiceTests.cs
+  <SecondaryService>Tests.cs
+  <Section>RepositoryTests.cs       # if the section's repo has unit tests
+  ...
+```
+
+If the section's tests are split across `tests/Humans.Application.Tests/<Section>/` AND `tests/Humans.Application.Tests/Services/<Section>/` AND `tests/Humans.Application.Tests/Services/<Section>FooTests.cs` AND `tests/Humans.Application.Tests/Repositories/<Section>RepositoryTests.cs`, that's drift. Inventory the scatter, pick the top-level folder as the canonical home, and propose moves.
+
+Tests that belong elsewhere by category (not section drift):
+- `tests/Humans.Application.Tests/Architecture/<Section>ArchitectureTests.cs` — arch tests for this section (covered in Axis 2.7)
+- `tests/Humans.Application.Tests/Authorization/<Section>AuthorizationHandlerTests.cs` — auth handler tests
+- `tests/Humans.Integration.Tests/...` — cross-section by definition
+- `tests/Humans.Web.Tests/Controllers/<Section>*Tests.cs` — controller tests live with the Web project
+- `tests/Humans.Domain.Tests/Entities/<Entity>Tests.cs` — pure entity behavior
+
+**A3.1a One test file per production class (1-to-1 rule).** For every production class in this section, there should be exactly one test file named `<ClassName>Tests.cs`:
+
+| Production | Test file |
+|------------|-----------|
+| `<Section>Service.cs` | `<Section>ServiceTests.cs` |
+| `<Section>Repository.cs` | `<Section>RepositoryTests.cs` |
+| `<HelperClass>.cs` | `<HelperClass>Tests.cs` |
+
+Two production classes sharing one test file (e.g. `AuditEvent` + `AuditEventTextualizer` → `AuditEventRenderTests.cs`) is drift — reviewers expect a 1-to-1 map. Exception: a single test file may exercise a tightly-coupled production pair if the pair is a documented helper-aggregator (rare; surface to user).
+
+A production class with **no** test file at all (e.g. `<Section>Repository.cs` covered only by `<Section>ArchitectureTests`) is drift — the architecture test pins shape, not behavior. Add a unit test file or document why none is needed (e.g. "pure pass-through repository — coverage flows through `<Section>ServiceTests`").
+
+**A3.2 Coverage map against section doc.** Read `docs/sections/<Section>.md`. Build a coverage map:
+- Each **Invariant** bullet → at least one test asserting it holds
+- Each **Negative Access Rule** → one test asserting the rejection
+- Each **Trigger** → one test asserting the side effect fires (audit row, notification, cascade)
+- Each public service method → at least one happy-path test (edge cases proportional to complexity, not exhaustive)
+
+Missing coverage on invariants/negatives/triggers = Phase 2 add. Missing happy-path on a method = Phase 2 add if the method is non-trivial; skip if it's a one-line pass-through with the underlying call already tested.
+
+**A3.3 Redundancy / over-testing flags.** Scan for:
+- Near-duplicate tests with minor parameter variation that doesn't add value (shotgun parameter coverage where one or two cases suffice)
+- Same scenario tested at multiple layers (unit + integration + controller) without rationale — pick the layer where the invariant lives
+- Tests of framework or library behavior (EF Core, ASP.NET, NodaTime internals) rather than our code
+- "No exception thrown" assertions with no meaningful invariant check
+- Mock-graph spaghetti where the test asserts the mock was called rather than an observable outcome
+- Tests coupled to implementation details (private method existence, internal call order) that break on innocent refactors
+
+Each flag is a Phase 3 prune candidate. The goal is to reduce test maintenance overhead where test value is already captured by a more direct test.
+
+**A3.4 Test-to-section ratio (sanity check).** Eyeball: section LOC vs test file count and test LOC.
+```bash
+find src/Humans.Application/Services/<Section>/ src/Humans.Infrastructure/Repositories/<Section>/ src/Humans.Domain/Entities/<SectionEntity>*.cs -name '*.cs' | xargs wc -l | tail -1
+find tests -path '*<Section>*' -name '*.cs' | xargs wc -l | tail -1
+```
+Order-of-magnitude check only. Outliers worth investigating:
+- Section LOC ~1k but 50+ test files → probably over-tested, Phase 3 prune candidate
+- Section LOC ~7k but <10 test files → probably under-tested, Phase 2 invariants-and-negatives add
+
+Not a budget. Judgment call surfaced to the user.
+
+**A3.5 Brittleness signals.** Tests that:
+- Reach into private state via reflection
+- Depend on specific clock values rather than `IClock` / `FakeClock`
+- Depend on test execution order
+- Take >1s without an explicit `[Slow]` marker
+- Hit real external services without sandbox/mock
+
+Each is a Phase 3 candidate (prune or rewrite).
+
+**A3.6 Mutation testing signal (Stryker.NET, optional but preferred).** The repo has Stryker.NET wired (`docs/testing/mutation-testing.md`). Use the **Profile-section probe pattern** to get section-targeted under/over-test signal without paying the cost of a full-suite run:
+
+1. Look for an existing report at `local/stryker-runs/<section>/reports/mutation-report.json`. If recent (< 30 days) and matches current HEAD, use it. If stale or absent and the section is significant, surface to user: "Run Stryker against this section before Phase 3? (~N minutes)" with the section-narrowed config command:
+
+   ```powershell
+   Push-Location tests/Humans.Application.Tests
+   dotnet tool run dotnet-stryker --config-file stryker-<section>-config.json `
+     --output ..\..\local\stryker-runs\<section>
+   Pop-Location
+   ```
+
+   If no `stryker-<section>-config.json` exists, propose creating one mirroring `stryker-profiles-config.json` with a narrowed `mutate` glob targeting this section's `src/` paths.
+
+2. Run `scripts/analyze-test-utility.ps1` against the report to produce the `High-Confidence Test-Debt Candidates` queue:
+
+   ```powershell
+   powershell -ExecutionPolicy Bypass -File scripts/analyze-test-utility.ps1 `
+     -Top 50 `
+     -StrykerReport local/stryker-runs/<section>/reports/mutation-report.json
+   ```
+
+   Output lands under `local/test-utility/`. The Markdown report has two queues — `High-Confidence Test-Debt Candidates` is the better starting point for Phase 3 pruning.
+
+3. Interpretation:
+   - **Surviving mutants** = under-tested production code. Phase 2 adds a behavior test that kills the mutant.
+   - **High utility-debt score + weak assertion + no policy value** = Phase 3 deletion candidate. Confirm by inspection — the score is heuristic.
+   - Architecture ratchets and DI cycle checks may look "useless" by score but exist for explicit policy reasons — exclude from deletion.
+
+Stryker is **a signal, not an authority**. Treat results as a triage queue. The skill never auto-deletes a test based on Stryker output alone.
 
 ### Plan file skeleton
 
 ```markdown
 # Section Align — <target>
 **Run started:** <date> | **Mode:** <mode> | **Worktree:** <path>
+**Branch:** `<branch>` (off `<base>` @ `<sha>`)
 **Canonical section name proposal:** <name>
 
-## Inventory
+## Axis 1 — boundary integrity
 1. Name consistency: <findings>
-2. URL surface: <routes table with violation flags>
-3. Role surface: <violations>
-4. Cross-section access: <list>
-5. Controller→DbContext: <list>
-6. Interface budget: <conflicts>
-7. Migrations: <findings>
-8. Invariant doc: <gaps>
-9. Prior review items: <list with comment IDs>
+2. Controller existence: <findings>
+3. URL surface: <routes table with violation flags>
+4. Views folder: <findings>
+5. ViewModel placement: <findings>
+6. Controller-base leak: <findings>
+7. Extensions placement: <findings>
+8. Role surface: <violations>
+9. Inbound cross-section DB access (reads + writes): <list with protocol disposition>
+10. Inbound EF navs: <list>
+11. Outbound cross-section access: <list with protocol disposition>
+12. Controller→DbContext: <list>
+13. Migrations: <findings>
+14. Invariant doc: <gaps>
+15. Prior review items: <list with comment IDs>
+
+## Axis 2 — internal cohesion
+1. EF leakage from service: <findings>
+2. Caching placement: <findings>
+3. DI lifetimes: <findings>
+4. Repository pattern: <findings>
+5. ViewComponent presence + reuse: <findings>
+6. Interface budget + segregation: <conflicts and trims>
+7. Architecture test coverage: <missing tests>
+
+## Axis 3 — test focus
+1. Test folder placement: <canonical home + scatter list>
+1a. 1-to-1 map (production class → test file): <table; missing tests; bundled-class drift>
+2. Coverage map (invariants / negatives / triggers / methods): <coverage holes>
+3. Redundancy flags: <list of prune candidates>
+4. Test-to-section ratio: <LOC ratio + verdict>
+5. Brittleness signals: <list>
+6. Mutation signal (Stryker.NET): <report path + summary, or "no recent report; propose run">
+
+## Test-attribute gate (per `docs/testing/mutation-testing.md`)
+- Baseline as of last gate update: <count from doc>
+- This run's net delta: +<added> / -<deleted> = <net>
+- Justification if net > 0: <explain or refuse>
 
 ## Stop conditions tripped
 <none or list with proposed decisions>
 
+## Follow-up /section-align targets
+<list of other sections this run surfaced as needing their own pass, with reason>
+
 ## Phase plan
-- Phase 1 (rename): <list>
-- Phase 2 (fix): <list, blocking items flagged>
-- Phase 3 (simplify): ~<N> fixes
+- Phase 1 (axis 1 + axis 3 mechanical — create/move surfaces and test folders): <list>
+- Phase 2 (axes 1, 2, 3; boundary-fix protocol; add missing arch tests + invariant tests): <list, blocking items flagged>
+- Phase 3 (simplify / internal cohesion / prune redundant tests): ~<N> fixes
 - Phase 4 (docs): <list>
 ```
 
@@ -116,22 +362,28 @@ Surface to user. If `--inventory-only`, stop. Otherwise: "Phase 0 complete. Proc
 
 ---
 
-## Phase 1 — Rename / surface alignment
+## Phase 1 — Surface alignment (axis 1)
 
 Sonnet subagents. `/reforge` for impact analysis before bulk edits. Build must stay green after each step.
 
-Order:
-1. **Invariant doc** — `git mv docs/sections/<Old>.md docs/sections/<New>.md`
-2. **Folders** — `git mv` (Application, Infrastructure, Views)
-3. **Namespaces** in lockstep
-4. **Symbols** — `IXService`, `XController`, `XAdminController`, etc. via `/reforge` + bulk Edit
-5. **Route attributes** — class-level to `/<Section>/*`; admin under `/<Section>/Admin/*`
-6. **Role names** — `*Admin` suffix unless Phase 0 justified exception
-7. **Config keys** — update `appsettings*.json`
-8. **Entities** — only if prefix is awkward post-rename; surface to user, default keep
-9. **DB tables** — leave alone (`architecture_no_drops_until_prod_verified`); use `[Table("legacy_name")]` if entity renamed
+**Create what's missing** (not only rename):
+1. **Invariant doc** — `git mv docs/sections/<Old>.md docs/sections/<New>.md` if renamed.
+2. **Controller** — if `<Section>Controller.cs` doesn't exist and routes live on foreign controllers, create it. Migrate route handlers off `BoardController` / `GoogleController` / etc. Update `RedirectToAction` targets and tag-helper links across views/tests.
+3. **Views folder** — if `Views/<Section>/` doesn't exist and page views live in `Views/Shared/<Section>.cshtml`, create it and move the page views. Keep genuine cross-section partials in Shared.
+4. **ViewModels file** — extract section types out of `Models/AdminViewModels.cs` or other grab-bag files into `Models/<Section>ViewModels.cs`.
+5. **Controller-base helpers** — move section-specific helpers off `HumansControllerBase` into `<Section>Controller` (or section-local helpers).
+6. **Folders** — `git mv` Application, Infrastructure, Views if rename triggered.
+7. **Namespaces** in lockstep.
+8. **Symbols** — `I<Section>Service`, `<Section>Controller`, etc. via `/reforge` + bulk Edit.
+9. **Route attributes** — class-level to `/<Section>/*`; admin under `/<Section>/Admin/*`.
+10. **Role names** — `*Admin` suffix unless Phase 0 justified exception.
+11. **Config keys** — update `appsettings*.json`.
+12. **Extensions** — `git mv Extensions/<Section>*.cs Extensions/Sections/`.
+13. **Test folder** — if the section's tests are scattered, `git mv` them into the canonical home picked in A3.1. Rename test files to `<ClassUnderTest>Tests.cs` 1-to-1 if they aren't already (one production class → one test file).
+14. **Entities** — only if prefix is awkward post-rename; surface to user, default keep.
+15. **DB tables** — leave alone (`architecture_no_drops_until_prod_verified`); use `[Table("legacy_name")]` if entity renamed.
 
-After each rename group:
+After each rename/move group:
 ```bash
 dotnet build Humans.slnx -v quiet && dotnet test Humans.slnx -v quiet
 ```
@@ -145,28 +397,53 @@ Push at end of phase. Bot-review sub-loop until clean (`feedback_done_means_code
 
 ---
 
-## Phase 2 — Fix arch violations + prior review items
+## Phase 2 — Fix arch violations + prior review items (both axes)
 
 Sonnet by default; Opus for nuanced items.
 
-- **Cross-section DB access** — route through owning interface. If addition busts budget, `/audit-surface <OtherInterface>` for 1-for-1 swap. **Stop and ask** if no swap found.
+**Boundary-fix protocol applies to every cross-section finding.** State the protocol disposition in the commit message ("Producer-side fix: added IFooService.GetByIdsAsync for the X consumer; flagging X for follow-up /section-align").
+
+Axis 1 items:
+- **Inbound cross-section DB access (producer-side)** — ensure our public API satisfies the need. Add the method if missing (budget bump if interface ≥10, add `InterfaceMethodBudgetTests.Budgets` entry). The caller's section becomes a follow-up /section-align target; do not touch their call site in this PR unless trivial (one or two lines).
+- **Outbound cross-section access (consumer-side)** — if the supplier section has the public API, switch to it. If not, document the gap, leave the code, flag their section as follow-up. Never reach into another section's repository or DbContext.
 - **Controller-DI-DbContext** — extract service+repo layer.
-- **Interface budget** — add to `InterfaceMethodBudgetTests.Budgets` with exact count; run the test.
 - **Hand-edited migration** — `dotnet ef migrations remove` + redo `dotnet ef migrations add`. Verify snapshot is byte-for-byte EF output.
+- **URL aliases / cross-section URL exposure** — remove; surface downstream consumer risk.
+- **Prior review threads** — fix or reply with reasoning via `gh api .../comments/<id>/replies`; never top-level.
+
+Axis 2 items:
+- **EF leak in service layer** — extract repository methods. Add the missing arch test.
+- **Caching in repo or controller** — move into service or its caching decorator.
+- **DI lifetime mismatch** — fix in `<Section>SectionExtensions`.
+- **Interface budget** — add `InterfaceMethodBudgetTests.Budgets` entry with exact count; run the test.
+- **Architecture test gaps** — add tests catching the section's worst violations (no controller→DbContext, no service→DbContext, only repo touches the DbSet, append-only repo shape).
 - **Docstring vs reality** — align to what's enforced; no DB triggers unless ConsentRecord-grade reason (`feedback_db_enforcement_minimal`).
-- **Architecture tests** — add tests catching the section's worst violations (e.g., "no controller injects `HumansDbContext`").
-- **URL aliases / cross-section exposure** — remove; surface downstream consumer risk.
-- **Prior review threads** — fix or reply with reasoning via `gh api .../comments/<id>/replies` (`feedback_codex_thread_replies`); never top-level.
+
+Axis 3 items:
+- **Missing coverage** — for each invariant / Negative Access Rule / Trigger from A3.2 without a test, add one. Keep terse: one focused test per item.
+- **Missing 1-to-1 test file** — if `<Section>Service` exists but `<Section>ServiceTests.cs` doesn't, create it (even if just stub + happy path). 1-to-1 helps reviewers find the test surface for a given class fast.
+- **Bundled-class test files** — split `AuditEventRenderTests.cs` (covers 2 classes) into per-class files unless the pair is a documented helper-aggregator.
+- **Surviving Stryker mutants** (if A3.6 report available) — add behavior tests that kill each high-value surviving mutant. Don't try to kill them all; focus on mutants that map to invariants/negatives/triggers in the section doc.
+- **Brittle tests** that are easy to rewrite to assert observable behavior instead of mock-graph internals — rewrite as part of the fix that touches them.
 
 Build + tests green. Push at end of phase. Bot-review sub-loop until clean.
 
 ---
 
-## Phase 3 — /simplify pass
+## Phase 3 — /simplify pass (internal cohesion)
 
 Opus. Volume scales to section LOC (`feedback_simplify_scope_to_section_size`): ~6–10 fixes for 7k LOC, ~2–3 for 1k LOC.
 
-Common targets: duplicated logic across controllers; LINQ-on-EF in services (push to thick repos, `feedback_no_linq_at_db_layer`); unnecessary `.ToList()`; `Cached*` names (`feedback_caching_transparent`); extensions on owned types (`feedback_no_extensions_for_owned_classes`); view-component caches (`feedback_viewcomponent_no_cache`).
+Common targets:
+- Duplicated logic across controllers.
+- LINQ-on-EF in services (push to thick repos, `feedback_no_linq_at_db_layer`).
+- Unnecessary `.ToList()`.
+- `Cached*` names (`feedback_caching_transparent`).
+- Extensions on owned types (`feedback_no_extensions_for_owned_classes`).
+- View-component caches (`feedback_viewcomponent_no_cache`).
+- **Interface trimming** — methods on the section's main service that exist only for one in-section consumer; move private or to the consumer.
+- **Read-shape consolidation** — if Service and ViewerService both expose the same read names with different return shapes, move all UI reads to ViewerService and trim Service.
+- **Test pruning** — delete redundant/over-tested cases flagged in A3.3, brittleness flagged in A3.5, and high-confidence test-debt candidates from the Stryker utility report (A3.6). Prefer deletion over refactoring: if a test isn't asserting something a reviewer would catch in code review, it's pulling its weight only if its absence would let a real regression slip. State the deletion rationale in the commit message ("redundant with X test; mock-graph assertion not behavior; Stryker survived no mutant"). Respect the test-attribute gate (`docs/testing/mutation-testing.md`): the net delta should trend down across Phase 3 commits.
 
 Push at end of phase. Bot-review sub-loop until clean.
 
@@ -176,15 +453,16 @@ Push at end of phase. Bot-review sub-loop until clean.
 
 Opus.
 
-- **Invariant doc** — verify all `SECTION-TEMPLATE.md` sections: Concepts, Data Model, Actors & Roles, Invariants, Negative Access Rules, Triggers, Cross-Section Dependencies, Architecture.
+- **Invariant doc** — verify all `SECTION-TEMPLATE.md` sections. Correct any false claims surfaced in Phase 0 (e.g., "only repo writes the table" claims that turned out false until Phase 2 fixed them — restore once truly true).
+- **Cross-Section Dependencies** — record any §6 violations still pending an upstream API (consumer-side gaps not fixable in this PR), naming the supplier section as the follow-up target.
 - **Feature specs** (`docs/features/*.md`) — match implementation; rename if section name changed.
-- **`data-model.md`** — update owned-entity index (per-entity detail belongs in invariant doc, not here).
+- **`data-model.md`** — update owned-entity index.
 - **`todos.md`** — per `feedback_todos_update_after_commits`.
 - **`maintenance-log.md`** — if a recurring task ran.
 - **About page** — if dependencies changed.
 - **`/freshness-sweep`** — if catalog covers touched docs.
 
-Push. Final bot-review loop until merge-ready. Report: PR/branch URL, commits per phase, one-line status. Do not offer `/schedule` follow-ups (`feedback_no_schedule_offers`).
+Push. Final bot-review loop until merge-ready. Report: PR/branch URL, commits per phase, **follow-up /section-align targets**, one-line status. Do not offer `/schedule` follow-ups (`feedback_no_schedule_offers`).
 
 ---
 
@@ -201,7 +479,7 @@ Push. Final bot-review loop until merge-ready. Report: PR/branch URL, commits pe
 
 ## Resume behavior
 
-If `local/section-align-<target>.md` exists: read it, find last completed phase, ask: "Found plan from <date>. Last complete: <phase>. Resume or start fresh?" Update the plan file at end of each phase.
+Plan files are durable, committed artifacts under `docs/plans/` — one per run, date-prefixed. On startup, glob `docs/plans/*-section-align-<target>.md`. If any exists for the current target, take the newest, read it, find last completed phase, ask: "Found plan from <date>. Last complete: <phase>. Resume or start fresh?" Update the plan file at end of each phase. Commit + push the plan file with Phase 0's commit so the user can review it via the PR/branch URL.
 
 ---
 
@@ -214,5 +492,7 @@ If `local/section-align-<target>.md` exists: read it, find last completed phase,
 - `feedback_codex_thread_replies` · `feedback_pr_review_both_repos` · `feedback_done_means_codex_clean`
 - `feedback_simplify_scope_to_section_size` · `feedback_dotnet_verbosity` · `feedback_always_use_worktree`
 - `feedback_no_direct_to_main` · `feedback_no_schedule_offers` · `feedback_todos_update_after_commits`
-- Design Rule §2a (no controller→DbContext) · §8 (table ownership) — `docs/architecture/design-rules.md`
+- Design Rule §2a (no controller→DbContext) · §2c (no cross-service table access) · §6 (no cross-domain `.Include`) · §8 (table ownership) · §11 (auth) · §12 (append-only) · §15 (caching pattern) — `docs/architecture/design-rules.md`
 - `docs/sections/SECTION-TEMPLATE.md`
+- `docs/testing/mutation-testing.md` (Stryker.NET setup, test-attribute gate)
+- `scripts/analyze-test-utility.ps1` (Stryker → high-confidence test-debt queue)

--- a/.claude/skills/section-align/SKILL.md
+++ b/.claude/skills/section-align/SKILL.md
@@ -28,10 +28,14 @@ A section is "aligned" when **all three axes hold**:
 
 ## Boundary-fix protocol
 
+**Zero-tolerance rule:** the only allowed cross-section data link going forward is the **User ↔ Profile** relationship (identity row ↔ volunteer profile). Every other cross-section read or write is a violation, including patterns previously documented as "sanctioned exceptions" in section docs (narrow display lookups like `ctx.Users.Select(u => u.DisplayName)`, `ctx.Teams.Select(t => t.Name)`, etc.). "Sanctioned" is not a category in this skill.
+
 When the inventory finds cross-section access (either direction), apply this protocol — **never just "fix the offending file" silently**, because that violates section ownership.
 
 - **We are the producer** (another section reads or writes our tables / navs into our entities): our job in THIS PR is to ensure the public API on our service satisfies the caller's need. Add the API if missing. Then flag the calling section as the next /section-align target — they own the call-site migration.
-- **We are the consumer** (we read or write into another section's tables / `.Include` across into another section's entity): flag the missing API on THEIR section. Don't fix it here. Document the gap, tolerate the current code (or fall back to a less-bad path), and surface the other section as the next /section-align target.
+- **We are the consumer** (we read or write into another section's tables / `.Include` across into another section's entity): if their public service API exists and delivers what we need, switch to it in THIS PR. If their API doesn't exist, flag their section as the next /section-align target, document the gap in our plan's follow-up list, and pause that specific fix until they're aligned. Then we come back and close out our section.
+
+Result-oriented framing: a section is **provisionally aligned** when all in-section work is done; **fully aligned** when every follow-up supplier has caught up and the last consumer-side fixes land. The Phase 4 doc polish acknowledges any provisional state by naming the pending suppliers.
 
 Output every Phase 0 plan with an explicit **Follow-up /section-align targets** list naming each section that surfaced as needing its own pass.
 
@@ -66,6 +70,22 @@ Phase 4  Doc polish — Opus; final review loop until merge-ready
 ```
 
 Sequential phases. Within a phase, parallel subagents up to **hard cap of 3** (`~/.claude-shared/shared/claude.md`). Escalate model: Sonnet for Phase 1 mechanical work → Opus for Phases 2–4.
+
+## Context discipline
+
+Phase 0 inventory reads a lot of the section's code and grows the context fast. By the time Phase 0 lands as a committed plan file, the main-session context is typically 100k–250k tokens.
+
+**Split rule:**
+1. Phase 0 runs in the initial session. End by committing + pushing the plan file under `docs/plans/<YYYY-MM-DD>-section-align-<target>.md`.
+2. **Start a fresh session (`/cls` or new conversation) before Phase 1** so impl begins on cached context.
+3. The impl session runs as an **Opus orchestrator over subagents** via the `superpowers:subagent-driven-development` pattern. The orchestrator:
+   - Reads the plan file once at the start.
+   - Stays under **100k tokens** by dispatching each plan item to a subagent.
+   - Aims to finish impl by **200k tokens**; if approaching that ceiling without convergence, commit progress and `/cls` again, resuming via the plan file.
+4. Each subagent gets one bounded job (one rename group, one boundary fix with API+caller, one test-folder reorg) and returns a 200-word summary. The orchestrator never reads subagent intermediate output — only the final summary.
+5. The closing /section-align re-run (Phase 4 tail) runs in the **same impl session** if budget allows, otherwise a third session.
+
+This keeps the orchestrator focused on plan-execution decisions; the heavy reading/editing happens in disposable subagent contexts.
 
 ## Mode detection
 
@@ -174,27 +194,56 @@ Caching belongs in the service layer **only** per §15 — either via a `Caching
 - has no Update/Delete if entity is append-only (§12)
 - lives at `Infrastructure/Repositories/<Section>/`
 
-**A2.5 ViewComponent presence and reuse.** If this section's data appears on other sections' pages (audit history on profile pages, profile cards in directories, notification meters in nav), there should be a `<Section>ViewComponent` and partial views under `Views/Shared/Components/<Section>/`. Inverse check: section pages with inline rendering of "should-be-a-VC" content (10+ lines of Razor stitching this section's data into another section's view).
+**A2.5 Shared visual components — inventory by type, ViewComponent preferred.** Cross-page UI for this section's data can live as one of three things; this skill is opinionated about which:
 
-Grep for invocations:
+| Type | Preference | Use when |
+|------|-----------|----------|
+| **ViewComponent** | ✓ preferred | Section data rendered on other sections' pages, needs DI to call section services, has parameter-driven invocation. |
+| **TagHelper** | call out | Wrap small reusable markup primitives (badges, buttons, formatters). Often candidates for promotion to ViewComponent if they take section data. |
+| **Partial view** (`_Partial.cshtml`) | call out | Acceptable for fragmenting one section's own view; **not** for cross-section reuse. Often candidates for promotion to ViewComponent if invoked across sections. |
+
+Inventory all three categories for this section:
+```bash
+git grep -ln 'ViewComponent' src/Humans.Web/ViewComponents/<Section>*.cs src/Humans.Web/ViewComponents/*<Section>*.cs
+git grep -ln 'ITagHelper\|TagHelper\b' src/Humans.Web/TagHelpers/ 2>/dev/null | grep -i <section>
+find src/Humans.Web/Views -name '_*.cshtml' | xargs grep -l '<section-related-pattern>'
+```
+
+For each shared component, classify and decide: keep, convert TagHelper→ViewComponent, convert Partial→ViewComponent, or leave (intra-section partials). Inverse check: section pages with inline rendering of "should-be-a-VC" content (10+ lines of Razor stitching this section's data into another section's view).
+
+Grep for ViewComponent invocations to verify reuse:
 ```bash
 git grep -nE '<vc:<section-kebab>|Component\.InvokeAsync\("<Section>"' src/Humans.Web/Views/
 ```
 
-**A2.6 Interface budget + segregation.** Count methods on each public interface. For each interface ≥10 methods, ensure `InterfaceMethodBudgetTests.Budgets` entry exists with current count. Beyond the budget number itself, flag:
-- Methods on the section's main service that exist only to be called by *another service within the same section* (UI plumbing leaking through the main interface — should be private or moved). Example: `IAuditLogService.GetUserDisplayNamesAsync` called only by `AuditViewerService`.
-- Multiple interfaces carrying overlapping read shapes (Service returns raw entity, ViewerService returns resolved record). Phase 3 candidate.
-- "Replace 2 methods with 1 broader bag-of-flags method" anti-pattern.
+**A2.6 Interface budget + segregation + consolidation.** Count methods on each public interface. For each interface ≥10 methods, ensure `InterfaceMethodBudgetTests.Budgets` entry exists with current count. Beyond the budget number, flag:
 
-**A2.7 Architecture test coverage.** For each service in the section, the section's `<Section>ArchitectureTests.cs` should pin:
-- Lives in `Humans.Application.Services.<Section>` namespace
-- No `DbContext` constructor parameter
-- No `IMemoryCache` constructor parameter (or has one, if caching is in-service)
-- Takes the section's repository
-- For append-only entities: repo has no Update/Delete/Remove methods
-- For sections that own DbSets: only `<Section>Repository` references `ctx.<SectionDbSet>` (Roslyn or reflection scan)
+- **Status-split methods that should be a single `GetAll()` + caller-side filter.** The canonical anti-pattern: `GetActiveUsers()`, `GetSuspendedUsers()`, `GetDeletedUsers()` instead of `GetUsers()` with callers writing `.Where(u => u.IsActive)`. At ~500-user scale most data fits in RAM; in-memory filtering is cheaper and clearer than predicate-pushed splits. Consolidate to `GetAll`/`GetByX` and let callers project. Architecture: the service holds the data; callers filter.
+- **Exception sections** where DB predicate-push genuinely matters because the dataset is large or unbounded (AuditLog, EmailOutbox, file storage indexes, anything append-only with long retention). For those, predicate-on-DB methods stay on the interface; the section doc must justify the exception explicitly under `## Architecture`.
+- **UI plumbing leaking through the main service interface** (methods that exist only to be called by *another service within the same section*). Example: `IAuditLogService.GetUserDisplayNamesAsync` called only by `AuditViewerService`. Move private, or move to the consumer.
+- **Multiple interfaces carrying overlapping read shapes** (Service returns raw entity, ViewerService returns resolved record). Phase 3 candidate.
+- **"Replace 2 methods with 1 broader bag-of-flags method"** — anti-pattern; count drops but surface grows.
 
-List missing tests. Each missing test is a Phase 2 add.
+**A2.7 Architecture test coverage — prefer generic over per-section.** Tests that apply to *every* section's same-shape class should be **one reflection-based test** over the matching interface, not a per-section copy. Prefer:
+
+| Generic test (preferred) | Replaces per-section copies |
+|--------------------------|------------------------------|
+| `IRepository_Implementations_AreAllSealed` (reflect over all `IRepository` impls) | `FooRepository_IsSealed`, `BarRepository_IsSealed`, … |
+| `Application_Services_TakeNoDbContext` (reflect over `IApplicationService` impls) | per-section `FooService_HasNoDbContextConstructorParameter` |
+| `Application_Services_TakeNoIMemoryCache_UnlessRegistered` | per-section copies |
+| `Repository_Implementations_LiveInInfrastructure` | per-section namespace tests |
+
+Section-specific tests are reserved for **section-specific invariants** that don't generalize:
+- Append-only repo shape (only some sections — `IAuditLogRepository_HasNoUpdateOrDeleteMethods`).
+- Single-writer DbSet rule (`Only<Section>Repository_References_<DbSet>` — Roslyn or reflection scan).
+- Domain-specific authorization handler shape.
+
+Phase 0 inventory:
+1. List section-specific tests in `<Section>ArchitectureTests.cs`.
+2. For each, ask: does this generalize to all sections? If yes, propose moving it to a generic test in a single shared file (e.g. `tests/Humans.Application.Tests/Architecture/Rules/RepositorySealing.cs`).
+3. List genuinely-section-specific invariants that need keeping or adding.
+
+Missing tests (in either category) are Phase 2 adds. Per-section duplicates of generic patterns are Phase 3 prunes.
 
 ### Axis 3 — test focus
 
@@ -364,7 +413,16 @@ Surface to user. If `--inventory-only`, stop. Otherwise: "Phase 0 complete. Proc
 
 ## Phase 1 — Surface alignment (axis 1)
 
-Sonnet subagents. `/reforge` for impact analysis before bulk edits. Build must stay green after each step.
+Sonnet subagents. Build must stay green after each step.
+
+**Tooling discipline (applies to all Phase 1+):**
+- **`/reforge`** before any rename, move, or interface change. The reforge skill returns the exact callers, references, and impact list so the subsequent Edit/Write is one-shot rather than iterative. Use it for: rename impact, find-references for a method, trace-call-chain when moving a route handler. **Always call /reforge before the Edit, never instead of testing after.**
+- **Long-running processes run in the background, scoped to the phase.** At phase start, kick off `dotnet build` + `dotnet test` watchers in background via `Bash run_in_background: true`; tail with `BashOutput` between commits. At phase end, stop the background processes with `KillShell`. Pattern:
+  ```bash
+  # Phase start (background)
+  dotnet watch --project Humans.slnx test -v quiet     # tail across commits
+  ```
+  Always inside the worktree. Don't leak background processes across phases or sessions.
 
 **Create what's missing** (not only rename):
 1. **Invariant doc** — `git mv docs/sections/<Old>.md docs/sections/<New>.md` if renamed.
@@ -455,6 +513,7 @@ Opus.
 
 - **Invariant doc** — verify all `SECTION-TEMPLATE.md` sections. Correct any false claims surfaced in Phase 0 (e.g., "only repo writes the table" claims that turned out false until Phase 2 fixed them — restore once truly true).
 - **Cross-Section Dependencies** — record any §6 violations still pending an upstream API (consumer-side gaps not fixable in this PR), naming the supplier section as the follow-up target.
+- **`docs/architecture/dependency-graph.md`** — update the section's inbound/outbound edges to reflect actual state after Phase 2. Add new dependencies introduced; remove ones eliminated by the cross-section fixes. The dependency graph is the at-a-glance map reviewers consult; if it's stale, alignment work is invisible.
 - **Feature specs** (`docs/features/*.md`) — match implementation; rename if section name changed.
 - **`data-model.md`** — update owned-entity index.
 - **`todos.md`** — per `feedback_todos_update_after_commits`.
@@ -463,6 +522,8 @@ Opus.
 - **`/freshness-sweep`** — if catalog covers touched docs.
 
 Push. Final bot-review loop until merge-ready. Report: PR/branch URL, commits per phase, **follow-up /section-align targets**, one-line status. Do not offer `/schedule` follow-ups (`feedback_no_schedule_offers`).
+
+**Re-run /section-align at the end** (still in the same worktree) as the closing audit. If the second run finds anything beyond the documented follow-up targets, that's leftover Phase 1–3 work — go back and finish before merging. Ideal end-state: the closing run returns "clean except for `<list of pending suppliers>`."
 
 ---
 

--- a/docs/plans/2026-05-12-section-align-auditLog.md
+++ b/docs/plans/2026-05-12-section-align-auditLog.md
@@ -1,0 +1,270 @@
+# Section Align — AuditLog (Two-Axis Re-Evaluation)
+**Run started:** 2026-05-12 | **Mode:** existing-section | **Worktree:** `H:\source\Humans\.worktrees\section-align-AuditLog`
+**Branch:** `align/auditlog` (off `origin/main` @ `760d98f2`)
+
+> **Re-evaluation note (2026-05-12):** the first pass treated convention exceptions in the section doc as closed questions and missed the second axis entirely. Peter clarified the framing:
+>
+> 1. **Boundary integrity (axis 1)** — the lines around the section. Other sections never reach across, our publics are clean, our routes/views/models are addressable under our name.
+> 2. **Internal cohesion (axis 2)** — the contents of the slice match current app standards. No EF leak from service, no caching outside service layer, proper interfaces, reusable view components, architecture-test coverage.
+>
+> **Boundary-fix protocol:** when an external section reaches across our boundary, our job is to *first* ensure the right public API exists on our service to satisfy that consumer. *Only then* do we flag the external section as needing its own /section-align. We own the API surface; they own the migration.
+>
+> Same flipped: when we reach across someone else's boundary, we flag the missing API on THEIR section. We don't fix it here — they become the next /section-align target. We document the gap and either live with the current code or fall back to a less-bad path.
+
+---
+
+## Axis 1 — Boundary integrity
+
+### 1.1 Section name consistency — names ✓, surfaces ✗
+
+Names align everywhere — folders, namespaces, interfaces, services, repo, tests, configurations, DbSet, ViewComponent partial folder. No variants.
+
+**But the section has no front door:**
+- No `AuditLogController.cs`
+- No `Views/AuditLog/` directory
+- No `/AuditLog/*` route prefix
+
+### 1.2 URL surface — **CONVENTION VIOLATION**
+
+| Current route | Host controller | Should be |
+|---------------|-----------------|-----------|
+| `GET /Board/AuditLog` | `BoardController.AuditLog` | `GET /AuditLog` on `AuditLogController.Index` |
+| `POST /Google/AuditLog/CheckDriveActivity` | `GoogleController.CheckDriveActivity` | `POST /AuditLog/CheckDriveActivity` |
+| `GET /Google/Sync/Resource/{id}/Audit` | `GoogleController.GoogleSyncResourceAudit` | `GET /AuditLog/Resource/{id}` |
+| `GET /Google/Human/{id}/SyncAudit` | `GoogleController.HumanGoogleSyncAudit` | `GET /AuditLog/Human/{id}` |
+
+`BoardController.Index` consuming `IAuditViewerService.GetRecentAsync(15)` for the dashboard activity widget is fine — that's widget consumption, not route ownership.
+
+### 1.3 Views surface — **CONVENTION VIOLATION**
+
+| Current view | Should be |
+|--------------|-----------|
+| `Views/Shared/AuditLog.cshtml` (list page) | `Views/AuditLog/Index.cshtml` |
+| `Views/Shared/GoogleSyncAudit.cshtml` (per-resource / per-user) | `Views/AuditLog/GoogleSync.cshtml` |
+| `Views/Shared/_AuditLogContent.cshtml`, `_AuditLogScripts.cshtml` | keep in Shared if Board dash reuses; else move |
+| `Views/Shared/Components/AuditLog/{Default,_Entry,_EntryList}.cshtml` | ✓ correctly placed (ViewComponent partials are genuinely shared widgets) |
+
+### 1.4 Controller-base leak — **CONVENTION VIOLATION**
+
+`Controllers/HumansControllerBase.cs:74-109` defines section-specific render helpers (`GoogleSyncAuditView`, `BuildGoogleSyncAuditViewModel`) on a generic base. Move into `AuditLogController`.
+
+### 1.5 ViewModel placement — **CONVENTION VIOLATION**
+
+`Models/AdminViewModels.cs` houses `AuditLogListViewModel` (line 219), `GoogleSyncAuditEntryViewModel` (230), `GoogleSyncAuditListViewModel` (245). Move to `Models/AuditLogViewModels.cs`.
+
+### 1.6 Extensions placement — minor violation
+
+`Extensions/AuditLogUiExtensions.cs` (Razor filter-class helpers) — should live under `Extensions/Sections/` to match the DI-wiring sibling `Extensions/Sections/AuditLogSectionExtensions.cs`.
+
+### 1.7 Inbound WRITES to `ctx.AuditLogEntries` — **CRITICAL VIOLATION (1)**
+
+Exhaustive grep across `src/`:
+
+| File:Line | Operation | Verdict |
+|-----------|-----------|---------|
+| `Infrastructure/Repositories/AuditLog/AuditLogRepository.cs` (17 sites) | reads + Add | ✓ legitimate |
+| `Infrastructure/Repositories/GoogleIntegration/DriveActivityMonitorRepository.cs:81` | `ctx.AuditLogEntries.AddRange(anomalies)` | **✗ VIOLATION** |
+| `Infrastructure/Data/HumansDbContext.cs:40` | DbSet declaration | ✓ |
+
+**Boundary-fix protocol applied:** caller bulk-writes pre-shaped `AuditLogEntry` objects. Our public surface (`IAuditLogService`) offers only single-entry `LogAsync` and `LogGoogleSyncAsync`. There's no `LogManyAsync` or anomaly-specific surface that matches the caller's batch shape.
+
+**Our job in THIS PR:** add the API the caller needs (one of):
+- (a) `IAuditLogService.LogAnomaliesAsync(IReadOnlyList<AnomalyEvent>)` — domain-specific, hides AuditLogEntry construction.
+- (b) Loop of per-entry `LogAsync` calls — no new API needed; document the call pattern explicitly.
+
+Option (b) is preferred (audit is already best-effort per-entry; batching loses no useful semantic since the "atomic with LastRunAt" rationale isn't section-grade). No new method = no IAuditLogService budget bump.
+
+**GoogleIntegration's job (next /section-align target):** switch `DriveActivityMonitorRepository.PersistAnomaliesAsync` to call through `IAuditLogService` and move the LastRunAt update to its own call (or accept that anomalies persist independently — they're best-effort).
+
+### 1.8 Inbound READS / EF joins on AuditLog — none
+
+Zero. No section reads `ctx.AuditLogEntries`, no `.Include(...Audit...)`, no LINQ traversal from outside. No entity declares an `AuditLogEntry?` nav inbound. **Boundary clean on the read side.**
+
+### 1.9 Cross-section `IAuditLogService` consumers — sink pattern working
+
+19 sections inject for writes (intentional sink). 5 inject `IAuditViewerService` for reads. All through public interfaces. This is exactly the design and not a violation.
+
+### 1.10 Controller → DbContext — clean
+
+No controller injects `HumansDbContext`.
+
+---
+
+## Axis 2 — Internal cohesion
+
+### 2.1 EF leakage from service layer — ✓ CLEAN
+
+`AuditLogService` and `AuditViewerService` both clean of `Microsoft.EntityFrameworkCore`, `IQueryable`, `DbContext`, `DbSet`, `.Where(...)`, `.Include(...)`, `.ToListAsync(...)`, `.SaveChangesAsync(...)`. Architecture test `AuditLogService_HasNoDbContextConstructorParameter` pins this.
+
+### 2.2 Caching placement — ✓ CLEAN
+
+No `IMemoryCache`/`MemoryCache`/`IDistributedCache` anywhere in service or repository. Section is small-volume and admin-only; doc justifies "no caching decorator" per §15 Option A. Architecture test `AuditLogService_HasNoIMemoryCacheConstructorParameter` pins this.
+
+### 2.3 Repository pattern — ✓ CLEAN
+
+`AuditLogRepository` is `sealed`, uses `IDbContextFactory<HumansDbContext>`, registered as Singleton. `AuditLogService` is Scoped, depends on `IAuditLogRepository`. Standard §15 shape.
+
+### 2.4 DI lifetimes — ✓ CLEAN
+
+`AuditLogSectionExtensions.AddAuditLogSection`:
+- Repository: Singleton ✓
+- Services: Scoped ✓
+- `IUserDataContributor` re-exports the scoped service ✓
+
+### 2.5 OUTBOUND cross-section access — **§6 VIOLATION** (1)
+
+`AuditLogRepository.GetGoogleSyncByUserAsync` (line 64) and `GetGoogleSyncByUserIdsAsync` (line 80):
+
+```csharp
+.Include(e => e.Resource)   // AuditLog → GoogleResource cross-domain Include
+```
+
+Violates design-rules §6 (no cross-domain `.Include`). The `Resource` nav exists on `AuditLogEntry` and points at `GoogleResource` (owned by GoogleIntegration). The repo uses it to populate `AuditEvent.ResourceName` for the GoogleSync audit view.
+
+**Boundary-fix protocol applied (we are the consumer):**
+- Does GoogleIntegration's public surface offer a batch name lookup for resources?
+- `IGoogleResourceRepository.GetByIdAsync(Guid)` exists — single, repository-layer (we shouldn't reach into another section's repo from our service).
+- No `IGoogleResourceService` exists in `Interfaces/GoogleIntegration/` (only `IGoogleSyncService`, `IGoogleRemovalNotificationService`, plus consumer-side `ITeamResourceService`/`ITeamPageService`).
+- **API gap on GoogleIntegration:** no public service-layer batch lookup `GetByIdsAsync(IReadOnlyCollection<Guid>) → Dictionary<Guid, string>` (or `(Name, …)` tuple), which is what AuditLog needs for in-memory display stitching (mirrors the pattern AuditLog already uses for User/Team names).
+
+**Disposition:**
+- THIS PR — leave the `.Include` in place; document the gap. AuditLog cannot fix this cleanly without an upstream API.
+- **GoogleIntegration becomes a /section-align target.** Its work includes: introduce `IGoogleResourceService` (or extend an existing one) with `GetByIdsAsync` for batched name resolution, then AuditLog migrates off the Include in a follow-up.
+- Flag for the AuditLog section doc: Cross-Section Dependencies should explicitly name "GoogleIntegration — currently joined via EF `Include(e => e.Resource)`; awaiting `IGoogleResourceService.GetByIdsAsync` to migrate to in-memory stitching."
+
+### 2.6 OUTBOUND cross-section access — sanctioned (1)
+
+`AuditLogRepository.GetUserDisplayNamesAsync` reads `ctx.Users`; `GetTeamNamesAsync` reads `ctx.Teams`. Both batch-load name dictionaries. The section doc owns this as a sanctioned exception ("narrow cross-table lookups behind the repository"). Could be migrated to `IUserService.GetByIdsAsync` / `ITeamService.GetTeamNamesByIdsAsync` (both exist per the doc — verify) — same pattern as the Camps section already follows for stripped navs. Pre-existing pattern; not blocking, but candidate for Phase 3 (`/simplify`) once verified those service methods deliver the right shape.
+
+### 2.7 Cross-domain navs on AuditLog entity
+
+`AuditLogEntry.ActorUser` (→ User) and `AuditLogEntry.Resource` (→ GoogleResource). Section doc claims "declared but never read" — **partly false**: `AuditLogRepository` actively uses `Resource` via Include (§2.5 above). `ActorUser` does appear unread. Phase 4 doc correction: revise the claim to "ActorUser declared but never read; Resource read by AuditLogRepository.GetGoogleSync* via Include — pending IGoogleResourceService batch API."
+
+### 2.8 Interface segregation — moderate issue
+
+| Interface | Methods | Budgeted? | Notes |
+|-----------|---------|-----------|-------|
+| `IAuditLogService` | 14 | ❌ no | 3 writes + 8 reads + 2 UI-batch helpers (`GetUserDisplayNamesAsync`, `GetTeamNamesAsync`) + 2 specialized lookups |
+| `IAuditViewerService` | 6 | n/a | wraps Service for resolved-event reads |
+| `IAuditLogRepository` | 15 | ❌ no | 1 write + 13 reads + 2 cross-table |
+
+**Issues:**
+- `IAuditLogService.GetUserDisplayNamesAsync` and `GetTeamNamesAsync` exist purely so `AuditViewerService` can call them. UI-rendering plumbing on the section's main write/read interface. Phase 3 candidate: move these private to AuditViewerService (it can inject the repo directly for those two methods, or AuditLogService keeps them but moves them to an internal helper).
+- IAuditLogService and IAuditViewerService both expose `GetRecentAsync`/`GetByResource`/`GetGoogleSyncByUser`/`GetFilteredEntries` shapes — Service returns raw `AuditLogEntry`, ViewerService returns resolved `AuditEvent`. Few callers outside AuditViewerService consume the raw-entry shape (jobs + GDPR contributor). Phase 3: trim IAuditLogService reads down to what non-UI callers actually need; route all UI reads through IAuditViewerService.
+- Both over-threshold interfaces need `InterfaceMethodBudgetTests.Budgets` entries even if Phase 3 isn't run — pin current size to start the ratchet.
+
+### 2.9 ViewComponent reuse — ✓ EXCELLENT
+
+`AuditLogViewComponent` (`src/Humans.Web/ViewComponents/AuditLogViewComponent.cs`) takes optional `entityType`/`entityId`/`userId`/`actions`/`limit`/`title`/`showCard` parameters and calls `IAuditViewerService.GetFilteredAsync`. Active usage:
+- `Views/Calendar/Event.cshtml:130`
+- `Views/Profile/AdminDetail.cshtml:218`
+- `Views/TeamAdmin/Members.cshtml:292`
+- `Views/WidgetGallery/Index.cshtml:794` (demo)
+
+Strong reuse pattern. Partials at `Views/Shared/Components/AuditLog/` properly placed.
+
+### 2.10 Architecture test coverage — partial
+
+Present:
+- ✓ `AuditLogService_LivesInHumansApplicationServicesAuditLogNamespace`
+- ✓ `AuditLogService_HasNoDbContextConstructorParameter`
+- ✓ `AuditLogService_HasNoIMemoryCacheConstructorParameter`
+- ✓ `AuditLogService_TakesRepository`
+- ✓ `AuditLogService_ConstructorTakesNoStoreType`
+- ✓ `IAuditLogRepository_LivesInApplicationInterfacesRepositoriesNamespace`
+- ✓ `AuditLogRepository_IsSealed`
+- ✓ `IAuditLogRepository_HasNoUpdateOrDeleteMethods`
+
+Missing (Phase 2 additions):
+- ✗ `AuditViewerService_HasNoDbContextConstructorParameter` (mirror for the second service)
+- ✗ `AuditViewerService_HasNoIMemoryCacheConstructorParameter`
+- ✗ `OnlyAuditLogRepository_TouchesAuditLogEntriesDbSet` — Roslyn/reflection scan over `Infrastructure/**` for any file outside `Repositories/AuditLog/` referencing `AuditLogEntries`. Would catch DriveActivityMonitorRepository.cs:81 today and prevent regressions tomorrow.
+- ✗ Interface budget entries for both over-threshold interfaces.
+
+### 2.11 Migrations — clean
+
+`20260403192839_DropAuditLogActorName.cs` is EF-generated. `20260212152552_Initial.cs` contains intentional `migrationBuilder.Sql(...)` for `prevent_audit_log_update` / `prevent_audit_log_delete` triggers — sanctioned per section doc.
+
+---
+
+## Stop conditions tripped
+
+**None blocking.** Two judgment calls for the user:
+
+1. **`AuditLogController` introduction (Phase 1)** — moves 4 routes off BoardController/GoogleController. Inbound link updates needed in views, redirects, tests. Observable URL change. Medium-size Phase 1.
+2. **GoogleResource Include retention (Phase 2)** — leave the §6 violation in place documented and wait for GoogleIntegration's section-align to provide a batch service API. Confirms the "consumer doesn't fix supplier API" protocol.
+
+---
+
+## Phase plan
+
+### Phase 1 — surface alignment (axis 1)
+
+1. Create `AuditLogController.cs` with `[Route("AuditLog")]` and section-appropriate policies (BoardOrAdmin globally, HumanAdminBoardOrAdmin on the per-user route).
+2. Move 4 route handlers (Board.AuditLog, Google.CheckDriveActivity, Google.GoogleSyncResourceAudit, Google.HumanGoogleSyncAudit) into the new controller; rename action methods to match the cleaner route shape.
+3. Create `Views/AuditLog/` and move `Views/Shared/AuditLog.cshtml` → `Index.cshtml`, `Views/Shared/GoogleSyncAudit.cshtml` → `GoogleSync.cshtml`. Evaluate `_AuditLogContent`/`_AuditLogScripts` partials — keep in `Shared` if Board dashboard reuses them; otherwise move.
+4. Move `GoogleSyncAuditView` + `BuildGoogleSyncAuditViewModel` off `HumansControllerBase` into `AuditLogController`.
+5. Move `AuditLogListViewModel`, `GoogleSyncAuditEntryViewModel`, `GoogleSyncAuditListViewModel` out of `Models/AdminViewModels.cs` into `Models/AuditLogViewModels.cs`.
+6. Move `Extensions/AuditLogUiExtensions.cs` → `Extensions/Sections/AuditLogUiExtensions.cs`.
+7. Update inbound links: `RedirectToAction(nameof(BoardController.AuditLog), "Board", ...)` (e.g. `GoogleController.cs:413`) becomes the new `AuditLogController.Index` target. Same for tag-helper links in views and any tests/nav that reference the old paths.
+8. Build + tests green after each commit. 4–6 commits expected.
+
+### Phase 2 — fix arch violations (axis 1 + axis 2)
+
+1. **Axis 2 — Add architecture test** `OnlyAuditLogRepository_TouchesAuditLogEntriesDbSet` (this PR's enforcement). Mark it `[Skip]` initially and document expected failures, OR add it red and fix in step 2 same PR. Adding it green is the goal.
+2. **Axis 1 — Inbound write boundary fix.** Decision: API surface for `DriveActivityMonitorRepository.PersistAnomaliesAsync`:
+   - Recommended path: no new API. The caller switches to per-anomaly `IAuditLogService.LogAsync` after writing LastRunAt. AuditLog gains no new method, GoogleIntegration owns the call-site change. Document in this section's plan: "GoogleIntegration is the next /section-align target — needs to switch off direct ctx.AuditLogEntries write."
+   - Alternative: add `LogAnomaliesAsync` if benchmarking shows per-call overhead matters. Pushes IAuditLogService 14 → 15; needs budget entry.
+3. **Axis 2 — Add architecture tests** for `AuditViewerService`: no DbContext, no IMemoryCache (mirror the AuditLogService tests).
+4. **Axis 2 — Add `InterfaceMethodBudgetTests.Budgets` entries** for `IAuditLogService` (14) and `IAuditLogRepository` (15), with current counts.
+
+### Phase 3 — /simplify (axis 2)
+
+- Move UI display-name helpers (`GetUserDisplayNamesAsync`, `GetTeamNamesAsync`) off `IAuditLogService`. They exist only for `AuditViewerService`; can become internal helpers or move to ViewerService (which then takes `IUserService.GetByIdsAsync` / `ITeamService.GetTeamNamesByIdsAsync` directly).
+- Trim `IAuditLogService` read methods that aren't consumed outside the section. Candidates: `GetByResourceAsync`, `GetGoogleSyncByUserAsync`, `GetFilteredAsync`, `GetByUserAsync`, `GetFilteredEntriesAsync` — verify each has at least one non-AuditViewerService caller before removing.
+- Migrate `AuditLogRepository.GetUserDisplayNamesAsync` / `GetTeamNamesAsync` off direct `ctx.Users`/`ctx.Teams` reads, onto `IUserService.GetByIdsAsync` / `ITeamService.GetTeamNamesByIdsAsync` if those service methods deliver the right shape. Removes two cross-table §6-adjacent reads (sanctioned but cleanable).
+- Lower volume target (section is small).
+
+### Phase 4 — doc polish
+
+- AuditLog.md § Routing — rewrite around `AuditLogController` after Phase 1.
+- AuditLog.md § Architecture — once Phase 2 fixes land in this PR, restore "only AuditLogRepository touches ctx.AuditLogEntries" (now actually true and test-pinned).
+- AuditLog.md § Negative Access Rules — same.
+- AuditLog.md § Cross-Section Dependencies — note GoogleResource Include as a known §6 violation pending `IGoogleResourceService.GetByIdsAsync`.
+- AuditLog.md § Data Model — correct the "ActorUser and Resource navs declared but never read" claim — `Resource` is read by AuditLogRepository.GetGoogleSync*.
+
+---
+
+## Follow-up /section-align targets surfaced by this run
+
+- **GoogleIntegration** — needs to (a) introduce `IGoogleResourceService` (or extend an existing service) with a batched `GetByIdsAsync` returning name dictionary, and (b) switch `DriveActivityMonitorRepository.PersistAnomaliesAsync` off direct `ctx.AuditLogEntries` writes.
+
+---
+
+## Skill gaps surfaced by this re-evaluation
+
+Items the current skill misses that the two-axis framing demands:
+
+### Axis 1 (boundary) gaps
+1. **Controller existence check** — does `<Section>Controller` exist? Routes hosted elsewhere = drift.
+2. **`Views/<Section>/` folder check** — section-owned page views in `Views/Shared/` = drift unless they are true cross-section partials.
+3. **ViewModel placement check** — section ViewModels in `Models/<Section>ViewModels.cs` or `Models/<Section>/`; types in grab-bag files (`AdminViewModels.cs`) = drift.
+4. **Controller-base leak check** — section-specific helpers on `HumansControllerBase` (or equivalent) = drift.
+5. **`Extensions/Sections/` placement** — section helpers should live under `Extensions/Sections/`, not the Extensions root.
+6. **Write-side cross-section DB access** — current regex hunts only reads (`Where|FirstOrDefault|FindAsync|ToListAsync`). Add writes (`Add|AddRange|Update|Remove|Attach`) and pure `DbSet` references.
+7. **EF nav inbound** — search other entities for navs pointing AT this section's entities.
+8. **Don't trust the section doc's exceptions** — when the doc declares "served from two controllers — required because…", treat as drift to evaluate, not as a closed question. The doc records what exists; it doesn't sanctify convention violations.
+
+### Axis 2 (internal cohesion) gaps — entirely absent today
+9. **EF leakage from service layer** — grep the section's `Application/Services/<Section>/**` for `Microsoft.EntityFrameworkCore`, `IQueryable`, `DbContext`, `DbSet`, EF query operators. Architecture test should pin if missing.
+10. **Caching placement** — grep service layer + repo + controllers for `IMemoryCache`/`MemoryCache`/`IDistributedCache`. Caching belongs in the service layer per §15 (decorator or inline `IMemoryCache`); never in repos or controllers.
+11. **DI lifetimes** — verify `<Section>SectionExtensions` registers repo as Singleton (factory-based), services as Scoped, decorator as Singleton if applicable.
+12. **Architecture test coverage** — for each service in the section, ensure tests pin: lives in correct namespace, has no DbContext ctor param, has no IMemoryCache ctor param, takes the repository. For each over-threshold interface, ensure InterfaceMethodBudgetTests has an entry.
+13. **ViewComponent reuse** — for sections whose data is rendered on other sections' pages (audit history, profile cards, notification meters), verify a `<Section>ViewComponent` exists and is invoked from the host views. Inverse check: section pages that bake in inline rendering of "should-be-a-VC" content.
+14. **Interface segregation** — flag plumbing methods that exist solely for one consumer ("`GetUserDisplayNamesAsync` is called only by `AuditViewerService`, move it private").
+
+### Boundary-fix protocol gap
+15. The skill currently treats cross-section DB access as "fix the offending file." The correct protocol is:
+    - **We are the producer (someone reads/writes our tables):** our job is to ensure the public API on our service satisfies the caller's need. Add it if missing (in THIS PR). Then flag the calling section as the next /section-align target — they own the migration.
+    - **We are the consumer (we cross into someone else's tables/nav):** flag the API gap on THEIR section. Don't fix it here — they're the next /section-align target. Document the gap and either tolerate the current code or fall back to a less-bad path.
+    - Never "we'll just fix the caller's file" — that violates the section ownership model and lets one section silently mutate another.

--- a/docs/plans/2026-05-12-section-align-auditLog.md
+++ b/docs/plans/2026-05-12-section-align-auditLog.md
@@ -1,15 +1,13 @@
-# Section Align — AuditLog (Two-Axis Re-Evaluation)
+# Section Align — AuditLog
 **Run started:** 2026-05-12 | **Mode:** existing-section | **Worktree:** `H:\source\Humans\.worktrees\section-align-AuditLog`
 **Branch:** `align/auditlog` (off `origin/main` @ `760d98f2`)
 
-> **Re-evaluation note (2026-05-12):** the first pass treated convention exceptions in the section doc as closed questions and missed the second axis entirely. Peter clarified the framing:
->
-> 1. **Boundary integrity (axis 1)** — the lines around the section. Other sections never reach across, our publics are clean, our routes/views/models are addressable under our name.
-> 2. **Internal cohesion (axis 2)** — the contents of the slice match current app standards. No EF leak from service, no caching outside service layer, proper interfaces, reusable view components, architecture-test coverage.
->
-> **Boundary-fix protocol:** when an external section reaches across our boundary, our job is to *first* ensure the right public API exists on our service to satisfy that consumer. *Only then* do we flag the external section as needing its own /section-align. We own the API surface; they own the migration.
->
-> Same flipped: when we reach across someone else's boundary, we flag the missing API on THEIR section. We don't fix it here — they become the next /section-align target. We document the gap and either live with the current code or fall back to a less-bad path.
+Phase 0 inventory across three axes per `.claude/skills/section-align/SKILL.md`:
+1. **Boundary integrity** — clean section name, addressable routes/views/models, no cross-section DB access (except User ↔ Profile).
+2. **Internal cohesion** — no EF leak from service layer, caching only in service layer, proper interfaces, reusable ViewComponents, architecture-test coverage.
+3. **Test focus** — section-aligned tests in one canonical folder, 1-to-1 production-class to test-file mapping, coverage maps to invariants/negatives/triggers, redundancy pruned.
+
+Boundary-fix protocol: producers own the API surface; consumers own the call site. When we can't fix our consumer-side cross-section access because the supplier doesn't have the API yet, we flag the supplier as a follow-up /section-align target and the section becomes **provisionally aligned**.
 
 ---
 
@@ -132,54 +130,70 @@ Violates design-rules §6 (no cross-domain `.Include`). The `Resource` nav exist
 - **GoogleIntegration becomes a /section-align target.** Its work includes: introduce `IGoogleResourceService` (or extend an existing one) with `GetByIdsAsync` for batched name resolution, then AuditLog migrates off the Include in a follow-up.
 - Flag for the AuditLog section doc: Cross-Section Dependencies should explicitly name "GoogleIntegration — currently joined via EF `Include(e => e.Resource)`; awaiting `IGoogleResourceService.GetByIdsAsync` to migrate to in-memory stitching."
 
-### 2.6 OUTBOUND cross-section access — sanctioned (1)
+### 2.6 OUTBOUND cross-section access — **§2c VIOLATIONS** (2) — fix now
 
-`AuditLogRepository.GetUserDisplayNamesAsync` reads `ctx.Users`; `GetTeamNamesAsync` reads `ctx.Teams`. Both batch-load name dictionaries. The section doc owns this as a sanctioned exception ("narrow cross-table lookups behind the repository"). Could be migrated to `IUserService.GetByIdsAsync` / `ITeamService.GetTeamNamesByIdsAsync` (both exist per the doc — verify) — same pattern as the Camps section already follows for stripped navs. Pre-existing pattern; not blocking, but candidate for Phase 3 (`/simplify`) once verified those service methods deliver the right shape.
+Zero-tolerance rule (updated 2026-05-12): only User ↔ Profile cross-section access is allowed. The previously-"sanctioned" reads are now violations.
 
-### 2.7 Cross-domain navs on AuditLog entity
+| File:Line | Read | Disposition |
+|-----------|------|-------------|
+| `AuditLogRepository.GetUserDisplayNamesAsync` (line 221) | `ctx.Users.Where(u => userIds.Contains(u.Id)).Select(...)` | **Phase 2 fix.** Move the resolution out of the Infrastructure repo into `AuditLogService` (Application layer); have the service call `IUserService.GetByIdsAsync(IReadOnlyList<Guid>)`. Verify the return shape includes `DisplayName`; if not, **Users section is a follow-up target** to expose the right shape. |
+| `AuditLogRepository.GetTeamNamesAsync` (line 234) | `ctx.Teams.Where(t => teamIds.Contains(t.Id)).Select(...)` | **Phase 2 fix.** Same shape: lift to `AuditLogService` calling `ITeamService.GetTeamNamesByIdsAsync` (referenced in Camps section doc as the existing pattern). Verify shape `Dictionary<Guid, (Name, Slug)>`; if not, **Teams section is a follow-up target**. |
 
-`AuditLogEntry.ActorUser` (→ User) and `AuditLogEntry.Resource` (→ GoogleResource). Section doc claims "declared but never read" — **partly false**: `AuditLogRepository` actively uses `Resource` via Include (§2.5 above). `ActorUser` does appear unread. Phase 4 doc correction: revise the claim to "ActorUser declared but never read; Resource read by AuditLogRepository.GetGoogleSync* via Include — pending IGoogleResourceService batch API."
+Side effect: `AuditLogRepository` drops two methods (15 → 13); both cross-table helpers move into `AuditLogService` as private compose-step + service-call. `IAuditLogService` surface unchanged (still exposes `GetUserDisplayNamesAsync`/`GetTeamNamesAsync` for `AuditViewerService` to consume — these now delegate to the cross-section service calls instead of the repo).
 
-### 2.8 Interface segregation — moderate issue
+### 2.7 Cross-domain navs on AuditLog entity — fix now
+
+| Nav | Status | Disposition |
+|-----|--------|-------------|
+| `AuditLogEntry.ActorUser` (→ User) | Declared, never read | **Phase 2 delete.** Drop the nav; keep `ActorUserId` scalar FK. EF config `OnDelete: SetNull` already present and stays. |
+| `AuditLogEntry.Resource` (→ GoogleResource) | Read by `AuditLogRepository.GetGoogleSyncByUserAsync` (line 64) and `GetGoogleSyncByUserIdsAsync` (line 80) via `.Include` | **§6 violation, blocked.** Cannot delete until `.Include` is removed. `.Include` cannot be removed until GoogleIntegration exposes batched name resolution. **Follow-up: GoogleIntegration.** Section becomes provisionally aligned; we return here to close out once GoogleIntegration ships `IGoogleResourceService.GetByIdsAsync` (or equivalent). |
+
+### 2.8 Interface segregation + consolidation evaluation
 
 | Interface | Methods | Budgeted? | Notes |
 |-----------|---------|-----------|-------|
-| `IAuditLogService` | 14 | ❌ no | 3 writes + 8 reads + 2 UI-batch helpers (`GetUserDisplayNamesAsync`, `GetTeamNamesAsync`) + 2 specialized lookups |
+| `IAuditLogService` | 14 | ❌ no | 3 writes + 8 reads + 2 cross-section display helpers + 2 specialized lookups |
 | `IAuditViewerService` | 6 | n/a | wraps Service for resolved-event reads |
-| `IAuditLogRepository` | 15 | ❌ no | 1 write + 13 reads + 2 cross-table |
+| `IAuditLogRepository` | 15 → 13 after §2.6 | ❌ no | 1 write + reads (cross-table helpers removed in Phase 2) |
 
 **Issues:**
-- `IAuditLogService.GetUserDisplayNamesAsync` and `GetTeamNamesAsync` exist purely so `AuditViewerService` can call them. UI-rendering plumbing on the section's main write/read interface. Phase 3 candidate: move these private to AuditViewerService (it can inject the repo directly for those two methods, or AuditLogService keeps them but moves them to an internal helper).
-- IAuditLogService and IAuditViewerService both expose `GetRecentAsync`/`GetByResource`/`GetGoogleSyncByUser`/`GetFilteredEntries` shapes — Service returns raw `AuditLogEntry`, ViewerService returns resolved `AuditEvent`. Few callers outside AuditViewerService consume the raw-entry shape (jobs + GDPR contributor). Phase 3: trim IAuditLogService reads down to what non-UI callers actually need; route all UI reads through IAuditViewerService.
-- Both over-threshold interfaces need `InterfaceMethodBudgetTests.Budgets` entries even if Phase 3 isn't run — pin current size to start the ratchet.
+- **Consolidation check (axis 2.6 anti-pattern):** AuditLog has many `GetByUser` / `GetGoogleSyncByUser` / `GetFiltered` / `GetByResource` methods rather than `GetAll().Where(...)`. **This section is one of the legitimate exceptions** — `audit_log` is a large append-only table where predicate-push to DB is required (~96 writers across the app, retention is indefinite). Keep the predicate-pushed reads on the interface; the section doc must justify this under `## Architecture` (Phase 4 doc add).
+- **UI plumbing on the main interface:** `IAuditLogService.GetUserDisplayNamesAsync` / `GetTeamNamesAsync` exist only so `AuditViewerService` can call them. After §2.6's move (resolution out of repo, into service), these become thin facade methods. Phase 3 candidate: move them private to AuditViewerService.
+- **Read-shape duplication between Service and ViewerService** — Service returns raw `AuditLogEntry`, ViewerService returns resolved `AuditEvent`. Few callers outside ViewerService consume raw entries (jobs + GDPR contributor). Phase 3: trim Service reads down to what non-UI callers need.
+- **Budget entries (Phase 2 add):** `InterfaceMethodBudgetTests.Budgets` entries for `IAuditLogService` (14) and `IAuditLogRepository` (post-§2.6 count, expected 13).
 
-### 2.9 ViewComponent reuse — ✓ EXCELLENT
+### 2.9 Shared visual components — inventory by type
 
-`AuditLogViewComponent` (`src/Humans.Web/ViewComponents/AuditLogViewComponent.cs`) takes optional `entityType`/`entityId`/`userId`/`actions`/`limit`/`title`/`showCard` parameters and calls `IAuditViewerService.GetFilteredAsync`. Active usage:
-- `Views/Calendar/Event.cshtml:130`
-- `Views/Profile/AdminDetail.cshtml:218`
-- `Views/TeamAdmin/Members.cshtml:292`
-- `Views/WidgetGallery/Index.cshtml:794` (demo)
+| Type | Component | Location | Verdict |
+|------|-----------|----------|---------|
+| **ViewComponent** ✓ preferred | `AuditLogViewComponent` | `src/Humans.Web/ViewComponents/AuditLogViewComponent.cs` | Keep. Strong reuse (Calendar/Event, Profile/AdminDetail, TeamAdmin/Members, WidgetGallery demo). Partials at `Views/Shared/Components/AuditLog/{Default,_Entry,_EntryList}.cshtml`. Wired to `IAuditViewerService.GetFilteredAsync`. |
+| **TagHelper** | none for AuditLog | — | n/a |
+| **Partial view** | `Views/Shared/_AuditLogContent.cshtml`, `_AuditLogScripts.cshtml` | Shared root | **Evaluate.** Used by `Views/Shared/AuditLog.cshtml` (the list page). If only the list page uses these, they should move with the page into `Views/AuditLog/_Content.cshtml` and `_Scripts.cshtml` (intra-section partials, not cross-section shared). Phase 1 verification step. |
 
-Strong reuse pattern. Partials at `Views/Shared/Components/AuditLog/` properly placed.
+The ViewComponent dominates the cross-section render path. No conversion candidates (no TagHelpers wrapping audit data, no cross-section partials).
 
-### 2.10 Architecture test coverage — partial
+### 2.10 Architecture test coverage — partial, plus per-section duplication to generalize
 
 Present:
-- ✓ `AuditLogService_LivesInHumansApplicationServicesAuditLogNamespace`
-- ✓ `AuditLogService_HasNoDbContextConstructorParameter`
-- ✓ `AuditLogService_HasNoIMemoryCacheConstructorParameter`
-- ✓ `AuditLogService_TakesRepository`
-- ✓ `AuditLogService_ConstructorTakesNoStoreType`
-- ✓ `IAuditLogRepository_LivesInApplicationInterfacesRepositoriesNamespace`
-- ✓ `AuditLogRepository_IsSealed`
-- ✓ `IAuditLogRepository_HasNoUpdateOrDeleteMethods`
+- ✓ `AuditLogService_LivesInHumansApplicationServicesAuditLogNamespace` — **per-section duplicate** of a generalizable pattern
+- ✓ `AuditLogService_HasNoDbContextConstructorParameter` — **per-section duplicate** (every section's service has the same constraint)
+- ✓ `AuditLogService_HasNoIMemoryCacheConstructorParameter` — **per-section duplicate**
+- ✓ `AuditLogService_TakesRepository` — **per-section duplicate**
+- ✓ `AuditLogService_ConstructorTakesNoStoreType` — **per-section duplicate**
+- ✓ `IAuditLogRepository_LivesInApplicationInterfacesRepositoriesNamespace` — **per-section duplicate**
+- ✓ `AuditLogRepository_IsSealed` — **per-section duplicate** — Peter explicitly called out: should become a generic `IRepository_Implementations_AreAllSealed` reflecting over every `IRepository` impl
+- ✓ `IAuditLogRepository_HasNoUpdateOrDeleteMethods` — **section-specific** (append-only invariant; keep)
 
-Missing (Phase 2 additions):
-- ✗ `AuditViewerService_HasNoDbContextConstructorParameter` (mirror for the second service)
-- ✗ `AuditViewerService_HasNoIMemoryCacheConstructorParameter`
-- ✗ `OnlyAuditLogRepository_TouchesAuditLogEntriesDbSet` — Roslyn/reflection scan over `Infrastructure/**` for any file outside `Repositories/AuditLog/` referencing `AuditLogEntries`. Would catch DriveActivityMonitorRepository.cs:81 today and prevent regressions tomorrow.
-- ✗ Interface budget entries for both over-threshold interfaces.
+Missing (Phase 2 additions, section-specific):
+- ✗ `Only<Section>Repository_References_AuditLogEntries_DbSet` — Roslyn/reflection scan; catches DriveActivityMonitorRepository.cs:81 today and prevents regression. Append-only-DbSet sole-writer rule is section-specific.
+
+Missing (Phase 2 additions, **as new generic tests** in `tests/Humans.Application.Tests/Architecture/Rules/`):
+- ✗ `Application_Services_TakeNoDbContext` — reflect over all `IApplicationService` impls
+- ✗ `Application_Services_TakeNoIMemoryCache_UnlessRegistered` — same
+- ✗ `IRepository_Implementations_AreAllSealed` — reflect over all `IRepository` impls
+- ✗ `Repository_Implementations_LiveInInfrastructureRepositories` — namespace check across all repos
+
+Phase 3 prune: once the generic tests exist and pass, delete the per-section `AuditLogService_*` / `AuditLogRepository_IsSealed` duplicates. Section-specific arch tests retained: append-only repo shape, sole-writer DbSet rule.
 
 ### 2.11 Migrations — clean
 
@@ -196,9 +210,16 @@ Missing (Phase 2 additions):
 
 ---
 
+## Tooling & process for impl
+
+- **Worktree:** `H:\source\Humans\.worktrees\section-align-AuditLog\`. All commands run from there. Branch `align/auditlog` already pushed.
+- **/reforge** before any rename, move, or interface signature change. Use `reforge references`, `reforge callers`, `reforge call-chain` to get the exact impact set before editing. If the binary isn't installed, the new `.claude/skills/reforge/SKILL.md` will prompt for install permission.
+- **Background processes**: at the start of each phase, kick off `dotnet watch test` in background; tail with `BashOutput` between commits. `KillShell` at phase end. Don't leak background watchers across phases.
+- **Subagent orchestration**: Phase 1+ runs as an **Opus orchestrator over Sonnet subagents** in a fresh `/cls` session. Orchestrator stays under 100k tokens; each subagent gets one bounded job and returns a 200-word summary. See `.claude/skills/section-align/SKILL.md` § "Context discipline."
+
 ## Phase plan
 
-### Phase 1 — surface alignment (axis 1)
+### Phase 1 — surface alignment (axis 1 + axis 3 mechanical)
 
 1. Create `AuditLogController.cs` with `[Route("AuditLog")]` and section-appropriate policies (BoardOrAdmin globally, HumanAdminBoardOrAdmin on the per-user route).
 2. Move 4 route handlers (Board.AuditLog, Google.CheckDriveActivity, Google.GoogleSyncResourceAudit, Google.HumanGoogleSyncAudit) into the new controller; rename action methods to match the cleaner route shape.
@@ -209,62 +230,55 @@ Missing (Phase 2 additions):
 7. Update inbound links: `RedirectToAction(nameof(BoardController.AuditLog), "Board", ...)` (e.g. `GoogleController.cs:413`) becomes the new `AuditLogController.Index` target. Same for tag-helper links in views and any tests/nav that reference the old paths.
 8. Build + tests green after each commit. 4–6 commits expected.
 
-### Phase 2 — fix arch violations (axis 1 + axis 2)
+### Phase 2 — fix arch violations + boundary protocol
 
-1. **Axis 2 — Add architecture test** `OnlyAuditLogRepository_TouchesAuditLogEntriesDbSet` (this PR's enforcement). Mark it `[Skip]` initially and document expected failures, OR add it red and fix in step 2 same PR. Adding it green is the goal.
-2. **Axis 1 — Inbound write boundary fix.** Decision: API surface for `DriveActivityMonitorRepository.PersistAnomaliesAsync`:
-   - Recommended path: no new API. The caller switches to per-anomaly `IAuditLogService.LogAsync` after writing LastRunAt. AuditLog gains no new method, GoogleIntegration owns the call-site change. Document in this section's plan: "GoogleIntegration is the next /section-align target — needs to switch off direct ctx.AuditLogEntries write."
-   - Alternative: add `LogAnomaliesAsync` if benchmarking shows per-call overhead matters. Pushes IAuditLogService 14 → 15; needs budget entry.
-3. **Axis 2 — Add architecture tests** for `AuditViewerService`: no DbContext, no IMemoryCache (mirror the AuditLogService tests).
-4. **Axis 2 — Add `InterfaceMethodBudgetTests.Budgets` entries** for `IAuditLogService` (14) and `IAuditLogRepository` (15), with current counts.
+Order matters — boundary fixes that depend on supplier APIs go last in case they get blocked.
 
-### Phase 3 — /simplify (axis 2)
+1. **Axis 1 — Inbound write boundary (DriveActivityMonitorRepository.cs:81).** Our API: `IAuditLogService.LogAsync` already covers per-entry writes; no new method needed. AuditLog work in this PR: none beyond documenting. **Follow-up target: GoogleIntegration** (owns switching `PersistAnomaliesAsync` off direct `ctx.AuditLogEntries`).
+2. **Axis 1 — Outbound cross-section reads (§2.6).** Verify `IUserService.GetByIdsAsync` returns display names and `ITeamService.GetTeamNamesByIdsAsync` returns `(Name, Slug)`. Use `/reforge members IUserService` and `/reforge members ITeamService` to confirm. If yes, lift `GetUserDisplayNamesAsync`/`GetTeamNamesAsync` out of `AuditLogRepository` into `AuditLogService` calling the cross-section services. If either shape is wrong, **flag that section as a follow-up** and pause this specific fix.
+3. **Axis 1 — Cross-domain nav delete (§2.7).** Drop `AuditLogEntry.ActorUser` nav (unread). Keep `AuditLogEntry.Resource` nav — blocked on GoogleIntegration follow-up.
+4. **Axis 2 — Section-specific arch tests.** Add `Only<Section>Repository_References_AuditLogEntries_DbSet` (Roslyn or reflection scan). Adding it green is the goal — it should be green after step 1 documents and follow-up routing puts the call-site fix on GoogleIntegration's plate. *(Note: the test will go red until GoogleIntegration migrates. Decide: gate this test on follow-up completion vs ship with a tracking comment.)*
+5. **Axis 2 — Generic arch tests (new, lift from per-section duplicates).** In `tests/Humans.Application.Tests/Architecture/Rules/`: `IRepository_Implementations_AreAllSealed`, `Application_Services_TakeNoDbContext`, `Application_Services_TakeNoIMemoryCache_UnlessRegistered`, `Repository_Implementations_LiveInInfrastructureRepositories`. These benefit every section, not just AuditLog.
+6. **Axis 2 — `AuditViewerService` arch test pair** (no DbContext, no IMemoryCache) — only needed if step 5's generic tests don't cover it via interface reflection. Likely covered; delete this step in that case.
+7. **Axis 2 — `InterfaceMethodBudgetTests.Budgets` entries** for `IAuditLogService` (14) and `IAuditLogRepository` (final post-§2.6 count, expected 13).
+8. **Axis 3 — Missing test coverage.** Per A3.2 coverage map: add tests for invariants/negatives/triggers that don't have one. Specifically:
+   - Append-only invariant — direct DbSet write rejected (covered at DB by trigger; an arch test now covers it at compile time too via step 4).
+   - Self-persisting semantics — `LogAsync` saves immediately without caller `SaveChanges`.
+   - Best-effort — `LogAsync` swallows repo failures and logs at Error.
+   - Cross-merge chain-follow — `GetByUserAsync` surfaces source-tombstone rows for the fold target.
+9. **Axis 3 — Add missing 1-to-1 unit-test file.** `AuditLogRepositoryTests.cs` doesn't exist (only `AuditLogArchitectureTests`). Add a minimal happy-path test file or document why none is needed.
+10. **Axis 3 — Split bundled-class test file.** `AuditEventRenderTests.cs` covers `AuditEvent` + `AuditEventTextualizer` — split into `AuditEventTests.cs` + `AuditEventTextualizerTests.cs`.
 
-- Move UI display-name helpers (`GetUserDisplayNamesAsync`, `GetTeamNamesAsync`) off `IAuditLogService`. They exist only for `AuditViewerService`; can become internal helpers or move to ViewerService (which then takes `IUserService.GetByIdsAsync` / `ITeamService.GetTeamNamesByIdsAsync` directly).
-- Trim `IAuditLogService` read methods that aren't consumed outside the section. Candidates: `GetByResourceAsync`, `GetGoogleSyncByUserAsync`, `GetFilteredAsync`, `GetByUserAsync`, `GetFilteredEntriesAsync` — verify each has at least one non-AuditViewerService caller before removing.
-- Migrate `AuditLogRepository.GetUserDisplayNamesAsync` / `GetTeamNamesAsync` off direct `ctx.Users`/`ctx.Teams` reads, onto `IUserService.GetByIdsAsync` / `ITeamService.GetTeamNamesByIdsAsync` if those service methods deliver the right shape. Removes two cross-table §6-adjacent reads (sanctioned but cleanable).
-- Lower volume target (section is small).
+### Phase 3 — /simplify
+
+- **Per-section arch test prune** — after step 5 above lands, delete per-section duplicates: `AuditLogService_HasNoDbContextConstructorParameter`, `AuditLogService_HasNoIMemoryCacheConstructorParameter`, `AuditLogService_TakesRepository`, `AuditLogService_ConstructorTakesNoStoreType`, `AuditLogService_LivesInHumansApplicationServicesAuditLogNamespace`, `AuditLogRepository_IsSealed`, `IAuditLogRepository_LivesInApplicationInterfacesRepositoriesNamespace`. Keep `IAuditLogRepository_HasNoUpdateOrDeleteMethods` (section-specific append-only invariant). Net test-attribute delta: substantial negative.
+- Move display-name helpers private (`AuditViewerService` owns them after §2.6 has lifted resolution into `AuditLogService`).
+- Trim `IAuditLogService` reads not consumed outside `AuditViewerService` (verify with `/reforge callers IAuditLogService.<method>` per candidate).
+- **Stryker probe** — propose creating `tests/Humans.Application.Tests/stryker-auditlog-config.json` mirroring the Profile-section probe pattern. Run `analyze-test-utility.ps1` against the resulting report. Prune from the High-Confidence queue.
+- Move list-page partials (`_AuditLogContent`, `_AuditLogScripts`) from `Views/Shared/` into `Views/AuditLog/` if they aren't reused by the Board dashboard (Phase 1 already split this open).
 
 ### Phase 4 — doc polish
 
-- AuditLog.md § Routing — rewrite around `AuditLogController` after Phase 1.
-- AuditLog.md § Architecture — once Phase 2 fixes land in this PR, restore "only AuditLogRepository touches ctx.AuditLogEntries" (now actually true and test-pinned).
-- AuditLog.md § Negative Access Rules — same.
-- AuditLog.md § Cross-Section Dependencies — note GoogleResource Include as a known §6 violation pending `IGoogleResourceService.GetByIdsAsync`.
-- AuditLog.md § Data Model — correct the "ActorUser and Resource navs declared but never read" claim — `Resource` is read by AuditLogRepository.GetGoogleSync*.
+- `docs/sections/AuditLog.md § Routing` — rewrite around `AuditLogController`.
+- `docs/sections/AuditLog.md § Architecture` — restore "only `AuditLogRepository` touches `ctx.AuditLogEntries`" once it's truly true and test-pinned. Add the predicate-pushed-reads exception justification (axis 2.6 — large-dataset section).
+- `docs/sections/AuditLog.md § Negative Access Rules` — same.
+- `docs/sections/AuditLog.md § Cross-Section Dependencies` — explicit "GoogleIntegration: `AuditLogEntry.Resource` Include retained pending `IGoogleResourceService.GetByIdsAsync`" + "Users: display names via `IUserService.GetByIdsAsync`" + "Teams: names via `ITeamService.GetTeamNamesByIdsAsync`."
+- `docs/sections/AuditLog.md § Data Model` — correct entity-nav claims: `ActorUser` deleted; `Resource` retained, awaiting GoogleIntegration.
+- **`docs/architecture/dependency-graph.md`** — update AuditLog node's outbound edges to: IUserService (display names), ITeamService (team names), GoogleResource Include (pending — flag as provisional). Remove any references to direct `ctx.Users`/`ctx.Teams` reads.
+- **Closing /section-align re-run** — same worktree, same impl session if budget allows. Should return: "clean except for [GoogleIntegration follow-up]."
 
 ---
 
 ## Follow-up /section-align targets surfaced by this run
 
-- **GoogleIntegration** — needs to (a) introduce `IGoogleResourceService` (or extend an existing service) with a batched `GetByIdsAsync` returning name dictionary, and (b) switch `DriveActivityMonitorRepository.PersistAnomaliesAsync` off direct `ctx.AuditLogEntries` writes.
+- **GoogleIntegration** — (a) introduce `IGoogleResourceService` (or extend an existing service) with batched `GetByIdsAsync` returning name dictionary so AuditLog can drop the `Include(e => e.Resource)`. (b) Switch `DriveActivityMonitorRepository.PersistAnomaliesAsync` off direct `ctx.AuditLogEntries` writes onto `IAuditLogService.LogAsync` per-anomaly.
+- **Users** — verify `IUserService.GetByIdsAsync` returns a display-name dictionary shape suitable for AuditLog's display stitching. If not, add or extend that method. (Likely already correct — Camps section align previously consumed it. Verify in Phase 2 step 2.)
+- **Teams** — verify `ITeamService.GetTeamNamesByIdsAsync` exists and returns `Dictionary<Guid, (Name, Slug)>`. (Referenced in Camps section doc as the canonical pattern. Verify in Phase 2 step 2.)
+
+Section status after this PR lands: **provisionally aligned** — fully aligned once GoogleIntegration ships its follow-up and we return to drop the Include + Resource nav.
 
 ---
 
-## Skill gaps surfaced by this re-evaluation
+## Status
 
-Items the current skill misses that the two-axis framing demands:
-
-### Axis 1 (boundary) gaps
-1. **Controller existence check** — does `<Section>Controller` exist? Routes hosted elsewhere = drift.
-2. **`Views/<Section>/` folder check** — section-owned page views in `Views/Shared/` = drift unless they are true cross-section partials.
-3. **ViewModel placement check** — section ViewModels in `Models/<Section>ViewModels.cs` or `Models/<Section>/`; types in grab-bag files (`AdminViewModels.cs`) = drift.
-4. **Controller-base leak check** — section-specific helpers on `HumansControllerBase` (or equivalent) = drift.
-5. **`Extensions/Sections/` placement** — section helpers should live under `Extensions/Sections/`, not the Extensions root.
-6. **Write-side cross-section DB access** — current regex hunts only reads (`Where|FirstOrDefault|FindAsync|ToListAsync`). Add writes (`Add|AddRange|Update|Remove|Attach`) and pure `DbSet` references.
-7. **EF nav inbound** — search other entities for navs pointing AT this section's entities.
-8. **Don't trust the section doc's exceptions** — when the doc declares "served from two controllers — required because…", treat as drift to evaluate, not as a closed question. The doc records what exists; it doesn't sanctify convention violations.
-
-### Axis 2 (internal cohesion) gaps — entirely absent today
-9. **EF leakage from service layer** — grep the section's `Application/Services/<Section>/**` for `Microsoft.EntityFrameworkCore`, `IQueryable`, `DbContext`, `DbSet`, EF query operators. Architecture test should pin if missing.
-10. **Caching placement** — grep service layer + repo + controllers for `IMemoryCache`/`MemoryCache`/`IDistributedCache`. Caching belongs in the service layer per §15 (decorator or inline `IMemoryCache`); never in repos or controllers.
-11. **DI lifetimes** — verify `<Section>SectionExtensions` registers repo as Singleton (factory-based), services as Scoped, decorator as Singleton if applicable.
-12. **Architecture test coverage** — for each service in the section, ensure tests pin: lives in correct namespace, has no DbContext ctor param, has no IMemoryCache ctor param, takes the repository. For each over-threshold interface, ensure InterfaceMethodBudgetTests has an entry.
-13. **ViewComponent reuse** — for sections whose data is rendered on other sections' pages (audit history, profile cards, notification meters), verify a `<Section>ViewComponent` exists and is invoked from the host views. Inverse check: section pages that bake in inline rendering of "should-be-a-VC" content.
-14. **Interface segregation** — flag plumbing methods that exist solely for one consumer ("`GetUserDisplayNamesAsync` is called only by `AuditViewerService`, move it private").
-
-### Boundary-fix protocol gap
-15. The skill currently treats cross-section DB access as "fix the offending file." The correct protocol is:
-    - **We are the producer (someone reads/writes our tables):** our job is to ensure the public API on our service satisfies the caller's need. Add it if missing (in THIS PR). Then flag the calling section as the next /section-align target — they own the migration.
-    - **We are the consumer (we cross into someone else's tables/nav):** flag the API gap on THEIR section. Don't fix it here — they're the next /section-align target. Document the gap and either tolerate the current code or fall back to a less-bad path.
-    - Never "we'll just fix the caller's file" — that violates the section ownership model and lets one section silently mutate another.
+Phase 0 complete. This plan is the impl-ready handoff. The skill's "Context discipline" rule applies — open a fresh `/cls` before Phase 1 and run the impl as an Opus orchestrator over Sonnet subagents in this same `align/auditlog` worktree.


### PR DESCRIPTION
## Summary

- Rewrites `/section-align` as a three-axis orchestrator: boundary integrity, internal cohesion, test focus. Adds Purpose + Vision statements, boundary-fix protocol, context-discipline split between Phase 0 (initial session) and Phase 1+ (Opus orchestrator over Sonnet subagents in a fresh `/cls`).
- Adds `.claude/skills/reforge/SKILL.md` as a repo-local mirror so /section-align works on machines without reforge globally installed. Includes a one-liner asking for permission to `dotnet tool install --global Reforge` (https://github.com/peterdrier/reforge) if missing.
- Lands the first Phase 0 plan under `docs/plans/2026-05-12-section-align-auditLog.md` — the AuditLog inventory across all three axes. This file is the impl-ready handoff for the follow-up branch.

## What the skill checks

**Axis 1 (boundary):** section name consistency, controller existence, URL surface, Views folder, ViewModel placement, controller-base leaks, Extensions/Sections placement, role suffix, inbound cross-section DB reads + writes, inbound EF navs, outbound cross-section access, controller→DbContext, migrations, invariant doc shape, prior review items.

**Axis 2 (internal cohesion):** EF leak from service layer, caching placement, DI lifetimes, repository pattern shape, shared visual components by type (ViewComponent / TagHelper / Partial), interface budget + segregation + consolidation evaluation (GetActive/GetDeleted anti-pattern with named large-dataset exceptions), generic vs per-section architecture tests.

**Axis 3 (test focus):** canonical per-section folder, 1-to-1 production-class to test-file mapping, coverage map against section doc invariants/negatives/triggers, redundancy and brittleness flags, Stryker.NET probe pattern + analyze-test-utility integration, test-attribute gate.

## Boundary-fix protocol

Zero-tolerance: only User ↔ Profile cross-section access is allowed. Previously-"sanctioned" display lookups (`ctx.Users.Select(DisplayName)`, `ctx.Teams.Select(Name)`) are now violations to fix via service interfaces. When a fix is blocked because the supplier section doesn't have the API yet, the supplier is flagged as a follow-up /section-align target and the section becomes **provisionally aligned** until the supplier ships.

## AuditLog Phase 0 findings (summary)

- 4 routes hosted on foreign controllers (Board + Google) → need `AuditLogController`.
- `Views/AuditLog/` folder doesn't exist; list page lives at `Views/Shared/AuditLog.cshtml`.
- 3 ViewModels in `Models/AdminViewModels.cs` grab-bag.
- `HumansControllerBase` has section-specific render helpers.
- `Extensions/AuditLogUiExtensions.cs` lives in Extensions root (not `Extensions/Sections/`).
- `DriveActivityMonitorRepository.cs:81` writes `ctx.AuditLogEntries.AddRange` directly.
- `.Include(e => e.Resource)` cross-domain join inside AuditLogRepository.
- 2 cross-section reads (`ctx.Users`, `ctx.Teams`) previously documented as sanctioned.
- Test files scattered across `Services/`, `AuditLog/`, `Architecture/`. `AuditLogRepository` has no unit-test file. `AuditEvent` + `AuditEventTextualizer` share one bundled file.
- 8 per-section architecture tests duplicating patterns that should be generic reflection-based tests.

**Follow-up /section-align targets surfaced:** GoogleIntegration (resource batch API + DriveActivityMonitor call-site migration), Users (verify display-name shape), Teams (verify `GetTeamNamesByIdsAsync` shape).

## Test plan

- [ ] `dotnet build Humans.slnx -v quiet` — green (no code changes in this PR)
- [ ] `dotnet test Humans.slnx -v quiet` — green
- [ ] Review the skill text at `.claude/skills/section-align/SKILL.md`
- [ ] Review the AuditLog Phase 0 plan at `docs/plans/2026-05-12-section-align-auditLog.md`
- [ ] Confirm the reforge install-permission line is acceptable

🤖 Generated with [Claude Code](https://claude.com/claude-code)