### PR TITLE
tech-debt: ReSharper sweep Batch 1 — real bugs (2 fixes, ~30 findings actioned)

### DIFF
--- a/src/Humans.Application/Services/Budget/BudgetService.cs
+++ b/src/Humans.Application/Services/Budget/BudgetService.cs
@@ -581,7 +581,9 @@ public sealed class BudgetService : IBudgetService, IUserDataContributor
 
     public BudgetSummaryResult ComputeBudgetSummary(IEnumerable<BudgetGroup> groups)
     {
-        var budgetLineItems = groups
+        var groupsList = groups as IReadOnlyCollection<BudgetGroup> ?? groups.ToList();
+
+        var budgetLineItems = groupsList
             .SelectMany(g => g.Categories)
             .SelectMany(c => c.LineItems)
             .Where(li => !li.IsCashflowOnly)
@@ -607,7 +609,7 @@ public sealed class BudgetService : IBudgetService, IUserDataContributor
         var netBalance = totalIncome + totalExpenses;
 
         // Build income slices.
-        var incomeCategories = groups
+        var incomeCategories = groupsList
             .SelectMany(g => g.Categories)
             .Select(c => new { c.Name, Total = c.LineItems.Where(li => li.Amount > 0 && !li.IsCashflowOnly).Sum(li => li.Amount) })
             .Where(c => c.Total > 0)
@@ -628,7 +630,7 @@ public sealed class BudgetService : IBudgetService, IUserDataContributor
             .ToList();
 
         // Build expense slices.
-        var expenseCategories = groups
+        var expenseCategories = groupsList
             .SelectMany(g => g.Categories)
             .Select(c => new { c.Name, Total = Math.Abs(c.LineItems.Where(li => li.Amount < 0 && !li.IsCashflowOnly).Sum(li => li.Amount)) })
             .Where(c => c.Total > 0)

--- a/src/Humans.Application/Services/Profiles/AdminHumanListAssembler.cs
+++ b/src/Humans.Application/Services/Profiles/AdminHumanListAssembler.cs
@@ -35,9 +35,9 @@ public static class AdminHumanListAssembler
         ArgumentNullException.ThrowIfNull(notificationEmailsByUserId);
         ArgumentNullException.ThrowIfNull(membershipCalculator);
 
-        IEnumerable<UserInfo> candidates = searchUserIds is null
+        var candidates = (searchUserIds is null
             ? allUsers
-            : allUsers.Where(u => searchUserIds.Contains(u.Id));
+            : allUsers.Where(u => searchUserIds.Contains(u.Id))).ToList();
 
         var ids = candidates.Select(u => u.Id).ToList();
         var partition = await membershipCalculator.PartitionUsersAsync(ids, ct);
@@ -53,7 +53,7 @@ public static class AdminHumanListAssembler
             _ => null,
         };
 
-        var rows = statusIds is null
+        IEnumerable<UserInfo> rows = statusIds is null
             ? candidates
             : candidates.Where(u => statusIds.Contains(u.Id));
 

--- a/src/Humans.Application/Services/Tickets/AttendeeContactImportService.cs
+++ b/src/Humans.Application/Services/Tickets/AttendeeContactImportService.cs
@@ -257,7 +257,7 @@ public sealed class AttendeeContactImportService : IAttendeeContactImportService
         }
 
         var existingRow = await _userEmails.FindAnyEmailRowByAddressAsync(a.AttendeeEmail, ct);
