### PR TITLE
Add [ExpiresOn] deadline attribute + HUM0010/HUM0011 analyzer

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,14 +16,17 @@
 
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <!--
-      Grandfathered analyzer rule IDs that emit some diagnostics at Warning
-      severity (via [Grandfathered("HUM####", ...)] on the violating class).
-      Listed here so those warnings don't fail the build; everything else
-      (nullable-reference CS8xxx, Roslynator RCS, Meziantou MA0xxx, …) stays
-      strict. Add an ID when you ship a new rule with grandfathered cases;
-      remove it once the last [Grandfathered] is deleted.
+      Analyzer rule IDs whose Warning severity must NOT be promoted to Error:
+        - HUM0009: grandfathered repository/DbContext violators carrying
+          [Grandfathered("HUM0009", ...)] — warnings stay warnings until the
+          last [Grandfathered] is deleted.
+        - HUM0010 / HUM0011: [ExpiresOn] deadline analyzer. The whole point
+          is staged escalation — warning before the date / during the grace
+          window, then error. Past-deadline diagnostics are emitted with
+          effectiveSeverity: Error directly (bypasses this list); pre-deadline
+          warnings must stay warnings so the deadline mechanism works.
     -->
-    <WarningsNotAsErrors>$(WarningsNotAsErrors);HUM0009</WarningsNotAsErrors>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);HUM0009;HUM0010;HUM0011</WarningsNotAsErrors>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisLevel>latest</AnalysisLevel>

--- a/docs/features/expires-on-deadline.md
+++ b/docs/features/expires-on-deadline.md
@@ -1,0 +1,74 @@
+<!-- freshness:triggers
+  src/Humans.Domain/Architecture/ExpiresOnAttribute.cs
+  src/Humans.Analyzers/ExpiresOnAnalyzer.cs
+  Directory.Build.props
+-->
+<!-- freshness:flag-on-change
+  Severity escalation contract, graceDays semantics, or the WarningsNotAsErrors entries for HUM0010/HUM0011 — review when these change.
+-->
+
+# `[ExpiresOn]` — Hard removal deadlines for deprecated symbols
+
+`[ExpiresOn("yyyy-MM-dd", graceDays: 7, reason: "...")]` decorates any symbol with a removal deadline. The build clock drives diagnostics from warning to error on that date, so deprecations cannot accumulate indefinitely the way `[Obsolete]` warnings do.
+
+## Business Context
+
+`[Obsolete]` is open-ended. A deprecation tagged in 2024 produces the same warning in 2026, and the warning blends into background noise. New code occasionally adds new callers because the warning is the same one that has been there for two years. Eventually the deprecated thing has more callers than when it was first marked, defeating the deprecation.
+
+`[ExpiresOn]` ships a clock. The deadline lives in source, in the same place a maintainer would look. The build progressively breaks on schedule whether or not anyone is paying attention. Two weeks out for the typical case — long enough for a normal migration, short enough that the deadline survives in working memory.
+
+## Escalation Contract
+
+Each `[ExpiresOn]` attribute carries one date and one `graceDays` window (default 7).
+
+**HUM0010 — usage sites.** Every reference to the decorated symbol (call, property/field/event/method-group access, or `new`) emits a diagnostic.
+
+| Build date relative to `date`     | Severity   |
+| --------------------------------- | ---------- |
+| Before `date`                     | Warning    |
+| On or after `date`                | Error      |
+
+**HUM0011 — declaration site.** The decorated symbol itself emits a diagnostic only after the date passes.
+
+| Build date relative to `date`              | Severity   |
+| ------------------------------------------ | ---------- |
+| Before `date`                              | (clean)    |
+| `date` ≤ today < `date + graceDays`        | Warning    |
+| `date + graceDays` ≤ today                 | Error      |
+
+The grace period is asymmetric on purpose: callers feel the deadline a week earlier than the author of the symbol. By the time the declaration starts erroring, callers have already been broken for `graceDays`, so the symbol is unreachable and safe to delete.
+
+"Today" is `DateTime.UtcNow.Date` on the build machine. A clean CI build on the deadline day flips red without any code change — which is exactly the point of a deadline.
+
+## Why warnings must stay warnings
+
+The repo runs with `<TreatWarningsAsErrors>true</TreatWarningsAsErrors>`. Without an exemption, HUM0010 and HUM0011 would be hard build breaks the moment the attribute is added, defeating the staged escalation.
+
+`Directory.Build.props` exempts both rule IDs via `<WarningsNotAsErrors>`. Past-deadline diagnostics are still emitted with `effectiveSeverity: Error` directly from the analyzer (which bypasses `WarningsNotAsErrors`), so the cliff is preserved.
+
+## `graceDays` Semantics
+
+`graceDays` extends only HUM0011 (declaration). HUM0010 (usage) flips to error on `date` regardless of `graceDays`. The default of 7 is suitable for most cases; raise it when the migration is large enough that callers might need extra time to be cleaned up after the deadline (the declaration stays compilable as a warning longer).
+
+A `graceDays` of 0 means the declaration errors on the same day callers do.
+
+## Malformed dates are silent no-ops
+
+`TryReadAttribute` requires `yyyy-MM-dd` ISO format. If the date string fails to parse, the analyzer skips that attribute and continues walking — it does not error, does not warn, does not block the build. The reasoning: a malformed deadline string is a configuration bug at the attribute site, not at the call site, and breaking unrelated callers for a typo isn't useful. When a member-level attribute is malformed but its containing type carries a valid `[ExpiresOn]`, the containing-type attribute still fires.
+
+## Authoring
+
+```csharp
+[ExpiresOn("2026-05-26", reason: "Replaced by IUserEmailService.UpdateEmailAsync")]
+public Task LegacyUpdateEmail(string email) { ... }
+```
+
+Combine with `[Obsolete]` when both apply — `[Obsolete]` carries the migration story and the alternative API; `[ExpiresOn]` carries the deadline. They layer cleanly.
+
+`[ExpiresOn]` lives in `Humans.Domain.Architecture` so any layer can use it; the attribute has no runtime behavior.
+
+## Currently Set Deadlines
+
+| Symbol                  | Date       | Grace | Tracking issue |
+| ----------------------- | ---------- | ----- | -------------- |
+| `User.NormalizedEmail`  | 2026-05-18 | 7     | #635           |

