### PR TITLE
fix(onboarding-widget): gate stub profiles to Names via UserInfo.IsStub

### DIFF
--- a/src/Humans.Application/Services/Onboarding/OnboardingWidgetState.cs
+++ b/src/Humans.Application/Services/Onboarding/OnboardingWidgetState.cs
@@ -1,15 +1,15 @@
 using Humans.Application.Interfaces.Consent;
 using Humans.Application.Interfaces.Governance;
 using Humans.Application.Interfaces.Onboarding;
-using Humans.Application.Interfaces.Profiles;
 using Humans.Application.Interfaces.Shifts;
+using Humans.Application.Interfaces.Users;
 using Humans.Domain.Constants;
 
 namespace Humans.Application.Services.Onboarding;
 
 public class OnboardingWidgetState : IOnboardingWidgetState
 {
-    private readonly IProfileService _profile;
+    private readonly IUserService _users;
     private readonly IShiftSignupService _signups;
     private readonly IMembershipCalculator _membership;
     private readonly IShiftManagementService _shiftMgmt;
@@ -17,14 +17,14 @@ public class OnboardingWidgetState : IOnboardingWidgetState
     private readonly IOnboardingWidgetSessionState _session;
 
     public OnboardingWidgetState(
-        IProfileService profile,
+        IUserService users,
         IShiftSignupService signups,
         IMembershipCalculator membership,
         IShiftManagementService shiftMgmt,
         IConsentService consents,
         IOnboardingWidgetSessionState session)
     {
-        _profile = profile;
+        _users = users;
         _signups = signups;
         _membership = membership;
         _shiftMgmt = shiftMgmt;
@@ -38,8 +38,11 @@ public class OnboardingWidgetState : IOnboardingWidgetState
         if (await _membership.HasAllRequiredConsentsForTeamAsync(userId, SystemTeamIds.Volunteers, ct))
             return OnboardingWidgetStep.Complete;
 
-        var profile = await _profile.GetProfileAsync(userId, ct);
-        if (profile is null)
+        // A Stub profile (or no profile row) means the user hasn't filled in
+        // legal name yet — the consent flow will refuse to write a record
+        // (ConsentService defense-in-depth gate), so route to Names first.
+        var info = await _users.GetUserInfoAsync(userId, ct);
+        if (info is null || info.IsStub)
             return OnboardingWidgetStep.Names;
 
         // Returning member: any signed row in the current required Volunteer

--- a/src/Humans.Web/Controllers/OnboardingWidgetController.cs
+++ b/src/Humans.Web/Controllers/OnboardingWidgetController.cs
@@ -4,6 +4,7 @@ using Humans.Application.Interfaces.Consent;
 using Humans.Application.Interfaces.Onboarding;
 using Humans.Application.Interfaces.Profiles;
 using Humans.Application.Interfaces.Shifts;
+using Humans.Application.Interfaces.Users;
 using Humans.Domain.Constants;
 using Humans.Domain.Entities;
 using Humans.Web.Models;
@@ -29,6 +30,7 @@ public class OnboardingWidgetController : HumansControllerBase
     private readonly IShiftSignupService _signupService;
     private readonly IShiftManagementService _shiftMgmt;
     private readonly IConsentService _consents;
+    private readonly IUserService _userService;
     private readonly IStringLocalizer<SharedResource> _localizer;
 
     public OnboardingWidgetController(
@@ -38,6 +40,7 @@ public class OnboardingWidgetController : HumansControllerBase
         IShiftSignupService signupService,
         IShiftManagementService shiftMgmt,
         IConsentService consents,
+        IUserService userService,
         IStringLocalizer<SharedResource> localizer)
         : base(userManager)
     {
@@ -46,6 +49,7 @@ public class OnboardingWidgetController : HumansControllerBase
         _signupService = signupService;
         _shiftMgmt = shiftMgmt;
         _consents = consents;
+        _userService = userService;
         _localizer = localizer;
     }
 
@@ -176,6 +180,13 @@ public class OnboardingWidgetController : HumansControllerBase
     public async Task<IActionResult> Consents(CancellationToken ct)
     {
         var userId = CurrentUserId();
+
+        // Stub-profile users can't sign consents (defense-in-depth gate in
+        // ConsentService.SubmitConsentAsync would refuse). Bounce them back to
+        // the Names step where they belong instead of rendering a doomed form.
+        if (await IsStubAsync(userId, ct))
+            return RedirectToNamesForStub();
+
         var rows = await _consents.GetRequiredConsentRowsForUserAsync(userId, SystemTeamIds.Volunteers, ct);
         var unsigned = rows.Where(r => !r.Signed).ToList();
         if (unsigned.Count == 0)
@@ -212,18 +223,49 @@ public class OnboardingWidgetController : HumansControllerBase
             return RedirectToAction(nameof(Consents));
         }
 
+        var userId = CurrentUserId();
+
+        // Mirror the GET-side gate so a Stub user who reaches the form via a
+        // stale page or back-button can't POST into the StubProfile refusal
+        // path below.
+        if (await IsStubAsync(userId, ct))
+            return RedirectToNamesForStub();
+
         var ipAddress = HttpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
         var userAgent = Request.Headers.UserAgent.ToString();
 
         var result = await _consents.SubmitConsentAsync(
-            CurrentUserId(), documentVersionId, explicitConsent: true, ipAddress, userAgent, ct);
+            userId, documentVersionId, explicitConsent: true, ipAddress, userAgent, ct);
 
-        if (!result.Success && !string.IsNullOrEmpty(result.ErrorKey))
-            SetError(result.ErrorKey);
+        if (!result.Success)
+        {
+            // Translate known error keys; never display the raw key to the user.
+            switch (result.ErrorKey)
+            {
+                case "StubProfile":
+                    // Defense-in-depth: gates above should have caught this.
+                    return RedirectToNamesForStub();
+                case "AlreadyConsented":
+                    SetInfo(_localizer["Consent_AlreadyConsented"].Value);
+                    break;
+            }
+        }
 
         // Always go through the dispatcher: routes Home once the final required
         // consent is signed instead of stranding the user on the signed-documents
-        // view. Failure path also dispatches; TempData carries the error.
+        // view. Failure path also dispatches; TempData carries the message.
         return RedirectToAction(nameof(Index));
+    }
+
+    private async Task<bool> IsStubAsync(Guid userId, CancellationToken ct)
+    {
+        var info = await _userService.GetUserInfoAsync(userId, ct);
+        return info is null || info.IsStub;
+    }
+
+    private IActionResult RedirectToNamesForStub()
+    {
+        SetInfo(_localizer["Consent_StubProfile_AddName"].Value);
+        return RedirectToAction(nameof(Names));
     }
 }

