### PR TITLE
fix(migrations): backfill stale AddExpensesSection.Designer with VolunteerBuildStatus

### DIFF
--- a/src/Humans.Infrastructure/Migrations/20260511012346_AddExpensesSection.Designer.cs
+++ b/src/Humans.Infrastructure/Migrations/20260511012346_AddExpensesSection.Designer.cs
@@ -4373,6 +4373,47 @@ namespace Humans.Infrastructure.Migrations
                     b.ToTable("user_emails", (string)null);
                 });
 
+            modelBuilder.Entity("Humans.Domain.Entities.VolunteerBuildStatus", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<LocalDate?>("BarrioSetupStartDate")
+                        .HasColumnType("date");
+
+                    b.Property<string>("DayOffs")
+                        .IsRequired()
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("jsonb")
+                        .HasDefaultValueSql("'[]'::jsonb");
+
+                    b.Property<Guid>("EventSettingsId")
+                        .HasColumnType("uuid");
+
+                    b.Property<string>("Notes")
+                        .HasMaxLength(500)
+                        .HasColumnType("character varying(500)");
+
+                    b.Property<Instant?>("SetAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<Guid?>("SetByUserId")
+                        .HasColumnType("uuid");
+
+                    b.Property<Guid>("UserId")
+                        .HasColumnType("uuid");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("EventSettingsId");
+
+                    b.HasIndex("UserId", "EventSettingsId")
+                        .IsUnique();
+
+                    b.ToTable("volunteer_build_statuses", (string)null);
+                });
+
             modelBuilder.Entity("Humans.Domain.Entities.VolunteerEventProfile", b =>
                 {
                     b.Property<Guid>("Id")
@@ -5629,6 +5670,15 @@ namespace Humans.Infrastructure.Migrations
                     b.HasOne("Humans.Domain.Entities.User", null)
                         .WithMany("UserEmails")
                         .HasForeignKey("UserId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+                });
+
+            modelBuilder.Entity("Humans.Domain.Entities.VolunteerBuildStatus", b =>
+                {
+                    b.HasOne("Humans.Domain.Entities.EventSettings", null)
+                        .WithMany()
+                        .HasForeignKey("EventSettingsId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
                 });


### PR DESCRIPTION
## Summary

- `AddExpensesSection.Designer.cs` has been missing the `VolunteerBuildStatus` entity + relationship blocks since PR #491 merged — a parallel-branch merge ordering artifact (PR #467 created the entity on a different branch first, but PR #491's Designer was frozen before that landed).
- Effect: every `dotnet ef migrations add` on top of `AddExpensesSection` diffs current model against the stale Designer and emits a bogus `create volunteer_build_statuses` block. PR #504's original migration was hand-edited to mask this — exactly the pattern this repair eliminates.
- This PR repairs the Designer by inserting the two missing blocks **verbatim** from the live `HumansDbContextModelSnapshot.cs`. No `Up`/`Down` logic touched. No semantic DB change.

## Verification

- Build clean (0 errors).
- Probe test: `dotnet ef migrations add Probe_DELETEME` produced an **empty** `Up`/`Down` — confirming model = snapshot post-repair. Probe removed.
- Post-repair diff between `AddExpensesSection.Designer.cs` and `HumansDbContextModelSnapshot.cs` shows only the expected structural-header differences (class name, `[Migration]` attribute, `BuildTargetModel` vs `BuildModel`).

## Why backfilling a committed Designer

`AddExpensesSection` is already applied to QA and prod; the migration history can't be rewritten. The Designer is a frozen snapshot artifact, not Up/Down logic — repairing it corrects EF tooling drift without touching anything the DB ever sees. Once this lands, PR #504's `AddCommunicationPreferenceSubscribedAt` migration regenerates cleanly with zero hand-edits.

## Test plan

- [ ] Verify diff: `AddExpensesSection.Designer.cs` vs `HumansDbContextModelSnapshot.cs` differs only in structural headers (class name / `[Migration]` / method name).
- [ ] `dotnet build Humans.slnx -v quiet` succeeds.
- [ ] `dotnet ef migrations add Probe --project src/Humans.Infrastructure --startup-project src/Humans.Web` produces empty `Up`/`Down`. (`dotnet ef migrations remove` to discard.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)