### PR TITLE
feat(shifts): 'Email a rota' coordinator action

### DIFF
--- a/docs/features/shifts/email-a-rota.md
+++ b/docs/features/shifts/email-a-rota.md
@@ -1,0 +1,160 @@
+<!-- freshness:triggers
+  src/Humans.Application/Interfaces/Shifts/IRotaCoordinatorMessageService.cs
+  src/Humans.Application/Services/Shifts/RotaCoordinatorMessageService.cs
+  src/Humans.Application/Interfaces/Email/IEmailService.cs
+  src/Humans.Application/Services/Email/OutboxEmailService.cs
+  src/Humans.Infrastructure/Services/EmailRenderer.cs
+  src/Humans.Web/Controllers/ShiftAdminController.cs
+  src/Humans.Web/Models/Shifts/EmailRotaViewModel.cs
+  src/Humans.Web/Views/ShiftAdmin/EmailRota.cshtml
+-->
+<!-- freshness:flag-on-change
+  Email template shape, recipient selection rules, and authorization scope — review when ShiftAdminController authorization, signup status filtering, or the coordinator-rota email body changes.
+-->
+
+# Email a Rota
+
+## Business Context
+
+Coordinators routinely need to communicate with everyone working a given rota — a last-minute schedule clarification, a venue change, a thank-you. Before this feature, coordinators built recipient lists by hand from the rota page or fell back on the per-person "Contact a person" button one signup at a time. Coordinators improvised via spreadsheets + Gmail, losing the personalization that makes operational messages actionable — specifically the "your shifts on this rota are…" tail that lets each recipient know exactly which shifts the message applies to.
+
+The "Email a rota" action gives coordinators a single bulk-to-rota messaging path that **preserves per-recipient personalization** (one email per recipient, each carrying that recipient's own shift list on this rota), while reusing the existing outbox/audit/opt-out infrastructure so logging and consent routing stay consistent with every other transactional send.
+
+Source: [nobodies-collective/Humans#732](https://github.com/nobodies-collective/Humans/issues/732).
+
+## User Stories
+
+### US-732.1: Coordinator emails everyone on a rota
+
+**As a** rota coordinator (Admin, VolunteerCoordinator, or department coordinator)
+**I want to** send one personalised email to every active signup on a rota
+**So that** I can broadcast schedule clarifications, venue changes, or thanks without losing the per-recipient shift context
+
+**Acceptance Criteria:**
+
+- An "Email a rota" entry point is visible on the rota admin view for users who can manage the department's shifts.
+- Compose form accepts a free-text message body (1–4000 characters, required).
+- Compose form shows the recipient count and the list of recipient names (`BurnerName`, alphabetical) so the coordinator can verify scope before sending.
+- On submit, each distinct active signup user receives a **separate, personalised email** — not a single CC/BCC blast.
+- Each email body contains the coordinator's free-text message plus that recipient's own chronologically ordered shifts on this rota.
+- Shift list uses the event's timezone (matches the rota detail page convention): `"ddd MMMM d"` for all-day shifts, `"ddd MMMM d @ HH:mm"` for time-slotted shifts.
+- Delivery flows through `IEmailService` → outbox so audit, opt-out routing, and category suppression stay consistent with every other transactional send.
+- A single audit row (`AuditAction.CoordinatorRotaMessageSent`) records the dispatch, including queued count, skipped count, and a truncated copy of the message text.
+- Non-coordinators (and `NoInfoAdmin`) do not see the entry point and are blocked at the controller by `ResolveDepartmentManagementAsync`.
+
+### US-732.2: Recipients see exactly their own shifts
+
+**As a** rota recipient
+**I want** the email I receive to list only my shifts on this rota
+**So that** the message is unambiguous about which commitments it applies to
+
+**Acceptance Criteria:**
+
+- Email lists only the recipient's signups on the target rota where `SignupStatus is Pending or Confirmed`.
+- Shifts are sorted chronologically by absolute start (event timezone).
+- Email rendering uses the recipient's `PreferredLanguage` culture.
+
+## Recipient Selection
+
+The recipient set is computed once per dispatch:
+
+1. Load the rota with its shifts and `EventSettings` (`IShiftSignupRepository.GetRotaWithShiftsAsync`).
+2. Load all active signups for the rota (`IShiftSignupRepository.GetActiveByRotaAsync`) — currently `Pending` or `Confirmed`.
+3. Group signups by `UserId` (one email per distinct user, even if they have multiple shifts on the rota).
+4. Skip users with no user record or no email address; record skipped count for the audit row.
+
+## Email Template (per recipient)
+
+Shape (template in `IEmailRenderer`):
+
+```
+Dear {BurnerName},
+
+A message from the coordinator for your shift:
+
+{coordinator's free-text message}
+
+—
+
+FYI, your shifts on this rota are:
+- Mon July 6 @ 19:30
+- Tue July 7 @ 12:30
+- …
+
+Thank you,
+— Humans & {sender BurnerName}
+```
+
+`CoordinatorRotaMessageRequest` carries the per-recipient inputs:
+
+- `RecipientEmail`, `RecipientName` — addressing + greeting.
+- `SenderName`, `SenderEmail` — signature + Reply-To attribution.
+- `RotaName` — subject + body context.
+- `MessageText` — coordinator's free-text body.
+- `ShiftLines` — pre-formatted, chronologically sorted, recipient-scoped shift labels.
+- `Culture` — recipient's preferred language for template rendering.
+
+## Authorization
+
+The compose + submit endpoints (`GET/POST /Teams/{slug}/Shifts/Rotas/{rotaId}/Email`) use the standard shift-admin gate:
+
+- Resolves the team and confirms the current user can **manage** that department (`ResolveDepartmentManagementAsync`).
+- That gate excludes `NoInfoAdmin` and non-managers; it admits Admin, VolunteerCoordinator, and department coordinators — matching the existing rota CRUD authorization scope.
+- `404` is returned when the rota does not belong to the resolved team (prevents cross-team probing).
+
+## Data Model
+
+No new entities or migrations. The feature is pure orchestration over existing types:
+
+- `IShiftSignupRepository` — new (or reused) read methods:
+  - `GetRotaWithShiftsAsync(rotaId, ct)` — rota + shifts + `EventSettings`.
+  - `GetActiveByRotaAsync(rotaId, ct)` — active signups for grouping.
+- `IUserService.GetUserInfosAsync(userIds, ct)` — recipient name/email/culture lookup.
+- `IEmailService.SendCoordinatorRotaMessageAsync(request, ct)` — outbox enqueue.
+- `IEmailRenderer` — rendering for the new template.
+- `AuditAction.CoordinatorRotaMessageSent` — new audit action value.
+
+## Workflow
+
+```
+Coordinator (GET)
+  → ShiftAdminController.EmailRota (GET)
+    → Resolve team + management permission
+    → Load rota + recipient names → render compose view
+
+Coordinator submits (POST)
+  → ShiftAdminController.EmailRota (POST)
+    → Re-resolve team + management permission
+    → Repopulate display fields (recipient list)
+    → Validate ModelState (Message required, ≤4000 chars)
+    → IRotaCoordinatorMessageService.SendRotaMessageAsync(rotaId, senderUserId, message)
+        → Load rota + EventSettings
+        → Load active signups → group by user
+        → Load sender + recipient infos
+        → For each recipient: build chronological shift lines → enqueue email
+        → Single audit row: CoordinatorRotaMessageSent (queued/skipped counts)
+        → RotaMessageDispatchResult.Success(count, rotaName)
+    → SetSuccess("Queued N email(s) to recipients on rota '…'")
+    → Redirect to rota index anchor (#rota-{id})
+
+Failure paths
+  → Rota missing                → "Rota not found." (validation summary)
+  → Empty/whitespace message    → ModelState error
+  → No active signups           → "This rota has no active signups to email."
+  → Sender not found            → "Sender not found."
+  → Recipient skipped (no user / no email) → logged, counted, does not abort dispatch
+```
+
+## Architecture Status
+
+- **Section:** Shifts.
+- **Layering:** new orchestrator service `RotaCoordinatorMessageService` lives in Application; no EF types leak across the boundary; recipient set computed via existing repository abstractions; rendering + delivery delegated to the Email service surface; controller is thin and authorization-gated.
+- **Cross-section dependencies:** Users (`IUserService`), Email (`IEmailService`, `IEmailRenderer`), AuditLog (`IAuditLogService`). All consumed through Application interfaces — no direct DbContext access.
+- **Caching:** none (one-shot dispatch path; per-recipient lookups bounded by signup count).
+
+## Related Features
+
+- [Shift Management](shift-management.md) — broader shift/rota admin context.
+- [Coordinator Roles](coordinator-roles.md) — Volunteer Coordinator role that gates many shift-admin actions.
+- [Shift Signup Visibility](shift-signup-visibility.md) — signup statuses used to scope the recipient set.
+- [`docs/sections/shifts.md`](../../sections/shifts.md) — section invariants for Shifts.

--- a/src/Humans.Application/Interfaces/Email/IEmailRenderer.cs
+++ b/src/Humans.Application/Interfaces/Email/IEmailRenderer.cs
@@ -102,6 +102,20 @@ public interface IEmailRenderer
         string? culture = null);
 
     /// <summary>
+    /// "Email a rota" message from the coordinator to a single signup on the
+    /// rota. Body contains the coordinator's free-text message plus the
+    /// recipient's chronologically-ordered shift list on this rota.
+    /// </summary>
+    EmailContent RenderCoordinatorRotaMessage(
+        string recipientName,
+        string senderName,
+        string? senderEmail,
+        string rotaName,
+        string messageText,
+        IReadOnlyList<string> shiftLines,
+        string? culture = null);
+
+    /// <summary>
     /// Magic link login email for an existing user.
     /// </summary>
     EmailContent RenderMagicLinkLogin(string displayName, string magicLinkUrl, string? culture = null);

--- a/src/Humans.Application/Interfaces/Email/IEmailService.cs
+++ b/src/Humans.Application/Interfaces/Email/IEmailService.cs
@@ -232,6 +232,17 @@ public interface IEmailService : IApplicationService
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Sends a personalized "email a rota" message from the rota's coordinator
+    /// to a single signup on the rota. The body carries the coordinator's free-text
+    /// message plus the recipient's own chronologically-ordered shift list on this
+    /// rota. Category is <see cref="MessageCategory.VolunteerUpdates"/>; replies go
+    /// to the coordinator's email when supplied.
+    /// </summary>
+    Task SendCoordinatorRotaMessageAsync(
+        CoordinatorRotaMessageRequest request,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Sends a magic link login email to an existing user.
     /// </summary>
     Task SendMagicLinkLoginAsync(
@@ -334,6 +345,22 @@ public interface IEmailService : IApplicationService
         string? culture = null,
         CancellationToken cancellationToken = default);
 }
+
+/// <summary>
+/// Payload for a coordinator "email a rota" message to a single signup.
+/// <see cref="ShiftLines"/> are pre-rendered, chronologically-ordered shift labels
+/// for the recipient on this rota (e.g. "Mon July 6 @ 19:30") — the renderer
+/// HTML-encodes them, it does not parse or sort them.
+/// </summary>
+public record CoordinatorRotaMessageRequest(
+    string RecipientEmail,
+    string RecipientName,
+    string SenderName,
+    string? SenderEmail,
+    string RotaName,
+    string MessageText,
+    IReadOnlyList<string> ShiftLines,
+    string? Culture = null);
 
 /// <summary>
 /// Payload for enqueuing a campaign-code email.

--- a/src/Humans.Application/Interfaces/Repositories/IShiftSignupRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/IShiftSignupRepository.cs
@@ -106,6 +106,16 @@ public interface IShiftSignupRepository : IRepository
     Task<IReadOnlyList<ShiftSignup>> GetByShiftAsync(Guid shiftId, CancellationToken ct = default);
 
     /// <summary>
+    /// Returns Pending and Confirmed signups for every shift on the given rota,
+    /// with <c>Shift</c> included for date/time resolution. Refused, Bailed,
+    /// Cancelled, and NoShow signups are excluded. Used by the coordinator
+    /// "email a rota" action to enumerate current recipients. Read-only.
+    /// Caller resolves user display fields via <c>IUserService.GetByIdsAsync</c>.
+    /// </summary>
+    Task<IReadOnlyList<ShiftSignup>> GetActiveByRotaAsync(
+        Guid rotaId, CancellationToken ct = default);
+
+    /// <summary>
     /// Returns all no-show signups for a user with <c>Shift.Rota.EventSettings</c>.
     /// Ordered by <c>ReviewedAt</c> descending. Read-only. Caller resolves
     /// reviewer display fields via <c>IUserService.GetByIdsAsync</c> and the

--- a/src/Humans.Application/Interfaces/Shifts/IRotaCoordinatorMessageService.cs
+++ b/src/Humans.Application/Interfaces/Shifts/IRotaCoordinatorMessageService.cs
@@ -1,0 +1,54 @@
+using Humans.Application.Architecture;
+
+namespace Humans.Application.Interfaces.Shifts;
+
+/// <summary>
+/// Orchestrator for the "Email a rota" coordinator action: enumerates current
+/// (Pending/Confirmed) signups on a rota, groups them by user, and queues one
+/// personalised email per recipient through <c>IEmailService</c>.
+/// </summary>
+/// <remarks>
+/// One method, one responsibility. Lives separate from
+/// <c>IShiftSignupService</c> / <c>IShiftManagementService</c> because the
+/// shape — fan-out enqueue across the Email and Users sections — does not
+/// belong on either existing shift surface.
+/// </remarks>
+public interface IRotaCoordinatorMessageService : IApplicationService
+{
+    /// <summary>
+    /// Queues one personalised email per recipient on the given rota.
+    /// Recipients = distinct users with a Pending or Confirmed signup on any
+    /// shift in the rota. Each email body contains the sender's free-text
+    /// <paramref name="messageText"/> plus the recipient's own chronologically
+    /// ordered shift list on this rota.
+    /// </summary>
+    /// <param name="rotaId">Rota whose signups receive the message.</param>
+    /// <param name="senderUserId">Coordinator sending the message. Used for
+    /// audit attribution and the Reply-To header.</param>
+    /// <param name="messageText">Free-text body composed by the coordinator.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Outcome with recipient count and rota name for the
+    /// coordinator-facing success message; failure shape on misconfiguration
+    /// (rota missing, no active event, etc.).</returns>
+    Task<RotaMessageDispatchResult> SendRotaMessageAsync(
+        Guid rotaId,
+        Guid senderUserId,
+        string messageText,
+        CancellationToken ct = default);
+}
+
+/// <summary>
+/// Outcome of <see cref="IRotaCoordinatorMessageService.SendRotaMessageAsync"/>.
+/// </summary>
+public sealed record RotaMessageDispatchResult(
+    bool Succeeded,
+    int RecipientCount,
+    string? RotaName,
+    string? Error)
+{
+    public static RotaMessageDispatchResult Success(int recipientCount, string rotaName) =>
+        new(true, recipientCount, rotaName, null);
+
+    public static RotaMessageDispatchResult Failure(string error) =>
+        new(false, 0, null, error);
+}

--- a/src/Humans.Application/Services/Email/OutboxEmailService.cs
+++ b/src/Humans.Application/Services/Email/OutboxEmailService.cs
@@ -259,6 +259,32 @@ public sealed class OutboxEmailService : IEmailService
     }
 
     /// <inheritdoc />
