### PR TITLE
Mailer: outbound slice + audience framework + Ticket-no-Shifts

### DIFF
--- a/docs/sections/AuditLog.md
+++ b/docs/sections/AuditLog.md
@@ -69,6 +69,7 @@ Append-only per design-rules §12. Enforced at two layers: the architecture test
 - **Issues:** `IssueStatusChanged`, `IssueAssigneeChanged`, `IssueSectionChanged`, `IssueGitHubLinked`.
 - **Store:** `StoreOrderCreated`, `StoreLineAdded`, `StoreLineRemoved`, `StoreCounterpartyEdited`, `StoreProductCreated`, `StoreProductUpdated`, `StoreProductDeactivated`, `StorePaymentRecorded`.
 - **Mailer / Imports:** `MailerLiteReconciliationCompleted` — job-level summary written at the end of each Mailer import. Description carries counts as a structured string; no per-row PII.
+- **Mailer / Audience sync:** `MailerLiteAudienceSyncCompleted` — written once per audience by `MailerAudienceSyncService.SyncAsync` (daily Hangfire job + on-demand admin button). Description is a JSON object with `audience_key`, `group_id`, `group_name`, `candidates`, `excluded_unsubscribed`, `created`, `assigned`, `already_assigned`, `unassigned`, `errors`. No per-row PII.
 
 Note: `BudgetAuditLog` is a separate per-section append-only log owned by Budget — it is **not** an `AuditAction` value and does not write to `audit_log`.
 

--- a/docs/sections/Mailer.md
+++ b/docs/sections/Mailer.md
@@ -1,12 +1,13 @@
 # Mailer — Section Invariants
 
-Orchestrates Humans ↔ MailerLite synchronisation. Currently inbound-only; outbound is the immediate next slice (see Invariants below).
+Orchestrates Humans ↔ MailerLite synchronisation. Inbound import + outbound audience management.
 
 ## Concepts
 
-- **MailerLite subscriber** — a row in ML's `subscribers` collection. Has `status ∈ {active, unsubscribed, unconfirmed, bounced, junk}` and `subscribed_at` / `unsubscribed_at` / `opted_in_at` timestamps.
+- **MailerLite subscriber** — a row in ML's `subscribers` collection. Has `status ∈ {active, unsubscribed, unconfirmed, bounced, junk}` and `subscribed_at` / `unsubscribed_at` / `opted_in_at` timestamps. Tracks the `groups` the subscriber belongs to.
 - **Import plan** — the classified result of pulling every ML subscriber and matching against Humans's user/email/preference state. Built fresh on every preview/commit; never persisted between runs.
 - **Apply** — executes an import plan: creates contacts, attaches verified users, deletes unverified UserEmail rows that block contact creation, updates Marketing preferences per the conflict rule, writes one summary audit.
+- **Audience** — a code-defined `IMailerAudience` implementation whose `MailerLiteGroupName` starts with `"Humans - "`. Membership is computed from Humans state and synced into the ML group by `MailerAudienceSyncService` (daily Hangfire job + on-demand admin button).
 
 ## Data Model
 
@@ -17,6 +18,7 @@ Mailer owns no tables. MailerLite is the system of record for subscriber state; 
 - `/Mailer/Admin` — dashboard
 - `/Mailer/Admin/Import` — preview (GET)
 - `/Mailer/Admin/Import/Commit` — apply (POST)
+- `/Mailer/Admin/Audiences/{key}/Sync` — on-demand audience push (POST)
 
 All routes are `AdminOnly`.
 
@@ -29,15 +31,17 @@ All routes are `AdminOnly`.
 
 ## Invariants
 
-- `IMailerLiteService` exposes only GET-shaped methods. No `Create`/`Update`/`Delete`/`Upsert`/`Add`/`Remove`/`Set`/`Post`/`Put`/`Patch` prefixes. Pinned by `MailerArchitectureTests.IMailerLiteService_HasNoWriteMethods`.
-- `MailerLiteClient` runtime-rejects any non-GET HTTP method with `InvalidOperationException`.
-- `MailerImportService` lives in `Humans.Application` and never references `Microsoft.EntityFrameworkCore`. Pinned by architecture test.
+- `IMailerLiteService` exposes reads + four narrow outbound writes: `CreateGroupAsync`, `AssignSubscriberToGroupAsync`, `UnassignSubscriberFromGroupAsync`, `BulkImportSubscribersToGroupAsync`. The set of allowed write methods is pinned by `MailerArchitectureTests.IMailerLiteService_OnlyAllowsAudienceWrites`.
+- Every outbound write targets an ML group whose `Name` starts with `"Humans - "`. `MailerLiteClient` runtime-rejects writes against non-`"Humans - "` groups with `InvalidOperationException`. Pinned by `MailerLiteClientWriteGuardTests`.
+- All `IMailerAudience` implementations target group names starting with `"Humans - "`. Pinned by `MailerArchitectureTests.AllAudiences_UseHumansPrefix`. Audience keys and group names are unique across registrations (pinned by `AllAudiences_HaveUniqueGroupNamesAndKeys`).
+- `MailerImportService` and `MailerAudienceSyncService` live in `Humans.Application` and never reference `Microsoft.EntityFrameworkCore`. Pinned by architecture tests.
 - Every write to `CommunicationPreference[Marketing]` goes through `CommunicationPreferenceService.UpdatePreferenceAsync` and produces a `CommunicationPreferenceChanged` audit entry on real state changes (not idempotent confirms).
 - `ApplyAsync` is idempotent: a second run against unchanged ML+Humans state writes zero per-row entries and exactly one `MailerLiteReconciliationCompleted` summary entry.
+- `SyncAsync` is idempotent: a second run against unchanged audience+ML state writes zero ML mutations and exactly one `MailerLiteAudienceSyncCompleted` summary entry whose counts are all zero.
 - Bounced/junk subscribers always set `OptedOut = true` regardless of any Humans-side timestamp. Delivery facts override preferences.
 - For non-bounce subscribers, Humans state wins only when the prior write's `UpdateSource ∈ {Profile, Guest, MagicLink, OneClick}` AND `UpdatedAt > mlActionAt`.
 - `CommunicationPreference.SubscribedAt` is stamped on first known opt-in and never overwritten while non-null.
-- Inbound-only is a known compliance gap. **Outbound is the next slice and must ship before any other Mailer feature.** Drift in the Humans-newer-than-ML direction is mitigated only by the dashboard drift report (§6.1 of the spec) and manual admin remediation in the ML UI until outbound lands.
+- Audience sync excludes ML subscribers with `status ∈ {unsubscribed, bounced, junk}` from group assignment — delivery/consent state overrides audience membership.
 
 ## Negative Access Rules
 
@@ -51,20 +55,23 @@ All routes are `AdminOnly`.
 - When admin commits an import → one `MailerLiteReconciliationCompleted` audit entry with counts (no PII).
 - When `ApplyAsync` flips `Marketing.OptedOut` → existing `CommunicationPreferenceChanged` audit fires through `CommunicationPreferenceService`.
 - When `ApplyAsync` creates a contact → existing `ContactCreated` audit through `AccountProvisioningService`.
+- When `MailerAudienceSyncService.SyncAsync` runs (via the daily Hangfire job or the on-demand admin button) → one `MailerLiteAudienceSyncCompleted` audit entry with counts (no PII). Per-row ML mutations are not separately audited.
 
 ## Cross-Section Dependencies
 
-- **Profiles**: reads `IUserEmailService.FindVerifiedEmailWithUserAsync`, `FindAnyUserIdByEmailAsync`, `DeleteEmailAsync`; reads/writes `ICommunicationPreferenceService.GetAsync` / `UpdatePreferenceAsync` / `GetCountByCategoryAndStateAsync`.
+- **Profiles**: reads `IUserEmailService.FindVerifiedEmailWithUserAsync`, `FindAnyUserIdByEmailAsync`, `DeleteEmailAsync`, `GetPrimaryEmailsByUserIdsAsync`; reads/writes `ICommunicationPreferenceService.GetAsync` / `UpdatePreferenceAsync` / `GetCountByCategoryAndStateAsync`.
 - **Users**: writes via `IAccountProvisioningService.FindOrCreateUserByEmailAsync`; reads `IUserService.GetByIdAsync` (tombstone follow), `IUserService.GetCountByContactSourceAsync`.
+- **Tickets**: `ITicketQueryService.GetUserIdsWithTicketsAsync` — audience-side ticket-holder enumeration for `TicketNoShiftsAudience`.
+- **Shifts**: `IShiftSignupService.GetActiveCommittedUserIdsForEventAsync` and `IShiftManagementService.GetActiveAsync` — audience-side shift commitment + active-event lookup.
 - **AuditLog**: writes via `IAuditLogService.LogAsync` (job overload).
 
 ## Architecture
 
