### PR TITLE
feat: attendee contact import (Tickets)

### DIFF
--- a/docs/sections/Tickets.md
+++ b/docs/sections/Tickets.md
@@ -1,5 +1,6 @@
 <!-- freshness:triggers
   src/Humans.Application/Services/Tickets/**
+  src/Humans.Application/Interfaces/Tickets/**
   src/Humans.Domain/Entities/TicketOrder.cs
   src/Humans.Domain/Entities/TicketAttendee.cs
   src/Humans.Domain/Entities/TicketSyncState.cs
@@ -8,6 +9,7 @@
   src/Humans.Infrastructure/Data/Configurations/Tickets/**
   src/Humans.Web/Controllers/TicketController.cs
   src/Humans.Web/Controllers/TicketTransferController.cs
+  src/Humans.Web/Controllers/TicketsContactsAdminController.cs
 -->
 <!-- freshness:flag-on-change
   Vendor sync flow, Stripe-fee enrichment, auto-matching to humans by email, and EventParticipation derivation rules — review when Tickets services/entities/controller change.
@@ -26,6 +28,7 @@ External ticket vendor sync (orders + attendees), Stripe-fee enrichment, auto-ma
 - **Ticket Sync** is a background Hangfire job (`TicketSyncJob`, every 15 min by default, configurable via `TicketVendor:SyncIntervalMinutes`) that pulls order and attendee data from the vendor through `ITicketVendorService`.
 - **TicketTransferRequest** is a Sender-initiated request to send an issued ticket to another Humans user (the Receiver). Lifecycle: `Pending → Approved | Rejected | Cancelled`. On approval, attempts a TicketTailor void+reissue (Option B). On vendor failure, falls back to Option C (Humans-only record; admin manually edits TT dashboard). The request still ends in `Approved` state under Option C; `VendorResult` records the failure.
 - **Vendor connector** is a thin Infrastructure adapter behind `ITicketVendorService`. Production binds `TicketTailorService` (HTTP client against `https://api.tickettailor.com/v1`); non-production binds `StubTicketVendorService` (deterministic in-memory fixture with ~450 orders / ~600 tickets).
+- **Attendee Contact Import** is a manually-triggered admin job (`IAttendeeContactImportService`) that creates a no-profile Humans user for each unmatched ticket attendee whose email doesn't already resolve to an existing UserEmail. Mirrors the Mailer import's plan/apply shape with squatter protection (unverified UserEmail rows are deleted before a fresh verified row is created for the new user). Decoupled from the sync today; Phase 2 will run it automatically at the end of each `TicketSyncService` run.
 
 ## Data Model
 
@@ -74,7 +77,7 @@ Sender-initiated transfer request. `OriginalTicketAttendeeId` FK → `ticket_att
 |-------|--------------|
 | Any authenticated user with attendees on their orders (Sender) | Send any `Valid` attendee from their own order to another Humans user; cancel a `Pending` transfer they created |
 | TicketAdmin, Board, Admin | View the ticket dashboard, orders, attendees, codes, gate list, sales aggregates, and the "Who Hasn't Bought" report (controller-wide policy `TicketAdminBoardOrAdmin`) |
-| TicketAdmin, Admin | Trigger an incremental ticket sync. Export attendee/order CSV. Generate discount codes for campaigns (Campaign section, policy `TicketAdminOrAdmin`). Approve or reject pending transfer requests from `/Tickets/Admin/Transfers` (policy `TicketAdminOrAdmin`) |
+| TicketAdmin, Admin | Trigger an incremental ticket sync. Export attendee/order CSV. Generate discount codes for campaigns (Campaign section, policy `TicketAdminOrAdmin`). Approve or reject pending transfer requests from `/Tickets/Admin/Transfers` (policy `TicketAdminOrAdmin`). Import attendee contacts (preview + selectively apply) from `/Tickets/Admin/Contacts` (policy `TicketAdminOrAdmin`) |
 | Admin | Trigger a full re-sync (clears the `LastSyncAt` cursor). Open and submit the participation backfill page (`/Tickets/Participation/Backfill`) |
 
 ## Invariants
@@ -97,6 +100,7 @@ Sender-initiated transfer request. `OriginalTicketAttendeeId` FK → `ticket_att
 
 - Board **cannot** trigger any sync (incremental or full), export CSV, or open the participation backfill page.
 - Board **cannot** approve or reject transfer requests — transfer review is gated by `TicketAdminOrAdmin`. Board can view ticket data but the transfer side-effects (vendor void+reissue, local attendee mutation) are admin-only.
+- Board **cannot** trigger attendee contact import — same `TicketAdminOrAdmin` gate as the sync.
 - TicketAdmin **cannot** trigger a Full Re-sync or open the participation backfill page (both `AdminOnly`).
 - Nobody can edit ticket configuration (vendor `EventId`, API key, sync interval) from inside the app — those values come from `appsettings`'s `TicketVendor` section and the `TICKET_VENDOR_API_KEY` environment variable, set at deploy time.
 - Regular humans have no access to `/Tickets/*` (dashboard, orders, attendees, codes, gate list, who-hasn't-bought, sales aggregates) — the controller-wide policy is `TicketAdminBoardOrAdmin`.
@@ -115,6 +119,8 @@ Sender-initiated transfer request. `OriginalTicketAttendeeId` FK → `ticket_att
 | `/Tickets/SalesAggregates` | GET | `TicketAdminBoardOrAdmin` | Weekly + quarterly aggregate reports |
 | `/Tickets/Sync` | POST | `TicketAdminOrAdmin` | Trigger incremental sync |
 | `/Tickets/FullResync` | POST | `AdminOnly` | Trigger full re-sync |
+| `/Tickets/Admin/Contacts` | GET | `TicketAdminOrAdmin` | Preview attendee-contact-import plan |
+| `/Tickets/Admin/Contacts/Apply` | POST | `TicketAdminOrAdmin` | Apply selected attendees |
 | `/Tickets/Participation/Backfill` | GET + POST | `AdminOnly` | CSV import of participation records |
 | `/Tickets/Export/Attendees` | GET | `TicketAdminOrAdmin` | CSV export of attendees |
 | `/Tickets/Export/Orders` | GET | `TicketAdminOrAdmin` | CSV export of orders |
@@ -136,6 +142,7 @@ Sender-initiated transfer request. `OriginalTicketAttendeeId` FK → `ticket_att
 - Audit actions written by ticket transfer: `TicketTransferRequested` (on `CreateRequestAsync`), `TicketTransferCancelled` (on `CancelAsync`), `TicketTransferApproved` (on `ApproveAsync` — includes vendor outcome in metadata), `TicketTransferRejected` (on `RejectAsync`).
 - On transfer approve + vendor success: `TicketAttendee.Status` → `Void`; new `TicketAttendee` created with `VendorTicketId` from TT issue response, `MatchedUserId` = Receiver, `TicketOrderId` = original order.
 - On transfer approve + vendor failure: no local attendee changes; `TicketTransferRequest.VendorResult` = `Failed` (or `VoidSucceededIssueFailed` if only the issue half failed); audit row includes `"optionC": true` metadata flag for admin visibility.
+- On attendee contact import apply: for selected unmatched attendees, `MatchedUserId` is set (via `UpsertAttendeesAsync`), new users are provisioned (via `IAccountProvisioningService` with `ContactSource.TicketTailor`, Stub Profile + verified `UserEmail`), squatter unverified rows are deleted first, `EventParticipation(Ticketed, TicketSync)` is written for each newly-matched user, ticket caches are invalidated via `ITicketQueryService.InvalidateAfterContactImport`, and a single `AuditAction.TicketContactsImported` row records the summary.
 
 ### TicketDashboardStats cache (ghost cache key)
 
@@ -144,7 +151,7 @@ Sender-initiated transfer request. `OriginalTicketAttendeeId` FK → `ticket_att
 ## Cross-Section Dependencies
 
 - **Campaigns:** `ICampaignService` — Tickets reads campaign + grant data for the Codes page (`GetCodeTrackingAsync`) and pushes redemptions back during sync (`MarkGrantsRedeemedAsync`). Discount-code *generation* lives in the Campaigns section's `CampaignController` (which calls `ITicketVendorService.GenerateDiscountCodesAsync` directly); the `/Tickets/Codes` page only reports redemption status, it does not create codes.
-- **Users/Identity:** `IUserService` — `GetAllUsersAsync` / `GetByIdsAsync` for stitching matched-user names into orders/attendees lists; `SetParticipationFromTicketSyncAsync` / `RemoveTicketSyncParticipationAsync` / `GetAllParticipationsForYearAsync` / `BackfillParticipationsAsync` for derived `EventParticipation` writes (User section owns `event_participations` per peterdrier/Humans PR #243).
+- **Users/Identity:** `IUserService` — `GetAllUsersAsync` / `GetByIdsAsync` for stitching matched-user names into orders/attendees lists; `SetParticipationFromTicketSyncAsync` / `RemoveTicketSyncParticipationAsync` / `GetAllParticipationsForYearAsync` / `BackfillParticipationsAsync` for derived `EventParticipation` writes (User section owns `event_participations` per peterdrier/Humans PR #243). `IAccountProvisioningService.FindOrCreateUserByEmailAsync` is consumed by `AttendeeContactImportService` to provision Humans users for unmatched ticket attendees.
 - **Profiles:** `IUserEmailService` — `GetAllUserEmailLookupEntriesAsync` builds the sync-time email→userId index; `GetVerifiedEmailsForUserAsync` and `SearchUserIdsByVerifiedEmailAsync` back the per-user ticket probe and the Who-Hasn't-Bought email search; `GetNotificationEmailsByUserIdsAsync` hydrates the report; `GetUserIdByExactEmailAsync` resolves transfer recipients by exact email; `GetPrimaryEmailAsync` snapshots recipient email at request creation time. `IProfileService.GetByUserIdsAsync` supplies `MembershipTier`; `IProfileService.SearchHumansByNameAsync` (filtered to `MatchField == "Burner Name"`) resolves transfer recipients by burner name. Called by `IAccountMergeService` (Profiles section) — `ITicketSyncService.ReassignToUserAsync` re-FKs `TicketOrder.MatchedUserId` and `TicketAttendee.MatchedUserId` during account merge fold.
 - **Teams:** `ITeamService.GetActiveMemberUserIdsAsync(SystemTeamIds.Volunteers)` for the Volunteers cohort used by both the dashboard's coverage card and the Who-Hasn't-Bought list; `GetActiveNonSystemTeamNamesByUserIdsAsync` for team labels on the report.
 - **Shifts:** `IShiftManagementService.GetActiveAsync` — active-event lookup for the year used by `EventParticipation` derivation and by the `Participation/Backfill` page (replaces the prior direct `EventSettings` read, PR #545c).

--- a/docs/sections/Tickets.md
+++ b/docs/sections/Tickets.md
@@ -169,6 +169,7 @@ Sender-initiated transfer request. `OriginalTicketAttendeeId` FK → `ticket_att
 - `TicketSyncService` — vendor sync orchestrator (orders + attendees upsert, Stripe enrichment, VAT compute, code redemption push, EventParticipation derivation); also implements `IUserMerge` so account merges re-FK `TicketOrder.MatchedUserId`, `TicketAttendee.MatchedUserId`, and `TicketTransferRequest.SenderUserId` / `TicketTransferRequest.ReceiverUserId`.
 - `TicketTransferService` — transfer request lifecycle: `CreateRequestAsync`, `CancelAsync`, `ApproveAsync` (void+reissue or Option-C fallback), `RejectAsync`.
 - `TicketingBudgetService` — Tickets→Budget bridge (feeds completed-week paid-sales totals into Budget projections via `IBudgetService`).
+- `AttendeeContactImportService` — manually-triggered admin job that classifies unmatched ticket attendees and provisions Humans users for them via `IAccountProvisioningService` (plan + apply pattern mirroring the Mailer import; squatter protection deletes unverified UserEmail rows before creating fresh verified ones).
 
 **Owned tables:** `ticket_orders`, `ticket_attendees`, `ticket_sync_states`, `ticket_transfer_requests`
 
@@ -187,6 +188,7 @@ Sender-initiated transfer request. `OriginalTicketAttendeeId` FK → `ticket_att
 - `tests/Humans.Application.Tests/Architecture/TicketSyncArchitectureTests.cs` — pins namespace, no DbContext, `ITicketRepository` + `ITicketVendorService` + `IUserService` + `ICampaignService` + `IShiftManagementService` all required; no Store dependency.
 - `tests/Humans.Application.Tests/Architecture/TicketingBudgetArchitectureTests.cs` — pins namespace, no DbContext, no `IMemoryCache`, `ITicketingBudgetRepository` + `IBudgetService` required.
 - `tests/Humans.Application.Tests/Architecture/TicketVendorArchitectureTests.cs` — pins `ITicketVendorService` in Application, no forbidden namespace leakage into signatures, `TicketTailorService` and `StubTicketVendorService` in Infrastructure.
+- `tests/Humans.Application.Tests/Architecture/AttendeeContactImportArchitectureTests.cs` — pins `AttendeeContactImportService` namespace, no DbContext, and required cross-section dependencies (`ITicketRepository`, `IUserEmailService`, `IAccountProvisioningService`, `IUserService`, `IShiftManagementService`, `ITicketQueryService`, `IAuditLogService`).
 
 ### Repositories
 

--- a/docs/superpowers/plans/2026-05-13-ticket-attendee-contact-import.md
+++ b/docs/superpowers/plans/2026-05-13-ticket-attendee-contact-import.md
@@ -1,0 +1,2411 @@
+# Ticket Attendee Contact Import — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a manually-triggered admin job that creates a no-profile Humans user for each unmatched ticket attendee, mirroring the Mailer plan/apply pattern with squatter protection and a per-row checkbox preview.
+
+**Architecture:** New Application service `AttendeeContactImportService` orchestrates four primitives that already exist (`IAccountProvisioningService`, `IUserEmailService`, `IUserService`, `ITicketRepository`) and exposes `BuildPlanAsync` + `ApplyAsync` returning DTOs. Web layer adds a `TicketsContactsAdminController` with GET (preview) + POST (apply selected) routes under `/Tickets/Admin/Contacts`. No new entity, no migration.
+
+**Tech Stack:** ASP.NET Core 10 (Razor + MVC), EF Core 10, NodaTime, xUnit + NSubstitute + AwesomeAssertions, NodaTime.Testing.
+
+**Spec:** [`docs/superpowers/specs/2026-05-13-ticket-attendee-contact-import-design.md`](../specs/2026-05-13-ticket-attendee-contact-import-design.md)
+
+---
+
+## File Structure
+
+**New files (Application layer):**
+- `src/Humans.Application/Interfaces/Tickets/IAttendeeContactImportService.cs`
+- `src/Humans.Application/Interfaces/Tickets/Dtos/AttendeeImportOutcome.cs`
+- `src/Humans.Application/Interfaces/Tickets/Dtos/AttendeeImportDecision.cs`
+- `src/Humans.Application/Interfaces/Tickets/Dtos/AttendeeImportPlan.cs`
+- `src/Humans.Application/Interfaces/Tickets/Dtos/AttendeeImportResult.cs`
+- `src/Humans.Application/Services/Tickets/AttendeeContactImportService.cs`
+
+**New files (Web layer):**
+- `src/Humans.Web/Controllers/Tickets/TicketsContactsAdminController.cs`
+- `src/Humans.Web/Models/Tickets/ContactImportPreviewViewModel.cs`
+- `src/Humans.Web/Views/Tickets/Admin/Contacts.cshtml`
+
+**Modified files:**
+- `src/Humans.Domain/Enums/AuditAction.cs` — add `TicketContactsImported`
+- `src/Humans.Application/Interfaces/Repositories/ITicketRepository.cs` — add `GetUnmatchedActiveAttendeesAsync`
+- `src/Humans.Infrastructure/Repositories/Tickets/TicketRepository.cs` — implement that method
+- `src/Humans.Application/Interfaces/Tickets/ITicketQueryService.cs` — add `InvalidateAfterContactImport`
+- `src/Humans.Application/Services/Tickets/TicketQueryService.cs` — implement
+- `src/Humans.Web/Extensions/Sections/TicketsSectionExtensions.cs` — DI registration
+- `src/Humans.Web/Views/Tickets/Index.cshtml` (or wherever the sync action lives) — add "Import Attendee Contacts" link
+- `docs/sections/tickets.md` — section invariants, routing table, freshness triggers
+
+**New test files:**
+- `tests/Humans.Application.Tests/Services/Tickets/AttendeeContactImportServicePlanTests.cs`
+- `tests/Humans.Application.Tests/Services/Tickets/AttendeeContactImportServiceApplyTests.cs`
+- `tests/Humans.Application.Tests/Services/Tickets/AttendeeContactImportServiceSquatterTests.cs`
+- `tests/Humans.Application.Tests/Architecture/AttendeeContactImportArchitectureTests.cs`
+- `tests/Humans.Web.Tests/Controllers/Tickets/TicketsContactsAdminControllerTests.cs`
+- `tests/Humans.Infrastructure.Tests/Repositories/Tickets/TicketRepositoryUnmatchedAttendeesTests.cs` (or extend existing repo test file if one exists)
+
+---
+
+## Task 1: Add `TicketContactsImported` audit action
+
+**Files:**
+- Modify: `src/Humans.Domain/Enums/AuditAction.cs`
+
+- [ ] **Step 1: Add the enum value**
+
+Open `src/Humans.Domain/Enums/AuditAction.cs`. Find the existing `MailerLiteReconciliationCompleted` value (around line 166). Add a new value `TicketContactsImported` near it (preserve enum ordering conventions — append to end if values are append-only, otherwise group with other Ticket actions near `TicketTransferRequested`):
+
+```csharp
+TicketContactsImported,
+```
+
+- [ ] **Step 2: Build to verify no breakage**
+
+Run: `dotnet build Humans.slnx -v quiet`
+Expected: build succeeds, no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/Humans.Domain/Enums/AuditAction.cs
+git commit -m "feat: add TicketContactsImported audit action"
+```
+
+---
+
+## Task 2: Add `AttendeeImportOutcome` enum
+
+**Files:**
+- Create: `src/Humans.Application/Interfaces/Tickets/Dtos/AttendeeImportOutcome.cs`
+
+- [ ] **Step 1: Create the enum file**
+
+```csharp
+namespace Humans.Application.Interfaces.Tickets.Dtos;
+
+/// <summary>
+/// Per-attendee classification produced by
+/// <see cref="Humans.Application.Interfaces.Tickets.IAttendeeContactImportService.BuildPlanAsync"/>.
+/// Mirrors the Mailer import's <c>SubscriberOutcome</c> shape — verified
+/// matches attach, unverified matches are deleted-then-created (squatter
+/// protection), no match creates a new user with a verified UserEmail row.
+/// </summary>
+public enum AttendeeImportOutcome
+{
+    /// <summary>Exactly one verified UserEmail matches — set MatchedUserId, no creation.</summary>
+    AttachVerified = 0,
+
+    /// <summary>&gt;1 verified users own this email — skip with LogError (data-integrity).</summary>
+    AmbiguousMultipleVerified = 1,
+
+    /// <summary>Only an unverified UserEmail row matches — delete it, then create new user with verified row.</summary>
+    DeleteUnverifiedThenCreate = 2,
+
+    /// <summary>No UserEmail row matches — create a brand-new user with verified row.</summary>
+    CreateNewUser = 3,
+
+    /// <summary>Attendee has no email — skip.</summary>
+    SkipNoEmail = 4,
+
+    /// <summary>Attendee is Void — skip (typically excluded from plan input).</summary>
+    SkipVoided = 5,
+}
+```
+
+- [ ] **Step 2: Build**
+
+Run: `dotnet build Humans.slnx -v quiet`
+Expected: build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/Humans.Application/Interfaces/Tickets/Dtos/AttendeeImportOutcome.cs
+git commit -m "feat: add AttendeeImportOutcome enum"
+```
+
+---
+
+## Task 3: Add `AttendeeImportDecision` and `AttendeeImportPlan` DTOs
+
+**Files:**
+- Create: `src/Humans.Application/Interfaces/Tickets/Dtos/AttendeeImportDecision.cs`
+- Create: `src/Humans.Application/Interfaces/Tickets/Dtos/AttendeeImportPlan.cs`
+
+- [ ] **Step 1: Create `AttendeeImportDecision`**
+
+```csharp
+namespace Humans.Application.Interfaces.Tickets.Dtos;
+
+/// <summary>
+/// One per attendee in <see cref="AttendeeImportPlan"/>. Carries the
+/// classification plus the data the apply step needs (target user id for
+/// attach, unverified row id for delete-then-create, etc).
+/// </summary>
+/// <param name="AttendeeId">PK of the TicketAttendee row.</param>
+/// <param name="Email">Attendee email (case preserved from vendor).</param>
+/// <param name="AttendeeName">
+/// Resolved display name: LegalName → FirstName+LastName → null fallback.
+/// </param>
+/// <param name="VendorTicketId">For cross-reference with the vendor dashboard.</param>
+/// <param name="Outcome">Classification result.</param>
+/// <param name="TargetUserId">
+/// For <see cref="AttendeeImportOutcome.AttachVerified"/>: the live user id
+/// (post tombstone follow). Null otherwise.
+/// </param>
+/// <param name="UnverifiedEmailIdToDelete">
+/// For <see cref="AttendeeImportOutcome.DeleteUnverifiedThenCreate"/>: the
+/// UserEmail row id to delete before provisioning. Null otherwise.
+/// </param>
+/// <param name="UnverifiedRowUserId">
+/// For <see cref="AttendeeImportOutcome.DeleteUnverifiedThenCreate"/>: the
+/// owning user id of the unverified row (DeleteEmailAsync requires both).
+/// Null otherwise.
+/// </param>
+/// <param name="AmbiguousUserIds">
+/// For <see cref="AttendeeImportOutcome.AmbiguousMultipleVerified"/>: the
+/// conflicting user ids, for admin visibility. Null otherwise.
+/// </param>
+public sealed record AttendeeImportDecision(
+    Guid AttendeeId,
+    string? Email,
+    string? AttendeeName,
+    string VendorTicketId,
+    AttendeeImportOutcome Outcome,
+    Guid? TargetUserId,
+    Guid? UnverifiedEmailIdToDelete,
+    Guid? UnverifiedRowUserId,
+    IReadOnlyList<Guid>? AmbiguousUserIds);
+```
+
+- [ ] **Step 2: Create `AttendeeImportPlan`**
+
+```csharp
+namespace Humans.Application.Interfaces.Tickets.Dtos;
+
+/// <summary>
+/// Output of <see cref="Humans.Application.Interfaces.Tickets.IAttendeeContactImportService.BuildPlanAsync"/>.
+/// Stateless — the apply step re-queries to defend against concurrent sync mutation.
+/// </summary>
+public sealed record AttendeeImportPlan(
+    IReadOnlyList<AttendeeImportDecision> Decisions,
+    int TotalUnmatched)
+{
+    public AttendeeImportPlanCounts Counts => new(
+        AttachVerified: Decisions.Count(d => d.Outcome == AttendeeImportOutcome.AttachVerified),
+        AmbiguousMultipleVerified: Decisions.Count(d => d.Outcome == AttendeeImportOutcome.AmbiguousMultipleVerified),
+        DeleteUnverifiedThenCreate: Decisions.Count(d => d.Outcome == AttendeeImportOutcome.DeleteUnverifiedThenCreate),
+        CreateNewUser: Decisions.Count(d => d.Outcome == AttendeeImportOutcome.CreateNewUser),
+        SkipNoEmail: Decisions.Count(d => d.Outcome == AttendeeImportOutcome.SkipNoEmail),
+        SkipVoided: Decisions.Count(d => d.Outcome == AttendeeImportOutcome.SkipVoided));
+}
+
+public sealed record AttendeeImportPlanCounts(
+    int AttachVerified,
+    int AmbiguousMultipleVerified,
+    int DeleteUnverifiedThenCreate,
+    int CreateNewUser,
+    int SkipNoEmail,
+    int SkipVoided);
+```
+
+- [ ] **Step 3: Build**
+
+Run: `dotnet build Humans.slnx -v quiet`
+Expected: build succeeds.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Humans.Application/Interfaces/Tickets/Dtos/AttendeeImportDecision.cs \
+        src/Humans.Application/Interfaces/Tickets/Dtos/AttendeeImportPlan.cs
+git commit -m "feat: add AttendeeImportDecision and AttendeeImportPlan DTOs"
+```
+
+---
+
+## Task 4: Add `AttendeeImportResult` DTO with `FormatSummary`
+
+**Files:**
+- Create: `src/Humans.Application/Interfaces/Tickets/Dtos/AttendeeImportResult.cs`
+- Create: `tests/Humans.Application.Tests/Services/Tickets/AttendeeImportResultTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+using AwesomeAssertions;
+using Humans.Application.Interfaces.Tickets.Dtos;
+using NodaTime;
+using Xunit;
+
+namespace Humans.Application.Tests.Services.Tickets;
+
+public class AttendeeImportResultTests
+{
+    [HumansFact]
+    public void FormatSummary_IncludesAllCounters()
+    {
+        var result = new AttendeeImportResult(
+            TotalAttempted: 100,
+            UsersCreated: 60,
+            AttachedToExistingVerified: 30,
+            UnverifiedRowsDeletedAndUserCreated: 5,
+            AmbiguousSkipped: 2,
+            NoEmailSkipped: 3,
+            VanishedBetweenPlanAndApply: 1,
+            Errors: 0,
+            Elapsed: Duration.FromSeconds(12));
+
+        var summary = result.FormatSummary();
+
+        summary.Should().Contain("created=60");
+        summary.Should().Contain("attached=30");
+        summary.Should().Contain("unverified-replaced=5");
+        summary.Should().Contain("ambiguous=2");
+        summary.Should().Contain("no-email=3");
+        summary.Should().Contain("vanished=1");
+        summary.Should().Contain("errors=0");
+        summary.Should().Contain("12000ms");
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test Humans.slnx -v quiet --filter "FullyQualifiedName~AttendeeImportResultTests"`
+Expected: FAIL — `AttendeeImportResult` does not exist.
+
+- [ ] **Step 3: Create the DTO**
+
+```csharp
+using NodaTime;
+
+namespace Humans.Application.Interfaces.Tickets.Dtos;
+
+/// <summary>
+/// Outcome counters from
+/// <see cref="Humans.Application.Interfaces.Tickets.IAttendeeContactImportService.ApplyAsync"/>.
+/// Format mirrors <c>ImportResult.FormatSummary</c> in the Mailer section so
+/// admin banner / audit row reads consistently across import jobs.
+/// </summary>
+public sealed record AttendeeImportResult(
+    int TotalAttempted,
+    int UsersCreated,
+    int AttachedToExistingVerified,
+    int UnverifiedRowsDeletedAndUserCreated,
+    int AmbiguousSkipped,
+    int NoEmailSkipped,
+    int VanishedBetweenPlanAndApply,
+    int Errors,
+    Duration Elapsed)
+{
+    public string FormatSummary() =>
+        $"attempted={TotalAttempted}, created={UsersCreated}, attached={AttachedToExistingVerified}, " +
+        $"unverified-replaced={UnverifiedRowsDeletedAndUserCreated}, ambiguous={AmbiguousSkipped}, " +
+        $"no-email={NoEmailSkipped}, vanished={VanishedBetweenPlanAndApply}, errors={Errors}, " +
+        $"elapsed={(long)Elapsed.TotalMilliseconds}ms";
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dotnet test Humans.slnx -v quiet --filter "FullyQualifiedName~AttendeeImportResultTests"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Humans.Application/Interfaces/Tickets/Dtos/AttendeeImportResult.cs \
+        tests/Humans.Application.Tests/Services/Tickets/AttendeeImportResultTests.cs
+git commit -m "feat: add AttendeeImportResult DTO with formatted summary"
+```
+
+---
+
+## Task 5: Add `IAttendeeContactImportService` interface
+
+**Files:**
+- Create: `src/Humans.Application/Interfaces/Tickets/IAttendeeContactImportService.cs`
+
+- [ ] **Step 1: Create the interface**
+
+```csharp
+using Humans.Application.Interfaces.Tickets.Dtos;
+
+namespace Humans.Application.Interfaces.Tickets;
+
+/// <summary>
+/// Plan-and-apply import that creates Humans users for ticket attendees
+/// whose email doesn't already resolve to an existing user. Mirrors the
+/// Mailer import shape: <see cref="BuildPlanAsync"/> classifies, the admin
+/// previews + selects, <see cref="ApplyAsync"/> executes only selected rows.
+///
+/// Stateless: <see cref="ApplyAsync"/> re-queries unmatched attendees so
+/// plan and apply are independent (a sync in between is tolerated and
+/// counted as <c>VanishedBetweenPlanAndApply</c>).
+/// </summary>
+public interface IAttendeeContactImportService : IApplicationService
+{
+    Task<AttendeeImportPlan> BuildPlanAsync(CancellationToken ct = default);
+
+    Task<AttendeeImportResult> ApplyAsync(
+        AttendeeImportPlan plan,
+        IReadOnlySet<Guid> selectedAttendeeIds,
+        CancellationToken ct = default);
+}
+```
+
+- [ ] **Step 2: Build**
+
+Run: `dotnet build Humans.slnx -v quiet`
+Expected: succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/Humans.Application/Interfaces/Tickets/IAttendeeContactImportService.cs
+git commit -m "feat: add IAttendeeContactImportService interface"
+```
+
+---
+
+## Task 6: Add `ITicketRepository.GetUnmatchedActiveAttendeesAsync` (integration-tested)
+
+**Files:**
+- Modify: `src/Humans.Application/Interfaces/Repositories/ITicketRepository.cs`
+- Modify: `src/Humans.Infrastructure/Repositories/Tickets/TicketRepository.cs`
+- Create: `tests/Humans.Infrastructure.Tests/Repositories/Tickets/TicketRepositoryUnmatchedAttendeesTests.cs`
+
+- [ ] **Step 1: Add the method to the interface**
+
+Open `src/Humans.Application/Interfaces/Repositories/ITicketRepository.cs`. Near the existing `UpsertAttendeesAsync` method, add:
+
+```csharp
+    /// <summary>
+    /// Returns every <see cref="TicketAttendee"/> for the given vendor event
+    /// that is currently unmatched (<c>MatchedUserId is null</c>) and whose
+    /// <see cref="Humans.Domain.Enums.TicketAttendeeStatus"/> is
+    /// <c>Valid</c> or <c>CheckedIn</c>, AND whose
+    /// <see cref="TicketAttendee.AttendeeEmail"/> is non-empty.
+    ///
+    /// Used by the attendee contact import to identify candidates for user
+    /// provisioning. Returns the full entity so the caller can mutate
+    /// <c>MatchedUserId</c> and pass the list back to
+    /// <see cref="UpsertAttendeesAsync"/>.
+    /// </summary>
+    Task<IReadOnlyList<TicketAttendee>> GetUnmatchedActiveAttendeesAsync(
+        string vendorEventId, CancellationToken ct = default);
+```
+
+- [ ] **Step 2: Write a failing integration test**
+
+Use the existing repo-test harness pattern (mirror `TicketRepositoryTests.cs` if present — its setup creates an in-memory `HumansDbContext`):
+
+```csharp
+using AwesomeAssertions;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using Humans.Infrastructure.Data;
+using Humans.Infrastructure.Repositories.Tickets;
+using Microsoft.EntityFrameworkCore;
+using NodaTime;
+using Xunit;
+
+namespace Humans.Infrastructure.Tests.Repositories.Tickets;
+
+public class TicketRepositoryUnmatchedAttendeesTests
+{
+    [HumansFact]
+    public async Task GetUnmatchedActiveAttendeesAsync_ReturnsOnlyValidAndCheckedIn_WithEmail_AndNullMatch()
+    {
+        var options = new DbContextOptionsBuilder<HumansDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        await using var db = new HumansDbContext(options);
+
+        var orderId = Guid.NewGuid();
+        var eventId = "evt_123";
+
+        db.Set<TicketOrder>().Add(new TicketOrder
+        {
+            Id = orderId,
+            VendorOrderId = "ord_1",
+            VendorEventId = eventId,
+            BuyerEmail = "buyer@x.com",
+            BuyerName = "Buyer",
+            TotalAmount = 0,
+            Currency = "EUR",
+            PaymentStatus = PaymentStatus.Paid,
+            PurchasedAt = Instant.FromUtc(2026, 1, 1, 0, 0),
+        });
+
+        var includedId = Guid.NewGuid();
+        db.Set<TicketAttendee>().AddRange(
+            new TicketAttendee
+            {
+                Id = includedId, TicketOrderId = orderId, VendorEventId = eventId,
+                VendorTicketId = "tkt_valid_unmatched", AttendeeEmail = "a@x.com",
+                Status = TicketAttendeeStatus.Valid, MatchedUserId = null,
+            },
+            new TicketAttendee
+            {
+                Id = Guid.NewGuid(), TicketOrderId = orderId, VendorEventId = eventId,
+                VendorTicketId = "tkt_voided", AttendeeEmail = "b@x.com",
+                Status = TicketAttendeeStatus.Void, MatchedUserId = null,
+            },
+            new TicketAttendee
+            {
+                Id = Guid.NewGuid(), TicketOrderId = orderId, VendorEventId = eventId,
+                VendorTicketId = "tkt_matched", AttendeeEmail = "c@x.com",
+                Status = TicketAttendeeStatus.Valid, MatchedUserId = Guid.NewGuid(),
+            },
+            new TicketAttendee
+            {
+                Id = Guid.NewGuid(), TicketOrderId = orderId, VendorEventId = eventId,
+                VendorTicketId = "tkt_no_email", AttendeeEmail = null,
+                Status = TicketAttendeeStatus.Valid, MatchedUserId = null,
+            },
+            new TicketAttendee
+            {
+                Id = Guid.NewGuid(), TicketOrderId = orderId, VendorEventId = "other_event",
+                VendorTicketId = "tkt_other_event", AttendeeEmail = "d@x.com",
+                Status = TicketAttendeeStatus.Valid, MatchedUserId = null,
+            });
+        await db.SaveChangesAsync();
+
+        var repo = new TicketRepository(db);
+
+        var result = await repo.GetUnmatchedActiveAttendeesAsync(eventId);
+
+        result.Should().HaveCount(1);
+        result.Single().Id.Should().Be(includedId);
+    }
+
+    [HumansFact]
+    public async Task GetUnmatchedActiveAttendeesAsync_IncludesCheckedInAttendees()
+    {
+        var options = new DbContextOptionsBuilder<HumansDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        await using var db = new HumansDbContext(options);
+
+        var orderId = Guid.NewGuid();
+        var eventId = "evt_123";
+        db.Set<TicketOrder>().Add(new TicketOrder
+        {
+            Id = orderId, VendorOrderId = "ord_1", VendorEventId = eventId,
+            BuyerEmail = "buyer@x.com", BuyerName = "Buyer", TotalAmount = 0,
+            Currency = "EUR", PaymentStatus = PaymentStatus.Paid,
+            PurchasedAt = Instant.FromUtc(2026, 1, 1, 0, 0),
+        });
+
+        var includedId = Guid.NewGuid();
+        db.Set<TicketAttendee>().Add(new TicketAttendee
+        {
+            Id = includedId, TicketOrderId = orderId, VendorEventId = eventId,
+            VendorTicketId = "tkt_ci", AttendeeEmail = "ci@x.com",
+            Status = TicketAttendeeStatus.CheckedIn, MatchedUserId = null,
+        });
+        await db.SaveChangesAsync();
+
+        var repo = new TicketRepository(db);
+        var result = await repo.GetUnmatchedActiveAttendeesAsync(eventId);
+
+        result.Should().ContainSingle(a => a.Id == includedId);
+    }
+}
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `dotnet test Humans.slnx -v quiet --filter "FullyQualifiedName~TicketRepositoryUnmatchedAttendeesTests"`
+Expected: FAIL — method not defined.
+
+- [ ] **Step 4: Implement on the repository**
+
+Open `src/Humans.Infrastructure/Repositories/Tickets/TicketRepository.cs`. Add the implementation alongside other attendee methods:
+
+```csharp
+public Task<IReadOnlyList<TicketAttendee>> GetUnmatchedActiveAttendeesAsync(
+    string vendorEventId, CancellationToken ct = default) =>
+    _db.Set<TicketAttendee>()
+        .Where(a =>
+            a.VendorEventId == vendorEventId &&
+            a.MatchedUserId == null &&
+            !string.IsNullOrEmpty(a.AttendeeEmail) &&
+            (a.Status == TicketAttendeeStatus.Valid ||
+             a.Status == TicketAttendeeStatus.CheckedIn))
+        .ToListAsync(ct)
+        .ContinueWith(t => (IReadOnlyList<TicketAttendee>)t.Result, ct);
+```
+
+(If the file's existing methods use a different pattern — e.g. `async` with `await` — match that style. The `.ContinueWith` form is a fallback only if the file is consistently `Task<T>` returning, which most EF repos in this codebase are not. Default to `async`/`await`:)
+
+```csharp
+public async Task<IReadOnlyList<TicketAttendee>> GetUnmatchedActiveAttendeesAsync(
+    string vendorEventId, CancellationToken ct = default)
+{
+    return await _db.Set<TicketAttendee>()
+        .Where(a =>
+            a.VendorEventId == vendorEventId &&
+            a.MatchedUserId == null &&
+            !string.IsNullOrEmpty(a.AttendeeEmail) &&
+            (a.Status == TicketAttendeeStatus.Valid ||
+             a.Status == TicketAttendeeStatus.CheckedIn))
+        .ToListAsync(ct);
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `dotnet test Humans.slnx -v quiet --filter "FullyQualifiedName~TicketRepositoryUnmatchedAttendeesTests"`
+Expected: PASS (both tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Humans.Application/Interfaces/Repositories/ITicketRepository.cs \
+        src/Humans.Infrastructure/Repositories/Tickets/TicketRepository.cs \
+        tests/Humans.Infrastructure.Tests/Repositories/Tickets/TicketRepositoryUnmatchedAttendeesTests.cs
+git commit -m "feat: ITicketRepository.GetUnmatchedActiveAttendeesAsync for contact import"
+```
+
+---
+
+## Task 7: Add `ITicketQueryService.InvalidateAfterContactImport`
+
+**Files:**
+- Modify: `src/Humans.Application/Interfaces/Tickets/ITicketQueryService.cs`
+- Modify: `src/Humans.Application/Services/Tickets/TicketQueryService.cs`
+
+- [ ] **Step 1: Add to the interface**
+
+Open `src/Humans.Application/Interfaces/Tickets/ITicketQueryService.cs`. Near the existing `InvalidateAfterTransfer` declaration (around line 199), add:
+
+```csharp
+    /// <summary>
+    /// Invalidates ticket-related caches after the attendee contact import
+    /// has applied new matches. Affects: <c>UserIdsWithTickets</c>,
+    /// <c>ValidAttendeeEmails</c>, the per-event <c>TicketEventSummary</c>,
+    /// and <c>TicketDashboardStats</c> (invalidator-only key). Per-user
+    /// <c>UserTicketCount:{userId}</c> entries are not enumerable and expire
+    /// naturally via 5-minute TTL — same policy as the sync.
+    /// </summary>
+    void InvalidateAfterContactImport();
+```
+
+- [ ] **Step 2: Implement it**
+
+Open `src/Humans.Application/Services/Tickets/TicketQueryService.cs`. Find the existing `InvalidateAfterTransfer` implementation. Add:
+
+```csharp
+public void InvalidateAfterContactImport()
+{
+    _cache.InvalidateTicketCaches();
+}
+```
+
+(Use the same `_cache.InvalidateTicketCaches()` seam used by `TicketSyncService`. Look at how `InvalidateAfterTransfer` is written and mirror it — single-line delegation is fine.)
+
+- [ ] **Step 3: Build**
+
+Run: `dotnet build Humans.slnx -v quiet`
+Expected: succeeds.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Humans.Application/Interfaces/Tickets/ITicketQueryService.cs \
+        src/Humans.Application/Services/Tickets/TicketQueryService.cs
+git commit -m "feat: ITicketQueryService.InvalidateAfterContactImport seam"
+```
+
+---
+
+## Task 8: Scaffold `AttendeeContactImportService` + plan-classifier harness
+
+**Files:**
+- Create: `src/Humans.Application/Services/Tickets/AttendeeContactImportService.cs`
+- Create: `tests/Humans.Application.Tests/Services/Tickets/AttendeeContactImportServicePlanTests.cs`
+
+- [ ] **Step 1: Write the first failing test — SkipNoEmail**
+
+```csharp
+using AwesomeAssertions;
+using Humans.Application.Interfaces.AuditLog;
+using Humans.Application.Interfaces.Profiles;
+using Humans.Application.Interfaces.Repositories;
+using Humans.Application.Interfaces.Shifts;
+using Humans.Application.Interfaces.Tickets;
+using Humans.Application.Interfaces.Tickets.Dtos;
+using Humans.Application.Interfaces.Users;
+using Humans.Application.Services.Tickets;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using Microsoft.Extensions.Logging.Abstractions;
+using NodaTime;
+using NodaTime.Testing;
+using NSubstitute;
+using Xunit;
+
+namespace Humans.Application.Tests.Services.Tickets;
+
+public class AttendeeContactImportServicePlanTests
+{
+    [HumansFact]
+    public async Task Plan_AttendeeWithoutEmail_ClassifiedAsSkipNoEmail()
+    {
+        var harness = new PlanHarness();
+        harness.AddUnmatched(new TicketAttendee
+        {
+            Id = Guid.NewGuid(),
+            VendorTicketId = "tkt_1",
+            AttendeeEmail = null,
+            FirstName = "Jane",
+            LastName = "Doe",
+            Status = TicketAttendeeStatus.Valid,
+        });
+
+        var plan = await harness.Service.BuildPlanAsync();
+
+        plan.Decisions.Should().ContainSingle()
+            .Which.Outcome.Should().Be(AttendeeImportOutcome.SkipNoEmail);
+    }
+}
+
+internal sealed class PlanHarness
+{
+    public ITicketRepository TicketRepo { get; } = Substitute.For<ITicketRepository>();
+    public IUserEmailService UserEmails { get; } = Substitute.For<IUserEmailService>();
+    public IAccountProvisioningService Provisioning { get; } = Substitute.For<IAccountProvisioningService>();
+    public IUserService Users { get; } = Substitute.For<IUserService>();
+    public IShiftManagementService Shifts { get; } = Substitute.For<IShiftManagementService>();
+    public ITicketQueryService TicketQuery { get; } = Substitute.For<ITicketQueryService>();
+    public IAuditLogService Audit { get; } = Substitute.For<IAuditLogService>();
+    public FakeClock Clock { get; } = new(Instant.FromUtc(2026, 5, 13, 12, 0));
+
+    private readonly List<TicketAttendee> _unmatched = new();
+
+    public PlanHarness()
+    {
+        TicketRepo.GetSyncStateAsync(Arg.Any<CancellationToken>())
+            .Returns(new TicketSyncState { Id = 1, VendorEventId = "evt_active" });
+        TicketRepo.GetUnmatchedActiveAttendeesAsync(
+                Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(_ => _unmatched);
+    }
+
+    public void AddUnmatched(TicketAttendee a) => _unmatched.Add(a);
+
+    public AttendeeContactImportService Service => new(
+        TicketRepo, UserEmails, Provisioning, Users, Shifts, TicketQuery, Audit, Clock,
+        NullLogger<AttendeeContactImportService>.Instance);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test Humans.slnx -v quiet --filter "FullyQualifiedName~AttendeeContactImportServicePlanTests"`
+Expected: FAIL — `AttendeeContactImportService` does not exist.
+
+- [ ] **Step 3: Scaffold the service with just enough to make the test pass**
+
+```csharp
+using Humans.Application.Interfaces;
+using Humans.Application.Interfaces.AuditLog;
+using Humans.Application.Interfaces.Profiles;
+using Humans.Application.Interfaces.Repositories;
+using Humans.Application.Interfaces.Shifts;
+using Humans.Application.Interfaces.Tickets;
+using Humans.Application.Interfaces.Tickets.Dtos;
+using Humans.Application.Interfaces.Users;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using Microsoft.Extensions.Logging;
+using NodaTime;
+
+namespace Humans.Application.Services.Tickets;
+
+public sealed class AttendeeContactImportService : IAttendeeContactImportService
+{
+    private readonly ITicketRepository _ticketRepository;
+    private readonly IUserEmailService _userEmails;
+    private readonly IAccountProvisioningService _provisioning;
+    private readonly IUserService _users;
+    private readonly IShiftManagementService _shifts;
+    private readonly ITicketQueryService _ticketQuery;
+    private readonly IAuditLogService _audit;
+    private readonly IClock _clock;
+    private readonly ILogger<AttendeeContactImportService> _logger;
+
+    public AttendeeContactImportService(
+        ITicketRepository ticketRepository,
+        IUserEmailService userEmails,
+        IAccountProvisioningService provisioning,
+        IUserService users,
+        IShiftManagementService shifts,
+        ITicketQueryService ticketQuery,
+        IAuditLogService audit,
+        IClock clock,
+        ILogger<AttendeeContactImportService> logger)
+    {
+        _ticketRepository = ticketRepository;
+        _userEmails = userEmails;
+        _provisioning = provisioning;
+        _users = users;
+        _shifts = shifts;
+        _ticketQuery = ticketQuery;
+        _audit = audit;
+        _clock = clock;
+        _logger = logger;
+    }
+
+    public async Task<AttendeeImportPlan> BuildPlanAsync(CancellationToken ct = default)
+    {
+        var state = await _ticketRepository.GetSyncStateAsync(ct);
+        var eventId = state?.VendorEventId
+            ?? throw new InvalidOperationException("No active vendor event id — sync has not run.");
+
+        var unmatched = await _ticketRepository.GetUnmatchedActiveAttendeesAsync(eventId, ct);
+        var decisions = new List<AttendeeImportDecision>(unmatched.Count);
+
+        foreach (var a in unmatched)
+        {
+            decisions.Add(await ClassifyAsync(a, ct));
+        }
+
+        return new AttendeeImportPlan(decisions, unmatched.Count);
+    }
+
+    public Task<AttendeeImportResult> ApplyAsync(
+        AttendeeImportPlan plan,
+        IReadOnlySet<Guid> selectedAttendeeIds,
+        CancellationToken ct = default) =>
+        throw new NotImplementedException("Filled in by Task 11");
+
+    private async Task<AttendeeImportDecision> ClassifyAsync(TicketAttendee a, CancellationToken ct)
+    {
+        var name = ResolveDisplayName(a);
+
+        if (string.IsNullOrWhiteSpace(a.AttendeeEmail))
+        {
+            return new AttendeeImportDecision(
+                a.Id, a.AttendeeEmail, name, a.VendorTicketId,
+                AttendeeImportOutcome.SkipNoEmail,
+                TargetUserId: null,
+                UnverifiedEmailIdToDelete: null,
+                UnverifiedRowUserId: null,
+                AmbiguousUserIds: null);
+        }
+
+        // Remaining classifications filled in by Tasks 9–10.
+        throw new NotImplementedException("Branches filled in by Tasks 9–10");
+    }
+
+    private static string? ResolveDisplayName(TicketAttendee a)
+    {
+        if (!string.IsNullOrWhiteSpace(a.LegalName)) return a.LegalName;
+        var first = a.FirstName?.Trim();
+        var last = a.LastName?.Trim();
+        var combined = $"{first} {last}".Trim();
+        return string.IsNullOrWhiteSpace(combined) ? null : combined;
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dotnet test Humans.slnx -v quiet --filter "FullyQualifiedName~AttendeeContactImportServicePlanTests"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Humans.Application/Services/Tickets/AttendeeContactImportService.cs \
+        tests/Humans.Application.Tests/Services/Tickets/AttendeeContactImportServicePlanTests.cs
+git commit -m "feat: AttendeeContactImportService scaffold + SkipNoEmail classifier"
+```
+
+---
+
+## Task 9: Add `AttachVerified` and `AmbiguousMultipleVerified` classifiers
+
+**Files:**
+- Modify: `src/Humans.Application/Services/Tickets/AttendeeContactImportService.cs`
+- Modify: `tests/Humans.Application.Tests/Services/Tickets/AttendeeContactImportServicePlanTests.cs`
+
+- [ ] **Step 1: Add the failing tests**
+
+Append to `AttendeeContactImportServicePlanTests`:
+
+```csharp
+[HumansFact]
+public async Task Plan_SingleVerifiedMatch_ClassifiedAsAttachVerified()
+{
+    var harness = new PlanHarness();
+    var userId = Guid.NewGuid();
+    harness.AddUnmatched(new TicketAttendee
+    {
+        Id = Guid.NewGuid(), VendorTicketId = "tkt_v",
+        AttendeeEmail = "jane@x.com", FirstName = "Jane", LastName = "Doe",
+        Status = TicketAttendeeStatus.Valid,
+    });
+    harness.UserEmails.GetDistinctVerifiedUserIdsAsync("jane@x.com", Arg.Any<CancellationToken>())
+        .Returns(new[] { userId });
+    harness.Users.GetByIdAsync(userId, Arg.Any<CancellationToken>())
+        .Returns(new User { Id = userId, MergedToUserId = null });
+
+    var plan = await harness.Service.BuildPlanAsync();
+
+    var decision = plan.Decisions.Single();
+    decision.Outcome.Should().Be(AttendeeImportOutcome.AttachVerified);
+    decision.TargetUserId.Should().Be(userId);
+    decision.AttendeeName.Should().Be("Jane Doe");
+}
+
+[HumansFact]
+public async Task Plan_AttachVerified_FollowsMergedTombstone()
+{
+    var harness = new PlanHarness();
+    var deadId = Guid.NewGuid();
+    var liveId = Guid.NewGuid();
+    harness.AddUnmatched(new TicketAttendee
+    {
+        Id = Guid.NewGuid(), VendorTicketId = "tkt_v",
+        AttendeeEmail = "jane@x.com", FirstName = "Jane",
+        Status = TicketAttendeeStatus.Valid,
+    });
+    harness.UserEmails.GetDistinctVerifiedUserIdsAsync("jane@x.com", Arg.Any<CancellationToken>())
+        .Returns(new[] { deadId });
+    harness.Users.GetByIdAsync(deadId, Arg.Any<CancellationToken>())
+        .Returns(new User { Id = deadId, MergedToUserId = liveId });
+    harness.Users.GetByIdAsync(liveId, Arg.Any<CancellationToken>())
+        .Returns(new User { Id = liveId, MergedToUserId = null });
+
+    var plan = await harness.Service.BuildPlanAsync();
+
+    plan.Decisions.Single().TargetUserId.Should().Be(liveId);
+}
+
+[HumansFact]
+public async Task Plan_MultipleVerifiedMatches_ClassifiedAsAmbiguous()
+{
+    var harness = new PlanHarness();
+    var u1 = Guid.NewGuid();
+    var u2 = Guid.NewGuid();
+    harness.AddUnmatched(new TicketAttendee
+    {
+        Id = Guid.NewGuid(), VendorTicketId = "tkt_v",
+        AttendeeEmail = "shared@x.com", Status = TicketAttendeeStatus.Valid,
+    });
+    harness.UserEmails.GetDistinctVerifiedUserIdsAsync("shared@x.com", Arg.Any<CancellationToken>())
+        .Returns(new[] { u1, u2 });
+
+    var plan = await harness.Service.BuildPlanAsync();
+
+    var decision = plan.Decisions.Single();
+    decision.Outcome.Should().Be(AttendeeImportOutcome.AmbiguousMultipleVerified);
+    decision.AmbiguousUserIds.Should().BeEquivalentTo(new[] { u1, u2 });
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `dotnet test Humans.slnx -v quiet --filter "FullyQualifiedName~AttendeeContactImportServicePlanTests"`
+Expected: 3 new tests FAIL with `NotImplementedException` from the classifier.
+
+- [ ] **Step 3: Implement the classifier branches**
+
+Replace the `throw new NotImplementedException(...)` at the end of `ClassifyAsync` with:
+
+```csharp
+var verifiedUserIds = await _userEmails.GetDistinctVerifiedUserIdsAsync(a.AttendeeEmail!, ct);
+
+if (verifiedUserIds.Count > 1)
+{
+    return new AttendeeImportDecision(
+        a.Id, a.AttendeeEmail, name, a.VendorTicketId,
+        AttendeeImportOutcome.AmbiguousMultipleVerified,
+        TargetUserId: null,
+        UnverifiedEmailIdToDelete: null,
+        UnverifiedRowUserId: null,
+        AmbiguousUserIds: verifiedUserIds);
+}
+
+if (verifiedUserIds.Count == 1)
+{
+    var liveTarget = await ResolveTombstoneAsync(verifiedUserIds[0], ct);
+    return new AttendeeImportDecision(
+        a.Id, a.AttendeeEmail, name, a.VendorTicketId,
+        AttendeeImportOutcome.AttachVerified,
+        TargetUserId: liveTarget,
+        UnverifiedEmailIdToDelete: null,
+        UnverifiedRowUserId: null,
+        AmbiguousUserIds: null);
+}
+
+// Remaining classifications filled in by Task 10.
+throw new NotImplementedException("Unverified/no-match branches filled in by Task 10");
+```
+
+And add the tombstone helper (copy the shape from `MailerImportService.ResolveTombstoneAsync`):
+
+```csharp
+private async Task<Guid> ResolveTombstoneAsync(Guid userId, CancellationToken ct)
+{
+    var visited = new HashSet<Guid> { userId };
+    var current = userId;
+    while (true)
+    {
+        var user = await _users.GetByIdAsync(current, ct);
+        if (user?.MergedToUserId is not Guid next) return current;
+        if (!visited.Add(next)) return current;
+        current = next;
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `dotnet test Humans.slnx -v quiet --filter "FullyQualifiedName~AttendeeContactImportServicePlanTests"`
+Expected: all 4 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Humans.Application/Services/Tickets/AttendeeContactImportService.cs \
+        tests/Humans.Application.Tests/Services/Tickets/AttendeeContactImportServicePlanTests.cs
+git commit -m "feat: AttachVerified + AmbiguousMultipleVerified classifiers + tombstone follow"
+```
+
+---
+
+## Task 10: Add `DeleteUnverifiedThenCreate` and `CreateNewUser` classifiers
+
+**Files:**
+- Modify: `src/Humans.Application/Services/Tickets/AttendeeContactImportService.cs`
+- Modify: `tests/Humans.Application.Tests/Services/Tickets/AttendeeContactImportServicePlanTests.cs`
+
+- [ ] **Step 1: Add the failing tests**
+
+```csharp
+[HumansFact]
+public async Task Plan_UnverifiedMatchOnly_ClassifiedAsDeleteUnverifiedThenCreate()
+{
+    var harness = new PlanHarness();
+    var squatterUserId = Guid.NewGuid();
+    var unverifiedRowId = Guid.NewGuid();
+    harness.AddUnmatched(new TicketAttendee
+    {
+        Id = Guid.NewGuid(), VendorTicketId = "tkt_v",
+        AttendeeEmail = "victim@x.com", FirstName = "Victim",
+        Status = TicketAttendeeStatus.Valid,
+    });
+    harness.UserEmails.GetDistinctVerifiedUserIdsAsync("victim@x.com", Arg.Any<CancellationToken>())
+        .Returns(Array.Empty<Guid>());
+    harness.UserEmails.FindAnyEmailRowByAddressAsync("victim@x.com", Arg.Any<CancellationToken>())
+        .Returns((squatterUserId, unverifiedRowId));
+
+    var plan = await harness.Service.BuildPlanAsync();
+
+    var decision = plan.Decisions.Single();
+    decision.Outcome.Should().Be(AttendeeImportOutcome.DeleteUnverifiedThenCreate);
+    decision.UnverifiedRowUserId.Should().Be(squatterUserId);
+    decision.UnverifiedEmailIdToDelete.Should().Be(unverifiedRowId);
+}
+
+[HumansFact]
+public async Task Plan_NoUserEmailMatch_ClassifiedAsCreateNewUser()
+{
+    var harness = new PlanHarness();
+    harness.AddUnmatched(new TicketAttendee
+    {
+        Id = Guid.NewGuid(), VendorTicketId = "tkt_v",
+        AttendeeEmail = "fresh@x.com", FirstName = "Fresh", LastName = "Face",
+        Status = TicketAttendeeStatus.Valid,
+    });
+    harness.UserEmails.GetDistinctVerifiedUserIdsAsync("fresh@x.com", Arg.Any<CancellationToken>())
+        .Returns(Array.Empty<Guid>());
+    harness.UserEmails.FindAnyEmailRowByAddressAsync("fresh@x.com", Arg.Any<CancellationToken>())
+        .Returns(((Guid, Guid)?)null);
+
+    var plan = await harness.Service.BuildPlanAsync();
+
+    var decision = plan.Decisions.Single();
+    decision.Outcome.Should().Be(AttendeeImportOutcome.CreateNewUser);
+    decision.AttendeeName.Should().Be("Fresh Face");
+}
+
+[HumansFact]
+public async Task Plan_DisplayName_PrefersLegalName()
+{
+    var harness = new PlanHarness();
+    harness.AddUnmatched(new TicketAttendee
+    {
+        Id = Guid.NewGuid(), VendorTicketId = "tkt_v",
+        AttendeeEmail = "jane@x.com",
+        LegalName = "Jane Q. Doe", FirstName = "Jane", LastName = "Doe",
+        Status = TicketAttendeeStatus.Valid,
+    });
+    harness.UserEmails.GetDistinctVerifiedUserIdsAsync("jane@x.com", Arg.Any<CancellationToken>())
+        .Returns(Array.Empty<Guid>());
+    harness.UserEmails.FindAnyEmailRowByAddressAsync("jane@x.com", Arg.Any<CancellationToken>())
+        .Returns(((Guid, Guid)?)null);
+
+    var plan = await harness.Service.BuildPlanAsync();
+
+    plan.Decisions.Single().AttendeeName.Should().Be("Jane Q. Doe");
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `dotnet test Humans.slnx -v quiet --filter "FullyQualifiedName~AttendeeContactImportServicePlanTests"`
+Expected: 3 new tests FAIL.
+
+- [ ] **Step 3: Replace the trailing `throw` with the final branches**
+
+Replace the trailing `throw new NotImplementedException("Unverified/no-match branches filled in by Task 10");` in `ClassifyAsync` with:
+
+```csharp
+var existingRow = await _userEmails.FindAnyEmailRowByAddressAsync(a.AttendeeEmail!, ct);
+if (existingRow is var (uid, emailId))
+{
+    return new AttendeeImportDecision(
+        a.Id, a.AttendeeEmail, name, a.VendorTicketId,
+        AttendeeImportOutcome.DeleteUnverifiedThenCreate,
+        TargetUserId: null,
+        UnverifiedEmailIdToDelete: emailId,
+        UnverifiedRowUserId: uid,
+        AmbiguousUserIds: null);
+}
+
+return new AttendeeImportDecision(
+    a.Id, a.AttendeeEmail, name, a.VendorTicketId,
+    AttendeeImportOutcome.CreateNewUser,
+    TargetUserId: null,
+    UnverifiedEmailIdToDelete: null,
+    UnverifiedRowUserId: null,
+    AmbiguousUserIds: null);
+```
+
+- [ ] **Step 4: Run all plan tests**
+
+Run: `dotnet test Humans.slnx -v quiet --filter "FullyQualifiedName~AttendeeContactImportServicePlanTests"`
+Expected: all 7 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Humans.Application/Services/Tickets/AttendeeContactImportService.cs \
+        tests/Humans.Application.Tests/Services/Tickets/AttendeeContactImportServicePlanTests.cs
+git commit -m "feat: DeleteUnverifiedThenCreate + CreateNewUser classifiers"
+```
+
+---
+
+## Task 11: Implement `ApplyAsync` — happy paths
+
+**Files:**
+- Modify: `src/Humans.Application/Services/Tickets/AttendeeContactImportService.cs`
+- Create: `tests/Humans.Application.Tests/Services/Tickets/AttendeeContactImportServiceApplyTests.cs`
+
+- [ ] **Step 1: Write failing tests for the three positive outcomes**
+
+```csharp
+using AwesomeAssertions;
+using Humans.Application.Interfaces.AuditLog;
+using Humans.Application.Interfaces.Profiles;
+using Humans.Application.Interfaces.Repositories;
+using Humans.Application.Interfaces.Shifts;
+using Humans.Application.Interfaces.Tickets;
+using Humans.Application.Interfaces.Tickets.Dtos;
+using Humans.Application.Interfaces.Users;
+using Humans.Application.Services.Tickets;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using Microsoft.Extensions.Logging.Abstractions;
+using NodaTime;
+using NodaTime.Testing;
+using NSubstitute;
+using Xunit;
+
+namespace Humans.Application.Tests.Services.Tickets;
+
+public class AttendeeContactImportServiceApplyTests
+{
+    [HumansFact]
+    public async Task Apply_AttachVerified_SetsMatchedUserIdAndUpserts()
+    {
+        var harness = new ApplyHarness();
+        var attendeeId = Guid.NewGuid();
+        var targetUserId = Guid.NewGuid();
+        var attendee = new TicketAttendee
+        {
+            Id = attendeeId, VendorTicketId = "tkt_v", VendorEventId = "evt_active",
+            AttendeeEmail = "jane@x.com", Status = TicketAttendeeStatus.Valid,
+            MatchedUserId = null,
+        };
+        harness.WithUnmatched(attendee);
+        harness.WithActiveYear(2026);
+
+        var plan = new AttendeeImportPlan(
+            new[]
+            {
+                new AttendeeImportDecision(
+                    attendeeId, "jane@x.com", "Jane Doe", "tkt_v",
+                    AttendeeImportOutcome.AttachVerified,
+                    TargetUserId: targetUserId,
+                    UnverifiedEmailIdToDelete: null,
+                    UnverifiedRowUserId: null,
+                    AmbiguousUserIds: null),
+            },
+            TotalUnmatched: 1);
+
+        var result = await harness.Service.ApplyAsync(plan, new HashSet<Guid> { attendeeId });
+
+        result.AttachedToExistingVerified.Should().Be(1);
+        result.UsersCreated.Should().Be(0);
+        attendee.MatchedUserId.Should().Be(targetUserId);
+
+        await harness.TicketRepo.Received(1)
+            .UpsertAttendeesAsync(Arg.Is<IReadOnlyList<TicketAttendee>>(
+                l => l.Count == 1 && l[0].Id == attendeeId), Arg.Any<CancellationToken>());
+
+        await harness.Users.Received(1).SetParticipationFromTicketSyncAsync(
+            targetUserId, 2026, ParticipationStatus.Ticketed, Arg.Any<CancellationToken>());
+
+        harness.TicketQuery.Received(1).InvalidateAfterContactImport();
+
+        await harness.Audit.Received(1).LogAsync(
+            AuditAction.TicketContactsImported,
+            "Tickets", Guid.Empty,
+            Arg.Is<string>(s => s.Contains("attached=1")),
+            nameof(AttendeeContactImportService));
+    }
+
+    [HumansFact]
+    public async Task Apply_CreateNewUser_CallsProvisioningWithAttendeeName_AndTicketTailorSource()
+    {
+        var harness = new ApplyHarness();
+        var attendeeId = Guid.NewGuid();
+        var newUserId = Guid.NewGuid();
+        var attendee = new TicketAttendee
+        {
+            Id = attendeeId, VendorTicketId = "tkt_v", VendorEventId = "evt_active",
+            AttendeeEmail = "fresh@x.com", Status = TicketAttendeeStatus.Valid,
+        };
+        harness.WithUnmatched(attendee);
+        harness.WithActiveYear(2026);
+        harness.Provisioning.FindOrCreateUserByEmailAsync(
+                "fresh@x.com", "Fresh Face", ContactSource.TicketTailor, Arg.Any<CancellationToken>())
+            .Returns(new AccountProvisioningResult(
+                new User { Id = newUserId }, Created: true));
+
+        var plan = new AttendeeImportPlan(
+            new[]
+            {
+                new AttendeeImportDecision(
+                    attendeeId, "fresh@x.com", "Fresh Face", "tkt_v",
+                    AttendeeImportOutcome.CreateNewUser,
+                    null, null, null, null),
+            },
+            1);
+
+        var result = await harness.Service.ApplyAsync(plan, new HashSet<Guid> { attendeeId });
+
+        result.UsersCreated.Should().Be(1);
+        attendee.MatchedUserId.Should().Be(newUserId);
+
+        await harness.Provisioning.Received(1).FindOrCreateUserByEmailAsync(
+            "fresh@x.com", "Fresh Face", ContactSource.TicketTailor, Arg.Any<CancellationToken>());
+
+        await harness.Users.Received(1).SetParticipationFromTicketSyncAsync(
+            newUserId, 2026, ParticipationStatus.Ticketed, Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task Apply_DeleteUnverifiedThenCreate_DeletesSquatterRowFirst()
+    {
+        var harness = new ApplyHarness();
+        var attendeeId = Guid.NewGuid();
+        var squatterId = Guid.NewGuid();
+        var squatterEmailId = Guid.NewGuid();
+        var newUserId = Guid.NewGuid();
+        var attendee = new TicketAttendee
+        {
+            Id = attendeeId, VendorTicketId = "tkt_v", VendorEventId = "evt_active",
+            AttendeeEmail = "victim@x.com", Status = TicketAttendeeStatus.Valid,
+        };
+        harness.WithUnmatched(attendee);
+        harness.WithActiveYear(2026);
+        harness.Provisioning.FindOrCreateUserByEmailAsync(
+                "victim@x.com", "Victim", ContactSource.TicketTailor, Arg.Any<CancellationToken>())
+            .Returns(new AccountProvisioningResult(new User { Id = newUserId }, true));
+
+        var plan = new AttendeeImportPlan(
+            new[]
+            {
+                new AttendeeImportDecision(
+                    attendeeId, "victim@x.com", "Victim", "tkt_v",
+                    AttendeeImportOutcome.DeleteUnverifiedThenCreate,
+                    TargetUserId: null,
+                    UnverifiedEmailIdToDelete: squatterEmailId,
+                    UnverifiedRowUserId: squatterId,
+                    AmbiguousUserIds: null),
+            },
+            1);
+
+        var result = await harness.Service.ApplyAsync(plan, new HashSet<Guid> { attendeeId });
+
+        result.UnverifiedRowsDeletedAndUserCreated.Should().Be(1);
+        result.UsersCreated.Should().Be(1);
+        attendee.MatchedUserId.Should().Be(newUserId);
+
+        Received.InOrder(() =>
+        {
+            harness.UserEmails.DeleteEmailAsync(squatterId, squatterEmailId, Arg.Any<CancellationToken>());
+            harness.Provisioning.FindOrCreateUserByEmailAsync(
+                "victim@x.com", "Victim", ContactSource.TicketTailor, Arg.Any<CancellationToken>());
+        });
+    }
+}
+
+internal sealed class ApplyHarness
+{
+    public ITicketRepository TicketRepo { get; } = Substitute.For<ITicketRepository>();
+    public IUserEmailService UserEmails { get; } = Substitute.For<IUserEmailService>();
+    public IAccountProvisioningService Provisioning { get; } = Substitute.For<IAccountProvisioningService>();
+    public IUserService Users { get; } = Substitute.For<IUserService>();
+    public IShiftManagementService Shifts { get; } = Substitute.For<IShiftManagementService>();
+    public ITicketQueryService TicketQuery { get; } = Substitute.For<ITicketQueryService>();
+    public IAuditLogService Audit { get; } = Substitute.For<IAuditLogService>();
+    public FakeClock Clock { get; } = new(Instant.FromUtc(2026, 5, 13, 12, 0));
+
+    private readonly List<TicketAttendee> _unmatched = new();
+
+    public ApplyHarness()
+    {
+        TicketRepo.GetSyncStateAsync(Arg.Any<CancellationToken>())
+            .Returns(new TicketSyncState { Id = 1, VendorEventId = "evt_active" });
+        TicketRepo.GetUnmatchedActiveAttendeesAsync(
+                Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(_ => _unmatched);
+    }
+
+    public void WithUnmatched(TicketAttendee a) => _unmatched.Add(a);
+
+    public void WithActiveYear(int year)
+    {
+        // Mirror whatever IShiftManagementService.GetActiveAsync returns —
+        // a record with a Year property. Inspect the interface and adjust the
+        // type below if needed; the property name "Year" is what matters.
+        Shifts.GetActiveAsync(Arg.Any<CancellationToken>())
+            .Returns(new ActiveEventInfo(year));
+    }
+
+    public AttendeeContactImportService Service => new(
+        TicketRepo, UserEmails, Provisioning, Users, Shifts, TicketQuery, Audit, Clock,
+        NullLogger<AttendeeContactImportService>.Instance);
+}
+
+// Local stand-in for whatever record IShiftManagementService.GetActiveAsync
+// returns. Replace with the real type during impl if its name differs.
+internal sealed record ActiveEventInfo(int Year);
+```
+
+> **Note for the implementer:** open `IShiftManagementService.cs` and use the real return type for `GetActiveAsync` — adjust `ActiveEventInfo` accordingly (probably an existing entity/DTO with a `.Year` int). The test compiles only after this resolution.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `dotnet test Humans.slnx -v quiet --filter "FullyQualifiedName~AttendeeContactImportServiceApplyTests"`
+Expected: FAIL — `ApplyAsync` throws NotImplementedException.
+
+- [ ] **Step 3: Implement `ApplyAsync` (full body)**
+
+Replace the throwing `ApplyAsync` body in `AttendeeContactImportService` with:
+
+```csharp
+public async Task<AttendeeImportResult> ApplyAsync(
+    AttendeeImportPlan plan,
+    IReadOnlySet<Guid> selectedAttendeeIds,
+    CancellationToken ct = default)
+{
+    var start = _clock.GetCurrentInstant();
+
+    var state = await _ticketRepository.GetSyncStateAsync(ct);
+    var eventId = state?.VendorEventId
+        ?? throw new InvalidOperationException("No active vendor event id — sync has not run.");
+
+    // Re-query so plan/apply are stateless (a sync between plan and apply is tolerated).
+    var freshUnmatched = await _ticketRepository.GetUnmatchedActiveAttendeesAsync(eventId, ct);
+    var freshById = freshUnmatched.ToDictionary(a => a.Id);
+
+    var toUpsert = new List<TicketAttendee>();
+    var newlyMatchedUserIds = new HashSet<Guid>();
+    int attempted = 0, created = 0, attached = 0, replaced = 0,
+        ambiguous = 0, noEmail = 0, vanished = 0, errors = 0;
+
+    foreach (var d in plan.Decisions.Where(d => selectedAttendeeIds.Contains(d.AttendeeId)))
+    {
+        attempted++;
+
+        if (!freshById.TryGetValue(d.AttendeeId, out var attendee))
+        {
+            vanished++;
+            _logger.LogInformation(
+                "Attendee {AttendeeId} ({Email}) vanished between plan and apply",
+                d.AttendeeId, d.Email);
+            continue;
+        }
+
+        try
+        {
+            switch (d.Outcome)
+            {
+                case AttendeeImportOutcome.SkipNoEmail:
+                    noEmail++;
+                    break;
+
+                case AttendeeImportOutcome.SkipVoided:
+                    break;
+
+                case AttendeeImportOutcome.AmbiguousMultipleVerified:
+                    ambiguous++;
+                    _logger.LogError(
+                        "Attendee {AttendeeId} email {Email} verified by multiple users {UserIds}",
+                        d.AttendeeId, d.Email, d.AmbiguousUserIds);
+                    break;
+
+                case AttendeeImportOutcome.AttachVerified:
+                {
+                    attendee.MatchedUserId = d.TargetUserId!.Value;
+                    toUpsert.Add(attendee);
+                    newlyMatchedUserIds.Add(d.TargetUserId.Value);
+                    attached++;
+                    break;
+                }
+
+                case AttendeeImportOutcome.DeleteUnverifiedThenCreate:
+                {
+                    if (d.UnverifiedRowUserId is Guid uid &&
+                        d.UnverifiedEmailIdToDelete is Guid eid)
+                    {
+                        await _userEmails.DeleteEmailAsync(uid, eid, ct);
+                    }
+                    var (newUser, wasCreated) = await _provisioning.FindOrCreateUserByEmailAsync(
+                        d.Email!, d.AttendeeName, ContactSource.TicketTailor, ct);
+                    attendee.MatchedUserId = newUser.Id;
+                    toUpsert.Add(attendee);
+                    newlyMatchedUserIds.Add(newUser.Id);
+                    if (wasCreated) created++;
+                    replaced++;
+                    break;
+                }
+
+                case AttendeeImportOutcome.CreateNewUser:
+                {
+                    var (newUser, wasCreated) = await _provisioning.FindOrCreateUserByEmailAsync(
+                        d.Email!, d.AttendeeName, ContactSource.TicketTailor, ct);
+                    attendee.MatchedUserId = newUser.Id;
+                    toUpsert.Add(attendee);
+                    newlyMatchedUserIds.Add(newUser.Id);
+                    if (wasCreated) created++;
+                    break;
+                }
+            }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            errors++;
+            _logger.LogError(ex,
+                "Attendee contact import failed for {AttendeeId} ({Email})",
+                d.AttendeeId, d.Email);
+        }
+    }
+
+    if (toUpsert.Count > 0)
+    {
+        await _ticketRepository.UpsertAttendeesAsync(toUpsert, ct);
+    }
+
+    var active = await _shifts.GetActiveAsync(ct);
+    if (active is not null && newlyMatchedUserIds.Count > 0)
+    {
+        foreach (var userId in newlyMatchedUserIds)
+        {
+            await _users.SetParticipationFromTicketSyncAsync(
+                userId, active.Year, ParticipationStatus.Ticketed, ct);
+        }
+    }
+
+    _ticketQuery.InvalidateAfterContactImport();
+
+    var elapsed = _clock.GetCurrentInstant() - start;
+    var result = new AttendeeImportResult(
+        TotalAttempted: attempted,
+        UsersCreated: created,
+        AttachedToExistingVerified: attached,
+        UnverifiedRowsDeletedAndUserCreated: replaced,
+        AmbiguousSkipped: ambiguous,
+        NoEmailSkipped: noEmail,
+        VanishedBetweenPlanAndApply: vanished,
+        Errors: errors,
+        Elapsed: elapsed);
+
+    await _audit.LogAsync(
+        AuditAction.TicketContactsImported,
+        entityType: "Tickets", entityId: Guid.Empty,
+        description: result.FormatSummary(),
+        jobName: nameof(AttendeeContactImportService));
+
+    return result;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `dotnet test Humans.slnx -v quiet --filter "FullyQualifiedName~AttendeeContactImportServiceApplyTests"`
+Expected: 3 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Humans.Application/Services/Tickets/AttendeeContactImportService.cs \
+        tests/Humans.Application.Tests/Services/Tickets/AttendeeContactImportServiceApplyTests.cs
+git commit -m "feat: AttendeeContactImportService.ApplyAsync — happy paths"
+```
+
+---
+
+## Task 12: Apply edge cases — selection filter, vanished, errors don't abort
+
+**Files:**
+- Modify: `tests/Humans.Application.Tests/Services/Tickets/AttendeeContactImportServiceApplyTests.cs`
+
+- [ ] **Step 1: Add edge-case tests**
+
+```csharp
+[HumansFact]
+public async Task Apply_OnlyProcessesSelectedAttendees()
+{
+    var harness = new ApplyHarness();
+    var pickedId = Guid.NewGuid();
+    var skippedId = Guid.NewGuid();
+    var picked = new TicketAttendee
+    {
+        Id = pickedId, VendorTicketId = "tkt_p", VendorEventId = "evt_active",
+        AttendeeEmail = "p@x.com", Status = TicketAttendeeStatus.Valid,
+    };
+    var unselected = new TicketAttendee
+    {
+        Id = skippedId, VendorTicketId = "tkt_s", VendorEventId = "evt_active",
+        AttendeeEmail = "s@x.com", Status = TicketAttendeeStatus.Valid,
+    };
+    harness.WithUnmatched(picked);
+    harness.WithUnmatched(unselected);
+    harness.WithActiveYear(2026);
+    harness.Provisioning.FindOrCreateUserByEmailAsync(
+            Arg.Any<string>(), Arg.Any<string?>(), ContactSource.TicketTailor, Arg.Any<CancellationToken>())
+        .Returns(ci => new AccountProvisioningResult(new User { Id = Guid.NewGuid() }, true));
+
+    var plan = new AttendeeImportPlan(
+        new[]
+        {
+            new AttendeeImportDecision(pickedId, "p@x.com", "P", "tkt_p",
+                AttendeeImportOutcome.CreateNewUser, null, null, null, null),
+            new AttendeeImportDecision(skippedId, "s@x.com", "S", "tkt_s",
+                AttendeeImportOutcome.CreateNewUser, null, null, null, null),
+        }, 2);
+
+    var result = await harness.Service.ApplyAsync(plan, new HashSet<Guid> { pickedId });
+
+    result.TotalAttempted.Should().Be(1);
+    result.UsersCreated.Should().Be(1);
+    picked.MatchedUserId.Should().NotBeNull();
+    unselected.MatchedUserId.Should().BeNull();
+}
+
+[HumansFact]
+public async Task Apply_AttendeeVanishedBetweenPlanAndApply_IsCountedAndSkipped()
+{
+    var harness = new ApplyHarness();
+    var goneId = Guid.NewGuid();
+    // No call to harness.WithUnmatched — the re-query returns empty.
+    harness.WithActiveYear(2026);
+
+    var plan = new AttendeeImportPlan(
+        new[]
+        {
+            new AttendeeImportDecision(goneId, "g@x.com", "G", "tkt_g",
+                AttendeeImportOutcome.CreateNewUser, null, null, null, null),
+        }, 1);
+
+    var result = await harness.Service.ApplyAsync(plan, new HashSet<Guid> { goneId });
+
+    result.VanishedBetweenPlanAndApply.Should().Be(1);
+    result.UsersCreated.Should().Be(0);
+
+    await harness.Provisioning.DidNotReceive().FindOrCreateUserByEmailAsync(
+        Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<ContactSource>(), Arg.Any<CancellationToken>());
+}
+
+[HumansFact]
+public async Task Apply_PerAttendeeFailure_DoesNotAbortBatch()
+{
+    var harness = new ApplyHarness();
+    var failId = Guid.NewGuid();
+    var okId = Guid.NewGuid();
+    harness.WithUnmatched(new TicketAttendee
+    {
+        Id = failId, VendorTicketId = "tkt_f", VendorEventId = "evt_active",
+        AttendeeEmail = "f@x.com", Status = TicketAttendeeStatus.Valid,
+    });
+    harness.WithUnmatched(new TicketAttendee
+    {
+        Id = okId, VendorTicketId = "tkt_o", VendorEventId = "evt_active",
+        AttendeeEmail = "o@x.com", Status = TicketAttendeeStatus.Valid,
+    });
+    harness.WithActiveYear(2026);
+    harness.Provisioning.FindOrCreateUserByEmailAsync(
+            "f@x.com", Arg.Any<string?>(), ContactSource.TicketTailor, Arg.Any<CancellationToken>())
+        .Throws(new InvalidOperationException("boom"));
+    harness.Provisioning.FindOrCreateUserByEmailAsync(
+            "o@x.com", Arg.Any<string?>(), ContactSource.TicketTailor, Arg.Any<CancellationToken>())
+        .Returns(new AccountProvisioningResult(new User { Id = Guid.NewGuid() }, true));
+
+    var plan = new AttendeeImportPlan(
+        new[]
+        {
+            new AttendeeImportDecision(failId, "f@x.com", "F", "tkt_f",
+                AttendeeImportOutcome.CreateNewUser, null, null, null, null),
+            new AttendeeImportDecision(okId, "o@x.com", "O", "tkt_o",
+                AttendeeImportOutcome.CreateNewUser, null, null, null, null),
+        }, 2);
+
+    var result = await harness.Service.ApplyAsync(plan, new HashSet<Guid> { failId, okId });
+
+    result.Errors.Should().Be(1);
+    result.UsersCreated.Should().Be(1);
+}
+```
+
+Add the matching using directive if not already present:
+```csharp
+using NSubstitute.ExceptionExtensions;
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `dotnet test Humans.slnx -v quiet --filter "FullyQualifiedName~AttendeeContactImportServiceApplyTests"`
+Expected: all 6 PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/Humans.Application.Tests/Services/Tickets/AttendeeContactImportServiceApplyTests.cs
+git commit -m "test: AttendeeContactImportService apply edge cases (selection, vanished, error isolation)"
+```
+
+---
+
+## Task 13: Squatter-protection test (security property)
+
+**Files:**
+- Create: `tests/Humans.Application.Tests/Services/Tickets/AttendeeContactImportServiceSquatterTests.cs`
+
+- [ ] **Step 1: Write the squatter test**
+
+```csharp
+using AwesomeAssertions;
+using Humans.Application.Interfaces.Profiles;
+using Humans.Application.Interfaces.Tickets.Dtos;
+using Humans.Application.Interfaces.Users;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using NSubstitute;
+using Xunit;
+
+namespace Humans.Application.Tests.Services.Tickets;
+
+public class AttendeeContactImportServiceSquatterTests
+{
+    [HumansFact]
+    public async Task Squatter_UnverifiedRowDeletedBeforeNewUserCreated_NewUserNotAttachedToSquatter()
+    {
+        var harness = new ApplyHarness();
+        var attendeeId = Guid.NewGuid();
+        var squatterUserId = Guid.NewGuid();
+        var squatterRowId = Guid.NewGuid();
+        var newVictimUserId = Guid.NewGuid();
+        var attendee = new TicketAttendee
+        {
+            Id = attendeeId, VendorTicketId = "tkt_v", VendorEventId = "evt_active",
+            AttendeeEmail = "victim@x.com", FirstName = "Victim",
+            Status = TicketAttendeeStatus.Valid,
+        };
+        harness.WithUnmatched(attendee);
+        harness.WithActiveYear(2026);
+        harness.Provisioning.FindOrCreateUserByEmailAsync(
+                "victim@x.com", Arg.Any<string?>(), ContactSource.TicketTailor, Arg.Any<CancellationToken>())
+            .Returns(new AccountProvisioningResult(new User { Id = newVictimUserId }, Created: true));
+
+        var plan = new AttendeeImportPlan(
+            new[]
+            {
+                new AttendeeImportDecision(
+                    attendeeId, "victim@x.com", "Victim", "tkt_v",
+                    AttendeeImportOutcome.DeleteUnverifiedThenCreate,
+                    null, squatterRowId, squatterUserId, null),
+            }, 1);
+
+        await harness.Service.ApplyAsync(plan, new HashSet<Guid> { attendeeId });
+
+        // 1. Squatter row deleted.
+        await harness.UserEmails.Received(1)
+            .DeleteEmailAsync(squatterUserId, squatterRowId, Arg.Any<CancellationToken>());
+
+        // 2. New user created — NOT attached to squatter.
+        attendee.MatchedUserId.Should().Be(newVictimUserId);
+        attendee.MatchedUserId.Should().NotBe(squatterUserId);
+
+        // 3. Delete happened before create (Received.InOrder).
+        Received.InOrder(() =>
+        {
+            harness.UserEmails.DeleteEmailAsync(squatterUserId, squatterRowId, Arg.Any<CancellationToken>());
+            harness.Provisioning.FindOrCreateUserByEmailAsync(
+                "victim@x.com", Arg.Any<string?>(), ContactSource.TicketTailor, Arg.Any<CancellationToken>());
+        });
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `dotnet test Humans.slnx -v quiet --filter "FullyQualifiedName~AttendeeContactImportServiceSquatterTests"`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/Humans.Application.Tests/Services/Tickets/AttendeeContactImportServiceSquatterTests.cs
+git commit -m "test: squatter protection — unverified row deleted before victim user created"
+```
+
+---
+
+## Task 14: Architecture tests
+
+**Files:**
+- Create: `tests/Humans.Application.Tests/Architecture/AttendeeContactImportArchitectureTests.cs`
+
+- [ ] **Step 1: Write the architecture tests**
+
+Mirror an existing arch-test in the same folder (`TicketSyncArchitectureTests.cs`) for the helper conventions — assertion style, ArchUnitNET vs reflection vs hand-rolled, etc. Adapt to:
+
+```csharp
+using AwesomeAssertions;
+using Humans.Application.Interfaces.AuditLog;
+using Humans.Application.Interfaces.Profiles;
+using Humans.Application.Interfaces.Repositories;
+using Humans.Application.Interfaces.Shifts;
+using Humans.Application.Interfaces.Tickets;
+using Humans.Application.Interfaces.Users;
+using Humans.Application.Services.Tickets;
+using Xunit;
+
+namespace Humans.Application.Tests.Architecture;
+
+public class AttendeeContactImportArchitectureTests
+{
+    [HumansFact]
+    public void Service_LivesInTicketsNamespace()
+    {
+        typeof(AttendeeContactImportService).Namespace
+            .Should().Be("Humans.Application.Services.Tickets");
+    }
+
+    [HumansFact]
+    public void Service_DoesNotReferenceDbContextOrEf()
+    {
+        var asmTypes = typeof(AttendeeContactImportService).Assembly.GetTypes();
+        // Service must not import anything from Microsoft.EntityFrameworkCore or
+        // reference HumansDbContext (Infrastructure type).
+        var fields = typeof(AttendeeContactImportService).GetFields(
+            System.Reflection.BindingFlags.NonPublic |
+            System.Reflection.BindingFlags.Instance);
+
+        foreach (var f in fields)
+        {
+            f.FieldType.FullName.Should().NotContain("Microsoft.EntityFrameworkCore");
+            f.FieldType.FullName.Should().NotContain("HumansDbContext");
+        }
+    }
+
+    [HumansFact]
+    public void Service_DependsOnExpectedAbstractions()
+    {
+        var ctor = typeof(AttendeeContactImportService).GetConstructors().Single();
+        var paramTypes = ctor.GetParameters().Select(p => p.ParameterType).ToHashSet();
+
+        paramTypes.Should().Contain(typeof(ITicketRepository));
+        paramTypes.Should().Contain(typeof(IUserEmailService));
+        paramTypes.Should().Contain(typeof(IAccountProvisioningService));
+        paramTypes.Should().Contain(typeof(IUserService));
+        paramTypes.Should().Contain(typeof(IShiftManagementService));
+        paramTypes.Should().Contain(typeof(ITicketQueryService));
+        paramTypes.Should().Contain(typeof(IAuditLogService));
+    }
+}
+```
+
+> If the existing arch tests use a different style (e.g. `NetArchTest.Rules` predicate-builder, or a project-wide architecture-fitness helper), adopt that style instead. The assertions above describe the invariants in plain reflection — restructure to match.
+
+- [ ] **Step 2: Run tests**
+
+Run: `dotnet test Humans.slnx -v quiet --filter "FullyQualifiedName~AttendeeContactImportArchitectureTests"`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/Humans.Application.Tests/Architecture/AttendeeContactImportArchitectureTests.cs
+git commit -m "test: architecture pins for AttendeeContactImportService"
+```
+
+---
+
+## Task 15: DI registration
+
+**Files:**
+- Modify: `src/Humans.Web/Extensions/Sections/TicketsSectionExtensions.cs`
+
+- [ ] **Step 1: Register the service**
+
+Open `src/Humans.Web/Extensions/Sections/TicketsSectionExtensions.cs`. Find the existing `TicketSyncService` registration (look for `services.AddScoped<TicketsTicketSyncService>();`). Add nearby:
+
+```csharp
+services.AddScoped<IAttendeeContactImportService,
+    Humans.Application.Services.Tickets.AttendeeContactImportService>();
+```
+
+(If the file already uses a `using` alias for `Humans.Application.Services.Tickets`, simplify accordingly.)
+
+- [ ] **Step 2: Build**
+
+Run: `dotnet build Humans.slnx -v quiet`
+Expected: succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/Humans.Web/Extensions/Sections/TicketsSectionExtensions.cs
+git commit -m "feat: DI registration for IAttendeeContactImportService"
+```
+
+---
+
+## Task 16: Controller + view-model — preview GET
+
+**Files:**
+- Create: `src/Humans.Web/Controllers/Tickets/TicketsContactsAdminController.cs`
+- Create: `src/Humans.Web/Models/Tickets/ContactImportPreviewViewModel.cs`
+- Create: `tests/Humans.Web.Tests/Controllers/Tickets/TicketsContactsAdminControllerTests.cs`
+
+- [ ] **Step 1: Create the view-model**
+
+```csharp
+using Humans.Application.Interfaces.Tickets.Dtos;
+
+namespace Humans.Web.Models.Tickets;
+
+public sealed record ContactImportPreviewViewModel(
+    AttendeeImportPlan Plan,
+    IReadOnlyList<AttendeeImportDecisionRow> Rows);
+
+public sealed record AttendeeImportDecisionRow(
+    Guid AttendeeId,
+    string? Email,
+    string? AttendeeName,
+    string VendorTicketId,
+    AttendeeImportOutcome Outcome,
+    Guid? TargetUserId,
+    Guid? UnverifiedRowUserId,
+    IReadOnlyList<Guid>? AmbiguousUserIds);
+```
+
+- [ ] **Step 2: Write the failing controller test for GET**
+
+```csharp
+using AwesomeAssertions;
+using Humans.Application.Interfaces.Tickets;
+using Humans.Application.Interfaces.Tickets.Dtos;
+using Humans.Domain.Entities;
+using Humans.Web.Controllers.Tickets;
+using Humans.Web.Models.Tickets;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Xunit;
+
+namespace Humans.Web.Tests.Controllers.Tickets;
+
+public class TicketsContactsAdminControllerTests
+{
+    [HumansFact]
+    public async Task Index_RendersPreview_WithPlanAndProjectedRows()
+    {
+        var import = Substitute.For<IAttendeeContactImportService>();
+        var attendeeId = Guid.NewGuid();
+        var plan = new AttendeeImportPlan(
+            new[]
+            {
+                new AttendeeImportDecision(attendeeId, "a@x.com", "A", "tkt_a",
+                    AttendeeImportOutcome.CreateNewUser, null, null, null, null),
+            }, 1);
+        import.BuildPlanAsync(Arg.Any<CancellationToken>()).Returns(plan);
+
+        var controller = new TicketsContactsAdminController(
+            import, Substitute.For<UserManager<User>>(
+                Substitute.For<IUserStore<User>>(), null!, null!, null!, null!, null!, null!, null!, null!),
+            NullLogger<TicketsContactsAdminController>.Instance);
+
+        var result = await controller.Index(default);
+
+        var view = result.Should().BeOfType<ViewResult>().Subject;
+        var vm = view.Model.Should().BeOfType<ContactImportPreviewViewModel>().Subject;
+        vm.Plan.Should().BeSameAs(plan);
+        vm.Rows.Should().ContainSingle()
+            .Which.AttendeeId.Should().Be(attendeeId);
+    }
+}
+```
+
+> **Note:** the existing test layer may have a controller-test base class that handles `UserManager<User>` mocking. Look for `HumansControllerBase` or a similar test helper and use it if present.
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `dotnet test Humans.slnx -v quiet --filter "FullyQualifiedName~TicketsContactsAdminControllerTests"`
+Expected: FAIL — controller doesn't exist.
+
+- [ ] **Step 4: Create the controller (GET only)**
+
+```csharp
+using Humans.Application.Interfaces.Tickets;
+using Humans.Application.Interfaces.Tickets.Dtos;
+using Humans.Domain.Entities;
+using Humans.Web.Authorization;
+using Humans.Web.Models.Tickets;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+namespace Humans.Web.Controllers.Tickets;
+
+[Authorize(Policy = PolicyNames.TicketAdminOrAdmin)]
+[Route("Tickets/Admin/Contacts")]
+public sealed class TicketsContactsAdminController : HumansControllerBase
+{
+    private readonly IAttendeeContactImportService _import;
+    private readonly ILogger<TicketsContactsAdminController> _logger;
+
+    public TicketsContactsAdminController(
+        IAttendeeContactImportService import,
+        UserManager<User> userManager,
+        ILogger<TicketsContactsAdminController> logger)
+        : base(userManager)
+    {
+        _import = import;
+        _logger = logger;
+    }
+
+    [HttpGet("")]
+    public async Task<IActionResult> Index(CancellationToken ct)
+    {
+        var plan = await _import.BuildPlanAsync(ct);
+        var rows = plan.Decisions
+            .OrderBy(d => SortKey(d.Outcome))
+            .ThenBy(d => d.Email)
+            .Select(d => new AttendeeImportDecisionRow(
+                d.AttendeeId, d.Email, d.AttendeeName, d.VendorTicketId,
+                d.Outcome, d.TargetUserId, d.UnverifiedRowUserId, d.AmbiguousUserIds))
+            .ToList();
+
+        return View("~/Views/Tickets/Admin/Contacts.cshtml",
+            new ContactImportPreviewViewModel(plan, rows));
+    }
+
+    // Ambiguous + DeleteUnverifiedThenCreate at top of the list so admin can't miss them.
+    private static int SortKey(AttendeeImportOutcome o) => o switch
+    {
+        AttendeeImportOutcome.AmbiguousMultipleVerified => 0,
+        AttendeeImportOutcome.DeleteUnverifiedThenCreate => 1,
+        AttendeeImportOutcome.CreateNewUser => 2,
+        AttendeeImportOutcome.AttachVerified => 3,
+        AttendeeImportOutcome.SkipNoEmail => 4,
+        AttendeeImportOutcome.SkipVoided => 5,
+        _ => 99,
+    };
+}
+```
+
+> **Note:** verify `PolicyNames.TicketAdminOrAdmin` is the exact constant name — `grep -rn "TicketAdminOrAdmin" src/Humans.Web` will confirm. If the policy is named differently (e.g. `TicketAdmin_Or_Admin`), use the existing spelling.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `dotnet test Humans.slnx -v quiet --filter "FullyQualifiedName~TicketsContactsAdminControllerTests"`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Humans.Web/Controllers/Tickets/TicketsContactsAdminController.cs \
+        src/Humans.Web/Models/Tickets/ContactImportPreviewViewModel.cs \
+        tests/Humans.Web.Tests/Controllers/Tickets/TicketsContactsAdminControllerTests.cs
+git commit -m "feat: TicketsContactsAdminController GET preview"
+```
+
+---
+
+## Task 17: Controller POST — apply selected
+
+**Files:**
+- Modify: `src/Humans.Web/Controllers/Tickets/TicketsContactsAdminController.cs`
+- Modify: `tests/Humans.Web.Tests/Controllers/Tickets/TicketsContactsAdminControllerTests.cs`
+
+- [ ] **Step 1: Add failing test**
+
+Append to the existing test class:
+
+```csharp
+[HumansFact]
+public async Task Apply_PassesSelectedIdsToService_AndRedirectsWithBanner()
+{
+    var import = Substitute.For<IAttendeeContactImportService>();
+    var plan = new AttendeeImportPlan(Array.Empty<AttendeeImportDecision>(), 0);
+    import.BuildPlanAsync(Arg.Any<CancellationToken>()).Returns(plan);
+    import.ApplyAsync(Arg.Any<AttendeeImportPlan>(),
+            Arg.Any<IReadOnlySet<Guid>>(), Arg.Any<CancellationToken>())
+        .Returns(new AttendeeImportResult(
+            TotalAttempted: 1, UsersCreated: 1, AttachedToExistingVerified: 0,
+            UnverifiedRowsDeletedAndUserCreated: 0, AmbiguousSkipped: 0, NoEmailSkipped: 0,
+            VanishedBetweenPlanAndApply: 0, Errors: 0,
+            Elapsed: NodaTime.Duration.FromSeconds(1)));
+
+    var controller = new TicketsContactsAdminController(
+        import, /* UserManager fake */ TestUserManagers.NoOp(),
+        NullLogger<TicketsContactsAdminController>.Instance);
+    controller.TempData = TestTempData.Empty();
+
+    var selectedId = Guid.NewGuid();
+    var result = await controller.Apply(new[] { selectedId }, default);
+
+    result.Should().BeOfType<RedirectToActionResult>()
+        .Which.ActionName.Should().Be(nameof(TicketsContactsAdminController.Index));
+    controller.TempData["Banner"].Should().NotBeNull();
+
+    await import.Received(1).ApplyAsync(
+        plan,
+        Arg.Is<IReadOnlySet<Guid>>(s => s.Contains(selectedId) && s.Count == 1),
+        Arg.Any<CancellationToken>());
+}
+
+[HumansFact]
+public async Task Apply_EmptySelection_RedirectsWithValidationBanner_NoServiceCall()
+{
+    var import = Substitute.For<IAttendeeContactImportService>();
+
+    var controller = new TicketsContactsAdminController(
+        import, TestUserManagers.NoOp(),
+        NullLogger<TicketsContactsAdminController>.Instance);
+    controller.TempData = TestTempData.Empty();
+
+    var result = await controller.Apply(Array.Empty<Guid>(), default);
+
+    result.Should().BeOfType<RedirectToActionResult>();
+    controller.TempData["Banner"].Should().NotBeNull();
+    await import.DidNotReceive().ApplyAsync(
+        Arg.Any<AttendeeImportPlan>(), Arg.Any<IReadOnlySet<Guid>>(), Arg.Any<CancellationToken>());
+}
+```
+
+> Replace `TestUserManagers.NoOp()` and `TestTempData.Empty()` with whatever helpers exist in the test project for those concerns — these are the standard names; adjust to actual.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `dotnet test Humans.slnx -v quiet --filter "FullyQualifiedName~TicketsContactsAdminControllerTests"`
+Expected: 2 new tests FAIL — `Apply` method doesn't exist.
+
+- [ ] **Step 3: Implement Apply on the controller**
+
+Add to `TicketsContactsAdminController`:
+
+```csharp
+[HttpPost("Apply")]
+[ValidateAntiForgeryToken]
+public async Task<IActionResult> Apply(
+    [FromForm(Name = "selected")] Guid[] selected,
+    CancellationToken ct)
+{
+    if (selected is null || selected.Length == 0)
+    {
+        TempData["Banner"] = "Select at least one attendee before applying.";
+        return RedirectToAction(nameof(Index));
+    }
+
+    var fresh = await _import.BuildPlanAsync(ct);
+    var result = await _import.ApplyAsync(fresh, new HashSet<Guid>(selected), ct);
+    TempData["Banner"] = $"Attendee contact import: {result.FormatSummary()}";
+    return RedirectToAction(nameof(Index));
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `dotnet test Humans.slnx -v quiet --filter "FullyQualifiedName~TicketsContactsAdminControllerTests"`
+Expected: 3 PASS total.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Humans.Web/Controllers/Tickets/TicketsContactsAdminController.cs \
+        tests/Humans.Web.Tests/Controllers/Tickets/TicketsContactsAdminControllerTests.cs
+git commit -m "feat: TicketsContactsAdminController.Apply with selection guard"
+```
+
+---
+
+## Task 18: Razor view — preview + apply
+
+**Files:**
+- Create: `src/Humans.Web/Views/Tickets/Admin/Contacts.cshtml`
+
+- [ ] **Step 1: Inspect existing patterns**
+
+Read `src/Humans.Web/Views/Mailer/Admin/Import.cshtml` for the preview-table style. Match its layout (Bootstrap 5 utility classes, count badges, form structure, anti-forgery token). The Mailer view is the reference.
+
+- [ ] **Step 2: Create the view**
+
+```cshtml
+@using Humans.Application.Interfaces.Tickets.Dtos
+@model Humans.Web.Models.Tickets.ContactImportPreviewViewModel
+@{
+    ViewData["Title"] = "Import Attendee Contacts";
+    var c = Model.Plan.Counts;
+}
+
+<h1>Import Attendee Contacts</h1>
+
+@if (TempData["Banner"] is string banner)
+{
+    <div class="alert alert-info" role="alert">@banner</div>
+}
+
+<p class="text-muted">
+    Found @Model.Plan.TotalUnmatched unmatched attendee@(Model.Plan.TotalUnmatched == 1 ? "" : "s")
+    for the active event. Each one below has no <code>MatchedUserId</code> yet.
+    Select rows and click Apply.
+</p>
+
+<div class="mb-3">
+    <span class="badge text-bg-success me-1">Attach existing: @c.AttachVerified</span>
+    <span class="badge text-bg-primary me-1">Create new user: @c.CreateNewUser</span>
+    <span class="badge text-bg-warning me-1">Delete unverified + create: @c.DeleteUnverifiedThenCreate</span>
+    @if (c.AmbiguousMultipleVerified > 0)
+    {
+        <span class="badge text-bg-danger me-1">Ambiguous (skipped): @c.AmbiguousMultipleVerified</span>
+    }
+    @if (c.SkipNoEmail > 0)
+    {
+        <span class="badge text-bg-secondary me-1">No email (skipped): @c.SkipNoEmail</span>
+    }
+</div>
+
+<form asp-action="Apply" method="post" id="contacts-apply">
+    @Html.AntiForgeryToken()
+
+    <div class="mb-2">
+        <button type="button" class="btn btn-outline-secondary btn-sm" id="select-all">Select all</button>
+        <button type="button" class="btn btn-outline-secondary btn-sm" id="select-first">Select first 1</button>
+        <button type="submit" class="btn btn-primary btn-sm" id="apply-btn">
+            Apply selected (<span id="selected-count">0</span>)
+        </button>
+    </div>
+
+    <table class="table table-sm table-hover">
+        <thead>
+            <tr>
+                <th style="width:2rem"></th>
+                <th>Email</th>
+                <th>Name</th>
+                <th>Decision</th>
+                <th>Target / Notes</th>
+                <th>Vendor Ticket Id</th>
+            </tr>
+        </thead>
+        <tbody>
+        @foreach (var row in Model.Rows)
+        {
+            <tr>
+                <td>
+                    @if (row.Outcome is AttendeeImportOutcome.AmbiguousMultipleVerified
+                                      or AttendeeImportOutcome.SkipNoEmail
+                                      or AttendeeImportOutcome.SkipVoided)
+                    {
+                        @* Non-actionable rows: no checkbox *@
+                    }
+                    else
+                    {
+                        <input type="checkbox" name="selected" value="@row.AttendeeId"
+                               class="form-check-input row-check" />
+                    }
+                </td>
+                <td>@(row.Email ?? "—")</td>
+                <td>@(row.AttendeeName ?? "—")</td>
+                <td>
+                    @switch (row.Outcome)
+                    {
+                        case AttendeeImportOutcome.AttachVerified:
+                            <span class="badge text-bg-success">Attach existing</span>
+                            break;
+                        case AttendeeImportOutcome.CreateNewUser:
+                            <span class="badge text-bg-primary">Create new user</span>
+                            break;
+                        case AttendeeImportOutcome.DeleteUnverifiedThenCreate:
+                            <span class="badge text-bg-warning">Delete unverified + create</span>
+                            break;
+                        case AttendeeImportOutcome.AmbiguousMultipleVerified:
+                            <span class="badge text-bg-danger">Ambiguous</span>
+                            break;
+                        case AttendeeImportOutcome.SkipNoEmail:
+                            <span class="badge text-bg-secondary">No email</span>
+                            break;
+                        case AttendeeImportOutcome.SkipVoided:
+                            <span class="badge text-bg-secondary">Voided</span>
+                            break;
+                    }
+                </td>
+                <td>
+                    @if (row.Outcome == AttendeeImportOutcome.AttachVerified && row.TargetUserId is Guid uid)
+                    {
+                        <a asp-controller="Admin" asp-action="EditUser" asp-route-id="@uid">
+                            View user</a>
+                    }
+                    else if (row.Outcome == AttendeeImportOutcome.DeleteUnverifiedThenCreate
+                             && row.UnverifiedRowUserId is Guid squatterId)
+                    {
+                        <text>Will delete unverified email row owned by </text>
+                        <a asp-controller="Admin" asp-action="EditUser" asp-route-id="@squatterId">user</a>
+                    }
+                    else if (row.Outcome == AttendeeImportOutcome.AmbiguousMultipleVerified
+                             && row.AmbiguousUserIds is { Count: > 0 } ids)
+                    {
+                        <text>Multiple verified owners: @string.Join(", ", ids)</text>
+                    }
+                </td>
+                <td><code>@row.VendorTicketId</code></td>
+            </tr>
+        }
+        </tbody>
+    </table>
+</form>
+
+<script>
+(function () {
+    const checks = document.querySelectorAll('.row-check');
+    const count = document.getElementById('selected-count');
+    function refresh() {
+        const n = Array.from(checks).filter(c => c.checked).length;
+        count.textContent = n;
+        document.getElementById('apply-btn').disabled = n === 0;
+    }
+    checks.forEach(c => c.addEventListener('change', refresh));
+    document.getElementById('select-all').addEventListener('click', () => {
+        checks.forEach(c => c.checked = true);
+        refresh();
+    });
+    document.getElementById('select-first').addEventListener('click', () => {
+        checks.forEach((c, i) => c.checked = (i === 0));
+        refresh();
+    });
+    refresh();
+})();
+</script>
+```
+
+> **Asp action link verification:** the "View user" link assumes an admin user-edit controller exists at `Admin/EditUser?id=`. Run `grep -rn "EditUser\|UserEdit\|users/edit" src/Humans.Web/Controllers` to confirm the actual route. If the admin user controller uses a different name (e.g. `UsersAdminController.Edit`), update both `asp-controller` and `asp-action` accordingly.
+
+- [ ] **Step 3: Build + smoke-render**
+
+Run: `dotnet build Humans.slnx -v quiet`
+Then start the app: `dotnet run --project src/Humans.Web`
+Visit `https://localhost:7XXX/Tickets/Admin/Contacts` while signed in as a TicketAdmin/Admin user. Confirm the page renders (the unmatched list will probably be empty in dev unless the stub vendor produced unmatched attendees — that's fine, the empty-state should still render).
+
+Stop the server when done.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Humans.Web/Views/Tickets/Admin/Contacts.cshtml
+git commit -m "feat: Razor view for attendee contact import preview + apply"
+```
+
+---
+
+## Task 19: Discoverability — link from the Tickets dashboard
+
+**Files:**
+- Modify: `src/Humans.Web/Views/Tickets/Index.cshtml` (or wherever the existing Sync/FullResync buttons live)
+
+- [ ] **Step 1: Find the admin actions block**
+
+Run: `grep -n "Sync\|FullResync\|FullReSync\|asp-action" src/Humans.Web/Views/Tickets/Index.cshtml | head -20`
+
+Identify the block that renders the "Run Sync" / "Full Re-sync" action buttons.
+
+- [ ] **Step 2: Add the link**
+
+Inside that admin-actions block (gated on the same `@if (User.IsInRole(...))` or policy check the existing buttons use), add:
+
+```cshtml
+<a asp-controller="TicketsContactsAdmin" asp-action="Index"
+   class="btn btn-outline-primary btn-sm">
+    Import Attendee Contacts
+</a>
+```
+
+- [ ] **Step 3: Smoke-test the link**
+
+Start the app and confirm the new button appears for admin users on `/Tickets`, and clicking it navigates to `/Tickets/Admin/Contacts`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Humans.Web/Views/Tickets/Index.cshtml
+git commit -m "feat: dashboard link to attendee contacts import"
+```
+
+---
+
+## Task 20: Section doc + freshness updates
+
+**Files:**
+- Modify: `docs/sections/tickets.md`
+- Modify: `docs/architecture/freshness-catalog.yml` (if `tickets.md` has a catalog entry)
+
+- [ ] **Step 1: Update `docs/sections/tickets.md`**
+
+Add a paragraph to the **Concepts** section near the existing "Ticket Sync" description:
+
+> **Attendee Contact Import** is a manually-triggered admin job (`IAttendeeContactImportService`) that creates a no-profile Humans user for each unmatched ticket attendee whose email doesn't already resolve to an existing UserEmail. Mirrors the Mailer import's plan/apply shape with squatter protection (unverified UserEmail rows are deleted before a fresh verified row is created for the new user). Decoupled from the sync today; Phase 2 will run it automatically at the end of each `TicketSyncService` run.
+
+Add to the **Routing** table:
+
+| `/Tickets/Admin/Contacts` | GET | `TicketAdminOrAdmin` | Preview attendee-contact-import plan |
+| `/Tickets/Admin/Contacts/Apply` | POST | `TicketAdminOrAdmin` | Apply selected attendees |
+
+Add to **Triggers**:
+
+> - On attendee contact import apply: for selected unmatched attendees, `MatchedUserId` is set (via `UpsertAttendeesAsync`), new users are provisioned (via `IAccountProvisioningService` with `ContactSource.TicketTailor`, Stub Profile + verified `UserEmail`), squatter unverified rows are deleted first, `EventParticipation(Ticketed, TicketSync)` is written for each newly-matched user, ticket caches are invalidated via `ITicketQueryService.InvalidateAfterContactImport`, and a single `AuditAction.TicketContactsImported` row records the summary.
+
+Extend the **Cross-Section Dependencies** list to mention `IAccountProvisioningService` (Users section).
+
+Extend **Actors & Roles** — the "TicketAdmin, Admin" row gets a new capability: "Import attendee contacts (preview + selectively apply)".
+
+Extend **Negative Access Rules** — add: "Board cannot trigger attendee contact import — same `TicketAdminOrAdmin` gate as the sync."
+
+Update the freshness-trigger comment at the top of `tickets.md`:
+
+```html
+<!-- freshness:triggers
+  ... (existing entries) ...
+  src/Humans.Application/Services/Tickets/AttendeeContactImportService.cs
+  src/Humans.Application/Interfaces/Tickets/IAttendeeContactImportService.cs
+  src/Humans.Web/Controllers/Tickets/TicketsContactsAdminController.cs
+-->
+```
+
+- [ ] **Step 2: Update freshness catalog (if entry exists)**
+
+Run: `grep -A 10 "tickets.md" docs/architecture/freshness-catalog.yml`
+
+If the catalog has a `tickets.md` entry with `triggers:`, add the three new file paths from Step 1 above to its trigger list. If the catalog auto-extracts from the markdown comment, the comment update above is sufficient.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/sections/tickets.md docs/architecture/freshness-catalog.yml
+git commit -m "docs: section invariants + freshness for attendee contact import"
+```
+
+---
+
+## Task 21: Full build + test pass, then push
+
+- [ ] **Step 1: Full build**
+
+Run: `dotnet build Humans.slnx -v quiet`
+Expected: succeeds with zero warnings introduced by these tasks (existing warnings are OK).
+
+- [ ] **Step 2: Full test pass**
+
+Run: `dotnet test Humans.slnx -v quiet`
+Expected: all tests pass. If pre-existing failures are present that are unrelated to this work, list them in the final commit message; otherwise expect a clean run.
+
+- [ ] **Step 3: Push the branch**
+
+Run: `git push origin feat/ticket-attendee-contact-import`
+
+- [ ] **Step 4: Open the PR**
+
+```bash
+gh pr create --title "feat: attendee contact import (Tickets)" --body "$(cat <<'EOF'
+## Summary
+- New manually-triggered admin job that creates Humans users from unmatched ticket attendees, mirroring the Mailer plan/apply pattern.
+- Squatter protection: unverified UserEmail rows are deleted before provisioning a new user with a verified row.
+- Per-row checkbox preview at `/Tickets/Admin/Contacts` — admin can test against a single attendee before bulk-applying.
+- Wires `EventParticipation(Ticketed, TicketSync)` immediately for newly-matched users (no wait for next sync).
+
+Spec: `docs/superpowers/specs/2026-05-13-ticket-attendee-contact-import-design.md`
+Plan: `docs/superpowers/plans/2026-05-13-ticket-attendee-contact-import.md`
+
+## Test plan
+- [ ] Build + test suite green
+- [ ] Smoke: visit `/Tickets/Admin/Contacts` in dev, confirm preview renders
+- [ ] Smoke: select 1 attendee, apply, confirm result banner + new user appears under `/Admin/Users`
+- [ ] Smoke: select all, apply, confirm remaining attendees matched and `Volunteer Ticket Coverage` denominator on `/Tickets` updates
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 5: Confirm PR URL printed and visible**
+
+Capture the PR URL printed by `gh pr create` and share it.
+
+---
+
+## Spec Coverage Check
+
+| Spec section | Covered by task |
+|---|---|
+| New audit action `TicketContactsImported` | 1 |
+| DTOs (Outcome, Decision, Plan, Result) | 2, 3, 4 |
+| `IAttendeeContactImportService` interface | 5 |
+| `GetUnmatchedActiveAttendeesAsync` repo method | 6 |
+| `InvalidateAfterContactImport` cache seam | 7 |
+| Plan classifier (six decisions) | 8, 9, 10 |
+| Tombstone follow | 9 |
+| `ApplyAsync` (selection, vanished, errors, audit, invalidate, participation) | 11, 12 |
+| Squatter protection security property | 13 |
+| Architecture tests | 14 |
+| DI registration | 15 |
+| Controller GET + POST with anti-forgery and policy | 16, 17 |
+| Razor preview with checkbox UI, sort-Ambiguous-first, Select-all/Select-first-1 | 18 |
+| Dashboard discoverability link | 19 |
+| Section docs + freshness | 20 |
+| Build + test + PR | 21 |

--- a/docs/superpowers/specs/2026-05-13-ticket-attendee-contact-import-design.md
+++ b/docs/superpowers/specs/2026-05-13-ticket-attendee-contact-import-design.md
@@ -1,0 +1,401 @@
+# Ticket Attendee Contact Import — Design
+
+**Status:** Draft
+**Date:** 2026-05-13
+**Section:** Tickets
+**Issue:** TBD (open after spec approval)
+
+## Goal
+
+When a person buys a ticket whose attendee email doesn't match an existing Humans user, **create a no-profile Humans user** for them (mirroring how the Mailer import provisions users from MailerLite subscribers). This unlocks two downstream wins:
+
+1. Every paying attendee becomes addressable in Humans — they show up under matched-user reports, the dashboard's "Volunteer Ticket Coverage" denominator stays honest, and the existing `EventParticipation(Status = Ticketed | Attended, Source = TicketSync)` derivation automatically marks them as having a valid ticket for the active year.
+2. We can later export MailerLite segments like *"People with tickets, but no shifts"* — currently impossible because unmatched attendees have no `UserId` to feed into segment queries.
+
+## Non-Goals
+
+- **Buyer-only matches.** The Tickets section invariant is explicit: *"buyer-only matches do not count — purchasing tickets for others does not give the buyer ticket coverage."* This import only creates users from **attendees**, never from `TicketOrder.BuyerEmail`.
+- **A new flag on User/Profile** to record "has a ticket". `EventParticipation` already represents this; no new state.
+- **Automatic invocation from inside `TicketSyncService`.** Phase 1 is a manually-triggered admin job. Phase 2 (later, when trust is established) integrates with the sync orchestrator.
+- **Inviting/emailing the new user.** Account is created cold; the user can sign in later via the standard sign-in flow against their (now verified) email and complete their profile.
+
+## What Already Exists (and Why This Is Small)
+
+| Primitive | Location | What it does |
+|---|---|---|
+| `IAccountProvisioningService.FindOrCreateUserByEmailAsync(email, displayName, ContactSource, ct)` | `Humans.Application.Services.Users` | Idempotent: looks up email across all `UserEmail` rows; if no match, creates `User` + verified `UserEmail` (via `AddProvisionedEmailAsync`, `IsVerified = true`) + Stub `Profile`. Audit row `ContactCreated`. |
+| `ContactSource.TicketTailor = 2` | `Humans.Domain.Enums.ContactSource` | Already in the enum; currently unused. |
+| `IUserEmailService.GetDistinctVerifiedUserIdsAsync(email, ct)` | `Humans.Application.Services.Profile` | Returns distinct user-ids that have a **verified** row for this address (case-insensitive normalized, including gmail/googlemail collapse). |
+| `IUserEmailService.FindAnyEmailRowByAddressAsync(email, ct)` | same | Returns `(UserId, EmailId)` for any matching row (verified or unverified) — used to identify the specific unverified row to delete. |
+| `IUserEmailService.DeleteEmailAsync(userId, emailId, ct)` | same | Service-level delete that preserves the last *verified* row; unverified rows are deletable without guard. |
+| `IUserService.SetParticipationFromTicketSyncAsync(userId, year, status)` | `Humans.Application.Services.Users` | Writes `EventParticipation(Source = TicketSync, Status = Ticketed | Attended)`. |
+| `IUserService.GetActiveYearAsync()` via `IShiftManagementService.GetActiveAsync()` | Shifts section | Active event/year used by `EventParticipation` derivation. |
+| `ITicketRepository.UpsertAttendeesAsync(IReadOnlyList<TicketAttendee>, ct)` | `Humans.Infrastructure.Repositories.Tickets` | Bulk upsert keyed by `VendorTicketId`. **Existing** write path used by `TicketSyncService`. No new repo method needed. |
+
+The import service is a thin orchestrator that wires these primitives together. No new entities, no new tables, no new migration.
+
+## Decision Matrix
+
+For each unmatched attendee (defined as: `MatchedUserId is null`, `Status in (Valid, CheckedIn)`, `VendorEventId == active event id`), the plan layer assigns one of six decisions:
+
+| Decision | Trigger | Apply behavior |
+|---|---|---|
+| `AttachVerified` | `GetDistinctVerifiedUserIdsAsync(email).Count == 1` | Set `attendee.MatchedUserId = userId`. No user creation. |
+| `AmbiguousMultipleVerified` | `GetDistinctVerifiedUserIdsAsync(email).Count > 1` | Skip. `LogError` (data-integrity violation; same rule as the sync). |
+| `DeleteUnverifiedThenCreate` | No verified match; `FindAnyEmailRowByAddressAsync` returns an unverified row | Delete the unverified row via `DeleteEmailAsync`, then `FindOrCreateUserByEmailAsync(email, attendee-name, ContactSource.TicketTailor)`. Creates new user with **verified** `UserEmail` row. Set `attendee.MatchedUserId = newUser.Id`. |
+| `CreateNewUser` | No UserEmail row at all matches | `FindOrCreateUserByEmailAsync(email, attendee-name, ContactSource.TicketTailor)`. Creates new user with verified `UserEmail` row. Set `attendee.MatchedUserId = newUser.Id`. |
+| `SkipNoEmail` | `AttendeeEmail is null` | — |
+| `SkipVoided` | `Status == Void` | — (these are excluded from the input set, but the decision exists for explicit visibility) |
+
+### Squatter protection
+
+The `DeleteUnverifiedThenCreate` decision is the load-bearing protection against email squatting. Without it, a hostile actor could create an account, add `victim@example.com` as an **unverified** `UserEmail` row, wait for the real victim to buy a ticket, and inherit their ticket match. By deleting the unverified row first and provisioning a fresh user, the new account ends up with a **verified** `UserEmail` (`AddProvisionedEmailAsync` sets `IsVerified = true`) owned by the ticket purchaser.
+
+Side effect: if the squatter's only `UserEmail` was the deleted unverified row, the squatter user ends up with zero `UserEmail` rows. `DeleteEmailAsync` only protects against deleting the last *verified* row. This is the existing Mailer import behavior; accepted as-is.
+
+## Display Name
+
+`FindOrCreateUserByEmailAsync` accepts a `displayName` parameter and falls back to the email-prefix if it's null/empty. For ticket-derived users, pass the attendee's full name in priority order:
+
+1. `attendee.LegalName` if non-empty.
+2. Otherwise `$"{attendee.FirstName} {attendee.LastName}".Trim()` if either is non-empty.
+3. Otherwise null (provisioning service falls back to email-prefix).
+
+This means a fresh user shows up in the admin as e.g. *"Jane Doe"* instead of *"jane.doe1234"*. The user can change it themselves after first sign-in.
+
+## Service Surface
+
+New Application service `IAttendeeContactImportService` in `Humans.Application.Interfaces.Tickets`:
+
+```csharp
+public interface IAttendeeContactImportService : IApplicationService
+{
+    Task<AttendeeImportPlan> BuildPlanAsync(CancellationToken ct = default);
+    Task<AttendeeImportResult> ApplyAsync(
+        AttendeeImportPlan plan,
+        IReadOnlySet<Guid> selectedAttendeeIds,
+        CancellationToken ct = default);
+}
+```
+
+DTOs in `Humans.Application.Interfaces.Tickets.Dtos`:
+
+```csharp
+public sealed record AttendeeImportPlan(
+    IReadOnlyList<AttendeeImportDecision> Decisions,
+    int TotalUnmatched);
+
+public sealed record AttendeeImportDecision(
+    Guid AttendeeId,
+    string Email,
+    string? AttendeeName,
+    string VendorTicketId,
+    AttendeeImportOutcome Outcome,
+    Guid? TargetUserId,                 // populated for AttachVerified
+    Guid? UnverifiedEmailIdToDelete,    // populated for DeleteUnverifiedThenCreate
+    Guid? UnverifiedRowUserId,          // owning userId of that unverified row
+    IReadOnlyList<Guid>? AmbiguousUserIds); // populated for AmbiguousMultipleVerified
+
+public enum AttendeeImportOutcome
+{
+    AttachVerified,
+    AmbiguousMultipleVerified,
+    DeleteUnverifiedThenCreate,
+    CreateNewUser,
+    SkipNoEmail,
+    SkipVoided,
+}
+
+public sealed record AttendeeImportResult(
+    int TotalAttempted,
+    int UsersCreated,
+    int AttachedToExistingVerified,
+    int UnverifiedRowsDeletedAndUserCreated,
+    int AmbiguousSkipped,
+    int NoEmailSkipped,
+    int VanishedBetweenPlanAndApply,    // attendee no longer unmatched (e.g. fresh sync ran in between)
+    int Errors,
+    Duration Elapsed);
+```
+
+Implementation `AttendeeContactImportService` lives in `Humans.Application.Services.Tickets`. Dependencies:
+
+- `ITicketRepository` (read unmatched attendees, bulk upsert after match)
+- `IUserEmailService` (verified/any-row lookups, unverified-row delete)
+- `IAccountProvisioningService` (find-or-create user)
+- `IUserService` (post-apply `SetParticipationFromTicketSyncAsync`)
+- `IShiftManagementService` (active year for participation derivation)
+- `IAuditLogService` (single summary audit row at end)
+- `IClock`, `ILogger<AttendeeContactImportService>`
+
+No `DbContext`, no `IMemoryCache` — invalidation after the bulk upsert is handled by calling `ITicketQueryService.InvalidateAfterContactImport()` (a new method on the existing service, mirroring the established touch-and-clean pattern: *"controllers, view components, or other domain services do not touch `IMemoryCache` directly"*).
+
+### `BuildPlanAsync` algorithm
+
+1. Resolve active `VendorEventId` via `ITicketRepository.GetSyncStateAsync()`.
+2. `var unmatched = await _ticketRepository.GetUnmatchedActiveAttendeesAsync(eventId, ct);` — new narrow read on the repo: attendees where `MatchedUserId is null`, `Status in (Valid, CheckedIn)`, `VendorEventId = active`. Returns `IReadOnlyList<TicketAttendee>` (entities, not a projection — we need the full row to upsert later).
+3. For each attendee:
+   - If `AttendeeEmail` is null → `SkipNoEmail`.
+   - Else call `GetDistinctVerifiedUserIdsAsync(email)`:
+     - `Count > 1` → `AmbiguousMultipleVerified` (record the user-id list).
+     - `Count == 1` → `AttachVerified` (resolve through tombstone follow — see below — and record the live target user id).
+     - `Count == 0` → call `FindAnyEmailRowByAddressAsync(email)`:
+       - Returns an unverified row → `DeleteUnverifiedThenCreate` (record `UserId` and `EmailId`).
+       - Returns null → `CreateNewUser`.
+
+**Tombstone follow** for `AttachVerified`: copy `MailerImportService.ResolveTombstoneAsync` — walk `User.MergedToUserId` to the live target. If a cycle is detected (defensive — shouldn't happen), stop at the current node.
+
+### `ApplyAsync` algorithm
+
+Mirrors `MailerImportService.ApplyAsync` shape (stateless: re-query unmatched attendees at apply time so plan/apply are independent):
+
+```
+start = clock.Now
+var freshUnmatched = await repo.GetUnmatchedActiveAttendeesAsync(eventId, ct);
+var freshById = freshUnmatched.ToDictionary(a => a.Id);
+
+var toUpsert = new List<TicketAttendee>();
+var newlyMatchedUserIds = new HashSet<Guid>();
+
+foreach (var decision in plan.Decisions where selectedAttendeeIds.Contains(d.AttendeeId))
+{
+    if (!freshById.TryGetValue(decision.AttendeeId, out var attendee))
+    {
+        vanishedBetweenPlanAndApply++;
+        continue;
+    }
+    try
+    {
+        switch (decision.Outcome)
+        {
+            case SkipNoEmail:
+            case SkipVoided:
+            case AmbiguousMultipleVerified:
+                break;
+
+            case AttachVerified:
+                attendee.MatchedUserId = decision.TargetUserId!.Value;
+                toUpsert.Add(attendee);
+                newlyMatchedUserIds.Add(attendee.MatchedUserId.Value);
+                attachedToExistingVerified++;
+                break;
+
+            case DeleteUnverifiedThenCreate:
+                if (decision.UnverifiedRowUserId is Guid uid &&
+                    decision.UnverifiedEmailIdToDelete is Guid eid)
+                    await userEmails.DeleteEmailAsync(uid, eid, ct);
+                var (newUser, created) = await provisioning.FindOrCreateUserByEmailAsync(
+                    decision.Email, decision.AttendeeName,
+                    ContactSource.TicketTailor, ct);
+                attendee.MatchedUserId = newUser.Id;
+                toUpsert.Add(attendee);
+                newlyMatchedUserIds.Add(newUser.Id);
+                if (created) usersCreated++;
+                unverifiedRowsDeletedAndUserCreated++;
+                break;
+
+            case CreateNewUser:
+                var (newUser2, created2) = await provisioning.FindOrCreateUserByEmailAsync(
+                    decision.Email, decision.AttendeeName,
+                    ContactSource.TicketTailor, ct);
+                attendee.MatchedUserId = newUser2.Id;
+                toUpsert.Add(attendee);
+                newlyMatchedUserIds.Add(newUser2.Id);
+                if (created2) usersCreated++;
+                break;
+        }
+    }
+    catch (Exception ex) when (ex is not OperationCanceledException)
+    {
+        errors++;
+        logger.LogError(ex, "Attendee contact import failed for {AttendeeId} ({Email})",
+            decision.AttendeeId, decision.Email);
+    }
+}
+
+if (toUpsert.Count > 0)
+{
+    await repo.UpsertAttendeesAsync(toUpsert, ct);
+}
+
+// EventParticipation derivation — write Ticketed for each newly-matched user
+// so coverage reflects immediately without waiting for the next sync.
+var activeYear = await shifts.GetActiveAsync(ct);
+if (activeYear is not null)
+{
+    foreach (var userId in newlyMatchedUserIds)
+    {
+        // Sync only writes Ticketed here; Attended is reserved for the
+        // sync's CheckedIn-aware reconciliation pass.
+        await users.SetParticipationFromTicketSyncAsync(
+            userId, activeYear.Year, ParticipationStatus.Ticketed, ct);
+    }
+}
+
+ticketQuery.InvalidateAfterContactImport();
+
+await audit.LogAsync(AuditAction.TicketContactsImported,
+    entityType: "Tickets", entityId: Guid.Empty,
+    description: result.FormatSummary(),
+    jobName: nameof(AttendeeContactImportService));
+```
+
+**New `AuditAction.TicketContactsImported`** value added to the existing `AuditAction` enum. Description follows Mailer's terse format: `"created=X, attached=Y, unverified-replaced=Z, ambiguous=A, no-email=B, errors=E, elapsed=Tms"`.
+
+### Why `Ticketed`, not `Attended`
+
+Only the sync's reconciliation pass knows which attendees are `CheckedIn`. This import job runs against `Valid` and `CheckedIn` attendees but writes `Ticketed` uniformly because:
+
+- For `Valid` attendees, `Ticketed` is correct.
+- For `CheckedIn` attendees, `Ticketed` is a temporary under-statement that the next ticket sync will upgrade to `Attended` via the existing reconciliation logic. Worst case: a few minutes of staleness on the participation status.
+
+This avoids duplicating the sync's "any `CheckedIn` → `Attended`, else any `Valid` → `Ticketed`" rule. Keep one source of truth for that derivation.
+
+## Routing
+
+| Route | Method | Auth Policy | Purpose |
+|---|---|---|---|
+| `/Tickets/Admin/Contacts` | GET | `TicketAdminOrAdmin` | Preview page — renders plan + per-row checkbox table |
+| `/Tickets/Admin/Contacts` | POST | `TicketAdminOrAdmin` | Apply with selected attendee ids |
+
+(Mailer uses `/Mailer/Admin`. Tickets already namespaces admin actions under `/Tickets/Admin/Transfers`, so `/Tickets/Admin/Contacts` fits.)
+
+`TicketAdminOrAdmin` policy already exists. Same role gating as ticket sync.
+
+Discoverability: add a "Import Attendee Contacts" action link from the `/Tickets` dashboard sidebar (same area as the "Sync" / "Full Re-sync" actions).
+
+## Preview UI
+
+GET `/Tickets/Admin/Contacts` renders:
+
+1. **Summary row** at the top: count badges per decision category (`CreateNewUser: 412`, `AttachVerified: 87`, `DeleteUnverifiedThenCreate: 12`, `AmbiguousMultipleVerified: 2 ⚠️`, `SkipNoEmail: 3`).
+2. **Decision table** below: one row per attendee with columns
+   - Checkbox (default unchecked)
+   - Email
+   - Attendee name (resolved per Display Name rules)
+   - Decision (color-coded)
+   - Target user (display name + link), shown for `AttachVerified` / `DeleteUnverifiedThenCreate` to make squatter cases visible
+   - VendorTicketId (for cross-reference)
+3. **Controls**:
+   - `Select all` button (top of table, checks every box)
+   - `Select first 1` button — convenience for the test-one-first workflow
+   - `Apply Selected` submit button (disabled when 0 rows selected, shows live count)
+
+Sorting: rows ordered by decision (Ambiguous first so they're impossible to miss, then DeleteUnverifiedThenCreate, then CreateNewUser, then AttachVerified, then Skips). Within each group, alphabetic by email.
+
+Paging: same pattern as Mailer's preview (server-side paged at 100/page). Selections must survive paging — store as hidden inputs in the form across pages, or use a sticky session-scoped selection. **Implementation decision deferred to writing-plans:** Mailer's existing approach is the reference; copy whatever it does.
+
+Workflow for "test with one first":
+
+1. Admin loads `/Tickets/Admin/Contacts` → preview renders.
+2. Admin clicks `Select first 1` → first row checked.
+3. Admin clicks `Apply Selected` → POST runs `ApplyAsync(plan, { selectedId })`.
+4. Result page renders summary (`1 user created`) with a link to the new user's admin profile and the now-matched attendee.
+5. Admin returns to `/Tickets/Admin/Contacts` → preview re-runs (stateless), the just-processed attendee is no longer in the list.
+6. Admin clicks `Select all` → all remaining rows checked → `Apply Selected`.
+
+## Phase 2 (Not in This Spec, Documented for Continuity)
+
+Once Peter trusts the import logic, the service is wired into `TicketSyncService` as a final pass:
+
+```
+// Inside RunSyncAsync, after UpsertAttendeesAsync and ComputeVatForOrdersAsync,
+// before SyncEventParticipationsAsync:
+await _attendeeContactImport.ApplyAsync(
+    plan: await _attendeeContactImport.BuildPlanAsync(ct),
+    selectedAttendeeIds: <all-decision-attendee-ids>,
+    ct);
+```
+
+This deletes the admin button (or leaves it as a manual catch-up tool). No service surface change between Phase 1 and Phase 2 — just a new caller. That's the test that the boundaries are right.
+
+## Tests
+
+### Unit tests (`tests/Humans.Application.Tests/Services/Tickets/`)
+
+- `AttendeeContactImportServicePlanTests` — classifier correctness:
+  - `Plan_AssignsAttachVerified_WhenSingleVerifiedMatchExists`
+  - `Plan_AssignsAttachVerified_FollowsMergedToUserIdTombstone`
+  - `Plan_AssignsAmbiguousMultipleVerified_WhenTwoUsersBothVerified`
+  - `Plan_AssignsDeleteUnverifiedThenCreate_WhenOnlyUnverifiedRowExists`
+  - `Plan_AssignsCreateNewUser_WhenNoUserEmailRowExists`
+  - `Plan_AssignsSkipNoEmail_WhenAttendeeEmailIsNull`
+  - `Plan_ExcludesVoidedAttendees`
+  - `Plan_ExcludesAlreadyMatchedAttendees`
+  - `Plan_ExcludesAttendeesFromInactiveEvents`
+- `AttendeeContactImportServiceApplyTests` — apply correctness, selection respect, idempotency:
+  - `Apply_OnlyProcessesSelectedAttendees`
+  - `Apply_AttachVerified_SetsMatchedUserIdAndDoesNotCreate`
+  - `Apply_DeleteUnverifiedThenCreate_DeletesRowAndCreatesUserWithVerifiedEmail`
+  - `Apply_CreateNewUser_CallsProvisioningWithAttendeeName`
+  - `Apply_CreateNewUser_PassesContactSourceTicketTailor`
+  - `Apply_WritesEventParticipationTicketedForEachNewlyMatchedUser`
+  - `Apply_VanishedAttendees_AreCountedAndSkipped`
+  - `Apply_PartialFailures_DontAbortBatch`
+  - `Apply_AuditRowWrittenOnce_WithSummary`
+- `AttendeeContactImportServiceSquatterTests` — focused on the security property:
+  - `Squatter_UnverifiedRowDeleted_BeforeNewUserCreated`
+  - `Squatter_NewUserGetsVerifiedRow_NotAttachedToSquatter`
+
+### Architecture tests (`tests/Humans.Application.Tests/Architecture/`)
+
+- Extend `TicketSyncArchitectureTests` (or new `TicketImportArchitectureTests`):
+  - `AttendeeContactImportService.Namespace == Humans.Application.Services.Tickets`
+  - Implementation does not reference `Microsoft.EntityFrameworkCore`
+  - Implementation does not reference `HumansDbContext`
+  - Implementation uses `IAccountProvisioningService`, `IUserEmailService`, `IUserService`, `IShiftManagementService`, `ITicketRepository`, `ITicketQueryService`, `IAuditLogService` (sentinel: depends on the cross-section service abstractions, not their implementations)
+
+### Web tests (`tests/Humans.Web.Tests/Controllers/Tickets/`)
+
+- `TicketsAdminControllerContactsTests`:
+  - `Get_ReturnsPreviewWithPlanCounts`
+  - `Get_RequiresTicketAdminOrAdmin`
+  - `Post_AppliesOnlySelectedRows`
+  - `Post_EmptySelection_ReturnsValidationError`
+
+## Section Doc Updates
+
+Update `docs/sections/tickets.md`:
+
+- **Concepts:** add a paragraph defining the attendee contact import as a separate manually-triggered job (and note Phase 2 sync integration).
+- **Routing table:** add `/Tickets/Admin/Contacts` GET + POST rows.
+- **Triggers:** note that on import apply, `MatchedUserId` is set for the selected attendees, `EventParticipation(Ticketed, TicketSync)` rows are written for newly-matched users, ticket caches are invalidated via `ITicketQueryService.InvalidateAfterContactImport`, and audit row `TicketContactsImported` is written.
+- **Cross-Section Dependencies:** add `IAccountProvisioningService` (Users section) to the Tickets section's dependency list.
+- **Actors & Roles:** extend the `TicketAdmin, Admin` row to mention "import attendee contacts".
+- **Negative Access Rules:** add a Board exclusion for the contacts import (same gating as the sync).
+
+Update freshness triggers at the top of `tickets.md` to include `src/Humans.Application/Services/Tickets/AttendeeContactImportService.cs` and its interface.
+
+## Audit + Logging
+
+- `AuditAction.TicketContactsImported` — single summary row at end of apply, mirroring Mailer's `MailerLiteReconciliationCompleted`.
+- Per-attendee `_logger.LogError` on failures (no per-attendee audit rows — would flood the audit log).
+- `_logger.LogInformation` with summary at end of apply (parity with Mailer).
+
+No per-user `ContactCreated` audit rows in this service — `AccountProvisioningService.FindOrCreateUserByEmailAsync` already writes one per user it creates. No need to duplicate.
+
+## Open Questions Resolved During Brainstorming
+
+| Question | Resolution |
+|---|---|
+| Display name for new users? | Pass attendee full name (`LegalName` → `FirstName + LastName` → null fallback). |
+| Preview screen? | Yes — required. Mirror Mailer's plan/apply split. |
+| Match against unverified UserEmails like Mailer does naively? | **No.** Match Mailer's full pattern: verified attaches, unverified deletes-then-creates (squatter protection). |
+| New narrow repo method for setting `MatchedUserId`? | **No.** Reuse existing `UpsertAttendeesAsync` — same primitive the sync uses. |
+| Buyer email creates a user too? | **No.** Attendees only. Buyer-only matches don't grant ticket coverage per section invariant. |
+| Plan/apply preview shows row detail or just counts? | Full row table — needed to catch unintended attach targets. |
+| Single-attendee test capability? | Per-row checkboxes + `Select first 1` button. |
+
+## Out-of-Scope (Explicit)
+
+- Reverse direction (push Humans users to the vendor) — not needed; we read from vendor only.
+- Automatic re-attempt of failed imports — failures show up in the next preview run and the admin retries manually.
+- Per-row audit trail — flooding the audit log isn't worth the granularity. The `ContactCreated` rows written by provisioning + the per-attendee error logs are enough.
+- Resolving `AmbiguousMultipleVerified` cases — these are data-integrity errors that require manual cleanup (merge accounts). The import correctly skips them; resolution lives in `/Admin/Users` merge tooling.
+- Removing the matched-attendee from MailerLite when the user changes their primary email — out of scope; that's a `MailerLite ↔ Humans` reconciliation concern, not a ticket-import concern.
+
+## Risks
+
+1. **Bulk user creation kicks off downstream invariants.** Every new user triggers Stub Profile creation and a `ContactCreated` audit row. For 1000 new attendees this is 1000 audit rows + 1000 profile rows in a single request. Mitigation: the per-row checkbox workflow is exactly the throttle — admin starts with one, then scales up. If we ever batch all 1000 in one POST and it times out, we add request-streaming or a Hangfire background job, but Phase 1 doesn't pre-optimize for it.
+2. **Vanished-attendee race.** If a ticket sync runs between plan-build and apply, an attendee in the plan may already be matched. Handled via re-query at apply time; outcome counted as `VanishedBetweenPlanAndApply`.
+3. **Display name from vendor may be empty for some attendees.** Falls back to email-prefix per provisioning service's existing logic. Acceptable.

--- a/src/Humans.Application/Interfaces/Repositories/ITicketRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/ITicketRepository.cs
@@ -170,6 +170,21 @@ public interface ITicketRepository : IRepository
     /// </summary>
     Task UpsertAttendeesAsync(IReadOnlyList<TicketAttendee> attendees, CancellationToken ct = default);
 
+    /// <summary>
+    /// Returns every <see cref="TicketAttendee"/> for the given vendor event
+    /// that is currently unmatched (<c>MatchedUserId is null</c>) and whose
+    /// <see cref="Humans.Domain.Enums.TicketAttendeeStatus"/> is
+    /// <c>Valid</c> or <c>CheckedIn</c>, AND whose
+    /// <see cref="TicketAttendee.AttendeeEmail"/> is non-empty.
+    ///
+    /// Used by the attendee contact import to identify candidates for user
+    /// provisioning. Returns the full entity so the caller can mutate
+    /// <c>MatchedUserId</c> and pass the list back to
+    /// <see cref="UpsertAttendeesAsync"/>.
+    /// </summary>
+    Task<IReadOnlyList<TicketAttendee>> GetUnmatchedActiveAttendeesAsync(
+        string vendorEventId, CancellationToken ct = default);
+
     /// <summary>Insert or update a single TicketAttendee row. Used when the Tickets section creates an attendee outside the sync loop (e.g. on approved transfer reissue).</summary>
     Task UpsertAttendeeAsync(TicketAttendee attendee, CancellationToken ct = default);
 

--- a/src/Humans.Application/Interfaces/Tickets/Dtos/AttendeeImportDecision.cs
+++ b/src/Humans.Application/Interfaces/Tickets/Dtos/AttendeeImportDecision.cs
@@ -1,0 +1,41 @@
+namespace Humans.Application.Interfaces.Tickets.Dtos;
+
+/// <summary>
+/// One per attendee in <see cref="AttendeeImportPlan"/>. Carries the
+/// classification plus the data the apply step needs (target user id for
+/// attach, unverified row id for delete-then-create, etc).
+/// </summary>
+/// <param name="AttendeeId">PK of the TicketAttendee row.</param>
+/// <param name="Email">Attendee email (case preserved from vendor).</param>
+/// <param name="AttendeeName">
+/// Resolved display name: LegalName → FirstName+LastName → null fallback.
+/// </param>
+/// <param name="VendorTicketId">For cross-reference with the vendor dashboard.</param>
+/// <param name="Outcome">Classification result.</param>
+/// <param name="TargetUserId">
+/// For <see cref="AttendeeImportOutcome.AttachVerified"/>: the live user id
+/// (post tombstone follow). Null otherwise.
+/// </param>
+/// <param name="UnverifiedEmailIdToDelete">
+/// For <see cref="AttendeeImportOutcome.DeleteUnverifiedThenCreate"/>: the
+/// UserEmail row id to delete before provisioning. Null otherwise.
+/// </param>
+/// <param name="UnverifiedRowUserId">
+/// For <see cref="AttendeeImportOutcome.DeleteUnverifiedThenCreate"/>: the
+/// owning user id of the unverified row (DeleteEmailAsync requires both).
+/// Null otherwise.
+/// </param>
+/// <param name="AmbiguousUserIds">
+/// For <see cref="AttendeeImportOutcome.AmbiguousMultipleVerified"/>: the
+/// conflicting user ids, for admin visibility. Null otherwise.
+/// </param>
+public sealed record AttendeeImportDecision(
+    Guid AttendeeId,
+    string? Email,
+    string? AttendeeName,
+    string VendorTicketId,
+    AttendeeImportOutcome Outcome,
+    Guid? TargetUserId,
+    Guid? UnverifiedEmailIdToDelete,
+    Guid? UnverifiedRowUserId,
+    IReadOnlyList<Guid>? AmbiguousUserIds);

--- a/src/Humans.Application/Interfaces/Tickets/Dtos/AttendeeImportOutcome.cs
+++ b/src/Humans.Application/Interfaces/Tickets/Dtos/AttendeeImportOutcome.cs
@@ -1,0 +1,29 @@
+namespace Humans.Application.Interfaces.Tickets.Dtos;
+
+/// <summary>
+/// Per-attendee classification produced by
+/// <see cref="Humans.Application.Interfaces.Tickets.IAttendeeContactImportService.BuildPlanAsync"/>.
+/// Mirrors the Mailer import's outcome shape — verified matches attach,
+/// unverified matches are deleted-then-created (squatter protection),
+/// no match creates a new user with a verified UserEmail row.
+/// </summary>
+public enum AttendeeImportOutcome
+{
+    /// <summary>Exactly one verified UserEmail matches — set MatchedUserId, no creation.</summary>
+    AttachVerified = 0,
+
+    /// <summary>&gt;1 verified users own this email — skip with LogError (data-integrity).</summary>
+    AmbiguousMultipleVerified = 1,
+
+    /// <summary>Only an unverified UserEmail row matches — delete it, then create new user with verified row.</summary>
+    DeleteUnverifiedThenCreate = 2,
+
+    /// <summary>No UserEmail row matches — create a brand-new user with verified row.</summary>
+    CreateNewUser = 3,
+
+    /// <summary>Attendee has no email — skip.</summary>
+    SkipNoEmail = 4,
+
+    /// <summary>Attendee is Void — skip (typically excluded from plan input).</summary>
+    SkipVoided = 5,
+}

--- a/src/Humans.Application/Interfaces/Tickets/Dtos/AttendeeImportPlan.cs
+++ b/src/Humans.Application/Interfaces/Tickets/Dtos/AttendeeImportPlan.cs
@@ -1,0 +1,26 @@
+namespace Humans.Application.Interfaces.Tickets.Dtos;
+
+/// <summary>
+/// Output of <see cref="Humans.Application.Interfaces.Tickets.IAttendeeContactImportService.BuildPlanAsync"/>.
+/// Stateless — the apply step re-queries to defend against concurrent sync mutation.
+/// </summary>
+public sealed record AttendeeImportPlan(
+    IReadOnlyList<AttendeeImportDecision> Decisions,
+    int TotalUnmatched)
+{
+    public AttendeeImportPlanCounts Counts => new(
+        AttachVerified: Decisions.Count(d => d.Outcome == AttendeeImportOutcome.AttachVerified),
+        AmbiguousMultipleVerified: Decisions.Count(d => d.Outcome == AttendeeImportOutcome.AmbiguousMultipleVerified),
+        DeleteUnverifiedThenCreate: Decisions.Count(d => d.Outcome == AttendeeImportOutcome.DeleteUnverifiedThenCreate),
+        CreateNewUser: Decisions.Count(d => d.Outcome == AttendeeImportOutcome.CreateNewUser),
+        SkipNoEmail: Decisions.Count(d => d.Outcome == AttendeeImportOutcome.SkipNoEmail),
+        SkipVoided: Decisions.Count(d => d.Outcome == AttendeeImportOutcome.SkipVoided));
+}
+
+public sealed record AttendeeImportPlanCounts(
+    int AttachVerified,
+    int AmbiguousMultipleVerified,
+    int DeleteUnverifiedThenCreate,
+    int CreateNewUser,
+    int SkipNoEmail,
+    int SkipVoided);

--- a/src/Humans.Application/Interfaces/Tickets/Dtos/AttendeeImportResult.cs
+++ b/src/Humans.Application/Interfaces/Tickets/Dtos/AttendeeImportResult.cs
@@ -1,0 +1,27 @@
+using NodaTime;
+
+namespace Humans.Application.Interfaces.Tickets.Dtos;
+
+/// <summary>
+/// Outcome counters from
+/// <see cref="Humans.Application.Interfaces.Tickets.IAttendeeContactImportService.ApplyAsync"/>.
+/// Format mirrors the Mailer import summary so admin banner / audit row
+/// read consistently across import jobs.
+/// </summary>
+public sealed record AttendeeImportResult(
+    int TotalAttempted,
+    int UsersCreated,
+    int AttachedToExistingVerified,
+    int UnverifiedRowsDeletedAndUserCreated,
+    int AmbiguousSkipped,
+    int NoEmailSkipped,
+    int VanishedBetweenPlanAndApply,
+    int Errors,
+    Duration Elapsed)
+{
+    public string FormatSummary() =>
+        $"attempted={TotalAttempted}, created={UsersCreated}, attached={AttachedToExistingVerified}, " +
+        $"unverified-replaced={UnverifiedRowsDeletedAndUserCreated}, ambiguous={AmbiguousSkipped}, " +
+        $"no-email={NoEmailSkipped}, vanished={VanishedBetweenPlanAndApply}, errors={Errors}, " +
+        $"elapsed={(long)Elapsed.TotalMilliseconds}ms";
+}

--- a/src/Humans.Application/Interfaces/Tickets/IAttendeeContactImportService.cs
+++ b/src/Humans.Application/Interfaces/Tickets/IAttendeeContactImportService.cs
@@ -20,5 +20,6 @@ public interface IAttendeeContactImportService : IApplicationService
     Task<AttendeeImportResult> ApplyAsync(
         AttendeeImportPlan plan,
         IReadOnlySet<Guid> selectedAttendeeIds,
+        Guid actorUserId,
         CancellationToken ct = default);
 }

--- a/src/Humans.Application/Interfaces/Tickets/IAttendeeContactImportService.cs
+++ b/src/Humans.Application/Interfaces/Tickets/IAttendeeContactImportService.cs
@@ -1,0 +1,24 @@
+using Humans.Application.Interfaces;
+using Humans.Application.Interfaces.Tickets.Dtos;
+
+namespace Humans.Application.Interfaces.Tickets;
+
+/// <summary>
+/// Plan-and-apply import that creates Humans users for ticket attendees
+/// whose email doesn't already resolve to an existing user. Mirrors the
+/// Mailer import shape: <see cref="BuildPlanAsync"/> classifies, the admin
+/// previews + selects, <see cref="ApplyAsync"/> executes only selected rows.
+///
+/// Stateless: <see cref="ApplyAsync"/> re-queries unmatched attendees so
+/// plan and apply are independent (a sync in between is tolerated and
+/// counted as <c>VanishedBetweenPlanAndApply</c>).
+/// </summary>
+public interface IAttendeeContactImportService : IApplicationService
+{
+    Task<AttendeeImportPlan> BuildPlanAsync(CancellationToken ct = default);
+
+    Task<AttendeeImportResult> ApplyAsync(
+        AttendeeImportPlan plan,
+        IReadOnlySet<Guid> selectedAttendeeIds,
+        CancellationToken ct = default);
+}

--- a/src/Humans.Application/Interfaces/Tickets/ITicketQueryService.cs
+++ b/src/Humans.Application/Interfaces/Tickets/ITicketQueryService.cs
@@ -11,7 +11,7 @@ namespace Humans.Application.Interfaces.Tickets;
 /// counts matched tickets, and computes aggregate dashboard statistics.
 /// All matching logic (MatchedUserId, email fallback, case-insensitive) lives here.
 /// </summary>
-[SurfaceBudget(27)]
+[SurfaceBudget(28)]
 public interface ITicketQueryService : IApplicationService
 {
     /// <summary>
@@ -197,6 +197,15 @@ public interface ITicketQueryService : IApplicationService
     /// when the Receiver did not gain a local row (vendor reissue half-failed).
     /// </summary>
     void InvalidateAfterTransfer(Guid senderUserId, Guid? receiverUserId);
+
+    /// <summary>
+    /// Invalidates ticket-related caches after the attendee contact import
+    /// has applied new matches. Drops <c>UserIdsWithTickets</c>,
+    /// <c>ValidAttendeeEmails</c>, the per-event <c>TicketEventSummary</c>,
+    /// and <c>TicketDashboardStats</c>. Per-user <c>UserTicketCount:{userId}</c>
+    /// entries expire naturally via 5-minute TTL — same policy as the sync.
+    /// </summary>
+    void InvalidateAfterContactImport();
 
     /// <summary>
     /// Snapshot of a user's ticket holdings: count of orders where they're the

--- a/src/Humans.Application/Services/Tickets/AttendeeContactImportService.cs
+++ b/src/Humans.Application/Services/Tickets/AttendeeContactImportService.cs
@@ -110,8 +110,25 @@ public sealed class AttendeeContactImportService : IAttendeeContactImportService
                 AmbiguousUserIds: null);
         }
 
-        // Remaining classifications filled in by Task 10.
-        throw new NotSupportedException("Unverified/no-match branches filled in by Task 10");
+        var existingRow = await _userEmails.FindAnyEmailRowByAddressAsync(a.AttendeeEmail, ct);
+        if (existingRow is var (uid, emailId) && existingRow is not null)
+        {
+            return new AttendeeImportDecision(
+                a.Id, a.AttendeeEmail, name, a.VendorTicketId,
+                AttendeeImportOutcome.DeleteUnverifiedThenCreate,
+                TargetUserId: null,
+                UnverifiedEmailIdToDelete: emailId,
+                UnverifiedRowUserId: uid,
+                AmbiguousUserIds: null);
+        }
+
+        return new AttendeeImportDecision(
+            a.Id, a.AttendeeEmail, name, a.VendorTicketId,
+            AttendeeImportOutcome.CreateNewUser,
+            TargetUserId: null,
+            UnverifiedEmailIdToDelete: null,
+            UnverifiedRowUserId: null,
+            AmbiguousUserIds: null);
     }
 
     private async Task<Guid> ResolveTombstoneAsync(Guid userId, CancellationToken ct)

