### PR TITLE
fix(google-integration): Drive sharing + Group membership for non-Google emails (nobodies-collective/Humans#677)

### DIFF
--- a/src/Humans.Application/Services/GoogleIntegration/GoogleGroupSyncService.cs
+++ b/src/Humans.Application/Services/GoogleIntegration/GoogleGroupSyncService.cs
@@ -510,23 +510,30 @@ public sealed class GoogleGroupSyncService : IGoogleGroupSync
         var statusCode = error?.StatusCode ?? 0;
         var rawMessage = error?.RawMessage ?? string.Empty;
 
-        if (statusCode != 403)
+        // Cloud Identity returns HTTP 403 when the target email has no Google
+        // account and HTTP 400 "precondition check failed" / Error(4002) for
+        // the same root cause (issue nobodies-collective/Humans#677). Both
+        // map to a permanent target rejection.
+        if (statusCode != 403 && statusCode != 400)
         {
             return FormatGoogleError($"Google group add failed for {email}", error);
         }
 
-        var isCallerPermissionError = rawMessage.Contains("caller", StringComparison.OrdinalIgnoreCase)
-            || rawMessage.Contains("service account", StringComparison.OrdinalIgnoreCase)
-            || rawMessage.Contains("does not have permission", StringComparison.OrdinalIgnoreCase);
-
-        if (isCallerPermissionError)
+        if (statusCode == 403)
         {
-            _logger.LogWarning(
-                "Service account lacks permission to add members to group {GroupKey} ({GroupId}) - HTTP 403: {ErrorMessage}",
-                groupKey,
-                resource?.GoogleId,
-                rawMessage);
-            return FormatGoogleError($"Google group add failed for {email}", error);
+            var isCallerPermissionError = rawMessage.Contains("caller", StringComparison.OrdinalIgnoreCase)
+                || rawMessage.Contains("service account", StringComparison.OrdinalIgnoreCase)
+                || rawMessage.Contains("does not have permission", StringComparison.OrdinalIgnoreCase);
+
+            if (isCallerPermissionError)
+            {
+                _logger.LogWarning(
+                    "Service account lacks permission to add members to group {GroupKey} ({GroupId}) - HTTP 403: {ErrorMessage}",
+                    groupKey,
+                    resource?.GoogleId,
+                    rawMessage);
+                return FormatGoogleError($"Google group add failed for {email}", error);
+            }
         }
 
         if (IsTargetMemberRejection(rawMessage))
@@ -541,26 +548,46 @@ public sealed class GoogleGroupSyncService : IGoogleGroupSync
             }
 
             _logger.LogWarning(
-                "Google rejected target member email {Email} while adding to Google Group {GroupKey} ({GroupId}) - HTTP 403. " +
+                "Google rejected target member email {Email} while adding to Google Group {GroupKey} ({GroupId}) - HTTP {StatusCode}. " +
                 "Legacy User.GoogleEmailStatus was marked Rejected when a matching user was found. Google error: {ErrorMessage}",
                 email,
                 groupKey,
                 resource?.GoogleId,
+                statusCode,
                 rawMessage);
 
-            return $"Google rejected {email} for group membership - no Google account for this address (HTTP 403)";
+            return $"Google rejected {email} for group membership - no Google account for this address (HTTP {statusCode})";
         }
 
         return FormatGoogleError($"Google group add failed for {email}", error);
     }
 
-    private static bool IsTargetMemberRejection(string rawMessage)
+    /// <summary>
+    /// Matches Google API error messages that indicate the target email is
+    /// not backed by a real Google identity. Covers Cloud Identity Group
+    /// membership 403/400 ("invalid member", "precondition check failed",
+    /// Error(4002)) and Drive permission 400 ("recipient has no Google
+    /// account ... SendNotificationEmail must be true"). See issue
+    /// nobodies-collective/Humans#677.
+    /// </summary>
+    internal static bool IsTargetMemberRejection(string rawMessage)
         => rawMessage.Contains("does not have a google account", StringComparison.OrdinalIgnoreCase)
+            || rawMessage.Contains("no google account", StringComparison.OrdinalIgnoreCase)
             || rawMessage.Contains("not a google account", StringComparison.OrdinalIgnoreCase)
             || rawMessage.Contains("not associated with a google account", StringComparison.OrdinalIgnoreCase)
             || rawMessage.Contains("invalid member", StringComparison.OrdinalIgnoreCase)
             || rawMessage.Contains("invalid email", StringComparison.OrdinalIgnoreCase)
-            || rawMessage.Contains("invalid user", StringComparison.OrdinalIgnoreCase);
+            || rawMessage.Contains("invalid user", StringComparison.OrdinalIgnoreCase)
+            // Drive permissions.create — 400 when the recipient is not on a
+            // Google domain. Google's response mentions SendNotificationEmail
+            // as the only path that would invite them.
+            || rawMessage.Contains("sendnotificationemail", StringComparison.OrdinalIgnoreCase)
+            // Cloud Identity groups.memberships.create — 400 / Error(4002)
+            // "Membership ... cannot be created since precondition check failed."
+            // The precondition is that the entity resolves to a real identity.
+            || rawMessage.Contains("precondition check failed", StringComparison.OrdinalIgnoreCase)
+            || rawMessage.Contains("error(4002)", StringComparison.OrdinalIgnoreCase)
+            || rawMessage.Contains("membership cannot be created", StringComparison.OrdinalIgnoreCase);
 
     private async Task ScheduleRetryAsync(string groupKey, string error, int retryAttempt)
     {

--- a/src/Humans.Application/Services/GoogleIntegration/GoogleGroupSyncService.cs
+++ b/src/Humans.Application/Services/GoogleIntegration/GoogleGroupSyncService.cs
@@ -563,31 +563,46 @@ public sealed class GoogleGroupSyncService : IGoogleGroupSync
     }
 
     /// <summary>
