### PR TITLE
refactor(profile): hydrate AccountMergeRequest snapshots via IUserService

### DIFF
--- a/src/Humans.Application/Services/Profiles/AccountMergeService.cs
+++ b/src/Humans.Application/Services/Profiles/AccountMergeService.cs
@@ -93,7 +93,7 @@ public sealed class AccountMergeService : IAccountMergeService, IUserDataContrib
         if (requests.Count == 0) return [];
 
         var userIds = CollectUserIds(requests);
-        var users = await _userService.GetByIdsAsync(userIds, ct);
+        var users = await _userService.GetUserInfosAsync(userIds, ct);
         return requests.Select(r => ToSnapshot(r, users)).ToList();
     }
 
@@ -103,7 +103,7 @@ public sealed class AccountMergeService : IAccountMergeService, IUserDataContrib
         if (request is null) return null;
 
         var userIds = CollectUserIds([request]);
-        var users = await _userService.GetByIdsAsync(userIds, ct);
+        var users = await _userService.GetUserInfosAsync(userIds, ct);
         return ToSnapshot(request, users);
     }
 
@@ -175,7 +175,7 @@ public sealed class AccountMergeService : IAccountMergeService, IUserDataContrib
 
     private static AccountMergeRequestSnapshot ToSnapshot(
         AccountMergeRequest request,
-        IReadOnlyDictionary<Guid, User> users) =>
+        IReadOnlyDictionary<Guid, UserInfo> users) =>
         new(
             request.Id,
             request.Email,
@@ -185,19 +185,19 @@ public sealed class AccountMergeService : IAccountMergeService, IUserDataContrib
             request.CreatedAt,
             request.ResolvedAt,
             request.ResolvedByUserId is Guid id && users.TryGetValue(id, out var rb)
-                ? rb.DisplayName
+                ? rb.BurnerName
                 : null,
             request.AdminNotes);
 
     private static AccountMergeUserSnapshot ToUserSnapshot(
         Guid userId,
-        IReadOnlyDictionary<Guid, User> users)
+        IReadOnlyDictionary<Guid, UserInfo> users)
     {
         if (users.TryGetValue(userId, out var user))
         {
             return new(
                 user.Id,
-                user.DisplayName,
+                user.BurnerName,
                 user.Email,
                 user.ProfilePictureUrl,
                 user.PreferredLanguage,

--- a/src/Humans.Application/Services/Profiles/AccountMergeService.cs
+++ b/src/Humans.Application/Services/Profiles/AccountMergeService.cs
@@ -90,13 +90,33 @@ public sealed class AccountMergeService : IAccountMergeService, IUserDataContrib
     public async Task<IReadOnlyList<AccountMergeRequestSnapshot>> GetPendingRequestsAsync(CancellationToken ct = default)
     {
         var requests = await _mergeRepository.GetPendingAsync(ct);
-        return requests.Select(ToSnapshot).ToList();
+        if (requests.Count == 0) return [];
+
+        var userIds = CollectUserIds(requests);
+        var users = await _userService.GetByIdsAsync(userIds, ct);
+        return requests.Select(r => ToSnapshot(r, users)).ToList();
     }
 
     public async Task<AccountMergeRequestSnapshot?> GetByIdAsync(Guid id, CancellationToken ct = default)
     {
         var request = await _mergeRepository.GetByIdAsync(id, ct);
-        return request is null ? null : ToSnapshot(request);
+        if (request is null) return null;
+
+        var userIds = CollectUserIds([request]);
+        var users = await _userService.GetByIdsAsync(userIds, ct);
+        return ToSnapshot(request, users);
+    }
+
+    private static IReadOnlyCollection<Guid> CollectUserIds(IReadOnlyList<AccountMergeRequest> requests)
+    {
+        var ids = new HashSet<Guid>();
+        foreach (var r in requests)
+        {
+            ids.Add(r.TargetUserId);
+            ids.Add(r.SourceUserId);
+            if (r.ResolvedByUserId is Guid resolvedBy) ids.Add(resolvedBy);
+        }
+        return ids;
     }
 
     public async Task AcceptAsync(
@@ -153,28 +173,40 @@ public sealed class AccountMergeService : IAccountMergeService, IUserDataContrib
         Guid? RelatedEntityId = null,
         string? RelatedEntityType = null);
 
-#pragma warning disable CS0618 // Cross-domain nav read: AccountMergeRequest.{TargetUser,SourceUser,ResolvedByUser} are included on this read path; resolving via IUserService here would be N+1 across the admin list view.
-    private static AccountMergeRequestSnapshot ToSnapshot(AccountMergeRequest request) =>
+    private static AccountMergeRequestSnapshot ToSnapshot(
+        AccountMergeRequest request,
+        IReadOnlyDictionary<Guid, User> users) =>
         new(
             request.Id,
             request.Email,
-            ToUserSnapshot(request.TargetUser),
-            ToUserSnapshot(request.SourceUser),
+            ToUserSnapshot(request.TargetUserId, users),
+            ToUserSnapshot(request.SourceUserId, users),
             request.Status,
             request.CreatedAt,
             request.ResolvedAt,
-            request.ResolvedByUser?.DisplayName,
+            request.ResolvedByUserId is Guid id && users.TryGetValue(id, out var rb)
+                ? rb.DisplayName
+                : null,
             request.AdminNotes);
-#pragma warning restore CS0618
 
-    private static AccountMergeUserSnapshot ToUserSnapshot(User user) =>
-        new(
-            user.Id,
-            user.DisplayName,
-            user.Email,
-            user.ProfilePictureUrl,
-            user.PreferredLanguage,
-            user.LastLoginAt);
+    private static AccountMergeUserSnapshot ToUserSnapshot(
+        Guid userId,
+        IReadOnlyDictionary<Guid, User> users)
+    {
+        if (users.TryGetValue(userId, out var user))
+        {
+            return new(
+                user.Id,
+                user.DisplayName,
+                user.Email,
+                user.ProfilePictureUrl,
+                user.PreferredLanguage,
+                user.LastLoginAt);
+        }
+        // User missing (deleted/purged): return a stub so the snapshot
+        // record's non-null contract holds. Display falls back to a sentinel.
+        return new(userId, "(unknown user)", null, null, null, null);
+    }
 
     private async Task FoldAsync(
         Guid sourceUserId, Guid targetUserId,

--- a/src/Humans.Infrastructure/Repositories/Profiles/AccountMergeRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Profiles/AccountMergeRepository.cs
@@ -27,8 +27,6 @@ public sealed class AccountMergeRepository : IAccountMergeRepository
         await using var ctx = await _factory.CreateDbContextAsync(ct);
         return await ctx.AccountMergeRequests
             .AsNoTracking()
-            .Include(r => r.TargetUser)
-            .Include(r => r.SourceUser)
             .Where(r => r.Status == AccountMergeRequestStatus.Pending)
             .OrderBy(r => r.CreatedAt)
             .ToListAsync(ct);
@@ -38,9 +36,6 @@ public sealed class AccountMergeRepository : IAccountMergeRepository
     {
         await using var ctx = await _factory.CreateDbContextAsync(ct);
         return await ctx.AccountMergeRequests
-            .Include(r => r.TargetUser)
-            .Include(r => r.SourceUser)
-            .Include(r => r.ResolvedByUser)
             .FirstOrDefaultAsync(r => r.Id == id, ct);
     }
 

--- a/tests/Humans.Application.Tests/Architecture/Baselines/NoObsoleteNavReads.baseline.txt
+++ b/tests/Humans.Application.Tests/Architecture/Baselines/NoObsoleteNavReads.baseline.txt
@@ -110,7 +110,6 @@ src/Humans.Infrastructure/Repositories/Camps/CampRepository.cs:User#1
 src/Humans.Infrastructure/Repositories/Legal/LegalDocumentRepository.cs:Team#1
 src/Humans.Infrastructure/Repositories/Notifications/NotificationRepository.cs:ResolvedByUser#1
 src/Humans.Infrastructure/Repositories/Notifications/NotificationRepository.cs:User#1
-src/Humans.Infrastructure/Repositories/Profiles/AccountMergeRepository.cs:ResolvedByUser#1
 src/Humans.Infrastructure/Repositories/Teams/TeamRepository.cs:Team#1
 src/Humans.Infrastructure/Repositories/Teams/TeamRepository.cs:Team#10
 src/Humans.Infrastructure/Repositories/Teams/TeamRepository.cs:Team#11


### PR DESCRIPTION
## Summary

Drops the three cross-domain `.Include()` calls on `AccountMergeRequest` (`TargetUser`, `SourceUser`, `ResolvedByUser`) in `AccountMergeRepository` and hydrates the user display fields through `IUserService.GetByIdsAsync` from `AccountMergeService.ToSnapshot` instead. Unblocks the next destructive-schema-cleanup PR from dropping those navs.

## Changes

- `AccountMergeRepository.GetPendingAsync` / `GetByIdAsync`: removed `.Include(r => r.TargetUser/SourceUser/ResolvedByUser)`.
- `AccountMergeService.GetPendingRequestsAsync` / `GetByIdAsync`: now batch-resolve the three user ids per request via `IUserService.GetByIdsAsync` and pass the lookup into `ToSnapshot`.
- `ToSnapshot` / `ToUserSnapshot` accept a `Guid → User` dictionary; falls back to a `(unknown user)` stub if a user row is missing.
- Dropped the obsolete `CS0618` pragma block that protected the previous nav reads.
- Removed `AccountMergeRepository.cs:ResolvedByUser#1` from `NoObsoleteNavReads.baseline.txt` (ratchet shrink).

## Acceptance

- [x] No `.Include(r => r.TargetUser)`, `.Include(r => r.SourceUser)`, or `.Include(r => r.ResolvedByUser)` remain in `AccountMergeRepository`.
- [x] `AdminMergeController` Index and Detail views read the same `AccountMergeRequestSnapshot` shape — no consumer-side change.
- [x] Architecture ratchet `NoObsoleteNavReads` passes after baseline shrink.

Closes nobodies-collective/Humans#729