--- a/tests/Humans.Application.Tests/Services/Onboarding/OnboardingWidgetStateTests.cs
+++ b/tests/Humans.Application.Tests/Services/Onboarding/OnboardingWidgetStateTests.cs
@@ -1,12 +1,14 @@
+using Humans.Application;
 using Humans.Application.Interfaces.Consent;
 using Humans.Application.Interfaces.Governance;
 using Humans.Application.Interfaces.Onboarding;
-using Humans.Application.Interfaces.Profiles;
 using Humans.Application.Interfaces.Shifts;
+using Humans.Application.Interfaces.Users;
 using Humans.Application.Services.Onboarding;
 using Humans.Domain.Constants;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
+using NodaTime;
 using NSubstitute;
 using Xunit;
 
@@ -14,7 +16,7 @@ namespace Humans.Application.Tests.Services.Onboarding;
 
 public class OnboardingWidgetStateTests
 {
-    private readonly IProfileService _profile = Substitute.For<IProfileService>();
+    private readonly IUserService _users = Substitute.For<IUserService>();
     private readonly IShiftSignupService _signups = Substitute.For<IShiftSignupService>();
     private readonly IMembershipCalculator _membership = Substitute.For<IMembershipCalculator>();
     private readonly IShiftManagementService _shiftMgmt = Substitute.For<IShiftManagementService>();
@@ -34,7 +36,49 @@ public class OnboardingWidgetStateTests
     }
 
     private OnboardingWidgetState BuildSut() =>