-    /// Matches Google API error messages that indicate the target email is
-    /// not backed by a real Google identity. Covers Cloud Identity Group
-    /// membership 403/400 ("invalid member", "precondition check failed",
-    /// Error(4002)) and Drive permission 400 ("recipient has no Google
-    /// account ... SendNotificationEmail must be true"). See issue
+    /// Matches Cloud Identity Group membership error messages that indicate
+    /// the target email is not backed by a real Google identity. Covers
+    /// <c>groups.memberships.create</c> 403/400 ("invalid member",
+    /// "precondition check failed", Error(4002), "membership cannot be
+    /// created"). Group-specific — do NOT use on the Drive path, where
+    /// "precondition check failed" can also mean an admin-configured
+    /// sharing-outside-domain restriction. See issue
     /// nobodies-collective/Humans#677.
     /// </summary>
     internal static bool IsTargetMemberRejection(string rawMessage)
+        => IsDriveTargetRejection(rawMessage)
+            || rawMessage.Contains("invalid member", StringComparison.OrdinalIgnoreCase)
+            || rawMessage.Contains("invalid email", StringComparison.OrdinalIgnoreCase)
+            || rawMessage.Contains("invalid user", StringComparison.OrdinalIgnoreCase)
+            // Cloud Identity groups.memberships.create — 400 / Error(4002)
+            // "Membership ... cannot be created since precondition check failed."
+            // The precondition is that the entity resolves to a real identity.
+            // These phrases are NOT safe on the Drive path: Drive returns
+            // the same 400 wording for sharing-policy / shared-drive
+            // restrictions that have nothing to do with the recipient.
+            || rawMessage.Contains("precondition check failed", StringComparison.OrdinalIgnoreCase)
+            || rawMessage.Contains("error(4002)", StringComparison.OrdinalIgnoreCase)
+            || rawMessage.Contains("membership cannot be created", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Matches Drive <c>permissions.create</c> error messages that indicate
+    /// the recipient is not backed by a real Google identity. Drive's
+    /// response is specific — it mentions <c>SendNotificationEmail</c> and
+    /// "no Google account" — so we scope the Drive detector to those
+    /// phrases only. Generic Google API phrases (e.g. "precondition check
+    /// failed") MUST NOT live here, because Drive uses the same wording for
+    /// admin-configured sharing-policy errors that should keep retrying.
+    /// See issue nobodies-collective/Humans#677.
+    /// </summary>
+    internal static bool IsDriveTargetRejection(string rawMessage)
         => rawMessage.Contains("does not have a google account", StringComparison.OrdinalIgnoreCase)
             || rawMessage.Contains("no google account", StringComparison.OrdinalIgnoreCase)
             || rawMessage.Contains("not a google account", StringComparison.OrdinalIgnoreCase)
             || rawMessage.Contains("not associated with a google account", StringComparison.OrdinalIgnoreCase)
-            || rawMessage.Contains("invalid member", StringComparison.OrdinalIgnoreCase)
-            || rawMessage.Contains("invalid email", StringComparison.OrdinalIgnoreCase)
-            || rawMessage.Contains("invalid user", StringComparison.OrdinalIgnoreCase)
-            // Drive permissions.create — 400 when the recipient is not on a
-            // Google domain. Google's response mentions SendNotificationEmail
-            // as the only path that would invite them.
-            || rawMessage.Contains("sendnotificationemail", StringComparison.OrdinalIgnoreCase)
-            // Cloud Identity groups.memberships.create — 400 / Error(4002)
-            // "Membership ... cannot be created since precondition check failed."
-            // The precondition is that the entity resolves to a real identity.
-            || rawMessage.Contains("precondition check failed", StringComparison.OrdinalIgnoreCase)
-            || rawMessage.Contains("error(4002)", StringComparison.OrdinalIgnoreCase)
-            || rawMessage.Contains("membership cannot be created", StringComparison.OrdinalIgnoreCase);
+            || rawMessage.Contains("sendnotificationemail", StringComparison.OrdinalIgnoreCase);
 
     private async Task ScheduleRetryAsync(string groupKey, string error, int retryAttempt)
     {

--- a/src/Humans.Application/Services/GoogleIntegration/GoogleGroupSyncService.cs
+++ b/src/Humans.Application/Services/GoogleIntegration/GoogleGroupSyncService.cs
@@ -565,18 +565,26 @@ public sealed class GoogleGroupSyncService : IGoogleGroupSync
     /// <summary>
     /// Matches Cloud Identity Group membership error messages that indicate
     /// the target email is not backed by a real Google identity. Covers
-    /// <c>groups.memberships.create</c> 403/400 ("invalid member",
-    /// "precondition check failed", Error(4002), "membership cannot be
-    /// created"). Group-specific — do NOT use on the Drive path, where
-    /// "precondition check failed" can also mean an admin-configured
-    /// sharing-outside-domain restriction. See issue
-    /// nobodies-collective/Humans#677.
+    /// <c>groups.memberships.create</c> 403 ("member does not have a Google
+    /// account", "invalid member") and 400 / Error(4002) ("precondition
+    /// check failed", "membership cannot be created"). Group-specific — do
+    /// NOT use on the Drive path, where "precondition check failed" can
+    /// also mean an admin-configured sharing-outside-domain restriction.
+    /// See issue nobodies-collective/Humans#677.
     /// </summary>
     internal static bool IsTargetMemberRejection(string rawMessage)
-        => IsDriveTargetRejection(rawMessage)
-            || rawMessage.Contains("invalid member", StringComparison.OrdinalIgnoreCase)
+        => rawMessage.Contains("invalid member", StringComparison.OrdinalIgnoreCase)
             || rawMessage.Contains("invalid email", StringComparison.OrdinalIgnoreCase)
             || rawMessage.Contains("invalid user", StringComparison.OrdinalIgnoreCase)
+            // Cloud Identity groups.memberships.create — 403 "member does
+            // not have a Google account" / "no Google account" / variants.
+            // Same phrasings appear on Drive 400 responses; the Drive
+            // detector lives separately on GoogleWorkspaceSyncService so
+            // each path owns its own predicate.
+            || rawMessage.Contains("does not have a google account", StringComparison.OrdinalIgnoreCase)
+            || rawMessage.Contains("no google account", StringComparison.OrdinalIgnoreCase)
+            || rawMessage.Contains("not a google account", StringComparison.OrdinalIgnoreCase)
+            || rawMessage.Contains("not associated with a google account", StringComparison.OrdinalIgnoreCase)
             // Cloud Identity groups.memberships.create — 400 / Error(4002)
             // "Membership ... cannot be created since precondition check failed."
             // The precondition is that the entity resolves to a real identity.
@@ -586,23 +594,6 @@ public sealed class GoogleGroupSyncService : IGoogleGroupSync
             || rawMessage.Contains("precondition check failed", StringComparison.OrdinalIgnoreCase)
             || rawMessage.Contains("error(4002)", StringComparison.OrdinalIgnoreCase)
             || rawMessage.Contains("membership cannot be created", StringComparison.OrdinalIgnoreCase);
-
-    /// <summary>
-    /// Matches Drive <c>permissions.create</c> error messages that indicate
-    /// the recipient is not backed by a real Google identity. Drive's
-    /// response is specific — it mentions <c>SendNotificationEmail</c> and
-    /// "no Google account" — so we scope the Drive detector to those
-    /// phrases only. Generic Google API phrases (e.g. "precondition check
-    /// failed") MUST NOT live here, because Drive uses the same wording for
-    /// admin-configured sharing-policy errors that should keep retrying.
-    /// See issue nobodies-collective/Humans#677.
-    /// </summary>
-    internal static bool IsDriveTargetRejection(string rawMessage)
-        => rawMessage.Contains("does not have a google account", StringComparison.OrdinalIgnoreCase)
-            || rawMessage.Contains("no google account", StringComparison.OrdinalIgnoreCase)
-            || rawMessage.Contains("not a google account", StringComparison.OrdinalIgnoreCase)
-            || rawMessage.Contains("not associated with a google account", StringComparison.OrdinalIgnoreCase)
-            || rawMessage.Contains("sendnotificationemail", StringComparison.OrdinalIgnoreCase);
 
     private async Task ScheduleRetryAsync(string groupKey, string error, int retryAttempt)
     {

--- a/src/Humans.Application/Services/GoogleIntegration/GoogleWorkspaceSyncService.cs
+++ b/src/Humans.Application/Services/GoogleIntegration/GoogleWorkspaceSyncService.cs
@@ -277,8 +277,60 @@ public sealed class GoogleWorkspaceSyncService : IGoogleSyncService
                     "Google API error granting {Role} to {Email} on {GoogleId} — HTTP {Code}: {Message}",
                     apiRole, userEmail, resource.GoogleId,
                     result.Error?.StatusCode, result.Error?.RawMessage);
+                await HandleDriveAddFailureAsync(resource, userEmail, result.Error, cancellationToken);
                 break;
         }
+    }
+
+    /// <summary>
+    /// Issue nobodies-collective/Humans#677 — when Drive's
+    /// <c>permissions.create</c> returns a target-rejection (HTTP 400/403
+    /// referencing "no Google account" / "SendNotificationEmail"), mark the
+    /// owning user's <see cref="GoogleEmailStatus"/> as
+    /// <see cref="GoogleEmailStatus.Rejected"/> so the orchestrator stops
+    /// re-attempting until an admin clears the state. Mirrors the existing
+    /// <c>GoogleGroupSyncService.HandleGroupAddFailureAsync</c> pattern.
+    /// </summary>
+    private async Task HandleDriveAddFailureAsync(
+        GoogleResource resource,
+        string userEmail,
+        GoogleClientError? error,
+        CancellationToken ct)
+    {
+        var statusCode = error?.StatusCode ?? 0;
+        var rawMessage = error?.RawMessage ?? string.Empty;
+
+        // Drive returns 400 when the recipient has no Google account on a
+        // domain that supports notification-free sharing. 403 covers caller-
+        // permission failures (not the target's problem) so we don't mark
+        // those.
+        if (statusCode != 400)
+        {
+            return;
+        }
+
+        if (!GoogleGroupSyncService.IsTargetMemberRejection(rawMessage))
+        {
+            return;
+        }
+
+        var user = await _userService.GetByEmailOrAlternateAsync(userEmail, ct);
+        if (user is null || user.GoogleEmailStatus == GoogleEmailStatus.Rejected)
+        {
+            return;
+        }
+
+        await _userService.TrySetGoogleEmailStatusFromSyncAsync(
+            user.Id,
+            GoogleEmailStatus.Rejected,
+            ct);
+
+        _logger.LogWarning(
+            "Google rejected target email {Email} while granting Drive permission on {GoogleId} - HTTP 400. " +
+            "User.GoogleEmailStatus marked Rejected. Google error: {ErrorMessage}",
+            userEmail,
+            resource.GoogleId,
+            rawMessage);
     }
 
     /// <summary>