--- a/src/Humans.Application/Services/Tickets/AttendeeContactImportService.cs
+++ b/src/Humans.Application/Services/Tickets/AttendeeContactImportService.cs
@@ -124,7 +124,7 @@ public sealed class AttendeeContactImportService : IAttendeeContactImportService
 
                     case AttendeeImportOutcome.AmbiguousMultipleVerified:
                         ambiguous++;
-                        _logger.LogError(
+                        _logger.LogWarning(
                             "Attendee {AttendeeId} email {Email} verified by multiple users {UserIds}",
                             d.AttendeeId, d.Email, d.AmbiguousUserIds);
                         break;

--- a/src/Humans.Application/Services/Tickets/AttendeeContactImportService.cs
+++ b/src/Humans.Application/Services/Tickets/AttendeeContactImportService.cs
@@ -70,23 +70,61 @@ public sealed class AttendeeContactImportService : IAttendeeContactImportService
         CancellationToken ct = default) =>
         throw new NotSupportedException("Filled in by Task 11");
 
-    private Task<AttendeeImportDecision> ClassifyAsync(TicketAttendee a, CancellationToken ct)
+    private async Task<AttendeeImportDecision> ClassifyAsync(TicketAttendee a, CancellationToken ct)
     {
         var name = ResolveDisplayName(a);
 
         if (string.IsNullOrWhiteSpace(a.AttendeeEmail))
         {
-            return Task.FromResult(new AttendeeImportDecision(
+            return new AttendeeImportDecision(
                 a.Id, a.AttendeeEmail, name, a.VendorTicketId,
                 AttendeeImportOutcome.SkipNoEmail,
                 TargetUserId: null,
                 UnverifiedEmailIdToDelete: null,
                 UnverifiedRowUserId: null,
-                AmbiguousUserIds: null));
+                AmbiguousUserIds: null);
         }
 
-        // Remaining classifications filled in by Tasks 9–10.
-        throw new NotSupportedException("Branches filled in by Tasks 9–10");
+        var verifiedUserIds = await _userEmails.GetDistinctVerifiedUserIdsAsync(a.AttendeeEmail, ct);
+
+        if (verifiedUserIds.Count > 1)
+        {
+            return new AttendeeImportDecision(
+                a.Id, a.AttendeeEmail, name, a.VendorTicketId,
+                AttendeeImportOutcome.AmbiguousMultipleVerified,
+                TargetUserId: null,
+                UnverifiedEmailIdToDelete: null,
+                UnverifiedRowUserId: null,
+                AmbiguousUserIds: verifiedUserIds);
+        }
+
+        if (verifiedUserIds.Count == 1)
+        {
+            var liveTarget = await ResolveTombstoneAsync(verifiedUserIds[0], ct);
+            return new AttendeeImportDecision(
+                a.Id, a.AttendeeEmail, name, a.VendorTicketId,
+                AttendeeImportOutcome.AttachVerified,
+                TargetUserId: liveTarget,
+                UnverifiedEmailIdToDelete: null,
+                UnverifiedRowUserId: null,
+                AmbiguousUserIds: null);
+        }
+
+        // Remaining classifications filled in by Task 10.
+        throw new NotSupportedException("Unverified/no-match branches filled in by Task 10");
+    }
+
+    private async Task<Guid> ResolveTombstoneAsync(Guid userId, CancellationToken ct)
+    {
+        var visited = new HashSet<Guid> { userId };
+        var current = userId;
+        while (true)
+        {
+            var user = await _users.GetByIdAsync(current, ct);
+            if (user?.MergedToUserId is not Guid next) return current;
+            if (!visited.Add(next)) return current;
+            current = next;
+        }
     }
 
     private static string? ResolveDisplayName(TicketAttendee a) =>