-        new(_profile, _signups, _membership, _shiftMgmt, _consents, _session);
+        new(_users, _signups, _membership, _shiftMgmt, _consents, _session);
+
+    private static UserInfo NonStubUserInfo(Guid userId) =>
+        WrapInUserInfo(userId, new Profile
+        {
+            UserId = userId,
+            BurnerName = "Burner",
+            FirstName = "First",
+            LastName = "Last",
+            State = ProfileState.Active,
+            CreatedAt = Instant.FromUtc(2026, 1, 1, 0, 0),
+            UpdatedAt = Instant.FromUtc(2026, 1, 1, 0, 0),
+        });
+
+    private static UserInfo StubUserInfo(Guid userId) =>
+        WrapInUserInfo(userId, new Profile
+        {
+            UserId = userId,
+            BurnerName = "",
+            FirstName = "",
+            LastName = "",
+            State = ProfileState.Stub,
+            CreatedAt = Instant.FromUtc(2026, 1, 1, 0, 0),
+            UpdatedAt = Instant.FromUtc(2026, 1, 1, 0, 0),
+        });
+
+    private static UserInfo WrapInUserInfo(Guid userId, Profile? profile) => UserInfo.Create(
+        user: new User
+        {
+            Id = userId,
+            DisplayName = "Test",
+            PreferredLanguage = "en",
+            CreatedAt = Instant.FromUtc(2026, 1, 1, 0, 0),
+            GoogleEmailStatus = GoogleEmailStatus.Unknown,
+        },
+        userEmails: Array.Empty<UserEmail>(),
+        eventParticipations: Array.Empty<EventParticipation>(),
+        externalLogins: Array.Empty<(string, string)>(),
+        profile: profile,
+        contactFields: Array.Empty<ContactField>(),
+        profileLanguages: Array.Empty<ProfileLanguage>(),
+        volunteerHistory: Array.Empty<VolunteerHistoryEntry>(),
+        communicationPreferences: Array.Empty<CommunicationPreference>());
 
     [HumansFact]
     public async Task ConsentsComplete_ShortCircuitsToComplete_EvenWithoutSignup()
@@ -49,12 +93,28 @@ public class OnboardingWidgetStateTests
     }
 
     [HumansFact]