--- a/src/Humans.Application/Services/GoogleIntegration/GoogleWorkspaceSyncService.cs
+++ b/src/Humans.Application/Services/GoogleIntegration/GoogleWorkspaceSyncService.cs
@@ -309,7 +309,12 @@ public sealed class GoogleWorkspaceSyncService : IGoogleSyncService
             return;
         }
 
-        if (!GoogleGroupSyncService.IsTargetMemberRejection(rawMessage))
+        // Drive-specific predicate — generic Cloud Identity phrases like
+        // "precondition check failed" appear in Drive responses too, but for
+        // unrelated admin-configured sharing-policy reasons. Only flip
+        // GoogleEmailStatus on phrases unique to Drive's no-Google-account
+        // signal. Issue nobodies-collective/Humans#677.
+        if (!GoogleGroupSyncService.IsDriveTargetRejection(rawMessage))
         {
             return;
         }

--- a/src/Humans.Application/Services/GoogleIntegration/GoogleWorkspaceSyncService.cs
+++ b/src/Humans.Application/Services/GoogleIntegration/GoogleWorkspaceSyncService.cs
@@ -314,7 +314,7 @@ public sealed class GoogleWorkspaceSyncService : IGoogleSyncService
         // unrelated admin-configured sharing-policy reasons. Only flip
         // GoogleEmailStatus on phrases unique to Drive's no-Google-account
         // signal. Issue nobodies-collective/Humans#677.
