### PR TITLE
Fix Mailer admin 500 + register missing config keys

### DIFF
--- a/src/Humans.Web/Controllers/Mailer/MailerAdminController.cs
+++ b/src/Humans.Web/Controllers/Mailer/MailerAdminController.cs
@@ -61,7 +61,7 @@ public sealed class MailerAdminController : HumansControllerBase
         }
         catch (HttpRequestException ex)
         {
-            _logger.LogError(ex, "MailerLite API call failed in Mailer dashboard");
+            _logger.LogWarning("MailerLite API call failed: {StatusCode} {Message}", ex.StatusCode, ex.Message);
             mlError = FormatMailerLiteError(ex);
         }
 

--- a/src/Humans.Web/Controllers/Mailer/MailerAdminController.cs
+++ b/src/Humans.Web/Controllers/Mailer/MailerAdminController.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Text.Json;
 using Humans.Application.Interfaces.AuditLog;
 using Humans.Application.Interfaces.Mailer;
@@ -11,6 +12,7 @@ using Humans.Web.Models.Mailer;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 
 namespace Humans.Web.Controllers.Mailer;
 
@@ -23,6 +25,7 @@ public sealed class MailerAdminController : HumansControllerBase
     private readonly IUserService _users;
     private readonly ICommunicationPreferenceService _prefs;
     private readonly IAuditLogService _audit;
+    private readonly ILogger<MailerAdminController> _logger;
 
     public MailerAdminController(
         IMailerLiteService ml,
@@ -30,6 +33,7 @@ public sealed class MailerAdminController : HumansControllerBase
         IUserService users,
         ICommunicationPreferenceService prefs,
         IAuditLogService audit,
+        ILogger<MailerAdminController> logger,
         UserManager<User> userManager)
         : base(userManager)
     {
@@ -38,13 +42,29 @@ public sealed class MailerAdminController : HumansControllerBase
         _users = users;
         _prefs = prefs;
         _audit = audit;
+        _logger = logger;
     }
 
     [HttpGet("")]
     public async Task<IActionResult> Index(CancellationToken ct)
     {
-        var summary = await _ml.GetAccountSummaryAsync(ct);
-        var groups = await _ml.ListGroupsAsync(ct);
+        MailerLiteAccountSummary? summary = null;
+        IReadOnlyList<MailerLiteGroup>? groups = null;
+        DriftReport? drift = null;
+        string? mlError = null;
+
+        try
+        {
+            summary = await _ml.GetAccountSummaryAsync(ct);
+            groups = await _ml.ListGroupsAsync(ct);
+            drift = await ComputeDriftAsync(ct);
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogError(ex, "MailerLite API call failed in Mailer dashboard");
+            mlError = FormatMailerLiteError(ex);
+        }
+
         var mlContacts = await _users.GetCountByContactSourceAsync(ContactSource.MailerLite, ct);
         var optedIn = await _prefs.GetCountByCategoryAndStateAsync(MessageCategory.Marketing, optedOut: false, ct);
         var optedOut = await _prefs.GetCountByCategoryAndStateAsync(MessageCategory.Marketing, optedOut: true, ct);
@@ -55,13 +75,20 @@ public sealed class MailerAdminController : HumansControllerBase
             ct: ct);
         var last = recent.FirstOrDefault();
 
-        var drift = await ComputeDriftAsync(ct);
-
         var vm = new MailerDashboardViewModel(
             summary, groups, mlContacts, optedIn, optedOut,
-            last?.OccurredAt, last?.Description, drift);
+            last?.OccurredAt, last?.Description, drift, mlError);
         return View("~/Views/Mailer/Admin/Index.cshtml", vm);
     }
+
+    private static string FormatMailerLiteError(HttpRequestException ex) => ex.StatusCode switch
+    {
+        HttpStatusCode.Unauthorized => "MailerLite rejected the API key (401). Check MAILERLITE_API_KEY on /Admin/Configuration.",
+        HttpStatusCode.Forbidden => "MailerLite API key lacks required permissions (403).",
+        HttpStatusCode.TooManyRequests => "MailerLite rate limit hit (429). Try again shortly.",
+        null => $"MailerLite call failed before getting a response: {ex.Message}",
+        _ => $"MailerLite API returned {(int)ex.StatusCode} {ex.StatusCode}.",
+    };
 
     [HttpPost("Import/Commit")]
     [ValidateAntiForgeryToken]

