### PR TITLE
fix(cancellation): catch all request-scope OCEs; guard AddMember vs empty Guid

### DIFF
--- a/src/Humans.Web/Controllers/HomeController.cs
+++ b/src/Humans.Web/Controllers/HomeController.cs
@@ -49,21 +49,6 @@ public class HomeController : HumansControllerBase
 
     public async Task<IActionResult> Index(CancellationToken cancellationToken)
     {
-        try
-        {
-            return await IndexCore(cancellationToken);
-        }
-        catch (OperationCanceledException) when (HttpContext.RequestAborted.IsCancellationRequested)
-        {
-            // Client aborted the request mid-read. Don't surface as 500/Error;
-            // log at Warning without the exception object.
-            _logger.LogWarning("Request aborted while rendering home dashboard");
-            return new EmptyResult();
-        }
-    }
-
-    private async Task<IActionResult> IndexCore(CancellationToken cancellationToken)
-    {
         if (!User.Identity?.IsAuthenticated ?? true)
         {
             return View();

--- a/src/Humans.Web/Controllers/ProfileController.cs
+++ b/src/Humans.Web/Controllers/ProfileController.cs
@@ -1776,24 +1776,13 @@ public class ProfileController : HumansControllerBase
         // store directly — IProfileService owns the FS-first / DB-fallback /
         // migrate-on-read orchestration AND the anonymization gate (issue
         // nobodies-collective/Humans#527).
-        try
+        var result = await _profileService.GetProfilePictureAsync(id, ct);
+        if (result is null)
         {
-            var result = await _profileService.GetProfilePictureAsync(id, ct);
-            if (result is null)
-            {
-                return NotFound();
-            }
+            return NotFound();
+        }
 
-            return File(result.Value.Data, result.Value.ContentType);
-        }
-        catch (OperationCanceledException) when (HttpContext.RequestAborted.IsCancellationRequested)
-        {
-            // Client aborted the request mid-read. Don't surface as 500/Error;
-            // log at Warning without the exception object so the prod log viewer
-            // still sees the event but the stack-trace noise is dropped.
-            _logger.LogWarning("Request aborted while reading profile picture for {ProfileId}", id);
-            return new EmptyResult();
-        }
+        return File(result.Value.Data, result.Value.ContentType);
     }
 
     [HttpPost("Me/ImportGooglePhoto")]