+    public async Task SendCoordinatorRotaMessageAsync(
+        CoordinatorRotaMessageRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var content = _renderer.RenderCoordinatorRotaMessage(
+            request.RecipientName,
+            request.SenderName,
+            request.SenderEmail,
+            request.RotaName,
+            request.MessageText,
+            request.ShiftLines,
+            request.Culture);
+
+        await EnqueueAsync(
+            request.RecipientEmail,
+            request.RecipientName,
+            content,
+            "coordinator_rota_message",
+            cancellationToken,
+            replyTo: request.SenderEmail,
+            category: MessageCategory.VolunteerUpdates);
+    }
+
+    /// <inheritdoc />
     public async Task SendMagicLinkLoginAsync(
         string toEmail,
         string displayName,

--- a/src/Humans.Application/Services/Shifts/RotaCoordinatorMessageService.cs
+++ b/src/Humans.Application/Services/Shifts/RotaCoordinatorMessageService.cs
@@ -1,0 +1,177 @@
+using System.Globalization;
+using Humans.Application.Interfaces.AuditLog;
+using Humans.Application.Interfaces.Email;
+using Humans.Application.Interfaces.Repositories;
+using Humans.Application.Interfaces.Shifts;
+using Humans.Application.Interfaces.Users;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using Microsoft.Extensions.Logging;
+using NodaTime;
+using NodaTime.Text;
+
+namespace Humans.Application.Services.Shifts;
+
+/// <summary>
+/// Application-layer implementation of <see cref="IRotaCoordinatorMessageService"/>.
+/// Enumerates current Pending/Confirmed signups on a rota, groups them by user,
+/// and enqueues one personalised email per recipient via <see cref="IEmailService"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Reuses the existing outbox path so logging, opt-out routing, and category
+/// suppression stay consistent with every other transactional send. The
+/// per-recipient shift list is computed here from <see cref="Shift.GetAbsoluteStart"/>
+/// in the event's timezone — same convention the rota detail page uses.
+/// </para>
+/// <para>
+/// One audit row per send (per rota dispatch). Per-recipient email rows are
+/// already auditable through the outbox table — no need to fan out audit log
+/// entries per recipient.
+/// </para>
+/// </remarks>
+public sealed class RotaCoordinatorMessageService : IRotaCoordinatorMessageService
+{
+    private readonly IShiftSignupRepository _signupRepo;
+    private readonly IShiftManagementService _shiftMgmt;
+    private readonly IUserService _userService;
+    private readonly IEmailService _emailService;
+    private readonly IAuditLogService _auditLogService;
+    private readonly ILogger<RotaCoordinatorMessageService> _logger;
+
+    public RotaCoordinatorMessageService(
+        IShiftSignupRepository signupRepo,
+        IShiftManagementService shiftMgmt,
+        IUserService userService,
+        IEmailService emailService,
+        IAuditLogService auditLogService,
+        ILogger<RotaCoordinatorMessageService> logger)
+    {
+        _signupRepo = signupRepo;
+        _shiftMgmt = shiftMgmt;
+        _userService = userService;
+        _emailService = emailService;
+        _auditLogService = auditLogService;
+        _logger = logger;
+    }
+
+    public async Task<RotaMessageDispatchResult> SendRotaMessageAsync(
+        Guid rotaId,
+        Guid senderUserId,
+        string messageText,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(messageText))
+            return RotaMessageDispatchResult.Failure("Message body is required.");
+
+        var rota = await _signupRepo.GetRotaWithShiftsAsync(rotaId, ct);
+        if (rota is null)
+            return RotaMessageDispatchResult.Failure("Rota not found.");
+
+        var eventSettings = rota.EventSettings
+            ?? throw new InvalidOperationException(
+                $"Rota {rotaId} loaded without EventSettings — repository contract broken.");
+
+        var signups = await _signupRepo.GetActiveByRotaAsync(rotaId, ct);
+        if (signups.Count == 0)
+            return RotaMessageDispatchResult.Failure("This rota has no active signups to email.");
+
+        var byUser = signups
+            .GroupBy(s => s.UserId)
+            .ToDictionary(g => g.Key, g => g.ToList());
+
+        var senderInfos = await _userService.GetUserInfosAsync([senderUserId], ct);
+        if (!senderInfos.TryGetValue(senderUserId, out var sender))
+            return RotaMessageDispatchResult.Failure("Sender not found.");
+
+        var recipientIds = byUser.Keys.ToList();
+        var recipientInfos = await _userService.GetUserInfosAsync(recipientIds, ct);
+
+        var queued = 0;
+        var skipped = 0;
+        foreach (var (userId, userSignups) in byUser)
+        {
+            if (!recipientInfos.TryGetValue(userId, out var recipient))
+            {
+                _logger.LogWarning(
+                    "Skipping rota-email recipient {UserId} on rota {RotaId}: user not found",
+                    userId, rotaId);
+                skipped++;
+                continue;
+            }
+
+            var email = recipient.Email;
+            if (string.IsNullOrWhiteSpace(email))
+            {
+                _logger.LogWarning(
+                    "Skipping rota-email recipient {UserId} on rota {RotaId}: no email address",
+                    userId, rotaId);
+                skipped++;
+                continue;
+            }
+
+            var shiftLines = BuildShiftLines(userSignups, eventSettings);
+
+            var request = new CoordinatorRotaMessageRequest(
+                RecipientEmail: email,
+                RecipientName: recipient.EmailGreetingName,
+                SenderName: sender.EmailGreetingName,
+                SenderEmail: sender.Email,
+                RotaName: rota.Name,
+                MessageText: messageText,
+                ShiftLines: shiftLines,
+                Culture: recipient.PreferredLanguage);
+
+            await _emailService.SendCoordinatorRotaMessageAsync(request, ct);
+            queued++;
+        }
+
+        await _auditLogService.LogAsync(
+            AuditAction.CoordinatorRotaMessageSent,
+            nameof(Rota), rota.Id,
+            $"Sent rota message '{Truncate(messageText, 120)}' to {queued} recipient(s) on '{rota.Name}'"
+                + (skipped > 0 ? $" ({skipped} skipped: no email or missing user)" : string.Empty),
+            senderUserId);
+
+        return RotaMessageDispatchResult.Success(queued, rota.Name);
+    }
+
+    /// <summary>
+    /// Builds a single recipient's chronologically ordered shift label list.
+    /// Format: <c>"ddd MMMM d"</c> for all-day, <c>"ddd MMMM d @ HH:mm"</c> for
+    /// time-slotted. Uses the event's timezone, matching the rota page convention.
+    /// </summary>
+    private static IReadOnlyList<string> BuildShiftLines(
+        IReadOnlyList<ShiftSignup> userSignups,
+        EventSettings eventSettings)
+    {
+        var tz = DateTimeZoneProviders.Tzdb[eventSettings.TimeZoneId];
+        // Shift may be null when the projection is partial; the repo includes Shift so this is defensive only.
+        return userSignups
+            .Where(s => s.Shift is not null)
+            .Select(s => new
+            {
+                s.Shift.IsAllDay,
+                ZonedStart = s.Shift.GetAbsoluteStart(eventSettings).InZone(tz)
+            })
+            .OrderBy(x => x.ZonedStart.ToInstant())
+            .Select(x => FormatShiftLine(x.ZonedStart, x.IsAllDay))
+            .ToList();
+    }
+
+    private static string FormatShiftLine(ZonedDateTime zoned, bool isAllDay)
+    {
+        var local = zoned.LocalDateTime;
+        // Invariant-culture day-and-month so the email body has a stable, parseable shape;
+        // recipient-locale formatting would require per-recipient pattern selection and
+        // doesn't materially help operational legibility (these messages are short ops notices).
+        var datePattern = LocalDateTimePattern.CreateWithInvariantCulture("ddd MMMM d");
+        var timePattern = LocalDateTimePattern.CreateWithInvariantCulture("HH:mm");
+        return isAllDay
+            ? datePattern.Format(local)
+            : $"{datePattern.Format(local)} @ {timePattern.Format(local)}";
+    }
+
+    private static string Truncate(string text, int max) =>
+        text.Length <= max ? text : text[..max] + "…";
+}