--- a/src/Humans.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Humans.Analyzers/AnalyzerReleases.Unshipped.md
@@ -10,5 +10,7 @@ HUM0005 | Humans.Architecture   | Error    | IUserEmailService.UpdateEmailAsync 
 HUM0006 | Humans.Architecture   | Error    | IUserEmailRepository.UpdateEmailAsync called from outside UserEmailService
 HUM0008 | Humans.Architecture   | Error    | Controller constructor injects HumansDbContext
 HUM0009 | Humans.Architecture   | Error    | Class uses HumansDbContext but does not implement IRepository (downgrades to Warning for classes carrying [Grandfathered("HUM0009", ...)])
+HUM0010 | Humans.Architecture   | Warning  | Reference to symbol decorated with [ExpiresOn(date)] (escalates to Error on/after the date)
+HUM0011 | Humans.Architecture   | Warning  | Declaration decorated with [ExpiresOn(date)] is past its date (escalates to Error after the graceDays window)
 HUM0015 | Humans.Architecture   | Error    | Type decorated with [SurfaceBudget(N)] declares more than N public-instance methods
 HUM0016 | Humans.Architecture   | Error    | Type decorated with [SurfaceBudget(N)] declares fewer than N public-instance methods (slack — decrement budget)

--- a/src/Humans.Analyzers/ExpiresOnAnalyzer.cs
+++ b/src/Humans.Analyzers/ExpiresOnAnalyzer.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Immutable;
 using System.Globalization;
+using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
@@ -37,7 +38,21 @@ public sealed class ExpiresOnAnalyzer : DiagnosticAnalyzer
     /// Test hook. When non-null, replaces <c>DateTime.UtcNow.Date</c> for
     /// computing diagnostic severity. Production code never sets this.
     /// </summary>
