### PR TITLE
refactor(profiles): stop touching the obsolete ProfilePictureData column

### DIFF
--- a/src/Humans.Application/Interfaces/Profiles/IProfileService.cs
+++ b/src/Humans.Application/Interfaces/Profiles/IProfileService.cs
@@ -54,14 +54,13 @@ public interface IProfileService : IApplicationService, IUserMerge
         CancellationToken ct = default);
 
     /// <summary>
-    /// Returns the profile picture for the given profile, reading from the
-    /// filesystem store first and falling back to the DB column. On a
-    /// DB-fallback hit the bytes are migrated to the filesystem store so
-    /// subsequent requests use the fast path. Returns <c>null</c> when the
-    /// profile has no picture or has been anonymized (the DB content-type
-    /// column is null), so a stale on-disk file left behind by a failed
-    /// anonymization cleanup is not served. Centralizing the read path here
-    /// keeps controllers free of <see cref="IFileStorage"/>.
+    /// Returns the profile picture for the given profile, read from the
+    /// filesystem store. The DB <c>ProfilePictureContentType</c> column is
+    /// consulted first as a GDPR gate — if null (no picture, or anonymized)
+    /// the call returns <c>null</c> without touching disk so a stale on-disk
+    /// file left behind by a failed anonymization cleanup is not served.
+    /// Returns <c>null</c> when the file is missing on disk. Centralizing
+    /// the read path here keeps controllers free of <see cref="IFileStorage"/>.
     /// </summary>
     Task<(byte[] Data, string ContentType)?> GetProfilePictureAsync(Guid profileId, CancellationToken ct = default);
 

--- a/src/Humans.Application/Interfaces/Repositories/IProfileRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/IProfileRepository.cs
@@ -53,20 +53,13 @@ public interface IProfileRepository : IRepository
     Task<Guid?> GetOwnerUserIdAsync(Guid profileId, CancellationToken ct = default);
 
     /// <summary>
-    /// Returns just the profile picture data and content type.
-    /// Read-only (AsNoTracking).
-    /// </summary>
-    Task<(byte[]? Data, string? ContentType)> GetProfilePictureDataAsync(
-        Guid profileId, CancellationToken ct = default);
-
-    /// <summary>
-    /// Returns just the <c>ProfilePictureContentType</c> column for a profile —
-    /// scalar projection that avoids loading the bytea picture data. Returns
-    /// <c>null</c> if the profile does not exist or has no picture (including
-    /// when the picture was cleared by an anonymization run). Used by
-    /// <c>ProfileService.GetProfilePictureAsync</c> as a lightweight gate
-    /// before consulting the filesystem store, so an anonymized profile cannot
-    /// be served a stale on-disk file. Read-only (AsNoTracking).
+    /// Returns the <c>ProfilePictureContentType</c> column for a profile —
+    /// the GDPR gate consulted by <c>ProfileService.GetProfilePictureAsync</c>
+    /// before serving the on-disk file, and the source of the file extension.
+    /// Returns <c>null</c> if the profile does not exist or has no picture
+    /// (including when the picture was cleared by an anonymization run), so
+    /// an anonymized profile cannot be served a stale on-disk file. Read-only
+    /// (AsNoTracking).
     /// </summary>
     Task<string?> GetProfilePictureContentTypeAsync(
         Guid profileId, CancellationToken ct = default);

--- a/src/Humans.Application/Services/Profiles/ProfileService.cs
+++ b/src/Humans.Application/Services/Profiles/ProfileService.cs
@@ -142,7 +142,6 @@ public sealed class ProfileService : IProfileService, IUserDataContributor, IUse
         }
 
         var oldContentType = profile.ProfilePictureContentType;
-        profile.ProfilePictureData = pictureData;
         profile.ProfilePictureContentType = contentType;
         profile.UpdatedAt = _clock.GetCurrentInstant();
         await _profileRepository.UpdateAsync(profile, ct);
@@ -163,7 +162,7 @@ public sealed class ProfileService : IProfileService, IUserDataContributor, IUse
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
             _logger.LogWarning(ex,
-                "Failed to write profile picture to filesystem for {ProfileId}; DB write still applied",
+                "Failed to write profile picture to filesystem for {ProfileId}; content-type column is set but the file is missing — picture will not render",
                 profile.Id);
         }
 