--- a/src/Humans.Application/Services/Shifts/RotaCoordinatorMessageService.cs
+++ b/src/Humans.Application/Services/Shifts/RotaCoordinatorMessageService.cs
@@ -1,4 +1,3 @@
-using System.Globalization;
 using Humans.Application.Interfaces.AuditLog;
 using Humans.Application.Interfaces.Email;
 using Humans.Application.Interfaces.Repositories;
@@ -33,7 +32,6 @@ namespace Humans.Application.Services.Shifts;
 public sealed class RotaCoordinatorMessageService : IRotaCoordinatorMessageService
 {
     private readonly IShiftSignupRepository _signupRepo;
-    private readonly IShiftManagementService _shiftMgmt;
     private readonly IUserService _userService;
     private readonly IEmailService _emailService;
     private readonly IAuditLogService _auditLogService;
@@ -41,14 +39,12 @@ public sealed class RotaCoordinatorMessageService : IRotaCoordinatorMessageServi
 
     public RotaCoordinatorMessageService(
         IShiftSignupRepository signupRepo,
-        IShiftManagementService shiftMgmt,
         IUserService userService,
         IEmailService emailService,
         IAuditLogService auditLogService,
         ILogger<RotaCoordinatorMessageService> logger)
     {
         _signupRepo = signupRepo;
-        _shiftMgmt = shiftMgmt;
         _userService = userService;
         _emailService = emailService;
         _auditLogService = auditLogService;
@@ -114,8 +110,8 @@ public sealed class RotaCoordinatorMessageService : IRotaCoordinatorMessageServi
 
             var request = new CoordinatorRotaMessageRequest(
                 RecipientEmail: email,
-                RecipientName: recipient.EmailGreetingName,
-                SenderName: sender.EmailGreetingName,
+                RecipientName: recipient.BurnerName,
+                SenderName: sender.BurnerName,
                 SenderEmail: sender.Email,
                 RotaName: rota.Name,
                 MessageText: messageText,

--- a/src/Humans.Application/Services/Shifts/RotaCoordinatorMessageService.cs
+++ b/src/Humans.Application/Services/Shifts/RotaCoordinatorMessageService.cs
@@ -142,9 +142,7 @@ public sealed class RotaCoordinatorMessageService : IRotaCoordinatorMessageServi
         EventSettings eventSettings)
     {
         var tz = DateTimeZoneProviders.Tzdb[eventSettings.TimeZoneId];
-        // Shift may be null when the projection is partial; the repo includes Shift so this is defensive only.
         return userSignups
-            .Where(s => s.Shift is not null)
             .Select(s => new
             {
                 s.Shift.IsAllDay,

--- a/src/Humans.Domain/Enums/AuditAction.cs
+++ b/src/Humans.Domain/Enums/AuditAction.cs
@@ -173,4 +173,5 @@ public enum AuditAction
     ContainerPlacementSaved,
     ContainerPlacementCleared,
     ContainerPlacementNotesUpdated,
+    CoordinatorRotaMessageSent,
 }

--- a/src/Humans.Infrastructure/Repositories/Shifts/ShiftSignupRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Shifts/ShiftSignupRepository.cs
@@ -122,6 +122,15 @@ public sealed class ShiftSignupRepository : IShiftSignupRepository
             .OrderBy(d => d.CreatedAt)
             .ToListAsync(ct);
 
+    public async Task<IReadOnlyList<ShiftSignup>> GetActiveByRotaAsync(
+        Guid rotaId, CancellationToken ct = default) =>
+        await _dbContext.ShiftSignups
+            .AsNoTracking()
+            .Include(d => d.Shift)
+            .Where(d => d.Shift.RotaId == rotaId &&
+                        (d.Status == SignupStatus.Pending || d.Status == SignupStatus.Confirmed))
+            .ToListAsync(ct);
+
     public async Task<IReadOnlyList<ShiftSignup>> GetNoShowHistoryAsync(
         Guid userId, CancellationToken ct = default) =>
         await _dbContext.ShiftSignups

--- a/src/Humans.Infrastructure/Services/EmailRenderer.cs
+++ b/src/Humans.Infrastructure/Services/EmailRenderer.cs
@@ -177,6 +177,39 @@ public class EmailRenderer : IEmailRenderer
                 Lf("Email_FacilitatedMessage_Body", HtmlEncode(recipientName), HtmlEncode(senderName), sanitizedMessage, contactInfoHtml));
         });
 
+    public EmailContent RenderCoordinatorRotaMessage(
+        string recipientName,
+        string senderName,
+        string? senderEmail,
+        string rotaName,
+        string messageText,
+        IReadOnlyList<string> shiftLines,
+        string? culture = null)
+        => RenderLocalized(culture, () =>
+        {
+            ArgumentNullException.ThrowIfNull(shiftLines);
+
+            var sanitizedMessage = HtmlEncode(messageText).Replace("\n", "<br />", StringComparison.Ordinal);
+
+            var shiftListHtml = shiftLines.Count == 0
+                ? $"<p><em>{HtmlEncode(L("Email_CoordinatorRotaMessage_NoShifts"))}</em></p>"
+                : "<ul>" + string.Concat(shiftLines.Select(line => $"<li>{HtmlEncode(line)}</li>")) + "</ul>";
+
+            var senderLine = !string.IsNullOrEmpty(senderEmail)
+                ? $"<p><strong>{HtmlEncode(senderName)}</strong> &mdash; <a href=\"mailto:{HtmlEncode(senderEmail)}\">{HtmlEncode(senderEmail)}</a></p>"
+                : $"<p><strong>{HtmlEncode(senderName)}</strong></p>";
+
+            return new EmailContent(
+                Lf("Email_CoordinatorRotaMessage_Subject", HtmlEncode(rotaName)),
+                Lf("Email_CoordinatorRotaMessage_Body",
+                    HtmlEncode(recipientName),
+                    HtmlEncode(senderName),
+                    HtmlEncode(rotaName),
+                    sanitizedMessage,
+                    shiftListHtml,
+                    senderLine));
+        });
+
     public EmailContent RenderMagicLinkLogin(string displayName, string magicLinkUrl, string? culture = null)
         => RenderLocalized(culture, () => new EmailContent(
             L("Email_MagicLinkLogin_Subject"),

--- a/src/Humans.Infrastructure/Services/SmtpEmailService.cs
+++ b/src/Humans.Infrastructure/Services/SmtpEmailService.cs
@@ -241,6 +241,18 @@ public class SmtpEmailService : IEmailService
         _metrics.RecordEmailSent("facilitated_message");
     }
 
+    public async Task SendCoordinatorRotaMessageAsync(
+        CoordinatorRotaMessageRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        var content = _renderer.RenderCoordinatorRotaMessage(
+            request.RecipientName, request.SenderName, request.SenderEmail,
+            request.RotaName, request.MessageText, request.ShiftLines, request.Culture);
+        await SendEmailAsync(request.RecipientEmail, content.Subject, content.HtmlBody, cancellationToken, request.SenderEmail);
+        _metrics.RecordEmailSent("coordinator_rota_message");
+    }
+
     public async Task SendMagicLinkLoginAsync(
         string toEmail, string displayName, string magicLinkUrl,
         string? culture = null, CancellationToken ct = default)

--- a/src/Humans.Infrastructure/Services/StubEmailService.cs
+++ b/src/Humans.Infrastructure/Services/StubEmailService.cs
@@ -217,6 +217,18 @@ public class StubEmailService : IEmailService
         return Task.CompletedTask;
     }
 
+    public Task SendCoordinatorRotaMessageAsync(
+        CoordinatorRotaMessageRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        _logger.LogInformation(
+            "[STUB] Would send coordinator rota message to {Email} ({RecipientName}) from {SenderName} for rota {RotaName} ({ShiftCount} shifts) [Culture: {Culture}]",
+            request.RecipientEmail, request.RecipientName, request.SenderName, request.RotaName,
+            request.ShiftLines.Count, request.Culture);
+        return Task.CompletedTask;
+    }
+
     public Task SendMagicLinkLoginAsync(
         string toEmail, string displayName, string magicLinkUrl,
         string? culture = null, CancellationToken ct = default)

--- a/src/Humans.Web/Controllers/ShiftAdminController.cs
+++ b/src/Humans.Web/Controllers/ShiftAdminController.cs
@@ -1,6 +1,7 @@
 using Humans.Application.Interfaces.Shifts;
 using Humans.Application.Interfaces.Teams;
 using Humans.Domain.Entities;
+using Humans.Domain.Enums;
 using Humans.Web.Authorization;
 using Humans.Web.Extensions;
 using Humans.Web.Helpers;
@@ -366,10 +367,13 @@ public class ShiftAdminController : HumansTeamControllerBase
     }
 
     // Issue nobodies-collective/Humans#732 — coordinator "email a rota" action.