-    public async Task NoProfile_ReturnsNames()
+    public async Task NoUserInfo_ReturnsNames()
     {
         var userId = Guid.NewGuid();
         _membership.HasAllRequiredConsentsForTeamAsync(userId, SystemTeamIds.Volunteers, default)
             .Returns(false);
-        _profile.GetProfileAsync(userId, default).Returns((Profile?)null);
+        _users.GetUserInfoAsync(userId, default).Returns((UserInfo?)null);
+
+        var step = await BuildSut().GetCurrentStepAsync(userId);
+
+        Assert.Equal(OnboardingWidgetStep.Names, step);
+    }
+
+    [HumansFact]
+    public async Task StubProfile_ReturnsNames()
+    {
+        // The bug fix: a Stub profile (created by EnsureStubProfileAsync at
+        // signup) means the user hasn't filled in legal name yet — they must
+        // hit the Names step before the consent flow can write a record.
+        var userId = Guid.NewGuid();
+        _membership.HasAllRequiredConsentsForTeamAsync(userId, SystemTeamIds.Volunteers, default)
+            .Returns(false);
+        _users.GetUserInfoAsync(userId, default).Returns(StubUserInfo(userId));
 
         var step = await BuildSut().GetCurrentStepAsync(userId);
 
@@ -68,8 +128,7 @@ public class OnboardingWidgetStateTests
         var eventId = Guid.NewGuid();
         _membership.HasAllRequiredConsentsForTeamAsync(userId, SystemTeamIds.Volunteers, default)
             .Returns(false);
-        _profile.GetProfileAsync(userId, default)
-            .Returns(new Profile { UserId = userId, BurnerName = "x", FirstName = "y", LastName = "z" });
+        _users.GetUserInfoAsync(userId, default).Returns(NonStubUserInfo(userId));
         _shiftMgmt.GetActiveAsync()
             .Returns(new EventSettings { Id = eventId });
         _signups.GetActiveSignupStatusesAsync(userId, eventId)
@@ -87,8 +146,7 @@ public class OnboardingWidgetStateTests
         var eventId = Guid.NewGuid();
         _membership.HasAllRequiredConsentsForTeamAsync(userId, SystemTeamIds.Volunteers, default)
             .Returns(false);
-        _profile.GetProfileAsync(userId, default)
-            .Returns(new Profile { UserId = userId });
+        _users.GetUserInfoAsync(userId, default).Returns(NonStubUserInfo(userId));
         _shiftMgmt.GetActiveAsync()
             .Returns(new EventSettings { Id = eventId });
         _signups.GetActiveSignupStatusesAsync(userId, eventId)
@@ -108,8 +166,7 @@ public class OnboardingWidgetStateTests
         var shiftId = Guid.NewGuid();
         _membership.HasAllRequiredConsentsForTeamAsync(userId, SystemTeamIds.Volunteers, default)
             .Returns(false);
-        _profile.GetProfileAsync(userId, default)
-            .Returns(new Profile { UserId = userId });
+        _users.GetUserInfoAsync(userId, default).Returns(NonStubUserInfo(userId));
         _shiftMgmt.GetActiveAsync()
             .Returns(new EventSettings { Id = eventId });
         _signups.GetActiveSignupStatusesAsync(userId, eventId)
@@ -133,8 +190,7 @@ public class OnboardingWidgetStateTests
         var unsignedDocId = Guid.NewGuid();
         _membership.HasAllRequiredConsentsForTeamAsync(userId, SystemTeamIds.Volunteers, default)
             .Returns(false);
-        _profile.GetProfileAsync(userId, default)
-            .Returns(new Profile { UserId = userId });
+        _users.GetUserInfoAsync(userId, default).Returns(NonStubUserInfo(userId));
         _consents.GetRequiredConsentRowsForUserAsync(
                 userId, SystemTeamIds.Volunteers, Arg.Any<CancellationToken>())
             .Returns(new[]
@@ -158,8 +214,7 @@ public class OnboardingWidgetStateTests
         var userId = Guid.NewGuid();
         _membership.HasAllRequiredConsentsForTeamAsync(userId, SystemTeamIds.Volunteers, default)
             .Returns(false);
-        _profile.GetProfileAsync(userId, default)
-            .Returns(new Profile { UserId = userId });
+        _users.GetUserInfoAsync(userId, default).Returns(NonStubUserInfo(userId));
         _shiftMgmt.GetActiveAsync().Returns((EventSettings?)null);
 
         var step = await BuildSut().GetCurrentStepAsync(userId);

--- a/tests/Humans.Web.Tests/Controllers/OnboardingWidgetControllerConsentsTests.cs
+++ b/tests/Humans.Web.Tests/Controllers/OnboardingWidgetControllerConsentsTests.cs
@@ -1,10 +1,13 @@
 using System.Security.Claims;
+using Humans.Application;
 using Humans.Application.Interfaces.Consent;
 using Humans.Application.Interfaces.Onboarding;
 using Humans.Application.Interfaces.Profiles;
 using Humans.Application.Interfaces.Shifts;
+using Humans.Application.Interfaces.Users;
 using Humans.Domain.Constants;
 using Humans.Domain.Entities;
+using Humans.Domain.Enums;
 using Humans.Testing;
 using Humans.Web.Constants;
 using Humans.Web.Controllers;
@@ -17,6 +20,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using NodaTime;
 using NSubstitute;
 using Xunit;
 
@@ -37,6 +41,7 @@ public class OnboardingWidgetControllerConsentsTests
     private readonly IShiftSignupService _signups = Substitute.For<IShiftSignupService>();
     private readonly IShiftManagementService _shiftMgmt = Substitute.For<IShiftManagementService>();
     private readonly IConsentService _consents = Substitute.For<IConsentService>();
+    private readonly IUserService _userService = Substitute.For<IUserService>();
     private readonly IStringLocalizer<Humans.Web.SharedResource> _localizer =
         Substitute.For<IStringLocalizer<Humans.Web.SharedResource>>();
     private readonly DefaultHttpContext _http = new();
@@ -50,7 +55,7 @@ public class OnboardingWidgetControllerConsentsTests
             new LocalizedString(ci.Arg<string>(), ci.Arg<string>()));
     }
 