-    public static Func<DateTime>? TodayOverride { get; set; }
+    /// <remarks>
+    /// Backed by <see cref="AsyncLocal{T}"/> so concurrent test collections
+    /// cannot bleed overrides into each other. AsyncLocal (rather than
+    /// ThreadStatic) is required because Roslyn schedules analyzer callbacks
+    /// on its own threadpool via <c>EnableConcurrentExecution</c> — the
+    /// override must flow through async/await and Task scheduling to reach
+    /// <c>OnCompilationStart</c>. Production code always sees <c>null</c>.
+    /// </remarks>
+    private static readonly AsyncLocal<Func<DateTime>?> _todayOverride = new();
+
+    public static Func<DateTime>? TodayOverride
+    {
+        get => _todayOverride.Value;
+        set => _todayOverride.Value = value;
+    }
 
     private static readonly LocalizableString UsageTitle =
         "Reference to symbol with expiration deadline";
@@ -178,8 +193,10 @@ public sealed class ExpiresOnAnalyzer : DiagnosticAnalyzer
             if (attr is null)
                 continue;
 
+            // Malformed attribute at this level is a no-op — keep walking so
+            // a valid attribute on a containing type still fires.
             if (!TryReadAttribute(attr, out var date, out var _, out var reason))
-                return;
+                continue;
 
             DiagnosticSeverity severity;
             string message;

