### PR TITLE
feat(tickets): group /Tickets/Admin/Contacts rows by email

### DIFF
--- a/src/Humans.Application/Interfaces/Tickets/Dtos/AttendeeImportDecision.cs
+++ b/src/Humans.Application/Interfaces/Tickets/Dtos/AttendeeImportDecision.cs
@@ -1,16 +1,23 @@
 namespace Humans.Application.Interfaces.Tickets.Dtos;
 
 /// <summary>
-/// One per attendee in <see cref="AttendeeImportPlan"/>. Carries the
+/// One per distinct email in <see cref="AttendeeImportPlan"/>. Carries the
 /// classification plus the data the apply step needs (target user id for
 /// attach, unverified row id for delete-then-create, etc).
 /// </summary>
-/// <param name="AttendeeId">PK of the TicketAttendee row.</param>
-/// <param name="Email">Attendee email (case preserved from vendor).</param>
-/// <param name="AttendeeName">
-/// Resolved display name: LegalName → FirstName+LastName → null fallback.
+/// <param name="AttendeeId">
+/// PK of the lead <c>TicketAttendee</c> row (the checkbox value, and the
+/// canonical row whose <c>AttendeeEmail</c> the apply step rechecks for
+/// drift). For grouped decisions (one buyer with multiple tickets on the
+/// same email), the additional attendees are in <see cref="AdditionalAttendeeIds"/>.
 /// </param>
-/// <param name="VendorTicketId">For cross-reference with the vendor dashboard.</param>
+/// <param name="Email">Attendee email (case preserved from vendor's lead row).</param>
+/// <param name="AttendeeName">
+/// Resolved display name of the lead attendee: LegalName → FirstName+LastName
+/// → null fallback. Use <see cref="ObservedNames"/> when surfacing the full
+/// set of names observed across grouped attendees.
+/// </param>
+/// <param name="VendorTicketId">Lead vendor ticket id, for cross-reference with the vendor dashboard.</param>
 /// <param name="Outcome">Classification result.</param>
 /// <param name="TargetUserId">
 /// For <see cref="AttendeeImportOutcome.AttachVerified"/>: the live user id
@@ -29,6 +36,18 @@ namespace Humans.Application.Interfaces.Tickets.Dtos;
 /// For <see cref="AttendeeImportOutcome.AmbiguousMultipleVerified"/>: the
 /// conflicting user ids, for admin visibility. Null otherwise.
 /// </param>
+/// <param name="AdditionalAttendeeIds">
+/// For email-grouped decisions: the other <c>TicketAttendee.Id</c> values
+/// in the same email group beyond <see cref="AttendeeId"/>. Empty when only
+/// one attendee shares this email. Apply fans the <c>MatchedUserId</c>
+/// update across the lead plus these.
+/// </param>
+/// <param name="ObservedNames">
+/// Distinct resolved display names observed across all attendees in the
+/// email group (lead + additional). When length &gt; 1 the operator should
+/// be alerted that the buyer used multiple names; the apply outcome still
+/// matches a single user to the email.
+/// </param>
 public sealed record AttendeeImportDecision(
     Guid AttendeeId,
     string? Email,
@@ -38,4 +57,6 @@ public sealed record AttendeeImportDecision(
     Guid? TargetUserId,
     Guid? UnverifiedEmailIdToDelete,
     Guid? UnverifiedRowUserId,
-    IReadOnlyList<Guid>? AmbiguousUserIds);
+    IReadOnlyList<Guid>? AmbiguousUserIds,
+    IReadOnlyList<Guid>? AdditionalAttendeeIds = null,
+    IReadOnlyList<string>? ObservedNames = null);

--- a/src/Humans.Application/Services/Tickets/AttendeeContactImportService.cs
+++ b/src/Humans.Application/Services/Tickets/AttendeeContactImportService.cs
@@ -69,7 +69,11 @@ public sealed class AttendeeContactImportService : IAttendeeContactImportService
 
         foreach (var group in grouped)
         {
-            var members = group.ToList();
+            // Sort by VendorTicketId (ordinal) so the lead is stable across plan
+            // refreshes — GetUnmatchedActiveAttendeesAsync has no ORDER BY, so
+            // members[0] would otherwise depend on DB return order, and the
+            // admin's selected AttendeeId could shift between GET and POST.
+            var members = group.OrderBy(m => m.VendorTicketId, StringComparer.Ordinal).ToList();
             var lead = members[0];
             var additional = members.Skip(1).Select(m => m.Id).ToList();
             var observed = members
@@ -129,7 +133,10 @@ public sealed class AttendeeContactImportService : IAttendeeContactImportService
                         gid, d.Email);
                     continue;
                 }
