### PR TITLE
Cache MailerLite reads on /Mailer/Admin, add manual refresh

### DIFF
--- a/src/Humans.Application/Interfaces/Mailer/IMailerLiteService.cs
+++ b/src/Humans.Application/Interfaces/Mailer/IMailerLiteService.cs
@@ -1,4 +1,5 @@
 using Humans.Application.Interfaces.Mailer.Dtos;
+using NodaTime;
 
 namespace Humans.Application.Interfaces.Mailer;
 
@@ -26,7 +27,7 @@ public interface IMailerLiteService : IApplicationService
     Task<MailerLiteSubscriber?> GetSubscriberAsync(
         string email, CancellationToken ct = default);
 
-    DateTimeOffset? LastFetchedAt { get; }
+    Instant? LastFetchedAt { get; }
 
     Task RefreshAsync(CancellationToken ct = default);
 }

--- a/src/Humans.Application/Interfaces/Mailer/IMailerLiteService.cs
+++ b/src/Humans.Application/Interfaces/Mailer/IMailerLiteService.cs
@@ -6,6 +6,11 @@ namespace Humans.Application.Interfaces.Mailer;
 /// Typed read-only MailerLite client surface. No write methods exist by
 /// design — outbound is a separate slice with its own review. Pinned by
 /// <c>MailerArchitectureTests.IMailerLiteService_HasNoWriteMethods</c>.
+///
+/// Implementations cache subscribers, groups, and the derived account
+/// summary in memory so page loads (e.g. /Mailer/Admin) don't burn the
+/// MailerLite rate limit on every request. The cache populates lazily on
+/// first read and refreshes only via <see cref="RefreshAsync"/>.
 /// </summary>
 public interface IMailerLiteService : IApplicationService
 {
@@ -20,4 +25,8 @@ public interface IMailerLiteService : IApplicationService
 
     Task<MailerLiteSubscriber?> GetSubscriberAsync(
         string email, CancellationToken ct = default);
+
+    DateTimeOffset? LastFetchedAt { get; }
+
+    Task RefreshAsync(CancellationToken ct = default);
 }

--- a/src/Humans.Infrastructure/Services/Mailer/MailerLiteClient.cs
+++ b/src/Humans.Infrastructure/Services/Mailer/MailerLiteClient.cs
@@ -1,5 +1,5 @@
 using System.Globalization;
-using System.Net.Http.Headers;
+using System.Net;
 using System.Net.Http.Json;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
@@ -7,43 +7,108 @@ using System.Text.Json.Serialization;
 using Humans.Application.Interfaces.Mailer;
 using Humans.Application.Interfaces.Mailer.Dtos;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
-using NodaTime;
 
 namespace Humans.Infrastructure.Services.Mailer;
 