-        if (existingRow is var (uid, emailId) && existingRow is not null)
+        if (existingRow is var (uid, emailId))
         {
             return new AttendeeImportDecision(
                 a.Id, a.AttendeeEmail, name, a.VendorTicketId,

--- a/src/Humans.Web/Views/EventsModeration/Index.cshtml
+++ b/src/Humans.Web/Views/EventsModeration/Index.cshtml
@@ -89,7 +89,7 @@ else
 
                                     <dt class="col-sm-3">Submitter</dt>
                                     <dd class="col-sm-9">
-                                        <a asp-controller="Human" asp-action="View" asp-route-id="@evt.SubmitterUserId">@evt.SubmitterName</a>
+                                        <vc:human user-id="@evt.SubmitterUserId" link="Admin" />
                                     </dd>
 
                                     @if (evt.CampName != null)

--- a/src/Humans.Web/Views/Ticket/Codes.cshtml
+++ b/src/Humans.Web/Views/Ticket/Codes.cshtml
@@ -98,29 +98,29 @@
                 </tr>
             </thead>
             <tbody>
-                @foreach (var code in Model.Codes)
+                @foreach (var tc in Model.Codes)
                 {
                     <tr>
-                        <td><code>@code.Code</code></td>
+                        <td><code>@tc.Code</code></td>
                         <td>
-                            <vc:human user-id="@code.RecipientUserId" link="Admin" />
+                            <vc:human user-id="@tc.RecipientUserId" link="Admin" />
                         </td>
-                        <td>@code.CampaignTitle</td>
+                        <td>@tc.CampaignTitle</td>
                         <td>
                             @{
-                                var badgeClass = code.Status switch
+                                var badgeClass = tc.Status switch
                                 {
                                     "Redeemed" => "bg-success",
                                     "Sent" or "Delivered" => "bg-primary",
                                     _ => "bg-secondary"
                                 };
                             }
-                            <span class="badge @badgeClass">@code.Status</span>
+                            <span class="badge @badgeClass">@tc.Status</span>
                         </td>
                         <td>
-                            @if (code.RedeemedAt.HasValue)
+                            @if (tc.RedeemedAt.HasValue)
                             {
-                                @code.RedeemedAt.Value.ToDisplayDate()
+                                @tc.RedeemedAt.Value.ToDisplayDate()
                             }
                             else
                             {
@@ -128,10 +128,10 @@
                             }
                         </td>
                         <td>
-                            @if (code.RedeemedByName != null)
+                            @if (tc.RedeemedByName != null)
                             {
-                                <text>@code.RedeemedByName</text>
-                                <br /><small class="text-muted">@code.RedeemedByEmail</small>
+                                <text>@tc.RedeemedByName</text>
+                                <br /><small class="text-muted">@tc.RedeemedByEmail</small>
                             }
                             else
                             {
@@ -139,9 +139,9 @@
                             }
                         </td>
                         <td>
-                            @if (code.RedeemedOrderVendorId != null)
+                            @if (tc.RedeemedOrderVendorId != null)
                             {
-                                <small><code>@code.RedeemedOrderVendorId</code></small>
+                                <small><code>@tc.RedeemedOrderVendorId</code></small>
                             }
                             else
                             {

--- a/tests/Humans.Application.Tests/GoogleIntegration/DriveActivityMonitorServiceTests.cs
+++ b/tests/Humans.Application.Tests/GoogleIntegration/DriveActivityMonitorServiceTests.cs
@@ -315,6 +315,7 @@ public class DriveActivityMonitorServiceTests
         await Task.Yield();
         throw new InvalidOperationException("boom");
 #pragma warning disable CS0162 // Unreachable code — required for iterator signature.
+        // ReSharper disable once HeuristicUnreachableCode
         yield break;
 #pragma warning restore CS0162
     }
@@ -324,6 +325,7 @@ public class DriveActivityMonitorServiceTests
         await Task.Yield();
         throw new DriveActivityResourceNotFoundException(googleItemId);
 #pragma warning disable CS0162
+        // ReSharper disable once HeuristicUnreachableCode
         yield break;
 #pragma warning restore CS0162
     }

--- a/tests/Humans.Application.Tests/Services/Shifts/ShiftManagementServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Shifts/ShiftManagementServiceTests.cs
@@ -112,7 +112,7 @@ public class ShiftManagementServiceTests : IDisposable
         var adminAuthorization = Substitute.For<IAdminAuthorizationService>();
         using var cache = new MemoryCache(new MemoryCacheOptions());
 
-        var periods = new ShiftPeriod?[] { null }.Concat(Enum.GetValues<ShiftPeriod>().Cast<ShiftPeriod?>());
+        var periods = new ShiftPeriod?[] { null }.Concat(Enum.GetValues<ShiftPeriod>().Cast<ShiftPeriod?>()).ToList();
         foreach (var period in periods)
         {
             cache.Set(ShiftManagementService.OverviewCacheKey(eventId, period), new object());

--- a/tests/Humans.Application.Tests/Services/Shifts/ShiftSignupServiceFilterIncompleteOnboardingTests.cs
+++ b/tests/Humans.Application.Tests/Services/Shifts/ShiftSignupServiceFilterIncompleteOnboardingTests.cs
@@ -163,6 +163,7 @@ public class ShiftSignupServiceFilterIncompleteOnboardingTests : IDisposable
         await _service.FilterToIncompleteOnboardingAsync(signups);
 
         await _membership.Received(1).GetUsersWithAllRequiredConsentsForTeamAsync(
+            // ReSharper disable once PossibleMultipleEnumeration — Arg.Is requires an expression-tree lambda.
             Arg.Is<IEnumerable<Guid>>(ids => ids.Distinct().Count() == ids.Count() && ids.Count() == 2),
             SystemTeamIds.Volunteers,
             Arg.Any<CancellationToken>());


### PR DESCRIPTION
## Summary

First of three planned ReSharper InspectCode cleanup batches. Ran `jb inspectcode Humans.slnx` for the first time since the cache-migration sprint landed; surfaced **2471 findings across 61 rule types in 624 files**. This PR addresses the errors / real-bugs bucket (~30 findings); Batch 2 (redundancy cleanup) and Batch 3 (unused locals) will follow in dedicated PRs.

### Real bugs fixed

- **`EventsModeration/Index.cshtml:92`** linked to a nonexistent `HumanController.View` — would 404 in QA. Switched to the standard `<vc:human user-id link="Admin" />` view component (consistent with every other admin-list "click on a human" reference).

### Structural fixes for ReSharper false-positives we can clear up

- **`Ticket/Codes.cshtml`** — `@foreach (var code in ...)` confused ReSharper into parsing `@code` as a Blazor `@code {}` directive, cascading into 14 .Razor/.CSharpErrors. Renamed the loop variable to `tc`. Equivalent compile output; clears the noise so future runs surface real findings.

### Real findings — `PossibleMultipleEnumeration` (4 production/test sites)

- `BudgetService.ComputeBudgetSummary` iterated `IEnumerable<BudgetGroup>` three times → materialize once.
- `AdminHumanListAssembler.AssembleAsync` iterated `candidates` four times → materialize once.
- `ShiftManagementServiceTests` `periods` enumerable enumerated twice → `.ToList()`.
- `ShiftSignupServiceFilterIncompleteOnboardingTests`: NSubstitute `Arg.Is<>` predicate enumerates `ids` three times; the expression-tree constraint forbids the obvious materializing statement-body lambda, so suppressed with a comment.

### `ConditionIsAlwaysTrueOrFalse` (1) + `HeuristicUnreachableCode` (2)

- `AttendeeContactImportService.cs:260` — `is var (uid, emailId)` already returns false on null; redundant `&& existingRow is not null`. Dropped.
- `DriveActivityMonitorServiceTests` — `yield break` after unconditional `throw` is required by the `IAsyncEnumerable` iterator signature; CS0162 was already suppressed, added matching ReSharper comment.

### False positives investigated and documented (no code change)

- **14 `Mvc.ActionNotResolved` + 1 `Mvc.ControllerNotResolved`** — controllers use `[Route(...)]` attribute paths (`Governance/Applications`, `Governance/BoardVoting`, etc.) that don't match the corresponding view folder names. All target actions verified present on the right controllers. ReSharper's view-to-controller binder doesn't follow the route attributes.
- **4 `ResourceItemNotResolved`** in `_ConsentReviewBody.cshtml` — `ConsentReview_CheckboxRequired` / `ConsentReview_ConsentCheckbox` / `ConsentReview_SpanishLegalNote` all present in `SharedResource.resx`. ReSharper can't bind because the resx lives under `Resources/` but the class is at namespace `Humans.Web` (no `.Resources` segment).
- **6 `.HtmlErrors`** in `_VolunteerSearchScript.cshtml` — file is pure JS that builds HTML via string concatenation; ReSharper's HTML parser misreads the embedded markup. Cleanly fixing would mean rewriting to template literals or moving to a `.js` file — out of scope.
- **11 `AccessToDisposedClosure`** — all FPs. `Should().Throw/NotThrow()` invokes the lambda synchronously inside the `using` scope (7 test sites); `GoogleWorkspaceSyncService` semaphore-in-`Task.WhenAll` pattern awaits before disposal (2 sites); `CampaignRepository` EF LINQ subqueries compile to SQL not runtime closures (2 sites).

### Deferred to dedicated follow-up PRs

- **`HUM0017` cross-section repo injections (7)** — each is a section-level refactor with arch implications. `UserService` injects 4 Profile-section repos to compose `UserInfo`; eliminating them would require either pulling Profile services up (creates DI cycle) or moving composition into a dedicated stitcher. `DuplicateAccountService`, `TeamResourceService`, `UserEmailProviderBackfillService` each need their own service-API additions. Better as one focused PR per section.
- **`NullCoalescingConditionIsAlwaysNotNullAccordingToAPIContract` (28) + `ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract` (26)** — 54 findings, each a per-site judgment between "annotation is wrong, fix it on the entity" vs "defensive guard is intentional, loosen the annotation". Wants a focused triage pass.

### Batch 2 / Batch 3 preview

Batch 2 (~830 mechanical redundancy issues): `RedundantUsingDirective` (116), `RedundantCast` (75), `RedundantSuppressNullableWarningExpression` (145), `RedundantArgumentDefaultValue` (200), `RedundantAnonymousTypePropertyName` (35), etc.

Batch 3 (~245 unused-locals): `UnusedVariable` (98), `UnusedParameter.Local` (52), `UnusedMember.Local` (31), `NotAccessedField.Local` (27), etc.

## Test plan

- [x] `dotnet build Humans.slnx -v quiet` — 0 errors, no new warnings
- [x] `dotnet test Humans.slnx --filter "FullyQualifiedName!~Integration"` — all 3175 unit tests pass
- [x] `dotnet format Humans.slnx --verify-no-changes` — clean
- [ ] Browser smoke on preview: /EventsModeration (Index page renders, submitter link works) + /Ticket/Codes admin grid (renders without error)
- Integration tests not run locally (require a test DB); CI will exercise them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)