### PR TITLE
Add value comparer to AgentMessage.FetchedDocs

### DIFF
--- a/src/Humans.Infrastructure/Data/Configurations/AgentMessageConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/AgentMessageConfiguration.cs
@@ -25,7 +25,7 @@ public class AgentMessageConfiguration : IEntityTypeConfiguration<AgentMessage>
                 v => System.Text.Json.JsonSerializer.Serialize(v, (System.Text.Json.JsonSerializerOptions?)null),
                 v => System.Text.Json.JsonSerializer.Deserialize<string[]>(v, (System.Text.Json.JsonSerializerOptions?)null) ?? Array.Empty<string>(),
                 new ValueComparer<string[]>(
-                    (a, b) => a != null && b != null && a.SequenceEqual(b, StringComparer.Ordinal),
+                    (a, b) => ReferenceEquals(a, b) || (a != null && b != null && a.SequenceEqual(b, StringComparer.Ordinal)),
                     v => v.Aggregate(0, (h, e) => HashCode.Combine(h, e == null ? 0 : StringComparer.Ordinal.GetHashCode(e))),
                     v => v.ToArray()));
 

--- a/src/Humans.Infrastructure/Data/Configurations/AgentMessageConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/AgentMessageConfiguration.cs
@@ -1,5 +1,6 @@
 using Humans.Domain.Entities;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace Humans.Infrastructure.Data.Configurations;
@@ -22,7 +23,11 @@ public class AgentMessageConfiguration : IEntityTypeConfiguration<AgentMessage>
             .HasColumnType("jsonb")
             .HasConversion(
                 v => System.Text.Json.JsonSerializer.Serialize(v, (System.Text.Json.JsonSerializerOptions?)null),
-                v => System.Text.Json.JsonSerializer.Deserialize<string[]>(v, (System.Text.Json.JsonSerializerOptions?)null) ?? Array.Empty<string>());
+                v => System.Text.Json.JsonSerializer.Deserialize<string[]>(v, (System.Text.Json.JsonSerializerOptions?)null) ?? Array.Empty<string>(),
+                new ValueComparer<string[]>(
+                    (a, b) => a != null && b != null && a.SequenceEqual(b, StringComparer.Ordinal),
+                    v => v.Aggregate(0, (h, e) => HashCode.Combine(h, e == null ? 0 : StringComparer.Ordinal.GetHashCode(e))),
+                    v => v.ToArray()));
 
         // Same-section FK only: agent_messages → agent_conversations.
         builder.HasOne(m => m.Conversation)


### PR DESCRIPTION
## Summary

EF Core emitted at startup:

> The property "AgentMessage"."FetchedDocs" is a collection or enumeration type with a value converter but with no value comparer. Set a value comparer to ensure the collection/enumeration elements are compared correctly.

Without a comparer, EF tracks the array by reference; an in-place mutation (Add/Remove on an existing entity's FetchedDocs) would be invisible to change tracking and silently dropped at `SaveChangesAsync`.

Add a `ValueComparer<string[]>` mirroring the project's existing list-conversion patterns (`CampSettings.OpenSeasons`, etc.):

- Equals: `SequenceEqual(StringComparer.Ordinal)`
- Hash: combined ordinal hash of elements
- Snapshot: `ToArray()`

Configuration-only — `dotnet ef migrations has-pending-model-changes` returns "No changes."

Closes nobodies-collective/Humans#679

## Test plan

- [ ] CI green
- [ ] Manual: app startup logs no longer emit the AgentMessage.FetchedDocs comparer warning.