### PR TITLE
Enrich /Tickets/Admin/Transfers/Detail with full context + approval walkthrough

### DIFF
--- a/src/Humans.Application/DTOs/TicketTransferDtos.cs
+++ b/src/Humans.Application/DTOs/TicketTransferDtos.cs
@@ -65,8 +65,7 @@ public sealed record TicketTransferDetailDto(
     string OrderVendorId,
     Instant OrderPurchasedAt,
     string OrderBuyerEmail,
-    int TicketIndexInOrder,
-    int TicketCountInOrder);
+    IReadOnlyList<string> SiblingVendorTicketIds);
 
 /// <summary>
 /// One row in the homepage "My tickets" attendee list, with eligibility flags

--- a/src/Humans.Application/DTOs/TicketTransferDtos.cs
+++ b/src/Humans.Application/DTOs/TicketTransferDtos.cs
@@ -59,7 +59,14 @@ public sealed record TicketTransferDetailDto(
     ReceiverLookupResultDto SenderCard,
     ReceiverLookupResultDto ReceiverCard,
     string? OrderDashboardUrl,
-    string VendorStepsJson);
+    string VendorStepsJson,
+    string OriginalAttendeeVendorTicketId,
+    string? OriginalAttendeeEmail,
+    string OrderVendorId,
+    Instant OrderPurchasedAt,
+    string OrderBuyerEmail,
+    int TicketIndexInOrder,
+    int TicketCountInOrder);
 
 /// <summary>
 /// One row in the homepage "My tickets" attendee list, with eligibility flags

--- a/src/Humans.Application/Services/Tickets/TicketTransferService.cs
+++ b/src/Humans.Application/Services/Tickets/TicketTransferService.cs
@@ -361,13 +361,8 @@ public sealed class TicketTransferService : ITicketTransferService
         var attendee = await _ticketRepo.GetAttendeeByIdAsync(request.OriginalTicketAttendeeId, ct);
 
         var order = attendee?.TicketOrder;
-        var siblings = order?.Attendees
-            .OrderBy(a => a.VendorTicketId, StringComparer.Ordinal)
-            .ToList()
-            ?? new List<TicketAttendee>();
-        var indexInOrder = attendee is null
-            ? 0
-            : siblings.FindIndex(a => a.Id == attendee.Id) + 1;
+        var siblingIds = order?.Attendees.Select(a => a.VendorTicketId).ToList()
+            ?? new List<string>();
 
         // Cards fall back to a minimal stub if a profile somehow can't be built
         // (e.g. user soft-deleted between request and admin review). The row's
@@ -383,8 +378,7 @@ public sealed class TicketTransferService : ITicketTransferService
             OrderVendorId: order?.VendorOrderId ?? string.Empty,
             OrderPurchasedAt: order?.PurchasedAt ?? Instant.MinValue,
             OrderBuyerEmail: order?.BuyerEmail ?? string.Empty,
-            TicketIndexInOrder: indexInOrder,
-            TicketCountInOrder: siblings.Count);
+            SiblingVendorTicketIds: siblingIds);
     }
 
     private static ReceiverLookupResultDto StubCard(Guid userId, string displayName) =>

--- a/src/Humans.Application/Services/Tickets/TicketTransferService.cs
+++ b/src/Humans.Application/Services/Tickets/TicketTransferService.cs
@@ -360,6 +360,15 @@ public sealed class TicketTransferService : ITicketTransferService
 
         var attendee = await _ticketRepo.GetAttendeeByIdAsync(request.OriginalTicketAttendeeId, ct);
 
+        var order = attendee?.TicketOrder;
+        var siblings = order?.Attendees
+            .OrderBy(a => a.VendorTicketId, StringComparer.Ordinal)
+            .ToList()
+            ?? new List<TicketAttendee>();
+        var indexInOrder = attendee is null
+            ? 0
+            : siblings.FindIndex(a => a.Id == attendee.Id) + 1;
+
         // Cards fall back to a minimal stub if a profile somehow can't be built
         // (e.g. user soft-deleted between request and admin review). The row's
         // snapshot fields still carry the names we need.
