### PR TITLE
refactor(cache): T-02 GuideRoleResolver bypass -> ITeamService

### DIFF
--- a/src/Humans.Infrastructure/Services/GuideRoleResolver.cs
+++ b/src/Humans.Infrastructure/Services/GuideRoleResolver.cs
@@ -1,8 +1,9 @@
 using System.Security.Claims;
 using Humans.Application.Interfaces;
-using Humans.Application.Interfaces.Repositories;
+using Humans.Application.Interfaces.Teams;
 using Humans.Application.Models;
 using Humans.Domain.Constants;
+using Humans.Domain.Enums;
 
 namespace Humans.Infrastructure.Services;
 
@@ -23,11 +24,11 @@ public sealed class GuideRoleResolver : IGuideRoleResolver
         RoleNames.VolunteerCoordinator
     ];
 
-    private readonly ITeamRepository _teamRepository;
+    private readonly ITeamService _teamService;
 
-    public GuideRoleResolver(ITeamRepository teamRepository)
+    public GuideRoleResolver(ITeamService teamService)
     {
-        _teamRepository = teamRepository;
+        _teamService = teamService;
     }
 
     public async Task<GuideRoleContext> ResolveAsync(ClaimsPrincipal user, CancellationToken cancellationToken = default)
@@ -52,7 +53,13 @@ public sealed class GuideRoleResolver : IGuideRoleResolver
         var isCoordinator = false;
         if (Guid.TryParse(userIdClaim, out var userId))
         {
-            isCoordinator = await _teamRepository.IsAnyActiveCoordinatorAsync(userId, cancellationToken);
+            // Answered from the cached TeamInfo snapshot: TeamInfo.Members only
+            // contains active (LeftAt is null) memberships, so we just look for
+            // any team where the user holds the Coordinator role. Mirrors the
+            // SQL filter UserId == userId && Role == Coordinator && LeftAt == null.
+            var teamsById = await _teamService.GetTeamsAsync(cancellationToken);
+            isCoordinator = teamsById.Values.Any(t =>
+                t.Members.Any(m => m.UserId == userId && m.Role == TeamMemberRole.Coordinator));
         }
 
         return new GuideRoleContext(

--- a/tests/Humans.Application.Tests/Architecture/TeamsArchitectureTests.cs
+++ b/tests/Humans.Application.Tests/Architecture/TeamsArchitectureTests.cs
@@ -95,15 +95,19 @@ public class TeamsArchitectureTests
     /// <see cref="CachingTeamService"/>) so they hit the cache instead of the DB
     /// on every request. Repository injection inside the Teams section
     /// (<c>TeamService</c>, <c>CachingTeamService</c>, and the EF impl itself) is
-    /// the intended layering and is allowed.
+    /// the intended layering and is allowed. Scans all three production
+    /// assemblies — Application, Infrastructure, and Web — so a future regression
+    /// where a controller, page handler, or filter takes <see cref="ITeamRepository"/>
+    /// directly fails this test.
     /// </summary>
     [HumansFact]
     public void ITeamRepository_InjectedOnlyInsideTeamsSection()
     {
         var assembliesToScan = new[]
         {
-            typeof(TeamService).Assembly,           // Humans.Application
-            typeof(CachingTeamService).Assembly,    // Humans.Infrastructure
+            typeof(TeamService).Assembly,                                // Humans.Application
+            typeof(CachingTeamService).Assembly,                         // Humans.Infrastructure
+            typeof(Humans.Web.Controllers.HomeController).Assembly,      // Humans.Web
         };
 
         var violations = new List<string>();

--- a/tests/Humans.Application.Tests/Architecture/TeamsArchitectureTests.cs
+++ b/tests/Humans.Application.Tests/Architecture/TeamsArchitectureTests.cs
@@ -1,7 +1,9 @@
+using System.Reflection;
 using AwesomeAssertions;
 using Humans.Application.Interfaces.Repositories;
 using Humans.Application.Interfaces.Teams;
 using Humans.Infrastructure.Repositories.Teams;
+using Humans.Infrastructure.Services.Teams;
 using TeamService = Humans.Application.Services.Teams.TeamService;
 
 namespace Humans.Application.Tests.Architecture;
@@ -82,5 +84,67 @@ public class TeamsArchitectureTests
         typeof(TeamRepository).Namespace
             .Should().Be("Humans.Infrastructure.Repositories.Teams",
                 because: "EF-backed repository implementations live in Humans.Infrastructure.Repositories.<Section> per design-rules §15b");
+    }
+
+    // ── ITeamRepository injection is Teams-section-only ──────────────────────
+
+    /// <summary>
+    /// Production code outside the Teams section namespace must not inject
+    /// <see cref="ITeamRepository"/> directly. Cross-section reads route through
+    /// the public <see cref="ITeamService"/> surface (decorated by
+    /// <see cref="CachingTeamService"/>) so they hit the cache instead of the DB
+    /// on every request. Repository injection inside the Teams section
+    /// (<c>TeamService</c>, <c>CachingTeamService</c>, and the EF impl itself) is
+    /// the intended layering and is allowed.
+    /// </summary>
+    [HumansFact]
+    public void ITeamRepository_InjectedOnlyInsideTeamsSection()
+    {
+        var assembliesToScan = new[]
+        {
+            typeof(TeamService).Assembly,           // Humans.Application
+            typeof(CachingTeamService).Assembly,    // Humans.Infrastructure
+        };
+
+        var violations = new List<string>();
+        foreach (var assembly in assembliesToScan)
+        {
+            foreach (var type in assembly.GetTypes()
+                         .Where(t => t.IsClass && !t.IsAbstract))
+            {
+                if (IsTeamsSectionType(type))
+                    continue;
+
+                foreach (var ctor in type.GetConstructors(BindingFlags.Public | BindingFlags.Instance))
+                {
+                    foreach (var parameter in ctor.GetParameters())
+                    {
+                        if (parameter.ParameterType == typeof(ITeamRepository))
+                        {
+                            violations.Add($"{type.FullName}:{parameter.ParameterType.Name}");
+                        }
+                    }
+                }
+            }
+        }
+
+        violations.Should().BeEmpty(
+            because: "non-Teams sections must read teams via ITeamService (cache-backed), not ITeamRepository (DB-direct). " +
+                     "T-02 (docs/plans/2026-05-16-cache-migration.md) removes the last bypass; this test pins the rule.");
+    }
+
+    private static bool IsTeamsSectionType(Type type)
+    {
+        var ns = type.Namespace;
+        if (ns is null)
+            return false;
+
+        // Teams section homes for production code that legitimately injects ITeamRepository:
+        //   - Humans.Application.Services.Teams.*   (TeamService and helpers)
+        //   - Humans.Infrastructure.Services.Teams.* (CachingTeamService decorator)
+        //   - Humans.Infrastructure.Repositories.Teams.* (the EF impl itself)
+        return ns.StartsWith("Humans.Application.Services.Teams", StringComparison.Ordinal)
+            || ns.StartsWith("Humans.Infrastructure.Services.Teams", StringComparison.Ordinal)
+            || ns.StartsWith("Humans.Infrastructure.Repositories.Teams", StringComparison.Ordinal);
     }
 }