-                if (!string.Equals(ga.AttendeeEmail, d.Email, StringComparison.OrdinalIgnoreCase))
+                // Trim both sides to match plan-time grouping (which uses Trim() +
+                // OrdinalIgnoreCase). Without trimming, "buyer@x.com" vs " buyer@x.com "
+                // would be treated as drift and silently skipped during fan-out.
+                if (!string.Equals(ga.AttendeeEmail?.Trim(), d.Email?.Trim(), StringComparison.OrdinalIgnoreCase))
                 {
                     _logger.LogWarning(
                         "Attendee {AttendeeId} email drifted between plan ({PlanEmail}) and apply ({FreshEmail}); skipping",

--- a/src/Humans.Application/Services/Tickets/AttendeeContactImportService.cs
+++ b/src/Humans.Application/Services/Tickets/AttendeeContactImportService.cs
@@ -54,11 +54,31 @@ public sealed class AttendeeContactImportService : IAttendeeContactImportService
             throw new InvalidOperationException("No active vendor event id — sync has not run.");
 
         var unmatched = await _ticketRepository.GetUnmatchedActiveAttendeesAsync(eventId, ct);
-        var decisions = new List<AttendeeImportDecision>(unmatched.Count);
+        var decisions = new List<AttendeeImportDecision>();
 
-        foreach (var a in unmatched)
+        // Rows without an email cannot be grouped — emit one decision each.
+        foreach (var a in unmatched.Where(a => string.IsNullOrWhiteSpace(a.AttendeeEmail)))
         {
-            decisions.Add(await ClassifyAsync(a, ct));
+            decisions.Add(await ClassifyAsync(a, [], [], ct));
+        }
+
+        // Rows with an email: group by normalized email so one buyer = one decision.
+        var grouped = unmatched
+            .Where(a => !string.IsNullOrWhiteSpace(a.AttendeeEmail))
+            .GroupBy(a => a.AttendeeEmail!.Trim(), StringComparer.OrdinalIgnoreCase);
+
+        foreach (var group in grouped)
+        {
+            var members = group.ToList();
+            var lead = members[0];
+            var additional = members.Skip(1).Select(m => m.Id).ToList();
+            var observed = members
+                .Select(ResolveDisplayName)
+                .Where(n => !string.IsNullOrWhiteSpace(n))
+                .Select(n => n!)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+            decisions.Add(await ClassifyAsync(lead, additional, observed, ct));
         }
 
         return new AttendeeImportPlan(decisions, unmatched.Count);
@@ -90,24 +110,39 @@ public sealed class AttendeeContactImportService : IAttendeeContactImportService
         {
             attempted++;
 
-            if (!freshById.TryGetValue(d.AttendeeId, out var attendee))
+            // Collect the group: lead + any additional attendees in the same email
+            // group (one buyer with multiple tickets on the same email).
+            var groupIds = new List<Guid>(1 + (d.AdditionalAttendeeIds?.Count ?? 0))
+                { d.AttendeeId };
+            if (d.AdditionalAttendeeIds is { Count: > 0 } more) groupIds.AddRange(more);
+
+            // Filter to the subset still present with the same email at apply time.
+            // Per-attendee drift (email change or row deletion) is tolerated as long
+            // as the lead is intact — the others are logged and skipped.
+            var resolved = new List<TicketAttendee>();
+            foreach (var gid in groupIds)
             {
-                vanished++;
-                _logger.LogWarning(
-                    "Attendee {AttendeeId} ({Email}) vanished between plan and apply",
-                    d.AttendeeId, d.Email);
-                continue;
+                if (!freshById.TryGetValue(gid, out var ga))
+                {
+                    _logger.LogWarning(
+                        "Attendee {AttendeeId} ({Email}) vanished between plan and apply",
+                        gid, d.Email);
+                    continue;
+                }
+                if (!string.Equals(ga.AttendeeEmail, d.Email, StringComparison.OrdinalIgnoreCase))
+                {
+                    _logger.LogWarning(
+                        "Attendee {AttendeeId} email drifted between plan ({PlanEmail}) and apply ({FreshEmail}); skipping",
+                        gid, d.Email, ga.AttendeeEmail);
+                    continue;
+                }
+                resolved.Add(ga);
             }
 
-            // If the attendee's email changed between plan and apply, the plan's
-            // decision (TargetUserId / UnverifiedEmailIdToDelete / etc.) was computed
-            // against a stale email and may attach the wrong user. Treat as vanished.
-            if (!string.Equals(attendee.AttendeeEmail, d.Email, StringComparison.OrdinalIgnoreCase))
+            // If nothing in the group survived, the decision as a whole is void.
+            if (resolved.Count == 0)
             {
                 vanished++;
-                _logger.LogWarning(
-                    "Attendee {AttendeeId} email drifted between plan ({PlanEmail}) and apply ({FreshEmail}); treating as vanished",
-                    d.AttendeeId, d.Email, attendee.AttendeeEmail);
                 continue;
             }
 
@@ -131,9 +166,13 @@ public sealed class AttendeeContactImportService : IAttendeeContactImportService
 
                     case AttendeeImportOutcome.AttachVerified:
                         {
-                            attendee.MatchedUserId = d.TargetUserId!.Value;
-                            toUpsert.Add(attendee);
-                            newlyMatchedUserIds.Add(d.TargetUserId.Value);
+                            var targetUserId = d.TargetUserId!.Value;
+                            foreach (var ga in resolved)
+                            {
+                                ga.MatchedUserId = targetUserId;
+                                toUpsert.Add(ga);
+                            }
+                            newlyMatchedUserIds.Add(targetUserId);
                             attached++;
                             break;
                         }
@@ -147,8 +186,11 @@ public sealed class AttendeeContactImportService : IAttendeeContactImportService
                             }
                             var (newUser, wasCreated) = await _provisioning.FindOrCreateUserByEmailAsync(
                                 d.Email!, d.AttendeeName, ContactSource.TicketTailor, ct);
-                            attendee.MatchedUserId = newUser.Id;
-                            toUpsert.Add(attendee);
+                            foreach (var ga in resolved)
+                            {
+                                ga.MatchedUserId = newUser.Id;
+                                toUpsert.Add(ga);
+                            }
                             newlyMatchedUserIds.Add(newUser.Id);
                             if (wasCreated) created++;
                             replaced++;
@@ -159,8 +201,11 @@ public sealed class AttendeeContactImportService : IAttendeeContactImportService
                         {
                             var (newUser, wasCreated) = await _provisioning.FindOrCreateUserByEmailAsync(
                                 d.Email!, d.AttendeeName, ContactSource.TicketTailor, ct);
-                            attendee.MatchedUserId = newUser.Id;
-                            toUpsert.Add(attendee);
+                            foreach (var ga in resolved)
+                            {
+                                ga.MatchedUserId = newUser.Id;
+                                toUpsert.Add(ga);
+                            }
                             newlyMatchedUserIds.Add(newUser.Id);
                             if (wasCreated) created++;
                             break;
@@ -216,9 +261,15 @@ public sealed class AttendeeContactImportService : IAttendeeContactImportService
         return result;
     }
 
-    private async Task<AttendeeImportDecision> ClassifyAsync(TicketAttendee a, CancellationToken ct)
+    private async Task<AttendeeImportDecision> ClassifyAsync(
+        TicketAttendee a,
+        IReadOnlyList<Guid> additionalAttendeeIds,
+        IReadOnlyList<string> observedNames,
+        CancellationToken ct)
     {
         var name = ResolveDisplayName(a);
+        var addl = additionalAttendeeIds.Count > 0 ? additionalAttendeeIds : null;
+        var names = observedNames.Count > 0 ? observedNames : null;
 
         if (string.IsNullOrWhiteSpace(a.AttendeeEmail))
         {
@@ -228,7 +279,9 @@ public sealed class AttendeeContactImportService : IAttendeeContactImportService
                 TargetUserId: null,
                 UnverifiedEmailIdToDelete: null,
                 UnverifiedRowUserId: null,
-                AmbiguousUserIds: null);
+                AmbiguousUserIds: null,
+                AdditionalAttendeeIds: addl,
+                ObservedNames: names);
         }
 
         var verifiedUserIds = await _userEmails.GetDistinctVerifiedUserIdsAsync(a.AttendeeEmail, ct);
@@ -241,7 +294,9 @@ public sealed class AttendeeContactImportService : IAttendeeContactImportService
                 TargetUserId: null,
                 UnverifiedEmailIdToDelete: null,
                 UnverifiedRowUserId: null,
-                AmbiguousUserIds: verifiedUserIds);
+                AmbiguousUserIds: verifiedUserIds,
+                AdditionalAttendeeIds: addl,
+                ObservedNames: names);
         }
 
         if (verifiedUserIds.Count == 1)
