### PR TITLE
Extract comm-prefs panel into ViewComponent; show on admin profile

### DIFF
--- a/src/Humans.Web/Controllers/ProfileController.cs
+++ b/src/Humans.Web/Controllers/ProfileController.cs
@@ -1695,7 +1695,9 @@ public class ProfileController : HumansControllerBase
             if (user is null)
                 return NotFound();
 
-            return View(await BuildCommunicationPreferencesViewModelAsync(user.Id));
+            // Panel rendering moved to CommunicationPreferencesPanelViewComponent (issue #706).
+            // The view invokes the VC with the current user's id; no model needed.
+            return View(model: user.Id);
         }
         catch (Exception ex)
         {
@@ -2724,40 +2726,6 @@ public class ProfileController : HumansControllerBase
                 ? user.IdentityEmailColumn
                 : null,
         };
-    }
-
-    private async Task<CommunicationPreferencesViewModel> BuildCommunicationPreferencesViewModelAsync(Guid userId)
-    {
-        var prefs = await _commPrefService.GetPreferencesAsync(userId);
-        var prefsByCategory = prefs.ToDictionary(p => p.Category);
-
-        // Check if user is a matched ticket attendee (locks ticketing preference)
-        var hasTicketOrder = await _ticketQueryService.HasTicketAttendeeMatchAsync(userId);
-
-        var categories = new List<CategoryPreferenceItem>();
-
-        foreach (var category in MessageCategoryExtensions.ActiveCategories)
-        {
-            var pref = prefsByCategory.GetValueOrDefault(category);
-            var isAlwaysOn = category.IsAlwaysOn();
-            var isTicketingLocked = category == MessageCategory.Ticketing && hasTicketOrder;
-
-            categories.Add(new CategoryPreferenceItem
-            {
-                Category = category,
-                DisplayName = category == MessageCategory.Ticketing
-                    ? $"Ticketing — {_clock.GetCurrentInstant().InUtc().Year}"
-                    : category.ToDisplayName(),
-                Description = category.ToDescription(),
-                EmailEnabled = pref is null || !pref.OptedOut,
-                AlertEnabled = pref?.InboxEnabled ?? true,
-                EmailEditable = !isAlwaysOn && !isTicketingLocked,
-                AlertEditable = !isAlwaysOn && !isTicketingLocked,
-                Note = isTicketingLocked ? "Locked — you have a ticket for this year" : null,
-            });
-        }
-
-        return new CommunicationPreferencesViewModel { Categories = categories };
     }
 
 }

--- a/src/Humans.Web/Models/CommunicationPreferenceViewModels.cs
+++ b/src/Humans.Web/Models/CommunicationPreferenceViewModels.cs
@@ -1,4 +1,5 @@
 using Humans.Domain.Enums;
+using NodaTime;
 
 namespace Humans.Web.Models;
 
@@ -17,6 +18,13 @@ public class CommunicationPreferencesViewModel
     /// "Unsubscribe from <category>" banner and pre-focuses that row in the matrix.
     /// </summary>
     public MessageCategory? HighlightCategory { get; set; }
+
+    /// <summary>
+    /// When true, the panel renders values only (no toggles, no POST forms) and exposes
+    /// <see cref="CategoryPreferenceItem.UpdateSource"/> / <see cref="CategoryPreferenceItem.UpdatedAt"/>
+    /// for admin attribution. False on self-service.
+    /// </summary>
+    public bool ReadOnly { get; set; }
 }
 
 public class CategoryPreferenceItem
@@ -52,4 +60,16 @@ public class CategoryPreferenceItem
     /// Optional note shown below the category (e.g., "Locked — you have a ticket order for 2026").
     /// </summary>
     public string? Note { get; set; }
