### PR TITLE
refactor(user-cache): drain 18 readers onto UserInfo.Profile (Slice 3)

### DIFF
--- a/src/Humans.Application/Helpers/ProfileCompletion.cs
+++ b/src/Humans.Application/Helpers/ProfileCompletion.cs
@@ -1,3 +1,4 @@
+using Humans.Application;
 using Humans.Domain.Entities;
 
 namespace Humans.Application.Helpers;
@@ -60,6 +61,34 @@ public static class ProfileCompletion
             (profile.VolunteerHistory.Count > 0 || profile.NoPriorBurnExperience, 2),
 
             // Shift tag preferences (separate table; caller passes a bool).
+            (hasShiftTagPreferences, 1),
+        };
+
+        var earned = checks.Where(c => c.Filled).Sum(c => c.Weight);
+        var total = checks.Sum(c => c.Weight);
+        return (int)Math.Round(100.0 * earned / total);
+    }
+
+    public static int ComputePercent(ProfileInfo? profile, bool hasShiftTagPreferences)
+    {
+        if (profile is null) return 0;
+
+        var checks = new (bool Filled, int Weight)[]
+        {
+            (!string.IsNullOrWhiteSpace(profile.BurnerName), 1),
+            (!string.IsNullOrWhiteSpace(profile.FirstName), 1),
+            (!string.IsNullOrWhiteSpace(profile.LastName), 1),
+            (profile.HasCustomPicture, 5),
+            (!string.IsNullOrWhiteSpace(profile.Pronouns), 1),
+            (!string.IsNullOrWhiteSpace(profile.Bio), 2),
+            (!string.IsNullOrWhiteSpace(profile.City) && !string.IsNullOrWhiteSpace(profile.CountryCode), 1),
+            (profile.BirthdayDay.HasValue && profile.BirthdayMonth.HasValue, 1),
+            (!string.IsNullOrWhiteSpace(profile.ContributionInterests), 2),
+            (!string.IsNullOrWhiteSpace(profile.EmergencyContactName)
+                || !string.IsNullOrWhiteSpace(profile.EmergencyContactPhone)
+                || !string.IsNullOrWhiteSpace(profile.EmergencyContactRelationship), 1),
+            (profile.Languages.Count > 0, 1),
+            (profile.VolunteerHistory.Count > 0 || profile.NoPriorBurnExperience, 2),
             (hasShiftTagPreferences, 1),
         };
 

--- a/src/Humans.Application/Interfaces/Profiles/IProfileService.cs
+++ b/src/Humans.Application/Interfaces/Profiles/IProfileService.cs
@@ -18,18 +18,6 @@ namespace Humans.Application.Interfaces.Profiles;
 /// </remarks>
 public interface IProfileService : IApplicationService, IUserMerge
 {
-    Task<Profile?> GetProfileAsync(Guid userId, CancellationToken ct = default);
-
-    /// <summary>
-    /// Batched profile fetch keyed by user id. Missing users are absent
-    /// from the returned dictionary. Used by cross-section services that
-    /// need to stitch profile slices in memory instead of pulling them
-    /// through a cross-domain <c>.Include</c> chain.
-    /// </summary>
-    Task<IReadOnlyDictionary<Guid, Profile>> GetByUserIdsAsync(
-        IReadOnlyCollection<Guid> userIds,
-        CancellationToken ct = default);
-
     /// <summary>
     /// Issue #635 (§15i): idempotently materialize a <see cref="ProfileState.Stub"/>
     /// Profile row for the given user. Called by User-creation paths

--- a/src/Humans.Application/Interfaces/Users/IUserService.cs
+++ b/src/Humans.Application/Interfaces/Users/IUserService.cs
@@ -19,6 +19,19 @@ namespace Humans.Application.Interfaces.Users;
 public interface IUserService : IApplicationService, IUserMerge
 {
     /// <summary>
+    /// True once the UserInfo cache has been fully populated by the startup
+    /// warmup. Stays false if warmup failed or has not yet completed. Reads
+    /// against <see cref="GetAllUserInfos"/> are only trustworthy as a
+    /// "complete picture" when this is true — destructive bulk reconciliation
+    /// jobs MUST guard on this flag, otherwise an empty post-warmup-failure
+    /// cache will be misread as "no one is eligible" and deprovision every
+    /// affected user. Per-user reads (<see cref="GetUserInfoAsync"/>,
+    /// <see cref="GetUserInfosAsync"/>) lazily fill the cache and are safe
+    /// regardless.
+    /// </summary>
+    bool IsWarmedUp { get; }
+
+    /// <summary>
     /// Returns the unified <see cref="UserInfo"/> read-model for the given
     /// user, stitched from <c>users</c>, <c>user_emails</c>,
     /// <c>event_participations</c>, <c>user_logins</c>, <c>profiles</c>,

--- a/src/Humans.Application/Services/AuditLog/AuditViewerService.cs
+++ b/src/Humans.Application/Services/AuditLog/AuditViewerService.cs
@@ -1,6 +1,6 @@
 using Humans.Application.Interfaces.AuditLog;
-using Humans.Application.Interfaces.Profiles;
 using Humans.Application.Interfaces.Teams;
+using Humans.Application.Interfaces.Users;
 using Humans.Domain.Entities;
 
 namespace Humans.Application.Services.AuditLog;
@@ -11,25 +11,25 @@ namespace Humans.Application.Services.AuditLog;
 /// <remarks>
 /// Pure read-side service — wraps <see cref="IAuditLogService"/> for the raw
 /// queries and resolves actor, subject, and target-team names via
-/// <see cref="IProfileService"/> and <see cref="ITeamService"/>. No DB access,
+/// <see cref="IUserService"/> and <see cref="ITeamService"/>. No DB access,
 /// no caching, no merge-chain logic of its own — those concerns stay in
 /// <see cref="IAuditLogService"/> where the audit-log table is owned.
 /// </remarks>
 public sealed class AuditViewerService : IAuditViewerService
 {
     private readonly IAuditLogService _auditLog;
-    private readonly IProfileService _profileService;
+    private readonly IUserService _userService;
     private readonly ITeamService _teamService;
     private readonly ITeamResourceService _teamResourceService;
 
     public AuditViewerService(
         IAuditLogService auditLog,
-        IProfileService profileService,
+        IUserService userService,
         ITeamService teamService,
         ITeamResourceService teamResourceService)
     {
         _auditLog = auditLog;
-        _profileService = profileService;
+        _userService = userService;
         _teamService = teamService;
         _teamResourceService = teamResourceService;
     }
@@ -220,14 +220,14 @@ public sealed class AuditViewerService : IAuditViewerService
     private async Task<Dictionary<Guid, string>> GetUserDisplayNamesAsync(
         IReadOnlyList<Guid> userIds, CancellationToken ct)
     {
-        // Use IProfileService so BurnerName is returned when the profile has one
+        // BurnerName is returned when the profile has one
         // (memory/architecture/burnername-is-the-display-name.md). For users
         // without a profile, or with a null BurnerName (Stub), the entry is
         // absent from the dict — callers already handle null display names.
-        var profiles = await _profileService.GetByUserIdsAsync(userIds, ct);
-        return profiles
-            .Where(kvp => !string.IsNullOrWhiteSpace(kvp.Value.BurnerName))
-            .ToDictionary(kvp => kvp.Key, kvp => kvp.Value.BurnerName!);
+        var users = await _userService.GetUserInfosAsync(userIds, ct);
+        return users
+            .Where(kvp => !string.IsNullOrWhiteSpace(kvp.Value.Profile?.BurnerName))
+            .ToDictionary(kvp => kvp.Key, kvp => kvp.Value.Profile!.BurnerName!);
     }
 
     private async Task<Dictionary<Guid, (string Name, string Slug)>> GetTeamNamesAsync(

--- a/src/Humans.Application/Services/Dashboard/DashboardService.cs
+++ b/src/Humans.Application/Services/Dashboard/DashboardService.cs
@@ -2,7 +2,6 @@ using Humans.Application.Configuration;
 using Humans.Application.Helpers;
 using Humans.Application.Interfaces.Dashboard;
 using Humans.Application.Interfaces.Governance;
-using Humans.Application.Interfaces.Profiles;
 using Humans.Application.Interfaces.Shifts;
 using Humans.Application.Interfaces.Teams;
 using Humans.Application.Interfaces.Tickets;
@@ -23,7 +22,6 @@ namespace Humans.Application.Services.Dashboard;
 /// </summary>
 public class DashboardService : IDashboardService
 {
-    private readonly IProfileService _profileService;
     private readonly IMembershipCalculator _membershipCalculator;
     private readonly IApplicationDecisionService _applicationDecisionService;
     private readonly IShiftManagementService _shiftMgmt;
@@ -36,7 +34,6 @@ public class DashboardService : IDashboardService
     private readonly ILogger<DashboardService> _logger;
 
     public DashboardService(
-        IProfileService profileService,
         IMembershipCalculator membershipCalculator,
         IApplicationDecisionService applicationDecisionService,
         IShiftManagementService shiftMgmt,
@@ -48,7 +45,6 @@ public class DashboardService : IDashboardService
         IClock clock,
         ILogger<DashboardService> logger)
     {
-        _profileService = profileService;
         _membershipCalculator = membershipCalculator;
         _applicationDecisionService = applicationDecisionService;
         _shiftMgmt = shiftMgmt;
@@ -68,7 +64,8 @@ public class DashboardService : IDashboardService
     {
         _ = isPrivileged; // Retained for future privileged-only fields; no current effect.
 
-        var profile = await _profileService.GetProfileAsync(userId, cancellationToken);
+        var userInfo = await _userService.GetUserInfoAsync(userId, cancellationToken);
+        var profile = userInfo?.Profile;
         var shiftTagPreferences = await _shiftMgmt.GetVolunteerTagPreferencesAsync(userId);
         var dashboardProfile = profile is null
             ? null

--- a/src/Humans.Application/Services/Expenses/ExpenseReportService.cs
+++ b/src/Humans.Application/Services/Expenses/ExpenseReportService.cs
@@ -568,17 +568,17 @@ public sealed class ExpenseReportService : IExpenseReportService, IUserDataContr
         Guid submitterUserId, string? iban, CancellationToken ct = default)
     {
         var ibanValue = string.IsNullOrWhiteSpace(iban) ? null : iban.Trim();
-        var profile = await _profileService.GetProfileAsync(submitterUserId, ct);
+        var existingIban = (await _userService.GetUserInfoAsync(submitterUserId, ct))?.Profile?.Iban;
 
         if (ibanValue is not null && !IbanValidator.IsValid(ibanValue))
-            return IbanFailure("Invalid IBAN format.", isValidationError: true, profile);
+            return IbanFailure("Invalid IBAN format.", isValidationError: true, existingIban);
 
         var normalized = ibanValue is null ? null : IbanValidator.Normalize(ibanValue);
         try
         {
             var saved = await _profileService.SetIbanAsync(submitterUserId, normalized, ct);
             if (!saved)
-                return IbanFailure("Failed to save IBAN.", isValidationError: false, profile);
+                return IbanFailure("Failed to save IBAN.", isValidationError: false, existingIban);
 
             return new ExpenseIbanSaveResult(
                 Succeeded: true,
@@ -590,29 +590,29 @@ public sealed class ExpenseReportService : IExpenseReportService, IUserDataContr
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error setting IBAN for user {UserId}", submitterUserId);
-            return IbanFailure("Failed to save IBAN.", isValidationError: false, profile);
+            return IbanFailure("Failed to save IBAN.", isValidationError: false, existingIban);
         }
     }
 
     public async Task<ExpenseIbanViewData> GetSubmitterIbanViewAsync(
         Guid submitterUserId, CancellationToken ct = default)
     {
-        var profile = await _profileService.GetProfileAsync(submitterUserId, ct);
-        var hasIban = !string.IsNullOrEmpty(profile?.Iban);
+        var iban = (await _userService.GetUserInfoAsync(submitterUserId, ct))?.Profile?.Iban;
+        var hasIban = !string.IsNullOrEmpty(iban);
         return new ExpenseIbanViewData(
             HasIban: hasIban,
-            MaskedIban: hasIban ? IbanFormatter.Mask(profile!.Iban!) : null);
+            MaskedIban: hasIban ? IbanFormatter.Mask(iban!) : null);
     }
 
-    private static ExpenseIbanSaveResult IbanFailure(string message, bool isValidationError, Profile? profile)
+    private static ExpenseIbanSaveResult IbanFailure(string message, bool isValidationError, string? existingIban)
     {
-        var hasIban = !string.IsNullOrEmpty(profile?.Iban);
+        var hasIban = !string.IsNullOrEmpty(existingIban);
         return new ExpenseIbanSaveResult(
             Succeeded: false,
             IsValidationError: isValidationError,
             Message: message,
             HasIban: hasIban,
-            MaskedIban: hasIban ? IbanFormatter.Mask(profile!.Iban!) : null);
+            MaskedIban: hasIban ? IbanFormatter.Mask(existingIban!) : null);
     }
 
     public async Task<bool> CoordinatorEndorseAsync(

--- a/src/Humans.Application/Services/Feedback/FeedbackService.cs
+++ b/src/Humans.Application/Services/Feedback/FeedbackService.cs
@@ -24,8 +24,8 @@ namespace Humans.Application.Services.Feedback;
 /// never imports <c>Microsoft.EntityFrameworkCore</c>, enforced by
 /// <c>Humans.Application.csproj</c>'s reference graph. Cross-section reads
 /// (reporter/assignee/resolver display names, team names, effective emails)
-/// go through <see cref="IUserService"/>, <see cref="IProfileService"/>,
-/// <see cref="ITeamService"/>, and <see cref="IUserEmailService"/>, and are
+/// go through <see cref="IUserService"/>, <see cref="ITeamService"/>, and
+/// <see cref="IUserEmailService"/>, and are
 /// projected into <see cref="FeedbackReportInfo"/> / <see cref="FeedbackMessageInfo"/>
 /// records before returning. Nav-badge cache invalidation is routed through
 /// <see cref="INavBadgeCacheInvalidator"/> rather than <c>IMemoryCache</c> directly.
@@ -36,7 +36,6 @@ public sealed class FeedbackService : IFeedbackService, IUserDataContributor, IU
     private readonly IUserService _userService;
     private readonly IUserEmailService _userEmailService;
     private readonly ITeamService _teamService;
-    private readonly IProfileService _profileService;
     private readonly IEmailService _emailService;
     private readonly INotificationService _notificationService;
     private readonly IAuditLogService _auditLogService;
@@ -57,7 +56,6 @@ public sealed class FeedbackService : IFeedbackService, IUserDataContributor, IU
         IUserService userService,
         IUserEmailService userEmailService,
         ITeamService teamService,
-        IProfileService profileService,
         IEmailService emailService,
         INotificationService notificationService,
         IAuditLogService auditLogService,
@@ -70,7 +68,6 @@ public sealed class FeedbackService : IFeedbackService, IUserDataContributor, IU
         _userService = userService;
         _userEmailService = userEmailService;
         _teamService = teamService;
-        _profileService = profileService;
         _emailService = emailService;
         _notificationService = notificationService;
         _auditLogService = auditLogService;
@@ -446,8 +443,7 @@ public sealed class FeedbackService : IFeedbackService, IUserDataContributor, IU
             return [];
 
         var userIds = rows.Select(r => r.UserId).ToHashSet();
-        var users = await _userService.GetByIdsAsync(userIds, cancellationToken);
-        var displayNames = await BuildDisplayNamesAsync(userIds, users, cancellationToken);
+        var displayNames = await BuildDisplayNamesAsync(userIds, cancellationToken);
 
         return rows
             .Select(r =>
@@ -559,25 +555,24 @@ public sealed class FeedbackService : IFeedbackService, IUserDataContributor, IU
             }
         }
 
-        return await BuildDisplayNamesAsync(userIds, users, ct);
+        return await BuildDisplayNamesAsync(userIds, ct);
     }
 
-    // Resolves display names using the BurnerName-first rule (memory/architecture/burnername-is-the-display-name.md):
-    // Profile.BurnerName when present, else User.DisplayName. Mirrors the BurnerName-or-DisplayName fallback used everywhere else.
+    // Resolves display names via UserInfo.BurnerName, which implements the
+    // BurnerName-first fallback (memory/architecture/burnername-is-the-display-name.md):
+    // Profile.BurnerName when present, else User.DisplayName.
     private async Task<IReadOnlyDictionary<Guid, string>> BuildDisplayNamesAsync(
         IReadOnlyCollection<Guid> userIds,
-        IReadOnlyDictionary<Guid, User>? users,
         CancellationToken ct)
     {
-        if (userIds.Count == 0 || users is null) return EmptyDisplayNames;
+        if (userIds.Count == 0) return EmptyDisplayNames;
 
-        var profiles = await _profileService.GetByUserIdsAsync(userIds, ct);
+        var infos = await _userService.GetUserInfosAsync(userIds, ct);
         var result = new Dictionary<Guid, string>(userIds.Count);
         foreach (var id in userIds)
         {
-            if (!users.TryGetValue(id, out var user)) continue;
-            var burnerName = profiles.TryGetValue(id, out var profile) ? profile.BurnerName : null;
-            result[id] = !string.IsNullOrWhiteSpace(burnerName) ? burnerName : user.DisplayName;
+            if (infos.TryGetValue(id, out var info))
+                result[id] = info.BurnerName;
         }
         return result;
     }

--- a/src/Humans.Application/Services/GoogleIntegration/GoogleGroupSyncService.cs
+++ b/src/Humans.Application/Services/GoogleIntegration/GoogleGroupSyncService.cs
@@ -28,7 +28,6 @@ public sealed class GoogleGroupSyncService : IGoogleGroupSync
     private readonly ITeamService _teamService;
     private readonly IUserService _userService;
     private readonly IUserEmailService _userEmailService;
-    private readonly IProfileService _profileService;
     private readonly ISyncSettingsService _syncSettingsService;
     private readonly IAuditLogService _auditLogService;
     private readonly IGoogleRemovalNotificationService _removalNotifications;
@@ -46,7 +45,6 @@ public sealed class GoogleGroupSyncService : IGoogleGroupSync
         ITeamService teamService,
         IUserService userService,
         IUserEmailService userEmailService,
-        IProfileService profileService,
         ISyncSettingsService syncSettingsService,
         IAuditLogService auditLogService,
         IGoogleRemovalNotificationService removalNotifications,
@@ -63,7 +61,6 @@ public sealed class GoogleGroupSyncService : IGoogleGroupSync
         _teamService = teamService;
         _userService = userService;
         _userEmailService = userEmailService;
-        _profileService = profileService;
         _syncSettingsService = syncSettingsService;
         _auditLogService = auditLogService;
         _removalNotifications = removalNotifications;
@@ -358,7 +355,6 @@ public sealed class GoogleGroupSyncService : IGoogleGroupSync
 
         var users = await _userService.GetUserInfosAsync(userIds, ct);
         var emailsByUserId = await _userEmailService.GetEntitiesByUserIdsAsync(userIds, ct);
-        var profilesByUserId = await _profileService.GetByUserIdsAsync(userIds, ct);
 
         var result = new Dictionary<Guid, ExpectedMember>();
         foreach (var userId in userIds)
@@ -367,16 +363,15 @@ public sealed class GoogleGroupSyncService : IGoogleGroupSync
                 continue;
             if (user.GoogleEmailStatus == GoogleEmailStatus.Rejected || user.IsDeletionPending || user.MergedToUserId is not null)
                 continue;
-            profilesByUserId.TryGetValue(userId, out var profile);
-            if (profile is not null && IsSuspended(profile))
+            if (user.IsSuspended)
                 continue;
 
             var email = TryGetGoogleEmail(userId, emailsByUserId);
             if (email is null)
                 continue;
 
-            var displayName = profile is not null && !string.IsNullOrWhiteSpace(profile.BurnerName)
-                ? profile.BurnerName
+            var displayName = !string.IsNullOrWhiteSpace(user.Profile?.BurnerName)
+                ? user.Profile!.BurnerName
                 : user.DisplayName;
 
             result[user.Id] = new ExpectedMember(user.Id, email, displayName, user.ProfilePictureUrl);
@@ -416,16 +411,6 @@ public sealed class GoogleGroupSyncService : IGoogleGroupSync
                 .OrderBy(e => e.Email, StringComparer.OrdinalIgnoreCase)
                 .Select(e => e.Email)
                 .FirstOrDefault();
-    }
-
-    private static bool IsSuspended(Profile profile)
-    {
-        if (profile.State == ProfileState.Suspended)
-            return true;
-
-#pragma warning disable HUM_PROFILE_ISSUSPENDED
-        return profile.IsSuspended;
-#pragma warning restore HUM_PROFILE_ISSUSPENDED
     }
 
     private async Task<ResourceSyncDiff> BuildCollisionDiffAsync(

--- a/src/Humans.Application/Services/Governance/MembershipCalculator.cs
+++ b/src/Humans.Application/Services/Governance/MembershipCalculator.cs
@@ -7,7 +7,6 @@ using Humans.Application.Interfaces.Consent;
 using Humans.Application.Interfaces.Legal;
 using Humans.Application.Interfaces.Users;
 using Humans.Application.Interfaces.Governance;
-using Humans.Application.Interfaces.Profiles;
 
 namespace Humans.Application.Services.Governance;
 
@@ -28,7 +27,6 @@ namespace Humans.Application.Services.Governance;
 /// </summary>
 public sealed class MembershipCalculator : IMembershipCalculator
 {
-    private readonly IProfileService _profileService;
     // Team + role reads go through IMembershipQuery (not ITeamService /
     // IRoleAssignmentService directly) to break a circular DI graph: both of
     // those services inject ISystemTeamSync, whose implementation injects
@@ -46,14 +44,12 @@ public sealed class MembershipCalculator : IMembershipCalculator
     private readonly IClock _clock;
 
     public MembershipCalculator(
-        IProfileService profileService,
         IMembershipQuery membershipQuery,
         IUserService userService,
         ILegalDocumentSyncService legalDocumentSyncService,
         IServiceProvider serviceProvider,
         IClock clock)
     {
-        _profileService = profileService;
         _membershipQuery = membershipQuery;
         _userService = userService;
         _legalDocumentSyncService = legalDocumentSyncService;
@@ -354,22 +350,22 @@ public sealed class MembershipCalculator : IMembershipCalculator
     {
         var allIds = userIds.ToList();
 
-        // Pull users and profiles through their owning services — no direct
-        // DbContext access. Missing entities are simply absent from the maps.
+        // Pull users (UserInfo carries the profile slice) through the cache —
+        // no direct DbContext access. Missing entities are simply absent from
+        // the map.
         var usersById = await _userService.GetUserInfosAsync(allIds, ct);
-        var profilesByUserId = await _profileService.GetByUserIdsAsync(allIds, ct);
 
         // 1. PendingDeletion — DeletionRequestedAt is not null (highest priority)
         var pendingDeletion = allIds
             .Where(id => usersById.TryGetValue(id, out var u) && u.DeletionRequestedAt != null)
             .ToHashSet();
 
-        // 2. IncompleteSignup — no Profile entity
+        // 2. IncompleteSignup — no Profile slice
         var remaining = allIds.Where(id => !pendingDeletion.Contains(id)).ToList();
         var incompleteSignup = new HashSet<Guid>();
         foreach (var id in remaining)
         {
-            if (!profilesByUserId.ContainsKey(id))
+            if (!usersById.TryGetValue(id, out var u) || u.Profile is null)
             {
                 incompleteSignup.Add(id);
             }
@@ -377,11 +373,11 @@ public sealed class MembershipCalculator : IMembershipCalculator
 
         remaining = remaining.Where(id => !incompleteSignup.Contains(id)).ToList();
 
-        // 3. Suspended — Profile.IsSuspended
+        // 3. Suspended — UserInfo.IsSuspended (State == Suspended)
         var suspended = new HashSet<Guid>();
         foreach (var id in remaining)
         {
-            if (profilesByUserId[id].IsSuspended)
+            if (usersById[id].IsSuspended)
             {
                 suspended.Add(id);
             }
@@ -393,9 +389,10 @@ public sealed class MembershipCalculator : IMembershipCalculator
         var pendingApproval = new HashSet<Guid>();
         foreach (var id in remaining)
         {
-            if (!profilesByUserId[id].IsApproved)
+            var profile = usersById[id].Profile!;
+            if (!profile.IsApproved)
             {
-                if (profilesByUserId[id].RejectedAt is not null)
+                if (profile.RejectedAt is not null)
                 {
                     incompleteSignup.Add(id);
                 }

--- a/src/Humans.Application/Services/Onboarding/OnboardingService.cs
+++ b/src/Humans.Application/Services/Onboarding/OnboardingService.cs
@@ -104,7 +104,7 @@ public sealed class OnboardingService : IOnboardingService
 
     public async Task<ReviewDetailData> GetReviewDetailAsync(Guid userId, CancellationToken ct = default)
     {
-        var profile = await _profileService.GetProfileAsync(userId, ct);
+        var profile = (await _userService.GetUserInfoAsync(userId, ct))?.Profile;
 
         if (profile is null)
             return new ReviewDetailData(null, 0, 0, null);

--- a/src/Humans.Application/Services/Profiles/AdminHumanListAssembler.cs
+++ b/src/Humans.Application/Services/Profiles/AdminHumanListAssembler.cs
@@ -1,7 +1,6 @@
 using Humans.Application.DTOs;
 using Humans.Application.Interfaces.Governance;
 using Humans.Domain.Constants;
-using ProfileEntity = Humans.Domain.Entities.Profile;
 
 namespace Humans.Application.Services.Profiles;
 
@@ -26,7 +25,6 @@ public static class AdminHumanListAssembler
 {
     public static async Task<IReadOnlyList<AdminHumanRow>> AssembleAsync(
         IReadOnlyCollection<UserInfo> allUsers,
-        IReadOnlyDictionary<Guid, ProfileEntity> profilesByUserId,
         IReadOnlyDictionary<Guid, string> notificationEmailsByUserId,
         IReadOnlySet<Guid>? searchUserIds,
         string? statusFilter,
@@ -34,7 +32,6 @@ public static class AdminHumanListAssembler
         CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(allUsers);
-        ArgumentNullException.ThrowIfNull(profilesByUserId);
         ArgumentNullException.ThrowIfNull(notificationEmailsByUserId);
         ArgumentNullException.ThrowIfNull(membershipCalculator);
 
@@ -62,9 +59,8 @@ public static class AdminHumanListAssembler
 
         return rows.Select(u =>
         {
-            profilesByUserId.TryGetValue(u.Id, out var profile);
-            var hasProfile = profile is not null;
-            var isApproved = profile?.IsApproved ?? false;
+            var hasProfile = u.Profile is not null;
+            var isApproved = u.Profile?.IsApproved ?? false;
 
             var email = notificationEmailsByUserId.TryGetValue(u.Id, out var primary)
                 ? primary

--- a/src/Humans.Application/Services/Profiles/ProfileService.cs
+++ b/src/Humans.Application/Services/Profiles/ProfileService.cs
@@ -68,15 +68,6 @@ public sealed class ProfileService : IProfileService, IUserDataContributor, IUse
         _logger = logger;
     }
 
-    public async Task<Profile?> GetProfileAsync(Guid userId, CancellationToken ct = default)
-    {
-        return await _profileRepository.GetByUserIdReadOnlyAsync(userId, ct);
-    }
-
-    public async Task<IReadOnlyDictionary<Guid, Profile>> GetByUserIdsAsync(
-        IReadOnlyCollection<Guid> userIds, CancellationToken ct = default) =>
-        await _profileRepository.GetByUserIdsAsync(userIds, ct);
-
     public async Task SetMembershipTierAsync(
         Guid userId, MembershipTier tier, CancellationToken ct = default)
     {

--- a/src/Humans.Application/Services/Profiles/ProfileService.cs
+++ b/src/Humans.Application/Services/Profiles/ProfileService.cs
@@ -29,6 +29,7 @@ public sealed class ProfileService : IProfileService, IUserDataContributor, IUse
     private readonly ICommunicationPreferenceRepository _communicationPreferenceRepository;
     private readonly IAuditLogService _auditLogService;
     private readonly IFileStorage _fileStorage;
+    private readonly IUserInfoInvalidator _userInfoInvalidator;
     private readonly IClock _clock;
     private readonly ILogger<ProfileService> _logger;
 
@@ -54,6 +55,7 @@ public sealed class ProfileService : IProfileService, IUserDataContributor, IUse
         ICommunicationPreferenceRepository communicationPreferenceRepository,
         IAuditLogService auditLogService,
         IFileStorage fileStorage,
+        IUserInfoInvalidator userInfoInvalidator,
         IClock clock,
         ILogger<ProfileService> logger)
     {
@@ -64,6 +66,7 @@ public sealed class ProfileService : IProfileService, IUserDataContributor, IUse
         _communicationPreferenceRepository = communicationPreferenceRepository;
         _auditLogService = auditLogService;
         _fileStorage = fileStorage;
+        _userInfoInvalidator = userInfoInvalidator;
         _clock = clock;
         _logger = logger;
     }
@@ -82,8 +85,7 @@ public sealed class ProfileService : IProfileService, IUserDataContributor, IUse
         profile.MembershipTier = tier;
         profile.UpdatedAt = _clock.GetCurrentInstant();
         await _profileRepository.UpdateAsync(profile, ct);
-
-        // Store update handled by CachingUserService decorator
+        await _userInfoInvalidator.InvalidateAsync(userId, ct);
     }
 
     public async Task EnsureStubProfileAsync(Guid userId, CancellationToken ct = default)
@@ -105,6 +107,7 @@ public sealed class ProfileService : IProfileService, IUserDataContributor, IUse
                 State = ProfileState.Stub,
             };
             await _profileRepository.AddAsync(profile, ct);
+            await _userInfoInvalidator.InvalidateAsync(userId, ct);
         }
         finally
         {
@@ -137,6 +140,7 @@ public sealed class ProfileService : IProfileService, IUserDataContributor, IUse
         profile.ProfilePictureContentType = contentType;
         profile.UpdatedAt = _clock.GetCurrentInstant();
         await _profileRepository.UpdateAsync(profile, ct);
+        await _userInfoInvalidator.InvalidateAsync(userId, ct);
 
         try
         {
@@ -388,7 +392,7 @@ public sealed class ProfileService : IProfileService, IUserDataContributor, IUse
         // Update display name on user (cross-section → IUserService)
         await _userService.UpdateDisplayNameAsync(userId, displayName, ct);
 
-        // Cache invalidation and store update handled by CachingUserService decorator
+        await _userInfoInvalidator.InvalidateAsync(userId, ct);
 
         _logger.LogInformation("User {UserId} updated their profile", userId);
 
@@ -424,6 +428,7 @@ public sealed class ProfileService : IProfileService, IUserDataContributor, IUse
         if (profile is null) return;
 
         await _profileRepository.ReconcileCVEntriesAsync(profile.Id, entries, ct);
+        await _userInfoInvalidator.InvalidateAsync(userId, ct);
     }
 
     public async Task<IReadOnlyList<ProfileLanguageSnapshot>> GetProfileLanguagesAsync(
@@ -437,8 +442,13 @@ public sealed class ProfileService : IProfileService, IUserDataContributor, IUse
             l.Proficiency)).ToList();
     }
 
-    public Task SaveProfileLanguagesAsync(Guid profileId, IReadOnlyList<ProfileLanguage> languages, CancellationToken ct = default) =>
-        _profileRepository.ReplaceLanguagesAsync(profileId, languages, ct);
+    public async Task SaveProfileLanguagesAsync(Guid profileId, IReadOnlyList<ProfileLanguage> languages, CancellationToken ct = default)
+    {
+        await _profileRepository.ReplaceLanguagesAsync(profileId, languages, ct);
+        var ownerUserId = await _profileRepository.GetOwnerUserIdAsync(profileId, ct);
+        if (ownerUserId is { } userId)
+            await _userInfoInvalidator.InvalidateAsync(userId, ct);
+    }
 
     // ==========================================================================
     // Volunteer Event Profiles — cross-section reads (§15 Step 1 quarantine)
@@ -566,8 +576,8 @@ public sealed class ProfileService : IProfileService, IUserDataContributor, IUse
     // ==========================================================================
     // Onboarding-section support methods — profile mutations that OnboardingService
     // delegates here so each section owns its DbSet writes (design-rules §2c).
-    // Cache invalidation (UserInfo refresh, nav-badge, notification meter) is
-    // handled by the CachingUserService decorator's wrappers for these methods.
+    // Each write invalidates the UserInfo cache so downstream readers see the
+    // committed state immediately.
     // ==========================================================================
 
     public async Task<OnboardingResult> RecordConsentCheckAsync(
@@ -600,6 +610,7 @@ public sealed class ProfileService : IProfileService, IUserDataContributor, IUse
         profile.UpdatedAt = now;
 
         await _profileRepository.UpdateAsync(profile, ct);
+        await _userInfoInvalidator.InvalidateAsync(userId, ct);
 
         await _auditLogService.LogAsync(
             cleared ? AuditAction.ConsentCheckCleared : AuditAction.ConsentCheckFlagged,
@@ -633,6 +644,7 @@ public sealed class ProfileService : IProfileService, IUserDataContributor, IUse
         profile.UpdatedAt = now;
 
         await _profileRepository.UpdateAsync(profile, ct);
+        await _userInfoInvalidator.InvalidateAsync(userId, ct);
 
         await _auditLogService.LogAsync(
             AuditAction.SignupRejected, nameof(Profile), userId,
@@ -657,6 +669,7 @@ public sealed class ProfileService : IProfileService, IUserDataContributor, IUse
         profile.UpdatedAt = now;
 
         await _profileRepository.UpdateAsync(profile, ct);
+        await _userInfoInvalidator.InvalidateAsync(userId, ct);
 
         await _auditLogService.LogAsync(
             AuditAction.VolunteerApproved, nameof(User), userId,
@@ -699,6 +712,7 @@ public sealed class ProfileService : IProfileService, IUserDataContributor, IUse
         profile.UpdatedAt = _clock.GetCurrentInstant();
 
         await _profileRepository.UpdateAsync(profile, ct);
+        await _userInfoInvalidator.InvalidateAsync(userId, ct);
 
         await _auditLogService.LogAsync(
             suspended ? AuditAction.MemberSuspended : AuditAction.MemberUnsuspended,
@@ -724,6 +738,7 @@ public sealed class ProfileService : IProfileService, IUserDataContributor, IUse
         profile.ConsentCheckStatus = ConsentCheckStatus.Pending;
         profile.UpdatedAt = _clock.GetCurrentInstant();
         await _profileRepository.UpdateAsync(profile, ct);
+        await _userInfoInvalidator.InvalidateAsync(userId, ct);
 
         _logger.LogInformation(
             "User {UserId} has all consents signed, consent check set to Pending", userId);
@@ -744,6 +759,8 @@ public sealed class ProfileService : IProfileService, IUserDataContributor, IUse
         // an operator can clean up the stale file out-of-band.
         var profile = await _profileRepository.GetByUserIdReadOnlyAsync(userId, ct);
         var anonymized = await _profileRepository.AnonymizeForDeletionByUserIdAsync(userId, ct);
+        if (anonymized)
+            await _userInfoInvalidator.InvalidateAsync(userId, ct);
         if (anonymized && profile?.ProfilePictureContentType is not null)
         {
             try
@@ -787,28 +804,39 @@ public sealed class ProfileService : IProfileService, IUserDataContributor, IUse
         _ => string.Empty
     };
 
-    public Task<IReadOnlySet<Guid>> SuspendForMissingConsentAsync(
+    public async Task<IReadOnlySet<Guid>> SuspendForMissingConsentAsync(
         IReadOnlyCollection<Guid> userIds,
         Instant now,
-        CancellationToken ct = default) =>
-        _profileRepository.SuspendManyAsync(userIds, now, ct);
+        CancellationToken ct = default)
+    {
+        var mutated = await _profileRepository.SuspendManyAsync(userIds, now, ct);
+        foreach (var id in mutated)
+            await _userInfoInvalidator.InvalidateAsync(id, ct);
+        return mutated;
+    }
 
-    public Task<IReadOnlyList<(Guid UserId, MembershipTier NewTier)>>
+    public async Task<IReadOnlyList<(Guid UserId, MembershipTier NewTier)>>
         DowngradeTierForExpiredAsync(
             MembershipTier currentTier,
             IReadOnlyCollection<Guid> userIdsToKeep,
             IReadOnlyDictionary<Guid, MembershipTier> fallbackTierByUser,
             Instant now,
-            CancellationToken ct = default) =>
-        _profileRepository.DowngradeTierForExpiredAsync(
+            CancellationToken ct = default)
+    {
+        var downgrades = await _profileRepository.DowngradeTierForExpiredAsync(
             currentTier, userIdsToKeep, fallbackTierByUser, now, ct);
+        foreach (var (userId, _) in downgrades)
+            await _userInfoInvalidator.InvalidateAsync(userId, ct);
+        return downgrades;
+    }
 
-    // Cache invalidation (UserInfo refresh for both source and target) is
-    // handled by the CachingUserService decorator's wrapper for this
-    // method — ProfileService is the inner / non-cached implementation.
-    public Task ReassignAsync(Guid sourceUserId, Guid targetUserId, Guid actorUserId, Instant updatedAt,
-        CancellationToken ct) =>
-        _profileRepository.ReassignSubAggregatesToUserAsync(sourceUserId, targetUserId, updatedAt, ct);
+    public async Task ReassignAsync(Guid sourceUserId, Guid targetUserId, Guid actorUserId, Instant updatedAt,
+        CancellationToken ct)
+    {
+        await _profileRepository.ReassignSubAggregatesToUserAsync(sourceUserId, targetUserId, updatedAt, ct);
+        await _userInfoInvalidator.InvalidateAsync(sourceUserId, ct);
+        await _userInfoInvalidator.InvalidateAsync(targetUserId, ct);
+    }
 
     public async Task<bool> SetIbanAsync(Guid userId, string? iban, CancellationToken ct = default)
     {
@@ -826,6 +854,7 @@ public sealed class ProfileService : IProfileService, IUserDataContributor, IUse
         profile.Iban = normalized;
         profile.UpdatedAt = _clock.GetCurrentInstant();
         await _profileRepository.UpdateAsync(profile, ct);
+        await _userInfoInvalidator.InvalidateAsync(userId, ct);
 
         await _auditLogService.LogAsync(
             isClearing ? AuditAction.IbanRemove : AuditAction.IbanSet,

--- a/src/Humans.Application/Services/Tickets/TicketQueryService.cs
+++ b/src/Humans.Application/Services/Tickets/TicketQueryService.cs
@@ -8,12 +8,12 @@ using Humans.Application.Interfaces.Repositories;
 using Humans.Domain.Constants;
 using Humans.Domain.Enums;
 using Humans.Application.Interfaces.Budget;
+using Humans.Application.Interfaces.Profiles;
 using Humans.Application.Interfaces.Campaigns;
 using Humans.Application.Interfaces.Shifts;
 using Humans.Application.Interfaces.Teams;
 using Humans.Application.Interfaces.Tickets;
 using Humans.Application.Interfaces.Users;
-using Humans.Application.Interfaces.Profiles;
 
 namespace Humans.Application.Services.Tickets;
 
@@ -41,7 +41,6 @@ public sealed class TicketQueryService : ITicketQueryService, IUserDataContribut
     private readonly ICampaignService _campaignService;
     private readonly IUserService _userService;
     private readonly IUserEmailService _userEmailService;
-    private readonly IProfileService _profileService;
     private readonly ITeamService _teamService;
     private readonly IShiftManagementService _shiftManagementService;
     private readonly IClock _clock;
@@ -53,7 +52,6 @@ public sealed class TicketQueryService : ITicketQueryService, IUserDataContribut
         ICampaignService campaignService,
         IUserService userService,
         IUserEmailService userEmailService,
-        IProfileService profileService,
         ITeamService teamService,
         IShiftManagementService shiftManagementService,
         IClock clock)
@@ -64,7 +62,6 @@ public sealed class TicketQueryService : ITicketQueryService, IUserDataContribut
         _campaignService = campaignService;
         _userService = userService;
         _userEmailService = userEmailService;
-        _profileService = profileService;
         _teamService = teamService;
         _shiftManagementService = shiftManagementService;
         _clock = clock;
@@ -620,8 +617,8 @@ public sealed class TicketQueryService : ITicketQueryService, IUserDataContribut
             };
         }
 
-        // Stitch in memory: profiles (for tier), notification emails, team memberships.
-        var profiles = await _profileService.GetByUserIdsAsync(candidateIds);
+        // Stitch in memory: notification emails, team memberships. MembershipTier
+        // rides along on the cached UserInfo.Profile.
         var emailsById = await _userEmailService.GetNotificationEmailsByUserIdsAsync(candidateIds);
         var candidateIdSet = candidateIds.ToHashSet();
         var teamsByIdLookup = await _teamService.GetTeamsAsync();
@@ -643,11 +640,10 @@ public sealed class TicketQueryService : ITicketQueryService, IUserDataContribut
         var usersById = allUsers.ToDictionary(u => u.Id);
 
         var rows = candidateIds
-            .Where(id => profiles.ContainsKey(id))
+            .Where(id => usersById.TryGetValue(id, out var u) && u.Profile is not null)
             .Select(id =>
             {
                 var user = usersById[id];
-                var profile = profiles[id];
                 emailsById.TryGetValue(id, out var email);
                 teamsByUser.TryGetValue(id, out var teamNames);
 
@@ -658,7 +654,7 @@ public sealed class TicketQueryService : ITicketQueryService, IUserDataContribut
                     Name = user.DisplayName,
                     Email = email ?? string.Empty,
                     TeamNames = teamNames ?? [],
-                    Tier = profile.MembershipTier,
+                    Tier = user.Profile!.MembershipTier,
                 };
             })
             .ToList();

--- a/src/Humans.Application/Services/Users/UserService.cs
+++ b/src/Humans.Application/Services/Users/UserService.cs
@@ -69,6 +69,11 @@ public sealed class UserService : IUserService, IUserDataContributor, IUserMerge
         _logger = logger;
     }
 
+    // The undecorated service has no cache to warm — bulk-read callers that
+    // care about warmup state are decorated, this base impl is only used by
+    // the decorator on miss.
+    public bool IsWarmedUp => true;
+
     // ==========================================================================
     // User reads
     // ==========================================================================

--- a/src/Humans.Infrastructure/Jobs/SystemTeamSyncJob.cs
+++ b/src/Humans.Infrastructure/Jobs/SystemTeamSyncJob.cs
@@ -101,6 +101,12 @@ public class SystemTeamSyncJob : ISystemTeamSync
     private IProfileService ProfileService =>
         _serviceProvider.GetRequiredService<IProfileService>();
 
+    // Direct repository read for the destructive Volunteers reconciliation: a
+    // startup UserInfo cache that came up empty would otherwise deprovision
+    // every Volunteers member. See SyncVolunteersTeamAsync below.
+    private IProfileRepository ProfileRepository =>
+        _serviceProvider.GetRequiredService<IProfileRepository>();
+
     private ITeamResourceService TeamResourceService =>
         _serviceProvider.GetRequiredService<ITeamResourceService>();
 
@@ -262,7 +268,7 @@ public class SystemTeamSyncJob : ISystemTeamSync
         // users-table scan is trivial next to that risk.
         var allUsers = await _userService.GetAllUsersAsync(cancellationToken);
         var allUserIds = allUsers.Select(u => u.Id).ToList();
-        var profiles = await ProfileService.GetByUserIdsAsync(allUserIds, cancellationToken);
+        var profiles = await ProfileRepository.GetByUserIdsAsync(allUserIds, cancellationToken);
         var candidateIds = allUserIds
             .Where(id => profiles.TryGetValue(id, out var p)
                 && !p.IsSuspended
@@ -464,7 +470,7 @@ public class SystemTeamSyncJob : ISystemTeamSync
             return;
         }
 
-        var profiles = await ProfileService.GetByUserIdsAsync([userId], cancellationToken);
+        var profiles = await ProfileRepository.GetByUserIdsAsync([userId], cancellationToken);
         profiles.TryGetValue(userId, out var profile);
 
         // Volunteers admission no longer requires Profile.IsApproved (CC clearance).
@@ -536,7 +542,7 @@ public class SystemTeamSyncJob : ISystemTeamSync
         var hasApprovedApp = await ApplicationDecisionService
             .HasActiveApprovedTierAsync(userId, tier, today, cancellationToken);
 
-        var profiles = await ProfileService.GetByUserIdsAsync([userId], cancellationToken);
+        var profiles = await ProfileRepository.GetByUserIdsAsync([userId], cancellationToken);
         profiles.TryGetValue(userId, out var profile);
 
         var isEligible = hasApprovedApp

--- a/src/Humans.Infrastructure/Jobs/SystemTeamSyncJob.cs
+++ b/src/Humans.Infrastructure/Jobs/SystemTeamSyncJob.cs
@@ -101,12 +101,6 @@ public class SystemTeamSyncJob : ISystemTeamSync
     private IProfileService ProfileService =>
         _serviceProvider.GetRequiredService<IProfileService>();
 
-    // Direct repository read for the destructive Volunteers reconciliation: a
-    // startup UserInfo cache that came up empty would otherwise deprovision
-    // every Volunteers member. See SyncVolunteersTeamAsync below.
-    private IProfileRepository ProfileRepository =>
-        _serviceProvider.GetRequiredService<IProfileRepository>();
-
     private ITeamResourceService TeamResourceService =>
         _serviceProvider.GetRequiredService<ITeamResourceService>();
 
@@ -260,20 +254,24 @@ public class SystemTeamSyncJob : ISystemTeamSync
         // Flagged + RejectedAt exclusions preserve the CC's existing kick-out
         // levers (FlagConsentCheckAsync and RejectSignupAsync set those fields
         // before calling DeprovisionApprovalGatedSystemTeamsAsync).
-        // Read straight from the DB rather than the UserInfo cache: this is a
-        // destructive reconciliation that removes every Volunteers-team member
-        // not in candidateIds. UserInfoWarmupHostedService is explicitly
-        // non-fatal, so a startup warmup failure leaves GetAllUserInfos() empty
-        // and would deprovision the entire team. The hourly cost of one
-        // users-table scan is trivial next to that risk.
-        var allUsers = await _userService.GetAllUsersAsync(cancellationToken);
-        var allUserIds = allUsers.Select(u => u.Id).ToList();
-        var profiles = await ProfileRepository.GetByUserIdsAsync(allUserIds, cancellationToken);
-        var candidateIds = allUserIds
-            .Where(id => profiles.TryGetValue(id, out var p)
-                && !p.IsSuspended
-                && p.ConsentCheckStatus != ConsentCheckStatus.Flagged
-                && p.RejectedAt is null)
+        //
+        // Destructive reconciliation guard: if the UserInfo cache has not warmed
+        // (startup failure), GetAllUserInfos() returns empty and would
+        // deprovision every Volunteers-team member. The job runs hourly, so a
+        // skipped run is cheap; the next run after warmup recovers.
+        if (!_userService.IsWarmedUp)
+        {
+            _logger.LogWarning("Skipping Volunteers team sync: UserInfo cache is not warmed");
+            report?.Steps.Add(step);
+            return;
+        }
+
+        var candidateIds = _userService.GetAllUserInfos()
+            .Where(u => u.Profile is not null
+                && !u.IsSuspended
+                && u.Profile.ConsentCheckStatus != ConsentCheckStatus.Flagged
+                && u.Profile.RejectedAt is null)
+            .Select(u => u.Id)
             .ToList();
 
         var eligibleSet = await MembershipCalculator.GetUsersWithAllRequiredConsentsForTeamAsync(
@@ -470,8 +468,7 @@ public class SystemTeamSyncJob : ISystemTeamSync
             return;
         }
 
-        var profiles = await ProfileRepository.GetByUserIdsAsync([userId], cancellationToken);
-        profiles.TryGetValue(userId, out var profile);
+        var profile = (await _userService.GetUserInfoAsync(userId, cancellationToken))?.Profile;
 
         // Volunteers admission no longer requires Profile.IsApproved (CC clearance).
         // Profile.IsApproved is tracked as the CC's audit annotation but is not
@@ -479,7 +476,7 @@ public class SystemTeamSyncJob : ISystemTeamSync
         // signups remain excluded so DeprovisionApprovalGatedSystemTeamsAsync
         // (called from FlagConsentCheckAsync / RejectSignupAsync after those
         // mutations) actually removes the user from Volunteers.
-        var isEligible = profile is { IsSuspended: false, RejectedAt: null }
+        var isEligible = profile is { RejectedAt: null, State: not ProfileState.Suspended }
             && profile.ConsentCheckStatus != ConsentCheckStatus.Flagged
             && await MembershipCalculator.HasAllRequiredConsentsForTeamAsync(userId, SystemTeamIds.Volunteers, cancellationToken);
 
@@ -542,11 +539,10 @@ public class SystemTeamSyncJob : ISystemTeamSync
         var hasApprovedApp = await ApplicationDecisionService
             .HasActiveApprovedTierAsync(userId, tier, today, cancellationToken);
 
-        var profiles = await ProfileRepository.GetByUserIdsAsync([userId], cancellationToken);
-        profiles.TryGetValue(userId, out var profile);
+        var profile = (await _userService.GetUserInfoAsync(userId, cancellationToken))?.Profile;
 
         var isEligible = hasApprovedApp
-            && profile is { IsApproved: true, IsSuspended: false }
+            && profile is { IsApproved: true, State: not ProfileState.Suspended }
             && await MembershipCalculator.HasAllRequiredConsentsForTeamAsync(userId, teamId, cancellationToken);
 
         var eligibleUserIds = isEligible ? [userId] : new List<Guid>();

--- a/src/Humans.Infrastructure/Services/AdminDatabaseDiagnosticsService.cs
+++ b/src/Humans.Infrastructure/Services/AdminDatabaseDiagnosticsService.cs
@@ -1,5 +1,4 @@
 using Humans.Application.Interfaces.Admin;
-using Humans.Application.Interfaces.Profiles;
 using Humans.Application.Interfaces.Repositories;
 using Humans.Application.Interfaces.Tickets;
 using Humans.Application.Interfaces.Users;
@@ -10,18 +9,15 @@ public sealed class AdminDatabaseDiagnosticsService : IAdminDatabaseDiagnosticsS
 {
     private readonly IAdminDatabaseDiagnosticsRepository _repository;
     private readonly IUserService _userService;
-    private readonly IProfileService _profileService;
     private readonly ITicketQueryService _ticketQueryService;
 
     public AdminDatabaseDiagnosticsService(
         IAdminDatabaseDiagnosticsRepository repository,
         IUserService userService,
-        IProfileService profileService,
         ITicketQueryService ticketQueryService)
     {
         _repository = repository;
         _userService = userService;
-        _profileService = profileService;
         _ticketQueryService = ticketQueryService;
     }
 
@@ -34,9 +30,6 @@ public sealed class AdminDatabaseDiagnosticsService : IAdminDatabaseDiagnosticsS
     public async Task<AudienceSegmentation> GetAudienceSegmentationAsync(int? year, CancellationToken ct = default)
     {
         var allUsers = _userService.GetAllUserInfos();
-        var allUserIds = allUsers.Select(u => u.Id).ToArray();
-        var profilesByUserId = await _profileService.GetByUserIdsAsync(allUserIds, ct);
-        var profileUserIds = profilesByUserId.Keys.ToHashSet();
         IReadOnlySet<Guid> ticketUserIds = year.HasValue
             ? await _ticketQueryService.GetMatchedUserIdsForYearAsync(year.Value, ct)
             : await _ticketQueryService.GetAllMatchedUserIdsAsync();
@@ -48,7 +41,7 @@ public sealed class AdminDatabaseDiagnosticsService : IAdminDatabaseDiagnosticsS
 
         foreach (var user in allUsers)
         {
-            var hasProfile = profileUserIds.Contains(user.Id);
+            var hasProfile = user.Profile is not null;
             var hasTicket = ticketUserIds.Contains(user.Id);
 
             if (hasProfile) withProfile++;

--- a/src/Humans.Infrastructure/Services/Agent/AgentUserSnapshotProvider.cs
+++ b/src/Humans.Infrastructure/Services/Agent/AgentUserSnapshotProvider.cs
@@ -3,7 +3,6 @@ using Humans.Application.Interfaces;
 using Humans.Application.Interfaces.Auth;
 using Humans.Application.Interfaces.Consent;
 using Humans.Application.Interfaces.Feedback;
-using Humans.Application.Interfaces.Profiles;
 using Humans.Application.Interfaces.Shifts;
 using Humans.Application.Interfaces.Teams;
 using Humans.Application.Interfaces.Tickets;
@@ -16,7 +15,6 @@ namespace Humans.Infrastructure.Services.Agent;
 
 public sealed class AgentUserSnapshotProvider : IAgentUserSnapshotProvider
 {
-    private readonly IProfileService _profiles;
     private readonly IUserService _users;
     private readonly IRoleAssignmentService _roles;
     private readonly ITeamService _teams;
@@ -28,7 +26,6 @@ public sealed class AgentUserSnapshotProvider : IAgentUserSnapshotProvider
     private readonly IClock _clock;
 
     public AgentUserSnapshotProvider(
-        IProfileService profiles,
         IUserService users,
         IRoleAssignmentService roles,
         ITeamService teams,
@@ -39,7 +36,6 @@ public sealed class AgentUserSnapshotProvider : IAgentUserSnapshotProvider
         IShiftManagementService shiftManagement,
         IClock clock)
     {
-        _profiles = profiles;
         _users = users;
         _roles = roles;
         _teams = teams;
@@ -53,8 +49,8 @@ public sealed class AgentUserSnapshotProvider : IAgentUserSnapshotProvider
 
     public async Task<AgentUserSnapshot> LoadAsync(Guid userId, CancellationToken cancellationToken)
     {
-        var profile = await _profiles.GetProfileAsync(userId, cancellationToken);
-        var user = await _users.GetByIdAsync(userId, cancellationToken);
+        var user = await _users.GetUserInfoAsync(userId, cancellationToken);
+        var profile = user?.Profile;
         var activeRoles = await _roles.GetActiveForUserAsync(userId, cancellationToken);
         var teamMemberships = await _teams.GetActiveTeamMembershipsForUserAsync(userId, cancellationToken);
         var pendingDocs = await _consents.GetPendingDocumentNamesAsync(userId, cancellationToken);

--- a/src/Humans.Infrastructure/Services/Users/CachingUserService.cs
+++ b/src/Humans.Infrastructure/Services/Users/CachingUserService.cs
@@ -60,6 +60,8 @@ public sealed class CachingUserService : TrackedCache<Guid, UserInfo>, IUserServ
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly ILogger<CachingUserService> _logger;
 
+    public bool IsWarmedUp { get; private set; }
+
     public CachingUserService(
         IUserRepository userRepository,
         IUserEmailRepository userEmailRepository,
@@ -336,7 +338,13 @@ public sealed class CachingUserService : TrackedCache<Guid, UserInfo>, IUserServ
     public async Task WarmAllAsync(CancellationToken ct = default)
     {
         var users = await _userRepository.GetAllAsync(ct);
-        if (users.Count == 0) return;
+        if (users.Count == 0)
+        {
+            // Empty system (fresh dev DB / new deploy) is a legitimate warm
+            // state — flag flips, jobs may safely run against an empty cache.
+            IsWarmedUp = true;
+            return;
+        }
 
         var userIds = users.Select(u => u.Id).ToList();
 
@@ -392,6 +400,8 @@ public sealed class CachingUserService : TrackedCache<Guid, UserInfo>, IUserServ
                 profile, contactFields, languages, volunteerHistory,
                 preferences));
         }
+
+        IsWarmedUp = true;
     }
 
     // ==========================================================================

--- a/src/Humans.Web/Controllers/ExpensesController.cs
+++ b/src/Humans.Web/Controllers/ExpensesController.cs
@@ -1,7 +1,6 @@
 using System.Text;
 using Humans.Application.Interfaces.Budget;
 using Humans.Application.Interfaces.Expenses;
-using Humans.Application.Interfaces.Profiles;
 using Humans.Application.Interfaces.Users;
 using Humans.Application.Services.Expenses.Dtos;
 using Humans.Domain.Entities;
@@ -23,7 +22,6 @@ public sealed class ExpensesController : HumansControllerBase
 {
     private readonly IExpenseReportService _service;
     private readonly IBudgetService _budgetService;
-    private readonly IProfileService _profileService;
     private readonly IUserService _userService;
     private readonly IClock _clock;
     private readonly IAuthorizationService _authService;
@@ -35,7 +33,6 @@ public sealed class ExpensesController : HumansControllerBase
         IUserService userService,
         IExpenseReportService service,
         IBudgetService budgetService,
-        IProfileService profileService,
         IClock clock,
         IAuthorizationService authService,
         ISepaPaymentFileBuilder sepaBuilder,
@@ -45,7 +42,6 @@ public sealed class ExpensesController : HumansControllerBase
     {
         _service = service;
         _budgetService = budgetService;
-        _profileService = profileService;
         _userService = userService;
         _clock = clock;
         _authService = authService;
@@ -767,15 +763,12 @@ public sealed class ExpensesController : HumansControllerBase
         var ids = reports.Select(r => r.SubmitterUserId).Distinct().ToList();
         if (ids.Count == 0) return new Dictionary<Guid, string>();
 
-        var profiles = await _profileService.GetByUserIdsAsync(ids);
-        var users = await _userService.GetByIdsAsync(ids);
+        var users = await _userService.GetUserInfosAsync(ids);
         return ids.ToDictionary(
             id => id,
-            id => profiles.TryGetValue(id, out var p) && !string.IsNullOrWhiteSpace(p.BurnerName)
-                ? p.BurnerName
-                : users.TryGetValue(id, out var u) && !string.IsNullOrWhiteSpace(u.DisplayName)
-                    ? u.DisplayName
-                    : "(unknown)");
+            id => users.TryGetValue(id, out var u) && !string.IsNullOrWhiteSpace(u.BurnerName)
+                ? u.BurnerName
+                : "(unknown)");
     }
 
     private async Task PopulateEditModelAsync(ExpenseEditViewModel model, ExpenseReportDto report)

--- a/src/Humans.Web/Controllers/FeedbackController.cs
+++ b/src/Humans.Web/Controllers/FeedbackController.cs
@@ -8,7 +8,6 @@ using Humans.Web.Authorization;
 using Humans.Web.Models;
 using Humans.Application.Interfaces.Feedback;
 using Humans.Application.Interfaces.Teams;
-using Humans.Application.Interfaces.Profiles;
 using Humans.Application.Interfaces.Users;
 
 namespace Humans.Web.Controllers;
@@ -19,7 +18,6 @@ public class FeedbackController : HumansControllerBase
 {
     private readonly IFeedbackService _feedbackService;
     private readonly ITeamService _teamService;
-    private readonly IProfileService _profileService;
     private readonly IUserService _userService;
     private readonly IStringLocalizer<SharedResource> _localizer;
     private readonly ILogger<FeedbackController> _logger;
@@ -27,7 +25,6 @@ public class FeedbackController : HumansControllerBase
     public FeedbackController(
         IFeedbackService feedbackService,
         ITeamService teamService,
-        IProfileService profileService,
         IUserService userService,
         IStringLocalizer<SharedResource> localizer,
         ILogger<FeedbackController> logger)
@@ -35,7 +32,6 @@ public class FeedbackController : HumansControllerBase
     {
         _feedbackService = feedbackService;
         _teamService = teamService;
-        _profileService = profileService;
         _userService = userService;
         _localizer = localizer;
         _logger = logger;
@@ -50,26 +46,14 @@ public class FeedbackController : HumansControllerBase
     /// population queries. Population goes through the UserInfo snapshot +
     /// <c>IUserService.GetByIdsAsync</c> primitives.
     /// </summary>
-    private async Task<List<AssigneeOption>> GetActiveAssigneeOptionsAsync(CancellationToken ct = default)
+    private Task<List<AssigneeOption>> GetActiveAssigneeOptionsAsync(CancellationToken ct = default)
     {
-        var activeIds = _userService.GetAllUserInfos()
+        var options = _userService.GetAllUserInfos()
             .Where(u => u.IsActive)
-            .Select(u => u.Id)
-            .ToList();
-        if (activeIds.Count == 0) return [];
-
-        var users = await _userService.GetByIdsAsync(activeIds, ct);
-        var profiles = await _profileService.GetByUserIdsAsync(activeIds, ct);
-
-        return users.Values
-            .Select(u =>
-            {
-                var burnerName = profiles.TryGetValue(u.Id, out var p) ? p.BurnerName : null;
-                var displayName = !string.IsNullOrWhiteSpace(burnerName) ? burnerName : u.DisplayName;
-                return new AssigneeOption { Id = u.Id, DisplayName = displayName };
-            })
+            .Select(u => new AssigneeOption { Id = u.Id, DisplayName = u.BurnerName })
             .OrderBy(o => o.DisplayName, StringComparer.OrdinalIgnoreCase)
             .ToList();
+        return Task.FromResult(options);
     }
 
     [HttpGet("")]

--- a/src/Humans.Web/Controllers/ProfileBackfillAdminController.cs
+++ b/src/Humans.Web/Controllers/ProfileBackfillAdminController.cs
@@ -85,14 +85,10 @@ public sealed class ProfileBackfillAdminController : HumansControllerBase
         return RedirectToAction(nameof(Index));
     }
 
-    private async Task<IReadOnlyList<MissingProfileRow>> GetUsersMissingProfileAsync(CancellationToken ct)
+    private Task<IReadOnlyList<MissingProfileRow>> GetUsersMissingProfileAsync(CancellationToken ct)
     {
-        var users = _userService.GetAllUserInfos();
-        var userIds = users.Select(u => u.Id).ToList();
-        var profiles = await _profileService.GetByUserIdsAsync(userIds, ct);
-
-        return users
-            .Where(u => !profiles.ContainsKey(u.Id))
+        IReadOnlyList<MissingProfileRow> rows = _userService.GetAllUserInfos()
+            .Where(u => u.Profile is null)
             .Select(u => new MissingProfileRow(
                 u.Id,
                 u.Email ?? string.Empty,
@@ -101,6 +97,7 @@ public sealed class ProfileBackfillAdminController : HumansControllerBase
                 u.ContactSource))
             .OrderByDescending(r => r.CreatedAt)
             .ToList();
+        return Task.FromResult(rows);
     }
 }
 

--- a/src/Humans.Web/Controllers/ProfileController.cs
+++ b/src/Humans.Web/Controllers/ProfileController.cs
@@ -189,7 +189,6 @@ public class ProfileController : HumansControllerBase
     {
         var allUsers = _userService.GetAllUserInfos();
         var allUserIds = allUsers.Select(u => u.Id).ToList();
-        var profilesByUserId = await _profileService.GetByUserIdsAsync(allUserIds, ct);
         var notificationEmails =
             await _userEmailService.GetNotificationEmailsByUserIdsAsync(allUserIds, ct);
 
@@ -220,7 +219,6 @@ public class ProfileController : HumansControllerBase
 
         return await AdminHumanListAssembler.AssembleAsync(
             allUsers,
-            profilesByUserId,
             notificationEmails,
             searchUserIds,
             statusFilter,

--- a/tests/Humans.Application.Tests/Agent/AgentUserSnapshotProviderTests.cs
+++ b/tests/Humans.Application.Tests/Agent/AgentUserSnapshotProviderTests.cs
@@ -2,12 +2,12 @@ using AwesomeAssertions;
 using Humans.Application.Interfaces.Auth;
 using Humans.Application.Interfaces.Consent;
 using Humans.Application.Interfaces.Feedback;
-using Humans.Application.Interfaces.Profiles;
 using Humans.Application.Interfaces.Shifts;
 using Humans.Application.Interfaces.Teams;
 using Humans.Application.Interfaces.Tickets;
 using Humans.Application.Interfaces.Users;
 using Humans.Application.Models;
+using Humans.Application.Tests.Infrastructure;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using Humans.Infrastructure.Services.Agent;
@@ -148,10 +148,11 @@ public class AgentUserSnapshotProviderTests
         IReadOnlyList<Guid>? openTicketIds = null,
         IReadOnlyList<TeamMembership>? teamMemberships = null)
     {
-        var profiles = Substitute.For<IProfileService>();
         var users = Substitute.For<IUserService>();
-        users.GetByIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
-            .Returns(new User { Id = userId, DisplayName = "T", PreferredLanguage = "es" });
+        users.GetUserInfoAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<UserInfo?>(
+                new User { Id = userId, DisplayName = "T", PreferredLanguage = "es" }
+                    .ToUserInfo()));
         var roles = Substitute.For<IRoleAssignmentService>();
         roles.GetActiveForUserAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
             .Returns([]);
@@ -181,7 +182,7 @@ public class AgentUserSnapshotProviderTests
         var clock = new FakeClock(Instant.FromUtc(2026, 6, 1, 0, 0));
 
         return new AgentUserSnapshotProvider(
-            profiles, users, roles, teams, consents, feedback, tickets,
+            users, roles, teams, consents, feedback, tickets,
             shiftSignups, shiftMgmt, clock);
     }
 

--- a/tests/Humans.Application.Tests/Architecture/Baselines/ApplicationServiceEntityReadReturns.baseline.txt
+++ b/tests/Humans.Application.Tests/Architecture/Baselines/ApplicationServiceEntityReadReturns.baseline.txt
@@ -33,8 +33,6 @@ Humans.Application.Interfaces.Events.IEventService.GetUserEventAsync:Humans.Doma
 Humans.Application.Interfaces.Events.IEventService.GetUserSubmissionsAsync:Humans.Domain.Entities.Event
 Humans.Application.Interfaces.Events.IEventService.GetVenueAsync:Humans.Domain.Entities.EventVenue
 Humans.Application.Interfaces.Issues.IIssuesService.GetIssueByIdAsync:Humans.Domain.Entities.Issue
-Humans.Application.Interfaces.Profiles.IProfileService.GetByUserIdsAsync:Humans.Domain.Entities.Profile
-Humans.Application.Interfaces.Profiles.IProfileService.GetProfileAsync:Humans.Domain.Entities.Profile
 Humans.Application.Interfaces.Shifts.IShiftManagementService.GetActiveAsync:Humans.Domain.Entities.EventSettings
 Humans.Application.Interfaces.Shifts.IShiftManagementService.GetBrowseShiftsAsync:Humans.Domain.Entities.Shift
 Humans.Application.Interfaces.Shifts.IShiftManagementService.GetByIdAsync:Humans.Domain.Entities.EventSettings

--- a/tests/Humans.Application.Tests/Architecture/FeedbackArchitectureTests.cs
+++ b/tests/Humans.Application.Tests/Architecture/FeedbackArchitectureTests.cs
@@ -59,9 +59,7 @@ public class FeedbackArchitectureTests
         var paramTypes = ctor.GetParameters().Select(p => p.ParameterType).ToList();
 
         paramTypes.Should().Contain(typeof(IUserService),
-            because: "Feedback resolves reporter / assignee / resolver display names via IUserService instead of cross-domain .Include() chains");
-        paramTypes.Should().Contain(typeof(IProfileService),
-            because: "Feedback resolves BurnerName-first display names via IProfileService.GetByUserIdsAsync per memory/architecture/burnername-is-the-display-name.md");
+            because: "Feedback resolves reporter / assignee / resolver display names via IUserService.GetUserInfosAsync — UserInfo.BurnerName implements the BurnerName-first fallback per memory/architecture/burnername-is-the-display-name.md");
         paramTypes.Should().Contain(typeof(IUserEmailService),
             because: "Feedback resolves the reporter's effective notification email via IUserEmailService.GetNotificationTargetEmailsAsync — no User.UserEmails navigation");
         paramTypes.Should().Contain(typeof(ITeamService),

--- a/tests/Humans.Application.Tests/Architecture/MembershipCalculatorArchitectureTests.cs
+++ b/tests/Humans.Application.Tests/Architecture/MembershipCalculatorArchitectureTests.cs
@@ -1,7 +1,6 @@
 using AwesomeAssertions;
 using Humans.Application.Interfaces.Auth;
 using Humans.Application.Interfaces.Governance;
-using Humans.Application.Interfaces.Profiles;
 using Humans.Application.Interfaces.Teams;
 using Humans.Application.Interfaces.Users;
 using Humans.Application.Services.Governance;
@@ -36,15 +35,6 @@ public class MembershipCalculatorArchitectureTests
                 p => (p.ParameterType.Namespace ?? string.Empty)
                     .StartsWith("Humans.Application.Interfaces.Repositories", StringComparison.Ordinal),
                 because: "MembershipCalculator owns no data — it must read only through other sections' service interfaces");
-    }
-
-    [HumansFact]
-    public void MembershipCalculator_TakesProfileService()
-    {
-        var ctor = typeof(MembershipCalculator).GetConstructors().Single();
-        ctor.GetParameters().Select(p => p.ParameterType)
-            .Should().Contain(typeof(IProfileService),
-                because: "profile reads go through IProfileService per design-rules §9");
     }
 
     [HumansFact]

--- a/tests/Humans.Application.Tests/Architecture/TicketQueryArchitectureTests.cs
+++ b/tests/Humans.Application.Tests/Architecture/TicketQueryArchitectureTests.cs
@@ -57,7 +57,6 @@ public class TicketQueryArchitectureTests
         paramTypes.Should().Contain(typeof(ICampaignService));
         paramTypes.Should().Contain(typeof(IUserService));
         paramTypes.Should().Contain(typeof(IUserEmailService));
-        paramTypes.Should().Contain(typeof(IProfileService));
         paramTypes.Should().Contain(typeof(ITeamService));
         paramTypes.Should().Contain(typeof(IShiftManagementService));
     }

--- a/tests/Humans.Application.Tests/AuditLog/AuditViewerServiceTests.cs
+++ b/tests/Humans.Application.Tests/AuditLog/AuditViewerServiceTests.cs
@@ -1,8 +1,9 @@
 using AwesomeAssertions;
 using Humans.Application.Interfaces.AuditLog;
-using Humans.Application.Interfaces.Profiles;
 using Humans.Application.Interfaces.Teams;
+using Humans.Application.Interfaces.Users;
 using Humans.Application.Services.AuditLog;
+using Humans.Application.Tests.Infrastructure;
 using Humans.Domain.Entities;
 using Humans.Domain.Enums;
 using NodaTime;
@@ -32,13 +33,9 @@ public class AuditViewerServiceTests
         auditLog.GetByUserAsync(viewer, 10, Arg.Any<CancellationToken>())
             .Returns([ToSnapshot(entry)]);
 
-        var profileService = Substitute.For<IProfileService>();
-        profileService.GetByUserIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
-            .Returns(new Dictionary<Guid, Profile>
-            {
-                [actor] = new Profile { UserId = actor, BurnerName = "Frank" },
-                [viewer] = new Profile { UserId = viewer, BurnerName = "Peter" }
-            });
+        var userService = StubUserService(
+            (actor, "Frank"),
+            (viewer, "Peter"));
 
         var teamService = Substitute.For<ITeamService>();
         teamService.GetByIdsWithParentsAsync(Arg.Any<IReadOnlyList<Guid>>(), Arg.Any<CancellationToken>())
@@ -48,7 +45,7 @@ public class AuditViewerServiceTests
         teamResourceService.GetResourceNamesByIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
             .Returns(new Dictionary<Guid, string>());
 
-        var service = new AuditViewerService(auditLog, profileService, teamService, teamResourceService);
+        var service = new AuditViewerService(auditLog, userService, teamService, teamResourceService);
 
         var events = await service.GetForUserAsync(viewer, 10);
 
@@ -66,16 +63,16 @@ public class AuditViewerServiceTests
         auditLog.GetByUserAsync(Arg.Any<Guid>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
             .Returns([]);
 
-        var profileService = Substitute.For<IProfileService>();
+        var userService = Substitute.For<IUserService>();
         var teamService = Substitute.For<ITeamService>();
         var teamResourceService = Substitute.For<ITeamResourceService>();
-        var service = new AuditViewerService(auditLog, profileService, teamService, teamResourceService);
+        var service = new AuditViewerService(auditLog, userService, teamService, teamResourceService);
 
         var events = await service.GetForUserAsync(Guid.NewGuid(), 10);
 
         events.Should().BeEmpty();
         // No name lookups should fire on empty input — short-circuit guard.
-        await profileService.DidNotReceive().GetByUserIdsAsync(
+        await userService.DidNotReceive().GetUserInfosAsync(
             Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>());
     }
 
@@ -93,8 +90,8 @@ public class AuditViewerServiceTests
             relatedEntityType: "User",
             description: "shift 'Cantina dinner'");
 
-        var (auditLog, profileService, teamService, teamResourceService) = MakeServices(entry, actor, viewer, "Frank", "Peter");
-        var service = new AuditViewerService(auditLog, profileService, teamService, teamResourceService);
+        var (auditLog, userService, teamService, teamResourceService) = MakeServices(entry, actor, viewer, "Frank", "Peter");
+        var service = new AuditViewerService(auditLog, userService, teamService, teamResourceService);
 
         var events = await service.GetForUserAsync(viewer, 10);
         var line = events[0].RenderPlainText(viewerUserId: viewer);
@@ -123,9 +120,7 @@ public class AuditViewerServiceTests
         var auditLog = Substitute.For<IAuditLogService>();
         auditLog.GetByResourceAsync(resourceId).Returns([ToSnapshot(entry)]);
 
-        var profileService = Substitute.For<IProfileService>();
-        profileService.GetByUserIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
-            .Returns(new Dictionary<Guid, Profile>());
+        var userService = StubUserService();
 
         var teamService = Substitute.For<ITeamService>();
         teamService.GetByIdsWithParentsAsync(Arg.Any<IReadOnlyList<Guid>>(), Arg.Any<CancellationToken>())
@@ -135,7 +130,7 @@ public class AuditViewerServiceTests
         teamResourceService.GetResourceNamesByIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
             .Returns(new Dictionary<Guid, string>());
 
-        var service = new AuditViewerService(auditLog, profileService, teamService, teamResourceService);
+        var service = new AuditViewerService(auditLog, userService, teamService, teamResourceService);
 
         var events = await service.GetForResourceAsync(resourceId);
 
@@ -162,9 +157,7 @@ public class AuditViewerServiceTests
         auditLog.GetFilteredAsync(null, 1, 50, Arg.Any<CancellationToken>())
             .Returns(([ToSnapshot(entry)], 1, 0));
 
-        var profileService = Substitute.For<IProfileService>();
-        profileService.GetByUserIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
-            .Returns(new Dictionary<Guid, Profile> { [actor] = new Profile { UserId = actor, BurnerName = "Frank" } });
+        var userService = StubUserService((actor, "Frank"));
 
         var teamService = Substitute.For<ITeamService>();
         teamService.GetByIdsWithParentsAsync(Arg.Any<IReadOnlyList<Guid>>(), Arg.Any<CancellationToken>())
@@ -174,7 +167,7 @@ public class AuditViewerServiceTests
         teamResourceService.GetResourceNamesByIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
             .Returns(new Dictionary<Guid, string>());
 
-        var service = new AuditViewerService(auditLog, profileService, teamService, teamResourceService);
+        var service = new AuditViewerService(auditLog, userService, teamService, teamResourceService);
 
         var result = await service.GetPageAsync(null, 1, 50);
 
@@ -183,20 +176,16 @@ public class AuditViewerServiceTests
         result.Items[0].ActorDisplayName.Should().Be("Frank");
     }
 
-    private static (IAuditLogService, IProfileService, ITeamService, ITeamResourceService) MakeServices(
+    private static (IAuditLogService, IUserService, ITeamService, ITeamResourceService) MakeServices(
         AuditLogEntry entry, Guid actor, Guid viewer, string actorName, string viewerName)
     {
         var auditLog = Substitute.For<IAuditLogService>();
         auditLog.GetByUserAsync(viewer, Arg.Any<int>(), Arg.Any<CancellationToken>())
             .Returns([ToSnapshot(entry)]);
 
-        var profileService = Substitute.For<IProfileService>();
-        profileService.GetByUserIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
-            .Returns(new Dictionary<Guid, Profile>
-            {
-                [actor] = new Profile { UserId = actor, BurnerName = actorName },
-                [viewer] = new Profile { UserId = viewer, BurnerName = viewerName }
-            });
+        var userService = StubUserService(
+            (actor, actorName),
+            (viewer, viewerName));
 
         var teamService = Substitute.For<ITeamService>();
         teamService.GetByIdsWithParentsAsync(Arg.Any<IReadOnlyList<Guid>>(), Arg.Any<CancellationToken>())
@@ -206,7 +195,20 @@ public class AuditViewerServiceTests
         teamResourceService.GetResourceNamesByIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
             .Returns(new Dictionary<Guid, string>());
 
-        return (auditLog, profileService, teamService, teamResourceService);
+        return (auditLog, userService, teamService, teamResourceService);
+    }
+
+    private static IUserService StubUserService(params (Guid Id, string BurnerName)[] users)
+    {
+        var userService = Substitute.For<IUserService>();
+        var dict = users.ToDictionary(
+            u => u.Id,
+            u => UserInfoStubHelpers.MakeUserInfo(
+                u.Id,
+                profile: new Profile { UserId = u.Id, BurnerName = u.BurnerName }));
+        userService.GetUserInfosAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<IReadOnlyDictionary<Guid, UserInfo>>(dict));
+        return userService;
     }
 
     private static AuditLogEntry MakeEntry(

--- a/tests/Humans.Application.Tests/Controllers/ProfileControllerEditTests.cs
+++ b/tests/Humans.Application.Tests/Controllers/ProfileControllerEditTests.cs
@@ -157,8 +157,6 @@ public class ProfileControllerEditTests
     [HumansFact]
     public async Task Edit_InitialSetup_Volunteer_DoesNotDispatchTierApplication()
     {
-        // Initial setup is signalled by GetProfileAsync returning null.
-        _profileService.GetProfileAsync(_userId, Arg.Any<CancellationToken>()).Returns((Profile?)null);
 
         var model = MakeValidModel(MembershipTier.Volunteer);
 
@@ -173,7 +171,6 @@ public class ProfileControllerEditTests
     [HumansFact]
     public async Task Edit_InitialSetup_Colaborador_NoExistingApp_CallsSubmitAsync()
     {
-        _profileService.GetProfileAsync(_userId, Arg.Any<CancellationToken>()).Returns((Profile?)null);
         _applicationDecisionService.GetUserApplicationsAsync(_userId, Arg.Any<CancellationToken>())
             .Returns([]);
 
@@ -200,7 +197,6 @@ public class ProfileControllerEditTests
         // pending applications by replaying the form. ApplicationDecisionService
         // also rejects with AlreadyPending as a backstop, but the controller
         // shouldn't lean on that.
-        _profileService.GetProfileAsync(_userId, Arg.Any<CancellationToken>()).Returns((Profile?)null);
 
         var existingDraftId = Guid.NewGuid();
         var existingDraft = new UserApplicationSnapshot(
@@ -265,7 +261,6 @@ public class ProfileControllerEditTests
     [HumansFact]
     public async Task Edit_Post_WithShiftTagIds_CallsSetVolunteerTagPreferencesAsync()
     {
-        _profileService.GetProfileAsync(_userId, Arg.Any<CancellationToken>()).Returns((Profile?)null);
         _applicationDecisionService.GetUserApplicationsAsync(_userId, Arg.Any<CancellationToken>())
             .Returns([]);
 
@@ -284,7 +279,6 @@ public class ProfileControllerEditTests
     [HumansFact]
     public async Task Edit_Post_WithEmptyShiftTagIds_CallsSetVolunteerTagPreferencesAsyncWithEmptyList()
     {
-        _profileService.GetProfileAsync(_userId, Arg.Any<CancellationToken>()).Returns((Profile?)null);
         _applicationDecisionService.GetUserApplicationsAsync(_userId, Arg.Any<CancellationToken>())
             .Returns([]);
 

--- a/tests/Humans.Application.Tests/GoogleIntegration/GoogleSyncRemovalNotificationIntegrationTests.cs
+++ b/tests/Humans.Application.Tests/GoogleIntegration/GoogleSyncRemovalNotificationIntegrationTests.cs
@@ -34,7 +34,6 @@ public sealed class GoogleSyncRemovalNotificationIntegrationTests
     private readonly ITeamService _teamService = Substitute.For<ITeamService>();
     private readonly IUserService _userService = Substitute.For<IUserService>();
     private readonly IUserEmailService _userEmailService = Substitute.For<IUserEmailService>();
-    private readonly IProfileService _profileService = Substitute.For<IProfileService>();
     private readonly ISyncSettingsService _syncSettingsService = Substitute.For<ISyncSettingsService>();
     private readonly IAuditLogService _auditLogService = Substitute.For<IAuditLogService>();
     private readonly IEmailService _emailService = Substitute.For<IEmailService>();
@@ -73,7 +72,6 @@ public sealed class GoogleSyncRemovalNotificationIntegrationTests
             _teamService,
             _userService,
             _userEmailService,
-            _profileService,
             _syncSettingsService,
             _auditLogService,
             notifications,

--- a/tests/Humans.Application.Tests/Infrastructure/GoogleIntegration/GoogleGroupSyncServiceTests.cs
+++ b/tests/Humans.Application.Tests/Infrastructure/GoogleIntegration/GoogleGroupSyncServiceTests.cs
@@ -25,7 +25,7 @@ public sealed class GoogleGroupSyncServiceTests
     private readonly ITeamService _teamService = Substitute.For<ITeamService>();
     private readonly IUserService _userService = Substitute.For<IUserService>();
     private readonly IUserEmailService _userEmailService = Substitute.For<IUserEmailService>();
-    private readonly IProfileService _profileService = Substitute.For<IProfileService>();
+    private readonly Dictionary<Guid, Profile> _profilesByUserId = new();
     private readonly ISyncSettingsService _syncSettingsService = Substitute.For<ISyncSettingsService>();
     private readonly IAuditLogService _auditLogService = Substitute.For<IAuditLogService>();
     private readonly IGoogleRemovalNotificationService _removalNotifications = Substitute.For<IGoogleRemovalNotificationService>();
@@ -438,7 +438,6 @@ public sealed class GoogleGroupSyncServiceTests
         _teamService,
         _userService,
         _userEmailService,
-        _profileService,
         _syncSettingsService,
         _auditLogService,
         _removalNotifications,
@@ -471,7 +470,9 @@ public sealed class GoogleGroupSyncServiceTests
                 var requested = call.ArgAt<IReadOnlyCollection<Guid>>(0).ToHashSet();
                 IReadOnlyDictionary<Guid, UserInfo> dict = userEntities
                     .Where(kv => requested.Contains(kv.Key))
-                    .ToDictionary(kv => kv.Key, kv => kv.Value.ToUserInfo());
+                    .ToDictionary(
+                        kv => kv.Key,
+                        kv => kv.Value.ToUserInfo(profile: _profilesByUserId.GetValueOrDefault(kv.Key)));
                 return new ValueTask<IReadOnlyDictionary<Guid, UserInfo>>(dict);
             });
 
@@ -501,38 +502,33 @@ public sealed class GoogleGroupSyncServiceTests
                         ]);
             });
 
-        _profileService.GetByUserIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
-            .Returns(call =>
+        foreach (var u in users)
+        {
+            _profilesByUserId[u.UserId] = new Profile
             {
-                var requested = call.ArgAt<IReadOnlyCollection<Guid>>(0);
-                return requested.ToDictionary(id => id, id => new Profile
-                {
-                    Id = Guid.NewGuid(),
-                    UserId = id,
-                    State = ProfileState.Active,
-                    CreatedAt = _clock.GetCurrentInstant(),
-                    UpdatedAt = _clock.GetCurrentInstant()
-                });
-            });
+                Id = Guid.NewGuid(),
+                UserId = u.UserId,
+                State = ProfileState.Active,
+                CreatedAt = _clock.GetCurrentInstant(),
+                UpdatedAt = _clock.GetCurrentInstant()
+            };
+        }
     }
 
     private void StubProfiles(params (Guid UserId, string? BurnerName)[] profiles)
     {
-        _profileService.GetByUserIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
-            .Returns(call =>
+        foreach (var p in profiles)
+        {
+            _profilesByUserId[p.UserId] = new Profile
             {
-                var requested = call.ArgAt<IReadOnlyCollection<Guid>>(0);
-                var byUserId = profiles.ToDictionary(p => p.UserId, p => p.BurnerName);
-                return requested.ToDictionary(id => id, id => new Profile
-                {
-                    Id = Guid.NewGuid(),
-                    UserId = id,
-                    BurnerName = byUserId.GetValueOrDefault(id) ?? string.Empty,
-                    State = ProfileState.Active,
-                    CreatedAt = _clock.GetCurrentInstant(),
-                    UpdatedAt = _clock.GetCurrentInstant()
-                });
-            });
+                Id = Guid.NewGuid(),
+                UserId = p.UserId,
+                BurnerName = p.BurnerName ?? string.Empty,
+                State = ProfileState.Active,
+                CreatedAt = _clock.GetCurrentInstant(),
+                UpdatedAt = _clock.GetCurrentInstant()
+            };
+        }
     }
 
     private void StubGroup(string groupKey, string groupId, params GroupMembership[] currentMembers)

--- a/tests/Humans.Application.Tests/Infrastructure/UserInfoStubHelpers.cs
+++ b/tests/Humans.Application.Tests/Infrastructure/UserInfoStubHelpers.cs
@@ -15,13 +15,28 @@ namespace Humans.Application.Tests.Infrastructure;
 /// </summary>
 internal static class UserInfoStubHelpers
 {
-    public static UserInfo ToUserInfo(this User user, IReadOnlyList<UserEmail>? userEmails = null)
+    public static UserInfo ToUserInfo(
+        this User user,
+        IReadOnlyList<UserEmail>? userEmails = null,
+        Profile? profile = null)
         => UserInfo.Create(
             user,
             userEmails ?? user.UserEmails?.ToList() ?? [],
             [],
             [],
-            profile: null,
+            profile: profile,
+            [],
+            [],
+            [],
+            []);
+
+    public static UserInfo MakeUserInfo(Guid userId, Profile? profile = null, string displayName = "User")
+        => UserInfo.Create(
+            new User { Id = userId, DisplayName = displayName, PreferredLanguage = "en" },
+            [],
+            [],
+            [],
+            profile: profile,
             [],
             [],
             [],
@@ -29,7 +44,7 @@ internal static class UserInfoStubHelpers
 
     /// <summary>
     /// Stubs GetUserInfosAsync to read from the provided DbContext options (new context per call,
-    /// includes UserEmails).
+    /// includes UserEmails + Profile slice).
     /// </summary>
     public static IUserService StubGetUserInfosFromDb(this IUserService userService, DbContextOptions<HumansDbContext> options)
     {
@@ -46,9 +61,12 @@ internal static class UserInfoStubHelpers
                     .Include(u => u.UserEmails)
                     .Where(u => ids.Contains(u.Id))
                     .ToList();
+                var profiles = db.Profiles.AsNoTracking()
+                    .Where(p => ids.Contains(p.UserId))
+                    .ToDictionary(p => p.UserId);
                 IReadOnlyDictionary<Guid, UserInfo> dict = users.ToDictionary(
                     u => u.Id,
-                    u => u.ToUserInfo(u.UserEmails.ToList()));
+                    u => u.ToUserInfo(u.UserEmails.ToList(), profiles.GetValueOrDefault(u.Id)));
                 return new ValueTask<IReadOnlyDictionary<Guid, UserInfo>>(dict);
             });
         return userService;
@@ -72,9 +90,12 @@ internal static class UserInfoStubHelpers
                     .Include(u => u.UserEmails)
                     .Where(u => ids.Contains(u.Id))
                     .ToList();
+                var profiles = dbContext.Profiles.AsNoTracking()
+                    .Where(p => ids.Contains(p.UserId))
+                    .ToDictionary(p => p.UserId);
                 IReadOnlyDictionary<Guid, UserInfo> dict = users.ToDictionary(
                     u => u.Id,
-                    u => u.ToUserInfo(u.UserEmails.ToList()));
+                    u => u.ToUserInfo(u.UserEmails.ToList(), profiles.GetValueOrDefault(u.Id)));
                 return new ValueTask<IReadOnlyDictionary<Guid, UserInfo>>(dict);
             });
         return userService;

--- a/tests/Humans.Application.Tests/Services/Expenses/ExpenseReportServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Expenses/ExpenseReportServiceTests.cs
@@ -194,8 +194,8 @@ public class ExpenseReportServiceTests
         var submitter = Guid.NewGuid();
         var id = await _sut.CreateDraftAsync(submitter, category.Id, null);
         var report = await _sut.GetAsync(id);
-        _profileService.GetProfileAsync(submitter, Arg.Any<CancellationToken>())
-            .Returns(new Profile { Id = Guid.NewGuid(), UserId = submitter, Iban = "ES9121000418450200051332" });
+        _userService.GetUserInfoAsync(submitter, Arg.Any<CancellationToken>())
+            .Returns(WrapInUserInfo(new Profile { Id = Guid.NewGuid(), UserId = submitter, Iban = "ES9121000418450200051332" }));
 
         var result = await _sut.GetDetailViewDataAsync(submitter, report!);
 
@@ -747,8 +747,8 @@ public class ExpenseReportServiceTests
     public async Task SaveSubmitterIbanWithResultAsync_ReturnsValidationFailure_WhenIbanInvalid()
     {
         var submitter = Guid.NewGuid();
-        _profileService.GetProfileAsync(submitter, Arg.Any<CancellationToken>())
-            .Returns(new Profile { Id = Guid.NewGuid(), UserId = submitter, Iban = "ES9121000418450200051332" });
+        _userService.GetUserInfoAsync(submitter, Arg.Any<CancellationToken>())
+            .Returns(WrapInUserInfo(new Profile { Id = Guid.NewGuid(), UserId = submitter, Iban = "ES9121000418450200051332" }));
 
         var result = await _sut.SaveSubmitterIbanWithResultAsync(submitter, "not-an-iban");
 
@@ -762,8 +762,8 @@ public class ExpenseReportServiceTests
     public async Task GetSubmitterIbanViewAsync_ReturnsMaskedIban_WhenProfileHasIban()
     {
         var submitter = Guid.NewGuid();
-        _profileService.GetProfileAsync(submitter, Arg.Any<CancellationToken>())
-            .Returns(new Profile { Id = Guid.NewGuid(), UserId = submitter, Iban = "ES9121000418450200051332" });
+        _userService.GetUserInfoAsync(submitter, Arg.Any<CancellationToken>())
+            .Returns(WrapInUserInfo(new Profile { Id = Guid.NewGuid(), UserId = submitter, Iban = "ES9121000418450200051332" }));
 
         var result = await _sut.GetSubmitterIbanViewAsync(submitter);
 

--- a/tests/Humans.Application.Tests/Services/FeedbackServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/FeedbackServiceTests.cs
@@ -31,7 +31,6 @@ public class FeedbackServiceTests : IDisposable
     private readonly IUserService _userService;
     private readonly IUserEmailService _userEmailService;
     private readonly ITeamService _teamService;
-    private readonly IProfileService _profileService;
     private readonly INotificationService _notificationService;
     private readonly INavBadgeCacheInvalidator _navBadge;
     private readonly IFeedbackRepository _repository;
@@ -130,26 +129,13 @@ public class FeedbackServiceTests : IDisposable
                     t.ParentTeamId));
             });
 
-        _profileService = Substitute.For<IProfileService>();
-        _profileService
-            .GetByUserIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
-            .Returns(call =>
-            {
-                var ids = (IReadOnlyCollection<Guid>)call[0]!;
-                IReadOnlyDictionary<Guid, Profile> dict = _dbContext.Profiles
-                    .AsNoTracking()
-                    .Where(p => ids.Contains(p.UserId))
-                    .ToDictionary(p => p.UserId);
-                return Task.FromResult(dict);
-            });
-
         _notificationService = Substitute.For<INotificationService>();
         _navBadge = Substitute.For<INavBadgeCacheInvalidator>();
 
         _repository = new FeedbackRepository(new TestDbContextFactory(options));
 
         _service = new FeedbackApplicationService(
-            _repository, _userService, _userEmailService, _teamService, _profileService,
+            _repository, _userService, _userEmailService, _teamService,
             _emailService, _notificationService, _auditLog, _navBadge, _clock, env,
             NullLogger<FeedbackApplicationService>.Instance);
     }

--- a/tests/Humans.Application.Tests/Services/MembershipCalculatorTests.cs
+++ b/tests/Humans.Application.Tests/Services/MembershipCalculatorTests.cs
@@ -10,7 +10,6 @@ using Humans.Application.Interfaces.Consent;
 using Humans.Application.Interfaces.Legal;
 using Humans.Application.Interfaces.Users;
 using Humans.Application.Interfaces.Governance;
-using Humans.Application.Interfaces.Profiles;
 
 namespace Humans.Application.Tests.Services;
 
@@ -18,7 +17,6 @@ public class MembershipCalculatorTests
 {
     private readonly FakeClock _clock;
     private readonly MembershipCalculator _service;
-    private readonly IProfileService _profileService = Substitute.For<IProfileService>();
     private readonly IMembershipQuery _membershipQuery = Substitute.For<IMembershipQuery>();
     private readonly IUserService _userService = Substitute.For<IUserService>();
     private readonly IConsentService _consentService = Substitute.For<IConsentService>();
@@ -39,7 +37,6 @@ public class MembershipCalculatorTests
         serviceProvider.GetService(typeof(IConsentService)).Returns(_consentService);
 
         _service = new MembershipCalculator(
-            _profileService,
             _membershipQuery,
             _userService,
             _legalDocumentSyncService,
@@ -55,14 +52,14 @@ public class MembershipCalculatorTests
                 return profile is null ? null : WrapInUserInfo(profile);
             });
 
-        _profileService.GetByUserIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
+        _userService.GetUserInfosAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
             .Returns(ci =>
             {
                 var ids = ci.Arg<IReadOnlyCollection<Guid>>();
                 var map = ids
                     .Where(_profilesByUserId.ContainsKey)
-                    .ToDictionary(id => id, id => _profilesByUserId[id]);
-                return Task.FromResult<IReadOnlyDictionary<Guid, Profile>>(map);
+                    .ToDictionary(id => id, id => WrapInUserInfo(_profilesByUserId[id]));
+                return new ValueTask<IReadOnlyDictionary<Guid, UserInfo>>(map);
             });
 
         _membershipQuery.GetUserTeamsAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())

--- a/tests/Humans.Application.Tests/Services/MembershipPartitionTests.cs
+++ b/tests/Humans.Application.Tests/Services/MembershipPartitionTests.cs
@@ -10,7 +10,7 @@ using Humans.Application.Interfaces.Consent;
 using Humans.Application.Interfaces.Legal;
 using Humans.Application.Interfaces.Users;
 using Humans.Application.Interfaces.Governance;
-using Humans.Application.Interfaces.Profiles;
+using Humans.Domain.Enums;
 
 namespace Humans.Application.Tests.Services;
 
@@ -18,7 +18,6 @@ public class MembershipPartitionTests
 {
     private readonly FakeClock _clock;
     private readonly MembershipCalculator _service;
-    private readonly IProfileService _profileService = Substitute.For<IProfileService>();
     private readonly IMembershipQuery _membershipQuery = Substitute.For<IMembershipQuery>();
     private readonly IUserService _userService = Substitute.For<IUserService>();
     private readonly IConsentService _consentService = Substitute.For<IConsentService>();
@@ -37,40 +36,23 @@ public class MembershipPartitionTests
         serviceProvider.GetService(typeof(IConsentService)).Returns(_consentService);
 
         _service = new MembershipCalculator(
-            _profileService,
             _membershipQuery,
             _userService,
             _legalDocumentSyncService,
             serviceProvider,
             _clock);
 
-        _userService.GetByIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
-            .Returns(ci =>
-            {
-                var ids = ci.Arg<IReadOnlyCollection<Guid>>();
-                var map = ids
-                    .Where(_usersById.ContainsKey)
-                    .ToDictionary(id => id, id => _usersById[id]);
-                return Task.FromResult<IReadOnlyDictionary<Guid, User>>(map);
-            });
         _userService.GetUserInfosAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
             .Returns(ci =>
             {
                 var ids = ci.Arg<IReadOnlyCollection<Guid>>();
                 IReadOnlyDictionary<Guid, UserInfo> map = ids
                     .Where(_usersById.ContainsKey)
-                    .ToDictionary(id => id, id => _usersById[id].ToUserInfo());
+                    .ToDictionary(
+                        id => id,
+                        id => _usersById[id].ToUserInfo(
+                            profile: _profilesByUserId.GetValueOrDefault(id)));
                 return new ValueTask<IReadOnlyDictionary<Guid, UserInfo>>(map);
-            });
-
-        _profileService.GetByUserIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
-            .Returns(ci =>
-            {
-                var ids = ci.Arg<IReadOnlyCollection<Guid>>();
-                var map = ids
-                    .Where(_profilesByUserId.ContainsKey)
-                    .ToDictionary(id => id, id => _profilesByUserId[id]);
-                return Task.FromResult<IReadOnlyDictionary<Guid, Profile>>(map);
             });
 
         _legalDocumentSyncService.GetRequiredDocumentVersionsForTeamAsync(
@@ -304,7 +286,7 @@ public class MembershipPartitionTests
             FirstName = "Test",
             LastName = "User",
             IsApproved = isApproved,
-            IsSuspended = isSuspended,
+            State = isSuspended ? ProfileState.Suspended : ProfileState.Active,
             CreatedAt = _clock.GetCurrentInstant(),
             UpdatedAt = _clock.GetCurrentInstant()
         };

--- a/tests/Humans.Application.Tests/Services/ProfileServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/ProfileServiceTests.cs
@@ -243,31 +243,6 @@ public class ProfileServiceTests : IDisposable
     // issue nobodies-collective/Humans#685. Deletion request/cancel moved to
     // IAccountDeletionService (covered by AccountDeletionServiceTests).
 
-    // --- Simple lookups ---
-
-    [HumansFact]
-    public async Task GetProfileAsync_ExistingUser_ReturnsProfile()
-    {
-        var userId = Guid.NewGuid();
-        await SeedUserWithProfileAsync(userId);
-
-        var result = await _service.GetProfileAsync(userId);
-
-        result.Should().NotBeNull();
-        result!.UserId.Should().Be(userId);
-    }
-
-    [HumansFact]
-    public async Task GetProfileAsync_NoProfile_ReturnsNull()
-    {
-        var userId = Guid.NewGuid();
-        await SeedUserAsync(userId);
-
-        var result = await _service.GetProfileAsync(userId);
-
-        result.Should().BeNull();
-    }
-
     [HumansFact]
     public async Task GetProfilePictureAsync_WithPicture_ReturnsData()
     {

--- a/tests/Humans.Application.Tests/Services/ProfileServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/ProfileServiceTests.cs
@@ -58,6 +58,7 @@ public class ProfileServiceTests : IDisposable
             _contactFieldRepository, _communicationPreferenceRepository,
             _auditLogService,
             _fileStorage,
+            Substitute.For<IUserInfoInvalidator>(),
             _clock,
             NullLogger<ProfileService>.Instance);
 
@@ -525,6 +526,7 @@ public class ProfileServiceTests : IDisposable
         _contactFieldRepository, _communicationPreferenceRepository,
         _auditLogService,
         _fileStorage,
+        Substitute.For<IUserInfoInvalidator>(),
         _clock,
         NullLogger<ProfileService>.Instance);
 
@@ -671,6 +673,7 @@ public class ProfileServiceTests : IDisposable
             _contactFieldRepository, _communicationPreferenceRepository,
             _auditLogService,
             _fileStorage,
+            Substitute.For<IUserInfoInvalidator>(),
             _clock,
             NullLogger<ProfileService>.Instance);
 

--- a/tests/Humans.Application.Tests/Services/Shifts/ShiftDashboardMetricsTests.cs
+++ b/tests/Humans.Application.Tests/Services/Shifts/ShiftDashboardMetricsTests.cs
@@ -1010,6 +1010,8 @@ public class ShiftDashboardMetricsTests : IDisposable
         private readonly HumansDbContext _db;
         public FakeUserService(HumansDbContext db) => _db = db;
 
+        public bool IsWarmedUp => true;
+
         public ValueTask<UserInfo?> GetUserInfoAsync(Guid userId, CancellationToken ct = default)
             => throw new NotSupportedException();
 

--- a/tests/Humans.Application.Tests/Services/TicketQueryServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/TicketQueryServiceTests.cs
@@ -28,7 +28,6 @@ public sealed class TicketQueryServiceTests : IDisposable
     private readonly ICampaignService _campaignService = Substitute.For<ICampaignService>();
     private readonly IUserService _userService = Substitute.For<IUserService>();
     private readonly IUserEmailService _userEmailService = Substitute.For<IUserEmailService>();
-    private readonly IProfileService _profileService = Substitute.For<IProfileService>();
     private readonly ITeamService _teamService = Substitute.For<ITeamService>();
     private readonly IShiftManagementService _shiftManagementService = Substitute.For<IShiftManagementService>();
     private readonly TicketQueryService _service;
@@ -49,7 +48,6 @@ public sealed class TicketQueryServiceTests : IDisposable
             _campaignService,
             _userService,
             _userEmailService,
-            _profileService,
             _teamService,
             _shiftManagementService,
             SystemClock.Instance);
@@ -69,10 +67,6 @@ public sealed class TicketQueryServiceTests : IDisposable
                 Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
             .Returns(new Dictionary<Guid, User>());
         _userService.StubGetUserInfosFromDb(_options);
-
-        _profileService.GetByUserIdsAsync(
-                Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
-            .Returns(new Dictionary<Guid, Profile>());
 
         _userEmailService.GetNotificationEmailsByUserIdsAsync(
                 Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
@@ -600,23 +594,15 @@ public sealed class TicketQueryServiceTests : IDisposable
         _userService.GetAllUsersAsync(Arg.Any<CancellationToken>())
             .Returns(allUsers);
         _userService.GetAllUserInfos()
-            .Returns(allUsers.Select(u => u.ToUserInfo()).ToList());
-
-        _teamService.GetTeamAsync(SystemTeamIds.Volunteers, Arg.Any<CancellationToken>())
-            .Returns(VolunteersTeam(userIds));
-
-        var profilesByUserId = users
-            .Select(u => (UserId: u.Id, Profile: new Profile
+            .Returns(allUsers.Select(u => u.ToUserInfo(profile: new Profile
             {
                 Id = Guid.NewGuid(),
                 UserId = u.Id,
                 MembershipTier = MembershipTier.Volunteer,
-            }))
-            .ToDictionary(t => t.UserId, t => t.Profile);
+            })).ToList());
 
-        _profileService.GetByUserIdsAsync(
-                Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
-            .Returns(profilesByUserId);
+        _teamService.GetTeamAsync(SystemTeamIds.Volunteers, Arg.Any<CancellationToken>())
+            .Returns(VolunteersTeam(userIds));
 
         _userEmailService.GetNotificationEmailsByUserIdsAsync(
                 Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())

--- a/tests/Humans.Application.Tests/Services/Tickets/TicketQueryService_HoldingsTests.cs
+++ b/tests/Humans.Application.Tests/Services/Tickets/TicketQueryService_HoldingsTests.cs
@@ -36,7 +36,6 @@ public sealed class TicketQueryService_HoldingsTests
             Substitute.For<ICampaignService>(),
             Substitute.For<IUserService>(),
             Substitute.For<IUserEmailService>(),
-            Substitute.For<IProfileService>(),
             Substitute.For<ITeamService>(),
             Substitute.For<IShiftManagementService>(),
             SystemClock.Instance);

--- a/tests/Humans.Application.Tests/Services/Tickets/TicketTransferServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Tickets/TicketTransferServiceTests.cs
@@ -124,8 +124,6 @@ public sealed class TicketTransferServiceTests
                 new Profile { BurnerName = "Alice", FirstName = "Alice", LastName = "Smith" }));
         _userEmailService.GetPrimaryEmailAsync(userId, Arg.Any<CancellationToken>())
             .Returns("alice@example.com");
-        _profileService.GetProfileAsync(userId, Arg.Any<CancellationToken>())
-            .Returns((Profile?)null);
 
         var result = await _service.LookupReceiversAsync("alice@example.com", _senderId);
 
@@ -171,8 +169,6 @@ public sealed class TicketTransferServiceTests
                 new Profile { BurnerName = "Sparkle Person", FirstName = "Sparkle", LastName = "Person" }));
         _userEmailService.GetPrimaryEmailAsync(userId, Arg.Any<CancellationToken>())
             .Returns("sp@example.com");