-    private OnboardingWidgetController BuildSut(Guid userId)
+    private OnboardingWidgetController BuildSut(Guid userId, bool isStub = false)
     {
         var user = new User { Id = userId };
         _userManager.GetUserAsync(Arg.Any<ClaimsPrincipal>()).Returns(user);
@@ -61,7 +66,11 @@ public class OnboardingWidgetControllerConsentsTests
         var services = new ServiceCollection();
         services.AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance);
         _http.RequestServices = services.BuildServiceProvider();
-        var ctrl = new OnboardingWidgetController(_userManager, _state, _profile, _signups, _shiftMgmt, _consents, _localizer);
+        // Default: user has a non-Stub profile so the new pre-flight gate
+        // doesn't divert tests that exercise the consent flow itself.
+        _userService.GetUserInfoAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(isStub ? StubUserInfo(userId) : NonStubUserInfo(userId));
+        var ctrl = new OnboardingWidgetController(_userManager, _state, _profile, _signups, _shiftMgmt, _consents, _userService, _localizer);
         ctrl.ControllerContext = new ControllerContext
         {
             HttpContext = _http,
@@ -72,6 +81,46 @@ public class OnboardingWidgetControllerConsentsTests
         ctrl.Url = Substitute.For<IUrlHelper>();
         return ctrl;
     }
+
+    private static UserInfo NonStubUserInfo(Guid userId) => WrapInUserInfo(userId, new Profile
+    {
+        UserId = userId,
+        BurnerName = "Burner",
+        FirstName = "First",
+        LastName = "Last",
+        State = ProfileState.Active,
+        CreatedAt = Instant.FromUtc(2026, 1, 1, 0, 0),
+        UpdatedAt = Instant.FromUtc(2026, 1, 1, 0, 0),
+    });
+
+    private static UserInfo StubUserInfo(Guid userId) => WrapInUserInfo(userId, new Profile
+    {
+        UserId = userId,
+        BurnerName = "",
+        FirstName = "",
+        LastName = "",
+        State = ProfileState.Stub,
+        CreatedAt = Instant.FromUtc(2026, 1, 1, 0, 0),
+        UpdatedAt = Instant.FromUtc(2026, 1, 1, 0, 0),
+    });
+
+    private static UserInfo WrapInUserInfo(Guid userId, Profile profile) => UserInfo.Create(
+        user: new User
+        {
+            Id = userId,
+            DisplayName = "Test",
+            PreferredLanguage = "en",
+            CreatedAt = Instant.FromUtc(2026, 1, 1, 0, 0),
+            GoogleEmailStatus = GoogleEmailStatus.Unknown,
+        },
+        userEmails: Array.Empty<UserEmail>(),
+        eventParticipations: Array.Empty<EventParticipation>(),
+        externalLogins: Array.Empty<(string, string)>(),
+        profile: profile,
+        contactFields: Array.Empty<ContactField>(),
+        profileLanguages: Array.Empty<ProfileLanguage>(),
+        volunteerHistory: Array.Empty<VolunteerHistoryEntry>(),
+        communicationPreferences: Array.Empty<CommunicationPreference>());
 
     [HumansFact]
     public async Task SignConsent_Post_CallsConsentService_AndRedirectsThroughIndexDispatcher()
@@ -97,11 +146,10 @@ public class OnboardingWidgetControllerConsentsTests
     }
 
     [HumansFact]