--- a/src/Humans.Web/Extensions/Infrastructure/ConfigurationMetadataExtensions.cs
+++ b/src/Humans.Web/Extensions/Infrastructure/ConfigurationMetadataExtensions.cs
@@ -55,6 +55,40 @@ internal static class ConfigurationMetadataExtensions
             configuration.GetOptionalSetting(configRegistry, "TicketVendor:Provider", "Ticket Vendor");
             configuration.GetOptionalSetting(configRegistry, "TicketVendor:SyncIntervalMinutes", "Ticket Vendor");
 
+            // MailerLite — env var is the production path; dotted key is the dev/user-secrets path.
+            configuration.GetOptionalSetting(configRegistry, "MailerLite:ApiKey", "MailerLite", isSensitive: true,
+                importance: ConfigurationImportance.Recommended);
+
+            // Holded (Expenses) — env var is the production path; BaseUrl has a default.
+            configuration.GetOptionalSetting(configRegistry, "Holded:BaseUrl", "Holded");
+
+            // Anthropic (Agent section)
+            configuration.GetOptionalSetting(configRegistry, "Anthropic:ApiKey", "Anthropic", isSensitive: true,
+                importance: ConfigurationImportance.Recommended);
+            configuration.GetOptionalSetting(configRegistry, "Anthropic:DefaultModel", "Anthropic");
+
+            // SEPA — read by Expenses payment file generation. Without these, payment files are unusable.
+            configuration.GetOptionalSetting(configRegistry, "Sepa:CreditorName", "SEPA",
+                importance: ConfigurationImportance.Recommended);
+            configuration.GetOptionalSetting(configRegistry, "Sepa:CreditorIban", "SEPA", isSensitive: true,
+                importance: ConfigurationImportance.Recommended);
+            configuration.GetOptionalSetting(configRegistry, "Sepa:CreditorBic", "SEPA",
+                importance: ConfigurationImportance.Recommended);
+            configuration.GetOptionalSetting(configRegistry, "Sepa:CreditorIdentifier", "SEPA",
+                importance: ConfigurationImportance.Recommended);
+            configuration.GetOptionalSetting(configRegistry, "Sepa:ChargeBearer", "SEPA");
+
+            // City Planning team slug — without it, only admins can edit polygons.
+            configuration.GetOptionalSetting(configRegistry, "CityPlanning:CityPlanningTeamSlug", "City Planning");
+
+            // Team Resource Management toggle
+            configuration.GetOptionalSetting(configRegistry, "TeamResourceManagement:AllowCoordinatorsToManageResources",
+                "Teams");
+
+            // Stripe webhook cleanup (operational — GitHub repo that runs the cleanup workflow)
+            configuration.GetOptionalSetting(configRegistry, "Stripe:WebhookCleanupOwner", "Stripe (Store)");
+            configuration.GetOptionalSetting(configRegistry, "Stripe:WebhookCleanupRepository", "Stripe (Store)");
+
             // Dev auth
             configuration.GetOptionalSetting(configRegistry, "DevAuth:Enabled", "Development");
 
@@ -65,6 +99,14 @@ internal static class ConfigurationMetadataExtensions
                 importance: ConfigurationImportance.Recommended);
             configRegistry.RegisterEnvironmentVariable("LOG_API_KEY", "Log API", isSensitive: true);
             configRegistry.RegisterEnvironmentVariable("AGENT_API_KEY", "Agent API", isSensitive: true);