--- a/src/Humans.Application/Services/Tickets/AttendeeContactImportService.cs
+++ b/src/Humans.Application/Services/Tickets/AttendeeContactImportService.cs
@@ -93,7 +93,7 @@ public sealed class AttendeeContactImportService : IAttendeeContactImportService
             if (!freshById.TryGetValue(d.AttendeeId, out var attendee))
             {
                 vanished++;
-                _logger.LogInformation(
+                _logger.LogWarning(
                     "Attendee {AttendeeId} ({Email}) vanished between plan and apply",
                     d.AttendeeId, d.Email);
                 continue;
@@ -105,7 +105,7 @@ public sealed class AttendeeContactImportService : IAttendeeContactImportService
             if (!string.Equals(attendee.AttendeeEmail, d.Email, StringComparison.OrdinalIgnoreCase))
             {
                 vanished++;
-                _logger.LogInformation(
+                _logger.LogWarning(
                     "Attendee {AttendeeId} email drifted between plan ({PlanEmail}) and apply ({FreshEmail}); treating as vanished",
                     d.AttendeeId, d.Email, attendee.AttendeeEmail);
                 continue;

--- a/src/Humans.Application/Services/Tickets/AttendeeContactImportService.cs
+++ b/src/Humans.Application/Services/Tickets/AttendeeContactImportService.cs
@@ -181,6 +181,10 @@ public sealed class AttendeeContactImportService : IAttendeeContactImportService
             await _ticketRepository.UpsertAttendeesAsync(toUpsert, ct);
         }
 
+        // Evict before the participation loop — if SetParticipationFromTicketSyncAsync throws,
+        // the attendee mutation above must still invalidate ticket caches.
+        _ticketQuery.InvalidateAfterContactImport();
+
         var active = await _shifts.GetActiveAsync();
         if (active is not null && newlyMatchedUserIds.Count > 0)
         {
@@ -190,8 +194,6 @@ public sealed class AttendeeContactImportService : IAttendeeContactImportService
                     userId, active.Year, ParticipationStatus.Ticketed, ct);
             }
         }
-
-        _ticketQuery.InvalidateAfterContactImport();
 
         var elapsed = _clock.GetCurrentInstant() - start;
         var result = new AttendeeImportResult(

--- a/src/Humans.Application/Services/Tickets/AttendeeContactImportService.cs
+++ b/src/Humans.Application/Services/Tickets/AttendeeContactImportService.cs
@@ -67,6 +67,7 @@ public sealed class AttendeeContactImportService : IAttendeeContactImportService
     public async Task<AttendeeImportResult> ApplyAsync(
         AttendeeImportPlan plan,
         IReadOnlySet<Guid> selectedAttendeeIds,
+        Guid actorUserId,
         CancellationToken ct = default)
     {
         var start = _clock.GetCurrentInstant();
@@ -98,6 +99,18 @@ public sealed class AttendeeContactImportService : IAttendeeContactImportService
                 continue;
             }
 
+            // If the attendee's email changed between plan and apply, the plan's
+            // decision (TargetUserId / UnverifiedEmailIdToDelete / etc.) was computed
+            // against a stale email and may attach the wrong user. Treat as vanished.
+            if (!string.Equals(attendee.AttendeeEmail, d.Email, StringComparison.OrdinalIgnoreCase))
+            {
+                vanished++;
+                _logger.LogInformation(
+                    "Attendee {AttendeeId} email drifted between plan ({PlanEmail}) and apply ({FreshEmail}); treating as vanished",
+                    d.AttendeeId, d.Email, attendee.AttendeeEmail);
+                continue;
+            }
+
             try
             {
                 switch (d.Outcome)
@@ -117,41 +130,41 @@ public sealed class AttendeeContactImportService : IAttendeeContactImportService
                         break;
 
                     case AttendeeImportOutcome.AttachVerified:
-                    {
-                        attendee.MatchedUserId = d.TargetUserId!.Value;
-                        toUpsert.Add(attendee);
-                        newlyMatchedUserIds.Add(d.TargetUserId.Value);
-                        attached++;
-                        break;
-                    }
+                        {
+                            attendee.MatchedUserId = d.TargetUserId!.Value;
+                            toUpsert.Add(attendee);
+                            newlyMatchedUserIds.Add(d.TargetUserId.Value);
+                            attached++;
+                            break;
+                        }
 
                     case AttendeeImportOutcome.DeleteUnverifiedThenCreate:
-                    {
-                        if (d.UnverifiedRowUserId is Guid uid &&
-                            d.UnverifiedEmailIdToDelete is Guid eid)
                         {
-                            await _userEmails.DeleteEmailAsync(uid, eid, ct);
+                            if (d.UnverifiedRowUserId is Guid uid &&
+                                d.UnverifiedEmailIdToDelete is Guid eid)
+                            {
+                                await _userEmails.DeleteEmailAsync(uid, eid, ct);
+                            }
+                            var (newUser, wasCreated) = await _provisioning.FindOrCreateUserByEmailAsync(
+                                d.Email!, d.AttendeeName, ContactSource.TicketTailor, ct);
+                            attendee.MatchedUserId = newUser.Id;
+                            toUpsert.Add(attendee);
+                            newlyMatchedUserIds.Add(newUser.Id);
+                            if (wasCreated) created++;
+                            replaced++;
+                            break;
                         }
-                        var (newUser, wasCreated) = await _provisioning.FindOrCreateUserByEmailAsync(
-                            d.Email!, d.AttendeeName, ContactSource.TicketTailor, ct);
-                        attendee.MatchedUserId = newUser.Id;
-                        toUpsert.Add(attendee);
-                        newlyMatchedUserIds.Add(newUser.Id);
-                        if (wasCreated) created++;
-                        replaced++;
-                        break;
-                    }
 
                     case AttendeeImportOutcome.CreateNewUser:
-                    {
-                        var (newUser, wasCreated) = await _provisioning.FindOrCreateUserByEmailAsync(
-                            d.Email!, d.AttendeeName, ContactSource.TicketTailor, ct);
-                        attendee.MatchedUserId = newUser.Id;
-                        toUpsert.Add(attendee);
-                        newlyMatchedUserIds.Add(newUser.Id);
-                        if (wasCreated) created++;
-                        break;
-                    }
+                        {
+                            var (newUser, wasCreated) = await _provisioning.FindOrCreateUserByEmailAsync(
+                                d.Email!, d.AttendeeName, ContactSource.TicketTailor, ct);
+                            attendee.MatchedUserId = newUser.Id;
+                            toUpsert.Add(attendee);
+                            newlyMatchedUserIds.Add(newUser.Id);
+                            if (wasCreated) created++;
+                            break;
+                        }
                 }
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
@@ -194,9 +207,9 @@ public sealed class AttendeeContactImportService : IAttendeeContactImportService
 
         await _audit.LogAsync(
             AuditAction.TicketContactsImported,
-            entityType: "Tickets", entityId: Guid.Empty,
+            "Tickets", Guid.Empty,
             description: result.FormatSummary(),
-            jobName: nameof(AttendeeContactImportService));
+            actorUserId: actorUserId);
 
         return result;
     }