--- a/tests/Humans.Application.Tests/Services/GuideRoleResolverTests.cs
+++ b/tests/Humans.Application.Tests/Services/GuideRoleResolverTests.cs
@@ -1,37 +1,26 @@
 using System.Security.Claims;
 using AwesomeAssertions;
-using Microsoft.EntityFrameworkCore;
+using Humans.Application.Interfaces.Teams;
+using Humans.Domain.Constants;
+using Humans.Domain.Enums;
+using Humans.Infrastructure.Services;
 using NodaTime;
 using NodaTime.Testing;
-using Humans.Application.Tests.Infrastructure;
-using Humans.Domain.Constants;
-using Humans.Domain.Entities;
-using Humans.Domain.Enums;
-using Humans.Infrastructure.Data;
-using Humans.Infrastructure.Repositories.Teams;
-using Humans.Infrastructure.Services;
+using NSubstitute;
 
 namespace Humans.Application.Tests.Services;
 
-public class GuideRoleResolverTests : IDisposable
+public class GuideRoleResolverTests
 {
-    private readonly HumansDbContext _db;
-    private readonly TestDbContextFactory _factory;
     private readonly FakeClock _clock = new(Instant.FromUtc(2026, 4, 21, 12, 0));
+    private readonly ITeamService _teamService = Substitute.For<ITeamService>();
 
     public GuideRoleResolverTests()
     {
-        var options = new DbContextOptionsBuilder<HumansDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .Options;
-        _db = new HumansDbContext(options);
-        _factory = new TestDbContextFactory(options);
-    }
-
-    public void Dispose()
-    {
-        _db.Dispose();
-        GC.SuppressFinalize(this);
+        // Default: empty team cache.
+        _teamService
+            .GetTeamsAsync(Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<Guid, TeamInfo>());
     }
 
     private ClaimsPrincipal PrincipalWithRoles(Guid? userId, params string[] roles)
@@ -49,8 +38,39 @@ public class GuideRoleResolverTests : IDisposable
         return new ClaimsPrincipal(identity);
     }
 
