### PR TITLE
fix(teams): promoted sub-team card — name as title, parent as breadcrumb

### DIFF
--- a/src/Humans.Web/Views/Team/_TeamCard.cshtml
+++ b/src/Humans.Web/Views/Team/_TeamCard.cshtml
@@ -5,25 +5,17 @@
         <div class="card-body">
             @if (Model.ParentTeamName != null)
             {
-                <h5 class="card-title mb-0">
-                    <a asp-action="Details" asp-route-slug="@Model.ParentTeamSlug" class="text-decoration-none">
+                <div class="small text-muted mb-1">
+                    <a asp-action="Details" asp-route-slug="@Model.ParentTeamSlug" class="text-muted text-decoration-none">
                         @Model.ParentTeamName
-                    </a>
-                </h5>
-                <div class="ms-3 mt-1">
-                    <a asp-action="Details" asp-route-slug="@Model.Slug" class="text-muted text-decoration-none">
-                        @Model.Name
                     </a>
                 </div>
             }
-            else
-            {
-                <h5 class="card-title mb-0">
-                    <a asp-action="Details" asp-route-slug="@Model.Slug" class="text-decoration-none">
-                        @Model.Name
-                    </a>
-                </h5>
-            }
+            <h5 class="card-title mb-0">
+                <a asp-action="Details" asp-route-slug="@Model.Slug" class="text-decoration-none">
+                    @Model.Name
+                </a>
+            </h5>
             @if (!string.IsNullOrEmpty(Model.Description))
             {
                 <p class="card-text text-muted small mt-2 mb-0">


### PR DESCRIPTION
## Summary

The /Teams directory card for a promoted sub-team (Team.IsPromotedToDirectory = true) currently buries the sub-team's identity: the **parent** is rendered as the card's h5 title and the sub-team appears dimmed underneath. Reverses the hierarchy so the sub-team is the h5 title and the parent shows as a small breadcrumb above it.

## Before / after

**Before (current main):**
```
┌────────────────────────────┐
│ Medical (dev)              │  ← big h5, primary link
│     Bike EMS (dev)         │  ← indented + dimmed
│ Mobile medical response.   │
└────────────────────────────┘
```

**After:**
```
┌────────────────────────────┐
│ medical (dev)              │  ← small dimmed breadcrumb
│ Bike EMS (dev)             │  ← big h5, primary link
│ Mobile medical response.   │
└────────────────────────────┘
```

## Rationale

`Team.IsPromotedToDirectory` exists exactly so a sub-team can stand on its own in directory views. The card was treating it as a child element of the parent, which contradicts the flag's purpose.

Same conceptual fix as the coverage-pie row on /Shifts (PR #602), where promoted sub-teams now render as their own pie next to the parent with a gold left-edge. Both surfaces converge on a consistent reading of `IsPromotedToDirectory`: this team is first-class in directory views, with the parent shown as context, not as a containing structure.

## Scope

- 15-line diff, one file: `src/Humans.Web/Views/Team/_TeamCard.cshtml`.
- No model changes (`ParentTeamName` / `ParentTeamSlug` were already populated on `TeamCardViewModel`).
- No controller, service, or repository change.
- No new i18n strings (names rendered are data, not labels).
- No new tests — Razor partial layout tweaks aren't unit-tested in this project; the existing view-model assembly path is unchanged.

Top-level teams (no parent) render unchanged.

## Test plan

- [ ] Visit /Teams as any authenticated user with at least one promoted sub-team.
- [ ] Promoted sub-team card shows the sub-team's name as the h5 title.
- [ ] Promoted sub-team card shows the parent's name as a small dimmed breadcrumb above the title; clicking it navigates to the parent's Details page.
- [ ] Top-level team cards (no parent) render only the team name as title — no breadcrumb area.
- [ ] Description, member count, and other card body content render unchanged for both top-level and promoted sub-teams.

🤖 Generated with [Claude Code](https://claude.com/claude-code)