--- a/src/Humans.Application/Services/Tickets/AttendeeContactImportService.cs
+++ b/src/Humans.Application/Services/Tickets/AttendeeContactImportService.cs
@@ -64,11 +64,142 @@ public sealed class AttendeeContactImportService : IAttendeeContactImportService
         return new AttendeeImportPlan(decisions, unmatched.Count);
     }
 
-    public Task<AttendeeImportResult> ApplyAsync(
+    public async Task<AttendeeImportResult> ApplyAsync(
         AttendeeImportPlan plan,
         IReadOnlySet<Guid> selectedAttendeeIds,
-        CancellationToken ct = default) =>
-        throw new NotSupportedException("Filled in by Task 11");
+        CancellationToken ct = default)
+    {
+        var start = _clock.GetCurrentInstant();
+
+        var state = await _ticketRepository.GetSyncStateAsync(ct);
+        var eventId = state?.VendorEventId;
+        if (string.IsNullOrEmpty(eventId))
+            throw new InvalidOperationException("No active vendor event id — sync has not run.");
+
+        // Re-query so plan/apply are stateless (a sync between plan and apply is tolerated).
+        var freshUnmatched = await _ticketRepository.GetUnmatchedActiveAttendeesAsync(eventId, ct);
+        var freshById = freshUnmatched.ToDictionary(a => a.Id);
+
+        var toUpsert = new List<TicketAttendee>();
+        var newlyMatchedUserIds = new HashSet<Guid>();
+        int attempted = 0, created = 0, attached = 0, replaced = 0,
+            ambiguous = 0, noEmail = 0, vanished = 0, errors = 0;
+
+        foreach (var d in plan.Decisions.Where(d => selectedAttendeeIds.Contains(d.AttendeeId)))
+        {
+            attempted++;
+
+            if (!freshById.TryGetValue(d.AttendeeId, out var attendee))
+            {
+                vanished++;
+                _logger.LogInformation(
+                    "Attendee {AttendeeId} ({Email}) vanished between plan and apply",
+                    d.AttendeeId, d.Email);
+                continue;
+            }
+
+            try
+            {
+                switch (d.Outcome)
+                {
+                    case AttendeeImportOutcome.SkipNoEmail:
+                        noEmail++;
+                        break;
+
+                    case AttendeeImportOutcome.SkipVoided:
+                        break;
+
+                    case AttendeeImportOutcome.AmbiguousMultipleVerified:
+                        ambiguous++;
+                        _logger.LogError(
+                            "Attendee {AttendeeId} email {Email} verified by multiple users {UserIds}",
+                            d.AttendeeId, d.Email, d.AmbiguousUserIds);
+                        break;
+
+                    case AttendeeImportOutcome.AttachVerified:
+                    {
+                        attendee.MatchedUserId = d.TargetUserId!.Value;
+                        toUpsert.Add(attendee);
+                        newlyMatchedUserIds.Add(d.TargetUserId.Value);
+                        attached++;
+                        break;
+                    }
+
+                    case AttendeeImportOutcome.DeleteUnverifiedThenCreate:
+                    {
+                        if (d.UnverifiedRowUserId is Guid uid &&
+                            d.UnverifiedEmailIdToDelete is Guid eid)
+                        {
+                            await _userEmails.DeleteEmailAsync(uid, eid, ct);
+                        }
+                        var (newUser, wasCreated) = await _provisioning.FindOrCreateUserByEmailAsync(
+                            d.Email!, d.AttendeeName, ContactSource.TicketTailor, ct);
+                        attendee.MatchedUserId = newUser.Id;
+                        toUpsert.Add(attendee);
+                        newlyMatchedUserIds.Add(newUser.Id);
+                        if (wasCreated) created++;
+                        replaced++;
+                        break;
+                    }
+
+                    case AttendeeImportOutcome.CreateNewUser:
+                    {
+                        var (newUser, wasCreated) = await _provisioning.FindOrCreateUserByEmailAsync(
+                            d.Email!, d.AttendeeName, ContactSource.TicketTailor, ct);
+                        attendee.MatchedUserId = newUser.Id;
+                        toUpsert.Add(attendee);
+                        newlyMatchedUserIds.Add(newUser.Id);
+                        if (wasCreated) created++;
+                        break;
+                    }
+                }
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                errors++;
+                _logger.LogError(ex,
+                    "Attendee contact import failed for {AttendeeId} ({Email})",
+                    d.AttendeeId, d.Email);
+            }
+        }
+
+        if (toUpsert.Count > 0)
+        {
+            await _ticketRepository.UpsertAttendeesAsync(toUpsert, ct);
+        }
+
+        var active = await _shifts.GetActiveAsync();
+        if (active is not null && newlyMatchedUserIds.Count > 0)
+        {
+            foreach (var userId in newlyMatchedUserIds)
+            {
+                await _users.SetParticipationFromTicketSyncAsync(
+                    userId, active.Year, ParticipationStatus.Ticketed, ct);
+            }
+        }
+
+        _ticketQuery.InvalidateAfterContactImport();
+
+        var elapsed = _clock.GetCurrentInstant() - start;
+        var result = new AttendeeImportResult(
+            TotalAttempted: attempted,
+            UsersCreated: created,
+            AttachedToExistingVerified: attached,
+            UnverifiedRowsDeletedAndUserCreated: replaced,
+            AmbiguousSkipped: ambiguous,
+            NoEmailSkipped: noEmail,
+            VanishedBetweenPlanAndApply: vanished,
+            Errors: errors,
+            Elapsed: elapsed);
+
+        await _audit.LogAsync(
+            AuditAction.TicketContactsImported,
+            entityType: "Tickets", entityId: Guid.Empty,
+            description: result.FormatSummary(),
+            jobName: nameof(AttendeeContactImportService));
+
+        return result;
+    }
 
     private async Task<AttendeeImportDecision> ClassifyAsync(TicketAttendee a, CancellationToken ct)
     {

--- a/src/Humans.Application/Services/Tickets/AttendeeContactImportService.cs
+++ b/src/Humans.Application/Services/Tickets/AttendeeContactImportService.cs
@@ -1,0 +1,94 @@
+using Humans.Application.Interfaces.AuditLog;
+using Humans.Application.Interfaces.Profiles;
+using Humans.Application.Interfaces.Repositories;
+using Humans.Application.Interfaces.Shifts;
+using Humans.Application.Interfaces.Tickets;
+using Humans.Application.Interfaces.Tickets.Dtos;
+using Humans.Application.Interfaces.Users;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using Microsoft.Extensions.Logging;
+using NodaTime;
+
+namespace Humans.Application.Services.Tickets;
+
+public sealed class AttendeeContactImportService : IAttendeeContactImportService
+{
+    private readonly ITicketRepository _ticketRepository;
+    private readonly IUserEmailService _userEmails;
+    private readonly IAccountProvisioningService _provisioning;
+    private readonly IUserService _users;
+    private readonly IShiftManagementService _shifts;
+    private readonly ITicketQueryService _ticketQuery;
+    private readonly IAuditLogService _audit;
+    private readonly IClock _clock;
+    private readonly ILogger<AttendeeContactImportService> _logger;
+
+    public AttendeeContactImportService(
+        ITicketRepository ticketRepository,
+        IUserEmailService userEmails,
+        IAccountProvisioningService provisioning,
+        IUserService users,
+        IShiftManagementService shifts,
+        ITicketQueryService ticketQuery,
+        IAuditLogService audit,
+        IClock clock,
+        ILogger<AttendeeContactImportService> logger)
+    {
+        _ticketRepository = ticketRepository;
+        _userEmails = userEmails;
+        _provisioning = provisioning;
+        _users = users;
+        _shifts = shifts;
+        _ticketQuery = ticketQuery;
+        _audit = audit;
+        _clock = clock;
+        _logger = logger;
+    }
+
+    public async Task<AttendeeImportPlan> BuildPlanAsync(CancellationToken ct = default)
+    {
+        var state = await _ticketRepository.GetSyncStateAsync(ct);
+        var eventId = state?.VendorEventId;
+        if (string.IsNullOrEmpty(eventId))
+            throw new InvalidOperationException("No active vendor event id — sync has not run.");
+
+        var unmatched = await _ticketRepository.GetUnmatchedActiveAttendeesAsync(eventId, ct);
+        var decisions = new List<AttendeeImportDecision>(unmatched.Count);
+
+        foreach (var a in unmatched)
+        {
+            decisions.Add(await ClassifyAsync(a, ct));
+        }
+
+        return new AttendeeImportPlan(decisions, unmatched.Count);
+    }
+
+    public Task<AttendeeImportResult> ApplyAsync(
+        AttendeeImportPlan plan,
+        IReadOnlySet<Guid> selectedAttendeeIds,
+        CancellationToken ct = default) =>
+        throw new NotSupportedException("Filled in by Task 11");
+
+    private Task<AttendeeImportDecision> ClassifyAsync(TicketAttendee a, CancellationToken ct)
+    {
+        var name = ResolveDisplayName(a);
+
+        if (string.IsNullOrWhiteSpace(a.AttendeeEmail))
+        {
+            return Task.FromResult(new AttendeeImportDecision(
+                a.Id, a.AttendeeEmail, name, a.VendorTicketId,
+                AttendeeImportOutcome.SkipNoEmail,
+                TargetUserId: null,
+                UnverifiedEmailIdToDelete: null,
+                UnverifiedRowUserId: null,
+                AmbiguousUserIds: null));
+        }
+
+        // Remaining classifications filled in by Tasks 9–10.
+        throw new NotSupportedException("Branches filled in by Tasks 9–10");
+    }
+
+    private static string? ResolveDisplayName(TicketAttendee a) =>
+        string.IsNullOrWhiteSpace(a.AttendeeName) ? null : a.AttendeeName.Trim();
+}

--- a/src/Humans.Application/Services/Tickets/TicketQueryService.cs
+++ b/src/Humans.Application/Services/Tickets/TicketQueryService.cs
@@ -923,6 +923,11 @@ public sealed class TicketQueryService : ITicketQueryService, IUserDataContribut
         }
     }
 