-        if (!GoogleGroupSyncService.IsDriveTargetRejection(rawMessage))
+        if (!IsDriveTargetRejection(rawMessage))
         {
             return;
         }
@@ -337,6 +337,23 @@ public sealed class GoogleWorkspaceSyncService : IGoogleSyncService
             resource.GoogleId,
             rawMessage);
     }
+
+    /// <summary>
+    /// Matches Drive <c>permissions.create</c> error messages that indicate
+    /// the recipient is not backed by a real Google identity. Drive's
+    /// response is specific — it mentions <c>SendNotificationEmail</c> and
+    /// "no Google account" — so we scope the Drive detector to those
+    /// phrases only. Generic Google API phrases (e.g. "precondition check
+    /// failed") MUST NOT live here, because Drive uses the same wording for
+    /// admin-configured sharing-policy errors that should keep retrying.
+    /// See issue nobodies-collective/Humans#677.
+    /// </summary>
+    private static bool IsDriveTargetRejection(string rawMessage)
+        => rawMessage.Contains("does not have a google account", StringComparison.OrdinalIgnoreCase)
+            || rawMessage.Contains("no google account", StringComparison.OrdinalIgnoreCase)
+            || rawMessage.Contains("not a google account", StringComparison.OrdinalIgnoreCase)
+            || rawMessage.Contains("not associated with a google account", StringComparison.OrdinalIgnoreCase)
+            || rawMessage.Contains("sendnotificationemail", StringComparison.OrdinalIgnoreCase);
 
     /// <summary>
     /// GATEWAY METHOD: the only path that removes a user from a Google Drive

--- a/src/Humans.Web/Resources/SharedResource.ca.resx
+++ b/src/Humans.Web/Resources/SharedResource.ca.resx
@@ -5030,6 +5030,12 @@
   <data name="EmailGrid_VerificationPendingBody" xml:space="preserve">
     <value>Revisa la teva safata d’entrada i fes clic a l’enllaç del correu de verificació per confirmar la teva adreça.</value>
   </data>
+  <data name="EmailGrid_GoogleSyncRejectedTitle" xml:space="preserve">
+    <value>Sincronització de Google pausada per a aquesta adreça.</value>
+  </data>
+  <data name="EmailGrid_GoogleSyncRejectedBody" xml:space="preserve">
+    <value>Google ha rebutjat el correu de Google seleccionat en intentar concedir accés a Drive o afegir-te a un grup — normalment perquè l’adreça no està vinculada a un compte de Google. Els nous intents de sincronització es suprimeixen fins que un administrador ho resolgui. Selecciona un altre correu vinculat a un compte de Google i demana a un administrador que esborri l’estat rebutjat.</value>
+  </data>
   <data name="EmailGrid_Visibility" xml:space="preserve">
     <value>Visibilitat</value>
   </data>

--- a/src/Humans.Web/Resources/SharedResource.de.resx
+++ b/src/Humans.Web/Resources/SharedResource.de.resx
@@ -5030,6 +5030,12 @@
   <data name="EmailGrid_VerificationPendingBody" xml:space="preserve">
     <value>Prüfe deinen Posteingang und klicke auf den Link in der Bestätigungs-E-Mail, um deine Adresse zu bestätigen.</value>
   </data>
+  <data name="EmailGrid_GoogleSyncRejectedTitle" xml:space="preserve">
+    <value>Google-Synchronisierung für diese Adresse pausiert.</value>
+  </data>
+  <data name="EmailGrid_GoogleSyncRejectedBody" xml:space="preserve">
+    <value>Google hat die ausgewählte Google-Adresse abgelehnt, als versucht wurde, Drive-Zugriff zu gewähren oder dich einer Gruppe hinzuzufügen — meist weil die Adresse mit keinem Google-Konto verknüpft ist. Neue Synchronisationsversuche werden ausgesetzt, bis ein Administrator das Problem behebt. Wähle eine andere von Google unterstützte Adresse und bitte einen Administrator, den abgelehnten Status zu löschen.</value>
+  </data>
   <data name="EmailGrid_Visibility" xml:space="preserve">
     <value>Sichtbarkeit</value>
   </data>

--- a/src/Humans.Web/Resources/SharedResource.es.resx
+++ b/src/Humans.Web/Resources/SharedResource.es.resx
@@ -5028,6 +5028,12 @@
   <data name="EmailGrid_VerificationPendingBody" xml:space="preserve">
     <value>Revisa tu bandeja de entrada y haz clic en el enlace del correo de verificación para confirmar tu dirección.</value>
   </data>
+  <data name="EmailGrid_GoogleSyncRejectedTitle" xml:space="preserve">
+    <value>Sincronización de Google pausada para esta dirección.</value>
+  </data>
+  <data name="EmailGrid_GoogleSyncRejectedBody" xml:space="preserve">
+    <value>Google rechazó el correo de Google seleccionado al intentar conceder acceso a Drive o añadirte a un grupo — normalmente porque la dirección no está vinculada a una cuenta de Google. Los nuevos intentos de sincronización se suprimen hasta que un administrador lo resuelva. Selecciona otro correo respaldado por Google y pide a un administrador que borre el estado rechazado.</value>
+  </data>
   <data name="EmailGrid_Visibility" xml:space="preserve">
     <value>Visibilidad</value>
   </data>