-        _profileService.GetProfileAsync(userId, Arg.Any<CancellationToken>())
-            .Returns((Profile?)null);
 
         var result = await _service.LookupReceiversAsync("sparkle", _senderId);
 
@@ -203,8 +199,6 @@ public sealed class TicketTransferServiceTests
                 new Profile { BurnerName = "B", FirstName = "Bbb", LastName = "Bbb" }));
         _userEmailService.GetPrimaryEmailAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
             .Returns((string?)null);
-        _profileService.GetProfileAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
-            .Returns((Profile?)null);
 
         var result = await _service.LookupReceiversAsync("popular", _senderId);
 

--- a/tests/Humans.Web.Tests/Controllers/ProfileApiControllerTests.cs
+++ b/tests/Humans.Web.Tests/Controllers/ProfileApiControllerTests.cs
@@ -223,9 +223,6 @@ public class ProfileApiControllerTests
             .Should().BeAssignableTo<IEnumerable<HumanLookupSearchResult>>().Subject.Single();
         row.Detail.Should().Be("primary@example.com");
 
-        // GetByUserIdsAsync (DB-bound) is bypassed — ProfileId comes from HumanSearchResult.
-        await _profileService.DidNotReceive().GetByUserIdsAsync(
-            Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>());
     }
 
     [HumansFact]


