### PR TITLE
refactor(userinfo-readers): drain FullProfile readers + cleanup N+1 patterns

### DIFF
--- a/src/Humans.Application/Services/Profile/EmailProblemsService.cs
+++ b/src/Humans.Application/Services/Profile/EmailProblemsService.cs
@@ -1,7 +1,6 @@
 using Humans.Application.DTOs.EmailProblems;
 using Humans.Application.Interfaces.Profiles;
 using Humans.Application.Interfaces.Users;
-using Humans.Domain.Entities;
 using Humans.Domain.Helpers;
 using NodaTime;
 
@@ -9,18 +8,15 @@ namespace Humans.Application.Services.Profile;
 
 public sealed class EmailProblemsService : IEmailProblemsService
 {
-    private readonly IProfileService _profileService;
     private readonly IUserEmailService _userEmailService;
     private readonly IUserService _userService;
     private readonly IClock _clock;
 
     public EmailProblemsService(
-        IProfileService profileService,
         IUserEmailService userEmailService,
         IUserService userService,
         IClock clock)
     {
-        _profileService = profileService;
         _userEmailService = userEmailService;
         _userService = userService;
         _clock = clock;
@@ -30,47 +26,42 @@ public sealed class EmailProblemsService : IEmailProblemsService
     {
         var problems = new List<EmailProblem>();
 
-        var users = await _userService.GetAllUsersAsync(ct);
-        var profiles = new List<FullProfile>(users.Count);
-        foreach (var u in users)
-        {
-            var fp = await _profileService.GetFullProfileAsync(u.Id, ct);
-            if (fp is not null) profiles.Add(fp);
-        }
+        var allInfos = _userService.GetAllUserInfos();
+        var profiled = allInfos.Where(i => i.Profile is not null).ToList();
 
-        foreach (var p in profiles)
+        foreach (var p in profiled)
         {
-            var emails = p.AllUserEmails;
+            var emails = p.UserEmails;
 
             if (emails.Count(e => e.IsPrimary) > 1)
                 problems.Add(new EmailProblem(
-                    EmailProblemKind.MultipleIsPrimary, p.UserId, null, null, null, null));
+                    EmailProblemKind.MultipleIsPrimary, p.Id, null, null, null, null));
 
             if (emails.Count(e => e.IsGoogle) > 1)
                 problems.Add(new EmailProblem(
-                    EmailProblemKind.MultipleIsGoogle, p.UserId, null, null, null, null));
+                    EmailProblemKind.MultipleIsGoogle, p.Id, null, null, null, null));
 
             if (emails.Any(e => e.IsVerified) && !emails.Any(e => e.IsPrimary))
                 problems.Add(new EmailProblem(
-                    EmailProblemKind.ZeroIsPrimary, p.UserId, null, null, null, null));
+                    EmailProblemKind.ZeroIsPrimary, p.Id, null, null, null, null));
 
             if (!emails.Any(e => e.IsGoogle))
                 problems.Add(new EmailProblem(
-                    EmailProblemKind.ZeroIsGoogle, p.UserId, null, null, null, null));
+                    EmailProblemKind.ZeroIsGoogle, p.Id, null, null, null, null));
 
             foreach (var unverified in emails.Where(e => !e.IsVerified))
             {
                 problems.Add(new EmailProblem(
-                    EmailProblemKind.Unverified, p.UserId, null,
+                    EmailProblemKind.Unverified, p.Id, null,
                     unverified.Id, unverified.Email, null));
             }
         }
 
         // Cross-user duplicates: build normalized-email -> userIds map, flag pairs.
         var normToUsers = new Dictionary<string, List<(Guid UserId, string Raw)>>(StringComparer.Ordinal);
-        foreach (var p in profiles)
+        foreach (var p in profiled)
         {
-            foreach (var email in p.AllUserEmails)
+            foreach (var email in p.UserEmails)
             {
                 var norm = EmailNormalization.NormalizeForComparison(email.Email);
                 if (!normToUsers.TryGetValue(norm, out var list))
@@ -78,7 +69,7 @@ public sealed class EmailProblemsService : IEmailProblemsService
                     list = new List<(Guid, string)>();
                     normToUsers[norm] = list;
                 }
-                list.Add((p.UserId, email.Email));
+                list.Add((p.Id, email.Email));
             }
         }
 
@@ -115,28 +106,23 @@ public sealed class EmailProblemsService : IEmailProblemsService
         }
 
         // Case 9: legacy AspNetIdentity Email column populated but no matching
-        // verified UserEmail row exists. Read user_emails directly by UserId —
-        // Profile-less users (mailing-list / ticketing imports) have a valid
-        // UserEmail row but no Profile aggregate, so the FullProfile path
-        // would false-positive them.
-        var emailsByUser = await _userEmailService.GetEntitiesByUserIdsAsync(
-            users.Select(u => u.Id).ToList(), ct);
-
-        foreach (var u in users)
+        // verified UserEmail row exists. UserInfo carries both the legacy
+        // column (IdentityEmailColumn) and the loaded UserEmail rows —
+        // Profile-less users (mailing-list / ticketing imports) are
+        // surfaced too because we iterate every UserInfo, not just the
+        // profile-having subset.
+        foreach (var info in allInfos)
         {
-            var legacy = u.IdentityEmailColumn;
+            var legacy = info.IdentityEmailColumn;
             if (string.IsNullOrEmpty(legacy)) continue;
 
-            var userEmails = emailsByUser.TryGetValue(u.Id, out var list)
-                ? list
-                : (IReadOnlyList<UserEmail>)Array.Empty<UserEmail>();
-            var hasMatchingVerifiedRow = userEmails.Any(e =>
+            var hasMatchingVerifiedRow = info.UserEmails.Any(e =>
                 e.IsVerified && string.Equals(e.Email, legacy, StringComparison.OrdinalIgnoreCase));
             if (hasMatchingVerifiedRow) continue;
 
             problems.Add(new EmailProblem(
                 EmailProblemKind.LegacyIdentityEmailNotInUserEmails,
-                u.Id, null, null, legacy, null));
+                info.Id, null, null, legacy, null));
         }
 
         return new EmailProblemsReport(_clock.GetCurrentInstant(), problems);
@@ -146,14 +132,14 @@ public sealed class EmailProblemsService : IEmailProblemsService
     {
         if (user1Id == user2Id) return false;
 
-        var p1 = await _profileService.GetFullProfileAsync(user1Id, ct);
-        var p2 = await _profileService.GetFullProfileAsync(user2Id, ct);
-        if (p1 is null || p2 is null) return false;
+        var info1 = await _userService.GetUserInfoAsync(user1Id, ct);
+        var info2 = await _userService.GetUserInfoAsync(user2Id, ct);
+        if (info1 is null || info2 is null) return false;
 
-        var norms1 = p1.AllUserEmails
+        var norms1 = info1.UserEmails
             .Select(e => EmailNormalization.NormalizeForComparison(e.Email))
             .ToHashSet(StringComparer.Ordinal);
-        return p2.AllUserEmails
+        return info2.UserEmails
             .Any(e => norms1.Contains(EmailNormalization.NormalizeForComparison(e.Email)));
     }
 
@@ -170,21 +156,15 @@ public sealed class EmailProblemsService : IEmailProblemsService
         // admin-invoked and the per-row audit lives at the controller level.
         _ = actorUserId;
 
-        var users = await _userService.GetAllUsersAsync(ct);
-        var userIds = users.Select(u => u.Id).ToList();
-        var emailsByUser = await _userEmailService.GetEntitiesByUserIdsAsync(userIds, ct);
-
+        var allInfos = _userService.GetAllUserInfos();
         var backfilled = new List<(Guid, string)>();
 