-    private GuideRoleResolver CreateResolver() =>
-        new(new TeamRepository(_factory));
+    private GuideRoleResolver CreateResolver() => new(_teamService);
+
+    private TeamInfo BuildTeam(Guid teamId, params TeamMemberInfo[] members) => new(
+        Id: teamId,
+        Name: "T",
+        Description: null,
+        Slug: "t",
+        IsActive: true,
+        IsSystemTeam: false,
+        SystemTeamType: SystemTeamType.None,
+        RequiresApproval: false,
+        IsPublicPage: false,
+        IsHidden: false,
+        IsPromotedToDirectory: false,
+        CreatedAt: _clock.GetCurrentInstant(),
+        Members: members.ToList());
+
+    private TeamMemberInfo Member(Guid userId, TeamMemberRole role) => new(
+        TeamMemberId: Guid.NewGuid(),
+        UserId: userId,
+        DisplayName: "u",
+        Email: null,
+        ProfilePictureUrl: null,
+        Role: role,
+        JoinedAt: _clock.GetCurrentInstant());
+
+    private void StubTeams(params TeamInfo[] teams)
+    {
+        var byId = teams.ToDictionary(t => t.Id);
+        _teamService
+            .GetTeamsAsync(Arg.Any<CancellationToken>())
+            .Returns((IReadOnlyDictionary<Guid, TeamInfo>)byId);
+    }
 
     [HumansFact]
     public async Task Resolve_Anonymous_ReturnsAnonymousContext()