@@ -367,8 +376,15 @@ public sealed class TicketTransferService : ITicketTransferService
             Row: row,
             SenderCard: senderCard ?? StubCard(request.SenderUserId, row.SenderDisplayName),
             ReceiverCard: receiverCard ?? StubCard(request.ReceiverUserId, row.ReceiverLegalName),
-            OrderDashboardUrl: attendee?.TicketOrder?.VendorDashboardUrl,
-            VendorStepsJson: request.VendorStepsJson);
+            OrderDashboardUrl: order?.VendorDashboardUrl,
+            VendorStepsJson: request.VendorStepsJson,
+            OriginalAttendeeVendorTicketId: attendee?.VendorTicketId ?? string.Empty,
+            OriginalAttendeeEmail: attendee?.AttendeeEmail,
+            OrderVendorId: order?.VendorOrderId ?? string.Empty,
+            OrderPurchasedAt: order?.PurchasedAt ?? Instant.MinValue,
+            OrderBuyerEmail: order?.BuyerEmail ?? string.Empty,
+            TicketIndexInOrder: indexInOrder,
+            TicketCountInOrder: siblings.Count);
     }
 
     private static ReceiverLookupResultDto StubCard(Guid userId, string displayName) =>

--- a/src/Humans.Infrastructure/Repositories/Tickets/TicketRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Tickets/TicketRepository.cs
@@ -172,6 +172,7 @@ public sealed class TicketRepository : ITicketRepository
         return await ctx.TicketAttendees
             .AsNoTracking()
             .Include(a => a.TicketOrder)
+                .ThenInclude(o => o.Attendees)
             .FirstOrDefaultAsync(a => a.Id == attendeeId, ct);
     }
 