--- a/src/Humans.Web/Resources/SharedResource.fr.resx
+++ b/src/Humans.Web/Resources/SharedResource.fr.resx
@@ -5030,6 +5030,12 @@
   <data name="EmailGrid_VerificationPendingBody" xml:space="preserve">
     <value>Vérifiez votre boîte de réception et cliquez sur le lien dans l’e-mail de vérification pour confirmer votre adresse.</value>
   </data>
+  <data name="EmailGrid_GoogleSyncRejectedTitle" xml:space="preserve">
+    <value>Synchronisation Google suspendue pour cette adresse.</value>
+  </data>
+  <data name="EmailGrid_GoogleSyncRejectedBody" xml:space="preserve">
+    <value>Google a rejeté l’adresse Google sélectionnée lors de la tentative d’octroi d’accès à Drive ou d’ajout à un Groupe — généralement parce que l’adresse n’est pas liée à un compte Google. Les nouvelles tentatives de synchronisation sont suspendues jusqu’à ce qu’un administrateur résolve le problème. Sélectionnez une autre adresse liée à un compte Google et demandez à un administrateur d’effacer l’état rejeté.</value>
+  </data>
   <data name="EmailGrid_Visibility" xml:space="preserve">
     <value>Visibilité</value>
   </data>

--- a/src/Humans.Web/Resources/SharedResource.it.resx
+++ b/src/Humans.Web/Resources/SharedResource.it.resx
@@ -5030,6 +5030,12 @@
   <data name="EmailGrid_VerificationPendingBody" xml:space="preserve">
     <value>Controlla la tua casella di posta e fai clic sul link nell’email di verifica per confermare il tuo indirizzo.</value>
   </data>
+  <data name="EmailGrid_GoogleSyncRejectedTitle" xml:space="preserve">
+    <value>Sincronizzazione Google sospesa per questo indirizzo.</value>
+  </data>
+  <data name="EmailGrid_GoogleSyncRejectedBody" xml:space="preserve">
+    <value>Google ha rifiutato l’indirizzo Google selezionato durante il tentativo di concedere l’accesso a Drive o di aggiungerti a un Gruppo — di solito perché l’indirizzo non è collegato a un account Google. I nuovi tentativi di sincronizzazione sono sospesi finché un amministratore non risolve il problema. Seleziona un altro indirizzo supportato da Google e chiedi a un amministratore di cancellare lo stato rifiutato.</value>
+  </data>
   <data name="EmailGrid_Visibility" xml:space="preserve">
     <value>Visibilità</value>
   </data>

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -2026,6 +2026,8 @@
   <data name="EmailGrid_WorkspaceLockedHelp" xml:space="preserve"><value>Primary and Google are managed by Google Workspace while your @nobodies.team address is present.</value></data>
   <data name="EmailGrid_VerificationPendingTitle" xml:space="preserve"><value>Email verification pending</value></data>
   <data name="EmailGrid_VerificationPendingBody" xml:space="preserve"><value>Check your inbox for the verification email and click the link to confirm your address.</value></data>
+  <data name="EmailGrid_GoogleSyncRejectedTitle" xml:space="preserve"><value>Google sync paused for this address.</value></data>
+  <data name="EmailGrid_GoogleSyncRejectedBody" xml:space="preserve"><value>Google rejected your selected Google email when trying to grant access to Drive or add you to a Group — typically because the address is not backed by a Google account. New sync attempts are suppressed until an administrator resolves this. Select a different Google-backed email and ask an admin to clear the rejected state.</value></data>
   <data name="EmailGrid_Visibility" xml:space="preserve"><value>Visibility</value></data>
   <data name="EmailGrid_Actions" xml:space="preserve"><value>Actions</value></data>
   <data name="EmailGrid_StatusMergePending" xml:space="preserve"><value>Merge pending</value></data>

--- a/src/Humans.Web/Views/Profile/Emails.cshtml
+++ b/src/Humans.Web/Views/Profile/Emails.cshtml
@@ -98,12 +98,8 @@
             <div class="alert alert-danger d-flex align-items-start mb-3">
                 <i class="fa-solid fa-triangle-exclamation me-2 fs-4 mt-1"></i>
                 <div>
-                    <strong>Google sync paused for this address.</strong>
-                    Google rejected your selected Google email when trying to grant access to
-                    Drive or add you to a Group — typically because the address is not backed by
-                    a Google account. New sync attempts are suppressed until an administrator
-                    resolves this. Select a different Google-backed email and ask an admin to
-                    clear the rejected state.
+                    <strong>@Localizer["EmailGrid_GoogleSyncRejectedTitle"]</strong>
+                    @Localizer["EmailGrid_GoogleSyncRejectedBody"]
                 </div>
             </div>
         }

--- a/src/Humans.Web/Views/Profile/Emails.cshtml
+++ b/src/Humans.Web/Views/Profile/Emails.cshtml
@@ -1,4 +1,5 @@
 @using Microsoft.AspNetCore.Authorization
+@using Humans.Domain.Enums
 @using Humans.Web.Authorization
 @inject IAuthorizationService AuthService
 @model Humans.Web.Models.EmailsViewModel
@@ -83,6 +84,26 @@
                 <i class="fa-solid fa-envelope-circle-check me-2 fs-4"></i>
                 <div>
                     <strong>@Localizer["EmailGrid_VerificationPendingTitle"]</strong> — @Localizer["EmailGrid_VerificationPendingBody"]
