### PR TITLE
Gate OnboardingReview + Consent on ProfileState.Active

### DIFF
--- a/src/Humans.Application/Services/Consent/ConsentService.cs
+++ b/src/Humans.Application/Services/Consent/ConsentService.cs
@@ -181,6 +181,15 @@ public sealed class ConsentService : IConsentService, IUserDataContributor
         Guid userId, Guid documentVersionId, bool explicitConsent,
         string ipAddress, string userAgent, CancellationToken ct = default)
     {
+        // Issue #711: defense-in-depth Stub gate. The ConsentController also
+        // redirects Stub-state users to /Profile/Edit before calling here, but
+        // any future caller that bypasses the controller must still be refused
+        // so a ConsentRecord is never written for a Profile with null legal
+        // name. Mirrors the upstream ProfileRepository.GetReviewableAsync rule.
+        var profile = await _profileService.GetProfileAsync(userId, ct);
+        if (profile is not null && !profile.HasRequiredIdentityFields())
+            return new ConsentSubmitResult(false, ErrorKey: "StubProfile");
+
         var version = await _legalDocumentSyncService.GetVersionByIdAsync(documentVersionId, ct);
 
         if (version is null)

--- a/src/Humans.Application/Services/Consent/ConsentService.cs
+++ b/src/Humans.Application/Services/Consent/ConsentService.cs
@@ -181,13 +181,13 @@ public sealed class ConsentService : IConsentService, IUserDataContributor
         Guid userId, Guid documentVersionId, bool explicitConsent,
         string ipAddress, string userAgent, CancellationToken ct = default)
     {
-        // Issue #711: defense-in-depth Stub gate. The ConsentController also
-        // redirects Stub-state users to /Profile/Edit before calling here, but
-        // any future caller that bypasses the controller must still be refused
-        // so a ConsentRecord is never written for a Profile with null legal
-        // name. Mirrors the upstream ProfileRepository.GetReviewableAsync rule.
+        // Defense-in-depth Stub gate. ConsentController redirects Stub-state
+        // users to /Profile/Edit before calling here, but any future caller
+        // that bypasses the controller — including the case where the profile
+        // row is missing entirely — must still be refused so a ConsentRecord
+        // is never written for a Profile with no verified legal name.
         var profile = await _profileService.GetProfileAsync(userId, ct);
-        if (profile is not null && !profile.HasRequiredIdentityFields())
+        if (profile is null || !profile.HasRequiredIdentityFields())
             return new ConsentSubmitResult(false, ErrorKey: "StubProfile");
 
         var version = await _legalDocumentSyncService.GetVersionByIdAsync(documentVersionId, ct);

--- a/src/Humans.Application/Services/Onboarding/OnboardingService.cs
+++ b/src/Humans.Application/Services/Onboarding/OnboardingService.cs
@@ -154,10 +154,6 @@ public sealed class OnboardingService : IOnboardingService
 
         var selected = userIds.ToHashSet();
         var data = await GetReviewQueueAsync(ct);
-        // Issue #711: the FullName check is no longer needed — the upstream
-        // ProfileRepository.GetReviewableAsync filter excludes Stub profiles
-        // entirely, so anything reaching this list already has the required
-        // identity fields populated.
         var eligibleUserIds = data.Pending
             .Concat(data.Flagged)
             .Where(p => selected.Contains(p.UserId))

--- a/src/Humans.Application/Services/Onboarding/OnboardingService.cs
+++ b/src/Humans.Application/Services/Onboarding/OnboardingService.cs
@@ -154,9 +154,13 @@ public sealed class OnboardingService : IOnboardingService
 
         var selected = userIds.ToHashSet();
         var data = await GetReviewQueueAsync(ct);
+        // Issue #711: the FullName check is no longer needed — the upstream
+        // ProfileRepository.GetReviewableAsync filter excludes Stub profiles
+        // entirely, so anything reaching this list already has the required
+        // identity fields populated.
         var eligibleUserIds = data.Pending
             .Concat(data.Flagged)
-            .Where(p => selected.Contains(p.UserId) && !string.IsNullOrWhiteSpace(p.FullName))
+            .Where(p => selected.Contains(p.UserId))
             .Select(p => p.UserId)
             .ToList();
 

--- a/src/Humans.Infrastructure/Repositories/Profiles/ProfileRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Profiles/ProfileRepository.cs
@@ -148,19 +148,26 @@ public sealed class ProfileRepository : IProfileRepository
 
     public async Task<IReadOnlyList<Profile>> GetReviewableAsync(CancellationToken ct = default)
     {
+        // Issue #711: gate on ProfileState.Active so Stub profiles (e.g. those
+        // provisioned by the MailerLite importer with null legal names) do not
+        // clutter the Consent Coordinator's review queue. Single upstream rule
+        // via Profile.HasRequiredIdentityFields() / ProfileState.Active.
         await using var ctx = await _factory.CreateDbContextAsync(ct);
         return await ctx.Profiles
             .AsNoTracking()
-            .Where(p => !p.IsApproved && p.RejectedAt == null)
+            .Where(p => !p.IsApproved && p.RejectedAt == null && p.State == ProfileState.Active)
             .OrderBy(p => p.CreatedAt)
             .ToListAsync(ct);
     }
 
     public async Task<int> GetReviewableCountAsync(CancellationToken ct = default)
     {
+        // Issue #711: matches GetReviewableAsync — Stub profiles are excluded
+        // from the badge count so the Consent Coordinator's review queue and
+        // its nav badge stay in lockstep.
         await using var ctx = await _factory.CreateDbContextAsync(ct);
         return await ctx.Profiles
-            .CountAsync(p => !p.IsApproved && p.RejectedAt == null, ct);
+            .CountAsync(p => !p.IsApproved && p.RejectedAt == null && p.State == ProfileState.Active, ct);
     }
 
     public async Task<IReadOnlyList<Guid>> GetApprovedUserIdsAsync(CancellationToken ct = default)

--- a/src/Humans.Infrastructure/Repositories/Profiles/ProfileRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Profiles/ProfileRepository.cs
@@ -148,26 +148,36 @@ public sealed class ProfileRepository : IProfileRepository
 
     public async Task<IReadOnlyList<Profile>> GetReviewableAsync(CancellationToken ct = default)
     {
-        // Issue #711: gate on ProfileState.Active so Stub profiles (e.g. those
-        // provisioned by the MailerLite importer with null legal names) do not
-        // clutter the Consent Coordinator's review queue. Single upstream rule
-        // via Profile.HasRequiredIdentityFields() / ProfileState.Active.
+        // Exclude Stub profiles (null legal name) from the Consent Coordinator's
+        // queue. Profile.State is nullable during the §15i rollout (legacy rows
+        // are backfilled lazily), so we also include null-state rows whose
+        // identity fields are complete — those are Active-equivalent and would
+        // otherwise disappear from the queue until backfill runs.
         await using var ctx = await _factory.CreateDbContextAsync(ct);
         return await ctx.Profiles
             .AsNoTracking()
-            .Where(p => !p.IsApproved && p.RejectedAt == null && p.State == ProfileState.Active)
+            .Where(p => !p.IsApproved
+                && p.RejectedAt == null
+                && (p.State == ProfileState.Active
+                    || (p.State == null
+                        && !string.IsNullOrWhiteSpace(p.BurnerName)
+                        && !string.IsNullOrWhiteSpace(p.FirstName)
+                        && !string.IsNullOrWhiteSpace(p.LastName))))
             .OrderBy(p => p.CreatedAt)
             .ToListAsync(ct);
     }
 
     public async Task<int> GetReviewableCountAsync(CancellationToken ct = default)
     {
-        // Issue #711: matches GetReviewableAsync — Stub profiles are excluded
-        // from the badge count so the Consent Coordinator's review queue and
-        // its nav badge stay in lockstep.
         await using var ctx = await _factory.CreateDbContextAsync(ct);
         return await ctx.Profiles
-            .CountAsync(p => !p.IsApproved && p.RejectedAt == null && p.State == ProfileState.Active, ct);
+            .CountAsync(p => !p.IsApproved
+                && p.RejectedAt == null
+                && (p.State == ProfileState.Active
+                    || (p.State == null
+                        && !string.IsNullOrWhiteSpace(p.BurnerName)
+                        && !string.IsNullOrWhiteSpace(p.FirstName)
+                        && !string.IsNullOrWhiteSpace(p.LastName))), ct);
     }
 
     public async Task<IReadOnlyList<Guid>> GetApprovedUserIdsAsync(CancellationToken ct = default)

--- a/src/Humans.Web/Controllers/ConsentController.cs
+++ b/src/Humans.Web/Controllers/ConsentController.cs
@@ -165,7 +165,7 @@ public class ConsentController : HumansControllerBase
     private IActionResult RedirectToProfileEditForStub()
     {
         SetInfo(_localizer["Consent_StubProfile_AddName"].Value);
-        return RedirectToAction("Edit", "Profile");
+        return RedirectToAction(nameof(ProfileController.Edit), "Profile");
     }
 
     private async Task<ConsentDetailViewModel?> BuildConsentReviewViewModelAsync(Guid documentVersionId, Guid userId)

--- a/src/Humans.Web/Controllers/ConsentController.cs
+++ b/src/Humans.Web/Controllers/ConsentController.cs
@@ -91,9 +91,9 @@ public class ConsentController : HumansControllerBase
         if (user is null)
             return NotFound();
 
-        // Issue #711: a Stub profile (null legal name) cannot legally attest
-        // to a consent document. Bounce to /Profile/Edit so the user can add
-        // the required identity fields before signing.
+        // A Stub profile (null legal name) cannot legally attest to a consent
+        // document. Bounce to /Profile/Edit so the user can add the required
+        // identity fields before signing.
         if (await IsStubProfileAsync(user.Id))
             return RedirectToProfileEditForStub();
 
@@ -112,8 +112,6 @@ public class ConsentController : HumansControllerBase
         if (user is null)
             return NotFound();
 
-        // Issue #711: same Stub gate as the Review GET. Refuse the write
-        // before calling the service.
         if (await IsStubProfileAsync(user.Id))
             return RedirectToProfileEditForStub();
 

--- a/src/Humans.Web/Controllers/ConsentController.cs
+++ b/src/Humans.Web/Controllers/ConsentController.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Localization;
 using Humans.Domain.Entities;
 using Humans.Web.Models;
 using Humans.Application.Interfaces.Consent;
+using Humans.Application.Interfaces.Profiles;
 
 namespace Humans.Web.Controllers;
 
@@ -12,17 +13,20 @@ namespace Humans.Web.Controllers;
 public class ConsentController : HumansControllerBase
 {
     private readonly IConsentService _consentService;
+    private readonly IProfileService _profileService;
     private readonly IStringLocalizer<SharedResource> _localizer;
     private readonly ILogger<ConsentController> _logger;
 
     public ConsentController(
         UserManager<User> userManager,
         IConsentService consentService,
+        IProfileService profileService,
         IStringLocalizer<SharedResource> localizer,
         ILogger<ConsentController> logger)
         : base(userManager)
     {
         _consentService = consentService;
+        _profileService = profileService;
         _localizer = localizer;
         _logger = logger;
     }
@@ -87,6 +91,12 @@ public class ConsentController : HumansControllerBase
         if (user is null)
             return NotFound();
 
+        // Issue #711: a Stub profile (null legal name) cannot legally attest
+        // to a consent document. Bounce to /Profile/Edit so the user can add
+        // the required identity fields before signing.
+        if (await IsStubProfileAsync(user.Id))
+            return RedirectToProfileEditForStub();
+
         var viewModel = await BuildConsentReviewViewModelAsync(id, user.Id);
         if (viewModel is null)
             return NotFound();
@@ -101,6 +111,11 @@ public class ConsentController : HumansControllerBase
         var user = await GetCurrentUserAsync();
         if (user is null)
             return NotFound();
+
+        // Issue #711: same Stub gate as the Review GET. Refuse the write
+        // before calling the service.
+        if (await IsStubProfileAsync(user.Id))
+            return RedirectToProfileEditForStub();
 
         if (!model.ExplicitConsent)
         {
@@ -138,6 +153,21 @@ public class ConsentController : HumansControllerBase
             SetError(_localizer["Consent_SubmitError"].Value);
         }
         return RedirectToAction(nameof(Index));
+    }
+
+    private async Task<bool> IsStubProfileAsync(Guid userId)
+    {
+        var profile = await _profileService.GetProfileAsync(userId);
+        // Treat a missing profile as non-Stub (NotFound semantics flow through
+        // the existing service path); only block when the profile exists and
+        // is missing required identity fields.
+        return profile is not null && !profile.HasRequiredIdentityFields();
+    }
+
+    private IActionResult RedirectToProfileEditForStub()
+    {
+        SetInfo(_localizer["Consent_StubProfile_AddName"].Value);
+        return RedirectToAction("Edit", "Profile");
     }
 
     private async Task<ConsentDetailViewModel?> BuildConsentReviewViewModelAsync(Guid documentVersionId, Guid userId)

--- a/src/Humans.Web/Controllers/Mailer/MailerAdminController.cs
+++ b/src/Humans.Web/Controllers/Mailer/MailerAdminController.cs
@@ -96,7 +96,7 @@ public sealed class MailerAdminController : HumansControllerBase
             _logger.LogWarning("MailerLite refresh failed: {StatusCode} {Message}", ex.StatusCode, ex.Message);
             TempData["Banner"] = "Refresh failed: " + FormatMailerLiteError(ex);
         }
