### PR TITLE
Fix /Tickets/Admin/Transfers/Detail 500: no-tracking cycle in attendee fetch

### DIFF
--- a/src/Humans.Application/Interfaces/Repositories/ITicketRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/ITicketRepository.cs
@@ -135,7 +135,23 @@ public interface ITicketRepository : IRepository
     /// Used by the transfer-request flow so it can validate ownership without
     /// loading the full attendee set.
     /// </summary>
+    /// <remarks>
+    /// Does NOT include sibling <see cref="TicketOrder.Attendees"/> — that path
+    /// (TicketAttendee → TicketOrder → Attendees) is a cycle and EF Core
+    /// rejects it under <c>AsNoTracking</c>. Callers that need sibling vendor
+    /// ticket ids should call <see cref="GetVendorTicketIdsForOrderAsync"/>.
+    /// </remarks>
     Task<TicketAttendee?> GetAttendeeByIdAsync(Guid attendeeId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns the <c>VendorTicketId</c>s of every attendee on a given order,
+    /// in stable order by vendor ticket id. Used by the transfer admin detail
+    /// page to render sibling tickets without loading the full
+    /// <see cref="TicketAttendee"/> graph (which would form a cycle through
+    /// <see cref="TicketOrder.Attendees"/>).
+    /// </summary>
+    Task<IReadOnlyList<string>> GetVendorTicketIdsForOrderAsync(
+        Guid orderId, CancellationToken ct = default);
 
     /// <summary>
     /// Get all TicketAttendees the user is attached to: either as the buyer

--- a/src/Humans.Application/Services/Tickets/TicketTransferService.cs
+++ b/src/Humans.Application/Services/Tickets/TicketTransferService.cs
@@ -361,8 +361,10 @@ public sealed class TicketTransferService : ITicketTransferService
         var attendee = await _ticketRepo.GetAttendeeByIdAsync(request.OriginalTicketAttendeeId, ct);
 
         var order = attendee?.TicketOrder;
-        var siblingIds = order?.Attendees.Select(a => a.VendorTicketId).ToList()
-            ?? new List<string>();
+        var siblingIds = order is not null
+            ? (await _ticketRepo.GetVendorTicketIdsForOrderAsync(order.Id, ct))
+                .OrderBy(s => s, StringComparer.Ordinal).ToList()
+            : (IReadOnlyList<string>)Array.Empty<string>();
 
         // Cards fall back to a minimal stub if a profile somehow can't be built
         // (e.g. user soft-deleted between request and admin review). The row's

--- a/src/Humans.Infrastructure/Repositories/Tickets/TicketRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Tickets/TicketRepository.cs
@@ -172,8 +172,18 @@ public sealed class TicketRepository : ITicketRepository
         return await ctx.TicketAttendees
             .AsNoTracking()
             .Include(a => a.TicketOrder)
-                .ThenInclude(o => o.Attendees)
             .FirstOrDefaultAsync(a => a.Id == attendeeId, ct);
+    }
+
+    public async Task<IReadOnlyList<string>> GetVendorTicketIdsForOrderAsync(
+        Guid orderId, CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        return await ctx.TicketAttendees
+            .AsNoTracking()
+            .Where(a => a.TicketOrderId == orderId)
+            .Select(a => a.VendorTicketId)
+            .ToListAsync(ct);
     }
 
     public async Task<IReadOnlyList<MatchedAttendeeRow>> GetMatchedAttendeesForEventAsync(

--- a/tests/Humans.Application.Tests/Repositories/TicketRepositoryTests.cs
+++ b/tests/Humans.Application.Tests/Repositories/TicketRepositoryTests.cs
@@ -374,4 +374,124 @@ public sealed class TicketRepositoryTests : IDisposable
 
         result.Should().ContainSingle(a => a.Id == includedId);
     }