+/// <summary>
+/// Caching MailerLite client. Registered as a Singleton so the in-memory
+/// subscriber list, account summary, and group list survive across requests.
+/// First read after startup (or after <see cref="RefreshAsync"/>) populates
+/// the cache from MailerLite; every subsequent read is served from RAM.
+/// Admins force a re-pull via POST /Mailer/Admin/Refresh.
+/// </summary>
 public sealed class MailerLiteClient : IMailerLiteService
 {
-    private static readonly JsonSerializerOptions Json = BuildJson();
-    private readonly HttpClient _http;
-    private readonly MailerLiteOptions _opts;
-    private readonly ILogger<MailerLiteClient> _logger;
+    public const string HttpClientName = "mailerlite";
 
-    public MailerLiteClient(
-        HttpClient http,
-        IOptions<MailerLiteOptions> opts,
-        IClock _,
-        ILogger<MailerLiteClient> logger)
+    private static readonly JsonSerializerOptions Json = BuildJson();
+    private readonly IHttpClientFactory _httpFactory;
+    private readonly ILogger<MailerLiteClient> _logger;
+    private readonly SemaphoreSlim _gate = new(1, 1);
+
+    private IReadOnlyList<MailerLiteSubscriber>? _subscribers;
+    private MailerLiteAccountSummary? _summary;
+    private IReadOnlyList<MailerLiteGroup>? _groups;
+    private DateTimeOffset? _lastFetchedAt;
+
+    public MailerLiteClient(IHttpClientFactory httpFactory, ILogger<MailerLiteClient> logger)
     {
-        _http = http;
-        _opts = opts.Value;
+        _httpFactory = httpFactory;
         _logger = logger;
-        _http.BaseAddress = new Uri(_opts.BaseUrl);
-        _http.DefaultRequestHeaders.Authorization =
-            new AuthenticationHeaderValue("Bearer", _opts.ApiKey);
-        _http.DefaultRequestHeaders.Add("X-Version", _opts.ApiVersion);
-        _http.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
     }
+
+    public DateTimeOffset? LastFetchedAt => _lastFetchedAt;
 
     public async Task<MailerLiteAccountSummary> GetAccountSummaryAsync(CancellationToken ct = default)
     {
-        // MailerLite v2 has no endpoint for subscriber-status totals. /api/subscribers
-        // uses cursor pagination and the response 'meta' carries only path / per_page /
-        // next_cursor / prev_cursor — no total. We do a single full sweep of subscribers
-        // and bucket by status client-side.
-        int active = 0, unsub = 0, unc = 0, bnc = 0, jnk = 0;
-        await foreach (var s in ListSubscribersAsync(ct))
+        await EnsurePopulatedAsync(ct);
+        return _summary!;
+    }
+
+    public async Task<IReadOnlyList<MailerLiteGroup>> ListGroupsAsync(CancellationToken ct = default)
+    {
+        await EnsurePopulatedAsync(ct);
+        return _groups!;
+    }
+
+    public async IAsyncEnumerable<MailerLiteSubscriber> ListSubscribersAsync(
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        await EnsurePopulatedAsync(ct);
+        foreach (var s in _subscribers!) yield return s;
+    }
+
+    public async Task<MailerLiteSubscriber?> GetSubscriberAsync(string email, CancellationToken ct = default)
+    {
+        // Single-email lookup is a passthrough — callers asking for a specific
+        // address want live state, not a snapshot from the dashboard cache.
+        using var resp = await SendAsync(HttpMethod.Get,
+            $"/api/subscribers/{Uri.EscapeDataString(email)}", ct);
+        if (resp.StatusCode == HttpStatusCode.NotFound) return null;
+        resp.EnsureSuccessStatusCode();
+        var body = await resp.Content.ReadFromJsonAsync<SubscriberSingleEnvelope>(Json, ct);
+        return body?.Data;
+    }
+
+    public async Task RefreshAsync(CancellationToken ct = default)
+    {
+        await _gate.WaitAsync(ct);
+        try
         {
+            await PopulateLockedAsync(ct);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    private async Task EnsurePopulatedAsync(CancellationToken ct)
+    {
+        if (_subscribers is not null && _summary is not null && _groups is not null)
+            return;
+        await _gate.WaitAsync(ct);
+        try
+        {
+            if (_subscribers is not null && _summary is not null && _groups is not null)
+                return;
+            await PopulateLockedAsync(ct);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    // Pulls everything fresh. If any underlying call throws, the prior cache
+    // (if any) is left intact — callers see the exception and can retry.
+    private async Task PopulateLockedAsync(CancellationToken ct)
+    {
+        var subscribers = new List<MailerLiteSubscriber>();
+        int active = 0, unsub = 0, unc = 0, bnc = 0, jnk = 0;
+        await foreach (var s in FetchSubscribersAsync(ct))
+        {
+            subscribers.Add(s);
             switch (s.Status)
             {
                 case "active": active++; break;
@@ -53,28 +118,16 @@ public sealed class MailerLiteClient : IMailerLiteService
                 case "junk": jnk++; break;
             }
         }
-        return new MailerLiteAccountSummary(active, unsub, unc, bnc, jnk);
+        var groups = await FetchGroupsAsync(ct);
+
+        _subscribers = subscribers;
+        _summary = new MailerLiteAccountSummary(active, unsub, unc, bnc, jnk);
+        _groups = groups;
+        _lastFetchedAt = DateTimeOffset.UtcNow;
     }
 
-    public async Task<IReadOnlyList<MailerLiteGroup>> ListGroupsAsync(CancellationToken ct = default)
-    {
-        var results = new List<MailerLiteGroup>();
-        int page = 1;
-        while (true)
-        {
-            using var resp = await SendAsync(HttpMethod.Get, $"/api/groups?page={page}&limit=100", ct);
-            resp.EnsureSuccessStatusCode();
-            var body = await resp.Content.ReadFromJsonAsync<GroupListEnvelope>(Json, ct);
-            if (body is null || body.Data.Count == 0) break;
-            results.AddRange(body.Data);
-            if (body.Meta.CurrentPage >= body.Meta.LastPage) break;
-            page++;
-        }
-        return results;
-    }
-
-    public async IAsyncEnumerable<MailerLiteSubscriber> ListSubscribersAsync(
-        [EnumeratorCancellation] CancellationToken ct = default)
+    private async IAsyncEnumerable<MailerLiteSubscriber> FetchSubscribersAsync(
+        [EnumeratorCancellation] CancellationToken ct)
     {
         string? cursor = null;
         while (true)
@@ -91,14 +144,21 @@ public sealed class MailerLiteClient : IMailerLiteService
         }
     }
 
-    public async Task<MailerLiteSubscriber?> GetSubscriberAsync(string email, CancellationToken ct = default)
+    private async Task<IReadOnlyList<MailerLiteGroup>> FetchGroupsAsync(CancellationToken ct)
     {
-        using var resp = await SendAsync(HttpMethod.Get,
-            $"/api/subscribers/{Uri.EscapeDataString(email)}", ct);
-        if (resp.StatusCode == System.Net.HttpStatusCode.NotFound) return null;
-        resp.EnsureSuccessStatusCode();
-        var body = await resp.Content.ReadFromJsonAsync<SubscriberSingleEnvelope>(Json, ct);
-        return body?.Data;
+        var results = new List<MailerLiteGroup>();
+        int page = 1;
+        while (true)
+        {
+            using var resp = await SendAsync(HttpMethod.Get, $"/api/groups?page={page}&limit=100", ct);
+            resp.EnsureSuccessStatusCode();
+            var body = await resp.Content.ReadFromJsonAsync<GroupListEnvelope>(Json, ct);
+            if (body is null || body.Data.Count == 0) break;
+            results.AddRange(body.Data);
+            if (body.Meta.CurrentPage >= body.Meta.LastPage) break;
+            page++;
+        }
+        return results;
     }
 
     // Internal seam for tests — exposes the private guard.
@@ -111,11 +171,12 @@ public sealed class MailerLiteClient : IMailerLiteService
             throw new InvalidOperationException(
                 $"MailerLite client is read-only. Attempted {method} {url}. " +
                 "Outbound writes belong to a separate slice with its own review.");
+        var http = _httpFactory.CreateClient(HttpClientName);
         using var req = new HttpRequestMessage(method, url);
         HttpResponseMessage resp;
         try
         {
-            resp = await _http.SendAsync(req, ct);
+            resp = await http.SendAsync(req, ct);
         }
         catch (HttpRequestException ex)
         {
@@ -154,8 +215,6 @@ public sealed class MailerLiteClient : IMailerLiteService
     // MailerLite stores name/last_name under a nested "fields" object, not at the
     // top level of the subscriber JSON. The spec says the importer preview doesn't
     // surface ML's name in this slice, so null is acceptable here.
-    // TODO (Task 20): if ML names are needed, add a custom JsonConverter<MailerLiteSubscriber>
-    // that reads fields.name → FirstName and fields.last_name → LastName.
 
     private sealed record SubscriberListEnvelope(
         [property: JsonPropertyName("data")] IReadOnlyList<MailerLiteSubscriber> Data,

--- a/src/Humans.Infrastructure/Services/Mailer/MailerLiteClient.cs
+++ b/src/Humans.Infrastructure/Services/Mailer/MailerLiteClient.cs
@@ -7,6 +7,7 @@ using System.Text.Json.Serialization;
 using Humans.Application.Interfaces.Mailer;
 using Humans.Application.Interfaces.Mailer.Dtos;
 using Microsoft.Extensions.Logging;
+using NodaTime;
 
 namespace Humans.Infrastructure.Services.Mailer;
 
@@ -23,21 +24,23 @@ public sealed class MailerLiteClient : IMailerLiteService
 
     private static readonly JsonSerializerOptions Json = BuildJson();
     private readonly IHttpClientFactory _httpFactory;
+    private readonly IClock _clock;
     private readonly ILogger<MailerLiteClient> _logger;
     private readonly SemaphoreSlim _gate = new(1, 1);
 
     private IReadOnlyList<MailerLiteSubscriber>? _subscribers;
     private MailerLiteAccountSummary? _summary;
     private IReadOnlyList<MailerLiteGroup>? _groups;
-    private DateTimeOffset? _lastFetchedAt;
+    private Instant? _lastFetchedAt;
 
-    public MailerLiteClient(IHttpClientFactory httpFactory, ILogger<MailerLiteClient> logger)
+    public MailerLiteClient(IHttpClientFactory httpFactory, IClock clock, ILogger<MailerLiteClient> logger)
     {
         _httpFactory = httpFactory;
+        _clock = clock;
         _logger = logger;
     }
 
-    public DateTimeOffset? LastFetchedAt => _lastFetchedAt;
+    public Instant? LastFetchedAt => _lastFetchedAt;
 
     public async Task<MailerLiteAccountSummary> GetAccountSummaryAsync(CancellationToken ct = default)
     {
@@ -123,7 +126,7 @@ public sealed class MailerLiteClient : IMailerLiteService
         _subscribers = subscribers;
         _summary = new MailerLiteAccountSummary(active, unsub, unc, bnc, jnk);
         _groups = groups;
-        _lastFetchedAt = DateTimeOffset.UtcNow;
+        _lastFetchedAt = _clock.GetCurrentInstant();
     }
 
     private async IAsyncEnumerable<MailerLiteSubscriber> FetchSubscribersAsync(

--- a/src/Humans.Web/Controllers/Mailer/MailerAdminController.cs
+++ b/src/Humans.Web/Controllers/Mailer/MailerAdminController.cs
@@ -77,8 +77,26 @@ public sealed class MailerAdminController : HumansControllerBase
 
         var vm = new MailerDashboardViewModel(
             summary, groups, mlContacts, optedIn, optedOut,
-            last?.OccurredAt, last?.Description, drift, mlError);
+            last?.OccurredAt, last?.Description, drift, mlError,
+            _ml.LastFetchedAt);
         return View("~/Views/Mailer/Admin/Index.cshtml", vm);
+    }
+
+    [HttpPost("Refresh")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Refresh(CancellationToken ct)
+    {
+        try
+        {
+            await _ml.RefreshAsync(ct);
+            TempData["Banner"] = "MailerLite cache refreshed.";
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogWarning("MailerLite refresh failed: {StatusCode} {Message}", ex.StatusCode, ex.Message);
+            TempData["Banner"] = "Refresh failed: " + FormatMailerLiteError(ex);
+        }
+        return RedirectToAction(nameof(Index));
     }
 
     private static string FormatMailerLiteError(HttpRequestException ex) => ex.StatusCode switch

--- a/src/Humans.Web/Controllers/Mailer/MailerAdminController.cs
+++ b/src/Humans.Web/Controllers/Mailer/MailerAdminController.cs
@@ -100,7 +100,7 @@ public sealed class MailerAdminController : HumansControllerBase
         {
             // MailerLiteClient surfaces HttpClient timeouts as TaskCanceledException
             // when the caller did not cancel. Treat it as a transient refresh failure.
-            _logger.LogWarning(ex, "MailerLite refresh timed out");
+            _logger.LogWarning("MailerLite refresh timed out");
             TempData["Banner"] = "Refresh failed: MailerLite request timed out. Try again shortly.";
         }
         return RedirectToAction(nameof(Index));

--- a/src/Humans.Web/Controllers/Mailer/MailerAdminController.cs
+++ b/src/Humans.Web/Controllers/Mailer/MailerAdminController.cs
@@ -96,6 +96,13 @@ public sealed class MailerAdminController : HumansControllerBase
             _logger.LogWarning("MailerLite refresh failed: {StatusCode} {Message}", ex.StatusCode, ex.Message);
             TempData["Banner"] = "Refresh failed: " + FormatMailerLiteError(ex);
         }
+        catch (TaskCanceledException ex) when (!ct.IsCancellationRequested)
+        {
+            // MailerLiteClient surfaces HttpClient timeouts as TaskCanceledException
+            // when the caller did not cancel. Treat it as a transient refresh failure.
+            _logger.LogWarning(ex, "MailerLite refresh timed out");
+            TempData["Banner"] = "Refresh failed: MailerLite request timed out. Try again shortly.";
+        }
         return RedirectToAction(nameof(Index));
     }
 

--- a/src/Humans.Web/Extensions/Sections/MailerSectionExtensions.cs
+++ b/src/Humans.Web/Extensions/Sections/MailerSectionExtensions.cs
@@ -1,6 +1,8 @@
+using System.Net.Http.Headers;
 using Humans.Application.Interfaces.Mailer;
 using Humans.Application.Services.Mailer;
 using Humans.Infrastructure.Services.Mailer;
+using Microsoft.Extensions.Options;
 
 namespace Humans.Web.Extensions.Sections;
 
@@ -22,10 +24,20 @@ internal static class MailerSectionExtensions
                     opts.ApiKey = flat;
             });
 
-        // Typed HttpClient — MailerLiteClient satisfies IMailerLiteService.
-        // No Polly retry: Microsoft.Extensions.Http.Polly is not in this project;
-        // MailerLiteClient handles rate-limit warnings internally (Task 21).
-        services.AddHttpClient<IMailerLiteService, MailerLiteClient>();
+        // Named HttpClient for MailerLite — resolved per-call by the Singleton
+        // MailerLiteClient through IHttpClientFactory. Keeping the client
+        // Singleton lets it cache subscribers/groups across requests.
+        services.AddHttpClient(MailerLiteClient.HttpClientName, (sp, http) =>
+        {
+            var opts = sp.GetRequiredService<IOptions<MailerLiteOptions>>().Value;
+            http.BaseAddress = new Uri(opts.BaseUrl);
+            http.DefaultRequestHeaders.Authorization =
+                new AuthenticationHeaderValue("Bearer", opts.ApiKey);
+            http.DefaultRequestHeaders.Add("X-Version", opts.ApiVersion);
+            http.DefaultRequestHeaders.Accept.Add(
+                new MediaTypeWithQualityHeaderValue("application/json"));
+        });
+        services.AddSingleton<IMailerLiteService, MailerLiteClient>();
 
         // Import orchestrator — stateless plan+apply, injected by the Admin controller.
         services.AddScoped<IMailerImportService, MailerImportService>();

--- a/src/Humans.Web/Models/Mailer/MailerDashboardViewModel.cs
+++ b/src/Humans.Web/Models/Mailer/MailerDashboardViewModel.cs
@@ -13,7 +13,7 @@ public sealed record MailerDashboardViewModel(
     string? LastReconciliationSummary,
     DriftReport? Drift,
     string? MlError,
-    DateTimeOffset? CacheFetchedAt);
+    Instant? CacheFetchedAt);
 
 public sealed record DriftReport(
     int HumansOptedOutMlActive,           // legal-trouble row

--- a/src/Humans.Web/Models/Mailer/MailerDashboardViewModel.cs
+++ b/src/Humans.Web/Models/Mailer/MailerDashboardViewModel.cs
@@ -12,7 +12,8 @@ public sealed record MailerDashboardViewModel(
     Instant? LastReconciliationAt,
     string? LastReconciliationSummary,
     DriftReport? Drift,
-    string? MlError);
+    string? MlError,
+    DateTimeOffset? CacheFetchedAt);
 
 public sealed record DriftReport(
     int HumansOptedOutMlActive,           // legal-trouble row

--- a/src/Humans.Web/Views/Mailer/Admin/Index.cshtml
+++ b/src/Humans.Web/Views/Mailer/Admin/Index.cshtml
@@ -6,12 +6,31 @@
 
 <div class="d-flex justify-content-between align-items-center mb-3">
     <h1 class="mb-0">Mailer Dashboard</h1>
-    @if (Model.MlError is null)
-    {
-        <a href="/Mailer/Admin/Import" class="btn btn-primary">
-            <i class="fa-solid fa-file-import me-1"></i>Run Import &rarr;
-        </a>
-    }
+    <div class="d-flex align-items-center gap-2">
+        <span class="text-muted small">
+            @if (Model.CacheFetchedAt is { } fetched)
+            {
+                <i class="fa-regular fa-clock me-1"></i>
+                <text>Cached @fetched.LocalDateTime.ToString("yyyy-MM-dd HH:mm")</text>
+            }
+            else
+            {
+                <text>Cache empty</text>
+            }
+        </span>
+        <form method="post" action="/Mailer/Admin/Refresh" class="m-0">
+            @Html.AntiForgeryToken()
+            <button type="submit" class="btn btn-outline-secondary">
+                <i class="fa-solid fa-arrows-rotate me-1"></i>Refresh
+            </button>
+        </form>
+        @if (Model.MlError is null)
+        {
+            <a href="/Mailer/Admin/Import" class="btn btn-primary">
+                <i class="fa-solid fa-file-import me-1"></i>Run Import &rarr;
+            </a>
+        }
+    </div>
 </div>
 
 <vc:temp-data-alerts />

--- a/src/Humans.Web/Views/Mailer/Admin/Index.cshtml
+++ b/src/Humans.Web/Views/Mailer/Admin/Index.cshtml
@@ -1,3 +1,4 @@
+@using Humans.Web.Extensions
 @using Humans.Web.Models.Mailer
 @model MailerDashboardViewModel
 @{
@@ -11,7 +12,7 @@
             @if (Model.CacheFetchedAt is { } fetched)
             {
                 <i class="fa-regular fa-clock me-1"></i>
-                <text>Cached @fetched.LocalDateTime.ToString("yyyy-MM-dd HH:mm")</text>
+                <text>Cached @fetched.ToDisplayCompactDateTime()</text>
             }
             else
             {

--- a/tests/Humans.Application.Tests/Services/Mailer/MailerLiteClientCacheTests.cs
+++ b/tests/Humans.Application.Tests/Services/Mailer/MailerLiteClientCacheTests.cs
@@ -1,0 +1,81 @@
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using AwesomeAssertions;
+using Humans.Infrastructure.Services.Mailer;
+
+namespace Humans.Application.Tests.Services.Mailer;
+
+public class MailerLiteClientCacheTests
+{
+    [HumansFact]
+    public async Task SecondRead_DoesNotHitHttp()
+    {
+        var handler = new CountingHandler();
+        var client = BuildClient(handler);
+
+        _ = await client.GetAccountSummaryAsync();
+        var callsAfterFirst = handler.Calls;
+        _ = await client.GetAccountSummaryAsync();
+        _ = await client.ListGroupsAsync();
+        await foreach (var _ in client.ListSubscribersAsync()) { /* drain */ }
+
+        handler.Calls.Should().Be(callsAfterFirst, "every read after the first must be served from the cache");
+    }
+
+    [HumansFact]
+    public async Task LastFetchedAt_IsNullUntilFirstRead()
+    {
+        var client = BuildClient(new CountingHandler());
+        client.LastFetchedAt.Should().BeNull();
+
+        _ = await client.GetAccountSummaryAsync();
+
+        client.LastFetchedAt.Should().NotBeNull();
+    }
+
+    [HumansFact]
+    public async Task RefreshAsync_RepullsFromHttp()
+    {
+        var handler = new CountingHandler();
+        var client = BuildClient(handler);
+
+        _ = await client.GetAccountSummaryAsync();
+        var callsBeforeRefresh = handler.Calls;
+
+        await client.RefreshAsync();
+
+        handler.Calls.Should().BeGreaterThan(callsBeforeRefresh, "Refresh must re-fetch from MailerLite");
+    }
+
+    private static MailerLiteClient BuildClient(HttpMessageHandler handler) =>
+        new(new StubHttpClientFactory(handler),
+            Microsoft.Extensions.Logging.Abstractions.NullLogger<MailerLiteClient>.Instance);
+
+    // Returns one empty subscriber page and one empty groups page. The client
+    // treats an empty payload as "end of list", so a single call settles each
+    // collection and we can simply count handler invocations.
+    private sealed class CountingHandler : HttpMessageHandler
+    {
+        public int Calls { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage req, CancellationToken ct)
+        {
+            Calls++;
+            var path = req.RequestUri!.AbsolutePath;
+            var body = path.Contains("/api/groups", StringComparison.Ordinal)
+                ? """{"data":[],"meta":{"current_page":1,"last_page":1}}"""
+                : """{"data":[],"meta":{"next_cursor":null}}""";
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(body, Encoding.UTF8, "application/json"),
+            });
+        }
+    }
+
+    private sealed class StubHttpClientFactory(HttpMessageHandler handler) : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) =>
+            new(handler, disposeHandler: false) { BaseAddress = new Uri("https://example.test/") };
+    }
+}

