### PR TITLE
feat(users-debug): add HasName, Created, Last login columns

### DIFF
--- a/src/Humans.Web/Controllers/UsersAdminDebugController.cs
+++ b/src/Humans.Web/Controllers/UsersAdminDebugController.cs
@@ -65,7 +65,10 @@ public sealed class UsersAdminDebugController : HumansControllerBase
             "marketing" => rows.OrderBy(r => NullableBool(r.MarketingOptedOut)),
             "burnerName" => rows.OrderBy(r => r.BurnerName, StringComparer.OrdinalIgnoreCase),
             "legalName" => rows.OrderBy(r => r.LegalName, StringComparer.OrdinalIgnoreCase),
+            "hasName" => rows.OrderBy(r => NullableBool(r.HasName)),
             "hasConsent" => rows.OrderBy(r => NullableBool(r.HasConsent)),
+            "createdAt" => rows.OrderBy(r => r.CreatedAt),
+            "lastLoginAt" => rows.OrderBy(r => r.LastLoginAt ?? NodaTime.Instant.MinValue),
             _ => rows.OrderBy(r => r.DisplayName, StringComparer.OrdinalIgnoreCase),
         };
 

--- a/src/Humans.Web/Models/UsersDebugViewModel.cs
+++ b/src/Humans.Web/Models/UsersDebugViewModel.cs
@@ -1,5 +1,6 @@
 using Humans.Application;
 using Humans.Domain.Enums;
+using NodaTime;
 
 namespace Humans.Web.Models;
 
@@ -26,7 +27,10 @@ public sealed record UserDebugRow(
     string DisplayName,
     string BurnerName,
     string LegalName,
-    bool? HasConsent)
+    bool? HasName,
+    bool? HasConsent,
+    Instant CreatedAt,
+    Instant? LastLoginAt)
 {
     public static UserDebugRow From(UserInfo info) => new(
         UserId: info.Id,
@@ -36,7 +40,10 @@ public sealed record UserDebugRow(
         DisplayName: info.DisplayName,
         BurnerName: info.Profile?.BurnerName ?? string.Empty,
         LegalName: info.Profile?.FullName ?? string.Empty,
+        HasName: info.Profile is null ? null : info.HasRequiredNameFields,
         HasConsent: info.Profile is null
             ? null
-            : info.Profile.ConsentCheckStatus == ConsentCheckStatus.Cleared);
+            : info.Profile.ConsentCheckStatus == ConsentCheckStatus.Cleared,
+        CreatedAt: info.CreatedAt,
+        LastLoginAt: info.LastLoginAt);
 }

--- a/src/Humans.Web/Views/UsersAdminDebug/Index.cshtml
+++ b/src/Humans.Web/Views/UsersAdminDebug/Index.cshtml
@@ -34,7 +34,10 @@
                         <th><a href="@Toggle("displayName")">Display name@(ArrowFor("displayName"))</a></th>
                         <th><a href="@Toggle("burnerName")">Burner name@(ArrowFor("burnerName"))</a></th>
                         <th><a href="@Toggle("legalName")">Legal name@(ArrowFor("legalName"))</a></th>
+                        <th class="text-center"><a href="@Toggle("hasName")">HasName@(ArrowFor("hasName"))</a></th>
                         <th class="text-center"><a href="@Toggle("hasConsent")">HasConsent@(ArrowFor("hasConsent"))</a></th>
+                        <th><a href="@Toggle("createdAt")">Created@(ArrowFor("createdAt"))</a></th>
+                        <th><a href="@Toggle("lastLoginAt")">Last login@(ArrowFor("lastLoginAt"))</a></th>
                     </tr>
                 </thead>
                 <tbody>
@@ -48,7 +51,10 @@
                         <td>@row.DisplayName</td>
                         <td>@row.BurnerName</td>
                         <td>@row.LegalName</td>
+                        <td class="text-center">@Tri(row.HasName)</td>
                         <td class="text-center">@Tri(row.HasConsent)</td>
+                        <td>@row.CreatedAt.ToDisplayCompactDateTime()</td>
+                        <td>@(row.LastLoginAt?.ToDisplayCompactDateTime() ?? "—")</td>
                     </tr>
                 }
                 </tbody>


### PR DESCRIPTION
## Summary
- Adds three sortable columns to `/Users/Admin/Debug`:
  - **HasName** — surfaces `UserInfo.HasRequiredNameFields` (null/—/Yes/No, tri-state like HasConsent).
  - **Created** — `UserInfo.CreatedAt` rendered via the existing `ToDisplayCompactDateTime` extension.
  - **Last login** — `UserInfo.LastLoginAt` (same formatter, "—" when never logged in).
- All read from the in-memory `UserInfo` cache; no new queries.

## Test plan
- [ ] Visit `/Users/Admin/Debug` and confirm the three new columns render.
- [ ] Sort ascending/descending on each new column.
- [ ] Spot-check a row with no `Profile` shows "—" for HasName.