+
+    /// <summary>
+    /// Who/what last changed this preference (e.g. "Profile", "MailerLiteSync", "MagicLink").
+    /// Surfaced in admin read-only view; null on self-service.
+    /// </summary>
+    public string? UpdateSource { get; set; }
+
+    /// <summary>
+    /// When this preference was last changed. Null if no preference row exists yet
+    /// (i.e. the user has never touched this category and we're showing defaults).
+    /// </summary>
+    public Instant? UpdatedAt { get; set; }
 }

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -1656,6 +1656,8 @@
   <data name="CommPrefs_OneClick_Hint" xml:space="preserve"><value>One-click unsubscribe, or fine-tune the matrix below.</value></data>
   <data name="CommPrefs_OneClick_Button" xml:space="preserve"><value>Unsubscribe from {0}</value></data>
   <data name="CommPrefs_OneClick_Done" xml:space="preserve"><value>Unsubscribed. You can re-enable any category below.</value></data>
+  <data name="CommPrefs_UpdateSource" xml:space="preserve"><value>Source</value></data>
+  <data name="CommPrefs_UpdatedAt" xml:space="preserve"><value>Updated</value></data>
 
   <data name="Emails_Header_Email" xml:space="preserve"><value>Email</value></data>
   <data name="Emails_Header_Status" xml:space="preserve"><value>Status</value></data>

--- a/src/Humans.Web/ViewComponents/CommunicationPreferencesPanelViewComponent.cs
+++ b/src/Humans.Web/ViewComponents/CommunicationPreferencesPanelViewComponent.cs
@@ -1,0 +1,72 @@
+using Humans.Application.Interfaces.Profiles;
+using Humans.Application.Interfaces.Tickets;
+using Humans.Domain.Enums;
+using Humans.Web.Models;
+using Microsoft.AspNetCore.Mvc;
+using NodaTime;
+
+namespace Humans.Web.ViewComponents;
+
+/// <summary>
+/// Renders the communication-preferences matrix for a given user.
+/// Two modes:
+///   - <c>readonly: false</c> (self-service, default): toggle checkboxes that POST to
+///     <c>/Profile/Me/CommunicationPreferences/Update</c>.
+///   - <c>readonly: true</c> (admin view on <c>/Profile/{id}/Admin</c>): values only,
+///     plus per-category <c>UpdateSource</c> and <c>UpdatedAt</c> for attribution.
+///     No POST forms, no anti-forgery, no submit buttons.
+/// </summary>
+public sealed class CommunicationPreferencesPanelViewComponent : ViewComponent
+{
+    private readonly ICommunicationPreferenceService _commPrefService;
+    private readonly ITicketQueryService _ticketQueryService;
+    private readonly IClock _clock;
+
+    public CommunicationPreferencesPanelViewComponent(
+        ICommunicationPreferenceService commPrefService,
+        ITicketQueryService ticketQueryService,
+        IClock clock)
+    {
+        _commPrefService = commPrefService;
+        _ticketQueryService = ticketQueryService;
+        _clock = clock;
+    }
+
+    public async Task<IViewComponentResult> InvokeAsync(Guid userId, bool readOnly = false)
+    {
+        var prefs = await _commPrefService.GetPreferencesAsync(userId);
+        var prefsByCategory = prefs.ToDictionary(p => p.Category);
+
+        var hasTicketOrder = await _ticketQueryService.HasTicketAttendeeMatchAsync(userId);
+
+        var categories = new List<CategoryPreferenceItem>();
+        foreach (var category in MessageCategoryExtensions.ActiveCategories)
+        {
+            var pref = prefsByCategory.GetValueOrDefault(category);
+            var isAlwaysOn = category.IsAlwaysOn();
+            var isTicketingLocked = category == MessageCategory.Ticketing && hasTicketOrder;
+
+            categories.Add(new CategoryPreferenceItem
+            {
+                Category = category,
+                DisplayName = category == MessageCategory.Ticketing
+                    ? $"Ticketing — {_clock.GetCurrentInstant().InUtc().Year}"
+                    : category.ToDisplayName(),
+                Description = category.ToDescription(),
+                EmailEnabled = pref is null || !pref.OptedOut,
+                AlertEnabled = pref?.InboxEnabled ?? true,
+                EmailEditable = !isAlwaysOn && !isTicketingLocked,
+                AlertEditable = !isAlwaysOn && !isTicketingLocked,
+                Note = isTicketingLocked ? "Locked — you have a ticket for this year" : null,
+                UpdateSource = pref?.UpdateSource,
+                UpdatedAt = pref?.UpdatedAt,
+            });
+        }
+
+        return View(new CommunicationPreferencesViewModel
+        {
+            Categories = categories,
+            ReadOnly = readOnly,
+        });
+    }
+}