--- a/src/Humans.Web/ViewComponents/HumanSummaryViewComponent.cs
+++ b/src/Humans.Web/ViewComponents/HumanSummaryViewComponent.cs
@@ -1,0 +1,104 @@
+using Humans.Application.Interfaces.Profiles;
+using Humans.Application.Interfaces.Teams;
+using Humans.Application.Interfaces.Users;
+using Humans.Web.Controllers;
+using Humans.Web.Helpers;
+using Humans.Web.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Humans.Web.ViewComponents;
+
+/// <summary>
+/// Renders the same content as the hover popover (<c>_HumanPopover.cshtml</c>)
+/// inline — avatar, name, membership badge, city/country, public teams +
+/// (admin-only) hidden teams, and languages. Use on admin-review screens
+/// (e.g. ticket-transfer detail) where the reviewer needs identity context
+/// without having to hover.
+/// </summary>
+public sealed class HumanSummaryViewComponent : ViewComponent
+{
+    private readonly IUserService _userService;
+    private readonly IProfileService _profileService;
+    private readonly IUserEmailService _userEmailService;
+    private readonly ITeamService _teamService;
+
+    public HumanSummaryViewComponent(
+        IUserService userService,
+        IProfileService profileService,
+        IUserEmailService userEmailService,
+        ITeamService teamService)
+    {
+        _userService = userService;
+        _profileService = profileService;
+        _userEmailService = userEmailService;
+        _teamService = teamService;
+    }
+
+    public async Task<IViewComponentResult> InvokeAsync(Guid userId)
+    {
+        var user = await _userService.GetByIdAsync(userId);
+        if (user is null)
+        {
+            return View("Default", new ProfileSummaryViewModel
+            {
+                UserId = userId,
+                DisplayName = "(unknown)",
+                HasProfile = false,
+            });
+        }
+
+        var profile = await _profileService.GetProfileAsync(userId);
+        if (profile is null)
+        {
+            var userEmails = await _userEmailService.GetUserEmailsAsync(userId);
+            var fallbackEmail = userEmails.FirstOrDefault(e => e.IsVerified && e.IsPrimary)?.Email
+                ?? userEmails.FirstOrDefault(e => e.IsVerified)?.Email;
+            return View("Default", new ProfileSummaryViewModel
+            {
+                UserId = userId,
+                DisplayName = user.DisplayName,
+                Email = fallbackEmail,
+                ProfilePictureUrl = user.ProfilePictureUrl,
+                PreferredLanguage = user.PreferredLanguage,
+                HasProfile = false,
+            });
+        }
+
+        var memberships = (await _teamService.GetActiveTeamMembershipsForUserAsync(userId))
+            .OrderBy(m => m.TeamName, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        var publicTeams = memberships.Where(m => !m.IsHidden).Select(m => m.TeamName).ToList();
+        var hiddenTeams = memberships.Where(m => m.IsHidden).Select(m => m.TeamName).ToList();
+        var profileLanguages = await _profileService.GetProfileLanguagesAsync(profile.Id);
+
+        var effectivePictureUrl = profile.HasCustomProfilePicture
+            ? Url.Action(nameof(ProfileController.Picture), "Profile",
+                new { id = profile.Id, v = profile.UpdatedAt.ToUnixTimeTicks() })
+            : user.ProfilePictureUrl;
+
+        var vm = new ProfileSummaryViewModel
+        {
+            UserId = userId,
+            DisplayName = user.DisplayName,
+            Email = user.Email,
+            ProfilePictureUrl = effectivePictureUrl,
+            PreferredLanguage = user.PreferredLanguage,
+            MembershipTier = profile.MembershipTier.ToString(),
+            MembershipStatus = profile.IsSuspended ? "Suspended"
+                : profile.IsApproved ? "Active" : "Pending",
+            City = profile.City,
+            CountryCode = profile.CountryCode,
+            IsSuspended = profile.IsSuspended,
+            Teams = publicTeams,
+            HiddenTeams = hiddenTeams,
+            Languages = profileLanguages.Select(pl => new ProfileLanguageDisplayViewModel
+            {
+                LanguageCode = pl.LanguageCode,
+                LanguageName = LanguageCatalog.GetDisplayName(pl.LanguageCode),
+                Proficiency = pl.Proficiency
+            }).ToList(),
+        };
+
+        return View("Default", vm);
+    }
+}

--- a/src/Humans.Web/ViewComponents/HumanSummaryViewComponent.cs
+++ b/src/Humans.Web/ViewComponents/HumanSummaryViewComponent.cs
@@ -79,7 +79,9 @@ public sealed class HumanSummaryViewComponent : ViewComponent
         var vm = new ProfileSummaryViewModel
         {
             UserId = userId,
-            DisplayName = user.DisplayName,
+            DisplayName = !string.IsNullOrWhiteSpace(profile.BurnerName)
+                ? profile.BurnerName
+                : user.DisplayName,
             Email = user.Email,
             ProfilePictureUrl = effectivePictureUrl,
             PreferredLanguage = user.PreferredLanguage,

--- a/src/Humans.Web/Views/Shared/Components/HumanSummary/Default.cshtml
+++ b/src/Humans.Web/Views/Shared/Components/HumanSummary/Default.cshtml
@@ -1,0 +1,3 @@
+@model Humans.Web.Models.ProfileSummaryViewModel
+
+@await Html.PartialAsync("_HumanPopover", Model)

--- a/src/Humans.Web/Views/TicketTransferAdmin/Detail.cshtml
+++ b/src/Humans.Web/Views/TicketTransferAdmin/Detail.cshtml
@@ -11,8 +11,12 @@
         _ => (row.OriginalAttendeeStatus.ToString(), "bg-secondary"),
     };
     var hasOrder = !string.IsNullOrEmpty(Model.OrderVendorId);
-    var ticketPosition = Model.TicketCountInOrder > 0
-        ? $"ticket #{Model.TicketIndexInOrder} of {Model.TicketCountInOrder}"
+    var orderedSiblingIds = Model.SiblingVendorTicketIds
+        .OrderBy(s => s, StringComparer.Ordinal)
+        .ToList();
+    var ticketIndex = orderedSiblingIds.IndexOf(Model.OriginalAttendeeVendorTicketId) + 1;
+    var ticketPosition = orderedSiblingIds.Count > 0 && ticketIndex > 0
+        ? $"ticket #{ticketIndex} of {orderedSiblingIds.Count}"
         : null;
 }
 