### PR DESCRIPTION
## Summary

- 18 call sites move from `IProfileService.GetProfileAsync` / `GetByUserIdsAsync` to `UserInfo.Profile` from the cached read-model.
- Both methods are deleted from `IProfileService` and `ProfileService`.
- Slice 3 of the user-cache migration (`local/user-cache-migration-plan.md`).

## Notable decisions

- **SystemTeamSyncJob** keeps DB-direct semantics for the Volunteers reconciliation (cache-bypass on purpose per existing comment) by injecting `IProfileRepository` directly. The plan didn't list these 3 sites; preserving the warmup-bypass invariant requires keeping them off the cache.
- **AgentUserSnapshotProvider** was found by grep (not in plan); migrated to `UserInfo.Profile`.
- **ProfileCompletion** gains a `ProfileInfo` overload alongside the existing `Profile` overload so `DashboardService` can compute completion off the cached projection.
- **MembershipCalculator.PartitionUsersAsync** now reads everything (incl. State-based `IsSuspended`) off `UserInfo` — drops the legacy `Profile.IsSuspended` bool read at the partition site.
- **AdminHumanListAssembler** drops the `profilesByUserId` parameter; reads `IsApproved` off `UserInfo.Profile`.
- **IbanFailure** helper in `ExpenseReportService` now takes the iban string instead of a `Profile`.
- **`ProfileInfo` parity caveat:** `UserInfo.Profile` does not include `ProfilePictureData` (large blob, served separately) and exposes `BirthdayDay`/`BirthdayMonth` instead of full `DateOfBirth` (year-of-birth excluded by design). None of the 18 sites needed those fields.

## Test plan

- [x] `dotnet build Humans.slnx -v quiet` — clean
- [x] `dotnet test Humans.slnx` (Domain, Analyzers, Web, Application) — all green
- [ ] Integration tests have pre-existing Hangfire init failures on `origin/main` — not affected by this PR
- [ ] Preview environment smoke test

🤖 Generated with [Claude Code](https://claude.com/claude-code)