### PR TITLE
refactor(user-cache): migrate 38 ProfileController readers onto UserInfo

### DIFF
--- a/src/Humans.Web/Controllers/ProfileController.cs
+++ b/src/Humans.Web/Controllers/ProfileController.cs
@@ -240,28 +240,28 @@ public class ProfileController : HumansControllerBase
     [HttpGet("Me")]
     public async Task<IActionResult> Me(CancellationToken ct)
     {
-        var user = await GetCurrentUserAsync();
-        if (user is null)
+        var info = await GetCurrentUserInfoAsync(ct);
+        if (info is null)
             return NotFound();
 
-        var profile = (await _userService.GetUserInfoAsync(user.Id, ct))?.Profile;
-        var snapshot = await _membershipCalculator.GetMembershipSnapshotAsync(user.Id, ct);
+        var profile = info.Profile;
+        var snapshot = await _membershipCalculator.GetMembershipSnapshotAsync(info.Id, ct);
         var pendingConsentCount = snapshot.PendingConsentCount;
 
-        var applications = await _applicationDecisionService.GetUserApplicationsAsync(user.Id, ct);
+        var applications = await _applicationDecisionService.GetUserApplicationsAsync(info.Id, ct);
         var latestApplication = applications.Count > 0 ? applications[0] : null;
 
-        var campaignGrants = await _campaignService.GetActiveOrCompletedGrantsForUserAsync(user.Id, ct);
+        var campaignGrants = await _campaignService.GetActiveOrCompletedGrantsForUserAsync(info.Id, ct);
 
         var viewModel = new ProfileViewModel
         {
             Id = profile?.Id ?? Guid.Empty,
-            UserId = user.Id,
+            UserId = info.Id,
             HasPendingConsents = pendingConsentCount > 0,
             PendingConsentCount = pendingConsentCount,
             IsApproved = profile?.IsApproved ?? false,
             IsOwnProfile = true,
-            DisplayName = user.DisplayName,
+            DisplayName = info.DisplayName,
             CampaignGrants = campaignGrants,
         };
 
@@ -320,7 +320,7 @@ public class ProfileController : HumansControllerBase
             return View(model);
         }
 
-        var user = await GetCurrentUserAsync();
+        var user = await GetCurrentUserInfoAsync();
         if (user is null)
             return NotFound();
 
