### PR TITLE
fix(shifts): integer ticks on team staffing chart y-axis

### DIFF
--- a/src/Humans.Web/Views/Shared/_StaffingChart.cshtml
+++ b/src/Humans.Web/Views/Shared/_StaffingChart.cshtml
@@ -94,7 +94,12 @@
             options: {
                 responsive: true,
                 layout: { padding: { top: 20 } },
-                scales: { x: { stacked: true }, y: { stacked: true, beginAtZero: true } },
+                scales: {
+                    x: { stacked: true },
+                    // Volunteer counts are integers — pin ticks to whole numbers so
+                    // small ranges (e.g. 0–3 vols) don't show 0.5/1.5/2.5.
+                    y: { stacked: true, beginAtZero: true, ticks: { precision: 0, stepSize: 1 } }
+                },
                 interaction: { mode: 'index', intersect: false },
                 plugins: {
                     tooltip: {


### PR DESCRIPTION
## Summary

The volunteer-count staffing chart on `/Teams/{slug}/Shifts` (rendered via `Views/Shared/_StaffingChart.cshtml`, consumed by `ShiftAdmin/Index`) shows half-person ticks like `0.5, 1.5, 2.5` when the y-range is small.

Chart.js's auto-step picker drops to 0.5 increments below ~5. Volunteer counts are integers — half a person doesn't exist — so this fix pins the y-axis ticks to whole numbers via Chart.js's `precision: 0` + `stepSize: 1`.

## Before / after

For a Build rota with three shifts at `MaxVolunteers = 3` and zero confirmed signups:

**Before:** y-axis ticks `0, 0.5, 1, 1.5, 2, 2.5, 3`
**After:** y-axis ticks `0, 1, 2, 3`

Verified in-browser by reading the live Chart.js instance:
```
{"id":"deptStaffingChart_Setup","ticks":[0,1,2,3],"stepSize":1,"precision":0}
```

## Scope

- One file: `src/Humans.Web/Views/Shared/_StaffingChart.cshtml`, six-line change to the y-scale config block.
- `_StaffingHoursChart.cshtml` is **not** touched — hours are legitimately decimal (a 4.5h shift × N volunteers produces fractional totals).
- No model, controller, service, or test changes.
- No new i18n strings.

## Test plan

- [ ] On `/Teams/{slug}/Shifts` for any team with at least one Build/Event/Strike rota with low `MaxVolunteers` (1–5 range), confirm each period's staffing chart shows only integer y-axis ticks.
- [ ] Confirm the `_StaffingHoursChart` ("Hours" chart) below it still shows decimal ticks where appropriate.
- [ ] Confirm tooltips, percentage labels, and bar colors are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)