--- a/src/Humans.Analyzers/ExpiresOnAnalyzer.cs
+++ b/src/Humans.Analyzers/ExpiresOnAnalyzer.cs
@@ -1,0 +1,298 @@
+using System;
+using System.Collections.Immutable;
+using System.Globalization;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Humans.Analyzers;
+
+/// <summary>
+/// HUM0010 / HUM0011 — Hard removal deadlines via
+/// <c>[ExpiresOn("yyyy-MM-dd", graceDays: N, reason: "...")]</c>.
+///
+/// <para>
+/// <b>HUM0010 (usage):</b> every reference to a decorated symbol fires a
+/// warning before the date and an error on/after it. Callers must migrate
+/// before the deadline.
+/// </para>
+///
+/// <para>
+/// <b>HUM0011 (declaration):</b> the decorated symbol itself is clean before
+/// the date, a warning during the <c>graceDays</c> window (default 7), and
+/// an error after. The grace period gives the author time to delete the
+/// symbol after callers have migrated.
+/// </para>
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class ExpiresOnAnalyzer : DiagnosticAnalyzer
+{
+    public const string UsageDiagnosticId = "HUM0010";
+    public const string DeclarationDiagnosticId = "HUM0011";
+
+    private const string ExpiresOnAttributeFullName =
+        "Humans.Domain.Architecture.ExpiresOnAttribute";
+
+    /// <summary>
+    /// Test hook. When non-null, replaces <c>DateTime.UtcNow.Date</c> for
+    /// computing diagnostic severity. Production code never sets this.
+    /// </summary>
+    public static Func<DateTime>? TodayOverride { get; set; }
+
+    private static readonly LocalizableString UsageTitle =
+        "Reference to symbol with expiration deadline";
+
+    // The format is a single positional slot — the analyzer assembles the
+    // full message dynamically because severity-dependent wording would
+    // otherwise require multiple descriptors. RS1032 requires the format
+    // itself to be a clean single sentence with no trailing period.
+    private static readonly LocalizableString UsageMessageFormat = "{0}";
+
+    public static readonly DiagnosticDescriptor UsageRule = new(
+        id: UsageDiagnosticId,
+        title: UsageTitle,
+        messageFormat: UsageMessageFormat,
+        category: AnalyzerCategories.Architecture,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description:
+            "[ExpiresOn(date)] sets a hard deadline. References emit a warning " +
+            "before the date and an error on/after the date. Migrate callers " +
+            "before the deadline.");
+
+    private static readonly LocalizableString DeclarationTitle =
+        "Declaration past its expiration deadline";
+
+    private static readonly LocalizableString DeclarationMessageFormat = "{0}";
+
+    public static readonly DiagnosticDescriptor DeclarationRule = new(
+        id: DeclarationDiagnosticId,
+        title: DeclarationTitle,
+        messageFormat: DeclarationMessageFormat,
+        category: AnalyzerCategories.Architecture,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description:
+            "After the [ExpiresOn] date, the decorated symbol itself becomes a " +
+            "warning for graceDays (default 7), then an error. Delete the symbol " +
+            "during the grace period.");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(UsageRule, DeclarationRule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterCompilationStartAction(OnCompilationStart);
+    }
+
+    private static void OnCompilationStart(CompilationStartAnalysisContext context)
+    {
+        var attributeType = context.Compilation.GetTypeByMetadataName(ExpiresOnAttributeFullName);
+        if (attributeType is null)
+            return;
+
+        var today = (TodayOverride?.Invoke() ?? DateTime.UtcNow).Date;
+
+        context.RegisterSymbolAction(
+            ctx => AnalyzeDeclaration(ctx, attributeType, today),
+            SymbolKind.NamedType,
+            SymbolKind.Method,
+            SymbolKind.Property,
+            SymbolKind.Field,
+            SymbolKind.Event);
+
+        context.RegisterOperationAction(
+            ctx => AnalyzeOperation(ctx, attributeType, today),
+            OperationKind.Invocation,
+            OperationKind.PropertyReference,
+            OperationKind.FieldReference,
+            OperationKind.MethodReference,
+            OperationKind.EventReference,
+            OperationKind.ObjectCreation);
+    }
+
+    private static void AnalyzeDeclaration(
+        SymbolAnalysisContext context,
+        INamedTypeSymbol attributeType,
+        DateTime today)
+    {
+        var attr = FindAttribute(context.Symbol, attributeType);
+        if (attr is null)
+            return;
+
+        if (!TryReadAttribute(attr, out var date, out var graceDays, out var reason))
+            return;
+
+        var graceEnd = date.AddDays(graceDays);
+        if (today < date)
+            return;
+
+        var location = context.Symbol.Locations.Length > 0
+            ? context.Symbol.Locations[0]
+            : Location.None;
+
+        DiagnosticSeverity severity;
+        string message;
+        if (today < graceEnd)
+        {
+            severity = DiagnosticSeverity.Warning;
+            var daysLeft = (graceEnd - today).Days;
+            message =
+                $"'{context.Symbol.Name}' expired on {Format(date)} and is in its " +
+                $"{graceDays}-day grace period. Delete it within {daysLeft} day(s).{FormatReason(reason)}";
+        }
+        else
+        {
+            severity = DiagnosticSeverity.Error;
+            var daysOver = (today - graceEnd).Days;
+            message =
+                $"'{context.Symbol.Name}' is past its expiration of {Format(date)} and " +
+                $"{graceDays}-day grace period (by {daysOver} day(s)). Delete it now.{FormatReason(reason)}";
+        }
+
+        context.ReportDiagnostic(Diagnostic.Create(
+            descriptor: DeclarationRule,
+            location: location,
+            effectiveSeverity: severity,
+            additionalLocations: null,
+            properties: null,
+            messageArgs: new object[] { message }));
+    }
+
+    private static void AnalyzeOperation(
+        OperationAnalysisContext context,
+        INamedTypeSymbol attributeType,
+        DateTime today)
+    {
+        var target = ResolveTarget(context.Operation);
+        if (target is null)
+            return;
+
+        // Walk the symbol and its containing types so a usage of a member
+        // inside an [ExpiresOn] class also fires.
+        for (var current = target; current is not null; current = current.ContainingType)
+        {
+            var attr = FindAttribute(current, attributeType);
+            if (attr is null)
+                continue;
+
+            if (!TryReadAttribute(attr, out var date, out var _, out var reason))
+                return;
+
+            DiagnosticSeverity severity;
+            string message;
+            if (today < date)
+            {
+                severity = DiagnosticSeverity.Warning;
+                var daysLeft = (date - today).Days;
+                message =
+                    $"'{current.Name}' is scheduled to expire on {Format(date)} " +
+                    $"(in {daysLeft} day(s)). Migrate before then.{FormatReason(reason)}";
+            }
+            else
+            {
+                severity = DiagnosticSeverity.Error;
+                var daysOver = (today - date).Days;
+                message =
+                    $"'{current.Name}' expired on {Format(date)} ({daysOver} day(s) ago). " +
+                    $"Remove this reference.{FormatReason(reason)}";
+            }
+
+            context.ReportDiagnostic(Diagnostic.Create(
+                descriptor: UsageRule,
+                location: context.Operation.Syntax.GetLocation(),
+                effectiveSeverity: severity,
+                additionalLocations: null,
+                properties: null,
+                messageArgs: new object[] { message }));
+
+            // Report once per usage even if both the member and the
+            // containing type are decorated.
+            return;
+        }
+    }
+
+    private static ISymbol? ResolveTarget(IOperation operation) => operation switch
+    {
+        IInvocationOperation inv => inv.TargetMethod,
+        IPropertyReferenceOperation prop => prop.Property,
+        IFieldReferenceOperation field => field.Field,
+        IMethodReferenceOperation methodRef => methodRef.Method,
+        IEventReferenceOperation evt => evt.Event,
+        IObjectCreationOperation ctor => ctor.Constructor,
+        _ => null,
+    };
+
+    private static AttributeData? FindAttribute(ISymbol symbol, INamedTypeSymbol attributeType)
+    {
+        foreach (var attr in symbol.GetAttributes())
+        {
+            if (SymbolEqualityComparer.Default.Equals(attr.AttributeClass, attributeType))
+                return attr;
+        }
+        return null;
+    }
+
+    private static bool TryReadAttribute(
+        AttributeData attr,
+        out DateTime date,
+        out int graceDays,
+        out string? reason)
+    {
+        date = default;
+        graceDays = 7;
+        reason = null;
+
+        if (attr.ConstructorArguments.Length == 0)
+            return false;
+
+        if (attr.ConstructorArguments[0].Value is not string dateText)
+            return false;
+
+        if (!DateTime.TryParseExact(
+                dateText,
+                "yyyy-MM-dd",
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.None,
+                out date))
+        {
+            return false;
+        }
+
+        if (attr.ConstructorArguments.Length >= 2 &&
+            attr.ConstructorArguments[1].Value is int g)
+        {
+            graceDays = g;
+        }
+
+        if (attr.ConstructorArguments.Length >= 3 &&
+            attr.ConstructorArguments[2].Value is string r)
+        {
+            reason = r;
+        }
+
+        // Named arguments override positional (uncommon, but supported).
+        foreach (var named in attr.NamedArguments)
+        {
+            switch (named.Key)
+            {
+                case "GraceDays" when named.Value.Value is int gn:
+                    graceDays = gn;
+                    break;
+                case "Reason" when named.Value.Value is string rn:
+                    reason = rn;
+                    break;
+            }
+        }
+
+        return true;
+    }
+
+    private static string Format(DateTime date) =>
+        date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+
+    private static string FormatReason(string? reason) =>
+        string.IsNullOrWhiteSpace(reason) ? string.Empty : $" Reason: {reason}";
+}

