### PR TITLE
feat(shifts): department coverage pies on /Shifts

### DIFF
--- a/docs/features/shifts/department-coverage-pies.md
+++ b/docs/features/shifts/department-coverage-pies.md
@@ -1,0 +1,111 @@
+<!-- freshness:triggers
+  src/Humans.Application/Services/Shifts/ShiftManagementService.cs
+  src/Humans.Application/Interfaces/Shifts/IShiftManagementService.cs
+  src/Humans.Web/Models/Shifts/ShiftBrowsePageBuilder.cs
+  src/Humans.Web/Views/Shifts/Index.cshtml
+  src/Humans.Web/Views/Shifts/_DepartmentCoveragePieRow.cshtml
+  src/Humans.Web/wwwroot/css/site.css
+-->
+<!-- freshness:flag-on-change
+  Pie eligibility rule (IsInDirectory), sub-team roll-up math, capacity cap, AllDay window, or display ordering may have changed.
+-->
+
+# Department Coverage Pies
+
+## Business Context
+
+Volunteers browsing `/Shifts` see a long flat list of shifts grouped by department. Coordinators wanted an at-a-glance way to see which departments are under-staffed and a one-click filter to focus on a specific department. The coverage-pie row above the page shows percentage-filled per department and acts as a clickable filter — analogous to the existing department dropdown but visual and persistent.
+
+## User Stories
+
+### US-Pie.1: Volunteer Sees Department Coverage at a Glance
+**As a** volunteer
+**I want to** see a row of conic-gradient discs above the shift list, one per department, with a percentage-filled fill
+**So that** I can pick an under-staffed department to help with without scanning the whole page
+
+**Acceptance Criteria:**
+- One pie per pie-eligible department (top-level + promoted sub-team)
+- Disc fill = `FilledHours / RequestedHours` clamped to `[0, 100]%`
+- Hover tooltip shows `Name — N h / M h (P%)`
+- ARIA label reads `Name: P% covered, N of M hours` for screen readers
+- A tip pill above the row reads `Tip — click any chart below to filter shifts to that department.`
+
+### US-Pie.2: Click a Pie to Filter; Click Again to Clear
+**As a** volunteer
+**I want to** click a pie to filter the shift list to that department, and click the same pie again to clear the filter
+**So that** filtering by department is one click instead of opening the dropdown
+
+**Acceptance Criteria:**
+- Click on a pie POSTs the existing `?departmentId=…` query to `/Shifts`
+- Selected pie renders with a gold outline + `vellum` background
+- Clicking the selected pie submits with empty `departmentId`, clearing the filter
+- Period (`?period=…`) and date-range (`?fromDate=…&toDate=…`) filters are preserved across pie clicks
+
+### US-Pie.3: Promoted Sub-Team Pies Sit Next to Their Parent
+**As a** volunteer
+**I want to** see a promoted sub-team's pie immediately after its parent's pie
+**So that** the relationship between sub-team and parent is visually clear
+
+**Acceptance Criteria:**
+- A team with `IsPromotedToDirectory = true` and `ParentTeamId != null` renders its own pie
+- The promoted sub-team's pie appears immediately after its parent's pie in the row (not alphabetically by its own name)
+- Multiple promoted sub-teams under the same parent sort alphabetically among themselves after the parent
+- A non-promoted sub-team does **not** render a pie; its shift hours roll up into the parent's pie
+
+## Data Model
+
+No new tables. Derived from existing `event_settings`, `rotas`, `shifts`, `shift_signups`, and `teams`.
+
+### Pie eligibility
+
+A team is **pie-eligible** when `Team.IsInDirectory` is true:
+
+```
+IsInDirectory = (ParentTeamId == null) OR IsPromotedToDirectory
+```
+
+— top-level departments always; sub-teams only when promoted.
+
+### Bucket assignment
+
+Each visible rota's shifts contribute hours to a single pie:
+
+- If the rota's owning team is pie-eligible → its own pie.
+- Otherwise (a non-promoted sub-team) → the parent team's pie (if the parent is pie-eligible).
+- Otherwise → dropped (no bucket).
+
+### Hour math
+
+For each non-`AdminOnly` shift on a visible (`IsVisibleToVolunteers = true`) rota:
+
+```
+hours       = shift.IsAllDay ? (AllDayWindowEnd − AllDayWindowStart) : shift.Duration.TotalHours
+requested  += hours × shift.MaxVolunteers
+filled     += hours × min(confirmed signups on shift, shift.MaxVolunteers)
+```
+
+- `AdminOnly` shifts and rotas with `IsVisibleToVolunteers = false` are excluded entirely.
+- Confirmed-only — signups in `Pending`, `Refused`, `Bailed`, `Cancelled`, `NoShow` do not count.
+- The cap (`min(confirmed, MaxVolunteers)`) prevents > 100 % when over-enrolled.
+
+### Date range filter
+
+When the page has a `fromDate` / `toDate` filter applied, the same window is applied per-shift via `EventSettings.GateOpeningDate + DayOffset`. The percentage matches what the user is filtering to.
+
+### Display ordering
+
+Service returns rows in natural `TeamName` order. The view-model assembly layer (`ShiftBrowsePageBuilder.OrderPiesGroupedByParent`) applies the sub-team-next-to-parent grouping for display — keeping display ordering out of the service per `memory/architecture/display-sort-in-controllers`.
+
+## Routes
+
+No new routes. Pies submit GET to the existing `/Shifts` action with the same `departmentId` parameter the dropdown uses.
+
+## Authorization
+
+No new gates. Pies inherit `/Shifts`'s existing `[Authorize]` + `CanBrowseShifts` check. A pie's filtered view shows the same shifts a non-pie filter (the dropdown) would.
+
+## Related Features
+
+- [Shift Management](shift-management.md) — pies derive from rotas/shifts/signups owned by Shift Management.
+- [Teams](../teams/teams.md) — `IsPromotedToDirectory` is set in Team admin.
+- Section invariants: [`docs/sections/Shifts.md`](../../sections/Shifts.md#department-coverage-pies).

--- a/docs/sections/Shifts.md
+++ b/docs/sections/Shifts.md
@@ -238,6 +238,12 @@ Selected routes:
 - All 9 dashboard analytics methods on `IShiftManagementService` accept an optional `BuildSubPeriod? subPeriod = null` parameter. When set, it narrows the filter to that sub-window using `BuildSubPeriodClassifier.BoundsFor`. Sub-period is meaningful only when `period == ShiftPeriod.Build` — calls with sub-period set against any other period are treated as if sub-period is null. Sub-period bypasses the dashboard cache (4× key fan-out is not worth it for a side filter).
 - `DevelopmentDashboardSeeder` and its `POST /dev/seed/dashboard` endpoint are gated to `IWebHostEnvironment.IsDevelopment()` AND the `DevAuth:Enabled` setting. QA, preview, and production environments cannot invoke it regardless of role. The endpoint also requires `ShiftDashboardAccess`.
 - Pending status on a Public rota indicates either (a) a coordinator-approval-required rota, or (b) a mid-widget volunteer whose required Volunteer consents have not landed yet. Case (b) auto-promotes to Confirmed when consents complete via `IShiftSignupService.PromoteWidgetPendingSignupsAfterAdmissionAsync`, called from `ConsentService.SubmitConsentAsync`.
+- **Department coverage pies** (rendered above `/Shifts`, see [feature](../features/shifts/department-coverage-pies.md)):
+  - Pie eligibility = `Team.IsInDirectory` (top-level department OR promoted sub-team). Non-promoted sub-team rotas roll up into the parent's pie; if no eligible ancestor exists, the rota is dropped from pies.
+  - `AdminOnly` shifts and rotas with `IsVisibleToVolunteers = false` contribute zero hours regardless of viewer privilege.
+  - Confirmed signups are capped at `MaxVolunteers` per shift before they roll into `FilledHours`, so a pie never exceeds 100 %.
+  - All-day shifts contribute the standard 08:00–18:00 window's duration per slot, never `Shift.Duration` directly.
+  - Service (`IShiftManagementService.GetDepartmentCoveragePiesAsync`) returns rows in natural `TeamName` order; the "promoted sub-team next to its parent" display ordering is applied in `ShiftBrowsePageBuilder.OrderPiesGroupedByParent` (display ordering belongs in view-model assembly).
 
 ## Negative Access Rules
 

--- a/memory/INDEX.md
+++ b/memory/INDEX.md
@@ -84,6 +84,7 @@ Atomic rules. Fetch the body when the description's trigger matches your task. S
 
 - [`about-page-license-attribution`](process/about-page-license-attribution.md) — after any NuGet update, add new versions + licenses to `Views/About/Index.cshtml`
 - [`after-prod-merge-reset`](process/after-prod-merge-reset.md) — after upstream PR lands: `git fetch upstream && git reset --hard upstream/main && git push origin main --force-with-lease`
+- [`cross-repo-pr-push-target`](process/cross-repo-pr-push-target.md) — when fixing a cross-repo PR (head on a contributor's fork), push to that fork's remote, NOT `origin`; check `isCrossRepository` first
 - [`diff-snapshot-after-ef-tool`](process/diff-snapshot-after-ef-tool.md) — after any `dotnet ef` tool run, `git diff HumansDbContextModelSnapshot.cs` before staging; empty migration body ≠ clean snapshot. Don't run EF tooling for code-only refactors (nav drop/rename, reorder) — pure C# changes can't change schema.
 - [`discord-release-notes-format`](process/discord-release-notes-format.md) — audience-grouped (coordinators/volunteers/under-the-hood/known-issues), plain-language, no emojis
 - [`dotnet-verbosity-quiet`](process/dotnet-verbosity-quiet.md) — always `-v quiet` on `dotnet build`/`test`; never pipe through `tail`/`head`/`grep`

--- a/memory/process/cross-repo-pr-push-target.md
+++ b/memory/process/cross-repo-pr-push-target.md
@@ -1,0 +1,31 @@
+---
+name: Cross-repo PRs push to the contributor's fork, not origin
+description: When fixing a PR opened from a contributor's fork, `git push origin HEAD:<branch>` lands on peterdrier/Humans and never reaches the PR. Push to the contributor's fork remote instead.
+---
+
+Before pushing fixes to any PR, check whether it's cross-repository:
+
+```bash
+gh pr view <N> --json isCrossRepository,headRepositoryOwner,headRefName,maintainerCanModify
+```
+
+If `isCrossRepository: true`, the PR's head branch lives on `<headRepositoryOwner.login>/Humans`, **not** on `origin` (peterdrier/Humans). Pushing to `origin HEAD:<headRefName>` will succeed but the commit will not appear on the PR — the PR's head SHA stays where it was, and the "fix" is invisible to reviewers.
+
+**Why:** A push that goes nowhere is worse than a push that fails — git reports success, the agent reports "done", and the regression only surfaces when Peter checks the PR page and sees no new commit. Already burned once on peterdrier/Humans#602 (Frank Fanteev's `pie-info-pill` branch).
+
+**How to apply:**
+
+1. Check `isCrossRepository` before composing the push command.
+2. If `true` and `maintainerCanModify: true`, ensure a remote exists for the contributor's fork:
+   ```bash
+   git remote get-url <login> 2>/dev/null || git remote add <login> https://github.com/<login>/Humans.git
+   git fetch <login>
+   ```
+3. Push to that remote, not `origin`:
+   ```bash
+   git push <login> HEAD:<headRefName>
+   ```
+4. If `maintainerCanModify: false`, you cannot push directly — stop and ask Peter. Don't push to `origin` as a fallback; the PR won't see it.
+5. After pushing, verify with `gh pr view <N> --json headRefOid` that the head SHA matches your new commit.
+
+Most contributor remotes already exist in the worktree (check `git remote -v`) because earlier review rounds added them.

--- a/src/Humans.Application/Interfaces/Shifts/IShiftManagementService.cs
+++ b/src/Humans.Application/Interfaces/Shifts/IShiftManagementService.cs
@@ -17,7 +17,7 @@ public record ShiftTagPreferenceSummary(Guid Id, string Name);
 /// <remarks>
 /// Surface-budget recent history (newest first):
 /// <list type="bullet">
-///   <item>48→49 — feat(shifts): department coverage pies on /Shifts (peterdrier#?). Added GetDepartmentCoveragePiesAsync. Authorized by Peter, 2026-05-16.</item>
+///   <item>48→49 — feat(shifts): department coverage pies on /Shifts (peterdrier#602). Added GetDepartmentCoveragePiesAsync. Authorized by Peter, 2026-05-16.</item>
 ///   <item>2026-05-11 — InterfaceMethodBudgetTests retired; budget migrated to [SurfaceBudget(48)] (issue nobodies-collective/Humans#700).</item>
 ///   <item>49→48 — collapsed GetAllTagsAsync and SearchTagsAsync into one GetTagsAsync(query) method.</item>
 /// </list>

--- a/src/Humans.Application/Interfaces/Shifts/IShiftManagementService.cs
+++ b/src/Humans.Application/Interfaces/Shifts/IShiftManagementService.cs
@@ -26,7 +26,7 @@ public record ShiftTagPreferenceSummary(Guid Id, string Name);
 ///   <item>+1 GetOverallCoverageAsync for admin dashboard shift-coverage tile (peterdrier#349).</item>
 /// </list>
 /// </remarks>
-[SurfaceBudget(48)]
+[SurfaceBudget(49)]
 public interface IShiftManagementService : IApplicationService
 {
     // === Authorization ===
@@ -245,6 +245,21 @@ public interface IShiftManagementService : IApplicationService
         IReadOnlyCollection<Guid> teamIds,
         CancellationToken ct = default);
 
+    /// <summary>
+    /// Returns one row per department pie shown above the /Shifts page.
+    /// Pie-eligible teams = top-level departments + promoted sub-teams
+    /// (<see cref="Team.IsInDirectory"/>). Non-promoted sub-team rotas roll
+    /// up to their parent's pie. AdminOnly shifts and hidden rotas are
+    /// excluded. Date filters are applied per-shift via
+    /// <c>EventSettings.GateOpeningDate + DayOffset</c>.
+    /// Result order: each promoted sub-team follows its parent in the row.
+    /// </summary>
+    Task<IReadOnlyList<DepartmentCoveragePie>> GetDepartmentCoveragePiesAsync(
+        Guid eventSettingsId,
+        LocalDate? fromDate = null,
+        LocalDate? toDate = null,
+        CancellationToken ct = default);
+
     // === Coordinator Dashboard ===
 
     /// <summary>
@@ -396,6 +411,20 @@ public record ShiftsSummaryData(
     int ConfirmedCount,
     int PendingCount,
     int UniqueVolunteerCount);
+
+/// <summary>
+/// One pie shown above the /Shifts page. Hours are decimal so callers can
+/// render an exact percentage; the ratio <c>FilledHours / RequestedHours</c>
+/// is the disc fill.
+/// </summary>
+public record DepartmentCoveragePie(
+    Guid TeamId,
+    string TeamName,
+    string TeamSlug,
+    bool IsSubTeam,
+    Guid? ParentTeamId,
+    decimal RequestedHours,
+    decimal FilledHours);
 
 /// <summary>
 /// Per-day staffing hours grouped by shift priority for volume visualization.

--- a/src/Humans.Application/Interfaces/Shifts/IShiftManagementService.cs
+++ b/src/Humans.Application/Interfaces/Shifts/IShiftManagementService.cs
@@ -17,13 +17,9 @@ public record ShiftTagPreferenceSummary(Guid Id, string Name);
 /// <remarks>
 /// Surface-budget recent history (newest first):
 /// <list type="bullet">
+///   <item>48→49 — feat(shifts): department coverage pies on /Shifts (peterdrier#?). Added GetDepartmentCoveragePiesAsync. Authorized by Peter, 2026-05-16.</item>
 ///   <item>2026-05-11 — InterfaceMethodBudgetTests retired; budget migrated to [SurfaceBudget(48)] (issue nobodies-collective/Humans#700).</item>
 ///   <item>49→48 — collapsed GetAllTagsAsync and SearchTagsAsync into one GetTagsAsync(query) method.</item>
-///   <item>50→49 — tech-debt interface consolidation: collapsed GetShiftsSummaryAsync(single team) and GetShiftsSummaryForTeamsAsync into one GetShiftsSummaryAsync(eventId, teamIds) method.</item>
-///   <item>49→50 — issue-682 global search: added SearchAsync(query, max). Authorized exception (Peter, 2026-05-09): queries against rotas must live in the owning section per design-rules §6.</item>
-///   <item>50→49 — account-merge fold final consolidation: removed ReassignProfilesAndTagPrefsToUserAsync from IShiftManagementService (moved to IUserMerge.ReassignAsync, dispatched via fan-out).</item>
-///   <item>50→50 — account-merge fold redesign Phase 3.2: added ReassignProfilesAndTagPrefsToUserAsync; removed CanManageShiftsAsync (zero production callers, zero tests — fully dead since the shift-management slice 1/2 plan that introduced it never wired it up; controllers use IsDeptCoordinatorAsync + role checks directly).</item>
-///   <item>+1 GetOverallCoverageAsync for admin dashboard shift-coverage tile (peterdrier#349).</item>
 /// </list>
 /// </remarks>
 [SurfaceBudget(49)]
@@ -252,7 +248,9 @@ public interface IShiftManagementService : IApplicationService
     /// up to their parent's pie. AdminOnly shifts and hidden rotas are
     /// excluded. Date filters are applied per-shift via
     /// <c>EventSettings.GateOpeningDate + DayOffset</c>.
-    /// Result order: each promoted sub-team follows its parent in the row.
+    /// Rows are returned in natural <c>TeamName</c> order; the
+    /// "promoted sub-team next to its parent" display ordering is applied
+    /// in the view-model assembly layer.
     /// </summary>
     Task<IReadOnlyList<DepartmentCoveragePie>> GetDepartmentCoveragePiesAsync(
         Guid eventSettingsId,
@@ -415,7 +413,10 @@ public record ShiftsSummaryData(
 /// <summary>
 /// One pie shown above the /Shifts page. Hours are decimal so callers can
 /// render an exact percentage; the ratio <c>FilledHours / RequestedHours</c>
-/// is the disc fill.
+/// is the disc fill. <see cref="ParentTeamName"/> is non-null only for
+/// promoted sub-team rows and carries the parent's display name so the
+/// presentation layer can group sub-teams next to their parent without a
+/// second team lookup.
 /// </summary>
 public record DepartmentCoveragePie(
     Guid TeamId,
@@ -423,6 +424,7 @@ public record DepartmentCoveragePie(
     string TeamSlug,
     bool IsSubTeam,
     Guid? ParentTeamId,
+    string? ParentTeamName,
     decimal RequestedHours,
     decimal FilledHours);
 

--- a/src/Humans.Application/Interfaces/Shifts/IShiftManagementService.cs
+++ b/src/Humans.Application/Interfaces/Shifts/IShiftManagementService.cs
@@ -426,7 +426,20 @@ public record DepartmentCoveragePie(
     Guid? ParentTeamId,
     string? ParentTeamName,
     decimal RequestedHours,
-    decimal FilledHours);
+    decimal FilledHours)
+{
+    /// <summary>
+    /// Filled / requested as an integer 0..100. Single source of truth for
+    /// the disc fill — service caps the inputs so the ratio is bounded, but
+    /// we clamp here too in case a future contributor wires a different
+    /// input path.
+    /// </summary>
+    public int FillPercent => RequestedHours > 0
+        ? Math.Clamp(
+            (int)Math.Round(FilledHours / RequestedHours * 100m, MidpointRounding.AwayFromZero),
+            0, 100)
+        : 0;
+}
 
 /// <summary>
 /// Per-day staffing hours grouped by shift priority for volume visualization.

--- a/src/Humans.Application/Services/Shifts/ShiftManagementService.cs
+++ b/src/Humans.Application/Services/Shifts/ShiftManagementService.cs
@@ -52,6 +52,11 @@ public sealed class ShiftManagementService : IShiftManagementService, IShiftAuth
         [ShiftPriority.Essential] = 6
     };
 
+    // Width of the all-day shift window, used by the pie-row math. Inputs are
+    // static constants so this evaluates once per process.
+    private static readonly decimal AllDayShiftHours = (decimal)Duration.FromTicks(
+        Shift.AllDayWindowEnd.TickOfDay - Shift.AllDayWindowStart.TickOfDay).TotalHours;
+
     private readonly IShiftManagementRepository _repo;
     private readonly IAuditLogService _auditLogService;
     private readonly IAdminAuthorizationService _adminAuthorization;
@@ -1034,8 +1039,6 @@ public sealed class ShiftManagementService : IShiftManagementService, IShiftAuth
 
         var requested = new Dictionary<Guid, decimal>();
         var filled = new Dictionary<Guid, decimal>();
-        var allDayHours = (decimal)Duration.FromTicks(
-            Shift.AllDayWindowEnd.TickOfDay - Shift.AllDayWindowStart.TickOfDay).TotalHours;
 
         foreach (var rota in allRotas.Where(r => r.IsVisibleToVolunteers))
         {
@@ -1056,7 +1059,7 @@ public sealed class ShiftManagementService : IShiftManagementService, IShiftAuth
                     if (toDate is { } to && shiftDate > to) continue;
                 }
 
-                var hours = shift.IsAllDay ? allDayHours : (decimal)shift.Duration.TotalHours;
+                var hours = shift.IsAllDay ? AllDayShiftHours : (decimal)shift.Duration.TotalHours;
                 requested[bucketId.Value] = requested.GetValueOrDefault(bucketId.Value)
                     + hours * shift.MaxVolunteers;
 

--- a/src/Humans.Application/Services/Shifts/ShiftManagementService.cs
+++ b/src/Humans.Application/Services/Shifts/ShiftManagementService.cs
@@ -1066,19 +1066,21 @@ public sealed class ShiftManagementService : IShiftManagementService, IShiftAuth
             }
         }
 
+        // Natural name order. Display-layer ordering rule (sub-team next to
+        // parent) lives in the view-model assembly per
+        // memory/architecture/display-sort-in-controllers.
         return pieTeams
             .Where(t => requested.GetValueOrDefault(t.Id) > 0)
-            .OrderBy(t => t.ParentTeamId is { } pid && teamLookup.TryGetValue(pid, out var parent)
-                ? parent.Name
-                : t.Name, StringComparer.Ordinal)
-            .ThenBy(t => t.ParentTeamId is null ? 0 : 1)
-            .ThenBy(t => t.Name, StringComparer.Ordinal)
+            .OrderBy(t => t.Name, StringComparer.Ordinal)
             .Select(t => new DepartmentCoveragePie(
                 TeamId: t.Id,
                 TeamName: t.Name,
                 TeamSlug: t.Slug,
                 IsSubTeam: t.ParentTeamId is not null,
                 ParentTeamId: t.ParentTeamId,
+                ParentTeamName: t.ParentTeamId is { } pid && teamLookup.TryGetValue(pid, out var parent)
+                    ? parent.Name
+                    : null,
                 RequestedHours: requested[t.Id],
                 FilledHours: filled.GetValueOrDefault(t.Id)))
             .ToList();

--- a/src/Humans.Application/Services/Shifts/ShiftManagementService.cs
+++ b/src/Humans.Application/Services/Shifts/ShiftManagementService.cs
@@ -1028,7 +1028,7 @@ public sealed class ShiftManagementService : IShiftManagementService, IShiftAuth
 
         // Brings rota-owning teams AND their parents into one lookup, so a
         // non-promoted sub-team rota can find its parent without a second hop.
-        var teamLookup = await TeamService.GetByIdsWithParentsAsync(teamIdsWithRotas);
+        var teamLookup = await TeamService.GetByIdsWithParentsAsync(teamIdsWithRotas, ct);
 
         var allRotas = await _repo.GetRotasWithShiftsAndSignupsAsync(
             eventSettingsId, teamIdsWithRotas.ToList(), ct);

--- a/src/Humans.Application/Services/Shifts/ShiftManagementService.cs
+++ b/src/Humans.Application/Services/Shifts/ShiftManagementService.cs
@@ -1009,6 +1009,81 @@ public sealed class ShiftManagementService : IShiftManagementService, IShiftAuth
         CancellationToken ct = default) =>
         _repo.GetTeamIdsWithShiftsInEventAsync(eventSettingsId, teamIds, ct);
 
