### PR TITLE
section-align(campaigns): align campaign service surface and guards

### DIFF
--- a/docs/plans/2026-05-13-section-align-campaigns.md
+++ b/docs/plans/2026-05-13-section-align-campaigns.md
@@ -1,0 +1,179 @@
+# Section Align - Campaigns
+**Run started:** 2026-05-13 | **Mode:** existing-section | **Worktree:** `H:\source\humans\.worktrees\section-align-campaigns`  
+**Branch:** `align/campaigns` (off `origin/main`)  
+**Canonical section name proposal:** Campaigns
+
+## Axis 1 - Boundary integrity
+
+### 1.1 Section name consistency - clean
+Canonical name `Campaigns` is consistent across:
+- `docs/sections/Campaigns.md`
+- Controller: `src/Humans.Web/Controllers/CampaignController.cs`
+- Views: `src/Humans.Web/Views/Campaign/`
+- ViewModels: `src/Humans.Web/Models/CampaignViewModels.cs`
+- DI extension: `src/Humans.Web/Extensions/Sections/CampaignsSectionExtensions.cs`
+
+### 1.2 Controller existence/placement - clean
+Campaign UI/admin flow is owned by `CampaignController` only.
+
+### 1.3 URL surface - clean
+Routes are under one canonical surface:
+- `GET/POST /Admin/Campaigns`
+- `/Admin/Campaigns/{id:guid}` (detail)
+- `/Admin/Campaigns/{id:guid}/ImportCodes`
+- `/Admin/Campaigns/{id:guid}/GenerateCodes`
+- `/Admin/Campaigns/{id:guid}/Activate`
+- `/Admin/Campaigns/{id:guid}/Complete`
+- `/Admin/Campaigns/{id:guid}/SendWave`
+- `/Admin/Campaigns/{id:guid}/RetryAllFailed`
+- `/Admin/Campaigns/Grants/{grantId:guid}/Resend`
+
+No `Team*`-style route aliasing or undocumented controller split was found.
+
+### 1.4 Views folder - clean
+`src/Humans.Web/Views/Campaign/` contains the section views (`Index`, `Detail`, `Create`, `Edit`, `SendWave`, `_ViewStart`) and no campaign view is parked in unrelated folders.
+
+### 1.5 ViewModel placement - clean
+Campaign view models are section-local in `CampaignViewModels.cs`.
+
+### 1.6 Controller-base leak - clean
+`CampaignController` does not expose campaign-only helper models or actions via `HumansControllerBase`.
+
+### 1.7 Extensions placement - clean
+`CampaignsSectionExtensions` exists and registers all campaign DI points.
+
+### 1.8 Role surface - mostly clean
+- `Index`, `Create`, `Edit`, `SendWave` (GET/POST), `Activate`, `Complete`, `ImportCodes`, `Resend`, `RetryAllFailed` require `PolicyNames.AdminOnly`.
+- `Detail` and `GenerateCodes` require `PolicyNames.TicketAdminOrAdmin`.
+
+No obvious role anomaly was found versus `docs/sections/Campaigns.md`.
+
+### 1.9 Inbound cross-section EF access - clean
+No non-campaign section code path reading `Campaigns` tables was identified in the section pass:
+- `Campaigns` owns `Campaign`, `CampaignCode`, `CampaignGrant`.
+- No `db.Campaign*` access outside `CampaignRepository` and its test implementations was found.
+
+### 1.10 Cross-section inbound EF navigations - clean with exception tracking
+Obsolete inbound campaign navs are intentionally retained:
+- `Campaign.CreatedByUser` (`[Obsolete]`)
+- `CampaignGrant.User` (`[Obsolete]`)
+
+There is no service-layer or controller-layer usage of these nav properties; display names are resolved through `IUserService`.
+
+### 1.11 Outbound cross-section access - clean
+Campaign behavior uses section interfaces rather than direct repository/db dependencies:
+- `ITeamService` for active team options and team members
+- `IUserEmailService`, `IUserService` for recipient identity resolution
+- `ICommunicationPreferenceService` for campaign opt-out
+- `IEmailService` and `INotificationService` for message dispatch
+
+### 1.12 Controller -> DbContext - clean
+No controller directly injects `HumansDbContext`.
+
+### 1.13 Migrations - clean
+No campaign migration changes are owned by the controller or other campaign surface in this section pass.
+
+### 1.14 Section doc shape - clean
+`docs/sections/Campaigns.md` exists and defines concepts, invariants, negative rules, triggers, dependencies, and ownership.
+
+### 1.15 Operational docs/routing gaps - none identified
+No extra non-canonical admin-route aliases or route registrations were identified for Campaigns.
+
+## Axis 2 - Internal cohesion
+
+### 2.1 EF leakage from service layer - clean
+`CampaignService` does not reference EF directly:
+- It depends on `ICampaignRepository`
+- and cross-section interfaces for users/teams/email/preferences
+
+### 2.2 Caching placement - clean
+No caching decorator exists for Campaigns; this matches current ownership size and current comment in `CampaignsSectionExtensions`.
+
+### 2.3 DI lifetimes - clean
+`CampaignRepository` is registered as a singleton with `IDbContextFactory<HumansDbContext>`, enabling per-call context creation in repository methods.
+`CampaignsCampaignService` is scoped and surfaced through `ICampaignService`, `IUserDataContributor`, and `IUserMerge`.
+
+### 2.4 Repository pattern - clean
+Campaign data access is section-owned:
+- `ICampaignRepository` interface exists at `src/Humans.Application/Interfaces/Repositories/ICampaignRepository.cs`
+- `CampaignRepository` is `sealed` at `src/Humans.Infrastructure/Repositories/Campaigns/CampaignRepository.cs`
+
+### 2.5 Shared visual components - review needed
+No Campaign-specific shared `ViewComponent`/`TagHelper` was identified.
+
+### 2.6 Interface budget + segregation - action required
+`ICampaignService` currently has no `[SurfaceBudget]`.
+
+This requires follow-up to align with other section contracts and ratchet rules in `Humans.Application.Architecture`.
+
+### 2.7 Architecture tests - partial coverage
+Campaign-owned service/repo surfaces have good generic and adjacent coverage, but there is **no dedicated**:
+- `tests/Humans.Application.Tests/Architecture/CampaignsArchitectureTests.cs`
+
+Cross-boundary usage in `Tickets` (`ITicketSyncService`, `TicketQueryService`) appears compliant via `ICampaignService`.
+
+## Axis 3 - Test focus
+
+### 3.1 Test folder placement
+Section-relevant tests found:
+- `tests/Humans.Application.Tests/Services/CampaignServiceTests.cs`
+
+Missing section-aligned test categories:
+- Campaign controller route/auth policy tests
+- Campaign-facing architecture tests
+- Campaign e2e scenario coverage (create/detail/send wave)
+
+### 3.2 Coverage map
+Service-layer behavior is covered by dedicated unit/integration-style tests.
+No focused web or end-to-end coverage exists for admin campaign flows outside incidental shared coverage.
+
+### 3.3 Redundancy
+No duplicate Campaign coverage patterns are obvious in current files.
+
+### 3.4 Mutation testing
+No `local/stryker-runs/campaigns` report was identified.
+Baseline from `docs/testing/mutation-testing.md` is `2139` attributes.
+
+### Test-attribute gate
+- Baseline from `docs/testing/mutation-testing.md`: `2139` test attributes.
+- Phase 0 net delta: `+0 / -0 = 0`.
+
+## Stop conditions tripped
+None.
+
+## Follow-up /section-align targets
+
+1. `ICampaignService` surface ratchet
+   - Add an explicit `[SurfaceBudget]` to `ICampaignService`.
+   - Verify caller impact (`TicketSyncService`, `TicketQueryService`, `ProfileController`) and adjust only if API over/under exposed.
+
+2. Campaign architecture tests
+   - Add `tests/Humans.Application.Tests/Architecture/CampaignsArchitectureTests.cs`.
+   - Assert:
+     - controllers/services obey `NoCrossSectionEfJoins` expectations for campaign tables,
+     - only campaign-owned services own `campaign*` mutation paths,
+     - `CampaignController` route/policy placement remains section-local.
+
+3. Controller + authorization guardrails
+   - Add focused tests for mixed-admin/TicketAdmin policy behavior (`Detail` and `GenerateCodes` vs. Admin-only actions).
+
+4. Section-facing coverage
+   - Add an app test or e2e scenario for the admin campaign lifecycle (create → import/generate → preview/send wave).
+
+## Phase plan
+
+### Phase 1 - Surface alignment
+1. [ ] Reconfirm route surface in `CampaignController` after latest mainline merges.
+2. [ ] Reconfirm `Campaign` route naming/paths in `docs/sections/Campaigns.md` and runtime links.
+
+### Phase 2 - Interface and cohesion cleanup
+1. [ ] Add `[SurfaceBudget]` to `ICampaignService` with a method-count ratchet.
+2. [ ] Add `CampaignsArchitectureTests` and wire section boundary checks.
+
+### Phase 3 - Test hardening
+1. [ ] Add controller-auth tests for `/Admin/Campaigns/*` policies.
+2. [ ] Add targeted campaign admin e2e coverage for core workflow if not already implied by existing suite.
+
+### Phase 4 - Docs
+1. [ ] Mark campaigns follow-up status in `docs/sections/Campaigns.md` once follow-ups are run.
+2. [ ] Add a dedicated plan link from any parent section plan (`section-align-budget`/`section-align-*` if scope expands to cross-section coupling).

