### PR TITLE
refactor(cache): T-05 Drain IProfileService.GetByUserIdsAsync onto UserInfo.Profile

### DIFF
--- a/src/Humans.Application/DTOs/ProfileSearchResults.cs
+++ b/src/Humans.Application/DTOs/ProfileSearchResults.cs
@@ -9,7 +9,7 @@ namespace Humans.Application.DTOs;
 /// <param name="UserId">Owning user id.</param>
 /// <param name="ProfileId">Owning profile id. Surfaced so callers that need
 /// to fan out into <c>IContactFieldService</c> (which keys by profile id)
-/// don't have to round-trip through <c>GetByUserIdsAsync</c>.</param>
+/// don't have to round-trip through a profile lookup.</param>
 /// <param name="BurnerName">The human's primary public display label.
 /// Falls back to <c>User.DisplayName</c> when
 /// <see cref="Humans.Domain.Entities.Profile.BurnerName"/> is unset.</param>

--- a/src/Humans.Application/Interfaces/Repositories/IProfileRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/IProfileRepository.cs
@@ -31,13 +31,6 @@ public interface IProfileRepository : IRepository
     Task<Profile?> GetByUserIdReadOnlyAsync(Guid userId, CancellationToken ct = default);
 
     /// <summary>
-    /// Batched profile fetch keyed by user id. Missing users are absent from
-    /// the returned dictionary. Read-only (AsNoTracking).
-    /// </summary>
-    Task<IReadOnlyDictionary<Guid, Profile>> GetByUserIdsAsync(
-        IReadOnlyCollection<Guid> userIds, CancellationToken ct = default);
-
-    /// <summary>
     /// Loads every profile with aggregate-local <c>VolunteerHistory</c> and
     /// <c>Languages</c> collections. Used by the startup warmup hosted service
     /// to populate the profile cache. Trivial at ~500-user scale.

--- a/src/Humans.Application/Services/Profiles/DuplicateAccountService.cs
+++ b/src/Humans.Application/Services/Profiles/DuplicateAccountService.cs
@@ -64,13 +64,14 @@ public sealed class DuplicateAccountService : IDuplicateAccountService
     public async Task<IReadOnlyList<DuplicateAccountGroup>> DetectDuplicatesAsync(CancellationToken ct = default)
     {
         // At ~500 users, loading all data into memory is cheap and avoids
-        // complex SQL for gmail/googlemail equivalence.
-        var allUsers = await _userRepository.GetAllAsync(ct);
-        var users = allUsers
+        // complex SQL for gmail/googlemail equivalence. Reads off the
+        // UserInfo snapshot — same source-of-truth used by every other
+        // cross-user diagnostic surface (T-05 cache migration).
+        var allInfos = await _userService.GetAllUserInfosAsync(ct);
+        var users = allInfos
             .Where(u => !string.IsNullOrEmpty(u.Email) &&
                         !u.Email!.EndsWith("@merged.local", StringComparison.OrdinalIgnoreCase))
             .ToList();
-        var userEmails = await _userEmailRepository.GetAllAsync(ct);
 
         // Build map: normalized email -> list of (userId, source description)
         var emailToUsers = new Dictionary<string, List<(Guid UserId, string Source)>>(StringComparer.Ordinal);
@@ -84,19 +85,19 @@ public sealed class DuplicateAccountService : IDuplicateAccountService
                 emailToUsers[normalized] = list;
             }
             list.Add((u.Id, $"User.Email ({u.Email})"));
-        }
 
-        foreach (var ue in userEmails)
-        {
-            var normalized = EmailNormalization.NormalizeForComparison(ue.Email);
-            if (!emailToUsers.TryGetValue(normalized, out var list))
+            foreach (var ue in u.UserEmails)
             {
-                list = [];
-                emailToUsers[normalized] = list;
+                var ueNormalized = EmailNormalization.NormalizeForComparison(ue.Email);
+                if (!emailToUsers.TryGetValue(ueNormalized, out var ueList))
+                {
+                    ueList = [];
+                    emailToUsers[ueNormalized] = ueList;
+                }
+                var verifiedTag = ue.IsVerified ? "verified" : "unverified";
+                var googleTag = ue.IsGoogle ? ", Google" : "";
+                ueList.Add((u.Id, $"UserEmail ({ue.Email}, {verifiedTag}{googleTag})"));
             }
-            var verifiedTag = ue.IsVerified ? "verified" : "unverified";
-            var googleTag = ue.IsGoogle ? ", Google" : "";
-            list.Add((ue.UserId, $"UserEmail ({ue.Email}, {verifiedTag}{googleTag})"));
         }
 
         // Find emails that appear on more than one distinct user
@@ -115,10 +116,8 @@ public sealed class DuplicateAccountService : IDuplicateAccountService
             .ToList();
         var involvedUserSet = involvedUserIds.ToHashSet();
 