@@ -81,24 +101,7 @@ public class GuideRoleResolverTests : IDisposable
     {
         var userId = Guid.NewGuid();
         var teamId = Guid.NewGuid();
-        _db.Teams.Add(new Team
-        {
-            Id = teamId,
-            Name = "T",
-            Slug = "t",
-            IsActive = true,
-            CreatedAt = _clock.GetCurrentInstant(),
-            UpdatedAt = _clock.GetCurrentInstant()
-        });
-        _db.TeamMembers.Add(new TeamMember
-        {
-            Id = Guid.NewGuid(),
-            TeamId = teamId,
-            UserId = userId,
-            Role = TeamMemberRole.Coordinator,
-            JoinedAt = _clock.GetCurrentInstant()
-        });
-        await _db.SaveChangesAsync(CancellationToken.None);
+        StubTeams(BuildTeam(teamId, Member(userId, TeamMemberRole.Coordinator)));
 
         var resolver = CreateResolver();
         var user = PrincipalWithRoles(userId);
@@ -111,27 +114,11 @@ public class GuideRoleResolverTests : IDisposable
     [HumansFact]
     public async Task Resolve_FormerTeamCoordinator_IsTeamCoordinatorFalse()
     {
+        // TeamInfo.Members in the cache only contains active (LeftAt is null) memberships,
+        // so a former coordinator simply does not appear in the cached members list.
         var userId = Guid.NewGuid();
         var teamId = Guid.NewGuid();
-        _db.Teams.Add(new Team
-        {
-            Id = teamId,
-            Name = "T",
-            Slug = "t",
-            IsActive = true,
-            CreatedAt = _clock.GetCurrentInstant(),
-            UpdatedAt = _clock.GetCurrentInstant()
-        });
-        _db.TeamMembers.Add(new TeamMember
-        {
-            Id = Guid.NewGuid(),
-            TeamId = teamId,
-            UserId = userId,
-            Role = TeamMemberRole.Coordinator,
-            JoinedAt = _clock.GetCurrentInstant(),
-            LeftAt = _clock.GetCurrentInstant()
-        });
-        await _db.SaveChangesAsync(CancellationToken.None);
+        StubTeams(BuildTeam(teamId)); // no members — former coordinator pruned
 
         var resolver = CreateResolver();
         var user = PrincipalWithRoles(userId);
@@ -146,24 +133,7 @@ public class GuideRoleResolverTests : IDisposable
     {
         var userId = Guid.NewGuid();
         var teamId = Guid.NewGuid();
-        _db.Teams.Add(new Team
-        {
-            Id = teamId,
-            Name = "T",
-            Slug = "t",
-            IsActive = true,
-            CreatedAt = _clock.GetCurrentInstant(),
-            UpdatedAt = _clock.GetCurrentInstant()
-        });
-        _db.TeamMembers.Add(new TeamMember
-        {
-            Id = Guid.NewGuid(),
-            TeamId = teamId,
-            UserId = userId,
-            Role = TeamMemberRole.Member,
-            JoinedAt = _clock.GetCurrentInstant()
-        });
-        await _db.SaveChangesAsync(CancellationToken.None);
+        StubTeams(BuildTeam(teamId, Member(userId, TeamMemberRole.Member)));
 
         var resolver = CreateResolver();
         var user = PrincipalWithRoles(userId);
@@ -171,5 +141,21 @@ public class GuideRoleResolverTests : IDisposable
         var result = await resolver.ResolveAsync(user, CancellationToken.None);
 
         result.IsTeamCoordinator.Should().BeFalse();
+    }
+
+    [HumansFact]
+    public async Task Resolve_CoordinatorOnOneTeamMemberOnAnother_IsTeamCoordinatorTrue()
+    {
+        var userId = Guid.NewGuid();
+        StubTeams(
+            BuildTeam(Guid.NewGuid(), Member(userId, TeamMemberRole.Member)),
+            BuildTeam(Guid.NewGuid(), Member(userId, TeamMemberRole.Coordinator)));
+
+        var resolver = CreateResolver();
+        var user = PrincipalWithRoles(userId);
+
+        var result = await resolver.ResolveAsync(user, CancellationToken.None);
+
+        result.IsTeamCoordinator.Should().BeTrue();
     }
 }


### PR DESCRIPTION
## Task
T-02 - GuideRoleResolver direct repo bypass -> cache read

Spec: [docs/plans/2026-05-16-cache-migration.md](docs/plans/2026-05-16-cache-migration.md) - see the T-02 section.

## Definition of done
- [x] GuideRoleResolver injects ITeamService instead of ITeamRepository
- [x] IsAnyActiveCoordinatorAsync answers from cached TeamInfo snapshot
- [x] Architecture test pins no direct ITeamRepository injection outside Teams section

## What changed

`GuideRoleResolver.ResolveAsync` previously injected `ITeamRepository` and issued `db.TeamMembers.AnyAsync(...)` on every authenticated nav render. Now it injects `ITeamService` and answers in-memory against the cached `TeamInfo` snapshot:

```csharp
var teamsById = await _teamService.GetTeamsAsync(cancellationToken);
isCoordinator = teamsById.Values.Any(t =>
    t.Members.Any(m => m.UserId == userId && m.Role == TeamMemberRole.Coordinator));
```

`TeamInfo.Members` only contains active memberships (the projection in `CachingTeamService.BuildTeamInfo` filters `LeftAt is null`), so the predicate exactly mirrors the original SQL filter `UserId == userId && Role == Coordinator && LeftAt == null` with no extra active-team or system-team filter.

## Architecture test

Added `TeamsArchitectureTests.ITeamRepository_InjectedOnlyInsideTeamsSection` that reflects across `Humans.Application` and `Humans.Infrastructure`, finds every non-abstract class whose constructor takes `ITeamRepository`, and asserts the declaring namespace lives under one of:

- `Humans.Application.Services.Teams.*` (TeamService)
- `Humans.Infrastructure.Services.Teams.*` (CachingTeamService decorator)
- `Humans.Infrastructure.Repositories.Teams.*` (the EF impl itself)

Catches any future regression where a non-Teams section injects `ITeamRepository` directly.

## Files touched
- `src/Humans.Infrastructure/Services/GuideRoleResolver.cs` - switch dependency, read from cache
- `tests/Humans.Application.Tests/Services/GuideRoleResolverTests.cs` - mock `ITeamService`, drop the in-memory DB fixture; added one case for coordinator-on-one-team-member-on-another
- `tests/Humans.Application.Tests/Architecture/TeamsArchitectureTests.cs` - added `ITeamRepository_InjectedOnlyInsideTeamsSection`

## Tests added/updated
- 6 `GuideRoleResolverTests` (was 4): added `Resolve_CoordinatorOnOneTeamMemberOnAnother_IsTeamCoordinatorTrue`; rewrote three existing cases to use the cache rather than EF in-memory.
- 1 new architecture test: `ITeamRepository_InjectedOnlyInsideTeamsSection`.

## Verification
- `dotnet build Humans.slnx -v quiet` - 0 warnings, 0 errors
- `dotnet test Humans.slnx -v quiet`:
  - Humans.Domain.Tests: 186 passed, 1 skipped
  - Humans.Analyzers.Tests: 96 passed
  - Humans.Application.Tests: 2884 passed, 1 skipped (includes the new arch + resolver tests)
  - Humans.Web.Tests: 93 passed
  - Humans.Integration.Tests: 62 pre-existing failures on origin/main (Hangfire `JobStorage` host wiring); verified by checking out clean `origin/main` and rerunning - identical failure set, not introduced by this PR.

## Eventual-consistency note
Cache reads are eventually consistent. If a user just gained a Coordinator role on a team, a stale `false` is acceptable (next page renders correctly after invalidation). A stale `true` is bounded: `IsTeamCoordinator` only gates Guide visibility, not data access - the per-team Coordinator authorization paths still re-check against `ITeamService.IsUserCoordinatorOfTeamAsync` (also cache-backed and invalidated on the same writes).

## Shortcuts / compromises
NONE.

## Coordination
No conflict. No `HumansDbContext` touch. T-01 (parallel) lives in `CachingTeamService.GetTeamDetailAsync` and the inner `TeamService` - disjoint from this PR's surface.