### PR TITLE
tech-debt: Stream A — drain reads of obsolete Profile/User fields

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -25,8 +25,15 @@
           window, then error. Past-deadline diagnostics are emitted with
           effectiveSeverity: Error directly (bypasses this list); pre-deadline
           warnings must stay warnings so the deadline mechanism works.
+        - HUM_USER_DISPLAYNAME / HUM_USERINFO_DISPLAYNAME: [Obsolete] markers
+          on User.DisplayName and UserInfo.DisplayName. Legitimate consumers
+          (Identity claims, merge/purge/delete labels, GDPR export, dev
+          seeders, email greetings, admin merge UI) remain until UserInfo
+          handles are threaded through every Application-layer service entry
+          point per issue #691. Kept visible as warnings (not hidden via
+          NoWarn) so new render-path violations stay surfaced.
     -->
-    <WarningsNotAsErrors>$(WarningsNotAsErrors);HUM0009;HUM0010;HUM0011</WarningsNotAsErrors>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);HUM0009;HUM0010;HUM0011;HUM_USER_DISPLAYNAME;HUM_USERINFO_DISPLAYNAME</WarningsNotAsErrors>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisLevel>latest</AnalysisLevel>
@@ -43,12 +50,7 @@
     <!-- HUM_USER_NORMALIZEDEMAIL: User.NormalizedEmail is shadow-populated by -->
     <!--   Identity; application-code reads are not canonical but a few legacy -->
     <!--   reads remain. Issue #635 §15i. -->
-    <!-- HUM_USER_DISPLAYNAME: render-path callers drained to UserInfo.BurnerName; -->
-    <!--   remaining legitimate consumers (Identity claims, merge/purge/delete -->
-    <!--   labels, GDPR export, dev seeders, email greetings on User-typed -->
-    <!--   handles, admin merge UI) stay until UserInfo handles are threaded -->
-    <!--   through every Application-layer service entry point. Issue #691. -->
-    <NoWarn>$(NoWarn);CS1591;MA0048;MA0016;MA0026;MA0051;VSTHRD200;HUM_PROFILE_ISSUSPENDED;HUM_USER_NORMALIZEDEMAIL;HUM_USER_DISPLAYNAME;HUM_USERINFO_DISPLAYNAME</NoWarn>
+    <NoWarn>$(NoWarn);CS1591;MA0048;MA0016;MA0026;MA0051;VSTHRD200;HUM_PROFILE_ISSUSPENDED;HUM_USER_NORMALIZEDEMAIL</NoWarn>
   </PropertyGroup>
 
   <!-- Embed git commit hash into InformationalVersion at build time (skip when already set via -p:SourceRevisionId) -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -43,7 +43,12 @@
     <!-- HUM_USER_NORMALIZEDEMAIL: User.NormalizedEmail is shadow-populated by -->
     <!--   Identity; application-code reads are not canonical but a few legacy -->
     <!--   reads remain. Issue #635 §15i. -->
-    <NoWarn>$(NoWarn);CS1591;MA0048;MA0016;MA0026;MA0051;VSTHRD200;HUM_PROFILE_ISSUSPENDED;HUM_USER_NORMALIZEDEMAIL</NoWarn>
+    <!-- HUM_USER_DISPLAYNAME: render-path callers drained to UserInfo.BurnerName; -->
+    <!--   remaining legitimate consumers (Identity claims, merge/purge/delete -->
+    <!--   labels, GDPR export, dev seeders, email greetings on User-typed -->
+    <!--   handles, admin merge UI) stay until UserInfo handles are threaded -->
+    <!--   through every Application-layer service entry point. Issue #691. -->
+    <NoWarn>$(NoWarn);CS1591;MA0048;MA0016;MA0026;MA0051;VSTHRD200;HUM_PROFILE_ISSUSPENDED;HUM_USER_NORMALIZEDEMAIL;HUM_USER_DISPLAYNAME;HUM_USERINFO_DISPLAYNAME</NoWarn>
   </PropertyGroup>
 
   <!-- Embed git commit hash into InformationalVersion at build time (skip when already set via -p:SourceRevisionId) -->

--- a/src/Humans.Application/Services/Campaigns/CampaignService.cs
+++ b/src/Humans.Application/Services/Campaigns/CampaignService.cs
@@ -607,7 +607,7 @@ public sealed class CampaignService : ICampaignService, IUserDataContributor, IU
         foreach (var row in grantRowsRaw)
         {
             var recipientName = users.TryGetValue(row.UserId, out var user)
-                ? user.DisplayName
+                ? user.BurnerName
                 : string.Empty;
 
             grantRows.Add(new CampaignCodeTrackingGrant(
@@ -724,7 +724,7 @@ public sealed class CampaignService : ICampaignService, IUserDataContributor, IU
             UserId: user.Id,
             CampaignGrantId: grantId,
             RecipientEmail: recipientEmail,
-            RecipientName: user.DisplayName,
+            RecipientName: user.BurnerName,
             Subject: campaign.EmailSubject,
             MarkdownBody: campaign.EmailBodyTemplate,
             Code: code,

--- a/src/Humans.Application/Services/Camps/CampRoleService.cs
+++ b/src/Humans.Application/Services/Camps/CampRoleService.cs
@@ -193,7 +193,7 @@ public sealed class CampRoleService : ICampRoleService
             var filled = defAssignments.Select(a =>
             {
                 var displayName = users.TryGetValue(a.CampMember.UserId, out var u)
-                    ? u.DisplayName ?? "(unknown)"
+                    ? u.BurnerName ?? "(unknown)"
                     : "(unknown)";
                 return new CampRolesPanelSlot(a.Id, a.CampMemberId, a.CampMember.UserId, displayName);
             }).ToList();

--- a/src/Humans.Application/Services/Camps/CampService.cs
+++ b/src/Humans.Application/Services/Camps/CampService.cs
@@ -587,7 +587,7 @@ public sealed class CampService : ICampService, IUserDataContributor, IUserMerge
             .Select(l => new CampLeadSummary(
                 l.Id,
                 l.UserId,
-                users.TryGetValue(l.UserId, out var user) ? user.DisplayName : string.Empty))
+                users.TryGetValue(l.UserId, out var user) ? user.BurnerName : string.Empty))
             .ToList();
     }
 