-        foreach (var u in users)
+        foreach (var info in allInfos)
         {
-            var legacy = u.IdentityEmailColumn;
+            var legacy = info.IdentityEmailColumn;
             if (string.IsNullOrEmpty(legacy)) continue;
 
-            var userEmails = emailsByUser.TryGetValue(u.Id, out var list)
-                ? list
-                : (IReadOnlyList<UserEmail>)Array.Empty<UserEmail>();
-            if (userEmails.Any(e => e.IsVerified
+            if (info.UserEmails.Any(e => e.IsVerified
                 && string.Equals(e.Email, legacy, StringComparison.OrdinalIgnoreCase)))
                 continue;
 
@@ -193,8 +173,8 @@ public sealed class EmailProblemsService : IEmailProblemsService
             // longer authoritative for OAuth identity (AspNetUserLogins is) —
             // the next OAuth sign-in's reconcile finds the matching row by
             // address and attaches the tag via TagMoved.
-            await _userEmailService.AddVerifiedEmailAsync(u.Id, legacy, ct);
-            backfilled.Add((u.Id, legacy));
+            await _userEmailService.AddVerifiedEmailAsync(info.Id, legacy, ct);
+            backfilled.Add((info.Id, legacy));
         }
 
         return backfilled;

--- a/src/Humans.Web/Controllers/AuditLogController.cs
+++ b/src/Humans.Web/Controllers/AuditLogController.cs
@@ -3,8 +3,8 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Humans.Application.Interfaces.AuditLog;
 using Humans.Application.Interfaces.GoogleIntegration;
-using Humans.Application.Interfaces.Profiles;
 using Humans.Application.Interfaces.Teams;
+using Humans.Application.Interfaces.Users;
 using Humans.Application.Services.AuditLog;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
@@ -17,18 +17,18 @@ namespace Humans.Web.Controllers;
 public class AuditLogController : HumansControllerBase
 {
     private readonly IAuditViewerService _auditViewer;
-    private readonly IProfileService _profileService;
+    private readonly IUserService _userService;
     private readonly ILogger<AuditLogController> _logger;
 
     public AuditLogController(
         UserManager<User> userManager,
         IAuditViewerService auditViewer,
-        IProfileService profileService,
+        IUserService userService,
         ILogger<AuditLogController> logger)
         : base(userManager)
     {
         _auditViewer = auditViewer;
-        _profileService = profileService;
+        _userService = userService;
         _logger = logger;
     }
 
@@ -112,8 +112,8 @@ public class AuditLogController : HumansControllerBase
         }
 
         var events = await _auditViewer.GetGoogleSyncForUserAsync(id);
-        var profile = await _profileService.GetFullProfileAsync(id);
-        var displayName = profile?.DisplayName ?? user.DisplayName;
+        var info = await _userService.GetUserInfoAsync(id);
+        var displayName = info?.BurnerName ?? user.DisplayName;
         return GoogleSyncAuditView(
             $"Google Sync Audit: {displayName}",
             Url.Action(nameof(ProfileController.AdminDetail), "Profile", new { id }),

--- a/src/Humans.Web/Controllers/GoogleController.cs
+++ b/src/Humans.Web/Controllers/GoogleController.cs
@@ -681,28 +681,26 @@ public class GoogleController : HumansControllerBase
     [Authorize(Policy = PolicyNames.AdminOnly)]
     public async Task<IActionResult> SyncOutbox(
         [FromServices] IUserService userService,
-        [FromServices] ITeamService teamService,
-        [FromServices] IProfileService profileService)
+        [FromServices] ITeamService teamService)
     {
         var events = (await _googleSyncService.GetRecentOutboxEventsAsync(200)).ToList();
 
-        // Resolve display info for events via section-owned services (§15 Part 2c,
-        // design-rules §2a — controllers go through service interfaces, not repos).
-        // Issue #635 (§15i): GoogleEmail derives from FullProfile.GoogleEmail
-        // (which reads the IsGoogle UserEmail row); fall back to user.Email
-        // (the canonical primary, computed via the override) when no
-        // IsGoogle row is set.
+        // Resolve display info for events via the UserInfo cache (one
+        // sync-on-hit lookup per user, no per-event DB round-trip).
+        // GoogleEmail derives from the IsGoogle UserEmail row carried inside
+        // UserInfo; fall back to the canonical primary email when no
+        // IsGoogle row is set. BurnerName-resolved name per
+        // memory/architecture/burnername-is-the-display-name.md.
         var userIds = events.Select(e => e.UserId).Distinct().ToList();
         var teamIds = events.Select(e => e.TeamId).Distinct().ToList();
-        var users = await userService.GetByIdsWithEmailsAsync(userIds);
-        var googleEmailLookup = new Dictionary<Guid, string>();
-        foreach (var (userId, user) in users)
+        var googleEmailLookup = new Dictionary<Guid, string>(userIds.Count);
+        var displayNameLookup = new Dictionary<Guid, string>(userIds.Count);
+        foreach (var userId in userIds)
         {
-            var fullProfile = await profileService.GetFullProfileAsync(userId);
-            googleEmailLookup[userId] = fullProfile?.GoogleEmail ?? user.Email ?? "unknown";
+            var info = await userService.GetUserInfoAsync(userId);
+            googleEmailLookup[userId] = info?.GoogleEmail ?? info?.Email ?? "unknown";
+            displayNameLookup[userId] = info?.BurnerName ?? "(unknown)";
         }
-        var displayNameLookup = users.ToDictionary(
-            kvp => kvp.Key, kvp => kvp.Value.DisplayName);
         var teamLookup = (await teamService.GetTeamNamesByIdsAsync(teamIds))
             .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
         var resourcesByTeam = await _teamResourceService.GetResourcesByTeamIdsAsync(teamIds);

--- a/src/Humans.Web/Controllers/ProfileApiController.cs
+++ b/src/Humans.Web/Controllers/ProfileApiController.cs
@@ -1,5 +1,6 @@
 using Humans.Application.DTOs;
 using Humans.Application.Interfaces.Profiles;
+using Humans.Application.Interfaces.Users;
 using Humans.Application.Services.Profiles;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
@@ -20,17 +21,20 @@ public class ProfileApiController : ApiControllerBase
     private const int MaxResults = 10;
 
     private readonly IProfileService _profileService;
+    private readonly IUserService _userService;
     private readonly IContactFieldService _contactFieldService;
     private readonly IUserEmailService _userEmailService;
 
     public ProfileApiController(
         IProfileService profileService,
+        IUserService userService,
         IContactFieldService contactFieldService,
         IUserEmailService userEmailService,
         UserManager<User> userManager)
         : base(userManager)
     {
         _profileService = profileService;
+        _userService = userService;
         _contactFieldService = contactFieldService;
         _userEmailService = userEmailService;
     }
@@ -105,8 +109,8 @@ public class ProfileApiController : ApiControllerBase
             return authError;
         var viewerUserId = viewer.Id;
 
-        var fullProfile = await _profileService.GetFullProfileAsync(userId, ct);
-        if (fullProfile is null || fullProfile.IsRejected)
+        var info = await _userService.GetUserInfoAsync(userId, ct);
+        if (info?.Profile is null || info.Profile.RejectedAt is not null)
             return NotFound();
 
         var pictureUrls = await ProfilePictureUrlHelper.BuildEffectiveUrlsAsync(
@@ -117,17 +121,13 @@ public class ProfileApiController : ApiControllerBase
 
         var detail = await GetSharedDetailAsync(
             userId,
-            fullProfile.ProfileId,
+            info.Profile.Id,
             viewerUserId,
             ct);
 
-        var displayName = string.IsNullOrWhiteSpace(fullProfile.BurnerName)
-            ? fullProfile.DisplayName
-            : fullProfile.BurnerName!;
-
         return Ok(new HumanLookupSearchResult(
             userId,
-            displayName,
+            info.BurnerName,
             detail,
             pictureUrls.GetValueOrDefault(userId)));
     }

--- a/src/Humans.Web/Controllers/VolunteerTrackingController.cs
+++ b/src/Humans.Web/Controllers/VolunteerTrackingController.cs
@@ -1,7 +1,7 @@
 using Humans.Application.DTOs;
 using Humans.Application.Interfaces.AuditLog;
-using Humans.Application.Interfaces.Profiles;
 using Humans.Application.Interfaces.Shifts;
+using Humans.Application.Interfaces.Users;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Humans.Web.Authorization;
@@ -29,20 +29,20 @@ namespace Humans.Web.Controllers;
 public sealed class VolunteerTrackingController : HumansControllerBase
 {
     private readonly IVolunteerTrackingService _service;
-    private readonly IProfileService _profileService;
+    private readonly IUserService _userService;
     private readonly IAuditLogService _auditLogService;
     private readonly IStringLocalizer<SharedResource> _localizer;
 
     public VolunteerTrackingController(
         IVolunteerTrackingService service,
-        IProfileService profileService,
+        IUserService userService,
         IAuditLogService auditLogService,
         UserManager<User> userManager,
         IStringLocalizer<SharedResource> localizer)
         : base(userManager)
     {
         _service = service;
-        _profileService = profileService;
+        _userService = userService;
         _auditLogService = auditLogService;
         _localizer = localizer;
     }
@@ -60,11 +60,13 @@ public sealed class VolunteerTrackingController : HumansControllerBase
             return View(VolunteerTrackingPageViewModel.Empty);
         }
 
-        // Resolve BurnerName-aware display names for the sort key. Per
+        // Resolve BurnerName-aware display names for the sort key and the
+        // partials' tooltip/search strings. One sync-on-hit lookup per user
+        // (no DB round-trip in steady state). Per
         // memory/architecture/burnername-is-the-display-name.md, never read
-        // user.DisplayName for rendering when a Profile exists. The cell-
-        // rendering path uses <vc:human> which fetches its own FullProfile;
-        // here we only need a stable string per user-id for the row sort.
+        // user.DisplayName for rendering when a Profile exists — cell render
+        // uses <vc:human>; this dict is just for the controller-side sort
+        // and the row tooltip text in the partial.
         var displayUserIds = data.MainCohort.Select(r => r.UserId)
             .Concat(data.UnbookedCohort.Select(r => r.UserId))
             .Distinct()
@@ -72,8 +74,8 @@ public sealed class VolunteerTrackingController : HumansControllerBase
         var nameByUserId = new Dictionary<Guid, string>(displayUserIds.Length);
         foreach (var uid in displayUserIds)
         {
-            var fp = await _profileService.GetFullProfileAsync(uid, ct);
-            nameByUserId[uid] = fp?.DisplayName ?? "";
+            var info = await _userService.GetUserInfoAsync(uid, ct);
+            nameByUserId[uid] = info?.BurnerName ?? "";
         }
 
         // Display sort in the controller (presentation concern).
@@ -99,6 +101,7 @@ public sealed class VolunteerTrackingController : HumansControllerBase
             data.Today,
             mainSorted,
             unbookedSorted,
+            nameByUserId,
             hideNoGaps,
             hideCampSetup,
             hideUnbookedSection);

--- a/src/Humans.Web/Models/VolunteerHeatmapPartialModels.cs
+++ b/src/Humans.Web/Models/VolunteerHeatmapPartialModels.cs
@@ -5,17 +5,21 @@ namespace Humans.Web.Models;
 
 /// <summary>
 /// Bundle passed to <c>Views/VolunteerTracking/_VolunteerHeatmap.cshtml</c> —
-/// the rows + the build-window start offset for the column layout. The partial
-/// resolves its own write-policy gate per
-/// <c>memory/code/auth-in-views-self-resolving.md</c> and resolves display
-/// names via <c>&lt;vc:human&gt;</c> per
-/// <c>memory/architecture/burnername-is-the-display-name.md</c>; it does NOT
-/// receive a pre-computed <c>CanWrite</c> bool nor a user dictionary.
+/// the rows + the build-window start offset for the column layout +
+/// pre-resolved BurnerName-aware display names keyed by user id (the
+/// controller batches the lookup; the partial renders without any per-row
+/// service call). The partial resolves its own write-policy gate per
+/// <c>memory/code/auth-in-views-self-resolving.md</c>; avatars and rendered
+/// names come from <c>&lt;vc:human&gt;</c> per
+/// <c>memory/architecture/burnername-is-the-display-name.md</c>. The
+/// <see cref="DisplayNameByUserId"/> dictionary is only used for the row
+/// tooltip/search-filter string.
 /// </summary>
 public sealed record HeatmapPartialModel(
     IReadOnlyList<VolunteerHeatmapRow> Rows,
     int BuildStartOffset,
-    LocalDate GateOpeningDate);
+    LocalDate GateOpeningDate,
+    IReadOnlyDictionary<Guid, string> DisplayNameByUserId);
 
 /// <summary>
 /// Bundle passed to <c>Views/VolunteerTracking/_VolunteerUnbookedHeatmap.cshtml</c>.
@@ -25,4 +29,5 @@ public sealed record HeatmapPartialModel(
 public sealed record UnbookedHeatmapPartialModel(
     IReadOnlyList<VolunteerCohortRow> Rows,
     int BuildStartOffset,
-    LocalDate GateOpeningDate);
+    LocalDate GateOpeningDate,
+    IReadOnlyDictionary<Guid, string> DisplayNameByUserId);

--- a/src/Humans.Web/Models/VolunteerTrackingPageViewModel.cs
+++ b/src/Humans.Web/Models/VolunteerTrackingPageViewModel.cs
@@ -7,10 +7,13 @@ namespace Humans.Web.Models;
 /// View-model for <c>Views/VolunteerTracking/Index.cshtml</c>. Carries both
 /// cohorts (already sorted in the controller per
 /// <c>memory/architecture/display-sort-in-controllers.md</c>), the build-
-/// window start offset for the column layout, and the three filter-toggle
-/// states so the view can render the toggles in their current state. Display
-/// names are resolved by <c>&lt;vc:human&gt;</c> at row-render time per
-/// <c>memory/architecture/burnername-is-the-display-name.md</c>.
+/// window start offset for the column layout, the three filter-toggle states,
+/// and the BurnerName-resolved display name per row (batched in the
+/// controller so the partials never make per-row service calls). Avatars and
+/// rendered names come from <c>&lt;vc:human&gt;</c> per
+/// <c>memory/architecture/burnername-is-the-display-name.md</c>; the
+/// <see cref="DisplayNameByUserId"/> dictionary is only used for the row
+/// tooltip / search-filter string and for the controller-side display sort.
 /// </summary>
 public sealed class VolunteerTrackingPageViewModel
 {
@@ -20,6 +23,8 @@ public sealed class VolunteerTrackingPageViewModel
     public LocalDate Today { get; init; }
     public IReadOnlyList<VolunteerHeatmapRow> MainCohort { get; init; } = Array.Empty<VolunteerHeatmapRow>();
     public IReadOnlyList<VolunteerCohortRow> UnbookedCohort { get; init; } = Array.Empty<VolunteerCohortRow>();
+    public IReadOnlyDictionary<Guid, string> DisplayNameByUserId { get; init; }
+        = new Dictionary<Guid, string>();
 
     public bool HideNoGaps { get; init; }
     public bool HideCampSetup { get; init; }
@@ -33,6 +38,7 @@ public sealed class VolunteerTrackingPageViewModel
         LocalDate today,
         IReadOnlyList<VolunteerHeatmapRow> mainCohort,
         IReadOnlyList<VolunteerCohortRow> unbookedCohort,
+        IReadOnlyDictionary<Guid, string> displayNameByUserId,
         bool hideNoGaps,
         bool hideCampSetup,
         bool hideUnbookedSection)
@@ -43,6 +49,7 @@ public sealed class VolunteerTrackingPageViewModel
         Today = today;
         MainCohort = mainCohort;
         UnbookedCohort = unbookedCohort;
+        DisplayNameByUserId = displayNameByUserId;
         HideNoGaps = hideNoGaps;
         HideCampSetup = hideCampSetup;
         HideUnbookedSection = hideUnbookedSection;

--- a/src/Humans.Web/ViewComponents/HumanSummaryViewComponent.cs
+++ b/src/Humans.Web/ViewComponents/HumanSummaryViewComponent.cs
@@ -1,6 +1,6 @@
-using Humans.Application.Interfaces.Profiles;
 using Humans.Application.Interfaces.Teams;
 using Humans.Application.Interfaces.Users;
+using Humans.Domain.Enums;
 using Humans.Web.Controllers;
 using Humans.Web.Helpers;
 using Humans.Web.Models;
@@ -18,26 +18,20 @@ namespace Humans.Web.ViewComponents;
 public sealed class HumanSummaryViewComponent : ViewComponent
 {
     private readonly IUserService _userService;
-    private readonly IProfileService _profileService;
-    private readonly IUserEmailService _userEmailService;
     private readonly ITeamService _teamService;
 
     public HumanSummaryViewComponent(
         IUserService userService,
-        IProfileService profileService,
-        IUserEmailService userEmailService,
         ITeamService teamService)
     {
         _userService = userService;
-        _profileService = profileService;
-        _userEmailService = userEmailService;
         _teamService = teamService;
     }
 
     public async Task<IViewComponentResult> InvokeAsync(Guid userId)
     {
-        var user = await _userService.GetByIdAsync(userId);
-        if (user is null)
+        var info = await _userService.GetUserInfoAsync(userId);
+        if (info is null)
         {
             return View("Default", new ProfileSummaryViewModel
             {
@@ -47,53 +41,50 @@ public sealed class HumanSummaryViewComponent : ViewComponent
             });
         }
 
-        var profile = await _profileService.GetProfileAsync(userId);
-        if (profile is null)
+        if (info.Profile is null)
         {
-            var userEmails = await _userEmailService.GetUserEmailsAsync(userId);
-            var fallbackEmail = userEmails.FirstOrDefault(e => e.IsVerified && e.IsPrimary)?.Email
-                ?? userEmails.FirstOrDefault(e => e.IsVerified)?.Email;
             return View("Default", new ProfileSummaryViewModel
             {
                 UserId = userId,
-                DisplayName = user.DisplayName,
-                Email = fallbackEmail,
-                ProfilePictureUrl = user.ProfilePictureUrl,
-                PreferredLanguage = user.PreferredLanguage,
+                DisplayName = info.BurnerName,
+                Email = info.PrimaryEmail
+                    ?? info.UserEmails.FirstOrDefault(e => e.IsVerified)?.Email,
+                ProfilePictureUrl = info.ProfilePictureUrl,
+                PreferredLanguage = info.PreferredLanguage,
                 HasProfile = false,
             });
         }
 
+        var profile = info.Profile;
         var memberships = (await _teamService.GetActiveTeamMembershipsForUserAsync(userId))
             .OrderBy(m => m.TeamName, StringComparer.OrdinalIgnoreCase)
             .ToList();
         var publicTeams = memberships.Where(m => !m.IsHidden).Select(m => m.TeamName).ToList();
         var hiddenTeams = memberships.Where(m => m.IsHidden).Select(m => m.TeamName).ToList();
-        var profileLanguages = await _profileService.GetProfileLanguagesAsync(profile.Id);
 
-        var effectivePictureUrl = profile.HasCustomProfilePicture
+        var effectivePictureUrl = profile.HasCustomPicture
             ? Url.Action(nameof(ProfileController.Picture), "Profile",
                 new { id = profile.Id, v = profile.UpdatedAt.ToUnixTimeTicks() })
-            : user.ProfilePictureUrl;
+            : info.ProfilePictureUrl;
+
+        var isSuspended = profile.State == ProfileState.Suspended;
 
         var vm = new ProfileSummaryViewModel
         {
             UserId = userId,
-            DisplayName = !string.IsNullOrWhiteSpace(profile.BurnerName)
-                ? profile.BurnerName
-                : user.DisplayName,
-            Email = user.Email,
+            DisplayName = info.BurnerName,
+            Email = info.Email,
             ProfilePictureUrl = effectivePictureUrl,
-            PreferredLanguage = user.PreferredLanguage,
+            PreferredLanguage = info.PreferredLanguage,
             MembershipTier = profile.MembershipTier.ToString(),
-            MembershipStatus = profile.IsSuspended ? "Suspended"
+            MembershipStatus = isSuspended ? "Suspended"
                 : profile.IsApproved ? "Active" : "Pending",
             City = profile.City,
             CountryCode = profile.CountryCode,
-            IsSuspended = profile.IsSuspended,
+            IsSuspended = isSuspended,
             Teams = publicTeams,
             HiddenTeams = hiddenTeams,
-            Languages = profileLanguages.Select(pl => new ProfileLanguageDisplayViewModel
+            Languages = profile.Languages.Select(pl => new ProfileLanguageDisplayViewModel
             {
                 LanguageCode = pl.LanguageCode,
                 LanguageName = LanguageCatalog.GetDisplayName(pl.LanguageCode),

--- a/src/Humans.Web/Views/VolunteerTracking/Index.cshtml
+++ b/src/Humans.Web/Views/VolunteerTracking/Index.cshtml
@@ -121,7 +121,7 @@
     else
     {
         @await Html.PartialAsync("_VolunteerHeatmap",
-            new HeatmapPartialModel(Model.MainCohort, Model.BuildStartOffset, Model.GateOpeningDate))
+            new HeatmapPartialModel(Model.MainCohort, Model.BuildStartOffset, Model.GateOpeningDate, Model.DisplayNameByUserId))
 
         @if (!Model.HideUnbookedSection)
         {
@@ -130,7 +130,7 @@
             <p class="text-muted small">@Localizer["VolTrack_Unbooked_Subtitle"]</p>
 
             @await Html.PartialAsync("_VolunteerUnbookedHeatmap",
-                new UnbookedHeatmapPartialModel(Model.UnbookedCohort, Model.BuildStartOffset, Model.GateOpeningDate))
+                new UnbookedHeatmapPartialModel(Model.UnbookedCohort, Model.BuildStartOffset, Model.GateOpeningDate, Model.DisplayNameByUserId))
         }
     }
 

--- a/src/Humans.Web/Views/VolunteerTracking/_VolunteerHeatmap.cshtml
+++ b/src/Humans.Web/Views/VolunteerTracking/_VolunteerHeatmap.cshtml
@@ -1,11 +1,9 @@
 @model Humans.Web.Models.HeatmapPartialModel
 @using Humans.Application.DTOs
-@using Humans.Application.Interfaces.Profiles
 @using Humans.Web.Authorization
 @using Microsoft.AspNetCore.Authorization
 @using NodaTime
 @inject IAuthorizationService AuthService
-@inject IProfileService ProfileService
 
 @{
     var canWrite = (await AuthService.AuthorizeAsync(User, PolicyNames.VolunteerTrackingWrite)).Succeeded;
@@ -74,12 +72,17 @@
             <tbody>
                 @foreach (var row in Model.Rows)
                 {
-                    // BurnerName-resolved name for tooltips/aria — never read user.DisplayName
-                    // for rendering when a Profile exists (memory/architecture/burnername-is-the-display-name.md).
-                    // The <vc:human> below resolves and renders the displayed name itself; this is just
-                    // a string we need for cell tooltip text and the search-row data attribute.
-                    var fullProfile = await ProfileService.GetFullProfileAsync(row.UserId);
-                    var displayName = fullProfile?.DisplayName ?? Localizer["VolTrack_UnknownUser"].Value;
+                    // BurnerName-resolved name for tooltips/aria — resolved
+                    // by the controller in a single batch (see
+                    // VolunteerTrackingController.Index); the partial never
+                    // makes per-row service calls. The <vc:human> below
+                    // renders the avatar+name itself; this string is only
+                    // for the row search/tooltip data attribute.
+                    var displayName = Model.DisplayNameByUserId.GetValueOrDefault(row.UserId, "");
+                    if (string.IsNullOrEmpty(displayName))
+                    {
+                        displayName = Localizer["VolTrack_UnknownUser"].Value;
+                    }
 
                     // Build the day-off tooltip ("Wed 24 Jun — doctor; Fri 26 Jun") for the row badge.
                     var dayOffTooltip = string.Join("; ", row.DayOffs

--- a/src/Humans.Web/Views/VolunteerTracking/_VolunteerUnbookedHeatmap.cshtml
+++ b/src/Humans.Web/Views/VolunteerTracking/_VolunteerUnbookedHeatmap.cshtml
@@ -1,11 +1,9 @@
 @model Humans.Web.Models.UnbookedHeatmapPartialModel
 @using Humans.Application.DTOs
-@using Humans.Application.Interfaces.Profiles
 @using Humans.Web.Authorization
 @using Microsoft.AspNetCore.Authorization
 @using NodaTime
 @inject IAuthorizationService AuthService
-@inject IProfileService ProfileService
 
 @{
     var canWrite = (await AuthService.AuthorizeAsync(User, PolicyNames.VolunteerTrackingWrite)).Succeeded;
@@ -70,8 +68,11 @@
                 @foreach (var row in Model.Rows)
                 {
                     // BurnerName-resolved name for tooltips/aria — see _VolunteerHeatmap.cshtml.
-                    var fullProfile = await ProfileService.GetFullProfileAsync(row.UserId);
-                    var displayName = fullProfile?.DisplayName ?? Localizer["VolTrack_UnknownUser"].Value;
+                    var displayName = Model.DisplayNameByUserId.GetValueOrDefault(row.UserId, "");
+                    if (string.IsNullOrEmpty(displayName))
+                    {
+                        displayName = Localizer["VolTrack_UnknownUser"].Value;
+                    }
                     var availableDays = row.Cells.Count(c => IsAvailable(c.State));
 
                     <tr data-vt-search-name="@displayName.ToLowerInvariant()">

--- a/tests/Humans.Application.Tests/Services/EmailProblemsServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/EmailProblemsServiceTests.cs
@@ -1,9 +1,12 @@
 using AwesomeAssertions;
+using Humans.Application;
 using Humans.Application.DTOs.EmailProblems;
 using Humans.Application.Interfaces.Profiles;
 using Humans.Application.Interfaces.Users;
 using Humans.Application.Services.Profile;
 using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using NodaTime;
 using NodaTime.Testing;
 using NSubstitute;
 
@@ -11,55 +14,77 @@ namespace Humans.Application.Tests.Services;
 
 public class EmailProblemsServiceTests
 {
-    private readonly IProfileService _profileService = Substitute.For<IProfileService>();
     private readonly IUserEmailService _userEmailService = Substitute.For<IUserEmailService>();
     private readonly IUserService _userService = Substitute.For<IUserService>();
-    private readonly FakeClock _clock = new(NodaTime.Instant.FromUtc(2026, 5, 5, 12, 0));
+    private readonly FakeClock _clock = new(Instant.FromUtc(2026, 5, 5, 12, 0));
+
+    private readonly List<UserInfo> _allInfos = new();
 
     public EmailProblemsServiceTests()
     {
-        _userEmailService.GetEntitiesByUserIdsAsync(
-                Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
-            .Returns(new Dictionary<Guid, IReadOnlyList<UserEmail>>());
+        _userService.GetAllUserInfos().Returns(_ => _allInfos.ToArray());
     }
 
     private EmailProblemsService Sut => new(
-        _profileService, _userEmailService, _userService, _clock);
+        _userEmailService, _userService, _clock);
 
-    private void SetAllUserEmails(params UserEmail[] emails)
+    private static UserEmail Email(Guid userId, string address,
+        bool isVerified = true, bool isPrimary = false, bool isGoogle = false) =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            Email = address,
+            IsVerified = isVerified,
+            IsPrimary = isPrimary,
+            IsGoogle = isGoogle,
+        };
+
+    private static UserInfo MakeInfo(
+        Guid userId,
+        bool hasProfile = true,
+        string? identityEmailColumn = null,
+        params UserEmail[] emails)
     {
-        var grouped = emails
-            .GroupBy(e => e.UserId)
-            .ToDictionary(g => g.Key, g => (IReadOnlyList<UserEmail>)g.ToList());
-        _userEmailService.GetEntitiesByUserIdsAsync(
-                Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
-            .Returns(grouped);
+        var user = new User
+        {
+            Id = userId,
+            DisplayName = "Test User",
+            PreferredLanguage = "en",
+            CreatedAt = Instant.FromUtc(2026, 1, 1, 0, 0),
+            GoogleEmailStatus = GoogleEmailStatus.Unknown,
+            Email = identityEmailColumn,
+        };
+        Profile? profile = hasProfile
+            ? new Profile
+            {
+                Id = Guid.NewGuid(),
+                UserId = userId,
+                BurnerName = "Test",
+                FirstName = "Test",
+                LastName = "User",
+                IsApproved = true,
+                CreatedAt = Instant.FromUtc(2026, 1, 1, 0, 0),
+                UpdatedAt = Instant.FromUtc(2026, 1, 1, 0, 0),
+            }
+            : null;
+        return UserInfo.Create(
+            user: user,
+            userEmails: emails,
+            eventParticipations: Array.Empty<EventParticipation>(),
+            externalLogins: Array.Empty<(string, string)>(),
+            profile: profile,
+            contactFields: Array.Empty<ContactField>(),
+            profileLanguages: Array.Empty<ProfileLanguage>(),
+            volunteerHistory: Array.Empty<VolunteerHistoryEntry>(),
+            communicationPreferences: Array.Empty<CommunicationPreference>());
     }
 
-    private static FullProfile MakeProfile(Guid userId, params UserEmailSnapshot[] emails) =>
-        new FullProfile(
-            UserId: userId, DisplayName: "Test User", ProfilePictureUrl: null,
-            HasCustomPicture: false, ProfileId: Guid.NewGuid(), UpdatedAtTicks: 0,
-            BurnerName: "Test", Bio: null, Pronouns: null, ContributionInterests: null,
-            City: null, CountryCode: null, Latitude: null, Longitude: null,
-            BirthdayDay: null, BirthdayMonth: null,
-            IsApproved: true, IsSuspended: false,
-            CVEntries: Array.Empty<CVEntry>(),
-            UserEmails: emails);
-
-    private void SetProfiles(params FullProfile[] profiles)
+    private void AddInfo(UserInfo info)
     {
-        var users = profiles
-            .Select(p => new User { Id = p.UserId })
-            .ToList();
-        _userService.GetAllUsersAsync(Arg.Any<CancellationToken>())
-            .Returns(users);
-
-        foreach (var p in profiles)
-        {
-            _profileService.GetFullProfileAsync(p.UserId, Arg.Any<CancellationToken>())
-                .Returns(new ValueTask<FullProfile?>(p));
-        }
+        _allInfos.Add(info);
+        _userService.GetUserInfoAsync(info.Id, Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<UserInfo?>(info));
     }
 
     private void SetOrphans(params UserEmail[] orphans) =>
@@ -73,7 +98,6 @@ public class EmailProblemsServiceTests
     [HumansFact]
     public async Task EmptySnapshot_ReturnsEmptyReport()
     {
-        SetProfiles();
         SetOrphans();
         SetGhosts();
 
@@ -86,9 +110,11 @@ public class EmailProblemsServiceTests
     public async Task DetectsMultipleIsPrimary()
     {
         var userId = Guid.NewGuid();
-        SetProfiles(MakeProfile(userId,
-            new UserEmailSnapshot(Guid.NewGuid(), "a@x.com", true, true, false),
-            new UserEmailSnapshot(Guid.NewGuid(), "b@x.com", true, true, false)));
+        AddInfo(MakeInfo(userId, emails: new[]
+        {
+            Email(userId, "a@x.com", isVerified: true, isPrimary: true),
+            Email(userId, "b@x.com", isVerified: true, isPrimary: true),
+        }));
         SetOrphans();
         SetGhosts();
 
@@ -102,9 +128,11 @@ public class EmailProblemsServiceTests
     public async Task DetectsMultipleIsGoogle()
     {
         var userId = Guid.NewGuid();
-        SetProfiles(MakeProfile(userId,
-            new UserEmailSnapshot(Guid.NewGuid(), "a@x.com", true, false, true),
-            new UserEmailSnapshot(Guid.NewGuid(), "b@x.com", true, false, true)));
+        AddInfo(MakeInfo(userId, emails: new[]
+        {
+            Email(userId, "a@x.com", isVerified: true, isGoogle: true),
+            Email(userId, "b@x.com", isVerified: true, isGoogle: true),
+        }));
         SetOrphans();
         SetGhosts();
 
@@ -118,9 +146,11 @@ public class EmailProblemsServiceTests
     public async Task DetectsZeroIsPrimary_WhenUserHasVerifiedEmails()
     {
         var userId = Guid.NewGuid();
-        SetProfiles(MakeProfile(userId,
-            new UserEmailSnapshot(Guid.NewGuid(), "a@x.com", true, false, false),
-            new UserEmailSnapshot(Guid.NewGuid(), "b@x.com", true, false, false)));
+        AddInfo(MakeInfo(userId, emails: new[]
+        {
+            Email(userId, "a@x.com", isVerified: true),
+            Email(userId, "b@x.com", isVerified: true),
+        }));
         SetOrphans();
         SetGhosts();
 
@@ -134,8 +164,10 @@ public class EmailProblemsServiceTests
     public async Task DoesNotFlagZeroIsPrimary_WhenUserHasNoVerifiedEmails()
     {
         var userId = Guid.NewGuid();
-        SetProfiles(MakeProfile(userId,
-            new UserEmailSnapshot(Guid.NewGuid(), "a@x.com", false, false, false)));
+        AddInfo(MakeInfo(userId, emails: new[]
+        {
+            Email(userId, "a@x.com", isVerified: false),
+        }));
         SetOrphans();
         SetGhosts();
 
@@ -148,8 +180,10 @@ public class EmailProblemsServiceTests
     public async Task DetectsZeroIsGoogle()
     {
         var userId = Guid.NewGuid();
-        SetProfiles(MakeProfile(userId,
-            new UserEmailSnapshot(Guid.NewGuid(), "a@x.com", true, true, false)));
+        AddInfo(MakeInfo(userId, emails: new[]
+        {
+            Email(userId, "a@x.com", isVerified: true, isPrimary: true),
+        }));
         SetOrphans();
         SetGhosts();
 
@@ -163,9 +197,8 @@ public class EmailProblemsServiceTests
     public async Task DetectsUnverifiedEmail_RegardlessOfFlags()
     {
         var userId = Guid.NewGuid();
-        var emailId = Guid.NewGuid();
-        SetProfiles(MakeProfile(userId,
-            new UserEmailSnapshot(emailId, "a@x.com", false, false, false)));
+        var unverified = Email(userId, "a@x.com", isVerified: false);
+        AddInfo(MakeInfo(userId, emails: new[] { unverified }));
         SetOrphans();
         SetGhosts();
 
@@ -174,7 +207,7 @@ public class EmailProblemsServiceTests
         report.Problems.Should().ContainSingle(p =>
             p.Kind == EmailProblemKind.Unverified
             && p.UserId == userId
-            && p.UserEmailId == emailId
+            && p.UserEmailId == unverified.Id
             && p.Email == "a@x.com");
     }
 
@@ -183,9 +216,8 @@ public class EmailProblemsServiceTests
     {
         var u1 = Guid.NewGuid();
         var u2 = Guid.NewGuid();
-        SetProfiles(
-            MakeProfile(u1, new UserEmailSnapshot(Guid.NewGuid(), "joe@x.com", true, true, false)),
-            MakeProfile(u2, new UserEmailSnapshot(Guid.NewGuid(), "joe@x.com", true, true, false)));
+        AddInfo(MakeInfo(u1, emails: new[] { Email(u1, "joe@x.com", isVerified: true, isPrimary: true) }));
+        AddInfo(MakeInfo(u2, emails: new[] { Email(u2, "joe@x.com", isVerified: true, isPrimary: true) }));
         SetOrphans();
         SetGhosts();
 
@@ -204,9 +236,8 @@ public class EmailProblemsServiceTests
     {
         var u1 = Guid.NewGuid();
         var u2 = Guid.NewGuid();
-        SetProfiles(
-            MakeProfile(u1, new UserEmailSnapshot(Guid.NewGuid(), "joe@gmail.com", true, true, false)),
-            MakeProfile(u2, new UserEmailSnapshot(Guid.NewGuid(), "joe@googlemail.com", true, true, false)));
+        AddInfo(MakeInfo(u1, emails: new[] { Email(u1, "joe@gmail.com", isVerified: true, isPrimary: true) }));
+        AddInfo(MakeInfo(u2, emails: new[] { Email(u2, "joe@googlemail.com", isVerified: true, isPrimary: true) }));
         SetOrphans();
         SetGhosts();
 
@@ -220,7 +251,6 @@ public class EmailProblemsServiceTests
     {
         var deadUserId = Guid.NewGuid();
         var emailId = Guid.NewGuid();
-        SetProfiles();
         SetOrphans(new UserEmail
         {
             Id = emailId,
@@ -243,7 +273,6 @@ public class EmailProblemsServiceTests
     public async Task DetectsGhostExternalLogins()
     {
         var ghostUserId = Guid.NewGuid();
-        SetProfiles();
         SetOrphans();
         SetGhosts(ghostUserId);
 
@@ -258,9 +287,8 @@ public class EmailProblemsServiceTests
     {
         var u1 = Guid.NewGuid();
         var u2 = Guid.NewGuid();
-        SetProfiles(
-            MakeProfile(u1, new UserEmailSnapshot(Guid.NewGuid(), "joe@x.com", true, true, false)),
-            MakeProfile(u2, new UserEmailSnapshot(Guid.NewGuid(), "joe@x.com", true, true, false)));
+        AddInfo(MakeInfo(u1, emails: new[] { Email(u1, "joe@x.com", isVerified: true, isPrimary: true) }));
+        AddInfo(MakeInfo(u2, emails: new[] { Email(u2, "joe@x.com", isVerified: true, isPrimary: true) }));
 
         (await Sut.UsersShareAnyEmailAsync(u1, u2)).Should().BeTrue();
     }
@@ -270,9 +298,8 @@ public class EmailProblemsServiceTests
     {
         var u1 = Guid.NewGuid();
         var u2 = Guid.NewGuid();
-        SetProfiles(
-            MakeProfile(u1, new UserEmailSnapshot(Guid.NewGuid(), "joe@gmail.com", true, true, false)),
-            MakeProfile(u2, new UserEmailSnapshot(Guid.NewGuid(), "joe@googlemail.com", true, true, false)));
+        AddInfo(MakeInfo(u1, emails: new[] { Email(u1, "joe@gmail.com", isVerified: true, isPrimary: true) }));
+        AddInfo(MakeInfo(u2, emails: new[] { Email(u2, "joe@googlemail.com", isVerified: true, isPrimary: true) }));
 
         (await Sut.UsersShareAnyEmailAsync(u1, u2)).Should().BeTrue();
     }
@@ -282,9 +309,8 @@ public class EmailProblemsServiceTests
     {
         var u1 = Guid.NewGuid();
         var u2 = Guid.NewGuid();
-        SetProfiles(
-            MakeProfile(u1, new UserEmailSnapshot(Guid.NewGuid(), "alice@x.com", true, true, false)),
-            MakeProfile(u2, new UserEmailSnapshot(Guid.NewGuid(), "bob@x.com", true, true, false)));
+        AddInfo(MakeInfo(u1, emails: new[] { Email(u1, "alice@x.com", isVerified: true, isPrimary: true) }));
+        AddInfo(MakeInfo(u2, emails: new[] { Email(u2, "bob@x.com", isVerified: true, isPrimary: true) }));
 
         (await Sut.UsersShareAnyEmailAsync(u1, u2)).Should().BeFalse();
     }
@@ -293,7 +319,7 @@ public class EmailProblemsServiceTests
     public async Task UsersShareAnyEmail_SameUserId_False()
     {
         var u = Guid.NewGuid();
-        SetProfiles(MakeProfile(u, new UserEmailSnapshot(Guid.NewGuid(), "joe@x.com", true, true, false)));
+        AddInfo(MakeInfo(u, emails: new[] { Email(u, "joe@x.com", isVerified: true, isPrimary: true) }));
 
         (await Sut.UsersShareAnyEmailAsync(u, u)).Should().BeFalse();
     }
@@ -317,41 +343,14 @@ public class EmailProblemsServiceTests
         (await Sut.IsGhostExternalLoginsUserAsync(otherUserId)).Should().BeFalse();
     }
 
-    private void SetUsersWithProfiles(params (User User, FullProfile Profile)[] pairs)
-    {
-        var users = pairs.Select(p => p.User).ToList();
-        _userService.GetAllUsersAsync(Arg.Any<CancellationToken>()).Returns(users);
-        var grouped = new Dictionary<Guid, IReadOnlyList<UserEmail>>();
-        foreach (var (u, profile) in pairs)
-        {
-            _profileService.GetFullProfileAsync(u.Id, Arg.Any<CancellationToken>())
-                .Returns(new ValueTask<FullProfile?>(profile));
-            var rows = profile.AllUserEmails.Select(s => new UserEmail
-            {
-                Id = s.Id,
-                UserId = u.Id,
-                Email = s.Email,
-                IsVerified = s.IsVerified,
-                IsPrimary = s.IsPrimary,
-                IsGoogle = s.IsGoogle
-            }).ToList();
-            if (rows.Count > 0) grouped[u.Id] = rows;
-        }
-        _userEmailService.GetEntitiesByUserIdsAsync(
-                Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
-            .Returns(grouped);
-    }
-
-    private static User MakeUser(Guid id, string? legacyEmail) =>
-        new User { Id = id, DisplayName = "Test User", Email = legacyEmail };
-
     [HumansFact]
     public async Task DetectsLegacyIdentityEmailNotInUserEmails()
     {
         var userId = Guid.NewGuid();
-        var user = MakeUser(userId, "legacy@x.com");
-        SetUsersWithProfiles((user, MakeProfile(userId,
-            new UserEmailSnapshot(Guid.NewGuid(), "other@x.com", true, true, false))));
+        AddInfo(MakeInfo(userId, identityEmailColumn: "legacy@x.com", emails: new[]
+        {
+            Email(userId, "other@x.com", isVerified: true, isPrimary: true),
+        }));
         SetOrphans();
         SetGhosts();
 
@@ -367,9 +366,10 @@ public class EmailProblemsServiceTests
     public async Task DoesNotFlagLegacyEmail_WhenMatchingVerifiedRowExists()
     {
         var userId = Guid.NewGuid();
-        var user = MakeUser(userId, "match@x.com");
-        SetUsersWithProfiles((user, MakeProfile(userId,
-            new UserEmailSnapshot(Guid.NewGuid(), "match@x.com", true, true, false))));
+        AddInfo(MakeInfo(userId, identityEmailColumn: "match@x.com", emails: new[]
+        {
+            Email(userId, "match@x.com", isVerified: true, isPrimary: true),
+        }));
         SetOrphans();
         SetGhosts();
 
@@ -383,8 +383,7 @@ public class EmailProblemsServiceTests
     public async Task DoesNotFlagLegacyEmail_WhenColumnIsNull()
     {
         var userId = Guid.NewGuid();
-        var user = MakeUser(userId, legacyEmail: null);
-        SetUsersWithProfiles((user, MakeProfile(userId)));
+        AddInfo(MakeInfo(userId, identityEmailColumn: null));
         SetOrphans();
         SetGhosts();
 
@@ -398,9 +397,10 @@ public class EmailProblemsServiceTests
     public async Task DoesNotFlagLegacyEmail_WhenMatchingRowIsUnverified()
     {
         var userId = Guid.NewGuid();
-        var user = MakeUser(userId, "legacy@x.com");
-        SetUsersWithProfiles((user, MakeProfile(userId,
-            new UserEmailSnapshot(Guid.NewGuid(), "legacy@x.com", false, false, false))));
+        AddInfo(MakeInfo(userId, identityEmailColumn: "legacy@x.com", emails: new[]
+        {
+            Email(userId, "legacy@x.com", isVerified: false),
+        }));
         SetOrphans();
         SetGhosts();
 
@@ -419,8 +419,7 @@ public class EmailProblemsServiceTests
         // address is added as a plain verified row; the next OAuth sign-in's
         // reconcile attaches the provider tag via TagMoved.
         var userId = Guid.NewGuid();
-        var user = MakeUser(userId, "legacy@x.com");
-        SetUsersWithProfiles((user, MakeProfile(userId)));
+        AddInfo(MakeInfo(userId, identityEmailColumn: "legacy@x.com"));
 
         var result = await Sut.BackfillLegacyIdentityEmailsAsync(Guid.NewGuid());
 
@@ -434,9 +433,10 @@ public class EmailProblemsServiceTests
     public async Task BackfillLegacyIdentityEmails_AlreadyHasMatchingVerifiedRow_SkipsUser()
     {
         var userId = Guid.NewGuid();
-        var user = MakeUser(userId, "match@x.com");
-        SetUsersWithProfiles((user, MakeProfile(userId,
-            new UserEmailSnapshot(Guid.NewGuid(), "match@x.com", true, true, false))));
+        AddInfo(MakeInfo(userId, identityEmailColumn: "match@x.com", emails: new[]
+        {
+            Email(userId, "match@x.com", isVerified: true, isPrimary: true),
+        }));
 
         var result = await Sut.BackfillLegacyIdentityEmailsAsync(Guid.NewGuid());
 
@@ -449,8 +449,7 @@ public class EmailProblemsServiceTests
     public async Task BackfillLegacyIdentityEmails_NullColumn_SkipsUser()
     {
         var userId = Guid.NewGuid();
-        var user = MakeUser(userId, legacyEmail: null);
-        SetUsersWithProfiles((user, MakeProfile(userId)));
+        AddInfo(MakeInfo(userId, identityEmailColumn: null));
 
         var result = await Sut.BackfillLegacyIdentityEmailsAsync(Guid.NewGuid());
 
@@ -461,18 +460,10 @@ public class EmailProblemsServiceTests
     public async Task DoesNotFlagLegacyEmail_WhenProfileLessUserHasMatchingVerifiedRow()
     {
         var userId = Guid.NewGuid();
-        var user = MakeUser(userId, "import@x.com");
-        _userService.GetAllUsersAsync(Arg.Any<CancellationToken>())
-            .Returns(new List<User> { user });
-        _profileService.GetFullProfileAsync(userId, Arg.Any<CancellationToken>())
-            .Returns(new ValueTask<FullProfile?>((FullProfile?)null));
-        SetAllUserEmails(new UserEmail
+        AddInfo(MakeInfo(userId, hasProfile: false, identityEmailColumn: "import@x.com", emails: new[]
         {
-            Id = Guid.NewGuid(),
-            UserId = userId,
-            Email = "import@x.com",
-            IsVerified = true
-        });
+            Email(userId, "import@x.com", isVerified: true),
+        }));
         SetOrphans();
         SetGhosts();
 
@@ -486,12 +477,7 @@ public class EmailProblemsServiceTests
     public async Task DetectsLegacyEmail_WhenProfileLessUserHasNoMatchingRow()
     {
         var userId = Guid.NewGuid();
-        var user = MakeUser(userId, "legacy@x.com");
-        _userService.GetAllUsersAsync(Arg.Any<CancellationToken>())
-            .Returns(new List<User> { user });
-        _profileService.GetFullProfileAsync(userId, Arg.Any<CancellationToken>())
-            .Returns(new ValueTask<FullProfile?>((FullProfile?)null));
-        SetAllUserEmails();
+        AddInfo(MakeInfo(userId, hasProfile: false, identityEmailColumn: "legacy@x.com"));
         SetOrphans();
         SetGhosts();
 
@@ -507,18 +493,10 @@ public class EmailProblemsServiceTests
     public async Task BackfillLegacyIdentityEmails_ProfileLessUserAlreadyMatched_SkipsUser()
     {
         var userId = Guid.NewGuid();
-        var user = MakeUser(userId, "import@x.com");
-        _userService.GetAllUsersAsync(Arg.Any<CancellationToken>())
-            .Returns(new List<User> { user });
-        _profileService.GetFullProfileAsync(userId, Arg.Any<CancellationToken>())
-            .Returns(new ValueTask<FullProfile?>((FullProfile?)null));
-        SetAllUserEmails(new UserEmail
+        AddInfo(MakeInfo(userId, hasProfile: false, identityEmailColumn: "import@x.com", emails: new[]
         {
-            Id = Guid.NewGuid(),
-            UserId = userId,
-            Email = "import@x.com",
-            IsVerified = true
-        });
+            Email(userId, "import@x.com", isVerified: true),
+        }));
 
         var result = await Sut.BackfillLegacyIdentityEmailsAsync(Guid.NewGuid());
 

--- a/tests/Humans.Web.Tests/Controllers/ProfileApiControllerTests.cs
+++ b/tests/Humans.Web.Tests/Controllers/ProfileApiControllerTests.cs
@@ -3,11 +3,13 @@ using AwesomeAssertions;
 using Humans.Application;
 using Humans.Application.DTOs;
 using Humans.Application.Interfaces.Profiles;
+using Humans.Application.Interfaces.Users;
 using Humans.Application.Services.Profiles;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Humans.Testing;
 using Humans.Web.Controllers;
+using NodaTime;
 using Humans.Web.Models;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
@@ -46,6 +48,7 @@ namespace Humans.Web.Tests.Controllers;
 public class ProfileApiControllerTests
 {
     private readonly IProfileService _profileService = Substitute.For<IProfileService>();
+    private readonly IUserService _userService = Substitute.For<IUserService>();
     private readonly IContactFieldService _contactFieldService = Substitute.For<IContactFieldService>();
     private readonly IUserEmailService _userEmailService = Substitute.For<IUserEmailService>();
     private readonly UserManager<User> _userManager;
@@ -71,7 +74,7 @@ public class ProfileApiControllerTests
         }
 
         var ctrl = new ProfileApiController(
-            _profileService, _contactFieldService, _userEmailService, _userManager);
+            _profileService, _userService, _contactFieldService, _userEmailService, _userManager);
 
         var http = new DefaultHttpContext();
         if (currentUser is not null)
@@ -113,6 +116,44 @@ public class ProfileApiControllerTests
 
     private static User MakeUser(Guid id) =>
         new() { Id = id, Email = $"viewer-{id:N}@example.com", DisplayName = "Viewer" };
+
+    private static UserInfo MakeUserInfo(
+        Guid userId,
+        Guid profileId,
+        string burnerName = "Target Burner",
+        bool isRejected = false)
+    {
+        var profile = new Profile
+        {
+            Id = profileId,
+            UserId = userId,
+            BurnerName = burnerName,
+            FirstName = "Target",
+            LastName = "Display",
+            IsApproved = true,
+            CreatedAt = Instant.FromUtc(2026, 1, 1, 0, 0),
+            UpdatedAt = Instant.FromUtc(2026, 1, 1, 0, 0),
+            RejectedAt = isRejected ? Instant.FromUtc(2026, 2, 1, 0, 0) : (Instant?)null,
+        };
+        var user = new User
+        {
+            Id = userId,
+            DisplayName = "Target Display",
+            PreferredLanguage = "en",
+            CreatedAt = Instant.FromUtc(2026, 1, 1, 0, 0),
+            GoogleEmailStatus = GoogleEmailStatus.Unknown,
+        };
+        return UserInfo.Create(
+            user: user,
+            userEmails: Array.Empty<UserEmail>(),
+            eventParticipations: Array.Empty<EventParticipation>(),
+            externalLogins: Array.Empty<(string, string)>(),
+            profile: profile,
+            contactFields: Array.Empty<ContactField>(),
+            profileLanguages: Array.Empty<ProfileLanguage>(),
+            volunteerHistory: Array.Empty<VolunteerHistoryEntry>(),
+            communicationPreferences: Array.Empty<CommunicationPreference>());
+    }
 
     private static FullProfile MakeFullProfile(
         Guid userId,
@@ -309,8 +350,8 @@ public class ProfileApiControllerTests
     public async Task GetByUserId_returns_404_when_full_profile_not_in_cache()
     {
         var viewer = MakeUser(Guid.NewGuid());
-        _profileService.GetFullProfileAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
-            .Returns((FullProfile?)null);
+        _userService.GetUserInfoAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<UserInfo?>((UserInfo?)null));
 
         var sut = BuildSut(viewer);
 
@@ -326,8 +367,8 @@ public class ProfileApiControllerTests
         var targetUserId = Guid.NewGuid();
         var targetProfileId = Guid.NewGuid();
 
-        _profileService.GetFullProfileAsync(targetUserId, Arg.Any<CancellationToken>())
-            .Returns(MakeFullProfile(targetUserId, targetProfileId, isRejected: true));
+        _userService.GetUserInfoAsync(targetUserId, Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<UserInfo?>(MakeUserInfo(targetUserId, targetProfileId, isRejected: true)));
 
         var sut = BuildSut(viewer);
 
@@ -343,8 +384,8 @@ public class ProfileApiControllerTests
         var targetUserId = Guid.NewGuid();
         var targetProfileId = Guid.NewGuid();
 
-        _profileService.GetFullProfileAsync(targetUserId, Arg.Any<CancellationToken>())
-            .Returns(MakeFullProfile(targetUserId, targetProfileId, burnerName: "Davey"));
+        _userService.GetUserInfoAsync(targetUserId, Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<UserInfo?>(MakeUserInfo(targetUserId, targetProfileId, burnerName: "Davey")));
         _contactFieldService.GetViewerAccessLevelAsync(targetUserId, viewer.Id, Arg.Any<CancellationToken>())
             .Returns(ContactFieldVisibility.AllActiveProfiles);
         _userEmailService.GetVisibleEmailsAsync(targetUserId, Arg.Any<ContactFieldVisibility>(), Arg.Any<CancellationToken>())

--- a/tests/Humans.Web.Tests/Controllers/VolunteerTrackingControllerTests.cs
+++ b/tests/Humans.Web.Tests/Controllers/VolunteerTrackingControllerTests.cs
@@ -1,10 +1,11 @@
 using System.Reflection;
 using System.Security.Claims;
 using AwesomeAssertions;
+using Humans.Application;
 using Humans.Application.DTOs;
 using Humans.Application.Interfaces.AuditLog;
-using Humans.Application.Interfaces.Profiles;
 using Humans.Application.Interfaces.Shifts;
+using Humans.Application.Interfaces.Users;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Humans.Testing;
@@ -46,7 +47,7 @@ public class VolunteerTrackingControllerTests
 {
     private readonly UserManager<User> _userManager;
     private readonly IVolunteerTrackingService _service = Substitute.For<IVolunteerTrackingService>();
-    private readonly IProfileService _profileService = Substitute.For<IProfileService>();
+    private readonly IUserService _userService = Substitute.For<IUserService>();
     private readonly IAuditLogService _auditLog = Substitute.For<IAuditLogService>();
     private readonly IStringLocalizer<Humans.Web.SharedResource> _localizer =
         Substitute.For<IStringLocalizer<Humans.Web.SharedResource>>();
@@ -68,7 +69,7 @@ public class VolunteerTrackingControllerTests
         }
 
         var ctrl = new VolunteerTrackingController(
-            _service, _profileService, _auditLog, _userManager, _localizer);
+            _service, _userService, _auditLog, _userManager, _localizer);
 
         var http = new DefaultHttpContext();
         if (currentUser is not null)
@@ -202,12 +203,12 @@ public class VolunteerTrackingControllerTests
         _service.GetTrackingDataAsync(Arg.Any<CancellationToken>())
             .Returns(new VolunteerTrackingViewModel(true, -10, new LocalDate(2026, 6, 24), new LocalDate(2026, 6, 15), rows,
                 Array.Empty<VolunteerCohortRow>()));
-        _profileService.GetFullProfileAsync(aliceId, Arg.Any<CancellationToken>())
-            .Returns(new ValueTask<Humans.Application.FullProfile?>(StubFullProfile("Alice")));
-        _profileService.GetFullProfileAsync(bobId, Arg.Any<CancellationToken>())
-            .Returns(new ValueTask<Humans.Application.FullProfile?>(StubFullProfile("Bob")));
-        _profileService.GetFullProfileAsync(carolId, Arg.Any<CancellationToken>())
-            .Returns(new ValueTask<Humans.Application.FullProfile?>(StubFullProfile("Carol")));
+        _userService.GetUserInfoAsync(aliceId, Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<UserInfo?>(StubUserInfo(aliceId, "Alice")));
+        _userService.GetUserInfoAsync(bobId, Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<UserInfo?>(StubUserInfo(bobId, "Bob")));
+        _userService.GetUserInfoAsync(carolId, Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<UserInfo?>(StubUserInfo(carolId, "Carol")));
 
         var ctrl = BuildSut(new User { Id = Guid.NewGuid() });
 
@@ -564,14 +565,36 @@ public class VolunteerTrackingControllerTests
             Arg.Any<string>(), current.Id, Arg.Any<Guid?>(), Arg.Any<string?>());
     }
 
-    private static Humans.Application.FullProfile StubFullProfile(string displayName) =>
-        new(
-            UserId: Guid.NewGuid(), DisplayName: displayName, ProfilePictureUrl: null,
-            HasCustomPicture: false, ProfileId: Guid.NewGuid(), UpdatedAtTicks: 0,
-            BurnerName: null, Bio: null, Pronouns: null, ContributionInterests: null,
-            City: null, CountryCode: null, Latitude: null, Longitude: null,
-            BirthdayDay: null, BirthdayMonth: null,
-            IsApproved: true, IsSuspended: false,
-            CVEntries: Array.Empty<Humans.Application.CVEntry>(),
-            PrimaryEmail: null);
+    private static UserInfo StubUserInfo(Guid userId, string burnerName)
+    {
+        var user = new User
+        {
+            Id = userId,
+            DisplayName = burnerName,
+            PreferredLanguage = "en",
+            CreatedAt = Instant.FromUtc(2026, 1, 1, 0, 0),
+            GoogleEmailStatus = GoogleEmailStatus.Unknown,
+        };
+        var profile = new Profile
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            BurnerName = burnerName,
+            FirstName = burnerName,
+            LastName = "Test",
+            IsApproved = true,
+            CreatedAt = Instant.FromUtc(2026, 1, 1, 0, 0),
+            UpdatedAt = Instant.FromUtc(2026, 1, 1, 0, 0),
+        };
+        return UserInfo.Create(
+            user: user,
+            userEmails: Array.Empty<UserEmail>(),
+            eventParticipations: Array.Empty<EventParticipation>(),
+            externalLogins: Array.Empty<(string, string)>(),
+            profile: profile,
+            contactFields: Array.Empty<ContactField>(),
+            profileLanguages: Array.Empty<ProfileLanguage>(),
+            volunteerHistory: Array.Empty<VolunteerHistoryEntry>(),
+            communicationPreferences: Array.Empty<CommunicationPreference>());
+    }
 }


### PR DESCRIPTION
Follow-up to #549 — drains the next batch of read-path callers off `IProfileService.GetFullProfileAsync` onto `IUserService.GetUserInfoAsync` / `GetAllUserInfos()`, per the direction codified in `memory/architecture/iuserservice-onestop-userinfo.md`.

Where the existing code was per-row fetching inside views or controllers, this PR fixes the N+1 rather than propagating it — Peter's call: \"we don't migrate the crap that's supposed to get cleaned up, we do the cleanup.\"

## Summary

- **`<vc:humanSummary>`** — 4 service calls collapsed to one `GetUserInfoAsync`. Drops `IProfileService` and `IUserEmailService` ctor deps. `IsSuspended` reads `Profile.State == ProfileState.Suspended` (the modern column).
- **`EmailProblemsService`** — `GetAllUsersAsync` + per-user `GetFullProfileAsync` loop replaced with one `GetAllUserInfos()` snapshot. Drops a redundant `IUserEmailService.GetEntitiesByUserIdsAsync` call. Drops `IProfileService` ctor dep.
- **Volunteer heatmap (N+1 cleanup)** — controller batches BurnerName resolution once and passes a dict through the page VM. Both `_VolunteerHeatmap.cshtml` and `_VolunteerUnbookedHeatmap.cshtml` drop their `@inject IProfileService` + per-row `GetFullProfileAsync` calls. Drops `IProfileService` from the controller ctor.
- **`AuditLogController.Human`** — `GetFullProfileAsync` swap; drops `IProfileService` ctor dep.
- **`ProfileApiController.GetByUserId`** — `GetFullProfileAsync` swap; uses `info.BurnerName`. `IProfileService` stays (still needed by `ProfilePictureUrlHelper`).
- **`GoogleController.SyncOutbox`** — replaces `GetByIdsWithEmailsAsync` + per-user `GetFullProfileAsync` loop with per-id `GetUserInfoAsync`. **Fixes a `burnername-is-the-display-name` violation** — the previous `displayNameLookup` read `user.DisplayName` directly; now uses `info.BurnerName`.

## Sharp edges addressed (per Codex P1 in #549)

Every render call site reads `info.BurnerName`, never `info.DisplayName`.

## Test plan

- [x] `dotnet build` clean.
- [x] Unit suites green: Domain (164), Analyzers (69), Web (88), Application (2805) = 3126 passing.
- [ ] Integration suite — pre-existing `Hangfire JobStorage not initialized` (unrelated to this PR).
- [ ] Preview env: heatmap render unchanged (avatars + tooltip strings), Profile picker `by-userid` endpoint, AuditLog Human page, Google SyncOutbox admin page, ticket-transfer detail `<vc:humanSummary>` panel.

## Test refactor scope

`EmailProblemsServiceTests` rewritten to fixture from `GetAllUserInfos()` mocks. `ProfileApiControllerTests` and `VolunteerTrackingControllerTests` get parallel `MakeUserInfo`/`StubUserInfo` helpers and updated mock wiring. ~270 lines of test-only churn, mechanical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)