+    public async Task<IReadOnlyList<DepartmentCoveragePie>> GetDepartmentCoveragePiesAsync(
+        Guid eventSettingsId,
+        LocalDate? fromDate = null,
+        LocalDate? toDate = null,
+        CancellationToken ct = default)
+    {
+        var es = await _repo.GetEventSettingsByIdAsync(eventSettingsId, ct);
+        if (es is null) return [];
+
+        var teamIdsWithRotas = await _repo.GetTeamIdsWithRotasInEventAsync(eventSettingsId, ct);
+        if (teamIdsWithRotas.Count == 0) return [];
+
+        // Brings rota-owning teams AND their parents into one lookup, so a
+        // non-promoted sub-team rota can find its parent without a second hop.
+        var teamLookup = await TeamService.GetByIdsWithParentsAsync(teamIdsWithRotas);
+
+        var allRotas = await _repo.GetRotasWithShiftsAndSignupsAsync(
+            eventSettingsId, teamIdsWithRotas.ToList(), ct);
+
+        // Pie-eligible teams = top-level departments + promoted sub-teams.
+        var pieTeams = teamLookup.Values.Where(t => t.IsInDirectory).ToList();
+        var pieTeamIds = pieTeams.Select(t => t.Id).ToHashSet();
+
+        var requested = new Dictionary<Guid, decimal>();
+        var filled = new Dictionary<Guid, decimal>();
+        var allDayHours = (decimal)Duration.FromTicks(
+            Shift.AllDayWindowEnd.TickOfDay - Shift.AllDayWindowStart.TickOfDay).TotalHours;
+
+        foreach (var rota in allRotas.Where(r => r.IsVisibleToVolunteers))
+        {
+            if (!teamLookup.TryGetValue(rota.TeamId, out var rotaTeam)) continue;
+
+            // Bucket: own pie if eligible; otherwise nearest ancestor's pie.
+            Guid? bucketId = pieTeamIds.Contains(rotaTeam.Id)
+                ? rotaTeam.Id
+                : (rotaTeam.ParentTeamId is { } pid && pieTeamIds.Contains(pid) ? pid : null);
+            if (bucketId is null) continue;
+
+            foreach (var shift in rota.Shifts.Where(s => !s.AdminOnly))
+            {
+                if (fromDate is not null || toDate is not null)
+                {
+                    var shiftDate = es.GateOpeningDate.PlusDays(shift.DayOffset);
+                    if (fromDate is { } from && shiftDate < from) continue;
+                    if (toDate is { } to && shiftDate > to) continue;
+                }
+
+                var hours = shift.IsAllDay ? allDayHours : (decimal)shift.Duration.TotalHours;
+                requested[bucketId.Value] = requested.GetValueOrDefault(bucketId.Value)
+                    + hours * shift.MaxVolunteers;
+
+                var confirmed = shift.ShiftSignups.Count(ss => ss.Status == SignupStatus.Confirmed);
+                var capped = Math.Min(confirmed, shift.MaxVolunteers);
+                filled[bucketId.Value] = filled.GetValueOrDefault(bucketId.Value) + hours * capped;
+            }
+        }
+
+        return pieTeams
+            .Where(t => requested.GetValueOrDefault(t.Id) > 0)
+            .OrderBy(t => t.ParentTeamId is { } pid && teamLookup.TryGetValue(pid, out var parent)
+                ? parent.Name
+                : t.Name, StringComparer.Ordinal)
+            .ThenBy(t => t.ParentTeamId is null ? 0 : 1)
+            .ThenBy(t => t.Name, StringComparer.Ordinal)
+            .Select(t => new DepartmentCoveragePie(
+                TeamId: t.Id,
+                TeamName: t.Name,
+                TeamSlug: t.Slug,
+                IsSubTeam: t.ParentTeamId is not null,
+                ParentTeamId: t.ParentTeamId,
+                RequestedHours: requested[t.Id],
+                FilledHours: filled.GetValueOrDefault(t.Id)))
+            .ToList();
+    }
+
     public async Task<IReadOnlyList<(Guid TeamId, string TeamName)>> GetDepartmentsWithRotasAsync(
         Guid eventSettingsId)
     {

--- a/src/Humans.Web/Controllers/ShiftsController.cs
+++ b/src/Humans.Web/Controllers/ShiftsController.cs
@@ -105,7 +105,8 @@ public class ShiftsController : HumansControllerBase
             tagIds,
             sort,
             periods,
-            isPrivileged));
+            isPrivileged),
+            HttpContext.RequestAborted);
 
         return View(model);
     }