--- a/src/Humans.Web/Views/TicketTransferAdmin/Detail.cshtml
+++ b/src/Humans.Web/Views/TicketTransferAdmin/Detail.cshtml
@@ -10,6 +10,10 @@
         TicketAttendeeStatus.Void => ("Void", "bg-secondary"),
         _ => (row.OriginalAttendeeStatus.ToString(), "bg-secondary"),
     };
+    var hasOrder = !string.IsNullOrEmpty(Model.OrderVendorId);
+    var ticketPosition = Model.TicketCountInOrder > 0
+        ? $"ticket #{Model.TicketIndexInOrder} of {Model.TicketCountInOrder}"
+        : null;
 }
 
 <h1>Review transfer</h1>
@@ -18,8 +22,35 @@
 
 <div class="card mb-3">
     <div class="card-body">
-        <h2 class="h5 mb-2">Ticket</h2>
-        <div>@row.OriginalAttendeeName — @row.TicketTypeName</div>
+        <h2 class="h5 mb-2">Ticket being transferred</h2>
+        @if (hasOrder)
+        {
+            <div>
+                Order <strong>@Model.OrderVendorId</strong>
+                purchased on <strong>@Model.OrderPurchasedAt.ToDisplayDate()</strong>
+                @if (ticketPosition is not null)
+                {
+                    <text>, @ticketPosition</text>
+                }
+            </div>
+        }
+        <div>Ticket ID <strong>@Model.OriginalAttendeeVendorTicketId</strong> — @row.TicketTypeName</div>
+        <div>Name on ticket: <strong>@row.OriginalAttendeeName</strong></div>
+        <div>
+            Email on ticket:
+            @if (!string.IsNullOrEmpty(Model.OriginalAttendeeEmail))
+            {
+                <strong>@Model.OriginalAttendeeEmail</strong>
+            }
+            else
+            {
+                <span class="text-muted">(none)</span>
+            }
+        </div>
+        @if (hasOrder)
+        {
+            <div>Order buyer email: <strong>@Model.OrderBuyerEmail</strong></div>
+        }
         <div class="mt-2 d-flex align-items-center gap-2">
             <span class="badge @statusClass">@statusLabel</span>
             @if (!string.IsNullOrEmpty(Model.OrderDashboardUrl))
@@ -44,12 +75,15 @@
 <div class="row g-3 mb-3">
     <div class="col-md-6">
         <h3 class="h6 text-uppercase text-muted">Sender</h3>
-        <vc:human user-id="@row.SenderUserId" layout="Card" link="Admin" />
-        <vc:ticket-holdings user-id="@row.SenderUserId" show-empty="true" />
+        <div class="card"><div class="card-body">
+            <vc:human-summary user-id="@row.SenderUserId" />
+        </div></div>
     </div>
     <div class="col-md-6">
         <h3 class="h6 text-uppercase text-muted">Recipient</h3>
-        <vc:human user-id="@row.ReceiverUserId" layout="Card" link="Admin" />
+        <div class="card"><div class="card-body">
+            <vc:human-summary user-id="@row.ReceiverUserId" />
+        </div></div>
     </div>
 </div>
 