@@ -732,7 +732,7 @@ public class ProfileController : HumansControllerBase
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> SetPrimary(Guid emailId, CancellationToken ct)
     {
-        var user = await GetCurrentUserAsync();
+        var user = await GetCurrentUserInfoAsync(ct);
         if (user is null)
             return NotFound();
 
@@ -767,7 +767,7 @@ public class ProfileController : HumansControllerBase
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> SetEmailVisibility(Guid emailId, string? visibility)
     {
-        var user = await GetCurrentUserAsync();
+        var user = await GetCurrentUserInfoAsync();
         if (user is null)
             return NotFound();
 
@@ -812,7 +812,7 @@ public class ProfileController : HumansControllerBase
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> DeleteEmail(Guid emailId)
     {
-        var user = await GetCurrentUserAsync();
+        var user = await GetCurrentUserInfoAsync();
         if (user is null)
             return NotFound();
 
@@ -856,7 +856,7 @@ public class ProfileController : HumansControllerBase
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> SetGoogle(Guid emailId, CancellationToken ct)
     {
-        var user = await GetCurrentUserAsync();
+        var user = await GetCurrentUserInfoAsync(ct);
         if (user is null)
             return NotFound();
 
@@ -894,7 +894,7 @@ public class ProfileController : HumansControllerBase
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> ClearGoogle(Guid emailId, CancellationToken ct)
     {
-        var user = await GetCurrentUserAsync();
+        var user = await GetCurrentUserInfoAsync(ct);
         if (user is null)
             return NotFound();
 
@@ -932,7 +932,7 @@ public class ProfileController : HumansControllerBase
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> ClearPrimary(Guid emailId, CancellationToken ct)
     {
-        var user = await GetCurrentUserAsync();
+        var user = await GetCurrentUserInfoAsync(ct);
         if (user is null)
             return NotFound();
 
@@ -970,7 +970,7 @@ public class ProfileController : HumansControllerBase
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> Link(string provider, string? returnUrl = null)
     {
-        var user = await GetCurrentUserAsync();
+        var user = await GetCurrentUserInfoAsync();
         if (user is null)
             return NotFound();
 
@@ -994,7 +994,7 @@ public class ProfileController : HumansControllerBase
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> Unlink(Guid id, CancellationToken ct)
     {
-        var user = await GetCurrentUserAsync();
+        var user = await GetCurrentUserInfoAsync(ct);
         if (user is null)
             return NotFound();
 
@@ -1054,7 +1054,7 @@ public class ProfileController : HumansControllerBase
         if (!authz.Succeeded)
             return Forbid();
 
-        var actor = await GetCurrentUserAsync();
+        var actor = await GetCurrentUserInfoAsync(ct);
         if (actor is null)
             return Forbid();
 
@@ -1080,7 +1080,7 @@ public class ProfileController : HumansControllerBase
         if (!authz.Succeeded)
             return Forbid();
 
-        var actor = await GetCurrentUserAsync();
+        var actor = await GetCurrentUserInfoAsync(ct);
         if (actor is null)
             return Forbid();
 
@@ -1114,7 +1114,7 @@ public class ProfileController : HumansControllerBase
         if (!authz.Succeeded)
             return Forbid();
 
-        var actor = await GetCurrentUserAsync();
+        var actor = await GetCurrentUserInfoAsync(ct);
         if (actor is null)
             return Forbid();
 
@@ -1140,7 +1140,7 @@ public class ProfileController : HumansControllerBase
         if (!authz.Succeeded)
             return Forbid();
 
-        var actor = await GetCurrentUserAsync();
+        var actor = await GetCurrentUserInfoAsync(ct);
         if (actor is null)
             return Forbid();
 
@@ -1172,7 +1172,7 @@ public class ProfileController : HumansControllerBase
             return RedirectToAction(nameof(AdminEmails), new { id });
         }
 
-        var actor = await GetCurrentUserAsync();
+        var actor = await GetCurrentUserInfoAsync(ct);
         if (actor is null)
             return Forbid();
 
@@ -1309,7 +1309,7 @@ public class ProfileController : HumansControllerBase
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> AdminVerifyEmail(Guid id, Guid emailId, CancellationToken ct)
     {
-        var actor = await GetCurrentUserAsync();
+        var actor = await GetCurrentUserInfoAsync(ct);
         if (actor is null)
             return Forbid();
 
@@ -1345,7 +1345,7 @@ public class ProfileController : HumansControllerBase
         if (!authz.Succeeded)
             return Forbid();
 
-        var actor = await GetCurrentUserAsync();
+        var actor = await GetCurrentUserInfoAsync(ct);
         if (actor is null)
             return Forbid();
 
@@ -1371,7 +1371,7 @@ public class ProfileController : HumansControllerBase
         if (!authz.Succeeded)
             return Forbid();
 
-        var actor = await GetCurrentUserAsync();
+        var actor = await GetCurrentUserInfoAsync(ct);
         if (actor is null)
             return Forbid();
 
@@ -1416,7 +1416,7 @@ public class ProfileController : HumansControllerBase
         if (!authz.Succeeded)
             return Forbid();
 
-        var actor = await GetCurrentUserAsync();
+        var actor = await GetCurrentUserInfoAsync(ct);
         if (actor is null)
             return Forbid();
 
@@ -1452,7 +1452,7 @@ public class ProfileController : HumansControllerBase
     [HttpGet("Me/Outbox")]
     public async Task<IActionResult> MyOutbox()
     {
-        var user = await GetCurrentUserAsync();
+        var user = await GetCurrentUserInfoAsync();
         if (user is null)
             return NotFound();
 
@@ -1464,7 +1464,7 @@ public class ProfileController : HumansControllerBase
     [HttpGet("Me/Privacy")]
     public async Task<IActionResult> Privacy()
     {
-        var user = await GetCurrentUserAsync();
+        var user = await GetCurrentUserInfoAsync();
         if (user is null)
             return NotFound();
 
@@ -1483,7 +1483,7 @@ public class ProfileController : HumansControllerBase
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> RequestDeletion()
     {
-        var user = await GetCurrentUserAsync();
+        var user = await GetCurrentUserInfoAsync();
         if (user is null)
             return NotFound();
 
@@ -1505,7 +1505,7 @@ public class ProfileController : HumansControllerBase
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> CancelDeletion()
     {
-        var user = await GetCurrentUserAsync();
+        var user = await GetCurrentUserInfoAsync();
         if (user is null)
             return NotFound();
 
@@ -1526,7 +1526,7 @@ public class ProfileController : HumansControllerBase
     {
         try
         {
-            var user = await GetCurrentUserAsync();
+            var user = await GetCurrentUserInfoAsync();
             if (user is null)
                 return NotFound(); var profile = await _shiftMgmt.GetShiftProfileAsync(user.Id, includeMedical: false);
             return View(ShiftInfoViewModel.FromProfile(profile));
@@ -1545,7 +1545,7 @@ public class ProfileController : HumansControllerBase
     {
         try
         {
-            var user = await GetCurrentUserAsync();
+            var user = await GetCurrentUserInfoAsync();
             if (user is null)
                 return NotFound();
 
@@ -1576,7 +1576,7 @@ public class ProfileController : HumansControllerBase
     {
         try
         {
-            var user = await GetCurrentUserAsync();
+            var user = await GetCurrentUserInfoAsync();
             if (user is null)
                 return NotFound();
 
@@ -1598,7 +1598,7 @@ public class ProfileController : HumansControllerBase
     {
         try
         {
-            var user = await GetCurrentUserAsync();
+            var user = await GetCurrentUserInfoAsync();
             if (user is null)
                 return Unauthorized();
 
@@ -1624,7 +1624,7 @@ public class ProfileController : HumansControllerBase
     [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
     public async Task<IActionResult> DownloadData(CancellationToken ct)
     {
-        var user = await GetCurrentUserAsync();
+        var user = await GetCurrentUserInfoAsync(ct);
         if (user is null)
             return NotFound();
 
@@ -1807,7 +1807,7 @@ public class ProfileController : HumansControllerBase
             return NotFound();
         }
 
-        var viewer = await GetCurrentUserAsync();
+        var viewer = await GetCurrentUserInfoAsync(ct);
         if (viewer is null)
         {
             return NotFound();
@@ -1815,7 +1815,7 @@ public class ProfileController : HumansControllerBase
 
         var isOwnProfile = viewer.Id == id;
 
-        var noShowContext = await BuildNoShowHistoryContextAsync(id, viewer, isOwnProfile, ct);
+        var noShowContext = await BuildNoShowHistoryContextAsync(id, viewer.Id, isOwnProfile, ct);
 
         // The ProfileCard ViewComponent handles all data fetching and permission checks.
         var viewModel = new ProfileViewModel
@@ -1834,7 +1834,7 @@ public class ProfileController : HumansControllerBase
 
     private async Task<(bool CanView, List<NoShowHistoryItem>? History)> BuildNoShowHistoryContextAsync(
         Guid profileUserId,
-        User viewer,
+        Guid viewerId,
         bool isOwnProfile,
         CancellationToken ct)
     {
@@ -1843,7 +1843,7 @@ public class ProfileController : HumansControllerBase
             return (false, null);
         }
 
-        var viewerIsCoordinator = (await _shiftMgmt.GetCoordinatorTeamIdsAsync(viewer.Id)).Count > 0;
+        var viewerIsCoordinator = (await _shiftMgmt.GetCoordinatorTeamIdsAsync(viewerId)).Count > 0;
         var viewerCanViewShiftHistory = viewerIsCoordinator || ShiftRoleChecks.IsPrivilegedSignupApprover(User);
         if (!viewerCanViewShiftHistory)
         {
@@ -1915,7 +1915,7 @@ public class ProfileController : HumansControllerBase
     [HttpGet("{id:guid}/SendMessage")]
     public async Task<IActionResult> SendMessage(Guid id)
     {
-        var currentUser = await GetCurrentUserAsync();
+        var currentUser = await GetCurrentUserInfoAsync();
         if (currentUser is null)
             return NotFound();
 
@@ -1945,7 +1945,7 @@ public class ProfileController : HumansControllerBase
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> SendMessage(Guid id, SendMessageViewModel model)
     {
-        var currentUser = await GetCurrentUserAsync();
+        var currentUser = await GetCurrentUserInfoAsync();
         if (currentUser is null)
             return NotFound();
 
@@ -2111,7 +2111,7 @@ public class ProfileController : HumansControllerBase
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> RevealIban(Guid id, CancellationToken ct)
     {
-        var actor = await GetCurrentUserAsync();
+        var actor = await GetCurrentUserInfoAsync(ct);
         if (actor is null) return Forbid();
         return await RevealIbanCoreAsync(id, actor.Id, ct);
     }
@@ -2147,7 +2147,7 @@ public class ProfileController : HumansControllerBase
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> SuspendHuman(Guid id, string? notes)
     {
-        var currentUser = await GetCurrentUserAsync();
+        var currentUser = await GetCurrentUserInfoAsync();
         if (currentUser is null)
             return NotFound();
 
@@ -2164,7 +2164,7 @@ public class ProfileController : HumansControllerBase
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> UnsuspendHuman(Guid id)
     {
-        var currentUser = await GetCurrentUserAsync();
+        var currentUser = await GetCurrentUserInfoAsync();
         if (currentUser is null)
             return NotFound();
 
@@ -2181,7 +2181,7 @@ public class ProfileController : HumansControllerBase
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> ApproveVolunteer(Guid id)
     {
-        var currentUser = await GetCurrentUserAsync();
+        var currentUser = await GetCurrentUserInfoAsync();
         if (currentUser is null)
             return NotFound();
 
@@ -2198,7 +2198,7 @@ public class ProfileController : HumansControllerBase
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> RejectSignup(Guid id, string? reason)
     {
-        var currentUser = await GetCurrentUserAsync();
+        var currentUser = await GetCurrentUserInfoAsync();
         if (currentUser is null)
             return Unauthorized();
 
@@ -2254,7 +2254,7 @@ public class ProfileController : HumansControllerBase
             return View(model);
         }
 
-        var currentUser = await GetCurrentUserAsync();
+        var currentUser = await GetCurrentUserInfoAsync();
         if (currentUser is null)
         {
             return Unauthorized();
@@ -2308,7 +2308,7 @@ public class ProfileController : HumansControllerBase
             return NotFound();
         }
 
-        var currentUser = await GetCurrentUserAsync();
+        var currentUser = await GetCurrentUserInfoAsync();
         if (currentUser is null)
         {
             return Unauthorized();
@@ -2343,6 +2343,23 @@ public class ProfileController : HumansControllerBase
         SetError(_localizer["Admin_RoleNotActive"].Value);
     }
     // ─── Helpers ─────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Cache-resident counterpart to <c>GetCurrentUserAsync</c>. Resolves the
+    /// current user's id from the <see cref="System.Security.Claims.ClaimsPrincipal"/>
+    /// (no DB hit) and returns the cached <see cref="UserInfo"/> projection.
+    /// Prefer this over <c>GetCurrentUserAsync</c> in actions that only read
+    /// display/profile fields — the entity load is only needed when calling
+    /// <see cref="UserManager{TUser}"/> mutators or otherwise passing the
+    /// EF-tracked user across an Identity boundary.
+    /// </summary>
+    private async Task<UserInfo?> GetCurrentUserInfoAsync(CancellationToken ct = default)
+    {
+        var idString = UserManager.GetUserId(User);
+        if (idString is null || !Guid.TryParse(idString, out var id))
+            return null;
+        return await _userService.GetUserInfoAsync(id, ct);
+    }
 
     private (byte[] Data, string ContentType)? ResizeProfilePicture(byte[] imageData, string contentType) =>
         Helpers.ProfilePictureProcessor.ResizeProfilePicture(imageData, _logger);

--- a/tests/Humans.Application.Tests/Controllers/ProfileControllerEditTests.cs
+++ b/tests/Humans.Application.Tests/Controllers/ProfileControllerEditTests.cs
@@ -17,6 +17,7 @@ using Humans.Application.Interfaces.Shifts;
 using Humans.Application.Interfaces.Teams;
 using Humans.Application.Interfaces.Tickets;
 using Humans.Application.Interfaces.Users;
+using Humans.Application.Tests.Infrastructure;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Humans.Testing;
@@ -139,6 +140,17 @@ public class ProfileControllerEditTests
 
         _userManager.GetUserAsync(Arg.Any<ClaimsPrincipal>())
             .Returns(new User { Id = _userId, DisplayName = "Test Human", PreferredLanguage = "en" });
+        _userManager.GetUserId(Arg.Any<ClaimsPrincipal>()).Returns(_userId.ToString());
+
+        // Edit POST resolves the current user through GetCurrentUserInfoAsync
+        // (cache-resident); subsequent setup-detection lookups in the action body
+        // also call IUserService.GetUserInfoAsync. Default stub returns a UserInfo
+        // with no profile so the initial-setup branch is taken; per-test overrides
+        // (e.g. approved profile) replace it.
+        _userService.GetUserInfoAsync(_userId, Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<UserInfo?>(
+                new User { Id = _userId, DisplayName = "Test Human", PreferredLanguage = "en" }
+                    .ToUserInfo()));
 
         // SaveProfileAsync is invoked unconditionally by the happy path.
         _profileService.SaveProfileAsync(

--- a/tests/Humans.Application.Tests/Controllers/ProfileControllerEmailGridTests.cs
+++ b/tests/Humans.Application.Tests/Controllers/ProfileControllerEmailGridTests.cs
@@ -17,6 +17,8 @@ using Humans.Application.Interfaces.Shifts;
 using Humans.Application.Interfaces.Teams;
 using Humans.Application.Interfaces.Tickets;
 using Humans.Application.Interfaces.Users;
+using Humans.Application;
+using Humans.Application.Tests.Infrastructure;
 using Humans.Domain.Entities;
 using Humans.Testing;
 using Humans.Web;
@@ -52,6 +54,7 @@ public class ProfileControllerEmailGridTests
     private readonly IEmailService _emailService = Substitute.For<IEmailService>();
     private readonly IAuthorizationService _authorizationService = Substitute.For<IAuthorizationService>();
     private readonly IAuditLogService _auditLogService = Substitute.For<IAuditLogService>();
+    private readonly IUserService _userService = Substitute.For<IUserService>();
     private readonly IMemoryCache _cache = new MemoryCache(new MemoryCacheOptions());
     private readonly UserManager<User> _userManager;
     private readonly SignInManager<User> _signInManager;
@@ -102,7 +105,7 @@ public class ProfileControllerEmailGridTests
             _cache,
             new FakeClock(Instant.FromUtc(2026, 4, 30, 12, 0)),
             _authorizationService,
-            Substitute.For<IUserService>(),
+            _userService,
             Substitute.For<IConsentService>(),
             Substitute.For<IApplicationDecisionService>(),
             Substitute.For<IAccountDeletionService>(),
@@ -125,6 +128,13 @@ public class ProfileControllerEmailGridTests
 
         _userManager.GetUserAsync(Arg.Any<ClaimsPrincipal>())
             .Returns(new User { Id = _userId });
+        _userManager.GetUserId(Arg.Any<ClaimsPrincipal>()).Returns(_userId.ToString());
+
+        // GetCurrentUserInfoAsync helper reads through IUserService; default
+        // stub returns a minimal UserInfo for the test user so the actions
+        // continue past the null-guard. Per-test overrides can replace this.
+        _userService.GetUserInfoAsync(_userId, Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<UserInfo?>(new User { Id = _userId }.ToUserInfo()));
 
         _authorizationService.AuthorizeAsync(
             Arg.Any<ClaimsPrincipal>(),


### PR DESCRIPTION
## Summary

Slice 1 of the post-#564 audit (full plan in `local/user-cache-migration-plan.md`). Adds a private `GetCurrentUserInfoAsync()` helper to `ProfileController` and migrates 38 of the 43 `GetCurrentUserAsync()` call sites in that file — every site that only reads `.Id` / `.DisplayName` / `.IsDeletionPending` etc. and doesn't pass the EF entity to `UserManager.*` or a cross-file helper.

Net DB-hit reduction: per-request `UserManager.GetUserAsync(claims)` is gone on 38 routes; replaced by a cache lookup keyed on the userId claim (no DB call when the entry is warm, which is the standard case after `UserInfoWarmupHostedService` startup). The `Me` action also drops a pre-existing doubled lookup — it was loading the User entity and then immediately calling `GetUserInfoAsync(user.Id)` for the Profile.

## Why this PR is narrow

- **One controller, one slice.** ProfileController is the largest single offender (44 of 134 `GetCurrentUserAsync` sites in the codebase). Proving the helper here before fanning out to the other 31 controllers is the next slice.
- **Helper is private to ProfileController, not promoted to `HumansControllerBase`.** ProfileController already injects `IUserService` — no DI plumbing needed. A base-class version (slice 2) will need to either constructor-inject `IUserService` into 58 derived controllers or use `HttpContext.RequestServices` with a test-fixture wiring change. Out of scope here.
- **5 hybrid sites kept on `GetCurrentUserAsync()`** because they pass the EF entity to `UserManager.GetLoginsAsync` (Edit GET, ImportGooglePhoto) or to cross-file helpers that take `User` (Emails GET, AddEmail POST, AdminAddVerifiedEmail). Migrating those requires helper-signature changes; cleaner as a follow-up.

## Side-effects in the diff

- `BuildNoShowHistoryContextAsync` private helper signature: `User viewer` → `Guid viewerId`. One call site, one method.
- Two test fixtures (`ProfileControllerEmailGridTests`, `ProfileControllerEditTests`) gain a default `IUserService.GetUserInfoAsync` stub mirroring the `UserInfoStubHelpers` pattern introduced in PR #564.

## What's next (slice 2+)

Plan in `local/user-cache-migration-plan.md`:
- **Slice 2** — sweep the other 90 controller sites + ViewComponents + `EventsApiController`'s 6 direct `_userManager.GetUserAsync(User)` calls.
- **Slice 3** — Profile-side reader migration (`IProfileService.GetProfileAsync` / `GetByUserIdsAsync` → `UserInfo.Profile`, ~12 sites).
- **Slice 4** — `FindByIdAsync` readers + `IUserRepository` direct-injection cleanup.

## Test plan

- [x] `dotnet build Humans.slnx -v quiet` — 0 warnings, 0 errors
- [x] `dotnet test Humans.slnx -v quiet --filter "FullyQualifiedName!~Humans.Integration"` — 3300 passed (+1 skipped, pre-existing)
- [ ] Smoke `/Profile/Me`, `/Profile/Me/Edit`, `/Profile/Me/Emails` (self + admin grid), `/Profile/Me/Privacy`, `/Profile/Me/ShiftInfo`, `/Profile/Me/CommunicationPreferences` in the preview env
- [ ] Smoke an admin per-person detail page → SuspendHuman / ApproveVolunteer / RejectSignup / role add+end actions
- [ ] Confirm `/Admin/CacheStats` `User.UserInfo` hit rate goes up on a refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)