-        catch (TaskCanceledException ex) when (!ct.IsCancellationRequested)
+        catch (TaskCanceledException) when (!ct.IsCancellationRequested)
         {
             // MailerLiteClient surfaces HttpClient timeouts as TaskCanceledException
             // when the caller did not cancel. Treat it as a transient refresh failure.

--- a/src/Humans.Web/Resources/SharedResource.ca.resx
+++ b/src/Humans.Web/Resources/SharedResource.ca.resx
@@ -518,6 +518,7 @@
   <data name="Consent_AlreadyConsented" xml:space="preserve"><value>Ja has atorgat el teu consentiment a aquest document.</value></data>
   <data name="Consent_ThankYou" xml:space="preserve"><value>Gràcies per atorgar el teu consentiment a {0}.</value><comment>{0} = document name</comment></data>
   <data name="Consent_SubmitError" xml:space="preserve"><value>Alguna cosa ha anat malament en registrar el teu consentiment. Si us plau, torna-ho a provar.</value></data>
+  <data name="Consent_StubProfile_AddName" xml:space="preserve"><value>Afegeix el teu nom legal abans de signar consentiments.</value></data>
 
   <!-- ======================== -->
   <!-- Teams                    -->

--- a/src/Humans.Web/Resources/SharedResource.de.resx
+++ b/src/Humans.Web/Resources/SharedResource.de.resx
@@ -514,6 +514,7 @@
   <data name="Consent_AlreadyConsented" xml:space="preserve"><value>Sie haben diesem Dokument bereits zugestimmt.</value></data>
   <data name="Consent_ThankYou" xml:space="preserve"><value>Vielen Dank für Ihre Einwilligung zu {0}.</value><comment>{0} = document name</comment></data>
   <data name="Consent_SubmitError" xml:space="preserve"><value>Beim Speichern Ihrer Einwilligung ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut.</value></data>
+  <data name="Consent_StubProfile_AddName" xml:space="preserve"><value>Bitte tragen Sie Ihren amtlichen Namen ein, bevor Sie Einwilligungen unterzeichnen.</value></data>
 
   <!-- ======================== -->
   <!-- Teams                    -->

--- a/src/Humans.Web/Resources/SharedResource.es.resx
+++ b/src/Humans.Web/Resources/SharedResource.es.resx
@@ -518,6 +518,7 @@
   <data name="Consent_AlreadyConsented" xml:space="preserve"><value>Ya ha otorgado su consentimiento a este documento.</value></data>
   <data name="Consent_ThankYou" xml:space="preserve"><value>Gracias por otorgar su consentimiento a {0}.</value><comment>{0} = document name</comment></data>
   <data name="Consent_SubmitError" xml:space="preserve"><value>Algo sali&#xF3; mal al registrar su consentimiento. Por favor, int&#xE9;ntelo de nuevo.</value></data>
+  <data name="Consent_StubProfile_AddName" xml:space="preserve"><value>A&#xF1;ada su nombre legal antes de firmar los consentimientos.</value></data>
 
   <!-- ======================== -->
   <!-- Teams                    -->

--- a/src/Humans.Web/Resources/SharedResource.fr.resx
+++ b/src/Humans.Web/Resources/SharedResource.fr.resx
@@ -514,6 +514,7 @@
   <data name="Consent_AlreadyConsented" xml:space="preserve"><value>Vous avez d&#xE9;j&#xE0; consenti &#xE0; ce document.</value></data>
   <data name="Consent_ThankYou" xml:space="preserve"><value>Merci d'avoir consenti &#xE0; {0}.</value><comment>{0} = document name</comment></data>
   <data name="Consent_SubmitError" xml:space="preserve"><value>Une erreur s&#x2019;est produite lors de l&#x2019;enregistrement de votre consentement. Veuillez r&#xE9;essayer.</value></data>
+  <data name="Consent_StubProfile_AddName" xml:space="preserve"><value>Ajoutez votre nom l&#xE9;gal avant de signer les consentements.</value></data>
 
   <!-- ======================== -->
   <!-- Teams                    -->

--- a/src/Humans.Web/Resources/SharedResource.it.resx
+++ b/src/Humans.Web/Resources/SharedResource.it.resx
@@ -514,6 +514,7 @@
   <data name="Consent_AlreadyConsented" xml:space="preserve"><value>Ha già acconsentito a questo documento.</value></data>
   <data name="Consent_ThankYou" xml:space="preserve"><value>Grazie per il Suo consenso a {0}.</value><comment>{0} = document name</comment></data>
   <data name="Consent_SubmitError" xml:space="preserve"><value>Si &#xE8; verificato un errore durante la registrazione del consenso. Per favore, riprovi.</value></data>
+  <data name="Consent_StubProfile_AddName" xml:space="preserve"><value>Aggiunga il Suo nome legale prima di firmare i consensi.</value></data>
 
   <!-- ======================== -->
   <!-- Teams                    -->

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -534,6 +534,7 @@
   <data name="Consent_AlreadyConsented" xml:space="preserve"><value>You have already consented to this document.</value></data>
   <data name="Consent_ThankYou" xml:space="preserve"><value>Thank you for consenting to {0}.</value><comment>{0} = document name</comment></data>
   <data name="Consent_SubmitError" xml:space="preserve"><value>Something went wrong while recording your consent. Please try again.</value></data>
+  <data name="Consent_StubProfile_AddName" xml:space="preserve"><value>Add your legal name before signing consents.</value></data>
 
   <!-- ======================== -->
   <!-- Teams                    -->

--- a/tests/Humans.Application.Tests/Repositories/ProfileRepositoryTests.cs
+++ b/tests/Humans.Application.Tests/Repositories/ProfileRepositoryTests.cs
@@ -5,6 +5,7 @@ using NodaTime.Testing;
 using Humans.Application;
 using Humans.Application.Tests.Infrastructure;
 using Humans.Domain.Entities;
+using Humans.Domain.Enums;
 using Humans.Infrastructure.Data;
 using Xunit;
 using Humans.Infrastructure.Repositories.Profiles;
@@ -181,5 +182,78 @@ public sealed class ProfileRepositoryTests : IDisposable
         persisted.Date.Should().Be(new LocalDate(2024, 6, 15));
         persisted.EventName.Should().Be("Renamed Event");
         persisted.UpdatedAt.Should().Be(afterAdvance);
+    }
+
+    // Issue #711: Stub profiles (e.g. those provisioned by the MailerLite
+    // importer with null legal names) must not appear in the Consent
+    // Coordinator's review queue or be counted in the nav badge.
+
+    [HumansFact]
+    public async Task GetReviewableAsync_ExcludesStubProfiles()
+    {
+        var now = _clock.GetCurrentInstant();
+
+        var activeProfile = NewProfile("Burner1", "First", "Last", ProfileState.Active);
+        var stubProfile = NewProfile("", "", "", ProfileState.Stub);
+
+        await _dbContext.Profiles.AddRangeAsync(activeProfile, stubProfile);
+        await _dbContext.SaveChangesAsync();
+
+        var reviewable = await _repo.GetReviewableAsync();
+
+        reviewable.Should().ContainSingle()
+            .Which.Id.Should().Be(activeProfile.Id);
+    }
+
+    [HumansFact]
+    public async Task GetReviewableCountAsync_ExcludesStubProfiles()
+    {
+        var activeOne = NewProfile("B1", "F1", "L1", ProfileState.Active);
+        var activeTwo = NewProfile("B2", "F2", "L2", ProfileState.Active);
+        var stubOne = NewProfile("", "", "", ProfileState.Stub);
+        var stubTwo = NewProfile("", "", "", ProfileState.Stub);
+
+        await _dbContext.Profiles.AddRangeAsync(activeOne, activeTwo, stubOne, stubTwo);
+        await _dbContext.SaveChangesAsync();
+
+        var count = await _repo.GetReviewableCountAsync();
+
+        count.Should().Be(2);
+    }
+
+    [HumansFact]
+    public async Task GetReviewableAsync_ExcludesAlreadyApprovedAndRejected()
+    {
+        var now = _clock.GetCurrentInstant();
+
+        var reviewable = NewProfile("B", "F", "L", ProfileState.Active);
+        var approved = NewProfile("B", "F", "L", ProfileState.Active);
+        approved.IsApproved = true;
+        var rejected = NewProfile("B", "F", "L", ProfileState.Active);
+        rejected.RejectedAt = now;
+
+        await _dbContext.Profiles.AddRangeAsync(reviewable, approved, rejected);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _repo.GetReviewableAsync();
+
+        result.Should().ContainSingle()
+            .Which.Id.Should().Be(reviewable.Id);
+    }
+
+    private Profile NewProfile(string burnerName, string firstName, string lastName, ProfileState state)
+    {
+        var now = _clock.GetCurrentInstant();
+        return new Profile
+        {
+            Id = Guid.NewGuid(),
+            UserId = Guid.NewGuid(),
+            BurnerName = burnerName,
+            FirstName = firstName,
+            LastName = lastName,
+            State = state,
+            CreatedAt = now,
+            UpdatedAt = now,
+        };
     }
 }

