### PR TITLE
Drop Users from /Tickets diagrams; add Shift set; tighten predicates

### DIFF
--- a/src/Humans.Application/DTOs/Shifts/ShiftUserView.cs
+++ b/src/Humans.Application/DTOs/Shifts/ShiftUserView.cs
@@ -1,4 +1,5 @@
 using Humans.Domain.Entities;
+using Humans.Domain.Enums;
 
 namespace Humans.Application.DTOs.Shifts;
 
@@ -22,6 +23,17 @@ public sealed record ShiftUserView(
     IReadOnlyList<VolunteerTagPreference> TagPreferences,
     IReadOnlyList<ShiftSignup> Signups)
 {
+    /// <summary>
+    /// True when the user has at least one signup in an active state
+    /// (<see cref="SignupStatus.Pending"/> or <see cref="SignupStatus.Confirmed"/>)
+    /// in the active event. Refused / Bailed / Cancelled / NoShow signups
+    /// don't count — they're no longer commitments. Mirrors the convention
+    /// used by <c>ShiftSignupRepository</c>, <c>ShiftManagementService</c>,
+    /// and the agent snapshot.
+    /// </summary>
+    public bool HasShift => Signups.Any(s =>
+        s.Status is SignupStatus.Pending or SignupStatus.Confirmed);
+
     /// <summary>
     /// Empty view returned for unknown ids / no active event.
     /// </summary>

--- a/src/Humans.Application/Services/Shifts/ShiftViewService.cs
+++ b/src/Humans.Application/Services/Shifts/ShiftViewService.cs
@@ -37,16 +37,18 @@ public sealed class ShiftViewService : IShiftView
 
         var profile = await _management.GetVolunteerEventProfileAsync(userId, ct).ConfigureAwait(false);
         var tagPrefs = await _signups.GetVolunteerTagPreferencesForUserAsync(userId, ct).ConfigureAwait(false);
-        var allSignups = await _signups.GetByUserAsync(userId, eventSettingsId: null, ct).ConfigureAwait(false);
 
         GeneralAvailability? availability = null;
         VolunteerBuildStatus? buildStatus = null;
+        IReadOnlyList<ShiftSignup> signups = Array.Empty<ShiftSignup>();
         if (activeEvent is not null)
         {
             availability = await _availability
                 .GetByUserAndEventAsync(userId, activeEvent.Id, ct).ConfigureAwait(false);
             buildStatus = await _tracking
                 .GetAsync(userId, activeEvent.Id, ct).ConfigureAwait(false);
+            signups = await _signups
+                .GetByUserAsync(userId, activeEvent.Id, ct).ConfigureAwait(false);
         }
 
         return new ShiftUserView(
@@ -55,7 +57,7 @@ public sealed class ShiftViewService : IShiftView
             availability,
             buildStatus,
             tagPrefs,
-            allSignups);
+            signups);
     }
 
     public async ValueTask<IReadOnlyDictionary<Guid, ShiftUserView>> GetUsersAsync(

--- a/src/Humans.Web/Controllers/AdminController.cs
+++ b/src/Humans.Web/Controllers/AdminController.cs
@@ -72,7 +72,7 @@ public class AdminController : HumansControllerBase
         var firstName = User.Identity?.Name?.Split(' ').FirstOrDefault() ?? "";
         var snapshot = userService.GetAllUserInfos();
         var totalUsers = snapshot.Count;
-        var activeProfileUsers = snapshot.Count(u => u.Profile is not null);
+        var activeProfileUsers = snapshot.Count(u => u.IsActive);
         var activeEvent = await shifts.GetActiveAsync();
         var ticketHolders = activeEvent is { Year: > 0 }
             ? snapshot.Count(u => u.HasTicketForYear(activeEvent.Year))

--- a/src/Humans.Web/Models/TicketViewModels.cs
+++ b/src/Humans.Web/Models/TicketViewModels.cs
@@ -39,26 +39,36 @@ public class TicketDashboardViewModel
     // Who hasn't bought count (for dashboard link)
     public int WhoHasntBoughtCount { get; set; }
 
-    // Set membership across UserInfo cache (Users, Profiles, Tickets).
-    // Used by the Venn + UpSet diagrams. Each user is bucketed into one of
-    // the four (HasProfile, HasTicket) combinations.
+    // Set membership across UserInfo cache for the Venn + UpSet diagrams.
+    // Three subsets: Profile (IsActive), Ticket (active event year),
+    // Shift (active signup in active event). Each user falls into exactly
+    // one of the eight (P, T, S) buckets.
     public UserSetMembership? SetMembership { get; set; }
 }
 
 /// <summary>