--- a/tests/Humans.Application.Tests/Services/Mailer/MailerLiteClientCacheTests.cs
+++ b/tests/Humans.Application.Tests/Services/Mailer/MailerLiteClientCacheTests.cs
@@ -49,7 +49,7 @@ public class MailerLiteClientCacheTests
     }
 
     private static MailerLiteClient BuildClient(HttpMessageHandler handler) =>
-        new(new StubHttpClientFactory(handler),
+        new(new StubHttpClientFactory(handler), NodaTime.SystemClock.Instance,
             Microsoft.Extensions.Logging.Abstractions.NullLogger<MailerLiteClient>.Instance);
 
     // Returns one empty subscriber page and one empty groups page. The client

--- a/tests/Humans.Application.Tests/Services/Mailer/MailerLiteClientWriteGuardTests.cs
+++ b/tests/Humans.Application.Tests/Services/Mailer/MailerLiteClientWriteGuardTests.cs
@@ -1,8 +1,6 @@
 using System.Net.Http;
 using AwesomeAssertions;
-using Humans.Application.Interfaces.Mailer;
 using Humans.Infrastructure.Services.Mailer;
-using Microsoft.Extensions.Options;
 
 namespace Humans.Application.Tests.Services.Mailer;
 
@@ -11,9 +9,8 @@ public class MailerLiteClientWriteGuardTests
     [HumansFact]
     public async Task SendAsync_ThrowsOnNonGetRequest()
     {
-        var opts = Options.Create(new MailerLiteOptions { ApiKey = "x" });
-        var http = new HttpClient(new RecordingHandler());
-        var client = new MailerLiteClient(http, opts, NodaTime.SystemClock.Instance,
+        var factory = new StubHttpClientFactory(new RecordingHandler());
+        var client = new MailerLiteClient(factory,
             Microsoft.Extensions.Logging.Abstractions.NullLogger<MailerLiteClient>.Instance);
 
         var act = async () => await client.SendForTestsAsync(HttpMethod.Post, "/api/subscribers", CancellationToken.None);
@@ -26,5 +23,11 @@ public class MailerLiteClientWriteGuardTests
     {
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage req, CancellationToken ct)
             => Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK));
+    }
+
+    private sealed class StubHttpClientFactory(HttpMessageHandler handler) : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) =>
+            new(handler, disposeHandler: false) { BaseAddress = new Uri("https://example.test/") };
     }
 }