+    // Management scope (Admin + VolunteerCoordinator + dept coordinator); matches
+    // the existing rota CRUD authorization gate and the "coordinator role" wording
+    // in the spec. Explicitly excludes NoInfoAdmin per CanManageDepartmentAsync.
     [HttpGet("Rotas/{rotaId}/Email")]
     public async Task<IActionResult> EmailRota(string slug, Guid rotaId)
     {
-        var (teamError, _, team) = await ResolveDepartmentApprovalAsync(slug);
+        var (teamError, _, team) = await ResolveDepartmentManagementAsync(slug);
         if (teamError is not null) return teamError;
 
         var rota = await GetRotaForTeamAsync(rotaId, team.Id);
@@ -392,7 +396,7 @@ public class ShiftAdminController : HumansTeamControllerBase
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> EmailRota(string slug, Guid rotaId, EmailRotaViewModel model)
     {
-        var (teamError, user, team) = await ResolveDepartmentApprovalAsync(slug);
+        var (teamError, user, team) = await ResolveDepartmentManagementAsync(slug);
         if (teamError is not null) return teamError;
 
         var rota = await GetRotaForTeamAsync(rotaId, team.Id);

--- a/src/Humans.Web/Controllers/ShiftAdminController.cs
+++ b/src/Humans.Web/Controllers/ShiftAdminController.cs
@@ -30,6 +30,8 @@ public class ShiftAdminController : HumansTeamControllerBase
     private readonly ShiftAdminPageBuilder _pageBuilder;
     private readonly ILogger<ShiftAdminController> _logger;
 
+    private readonly IRotaCoordinatorMessageService _rotaMessenger;
+
     public ShiftAdminController(
         ITeamService teamService,
         IShiftManagementService shiftMgmt,
@@ -41,6 +43,7 @@ public class ShiftAdminController : HumansTeamControllerBase
         IAuthorizationService authorizationService,
         IClock clock,
         ShiftAdminPageBuilder pageBuilder,
+        IRotaCoordinatorMessageService rotaMessenger,
         ILogger<ShiftAdminController> logger)
         : base(userService, teamService, authorizationService)
     {
@@ -52,6 +55,7 @@ public class ShiftAdminController : HumansTeamControllerBase
         _userManager = userManager;
         _clock = clock;
         _pageBuilder = pageBuilder;
+        _rotaMessenger = rotaMessenger;
         _logger = logger;
     }
 
@@ -359,6 +363,80 @@ public class ShiftAdminController : HumansTeamControllerBase
         }
 
         return RedirectToAction(nameof(Index), new { slug });
+    }
+
+    // Issue nobodies-collective/Humans#732 — coordinator "email a rota" action.
+    [HttpGet("Rotas/{rotaId}/Email")]
+    public async Task<IActionResult> EmailRota(string slug, Guid rotaId)
+    {
+        var (teamError, _, team) = await ResolveDepartmentApprovalAsync(slug);
+        if (teamError is not null) return teamError;
+
+        var rota = await GetRotaForTeamAsync(rotaId, team.Id);
+        if (rota is null) return NotFound();
+
+        var recipientNames = await GetRotaRecipientNamesAsync(rota.Id);
+
+        var vm = new EmailRotaViewModel
+        {
+            RotaId = rota.Id,
+            RotaName = rota.Name,
+            TeamSlug = slug,
+            RecipientCount = recipientNames.Count,
+            RecipientNames = recipientNames
+        };
+        return View(vm);
+    }
+
+    [HttpPost("Rotas/{rotaId}/Email")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> EmailRota(string slug, Guid rotaId, EmailRotaViewModel model)
+    {
+        var (teamError, user, team) = await ResolveDepartmentApprovalAsync(slug);
+        if (teamError is not null) return teamError;
+
+        var rota = await GetRotaForTeamAsync(rotaId, team.Id);
+        if (rota is null) return NotFound();
+
+        // Repopulate display fields before any return-with-error path.
+        var recipientNames = await GetRotaRecipientNamesAsync(rota.Id);
+        model.RotaId = rota.Id;
+        model.RotaName = rota.Name;
+        model.TeamSlug = slug;
+        model.RecipientCount = recipientNames.Count;
+        model.RecipientNames = recipientNames;
+
+        if (!ModelState.IsValid)
+            return View(model);
+
+        var result = await _rotaMessenger.SendRotaMessageAsync(rota.Id, user.Id, model.Message);
+        if (!result.Succeeded)
+        {
+            ModelState.AddModelError(string.Empty, result.Error ?? "Failed to queue rota emails.");
+            return View(model);
+        }
+
+        SetSuccess($"Queued {result.RecipientCount} email(s) to recipients on rota '{result.RotaName}'.");
+        return Redirect(Url.Action(nameof(Index), new { slug }) + "#rota-" + rota.Id.ToString("N"));
+    }
+
+    private async Task<IReadOnlyList<string>> GetRotaRecipientNamesAsync(Guid rotaId)
+    {
+        var view = await _shiftView.GetRotaAsync(rotaId);
+        var userIds = view.Signups
+            .Where(s => s.Status is SignupStatus.Pending or SignupStatus.Confirmed)
+            .Select(s => s.UserId)
+            .Distinct()
+            .ToList();
+        if (userIds.Count == 0) return [];
+
+        var infos = await UserService.GetUserInfosAsync(userIds);
+        return userIds
+            .Select(id => infos.TryGetValue(id, out var u) ? u.BurnerName : null)
+            .Where(n => !string.IsNullOrWhiteSpace(n))
+            .Select(n => n!)
+            .OrderBy(n => n, StringComparer.OrdinalIgnoreCase)
+            .ToList();
     }
 
     [HttpPost("Rotas/{rotaId}/Delete")]

--- a/src/Humans.Web/Extensions/Sections/ShiftsSectionExtensions.cs
+++ b/src/Humans.Web/Extensions/Sections/ShiftsSectionExtensions.cs
@@ -80,6 +80,13 @@ internal static class ShiftsSectionExtensions
         services.AddScoped<ShiftAdminPageBuilder>();
         services.AddScoped<ShiftDashboardPageBuilder>();
 
+        // Issue nobodies-collective/Humans#732 — coordinator "email a rota" action.
+        // Pure orchestrator: enumerates active signups on a rota and fans out one
+        // outbox email per recipient via IEmailService. Scoped so it can pull the
+        // request-scoped IShiftSignupRepository + IUserService.
+        services.AddScoped<IRotaCoordinatorMessageService,
+            Humans.Application.Services.Shifts.RotaCoordinatorMessageService>();
+
         return services;
     }
 }

