### PR TITLE
Render Markdown in Store catalog product Description

### DIFF
--- a/src/Humans.Domain/Entities/StoreProduct.cs
+++ b/src/Humans.Domain/Entities/StoreProduct.cs
@@ -1,3 +1,4 @@
+using Humans.Domain.Attributes;
 using NodaTime;
 
 namespace Humans.Domain.Entities;
@@ -7,6 +8,7 @@ public class StoreProduct
     public Guid Id { get; set; }
     public int Year { get; set; }
     public string Name { get; set; } = string.Empty;
+    [MarkdownContent]
     public string Description { get; set; } = string.Empty;
     public decimal UnitPriceEur { get; set; }
     public decimal VatRatePercent { get; set; }

--- a/src/Humans.Web/Models/ProductInputModel.cs
+++ b/src/Humans.Web/Models/ProductInputModel.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using Humans.Domain.Attributes;
 
 namespace Humans.Web.Models;
 
@@ -15,6 +16,7 @@ public sealed class ProductInputModel
     public string Name { get; set; } = string.Empty;
 
     [StringLength(2000)]
+    [MarkdownContent]
     public string Description { get; set; } = string.Empty;
 
     [Range(0.0, 1_000_000.0)]

--- a/src/Humans.Web/Views/Store/Index.cshtml
+++ b/src/Humans.Web/Views/Store/Index.cshtml
@@ -95,7 +95,7 @@ else
             {
                 <tr>
                     <td>@product.Name</td>
-                    <td>@product.Description</td>
+                    <td>@Html.SanitizedMarkdown(product.Description)</td>
                     <td class="text-end">&euro;@product.UnitPriceEur.ToString("N2")</td>
                     <td class="text-end">@product.VatRatePercent.ToString("0.##")%</td>
                     <td class="text-end">@(product.DepositAmountEur.HasValue ? $"€{product.DepositAmountEur.Value:N2}" : "—")</td>

--- a/src/Humans.Web/Views/StoreAdmin/Catalog.cshtml
+++ b/src/Humans.Web/Views/StoreAdmin/Catalog.cshtml
@@ -44,7 +44,7 @@ else
                                 <strong>@p.Name</strong>
                                 @if (!string.IsNullOrWhiteSpace(p.Description))
                                 {
-                                    <div class="small text-muted">@p.Description</div>
+                                    <div class="small text-muted">@Html.SanitizedMarkdown(p.Description)</div>
                                 }
                             </td>
                             <td class="text-end">@p.UnitPriceEur.ToString("0.00") €</td>

--- a/src/Humans.Web/Views/StoreAdmin/CatalogEdit.cshtml
+++ b/src/Humans.Web/Views/StoreAdmin/CatalogEdit.cshtml
@@ -34,7 +34,7 @@
                 </div>
                 <div class="col-12">
                     <label asp-for="Description" class="form-label">Description</label>
-                    <textarea asp-for="Description" class="form-control" rows="2"></textarea>
+                    <textarea asp-for="Description" class="form-control" rows="6"></textarea>
                     <span asp-validation-for="Description" class="text-danger small"></span>
                 </div>
                 <div class="col-md-3">
@@ -74,6 +74,8 @@
         </form>
     </div>
 </div>
+
+<partial name="_MarkdownHelp" />
 
 @section Scripts {
     <partial name="_ValidationScriptsPartial" />


### PR DESCRIPTION
## Summary
- Mark `StoreProduct.Description` (domain) and `ProductInputModel.Description` (view-model) with `[MarkdownContent]`.
- `CatalogEdit.cshtml`: textarea grows to `rows="6"` and the shared `_MarkdownHelp` partial sits below the form, matching `Camp/Edit.cshtml`.
- `/Store` and `/Store/Admin/Catalog` now render `Description` through `@Html.SanitizedMarkdown(...)` — links/lists/formatting work; HTML is sanitized via the established path.
- No new local `Markdig` / `HtmlSanitizer` / `ConvertMarkdownToHtml` calls (per `memory/code/sanitized-markdown-rendering.md`).
- No DB change.

Closes nobodies-collective/Humans#668

## Test plan
- [ ] Edit a product, paste markdown (links, list, bold), save.
- [ ] `/Store` shows formatted output (links clickable, lists render).
- [ ] `/Store/Admin/Catalog` shows the same formatted description.
- [ ] Raw `<script>` in description is sanitized away.

Generated with [Claude Code](https://claude.com/claude-code)