--- a/tests/Humans.Application.Tests/Services/Mailer/MailerLiteClientWriteGuardTests.cs
+++ b/tests/Humans.Application.Tests/Services/Mailer/MailerLiteClientWriteGuardTests.cs
@@ -10,7 +10,7 @@ public class MailerLiteClientWriteGuardTests
     public async Task SendAsync_ThrowsOnNonGetRequest()
     {
         var factory = new StubHttpClientFactory(new RecordingHandler());
-        var client = new MailerLiteClient(factory,
+        var client = new MailerLiteClient(factory, NodaTime.SystemClock.Instance,
             Microsoft.Extensions.Logging.Abstractions.NullLogger<MailerLiteClient>.Instance);
 
         var act = async () => await client.SendForTestsAsync(HttpMethod.Post, "/api/subscribers", CancellationToken.None);

--- a/tests/Humans.Web.Tests/Controllers/Mailer/MailerAdminControllerTests.cs
+++ b/tests/Humans.Web.Tests/Controllers/Mailer/MailerAdminControllerTests.cs
@@ -224,6 +224,44 @@ public class MailerAdminControllerTests
     }
 
     // -----------------------------------------------------------------------
+    // Refresh — calls IMailerLiteService.RefreshAsync and redirects to Index.
+    // -----------------------------------------------------------------------
+
+    [HumansFact]
+    public async Task Refresh_CallsRefreshAsync_AndRedirectsToIndex()
+    {
+        var ctrl = BuildSut();
+
+        var result = await ctrl.Refresh(CancellationToken.None);
+
+        await _mlService.Received(1).RefreshAsync(Arg.Any<CancellationToken>());
+        var redirect = Assert.IsType<RedirectToActionResult>(result);
+        Assert.Equal(nameof(MailerAdminController.Index), redirect.ActionName);
+        Assert.Equal("MailerLite cache refreshed.", ctrl.TempData["Banner"]);
+    }
+
+    [HumansFact]
+    public async Task Refresh_OnHttpFailure_SetsErrorBannerAndRedirects()
+    {
+        _mlService.RefreshAsync(Arg.Any<CancellationToken>())
+            .ThrowsAsync(new HttpRequestException(
+                "Too Many Requests",
+                inner: null,
+                statusCode: System.Net.HttpStatusCode.TooManyRequests));
+
+        var ctrl = BuildSut();
+
+        var result = await ctrl.Refresh(CancellationToken.None);
+
+        var redirect = Assert.IsType<RedirectToActionResult>(result);
+        Assert.Equal(nameof(MailerAdminController.Index), redirect.ActionName);
+        var banner = ctrl.TempData["Banner"] as string;
+        Assert.NotNull(banner);
+        Assert.Contains("Refresh failed", banner!, StringComparison.Ordinal);
+        Assert.Contains("429", banner!, StringComparison.Ordinal);
+    }
+
+    // -----------------------------------------------------------------------
     // Commit — counts within tolerance, calls ApplyAsync and redirects to Index.
     // -----------------------------------------------------------------------
 

--- a/tests/Humans.Web.Tests/Controllers/Mailer/MailerAdminControllerTests.cs
+++ b/tests/Humans.Web.Tests/Controllers/Mailer/MailerAdminControllerTests.cs
@@ -261,6 +261,25 @@ public class MailerAdminControllerTests
         Assert.Contains("429", banner!, StringComparison.Ordinal);
     }
 
