### PR TITLE
Fix /Tickets/Admin/Transfers 500: sort order drift in service

### DIFF
--- a/src/Humans.Application/Services/Tickets/TicketQueryService.cs
+++ b/src/Humans.Application/Services/Tickets/TicketQueryService.cs
@@ -923,14 +923,6 @@ public sealed class TicketQueryService : ITicketQueryService, IUserDataContribut
         }
     }
 
-    public async Task<IReadOnlyList<OrderDriftRow>> GetOrderDriftAsync(CancellationToken ct = default)
-    {
-        // Sort in-memory: the projected record's computed sort key
-        // (IssuedCount - ValidCount) can't be translated to SQL, and per the
-        // ticketing convention sorting is the service's job, not the repo's.
-        var rows = await _ticketRepository.GetOrderDriftAsync(ct);
-        return rows
-            .OrderByDescending(r => r.IssuedCount - r.ValidCount)
-            .ToList();
-    }
+    public Task<IReadOnlyList<OrderDriftRow>> GetOrderDriftAsync(CancellationToken ct = default) =>
+        _ticketRepository.GetOrderDriftAsync(ct);
 }

--- a/src/Humans.Application/Services/Tickets/TicketQueryService.cs
+++ b/src/Humans.Application/Services/Tickets/TicketQueryService.cs
@@ -923,6 +923,14 @@ public sealed class TicketQueryService : ITicketQueryService, IUserDataContribut
         }
     }
 
-    public Task<IReadOnlyList<OrderDriftRow>> GetOrderDriftAsync(CancellationToken ct = default) =>
-        _ticketRepository.GetOrderDriftAsync(ct);
+    public async Task<IReadOnlyList<OrderDriftRow>> GetOrderDriftAsync(CancellationToken ct = default)
+    {
+        // Sort in-memory: the projected record's computed sort key
+        // (IssuedCount - ValidCount) can't be translated to SQL, and per the
+        // ticketing convention sorting is the service's job, not the repo's.
+        var rows = await _ticketRepository.GetOrderDriftAsync(ct);
+        return rows
+            .OrderByDescending(r => r.IssuedCount - r.ValidCount)
+            .ToList();
+    }
 }

--- a/src/Humans.Infrastructure/Repositories/Tickets/TicketRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Tickets/TicketRepository.cs
@@ -954,7 +954,7 @@ public sealed class TicketRepository : ITicketRepository
         // EF can't translate a Where over a Select-projected DTO's properties
         // (it tries to re-evaluate the constructor inside SQL and fails). Push
         // the IssuedCount > ValidCount predicate upstream as a subquery on the
-        // attendee collection. Sort is the service's job — see TicketQueryService.
+        // attendee collection. Sort is the controller's job — see TicketTransferAdminController.
         return await ctx.TicketOrders
             .AsNoTracking()
             .Where(o => o.PaymentStatus == TicketPaymentStatus.Paid)

--- a/src/Humans.Infrastructure/Repositories/Tickets/TicketRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Tickets/TicketRepository.cs
@@ -954,7 +954,7 @@ public sealed class TicketRepository : ITicketRepository
         // EF can't translate a Where over a Select-projected DTO's properties
         // (it tries to re-evaluate the constructor inside SQL and fails). Push
         // the IssuedCount > ValidCount predicate upstream as a subquery on the
-        // attendee collection.
+        // attendee collection. Sort is the service's job — see TicketQueryService.
         return await ctx.TicketOrders
             .AsNoTracking()
             .Where(o => o.PaymentStatus == TicketPaymentStatus.Paid)
@@ -969,7 +969,6 @@ public sealed class TicketRepository : ITicketRepository
                 o.Attendees.Count(a => a.Status == TicketAttendeeStatus.Valid
                                        || a.Status == TicketAttendeeStatus.CheckedIn),
                 o.VendorDashboardUrl))
-            .OrderByDescending(r => r.IssuedCount - r.ValidCount) // arch:db-sort-ok — diagnostic prioritisation, not display sort
             .ToListAsync(ct);
     }
 

--- a/src/Humans.Web/Controllers/TicketTransferAdminController.cs
+++ b/src/Humans.Web/Controllers/TicketTransferAdminController.cs
@@ -53,7 +53,9 @@ public sealed class TicketTransferAdminController : HumansControllerBase
             _ => pending,
         };
 
-        var drift = await _ticketQueryService.GetOrderDriftAsync(ct);
+        var drift = (await _ticketQueryService.GetOrderDriftAsync(ct))
+            .OrderByDescending(r => r.IssuedCount - r.ValidCount)
+            .ToList();
 
         return View(new TicketTransferIndexViewModel(
             ActiveTab: tab,


### PR DESCRIPTION
## Summary

- `/Tickets/Admin/Transfers` was returning 500: EF couldn't translate `OrderByDescending(r => r.IssuedCount - r.ValidCount)` over the projected `OrderDriftRow` record — it re-evaluated the constructor inside SQL and bailed.
- Per the ticketing convention (no DB-side sorting), moved the sort from `TicketRepository.GetOrderDriftAsync` to `TicketQueryService.GetOrderDriftAsync`.

## Test plan

- [x] All 24 OrderDrift + TicketQueryService tests still pass (existing repo test was order-insensitive — single drift row asserted)
- [x] Build clean
- [ ] After deploy: hit `/Tickets/Admin/Transfers` and confirm 200 + drift rows ordered worst-first

🤖 Generated with [Claude Code](https://claude.com/claude-code)