+                </div>
+            </div>
+        }
+
+        @* Issue nobodies-collective/Humans#677 — surface Google sync rejection *@
+        @* to the affected user so they understand why Drive/Groups access is   *@
+        @* not being granted. Cleared by an admin once the underlying problem   *@
+        @* (typically a non-Google email selected as the Google address) is     *@
+        @* resolved.                                                            *@
+        @if (Model.GoogleEmailStatus == GoogleEmailStatus.Rejected)
+        {
+            <div class="alert alert-danger d-flex align-items-start mb-3">
+                <i class="fa-solid fa-triangle-exclamation me-2 fs-4 mt-1"></i>
+                <div>
+                    <strong>Google sync paused for this address.</strong>
+                    Google rejected your selected Google email when trying to grant access to
+                    Drive or add you to a Group — typically because the address is not backed by
+                    a Google account. New sync attempts are suppressed until an administrator
+                    resolves this. Select a different Google-backed email and ask an admin to
+                    clear the rejected state.
                 </div>
             </div>
         }

--- a/tests/Humans.Application.Tests/GoogleIntegration/GoogleWorkspaceSyncServiceTests.cs
+++ b/tests/Humans.Application.Tests/GoogleIntegration/GoogleWorkspaceSyncServiceTests.cs
@@ -245,6 +245,125 @@ public sealed class GoogleWorkspaceSyncServiceTests
     // per-user AddUserToGroupAsync / RemoveUserFromGroupAsync gateways were
     // retired by PR #478 (issue #615).
 