+    [HumansFact]
+    public async Task Refresh_OnTimeout_SetsErrorBannerAndRedirects()
+    {
+        // MailerLiteClient surfaces HttpClient timeouts as TaskCanceledException
+        // when the caller's CancellationToken was not the one that fired.
+        _mlService.RefreshAsync(Arg.Any<CancellationToken>())
+            .ThrowsAsync(new TaskCanceledException("timed out"));
+
+        var ctrl = BuildSut();
+
+        var result = await ctrl.Refresh(CancellationToken.None);
+
+        var redirect = Assert.IsType<RedirectToActionResult>(result);
+        Assert.Equal(nameof(MailerAdminController.Index), redirect.ActionName);
+        var banner = ctrl.TempData["Banner"] as string;
+        Assert.NotNull(banner);
+        Assert.Contains("timed out", banner!, StringComparison.Ordinal);
+    }
+
     // -----------------------------------------------------------------------
     // Commit — counts within tolerance, calls ApplyAsync and redirects to Index.
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `/Mailer/Admin/Index` was re-pulling the full subscriber list (and groups, and running `BuildPlanAsync`) on every page load, burning MailerLite quota until 429s.
- `MailerLiteClient` becomes a Singleton that caches subscribers / groups / account summary in-process. First read populates; subsequent reads serve from RAM.
- `IMailerLiteService` gains `LastFetchedAt` + `RefreshAsync`. A "Refresh" button on the dashboard (POST `/Mailer/Admin/Refresh`) is the only way to re-pull; failed refreshes leave the prior cache intact.

## Test plan
- [x] Build clean
- [x] Mailer unit tests pass (application + web + architecture)
- [x] New cache-behavior tests: second read serves zero HTTP, `RefreshAsync` re-fetches
- [x] New controller tests for `Refresh` (happy path + 429 banner)
- [ ] Preview env smoke: load `/Mailer/Admin`, confirm "Cached <timestamp>" appears and a second load doesn't hit ML; click Refresh and confirm new timestamp

🤖 Generated with [Claude Code](https://claude.com/claude-code)