### PR TITLE
Add server uptime + events/hour readouts to /Admin/Logs header

### DIFF
--- a/src/Humans.Web/Controllers/AdminController.cs
+++ b/src/Humans.Web/Controllers/AdminController.cs
@@ -157,6 +157,8 @@ public class AdminController : HumansControllerBase
         var sink = Infrastructure.InMemoryLogSink.Instance;
         var events = sink.GetEvents(count);
         ViewBag.LifetimeCounts = sink.GetLifetimeCounts();
+        ViewBag.SinkStartedAt = sink.StartedAt;
+        ViewBag.TotalEvents = sink.TotalEvents;
         return View(events);
     }
 

--- a/src/Humans.Web/Infrastructure/InMemoryLogSink.cs
+++ b/src/Humans.Web/Infrastructure/InMemoryLogSink.cs
@@ -18,7 +18,14 @@ public sealed class InMemoryLogSink : ILogEventSink
     public InMemoryLogSink(int capacity = 1000)
     {
         _capacity = capacity;
+        StartedAt = DateTimeOffset.UtcNow;
     }
+
+    /// <summary>UTC timestamp captured when the sink (and process) started.</summary>
+    public DateTimeOffset StartedAt { get; }
+
+    /// <summary>Total events emitted since startup, summed across all log levels.</summary>
+    public long TotalEvents => _lifetimeCounts.Values.Sum();
 
     public void Emit(LogEvent logEvent)
     {

--- a/src/Humans.Web/Views/Admin/Logs.cshtml
+++ b/src/Humans.Web/Views/Admin/Logs.cshtml
@@ -17,8 +17,8 @@
         // Examples: "2d 4h 13m", "47m", "12s".
         var parts = new List<string>(3);
         if (t.Days > 0) parts.Add($"{t.Days}d");
-        if (t.Hours > 0 || parts.Count > 0) parts.Add($"{t.Hours}h");
-        if (t.Minutes > 0 || parts.Count > 0) parts.Add($"{t.Minutes}m");
+        if (t.Hours > 0) parts.Add($"{t.Hours}h");
+        if (t.Minutes > 0) parts.Add($"{t.Minutes}m");
         if (parts.Count == 0) parts.Add($"{t.Seconds}s");
         return string.Join(' ', parts);
     }

--- a/src/Humans.Web/Views/Admin/Logs.cshtml
+++ b/src/Humans.Web/Views/Admin/Logs.cshtml
@@ -5,6 +5,27 @@
     ViewData["Title"] = "Application Logs";
     var lifetimeCounts = ViewBag.LifetimeCounts as IReadOnlyDictionary<Serilog.Events.LogEventLevel, long>
         ?? new Dictionary<Serilog.Events.LogEventLevel, long>();
+
+    var startedAt = ViewBag.SinkStartedAt is DateTimeOffset sa ? sa : DateTimeOffset.UtcNow;
+    var totalEvents = ViewBag.TotalEvents is long te ? te : 0L;
+    var uptime = DateTimeOffset.UtcNow - startedAt;
+    if (uptime < TimeSpan.Zero) { uptime = TimeSpan.Zero; }
+
+    static string HumanizeUptime(TimeSpan t)
+    {
+        // Skip zero-leading units, show two largest non-zero units down to seconds.
+        // Examples: "2d 4h 13m", "47m", "12s".
+        var parts = new List<string>(3);
+        if (t.Days > 0) parts.Add($"{t.Days}d");
+        if (t.Hours > 0 || parts.Count > 0) parts.Add($"{t.Hours}h");
+        if (t.Minutes > 0 || parts.Count > 0) parts.Add($"{t.Minutes}m");
+        if (parts.Count == 0) parts.Add($"{t.Seconds}s");
+        return string.Join(' ', parts);
+    }
+
+    var uptimeText = HumanizeUptime(uptime);
+    var hours = Math.Max(uptime.TotalHours, 1.0 / 3600);
+    var eventsPerHour = (long)Math.Round(totalEvents / hours);
 }
 
 <div class="container-fluid px-4">
@@ -17,7 +38,11 @@
 
     <div class="d-flex justify-content-between align-items-center mb-3">
         <h1>Application Logs</h1>
-        <span class="text-muted">Showing @Model.Count of last 1000 (in-memory buffer)</span>
+        <div class="text-muted text-end">
+            <div><small>Uptime: @uptimeText</small></div>
+            <div>Showing @Model.Count of last 1000 (in-memory buffer)</div>
+            <div><small>@eventsPerHour.ToString("#,##0") events/hour</small></div>
+        </div>
     </div>
 
     <div class="d-flex gap-3 mb-3 flex-wrap">


### PR DESCRIPTION
## Summary

- `InMemoryLogSink` now captures `StartedAt` at construction and exposes `TotalEvents` (sum across log levels).
- `AdminController.Logs` passes both to the view via `ViewBag` (matches existing `LifetimeCounts` pattern).
- Header replaces the single "Showing N of last 1000" span with a three-line right-aligned stack: humanized uptime above, the existing buffer line, and events/hour with thousands-separator formatting below.

Uptime humanization skips zero-leading units (e.g. `2d 4h 13m`, `47m`, `12s` for fresh starts). Rate guarded against divide-by-near-zero with `Math.Max(uptime.TotalHours, 1.0/3600)`.

Closes nobodies-collective/Humans#708

## Test plan

- [ ] Visit `/Admin/Logs` on a freshly-started instance — expect `Uptime: <seconds>s` and a non-zero `events/hour`.
- [ ] After the process has been up >1 minute, uptime should switch to `m` format; >1 hour to `h`; >1 day to `d`.
- [ ] Header layout remains clean at narrow widths (right-aligned stack inside `d-flex justify-content-between`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)