--- a/src/Humans.Application/Services/CityPlanning/CityPlanningService.cs
+++ b/src/Humans.Application/Services/CityPlanning/CityPlanningService.cs
@@ -159,8 +159,8 @@ public sealed class CityPlanningService : ICityPlanningService
 
         return rows.Select(h =>
         {
-            var displayName = users.TryGetValue(h.ModifiedByUserId, out var user) && !string.IsNullOrEmpty(user.DisplayName)
-                ? user.DisplayName
+            var displayName = users.TryGetValue(h.ModifiedByUserId, out var user) && !string.IsNullOrEmpty(user.BurnerName)
+                ? user.BurnerName
                 : h.ModifiedByUserId.ToString();
 
             return new CampPolygonHistoryEntryDto(

--- a/src/Humans.Application/Services/GoogleIntegration/GoogleAdminService.cs
+++ b/src/Humans.Application/Services/GoogleIntegration/GoogleAdminService.cs
@@ -723,7 +723,7 @@ public sealed class GoogleAdminService : IGoogleAdminService
                             .OrderBy(e => e.Email, StringComparer.OrdinalIgnoreCase)
                             .Select(e => e.Email)
                             .FirstOrDefault();
-                    return new { u.Id, u.DisplayName, GoogleEmail = googleEmail };
+                    return new { u.Id, DisplayName = u.BurnerName, GoogleEmail = googleEmail };
                 })
                 .Where(x => x.GoogleEmail is not null &&
                     x.GoogleEmail.EndsWith($"@{NobodiesTeamDomain}", StringComparison.OrdinalIgnoreCase))

--- a/src/Humans.Application/Services/GoogleIntegration/GoogleGroupSyncService.cs
+++ b/src/Humans.Application/Services/GoogleIntegration/GoogleGroupSyncService.cs
@@ -370,9 +370,7 @@ public sealed class GoogleGroupSyncService : IGoogleGroupSync
             if (email is null)
                 continue;
 
-            var displayName = !string.IsNullOrWhiteSpace(user.Profile?.BurnerName)
-                ? user.Profile!.BurnerName
-                : user.DisplayName;
+            var displayName = user.BurnerName;
 
             result[user.Id] = new ExpectedMember(user.Id, email, displayName, user.ProfilePictureUrl);
         }

--- a/src/Humans.Application/Services/GoogleIntegration/GoogleRemovalNotificationService.cs
+++ b/src/Humans.Application/Services/GoogleIntegration/GoogleRemovalNotificationService.cs
@@ -93,8 +93,8 @@ public sealed class GoogleRemovalNotificationService : IGoogleRemovalNotificatio
             return;
         }
 
-        var userName = !string.IsNullOrWhiteSpace(user.DisplayName)
-            ? user.DisplayName
+        var userName = !string.IsNullOrWhiteSpace(user.BurnerName)
+            ? user.BurnerName
             : removedEmail;
         var culture = string.IsNullOrWhiteSpace(user.PreferredLanguage) ? "en" : user.PreferredLanguage;
 

--- a/src/Humans.Application/Services/Governance/ApplicationDecisionService.cs
+++ b/src/Humans.Application/Services/Governance/ApplicationDecisionService.cs
@@ -605,7 +605,7 @@ public sealed class ApplicationDecisionService : IApplicationDecisionService, IU
             RoleNames.Board, ct);
         var boardUsersById = await _userService.GetUserInfosAsync(boardMemberIds, ct);
         var boardMembers = boardUsersById.Values
-            .Select(u => new BoardMemberInfo(u.Id, u.DisplayName))
+            .Select(u => new BoardMemberInfo(u.Id, u.BurnerName))
             .OrderBy(m => m.DisplayName, StringComparer.OrdinalIgnoreCase)
             .ToList();
 

--- a/src/Humans.Application/Services/Issues/IssuesService.cs
+++ b/src/Humans.Application/Services/Issues/IssuesService.cs
@@ -338,7 +338,7 @@ public sealed class IssuesService : IIssuesService, IUserDataContributor
             a.OccurredAt,
             a.ActorUserId,
             a.ActorUserId.HasValue && actorUsers.TryGetValue(a.ActorUserId.Value, out var u)
-                ? u.DisplayName
+                ? u.BurnerName
                 : null,
             a.Action,
             a.Description));
@@ -500,10 +500,10 @@ public sealed class IssuesService : IIssuesService, IUserDataContributor
             : await _users.GetUserInfosAsync(idsToResolve, ct);
 
         var oldName = oldAssigneeId.HasValue
-            ? (users!.TryGetValue(oldAssigneeId.Value, out var ou) ? ou.DisplayName : oldAssigneeId.Value.ToString())
+            ? (users!.TryGetValue(oldAssigneeId.Value, out var ou) ? ou.BurnerName : oldAssigneeId.Value.ToString())
             : "Unassigned";
         var newName = newAssigneeUserId.HasValue
-            ? (users!.TryGetValue(newAssigneeUserId.Value, out var nu) ? nu.DisplayName : newAssigneeUserId.Value.ToString())
+            ? (users!.TryGetValue(newAssigneeUserId.Value, out var nu) ? nu.BurnerName : newAssigneeUserId.Value.ToString())
             : "Unassigned";
 
         issue.AssigneeUserId = newAssigneeUserId;
