### PR TITLE
[codex] Improve human picker shared details

### DIFF
--- a/docs/features/profiles/profile-search-detail.md
+++ b/docs/features/profiles/profile-search-detail.md
@@ -1,0 +1,111 @@
+<!-- freshness:triggers
+  src/Humans.Web/Controllers/ProfileApiController.cs
+  src/Humans.Web/Models/SearchResponseModels.cs
+  src/Humans.Web/Views/Shared/_HumanSearchInput.cshtml
+  src/Humans.Application/Services/Profiles/PersonSearchMatcher.cs
+  src/Humans.Application/DTOs/ProfileSearchResults.cs
+  src/Humans.Application/Services/Profile/ContactFieldService.cs
+  src/Humans.Application/Services/Profile/UserEmailService.cs
+-->
+<!-- freshness:flag-on-change
+  Detail priority order, avatar visibility rule, or the viewer-access ladder used by ContactFieldService / UserEmailService — review when any of these shift.
+-->
+
+# Profile Search Detail (Picker Row Enrichment)
+
+## Business Context
+
+The shared human picker (`_HumanSearchInput`, used by barrio member setup, role-assignment, ticket-transfer admin, etc.) originally rendered each result row as a single line of burner/playa name. When multiple humans share a common Playa name — three "David"s in the same barrio is the canonical case — the picker can't be used to disambiguate without an out-of-band cross-check.
+
+This feature adds a second line of context to each row and an avatar thumbnail, picked per-viewer so privacy rules stay intact.
+
+## User Stories
+
+### US-S.1: Disambiguate by visible contact info
+**As a** barrio lead
+**I want to** see a second line on each picker row (email / phone / Signal handle / etc.)
+**So that** I can tell apart members whose Playa names collide
+
+**Acceptance Criteria:**
+- Each result row in the shared human picker shows: optional avatar (32px circular), burner/playa name (bold), and an optional detail line (small muted text) underneath.
+- The detail line is computed per result based on what the **current viewer** is allowed to see; the search bit / endpoint does not change visibility.
+- If the viewer can see nothing about the target beyond name, the detail line is omitted (no empty space, no placeholder).
+- Row height stays bounded — 10 results scroll within the existing 260px dropdown max-height.
+
+### US-S.2: Lookup by userId
+**As a** caller that already knows a userId
+**I want to** request the same picker row for that single human
+**So that** I can pre-fill a picker, render a known reference, or recover from a name collision when search isn't narrowing enough
+
+**Acceptance Criteria:**
+- `GET /api/profiles/by-userid/{userId:guid}` returns one `HumanLookupSearchResult` (same shape as the search endpoint elements).
+- Authentication required (same `[Authorize]` boundary as search). Privacy gating identical to search-result enrichment.
+- 404 when the user does not exist or the profile is rejected.
+
+## Data Model
+
+No new entities. Reads from:
+- `Profile` / `User` / `Profile.ProfilePictureData` — already projected into the cached `FullProfile` snapshot.
+- `UserEmail` rows (visibility-filtered).
+- `ContactField` rows (visibility-filtered).
+- `RoleAssignment` (board check is upstream of the visibility ladder, not surfaced here directly).
+
+`HumanSearchResult` (the service-returned DTO) carries `ProfileId` alongside `UserId` so the controller can drive `IContactFieldService.GetVisibleContactFieldsAsync` (which keys by profile id) without a separate `GetByUserIdsAsync` round-trip.
+
+## Detail Priority Order
+
+For each result row, the controller calls `GetSharedDetailAsync(userId, profileId, viewerUserId, ct)` and returns the first non-empty value:
+
+1. **Highest-priority viewer-visible email** from `IUserEmailService.GetVisibleEmailsAsync(userId, accessLevel)`. Ordered: `IsPrimary` first, then alphabetical.
+2. **Highest-priority viewer-visible contact field** from `IContactFieldService.GetVisibleContactFieldsAsync(profileId, viewerUserId)`. Ordered by type:
+   1. `Phone`
+   2. `Signal`
+   3. `Telegram`
+   4. `WhatsApp`
+   5. `Discord`
+   6. `Other`
+   The obsolete `ContactFieldType.Email` is skipped (`UserEmail` is the canonical email source).
+3. `null` — no second line is rendered.
+
+Legal name (`Profile.FirstName + Profile.LastName`) is deliberately **not** part of the priority order, even for self or board viewers. The branch was previously included but produced essentially no value at ~500 users (only the tiny board cohort benefits) while costing a per-search `GetByUserIdsAsync` round-trip. Board members can still see legal name via the profile card on click-through. See `memory/architecture/no-business-logic-in-controllers.md` and the [PR #538 review thread](https://github.com/peterdrier/Humans/pull/538) for context.
+
+## Privacy Gating
+
+Viewer-visibility is delegated to the existing `IContactFieldService.GetViewerAccessLevelAsync(ownerUserId, viewerUserId)` ladder:
+
+| Viewer relationship to target | Access level |
+| --- | --- |
+| Self | `BoardOnly` (sees everything self has set) |
+| Board member | `BoardOnly` |
+| Coordinator (any team) | `CoordinatorsAndBoard` |
+| Shared team with target | `MyTeams` |
+| None of the above | `AllActiveProfiles` |
+
+`GetVisibleEmailsAsync` and `GetVisibleContactFieldsAsync` then filter rows whose `Visibility` is within the viewer's access level. Rows whose `Visibility` is `null` (explicitly private) are always excluded — including from self.
+
+This is the same ladder used by `ProfileCardViewComponent` for the canonical profile page, so the picker row never reveals more than the click-through card would.
+
+## Avatar Rule
+
+Each row renders an `<img>` thumbnail only when `ProfilePictureUrlHelper.BuildEffectiveUrlsAsync` returns a non-null URL for the target. That helper returns a URL only when the target has a **custom-uploaded** profile picture (Google avatar URLs are intentionally excluded per issue nobodies-collective/Humans#532). Custom profile pictures are publicly served by the existing `/Profile/Picture/{id}` endpoint, so the picker is consistent with every other picture-display site (profile card, `<vc:human>`, etc.).
+
+The view defends against broken URLs with `img.onerror = () => img.remove();` — a bad picture URL silently drops the thumbnail without leaving a broken-image icon.
+
+## Caching
+
+- **Search index + ProfileId resolution**: served from the `CachingProfileService._byUserId` `ConcurrentDictionary<Guid, FullProfile>` warmed at startup by `FullProfileWarmupHostedService`. No DB hit for the matcher itself or for resolving `ProfileId` per result.
+- **Single-person lookup endpoint**: served from the same dict via `IProfileService.GetFullProfileAsync(userId)`.
+- **Per-result email / contact-field reads**: not cached. These remain DB-bound, one round-trip per result row per visibility category. Acceptable at the project's ~500-user scale per `CLAUDE.md` ("prefer in-memory caching over query optimization"). Batching these is a separate, follow-up optimization if the picker latency ever becomes user-visible.
+
+## XSS Posture
+
+The Razor partial renders all user-controlled values (`displayName`, `detail`) via DOM `textContent`, never `innerHTML`. Avatar URLs come from `Url.Action` (server-side route generation), not user input. No raw HTML injection path exists.
+
+## Endpoints
+
+| Method | Route | Returns | Notes |
+| --- | --- | --- | --- |
+| `GET` | `/api/profiles/search?q={term}&scope={name|...}` | `HumanLookupSearchResult[]` | Existing endpoint. Detail enrichment added by this feature. Up to `MaxResults = 10` rows. |
+| `GET` | `/api/profiles/by-userid/{userId:guid}` | `HumanLookupSearchResult` | New. Single-person lookup. 404 if user not found or profile rejected. |
+
+`HumanLookupSearchResult` shape: `{ userId, displayName, detail, profilePictureUrl }`.

--- a/memory/code/controller-base-conventions.md
+++ b/memory/code/controller-base-conventions.md
@@ -1,14 +1,19 @@
 ---
 name: Controllers inherit shared bases for user resolution and TempData messaging
-description: Use `HumansControllerBase` (or specialized base) for `GetCurrentUserAsync`, `SetSuccess`/`SetError`/`SetInfo`, etc. Don't write direct `_userManager.GetUserAsync` or `TempData["..."]` calls.
+description: MVC controllers extend `HumansControllerBase`; JSON API controllers extend `ApiControllerBase`. Don't write direct `_userManager.GetUserAsync` or `TempData["..."]` calls in either.
 ---
 
-Controllers that resolve the current human or set TempData messages must use the shared base classes instead of duplicating those patterns.
+Controllers that resolve the current human or set TempData messages must use the shared base classes instead of duplicating those patterns. The base is split by controller flavor so an API controller doesn't drag in view-rendering / TempData machinery it never uses.
 
 **Rule:**
-- Inherit from `HumansControllerBase` or the appropriate specialized base when authenticated-user resolution or shared controller helpers are needed
-- Use shared helpers such as `GetCurrentUserAsync`, `ResolveCurrentUserAsync`, `FindUserByIdAsync`, `SetSuccess`, `SetError`, `SetInfo`
-- Do not write new direct `_userManager.GetUserAsync(User)` calls in controllers when a base helper already covers the case
-- Do not write direct `TempData["SuccessMessage"]`, `TempData["ErrorMessage"]`, or `TempData["InfoMessage"]` assignments in controllers
+- MVC controllers (return views, use TempData, server-rendered pages) → inherit from `HumansControllerBase` (defined in `src/Humans.Web/Controllers/HumansControllerBase.cs`). Extends `Controller`.
+- JSON API controllers (return `IActionResult` / `ActionResult<T>`, `[ApiController]` attribute, `/api/...` routes) → inherit from `ApiControllerBase` (defined in `src/Humans.Web/Controllers/ApiControllerBase.cs`). Extends `ControllerBase`. Intentional separation so API controllers stay slim and the LLM signal "this is an API controller" is loud.
+- Use shared helpers:
+  - Both bases: `GetCurrentUserAsync()`, `FindUserByIdAsync(userId)`.
+  - `HumansControllerBase`: `ResolveCurrentUserOrChallengeAsync()` (challenges into the cookie-auth flow — right for MVC), `RequireCurrentUserAsync()` (NotFound), `SetSuccess`/`SetError`/`SetInfo` (TempData PRG messaging).
+  - `ApiControllerBase`: `ResolveCurrentUserOrUnauthorizedAsync()` (returns 401 — right for JSON APIs).
+- Do not write new direct `_userManager.GetUserAsync(User)` calls in either kind of controller when a base helper covers the case.
+- Do not write direct `TempData["SuccessMessage"]`, `TempData["ErrorMessage"]`, or `TempData["InfoMessage"]` assignments in controllers.
+- Do not extend bare `ControllerBase` or bare `Controller` in new controllers — pick the right shared base.
 
-**Why:** Keeps PRG messaging, not-found handling, and user lookup behavior consistent across controllers.
+**Why:** Keeps PRG messaging, not-found handling, and user lookup behavior consistent across controllers. The MVC/API split prevents an API controller from accidentally being treated as a view-returning page (and the LLM mistake of recommending TempData helpers on an API controller).

--- a/src/Humans.Application/DTOs/ProfileSearchResults.cs
+++ b/src/Humans.Application/DTOs/ProfileSearchResults.cs
@@ -7,6 +7,9 @@ namespace Humans.Application.DTOs;
 /// lets more rows match.
 /// </summary>
 /// <param name="UserId">Owning user id.</param>
+/// <param name="ProfileId">Owning profile id. Surfaced so callers that need
+/// to fan out into <c>IContactFieldService</c> (which keys by profile id)
+/// don't have to round-trip through <c>GetByUserIdsAsync</c>.</param>
 /// <param name="BurnerName">The human's primary public display label.
 /// Falls back to <c>User.DisplayName</c> when
 /// <see cref="Humans.Domain.Entities.Profile.BurnerName"/> is unset.</param>
@@ -25,6 +28,7 @@ namespace Humans.Application.DTOs;
 /// content into the basic shape.</param>
 public record HumanSearchResult(
     Guid UserId,
+    Guid ProfileId,
     string BurnerName,
     string? ProfilePictureUrl,
     string? MatchField,

--- a/src/Humans.Application/Services/Profiles/PersonSearchMatcher.cs
+++ b/src/Humans.Application/Services/Profiles/PersonSearchMatcher.cs
@@ -68,6 +68,7 @@ public static class PersonSearchMatcher
 
             return new[] { new HumanSearchResult(
                 UserId: byId.UserId,
+                ProfileId: byId.ProfileId,
                 BurnerName: idBurnerName,
                 ProfilePictureUrl: byId.ProfilePictureUrl,
                 MatchField: "User ID",
@@ -97,6 +98,7 @@ public static class PersonSearchMatcher
 
             results.Add(new HumanSearchResult(
                 UserId: p.UserId,
+                ProfileId: p.ProfileId,
                 BurnerName: burnerName,
                 ProfilePictureUrl: p.ProfilePictureUrl,
                 MatchField: match.Value.Field,

--- a/src/Humans.Web/Controllers/ApiControllerBase.cs
+++ b/src/Humans.Web/Controllers/ApiControllerBase.cs
@@ -1,0 +1,54 @@
+using Humans.Domain.Entities;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Humans.Web.Controllers;
+
+/// <summary>
+/// Base class for JSON API controllers. Inherit from this instead of
+/// <see cref="ControllerBase"/> so authenticated-user resolution stays
+/// consistent across the API surface without dragging in the
+/// view-rendering / TempData machinery that <see cref="HumansControllerBase"/>
+/// provides for server-rendered MVC controllers.
+///
+/// <para>
+/// Convention (see <c>memory/code/controller-base-conventions.md</c>):
+/// <list type="bullet">
+///   <item>MVC controllers returning views or using TempData → <see cref="HumansControllerBase"/>.</item>
+///   <item>API controllers returning JSON via <c>IActionResult</c> / <c>ActionResult&lt;T&gt;</c> → this class.</item>
+/// </list>
+/// Don't write new direct <c>_userManager.GetUserAsync(User)</c> calls in
+/// either kind of controller — use the helpers below (or the MVC
+/// equivalents) so the user-resolution behavior stays uniform.
+/// </para>
+/// </summary>
+public abstract class ApiControllerBase : ControllerBase
+{
+    private readonly UserManager<User> _userManager;
+
+    protected UserManager<User> UserManager => _userManager;
+
+    protected ApiControllerBase(UserManager<User> userManager)
+    {
+        _userManager = userManager;
+    }
+
+    protected Task<User?> GetCurrentUserAsync() => _userManager.GetUserAsync(User);
+
+    protected Task<User?> FindUserByIdAsync(Guid userId) =>
+        _userManager.FindByIdAsync(userId.ToString());
+
+    /// <summary>
+    /// Resolves the current user or returns 401 Unauthorized. Use this on
+    /// authenticated API actions so the "auth cookie still valid but the
+    /// user row is gone" race produces 401 rather than soft-failing into
+    /// empty data. <see cref="Microsoft.AspNetCore.Authorization.AuthorizeAttribute"/>
+    /// handles the no-cookie case at the framework layer; this helper
+    /// covers the deleted-while-session-valid case at the action layer.
+    /// </summary>
+    protected async Task<(IActionResult? ErrorResult, User User)> ResolveCurrentUserOrUnauthorizedAsync()
+    {
+        var user = await GetCurrentUserAsync();
+        return user is null ? (Unauthorized(), null!) : (null, user);
+    }
+}

--- a/src/Humans.Web/Controllers/ProfileApiController.cs
+++ b/src/Humans.Web/Controllers/ProfileApiController.cs
@@ -15,7 +15,7 @@ namespace Humans.Web.Controllers;
 [Authorize]
 [ApiController]
 [Route("api/profiles")]
-public class ProfileApiController : HumansControllerBase
+public class ProfileApiController : ApiControllerBase
 {
     private const int MaxResults = 10;
 
@@ -53,6 +53,14 @@ public class ProfileApiController : HumansControllerBase
             ? PersonSearchFields.Name
             : PersonSearchFields.PublicAll;
 
+        // [Authorize] handles the no-cookie case at the framework layer;
+        // resolve here to cover the deleted-user-but-session-still-valid race
+        // — fail-closed with 401 rather than soft-fail into empty details.
+        var (authError, viewer) = await ResolveCurrentUserOrUnauthorizedAsync();
+        if (authError is not null)
+            return authError;
+        var viewerUserId = viewer.Id;
+
         var results = await _profileService.SearchProfilesAsync(q, fields, MaxResults, ct);
         var userIds = results.Select(r => r.UserId).ToList();
         var pictureUrls = await ProfilePictureUrlHelper.BuildEffectiveUrlsAsync(
@@ -60,9 +68,6 @@ public class ProfileApiController : HumansControllerBase
             Url,
             userIds,
             ct);
-
-        var viewer = await GetCurrentUserAsync();
-        var viewerUserId = viewer?.Id;
 
         var response = new List<HumanLookupSearchResult>(results.Count);
         foreach (var result in results.OrderBy(r => r.BurnerName, StringComparer.OrdinalIgnoreCase))
@@ -95,6 +100,11 @@ public class ProfileApiController : HumansControllerBase
     [HttpGet("by-userid/{userId:guid}")]
     public async Task<IActionResult> GetByUserId(Guid userId, CancellationToken ct = default)
     {
+        var (authError, viewer) = await ResolveCurrentUserOrUnauthorizedAsync();
+        if (authError is not null)
+            return authError;
+        var viewerUserId = viewer.Id;
+
         var fullProfile = await _profileService.GetFullProfileAsync(userId, ct);
         if (fullProfile is null || fullProfile.IsRejected)
             return NotFound();
@@ -104,9 +114,6 @@ public class ProfileApiController : HumansControllerBase
             Url,
             new[] { userId },
             ct);
-
-        var viewer = await GetCurrentUserAsync();
-        var viewerUserId = viewer?.Id;
 
         var detail = await GetSharedDetailAsync(
             userId,
@@ -138,15 +145,12 @@ public class ProfileApiController : HumansControllerBase
     private async Task<string?> GetSharedDetailAsync(
         Guid userId,
         Guid profileId,
-        Guid? viewerUserId,
+        Guid viewerUserId,
         CancellationToken ct)
     {
-        if (viewerUserId is null)
-            return null;
-
         var accessLevel = await _contactFieldService.GetViewerAccessLevelAsync(
             userId,
-            viewerUserId.Value,
+            viewerUserId,
             ct);
         var visibleEmails = await _userEmailService.GetVisibleEmailsAsync(userId, accessLevel, ct);
         var visibleEmail = visibleEmails
@@ -160,7 +164,7 @@ public class ProfileApiController : HumansControllerBase
 
         var visibleContactFields = await _contactFieldService.GetVisibleContactFieldsAsync(
             profileId,
-            viewerUserId.Value,
+            viewerUserId,
             ct);
 
         return visibleContactFields

--- a/src/Humans.Web/Controllers/ProfileApiController.cs
+++ b/src/Humans.Web/Controllers/ProfileApiController.cs
@@ -15,25 +15,24 @@ namespace Humans.Web.Controllers;
 [Authorize]
 [ApiController]
 [Route("api/profiles")]
-public class ProfileApiController : ControllerBase
+public class ProfileApiController : HumansControllerBase
 {
     private const int MaxResults = 10;
 
     private readonly IProfileService _profileService;
     private readonly IContactFieldService _contactFieldService;
     private readonly IUserEmailService _userEmailService;
-    private readonly UserManager<User> _userManager;
 
     public ProfileApiController(
         IProfileService profileService,
         IContactFieldService contactFieldService,
         IUserEmailService userEmailService,
         UserManager<User> userManager)
+        : base(userManager)
     {
         _profileService = profileService;
         _contactFieldService = contactFieldService;
         _userEmailService = userEmailService;
-        _userManager = userManager;
     }
 
     [HttpGet("search")]
@@ -62,7 +61,7 @@ public class ProfileApiController : ControllerBase
             userIds,
             ct);
 
-        var viewer = await _userManager.GetUserAsync(User);
+        var viewer = await GetCurrentUserAsync();
         var viewerUserId = viewer?.Id;
 
         var response = new List<HumanLookupSearchResult>(results.Count);
@@ -106,7 +105,7 @@ public class ProfileApiController : ControllerBase
             new[] { userId },
             ct);
 
-        var viewer = await _userManager.GetUserAsync(User);
+        var viewer = await GetCurrentUserAsync();
         var viewerUserId = viewer?.Id;
 
         var detail = await GetSharedDetailAsync(

--- a/src/Humans.Web/Controllers/ProfileApiController.cs
+++ b/src/Humans.Web/Controllers/ProfileApiController.cs
@@ -1,5 +1,4 @@
 using Humans.Application.DTOs;
-using Humans.Application.Interfaces.Auth;
 using Humans.Application.Interfaces.Profiles;
 using Humans.Application.Services.Profiles;
 using Humans.Domain.Entities;
@@ -23,20 +22,17 @@ public class ProfileApiController : ControllerBase
     private readonly IProfileService _profileService;
     private readonly IContactFieldService _contactFieldService;
     private readonly IUserEmailService _userEmailService;
-    private readonly IRoleAssignmentService _roleAssignmentService;
     private readonly UserManager<User> _userManager;
 
     public ProfileApiController(
         IProfileService profileService,
         IContactFieldService contactFieldService,
         IUserEmailService userEmailService,
-        IRoleAssignmentService roleAssignmentService,
         UserManager<User> userManager)
     {
         _profileService = profileService;
         _contactFieldService = contactFieldService;
         _userEmailService = userEmailService;
-        _roleAssignmentService = roleAssignmentService;
         _userManager = userManager;
     }
 
@@ -60,7 +56,6 @@ public class ProfileApiController : ControllerBase
 
         var results = await _profileService.SearchProfilesAsync(q, fields, MaxResults, ct);
         var userIds = results.Select(r => r.UserId).ToList();
-        var profilesByUserId = await _profileService.GetByUserIdsAsync(userIds, ct);
         var pictureUrls = await ProfilePictureUrlHelper.BuildEffectiveUrlsAsync(
             _profileService,
             Url,
@@ -69,17 +64,14 @@ public class ProfileApiController : ControllerBase
 
         var viewer = await _userManager.GetUserAsync(User);
         var viewerUserId = viewer?.Id;
-        var viewerIsBoard = viewerUserId.HasValue
-            && await _roleAssignmentService.IsUserBoardMemberAsync(viewerUserId.Value, ct);
 
         var response = new List<HumanLookupSearchResult>(results.Count);
         foreach (var result in results.OrderBy(r => r.BurnerName, StringComparer.OrdinalIgnoreCase))
         {
             var detail = await GetSharedDetailAsync(
                 result.UserId,
-                profilesByUserId.GetValueOrDefault(result.UserId),
+                result.ProfileId,
                 viewerUserId,
-                viewerIsBoard,
                 ct);
 
             response.Add(new HumanLookupSearchResult(
@@ -94,22 +86,64 @@ public class ProfileApiController : ControllerBase
         return Ok(response);
     }
 
+    /// <summary>
+    /// Single-person lookup by userId. Returns the same picker row shape as
+    /// <see cref="Search"/>, so callers that already know the userId (URL
+    /// param, integration, pre-fill) can render the row without typing a name
+    /// and choosing from a dropdown. Cache-backed via
+    /// <see cref="IProfileService.GetFullProfileAsync"/>.
+    /// </summary>
+    [HttpGet("by-userid/{userId:guid}")]
+    public async Task<IActionResult> GetByUserId(Guid userId, CancellationToken ct = default)
+    {
+        var fullProfile = await _profileService.GetFullProfileAsync(userId, ct);
+        if (fullProfile is null || fullProfile.IsRejected)
+            return NotFound();
+
+        var pictureUrls = await ProfilePictureUrlHelper.BuildEffectiveUrlsAsync(
+            _profileService,
+            Url,
+            new[] { userId },
+            ct);
+
+        var viewer = await _userManager.GetUserAsync(User);
+        var viewerUserId = viewer?.Id;
+
+        var detail = await GetSharedDetailAsync(
+            userId,
+            fullProfile.ProfileId,
+            viewerUserId,
+            ct);
+
+        var displayName = string.IsNullOrWhiteSpace(fullProfile.BurnerName)
+            ? fullProfile.DisplayName
+            : fullProfile.BurnerName!;
+
+        return Ok(new HumanLookupSearchResult(
+            userId,
+            displayName,
+            detail,
+            pictureUrls.GetValueOrDefault(userId)));
+    }
+
+    /// <summary>
+    /// Returns the disambiguation detail to render under the human's name in
+    /// the shared picker row. Priority: viewer-visible primary email →
+    /// highest-priority visible contact field (Phone → Signal → Telegram →
+    /// WhatsApp → Discord → Other) → <c>null</c>. Legal name is deliberately
+    /// not surfaced here even for board viewers: at ~500 users with mostly
+    /// non-board callers it would be a distraction that almost no one
+    /// benefits from, and board members can still see legal name via the
+    /// profile card on click-through.
+    /// </summary>
     private async Task<string?> GetSharedDetailAsync(
         Guid userId,
-        Profile? profile,
+        Guid profileId,
         Guid? viewerUserId,
-        bool viewerIsBoard,
         CancellationToken ct)
     {
         if (viewerUserId is null)
             return null;
-
-        if (profile is not null && (viewerUserId.Value == userId || viewerIsBoard))
-        {
-            var legalName = profile.FullName;
-            if (!string.IsNullOrWhiteSpace(legalName))
-                return legalName;
-        }
 
         var accessLevel = await _contactFieldService.GetViewerAccessLevelAsync(
             userId,
@@ -125,11 +159,8 @@ public class ProfileApiController : ControllerBase
         if (!string.IsNullOrWhiteSpace(visibleEmail))
             return visibleEmail;
 
-        if (profile is null)
-            return null;
-
         var visibleContactFields = await _contactFieldService.GetVisibleContactFieldsAsync(
-            profile.Id,
+            profileId,
             viewerUserId.Value,
             ct);
 

--- a/src/Humans.Web/Controllers/ProfileApiController.cs
+++ b/src/Humans.Web/Controllers/ProfileApiController.cs
@@ -1,8 +1,14 @@
+using Humans.Application.DTOs;
+using Humans.Application.Interfaces.Auth;
 using Humans.Application.Interfaces.Profiles;
 using Humans.Application.Services.Profiles;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
 using Humans.Web.Extensions;
+using Humans.Web.Helpers;
 using Humans.Web.Models;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Humans.Web.Controllers;
@@ -15,14 +21,30 @@ public class ProfileApiController : ControllerBase
     private const int MaxResults = 10;
 
     private readonly IProfileService _profileService;
+    private readonly IContactFieldService _contactFieldService;
+    private readonly IUserEmailService _userEmailService;
+    private readonly IRoleAssignmentService _roleAssignmentService;
+    private readonly UserManager<User> _userManager;
 
-    public ProfileApiController(IProfileService profileService)
+    public ProfileApiController(
+        IProfileService profileService,
+        IContactFieldService contactFieldService,
+        IUserEmailService userEmailService,
+        IRoleAssignmentService roleAssignmentService,
+        UserManager<User> userManager)
     {
         _profileService = profileService;
+        _contactFieldService = contactFieldService;
+        _userEmailService = userEmailService;
+        _roleAssignmentService = roleAssignmentService;
+        _userManager = userManager;
     }
 
     [HttpGet("search")]
-    public async Task<IActionResult> Search([FromQuery] string? q, [FromQuery] string? scope = null)
+    public async Task<IActionResult> Search(
+        [FromQuery] string? q,
+        [FromQuery] string? scope = null,
+        CancellationToken ct = default)
     {
         if (!q.HasSearchTerm())
             return Ok(Array.Empty<HumanLookupSearchResult>());
@@ -36,12 +58,110 @@ public class ProfileApiController : ControllerBase
             ? PersonSearchFields.Name
             : PersonSearchFields.PublicAll;
 
-        var results = await _profileService.SearchProfilesAsync(q, fields, MaxResults);
+        var results = await _profileService.SearchProfilesAsync(q, fields, MaxResults, ct);
+        var userIds = results.Select(r => r.UserId).ToList();
+        var profilesByUserId = await _profileService.GetByUserIdsAsync(userIds, ct);
+        var pictureUrls = await ProfilePictureUrlHelper.BuildEffectiveUrlsAsync(
+            _profileService,
+            Url,
+            userIds,
+            ct);
+
+        var viewer = await _userManager.GetUserAsync(User);
+        var viewerUserId = viewer?.Id;
+        var viewerIsBoard = viewerUserId.HasValue
+            && await _roleAssignmentService.IsUserBoardMemberAsync(viewerUserId.Value, ct);
+
+        var response = new List<HumanLookupSearchResult>(results.Count);
+        foreach (var result in results.OrderBy(r => r.BurnerName, StringComparer.OrdinalIgnoreCase))
+        {
+            var detail = await GetSharedDetailAsync(
+                result.UserId,
+                profilesByUserId.GetValueOrDefault(result.UserId),
+                viewerUserId,
+                viewerIsBoard,
+                ct);
+
+            response.Add(new HumanLookupSearchResult(
+                result.UserId,
+                result.BurnerName,
+                detail,
+                pictureUrls.GetValueOrDefault(result.UserId)));
+        }
 
         // Display ordering belongs at the presentation layer, per
         // memory/architecture/display-sort-in-controllers.md.
-        return Ok(results
-            .OrderBy(r => r.BurnerName, StringComparer.OrdinalIgnoreCase)
-            .Select(r => new HumanLookupSearchResult(r.UserId, r.BurnerName)));
+        return Ok(response);
+    }
+
+    private async Task<string?> GetSharedDetailAsync(
+        Guid userId,
+        Profile? profile,
+        Guid? viewerUserId,
+        bool viewerIsBoard,
+        CancellationToken ct)
+    {
+        if (viewerUserId is null)
+            return null;
+
+        if (profile is not null && (viewerUserId.Value == userId || viewerIsBoard))
+        {
+            var legalName = profile.FullName;
+            if (!string.IsNullOrWhiteSpace(legalName))
+                return legalName;
+        }
+
+        var accessLevel = await _contactFieldService.GetViewerAccessLevelAsync(
+            userId,
+            viewerUserId.Value,
+            ct);
+        var visibleEmails = await _userEmailService.GetVisibleEmailsAsync(userId, accessLevel, ct);
+        var visibleEmail = visibleEmails
+            .OrderByDescending(e => e.IsPrimary)
+            .ThenBy(e => e.Email, StringComparer.OrdinalIgnoreCase)
+            .Select(e => e.Email)
+            .FirstOrDefault();
+
+        if (!string.IsNullOrWhiteSpace(visibleEmail))
+            return visibleEmail;
+
+        if (profile is null)
+            return null;
+
+        var visibleContactFields = await _contactFieldService.GetVisibleContactFieldsAsync(
+            profile.Id,
+            viewerUserId.Value,
+            ct);
+
+        return visibleContactFields
+#pragma warning disable CS0618 // Obsolete ContactFieldType.Email is skipped; UserEmail is the canonical email source.
+            .Where(f => f.FieldType is not ContactFieldType.Email)
+#pragma warning restore CS0618
+            .OrderBy(f => GetContactFieldDisplayPriority(f.FieldType))
+            .ThenBy(f => f.Label, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(f => f.Value, StringComparer.OrdinalIgnoreCase)
+            .Select(FormatContactFieldDetail)
+            .FirstOrDefault();
+    }
+
+    private static int GetContactFieldDisplayPriority(ContactFieldType fieldType) =>
+        fieldType switch
+        {
+            ContactFieldType.Phone => 0,
+            ContactFieldType.Signal => 1,
+            ContactFieldType.Telegram => 2,
+            ContactFieldType.WhatsApp => 3,
+            ContactFieldType.Discord => 4,
+            ContactFieldType.Other => 5,
+            _ => 99
+        };
+
+    private static string FormatContactFieldDetail(ContactFieldDto field)
+    {
+        var label = string.IsNullOrWhiteSpace(field.Label)
+            ? field.FieldType.ToString()
+            : field.Label;
+
+        return $"{label} {field.Value}";
     }
 }

--- a/src/Humans.Web/Models/SearchResponseModels.cs
+++ b/src/Humans.Web/Models/SearchResponseModels.cs
@@ -1,5 +1,9 @@
 namespace Humans.Web.Models;
 
-public record HumanLookupSearchResult(Guid UserId, string DisplayName);
+public record HumanLookupSearchResult(
+    Guid UserId,
+    string DisplayName,
+    string? Detail = null,
+    string? ProfilePictureUrl = null);
 
 public record RoleAssignmentSearchResult(Guid Id, string DisplayName, string Email, bool OnTeam);

--- a/src/Humans.Web/Views/Shared/_HumanSearchInput.cshtml
+++ b/src/Humans.Web/Views/Shared/_HumanSearchInput.cshtml
@@ -175,7 +175,5 @@
         });
         showDropdown();
     }
-
-    @await Html.PartialAsync("~/Views/Shared/_EscapeHtmlScript.cshtml")
 })();
 </script>

--- a/src/Humans.Web/Views/Shared/_HumanSearchInput.cshtml
+++ b/src/Humans.Web/Views/Shared/_HumanSearchInput.cshtml
@@ -134,9 +134,37 @@
         }
         results.forEach(function (r) {
             var li = document.createElement('li');
-            li.className = 'list-group-item list-group-item-action py-2 px-3';
+            li.className = 'list-group-item list-group-item-action py-2 px-3 d-flex align-items-center gap-2';
             li.style.cursor = 'pointer';
-            li.innerHTML = escapeHtml(r.displayName);
+
+            if (r.profilePictureUrl) {
+                var img = document.createElement('img');
+                img.src = r.profilePictureUrl;
+                img.alt = '';
+                img.className = 'rounded-circle flex-shrink-0';
+                img.style.width = '32px';
+                img.style.height = '32px';
+                img.style.objectFit = 'cover';
+                img.onerror = function () { img.remove(); };
+                li.appendChild(img);
+            }
+
+            var textWrap = document.createElement('div');
+            textWrap.style.minWidth = '0';
+
+            var nameLine = document.createElement('div');
+            nameLine.className = 'fw-semibold text-truncate';
+            nameLine.textContent = r.displayName;
+            textWrap.appendChild(nameLine);
+
+            if (r.detail) {
+                var detailLine = document.createElement('div');
+                detailLine.className = 'small text-muted text-truncate';
+                detailLine.textContent = r.detail;
+                textWrap.appendChild(detailLine);
+            }
+
+            li.appendChild(textWrap);
             li.addEventListener('mousedown', function (e) {
                 e.preventDefault();
                 hiddenInput.value = r.userId;

--- a/tests/Humans.Application.Tests/Services/Tickets/TicketTransferServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Tickets/TicketTransferServiceTests.cs
@@ -825,6 +825,7 @@ public sealed class TicketTransferServiceTests
     private static HumanSearchResult MakeSearchResult(Guid userId, string displayName) =>
         new(
             UserId: userId,
+            ProfileId: Guid.NewGuid(),
             BurnerName: displayName,
             ProfilePictureUrl: null,
             MatchField: "Name",

--- a/tests/Humans.Web.Tests/Controllers/ProfileApiControllerTests.cs
+++ b/tests/Humans.Web.Tests/Controllers/ProfileApiControllerTests.cs
@@ -13,7 +13,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Routing;
-using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
@@ -98,7 +97,6 @@ public class ProfileApiControllerTests
                 ActionName = "Test",
             },
         };
-        ctrl.TempData = new TempDataDictionary(http, Substitute.For<ITempDataProvider>());
         ctrl.Url = Substitute.For<IUrlHelper>();
         return ctrl;
     }
@@ -148,27 +146,22 @@ public class ProfileApiControllerTests
     // ==========================================================================
 
     [HumansFact]
-    public async Task Search_returns_null_detail_when_viewer_is_anonymous()
+    public async Task Search_returns_401_when_current_user_resolves_to_null()
     {
-        var userId = Guid.NewGuid();
-        var profileId = Guid.NewGuid();
-        _profileService.SearchProfilesAsync(Arg.Any<string>(),
-                Arg.Any<PersonSearchFields>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
-            .Returns(new[] { MakeSearchResult(userId, profileId, "David") });
-
+        // [Authorize] handles no-cookie at the framework layer. This covers the
+        // session-valid-but-user-row-gone race: the action must fail closed
+        // (401) instead of returning rows with empty details.
         var sut = BuildSut(currentUser: null);
 
         var result = await sut.Search(q: "David");
 
-        var rows = result.Should().BeOfType<OkObjectResult>().Subject.Value
-            .Should().BeAssignableTo<IEnumerable<HumanLookupSearchResult>>().Subject.ToList();
-        rows.Should().ContainSingle().Which.Detail.Should().BeNull();
+        result.Should().BeOfType<UnauthorizedResult>();
 
-        // No DB / service calls were made for visibility resolution.
+        await _profileService.DidNotReceive().SearchProfilesAsync(
+            Arg.Any<string>(), Arg.Any<PersonSearchFields>(),
+            Arg.Any<int>(), Arg.Any<CancellationToken>());
         await _contactFieldService.DidNotReceive().GetViewerAccessLevelAsync(
             Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>());
-        await _userEmailService.DidNotReceive().GetVisibleEmailsAsync(
-            Arg.Any<Guid>(), Arg.Any<ContactFieldVisibility>(), Arg.Any<CancellationToken>());
     }
 
     [HumansFact]

--- a/tests/Humans.Web.Tests/Controllers/ProfileApiControllerTests.cs
+++ b/tests/Humans.Web.Tests/Controllers/ProfileApiControllerTests.cs
@@ -1,0 +1,375 @@
+using System.Security.Claims;
+using AwesomeAssertions;
+using Humans.Application;
+using Humans.Application.DTOs;
+using Humans.Application.Interfaces.Profiles;
+using Humans.Application.Services.Profiles;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using Humans.Testing;
+using Humans.Web.Controllers;
+using Humans.Web.Models;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Routing;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Xunit;
+
+namespace Humans.Web.Tests.Controllers;
+
+/// <summary>
+/// Privacy-gate coverage for <see cref="ProfileApiController"/>.
+///
+/// <para>
+/// The two endpoints under test (<c>GET /api/profiles/search</c> and
+/// <c>GET /api/profiles/by-userid/{userId}</c>) both feed each result row
+/// through <c>GetSharedDetailAsync</c>, whose job is to pick a viewer-visible
+/// disambiguation line: viewer-visible primary email → highest-priority
+/// visible contact field (Phone → Signal → Telegram → WhatsApp → Discord →
+/// Other) → null. Legal name is never surfaced (dropped from the priority
+/// chain at PR #538 review).
+/// </para>
+///
+/// <para>
+/// These tests target the load-bearing privacy concern: a row only ever
+/// surfaces data the current viewer is allowed to see, as decided by
+/// <c>IContactFieldService.GetViewerAccessLevelAsync</c> +
+/// <c>IUserEmailService.GetVisibleEmailsAsync</c> +
+/// <c>IContactFieldService.GetVisibleContactFieldsAsync</c>. The controller
+/// is verified to delegate visibility decisions to those services, not to
+/// re-implement them.
+/// </para>
+/// </summary>
+public class ProfileApiControllerTests
+{
+    private readonly IProfileService _profileService = Substitute.For<IProfileService>();
+    private readonly IContactFieldService _contactFieldService = Substitute.For<IContactFieldService>();
+    private readonly IUserEmailService _userEmailService = Substitute.For<IUserEmailService>();
+    private readonly UserManager<User> _userManager;
+
+    public ProfileApiControllerTests()
+    {
+        var userStore = Substitute.For<IUserStore<User>>();
+        _userManager = Substitute.For<UserManager<User>>(
+            userStore, null, null, null, null, null, null, null, null);
+
+        // Picture URLs are not the focus here — return an empty dictionary so the
+        // helper returns null URLs for every result row.
+        _profileService
+            .GetCustomPictureInfoByUserIdsAsync(Arg.Any<IEnumerable<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<(Guid ProfileId, Guid UserId, long UpdatedAtTicks)>());
+    }
+
+    private ProfileApiController BuildSut(User? currentUser)
+    {
+        if (currentUser is not null)
+        {
+            _userManager.GetUserAsync(Arg.Any<ClaimsPrincipal>()).Returns(currentUser);
+        }
+
+        var ctrl = new ProfileApiController(
+            _profileService, _contactFieldService, _userEmailService, _userManager);
+
+        var http = new DefaultHttpContext();
+        if (currentUser is not null)
+        {
+            http.User = new ClaimsPrincipal(new ClaimsIdentity(
+                new[] { new Claim(ClaimTypes.NameIdentifier, currentUser.Id.ToString()) },
+                "test"));
+        }
+
+        var services = new ServiceCollection();
+        services.AddSingleton(NullLoggerFactory.Instance);
+        var urlHelperFactory = Substitute.For<IUrlHelperFactory>();
+        urlHelperFactory.GetUrlHelper(Arg.Any<ActionContext>())
+            .Returns(Substitute.For<IUrlHelper>());
+        services.AddSingleton(urlHelperFactory);
+        http.RequestServices = services.BuildServiceProvider();
+
+        ctrl.ControllerContext = new ControllerContext
+        {
+            HttpContext = http,
+            ActionDescriptor = new Microsoft.AspNetCore.Mvc.Controllers.ControllerActionDescriptor
+            {
+                ActionName = "Test",
+            },
+        };
+        ctrl.TempData = new TempDataDictionary(http, Substitute.For<ITempDataProvider>());
+        ctrl.Url = Substitute.For<IUrlHelper>();
+        return ctrl;
+    }
+
+    private static HumanSearchResult MakeSearchResult(Guid userId, Guid profileId, string burnerName) =>
+        new(
+            UserId: userId,
+            ProfileId: profileId,
+            BurnerName: burnerName,
+            ProfilePictureUrl: null,
+            MatchField: "Name",
+            MatchSnippet: null,
+            MatchedEmail: null);
+
+    private static User MakeUser(Guid id) =>
+        new() { Id = id, Email = $"viewer-{id:N}@example.com", DisplayName = "Viewer" };
+
+    private static FullProfile MakeFullProfile(
+        Guid userId,
+        Guid profileId,
+        string? burnerName = "Target Burner",
+        bool isRejected = false) =>
+        new(
+            UserId: userId,
+            DisplayName: "Target Display",
+            ProfilePictureUrl: null,
+            HasCustomPicture: false,
+            ProfileId: profileId,
+            UpdatedAtTicks: 0,
+            BurnerName: burnerName,
+            Bio: null,
+            Pronouns: null,
+            ContributionInterests: null,
+            City: null,
+            CountryCode: null,
+            Latitude: null,
+            Longitude: null,
+            BirthdayDay: null,
+            BirthdayMonth: null,
+            IsApproved: true,
+            IsSuspended: false,
+            CVEntries: Array.Empty<CVEntry>(),
+            IsRejected: isRejected);
+
+    // ==========================================================================
+    // Search — privacy gate behavior on the per-row detail line.
+    // ==========================================================================
+
+    [HumansFact]
+    public async Task Search_returns_null_detail_when_viewer_is_anonymous()
+    {
+        var userId = Guid.NewGuid();
+        var profileId = Guid.NewGuid();
+        _profileService.SearchProfilesAsync(Arg.Any<string>(),
+                Arg.Any<PersonSearchFields>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(new[] { MakeSearchResult(userId, profileId, "David") });
+
+        var sut = BuildSut(currentUser: null);
+
+        var result = await sut.Search(q: "David");
+
+        var rows = result.Should().BeOfType<OkObjectResult>().Subject.Value
+            .Should().BeAssignableTo<IEnumerable<HumanLookupSearchResult>>().Subject.ToList();
+        rows.Should().ContainSingle().Which.Detail.Should().BeNull();
+
+        // No DB / service calls were made for visibility resolution.
+        await _contactFieldService.DidNotReceive().GetViewerAccessLevelAsync(
+            Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+        await _userEmailService.DidNotReceive().GetVisibleEmailsAsync(
+            Arg.Any<Guid>(), Arg.Any<ContactFieldVisibility>(), Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task Search_surfaces_visible_primary_email_as_detail()
+    {
+        var viewer = MakeUser(Guid.NewGuid());
+        var targetUserId = Guid.NewGuid();
+        var targetProfileId = Guid.NewGuid();
+
+        _profileService.SearchProfilesAsync(Arg.Any<string>(),
+                Arg.Any<PersonSearchFields>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(new[] { MakeSearchResult(targetUserId, targetProfileId, "David") });
+
+        _contactFieldService.GetViewerAccessLevelAsync(targetUserId, viewer.Id, Arg.Any<CancellationToken>())
+            .Returns(ContactFieldVisibility.AllActiveProfiles);
+
+        _userEmailService.GetVisibleEmailsAsync(targetUserId,
+                ContactFieldVisibility.AllActiveProfiles, Arg.Any<CancellationToken>())
+            .Returns(new[]
+            {
+                new UserEmailDto(Guid.NewGuid(), "alt@example.com",
+                    IsVerified: true, IsGoogle: false, Provider: null, ProviderKey: null,
+                    IsPrimary: false, Visibility: ContactFieldVisibility.AllActiveProfiles),
+                new UserEmailDto(Guid.NewGuid(), "primary@example.com",
+                    IsVerified: true, IsGoogle: false, Provider: null, ProviderKey: null,
+                    IsPrimary: true, Visibility: ContactFieldVisibility.AllActiveProfiles),
+            });
+
+        var sut = BuildSut(viewer);
+
+        var result = await sut.Search(q: "David");
+
+        var row = result.Should().BeOfType<OkObjectResult>().Subject.Value
+            .Should().BeAssignableTo<IEnumerable<HumanLookupSearchResult>>().Subject.Single();
+        row.Detail.Should().Be("primary@example.com");
+
+        // GetByUserIdsAsync (DB-bound) is bypassed — ProfileId comes from HumanSearchResult.
+        await _profileService.DidNotReceive().GetByUserIdsAsync(
+            Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task Search_falls_back_to_contact_field_in_priority_order_when_no_visible_email()
+    {
+        var viewer = MakeUser(Guid.NewGuid());
+        var targetUserId = Guid.NewGuid();
+        var targetProfileId = Guid.NewGuid();
+
+        _profileService.SearchProfilesAsync(Arg.Any<string>(),
+                Arg.Any<PersonSearchFields>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(new[] { MakeSearchResult(targetUserId, targetProfileId, "David") });
+
+        _contactFieldService.GetViewerAccessLevelAsync(targetUserId, viewer.Id, Arg.Any<CancellationToken>())
+            .Returns(ContactFieldVisibility.AllActiveProfiles);
+        _userEmailService.GetVisibleEmailsAsync(targetUserId, Arg.Any<ContactFieldVisibility>(), Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<UserEmailDto>());
+
+        // Mix of types — Phone must win over Signal regardless of insert order.
+        _contactFieldService.GetVisibleContactFieldsAsync(targetProfileId, viewer.Id, Arg.Any<CancellationToken>())
+            .Returns(new[]
+            {
+                new ContactFieldDto(Guid.NewGuid(), ContactFieldType.Signal, "Signal", "signal-handle",
+                    ContactFieldVisibility.AllActiveProfiles),
+                new ContactFieldDto(Guid.NewGuid(), ContactFieldType.Phone, "Phone", "+1-555-0100",
+                    ContactFieldVisibility.AllActiveProfiles),
+            });
+
+        var sut = BuildSut(viewer);
+
+        var result = await sut.Search(q: "David");
+
+        var row = result.Should().BeOfType<OkObjectResult>().Subject.Value
+            .Should().BeAssignableTo<IEnumerable<HumanLookupSearchResult>>().Subject.Single();
+        row.Detail.Should().Be("Phone +1-555-0100");
+    }
+
+    [HumansFact]
+    public async Task Search_returns_null_detail_when_viewer_can_see_nothing()
+    {
+        var viewer = MakeUser(Guid.NewGuid());
+        var targetUserId = Guid.NewGuid();
+        var targetProfileId = Guid.NewGuid();
+
+        _profileService.SearchProfilesAsync(Arg.Any<string>(),
+                Arg.Any<PersonSearchFields>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(new[] { MakeSearchResult(targetUserId, targetProfileId, "David") });
+
+        _contactFieldService.GetViewerAccessLevelAsync(targetUserId, viewer.Id, Arg.Any<CancellationToken>())
+            .Returns(ContactFieldVisibility.AllActiveProfiles);
+        _userEmailService.GetVisibleEmailsAsync(targetUserId, Arg.Any<ContactFieldVisibility>(), Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<UserEmailDto>());
+        _contactFieldService.GetVisibleContactFieldsAsync(targetProfileId, viewer.Id, Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<ContactFieldDto>());
+
+        var sut = BuildSut(viewer);
+
+        var result = await sut.Search(q: "David");
+
+        result.Should().BeOfType<OkObjectResult>().Subject.Value
+            .Should().BeAssignableTo<IEnumerable<HumanLookupSearchResult>>().Subject
+            .Single().Detail.Should().BeNull();
+    }
+
+    [HumansFact]
+    public async Task Search_skips_obsolete_email_contact_field_type()
+    {
+        var viewer = MakeUser(Guid.NewGuid());
+        var targetUserId = Guid.NewGuid();
+        var targetProfileId = Guid.NewGuid();
+
+        _profileService.SearchProfilesAsync(Arg.Any<string>(),
+                Arg.Any<PersonSearchFields>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(new[] { MakeSearchResult(targetUserId, targetProfileId, "David") });
+
+        _contactFieldService.GetViewerAccessLevelAsync(targetUserId, viewer.Id, Arg.Any<CancellationToken>())
+            .Returns(ContactFieldVisibility.AllActiveProfiles);
+        _userEmailService.GetVisibleEmailsAsync(targetUserId, Arg.Any<ContactFieldVisibility>(), Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<UserEmailDto>());
+
+#pragma warning disable CS0618 // Verifying the controller skips the obsolete Email enum value.
+        _contactFieldService.GetVisibleContactFieldsAsync(targetProfileId, viewer.Id, Arg.Any<CancellationToken>())
+            .Returns(new[]
+            {
+                new ContactFieldDto(Guid.NewGuid(), ContactFieldType.Email, "Email", "obsolete@example.com",
+                    ContactFieldVisibility.AllActiveProfiles),
+                new ContactFieldDto(Guid.NewGuid(), ContactFieldType.Discord, "Discord", "user#1234",
+                    ContactFieldVisibility.AllActiveProfiles),
+            });
+#pragma warning restore CS0618
+
+        var sut = BuildSut(viewer);
+
+        var result = await sut.Search(q: "David");
+
+        var row = result.Should().BeOfType<OkObjectResult>().Subject.Value
+            .Should().BeAssignableTo<IEnumerable<HumanLookupSearchResult>>().Subject.Single();
+        row.Detail.Should().Be("Discord user#1234");
+    }
+
+    // ==========================================================================
+    // GetByUserId — single-person lookup. Same privacy gate, plus 404 paths.
+    // ==========================================================================
+
+    [HumansFact]
+    public async Task GetByUserId_returns_404_when_full_profile_not_in_cache()
+    {
+        var viewer = MakeUser(Guid.NewGuid());
+        _profileService.GetFullProfileAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns((FullProfile?)null);
+
+        var sut = BuildSut(viewer);
+
+        var result = await sut.GetByUserId(Guid.NewGuid());
+
+        result.Should().BeOfType<NotFoundResult>();
+    }
+
+    [HumansFact]
+    public async Task GetByUserId_returns_404_when_profile_is_rejected()
+    {
+        var viewer = MakeUser(Guid.NewGuid());
+        var targetUserId = Guid.NewGuid();
+        var targetProfileId = Guid.NewGuid();
+
+        _profileService.GetFullProfileAsync(targetUserId, Arg.Any<CancellationToken>())
+            .Returns(MakeFullProfile(targetUserId, targetProfileId, isRejected: true));
+
+        var sut = BuildSut(viewer);
+
+        var result = await sut.GetByUserId(targetUserId);
+
+        result.Should().BeOfType<NotFoundResult>();
+    }
+
+    [HumansFact]
+    public async Task GetByUserId_returns_picker_row_with_viewer_visible_email()
+    {
+        var viewer = MakeUser(Guid.NewGuid());
+        var targetUserId = Guid.NewGuid();
+        var targetProfileId = Guid.NewGuid();
+
+        _profileService.GetFullProfileAsync(targetUserId, Arg.Any<CancellationToken>())
+            .Returns(MakeFullProfile(targetUserId, targetProfileId, burnerName: "Davey"));
+        _contactFieldService.GetViewerAccessLevelAsync(targetUserId, viewer.Id, Arg.Any<CancellationToken>())
+            .Returns(ContactFieldVisibility.AllActiveProfiles);
+        _userEmailService.GetVisibleEmailsAsync(targetUserId, Arg.Any<ContactFieldVisibility>(), Arg.Any<CancellationToken>())
+            .Returns(new[]
+            {
+                new UserEmailDto(Guid.NewGuid(), "shared@example.com",
+                    IsVerified: true, IsGoogle: false, Provider: null, ProviderKey: null,
+                    IsPrimary: true, Visibility: ContactFieldVisibility.AllActiveProfiles),
+            });
+
+        var sut = BuildSut(viewer);
+
+        var result = await sut.GetByUserId(targetUserId);
+
+        var row = result.Should().BeOfType<OkObjectResult>().Subject.Value
+            .Should().BeOfType<HumanLookupSearchResult>().Subject;
+        row.UserId.Should().Be(targetUserId);
+        row.DisplayName.Should().Be("Davey");
+        row.Detail.Should().Be("shared@example.com");
+    }
+}


### PR DESCRIPTION
Closes nobodies-collective/Humans#714

## What changed

- Enriches shared human picker results with a second-line detail when the current viewer is allowed to see one.
- Privacy gate uses the existing `IContactFieldService` visibility ladder (`BoardOnly` / `CoordinatorsAndBoard` / `MyTeams` / `AllActiveProfiles`). The detail priority order is: viewer-visible primary email → highest-priority visible contact field (Phone → Signal → Telegram → WhatsApp → Discord → Other) → null.
- Adds optional avatar thumbnails to the shared picker dropdown when a profile has a custom-uploaded picture.
- Adds `GET /api/profiles/by-userid/{userId:guid}` for callers that already know a userId (URL params, integrations, picker pre-fill).

## Why

Barrio lead selection and the other shared human picker surfaces only showed playa name, which makes it hard to distinguish people with common names. The picker now shows privacy-respecting context without exposing legal names or contact methods to viewers who should not see them.

## AC4 note — semantic shift vs the original sketch

Issue #714's AC4 was originally framed as "admin-bit content only renders for admin-bit callers." This PR replaces that search-bit gate with a strictly stronger per-viewer visibility ladder: a non-admin viewer on a non-admin endpoint sees only `AllActiveProfiles`-visible data. The ladder is the same one `ProfileCardViewComponent` uses for the profile card, so the picker row never reveals more than the click-through card would. This is cleaner than the original sketch — no semantic regression.

## Why no legal-name fallback

An earlier revision included a self/board → legal-name branch at the top of the priority chain. Dropped at PR review: at the project's ~500-user scale the branch helped only the tiny board cohort (who already see legal name on profile-card click-through) while costing a per-search `IProfileService.GetByUserIdsAsync` DB round-trip. Removing it lets the entire search path stay cache-backed (`CachingProfileService._byUserId` + `FullProfile.ProfileId`).

## Validation

- Tested locally on the barrio member setup picker with seeded `David` profiles covering shared email, avatar, public contact fields, and hidden/team-only fields.
- Confirmed `/api/profiles/search?q=David&scope=name` returns expected visible details for `barrio-1-lead`.
- 8 new tests under `Humans.Web.Tests/Controllers/ProfileApiControllerTests` cover the privacy-gate decision tree end-to-end (anonymous viewer, visible email surfaces, contact-field priority ordering, null-detail fallback, obsolete-Email skip, `GetByUserId` not-found / rejected branches).
- `dotnet build Humans.slnx -v quiet` — clean (0 errors, warnings unrelated to this PR).
- Feature spec: `docs/features/profiles/profile-search-detail.md`.