--- a/src/Humans.Web/Models/SectionHelpContent.cs
+++ b/src/Humans.Web/Models/SectionHelpContent.cs
@@ -113,8 +113,9 @@ public static class SectionHelpContent
 
             1. Browse available shifts on the **Shifts** page
             2. Filter by date, department, or shift type to find what suits you
-            3. Click on a shift to see details and sign up
-            4. Some shifts require coordinator approval before your signup is confirmed
+            3. Or click a department pie above the list to filter by that department; click it again to clear
+            4. Click on a shift to see details and sign up
+            5. Some shifts require coordinator approval before your signup is confirmed
 
             ### Managing Your Shifts
 

--- a/src/Humans.Web/Models/ShiftViewModels.cs
+++ b/src/Humans.Web/Models/ShiftViewModels.cs
@@ -190,6 +190,13 @@ public class ShiftBrowseViewModel
     public bool ShowSignups { get; set; }
 
     /// <summary>
+    /// Department coverage pies rendered above the page. One row per
+    /// top-level department + each promoted sub-team. Empty when the event
+    /// has no rotas that contribute pie hours.
+    /// </summary>
+    public IReadOnlyList<DepartmentCoveragePie> CoveragePies { get; set; } = [];
+
+    /// <summary>
     /// Current sort mode: "urgency" for most-needed-first, null/empty for default by-department grouping.
     /// </summary>
     public string? Sort { get; set; }

--- a/src/Humans.Web/Models/Shifts/ShiftBrowsePageBuilder.cs
+++ b/src/Humans.Web/Models/Shifts/ShiftBrowsePageBuilder.cs
@@ -99,6 +99,11 @@ public sealed class ShiftBrowsePageBuilder
         // VolunteerTagPreference.ShiftTagId.
         var (userSignupShiftIds, userSignupStatuses) = ShiftSignupHelper.ResolveActiveStatuses(request.UserSignups);
 
+        // Pies use the same date window as the shift list so the percentages
+        // line up with what the user is filtering to.
+        var coveragePies = await _shiftManagement.GetDepartmentCoveragePiesAsync(
+            es.Id, filterFromDate, filterToDate);
+
         return new ShiftBrowseViewModel
         {
             EventSettings = es,
@@ -121,7 +126,8 @@ public sealed class ShiftBrowsePageBuilder
             FilterTagIds = activeTagFilter,
             UserPreferredTagIds = request.UserTagPreferences.Select(t => t.ShiftTagId).ToHashSet(),
             MySignupCount = request.UserSignups.Count(s => s.Status is SignupStatus.Confirmed or SignupStatus.Pending),
-            UserActiveSignups = request.UserActiveSignups
+            UserActiveSignups = request.UserActiveSignups,
+            CoveragePies = coveragePies
         };
     }
 

--- a/src/Humans.Web/Models/Shifts/ShiftBrowsePageBuilder.cs
+++ b/src/Humans.Web/Models/Shifts/ShiftBrowsePageBuilder.cs
@@ -101,8 +101,12 @@ public sealed class ShiftBrowsePageBuilder
 
         // Pies use the same date window as the shift list so the percentages
         // line up with what the user is filtering to.
-        var coveragePies = await _shiftManagement.GetDepartmentCoveragePiesAsync(
-            es.Id, filterFromDate, filterToDate);
+        // Service returns natural-name-ordered rows; apply the display
+        // grouping here so each promoted sub-team renders right after its
+        // parent (memory/architecture/display-sort-in-controllers).
+        var coveragePies = OrderPiesGroupedByParent(
+            await _shiftManagement.GetDepartmentCoveragePiesAsync(
+                es.Id, filterFromDate, filterToDate));
 
         return new ShiftBrowseViewModel
         {
@@ -208,6 +212,20 @@ public sealed class ShiftBrowsePageBuilder
 
         return activePeriods;
     }
+
+    /// <summary>
+    /// Orders pies for display: each promoted sub-team is placed immediately
+    /// after its parent (using the parent's name as the group key), instead
+    /// of strict alphabetical order. Multiple sub-teams under the same parent
+    /// sort alphabetically. <c>internal</c> so unit tests can target it.
+    /// </summary>
+    internal static IReadOnlyList<DepartmentCoveragePie> OrderPiesGroupedByParent(
+        IReadOnlyList<DepartmentCoveragePie> pies) =>
+        pies
+            .OrderBy(p => p.ParentTeamName ?? p.TeamName, StringComparer.Ordinal)
+            .ThenBy(p => p.IsSubTeam ? 1 : 0)
+            .ThenBy(p => p.TeamName, StringComparer.Ordinal)
+            .ToList();
 
     private static (LocalDate From, LocalDate To) GetPeriodDateRange(EventSettings es, ShiftPeriod period)
     {

--- a/src/Humans.Web/Models/Shifts/ShiftBrowsePageBuilder.cs
+++ b/src/Humans.Web/Models/Shifts/ShiftBrowsePageBuilder.cs
@@ -41,7 +41,7 @@ public sealed class ShiftBrowsePageBuilder
         _teamService = teamService;
     }
 
