### PR TITLE
feat(tickets): wire UpSet plot hover-highlight

### DIFF
--- a/src/Humans.Web/Views/Ticket/Index.cshtml
+++ b/src/Humans.Web/Views/Ticket/Index.cshtml
@@ -445,12 +445,16 @@
                 for (var i = 0; i < allThree; i++)      elems.push({ name: 'a' + i,  sets: ['Profile', 'Ticket', 'Shift'] });
                 var sets = window.UpSetJS.extractSets(elems);
                 var combinations = window.UpSetJS.generateCombinations(sets);
-                window.UpSetJS.render(upset, {
+                var props = {
                     sets: sets,
                     combinations: combinations,
                     width: 400,
-                    height: 360
-                });
+                    height: 360,
+                    selection: null
+                };
+                function rerender() { window.UpSetJS.render(upset, props); }
+                props.onHover = function (s) { props.selection = s; rerender(); };
+                rerender();
             }
         });
     </script>


### PR DESCRIPTION
## Summary

The UpSet plot on `/Tickets` has been rendered statically since it landed in #546. UpSetJS's hover/click feedback is opt-in — the bare `render({ sets, combinations, ... })` call produces a non-interactive chart. Wires `props.onHover` to update `props.selection` and re-render, giving the bar/dot highlight effect the upsetjs.org demos show by default.

No `onClick` yet — the rendered elements are synthetic placeholders (`{ name: 'p' + i, sets: [...] }`) built only to drive the count buckets, so there's no real user id to drill into. Easy follow-up if we want a backend endpoint for "users in this intersection".

## Test plan

- [x] `dotnet build Humans.slnx -v quiet` clean
- [ ] Preview env: hover bars / matrix dots on the UpSet plot, confirm the highlight tracks the cursor and clears on mouse-out