### PR TITLE
Gate camp Approve/Reject buttons on member Status (#678)

### DIFF
--- a/src/Humans.Application/Interfaces/Camps/ICampService.cs
+++ b/src/Humans.Application/Interfaces/Camps/ICampService.cs
@@ -377,7 +377,8 @@ public record CampMemberRow(
     Instant RequestedAt,
     Instant? ConfirmedAt,
     bool IsLead,
-    bool HasEarlyEntry);
+    bool HasEarlyEntry,
+    CampMemberStatus Status);
 
 public record CampMembershipSummary(
     Guid CampMemberId,

--- a/src/Humans.Application/Services/Camps/CampService.cs
+++ b/src/Humans.Application/Services/Camps/CampService.cs
@@ -1797,7 +1797,8 @@ public sealed class CampService : ICampService, IUserDataContributor, IUserMerge
             .Select(m => new CampMemberRow(
                 m.Id, m.UserId, DisplayName(m.UserId, userMap), m.RequestedAt, m.ConfirmedAt,
                 IsLead: leadUserIds.Contains(m.UserId),
-                HasEarlyEntry: false))
+                HasEarlyEntry: false,
+                Status: m.Status))
             .ToList();
 
         var activeMemberUserIds = members
@@ -1810,7 +1811,8 @@ public sealed class CampService : ICampService, IUserDataContributor, IUserMerge
             .Select(m => new CampMemberRow(
                 m.Id, m.UserId, DisplayName(m.UserId, userMap), m.RequestedAt, m.ConfirmedAt,
                 IsLead: leadUserIds.Contains(m.UserId),
-                HasEarlyEntry: m.HasEarlyEntry));
+                HasEarlyEntry: m.HasEarlyEntry,
+                Status: m.Status));
 
         var activeFromLeads = activeLeads
             .Where(l => !activeMemberUserIds.Contains(l.UserId))
@@ -1821,7 +1823,8 @@ public sealed class CampService : ICampService, IUserDataContributor, IUserMerge
                 RequestedAt: l.JoinedAt,
                 ConfirmedAt: l.JoinedAt,
                 IsLead: true,
-                HasEarlyEntry: false));
+                HasEarlyEntry: false,
+                Status: CampMemberStatus.Active));
 
         var active = activeFromMembers
             .Concat(activeFromLeads)

--- a/src/Humans.Web/Controllers/CampController.cs
+++ b/src/Humans.Web/Controllers/CampController.cs
@@ -486,7 +486,8 @@ public class CampController : HumansCampControllerBase
                 RequestedAt = m.RequestedAt,
                 ConfirmedAt = m.ConfirmedAt,
                 IsLead = m.IsLead,
-                HasEarlyEntry = m.HasEarlyEntry
+                HasEarlyEntry = m.HasEarlyEntry,
+                Status = m.Status
             })
             .ToList();
         viewModel.ActiveMembers = members.Active
@@ -498,7 +499,8 @@ public class CampController : HumansCampControllerBase
                 RequestedAt = m.RequestedAt,
                 ConfirmedAt = m.ConfirmedAt,
                 IsLead = m.IsLead,
-                HasEarlyEntry = m.HasEarlyEntry
+                HasEarlyEntry = m.HasEarlyEntry,
+                Status = m.Status
             })
             .ToList();
         viewModel.EeSlotCount = members.EeSlotCount;

--- a/src/Humans.Web/Models/CampViewModels.cs
+++ b/src/Humans.Web/Models/CampViewModels.cs
@@ -173,6 +173,7 @@ public class CampMemberRowViewModel
     public NodaTime.Instant? ConfirmedAt { get; set; }
     public bool IsLead { get; set; }
     public bool HasEarlyEntry { get; set; }
+    public CampMemberStatus Status { get; set; }
 }
 
 public class CampImageViewModel

--- a/src/Humans.Web/Views/Camp/Members.cshtml
+++ b/src/Humans.Web/Views/Camp/Members.cshtml
@@ -152,18 +152,23 @@
                             <li class="list-group-item d-flex justify-content-between align-items-center gap-2">
                                 <vc:human user-id="@pending.UserId" />
                                 <div class="d-flex gap-2">
-                                    <form asp-action="ApproveMembership" asp-route-slug="@Model.Slug" asp-route-campMemberId="@pending.CampMemberId" method="post" class="d-inline">
-                                        @Html.AntiForgeryToken()
-                                        <button type="submit" class="btn btn-sm btn-outline-success" title="Approve">
-                                            <i class="fa-solid fa-check"></i>
-                                        </button>
-                                    </form>
-                                    <form asp-action="RejectMembership" asp-route-slug="@Model.Slug" asp-route-campMemberId="@pending.CampMemberId" method="post" class="d-inline">
-                                        @Html.AntiForgeryToken()
-                                        <button type="submit" class="btn btn-sm btn-outline-danger" title="Reject" data-confirm="Reject this request?">
-                                            <i class="fa-solid fa-xmark"></i>
-                                        </button>
-                                    </form>
+                                    @* Defense-in-depth: only render approve/reject when status is actually Pending.
+                                       Service-side guard in CampService.ApproveCampMemberAsync remains. *@
+                                    @if (pending.Status == Humans.Domain.Enums.CampMemberStatus.Pending)
+                                    {
+                                        <form asp-action="ApproveMembership" asp-route-slug="@Model.Slug" asp-route-campMemberId="@pending.CampMemberId" method="post" class="d-inline">
+                                            @Html.AntiForgeryToken()
+                                            <button type="submit" class="btn btn-sm btn-outline-success" title="Approve">
+                                                <i class="fa-solid fa-check"></i>
+                                            </button>
+                                        </form>
+                                        <form asp-action="RejectMembership" asp-route-slug="@Model.Slug" asp-route-campMemberId="@pending.CampMemberId" method="post" class="d-inline">
+                                            @Html.AntiForgeryToken()
+                                            <button type="submit" class="btn btn-sm btn-outline-danger" title="Reject" data-confirm="Reject this request?">
+                                                <i class="fa-solid fa-xmark"></i>
+                                            </button>
+                                        </form>
+                                    }
                                 </div>
                             </li>
                         }


### PR DESCRIPTION
## Summary

A camp admin clicked Approve for a member whose status was already `Active`. `CampService.ApproveCampMemberAsync` correctly threw, but the call should never have been issued — the Approve button was reachable for a non-Pending member (most likely a stale page after another admin approved, or a double-submit).

The data-layer projection already filters `PendingMembers` by `Status == Pending`, but that's an implicit invariant. This change adds a defense-in-depth check at the view itself.

- Added `Status` to `CampMemberRow` (Application DTO) and `CampMemberRowViewModel` (Web VM)
- Populated `Status` in `CampService.GetCampMembersAsync` and the controller projections
- Gated the Approve/Reject form block in `Views/Camp/Members.cshtml` on `pending.Status == CampMemberStatus.Pending`
- Service-side guard in `ApproveCampMemberAsync` remains unchanged

## Test plan

- [x] `dotnet build Humans.slnx -v quiet` clean
- [ ] Manual: on the Members page for a camp, an Active member's row shows no Approve action
- [ ] Manual: a Pending member's row still shows Approve and Reject

Closes nobodies-collective/Humans#678