-    public async Task<ShiftBrowseViewModel> BuildAsync(ShiftBrowsePageRequest request)
+    public async Task<ShiftBrowseViewModel> BuildAsync(ShiftBrowsePageRequest request, CancellationToken ct = default)
     {
         var es = request.EventSettings;
         var period = request.Period;
@@ -106,7 +106,7 @@ public sealed class ShiftBrowsePageBuilder
         // parent (memory/architecture/display-sort-in-controllers).
         var coveragePies = OrderPiesGroupedByParent(
             await _shiftManagement.GetDepartmentCoveragePiesAsync(
-                es.Id, filterFromDate, filterToDate));
+                es.Id, filterFromDate, filterToDate, ct: ct));
 
         return new ShiftBrowseViewModel
         {

--- a/src/Humans.Web/Resources/SharedResource.ca.resx
+++ b/src/Humans.Web/Resources/SharedResource.ca.resx
@@ -4197,6 +4197,12 @@
   <data name="Shifts_PieCoverage_TipDismiss" xml:space="preserve">
     <value>Descarta el consell</value>
   </data>
+  <data name="Shifts_FilterChip_Prefix" xml:space="preserve">
+    <value>Filtre:</value>
+  </data>
+  <data name="Shifts_FilterChip_Clear" xml:space="preserve">
+    <value>Treu el filtre de departament</value>
+  </data>
   <data name="Shifts_From" xml:space="preserve">
     <value>Des de</value>
   </data>

--- a/src/Humans.Web/Resources/SharedResource.ca.resx
+++ b/src/Humans.Web/Resources/SharedResource.ca.resx
@@ -4182,6 +4182,18 @@
   <data name="Shifts_AllDepartments" xml:space="preserve">
     <value>Tots els departaments</value>
   </data>
+  <data name="Shifts_PieCoverage_RowAria" xml:space="preserve">
+    <value>Cobertura per departament — fes clic en un cercle per filtrar</value>
+  </data>
+  <data name="Shifts_PieCoverage_Aria" xml:space="preserve">
+    <value>{0}: {1}% cobert, {2} de {3} hores</value>
+  </data>
+  <data name="Shifts_PieCoverage_Title" xml:space="preserve">
+    <value>{0} — {1} h / {2} h ({3}%)</value>
+  </data>
+  <data name="Shifts_PieCoverage_TipFilter" xml:space="preserve">
+    <value>Consell — fes clic en qualsevol gràfic de sota per filtrar els torns d'aquest departament.</value>
+  </data>
   <data name="Shifts_From" xml:space="preserve">
     <value>Des de</value>
   </data>

--- a/src/Humans.Web/Resources/SharedResource.ca.resx
+++ b/src/Humans.Web/Resources/SharedResource.ca.resx
@@ -4192,7 +4192,10 @@
     <value>{0} — {1} h / {2} h ({3}%)</value>
   </data>
   <data name="Shifts_PieCoverage_TipFilter" xml:space="preserve">
-    <value>Consell — fes clic en qualsevol gràfic de sota per filtrar els torns d'aquest departament.</value>
+    <value>Consell — fes clic en un gràfic per filtrar per aquest departament; torna a fer-hi clic per esborrar.</value>
+  </data>
+  <data name="Shifts_PieCoverage_TipDismiss" xml:space="preserve">
+    <value>Descarta el consell</value>
   </data>
   <data name="Shifts_From" xml:space="preserve">
     <value>Des de</value>

--- a/src/Humans.Web/Resources/SharedResource.de.resx
+++ b/src/Humans.Web/Resources/SharedResource.de.resx
@@ -4192,7 +4192,10 @@
     <value>{0} — {1} h / {2} h ({3}%)</value>
   </data>
   <data name="Shifts_PieCoverage_TipFilter" xml:space="preserve">
-    <value>Tipp — klicke auf ein Diagramm unten, um die Schichten dieser Abteilung zu filtern.</value>
+    <value>Tipp — klicke auf ein Diagramm, um diese Abteilung zu filtern; klicke erneut zum Aufheben.</value>
+  </data>
+  <data name="Shifts_PieCoverage_TipDismiss" xml:space="preserve">
+    <value>Tipp ausblenden</value>
   </data>
   <data name="Shifts_From" xml:space="preserve">
     <value>Von</value>

--- a/src/Humans.Web/Resources/SharedResource.de.resx
+++ b/src/Humans.Web/Resources/SharedResource.de.resx
@@ -4197,6 +4197,12 @@
   <data name="Shifts_PieCoverage_TipDismiss" xml:space="preserve">
     <value>Tipp ausblenden</value>
   </data>
+  <data name="Shifts_FilterChip_Prefix" xml:space="preserve">
+    <value>Filter:</value>
+  </data>
+  <data name="Shifts_FilterChip_Clear" xml:space="preserve">
+    <value>Abteilungsfilter entfernen</value>
+  </data>
   <data name="Shifts_From" xml:space="preserve">
     <value>Von</value>
   </data>

--- a/src/Humans.Web/Resources/SharedResource.de.resx
+++ b/src/Humans.Web/Resources/SharedResource.de.resx
@@ -4182,6 +4182,18 @@
   <data name="Shifts_AllDepartments" xml:space="preserve">
     <value>Alle Abteilungen</value>
   </data>
+  <data name="Shifts_PieCoverage_RowAria" xml:space="preserve">
+    <value>Abdeckung pro Abteilung — klicken zum Filtern</value>
+  </data>
+  <data name="Shifts_PieCoverage_Aria" xml:space="preserve">
+    <value>{0}: {1}% abgedeckt, {2} von {3} Stunden</value>
+  </data>
+  <data name="Shifts_PieCoverage_Title" xml:space="preserve">
+    <value>{0} — {1} h / {2} h ({3}%)</value>
+  </data>
+  <data name="Shifts_PieCoverage_TipFilter" xml:space="preserve">
+    <value>Tipp — klicke auf ein Diagramm unten, um die Schichten dieser Abteilung zu filtern.</value>
+  </data>
   <data name="Shifts_From" xml:space="preserve">
     <value>Von</value>
   </data>

--- a/src/Humans.Web/Resources/SharedResource.es.resx
+++ b/src/Humans.Web/Resources/SharedResource.es.resx
@@ -4192,7 +4192,10 @@
     <value>{0} — {1} h / {2} h ({3}%)</value>
   </data>
   <data name="Shifts_PieCoverage_TipFilter" xml:space="preserve">
-    <value>Consejo — haz clic en cualquier gráfico de abajo para filtrar los turnos por ese departamento.</value>
+    <value>Consejo — haz clic en un gráfico para filtrar por ese departamento; vuelve a hacer clic para borrar.</value>
+  </data>
+  <data name="Shifts_PieCoverage_TipDismiss" xml:space="preserve">
+    <value>Descartar consejo</value>
   </data>
   <data name="Shifts_From" xml:space="preserve">
     <value>Desde</value>

--- a/src/Humans.Web/Resources/SharedResource.es.resx
+++ b/src/Humans.Web/Resources/SharedResource.es.resx
@@ -4182,6 +4182,18 @@
   <data name="Shifts_AllDepartments" xml:space="preserve">
     <value>Todos los departamentos</value>
   </data>
+  <data name="Shifts_PieCoverage_RowAria" xml:space="preserve">
+    <value>Cobertura por departamento — haz clic en un círculo para filtrar</value>
+  </data>
+  <data name="Shifts_PieCoverage_Aria" xml:space="preserve">
+    <value>{0}: {1}% cubierto, {2} de {3} horas</value>
+  </data>
+  <data name="Shifts_PieCoverage_Title" xml:space="preserve">
+    <value>{0} — {1} h / {2} h ({3}%)</value>
+  </data>
+  <data name="Shifts_PieCoverage_TipFilter" xml:space="preserve">
+    <value>Consejo — haz clic en cualquier gráfico de abajo para filtrar los turnos por ese departamento.</value>
+  </data>
   <data name="Shifts_From" xml:space="preserve">
     <value>Desde</value>
   </data>

--- a/src/Humans.Web/Resources/SharedResource.es.resx
+++ b/src/Humans.Web/Resources/SharedResource.es.resx
@@ -4197,6 +4197,12 @@
   <data name="Shifts_PieCoverage_TipDismiss" xml:space="preserve">
     <value>Descartar consejo</value>
   </data>
+  <data name="Shifts_FilterChip_Prefix" xml:space="preserve">
+    <value>Filtro:</value>
+  </data>
+  <data name="Shifts_FilterChip_Clear" xml:space="preserve">
+    <value>Quitar filtro de departamento</value>
+  </data>
   <data name="Shifts_From" xml:space="preserve">
     <value>Desde</value>
   </data>

--- a/src/Humans.Web/Resources/SharedResource.fr.resx
+++ b/src/Humans.Web/Resources/SharedResource.fr.resx
@@ -4197,6 +4197,12 @@
   <data name="Shifts_PieCoverage_TipDismiss" xml:space="preserve">
     <value>Masquer l'astuce</value>
   </data>
+  <data name="Shifts_FilterChip_Prefix" xml:space="preserve">
+    <value>Filtre :</value>
+  </data>
+  <data name="Shifts_FilterChip_Clear" xml:space="preserve">
+    <value>Effacer le filtre de département</value>
+  </data>
   <data name="Shifts_From" xml:space="preserve">
     <value>De</value>
   </data>

--- a/src/Humans.Web/Resources/SharedResource.fr.resx
+++ b/src/Humans.Web/Resources/SharedResource.fr.resx
@@ -4182,6 +4182,18 @@
   <data name="Shifts_AllDepartments" xml:space="preserve">
     <value>Tous les départements</value>
   </data>
+  <data name="Shifts_PieCoverage_RowAria" xml:space="preserve">
+    <value>Couverture par département — cliquez sur un cercle pour filtrer</value>
+  </data>
+  <data name="Shifts_PieCoverage_Aria" xml:space="preserve">
+    <value>{0} : {1}% couvert, {2} sur {3} heures</value>
+  </data>
+  <data name="Shifts_PieCoverage_Title" xml:space="preserve">
+    <value>{0} — {1} h / {2} h ({3}%)</value>
+  </data>
+  <data name="Shifts_PieCoverage_TipFilter" xml:space="preserve">
+    <value>Astuce — cliquez sur un graphique ci-dessous pour filtrer les créneaux de ce département.</value>
+  </data>
   <data name="Shifts_From" xml:space="preserve">
     <value>De</value>
   </data>

--- a/src/Humans.Web/Resources/SharedResource.fr.resx
+++ b/src/Humans.Web/Resources/SharedResource.fr.resx
@@ -4192,7 +4192,10 @@
     <value>{0} — {1} h / {2} h ({3}%)</value>
   </data>
   <data name="Shifts_PieCoverage_TipFilter" xml:space="preserve">
-    <value>Astuce — cliquez sur un graphique ci-dessous pour filtrer les créneaux de ce département.</value>
+    <value>Astuce — cliquez sur un graphique pour filtrer ce département ; cliquez à nouveau pour effacer.</value>
+  </data>
+  <data name="Shifts_PieCoverage_TipDismiss" xml:space="preserve">
+    <value>Masquer l'astuce</value>
   </data>
   <data name="Shifts_From" xml:space="preserve">
     <value>De</value>

--- a/src/Humans.Web/Resources/SharedResource.it.resx
+++ b/src/Humans.Web/Resources/SharedResource.it.resx
@@ -4192,7 +4192,10 @@
     <value>{0} — {1} h / {2} h ({3}%)</value>
   </data>
   <data name="Shifts_PieCoverage_TipFilter" xml:space="preserve">
-    <value>Suggerimento — clicca su un grafico qui sotto per filtrare i turni di quel dipartimento.</value>
+    <value>Suggerimento — clicca su un grafico per filtrare quel dipartimento; clicca di nuovo per cancellare.</value>
+  </data>
+  <data name="Shifts_PieCoverage_TipDismiss" xml:space="preserve">
+    <value>Ignora il suggerimento</value>
   </data>
   <data name="Shifts_From" xml:space="preserve">
     <value>Da</value>

--- a/src/Humans.Web/Resources/SharedResource.it.resx
+++ b/src/Humans.Web/Resources/SharedResource.it.resx
@@ -4197,6 +4197,12 @@
   <data name="Shifts_PieCoverage_TipDismiss" xml:space="preserve">
     <value>Ignora il suggerimento</value>
   </data>
+  <data name="Shifts_FilterChip_Prefix" xml:space="preserve">
+    <value>Filtro:</value>
+  </data>
+  <data name="Shifts_FilterChip_Clear" xml:space="preserve">
+    <value>Rimuovi filtro dipartimento</value>
+  </data>
   <data name="Shifts_From" xml:space="preserve">
     <value>Da</value>
   </data>

--- a/src/Humans.Web/Resources/SharedResource.it.resx
+++ b/src/Humans.Web/Resources/SharedResource.it.resx
@@ -4182,6 +4182,18 @@
   <data name="Shifts_AllDepartments" xml:space="preserve">
     <value>Tutti i dipartimenti</value>
   </data>
+  <data name="Shifts_PieCoverage_RowAria" xml:space="preserve">
+    <value>Copertura per dipartimento — clicca su un cerchio per filtrare</value>
+  </data>
+  <data name="Shifts_PieCoverage_Aria" xml:space="preserve">
+    <value>{0}: {1}% coperto, {2} di {3} ore</value>
+  </data>
+  <data name="Shifts_PieCoverage_Title" xml:space="preserve">
+    <value>{0} — {1} h / {2} h ({3}%)</value>
+  </data>
+  <data name="Shifts_PieCoverage_TipFilter" xml:space="preserve">
+    <value>Suggerimento — clicca su un grafico qui sotto per filtrare i turni di quel dipartimento.</value>
+  </data>
   <data name="Shifts_From" xml:space="preserve">
     <value>Da</value>
   </data>

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -1739,6 +1739,10 @@
   <data name="Shifts_BrowseTitle" xml:space="preserve"><value>Browse Volunteer Options</value></data>
   <data name="Shifts_Department" xml:space="preserve"><value>Department</value></data>
   <data name="Shifts_AllDepartments" xml:space="preserve"><value>All Departments</value></data>
+  <data name="Shifts_PieCoverage_RowAria" xml:space="preserve"><value>Department coverage pies — click a pie to filter the page</value></data>
+  <data name="Shifts_PieCoverage_Aria" xml:space="preserve"><value>{0}: {1}% covered, {2} of {3} hours</value></data>
+  <data name="Shifts_PieCoverage_Title" xml:space="preserve"><value>{0} — {1} h / {2} h ({3}%)</value></data>
+  <data name="Shifts_PieCoverage_TipFilter" xml:space="preserve"><value>Tip — click any chart below to filter shifts to that department.</value></data>
   <data name="Shifts_From" xml:space="preserve"><value>From</value></data>
   <data name="Shifts_To" xml:space="preserve"><value>To</value></data>
   <data name="Shifts_ClearFilters" xml:space="preserve"><value>Clear Filters</value></data>

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -1744,6 +1744,8 @@
   <data name="Shifts_PieCoverage_Title" xml:space="preserve"><value>{0} — {1} h / {2} h ({3}%)</value></data>
   <data name="Shifts_PieCoverage_TipFilter" xml:space="preserve"><value>Tip — click a chart to filter to that department; click it again to clear.</value></data>
   <data name="Shifts_PieCoverage_TipDismiss" xml:space="preserve"><value>Dismiss tip</value></data>
+  <data name="Shifts_FilterChip_Prefix" xml:space="preserve"><value>Filter:</value></data>
+  <data name="Shifts_FilterChip_Clear" xml:space="preserve"><value>Clear department filter</value></data>
   <data name="Shifts_From" xml:space="preserve"><value>From</value></data>
   <data name="Shifts_To" xml:space="preserve"><value>To</value></data>
   <data name="Shifts_ClearFilters" xml:space="preserve"><value>Clear Filters</value></data>

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -1742,7 +1742,8 @@
   <data name="Shifts_PieCoverage_RowAria" xml:space="preserve"><value>Department coverage pies — click a pie to filter the page</value></data>
   <data name="Shifts_PieCoverage_Aria" xml:space="preserve"><value>{0}: {1}% covered, {2} of {3} hours</value></data>
   <data name="Shifts_PieCoverage_Title" xml:space="preserve"><value>{0} — {1} h / {2} h ({3}%)</value></data>
-  <data name="Shifts_PieCoverage_TipFilter" xml:space="preserve"><value>Tip — click any chart below to filter shifts to that department.</value></data>
+  <data name="Shifts_PieCoverage_TipFilter" xml:space="preserve"><value>Tip — click a chart to filter to that department; click it again to clear.</value></data>
+  <data name="Shifts_PieCoverage_TipDismiss" xml:space="preserve"><value>Dismiss tip</value></data>
   <data name="Shifts_From" xml:space="preserve"><value>From</value></data>
   <data name="Shifts_To" xml:space="preserve"><value>To</value></data>
   <data name="Shifts_ClearFilters" xml:space="preserve"><value>Clear Filters</value></data>

--- a/src/Humans.Web/Views/Shifts/Index.cshtml
+++ b/src/Humans.Web/Views/Shifts/Index.cshtml
@@ -164,6 +164,25 @@
         }
     </form>
 
+    @if (Model.FilterDepartmentId is { } depId)
+    {
+        var deptName = Model.AllDepartments.FirstOrDefault(d => d.TeamId == depId)?.Name ?? "";
+        var clearRoute = new Dictionary<string, string?>();
+        if (!string.IsNullOrEmpty(Model.FilterPeriod)) clearRoute["period"] = Model.FilterPeriod;
+        if (!string.IsNullOrEmpty(Model.FilterFromDate)) clearRoute["fromDate"] = Model.FilterFromDate;
+        if (!string.IsNullOrEmpty(Model.FilterToDate)) clearRoute["toDate"] = Model.FilterToDate;
+        if (!string.IsNullOrEmpty(Model.Sort)) clearRoute["sort"] = Model.Sort;
+        for (var i = 0; i < Model.FilterTagIds.Count; i++) clearRoute[$"tags[{i}]"] = Model.FilterTagIds[i].ToString();
+        for (var i = 0; i < activePeriods.Count; i++) clearRoute[$"periods[{i}]"] = activePeriods[i];
+
+        <a asp-action="Index" asp-all-route-data="clearRoute"
+           class="dept-filter-chip"
+           aria-label="@Localizer["Shifts_FilterChip_Clear"]">
+            <span class="dept-filter-chip-label">@Localizer["Shifts_FilterChip_Prefix"] @deptName</span>
+            <span class="dept-filter-chip-x" aria-hidden="true">&times;</span>
+        </a>
+    }
+
     @await Html.PartialAsync("_DepartmentCoveragePieRow", Model)
 
     @* === Tag Filters with Preferences as Defaults === *@