+            // MailerLite flat env-var fallback — primary path in PR/prod (Coolify can't use dotted keys).
+            configRegistry.RegisterEnvironmentVariable("MAILERLITE_API_KEY", "MailerLite", isSensitive: true,
+                importance: ConfigurationImportance.Recommended);
+            // Holded flat env-var — required for Expenses integration.
+            configRegistry.RegisterEnvironmentVariable("HOLDED_API_KEY", "Holded", isSensitive: true,
+                importance: ConfigurationImportance.Recommended);
+            // SEPA IBAN override — env-var wins over Sepa:CreditorIban appsetting.
+            configRegistry.RegisterEnvironmentVariable("SEPA_CREDITOR_IBAN", "SEPA", isSensitive: true);
             // Stripe — one key per account/purpose; production keys must be Restricted API Keys (rk_*).
             configRegistry.RegisterEnvironmentVariable("STRIPE_TICKETS_KEY", "Stripe (Tickets)", isSensitive: true);
             configRegistry.RegisterEnvironmentVariable("STRIPE_STORE_KEY", "Stripe (Store)", isSensitive: true,

--- a/src/Humans.Web/Models/Mailer/MailerDashboardViewModel.cs
+++ b/src/Humans.Web/Models/Mailer/MailerDashboardViewModel.cs
@@ -4,14 +4,15 @@ using NodaTime;
 namespace Humans.Web.Models.Mailer;
 
 public sealed record MailerDashboardViewModel(
-    MailerLiteAccountSummary MlSummary,
-    IReadOnlyList<MailerLiteGroup> Groups,
+    MailerLiteAccountSummary? MlSummary,
+    IReadOnlyList<MailerLiteGroup>? Groups,
     int HumansMailerLiteContacts,
     int HumansMarketingOptedIn,
     int HumansMarketingOptedOut,
     Instant? LastReconciliationAt,
     string? LastReconciliationSummary,
-    DriftReport Drift);
+    DriftReport? Drift,
+    string? MlError);
 
 public sealed record DriftReport(
     int HumansOptedOutMlActive,           // legal-trouble row

--- a/src/Humans.Web/Views/Mailer/Admin/Index.cshtml
+++ b/src/Humans.Web/Views/Mailer/Admin/Index.cshtml
@@ -6,12 +6,23 @@
 
 <div class="d-flex justify-content-between align-items-center mb-3">
     <h1 class="mb-0">Mailer Dashboard</h1>
-    <a href="/Mailer/Admin/Import" class="btn btn-primary">
-        <i class="fa-solid fa-file-import me-1"></i>Run Import &rarr;
-    </a>
+    @if (Model.MlError is null)
+    {
+        <a href="/Mailer/Admin/Import" class="btn btn-primary">
+            <i class="fa-solid fa-file-import me-1"></i>Run Import &rarr;
+        </a>
+    }
 </div>
 
 <vc:temp-data-alerts />
+
+@if (Model.MlError is not null)
+{
+    <div class="alert alert-danger" role="alert">
+        <strong>MailerLite unavailable.</strong>
+        @Model.MlError
+    </div>
+}
 
 @* ── MailerLite side counts ──────────────────────────────────────────────── *@
 <div class="row mb-4">
@@ -21,26 +32,33 @@
                 <strong>MailerLite Account</strong>
             </div>
             <div class="card-body p-0">
-                <table class="table table-sm mb-0">
-                    <thead>
-                        <tr>
-                            <th>Active</th>
-                            <th>Unsubscribed</th>
-                            <th>Unconfirmed</th>
-                            <th>Bounced</th>
-                            <th>Junk</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr>
-                            <td>@Model.MlSummary.ActiveCount.ToString("N0")</td>
-                            <td>@Model.MlSummary.UnsubscribedCount.ToString("N0")</td>
-                            <td>@Model.MlSummary.UnconfirmedCount.ToString("N0")</td>
-                            <td>@Model.MlSummary.BouncedCount.ToString("N0")</td>
-                            <td>@Model.MlSummary.JunkCount.ToString("N0")</td>
-                        </tr>
-                    </tbody>
-                </table>
+                @if (Model.MlSummary is { } mlSummary)
+                {
+                    <table class="table table-sm mb-0">
+                        <thead>
+                            <tr>
+                                <th>Active</th>
+                                <th>Unsubscribed</th>
+                                <th>Unconfirmed</th>
+                                <th>Bounced</th>
+                                <th>Junk</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td>@mlSummary.ActiveCount.ToString("N0")</td>
+                                <td>@mlSummary.UnsubscribedCount.ToString("N0")</td>
+                                <td>@mlSummary.UnconfirmedCount.ToString("N0")</td>
+                                <td>@mlSummary.BouncedCount.ToString("N0")</td>
+                                <td>@mlSummary.JunkCount.ToString("N0")</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                }
+                else
+                {
+                    <div class="p-3"><span class="text-muted">—</span></div>
+                }
             </div>
         </div>
     </div>
@@ -84,51 +102,58 @@
                 <small class="text-muted ms-2">Discrepancies between Humans and MailerLite</small>
             </div>
             <div class="card-body p-0">
-                <table class="table table-sm mb-0">
-                    <thead>
-                        <tr>
-                            <th>Check</th>
-                            <th>Count</th>
-                            <th>Severity</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        @{
-                            var optedOutActiveClass = Model.Drift.HumansOptedOutMlActive > 0 ? "table-danger" : "";
-                        }
-                        <tr class="@optedOutActiveClass">
-                            <td>Opted-out in Humans but active in ML</td>
-                            <td>@Model.Drift.HumansOptedOutMlActive.ToString("N0")</td>
-                            <td>
-                                @if (Model.Drift.HumansOptedOutMlActive > 0)
-                                {
-                                    <span class="badge bg-danger">Legal risk</span>
-                                }
-                                else
-                                {
-                                    <span class="text-muted">—</span>
-                                }
-                            </td>
-                        </tr>
-                        @{
-                            var optedInAbsentClass = Model.Drift.HumansOptedInMlAbsent > 0 ? "table-warning" : "";
-                        }
-                        <tr class="@optedInAbsentClass">
-                            <td>Opted-in in Humans but absent from ML</td>
-                            <td>@(Model.Drift.HumansOptedInMlAbsent?.ToString("N0") ?? "—")</td>
-                            <td>
-                                @if (Model.Drift.HumansOptedInMlAbsent > 0)
-                                {
-                                    <span class="badge bg-warning text-dark">Service quality</span>
-                                }
-                                else
-                                {
-                                    <span class="text-muted">—</span>
-                                }
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
+                @if (Model.Drift is { } drift)
+                {
+                    <table class="table table-sm mb-0">
+                        <thead>
+                            <tr>
+                                <th>Check</th>
+                                <th>Count</th>
+                                <th>Severity</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @{
+                                var optedOutActiveClass = drift.HumansOptedOutMlActive > 0 ? "table-danger" : "";
+                            }
+                            <tr class="@optedOutActiveClass">
+                                <td>Opted-out in Humans but active in ML</td>
+                                <td>@drift.HumansOptedOutMlActive.ToString("N0")</td>
+                                <td>
+                                    @if (drift.HumansOptedOutMlActive > 0)
+                                    {
+                                        <span class="badge bg-danger">Legal risk</span>
+                                    }
+                                    else
+                                    {
+                                        <span class="text-muted">—</span>
+                                    }
+                                </td>
+                            </tr>
+                            @{
+                                var optedInAbsentClass = drift.HumansOptedInMlAbsent > 0 ? "table-warning" : "";
+                            }
+                            <tr class="@optedInAbsentClass">
+                                <td>Opted-in in Humans but absent from ML</td>
+                                <td>@(drift.HumansOptedInMlAbsent?.ToString("N0") ?? "—")</td>
+                                <td>
+                                    @if (drift.HumansOptedInMlAbsent > 0)
+                                    {
+                                        <span class="badge bg-warning text-dark">Service quality</span>
+                                    }
+                                    else
+                                    {
+                                        <span class="text-muted">—</span>
+                                    }
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                }
+                else
+                {
+                    <div class="p-3"><span class="text-muted">—</span></div>
+                }
             </div>
         </div>
     </div>
@@ -140,9 +165,18 @@
         <div class="card">
             <div class="card-header">
                 <strong>MailerLite Groups</strong>
-                <span class="badge bg-secondary ms-2">@Model.Groups.Count</span>
+                @if (Model.Groups is { } groupsHeader)
+                {
+                    <span class="badge bg-secondary ms-2">@groupsHeader.Count</span>
+                }
             </div>
-            @if (Model.Groups.Count == 0)
+            @if (Model.Groups is null)
+            {
+                <div class="card-body">
+                    <span class="text-muted">—</span>
+                </div>
+            }
+            else if (Model.Groups.Count == 0)
             {
                 <div class="card-body">
                     <span class="text-muted">No groups found.</span>

--- a/tests/Humans.Web.Tests/Controllers/Mailer/MailerAdminControllerTests.cs
+++ b/tests/Humans.Web.Tests/Controllers/Mailer/MailerAdminControllerTests.cs
@@ -14,8 +14,10 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Humans.Web.Tests.Controllers.Mailer;
@@ -45,7 +47,8 @@ public class MailerAdminControllerTests
     private MailerAdminController BuildSut(ImportPlanCounts? snapshotCounts = null)
     {
         var ctrl = new MailerAdminController(
-            _mlService, _importService, _userService, _prefs, _audit, _userManager);
+            _mlService, _importService, _userService, _prefs, _audit,
+            NullLogger<MailerAdminController>.Instance, _userManager);
 
         var http = new DefaultHttpContext
         {
@@ -165,7 +168,55 @@ public class MailerAdminControllerTests
         // Assert: drift report should count 1 Humans-opted-out / ML-active disagreement.
         var view = Assert.IsType<ViewResult>(result);
         var vm = Assert.IsType<MailerDashboardViewModel>(view.Model);
-        Assert.Equal(1, vm.Drift.HumansOptedOutMlActive);
+        Assert.NotNull(vm.Drift);
+        Assert.Equal(1, vm.Drift!.HumansOptedOutMlActive);
+        Assert.Null(vm.MlError);
+    }
+
+    // -----------------------------------------------------------------------
+    // Index — MailerLite outage: page still renders with MlError set.
+    // -----------------------------------------------------------------------
+
+    [HumansFact]
+    public async Task Index_RendersWithMlError_WhenMailerLiteApiUnauthorized()
+    {
+        // Arrange: ML call throws 401 (e.g., missing/invalid MAILERLITE_API_KEY).
+        _mlService.GetAccountSummaryAsync(Arg.Any<CancellationToken>())
+            .ThrowsAsync(new HttpRequestException(
+                "Response status code does not indicate success: 401 (Unauthorized).",
+                inner: null,
+                statusCode: System.Net.HttpStatusCode.Unauthorized));
+
+        // Humans-side dependencies still succeed.
+        _userService.GetCountByContactSourceAsync(Arg.Any<ContactSource>(), Arg.Any<CancellationToken>())
+            .Returns(7);
+        _prefs.GetCountByCategoryAndStateAsync(
+                Arg.Any<MessageCategory>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns(3);
+        _audit.GetFilteredEntriesAsync(
+                entityType: Arg.Any<string?>(),
+                entityId: Arg.Any<Guid?>(),
+                userId: Arg.Any<Guid?>(),
+                actions: Arg.Any<IReadOnlyList<AuditAction>?>(),
+                limit: Arg.Any<int>(),
+                ct: Arg.Any<CancellationToken>())
+            .Returns((IReadOnlyList<AuditLogEntry>)Array.Empty<AuditLogEntry>());
+
+        var ctrl = BuildSut();
+
+        // Act
+        var result = await ctrl.Index(CancellationToken.None);
+
+        // Assert: page rendered with friendly error, Humans-side data preserved, no ML data.
+        var view = Assert.IsType<ViewResult>(result);
+        var vm = Assert.IsType<MailerDashboardViewModel>(view.Model);
+        Assert.NotNull(vm.MlError);
+        Assert.Contains("401", vm.MlError, StringComparison.Ordinal);
+        Assert.Contains("MAILERLITE_API_KEY", vm.MlError, StringComparison.Ordinal);
+        Assert.Null(vm.MlSummary);
+        Assert.Null(vm.Groups);
+        Assert.Null(vm.Drift);
+        Assert.Equal(7, vm.HumansMailerLiteContacts);
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `/Mailer/Admin` 500'd when MailerLite returned 401 (missing/invalid `MAILERLITE_API_KEY` in QA). Controller now catches `HttpRequestException`, surfaces a banner with the failing status code (with a `MAILERLITE_API_KEY` hint for 401), and renders the Humans-side counts + reconciliation card regardless. "Run Import" CTA hides while ML is unavailable to avoid a chained 500 on the Import page.
- `/Admin/Configuration` was missing every key the Mailer/Holded/Anthropic/SEPA/CityPlanning/TeamResourceManagement/Stripe-webhook-cleanup sections actually read, plus three env-var fallbacks (`MAILERLITE_API_KEY`, `HOLDED_API_KEY`, `SEPA_CREDITOR_IBAN`). Registered all of them with importance + sensitivity flags matching the existing pattern.

## Test plan

- [x] `dotnet build Humans.slnx -v quiet` — clean
- [x] `dotnet test Humans.slnx --filter MailerAdminControllerTests` — 4/4 pass (existing 3 + new `Index_RendersWithMlError_WhenMailerLiteApiUnauthorized`)
- [x] All non-integration test projects pass (Domain 164/164, Analyzers 69/69, Web 54/54, Application 2609/2609)
- [ ] Integration tests: 49 pre-existing `AccountMerge.AcceptAsync_*` failures from the merge-fold WIP area — **not related to this PR** (ambient-transaction bug in `TicketTransferRepository.ReassignUserAsync`).
- [ ] On QA: hit `/Mailer/Admin` with `MAILERLITE_API_KEY` unset/invalid → red banner appears, page renders, no 500.
- [ ] `/Admin/Configuration` now lists MailerLite, Holded, Anthropic, SEPA, City Planning, TeamResourceManagement, and the three new env-vars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)