@@ -253,7 +308,9 @@ public sealed class AttendeeContactImportService : IAttendeeContactImportService
                 TargetUserId: liveTarget,
                 UnverifiedEmailIdToDelete: null,
                 UnverifiedRowUserId: null,
-                AmbiguousUserIds: null);
+                AmbiguousUserIds: null,
+                AdditionalAttendeeIds: addl,
+                ObservedNames: names);
         }
 
         var existingRow = await _userEmails.FindAnyEmailRowByAddressAsync(a.AttendeeEmail, ct);
@@ -265,7 +322,9 @@ public sealed class AttendeeContactImportService : IAttendeeContactImportService
                 TargetUserId: null,
                 UnverifiedEmailIdToDelete: emailId,
                 UnverifiedRowUserId: uid,
-                AmbiguousUserIds: null);
+                AmbiguousUserIds: null,
+                AdditionalAttendeeIds: addl,
+                ObservedNames: names);
         }
 
         return new AttendeeImportDecision(
@@ -274,7 +333,9 @@ public sealed class AttendeeContactImportService : IAttendeeContactImportService
             TargetUserId: null,
             UnverifiedEmailIdToDelete: null,
             UnverifiedRowUserId: null,
-            AmbiguousUserIds: null);
+            AmbiguousUserIds: null,
+            AdditionalAttendeeIds: addl,
+            ObservedNames: names);
     }
 
     private async Task<Guid> ResolveTombstoneAsync(Guid userId, CancellationToken ct)