-/// User-set bucketing for the Tickets dashboard Venn + UpSet diagrams.
-/// Users is the universe (every UserInfo); Profiles and Tickets are subsets.
-/// Each user falls into exactly one of the four buckets defined here.
+/// User-set bucketing for the Tickets dashboard Venn + UpSet diagrams. The
+/// cached <c>UserInfo</c> set is the universe; <c>Profile</c>, <c>Ticket</c>,
+/// and <c>Shift</c> are three subsets over it. Each user falls into exactly
+/// one of the eight disjoint buckets defined here.
 /// </summary>
 public sealed record UserSetMembership(
-    int UsersOnly,              // !HasProfile && !HasTicket
-    int UsersAndProfileOnly,    //  HasProfile && !HasTicket
-    int UsersAndTicketOnly,     // !HasProfile &&  HasTicket
-    int AllThree)               //  HasProfile &&  HasTicket
+    int None,            // !P && !T && !S
+    int ProfileOnly,     //  P && !T && !S
+    int TicketOnly,      // !P &&  T && !S
+    int ShiftOnly,       // !P && !T &&  S
+    int ProfileTicket,   //  P &&  T && !S
+    int ProfileShift,    //  P && !T &&  S
+    int TicketShift,     // !P &&  T &&  S
+    int All)             //  P &&  T &&  S
 {
-    public int TotalUsers => UsersOnly + UsersAndProfileOnly + UsersAndTicketOnly + AllThree;
-    public int ProfilesCount => UsersAndProfileOnly + AllThree;
-    public int TicketsCount => UsersAndTicketOnly + AllThree;
+    public int TotalUsers =>
+        None + ProfileOnly + TicketOnly + ShiftOnly
+        + ProfileTicket + ProfileShift + TicketShift + All;
+
+    public int ProfilesCount => ProfileOnly + ProfileTicket + ProfileShift + All;
+    public int TicketsCount  => TicketOnly + ProfileTicket + TicketShift + All;
+    public int ShiftsCount   => ShiftOnly + ProfileShift + TicketShift + All;
 }
 
 public class PaymentMethodFeeBreakdown

--- a/src/Humans.Web/Models/TicketViewModels.cs
+++ b/src/Humans.Web/Models/TicketViewModels.cs
@@ -67,8 +67,8 @@ public sealed record UserSetMembership(
         + ProfileTicket + ProfileShift + TicketShift + All;
 
     public int ProfilesCount => ProfileOnly + ProfileTicket + ProfileShift + All;
-    public int TicketsCount  => TicketOnly + ProfileTicket + TicketShift + All;
-    public int ShiftsCount   => ShiftOnly + ProfileShift + TicketShift + All;
+    public int TicketsCount => TicketOnly + ProfileTicket + TicketShift + All;
+    public int ShiftsCount => ShiftOnly + ProfileShift + TicketShift + All;
 }
 
 public class PaymentMethodFeeBreakdown

--- a/src/Humans.Web/Models/Tickets/TicketDashboardPageBuilder.cs
+++ b/src/Humans.Web/Models/Tickets/TicketDashboardPageBuilder.cs
@@ -14,6 +14,7 @@ public sealed class TicketDashboardPageBuilder
     private readonly ITicketQueryService _ticketQueryService;
     private readonly IUserService _userService;
     private readonly IShiftManagementService _shiftManagement;