-        var userMap = users.Where(u => involvedUserSet.Contains(u.Id))
+        var infoMap = users.Where(u => involvedUserSet.Contains(u.Id))
             .ToDictionary(u => u.Id);
-
-        var profiles = await _profileRepository.GetByUserIdsAsync(involvedUserIds, ct);
 
         // Per-user team membership counts (active only). Few involved users;
         // per-user calls are trivial at this scale.
@@ -166,10 +165,10 @@ public sealed class DuplicateAccountService : IDuplicateAccountService
                         [
                             BuildAccountInfo(id1,
                                 entries.Where(e => e.UserId == id1).Select(e => e.Source).ToList(),
-                                userMap, profiles, teamCounts, roleAssignmentCounts),
+                                infoMap, teamCounts, roleAssignmentCounts),
                             BuildAccountInfo(id2,
                                 entries.Where(e => e.UserId == id2).Select(e => e.Source).ToList(),
-                                userMap, profiles, teamCounts, roleAssignmentCounts)
+                                infoMap, teamCounts, roleAssignmentCounts)
                         ]
                     };
                 }
@@ -333,23 +332,22 @@ public sealed class DuplicateAccountService : IDuplicateAccountService
     private static DuplicateAccountInfo BuildAccountInfo(
         Guid userId,
         List<string> emailSources,
-        Dictionary<Guid, User> userMap,
-        IReadOnlyDictionary<Guid, Profile> profiles,
+        Dictionary<Guid, UserInfo> infoMap,
         Dictionary<Guid, int> teamCounts,
         Dictionary<Guid, int> roleAssignmentCounts)
     {
-        userMap.TryGetValue(userId, out var user);
-        profiles.TryGetValue(userId, out var profile);
+        infoMap.TryGetValue(userId, out var info);
+        var profile = info?.Profile;
 
         string? membershipStatus = null;
         string? membershipTier = null;
         var hasProfile = profile is not null;
         var isProfileComplete = false;
 
-        if (profile is not null)
+        if (info is not null && profile is not null)
         {
             membershipTier = profile.MembershipTier.ToString();
-            membershipStatus = profile.IsSuspended ? "Suspended"
+            membershipStatus = info.IsSuspended ? "Suspended"
                 : profile.IsApproved ? "Active" : "Pending";
             isProfileComplete = !string.IsNullOrEmpty(profile.FirstName) &&
                                 !string.IsNullOrEmpty(profile.LastName);
@@ -358,13 +356,13 @@ public sealed class DuplicateAccountService : IDuplicateAccountService
         return new DuplicateAccountInfo
         {
             UserId = userId,
-            DisplayName = user?.DisplayName ?? "Unknown",
-            Email = user?.Email,
-            ProfilePictureUrl = user?.ProfilePictureUrl,
+            DisplayName = info?.DisplayName ?? "Unknown",
+            Email = info?.Email,
+            ProfilePictureUrl = info?.ProfilePictureUrl,
             MembershipTier = membershipTier,
             MembershipStatus = membershipStatus,
-            LastLogin = user?.LastLoginAt?.ToDateTimeUtc(),
-            CreatedAt = user?.CreatedAt.ToDateTimeUtc(),
+            LastLogin = info?.LastLoginAt?.ToDateTimeUtc(),
+            CreatedAt = info?.CreatedAt.ToDateTimeUtc(),
             TeamCount = teamCounts.GetValueOrDefault(userId),
             RoleAssignmentCount = roleAssignmentCounts.GetValueOrDefault(userId),
             HasProfile = hasProfile,

--- a/src/Humans.Infrastructure/Repositories/Profiles/ProfileRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Profiles/ProfileRepository.cs
@@ -43,21 +43,6 @@ public sealed class ProfileRepository : IProfileRepository
             .FirstOrDefaultAsync(p => p.UserId == userId, ct);
     }
 
-    public async Task<IReadOnlyDictionary<Guid, Profile>> GetByUserIdsAsync(
-        IReadOnlyCollection<Guid> userIds, CancellationToken ct = default)
-    {
-        if (userIds.Count == 0)
-            return new Dictionary<Guid, Profile>();
-
-        await using var ctx = await _factory.CreateDbContextAsync(ct);
-        var list = await ctx.Profiles
-            .AsNoTracking()
-            .Where(p => userIds.Contains(p.UserId))
-            .ToListAsync(ct);
-
-        return list.ToDictionary(p => p.UserId);
-    }
-
     public async Task<IReadOnlyList<Profile>> GetAllAsync(CancellationToken ct = default)
     {
         await using var ctx = await _factory.CreateDbContextAsync(ct);

--- a/tests/Humans.Application.Tests/Architecture/ProfileArchitectureTests.cs
+++ b/tests/Humans.Application.Tests/Architecture/ProfileArchitectureTests.cs
@@ -106,6 +106,26 @@ public class ProfileArchitectureTests
     }
 
     [HumansFact]
+    public void Profile_lookup_by_user_ids_does_not_exist_on_profile_surface()
+    {
+        // T-05 cache migration: GetByUserIdsAsync was the last fan-out path that
+        // re-loaded Profile rows from the DB after a caller already had the
+        // user ids in hand. Every consumer now reads UserInfo.Profile from the
+        // unified read-model (UserInfo) instead. Re-adding GetByUserIdsAsync to
+        // either surface would resurrect the parallel-read-path divergence the
+        // unified read-model was built to eliminate — pin it.
+        typeof(IProfileService)
+            .GetMethod("GetByUserIdsAsync")
+            .Should().BeNull(
+                because: "callers read UserInfo.Profile via IUserService.GetUserInfoAsync / GetUserInfosAsync");
+
+        typeof(IProfileRepository)
+            .GetMethod("GetByUserIdsAsync")
+            .Should().BeNull(
+                because: "IProfileRepository has no fan-out reader path; the only legitimate batched profile read is UserInfo.Profile off the cache");
+    }
+
+    [HumansFact]
     public void EmailProblemsService_depends_only_on_section_services_not_repositories()
     {
         var ctor = typeof(EmailProblemsService).GetConstructors().Single();


### PR DESCRIPTION
## Task
T-05 · Drain IProfileService.GetByUserIdsAsync callers onto UserInfo.Profile

Spec: [docs/plans/2026-05-16-cache-migration.md](docs/plans/2026-05-16-cache-migration.md) — see the T-05 section.

## What this PR does

Eight of the nine callers in the T-05 list had already been drained onto UserInfo.Profile by Slice 3 (PR #575). The single remaining consumer of the batched-by-user-ids profile read was `DuplicateAccountService.DetectDuplicatesAsync`, which still pulled three full table reads (`IUserRepository.GetAllAsync`, `IUserEmailRepository.GetAllAsync`, `IProfileRepository.GetByUserIdsAsync`) to build duplicate-account groups.

This PR drains that last caller onto a single `IUserService.GetAllUserInfos()` snapshot and deletes `IProfileRepository.GetByUserIdsAsync` outright.

`IProfileService.GetByUserIdsAsync` is already gone (deleted in PR #575) — the architecture test added here pins the absence on both surfaces.

## Definition of done

- [x] All listed sites switched to UserInfo reads (eight by PR #575, ninth — DuplicateAccountService — by this PR)
- [x] `IProfileService.GetByUserIdsAsync` deleted (PR #575) and pinned by architecture test (this PR)
- [x] `IProfileRepository.GetByUserIdsAsync` deleted (this PR)
- [x] Architecture test pins no `GetByUserIdsAsync` injection in non-Profile sections — `ServiceBoundaryArchitectureTests.ScanCrossSectionRepositoryInjections` already ratchets cross-section `IProfileRepository` injection; the new `Profile_lookup_by_user_ids_does_not_exist_on_profile_surface` test pins absence of the specific method

## Files touched

- `src/Humans.Application/Services/Profiles/DuplicateAccountService.cs` — `DetectDuplicatesAsync` now reads off the UserInfo snapshot; `BuildAccountInfo` takes `Dictionary<Guid, UserInfo>` instead of `Dictionary<Guid, User>` + `IReadOnlyDictionary<Guid, Profile>`
- `src/Humans.Application/Interfaces/Repositories/IProfileRepository.cs` — `GetByUserIdsAsync` removed
- `src/Humans.Infrastructure/Repositories/Profiles/ProfileRepository.cs` — `GetByUserIdsAsync` impl removed
- `src/Humans.Application/DTOs/ProfileSearchResults.cs` — stale XML doc reference fixed
- `tests/Humans.Application.Tests/Architecture/ProfileArchitectureTests.cs` — new `Profile_lookup_by_user_ids_does_not_exist_on_profile_surface` test

## Verification

- `dotnet build Humans.slnx -v quiet` — clean
- `dotnet test Humans.slnx -v quiet` (non-integration) — 3258 passed, 2 skipped, 0 failed
- Integration tests fail with pre-existing Hangfire `JobStorage instance has not been initialized` DI issue on origin/main; confirmed unrelated by re-running the same test on the base branch SHA (b5d0900a5) without these changes

## Shortcuts / compromises

NONE. The spec's named callers (`ProfileController.BuildAdminHumansAsync`, `FeedbackController`, `FeedbackService`, `ExpensesController`, `AuditViewerService`, `MembershipCalculator`, `GoogleGroupSyncService`, `SystemTeamSyncJob` ×3) were already migrated by PR #575 — verified by grep across `src/`. `DuplicateAccountService` was the only remaining reader that referenced batched-by-user-ids profile data.

## Coordination

No HumansDbContext touch. Lane is safe per spec. `DuplicateAccountService` lives in the Profile section and continues to legitimately inject `IProfileRepository` for the writes it owns (`AnonymizeForMergeByUserIdAsync`); only the batched-by-ids read path moves to UserInfo.