-    public async Task SignConsent_Post_OnFailure_RedirectsToIndex_WithTempDataError()
+    public async Task SignConsent_Post_AlreadyConsented_RedirectsToIndex_WithLocalizedInfo()
     {
-        // Failure path also goes through Index so the dispatcher applies; the
-        // dispatcher will route back to Consents (or wherever appropriate)
-        // and TempData["Error"] survives the redirect.
+        // AlreadyConsented isn't really an error — they already signed it.
+        // Mirror ConsentController: localized info, never the raw error key.
         var userId = Guid.NewGuid();
         var docVersionId = Guid.NewGuid();
         _consents.SubmitConsentAsync(
@@ -114,7 +162,69 @@ public class OnboardingWidgetControllerConsentsTests
 
         var redirect = Assert.IsType<RedirectToActionResult>(result);
         Assert.Equal(nameof(OnboardingWidgetController.Index), redirect.ActionName);
-        Assert.Equal("AlreadyConsented", ctrl.TempData[TempDataKeys.ErrorMessage]);
+        // Localizer stub returns the key as the value — verifies localization
+        // ran rather than the raw ErrorKey being dumped into TempData.
+        Assert.Equal("Consent_AlreadyConsented", ctrl.TempData[TempDataKeys.InfoMessage]);
+        Assert.Null(ctrl.TempData[TempDataKeys.ErrorMessage]);
+    }
+
+    [HumansFact]
+    public async Task Consents_Get_StubProfile_RedirectsToNames_WithLocalizedInfo()
+    {
+        // Stub-profile gate: a user with no legal name reaching the consent
+        // step (the original "StubProfile red toast" production bug) gets
+        // bounced back to the Names step with a localized prompt rather than
+        // the doomed-form / raw-error-key UX.
+        var userId = Guid.NewGuid();
+        var ctrl = BuildSut(userId, isStub: true);
+
+        var result = await ctrl.Consents(CancellationToken.None);
+
+        var redirect = Assert.IsType<RedirectToActionResult>(result);
+        Assert.Equal(nameof(OnboardingWidgetController.Names), redirect.ActionName);
+        Assert.Equal("Consent_StubProfile_AddName", ctrl.TempData[TempDataKeys.InfoMessage]);
+        await _consents.DidNotReceive().GetRequiredConsentRowsForUserAsync(
+            Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task SignConsent_Post_StubProfile_RedirectsToNames_AndDoesNotCallService()
+    {
+        var userId = Guid.NewGuid();
+        var ctrl = BuildSut(userId, isStub: true);
+
+        var result = await ctrl.SignConsent(Guid.NewGuid(), explicitConsent: true, CancellationToken.None);
+
+        var redirect = Assert.IsType<RedirectToActionResult>(result);
+        Assert.Equal(nameof(OnboardingWidgetController.Names), redirect.ActionName);
+        Assert.Equal("Consent_StubProfile_AddName", ctrl.TempData[TempDataKeys.InfoMessage]);
+        await _consents.DidNotReceive().SubmitConsentAsync(
+            Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<bool>(),
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task SignConsent_Post_StubProfileErrorKey_RedirectsToNames_NoRawKeyDisplayed()
+    {
+        // Defense-in-depth: if upstream gates somehow miss and the service
+        // returns ErrorKey "StubProfile", controller still must NOT display
+        // the raw key. The localized info banner replaces it.
+        var userId = Guid.NewGuid();
+        var docVersionId = Guid.NewGuid();
+        _consents.SubmitConsentAsync(
+                userId, docVersionId, true,
+                Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new ConsentSubmitResult(Success: false, ErrorKey: "StubProfile"));
+        // BuildSut defaults to non-Stub UserInfo so the GET-side gate passes —
+        // we want to specifically exercise the SubmitConsentAsync return path.
+        var ctrl = BuildSut(userId);
+
+        var result = await ctrl.SignConsent(docVersionId, explicitConsent: true, CancellationToken.None);
+
+        var redirect = Assert.IsType<RedirectToActionResult>(result);
+        Assert.Equal(nameof(OnboardingWidgetController.Names), redirect.ActionName);
+        Assert.Equal("Consent_StubProfile_AddName", ctrl.TempData[TempDataKeys.InfoMessage]);
+        Assert.Null(ctrl.TempData[TempDataKeys.ErrorMessage]);
     }
 
     [HumansFact]

--- a/tests/Humans.Web.Tests/Controllers/OnboardingWidgetControllerDispatcherTests.cs
+++ b/tests/Humans.Web.Tests/Controllers/OnboardingWidgetControllerDispatcherTests.cs
@@ -3,6 +3,7 @@ using Humans.Application.Interfaces.Consent;
 using Humans.Application.Interfaces.Onboarding;
 using Humans.Application.Interfaces.Profiles;
 using Humans.Application.Interfaces.Shifts;
+using Humans.Application.Interfaces.Users;
 using Humans.Domain.Entities;
 using Humans.Testing;
 using Humans.Web.Controllers;
@@ -29,6 +30,7 @@ public class OnboardingWidgetControllerDispatcherTests
     private readonly IShiftSignupService _signups = Substitute.For<IShiftSignupService>();
     private readonly IShiftManagementService _shiftMgmt = Substitute.For<IShiftManagementService>();
     private readonly IConsentService _consents = Substitute.For<IConsentService>();
+    private readonly IUserService _userService = Substitute.For<IUserService>();
     private readonly IStringLocalizer<Humans.Web.SharedResource> _localizer =
         Substitute.For<IStringLocalizer<Humans.Web.SharedResource>>();
 
@@ -45,7 +47,7 @@ public class OnboardingWidgetControllerDispatcherTests
     {
         var user = new User { Id = userId };
         _userManager.GetUserAsync(Arg.Any<ClaimsPrincipal>()).Returns(user);
-        var ctrl = new OnboardingWidgetController(_userManager, _state, _profile, _signups, _shiftMgmt, _consents, _localizer);
+        var ctrl = new OnboardingWidgetController(_userManager, _state, _profile, _signups, _shiftMgmt, _consents, _userService, _localizer);
         var http = new DefaultHttpContext
         {
             User = new ClaimsPrincipal(new ClaimsIdentity(

--- a/tests/Humans.Web.Tests/Controllers/OnboardingWidgetControllerNamesTests.cs
+++ b/tests/Humans.Web.Tests/Controllers/OnboardingWidgetControllerNamesTests.cs
@@ -4,6 +4,7 @@ using Humans.Application.Interfaces.Consent;
 using Humans.Application.Interfaces.Onboarding;
 using Humans.Application.Interfaces.Profiles;
 using Humans.Application.Interfaces.Shifts;
+using Humans.Application.Interfaces.Users;
 using Humans.Domain.Entities;
 using Humans.Testing;
 using Humans.Web.Controllers;
@@ -25,6 +26,7 @@ public class OnboardingWidgetControllerNamesTests
     private readonly IShiftSignupService _signups = Substitute.For<IShiftSignupService>();
     private readonly IShiftManagementService _shiftMgmt = Substitute.For<IShiftManagementService>();
     private readonly IConsentService _consents = Substitute.For<IConsentService>();
+    private readonly IUserService _userService = Substitute.For<IUserService>();
     private readonly IStringLocalizer<Humans.Web.SharedResource> _localizer =
         Substitute.For<IStringLocalizer<Humans.Web.SharedResource>>();
 
@@ -42,7 +44,7 @@ public class OnboardingWidgetControllerNamesTests
         var user = new User { Id = userId };
         _userManager.GetUserAsync(Arg.Any<ClaimsPrincipal>()).Returns(user);
         _state.GetCurrentStepAsync(userId, Arg.Any<CancellationToken>()).Returns(currentStep);
-        var ctrl = new OnboardingWidgetController(_userManager, _state, _profile, _signups, _shiftMgmt, _consents, _localizer);
+        var ctrl = new OnboardingWidgetController(_userManager, _state, _profile, _signups, _shiftMgmt, _consents, _userService, _localizer);
         var http = new DefaultHttpContext
         {
             User = new ClaimsPrincipal(new ClaimsIdentity(

--- a/tests/Humans.Web.Tests/Controllers/OnboardingWidgetControllerShiftsTests.cs
+++ b/tests/Humans.Web.Tests/Controllers/OnboardingWidgetControllerShiftsTests.cs
@@ -3,6 +3,7 @@ using Humans.Application.Interfaces.Consent;
 using Humans.Application.Interfaces.Onboarding;
 using Humans.Application.Interfaces.Profiles;
 using Humans.Application.Interfaces.Shifts;
+using Humans.Application.Interfaces.Users;
 using Humans.Domain.Entities;
 using Humans.Testing;
 using Humans.Web.Constants;
@@ -34,6 +35,7 @@ public class OnboardingWidgetControllerShiftsTests
     private readonly IShiftSignupService _signups = Substitute.For<IShiftSignupService>();
     private readonly IShiftManagementService _shiftMgmt = Substitute.For<IShiftManagementService>();
     private readonly IConsentService _consents = Substitute.For<IConsentService>();
+    private readonly IUserService _userService = Substitute.For<IUserService>();
     private readonly IStringLocalizer<Humans.Web.SharedResource> _localizer =
         Substitute.For<IStringLocalizer<Humans.Web.SharedResource>>();
     private readonly DefaultHttpContext _http = new();
@@ -59,7 +61,7 @@ public class OnboardingWidgetControllerShiftsTests
         var services = new ServiceCollection();
         services.AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance);
         _http.RequestServices = services.BuildServiceProvider();
-        var ctrl = new OnboardingWidgetController(_userManager, _state, _profile, _signups, _shiftMgmt, _consents, _localizer);
+        var ctrl = new OnboardingWidgetController(_userManager, _state, _profile, _signups, _shiftMgmt, _consents, _userService, _localizer);
         ctrl.ControllerContext = new ControllerContext
         {
             HttpContext = _http,


### PR DESCRIPTION
## Summary

Production bug: a user filling out the Volunteer Agreement saw a red ``StubProfile`` toast and could not proceed.

Two compounding bugs in the onboarding widget — both fixed via the new `UserInfo.IsStub` read-model:

- **`OnboardingWidgetState.GetCurrentStepAsync`** routed Stub-profile users *past* the Names step. The dispatcher checked `profile is null`, but `EnsureStubProfileAsync` (called at signup in `AccountController` / `AccountProvisioningService`) now creates a Stub `Profile` row at user creation time — so the gate stopped firing for new users. They landed on Shifts → Consents without ever filling in legal name. Now reads `IUserService.GetUserInfoAsync` and gates on `info.IsStub` (matches the `Profile.HasRequiredIdentityFields()` semantics via the canonical predicate on `UserInfo`).

- **`OnboardingWidgetController.SignConsent`** displayed the raw `result.ErrorKey` in a red ``alert-danger`` toast. When `ConsentService.SubmitConsentAsync`'s defense-in-depth gate fired with `ErrorKey: \"StubProfile\"`, the user literally saw the string ``StubProfile`` on screen. Now:
  - Pre-flight `IsStubAsync` gate on `Consents` (GET) and `SignConsent` (POST) — mirrors `ConsentController.IsStubProfileAsync` and redirects to `Names` with a localized `Consent_StubProfile_AddName` info banner instead of `/Profile/Edit` (we're already in the widget).
  - Error key translation: `StubProfile` → redirect to Names with localized info; `AlreadyConsented` → localized info; everything else silent. Raw error keys never reach the user.

## Test plan

- [x] `dotnet build Humans.slnx -v quiet` clean (3 pre-existing HUM0009 warnings, unrelated)
- [x] `OnboardingWidgetStateTests` (10) pass — added `StubProfile_ReturnsNames`; existing tests reworked to mock `IUserService` + `UserInfo.Create`
- [x] `OnboardingWidgetControllerConsentsTests` (8) pass — added `Consents_Get_StubProfile_RedirectsToNames_WithLocalizedInfo`, `SignConsent_Post_StubProfile_RedirectsToNames_AndDoesNotCallService`, `SignConsent_Post_StubProfileErrorKey_RedirectsToNames_NoRawKeyDisplayed`; fixed the `AlreadyConsented` test that previously asserted raw key in `ErrorMessage`
- [ ] Smoke: sign up new user → land on Names step (not Shifts) → fill in name → Shifts → Consents → sign Volunteer Agreement (no red toast)
- [ ] Smoke: sign up new user, sign up for a shift first, then attempt Volunteer Agreement → bounced to Names with the localized prompt instead of red ``StubProfile`` text