--- a/tests/Humans.Application.Tests/Repositories/ProfileRepositoryTests.cs
+++ b/tests/Humans.Application.Tests/Repositories/ProfileRepositoryTests.cs
@@ -184,10 +184,6 @@ public sealed class ProfileRepositoryTests : IDisposable
         persisted.UpdatedAt.Should().Be(afterAdvance);
     }
 
-    // Issue #711: Stub profiles (e.g. those provisioned by the MailerLite
-    // importer with null legal names) must not appear in the Consent
-    // Coordinator's review queue or be counted in the nav badge.
-
     [HumansFact]
     public async Task GetReviewableAsync_ExcludesStubProfiles()
     {
@@ -219,6 +215,27 @@ public sealed class ProfileRepositoryTests : IDisposable
         var count = await _repo.GetReviewableCountAsync();
 
         count.Should().Be(2);
+    }
+
+    [HumansFact]
+    public async Task GetReviewableAsync_IncludesNullStateRowsWithCompleteIdentity()
+    {
+        // Legacy rows whose State has not yet been backfilled by
+        // CachingProfileService are Active-equivalent when identity fields are
+        // complete; they must remain in the queue, while null-state rows with
+        // missing names (legacy Stub-equivalent) must be excluded.
+        var nullStateComplete = NewProfile("Burner", "First", "Last", ProfileState.Active);
+        nullStateComplete.State = null;
+        var nullStateIncomplete = NewProfile("", "", "", ProfileState.Stub);
+        nullStateIncomplete.State = null;
+
+        await _dbContext.Profiles.AddRangeAsync(nullStateComplete, nullStateIncomplete);
+        await _dbContext.SaveChangesAsync();
+
+        var reviewable = await _repo.GetReviewableAsync();
+
+        reviewable.Should().ContainSingle()
+            .Which.Id.Should().Be(nullStateComplete.Id);
     }
 
     [HumansFact]