+    private readonly IShiftView _shiftView;
     private readonly ILogger<TicketDashboardPageBuilder> _logger;
 
     public TicketDashboardPageBuilder(
@@ -22,6 +23,7 @@ public sealed class TicketDashboardPageBuilder
         ITicketQueryService ticketQueryService,
         IUserService userService,
         IShiftManagementService shiftManagement,
+        IShiftView shiftView,
         ILogger<TicketDashboardPageBuilder> logger)
     {
         _vendorService = vendorService;
@@ -29,6 +31,7 @@ public sealed class TicketDashboardPageBuilder
         _ticketQueryService = ticketQueryService;
         _userService = userService;
         _shiftManagement = shiftManagement;
+        _shiftView = shiftView;
         _logger = logger;
     }
 
@@ -114,21 +117,44 @@ public sealed class TicketDashboardPageBuilder
         var snapshot = _userService.GetAllUserInfos();
         var activeEvent = await _shiftManagement.GetActiveAsync();
         var activeYear = activeEvent?.Year ?? 0;
-        var usersOnly = 0;
+        var shiftViews = await _shiftView.GetUsersAsync(snapshot.Select(u => u.Id));
+
+        var none = 0;
         var profileOnly = 0;
         var ticketOnly = 0;
-        var both = 0;
+        var shiftOnly = 0;
+        var profileTicket = 0;
+        var profileShift = 0;
+        var ticketShift = 0;
+        var all = 0;
 
         foreach (var u in snapshot)
         {
-            var hasProfile = u.Profile is not null;
-            var hasTicket = activeYear > 0 && u.HasTicketForYear(activeYear);
-            if (hasProfile && hasTicket) both++;
-            else if (hasProfile) profileOnly++;
-            else if (hasTicket) ticketOnly++;
-            else usersOnly++;
+            var p = u.IsActive;
+            var t = activeYear > 0 && u.HasTicketForYear(activeYear);
+            var s = shiftViews[u.Id].HasShift;
+
+            switch ((p, t, s))
+            {
+                case (false, false, false): none++; break;
+                case (true,  false, false): profileOnly++; break;
+                case (false, true,  false): ticketOnly++; break;
+                case (false, false, true):  shiftOnly++; break;
+                case (true,  true,  false): profileTicket++; break;
+                case (true,  false, true):  profileShift++; break;
+                case (false, true,  true):  ticketShift++; break;
+                case (true,  true,  true):  all++; break;
+            }
         }
 
-        return new UserSetMembership(usersOnly, profileOnly, ticketOnly, both);
+        return new UserSetMembership(
+            None: none,
+            ProfileOnly: profileOnly,
+            TicketOnly: ticketOnly,
+            ShiftOnly: shiftOnly,
+            ProfileTicket: profileTicket,
+            ProfileShift: profileShift,
+            TicketShift: ticketShift,
+            All: all);
     }
 }

--- a/src/Humans.Web/Models/Tickets/TicketDashboardPageBuilder.cs
+++ b/src/Humans.Web/Models/Tickets/TicketDashboardPageBuilder.cs
@@ -137,13 +137,13 @@ public sealed class TicketDashboardPageBuilder
             switch ((p, t, s))
             {
                 case (false, false, false): none++; break;
-                case (true,  false, false): profileOnly++; break;
-                case (false, true,  false): ticketOnly++; break;
-                case (false, false, true):  shiftOnly++; break;
-                case (true,  true,  false): profileTicket++; break;
-                case (true,  false, true):  profileShift++; break;
-                case (false, true,  true):  ticketShift++; break;
-                case (true,  true,  true):  all++; break;
+                case (true, false, false): profileOnly++; break;
+                case (false, true, false): ticketOnly++; break;
+                case (false, false, true): shiftOnly++; break;
+                case (true, true, false): profileTicket++; break;
+                case (true, false, true): profileShift++; break;
+                case (false, true, true): ticketShift++; break;
+                case (true, true, true): all++; break;
             }
         }
 

--- a/src/Humans.Web/Views/Ticket/Index.cshtml
+++ b/src/Humans.Web/Views/Ticket/Index.cshtml
@@ -100,14 +100,20 @@
         </div>
     </div>
 