--- a/src/Humans.Domain/Architecture/ExpiresOnAttribute.cs
+++ b/src/Humans.Domain/Architecture/ExpiresOnAttribute.cs
@@ -1,0 +1,63 @@
+namespace Humans.Domain.Architecture;
+
+/// <summary>
+/// Marks a symbol as having a hard removal deadline. The
+/// <c>ExpiresOnAnalyzer</c> emits diagnostics that escalate from warning to
+/// error as the date passes, so a deadline cannot silently slip past.
+/// </summary>
+/// <remarks>
+/// <para>Two diagnostics derive from this attribute:</para>
+/// <list type="bullet">
+///   <item>
+///     <b>HUM0010 — Usage site.</b> Every reference to the decorated symbol
+///     (call, property/field/event/method-group access, or constructor)
+///     fires a <b>warning</b> before the date and an <b>error</b> on/after
+///     the date. Callers must migrate before the deadline.
+///   </item>
+///   <item>
+///     <b>HUM0011 — Declaration site.</b> The decorated symbol itself is
+///     clean until the date, then a <b>warning</b> during the <see cref="GraceDays"/>
+///     window (default 7 days), then an <b>error</b>. The grace period
+///     gives the author time to actually delete the symbol after the callers
+///     have all migrated.
+///   </item>
+/// </list>
+///
+/// <para>
+/// Use this to set a real deadline on deprecated API surface — typically two
+/// weeks out — rather than letting <c>[Obsolete]</c> warnings accumulate
+/// indefinitely.
+/// </para>
+///
+/// <para>"Today" is the build machine's UTC date. A clean CI build on the
+/// deadline day will flip red without any code change — which is exactly the
+/// point of a deadline.</para>
+/// </remarks>
+/// <example>
+/// <code>
+/// [ExpiresOn("2026-05-26", reason: "replaced by IUserEmailService.UpdateEmailAsync")]
+/// public Task LegacyUpdateEmail(string email) { ... }
+/// </code>
+/// </example>
+[AttributeUsage(AttributeTargets.All, AllowMultiple = false, Inherited = false)]
+public sealed class ExpiresOnAttribute : Attribute
+{
+    public ExpiresOnAttribute(string date, int graceDays = 7, string? reason = null)
+    {
+        Date = date;
+        GraceDays = graceDays;
+        Reason = reason;
+    }
+
+    /// <summary>ISO date (<c>yyyy-MM-dd</c>) on which callers start erroring.</summary>
+    public string Date { get; }
+
+    /// <summary>
+    /// Additional days after <see cref="Date"/> during which the declaration
+    /// itself is only a warning. After this window the declaration also errors.
+    /// </summary>
+    public int GraceDays { get; }
+
+    /// <summary>Optional context shown in the diagnostic message.</summary>
+    public string? Reason { get; }
+}