--- a/src/Humans.Web/Models/Shifts/EmailRotaViewModel.cs
+++ b/src/Humans.Web/Models/Shifts/EmailRotaViewModel.cs
@@ -1,0 +1,20 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Humans.Web.Models.Shifts;
+
+/// <summary>
+/// Compose-form model for the coordinator "email a rota" action
+/// (issue nobodies-collective/Humans#732).
+/// </summary>
+public sealed class EmailRotaViewModel
+{
+    public Guid RotaId { get; set; }
+    public string RotaName { get; set; } = string.Empty;
+    public string TeamSlug { get; set; } = string.Empty;
+    public int RecipientCount { get; set; }
+    public IReadOnlyList<string> RecipientNames { get; set; } = [];
+
+    [Required]
+    [StringLength(4000, MinimumLength = 1)]
+    public string Message { get; set; } = string.Empty;
+}

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -2272,5 +2272,19 @@
 
   <data name="VolTrack_AuditAction_CampSetupSet" xml:space="preserve"><value>Camp set-up date set</value></data>
   <data name="VolTrack_AuditAction_CampSetupCleared" xml:space="preserve"><value>Camp set-up date cleared</value></data>
+  <!-- Coordinator Rota Message ("Email a rota") -->
+  <data name="Email_CoordinatorRotaMessage_Subject" xml:space="preserve"><value>A message about your shifts on {0}</value><comment>{0} = rota name (HTML-encoded)</comment></data>
+  <data name="Email_CoordinatorRotaMessage_Body" xml:space="preserve"><value>&lt;p&gt;Dear {0},&lt;/p&gt;&lt;p&gt;A message from the coordinator of &lt;strong&gt;{2}&lt;/strong&gt;:&lt;/p&gt;&lt;hr /&gt;&lt;p&gt;{3}&lt;/p&gt;&lt;hr /&gt;&lt;p&gt;FYI, your shifts on this rota are:&lt;/p&gt;{4}&lt;p&gt;Thank you,&lt;/p&gt;{5}</value><comment>{0}=recipient name, {1}=sender name, {2}=rota name, {3}=message body, {4}=shift list HTML, {5}=sender contact block HTML</comment></data>
+  <data name="Email_CoordinatorRotaMessage_NoShifts" xml:space="preserve"><value>(no shifts on this rota yet)</value></data>
+  <data name="EmailRota_Title" xml:space="preserve"><value>Email rota: {0}</value><comment>{0} = rota name</comment></data>
+  <data name="EmailRota_Heading" xml:space="preserve"><value>Email everyone on rota: {0}</value><comment>{0} = rota name</comment></data>
+  <data name="EmailRota_RecipientsHeading" xml:space="preserve"><value>Recipients ({0})</value><comment>{0} = recipient count</comment></data>
+  <data name="EmailRota_NoRecipients" xml:space="preserve"><value>No one is signed up to this rota yet.</value></data>
+  <data name="EmailRota_MessageLabel" xml:space="preserve"><value>Your message</value></data>
+  <data name="EmailRota_MessageHelp" xml:space="preserve"><value>Plain text only. Each recipient will see this body plus their own shift list on this rota.</value></data>
+  <data name="EmailRota_Button" xml:space="preserve"><value>Email a rota</value></data>
+  <data name="EmailRota_Send" xml:space="preserve"><value>Send to {0} recipient(s)</value><comment>{0} = recipient count</comment></data>
+  <data name="EmailRota_Success" xml:space="preserve"><value>Queued {0} email(s) to recipients on rota '{1}'.</value><comment>{0} = recipient count, {1} = rota name</comment></data>
+  <data name="EmailRota_NoActiveSignups" xml:space="preserve"><value>This rota has no active signups to email.</value></data>
 
 </root>

--- a/src/Humans.Web/Resources/SharedResource.resx
+++ b/src/Humans.Web/Resources/SharedResource.resx
@@ -2277,6 +2277,7 @@
   <data name="Email_CoordinatorRotaMessage_Body" xml:space="preserve"><value>&lt;p&gt;Dear {0},&lt;/p&gt;&lt;p&gt;A message from the coordinator of &lt;strong&gt;{2}&lt;/strong&gt;:&lt;/p&gt;&lt;hr /&gt;&lt;p&gt;{3}&lt;/p&gt;&lt;hr /&gt;&lt;p&gt;FYI, your shifts on this rota are:&lt;/p&gt;{4}&lt;p&gt;Thank you,&lt;/p&gt;{5}</value><comment>{0}=recipient name, {1}=sender name, {2}=rota name, {3}=message body, {4}=shift list HTML, {5}=sender contact block HTML</comment></data>
   <data name="Email_CoordinatorRotaMessage_NoShifts" xml:space="preserve"><value>(no shifts on this rota yet)</value></data>
   <data name="EmailRota_Title" xml:space="preserve"><value>Email rota: {0}</value><comment>{0} = rota name</comment></data>