-    <!-- User set membership — Venn (Profiles ∩ Tickets within Users) + UpSet -->
+    <!-- User set membership — Venn + UpSet over Profile / Ticket / Shift -->
     @if (Model.SetMembership is { TotalUsers: > 0 } sm)
     {
+        var profileTicket = sm.ProfileTicket + sm.All;
+        var profileShift  = sm.ProfileShift + sm.All;
+        var ticketShift   = sm.TicketShift + sm.All;
         <div class="card mb-4">
             <div class="card-header">
                 <i class="fa-solid fa-chart-pie"></i> User set membership
                 <small class="text-muted">
-                    @sm.TotalUsers total users · @sm.ProfilesCount with profile · @sm.TicketsCount with ticket
+                    @sm.TotalUsers total users ·
+                    @sm.ProfilesCount with profile ·
+                    @sm.TicketsCount with ticket ·
+                    @sm.ShiftsCount with shift
                 </small>
             </div>
             <div class="card-body">
@@ -115,31 +121,34 @@
                     <div class="col-md-6">
                         <h6 class="text-center">Proportional Venn</h6>
                         <div id="userVenn"
-                             data-users="@sm.TotalUsers"
-                             data-profiles="@sm.ProfilesCount"
-                             data-tickets="@sm.TicketsCount"
-                             data-users-profiles="@sm.ProfilesCount"
-                             data-users-tickets="@sm.TicketsCount"
-                             data-profiles-tickets="@sm.AllThree"
-                             data-all-three="@sm.AllThree"
+                             data-profile="@sm.ProfilesCount"
+                             data-ticket="@sm.TicketsCount"
+                             data-shift="@sm.ShiftsCount"
+                             data-profile-ticket="@profileTicket"
+                             data-profile-shift="@profileShift"
+                             data-ticket-shift="@ticketShift"
+                             data-all="@sm.All"
                              style="height: 500px; width: 100%;"></div>
                     </div>
                     <div class="col-md-6">
                         <h6 class="text-center">UpSet plot</h6>
                         <div id="userUpset"
-                             data-users-only="@sm.UsersOnly"
-                             data-profile-only="@sm.UsersAndProfileOnly"
-                             data-ticket-only="@sm.UsersAndTicketOnly"
-                             data-all-three="@sm.AllThree"
+                             data-profile-only="@sm.ProfileOnly"
+                             data-ticket-only="@sm.TicketOnly"
+                             data-shift-only="@sm.ShiftOnly"
+                             data-profile-ticket="@sm.ProfileTicket"
+                             data-profile-shift="@sm.ProfileShift"
+                             data-ticket-shift="@sm.TicketShift"
+                             data-all="@sm.All"
                              style="height: 500px; width: 100%;"></div>
                     </div>
                 </div>
                 <p class="text-muted small mt-2 mb-0">
-                    Users is the universe — every cached user is in it. Profiles ⊆ Users, Tickets ⊆ Users.
+                    Profile = active profile (not rejected). Ticket = Ticketed/Attended in active event year.
+                    Shift = active signup (Pending/Confirmed) in active event.
                 </p>
             </div>
         </div>
-        @* TODO: extend to Shifts set when IShiftManager caching lands. *@
     }
 
     <!-- Daily Sales Chart -->