@@ -697,7 +697,7 @@ public sealed class IssuesService : IIssuesService, IUserDataContributor
         return rows
             .Select(r => new DistinctReporterRow(
                 r.UserId,
-                users.TryGetValue(r.UserId, out var u) ? u.DisplayName : r.UserId.ToString(),
+                users.TryGetValue(r.UserId, out var u) ? u.BurnerName : r.UserId.ToString(),
                 r.Count))
             .OrderBy(r => r.DisplayName, StringComparer.OrdinalIgnoreCase)
             .ToList();

--- a/src/Humans.Application/Services/Profiles/AdminHumanListAssembler.cs
+++ b/src/Humans.Application/Services/Profiles/AdminHumanListAssembler.cs
@@ -69,7 +69,7 @@ public static class AdminHumanListAssembler
             return new AdminHumanRow(
                 u.Id,
                 email,
-                u.DisplayName,
+                u.BurnerName,
                 u.ProfilePictureUrl,
                 u.CreatedAt.ToDateTimeUtc(),
                 u.LastLoginAt?.ToDateTimeUtc(),

--- a/src/Humans.Application/Services/Profiles/ProfileService.cs
+++ b/src/Humans.Application/Services/Profiles/ProfileService.cs
@@ -207,7 +207,7 @@ public sealed class ProfileService : IProfileService, IUserDataContributor, IUse
             {
                 var displayName = !string.IsNullOrWhiteSpace(burnerName)
                     ? burnerName
-                    : (users.TryGetValue(userId, out var u) ? u.DisplayName : string.Empty);
+                    : (users.TryGetValue(userId, out var u) ? u.BurnerName : string.Empty);
                 dbOnly.Add(new ProfilePictureMigrationRow(profileId, userId, displayName, contentType, updatedAt));
             }
         }

--- a/src/Humans.Application/Services/Profiles/UserEmailService.cs
+++ b/src/Humans.Application/Services/Profiles/UserEmailService.cs
@@ -1029,7 +1029,7 @@ public sealed class UserEmailService : IUserEmailService, IUserMerge
         return perUser
             .Select(x => new UserEmailFlagViolation(
                 x.UserId,
-                users.TryGetValue(x.UserId, out var user) ? user.DisplayName : null,
+                users.TryGetValue(x.UserId, out var user) ? user.BurnerName : null,
                 x.IsGoogleCount,
                 x.VerifiedCount,
                 x.VerifiedPrimaryCount,

--- a/src/Humans.Application/Services/Teams/TeamService.cs
+++ b/src/Humans.Application/Services/Teams/TeamService.cs
@@ -2231,7 +2231,7 @@ public sealed class TeamService : ITeamService, IGoogleGroupMembershipSource, IU
                 var resources = await TeamResourceService.GetTeamResourcesAsync(team.Id, cancellationToken);
 
                 await EmailService.SendAddedToTeamAsync(
-                    email, user.DisplayName, team.Name, team.Slug,
+                    email, user.BurnerName, team.Name, team.Slug,
                     resources.Select(r => (r.Name, r.Url)),
                     user.PreferredLanguage,
                     cancellationToken);

--- a/src/Humans.Application/Services/Tickets/TicketQueryService.cs
+++ b/src/Humans.Application/Services/Tickets/TicketQueryService.cs
@@ -535,7 +535,7 @@ public sealed class TicketQueryService : ITicketQueryService, IUserDataContribut
                     PaymentStatus = r.PaymentStatus,
                     VendorDashboardUrl = r.VendorDashboardUrl,
                     MatchedUserId = r.MatchedUserId,
-                    MatchedUserName = user.DisplayName,
+                    MatchedUserName = user.BurnerName,
                 };
             }
             return r;
@@ -566,7 +566,7 @@ public sealed class TicketQueryService : ITicketQueryService, IUserDataContribut
                     Price = r.Price,
                     Status = r.Status,
                     MatchedUserId = r.MatchedUserId,
-                    MatchedUserName = user.DisplayName,
+                    MatchedUserName = user.BurnerName,
                     VendorOrderId = r.VendorOrderId,
                 };
             }