--- a/src/Humans.Web/Views/Shifts/Index.cshtml
+++ b/src/Humans.Web/Views/Shifts/Index.cshtml
@@ -164,6 +164,8 @@
         }
     </form>
 
+    @await Html.PartialAsync("_DepartmentCoveragePieRow", Model)
+
     @* === Tag Filters with Preferences as Defaults === *@
     @if (Model.AllTags.Count > 0)
     {

--- a/src/Humans.Web/Views/Shifts/_DepartmentCoveragePieRow.cshtml
+++ b/src/Humans.Web/Views/Shifts/_DepartmentCoveragePieRow.cshtml
@@ -12,7 +12,20 @@
             aria-label="@Localizer["Shifts_PieCoverage_TipDismiss"]"
             data-dept-pie-tip-dismiss>&times;</button>
 </div>
-<div class="dept-pie-row" role="group" aria-label="@Localizer["Shifts_PieCoverage_RowAria"]">
+<form method="get" asp-action="Index" class="dept-pie-row" role="group"
+      aria-label="@Localizer["Shifts_PieCoverage_RowAria"]">
+    @if (!string.IsNullOrEmpty(Model.FilterPeriod))
+    {
+        <input type="hidden" name="period" value="@Model.FilterPeriod" />
+    }
+    @if (!string.IsNullOrEmpty(Model.FilterFromDate))
+    {
+        <input type="hidden" name="fromDate" value="@Model.FilterFromDate" />
+    }
+    @if (!string.IsNullOrEmpty(Model.FilterToDate))
+    {
+        <input type="hidden" name="toDate" value="@Model.FilterToDate" />
+    }
     @foreach (var pie in Model.CoveragePies)
     {
         var isSelected = Model.FilterDepartmentId == pie.TeamId;
@@ -30,36 +43,26 @@
             Localizer["Shifts_PieCoverage_Title"].Value,
             pie.TeamName, filledDisplay, requestedDisplay, pct);
         var deptValue = isSelected ? string.Empty : pie.TeamId.ToString();
-        var coverageClass = pct < 25 ? " coverage-critical" : pct < 50 ? " coverage-warning" : string.Empty;
+        var coverageClass = pct >= 100 ? " coverage-complete"
+                          : pct < 25 ? " coverage-critical"
+                          : pct < 50 ? " coverage-warning"
+                          : string.Empty;
 
-        <form method="get" asp-action="Index" class="dept-pie-form">
-            @if (!string.IsNullOrEmpty(Model.FilterPeriod))
-            {
-                <input type="hidden" name="period" value="@Model.FilterPeriod" />
-            }
-            @if (!string.IsNullOrEmpty(Model.FilterFromDate))
-            {
-                <input type="hidden" name="fromDate" value="@Model.FilterFromDate" />
-            }
-            @if (!string.IsNullOrEmpty(Model.FilterToDate))
-            {
-                <input type="hidden" name="toDate" value="@Model.FilterToDate" />
-            }
-            <input type="hidden" name="departmentId" value="@deptValue" />
-            <button type="submit"
-                    class="dept-pie@(isSelected ? " selected" : "")@(pie.IsSubTeam ? " is-subteam" : "")@coverageClass"
-                    aria-label="@ariaLabel"
-                    title="@titleText"
-                    style="--pct: @pct%;">
-                <span class="dept-pie-disc" aria-hidden="true"></span>
-                <span class="dept-pie-label">
-                    <span class="dept-pie-name">@pie.TeamName</span>
-                    <span class="dept-pie-stat">@filledDisplay / @requestedDisplay h</span>
-                </span>
-            </button>
-        </form>
+        <button type="submit"
+                name="departmentId"
+                value="@deptValue"
+                class="dept-pie@(isSelected ? " selected" : "")@(pie.IsSubTeam ? " is-subteam" : "")@coverageClass"
+                aria-label="@ariaLabel"
+                title="@titleText"
+                style="--pct: @pct%;">
+            <span class="dept-pie-disc" aria-hidden="true"></span>
+            <span class="dept-pie-label">
+                <span class="dept-pie-name">@pie.TeamName</span>
+                <span class="dept-pie-stat">@filledDisplay h / @requestedDisplay h</span>
+            </span>
+        </button>
     }
-</div>
+</form>
 
 <script>
     (function () {

--- a/src/Humans.Web/Views/Shifts/_DepartmentCoveragePieRow.cshtml
+++ b/src/Humans.Web/Views/Shifts/_DepartmentCoveragePieRow.cshtml
@@ -1,0 +1,58 @@
+@model Humans.Web.Models.ShiftBrowseViewModel
+
+@if (Model.CoveragePies.Count == 0)
+{
+    return;
+}
+
+<div class="dept-pie-tip" role="note">
+    <i class="bi bi-info-circle" aria-hidden="true"></i>
+    <span>@Localizer["Shifts_PieCoverage_TipFilter"]</span>
+</div>
+<div class="dept-pie-row" role="navigation" aria-label="@Localizer["Shifts_PieCoverage_RowAria"]">
+    @foreach (var pie in Model.CoveragePies)
+    {
+        var isSelected = Model.FilterDepartmentId == pie.TeamId;
+        var pct = pie.RequestedHours > 0
+            ? (int)Math.Round(pie.FilledHours / pie.RequestedHours * 100m, MidpointRounding.AwayFromZero)
+            : 0;
+        if (pct < 0) pct = 0;
+        if (pct > 100) pct = 100;
+        var requestedDisplay = pie.RequestedHours.ToString("0.#");
+        var filledDisplay = pie.FilledHours.ToString("0.#");
+        var ariaLabel = string.Format(
+            Localizer["Shifts_PieCoverage_Aria"].Value,
+            pie.TeamName, pct, filledDisplay, requestedDisplay);
+        var titleText = string.Format(
+            Localizer["Shifts_PieCoverage_Title"].Value,
+            pie.TeamName, filledDisplay, requestedDisplay, pct);
+        var deptValue = isSelected ? string.Empty : pie.TeamId.ToString();
+
+        <form method="get" asp-action="Index" class="dept-pie-form">
+            @if (!string.IsNullOrEmpty(Model.FilterPeriod))
+            {
+                <input type="hidden" name="period" value="@Model.FilterPeriod" />
+            }
+            @if (!string.IsNullOrEmpty(Model.FilterFromDate))
+            {
+                <input type="hidden" name="fromDate" value="@Model.FilterFromDate" />
+            }
+            @if (!string.IsNullOrEmpty(Model.FilterToDate))
+            {
+                <input type="hidden" name="toDate" value="@Model.FilterToDate" />
+            }
+            <input type="hidden" name="departmentId" value="@deptValue" />
+            <button type="submit"
+                    class="dept-pie@(isSelected ? " selected" : "")@(pie.IsSubTeam ? " is-subteam" : "")"
+                    aria-label="@ariaLabel"
+                    title="@titleText"
+                    style="--pct: @pct%;">
+                <span class="dept-pie-disc" aria-hidden="true"></span>
+                <span class="dept-pie-label">
+                    <span class="dept-pie-name">@pie.TeamName</span>
+                    <span class="dept-pie-stat">@filledDisplay / @requestedDisplay h</span>
+                </span>
+            </button>
+        </form>
+    }
+</div>

--- a/src/Humans.Web/Views/Shifts/_DepartmentCoveragePieRow.cshtml
+++ b/src/Humans.Web/Views/Shifts/_DepartmentCoveragePieRow.cshtml
@@ -5,11 +5,14 @@
     return;
 }
 
-<div class="dept-pie-tip" role="note">
+<div class="dept-pie-tip" role="note" data-dept-pie-tip hidden>
     <i class="fa-solid fa-circle-info" aria-hidden="true"></i>
     <span>@Localizer["Shifts_PieCoverage_TipFilter"]</span>
+    <button type="button" class="dept-pie-tip-dismiss"
+            aria-label="@Localizer["Shifts_PieCoverage_TipDismiss"]"
+            data-dept-pie-tip-dismiss>&times;</button>
 </div>
-<div class="dept-pie-row" role="navigation" aria-label="@Localizer["Shifts_PieCoverage_RowAria"]">
+<div class="dept-pie-row" role="group" aria-label="@Localizer["Shifts_PieCoverage_RowAria"]">
     @foreach (var pie in Model.CoveragePies)
     {
         var isSelected = Model.FilterDepartmentId == pie.TeamId;
@@ -27,6 +30,7 @@
             Localizer["Shifts_PieCoverage_Title"].Value,
             pie.TeamName, filledDisplay, requestedDisplay, pct);
         var deptValue = isSelected ? string.Empty : pie.TeamId.ToString();
+        var coverageClass = pct < 25 ? " coverage-critical" : pct < 50 ? " coverage-warning" : string.Empty;
 
         <form method="get" asp-action="Index" class="dept-pie-form">
             @if (!string.IsNullOrEmpty(Model.FilterPeriod))
@@ -43,7 +47,7 @@
             }
             <input type="hidden" name="departmentId" value="@deptValue" />
             <button type="submit"
-                    class="dept-pie@(isSelected ? " selected" : "")@(pie.IsSubTeam ? " is-subteam" : "")"
+                    class="dept-pie@(isSelected ? " selected" : "")@(pie.IsSubTeam ? " is-subteam" : "")@coverageClass"
                     aria-label="@ariaLabel"
                     title="@titleText"
                     style="--pct: @pct%;">
@@ -56,3 +60,18 @@
         </form>
     }
 </div>
+
+<script>
+    (function () {
+        var key = 'humans.pieTipDismissed';
+        var tip = document.querySelector('[data-dept-pie-tip]');
+        if (!tip) return;
+        if (localStorage.getItem(key) !== '1') tip.removeAttribute('hidden');
+        var btn = tip.querySelector('[data-dept-pie-tip-dismiss]');
+        if (!btn) return;
+        btn.addEventListener('click', function () {
+            try { localStorage.setItem(key, '1'); } catch (_) { /* private mode */ }
+            tip.setAttribute('hidden', '');
+        });
+    })();
+</script>

--- a/src/Humans.Web/Views/Shifts/_DepartmentCoveragePieRow.cshtml
+++ b/src/Humans.Web/Views/Shifts/_DepartmentCoveragePieRow.cshtml
@@ -6,7 +6,7 @@
 }
 
 <div class="dept-pie-tip" role="note">
-    <i class="bi bi-info-circle" aria-hidden="true"></i>
+    <i class="fa-solid fa-circle-info" aria-hidden="true"></i>
     <span>@Localizer["Shifts_PieCoverage_TipFilter"]</span>
 </div>
 <div class="dept-pie-row" role="navigation" aria-label="@Localizer["Shifts_PieCoverage_RowAria"]">

