### PR TITLE
ci(claude-review): split concurrency slots by event_name to stop self-cancellation

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -71,7 +71,15 @@ on:
   # below, which checks the actual push delta via the compare API.
 
 concurrency:
-  group: claude-review-${{ github.repository }}-${{ github.event.pull_request.number || github.event.issue.number }}
+  # Include event_name so pull_request, pull_request_target, and issue_comment
+  # events get separate slots per PR. Workflow-level concurrency is evaluated
+  # BEFORE job-level `if:`, so without this split, every PR comment (which
+  # queues an issue_comment run that then skips) would cancel an in-flight
+  # review via cancel-in-progress. Trade-off: a `/review` comment posted
+  # while a pull_request review is still running won't cancel that review —
+  # both run to completion. Cancel-in-progress still consolidates repeats
+  # within the same event type.
+  group: claude-review-${{ github.repository }}-${{ github.event.pull_request.number || github.event.issue.number }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary

- claude-review jobs are getting cancelled within ~2s of starting because every PR comment queues an \`issue_comment\` workflow run that joins the same concurrency group as the in-flight \`pull_request\` review. With \`cancel-in-progress: true\`, the comment run kills the review — even though the comment's job then skips via \`if:\` (workflow-level concurrency is evaluated BEFORE job \`if:\`).
- Add \`\${{ github.event_name }}\` to the group key so \`pull_request\`, \`pull_request_target\`, and \`issue_comment\` each get their own slot per PR.

## Evidence

Run [25964751550](https://github.com/peterdrier/Humans/actions/runs/25964751550) (T-04 \`pull_request\` review) cancelled at \"Set up job\" 2s after starting, exactly when run [25964752832](https://github.com/peterdrier/Humans/actions/runs/25964752832) (a peterdrier \`issue_comment\` on the same PR) queued. The pattern repeats across the run history: paired \`pull_request_target\` (skipped) + \`pull_request\` (cancelled) entries.

## Trade-off

A \`/review\` comment posted while a \`pull_request\` review is still running will no longer cancel that review — both run to completion in parallel. Small budget hit, no correctness issue. Cancel-in-progress still consolidates repeats *within* the same event type (e.g., two \`/review\` comments in a row).

## Test plan

- [ ] Merge, then open a fresh PR — confirm the \`pull_request\` run isn't cancelled by the paired \`pull_request_target\` (skipped) run.
- [ ] Post a comment on the open PR while the review is still in-flight — confirm the review is no longer killed.
- [ ] Post \`/review\` twice in quick succession — confirm only the latest \`issue_comment\` run survives (cancel-in-progress within event type).

🤖 Generated with [Claude Code](https://claude.com/claude-code)