--- a/tests/Humans.Application.Tests/Services/ConsentServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/ConsentServiceTests.cs
@@ -258,6 +258,66 @@ public class ConsentServiceTests : IDisposable
         result.DocumentName.Should().Be("Privacy Policy");
     }
 
+    // Issue #711: defense-in-depth Stub gate — even if a future caller bypasses
+    // the controller's redirect, ConsentService must refuse Stub-state writes
+    // so no ConsentRecord is ever persisted for a Profile with null legal name.
+
+    [HumansFact]
+    public async Task SubmitConsentAsync_StubProfile_ReturnsStubProfileErrorAndWritesNoRecord()
+    {
+        var userId = Guid.NewGuid();
+        var versionId = Guid.NewGuid();
+        SeedDocumentVersion(versionId, "Privacy Policy", new Dictionary<string, string>(StringComparer.Ordinal) { ["es"] = "text" });
+
+        // Stub profile = required identity fields blank.
+        var stubProfile = new Profile
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            BurnerName = "",
+            FirstName = "",
+            LastName = "",
+            State = ProfileState.Stub,
+            CreatedAt = _clock.GetCurrentInstant(),
+            UpdatedAt = _clock.GetCurrentInstant()
+        };
+        _profileService.GetProfileAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(stubProfile);
+
+        var result = await _service.SubmitConsentAsync(userId, versionId, true, "127.0.0.1", "Agent");
+
+        result.Success.Should().BeFalse();
+        result.ErrorKey.Should().Be("StubProfile");
+        (await _dbContext.ConsentRecords.CountAsync()).Should().Be(0);
+    }
+
+    [HumansFact]
+    public async Task SubmitConsentAsync_ActiveProfile_AllowsWrite()
+    {
+        var userId = Guid.NewGuid();
+        var versionId = Guid.NewGuid();
+        SeedDocumentVersion(versionId, "Privacy Policy", new Dictionary<string, string>(StringComparer.Ordinal) { ["es"] = "text" });
+
+        var activeProfile = new Profile
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            BurnerName = "Burner",
+            FirstName = "First",
+            LastName = "Last",
+            State = ProfileState.Active,
+            CreatedAt = _clock.GetCurrentInstant(),
+            UpdatedAt = _clock.GetCurrentInstant()
+        };
+        _profileService.GetProfileAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(activeProfile);
+
+        var result = await _service.SubmitConsentAsync(userId, versionId, true, "127.0.0.1", "Agent");
+
+        result.Success.Should().BeTrue();
+        (await _dbContext.ConsentRecords.CountAsync()).Should().Be(1);
+    }
+
     // --- GetConsentDashboardAsync ---
 
     [HumansFact]

