### PR TITLE
Fix Tickets Admin Transfers 500 — push drift filter upstream

### DIFF
--- a/src/Humans.Infrastructure/Repositories/Tickets/TicketRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Tickets/TicketRepository.cs
@@ -950,9 +950,17 @@ public sealed class TicketRepository : ITicketRepository
     public async Task<IReadOnlyList<OrderDriftRow>> GetOrderDriftAsync(CancellationToken ct = default)
     {
         await using var ctx = await _factory.CreateDbContextAsync(ct);
+        // Filter must run against the source entity, not the projected record:
+        // EF can't translate a Where over a Select-projected DTO's properties
+        // (it tries to re-evaluate the constructor inside SQL and fails). Push
+        // the IssuedCount > ValidCount predicate upstream as a subquery on the
+        // attendee collection.
         return await ctx.TicketOrders
             .AsNoTracking()
             .Where(o => o.PaymentStatus == TicketPaymentStatus.Paid)
+            .Where(o => o.Attendees.Count(a => a.Status == TicketAttendeeStatus.Valid
+                                               || a.Status == TicketAttendeeStatus.CheckedIn)
+                        < o.Attendees.Count())
             .Select(o => new OrderDriftRow(
                 o.Id,
                 o.VendorOrderId,
@@ -961,7 +969,6 @@ public sealed class TicketRepository : ITicketRepository
                 o.Attendees.Count(a => a.Status == TicketAttendeeStatus.Valid
                                        || a.Status == TicketAttendeeStatus.CheckedIn),
                 o.VendorDashboardUrl))
-            .Where(r => r.ValidCount < r.IssuedCount)
             .OrderByDescending(r => r.IssuedCount - r.ValidCount) // arch:db-sort-ok — diagnostic prioritisation, not display sort
             .ToListAsync(ct);
     }


### PR DESCRIPTION
## Summary

- `/Tickets/Admin/Transfers` returns 500 in QA: `InvalidOperationException` — EF can't translate `.Where(r => r.ValidCount < r.IssuedCount)` over a `Select`-projected `OrderDriftRow` record.
- Move the drift predicate upstream onto the source `TicketOrder` query (`o.Attendees.Count(valid) < o.Attendees.Count()`), then project. Same shape, EF-translatable.

## Why the test didn't catch it

`TicketRepository_OrderDriftTests` uses `UseInMemoryDatabase`, which executes the LINQ in-process and never exercises the SQL translator. The in-memory provider tolerated the projected-record predicate; the SQL provider didn't.

Existing test still passes against the rewritten query.

## Test plan

- [x] `dotnet build Humans.slnx -v quiet` — clean
- [x] `dotnet test --filter TicketRepository_OrderDriftTests` — 1/1 passing
- [ ] Preview env: visit `/Tickets/Admin/Transfers` — page loads (no 500)

🤖 Generated with [Claude Code](https://claude.com/claude-code)