### PR TITLE
fix(mailer): include=groups + reactive rate-limit sleep

### DIFF
--- a/src/Humans.Infrastructure/Services/Mailer/MailerLiteClient.cs
+++ b/src/Humans.Infrastructure/Services/Mailer/MailerLiteClient.cs
@@ -334,12 +334,7 @@ public sealed class MailerLiteClient : IMailerLiteService
                 _ => TimeSpan.Zero,
             };
             if (delay > TimeSpan.Zero)
-            {
-                _logger.LogWarning(
-                    "MailerLite rate limit remaining: {Remaining}; sleeping {Delay}ms",
-                    remaining, (int)delay.TotalMilliseconds);
                 await Task.Delay(delay, ct);
-            }
         }
         if (!resp.IsSuccessStatusCode)
             _logger.LogWarning("MailerLite returned {StatusCode}: {Method} {Url}",

--- a/src/Humans.Infrastructure/Services/Mailer/MailerLiteClient.cs
+++ b/src/Humans.Infrastructure/Services/Mailer/MailerLiteClient.cs
@@ -334,7 +334,18 @@ public sealed class MailerLiteClient : IMailerLiteService
                 _ => TimeSpan.Zero,
             };
             if (delay > TimeSpan.Zero)
-                await Task.Delay(delay, ct);
+            {
+                try
+                {
+                    await Task.Delay(delay, ct);
+                }
+                catch
+                {
+                    // Caller never sees this response — dispose it so we don't leak the socket.
+                    resp.Dispose();
+                    throw;
+                }
+            }
         }
         if (!resp.IsSuccessStatusCode)
             _logger.LogWarning("MailerLite returned {StatusCode}: {Method} {Url}",

--- a/src/Humans.Infrastructure/Services/Mailer/MailerLiteClient.cs
+++ b/src/Humans.Infrastructure/Services/Mailer/MailerLiteClient.cs
@@ -260,7 +260,10 @@ public sealed class MailerLiteClient : IMailerLiteService
         string? cursor = null;
         while (true)
         {
-            var url = "/api/subscribers?limit=100";
+            // include=groups is required — ML's list endpoint omits the per-subscriber
+            // groups array without it, which leaves GroupIds empty and breaks both the
+            // audience "currently in group" stat and the diff that suppresses re-assigns.
+            var url = "/api/subscribers?limit=100&include=groups";
             if (cursor is not null) url += $"&cursor={Uri.EscapeDataString(cursor)}";
             using var resp = await SendAsync(HttpMethod.Get, url, content: null, ct);
             resp.EnsureSuccessStatusCode();
@@ -317,8 +320,27 @@ public sealed class MailerLiteClient : IMailerLiteService
             throw;
         }
         if (resp.Headers.TryGetValues("X-RateLimit-Remaining", out var values)
-            && int.TryParse(values.FirstOrDefault(), CultureInfo.InvariantCulture, out var remaining) && remaining < 20)
-            _logger.LogWarning("MailerLite rate limit remaining: {Remaining}", remaining);
+            && int.TryParse(values.FirstOrDefault(), CultureInfo.InvariantCulture, out var remaining))
+        {
+            // Reactive back-off — ML allows 120 req/min and returns Remaining in every
+            // response. Sleep proportionally as the window drains so tight write loops
+            // (Assign/Unassign/BulkImport) don't slam into 429s. Tiers are intentionally
+            // wide; 429-with-Retry-After handling is a separate concern.
+            var delay = remaining switch
+            {
+                < 5 => TimeSpan.FromSeconds(5),
+                < 10 => TimeSpan.FromSeconds(2),
+                < 20 => TimeSpan.FromSeconds(1),
+                _ => TimeSpan.Zero,
+            };
+            if (delay > TimeSpan.Zero)
+            {
+                _logger.LogWarning(
+                    "MailerLite rate limit remaining: {Remaining}; sleeping {Delay}ms",
+                    remaining, (int)delay.TotalMilliseconds);
+                await Task.Delay(delay, ct);
+            }
+        }
         if (!resp.IsSuccessStatusCode)
             _logger.LogWarning("MailerLite returned {StatusCode}: {Method} {Url}",
                 (int)resp.StatusCode, method, url);


### PR DESCRIPTION
## Summary
- Add `?include=groups` to `/api/subscribers` so cached `MailerLiteSubscriber.GroupIds` is actually populated. Without it the audience card always shows "0 currently in group" and `SyncAsync` re-assigns everyone every run.
- Replace the log-only `X-RateLimit-Remaining < 20` branch in `SendAsync` with reactive sleep tiers (<20 → 1s, <10 → 2s, <5 → 5s) so write loops (Assign / Unassign / per-email BulkImport) don't blow through ML's 120/min limit.

## Context
Triggered by today's Ticket-no-Shifts audience sync: 1149 candidates → 361 landed, ~2k 429 warnings in the log. Both bugs are in the same file (`MailerLiteClient.cs`) and compound each other — without `include=groups`, `currentGroupMemberIds` stays empty, so every re-run re-fires assigns at users already in the group, multiplying the rate-limit storm.

429-with-Retry-After handling and switching the create-new path to the documented async bulk-import endpoint are deliberately left out — separate PRs.

## Test plan
- [ ] `dotnet build Humans.slnx -v quiet` — clean
- [ ] `dotnet test Humans.slnx --filter "FullyQualifiedName~Mailer"` — 66 pass
- [ ] Re-run Ticket-no-Shifts sync on QA, confirm: (a) no 429 flood, (b) audience card shows non-zero "currently in group", (c) second sync is mostly no-op (alreadyAssigned ≈ total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)