@@ -1990,79 +1979,69 @@ public class ProfileController : HumansControllerBase
     [HttpGet("{id:guid}/Popover")]
     public async Task<IActionResult> Popover(Guid id, CancellationToken ct)
     {
-        try
+        var userTask = _userService.GetByIdAsync(id, ct);
+        var profileTask = _profileService.GetProfileAsync(id, ct);
+        await Task.WhenAll(userTask, profileTask);
+        var popoverUser = await userTask;
+        if (popoverUser is null) return NotFound();
+
+        var profile = await profileTask;
+        if (profile is null)
         {
-            var userTask = _userService.GetByIdAsync(id, ct);
-            var profileTask = _profileService.GetProfileAsync(id, ct);
-            await Task.WhenAll(userTask, profileTask);
-            var popoverUser = await userTask;
-            if (popoverUser is null) return NotFound();
+            // popoverUser.Email is unsafe here — User.Email SILENT-FALLBACK FOOTGUN.
+            var userEmails = await _userEmailService.GetUserEmailsAsync(id, ct);
+            var fallbackEmail = userEmails.FirstOrDefault(e => e.IsVerified && e.IsPrimary)?.Email
+                ?? userEmails.FirstOrDefault(e => e.IsVerified)?.Email;
 
-            var profile = await profileTask;
-            if (profile is null)
-            {
-                // popoverUser.Email is unsafe here — User.Email SILENT-FALLBACK FOOTGUN.
-                var userEmails = await _userEmailService.GetUserEmailsAsync(id, ct);
-                var fallbackEmail = userEmails.FirstOrDefault(e => e.IsVerified && e.IsPrimary)?.Email
-                    ?? userEmails.FirstOrDefault(e => e.IsVerified)?.Email;
-
-                var fallbackVm = new ProfileSummaryViewModel
-                {
-                    UserId = id,
-                    DisplayName = popoverUser.DisplayName,
-                    Email = fallbackEmail,
-                    ProfilePictureUrl = popoverUser.ProfilePictureUrl,
-                    PreferredLanguage = popoverUser.PreferredLanguage,
-                    HasProfile = false,
-                };
-
-                return PartialView("_HumanPopover", fallbackVm);
-            }
-
-            var memberships = (await _teamService.GetActiveTeamMembershipsForUserAsync(id, ct))
-                .OrderBy(m => m.TeamName, StringComparer.OrdinalIgnoreCase)
-                .ToList();
-            var publicTeams = memberships.Where(m => !m.IsHidden).Select(m => m.TeamName).ToList();
-            var hiddenTeams = memberships.Where(m => m.IsHidden).Select(m => m.TeamName).ToList();
-            var profileLanguages = await _profileService.GetProfileLanguagesAsync(profile.Id, ct);
-
-            var effectivePictureUrl = profile.HasCustomProfilePicture
-                ? Url.Action(nameof(Picture), "Profile",
-                    new { id = profile.Id, v = profile.UpdatedAt.ToUnixTimeTicks() })
-                : popoverUser.ProfilePictureUrl;
-
-            var vm = new ProfileSummaryViewModel
+            var fallbackVm = new ProfileSummaryViewModel
             {
                 UserId = id,
                 DisplayName = popoverUser.DisplayName,
-                Email = popoverUser.Email,
-                ProfilePictureUrl = effectivePictureUrl,
+                Email = fallbackEmail,
+                ProfilePictureUrl = popoverUser.ProfilePictureUrl,
                 PreferredLanguage = popoverUser.PreferredLanguage,
-                MembershipTier = profile.MembershipTier.ToString(),
-                MembershipStatus = profile.IsSuspended ? "Suspended"
-                    : profile.IsApproved ? "Active" : "Pending",
-                City = profile.City,
-                CountryCode = profile.CountryCode,
-                IsSuspended = profile.IsSuspended,
-                Teams = publicTeams,
-                HiddenTeams = hiddenTeams,
-                Languages = profileLanguages.Select(pl => new ProfileLanguageDisplayViewModel
-                {
-                    LanguageCode = pl.LanguageCode,
-                    LanguageName = Helpers.LanguageCatalog.GetDisplayName(pl.LanguageCode),
-                    Proficiency = pl.Proficiency
-                }).ToList()
+                HasProfile = false,
             };
 
-            return PartialView("_HumanPopover", vm);
+            return PartialView("_HumanPopover", fallbackVm);
         }
-        catch (OperationCanceledException) when (HttpContext.RequestAborted.IsCancellationRequested)
+
+        var memberships = (await _teamService.GetActiveTeamMembershipsForUserAsync(id, ct))
+            .OrderBy(m => m.TeamName, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        var publicTeams = memberships.Where(m => !m.IsHidden).Select(m => m.TeamName).ToList();
+        var hiddenTeams = memberships.Where(m => m.IsHidden).Select(m => m.TeamName).ToList();
+        var profileLanguages = await _profileService.GetProfileLanguagesAsync(profile.Id, ct);
+
+        var effectivePictureUrl = profile.HasCustomProfilePicture
+            ? Url.Action(nameof(Picture), "Profile",
+                new { id = profile.Id, v = profile.UpdatedAt.ToUnixTimeTicks() })
+            : popoverUser.ProfilePictureUrl;
+
+        var vm = new ProfileSummaryViewModel
         {
-            // Client aborted the request mid-read. Don't surface as 500/Error;
-            // log at Warning without the exception object.
-            _logger.LogWarning("Request aborted while loading popover for {ProfileId}", id);
-            return new EmptyResult();
-        }
+            UserId = id,
+            DisplayName = popoverUser.DisplayName,
+            Email = popoverUser.Email,
+            ProfilePictureUrl = effectivePictureUrl,
+            PreferredLanguage = popoverUser.PreferredLanguage,
+            MembershipTier = profile.MembershipTier.ToString(),
+            MembershipStatus = profile.IsSuspended ? "Suspended"
+                : profile.IsApproved ? "Active" : "Pending",
+            City = profile.City,
+            CountryCode = profile.CountryCode,
+            IsSuspended = profile.IsSuspended,
+            Teams = publicTeams,
+            HiddenTeams = hiddenTeams,
+            Languages = profileLanguages.Select(pl => new ProfileLanguageDisplayViewModel
+            {
+                LanguageCode = pl.LanguageCode,
+                LanguageName = Helpers.LanguageCatalog.GetDisplayName(pl.LanguageCode),
+                Proficiency = pl.Proficiency
+            }).ToList()
+        };
+
+        return PartialView("_HumanPopover", vm);
     }
 
     [HttpGet("{id:guid}/SendMessage")]