+    [HumansFact]
+    public async Task AddUserToDriveAsync_When400NoGoogleAccount_MarksGoogleEmailRejected()
+    {
+        // Issue nobodies-collective/Humans#677 — Drive's permissions.create
+        // returns HTTP 400 referencing SendNotificationEmail when the
+        // recipient is not on a Google domain. Must mark the owning user's
+        // GoogleEmailStatus as Rejected so the orchestrator stops retrying.
+        _syncSettingsService
+            .GetModeAsync(SyncServiceType.GoogleDrive, Arg.Any<CancellationToken>())
+            .Returns(SyncMode.AddAndRemove);
+        _syncSettingsService
+            .GetModeAsync(SyncServiceType.GoogleGroups, Arg.Any<CancellationToken>())
+            .Returns(SyncMode.None);
+
+        var user = MakeUser(TestUserId, TestUserEmail);
+        _userService.GetByIdAsync(TestUserId, Arg.Any<CancellationToken>()).Returns(user);
+        _userService.GetByEmailOrAlternateAsync(TestUserEmail, Arg.Any<CancellationToken>()).Returns(user);
+
+        _userEmailService
+            .GetEntitiesByUserIdAsync(TestUserId, Arg.Any<CancellationToken>())
+            .Returns((IReadOnlyList<UserEmailRowSnapshot>)[
+                new UserEmailRowSnapshot(
+                    Guid.NewGuid(),
+                    TestUserId,
+                    TestUserEmail,
+                    IsVerified: true,
+                    Provider: null,
+                    ProviderKey: null,
+                    IsGoogle: true,
+                    IsPrimary: false,
+                    Visibility: null,
+                    VerificationSentAt: null,
+                    CreatedAt: default,
+                    UpdatedAt: default)
+            ]);
+
+        var driveResource = MakeDriveFolderResource(TestDriveFolderResourceId, TestTeamId, TestGoogleFolderId);
+        _resourceRepository
+            .GetActiveByTeamIdAsync(TestTeamId, Arg.Any<CancellationToken>())
+            .Returns([driveResource]);
+
+        _teamService.GetTeamByIdAsync(TestTeamId, Arg.Any<CancellationToken>())
+            .Returns((Team?)null);
+        _teamService.GetUserTeamsAsync(TestUserId, Arg.Any<CancellationToken>())
+            .Returns([]);
+
+        _drivePermissions
+            .CreatePermissionAsync(TestGoogleFolderId, TestUserEmail, Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new DrivePermissionMutationResult(
+                DrivePermissionCreateOutcome.Failed,
+                new GoogleClientError(
+                    400,
+                    "The recipient has no Google account associated with this address. " +
+                    "Please set SendNotificationEmail to true to invite them.")));
+
+        await _syncService.AddUserToTeamResourcesAsync(TestTeamId, TestUserId);
+
+        await _userService.Received(1).TrySetGoogleEmailStatusFromSyncAsync(
+            TestUserId,
+            GoogleEmailStatus.Rejected,
+            Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task AddUserToDriveAsync_WhenGeneric400_DoesNotMarkGoogleEmailRejected()
+    {
+        // Issue nobodies-collective/Humans#677 — generic 400 (malformed role,
+        // etc.) is NOT a target-rejection. The orchestrator must continue
+        // retrying these, so GoogleEmailStatus must not flip.
+        _syncSettingsService
+            .GetModeAsync(SyncServiceType.GoogleDrive, Arg.Any<CancellationToken>())
+            .Returns(SyncMode.AddAndRemove);
+        _syncSettingsService
+            .GetModeAsync(SyncServiceType.GoogleGroups, Arg.Any<CancellationToken>())
+            .Returns(SyncMode.None);
+
+        var user = MakeUser(TestUserId, TestUserEmail);
+        _userService.GetByIdAsync(TestUserId, Arg.Any<CancellationToken>()).Returns(user);
+
+        _userEmailService
+            .GetEntitiesByUserIdAsync(TestUserId, Arg.Any<CancellationToken>())
+            .Returns((IReadOnlyList<UserEmailRowSnapshot>)[
+                new UserEmailRowSnapshot(
+                    Guid.NewGuid(),
+                    TestUserId,
+                    TestUserEmail,
+                    IsVerified: true,
+                    Provider: null,
+                    ProviderKey: null,
+                    IsGoogle: true,
+                    IsPrimary: false,
+                    Visibility: null,
+                    VerificationSentAt: null,
+                    CreatedAt: default,
+                    UpdatedAt: default)
+            ]);
+
+        var driveResource = MakeDriveFolderResource(TestDriveFolderResourceId, TestTeamId, TestGoogleFolderId);
+        _resourceRepository
+            .GetActiveByTeamIdAsync(TestTeamId, Arg.Any<CancellationToken>())
+            .Returns([driveResource]);
+
+        _teamService.GetTeamByIdAsync(TestTeamId, Arg.Any<CancellationToken>())
+            .Returns((Team?)null);
+        _teamService.GetUserTeamsAsync(TestUserId, Arg.Any<CancellationToken>())
+            .Returns([]);
+
+        _drivePermissions
+            .CreatePermissionAsync(TestGoogleFolderId, TestUserEmail, Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new DrivePermissionMutationResult(
+                DrivePermissionCreateOutcome.Failed,
+                new GoogleClientError(400, "Bad Request: invalid role 'archivist'")));
+
+        await _syncService.AddUserToTeamResourcesAsync(TestTeamId, TestUserId);
+
+        await _userService.DidNotReceiveWithAnyArgs()
+            .TrySetGoogleEmailStatusFromSyncAsync(default, default, default);
+    }
+
     // ==========================================================================
     // Helpers
     // ==========================================================================

--- a/tests/Humans.Application.Tests/GoogleIntegration/GoogleWorkspaceSyncServiceTests.cs
+++ b/tests/Humans.Application.Tests/GoogleIntegration/GoogleWorkspaceSyncServiceTests.cs
@@ -364,6 +364,68 @@ public sealed class GoogleWorkspaceSyncServiceTests
             .TrySetGoogleEmailStatusFromSyncAsync(default, default, default);
     }
 
+    [HumansFact]
+    public async Task AddUserToDriveAsync_WhenPreconditionCheckFailed_DoesNotMarkGoogleEmailRejected()
+    {
+        // Issue nobodies-collective/Humans#677 — Drive returns HTTP 400
+        // "precondition check failed" for admin-configured policies like
+        // sharing-outside-domain restrictions on a shared drive, NOT just for
+        // missing Google accounts. The Cloud Identity Group path treats that
+        // phrase as a target-rejection, but the Drive path must not — flipping
+        // GoogleEmailStatus to Rejected would permanently silence retries for
+        // what is actually an admin-configuration issue affecting every user.
+        _syncSettingsService
+            .GetModeAsync(SyncServiceType.GoogleDrive, Arg.Any<CancellationToken>())
+            .Returns(SyncMode.AddAndRemove);
+        _syncSettingsService
+            .GetModeAsync(SyncServiceType.GoogleGroups, Arg.Any<CancellationToken>())
+            .Returns(SyncMode.None);
+
+        var user = MakeUser(TestUserId, TestUserEmail);
+        _userService.GetByIdAsync(TestUserId, Arg.Any<CancellationToken>()).Returns(user);
+
+        _userEmailService
+            .GetEntitiesByUserIdAsync(TestUserId, Arg.Any<CancellationToken>())
+            .Returns((IReadOnlyList<UserEmailRowSnapshot>)[
+                new UserEmailRowSnapshot(
+                    Guid.NewGuid(),
+                    TestUserId,
+                    TestUserEmail,
+                    IsVerified: true,
+                    Provider: null,
+                    ProviderKey: null,
+                    IsGoogle: true,
+                    IsPrimary: false,
+                    Visibility: null,
+                    VerificationSentAt: null,
+                    CreatedAt: default,
+                    UpdatedAt: default)
+            ]);
+
+        var driveResource = MakeDriveFolderResource(TestDriveFolderResourceId, TestTeamId, TestGoogleFolderId);
+        _resourceRepository
+            .GetActiveByTeamIdAsync(TestTeamId, Arg.Any<CancellationToken>())
+            .Returns([driveResource]);
+
+        _teamService.GetTeamByIdAsync(TestTeamId, Arg.Any<CancellationToken>())
+            .Returns((Team?)null);
+        _teamService.GetUserTeamsAsync(TestUserId, Arg.Any<CancellationToken>())
+            .Returns([]);
+
+        _drivePermissions
+            .CreatePermissionAsync(TestGoogleFolderId, TestUserEmail, Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new DrivePermissionMutationResult(
+                DrivePermissionCreateOutcome.Failed,
+                new GoogleClientError(
+                    400,
+                    "Precondition check failed for shared drive sharing policy.")));
+
+        await _syncService.AddUserToTeamResourcesAsync(TestTeamId, TestUserId);
+
+        await _userService.DidNotReceiveWithAnyArgs()
+            .TrySetGoogleEmailStatusFromSyncAsync(default, default, default);
+    }
+
     // ==========================================================================
     // Helpers
     // ==========================================================================

--- a/tests/Humans.Application.Tests/Infrastructure/GoogleIntegration/GoogleGroupSyncServiceTests.cs
+++ b/tests/Humans.Application.Tests/Infrastructure/GoogleIntegration/GoogleGroupSyncServiceTests.cs
@@ -379,6 +379,68 @@ public sealed class GoogleGroupSyncServiceTests
     }
 
     [HumansFact]