--- a/src/Humans.Web/Controllers/TicketsContactsAdminController.cs
+++ b/src/Humans.Web/Controllers/TicketsContactsAdminController.cs
@@ -37,7 +37,9 @@ public sealed class TicketsContactsAdminController : HumansControllerBase
             .ThenBy(d => d.Email, StringComparer.OrdinalIgnoreCase)
             .Select(d => new AttendeeImportDecisionRow(
                 d.AttendeeId, d.Email, d.AttendeeName, d.VendorTicketId,
-                d.Outcome, d.TargetUserId, d.UnverifiedRowUserId, d.AmbiguousUserIds))
+                d.Outcome, d.TargetUserId, d.UnverifiedRowUserId, d.AmbiguousUserIds,
+                GroupSize: 1 + (d.AdditionalAttendeeIds?.Count ?? 0),
+                ObservedNames: d.ObservedNames))
             .ToList();
 
         return View("~/Views/Tickets/Admin/Contacts.cshtml",

--- a/src/Humans.Web/Models/Tickets/ContactImportPreviewViewModel.cs
+++ b/src/Humans.Web/Models/Tickets/ContactImportPreviewViewModel.cs
@@ -14,4 +14,6 @@ public sealed record AttendeeImportDecisionRow(
     AttendeeImportOutcome Outcome,
     Guid? TargetUserId,
     Guid? UnverifiedRowUserId,
-    IReadOnlyList<Guid>? AmbiguousUserIds);
+    IReadOnlyList<Guid>? AmbiguousUserIds,
+    int GroupSize,
+    IReadOnlyList<string>? ObservedNames);

--- a/src/Humans.Web/Views/Tickets/Admin/Contacts.cshtml
+++ b/src/Humans.Web/Views/Tickets/Admin/Contacts.cshtml
@@ -66,8 +66,34 @@
                                class="form-check-input row-check" />
                     }
                 </td>
