### PR TITLE
refactor(profile-readers): drain 22 GetProfileAsync/GetFullProfileAsync readers onto UserInfo

### DIFF
--- a/src/Humans.Application/Services/Governance/ApplicationDecisionService.cs
+++ b/src/Humans.Application/Services/Governance/ApplicationDecisionService.cs
@@ -620,8 +620,8 @@ public sealed class ApplicationDecisionService : IApplicationDecisionService, IU
         if (application is null)
             return null;
 
-        var applicant = await _userService.GetByIdAsync(application.UserId, ct);
-        var profile = await _profileService.GetProfileAsync(application.UserId, ct);
+        var applicantInfo = await _userService.GetUserInfoAsync(application.UserId, ct);
+        var profile = applicantInfo?.Profile;
 
         var voterIds = application.BoardVotes
             .Select(v => v.BoardMemberUserId)
@@ -641,9 +641,9 @@ public sealed class ApplicationDecisionService : IApplicationDecisionService, IU
         return new BoardVotingDetailData(
             ApplicationId: application.Id,
             UserId: application.UserId,
-            DisplayName: applicant?.DisplayName ?? string.Empty,
-            ProfilePictureUrl: applicant?.ProfilePictureUrl,
-            Email: applicant?.Email ?? string.Empty,
+            DisplayName: applicantInfo?.DisplayName ?? string.Empty,
+            ProfilePictureUrl: applicantInfo?.ProfilePictureUrl,
+            Email: applicantInfo?.Email ?? string.Empty,
             FirstName: profile?.FirstName ?? string.Empty,
             LastName: profile?.LastName ?? string.Empty,
             City: profile?.City,

--- a/src/Humans.Application/Services/Governance/MembershipCalculator.cs
+++ b/src/Humans.Application/Services/Governance/MembershipCalculator.cs
@@ -67,14 +67,15 @@ public sealed class MembershipCalculator : IMembershipCalculator
         Guid userId,
         CancellationToken cancellationToken = default)
     {
-        var profile = await _profileService.GetProfileAsync(userId, cancellationToken);
+        var info = await _userService.GetUserInfoAsync(userId, cancellationToken);
+        var profile = info?.Profile;
 
         if (profile is null)
         {
             return MembershipStatus.None;
         }
 
-        if (profile.IsSuspended)
+        if (profile.State == ProfileState.Suspended)
         {
             return MembershipStatus.Suspended;
         }

--- a/src/Humans.Application/Services/Governance/MembershipCalculator.cs
+++ b/src/Humans.Application/Services/Governance/MembershipCalculator.cs
@@ -68,19 +68,18 @@ public sealed class MembershipCalculator : IMembershipCalculator
         CancellationToken cancellationToken = default)
     {
         var info = await _userService.GetUserInfoAsync(userId, cancellationToken);
-        var profile = info?.Profile;
 
-        if (profile is null)
+        if (info?.Profile is null)
         {
             return MembershipStatus.None;
         }
 
-        if (profile.State == ProfileState.Suspended)
+        if (info.IsSuspended)
         {
             return MembershipStatus.Suspended;
         }
 
-        if (!profile.IsApproved)
+        if (!info.Profile.IsApproved)
         {
             return MembershipStatus.Pending;
         }

--- a/src/Humans.Application/Services/Onboarding/OnboardingService.cs
+++ b/src/Humans.Application/Services/Onboarding/OnboardingService.cs
@@ -300,8 +300,7 @@ public sealed class OnboardingService : IOnboardingService
         Guid userId, CancellationToken ct = default)
     {
         var info = await _userService.GetUserInfoAsync(userId, ct);
-        var profile = info?.Profile;
-        if (profile is null || profile.IsApproved || profile.ConsentCheckStatus is not null)
+        if (info is null || !info.NeedsConsentReview || info.Profile!.ConsentCheckStatus is not null)
             return false;
 
         var hasAllConsents = await _membershipCalculator.HasAllRequiredConsentsForTeamAsync(

--- a/src/Humans.Application/Services/Onboarding/OnboardingService.cs
+++ b/src/Humans.Application/Services/Onboarding/OnboardingService.cs
@@ -299,7 +299,8 @@ public sealed class OnboardingService : IOnboardingService
     public async Task<bool> SetConsentCheckPendingIfEligibleAsync(
         Guid userId, CancellationToken ct = default)
     {
-        var profile = await _profileService.GetProfileAsync(userId, ct);
+        var info = await _userService.GetUserInfoAsync(userId, ct);
+        var profile = info?.Profile;
         if (profile is null || profile.IsApproved || profile.ConsentCheckStatus is not null)
             return false;
 

--- a/src/Humans.Application/Services/Tickets/TicketTransferService.cs
+++ b/src/Humans.Application/Services/Tickets/TicketTransferService.cs
@@ -177,7 +177,7 @@ public sealed class TicketTransferService : ITicketTransferService
         // path can't bypass the security gate. Wording matches the not-found case
         // above so a tampered POST learns nothing about why the recipient was rejected.
         if (receiverProfile is not null
-            && (receiverProfile.State == ProfileState.Suspended || !receiverProfile.IsApproved))
+            && (receiverInfo.IsSuspended || !receiverProfile.IsApproved))
             throw new InvalidOperationException("Receiver user not found.");
         // No double-submits: refuse if there's already a pending transfer from this
         // sender for this attendee. ToDictionary in GetMyAttendeesAsync would crash
@@ -654,7 +654,7 @@ public sealed class TicketTransferService : ITicketTransferService
         // (per docs/features/tickets/ticket-transfer.md — Receiver Lookup Contract). Gates
         // both lookup paths (exact-email + burner-name) and the detail-fetch used by
         // the confirm-card render.
-        if (profile is not null && (profile.State == ProfileState.Suspended || !profile.IsApproved))
+        if (profile is not null && (info.IsSuspended || !profile.IsApproved))
             return null;
         var primary = await _userEmailService.GetPrimaryEmailAsync(userId, ct);
         return new ReceiverLookupResultDto(

--- a/src/Humans.Application/Services/Tickets/TicketTransferService.cs
+++ b/src/Humans.Application/Services/Tickets/TicketTransferService.cs
@@ -170,15 +170,14 @@ public sealed class TicketTransferService : ITicketTransferService
 
         var receiverInfo = await _userService.GetUserInfoAsync(dto.ReceiverUserId, ct)
             ?? throw new InvalidOperationException("Receiver user not found.");
-        var receiverProfile = receiverInfo.Profile;
-        // Defense-in-depth: BuildReceiverCardAsync filters suspended/unapproved at
-        // the lookup layer, but Submit accepts a direct POST with a crafted
-        // ReceiverUserId. Mirror the lookup behaviour (treat as not-found) so this
-        // path can't bypass the security gate. Wording matches the not-found case
-        // above so a tampered POST learns nothing about why the recipient was rejected.
-        if (receiverProfile is not null
-            && (receiverInfo.IsSuspended || !receiverProfile.IsApproved))
+        // Defense-in-depth: BuildReceiverCardAsync filters at the lookup layer, but
+        // Submit accepts a direct POST with a crafted ReceiverUserId. Receivers
+        // MUST have a legal name on file — the transfer snapshot records it onto
+        // the reissued ticket. Wording matches the not-found case above so a
+        // tampered POST learns nothing about why the recipient was rejected.
+        if (!receiverInfo.HasRequiredIdentityFields)
             throw new InvalidOperationException("Receiver user not found.");
+        var receiverProfile = receiverInfo.Profile!;
         // No double-submits: refuse if there's already a pending transfer from this
         // sender for this attendee. ToDictionary in GetMyAttendeesAsync would crash
         // on duplicates, and the legitimate UX hides the Send button while pending.
@@ -187,9 +186,7 @@ public sealed class TicketTransferService : ITicketTransferService
                 && r.Status == TicketTransferStatus.Pending);
         if (existingPending)
             throw new InvalidOperationException("There is already a pending transfer request for this ticket.");
-        var receiverLegalName = receiverProfile?.FullName is { Length: > 0 } legal
-            ? legal
-            : receiverInfo.DisplayName;
+        var receiverLegalName = receiverProfile.FullName;
         var receiverEmail = await _userEmailService.GetPrimaryEmailAsync(dto.ReceiverUserId, ct)
             ?? throw new InvalidOperationException("Receiver has no primary email on file.");
 
@@ -648,21 +645,19 @@ public sealed class TicketTransferService : ITicketTransferService
     private async Task<ReceiverLookupResultDto?> BuildReceiverCardAsync(Guid userId, CancellationToken ct)
     {
         var info = await _userService.GetUserInfoAsync(userId, ct);
-        if (info is null) return null;
-        var profile = info.Profile;
-        // Security gate: filter suspended or unapproved profiles at the lookup layer
-        // (per docs/features/tickets/ticket-transfer.md — Receiver Lookup Contract). Gates
-        // both lookup paths (exact-email + burner-name) and the detail-fetch used by
-        // the confirm-card render.
-        if (profile is not null && (info.IsSuspended || !profile.IsApproved))
-            return null;
+        // Receiver Lookup Contract (docs/features/tickets/ticket-transfer.md):
+        // recipients must have a legal name on file — the transfer snapshot records
+        // it onto the reissued ticket. Suspension/approval state isn't relevant
+        // to a transfer recipient.
+        if (info is null || !info.HasRequiredIdentityFields) return null;
+        var profile = info.Profile!;
         var primary = await _userEmailService.GetPrimaryEmailAsync(userId, ct);
         return new ReceiverLookupResultDto(
             UserId: userId,
             DisplayName: info.DisplayName,
-            BurnerName: profile?.BurnerName,
+            BurnerName: profile.BurnerName,
             PreferredEmail: primary,
-            HasCustomProfilePicture: profile?.HasCustomPicture ?? false,
+            HasCustomProfilePicture: profile.HasCustomPicture,
             ProfilePictureUrl: info.ProfilePictureUrl);
     }
 

--- a/src/Humans.Application/Services/Tickets/TicketTransferService.cs
+++ b/src/Humans.Application/Services/Tickets/TicketTransferService.cs
@@ -168,15 +168,16 @@ public sealed class TicketTransferService : ITicketTransferService
         if (attendee.Status != TicketAttendeeStatus.Valid)
             throw new InvalidOperationException("Only Valid tickets can be transferred.");
 
-        var receiverUser = await _userService.GetByIdAsync(dto.ReceiverUserId, ct)
+        var receiverInfo = await _userService.GetUserInfoAsync(dto.ReceiverUserId, ct)
             ?? throw new InvalidOperationException("Receiver user not found.");
-        var receiverProfile = await _profileService.GetProfileAsync(dto.ReceiverUserId, ct);
+        var receiverProfile = receiverInfo.Profile;
         // Defense-in-depth: BuildReceiverCardAsync filters suspended/unapproved at
         // the lookup layer, but Submit accepts a direct POST with a crafted
         // ReceiverUserId. Mirror the lookup behaviour (treat as not-found) so this
         // path can't bypass the security gate. Wording matches the not-found case
         // above so a tampered POST learns nothing about why the recipient was rejected.
-        if (receiverProfile is not null && (receiverProfile.IsSuspended || !receiverProfile.IsApproved))
+        if (receiverProfile is not null
+            && (receiverProfile.State == ProfileState.Suspended || !receiverProfile.IsApproved))
             throw new InvalidOperationException("Receiver user not found.");
         // No double-submits: refuse if there's already a pending transfer from this
         // sender for this attendee. ToDictionary in GetMyAttendeesAsync would crash
@@ -188,7 +189,7 @@ public sealed class TicketTransferService : ITicketTransferService
             throw new InvalidOperationException("There is already a pending transfer request for this ticket.");
         var receiverLegalName = receiverProfile?.FullName is { Length: > 0 } legal
             ? legal
-            : receiverUser.DisplayName;
+            : receiverInfo.DisplayName;
         var receiverEmail = await _userEmailService.GetPrimaryEmailAsync(dto.ReceiverUserId, ct)
             ?? throw new InvalidOperationException("Receiver has no primary email on file.");
 
@@ -646,23 +647,23 @@ public sealed class TicketTransferService : ITicketTransferService
 
     private async Task<ReceiverLookupResultDto?> BuildReceiverCardAsync(Guid userId, CancellationToken ct)
     {
-        var user = await _userService.GetByIdAsync(userId, ct);
-        if (user is null) return null;
-        var profile = await _profileService.GetProfileAsync(userId, ct);
+        var info = await _userService.GetUserInfoAsync(userId, ct);
+        if (info is null) return null;
+        var profile = info.Profile;
         // Security gate: filter suspended or unapproved profiles at the lookup layer
         // (per docs/features/tickets/ticket-transfer.md — Receiver Lookup Contract). Gates
         // both lookup paths (exact-email + burner-name) and the detail-fetch used by
         // the confirm-card render.
-        if (profile is not null && (profile.IsSuspended || !profile.IsApproved))
+        if (profile is not null && (profile.State == ProfileState.Suspended || !profile.IsApproved))
             return null;
         var primary = await _userEmailService.GetPrimaryEmailAsync(userId, ct);
         return new ReceiverLookupResultDto(
             UserId: userId,
-            DisplayName: user.DisplayName,
+            DisplayName: info.DisplayName,
             BurnerName: profile?.BurnerName,
             PreferredEmail: primary,
-            HasCustomProfilePicture: profile?.HasCustomProfilePicture ?? false,
-            ProfilePictureUrl: user.ProfilePictureUrl);
+            HasCustomProfilePicture: profile?.HasCustomPicture ?? false,
+            ProfilePictureUrl: info.ProfilePictureUrl);
     }
 
     private async Task<TicketTransferRowDto> BuildRowDtoAsync(TicketTransferRequest r, CancellationToken ct)

--- a/src/Humans.Application/UserInfo.cs
+++ b/src/Humans.Application/UserInfo.cs
@@ -330,6 +330,16 @@ public sealed record UserInfo(
         Profile is not null && Profile.RejectedAt is null;
 
     /// <summary>
+    /// True when the user has a profile in <see cref="ProfileState.Suspended"/>.
+    /// Canonical "is this user suspended" predicate — read this instead of paving
+    /// <c>Profile.State == ProfileState.Suspended</c> at call sites (or worse,
+    /// the legacy <c>Profile.IsSuspended</c> bool — see
+    /// <c>memory/code/no-issuspended.md</c>).
+    /// </summary>
+    public bool IsSuspended =>
+        Profile?.State == ProfileState.Suspended;
+
+    /// <summary>
     /// True when the user has a profile and BurnerName + FirstName + LastName
     /// are all non-blank. The "has a name" predicate — Consent Coordinator
     /// review cannot proceed without it. Reads field values directly, ignores

--- a/src/Humans.Web/Controllers/ExpensesController.cs
+++ b/src/Humans.Web/Controllers/ExpensesController.cs
@@ -71,7 +71,7 @@ public sealed class ExpensesController : HumansControllerBase
 
             var reports = await _service.GetForSubmitterAsync(user.Id);
             var activeYear = await _budgetService.GetActiveYearAsync();
-            var profile = await _profileService.GetProfileAsync(user.Id);
+            var info = await _userService.GetUserInfoAsync(user.Id);
 
             var categoryNames = activeYear?.Groups
                 .SelectMany(g => g.Categories.Select(c => (c.Id, Display: $"{g.Name} / {c.Name}")))
@@ -82,7 +82,7 @@ public sealed class ExpensesController : HumansControllerBase
             {
                 Reports = reports,
                 HasActiveYear = activeYear is not null,
-                HasIban = !string.IsNullOrEmpty(profile?.Iban),
+                HasIban = !string.IsNullOrEmpty(info?.Profile?.Iban),
                 CategoryNames = categoryNames,
             };
             return View(model);

--- a/src/Humans.Web/Controllers/ProfileController.cs
+++ b/src/Humans.Web/Controllers/ProfileController.cs
@@ -283,26 +283,17 @@ public class ProfileController : HumansControllerBase
         if (user is null)
             return NotFound();
 
-        var profile = await _profileService.GetProfileAsync(user.Id, ct);
+        var info = await _userService.GetUserInfoAsync(user.Id, ct);
+        if (info is null) return NotFound();
+
         var applications = await _applicationDecisionService.GetUserApplicationsAsync(user.Id, ct);
-        var contactFields = profile is not null
-            ? await _contactFieldService.GetAllContactFieldsAsync(profile.Id, ct)
-            : [];
-        var fullProfile = await _profileService.GetFullProfileAsync(user.Id, ct);
-        var languages = profile is not null
-            ? await _profileService.GetProfileLanguagesAsync(profile.Id, ct)
-            : (IReadOnlyList<ProfileLanguageSnapshot>)[];
         var allShiftTags = await _shiftMgmt.GetTagsAsync();
         var preferredShiftTags = await _shiftMgmt.GetVolunteerTagPreferencesAsync(user.Id);
         var externalLogins = await UserManager.GetLoginsAsync(user);
 
         var viewModel = ProfileEditViewModelBuilder.Build(
-            user,
-            profile,
+            info,
             applications,
-            contactFields,
-            fullProfile?.CVEntries ?? [],
-            languages,
             allShiftTags,
             preferredShiftTags,
             preview,

--- a/src/Humans.Web/Controllers/ProfileController.cs
+++ b/src/Humans.Web/Controllers/ProfileController.cs
@@ -365,7 +365,7 @@ public class ProfileController : HumansControllerBase
             ModelState.AddModelError(nameof(model.NoPriorBurnExperience),
                 _localizer["Profile_BurnerCVRequired"].Value);
             // Need to check if initial setup for the view
-            var existingProfile = await _profileService.GetProfileAsync(user.Id);
+            var existingProfile = (await _userService.GetUserInfoAsync(user.Id))?.Profile;
             model.IsInitialSetup = existingProfile is null || !existingProfile.IsApproved;
             model.ShowPrivateFirst = string.IsNullOrEmpty(model.FirstName)
                 && string.IsNullOrEmpty(model.LastName)
@@ -375,7 +375,7 @@ public class ProfileController : HumansControllerBase
         }
 
         // Validate tier-specific fields during initial setup
-        var profileForSetupCheck = await _profileService.GetProfileAsync(user.Id);
+        var profileForSetupCheck = (await _userService.GetUserInfoAsync(user.Id))?.Profile;
         var isInitialSetup = profileForSetupCheck is null || !profileForSetupCheck.IsApproved;
         if (isInitialSetup)
         {
@@ -1696,13 +1696,13 @@ public class ProfileController : HumansControllerBase
             return RedirectToAction(nameof(Edit));
         }
 
-        var profile = await _profileService.GetProfileAsync(user.Id, ct);
-        if (profile is null)
+        var info = await _userService.GetUserInfoAsync(user.Id, ct);
+        if (info?.Profile is null)
         {
             SetError(_localizer["Profile_ImportGooglePhoto_NoProfile"].Value);
             return RedirectToAction(nameof(Edit));
         }
-        if (profile.HasCustomProfilePicture)
+        if (info.Profile.HasCustomPicture)
         {
             SetError(_localizer["Profile_ImportGooglePhoto_AlreadyHasCustom"].Value);
             return RedirectToAction(nameof(Edit));
@@ -1898,27 +1898,20 @@ public class ProfileController : HumansControllerBase
     [HttpGet("{id:guid}/Popover")]
     public async Task<IActionResult> Popover(Guid id, CancellationToken ct)
     {
-        var userTask = _userService.GetByIdAsync(id, ct);
-        var profileTask = _profileService.GetProfileAsync(id, ct);
-        await Task.WhenAll(userTask, profileTask);
-        var popoverUser = await userTask;
-        if (popoverUser is null) return NotFound();
+        var info = await _userService.GetUserInfoAsync(id, ct);
+        if (info is null) return NotFound();
 
-        var profile = await profileTask;
+        var profile = info.Profile;
         if (profile is null)
         {
-            var userEmails = await _userEmailService.GetUserEmailsAsync(id, ct);
             return PartialView("_HumanPopover",
-                ProfileSummaryViewModelBuilder.BuildWithoutProfile(popoverUser, userEmails));
+                ProfileSummaryViewModelBuilder.BuildWithoutProfile(info));
         }
 
         var memberships = await _teamService.GetActiveTeamMembershipsForUserAsync(id, ct);
-        var profileLanguages = await _profileService.GetProfileLanguagesAsync(profile.Id, ct);
         var vm = ProfileSummaryViewModelBuilder.BuildWithProfile(
-            popoverUser,
-            profile,
+            info,
             memberships,
-            profileLanguages,
             p => Url.Action(nameof(Picture), "Profile",
                 new { id = p.Id, v = p.UpdatedAt.ToUnixTimeTicks() }));
 
@@ -2069,11 +2062,14 @@ public class ProfileController : HumansControllerBase
     [HttpGet("{id:guid}/Admin")]
     public async Task<IActionResult> AdminDetail(Guid id, CancellationToken ct)
     {
-        var user = await _userService.GetByIdAsync(id, ct);
-        if (user is null)
+        // Per-section composition (issue nobodies-collective/Humans#685): the
+        // Profile section reads its own row; cross-section data (Applications,
+        // RoleAssignments, ConsentCount, UserEmails, rejected-by display name)
+        // is fetched from each owning section here.
+        var info = await _userService.GetUserInfoAsync(id, ct);
+        if (info is null)
             return NotFound();
 
-        var profile = await _profileService.GetProfileAsync(id, ct);
         var applications = await _applicationDecisionService.GetUserApplicationsAsync(id, ct);
         var userEmails = await _userEmailService.GetEntitiesByUserIdAsync(id, ct);
         var consentCount = await _consentService.GetConsentRecordCountAsync(id, ct);
@@ -2083,38 +2079,33 @@ public class ProfileController : HumansControllerBase
             .ToDictionary(kvp => kvp.Key, kvp => kvp.Value.DisplayName);
         var campaignGrants = await _campaignService.GetAllGrantsForUserAsync(id, ct);
         var outboxCount = await _emailOutboxService.GetMessageCountForUserAsync(id, ct);
-        var profileLanguages = profile is not null
-            ? await _profileService.GetProfileLanguagesAsync(profile.Id, ct)
-            : (IReadOnlyList<ProfileLanguageSnapshot>)[];
         var revealedIban = TempData.TryGetValue("RevealedIban", out var revealed) && revealed is string value
             ? value
             : null;
 
         var viewModel = AdminHumanDetailViewModelBuilder.Build(
-            user,
-            profile,
+            info,
             applications,
             userEmails,
             consentCount,
             roleAssignments,
             roleCreatorNamesByUserId,
-            profileLanguages,
             campaignGrants,
             outboxCount,
             _clock.GetCurrentInstant(),
-            await GetRejectedByNameAsync(profile, ct),
+            await GetRejectedByNameAsync(info.Profile, ct),
             revealedIban);
 
         return View("AdminDetail", viewModel);
     }
 
-    private async Task<string?> GetRejectedByNameAsync(Profile? profile, CancellationToken ct)
+    private async Task<string?> GetRejectedByNameAsync(ProfileInfo? profile, CancellationToken ct)
     {
         if (profile?.RejectedByUserId is null)
             return null;
 
-        var rejectedByUser = await _userService.GetByIdAsync(profile.RejectedByUserId.Value, ct);
-        return rejectedByUser?.DisplayName;
+        var rejectedByInfo = await _userService.GetUserInfoAsync(profile.RejectedByUserId.Value, ct);
+        return rejectedByInfo?.DisplayName;
     }
 
     /// <summary>
@@ -2133,8 +2124,9 @@ public class ProfileController : HumansControllerBase
 
     private async Task<IActionResult> RevealIbanCoreAsync(Guid id, Guid actorId, CancellationToken ct)
     {
-        var profile = await _profileService.GetProfileAsync(id, ct);
-        if (profile?.Iban is null)
+        var info = await _userService.GetUserInfoAsync(id, ct);
+        var iban = info?.Profile?.Iban;
+        if (iban is null)
         {
             SetError("No IBAN on record for this user.");
             return RedirectToAction(nameof(AdminDetail), new { id });
@@ -2142,7 +2134,7 @@ public class ProfileController : HumansControllerBase
         await _auditLogService.LogAsync(
             AuditAction.IbanReveal, "User", id,
             $"Admin revealed IBAN for user {id}", actorId);
-        TempData["RevealedIban"] = profile.Iban;
+        TempData["RevealedIban"] = iban;
         return RedirectToAction(nameof(AdminDetail), new { id });
     }
 

--- a/src/Humans.Web/Controllers/ProfileController.cs
+++ b/src/Humans.Web/Controllers/ProfileController.cs
@@ -1802,7 +1802,7 @@ public class ProfileController : HumansControllerBase
         var profileInfo = await _userService.GetUserInfoAsync(id, ct);
         var profile = profileInfo?.Profile;
 
-        if (profile is null || profile.State == ProfileState.Suspended)
+        if (profile is null || profileInfo!.IsSuspended)
         {
             return NotFound();
         }

--- a/src/Humans.Web/Controllers/ProfileController.cs
+++ b/src/Humans.Web/Controllers/ProfileController.cs
@@ -244,7 +244,7 @@ public class ProfileController : HumansControllerBase
         if (user is null)
             return NotFound();
 
-        var profile = await _profileService.GetProfileAsync(user.Id, ct);
+        var profile = (await _userService.GetUserInfoAsync(user.Id, ct))?.Profile;
         var snapshot = await _membershipCalculator.GetMembershipSnapshotAsync(user.Id, ct);
         var pendingConsentCount = snapshot.PendingConsentCount;
 
@@ -1808,9 +1808,10 @@ public class ProfileController : HumansControllerBase
     [HttpGet("{id:guid}")]
     public async Task<IActionResult> ViewProfile(Guid id, CancellationToken ct)
     {
-        var profile = await _profileService.GetProfileAsync(id, ct);
+        var profileInfo = await _userService.GetUserInfoAsync(id, ct);
+        var profile = profileInfo?.Profile;
 
-        if (profile is null || profile.IsSuspended)
+        if (profile is null || profile.State == ProfileState.Suspended)
         {
             return NotFound();
         }
@@ -1826,12 +1827,11 @@ public class ProfileController : HumansControllerBase
         var noShowContext = await BuildNoShowHistoryContextAsync(id, viewer, isOwnProfile, ct);
 
         // The ProfileCard ViewComponent handles all data fetching and permission checks.
-        var profileUser = await _userService.GetByIdAsync(id, ct);
         var viewModel = new ProfileViewModel
         {
             Id = profile.Id,
             UserId = id,
-            DisplayName = profileUser?.DisplayName ?? "Unknown",
+            DisplayName = profileInfo!.DisplayName,
             IsOwnProfile = isOwnProfile,
             IsApproved = profile.IsApproved,
             NoShowHistory = noShowContext.History,

--- a/src/Humans.Web/Models/AdminHumanDetailViewModelBuilder.cs
+++ b/src/Humans.Web/Models/AdminHumanDetailViewModelBuilder.cs
@@ -1,4 +1,4 @@
-using Humans.Domain.Entities;
+using Humans.Application;
 using Humans.Domain.Enums;
 using Humans.Domain.Helpers;
 using Humans.Application.Interfaces.Auth;
@@ -6,52 +6,50 @@ using Humans.Application.Interfaces.Campaigns;
 using Humans.Application.Interfaces.Governance;
 using Humans.Application.Interfaces.Profiles;
 using NodaTime;
-using ProfileEntity = Humans.Domain.Entities.Profile;
 
 namespace Humans.Web.Models;
 
 public static class AdminHumanDetailViewModelBuilder
 {
     public static AdminHumanDetailViewModel Build(
-        User user,
-        ProfileEntity? profile,
+        UserInfo info,
         IReadOnlyList<UserApplicationSnapshot> applications,
         IReadOnlyList<UserEmailRowSnapshot> userEmails,
         int consentCount,
         IReadOnlyList<RoleAssignmentSummarySnapshot> roleAssignments,
         IReadOnlyDictionary<Guid, string> roleCreatorNamesByUserId,
-        IReadOnlyList<ProfileLanguageSnapshot> profileLanguages,
         IReadOnlyList<CampaignGrantSummary> campaignGrants,
         int outboxCount,
         Instant now,
         string? rejectedByName,
         string? revealedIban)
     {
-        ArgumentNullException.ThrowIfNull(user);
+        ArgumentNullException.ThrowIfNull(info);
         ArgumentNullException.ThrowIfNull(applications);
         ArgumentNullException.ThrowIfNull(userEmails);
         ArgumentNullException.ThrowIfNull(roleAssignments);
         ArgumentNullException.ThrowIfNull(roleCreatorNamesByUserId);
-        ArgumentNullException.ThrowIfNull(profileLanguages);
         ArgumentNullException.ThrowIfNull(campaignGrants);
+
+        var profile = info.Profile;
 
         var effectiveEmail = userEmails
             .FirstOrDefault(e => e.IsPrimary && e.IsVerified)?.Email
-            ?? user.Email;
+            ?? info.Email;
 
         return new AdminHumanDetailViewModel
         {
-            UserId = user.Id,
+            UserId = info.Id,
             Email = effectiveEmail ?? string.Empty,
-            DisplayName = user.DisplayName,
-            ProfilePictureUrl = user.ProfilePictureUrl,
-            CreatedAt = user.CreatedAt.ToDateTimeUtc(),
-            LastLoginAt = user.LastLoginAt?.ToDateTimeUtc(),
-            IsSuspended = profile?.IsSuspended ?? false,
+            DisplayName = info.DisplayName,
+            ProfilePictureUrl = info.ProfilePictureUrl,
+            CreatedAt = info.CreatedAt.ToDateTimeUtc(),
+            LastLoginAt = info.LastLoginAt?.ToDateTimeUtc(),
+            IsSuspended = info.IsSuspended,
             IsApproved = profile?.IsApproved ?? false,
             HasProfile = profile is not null,
             AdminNotes = profile?.AdminNotes,
-            PreferredLanguage = user.PreferredLanguage,
+            PreferredLanguage = info.PreferredLanguage,
             MembershipTier = profile?.MembershipTier ?? MembershipTier.Volunteer,
             ConsentCheckStatus = profile?.ConsentCheckStatus,
             IsRejected = profile?.RejectedAt is not null,
@@ -83,19 +81,19 @@ public static class AdminHumanDetailViewModelBuilder
                 CreatedByName = GetRoleCreatorName(roleCreatorNamesByUserId, ra),
                 CreatedAt = ra.CreatedAt.ToDateTimeUtc()
             }).ToList(),
-            Languages = profileLanguages.Select(pl => new ProfileLanguageDisplayViewModel
+            Languages = (profile?.Languages ?? []).Select(pl => new ProfileLanguageDisplayViewModel
             {
                 LanguageCode = pl.LanguageCode,
                 LanguageName = Helpers.LanguageCatalog.GetDisplayName(pl.LanguageCode),
                 Proficiency = pl.Proficiency
             }).ToList(),
-            OAuthEmail = user.Email,
+            OAuthEmail = info.Email,
             GoogleServiceEmail = userEmails
                 .Where(e => e.IsVerified && e.IsGoogle)
                 .Select(e => e.Email)
                 .FirstOrDefault()
-                ?? user.Email,
-            GoogleEmailStatus = user.GoogleEmailStatus,
+                ?? info.Email,
+            GoogleEmailStatus = info.GoogleEmailStatus,
             UserEmails = userEmails
                 .OrderBy(e => e.Email, StringComparer.OrdinalIgnoreCase)
                 .Select(e => new AdminUserEmailViewModel

--- a/src/Humans.Web/Models/ProfileEditViewModelBuilder.cs
+++ b/src/Humans.Web/Models/ProfileEditViewModelBuilder.cs
@@ -1,63 +1,54 @@
 using Humans.Application;
-using Humans.Application.DTOs;
 using Humans.Application.Interfaces.Governance;
-using Humans.Application.Interfaces.Profiles;
 using Humans.Application.Interfaces.Shifts;
 using Humans.Application.Extensions;
-using Humans.Domain.Entities;
 using Humans.Domain.Enums;
-using ProfileEntity = Humans.Domain.Entities.Profile;
 
 namespace Humans.Web.Models;
 
 public static class ProfileEditViewModelBuilder
 {
     public static ProfileViewModel Build(
-        User user,
-        ProfileEntity? profile,
+        UserInfo info,
         IReadOnlyList<UserApplicationSnapshot> applications,
-        IReadOnlyList<ContactFieldEditDto> contactFields,
-        IReadOnlyList<CVEntry> cvEntries,
-        IReadOnlyList<ProfileLanguageSnapshot> languages,
         IReadOnlyList<ShiftTagSummary> allShiftTags,
         IReadOnlyList<ShiftTagPreferenceSummary> preferredShiftTags,
         bool preview,
         bool hasGoogleLogin,
-        Func<ProfileEntity, string?> customPictureUrl)
+        Func<ProfileInfo, string?> customPictureUrl)
     {
-        ArgumentNullException.ThrowIfNull(user);
+        ArgumentNullException.ThrowIfNull(info);
         ArgumentNullException.ThrowIfNull(applications);
-        ArgumentNullException.ThrowIfNull(contactFields);
-        ArgumentNullException.ThrowIfNull(cvEntries);
-        ArgumentNullException.ThrowIfNull(languages);
         ArgumentNullException.ThrowIfNull(allShiftTags);
         ArgumentNullException.ThrowIfNull(preferredShiftTags);
         ArgumentNullException.ThrowIfNull(customPictureUrl);
+
+        var profile = info.Profile;
 
         var isTierLocked = profile is not null && applications.Any(a =>
             a.Status == ApplicationStatus.Submitted || a.Status == ApplicationStatus.Approved);
         var pendingApplication = profile is null || !profile.IsApproved
             ? applications.FirstOrDefault(a => a.Status == ApplicationStatus.Submitted)
             : null;
-        var hasCustomPicture = profile?.HasCustomProfilePicture == true;
+        var hasCustomPicture = profile?.HasCustomPicture == true;
         var isInitialSetup = profile is null || !profile.IsApproved || preview;
         var canImportGooglePicture = hasGoogleLogin
             && !hasCustomPicture
-            && !string.IsNullOrEmpty(user.ProfilePictureUrl);
+            && !string.IsNullOrEmpty(info.ProfilePictureUrl);
 
         return new ProfileViewModel
         {
             Id = profile?.Id ?? Guid.Empty,
-            UserId = user.Id,
-            Email = user.Email ?? string.Empty,
-            DisplayName = user.DisplayName,
-            ProfilePictureUrl = user.ProfilePictureUrl,
+            UserId = info.Id,
+            Email = info.Email ?? string.Empty,
+            DisplayName = info.DisplayName,
+            ProfilePictureUrl = info.ProfilePictureUrl,
             HasCustomProfilePicture = hasCustomPicture,
             CustomProfilePictureUrl = hasCustomPicture && profile is not null
                 ? customPictureUrl(profile)
                 : null,
             CanImportGooglePicture = canImportGooglePicture,
-            BurnerName = profile?.BurnerName ?? user.DisplayName,
+            BurnerName = profile?.BurnerName ?? info.DisplayName,
             FirstName = profile?.FirstName ?? string.Empty,
             LastName = profile?.LastName ?? string.Empty,
             City = profile?.City,
@@ -69,8 +60,8 @@ public static class ProfileEditViewModelBuilder
             Pronouns = profile?.Pronouns,
             ContributionInterests = profile?.ContributionInterests,
             BoardNotes = profile?.BoardNotes,
-            BirthdayMonth = profile?.DateOfBirth?.Month,
-            BirthdayDay = profile?.DateOfBirth?.Day,
+            BirthdayMonth = profile?.BirthdayMonth,
+            BirthdayDay = profile?.BirthdayDay,
             EmergencyContactName = profile?.EmergencyContactName,
             EmergencyContactPhone = profile?.EmergencyContactPhone,
             EmergencyContactRelationship = profile?.EmergencyContactRelationship,
@@ -86,7 +77,7 @@ public static class ProfileEditViewModelBuilder
             ShowPrivateFirst = string.IsNullOrEmpty(profile?.FirstName)
                 && string.IsNullOrEmpty(profile?.LastName)
                 && string.IsNullOrEmpty(profile?.EmergencyContactName),
-            EditableContactFields = contactFields.Select(cf => new ContactFieldEditViewModel
+            EditableContactFields = (profile?.ContactFields ?? []).Select(cf => new ContactFieldEditViewModel
             {
                 Id = cf.Id,
                 FieldType = cf.FieldType,
@@ -95,14 +86,14 @@ public static class ProfileEditViewModelBuilder
                 Visibility = cf.Visibility,
                 DisplayOrder = cf.DisplayOrder
             }).ToList(),
-            EditableVolunteerHistory = cvEntries.Select(cv => new VolunteerHistoryEntryEditViewModel
+            EditableVolunteerHistory = (profile?.VolunteerHistory ?? []).Select(cv => new VolunteerHistoryEntryEditViewModel
             {
                 Id = cv.Id,
                 DateString = cv.Date.ToIsoDateString(),
                 EventName = cv.EventName,
                 Description = cv.Description
             }).ToList(),
-            EditableLanguages = languages.Select(pl => new ProfileLanguageEditViewModel
+            EditableLanguages = (profile?.Languages ?? []).Select(pl => new ProfileLanguageEditViewModel
             {
                 Id = pl.Id,
                 LanguageCode = pl.LanguageCode,

--- a/src/Humans.Web/Models/ProfileSummaryViewModelBuilder.cs
+++ b/src/Humans.Web/Models/ProfileSummaryViewModelBuilder.cs
@@ -1,46 +1,36 @@
-using Humans.Application.DTOs;
+using Humans.Application;
 using Humans.Application.Models;
-using Humans.Application.Interfaces.Profiles;
-using Humans.Domain.Entities;
-using ProfileEntity = Humans.Domain.Entities.Profile;
 
 namespace Humans.Web.Models;
 
 public static class ProfileSummaryViewModelBuilder
 {
-    public static ProfileSummaryViewModel BuildWithoutProfile(
-        User user,
-        IReadOnlyList<UserEmailEditDto> userEmails)
+    public static ProfileSummaryViewModel BuildWithoutProfile(UserInfo info)
     {
-        ArgumentNullException.ThrowIfNull(user);
-        ArgumentNullException.ThrowIfNull(userEmails);
-
-        var fallbackEmail = userEmails.FirstOrDefault(e => e.IsVerified && e.IsPrimary)?.Email
-            ?? userEmails.FirstOrDefault(e => e.IsVerified)?.Email;
+        ArgumentNullException.ThrowIfNull(info);
 
         return new ProfileSummaryViewModel
         {
-            UserId = user.Id,
-            DisplayName = user.DisplayName,
-            Email = fallbackEmail,
-            ProfilePictureUrl = user.ProfilePictureUrl,
-            PreferredLanguage = user.PreferredLanguage,
+            UserId = info.Id,
+            DisplayName = info.DisplayName,
+            Email = info.Email,
+            ProfilePictureUrl = info.ProfilePictureUrl,
+            PreferredLanguage = info.PreferredLanguage,
             HasProfile = false,
         };
     }
 
     public static ProfileSummaryViewModel BuildWithProfile(
-        User user,
-        ProfileEntity profile,
+        UserInfo info,
         IReadOnlyList<TeamMembership> memberships,
-        IReadOnlyList<ProfileLanguageSnapshot> profileLanguages,
-        Func<ProfileEntity, string?> customPictureUrl)
+        Func<ProfileInfo, string?> customPictureUrl)
     {
-        ArgumentNullException.ThrowIfNull(user);
-        ArgumentNullException.ThrowIfNull(profile);
+        ArgumentNullException.ThrowIfNull(info);
         ArgumentNullException.ThrowIfNull(memberships);
-        ArgumentNullException.ThrowIfNull(profileLanguages);
         ArgumentNullException.ThrowIfNull(customPictureUrl);
+
+        var profile = info.Profile
+            ?? throw new ArgumentException("UserInfo.Profile must be non-null.", nameof(info));
 
         var orderedMemberships = memberships
             .OrderBy(m => m.TeamName, StringComparer.OrdinalIgnoreCase)
@@ -48,22 +38,22 @@ public static class ProfileSummaryViewModelBuilder
 
         return new ProfileSummaryViewModel
         {
-            UserId = user.Id,
-            DisplayName = user.DisplayName,
-            Email = user.Email,
-            ProfilePictureUrl = profile.HasCustomProfilePicture
+            UserId = info.Id,
+            DisplayName = info.DisplayName,
+            Email = info.Email,
+            ProfilePictureUrl = profile.HasCustomPicture
                 ? customPictureUrl(profile)
-                : user.ProfilePictureUrl,
-            PreferredLanguage = user.PreferredLanguage,
+                : info.ProfilePictureUrl,
+            PreferredLanguage = info.PreferredLanguage,
             MembershipTier = profile.MembershipTier.ToString(),
-            MembershipStatus = profile.IsSuspended ? "Suspended"
+            MembershipStatus = info.IsSuspended ? "Suspended"
                 : profile.IsApproved ? "Active" : "Pending",
             City = profile.City,
             CountryCode = profile.CountryCode,
-            IsSuspended = profile.IsSuspended,
+            IsSuspended = info.IsSuspended,
             Teams = orderedMemberships.Where(m => !m.IsHidden).Select(m => m.TeamName).ToList(),
             HiddenTeams = orderedMemberships.Where(m => m.IsHidden).Select(m => m.TeamName).ToList(),
-            Languages = profileLanguages.Select(pl => new ProfileLanguageDisplayViewModel
+            Languages = profile.Languages.Select(pl => new ProfileLanguageDisplayViewModel
             {
                 LanguageCode = pl.LanguageCode,
                 LanguageName = Helpers.LanguageCatalog.GetDisplayName(pl.LanguageCode),

--- a/src/Humans.Web/Models/ProfileSummaryViewModelBuilder.cs
+++ b/src/Humans.Web/Models/ProfileSummaryViewModelBuilder.cs
@@ -9,11 +9,13 @@ public static class ProfileSummaryViewModelBuilder
     {
         ArgumentNullException.ThrowIfNull(info);
 
+        // Email is intentionally NOT populated here — the popover surfaces this
+        // model to any authenticated user, so exposing email (verified or not)
+        // is a GDPR PII leak. Admins who need email use /Profile/{id}/Admin.
         return new ProfileSummaryViewModel
         {
             UserId = info.Id,
             DisplayName = info.DisplayName,
-            Email = info.Email,
             ProfilePictureUrl = info.ProfilePictureUrl,
             PreferredLanguage = info.PreferredLanguage,
             HasProfile = false,

--- a/src/Humans.Web/ViewComponents/ProfileCardViewComponent.cs
+++ b/src/Humans.Web/ViewComponents/ProfileCardViewComponent.cs
@@ -23,7 +23,6 @@ public enum ProfileCardViewMode
 public class ProfileCardViewComponent : ViewComponent
 {
     private readonly UserManager<User> _userManager;
-    private readonly IProfileService _profileService;
     private readonly IUserService _userService;
     private readonly IContactFieldService _contactFieldService;
     private readonly IUserEmailService _userEmailService;
@@ -34,7 +33,6 @@ public class ProfileCardViewComponent : ViewComponent
 
     public ProfileCardViewComponent(
         UserManager<User> userManager,
-        IProfileService profileService,
         IUserService userService,
         IContactFieldService contactFieldService,
         IUserEmailService userEmailService,
@@ -44,7 +42,6 @@ public class ProfileCardViewComponent : ViewComponent
         ICommunicationPreferenceService commPrefService)
     {
         _userManager = userManager;
-        _profileService = profileService;
         _userService = userService;
         _contactFieldService = contactFieldService;
         _userEmailService = userEmailService;
@@ -56,15 +53,12 @@ public class ProfileCardViewComponent : ViewComponent
 
     public async Task<IViewComponentResult> InvokeAsync(Guid userId, ProfileCardViewMode viewMode)
     {
-        // Load profile and user independently (nav property stripped)
-        var profile = await _profileService.GetProfileAsync(userId);
-        var user = await _userService.GetByIdAsync(userId)
-            ?? await _userManager.FindByIdAsync(userId.ToString());
-
-        if (user is null)
+        var info = await _userService.GetUserInfoAsync(userId);
+        if (info is null)
         {
             return Content(string.Empty);
         }
+        var profile = info.Profile;
 
         var isOwnProfile = viewMode == ProfileCardViewMode.Self;
         var canViewLegalName = viewMode != ProfileCardViewMode.Public;
@@ -100,15 +94,6 @@ public class ProfileCardViewComponent : ViewComponent
 
         // nobodies.team email badge is now handled by NobodiesEmailBadgeViewComponent
 
-        // Get CV entries from the FullProfile projection
-        var fullProfile = await _profileService.GetFullProfileAsync(userId);
-        var cvEntries = fullProfile?.CVEntries ?? [];
-
-        // Get profile languages (service returns sorted by proficiency desc, then language code)
-        var profileLanguages = profile is not null
-            ? await _profileService.GetProfileLanguagesAsync(profile.Id)
-            : (IReadOnlyList<ProfileLanguageSnapshot>)[];
-
         // Get user's teams (excluding Volunteers system team)
         var userTeams = await _teamService.GetUserTeamsAsync(userId);
         var displayableTeams = userTeams
@@ -128,7 +113,7 @@ public class ProfileCardViewComponent : ViewComponent
         // Get membership status
         var membershipSnapshot = await _membershipCalculator.GetMembershipSnapshotAsync(userId);
 
-        var hasCustomPicture = profile?.HasCustomProfilePicture == true;
+        var hasCustomPicture = profile?.HasCustomPicture == true;
         var pictureUrl = hasCustomPicture
             ? Url.Action(nameof(ProfileController.Picture), "Profile", new { id = profile!.Id, v = profile.UpdatedAt.ToUnixTimeTicks() })
             : null;
@@ -136,8 +121,8 @@ public class ProfileCardViewComponent : ViewComponent
         var model = new ProfileCardViewModel
         {
             UserId = userId,
-            DisplayName = user.DisplayName,
-            ProfilePictureUrl = user.ProfilePictureUrl,
+            DisplayName = info.DisplayName,
+            ProfilePictureUrl = info.ProfilePictureUrl,
             HasCustomProfilePicture = hasCustomPicture,
             CustomProfilePictureUrl = pictureUrl,
             BurnerName = profile?.BurnerName ?? string.Empty,
@@ -146,8 +131,8 @@ public class ProfileCardViewComponent : ViewComponent
             IsApproved = profile?.IsApproved ?? false,
             City = profile?.City,
             CountryCode = profile?.CountryCode,
-            BirthdayMonth = profile?.DateOfBirth?.Month,
-            BirthdayDay = profile?.DateOfBirth?.Day,
+            BirthdayMonth = profile?.BirthdayMonth,
+            BirthdayDay = profile?.BirthdayDay,
             Bio = profile?.Bio,
             ContributionInterests = profile?.ContributionInterests,
             BoardNotes = canViewLegalName ? profile?.BoardNotes : null,
@@ -175,20 +160,20 @@ public class ProfileCardViewComponent : ViewComponent
                 Value = cf.Value,
                 Visibility = cf.Visibility
             }).ToList(),
-            VolunteerHistory = cvEntries.Select(cv => new VolunteerHistoryEntryViewModel
+            VolunteerHistory = (profile?.VolunteerHistory ?? []).Select(cv => new VolunteerHistoryEntryViewModel
             {
                 Date = cv.Date,
                 EventName = cv.EventName,
                 Description = cv.Description
             }).ToList(),
             Teams = displayableTeams,
-            Languages = profileLanguages.Select(pl => new ProfileLanguageDisplayViewModel
+            Languages = (profile?.Languages ?? []).Select(pl => new ProfileLanguageDisplayViewModel
             {
                 LanguageCode = pl.LanguageCode,
                 LanguageName = LanguageCatalog.GetDisplayName(pl.LanguageCode),
                 Proficiency = pl.Proficiency
             }).ToList(),
-            PreferredLanguage = user.PreferredLanguage,
+            PreferredLanguage = info.PreferredLanguage,
             CanSendMessage = !isOwnProfile
                 && !visibleEmails.Any(e => e.Visibility >= ContactFieldVisibility.AllActiveProfiles)
                 && await _commPrefService.AcceptsFacilitatedMessagesAsync(userId)

--- a/src/Humans.Web/Views/Shared/_HumanPopover.cshtml
+++ b/src/Humans.Web/Views/Shared/_HumanPopover.cshtml
@@ -33,12 +33,6 @@
         {
             <span class="badge bg-success" style="font-size: 0.7rem;">@Model.MembershipTier</span>
         }
-        @if (!Model.HasProfile && !string.IsNullOrEmpty(Model.Email))
-        {
-            <div class="text-muted small text-break">
-                <i class="fa-solid fa-envelope me-1"></i>@Model.Email
-            </div>
-        }
         @if (!string.IsNullOrEmpty(Model.City) || !string.IsNullOrEmpty(Model.CountryCode))
         {
             <div class="text-muted small">

--- a/tests/Humans.Application.Tests/Controllers/ProfileControllerEditTests.cs
+++ b/tests/Humans.Application.Tests/Controllers/ProfileControllerEditTests.cs
@@ -1,5 +1,6 @@
 using System.Security.Claims;
 using AwesomeAssertions;
+using Humans.Application;
 using Humans.Application.Configuration;
 using Humans.Application.DTOs;
 using Humans.Application.Interfaces.AuditLog;
@@ -57,6 +58,7 @@ public class ProfileControllerEditTests
 {
     private readonly UserManager<User> _userManager;
     private readonly IProfileService _profileService = Substitute.For<IProfileService>();
+    private readonly IUserService _userService = Substitute.For<IUserService>();
     private readonly IApplicationDecisionService _applicationDecisionService =
         Substitute.For<IApplicationDecisionService>();
     private readonly IConfiguration _configuration = Substitute.For<IConfiguration>();
@@ -111,7 +113,7 @@ public class ProfileControllerEditTests
             new MemoryCache(new MemoryCacheOptions()),
             new FakeClock(Instant.FromUtc(2026, 5, 9, 12, 0)),
             authorizationService,
-            Substitute.For<IUserService>(),
+            _userService,
             Substitute.For<IConsentService>(),
             _applicationDecisionService,
             Substitute.For<IAccountDeletionService>(),
@@ -238,7 +240,8 @@ public class ProfileControllerEditTests
             LastName = "Human",
             IsApproved = true,
         };
-        _profileService.GetProfileAsync(_userId, Arg.Any<CancellationToken>()).Returns(approvedProfile);
+        _userService.GetUserInfoAsync(_userId, Arg.Any<CancellationToken>())
+            .Returns(BuildUserInfo(approvedProfile));
 
         var model = MakeValidModel(MembershipTier.Colaborador, motivation: "irrelevant");
 
@@ -325,4 +328,15 @@ public class ProfileControllerEditTests
             SelectedTier = tier,
             ApplicationMotivation = motivation,
         };
+
+    private UserInfo BuildUserInfo(Profile? profile) => UserInfo.Create(
+        user: new User { Id = _userId, DisplayName = "Test Human", PreferredLanguage = "en" },
+        userEmails: Array.Empty<UserEmail>(),
+        eventParticipations: Array.Empty<EventParticipation>(),
+        externalLogins: Array.Empty<(string, string)>(),
+        profile: profile,
+        contactFields: Array.Empty<ContactField>(),
+        profileLanguages: Array.Empty<ProfileLanguage>(),
+        volunteerHistory: Array.Empty<VolunteerHistoryEntry>(),
+        communicationPreferences: Array.Empty<CommunicationPreference>());
 }

--- a/tests/Humans.Application.Tests/Controllers/ProfileControllerPopoverTests.cs
+++ b/tests/Humans.Application.Tests/Controllers/ProfileControllerPopoverTests.cs
@@ -130,20 +130,22 @@ public class ProfileControllerPopoverTests
     }
 
     [HumansFact]
-    public async Task Popover_UserWithoutProfile_RendersFallbackWithVerifiedPrimaryEmail()
+    public async Task Popover_UserWithoutProfile_RendersFallbackWithoutEmail()
     {
+        // The popover is reachable by any authenticated user. Surfacing email
+        // (verified or not) for the imported-no-profile path is a GDPR PII leak.
+        // Admins who need email use /Profile/{id}/Admin.
         var id = Guid.NewGuid();
         var user = new User
         {
             Id = id,
             DisplayName = "Imported Human",
-            Email = null,
+            Email = "stale-legacy@example.com",
             PreferredLanguage = "es",
             ProfilePictureUrl = null,
         };
         var userEmails = new List<UserEmail>
         {
-            new() { Id = Guid.NewGuid(), UserId = id, Email = "secondary@example.com", IsVerified = true, IsPrimary = false },
             new() { Id = Guid.NewGuid(), UserId = id, Email = "primary@example.com", IsVerified = true, IsPrimary = true },
         };
         _userService.GetUserInfoAsync(id, Arg.Any<CancellationToken>())
@@ -156,40 +158,13 @@ public class ProfileControllerPopoverTests
         var vm = partial.Model.Should().BeOfType<ProfileSummaryViewModel>().Subject;
         vm.HasProfile.Should().BeFalse();
         vm.DisplayName.Should().Be("Imported Human");
-        vm.Email.Should().Be("primary@example.com");
+        vm.Email.Should().BeNull();
         vm.PreferredLanguage.Should().Be("es");
         vm.MembershipTier.Should().BeNull();
         vm.MembershipStatus.Should().BeNull();
         vm.City.Should().BeNull();
         vm.Teams.Should().BeEmpty();
         vm.Languages.Should().BeEmpty();
-    }
-
-    [HumansFact]
-    public async Task Popover_UserWithoutProfile_DoesNotSeedFromLegacyUserEmail()
-    {
-        // Regression: UserInfo.Email derives from verified UserEmail rows, not
-        // the legacy Identity column (see User.cs SILENT-FALLBACK FOOTGUN).
-        var id = Guid.NewGuid();
-        var user = new User
-        {
-            Id = id,
-            DisplayName = "Imported Human",
-            Email = "stale-legacy@example.com",
-            PreferredLanguage = "en",
-        };
-        var userEmails = new List<UserEmail>
-        {
-            new() { Id = Guid.NewGuid(), UserId = id, Email = "canonical@example.com", IsVerified = true, IsPrimary = true },
-        };
-        _userService.GetUserInfoAsync(id, Arg.Any<CancellationToken>())
-            .Returns(BuildUserInfo(user, profile: null, userEmails));
-
-        var result = await _controller.Popover(id, CancellationToken.None);
-
-        var partial = result.Should().BeOfType<PartialViewResult>().Subject;
-        var vm = partial.Model.Should().BeOfType<ProfileSummaryViewModel>().Subject;
-        vm.Email.Should().Be("canonical@example.com");
     }
 
     [HumansFact]

--- a/tests/Humans.Application.Tests/Controllers/ProfileControllerPopoverTests.cs
+++ b/tests/Humans.Application.Tests/Controllers/ProfileControllerPopoverTests.cs
@@ -1,5 +1,6 @@
 using System.Security.Claims;
 using AwesomeAssertions;
+using Humans.Application;
 using Humans.Application.Configuration;
 using Humans.Application.DTOs;
 using Humans.Application.Interfaces.AuditLog;
@@ -121,7 +122,7 @@ public class ProfileControllerPopoverTests
     public async Task Popover_UnknownUser_Returns404()
     {
         var id = Guid.NewGuid();
-        _userService.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns((User?)null);
+        _userService.GetUserInfoAsync(id, Arg.Any<CancellationToken>()).Returns((UserInfo?)null);
 
         var result = await _controller.Popover(id, CancellationToken.None);
 
@@ -140,19 +141,13 @@ public class ProfileControllerPopoverTests
             PreferredLanguage = "es",
             ProfilePictureUrl = null,
         };
-        _userService.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns(user);
-        _profileService.GetProfileAsync(id, Arg.Any<CancellationToken>()).Returns((Profile?)null);
-
-        var emails = new List<UserEmailEditDto>
+        var userEmails = new List<UserEmail>
         {
-            new(Guid.NewGuid(), "secondary@example.com", IsVerified: true, IsGoogle: false,
-                Provider: null, ProviderKey: null, IsPrimary: false, Visibility: null,
-                IsPendingVerification: false),
-            new(Guid.NewGuid(), "primary@example.com", IsVerified: true, IsGoogle: false,
-                Provider: null, ProviderKey: null, IsPrimary: true, Visibility: null,
-                IsPendingVerification: false),
+            new() { Id = Guid.NewGuid(), UserId = id, Email = "secondary@example.com", IsVerified = true, IsPrimary = false },
+            new() { Id = Guid.NewGuid(), UserId = id, Email = "primary@example.com", IsVerified = true, IsPrimary = true },
         };
-        _userEmailService.GetUserEmailsAsync(id, Arg.Any<CancellationToken>()).Returns(emails);
+        _userService.GetUserInfoAsync(id, Arg.Any<CancellationToken>())
+            .Returns(BuildUserInfo(user, profile: null, userEmails));
 
         var result = await _controller.Popover(id, CancellationToken.None);
 
@@ -173,10 +168,8 @@ public class ProfileControllerPopoverTests
     [HumansFact]
     public async Task Popover_UserWithoutProfile_DoesNotSeedFromLegacyUserEmail()
     {
-        // Regression: User.Email falls back to the legacy Identity column when
-        // UserEmails isn't loaded (see User.cs SILENT-FALLBACK FOOTGUN), so the
-        // fallback popover must always derive from verified UserEmail rows
-        // regardless of what popoverUser.Email returns.
+        // Regression: UserInfo.Email derives from verified UserEmail rows, not
+        // the legacy Identity column (see User.cs SILENT-FALLBACK FOOTGUN).
         var id = Guid.NewGuid();
         var user = new User
         {
@@ -185,16 +178,12 @@ public class ProfileControllerPopoverTests
             Email = "stale-legacy@example.com",
             PreferredLanguage = "en",
         };
-        _userService.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns(user);
-        _profileService.GetProfileAsync(id, Arg.Any<CancellationToken>()).Returns((Profile?)null);
-
-        var emails = new List<UserEmailEditDto>
+        var userEmails = new List<UserEmail>
         {
-            new(Guid.NewGuid(), "canonical@example.com", IsVerified: true, IsGoogle: false,
-                Provider: null, ProviderKey: null, IsPrimary: true, Visibility: null,
-                IsPendingVerification: false),
+            new() { Id = Guid.NewGuid(), UserId = id, Email = "canonical@example.com", IsVerified = true, IsPrimary = true },
         };
-        _userEmailService.GetUserEmailsAsync(id, Arg.Any<CancellationToken>()).Returns(emails);
+        _userService.GetUserInfoAsync(id, Arg.Any<CancellationToken>())
+            .Returns(BuildUserInfo(user, profile: null, userEmails));
 
         var result = await _controller.Popover(id, CancellationToken.None);
 
@@ -214,8 +203,6 @@ public class ProfileControllerPopoverTests
             Email = "active@example.com",
             PreferredLanguage = "en",
         };
-        _userService.GetByIdAsync(id, Arg.Any<CancellationToken>()).Returns(user);
-
         var profile = new Profile
         {
             Id = Guid.NewGuid(),
@@ -223,12 +210,12 @@ public class ProfileControllerPopoverTests
             MembershipTier = MembershipTier.Volunteer,
             IsApproved = true,
             IsSuspended = false,
+            State = ProfileState.Active,
             City = "Madrid",
             CountryCode = "ES",
         };
-        _profileService.GetProfileAsync(id, Arg.Any<CancellationToken>()).Returns(profile);
-        _profileService.GetProfileLanguagesAsync(profile.Id, Arg.Any<CancellationToken>())
-            .Returns(new List<ProfileLanguageSnapshot>());
+        _userService.GetUserInfoAsync(id, Arg.Any<CancellationToken>())
+            .Returns(BuildUserInfo(user, profile, userEmails: null));
         _teamService.GetActiveTeamMembershipsForUserAsync(id, Arg.Any<CancellationToken>())
             .Returns(new List<Humans.Application.Models.TeamMembership>());
 
@@ -244,4 +231,16 @@ public class ProfileControllerPopoverTests
         vm.City.Should().Be("Madrid");
         vm.CountryCode.Should().Be("ES");
     }
+
+    private static UserInfo BuildUserInfo(User user, Profile? profile, IReadOnlyList<UserEmail>? userEmails) =>
+        UserInfo.Create(
+            user: user,
+            userEmails: userEmails ?? Array.Empty<UserEmail>(),
+            eventParticipations: Array.Empty<EventParticipation>(),
+            externalLogins: Array.Empty<(string, string)>(),
+            profile: profile,
+            contactFields: Array.Empty<ContactField>(),
+            profileLanguages: Array.Empty<ProfileLanguage>(),
+            volunteerHistory: Array.Empty<VolunteerHistoryEntry>(),
+            communicationPreferences: Array.Empty<CommunicationPreference>());
 }

--- a/tests/Humans.Application.Tests/Services/MembershipCalculatorTests.cs
+++ b/tests/Humans.Application.Tests/Services/MembershipCalculatorTests.cs
@@ -2,6 +2,7 @@ using AwesomeAssertions;
 using NodaTime;
 using NodaTime.Testing;
 using NSubstitute;
+using Humans.Application;
 using Humans.Application.Services.Governance;
 using Humans.Domain.Constants;
 using Humans.Domain.Entities;
@@ -48,8 +49,13 @@ public class MembershipCalculatorTests
             _clock);
 
         // Wire substitutes to the seed maps so tests can just mutate state.
-        _profileService.GetProfileAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
-            .Returns(ci => Task.FromResult(_profilesByUserId.GetValueOrDefault(ci.Arg<Guid>())));
+        _userService.GetUserInfoAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(ci =>
+            {
+                var userId = ci.Arg<Guid>();
+                var profile = _profilesByUserId.GetValueOrDefault(userId);
+                return profile is null ? null : WrapInUserInfo(profile);
+            });
 
         _profileService.GetByUserIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
             .Returns(ci =>
@@ -780,6 +786,7 @@ public class MembershipCalculatorTests
             LastName = "User",
             IsApproved = isApproved,
             IsSuspended = isSuspended,
+            State = isSuspended ? ProfileState.Suspended : ProfileState.Active,
             CreatedAt = _clock.GetCurrentInstant(),
             UpdatedAt = _clock.GetCurrentInstant()
         };
@@ -844,4 +851,22 @@ public class MembershipCalculatorTests
         }
         list.Add(version);
     }
+
+    private static UserInfo WrapInUserInfo(Profile profile) => UserInfo.Create(
+        user: new User
+        {
+            Id = profile.UserId,
+            DisplayName = profile.BurnerName ?? "",
+            PreferredLanguage = "en",
+            CreatedAt = profile.CreatedAt,
+            GoogleEmailStatus = GoogleEmailStatus.Unknown,
+        },
+        userEmails: Array.Empty<UserEmail>(),
+        eventParticipations: Array.Empty<EventParticipation>(),
+        externalLogins: Array.Empty<(string, string)>(),
+        profile: profile,
+        contactFields: Array.Empty<ContactField>(),
+        profileLanguages: Array.Empty<ProfileLanguage>(),
+        volunteerHistory: Array.Empty<VolunteerHistoryEntry>(),
+        communicationPreferences: Array.Empty<CommunicationPreference>());
 }

--- a/tests/Humans.Application.Tests/Services/Tickets/TicketTransferServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Tickets/TicketTransferServiceTests.cs
@@ -66,6 +66,8 @@ public sealed class TicketTransferServiceTests
         // Default: Receiver user exists
         _userService.GetByIdAsync(_receiverId, Arg.Any<CancellationToken>())
             .Returns(MakeUser(_receiverId, "Alice"));
+        _userService.GetUserInfoAsync(_receiverId, Arg.Any<CancellationToken>())
+            .Returns(WrapInUserInfo(MakeUser(_receiverId, "Alice"), null));
 
         // Default: Receiver has primary email
         _userEmailService.GetPrimaryEmailAsync(_receiverId, Arg.Any<CancellationToken>())
@@ -101,6 +103,8 @@ public sealed class TicketTransferServiceTests
             .Returns(userId);
         _userService.GetByIdAsync(userId, Arg.Any<CancellationToken>())
             .Returns(MakeUser(userId, "Alice"));
+        _userService.GetUserInfoAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(WrapInUserInfo(MakeUser(userId, "Alice"), null));
         _userEmailService.GetPrimaryEmailAsync(userId, Arg.Any<CancellationToken>())
             .Returns("alice@example.com");
         _profileService.GetProfileAsync(userId, Arg.Any<CancellationToken>())
@@ -144,6 +148,8 @@ public sealed class TicketTransferServiceTests
             .Returns(new[] { MakeSearchResult(userId, "Sparkle Person") });
         _userService.GetByIdAsync(userId, Arg.Any<CancellationToken>())
             .Returns(MakeUser(userId, "Sparkle Person"));
+        _userService.GetUserInfoAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(WrapInUserInfo(MakeUser(userId, "Sparkle Person"), null));
         _userEmailService.GetPrimaryEmailAsync(userId, Arg.Any<CancellationToken>())
             .Returns("sp@example.com");
         _profileService.GetProfileAsync(userId, Arg.Any<CancellationToken>())
@@ -169,6 +175,10 @@ public sealed class TicketTransferServiceTests
             });
         _userService.GetByIdAsync(aId, Arg.Any<CancellationToken>()).Returns(MakeUser(aId, "A"));
         _userService.GetByIdAsync(bId, Arg.Any<CancellationToken>()).Returns(MakeUser(bId, "B"));
+        _userService.GetUserInfoAsync(aId, Arg.Any<CancellationToken>())
+            .Returns(WrapInUserInfo(MakeUser(aId, "A"), null));
+        _userService.GetUserInfoAsync(bId, Arg.Any<CancellationToken>())
+            .Returns(WrapInUserInfo(MakeUser(bId, "B"), null));
         _userEmailService.GetPrimaryEmailAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
             .Returns((string?)null);
         _profileService.GetProfileAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
@@ -289,6 +299,8 @@ public sealed class TicketTransferServiceTests
             .Returns(attendee);
         _userService.GetByIdAsync(_receiverId, Arg.Any<CancellationToken>())
             .Returns((User?)null);
+        _userService.GetUserInfoAsync(_receiverId, Arg.Any<CancellationToken>())
+            .Returns((UserInfo?)null);
 
         var dto = new TicketTransferRequestDto(_attendeeId, _receiverId, "test");
 
@@ -323,8 +335,10 @@ public sealed class TicketTransferServiceTests
         var attendee = MakeAttendee(_attendeeId, _orderId, _senderId, TicketAttendeeStatus.Valid);
         _ticketRepo.GetAttendeeByIdAsync(_attendeeId, Arg.Any<CancellationToken>())
             .Returns(attendee);
-        _profileService.GetProfileAsync(_receiverId, Arg.Any<CancellationToken>())
-            .Returns(new Profile { IsSuspended = true, IsApproved = true });
+        _userService.GetUserInfoAsync(_receiverId, Arg.Any<CancellationToken>())
+            .Returns(WrapInUserInfo(
+                MakeUser(_receiverId, "Alice"),
+                new Profile { IsSuspended = true, IsApproved = true, State = ProfileState.Suspended }));
 
         var dto = new TicketTransferRequestDto(_attendeeId, _receiverId, "test");
 
@@ -343,8 +357,10 @@ public sealed class TicketTransferServiceTests
         var attendee = MakeAttendee(_attendeeId, _orderId, _senderId, TicketAttendeeStatus.Valid);
         _ticketRepo.GetAttendeeByIdAsync(_attendeeId, Arg.Any<CancellationToken>())
             .Returns(attendee);
-        _profileService.GetProfileAsync(_receiverId, Arg.Any<CancellationToken>())
-            .Returns(new Profile { IsSuspended = false, IsApproved = false });
+        _userService.GetUserInfoAsync(_receiverId, Arg.Any<CancellationToken>())
+            .Returns(WrapInUserInfo(
+                MakeUser(_receiverId, "Alice"),
+                new Profile { IsSuspended = false, IsApproved = false, State = ProfileState.Active }));
 
         var dto = new TicketTransferRequestDto(_attendeeId, _receiverId, "test");
 
@@ -362,8 +378,10 @@ public sealed class TicketTransferServiceTests
         var attendee = MakeAttendee(_attendeeId, _orderId, _senderId, TicketAttendeeStatus.Valid);
         _ticketRepo.GetAttendeeByIdAsync(_attendeeId, Arg.Any<CancellationToken>())
             .Returns(attendee);
-        _profileService.GetProfileAsync(_receiverId, Arg.Any<CancellationToken>())
-            .Returns(new Profile { IsSuspended = false, IsApproved = true });
+        _userService.GetUserInfoAsync(_receiverId, Arg.Any<CancellationToken>())
+            .Returns(WrapInUserInfo(
+                MakeUser(_receiverId, "Alice"),
+                new Profile { IsSuspended = false, IsApproved = true, State = ProfileState.Active }));
         _transferRepo.GetBySenderAsync(_senderId, Arg.Any<CancellationToken>())
             .Returns(new[]
             {
@@ -396,8 +414,10 @@ public sealed class TicketTransferServiceTests
             .Returns(attendee);
         _userService.GetByIdAsync(_senderId, Arg.Any<CancellationToken>())
             .Returns(MakeUser(_senderId, "Bob"));
-        _profileService.GetProfileAsync(_receiverId, Arg.Any<CancellationToken>())
-            .Returns(new Profile { FirstName = "Alice", LastName = "Smith", IsApproved = true });
+        _userService.GetUserInfoAsync(_receiverId, Arg.Any<CancellationToken>())
+            .Returns(WrapInUserInfo(
+                MakeUser(_receiverId, "Alice"),
+                new Profile { FirstName = "Alice", LastName = "Smith", IsApproved = true, State = ProfileState.Active }));
 
         var dto = new TicketTransferRequestDto(_attendeeId, _receiverId, "Going abroad");
 
@@ -773,6 +793,17 @@ public sealed class TicketTransferServiceTests
         NormalizedEmail = $"{displayName.ToLowerInvariant().Replace(" ", "")}@EXAMPLE.COM",
         NormalizedUserName = $"{displayName.ToLowerInvariant().Replace(" ", "")}@EXAMPLE.COM",
     };
+
+    private static UserInfo WrapInUserInfo(User user, Profile? profile) => UserInfo.Create(
+        user: user,
+        userEmails: Array.Empty<UserEmail>(),
+        eventParticipations: Array.Empty<EventParticipation>(),
+        externalLogins: Array.Empty<(string, string)>(),
+        profile: profile,
+        contactFields: Array.Empty<ContactField>(),
+        profileLanguages: Array.Empty<ProfileLanguage>(),
+        volunteerHistory: Array.Empty<VolunteerHistoryEntry>(),
+        communicationPreferences: Array.Empty<CommunicationPreference>());
 
     private static TicketAttendee MakeAttendee(
         Guid id, Guid orderId, Guid orderMatchedUserId, TicketAttendeeStatus status)

--- a/tests/Humans.Application.Tests/Services/Tickets/TicketTransferServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Tickets/TicketTransferServiceTests.cs
@@ -63,11 +63,14 @@ public sealed class TicketTransferServiceTests
             _clock,
             NullLogger<TicketTransferService>.Instance);
 
-        // Default: Receiver user exists
+        // Default: Receiver user exists with a complete profile (BurnerName +
+        // FirstName + LastName populated — required for transfer recipient).
         _userService.GetByIdAsync(_receiverId, Arg.Any<CancellationToken>())
             .Returns(MakeUser(_receiverId, "Alice"));
         _userService.GetUserInfoAsync(_receiverId, Arg.Any<CancellationToken>())
-            .Returns(WrapInUserInfo(MakeUser(_receiverId, "Alice"), null));
+            .Returns(WrapInUserInfo(
+                MakeUser(_receiverId, "Alice"),
+                new Profile { BurnerName = "Alice", FirstName = "Alice", LastName = "Smith" }));
 
         // Default: Receiver has primary email
         _userEmailService.GetPrimaryEmailAsync(_receiverId, Arg.Any<CancellationToken>())
@@ -104,7 +107,9 @@ public sealed class TicketTransferServiceTests
         _userService.GetByIdAsync(userId, Arg.Any<CancellationToken>())
             .Returns(MakeUser(userId, "Alice"));
         _userService.GetUserInfoAsync(userId, Arg.Any<CancellationToken>())
-            .Returns(WrapInUserInfo(MakeUser(userId, "Alice"), null));
+            .Returns(WrapInUserInfo(
+                MakeUser(userId, "Alice"),
+                new Profile { BurnerName = "Alice", FirstName = "Alice", LastName = "Smith" }));
         _userEmailService.GetPrimaryEmailAsync(userId, Arg.Any<CancellationToken>())
             .Returns("alice@example.com");
         _profileService.GetProfileAsync(userId, Arg.Any<CancellationToken>())
@@ -149,7 +154,9 @@ public sealed class TicketTransferServiceTests
         _userService.GetByIdAsync(userId, Arg.Any<CancellationToken>())
             .Returns(MakeUser(userId, "Sparkle Person"));
         _userService.GetUserInfoAsync(userId, Arg.Any<CancellationToken>())
-            .Returns(WrapInUserInfo(MakeUser(userId, "Sparkle Person"), null));
+            .Returns(WrapInUserInfo(
+                MakeUser(userId, "Sparkle Person"),
+                new Profile { BurnerName = "Sparkle Person", FirstName = "Sparkle", LastName = "Person" }));
         _userEmailService.GetPrimaryEmailAsync(userId, Arg.Any<CancellationToken>())
             .Returns("sp@example.com");
         _profileService.GetProfileAsync(userId, Arg.Any<CancellationToken>())
@@ -176,9 +183,13 @@ public sealed class TicketTransferServiceTests
         _userService.GetByIdAsync(aId, Arg.Any<CancellationToken>()).Returns(MakeUser(aId, "A"));
         _userService.GetByIdAsync(bId, Arg.Any<CancellationToken>()).Returns(MakeUser(bId, "B"));
         _userService.GetUserInfoAsync(aId, Arg.Any<CancellationToken>())
-            .Returns(WrapInUserInfo(MakeUser(aId, "A"), null));
+            .Returns(WrapInUserInfo(
+                MakeUser(aId, "A"),
+                new Profile { BurnerName = "A", FirstName = "Aaa", LastName = "Aaa" }));
         _userService.GetUserInfoAsync(bId, Arg.Any<CancellationToken>())
-            .Returns(WrapInUserInfo(MakeUser(bId, "B"), null));
+            .Returns(WrapInUserInfo(
+                MakeUser(bId, "B"),
+                new Profile { BurnerName = "B", FirstName = "Bbb", LastName = "Bbb" }));
         _userEmailService.GetPrimaryEmailAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
             .Returns((string?)null);
         _profileService.GetProfileAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
@@ -221,7 +232,7 @@ public sealed class TicketTransferServiceTests
 
         row.Status.Should().Be(TicketTransferStatus.Pending);
         row.ReceiverUserId.Should().Be(_receiverId);
-        row.ReceiverLegalName.Should().Be("Alice");
+        row.ReceiverLegalName.Should().Be("Alice Smith");
         await _transferRepo.Received(1).AddAsync(
             Arg.Is<TicketTransferRequest>(r => r.Status == TicketTransferStatus.Pending),
             Arg.Any<CancellationToken>());
@@ -328,39 +339,18 @@ public sealed class TicketTransferServiceTests
     }
 
     [HumansFact]
-    public async Task CreateRequestAsync_ThrowsWhenReceiverIsSuspended()
+    public async Task CreateRequestAsync_ThrowsWhenReceiverMissingLegalName()
     {
-        // Defense-in-depth: lookup layer filters suspended profiles; submit
-        // accepts a direct POST, so the service must re-check on the way in.
+        // Defense-in-depth: BuildReceiverCardAsync filters at the lookup layer,
+        // but Submit accepts a direct POST. Recipients without a legal name on
+        // file cannot receive transfers — the transfer snapshot writes the name
+        // onto the reissued ticket. Wording matches the not-found case so a
+        // tampered POST learns nothing about why the recipient was rejected.
         var attendee = MakeAttendee(_attendeeId, _orderId, _senderId, TicketAttendeeStatus.Valid);
         _ticketRepo.GetAttendeeByIdAsync(_attendeeId, Arg.Any<CancellationToken>())
             .Returns(attendee);
         _userService.GetUserInfoAsync(_receiverId, Arg.Any<CancellationToken>())
-            .Returns(WrapInUserInfo(
-                MakeUser(_receiverId, "Alice"),
-                new Profile { IsSuspended = true, IsApproved = true, State = ProfileState.Suspended }));
-
-        var dto = new TicketTransferRequestDto(_attendeeId, _receiverId, "test");
-
-        var act = () => _service.CreateRequestAsync(dto, _senderId);
-
-        // Wording mirrors the genuine not-found case so a tampered POST learns nothing.
-        await act.Should().ThrowAsync<InvalidOperationException>()
-            .WithMessage("*Receiver user not found*");
-        await _transferRepo.DidNotReceive().AddAsync(
-            Arg.Any<TicketTransferRequest>(), Arg.Any<CancellationToken>());
-    }
-
-    [HumansFact]
-    public async Task CreateRequestAsync_ThrowsWhenReceiverIsUnapproved()
-    {
-        var attendee = MakeAttendee(_attendeeId, _orderId, _senderId, TicketAttendeeStatus.Valid);
-        _ticketRepo.GetAttendeeByIdAsync(_attendeeId, Arg.Any<CancellationToken>())
-            .Returns(attendee);
-        _userService.GetUserInfoAsync(_receiverId, Arg.Any<CancellationToken>())
-            .Returns(WrapInUserInfo(
-                MakeUser(_receiverId, "Alice"),
-                new Profile { IsSuspended = false, IsApproved = false, State = ProfileState.Active }));
+            .Returns(WrapInUserInfo(MakeUser(_receiverId, "Alice"), profile: null));
 
         var dto = new TicketTransferRequestDto(_attendeeId, _receiverId, "test");
 
@@ -381,7 +371,7 @@ public sealed class TicketTransferServiceTests
         _userService.GetUserInfoAsync(_receiverId, Arg.Any<CancellationToken>())
             .Returns(WrapInUserInfo(
                 MakeUser(_receiverId, "Alice"),
-                new Profile { IsSuspended = false, IsApproved = true, State = ProfileState.Active }));
+                new Profile { BurnerName = "Alice", FirstName = "Alice", LastName = "Smith" }));
         _transferRepo.GetBySenderAsync(_senderId, Arg.Any<CancellationToken>())
             .Returns(new[]
             {
@@ -417,7 +407,7 @@ public sealed class TicketTransferServiceTests
         _userService.GetUserInfoAsync(_receiverId, Arg.Any<CancellationToken>())
             .Returns(WrapInUserInfo(
                 MakeUser(_receiverId, "Alice"),
-                new Profile { FirstName = "Alice", LastName = "Smith", IsApproved = true, State = ProfileState.Active }));
+                new Profile { BurnerName = "Alice", FirstName = "Alice", LastName = "Smith" }));
 
         var dto = new TicketTransferRequestDto(_attendeeId, _receiverId, "Going abroad");
 

--- a/tests/Humans.Application.Tests/Services/Tickets/TicketTransferService_OnwardTransferTests.cs
+++ b/tests/Humans.Application.Tests/Services/Tickets/TicketTransferService_OnwardTransferTests.cs
@@ -1,4 +1,5 @@
 using AwesomeAssertions;
+using Humans.Application;
 using Humans.Application.DTOs;
 using Humans.Application.Interfaces.AuditLog;
 using Humans.Application.Interfaces.Profiles;
@@ -139,8 +140,19 @@ public sealed class TicketTransferService_OnwardTransferTests
                 MatchedUserId = UserB,
                 TicketOrder = new TicketOrder { Id = OrderId, MatchedUserId = UserA },
             });
-        _userService.GetByIdAsync(UserC, Arg.Any<CancellationToken>())
-            .Returns(new User { Id = UserC, DisplayName = "Carol" });
+        var carol = new User { Id = UserC, DisplayName = "Carol", PreferredLanguage = "en" };
+        _userService.GetByIdAsync(UserC, Arg.Any<CancellationToken>()).Returns(carol);
+        _userService.GetUserInfoAsync(UserC, Arg.Any<CancellationToken>())
+            .Returns(UserInfo.Create(
+                user: carol,
+                userEmails: Array.Empty<UserEmail>(),
+                eventParticipations: Array.Empty<EventParticipation>(),
+                externalLogins: Array.Empty<(string, string)>(),
+                profile: null,
+                contactFields: Array.Empty<ContactField>(),
+                profileLanguages: Array.Empty<ProfileLanguage>(),
+                volunteerHistory: Array.Empty<VolunteerHistoryEntry>(),
+                communicationPreferences: Array.Empty<CommunicationPreference>()));
         _userEmailService.GetPrimaryEmailAsync(UserC, Arg.Any<CancellationToken>())
             .Returns("carol@example.com");
         _transferRepo.GetBySenderAsync(UserB, Arg.Any<CancellationToken>())

--- a/tests/Humans.Application.Tests/Services/Tickets/TicketTransferService_OnwardTransferTests.cs
+++ b/tests/Humans.Application.Tests/Services/Tickets/TicketTransferService_OnwardTransferTests.cs
@@ -141,6 +141,7 @@ public sealed class TicketTransferService_OnwardTransferTests
                 TicketOrder = new TicketOrder { Id = OrderId, MatchedUserId = UserA },
             });
         var carol = new User { Id = UserC, DisplayName = "Carol", PreferredLanguage = "en" };
+        var carolProfile = new Profile { BurnerName = "Carol", FirstName = "Carol", LastName = "Cohen" };
         _userService.GetByIdAsync(UserC, Arg.Any<CancellationToken>()).Returns(carol);
         _userService.GetUserInfoAsync(UserC, Arg.Any<CancellationToken>())
             .Returns(UserInfo.Create(
@@ -148,7 +149,7 @@ public sealed class TicketTransferService_OnwardTransferTests
                 userEmails: Array.Empty<UserEmail>(),
                 eventParticipations: Array.Empty<EventParticipation>(),
                 externalLogins: Array.Empty<(string, string)>(),
-                profile: null,
+                profile: carolProfile,
                 contactFields: Array.Empty<ContactField>(),
                 profileLanguages: Array.Empty<ProfileLanguage>(),
                 volunteerHistory: Array.Empty<VolunteerHistoryEntry>(),


### PR DESCRIPTION
## Summary

Continues the IProfileService drain from #553. Migrates 22 of 25 read-only `_profileService.GetProfileAsync` / `_profileService.GetFullProfileAsync` call sites onto `_userService.GetUserInfoAsync`.

Where the call site previously fetched User + Profile (and sometimes FullProfile + ContactFields + Languages) separately, those collapse onto a single `GetUserInfoAsync` per the `iuserservice-onestop-userinfo` direction.

Commits (5):

1. **ExpensesController** (4 sites — `profile?.Iban`)
2. **MembershipCalculator + OnboardingService + TicketTransferService** (4 sites; paves legacy `Profile.IsSuspended` bool with `State == ProfileState.Suspended` at the read; folds receiver-user + receiver-profile fetches into one)
3. **ProfileController simple readers + ApplicationDecisionService.BoardVotingDetail** (7 sites — RevealIban, ImportGooglePhoto pre-check, Popover, AdminDetail, two Edit-POST error paths)
4. **Me, ViewProfile, ProfileCardViewComponent** (4 sites; ProfileCardViewComponent loses its `IProfileService` dependency — three fetches collapse to one)
5. **Edit GET** — folds four fetches (`GetProfileAsync` + `GetFullProfileAsync` + `GetAllContactFieldsAsync` + `GetProfileLanguagesAsync`) into one `GetUserInfoAsync`. ProfileInfo's ContactFields / VolunteerHistory / Languages cover them.

`HasCustomPicture` / `BirthdayDay` / `BirthdayMonth` (ProfileInfo) replace `HasCustomProfilePicture` / `DateOfBirth.Day` / `.Month` (Profile entity) at the read sites.

## Out of scope (deferred — require contract changes)

Three sites still call `GetProfileAsync` / `GetFullProfileAsync` because they pass the Profile/FullProfile entity downstream through a data-record / view-model contract:

- **DashboardService.GetMemberDashboardAsync:71** — `MemberDashboardData.Profile` flows to `HomeController` + `ProfileCompletion.ComputePercent(Profile, bool)`. Reshape requires touching `IDashboardService`.
- **OnboardingService.GetReviewDetailAsync:107** — `ReviewDetailData` first arg is the `Profile` entity.
- **ProfileAdminController.Compare:87/88** — `EmailProblemsCompareViewModel.CompareSide` uses `IReadOnlyCollection<UserEmailSnapshot>` from `FullProfile.AllUserEmails`. UserInfo carries `UserEmailInfo` (different shape).

These are read-only at the call sites but the entity shape leaks through the contract, so they're not a clean swap. Follow-up PRs.

## Test Plan

- [x] `dotnet build Humans.slnx -v quiet` clean (0 errors).
- [x] `dotnet test Humans.slnx -v quiet --filter "FullyQualifiedName!~Humans.Integration.Tests"` — Application 2805/2806 + Web 88/88 pass.
- [ ] Smoke: `/Profile/Me`, `/Profile/Me/Edit`, `/Profile/{id}`, `/Profile/{id}/Popover`, `/Profile/{id}/Admin`, ticket transfer flow, expense report Iban.