@@ -173,48 +172,19 @@ public sealed class ProfileService : IProfileService, IUserDataContributor, IUse
     public async Task<(byte[] Data, string ContentType)?> GetProfilePictureAsync(
         Guid profileId, CancellationToken ct = default)
     {
-        // Anonymization gate (GDPR): a cheap scalar projection of the DB
-        // content-type column is the source of truth for whether a picture
-        // should be served. If anonymization (or any future cleanup) has
-        // cleared the DB column, do not serve from disk even if a stale
-        // file remains.
+        // Anonymization gate (GDPR): the content-type column is the source of
+        // truth for whether a picture should be served. If anonymization (or
+        // any future cleanup) has cleared the column, do not serve from disk
+        // even if a stale file remains.
         var dbContentType = await _profileRepository.GetProfilePictureContentTypeAsync(profileId, ct);
         if (string.IsNullOrEmpty(dbContentType))
         {
             return null;
         }
 
-        // Filesystem fast path. Avoids loading the bytea column when the file
-        // is already on disk (the common case after migrate-on-read).
         var key = ProfilePictureKey(profileId, dbContentType);
         var fsBytes = await _fileStorage.TryReadAsync(key, ct);
-        if (fsBytes is not null)
-        {
-            return (fsBytes, dbContentType);
-        }
-
-        // DB fallback + migrate-on-read.
-        var (data, contentType) = await _profileRepository.GetProfilePictureDataAsync(profileId, ct);
-        if (data is null || string.IsNullOrEmpty(contentType))
-        {
-            return null;
-        }
-
-        try
-        {
-            await _fileStorage.SaveAsync(ProfilePictureKey(profileId, contentType), data, ct);
-            _logger.LogInformation(
-                "Profile picture {ProfileId} served from DB fallback; migrated to filesystem",
-                profileId);
-        }
-        catch (Exception ex) when (ex is not OperationCanceledException)
-        {
-            _logger.LogWarning(ex,
-                "Profile picture {ProfileId} served from DB fallback; migration to filesystem failed",
-                profileId);
-        }
-
-        return (data, contentType);
+        return fsBytes is not null ? (fsBytes, dbContentType) : null;
     }
 
     public async Task<ProfilePictureMigrationSnapshot> GetProfilePictureMigrationSnapshotAsync(
@@ -330,13 +300,13 @@ public sealed class ProfileService : IProfileService, IUserDataContributor, IUse
             profile.DateOfBirth = null;
         }
 
