### PR TITLE
Remove dead ShiftSignupInfo.ProfilePictureUrl + HasProfilePicture plumbing

### DIFF
--- a/src/Humans.Application/Interfaces/Shifts/IShiftManagementService.cs
+++ b/src/Humans.Application/Interfaces/Shifts/IShiftManagementService.cs
@@ -372,7 +372,7 @@ public record UrgentShift(
     int ConfirmedCount,
     int RemainingSlots,
     string DepartmentName,
-    IReadOnlyList<(Guid UserId, string DisplayName, SignupStatus Status, bool HasProfilePicture)> Signups);
+    IReadOnlyList<(Guid UserId, string DisplayName, SignupStatus Status)> Signups);
 
 /// <summary>
 /// Per-day staffing data for set-up/event/strike visualization.

--- a/src/Humans.Application/Services/Shifts/ShiftManagementService.cs
+++ b/src/Humans.Application/Services/Shifts/ShiftManagementService.cs
@@ -638,8 +638,7 @@ public sealed class ShiftManagementService : IShiftManagementService, IShiftAuth
                             return (
                                 ss.UserId,
                                 DisplayName: user?.DisplayName ?? string.Empty,
-                                ss.Status,
-                                HasProfilePicture: user?.ProfilePictureUrl is not null);
+                                ss.Status);
                         })
                         .OrderBy(ss => ss.Status == SignupStatus.Confirmed ? 0 : 1)
                         .ThenBy(ss => ss.DisplayName, StringComparer.OrdinalIgnoreCase)

--- a/src/Humans.Web/Controllers/WidgetGalleryController.cs
+++ b/src/Humans.Web/Controllers/WidgetGalleryController.cs
@@ -213,9 +213,7 @@ public sealed class WidgetGalleryController : HumansControllerBase
             RemainingSlots = u.RemainingSlots,
             UrgencyScore = u.UrgencyScore,
             Signups = u.Signups
-                .Select(s => new ShiftSignupInfo(
-                    s.UserId, s.DisplayName, s.Status,
-                    s.HasProfilePicture ? $"/Profile/Picture?id={s.UserId}" : null))
+                .Select(s => new ShiftSignupInfo(s.UserId, s.DisplayName, s.Status))
                 .ToList(),
         };
     }

--- a/src/Humans.Web/Models/ShiftViewModels.cs
+++ b/src/Humans.Web/Models/ShiftViewModels.cs
@@ -263,7 +263,7 @@ public class RotaShiftGroup
     public int TotalSlots { get; set; }
 }
 
-public record ShiftSignupInfo(Guid UserId, string DisplayName, SignupStatus Status, string? ProfilePictureUrl);
+public record ShiftSignupInfo(Guid UserId, string DisplayName, SignupStatus Status);
 
 public class ShiftDisplayItem
 {

--- a/src/Humans.Web/Models/Shifts/ShiftBrowseMapper.cs
+++ b/src/Humans.Web/Models/Shifts/ShiftBrowseMapper.cs
@@ -31,9 +31,7 @@ internal static class ShiftBrowseMapper
             RemainingSlots = u.RemainingSlots,
             UrgencyScore = u.UrgencyScore,
             Signups = u.Signups
-                .Select(s => new ShiftSignupInfo(
-                    s.UserId, s.DisplayName, s.Status,
-                    s.HasProfilePicture ? $"/Profile/Picture?id={s.UserId}" : null))
+                .Select(s => new ShiftSignupInfo(s.UserId, s.DisplayName, s.Status))
                 .ToList(),
         };
     }


### PR DESCRIPTION
## Summary
Deletes the dead `ShiftSignupInfo.ProfilePictureUrl` field and the `HasProfilePicture` plumbing through `IShiftManagementService`. `<vc:human>` is the sole avatar producer now.

Closes nobodies-collective/Humans#704

## Test plan
- [x] Build green
- [x] Tests green
- [ ] Manual: visit `/Teams/{slug}/Shifts` (admin rota — uses `Views/ShiftAdmin/Index.cshtml`) and confirm avatars still render
- [ ] Manual: visit `/Shifts` (public rota — uses `_EventRotaTable` / `_BuildStrikeRotaTable`) and confirm avatars still render

Note: the issue body listed `/Shifts/Admin/Index` as the smoke URL — that route does not exist. `ShiftAdminController` is team-scoped (`[Route("Teams/{slug}/Shifts")]`), so the admin rota lives at `/Teams/{slug}/Shifts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)