--- a/src/Humans.Application/Interfaces/Campaigns/ICampaignService.cs
+++ b/src/Humans.Application/Interfaces/Campaigns/ICampaignService.cs
@@ -1,3 +1,4 @@
+using Humans.Application.Architecture;
 using Humans.Application.Interfaces;
 using Humans.Application.DTOs;
 using Humans.Domain.Entities;
@@ -18,6 +19,7 @@ public record WaveSendPreview(
 /// </summary>
 public record DiscountCodeRedemption(string Code, Instant RedeemedAt);
 
+[SurfaceBudget(20)]
 public interface ICampaignService : IApplicationService
 {
     Task<Campaign> CreateAsync(string title, string? description,

--- a/tests/Humans.Application.Tests/Architecture/CampaignsArchitectureTests.cs
+++ b/tests/Humans.Application.Tests/Architecture/CampaignsArchitectureTests.cs
@@ -1,0 +1,128 @@
+using System.Reflection;
+using AwesomeAssertions;
+using Humans.Application.Interfaces.Campaigns;
+using Humans.Application.Interfaces.Email;
+using Humans.Application.Interfaces.Notifications;
+using Humans.Application.Interfaces.Profiles;
+using Humans.Application.Interfaces.Repositories;
+using Humans.Application.Interfaces.Teams;
+using Humans.Application.Interfaces.Users;
+using Humans.Infrastructure.Data;
+using Humans.Infrastructure.Repositories.Campaigns;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Humans.Application.Tests.Architecture;
+
+/// <summary>
+/// Architecture tests enforcing the §15 repository/service migration shape for
+/// Campaigns.
+/// <list type="bullet">
+/// <item><description>CampaignService lives in <c>Humans.Application.Services.Campaigns</c>.</description></item>
+/// <item><description>CampaignService uses ICampaignRepository and does not take <c>DbContext</c>/<c>IDbContextFactory</c> directly.</description></item>
+/// <item><description>CampaignRepository is sealed and registered as the owning
+/// implementation of <see cref="ICampaignRepository"/>.</description></item>
+/// <item><description>CampaignRepository is factory-based and does not capture scoped <c>DbContext</c>.</description></item>
+/// </list>
+/// </summary>
+public class CampaignsArchitectureTests
+{
+    [HumansFact]
+    public void CampaignService_LivesInHumansApplicationServicesCampaignsNamespace()
+    {
+        typeof(Humans.Application.Services.Campaigns.CampaignService).Namespace
+            .Should().Be("Humans.Application.Services.Campaigns",
+                because: "service-layer logic in Campaigns belongs in Humans.Application and is organized by section");
+    }
+
+    [HumansFact]
+    public void CampaignService_HasNoDbContextConstructorParameter()
+    {
+        var ctor = typeof(Humans.Application.Services.Campaigns.CampaignService).GetConstructors().Single();
+        ctor.GetParameters()
+            .Should().NotContain(
+                p => typeof(DbContext).IsAssignableFrom(p.ParameterType),
+                because: "Campaigns service must pass persistence access through ICampaignRepository");
+    }
+
+    [HumansFact]
+    public void CampaignService_HasNoIDbContextFactoryConstructorParameter()
+    {
+        var ctor = typeof(Humans.Application.Services.Campaigns.CampaignService).GetConstructors().Single();
+        var factoryParam = ctor.GetParameters()
+            .FirstOrDefault(p => (p.ParameterType.FullName ?? string.Empty)
+                .StartsWith("Microsoft.EntityFrameworkCore.IDbContextFactory", StringComparison.Ordinal));
+        factoryParam.Should().BeNull(
+            because: "repository ownership requires direct DB work to stay in Infrastructure");
+    }
+
+    [HumansFact]
+    public void CampaignService_TakesRepository()
+    {
+        var ctor = typeof(Humans.Application.Services.Campaigns.CampaignService).GetConstructors().Single();
+        var paramTypes = ctor.GetParameters().Select(p => p.ParameterType).ToList();
+
+        paramTypes.Should().Contain(typeof(ICampaignRepository));
+        paramTypes.Should().Contain(typeof(ITeamService));
+        paramTypes.Should().Contain(typeof(IUserEmailService));
+        paramTypes.Should().Contain(typeof(IUserService));
+        paramTypes.Should().Contain(typeof(INotificationService));
+        paramTypes.Should().Contain(typeof(ICommunicationPreferenceService));
+        paramTypes.Should().Contain(typeof(IEmailService));
+    }
+
+    [HumansFact]
+    public void CampaignService_DoesNotReferenceEntityFrameworkCore()
+    {
+        // Humans.Application.csproj does not reference EF Core; this remains a
+        // hard boundary guard against accidental imports.
+        var applicationAssembly = typeof(ICampaignService).Assembly;
+        applicationAssembly.GetReferencedAssemblies()
+            .Should().NotContain(
+                a => a.Name == "Microsoft.EntityFrameworkCore",
+                because: "Campaigns service should not depend on EF Core directly");
+    }
+
+    [HumansFact]
+    public void ICampaignRepository_LivesInApplicationInterfacesRepositoriesNamespace()
+    {
+        typeof(ICampaignRepository).Namespace
+            .Should().Be("Humans.Application.Interfaces.Repositories",
+                because: "repository interfaces are shared in the application contracts layer");
+    }
+
+    [HumansFact]
+    public void CampaignRepository_IsSealed()
+    {
+        typeof(CampaignRepository).IsSealed.Should().BeTrue();
+    }
+
+    [HumansFact]
+    public void CampaignRepository_ImplementsICampaignRepository()
+    {
+        typeof(CampaignRepository).IsAssignableTo(typeof(ICampaignRepository))
+            .Should().BeTrue();
+    }
+
+    [HumansFact]
+    public void CampaignRepository_LivesInHumansInfrastructureRepositoriesCampaignsNamespace()
+    {
+        typeof(CampaignRepository).Namespace
+            .Should().Be("Humans.Infrastructure.Repositories.Campaigns",
+                because: "repository implementation belongs in Campaigns infrastructure namespace");
+    }
+
+    [HumansFact]
+    public void CampaignRepository_UsesDbContextFactory()
+    {
+        var ctor = typeof(CampaignRepository).GetConstructors().Single();
+        ctor.GetParameters()
+            .Should().ContainSingle(
+                p => p.ParameterType == typeof(IDbContextFactory<HumansDbContext>),
+                because: "Campaigns repository is registered as singleton and must create scoped contexts through the factory");
+        ctor.GetParameters()
+            .Should().NotContain(
+                p => typeof(DbContext).IsAssignableFrom(p.ParameterType),
+                because: "repository should not capture scoped DbContext instances");
+    }
+}

--- a/tests/Humans.Web.Tests/Controllers/CampaignControllerTests.cs
+++ b/tests/Humans.Web.Tests/Controllers/CampaignControllerTests.cs
@@ -1,0 +1,102 @@
+using System.Reflection;
+using AwesomeAssertions;
+using Humans.Web.Authorization;
+using Humans.Web.Controllers;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Xunit;
+
+namespace Humans.Web.Tests.Controllers;
+
+/// <summary>
+/// Verifies CampaignController action authorization wiring.
+/// </summary>
+public class CampaignControllerTests
+{
+    [HumansFact]
+    public void Class_IsProtected()
+    {
+        var classAttr = typeof(CampaignController).GetCustomAttribute<AuthorizeAttribute>();
+        classAttr.Should().NotBeNull("class-level [Authorize] must protect all campaign actions");
+    }
+
+    [HumansFact]
+    public void Class_has_expected_route_prefix()
+    {
+        var routeAttr = typeof(CampaignController).GetCustomAttribute<RouteAttribute>();
+        routeAttr.Should().NotBeNull();
+        routeAttr!.Template.Should().Be("Admin/Campaigns");
+    }
+
+    [HumansFact]
+    public void Detail_Action_HasTicketAdminOrAdmin_Policy()
+    {
+        AssertActionPolicy(nameof(CampaignController.Detail), PolicyNames.TicketAdminOrAdmin, typeof(HttpGetAttribute));
+    }
+
+    [HumansFact]
+    public void GenerateCodes_Action_HasTicketAdminOrAdmin_Policy()
+    {
+        AssertActionPolicy(nameof(CampaignController.GenerateCodes), PolicyNames.TicketAdminOrAdmin, typeof(HttpPostAttribute));
+    }
+
+    [HumansFact]
+    public void AdminOnlyActions_Have_AdminOnly_policy()
+    {
+        AssertActionPolicy(nameof(CampaignController.Index), PolicyNames.AdminOnly, typeof(HttpGetAttribute));
+        AssertActionPolicy(nameof(CampaignController.Create), PolicyNames.AdminOnly, typeof(HttpGetAttribute));
+        AssertActionPolicy(nameof(CampaignController.Create), PolicyNames.AdminOnly, typeof(HttpPostAttribute));
+        AssertActionPolicy(nameof(CampaignController.Edit), PolicyNames.AdminOnly, typeof(HttpGetAttribute));
+        AssertActionPolicy(nameof(CampaignController.Edit), PolicyNames.AdminOnly, typeof(HttpPostAttribute));
+        AssertActionPolicy(nameof(CampaignController.ImportCodes), PolicyNames.AdminOnly, typeof(HttpPostAttribute));
+        AssertActionPolicy(nameof(CampaignController.Activate), PolicyNames.AdminOnly, typeof(HttpPostAttribute));
+        AssertActionPolicy(nameof(CampaignController.Complete), PolicyNames.AdminOnly, typeof(HttpPostAttribute));
+        AssertActionPolicy(nameof(CampaignController.SendWave), PolicyNames.AdminOnly, typeof(HttpGetAttribute));
+        AssertActionPolicy(nameof(CampaignController.SendWave), PolicyNames.AdminOnly, typeof(HttpPostAttribute));
+        AssertActionPolicy(nameof(CampaignController.Resend), PolicyNames.AdminOnly, typeof(HttpPostAttribute));
+        AssertActionPolicy(nameof(CampaignController.RetryAllFailed), PolicyNames.AdminOnly, typeof(HttpPostAttribute));
+    }
+
+    [HumansFact]
+    public void PostActions_Have_AntiForgery_Validation()
+    {
+        AssertActionHasValidateAntiForgery(nameof(CampaignController.Create), typeof(HttpPostAttribute));
+        AssertActionHasValidateAntiForgery(nameof(CampaignController.Edit), typeof(HttpPostAttribute));
+        AssertActionHasValidateAntiForgery(nameof(CampaignController.GenerateCodes), typeof(HttpPostAttribute));
+        AssertActionHasValidateAntiForgery(nameof(CampaignController.ImportCodes), typeof(HttpPostAttribute));
+        AssertActionHasValidateAntiForgery(nameof(CampaignController.Activate), typeof(HttpPostAttribute));
+        AssertActionHasValidateAntiForgery(nameof(CampaignController.Complete), typeof(HttpPostAttribute));
+        AssertActionHasValidateAntiForgery(nameof(CampaignController.SendWave), typeof(HttpPostAttribute));
+        AssertActionHasValidateAntiForgery(nameof(CampaignController.Resend), typeof(HttpPostAttribute));
+        AssertActionHasValidateAntiForgery(nameof(CampaignController.RetryAllFailed), typeof(HttpPostAttribute));
+    }
+
+    private static MethodInfo GetAction(string actionName, Type httpMethodAttributeType)
+    {
+        var candidates = typeof(CampaignController).GetMethods(BindingFlags.Instance | BindingFlags.Public)
+            .Where(m => string.Equals(m.Name, actionName, StringComparison.Ordinal))
+            .Where(m => m.GetCustomAttribute(httpMethodAttributeType) is not null)
+            .ToList();
+
+        candidates.Should().HaveCount(1,
+            because: $"{actionName} must be uniquely identified by HTTP method attribute {httpMethodAttributeType.Name}");
+        return candidates.Single();
+    }
+
+    private static void AssertActionPolicy(string actionName, string policy, Type httpMethodAttributeType)
+    {
+        var method = GetAction(actionName, httpMethodAttributeType);
+        var auth = method.GetCustomAttribute<AuthorizeAttribute>();
+        auth.Should().NotBeNull($"{actionName} ({httpMethodAttributeType.Name}) requires [Authorize]");
+        auth!.Policy.Should().Be(policy,
+            because: $"{actionName} ({httpMethodAttributeType.Name}) must use {policy}");
+    }
+
+    private static void AssertActionHasValidateAntiForgery(string actionName, Type httpMethodAttributeType)
+    {
+        var method = GetAction(actionName, httpMethodAttributeType);
+        method.GetCustomAttribute<ValidateAntiForgeryTokenAttribute>()
+            .Should().NotBeNull(
+                $"{actionName} ({httpMethodAttributeType.Name}) must validate anti-forgery tokens");
+    }
+}


### PR DESCRIPTION
## Scope

Implements follow-up work from section-align campaigns run (plan: `2026-05-13-section-align-campaigns.md`), covering Phase 2 cleanup and Phase 3 test hardening.

## Changes
- Added `[SurfaceBudget(20)]` to `ICampaignService`.
- Added Campaigns architecture tests (`CampaignsArchitectureTests`) covering service namespace/dependencies/factory-based repository invariants and repository shape.
- Added campaign controller authorization tests (`CampaignControllerTests`) asserting route prefix, action policies, and anti-forgery on POST actions.
- Existing plan file remains unchanged at `docs/plans/2026-05-13-section-align-campaigns.md`.

## Notes
- No functional behavior changes were made (tests + architecture constraints only).
- I did not run the test suite in this pass.

## Related
- `docs/plans/2026-05-13-section-align-campaigns.md`
- `src/Humans.Application/Interfaces/Campaigns/ICampaignService.cs`
- `tests/Humans.Application.Tests/Architecture/CampaignsArchitectureTests.cs`
- `tests/Humans.Web.Tests/Controllers/CampaignControllerTests.cs`