--- a/tests/Humans.Application.Tests/Services/ConsentServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/ConsentServiceTests.cs
@@ -258,10 +258,6 @@ public class ConsentServiceTests : IDisposable
         result.DocumentName.Should().Be("Privacy Policy");
     }
 
-    // Issue #711: defense-in-depth Stub gate — even if a future caller bypasses
-    // the controller's redirect, ConsentService must refuse Stub-state writes
-    // so no ConsentRecord is ever persisted for a Profile with null legal name.
-
     [HumansFact]
     public async Task SubmitConsentAsync_StubProfile_ReturnsStubProfileErrorAndWritesNoRecord()
     {

--- a/tests/Humans.Application.Tests/Services/ConsentServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/ConsentServiceTests.cs
@@ -83,6 +83,22 @@ public class ConsentServiceTests : IDisposable
         _userService.GetMergedSourceIdsAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
             .Returns((IReadOnlySet<Guid>)new HashSet<Guid>());
 
+        // Default: requesting any profile returns an Active profile with all
+        // required identity fields populated. Tests that need a Stub-state
+        // (or missing) profile override this for the specific userId.
+        _profileService.GetProfileAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo => new Profile
+            {
+                Id = Guid.NewGuid(),
+                UserId = callInfo.ArgAt<Guid>(0),
+                BurnerName = "Burner",
+                FirstName = "First",
+                LastName = "Last",
+                State = ProfileState.Active,
+                CreatedAt = _clock.GetCurrentInstant(),
+                UpdatedAt = _clock.GetCurrentInstant()
+            });
+
         _service = new ConsentService(
             consentRepository,
             _onboardingService,

--- a/tests/Humans.Web.Tests/Controllers/ConsentControllerTests.cs
+++ b/tests/Humans.Web.Tests/Controllers/ConsentControllerTests.cs
@@ -20,10 +20,9 @@ using Xunit;
 namespace Humans.Web.Tests.Controllers;
 
 /// <summary>
-/// Issue #711: ConsentController must gate <c>Review</c> (GET) and
-/// <c>Submit</c> (POST) on <c>ProfileState.Active</c>. A Stub-state profile
-/// (null legal name) is redirected to <c>/Profile/Edit</c> rather than being
-/// allowed to render the signing form or persist a <c>ConsentRecord</c>.
+/// Gates: <c>Review</c> (GET) and <c>Submit</c> (POST) redirect Stub-state
+/// profiles (null legal name) to <c>/Profile/Edit</c> rather than rendering
+/// the signing form or persisting a <c>ConsentRecord</c>.
 /// </summary>
 public class ConsentControllerTests
 {

--- a/tests/Humans.Web.Tests/Controllers/ConsentControllerTests.cs
+++ b/tests/Humans.Web.Tests/Controllers/ConsentControllerTests.cs
@@ -1,0 +1,159 @@
+using System.Security.Claims;
+using Humans.Application.Interfaces.Consent;
+using Humans.Application.Interfaces.Profiles;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using Humans.Testing;
+using Humans.Web.Controllers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using NodaTime;
+using NSubstitute;
+using Xunit;
+
+namespace Humans.Web.Tests.Controllers;
+
+/// <summary>
+/// Issue #711: ConsentController must gate <c>Review</c> (GET) and
+/// <c>Submit</c> (POST) on <c>ProfileState.Active</c>. A Stub-state profile
+/// (null legal name) is redirected to <c>/Profile/Edit</c> rather than being
+/// allowed to render the signing form or persist a <c>ConsentRecord</c>.
+/// </summary>
+public class ConsentControllerTests
+{
+    private readonly UserManager<User> _userManager;
+    private readonly IConsentService _consentService = Substitute.For<IConsentService>();
+    private readonly IProfileService _profileService = Substitute.For<IProfileService>();
+    private readonly IStringLocalizer<Humans.Web.SharedResource> _localizer =
+        Substitute.For<IStringLocalizer<Humans.Web.SharedResource>>();
+    private readonly DefaultHttpContext _http = new();
+
+    public ConsentControllerTests()
+    {
+        var userStore = Substitute.For<IUserStore<User>>();
+        _userManager = Substitute.For<UserManager<User>>(
+            userStore, null, null, null, null, null, null, null, null);
+        _localizer[Arg.Any<string>()].Returns(ci =>
+            new LocalizedString(ci.Arg<string>(), ci.Arg<string>()));
+    }
+
+    private ConsentController BuildSut(Guid userId)
+    {
+        var user = new User { Id = userId };
+        _userManager.GetUserAsync(Arg.Any<ClaimsPrincipal>()).Returns(user);
+        _http.User = new ClaimsPrincipal(new ClaimsIdentity(
+            new[] { new Claim(ClaimTypes.NameIdentifier, userId.ToString()) },
+            "test"));
+        var services = new ServiceCollection();
+        services.AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance);
+        _http.RequestServices = services.BuildServiceProvider();
+        _http.Connection.RemoteIpAddress = System.Net.IPAddress.Parse("127.0.0.1");
+
+        var ctrl = new ConsentController(
+            _userManager,
+            _consentService,
+            _profileService,
+            _localizer,
+            NullLogger<ConsentController>.Instance);
+        ctrl.ControllerContext = new ControllerContext
+        {
+            HttpContext = _http,
+            ActionDescriptor = new Microsoft.AspNetCore.Mvc.Controllers.ControllerActionDescriptor { ActionName = "Test" },
+        };
+        ctrl.TempData = new TempDataDictionary(_http, Substitute.For<ITempDataProvider>());
+        ctrl.Url = Substitute.For<IUrlHelper>();
+        return ctrl;
+    }
+
+    private static Profile StubProfile(Guid userId) => new()
+    {
+        Id = Guid.NewGuid(),
+        UserId = userId,
+        BurnerName = "",
+        FirstName = "",
+        LastName = "",
+        State = ProfileState.Stub,
+        CreatedAt = Instant.FromUtc(2026, 1, 1, 0, 0),
+        UpdatedAt = Instant.FromUtc(2026, 1, 1, 0, 0),
+    };
+
+    private static Profile ActiveProfile(Guid userId) => new()
+    {
+        Id = Guid.NewGuid(),
+        UserId = userId,
+        BurnerName = "Burner",
+        FirstName = "First",
+        LastName = "Last",
+        State = ProfileState.Active,
+        CreatedAt = Instant.FromUtc(2026, 1, 1, 0, 0),
+        UpdatedAt = Instant.FromUtc(2026, 1, 1, 0, 0),
+    };
+
+    [HumansFact]
+    public async Task Review_Get_StubProfile_RedirectsToProfileEdit()
+    {
+        var userId = Guid.NewGuid();
+        _profileService.GetProfileAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(StubProfile(userId));
+        var ctrl = BuildSut(userId);
+
+        var result = await ctrl.Review(Guid.NewGuid());
+
+        var redirect = Assert.IsType<RedirectToActionResult>(result);
+        Assert.Equal("Edit", redirect.ActionName);
+        Assert.Equal("Profile", redirect.ControllerName);
+        // Service must NOT be called when gated.
+        await _consentService.DidNotReceive().GetConsentReviewDetailAsync(
+            Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task Submit_Post_StubProfile_RedirectsToProfileEdit_AndDoesNotSubmit()
+    {
+        var userId = Guid.NewGuid();
+        _profileService.GetProfileAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(StubProfile(userId));
+        var ctrl = BuildSut(userId);
+
+        var result = await ctrl.Submit(new Humans.Web.Models.ConsentSubmitModel
+        {
+            DocumentVersionId = Guid.NewGuid(),
+            ExplicitConsent = true,
+        });
+
+        var redirect = Assert.IsType<RedirectToActionResult>(result);
+        Assert.Equal("Edit", redirect.ActionName);
+        Assert.Equal("Profile", redirect.ControllerName);
+        await _consentService.DidNotReceive().SubmitConsentAsync(
+            Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<bool>(),
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task Review_Get_ActiveProfile_DoesNotRedirect()
+    {
+        var userId = Guid.NewGuid();
+        _profileService.GetProfileAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(ActiveProfile(userId));
+        var documentVersionId = Guid.NewGuid();
+        // Service returns nothing — controller will NotFound. The point of
+        // the test is that the Stub redirect was NOT taken; a NotFound is
+        // proof that control reached the service.
+        _consentService.GetConsentReviewDetailAsync(
+                documentVersionId, userId, Arg.Any<CancellationToken>())
+            .Returns(((DocumentVersion?)null, (ConsentRecord?)null, (string?)null));
+        var ctrl = BuildSut(userId);
+
+        var result = await ctrl.Review(documentVersionId);
+
+        Assert.IsType<NotFoundResult>(result);
+        await _consentService.Received(1).GetConsentReviewDetailAsync(
+            documentVersionId, userId, Arg.Any<CancellationToken>());
+    }
+}


### PR DESCRIPTION
## Summary

- Excludes Stub-state profiles from the Consent Coordinator's review queue (`ProfileRepository.GetReviewableAsync` / `GetReviewableCountAsync`).
- Removes the downstream `!IsNullOrWhiteSpace(FullName)` workaround in `OnboardingService.BulkClearConsentChecksAsync` now that the upstream filter covers it.
- Gates `ConsentController.Review` (GET) and `Submit` (POST) on `Profile.HasRequiredIdentityFields()`, redirecting Stub-state users to `/Profile/Edit` with a flash message.
- Adds defense-in-depth in `ConsentService.SubmitConsentAsync`: returns a new `"StubProfile"` error key without writing a `ConsentRecord`, even if a future caller bypasses the controller.
- Adds `Consent_StubProfile_AddName` localization key in all 6 resource files.

Drive-by: fixed a pre-existing CS0168 build error on `main` in `MailerAdminController.cs` (unused exception variable in a `when`-filter) so the worktree could build.

Fixes nobodies-collective/Humans#711

## Test plan

- [x] `dotnet build Humans.slnx -v quiet` — clean.
- [x] `ProfileRepositoryTests.GetReviewableAsync_ExcludesStubProfiles` — only Active profiles are returned.
- [x] `ProfileRepositoryTests.GetReviewableCountAsync_ExcludesStubProfiles` — Stub rows are not counted.
- [x] `ProfileRepositoryTests.GetReviewableAsync_ExcludesAlreadyApprovedAndRejected` — existing predicates still hold.
- [x] `ConsentServiceTests.SubmitConsentAsync_StubProfile_ReturnsStubProfileErrorAndWritesNoRecord` — service refuses Stub state and writes nothing.
- [x] `ConsentServiceTests.SubmitConsentAsync_ActiveProfile_AllowsWrite` — Active still allowed.
- [x] `ConsentControllerTests.Review_Get_StubProfile_RedirectsToProfileEdit` — GET bounces to `/Profile/Edit`.
- [x] `ConsentControllerTests.Submit_Post_StubProfile_RedirectsToProfileEdit_AndDoesNotSubmit` — POST bounces without calling the service.
- [x] `ConsentControllerTests.Review_Get_ActiveProfile_DoesNotRedirect` — Active user reaches the service.
- [x] Existing Application + Web test suites pass (2770 tests).
- [ ] Manual: on preview env, log in as a freshly imported MailerLite stub user and confirm `/Consent/Review/{id}` redirects to `/Profile/Edit`.

> Integration tests (`Humans.Integration.Tests`) were not green locally due to a pre-existing Hangfire-init issue on `origin/main` unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)