-                <td>@(row.Email ?? "—")</td>
-                <td>@(row.AttendeeName ?? "—")</td>
+                <td>
+                    @(row.Email ?? "—")
+                    @if (row.GroupSize > 1)
+                    {
+                        <span class="badge text-bg-info ms-1" title="@row.GroupSize tickets share this email">×@row.GroupSize</span>
+                    }
+                </td>
+                <td>
+                    @if (row.ObservedNames is { Count: > 1 } names)
+                    {
+                        <details>
+                            <summary>
+                                @(row.AttendeeName ?? "—")
+                                <span class="badge text-bg-warning ms-1" title="Multiple distinct names observed">@names.Count names</span>
+                            </summary>
+                            <ul class="mb-0 small text-muted">
+                                @foreach (var n in names)
+                                {
+                                    <li>@n</li>
+                                }
+                            </ul>
+                        </details>
+                    }
+                    else
+                    {
+                        @(row.AttendeeName ?? "—")
+                    }
+                </td>
                 <td>
                     @switch (row.Outcome)
                     {

--- a/tests/Humans.Application.Tests/Services/Tickets/AttendeeContactImportServiceApplyTests.cs
+++ b/tests/Humans.Application.Tests/Services/Tickets/AttendeeContactImportServiceApplyTests.cs
@@ -204,6 +204,167 @@ public class AttendeeContactImportServiceApplyTests
     }
 
     [HumansFact]