+  <data name="EmailRota_Breadcrumb" xml:space="preserve"><value>Email rota</value></data>
   <data name="EmailRota_Heading" xml:space="preserve"><value>Email everyone on rota: {0}</value><comment>{0} = rota name</comment></data>
   <data name="EmailRota_RecipientsHeading" xml:space="preserve"><value>Recipients ({0})</value><comment>{0} = recipient count</comment></data>
   <data name="EmailRota_NoRecipients" xml:space="preserve"><value>No one is signed up to this rota yet.</value></data>

--- a/src/Humans.Web/Views/ShiftAdmin/EmailRota.cshtml
+++ b/src/Humans.Web/Views/ShiftAdmin/EmailRota.cshtml
@@ -1,0 +1,72 @@
+@model Humans.Web.Models.Shifts.EmailRotaViewModel
+@{
+    ViewData["Title"] = string.Format(Localizer["EmailRota_Title"].Value, Model.RotaName);
+}
+
+<div class="container py-4">
+    <nav aria-label="breadcrumb">
+        <ol class="breadcrumb">
+            <li class="breadcrumb-item"><a asp-controller="Team" asp-action="Index">@Localizer["Teams_Title"]</a></li>
+            <li class="breadcrumb-item"><a asp-controller="ShiftAdmin" asp-action="Index" asp-route-slug="@Model.TeamSlug">@Localizer["Shifts_Title"]</a></li>
+            <li class="breadcrumb-item active" aria-current="page">@Localizer["EmailRota_Breadcrumb"]</li>
+        </ol>
+    </nav>
+
+    <h2>@string.Format(Localizer["EmailRota_Heading"].Value, Model.RotaName)</h2>
+
+    <vc:temp-data-alerts />
+
+    <div class="row mt-3">
+        <div class="col-lg-8">
+            <div class="card">
+                <div class="card-body">
+                    <form asp-action="EmailRota" asp-route-slug="@Model.TeamSlug" asp-route-rotaId="@Model.RotaId" method="post">
+                        @Html.AntiForgeryToken()
+                        <input type="hidden" asp-for="RotaId" />
+                        <input type="hidden" asp-for="RotaName" />
+                        <input type="hidden" asp-for="TeamSlug" />
+
+                        <div asp-validation-summary="ModelOnly" class="alert alert-danger"></div>
+
+                        <div class="mb-3">
+                            <label asp-for="Message" class="form-label">@Localizer["EmailRota_MessageLabel"]</label>
+                            <textarea asp-for="Message" class="form-control" rows="10" maxlength="4000" required></textarea>
+                            <span asp-validation-for="Message" class="text-danger"></span>
+                            <div class="form-text">@Localizer["EmailRota_MessageHelp"]</div>
+                        </div>
+
+                        <div class="d-flex gap-2">
+                            <button type="submit" class="btn btn-primary" @(Model.RecipientCount == 0 ? "disabled" : null)>
+                                @string.Format(Localizer["EmailRota_Send"].Value, Model.RecipientCount)
+                            </button>
+                            <a asp-action="Index" asp-route-slug="@Model.TeamSlug" class="btn btn-outline-secondary">@Localizer["Common_Cancel"]</a>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+
+        <div class="col-lg-4">
+            <div class="card">
+                <div class="card-header">
+                    <h5 class="mb-0">@string.Format(Localizer["EmailRota_RecipientsHeading"].Value, Model.RecipientCount)</h5>
+                </div>
+                <div class="card-body">
+                    @if (Model.RecipientCount == 0)
+                    {
+                        <p class="text-muted mb-0">@Localizer["EmailRota_NoRecipients"]</p>
+                    }
+                    else
+                    {
+                        <ul class="list-unstyled mb-0 small">
+                            @foreach (var name in Model.RecipientNames)
+                            {
+                                <li>@name</li>
+                            }
+                        </ul>
+                    }
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/Humans.Web/Views/ShiftAdmin/Index.cshtml
+++ b/src/Humans.Web/Views/ShiftAdmin/Index.cshtml
@@ -205,6 +205,14 @@
                             }
                         </form>
                         <button class="btn btn-sm btn-outline-primary" type="button" data-bs-toggle="collapse" data-bs-target="#edit-rota-@rota.Id.ToString("N")">Edit</button>