+
+    // ── GetAttendeeByIdAsync + GetVendorTicketIdsForOrderAsync ───────────────
+
+    // Regression: peterdrier/Humans#537 included TicketOrder->Attendees under
+    // AsNoTracking, which forms a cycle and EF rejects at query translation.
+    // The fix splits sibling lookup into its own query.
+    [HumansFact]
+    public async Task GetAttendeeByIdAsync_WithSiblingAttendees_DoesNotThrow()
+    {
+        var orderId = Guid.NewGuid();
+        _dbContext.TicketOrders.Add(new TicketOrder
+        {
+            Id = orderId,
+            VendorOrderId = "ord_siblings",
+            VendorEventId = "ev_x",
+            BuyerEmail = "b@x.com",
+            BuyerName = "B",
+            Currency = "EUR",
+            PaymentStatus = TicketPaymentStatus.Paid,
+            PurchasedAt = _clock.GetCurrentInstant(),
+            SyncedAt = _clock.GetCurrentInstant(),
+        });
+
+        var targetId = Guid.NewGuid();
+        await _dbContext.TicketAttendees.AddRangeAsync(
+            new TicketAttendee
+            {
+                Id = targetId,
+                TicketOrderId = orderId,
+                VendorEventId = "ev_x",
+                VendorTicketId = "tkt_1",
+                AttendeeName = "First",
+                Status = TicketAttendeeStatus.Valid,
+                SyncedAt = _clock.GetCurrentInstant(),
+            },
+            new TicketAttendee
+            {
+                Id = Guid.NewGuid(),
+                TicketOrderId = orderId,
+                VendorEventId = "ev_x",
+                VendorTicketId = "tkt_2",
+                AttendeeName = "Second",
+                Status = TicketAttendeeStatus.Valid,
+                SyncedAt = _clock.GetCurrentInstant(),
+            });
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _repo.GetAttendeeByIdAsync(targetId);
+
+        result.Should().NotBeNull();
+        result!.VendorTicketId.Should().Be("tkt_1");
+        result.TicketOrder.Should().NotBeNull();
+        result.TicketOrder.VendorOrderId.Should().Be("ord_siblings");
+    }
+
+    [HumansFact]
+    public async Task GetVendorTicketIdsForOrderAsync_ReturnsAllAttendeesForOrder()
+    {
+        var orderId = Guid.NewGuid();
+        var otherOrderId = Guid.NewGuid();
+        await _dbContext.TicketOrders.AddRangeAsync(
+            new TicketOrder
+            {
+                Id = orderId,
+                VendorOrderId = "ord_target",
+                VendorEventId = "ev_x",
+                BuyerEmail = "b@x.com",
+                BuyerName = "B",
+                Currency = "EUR",
+                PaymentStatus = TicketPaymentStatus.Paid,
+                PurchasedAt = _clock.GetCurrentInstant(),
+                SyncedAt = _clock.GetCurrentInstant(),
+            },
+            new TicketOrder
+            {
+                Id = otherOrderId,
+                VendorOrderId = "ord_other",
+                VendorEventId = "ev_x",
+                BuyerEmail = "c@x.com",
+                BuyerName = "C",
+                Currency = "EUR",
+                PaymentStatus = TicketPaymentStatus.Paid,
+                PurchasedAt = _clock.GetCurrentInstant(),
+                SyncedAt = _clock.GetCurrentInstant(),
+            });
+
+        await _dbContext.TicketAttendees.AddRangeAsync(
+            new TicketAttendee
+            {
+                Id = Guid.NewGuid(),
+                TicketOrderId = orderId,
+                VendorEventId = "ev_x",
+                VendorTicketId = "tkt_b",
+                Status = TicketAttendeeStatus.Valid,
+                SyncedAt = _clock.GetCurrentInstant(),
+            },
+            new TicketAttendee
+            {
+                Id = Guid.NewGuid(),
+                TicketOrderId = orderId,
+                VendorEventId = "ev_x",
+                VendorTicketId = "tkt_a",
+                Status = TicketAttendeeStatus.Valid,
+                SyncedAt = _clock.GetCurrentInstant(),
+            },
+            new TicketAttendee
+            {
+                Id = Guid.NewGuid(),
+                TicketOrderId = otherOrderId,
+                VendorEventId = "ev_x",
+                VendorTicketId = "tkt_other_order",
+                Status = TicketAttendeeStatus.Valid,
+                SyncedAt = _clock.GetCurrentInstant(),
+            });
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _repo.GetVendorTicketIdsForOrderAsync(orderId);
+
+        result.Should().BeEquivalentTo(new[] { "tkt_a", "tkt_b" });
+    }
 }


### PR DESCRIPTION
## Summary

Production 500 on `/Tickets/Admin/Transfers/Detail/{id}`:

```
System.InvalidOperationException: The Include path 'TicketOrder->Attendees' results in a cycle.
Cycles are not allowed in no-tracking queries; either use a tracking query or remove the cycle.
   at TicketRepository.GetAttendeeByIdAsync(...) line 172
   at TicketTransferService.GetDetailAsync(...) line 361
   at TicketTransferAdminController.Detail(...) line 80
```

Introduced by peterdrier/Humans#537 — the sibling-attendee enrichment did `.Include(a => a.TicketOrder).ThenInclude(o => o.Attendees)` under `AsNoTracking`, which EF Core rejects at query translation.

## Fix

Split the query — `GetAttendeeByIdAsync` keeps `Include(a => a.TicketOrder)` only, and a new `GetVendorTicketIdsForOrderAsync(orderId)` loads the sibling ids in a separate no-tracking call. `TicketTransferService.GetDetailAsync` now calls both and orders the sibling ids in the service layer (per `memory/architecture/display-sort-in-controllers.md` — no `OrderBy` in the repo).

## Test plan

- [x] `TicketRepositoryTests.GetAttendeeByIdAsync_WithSiblingAttendees_DoesNotThrow` (regression).
- [x] `TicketRepositoryTests.GetVendorTicketIdsForOrderAsync_ReturnsAllAttendeesForOrder` (filters to the right order).
- [x] Full `Humans.Application.Tests` run: 2727 passing, 1 skipped.
- [x] Display-sort-in-repos architecture ratchet still passes.
- [ ] QA: hit `/Tickets/Admin/Transfers/Detail/dae13497-d6ea-4b7a-9705-3357d57a4471` after deploy, confirm 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)