### PR TITLE
Fix FeedbackReport.Source has DB default but no sentinel value

### DIFF
--- a/src/Humans.Infrastructure/Data/Configurations/Feedback/FeedbackReportConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/Feedback/FeedbackReportConfiguration.cs
@@ -46,15 +46,19 @@ public class FeedbackReportConfiguration : IEntityTypeConfiguration<FeedbackRepo
             .HasMaxLength(50)
             .IsRequired();
 
-        // HasDefaultValueSql (raw SQL) instead of HasDefaultValue: the latter
-        // trips EF's sentinel detection because FeedbackSource.UserReport == 0
-        // is the CLR default and EF would silently overwrite explicit assignments
-        // with the DB default. We still need a DB-level default so the migration
-        // can backfill existing rows when this NOT-NULL column is added.
+        // Sentinel = (FeedbackSource)(-1) — not a real enum member — so EF can
+        // distinguish "explicitly assigned" from "unset". Without it the CLR
+        // default (UserReport == 0) tripped EF's sentinel detection: explicit
+        // `Source = FeedbackSource.UserReport` assignments were silently
+        // dropped in favor of the DB default. Behavior was accidentally
+        // correct only because the DB default and CLR default both produce
+        // 'UserReport' today. Keeps the DB default for migration backfill of
+        // existing rows.
         builder.Property(f => f.Source)
             .HasConversion<string>()
             .HasMaxLength(32)
             .HasDefaultValueSql("'UserReport'")
+            .HasSentinel((FeedbackSource)(-1))
             .IsRequired();
 
         builder.HasIndex(f => f.Source);


### PR DESCRIPTION
## Summary

EF was emitting an advisory at startup:

> The "FeedbackSource" property "Source" on entity type "FeedbackReport" is configured with a database-generated default, but has no configured sentinel value. The database-generated default will always be used for inserts when the property has the value "UserReport", since this is the CLR default for the "FeedbackSource" type.

Set `.HasSentinel((FeedbackSource)(-1))` — a value that is not a real enum member — so EF can distinguish "explicitly assigned" from "unset". Without it, any explicit `Source = FeedbackSource.UserReport` would be silently substituted with the DB default; the behavior was correct only by accident (both happened to produce `'UserReport'`).

Configuration-only — verified `dotnet ef migrations has-pending-model-changes` returns "No changes." No migration generated.

Closes nobodies-collective/Humans#680

## Test plan

- [ ] CI green
- [ ] Manual: app startup logs no longer emit the FeedbackSource sentinel warning.
- [ ] Existing FeedbackService.cs `new FeedbackReport { ... }` (no Source assignment) continues to persist `'UserReport'`.