--- a/src/Humans.Web/Controllers/TeamAdminController.cs
+++ b/src/Humans.Web/Controllers/TeamAdminController.cs
@@ -330,6 +330,15 @@ public class TeamAdminController : HumansTeamControllerBase
             return teamError;
         }
 
+        // Form posted without a user selected (or the hidden input was empty / tampered).
+        // Reject at the controller so we don't reach EF and crash on the
+        // google_sync_outbox FK with Guid.Empty.
+        if (model.UserId == Guid.Empty)
+        {
+            SetError("Select a user to add.");
+            return RedirectToAction(nameof(Members), new { slug });
+        }
+
         try
         {
             await _teamService.AddMemberToTeamAsync(team.Id, model.UserId, user.Id);

--- a/src/Humans.Web/ExceptionHandlers/CancellationExceptionHandler.cs
+++ b/src/Humans.Web/ExceptionHandlers/CancellationExceptionHandler.cs
@@ -3,15 +3,19 @@ using Microsoft.AspNetCore.Diagnostics;
 namespace Humans.Web.ExceptionHandlers;
 
 /// <summary>
-/// Swallows <see cref="OperationCanceledException"/> when the cancellation originated
-/// from the client aborting the request (<see cref="HttpContext.RequestAborted"/>).
-/// Logs at Warning (without the exception) per <c>memory/code/always-log-problems.md</c>
-/// — expected events still need to be visible in the prod log viewer. Sets status 499
-/// ("Client Closed Request", an nginx convention) when the response hasn't already
-/// started, and returns <c>true</c> to short-circuit further handlers.
+/// Swallows every <see cref="OperationCanceledException"/> that reaches the exception
+/// pipeline. Inside a request scope an OCE is always non-actionable: either the client
+/// aborted, the host is shutting down, or a linked/scope token tripped — in all cases
+/// the response is going nowhere useful. Logs at Warning (without the exception object)
+/// so the event is still visible in the prod log viewer per
+/// <c>memory/code/always-log-problems.md</c>, and sets status 499 ("Client Closed
+/// Request", nginx convention) when the response hasn't already started.
 ///
-/// Registered BEFORE <see cref="GlobalLoggingExceptionHandler"/> so cancellations
-/// never get logged as errors.
+/// The earlier predicate required <see cref="HttpContext.RequestAborted"/> to be
+/// flagged or the OCE's token to be reference-equal to it; EF/Npgsql often throw with
+/// a linked token instead, so real aborts fell through to
+/// <see cref="GlobalLoggingExceptionHandler"/> and surfaced as 500s. Registered BEFORE
+/// <see cref="GlobalLoggingExceptionHandler"/> so cancellations never reach Error.
 /// </summary>
 public sealed class CancellationExceptionHandler : IExceptionHandler
 {
@@ -27,32 +31,13 @@ public sealed class CancellationExceptionHandler : IExceptionHandler
         Exception exception,
         CancellationToken cancellationToken)
     {
-        if (exception is not OperationCanceledException oce)
+        if (exception is not OperationCanceledException)
         {
-            return ValueTask.FromResult(false);
-        }
-
-        // Treat as a client abort when either:
-        //  - the request has been aborted (RequestAborted flagged), or
-        //  - the OCE carries the request's cancellation token (Npgsql and other
-        //    DB-level cancellations propagate this even when RequestAborted
-        //    hasn't been observed yet on this thread).
-        // This second branch covers `NpgsqlOperationCanceledException` from
-        // mid-query aborts where the request token tripped Npgsql before the
-        // pipeline had a chance to flag RequestAborted.
-        var isClientAbort =
-            httpContext.RequestAborted.IsCancellationRequested
-            || (oce.CancellationToken.IsCancellationRequested
-                && oce.CancellationToken == httpContext.RequestAborted);
-
-        if (!isClientAbort)
-        {
-            // Server-initiated cancellation — let other handlers log/handle.
             return ValueTask.FromResult(false);
         }
 
         _logger.LogWarning(
-            "Request cancelled by client on {Method} {Path}",
+            "Request cancelled on {Method} {Path}",
             httpContext.Request.Method,
             httpContext.Request.Path);
 

--- a/src/Humans.Web/ExceptionHandlers/CancellationExceptionHandler.cs
+++ b/src/Humans.Web/ExceptionHandlers/CancellationExceptionHandler.cs
@@ -36,8 +36,27 @@ public sealed class CancellationExceptionHandler : IExceptionHandler
             return ValueTask.FromResult(false);
         }
 
+        // Differentiated log messages so triage can tell "user clicked away" from
+        // "server-initiated cancellation" — but BOTH paths are intentionally
+        // swallowed at Warning + 499, never escalated to Error:
+        //   - Client abort: the response is dead, there's nothing useful to send,
+        //     stack-trace-level logging is noise.
+        //   - Non-client cancellation (linked CTS timeout, scope dispose, host
+        //     shutdown): same thing — the response is going nowhere; an Error log
+        //     with stack trace would imply an actionable bug when typically there
+        //     is none. We log at Warning so it stays visible in the prod log
+        //     viewer; if a real server-side timeout ever needs Error-level
+        //     attention, the code introducing the timeout should log it directly
+        //     before letting the OCE escape.
+        // This comment exists to prevent re-tightening the predicate; the prior
+        // form gated on `RequestAborted.IsCancellationRequested` and missed real
+        // client aborts where Npgsql/EF threw with a linked token, surfacing them
+        // as 500s.
+        var clientAborted = httpContext.RequestAborted.IsCancellationRequested;
         _logger.LogWarning(
-            "Request cancelled on {Method} {Path}",
+            clientAborted
+                ? "Request cancelled by client on {Method} {Path}"
+                : "Request cancelled (non-client) on {Method} {Path}",
             httpContext.Request.Method,
             httpContext.Request.Path);
 


### PR DESCRIPTION
## Summary
Two production-log fixes discovered during `/triage` on 2026-05-14:

- **Cancellation noise → 500s.** `CancellationExceptionHandler`'s predicate required `HttpContext.RequestAborted.IsCancellationRequested` to be flagged OR the OCE's token to be reference-equal to `RequestAborted`. EF/Npgsql often throw OCE with a *linked* token instead, so real client aborts on `/Admin` and `/Governance/BoardVoting/{id}` fell through to `GlobalLoggingExceptionHandler` → logged at Error → 500. The handler now treats every request-scope OCE as non-actionable (log Warning, set 499 if response not started). The three per-controller `catch (OCE) when RequestAborted` blocks in `ProfileController.Picture`, `ProfileController.Popover`, and `HomeController.Index` existed as workarounds for the unreliable global — they're gone.
- **Empty-Guid AddMember 500.** `TeamAdminController.AddMember` accepted `model.UserId == Guid.Empty` (form posted without a user selected), reached EF, and crashed at the `google_sync_outbox.UserId` FK. `CampController.AddMember` already had the empty-Guid guard; this brings `TeamAdminController` to parity (`SetError("Select a user to add.")` + redirect).

Related — still open: #677 (Google sync precondition 4002 retry loop for non-Google emails) — separate concern, not touched here.

## Test plan
- [x] `dotnet build Humans.slnx -v quiet` clean (only pre-existing HUM0009 warnings)
- [x] Domain / Analyzers / Web / Application test suites all pass
- [x] Integration test failures (66) are pre-existing on `origin/main` (Hangfire `JobStorage` not initialized in `WebApplicationFactory` for AccountMerge tests) — not introduced by this PR
- [ ] Verify in preview env that an aborted GET (e.g., navigate away during `/Admin` load) logs `"Request cancelled on …"` at Warning, not Error 500
- [ ] Verify in preview env that submitting `Teams/{slug}/Members/Add` with no user selected shows `"Select a user to add."` and doesn't 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)