@@ -398,18 +407,18 @@
     <script src="https://cdn.jsdelivr.net/npm/@@upsetjs/bundle@1.11.0/dist/upsetjs.umd.production.min.js" crossorigin="anonymous"></script>
     <script>
         document.addEventListener('DOMContentLoaded', function () {
-            // ---- Venn: 3 sets (Users / Profiles / Tickets) ----
+            // ---- Venn: 3 sets (Profile / Ticket / Shift) ----
             var venn = document.getElementById('userVenn');
             if (venn && window.venn && window.d3) {
                 var d = venn.dataset;
                 var sets = [
-                    { sets: ['Users'], size: +d.users, label: 'Users (' + d.users + ')' },
-                    { sets: ['Profiles'], size: +d.profiles, label: 'Profiles (' + d.profiles + ')' },
-                    { sets: ['Tickets'], size: +d.tickets, label: 'Tickets (' + d.tickets + ')' },
-                    { sets: ['Users', 'Profiles'], size: +d.usersProfiles },
-                    { sets: ['Users', 'Tickets'], size: +d.usersTickets },
-                    { sets: ['Profiles', 'Tickets'], size: +d.profilesTickets },
-                    { sets: ['Users', 'Profiles', 'Tickets'], size: +d.allThree }
+                    { sets: ['Profile'], size: +d.profile, label: 'Profile (' + d.profile + ')' },
+                    { sets: ['Ticket'],  size: +d.ticket,  label: 'Ticket (' + d.ticket + ')' },
+                    { sets: ['Shift'],   size: +d.shift,   label: 'Shift (' + d.shift + ')' },
+                    { sets: ['Profile', 'Ticket'], size: +d.profileTicket },
+                    { sets: ['Profile', 'Shift'],  size: +d.profileShift },
+                    { sets: ['Ticket', 'Shift'],   size: +d.ticketShift },
+                    { sets: ['Profile', 'Ticket', 'Shift'], size: +d.all }
                 ];
                 var chart = window.venn.VennDiagram().width(400).height(360);
                 window.d3.select('#userVenn').datum(sets).call(chart);
@@ -419,15 +428,21 @@
             var upset = document.getElementById('userUpset');
             if (upset && window.UpSetJS) {
                 var u = upset.dataset;
-                var usersOnly = +u.usersOnly;
-                var profileOnly = +u.profileOnly;
-                var ticketOnly = +u.ticketOnly;
-                var allThree = +u.allThree;
+                var profileOnly   = +u.profileOnly;
+                var ticketOnly    = +u.ticketOnly;
+                var shiftOnly     = +u.shiftOnly;
+                var profileTicket = +u.profileTicket;
+                var profileShift  = +u.profileShift;
+                var ticketShift   = +u.ticketShift;
+                var allThree      = +u.all;
                 var elems = [];
-                for (var i = 0; i < usersOnly; i++)    elems.push({ name: 'u' + i, sets: ['Users'] });
-                for (var i = 0; i < profileOnly; i++)  elems.push({ name: 'p' + i, sets: ['Users', 'Profiles'] });
-                for (var i = 0; i < ticketOnly; i++)   elems.push({ name: 't' + i, sets: ['Users', 'Tickets'] });
-                for (var i = 0; i < allThree; i++)     elems.push({ name: 'a' + i, sets: ['Users', 'Profiles', 'Tickets'] });
+                for (var i = 0; i < profileOnly; i++)   elems.push({ name: 'p' + i,  sets: ['Profile'] });
+                for (var i = 0; i < ticketOnly; i++)    elems.push({ name: 't' + i,  sets: ['Ticket'] });
+                for (var i = 0; i < shiftOnly; i++)     elems.push({ name: 's' + i,  sets: ['Shift'] });
+                for (var i = 0; i < profileTicket; i++) elems.push({ name: 'pt' + i, sets: ['Profile', 'Ticket'] });
+                for (var i = 0; i < profileShift; i++)  elems.push({ name: 'ps' + i, sets: ['Profile', 'Shift'] });
+                for (var i = 0; i < ticketShift; i++)   elems.push({ name: 'ts' + i, sets: ['Ticket', 'Shift'] });
+                for (var i = 0; i < allThree; i++)      elems.push({ name: 'a' + i,  sets: ['Profile', 'Ticket', 'Shift'] });
                 var sets = window.UpSetJS.extractSets(elems);
                 var combinations = window.UpSetJS.generateCombinations(sets);
                 window.UpSetJS.render(upset, {

--- a/tests/Humans.Application.Tests/Services/Shifts/ShiftViewServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Shifts/ShiftViewServiceTests.cs
@@ -76,6 +76,49 @@ public class ShiftViewServiceTests
     }
 
     [HumansFact]
+    public async Task GetUserAsync_NoActiveEvent_DoesNotQuerySignups()
+    {
+        var userId = Guid.NewGuid();
+        _management.GetActiveEventSettingsAsync(Arg.Any<CancellationToken>())
+            .Returns((EventSettings?)null);
+        _management.GetVolunteerEventProfileAsync(userId, Arg.Any<CancellationToken>())
+            .Returns((VolunteerEventProfile?)null);
+        _signups.GetVolunteerTagPreferencesForUserAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<VolunteerTagPreference>());
+
+        var sut = CreateSut();
+        var view = await sut.GetUserAsync(userId);
+
+        view.Signups.Should().BeEmpty();
+        await _signups.DidNotReceive().GetByUserAsync(
+            Arg.Any<Guid>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task GetUserAsync_WithActiveEvent_ScopesSignupsToActiveEventId()
+    {
+        var userId = Guid.NewGuid();
+        var eventId = Guid.NewGuid();
+        var es = new EventSettings { Id = eventId, IsActive = true };
+        var scoped = new[] { new ShiftSignup { Id = Guid.NewGuid(), UserId = userId } };
+
+        _management.GetActiveEventSettingsAsync(Arg.Any<CancellationToken>()).Returns(es);
+        _management.GetVolunteerEventProfileAsync(userId, Arg.Any<CancellationToken>())
+            .Returns((VolunteerEventProfile?)null);
+        _signups.GetVolunteerTagPreferencesForUserAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<VolunteerTagPreference>());
+        _signups.GetByUserAsync(userId, eventId, Arg.Any<CancellationToken>()).Returns(scoped);
+
+        var sut = CreateSut();
+        var view = await sut.GetUserAsync(userId);
+
+        view.Signups.Should().BeSameAs(scoped);
+        await _signups.Received(1).GetByUserAsync(userId, eventId, Arg.Any<CancellationToken>());
+        await _signups.DidNotReceive().GetByUserAsync(
+            userId, (Guid?)null, Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
     public async Task GetRotaAsync_UnknownRotaId_ReturnsEmptyView()
     {
         var rotaId = Guid.NewGuid();


### PR DESCRIPTION
## Summary

- Drops the degenerate Users circle from `/Ticket`'s Venn + UpSet, replaces it with a real Shift set (Profile / Ticket / Shift).
- Switches the "has profile" predicate on `/Ticket` and `/Admin` from `u.Profile is not null` to `u.IsActive`, so stubs and rejecteds no longer inflate the count.
- Scopes `ShiftViewService.Signups` to the active event (was loading every year), matching the rest of `ShiftUserView`.
- Adds `ShiftUserView.HasShift` — true when the user has at least one Pending or Confirmed signup.

Closes nobodies-collective/Humans#724.

## Notes for review

- `IShiftView` is the only signup source used by the new Shift set, per Peter's direction — the lazy per-user cache warms on first dashboard load (~500 scoped resolutions cold, warm thereafter).
- UpSet click behavior is preserved (no handlers wired before, none wired now).
- "users" terminology in the card header / card body is pre-existing and consistent with surrounding pages (`_DashboardStats`, `/Admin` page-head). Razor lint flagged it INFO-level on the lines I touched; left as-is here to avoid a mixed-terminology PR — could be a follow-up sweep.
- 62 pre-existing failures in `Humans.Integration.Tests` (`AcceptAsync_*`) reproduce on `origin/main` without these changes — unrelated to this PR (active merge-fold work).

## Test plan

- [ ] Verify `/Ticket` renders three Venn circles (Profile / Ticket / Shift) — no Users circle.
- [ ] Verify UpSet renders 7 combinations max (P, T, S, P∩T, P∩S, T∩S, P∩T∩S) and is still interactive on hover.
- [ ] Verify the card header summary line shows `total users · with profile · with ticket · with shift`.
- [ ] Verify `/Admin` page-head sub-line and the "Active (has profile)" stat card show the IsActive count (excludes rejecteds and stubs).
- [ ] Cold-load the dashboard once on the preview env to validate the per-user shift-view warmup completes in acceptable time at production-like data volume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