--- a/src/Humans.Domain/Entities/User.cs
+++ b/src/Humans.Domain/Entities/User.cs
@@ -121,6 +121,7 @@ public class User : IdentityUser<Guid>
     /// </remarks>
 #pragma warning disable CS0809 // Obsolete override of non-obsolete base — intentional: marks application reads as non-canonical.
     [Obsolete("NormalizedEmail is shadow-populated by Identity. Use User.Email or IUserEmailRepository for canonical email lookup.", DiagnosticId = "HUM_USER_NORMALIZEDEMAIL", UrlFormat = "https://github.com/nobodies-collective/Humans/issues/635")]
+    [Humans.Domain.Architecture.ExpiresOn("2026-05-18", reason: "Issue #635 — Identity shadow column; application reads should go through User.Email / IUserEmailRepository.")]
     public override string? NormalizedEmail
     {
         get => Email?.ToUpperInvariant();

--- a/tests/Humans.Analyzers.Tests/ExpiresOnAnalyzerTests.cs
+++ b/tests/Humans.Analyzers.Tests/ExpiresOnAnalyzerTests.cs
@@ -1,0 +1,236 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using AwesomeAssertions;
+using Humans.Testing;
+using Microsoft.CodeAnalysis;
+
+namespace Humans.Analyzers.Tests;
+
+/// <summary>
+/// Tests pin "today" via <see cref="ExpiresOnAnalyzer.TodayOverride"/> so the
+/// suite is deterministic across machines and dates. Each test restores the
+/// override in a try/finally.
+/// </summary>
+public class ExpiresOnAnalyzerTests
+{
+    private const string AttributeStub = """
+        namespace Humans.Domain.Architecture
+        {
+            [System.AttributeUsage(System.AttributeTargets.All)]
+            public sealed class ExpiresOnAttribute : System.Attribute
+            {
+                public ExpiresOnAttribute(string date, int graceDays = 7, string? reason = null)
+                {
+                    Date = date;
+                    GraceDays = graceDays;
+                    Reason = reason;
+                }
+                public string Date { get; }
+                public int GraceDays { get; }
+                public string? Reason { get; }
+            }
+        }
+        """;
+
+    private const string SampleSource = AttributeStub + """
+
+        namespace Sample
+        {
+            using Humans.Domain.Architecture;
+
+            public class Container
+            {
+                [ExpiresOn("2026-05-26", 7, "use NewMethod instead")]
+                public int Foo { get; set; }
+
+                public void NewMethod() { }
+            }
+
+            public class Caller
+            {
+                public int Read(Container c) => c.Foo;
+                public void Write(Container c) => c.Foo = 1;
+            }
+        }
+        """;
+
+    private static bool IsUsage(Diagnostic d) =>
+        string.Equals(d.Id, ExpiresOnAnalyzer.UsageDiagnosticId, StringComparison.Ordinal);
+
+    private static bool IsDeclaration(Diagnostic d) =>
+        string.Equals(d.Id, ExpiresOnAnalyzer.DeclarationDiagnosticId, StringComparison.Ordinal);
+
+    private static async Task<System.Collections.Immutable.ImmutableArray<Diagnostic>> RunAtAsync(
+        DateTime today,
+        string source = SampleSource)
+    {
+        ExpiresOnAnalyzer.TodayOverride = () => today;
+        try
+        {
+            return await AnalyzerTestHarness.RunAsync(
+                new ExpiresOnAnalyzer(),
+                "Humans.Application",
+                source);
+        }
+        finally
+        {
+            ExpiresOnAnalyzer.TodayOverride = null;
+        }
+    }
+
+    [HumansFact]
+    public async Task Before_date_callers_warn_and_declaration_clean()
+    {
+        var diagnostics = await RunAtAsync(new DateTime(2026, 5, 12));
+
+        var usage = diagnostics.Where(IsUsage).ToArray();
+        usage.Should().HaveCount(2, "both Read and Write reference Foo");
+        usage.Should().AllSatisfy(d => d.Severity.Should().Be(DiagnosticSeverity.Warning));
+
+        diagnostics.Where(IsDeclaration).Should().BeEmpty();
+    }
+
+    [HumansFact]
+    public async Task On_date_callers_error_and_declaration_warns_grace_period()
+    {
+        var diagnostics = await RunAtAsync(new DateTime(2026, 5, 26));
+
+        diagnostics.Where(IsUsage).Should().AllSatisfy(d =>
+            d.Severity.Should().Be(DiagnosticSeverity.Error));
+
+        var decl = diagnostics.Where(IsDeclaration).ToArray();
+        decl.Should().ContainSingle();
+        decl[0].Severity.Should().Be(DiagnosticSeverity.Warning);
+    }
+
+    [HumansFact]
+    public async Task Within_grace_window_declaration_still_warns()
+    {
+        var diagnostics = await RunAtAsync(new DateTime(2026, 6, 1));
+
+        var decl = diagnostics.Where(IsDeclaration).ToArray();
+        decl.Should().ContainSingle();
+        decl[0].Severity.Should().Be(DiagnosticSeverity.Warning);
+    }
+
+    [HumansFact]
+    public async Task After_grace_window_declaration_errors()
+    {
+        var diagnostics = await RunAtAsync(new DateTime(2026, 6, 3));
+
+        var decl = diagnostics.Where(IsDeclaration).ToArray();
+        decl.Should().ContainSingle();
+        decl[0].Severity.Should().Be(DiagnosticSeverity.Error);
+
+        diagnostics.Where(IsUsage).Should().AllSatisfy(d =>
+            d.Severity.Should().Be(DiagnosticSeverity.Error));
+    }
+
+    [HumansFact]
+    public async Task Custom_grace_days_extends_warning_window()
+    {
+        var source = AttributeStub + """
+
+            namespace Sample
+            {
+                using Humans.Domain.Architecture;
+
+                public class Container
+                {
+                    [ExpiresOn("2026-05-26", graceDays: 30)]
+                    public void Old() { }
+                }
+            }
+            """;
+
+        var diagnostics = await RunAtAsync(new DateTime(2026, 6, 20), source);
+
+        var decl = diagnostics.Where(IsDeclaration).ToArray();
+        decl.Should().ContainSingle();
+        decl[0].Severity.Should().Be(DiagnosticSeverity.Warning,
+            "30-day grace covers 2026-05-26 through 2026-06-25");
+    }
+
+    [HumansFact]
+    public async Task Class_level_attribute_flags_member_usage()
+    {
+        var source = AttributeStub + """
+
+            namespace Sample
+            {
+                using Humans.Domain.Architecture;
+
+                [ExpiresOn("2026-05-26")]
+                public class LegacyService
+                {
+                    public void DoThing() { }
+                }
+
+                public class Caller
+                {
+                    public void Use() => new LegacyService().DoThing();
+                }
+            }
+            """;
+
+        var diagnostics = await RunAtAsync(new DateTime(2026, 5, 12), source);
+
+        var usage = diagnostics.Where(IsUsage).ToArray();
+        usage.Should().NotBeEmpty(
+            "constructing or calling a member of an [ExpiresOn] class is a usage");
+        usage.Should().AllSatisfy(d => d.Severity.Should().Be(DiagnosticSeverity.Warning));
+    }
+
+    [HumansFact]
+    public async Task No_attribute_no_diagnostics()
+    {
+        var source = AttributeStub + """
+
+            namespace Sample
+            {
+                public class Plain
+                {
+                    public int Foo { get; set; }
+                }
+
+                public class Caller
+                {
+                    public int Use(Plain p) => p.Foo;
+                }
+            }
+            """;
+
+        var diagnostics = await RunAtAsync(new DateTime(2026, 5, 26), source);
+
+        diagnostics.Where(d => IsUsage(d) || IsDeclaration(d)).Should().BeEmpty();
+    }
+
+    [HumansFact]
+    public async Task Malformed_date_emits_no_diagnostic()
+    {
+        var source = AttributeStub + """
+
+            namespace Sample
+            {
+                using Humans.Domain.Architecture;
+
+                public class Container
+                {
+                    [ExpiresOn("not-a-date")]
+                    public void Old() { }
+                }
+
+                public class Caller
+                {
+                    public void Use(Container c) => c.Old();
+                }
+            }
+            """;
+
+        var diagnostics = await RunAtAsync(new DateTime(2026, 5, 26), source);
+
+        diagnostics.Where(d => IsUsage(d) || IsDeclaration(d)).Should().BeEmpty(
+            "a malformed date is a no-op rather than a hard failure");
+    }
+}

--- a/tests/Humans.Analyzers.Tests/ExpiresOnAnalyzerTests.cs
+++ b/tests/Humans.Analyzers.Tests/ExpiresOnAnalyzerTests.cs
@@ -207,6 +207,40 @@ public class ExpiresOnAnalyzerTests
     }
 
     [HumansFact]