+    public void InvalidateAfterContactImport()
+    {
+        _cache.InvalidateTicketCaches();
+    }
+
     public Task<IReadOnlyList<OrderDriftRow>> GetOrderDriftAsync(CancellationToken ct = default) =>
         _ticketRepository.GetOrderDriftAsync(ct);
 }

--- a/src/Humans.Domain/Enums/AuditAction.cs
+++ b/src/Humans.Domain/Enums/AuditAction.cs
@@ -165,4 +165,5 @@ public enum AuditAction
     UserEmailDisplacedByOAuthRename,
     MailerLiteReconciliationCompleted,
     GoogleSyncRetryScheduled,
+    TicketContactsImported,
 }

--- a/src/Humans.Infrastructure/Repositories/Tickets/TicketRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Tickets/TicketRepository.cs
@@ -265,6 +265,20 @@ public sealed class TicketRepository : ITicketRepository
         await ctx.SaveChangesAsync(ct);
     }
 
+    public async Task<IReadOnlyList<TicketAttendee>> GetUnmatchedActiveAttendeesAsync(
+        string vendorEventId, CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        return await ctx.TicketAttendees
+            .Where(a =>
+                a.VendorEventId == vendorEventId &&
+                a.MatchedUserId == null &&
+                !string.IsNullOrEmpty(a.AttendeeEmail) &&
+                (a.Status == TicketAttendeeStatus.Valid ||
+                 a.Status == TicketAttendeeStatus.CheckedIn))
+            .ToListAsync(ct);
+    }
+
     public async Task UpsertAttendeeAsync(TicketAttendee attendee, CancellationToken ct = default)
     {
         await using var ctx = await _factory.CreateDbContextAsync(ct);

--- a/src/Humans.Infrastructure/Repositories/Tickets/TicketRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Tickets/TicketRepository.cs
@@ -265,6 +265,9 @@ public sealed class TicketRepository : ITicketRepository
         await ctx.SaveChangesAsync(ct);
     }
 