-**Owning services:** `MailerImportService`, `MailerLiteClient`
-**Owned tables:** _(none — MailerLite is read-only; classifier writes through other sections' services)_
-**Status:** (A) Migrated — new section, born §15-compliant on 2026-05-12.
+**Owning services:** `MailerImportService`, `MailerAudienceSyncService`, `MailerLiteClient`
+**Owned tables:** _(none — MailerLite is read-write for groups owned by Humans; in-Humans writes route through other sections' services)_
+**Status:** (A) Migrated — new section, born §15-compliant on 2026-05-12; outbound + audience framework added 2026-05-14.
 
-- Services live in `Humans.Application.Services.Mailer/` and never import `Microsoft.EntityFrameworkCore`. `MailerLiteClient` lives in `Humans.Infrastructure.Services.Mailer/` (it owns the `HttpClient` + JSON parsing).
+- Services live in `Humans.Application.Services.Mailer/` and never import `Microsoft.EntityFrameworkCore`. `MailerLiteClient` lives in `Humans.Infrastructure.Services.Mailer/` (it owns the `HttpClient` + JSON parsing). `MailerAudienceSyncJob` lives in `Humans.Infrastructure.Jobs/`.
 - **Decorator decision** — no caching decorator. Rationale: admin-only, sequential, runs by hand; one DB count per dashboard load is fine at 500 users.
-- **Cross-section calls** — `IUserEmailService`, `IAccountProvisioningService`, `ICommunicationPreferenceService`, `IUserService`, `IAuditLogService`.
-- **Architecture test** — `tests/Humans.Application.Tests/Architecture/MailerArchitectureTests.cs` pins: namespace, no-EF, GET-only client interface, no cross-section repository injection in `MailerImportService`.
+- **Cross-section calls** — `IUserEmailService`, `IAccountProvisioningService`, `ICommunicationPreferenceService`, `IUserService`, `ITicketQueryService`, `IShiftSignupService`, `IShiftManagementService`, `IAuditLogService`.
+- **Architecture test** — `tests/Humans.Application.Tests/Architecture/MailerArchitectureTests.cs` pins: namespace, no-EF on `MailerImportService` and `MailerAudienceSyncService`, allowed-write surface on `IMailerLiteService`, audience group-name prefix + uniqueness, and no cross-section repository injection in `MailerImportService`. `MailerLiteClientWriteGuardTests` pins the runtime "Humans - " prefix guard.

--- a/docs/superpowers/plans/2026-05-14-mailer-outbound-audiences.md
+++ b/docs/superpowers/plans/2026-05-14-mailer-outbound-audiences.md
@@ -1,0 +1,2440 @@
+# Mailer Outbound + Audience Framework Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add outbound writes to `IMailerLiteService` (prefix-guarded to `"Humans - "` ML groups), introduce an `IMailerAudience` framework, ship the first audience `TicketNoShiftsAudience`, wire a daily Hangfire sync + on-demand admin button.
+
+**Architecture:** Two layers. The outbound slice adds four write methods to the existing `MailerLiteClient` (singleton, `IHttpClientFactory`-based, with an in-memory cache populated lazily). Every write looks up the target group by id and rejects unless `Name.StartsWith("Humans - ")`. On top, a new `IMailerAudience` primitive (registered as singletons in DI) defines audiences as code; `MailerAudienceSyncService` orchestrates compute → diff → apply → audit. One audience implementation: `TicketNoShiftsAudience` (Valid/CheckedIn matched ticket attendee in active vendor event, no Pending/Confirmed shift signup in active `EventSettings`).
+
+**Tech Stack:** .NET 10, ASP.NET Core MVC, NodaTime, Hangfire (recurring jobs), xUnit + AwesomeAssertions, Humans Clean Architecture (Domain / Application / Infrastructure / Web).
+
+**Spec:** [`docs/superpowers/specs/2026-05-14-mailer-outbound-audiences-design.md`](../specs/2026-05-14-mailer-outbound-audiences-design.md).
+
+**Branch:** `mailer-outbound-audiences` (worktree at `.worktrees/mailer-outbound-audiences`).
+
+---
+
+## File Map
+
+**New files:**
+- `src/Humans.Application/Interfaces/Mailer/IMailerAudience.cs` — audience primitive
+- `src/Humans.Application/Interfaces/Mailer/IMailerAudienceSyncService.cs` — orchestrator interface
+- `src/Humans.Application/Interfaces/Mailer/Dtos/AudienceStats.cs` — dashboard stats record
+- `src/Humans.Application/Interfaces/Mailer/Dtos/AudienceSyncResult.cs` — post-sync counts record
+- `src/Humans.Application/Interfaces/Mailer/Dtos/BulkImportResult.cs` — ML bulk-import response shape
+- `src/Humans.Application/Services/Mailer/MailerAudienceSyncService.cs` — orchestrator impl
+- `src/Humans.Application/Services/Mailer/Audiences/TicketNoShiftsAudience.cs` — first audience
+- `src/Humans.Infrastructure/Jobs/MailerAudienceSyncJob.cs` — Hangfire recurring job
+- `src/Humans.Web/Models/Mailer/AudienceCardRow.cs` — one row of the dashboard card
+- `src/Humans.Web/Views/Mailer/Admin/_AudiencesCard.cshtml` — dashboard partial
+- `tests/Humans.Application.Tests/Services/Mailer/MailerAudienceSyncServiceTests.cs`
+- `tests/Humans.Application.Tests/Services/Mailer/Audiences/TicketNoShiftsAudienceTests.cs`
+- `tests/Humans.Web.Tests/Controllers/Mailer/MailerAdminControllerAudienceSyncTests.cs`
+
+**Modified files:**
+- `src/Humans.Domain/Enums/AuditAction.cs` — add `MailerLiteAudienceSyncCompleted`
+- `src/Humans.Application/Interfaces/Mailer/MailerLiteOptions.cs` — add `AudienceSyncCron`, `BulkImportChunkSize`
+- `src/Humans.Application/Interfaces/Mailer/IMailerLiteService.cs` — add four write methods
+- `src/Humans.Application/Interfaces/Shifts/IShiftSignupService.cs` — add `GetActiveCommittedUserIdsForEventAsync`
+- `src/Humans.Application/Interfaces/Shifts/IShiftSignupRepository.cs` — add matching repo method
+- `src/Humans.Application/Services/Shifts/ShiftSignupService.cs` — implement
+- `src/Humans.Infrastructure/Repositories/Shifts/ShiftSignupRepository.cs` — implement
+- `src/Humans.Infrastructure/Services/Mailer/MailerLiteClient.cs` — implement four write methods + prefix guard + cache invalidation
+- `src/Humans.Web/Controllers/Mailer/MailerAdminController.cs` — add audience-sync POST + extend `Index`
+- `src/Humans.Web/Models/Mailer/MailerDashboardViewModel.cs` — add `Audiences`
+- `src/Humans.Web/Views/Mailer/Admin/Index.cshtml` — render audiences card
+- `src/Humans.Web/Extensions/RecurringJobExtensions.cs` — register `mailer-audience-sync`
+- `src/Humans.Web/Program.cs` — DI registrations (`IMailerAudience`, sync service, job)
+- `tests/Humans.Application.Tests/Architecture/MailerArchitectureTests.cs` — replace `HasNoWriteMethods`, add three new pins
+- `tests/Humans.Application.Tests/Services/Mailer/MailerLiteClientWriteGuardTests.cs` — replace with new write-guard tests
+- `docs/sections/Mailer.md` — update invariants (relax GET-only, add prefix-write, audience framework)
+- `docs/sections/AuditLog.md` — list new action
+
+---
+
+## Phase 1: Outbound primitives on `IMailerLiteService`
+
+### Task 1: Add audit action enum value
+
+**Files:**
+- Modify: `src/Humans.Domain/Enums/AuditAction.cs`
+
+- [ ] **Step 1: Locate the existing Mailer action**
+
+Run: `grep -n MailerLiteReconciliationCompleted src/Humans.Domain/Enums/AuditAction.cs`
+Expected: one match around line 166.
+
+- [ ] **Step 2: Add the new action immediately after it**
+
+Edit `src/Humans.Domain/Enums/AuditAction.cs` — locate the line:
+```csharp
+    MailerLiteReconciliationCompleted,
+```
+Add the next line immediately below it:
+```csharp
+    MailerLiteAudienceSyncCompleted,
+```
+
+- [ ] **Step 3: Build to verify**
+
+Run: `dotnet build Humans.slnx -v quiet`
+Expected: build succeeds (no test failures expected from this change alone — but any code using exhaustive switches over `AuditAction` may surface; if so, add a default case-mapping in the same commit).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Humans.Domain/Enums/AuditAction.cs
+git commit -m "feat(audit): add MailerLiteAudienceSyncCompleted action"
+```
+
+---
+
+### Task 2: Add `BulkImportResult` DTO
+
+**Files:**
+- Create: `src/Humans.Application/Interfaces/Mailer/Dtos/BulkImportResult.cs`
+
+- [ ] **Step 1: Write the DTO**
+
+Create `src/Humans.Application/Interfaces/Mailer/Dtos/BulkImportResult.cs`:
+```csharp
+namespace Humans.Application.Interfaces.Mailer.Dtos;
+
+/// <summary>
+/// Aggregated outcome of a bulk import call (or chain of chunked calls) that
+/// creates-and-assigns subscribers to a single MailerLite group.
+/// </summary>
+public sealed record BulkImportResult(
+    int Created,
+    int Updated,
+    int Duplicates,
+    int Errors);
+```
+
+- [ ] **Step 2: Build to verify**
+
+Run: `dotnet build Humans.slnx -v quiet`
+Expected: build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/Humans.Application/Interfaces/Mailer/Dtos/BulkImportResult.cs
+git commit -m "feat(mailer): add BulkImportResult DTO"
+```
+
+---
+
+### Task 3: Extend `MailerLiteOptions`
+
+**Files:**
+- Modify: `src/Humans.Application/Interfaces/Mailer/MailerLiteOptions.cs`
+
+- [ ] **Step 1: Add the two new properties**
+
+Edit `src/Humans.Application/Interfaces/Mailer/MailerLiteOptions.cs` to read in full:
+```csharp
+namespace Humans.Application.Interfaces.Mailer;
+
+/// <summary>
+/// MailerLite client configuration. Bound from <c>MailerLite:*</c> in
+/// configuration (user-secrets in dev, env-var-shaped <c>MailerLite__ApiKey</c>
+/// or flat <c>MAILERLITE_API_KEY</c> in PR/prod — see Program.cs binding).
+/// </summary>
+public sealed class MailerLiteOptions
+{
+    public const string SectionName = "MailerLite";
+    public string ApiKey { get; set; } = string.Empty;
+    public string BaseUrl { get; set; } = "https://connect.mailerlite.com";
+    public string ApiVersion { get; set; } = "2038-01-01";
+
+    /// <summary>Cron expression for the daily audience sync job. Default 06:00 UTC.</summary>
+    public string AudienceSyncCron { get; set; } = "0 6 * * *";
+
+    /// <summary>
+    /// Max subscribers per call to <c>POST /api/groups/{id}/subscribers/import</c>.
+    /// Implementer to verify ML v2 current ceiling; 50 is the documented safe value
+    /// observed in 2026-05.
+    /// </summary>
+    public int BulkImportChunkSize { get; set; } = 50;
+}
+```
+
+- [ ] **Step 2: Build**
+
+Run: `dotnet build Humans.slnx -v quiet`
+Expected: build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/Humans.Application/Interfaces/Mailer/MailerLiteOptions.cs
+git commit -m "feat(mailer): add AudienceSyncCron + BulkImportChunkSize options"
+```
+
+---
+
+### Task 4: Replace the architecture pin on `IMailerLiteService`
+
+**Files:**
+- Modify: `tests/Humans.Application.Tests/Architecture/MailerArchitectureTests.cs`
+
+- [ ] **Step 1: Find the existing test**
+
+Run: `grep -n IMailerLiteService_HasNoWriteMethods tests/Humans.Application.Tests/Architecture/MailerArchitectureTests.cs`
+Expected: at least one match.
+
+- [ ] **Step 2: Replace it with the new pin**
+
+Replace the existing `IMailerLiteService_HasNoWriteMethods` test (entire `[HumansFact]` method) with:
+```csharp
+[HumansFact]
+public void IMailerLiteService_OnlyAllowsAudienceWrites()
+{
+    var allowedWrites = new HashSet<string>
+    {
+        nameof(IMailerLiteService.CreateGroupAsync),
+        nameof(IMailerLiteService.AssignSubscriberToGroupAsync),
+        nameof(IMailerLiteService.UnassignSubscriberFromGroupAsync),
+        nameof(IMailerLiteService.BulkImportSubscribersToGroupAsync),
+    };
+
+    var writePrefixes = new[]
+    {
+        "Create", "Update", "Delete", "Upsert", "Add", "Remove",
+        "Set", "Post", "Put", "Patch", "Assign", "Unassign", "Bulk",
+    };
+
+    var unexpectedWrites = typeof(IMailerLiteService).GetMethods()
+        .Where(m => writePrefixes.Any(p => m.Name.StartsWith(p, StringComparison.Ordinal)))
+        .Where(m => !allowedWrites.Contains(m.Name))
+        .Select(m => m.Name)
+        .ToList();
+
+    unexpectedWrites.Should().BeEmpty(
+        "IMailerLiteService writes are restricted to the four audience-management methods. " +
+        "New writes need their own architecture review.");
+}
+```
+
+- [ ] **Step 3: Run — should fail to compile**
+
+Run: `dotnet test Humans.slnx --filter "FullyQualifiedName~MailerArchitectureTests" -v quiet`
+Expected: compile error — `IMailerLiteService.CreateGroupAsync` and the other three don't exist yet. This is the failing test that locks in the contract for the next task.
+
+- [ ] **Step 4: Commit the failing test**
+
+```bash
+git add tests/Humans.Application.Tests/Architecture/MailerArchitectureTests.cs
+git commit -m "test(mailer): replace HasNoWriteMethods with OnlyAllowsAudienceWrites pin"
+```
+
+---
+
+### Task 5: Add write method signatures to `IMailerLiteService`
+
+**Files:**
+- Modify: `src/Humans.Application/Interfaces/Mailer/IMailerLiteService.cs`
+
+- [ ] **Step 1: Update the interface**
+
+Replace the entire file with:
+```csharp
+using Humans.Application.Interfaces.Mailer.Dtos;
+
+namespace Humans.Application.Interfaces.Mailer;
+
+/// <summary>
+/// MailerLite client surface. Reads cover account summary, groups, and
+/// subscribers. Writes are narrow: limited to creating "Humans - "-prefixed
+/// groups and managing membership in those groups. Pinned by
+/// <c>MailerArchitectureTests.IMailerLiteService_OnlyAllowsAudienceWrites</c>.
+/// </summary>
+public interface IMailerLiteService : IApplicationService
+{
+    Task<MailerLiteAccountSummary> GetAccountSummaryAsync(CancellationToken ct = default);
+
+    Task<IReadOnlyList<MailerLiteGroup>> ListGroupsAsync(CancellationToken ct = default);
+
+    IAsyncEnumerable<MailerLiteSubscriber> ListSubscribersAsync(CancellationToken ct = default);
+
+    Task<MailerLiteSubscriber?> GetSubscriberAsync(string email, CancellationToken ct = default);
+
+    /// <summary>
+    /// Creates a new group in MailerLite. Runtime-rejects with
+    /// <see cref="InvalidOperationException"/> if <paramref name="name"/> does
+    /// not start with <c>"Humans - "</c>.
+    /// </summary>
+    Task<MailerLiteGroup> CreateGroupAsync(string name, CancellationToken ct = default);
+
+    /// <summary>
+    /// Assigns an existing subscriber to a group. Runtime-rejects with
+    /// <see cref="InvalidOperationException"/> if the target group's
+    /// <see cref="MailerLiteGroup.Name"/> does not start with <c>"Humans - "</c>.
+    /// </summary>
+    Task AssignSubscriberToGroupAsync(string subscriberId, string groupId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Removes a subscriber from a group. Same prefix guard as assign.
+    /// </summary>
+    Task UnassignSubscriberFromGroupAsync(string subscriberId, string groupId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Bulk-creates-or-updates subscribers from a list of emails and assigns them
+    /// to the target group in one MailerLite call (chunked per
+    /// <c>MailerLiteOptions.BulkImportChunkSize</c> by the implementation).
+    /// Same prefix guard as assign.
+    /// </summary>
+    Task<BulkImportResult> BulkImportSubscribersToGroupAsync(
+        string groupId, IReadOnlyList<string> emails, CancellationToken ct = default);
+}
+```
+
+- [ ] **Step 2: Build — interface compiles, but client doesn't implement yet**
+
+Run: `dotnet build Humans.slnx -v quiet`
+Expected: build FAILS in `Humans.Infrastructure` — `MailerLiteClient` doesn't implement the four new methods.
+
+- [ ] **Step 3: Commit the interface alone**
+
+```bash
+git add src/Humans.Application/Interfaces/Mailer/IMailerLiteService.cs
+git commit -m "feat(mailer): declare four prefix-guarded write methods on IMailerLiteService"
+```
+
+---
+
+### Task 6: Replace the `MailerLiteClientWriteGuardTests` test fixture
+
+**Files:**
+- Modify: `tests/Humans.Application.Tests/Services/Mailer/MailerLiteClientWriteGuardTests.cs`
+
+- [ ] **Step 1: Rewrite the test fixture**
+
+Replace the entire file with:
+```csharp
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text.Json;
+using AwesomeAssertions;
+using Humans.Infrastructure.Services.Mailer;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Humans.Application.Tests.Services.Mailer;
+
+public class MailerLiteClientWriteGuardTests
+{
+    [HumansFact]
+    public async Task CreateGroupAsync_RejectsNonHumansName()
+    {
+        var client = NewClient(new ScriptedHandler());
+
+        var act = async () => await client.CreateGroupAsync("Newsletter", CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*Humans - *");
+    }
+
+    [HumansFact]
+    public async Task AssignSubscriberToGroupAsync_RejectsWritesToNonHumansGroups()
+    {
+        var handler = new ScriptedHandler();
+        // First /api/groups call returns a single non-Humans group; the guard reads it
+        // and rejects before any write hits the wire.
+        handler.EnqueueJson(HttpStatusCode.OK,
+            """{"data":[{"id":"99","name":"Newsletter","created_at":"2026-01-01 00:00:00","active_count":0,"unsubscribed_count":0,"unconfirmed_count":0,"bounced_count":0,"junk_count":0}],"meta":{"current_page":1,"last_page":1}}""");
+        handler.EnqueueJson(HttpStatusCode.OK,
+            """{"data":[],"meta":{"next_cursor":null}}"""); // for the subscriber pre-populate
+        var client = NewClient(handler);
+
+        var act = async () => await client.AssignSubscriberToGroupAsync("sub-1", "99", CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*Humans - *");
+    }
+
+    [HumansFact]
+    public async Task UnassignSubscriberFromGroupAsync_RejectsWritesToNonHumansGroups()
+    {
+        var handler = new ScriptedHandler();
+        handler.EnqueueJson(HttpStatusCode.OK,
+            """{"data":[{"id":"99","name":"Newsletter","created_at":"2026-01-01 00:00:00","active_count":0,"unsubscribed_count":0,"unconfirmed_count":0,"bounced_count":0,"junk_count":0}],"meta":{"current_page":1,"last_page":1}}""");
+        handler.EnqueueJson(HttpStatusCode.OK, """{"data":[],"meta":{"next_cursor":null}}""");
+        var client = NewClient(handler);
+
+        var act = async () => await client.UnassignSubscriberFromGroupAsync("sub-1", "99", CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    [HumansFact]
+    public async Task BulkImportSubscribersToGroupAsync_RejectsWritesToNonHumansGroups()
+    {
+        var handler = new ScriptedHandler();
+        handler.EnqueueJson(HttpStatusCode.OK,
+            """{"data":[{"id":"99","name":"Newsletter","created_at":"2026-01-01 00:00:00","active_count":0,"unsubscribed_count":0,"unconfirmed_count":0,"bounced_count":0,"junk_count":0}],"meta":{"current_page":1,"last_page":1}}""");
+        handler.EnqueueJson(HttpStatusCode.OK, """{"data":[],"meta":{"next_cursor":null}}""");
+        var client = NewClient(handler);
+
+        var act = async () => await client.BulkImportSubscribersToGroupAsync(
+            "99", new[] { "a@example.com" }, CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    private static MailerLiteClient NewClient(HttpMessageHandler handler) =>
+        new(new StubHttpClientFactory(handler), NodaTime.SystemClock.Instance,
+            NullLogger<MailerLiteClient>.Instance);
+
+    private sealed class ScriptedHandler : HttpMessageHandler
+    {
+        private readonly Queue<HttpResponseMessage> _responses = new();
+        public void EnqueueJson(HttpStatusCode status, string body)
+            => _responses.Enqueue(new HttpResponseMessage(status)
+            {
+                Content = new StringContent(body, System.Text.Encoding.UTF8, "application/json"),
+            });
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage req, CancellationToken ct)
+            => Task.FromResult(_responses.Count > 0
+                ? _responses.Dequeue()
+                : new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{}", System.Text.Encoding.UTF8, "application/json"),
+                });
+    }
+
+    private sealed class StubHttpClientFactory(HttpMessageHandler handler) : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) =>
+            new(handler, disposeHandler: false) { BaseAddress = new Uri("https://example.test/") };
+    }
+}
+```
+
+- [ ] **Step 2: Run — should fail to compile (write methods not yet implemented in `MailerLiteClient`)**
+
+Run: `dotnet test Humans.slnx --filter "FullyQualifiedName~MailerLiteClientWriteGuardTests" -v quiet`
+Expected: compile error — methods don't exist on the client yet.
+
+- [ ] **Step 3: Commit the failing tests**
+
+```bash
+git add tests/Humans.Application.Tests/Services/Mailer/MailerLiteClientWriteGuardTests.cs
+git commit -m "test(mailer): replace write-guard tests with audience-write specifications"
+```
+
+---
+
+### Task 7: Implement the four writes in `MailerLiteClient` with prefix guard + cache invalidation
+
+**Files:**
+- Modify: `src/Humans.Infrastructure/Services/Mailer/MailerLiteClient.cs`
+
+- [ ] **Step 1: Add a typed Options dependency**
+
+Currently `MailerLiteClient` doesn't take `MailerLiteOptions` — it relies on the `IHttpClientFactory` named client for base URL + auth. We need `BulkImportChunkSize` injected, so update the constructor.
+
+Replace lines 36-41 (the constructor) with:
+```csharp
+public MailerLiteClient(
+    IHttpClientFactory httpFactory,
+    IClock clock,
+    Microsoft.Extensions.Options.IOptions<MailerLiteOptions> options,
+    ILogger<MailerLiteClient> logger)
+{
+    _httpFactory = httpFactory;
+    _clock = clock;
+    _options = options.Value;
+    _logger = logger;
+}
+```
+
+Add the field declaration immediately before `_logger`'s declaration (around line 28):
+```csharp
+private readonly MailerLiteOptions _options;
+```
+
+- [ ] **Step 2: Relax the `SendAsync` GET-only guard**
+
+Replace lines 171-202 (the existing `SendAsync` method) with:
+```csharp
+private async Task<HttpResponseMessage> SendAsync(
+    HttpMethod method, string url, HttpContent? content, CancellationToken ct)
+{
+    var http = _httpFactory.CreateClient(HttpClientName);
+    using var req = new HttpRequestMessage(method, url);
+    if (content is not null) req.Content = content;
+    HttpResponseMessage resp;
+    try
+    {
+        resp = await http.SendAsync(req, ct);
+    }
+    catch (HttpRequestException ex)
+    {
+        _logger.LogError(ex, "MailerLite HTTP call failed: {Method} {Url}", method, url);
+        throw;
+    }
+    catch (TaskCanceledException ex) when (!ct.IsCancellationRequested)
+    {
+        _logger.LogError(ex, "MailerLite HTTP call timed out: {Method} {Url}", method, url);
+        throw;
+    }
+    if (resp.Headers.TryGetValues("X-RateLimit-Remaining", out var values)
+        && int.TryParse(values.FirstOrDefault(), CultureInfo.InvariantCulture, out var remaining) && remaining < 20)
+        _logger.LogWarning("MailerLite rate limit remaining: {Remaining}", remaining);
+    if (!resp.IsSuccessStatusCode)
+        _logger.LogWarning("MailerLite returned {StatusCode}: {Method} {Url}",
+            (int)resp.StatusCode, method, url);
+    return resp;
+}
+```
+
+Then update all existing call sites of `SendAsync` (search for `SendAsync(HttpMethod.Get,`) to pass `null` as the new `content` parameter:
+```csharp
+using var resp = await SendAsync(HttpMethod.Get, url, content: null, ct);
+```
+
+Also update `SendForTestsAsync` signature:
+```csharp
+internal Task<HttpResponseMessage> SendForTestsAsync(HttpMethod method, string url, CancellationToken ct)
+    => SendAsync(method, url, content: null, ct);
+```
+
+- [ ] **Step 3: Add the prefix guard helper**
+
+Add this private helper at the top of the class (after the constructor):
+```csharp
+private const string HumansGroupPrefix = "Humans - ";
+
+private async Task<MailerLiteGroup> RequireHumansGroupAsync(string groupId, CancellationToken ct)
+{
+    var groups = await ListGroupsAsync(ct);
+    var group = groups.FirstOrDefault(g => g.Id == groupId)
+        ?? throw new InvalidOperationException(
+            $"MailerLite group '{groupId}' not found.");
+    if (!group.Name.StartsWith(HumansGroupPrefix, StringComparison.Ordinal))
+        throw new InvalidOperationException(
+            $"MailerLite group '{group.Name}' (id={groupId}) is not managed by Humans. " +
+            $"Writes are restricted to groups whose name starts with '{HumansGroupPrefix}'.");
+    return group;
+}
+```
+
+- [ ] **Step 4: Implement `CreateGroupAsync`**
+
+Add to the class body (suggested location: after `RefreshAsync`):
+```csharp
+public async Task<MailerLiteGroup> CreateGroupAsync(string name, CancellationToken ct = default)
+{
+    if (!name.StartsWith(HumansGroupPrefix, StringComparison.Ordinal))
+        throw new InvalidOperationException(
+            $"Group name '{name}' must start with '{HumansGroupPrefix}'.");
+
+    using var body = JsonContent.Create(new { name }, options: Json);
+    using var resp = await SendAsync(HttpMethod.Post, "/api/groups", body, ct);
+    resp.EnsureSuccessStatusCode();
+    var env = await resp.Content.ReadFromJsonAsync<GroupSingleEnvelope>(Json, ct)
+        ?? throw new InvalidOperationException("MailerLite returned empty body on CreateGroup.");
+
+    InvalidateGroupsCache();
+    return env.Data;
+}
+```
+
+Add the envelope record alongside the existing private records at the bottom of the class:
+```csharp
+private sealed record GroupSingleEnvelope(
+    [property: JsonPropertyName("data")] MailerLiteGroup Data);
+```
+
+- [ ] **Step 5: Implement `AssignSubscriberToGroupAsync`**
+
+Add to the class body:
+```csharp
+public async Task AssignSubscriberToGroupAsync(
+    string subscriberId, string groupId, CancellationToken ct = default)
+{
+    await RequireHumansGroupAsync(groupId, ct);
+
+    using var resp = await SendAsync(
+        HttpMethod.Post,
+        $"/api/subscribers/{Uri.EscapeDataString(subscriberId)}/groups/{Uri.EscapeDataString(groupId)}",
+        content: null, ct);
+    resp.EnsureSuccessStatusCode();
+    InvalidateSubscribersCache();
+}
+```
+
+- [ ] **Step 6: Implement `UnassignSubscriberFromGroupAsync`**
+
+Add to the class body:
+```csharp
+public async Task UnassignSubscriberFromGroupAsync(
+    string subscriberId, string groupId, CancellationToken ct = default)
+{
+    await RequireHumansGroupAsync(groupId, ct);
+
+    using var resp = await SendAsync(
+        HttpMethod.Delete,
+        $"/api/subscribers/{Uri.EscapeDataString(subscriberId)}/groups/{Uri.EscapeDataString(groupId)}",
+        content: null, ct);
+    resp.EnsureSuccessStatusCode();
+    InvalidateSubscribersCache();
+}
+```
+
+- [ ] **Step 7: Implement `BulkImportSubscribersToGroupAsync`**
+
+Add to the class body:
+```csharp
+public async Task<BulkImportResult> BulkImportSubscribersToGroupAsync(
+    string groupId, IReadOnlyList<string> emails, CancellationToken ct = default)
+{
+    await RequireHumansGroupAsync(groupId, ct);
+    if (emails.Count == 0)
+        return new BulkImportResult(0, 0, 0, 0);
+
+    int created = 0, updated = 0, duplicates = 0, errors = 0;
+    var chunkSize = Math.Max(1, _options.BulkImportChunkSize);
+
+    foreach (var chunk in emails.Chunk(chunkSize))
+    {
+        var payload = new
+        {
+            subscribers = chunk.Select(e => new { email = e }).ToArray(),
+            resubscribe = false,        // do not re-subscribe unsubscribed users
+            autoresponders = false,     // do not trigger ML automations on import
+        };
+        using var body = JsonContent.Create(payload, options: Json);
+        using var resp = await SendAsync(
+            HttpMethod.Post,
+            $"/api/groups/{Uri.EscapeDataString(groupId)}/subscribers/import",
+            body, ct);
+        if (!resp.IsSuccessStatusCode)
+        {
+            errors += chunk.Length;
+            _logger.LogWarning(
+                "BulkImport chunk failed for group {GroupId}: {StatusCode}",
+                groupId, (int)resp.StatusCode);
+            continue;
+        }
+        var parsed = await resp.Content.ReadFromJsonAsync<BulkImportEnvelope>(Json, ct);
+        created += parsed?.Imported ?? 0;
+        updated += parsed?.Updated ?? 0;
+        duplicates += parsed?.Duplicates ?? 0;
+    }
+
+    InvalidateSubscribersCache();
+    return new BulkImportResult(created, updated, duplicates, errors);
+}
+```
+
+Add the envelope record alongside the other private records:
+```csharp
+private sealed record BulkImportEnvelope(
+    [property: JsonPropertyName("imported")] int Imported,
+    [property: JsonPropertyName("updated")] int Updated,
+    [property: JsonPropertyName("duplicates")] int Duplicates);
+```
+
+> Implementer note: ML v2's actual response envelope for `groups/{id}/subscribers/import` may differ (the documented shape historically uses `import_added` / `import_updated`). Adjust property names + `BulkImportEnvelope` to match current ML docs at impl time. The DTO `BulkImportResult` exposed to callers is stable.
+
+- [ ] **Step 8: Add cache-invalidation helpers**
+
+Add to the class body (after `RefreshAsync`):
+```csharp
+private void InvalidateSubscribersCache()
+{
+    _gate.Wait();
+    try
+    {
+        _subscribers = null;
+        _summary = null;
+    }
+    finally { _gate.Release(); }
+}
+
+private void InvalidateGroupsCache()
+{
+    _gate.Wait();
+    try { _groups = null; }
+    finally { _gate.Release(); }
+}
+```
+
+- [ ] **Step 9: Update DI registration to provide `IOptions<MailerLiteOptions>`**
+
+Run: `grep -rn "AddSingleton<IMailerLiteService" src/Humans.Web src/Humans.Infrastructure`
+Expected: one registration site (likely `Program.cs` or a service-registration extension).
+
+At that site, ensure `services.Configure<MailerLiteOptions>(...)` is already bound (it is — Slice 1 set this up). Nothing else to change; the constructor change in Step 1 is satisfied automatically.
+
+- [ ] **Step 10: Run the write-guard tests**
+
+Run: `dotnet test Humans.slnx --filter "FullyQualifiedName~MailerLiteClientWriteGuardTests" -v quiet`
+Expected: all four tests PASS.
+
+- [ ] **Step 11: Run the architecture pin**
+
+Run: `dotnet test Humans.slnx --filter "FullyQualifiedName~IMailerLiteService_OnlyAllowsAudienceWrites" -v quiet`
+Expected: PASS.
+
+- [ ] **Step 12: Run the full Mailer test suite**
+
+Run: `dotnet test Humans.slnx --filter "FullyQualifiedName~Mailer" -v quiet`
+Expected: all Mailer tests pass, including the Slice 1 import tests (the GET-only guard removal didn't break them — they still go through `SendAsync(HttpMethod.Get, ...)`).
+
+- [ ] **Step 13: Commit**
+
+```bash
+git add src/Humans.Infrastructure/Services/Mailer/MailerLiteClient.cs
+git commit -m "feat(mailer): implement four prefix-guarded outbound writes on MailerLiteClient"
+```
+
+---
+
+## Phase 2: Audience primitive + framework
+
+### Task 8: Define `IMailerAudience`
+
+**Files:**
+- Create: `src/Humans.Application/Interfaces/Mailer/IMailerAudience.cs`
+
+- [ ] **Step 1: Write the interface**
+
+Create `src/Humans.Application/Interfaces/Mailer/IMailerAudience.cs`:
+```csharp
+namespace Humans.Application.Interfaces.Mailer;
+
+/// <summary>
+/// A code-defined mailing list. Each implementation computes a set of Humans
+/// user-ids who belong in the audience and maps it to a single MailerLite group
+/// whose <see cref="MailerLiteGroupName"/> must start with "Humans - "
+/// (pinned by <c>MailerArchitectureTests.AllAudiences_UseHumansPrefix</c>).
+/// </summary>
+public interface IMailerAudience
+{
+    /// <summary>Stable URL-safe key (e.g. "ticket-no-shifts").</summary>
+    string Key { get; }
+
+    /// <summary>Display name shown on the dashboard card.</summary>
+    string DisplayName { get; }
+
+    /// <summary>Target MailerLite group name. Must start with "Humans - ".</summary>
+    string MailerLiteGroupName { get; }
+
+    /// <summary>
+    /// Returns the current Humans user-ids who belong in this audience.
+    /// Implementations read cross-section state via service interfaces only —
+    /// never via <c>HumansDbContext</c> directly.
+    /// </summary>
+    Task<IReadOnlySet<Guid>> ComputeMemberUserIdsAsync(CancellationToken ct);
+}
+```
+
+- [ ] **Step 2: Build**
+
+Run: `dotnet build Humans.slnx -v quiet`
+Expected: build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/Humans.Application/Interfaces/Mailer/IMailerAudience.cs
+git commit -m "feat(mailer): define IMailerAudience primitive"
+```
+
+---
+
+### Task 9: Add audience DTOs
+
+**Files:**
+- Create: `src/Humans.Application/Interfaces/Mailer/Dtos/AudienceStats.cs`
+- Create: `src/Humans.Application/Interfaces/Mailer/Dtos/AudienceSyncResult.cs`
+
+- [ ] **Step 1: Write `AudienceStats`**
+
+Create `src/Humans.Application/Interfaces/Mailer/Dtos/AudienceStats.cs`:
+```csharp
+using NodaTime;
+
+namespace Humans.Application.Interfaces.Mailer.Dtos;
+
+/// <summary>Read-only stats for one audience, shown on the Mailer admin dashboard.</summary>
+public sealed record AudienceStats(
+    string Key,
+    string DisplayName,
+    string MailerLiteGroupName,
+    int Candidates,
+    int ExcludedUnsubscribed,
+    int CurrentlyInGroup,
+    Instant? LastSyncAt,
+    string? LastSyncSummary);
+```
+
+- [ ] **Step 2: Write `AudienceSyncResult`**
+
+Create `src/Humans.Application/Interfaces/Mailer/Dtos/AudienceSyncResult.cs`:
+```csharp
+namespace Humans.Application.Interfaces.Mailer.Dtos;
+
+/// <summary>Post-sync counts for one audience. Mirrors the audit metadata.</summary>
+public sealed record AudienceSyncResult(
+    string Key,
+    string GroupId,
+    string GroupName,
+    int Candidates,
+    int ExcludedUnsubscribed,
+    int Created,
+    int Assigned,
+    int AlreadyAssigned,
+    int Unassigned,
+    int Errors)
+{
+    public string FormatSummary() =>
+        $"{DisplayCount(Created, "created")}, {DisplayCount(Assigned, "newly assigned")}, " +
+        $"{DisplayCount(Unassigned, "unassigned")}, {DisplayCount(Errors, "errors")}.";
+
+    private static string DisplayCount(int n, string label) => $"{n} {label}";
+}
+```
+
+- [ ] **Step 3: Build**
+
+Run: `dotnet build Humans.slnx -v quiet`
+Expected: build succeeds.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Humans.Application/Interfaces/Mailer/Dtos/AudienceStats.cs src/Humans.Application/Interfaces/Mailer/Dtos/AudienceSyncResult.cs
+git commit -m "feat(mailer): add AudienceStats and AudienceSyncResult DTOs"
+```
+
+---
+
+### Task 10: Add the audience architecture pin
+
+**Files:**
+- Modify: `tests/Humans.Application.Tests/Architecture/MailerArchitectureTests.cs`
+
+- [ ] **Step 1: Add two new test methods**
+
+Inside the existing `MailerArchitectureTests` class, add:
+```csharp
+[HumansFact]
+public void AllAudiences_UseHumansPrefix()
+{
+    var audienceType = typeof(IMailerAudience);
+    var impls = typeof(MailerImportService).Assembly
+        .GetTypes()
+        .Where(t => audienceType.IsAssignableFrom(t) && t is { IsInterface: false, IsAbstract: false })
+        .ToList();
+
+    impls.Should().NotBeEmpty("at least one IMailerAudience implementation is expected once Phase 3 lands.");
+
+    foreach (var impl in impls)
+    {
+        var instance = (IMailerAudience)Activator.CreateInstance(impl, NonPublicConstructorBypass(impl))!;
+        instance.MailerLiteGroupName.Should().StartWith("Humans - ",
+            $"every IMailerAudience must target a Humans-prefixed group; {impl.Name} does not.");
+    }
+}
+
+[HumansFact]
+public void AllAudiences_HaveUniqueGroupNamesAndKeys()
+{
+    var audienceType = typeof(IMailerAudience);
+    var impls = typeof(MailerImportService).Assembly
+        .GetTypes()
+        .Where(t => audienceType.IsAssignableFrom(t) && t is { IsInterface: false, IsAbstract: false })
+        .Select(t => (IMailerAudience)Activator.CreateInstance(t, NonPublicConstructorBypass(t))!)
+        .ToList();
+
+    impls.Select(a => a.Key).Distinct().Count().Should().Be(impls.Count,
+        "audience keys collide");
+    impls.Select(a => a.MailerLiteGroupName).Distinct().Count().Should().Be(impls.Count,
+        "audience group names collide");
+}
+
+// Reflection helper — passes null/default args to allow constructing audiences
+// that take service dependencies. The arch test only inspects metadata properties.
+private static object?[] NonPublicConstructorBypass(Type t)
+{
+    var ctor = t.GetConstructors().OrderByDescending(c => c.GetParameters().Length).First();
+    return ctor.GetParameters().Select(p =>
+        p.ParameterType.IsValueType ? Activator.CreateInstance(p.ParameterType) : null).ToArray();
+}
+```
+
+- [ ] **Step 2: Run — will fail with `Should().NotBeEmpty()` until Phase 3 adds the first audience**
+
+Run: `dotnet test Humans.slnx --filter "FullyQualifiedName~AllAudiences" -v quiet`
+Expected: FAIL — no audience implementations exist yet.
+
+- [ ] **Step 3: Commit the failing pin**
+
+```bash
+git add tests/Humans.Application.Tests/Architecture/MailerArchitectureTests.cs
+git commit -m "test(mailer): pin audience prefix + uniqueness invariants"
+```
+
+> The two new tests stay red until Task 13 lands `TicketNoShiftsAudience`. That is expected and intentional — they're the lock-in for Phase 3.
+
+---
+
+## Phase 3: First audience — `TicketNoShiftsAudience`
+
+### Task 11: Add `GetActiveCommittedUserIdsForEventAsync` to Shifts
+
+**Files:**
+- Modify: `src/Humans.Application/Interfaces/Shifts/IShiftSignupService.cs`
+- Modify: `src/Humans.Application/Interfaces/Shifts/IShiftSignupRepository.cs`
+- Modify: `src/Humans.Application/Services/Shifts/ShiftSignupService.cs`
+- Modify: `src/Humans.Infrastructure/Repositories/Shifts/ShiftSignupRepository.cs`
+- Test: `tests/Humans.Application.Tests/Services/Shifts/ShiftSignupServiceTests.cs` (or new file if a separate one exists for narrow reads — discover during impl)
+
+- [ ] **Step 1: Locate the existing interface**
+
+Run: `grep -n "interface IShiftSignupService" src/Humans.Application/Interfaces/Shifts/IShiftSignupService.cs`
+Expected: one match.
+
+- [ ] **Step 2: Add the interface method**
+
+Inside `IShiftSignupService`, add:
+```csharp
+/// <summary>
+/// Returns user-ids with at least one ShiftSignup for the given event whose
+/// Status is Pending or Confirmed. Used by audience computations to identify
+/// "users who have a shift". Refused/Bailed/Cancelled/NoShow signups do not count.
+/// </summary>
+Task<IReadOnlySet<Guid>> GetActiveCommittedUserIdsForEventAsync(
+    Guid eventSettingsId, CancellationToken ct = default);
+```
+
+- [ ] **Step 3: Add the repository method**
+
+Inside `IShiftSignupRepository`, add:
+```csharp
+Task<IReadOnlySet<Guid>> GetActiveCommittedUserIdsForEventAsync(
+    Guid eventSettingsId, CancellationToken ct = default);
+```
+
+- [ ] **Step 4: Write the failing service test**
+
+Add to the existing service tests file (or create `ShiftSignupServiceActiveCommittedTests.cs` if a new file is more idiomatic to this codebase):
+```csharp
+[HumansFact]
+public async Task GetActiveCommittedUserIdsForEventAsync_DelegatesToRepository()
+{
+    var userA = Guid.NewGuid();
+    var userB = Guid.NewGuid();
+    var eventId = Guid.NewGuid();
+    var repo = new Mock<IShiftSignupRepository>();
+    repo.Setup(r => r.GetActiveCommittedUserIdsForEventAsync(eventId, It.IsAny<CancellationToken>()))
+        .ReturnsAsync(new HashSet<Guid> { userA, userB });
+
+    var svc = NewService(repo.Object);
+
+    var result = await svc.GetActiveCommittedUserIdsForEventAsync(eventId, CancellationToken.None);
+
+    result.Should().BeEquivalentTo(new[] { userA, userB });
+}
+```
+
+(`NewService` is the existing test factory in this fixture — match its shape; if there isn't one, build a constructor call with the minimum required dependencies and Mock the rest.)
+
+- [ ] **Step 5: Run — expect failure (method doesn't exist on service)**
+
+Run: `dotnet test Humans.slnx --filter "FullyQualifiedName~GetActiveCommittedUserIdsForEventAsync_DelegatesToRepository" -v quiet`
+Expected: compile error.
+
+- [ ] **Step 6: Implement the service method**
+
+In `ShiftSignupService`:
+```csharp
+public Task<IReadOnlySet<Guid>> GetActiveCommittedUserIdsForEventAsync(
+    Guid eventSettingsId, CancellationToken ct = default) =>
+    _repo.GetActiveCommittedUserIdsForEventAsync(eventSettingsId, ct);
+```
+
+- [ ] **Step 7: Implement the repository method**
+
+In `ShiftSignupRepository`:
+```csharp
+public async Task<IReadOnlySet<Guid>> GetActiveCommittedUserIdsForEventAsync(
+    Guid eventSettingsId, CancellationToken ct = default)
+{
+    var committedStatuses = new[] { ShiftSignupStatus.Pending, ShiftSignupStatus.Confirmed };
+    var userIds = await _db.ShiftSignups
+        .AsNoTracking()
+        .Where(s => s.Shift.Rota.EventSettingsId == eventSettingsId
+                 && committedStatuses.Contains(s.Status))
+        .Select(s => s.UserId)
+        .Distinct()
+        .ToListAsync(ct);
+    return userIds.ToHashSet();
+}
+```
+
+> Verify the navigation path `Shift.Rota.EventSettingsId` exists on this codebase's `ShiftSignup` entity (Shifts.md confirms `ShiftSignup.Shift` and aggregate-local navs to `Rota` and `EventSettings`). If the FK is exposed directly (`Shift.Rota.EventSettingsId` vs an inverse nav), adjust accordingly.
+
+- [ ] **Step 8: Run — test passes**
+
+Run: `dotnet test Humans.slnx --filter "FullyQualifiedName~GetActiveCommittedUserIdsForEventAsync_DelegatesToRepository" -v quiet`
+Expected: PASS.
+
+- [ ] **Step 9: Run all Shifts tests for regression**
+
+Run: `dotnet test Humans.slnx --filter "FullyQualifiedName~Shifts" -v quiet`
+Expected: all PASS (no existing tests should be affected by the additive read).
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/Humans.Application/Interfaces/Shifts/IShiftSignupService.cs \
+        src/Humans.Application/Interfaces/Shifts/IShiftSignupRepository.cs \
+        src/Humans.Application/Services/Shifts/ShiftSignupService.cs \
+        src/Humans.Infrastructure/Repositories/Shifts/ShiftSignupRepository.cs \
+        tests/Humans.Application.Tests/Services/Shifts/
+git commit -m "feat(shifts): GetActiveCommittedUserIdsForEventAsync narrow read"
+```
+
+---
+
+### Task 12: Confirm ticket-side read
+
+**Files:**
+- Read-only: `src/Humans.Application/Interfaces/Tickets/ITicketQueryService.cs`
+
+- [ ] **Step 1: Inspect existing method signature**
+
+Run: `grep -n "GetAllMatchedUserIdsAsync\|MatchedAttendee" src/Humans.Application/Interfaces/Tickets/ITicketQueryService.cs src/Humans.Application/Services/Tickets/TicketQueryService.cs`
+
+Expected: `GetAllMatchedUserIdsAsync` exists. Inspect its implementation: does it return *attendee*-matched users only (Valid|CheckedIn), or also buyer-matched? Per `Tickets.md`: "GetAllMatchedUserIdsAsync (the union of matched attendee user-ids and matched order user-ids)". So it includes buyers.
+
+- [ ] **Step 2: Decide path**
+
+`TicketNoShiftsAudience` needs **attendee-matched only, status Valid|CheckedIn**. Buyer-only matches are excluded per the audience definition.
+
+Two options:
+- **(a)** Add a new narrow method `GetUserIdsWithMatchedValidAttendeesAsync(CancellationToken)` on `ITicketQueryService` that returns exactly the attendee-matched set with `Status ∈ {Valid, CheckedIn}` in the active vendor event.
+- **(b)** Reuse `GetUserIdsWithTicketsAsync` if such a method already exists with this semantic.
+
+Run: `grep -n "UserIdsWithTickets\|ValidAttendee\|MatchedAttendee" src/Humans.Application/Interfaces/Tickets src/Humans.Application/Services/Tickets`
+
+Expected: discover any existing read with the exact semantic. The `UserIdsWithTickets` cache key referenced in `Tickets.md` may already expose this — look at `TicketQueryService` for a method backing it.
+
+- [ ] **Step 3: Pick the reuse path if available; otherwise add a new method**
+
+If a method like `GetUserIdsWithTicketsAsync()` already returns the correct set (Valid|CheckedIn attendee matches in active event, no buyer-only), reuse it directly. Skip Step 4.
+
+If not, add to `ITicketQueryService`:
+```csharp
+/// <summary>
+/// Returns user-ids with at least one Valid or CheckedIn matched TicketAttendee
+/// in the active vendor event. Buyer-only matches excluded.
+/// </summary>
+Task<IReadOnlySet<Guid>> GetUserIdsWithMatchedValidAttendeesAsync(CancellationToken ct = default);
+```
+
+And implement it in `TicketQueryService` by adapting the existing `UserIdsWithTickets` computation (cache key `CacheKeys.UserIdsWithTickets`).
+
+- [ ] **Step 4: If a new method was added, write a test**
+
+Add to the existing `TicketQueryServiceTests`:
+```csharp
+[HumansFact]
+public async Task GetUserIdsWithMatchedValidAttendeesAsync_ExcludesBuyerOnlyAndVoidedAttendees()
+{
+    // Arrange: seed three users
+    //   - userA has a Valid matched attendee → included
+    //   - userB has a Void matched attendee → excluded
+    //   - userC is a matched buyer with no matched attendees → excluded
+    // ...
+    // Act
+    var result = await _service.GetUserIdsWithMatchedValidAttendeesAsync(CancellationToken.None);
+    // Assert
+    result.Should().Equal(new HashSet<Guid> { userA });
+}
+```
+
+Match the existing Tickets test scaffolding (in-memory DbContext seeding pattern used by `TicketQueryServiceTests`).
+
+- [ ] **Step 5: Run + commit**
+
+If you added a new method:
+```bash
+dotnet test Humans.slnx --filter "FullyQualifiedName~Tickets" -v quiet
+git add src/Humans.Application/Interfaces/Tickets/ITicketQueryService.cs \
+        src/Humans.Application/Services/Tickets/TicketQueryService.cs \
+        tests/Humans.Application.Tests/Services/Tickets/
+git commit -m "feat(tickets): GetUserIdsWithMatchedValidAttendeesAsync narrow read"
+```
+
+If you reused an existing method, no commit for this task — note in the next task's commit which method was reused.
+
+---
+
+### Task 13: Implement `TicketNoShiftsAudience`
+
+**Files:**
+- Create: `src/Humans.Application/Services/Mailer/Audiences/TicketNoShiftsAudience.cs`
+- Create: `tests/Humans.Application.Tests/Services/Mailer/Audiences/TicketNoShiftsAudienceTests.cs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/Humans.Application.Tests/Services/Mailer/Audiences/TicketNoShiftsAudienceTests.cs`:
+```csharp
+using AwesomeAssertions;
+using Humans.Application.Interfaces.Mailer;
+using Humans.Application.Interfaces.Shifts;
+using Humans.Application.Interfaces.Tickets;
+using Humans.Application.Services.Mailer.Audiences;
+using Humans.Domain.Entities;
+using Moq;
+
+namespace Humans.Application.Tests.Services.Mailer.Audiences;
+
+public class TicketNoShiftsAudienceTests
+{
+    private static readonly Guid EventId = Guid.NewGuid();
+
+    [HumansFact]
+    public async Task ComputeMemberUserIdsAsync_ReturnsTicketHoldersMinusShiftHavers()
+    {
+        var userA = Guid.NewGuid(); // ticket, no shift          → IN
+        var userB = Guid.NewGuid(); // ticket, has Confirmed shift → OUT
+        var userC = Guid.NewGuid(); // no ticket                  → OUT
+        var userD = Guid.NewGuid(); // ticket, has Pending shift   → OUT
+
+        var audience = NewAudience(
+            ticketHolders: new HashSet<Guid> { userA, userB, userD },
+            shiftCommitted: new HashSet<Guid> { userB, userD });
+
+        var members = await audience.ComputeMemberUserIdsAsync(CancellationToken.None);
+
+        members.Should().BeEquivalentTo(new[] { userA });
+    }
+
+    [HumansFact]
+    public async Task ComputeMemberUserIdsAsync_NoActiveEvent_ReturnsEmpty()
+    {
+        var audience = NewAudience(ticketHolders: new HashSet<Guid> { Guid.NewGuid() },
+            shiftCommitted: new HashSet<Guid>(),
+            activeEvent: null);
+
+        var members = await audience.ComputeMemberUserIdsAsync(CancellationToken.None);
+
+        members.Should().BeEmpty();
+    }
+
+    [HumansFact]
+    public void Metadata_UsesHumansPrefix()
+    {
+        var audience = NewAudience(new HashSet<Guid>(), new HashSet<Guid>());
+        audience.Key.Should().Be("ticket-no-shifts");
+        audience.MailerLiteGroupName.Should().Be("Humans - Ticket no Shifts");
+    }
+
+    private static TicketNoShiftsAudience NewAudience(
+        HashSet<Guid> ticketHolders,
+        HashSet<Guid> shiftCommitted,
+        EventSettings? activeEvent = null)
+    {
+        var tickets = new Mock<ITicketQueryService>();
+        tickets.Setup(t => t.GetUserIdsWithMatchedValidAttendeesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ticketHolders);
+
+        var signups = new Mock<IShiftSignupService>();
+        signups.Setup(s => s.GetActiveCommittedUserIdsForEventAsync(EventId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(shiftCommitted);
+
+        var mgmt = new Mock<IShiftManagementService>();
+        mgmt.Setup(m => m.GetActiveAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(activeEvent ?? FakeEventSettings(EventId));
+
+        return new TicketNoShiftsAudience(tickets.Object, signups.Object, mgmt.Object);
+    }
+
+    private static EventSettings FakeEventSettings(Guid id)
+    {
+        // Match the construction pattern used in existing Shifts unit tests.
+        // If EventSettings has a private constructor, use the existing test factory.
+        // Substitute appropriately during implementation.
+        return new EventSettings { Id = id, IsActive = true, Year = 2026, Name = "Test" };
+    }
+}
+```
+
+> Implementer note: if `EventSettings` is internal-constructor or has invariants requiring a factory, locate the existing test factory under `tests/Humans.Application.Tests/Services/Shifts/` and reuse. The audience tests don't need a fully-constructed `EventSettings` — only its `Id` is read.
+
+- [ ] **Step 2: Run — should fail to compile**
+
+Run: `dotnet test Humans.slnx --filter "FullyQualifiedName~TicketNoShiftsAudience" -v quiet`
+Expected: compile error — `TicketNoShiftsAudience` doesn't exist yet.
+
+- [ ] **Step 3: Implement the audience**
+
+Create `src/Humans.Application/Services/Mailer/Audiences/TicketNoShiftsAudience.cs`:
+```csharp
+using Humans.Application.Interfaces.Mailer;
+using Humans.Application.Interfaces.Shifts;
+using Humans.Application.Interfaces.Tickets;
+
+namespace Humans.Application.Services.Mailer.Audiences;
+
+/// <summary>
+/// "Humans - Ticket no Shifts" — humans with a Valid/CheckedIn matched
+/// ticket attendee in the active vendor event who have NOT signed up for any
+/// shift in the active EventSettings event (Pending and Confirmed signups
+/// count as "has a shift"; Refused/Bailed/Cancelled/NoShow do not).
+/// </summary>
+public sealed class TicketNoShiftsAudience(
+    ITicketQueryService tickets,
+    IShiftSignupService shiftSignups,
+    IShiftManagementService shiftManagement) : IMailerAudience
+{
+    public string Key => "ticket-no-shifts";
+    public string DisplayName => "Ticket holders without a shift";
+    public string MailerLiteGroupName => "Humans - Ticket no Shifts";
+
+    public async Task<IReadOnlySet<Guid>> ComputeMemberUserIdsAsync(CancellationToken ct)
+    {
+        var activeEvent = await shiftManagement.GetActiveAsync(ct);
+        if (activeEvent is null) return new HashSet<Guid>();
+
+        var ticketHolders = await tickets.GetUserIdsWithMatchedValidAttendeesAsync(ct);
+        var shiftHavers = await shiftSignups.GetActiveCommittedUserIdsForEventAsync(activeEvent.Id, ct);
+
+        var audience = new HashSet<Guid>(ticketHolders);
+        audience.ExceptWith(shiftHavers);
+        return audience;
+    }
+}
+```
+
+> Implementer note: if Task 12 reused an existing method instead of adding `GetUserIdsWithMatchedValidAttendeesAsync`, swap that call to whichever method name you settled on.
+
+- [ ] **Step 4: Run the tests**
+
+Run: `dotnet test Humans.slnx --filter "FullyQualifiedName~TicketNoShiftsAudience" -v quiet`
+Expected: all PASS.
+
+- [ ] **Step 5: Confirm the architecture pin now passes**
+
+Run: `dotnet test Humans.slnx --filter "FullyQualifiedName~AllAudiences" -v quiet`
+Expected: both `AllAudiences_UseHumansPrefix` and `AllAudiences_HaveUniqueGroupNamesAndKeys` PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Humans.Application/Services/Mailer/Audiences/TicketNoShiftsAudience.cs \
+        tests/Humans.Application.Tests/Services/Mailer/Audiences/
+git commit -m "feat(mailer): add TicketNoShiftsAudience"
+```
+
+---
+
+## Phase 4: Audience sync orchestrator
+
+### Task 14: Define `IMailerAudienceSyncService`
+
+**Files:**
+- Create: `src/Humans.Application/Interfaces/Mailer/IMailerAudienceSyncService.cs`
+
+- [ ] **Step 1: Write the interface**
+
+```csharp
+using Humans.Application.Interfaces.Mailer.Dtos;
+
+namespace Humans.Application.Interfaces.Mailer;
+
+/// <summary>
+/// Orchestrates pulling audience definitions, diffing against ML state, and
+/// pushing membership changes to MailerLite. Stat-only reads are split out so
+/// the dashboard can render without forcing a sync.
+/// </summary>
+public interface IMailerAudienceSyncService : IApplicationService
+{
+    /// <summary>Read-only: candidates / excluded-unsubscribed / currently-in-group / last sync.</summary>
+    Task<AudienceStats> ComputeStatsAsync(IMailerAudience audience, CancellationToken ct = default);
+
+    /// <summary>Build diff and apply to MailerLite. Writes the summary audit entry.</summary>
+    Task<AudienceSyncResult> SyncAsync(IMailerAudience audience, CancellationToken ct = default);
+
+    /// <summary>Calls SyncAsync sequentially for every registered audience.</summary>
+    Task<IReadOnlyList<AudienceSyncResult>> SyncAllAsync(CancellationToken ct = default);
+}
+```
+
+- [ ] **Step 2: Build**
+
+Run: `dotnet build Humans.slnx -v quiet`
+Expected: build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/Humans.Application/Interfaces/Mailer/IMailerAudienceSyncService.cs
+git commit -m "feat(mailer): declare IMailerAudienceSyncService"
+```
+
+---
+
+### Task 15: Write failing sync orchestrator tests
+
+**Files:**
+- Create: `tests/Humans.Application.Tests/Services/Mailer/MailerAudienceSyncServiceTests.cs`
+
+- [ ] **Step 1: Write the test fixture**
+
+Create `tests/Humans.Application.Tests/Services/Mailer/MailerAudienceSyncServiceTests.cs`:
+```csharp
+using AwesomeAssertions;
+using Humans.Application.Interfaces.AuditLog;
+using Humans.Application.Interfaces.Mailer;
+using Humans.Application.Interfaces.Mailer.Dtos;
+using Humans.Application.Interfaces.Profiles;
+using Humans.Application.Services.Mailer;
+using Humans.Domain.Enums;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NodaTime;
+
+namespace Humans.Application.Tests.Services.Mailer;
+
+public class MailerAudienceSyncServiceTests
+{
+    private readonly Mock<IMailerLiteService> _ml = new();
+    private readonly Mock<IUserEmailService> _emails = new();
+    private readonly Mock<IAuditLogService> _audit = new();
+
+    [HumansFact]
+    public async Task SyncAsync_NewUserNotInML_BulkImportsAndAssigns()
+    {
+        var userA = Guid.NewGuid();
+        var audience = NewAudience("a-aud", "Humans - A", new[] { userA });
+        SetupEmails(new (Guid, string)[] { (userA, "a@example.com") });
+        SetupGroups(new[] { new MailerLiteGroup("g1", "Humans - A",
+            Instant.FromUtc(2026,1,1,0,0), 0, 0, 0, 0, 0) });
+        SetupSubscribers(Array.Empty<MailerLiteSubscriber>());
+        _ml.Setup(m => m.BulkImportSubscribersToGroupAsync(
+                "g1", It.Is<IReadOnlyList<string>>(l => l.Single() == "a@example.com"),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BulkImportResult(1, 0, 0, 0));
+
+        var result = await NewService().SyncAsync(audience.Object, CancellationToken.None);
+
+        result.Created.Should().Be(1);
+        result.Assigned.Should().Be(0);
+        result.Unassigned.Should().Be(0);
+        _ml.Verify(m => m.BulkImportSubscribersToGroupAsync(
+            "g1", It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [HumansFact]
+    public async Task SyncAsync_UnsubscribedUser_ExcludedFromGroup()
+    {
+        var userA = Guid.NewGuid();
+        var audience = NewAudience("a-aud", "Humans - A", new[] { userA });
+        SetupEmails(new (Guid, string)[] { (userA, "a@example.com") });
+        SetupGroups(new[] { Group("g1", "Humans - A") });
+        SetupSubscribers(new[] { Subscriber("s1", "a@example.com", "unsubscribed") });
+
+        var result = await NewService().SyncAsync(audience.Object, CancellationToken.None);
+
+        result.ExcludedUnsubscribed.Should().Be(1);
+        result.Created.Should().Be(0);
+        result.Assigned.Should().Be(0);
+        _ml.Verify(m => m.AssignSubscriberToGroupAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        _ml.Verify(m => m.BulkImportSubscribersToGroupAsync(
+            It.IsAny<string>(), It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [HumansFact]
+    public async Task SyncAsync_ExistingSubscriberNotInGroup_AssignsIt()
+    {
+        var userA = Guid.NewGuid();
+        var audience = NewAudience("a-aud", "Humans - A", new[] { userA });
+        SetupEmails(new (Guid, string)[] { (userA, "a@example.com") });
+        SetupGroups(new[] { Group("g1", "Humans - A") });
+        SetupSubscribers(new[] { Subscriber("s1", "a@example.com", "active") });
+
+        var result = await NewService().SyncAsync(audience.Object, CancellationToken.None);
+
+        result.Assigned.Should().Be(1);
+        _ml.Verify(m => m.AssignSubscriberToGroupAsync("s1", "g1", It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [HumansFact]
+    public async Task SyncAsync_UserDroppedOut_Unassigned()
+    {
+        var audience = NewAudience("a-aud", "Humans - A", Array.Empty<Guid>());
+        SetupEmails(Array.Empty<(Guid, string)>());
+        SetupGroups(new[] { Group("g1", "Humans - A") });
+        SetupSubscribers(new[] {
+            Subscriber("s1", "a@example.com", "active", inGroups: new[] { "g1" }),
+        });
+
+        var result = await NewService().SyncAsync(audience.Object, CancellationToken.None);
+
+        result.Unassigned.Should().Be(1);
+        _ml.Verify(m => m.UnassignSubscriberFromGroupAsync("s1", "g1", It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [HumansFact]
+    public async Task SyncAsync_GroupMissing_CreatesItFirst()
+    {
+        var userA = Guid.NewGuid();
+        var audience = NewAudience("a-aud", "Humans - A", new[] { userA });
+        SetupEmails(new (Guid, string)[] { (userA, "a@example.com") });
+        SetupGroups(Array.Empty<MailerLiteGroup>());
+        _ml.Setup(m => m.CreateGroupAsync("Humans - A", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Group("g1", "Humans - A"));
+        SetupSubscribers(Array.Empty<MailerLiteSubscriber>());
+        _ml.Setup(m => m.BulkImportSubscribersToGroupAsync(
+                "g1", It.IsAny<IReadOnlyList<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BulkImportResult(1, 0, 0, 0));
+
+        await NewService().SyncAsync(audience.Object, CancellationToken.None);
+
+        _ml.Verify(m => m.CreateGroupAsync("Humans - A", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [HumansFact]
+    public async Task SyncAsync_Idempotent_AllAlreadyAssignedOnSecondRun()
+    {
+        var userA = Guid.NewGuid();
+        var audience = NewAudience("a-aud", "Humans - A", new[] { userA });
+        SetupEmails(new (Guid, string)[] { (userA, "a@example.com") });
+        SetupGroups(new[] { Group("g1", "Humans - A") });
+        SetupSubscribers(new[] {
+            Subscriber("s1", "a@example.com", "active", inGroups: new[] { "g1" }),
+        });
+
+        var result = await NewService().SyncAsync(audience.Object, CancellationToken.None);
+
+        result.AlreadyAssigned.Should().Be(1);
+        result.Created.Should().Be(0);
+        result.Assigned.Should().Be(0);
+        result.Unassigned.Should().Be(0);
+        _ml.VerifyNoOtherCalls();
+    }
+
+    [HumansFact]
+    public async Task SyncAsync_AssignFails_CountedInErrorsAndSyncContinues()
+    {
+        var userA = Guid.NewGuid();
+        var userB = Guid.NewGuid();
+        var audience = NewAudience("a-aud", "Humans - A", new[] { userA, userB });
+        SetupEmails(new (Guid, string)[] { (userA, "a@example.com"), (userB, "b@example.com") });
+        SetupGroups(new[] { Group("g1", "Humans - A") });
+        SetupSubscribers(new[] {
+            Subscriber("s1", "a@example.com", "active"),
+            Subscriber("s2", "b@example.com", "active"),
+        });
+        _ml.Setup(m => m.AssignSubscriberToGroupAsync("s1", "g1", It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("simulated 500"));
+
+        var result = await NewService().SyncAsync(audience.Object, CancellationToken.None);
+
+        result.Errors.Should().Be(1);
+        result.Assigned.Should().Be(1); // s2 still succeeded
+    }
+
+    [HumansFact]
+    public async Task SyncAsync_GroupNameLacksPrefix_ThrowsBeforeAnyMlCall()
+    {
+        var audience = NewAudience("a-aud", "Newsletter", Array.Empty<Guid>());
+
+        var act = async () => await NewService().SyncAsync(audience.Object, CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*Humans - *");
+        _ml.VerifyNoOtherCalls();
+    }
+
+    [HumansFact]
+    public async Task SyncAsync_WritesAuditEntryWithCounts()
+    {
+        var userA = Guid.NewGuid();
+        var audience = NewAudience("a-aud", "Humans - A", new[] { userA });
+        SetupEmails(new (Guid, string)[] { (userA, "a@example.com") });
+        SetupGroups(new[] { Group("g1", "Humans - A") });
+        SetupSubscribers(new[] { Subscriber("s1", "a@example.com", "active") });
+
+        await NewService().SyncAsync(audience.Object, CancellationToken.None);
+
+        _audit.Verify(a => a.LogAsync(
+            AuditAction.MailerLiteAudienceSyncCompleted,
+            null, null, null,
+            It.Is<IReadOnlyDictionary<string, object?>>(d =>
+                (string)d["audience_key"]! == "a-aud"
+                && (int)d["assigned"]! == 1),
+            It.IsAny<string?>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    // -- helpers --
+
+    private MailerAudienceSyncService NewService() => new(
+        _ml.Object, _emails.Object, _audit.Object,
+        NullLogger<MailerAudienceSyncService>.Instance);
+
+    private static Mock<IMailerAudience> NewAudience(
+        string key, string groupName, IEnumerable<Guid> members)
+    {
+        var mock = new Mock<IMailerAudience>();
+        mock.SetupGet(a => a.Key).Returns(key);
+        mock.SetupGet(a => a.DisplayName).Returns(key);
+        mock.SetupGet(a => a.MailerLiteGroupName).Returns(groupName);
+        mock.Setup(a => a.ComputeMemberUserIdsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(members.ToHashSet());
+        return mock;
+    }
+
+    private void SetupEmails(IEnumerable<(Guid UserId, string Email)> mapping)
+    {
+        var dict = mapping.ToDictionary(x => x.UserId, x => x.Email);
+        _emails.Setup(e => e.GetPrimaryEmailsByUserIdsAsync(
+                It.IsAny<IEnumerable<Guid>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(dict);
+    }
+
+    private void SetupGroups(IReadOnlyList<MailerLiteGroup> groups)
+        => _ml.Setup(m => m.ListGroupsAsync(It.IsAny<CancellationToken>())).ReturnsAsync(groups);
+
+    private void SetupSubscribers(IEnumerable<MailerLiteSubscriber> subscribers)
+    {
+        async IAsyncEnumerable<MailerLiteSubscriber> Enumerate()
+        {
+            foreach (var s in subscribers) yield return s;
+            await Task.CompletedTask;
+        }
+        _ml.Setup(m => m.ListSubscribersAsync(It.IsAny<CancellationToken>()))
+            .Returns(Enumerate());
+    }
+
+    private static MailerLiteGroup Group(string id, string name) =>
+        new(id, name, Instant.FromUtc(2026,1,1,0,0), 0, 0, 0, 0, 0);
+
+    private static MailerLiteSubscriber Subscriber(
+        string id, string email, string status, string[]? inGroups = null) =>
+        new(id, email, status, "api",
+            SubscribedAt: Instant.FromUtc(2026,1,1,0,0),
+            UnsubscribedAt: null, OptedInAt: null,
+            FirstName: null, LastName: null);
+        // Note: MailerLiteSubscriber today does not carry a Groups list — see
+        // implementation note in Task 16 for how the orchestrator obtains current
+        // group membership. The test plumbs that via a separate setup hook.
+}
+```
+
+> Implementer note: today's `MailerLiteSubscriber` record (Task 9 of Slice 1) does not include a `Groups` collection. The orchestrator's "is this subscriber currently in the target group?" check needs a source — either extend `MailerLiteSubscriber` with `Groups: IReadOnlyList<string>` and parse it from the ML payload's `groups` array, OR fetch group-member-ids via a dedicated `ListGroupSubscriberIdsAsync(groupId)` method on `IMailerLiteService`. The latter keeps the subscriber DTO unchanged but adds a fifth read method. Implementer to pick — recommendation: extend the subscriber DTO (cleaner — group membership is a property of the subscriber per ML's data model).
+
+If extending the DTO is chosen, the `Subscriber()` test helper above needs an extra constructor arg for `Groups`; the `inGroups` parameter is wired to populate it.
+
+- [ ] **Step 2: Run — fail to compile**
+
+Run: `dotnet test Humans.slnx --filter "FullyQualifiedName~MailerAudienceSyncServiceTests" -v quiet`
+Expected: compile error — `MailerAudienceSyncService` doesn't exist.
+
+- [ ] **Step 3: Commit the failing test fixture**
+
+```bash
+git add tests/Humans.Application.Tests/Services/Mailer/MailerAudienceSyncServiceTests.cs
+git commit -m "test(mailer): write failing MailerAudienceSyncService tests"
+```
+
+---
+
+### Task 16: Resolve the "current group membership" decision and add the bulk email-lookup
+
+**Files (decision-dependent):**
+- Modify: `src/Humans.Application/Interfaces/Mailer/Dtos/MailerLiteSubscriber.cs` (if extending subscriber DTO)
+- Modify: `src/Humans.Infrastructure/Services/Mailer/MailerLiteSubscriberConverter.cs` (if extending subscriber DTO)
+- Modify: `src/Humans.Application/Interfaces/Profiles/IUserEmailService.cs` (add bulk lookup)
+- Modify: `src/Humans.Application/Services/Profiles/UserEmailService.cs` (implement)
+
+- [ ] **Step 1: Extend `MailerLiteSubscriber` with `Groups`**
+
+Edit `src/Humans.Application/Interfaces/Mailer/Dtos/MailerLiteSubscriber.cs` to add the new field:
+```csharp
+using NodaTime;
+
+namespace Humans.Application.Interfaces.Mailer.Dtos;
+
+public sealed record MailerLiteSubscriber(
+    string Id,
+    string Email,
+    string Status,
+    string Source,
+    Instant? SubscribedAt,
+    Instant? UnsubscribedAt,
+    Instant? OptedInAt,
+    string? FirstName,
+    string? LastName,
+    IReadOnlyList<string> GroupIds);  // NEW — IDs of groups this subscriber currently belongs to
+```
+
+- [ ] **Step 2: Parse `groups` from the ML payload**
+
+Open `src/Humans.Infrastructure/Services/Mailer/MailerLiteSubscriberConverter.cs` and locate where the converter constructs `MailerLiteSubscriber`. The ML payload's subscriber object includes a `groups` array of objects with `id` and `name`. Extract the ids:
+```csharp
+// inside the converter's Read method, before constructing the record:
+var groupIds = new List<string>();
+if (root.TryGetProperty("groups", out var groupsEl) && groupsEl.ValueKind == JsonValueKind.Array)
+{
+    foreach (var g in groupsEl.EnumerateArray())
+    {
+        if (g.TryGetProperty("id", out var idEl) && idEl.ValueKind == JsonValueKind.String)
+            groupIds.Add(idEl.GetString()!);
+    }
+}
+
+return new MailerLiteSubscriber(
+    /* existing args */,
+    GroupIds: groupIds);
+```
+
+Update existing test fixtures that construct `MailerLiteSubscriber` to pass `Array.Empty<string>()` for the new field.
+
+- [ ] **Step 3: Add `GetPrimaryEmailsByUserIdsAsync` to `IUserEmailService`**
+
+Locate `IUserEmailService` and add:
+```csharp
+/// <summary>
+/// Bulk variant of <see cref="GetPrimaryEmailAsync"/>. Returns a map of user-id
+/// to primary email for each user that has one. Users without a primary email
+/// are omitted from the result.
+/// </summary>
+Task<IReadOnlyDictionary<Guid, string>> GetPrimaryEmailsByUserIdsAsync(
+    IEnumerable<Guid> userIds, CancellationToken ct = default);
+```
+
+Implement in `UserEmailService`. The existing repository likely has the rows already addressable; if not, add a repository method `GetPrimaryEmailRowsForUsersAsync(IEnumerable<Guid>)` and use it.
+
+- [ ] **Step 4: Run existing Mailer + Profiles tests**
+
+Run: `dotnet test Humans.slnx --filter "FullyQualifiedName~Mailer|FullyQualifiedName~UserEmail" -v quiet`
+Expected: all PASS (including the existing import-side tests that read `MailerLiteSubscriber` — they need the `GroupIds` arg updated in their fixture construction).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Humans.Application/Interfaces/Mailer/Dtos/MailerLiteSubscriber.cs \
+        src/Humans.Infrastructure/Services/Mailer/MailerLiteSubscriberConverter.cs \
+        src/Humans.Application/Interfaces/Profiles/IUserEmailService.cs \
+        src/Humans.Application/Services/Profiles/UserEmailService.cs \
+        tests/Humans.Application.Tests/Services/Mailer/
+git commit -m "feat: MailerLiteSubscriber.GroupIds + bulk primary-email lookup"
+```
+
+---
+
+### Task 17: Implement `MailerAudienceSyncService`
+
+**Files:**
+- Create: `src/Humans.Application/Services/Mailer/MailerAudienceSyncService.cs`
+
+- [ ] **Step 1: Write the implementation**
+
+```csharp
+using Humans.Application.Interfaces;
+using Humans.Application.Interfaces.AuditLog;
+using Humans.Application.Interfaces.Mailer;
+using Humans.Application.Interfaces.Mailer.Dtos;
+using Humans.Application.Interfaces.Profiles;
+using Humans.Domain.Enums;
+using Microsoft.Extensions.Logging;
+
+namespace Humans.Application.Services.Mailer;
+
+public sealed class MailerAudienceSyncService(
+    IMailerLiteService ml,
+    IUserEmailService emails,
+    IAuditLogService audit,
+    ILogger<MailerAudienceSyncService> logger,
+    IEnumerable<IMailerAudience> audiences) : IMailerAudienceSyncService
+{
+    private const string HumansGroupPrefix = "Humans - ";
+    private static readonly HashSet<string> UnsubscribedStatuses =
+        new(StringComparer.OrdinalIgnoreCase) { "unsubscribed", "bounced", "junk" };
+
+    public async Task<IReadOnlyList<AudienceSyncResult>> SyncAllAsync(CancellationToken ct = default)
+    {
+        var results = new List<AudienceSyncResult>();
+        foreach (var audience in audiences)
+        {
+            try
+            {
+                results.Add(await SyncAsync(audience, ct));
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Audience sync failed for {Audience}", audience.Key);
+            }
+        }
+        return results;
+    }
+
+    public async Task<AudienceStats> ComputeStatsAsync(IMailerAudience audience, CancellationToken ct = default)
+    {
+        var memberUserIds = await audience.ComputeMemberUserIdsAsync(ct);
+        var userEmailMap = await emails.GetPrimaryEmailsByUserIdsAsync(memberUserIds, ct);
+
+        var subscribers = new List<MailerLiteSubscriber>();
+        await foreach (var s in ml.ListSubscribersAsync(ct)) subscribers.Add(s);
+        var byEmail = subscribers.ToDictionary(s => NormalizeEmail(s.Email), s => s, StringComparer.Ordinal);
+
+        var groups = await ml.ListGroupsAsync(ct);
+        var group = groups.FirstOrDefault(g => g.Name == audience.MailerLiteGroupName);
+
+        int excluded = 0, inGroup = 0;
+        foreach (var (_, email) in userEmailMap)
+        {
+            if (!byEmail.TryGetValue(NormalizeEmail(email), out var sub)) continue;
+            if (UnsubscribedStatuses.Contains(sub.Status)) excluded++;
+            else if (group is not null && sub.GroupIds.Contains(group.Id)) inGroup++;
+        }
+
+        return new AudienceStats(
+            audience.Key,
+            audience.DisplayName,
+            audience.MailerLiteGroupName,
+            Candidates: userEmailMap.Count,
+            ExcludedUnsubscribed: excluded,
+            CurrentlyInGroup: inGroup,
+            LastSyncAt: null,
+            LastSyncSummary: null);
+        // LastSyncAt/Summary are populated by the controller layer from the
+        // most recent MailerLiteAudienceSyncCompleted audit entry. Keeping the
+        // service free of audit-read I/O keeps it focused.
+    }
+
+    public async Task<AudienceSyncResult> SyncAsync(IMailerAudience audience, CancellationToken ct = default)
+    {
+        if (!audience.MailerLiteGroupName.StartsWith(HumansGroupPrefix, StringComparison.Ordinal))
+            throw new InvalidOperationException(
+                $"Audience '{audience.Key}' targets group '{audience.MailerLiteGroupName}' " +
+                $"which does not start with '{HumansGroupPrefix}'.");
+
+        var memberUserIds = await audience.ComputeMemberUserIdsAsync(ct);
+        var userEmailMap = await emails.GetPrimaryEmailsByUserIdsAsync(memberUserIds, ct);
+        var droppedNoEmail = memberUserIds.Count - userEmailMap.Count;
+        if (droppedNoEmail > 0)
+            logger.LogInformation(
+                "Audience {Audience}: dropped {Count} candidates with no primary email",
+                audience.Key, droppedNoEmail);
+
+        // Ensure group exists.
+        var groups = await ml.ListGroupsAsync(ct);
+        var group = groups.FirstOrDefault(g => g.Name == audience.MailerLiteGroupName)
+            ?? await ml.CreateGroupAsync(audience.MailerLiteGroupName, ct);
+
+        // Snapshot ML state.
+        var subscribers = new List<MailerLiteSubscriber>();
+        await foreach (var s in ml.ListSubscribersAsync(ct)) subscribers.Add(s);
+        var byEmail = subscribers.ToDictionary(s => NormalizeEmail(s.Email), s => s, StringComparer.Ordinal);
+        var currentGroupMemberIds = subscribers
+            .Where(s => s.GroupIds.Contains(group.Id))
+            .Select(s => s.Id)
+            .ToHashSet(StringComparer.Ordinal);
+
+        // Classify candidates.
+        var toBulkImport = new List<string>();
+        var toAssign = new List<string>();
+        var keepSubscriberIds = new HashSet<string>(StringComparer.Ordinal);
+        int excluded = 0, alreadyAssigned = 0;
+
+        foreach (var (userId, email) in userEmailMap)
+        {
+            var norm = NormalizeEmail(email);
+            if (!byEmail.TryGetValue(norm, out var sub))
+            {
+                toBulkImport.Add(email);
+                continue;
+            }
+            if (UnsubscribedStatuses.Contains(sub.Status))
+            {
+                excluded++;
+                continue;
+            }
+            keepSubscriberIds.Add(sub.Id);
+            if (currentGroupMemberIds.Contains(sub.Id))
+                alreadyAssigned++;
+            else
+                toAssign.Add(sub.Id);
+        }
+
+        // Compute removals.
+        var toUnassign = currentGroupMemberIds.Except(keepSubscriberIds).ToList();
+
+        // Apply.
+        int created = 0, assigned = 0, unassigned = 0, errors = 0;
+
+        if (toBulkImport.Count > 0)
+        {
+            try
+            {
+                var bulk = await ml.BulkImportSubscribersToGroupAsync(group.Id, toBulkImport, ct);
+                created = bulk.Created;
+                errors += bulk.Errors;
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "BulkImport failed for {Audience}", audience.Key);
+                errors += toBulkImport.Count;
+            }
+        }
+
+        foreach (var subId in toAssign)
+        {
+            try
+            {
+                await ml.AssignSubscriberToGroupAsync(subId, group.Id, ct);
+                assigned++;
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Assign failed for {Sub} in {Audience}", subId, audience.Key);
+                errors++;
+            }
+        }
+
+        foreach (var subId in toUnassign)
+        {
+            try
+            {
+                await ml.UnassignSubscriberFromGroupAsync(subId, group.Id, ct);
+                unassigned++;
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Unassign failed for {Sub} in {Audience}", subId, audience.Key);
+                errors++;
+            }
+        }
+
+        var result = new AudienceSyncResult(
+            audience.Key, group.Id, group.Name,
+            Candidates: userEmailMap.Count,
+            ExcludedUnsubscribed: excluded,
+            Created: created,
+            Assigned: assigned,
+            AlreadyAssigned: alreadyAssigned,
+            Unassigned: unassigned,
+            Errors: errors);
+
+        await audit.LogAsync(
+            AuditAction.MailerLiteAudienceSyncCompleted,
+            entityType: null, entityId: null, actorUserId: null,
+            metadata: new Dictionary<string, object?>
+            {
+                ["audience_key"] = audience.Key,
+                ["group_id"] = group.Id,
+                ["group_name"] = group.Name,
+                ["candidates"] = result.Candidates,
+                ["excluded_unsubscribed"] = result.ExcludedUnsubscribed,
+                ["created"] = result.Created,
+                ["assigned"] = result.Assigned,
+                ["already_assigned"] = result.AlreadyAssigned,
+                ["unassigned"] = result.Unassigned,
+                ["errors"] = result.Errors,
+            },
+            description: null,
+            ct: ct);
+
+        return result;
+    }
+
+    private static string NormalizeEmail(string email) =>
+        email.Trim().ToLowerInvariant();
+        // If a NormalizingEmailComparer/Normalizer helper exists in Humans.Application
+        // (the Tickets section uses one — see Tickets.md), reuse it here instead.
+}
+```
+
+> Implementer note: confirm the exact signature of `IAuditLogService.LogAsync` — the snippet uses a hypothetical metadata-bag overload. If the existing audit signature differs (`LogAsync(AuditAction, string description, ...)` etc.), serialize the metadata dictionary into a JSON-encoded description string instead. The audit metadata schema (the keys) is the contract; how it's stored is implementation detail.
+
+- [ ] **Step 2: Run tests**
+
+Run: `dotnet test Humans.slnx --filter "FullyQualifiedName~MailerAudienceSyncServiceTests" -v quiet`
+Expected: all PASS.
+
+- [ ] **Step 3: Add architecture pin for the service**
+
+In `MailerArchitectureTests`, add:
+```csharp
+[HumansFact]
+public void MailerAudienceSyncService_LivesInApplication_NoEF()
+{
+    var serviceType = typeof(MailerAudienceSyncService);
+    serviceType.Namespace.Should().Be("Humans.Application.Services.Mailer");
+    serviceType.Assembly.GetReferencedAssemblies()
+        .Should().NotContain(a => a.Name == "Microsoft.EntityFrameworkCore");
+}
+```
+
+- [ ] **Step 4: Run all Mailer arch + service tests**
+
+Run: `dotnet test Humans.slnx --filter "FullyQualifiedName~Mailer" -v quiet`
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Humans.Application/Services/Mailer/MailerAudienceSyncService.cs \
+        tests/Humans.Application.Tests/Architecture/MailerArchitectureTests.cs
+git commit -m "feat(mailer): implement MailerAudienceSyncService"
+```
+
+---
+
+## Phase 5: UI + Hangfire job
+
+### Task 18: Extend dashboard view model
+
+**Files:**
+- Modify: `src/Humans.Web/Models/Mailer/MailerDashboardViewModel.cs`
+- Create: `src/Humans.Web/Models/Mailer/AudienceCardRow.cs`
+
+- [ ] **Step 1: Define `AudienceCardRow`**
+
+Create `src/Humans.Web/Models/Mailer/AudienceCardRow.cs`:
+```csharp
+using NodaTime;
+
+namespace Humans.Web.Models.Mailer;
+
+public sealed record AudienceCardRow(
+    string Key,
+    string DisplayName,
+    string MailerLiteGroupName,
+    int Candidates,
+    int ExcludedUnsubscribed,
+    int CurrentlyInGroup,
+    Instant? LastSyncAt,
+    string? LastSyncSummary);
+```
+
+- [ ] **Step 2: Extend the dashboard VM**
+
+Edit `MailerDashboardViewModel.cs` — add a new positional field to the record:
+```csharp
+public sealed record MailerDashboardViewModel(
+    MailerLiteAccountSummary? MlSummary,
+    IReadOnlyList<MailerLiteGroup>? Groups,
+    int HumansMailerLiteContacts,
+    int HumansMarketingOptedIn,
+    int HumansMarketingOptedOut,
+    Instant? LastReconciliationAt,
+    string? LastReconciliationSummary,
+    DriftReport? Drift,
+    string? MlError,
+    Instant? CacheFetchedAt,
+    IReadOnlyList<AudienceCardRow> Audiences);   // NEW
+```
+
+- [ ] **Step 3: Build — controller will fail until we update it**
+
+Run: `dotnet build Humans.slnx -v quiet`
+Expected: build FAILS in `MailerAdminController` because the VM constructor now has an extra param.
+
+- [ ] **Step 4: Commit the model changes alone**
+
+```bash
+git add src/Humans.Web/Models/Mailer/AudienceCardRow.cs \
+        src/Humans.Web/Models/Mailer/MailerDashboardViewModel.cs
+git commit -m "feat(mailer): add Audiences field to MailerDashboardViewModel"
+```
+
+> Intentionally broken at HEAD — the next task fixes the controller. This is a single PR so the broken-at-this-commit window is short.
+
+---
+
+### Task 19: Wire the controller — `Index` + `Sync` action
+
+**Files:**
+- Modify: `src/Humans.Web/Controllers/Mailer/MailerAdminController.cs`
+
+- [ ] **Step 1: Inject `IMailerAudienceSyncService` and audiences enumerable**
+
+Add to the constructor signature and `_field` assignments:
+```csharp
+private readonly IMailerAudienceSyncService _audienceSync;
+private readonly IReadOnlyList<IMailerAudience> _audiences;
+
+public MailerAdminController(
+    // ...existing deps...
+    IMailerAudienceSyncService audienceSync,
+    IEnumerable<IMailerAudience> audiences,
+    UserManager<User> userManager)
+    : base(userManager)
+{
+    // ...existing assignments...
+    _audienceSync = audienceSync;
+    _audiences = audiences.ToList();
+}
+```
+
+- [ ] **Step 2: Populate `Audiences` in `Index`**
+
+At the bottom of the existing `Index` method, before constructing the VM:
+```csharp
+var audienceRows = new List<AudienceCardRow>();
+foreach (var audience in _audiences)
+{
+    AudienceStats stats;
+    try
+    {
+        stats = await _audienceSync.ComputeStatsAsync(audience, ct);
+    }
+    catch (HttpRequestException ex)
+    {
+        _logger.LogWarning(ex, "Audience stats failed for {Audience}", audience.Key);
+        continue; // skip the row rather than fail the whole dashboard
+    }
+    var lastSync = await _audit.GetFilteredEntriesAsync(
+        actions: new[] { AuditAction.MailerLiteAudienceSyncCompleted },
+        limit: 50, // we filter by audience_key in-memory
+        ct: ct);
+    var lastForThisAudience = lastSync.FirstOrDefault(e =>
+        TryGetMetadata(e, "audience_key") == audience.Key);
+    audienceRows.Add(new AudienceCardRow(
+        audience.Key, audience.DisplayName, audience.MailerLiteGroupName,
+        stats.Candidates, stats.ExcludedUnsubscribed, stats.CurrentlyInGroup,
+        lastForThisAudience?.OccurredAt,
+        lastForThisAudience?.Description));
+}
+```
+
+(`TryGetMetadata` is a small helper that pulls a key from the audit entry's metadata bag — match whatever shape the existing audit entries expose.)
+
+Update the VM construction to pass `audienceRows` as the last argument.
+
+- [ ] **Step 3: Add the `Sync` action**
+
+Add to the controller:
+```csharp
+[HttpPost("Audiences/{key}/Sync")]
+[ValidateAntiForgeryToken]
+public async Task<IActionResult> SyncAudience(string key, CancellationToken ct)
+{
+    var audience = _audiences.FirstOrDefault(a => a.Key == key);
+    if (audience is null) return NotFound();
+
+    try
+    {
+        var result = await _audienceSync.SyncAsync(audience, ct);
+        TempData["Banner"] = $"{audience.DisplayName}: {result.FormatSummary()}";
+    }
+    catch (Exception ex)
+    {
+        _logger.LogError(ex, "Audience sync failed for {Audience}", key);
+        TempData["Banner"] = $"{audience.DisplayName}: sync failed — {ex.Message}";
+    }
+    return RedirectToAction(nameof(Index));
+}
+```
+
+- [ ] **Step 4: Build**
+
+Run: `dotnet build Humans.slnx -v quiet`
+Expected: build succeeds.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Humans.Web/Controllers/Mailer/MailerAdminController.cs
+git commit -m "feat(mailer): wire Audiences card and Sync action in MailerAdminController"
+```
+
+---
+
+### Task 20: Render the dashboard card
+
+**Files:**
+- Create: `src/Humans.Web/Views/Mailer/Admin/_AudiencesCard.cshtml`
+- Modify: `src/Humans.Web/Views/Mailer/Admin/Index.cshtml`
+
+- [ ] **Step 1: Write the partial**
+
+Create `src/Humans.Web/Views/Mailer/Admin/_AudiencesCard.cshtml`:
+```cshtml
+@model IReadOnlyList<Humans.Web.Models.Mailer.AudienceCardRow>
+
+<section class="card mb-4">
+    <header class="card-header">
+        <h2 class="h5 mb-0">Audiences</h2>
+    </header>
+    <div class="card-body">
+        @if (Model.Count == 0)
+        {
+            <p class="text-muted mb-0">No audiences registered.</p>
+        }
+        else
+        {
+            <ul class="list-unstyled mb-0">
+                @foreach (var row in Model)
+                {
+                    <li class="d-flex justify-content-between align-items-center py-2 border-bottom">
+                        <div>
+                            <strong>@row.MailerLiteGroupName</strong>
+                            <div class="small text-muted">
+                                @row.Candidates humans match · @row.ExcludedUnsubscribed ML-unsubscribed ·
+                                @row.CurrentlyInGroup currently in group
+                                @if (row.LastSyncAt is not null)
+                                {
+                                    <text> · last sync @row.LastSyncAt.Value.ToDateTimeUtc().ToString("yyyy-MM-dd HH:mm 'UTC'")</text>
+                                }
+                            </div>
+                        </div>
+                        <form asp-action="SyncAudience" asp-route-key="@row.Key" method="post" class="m-0">
+                            <button type="submit" class="btn btn-sm btn-outline-primary">Push Now</button>
+                        </form>
+                    </li>
+                }
+            </ul>
+        }
+    </div>
+</section>
+```
+
+- [ ] **Step 2: Render it from `Index.cshtml`**
+
+Open `src/Humans.Web/Views/Mailer/Admin/Index.cshtml` and add the partial render at the appropriate visual location (after the existing dashboard summary, before the drift report — matches the spec's UI ordering):
+```cshtml
+<partial name="_AudiencesCard" model="Model.Audiences" />
+```
+
+- [ ] **Step 3: Manual smoke (optional but useful)**
+
+Run: `dotnet run --project src/Humans.Web` and navigate to `/Mailer/Admin` as admin. Visually verify the card renders with the one row "Humans - Ticket no Shifts". Stop the server.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Humans.Web/Views/Mailer/Admin/_AudiencesCard.cshtml \
+        src/Humans.Web/Views/Mailer/Admin/Index.cshtml
+git commit -m "feat(mailer): render Audiences card on /Mailer/Admin"
+```
+
+---
+
+### Task 21: Controller tests
+
+**Files:**
+- Create: `tests/Humans.Web.Tests/Controllers/Mailer/MailerAdminControllerAudienceSyncTests.cs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Match the shape of the existing `MailerAdminControllerTests.cs` for setup helpers. Outline:
+```csharp
+public class MailerAdminControllerAudienceSyncTests
+{
+    [HumansFact]
+    public async Task SyncAudience_AsAdmin_ReturnsRedirectWithBanner()
+    {
+        var audience = StubAudience("ticket-no-shifts");
+        var sync = new Mock<IMailerAudienceSyncService>();
+        sync.Setup(s => s.SyncAsync(It.IsAny<IMailerAudience>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AudienceSyncResult(
+                "ticket-no-shifts", "g1", "Humans - Ticket no Shifts",
+                Candidates: 10, ExcludedUnsubscribed: 1,
+                Created: 5, Assigned: 3, AlreadyAssigned: 1, Unassigned: 0, Errors: 0));
+
+        var controller = NewController(audiences: new[] { audience }, sync: sync.Object);
+        var result = await controller.SyncAudience("ticket-no-shifts", CancellationToken.None);
+
+        result.Should().BeOfType<RedirectToActionResult>()
+            .Which.ActionName.Should().Be(nameof(MailerAdminController.Index));
+        controller.TempData["Banner"].Should().NotBeNull();
+    }
+
+    [HumansFact]
+    public async Task SyncAudience_UnknownKey_Returns404()
+    {
+        var controller = NewController(audiences: Array.Empty<IMailerAudience>(),
+            sync: Mock.Of<IMailerAudienceSyncService>());
+        var result = await controller.SyncAudience("nope", CancellationToken.None);
+
+        result.Should().BeOfType<NotFoundResult>();
+    }
+
+    // helpers omitted — match existing fixture pattern
+}
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `dotnet test Humans.slnx --filter "FullyQualifiedName~MailerAdminControllerAudienceSyncTests" -v quiet`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/Humans.Web.Tests/Controllers/Mailer/MailerAdminControllerAudienceSyncTests.cs
+git commit -m "test(mailer): controller smoke for SyncAudience action"
+```
+
+---
+
+### Task 22: Hangfire recurring job
+
+**Files:**
+- Create: `src/Humans.Infrastructure/Jobs/MailerAudienceSyncJob.cs`
+- Modify: `src/Humans.Web/Extensions/RecurringJobExtensions.cs`
+
+- [ ] **Step 1: Write the job**
+
+Create `src/Humans.Infrastructure/Jobs/MailerAudienceSyncJob.cs`:
+```csharp
+using Hangfire;
+using Humans.Application.Interfaces.Mailer;
+using Microsoft.Extensions.Logging;
+
+namespace Humans.Infrastructure.Jobs;
+
+[DisableConcurrentExecution(timeoutInSeconds: 300)]
+public sealed class MailerAudienceSyncJob
+{
+    private readonly IMailerAudienceSyncService _sync;
+    private readonly ILogger<MailerAudienceSyncJob> _logger;
+
+    public MailerAudienceSyncJob(IMailerAudienceSyncService sync, ILogger<MailerAudienceSyncJob> logger)
+    {
+        _sync = sync;
+        _logger = logger;
+    }
+
+    public async Task ExecuteAsync(CancellationToken ct = default)
+    {
+        _logger.LogInformation("MailerAudienceSyncJob starting");
+        var results = await _sync.SyncAllAsync(ct);
+        _logger.LogInformation(
+            "MailerAudienceSyncJob completed: {Count} audiences processed",
+            results.Count);
+    }
+}
+```
+
+- [ ] **Step 2: Register in `RecurringJobExtensions`**
+
+Open `src/Humans.Web/Extensions/RecurringJobExtensions.cs`. Inside `UseHumansRecurringJobs`, near the top after the existing `ticketSyncInterval` resolution, add:
+```csharp
+var mailerAudienceCron = app.Configuration.GetValue<string>("MailerLite:AudienceSyncCron")
+    ?? "0 6 * * *";
+```
+
+Then add to the `jobs` array (anywhere logical — placing it after the Ticketing entries makes sense):
+```csharp
+("mailer-audience-sync", () => RecurringJob.AddOrUpdate<MailerAudienceSyncJob>(
+    "mailer-audience-sync", job => job.ExecuteAsync(CancellationToken.None), mailerAudienceCron)),
+```
+
+- [ ] **Step 3: Build**
+
+Run: `dotnet build Humans.slnx -v quiet`
+Expected: build succeeds.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Humans.Infrastructure/Jobs/MailerAudienceSyncJob.cs \
+        src/Humans.Web/Extensions/RecurringJobExtensions.cs
+git commit -m "feat(mailer): register MailerAudienceSyncJob (daily 06:00 UTC by default)"
+```
+
+---
+
+### Task 23: DI registration
+
+**Files:**
+- Modify: wherever Slice 1 registered Mailer services (`Program.cs` or a Mailer-specific extension method — discover via grep)
+
+- [ ] **Step 1: Locate the Mailer DI block**
+
+Run: `grep -rn "IMailerImportService\|IMailerLiteService" src/Humans.Web/Program.cs src/Humans.Web/Extensions/`
+Expected: one block where Slice 1 wired things up.
+
+- [ ] **Step 2: Add the new registrations**
+
+In the same block:
+```csharp
+services.AddScoped<IMailerAudienceSyncService, MailerAudienceSyncService>();
+services.AddSingleton<IMailerAudience, TicketNoShiftsAudience>();
+services.AddTransient<MailerAudienceSyncJob>();
+```
+
+> Lifetime note: `TicketNoShiftsAudience` is a singleton, but its constructor takes scoped services (`ITicketQueryService`, etc.). In ASP.NET Core, registering a singleton that depends on scoped services would throw at first resolution. Verify: either register the audience as `Transient`/`Scoped` to match its deps, or refactor the audience to use `IServiceScopeFactory` and resolve its deps per call. Recommended path: register as `Scoped` (fast enough; one audience instance per request/job execution).
+>
+> Change the registration to:
+> ```csharp
+> services.AddScoped<IMailerAudience, TicketNoShiftsAudience>();
+> ```
+
+- [ ] **Step 3: Build + run full test suite**
+
+Run: `dotnet build Humans.slnx -v quiet && dotnet test Humans.slnx -v quiet`
+Expected: all PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Humans.Web/
+git commit -m "feat(mailer): DI registration for audience sync service + audience + job"
+```
+
+---
+
+## Phase 6: Docs
+
+### Task 24: Update `docs/sections/Mailer.md`
+
+**Files:**
+- Modify: `docs/sections/Mailer.md`
+
+- [ ] **Step 1: Update the invariants block**
+
+Replace the existing two lines about `IMailerLiteService` GET-only with the three replacement lines from §6 of the spec (`docs/superpowers/specs/2026-05-14-mailer-outbound-audiences-design.md`).
+
+- [ ] **Step 2: Remove the "inbound-only" line**
+
+Delete the line:
+```
+- Inbound-only is a known compliance gap. **Outbound is the next slice and must ship before any other Mailer feature.** Drift in the Humans-newer-than-ML direction is mitigated only by the dashboard drift report (§6.1 of the spec) and manual admin remediation in the ML UI until outbound lands.
+```
+
+- [ ] **Step 3: Add to *Cross-Section Dependencies***
+
+Append:
+```markdown
+- **Tickets:** `ITicketQueryService.GetUserIdsWithMatchedValidAttendeesAsync` — audience-side ticket-holder enumeration for `TicketNoShiftsAudience`.
+- **Shifts:** `IShiftSignupService.GetActiveCommittedUserIdsForEventAsync` and `IShiftManagementService.GetActiveAsync` — audience-side shift commitment + active-event lookup.
+```
+
+(If Task 12 reused an existing method, update the Tickets line to reference it.)
+
+- [ ] **Step 4: Add to *Routing***
+
+Append to the routing list:
+```markdown
+- `/Mailer/Admin/Audiences/{key}/Sync` — on-demand audience push (POST)
+```
+
+- [ ] **Step 5: Add a *Concepts* entry**
+
+Add to the Concepts section:
+```markdown
+- **Audience** — a code-defined `IMailerAudience` implementation whose `MailerLiteGroupName` starts with `"Humans - "`. Membership is computed from Humans state and synced into the ML group by `MailerAudienceSyncService` (daily Hangfire job + on-demand admin button).
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/sections/Mailer.md
+git commit -m "docs(mailer): relax inbound-only; document audience framework"
+```
+
+---
+
+### Task 25: Update `docs/sections/AuditLog.md`
+
+**Files:**
+- Modify: `docs/sections/AuditLog.md`
+
+- [ ] **Step 1: List the new action**
+
+Run: `grep -n MailerLiteReconciliationCompleted docs/sections/AuditLog.md`
+Expected: one match (if `AuditLog.md` enumerates actions).
+
+Immediately after that entry, add a row for `MailerLiteAudienceSyncCompleted` matching the surrounding table/list format.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/sections/AuditLog.md
+git commit -m "docs(audit): list MailerLiteAudienceSyncCompleted action"
+```
+
+---
+
+## Phase 7: End-to-end verification
+
+### Task 26: Final build, test, and smoke
+
+- [ ] **Step 1: Full build + test**
+
+Run: `dotnet build Humans.slnx -v quiet && dotnet test Humans.slnx -v quiet`
+Expected: build succeeds; all tests pass.
+
+- [ ] **Step 2: Architecture pins**
+
+Run: `dotnet test Humans.slnx --filter "FullyQualifiedName~MailerArchitectureTests" -v quiet`
+Expected: all four pins pass:
+- `IMailerLiteService_OnlyAllowsAudienceWrites`
+- `AllAudiences_UseHumansPrefix`
+- `AllAudiences_HaveUniqueGroupNamesAndKeys`
+- `MailerAudienceSyncService_LivesInApplication_NoEF`
+
+- [ ] **Step 3: Manual smoke**
+
+Run: `dotnet run --project src/Humans.Web`. Log in as admin. Visit `/Mailer/Admin`. Verify the Audiences card appears with one row. Click **Push Now**.
+
+Expected:
+- 302 redirect back to `/Mailer/Admin` with a banner "Ticket holders without a shift: 0 created, N newly assigned, …" or similar.
+- Audit entry `MailerLiteAudienceSyncCompleted` appears in `/AuditLog`.
+- Refresh `/Mailer/Admin` — `currently in group` count should now equal `candidates − ML-unsubscribed`.
+
+Stop the server.
+
+- [ ] **Step 4: Push the branch**
+
+```bash
+git push origin mailer-outbound-audiences
+```
+
+- [ ] **Step 5: Open the PR**
+
+```bash
+gh pr create --base main --head mailer-outbound-audiences --title "Mailer: outbound slice + audience framework + Ticket-no-Shifts" --body "$(cat <<'EOF'
+## Summary
+- Adds four prefix-guarded outbound writes to `IMailerLiteService` (`CreateGroupAsync`, `AssignSubscriberToGroupAsync`, `UnassignSubscriberFromGroupAsync`, `BulkImportSubscribersToGroupAsync`). All writes runtime-rejected unless the target group's name starts with `"Humans - "`.
+- Introduces `IMailerAudience` code-registered audience primitive and `MailerAudienceSyncService` orchestrator (compute → diff → apply → audit).
+- Ships first audience `TicketNoShiftsAudience` → `"Humans - Ticket no Shifts"` ML group.
+- Daily Hangfire job (`mailer-audience-sync`, default 06:00 UTC, configurable via `MailerLite:AudienceSyncCron`) + on-demand admin button on `/Mailer/Admin`.
+- Relaxes `docs/sections/Mailer.md` inbound-only invariant; pins new invariants in architecture tests.
+
+Spec: [`docs/superpowers/specs/2026-05-14-mailer-outbound-audiences-design.md`](docs/superpowers/specs/2026-05-14-mailer-outbound-audiences-design.md).
+
+## Test plan
+- [ ] Architecture pins pass (`MailerArchitectureTests` — four pins)
+- [ ] Sync-service unit tests pass (idempotency, unsubscribed exclusion, group auto-create, error counting, prefix violation, audit metadata)
+- [ ] Audience unit tests pass (Valid/CheckedIn ticket × Pending/Confirmed/non-active shift matrix)
+- [ ] Controller test passes (admin redirect with banner; 404 on unknown key)
+- [ ] Manual: `/Mailer/Admin` Push Now produces a 302 + audit entry; second click is no-op (all-zero deltas)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-review checklist
+
+After completing all tasks, before requesting code review:
+
+- [ ] Every spec requirement maps to a task. Cross-reference against §3, §4, §7, §8, §9 of the spec.
+- [ ] No `TBD`, `TODO`, or "implement later" left in code.
+- [ ] Every new method has at least one unit test.
+- [ ] Every architecture invariant claimed in `docs/sections/Mailer.md` is pinned by a test.
+- [ ] Hangfire job name `mailer-audience-sync` is consistent everywhere.
+- [ ] DI lifetimes match dependency lifetimes (`IMailerAudience` registered Scoped because its deps are Scoped).
+- [ ] Cache invalidation runs after every write in `MailerLiteClient` so the dashboard reflects post-sync state on the next render.

--- a/docs/superpowers/specs/2026-05-14-mailer-outbound-audiences-design.md
+++ b/docs/superpowers/specs/2026-05-14-mailer-outbound-audiences-design.md
@@ -1,0 +1,391 @@
+# Mailer Section — Outbound Slice + Audience Framework (Slice 2)
+
+**Status:** Design — awaiting user approval before plan.
+**Author / facilitator:** brainstorming session 2026-05-14.
+**Related:** [`docs/sections/Mailer.md`](../../sections/Mailer.md) (inbound-only invariant to be relaxed), [`docs/superpowers/specs/2026-05-12-mailer-section-inbound-import-design.md`](2026-05-12-mailer-section-inbound-import-design.md) (Slice 1).
+
+## 1. Context
+
+Slice 1 (inbound-only) shipped 2026-05-12. Today's slice flips the long-standing "outbound is the next slice and must ship before any other Mailer feature" invariant from a TODO into reality, and lays down an extensible **audience framework** on top — Humans-defined, code-registered mailing lists whose membership is computed from Humans state and synced into named ML groups.
+
+The first audience is **"Humans - Ticket no Shifts"** — humans who hold a valid ticket but have not signed up for any shift in the active event. Future audiences are anticipated (per-language splits like "Humans - General - DE", and a handful of other segments) but only the framework + first audience are in scope here.
+
+## 2. Scope
+
+### In scope
+
+- Outbound writes on `IMailerLiteService`: create group, assign subscriber to group, unassign, bulk-import-to-group.
+- Prefix-write invariant: writes only target ML groups whose `name` starts with `"Humans - "`. Enforced at runtime in the client and pinned by architecture test.
+- `IMailerAudience` primitive — code-registered audience definitions.
+- One audience implementation: `TicketNoShiftsAudience`.
+- New service `MailerAudienceSyncService` (orchestrator: compute → diff → apply → audit).
+- New Hangfire job `MailerAudienceSyncJob` (daily, configurable cron, default low-traffic Madrid morning).
+- On-demand "Push Now" button per audience on `/Mailer/Admin`.
+- Audiences card on `/Mailer/Admin` dashboard with per-audience stats.
+- New `AuditAction.MailerLiteAudienceSyncCompleted`.
+- Tests: audience definition, sync orchestration, idempotency, architecture pins, controller smoke.
+- Section-doc update: relax `IMailerLiteService` GET-only invariant; add prefix-write invariant; document the audience-framework concept.
+
+### Out of scope
+
+- CRUD UI for audiences (audiences are code-registered; adding one is a PR).
+- Other audiences besides "Ticket no Shifts" (language splits etc. follow in their own PRs once the framework lands).
+- Webhooks from ML to Humans (Slice 3+ territory).
+- Engagement metrics (open/click rates).
+- Two-way drift reconciliation beyond what Slice 1 already does (we still treat ML as the source of truth for subscriber `status`).
+- Removing a subscriber from ML entirely (only group membership is managed here).
+
+## 3. Architecture
+
+### Outbound slice on `IMailerLiteService`
+
+The interface gains four write methods. The client (`MailerLiteClient`) runtime-guards every write against the `"Humans - "` group-name prefix; an architecture test pins the set of allowed write methods and the prefix check.
+
+```csharp
+public interface IMailerLiteService : IApplicationService
+{
+    // existing reads (unchanged)
+    Task<MailerLiteAccountSummary> GetAccountSummaryAsync(CancellationToken ct = default);
+    Task<IReadOnlyList<MailerLiteGroup>> ListGroupsAsync(CancellationToken ct = default);
+    IAsyncEnumerable<MailerLiteSubscriber> ListSubscribersAsync(CancellationToken ct = default);
+    Task<MailerLiteSubscriber?> GetSubscriberAsync(string email, CancellationToken ct = default);
+
+    // new — outbound writes (prefix-guarded)
+    Task<MailerLiteGroup> CreateGroupAsync(string name, CancellationToken ct = default);
+    Task AssignSubscriberToGroupAsync(string subscriberId, string groupId, CancellationToken ct = default);
+    Task UnassignSubscriberFromGroupAsync(string subscriberId, string groupId, CancellationToken ct = default);
+    Task<BulkImportResult> BulkImportSubscribersToGroupAsync(
+        string groupId, IReadOnlyList<string> emails, CancellationToken ct = default);
+}
+```
+
+**Runtime guard** (in `MailerLiteClient`): every write method first looks up the group by id (or, in `CreateGroupAsync`, inspects the requested `name`) and throws `InvalidOperationException` before the HTTP call if the name doesn't start with `"Humans - "`. The existing GET-only `SendAsync` guard is removed and replaced with per-method write paths that share the same group-name verification helper.
+
+**MailerLite API notes for implementer to verify against current v2 docs:**
+
+- ML v2 has **no "set membership to exactly this set"** endpoint — adds and removes are computed by diff and applied individually (or bulk on the add side).
+- **Add path**: `POST /api/groups/{group_id}/subscribers/import` accepts an array of subscriber objects per call (documented max believed ~50 — implementer to confirm exact ceiling). Used for `BulkImportSubscribersToGroupAsync` (chunked).
+- **Single-assign fallback**: `POST /api/subscribers/{id_or_email}/groups/{group_id}`. Used by `AssignSubscriberToGroupAsync` and as a fallback if the bulk import endpoint is not available.
+- **Remove path**: `DELETE /api/subscribers/{id}/groups/{group_id}`, one call per subscriber. (No documented bulk remove in v2.)
+- **Group create**: `POST /api/groups` with `{ "name": "..." }`.
+
+Implementer fetches current ML v2 docs before writing `MailerLiteClient` and adjusts the bulk shape (max chunk size, exact endpoint path, request body) to whatever's current. The four interface methods are the stable contract; their HTTP shape is implementation detail.
+
+### Audience framework (new)
+
+```
+src/Humans.Application/Interfaces/Mailer/
+  IMailerAudience.cs                ← audience primitive
+  IMailerAudienceSyncService.cs     ← orchestrator
+  Dtos/
+    AudienceSyncResult.cs           ← per-audience post-sync counts
+    AudienceStats.cs                ← computed-but-not-yet-pushed counts for dashboard
+
+src/Humans.Application/Services/Mailer/
+  MailerAudienceSyncService.cs      ← orchestrator impl; Application layer; no DbContext
+  Audiences/
+    TicketNoShiftsAudience.cs       ← first IMailerAudience impl
+
+src/Humans.Infrastructure/Jobs/
+  MailerAudienceSyncJob.cs          ← Hangfire recurring job
+
+src/Humans.Web/Controllers/Mailer/
+  MailerAdminController.cs          ← extended with POST /Mailer/Admin/Audiences/{key}/Sync
+
+src/Humans.Web/Models/Mailer/
+  AudiencesCardViewModel.cs         ← per-audience stats for the dashboard card
+
+src/Humans.Web/Views/Mailer/Admin/
+  Index.cshtml                      ← extended with Audiences card
+  _AudiencesCard.cshtml             ← new partial (one row per registered audience)
+```
+
+### `IMailerAudience` primitive
+
+```csharp
+public interface IMailerAudience
+{
+    /// <summary>Stable key used in the audience-sync URL (e.g. "ticket-no-shifts").</summary>
+    string Key { get; }
+
+    /// <summary>Display name shown on the dashboard.</summary>
+    string DisplayName { get; }
+
+    /// <summary>
+    /// Target ML group name. Must start with "Humans - " — enforced by
+    /// MailerArchitectureTests.AllAudiences_UseHumansPrefix.
+    /// </summary>
+    string MailerLiteGroupName { get; }
+
+    /// <summary>
+    /// Computes the set of Humans user-ids who currently belong in this audience.
+    /// Implementation reads cross-section state via service interfaces only — never DbContext.
+    /// </summary>
+    Task<IReadOnlySet<Guid>> ComputeMemberUserIdsAsync(CancellationToken ct);
+}
+```
+
+Audiences are registered as singletons in DI: `services.AddSingleton<IMailerAudience, TicketNoShiftsAudience>();`. The framework discovers all of them via `IEnumerable<IMailerAudience>` injection.
+
+### `TicketNoShiftsAudience`
+
+```csharp
+public sealed class TicketNoShiftsAudience(
+    ITicketQueryService tickets,
+    IShiftSignupService shiftSignups,
+    IShiftManagementService shiftManagement) : IMailerAudience
+{
+    public string Key => "ticket-no-shifts";
+    public string DisplayName => "Ticket holders without a shift";
+    public string MailerLiteGroupName => "Humans - Ticket no Shifts";
+
+    public async Task<IReadOnlySet<Guid>> ComputeMemberUserIdsAsync(CancellationToken ct)
+    {
+        var activeEvent = await shiftManagement.GetActiveAsync(ct);
+        if (activeEvent is null) return new HashSet<Guid>();
+
+        var ticketHolders = await tickets.GetUserIdsWithMatchedAttendeesAsync(ct);
+        // Returns userIds with at least one Valid|CheckedIn matched TicketAttendee
+        // in the active vendor event. Buyer-only matches excluded — matches the
+        // existing "has a ticket" definition pinned by Tickets.md.
+
+        var shiftHaverUserIds = await shiftSignups.GetActiveCommittedUserIdsForEventAsync(
+            activeEvent.Id, ct);
+        // Returns userIds with at least one ShiftSignup whose Status ∈ {Pending, Confirmed}
+        // for the active event.
+
+        var audience = new HashSet<Guid>(ticketHolders);
+        audience.ExceptWith(shiftHaverUserIds);
+        return audience;
+    }
+}
+```
+
+Two read methods are added to existing section services:
+
+- `ITicketQueryService.GetUserIdsWithMatchedAttendeesAsync(ct)` — already exists in spirit as `GetAllMatchedUserIdsAsync` (filtered to attendees, status Valid|CheckedIn); confirm name during implementation.
+- `IShiftSignupService.GetActiveCommittedUserIdsForEventAsync(eventSettingsId, ct)` — new narrow read; routes through `IShiftSignupRepository`.
+
+### `MailerAudienceSyncService`
+
+```csharp
+public interface IMailerAudienceSyncService : IApplicationService
+{
+    Task<AudienceStats> ComputeStatsAsync(IMailerAudience audience, CancellationToken ct);
+    Task<AudienceSyncResult> SyncAsync(IMailerAudience audience, CancellationToken ct);
+    Task<IReadOnlyList<AudienceSyncResult>> SyncAllAsync(CancellationToken ct);
+}
+```
+
+**`ComputeStatsAsync`** — read-only, no ML writes. Used by the dashboard card to display the headline numbers without forcing a sync:
+- `Candidates` = `audience.ComputeMemberUserIdsAsync().Count`
+- `ExcludedUnsubscribed` = candidates whose primary email maps to an ML subscriber with `status ∈ {unsubscribed, bounced, junk}`
+- `CurrentlyInGroup` = ML subscribers currently in the target group (or 0 if group doesn't exist yet)
+- `LastSyncAt`, `LastSyncSummary` — from the most recent `MailerLiteAudienceSyncCompleted` audit entry for this audience key
+
+**`SyncAsync`** — full data flow:
+
+1. `memberUserIds = audience.ComputeMemberUserIdsAsync(ct)`
+2. `userEmailMap = IUserEmailService.GetPrimaryEmailsByUserIdsAsync(memberUserIds)` — drop users with no primary email, log count.
+3. **Ensure ML group exists.** `groups = _ml.ListGroupsAsync()`; find by `Name == audience.MailerLiteGroupName`; create if missing (prefix-guarded).
+4. **Snapshot ML state.** One paginated sweep of `_ml.ListSubscribersAsync()` → `byEmail: Dict<normalized-email, MailerLiteSubscriber>`. From each subscriber's `Groups` collection, build `currentGroupMemberIds: Set<subscriberId>` for the target group.
+5. **Classify candidates.** For each `(userId, email)`:
+   - `normalized = NormalizingEmailComparer.Normalize(email)`
+   - `sub = byEmail.TryGet(normalized)`
+   - `sub?.Status ∈ {unsubscribed, bounced, junk}` → bucket `ExcludedUnsubscribed`
+   - `sub is null` → bucket `ToCreateAndAssign` (uses bulk import)
+   - `sub.Id ∈ currentGroupMemberIds` → bucket `AlreadyAssigned`
+   - else → bucket `ToAssign`
+6. **Compute removals.** For each `subId ∈ currentGroupMemberIds` whose subscriber email's user-id is NOT in `memberUserIds` (or maps to no Humans user at all) → bucket `ToUnassign`.
+7. **Apply.**
+   - `ToCreateAndAssign` → `_ml.BulkImportSubscribersToGroupAsync(group.Id, chunk, ct)`, chunked per ML's documented batch ceiling.
+   - `ToAssign` → `_ml.AssignSubscriberToGroupAsync(sub.Id, group.Id, ct)` per subscriber.
+   - `ToUnassign` → `_ml.UnassignSubscriberFromGroupAsync(sub.Id, group.Id, ct)` per subscriber.
+   - Each individual ML call wrapped in try/catch; failures logged + counted in `errors`; sync continues.
+8. **Audit.** Write one `AuditAction.MailerLiteAudienceSyncCompleted` entry with metadata `{ audience_key, group_id, candidates, excluded_unsubscribed, created, assigned, already_assigned, unassigned, errors }`. No per-row audit entries (matches the existing inbound-import pattern's idempotent-summary shape).
+
+**Idempotency:** a second immediate run produces all-zero deltas except `AlreadyAssigned`. The audit is still written (one summary entry) but its counts are all zero.
+
+**Failure semantics:** any individual ML write that fails does NOT roll back the sync. Partial progress is fine; the next run reconciles. The summary audit surfaces the error count so admins can see failures without grepping logs.
+
+### `MailerAudienceSyncJob` (Hangfire recurring)
+
+```csharp
+public sealed class MailerAudienceSyncJob(IMailerAudienceSyncService sync, ILogger<MailerAudienceSyncJob> log)
+{
+    public async Task RunAsync(CancellationToken ct)
+    {
+        var results = await sync.SyncAllAsync(ct);
+        log.LogInformation("Audience sync ran for {Count} audiences", results.Count);
+    }
+}
+```
+
+Registered in `HangfireConfiguration` with cron from `MailerLiteOptions.AudienceSyncCron` (new option, default `0 6 * * *` Madrid time — early morning, low ML traffic, fresh for the day's admin checks). Job runs sequentially across audiences (no parallelism — keeps ML rate-limit headroom).
+
+## 4. UI
+
+### `/Mailer/Admin` index — Audiences card (new)
+
+Rendered as a partial below the existing dashboard summary, MailerLite groups list, and drift report.
+
+```
+┌─ Audiences ───────────────────────────────────────────┐
+│ Humans - Ticket no Shifts                             │
+│   533 humans match  ·  17 ML-unsubscribed             │
+│   516 currently in group  ·  last sync 2h ago         │
+│                                  [ Push Now ]         │
+└───────────────────────────────────────────────────────┘
+```
+
+Per-row stats come from `IMailerAudienceSyncService.ComputeStatsAsync` — a single ML subscriber sweep is shared across all audiences on the page render (compute stats for the first audience, reuse the in-memory subscriber map for the rest). At one audience today, fan-out is irrelevant; at five, sharing the sweep saves four full enumerations.
+
+### Routes
+
+| Route | Method | Auth | Purpose |
+|-------|--------|------|---------|
+| `/Mailer/Admin` | GET | `AdminOnly` | Dashboard, extended with Audiences card |
+| `/Mailer/Admin/Audiences/{key}/Sync` | POST | `AdminOnly` | Trigger on-demand sync for one audience |
+
+The controller action looks up the `IMailerAudience` by `Key` from the injected `IEnumerable<IMailerAudience>`. 404 if not found.
+
+### Antiforgery + TempData
+
+`POST /Mailer/Admin/Audiences/{key}/Sync` requires antiforgery token (matches existing `/Mailer/Admin/Import/Commit` pattern). On success, sets `TempData["Banner"]` with the summary line (e.g. `"Synced: 0 created, 8 newly assigned, 3 unassigned, 0 errors."`) and redirects back to the index.
+
+## 5. Configuration
+
+`MailerLiteOptions` (existing class) gains:
+
+```csharp
+public sealed class MailerLiteOptions
+{
+    public string BaseUrl { get; init; } = "https://connect.mailerlite.com";
+    public string ApiVersion { get; init; } = "2038-01-01";
+    public string ApiKey { get; init; } = string.Empty;
+    public string AudienceSyncCron { get; init; } = "0 6 * * *";   // new
+    public int BulkImportChunkSize { get; init; } = 50;            // new — per ML docs ceiling
+}
+```
+
+`MAILERLITE_API_KEY` continues to be set via environment variable / Coolify secret; cron and chunk size are config-only (bound in `appsettings.json`).
+
+## 6. Section invariants — updates to `docs/sections/Mailer.md`
+
+Replace:
+
+> - `IMailerLiteService` exposes only GET-shaped methods. No `Create`/`Update`/`Delete`/`Upsert`/`Add`/`Remove`/`Set`/`Post`/`Put`/`Patch` prefixes. Pinned by `MailerArchitectureTests.IMailerLiteService_HasNoWriteMethods`.
+> - `MailerLiteClient` runtime-rejects any non-GET HTTP method with `InvalidOperationException`.
+
+with:
+
+> - `IMailerLiteService` exposes reads + four narrow outbound writes: `CreateGroupAsync`, `AssignSubscriberToGroupAsync`, `UnassignSubscriberFromGroupAsync`, `BulkImportSubscribersToGroupAsync`. The set of allowed write methods is pinned by `MailerArchitectureTests.IMailerLiteService_OnlyAllowsAudienceWrites`.
+> - Every outbound write targets an ML group whose `Name` starts with `"Humans - "`. `MailerLiteClient` runtime-rejects writes against non-`"Humans - "` groups with `InvalidOperationException`. Pinned by `MailerLiteClientWriteGuardTests.RejectsWritesToNonHumansGroups`.
+> - All `IMailerAudience` implementations target group names starting with `"Humans - "`. Pinned by `MailerArchitectureTests.AllAudiences_UseHumansPrefix`.
+
+Remove the line:
+
+> - Inbound-only is a known compliance gap. **Outbound is the next slice and must ship before any other Mailer feature.** …
+
+(Replaced by the section's new outbound capabilities documented above.)
+
+Add to *Cross-Section Dependencies*:
+
+> - **Tickets:** `ITicketQueryService.GetUserIdsWithMatchedAttendeesAsync` — audience-side ticket-holder enumeration for `TicketNoShiftsAudience`.
+> - **Shifts:** `IShiftSignupService.GetActiveCommittedUserIdsForEventAsync` and `IShiftManagementService.GetActiveAsync` — audience-side shift commitment + active-event lookup.
+
+Add to *Routing*:
+
+> - `/Mailer/Admin/Audiences/{key}/Sync` — on-demand audience push (POST)
+
+## 7. Architecture invariants — tests
+
+`tests/Humans.Application.Tests/Architecture/MailerArchitectureTests.cs` updates:
+
+- **Replace** `IMailerLiteService_HasNoWriteMethods` with `IMailerLiteService_OnlyAllowsAudienceWrites`:
+  - Reflection scan of `IMailerLiteService` methods; allowed writes are exactly `CreateGroupAsync`, `AssignSubscriberToGroupAsync`, `UnassignSubscriberFromGroupAsync`, `BulkImportSubscribersToGroupAsync`. Any other write-shaped name (`Update*`, `Delete*` not on the allow-list, `Set*`, `Patch*`, additional `Post*`, etc.) fails the test.
+- **New** `MailerAudienceSyncService_LivesInApplication_NoEF` — same shape as the existing `MailerImportService` arch pin.
+- **New** `AllAudiences_UseHumansPrefix` — load all `IMailerAudience` registrations from DI, assert every `MailerLiteGroupName.StartsWith("Humans - ")`.
+- **New** `AllAudiences_HaveUniqueGroupNamesAndKeys` — assert `MailerLiteGroupName` and `Key` are unique across registrations (two audiences would race over the same group otherwise).
+
+`tests/Humans.Application.Tests/Services/Mailer/MailerLiteClientWriteGuardTests.cs` extends:
+
+- **New** `RejectsWritesToNonHumansGroups` — with a `FakeHttpMessageHandler` that returns a group whose name is `"Newsletter"`, calling `AssignSubscriberToGroupAsync(..., that.Id, ...)` throws `InvalidOperationException` before any HTTP write is dispatched.
+- **New** `CreateGroupAsync_RejectsNonHumansName` — `CreateGroupAsync("Newsletter")` throws synchronously.
+
+## 8. Service + audience tests
+
+`tests/Humans.Application.Tests/Services/Mailer/MailerAudienceSyncServiceTests.cs` (new):
+
+- **Idempotency** — second run after no Humans/ML state change → all deltas zero, one summary audit entry with zero counts.
+- **ML-unsubscribed user filtered** — candidate whose ML subscriber `status = unsubscribed` is bucketed `ExcludedUnsubscribed`, never assigned. Same for `bounced` and `junk`.
+- **New user (no ML subscriber record)** — bucketed `ToCreateAndAssign`, uses `BulkImportSubscribersToGroupAsync`.
+- **Removal** — user who was in the group but no longer qualifies → `ToUnassign`, single-call unassign issued.
+- **Group auto-create** — first run with missing group → calls `CreateGroupAsync`, then assigns.
+- **Group prefix violation** — an `IMailerAudience` impl whose `MailerLiteGroupName` lacks `"Humans - "` causes `SyncAsync` to throw before any ML call. (Belt-and-braces alongside the `AllAudiences_UseHumansPrefix` arch test.)
+- **Error counting** — an assign call that throws is counted in `errors`; sync continues; summary audit records the count.
+- **Audit metadata shape** — verify keys and value types on the summary entry's metadata bag.
+
+`tests/Humans.Application.Tests/Services/Mailer/TicketNoShiftsAudienceTests.cs` (new):
+
+| Scenario | In audience? |
+|----------|:-:|
+| Has matched ticket (Valid), no shift signup | ✅ |
+| Has matched ticket (CheckedIn), no shift signup | ✅ |
+| Has matched ticket but a Pending shift signup | ❌ |
+| Has matched ticket but a Confirmed shift signup | ❌ |
+| Has matched ticket and a Refused signup only | ✅ |
+| Has matched ticket and a Bailed signup only | ✅ |
+| Has matched ticket and a Cancelled signup only | ✅ |
+| Has matched ticket and a NoShow signup only | ✅ |
+| Buyer-only match (TicketOrder matched, no Valid attendee) | ❌ |
+| No ticket at all | ❌ |
+| Shift signup is on a non-active event | ✅ (only active event counts) |
+| No active event exists | empty set |
+
+`tests/Humans.Web.Tests/Controllers/Mailer/MailerAdminControllerAudienceSyncTests.cs` (new):
+
+- `POST /Mailer/Admin/Audiences/ticket-no-shifts/Sync` — admin → 302 with TempData banner.
+- Non-admin → 403.
+- Unknown `key` → 404.
+- Antiforgery token required.
+
+## 9. Audit log
+
+New action: `AuditAction.MailerLiteAudienceSyncCompleted`.
+
+Audit metadata schema:
+```json
+{
+  "audience_key": "ticket-no-shifts",
+  "group_id": "12345",
+  "group_name": "Humans - Ticket no Shifts",
+  "candidates": 533,
+  "excluded_unsubscribed": 17,
+  "created": 0,
+  "assigned": 8,
+  "already_assigned": 508,
+  "unassigned": 3,
+  "errors": 0
+}
+```
+
+No PII in the audit metadata — counts only. Matches the existing `MailerLiteReconciliationCompleted` pattern.
+
+Update `docs/sections/AuditLog.md` to list the new action under Mailer's writes.
+
+## 10. Build sequence
+
+The slice is one PR. Logical commit groups for review:
+
+1. **Outbound primitives** — `IMailerLiteService` write methods, `MailerLiteClient` impls with prefix guard, write-guard tests, arch tests updated. No audience code yet — proves the outbound slice is self-consistent and prefix-safe.
+2. **Audience framework** — `IMailerAudience`, `IMailerAudienceSyncService` + impl, DI registration shape, sync service tests with a fake audience.
+3. **First audience** — `TicketNoShiftsAudience` + new read methods on `ITicketQueryService` / `IShiftSignupService` it depends on. Audience tests.
+4. **UI + job** — dashboard card, `POST /Mailer/Admin/Audiences/{key}/Sync`, Hangfire job + cron config, controller tests.
+5. **Section doc + AuditLog doc updates** — `docs/sections/Mailer.md` invariants, `docs/sections/AuditLog.md` new action.
+
+## 11. Open questions for implementer
+
+1. **ML v2 endpoint shapes** — confirm `POST /api/groups/{group_id}/subscribers/import` exists and document its max batch size in `MailerLiteOptions.BulkImportChunkSize`'s comment. If the endpoint has been retired in current ML v2, fall back to a per-subscriber loop in `BulkImportSubscribersToGroupAsync` and reduce `BulkImportChunkSize` to 1 (or remove the option).
+2. **Existing tickets read** — confirm whether `ITicketQueryService.GetAllMatchedUserIdsAsync` (referenced in `Tickets.md`) returns exactly the set we want (Valid|CheckedIn attendee match, buyer-only excluded), or whether `TicketNoShiftsAudience` needs a new narrowed read method `GetUserIdsWithMatchedAttendeesAsync`. Prefer reusing the existing method; add a new one only if its semantics don't match.
+3. **Primary email lookup** — confirm `IUserEmailService` exposes a bulk `GetPrimaryEmailsByUserIdsAsync` shape; if not, add one as part of this PR (Profiles section), or fall back to per-user `GetPrimaryEmailAsync` calls (acceptable at 500-user scale).

--- a/src/Humans.Application/Interfaces/Mailer/Dtos/AudienceStats.cs
+++ b/src/Humans.Application/Interfaces/Mailer/Dtos/AudienceStats.cs
@@ -1,0 +1,14 @@
+using NodaTime;
+
+namespace Humans.Application.Interfaces.Mailer.Dtos;
+
+/// <summary>Read-only stats for one audience, shown on the Mailer admin dashboard.</summary>
+public sealed record AudienceStats(
+    string Key,
+    string DisplayName,
+    string MailerLiteGroupName,
+    int Candidates,
+    int ExcludedUnsubscribed,
+    int CurrentlyInGroup,
+    Instant? LastSyncAt,
+    string? LastSyncSummary);

--- a/src/Humans.Application/Interfaces/Mailer/Dtos/AudienceSyncResult.cs
+++ b/src/Humans.Application/Interfaces/Mailer/Dtos/AudienceSyncResult.cs
@@ -1,0 +1,21 @@
+using System.Globalization;
+
+namespace Humans.Application.Interfaces.Mailer.Dtos;
+
+/// <summary>Post-sync counts for one audience. Mirrors the audit metadata.</summary>
+public sealed record AudienceSyncResult(
+    string Key,
+    string GroupId,
+    string GroupName,
+    int Candidates,
+    int ExcludedUnsubscribed,
+    int Created,
+    int Assigned,
+    int AlreadyAssigned,
+    int Unassigned,
+    int Errors)
+{
+    public string FormatSummary() => string.Create(
+        CultureInfo.InvariantCulture,
+        $"{Created} created, {Assigned} newly assigned, {Unassigned} unassigned, {Errors} errors.");
+}

--- a/src/Humans.Application/Interfaces/Mailer/Dtos/BulkImportResult.cs
+++ b/src/Humans.Application/Interfaces/Mailer/Dtos/BulkImportResult.cs
@@ -1,0 +1,11 @@
+namespace Humans.Application.Interfaces.Mailer.Dtos;
+
+/// <summary>
+/// Aggregated outcome of a bulk import call (or chain of chunked calls) that
+/// creates-and-assigns subscribers to a single MailerLite group.
+/// </summary>
+public sealed record BulkImportResult(
+    int Created,
+    int Updated,
+    int Duplicates,
+    int Errors);

--- a/src/Humans.Application/Interfaces/Mailer/Dtos/MailerLiteSubscriber.cs
+++ b/src/Humans.Application/Interfaces/Mailer/Dtos/MailerLiteSubscriber.cs
@@ -15,4 +15,5 @@ public sealed record MailerLiteSubscriber(
     Instant? UnsubscribedAt,  // UTC; null when not unsubscribed
     Instant? OptedInAt,       // UTC; null until double-opt-in confirmed
     string? FirstName,
-    string? LastName);
+    string? LastName,
+    IReadOnlyList<string> GroupIds); // IDs of groups this subscriber currently belongs to

--- a/src/Humans.Application/Interfaces/Mailer/IMailerAudience.cs
+++ b/src/Humans.Application/Interfaces/Mailer/IMailerAudience.cs
@@ -1,0 +1,26 @@
+namespace Humans.Application.Interfaces.Mailer;
+
+/// <summary>
+/// A code-defined mailing list. Each implementation computes a set of Humans
+/// user-ids who belong in the audience and maps it to a single MailerLite group
+/// whose <see cref="MailerLiteGroupName"/> must start with "Humans - "
+/// (pinned by <c>MailerArchitectureTests.AllAudiences_UseHumansPrefix</c>).
+/// </summary>
+public interface IMailerAudience
+{
+    /// <summary>Stable URL-safe key (e.g. "ticket-no-shifts").</summary>
+    string Key { get; }
+
+    /// <summary>Display name shown on the dashboard card.</summary>
+    string DisplayName { get; }
+
+    /// <summary>Target MailerLite group name. Must start with "Humans - ".</summary>
+    string MailerLiteGroupName { get; }
+
+    /// <summary>
+    /// Returns the current Humans user-ids who belong in this audience.
+    /// Implementations read cross-section state via service interfaces only —
+    /// never via <c>HumansDbContext</c> directly.
+    /// </summary>
+    Task<IReadOnlySet<Guid>> ComputeMemberUserIdsAsync(CancellationToken ct);
+}

--- a/src/Humans.Application/Interfaces/Mailer/IMailerAudienceSyncService.cs
+++ b/src/Humans.Application/Interfaces/Mailer/IMailerAudienceSyncService.cs
@@ -1,0 +1,20 @@
+using Humans.Application.Interfaces.Mailer.Dtos;
+
+namespace Humans.Application.Interfaces.Mailer;
+
+/// <summary>
+/// Orchestrates pulling audience definitions, diffing against ML state, and
+/// pushing membership changes to MailerLite. Stat-only reads are split out so
+/// the dashboard can render without forcing a sync.
+/// </summary>
+public interface IMailerAudienceSyncService : IApplicationService
+{
+    /// <summary>Read-only: candidates / excluded-unsubscribed / currently-in-group / last sync.</summary>
+    Task<AudienceStats> ComputeStatsAsync(IMailerAudience audience, CancellationToken ct = default);
+
+    /// <summary>Build diff and apply to MailerLite. Writes the summary audit entry.</summary>
+    Task<AudienceSyncResult> SyncAsync(IMailerAudience audience, CancellationToken ct = default);
+
+    /// <summary>Calls SyncAsync sequentially for every registered audience.</summary>
+    Task<IReadOnlyList<AudienceSyncResult>> SyncAllAsync(CancellationToken ct = default);
+}

--- a/src/Humans.Application/Interfaces/Mailer/IMailerAudienceSyncService.cs
+++ b/src/Humans.Application/Interfaces/Mailer/IMailerAudienceSyncService.cs
@@ -9,12 +9,28 @@ namespace Humans.Application.Interfaces.Mailer;
 /// </summary>
 public interface IMailerAudienceSyncService : IApplicationService
 {
-    /// <summary>Read-only: candidates / excluded-unsubscribed / currently-in-group / last sync.</summary>
+    /// <summary>Read-only stats for one audience: candidates / excluded-unsubscribed / currently-in-group.</summary>
     Task<AudienceStats> ComputeStatsAsync(IMailerAudience audience, CancellationToken ct = default);
 
-    /// <summary>Build diff and apply to MailerLite. Writes the summary audit entry.</summary>
-    Task<AudienceSyncResult> SyncAsync(IMailerAudience audience, CancellationToken ct = default);
+    /// <summary>
+    /// Read-only stats for every registered audience in a single pass.
+    /// Pulls the MailerLite subscriber/group snapshot once and the audit-log
+    /// last-sync entries once, then folds them into per-audience rows. Used
+    /// by the /Mailer/Admin dashboard so the controller doesn't fan out
+    /// multiple service+audit calls per render.
+    /// </summary>
+    Task<IReadOnlyList<AudienceStats>> ComputeAllStatsAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Build diff and apply to MailerLite. Writes the summary audit entry.
+    /// Pass <paramref name="actorUserId"/> for human-triggered runs (admin
+    /// "Push Now"); leave null for the scheduled job so the audit entry uses
+    /// the job-actor overload.
+    /// </summary>
+    Task<AudienceSyncResult> SyncAsync(
+        IMailerAudience audience, Guid? actorUserId = null, CancellationToken ct = default);
 
     /// <summary>Calls SyncAsync sequentially for every registered audience.</summary>
-    Task<IReadOnlyList<AudienceSyncResult>> SyncAllAsync(CancellationToken ct = default);
+    Task<IReadOnlyList<AudienceSyncResult>> SyncAllAsync(
+        Guid? actorUserId = null, CancellationToken ct = default);
 }

--- a/src/Humans.Application/Interfaces/Mailer/IMailerLiteService.cs
+++ b/src/Humans.Application/Interfaces/Mailer/IMailerLiteService.cs
@@ -4,9 +4,10 @@ using NodaTime;
 namespace Humans.Application.Interfaces.Mailer;
 
 /// <summary>
-/// Typed read-only MailerLite client surface. No write methods exist by
-/// design — outbound is a separate slice with its own review. Pinned by
-/// <c>MailerArchitectureTests.IMailerLiteService_HasNoWriteMethods</c>.
+/// MailerLite client surface. Reads cover account summary, groups, and
+/// subscribers. Writes are narrow: limited to creating "Humans - "-prefixed
+/// groups and managing membership in those groups. Pinned by
+/// <c>MailerArchitectureTests.IMailerLiteService_OnlyAllowsAudienceWrites</c>.
 ///
 /// Implementations cache subscribers, groups, and the derived account
 /// summary in memory so page loads (e.g. /Mailer/Admin) don't burn the
@@ -30,4 +31,32 @@ public interface IMailerLiteService : IApplicationService
     Instant? LastFetchedAt { get; }
 
     Task RefreshAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Creates a new group in MailerLite. Runtime-rejects with
+    /// <see cref="InvalidOperationException"/> if <paramref name="name"/> does
+    /// not start with <c>"Humans - "</c>.
+    /// </summary>
+    Task<MailerLiteGroup> CreateGroupAsync(string name, CancellationToken ct = default);
+
+    /// <summary>
+    /// Assigns an existing subscriber to a group. Runtime-rejects with
+    /// <see cref="InvalidOperationException"/> if the target group's
+    /// <see cref="MailerLiteGroup.Name"/> does not start with <c>"Humans - "</c>.
+    /// </summary>
+    Task AssignSubscriberToGroupAsync(string subscriberId, string groupId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Removes a subscriber from a group. Same prefix guard as assign.
+    /// </summary>
+    Task UnassignSubscriberFromGroupAsync(string subscriberId, string groupId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Bulk-creates-or-updates subscribers from a list of emails and assigns them
+    /// to the target group in one MailerLite call (chunked per
+    /// <c>MailerLiteOptions.BulkImportChunkSize</c> by the implementation).
+    /// Same prefix guard as assign.
+    /// </summary>
+    Task<BulkImportResult> BulkImportSubscribersToGroupAsync(
+        string groupId, IReadOnlyList<string> emails, CancellationToken ct = default);
 }

--- a/src/Humans.Application/Interfaces/Mailer/MailerLiteOptions.cs
+++ b/src/Humans.Application/Interfaces/Mailer/MailerLiteOptions.cs
@@ -11,4 +11,14 @@ public sealed class MailerLiteOptions
     public string ApiKey { get; set; } = string.Empty;
     public string BaseUrl { get; set; } = "https://connect.mailerlite.com";
     public string ApiVersion { get; set; } = "2038-01-01";
+
+    /// <summary>Cron expression for the daily audience sync job. Default 06:00 UTC.</summary>
+    public string AudienceSyncCron { get; set; } = "0 6 * * *";
+
+    /// <summary>
+    /// Max subscribers per call to <c>POST /api/groups/{id}/subscribers/import</c>.
+    /// Implementer to verify ML v2 current ceiling; 50 is the documented safe value
+    /// observed in 2026-05.
+    /// </summary>
+    public int BulkImportChunkSize { get; set; } = 50;
 }

--- a/src/Humans.Application/Interfaces/Mailer/MailerLiteOptions.cs
+++ b/src/Humans.Application/Interfaces/Mailer/MailerLiteOptions.cs
@@ -19,11 +19,4 @@ public sealed class MailerLiteOptions
     /// to enable a daily 06:00 UTC run.
     /// </summary>
     public string AudienceSyncCron { get; set; } = string.Empty;
-
-    /// <summary>
-    /// Max subscribers per call to <c>POST /api/groups/{id}/subscribers/import</c>.
-    /// Implementer to verify ML v2 current ceiling; 50 is the documented safe value
-    /// observed in 2026-05.
-    /// </summary>
-    public int BulkImportChunkSize { get; set; } = 50;
 }

--- a/src/Humans.Application/Interfaces/Mailer/MailerLiteOptions.cs
+++ b/src/Humans.Application/Interfaces/Mailer/MailerLiteOptions.cs
@@ -12,8 +12,13 @@ public sealed class MailerLiteOptions
     public string BaseUrl { get; set; } = "https://connect.mailerlite.com";
     public string ApiVersion { get; set; } = "2038-01-01";
 
-    /// <summary>Cron expression for the daily audience sync job. Default 06:00 UTC.</summary>
-    public string AudienceSyncCron { get; set; } = "0 6 * * *";
+    /// <summary>
+    /// Cron expression for the recurring audience sync job. Empty (default) means
+    /// the recurring job is not registered — admins can still trigger syncs on
+    /// demand via the /Mailer/Admin "Push Now" button. Set to e.g. <c>"0 6 * * *"</c>
+    /// to enable a daily 06:00 UTC run.
+    /// </summary>
+    public string AudienceSyncCron { get; set; } = string.Empty;
 
     /// <summary>
     /// Max subscribers per call to <c>POST /api/groups/{id}/subscribers/import</c>.

--- a/src/Humans.Application/Interfaces/Profiles/IUserEmailService.cs
+++ b/src/Humans.Application/Interfaces/Profiles/IUserEmailService.cs
@@ -282,6 +282,14 @@ public interface IUserEmailService : IApplicationService
     Task<string?> GetPrimaryEmailAsync(Guid userId, CancellationToken ct = default);
 
     /// <summary>
+    /// Bulk variant of <see cref="GetPrimaryEmailAsync"/>. Returns a map of user-id
+    /// to primary email for each user that has one. Users without a primary email
+    /// are omitted from the result.
+    /// </summary>
+    Task<IReadOnlyDictionary<Guid, string>> GetPrimaryEmailsByUserIdsAsync(
+        IEnumerable<Guid> userIds, CancellationToken ct = default);
+
+    /// <summary>
     /// Returns every verified email address belonging to the user. Used by
     /// cross-section callers (Tickets, matching) that need to compare incoming
     /// addresses against a user's verified set without reading

--- a/src/Humans.Application/Interfaces/Profiles/IUserEmailService.cs
+++ b/src/Humans.Application/Interfaces/Profiles/IUserEmailService.cs
@@ -282,14 +282,6 @@ public interface IUserEmailService : IApplicationService
     Task<string?> GetPrimaryEmailAsync(Guid userId, CancellationToken ct = default);
 
     /// <summary>
-    /// Bulk variant of <see cref="GetPrimaryEmailAsync"/>. Returns a map of user-id
-    /// to primary email for each user that has one. Users without a primary email
-    /// are omitted from the result.
-    /// </summary>
-    Task<IReadOnlyDictionary<Guid, string>> GetPrimaryEmailsByUserIdsAsync(
-        IEnumerable<Guid> userIds, CancellationToken ct = default);
-
-    /// <summary>
     /// Returns every verified email address belonging to the user. Used by
     /// cross-section callers (Tickets, matching) that need to compare incoming
     /// addresses against a user's verified set without reading

--- a/src/Humans.Application/Interfaces/Repositories/IShiftSignupRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/IShiftSignupRepository.cs
@@ -261,4 +261,11 @@ public interface IShiftSignupRepository : IRepository
     /// reconciliation screen. Read-only.
     /// </summary>
     Task<IReadOnlyList<ShiftSignup>> GetAllForOrphanScanAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns user-ids with at least one Pending or Confirmed signup for the
+    /// given event. Read-only. Used by Mailer audience computations.
+    /// </summary>
+    Task<IReadOnlySet<Guid>> GetActiveCommittedUserIdsForEventAsync(
+        Guid eventSettingsId, CancellationToken ct = default);
 }

--- a/src/Humans.Application/Interfaces/Shifts/IShiftSignupService.cs
+++ b/src/Humans.Application/Interfaces/Shifts/IShiftSignupService.cs
@@ -9,7 +9,7 @@ namespace Humans.Application.Interfaces.Shifts;
 /// <summary>
 /// Manages the shift signup state machine with invariant enforcement.
 /// </summary>
-[SurfaceBudget(24)]
+[SurfaceBudget(25)]
 public interface IShiftSignupService : IApplicationService
 {
     /// <summary>
@@ -163,6 +163,14 @@ public interface IShiftSignupService : IApplicationService
     /// </summary>
     Task<IReadOnlyList<ShiftSignup>> FilterToIncompleteOnboardingAsync(
         IReadOnlyList<ShiftSignup> signups, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns user-ids with at least one ShiftSignup for the given event whose
+    /// Status is Pending or Confirmed. Used by audience computations to identify
+    /// "users who have a shift". Refused/Bailed/Cancelled/NoShow signups do not count.
+    /// </summary>
+    Task<IReadOnlySet<Guid>> GetActiveCommittedUserIdsForEventAsync(
+        Guid eventSettingsId, CancellationToken ct = default);
 }
 
 /// <summary>

--- a/src/Humans.Application/Services/Mailer/Audiences/TicketNoShiftsAudience.cs
+++ b/src/Humans.Application/Services/Mailer/Audiences/TicketNoShiftsAudience.cs
@@ -1,0 +1,36 @@
+using Humans.Application.Interfaces.Mailer;
+using Humans.Application.Interfaces.Shifts;
+using Humans.Application.Interfaces.Tickets;
+
+namespace Humans.Application.Services.Mailer.Audiences;
+
+/// <summary>
+/// "Humans - Ticket no Shifts" — humans with a Valid/CheckedIn matched
+/// ticket attendee in the active vendor event who have NOT signed up for any
+/// shift in the active EventSettings event (Pending and Confirmed signups
+/// count as "has a shift"; Refused/Bailed/Cancelled/NoShow do not).
+/// </summary>
+public sealed class TicketNoShiftsAudience(
+    ITicketQueryService tickets,
+    IShiftSignupService shiftSignups,
+    IShiftManagementService shiftManagement) : IMailerAudience
+{
+    public string Key => "ticket-no-shifts";
+    public string DisplayName => "Ticket holders without a shift";
+    public string MailerLiteGroupName => "Humans - Ticket no Shifts";
+
+    public async Task<IReadOnlySet<Guid>> ComputeMemberUserIdsAsync(CancellationToken ct)
+    {
+        var activeEvent = await shiftManagement.GetActiveAsync();
+        if (activeEvent is null) return new HashSet<Guid>();
+
+        // GetUserIdsWithTicketsAsync returns Valid/CheckedIn matched attendees
+        // (buyer-only matches excluded) — see ITicketQueryService docs.
+        var ticketHolders = await tickets.GetUserIdsWithTicketsAsync();
+        var shiftHavers = await shiftSignups.GetActiveCommittedUserIdsForEventAsync(activeEvent.Id, ct);
+
+        var audience = new HashSet<Guid>(ticketHolders);
+        audience.ExceptWith(shiftHavers);
+        return audience;
+    }
+}

--- a/src/Humans.Application/Services/Mailer/MailerAudienceSyncService.cs
+++ b/src/Humans.Application/Services/Mailer/MailerAudienceSyncService.cs
@@ -1,0 +1,212 @@
+using System.Text.Json;
+using Humans.Application.Interfaces;
+using Humans.Application.Interfaces.AuditLog;
+using Humans.Application.Interfaces.Mailer;
+using Humans.Application.Interfaces.Mailer.Dtos;
+using Humans.Application.Interfaces.Profiles;
+using Humans.Domain.Enums;
+using Microsoft.Extensions.Logging;
+
+namespace Humans.Application.Services.Mailer;
+
+/// <summary>
+/// Orchestrates audience computation, ML state diffing, and the apply step.
+/// Lives in the Application layer; no DbContext.
+/// </summary>
+public sealed class MailerAudienceSyncService(
+    IMailerLiteService ml,
+    IUserEmailService emails,
+    IAuditLogService audit,
+    IEnumerable<IMailerAudience> audiences,
+    ILogger<MailerAudienceSyncService> logger) : IMailerAudienceSyncService
+{
+    private const string HumansGroupPrefix = "Humans - ";
+    private const string JobName = nameof(MailerAudienceSyncService);
+
+    private static readonly HashSet<string> UnsubscribedStatuses =
+        new(StringComparer.OrdinalIgnoreCase) { "unsubscribed", "bounced", "junk" };
+
+    public async Task<IReadOnlyList<AudienceSyncResult>> SyncAllAsync(CancellationToken ct = default)
+    {
+        var results = new List<AudienceSyncResult>();
+        foreach (var audience in audiences)
+        {
+            try
+            {
+                results.Add(await SyncAsync(audience, ct));
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Audience sync failed for {Audience}", audience.Key);
+            }
+        }
+        return results;
+    }
+
+    public async Task<AudienceStats> ComputeStatsAsync(IMailerAudience audience, CancellationToken ct = default)
+    {
+        var memberUserIds = await audience.ComputeMemberUserIdsAsync(ct);
+        var userEmailMap = await emails.GetPrimaryEmailsByUserIdsAsync(memberUserIds, ct);
+
+        var subscribers = new List<MailerLiteSubscriber>();
+        await foreach (var s in ml.ListSubscribersAsync(ct)) subscribers.Add(s);
+        var byEmail = subscribers.ToDictionary(s => NormalizeEmail(s.Email), s => s, StringComparer.Ordinal);
+
+        var groups = await ml.ListGroupsAsync(ct);
+        var group = groups.FirstOrDefault(g => string.Equals(g.Name, audience.MailerLiteGroupName, StringComparison.Ordinal));
+
+        int excluded = 0, inGroup = 0;
+        foreach (var (_, email) in userEmailMap)
+        {
+            if (!byEmail.TryGetValue(NormalizeEmail(email), out var sub)) continue;
+            if (UnsubscribedStatuses.Contains(sub.Status)) excluded++;
+            else if (group is not null && sub.GroupIds.Contains(group.Id, StringComparer.Ordinal)) inGroup++;
+        }
+
+        return new AudienceStats(
+            audience.Key,
+            audience.DisplayName,
+            audience.MailerLiteGroupName,
+            Candidates: userEmailMap.Count,
+            ExcludedUnsubscribed: excluded,
+            CurrentlyInGroup: inGroup,
+            LastSyncAt: null,
+            LastSyncSummary: null);
+    }
+
+    public async Task<AudienceSyncResult> SyncAsync(IMailerAudience audience, CancellationToken ct = default)
+    {
+        if (!audience.MailerLiteGroupName.StartsWith(HumansGroupPrefix, StringComparison.Ordinal))
+            throw new InvalidOperationException(
+                $"Audience '{audience.Key}' targets group '{audience.MailerLiteGroupName}' " +
+                $"which does not start with '{HumansGroupPrefix}'.");
+
+        var memberUserIds = await audience.ComputeMemberUserIdsAsync(ct);
+        var userEmailMap = await emails.GetPrimaryEmailsByUserIdsAsync(memberUserIds, ct);
+        var droppedNoEmail = memberUserIds.Count - userEmailMap.Count;
+        if (droppedNoEmail > 0)
+            logger.LogInformation(
+                "Audience {Audience}: dropped {Count} candidates with no primary email",
+                audience.Key, droppedNoEmail);
+
+        var groups = await ml.ListGroupsAsync(ct);
+        var group = groups.FirstOrDefault(g => string.Equals(g.Name, audience.MailerLiteGroupName, StringComparison.Ordinal))
+            ?? await ml.CreateGroupAsync(audience.MailerLiteGroupName, ct);
+
+        var subscribers = new List<MailerLiteSubscriber>();
+        await foreach (var s in ml.ListSubscribersAsync(ct)) subscribers.Add(s);
+        var byEmail = subscribers.ToDictionary(s => NormalizeEmail(s.Email), s => s, StringComparer.Ordinal);
+        var currentGroupMemberIds = subscribers
+            .Where(s => s.GroupIds.Contains(group.Id, StringComparer.Ordinal))
+            .Select(s => s.Id)
+            .ToHashSet(StringComparer.Ordinal);
+
+        var toBulkImport = new List<string>();
+        var toAssign = new List<string>();
+        var keepSubscriberIds = new HashSet<string>(StringComparer.Ordinal);
+        int excluded = 0, alreadyAssigned = 0;
+
+        foreach (var (_, email) in userEmailMap)
+        {
+            var norm = NormalizeEmail(email);
+            if (!byEmail.TryGetValue(norm, out var sub))
+            {
+                toBulkImport.Add(email);
+                continue;
+            }
+            if (UnsubscribedStatuses.Contains(sub.Status))
+            {
+                excluded++;
+                continue;
+            }
+            keepSubscriberIds.Add(sub.Id);
+            if (currentGroupMemberIds.Contains(sub.Id))
+                alreadyAssigned++;
+            else
+                toAssign.Add(sub.Id);
+        }
+
+        var toUnassign = currentGroupMemberIds.Except(keepSubscriberIds, StringComparer.Ordinal).ToList();
+
+        int created = 0, assigned = 0, unassigned = 0, errors = 0;
+
+        if (toBulkImport.Count > 0)
+        {
+            try
+            {
+                var bulk = await ml.BulkImportSubscribersToGroupAsync(group.Id, toBulkImport, ct);
+                created = bulk.Created;
+                errors += bulk.Errors;
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "BulkImport failed for {Audience}", audience.Key);
+                errors += toBulkImport.Count;
+            }
+        }
+
+        foreach (var subId in toAssign)
+        {
+            try
+            {
+                await ml.AssignSubscriberToGroupAsync(subId, group.Id, ct);
+                assigned++;
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Assign failed for {Sub} in {Audience}", subId, audience.Key);
+                errors++;
+            }
+        }
+
+        foreach (var subId in toUnassign)
+        {
+            try
+            {
+                await ml.UnassignSubscriberFromGroupAsync(subId, group.Id, ct);
+                unassigned++;
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Unassign failed for {Sub} in {Audience}", subId, audience.Key);
+                errors++;
+            }
+        }
+
+        var result = new AudienceSyncResult(
+            audience.Key, group.Id, group.Name,
+            Candidates: userEmailMap.Count,
+            ExcludedUnsubscribed: excluded,
+            Created: created,
+            Assigned: assigned,
+            AlreadyAssigned: alreadyAssigned,
+            Unassigned: unassigned,
+            Errors: errors);
+
+        var metadata = new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["audience_key"] = result.Key,
+            ["group_id"] = result.GroupId,
+            ["group_name"] = result.GroupName,
+            ["candidates"] = result.Candidates,
+            ["excluded_unsubscribed"] = result.ExcludedUnsubscribed,
+            ["created"] = result.Created,
+            ["assigned"] = result.Assigned,
+            ["already_assigned"] = result.AlreadyAssigned,
+            ["unassigned"] = result.Unassigned,
+            ["errors"] = result.Errors,
+        };
+        var description = JsonSerializer.Serialize(metadata);
+
+        await audit.LogAsync(
+            AuditAction.MailerLiteAudienceSyncCompleted,
+            entityType: "MailerAudience", entityId: Guid.Empty,
+            description: description,
+            jobName: JobName);
+
+        return result;
+    }
+
+    private static string NormalizeEmail(string email) =>
+        email.Trim().ToLowerInvariant();
+}

--- a/src/Humans.Application/Services/Mailer/MailerAudienceSyncService.cs
+++ b/src/Humans.Application/Services/Mailer/MailerAudienceSyncService.cs
@@ -4,6 +4,7 @@ using Humans.Application.Interfaces.AuditLog;
 using Humans.Application.Interfaces.Mailer;
 using Humans.Application.Interfaces.Mailer.Dtos;
 using Humans.Application.Interfaces.Profiles;
+using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Microsoft.Extensions.Logging;
 
@@ -26,14 +27,15 @@ public sealed class MailerAudienceSyncService(
     private static readonly HashSet<string> UnsubscribedStatuses =
         new(StringComparer.OrdinalIgnoreCase) { "unsubscribed", "bounced", "junk" };
 
-    public async Task<IReadOnlyList<AudienceSyncResult>> SyncAllAsync(CancellationToken ct = default)
+    public async Task<IReadOnlyList<AudienceSyncResult>> SyncAllAsync(
+        Guid? actorUserId = null, CancellationToken ct = default)
     {
         var results = new List<AudienceSyncResult>();
         foreach (var audience in audiences)
         {
             try
             {
-                results.Add(await SyncAsync(audience, ct));
+                results.Add(await SyncAsync(audience, actorUserId, ct));
             }
             catch (Exception ex)
             {
@@ -45,36 +47,45 @@ public sealed class MailerAudienceSyncService(
 
     public async Task<AudienceStats> ComputeStatsAsync(IMailerAudience audience, CancellationToken ct = default)
     {
-        var memberUserIds = await audience.ComputeMemberUserIdsAsync(ct);
-        var userEmailMap = await emails.GetPrimaryEmailsByUserIdsAsync(memberUserIds, ct);
-
-        var subscribers = new List<MailerLiteSubscriber>();
-        await foreach (var s in ml.ListSubscribersAsync(ct)) subscribers.Add(s);
-        var byEmail = subscribers.ToDictionary(s => NormalizeEmail(s.Email), s => s, StringComparer.Ordinal);
-
-        var groups = await ml.ListGroupsAsync(ct);
-        var group = groups.FirstOrDefault(g => string.Equals(g.Name, audience.MailerLiteGroupName, StringComparison.Ordinal));
-
-        int excluded = 0, inGroup = 0;
-        foreach (var (_, email) in userEmailMap)
-        {
-            if (!byEmail.TryGetValue(NormalizeEmail(email), out var sub)) continue;
-            if (UnsubscribedStatuses.Contains(sub.Status)) excluded++;
-            else if (group is not null && sub.GroupIds.Contains(group.Id, StringComparer.Ordinal)) inGroup++;
-        }
-
-        return new AudienceStats(
-            audience.Key,
-            audience.DisplayName,
-            audience.MailerLiteGroupName,
-            Candidates: userEmailMap.Count,
-            ExcludedUnsubscribed: excluded,
-            CurrentlyInGroup: inGroup,
-            LastSyncAt: null,
-            LastSyncSummary: null);
+        var snapshot = await BuildSnapshotAsync(ct);
+        return await BuildStatsForAudienceAsync(audience, snapshot, ct);
     }
 
-    public async Task<AudienceSyncResult> SyncAsync(IMailerAudience audience, CancellationToken ct = default)
+    public async Task<IReadOnlyList<AudienceStats>> ComputeAllStatsAsync(CancellationToken ct = default)
+    {
+        var snapshot = await BuildSnapshotAsync(ct);
+
+        // Single audit-log read covering every audience; map by audience_key in memory.
+        var auditEntries = await audit.GetFilteredEntriesAsync(
+            actions: new[] { AuditAction.MailerLiteAudienceSyncCompleted },
+            limit: 200,
+            ct: ct);
+
+        var lastByKey = new Dictionary<string, AuditLogEntry>(StringComparer.Ordinal);
+        foreach (var e in auditEntries)
+        {
+            var key = TryExtractAudienceKey(e.Description);
+            if (key is null) continue;
+            if (!lastByKey.ContainsKey(key)) lastByKey[key] = e; // entries arrive newest-first
+        }
+
+        var rows = new List<AudienceStats>();
+        foreach (var audience in audiences)
+        {
+            var stats = await BuildStatsForAudienceAsync(audience, snapshot, ct);
+            if (lastByKey.TryGetValue(audience.Key, out var entry))
+                stats = stats with
+                {
+                    LastSyncAt = entry.OccurredAt,
+                    LastSyncSummary = entry.Description,
+                };
+            rows.Add(stats);
+        }
+        return rows;
+    }
+
+    public async Task<AudienceSyncResult> SyncAsync(
+        IMailerAudience audience, Guid? actorUserId = null, CancellationToken ct = default)
     {
         if (!audience.MailerLiteGroupName.StartsWith(HumansGroupPrefix, StringComparison.Ordinal))
             throw new InvalidOperationException(
@@ -82,17 +93,20 @@ public sealed class MailerAudienceSyncService(
                 $"which does not start with '{HumansGroupPrefix}'.");
 
         var memberUserIds = await audience.ComputeMemberUserIdsAsync(ct);
-        var userEmailMap = await emails.GetPrimaryEmailsByUserIdsAsync(memberUserIds, ct);
+        var userEmailMap = await emails.GetNotificationTargetEmailsAsync(memberUserIds.ToList(), ct);
         var droppedNoEmail = memberUserIds.Count - userEmailMap.Count;
         if (droppedNoEmail > 0)
             logger.LogInformation(
-                "Audience {Audience}: dropped {Count} candidates with no primary email",
+                "Audience {Audience}: dropped {Count} candidates with no notification-target email",
                 audience.Key, droppedNoEmail);
 
         var groups = await ml.ListGroupsAsync(ct);
         var group = groups.FirstOrDefault(g => string.Equals(g.Name, audience.MailerLiteGroupName, StringComparison.Ordinal))
             ?? await ml.CreateGroupAsync(audience.MailerLiteGroupName, ct);
 
+        // Single snapshot of ML subscribers — reused for the entire diff + apply pass.
+        // The per-write methods do NOT invalidate the subscriber cache, so this snapshot
+        // remains the source of truth throughout the loop.
         var subscribers = new List<MailerLiteSubscriber>();
         await foreach (var s in ml.ListSubscribersAsync(ct)) subscribers.Add(s);
         var byEmail = subscribers.ToDictionary(s => NormalizeEmail(s.Email), s => s, StringComparer.Ordinal);
@@ -198,15 +212,83 @@ public sealed class MailerAudienceSyncService(
         };
         var description = JsonSerializer.Serialize(metadata);
 
-        await audit.LogAsync(
-            AuditAction.MailerLiteAudienceSyncCompleted,
-            entityType: "MailerAudience", entityId: Guid.Empty,
-            description: description,
-            jobName: JobName);
+        if (actorUserId is Guid actor)
+        {
+            await audit.LogAsync(
+                AuditAction.MailerLiteAudienceSyncCompleted,
+                entityType: "MailerAudience", entityId: Guid.Empty,
+                description: description,
+                actorUserId: actor);
+        }
+        else
+        {
+            await audit.LogAsync(
+                AuditAction.MailerLiteAudienceSyncCompleted,
+                entityType: "MailerAudience", entityId: Guid.Empty,
+                description: description,
+                jobName: JobName);
+        }
 
         return result;
     }
 
+    private async Task<MlSnapshot> BuildSnapshotAsync(CancellationToken ct)
+    {
+        var subscribers = new List<MailerLiteSubscriber>();
+        await foreach (var s in ml.ListSubscribersAsync(ct)) subscribers.Add(s);
+        var byEmail = subscribers.ToDictionary(s => NormalizeEmail(s.Email), s => s, StringComparer.Ordinal);
+        var groups = await ml.ListGroupsAsync(ct);
+        return new MlSnapshot(byEmail, groups);
+    }
+
+    private async Task<AudienceStats> BuildStatsForAudienceAsync(
+        IMailerAudience audience, MlSnapshot snapshot, CancellationToken ct)
+    {
+        var memberUserIds = await audience.ComputeMemberUserIdsAsync(ct);
+        var userEmailMap = await emails.GetNotificationTargetEmailsAsync(memberUserIds.ToList(), ct);
+
+        var group = snapshot.Groups.FirstOrDefault(g =>
+            string.Equals(g.Name, audience.MailerLiteGroupName, StringComparison.Ordinal));
+
+        int excluded = 0, inGroup = 0;
+        foreach (var (_, email) in userEmailMap)
+        {
+            if (!snapshot.ByEmail.TryGetValue(NormalizeEmail(email), out var sub)) continue;
+            if (UnsubscribedStatuses.Contains(sub.Status)) excluded++;
+            else if (group is not null && sub.GroupIds.Contains(group.Id, StringComparer.Ordinal)) inGroup++;
+        }
+
+        return new AudienceStats(
+            audience.Key,
+            audience.DisplayName,
+            audience.MailerLiteGroupName,
+            Candidates: userEmailMap.Count,
+            ExcludedUnsubscribed: excluded,
+            CurrentlyInGroup: inGroup,
+            LastSyncAt: null,
+            LastSyncSummary: null);
+    }
+
+    private static string? TryExtractAudienceKey(string? description)
+    {
+        if (string.IsNullOrEmpty(description)) return null;
+        try
+        {
+            using var doc = JsonDocument.Parse(description);
+            if (doc.RootElement.ValueKind != JsonValueKind.Object) return null;
+            if (!doc.RootElement.TryGetProperty("audience_key", out var keyEl)) return null;
+            return keyEl.ValueKind == JsonValueKind.String ? keyEl.GetString() : null;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
     private static string NormalizeEmail(string email) =>
         email.Trim().ToLowerInvariant();
+
+    private sealed record MlSnapshot(
+        IReadOnlyDictionary<string, MailerLiteSubscriber> ByEmail,
+        IReadOnlyList<MailerLiteGroup> Groups);
 }

--- a/src/Humans.Application/Services/Profile/UserEmailService.cs
+++ b/src/Humans.Application/Services/Profile/UserEmailService.cs
@@ -580,6 +580,19 @@ public sealed class UserEmailService : IUserEmailService, IUserMerge
         return user?.Email;
     }
 
+    public async Task<IReadOnlyDictionary<Guid, string>> GetPrimaryEmailsByUserIdsAsync(
+        IEnumerable<Guid> userIds, CancellationToken ct = default)
+    {
+        var ids = userIds.Distinct().ToList();
+        var result = new Dictionary<Guid, string>(ids.Count);
+        foreach (var id in ids)
+        {
+            var email = await GetPrimaryEmailAsync(id, ct);
+            if (!string.IsNullOrEmpty(email)) result[id] = email;
+        }
+        return result;
+    }
+
     public async Task<IReadOnlyList<string>> GetVerifiedEmailsForUserAsync(
         Guid userId, CancellationToken cancellationToken = default)
     {

--- a/src/Humans.Application/Services/Profile/UserEmailService.cs
+++ b/src/Humans.Application/Services/Profile/UserEmailService.cs
@@ -580,18 +580,6 @@ public sealed class UserEmailService : IUserEmailService, IUserMerge
         return user?.Email;
     }
 
-    public async Task<IReadOnlyDictionary<Guid, string>> GetPrimaryEmailsByUserIdsAsync(
-        IEnumerable<Guid> userIds, CancellationToken ct = default)
-    {
-        var ids = userIds.Distinct().ToList();
-        var result = new Dictionary<Guid, string>(ids.Count);
-        foreach (var id in ids)
-        {
-            var email = await GetPrimaryEmailAsync(id, ct);
-            if (!string.IsNullOrEmpty(email)) result[id] = email;
-        }
-        return result;
-    }
 
     public async Task<IReadOnlyList<string>> GetVerifiedEmailsForUserAsync(
         Guid userId, CancellationToken cancellationToken = default)

--- a/src/Humans.Application/Services/Shifts/ShiftSignupService.cs
+++ b/src/Humans.Application/Services/Shifts/ShiftSignupService.cs
@@ -1252,6 +1252,10 @@ public sealed class ShiftSignupService : IShiftSignupService, IUserDataContribut
         return signups.Where(s => !withConsents.Contains(s.UserId)).ToList();
     }
 
+    public Task<IReadOnlySet<Guid>> GetActiveCommittedUserIdsForEventAsync(
+        Guid eventSettingsId, CancellationToken ct = default) =>
+        _repo.GetActiveCommittedUserIdsForEventAsync(eventSettingsId, ct);
+
     public async Task ReassignAsync(Guid sourceUserId, Guid targetUserId, Guid actorUserId, Instant updatedAt,
         CancellationToken ct)
     {

--- a/src/Humans.Domain/Enums/AuditAction.cs
+++ b/src/Humans.Domain/Enums/AuditAction.cs
@@ -164,6 +164,7 @@ public enum AuditAction
     OAuthRenameCollisionBlocked,
     UserEmailDisplacedByOAuthRename,
     MailerLiteReconciliationCompleted,
+    MailerLiteAudienceSyncCompleted,
     GoogleSyncRetryScheduled,
     TicketContactsImported,
 }

--- a/src/Humans.Infrastructure/Jobs/MailerAudienceSyncJob.cs
+++ b/src/Humans.Infrastructure/Jobs/MailerAudienceSyncJob.cs
@@ -23,7 +23,7 @@ public sealed class MailerAudienceSyncJob
     public async Task ExecuteAsync(CancellationToken ct = default)
     {
         _logger.LogInformation("MailerAudienceSyncJob starting");
-        var results = await _sync.SyncAllAsync(ct);
+        var results = await _sync.SyncAllAsync(actorUserId: null, ct);
         _logger.LogInformation(
             "MailerAudienceSyncJob completed: {Count} audiences processed",
             results.Count);

--- a/src/Humans.Infrastructure/Jobs/MailerAudienceSyncJob.cs
+++ b/src/Humans.Infrastructure/Jobs/MailerAudienceSyncJob.cs
@@ -1,0 +1,31 @@
+using Hangfire;
+using Humans.Application.Interfaces.Mailer;
+using Microsoft.Extensions.Logging;
+
+namespace Humans.Infrastructure.Jobs;
+
+/// <summary>
+/// Hangfire recurring job that runs <see cref="IMailerAudienceSyncService.SyncAllAsync"/>
+/// daily. Default cron <c>0 6 * * *</c> (06:00 UTC) — early morning, low MailerLite traffic.
+/// </summary>
+[DisableConcurrentExecution(timeoutInSeconds: 300)]
+public sealed class MailerAudienceSyncJob
+{
+    private readonly IMailerAudienceSyncService _sync;
+    private readonly ILogger<MailerAudienceSyncJob> _logger;
+
+    public MailerAudienceSyncJob(IMailerAudienceSyncService sync, ILogger<MailerAudienceSyncJob> logger)
+    {
+        _sync = sync;
+        _logger = logger;
+    }
+
+    public async Task ExecuteAsync(CancellationToken ct = default)
+    {
+        _logger.LogInformation("MailerAudienceSyncJob starting");
+        var results = await _sync.SyncAllAsync(ct);
+        _logger.LogInformation(
+            "MailerAudienceSyncJob completed: {Count} audiences processed",
+            results.Count);
+    }
+}

--- a/src/Humans.Infrastructure/Repositories/Shifts/ShiftSignupRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Shifts/ShiftSignupRepository.cs
@@ -314,4 +314,17 @@ public sealed class ShiftSignupRepository : IShiftSignupRepository
             .OrderBy(s => s.CreatedAt)
             .ToListAsync(ct);
     }
+
+    public async Task<IReadOnlySet<Guid>> GetActiveCommittedUserIdsForEventAsync(
+        Guid eventSettingsId, CancellationToken ct = default)
+    {
+        var userIds = await _dbContext.ShiftSignups
+            .AsNoTracking()
+            .Where(s => s.Shift.Rota.EventSettingsId == eventSettingsId
+                     && (s.Status == SignupStatus.Pending || s.Status == SignupStatus.Confirmed))
+            .Select(s => s.UserId)
+            .Distinct()
+            .ToListAsync(ct);
+        return userIds.ToHashSet();
+    }
 }

--- a/src/Humans.Infrastructure/Services/Mailer/MailerLiteClient.cs
+++ b/src/Humans.Infrastructure/Services/Mailer/MailerLiteClient.cs
@@ -116,6 +116,13 @@ public sealed class MailerLiteClient : IMailerLiteService
         return env.Data;
     }
 
+    // NOTE: Assign/Unassign/BulkImport intentionally do NOT call InvalidateSubscribersCache().
+    // They are called in tight loops by MailerAudienceSyncService, which holds its own
+    // per-sync subscriber snapshot — invalidating mid-loop would force a full ML re-fetch
+    // before every single write (N+M extra full-list calls for N assigns + M unassigns,
+    // burning the rate limit). The cache will refresh on the next admin "Refresh" click
+    // or via the singleton expiry path; the staleness window is bounded and harmless.
+
     public async Task AssignSubscriberToGroupAsync(
         string subscriberId, string groupId, CancellationToken ct = default)
     {
@@ -126,7 +133,6 @@ public sealed class MailerLiteClient : IMailerLiteService
             $"/api/subscribers/{Uri.EscapeDataString(subscriberId)}/groups/{Uri.EscapeDataString(groupId)}",
             content: null, ct);
         resp.EnsureSuccessStatusCode();
-        InvalidateSubscribersCache();
     }
 
     public async Task UnassignSubscriberFromGroupAsync(
@@ -139,7 +145,6 @@ public sealed class MailerLiteClient : IMailerLiteService
             $"/api/subscribers/{Uri.EscapeDataString(subscriberId)}/groups/{Uri.EscapeDataString(groupId)}",
             content: null, ct);
         resp.EnsureSuccessStatusCode();
-        InvalidateSubscribersCache();
     }
 
     public async Task<BulkImportResult> BulkImportSubscribersToGroupAsync(
@@ -179,7 +184,6 @@ public sealed class MailerLiteClient : IMailerLiteService
             duplicates += parsed?.Duplicates ?? 0;
         }
 
-        InvalidateSubscribersCache();
         return new BulkImportResult(created, updated, duplicates, errors);
     }
 
@@ -194,17 +198,6 @@ public sealed class MailerLiteClient : IMailerLiteService
                 $"MailerLite group '{group.Name}' (id={groupId}) is not managed by Humans. " +
                 $"Writes are restricted to groups whose name starts with '{HumansGroupPrefix}'.");
         return group;
-    }
-
-    private void InvalidateSubscribersCache()
-    {
-        _gate.Wait();
-        try
-        {
-            _subscribers = null;
-            _summary = null;
-        }
-        finally { _gate.Release(); }
     }
 
     private void InvalidateGroupsCache()

--- a/src/Humans.Infrastructure/Services/Mailer/MailerLiteClient.cs
+++ b/src/Humans.Infrastructure/Services/Mailer/MailerLiteClient.cs
@@ -7,7 +7,6 @@ using System.Text.Json.Serialization;
 using Humans.Application.Interfaces.Mailer;
 using Humans.Application.Interfaces.Mailer.Dtos;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using NodaTime;
 
 namespace Humans.Infrastructure.Services.Mailer;
@@ -33,7 +32,6 @@ public sealed class MailerLiteClient : IMailerLiteService
     private static readonly JsonSerializerOptions Json = BuildJson();
     private readonly IHttpClientFactory _httpFactory;
     private readonly IClock _clock;
-    private readonly MailerLiteOptions _options;
     private readonly ILogger<MailerLiteClient> _logger;
     private readonly SemaphoreSlim _gate = new(1, 1);
 
@@ -45,12 +43,10 @@ public sealed class MailerLiteClient : IMailerLiteService
     public MailerLiteClient(
         IHttpClientFactory httpFactory,
         IClock clock,
-        IOptions<MailerLiteOptions> options,
         ILogger<MailerLiteClient> logger)
     {
         _httpFactory = httpFactory;
         _clock = clock;
-        _options = options.Value;
         _logger = logger;
     }
 
@@ -154,37 +150,35 @@ public sealed class MailerLiteClient : IMailerLiteService
         if (emails.Count == 0)
             return new BulkImportResult(0, 0, 0, 0);
 
-        int created = 0, updated = 0, duplicates = 0, errors = 0;
-        var chunkSize = Math.Max(1, _options.BulkImportChunkSize);
+        // MailerLite's documented bulk-import endpoint
+        // (POST /api/groups/{id}/import-subscribers) is asynchronous: it returns
+        // an import_progress_url and we'd have to poll. Per-email upsert via
+        // POST /api/subscribers with the groups array is synchronous, returns
+        // the subscriber object directly, and is fine at our ~500-user scale.
+        // ML treats it as upsert-or-update keyed on email.
+        int created = 0, errors = 0;
 
-        foreach (var chunk in emails.Chunk(chunkSize))
+        foreach (var email in emails)
         {
             var payload = new
             {
-                subscribers = chunk.Select(e => new { email = e }).ToArray(),
-                resubscribe = false,
-                autoresponders = false,
+                email,
+                groups = new[] { groupId },
             };
             using var body = JsonContent.Create(payload, options: Json);
-            using var resp = await SendAsync(
-                HttpMethod.Post,
-                $"/api/groups/{Uri.EscapeDataString(groupId)}/subscribers/import",
-                body, ct);
+            using var resp = await SendAsync(HttpMethod.Post, "/api/subscribers", body, ct);
             if (!resp.IsSuccessStatusCode)
             {
-                errors += chunk.Length;
+                errors++;
                 _logger.LogWarning(
-                    "BulkImport chunk failed for group {GroupId}: {StatusCode}",
-                    groupId, (int)resp.StatusCode);
+                    "Subscriber upsert failed for {Email} into group {GroupId}: {StatusCode}",
+                    email, groupId, (int)resp.StatusCode);
                 continue;
             }
-            var parsed = await resp.Content.ReadFromJsonAsync<BulkImportEnvelope>(Json, ct);
-            created += parsed?.Imported ?? 0;
-            updated += parsed?.Updated ?? 0;
-            duplicates += parsed?.Duplicates ?? 0;
+            created++;
         }
 
-        return new BulkImportResult(created, updated, duplicates, errors);
+        return new BulkImportResult(Created: created, Updated: 0, Duplicates: 0, Errors: errors);
     }
 
     private async Task<MailerLiteGroup> RequireHumansGroupAsync(string groupId, CancellationToken ct)
@@ -369,9 +363,4 @@ public sealed class MailerLiteClient : IMailerLiteService
 
     private sealed record GroupSingleEnvelope(
         [property: JsonPropertyName("data")] MailerLiteGroup Data);
-
-    private sealed record BulkImportEnvelope(
-        [property: JsonPropertyName("imported")] int Imported,
-        [property: JsonPropertyName("updated")] int Updated,
-        [property: JsonPropertyName("duplicates")] int Duplicates);
 }

--- a/src/Humans.Infrastructure/Services/Mailer/MailerLiteClient.cs
+++ b/src/Humans.Infrastructure/Services/Mailer/MailerLiteClient.cs
@@ -7,6 +7,7 @@ using System.Text.Json.Serialization;
 using Humans.Application.Interfaces.Mailer;
 using Humans.Application.Interfaces.Mailer.Dtos;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using NodaTime;
 
 namespace Humans.Infrastructure.Services.Mailer;
@@ -17,14 +18,22 @@ namespace Humans.Infrastructure.Services.Mailer;
 /// First read after startup (or after <see cref="RefreshAsync"/>) populates
 /// the cache from MailerLite; every subsequent read is served from RAM.
 /// Admins force a re-pull via POST /Mailer/Admin/Refresh.
+///
+/// Writes (CreateGroup, Assign/Unassign, BulkImport) are runtime-guarded:
+/// every write either inspects the requested group name (CreateGroup) or
+/// looks up the target group by id (Assign/Unassign/BulkImport) and throws
+/// <see cref="InvalidOperationException"/> if the name doesn't start with
+/// "Humans - ". Pinned by <c>MailerLiteClientWriteGuardTests</c>.
 /// </summary>
 public sealed class MailerLiteClient : IMailerLiteService
 {
     public const string HttpClientName = "mailerlite";
+    private const string HumansGroupPrefix = "Humans - ";
 
     private static readonly JsonSerializerOptions Json = BuildJson();
     private readonly IHttpClientFactory _httpFactory;
     private readonly IClock _clock;
+    private readonly MailerLiteOptions _options;
     private readonly ILogger<MailerLiteClient> _logger;
     private readonly SemaphoreSlim _gate = new(1, 1);
 
@@ -33,10 +42,15 @@ public sealed class MailerLiteClient : IMailerLiteService
     private IReadOnlyList<MailerLiteGroup>? _groups;
     private Instant? _lastFetchedAt;
 
-    public MailerLiteClient(IHttpClientFactory httpFactory, IClock clock, ILogger<MailerLiteClient> logger)
+    public MailerLiteClient(
+        IHttpClientFactory httpFactory,
+        IClock clock,
+        IOptions<MailerLiteOptions> options,
+        ILogger<MailerLiteClient> logger)
     {
         _httpFactory = httpFactory;
         _clock = clock;
+        _options = options.Value;
         _logger = logger;
     }
 
@@ -66,7 +80,7 @@ public sealed class MailerLiteClient : IMailerLiteService
         // Single-email lookup is a passthrough — callers asking for a specific
         // address want live state, not a snapshot from the dashboard cache.
         using var resp = await SendAsync(HttpMethod.Get,
-            $"/api/subscribers/{Uri.EscapeDataString(email)}", ct);
+            $"/api/subscribers/{Uri.EscapeDataString(email)}", content: null, ct);
         if (resp.StatusCode == HttpStatusCode.NotFound) return null;
         resp.EnsureSuccessStatusCode();
         var body = await resp.Content.ReadFromJsonAsync<SubscriberSingleEnvelope>(Json, ct);
@@ -84,6 +98,120 @@ public sealed class MailerLiteClient : IMailerLiteService
         {
             _gate.Release();
         }
+    }
+
+    public async Task<MailerLiteGroup> CreateGroupAsync(string name, CancellationToken ct = default)
+    {
+        if (!name.StartsWith(HumansGroupPrefix, StringComparison.Ordinal))
+            throw new InvalidOperationException(
+                $"Group name '{name}' must start with '{HumansGroupPrefix}'.");
+
+        using var body = JsonContent.Create(new { name }, options: Json);
+        using var resp = await SendAsync(HttpMethod.Post, "/api/groups", body, ct);
+        resp.EnsureSuccessStatusCode();
+        var env = await resp.Content.ReadFromJsonAsync<GroupSingleEnvelope>(Json, ct)
+            ?? throw new InvalidOperationException("MailerLite returned empty body on CreateGroup.");
+
+        InvalidateGroupsCache();
+        return env.Data;
+    }
+
+    public async Task AssignSubscriberToGroupAsync(
+        string subscriberId, string groupId, CancellationToken ct = default)
+    {
+        await RequireHumansGroupAsync(groupId, ct);
+
+        using var resp = await SendAsync(
+            HttpMethod.Post,
+            $"/api/subscribers/{Uri.EscapeDataString(subscriberId)}/groups/{Uri.EscapeDataString(groupId)}",
+            content: null, ct);
+        resp.EnsureSuccessStatusCode();
+        InvalidateSubscribersCache();
+    }
+
+    public async Task UnassignSubscriberFromGroupAsync(
+        string subscriberId, string groupId, CancellationToken ct = default)
+    {
+        await RequireHumansGroupAsync(groupId, ct);
+
+        using var resp = await SendAsync(
+            HttpMethod.Delete,
+            $"/api/subscribers/{Uri.EscapeDataString(subscriberId)}/groups/{Uri.EscapeDataString(groupId)}",
+            content: null, ct);
+        resp.EnsureSuccessStatusCode();
+        InvalidateSubscribersCache();
+    }
+
+    public async Task<BulkImportResult> BulkImportSubscribersToGroupAsync(
+        string groupId, IReadOnlyList<string> emails, CancellationToken ct = default)
+    {
+        await RequireHumansGroupAsync(groupId, ct);
+        if (emails.Count == 0)
+            return new BulkImportResult(0, 0, 0, 0);
+
+        int created = 0, updated = 0, duplicates = 0, errors = 0;
+        var chunkSize = Math.Max(1, _options.BulkImportChunkSize);
+
+        foreach (var chunk in emails.Chunk(chunkSize))
+        {
+            var payload = new
+            {
+                subscribers = chunk.Select(e => new { email = e }).ToArray(),
+                resubscribe = false,
+                autoresponders = false,
+            };
+            using var body = JsonContent.Create(payload, options: Json);
+            using var resp = await SendAsync(
+                HttpMethod.Post,
+                $"/api/groups/{Uri.EscapeDataString(groupId)}/subscribers/import",
+                body, ct);
+            if (!resp.IsSuccessStatusCode)
+            {
+                errors += chunk.Length;
+                _logger.LogWarning(
+                    "BulkImport chunk failed for group {GroupId}: {StatusCode}",
+                    groupId, (int)resp.StatusCode);
+                continue;
+            }
+            var parsed = await resp.Content.ReadFromJsonAsync<BulkImportEnvelope>(Json, ct);
+            created += parsed?.Imported ?? 0;
+            updated += parsed?.Updated ?? 0;
+            duplicates += parsed?.Duplicates ?? 0;
+        }
+
+        InvalidateSubscribersCache();
+        return new BulkImportResult(created, updated, duplicates, errors);
+    }
+
+    private async Task<MailerLiteGroup> RequireHumansGroupAsync(string groupId, CancellationToken ct)
+    {
+        var groups = await ListGroupsAsync(ct);
+        var group = groups.FirstOrDefault(g => string.Equals(g.Id, groupId, StringComparison.Ordinal))
+            ?? throw new InvalidOperationException(
+                $"MailerLite group '{groupId}' not found.");
+        if (!group.Name.StartsWith(HumansGroupPrefix, StringComparison.Ordinal))
+            throw new InvalidOperationException(
+                $"MailerLite group '{group.Name}' (id={groupId}) is not managed by Humans. " +
+                $"Writes are restricted to groups whose name starts with '{HumansGroupPrefix}'.");
+        return group;
+    }
+
+    private void InvalidateSubscribersCache()
+    {
+        _gate.Wait();
+        try
+        {
+            _subscribers = null;
+            _summary = null;
+        }
+        finally { _gate.Release(); }
+    }
+
+    private void InvalidateGroupsCache()
+    {
+        _gate.Wait();
+        try { _groups = null; }
+        finally { _gate.Release(); }
     }
 
     private async Task EnsurePopulatedAsync(CancellationToken ct)
@@ -137,7 +265,7 @@ public sealed class MailerLiteClient : IMailerLiteService
         {
             var url = "/api/subscribers?limit=100";
             if (cursor is not null) url += $"&cursor={Uri.EscapeDataString(cursor)}";
-            using var resp = await SendAsync(HttpMethod.Get, url, ct);
+            using var resp = await SendAsync(HttpMethod.Get, url, content: null, ct);
             resp.EnsureSuccessStatusCode();
             var body = await resp.Content.ReadFromJsonAsync<SubscriberListEnvelope>(Json, ct);
             if (body is null) yield break;
@@ -153,7 +281,7 @@ public sealed class MailerLiteClient : IMailerLiteService
         int page = 1;
         while (true)
         {
-            using var resp = await SendAsync(HttpMethod.Get, $"/api/groups?page={page}&limit=100", ct);
+            using var resp = await SendAsync(HttpMethod.Get, $"/api/groups?page={page}&limit=100", content: null, ct);
             resp.EnsureSuccessStatusCode();
             var body = await resp.Content.ReadFromJsonAsync<GroupListEnvelope>(Json, ct);
             if (body is null || body.Data.Count == 0) break;
@@ -164,18 +292,17 @@ public sealed class MailerLiteClient : IMailerLiteService
         return results;
     }
 
-    // Internal seam for tests — exposes the private guard.
+    // Internal seam for tests — calls SendAsync without the GET-only guard
+    // (the guard was removed when outbound writes landed).
     internal Task<HttpResponseMessage> SendForTestsAsync(HttpMethod method, string url, CancellationToken ct)
-        => SendAsync(method, url, ct);
+        => SendAsync(method, url, content: null, ct);
 
-    private async Task<HttpResponseMessage> SendAsync(HttpMethod method, string url, CancellationToken ct)
+    private async Task<HttpResponseMessage> SendAsync(
+        HttpMethod method, string url, HttpContent? content, CancellationToken ct)
     {
-        if (method != HttpMethod.Get)
-            throw new InvalidOperationException(
-                $"MailerLite client is read-only. Attempted {method} {url}. " +
-                "Outbound writes belong to a separate slice with its own review.");
         var http = _httpFactory.CreateClient(HttpClientName);
         using var req = new HttpRequestMessage(method, url);
+        if (content is not null) req.Content = content;
         HttpResponseMessage resp;
         try
         {
@@ -236,4 +363,12 @@ public sealed class MailerLiteClient : IMailerLiteService
     private sealed record GroupMeta(
         [property: JsonPropertyName("current_page")] int CurrentPage,
         [property: JsonPropertyName("last_page")] int LastPage);
+
+    private sealed record GroupSingleEnvelope(
+        [property: JsonPropertyName("data")] MailerLiteGroup Data);
+
+    private sealed record BulkImportEnvelope(
+        [property: JsonPropertyName("imported")] int Imported,
+        [property: JsonPropertyName("updated")] int Updated,
+        [property: JsonPropertyName("duplicates")] int Duplicates);
 }

--- a/src/Humans.Infrastructure/Services/Mailer/MailerLiteClient.cs
+++ b/src/Humans.Infrastructure/Services/Mailer/MailerLiteClient.cs
@@ -112,7 +112,7 @@ public sealed class MailerLiteClient : IMailerLiteService
         var env = await resp.Content.ReadFromJsonAsync<GroupSingleEnvelope>(Json, ct)
             ?? throw new InvalidOperationException("MailerLite returned empty body on CreateGroup.");
 
-        InvalidateGroupsCache();
+        await AppendToGroupsCacheAsync(env.Data, ct);
         return env.Data;
     }
 
@@ -200,10 +200,20 @@ public sealed class MailerLiteClient : IMailerLiteService
         return group;
     }
 
-    private void InvalidateGroupsCache()
+    // Merges a newly-created group into the cached list under the gate so the
+    // next RequireHumansGroupAsync call doesn't trigger a full re-populate.
+    // Nullifying _groups would cascade into EnsurePopulatedAsync re-fetching the
+    // entire subscriber list too — eviction would be disproportionate to the
+    // change. If the cache hasn't been populated yet, this is a no-op; the first
+    // read will pull the new group along with everything else.
+    private async Task AppendToGroupsCacheAsync(MailerLiteGroup newGroup, CancellationToken ct)
     {
-        _gate.Wait();
-        try { _groups = null; }
+        await _gate.WaitAsync(ct);
+        try
+        {
+            if (_groups is not null)
+                _groups = _groups.Append(newGroup).ToList();
+        }
         finally { _gate.Release(); }
     }
 

--- a/src/Humans.Infrastructure/Services/Mailer/MailerLiteSubscriberConverter.cs
+++ b/src/Humans.Infrastructure/Services/Mailer/MailerLiteSubscriberConverter.cs
@@ -38,10 +38,30 @@ public sealed class MailerLiteSubscriberConverter : JsonConverter<MailerLiteSubs
             lastName = ReadString(fields, "last_name");
         }
 
+        var groupIds = new List<string>();
+        if (root.TryGetProperty("groups", out var groupsEl) && groupsEl.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var g in groupsEl.EnumerateArray())
+            {
+                // ML returns either an array of objects with id+name or an array of id strings.
+                if (g.ValueKind == JsonValueKind.String)
+                {
+                    var s = g.GetString();
+                    if (!string.IsNullOrEmpty(s)) groupIds.Add(s);
+                }
+                else if (g.ValueKind == JsonValueKind.Object
+                    && g.TryGetProperty("id", out var idEl)
+                    && idEl.ValueKind == JsonValueKind.String)
+                {
+                    groupIds.Add(idEl.GetString()!);
+                }
+            }
+        }
+
         return new MailerLiteSubscriber(
             id, email, status, source,
             subscribedAt, unsubscribedAt, optedInAt,
-            firstName, lastName);
+            firstName, lastName, groupIds);
     }
 
     public override void Write(Utf8JsonWriter writer, MailerLiteSubscriber value, JsonSerializerOptions options) =>

--- a/src/Humans.Web/Controllers/Mailer/MailerAdminController.cs
+++ b/src/Humans.Web/Controllers/Mailer/MailerAdminController.cs
@@ -122,6 +122,13 @@ public sealed class MailerAdminController : HumansControllerBase
             _logger.LogError(ex, "Audience sync failed for {Audience}", key);
             TempData["Banner"] = $"{audience.DisplayName}: sync failed — {ex.Message}";
         }
+        catch (TaskCanceledException) when (!ct.IsCancellationRequested)
+        {
+            // MailerLiteClient surfaces HttpClient timeouts as TaskCanceledException
+            // when the caller did not cancel. Treat it as a transient failure.
+            _logger.LogWarning("Audience sync timed out for {Audience}", key);
+            TempData["Banner"] = $"{audience.DisplayName}: sync timed out. Try again shortly.";
+        }
         return RedirectToAction(nameof(Index));
     }
 

--- a/src/Humans.Web/Controllers/Mailer/MailerAdminController.cs
+++ b/src/Humans.Web/Controllers/Mailer/MailerAdminController.cs
@@ -81,7 +81,20 @@ public sealed class MailerAdminController : HumansControllerBase
             ct: ct);
         var last = recent.FirstOrDefault();
 
-        var audienceRows = await BuildAudienceRowsAsync(ct);
+        IReadOnlyList<AudienceCardRow> audienceRows;
+        try
+        {
+            var stats = await _audienceSync.ComputeAllStatsAsync(ct);
+            audienceRows = stats.Select(s => new AudienceCardRow(
+                s.Key, s.DisplayName, s.MailerLiteGroupName,
+                s.Candidates, s.ExcludedUnsubscribed, s.CurrentlyInGroup,
+                s.LastSyncAt, s.LastSyncSummary)).ToList();
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogWarning(ex, "Audience stats failed");
+            audienceRows = Array.Empty<AudienceCardRow>();
+        }
 
         var vm = new MailerDashboardViewModel(
             summary, groups, mlContacts, optedIn, optedOut,
@@ -89,40 +102,6 @@ public sealed class MailerAdminController : HumansControllerBase
             _ml.LastFetchedAt,
             audienceRows);
         return View("~/Views/Mailer/Admin/Index.cshtml", vm);
-    }
-
-    private async Task<IReadOnlyList<AudienceCardRow>> BuildAudienceRowsAsync(CancellationToken ct)
-    {
-        if (_audiences.Count == 0) return Array.Empty<AudienceCardRow>();
-
-        var rows = new List<AudienceCardRow>();
-        var lastSyncEntries = await _audit.GetFilteredEntriesAsync(
-            actions: new[] { AuditAction.MailerLiteAudienceSyncCompleted },
-            limit: 50,
-            ct: ct);
-
-        foreach (var audience in _audiences)
-        {
-            AudienceStats stats;
-            try
-            {
-                stats = await _audienceSync.ComputeStatsAsync(audience, ct);
-            }
-            catch (HttpRequestException ex)
-            {
-                _logger.LogWarning(ex, "Audience stats failed for {Audience}", audience.Key);
-                continue;
-            }
-            var lastForThisAudience = lastSyncEntries.FirstOrDefault(e =>
-                e.Description is not null
-                && e.Description.Contains($"\"audience_key\":\"{audience.Key}\"", StringComparison.Ordinal));
-            rows.Add(new AudienceCardRow(
-                audience.Key, audience.DisplayName, audience.MailerLiteGroupName,
-                stats.Candidates, stats.ExcludedUnsubscribed, stats.CurrentlyInGroup,
-                lastForThisAudience?.OccurredAt,
-                lastForThisAudience?.Description));
-        }
-        return rows;
     }
 
     [HttpPost("Audiences/{key}/Sync")]
@@ -134,7 +113,8 @@ public sealed class MailerAdminController : HumansControllerBase
 
         try
         {
-            var result = await _audienceSync.SyncAsync(audience, ct);
+            var actor = await GetCurrentUserAsync();
+            var result = await _audienceSync.SyncAsync(audience, actor?.Id, ct);
             TempData["Banner"] = $"{audience.DisplayName}: {result.FormatSummary()}";
         }
         catch (Exception ex) when (ex is HttpRequestException or InvalidOperationException)

--- a/src/Humans.Web/Controllers/Mailer/MailerAdminController.cs
+++ b/src/Humans.Web/Controllers/Mailer/MailerAdminController.cs
@@ -95,6 +95,11 @@ public sealed class MailerAdminController : HumansControllerBase
             _logger.LogWarning(ex, "Audience stats failed");
             audienceRows = Array.Empty<AudienceCardRow>();
         }
+        catch (TaskCanceledException) when (!ct.IsCancellationRequested)
+        {
+            _logger.LogWarning("Audience stats timed out");
+            audienceRows = Array.Empty<AudienceCardRow>();
+        }
 
         var vm = new MailerDashboardViewModel(
             summary, groups, mlContacts, optedIn, optedOut,

--- a/src/Humans.Web/Controllers/Mailer/MailerAdminController.cs
+++ b/src/Humans.Web/Controllers/Mailer/MailerAdminController.cs
@@ -22,6 +22,8 @@ public sealed class MailerAdminController : HumansControllerBase
 {
     private readonly IMailerLiteService _ml;
     private readonly IMailerImportService _import;
+    private readonly IMailerAudienceSyncService _audienceSync;
+    private readonly IReadOnlyList<IMailerAudience> _audiences;
     private readonly IUserService _users;
     private readonly ICommunicationPreferenceService _prefs;
     private readonly IAuditLogService _audit;
@@ -30,6 +32,8 @@ public sealed class MailerAdminController : HumansControllerBase
     public MailerAdminController(
         IMailerLiteService ml,
         IMailerImportService import,
+        IMailerAudienceSyncService audienceSync,
+        IEnumerable<IMailerAudience> audiences,
         IUserService users,
         ICommunicationPreferenceService prefs,
         IAuditLogService audit,
@@ -39,6 +43,8 @@ public sealed class MailerAdminController : HumansControllerBase
     {
         _ml = ml;
         _import = import;
+        _audienceSync = audienceSync;
+        _audiences = audiences.ToList();
         _users = users;
         _prefs = prefs;
         _audit = audit;
@@ -75,11 +81,68 @@ public sealed class MailerAdminController : HumansControllerBase
             ct: ct);
         var last = recent.FirstOrDefault();
 
+        var audienceRows = await BuildAudienceRowsAsync(ct);
+
         var vm = new MailerDashboardViewModel(
             summary, groups, mlContacts, optedIn, optedOut,
             last?.OccurredAt, last?.Description, drift, mlError,
-            _ml.LastFetchedAt);
+            _ml.LastFetchedAt,
+            audienceRows);
         return View("~/Views/Mailer/Admin/Index.cshtml", vm);
+    }
+
+    private async Task<IReadOnlyList<AudienceCardRow>> BuildAudienceRowsAsync(CancellationToken ct)
+    {
+        if (_audiences.Count == 0) return Array.Empty<AudienceCardRow>();
+
+        var rows = new List<AudienceCardRow>();
+        var lastSyncEntries = await _audit.GetFilteredEntriesAsync(
+            actions: new[] { AuditAction.MailerLiteAudienceSyncCompleted },
+            limit: 50,
+            ct: ct);
+
+        foreach (var audience in _audiences)
+        {
+            AudienceStats stats;
+            try
+            {
+                stats = await _audienceSync.ComputeStatsAsync(audience, ct);
+            }
+            catch (HttpRequestException ex)
+            {
+                _logger.LogWarning(ex, "Audience stats failed for {Audience}", audience.Key);
+                continue;
+            }
+            var lastForThisAudience = lastSyncEntries.FirstOrDefault(e =>
+                e.Description is not null
+                && e.Description.Contains($"\"audience_key\":\"{audience.Key}\"", StringComparison.Ordinal));
+            rows.Add(new AudienceCardRow(
+                audience.Key, audience.DisplayName, audience.MailerLiteGroupName,
+                stats.Candidates, stats.ExcludedUnsubscribed, stats.CurrentlyInGroup,
+                lastForThisAudience?.OccurredAt,
+                lastForThisAudience?.Description));
+        }
+        return rows;
+    }
+
+    [HttpPost("Audiences/{key}/Sync")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> SyncAudience(string key, CancellationToken ct)
+    {
+        var audience = _audiences.FirstOrDefault(a => string.Equals(a.Key, key, StringComparison.Ordinal));
+        if (audience is null) return NotFound();
+
+        try
+        {
+            var result = await _audienceSync.SyncAsync(audience, ct);
+            TempData["Banner"] = $"{audience.DisplayName}: {result.FormatSummary()}";
+        }
+        catch (Exception ex) when (ex is HttpRequestException or InvalidOperationException)
+        {
+            _logger.LogError(ex, "Audience sync failed for {Audience}", key);
+            TempData["Banner"] = $"{audience.DisplayName}: sync failed — {ex.Message}";
+        }
+        return RedirectToAction(nameof(Index));
     }
 
     [HttpPost("Refresh")]

--- a/src/Humans.Web/Extensions/RecurringJobExtensions.cs
+++ b/src/Humans.Web/Extensions/RecurringJobExtensions.cs
@@ -15,6 +15,8 @@ public static class RecurringJobExtensions
         var registry = app.Services.GetRequiredService<ConfigurationRegistry>();
         var ticketSyncInterval = app.Configuration.GetSettingValue(
             registry, "TicketVendor:SyncIntervalMinutes", "Ticket Vendor", defaultValue: 15);
+        var mailerAudienceCron = app.Configuration.GetValue<string>("MailerLite:AudienceSyncCron")
+            ?? "0 6 * * *";
 
         var jobs = new (string Id, Action Register)[]
         {
@@ -91,6 +93,10 @@ public static class RecurringJobExtensions
             // Purge old agent conversations — daily at 03:15 UTC.
             ("agent-conversation-retention", () => RecurringJob.AddOrUpdate<AgentConversationRetentionJob>(
                 "agent-conversation-retention", job => job.ExecuteAsync(CancellationToken.None), "15 3 * * *")),
+
+            // Sync code-defined Mailer audiences into MailerLite groups — daily.
+            ("mailer-audience-sync", () => RecurringJob.AddOrUpdate<MailerAudienceSyncJob>(
+                "mailer-audience-sync", job => job.ExecuteAsync(CancellationToken.None), mailerAudienceCron)),
         };
 
         foreach (var (id, register) in jobs)

--- a/src/Humans.Web/Extensions/RecurringJobExtensions.cs
+++ b/src/Humans.Web/Extensions/RecurringJobExtensions.cs
@@ -15,8 +15,11 @@ public static class RecurringJobExtensions
         var registry = app.Services.GetRequiredService<ConfigurationRegistry>();
         var ticketSyncInterval = app.Configuration.GetSettingValue(
             registry, "TicketVendor:SyncIntervalMinutes", "Ticket Vendor", defaultValue: 15);
+        // MailerLite:AudienceSyncCron is opt-in. When empty/unset, the recurring
+        // job is not registered — admins still trigger syncs on demand via the
+        // /Mailer/Admin "Push Now" button. Set to e.g. "0 6 * * *" to enable.
         var mailerAudienceCron = app.Configuration.GetValue<string>("MailerLite:AudienceSyncCron")
-            ?? "0 6 * * *";
+            ?? string.Empty;
 
         var jobs = new (string Id, Action Register)[]
         {
@@ -94,10 +97,23 @@ public static class RecurringJobExtensions
             ("agent-conversation-retention", () => RecurringJob.AddOrUpdate<AgentConversationRetentionJob>(
                 "agent-conversation-retention", job => job.ExecuteAsync(CancellationToken.None), "15 3 * * *")),
 
-            // Sync code-defined Mailer audiences into MailerLite groups — daily.
-            ("mailer-audience-sync", () => RecurringJob.AddOrUpdate<MailerAudienceSyncJob>(
-                "mailer-audience-sync", job => job.ExecuteAsync(CancellationToken.None), mailerAudienceCron)),
         };
+
+        if (!string.IsNullOrWhiteSpace(mailerAudienceCron))
+        {
+            jobs = jobs.Append(("mailer-audience-sync", () => RecurringJob.AddOrUpdate<MailerAudienceSyncJob>(
+                "mailer-audience-sync", job => job.ExecuteAsync(CancellationToken.None), mailerAudienceCron))).ToArray();
+        }
+        else
+        {
+            // Best-effort cleanup so a previously-registered job doesn't stick around
+            // after operators disable the schedule by clearing the config value.
+            try { RecurringJob.RemoveIfExists("mailer-audience-sync"); }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Failed to remove mailer-audience-sync recurring job entry");
+            }
+        }
 
         foreach (var (id, register) in jobs)
         {

--- a/src/Humans.Web/Extensions/Sections/MailerSectionExtensions.cs
+++ b/src/Humans.Web/Extensions/Sections/MailerSectionExtensions.cs
@@ -1,6 +1,8 @@
 using System.Net.Http.Headers;
 using Humans.Application.Interfaces.Mailer;
 using Humans.Application.Services.Mailer;
+using Humans.Application.Services.Mailer.Audiences;
+using Humans.Infrastructure.Jobs;
 using Humans.Infrastructure.Services.Mailer;
 using Microsoft.Extensions.Options;
 
@@ -41,6 +43,13 @@ internal static class MailerSectionExtensions
 
         // Import orchestrator — stateless plan+apply, injected by the Admin controller.
         services.AddScoped<IMailerImportService, MailerImportService>();
+
+        // Audience framework — orchestrator + audience registrations + recurring job.
+        // Audiences are Scoped (not Singleton) because their constructor dependencies
+        // (ITicketQueryService, IShiftSignupService, IShiftManagementService) are Scoped.
+        services.AddScoped<IMailerAudienceSyncService, MailerAudienceSyncService>();
+        services.AddScoped<IMailerAudience, TicketNoShiftsAudience>();
+        services.AddTransient<MailerAudienceSyncJob>();
 
         return services;
     }

--- a/src/Humans.Web/Models/Mailer/AudienceCardRow.cs
+++ b/src/Humans.Web/Models/Mailer/AudienceCardRow.cs
@@ -1,0 +1,13 @@
+using NodaTime;
+
+namespace Humans.Web.Models.Mailer;
+
+public sealed record AudienceCardRow(
+    string Key,
+    string DisplayName,
+    string MailerLiteGroupName,
+    int Candidates,
+    int ExcludedUnsubscribed,
+    int CurrentlyInGroup,
+    Instant? LastSyncAt,
+    string? LastSyncSummary);

--- a/src/Humans.Web/Models/Mailer/MailerDashboardViewModel.cs
+++ b/src/Humans.Web/Models/Mailer/MailerDashboardViewModel.cs
@@ -13,7 +13,8 @@ public sealed record MailerDashboardViewModel(
     string? LastReconciliationSummary,
     DriftReport? Drift,
     string? MlError,
-    Instant? CacheFetchedAt);
+    Instant? CacheFetchedAt,
+    IReadOnlyList<AudienceCardRow> Audiences);
 
 public sealed record DriftReport(
     int HumansOptedOutMlActive,           // legal-trouble row

--- a/src/Humans.Web/Views/Mailer/Admin/Index.cshtml
+++ b/src/Humans.Web/Views/Mailer/Admin/Index.cshtml
@@ -269,4 +269,4 @@
 </div>
 
 @* ── Audiences ─────────────────────────────────────────────────────────── *@
-<partial name="_AudiencesCard" model="Model.Audiences" />
+<partial name="~/Views/Mailer/Admin/_AudiencesCard.cshtml" model="Model.Audiences" />

--- a/src/Humans.Web/Views/Mailer/Admin/Index.cshtml
+++ b/src/Humans.Web/Views/Mailer/Admin/Index.cshtml
@@ -267,3 +267,6 @@
         </div>
     </div>
 </div>
+
+@* ── Audiences ─────────────────────────────────────────────────────────── *@
+<partial name="_AudiencesCard" model="Model.Audiences" />

--- a/src/Humans.Web/Views/Mailer/Admin/_AudiencesCard.cshtml
+++ b/src/Humans.Web/Views/Mailer/Admin/_AudiencesCard.cshtml
@@ -1,0 +1,37 @@
+@model IReadOnlyList<Humans.Web.Models.Mailer.AudienceCardRow>
+
+<section class="card mb-4">
+    <header class="card-header">
+        <h2 class="h5 mb-0">Audiences</h2>
+    </header>
+    <div class="card-body">
+        @if (Model.Count == 0)
+        {
+            <p class="text-muted mb-0">No audiences registered.</p>
+        }
+        else
+        {
+            <ul class="list-unstyled mb-0">
+                @foreach (var row in Model)
+                {
+                    <li class="d-flex justify-content-between align-items-center py-2 border-bottom">
+                        <div>
+                            <strong>@row.MailerLiteGroupName</strong>
+                            <div class="small text-muted">
+                                @row.Candidates humans match · @row.ExcludedUnsubscribed ML-unsubscribed ·
+                                @row.CurrentlyInGroup currently in group
+                                @if (row.LastSyncAt is not null)
+                                {
+                                    <text> · last sync @row.LastSyncAt.Value.ToDateTimeUtc().ToString("yyyy-MM-dd HH:mm 'UTC'")</text>
+                                }
+                            </div>
+                        </div>
+                        <form asp-action="SyncAudience" asp-route-key="@row.Key" method="post" class="m-0">
+                            <button type="submit" class="btn btn-sm btn-outline-primary">Push Now</button>
+                        </form>
+                    </li>
+                }
+            </ul>
+        }
+    </div>
+</section>

--- a/src/Humans.Web/Views/Mailer/Admin/_AudiencesCard.cshtml
+++ b/src/Humans.Web/Views/Mailer/Admin/_AudiencesCard.cshtml
@@ -1,3 +1,4 @@
+@using Humans.Web.Extensions
 @model IReadOnlyList<Humans.Web.Models.Mailer.AudienceCardRow>
 
 <section class="card mb-4">
@@ -22,7 +23,7 @@
                                 @row.CurrentlyInGroup currently in group
                                 @if (row.LastSyncAt is not null)
                                 {
-                                    <text> · last sync @row.LastSyncAt.Value.ToDateTimeUtc().ToString("yyyy-MM-dd HH:mm 'UTC'")</text>
+                                    <text> · last sync @row.LastSyncAt.Value.ToAuditTimestamp()</text>
                                 }
                             </div>
                         </div>

--- a/tests/Humans.Application.Tests/Architecture/MailerArchitectureTests.cs
+++ b/tests/Humans.Application.Tests/Architecture/MailerArchitectureTests.cs
@@ -7,15 +7,31 @@ namespace Humans.Application.Tests.Architecture;
 public class MailerArchitectureTests
 {
     [HumansFact]
-    public void IMailerLiteService_HasNoWriteMethods()
+    public void IMailerLiteService_OnlyAllowsAudienceWrites()
     {
-        string[] forbidden = ["Create", "Update", "Delete", "Upsert", "Add", "Remove", "Set", "Post", "Put", "Patch"];
-        var methods = typeof(IMailerLiteService).GetMethods();
-        methods.Should().NotBeEmpty();
-        foreach (var m in methods)
-            foreach (var prefix in forbidden)
-                m.Name.Should().NotStartWith(prefix,
-                    $"IMailerLiteService is read-only by design; '{m.Name}' looks like a write method.");
+        var allowedWrites = new HashSet<string>
+        {
+            nameof(IMailerLiteService.CreateGroupAsync),
+            nameof(IMailerLiteService.AssignSubscriberToGroupAsync),
+            nameof(IMailerLiteService.UnassignSubscriberFromGroupAsync),
+            nameof(IMailerLiteService.BulkImportSubscribersToGroupAsync),
+        };
+
+        var writePrefixes = new[]
+        {
+            "Create", "Update", "Delete", "Upsert", "Add", "Remove",
+            "Set", "Post", "Put", "Patch", "Assign", "Unassign", "Bulk",
+        };
+
+        var unexpectedWrites = typeof(IMailerLiteService).GetMethods()
+            .Where(m => writePrefixes.Any(p => m.Name.StartsWith(p, StringComparison.Ordinal)))
+            .Where(m => !allowedWrites.Contains(m.Name))
+            .Select(m => m.Name)
+            .ToList();
+
+        unexpectedWrites.Should().BeEmpty(
+            "IMailerLiteService writes are restricted to the four audience-management methods. " +
+            "New writes need their own architecture review.");
     }
 
     [HumansFact]

--- a/tests/Humans.Application.Tests/Architecture/MailerArchitectureTests.cs
+++ b/tests/Humans.Application.Tests/Architecture/MailerArchitectureTests.cs
@@ -67,4 +67,48 @@ public class MailerArchitectureTests
         typeof(IMailerLiteService).Assembly.GetName().Name
             .Should().Be("Humans.Application");
     }
+
+    [HumansFact]
+    public void AllAudiences_UseHumansPrefix()
+    {
+        var audienceType = typeof(IMailerAudience);
+        var impls = typeof(MailerImportService).Assembly
+            .GetTypes()
+            .Where(t => audienceType.IsAssignableFrom(t) && t is { IsInterface: false, IsAbstract: false })
+            .ToList();
+
+        impls.Should().NotBeEmpty("at least one IMailerAudience implementation is expected.");
+
+        foreach (var impl in impls)
+        {
+            var instance = (IMailerAudience)Activator.CreateInstance(impl, NonPublicConstructorBypass(impl))!;
+            instance.MailerLiteGroupName.Should().StartWith("Humans - ",
+                $"every IMailerAudience must target a Humans-prefixed group; {impl.Name} does not.");
+        }
+    }
+
+    [HumansFact]
+    public void AllAudiences_HaveUniqueGroupNamesAndKeys()
+    {
+        var audienceType = typeof(IMailerAudience);
+        var impls = typeof(MailerImportService).Assembly
+            .GetTypes()
+            .Where(t => audienceType.IsAssignableFrom(t) && t is { IsInterface: false, IsAbstract: false })
+            .Select(t => (IMailerAudience)Activator.CreateInstance(t, NonPublicConstructorBypass(t))!)
+            .ToList();
+
+        impls.Select(a => a.Key).Distinct(StringComparer.Ordinal).Count().Should().Be(impls.Count,
+            "audience keys collide");
+        impls.Select(a => a.MailerLiteGroupName).Distinct(StringComparer.Ordinal).Count().Should().Be(impls.Count,
+            "audience group names collide");
+    }
+
+    // Reflection helper — passes null/default args to allow constructing audiences
+    // that take service dependencies. The arch test only inspects metadata properties.
+    private static object?[] NonPublicConstructorBypass(Type t)
+    {
+        var ctor = t.GetConstructors().OrderByDescending(c => c.GetParameters().Length).First();
+        return ctor.GetParameters().Select(p =>
+            p.ParameterType.IsValueType ? Activator.CreateInstance(p.ParameterType) : null).ToArray();
+    }
 }

--- a/tests/Humans.Application.Tests/Architecture/MailerArchitectureTests.cs
+++ b/tests/Humans.Application.Tests/Architecture/MailerArchitectureTests.cs
@@ -9,7 +9,7 @@ public class MailerArchitectureTests
     [HumansFact]
     public void IMailerLiteService_OnlyAllowsAudienceWrites()
     {
-        var allowedWrites = new HashSet<string>
+        var allowedWrites = new HashSet<string>(StringComparer.Ordinal)
         {
             nameof(IMailerLiteService.CreateGroupAsync),
             nameof(IMailerLiteService.AssignSubscriberToGroupAsync),

--- a/tests/Humans.Application.Tests/Architecture/MailerArchitectureTests.cs
+++ b/tests/Humans.Application.Tests/Architecture/MailerArchitectureTests.cs
@@ -103,6 +103,15 @@ public class MailerArchitectureTests
             "audience group names collide");
     }
 
+    [HumansFact]
+    public void MailerAudienceSyncService_LivesInApplication_NoEF()
+    {
+        var serviceType = typeof(MailerAudienceSyncService);
+        serviceType.Namespace.Should().Be("Humans.Application.Services.Mailer");
+        serviceType.Assembly.GetReferencedAssemblies()
+            .Should().NotContain(a => string.Equals(a.Name, "Microsoft.EntityFrameworkCore", StringComparison.Ordinal));
+    }
+
     // Reflection helper — passes null/default args to allow constructing audiences
     // that take service dependencies. The arch test only inspects metadata properties.
     private static object?[] NonPublicConstructorBypass(Type t)

--- a/tests/Humans.Application.Tests/Services/Mailer/Audiences/TicketNoShiftsAudienceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Mailer/Audiences/TicketNoShiftsAudienceTests.cs
@@ -1,0 +1,111 @@
+using AwesomeAssertions;
+using Humans.Application.Interfaces.Shifts;
+using Humans.Application.Interfaces.Tickets;
+using Humans.Application.Services.Mailer.Audiences;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using NodaTime;
+using NSubstitute;
+
+namespace Humans.Application.Tests.Services.Mailer.Audiences;
+
+public class TicketNoShiftsAudienceTests
+{
+    private static readonly Guid EventId = Guid.NewGuid();
+
+    [HumansFact]
+    public async Task ComputeMemberUserIdsAsync_ReturnsTicketHoldersMinusShiftHavers()
+    {
+        var userA = Guid.NewGuid(); // ticket, no shift          → IN
+        var userB = Guid.NewGuid(); // ticket, has Confirmed shift → OUT
+        var userC = Guid.NewGuid(); // no ticket                  → OUT (not in ticketHolders)
+        var userD = Guid.NewGuid(); // ticket, has Pending shift   → OUT
+        _ = userC;
+
+        var audience = NewAudience(
+            ticketHolders: new HashSet<Guid> { userA, userB, userD },
+            shiftCommitted: new HashSet<Guid> { userB, userD });
+
+        var members = await audience.ComputeMemberUserIdsAsync(CancellationToken.None);
+
+        members.Should().BeEquivalentTo(new[] { userA });
+    }
+
+    [HumansFact]
+    public async Task ComputeMemberUserIdsAsync_NoActiveEvent_ReturnsEmpty()
+    {
+        var audience = NewAudience(
+            ticketHolders: new HashSet<Guid> { Guid.NewGuid() },
+            shiftCommitted: new HashSet<Guid>(),
+            activeEvent: null,
+            useDefaultEvent: false);
+
+        var members = await audience.ComputeMemberUserIdsAsync(CancellationToken.None);
+
+        members.Should().BeEmpty();
+    }
+
+    [HumansFact]
+    public void Metadata_UsesHumansPrefix()
+    {
+        var audience = NewAudience(new HashSet<Guid>(), new HashSet<Guid>());
+        audience.Key.Should().Be("ticket-no-shifts");
+        audience.MailerLiteGroupName.Should().Be("Humans - Ticket no Shifts");
+        audience.MailerLiteGroupName.Should().StartWith("Humans - ");
+    }
+
+    [HumansFact]
+    public async Task ComputeMemberUserIdsAsync_TicketWithoutCommittedShift_IncludesUser()
+    {
+        // Users with only Refused/Bailed/Cancelled/NoShow signups are NOT in
+        // shiftCommitted (per repo semantics — only Pending+Confirmed count).
+        // They should remain in the audience.
+        var userA = Guid.NewGuid();
+        var audience = NewAudience(
+            ticketHolders: new HashSet<Guid> { userA },
+            shiftCommitted: new HashSet<Guid>());
+
+        var members = await audience.ComputeMemberUserIdsAsync(CancellationToken.None);
+
+        members.Should().BeEquivalentTo(new[] { userA });
+    }
+
+    private static TicketNoShiftsAudience NewAudience(
+        HashSet<Guid> ticketHolders,
+        HashSet<Guid> shiftCommitted,
+        EventSettings? activeEvent = null,
+        bool useDefaultEvent = true)
+    {
+        var tickets = Substitute.For<ITicketQueryService>();
+        tickets.GetUserIdsWithTicketsAsync().Returns(ticketHolders);
+
+        var signups = Substitute.For<IShiftSignupService>();
+        signups.GetActiveCommittedUserIdsForEventAsync(EventId, Arg.Any<CancellationToken>())
+            .Returns(shiftCommitted);
+
+        var mgmt = Substitute.For<IShiftManagementService>();
+        var resolved = activeEvent ?? (useDefaultEvent ? FakeEventSettings(EventId) : null);
+        mgmt.GetActiveAsync().Returns(resolved);
+
+        return new TicketNoShiftsAudience(tickets, signups, mgmt);
+    }
+
+    private static EventSettings FakeEventSettings(Guid id)
+    {
+        var now = Instant.FromUtc(2026, 1, 1, 0, 0);
+        return new EventSettings
+        {
+            Id = id,
+            EventName = "Test Event",
+            TimeZoneId = "Europe/Madrid",
+            GateOpeningDate = new LocalDate(2026, 7, 1),
+            BuildStartOffset = -14,
+            EventEndOffset = 6,
+            StrikeEndOffset = 9,
+            IsShiftBrowsingOpen = true,
+            IsActive = true,
+            CreatedAt = now,
+            UpdatedAt = now,
+        };
+    }
+}

--- a/tests/Humans.Application.Tests/Services/Mailer/MailerAudienceSyncServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Mailer/MailerAudienceSyncServiceTests.cs
@@ -31,7 +31,7 @@ public class MailerAudienceSyncServiceTests
                 Arg.Any<CancellationToken>())
             .Returns(new BulkImportResult(1, 0, 0, 0));
 
-        var result = await NewService(audience).SyncAsync(audience, CancellationToken.None);
+        var result = await NewService(audience).SyncAsync(audience, ct: CancellationToken.None);
 
         result.Created.Should().Be(1);
         result.Assigned.Should().Be(0);
@@ -49,7 +49,7 @@ public class MailerAudienceSyncServiceTests
         SetupGroups(Group("g1", "Humans - A"));
         SetupSubscribers(Subscriber("s1", "a@example.com", "unsubscribed"));
 
-        var result = await NewService(audience).SyncAsync(audience, CancellationToken.None);
+        var result = await NewService(audience).SyncAsync(audience, ct: CancellationToken.None);
 
         result.ExcludedUnsubscribed.Should().Be(1);
         result.Created.Should().Be(0);
@@ -69,7 +69,7 @@ public class MailerAudienceSyncServiceTests
         SetupGroups(Group("g1", "Humans - A"));
         SetupSubscribers(Subscriber("s1", "a@example.com", "active"));
 
-        var result = await NewService(audience).SyncAsync(audience, CancellationToken.None);
+        var result = await NewService(audience).SyncAsync(audience, ct: CancellationToken.None);
 
         result.Assigned.Should().Be(1);
         await _ml.Received(1).AssignSubscriberToGroupAsync("s1", "g1", Arg.Any<CancellationToken>());
@@ -83,7 +83,7 @@ public class MailerAudienceSyncServiceTests
         SetupGroups(Group("g1", "Humans - A"));
         SetupSubscribers(Subscriber("s1", "a@example.com", "active", inGroups: new[] { "g1" }));
 
-        var result = await NewService(audience).SyncAsync(audience, CancellationToken.None);
+        var result = await NewService(audience).SyncAsync(audience, ct: CancellationToken.None);
 
         result.Unassigned.Should().Be(1);
         await _ml.Received(1).UnassignSubscriberFromGroupAsync("s1", "g1", Arg.Any<CancellationToken>());
@@ -103,7 +103,7 @@ public class MailerAudienceSyncServiceTests
                 "g1", Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>())
             .Returns(new BulkImportResult(1, 0, 0, 0));
 
-        await NewService(audience).SyncAsync(audience, CancellationToken.None);
+        await NewService(audience).SyncAsync(audience, ct: CancellationToken.None);
 
         await _ml.Received(1).CreateGroupAsync("Humans - A", Arg.Any<CancellationToken>());
     }
@@ -117,7 +117,7 @@ public class MailerAudienceSyncServiceTests
         SetupGroups(Group("g1", "Humans - A"));
         SetupSubscribers(Subscriber("s1", "a@example.com", "active", inGroups: new[] { "g1" }));
 
-        var result = await NewService(audience).SyncAsync(audience, CancellationToken.None);
+        var result = await NewService(audience).SyncAsync(audience, ct: CancellationToken.None);
 
         result.AlreadyAssigned.Should().Be(1);
         result.Created.Should().Be(0);
@@ -145,7 +145,7 @@ public class MailerAudienceSyncServiceTests
         _ml.AssignSubscriberToGroupAsync("s1", "g1", Arg.Any<CancellationToken>())
             .Returns<Task>(_ => throw new HttpRequestException("simulated 500"));
 
-        var result = await NewService(audience).SyncAsync(audience, CancellationToken.None);
+        var result = await NewService(audience).SyncAsync(audience, ct: CancellationToken.None);
 
         result.Errors.Should().Be(1);
         result.Assigned.Should().Be(1); // s2 still succeeded
@@ -156,7 +156,7 @@ public class MailerAudienceSyncServiceTests
     {
         var audience = NewAudience("a-aud", "Newsletter", Array.Empty<Guid>());
 
-        var act = async () => await NewService(audience).SyncAsync(audience, CancellationToken.None);
+        var act = async () => await NewService(audience).SyncAsync(audience, ct: CancellationToken.None);
 
         await act.Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("*Humans - *");
@@ -171,7 +171,7 @@ public class MailerAudienceSyncServiceTests
         SetupGroups(Group("g1", "Humans - A"));
         SetupSubscribers(Subscriber("s1", "a@example.com", "active"));
 
-        await NewService(audience).SyncAsync(audience, CancellationToken.None);
+        await NewService(audience).SyncAsync(audience, ct: CancellationToken.None);
 
         await _audit.Received(1).LogAsync(
             AuditAction.MailerLiteAudienceSyncCompleted,
@@ -205,15 +205,15 @@ public class MailerAudienceSyncServiceTests
     private void SetupEmails(params (Guid UserId, string Email)[] mapping)
     {
         var dict = mapping.ToDictionary(x => x.UserId, x => x.Email);
-        _emails.GetPrimaryEmailsByUserIdsAsync(
-                Arg.Any<IEnumerable<Guid>>(), Arg.Any<CancellationToken>())
+        _emails.GetNotificationTargetEmailsAsync(
+                Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
             .Returns((IReadOnlyDictionary<Guid, string>)dict);
     }
 
     private void SetupEmailsEmpty()
     {
-        _emails.GetPrimaryEmailsByUserIdsAsync(
-                Arg.Any<IEnumerable<Guid>>(), Arg.Any<CancellationToken>())
+        _emails.GetNotificationTargetEmailsAsync(
+                Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
             .Returns((IReadOnlyDictionary<Guid, string>)new Dictionary<Guid, string>());
     }
 

--- a/tests/Humans.Application.Tests/Services/Mailer/MailerAudienceSyncServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Mailer/MailerAudienceSyncServiceTests.cs
@@ -1,0 +1,237 @@
+using AwesomeAssertions;
+using Humans.Application.Interfaces.AuditLog;
+using Humans.Application.Interfaces.Mailer;
+using Humans.Application.Interfaces.Mailer.Dtos;
+using Humans.Application.Interfaces.Profiles;
+using Humans.Application.Services.Mailer;
+using Humans.Domain.Enums;
+using Microsoft.Extensions.Logging.Abstractions;
+using NodaTime;
+using NSubstitute;
+
+namespace Humans.Application.Tests.Services.Mailer;
+
+public class MailerAudienceSyncServiceTests
+{
+    private readonly IMailerLiteService _ml = Substitute.For<IMailerLiteService>();
+    private readonly IUserEmailService _emails = Substitute.For<IUserEmailService>();
+    private readonly IAuditLogService _audit = Substitute.For<IAuditLogService>();
+
+    [HumansFact]
+    public async Task SyncAsync_NewUserNotInML_BulkImportsAndAssigns()
+    {
+        var userA = Guid.NewGuid();
+        var audience = NewAudience("a-aud", "Humans - A", new[] { userA });
+        SetupEmails((userA, "a@example.com"));
+        SetupGroups(Group("g1", "Humans - A"));
+        SetupSubscribers();
+        _ml.BulkImportSubscribersToGroupAsync(
+                "g1",
+                Arg.Is<IReadOnlyList<string>>(l => l.Single() == "a@example.com"),
+                Arg.Any<CancellationToken>())
+            .Returns(new BulkImportResult(1, 0, 0, 0));
+
+        var result = await NewService(audience).SyncAsync(audience, CancellationToken.None);
+
+        result.Created.Should().Be(1);
+        result.Assigned.Should().Be(0);
+        result.Unassigned.Should().Be(0);
+        await _ml.Received(1).BulkImportSubscribersToGroupAsync(
+            "g1", Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task SyncAsync_UnsubscribedUser_ExcludedFromGroup()
+    {
+        var userA = Guid.NewGuid();
+        var audience = NewAudience("a-aud", "Humans - A", new[] { userA });
+        SetupEmails((userA, "a@example.com"));
+        SetupGroups(Group("g1", "Humans - A"));
+        SetupSubscribers(Subscriber("s1", "a@example.com", "unsubscribed"));
+
+        var result = await NewService(audience).SyncAsync(audience, CancellationToken.None);
+
+        result.ExcludedUnsubscribed.Should().Be(1);
+        result.Created.Should().Be(0);
+        result.Assigned.Should().Be(0);
+        await _ml.DidNotReceive().AssignSubscriberToGroupAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await _ml.DidNotReceive().BulkImportSubscribersToGroupAsync(
+            Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task SyncAsync_ExistingSubscriberNotInGroup_AssignsIt()
+    {
+        var userA = Guid.NewGuid();
+        var audience = NewAudience("a-aud", "Humans - A", new[] { userA });
+        SetupEmails((userA, "a@example.com"));
+        SetupGroups(Group("g1", "Humans - A"));
+        SetupSubscribers(Subscriber("s1", "a@example.com", "active"));
+
+        var result = await NewService(audience).SyncAsync(audience, CancellationToken.None);
+
+        result.Assigned.Should().Be(1);
+        await _ml.Received(1).AssignSubscriberToGroupAsync("s1", "g1", Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task SyncAsync_UserDroppedOut_Unassigned()
+    {
+        var audience = NewAudience("a-aud", "Humans - A", Array.Empty<Guid>());
+        SetupEmailsEmpty();
+        SetupGroups(Group("g1", "Humans - A"));
+        SetupSubscribers(Subscriber("s1", "a@example.com", "active", inGroups: new[] { "g1" }));
+
+        var result = await NewService(audience).SyncAsync(audience, CancellationToken.None);
+
+        result.Unassigned.Should().Be(1);
+        await _ml.Received(1).UnassignSubscriberFromGroupAsync("s1", "g1", Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task SyncAsync_GroupMissing_CreatesItFirst()
+    {
+        var userA = Guid.NewGuid();
+        var audience = NewAudience("a-aud", "Humans - A", new[] { userA });
+        SetupEmails((userA, "a@example.com"));
+        SetupGroups(); // empty
+        _ml.CreateGroupAsync("Humans - A", Arg.Any<CancellationToken>())
+            .Returns(Group("g1", "Humans - A"));
+        SetupSubscribers();
+        _ml.BulkImportSubscribersToGroupAsync(
+                "g1", Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>())
+            .Returns(new BulkImportResult(1, 0, 0, 0));
+
+        await NewService(audience).SyncAsync(audience, CancellationToken.None);
+
+        await _ml.Received(1).CreateGroupAsync("Humans - A", Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task SyncAsync_Idempotent_AllAlreadyAssignedOnSecondRun()
+    {
+        var userA = Guid.NewGuid();
+        var audience = NewAudience("a-aud", "Humans - A", new[] { userA });
+        SetupEmails((userA, "a@example.com"));
+        SetupGroups(Group("g1", "Humans - A"));
+        SetupSubscribers(Subscriber("s1", "a@example.com", "active", inGroups: new[] { "g1" }));
+
+        var result = await NewService(audience).SyncAsync(audience, CancellationToken.None);
+
+        result.AlreadyAssigned.Should().Be(1);
+        result.Created.Should().Be(0);
+        result.Assigned.Should().Be(0);
+        result.Unassigned.Should().Be(0);
+        await _ml.DidNotReceive().AssignSubscriberToGroupAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await _ml.DidNotReceive().UnassignSubscriberFromGroupAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await _ml.DidNotReceive().BulkImportSubscribersToGroupAsync(
+            Arg.Any<string>(), Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task SyncAsync_AssignFails_CountedInErrorsAndSyncContinues()
+    {
+        var userA = Guid.NewGuid();
+        var userB = Guid.NewGuid();
+        var audience = NewAudience("a-aud", "Humans - A", new[] { userA, userB });
+        SetupEmails((userA, "a@example.com"), (userB, "b@example.com"));
+        SetupGroups(Group("g1", "Humans - A"));
+        SetupSubscribers(
+            Subscriber("s1", "a@example.com", "active"),
+            Subscriber("s2", "b@example.com", "active"));
+        _ml.AssignSubscriberToGroupAsync("s1", "g1", Arg.Any<CancellationToken>())
+            .Returns<Task>(_ => throw new HttpRequestException("simulated 500"));
+
+        var result = await NewService(audience).SyncAsync(audience, CancellationToken.None);
+
+        result.Errors.Should().Be(1);
+        result.Assigned.Should().Be(1); // s2 still succeeded
+    }
+
+    [HumansFact]
+    public async Task SyncAsync_GroupNameLacksPrefix_ThrowsBeforeAnyMlCall()
+    {
+        var audience = NewAudience("a-aud", "Newsletter", Array.Empty<Guid>());
+
+        var act = async () => await NewService(audience).SyncAsync(audience, CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*Humans - *");
+    }
+
+    [HumansFact]
+    public async Task SyncAsync_WritesAuditEntryWithSerializedCounts()
+    {
+        var userA = Guid.NewGuid();
+        var audience = NewAudience("a-aud", "Humans - A", new[] { userA });
+        SetupEmails((userA, "a@example.com"));
+        SetupGroups(Group("g1", "Humans - A"));
+        SetupSubscribers(Subscriber("s1", "a@example.com", "active"));
+
+        await NewService(audience).SyncAsync(audience, CancellationToken.None);
+
+        await _audit.Received(1).LogAsync(
+            AuditAction.MailerLiteAudienceSyncCompleted,
+            "MailerAudience",
+            Guid.Empty,
+            Arg.Is<string>(d => d.Contains("\"audience_key\":\"a-aud\"")
+                             && d.Contains("\"assigned\":1")),
+            Arg.Any<string>(),
+            Arg.Any<Guid?>(),
+            Arg.Any<string?>());
+    }
+
+    // ---------- helpers ----------
+
+    private MailerAudienceSyncService NewService(params IMailerAudience[] audiences) => new(
+        _ml, _emails, _audit, audiences,
+        NullLogger<MailerAudienceSyncService>.Instance);
+
+    private static IMailerAudience NewAudience(
+        string key, string groupName, IEnumerable<Guid> members)
+    {
+        var mock = Substitute.For<IMailerAudience>();
+        mock.Key.Returns(key);
+        mock.DisplayName.Returns(key);
+        mock.MailerLiteGroupName.Returns(groupName);
+        mock.ComputeMemberUserIdsAsync(Arg.Any<CancellationToken>())
+            .Returns(members.ToHashSet());
+        return mock;
+    }
+
+    private void SetupEmails(params (Guid UserId, string Email)[] mapping)
+    {
+        var dict = mapping.ToDictionary(x => x.UserId, x => x.Email);
+        _emails.GetPrimaryEmailsByUserIdsAsync(
+                Arg.Any<IEnumerable<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns((IReadOnlyDictionary<Guid, string>)dict);
+    }
+
+    private void SetupEmailsEmpty()
+    {
+        _emails.GetPrimaryEmailsByUserIdsAsync(
+                Arg.Any<IEnumerable<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns((IReadOnlyDictionary<Guid, string>)new Dictionary<Guid, string>());
+    }
+
+    private void SetupGroups(params MailerLiteGroup[] groups)
+        => _ml.ListGroupsAsync(Arg.Any<CancellationToken>()).Returns(groups);
+
+    private void SetupSubscribers(params MailerLiteSubscriber[] subscribers)
+        => _ml.ListSubscribersAsync(Arg.Any<CancellationToken>())
+              .Returns(subscribers.ToAsyncEnumerable());
+
+    private static MailerLiteGroup Group(string id, string name) =>
+        new(id, name, Instant.FromUtc(2026, 1, 1, 0, 0), 0, 0, 0, 0, 0);
+
+    private static MailerLiteSubscriber Subscriber(
+        string id, string email, string status, string[]? inGroups = null) =>
+        new(id, email, status, "api",
+            SubscribedAt: Instant.FromUtc(2026, 1, 1, 0, 0),
+            UnsubscribedAt: null, OptedInAt: null,
+            FirstName: null, LastName: null,
+            GroupIds: inGroups ?? Array.Empty<string>());
+}

--- a/tests/Humans.Application.Tests/Services/Mailer/MailerImportServiceClassifierTests.cs
+++ b/tests/Humans.Application.Tests/Services/Mailer/MailerImportServiceClassifierTests.cs
@@ -21,18 +21,18 @@ public class MailerImportServiceClassifierTests
     private static MailerLiteSubscriber Active(string email) =>
         new("ml-id", email, "active", "api",
             Instant.FromUtc(2026, 1, 1, 0, 0), null, Instant.FromUtc(2026, 1, 1, 0, 0),
-            null, null);
+            null, null, Array.Empty<string>());
 
     private static MailerLiteSubscriber Unsubscribed(string email, Instant? unsubscribedAt = null) =>
         new("ml-id", email, "unsubscribed", "api",
             Instant.FromUtc(2026, 1, 1, 0, 0),
             unsubscribedAt ?? Instant.FromUtc(2026, 3, 1, 0, 0),
             Instant.FromUtc(2026, 1, 1, 0, 0),
-            null, null);
+            null, null, Array.Empty<string>());
 
     private static MailerLiteSubscriber Unconfirmed(string email) =>
         new("ml-id", email, "unconfirmed", "form",
-            null, null, null, null, null);
+            null, null, null, null, null, Array.Empty<string>());
 
     [HumansFact]
     public async Task Classifies_UnconfirmedAsSkipped()

--- a/tests/Humans.Application.Tests/Services/Mailer/MailerImportServiceConflictRuleTests.cs
+++ b/tests/Humans.Application.Tests/Services/Mailer/MailerImportServiceConflictRuleTests.cs
@@ -27,7 +27,7 @@ public class MailerImportServiceConflictRuleTests
 
         var bounced = new MailerLiteSubscriber(
             "ml-id", "user@x.com", "bounced", "api",
-            Instant.FromUtc(2026, 1, 1, 0, 0), null, null, null, null);
+            Instant.FromUtc(2026, 1, 1, 0, 0), null, null, null, null, Array.Empty<string>());
 
         harness.MlReturns(bounced);
         harness.SetVerifiedMatch("user@x.com", userId);
@@ -53,7 +53,7 @@ public class MailerImportServiceConflictRuleTests
             "ml-id", "user@x.com", "unsubscribed", "api",
             Instant.FromUtc(2026, 1, 1, 0, 0),
             Instant.FromUtc(2026, 4, 1, 0, 0), // UnsubscribedAt = 2026-04-01 (older than Humans)
-            null, null, null);
+            null, null, null, Array.Empty<string>());
 
         harness.MlReturns(unsubscribed);
         harness.SetVerifiedMatch("user@x.com", userId);
@@ -79,7 +79,7 @@ public class MailerImportServiceConflictRuleTests
             "ml-id", "user@x.com", "unsubscribed", "api",
             Instant.FromUtc(2026, 1, 1, 0, 0),
             Instant.FromUtc(2026, 4, 1, 0, 0), // UnsubscribedAt = 2026-04-01
-            null, null, null);
+            null, null, null, Array.Empty<string>());
 
         harness.MlReturns(unsubscribed);
         harness.SetVerifiedMatch("user@x.com", userId);

--- a/tests/Humans.Application.Tests/Services/Mailer/MailerImportServiceIdempotencyTests.cs
+++ b/tests/Humans.Application.Tests/Services/Mailer/MailerImportServiceIdempotencyTests.cs
@@ -63,7 +63,7 @@ internal sealed class IdempotencyHarness
     private static readonly MailerLiteSubscriber ActiveSubscriber =
         new("ml-id", Email, "active", "api",
             Instant.FromUtc(2026, 1, 1, 0, 0), null, Instant.FromUtc(2026, 1, 1, 0, 0),
-            null, null);
+            null, null, Array.Empty<string>());
 
     private readonly Guid _userId = Guid.NewGuid();
 

--- a/tests/Humans.Application.Tests/Services/Mailer/MailerImportServiceThrottleTests.cs
+++ b/tests/Humans.Application.Tests/Services/Mailer/MailerImportServiceThrottleTests.cs
@@ -176,17 +176,17 @@ internal sealed class ThrottleHarness
     public static MailerLiteSubscriber Active(string email) =>
         new("ml-id", email, "active", "api",
             Instant.FromUtc(2026, 1, 1, 0, 0), null,
-            Instant.FromUtc(2026, 1, 1, 0, 0), null, null);
+            Instant.FromUtc(2026, 1, 1, 0, 0), null, null, Array.Empty<string>());
 
     public static MailerLiteSubscriber Unsubscribed(string email) =>
         new("ml-id", email, "unsubscribed", "api",
             Instant.FromUtc(2026, 1, 1, 0, 0),
             Instant.FromUtc(2026, 3, 1, 0, 0),
-            Instant.FromUtc(2026, 1, 1, 0, 0), null, null);
+            Instant.FromUtc(2026, 1, 1, 0, 0), null, null, Array.Empty<string>());
 
     public static MailerLiteSubscriber Unconfirmed(string email) =>
         new("ml-id", email, "unconfirmed", "form",
-            null, null, null, null, null);
+            null, null, null, null, null, Array.Empty<string>());
 
     public void SetMlSubscribers(params MailerLiteSubscriber[] subscribers)
     {

--- a/tests/Humans.Application.Tests/Services/Mailer/MailerLiteClientCacheTests.cs
+++ b/tests/Humans.Application.Tests/Services/Mailer/MailerLiteClientCacheTests.cs
@@ -50,7 +50,6 @@ public class MailerLiteClientCacheTests
 
     private static MailerLiteClient BuildClient(HttpMessageHandler handler) =>
         new(new StubHttpClientFactory(handler), NodaTime.SystemClock.Instance,
-            Microsoft.Extensions.Options.Options.Create(new Humans.Application.Interfaces.Mailer.MailerLiteOptions()),
             Microsoft.Extensions.Logging.Abstractions.NullLogger<MailerLiteClient>.Instance);
 
     // Returns one empty subscriber page and one empty groups page. The client

--- a/tests/Humans.Application.Tests/Services/Mailer/MailerLiteClientCacheTests.cs
+++ b/tests/Humans.Application.Tests/Services/Mailer/MailerLiteClientCacheTests.cs
@@ -50,6 +50,7 @@ public class MailerLiteClientCacheTests
 
     private static MailerLiteClient BuildClient(HttpMessageHandler handler) =>
         new(new StubHttpClientFactory(handler), NodaTime.SystemClock.Instance,
+            Microsoft.Extensions.Options.Options.Create(new Humans.Application.Interfaces.Mailer.MailerLiteOptions()),
             Microsoft.Extensions.Logging.Abstractions.NullLogger<MailerLiteClient>.Instance);
 
     // Returns one empty subscriber page and one empty groups page. The client

--- a/tests/Humans.Application.Tests/Services/Mailer/MailerLiteClientWriteGuardTests.cs
+++ b/tests/Humans.Application.Tests/Services/Mailer/MailerLiteClientWriteGuardTests.cs
@@ -25,8 +25,8 @@ public class MailerLiteClientWriteGuardTests
     public async Task AssignSubscriberToGroupAsync_RejectsWritesToNonHumansGroups()
     {
         var handler = new ScriptedHandler();
-        // First /api/groups call returns a single non-Humans group; the guard reads it
-        // and rejects before any write hits the wire.
+        // Cache pre-populate: empty subscriber page, then groups page with one non-Humans group.
+        handler.EnqueueJson(HttpStatusCode.OK, """{"data":[],"meta":{"next_cursor":null}}""");
         handler.EnqueueJson(HttpStatusCode.OK,
             """{"data":[{"id":"99","name":"Newsletter","created_at":"2026-01-01 00:00:00","active_count":0,"unsubscribed_count":0,"unconfirmed_count":0,"bounced_count":0,"junk_count":0}],"meta":{"current_page":1,"last_page":1}}""");
         var client = NewClient(handler);
@@ -41,6 +41,7 @@ public class MailerLiteClientWriteGuardTests
     public async Task UnassignSubscriberFromGroupAsync_RejectsWritesToNonHumansGroups()
     {
         var handler = new ScriptedHandler();
+        handler.EnqueueJson(HttpStatusCode.OK, """{"data":[],"meta":{"next_cursor":null}}""");
         handler.EnqueueJson(HttpStatusCode.OK,
             """{"data":[{"id":"99","name":"Newsletter","created_at":"2026-01-01 00:00:00","active_count":0,"unsubscribed_count":0,"unconfirmed_count":0,"bounced_count":0,"junk_count":0}],"meta":{"current_page":1,"last_page":1}}""");
         var client = NewClient(handler);
@@ -54,6 +55,7 @@ public class MailerLiteClientWriteGuardTests
     public async Task BulkImportSubscribersToGroupAsync_RejectsWritesToNonHumansGroups()
     {
         var handler = new ScriptedHandler();
+        handler.EnqueueJson(HttpStatusCode.OK, """{"data":[],"meta":{"next_cursor":null}}""");
         handler.EnqueueJson(HttpStatusCode.OK,
             """{"data":[{"id":"99","name":"Newsletter","created_at":"2026-01-01 00:00:00","active_count":0,"unsubscribed_count":0,"unconfirmed_count":0,"bounced_count":0,"junk_count":0}],"meta":{"current_page":1,"last_page":1}}""");
         var client = NewClient(handler);

--- a/tests/Humans.Application.Tests/Services/Mailer/MailerLiteClientWriteGuardTests.cs
+++ b/tests/Humans.Application.Tests/Services/Mailer/MailerLiteClientWriteGuardTests.cs
@@ -1,28 +1,90 @@
+using System.Net;
 using System.Net.Http;
 using AwesomeAssertions;
+using Humans.Application.Interfaces.Mailer;
 using Humans.Infrastructure.Services.Mailer;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 
 namespace Humans.Application.Tests.Services.Mailer;
 
 public class MailerLiteClientWriteGuardTests
 {
     [HumansFact]
-    public async Task SendAsync_ThrowsOnNonGetRequest()
+    public async Task CreateGroupAsync_RejectsNonHumansName()
     {
-        var factory = new StubHttpClientFactory(new RecordingHandler());
-        var client = new MailerLiteClient(factory, NodaTime.SystemClock.Instance,
-            Microsoft.Extensions.Logging.Abstractions.NullLogger<MailerLiteClient>.Instance);
+        var client = NewClient(new ScriptedHandler());
 
-        var act = async () => await client.SendForTestsAsync(HttpMethod.Post, "/api/subscribers", CancellationToken.None);
+        var act = async () => await client.CreateGroupAsync("Newsletter", CancellationToken.None);
 
         await act.Should().ThrowAsync<InvalidOperationException>()
-            .WithMessage("*read-only*");
+            .WithMessage("*Humans - *");
     }
 
-    private sealed class RecordingHandler : HttpMessageHandler
+    [HumansFact]
+    public async Task AssignSubscriberToGroupAsync_RejectsWritesToNonHumansGroups()
     {
+        var handler = new ScriptedHandler();
+        // First /api/groups call returns a single non-Humans group; the guard reads it
+        // and rejects before any write hits the wire.
+        handler.EnqueueJson(HttpStatusCode.OK,
+            """{"data":[{"id":"99","name":"Newsletter","created_at":"2026-01-01 00:00:00","active_count":0,"unsubscribed_count":0,"unconfirmed_count":0,"bounced_count":0,"junk_count":0}],"meta":{"current_page":1,"last_page":1}}""");
+        var client = NewClient(handler);
+
+        var act = async () => await client.AssignSubscriberToGroupAsync("sub-1", "99", CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*Humans - *");
+    }
+
+    [HumansFact]
+    public async Task UnassignSubscriberFromGroupAsync_RejectsWritesToNonHumansGroups()
+    {
+        var handler = new ScriptedHandler();
+        handler.EnqueueJson(HttpStatusCode.OK,
+            """{"data":[{"id":"99","name":"Newsletter","created_at":"2026-01-01 00:00:00","active_count":0,"unsubscribed_count":0,"unconfirmed_count":0,"bounced_count":0,"junk_count":0}],"meta":{"current_page":1,"last_page":1}}""");
+        var client = NewClient(handler);
+
+        var act = async () => await client.UnassignSubscriberFromGroupAsync("sub-1", "99", CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    [HumansFact]
+    public async Task BulkImportSubscribersToGroupAsync_RejectsWritesToNonHumansGroups()
+    {
+        var handler = new ScriptedHandler();
+        handler.EnqueueJson(HttpStatusCode.OK,
+            """{"data":[{"id":"99","name":"Newsletter","created_at":"2026-01-01 00:00:00","active_count":0,"unsubscribed_count":0,"unconfirmed_count":0,"bounced_count":0,"junk_count":0}],"meta":{"current_page":1,"last_page":1}}""");
+        var client = NewClient(handler);
+
+        var act = async () => await client.BulkImportSubscribersToGroupAsync(
+            "99", new[] { "a@example.com" }, CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    private static MailerLiteClient NewClient(HttpMessageHandler handler) =>
+        new(new StubHttpClientFactory(handler),
+            NodaTime.SystemClock.Instance,
+            Options.Create(new MailerLiteOptions()),
+            NullLogger<MailerLiteClient>.Instance);
+
+    private sealed class ScriptedHandler : HttpMessageHandler
+    {
+        private readonly Queue<HttpResponseMessage> _responses = new();
+        public void EnqueueJson(HttpStatusCode status, string body)
+            => _responses.Enqueue(new HttpResponseMessage(status)
+            {
+                Content = new StringContent(body, System.Text.Encoding.UTF8, "application/json"),
+            });
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage req, CancellationToken ct)
-            => Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK));
+            => Task.FromResult(_responses.Count > 0
+                ? _responses.Dequeue()
+                : new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{}", System.Text.Encoding.UTF8, "application/json"),
+                });
     }
 
     private sealed class StubHttpClientFactory(HttpMessageHandler handler) : IHttpClientFactory

--- a/tests/Humans.Application.Tests/Services/Mailer/MailerLiteClientWriteGuardTests.cs
+++ b/tests/Humans.Application.Tests/Services/Mailer/MailerLiteClientWriteGuardTests.cs
@@ -1,10 +1,8 @@
 using System.Net;
 using System.Net.Http;
 using AwesomeAssertions;
-using Humans.Application.Interfaces.Mailer;
 using Humans.Infrastructure.Services.Mailer;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Options;
 
 namespace Humans.Application.Tests.Services.Mailer;
 
@@ -69,7 +67,6 @@ public class MailerLiteClientWriteGuardTests
     private static MailerLiteClient NewClient(HttpMessageHandler handler) =>
         new(new StubHttpClientFactory(handler),
             NodaTime.SystemClock.Instance,
-            Options.Create(new MailerLiteOptions()),
             NullLogger<MailerLiteClient>.Instance);
 
     private sealed class ScriptedHandler : HttpMessageHandler

--- a/tests/Humans.Application.Tests/Services/Shifts/ShiftSignupRepositoryActiveCommittedTests.cs
+++ b/tests/Humans.Application.Tests/Services/Shifts/ShiftSignupRepositoryActiveCommittedTests.cs
@@ -1,0 +1,168 @@
+using AwesomeAssertions;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using Humans.Infrastructure.Data;
+using Humans.Infrastructure.Repositories.Shifts;
+using Microsoft.EntityFrameworkCore;
+using NodaTime;
+using NodaTime.Testing;
+
+namespace Humans.Application.Tests.Services.Shifts;
+
+/// <summary>
+/// Covers the narrow read used by Mailer audience computations:
+/// "users with at least one Pending or Confirmed signup for the given event".
+/// </summary>
+public class ShiftSignupRepositoryActiveCommittedTests : IDisposable
+{
+    private static readonly Instant TestNow = Instant.FromUtc(2026, 6, 15, 12, 0);
+
+    private readonly HumansDbContext _dbContext;
+    private readonly ShiftSignupRepository _repo;
+
+    public ShiftSignupRepositoryActiveCommittedTests()
+    {
+        var options = new DbContextOptionsBuilder<HumansDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        _dbContext = new HumansDbContext(options);
+        _repo = new ShiftSignupRepository(_dbContext, new FakeClock(TestNow));
+    }
+
+    public void Dispose()
+    {
+        _dbContext.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    [HumansFact]
+    public async Task GetActiveCommittedUserIdsForEventAsync_IncludesPendingAndConfirmed_ExcludesOthers()
+    {
+        var (es, _, shift) = await SeedShiftAsync();
+        var pending = Guid.NewGuid();
+        var confirmed = Guid.NewGuid();
+        var refused = Guid.NewGuid();
+        var bailed = Guid.NewGuid();
+        var cancelled = Guid.NewGuid();
+        var noShow = Guid.NewGuid();
+
+        await AddSignupAsync(shift, pending, SignupStatus.Pending);
+        await AddSignupAsync(shift, confirmed, SignupStatus.Confirmed);
+        await AddSignupAsync(shift, refused, SignupStatus.Refused);
+        await AddSignupAsync(shift, bailed, SignupStatus.Bailed);
+        await AddSignupAsync(shift, cancelled, SignupStatus.Cancelled);
+        await AddSignupAsync(shift, noShow, SignupStatus.NoShow);
+
+        var result = await _repo.GetActiveCommittedUserIdsForEventAsync(es.Id, CancellationToken.None);
+
+        result.Should().BeEquivalentTo(new[] { pending, confirmed });
+    }
+
+    [HumansFact]
+    public async Task GetActiveCommittedUserIdsForEventAsync_FiltersByEvent()
+    {
+        var (esA, _, shiftA) = await SeedShiftAsync(eventName: "Event A");
+        var (esB, _, shiftB) = await SeedShiftAsync(eventName: "Event B");
+        var userA = Guid.NewGuid();
+        var userB = Guid.NewGuid();
+
+        await AddSignupAsync(shiftA, userA, SignupStatus.Confirmed);
+        await AddSignupAsync(shiftB, userB, SignupStatus.Confirmed);
+
+        var resultA = await _repo.GetActiveCommittedUserIdsForEventAsync(esA.Id, CancellationToken.None);
+
+        resultA.Should().BeEquivalentTo(new[] { userA });
+        resultA.Should().NotContain(userB);
+    }
+
+    [HumansFact]
+    public async Task GetActiveCommittedUserIdsForEventAsync_DistinctUsersOnly()
+    {
+        var (es, _, shift) = await SeedShiftAsync();
+        var userA = Guid.NewGuid();
+        // Same user with two signups on the same shift (synthetic).
+        await AddSignupAsync(shift, userA, SignupStatus.Pending);
+        await AddSignupAsync(shift, userA, SignupStatus.Confirmed);
+
+        var result = await _repo.GetActiveCommittedUserIdsForEventAsync(es.Id, CancellationToken.None);
+
+        result.Should().ContainSingle().Which.Should().Be(userA);
+    }
+
+    private async Task<(EventSettings es, Rota rota, Shift shift)> SeedShiftAsync(string eventName = "Test Event")
+    {
+        var es = new EventSettings
+        {
+            Id = Guid.NewGuid(),
+            EventName = eventName,
+            TimeZoneId = "Europe/Madrid",
+            GateOpeningDate = new LocalDate(2026, 7, 1),
+            BuildStartOffset = -14,
+            EventEndOffset = 6,
+            StrikeEndOffset = 9,
+            IsShiftBrowsingOpen = true,
+            IsActive = true,
+            CreatedAt = TestNow,
+            UpdatedAt = TestNow,
+        };
+        _dbContext.EventSettings.Add(es);
+
+        var team = new Team
+        {
+            Id = Guid.NewGuid(),
+            Name = $"Dept-{eventName}",
+            Slug = $"dept-{eventName.ToLowerInvariant().Replace(' ', '-')}",
+            SystemTeamType = SystemTeamType.None,
+            ParentTeamId = null,
+            CreatedAt = TestNow,
+            UpdatedAt = TestNow,
+        };
+        _dbContext.Teams.Add(team);
+
+        var rota = new Rota
+        {
+            Id = Guid.NewGuid(),
+            EventSettingsId = es.Id,
+            TeamId = team.Id,
+            Name = $"Rota-{eventName}",
+            Priority = ShiftPriority.Normal,
+            Policy = SignupPolicy.Public,
+            Period = RotaPeriod.Event,
+            CreatedAt = TestNow,
+            UpdatedAt = TestNow,
+            EventSettings = es,
+        };
+        _dbContext.Rotas.Add(rota);
+
+        var shift = new Shift
+        {
+            Id = Guid.NewGuid(),
+            RotaId = rota.Id,
+            DayOffset = 1,
+            StartTime = new LocalTime(10, 0),
+            Duration = Duration.FromHours(4),
+            MinVolunteers = 1,
+            MaxVolunteers = 10,
+            CreatedAt = TestNow,
+            UpdatedAt = TestNow,
+            Rota = rota,
+        };
+        _dbContext.Shifts.Add(shift);
+        await _dbContext.SaveChangesAsync();
+        return (es, rota, shift);
+    }
+
+    private async Task AddSignupAsync(Shift shift, Guid userId, SignupStatus status)
+    {
+        _dbContext.ShiftSignups.Add(new ShiftSignup
+        {
+            Id = Guid.NewGuid(),
+            ShiftId = shift.Id,
+            UserId = userId,
+            Status = status,
+            CreatedAt = TestNow,
+            UpdatedAt = TestNow,
+        });
+        await _dbContext.SaveChangesAsync();
+    }
+}

--- a/tests/Humans.Web.Tests/Controllers/Mailer/MailerAdminControllerAudienceSyncTests.cs
+++ b/tests/Humans.Web.Tests/Controllers/Mailer/MailerAdminControllerAudienceSyncTests.cs
@@ -46,7 +46,7 @@ public class MailerAdminControllerAudienceSyncTests
         audience.DisplayName.Returns("Ticket holders without a shift");
         audience.MailerLiteGroupName.Returns("Humans - Ticket no Shifts");
 
-        _audienceSync.SyncAsync(audience, Arg.Any<CancellationToken>())
+        _audienceSync.SyncAsync(audience, Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
             .Returns(new AudienceSyncResult(
                 "ticket-no-shifts", "g1", "Humans - Ticket no Shifts",
                 Candidates: 10, ExcludedUnsubscribed: 1,
@@ -79,7 +79,7 @@ public class MailerAdminControllerAudienceSyncTests
         audience.Key.Returns("bad-audience");
         audience.DisplayName.Returns("Bad");
         audience.MailerLiteGroupName.Returns("Bad");
-        _audienceSync.SyncAsync(audience, Arg.Any<CancellationToken>())
+        _audienceSync.SyncAsync(audience, Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
             .Returns<Task<AudienceSyncResult>>(_ => throw new InvalidOperationException("prefix violation"));
 
         var ctrl = BuildSut(new[] { audience });

--- a/tests/Humans.Web.Tests/Controllers/Mailer/MailerAdminControllerAudienceSyncTests.cs
+++ b/tests/Humans.Web.Tests/Controllers/Mailer/MailerAdminControllerAudienceSyncTests.cs
@@ -1,0 +1,111 @@
+using System.Security.Claims;
+using AwesomeAssertions;
+using Humans.Application.Interfaces.AuditLog;
+using Humans.Application.Interfaces.Mailer;
+using Humans.Application.Interfaces.Mailer.Dtos;
+using Humans.Application.Interfaces.Profiles;
+using Humans.Application.Interfaces.Users;
+using Humans.Domain.Entities;
+using Humans.Web.Controllers.Mailer;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Xunit;
+
+namespace Humans.Web.Tests.Controllers.Mailer;
+
+/// <summary>
+/// Verifies <see cref="MailerAdminController.SyncAudience"/>: known key syncs
+/// and sets the banner; unknown key returns 404.
+/// </summary>
+public class MailerAdminControllerAudienceSyncTests
+{
+    private readonly UserManager<User> _userManager;
+    private readonly IMailerImportService _importService = Substitute.For<IMailerImportService>();
+    private readonly IMailerLiteService _mlService = Substitute.For<IMailerLiteService>();
+    private readonly IMailerAudienceSyncService _audienceSync = Substitute.For<IMailerAudienceSyncService>();
+    private readonly IUserService _userService = Substitute.For<IUserService>();
+    private readonly ICommunicationPreferenceService _prefs = Substitute.For<ICommunicationPreferenceService>();
+    private readonly IAuditLogService _audit = Substitute.For<IAuditLogService>();
+
+    public MailerAdminControllerAudienceSyncTests()
+    {
+        var userStore = Substitute.For<IUserStore<User>>();
+        _userManager = Substitute.For<UserManager<User>>(
+            userStore, null, null, null, null, null, null, null, null);
+    }
+
+    [HumansFact]
+    public async Task SyncAudience_KnownKey_RedirectsWithBanner()
+    {
+        var audience = Substitute.For<IMailerAudience>();
+        audience.Key.Returns("ticket-no-shifts");
+        audience.DisplayName.Returns("Ticket holders without a shift");
+        audience.MailerLiteGroupName.Returns("Humans - Ticket no Shifts");
+
+        _audienceSync.SyncAsync(audience, Arg.Any<CancellationToken>())
+            .Returns(new AudienceSyncResult(
+                "ticket-no-shifts", "g1", "Humans - Ticket no Shifts",
+                Candidates: 10, ExcludedUnsubscribed: 1,
+                Created: 5, Assigned: 3, AlreadyAssigned: 1, Unassigned: 0, Errors: 0));
+
+        var ctrl = BuildSut(new[] { audience });
+
+        var result = await ctrl.SyncAudience("ticket-no-shifts", CancellationToken.None);
+
+        result.Should().BeOfType<RedirectToActionResult>()
+            .Which.ActionName.Should().Be(nameof(MailerAdminController.Index));
+        ctrl.TempData["Banner"].Should().NotBeNull();
+        ctrl.TempData["Banner"]!.ToString().Should().Contain("Ticket holders without a shift");
+    }
+
+    [HumansFact]
+    public async Task SyncAudience_UnknownKey_Returns404()
+    {
+        var ctrl = BuildSut(Array.Empty<IMailerAudience>());
+
+        var result = await ctrl.SyncAudience("nope", CancellationToken.None);
+
+        result.Should().BeOfType<NotFoundResult>();
+    }
+
+    [HumansFact]
+    public async Task SyncAudience_SyncThrowsInvalidOperation_RedirectsWithErrorBanner()
+    {
+        var audience = Substitute.For<IMailerAudience>();
+        audience.Key.Returns("bad-audience");
+        audience.DisplayName.Returns("Bad");
+        audience.MailerLiteGroupName.Returns("Bad");
+        _audienceSync.SyncAsync(audience, Arg.Any<CancellationToken>())
+            .Returns<Task<AudienceSyncResult>>(_ => throw new InvalidOperationException("prefix violation"));
+
+        var ctrl = BuildSut(new[] { audience });
+
+        var result = await ctrl.SyncAudience("bad-audience", CancellationToken.None);
+
+        result.Should().BeOfType<RedirectToActionResult>();
+        ctrl.TempData["Banner"]!.ToString().Should().Contain("sync failed");
+    }
+
+    private MailerAdminController BuildSut(IEnumerable<IMailerAudience> audiences)
+    {
+        var ctrl = new MailerAdminController(
+            _mlService, _importService, _audienceSync, audiences,
+            _userService, _prefs, _audit,
+            NullLogger<MailerAdminController>.Instance, _userManager);
+
+        var http = new DefaultHttpContext
+        {
+            User = new ClaimsPrincipal(new ClaimsIdentity(
+                new[] { new Claim(ClaimTypes.NameIdentifier, Guid.NewGuid().ToString()) },
+                "test")),
+        };
+        ctrl.ControllerContext = new ControllerContext { HttpContext = http };
+        ctrl.TempData = new TempDataDictionary(http, Substitute.For<ITempDataProvider>());
+
+        return ctrl;
+    }
+}

--- a/tests/Humans.Web.Tests/Controllers/Mailer/MailerAdminControllerTests.cs
+++ b/tests/Humans.Web.Tests/Controllers/Mailer/MailerAdminControllerTests.cs
@@ -33,6 +33,7 @@ public class MailerAdminControllerTests
     private readonly UserManager<User> _userManager;
     private readonly IMailerImportService _importService = Substitute.For<IMailerImportService>();
     private readonly IMailerLiteService _mlService = Substitute.For<IMailerLiteService>();
+    private readonly IMailerAudienceSyncService _audienceSync = Substitute.For<IMailerAudienceSyncService>();
     private readonly IUserService _userService = Substitute.For<IUserService>();
     private readonly ICommunicationPreferenceService _prefs = Substitute.For<ICommunicationPreferenceService>();
     private readonly IAuditLogService _audit = Substitute.For<IAuditLogService>();
@@ -47,7 +48,8 @@ public class MailerAdminControllerTests
     private MailerAdminController BuildSut(ImportPlanCounts? snapshotCounts = null)
     {
         var ctrl = new MailerAdminController(
-            _mlService, _importService, _userService, _prefs, _audit,
+            _mlService, _importService, _audienceSync, Array.Empty<IMailerAudience>(),
+            _userService, _prefs, _audit,
             NullLogger<MailerAdminController>.Instance, _userManager);
 
         var http = new DefaultHttpContext


### PR DESCRIPTION
## Summary
- Adds four prefix-guarded outbound writes to `IMailerLiteService` (`CreateGroupAsync`, `AssignSubscriberToGroupAsync`, `UnassignSubscriberFromGroupAsync`, `BulkImportSubscribersToGroupAsync`). All writes runtime-rejected unless the target group's name starts with `"Humans - "`.
- Introduces `IMailerAudience` code-registered audience primitive and `MailerAudienceSyncService` orchestrator (compute → diff → apply → audit). Audit metadata serialized as JSON in the `MailerLiteAudienceSyncCompleted` description.
- Ships first audience `TicketNoShiftsAudience` → `"Humans - Ticket no Shifts"` ML group. Reuses the existing `ITicketQueryService.GetUserIdsWithTicketsAsync` (Valid/CheckedIn attendee match) and adds the narrow `IShiftSignupService.GetActiveCommittedUserIdsForEventAsync` read.
- Daily Hangfire job (`mailer-audience-sync`, default 06:00 UTC, configurable via `MailerLite:AudienceSyncCron`) + on-demand admin button on `/Mailer/Admin`.
- Extends `MailerLiteSubscriber` with `GroupIds` so the sync orchestrator can diff current group membership without a second ML call.
- Relaxes `docs/sections/Mailer.md` inbound-only invariant; pins four new invariants in architecture tests.

Spec: [docs/superpowers/specs/2026-05-14-mailer-outbound-audiences-design.md](docs/superpowers/specs/2026-05-14-mailer-outbound-audiences-design.md)
Plan: [docs/superpowers/plans/2026-05-14-mailer-outbound-audiences.md](docs/superpowers/plans/2026-05-14-mailer-outbound-audiences.md)

## Test plan
- [x] Architecture pins pass — `MailerArchitectureTests` (4 new pins: `IMailerLiteService_OnlyAllowsAudienceWrites`, `AllAudiences_UseHumansPrefix`, `AllAudiences_HaveUniqueGroupNamesAndKeys`, `MailerAudienceSyncService_LivesInApplication_NoEF`)
- [x] Sync-service unit tests pass (idempotency, unsubscribed exclusion, group auto-create, error counting, prefix violation, audit metadata)
- [x] Audience unit tests pass (ticket-holders minus shift-havers, no-active-event, Humans-prefix metadata)
- [x] Controller tests pass (admin redirect with banner; 404 on unknown key; error fallback banner)
- [x] Shift repository test covers Pending+Confirmed inclusion and Refused/Bailed/Cancelled/NoShow exclusion
- [x] Write-guard tests confirm InvalidOperationException for non-`"Humans - "` group writes
- [ ] Manual: `/Mailer/Admin` Push Now produces a 302 + audit entry; second click is no-op (all-zero deltas)

Pre-existing integration test failures (Hangfire `JobStorage.Current` initialization) are unrelated to this slice — verified by running the same tests against the branch parent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)