### PR TITLE
Fix DI cycle: TeamResourceService → IGoogleDrivePermissionsClient

### DIFF
--- a/src/Humans.Application/Services/Teams/TeamResourceService.cs
+++ b/src/Humans.Application/Services/Teams/TeamResourceService.cs
@@ -24,7 +24,7 @@ public sealed partial class TeamResourceService : ITeamResourceService
 {
     private readonly IGoogleResourceRepository _repository;
     private readonly ITeamResourceGoogleClient _googleClient;
-    private readonly IGoogleSyncService _googleSyncService;
+    private readonly IGoogleDrivePermissionsClient _drivePermissions;
     private readonly ITeamService _teamService;
     private readonly IRoleAssignmentService _roleAssignmentService;
     private readonly IAuditLogService _auditLogService;
@@ -35,7 +35,7 @@ public sealed partial class TeamResourceService : ITeamResourceService
     public TeamResourceService(
         IGoogleResourceRepository repository,
         ITeamResourceGoogleClient googleClient,
-        IGoogleSyncService googleSyncService,
+        IGoogleDrivePermissionsClient drivePermissions,
         ITeamService teamService,
         IRoleAssignmentService roleAssignmentService,
         IAuditLogService auditLogService,
@@ -45,7 +45,7 @@ public sealed partial class TeamResourceService : ITeamResourceService
     {
         _repository = repository;
         _googleClient = googleClient;
-        _googleSyncService = googleSyncService;
+        _drivePermissions = drivePermissions;
         _teamService = teamService;
         _roleAssignmentService = roleAssignmentService;
         _auditLogService = auditLogService;
@@ -492,7 +492,12 @@ public sealed partial class TeamResourceService : ITeamResourceService
 
         try
         {
-            await _googleSyncService.SetInheritedPermissionsDisabledAsync(mutated.GoogleId, restrict, ct);
+            var error = await _drivePermissions.SetInheritedPermissionsDisabledAsync(mutated.GoogleId, restrict, ct);
+            if (error is not null)
+            {
+                throw new InvalidOperationException(
+                    $"Google Drive inheritedPermissionsDisabled update failed for {mutated.GoogleId}: HTTP {error.StatusCode} — {error.RawMessage}");
+            }
             _logger.LogInformation("Set RestrictInheritedAccess={Restrict} for resource {ResourceId} ({GoogleId})",
                 restrict, resourceId, mutated.GoogleId);
         }

--- a/tests/Humans.Application.Tests/Services/TeamResourceServiceDeactivateTests.cs
+++ b/tests/Humans.Application.Tests/Services/TeamResourceServiceDeactivateTests.cs
@@ -48,7 +48,7 @@ public class TeamResourceServiceDeactivateTests : IDisposable
         _service = new TeamResourceService(
             repository,
             googleClient: Substitute.For<ITeamResourceGoogleClient>(),
-            googleSyncService: Substitute.For<IGoogleSyncService>(),
+            drivePermissions: Substitute.For<IGoogleDrivePermissionsClient>(),
             teamService: Substitute.For<ITeamService>(),
             roleAssignmentService: Substitute.For<IRoleAssignmentService>(),
             auditLogService: _auditLogService,


### PR DESCRIPTION
## Summary

- PR #478 introduced a circular dependency that `ValidateOnBuild` rejects at startup:
  - `TeamResourceService` → `IGoogleSyncService` → `IGoogleGroupSync` → `ITeamResourceService`
- `TeamResourceService`'s only use of `IGoogleSyncService` was a single call to `SetInheritedPermissionsDisabledAsync` — itself a 5-line wrapper around `IGoogleDrivePermissionsClient`.
- Depend on the client directly; inline the throw-on-error check at the call site. The wrapper on `IGoogleSyncService` stays in place for `EnforceInheritedAccessRestrictionsAsync`.

## Test plan

- [x] `dotnet build Humans.slnx -v quiet` — 0 errors
- [x] `dotnet test --filter "FullyQualifiedName~TeamResourceService"` — 12/12 pass
- [ ] App starts without `InvalidOperationException` for `ITeamResourceService` circular dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)