+    private static readonly TicketAttendeeStatus[] ActiveAttendeeStatuses =
+        [TicketAttendeeStatus.Valid, TicketAttendeeStatus.CheckedIn];
+
     public async Task<IReadOnlyList<TicketAttendee>> GetUnmatchedActiveAttendeesAsync(
         string vendorEventId, CancellationToken ct = default)
     {
@@ -274,8 +277,7 @@ public sealed class TicketRepository : ITicketRepository
                 a.VendorEventId == vendorEventId &&
                 a.MatchedUserId == null &&
                 !string.IsNullOrEmpty(a.AttendeeEmail) &&
-                (a.Status == TicketAttendeeStatus.Valid ||
-                 a.Status == TicketAttendeeStatus.CheckedIn))
+                ActiveAttendeeStatuses.Contains(a.Status))
             .ToListAsync(ct);
     }
 

--- a/src/Humans.Web/Controllers/Mailer/MailerAdminController.cs
+++ b/src/Humans.Web/Controllers/Mailer/MailerAdminController.cs
@@ -96,7 +96,7 @@ public sealed class MailerAdminController : HumansControllerBase
             _logger.LogWarning("MailerLite refresh failed: {StatusCode} {Message}", ex.StatusCode, ex.Message);
             TempData["Banner"] = "Refresh failed: " + FormatMailerLiteError(ex);
         }
-        catch (TaskCanceledException ex) when (!ct.IsCancellationRequested)
+        catch (TaskCanceledException) when (!ct.IsCancellationRequested)
         {
             // MailerLiteClient surfaces HttpClient timeouts as TaskCanceledException
             // when the caller did not cancel. Treat it as a transient refresh failure.

--- a/src/Humans.Web/Controllers/TicketsContactsAdminController.cs
+++ b/src/Humans.Web/Controllers/TicketsContactsAdminController.cs
@@ -51,13 +51,20 @@ public sealed class TicketsContactsAdminController : HumansControllerBase
     {
         if (selected is null || selected.Length == 0)
         {
-            TempData["Banner"] = "Select at least one attendee before applying.";
+            SetError("Select at least one attendee before applying.");
+            return RedirectToAction(nameof(Index));
+        }
+
+        var actor = await GetCurrentUserAsync();
+        if (actor is null)
+        {
+            SetError("Could not resolve current user.");
             return RedirectToAction(nameof(Index));
         }
 
         var fresh = await _import.BuildPlanAsync(ct);
-        var result = await _import.ApplyAsync(fresh, new HashSet<Guid>(selected), ct);
-        TempData["Banner"] = $"Attendee contact import: {result.FormatSummary()}";
+        var result = await _import.ApplyAsync(fresh, new HashSet<Guid>(selected), actor.Id, ct);
+        SetInfo($"Attendee contact import: {result.FormatSummary()}");
         return RedirectToAction(nameof(Index));
     }
 

--- a/src/Humans.Web/Controllers/TicketsContactsAdminController.cs
+++ b/src/Humans.Web/Controllers/TicketsContactsAdminController.cs
@@ -1,0 +1,56 @@
+using Humans.Application.Interfaces.Tickets;
+using Humans.Application.Interfaces.Tickets.Dtos;
+using Humans.Domain.Entities;
+using Humans.Web.Authorization;
+using Humans.Web.Models.Tickets;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+namespace Humans.Web.Controllers;
+
+[Authorize(Policy = PolicyNames.TicketAdminOrAdmin)]
+[Route("Tickets/Admin/Contacts")]
+public sealed class TicketsContactsAdminController : HumansControllerBase
+{
+    private readonly IAttendeeContactImportService _import;
+    private readonly ILogger<TicketsContactsAdminController> _logger;
+
+    public TicketsContactsAdminController(
+        IAttendeeContactImportService import,
+        UserManager<User> userManager,
+        ILogger<TicketsContactsAdminController> logger)
+        : base(userManager)
+    {
+        _import = import;
+        _logger = logger;
+    }
+
+    [HttpGet("")]
+    public async Task<IActionResult> Index(CancellationToken ct)
+    {
+        var plan = await _import.BuildPlanAsync(ct);
+        var rows = plan.Decisions
+            .OrderBy(d => SortKey(d.Outcome))
+            .ThenBy(d => d.Email, StringComparer.OrdinalIgnoreCase)
+            .Select(d => new AttendeeImportDecisionRow(
+                d.AttendeeId, d.Email, d.AttendeeName, d.VendorTicketId,
+                d.Outcome, d.TargetUserId, d.UnverifiedRowUserId, d.AmbiguousUserIds))
+            .ToList();
+
+        return View("~/Views/Tickets/Admin/Contacts.cshtml",
+            new ContactImportPreviewViewModel(plan, rows));
+    }
+
+    private static int SortKey(AttendeeImportOutcome o) => o switch
+    {
+        AttendeeImportOutcome.AmbiguousMultipleVerified => 0,
+        AttendeeImportOutcome.DeleteUnverifiedThenCreate => 1,
+        AttendeeImportOutcome.CreateNewUser => 2,
+        AttendeeImportOutcome.AttachVerified => 3,
+        AttendeeImportOutcome.SkipNoEmail => 4,
+        AttendeeImportOutcome.SkipVoided => 5,
+        _ => 99,
+    };
+}

--- a/src/Humans.Web/Controllers/TicketsContactsAdminController.cs
+++ b/src/Humans.Web/Controllers/TicketsContactsAdminController.cs
@@ -43,6 +43,24 @@ public sealed class TicketsContactsAdminController : HumansControllerBase
             new ContactImportPreviewViewModel(plan, rows));
     }
 
+    [HttpPost("Apply")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Apply(
+        [FromForm(Name = "selected")] Guid[] selected,
+        CancellationToken ct)
+    {
+        if (selected is null || selected.Length == 0)
+        {
+            TempData["Banner"] = "Select at least one attendee before applying.";
+            return RedirectToAction(nameof(Index));
+        }
+
+        var fresh = await _import.BuildPlanAsync(ct);
+        var result = await _import.ApplyAsync(fresh, new HashSet<Guid>(selected), ct);
+        TempData["Banner"] = $"Attendee contact import: {result.FormatSummary()}";
+        return RedirectToAction(nameof(Index));
+    }
+
     private static int SortKey(AttendeeImportOutcome o) => o switch
     {
         AttendeeImportOutcome.AmbiguousMultipleVerified => 0,

--- a/src/Humans.Web/Extensions/Sections/TicketsSectionExtensions.cs
+++ b/src/Humans.Web/Extensions/Sections/TicketsSectionExtensions.cs
@@ -34,6 +34,9 @@ internal static class TicketsSectionExtensions
         services.AddSingleton<ITicketTransferRepository, TicketTransferRepository>();
         services.AddScoped<ITicketTransferService, TicketTransferService>();
 
+        // AttendeeContactImportService — orchestrates user provisioning from unmatched ticket attendees.
+        services.AddScoped<IAttendeeContactImportService, AttendeeContactImportService>();
+
         services.AddScoped<TicketSyncJob>();
         services.AddScoped<TicketingBudgetSyncJob>();
 

--- a/src/Humans.Web/Models/Tickets/ContactImportPreviewViewModel.cs
+++ b/src/Humans.Web/Models/Tickets/ContactImportPreviewViewModel.cs
@@ -1,0 +1,17 @@
+using Humans.Application.Interfaces.Tickets.Dtos;
+
+namespace Humans.Web.Models.Tickets;
+
+public sealed record ContactImportPreviewViewModel(
+    AttendeeImportPlan Plan,
+    IReadOnlyList<AttendeeImportDecisionRow> Rows);
+
+public sealed record AttendeeImportDecisionRow(
+    Guid AttendeeId,
+    string? Email,
+    string? AttendeeName,
+    string VendorTicketId,
+    AttendeeImportOutcome Outcome,
+    Guid? TargetUserId,
+    Guid? UnverifiedRowUserId,
+    IReadOnlyList<Guid>? AmbiguousUserIds);

--- a/src/Humans.Web/Views/Ticket/Index.cshtml
+++ b/src/Humans.Web/Views/Ticket/Index.cshtml
@@ -361,6 +361,10 @@
                     <i class="fa-solid fa-arrows-rotate"></i> Full Re-sync <i class="fa-solid fa-lock auth-lock-icon"></i>
                 </button>
             </form>
+            <a asp-controller="TicketsContactsAdmin" asp-action="Index"
+               class="btn btn-sm btn-outline-primary ms-2" authorize-policy="TicketAdminOrAdmin">
+                <i class="fa-solid fa-user-plus"></i> Import Attendee Contacts <i class="fa-solid fa-lock auth-lock-icon"></i>
+            </a>
         </div>
     </div>
 </div>

--- a/src/Humans.Web/Views/Tickets/Admin/Contacts.cshtml
+++ b/src/Humans.Web/Views/Tickets/Admin/Contacts.cshtml
@@ -7,11 +7,6 @@
 
 <h1>Import Attendee Contacts</h1>
 
-@if (TempData["Banner"] is string banner)
-{
-    <div class="alert alert-info" role="alert">@banner</div>
-}
-
 <p class="text-muted">
     Found @Model.Plan.TotalUnmatched unmatched attendee@(Model.Plan.TotalUnmatched == 1 ? "" : "s")
     for the active event. Each one below has no <code>MatchedUserId</code> yet.

--- a/src/Humans.Web/Views/Tickets/Admin/Contacts.cshtml
+++ b/src/Humans.Web/Views/Tickets/Admin/Contacts.cshtml
@@ -1,0 +1,144 @@
+@using Humans.Application.Interfaces.Tickets.Dtos
+@model Humans.Web.Models.Tickets.ContactImportPreviewViewModel
+@{
+    ViewData["Title"] = "Import Attendee Contacts";
+    var c = Model.Plan.Counts;
+}
+
+<h1>Import Attendee Contacts</h1>
+
+@if (TempData["Banner"] is string banner)
+{
+    <div class="alert alert-info" role="alert">@banner</div>
+}
+
+<p class="text-muted">
+    Found @Model.Plan.TotalUnmatched unmatched attendee@(Model.Plan.TotalUnmatched == 1 ? "" : "s")
+    for the active event. Each one below has no <code>MatchedUserId</code> yet.
+    Select rows and click Apply.
+</p>
+
+<div class="mb-3">
+    <span class="badge text-bg-success me-1">Attach existing: @c.AttachVerified</span>
+    <span class="badge text-bg-primary me-1">Create new user: @c.CreateNewUser</span>
+    <span class="badge text-bg-warning me-1">Delete unverified + create: @c.DeleteUnverifiedThenCreate</span>
+    @if (c.AmbiguousMultipleVerified > 0)
+    {
+        <span class="badge text-bg-danger me-1">Ambiguous (skipped): @c.AmbiguousMultipleVerified</span>
+    }
+    @if (c.SkipNoEmail > 0)
+    {
+        <span class="badge text-bg-secondary me-1">No email (skipped): @c.SkipNoEmail</span>
+    }
+</div>
+
+<form asp-controller="TicketsContactsAdmin" asp-action="Apply" method="post" id="contacts-apply">
+    @Html.AntiForgeryToken()
+
+    <div class="mb-2">
+        <button type="button" class="btn btn-outline-secondary btn-sm" id="select-all">Select all</button>
+        <button type="button" class="btn btn-outline-secondary btn-sm" id="select-first">Select first 1</button>
+        <button type="submit" class="btn btn-primary btn-sm" id="apply-btn">
+            Apply selected (<span id="selected-count">0</span>)
+        </button>
+    </div>
+
+    <table class="table table-sm table-hover">
+        <thead>
+            <tr>
+                <th style="width:2rem"></th>
+                <th>Email</th>
+                <th>Name</th>
+                <th>Decision</th>
+                <th>Target / Notes</th>
+                <th>Vendor Ticket Id</th>
+            </tr>
+        </thead>
+        <tbody>
+        @foreach (var row in Model.Rows)
+        {
+            <tr>
+                <td>
+                    @if (row.Outcome is AttendeeImportOutcome.AmbiguousMultipleVerified
+                                      or AttendeeImportOutcome.SkipNoEmail
+                                      or AttendeeImportOutcome.SkipVoided)
+                    {
+                        @* Non-actionable rows: no checkbox *@
+                    }
+                    else
+                    {
+                        <input type="checkbox" name="selected" value="@row.AttendeeId"
+                               class="form-check-input row-check" />
+                    }
+                </td>
+                <td>@(row.Email ?? "—")</td>
+                <td>@(row.AttendeeName ?? "—")</td>
+                <td>
+                    @switch (row.Outcome)
+                    {
+                        case AttendeeImportOutcome.AttachVerified:
+                            <span class="badge text-bg-success">Attach existing</span>
+                            break;
+                        case AttendeeImportOutcome.CreateNewUser:
+                            <span class="badge text-bg-primary">Create new user</span>
+                            break;
+                        case AttendeeImportOutcome.DeleteUnverifiedThenCreate:
+                            <span class="badge text-bg-warning">Delete unverified + create</span>
+                            break;
+                        case AttendeeImportOutcome.AmbiguousMultipleVerified:
+                            <span class="badge text-bg-danger">Ambiguous</span>
+                            break;
+                        case AttendeeImportOutcome.SkipNoEmail:
+                            <span class="badge text-bg-secondary">No email</span>
+                            break;
+                        case AttendeeImportOutcome.SkipVoided:
+                            <span class="badge text-bg-secondary">Voided</span>
+                            break;
+                    }
+                </td>
+                <td>
+                    @if (row.Outcome == AttendeeImportOutcome.AttachVerified && row.TargetUserId is Guid uid)
+                    {
+                        <a asp-controller="Profile" asp-action="AdminDetail" asp-route-id="@uid">
+                            View user</a>
+                    }
+                    else if (row.Outcome == AttendeeImportOutcome.DeleteUnverifiedThenCreate
+                             && row.UnverifiedRowUserId is Guid squatterId)
+                    {
+                        <text>Will delete unverified email row owned by </text>
+                        <a asp-controller="Profile" asp-action="AdminDetail" asp-route-id="@squatterId">user</a>
+                    }
+                    else if (row.Outcome == AttendeeImportOutcome.AmbiguousMultipleVerified
+                             && row.AmbiguousUserIds is { Count: > 0 } ids)
+                    {
+                        <text>Multiple verified owners: @string.Join(", ", ids)</text>
+                    }
+                </td>
+                <td><code>@row.VendorTicketId</code></td>
+            </tr>
+        }
+        </tbody>
+    </table>
+</form>
+
+<script>
+(function () {
+    const checks = document.querySelectorAll('.row-check');
+    const count = document.getElementById('selected-count');
+    function refresh() {
+        const n = Array.from(checks).filter(c => c.checked).length;
+        count.textContent = n;
+        document.getElementById('apply-btn').disabled = n === 0;
+    }
+    checks.forEach(c => c.addEventListener('change', refresh));
+    document.getElementById('select-all').addEventListener('click', () => {
+        checks.forEach(c => c.checked = true);
+        refresh();
+    });
+    document.getElementById('select-first').addEventListener('click', () => {
+        checks.forEach((c, i) => c.checked = (i === 0));
+        refresh();
+    });
+    refresh();
+})();
+</script>

--- a/src/Humans.Web/Views/Tickets/Admin/Contacts.cshtml
+++ b/src/Humans.Web/Views/Tickets/Admin/Contacts.cshtml
@@ -116,7 +116,7 @@
     </table>
 </form>
 
-<script>
+<script nonce="@Context.Items["CspNonce"]">
 (function () {
     const checks = document.querySelectorAll('.row-check');
     const count = document.getElementById('selected-count');

--- a/tests/Humans.Application.Tests/Architecture/AttendeeContactImportArchitectureTests.cs
+++ b/tests/Humans.Application.Tests/Architecture/AttendeeContactImportArchitectureTests.cs
@@ -1,0 +1,48 @@
+using AwesomeAssertions;
+using Humans.Application.Interfaces.AuditLog;
+using Humans.Application.Interfaces.Profiles;
+using Humans.Application.Interfaces.Repositories;
+using Humans.Application.Interfaces.Shifts;
+using Humans.Application.Interfaces.Tickets;
+using Humans.Application.Interfaces.Users;
+using Humans.Application.Services.Tickets;
+using Humans.Testing;
+using Microsoft.EntityFrameworkCore;
+
+namespace Humans.Application.Tests.Architecture;
+
+public class AttendeeContactImportArchitectureTests
+{
+    [HumansFact]
+    public void Service_LivesInTicketsNamespace()
+    {
+        typeof(AttendeeContactImportService).Namespace
+            .Should().Be("Humans.Application.Services.Tickets",
+                because: "services with business logic live in Humans.Application per design-rules §2b, organized by section");
+    }
+
+    [HumansFact]
+    public void Service_HasNoDbContextConstructorParameter()
+    {
+        var ctor = typeof(AttendeeContactImportService).GetConstructors().Single();
+        ctor.GetParameters()
+            .Should().NotContain(
+                p => typeof(DbContext).IsAssignableFrom(p.ParameterType),
+                because: "services in Humans.Application must never take DbContext — use ITicketRepository instead (design-rules §3)");
+    }
+
+    [HumansFact]
+    public void Service_DependsOnExpectedAbstractions()
+    {
+        var ctor = typeof(AttendeeContactImportService).GetConstructors().Single();
+        var paramTypes = ctor.GetParameters().Select(p => p.ParameterType).ToHashSet();
+
+        paramTypes.Should().Contain(typeof(ITicketRepository));
+        paramTypes.Should().Contain(typeof(IUserEmailService));
+        paramTypes.Should().Contain(typeof(IAccountProvisioningService));
+        paramTypes.Should().Contain(typeof(IUserService));
+        paramTypes.Should().Contain(typeof(IShiftManagementService));
+        paramTypes.Should().Contain(typeof(ITicketQueryService));
+        paramTypes.Should().Contain(typeof(IAuditLogService));
+    }
+}

--- a/tests/Humans.Application.Tests/Repositories/TicketRepositoryTests.cs
+++ b/tests/Humans.Application.Tests/Repositories/TicketRepositoryTests.cs
@@ -276,37 +276,57 @@ public sealed class TicketRepositoryTests : IDisposable
         await _dbContext.TicketAttendees.AddRangeAsync(
             new TicketAttendee
             {
-                Id = includedId, TicketOrderId = orderId, VendorEventId = eventId,
-                VendorTicketId = "tkt_valid_unmatched", AttendeeEmail = "a@x.com",
-                Status = TicketAttendeeStatus.Valid, MatchedUserId = null,
+                Id = includedId,
+                TicketOrderId = orderId,
+                VendorEventId = eventId,
+                VendorTicketId = "tkt_valid_unmatched",
+                AttendeeEmail = "a@x.com",
+                Status = TicketAttendeeStatus.Valid,
+                MatchedUserId = null,
                 SyncedAt = _clock.GetCurrentInstant(),
             },
             new TicketAttendee
             {
-                Id = Guid.NewGuid(), TicketOrderId = orderId, VendorEventId = eventId,
-                VendorTicketId = "tkt_voided", AttendeeEmail = "b@x.com",
-                Status = TicketAttendeeStatus.Void, MatchedUserId = null,
+                Id = Guid.NewGuid(),
+                TicketOrderId = orderId,
+                VendorEventId = eventId,
+                VendorTicketId = "tkt_voided",
+                AttendeeEmail = "b@x.com",
+                Status = TicketAttendeeStatus.Void,
+                MatchedUserId = null,
                 SyncedAt = _clock.GetCurrentInstant(),
             },
             new TicketAttendee
             {
-                Id = Guid.NewGuid(), TicketOrderId = orderId, VendorEventId = eventId,
-                VendorTicketId = "tkt_matched", AttendeeEmail = "c@x.com",
-                Status = TicketAttendeeStatus.Valid, MatchedUserId = Guid.NewGuid(),
+                Id = Guid.NewGuid(),
+                TicketOrderId = orderId,
+                VendorEventId = eventId,
+                VendorTicketId = "tkt_matched",
+                AttendeeEmail = "c@x.com",
+                Status = TicketAttendeeStatus.Valid,
+                MatchedUserId = Guid.NewGuid(),
                 SyncedAt = _clock.GetCurrentInstant(),
             },
             new TicketAttendee
             {
-                Id = Guid.NewGuid(), TicketOrderId = orderId, VendorEventId = eventId,
-                VendorTicketId = "tkt_no_email", AttendeeEmail = null,
-                Status = TicketAttendeeStatus.Valid, MatchedUserId = null,
+                Id = Guid.NewGuid(),
+                TicketOrderId = orderId,
+                VendorEventId = eventId,
+                VendorTicketId = "tkt_no_email",
+                AttendeeEmail = null,
+                Status = TicketAttendeeStatus.Valid,
+                MatchedUserId = null,
                 SyncedAt = _clock.GetCurrentInstant(),
             },
             new TicketAttendee
             {
-                Id = Guid.NewGuid(), TicketOrderId = orderId, VendorEventId = "other_event",
-                VendorTicketId = "tkt_other_event", AttendeeEmail = "d@x.com",
-                Status = TicketAttendeeStatus.Valid, MatchedUserId = null,
+                Id = Guid.NewGuid(),
+                TicketOrderId = orderId,
+                VendorEventId = "other_event",
+                VendorTicketId = "tkt_other_event",
+                AttendeeEmail = "d@x.com",
+                Status = TicketAttendeeStatus.Valid,
+                MatchedUserId = null,
                 SyncedAt = _clock.GetCurrentInstant(),
             });
         await _dbContext.SaveChangesAsync();
@@ -324,9 +344,14 @@ public sealed class TicketRepositoryTests : IDisposable
         var eventId = "evt_ci";
         _dbContext.TicketOrders.Add(new TicketOrder
         {
-            Id = orderId, VendorOrderId = "ord_ci", VendorEventId = eventId,
-            BuyerEmail = "buyer@x.com", BuyerName = "Buyer", TotalAmount = 0,
-            Currency = "EUR", PaymentStatus = TicketPaymentStatus.Paid,
+            Id = orderId,
+            VendorOrderId = "ord_ci",
+            VendorEventId = eventId,
+            BuyerEmail = "buyer@x.com",
+            BuyerName = "Buyer",
+            TotalAmount = 0,
+            Currency = "EUR",
+            PaymentStatus = TicketPaymentStatus.Paid,
             PurchasedAt = _clock.GetCurrentInstant(),
             SyncedAt = _clock.GetCurrentInstant(),
         });
@@ -334,9 +359,13 @@ public sealed class TicketRepositoryTests : IDisposable
         var includedId = Guid.NewGuid();
         _dbContext.TicketAttendees.Add(new TicketAttendee
         {
-            Id = includedId, TicketOrderId = orderId, VendorEventId = eventId,
-            VendorTicketId = "tkt_ci", AttendeeEmail = "ci@x.com",
-            Status = TicketAttendeeStatus.CheckedIn, MatchedUserId = null,
+            Id = includedId,
+            TicketOrderId = orderId,
+            VendorEventId = eventId,
+            VendorTicketId = "tkt_ci",
+            AttendeeEmail = "ci@x.com",
+            Status = TicketAttendeeStatus.CheckedIn,
+            MatchedUserId = null,
             SyncedAt = _clock.GetCurrentInstant(),
         });
         await _dbContext.SaveChangesAsync();

--- a/tests/Humans.Application.Tests/Repositories/TicketRepositoryTests.cs
+++ b/tests/Humans.Application.Tests/Repositories/TicketRepositoryTests.cs
@@ -249,4 +249,100 @@ public sealed class TicketRepositoryTests : IDisposable
         rows[0].MatchedUserId.Should().Be(matchedUserId);
         rows[0].Status.Should().Be(TicketAttendeeStatus.Valid);
     }
+
+    // ── GetUnmatchedActiveAttendeesAsync ─────────────────────────────────────
+
+    [HumansFact]
+    public async Task GetUnmatchedActiveAttendeesAsync_ReturnsOnlyValidAndCheckedIn_WithEmail_AndNullMatch()
+    {
+        var orderId = Guid.NewGuid();
+        var eventId = "evt_123";
+
+        _dbContext.TicketOrders.Add(new TicketOrder
+        {
+            Id = orderId,
+            VendorOrderId = "ord_1",
+            VendorEventId = eventId,
+            BuyerEmail = "buyer@x.com",
+            BuyerName = "Buyer",
+            TotalAmount = 0,
+            Currency = "EUR",
+            PaymentStatus = TicketPaymentStatus.Paid,
+            PurchasedAt = _clock.GetCurrentInstant(),
+            SyncedAt = _clock.GetCurrentInstant(),
+        });
+
+        var includedId = Guid.NewGuid();
+        await _dbContext.TicketAttendees.AddRangeAsync(
+            new TicketAttendee
+            {
+                Id = includedId, TicketOrderId = orderId, VendorEventId = eventId,
+                VendorTicketId = "tkt_valid_unmatched", AttendeeEmail = "a@x.com",
+                Status = TicketAttendeeStatus.Valid, MatchedUserId = null,
+                SyncedAt = _clock.GetCurrentInstant(),
+            },
+            new TicketAttendee
+            {
+                Id = Guid.NewGuid(), TicketOrderId = orderId, VendorEventId = eventId,
+                VendorTicketId = "tkt_voided", AttendeeEmail = "b@x.com",
+                Status = TicketAttendeeStatus.Void, MatchedUserId = null,
+                SyncedAt = _clock.GetCurrentInstant(),
+            },
+            new TicketAttendee
+            {
+                Id = Guid.NewGuid(), TicketOrderId = orderId, VendorEventId = eventId,
+                VendorTicketId = "tkt_matched", AttendeeEmail = "c@x.com",
+                Status = TicketAttendeeStatus.Valid, MatchedUserId = Guid.NewGuid(),
+                SyncedAt = _clock.GetCurrentInstant(),
+            },
+            new TicketAttendee
+            {
+                Id = Guid.NewGuid(), TicketOrderId = orderId, VendorEventId = eventId,
+                VendorTicketId = "tkt_no_email", AttendeeEmail = null,
+                Status = TicketAttendeeStatus.Valid, MatchedUserId = null,
+                SyncedAt = _clock.GetCurrentInstant(),
+            },
+            new TicketAttendee
+            {
+                Id = Guid.NewGuid(), TicketOrderId = orderId, VendorEventId = "other_event",
+                VendorTicketId = "tkt_other_event", AttendeeEmail = "d@x.com",
+                Status = TicketAttendeeStatus.Valid, MatchedUserId = null,
+                SyncedAt = _clock.GetCurrentInstant(),
+            });
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _repo.GetUnmatchedActiveAttendeesAsync(eventId);
+
+        result.Should().HaveCount(1);
+        result.Single().Id.Should().Be(includedId);
+    }
+
+    [HumansFact]
+    public async Task GetUnmatchedActiveAttendeesAsync_IncludesCheckedInAttendees()
+    {
+        var orderId = Guid.NewGuid();
+        var eventId = "evt_ci";
+        _dbContext.TicketOrders.Add(new TicketOrder
+        {
+            Id = orderId, VendorOrderId = "ord_ci", VendorEventId = eventId,
+            BuyerEmail = "buyer@x.com", BuyerName = "Buyer", TotalAmount = 0,
+            Currency = "EUR", PaymentStatus = TicketPaymentStatus.Paid,
+            PurchasedAt = _clock.GetCurrentInstant(),
+            SyncedAt = _clock.GetCurrentInstant(),
+        });
+
+        var includedId = Guid.NewGuid();
+        _dbContext.TicketAttendees.Add(new TicketAttendee
+        {
+            Id = includedId, TicketOrderId = orderId, VendorEventId = eventId,
+            VendorTicketId = "tkt_ci", AttendeeEmail = "ci@x.com",
+            Status = TicketAttendeeStatus.CheckedIn, MatchedUserId = null,
+            SyncedAt = _clock.GetCurrentInstant(),
+        });
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _repo.GetUnmatchedActiveAttendeesAsync(eventId);
+
+        result.Should().ContainSingle(a => a.Id == includedId);
+    }
 }

--- a/tests/Humans.Application.Tests/Services/Shifts/ShiftDashboardMetricsTests.cs
+++ b/tests/Humans.Application.Tests/Services/Shifts/ShiftDashboardMetricsTests.cs
@@ -999,6 +999,7 @@ public class ShiftDashboardMetricsTests : IDisposable
         public Task<UserTicketExportData> GetUserTicketExportDataAsync(Guid userId, CancellationToken ct = default) => throw new NotSupportedException();
         public Task<Instant?> GetPostEventHoldDateAsync(CancellationToken ct = default) => throw new NotSupportedException();
         public void InvalidateAfterTransfer(Guid senderUserId, Guid? receiverUserId) => throw new NotSupportedException();
+        public void InvalidateAfterContactImport() => throw new NotSupportedException();
         public Task<UserTicketHoldings> GetUserTicketHoldingsAsync(Guid userId, CancellationToken ct = default) => throw new NotSupportedException();
         public Task<IReadOnlyList<OrderDriftRow>> GetOrderDriftAsync(CancellationToken ct = default) => throw new NotSupportedException();
     }

--- a/tests/Humans.Application.Tests/Services/Tickets/AttendeeContactImportServiceApplyTests.cs
+++ b/tests/Humans.Application.Tests/Services/Tickets/AttendeeContactImportServiceApplyTests.cs
@@ -28,8 +28,11 @@ public class AttendeeContactImportServiceApplyTests
         var targetUserId = Guid.NewGuid();
         var attendee = new TicketAttendee
         {
-            Id = attendeeId, VendorTicketId = "tkt_v", VendorEventId = "evt_active",
-            AttendeeEmail = "jane@x.com", Status = TicketAttendeeStatus.Valid,
+            Id = attendeeId,
+            VendorTicketId = "tkt_v",
+            VendorEventId = "evt_active",
+            AttendeeEmail = "jane@x.com",
+            Status = TicketAttendeeStatus.Valid,
             MatchedUserId = null,
         };
         harness.WithUnmatched(attendee);
@@ -48,7 +51,8 @@ public class AttendeeContactImportServiceApplyTests
             },
             TotalUnmatched: 1);
 