--- a/src/Humans.Web/Views/Profile/AdminDetail.cshtml
+++ b/src/Humans.Web/Views/Profile/AdminDetail.cshtml
@@ -215,6 +215,9 @@
 
         <vc:shift-signups user-id="@Model.UserId" view-mode="@ShiftSignupsViewMode.Admin" display-name="@Model.DisplayName" />
 
+        <h5 class="mt-4 mb-2">@Localizer["CommPrefs_Title"]</h5>
+        <vc:communication-preferences-panel user-id="@Model.UserId" read-only="true" />
+
         <vc:audit-log user-id="@Model.UserId" limit="50" title="@Localizer["AdminHuman_AuditHistory"].Value" />
 
         @if (campaignGrants != null && campaignGrants.Any())

--- a/src/Humans.Web/Views/Profile/CommunicationPreferences.cshtml
+++ b/src/Humans.Web/Views/Profile/CommunicationPreferences.cshtml
@@ -1,6 +1,7 @@
-@model Humans.Web.Models.CommunicationPreferencesViewModel
+@model Guid
 @{
     ViewData["Title"] = Localizer["CommPrefs_Title"].Value;
+    var userId = Model;
 }
 
 <div class="row">
@@ -17,74 +18,7 @@
 
         <vc:temp-data-alerts />
 
-        <div class="card mb-4">
-            <div class="table-responsive">
-                <table class="table table-hover mb-0 align-middle">
-                    <thead>
-                        <tr>
-                            <th style="min-width: 250px;">@Localizer["CommPrefs_Category"]</th>
-                            <th class="text-center" style="width: 100px;">@Localizer["CommPrefs_Email"]</th>
-                            <th class="text-center" style="width: 100px;">@Localizer["CommPrefs_Alert"]</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        @for (var i = 0; i < Model.Categories.Count; i++)
-                        {
-                            var item = Model.Categories[i];
-
-                            <tr class="@(!item.EmailEditable ? "table-light" : "")">
-                                <td>
-                                    <div class="fw-semibold">@item.DisplayName</div>
-                                    <div class="form-text mb-0">@item.Description</div>
-                                    @if (item.Note is not null)
-                                    {
-                                        <div class="form-text text-warning-emphasis mb-0">
-                                            <i class="fa-solid fa-lock fa-xs me-1"></i>@item.Note
-                                        </div>
-                                    }
-                                </td>
-                                <td class="text-center">
-                                    @if (item.EmailEditable)
-                                    {
-                                        <input type="checkbox"
-                                               class="form-check-input pref-toggle"
-                                               data-category="@item.Category"
-                                               data-channel="email"
-                                               @(item.EmailEnabled ? "checked" : null) />
-                                    }
-                                    else
-                                    {
-                                        <input type="checkbox"
-                                               class="form-check-input"
-                                               checked
-                                               disabled />
-                                        <span class="text-muted small">Always on</span>
-                                    }
-                                </td>
-                                <td class="text-center">
-                                    @if (item.AlertEditable)
-                                    {
-                                        <input type="checkbox"
-                                               class="form-check-input pref-toggle"
-                                               data-category="@item.Category"
-                                               data-channel="alert"
-                                               @(item.AlertEnabled ? "checked" : null) />
-                                    }
-                                    else
-                                    {
-                                        <input type="checkbox"
-                                               class="form-check-input"
-                                               checked
-                                               disabled />
-                                        <span class="text-muted small">Always on</span>
-                                    }
-                                </td>
-                            </tr>
-                        }
-                    </tbody>
-                </table>
-            </div>
-        </div>
+        <vc:communication-preferences-panel user-id="@userId" read-only="false" />
 
         <a asp-action="Index" class="btn btn-outline-secondary">@Localizer["CommPrefs_BackToProfile"]</a>
     </div>
@@ -134,6 +68,3 @@
     });
 </script>
 }
-
-@* Anti-forgery token for AJAX posts *@
-<form id="__AjaxAntiForgeryForm" asp-antiforgery="true" style="display:none;"></form>