+    public async Task ReconcileOneAsync_UserRejectedByGoogle400Precondition_MarksGoogleEmailRejected()
+    {
+        // Issue nobodies-collective/Humans#677 — Cloud Identity returns HTTP
+        // 400 / Error(4002) "Membership cannot be created since precondition
+        // check failed" when the target email has no Google identity. Must
+        // be treated as a permanent target rejection, same as the 403 path.
+        var userId = Guid.NewGuid();
+        var service = CreateService(new StaticSource("team@nobodies.team", userId));
+        StubUsers((userId, "Alice", "alice@external.test"));
+        StubGroup("team@nobodies.team", "group-1");
+
+        _membershipClient.CreateMembershipAsync("group-1", "alice@external.test", Arg.Any<CancellationToken>())
+            .Returns(new GroupMembershipMutationResult(
+                GroupMembershipMutationOutcome.Failed,
+                new GoogleClientError(400, "Error(4002): Membership cannot be created since precondition check failed.")));
+        _userService.GetByEmailOrAlternateAsync("alice@external.test", Arg.Any<CancellationToken>())
+            .Returns(new User
+            {
+                Id = userId,
+                DisplayName = "Alice",
+                GoogleEmailStatus = GoogleEmailStatus.Unknown,
+                CreatedAt = _clock.GetCurrentInstant()
+            });
+
+        var diff = await service.ReconcileOneAsync("team@nobodies.team", SyncAction.Execute);
+
+        diff.ErrorMessage.Should().Contain("Google rejected alice@external.test");
+        diff.ErrorMessage.Should().Contain("HTTP 400");
+        await _userService.Received(1).TrySetGoogleEmailStatusFromSyncAsync(
+            userId,
+            GoogleEmailStatus.Rejected,
+            Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task ReconcileOneAsync_GenericGoogle400_DoesNotMarkGoogleEmailRejected()
+    {
+        // Issue nobodies-collective/Humans#677 — make sure the 400 branch only
+        // marks Rejected when the message text matches a target-rejection
+        // pattern. A generic 400 (e.g. malformed payload) must not flip the
+        // user's GoogleEmailStatus.
+        var userId = Guid.NewGuid();
+        var service = CreateService(new StaticSource("team@nobodies.team", userId));
+        StubUsers((userId, "Alice", "alice@nobodies.team"));
+        StubGroup("team@nobodies.team", "group-1");
+
+        _membershipClient.CreateMembershipAsync("group-1", "alice@nobodies.team", Arg.Any<CancellationToken>())
+            .Returns(new GroupMembershipMutationResult(
+                GroupMembershipMutationOutcome.Failed,
+                new GoogleClientError(400, "Bad Request: invalid argument 'roles'")));
+
+        var diff = await service.ReconcileOneAsync("team@nobodies.team", SyncAction.Execute);
+
+        diff.ErrorMessage.Should().Contain("invalid argument 'roles'");
+        await _userService.DidNotReceiveWithAnyArgs()
+            .TrySetGoogleEmailStatusFromSyncAsync(default, default, default);
+        await _userService.DidNotReceiveWithAnyArgs()
+            .GetByEmailOrAlternateAsync(default!, default);
+        _syncScheduler.Scheduled.Should().ContainSingle();
+    }
+
+    [HumansFact]
     public async Task ReconcileOneAsync_GenericGoogle403_DoesNotMarkGoogleEmailRejected()
     {
         var userId = Guid.NewGuid();


### PR DESCRIPTION
## Summary

When a sync target email has no Google account, two HTTP 400 failure modes were being logged as warnings and retried forever, filling logs with the same per-user failure:

- **Drive `permissions.create`** returns HTTP 400 referencing `SendNotificationEmail` / "recipient has no Google account".
- **Cloud Identity `groups.memberships.create`** returns HTTP 400 / Error(4002) "Membership cannot be created since precondition check failed".

Both responses now route through the existing **target-rejection** pipeline:

1. `User.GoogleEmailStatus` is flipped to `Rejected` for the affected user.
2. The orchestrator (TeamService outbox enqueue + GoogleGroupSyncService reconciliation) already skips users in the `Rejected` state — so retries stop.
3. Admin clears the state via `GoogleAdminService` once the user fixes their email (existing flow).
4. User-facing `Profile/Emails` page surfaces a `danger` alert explaining why Drive/Group access is paused; admin `AdminDetail` already badges the state.

The generic "capture-and-stop" infrastructure the issue asks for is already in place via `User.GoogleEmailStatus` (per-user) and `GoogleSyncOutboxEvent.FailedPermanently` (per-event). This PR just extends the classifier to also match the two HTTP 400 cases that triggered the bug report.

## Acceptance criteria

- [x] **Failed sync attempts persist the error and stop retrying without human intervention.** `User.GoogleEmailStatus = Rejected` is persisted; `TeamService` (`src/Humans.Application/Services/Teams/TeamService.cs:2147-2150`) and `GoogleGroupSyncService` (`src/Humans.Application/Services/GoogleIntegration/GoogleGroupSyncService.cs:364`) both skip these users.
- [x] **The affected user can see their own failed sync state.** New alert on `Profile/Emails` view (`src/Humans.Web/Views/Profile/Emails.cshtml` after `<vc:temp-data-alerts />`).
- [x] **Admins have visibility into failed sync targets across users.** Already surfaced on `Profile/AdminDetail` (badge at `src/Humans.Web/Views/Profile/AdminDetail.cshtml:413-420`) and on the `/Google/SyncOutbox` page for outbox events with `FailedPermanently`.

## Test plan

- [x] `GoogleGroupSyncServiceTests.ReconcileOneAsync_UserRejectedByGoogle400Precondition_MarksGoogleEmailRejected` — 400/Error(4002) marks Rejected.
- [x] `GoogleGroupSyncServiceTests.ReconcileOneAsync_GenericGoogle400_DoesNotMarkGoogleEmailRejected` — bad payload 400 does NOT flip status.
- [x] `GoogleWorkspaceSyncServiceTests.AddUserToDriveAsync_When400NoGoogleAccount_MarksGoogleEmailRejected` — Drive 400 with SendNotificationEmail marks Rejected.
- [x] `GoogleWorkspaceSyncServiceTests.AddUserToDriveAsync_WhenGeneric400_DoesNotMarkGoogleEmailRejected` — Drive 400 invalid role does NOT flip status.
- [x] Existing 403/transient tests still pass (`Humans.Application.Tests`: 2996 passed, 0 failed).
- [ ] Manual: in preview env, give a user a non-Google email as their Google address, trigger sync, confirm the alert appears on their Manage Emails page and admin can clear the state.

Closes nobodies-collective/Humans#677

IsGoogle remains user-controlled — no automatic email flagging in this change.