-        var result = await harness.Service.ApplyAsync(plan, new HashSet<Guid> { attendeeId });
+        var actorId = Guid.NewGuid();
+        var result = await harness.Service.ApplyAsync(plan, new HashSet<Guid> { attendeeId }, actorId);
 
         result.AttachedToExistingVerified.Should().Be(1);
         result.UsersCreated.Should().Be(0);
@@ -67,7 +71,7 @@ public class AttendeeContactImportServiceApplyTests
             AuditAction.TicketContactsImported,
             "Tickets", Guid.Empty,
             Arg.Is<string>(s => s.Contains("attached=1")),
-            nameof(AttendeeContactImportService));
+            actorId);
     }
 
     [HumansFact]
@@ -78,8 +82,11 @@ public class AttendeeContactImportServiceApplyTests
         var newUserId = Guid.NewGuid();
         var attendee = new TicketAttendee
         {
-            Id = attendeeId, VendorTicketId = "tkt_v", VendorEventId = "evt_active",
-            AttendeeEmail = "fresh@x.com", Status = TicketAttendeeStatus.Valid,
+            Id = attendeeId,
+            VendorTicketId = "tkt_v",
+            VendorEventId = "evt_active",
+            AttendeeEmail = "fresh@x.com",
+            Status = TicketAttendeeStatus.Valid,
         };
         harness.WithUnmatched(attendee);
         harness.WithActiveYear(2026);
@@ -98,7 +105,7 @@ public class AttendeeContactImportServiceApplyTests
             },
             1);
 
-        var result = await harness.Service.ApplyAsync(plan, new HashSet<Guid> { attendeeId });
+        var result = await harness.Service.ApplyAsync(plan, new HashSet<Guid> { attendeeId }, Guid.NewGuid());
 
         result.UsersCreated.Should().Be(1);
         attendee.MatchedUserId.Should().Be(newUserId);
@@ -120,8 +127,11 @@ public class AttendeeContactImportServiceApplyTests
         var newUserId = Guid.NewGuid();
         var attendee = new TicketAttendee
         {
-            Id = attendeeId, VendorTicketId = "tkt_v", VendorEventId = "evt_active",
-            AttendeeEmail = "victim@x.com", Status = TicketAttendeeStatus.Valid,
+            Id = attendeeId,
+            VendorTicketId = "tkt_v",
+            VendorEventId = "evt_active",
+            AttendeeEmail = "victim@x.com",
+            Status = TicketAttendeeStatus.Valid,
         };
         harness.WithUnmatched(attendee);
         harness.WithActiveYear(2026);
@@ -142,7 +152,7 @@ public class AttendeeContactImportServiceApplyTests
             },
             1);
 
-        var result = await harness.Service.ApplyAsync(plan, new HashSet<Guid> { attendeeId });
+        var result = await harness.Service.ApplyAsync(plan, new HashSet<Guid> { attendeeId }, Guid.NewGuid());
 
         result.UnverifiedRowsDeletedAndUserCreated.Should().Be(1);
         result.UsersCreated.Should().Be(1);
@@ -164,13 +174,19 @@ public class AttendeeContactImportServiceApplyTests
         var skippedId = Guid.NewGuid();
         var picked = new TicketAttendee
         {
-            Id = pickedId, VendorTicketId = "tkt_p", VendorEventId = "evt_active",
-            AttendeeEmail = "p@x.com", Status = TicketAttendeeStatus.Valid,
+            Id = pickedId,
+            VendorTicketId = "tkt_p",
+            VendorEventId = "evt_active",
+            AttendeeEmail = "p@x.com",
+            Status = TicketAttendeeStatus.Valid,
         };
         var unselected = new TicketAttendee
         {
-            Id = skippedId, VendorTicketId = "tkt_s", VendorEventId = "evt_active",
-            AttendeeEmail = "s@x.com", Status = TicketAttendeeStatus.Valid,
+            Id = skippedId,
+            VendorTicketId = "tkt_s",
+            VendorEventId = "evt_active",
+            AttendeeEmail = "s@x.com",
+            Status = TicketAttendeeStatus.Valid,
         };
         harness.WithUnmatched(picked);
         harness.WithUnmatched(unselected);
@@ -188,7 +204,7 @@ public class AttendeeContactImportServiceApplyTests
                     AttendeeImportOutcome.CreateNewUser, null, null, null, null),
             }, 2);
 
-        var result = await harness.Service.ApplyAsync(plan, new HashSet<Guid> { pickedId });
+        var result = await harness.Service.ApplyAsync(plan, new HashSet<Guid> { pickedId }, Guid.NewGuid());
 
         result.TotalAttempted.Should().Be(1);
         result.UsersCreated.Should().Be(1);
@@ -211,7 +227,7 @@ public class AttendeeContactImportServiceApplyTests
                     AttendeeImportOutcome.CreateNewUser, null, null, null, null),
             }, 1);
 
-        var result = await harness.Service.ApplyAsync(plan, new HashSet<Guid> { goneId });
+        var result = await harness.Service.ApplyAsync(plan, new HashSet<Guid> { goneId }, Guid.NewGuid());
 
         result.VanishedBetweenPlanAndApply.Should().Be(1);
         result.UsersCreated.Should().Be(0);
@@ -228,13 +244,19 @@ public class AttendeeContactImportServiceApplyTests
         var okId = Guid.NewGuid();
         harness.WithUnmatched(new TicketAttendee
         {
-            Id = failId, VendorTicketId = "tkt_f", VendorEventId = "evt_active",
-            AttendeeEmail = "f@x.com", Status = TicketAttendeeStatus.Valid,
+            Id = failId,
+            VendorTicketId = "tkt_f",
+            VendorEventId = "evt_active",
+            AttendeeEmail = "f@x.com",
+            Status = TicketAttendeeStatus.Valid,
         });
         harness.WithUnmatched(new TicketAttendee
         {
-            Id = okId, VendorTicketId = "tkt_o", VendorEventId = "evt_active",
-            AttendeeEmail = "o@x.com", Status = TicketAttendeeStatus.Valid,
+            Id = okId,
+            VendorTicketId = "tkt_o",
+            VendorEventId = "evt_active",
+            AttendeeEmail = "o@x.com",
+            Status = TicketAttendeeStatus.Valid,
         });
         harness.WithActiveYear(2026);
         harness.Provisioning.FindOrCreateUserByEmailAsync(
@@ -253,7 +275,7 @@ public class AttendeeContactImportServiceApplyTests
                     AttendeeImportOutcome.CreateNewUser, null, null, null, null),
             }, 2);
 
-        var result = await harness.Service.ApplyAsync(plan, new HashSet<Guid> { failId, okId });
+        var result = await harness.Service.ApplyAsync(plan, new HashSet<Guid> { failId, okId }, Guid.NewGuid());
 
         result.Errors.Should().Be(1);
         result.UsersCreated.Should().Be(1);

--- a/tests/Humans.Application.Tests/Services/Tickets/AttendeeContactImportServiceApplyTests.cs
+++ b/tests/Humans.Application.Tests/Services/Tickets/AttendeeContactImportServiceApplyTests.cs
@@ -14,6 +14,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NodaTime.Testing;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 
 namespace Humans.Application.Tests.Services.Tickets;
 
@@ -153,6 +154,109 @@ public class AttendeeContactImportServiceApplyTests
             _ = harness.Provisioning.FindOrCreateUserByEmailAsync(
                 "victim@x.com", "Victim", ContactSource.TicketTailor, Arg.Any<CancellationToken>());
         });
