### PR TITLE
feat(admin/users/tickets): UserInfo-driven stats, debug page, Venn

### DIFF
--- a/docs/superpowers/plans/2026-05-14-userinfo-debug-and-venn.md
+++ b/docs/superpowers/plans/2026-05-14-userinfo-debug-and-venn.md
@@ -1,0 +1,1823 @@
+# UserInfo-driven Admin Stats, Debug Table, and Ticket Venn — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the misleading `/Admin` "Active humans 979" card with three accurate stats sourced from the in-memory `UserInfo` cache, add a `/Users/Admin/Debug` flat table for cache spot-checking, and replace the redundant `/Tickets` coverage card + unbounded donut with a 3-set Venn + UpSet of Users/Profiles/Tickets.
+
+**Architecture:** Single source of truth — `IUserService.GetAllUserInfos()` returns a snapshot of the in-memory `UserInfo` dictionary held by `CachingUserService`. All three deliverables read from this snapshot only. `UserInfo` is extended with `CommunicationPreferences` so Marketing opt-in lives on the cached god-object; the SaveChanges interceptor catches preference writes for invalidation.
+
+**Tech Stack:** ASP.NET Core MVC + Razor, EF Core (Postgres) for persistence (untouched on this path), NodaTime, xUnit + NSubstitute (existing test patterns), `@upsetjs/venn.js` + `@upsetjs/bundle` (new JS libs for the Tickets page).
+
+**Worktree:** `H:\source\Humans\.worktrees\userinfo-debug-and-venn` (branch `feat/userinfo-debug-and-venn`, off `origin/main`). All commands assume this is the working directory.
+
+**Build command:** `dotnet build Humans.slnx -v quiet`
+**Test command:** `dotnet test Humans.slnx -v quiet`
+(`-v quiet` is required per `memory/process/dotnet-verbosity-quiet.md`.)
+
+**Reference spec:** `docs/superpowers/specs/2026-05-14-userinfo-debug-and-venn-design.md`
+
+---
+
+## File Structure
+
+### Modified
+
+- `src/Humans.Application/UserInfo.cs` — add `CommunicationPreferenceInfo` record, `CommunicationPreferences` field, `MarketingOptedOut` and `HasTicket` accessors, extend `Create()` signature.
+- `src/Humans.Application/Interfaces/Users/IUserService.cs` — add `GetAllUserInfos()`, bump `[SurfaceBudget(32)]` → `33`, add history line.
+- `src/Humans.Application/Services/Users/UserService.cs` — inner `GetUserInfoAsync` loads `CommunicationPreference` and passes through.
+- `src/Humans.Application/Interfaces/Repositories/ICommunicationPreferenceRepository.cs` — add `GetAllAsync(ct)`.
+- `src/Humans.Infrastructure/Repositories/Profiles/CommunicationPreferenceRepository.cs` — implement `GetAllAsync(ct)`.
+- `src/Humans.Infrastructure/Services/Users/CachingUserService.cs` — inject `ICommunicationPreferenceRepository`, extend `WarmAllAsync` and `RefreshEntryAsync`, add `GetAllUserInfos()`.
+- `src/Humans.Infrastructure/Data/UserInfoSaveChangesInterceptor.cs` — handle `CommunicationPreference` entity.
+- `src/Humans.Web/Models/AdminDashboardViewModel.cs` — replace `ActiveHumans` with `TotalUsers` + `ActiveProfileUsers` + `TicketHolders`.
+- `src/Humans.Web/Controllers/AdminController.cs` — `Index` uses `_userService.GetAllUserInfos()` snapshot.
+- `src/Humans.Web/Views/Shared/_DashboardStats.cshtml` — three new stat tiles.
+- `src/Humans.Web/Views/Admin/Index.cshtml` — top-of-page subtitle uses the new fields.
+- `src/Humans.Web/Models/TicketViewModels.cs` — replace `TotalActiveVolunteers` / `VolunteersWithTickets` / `VolunteerCoveragePercent` / `ParticipationNotAttending` / `ParticipationNoTicket` / `ParticipationHasTicket` with `SetMembership` data.
+- `src/Humans.Web/Controllers/TicketController.cs` — `Index` populates `SetMembership` from `_userService.GetAllUserInfos()`.
+- `src/Humans.Web/Views/Ticket/Index.cshtml` — remove old coverage card and donut; add Venn + UpSet panels and scripts.
+- `src/Humans.Web/ViewComponents/AdminNavTree.cs` — add `All users (debug)` entry to the `Diagnostics` group.
+
+### Created
+
+- `src/Humans.Web/Controllers/UsersAdminDebugController.cs` — new controller.
+- `src/Humans.Web/Models/UsersDebugViewModel.cs` — view model + row record.
+- `src/Humans.Web/Views/UsersAdminDebug/Index.cshtml` — debug table view.
+- `tests/Humans.Application.Tests/UserInfoTests.cs` — accessor unit tests.
+- `tests/Humans.Web.Tests/Controllers/UsersAdminDebugControllerTests.cs` — controller tests.
+
+---
+
+## Task 1: `CommunicationPreferenceInfo` record + `CommunicationPreferences` field on `UserInfo`
+
+**Files:**
+- Modify: `src/Humans.Application/UserInfo.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/Humans.Application.Tests/UserInfoTests.cs`:
+
+```csharp
+using FluentAssertions;
+using Humans.Application;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using NodaTime;
+using Xunit;
+
+namespace Humans.Application.Tests;
+
+public class UserInfoTests
+{
+    private static User MinimalUser(Guid? id = null) => new()
+    {
+        Id = id ?? Guid.NewGuid(),
+        DisplayName = "Test",
+        PreferredLanguage = "en",
+        CreatedAt = Instant.FromUtc(2026, 1, 1, 0, 0),
+        GoogleEmailStatus = GoogleEmailStatus.Unknown,
+    };
+
+    [Fact]
+    public void Create_carries_communication_preferences_projection()
+    {
+        var userId = Guid.NewGuid();
+        var prefs = new[]
+        {
+            new CommunicationPreference
+            {
+                Id = Guid.NewGuid(),
+                UserId = userId,
+                Category = MessageCategory.Marketing,
+                OptedOut = false,
+                InboxEnabled = true,
+                UpdatedAt = Instant.FromUtc(2026, 4, 1, 0, 0),
+                UpdateSource = "Profile",
+                SubscribedAt = Instant.FromUtc(2026, 4, 1, 0, 0),
+            },
+            new CommunicationPreference
+            {
+                Id = Guid.NewGuid(),
+                UserId = userId,
+                Category = MessageCategory.Governance,
+                OptedOut = true,
+                InboxEnabled = false,
+                UpdatedAt = Instant.FromUtc(2026, 4, 2, 0, 0),
+                UpdateSource = "MagicLink",
+                SubscribedAt = null,
+            },
+        };
+
+        var info = UserInfo.Create(
+            user: MinimalUser(userId),
+            userEmails: Array.Empty<UserEmail>(),
+            eventParticipations: Array.Empty<EventParticipation>(),
+            externalLogins: Array.Empty<(string, string)>(),
+            profile: null,
+            contactFields: Array.Empty<ContactField>(),
+            profileLanguages: Array.Empty<ProfileLanguage>(),
+            volunteerHistory: Array.Empty<VolunteerHistoryEntry>(),
+            communicationPreferences: prefs);
+
+        info.CommunicationPreferences.Should().HaveCount(2);
+        info.CommunicationPreferences.Select(c => c.Category)
+            .Should().Equal(MessageCategory.Governance, MessageCategory.Marketing);
+        info.CommunicationPreferences[1].OptedOut.Should().BeFalse();
+        info.CommunicationPreferences[1].UpdateSource.Should().Be("Profile");
+    }
+}
+```
+
+(The expected order is `Category` ascending — `Governance` (3) before `Marketing` (7) per the `MessageCategory` enum order.)
+
+- [ ] **Step 2: Run test to verify it fails (and the test file at least compiles)**
+
+Run: `dotnet test Humans.slnx -v quiet --filter "FullyQualifiedName~UserInfoTests"`
+
+Expected: compile error on the `communicationPreferences:` argument (parameter does not exist on `UserInfo.Create`).
+
+- [ ] **Step 3: Add `CommunicationPreferenceInfo` record**
+
+In `src/Humans.Application/UserInfo.cs`, add after the existing `VolunteerHistoryInfo` record (around line 48):
+
+```csharp
+/// <summary>
+/// Compact projection of a <see cref="CommunicationPreference"/> row.
+/// </summary>
+public sealed record CommunicationPreferenceInfo(
+    Guid Id,
+    MessageCategory Category,
+    bool OptedOut,
+    bool InboxEnabled,
+    Instant UpdatedAt,
+    string UpdateSource,
+    Instant? SubscribedAt);
+```
+
+- [ ] **Step 4: Add `CommunicationPreferences` field to `UserInfo`**
+
+In the `UserInfo` primary constructor (around line 180), add the new parameter at the end of the existing parameter list (after `Profile`):
+
+```csharp
+public sealed record UserInfo(
+    // ... existing parameters unchanged ...
+    ProfileInfo? Profile,
+    IReadOnlyList<CommunicationPreferenceInfo> CommunicationPreferences)
+{
+    // ... existing body ...
+}
+```
+
+Make sure the parameter has a comma after `ProfileInfo? Profile`.
+
+- [ ] **Step 5: Extend `UserInfo.Create()`**
+
+In the same file, find `public static UserInfo Create(`. Add a new parameter at the end:
+
+```csharp
+public static UserInfo Create(
+    User user,
+    IReadOnlyList<UserEmail> userEmails,
+    IReadOnlyList<EventParticipation> eventParticipations,
+    IReadOnlyList<(string Provider, string ProviderKey)> externalLogins,
+    Profile? profile,
+    IReadOnlyList<ContactField> contactFields,
+    IReadOnlyList<ProfileLanguage> profileLanguages,
+    IReadOnlyList<VolunteerHistoryEntry> volunteerHistory,
+    IReadOnlyList<CommunicationPreference> communicationPreferences)
+{
+    // ... existing body ...
+}
+```
+
+Inside the method body, before the final `return new UserInfo(...)`, add:
+
+```csharp
+var communicationPreferenceInfos = communicationPreferences
+    .OrderBy(c => c.Category)
+    .Select(c => new CommunicationPreferenceInfo(
+        c.Id, c.Category, c.OptedOut, c.InboxEnabled,
+        c.UpdatedAt, c.UpdateSource, c.SubscribedAt))
+    .ToList();
+```
+
+In the `return new UserInfo(...)` block, add the new argument at the end (after `Profile: profileInfo`):
+
+```csharp
+        Profile: profileInfo,
+        CommunicationPreferences: communicationPreferenceInfos);
+```
+
+- [ ] **Step 6: Fix existing callers of `UserInfo.Create()`**
+
+There are three known callers; each must pass the new parameter. Run `dotnet build Humans.slnx -v quiet` and let the compiler list them. Expected three error locations:
+
+- `src/Humans.Application/Services/Users/UserService.cs` (`GetUserInfoAsync`)
+- `src/Humans.Infrastructure/Services/Users/CachingUserService.cs` (`RefreshEntryAsync` and `WarmAllAsync`)
+
+For each one, pass `Array.Empty<CommunicationPreference>()` as the new last argument for now. Tasks 4 and 5 wire them properly.
+
+```csharp
+// In UserService.GetUserInfoAsync, end of the return:
+return UserInfo.Create(
+    user, userEmails, participations, externalLogins,
+    profile, contactFields, languages, volunteerHistory,
+    Array.Empty<CommunicationPreference>());
+```
+
+```csharp
+// In CachingUserService.RefreshEntryAsync:
+_byUserId[userId] = UserInfo.Create(
+    user, userEmails, participations, externalLogins,
+    profile, contactFields, languages, volunteerHistory,
+    Array.Empty<CommunicationPreference>());
+```
+
+```csharp
+// In CachingUserService.WarmAllAsync (inside the foreach):
+_byUserId[user.Id] = UserInfo.Create(
+    user, emails, participations, logins,
+    profile, contactFields, languages, volunteerHistory,
+    Array.Empty<CommunicationPreference>());
+```
+
+- [ ] **Step 7: Run build and test**
+
+Run: `dotnet build Humans.slnx -v quiet`
+Expected: build succeeds.
+
+Run: `dotnet test Humans.slnx -v quiet --filter "FullyQualifiedName~UserInfoTests"`
+Expected: `Create_carries_communication_preferences_projection` PASSES.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/Humans.Application/UserInfo.cs \
+        src/Humans.Application/Services/Users/UserService.cs \
+        src/Humans.Infrastructure/Services/Users/CachingUserService.cs \
+        tests/Humans.Application.Tests/UserInfoTests.cs
+git commit -m "feat(userinfo): add CommunicationPreferences to UserInfo projection"
+```
+
+---
+
+## Task 2: `UserInfo.MarketingOptedOut` and `UserInfo.HasTicket` accessors
+
+**Files:**
+- Modify: `src/Humans.Application/UserInfo.cs`
+- Modify: `tests/Humans.Application.Tests/UserInfoTests.cs`
+
+- [ ] **Step 1: Add failing tests**
+
+Append to `tests/Humans.Application.Tests/UserInfoTests.cs`:
+
+```csharp
+    [Fact]
+    public void MarketingOptedOut_is_null_when_no_marketing_pref()
+    {
+        var info = UserInfo.Create(
+            MinimalUser(),
+            Array.Empty<UserEmail>(),
+            Array.Empty<EventParticipation>(),
+            Array.Empty<(string, string)>(),
+            profile: null,
+            Array.Empty<ContactField>(),
+            Array.Empty<ProfileLanguage>(),
+            Array.Empty<VolunteerHistoryEntry>(),
+            Array.Empty<CommunicationPreference>());
+
+        info.MarketingOptedOut.Should().BeNull();
+    }
+
+    [Fact]
+    public void MarketingOptedOut_reflects_pref_when_present()
+    {
+        var userId = Guid.NewGuid();
+        var prefs = new[]
+        {
+            new CommunicationPreference
+            {
+                Id = Guid.NewGuid(),
+                UserId = userId,
+                Category = MessageCategory.Marketing,
+                OptedOut = true,
+                InboxEnabled = true,
+                UpdatedAt = Instant.FromUtc(2026, 4, 1, 0, 0),
+                UpdateSource = "Profile",
+            },
+        };
+
+        var info = UserInfo.Create(
+            MinimalUser(userId),
+            Array.Empty<UserEmail>(),
+            Array.Empty<EventParticipation>(),
+            Array.Empty<(string, string)>(),
+            profile: null,
+            Array.Empty<ContactField>(),
+            Array.Empty<ProfileLanguage>(),
+            Array.Empty<VolunteerHistoryEntry>(),
+            prefs);
+
+        info.MarketingOptedOut.Should().BeTrue();
+    }
+
+    [Fact]
+    public void HasTicket_true_when_any_participation_is_Ticketed_or_Attended()
+    {
+        var participations = new[]
+        {
+            new EventParticipation
+            {
+                Id = Guid.NewGuid(),
+                UserId = Guid.NewGuid(),
+                Year = 2026,
+                Status = ParticipationStatus.Ticketed,
+                Source = ParticipationSource.TicketSync,
+            }
+        };
+
+        var info = UserInfo.Create(
+            MinimalUser(),
+            Array.Empty<UserEmail>(),
+            participations,
+            Array.Empty<(string, string)>(),
+            profile: null,
+            Array.Empty<ContactField>(),
+            Array.Empty<ProfileLanguage>(),
+            Array.Empty<VolunteerHistoryEntry>(),
+            Array.Empty<CommunicationPreference>());
+
+        info.HasTicket.Should().BeTrue();
+    }
+
+    [Fact]
+    public void HasTicket_false_when_only_NotAttending_or_no_participations()
+    {
+        var participations = new[]
+        {
+            new EventParticipation
+            {
+                Id = Guid.NewGuid(),
+                UserId = Guid.NewGuid(),
+                Year = 2026,
+                Status = ParticipationStatus.NotAttending,
+                Source = ParticipationSource.UserDeclared,
+            }
+        };
+
+        var info = UserInfo.Create(
+            MinimalUser(),
+            Array.Empty<UserEmail>(),
+            participations,
+            Array.Empty<(string, string)>(),
+            profile: null,
+            Array.Empty<ContactField>(),
+            Array.Empty<ProfileLanguage>(),
+            Array.Empty<VolunteerHistoryEntry>(),
+            Array.Empty<CommunicationPreference>());
+
+        info.HasTicket.Should().BeFalse();
+    }
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+Run: `dotnet test Humans.slnx -v quiet --filter "FullyQualifiedName~UserInfoTests"`
+Expected: compile error — `MarketingOptedOut` and `HasTicket` not defined.
+
+- [ ] **Step 3: Add the accessors**
+
+In `src/Humans.Application/UserInfo.cs`, inside the `UserInfo` record body (after `AllVerifiedEmails`, before the `Create` static method), add:
+
+```csharp
+    /// <summary>
+    /// Marketing-category opt-in tri-state: null when no preference row exists
+    /// (e.g., user imported from an external source who never hit the prefs
+    /// flow), true when opted out, false when opted in.
+    /// </summary>
+    public bool? MarketingOptedOut => CommunicationPreferences
+        .Where(c => c.Category == MessageCategory.Marketing)
+        .Select(c => (bool?)c.OptedOut)
+        .FirstOrDefault();
+
+    /// <summary>
+    /// True when the user has at least one event participation in the
+    /// <see cref="ParticipationStatus.Ticketed"/> or
+    /// <see cref="ParticipationStatus.Attended"/> state — i.e., currently
+    /// holds a ticket or has been checked in. Matches the predicate used by
+    /// the Tickets dashboard so the admin stats and the Venn agree on
+    /// "ticket holder".
+    /// </summary>
+    public bool HasTicket => EventParticipations.Any(p =>
+        p.Status == ParticipationStatus.Ticketed ||
+        p.Status == ParticipationStatus.Attended);
+```
+
+- [ ] **Step 4: Run tests to confirm they pass**
+
+Run: `dotnet test Humans.slnx -v quiet --filter "FullyQualifiedName~UserInfoTests"`
+Expected: all 4 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Humans.Application/UserInfo.cs tests/Humans.Application.Tests/UserInfoTests.cs
+git commit -m "feat(userinfo): add MarketingOptedOut and HasTicket accessors"
+```
+
+---
+
+## Task 3: `ICommunicationPreferenceRepository.GetAllAsync` + implementation
+
+**Files:**
+- Modify: `src/Humans.Application/Interfaces/Repositories/ICommunicationPreferenceRepository.cs`
+- Modify: `src/Humans.Infrastructure/Repositories/Profiles/CommunicationPreferenceRepository.cs`
+
+- [ ] **Step 1: Add interface method**
+
+In `src/Humans.Application/Interfaces/Repositories/ICommunicationPreferenceRepository.cs`, add after `GetByUserIdReadOnlyAsync`:
+
+```csharp
+    /// <summary>
+    /// Returns every <c>communication_preferences</c> row, read-only. Used by
+    /// the <see cref="UserInfo"/> cache warm path to bulk-load preferences
+    /// once at startup. At ~500 users × ~7 categories the row count is small
+    /// — a single SELECT is cheaper than per-user round-trips.
+    /// </summary>
+    Task<IReadOnlyList<CommunicationPreference>> GetAllAsync(CancellationToken ct = default);
+```
+
+- [ ] **Step 2: Build to confirm the implementation is now missing**
+
+Run: `dotnet build Humans.slnx -v quiet`
+Expected: error — `CommunicationPreferenceRepository` doesn't implement `GetAllAsync`.
+
+- [ ] **Step 3: Implement in repository**
+
+Open `src/Humans.Infrastructure/Repositories/Profiles/CommunicationPreferenceRepository.cs`. Add this method (match the style of the existing `GetByUserIdReadOnlyAsync`):
+
+```csharp
+    public async Task<IReadOnlyList<CommunicationPreference>> GetAllAsync(CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        return await ctx.CommunicationPreferences
+            .AsNoTracking()
+            .ToListAsync(ct);
+    }
+```
+
+(If the existing methods use a different DbContext-acquisition pattern, match that pattern instead — `_factory.CreateDbContextAsync` is the most common one in this codebase. Read the existing `GetByUserIdReadOnlyAsync` in this same file first if uncertain.)
+
+- [ ] **Step 4: Run build**
+
+Run: `dotnet build Humans.slnx -v quiet`
+Expected: build succeeds.
+
+- [ ] **Step 5: Run repository tests if they exist**
+
+Run: `dotnet test Humans.slnx -v quiet --filter "FullyQualifiedName~CommunicationPreferenceRepository"`
+Expected: tests pass or no tests found (acceptable — `GetAllAsync` is a thin SELECT).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Humans.Application/Interfaces/Repositories/ICommunicationPreferenceRepository.cs \
+        src/Humans.Infrastructure/Repositories/Profiles/CommunicationPreferenceRepository.cs
+git commit -m "feat(repo): add ICommunicationPreferenceRepository.GetAllAsync"
+```
+
+---
+
+## Task 4: Inner `UserService.GetUserInfoAsync` loads preferences
+
+**Files:**
+- Modify: `src/Humans.Application/Services/Users/UserService.cs`
+
+- [ ] **Step 1: Inject `ICommunicationPreferenceRepository`**
+
+In `src/Humans.Application/Services/Users/UserService.cs`, add a field next to `_contactFieldRepo` (around line 48):
+
+```csharp
+    private readonly ICommunicationPreferenceRepository _communicationPreferenceRepo;
+```
+
+Add a constructor parameter (alphabetically after `contactFieldRepo`, before `fullProfileInvalidator`):
+
+```csharp
+    public UserService(
+        IUserRepository repo,
+        IUserEmailRepository userEmailRepo,
+        IProfileRepository profileRepo,
+        IContactFieldRepository contactFieldRepo,
+        ICommunicationPreferenceRepository communicationPreferenceRepo,
+        IFullProfileInvalidator fullProfileInvalidator,
+        IAdminAuthorizationService adminAuthorization,
+        IClock clock,
+        ILogger<UserService> logger)
+    {
+        _repo = repo;
+        _userEmailRepo = userEmailRepo;
+        _profileRepo = profileRepo;
+        _contactFieldRepo = contactFieldRepo;
+        _communicationPreferenceRepo = communicationPreferenceRepo;
+        _fullProfileInvalidator = fullProfileInvalidator;
+        _adminAuthorization = adminAuthorization;
+        _clock = clock;
+        _logger = logger;
+    }
+```
+
+- [ ] **Step 2: Load preferences inside `GetUserInfoAsync`**
+
+In the same file, find `GetUserInfoAsync` (around line 74). Inside, after the profile/contact-fields/languages/volunteerHistory load block, add:
+
+```csharp
+        var communicationPreferences = await _communicationPreferenceRepo
+            .GetByUserIdReadOnlyAsync(userId, ct);
+```
+
+Then change the final `return UserInfo.Create(...)` to pass `communicationPreferences` instead of `Array.Empty<CommunicationPreference>()`:
+
+```csharp
+        return UserInfo.Create(
+            user, userEmails, participations, externalLogins,
+            profile, contactFields, languages, volunteerHistory,
+            communicationPreferences);
+```
+
+- [ ] **Step 3: Build**
+
+Run: `dotnet build Humans.slnx -v quiet`
+Expected: build succeeds.
+
+Note: this will likely also require updating the DI registration if `UserService` is registered with explicit constructor injection. Search for `AddScoped<IUserService` / `AddKeyedScoped<IUserService`:
+
+Run: `grep -rn "AddScoped<IUserService\|AddKeyedScoped<IUserService\|services\.AddScoped<.*UserService>" src/`
+
+Most likely the DI registration is on `services.AddScoped<IUserService, UserService>()` — Microsoft.Extensions.DependencyInjection resolves the new dependency automatically. If a manual `new UserService(...)` exists anywhere, fix those call sites by adding the new parameter.
+
+- [ ] **Step 4: Run tests**
+
+Run: `dotnet test Humans.slnx -v quiet`
+Expected: all tests pass. If any test instantiates `UserService` directly with the old constructor shape, update those tests with a mock `ICommunicationPreferenceRepository`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Humans.Application/Services/Users/UserService.cs
+git commit -m "feat(userinfo): inner UserService loads communication preferences"
+```
+
+---
+
+## Task 5: `CachingUserService` warm + refresh load preferences
+
+**Files:**
+- Modify: `src/Humans.Infrastructure/Services/Users/CachingUserService.cs`
+
+- [ ] **Step 1: Inject `ICommunicationPreferenceRepository`**
+
+In `src/Humans.Infrastructure/Services/Users/CachingUserService.cs`, add a field after `_contactFieldRepository`:
+
+```csharp
+    private readonly ICommunicationPreferenceRepository _communicationPreferenceRepository;
+```
+
+Add a constructor parameter after `contactFieldRepository`:
+
+```csharp
+    public CachingUserService(
+        IUserRepository userRepository,
+        IUserEmailRepository userEmailRepository,
+        IProfileRepository profileRepository,
+        IContactFieldRepository contactFieldRepository,
+        ICommunicationPreferenceRepository communicationPreferenceRepository,
+        IServiceScopeFactory scopeFactory,
+        ILogger<CachingUserService> logger)
+    {
+        _userRepository = userRepository;
+        _userEmailRepository = userEmailRepository;
+        _profileRepository = profileRepository;
+        _contactFieldRepository = contactFieldRepository;
+        _communicationPreferenceRepository = communicationPreferenceRepository;
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+    }
+```
+
+- [ ] **Step 2: Update `RefreshEntryAsync`**
+
+Find `RefreshEntryAsync` (around line 104). After the existing per-user load block (before the `_byUserId[userId] = UserInfo.Create(...)` assignment), add:
+
+```csharp
+        var communicationPreferences = await _communicationPreferenceRepository
+            .GetByUserIdReadOnlyAsync(userId, ct);
+```
+
+Update the `UserInfo.Create()` call to pass `communicationPreferences` instead of `Array.Empty<CommunicationPreference>()`:
+
+```csharp
+        _byUserId[userId] = UserInfo.Create(
+            user, userEmails, participations, externalLogins,
+            profile, contactFields, languages, volunteerHistory,
+            communicationPreferences);
+```
+
+- [ ] **Step 3: Update `WarmAllAsync`**
+
+Find `WarmAllAsync` (around line 142). After the existing bulk-loads (after `participationsByUser`), add:
+
+```csharp
+        var allPreferences = await _communicationPreferenceRepository.GetAllAsync(ct);
+        var preferencesByUser = allPreferences
+            .GroupBy(p => p.UserId)
+            .ToDictionary(g => g.Key, g => (IReadOnlyList<CommunicationPreference>)g.ToList());
+```
+
+Inside the `foreach (var user in users)` loop, after the other per-user lookups, add:
+
+```csharp
+            var preferences = preferencesByUser.TryGetValue(user.Id, out var pp)
+                ? pp : Array.Empty<CommunicationPreference>();
+```
+
+Update the `UserInfo.Create()` call to pass `preferences` instead of `Array.Empty<CommunicationPreference>()`:
+
+```csharp
+            _byUserId[user.Id] = UserInfo.Create(
+                user, emails, participations, logins,
+                profile, contactFields, languages, volunteerHistory,
+                preferences);
+```
+
+- [ ] **Step 4: Build**
+
+Run: `dotnet build Humans.slnx -v quiet`
+Expected: build succeeds.
+
+- [ ] **Step 5: Run tests**
+
+Run: `dotnet test Humans.slnx -v quiet`
+Expected: tests pass. If `CachingUserServiceTests` has a setup helper that constructs the service, update it with a mock `ICommunicationPreferenceRepository`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Humans.Infrastructure/Services/Users/CachingUserService.cs \
+        tests/Humans.Application.Tests/Services/Users/CachingUserServiceTests.cs
+git commit -m "feat(userinfo): cache warm/refresh load communication preferences"
+```
+
+---
+
+## Task 6: `IUserService.GetAllUserInfos()` + bump SurfaceBudget
+
+**Files:**
+- Modify: `src/Humans.Application/Interfaces/Users/IUserService.cs`
+- Modify: `src/Humans.Application/Services/Users/UserService.cs`
+- Modify: `src/Humans.Infrastructure/Services/Users/CachingUserService.cs`
+
+- [ ] **Step 1: Add the surface method to the interface**
+
+In `src/Humans.Application/Interfaces/Users/IUserService.cs`, after the existing `GetUserInfoAsync` declaration (around line 41), add:
+
+```csharp
+    /// <summary>
+    /// Returns a snapshot of every cached <see cref="UserInfo"/>. Issue #703:
+    /// the cache is the canonical "everything-about-a-person" source; admin
+    /// stat tiles, debug surfaces, and cross-section aggregates read from
+    /// this snapshot rather than re-querying the contributing tables. Returns
+    /// a new collection per call — the underlying dictionary is mutable and
+    /// callers iterate without locking.
+    /// </summary>
+    IReadOnlyCollection<UserInfo> GetAllUserInfos();
+```
+
+Bump the `[SurfaceBudget(32)]` attribute on the interface to `[SurfaceBudget(33)]`. In the XML doc's `<remarks>` block, add a new history bullet at the top of the bullet list:
+
+```csharp
+///   <item>32→33 — admin stats + /Users/Admin/Debug + /Tickets Venn: added GetAllUserInfos. Snapshot accessor — the cache is the canonical read-model; all aggregate consumers read from it rather than re-querying the underlying tables.</item>
+```
+
+- [ ] **Step 2: Implement on inner `UserService`**
+
+In `src/Humans.Application/Services/Users/UserService.cs`, the inner service does not own the snapshot — it's a no-op delegate to a not-applicable case. Add:
+
+```csharp
+    public IReadOnlyCollection<UserInfo> GetAllUserInfos()
+    {
+        // Inner service is the cache-miss reload path; it never holds a
+        // snapshot. The caching decorator's implementation is the real one.
+        // This method exists to satisfy the interface; in practice every
+        // consumer resolves IUserService and gets the Singleton decorator.
+        throw new NotSupportedException(
+            "GetAllUserInfos is only meaningful through CachingUserService. " +
+            "If this is being called on the inner UserService it indicates a DI " +
+            "registration mistake — IUserService should resolve to CachingUserService.");
+    }
+```
+
+- [ ] **Step 3: Implement on `CachingUserService`**
+
+In `src/Humans.Infrastructure/Services/Users/CachingUserService.cs`, in the `// UserInfo reads` region (after `LoadAndCacheAsync`), add:
+
+```csharp
+    /// <inheritdoc cref="IUserService.GetAllUserInfos" />
+    public IReadOnlyCollection<UserInfo> GetAllUserInfos() => _byUserId.Values.ToArray();
+```
+
+- [ ] **Step 4: Build**
+
+Run: `dotnet build Humans.slnx -v quiet`
+Expected: build succeeds.
+
+- [ ] **Step 5: Add a smoke test for the snapshot**
+
+Append to `tests/Humans.Application.Tests/Services/Users/CachingUserServiceTests.cs`:
+
+```csharp
+    [Fact]
+    public async Task GetAllUserInfos_returns_snapshot_of_cached_entries()
+    {
+        // Arrange — drive a warm to populate the cache. Test harness setup
+        // already wires repositories with N seeded users in BuildSut.
+        var sut = BuildSut(out _);
+        await sut.WarmAllAsync();
+
+        // Act
+        var snapshot = sut.GetAllUserInfos();
+
+        // Assert — every cached entry appears in the snapshot.
+        snapshot.Should().NotBeEmpty();
+        snapshot.Count.Should().Be(_seededUserCount);
+    }
+```
+
+(Adjust to whatever `BuildSut` / seeded-user pattern actually exists in `CachingUserServiceTests`. The point is: warm, then `GetAllUserInfos()`, count matches the seeded users.)
+
+- [ ] **Step 6: Run tests**
+
+Run: `dotnet test Humans.slnx -v quiet --filter "FullyQualifiedName~CachingUserServiceTests"`
+Expected: all pass including the new test.
+
+Also run the full test suite to verify nothing relies on the SurfaceBudget number:
+
+Run: `dotnet test Humans.slnx -v quiet`
+Expected: all tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/Humans.Application/Interfaces/Users/IUserService.cs \
+        src/Humans.Application/Services/Users/UserService.cs \
+        src/Humans.Infrastructure/Services/Users/CachingUserService.cs \
+        tests/Humans.Application.Tests/Services/Users/CachingUserServiceTests.cs
+git commit -m "feat(userinfo): IUserService.GetAllUserInfos snapshot accessor"
+```
+
+---
+
+## Task 7: `UserInfoSaveChangesInterceptor` catches `CommunicationPreference` writes
+
+**Files:**
+- Modify: `src/Humans.Infrastructure/Data/UserInfoSaveChangesInterceptor.cs`
+
+- [ ] **Step 1: Add entity case to the switch**
+
+In `src/Humans.Infrastructure/Data/UserInfoSaveChangesInterceptor.cs`, find `CollectAffectedUserIds` (around line 142). Add a new case to the entity switch (after `IdentityUserLogin<Guid> uil:`):
+
+```csharp
+                case CommunicationPreference cp:
+                    affected.Add(cp.UserId);
+                    break;
+```
+
+- [ ] **Step 2: Update the XML doc covered-tables list**
+
+In the same file, in the class-level `<remarks>` block, find the bullet list listing covered tables (around lines 23-28). Add a new bullet:
+
+```csharp
+///   <item><c>communication_preferences</c> — opt-in/out toggles written directly via <c>ICommunicationPreferenceRepository</c>; rides on the User cache because the prefs collection is part of <c>UserInfo</c>.</item>
+```
+
+- [ ] **Step 3: Build**
+
+Run: `dotnet build Humans.slnx -v quiet`
+Expected: build succeeds (the `using` for `Humans.Domain.Entities` is already present).
+
+- [ ] **Step 4: Run interceptor tests if they exist**
+
+Run: `grep -rln "UserInfoSaveChangesInterceptor" tests/`
+
+If interceptor tests exist, add a case that writes a `CommunicationPreference` and asserts `IUserInfoInvalidator.InvalidateAsync` was called with the user's id. Match the existing test pattern for the other entities.
+
+If no test file exists, do NOT create one — the interceptor is exercised end-to-end by the cache integration tests already in `CachingUserServiceTests`. Move on.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Humans.Infrastructure/Data/UserInfoSaveChangesInterceptor.cs
+git commit -m "feat(userinfo): interceptor invalidates on CommunicationPreference writes"
+```
+
+---
+
+## Task 8: `AdminDashboardViewModel` swap fields
+
+**Files:**
+- Modify: `src/Humans.Web/Models/AdminDashboardViewModel.cs`
+
+- [ ] **Step 1: Replace `ActiveHumans` with three new fields**
+
+In `src/Humans.Web/Models/AdminDashboardViewModel.cs`, edit the record:
+
+```csharp
+public sealed record AdminDashboardViewModel(
+    string GreetingFirstName,
+    int TotalUsers,
+    int ActiveProfileUsers,
+    int TicketHolders,
+    int ShiftCoveragePercent,
+    int? ShiftFilledOf,
+    int? ShiftTotalOf,
+    int OpenFeedback,
+    IReadOnlyList<DepartmentCoverage> StaffingByDepartment,
+    IReadOnlyList<DashboardActivityRow> RecentActivity,
+    DashboardApplicationStats AppStats,
+    IReadOnlyList<DashboardLanguageCount> LanguageDistribution);
+```
+
+(Order matters — `TotalUsers`, `ActiveProfileUsers`, `TicketHolders` replace the single `ActiveHumans` parameter at position 2.)
+
+- [ ] **Step 2: Build**
+
+Run: `dotnet build Humans.slnx -v quiet`
+Expected: errors at every site that constructs `AdminDashboardViewModel` (likely just `AdminController.Index`) and at every site that reads `Model.ActiveHumans` (likely `_DashboardStats.cshtml` and `Admin/Index.cshtml`). These are fixed in the next tasks.
+
+- [ ] **Step 3: Do not commit alone** — bundle with Task 9 and 10.
+
+---
+
+## Task 9: `AdminController.Index` swap to snapshot
+
+**Files:**
+- Modify: `src/Humans.Web/Controllers/AdminController.cs`
+
+- [ ] **Step 1: Add `IUserService` dependency**
+
+`AdminController` does not currently inject `IUserService`. The `Index` action already takes `[FromServices]` deps; add another one:
+
+In `Index`'s parameter list, add `[FromServices] IUserService userService`:
+
+```csharp
+    [HttpGet("")]
+    [Authorize(Policy = PolicyNames.AnyAdminRole)]
+    public async Task<IActionResult> Index(
+        [FromServices] IProfileService profileService,
+        [FromServices] IShiftManagementService shifts,
+        [FromServices] IFeedbackService feedback,
+        [FromServices] IAuditViewerService auditViewer,
+        [FromServices] IAdminDashboardService adminDashboardService,
+        [FromServices] IUserService userService,
+        CancellationToken ct)
+    {
+```
+
+- [ ] **Step 2: Replace `activeHumans` with snapshot-derived counts**
+
+In `Index`'s body, replace:
+
+```csharp
+        var activeHumans = (await profileService.GetActiveApprovedUserIdsAsync(ct)).Count;
+```
+
+with:
+
+```csharp
+        var snapshot = userService.GetAllUserInfos();
+        var totalUsers = snapshot.Count;
+        var activeProfileUsers = snapshot.Count(u => u.Profile != null);
+        var ticketHolders = snapshot.Count(u => u.HasTicket);
+```
+
+(Keep `profileService` injected — other actions on the controller use it. Just drop the one call.)
+
+- [ ] **Step 3: Update the `new AdminDashboardViewModel(...)` constructor call**
+
+Replace:
+
+```csharp
+        var vm = new AdminDashboardViewModel(
+            GreetingFirstName: firstName,
+            ActiveHumans: activeHumans,
+            ShiftCoveragePercent: total > 0 ? (int)Math.Round(ratio * 100) : 0,
+            // ...
+```
+
+with:
+
+```csharp
+        var vm = new AdminDashboardViewModel(
+            GreetingFirstName: firstName,
+            TotalUsers: totalUsers,
+            ActiveProfileUsers: activeProfileUsers,
+            TicketHolders: ticketHolders,
+            ShiftCoveragePercent: total > 0 ? (int)Math.Round(ratio * 100) : 0,
+            // ...
+```
+
+(Leave the rest of the constructor arguments unchanged.)
+
+- [ ] **Step 4: Do not commit alone** — bundle with Task 10.
+
+---
+
+## Task 10: Update dashboard views
+
+**Files:**
+- Modify: `src/Humans.Web/Views/Shared/_DashboardStats.cshtml`
+- Modify: `src/Humans.Web/Views/Admin/Index.cshtml`
+
+- [ ] **Step 1: Replace `_DashboardStats.cshtml` body**
+
+Open `src/Humans.Web/Views/Shared/_DashboardStats.cshtml`. Replace its entire contents with:
+
+```cshtml
+@model Humans.Web.Models.AdminDashboardViewModel
+
+<div class="stats">
+    <div class="stat">
+        <div class="label">Total users</div>
+        <div class="value">@Model.TotalUsers</div>
+    </div>
+    <div class="stat">
+        <div class="label">Active (has profile)</div>
+        <div class="value">@Model.ActiveProfileUsers</div>
+    </div>
+    <div class="stat">
+        <div class="label">Ticket holders</div>
+        <div class="value">@Model.TicketHolders</div>
+    </div>
+    <div class="stat">
+        <div class="label">Shifts staffed</div>
+        <div class="value">
+            @if (Model.ShiftTotalOf.HasValue)
+            {
+                @Model.ShiftFilledOf <em>/ @Model.ShiftTotalOf</em>
+            }
+            else
+            {
+                <em>—</em>
+            }
+        </div>
+        <div class="delta">@Model.ShiftCoveragePercent% of slots filled</div>
+    </div>
+    <div class="stat">
+        <div class="label">Open feedback</div>
+        <div class="value">@Model.OpenFeedback</div>
+    </div>
+</div>
+```
+
+- [ ] **Step 2: Update the page subtitle in `Admin/Index.cshtml`**
+
+Open `src/Humans.Web/Views/Admin/Index.cshtml`. Replace line 10:
+
+```cshtml
+            @Model.ActiveHumans active humans · @Model.ShiftCoveragePercent% shift coverage · @Model.OpenFeedback open feedback
+```
+
+with:
+
+```cshtml
+            @Model.TotalUsers users · @Model.ActiveProfileUsers with profile · @Model.TicketHolders with ticket · @Model.ShiftCoveragePercent% shift coverage · @Model.OpenFeedback open feedback
+```
+
+- [ ] **Step 3: Build and run**
+
+Run: `dotnet build Humans.slnx -v quiet`
+Expected: build succeeds with no errors related to `AdminDashboardViewModel` / `ActiveHumans`.
+
+- [ ] **Step 4: Run tests**
+
+Run: `dotnet test Humans.slnx -v quiet`
+Expected: all tests pass. If any test asserts on `vm.ActiveHumans`, update to the new fields.
+
+- [ ] **Step 5: Commit tasks 8–10 together**
+
+```bash
+git add src/Humans.Web/Models/AdminDashboardViewModel.cs \
+        src/Humans.Web/Controllers/AdminController.cs \
+        src/Humans.Web/Views/Shared/_DashboardStats.cshtml \
+        src/Humans.Web/Views/Admin/Index.cshtml
+git commit -m "feat(admin): replace Active Humans with Total/Active/TicketHolders cards"
+```
+
+- [ ] **Step 6: Push** (per memory rule, push every 3-5 tasks during long runs)
+
+```bash
+git push
+```
+
+---
+
+## Task 11: `UsersDebugViewModel` + `UserDebugRow`
+
+**Files:**
+- Create: `src/Humans.Web/Models/UsersDebugViewModel.cs`
+
+- [ ] **Step 1: Create the view model**
+
+Create `src/Humans.Web/Models/UsersDebugViewModel.cs`:
+
+```csharp
+using Humans.Application;
+using Humans.Domain.Enums;
+
+namespace Humans.Web.Models;
+
+public sealed record UsersDebugViewModel(
+    IReadOnlyList<UserDebugRow> Rows,
+    int TotalCount,
+    int Page,
+    int PageSize,
+    string Sort,
+    string Dir)
+{
+    public int TotalPages => PageSize > 0
+        ? (int)Math.Ceiling((double)TotalCount / PageSize)
+        : 0;
+
+    public bool IsAsc => string.Equals(Dir, "asc", StringComparison.OrdinalIgnoreCase);
+}
+
+public sealed record UserDebugRow(
+    Guid UserId,
+    bool HasProfile,
+    bool HasTicket,
+    bool? MarketingOptedOut,
+    string DisplayName,
+    string BurnerName,
+    string LegalName,
+    bool? HasConsent)
+{
+    public static UserDebugRow From(UserInfo info) => new(
+        UserId: info.Id,
+        HasProfile: info.Profile is not null,
+        HasTicket: info.HasTicket,
+        MarketingOptedOut: info.MarketingOptedOut,
+        DisplayName: info.DisplayName,
+        BurnerName: info.Profile?.BurnerName ?? string.Empty,
+        LegalName: info.Profile?.FullName ?? string.Empty,
+        HasConsent: info.Profile is null
+            ? null
+            : info.Profile.ConsentCheckStatus == ConsentCheckStatus.Cleared);
+}
+```
+
+- [ ] **Step 2: Build**
+
+Run: `dotnet build Humans.slnx -v quiet`
+Expected: build succeeds.
+
+- [ ] **Step 3: Commit** — bundle with Task 12.
+
+---
+
+## Task 12: `UsersAdminDebugController`
+
+**Files:**
+- Create: `src/Humans.Web/Controllers/UsersAdminDebugController.cs`
+- Create: `tests/Humans.Web.Tests/Controllers/UsersAdminDebugControllerTests.cs`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/Humans.Web.Tests/Controllers/UsersAdminDebugControllerTests.cs`:
+
+```csharp
+using FluentAssertions;
+using Humans.Application;
+using Humans.Application.Interfaces.Users;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using Humans.Web.Controllers;
+using Humans.Web.Models;
+using Microsoft.AspNetCore.Mvc;
+using NodaTime;
+using NSubstitute;
+using Xunit;
+
+namespace Humans.Web.Tests.Controllers;
+
+public class UsersAdminDebugControllerTests
+{
+    private static UserInfo MakeUserInfo(
+        Guid id, string displayName, bool hasProfile, bool hasTicket)
+    {
+        var participations = hasTicket
+            ? new[]
+            {
+                new EventParticipation
+                {
+                    Id = Guid.NewGuid(),
+                    UserId = id,
+                    Year = 2026,
+                    Status = ParticipationStatus.Ticketed,
+                    Source = ParticipationSource.TicketSync,
+                }
+            }
+            : Array.Empty<EventParticipation>();
+
+        Profile? profile = hasProfile
+            ? new Profile
+            {
+                Id = Guid.NewGuid(),
+                UserId = id,
+                BurnerName = "Burner",
+                FirstName = "First",
+                LastName = "Last",
+                CreatedAt = Instant.FromUtc(2026, 1, 1, 0, 0),
+                UpdatedAt = Instant.FromUtc(2026, 1, 1, 0, 0),
+            }
+            : null;
+
+        return UserInfo.Create(
+            user: new User
+            {
+                Id = id,
+                DisplayName = displayName,
+                PreferredLanguage = "en",
+                CreatedAt = Instant.FromUtc(2026, 1, 1, 0, 0),
+                GoogleEmailStatus = GoogleEmailStatus.Unknown,
+            },
+            userEmails: Array.Empty<UserEmail>(),
+            eventParticipations: participations,
+            externalLogins: Array.Empty<(string, string)>(),
+            profile: profile,
+            contactFields: Array.Empty<ContactField>(),
+            profileLanguages: Array.Empty<ProfileLanguage>(),
+            volunteerHistory: Array.Empty<VolunteerHistoryEntry>(),
+            communicationPreferences: Array.Empty<CommunicationPreference>());
+    }
+
+    [Fact]
+    public void Index_returns_paged_rows_from_snapshot()
+    {
+        // Arrange — 60 users so default pageSize=50 leaves 10 on page 2.
+        var users = Enumerable.Range(0, 60)
+            .Select(i => MakeUserInfo(Guid.NewGuid(), $"User {i:D3}", hasProfile: i % 2 == 0, hasTicket: i % 3 == 0))
+            .ToArray();
+
+        var userService = Substitute.For<IUserService>();
+        userService.GetAllUserInfos().Returns(users);
+
+        var controller = new UsersAdminDebugController(userService);
+
+        // Act
+        var result = controller.Index(page: 1, pageSize: 50, sort: "displayName", dir: "asc") as ViewResult;
+
+        // Assert
+        result.Should().NotBeNull();
+        var vm = result!.Model.Should().BeOfType<UsersDebugViewModel>().Subject;
+        vm.TotalCount.Should().Be(60);
+        vm.Rows.Should().HaveCount(50);
+        vm.TotalPages.Should().Be(2);
+        vm.Rows[0].DisplayName.Should().Be("User 000");
+    }
+
+    [Fact]
+    public void Index_sort_displayName_descending_reverses_order()
+    {
+        var users = new[]
+        {
+            MakeUserInfo(Guid.NewGuid(), "Alice", hasProfile: true, hasTicket: false),
+            MakeUserInfo(Guid.NewGuid(), "Bob",   hasProfile: true, hasTicket: false),
+            MakeUserInfo(Guid.NewGuid(), "Carol", hasProfile: true, hasTicket: false),
+        };
+        var userService = Substitute.For<IUserService>();
+        userService.GetAllUserInfos().Returns(users);
+
+        var controller = new UsersAdminDebugController(userService);
+
+        var result = controller.Index(page: 1, pageSize: 50, sort: "displayName", dir: "desc") as ViewResult;
+
+        var vm = (UsersDebugViewModel)result!.Model!;
+        vm.Rows.Select(r => r.DisplayName).Should().Equal("Carol", "Bob", "Alice");
+    }
+
+    [Fact]
+    public void Index_clamps_pageSize_outside_10_to_200_range()
+    {
+        var users = Enumerable.Range(0, 5)
+            .Select(i => MakeUserInfo(Guid.NewGuid(), $"User {i}", true, false))
+            .ToArray();
+        var userService = Substitute.For<IUserService>();
+        userService.GetAllUserInfos().Returns(users);
+
+        var controller = new UsersAdminDebugController(userService);
+
+        var tooSmall = (UsersDebugViewModel)((ViewResult)controller.Index(1, 1, "displayName", "asc")).Model!;
+        tooSmall.PageSize.Should().Be(10);
+
+        var tooBig = (UsersDebugViewModel)((ViewResult)controller.Index(1, 9999, "displayName", "asc")).Model!;
+        tooBig.PageSize.Should().Be(200);
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to confirm they fail (controller doesn't exist)**
+
+Run: `dotnet test Humans.slnx -v quiet --filter "FullyQualifiedName~UsersAdminDebugControllerTests"`
+Expected: compile error — `UsersAdminDebugController` not found.
+
+- [ ] **Step 3: Create the controller**
+
+Create `src/Humans.Web/Controllers/UsersAdminDebugController.cs`:
+
+```csharp
+using Humans.Application;
+using Humans.Application.Interfaces.Users;
+using Humans.Web.Authorization;
+using Humans.Web.Models;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Humans.Web.Controllers;
+
+/// <summary>
+/// Diagnostic debug surface for the in-memory <see cref="UserInfo"/> cache.
+/// Flat paginated/sortable table of every cached user — used to verify the
+/// cache holds the expected data after imports and migrations. Every column
+/// comes from <see cref="IUserService.GetAllUserInfos"/>; nothing on this
+/// page makes a secondary query.
+/// </summary>
+[Authorize(Policy = PolicyNames.AdminOnly)]
+[Route("Users/Admin/Debug")]
+public sealed class UsersAdminDebugController : Controller
+{
+    private const int MinPageSize = 10;
+    private const int MaxPageSize = 200;
+    private const int DefaultPageSize = 50;
+
+    private readonly IUserService _userService;
+
+    public UsersAdminDebugController(IUserService userService)
+    {
+        _userService = userService;
+    }
+
+    [HttpGet("")]
+    public IActionResult Index(int page = 1, int pageSize = DefaultPageSize,
+                               string sort = "displayName", string dir = "asc")
+    {
+        pageSize = Math.Clamp(pageSize, MinPageSize, MaxPageSize);
+        if (page < 1) page = 1;
+
+        var snapshot = _userService.GetAllUserInfos();
+        var allRows = snapshot.Select(UserDebugRow.From).ToList();
+
+        var sorted = ApplySort(allRows, sort, dir);
+        var total = sorted.Count;
+        var paged = sorted.Skip((page - 1) * pageSize).Take(pageSize).ToList();
+
+        return View(new UsersDebugViewModel(paged, total, page, pageSize, sort, dir));
+    }
+
+    private static List<UserDebugRow> ApplySort(List<UserDebugRow> rows, string sort, string dir)
+    {
+        var asc = string.Equals(dir, "asc", StringComparison.OrdinalIgnoreCase);
+
+        // Null-first ascending semantics for tri-state booleans — null < false < true.
+        static int NullableBool(bool? b) => b is null ? 0 : b.Value ? 2 : 1;
+
+        IEnumerable<UserDebugRow> sorted = sort switch
+        {
+            "userId"      => rows.OrderBy(r => r.UserId),
+            "hasProfile"  => rows.OrderBy(r => r.HasProfile),
+            "hasTicket"   => rows.OrderBy(r => r.HasTicket),
+            "marketing"   => rows.OrderBy(r => NullableBool(r.MarketingOptedOut)),
+            "burnerName"  => rows.OrderBy(r => r.BurnerName, StringComparer.OrdinalIgnoreCase),
+            "legalName"   => rows.OrderBy(r => r.LegalName, StringComparer.OrdinalIgnoreCase),
+            "hasConsent"  => rows.OrderBy(r => NullableBool(r.HasConsent)),
+            _             => rows.OrderBy(r => r.DisplayName, StringComparer.OrdinalIgnoreCase),
+        };
+
+        return asc ? sorted.ToList() : sorted.Reverse().ToList();
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to confirm they pass**
+
+Run: `dotnet test Humans.slnx -v quiet --filter "FullyQualifiedName~UsersAdminDebugControllerTests"`
+Expected: all three tests PASS.
+
+- [ ] **Step 5: Commit tasks 11 + 12 together**
+
+```bash
+git add src/Humans.Web/Models/UsersDebugViewModel.cs \
+        src/Humans.Web/Controllers/UsersAdminDebugController.cs \
+        tests/Humans.Web.Tests/Controllers/UsersAdminDebugControllerTests.cs
+git commit -m "feat(users-debug): controller + view model for /Users/Admin/Debug"
+```
+
+---
+
+## Task 13: `Views/UsersAdminDebug/Index.cshtml`
+
+**Files:**
+- Create: `src/Humans.Web/Views/UsersAdminDebug/Index.cshtml`
+
+- [ ] **Step 1: Look at an existing precedent for table styling**
+
+Read `src/Humans.Web/Views/AdminDuplicateAccounts/Index.cshtml` (small, similar-shape admin table) to copy the table + pager layout. Adapt the column structure to the debug page's needs.
+
+- [ ] **Step 2: Create the view**
+
+Create `src/Humans.Web/Views/UsersAdminDebug/Index.cshtml`:
+
+```cshtml
+@model Humans.Web.Models.UsersDebugViewModel
+@{
+    ViewData["Title"] = "All users (debug)";
+
+    string Toggle(string column)
+    {
+        var newDir = (Model.Sort == column && Model.IsAsc) ? "desc" : "asc";
+        return Url.Action("Index", new { page = 1, pageSize = Model.PageSize, sort = column, dir = newDir })!;
+    }
+
+    string ArrowFor(string column) =>
+        Model.Sort != column ? "" : Model.IsAsc ? " ↑" : " ↓";
+
+    string Tri(bool? value) => value is null ? "—" : value.Value ? "Yes" : "No";
+    string Bool(bool value) => value ? "✓" : "✗";
+}
+
+<div class="page-head">
+    <h1 class="title">All users (debug)</h1>
+    <p class="sub">
+        @Model.TotalCount users · page @Model.Page of @Model.TotalPages · all fields read from the in-memory UserInfo cache
+    </p>
+</div>
+
+<div class="card">
+    <div class="card-body p-0">
+        <div class="table-responsive">
+            <table class="table table-sm table-hover mb-0">
+                <thead>
+                    <tr>
+                        <th><a href="@Toggle("userId")">UserId@ArrowFor("userId")</a></th>
+                        <th><a href="@Toggle("hasProfile")">HasProfile@ArrowFor("hasProfile")</a></th>
+                        <th><a href="@Toggle("hasTicket")">HasTicket@ArrowFor("hasTicket")</a></th>
+                        <th><a href="@Toggle("marketing")">Marketing@ArrowFor("marketing")</a></th>
+                        <th><a href="@Toggle("displayName")">Display name@ArrowFor("displayName")</a></th>
+                        <th><a href="@Toggle("burnerName")">Burner name@ArrowFor("burnerName")</a></th>
+                        <th><a href="@Toggle("legalName")">Legal name@ArrowFor("legalName")</a></th>
+                        <th><a href="@Toggle("hasConsent")">HasConsent@ArrowFor("hasConsent")</a></th>
+                    </tr>
+                </thead>
+                <tbody>
+                @foreach (var row in Model.Rows)
+                {
+                    <tr>
+                        <td><code class="small">@row.UserId</code></td>
+                        <td>@Bool(row.HasProfile)</td>
+                        <td>@Bool(row.HasTicket)</td>
+                        <td>@(row.MarketingOptedOut is null ? "—" : row.MarketingOptedOut.Value ? "No" : "Yes")</td>
+                        <td>@row.DisplayName</td>
+                        <td>@row.BurnerName</td>
+                        <td>@row.LegalName</td>
+                        <td>@Tri(row.HasConsent)</td>
+                    </tr>
+                }
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+
+@if (Model.TotalPages > 1)
+{
+    <nav class="mt-3" aria-label="pager">
+        <ul class="pagination">
+            @for (var p = 1; p <= Model.TotalPages; p++)
+            {
+                var href = Url.Action("Index", new { page = p, pageSize = Model.PageSize, sort = Model.Sort, dir = Model.Dir });
+                <li class="page-item @(p == Model.Page ? "active" : "")">
+                    <a class="page-link" href="@href">@p</a>
+                </li>
+            }
+        </ul>
+    </nav>
+}
+
+@* Marketing tri-state: "Yes" when subscribed (OptedOut == false), "No" when opted out, "—" when no row exists. *@
+@* TODO: HasShift column — pending IShiftManager caching (see spec out-of-scope). *@
+```
+
+- [ ] **Step 3: Build**
+
+Run: `dotnet build Humans.slnx -v quiet`
+Expected: build succeeds.
+
+- [ ] **Step 4: Commit** — bundle with Task 14.
+
+---
+
+## Task 14: AdminNavTree entry
+
+**Files:**
+- Modify: `src/Humans.Web/ViewComponents/AdminNavTree.cs`
+
+- [ ] **Step 1: Add the nav item**
+
+In `src/Humans.Web/ViewComponents/AdminNavTree.cs`, find the `Diagnostics` group (around line 75). Add a new entry inside it, after `"Cache stats"`:
+
+```csharp
+            new("All users (debug)", "UsersAdminDebug", "Index", null, null, "fa-solid fa-bug-slash", PolicyNames.AdminOnly),
+```
+
+The full group with the new entry (for context, the unchanged lines are in place):
+
+```csharp
+        new("Diagnostics", new AdminNavItem[]
+        {
+            new("Logs",            "Admin", "Logs",          null, null, "fa-solid fa-triangle-exclamation", PolicyNames.AdminOnly),
+            new("DB stats",        "Admin", "DbStats",       null, null, "fa-solid fa-database",            PolicyNames.AdminOnly),
+            new("Cache stats",     "Admin", "CacheStats",    null, null, "fa-solid fa-bolt",                PolicyNames.AdminOnly),
+            new("All users (debug)", "UsersAdminDebug", "Index", null, null, "fa-solid fa-bug-slash", PolicyNames.AdminOnly),
+            new("Configuration",   "Admin", "Configuration", null, null, "fa-solid fa-gear",                PolicyNames.AdminOnly),
+            // ... rest unchanged
+```
+
+- [ ] **Step 2: Build**
+
+Run: `dotnet build Humans.slnx -v quiet`
+Expected: build succeeds.
+
+- [ ] **Step 3: Run tests**
+
+Run: `dotnet test Humans.slnx -v quiet`
+Expected: all tests pass.
+
+- [ ] **Step 4: Commit tasks 13 + 14**
+
+```bash
+git add src/Humans.Web/Views/UsersAdminDebug/Index.cshtml \
+        src/Humans.Web/ViewComponents/AdminNavTree.cs
+git commit -m "feat(users-debug): view + nav entry for /Users/Admin/Debug"
+git push
+```
+
+---
+
+## Task 15: `TicketDashboardViewModel` set-membership data
+
+**Files:**
+- Modify: `src/Humans.Web/Models/TicketViewModels.cs`
+
+- [ ] **Step 1: Replace the coverage + participation fields with set-membership data**
+
+In `src/Humans.Web/Models/TicketViewModels.cs`, in the `TicketDashboardViewModel` class:
+
+Remove these properties:
+
+```csharp
+    // Volunteer ticket coverage
+    public int TotalActiveVolunteers { get; set; }
+    public int VolunteersWithTickets { get; set; }
+    public decimal VolunteerCoveragePercent { get; set; }
+
+    // Participation breakdown
+    public int ParticipationNotAttending { get; set; }
+    public int ParticipationNoTicket { get; set; }
+    public int ParticipationHasTicket { get; set; }
+```
+
+Add this property:
+
+```csharp
+    // Set membership across UserInfo cache (Users, Profiles, Tickets).
+    // Used by the Venn + UpSet diagrams. Each user is bucketed into one of
+    // the four (HasProfile, HasTicket) combinations.
+    public UserSetMembership? SetMembership { get; set; }
+```
+
+Below the `TicketDashboardViewModel` class, add the new record:
+
+```csharp
+/// <summary>
+/// User-set bucketing for the Tickets dashboard Venn + UpSet diagrams.
+/// Users is the universe (every UserInfo); Profiles and Tickets are subsets.
+/// Each user falls into exactly one of the four buckets defined here.
+/// </summary>
+public sealed record UserSetMembership(
+    int UsersOnly,              // !HasProfile && !HasTicket
+    int UsersAndProfileOnly,    //  HasProfile && !HasTicket
+    int UsersAndTicketOnly,     // !HasProfile &&  HasTicket
+    int AllThree)               //  HasProfile &&  HasTicket
+{
+    public int TotalUsers => UsersOnly + UsersAndProfileOnly + UsersAndTicketOnly + AllThree;
+    public int ProfilesCount => UsersAndProfileOnly + AllThree;
+    public int TicketsCount => UsersAndTicketOnly + AllThree;
+}
+```
+
+- [ ] **Step 2: Build**
+
+Run: `dotnet build Humans.slnx -v quiet`
+Expected: errors in `TicketController.cs` and `Views/Ticket/Index.cshtml` (next tasks).
+
+- [ ] **Step 3: Do not commit alone** — bundle with Task 16 and 17.
+
+---
+
+## Task 16: `TicketController.Index` swap data source
+
+**Files:**
+- Modify: `src/Humans.Web/Controllers/TicketController.cs`
+
+- [ ] **Step 1: Replace coverage assignments with snapshot-based bucketing**
+
+In `src/Humans.Web/Controllers/TicketController.cs`, in `Index`:
+
+Remove these lines from the model initializer (around lines 126-128):
+
+```csharp
+            TotalActiveVolunteers = stats.TotalActiveVolunteers,
+            VolunteersWithTickets = stats.VolunteersWithTickets,
+            VolunteerCoveragePercent = stats.VolunteerCoveragePercent,
+```
+
+Remove the entire `// Participation breakdown for donut chart` try/catch block (lines 131–154).
+
+After the `var model = new TicketDashboardViewModel { ... };` declaration (and after the existing model assignments), add:
+
+```csharp
+        // Set membership across the UserInfo cache — drives the Venn + UpSet.
+        var snapshot = _userService.GetAllUserInfos();
+        var usersOnly = 0;
+        var profileOnly = 0;
+        var ticketOnly = 0;
+        var both = 0;
+        foreach (var u in snapshot)
+        {
+            var hasProfile = u.Profile is not null;
+            var hasTicket = u.HasTicket;
+            if (hasProfile && hasTicket) both++;
+            else if (hasProfile) profileOnly++;
+            else if (hasTicket) ticketOnly++;
+            else usersOnly++;
+        }
+        model.SetMembership = new UserSetMembership(usersOnly, profileOnly, ticketOnly, both);
+```
+
+(Note: this also removes the `_shiftMgmt.GetActiveAsync()` call and the `_userService.GetAllParticipationsForYearAsync` call. Both are obsolete here — the snapshot's `HasTicket` accessor encodes the predicate.)
+
+- [ ] **Step 2: Build**
+
+Run: `dotnet build Humans.slnx -v quiet`
+Expected: build succeeds (view template still uses old fields — fixed in next task).
+
+- [ ] **Step 3: Do not commit alone** — bundle with Task 17.
+
+---
+
+## Task 17: `/Tickets` view — remove old cards, add Venn + UpSet
+
+**Files:**
+- Modify: `src/Humans.Web/Views/Ticket/Index.cshtml`
+
+- [ ] **Step 1: Remove the old "Volunteer Ticket Coverage" card**
+
+In `src/Humans.Web/Views/Ticket/Index.cshtml`, delete lines 103–129 (the `<!-- Volunteer Ticket Coverage -->` block — from `@if (Model.TotalActiveVolunteers > 0)` through its closing `}`).
+
+- [ ] **Step 2: Replace the "Participation Breakdown" card with the Venn + UpSet panel**
+
+Delete the entire `<!-- Participation Breakdown -->` block (originally lines 131–168, indexes will shift after step 1). Insert in its place:
+
+```cshtml
+    <!-- User set membership — Venn (Profiles ∩ Tickets within Users) + UpSet -->
+    @if (Model.SetMembership is { TotalUsers: > 0 } sm)
+    {
+        <div class="card mb-4">
+            <div class="card-header">
+                <i class="fa-solid fa-chart-pie"></i> User set membership
+                <small class="text-muted">
+                    @sm.TotalUsers total users · @sm.ProfilesCount with profile · @sm.TicketsCount with ticket
+                </small>
+            </div>
+            <div class="card-body">
+                <div class="row">
+                    <div class="col-md-6">
+                        <h6 class="text-center">Proportional Venn</h6>
+                        <div id="userVenn"
+                             data-users="@sm.TotalUsers"
+                             data-profiles="@sm.ProfilesCount"
+                             data-tickets="@sm.TicketsCount"
+                             data-users-profiles="@sm.ProfilesCount"
+                             data-users-tickets="@sm.TicketsCount"
+                             data-profiles-tickets="@sm.AllThree"
+                             data-all-three="@sm.AllThree"
+                             style="max-height: 420px; width: 100%;"></div>
+                    </div>
+                    <div class="col-md-6">
+                        <h6 class="text-center">UpSet plot</h6>
+                        <div id="userUpset"
+                             data-users-only="@sm.UsersOnly"
+                             data-profile-only="@sm.UsersAndProfileOnly"
+                             data-ticket-only="@sm.UsersAndTicketOnly"
+                             data-all-three="@sm.AllThree"
+                             style="max-height: 420px; width: 100%;"></div>
+                    </div>
+                </div>
+                <p class="text-muted small mt-2 mb-0">
+                    Users is the universe — every cached user is in it. Profiles ⊆ Users, Tickets ⊆ Users.
+                </p>
+            </div>
+        </div>
+        @* TODO: extend to Shifts set when IShiftManager caching lands (see 2026-05-14 spec). *@
+    }
+```
+
+- [ ] **Step 3: Remove participation Chart.js block from the script section**
+
+Find the `<script>` block at the bottom of the file (around line 372). Remove the `@if (participationTotal > 0)` block entirely (around lines 418–439 — the `<text> ... var partCtx ... </text>` block).
+
+The outer `@if (Model.DailySales.Count > 0 || participationTotal > 0)` script-tag predicate becomes just `@if (Model.DailySales.Count > 0)` since `participationTotal` no longer exists. Update accordingly. Also remove the `@{ var participationTotal = ...; }` block higher in the file (around lines 132–134).
+
+- [ ] **Step 4: Add Venn + UpSet rendering scripts at the bottom of the page**
+
+After the existing `</script>` block, add:
+
+```cshtml
+@if (Model.SetMembership is not null && Model.SetMembership.TotalUsers > 0)
+{
+    <script src="https://cdn.jsdelivr.net/npm/@@upsetjs/venn.js@1.4.4/build/venn.min.js" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@@upsetjs/bundle@1.13.1/build/upset.min.js" crossorigin="anonymous"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            // ---- Venn: 3 sets (Users / Profiles / Tickets) ----
+            var venn = document.getElementById('userVenn');
+            if (venn && window.venn) {
+                var d = venn.dataset;
+                var sets = [
+                    { sets: ['Users'], size: +d.users, label: 'Users (' + d.users + ')' },
+                    { sets: ['Profiles'], size: +d.profiles, label: 'Profiles (' + d.profiles + ')' },
+                    { sets: ['Tickets'], size: +d.tickets, label: 'Tickets (' + d.tickets + ')' },
+                    { sets: ['Users', 'Profiles'], size: +d.usersProfiles },
+                    { sets: ['Users', 'Tickets'], size: +d.usersTickets },
+                    { sets: ['Profiles', 'Tickets'], size: +d.profilesTickets },
+                    { sets: ['Users', 'Profiles', 'Tickets'], size: +d.allThree }
+                ];
+                var chart = window.venn.VennDiagram().width(400).height(360);
+                d3.select('#userVenn').datum(sets).call(chart);
+            }
+
+            // ---- UpSet: same 3 sets, intersection bar chart ----
+            var upset = document.getElementById('userUpset');
+            if (upset && window.UpSetJS) {
+                var u = upset.dataset;
+                var usersOnly = +u.usersOnly;
+                var profileOnly = +u.profileOnly;
+                var ticketOnly = +u.ticketOnly;
+                var allThree = +u.allThree;
+                var elems = [];
+                for (var i = 0; i < usersOnly; i++)    elems.push({ name: 'u' + i, sets: ['Users'] });
+                for (var i = 0; i < profileOnly; i++)  elems.push({ name: 'p' + i, sets: ['Users', 'Profiles'] });
+                for (var i = 0; i < ticketOnly; i++)   elems.push({ name: 't' + i, sets: ['Users', 'Tickets'] });
+                for (var i = 0; i < allThree; i++)     elems.push({ name: 'a' + i, sets: ['Users', 'Profiles', 'Tickets'] });
+                var sets = window.UpSetJS.extractSets(elems);
+                var combinations = window.UpSetJS.generateCombinations(sets);
+                window.UpSetJS.render(upset, {
+                    sets: sets,
+                    combinations: combinations,
+                    width: 400,
+                    height: 360
+                });
+            }
+        });
+    </script>
+}
+```
+
+Note the `@@upsetjs` — Razor `@` escaping: `@@` emits a literal `@`.
+
+- [ ] **Step 5: Verify the venn.js + upset.js library URLs**
+
+Run: `curl -I https://cdn.jsdelivr.net/npm/@upsetjs/venn.js@1.4.4/build/venn.min.js`
+Expected: HTTP 200.
+
+Run: `curl -I https://cdn.jsdelivr.net/npm/@upsetjs/bundle@1.13.1/build/upset.min.js`
+Expected: HTTP 200.
+
+If either URL returns 404, look up the correct latest version on jsdelivr (the package names are correct; only the version may have changed). Update the URLs in the view accordingly.
+
+- [ ] **Step 6: Build**
+
+Run: `dotnet build Humans.slnx -v quiet`
+Expected: build succeeds.
+
+- [ ] **Step 7: Run tests**
+
+Run: `dotnet test Humans.slnx -v quiet`
+Expected: all tests pass.
+
+- [ ] **Step 8: Commit tasks 15–17 together**
+
+```bash
+git add src/Humans.Web/Models/TicketViewModels.cs \
+        src/Humans.Web/Controllers/TicketController.cs \
+        src/Humans.Web/Views/Ticket/Index.cshtml
+git commit -m "feat(tickets): replace coverage card + donut with Venn + UpSet"
+```
+
+---
+
+## Task 18: Smoke + final verification
+
+**Files:** (none modified, manual verification only)
+
+- [ ] **Step 1: Full build**
+
+Run: `dotnet build Humans.slnx -v quiet`
+Expected: build succeeds, zero warnings related to this work.
+
+- [ ] **Step 2: Full test suite**
+
+Run: `dotnet test Humans.slnx -v quiet`
+Expected: every test passes.
+
+- [ ] **Step 3: Launch the app and visually verify**
+
+Run: `dotnet run --project src/Humans.Web`
+
+Open `https://localhost:<port>/Admin` (admin user). Verify:
+- Three new stat cards: Total users, Active (has profile), Ticket holders. No "Active humans 979" card.
+- Existing Shifts staffed, Open feedback, tier app totals, language chart all still present.
+
+Open `https://localhost:<port>/Users/Admin/Debug`. Verify:
+- Table renders all cached users.
+- Pager works, sort headers toggle correctly, Marketing tri-state displays "Yes" / "No" / "—".
+- Page subtitle shows the correct total count.
+
+Open `https://localhost:<port>/Tickets`. Verify:
+- "Volunteer Ticket Coverage" card is GONE.
+- "Participation Breakdown" donut is GONE.
+- A new "User set membership" card shows a 3-set Venn (left) and UpSet (right), both bounded in height.
+- Daily sales chart still renders.
+
+Open the admin sidebar — "All users (debug)" link is under the Diagnostics group, with the bug-slash icon.
+
+If anything looks wrong, fix and re-verify. UI feature correctness can't be guaranteed by tests alone (per CLAUDE.md).
+
+- [ ] **Step 4: Final push**
+
+```bash
+git push
+```
+
+- [ ] **Step 5: Open the PR**
+
+Use the GitHub CLI to open the PR against peter's fork:
+
+```bash
+gh pr create --title "feat(admin/users/tickets): UserInfo-driven stats, debug page, Venn" \
+  --body "$(cat <<'EOF'
+## Summary
+- Replaces `/Admin` "Active humans 979" with three UserInfo-snapshot cards: Total users / Active (has profile) / Ticket holders.
+- Adds `/Users/Admin/Debug` flat paginated/sortable table — every column from the cached `UserInfo`, no secondary queries.
+- Replaces `/Tickets` coverage card + unbounded donut with a 3-set Venn (Users / Profiles / Tickets) + UpSet plot, both height-bounded.
+- Extends `UserInfo` with `CommunicationPreferences` so Marketing opt-in lives on the cached god-object.
+
+Spec: `docs/superpowers/specs/2026-05-14-userinfo-debug-and-venn-design.md`
+
+## Test plan
+- [ ] Build is clean: `dotnet build Humans.slnx -v quiet`
+- [ ] Tests pass: `dotnet test Humans.slnx -v quiet`
+- [ ] `/Admin` dashboard shows three new cards, no "Active humans"
+- [ ] `/Users/Admin/Debug` lists all cached users with paging + sorting
+- [ ] `/Tickets` shows Venn + UpSet, old cards gone, donut gone
+- [ ] Admin nav has "All users (debug)" under Diagnostics
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-review checklist (after plan written)
+
+- [x] **Spec coverage** — every spec section maps to a task:
+  - §1 UserInfo extension → Task 1 + Task 2
+  - §2 Cache wiring → Task 4 + Task 5 + Task 6
+  - §3 Invalidation → Task 7
+  - §4 `/Admin` dashboard → Task 8 + Task 9 + Task 10
+  - §5 `/Users/Admin/Debug` → Task 11 + Task 12 + Task 13 + Task 14
+  - §6 `/Tickets` → Task 15 + Task 16 + Task 17
+  - Repository support → Task 3
+  - Final smoke → Task 18
+- [x] **Placeholder scan** — no "TBD" / "later" / "appropriate" / unreferenced types. Each step is concrete code or a concrete command.
+- [x] **Type consistency** — `UserInfo.HasTicket`, `UserInfo.MarketingOptedOut`, `IUserService.GetAllUserInfos()`, `UserSetMembership`, `UsersDebugViewModel`, `UserDebugRow` — same names used consistently across the tasks that consume them.

--- a/docs/superpowers/specs/2026-05-14-userinfo-debug-and-venn-design.md
+++ b/docs/superpowers/specs/2026-05-14-userinfo-debug-and-venn-design.md
@@ -1,0 +1,278 @@
+# UserInfo-driven admin stats, debug table, and ticket Venn
+
+**Date:** 2026-05-14
+**Branch:** `feat/userinfo-debug-and-venn`
+**Sections:** Users (Admin), Admin (dashboard), Tickets
+
+## Problem
+
+Recent imports (mailing list subscribers, ticket attendees) inflated the user table to ~3k rows. The existing `/Admin` dashboard shows "Active humans 979" sourced from `IProfileService.GetActiveApprovedUserIdsAsync()` (approved-and-not-suspended profiles). The number is technically correct but misleading next to the now-much-larger user count, and the dashboard has no signal of how many of the imported users actually became real members.
+
+The `/Tickets` page has two cards that partition the same population (Volunteer Ticket Coverage + Participation Breakdown donut) and the donut isn't size-bounded.
+
+There is no admin-visible way to spot-check the `UserInfo` cache — the unified read-model that should be the single source of truth for "everything about a person".
+
+## Goals
+
+1. **`/Admin` dashboard:** show Total Users, Active (has profile), Ticket Holders. Drop the existing "Active humans 979" card.
+2. **`/Users/Admin/Debug`:** flat paginated/sortable table of all users, every column derived from `UserInfo`, no fallback queries.
+3. **`/Tickets`:** replace the redundant coverage card + unbounded donut with a 3-set proportional Venn (Users / Profiles / Tickets) and an UpSet plot of the same sets, side-by-side.
+4. **`UserInfo` extension:** carry communication preferences on the cached god-object so the debug page (and future consumers) can see Marketing opt-in without secondary queries.
+
+## Non-goals
+
+- HasShift column on the debug page. `IShiftManager` isn't cached today; pausing until it is. Tracked as a follow-up.
+- Shifts set in the Venn / UpSet. Same reason.
+- Filtering / search on the debug page. Pure flat table for this iteration.
+- Retiring `IProfileService.GetActiveApprovedUserIdsAsync()`. Other call sites likely depend on it; out of scope.
+
+## Architecture
+
+All three deliverables read from a single source: `IUserService.GetAllUserInfos()`, a new method that returns an in-memory snapshot of the `UserInfo` cache held inside `CachingUserService`. No new repository queries are added on the read path. The existing cache invalidation pipeline (the `CachingUserService` write decorator + `UserInfoSaveChangesInterceptor`) is extended to cover the new contributing table (`communication_preferences`).
+
+### Layer changes
+
+| Layer | Change |
+|---|---|
+| Domain | (none) |
+| Application | `UserInfo` record gains `CommunicationPreferences` field; new `CommunicationPreferenceInfo` record. `UserInfo.Create()` accepts the new input. `IUserService` interface gains `GetAllUserInfos()`. |
+| Infrastructure | `CachingUserService` exposes the snapshot, injects `ICommunicationPreferenceRepository`, extends `WarmAllAsync` and `RefreshEntryAsync`. `UserInfoSaveChangesInterceptor` adds a `CommunicationPreference` case. |
+| Web | New `UsersAdminDebugController`. `AdminController.Index` swaps its stat sources. `TicketController` swaps its dashboard charts. New nav entry in `AdminNavTree`. |
+
+## Detailed design
+
+### 1. `UserInfo` extension — communication preferences
+
+Add to `UserInfo`:
+
+```csharp
+IReadOnlyList<CommunicationPreferenceInfo> CommunicationPreferences
+```
+
+New projection record (in `src/Humans.Application/UserInfo.cs` alongside the other `*Info` records):
+
+```csharp
+public sealed record CommunicationPreferenceInfo(
+    Guid Id,
+    MessageCategory Category,
+    bool OptedOut,
+    bool InboxEnabled,
+    Instant UpdatedAt,
+    Instant? SubscribedAt);
+```
+
+`UserInfo.Create()` gains an `IReadOnlyList<CommunicationPreference> communicationPreferences` parameter. Projection mirrors the existing pattern (order by `Category`, project each row).
+
+Derived accessor on `UserInfo` for the Marketing-specific tri-state:
+
+```csharp
+public bool? MarketingOptedOut =>
+    CommunicationPreferences
+        .Where(c => c.Category == MessageCategory.Marketing)
+        .Select(c => (bool?)c.OptedOut)
+        .FirstOrDefault();
+```
+
+`null` → no row exists for the Marketing category. Tri-state semantics:
+- `null` → "—" (e.g., imported user who never hit the prefs flow)
+- `true` → "No" (OptedOut)
+- `false` → "Yes" (subscribed)
+
+### 2. Cache wiring — `CachingUserService`
+
+Add a snapshot accessor on `IUserService`:
+
+```csharp
+IReadOnlyCollection<UserInfo> GetAllUserInfos();
+```
+
+Implementation in `CachingUserService`:
+
+```csharp
+public IReadOnlyCollection<UserInfo> GetAllUserInfos() => _byUserId.Values.ToArray();
+```
+
+`.ToArray()` is a O(N) snapshot — the dict is mutable, so we hand back a stable copy. At 3k users this is allocation-cheap.
+
+Inject `ICommunicationPreferenceRepository`. Both `WarmAllAsync` and `RefreshEntryAsync` are extended:
+
+- `WarmAllAsync`: bulk-load all preferences via a new `ICommunicationPreferenceRepository.GetAllAsync(ct)` (already exists or added if missing), group by `UserId`, look up per-user in the loop.
+- `RefreshEntryAsync`: per-user `ICommunicationPreferenceRepository.GetByUserIdReadOnlyAsync(userId, ct)`.
+
+Inner `IUserService.GetUserInfoAsync` (the non-cached path) also needs to load preferences. The caching decorator and the inner service both must pass the same data into `UserInfo.Create()`.
+
+### 3. Invalidation — `UserInfoSaveChangesInterceptor`
+
+Add a case to the entity switch:
+
+```csharp
+case CommunicationPreference cp:
+    affected.Add(cp.UserId);
+    break;
+```
+
+No category filter — any preference write triggers a refresh. The whole `CommunicationPreferences` collection on `UserInfo` is being rebuilt anyway.
+
+Update the XML doc on `UserInfoSaveChangesInterceptor` to list `communication_preferences` in the covered-tables list.
+
+### 4. `/Admin` dashboard stats
+
+In `AdminController.Index`, replace the three current calls that feed the dashboard stat row:
+
+| Before | After |
+|---|---|
+| `_profileService.GetActiveApprovedUserIdsAsync()` → "Active humans" | _removed_ |
+| (no equivalent) | `snapshot.Count` → "Total users" |
+| (no equivalent) | `snapshot.Count(u => u.Profile != null)` → "Active (has profile)" |
+| (no equivalent) | `snapshot.Count(u => u.EventParticipations.Any(HasTicketPredicate))` → "Ticket holders" |
+
+`snapshot` = `_userService.GetAllUserInfos()` taken once at the top of the action.
+
+`HasTicketPredicate` — a single predicate defined alongside `UserInfo` (likely as a `UserInfo` extension method or instance accessor `HasTicket`) so the same definition is used by the dashboard, the debug table, and the tickets page. The predicate matches what the existing `TicketController` uses for `VolunteerCoveragePercent` / `ParticipationHasTicket` — exact form to be confirmed when wiring (the implementation step reads `TicketController` and the participation-projection helpers, then promotes the predicate to a shared `UserInfo.HasTicket` instance accessor).
+
+`AdminDashboardViewModel` gains `TotalUsers`, `ActiveProfileUsers`, `TicketHolders`. `_DashboardStats.cshtml` renders the three cards in place of the removed "Active humans" card. "Shifts staffed" and "Open feedback" cards untouched.
+
+### 5. `/Users/Admin/Debug` page
+
+**Controller:** `src/Humans.Web/Controllers/Users/UsersAdminDebugController.cs`
+
+```csharp
+[Authorize(Policy = PolicyNames.AdminOnly)]
+[Route("Users/Admin/Debug")]
+public sealed class UsersAdminDebugController : Controller
+{
+    private readonly IUserService _userService;
+
+    public UsersAdminDebugController(IUserService userService) => _userService = userService;
+
+    [HttpGet("")]
+    public IActionResult Index(int page = 1, int pageSize = 50, string sort = "displayName", string dir = "asc")
+    {
+        var snapshot = _userService.GetAllUserInfos();
+        var rows = snapshot.Select(UserDebugRow.From).ToList();
+        var sorted = ApplySort(rows, sort, dir);
+        var paged = sorted.Skip((page - 1) * pageSize).Take(pageSize).ToList();
+        return View(new UsersDebugViewModel(paged, sorted.Count, page, pageSize, sort, dir));
+    }
+}
+```
+
+(Exact location under `Controllers/` follows the existing convention — `Controllers/Users/` if that subdir exists, otherwise `Controllers/`. The implementation step picks the right home based on the repo state at that moment.)
+
+**Row projection:** `UserDebugRow` is a small view-model record built from a `UserInfo`. Each column maps to one expression on the cached object:
+
+| Column | Expression on `UserInfo` |
+|---|---|
+| UserId | `Id` |
+| HasProfile | `Profile != null` |
+| HasTicket | `HasTicket` (shared accessor — see §4) |
+| Marketing | `MarketingOptedOut` |
+| Display name | `DisplayName` |
+| Burner name | `Profile?.BurnerName ?? ""` |
+| Legal name | `Profile?.FullName ?? ""` |
+| HasConsent | `Profile == null ? (bool?)null : Profile.ConsentCheckStatus == ConsentCheckStatus.Cleared` |
+
+**Sorting:** server-side over the in-memory snapshot. `ApplySort` switches on the `sort` query param. Nullable booleans sort `null < false < true` (i.e., "—" first ascending). Strings use `StringComparer.OrdinalIgnoreCase`.
+
+**Paging:** server-side `Skip`/`Take`. `pageSize` clamped to `[10, 200]`. Page count = `ceil(total / pageSize)`.
+
+**View:** `src/Humans.Web/Views/UsersAdminDebug/Index.cshtml`. Match the look of an existing admin table — likely the closest precedent is `Views/AdminMergeRequests/Index.cshtml` or `Views/AdminDuplicateAccounts/Index.cshtml`. Header cells are links that toggle `sort`/`dir`. Pager at the bottom.
+
+**Nav:** add to `AdminNavTree.Groups` under a "Diagnostics" or similar grouping. New entry:
+
+```csharp
+new("All users (debug)", "UsersAdminDebug", "Index", null, null, "fa-solid fa-bug", PolicyNames.AdminOnly)
+```
+
+### 6. `/Tickets` page — Venn + UpSet
+
+**Remove:**
+- "Volunteer Ticket Coverage" card (`Views/Ticket/Index.cshtml` lines ~104–129).
+- "Participation Breakdown" donut card (lines ~131–168) and its Chart.js initialization in the page-script block.
+
+**Add:** a single full-width card with two side-by-side panels:
+- Left: 3-set proportional Venn — sets are **Users**, **Profiles**, **Tickets**.
+- Right: UpSet plot — same three sets.
+
+Both panels in containers with `max-height: 420px; width: 100%` so the layout stops blowing out. Caption beneath: `N total users · M with profile · K with ticket`.
+
+**Data:** computed once in `TicketController` (or whichever action renders `Views/Ticket/Index.cshtml`) from `_userService.GetAllUserInfos()`. Bucket each user into the 4 combinations of `(HasProfile, HasTicket)`:
+
+| HasProfile | HasTicket | Bucket name |
+|---|---|---|
+| false | false | usersOnly |
+| true | false | usersAndProfileOnly |
+| false | true | usersAndTicketOnly |
+| true | true | all three |
+
+Set sizes derive trivially:
+- |Users| = total count
+- |Profiles| = usersAndProfileOnly + allThree
+- |Tickets| = usersAndTicketOnly + allThree
+- |Users ∩ Profiles| = same as |Profiles| (Profiles ⊆ Users)
+- |Users ∩ Tickets| = same as |Tickets| (Tickets ⊆ Users)
+- |Profiles ∩ Tickets| = allThree
+- |all three| = allThree
+
+`TicketDashboardViewModel` gains a `SetMembership` property carrying these counts. The view emits them as `data-*` attributes on the chart containers; the script reads them and feeds the libraries.
+
+**Libraries:**
+- `@upsetjs/venn.js` (maintained fork of Ben Frederickson's `venn.js`, MIT, ~12 KB) for the proportional Venn.
+- `@upsetjs/bundle` (vanilla wrapper around `@upsetjs/react`, MIT) for the UpSet plot.
+
+Both vendored as static asset references in `_Layout` or the page-script block — match how Chart.js is currently included (`Views/Ticket/Index.cshtml` line ~374). No npm pipeline added; CDN reference with integrity hash, or self-hosted under `wwwroot/lib/`.
+
+**TODO comments** in both the controller and the view: when `IShiftManager` caching lands, extend the bucketing to `(HasProfile, HasTicket, HasShift)`, refresh the diagrams to 4 sets, and update this spec / open follow-up issue link.
+
+## Data flow
+
+```
+SaveChanges on contributing tables
+  → UserInfoSaveChangesInterceptor.SavingChangesAsync (collects affected userIds)
+  → SaveChanges commits
+  → SavedChangesAsync → IUserInfoInvalidator.InvalidateAsync(userId)
+  → CachingUserService.RefreshEntryAsync(userId) rebuilds the cache entry
+       (now also loads communication_preferences)
+
+Reads (dashboard / debug page / tickets page):
+  Controller
+    → IUserService.GetAllUserInfos()  // snapshot of in-memory dict
+    → in-memory LINQ for stats, sort, page, set-membership bucketing
+    → view
+```
+
+No request-path query against `users`, `profiles`, `event_participations`, `communication_preferences`. If a field is missing from `UserInfo`, the fix is on `UserInfo`, not on the consumer.
+
+## Testing
+
+- **Unit tests** for the new accessors:
+  - `UserInfo.MarketingOptedOut` returns null / true / false for the three cases.
+  - `UserInfo.HasTicket` matches the predicate used by the existing tickets dashboard (snapshot the existing definition in a test so any drift is caught).
+- **Integration test** (existing repository test harness):
+  - `CommunicationPreference` write fires `IUserInfoInvalidator.InvalidateAsync` and the next `GetUserInfoAsync` shows the updated value.
+- **Controller tests** for `UsersAdminDebugController`:
+  - returns admin-policy 403 for non-admin.
+  - empty cache → empty rows, total 0, page 1.
+  - sorts respect tri-state null-first semantics.
+  - paging clamps `pageSize` outside `[10, 200]`.
+- **Smoke test** of `/Tickets` after change: page renders, both panels visible, containers stay within the page width.
+
+## Open questions
+
+1. **`HasTicket` predicate definition.** The existing `TicketController` uses some combination of `ParticipationStatus` and possibly `ParticipationSource`. The implementation step reads that code, picks the exact predicate, promotes it to a shared `UserInfo.HasTicket` accessor, and snapshot-tests it. Recording the choice in an inline comment on the accessor.
+2. **`AdminNavTree` grouping for the debug page.** A "Diagnostics" group may not exist yet. If not, this work adds it (or slots under an existing close-enough group like "System").
+
+Neither is a blocker — both are implementation-time decisions.
+
+## Out-of-scope follow-ups
+
+- `IShiftManager` caching → enables `HasShift` column on the debug page and Shifts set on the diagrams. Likely a separate spec; this one notes the TODOs.
+- Retiring `IProfileService.GetActiveApprovedUserIdsAsync()` from any other dashboards that show "approved" counts. Out of scope until a consumer audit happens.
+
+## Acceptance criteria
+
+- `/Admin` shows three new cards (Total users, Active (has profile), Ticket holders) sourced from the in-memory `UserInfo` snapshot. The "Active humans 979" card is gone.
+- `/Users/Admin/Debug` is reachable from the admin nav, lists all users in a paginated/sortable table with the eight specified columns, and produces every cell from `UserInfo` without secondary queries.
+- `/Tickets` no longer shows the "Volunteer Ticket Coverage" card or the unbounded donut; it shows a 3-set Venn and an UpSet plot side-by-side, both bounded in height.
+- A write to `communication_preferences` for any user invalidates that user's `UserInfo` entry and the next read reflects the change.
+- All build, all tests pass.

--- a/memory/product/humans-terminology.md
+++ b/memory/product/humans-terminology.md
@@ -1,17 +1,20 @@
 ---
 name: UI terminology — "humans", not "members" or "volunteers"
-description: All user-facing text uses "humans" — never "members", "volunteers", or "users". Branded org terminology. Applies across all locales (the word stays in English in es/de/fr/it). Internal code unaffected.
+description: Public-facing text uses "humans" — never "members" or "volunteers". Admin screens may say "users" when literally referring to the users table / IUserService. Branded org terminology. Applies across all locales (the word stays in English in es/de/fr/it). Internal code unaffected.
 ---
 
-In all user-facing text (views, localization strings, emails), use **"humans"** — not "members", "volunteers", or "users". This is the org's branded terminology.
+In **public-facing** text (views non-admin members see, localization strings, emails to humans, public copy), use **"humans"** — not "members" or "volunteers". This is the org's branded terminology.
 
 It applies across all locales (the word "humans" is kept in English even in es/de/fr/it translations). Internal code (entity names, variable names) is unaffected.
 
-**Why:** Branding decision by Nobodies Collective. The word "humans" carries the org's identity; "members" and "volunteers" sound generic and miss the framing.
+**"Users" is allowed on admin/diagnostic screens** when it specifically refers to the `users` DB table or `IUserService` cache — e.g., admin dashboard stat tiles ("Total users", "Active (has profile)"), debug surfaces (`/Users/Admin/Debug`), nav labels for admin-only tools. Admins benefit from the precise distinction between "row in the users table" (~3 k, includes imported contacts) and "human with a complete profile" (~979). Don't extend this carve-out to anything a non-admin sees.
+
+**Why:** Branding decision by Nobodies Collective. The word "humans" carries the org's identity; "members" and "volunteers" sound generic and miss the framing. "Users" is technically accurate vocabulary that's useful when an admin needs to talk about the underlying account/table state.
 
 **How to apply:**
 
-- Razor views, localization resources, emails, release notes, Discord posts, public-facing copy — use "humans" (capitalize per sentence position).
+- Public Razor views, localization resources, emails, release notes, Discord posts — use "humans" (capitalize per sentence position).
+- Admin Razor views, admin nav labels, admin-only diagnostics — "users" is fine when it refers to the users table / IUserService specifically. "Humans" is still the preferred word for member-shaped concepts on admin screens.
 - Even in es/de/fr/it `.resx` files, "humans" stays in English; don't translate to "miembros", "freiwillige", etc.
 - Internal code (`User`, `IUserService`, `humans` table — wait, the table IS named for users; entity is `User`) is fine as-is.
 - "Volunteer" is OK only when specifically referring to the **Volunteer** role/team (the Spanish `Volunteers` team, the volunteer-vs-Colaborador-vs-Asociado tier distinction).

--- a/src/Humans.Application/Interfaces/Repositories/ICommunicationPreferenceRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/ICommunicationPreferenceRepository.cs
@@ -48,6 +48,13 @@ public interface ICommunicationPreferenceRepository : IRepository
         Guid userId, CancellationToken ct = default);
 
     /// <summary>
+    /// Returns every <c>communication_preferences</c> row, read-only. Used by
+    /// the <see cref="UserInfo"/> cache warm path to bulk-load preferences
+    /// once at startup.
+    /// </summary>
+    Task<IReadOnlyList<CommunicationPreference>> GetAllAsync(CancellationToken ct = default);
+
+    /// <summary>
     /// Returns the count of preferences matching the given category and opt-out state.
     /// Used for dashboard metrics.
     /// </summary>

--- a/src/Humans.Application/Interfaces/Users/IUserService.cs
+++ b/src/Humans.Application/Interfaces/Users/IUserService.cs
@@ -13,6 +13,7 @@ namespace Humans.Application.Interfaces.Users;
 /// <remarks>
 /// Surface-budget recent history (newest first):
 /// <list type="bullet">
+///   <item>32→33 — admin stats + /Users/Admin/Debug + /Tickets Venn: added GetAllUserInfos. Snapshot accessor — the cache is the canonical read-model; all aggregate consumers read from it rather than re-querying the underlying tables.</item>
 ///   <item>32→31 — mailer-inbound-import follow-up: removed GetDisplayNamesByIdsAsync. HumanViewComponent already renders the cached DisplayName from a userId Guid; pre-fetching the dictionary was redundant.</item>
 ///   <item>33→32 — merge with main: issue-695 HUM0009 service-DbContext analyzer PR landed on main with net -1 (removed two [Obsolete] Google-email methods TrySetGoogleEmailAsync + SetGoogleEmailAsync; added DeleteUsersAsync for admin dev-reset).</item>
 ///   <item>32→33 — mailer-inbound-import: added GetDisplayNamesByIdsAsync for import preview — batch DisplayName lookup keyed by user id.</item>
@@ -26,7 +27,7 @@ namespace Humans.Application.Interfaces.Users;
 ///   <item>-1 GetContactUsersAsync removed (/Contacts surface deleted in PR 2 of email-identity-decoupling — only ContactService called it).</item>
 /// </list>
 /// </remarks>
-[SurfaceBudget(32)]
+[SurfaceBudget(33)]
 public interface IUserService : IApplicationService, IUserMerge
 {
     /// <summary>
@@ -39,6 +40,16 @@ public interface IUserService : IApplicationService, IUserMerge
     /// repositories on miss.
     /// </summary>
     ValueTask<UserInfo?> GetUserInfoAsync(Guid userId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns a snapshot of every cached <see cref="UserInfo"/>. The cache is
+    /// the canonical "everything-about-a-person" source; admin stat tiles,
+    /// debug surfaces, and cross-section aggregates read from this snapshot
+    /// rather than re-querying the contributing tables. Returns a new
+    /// collection per call — the underlying dictionary is mutable and callers
+    /// iterate without locking.
+    /// </summary>
+    IReadOnlyCollection<UserInfo> GetAllUserInfos();
 
     /// <summary>
     /// Fetches a single user by id. Returns null if the user does not exist.

--- a/src/Humans.Application/Services/Users/UserService.cs
+++ b/src/Humans.Application/Services/Users/UserService.cs
@@ -106,6 +106,12 @@ public sealed class UserService : IUserService, IUserDataContributor, IUserMerge
             communicationPreferences);
     }
 
+    public IReadOnlyCollection<UserInfo> GetAllUserInfos() =>
+        throw new NotSupportedException(
+            "GetAllUserInfos is only meaningful through CachingUserService. " +
+            "If this is being called on the inner UserService it indicates a DI " +
+            "registration mistake — IUserService should resolve to CachingUserService.");
+
     public Task<User?> GetByIdAsync(Guid userId, CancellationToken ct = default) =>
         _repo.GetByIdAsync(userId, ct);
 

--- a/src/Humans.Application/Services/Users/UserService.cs
+++ b/src/Humans.Application/Services/Users/UserService.cs
@@ -96,7 +96,8 @@ public sealed class UserService : IUserService, IUserDataContributor, IUserMerge
 
         return UserInfo.Create(
             user, userEmails, participations, externalLogins,
-            profile, contactFields, languages, volunteerHistory);
+            profile, contactFields, languages, volunteerHistory,
+            Array.Empty<CommunicationPreference>());
     }
 
     public Task<User?> GetByIdAsync(Guid userId, CancellationToken ct = default) =>

--- a/src/Humans.Application/Services/Users/UserService.cs
+++ b/src/Humans.Application/Services/Users/UserService.cs
@@ -46,12 +46,14 @@ public sealed class UserService : IUserService, IUserDataContributor, IUserMerge
     private readonly IUserEmailRepository _userEmailRepo;
     private readonly IProfileRepository _profileRepo;
     private readonly IContactFieldRepository _contactFieldRepo;
+    private readonly ICommunicationPreferenceRepository _communicationPreferenceRepo;
 
     public UserService(
         IUserRepository repo,
         IUserEmailRepository userEmailRepo,
         IProfileRepository profileRepo,
         IContactFieldRepository contactFieldRepo,
+        ICommunicationPreferenceRepository communicationPreferenceRepo,
         IFullProfileInvalidator fullProfileInvalidator,
         IAdminAuthorizationService adminAuthorization,
         IClock clock,
@@ -61,6 +63,7 @@ public sealed class UserService : IUserService, IUserDataContributor, IUserMerge
         _userEmailRepo = userEmailRepo;
         _profileRepo = profileRepo;
         _contactFieldRepo = contactFieldRepo;
+        _communicationPreferenceRepo = communicationPreferenceRepo;
         _fullProfileInvalidator = fullProfileInvalidator;
         _adminAuthorization = adminAuthorization;
         _clock = clock;
@@ -94,10 +97,13 @@ public sealed class UserService : IUserService, IUserDataContributor, IUserMerge
             volunteerHistory = profile.VolunteerHistory.ToList();
         }
 
+        var communicationPreferences = await _communicationPreferenceRepo
+            .GetByUserIdReadOnlyAsync(userId, ct);
+
         return UserInfo.Create(
             user, userEmails, participations, externalLogins,
             profile, contactFields, languages, volunteerHistory,
-            Array.Empty<CommunicationPreference>());
+            communicationPreferences);
     }
 
     public Task<User?> GetByIdAsync(Guid userId, CancellationToken ct = default) =>

--- a/src/Humans.Application/UserInfo.cs
+++ b/src/Humans.Application/UserInfo.cs
@@ -48,6 +48,18 @@ public sealed record VolunteerHistoryInfo(
     string? Description);
 
 /// <summary>
+/// Compact projection of a <see cref="CommunicationPreference"/> row.
+/// </summary>
+public sealed record CommunicationPreferenceInfo(
+    Guid Id,
+    MessageCategory Category,
+    bool OptedOut,
+    bool InboxEnabled,
+    Instant UpdatedAt,
+    string UpdateSource,
+    Instant? SubscribedAt);
+
+/// <summary>
 /// Compact projection of an <see cref="EventParticipation"/> row.
 /// </summary>
 public sealed record EventParticipationInfo(
@@ -177,7 +189,8 @@ public sealed record UserInfo(
     IReadOnlyList<UserEmailInfo> UserEmails,
     IReadOnlyList<EventParticipationInfo> EventParticipations,
     IReadOnlyList<UserExternalLoginInfo> ExternalLogins,
-    ProfileInfo? Profile)
+    ProfileInfo? Profile,
+    IReadOnlyList<CommunicationPreferenceInfo> CommunicationPreferences)
 {
     /// <summary>
     /// Canonical effective email — first verified UserEmail (primary-preferred),
@@ -252,7 +265,8 @@ public sealed record UserInfo(
         Profile? profile,
         IReadOnlyList<ContactField> contactFields,
         IReadOnlyList<ProfileLanguage> profileLanguages,
-        IReadOnlyList<VolunteerHistoryEntry> volunteerHistory)
+        IReadOnlyList<VolunteerHistoryEntry> volunteerHistory,
+        IReadOnlyList<CommunicationPreference> communicationPreferences)
     {
         var userEmailInfos = userEmails
             .OrderByDescending(e => e.IsPrimary)
@@ -333,6 +347,13 @@ public sealed record UserInfo(
                 VolunteerHistory: volunteerHistoryInfos);
         }
 
+        var communicationPreferenceInfos = communicationPreferences
+            .OrderBy(c => c.Category)
+            .Select(c => new CommunicationPreferenceInfo(
+                c.Id, c.Category, c.OptedOut, c.InboxEnabled,
+                c.UpdatedAt, c.UpdateSource, c.SubscribedAt))
+            .ToList();
+
         return new UserInfo(
             Id: user.Id,
             DisplayName: user.DisplayName,
@@ -357,6 +378,7 @@ public sealed record UserInfo(
             UserEmails: userEmailInfos,
             EventParticipations: participationInfos,
             ExternalLogins: loginInfos,
-            Profile: profileInfo);
+            Profile: profileInfo,
+            CommunicationPreferences: communicationPreferenceInfos);
     }
 }

--- a/src/Humans.Application/UserInfo.cs
+++ b/src/Humans.Application/UserInfo.cs
@@ -263,16 +263,30 @@ public sealed record UserInfo(
         .FirstOrDefault();
 
     /// <summary>
-    /// True when the user has at least one event participation in the
+    /// True when the user has <em>any</em> event participation in the
     /// <see cref="ParticipationStatus.Ticketed"/> or
-    /// <see cref="ParticipationStatus.Attended"/> state — i.e., currently
-    /// holds a ticket or has been checked in. Matches the predicate used by
-    /// the Tickets dashboard so the admin stats and the Venn agree on
-    /// "ticket holder".
+    /// <see cref="ParticipationStatus.Attended"/> state, across every year.
+    /// Year-agnostic — for diagnostic surfaces where "this user is on a
+    /// ticket somewhere in the cache" is the useful signal. For year-scoped
+    /// counts (dashboard tiles, the Tickets Venn) use
+    /// <see cref="HasTicketForYear"/> against the active event year so
+    /// counts don't carry stale post-rollover data.
     /// </summary>
     public bool HasTicket => EventParticipations.Any(p =>
         p.Status == ParticipationStatus.Ticketed ||
         p.Status == ParticipationStatus.Attended);
+
+    /// <summary>
+    /// True when the user has a <see cref="ParticipationStatus.Ticketed"/>
+    /// or <see cref="ParticipationStatus.Attended"/> participation in the
+    /// given <paramref name="year"/>. The right predicate for "current ticket
+    /// holder" stats — pass the active event year so post-rollover users
+    /// stop counting against the new year's totals.
+    /// </summary>
+    public bool HasTicketForYear(int year) => EventParticipations.Any(p =>
+        p.Year == year &&
+        (p.Status == ParticipationStatus.Ticketed ||
+         p.Status == ParticipationStatus.Attended));
 
     /// <summary>
     /// Builds a <see cref="UserInfo"/> from the 8 contributing tables. Each

--- a/src/Humans.Application/UserInfo.cs
+++ b/src/Humans.Application/UserInfo.cs
@@ -253,6 +253,28 @@ public sealed record UserInfo(
         .ToList();
 
     /// <summary>
+    /// Marketing-category opt-in tri-state: null when no preference row exists
+    /// (e.g., user imported from an external source who never hit the prefs
+    /// flow), true when opted out, false when opted in.
+    /// </summary>
+    public bool? MarketingOptedOut => CommunicationPreferences
+        .Where(c => c.Category == MessageCategory.Marketing)
+        .Select(c => (bool?)c.OptedOut)
+        .FirstOrDefault();
+
+    /// <summary>
+    /// True when the user has at least one event participation in the
+    /// <see cref="ParticipationStatus.Ticketed"/> or
+    /// <see cref="ParticipationStatus.Attended"/> state — i.e., currently
+    /// holds a ticket or has been checked in. Matches the predicate used by
+    /// the Tickets dashboard so the admin stats and the Venn agree on
+    /// "ticket holder".
+    /// </summary>
+    public bool HasTicket => EventParticipations.Any(p =>
+        p.Status == ParticipationStatus.Ticketed ||
+        p.Status == ParticipationStatus.Attended);
+
+    /// <summary>
     /// Builds a <see cref="UserInfo"/> from the 8 contributing tables. Each
     /// input is the raw read-only entity (or empty list) — all snapshotting,
     /// projection, and ordering happens here so the cached payload is immutable.

--- a/src/Humans.Infrastructure/Data/UserInfoSaveChangesInterceptor.cs
+++ b/src/Humans.Infrastructure/Data/UserInfoSaveChangesInterceptor.cs
@@ -25,6 +25,7 @@ namespace Humans.Infrastructure.Data;
 ///   <item><c>user_emails</c> — OAuth callback creating verified-email rows.</item>
 ///   <item><c>event_participations</c> — defensive coverage for any direct-repo write.</item>
 ///   <item>AspNet <c>user_logins</c> — OAuth callback creating login rows.</item>
+///   <item><c>communication_preferences</c> — opt-in/out toggles written directly via <c>ICommunicationPreferenceRepository</c>; rides on the User cache because the prefs collection is part of <c>UserInfo</c>.</item>
 /// </list>
 /// <para>
 /// Profile-section tables (<c>profiles</c>, <c>contact_fields</c>,
@@ -167,6 +168,9 @@ public sealed class UserInfoSaveChangesInterceptor : SaveChangesInterceptor
                     break;
                 case IdentityUserLogin<Guid> uil:
                     affected.Add(uil.UserId);
+                    break;
+                case CommunicationPreference cp:
+                    affected.Add(cp.UserId);
                     break;
             }
         }

--- a/src/Humans.Infrastructure/Repositories/Profiles/CommunicationPreferenceRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Profiles/CommunicationPreferenceRepository.cs
@@ -90,6 +90,14 @@ public sealed class CommunicationPreferenceRepository : ICommunicationPreference
             .ToListAsync(ct);
     }
 
+    public async Task<IReadOnlyList<CommunicationPreference>> GetAllAsync(CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        return await ctx.CommunicationPreferences
+            .AsNoTracking()
+            .ToListAsync(ct);
+    }
+
     public async Task<int> GetCountByCategoryAndStateAsync(
         MessageCategory category, bool optedOut, CancellationToken ct = default)
     {

--- a/src/Humans.Infrastructure/Services/Users/CachingUserService.cs
+++ b/src/Humans.Infrastructure/Services/Users/CachingUserService.cs
@@ -130,7 +130,8 @@ public sealed class CachingUserService : IUserService, IUserMerge, IUserInfoInva
 
         _byUserId[userId] = UserInfo.Create(
             user, userEmails, participations, externalLogins,
-            profile, contactFields, languages, volunteerHistory);
+            profile, contactFields, languages, volunteerHistory,
+            Array.Empty<CommunicationPreference>());
     }
 
     /// <summary>
@@ -187,7 +188,8 @@ public sealed class CachingUserService : IUserService, IUserMerge, IUserInfoInva
 
             _byUserId[user.Id] = UserInfo.Create(
                 user, emails, participations, logins,
-                profile, contactFields, languages, volunteerHistory);
+                profile, contactFields, languages, volunteerHistory,
+                Array.Empty<CommunicationPreference>());
         }
     }
 

--- a/src/Humans.Infrastructure/Services/Users/CachingUserService.cs
+++ b/src/Humans.Infrastructure/Services/Users/CachingUserService.cs
@@ -54,6 +54,7 @@ public sealed class CachingUserService : IUserService, IUserMerge, IUserInfoInva
     private readonly IUserEmailRepository _userEmailRepository;
     private readonly IProfileRepository _profileRepository;
     private readonly IContactFieldRepository _contactFieldRepository;
+    private readonly ICommunicationPreferenceRepository _communicationPreferenceRepository;
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly ILogger<CachingUserService> _logger;
 
@@ -64,6 +65,7 @@ public sealed class CachingUserService : IUserService, IUserMerge, IUserInfoInva
         IUserEmailRepository userEmailRepository,
         IProfileRepository profileRepository,
         IContactFieldRepository contactFieldRepository,
+        ICommunicationPreferenceRepository communicationPreferenceRepository,
         IServiceScopeFactory scopeFactory,
         ILogger<CachingUserService> logger)
     {
@@ -71,6 +73,7 @@ public sealed class CachingUserService : IUserService, IUserMerge, IUserInfoInva
         _userEmailRepository = userEmailRepository;
         _profileRepository = profileRepository;
         _contactFieldRepository = contactFieldRepository;
+        _communicationPreferenceRepository = communicationPreferenceRepository;
         _scopeFactory = scopeFactory;
         _logger = logger;
     }
@@ -128,10 +131,13 @@ public sealed class CachingUserService : IUserService, IUserMerge, IUserInfoInva
             volunteerHistory = profile.VolunteerHistory.ToList();
         }
 
+        var communicationPreferences = await _communicationPreferenceRepository
+            .GetByUserIdReadOnlyAsync(userId, ct);
+
         _byUserId[userId] = UserInfo.Create(
             user, userEmails, participations, externalLogins,
             profile, contactFields, languages, volunteerHistory,
-            Array.Empty<CommunicationPreference>());
+            communicationPreferences);
     }
 
     /// <summary>
@@ -165,6 +171,11 @@ public sealed class CachingUserService : IUserService, IUserMerge, IUserInfoInva
         var participationsByUser = await _userRepository
             .GetEventParticipationsByUserIdsAsync(userIds, ct);
 
+        var allPreferences = await _communicationPreferenceRepository.GetAllAsync(ct);
+        var preferencesByUser = allPreferences
+            .GroupBy(p => p.UserId)
+            .ToDictionary(g => g.Key, g => (IReadOnlyList<CommunicationPreference>)g.ToList());
+
         foreach (var user in users)
         {
             var emails = emailsByUser.TryGetValue(user.Id, out var es)
@@ -186,10 +197,13 @@ public sealed class CachingUserService : IUserService, IUserMerge, IUserInfoInva
                 volunteerHistory = profile.VolunteerHistory.ToList();
             }
 
+            var preferences = preferencesByUser.TryGetValue(user.Id, out var pp)
+                ? pp : Array.Empty<CommunicationPreference>();
+
             _byUserId[user.Id] = UserInfo.Create(
                 user, emails, participations, logins,
                 profile, contactFields, languages, volunteerHistory,
-                Array.Empty<CommunicationPreference>());
+                preferences);
         }
     }
 

--- a/src/Humans.Infrastructure/Services/Users/CachingUserService.cs
+++ b/src/Humans.Infrastructure/Services/Users/CachingUserService.cs
@@ -100,6 +100,9 @@ public sealed class CachingUserService : IUserService, IUserMerge, IUserInfoInva
         return result;
     }
 
+    /// <inheritdoc cref="IUserService.GetAllUserInfos" />
+    public IReadOnlyCollection<UserInfo> GetAllUserInfos() => _byUserId.Values.ToArray();
+
     /// <summary>
     /// Rebuilds the cache entry for <paramref name="userId"/> directly from
     /// repositories. If the user no longer exists, the entry is removed.

--- a/src/Humans.Web/Controllers/AdminController.cs
+++ b/src/Humans.Web/Controllers/AdminController.cs
@@ -66,10 +66,14 @@ public class AdminController : HumansControllerBase
         [FromServices] IFeedbackService feedback,
         [FromServices] IAuditViewerService auditViewer,
         [FromServices] IAdminDashboardService adminDashboardService,
+        [FromServices] IUserService userService,
         CancellationToken ct)
     {
         var firstName = User.Identity?.Name?.Split(' ').FirstOrDefault() ?? "";
-        var activeHumans = (await profileService.GetActiveApprovedUserIdsAsync(ct)).Count;
+        var snapshot = userService.GetAllUserInfos();
+        var totalUsers = snapshot.Count;
+        var activeProfileUsers = snapshot.Count(u => u.Profile is not null);
+        var ticketHolders = snapshot.Count(u => u.HasTicket);
         var (filled, total, ratio) = await shifts.GetOverallCoverageAsync(ct);
         var openFeedback = await feedback.GetActionableCountAsync(ct);
         var recent = (await auditViewer.GetRecentAsync(8, ct))
@@ -90,7 +94,9 @@ public class AdminController : HumansControllerBase
 
         var vm = new AdminDashboardViewModel(
             GreetingFirstName: firstName,
-            ActiveHumans: activeHumans,
+            TotalUsers: totalUsers,
+            ActiveProfileUsers: activeProfileUsers,
+            TicketHolders: ticketHolders,
             ShiftCoveragePercent: total > 0 ? (int)Math.Round(ratio * 100) : 0,
             ShiftFilledOf: total > 0 ? filled : null,
             ShiftTotalOf: total > 0 ? total : null,

--- a/src/Humans.Web/Controllers/AdminController.cs
+++ b/src/Humans.Web/Controllers/AdminController.cs
@@ -73,7 +73,10 @@ public class AdminController : HumansControllerBase
         var snapshot = userService.GetAllUserInfos();
         var totalUsers = snapshot.Count;
         var activeProfileUsers = snapshot.Count(u => u.Profile is not null);
-        var ticketHolders = snapshot.Count(u => u.HasTicket);
+        var activeEvent = await shifts.GetActiveAsync();
+        var ticketHolders = activeEvent is { Year: > 0 }
+            ? snapshot.Count(u => u.HasTicketForYear(activeEvent.Year))
+            : 0;
         var (filled, total, ratio) = await shifts.GetOverallCoverageAsync(ct);
         var openFeedback = await feedback.GetActionableCountAsync(ct);
         var recent = (await auditViewer.GetRecentAsync(8, ct))

--- a/src/Humans.Web/Controllers/TicketController.cs
+++ b/src/Humans.Web/Controllers/TicketController.cs
@@ -123,35 +123,25 @@ public class TicketController : HumansControllerBase
                 PaymentStatus = o.PaymentStatus,
             }).ToList(),
             IsConfigured = true,
-            TotalActiveVolunteers = stats.TotalActiveVolunteers,
-            VolunteersWithTickets = stats.VolunteersWithTickets,
-            VolunteerCoveragePercent = stats.VolunteerCoveragePercent,
         };
 
-        // Participation breakdown for donut chart
-        try
+        // Set membership across the UserInfo cache — drives the Venn + UpSet.
+        // TODO: extend to (HasProfile, HasTicket, HasShift) when IShiftManager caching lands.
+        var snapshot = _userService.GetAllUserInfos();
+        var usersOnly = 0;
+        var profileOnly = 0;
+        var ticketOnly = 0;
+        var both = 0;
+        foreach (var u in snapshot)
         {
-            var activeEvent = await _shiftMgmt.GetActiveAsync();
-            if (activeEvent is not null && activeEvent.Year > 0)
-            {
-                var participations = await _userService.GetAllParticipationsForYearAsync(activeEvent.Year);
-                var notAttendingCount = participations.Count(p => p.Status == ParticipationStatus.NotAttending);
-                var hasTicketCount = participations.Count(p =>
-                    p.Status == ParticipationStatus.Ticketed ||
-                    p.Status == ParticipationStatus.Attended);
-
-                // "No Ticket" = total active volunteers minus those with tickets minus those who declared not attending
-                var noTicketCount = Math.Max(0, stats.TotalActiveVolunteers - hasTicketCount - notAttendingCount);
-
-                model.ParticipationNotAttending = notAttendingCount;
-                model.ParticipationHasTicket = hasTicketCount;
-                model.ParticipationNoTicket = noTicketCount;
-            }
+            var hasProfile = u.Profile is not null;
+            var hasTicket = u.HasTicket;
+            if (hasProfile && hasTicket) both++;
+            else if (hasProfile) profileOnly++;
+            else if (hasTicket) ticketOnly++;
+            else usersOnly++;
         }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to load participation breakdown for ticket dashboard");
-        }
+        model.SetMembership = new UserSetMembership(usersOnly, profileOnly, ticketOnly, both);
 
         return View(model);
     }

--- a/src/Humans.Web/Controllers/TicketController.cs
+++ b/src/Humans.Web/Controllers/TicketController.cs
@@ -126,8 +126,12 @@ public class TicketController : HumansControllerBase
         };
 
         // Set membership across the UserInfo cache — drives the Venn + UpSet.
+        // Ticket-holder is scoped to the active event year so post-rollover
+        // users with only prior-year participations don't count.
         // TODO: extend to (HasProfile, HasTicket, HasShift) when IShiftManager caching lands.
         var snapshot = _userService.GetAllUserInfos();
+        var activeEvent = await _shiftMgmt.GetActiveAsync();
+        var activeYear = activeEvent?.Year ?? 0;
         var usersOnly = 0;
         var profileOnly = 0;
         var ticketOnly = 0;
@@ -135,7 +139,7 @@ public class TicketController : HumansControllerBase
         foreach (var u in snapshot)
         {
             var hasProfile = u.Profile is not null;
-            var hasTicket = u.HasTicket;
+            var hasTicket = activeYear > 0 && u.HasTicketForYear(activeYear);
             if (hasProfile && hasTicket) both++;
             else if (hasProfile) profileOnly++;
             else if (hasTicket) ticketOnly++;

--- a/src/Humans.Web/Controllers/UsersAdminDebugController.cs
+++ b/src/Humans.Web/Controllers/UsersAdminDebugController.cs
@@ -1,8 +1,10 @@
 using Humans.Application;
 using Humans.Application.Interfaces.Users;
+using Humans.Domain.Entities;
 using Humans.Web.Authorization;
 using Humans.Web.Models;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Humans.Web.Controllers;
@@ -16,7 +18,7 @@ namespace Humans.Web.Controllers;
 /// </summary>
 [Authorize(Policy = PolicyNames.AdminOnly)]
 [Route("Users/Admin/Debug")]
-public sealed class UsersAdminDebugController : Controller
+public sealed class UsersAdminDebugController : HumansControllerBase
 {
     private const int MinPageSize = 10;
     private const int MaxPageSize = 200;
@@ -24,7 +26,8 @@ public sealed class UsersAdminDebugController : Controller
 
     private readonly IUserService _userService;
 
-    public UsersAdminDebugController(IUserService userService)
+    public UsersAdminDebugController(IUserService userService, UserManager<User> userManager)
+        : base(userManager)
     {
         _userService = userService;
     }

--- a/src/Humans.Web/Controllers/UsersAdminDebugController.cs
+++ b/src/Humans.Web/Controllers/UsersAdminDebugController.cs
@@ -20,7 +20,7 @@ public sealed class UsersAdminDebugController : Controller
 {
     private const int MinPageSize = 10;
     private const int MaxPageSize = 200;
-    private const int DefaultPageSize = 50;
+    private const int DefaultPageSize = 25;
 
     private readonly IUserService _userService;
 

--- a/src/Humans.Web/Controllers/UsersAdminDebugController.cs
+++ b/src/Humans.Web/Controllers/UsersAdminDebugController.cs
@@ -1,0 +1,70 @@
+using Humans.Application;
+using Humans.Application.Interfaces.Users;
+using Humans.Web.Authorization;
+using Humans.Web.Models;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Humans.Web.Controllers;
+
+/// <summary>
+/// Diagnostic debug surface for the in-memory <see cref="UserInfo"/> cache.
+/// Flat paginated/sortable table of every cached user — used to verify the
+/// cache holds the expected data after imports and migrations. Every column
+/// comes from <see cref="IUserService.GetAllUserInfos"/>; nothing on this
+/// page makes a secondary query.
+/// </summary>
+[Authorize(Policy = PolicyNames.AdminOnly)]
+[Route("Users/Admin/Debug")]
+public sealed class UsersAdminDebugController : Controller
+{
+    private const int MinPageSize = 10;
+    private const int MaxPageSize = 200;
+    private const int DefaultPageSize = 50;
+
+    private readonly IUserService _userService;
+
+    public UsersAdminDebugController(IUserService userService)
+    {
+        _userService = userService;
+    }
+
+    [HttpGet("")]
+    public IActionResult Index(int page = 1, int pageSize = DefaultPageSize,
+                               string sort = "displayName", string dir = "asc")
+    {
+        pageSize = Math.Clamp(pageSize, MinPageSize, MaxPageSize);
+        if (page < 1) page = 1;
+
+        var snapshot = _userService.GetAllUserInfos();
+        var allRows = snapshot.Select(UserDebugRow.From).ToList();
+
+        var sorted = ApplySort(allRows, sort, dir);
+        var total = sorted.Count;
+        var paged = sorted.Skip((page - 1) * pageSize).Take(pageSize).ToList();
+
+        return View(new UsersDebugViewModel(paged, total, page, pageSize, sort, dir));
+    }
+
+    private static List<UserDebugRow> ApplySort(List<UserDebugRow> rows, string sort, string dir)
+    {
+        var asc = string.Equals(dir, "asc", StringComparison.OrdinalIgnoreCase);
+
+        // Null-first ascending semantics for tri-state booleans — null < false < true.
+        static int NullableBool(bool? b) => b is null ? 0 : b.Value ? 2 : 1;
+
+        IEnumerable<UserDebugRow> sorted = sort switch
+        {
+            "userId"      => rows.OrderBy(r => r.UserId),
+            "hasProfile"  => rows.OrderBy(r => r.HasProfile),
+            "hasTicket"   => rows.OrderBy(r => r.HasTicket),
+            "marketing"   => rows.OrderBy(r => NullableBool(r.MarketingOptedOut)),
+            "burnerName"  => rows.OrderBy(r => r.BurnerName, StringComparer.OrdinalIgnoreCase),
+            "legalName"   => rows.OrderBy(r => r.LegalName, StringComparer.OrdinalIgnoreCase),
+            "hasConsent"  => rows.OrderBy(r => NullableBool(r.HasConsent)),
+            _             => rows.OrderBy(r => r.DisplayName, StringComparer.OrdinalIgnoreCase),
+        };
+
+        return asc ? sorted.ToList() : sorted.Reverse().ToList();
+    }
+}

--- a/src/Humans.Web/Controllers/UsersAdminDebugController.cs
+++ b/src/Humans.Web/Controllers/UsersAdminDebugController.cs
@@ -55,14 +55,14 @@ public sealed class UsersAdminDebugController : Controller
 
         IEnumerable<UserDebugRow> sorted = sort switch
         {
-            "userId"      => rows.OrderBy(r => r.UserId),
-            "hasProfile"  => rows.OrderBy(r => r.HasProfile),
-            "hasTicket"   => rows.OrderBy(r => r.HasTicket),
-            "marketing"   => rows.OrderBy(r => NullableBool(r.MarketingOptedOut)),
-            "burnerName"  => rows.OrderBy(r => r.BurnerName, StringComparer.OrdinalIgnoreCase),
-            "legalName"   => rows.OrderBy(r => r.LegalName, StringComparer.OrdinalIgnoreCase),
-            "hasConsent"  => rows.OrderBy(r => NullableBool(r.HasConsent)),
-            _             => rows.OrderBy(r => r.DisplayName, StringComparer.OrdinalIgnoreCase),
+            "userId" => rows.OrderBy(r => r.UserId),
+            "hasProfile" => rows.OrderBy(r => r.HasProfile),
+            "hasTicket" => rows.OrderBy(r => r.HasTicket),
+            "marketing" => rows.OrderBy(r => NullableBool(r.MarketingOptedOut)),
+            "burnerName" => rows.OrderBy(r => r.BurnerName, StringComparer.OrdinalIgnoreCase),
+            "legalName" => rows.OrderBy(r => r.LegalName, StringComparer.OrdinalIgnoreCase),
+            "hasConsent" => rows.OrderBy(r => NullableBool(r.HasConsent)),
+            _ => rows.OrderBy(r => r.DisplayName, StringComparer.OrdinalIgnoreCase),
         };
 
         return asc ? sorted.ToList() : sorted.Reverse().ToList();

--- a/src/Humans.Web/Models/AdminDashboardViewModel.cs
+++ b/src/Humans.Web/Models/AdminDashboardViewModel.cs
@@ -5,7 +5,9 @@ namespace Humans.Web.Models;
 
 public sealed record AdminDashboardViewModel(
     string GreetingFirstName,
-    int ActiveHumans,
+    int TotalUsers,
+    int ActiveProfileUsers,
+    int TicketHolders,
     int ShiftCoveragePercent,
     int? ShiftFilledOf,
     int? ShiftTotalOf,

--- a/src/Humans.Web/Models/TicketViewModels.cs
+++ b/src/Humans.Web/Models/TicketViewModels.cs
@@ -39,15 +39,26 @@ public class TicketDashboardViewModel
     // Who hasn't bought count (for dashboard link)
     public int WhoHasntBoughtCount { get; set; }
 
-    // Volunteer ticket coverage
-    public int TotalActiveVolunteers { get; set; }
-    public int VolunteersWithTickets { get; set; }
-    public decimal VolunteerCoveragePercent { get; set; }
+    // Set membership across UserInfo cache (Users, Profiles, Tickets).
+    // Used by the Venn + UpSet diagrams. Each user is bucketed into one of
+    // the four (HasProfile, HasTicket) combinations.
+    public UserSetMembership? SetMembership { get; set; }
+}
 
-    // Participation breakdown
-    public int ParticipationNotAttending { get; set; }
-    public int ParticipationNoTicket { get; set; }
-    public int ParticipationHasTicket { get; set; }
+/// <summary>
+/// User-set bucketing for the Tickets dashboard Venn + UpSet diagrams.
+/// Users is the universe (every UserInfo); Profiles and Tickets are subsets.
+/// Each user falls into exactly one of the four buckets defined here.
+/// </summary>
+public sealed record UserSetMembership(
+    int UsersOnly,              // !HasProfile && !HasTicket
+    int UsersAndProfileOnly,    //  HasProfile && !HasTicket
+    int UsersAndTicketOnly,     // !HasProfile &&  HasTicket
+    int AllThree)               //  HasProfile &&  HasTicket
+{
+    public int TotalUsers => UsersOnly + UsersAndProfileOnly + UsersAndTicketOnly + AllThree;
+    public int ProfilesCount => UsersAndProfileOnly + AllThree;
+    public int TicketsCount => UsersAndTicketOnly + AllThree;
 }
 
 public class PaymentMethodFeeBreakdown

--- a/src/Humans.Web/Models/UsersDebugViewModel.cs
+++ b/src/Humans.Web/Models/UsersDebugViewModel.cs
@@ -1,0 +1,42 @@
+using Humans.Application;
+using Humans.Domain.Enums;
+
+namespace Humans.Web.Models;
+
+public sealed record UsersDebugViewModel(
+    IReadOnlyList<UserDebugRow> Rows,
+    int TotalCount,
+    int Page,
+    int PageSize,
+    string Sort,
+    string Dir)
+{
+    public int TotalPages => PageSize > 0
+        ? (int)Math.Ceiling((double)TotalCount / PageSize)
+        : 0;
+
+    public bool IsAsc => string.Equals(Dir, "asc", StringComparison.OrdinalIgnoreCase);
+}
+
+public sealed record UserDebugRow(
+    Guid UserId,
+    bool HasProfile,
+    bool HasTicket,
+    bool? MarketingOptedOut,
+    string DisplayName,
+    string BurnerName,
+    string LegalName,
+    bool? HasConsent)
+{
+    public static UserDebugRow From(UserInfo info) => new(
+        UserId: info.Id,
+        HasProfile: info.Profile is not null,
+        HasTicket: info.HasTicket,
+        MarketingOptedOut: info.MarketingOptedOut,
+        DisplayName: info.DisplayName,
+        BurnerName: info.Profile?.BurnerName ?? string.Empty,
+        LegalName: info.Profile?.FullName ?? string.Empty,
+        HasConsent: info.Profile is null
+            ? null
+            : info.Profile.ConsentCheckStatus == ConsentCheckStatus.Cleared);
+}

--- a/src/Humans.Web/ViewComponents/AdminNavTree.cs
+++ b/src/Humans.Web/ViewComponents/AdminNavTree.cs
@@ -77,6 +77,7 @@ public static class AdminNavTree
             new("Logs",            "Admin", "Logs",          null, null, "fa-solid fa-triangle-exclamation", PolicyNames.AdminOnly),
             new("DB stats",        "Admin", "DbStats",       null, null, "fa-solid fa-database",            PolicyNames.AdminOnly),
             new("Cache stats",     "Admin", "CacheStats",    null, null, "fa-solid fa-bolt",                PolicyNames.AdminOnly),
+            new("All users (debug)", "UsersAdminDebug", "Index", null, null, "fa-solid fa-bug-slash", PolicyNames.AdminOnly),
             new("Configuration",   "Admin", "Configuration", null, null, "fa-solid fa-gear",                PolicyNames.AdminOnly),
             new("Maintenance",     "Admin", "Maintenance",   null, null, "fa-solid fa-screwdriver-wrench",  PolicyNames.AdminOnly),
             new("Orphan signups",  "Shifts", "OrphanSignups", null, null, "fa-solid fa-user-secret",        PolicyNames.AdminOnly),

--- a/src/Humans.Web/Views/Admin/Index.cshtml
+++ b/src/Humans.Web/Views/Admin/Index.cshtml
@@ -7,7 +7,7 @@
     <div>
         <h1 class="title">Welcome back, @Model.GreetingFirstName.</h1>
         <p class="sub">
-            @Model.ActiveHumans active humans · @Model.ShiftCoveragePercent% shift coverage · @Model.OpenFeedback open feedback
+            @Model.TotalUsers users · @Model.ActiveProfileUsers with profile · @Model.TicketHolders with ticket · @Model.ShiftCoveragePercent% shift coverage · @Model.OpenFeedback open feedback
         </p>
     </div>
 </div>

--- a/src/Humans.Web/Views/Shared/_DashboardStats.cshtml
+++ b/src/Humans.Web/Views/Shared/_DashboardStats.cshtml
@@ -2,8 +2,16 @@
 
 <div class="stats">
     <div class="stat">
-        <div class="label">Active humans</div>
-        <div class="value">@Model.ActiveHumans</div>
+        <div class="label">Total users</div>
+        <div class="value">@Model.TotalUsers</div>
+    </div>
+    <div class="stat">
+        <div class="label">Active (has profile)</div>
+        <div class="value">@Model.ActiveProfileUsers</div>
+    </div>
+    <div class="stat">
+        <div class="label">Ticket holders</div>
+        <div class="value">@Model.TicketHolders</div>
     </div>
     <div class="stat">
         <div class="label">Shifts staffed</div>

--- a/src/Humans.Web/Views/Ticket/Index.cshtml
+++ b/src/Humans.Web/Views/Ticket/Index.cshtml
@@ -122,7 +122,7 @@
                              data-users-tickets="@sm.TicketsCount"
                              data-profiles-tickets="@sm.AllThree"
                              data-all-three="@sm.AllThree"
-                             style="max-height: 420px; width: 100%;"></div>
+                             style="height: 500px; width: 100%;"></div>
                     </div>
                     <div class="col-md-6">
                         <h6 class="text-center">UpSet plot</h6>
@@ -131,7 +131,7 @@
                              data-profile-only="@sm.UsersAndProfileOnly"
                              data-ticket-only="@sm.UsersAndTicketOnly"
                              data-all-three="@sm.AllThree"
-                             style="max-height: 420px; width: 100%;"></div>
+                             style="height: 500px; width: 100%;"></div>
                     </div>
                 </div>
                 <p class="text-muted small mt-2 mb-0">
@@ -150,7 +150,9 @@
                 <i class="fa-solid fa-chart-bar"></i> Daily Ticket Sales
             </div>
             <div class="card-body">
-                <canvas id="dailySalesChart" height="100"></canvas>
+                <div style="position: relative; height: 500px; width: 100%;">
+                    <canvas id="dailySalesChart"></canvas>
+                </div>
             </div>
         </div>
     }
@@ -378,6 +380,7 @@
                 },
                 options: {
                     responsive: true,
+                    maintainAspectRatio: false,
                     scales: {
                         x: { display: true },
                         y: { beginAtZero: true, title: { display: true, text: 'Tickets' } }
@@ -391,8 +394,8 @@
 @if (Model.SetMembership is not null && Model.SetMembership.TotalUsers > 0)
 {
     <script src="https://cdn.jsdelivr.net/npm/d3@7.9.0/dist/d3.min.js" crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@@upsetjs/venn.js@1.4.4/build/venn.min.js" crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@@upsetjs/bundle@1.13.1/build/index.umd.min.js" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@@upsetjs/venn.js@1.4.2/build/venn.min.js" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@@upsetjs/bundle@1.11.0/dist/upsetjs.umd.production.min.js" crossorigin="anonymous"></script>
     <script>
         document.addEventListener('DOMContentLoaded', function () {
             // ---- Venn: 3 sets (Users / Profiles / Tickets) ----

--- a/src/Humans.Web/Views/Ticket/Index.cshtml
+++ b/src/Humans.Web/Views/Ticket/Index.cshtml
@@ -100,71 +100,46 @@
         </div>
     </div>
 
-    <!-- Volunteer Ticket Coverage -->
-    @if (Model.TotalActiveVolunteers > 0)
+    <!-- User set membership — Venn (Profiles ∩ Tickets within Users) + UpSet -->
+    @if (Model.SetMembership is { TotalUsers: > 0 } sm)
     {
         <div class="card mb-4">
             <div class="card-header">
-                <i class="fa-solid fa-users"></i> Volunteer Ticket Coverage
+                <i class="fa-solid fa-chart-pie"></i> User set membership
+                <small class="text-muted">
+                    @sm.TotalUsers total users · @sm.ProfilesCount with profile · @sm.TicketsCount with ticket
+                </small>
             </div>
             <div class="card-body">
-                <div class="d-flex justify-content-between align-items-center mb-2">
-                    <span>
-                        <strong>@Model.VolunteersWithTickets</strong> / @Model.TotalActiveVolunteers humans have tickets
-                    </span>
-                    <span class="fs-4 fw-bold @(Model.VolunteerCoveragePercent >= 75 ? "text-success" : Model.VolunteerCoveragePercent >= 50 ? "text-warning" : "text-danger")">
-                        @Model.VolunteerCoveragePercent%
-                    </span>
-                </div>
-                <div class="progress" style="height: 20px;">
-                    <div class="progress-bar @(Model.VolunteerCoveragePercent >= 75 ? "bg-success" : Model.VolunteerCoveragePercent >= 50 ? "bg-warning" : "bg-danger")"
-                         style="width: @(Model.VolunteerCoveragePercent.ToString(System.Globalization.CultureInfo.InvariantCulture))%">
-                    </div>
-                </div>
-                <div class="mt-2">
-                    <a asp-action="WhoHasntBought" class="text-muted"><i class="fa-solid fa-arrow-right"></i> View details</a>
-                </div>
-            </div>
-        </div>
-    }
-
-    <!-- Participation Breakdown -->
-    @{
-        var participationTotal = Model.ParticipationNotAttending + Model.ParticipationNoTicket + Model.ParticipationHasTicket;
-    }
-    @if (participationTotal > 0)
-    {
-        <div class="card mb-4">
-            <div class="card-header">
-                <i class="fa-solid fa-chart-pie"></i> Participation Breakdown
-            </div>
-            <div class="card-body">
-                <div class="row align-items-center">
+                <div class="row">
                     <div class="col-md-6">
-                        <canvas id="participationChart" height="200"></canvas>
+                        <h6 class="text-center">Proportional Venn</h6>
+                        <div id="userVenn"
+                             data-users="@sm.TotalUsers"
+                             data-profiles="@sm.ProfilesCount"
+                             data-tickets="@sm.TicketsCount"
+                             data-users-profiles="@sm.ProfilesCount"
+                             data-users-tickets="@sm.TicketsCount"
+                             data-profiles-tickets="@sm.AllThree"
+                             data-all-three="@sm.AllThree"
+                             style="max-height: 420px; width: 100%;"></div>
                     </div>
                     <div class="col-md-6">
-                        <ul class="list-unstyled">
-                            <li class="mb-2">
-                                <span class="badge bg-success">&nbsp;&nbsp;</span>
-                                <strong>Has Ticket:</strong> @Model.ParticipationHasTicket
-                                (@(participationTotal > 0 ? Math.Round((decimal)Model.ParticipationHasTicket / participationTotal * 100) : 0)%)
-                            </li>
-                            <li class="mb-2">
-                                <span class="badge bg-warning">&nbsp;&nbsp;</span>
-                                <strong>No Ticket:</strong> @Model.ParticipationNoTicket
-                                (@(participationTotal > 0 ? Math.Round((decimal)Model.ParticipationNoTicket / participationTotal * 100) : 0)%)
-                            </li>
-                            <li class="mb-2">
-                                <span class="badge bg-secondary">&nbsp;&nbsp;</span>
-                                <strong>Not Coming:</strong> @Model.ParticipationNotAttending
-                                (@(participationTotal > 0 ? Math.Round((decimal)Model.ParticipationNotAttending / participationTotal * 100) : 0)%)
-                            </li>
-                        </ul>
+                        <h6 class="text-center">UpSet plot</h6>
+                        <div id="userUpset"
+                             data-users-only="@sm.UsersOnly"
+                             data-profile-only="@sm.UsersAndProfileOnly"
+                             data-ticket-only="@sm.UsersAndTicketOnly"
+                             data-all-three="@sm.AllThree"
+                             style="max-height: 420px; width: 100%;"></div>
                     </div>
                 </div>
+                <p class="text-muted small mt-2 mb-0">
+                    Users is the universe — every cached user is in it. Profiles ⊆ Users, Tickets ⊆ Users.
+                </p>
             </div>
         </div>
+        @* TODO: extend to Shifts set when IShiftManager caching lands. *@
     }
 
     <!-- Daily Sales Chart -->
@@ -369,73 +344,95 @@
     </div>
 </div>
 
-@if (Model.DailySales.Count > 0 || participationTotal > 0)
+@if (Model.DailySales.Count > 0)
 {
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1/dist/chart.umd.min.js"
             integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ"
             crossorigin="anonymous"></script>
     <script>
         document.addEventListener('DOMContentLoaded', function() {
-            @if (Model.DailySales.Count > 0)
-            {
-                <text>
-                var salesData = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.DailySales, new System.Text.Json.JsonSerializerOptions { PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase }));
-                var salesCtx = document.getElementById('dailySalesChart').getContext('2d');
-                new Chart(salesCtx, {
-                    type: 'bar',
-                    data: {
-                        labels: salesData.map(d => d.date),
-                        datasets: [
-                            {
-                                label: 'Tickets Sold',
-                                data: salesData.map(d => d.ticketsSold),
-                                backgroundColor: 'rgba(54, 162, 235, 0.6)',
-                                order: 2
-                            },
-                            {
-                                label: '7-day Avg',
-                                data: salesData.map(d => d.rollingAverage),
-                                type: 'line',
-                                borderColor: 'rgba(255, 99, 132, 1)',
-                                borderWidth: 2,
-                                fill: false,
-                                pointRadius: 0,
-                                order: 1
-                            }
-                        ]
-                    },
-                    options: {
-                        responsive: true,
-                        scales: {
-                            x: { display: true },
-                            y: { beginAtZero: true, title: { display: true, text: 'Tickets' } }
+            var salesData = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(Model.DailySales, new System.Text.Json.JsonSerializerOptions { PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase }));
+            var salesCtx = document.getElementById('dailySalesChart').getContext('2d');
+            new Chart(salesCtx, {
+                type: 'bar',
+                data: {
+                    labels: salesData.map(d => d.date),
+                    datasets: [
+                        {
+                            label: 'Tickets Sold',
+                            data: salesData.map(d => d.ticketsSold),
+                            backgroundColor: 'rgba(54, 162, 235, 0.6)',
+                            order: 2
+                        },
+                        {
+                            label: '7-day Avg',
+                            data: salesData.map(d => d.rollingAverage),
+                            type: 'line',
+                            borderColor: 'rgba(255, 99, 132, 1)',
+                            borderWidth: 2,
+                            fill: false,
+                            pointRadius: 0,
+                            order: 1
                         }
+                    ]
+                },
+                options: {
+                    responsive: true,
+                    scales: {
+                        x: { display: true },
+                        y: { beginAtZero: true, title: { display: true, text: 'Tickets' } }
                     }
-                });
-                </text>
+                }
+            });
+        });
+    </script>
+}
+
+@if (Model.SetMembership is not null && Model.SetMembership.TotalUsers > 0)
+{
+    <script src="https://cdn.jsdelivr.net/npm/d3@7.9.0/dist/d3.min.js" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@@upsetjs/venn.js@1.4.4/build/venn.min.js" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@@upsetjs/bundle@1.13.1/build/index.umd.min.js" crossorigin="anonymous"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            // ---- Venn: 3 sets (Users / Profiles / Tickets) ----
+            var venn = document.getElementById('userVenn');
+            if (venn && window.venn && window.d3) {
+                var d = venn.dataset;
+                var sets = [
+                    { sets: ['Users'], size: +d.users, label: 'Users (' + d.users + ')' },
+                    { sets: ['Profiles'], size: +d.profiles, label: 'Profiles (' + d.profiles + ')' },
+                    { sets: ['Tickets'], size: +d.tickets, label: 'Tickets (' + d.tickets + ')' },
+                    { sets: ['Users', 'Profiles'], size: +d.usersProfiles },
+                    { sets: ['Users', 'Tickets'], size: +d.usersTickets },
+                    { sets: ['Profiles', 'Tickets'], size: +d.profilesTickets },
+                    { sets: ['Users', 'Profiles', 'Tickets'], size: +d.allThree }
+                ];
+                var chart = window.venn.VennDiagram().width(400).height(360);
+                window.d3.select('#userVenn').datum(sets).call(chart);
             }
 
-            @if (participationTotal > 0)
-            {
-                <text>
-                var partCtx = document.getElementById('participationChart').getContext('2d');
-                new Chart(partCtx, {
-                    type: 'doughnut',
-                    data: {
-                        labels: ['Has Ticket', 'No Ticket', 'Not Coming'],
-                        datasets: [{
-                            data: [@Model.ParticipationHasTicket, @Model.ParticipationNoTicket, @Model.ParticipationNotAttending],
-                            backgroundColor: ['#198754', '#ffc107', '#6c757d']
-                        }]
-                    },
-                    options: {
-                        responsive: true,
-                        plugins: {
-                            legend: { position: 'bottom' }
-                        }
-                    }
+            // ---- UpSet: same 3 sets, intersection bar chart ----
+            var upset = document.getElementById('userUpset');
+            if (upset && window.UpSetJS) {
+                var u = upset.dataset;
+                var usersOnly = +u.usersOnly;
+                var profileOnly = +u.profileOnly;
+                var ticketOnly = +u.ticketOnly;
+                var allThree = +u.allThree;
+                var elems = [];
+                for (var i = 0; i < usersOnly; i++)    elems.push({ name: 'u' + i, sets: ['Users'] });
+                for (var i = 0; i < profileOnly; i++)  elems.push({ name: 'p' + i, sets: ['Users', 'Profiles'] });
+                for (var i = 0; i < ticketOnly; i++)   elems.push({ name: 't' + i, sets: ['Users', 'Tickets'] });
+                for (var i = 0; i < allThree; i++)     elems.push({ name: 'a' + i, sets: ['Users', 'Profiles', 'Tickets'] });
+                var sets = window.UpSetJS.extractSets(elems);
+                var combinations = window.UpSetJS.generateCombinations(sets);
+                window.UpSetJS.render(upset, {
+                    sets: sets,
+                    combinations: combinations,
+                    width: 400,
+                    height: 360
                 });
-                </text>
             }
         });
     </script>

--- a/src/Humans.Web/Views/UsersAdminDebug/Index.cshtml
+++ b/src/Humans.Web/Views/UsersAdminDebug/Index.cshtml
@@ -1,0 +1,77 @@
+@model Humans.Web.Models.UsersDebugViewModel
+@{
+    ViewData["Title"] = "All users (debug)";
+
+    string Toggle(string column)
+    {
+        var newDir = (Model.Sort == column && Model.IsAsc) ? "desc" : "asc";
+        return Url.Action("Index", new { page = 1, pageSize = Model.PageSize, sort = column, dir = newDir })!;
+    }
+
+    string ArrowFor(string column) =>
+        Model.Sort != column ? "" : Model.IsAsc ? " ↑" : " ↓";
+
+    string Tri(bool? value) => value is null ? "—" : value.Value ? "Yes" : "No";
+    string Bool(bool value) => value ? "✓" : "✗";
+}
+
+<div class="page-head">
+    <h1 class="title">All users (debug)</h1>
+    <p class="sub">
+        @Model.TotalCount users · page @Model.Page of @Model.TotalPages · all fields read from the in-memory UserInfo cache
+    </p>
+</div>
+
+<div class="card">
+    <div class="card-body p-0">
+        <div class="table-responsive">
+            <table class="table table-sm table-hover mb-0">
+                <thead>
+                    <tr>
+                        <th><a href="@Toggle("userId")">UserId@(ArrowFor("userId"))</a></th>
+                        <th><a href="@Toggle("hasProfile")">HasProfile@(ArrowFor("hasProfile"))</a></th>
+                        <th><a href="@Toggle("hasTicket")">HasTicket@(ArrowFor("hasTicket"))</a></th>
+                        <th><a href="@Toggle("marketing")">Marketing@(ArrowFor("marketing"))</a></th>
+                        <th><a href="@Toggle("displayName")">Display name@(ArrowFor("displayName"))</a></th>
+                        <th><a href="@Toggle("burnerName")">Burner name@(ArrowFor("burnerName"))</a></th>
+                        <th><a href="@Toggle("legalName")">Legal name@(ArrowFor("legalName"))</a></th>
+                        <th><a href="@Toggle("hasConsent")">HasConsent@(ArrowFor("hasConsent"))</a></th>
+                    </tr>
+                </thead>
+                <tbody>
+                @foreach (var row in Model.Rows)
+                {
+                    <tr>
+                        <td><code class="small">@row.UserId</code></td>
+                        <td>@Bool(row.HasProfile)</td>
+                        <td>@Bool(row.HasTicket)</td>
+                        <td>@(row.MarketingOptedOut is null ? "—" : row.MarketingOptedOut.Value ? "No" : "Yes")</td>
+                        <td>@row.DisplayName</td>
+                        <td>@row.BurnerName</td>
+                        <td>@row.LegalName</td>
+                        <td>@Tri(row.HasConsent)</td>
+                    </tr>
+                }
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+
+@if (Model.TotalPages > 1)
+{
+    <nav class="mt-3" aria-label="pager">
+        <ul class="pagination">
+            @for (var p = 1; p <= Model.TotalPages; p++)
+            {
+                var href = Url.Action("Index", new { page = p, pageSize = Model.PageSize, sort = Model.Sort, dir = Model.Dir });
+                <li class="page-item @(p == Model.Page ? "active" : "")">
+                    <a class="page-link" href="@href">@p</a>
+                </li>
+            }
+        </ul>
+    </nav>
+}
+
+@* Marketing tri-state: "Yes" when subscribed (OptedOut == false), "No" when opted out, "—" when no row exists. *@
+@* TODO: HasShift column — pending IShiftManager caching. *@

--- a/src/Humans.Web/Views/UsersAdminDebug/Index.cshtml
+++ b/src/Humans.Web/Views/UsersAdminDebug/Index.cshtml
@@ -12,7 +12,6 @@
         Model.Sort != column ? "" : Model.IsAsc ? " ↑" : " ↓";
 
     string Tri(bool? value) => value is null ? "—" : value.Value ? "Yes" : "No";
-    string Bool(bool value) => value ? "✓" : "✗";
 }
 
 <div class="page-head">
@@ -29,27 +28,27 @@
                 <thead>
                     <tr>
                         <th><a href="@Toggle("userId")">UserId@(ArrowFor("userId"))</a></th>
-                        <th><a href="@Toggle("hasProfile")">HasProfile@(ArrowFor("hasProfile"))</a></th>
-                        <th><a href="@Toggle("hasTicket")">HasTicket@(ArrowFor("hasTicket"))</a></th>
-                        <th><a href="@Toggle("marketing")">Marketing@(ArrowFor("marketing"))</a></th>
+                        <th class="text-center"><a href="@Toggle("hasProfile")">HasProfile@(ArrowFor("hasProfile"))</a></th>
+                        <th class="text-center"><a href="@Toggle("hasTicket")">HasTicket@(ArrowFor("hasTicket"))</a></th>
+                        <th class="text-center"><a href="@Toggle("marketing")">Marketing@(ArrowFor("marketing"))</a></th>
                         <th><a href="@Toggle("displayName")">Display name@(ArrowFor("displayName"))</a></th>
                         <th><a href="@Toggle("burnerName")">Burner name@(ArrowFor("burnerName"))</a></th>
                         <th><a href="@Toggle("legalName")">Legal name@(ArrowFor("legalName"))</a></th>
-                        <th><a href="@Toggle("hasConsent")">HasConsent@(ArrowFor("hasConsent"))</a></th>
+                        <th class="text-center"><a href="@Toggle("hasConsent")">HasConsent@(ArrowFor("hasConsent"))</a></th>
                     </tr>
                 </thead>
                 <tbody>
                 @foreach (var row in Model.Rows)
                 {
                     <tr>
-                        <td><code class="small">@row.UserId</code></td>
-                        <td>@Bool(row.HasProfile)</td>
-                        <td>@Bool(row.HasTicket)</td>
-                        <td>@(row.MarketingOptedOut is null ? "—" : row.MarketingOptedOut.Value ? "No" : "Yes")</td>
+                        <td><a asp-controller="Profile" asp-action="AdminDetail" asp-route-id="@row.UserId"><code class="small">@row.UserId</code></a></td>
+                        <td class="text-center">@Tri(row.HasProfile)</td>
+                        <td class="text-center">@Tri(row.HasTicket)</td>
+                        <td class="text-center">@(row.MarketingOptedOut is null ? "—" : row.MarketingOptedOut.Value ? "No" : "Yes")</td>
                         <td>@row.DisplayName</td>
                         <td>@row.BurnerName</td>
                         <td>@row.LegalName</td>
-                        <td>@Tri(row.HasConsent)</td>
+                        <td class="text-center">@Tri(row.HasConsent)</td>
                     </tr>
                 }
                 </tbody>

--- a/tests/Humans.Application.Tests/Services/DependencyCycleResolutionTests.cs
+++ b/tests/Humans.Application.Tests/Services/DependencyCycleResolutionTests.cs
@@ -48,6 +48,7 @@ public class DependencyCycleResolutionTests
         services.AddScoped<IUserEmailRepository>(_ => Substitute.For<IUserEmailRepository>());
         services.AddScoped<IProfileRepository>(_ => Substitute.For<IProfileRepository>());
         services.AddScoped<IContactFieldRepository>(_ => Substitute.For<IContactFieldRepository>());
+        services.AddScoped<ICommunicationPreferenceRepository>(_ => Substitute.For<ICommunicationPreferenceRepository>());
         services.AddScoped<IFullProfileInvalidator>(_ => Substitute.For<IFullProfileInvalidator>());
         services.AddScoped<IRoleAssignmentRepository>(_ => Substitute.For<IRoleAssignmentRepository>());
         services.AddScoped<IShiftManagementRepository>(_ => Substitute.For<IShiftManagementRepository>());
@@ -107,6 +108,7 @@ public class DependencyCycleResolutionTests
         services.AddScoped<IUserEmailRepository>(_ => Substitute.For<IUserEmailRepository>());
         services.AddScoped<IProfileRepository>(_ => Substitute.For<IProfileRepository>());
         services.AddScoped<IContactFieldRepository>(_ => Substitute.For<IContactFieldRepository>());
+        services.AddScoped<ICommunicationPreferenceRepository>(_ => Substitute.For<ICommunicationPreferenceRepository>());
         services.AddScoped<IFullProfileInvalidator>(_ => Substitute.For<IFullProfileInvalidator>());
         services.AddScoped<IRoleAssignmentRepository>(_ => Substitute.For<IRoleAssignmentRepository>());
         services.AddScoped<IShiftManagementRepository>(_ => Substitute.For<IShiftManagementRepository>());

--- a/tests/Humans.Application.Tests/Services/Shifts/ShiftDashboardMetricsTests.cs
+++ b/tests/Humans.Application.Tests/Services/Shifts/ShiftDashboardMetricsTests.cs
@@ -1012,6 +1012,9 @@ public class ShiftDashboardMetricsTests : IDisposable
         public ValueTask<Humans.Application.UserInfo?> GetUserInfoAsync(Guid userId, CancellationToken ct = default)
             => throw new NotSupportedException();
 
+        public IReadOnlyCollection<Humans.Application.UserInfo> GetAllUserInfos()
+            => throw new NotSupportedException();
+
         public async Task<User?> GetByIdAsync(Guid userId, CancellationToken ct = default)
             => await _db.Users.FirstOrDefaultAsync(u => u.Id == userId, ct);
 

--- a/tests/Humans.Application.Tests/Services/Users/CachingUserServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Users/CachingUserServiceTests.cs
@@ -25,6 +25,7 @@ public class CachingUserServiceTests
     private readonly IUserEmailRepository _userEmailRepo = Substitute.For<IUserEmailRepository>();
     private readonly IProfileRepository _profileRepo = Substitute.For<IProfileRepository>();
     private readonly IContactFieldRepository _contactFieldRepo = Substitute.For<IContactFieldRepository>();
+    private readonly ICommunicationPreferenceRepository _communicationPreferenceRepo = Substitute.For<ICommunicationPreferenceRepository>();
 
     private CachingUserService CreateSut()
     {
@@ -33,6 +34,7 @@ public class CachingUserServiceTests
         var scopeFactory = services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
         return new CachingUserService(
             _userRepo, _userEmailRepo, _profileRepo, _contactFieldRepo,
+            _communicationPreferenceRepo,
             scopeFactory, NullLogger<CachingUserService>.Instance);
     }
 

--- a/tests/Humans.Application.Tests/Services/Users/CachingUserServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Users/CachingUserServiceTests.cs
@@ -53,7 +53,8 @@ public class CachingUserServiceTests
             profile: null,
             contactFields: Array.Empty<ContactField>(),
             profileLanguages: Array.Empty<ProfileLanguage>(),
-            volunteerHistory: Array.Empty<VolunteerHistoryEntry>());
+            volunteerHistory: Array.Empty<VolunteerHistoryEntry>(),
+            communicationPreferences: Array.Empty<CommunicationPreference>());
 
     [HumansFact]
     public async Task GetUserInfoAsync_DictMiss_DelegatesToInnerAndCaches()
@@ -333,7 +334,8 @@ public class CachingUserServiceTests
             profile,
             new[] { contactField },
             profile.Languages.ToList(),
-            profile.VolunteerHistory.ToList());
+            profile.VolunteerHistory.ToList(),
+            Array.Empty<CommunicationPreference>());
 
         _inner.GetUserInfoAsync(userId, Arg.Any<CancellationToken>())
             .Returns(new ValueTask<UserInfo?>(fullInfo));

--- a/tests/Humans.Application.Tests/Services/Users/UserServiceContactSourceCountTests.cs
+++ b/tests/Humans.Application.Tests/Services/Users/UserServiceContactSourceCountTests.cs
@@ -36,12 +36,14 @@ public sealed class UserServiceContactSourceCountTests : IDisposable
         var userEmailRepo = new UserEmailRepository(factory);
         var profileRepo = new ProfileRepository(factory, new FakeClock(Instant.FromUtc(2026, 1, 1, 0, 0)));
         var contactFieldRepo = new ContactFieldRepository(factory);
+        var communicationPreferenceRepo = new CommunicationPreferenceRepository(factory);
 
         _service = new UserService(
             userRepo,
             userEmailRepo,
             profileRepo,
             contactFieldRepo,
+            communicationPreferenceRepo,
             Substitute.For<IFullProfileInvalidator>(),
             Substitute.For<IAdminAuthorizationService>(),
             new FakeClock(Instant.FromUtc(2026, 1, 1, 0, 0)),

--- a/tests/Humans.Application.Tests/UserInfoTests.cs
+++ b/tests/Humans.Application.Tests/UserInfoTests.cs
@@ -146,6 +146,38 @@ public class UserInfoTests
     }
 
     [HumansFact]
+    public void HasTicketForYear_only_matches_the_requested_year()
+    {
+        var participations = new[]
+        {
+            new EventParticipation
+            {
+                Id = Guid.NewGuid(),
+                UserId = Guid.NewGuid(),
+                Year = 2025,
+                Status = ParticipationStatus.Attended,
+                Source = ParticipationSource.TicketSync,
+            }
+        };
+
+        var info = UserInfo.Create(
+            MinimalUser(),
+            Array.Empty<UserEmail>(),
+            participations,
+            Array.Empty<(string, string)>(),
+            profile: null,
+            Array.Empty<ContactField>(),
+            Array.Empty<ProfileLanguage>(),
+            Array.Empty<VolunteerHistoryEntry>(),
+            Array.Empty<CommunicationPreference>());
+
+        info.HasTicketForYear(2025).Should().BeTrue();
+        info.HasTicketForYear(2026).Should().BeFalse();
+        // Year-agnostic accessor still sees the prior-year ticket.
+        info.HasTicket.Should().BeTrue();
+    }
+
+    [HumansFact]
     public void HasTicket_false_when_only_NotAttending_or_no_participations()
     {
         var participations = new[]

--- a/tests/Humans.Application.Tests/UserInfoTests.cs
+++ b/tests/Humans.Application.Tests/UserInfoTests.cs
@@ -66,4 +66,111 @@ public class UserInfoTests
         info.CommunicationPreferences[0].OptedOut.Should().BeFalse();
         info.CommunicationPreferences[0].UpdateSource.Should().Be("Profile");
     }
+
+    [HumansFact]
+    public void MarketingOptedOut_is_null_when_no_marketing_pref()
+    {
+        var info = UserInfo.Create(
+            MinimalUser(),
+            Array.Empty<UserEmail>(),
+            Array.Empty<EventParticipation>(),
+            Array.Empty<(string, string)>(),
+            profile: null,
+            Array.Empty<ContactField>(),
+            Array.Empty<ProfileLanguage>(),
+            Array.Empty<VolunteerHistoryEntry>(),
+            Array.Empty<CommunicationPreference>());
+
+        info.MarketingOptedOut.Should().BeNull();
+    }
+
+    [HumansFact]
+    public void MarketingOptedOut_reflects_pref_when_present()
+    {
+        var userId = Guid.NewGuid();
+        var prefs = new[]
+        {
+            new CommunicationPreference
+            {
+                Id = Guid.NewGuid(),
+                UserId = userId,
+                Category = MessageCategory.Marketing,
+                OptedOut = true,
+                InboxEnabled = true,
+                UpdatedAt = Instant.FromUtc(2026, 4, 1, 0, 0),
+                UpdateSource = "Profile",
+            },
+        };
+
+        var info = UserInfo.Create(
+            MinimalUser(userId),
+            Array.Empty<UserEmail>(),
+            Array.Empty<EventParticipation>(),
+            Array.Empty<(string, string)>(),
+            profile: null,
+            Array.Empty<ContactField>(),
+            Array.Empty<ProfileLanguage>(),
+            Array.Empty<VolunteerHistoryEntry>(),
+            prefs);
+
+        info.MarketingOptedOut.Should().BeTrue();
+    }
+
+    [HumansFact]
+    public void HasTicket_true_when_any_participation_is_Ticketed_or_Attended()
+    {
+        var participations = new[]
+        {
+            new EventParticipation
+            {
+                Id = Guid.NewGuid(),
+                UserId = Guid.NewGuid(),
+                Year = 2026,
+                Status = ParticipationStatus.Ticketed,
+                Source = ParticipationSource.TicketSync,
+            }
+        };
+
+        var info = UserInfo.Create(
+            MinimalUser(),
+            Array.Empty<UserEmail>(),
+            participations,
+            Array.Empty<(string, string)>(),
+            profile: null,
+            Array.Empty<ContactField>(),
+            Array.Empty<ProfileLanguage>(),
+            Array.Empty<VolunteerHistoryEntry>(),
+            Array.Empty<CommunicationPreference>());
+
+        info.HasTicket.Should().BeTrue();
+    }
+
+    [HumansFact]
+    public void HasTicket_false_when_only_NotAttending_or_no_participations()
+    {
+        var participations = new[]
+        {
+            new EventParticipation
+            {
+                Id = Guid.NewGuid(),
+                UserId = Guid.NewGuid(),
+                Year = 2026,
+                Status = ParticipationStatus.NotAttending,
+                Source = ParticipationSource.UserDeclared,
+            }
+        };
+
+        var info = UserInfo.Create(
+            MinimalUser(),
+            Array.Empty<UserEmail>(),
+            participations,
+            Array.Empty<(string, string)>(),
+            profile: null,
+            Array.Empty<ContactField>(),
+            Array.Empty<ProfileLanguage>(),
+            Array.Empty<VolunteerHistoryEntry>(),
+            Array.Empty<CommunicationPreference>());
+
+        info.HasTicket.Should().BeFalse();
+    }
 }

--- a/tests/Humans.Application.Tests/UserInfoTests.cs
+++ b/tests/Humans.Application.Tests/UserInfoTests.cs
@@ -1,0 +1,69 @@
+using AwesomeAssertions;
+using Humans.Application;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using NodaTime;
+using Xunit;
+
+namespace Humans.Application.Tests;
+
+public class UserInfoTests
+{
+    private static User MinimalUser(Guid? id = null) => new()
+    {
+        Id = id ?? Guid.NewGuid(),
+        DisplayName = "Test",
+        PreferredLanguage = "en",
+        CreatedAt = Instant.FromUtc(2026, 1, 1, 0, 0),
+        GoogleEmailStatus = GoogleEmailStatus.Unknown,
+    };
+
+    [HumansFact]
+    public void Create_carries_communication_preferences_projection()
+    {
+        var userId = Guid.NewGuid();
+        var prefs = new[]
+        {
+            new CommunicationPreference
+            {
+                Id = Guid.NewGuid(),
+                UserId = userId,
+                Category = MessageCategory.Marketing,
+                OptedOut = false,
+                InboxEnabled = true,
+                UpdatedAt = Instant.FromUtc(2026, 4, 1, 0, 0),
+                UpdateSource = "Profile",
+                SubscribedAt = Instant.FromUtc(2026, 4, 1, 0, 0),
+            },
+            new CommunicationPreference
+            {
+                Id = Guid.NewGuid(),
+                UserId = userId,
+                Category = MessageCategory.Governance,
+                OptedOut = true,
+                InboxEnabled = false,
+                UpdatedAt = Instant.FromUtc(2026, 4, 2, 0, 0),
+                UpdateSource = "MagicLink",
+                SubscribedAt = null,
+            },
+        };
+
+        var info = UserInfo.Create(
+            user: MinimalUser(userId),
+            userEmails: Array.Empty<UserEmail>(),
+            eventParticipations: Array.Empty<EventParticipation>(),
+            externalLogins: Array.Empty<(string, string)>(),
+            profile: null,
+            contactFields: Array.Empty<ContactField>(),
+            profileLanguages: Array.Empty<ProfileLanguage>(),
+            volunteerHistory: Array.Empty<VolunteerHistoryEntry>(),
+            communicationPreferences: prefs);
+
+        // Marketing (3) sorts before Governance (4) by enum value ascending.
+        info.CommunicationPreferences.Should().HaveCount(2);
+        info.CommunicationPreferences.Select(c => c.Category)
+            .Should().Equal(MessageCategory.Marketing, MessageCategory.Governance);
+        info.CommunicationPreferences[0].OptedOut.Should().BeFalse();
+        info.CommunicationPreferences[0].UpdateSource.Should().Be("Profile");
+    }
+}

--- a/tests/Humans.Web.Tests/Controllers/UsersAdminDebugControllerTests.cs
+++ b/tests/Humans.Web.Tests/Controllers/UsersAdminDebugControllerTests.cs
@@ -6,6 +6,7 @@ using Humans.Domain.Enums;
 using Humans.Web.Controllers;
 using Humans.Web.Models;
 using Humans.Testing;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using NodaTime;
 using NSubstitute;
@@ -15,6 +16,11 @@ namespace Humans.Web.Tests.Controllers;
 
 public class UsersAdminDebugControllerTests
 {
+    private static UserManager<User> StubUserManager() =>
+        Substitute.For<UserManager<User>>(
+            Substitute.For<IUserStore<User>>(),
+            null, null, null, null, null, null, null, null);
+
     private static UserInfo MakeUserInfo(
         Guid id, string displayName, bool hasProfile, bool hasTicket)
     {
@@ -74,7 +80,7 @@ public class UsersAdminDebugControllerTests
         var userService = Substitute.For<IUserService>();
         userService.GetAllUserInfos().Returns(users);
 
-        var controller = new UsersAdminDebugController(userService);
+        var controller = new UsersAdminDebugController(userService, StubUserManager());
 
         var result = controller.Index(page: 1, pageSize: 50, sort: "displayName", dir: "asc") as ViewResult;
 
@@ -98,7 +104,7 @@ public class UsersAdminDebugControllerTests
         var userService = Substitute.For<IUserService>();
         userService.GetAllUserInfos().Returns(users);
 
-        var controller = new UsersAdminDebugController(userService);
+        var controller = new UsersAdminDebugController(userService, StubUserManager());
 
         var result = controller.Index(page: 1, pageSize: 50, sort: "displayName", dir: "desc") as ViewResult;
 
@@ -115,7 +121,7 @@ public class UsersAdminDebugControllerTests
         var userService = Substitute.For<IUserService>();
         userService.GetAllUserInfos().Returns(users);
 
-        var controller = new UsersAdminDebugController(userService);
+        var controller = new UsersAdminDebugController(userService, StubUserManager());
 
         var tooSmall = (UsersDebugViewModel)((ViewResult)controller.Index(1, 1, "displayName", "asc")).Model!;
         tooSmall.PageSize.Should().Be(10);

--- a/tests/Humans.Web.Tests/Controllers/UsersAdminDebugControllerTests.cs
+++ b/tests/Humans.Web.Tests/Controllers/UsersAdminDebugControllerTests.cs
@@ -1,0 +1,126 @@
+using AwesomeAssertions;
+using Humans.Application;
+using Humans.Application.Interfaces.Users;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using Humans.Web.Controllers;
+using Humans.Web.Models;
+using Humans.Testing;
+using Microsoft.AspNetCore.Mvc;
+using NodaTime;
+using NSubstitute;
+using Xunit;
+
+namespace Humans.Web.Tests.Controllers;
+
+public class UsersAdminDebugControllerTests
+{
+    private static UserInfo MakeUserInfo(
+        Guid id, string displayName, bool hasProfile, bool hasTicket)
+    {
+        var participations = hasTicket
+            ? new[]
+            {
+                new EventParticipation
+                {
+                    Id = Guid.NewGuid(),
+                    UserId = id,
+                    Year = 2026,
+                    Status = ParticipationStatus.Ticketed,
+                    Source = ParticipationSource.TicketSync,
+                }
+            }
+            : Array.Empty<EventParticipation>();
+
+        Profile? profile = hasProfile
+            ? new Profile
+            {
+                Id = Guid.NewGuid(),
+                UserId = id,
+                BurnerName = "Burner",
+                FirstName = "First",
+                LastName = "Last",
+                CreatedAt = Instant.FromUtc(2026, 1, 1, 0, 0),
+                UpdatedAt = Instant.FromUtc(2026, 1, 1, 0, 0),
+            }
+            : null;
+
+        return UserInfo.Create(
+            user: new User
+            {
+                Id = id,
+                DisplayName = displayName,
+                PreferredLanguage = "en",
+                CreatedAt = Instant.FromUtc(2026, 1, 1, 0, 0),
+                GoogleEmailStatus = GoogleEmailStatus.Unknown,
+            },
+            userEmails: Array.Empty<UserEmail>(),
+            eventParticipations: participations,
+            externalLogins: Array.Empty<(string, string)>(),
+            profile: profile,
+            contactFields: Array.Empty<ContactField>(),
+            profileLanguages: Array.Empty<ProfileLanguage>(),
+            volunteerHistory: Array.Empty<VolunteerHistoryEntry>(),
+            communicationPreferences: Array.Empty<CommunicationPreference>());
+    }
+
+    [HumansFact]
+    public void Index_returns_paged_rows_from_snapshot()
+    {
+        var users = Enumerable.Range(0, 60)
+            .Select(i => MakeUserInfo(Guid.NewGuid(), $"User {i:D3}", hasProfile: i % 2 == 0, hasTicket: i % 3 == 0))
+            .ToArray();
+
+        var userService = Substitute.For<IUserService>();
+        userService.GetAllUserInfos().Returns(users);
+
+        var controller = new UsersAdminDebugController(userService);
+
+        var result = controller.Index(page: 1, pageSize: 50, sort: "displayName", dir: "asc") as ViewResult;
+
+        result.Should().NotBeNull();
+        var vm = result!.Model.Should().BeOfType<UsersDebugViewModel>().Subject;
+        vm.TotalCount.Should().Be(60);
+        vm.Rows.Should().HaveCount(50);
+        vm.TotalPages.Should().Be(2);
+        vm.Rows[0].DisplayName.Should().Be("User 000");
+    }
+
+    [HumansFact]
+    public void Index_sort_displayName_descending_reverses_order()
+    {
+        var users = new[]
+        {
+            MakeUserInfo(Guid.NewGuid(), "Alice", hasProfile: true, hasTicket: false),
+            MakeUserInfo(Guid.NewGuid(), "Bob",   hasProfile: true, hasTicket: false),
+            MakeUserInfo(Guid.NewGuid(), "Carol", hasProfile: true, hasTicket: false),
+        };
+        var userService = Substitute.For<IUserService>();
+        userService.GetAllUserInfos().Returns(users);
+
+        var controller = new UsersAdminDebugController(userService);
+
+        var result = controller.Index(page: 1, pageSize: 50, sort: "displayName", dir: "desc") as ViewResult;
+
+        var vm = (UsersDebugViewModel)result!.Model!;
+        vm.Rows.Select(r => r.DisplayName).Should().Equal("Carol", "Bob", "Alice");
+    }
+
+    [HumansFact]
+    public void Index_clamps_pageSize_outside_10_to_200_range()
+    {
+        var users = Enumerable.Range(0, 5)
+            .Select(i => MakeUserInfo(Guid.NewGuid(), $"User {i}", true, false))
+            .ToArray();
+        var userService = Substitute.For<IUserService>();
+        userService.GetAllUserInfos().Returns(users);
+
+        var controller = new UsersAdminDebugController(userService);
+
+        var tooSmall = (UsersDebugViewModel)((ViewResult)controller.Index(1, 1, "displayName", "asc")).Model!;
+        tooSmall.PageSize.Should().Be(10);
+
+        var tooBig = (UsersDebugViewModel)((ViewResult)controller.Index(1, 9999, "displayName", "asc")).Model!;
+        tooBig.PageSize.Should().Be(200);
+    }
+}


### PR DESCRIPTION
## Summary
- Replaces `/Admin` "Active humans 979" with three UserInfo-snapshot cards: Total users / Active (has profile) / Ticket holders.
- Adds `/Users/Admin/Debug` flat paginated/sortable table — every column from the cached `UserInfo`, no secondary queries.
- Replaces `/Tickets` coverage card + unbounded donut with a 3-set Venn (Users / Profiles / Tickets) + UpSet plot, both height-bounded.
- Extends `UserInfo` with `CommunicationPreferences` so Marketing opt-in lives on the cached god-object; `UserInfoSaveChangesInterceptor` catches `communication_preferences` writes for invalidation.

Spec: `docs/superpowers/specs/2026-05-14-userinfo-debug-and-venn-design.md`
Plan: `docs/superpowers/plans/2026-05-14-userinfo-debug-and-venn.md`

## Test plan
- [x] Build clean: `dotnet build Humans.slnx -v quiet`
- [x] Unit tests pass: Domain, Analyzers, Web, Application (2766/2767 pass, 1 pre-existing skip).
- [ ] Integration tests are pre-existing red on main (environmental — LivenessEndpoint timeouts, merge tests). Not introduced by this PR.
- [ ] Visual smoke (preview env): `/Admin` shows three new cards, no "Active humans"; `/Users/Admin/Debug` lists cached users with paging+sort; `/Tickets` shows Venn + UpSet side-by-side, donut + coverage gone.
- [ ] Admin sidebar shows "All users (debug)" under Diagnostics group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)