+    public async Task Malformed_member_attribute_falls_through_to_valid_class_attribute()
+    {
+        // A malformed [ExpiresOn] on a member must not suppress a valid one
+        // on its containing type — the loop should `continue`, not `return`.
+        var source = AttributeStub + """
+
+            namespace Sample
+            {
+                using Humans.Domain.Architecture;
+
+                [ExpiresOn("2026-05-26")]
+                public class LegacyService
+                {
+                    [ExpiresOn("not-a-date")]
+                    public void DoThing() { }
+                }
+
+                public class Caller
+                {
+                    public void Use(LegacyService s) => s.DoThing();
+                }
+            }
+            """;
+
+        var diagnostics = await RunAtAsync(new DateTime(2026, 5, 12), source);
+
+        var usage = diagnostics.Where(IsUsage).ToArray();
+        usage.Should().NotBeEmpty(
+            "the class-level [ExpiresOn] is valid; the malformed member-level " +
+            "attribute must not block its discovery");
+        usage.Should().AllSatisfy(d => d.Severity.Should().Be(DiagnosticSeverity.Warning));
+    }
+
+    [HumansFact]
     public async Task Malformed_date_emits_no_diagnostic()
     {
         var source = AttributeStub + """


### PR DESCRIPTION
## Summary

- New `[ExpiresOn("yyyy-MM-dd", graceDays: 7, reason: "...")]` attribute (`Humans.Domain.Architecture`) sets a hard removal deadline that escalates from warning to error on the build clock.
- New `ExpiresOnAnalyzer` emits two diagnostics:
  - **HUM0010 (usage):** every reference to a decorated symbol — warning before the date, error on/after.
  - **HUM0011 (declaration):** the decorated symbol itself — clean before the date, warning during the `graceDays` window, error after.
- Dogfood: `User.NormalizedEmail` carries `[ExpiresOn("2026-05-18")]`. Property has zero application callers (existing `[Obsolete]` already cleared them), so HUM0010 stays silent; HUM0011 starts warning on 5/18 and errors on 5/25 unless the property is deleted first.

Solves the "Obsolete warnings accumulate forever" problem: set a deadline two weeks out, the build will go red without any code change.

## Test plan

- [x] `dotnet test tests/Humans.Analyzers.Tests` — 68 passing (8 new + 60 existing). New tests cover all 6 severity transitions plus class-level attribution, malformed date, and no-attribute cases.
- [x] `dotnet build Humans.slnx` — clean (only pre-existing HUM0009 grandfathered warnings).
- [ ] Watch the QA build on 2026-05-18 — HUM0011 should start warning on `User.NormalizedEmail`.
- [ ] If `NormalizedEmail` isn't deleted by 2026-05-25, the build flips to error (the intended behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)