+    }
+
+    [HumansFact]
+    public async Task Apply_OnlyProcessesSelectedAttendees()
+    {
+        var harness = new ApplyHarness();
+        var pickedId = Guid.NewGuid();
+        var skippedId = Guid.NewGuid();
+        var picked = new TicketAttendee
+        {
+            Id = pickedId, VendorTicketId = "tkt_p", VendorEventId = "evt_active",
+            AttendeeEmail = "p@x.com", Status = TicketAttendeeStatus.Valid,
+        };
+        var unselected = new TicketAttendee
+        {
+            Id = skippedId, VendorTicketId = "tkt_s", VendorEventId = "evt_active",
+            AttendeeEmail = "s@x.com", Status = TicketAttendeeStatus.Valid,
+        };
+        harness.WithUnmatched(picked);
+        harness.WithUnmatched(unselected);
+        harness.WithActiveYear(2026);
+        harness.Provisioning.FindOrCreateUserByEmailAsync(
+                Arg.Any<string>(), Arg.Any<string?>(), ContactSource.TicketTailor, Arg.Any<CancellationToken>())
+            .Returns(_ => new AccountProvisioningResult(new User { Id = Guid.NewGuid() }, true));
+
+        var plan = new AttendeeImportPlan(
+            new[]
+            {
+                new AttendeeImportDecision(pickedId, "p@x.com", "P", "tkt_p",
+                    AttendeeImportOutcome.CreateNewUser, null, null, null, null),
+                new AttendeeImportDecision(skippedId, "s@x.com", "S", "tkt_s",
+                    AttendeeImportOutcome.CreateNewUser, null, null, null, null),
+            }, 2);
+
+        var result = await harness.Service.ApplyAsync(plan, new HashSet<Guid> { pickedId });
+
+        result.TotalAttempted.Should().Be(1);
+        result.UsersCreated.Should().Be(1);
+        picked.MatchedUserId.Should().NotBeNull();
+        unselected.MatchedUserId.Should().BeNull();
+    }
+
+    [HumansFact]
+    public async Task Apply_AttendeeVanishedBetweenPlanAndApply_IsCountedAndSkipped()
+    {
+        var harness = new ApplyHarness();
+        var goneId = Guid.NewGuid();
+        // No call to harness.WithUnmatched — the re-query returns empty.
+        harness.WithActiveYear(2026);
+
+        var plan = new AttendeeImportPlan(
+            new[]
+            {
+                new AttendeeImportDecision(goneId, "g@x.com", "G", "tkt_g",
+                    AttendeeImportOutcome.CreateNewUser, null, null, null, null),
+            }, 1);
+
+        var result = await harness.Service.ApplyAsync(plan, new HashSet<Guid> { goneId });
+
+        result.VanishedBetweenPlanAndApply.Should().Be(1);
+        result.UsersCreated.Should().Be(0);
+
+        await harness.Provisioning.DidNotReceive().FindOrCreateUserByEmailAsync(
+            Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<ContactSource>(), Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task Apply_PerAttendeeFailure_DoesNotAbortBatch()
+    {
+        var harness = new ApplyHarness();
+        var failId = Guid.NewGuid();
+        var okId = Guid.NewGuid();
+        harness.WithUnmatched(new TicketAttendee
+        {
+            Id = failId, VendorTicketId = "tkt_f", VendorEventId = "evt_active",
+            AttendeeEmail = "f@x.com", Status = TicketAttendeeStatus.Valid,
+        });
+        harness.WithUnmatched(new TicketAttendee
+        {
+            Id = okId, VendorTicketId = "tkt_o", VendorEventId = "evt_active",
+            AttendeeEmail = "o@x.com", Status = TicketAttendeeStatus.Valid,
+        });
+        harness.WithActiveYear(2026);
+        harness.Provisioning.FindOrCreateUserByEmailAsync(
+                "f@x.com", Arg.Any<string?>(), ContactSource.TicketTailor, Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("boom"));
+        harness.Provisioning.FindOrCreateUserByEmailAsync(
+                "o@x.com", Arg.Any<string?>(), ContactSource.TicketTailor, Arg.Any<CancellationToken>())
+            .Returns(new AccountProvisioningResult(new User { Id = Guid.NewGuid() }, true));
+
+        var plan = new AttendeeImportPlan(
+            new[]
+            {
+                new AttendeeImportDecision(failId, "f@x.com", "F", "tkt_f",
+                    AttendeeImportOutcome.CreateNewUser, null, null, null, null),
+                new AttendeeImportDecision(okId, "o@x.com", "O", "tkt_o",
+                    AttendeeImportOutcome.CreateNewUser, null, null, null, null),
+            }, 2);
+
+        var result = await harness.Service.ApplyAsync(plan, new HashSet<Guid> { failId, okId });
+
+        result.Errors.Should().Be(1);
+        result.UsersCreated.Should().Be(1);
     }
 }
 

--- a/tests/Humans.Application.Tests/Services/Tickets/AttendeeContactImportServiceApplyTests.cs
+++ b/tests/Humans.Application.Tests/Services/Tickets/AttendeeContactImportServiceApplyTests.cs
@@ -1,0 +1,191 @@
+using AwesomeAssertions;
+using Humans.Application.Interfaces.AuditLog;
+using Humans.Application.Interfaces.Profiles;
+using Humans.Application.Interfaces.Repositories;
+using Humans.Application.Interfaces.Shifts;
+using Humans.Application.Interfaces.Tickets;
+using Humans.Application.Interfaces.Tickets.Dtos;
+using Humans.Application.Interfaces.Users;
+using Humans.Application.Services.Tickets;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using Humans.Testing;
+using Microsoft.Extensions.Logging.Abstractions;
+using NodaTime;
+using NodaTime.Testing;
+using NSubstitute;
+
+namespace Humans.Application.Tests.Services.Tickets;
+
+public class AttendeeContactImportServiceApplyTests
+{
+    [HumansFact]
+    public async Task Apply_AttachVerified_SetsMatchedUserIdAndUpserts()
+    {
+        var harness = new ApplyHarness();
+        var attendeeId = Guid.NewGuid();
+        var targetUserId = Guid.NewGuid();
+        var attendee = new TicketAttendee
+        {
+            Id = attendeeId, VendorTicketId = "tkt_v", VendorEventId = "evt_active",
+            AttendeeEmail = "jane@x.com", Status = TicketAttendeeStatus.Valid,
+            MatchedUserId = null,
+        };
+        harness.WithUnmatched(attendee);
+        harness.WithActiveYear(2026);
+
+        var plan = new AttendeeImportPlan(
+            new[]
+            {
+                new AttendeeImportDecision(
+                    attendeeId, "jane@x.com", "Jane Doe", "tkt_v",
+                    AttendeeImportOutcome.AttachVerified,
+                    TargetUserId: targetUserId,
+                    UnverifiedEmailIdToDelete: null,
+                    UnverifiedRowUserId: null,
+                    AmbiguousUserIds: null),
+            },
+            TotalUnmatched: 1);
+
+        var result = await harness.Service.ApplyAsync(plan, new HashSet<Guid> { attendeeId });
+
+        result.AttachedToExistingVerified.Should().Be(1);
+        result.UsersCreated.Should().Be(0);
+        attendee.MatchedUserId.Should().Be(targetUserId);
+
+        await harness.TicketRepo.Received(1)
+            .UpsertAttendeesAsync(Arg.Is<IReadOnlyList<TicketAttendee>>(
+                l => l.Count == 1 && l[0].Id == attendeeId), Arg.Any<CancellationToken>());
+
+        await harness.Users.Received(1).SetParticipationFromTicketSyncAsync(
+            targetUserId, 2026, ParticipationStatus.Ticketed, Arg.Any<CancellationToken>());
+
+        harness.TicketQuery.Received(1).InvalidateAfterContactImport();
+
+        await harness.Audit.Received(1).LogAsync(
+            AuditAction.TicketContactsImported,
+            "Tickets", Guid.Empty,
+            Arg.Is<string>(s => s.Contains("attached=1")),
+            nameof(AttendeeContactImportService));
+    }
+
+    [HumansFact]
+    public async Task Apply_CreateNewUser_CallsProvisioningWithAttendeeName_AndTicketTailorSource()
+    {
+        var harness = new ApplyHarness();
+        var attendeeId = Guid.NewGuid();
+        var newUserId = Guid.NewGuid();
+        var attendee = new TicketAttendee
+        {
+            Id = attendeeId, VendorTicketId = "tkt_v", VendorEventId = "evt_active",
+            AttendeeEmail = "fresh@x.com", Status = TicketAttendeeStatus.Valid,
+        };
+        harness.WithUnmatched(attendee);
+        harness.WithActiveYear(2026);
+        harness.Provisioning.FindOrCreateUserByEmailAsync(
+                "fresh@x.com", "Fresh Face", ContactSource.TicketTailor, Arg.Any<CancellationToken>())
+            .Returns(new AccountProvisioningResult(
+                new User { Id = newUserId }, Created: true));
+
+        var plan = new AttendeeImportPlan(
+            new[]
+            {
+                new AttendeeImportDecision(
+                    attendeeId, "fresh@x.com", "Fresh Face", "tkt_v",
+                    AttendeeImportOutcome.CreateNewUser,
+                    null, null, null, null),
+            },
+            1);
+
+        var result = await harness.Service.ApplyAsync(plan, new HashSet<Guid> { attendeeId });
+
+        result.UsersCreated.Should().Be(1);
+        attendee.MatchedUserId.Should().Be(newUserId);
+
+        await harness.Provisioning.Received(1).FindOrCreateUserByEmailAsync(
+            "fresh@x.com", "Fresh Face", ContactSource.TicketTailor, Arg.Any<CancellationToken>());
+
+        await harness.Users.Received(1).SetParticipationFromTicketSyncAsync(
+            newUserId, 2026, ParticipationStatus.Ticketed, Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task Apply_DeleteUnverifiedThenCreate_DeletesSquatterRowFirst()
+    {
+        var harness = new ApplyHarness();
+        var attendeeId = Guid.NewGuid();
+        var squatterId = Guid.NewGuid();
+        var squatterEmailId = Guid.NewGuid();
+        var newUserId = Guid.NewGuid();
+        var attendee = new TicketAttendee
+        {
+            Id = attendeeId, VendorTicketId = "tkt_v", VendorEventId = "evt_active",
+            AttendeeEmail = "victim@x.com", Status = TicketAttendeeStatus.Valid,
+        };
+        harness.WithUnmatched(attendee);
+        harness.WithActiveYear(2026);
+        harness.Provisioning.FindOrCreateUserByEmailAsync(
+                "victim@x.com", "Victim", ContactSource.TicketTailor, Arg.Any<CancellationToken>())
+            .Returns(new AccountProvisioningResult(new User { Id = newUserId }, true));
+
+        var plan = new AttendeeImportPlan(
+            new[]
+            {
+                new AttendeeImportDecision(
+                    attendeeId, "victim@x.com", "Victim", "tkt_v",
+                    AttendeeImportOutcome.DeleteUnverifiedThenCreate,
+                    TargetUserId: null,
+                    UnverifiedEmailIdToDelete: squatterEmailId,
+                    UnverifiedRowUserId: squatterId,
+                    AmbiguousUserIds: null),
+            },
+            1);
+
+        var result = await harness.Service.ApplyAsync(plan, new HashSet<Guid> { attendeeId });
+
+        result.UnverifiedRowsDeletedAndUserCreated.Should().Be(1);
+        result.UsersCreated.Should().Be(1);
+        attendee.MatchedUserId.Should().Be(newUserId);
+
+        Received.InOrder(() =>
+        {
+            _ = harness.UserEmails.DeleteEmailAsync(squatterId, squatterEmailId, Arg.Any<CancellationToken>());
+            _ = harness.Provisioning.FindOrCreateUserByEmailAsync(
+                "victim@x.com", "Victim", ContactSource.TicketTailor, Arg.Any<CancellationToken>());
+        });
+    }
+}
+
+internal sealed class ApplyHarness
+{
+    public ITicketRepository TicketRepo { get; } = Substitute.For<ITicketRepository>();
+    public IUserEmailService UserEmails { get; } = Substitute.For<IUserEmailService>();
+    public IAccountProvisioningService Provisioning { get; } = Substitute.For<IAccountProvisioningService>();
+    public IUserService Users { get; } = Substitute.For<IUserService>();
+    public IShiftManagementService Shifts { get; } = Substitute.For<IShiftManagementService>();
+    public ITicketQueryService TicketQuery { get; } = Substitute.For<ITicketQueryService>();
+    public IAuditLogService Audit { get; } = Substitute.For<IAuditLogService>();
+    public FakeClock Clock { get; } = new(Instant.FromUtc(2026, 5, 13, 12, 0));
+
+    private readonly List<TicketAttendee> _unmatched = new();
+
+    public ApplyHarness()
+    {
+        TicketRepo.GetSyncStateAsync(Arg.Any<CancellationToken>())
+            .Returns(new TicketSyncState { Id = 1, VendorEventId = "evt_active" });
+        TicketRepo.GetUnmatchedActiveAttendeesAsync(
+                Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(_ => _unmatched);
+    }
+
+    public void WithUnmatched(TicketAttendee a) => _unmatched.Add(a);
+
+    public void WithActiveYear(int year)
+    {
+        Shifts.GetActiveAsync().Returns(new EventSettings { Year = year, IsActive = true });
+    }
+
+    public AttendeeContactImportService Service => new(
+        TicketRepo, UserEmails, Provisioning, Users, Shifts, TicketQuery, Audit, Clock,
+        NullLogger<AttendeeContactImportService>.Instance);
+}

--- a/tests/Humans.Application.Tests/Services/Tickets/AttendeeContactImportServicePlanTests.cs
+++ b/tests/Humans.Application.Tests/Services/Tickets/AttendeeContactImportServicePlanTests.cs
@@ -1,0 +1,69 @@
+using AwesomeAssertions;
+using Humans.Application.Interfaces.AuditLog;
+using Humans.Application.Interfaces.Profiles;
+using Humans.Application.Interfaces.Repositories;
+using Humans.Application.Interfaces.Shifts;
+using Humans.Application.Interfaces.Tickets;
+using Humans.Application.Interfaces.Tickets.Dtos;
+using Humans.Application.Interfaces.Users;
+using Humans.Application.Services.Tickets;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using Humans.Testing;
+using Microsoft.Extensions.Logging.Abstractions;
+using NodaTime;
+using NodaTime.Testing;
+using NSubstitute;
+
+namespace Humans.Application.Tests.Services.Tickets;
+
+public class AttendeeContactImportServicePlanTests
+{
+    [HumansFact]
+    public async Task Plan_AttendeeWithoutEmail_ClassifiedAsSkipNoEmail()
+    {
+        var harness = new PlanHarness();
+        harness.AddUnmatched(new TicketAttendee
+        {
+            Id = Guid.NewGuid(),
+            VendorTicketId = "tkt_1",
+            AttendeeEmail = null,
+            AttendeeName = "Jane Doe",
+            Status = TicketAttendeeStatus.Valid,
+        });
+
+        var plan = await harness.Service.BuildPlanAsync();
+
+        plan.Decisions.Should().ContainSingle()
+            .Which.Outcome.Should().Be(AttendeeImportOutcome.SkipNoEmail);
+    }
+}
+
+internal sealed class PlanHarness
+{
+    public ITicketRepository TicketRepo { get; } = Substitute.For<ITicketRepository>();
+    public IUserEmailService UserEmails { get; } = Substitute.For<IUserEmailService>();
+    public IAccountProvisioningService Provisioning { get; } = Substitute.For<IAccountProvisioningService>();
+    public IUserService Users { get; } = Substitute.For<IUserService>();
+    public IShiftManagementService Shifts { get; } = Substitute.For<IShiftManagementService>();
+    public ITicketQueryService TicketQuery { get; } = Substitute.For<ITicketQueryService>();
+    public IAuditLogService Audit { get; } = Substitute.For<IAuditLogService>();
+    public FakeClock Clock { get; } = new(Instant.FromUtc(2026, 5, 13, 12, 0));
+
+    private readonly List<TicketAttendee> _unmatched = new();
+
+    public PlanHarness()
+    {
+        TicketRepo.GetSyncStateAsync(Arg.Any<CancellationToken>())
+            .Returns(new TicketSyncState { Id = 1, VendorEventId = "evt_active" });
+        TicketRepo.GetUnmatchedActiveAttendeesAsync(
+                Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(_ => _unmatched);
+    }
+
+    public void AddUnmatched(TicketAttendee a) => _unmatched.Add(a);
+
+    public AttendeeContactImportService Service => new(
+        TicketRepo, UserEmails, Provisioning, Users, Shifts, TicketQuery, Audit, Clock,
+        NullLogger<AttendeeContactImportService>.Instance);
+}

--- a/tests/Humans.Application.Tests/Services/Tickets/AttendeeContactImportServicePlanTests.cs
+++ b/tests/Humans.Application.Tests/Services/Tickets/AttendeeContactImportServicePlanTests.cs
@@ -37,6 +37,76 @@ public class AttendeeContactImportServicePlanTests
         plan.Decisions.Should().ContainSingle()
             .Which.Outcome.Should().Be(AttendeeImportOutcome.SkipNoEmail);
     }
+
+    [HumansFact]
+    public async Task Plan_SingleVerifiedMatch_ClassifiedAsAttachVerified()
+    {
+        var harness = new PlanHarness();
+        var userId = Guid.NewGuid();
+        harness.AddUnmatched(new TicketAttendee
+        {
+            Id = Guid.NewGuid(), VendorTicketId = "tkt_v",
+            AttendeeEmail = "jane@x.com", AttendeeName = "Jane Doe",
+            Status = TicketAttendeeStatus.Valid,
+        });
+        harness.UserEmails.GetDistinctVerifiedUserIdsAsync("jane@x.com", Arg.Any<CancellationToken>())
+            .Returns(new[] { userId });
+        harness.Users.GetByIdAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(new User { Id = userId, MergedToUserId = null });
+
+        var plan = await harness.Service.BuildPlanAsync();
+
+        var decision = plan.Decisions.Single();
+        decision.Outcome.Should().Be(AttendeeImportOutcome.AttachVerified);
+        decision.TargetUserId.Should().Be(userId);
+        decision.AttendeeName.Should().Be("Jane Doe");
+    }
+
+    [HumansFact]
+    public async Task Plan_AttachVerified_FollowsMergedTombstone()
+    {
+        var harness = new PlanHarness();
+        var deadId = Guid.NewGuid();
+        var liveId = Guid.NewGuid();
+        harness.AddUnmatched(new TicketAttendee
+        {
+            Id = Guid.NewGuid(), VendorTicketId = "tkt_v",
+            AttendeeEmail = "jane@x.com", AttendeeName = "Jane",
+            Status = TicketAttendeeStatus.Valid,
+        });
+        harness.UserEmails.GetDistinctVerifiedUserIdsAsync("jane@x.com", Arg.Any<CancellationToken>())
+            .Returns(new[] { deadId });
+        harness.Users.GetByIdAsync(deadId, Arg.Any<CancellationToken>())
+            .Returns(new User { Id = deadId, MergedToUserId = liveId });
+        harness.Users.GetByIdAsync(liveId, Arg.Any<CancellationToken>())
+            .Returns(new User { Id = liveId, MergedToUserId = null });
+
+        var plan = await harness.Service.BuildPlanAsync();
+
+        plan.Decisions.Single().TargetUserId.Should().Be(liveId);
+    }
+
+    [HumansFact]
+    public async Task Plan_MultipleVerifiedMatches_ClassifiedAsAmbiguous()
+    {
+        var harness = new PlanHarness();
+        var u1 = Guid.NewGuid();
+        var u2 = Guid.NewGuid();
+        harness.AddUnmatched(new TicketAttendee
+        {
+            Id = Guid.NewGuid(), VendorTicketId = "tkt_v",
+            AttendeeEmail = "shared@x.com",
+            Status = TicketAttendeeStatus.Valid,
+        });
+        harness.UserEmails.GetDistinctVerifiedUserIdsAsync("shared@x.com", Arg.Any<CancellationToken>())
+            .Returns(new[] { u1, u2 });
+
+        var plan = await harness.Service.BuildPlanAsync();
+
+        var decision = plan.Decisions.Single();
+        decision.Outcome.Should().Be(AttendeeImportOutcome.AmbiguousMultipleVerified);
+        decision.AmbiguousUserIds.Should().BeEquivalentTo(new[] { u1, u2 });
+    }
 }
 
 internal sealed class PlanHarness

--- a/tests/Humans.Application.Tests/Services/Tickets/AttendeeContactImportServicePlanTests.cs
+++ b/tests/Humans.Application.Tests/Services/Tickets/AttendeeContactImportServicePlanTests.cs
@@ -45,8 +45,10 @@ public class AttendeeContactImportServicePlanTests
         var userId = Guid.NewGuid();
         harness.AddUnmatched(new TicketAttendee
         {
-            Id = Guid.NewGuid(), VendorTicketId = "tkt_v",
-            AttendeeEmail = "jane@x.com", AttendeeName = "Jane Doe",
+            Id = Guid.NewGuid(),
+            VendorTicketId = "tkt_v",
+            AttendeeEmail = "jane@x.com",
+            AttendeeName = "Jane Doe",
             Status = TicketAttendeeStatus.Valid,
         });
         harness.UserEmails.GetDistinctVerifiedUserIdsAsync("jane@x.com", Arg.Any<CancellationToken>())
@@ -70,8 +72,10 @@ public class AttendeeContactImportServicePlanTests
         var liveId = Guid.NewGuid();
         harness.AddUnmatched(new TicketAttendee
         {
-            Id = Guid.NewGuid(), VendorTicketId = "tkt_v",
-            AttendeeEmail = "jane@x.com", AttendeeName = "Jane",
+            Id = Guid.NewGuid(),
+            VendorTicketId = "tkt_v",
+            AttendeeEmail = "jane@x.com",
+            AttendeeName = "Jane",
             Status = TicketAttendeeStatus.Valid,
         });
         harness.UserEmails.GetDistinctVerifiedUserIdsAsync("jane@x.com", Arg.Any<CancellationToken>())
@@ -94,8 +98,10 @@ public class AttendeeContactImportServicePlanTests
         var unverifiedRowId = Guid.NewGuid();
         harness.AddUnmatched(new TicketAttendee
         {
-            Id = Guid.NewGuid(), VendorTicketId = "tkt_v",
-            AttendeeEmail = "victim@x.com", AttendeeName = "Victim",
+            Id = Guid.NewGuid(),
+            VendorTicketId = "tkt_v",
+            AttendeeEmail = "victim@x.com",
+            AttendeeName = "Victim",
             Status = TicketAttendeeStatus.Valid,
         });
         harness.UserEmails.GetDistinctVerifiedUserIdsAsync("victim@x.com", Arg.Any<CancellationToken>())
@@ -117,8 +123,10 @@ public class AttendeeContactImportServicePlanTests
         var harness = new PlanHarness();
         harness.AddUnmatched(new TicketAttendee
         {
-            Id = Guid.NewGuid(), VendorTicketId = "tkt_v",
-            AttendeeEmail = "fresh@x.com", AttendeeName = "Fresh Face",
+            Id = Guid.NewGuid(),
+            VendorTicketId = "tkt_v",
+            AttendeeEmail = "fresh@x.com",
+            AttendeeName = "Fresh Face",
             Status = TicketAttendeeStatus.Valid,
         });
         harness.UserEmails.GetDistinctVerifiedUserIdsAsync("fresh@x.com", Arg.Any<CancellationToken>())
@@ -141,7 +149,8 @@ public class AttendeeContactImportServicePlanTests
         var u2 = Guid.NewGuid();
         harness.AddUnmatched(new TicketAttendee
         {
-            Id = Guid.NewGuid(), VendorTicketId = "tkt_v",
+            Id = Guid.NewGuid(),
+            VendorTicketId = "tkt_v",
             AttendeeEmail = "shared@x.com",
             Status = TicketAttendeeStatus.Valid,
         });

--- a/tests/Humans.Application.Tests/Services/Tickets/AttendeeContactImportServicePlanTests.cs
+++ b/tests/Humans.Application.Tests/Services/Tickets/AttendeeContactImportServicePlanTests.cs
@@ -87,6 +87,53 @@ public class AttendeeContactImportServicePlanTests
     }
 
     [HumansFact]
+    public async Task Plan_UnverifiedMatchOnly_ClassifiedAsDeleteUnverifiedThenCreate()
+    {
+        var harness = new PlanHarness();
+        var squatterUserId = Guid.NewGuid();
+        var unverifiedRowId = Guid.NewGuid();
+        harness.AddUnmatched(new TicketAttendee
+        {
+            Id = Guid.NewGuid(), VendorTicketId = "tkt_v",
+            AttendeeEmail = "victim@x.com", AttendeeName = "Victim",
+            Status = TicketAttendeeStatus.Valid,
+        });
+        harness.UserEmails.GetDistinctVerifiedUserIdsAsync("victim@x.com", Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<Guid>());
+        harness.UserEmails.FindAnyEmailRowByAddressAsync("victim@x.com", Arg.Any<CancellationToken>())
+            .Returns((squatterUserId, unverifiedRowId));
+
+        var plan = await harness.Service.BuildPlanAsync();
+
+        var decision = plan.Decisions.Single();
+        decision.Outcome.Should().Be(AttendeeImportOutcome.DeleteUnverifiedThenCreate);
+        decision.UnverifiedRowUserId.Should().Be(squatterUserId);
+        decision.UnverifiedEmailIdToDelete.Should().Be(unverifiedRowId);
+    }
+
+    [HumansFact]
+    public async Task Plan_NoUserEmailMatch_ClassifiedAsCreateNewUser()
+    {
+        var harness = new PlanHarness();
+        harness.AddUnmatched(new TicketAttendee
+        {
+            Id = Guid.NewGuid(), VendorTicketId = "tkt_v",
+            AttendeeEmail = "fresh@x.com", AttendeeName = "Fresh Face",
+            Status = TicketAttendeeStatus.Valid,
+        });
+        harness.UserEmails.GetDistinctVerifiedUserIdsAsync("fresh@x.com", Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<Guid>());
+        harness.UserEmails.FindAnyEmailRowByAddressAsync("fresh@x.com", Arg.Any<CancellationToken>())
+            .Returns(((Guid, Guid)?)null);
+
+        var plan = await harness.Service.BuildPlanAsync();
+
+        var decision = plan.Decisions.Single();
+        decision.Outcome.Should().Be(AttendeeImportOutcome.CreateNewUser);
+        decision.AttendeeName.Should().Be("Fresh Face");
+    }
+
+    [HumansFact]
     public async Task Plan_MultipleVerifiedMatches_ClassifiedAsAmbiguous()
     {
         var harness = new PlanHarness();

--- a/tests/Humans.Application.Tests/Services/Tickets/AttendeeContactImportServiceSquatterTests.cs
+++ b/tests/Humans.Application.Tests/Services/Tickets/AttendeeContactImportServiceSquatterTests.cs
@@ -20,8 +20,11 @@ public class AttendeeContactImportServiceSquatterTests
         var newVictimUserId = Guid.NewGuid();
         var attendee = new TicketAttendee
         {
-            Id = attendeeId, VendorTicketId = "tkt_v", VendorEventId = "evt_active",
-            AttendeeEmail = "victim@x.com", AttendeeName = "Victim",
+            Id = attendeeId,
+            VendorTicketId = "tkt_v",
+            VendorEventId = "evt_active",
+            AttendeeEmail = "victim@x.com",
+            AttendeeName = "Victim",
             Status = TicketAttendeeStatus.Valid,
         };
         harness.WithUnmatched(attendee);
@@ -39,7 +42,7 @@ public class AttendeeContactImportServiceSquatterTests
                     null, squatterRowId, squatterUserId, null),
             }, 1);
 
-        await harness.Service.ApplyAsync(plan, new HashSet<Guid> { attendeeId });
+        await harness.Service.ApplyAsync(plan, new HashSet<Guid> { attendeeId }, Guid.NewGuid());
 
         // 1. Squatter row deleted.
         await harness.UserEmails.Received(1)

--- a/tests/Humans.Application.Tests/Services/Tickets/AttendeeContactImportServiceSquatterTests.cs
+++ b/tests/Humans.Application.Tests/Services/Tickets/AttendeeContactImportServiceSquatterTests.cs
@@ -1,0 +1,60 @@
+using AwesomeAssertions;
+using Humans.Application.Interfaces.Tickets.Dtos;
+using Humans.Application.Interfaces.Users;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using Humans.Testing;
+using NSubstitute;
+
+namespace Humans.Application.Tests.Services.Tickets;
+
+public class AttendeeContactImportServiceSquatterTests
+{
+    [HumansFact]
+    public async Task Squatter_UnverifiedRowDeletedBeforeNewUserCreated_NewUserNotAttachedToSquatter()
+    {
+        var harness = new ApplyHarness();
+        var attendeeId = Guid.NewGuid();
+        var squatterUserId = Guid.NewGuid();
+        var squatterRowId = Guid.NewGuid();
+        var newVictimUserId = Guid.NewGuid();
+        var attendee = new TicketAttendee
+        {
+            Id = attendeeId, VendorTicketId = "tkt_v", VendorEventId = "evt_active",
+            AttendeeEmail = "victim@x.com", AttendeeName = "Victim",
+            Status = TicketAttendeeStatus.Valid,
+        };
+        harness.WithUnmatched(attendee);
+        harness.WithActiveYear(2026);
+        harness.Provisioning.FindOrCreateUserByEmailAsync(
+                "victim@x.com", Arg.Any<string?>(), ContactSource.TicketTailor, Arg.Any<CancellationToken>())
+            .Returns(new AccountProvisioningResult(new User { Id = newVictimUserId }, Created: true));
+
+        var plan = new AttendeeImportPlan(
+            new[]
+            {
+                new AttendeeImportDecision(
+                    attendeeId, "victim@x.com", "Victim", "tkt_v",
+                    AttendeeImportOutcome.DeleteUnverifiedThenCreate,
+                    null, squatterRowId, squatterUserId, null),
+            }, 1);
+
+        await harness.Service.ApplyAsync(plan, new HashSet<Guid> { attendeeId });
+
+        // 1. Squatter row deleted.
+        await harness.UserEmails.Received(1)
+            .DeleteEmailAsync(squatterUserId, squatterRowId, Arg.Any<CancellationToken>());
+
+        // 2. New user created — NOT attached to squatter.
+        attendee.MatchedUserId.Should().Be(newVictimUserId);
+        attendee.MatchedUserId.Should().NotBe(squatterUserId);
+
+        // 3. Delete happened before create.
+        Received.InOrder(() =>
+        {
+            _ = harness.UserEmails.DeleteEmailAsync(squatterUserId, squatterRowId, Arg.Any<CancellationToken>());
+            _ = harness.Provisioning.FindOrCreateUserByEmailAsync(
+                "victim@x.com", Arg.Any<string?>(), ContactSource.TicketTailor, Arg.Any<CancellationToken>());
+        });
+    }
+}

--- a/tests/Humans.Application.Tests/Services/Tickets/AttendeeImportResultTests.cs
+++ b/tests/Humans.Application.Tests/Services/Tickets/AttendeeImportResultTests.cs
@@ -1,0 +1,35 @@
+using AwesomeAssertions;
+using Humans.Application.Interfaces.Tickets.Dtos;
+using Humans.Testing;
+using NodaTime;
+
+namespace Humans.Application.Tests.Services.Tickets;
+
+public class AttendeeImportResultTests
+{
+    [HumansFact]
+    public void FormatSummary_IncludesAllCounters()
+    {
+        var result = new AttendeeImportResult(
+            TotalAttempted: 100,
+            UsersCreated: 60,
+            AttachedToExistingVerified: 30,
+            UnverifiedRowsDeletedAndUserCreated: 5,
+            AmbiguousSkipped: 2,
+            NoEmailSkipped: 3,
+            VanishedBetweenPlanAndApply: 1,
+            Errors: 0,
+            Elapsed: Duration.FromSeconds(12));
+
+        var summary = result.FormatSummary();
+
+        summary.Should().Contain("created=60");
+        summary.Should().Contain("attached=30");
+        summary.Should().Contain("unverified-replaced=5");
+        summary.Should().Contain("ambiguous=2");
+        summary.Should().Contain("no-email=3");
+        summary.Should().Contain("vanished=1");
+        summary.Should().Contain("errors=0");
+        summary.Should().Contain("12000ms");
+    }
+}

--- a/tests/Humans.Web.Tests/Controllers/TicketsContactsAdminControllerTests.cs
+++ b/tests/Humans.Web.Tests/Controllers/TicketsContactsAdminControllerTests.cs
@@ -3,12 +3,16 @@ using Humans.Application.Interfaces.Tickets;
 using Humans.Application.Interfaces.Tickets.Dtos;
 using Humans.Domain.Entities;
 using Humans.Testing;
+using Humans.Web.Constants;
 using Humans.Web.Controllers;
 using Humans.Web.Models.Tickets;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.Routing;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using NodaTime;
 using NSubstitute;
@@ -24,14 +28,29 @@ public class TicketsContactsAdminControllerTests
             userStore, null, null, null, null, null, null, null, null);
     }
 
-    private static TicketsContactsAdminController NewController(IAttendeeContactImportService import)
+    private static (TicketsContactsAdminController Ctrl, User CurrentUser, UserManager<User> Um)
+        NewController(IAttendeeContactImportService import)
     {
+        var um = NoOpUserManager();
+        var currentUser = new User { Id = Guid.NewGuid() };
+        um.GetUserAsync(Arg.Any<System.Security.Claims.ClaimsPrincipal>()).Returns(currentUser);
+
         var ctrl = new TicketsContactsAdminController(
-            import, NoOpUserManager(),
+            import, um,
             NullLogger<TicketsContactsAdminController>.Instance);
-        var http = new DefaultHttpContext();
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        var http = new DefaultHttpContext { RequestServices = services.BuildServiceProvider() };
+
+        ctrl.ControllerContext = new ControllerContext
+        {
+            HttpContext = http,
+            ActionDescriptor = new ControllerActionDescriptor { ActionName = "Test" },
+        };
         ctrl.TempData = new TempDataDictionary(http, Substitute.For<ITempDataProvider>());
-        return ctrl;
+        ctrl.Url = Substitute.For<IUrlHelper>();
+        return (ctrl, currentUser, um);
     }
 
     [HumansFact]
@@ -47,7 +66,7 @@ public class TicketsContactsAdminControllerTests
             }, 1);
         import.BuildPlanAsync(Arg.Any<CancellationToken>()).Returns(plan);
 
-        var controller = NewController(import);
+        var (controller, _, _) = NewController(import);
 
         var result = await controller.Index(default);
 
@@ -59,45 +78,46 @@ public class TicketsContactsAdminControllerTests
     }
 
     [HumansFact]
-    public async Task Apply_PassesSelectedIdsToService_AndRedirectsWithBanner()
+    public async Task Apply_PassesSelectedIdsAndActorToService_AndRedirectsWithInfoMessage()
     {
         var import = Substitute.For<IAttendeeContactImportService>();
         var plan = new AttendeeImportPlan(Array.Empty<AttendeeImportDecision>(), 0);
         import.BuildPlanAsync(Arg.Any<CancellationToken>()).Returns(plan);
         import.ApplyAsync(Arg.Any<AttendeeImportPlan>(),
-                Arg.Any<IReadOnlySet<Guid>>(), Arg.Any<CancellationToken>())
+                Arg.Any<IReadOnlySet<Guid>>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>())
             .Returns(new AttendeeImportResult(
                 TotalAttempted: 1, UsersCreated: 1, AttachedToExistingVerified: 0,
                 UnverifiedRowsDeletedAndUserCreated: 0, AmbiguousSkipped: 0, NoEmailSkipped: 0,
                 VanishedBetweenPlanAndApply: 0, Errors: 0,
                 Elapsed: Duration.FromSeconds(1)));
 
-        var controller = NewController(import);
+        var (controller, currentUser, _) = NewController(import);
 
         var selectedId = Guid.NewGuid();
         var result = await controller.Apply(new[] { selectedId }, default);
 
         result.Should().BeOfType<RedirectToActionResult>()
             .Which.ActionName.Should().Be(nameof(TicketsContactsAdminController.Index));
-        controller.TempData["Banner"].Should().NotBeNull();
+        controller.TempData[TempDataKeys.InfoMessage].Should().NotBeNull();
 
         await import.Received(1).ApplyAsync(
             plan,
             Arg.Is<IReadOnlySet<Guid>>(s => s.Contains(selectedId) && s.Count == 1),
+            currentUser.Id,
             Arg.Any<CancellationToken>());
     }
 
     [HumansFact]
-    public async Task Apply_EmptySelection_RedirectsWithValidationBanner_NoServiceCall()
+    public async Task Apply_EmptySelection_RedirectsWithErrorMessage_NoServiceCall()
     {
         var import = Substitute.For<IAttendeeContactImportService>();
-        var controller = NewController(import);
+        var (controller, _, _) = NewController(import);
 
         var result = await controller.Apply(Array.Empty<Guid>(), default);
 
         result.Should().BeOfType<RedirectToActionResult>();
-        controller.TempData["Banner"].Should().NotBeNull();
+        controller.TempData[TempDataKeys.ErrorMessage].Should().NotBeNull();
         await import.DidNotReceive().ApplyAsync(
-            Arg.Any<AttendeeImportPlan>(), Arg.Any<IReadOnlySet<Guid>>(), Arg.Any<CancellationToken>());
+            Arg.Any<AttendeeImportPlan>(), Arg.Any<IReadOnlySet<Guid>>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>());
     }
 }

--- a/tests/Humans.Web.Tests/Controllers/TicketsContactsAdminControllerTests.cs
+++ b/tests/Humans.Web.Tests/Controllers/TicketsContactsAdminControllerTests.cs
@@ -1,0 +1,49 @@
+using AwesomeAssertions;
+using Humans.Application.Interfaces.Tickets;
+using Humans.Application.Interfaces.Tickets.Dtos;
+using Humans.Domain.Entities;
+using Humans.Testing;
+using Humans.Web.Controllers;
+using Humans.Web.Models.Tickets;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace Humans.Web.Tests.Controllers;
+
+public class TicketsContactsAdminControllerTests
+{
+    private static UserManager<User> NoOpUserManager()
+    {
+        var userStore = Substitute.For<IUserStore<User>>();
+        return Substitute.For<UserManager<User>>(
+            userStore, null, null, null, null, null, null, null, null);
+    }
+
+    [HumansFact]
+    public async Task Index_RendersPreview_WithPlanAndProjectedRows()
+    {
+        var import = Substitute.For<IAttendeeContactImportService>();
+        var attendeeId = Guid.NewGuid();
+        var plan = new AttendeeImportPlan(
+            new[]
+            {
+                new AttendeeImportDecision(attendeeId, "a@x.com", "A", "tkt_a",
+                    AttendeeImportOutcome.CreateNewUser, null, null, null, null),
+            }, 1);
+        import.BuildPlanAsync(Arg.Any<CancellationToken>()).Returns(plan);
+
+        var controller = new TicketsContactsAdminController(
+            import, NoOpUserManager(),
+            NullLogger<TicketsContactsAdminController>.Instance);
+
+        var result = await controller.Index(default);
+
+        var view = result.Should().BeOfType<ViewResult>().Subject;
+        var vm = view.Model.Should().BeOfType<ContactImportPreviewViewModel>().Subject;
+        vm.Plan.Should().BeSameAs(plan);
+        vm.Rows.Should().ContainSingle()
+            .Which.AttendeeId.Should().Be(attendeeId);
+    }
+}

--- a/tests/Humans.Web.Tests/Controllers/TicketsContactsAdminControllerTests.cs
+++ b/tests/Humans.Web.Tests/Controllers/TicketsContactsAdminControllerTests.cs
@@ -5,9 +5,12 @@ using Humans.Domain.Entities;
 using Humans.Testing;
 using Humans.Web.Controllers;
 using Humans.Web.Models.Tickets;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.Extensions.Logging.Abstractions;
+using NodaTime;
 using NSubstitute;
 
 namespace Humans.Web.Tests.Controllers;
@@ -19,6 +22,16 @@ public class TicketsContactsAdminControllerTests
         var userStore = Substitute.For<IUserStore<User>>();
         return Substitute.For<UserManager<User>>(
             userStore, null, null, null, null, null, null, null, null);
+    }
+
+    private static TicketsContactsAdminController NewController(IAttendeeContactImportService import)
+    {
+        var ctrl = new TicketsContactsAdminController(
+            import, NoOpUserManager(),
+            NullLogger<TicketsContactsAdminController>.Instance);
+        var http = new DefaultHttpContext();
+        ctrl.TempData = new TempDataDictionary(http, Substitute.For<ITempDataProvider>());
+        return ctrl;
     }
 
     [HumansFact]
@@ -34,9 +47,7 @@ public class TicketsContactsAdminControllerTests
             }, 1);
         import.BuildPlanAsync(Arg.Any<CancellationToken>()).Returns(plan);
 
-        var controller = new TicketsContactsAdminController(
-            import, NoOpUserManager(),
-            NullLogger<TicketsContactsAdminController>.Instance);
+        var controller = NewController(import);
 
         var result = await controller.Index(default);
 
@@ -45,5 +56,48 @@ public class TicketsContactsAdminControllerTests
         vm.Plan.Should().BeSameAs(plan);
         vm.Rows.Should().ContainSingle()
             .Which.AttendeeId.Should().Be(attendeeId);
+    }
+
+    [HumansFact]
+    public async Task Apply_PassesSelectedIdsToService_AndRedirectsWithBanner()
+    {
+        var import = Substitute.For<IAttendeeContactImportService>();
+        var plan = new AttendeeImportPlan(Array.Empty<AttendeeImportDecision>(), 0);
+        import.BuildPlanAsync(Arg.Any<CancellationToken>()).Returns(plan);
+        import.ApplyAsync(Arg.Any<AttendeeImportPlan>(),
+                Arg.Any<IReadOnlySet<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(new AttendeeImportResult(
+                TotalAttempted: 1, UsersCreated: 1, AttachedToExistingVerified: 0,
+                UnverifiedRowsDeletedAndUserCreated: 0, AmbiguousSkipped: 0, NoEmailSkipped: 0,
+                VanishedBetweenPlanAndApply: 0, Errors: 0,
+                Elapsed: Duration.FromSeconds(1)));
+
+        var controller = NewController(import);
+
+        var selectedId = Guid.NewGuid();
+        var result = await controller.Apply(new[] { selectedId }, default);
+
+        result.Should().BeOfType<RedirectToActionResult>()
+            .Which.ActionName.Should().Be(nameof(TicketsContactsAdminController.Index));
+        controller.TempData["Banner"].Should().NotBeNull();
+
+        await import.Received(1).ApplyAsync(
+            plan,
+            Arg.Is<IReadOnlySet<Guid>>(s => s.Contains(selectedId) && s.Count == 1),
+            Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task Apply_EmptySelection_RedirectsWithValidationBanner_NoServiceCall()
+    {
+        var import = Substitute.For<IAttendeeContactImportService>();
+        var controller = NewController(import);
+
+        var result = await controller.Apply(Array.Empty<Guid>(), default);
+
+        result.Should().BeOfType<RedirectToActionResult>();
+        controller.TempData["Banner"].Should().NotBeNull();
+        await import.DidNotReceive().ApplyAsync(
+            Arg.Any<AttendeeImportPlan>(), Arg.Any<IReadOnlySet<Guid>>(), Arg.Any<CancellationToken>());
     }
 }


### PR DESCRIPTION
## Summary
- New manually-triggered admin job that creates Humans users from unmatched ticket attendees, mirroring the Mailer plan/apply pattern.
- Squatter protection: unverified UserEmail rows are deleted before provisioning a new user with a verified row.
- Per-row checkbox preview at `/Tickets/Admin/Contacts` — admin can test against a single attendee before bulk-applying.
- Wires `EventParticipation(Ticketed, TicketSync)` immediately for newly-matched users (no wait for next sync).

Spec: `docs/superpowers/specs/2026-05-13-ticket-attendee-contact-import-design.md`
Plan: `docs/superpowers/plans/2026-05-13-ticket-attendee-contact-import.md`

## Test plan
- [ ] Build + Application/Web/Domain/Architecture test suites green (3011 passed locally)
- [ ] Smoke: visit `/Tickets/Admin/Contacts` in dev, confirm preview renders
- [ ] Smoke: select 1 attendee, apply, confirm result banner + new user appears under `/Admin/Users`
- [ ] Smoke: select all, apply, confirm remaining attendees matched and `Volunteer Ticket Coverage` denominator on `/Tickets` updates

Note: integration tests (TestContainers/Postgres) require Docker and a working test environment; they were not run in this branch's local validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)