### PR TITLE
fix(shifts): per-event signup query for non-active-event volunteer search

### DIFF
--- a/src/Humans.Web/Controllers/ShiftAdminController.cs
+++ b/src/Humans.Web/Controllers/ShiftAdminController.cs
@@ -565,6 +565,7 @@ public class ShiftAdminController : HumansTeamControllerBase
                 ShiftRoleChecks.CanViewMedical(User),
                 _userManager,
                 _shiftView,
+                _signupService,
                 _availabilityService);
             return ToVolunteerSearchActionResult(result);
         }

--- a/src/Humans.Web/Controllers/ShiftDashboardController.cs
+++ b/src/Humans.Web/Controllers/ShiftDashboardController.cs
@@ -128,6 +128,7 @@ public class ShiftDashboardController : HumansControllerBase
                 ShiftRoleChecks.CanViewMedical(User),
                 _userManager,
                 _shiftView,
+                _signupService,
                 _availabilityService);
             return ToVolunteerSearchActionResult(result);
         }

--- a/src/Humans.Web/Helpers/ShiftVolunteerSearchBuilder.cs
+++ b/src/Humans.Web/Helpers/ShiftVolunteerSearchBuilder.cs
@@ -45,6 +45,7 @@ public static class ShiftVolunteerSearchBuilder
         bool canViewMedical,
         UserManager<User> userManager,
         IShiftView shiftView,
+        IShiftSignupService signupService,
         IGeneralAvailabilityService availabilityService)
     {
         if (!query.HasSearchTerm())
@@ -53,7 +54,8 @@ public static class ShiftVolunteerSearchBuilder
         if (shift is null)
             return VolunteerSearchBuildResult.NotFound;
 
-        var eventSettings = shift.Rota.EventSettings ?? await getActiveEventSettings();
+        var activeEvent = await getActiveEventSettings();
+        var eventSettings = shift.Rota.EventSettings ?? activeEvent;
         if (eventSettings is null)
             return VolunteerSearchBuildResult.NotFound;
 
@@ -61,9 +63,11 @@ public static class ShiftVolunteerSearchBuilder
             shift,
             query.Trim(),
             eventSettings,
+            activeEvent,
             canViewMedical,
             userManager,
             shiftView,
+            signupService,
             availabilityService);
 
         return VolunteerSearchBuildResult.Success(results);
@@ -73,9 +77,11 @@ public static class ShiftVolunteerSearchBuilder
         Shift shift,
         string query,
         EventSettings eventSettings,
+        EventSettings? activeEvent,
         bool canViewMedical,
         UserManager<User> userManager,
         IShiftView shiftView,
+        IShiftSignupService signupService,
         IGeneralAvailabilityService availabilityService)
     {
         var shiftStart = shift.GetAbsoluteStart(eventSettings);
@@ -96,12 +102,29 @@ public static class ShiftVolunteerSearchBuilder
         var userIds = users.Select(u => u.Id).ToList();
         var views = await shiftView.GetUsersAsync(userIds);
 
+        // The cached ShiftUserView.Signups is scoped to the currently active
+        // event (ShiftViewService.GetUserAsync). When the target shift belongs
+        // to a different event (e.g. admin searching a past/future event's
+        // shift), fall back to a per-user signup query for that event so
+        // BookedShiftCount/HasOverlap stay accurate (Codex P2, PR #579).
+        var targetIsActive = activeEvent is not null && eventSettings.Id == activeEvent.Id;
+        Dictionary<Guid, IReadOnlyList<ShiftSignup>>? targetEventSignups = null;
+        if (!targetIsActive)
+        {
+            targetEventSignups = new Dictionary<Guid, IReadOnlyList<ShiftSignup>>(userIds.Count);
+            foreach (var id in userIds)
+                targetEventSignups[id] = await signupService.GetByUserAsync(id, eventSettings.Id);
+        }
+
         var results = new List<VolunteerSearchResult>();
         foreach (var user in users)
         {
             var view = views[user.Id];
             var profile = view.Profile;
-            var confirmedSignups = view.Signups
+            var signupsForEvent = targetIsActive
+                ? view.Signups
+                : targetEventSignups![user.Id];
+            var confirmedSignups = signupsForEvent
                 .Where(s => s.Status == SignupStatus.Confirmed
                     && s.Shift?.Rota?.EventSettingsId == eventSettings.Id)
                 .ToList();


### PR DESCRIPTION
## Context

PR #579 (T-09 Shifts hot-path drain) merged before its Codex P2 follow-up could land. This PR is that follow-up, re-applied against post-merge `main`.

Original fix commit: `b2648b9dd` (on the merged `refactor/cache-t09-shifts-hot` branch).

## What this fixes

`ShiftVolunteerSearchBuilder` previously read every candidate's signups from the cached `IShiftView`, but `ShiftViewService.GetUserAsync` only loads signups for the currently active event. When an admin ran `SearchVolunteers` against a shift whose Rota belongs to a non-active event (past/future), the cached view returned an empty signup list and `BookedShiftCount`/`HasOverlap` silently collapsed to `0`/`false` — a regression vs the pre-T-09 path that passed the target event id directly to `IShiftSignupService.GetByUserAsync`.

## Resolution

Detect the mismatch up-front (compare `eventSettings.Id` against the active event id), and when they differ, fall back to a per-user `IShiftSignupService.GetByUserAsync(userId, eventSettings.Id)` for that candidate set. Cache hot-path is preserved for the common active-event case.

## Files

- `src/Humans.Web/Helpers/ShiftVolunteerSearchBuilder.cs` — added `IShiftSignupService` parameter; non-active-event fallback path
- `src/Humans.Web/Controllers/ShiftDashboardController.cs` — pass `_signupService` to `BuildForShiftAsync`
- `src/Humans.Web/Controllers/ShiftAdminController.cs` — same

## Verification

- `dotnet build Humans.slnx -v quiet` — clean (0 warnings, 0 errors)
- `dotnet test Humans.slnx --filter FullyQualifiedName~Shifts` — 239/239 pass

## Thread reference

Addresses Codex P2 on PR #579 (active-event-mismatch regression flagged during /pr-review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)