+    public async Task Apply_GroupedDecision_FansMatchedUserIdToAllGroupAttendees()
+    {
+        var harness = new ApplyHarness();
+        var leadId = Guid.NewGuid();
+        var extraId = Guid.NewGuid();
+        var newUserId = Guid.NewGuid();
+        var lead = new TicketAttendee
+        {
+            Id = leadId,
+            VendorTicketId = "tkt_1",
+            VendorEventId = "evt_active",
+            AttendeeEmail = "buyer@x.com",
+            Status = TicketAttendeeStatus.Valid,
+        };
+        var extra = new TicketAttendee
+        {
+            Id = extraId,
+            VendorTicketId = "tkt_2",
+            VendorEventId = "evt_active",
+            AttendeeEmail = "buyer@x.com",
+            Status = TicketAttendeeStatus.Valid,
+        };
+        harness.WithUnmatched(lead);
+        harness.WithUnmatched(extra);
+        harness.WithActiveYear(2026);
+        harness.Provisioning.FindOrCreateUserByEmailAsync(
+                "buyer@x.com", "Sara Smith", ContactSource.TicketTailor, Arg.Any<CancellationToken>())
+            .Returns(new AccountProvisioningResult(new User { Id = newUserId }, true));
+
+        var plan = new AttendeeImportPlan([
+            new AttendeeImportDecision(
+                leadId, "buyer@x.com", "Sara Smith", "tkt_1",
+                AttendeeImportOutcome.CreateNewUser,
+                TargetUserId: null,
+                UnverifiedEmailIdToDelete: null,
+                UnverifiedRowUserId: null,
+                AmbiguousUserIds: null,
+                AdditionalAttendeeIds: [extraId],
+                ObservedNames: ["Sara Smith"])
+        ], 2);
+
+        var result = await harness.Service.ApplyAsync(plan, new HashSet<Guid> { leadId }, Guid.NewGuid());
+
+        result.TotalAttempted.Should().Be(1);
+        result.UsersCreated.Should().Be(1);
+        lead.MatchedUserId.Should().Be(newUserId);
+        extra.MatchedUserId.Should().Be(newUserId);
+
+        // Provisioning runs once even though two attendees share the email.
+        await harness.Provisioning.Received(1).FindOrCreateUserByEmailAsync(
+            "buyer@x.com", "Sara Smith", ContactSource.TicketTailor, Arg.Any<CancellationToken>());
+
+        // Upsert receives both rows so DB is updated for every grouped attendee.
+        await harness.TicketRepo.Received(1)
+            .UpsertAttendeesAsync(Arg.Is<IReadOnlyList<TicketAttendee>>(
+                l => l.Count == 2
+                    && l.Any(x => x.Id == leadId)
+                    && l.Any(x => x.Id == extraId)),
+                Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task Apply_GroupedDecision_AttachVerified_FansToAllGroupAttendees()
+    {
+        var harness = new ApplyHarness();
+        var leadId = Guid.NewGuid();
+        var extraId = Guid.NewGuid();
+        var targetUserId = Guid.NewGuid();
+        var lead = new TicketAttendee
+        {
+            Id = leadId,
+            VendorTicketId = "tkt_1",
+            VendorEventId = "evt_active",
+            AttendeeEmail = "buyer@x.com",
+            Status = TicketAttendeeStatus.Valid,
+        };
+        var extra = new TicketAttendee
+        {
+            Id = extraId,
+            VendorTicketId = "tkt_2",
+            VendorEventId = "evt_active",
+            AttendeeEmail = "buyer@x.com",
+            Status = TicketAttendeeStatus.Valid,
+        };
+        harness.WithUnmatched(lead);
+        harness.WithUnmatched(extra);
+        harness.WithActiveYear(2026);
+
+        var plan = new AttendeeImportPlan([
+            new AttendeeImportDecision(
+                leadId, "buyer@x.com", "Sara Smith", "tkt_1",
+                AttendeeImportOutcome.AttachVerified,
+                TargetUserId: targetUserId,
+                UnverifiedEmailIdToDelete: null,
+                UnverifiedRowUserId: null,
+                AmbiguousUserIds: null,
+                AdditionalAttendeeIds: [extraId])
+        ], 2);
+
+        var result = await harness.Service.ApplyAsync(plan, new HashSet<Guid> { leadId }, Guid.NewGuid());
+
+        result.AttachedToExistingVerified.Should().Be(1);
+        lead.MatchedUserId.Should().Be(targetUserId);
+        extra.MatchedUserId.Should().Be(targetUserId);
+
+        // Participation flips once for the single user, not twice.
+        await harness.Users.Received(1).SetParticipationFromTicketSyncAsync(
+            targetUserId, 2026, ParticipationStatus.Ticketed, Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task Apply_GroupedDecision_GroupMemberWithDriftedEmail_IsSkippedButLeadProceeds()
+    {
+        var harness = new ApplyHarness();
+        var leadId = Guid.NewGuid();
+        var driftedId = Guid.NewGuid();
+        var newUserId = Guid.NewGuid();
+        var lead = new TicketAttendee
+        {
+            Id = leadId,
+            VendorTicketId = "tkt_1",
+            VendorEventId = "evt_active",
+            AttendeeEmail = "buyer@x.com",
+            Status = TicketAttendeeStatus.Valid,
+        };
+        var drifted = new TicketAttendee
+        {
+            Id = driftedId,
+            VendorTicketId = "tkt_2",
+            VendorEventId = "evt_active",
+            AttendeeEmail = "different@x.com", // email changed since plan
+            Status = TicketAttendeeStatus.Valid,
+        };
+        harness.WithUnmatched(lead);
+        harness.WithUnmatched(drifted);
+        harness.WithActiveYear(2026);
+        harness.Provisioning.FindOrCreateUserByEmailAsync(
+                "buyer@x.com", Arg.Any<string?>(), ContactSource.TicketTailor, Arg.Any<CancellationToken>())
+            .Returns(new AccountProvisioningResult(new User { Id = newUserId }, true));
+
+        var plan = new AttendeeImportPlan([
+            new AttendeeImportDecision(
+                leadId, "buyer@x.com", "Sara Smith", "tkt_1",
+                AttendeeImportOutcome.CreateNewUser,
+                TargetUserId: null,
+                UnverifiedEmailIdToDelete: null,
+                UnverifiedRowUserId: null,
+                AmbiguousUserIds: null,
+                AdditionalAttendeeIds: [driftedId])
+        ], 2);
+
+        var result = await harness.Service.ApplyAsync(plan, new HashSet<Guid> { leadId }, Guid.NewGuid());
+
+        // Lead still wins; drifted is silently skipped (logged), not vanished.
+        result.UsersCreated.Should().Be(1);
+        lead.MatchedUserId.Should().Be(newUserId);
+        drifted.MatchedUserId.Should().BeNull();
+        result.VanishedBetweenPlanAndApply.Should().Be(0);
+    }
+
+    [HumansFact]
     public async Task Apply_AttendeeVanishedBetweenPlanAndApply_IsCountedAndSkipped()
     {
         var harness = new ApplyHarness();

--- a/tests/Humans.Application.Tests/Services/Tickets/AttendeeContactImportServicePlanTests.cs
+++ b/tests/Humans.Application.Tests/Services/Tickets/AttendeeContactImportServicePlanTests.cs
@@ -141,6 +141,82 @@ public class AttendeeContactImportServicePlanTests
     }
 
     [HumansFact]
+    public async Task Plan_MultipleAttendeesSameEmail_CollapseToOneDecisionWithGroup()
+    {
+        var harness = new PlanHarness();
+        var leadId = Guid.NewGuid();
+        var extra1 = Guid.NewGuid();
+        var extra2 = Guid.NewGuid();
+        harness.AddUnmatched(new TicketAttendee
+        {
+            Id = leadId,
+            VendorTicketId = "tkt_1",
+            AttendeeEmail = "buyer@x.com",
+            AttendeeName = "Sara Smith",
+            Status = TicketAttendeeStatus.Valid,
+        });
+        harness.AddUnmatched(new TicketAttendee
+        {
+            Id = extra1,
+            VendorTicketId = "tkt_2",
+            AttendeeEmail = "buyer@x.com",
+            AttendeeName = "Sara S.",
+            Status = TicketAttendeeStatus.Valid,
+        });
+        harness.AddUnmatched(new TicketAttendee
+        {
+            Id = extra2,
+            VendorTicketId = "tkt_3",
+            // Case-insensitive grouping: trim + casefold should still group.
+            AttendeeEmail = "BUYER@x.com",
+            AttendeeName = "Sara Smith",
+            Status = TicketAttendeeStatus.Valid,
+        });
+        harness.UserEmails.GetDistinctVerifiedUserIdsAsync(
+                Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns([]);
+        harness.UserEmails.FindAnyEmailRowByAddressAsync(
+                Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(((Guid, Guid)?)null);
+
+        var plan = await harness.Service.BuildPlanAsync();
+
+        plan.Decisions.Should().ContainSingle();
+        var d = plan.Decisions[0];
+        d.Outcome.Should().Be(AttendeeImportOutcome.CreateNewUser);
+        d.AttendeeId.Should().Be(leadId);
+        d.AdditionalAttendeeIds.Should().BeEquivalentTo(new[] { extra1, extra2 });
+        d.ObservedNames.Should().BeEquivalentTo(new[] { "Sara Smith", "Sara S." });
+        plan.TotalUnmatched.Should().Be(3);
+    }
+
+    [HumansFact]
+    public async Task Plan_NoEmailAttendees_RemainPerAttendee_NotGrouped()
+    {
+        var harness = new PlanHarness();
+        harness.AddUnmatched(new TicketAttendee
+        {
+            Id = Guid.NewGuid(),
+            VendorTicketId = "tkt_a",
+            AttendeeEmail = null,
+            AttendeeName = "A",
+            Status = TicketAttendeeStatus.Valid,
+        });
+        harness.AddUnmatched(new TicketAttendee
+        {
+            Id = Guid.NewGuid(),
+            VendorTicketId = "tkt_b",
+            AttendeeEmail = "   ",
+            AttendeeName = "B",
+            Status = TicketAttendeeStatus.Valid,
+        });
+
+        var plan = await harness.Service.BuildPlanAsync();
+
+        plan.Decisions.Should().HaveCount(2);
+        plan.Decisions.Should().OnlyContain(d => d.Outcome == AttendeeImportOutcome.SkipNoEmail);
+        plan.Decisions.Should().OnlyContain(d => d.AdditionalAttendeeIds == null);
+    }
+
+    [HumansFact]
     public async Task Plan_MultipleVerifiedMatches_ClassifiedAsAmbiguous()
     {
         var harness = new PlanHarness();


### PR DESCRIPTION
## Summary

Collapses contact import preview rows that share an email into a single grouped row. Renders a group badge plus observed-names details. Fan-out is preserved on apply via `AdditionalAttendeeIds`.

## Notes for review

- Tests added for grouping in `BuildPlanAsync` and fan-out in `ApplyAsync`.
- This was produced by a swarm agent that was interrupted mid-flight; build/test verification was not completed by the agent. CI + Claude review bot pass will catch any drift.

Refs nobodies-collective/Humans#715

🤖 Generated with [Claude Code](https://claude.com/claude-code)