### PR TITLE
Fix SendAddedToTeamEmailAsync crash when user has no primary email

### DIFF
--- a/src/Humans.Application/Services/Teams/TeamService.cs
+++ b/src/Humans.Application/Services/Teams/TeamService.cs
@@ -2076,16 +2076,17 @@ public sealed class TeamService : ITeamService, IGoogleGroupMembershipSource, IU
                 _logger.LogWarning(
                     "Skipping added-to-team email for user {UserId}: no notification-target email",
                     userId);
-                return;
             }
+            else
+            {
+                var resources = await TeamResourceService.GetTeamResourcesAsync(team.Id, cancellationToken);
 
-            var resources = await TeamResourceService.GetTeamResourcesAsync(team.Id, cancellationToken);
-
-            await EmailService.SendAddedToTeamAsync(
-                email, user.DisplayName, team.Name, team.Slug,
-                resources.Select(r => (r.Name, r.Url)),
-                user.PreferredLanguage,
-                cancellationToken);
+                await EmailService.SendAddedToTeamAsync(
+                    email, user.DisplayName, team.Name, team.Slug,
+                    resources.Select(r => (r.Name, r.Url)),
+                    user.PreferredLanguage,
+                    cancellationToken);
+            }
         }
         catch (Exception ex)
         {

--- a/src/Humans.Application/Services/Teams/TeamService.cs
+++ b/src/Humans.Application/Services/Teams/TeamService.cs
@@ -2066,10 +2066,19 @@ public sealed class TeamService : ITeamService, IGoogleGroupMembershipSource, IU
 
         try
         {
-            var user = await UserService.GetByIdAsync(userId, cancellationToken);
-            if (user is null) return;
+            var users = await UserService.GetByIdsWithEmailsAsync(new[] { userId }, cancellationToken);
+            if (!users.TryGetValue(userId, out var user))
+                return;
 
-            var email = user.Email!;
+            var email = user.Email;
+            if (string.IsNullOrEmpty(email))
+            {
+                _logger.LogWarning(
+                    "Skipping added-to-team email for user {UserId}: no notification-target email",
+                    userId);
+                return;
+            }
+
             var resources = await TeamResourceService.GetTeamResourcesAsync(team.Id, cancellationToken);
 
             await EmailService.SendAddedToTeamAsync(


### PR DESCRIPTION
## Summary

`TeamService.SendAddedToTeamEmailAsync` read `var email = user.Email!;`. The null-forgiving operator silently passed null to `OutboxEmailService.EnqueueAsync` for users with no verified `UserEmail` rows and an empty legacy Identity email, hitting the `RecipientEmail IS NOT NULL` constraint on `email_outbox_messages` (production, 2026-05-07).

- Switch to `UserService.GetByIdsWithEmailsAsync` so the verified UserEmails collection is hydrated and `User.Email`'s computed override picks the canonical primary email.
- When `User.Email` is still null/empty (no verified rows AND legacy Identity column also empty), skip cleanly with a Warning log instead of attempting to enqueue.
- Service-side guard stays the same — this is the upstream caller that should never have produced a null recipient.

Closes nobodies-collective/Humans#675

## Test plan

- [ ] CI green
- [ ] Manual: add an existing user with verified primary email to a team — they receive the email.
- [ ] Manual / synthetic: add a user with no verified UserEmail rows to a team — team-add completes; Warning log emitted; no DbUpdateException.