-        // Handle profile picture. Phase 1 of issue nobodies-collective/Humans#527:
-        // dual-write to filesystem + DB so rollback stays safe. Phase 2 drops the
-        // DB columns once phase 1 has bedded in.
+        // Profile pictures live on the file share; the DB carries only the
+        // content-type marker so reads can find the file by extension and the
+        // GDPR gate has a single source of truth. The bytea column is dead —
+        // the column drop is a follow-up PR after prod soak.
         if (request.RemoveProfilePicture)
         {
             var oldContentType = profile.ProfilePictureContentType;
-            profile.ProfilePictureData = null;
             profile.ProfilePictureContentType = null;
             if (oldContentType is not null)
             {
@@ -347,7 +317,7 @@ public sealed class ProfileService : IProfileService, IUserDataContributor, IUse
                 catch (Exception ex) when (ex is not OperationCanceledException)
                 {
                     _logger.LogWarning(ex,
-                        "Failed to delete profile picture from filesystem for {ProfileId}; DB delete still applied",
+                        "Failed to delete profile picture from filesystem for {ProfileId}; content-type column has been cleared so the file will not be served",
                         profile.Id);
                 }
             }
@@ -355,7 +325,6 @@ public sealed class ProfileService : IProfileService, IUserDataContributor, IUse
         else if (request.ProfilePictureData is not null && request.ProfilePictureContentType is not null)
         {
             var oldContentType = profile.ProfilePictureContentType;
-            profile.ProfilePictureData = request.ProfilePictureData;
             profile.ProfilePictureContentType = request.ProfilePictureContentType;
             try
             {
@@ -375,7 +344,7 @@ public sealed class ProfileService : IProfileService, IUserDataContributor, IUse
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
                 _logger.LogWarning(ex,
-                    "Failed to write profile picture to filesystem for {ProfileId}; DB write still applied",
+                    "Failed to write profile picture to filesystem for {ProfileId}; content-type column is set but the file is missing — picture will not render",
                     profile.Id);
             }
         }
@@ -742,15 +711,13 @@ public sealed class ProfileService : IProfileService, IUserDataContributor, IUse
 
     public async Task<bool> AnonymizeExpiredProfileAsync(Guid userId, CancellationToken ct = default)
     {
-        // Anonymize clears ProfilePictureData / ProfilePictureContentType in
-        // the DB and best-effort wipes the filesystem copy (phase 1 of issue
-        // nobodies-collective/Humans#527). The DB clear alone is NOT
-        // sufficient under the FS-first read path: if this delete throws,
-        // the file remains on disk and TryReadAsync would otherwise serve it
-        // indefinitely. The read-path gate in GetProfilePictureAsync (which
-        // checks the DB content-type before consulting the filesystem)
-        // closes that loop — but we still log this failure as an Error so
-        // an operator can clean up the stale file out-of-band.
+        // Anonymize clears ProfilePictureContentType in the DB and best-effort
+        // wipes the filesystem copy. The DB clear alone is NOT sufficient on
+        // its own: if this delete throws, the file remains on disk. The
+        // read-path gate in GetProfilePictureAsync (which checks the
+        // content-type column before consulting the filesystem) closes that
+        // loop — but we still log this failure as an Error so an operator can
+        // clean up the stale file out-of-band.
         var profile = await _profileRepository.GetByUserIdReadOnlyAsync(userId, ct);
         var anonymized = await _profileRepository.AnonymizeForDeletionByUserIdAsync(userId, ct);
         if (anonymized && profile?.ProfilePictureContentType is not null)

--- a/src/Humans.Application/UserInfo.cs
+++ b/src/Humans.Application/UserInfo.cs
@@ -78,9 +78,10 @@ public sealed record UserExternalLoginInfo(
 
 /// <summary>
 /// Immutable projection of a <see cref="Profile"/> row carried inside
-/// <see cref="UserInfo"/>. <c>ProfilePictureData</c> is intentionally excluded
-/// (large blob, served separately); only <c>BirthdayDay</c> / <c>BirthdayMonth</c>
-/// are carried (year-of-birth excluded by design).
+/// <see cref="UserInfo"/>. Picture bytes are not carried — pictures live on
+/// the file share and are served via <c>ProfileController.Picture</c>; only
+/// <c>BirthdayDay</c> / <c>BirthdayMonth</c> are carried (year-of-birth
+/// excluded by design).
 /// </summary>
 public sealed record ProfileInfo(
     Guid Id,
@@ -430,7 +431,7 @@ public sealed record UserInfo(
                 EmergencyContactName: profile.EmergencyContactName,
                 EmergencyContactPhone: profile.EmergencyContactPhone,
                 EmergencyContactRelationship: profile.EmergencyContactRelationship,
-                HasCustomPicture: profile.ProfilePictureData is not null && profile.ProfilePictureData.Length > 0,
+                HasCustomPicture: profile.ProfilePictureContentType is not null,
                 ProfilePictureContentType: profile.ProfilePictureContentType,
                 CreatedAt: profile.CreatedAt,
                 UpdatedAt: profile.UpdatedAt,

--- a/src/Humans.Domain/Entities/Profile.cs
+++ b/src/Humans.Domain/Entities/Profile.cs
@@ -108,14 +108,19 @@ public class Profile
     public string? EmergencyContactRelationship { get; set; }
 
     /// <summary>
-    /// Custom profile picture data (resized to 256x256, max 2MB).
-    /// Stored in database given small scale (~500 users).
+    /// Obsolete — pictures live on the file share keyed by
+    /// <c>uploads/profile-pictures/{Id}.{ext}</c>. The column is retained
+    /// only until a follow-up PR drops it after prod soak per
+    /// <c>memory/architecture/no-drops-until-prod-verified.md</c>; no code
+    /// path reads or writes it.
     /// </summary>
     [PersonalData]
     public byte[]? ProfilePictureData { get; set; }
 
     /// <summary>
     /// MIME content type of the custom profile picture (e.g., "image/jpeg").
+    /// Doubles as the "has picture?" predicate (non-null ⇒ a file exists at
+    /// the convention-derived path) and the source of the file extension.
     /// </summary>
     public string? ProfilePictureContentType { get; set; }
 
@@ -249,7 +254,7 @@ public class Profile
     /// <summary>
     /// Whether this profile has a custom uploaded profile picture.
     /// </summary>
-    public bool HasCustomProfilePicture => ProfilePictureData is not null && ProfilePictureData.Length > 0;
+    public bool HasCustomProfilePicture => ProfilePictureContentType is not null;
 
     /// <summary>
     /// Contact fields with visibility controls.

--- a/src/Humans.Infrastructure/Repositories/Profiles/ProfileRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Profiles/ProfileRepository.cs
@@ -78,19 +78,6 @@ public sealed class ProfileRepository : IProfileRepository
             .FirstOrDefaultAsync(ct);
     }
 
-    public async Task<(byte[]? Data, string? ContentType)> GetProfilePictureDataAsync(
-        Guid profileId, CancellationToken ct = default)
-    {
-        await using var ctx = await _factory.CreateDbContextAsync(ct);
-        var data = await ctx.Profiles
-            .AsNoTracking()
-            .Where(p => p.Id == profileId)
-            .Select(p => new { p.ProfilePictureData, p.ProfilePictureContentType })
-            .FirstOrDefaultAsync(ct);
-
-        return (data?.ProfilePictureData, data?.ProfilePictureContentType);
-    }
-
     public async Task<string?> GetProfilePictureContentTypeAsync(
         Guid profileId, CancellationToken ct = default)
     {
@@ -112,7 +99,7 @@ public sealed class ProfileRepository : IProfileRepository
         await using var ctx = await _factory.CreateDbContextAsync(ct);
         return await ctx.Profiles
             .AsNoTracking()
-            .Where(p => userIdList.Contains(p.UserId) && p.ProfilePictureData != null)
+            .Where(p => userIdList.Contains(p.UserId) && p.ProfilePictureContentType != null)
             .Select(p => new { p.Id, p.UserId, p.UpdatedAt })
             .AsAsyncEnumerable()
             .Select(p => (p.Id, p.UserId, p.UpdatedAt.ToUnixTimeTicks()))
@@ -351,7 +338,6 @@ public sealed class ProfileRepository : IProfileRepository
         sourceProfile.AdminNotes = null;
         sourceProfile.Pronouns = null;
         sourceProfile.DateOfBirth = null;
-        sourceProfile.ProfilePictureData = null;
         sourceProfile.ProfilePictureContentType = null;
         sourceProfile.EmergencyContactName = null;
         sourceProfile.EmergencyContactPhone = null;
@@ -392,7 +378,6 @@ public sealed class ProfileRepository : IProfileRepository
         profile.AdminNotes = null;
         profile.Pronouns = null;
         profile.DateOfBirth = null;
-        profile.ProfilePictureData = null;
         profile.ProfilePictureContentType = null;
         profile.EmergencyContactName = null;
         profile.EmergencyContactPhone = null;

--- a/tests/Humans.Application.Tests/Helpers/ProfileCompletionTests.cs
+++ b/tests/Humans.Application.Tests/Helpers/ProfileCompletionTests.cs
@@ -43,7 +43,7 @@ public class ProfileCompletionTests
             BurnerName = "x",
             FirstName = "y",
             LastName = "z",
-            ProfilePictureData = [1, 2, 3],
+            ProfilePictureContentType = "image/png",
         };
 
         var delta = ProfileCompletion.ComputePercent(withPicture)
@@ -79,7 +79,7 @@ public class ProfileCompletionTests
             BurnerName = "x",
             FirstName = "y",
             LastName = "z",
-            ProfilePictureData = [1],
+            ProfilePictureContentType = "image/png",
             Pronouns = "they/them",
             Bio = "About me",
             City = "Madrid",

--- a/tests/Humans.Application.Tests/Services/ProfileServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/ProfileServiceTests.cs
@@ -177,24 +177,11 @@ public class ProfileServiceTests : IDisposable
         profile.DateOfBirth.Should().BeNull();
     }
 
-    [HumansFact]
-    public async Task SaveProfileAsync_RemoveProfilePicture_ClearsData()
-    {
-        var userId = Guid.NewGuid();
-        await SeedUserWithProfileAsync(userId, withPicture: true);
-        var request = MakeRequest(removeProfilePicture: true);
-
-        await _service.SaveProfileAsync(userId, "Test", request, "en");
-
-        var profile = await _dbContext.Profiles.AsNoTracking().FirstAsync(p => p.UserId == userId);
-        profile.ProfilePictureData.Should().BeNull();
-        profile.ProfilePictureContentType.Should().BeNull();
-    }
-
-    // --- Profile picture dual-write (phase 1 of issue nobodies-collective/Humans#527) ---
+    // --- Profile picture write paths (file share is the source of truth; the
+    // DB bytes column is obsolete and untouched by code) ---
 
     [HumansFact]
-    public async Task SaveProfileAsync_UploadsProfilePicture_DualWritesToDbAndFilesystem()
+    public async Task SaveProfileAsync_UploadsProfilePicture_WritesToFilesystem()
     {
         var userId = Guid.NewGuid();
         await SeedUserWithProfileAsync(userId);
@@ -204,32 +191,26 @@ public class ProfileServiceTests : IDisposable
         await _service.SaveProfileAsync(userId, "Test", request, "en");
 
         var profile = await _dbContext.Profiles.AsNoTracking().FirstAsync(p => p.UserId == userId);
-        // DB was written
-        profile.ProfilePictureData.Should().BeEquivalentTo(payload);
+        // Content-type column is the "has picture" marker + extension source.
         profile.ProfilePictureContentType.Should().Be("image/jpeg");
-        // Filesystem was written with the same bytes, keyed under uploads/profile-pictures/
+        // Bytes live on the file share, keyed under uploads/profile-pictures/.
         var key = PicKey(profile.Id, "image/jpeg");
         _fileStorage.Files.Should().ContainKey(key);
         _fileStorage.Files[key].Should().BeEquivalentTo(payload);
     }
 
     [HumansFact]
-    public async Task SaveProfileAsync_RemoveProfilePicture_DeletesFromDbAndFilesystem()
+    public async Task SaveProfileAsync_RemoveProfilePicture_ClearsContentTypeAndDeletesFile()
     {
         var userId = Guid.NewGuid();
         var profileId = await SeedUserWithProfileAsync(userId, withPicture: true);
-        // Pre-seed the filesystem side at the same content-type the seeded
-        // profile uses (image/png — see SeedUserWithProfileAsync) so we can
-        // assert deletion.
-        await _fileStorage.SaveAsync(PicKey(profileId, "image/png"), [1]);
 
         var request = MakeRequest(removeProfilePicture: true);
         await _service.SaveProfileAsync(userId, "Test", request, "en");
 
         var profile = await _dbContext.Profiles.AsNoTracking().FirstAsync(p => p.UserId == userId);
-        profile.ProfilePictureData.Should().BeNull();
         profile.ProfilePictureContentType.Should().BeNull();
-        _fileStorage.Files.Should().NotContainKey(PicKey(profile.Id, "image/png"));
+        _fileStorage.Files.Should().NotContainKey(PicKey(profileId, "image/png"));
     }
 
     // Threshold check (formerly SaveProfileAsync_CallsSetConsentCheckPending)
@@ -324,48 +305,34 @@ public class ProfileServiceTests : IDisposable
     }
 
     [HumansFact]
-    public async Task GetProfilePictureAsync_DbOnly_ReturnsAndMigratesToFilesystem()
+    public async Task GetProfilePictureAsync_FilesystemMiss_ReturnsNull()
     {
-        // Migrate-on-read: the DB still has the bytes (legacy data, or a
-        // disk-restore scenario) but the filesystem store does not. The
-        // service must return the DB copy AND seed the store so the next
-        // read takes the fast path.
+        // Content-type gate passes but the file is gone — the picture is
+        // simply missing. (Pre-cleanup PR a DB-bytes fallback masked this;
+        // the file share is now the only source of truth.)
         var userId = Guid.NewGuid();
         await SeedUserWithProfileAsync(userId, withPicture: true);
         var profile = await _dbContext.Profiles.FirstAsync(p => p.UserId == userId);
 
-        _fileStorage.Files.ContainsKey(PicKey(profile.Id, "image/png")).Should().BeFalse();
+        await _fileStorage.DeleteAsync(PicKey(profile.Id, "image/png"));
 
         var result = await _service.GetProfilePictureAsync(profile.Id);
 
-        result.Should().NotBeNull();
-        result!.Value.Data.Should().BeEquivalentTo(new byte[] { 1, 2, 3 });
-        result.Value.ContentType.Should().Be("image/png");
-
-        // Migrate-on-read should have populated the store under the content-typed key.
-        _fileStorage.Files.TryGetValue(PicKey(profile.Id, "image/png"), out var stored).Should().BeTrue();
-        stored.Should().BeEquivalentTo(new byte[] { 1, 2, 3 });
+        result.Should().BeNull();
     }
 
     [HumansFact]
     public async Task GetProfilePictureAsync_AnonymizedProfile_ReturnsNullEvenWithStaleFile()
     {
-        // GDPR / issue nobodies-collective/Humans#527 fix-pass: after
-        // anonymization the DB content-type is null. If the on-disk file
-        // wasn't successfully removed (best-effort delete failed) the read
-        // path MUST NOT serve it. The DB content-type column is the gate.
+        // GDPR: after anonymization the content-type column is null. If the
+        // on-disk file wasn't successfully removed (best-effort delete failed)
+        // the read path MUST NOT serve it. The content-type column is the gate.
         var userId = Guid.NewGuid();
         await SeedUserWithProfileAsync(userId, withPicture: true);
         var profile = await _dbContext.Profiles.FirstAsync(p => p.UserId == userId);
 
-        // Seed a stale on-disk file as if a prior anonymization left it behind.
-        await _fileStorage.SaveAsync(PicKey(profile.Id, "image/png"), [7, 7, 7]);
-
-        // Now anonymize via the service and force the FS delete to fail by
-        // pre-removing the entry, then re-add it AFTER the anonymize call.
-        // Easiest path: clear DB columns directly on the tracked profile.
+        // Clear the gate as if anonymization had run.
         var tracked = await _dbContext.Profiles.FirstAsync(p => p.UserId == userId);
-        tracked.ProfilePictureData = null;
         tracked.ProfilePictureContentType = null;
         await _dbContext.SaveChangesAsync();
 
@@ -589,11 +556,14 @@ public class ProfileServiceTests : IDisposable
         };
         if (withPicture)
         {
-            profile.ProfilePictureData = [1, 2, 3];
             profile.ProfilePictureContentType = "image/png";
         }
         _dbContext.Profiles.Add(profile);
         await _dbContext.SaveChangesAsync();
+        if (withPicture)
+        {
+            await _fileStorage.SaveAsync(PicKey(profile.Id, "image/png"), [1, 2, 3]);
+        }
         return profile.Id;
     }
 


### PR DESCRIPTION
## Summary

Profile pictures live on the file share at `uploads/profile-pictures/{Id}.{ext}`. The `Profile.ProfilePictureData` bytea column has been dual-written as a rollback fallback since nobodies-collective/Humans#527 phase 1. With every QA picture confirmed on disk, this PR makes the column tombstone-only — code stops reading and writing it. The column itself stays in place until a follow-up PR drops it after prod soak per [`memory/architecture/no-drops-until-prod-verified.md`](../blob/main/memory/architecture/no-drops-until-prod-verified.md).

`ProfilePictureContentType` stays live and load-bearing: GDPR gate (anonymization clears it; FS reads only happen when it's non-null), "has picture?" predicate, and source of the on-disk file extension.

### Writes removed
- `ProfileService.SetProfilePictureAsync` — no longer writes bytes.
- `ProfileService.SaveProfileCoreAsync` upload + remove branches — no longer write bytes.
- `ProfileRepository` merge + anonymize null-clears for the bytes column dropped. Per design, the column-drop PR sweeps remaining bytes; intervening leak window is acceptable.

### Reads removed
- `ProfileService.GetProfilePictureAsync` DB-fallback / migrate-on-read branch deleted. Filesystem is the only source of picture bytes.
- `IProfileRepository.GetProfilePictureDataAsync` (and its implementation) deleted as dead code.

### Predicates flipped from bytes-presence to content-type-presence
- `Profile.HasCustomProfilePicture`
- `UserInfo.HasCustomPicture` projection
- `ProfileRepository.GetCustomPictureInfoByUserIdsAsync` SQL filter

### Risk
Previously `SetProfilePictureAsync` logged "DB write still applied" if the FS save threw — the DB column was the rollback safety net. With this change, an FS write failure leaves `ProfilePictureContentType` set but no file on disk; `GetProfilePictureAsync` returns null and the picture doesn't render. Acceptable trade for local-disk storage on a single server.

### Follow-ups (separate PRs)
- nobodies-collective/Humans#528 — drop the `ProfilePictureData` column after prod soak.
- Re-key profile pictures by `userId` instead of `profileId` (profileId leaks the child id into URLs + on-disk filenames where the parent id would have done fine; orphans the file if a profile is ever replaced). New issue to be filed.

## Test plan

- [x] `dotnet build Humans.slnx -v quiet` — clean (0 warnings, 0 errors).
- [x] `dotnet test` Domain/Web/Analyzers/Application — all green (3260 passed, 1 skipped).
- [ ] Integration tests — pre-existing Hangfire `JobStorage.Current` bootstrap flake on main; unrelated to this diff.
- [ ] QA preview: upload a new picture, verify it renders; remove a picture, verify it goes away; verify existing legacy pictures still render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)