@@ -651,7 +651,7 @@ public sealed class TicketQueryService : ITicketQueryService, IUserDataContribut
                 {
                     UserId = id,
                     HasTicket = matchedUserIds.Contains(id),
-                    Name = user.DisplayName,
+                    Name = user.BurnerName,
                     Email = email ?? string.Empty,
                     TeamNames = teamNames ?? [],
                     Tier = user.Profile!.MembershipTier,

--- a/src/Humans.Application/Services/Tickets/TicketTransferService.cs
+++ b/src/Humans.Application/Services/Tickets/TicketTransferService.cs
@@ -652,7 +652,7 @@ public sealed class TicketTransferService : ITicketTransferService
         var primary = await _userEmailService.GetPrimaryEmailAsync(userId, ct);
         return new ReceiverLookupResultDto(
             UserId: userId,
-            DisplayName: info.DisplayName,
+            DisplayName: info.BurnerName,
             BurnerName: profile.BurnerName,
             PreferredEmail: primary,
             HasCustomProfilePicture: profile.HasCustomPicture,

--- a/src/Humans.Application/UserInfo.cs
+++ b/src/Humans.Application/UserInfo.cs
@@ -166,7 +166,7 @@ public sealed record ProfileInfo(
 /// </remarks>
 public sealed record UserInfo(
     Guid Id,
-    string DisplayName,
+    [property: Obsolete("Rendering callers must use UserInfo.BurnerName / <vc:human> — DisplayName is the raw legacy column mirror. See memory/architecture/burnername-is-the-display-name.md.", DiagnosticId = "HUM_USERINFO_DISPLAYNAME", UrlFormat = "https://github.com/nobodies-collective/Humans/issues/691")] string DisplayName,
     string PreferredLanguage,
     string? ProfilePictureUrl,
     Instant CreatedAt,

--- a/src/Humans.Domain/Entities/Profile.cs
+++ b/src/Humans.Domain/Entities/Profile.cs
@@ -115,6 +115,8 @@ public class Profile
     /// path reads or writes it.
     /// </summary>
     [PersonalData]
+    [Obsolete("Pictures live on the file share; this column is unused. The DB column stays until a follow-up PR after prod soak per memory/architecture/no-drops-until-prod-verified.md.", DiagnosticId = "HUM_PROFILE_PICTUREDATA", UrlFormat = "https://github.com/nobodies-collective/Humans/issues/702")]
+    [Architecture.ExpiresOn("2026-06-01", reason: "Issue #702 — DB→FS migration complete (PR #576); column reserved for prod-soak drop.")]
     public byte[]? ProfilePictureData { get; set; }
 
     /// <summary>

--- a/src/Humans.Domain/Entities/User.cs
+++ b/src/Humans.Domain/Entities/User.cs
@@ -121,7 +121,7 @@ public class User : IdentityUser<Guid>
     /// </remarks>
 #pragma warning disable CS0809 // Obsolete override of non-obsolete base — intentional: marks application reads as non-canonical.
     [Obsolete("NormalizedEmail is shadow-populated by Identity. Use User.Email or IUserEmailRepository for canonical email lookup.", DiagnosticId = "HUM_USER_NORMALIZEDEMAIL", UrlFormat = "https://github.com/nobodies-collective/Humans/issues/635")]
-    [Architecture.ExpiresOn("2026-05-18", reason: "Issue #635 — Identity shadow column; application reads should go through User.Email / IUserEmailRepository.")]
+    [Architecture.ExpiresOn("2026-06-01", reason: "Issue #635 — Identity shadow column; application reads should go through User.Email / IUserEmailRepository.")]
     public override string? NormalizedEmail
     {
         get => Email?.ToUpperInvariant();

--- a/src/Humans.Domain/Entities/User.cs
+++ b/src/Humans.Domain/Entities/User.cs
@@ -10,9 +10,14 @@ namespace Humans.Domain.Entities;
 public class User : IdentityUser<Guid>
 {
     /// <summary>
-    /// Display name for the user.
+    /// Display name for the user. Legacy Identity column — fallback only.
+    /// New code should render via <c>UserInfo.BurnerName</c> / <c>&lt;vc:human&gt;</c>
+    /// per <c>memory/architecture/burnername-is-the-display-name.md</c>.
+    /// Mutations live in <c>UserRepository</c> (merge / purge / delete labels)
+    /// and in <c>HumansUserClaimsPrincipalFactory</c> (Identity claim).
     /// </summary>
     [PersonalData]
+    [Obsolete("Rendering callers must use UserInfo.BurnerName / <vc:human> per memory/architecture/burnername-is-the-display-name.md. Legitimate consumers: Identity claims, repository merge/purge/delete labels, GDPR export, debug screens.", DiagnosticId = "HUM_USER_DISPLAYNAME", UrlFormat = "https://github.com/nobodies-collective/Humans/issues/691")]
     public string DisplayName { get; set; } = string.Empty;
 
     /// <summary>

--- a/src/Humans.Web/Controllers/AdminController.cs
+++ b/src/Humans.Web/Controllers/AdminController.cs
@@ -134,7 +134,7 @@ public class AdminController : HumansControllerBase
             return RedirectToAction(nameof(ProfileController.AdminDetail), "Profile", new { id });
         }
 
-        var displayName = user.DisplayName;
+        var displayName = user.BurnerName;
 
         _logger.LogWarning(
             "Admin {AdminId} purging human {HumanId} ({DisplayName}) in {Environment}",

--- a/src/Humans.Web/Controllers/AgentApiController.cs
+++ b/src/Humans.Web/Controllers/AgentApiController.cs
@@ -54,7 +54,7 @@ public class AgentApiController : ControllerBase
         if (conv is null) return NotFound();
 
         var users = await ResolveUsersAsync([conv.UserId], ct);
-        var displayName = users.TryGetValue(conv.UserId, out var u) ? u.DisplayName : null;
+        var displayName = users.TryGetValue(conv.UserId, out var u) ? u.BurnerName : null;
 
         return Ok(new
         {
@@ -107,7 +107,7 @@ public class AgentApiController : ControllerBase
         {
             c.Id,
             c.UserId,
-            UserDisplayName = users.TryGetValue(c.UserId, out var u) ? u.DisplayName : null,
+            UserDisplayName = users.TryGetValue(c.UserId, out var u) ? u.BurnerName : null,
             c.Locale,
             StartedAt = c.StartedAt.ToDateTimeUtc(),
             LastMessageAt = c.LastMessageAt.ToDateTimeUtc(),

--- a/src/Humans.Web/Controllers/AgentController.cs
+++ b/src/Humans.Web/Controllers/AgentController.cs
@@ -155,10 +155,10 @@ public class AgentController : HumansControllerBase
             return rows.Select(r => new AgentConversationRow(r, DisplayName: null)).ToList();
 
         var distinctUserIds = rows.Select(r => r.UserId).Distinct().ToArray();
-        var users = await _users.GetByIdsAsync(distinctUserIds, ct);
+        var users = await _users.GetUserInfosAsync(distinctUserIds, ct);
         return rows.Select(r => new AgentConversationRow(
             Conversation: r,
-            DisplayName: users.TryGetValue(r.UserId, out var u) ? u.DisplayName : null)
+            DisplayName: users.TryGetValue(r.UserId, out var u) ? u.BurnerName : null)
         ).ToList();
     }
 

--- a/src/Humans.Web/Controllers/CampController.cs
+++ b/src/Humans.Web/Controllers/CampController.cs
@@ -226,7 +226,7 @@ public class CampController : HumansCampControllerBase
                 camp.ContactEmail,
                 campDisplayName,
                 currentUser.Id,
-                currentUser.DisplayName,
+                currentUser.BurnerName,
                 senderEmail,
                 model.Message,
                 model.IncludeContactInfo,
@@ -416,7 +416,7 @@ public class CampController : HumansCampControllerBase
             .Select(m => new CampMemberPickerOption(
                 m.Id,
                 m.UserId,
-                users.TryGetValue(m.UserId, out var u) ? u.DisplayName ?? "(unknown)" : "(unknown)"))
+                users.TryGetValue(m.UserId, out var u) ? u.BurnerName ?? "(unknown)" : "(unknown)"))
             .OrderBy(o => o.DisplayName, StringComparer.OrdinalIgnoreCase)
             .ToList();
 

--- a/src/Humans.Web/Controllers/GoogleController.cs
+++ b/src/Humans.Web/Controllers/GoogleController.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Caching.Memory;
+using Humans.Application;
 using Humans.Application.DTOs;
 using Humans.Application.Extensions;
 using Humans.Domain.Entities;
@@ -70,8 +71,8 @@ public class GoogleController : HumansControllerBase
             .Distinct()
             .ToList();
         var updatedByUsers = updatedByUserIds.Count > 0
-            ? await userService.GetByIdsAsync(updatedByUserIds)
-            : new Dictionary<Guid, User>();
+            ? await userService.GetUserInfosAsync(updatedByUserIds)
+            : new Dictionary<Guid, UserInfo>();
 
         var viewModel = new SyncSettingsViewModel
         {
@@ -82,7 +83,7 @@ public class GoogleController : HumansControllerBase
                 CurrentMode = s.SyncMode,
                 UpdatedAt = s.UpdatedAt.ToDateTimeUtc(),
                 UpdatedByName = s.UpdatedByUserId is { } uid && updatedByUsers.TryGetValue(uid, out var u)
-                    ? u.DisplayName
+                    ? u.BurnerName
                     : null
             }).ToList()
         };

--- a/src/Humans.Web/Controllers/GuestController.cs
+++ b/src/Humans.Web/Controllers/GuestController.cs
@@ -83,7 +83,7 @@ public class GuestController : HumansControllerBase
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to load Guest dashboard for user {UserId}", user.Id);
-            return View(new GuestDashboardViewModel { DisplayName = user.DisplayName });
+            return View(new GuestDashboardViewModel { DisplayName = user.BurnerName });
         }
     }
 
@@ -252,7 +252,7 @@ public class GuestController : HumansControllerBase
     {
         var viewModel = new GuestDashboardViewModel
         {
-            DisplayName = user.DisplayName,
+            DisplayName = user.BurnerName,
         };
 
         // Ticket status: check for matched ticket orders and attendees

--- a/src/Humans.Web/Controllers/HomeController.cs
+++ b/src/Humans.Web/Controllers/HomeController.cs
@@ -80,7 +80,7 @@ public class HomeController : HumansControllerBase
         var viewModel = new DashboardViewModel
         {
             UserId = user.Id,
-            DisplayName = user.DisplayName,
+            DisplayName = user.BurnerName,
             ProfilePictureUrl = user.ProfilePictureUrl,
             MembershipStatus = data.MembershipSnapshot.Status,
             HasProfile = data.Profile is not null,

--- a/src/Humans.Web/Controllers/IssuesController.cs
+++ b/src/Humans.Web/Controllers/IssuesController.cs
@@ -267,10 +267,10 @@ public class IssuesController : HumansControllerBase
         }
         else
         {
-            var users = await _users.GetByIdsAsync(activeIds);
+            var users = await _users.GetUserInfosAsync(activeIds);
             vm.AssigneeOptions = users.Values
-                .OrderBy(u => u.DisplayName, StringComparer.OrdinalIgnoreCase)
-                .Select(u => new AssigneeOption { Id = u.Id, DisplayName = u.DisplayName })
+                .OrderBy(u => u.BurnerName, StringComparer.OrdinalIgnoreCase)
+                .Select(u => new AssigneeOption { Id = u.Id, DisplayName = u.BurnerName })
                 .ToList();
         }
 

--- a/src/Humans.Web/Controllers/OnboardingReviewController.cs
+++ b/src/Humans.Web/Controllers/OnboardingReviewController.cs
@@ -242,7 +242,7 @@ public class OnboardingReviewController : HumansControllerBase
         return new OnboardingReviewItemViewModel
         {
             UserId = info.Id,
-            DisplayName = info.DisplayName,
+            DisplayName = info.BurnerName,
             LegalName = profile.FullName,
             ProfilePictureUrl = info.ProfilePictureUrl,
             Email = info.Email ?? string.Empty,

--- a/src/Humans.Web/Controllers/ProfileController.cs
+++ b/src/Humans.Web/Controllers/ProfileController.cs
@@ -258,7 +258,7 @@ public class ProfileController : HumansControllerBase
             PendingConsentCount = pendingConsentCount,
             IsApproved = profile?.IsApproved ?? false,
             IsOwnProfile = true,
-            DisplayName = info.DisplayName,
+            DisplayName = info.BurnerName,
             CampaignGrants = campaignGrants,
         };
 

--- a/src/Humans.Web/Controllers/ProfileController.cs
+++ b/src/Humans.Web/Controllers/ProfileController.cs
@@ -1929,8 +1929,8 @@ public class ProfileController : HumansControllerBase
         if (currentUser.Id == id)
             return RedirectToAction(nameof(ViewProfile), new { id });
 
-        var targetUser = await _userManager.FindByIdAsync(id.ToString());
-        if (targetUser is null)
+        var targetInfo = await _userService.GetUserInfoAsync(id);
+        if (targetInfo is null)
             return NotFound();
 
         if (!await _commPrefService.AcceptsFacilitatedMessagesAsync(id))
@@ -1942,7 +1942,7 @@ public class ProfileController : HumansControllerBase
         var viewModel = new SendMessageViewModel
         {
             RecipientId = id,
-            RecipientDisplayName = targetUser.DisplayName
+            RecipientDisplayName = targetInfo.BurnerName
         };
 
         return View(viewModel);
@@ -1973,7 +1973,7 @@ public class ProfileController : HumansControllerBase
         }
 
         model.RecipientId = id;
-        model.RecipientDisplayName = targetUser.DisplayName;
+        model.RecipientDisplayName = targetUser.BurnerName;
 
         if (!ModelState.IsValid)
             return View(model);
@@ -2000,12 +2000,12 @@ public class ProfileController : HumansControllerBase
         await _auditLogService.LogAsync(
             AuditAction.FacilitatedMessageSent,
             nameof(User), targetUser.Id,
-            $"Message sent to {targetUser.DisplayName} (contact info shared: {(model.IncludeContactInfo ? "yes" : "no")})",
+            $"Message sent to {targetUser.BurnerName} (contact info shared: {(model.IncludeContactInfo ? "yes" : "no")})",
             currentUser.Id);
 
         SetSuccess(string.Format(
             _localizer["SendMessage_Success"].Value,
-            targetUser.DisplayName));
+            targetUser.BurnerName));
 
         return RedirectToAction(nameof(ViewProfile), new { id });
     }