+                        @* Issue nobodies-collective/Humans#732 — coordinator "Email a rota" action. *@
+                        <a class="btn btn-sm btn-outline-primary"
+                           asp-action="EmailRota"
+                           asp-route-slug="@Model.Department.Slug"
+                           asp-route-rotaId="@rota.Id"
+                           title="@Localizer["EmailRota_Button"]">
+                            <i class="fa-solid fa-envelope"></i>
+                        </a>
                         @if (Model.AllDepartments.Count > 0)
                         {
                             <button class="btn btn-sm btn-outline-secondary" type="button" data-bs-toggle="collapse" data-bs-target="#move-rota-@rota.Id.ToString("N")" title="Move to another team">

--- a/tests/Humans.Application.Tests/Services/Shifts/RotaCoordinatorMessageServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Shifts/RotaCoordinatorMessageServiceTests.cs
@@ -1,0 +1,334 @@
+using AwesomeAssertions;
+using Humans.Application.Interfaces.AuditLog;
+using Humans.Application.Interfaces.Email;
+using Humans.Application.Interfaces.Repositories;
+using Humans.Application.Interfaces.Users;
+using Humans.Application.Services.Shifts;
+using Humans.Application.Tests.Infrastructure;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using Microsoft.Extensions.Logging.Abstractions;
+using NodaTime;
+using NSubstitute;
+
+namespace Humans.Application.Tests.Services.Shifts;
+
+/// <summary>
+/// Orchestration tests for <see cref="RotaCoordinatorMessageService"/>:
+/// recipient fan-out, per-recipient shift list, audit log, and the failure shapes
+/// (missing message body, missing rota, missing signups). Issue
+/// nobodies-collective/Humans#732.
+/// </summary>
+public sealed class RotaCoordinatorMessageServiceTests
+{
+    private readonly IShiftSignupRepository _signupRepo = Substitute.For<IShiftSignupRepository>();
+    private readonly IUserService _userService = Substitute.For<IUserService>();
+    private readonly IEmailService _emailService = Substitute.For<IEmailService>();
+    private readonly IAuditLogService _auditLog = Substitute.For<IAuditLogService>();
+
+    private RotaCoordinatorMessageService CreateSut() =>
+        new(_signupRepo, _userService, _emailService, _auditLog,
+            NullLogger<RotaCoordinatorMessageService>.Instance);
+
+    [HumansFact]
+    public async Task SendRotaMessageAsync_RejectsBlankMessage()
+    {
+        var result = await CreateSut().SendRotaMessageAsync(Guid.NewGuid(), Guid.NewGuid(), "   ");
+
+        result.Succeeded.Should().BeFalse();
+        result.Error.Should().Contain("required", "blank body must surface a clear error");
+        await _emailService.DidNotReceiveWithAnyArgs().SendCoordinatorRotaMessageAsync(default!);
+        await _auditLog.DidNotReceiveWithAnyArgs().LogAsync(
+            default, default!, default, default!, default(Guid));
+    }
+
+    [HumansFact]
+    public async Task SendRotaMessageAsync_ReturnsFailure_WhenRotaMissing()
+    {
+        var rotaId = Guid.NewGuid();
+        _signupRepo.GetRotaWithShiftsAsync(rotaId, Arg.Any<CancellationToken>())
+            .Returns((Rota?)null);
+
+        var result = await CreateSut().SendRotaMessageAsync(rotaId, Guid.NewGuid(), "hello");
+
+        result.Succeeded.Should().BeFalse();
+        result.Error.Should().Contain("not found");
+        await _emailService.DidNotReceiveWithAnyArgs().SendCoordinatorRotaMessageAsync(default!);
+    }
+
+    [HumansFact]
+    public async Task SendRotaMessageAsync_ReturnsFailure_WhenNoActiveSignups()
+    {
+        var rota = MakeRota(out var eventSettings);
+        _signupRepo.GetRotaWithShiftsAsync(rota.Id, Arg.Any<CancellationToken>()).Returns(rota);
+        _signupRepo.GetActiveByRotaAsync(rota.Id, Arg.Any<CancellationToken>())
+            .Returns(Array.Empty<ShiftSignup>());
+
+        var result = await CreateSut().SendRotaMessageAsync(rota.Id, Guid.NewGuid(), "hello");
+
+        result.Succeeded.Should().BeFalse();
+        result.Error.Should().Contain("no active signups");
+    }
+
+    [HumansFact]
+    public async Task SendRotaMessageAsync_FansOut_OneEmailPerDistinctUser()
+    {
+        var rota = MakeRota(out var es);
+        _signupRepo.GetRotaWithShiftsAsync(rota.Id, Arg.Any<CancellationToken>()).Returns(rota);
+
+        var userA = Guid.NewGuid();
+        var userB = Guid.NewGuid();
+        var sender = Guid.NewGuid();
+
+        var shift1 = MakeShift(rota.Id, dayOffset: 1, startHour: 10);
+        var shift2 = MakeShift(rota.Id, dayOffset: 2, startHour: 14);
+
+        // userA has two signups (same shift twice + another shift), userB has one.
+        _signupRepo.GetActiveByRotaAsync(rota.Id, Arg.Any<CancellationToken>())
+            .Returns(new ShiftSignup[]
+            {
+                MakeSignup(userA, shift1),
+                MakeSignup(userA, shift2),
+                MakeSignup(userB, shift1),
+            });
+
+        StubUsers(sender, userA, userB);
+
+        await CreateSut().SendRotaMessageAsync(rota.Id, sender, "hello team");
+
+        await _emailService.Received(1).SendCoordinatorRotaMessageAsync(
+            Arg.Is<CoordinatorRotaMessageRequest>(r => r.RecipientEmail == "a@example.com"),
+            Arg.Any<CancellationToken>());
+        await _emailService.Received(1).SendCoordinatorRotaMessageAsync(
+            Arg.Is<CoordinatorRotaMessageRequest>(r => r.RecipientEmail == "b@example.com"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task SendRotaMessageAsync_PersonalisesShiftListPerRecipient()
+    {
+        var rota = MakeRota(out var es);
+        _signupRepo.GetRotaWithShiftsAsync(rota.Id, Arg.Any<CancellationToken>()).Returns(rota);
+
+        var userA = Guid.NewGuid();
+        var userB = Guid.NewGuid();
+        var sender = Guid.NewGuid();
+
+        var earlyShift = MakeShift(rota.Id, dayOffset: 1, startHour: 9);
+        var lateShift = MakeShift(rota.Id, dayOffset: 3, startHour: 18);
+        var midShift = MakeShift(rota.Id, dayOffset: 2, startHour: 12);
+
+        _signupRepo.GetActiveByRotaAsync(rota.Id, Arg.Any<CancellationToken>())
+            .Returns(new ShiftSignup[]
+            {
+                MakeSignup(userA, lateShift),  // userA: late + early (should sort)
+                MakeSignup(userA, earlyShift),
+                MakeSignup(userB, midShift),   // userB: only midShift
+            });
+
+        StubUsers(sender, userA, userB);
+
+        CoordinatorRotaMessageRequest? captured_A = null;
+        CoordinatorRotaMessageRequest? captured_B = null;
+        await _emailService.SendCoordinatorRotaMessageAsync(
+            Arg.Do<CoordinatorRotaMessageRequest>(r =>
+            {
+                if (string.Equals(r.RecipientEmail, "a@example.com", StringComparison.Ordinal)) captured_A = r;
+                else if (string.Equals(r.RecipientEmail, "b@example.com", StringComparison.Ordinal)) captured_B = r;
+            }),
+            Arg.Any<CancellationToken>());
+
+        await CreateSut().SendRotaMessageAsync(rota.Id, sender, "hello");
+
+        captured_A.Should().NotBeNull();
+        captured_A!.ShiftLines.Should().HaveCount(2, "userA has 2 distinct shifts on this rota");
+        captured_A.ShiftLines[0].Should().Contain("09:00", "earlier shift must come first");
+        captured_A.ShiftLines[1].Should().Contain("18:00");
+
+        captured_B.Should().NotBeNull();
+        captured_B!.ShiftLines.Should().ContainSingle("userB has only one shift on this rota");
+        captured_B.ShiftLines[0].Should().Contain("12:00");
+    }
+
+    [HumansFact]
+    public async Task SendRotaMessageAsync_WritesOneAuditEntry_WithSenderActor()
+    {
+        var rota = MakeRota(out _);
+        _signupRepo.GetRotaWithShiftsAsync(rota.Id, Arg.Any<CancellationToken>()).Returns(rota);
+
+        var userA = Guid.NewGuid();
+        var sender = Guid.NewGuid();
+        var shift = MakeShift(rota.Id, dayOffset: 1, startHour: 10);
+
+        _signupRepo.GetActiveByRotaAsync(rota.Id, Arg.Any<CancellationToken>())
+            .Returns(new ShiftSignup[] { MakeSignup(userA, shift) });
+
+        StubUsers(sender, userA);
+
+        var result = await CreateSut().SendRotaMessageAsync(rota.Id, sender, "schedule change");
+
+        result.Succeeded.Should().BeTrue();
+        result.RecipientCount.Should().Be(1);
+        result.RotaName.Should().Be(rota.Name);
+
+        await _auditLog.Received(1).LogAsync(
+            AuditAction.CoordinatorRotaMessageSent,
+            nameof(Rota),
+            rota.Id,
+            Arg.Is<string>(d => d.Contains("schedule change") && d.Contains(rota.Name)),
+            sender,
+            Arg.Any<Guid?>(),
+            Arg.Any<string?>());
+    }
+
+    [HumansFact]
+    public async Task SendRotaMessageAsync_SkipsRecipientWithNoEmail_DoesNotFail()
+    {
+        var rota = MakeRota(out _);
+        _signupRepo.GetRotaWithShiftsAsync(rota.Id, Arg.Any<CancellationToken>()).Returns(rota);
+
+        var withEmail = Guid.NewGuid();
+        var noEmail = Guid.NewGuid();
+        var sender = Guid.NewGuid();
+        var shift = MakeShift(rota.Id, dayOffset: 1, startHour: 10);
+
+        _signupRepo.GetActiveByRotaAsync(rota.Id, Arg.Any<CancellationToken>())
+            .Returns(new ShiftSignup[]
+            {
+                MakeSignup(withEmail, shift),
+                MakeSignup(noEmail, shift),
+            });
+
+        // sender + withEmail have addresses; noEmail's UserInfo has an empty email.
+        var dict = new Dictionary<Guid, UserInfo>
+        {
+            [sender] = UserInfoStubHelpers.MakeUserInfo(sender, displayName: "Sender"),
+            [withEmail] = MakeUserInfoWithEmail(withEmail, "with@example.com", "WithEmail"),
+            [noEmail] = UserInfoStubHelpers.MakeUserInfo(noEmail, displayName: "NoEmail"),
+        };
+        // Need to make sender resolvable too.
+        _userService.GetUserInfosAsync(Arg.Is<IReadOnlyCollection<Guid>>(c => c.Contains(sender)), Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<IReadOnlyDictionary<Guid, UserInfo>>(
+                new Dictionary<Guid, UserInfo> { [sender] = MakeUserInfoWithEmail(sender, "sender@example.com", "Sender") }));
+        _userService.GetUserInfosAsync(
+            Arg.Is<IReadOnlyCollection<Guid>>(c => c.Contains(withEmail) || c.Contains(noEmail)),
+            Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<IReadOnlyDictionary<Guid, UserInfo>>(
+                new Dictionary<Guid, UserInfo>
+                {
+                    [withEmail] = MakeUserInfoWithEmail(withEmail, "with@example.com", "WithEmail"),
+                    [noEmail] = UserInfoStubHelpers.MakeUserInfo(noEmail, displayName: "NoEmail"),
+                }));
+
+        var result = await CreateSut().SendRotaMessageAsync(rota.Id, sender, "hello");
+
+        result.Succeeded.Should().BeTrue();
+        result.RecipientCount.Should().Be(1, "only the recipient with an email is queued");
+        await _emailService.Received(1).SendCoordinatorRotaMessageAsync(
+            Arg.Any<CoordinatorRotaMessageRequest>(), Arg.Any<CancellationToken>());
+    }
+
+    private static Rota MakeRota(out EventSettings es)
+    {
+        es = new EventSettings
+        {
+            Id = Guid.NewGuid(),
+            EventName = "Test Event",
+            TimeZoneId = "UTC",
+            GateOpeningDate = new LocalDate(2026, 7, 1),
+            BuildStartOffset = -7,
+            EventEndOffset = 7,
+            StrikeEndOffset = 9,
+            IsShiftBrowsingOpen = true,
+            IsActive = true,
+            CreatedAt = Instant.FromUtc(2026, 1, 1, 0, 0),
+            UpdatedAt = Instant.FromUtc(2026, 1, 1, 0, 0),
+        };
+        var rota = new Rota
+        {
+            Id = Guid.NewGuid(),
+            EventSettingsId = es.Id,
+            TeamId = Guid.NewGuid(),
+            Name = "Test Rota",
+            Priority = ShiftPriority.Normal,
+            Policy = SignupPolicy.Public,
+            Period = RotaPeriod.Event,
+            CreatedAt = Instant.FromUtc(2026, 1, 1, 0, 0),
+            UpdatedAt = Instant.FromUtc(2026, 1, 1, 0, 0),
+            EventSettings = es,
+        };
+        return rota;
+    }
+
+    private static Shift MakeShift(Guid rotaId, int dayOffset, int startHour) => new()
+    {
+        Id = Guid.NewGuid(),
+        RotaId = rotaId,
+        DayOffset = dayOffset,
+        StartTime = new LocalTime(startHour, 0),
+        Duration = Duration.FromHours(4),
+        MinVolunteers = 1,
+        MaxVolunteers = 10,
+        CreatedAt = Instant.FromUtc(2026, 1, 1, 0, 0),
+        UpdatedAt = Instant.FromUtc(2026, 1, 1, 0, 0),
+    };
+
+    private static ShiftSignup MakeSignup(Guid userId, Shift shift) => new()
+    {
+        Id = Guid.NewGuid(),
+        UserId = userId,
+        ShiftId = shift.Id,
+        Status = SignupStatus.Confirmed,
+        Shift = shift,
+        CreatedAt = Instant.FromUtc(2026, 1, 1, 0, 0),
+        UpdatedAt = Instant.FromUtc(2026, 1, 1, 0, 0),
+    };
+
+    private static UserInfo MakeUserInfoWithEmail(Guid id, string email, string displayName)
+    {
+        var user = new User
+        {
+            Id = id,
+            DisplayName = displayName,
+            PreferredLanguage = "en",
+            Email = email,
+            EmailConfirmed = true,
+        };
+        var ue = new UserEmail
+        {
+            Id = Guid.NewGuid(),
+            UserId = id,
+            Email = email,
+            IsPrimary = true,
+            IsVerified = true,
+        };
+        return user.ToUserInfo([ue]);
+    }
+
+    /// <summary>
+    /// Stubs <see cref="IUserService.GetUserInfosAsync"/> so the sender and all
+    /// recipient ids resolve to UserInfo with letter-suffix emails (a@, b@, …).
+    /// </summary>
+    private void StubUsers(Guid sender, params Guid[] recipients)
+    {
+        var senderInfo = MakeUserInfoWithEmail(sender, "sender@example.com", "Sender");
+        var recipientInfos = new Dictionary<Guid, UserInfo>();
+        for (int i = 0; i < recipients.Length; i++)
+        {
+            var letter = (char)('a' + i);
+            recipientInfos[recipients[i]] = MakeUserInfoWithEmail(
+                recipients[i], $"{letter}@example.com", $"User{letter}");
+        }
+
+        _userService.GetUserInfosAsync(
+            Arg.Is<IReadOnlyCollection<Guid>>(c => c.Count == 1 && c.Contains(sender)),
+            Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<IReadOnlyDictionary<Guid, UserInfo>>(
+                new Dictionary<Guid, UserInfo> { [sender] = senderInfo }));
+
+        _userService.GetUserInfosAsync(
+            Arg.Is<IReadOnlyCollection<Guid>>(c => recipients.All(r => c.Contains(r))),
+            Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<IReadOnlyDictionary<Guid, UserInfo>>(recipientInfos));
+    }
+}

--- a/tests/Humans.Web.Tests/Controllers/EmailRotaViewModelTests.cs
+++ b/tests/Humans.Web.Tests/Controllers/EmailRotaViewModelTests.cs
@@ -1,0 +1,56 @@
+using System.ComponentModel.DataAnnotations;
+using AwesomeAssertions;
+using Humans.Web.Models.Shifts;
+
+namespace Humans.Web.Tests.Controllers;
+
+/// <summary>
+/// Validation coverage for <see cref="EmailRotaViewModel"/> — the compose-form
+/// model behind the coordinator "Email a rota" action
+/// (nobodies-collective/Humans#732). The controller's redirect-on-success and
+/// orchestrator wiring are covered by the orchestrator service tests; what
+/// remains controller-shaped is purely model-binding/validation.
+/// </summary>
+public sealed class EmailRotaViewModelTests
+{
+    [HumansFact]
+    public void Message_Empty_FailsValidation()
+    {
+        var vm = new EmailRotaViewModel { Message = string.Empty };
+        var results = Validate(vm);
+
+        results.Should().NotBeEmpty();
+        results.Should().Contain(r => r.MemberNames.Contains(nameof(EmailRotaViewModel.Message), StringComparer.Ordinal));
+    }
+
+    [HumansFact]
+    public void Message_TooLong_FailsValidation()
+    {
+        var vm = new EmailRotaViewModel { Message = new string('x', 4001) };
+        var results = Validate(vm);
+
+        results.Should().Contain(r => r.MemberNames.Contains(nameof(EmailRotaViewModel.Message), StringComparer.Ordinal));
+    }
+
+    [HumansFact]
+    public void Message_ValidPayload_Passes()
+    {
+        var vm = new EmailRotaViewModel
+        {
+            RotaId = Guid.NewGuid(),
+            RotaName = "Test Rota",
+            TeamSlug = "test-team",
+            Message = "Hello team — a quick note about Friday's shifts.",
+        };
+
+        Validate(vm).Should().BeEmpty();
+    }
+
+    private static IReadOnlyList<ValidationResult> Validate(EmailRotaViewModel vm)
+    {
+        var context = new ValidationContext(vm);
+        var results = new List<ValidationResult>();
+        Validator.TryValidateObject(vm, context, results, validateAllProperties: true);
+        return results;
+    }
+}


### PR DESCRIPTION
## Summary

Implements the "Email a rota" coordinator action from nobodies-collective/Humans#732 — a one-button broadcast that sends each rota signup a personalised email containing the coordinator's free-text message plus their own chronologically-ordered shift list on that rota.

- `IRotaCoordinatorMessageService` orchestrator fans the rota's active (Pending/Confirmed) signups out to one outbox email per distinct recipient, reusing the existing `IEmailService` path so audit/outbox/opt-out routing stays consistent.
- New `EmailRota.cshtml` compose page (textarea + recipient sidebar) on `Teams/{slug}/Shifts/Rotas/{rotaId}/Email`, gated by management-level authorization (Admin / VolunteerCoordinator / dept coordinator).
- Envelope button on each rota card in the existing `ShiftAdmin/Index` view, visible only when `CanManageShifts` is true.
- One audit-log row per dispatch (`AuditAction.CoordinatorRotaMessageSent`), with the sender as actor.

## Acceptance criteria walk

- [x] Coordinator sees button on rota detail — `Views/ShiftAdmin/Index.cshtml:208-216` inside the `Model.CanManageShifts` gate
- [x] Compose form accepts free-text body — `Views/ShiftAdmin/EmailRota.cshtml:31-35` (max 4000)
- [x] Each signup receives a separate personalised email — `RotaCoordinatorMessageService.cs:62-126`; template at `Resources/SharedResource.resx:2276-2277` matches the spec's "Dear {FirstName}/coordinator message/FYI your shifts.../Thank you, {sender}" shape
- [x] Shift list sorted chronologically in rota timezone — `RotaCoordinatorMessageService.cs:130-148` (`InZoneLeniently` + `OrderBy(ZonedStart.ToInstant)`)
- [x] Uses existing messaging infrastructure — `OutboxEmailService.SendCoordinatorRotaMessageAsync` calls `EnqueueAsync` with `MessageCategory.VolunteerUpdates`
- [x] Non-coordinator users don't see the button — `CanManageShifts` gate in the view + `ResolveDepartmentManagementAsync` server-side check in the controller

## Test plan

- [x] `RotaCoordinatorMessageServiceTests` — 7 cases: blank-body / missing-rota / empty-signups failure shapes, distinct-user fan-out, per-recipient chronological shift list, single audit-log entry with sender actor, skip-on-missing-email
- [x] `EmailRotaViewModelTests` — 3 cases: required, 4000-char cap, valid payload
- [x] `dotnet build Humans.slnx -v quiet` clean (0 warnings, 0 errors)
- [x] `dotnet test Humans.slnx --filter "FullyQualifiedName!~Integration" -v quiet` — 3203/3203 pass (Domain + Analyzers + Web + Application)
- [ ] Integration test suite has 55 pre-existing failures on `main` (Hangfire `JobStorage` DI initialisation) unrelated to this work
- [ ] Manual smoke on preview: send a message to a multi-shift rota and confirm each recipient gets the right shift list

Closes nobodies-collective/Humans#732