--- a/src/Humans.Web/Views/Shared/Components/CommunicationPreferencesPanel/Default.cshtml
+++ b/src/Humans.Web/Views/Shared/Components/CommunicationPreferencesPanel/Default.cshtml
@@ -1,0 +1,121 @@
+@model Humans.Web.Models.CommunicationPreferencesViewModel
+@{
+    var isReadOnly = Model.ReadOnly;
+}
+
+<div class="card mb-4">
+    <div class="table-responsive">
+        <table class="table table-hover mb-0 align-middle">
+            <thead>
+                <tr>
+                    <th style="min-width: 250px;">@Localizer["CommPrefs_Category"]</th>
+                    <th class="text-center" style="width: 100px;">@Localizer["CommPrefs_Email"]</th>
+                    <th class="text-center" style="width: 100px;">@Localizer["CommPrefs_Alert"]</th>
+                    @if (isReadOnly)
+                    {
+                        <th style="min-width: 140px;">@Localizer["CommPrefs_UpdateSource"]</th>
+                        <th style="min-width: 160px;">@Localizer["CommPrefs_UpdatedAt"]</th>
+                    }
+                </tr>
+            </thead>
+            <tbody>
+                @for (var i = 0; i < Model.Categories.Count; i++)
+                {
+                    var item = Model.Categories[i];
+
+                    <tr class="@(!item.EmailEditable ? "table-light" : "")">
+                        <td>
+                            <div class="fw-semibold">@item.DisplayName</div>
+                            <div class="form-text mb-0">@item.Description</div>
+                            @if (item.Note is not null)
+                            {
+                                <div class="form-text text-warning-emphasis mb-0">
+                                    <i class="fa-solid fa-lock fa-xs me-1"></i>@item.Note
+                                </div>
+                            }
+                        </td>
+                        <td class="text-center">
+                            @if (isReadOnly)
+                            {
+                                <input type="checkbox"
+                                       class="form-check-input"
+                                       checked="@item.EmailEnabled"
+                                       disabled />
+                            }
+                            else if (item.EmailEditable)
+                            {
+                                <input type="checkbox"
+                                       class="form-check-input pref-toggle"
+                                       data-category="@item.Category"
+                                       data-channel="email"
+                                       @(item.EmailEnabled ? "checked" : null) />
+                            }
+                            else
+                            {
+                                <input type="checkbox"
+                                       class="form-check-input"
+                                       checked
+                                       disabled />
+                                <span class="text-muted small">Always on</span>
+                            }
+                        </td>
+                        <td class="text-center">
+                            @if (isReadOnly)
+                            {
+                                <input type="checkbox"
+                                       class="form-check-input"
+                                       checked="@item.AlertEnabled"
+                                       disabled />
+                            }
+                            else if (item.AlertEditable)
+                            {
+                                <input type="checkbox"
+                                       class="form-check-input pref-toggle"
+                                       data-category="@item.Category"
+                                       data-channel="alert"
+                                       @(item.AlertEnabled ? "checked" : null) />
+                            }
+                            else
+                            {
+                                <input type="checkbox"
+                                       class="form-check-input"
+                                       checked
+                                       disabled />
+                                <span class="text-muted small">Always on</span>
+                            }
+                        </td>
+                        @if (isReadOnly)
+                        {
+                            <td>
+                                @if (!string.IsNullOrEmpty(item.UpdateSource))
+                                {
+                                    <code class="small">@item.UpdateSource</code>
+                                }
+                                else
+                                {
+                                    <span class="text-muted small">—</span>
+                                }
+                            </td>
+                            <td>
+                                @if (item.UpdatedAt is { } updatedAt)
+                                {
+                                    <span class="small">@updatedAt.ToDisplayDateTime()</span>
+                                }
+                                else
+                                {
+                                    <span class="text-muted small">—</span>
+                                }
+                            </td>
+                        }
+                    </tr>
+                }
+            </tbody>
+        </table>
+    </div>
+</div>
+
+@if (!isReadOnly)
+{
+    @* Anti-forgery token for AJAX posts. Read by the toggle script on the host view. *@
+    <form id="__AjaxAntiForgeryForm" asp-antiforgery="true" style="display:none;"></form>
+}