@@ -2226,8 +2226,8 @@ public class ProfileController : HumansControllerBase
     [HttpGet("{id:guid}/Admin/Roles/Add")]
     public async Task<IActionResult> AddRole(Guid id)
     {
-        var user = await _userManager.FindByIdAsync(id.ToString());
-        if (user is null)
+        var info = await _userService.GetUserInfoAsync(id);
+        if (info is null)
         {
             return NotFound();
         }
@@ -2235,7 +2235,7 @@ public class ProfileController : HumansControllerBase
         var viewModel = new CreateRoleAssignmentViewModel
         {
             UserId = id,
-            UserDisplayName = user.DisplayName,
+            UserDisplayName = info.BurnerName,
             AvailableRoles = [.. RoleChecks.GetAssignableRoles(User)]
         };
 
@@ -2247,8 +2247,8 @@ public class ProfileController : HumansControllerBase
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> AddRole(Guid id, CreateRoleAssignmentViewModel model)
     {
-        var user = await _userManager.FindByIdAsync(id.ToString());
-        if (user is null)
+        var info = await _userService.GetUserInfoAsync(id);
+        if (info is null)
         {
             return NotFound();
         }
@@ -2256,7 +2256,7 @@ public class ProfileController : HumansControllerBase
         if (string.IsNullOrWhiteSpace(model.RoleName))
         {
             ModelState.AddModelError(nameof(model.RoleName), "Please select a role.");
-            PopulateRoleAssignmentForm(model, id, user.DisplayName);
+            PopulateRoleAssignmentForm(model, id, info.BurnerName);
             return View(model);
         }
 
@@ -2356,6 +2356,8 @@ public class ProfileController : HumansControllerBase
     private async Task<EmailsViewModel> BuildEmailsViewModelAsync(User user, bool isAdminContext = false, CancellationToken ct = default)
     {
         var emails = await _userEmailService.GetUserEmailsAsync(user.Id, ct);
+        var info = await _userService.GetUserInfoAsync(user.Id, ct);
+        var burnerName = info?.BurnerName ?? user.DisplayName;
 
         var canAdd = true;
         var minutesUntilResend = 0;
@@ -2464,7 +2466,7 @@ public class ProfileController : HumansControllerBase
             HasNobodiesTeamEmail = hasNobodiesTeam,
             GoogleEmailStatus = user.GoogleEmailStatus,
             TargetUserId = user.Id,
-            TargetDisplayName = user.DisplayName,
+            TargetDisplayName = burnerName,
             IsAdminContext = isAdminContext,
             WorkspaceLockedEmailId = workspaceLockedEmail?.Id,
             LegacyIdentityEmailColumn = isAdminContext

--- a/src/Humans.Web/Controllers/ShiftsController.cs
+++ b/src/Humans.Web/Controllers/ShiftsController.cs
@@ -547,7 +547,7 @@ public class ShiftsController : HumansControllerBase
         IReadOnlyList<OrphanSignupSnapshot> orphans,
         IReadOnlyDictionary<Guid, UserInfo> users)
     {
-        string? GetName(Guid? id) => id.HasValue && users.TryGetValue(id.Value, out var u) ? u.DisplayName : null;
+        string? GetName(Guid? id) => id.HasValue && users.TryGetValue(id.Value, out var u) ? u.BurnerName : null;
 
         return orphans
             .Select(s => new OrphanSignupRow(

--- a/src/Humans.Web/Controllers/TeamAdminController.cs
+++ b/src/Humans.Web/Controllers/TeamAdminController.cs
@@ -245,7 +245,7 @@ public class TeamAdminController : HumansTeamControllerBase
             ParentDepartmentName = parentDepartmentName,
             ParentDepartmentSlug = parentDepartmentSlug,
             IsSensitive = team.IsSensitive,
-            ActorDisplayName = user.DisplayName
+            ActorDisplayName = user.BurnerName
         };
 
         return View(viewModel);

--- a/src/Humans.Web/Controllers/WidgetGalleryController.cs
+++ b/src/Humans.Web/Controllers/WidgetGalleryController.cs
@@ -48,9 +48,9 @@ public sealed class WidgetGalleryController : HumansControllerBase
         var sampleVolunteerProfile = await TryGetVolunteerProfileAsync(currentUser.Id);
         var shifts = await ResolveShiftsSamplesAsync(currentUser.Id);
 
-        var displayName = string.IsNullOrEmpty(currentUser.DisplayName)
+        var displayName = string.IsNullOrEmpty(currentUser.BurnerName)
             ? "Current user"
-            : currentUser.DisplayName;
+            : currentUser.BurnerName;
 
         var model = new WidgetGalleryViewModel
         {

--- a/src/Humans.Web/Models/AdminHumanDetailViewModelBuilder.cs
+++ b/src/Humans.Web/Models/AdminHumanDetailViewModelBuilder.cs
@@ -41,7 +41,7 @@ public static class AdminHumanDetailViewModelBuilder
         {
             UserId = info.Id,
             Email = effectiveEmail ?? string.Empty,
-            DisplayName = info.DisplayName,
+            DisplayName = info.BurnerName,
             ProfilePictureUrl = info.ProfilePictureUrl,
             CreatedAt = info.CreatedAt.ToDateTimeUtc(),
             LastLoginAt = info.LastLoginAt?.ToDateTimeUtc(),

--- a/src/Humans.Web/Models/ProfileEditViewModelBuilder.cs
+++ b/src/Humans.Web/Models/ProfileEditViewModelBuilder.cs
@@ -41,14 +41,14 @@ public static class ProfileEditViewModelBuilder
             Id = profile?.Id ?? Guid.Empty,
             UserId = info.Id,
             Email = info.Email ?? string.Empty,
-            DisplayName = info.DisplayName,
+            DisplayName = info.BurnerName,
             ProfilePictureUrl = info.ProfilePictureUrl,
             HasCustomProfilePicture = hasCustomPicture,
             CustomProfilePictureUrl = hasCustomPicture && profile is not null
                 ? customPictureUrl(profile)
                 : null,
             CanImportGooglePicture = canImportGooglePicture,
-            BurnerName = profile?.BurnerName ?? info.DisplayName,
+            BurnerName = profile?.BurnerName ?? info.BurnerName,
             FirstName = profile?.FirstName ?? string.Empty,
             LastName = profile?.LastName ?? string.Empty,
             City = profile?.City,

--- a/src/Humans.Web/Models/ProfileSummaryViewModelBuilder.cs
+++ b/src/Humans.Web/Models/ProfileSummaryViewModelBuilder.cs
@@ -15,7 +15,7 @@ public static class ProfileSummaryViewModelBuilder
         return new ProfileSummaryViewModel
         {
             UserId = info.Id,
-            DisplayName = info.DisplayName,
+            DisplayName = info.BurnerName,
             ProfilePictureUrl = info.ProfilePictureUrl,
             PreferredLanguage = info.PreferredLanguage,
             HasProfile = false,
@@ -41,7 +41,7 @@ public static class ProfileSummaryViewModelBuilder
         return new ProfileSummaryViewModel
         {
             UserId = info.Id,
-            DisplayName = info.DisplayName,
+            DisplayName = info.BurnerName,
             Email = info.Email,
             ProfilePictureUrl = profile.HasCustomPicture
                 ? customPictureUrl(profile)

--- a/src/Humans.Web/ViewComponents/ProfileCardViewComponent.cs
+++ b/src/Humans.Web/ViewComponents/ProfileCardViewComponent.cs
@@ -114,7 +114,7 @@ public class ProfileCardViewComponent : ViewComponent
         var model = new ProfileCardViewModel
         {
             UserId = userId,
-            DisplayName = info.DisplayName,
+            DisplayName = info.BurnerName,
             ProfilePictureUrl = info.ProfilePictureUrl,
             HasCustomProfilePicture = hasCustomPicture,
             CustomProfilePictureUrl = pictureUrl,


### PR DESCRIPTION
## Summary

Stream A of the obsolete-field drain (Profile/User read side). Migrates rendering-path consumers of legacy DisplayName off the raw Identity-column mirror onto the canonical `UserInfo.BurnerName` accessor, and flags the remaining legacy reads with `[Obsolete]` analyzer diagnostics so new callers light up.

Per the audit, several of the audited items turned out to be already-drained or out of scope:

| Member | Status | Notes |
|---|---|---|
| `Profile.ProfilePictureData` | **DRAINED** | PR #576 had already removed all reads. Added `[Obsolete]` + `[ExpiresOn(\"2026-06-01\")]`. |
| `User.NormalizedEmail` | **DRAINED** | App-code reads already zero. Bumped existing `[ExpiresOn]` from 2026-05-18 → 2026-06-01. |
| `UserEmail.IsNotificationTarget` | **N/A** | Property was renamed to `IsPrimary` per the maintenance log; no C# property to mark. |
| `UserInfo.DisplayName` | **DRAINED** (render-path) | All `info.DisplayName` reads in viewmodel-builders / controllers switched to `info.BurnerName`. `[Obsolete]` added with `HUM_USERINFO_DISPLAYNAME` diagnostic. |
| `User.DisplayName` | **PARTIAL DRAIN** | Render-path `user.DisplayName` reads in Web controllers + Application services switched to `UserInfo.BurnerName` where the local handle is UserInfo. `[Obsolete]` added with `HUM_USER_DISPLAYNAME` diagnostic + NoWarn suppression so legitimate consumers (Identity claims, repository merge/purge/delete labels, GDPR export, dev seeders, email greetings on User-typed handles, admin merge UI) don't break the build. **STOPPED** before adding `[ExpiresOn]` — the analyzer deadline would force the remaining ~31 legit-but-unsuppressed callers to error on 2026-06-01, which is unrealistic in 16 days. |
| `Profile.IsSuspended` | **NO-OP** | All canonical-path reads already on `UserInfo.IsSuspended`. Remaining `p.IsSuspended` reads are DB-layer LINQ filters (ProfileRepository, RoleAssignmentClaimsTransformation, HumansMetricsService, SystemTeamSyncJob) — explicitly exempt per `memory/architecture/no-column-drops-for-decoupling.md` (\"LINQ filter sites that read the column during decoupling work, that is not a blocker\"). Adding `[ExpiresOn]` here would erroneously red-flag the exempt sites. Skipped. |
| `Profile.HasRequiredIdentityFields()` | **NO-OP** | All canonical-path reads already on `UserInfo.HasRequiredIdentityFields`. Remaining 2 calls are the State-derivation write paths in `ProfileService` (the predicate's own dual-write window). Adding `[ExpiresOn]` would red-flag those exempt sites. Skipped. |

## Files migrated

**Viewmodel builders / view components (rendering surfaces):**
- `ProfileSummaryViewModelBuilder` (popover model)
- `AdminHumanDetailViewModelBuilder` (admin detail page header)
- `ProfileEditViewModelBuilder` (edit-form preview + BurnerName fallback)
- `ProfileCardViewComponent` (card model)

**Web controllers (render-path):**
- `HomeController.Index` (dashboard greeting)
- `GuestController` (guest dashboard greeting + viewmodel build)
- `ProfileController` (own-profile vm, SendMessage GET/POST, AddRole GET/POST, BuildEmailsViewModelAsync target name)
- `OnboardingReviewController.MapToReviewItem`
- `TicketTransferService` receiver card DTO
- `AgentController` / `AgentApiController` (conversation lists)
- `ShiftsController.BuildOrphanRows`
- `CampController` (member picker, facilitated message sender)
- `GoogleController` (sync settings UpdatedByName)
- `TeamAdminController.ActorDisplayName`
- `WidgetGalleryController` (current-user greeting)
- `IssuesController.AssigneeOptions`
- `AdminController.PurgeHuman` audit message

**Application services:**
- `CampService.GetActiveLeads` lead names
- `CampRoleService` panel slot labels
- `CityPlanningService` polygon-history modified-by labels
- `IssuesService` audit/assignee/reporter display names (3 sites)
- `AdminHumanListAssembler` admin row name
- `TicketQueryService` matched-user/who-hasn't-bought name
- `UserEmailService` flag-violation display name
- `TeamService.SendAddedToTeamEmail` greeting
- `Campaigns/CampaignService` grant-row recipient + UserInfo overload of `BuildCampaignCodeRequest`
- `Governance/ApplicationDecisionService.GetBoardMembersAsync` member name
- `Profiles/ProfileService` picture-migration-snapshot DB-only row name
- `GoogleRemovalNotificationService` removed-access email greeting
- `GoogleAdminService.GetEmailRenameDetectionAsync` anonymous-record DisplayName
- `GoogleGroupSyncService.BuildExpectedMembers` (collapsed manual `Profile.BurnerName ?? DisplayName` fallback to `user.BurnerName`)

**Domain markers:**
- `Profile.ProfilePictureData` → `[Obsolete]` + `[ExpiresOn(\"2026-06-01\")]`
- `User.NormalizedEmail` → bump `[ExpiresOn]` 2026-05-18 → 2026-06-01
- `User.DisplayName` → `[Obsolete(DiagnosticId = HUM_USER_DISPLAYNAME)]`
- `UserInfo.DisplayName` → `[property: Obsolete(DiagnosticId = HUM_USERINFO_DISPLAYNAME)]`

**Build config:**
- `Directory.Build.props` NoWarn: add `HUM_USER_DISPLAYNAME` and `HUM_USERINFO_DISPLAYNAME` (matches the existing `HUM_PROFILE_ISSUSPENDED` / `HUM_USER_NORMALIZEDEMAIL` precedents)

## Not migrated (with rationale)

- `User.DisplayName` reads on `User`-typed locals in `Application/Services` whose tests mock `IUserService.GetByIdAsync` (`AccountDeletionService.RequestDeletionAsync`, `ApplicationDecisionService.Approve/RejectAsync`, `GoogleAdminService.LinkWorkspaceAccountAsync`). Switching to `GetUserInfoAsync` breaks the mocks — needs a coordinated test update.
- `ProfileController.cs:660, 1223` — email-verification sends keyed off `User` entities passed into private helpers.
- `AdminMergeController` / merge UI — admin-only side-by-side compare where the legacy column is more useful than BurnerName for the merge-direction decision.
- `HumansUserClaimsPrincipalFactory` — ASP.NET Identity claim mutation (rule exemption).
- `UserRepository` merge / purge / delete labels — rule exemption (spec-listed).
- `NobodiesEmailBadgeViewComponent` — spec-listed.
- `DevPersonaSeeder`, `DevLoginController` — dev-only seeding.
- `UsersAdminDebugController`, `/Users/Admin/Debug` views — debug screens (rule exemption).
- LINQ filter sites against `Profile.IsSuspended` (DB-layer) — `no-column-drops-for-decoupling.md` rule exemption.
- `Profile.HasRequiredIdentityFields()` call sites (State derivation in ProfileService) — rule exemption.

## Test plan

- [x] `dotnet build Humans.slnx -v quiet` — clean.
- [x] `dotnet test Humans.slnx -v quiet --filter \"FullyQualifiedName!~Integration\"` — Domain 186, Analyzers 96, Web 93, Application 2732 pass.
- [ ] QA smoke: profile popover, dashboard greeting, send-message recipient name, agent conversation list, shift orphan rows, team admin actor name, issues assignee dropdown, ticket-receiver lookup card all show BurnerName (with Identity DisplayName fallback only when no Profile exists).

🤖 Generated with [Claude Code](https://claude.com/claude-code)