--- a/src/Humans.Web/Views/Shifts/_DepartmentCoveragePieRow.cshtml
+++ b/src/Humans.Web/Views/Shifts/_DepartmentCoveragePieRow.cshtml
@@ -29,11 +29,7 @@
     @foreach (var pie in Model.CoveragePies)
     {
         var isSelected = Model.FilterDepartmentId == pie.TeamId;
-        var pct = pie.RequestedHours > 0
-            ? (int)Math.Round(pie.FilledHours / pie.RequestedHours * 100m, MidpointRounding.AwayFromZero)
-            : 0;
-        if (pct < 0) pct = 0;
-        if (pct > 100) pct = 100;
+        var pct = pie.FillPercent;
         var requestedDisplay = pie.RequestedHours.ToString("0.#");
         var filledDisplay = pie.FilledHours.ToString("0.#");
         var ariaLabel = string.Format(

--- a/src/Humans.Web/Views/Shifts/_DepartmentCoveragePieRow.cshtml
+++ b/src/Humans.Web/Views/Shifts/_DepartmentCoveragePieRow.cshtml
@@ -29,7 +29,7 @@
     @foreach (var pie in Model.CoveragePies)
     {
         var isSelected = Model.FilterDepartmentId == pie.TeamId;
-        var pct = pie.FillPercent;
+        var pct = Math.Clamp(pie.FillPercent, 0, 100);
         var requestedDisplay = pie.RequestedHours.ToString("0.#");
         var filledDisplay = pie.FilledHours.ToString("0.#");
         var ariaLabel = string.Format(

--- a/src/Humans.Web/wwwroot/css/site.css
+++ b/src/Humans.Web/wwwroot/css/site.css
@@ -1959,7 +1959,7 @@ tr[data-href] {
     display: inline-flex;
     align-items: center;
     gap: .4rem;
-    padding: .3rem .7rem;
+    padding: .3rem .35rem .3rem .7rem;
     margin: .25rem 0 .6rem;
     background: var(--h-alert-info-bg);
     color: var(--h-alert-info-text);
@@ -1968,7 +1968,22 @@ tr[data-href] {
     font-size: .85rem;
     line-height: 1.2;
 }
+.dept-pie-tip[hidden] { display: none; }
 .dept-pie-tip .fa-solid { font-size: 1rem; }
+.dept-pie-tip-dismiss {
+    appearance: none;
+    background: transparent;
+    border: 0;
+    color: inherit;
+    font-size: 1.1rem;
+    line-height: 1;
+    padding: 0 .25rem;
+    margin-left: .25rem;
+    cursor: pointer;
+    opacity: .65;
+    transition: opacity 120ms ease;
+}
+.dept-pie-tip-dismiss:hover { opacity: 1; }
 
 .dept-pie-row {
     display: grid;
@@ -2003,9 +2018,11 @@ tr[data-href] {
     border-color: var(--h-gold);
     background: var(--h-vellum);
 }
+.dept-pie.is-subteam {
+    border-inline-start: 3px solid var(--h-gold-light);
+}
 .dept-pie.is-subteam .dept-pie-name {
     font-style: italic;
-    opacity: .9;
 }
 .dept-pie-disc {
     width: 56px;
@@ -2013,6 +2030,18 @@ tr[data-href] {
     border-radius: 50%;
     background: conic-gradient(
         var(--h-chart-success) 0 var(--pct, 0%),
+        var(--h-chart-muted) 0 100%
+    );
+}
+.dept-pie.coverage-warning .dept-pie-disc {
+    background: conic-gradient(
+        var(--h-amber) 0 var(--pct, 0%),
+        var(--h-chart-muted) 0 100%
+    );
+}
+.dept-pie.coverage-critical .dept-pie-disc {
+    background: conic-gradient(
+        var(--h-rust) 0 var(--pct, 0%),
         var(--h-chart-muted) 0 100%
     );
 }

--- a/src/Humans.Web/wwwroot/css/site.css
+++ b/src/Humans.Web/wwwroot/css/site.css
@@ -1953,3 +1953,86 @@ tr[data-href] {
 .shift-tag-preferred {
     border-color: var(--h-gold-light, #d9c08e);
 }
+
+/* ── Department coverage pies (Volunteer /Shifts page) ─────────────── */
+.dept-pie-tip {
+    display: inline-flex;
+    align-items: center;
+    gap: .4rem;
+    padding: .3rem .7rem;
+    margin: .25rem 0 .6rem;
+    background: var(--h-alert-info-bg);
+    color: var(--h-alert-info-text);
+    border: 1px solid color-mix(in srgb, var(--h-alert-info-text) 20%, transparent);
+    border-radius: 999px;
+    font-size: .85rem;
+    line-height: 1.2;
+}
+.dept-pie-tip .bi { font-size: 1rem; }
+
+.dept-pie-row {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+    gap: .5rem;
+    margin: .5rem 0 1rem;
+}
+.dept-pie-form { margin: 0; display: contents; }
+.dept-pie {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: .5rem;
+    padding: .75rem .5rem;
+    aspect-ratio: 1 / 1;
+    width: 100%;
+    border: 1px solid var(--h-border);
+    border-radius: var(--h-radius);
+    background: var(--h-bg-card);
+    color: var(--h-text);
+    cursor: pointer;
+    transition: border-color 120ms ease, box-shadow 120ms ease, background 120ms ease;
+}
+.dept-pie:hover {
+    border-color: var(--h-gold);
+    background: var(--h-vellum);
+}
+.dept-pie.selected {
+    outline: 2px solid var(--h-gold);
+    outline-offset: 1px;
+    border-color: var(--h-gold);
+    background: var(--h-vellum);
+}
+.dept-pie.is-subteam .dept-pie-name {
+    font-style: italic;
+    opacity: .9;
+}
+.dept-pie-disc {
+    width: 56px;
+    height: 56px;
+    border-radius: 50%;
+    background: conic-gradient(
+        var(--h-chart-success) 0 var(--pct, 0%),
+        var(--h-chart-muted) 0 100%
+    );
+}
+.dept-pie-label {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    line-height: 1.15;
+    font-size: .85rem;
+    text-align: center;
+    width: 100%;
+    min-width: 0;
+}
+.dept-pie-name {
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.dept-pie-stat {
+    color: var(--h-text-secondary);
+    font-size: .75rem;
+}

--- a/src/Humans.Web/wwwroot/css/site.css
+++ b/src/Humans.Web/wwwroot/css/site.css
@@ -1985,13 +1985,35 @@ tr[data-href] {
 }
 .dept-pie-tip-dismiss:hover { opacity: 1; }
 
+.dept-filter-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: .4rem;
+    padding: .3rem .5rem .3rem .7rem;
+    margin: .25rem 0 .6rem;
+    background: var(--h-vellum);
+    color: var(--h-text);
+    border: 1px solid var(--h-gold);
+    border-radius: 999px;
+    font-size: .85rem;
+    line-height: 1.2;
+    text-decoration: none;
+    transition: background 120ms ease;
+}
+.dept-filter-chip:hover {
+    background: var(--h-parchment-dark);
+    color: var(--h-text);
+}
+.dept-filter-chip-label { font-weight: 600; }
+.dept-filter-chip-x { font-size: 1.1rem; line-height: 1; opacity: .65; }
+.dept-filter-chip:hover .dept-filter-chip-x { opacity: 1; }
+
 .dept-pie-row {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
     gap: .5rem;
     margin: .5rem 0 1rem;
 }
-.dept-pie-form { margin: 0; display: contents; }
 .dept-pie {
     display: flex;
     flex-direction: column;
@@ -2045,6 +2067,13 @@ tr[data-href] {
         var(--h-chart-muted) 0 100%
     );
 }
+.dept-pie.coverage-complete {
+    opacity: .55;
+}
+.dept-pie.coverage-complete:hover,
+.dept-pie.coverage-complete.selected {
+    opacity: 1;
+}
 .dept-pie-label {
     display: flex;
     flex-direction: column;
@@ -2057,9 +2086,11 @@ tr[data-href] {
 }
 .dept-pie-name {
     max-width: 100%;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
     overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+    line-height: 1.15;
 }
 .dept-pie-stat {
     color: var(--h-text-secondary);

--- a/src/Humans.Web/wwwroot/css/site.css
+++ b/src/Humans.Web/wwwroot/css/site.css
@@ -1968,7 +1968,7 @@ tr[data-href] {
     font-size: .85rem;
     line-height: 1.2;
 }
-.dept-pie-tip .bi { font-size: 1rem; }
+.dept-pie-tip .fa-solid { font-size: 1rem; }
 
 .dept-pie-row {
     display: grid;

--- a/tests/Humans.Application.Tests/Services/Shifts/ShiftManagementServiceCoveragePiesTests.cs
+++ b/tests/Humans.Application.Tests/Services/Shifts/ShiftManagementServiceCoveragePiesTests.cs
@@ -201,22 +201,37 @@ public class ShiftManagementServiceCoveragePiesTests : IDisposable
         var (es, _, _) = SeedDeptScenario();
         var mango = new Team
         {
-            Id = Guid.NewGuid(), Name = "Mango", Slug = "mango",
-            SystemTeamType = SystemTeamType.None, ParentTeamId = null, IsActive = true,
-            CreatedAt = TestNow, UpdatedAt = TestNow
+            Id = Guid.NewGuid(),
+            Name = "Mango",
+            Slug = "mango",
+            SystemTeamType = SystemTeamType.None,
+            ParentTeamId = null,
+            IsActive = true,
+            CreatedAt = TestNow,
+            UpdatedAt = TestNow
         };
         var appleSlice = new Team
         {
-            Id = Guid.NewGuid(), Name = "Apple Slice", Slug = "apple-slice",
-            SystemTeamType = SystemTeamType.None, ParentTeamId = mango.Id,
-            IsPromotedToDirectory = true, IsActive = true,
-            CreatedAt = TestNow, UpdatedAt = TestNow
+            Id = Guid.NewGuid(),
+            Name = "Apple Slice",
+            Slug = "apple-slice",
+            SystemTeamType = SystemTeamType.None,
+            ParentTeamId = mango.Id,
+            IsPromotedToDirectory = true,
+            IsActive = true,
+            CreatedAt = TestNow,
+            UpdatedAt = TestNow
         };
         var banana = new Team
         {
-            Id = Guid.NewGuid(), Name = "Banana", Slug = "banana",
-            SystemTeamType = SystemTeamType.None, ParentTeamId = null, IsActive = true,
-            CreatedAt = TestNow, UpdatedAt = TestNow
+            Id = Guid.NewGuid(),
+            Name = "Banana",
+            Slug = "banana",
+            SystemTeamType = SystemTeamType.None,
+            ParentTeamId = null,
+            IsActive = true,
+            CreatedAt = TestNow,
+            UpdatedAt = TestNow
         };
         await _dbContext.Teams.AddRangeAsync(mango, appleSlice, banana);
 
@@ -278,15 +293,21 @@ public class ShiftManagementServiceCoveragePiesTests : IDisposable
         AddConfirmedSignup(shift);
         _dbContext.ShiftSignups.Add(new ShiftSignup
         {
-            Id = Guid.NewGuid(), ShiftId = shift.Id, UserId = Guid.NewGuid(),
+            Id = Guid.NewGuid(),
+            ShiftId = shift.Id,
+            UserId = Guid.NewGuid(),
             Status = SignupStatus.Pending,
-            CreatedAt = TestNow, UpdatedAt = TestNow
+            CreatedAt = TestNow,
+            UpdatedAt = TestNow
         });
         _dbContext.ShiftSignups.Add(new ShiftSignup
         {
-            Id = Guid.NewGuid(), ShiftId = shift.Id, UserId = Guid.NewGuid(),
+            Id = Guid.NewGuid(),
+            ShiftId = shift.Id,
+            UserId = Guid.NewGuid(),
             Status = SignupStatus.Bailed,
-            CreatedAt = TestNow, UpdatedAt = TestNow
+            CreatedAt = TestNow,
+            UpdatedAt = TestNow
         });
         await _dbContext.SaveChangesAsync();
 

--- a/tests/Humans.Application.Tests/Services/Shifts/ShiftManagementServiceCoveragePiesTests.cs
+++ b/tests/Humans.Application.Tests/Services/Shifts/ShiftManagementServiceCoveragePiesTests.cs
@@ -1,0 +1,391 @@
+using AwesomeAssertions;
+using Humans.Application.Enums;
+using Humans.Application.Interfaces.AuditLog;
+using Humans.Application.Interfaces.Auth;
+using Humans.Application.Interfaces.Shifts;
+using Humans.Application.Interfaces.Teams;
+using Humans.Application.Interfaces.Users;
+using Humans.Application.Services.Shifts;
+using Humans.Application.Tests.Infrastructure;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using Humans.Infrastructure.Data;
+using Humans.Infrastructure.Repositories.Shifts;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging.Abstractions;
+using NodaTime;
+using NodaTime.Testing;
+using NSubstitute;
+
+namespace Humans.Application.Tests.Services.Shifts;
+
+public class ShiftManagementServiceCoveragePiesTests : IDisposable
+{
+    private readonly HumansDbContext _dbContext;
+    private readonly ITeamService _teamService;
+    private readonly ShiftManagementService _service;
+
+    private static readonly Instant TestNow = Instant.FromUtc(2026, 6, 15, 12, 0);
+
+    public ShiftManagementServiceCoveragePiesTests()
+    {
+        var options = new DbContextOptionsBuilder<HumansDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        _dbContext = new HumansDbContext(options);
+        _teamService = Substitute.For<ITeamService>();
+
+        // Resolve teams (with their parents) directly from the in-memory DB —
+        // the production wrapper does the same join in SQL.
+        _teamService.GetByIdsWithParentsAsync(
+                Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(ci =>
+            {
+                var ids = ci.Arg<IReadOnlyCollection<Guid>>();
+                var direct = _dbContext.Teams.Where(t => ids.Contains(t.Id)).AsEnumerable().ToList();
+                var parentIds = direct.Where(t => t.ParentTeamId.HasValue).Select(t => t.ParentTeamId!.Value).ToList();
+                var parents = parentIds.Count == 0
+                    ? new List<Team>()
+                    : _dbContext.Teams.Where(t => parentIds.Contains(t.Id)).AsEnumerable().ToList();
+                var all = direct.Concat(parents).GroupBy(t => t.Id).Select(g => g.First());
+                return Task.FromResult<IReadOnlyDictionary<Guid, Team>>(all.ToDictionary(t => t.Id));
+            });
+
+        var serviceProvider = Substitute.For<IServiceProvider>();
+        serviceProvider.GetService(typeof(ITeamService)).Returns(_teamService);
+        serviceProvider.GetService(typeof(IRoleAssignmentService)).Returns(Substitute.For<IRoleAssignmentService>());
+        serviceProvider.GetService(typeof(IUserService)).Returns(Substitute.For<IUserService>());
+
+        var repo = new ShiftManagementRepository(new TestDbContextFactory(options));
+
+        _service = new ShiftManagementService(
+            repo,
+            Substitute.For<IAuditLogService>(),
+            Substitute.For<IAdminAuthorizationService>(),
+            serviceProvider,
+            new MemoryCache(new MemoryCacheOptions()),
+            Substitute.For<IShiftViewInvalidator>(),
+            new FakeClock(TestNow),
+            NullLogger<ShiftManagementService>.Instance);
+    }
+
+    public void Dispose()
+    {
+        _dbContext.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    [HumansFact]
+    public async Task EmptyEvent_ReturnsEmptyList()
+    {
+        var (es, _, _) = SeedDeptScenario();
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _service.GetDepartmentCoveragePiesAsync(es.Id);
+
+        result.Should().BeEmpty();
+    }
+
+    [HumansFact]
+    public async Task SingleDept_SingleRota_NoSignups_RequestedSummedFilledZero()
+    {
+        var (es, art, _) = SeedDeptScenario();
+        var rota = AddRota(es, art, RotaPeriod.Event);
+        AddShift(rota, dayOffset: 0, maxVolunteers: 5, durationHours: 4.0);
+        AddShift(rota, dayOffset: 0, maxVolunteers: 3, durationHours: 2.0);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _service.GetDepartmentCoveragePiesAsync(es.Id);
+
+        result.Should().HaveCount(1);
+        result[0].TeamId.Should().Be(art.Id);
+        result[0].TeamName.Should().Be("Art");
+        result[0].IsSubTeam.Should().BeFalse();
+        result[0].RequestedHours.Should().Be(26m); // (5×4) + (3×2)
+        result[0].FilledHours.Should().Be(0m);
+    }
+
+    [HumansFact]
+    public async Task PromotedSubteam_GetsOwnPie_ParentExcludesSubteamRotas()
+    {
+        var (es, art, lighting) = SeedDeptScenario(withSubteam: true, subteamPromoted: true);
+        AddShift(AddRota(es, art!, RotaPeriod.Event, name: "ArtRota"),
+            dayOffset: 0, maxVolunteers: 2, durationHours: 4.0);
+        AddShift(AddRota(es, lighting!, RotaPeriod.Event, name: "LightingRota"),
+            dayOffset: 0, maxVolunteers: 3, durationHours: 4.0);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _service.GetDepartmentCoveragePiesAsync(es.Id);
+
+        result.Should().HaveCount(2);
+        var artPie = result.Single(r => r.TeamId == art.Id);
+        var lightingPie = result.Single(r => r.TeamId == lighting!.Id);
+        artPie.RequestedHours.Should().Be(8m);
+        lightingPie.RequestedHours.Should().Be(12m);
+        lightingPie.IsSubTeam.Should().BeTrue();
+        lightingPie.ParentTeamId.Should().Be(art.Id);
+    }
+
+    [HumansFact]
+    public async Task NonPromotedSubteam_RotasRollUpToParent_NoSubteamPie()
+    {
+        var (es, art, lighting) = SeedDeptScenario(withSubteam: true, subteamPromoted: false);
+        AddShift(AddRota(es, art!, RotaPeriod.Event, name: "ArtRota"),
+            dayOffset: 0, maxVolunteers: 2, durationHours: 4.0);
+        AddShift(AddRota(es, lighting!, RotaPeriod.Event, name: "LightingRota"),
+            dayOffset: 0, maxVolunteers: 3, durationHours: 4.0);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _service.GetDepartmentCoveragePiesAsync(es.Id);
+
+        result.Should().HaveCount(1);
+        result[0].TeamId.Should().Be(art.Id);
+        result[0].RequestedHours.Should().Be(20m); // (2 + 3) × 4
+    }
+
+    [HumansFact]
+    public async Task PromotedSubteam_SortsImmediatelyAfterItsParent_NotByOwnName()
+    {
+        var (es, _, _) = SeedDeptScenario();
+        var mango = new Team
+        {
+            Id = Guid.NewGuid(), Name = "Mango", Slug = "mango",
+            SystemTeamType = SystemTeamType.None, ParentTeamId = null, IsActive = true,
+            CreatedAt = TestNow, UpdatedAt = TestNow
+        };
+        var appleSlice = new Team
+        {
+            Id = Guid.NewGuid(), Name = "Apple Slice", Slug = "apple-slice",
+            SystemTeamType = SystemTeamType.None, ParentTeamId = mango.Id,
+            IsPromotedToDirectory = true, IsActive = true,
+            CreatedAt = TestNow, UpdatedAt = TestNow
+        };
+        var banana = new Team
+        {
+            Id = Guid.NewGuid(), Name = "Banana", Slug = "banana",
+            SystemTeamType = SystemTeamType.None, ParentTeamId = null, IsActive = true,
+            CreatedAt = TestNow, UpdatedAt = TestNow
+        };
+        await _dbContext.Teams.AddRangeAsync(mango, appleSlice, banana);
+
+        foreach (var t in new[] { mango, appleSlice, banana })
+            AddShift(AddRota(es, t, RotaPeriod.Event), dayOffset: 0, maxVolunteers: 1, durationHours: 4.0);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _service.GetDepartmentCoveragePiesAsync(es.Id);
+
+        // Pure alphabetical would give Apple Slice, Banana, Mango.
+        // Grouped: each promoted subteam follows its parent in the row.
+        result.Select(r => r.TeamName).Should().Equal("Banana", "Mango", "Apple Slice");
+    }
+
+    [HumansFact]
+    public async Task HiddenRota_Excluded_AdminOnlyShift_Excluded()
+    {
+        var (es, art, _) = SeedDeptScenario();
+        var visibleRota = AddRota(es, art, RotaPeriod.Event, isVisibleToVolunteers: true, name: "Visible");
+        var hiddenRota = AddRota(es, art, RotaPeriod.Event, isVisibleToVolunteers: false, name: "Hidden");
+        AddShift(visibleRota, dayOffset: 0, maxVolunteers: 2, durationHours: 4.0);
+        AddShift(visibleRota, dayOffset: 0, maxVolunteers: 3, durationHours: 4.0, adminOnly: true);
+        AddShift(hiddenRota, dayOffset: 0, maxVolunteers: 10, durationHours: 4.0);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _service.GetDepartmentCoveragePiesAsync(es.Id);
+
+        result[0].RequestedHours.Should().Be(8m);
+        result[0].FilledHours.Should().Be(0m);
+    }
+
+    [HumansFact]
+    public async Task ConfirmedCountCappedAtMaxVolunteers_PreventsOver100Pct()
+    {
+        var (es, art, _) = SeedDeptScenario();
+        var rota = AddRota(es, art, RotaPeriod.Event);
+        var shift = AddShift(rota, dayOffset: 0, maxVolunteers: 5, durationHours: 4.0);
+        for (var i = 0; i < 7; i++) AddConfirmedSignup(shift);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _service.GetDepartmentCoveragePiesAsync(es.Id);
+
+        result[0].RequestedHours.Should().Be(20m);
+        result[0].FilledHours.Should().Be(20m); // capped, not 28
+    }
+
+    [HumansFact]
+    public async Task ConfirmedSignupsCounted_OtherStatusesIgnored()
+    {
+        var (es, art, _) = SeedDeptScenario();
+        var rota = AddRota(es, art, RotaPeriod.Event);
+        var shift = AddShift(rota, dayOffset: 0, maxVolunteers: 10, durationHours: 4.0);
+        AddConfirmedSignup(shift);
+        AddConfirmedSignup(shift);
+        AddConfirmedSignup(shift);
+        _dbContext.ShiftSignups.Add(new ShiftSignup
+        {
+            Id = Guid.NewGuid(), ShiftId = shift.Id, UserId = Guid.NewGuid(),
+            Status = SignupStatus.Pending,
+            CreatedAt = TestNow, UpdatedAt = TestNow
+        });
+        _dbContext.ShiftSignups.Add(new ShiftSignup
+        {
+            Id = Guid.NewGuid(), ShiftId = shift.Id, UserId = Guid.NewGuid(),
+            Status = SignupStatus.Bailed,
+            CreatedAt = TestNow, UpdatedAt = TestNow
+        });
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _service.GetDepartmentCoveragePiesAsync(es.Id);
+
+        result[0].RequestedHours.Should().Be(40m);
+        result[0].FilledHours.Should().Be(12m);
+    }
+
+    [HumansFact]
+    public async Task AllDayShift_Uses8HourWindow_NotDurationColumn()
+    {
+        var (es, art, _) = SeedDeptScenario();
+        var rota = AddRota(es, art, RotaPeriod.Build);
+        var shift = AddShift(rota, dayOffset: -3, maxVolunteers: 4, isAllDay: true);
+        shift.Duration = Duration.FromHours(24);
+        AddConfirmedSignup(shift);
+        AddConfirmedSignup(shift);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _service.GetDepartmentCoveragePiesAsync(es.Id);
+
+        // AllDayWindowStart=08:00, AllDayWindowEnd=18:00 → 10h per slot
+        result[0].RequestedHours.Should().Be(40m); // 4 × 10
+        result[0].FilledHours.Should().Be(20m);    // 2 × 10
+    }
+
+    [HumansFact]
+    public async Task DateRangeFilter_AppliedAtShiftLevel_RotaPeriodAllCorrect()
+    {
+        var (es, art, _) = SeedDeptScenario();
+        var rota = AddRota(es, art, RotaPeriod.All);
+        AddShift(rota, dayOffset: -7, maxVolunteers: 1, durationHours: 4.0);
+        AddShift(rota, dayOffset: 2, maxVolunteers: 1, durationHours: 4.0);
+        AddShift(rota, dayOffset: 8, maxVolunteers: 1, durationHours: 4.0);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _service.GetDepartmentCoveragePiesAsync(
+            es.Id,
+            fromDate: new LocalDate(2026, 6, 17),
+            toDate: new LocalDate(2026, 6, 30));
+
+        result[0].RequestedHours.Should().Be(4m);
+    }
+
+    private (EventSettings Es, Team Art, Team? Lighting) SeedDeptScenario(
+        bool withSubteam = false,
+        bool subteamPromoted = false)
+    {
+        var es = new EventSettings
+        {
+            Id = Guid.NewGuid(),
+            EventName = "Test Event 2026",
+            TimeZoneId = "Europe/Madrid",
+            GateOpeningDate = new LocalDate(2026, 7, 1),
+            BuildStartOffset = -14,
+            EventEndOffset = 6,
+            StrikeEndOffset = 9,
+            IsShiftBrowsingOpen = true,
+            IsActive = true,
+            CreatedAt = TestNow,
+            UpdatedAt = TestNow
+        };
+        _dbContext.EventSettings.Add(es);
+
+        var art = new Team
+        {
+            Id = Guid.NewGuid(),
+            Name = "Art",
+            Slug = "art",
+            SystemTeamType = SystemTeamType.None,
+            ParentTeamId = null,
+            IsActive = true,
+            CreatedAt = TestNow,
+            UpdatedAt = TestNow
+        };
+        _dbContext.Teams.Add(art);
+
+        Team? lighting = null;
+        if (withSubteam)
+        {
+            lighting = new Team
+            {
+                Id = Guid.NewGuid(),
+                Name = "Art / Lighting",
+                Slug = "art-lighting",
+                SystemTeamType = SystemTeamType.None,
+                ParentTeamId = art.Id,
+                IsPromotedToDirectory = subteamPromoted,
+                IsActive = true,
+                CreatedAt = TestNow,
+                UpdatedAt = TestNow
+            };
+            _dbContext.Teams.Add(lighting);
+        }
+
+        return (es, art, lighting);
+    }
+
+    private Rota AddRota(EventSettings es, Team team, RotaPeriod period = RotaPeriod.Event,
+        bool isVisibleToVolunteers = true, string name = "Rota")
+    {
+        var rota = new Rota
+        {
+            Id = Guid.NewGuid(),
+            EventSettingsId = es.Id,
+            TeamId = team.Id,
+            Name = name,
+            Priority = ShiftPriority.Normal,
+            Policy = SignupPolicy.Public,
+            Period = period,
+            IsVisibleToVolunteers = isVisibleToVolunteers,
+            CreatedAt = TestNow,
+            UpdatedAt = TestNow
+        };
+        _dbContext.Rotas.Add(rota);
+        return rota;
+    }
+
+    private Shift AddShift(Rota rota, int dayOffset, int maxVolunteers,
+        bool isAllDay = false, double durationHours = 4.0,
+        bool adminOnly = false, LocalTime? startTime = null)
+    {
+        var shift = new Shift
+        {
+            Id = Guid.NewGuid(),
+            RotaId = rota.Id,
+            DayOffset = dayOffset,
+            IsAllDay = isAllDay,
+            StartTime = startTime ?? new LocalTime(9, 0),
+            Duration = isAllDay ? Duration.FromHours(24) : Duration.FromHours(durationHours),
+            MinVolunteers = 1,
+            MaxVolunteers = maxVolunteers,
+            AdminOnly = adminOnly,
+            CreatedAt = TestNow,
+            UpdatedAt = TestNow
+        };
+        _dbContext.Shifts.Add(shift);
+        return shift;
+    }
+
+    private ShiftSignup AddConfirmedSignup(Shift shift, Guid? userId = null)
+    {
+        var s = new ShiftSignup
+        {
+            Id = Guid.NewGuid(),
+            ShiftId = shift.Id,
+            UserId = userId ?? Guid.NewGuid(),
+            Status = SignupStatus.Confirmed,
+            CreatedAt = TestNow,
+            UpdatedAt = TestNow
+        };
+        _dbContext.ShiftSignups.Add(s);
+        return s;
+    }
+}

--- a/tests/Humans.Application.Tests/Services/Shifts/ShiftManagementServiceCoveragePiesTests.cs
+++ b/tests/Humans.Application.Tests/Services/Shifts/ShiftManagementServiceCoveragePiesTests.cs
@@ -146,6 +146,54 @@ public class ShiftManagementServiceCoveragePiesTests : IDisposable
     }
 
     [HumansFact]
+    public async Task NonPromotedSubteam_WhenParentOwnsNoRota_StillRollsUpToParent()
+    {
+        // Parent (Art) owns NO rota of its own; only the non-promoted subteam
+        // (Art / Lighting) has a rota. GetByIdsWithParentsAsync must include
+        // Art in the team lookup so the bucket rollup finds a target —
+        // otherwise the subteam's hours would be silently dropped.
+        var (es, art, lighting) = SeedDeptScenario(withSubteam: true, subteamPromoted: false);
+        AddShift(AddRota(es, lighting!, RotaPeriod.Event, name: "LightingRota"),
+            dayOffset: 0, maxVolunteers: 3, durationHours: 4.0);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _service.GetDepartmentCoveragePiesAsync(es.Id);
+
+        result.Should().HaveCount(1);
+        result[0].TeamId.Should().Be(art.Id);
+        result[0].IsSubTeam.Should().BeFalse();
+        result[0].RequestedHours.Should().Be(12m); // 3 × 4, rolled up from the subteam
+    }
+
+    [HumansFact]
+    public async Task FillPercent_ClampedZeroToHundred_AndRoundedAwayFromZero()
+    {
+        // Service caps confirmed at MaxVolunteers, so 0..100 is already the
+        // service contract — this guards the DTO clamp.
+        var (es, art, _) = SeedDeptScenario();
+        var rota = AddRota(es, art, RotaPeriod.Event);
+        var shift = AddShift(rota, dayOffset: 0, maxVolunteers: 3, durationHours: 4.0);
+        AddConfirmedSignup(shift); // 1/3 → 33.3% → 33 (away from zero)
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _service.GetDepartmentCoveragePiesAsync(es.Id);
+
+        result[0].FillPercent.Should().Be(33);
+    }
+
+    [HumansFact]
+    public async Task FillPercent_NoRequestedHours_ReturnsZero()
+    {
+        var pie = new DepartmentCoveragePie(
+            TeamId: Guid.NewGuid(), TeamName: "X", TeamSlug: "x",
+            IsSubTeam: false, ParentTeamId: null, ParentTeamName: null,
+            RequestedHours: 0m, FilledHours: 0m);
+
+        await Task.CompletedTask;
+        pie.FillPercent.Should().Be(0);
+    }
+
+    [HumansFact]
     public async Task ResultSortedAlphabetically_ByTeamName_ParentNamePopulatedForSubteams()
     {
         // Service returns natural-name-ordered rows; the "sub-team next to

--- a/tests/Humans.Application.Tests/Services/Shifts/ShiftManagementServiceCoveragePiesTests.cs
+++ b/tests/Humans.Application.Tests/Services/Shifts/ShiftManagementServiceCoveragePiesTests.cs
@@ -146,8 +146,10 @@ public class ShiftManagementServiceCoveragePiesTests : IDisposable
     }
 
     [HumansFact]
-    public async Task PromotedSubteam_SortsImmediatelyAfterItsParent_NotByOwnName()
+    public async Task ResultSortedAlphabetically_ByTeamName_ParentNamePopulatedForSubteams()
     {
+        // Service returns natural-name-ordered rows; the "sub-team next to
+        // parent" rule is applied later in the view-model assembly layer.
         var (es, _, _) = SeedDeptScenario();
         var mango = new Team
         {
@@ -176,9 +178,13 @@ public class ShiftManagementServiceCoveragePiesTests : IDisposable
 
         var result = await _service.GetDepartmentCoveragePiesAsync(es.Id);
 
-        // Pure alphabetical would give Apple Slice, Banana, Mango.
-        // Grouped: each promoted subteam follows its parent in the row.
-        result.Select(r => r.TeamName).Should().Equal("Banana", "Mango", "Apple Slice");
+        result.Select(r => r.TeamName).Should().Equal("Apple Slice", "Banana", "Mango");
+        result.Single(r => string.Equals(r.TeamName, "Apple Slice", StringComparison.Ordinal))
+            .ParentTeamName.Should().Be("Mango");
+        result.Single(r => string.Equals(r.TeamName, "Banana", StringComparison.Ordinal))
+            .ParentTeamName.Should().BeNull();
+        result.Single(r => string.Equals(r.TeamName, "Mango", StringComparison.Ordinal))
+            .ParentTeamName.Should().BeNull();
     }
 
     [HumansFact]

--- a/tests/Humans.Web.Tests/Shifts/ShiftBrowsePageBuilderPieSortTests.cs
+++ b/tests/Humans.Web.Tests/Shifts/ShiftBrowsePageBuilderPieSortTests.cs
@@ -1,0 +1,81 @@
+using AwesomeAssertions;
+using Humans.Application.Interfaces.Shifts;
+using Humans.Web.Models.Shifts;
+
+namespace Humans.Web.Tests.Shifts;
+
+/// <summary>
+/// Display ordering for the coverage-pie row lives in the view-model
+/// assembly (memory/architecture/display-sort-in-controllers). The service
+/// returns natural <c>TeamName</c> order; the page builder applies the
+/// "promoted sub-team next to parent" rule before stuffing the view model.
+/// </summary>
+public class ShiftBrowsePageBuilderPieSortTests
+{
+    [HumansFact]
+    public void PromotedSubteam_RendersImmediatelyAfterItsParent_NotByOwnName()
+    {
+        var mangoId = Guid.NewGuid();
+        var pies = new List<DepartmentCoveragePie>
+        {
+            new(Guid.NewGuid(), "Apple Slice", "apple-slice",
+                IsSubTeam: true, ParentTeamId: mangoId, ParentTeamName: "Mango",
+                RequestedHours: 4m, FilledHours: 0m),
+            new(Guid.NewGuid(), "Banana", "banana",
+                IsSubTeam: false, ParentTeamId: null, ParentTeamName: null,
+                RequestedHours: 4m, FilledHours: 0m),
+            new(mangoId, "Mango", "mango",
+                IsSubTeam: false, ParentTeamId: null, ParentTeamName: null,
+                RequestedHours: 4m, FilledHours: 0m),
+        };
+
+        var ordered = ShiftBrowsePageBuilder.OrderPiesGroupedByParent(pies);
+
+        // Pure alphabetical would give: Apple Slice, Banana, Mango.
+        // Grouped-by-parent: each promoted sub-team follows its parent.
+        ordered.Select(p => p.TeamName).Should().Equal("Banana", "Mango", "Apple Slice");
+    }
+
+    [HumansFact]
+    public void TopLevelOnly_FallsBackToAlphabetical()
+    {
+        var pies = new List<DepartmentCoveragePie>
+        {
+            new(Guid.NewGuid(), "Charlie", "charlie",
+                IsSubTeam: false, ParentTeamId: null, ParentTeamName: null,
+                RequestedHours: 1m, FilledHours: 0m),
+            new(Guid.NewGuid(), "Alpha", "alpha",
+                IsSubTeam: false, ParentTeamId: null, ParentTeamName: null,
+                RequestedHours: 1m, FilledHours: 0m),
+            new(Guid.NewGuid(), "Bravo", "bravo",
+                IsSubTeam: false, ParentTeamId: null, ParentTeamName: null,
+                RequestedHours: 1m, FilledHours: 0m),
+        };
+
+        var ordered = ShiftBrowsePageBuilder.OrderPiesGroupedByParent(pies);
+
+        ordered.Select(p => p.TeamName).Should().Equal("Alpha", "Bravo", "Charlie");
+    }
+
+    [HumansFact]
+    public void MultipleSubteamsUnderSameParent_SortAlphabeticallyAfterParent()
+    {
+        var parentId = Guid.NewGuid();
+        var pies = new List<DepartmentCoveragePie>
+        {
+            new(Guid.NewGuid(), "Zeta", "zeta",
+                IsSubTeam: true, ParentTeamId: parentId, ParentTeamName: "Mango",
+                RequestedHours: 1m, FilledHours: 0m),
+            new(parentId, "Mango", "mango",
+                IsSubTeam: false, ParentTeamId: null, ParentTeamName: null,
+                RequestedHours: 1m, FilledHours: 0m),
+            new(Guid.NewGuid(), "Alpha", "alpha",
+                IsSubTeam: true, ParentTeamId: parentId, ParentTeamName: "Mango",
+                RequestedHours: 1m, FilledHours: 0m),
+        };
+
+        var ordered = ShiftBrowsePageBuilder.OrderPiesGroupedByParent(pies);
+
+        ordered.Select(p => p.TeamName).Should().Equal("Mango", "Alpha", "Zeta");
+    }
+}


### PR DESCRIPTION
## Summary

Adds a row of per-department coverage pies above the /Shifts browse page. Each pie shows the team's filled / requested hour ratio as a conic-gradient disc; clicking a pie filters the page to that department, clicking again clears the filter. A "Filter: X ×" chip appears between the filter form and the pie row when a department is selected.

The service (IShiftManagementService.GetDepartmentCoveragePiesAsync) lives in Humans.Application/Services/Shifts/, goes through IShiftManagementRepository + ITeamService.GetByIdsWithParentsAsync, and never imports EF Core. Pie eligibility is Team.IsInDirectory (top-level OR promoted sub-team); non-promoted sub-team rotas roll up to the parent. AdminOnly shifts and hidden rotas are excluded; all-day shifts use the 08:00–18:00 window, not the Duration column.

## What's new on the page

- Tip pill above the row: "click a chart to filter to that department; click it again to clear." Dismissable with persistence in localStorage (key humans.pieTipDismissed).
- Severity color on the disc: green ≥50%, amber 25–50%, rust <25%.
- 100% fade: completed teams fade to opacity .55 so the row visually de-emphasizes "done" departments. Hover and selected state restore full opacity.
- Sub-team grouping: promoted sub-teams render immediately after their parent in the row (display ordering applied in the page builder per memory/architecture/display-sort-in-controllers). Sub-teams carry a 3px gold border-inline-start and italic name.
- Filter chip under the filter form when a department is selected.
- A11y: row is role="group" with aria-label; pies are submit buttons with descriptive aria-label and title.
- i18n: en, es, ca, it, fr, de — all new strings localized.

## Architecture / rule compliance

- [SurfaceBudget(48 → 49)] on IShiftManagementService. History trimmed to 3 newest bullets per memory/code/surface-budget-history-trim.
- Display ordering is applied in the page builder (ShiftBrowsePageBuilder.OrderPiesGroupedByParent), not the service.
- Icon uses FontAwesome 6 (fa-solid fa-circle-info), not Bootstrap Icons (memory/code/icons-fa6-only).
- New CSS hooks into the existing design-token system (--h-*) — no --bs-* usage.

## Docs

- docs/features/shifts/department-coverage-pies.md — feature spec with user stories, eligibility, hour math, ordering.
- docs/sections/Shifts.md — section invariants block for the pie row (eligibility, exclusion rules, cap, all-day window, ordering location).

## Tests

- 13 service-level pie tests in tests/Humans.Application.Tests/Services/Shifts/ShiftManagementServiceCoveragePiesTests.cs covering: empty event, single-dept, promoted vs non-promoted sub-team rollup, hidden rota / AdminOnly exclusion, cap, all-day window, date-range filter, FillPercent rounding/zero-divisor, parent-only-via-subteam edge.
- 3 page-builder tests in tests/Humans.Web.Tests/Shifts/ShiftBrowsePageBuilderPieSortTests.cs for the grouped sort.

Full Application (2964) and Web (104) tests pass.

## Test plan

- [x] Open /Shifts as a volunteer with active event and >0 rotas — pies row renders above the period buttons.
- [x] Click a pie — page filters; selected pie has gold outline.
- [x] Click the same pie again — filter clears.
- [x] Click a different pie — filter switches.
- [x] Click the chip ✕ — clears just the department filter; period / dates / tags / sort preserved.
- [x] Click ✕ on the tip pill — pill disappears; survives reload.
- [x] Visit /Shifts for an event with no rotas — no pie row renders (early-return).
- [x] As an admin / coordinator, confirm AdminOnly shifts and hidden rotas don't contribute to pie hours.
- [x] In all 6 locales, the pie tooltip, ARIA label, tip text, dismiss label, and chip prefix render in the active language.

🤖 Generated with [Claude Code](https://claude.com/claude-code)