### PR TITLE
fix(di): register missing services from peterdrier/Humans#554 (TicketController, GovernanceController)

### DIFF
--- a/src/Humans.Web/Extensions/Sections/GovernanceSectionExtensions.cs
+++ b/src/Humans.Web/Extensions/Sections/GovernanceSectionExtensions.cs
@@ -12,6 +12,7 @@ using Humans.Infrastructure.Repositories.Governance;
 using Humans.Infrastructure.Services;
 using Humans.Web.Services.Onboarding;
 using GovernanceApplicationDecisionService = Humans.Application.Services.Governance.ApplicationDecisionService;
+using GovernanceIndexService = Humans.Application.Services.Governance.GovernanceIndexService;
 using GovernanceMembershipCalculator = Humans.Application.Services.Governance.MembershipCalculator;
 using GovernanceMembershipQuery = Humans.Application.Services.Governance.MembershipQuery;
 using OnboardingOrchestratorService = Humans.Application.Services.Onboarding.OnboardingService;
@@ -37,6 +38,8 @@ internal static class GovernanceSectionExtensions
         services.AddScoped<IApplicationDecisionService>(sp => sp.GetRequiredService<GovernanceApplicationDecisionService>());
         services.AddScoped<IUserDataContributor>(sp => sp.GetRequiredService<GovernanceApplicationDecisionService>());
         services.AddScoped<IUserMerge>(sp => sp.GetRequiredService<GovernanceApplicationDecisionService>());
+
+        services.AddScoped<IGovernanceIndexService, GovernanceIndexService>();
 
         // Query adapter breaks the circular DI graph between IMembershipCalculator
         // and ITeamService / IRoleAssignmentService (both of which inject

--- a/src/Humans.Web/Extensions/Sections/TicketsSectionExtensions.cs
+++ b/src/Humans.Web/Extensions/Sections/TicketsSectionExtensions.cs
@@ -7,6 +7,7 @@ using TicketsTicketSyncService = Humans.Application.Services.Tickets.TicketSyncS
 using TicketsTicketQueryService = Humans.Application.Services.Tickets.TicketQueryService;
 using Humans.Application.Interfaces.Tickets;
 using Humans.Application.Services.Tickets;
+using Humans.Application.Services.Users;
 using Humans.Infrastructure.Repositories.Tickets;
 using Humans.Web.Models.Tickets;
 
@@ -38,6 +39,8 @@ internal static class TicketsSectionExtensions
         // AttendeeContactImportService — orchestrates user provisioning from unmatched ticket attendees.
         services.AddScoped<IAttendeeContactImportService, AttendeeContactImportService>();
         services.AddScoped<TicketDashboardPageBuilder>();
+
+        services.AddScoped<IUserParticipationBackfillService, UserParticipationBackfillService>();
 
         services.AddScoped<TicketSyncJob>();
         services.AddScoped<TicketingBudgetSyncJob>();


### PR DESCRIPTION
## Summary

PR peterdrier/Humans#554 wired two new service interfaces into controllers without adding their DI registrations:

- `IUserParticipationBackfillService` → injected into `TicketController` but never registered.
- `IGovernanceIndexService` → injected into `GovernanceController` but never registered.

Symptom on QA (logs):

```
HTTP "GET" "/Tickets" responded 500
System.InvalidOperationException: Unable to resolve service for type
'Humans.Application.Interfaces.Users.IUserParticipationBackfillService'
while attempting to activate 'Humans.Web.Controllers.TicketController'.
```

```
HTTP "GET" "/Governance/Roles" responded 500
System.InvalidOperationException: Unable to resolve service for type
'Humans.Application.Interfaces.Governance.IGovernanceIndexService'
while attempting to activate 'Humans.Web.Controllers.GovernanceController'.
```

The companion service added in peterdrier/Humans#554 (`IUserEmailProviderBackfillService`) was correctly registered in `ProfileSectionExtensions`; these two were the misses.

## Changes

- `TicketsSectionExtensions.cs`: `AddScoped<IUserParticipationBackfillService, UserParticipationBackfillService>()`
- `GovernanceSectionExtensions.cs`: `AddScoped<IGovernanceIndexService, GovernanceIndexService>()`

I audited all 79 `IFoo` types injected into Web controllers against the DI graph; the only unregistered ones outside framework services (`IAuthorizationService`, `IConfiguration`, `IHttpClientFactory`) were these two.

## Out of scope (worth a follow-up)

There is no Web-side DI smoke test that activates every controller against the real composition root. A `[Fact] public void Every_controller_can_be_activated()` that walks `typeof(HumansControllerBase).Assembly` would have caught this class of regression at PR time. Not adding it here to keep the hotfix minimal.

## Test plan

- [ ] QA preview environment boots
- [ ] `/Tickets` index loads as Admin
- [ ] `/Tickets/Participation/Backfill` loads
- [ ] `/Governance/Roles` loads as Board
- [ ] Existing test suite still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)