@@ -60,6 +94,18 @@
 
 @if (row.Status == TicketTransferStatus.Pending)
 {
+    <div class="card mb-3 border-info">
+        <div class="card-body">
+            <h2 class="h6 mb-2">If you approve, this will happen:</h2>
+            <ol class="mb-0">
+                <li>Void ticket <strong>@Model.OriginalAttendeeVendorTicketId</strong> at TicketTailor with a hold (seat is reserved, not resold).</li>
+                <li>Issue a new ticket to <strong>@row.ReceiverLegalName</strong> / <strong>@row.ReceiverEmail</strong> using the hold from step&nbsp;1.</li>
+                <li>TicketTailor emails @row.ReceiverLegalName the new ticket / barcode directly.</li>
+                <li>Each step (success or failure) is recorded in the audit history below.</li>
+            </ol>
+        </div>
+    </div>
+
     <form asp-action="Decide" method="post" class="mt-3">
         @Html.AntiForgeryToken()
         <input type="hidden" name="id" value="@row.Id" />

--- a/src/Humans.Web/Views/WidgetGallery/Index.cshtml
+++ b/src/Humans.Web/Views/WidgetGallery/Index.cshtml
@@ -381,6 +381,29 @@
                 <div class="wg-card">
                     <div class="wg-card-header">
                         <div>
+                            <span class="wg-card-name">&lt;vc:human-summary&gt;</span>
+                            <span class="wg-card-kind kind-vc">ViewComponent</span>
+                        </div>
+                        <span class="wg-card-path">src/Humans.Web/ViewComponents/HumanSummaryViewComponent.cs</span>
+                    </div>
+                    <div class="wg-card-note">
+                        Renders the same content as the hover popover (<code>_HumanPopover.cshtml</code>) inline — avatar, name, membership badge, city/country, public + (admin-only) hidden teams, and languages. Use on admin-review screens where the reviewer needs identity context without having to hover (e.g. ticket-transfer detail).
+                    </div>
+                    @ParamsBlock(
+                        ("user-id", "<code>Guid</code> — required")
+                    )
+                    @AuthLine("Hidden-team rows render only for viewers with <code>TeamsAdminBoardOrAdmin</code> policy (gating lives in <code>_HumanPopover.cshtml</code>).")
+                    <div class="wg-variants">
+                        <div class="wg-variant-label">user-id=current<span class="wg-variant-sub">has profile</span></div>
+                        <div class="wg-variant-render" style="display:block;">
+                            <vc:human-summary user-id="@Model.CurrentUserId" />
+                        </div>
+                    </div>
+                </div>
+
+                <div class="wg-card">
+                    <div class="wg-card-header">
+                        <div>
                             <span class="wg-card-name">&lt;vc:nobodies-email-badge&gt;</span>
                             <span class="wg-card-kind kind-vc">ViewComponent</span>
                         </div>


### PR DESCRIPTION
## Summary

- **Ticket card now shows full context**: order #, purchase date, ticket N of M, ticket ID, name + email on the ticket, and order buyer email — instead of just attendee name + type.
- **Sender / Recipient become inline mini-cards** with avatar, name, membership badge, city, public + hidden teams, and languages. New `<vc:human-summary>` view component reuses the existing `_HumanPopover.cshtml` partial, so the rendering source stays single.
- **Removed the redundant `<vc:ticket-holdings>`** from the Sender column (the new Ticket card covers it).
- **Added an "If you approve, this will happen" walkthrough** above Approve / Reject (Pending only):
  1. Void ticket #### at TT with a hold
  2. Issue a new ticket to {Receiver} / {email} using the hold
  3. TT emails the receiver their new ticket/barcode
  4. Each step is recorded in the audit history below

Mechanical changes:
- `TicketTransferDetailDto` gains 7 fields (order ids/dates, attendee vendor ticket id + email, ticket index/count).
- `ITicketRepository.GetAttendeeByIdAsync` now `.ThenInclude(o => o.Attendees)` so sibling tickets are available for "N of M". Trivial cost at our scale (≤6 siblings per order).
- `TicketTransferService.GetDetailAsync` computes the new fields, siblings sorted by `VendorTicketId` ascending (matches TT issue order).

## Test plan

- [ ] Pending transfer → Detail shows order/date/ticket-position/IDs, walkthrough block visible, mini-cards render teams + city for both sides.
- [ ] Approved transfer → Detail still shows full ticket context, walkthrough block hidden, timeline + audit history below.
- [ ] Transfer where the original attendee was voided → status badge still renders, walkthrough text references the (now-voided) ticket ID.
- [ ] Sender with multi-ticket order → "ticket #2 of 3" matches TT dashboard ordering.
- [ ] Receiver with hidden team memberships → admin viewer sees hidden teams section, non-admin viewer would not (popover policy still applies via `_HumanPopover`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)