--- a/src/Humans.Web/Views/Shared/Components/CommunicationPreferencesPanel/Default.cshtml
+++ b/src/Humans.Web/Views/Shared/Components/CommunicationPreferencesPanel/Default.cshtml
@@ -37,10 +37,14 @@
                         <td class="text-center">
                             @if (isReadOnly)
                             {
-                                <input type="checkbox"
-                                       class="form-check-input"
-                                       checked="@item.EmailEnabled"
-                                       disabled />
+                                if (item.EmailEnabled)
+                                {
+                                    <input type="checkbox" class="form-check-input" checked disabled />
+                                }
+                                else
+                                {
+                                    <input type="checkbox" class="form-check-input" disabled />
+                                }
                             }
                             else if (item.EmailEditable)
                             {
@@ -62,10 +66,14 @@
                         <td class="text-center">
                             @if (isReadOnly)
                             {
-                                <input type="checkbox"
-                                       class="form-check-input"
-                                       checked="@item.AlertEnabled"
-                                       disabled />
+                                if (item.AlertEnabled)
+                                {
+                                    <input type="checkbox" class="form-check-input" checked disabled />
+                                }
+                                else
+                                {
+                                    <input type="checkbox" class="form-check-input" disabled />
+                                }
                             }
                             else if (item.AlertEditable)
                             {

--- a/src/Humans.Web/Views/WidgetGallery/Index.cshtml
+++ b/src/Humans.Web/Views/WidgetGallery/Index.cshtml
@@ -331,6 +331,34 @@
                 <div class="wg-card">
                     <div class="wg-card-header">
                         <div>
+                            <span class="wg-card-name">&lt;vc:communication-preferences-panel&gt;</span>
+                            <span class="wg-card-kind kind-vc">ViewComponent</span>
+                        </div>
+                        <span class="wg-card-path">src/Humans.Web/ViewComponents/CommunicationPreferencesPanelViewComponent.cs</span>
+                    </div>
+                    <div class="wg-card-note">
+                        Per-user communication-preferences matrix. Write mode (default) renders toggle checkboxes that POST to <code>/Profile/Me/CommunicationPreferences/Update</code>. Read-only mode hides the form and surfaces <code>UpdateSource</code> + <code>UpdatedAt</code> per category — used on <code>/Profile/{id}/Admin</code>.
+                    </div>
+                    @ParamsBlock(
+                        ("user-id", "<code>Guid</code> — required"),
+                        ("read-only", "<code>bool</code> — default <code>false</code>; <code>true</code> hides forms and adds attribution columns")
+                    )
+                    <div class="wg-variants">
+                        <div class="wg-variant-label">read-only="false"<span class="wg-variant-sub">default — toggleable</span></div>
+                        <div class="wg-variant-render" style="display:block;">
+                            <vc:communication-preferences-panel user-id="@Model.CurrentUserId" />
+                        </div>
+
+                        <div class="wg-variant-label">read-only="true"<span class="wg-variant-sub">admin view</span></div>
+                        <div class="wg-variant-render" style="display:block;">
+                            <vc:communication-preferences-panel user-id="@Model.CurrentUserId" read-only="true" />
+                        </div>
+                    </div>
+                </div>
+
+                <div class="wg-card">
+                    <div class="wg-card-header">
+                        <div>
                             <span class="wg-card-name">_HumanPopover.cshtml</span>
                             <span class="wg-card-kind kind-pa">Partial</span>
                         </div>


### PR DESCRIPTION
## Summary
- Extracts the comm-prefs panel from `Views/Profile/CommunicationPreferences.cshtml` into `CommunicationPreferencesPanelViewComponent`.
- Self-service view reuses the VC (write mode).
- `/Profile/{id}/Admin` renders it in readonly mode with `UpdateSource` + `UpdatedAt` columns.

Closes nobodies-collective/Humans#706

## Test plan
- [x] Build green
- [x] Tests green
- [ ] Manual: `/Profile/Me/CommunicationPreferences` still toggleable
- [ ] Manual: `/Profile/{id}/Admin` shows read-only panel with source/updated columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)