### PR TITLE
fix(caching): GetUserInfosAsync ensures warm before per-row fallback

### DIFF
--- a/src/Humans.Infrastructure/Services/Users/CachingUserService.cs
+++ b/src/Humans.Infrastructure/Services/Users/CachingUserService.cs
@@ -109,6 +109,11 @@ public sealed class CachingUserService : TrackedCache<Guid, UserInfo>, IUserServ
     public async ValueTask<IReadOnlyDictionary<Guid, UserInfo>> GetUserInfosAsync(
         IReadOnlyCollection<Guid> userIds, CancellationToken ct = default)
     {
+        // Issue #743: warm before the miss-detection loop. Without this, a cold
+        // cache turns every requested id into a per-row LoadRowAsync (7 SELECTs
+        // each) instead of the single bulk WarmAllAsync.
+        await EnsureWarmedAsync(ct).ConfigureAwait(false);
+
         var result = new Dictionary<Guid, UserInfo>(userIds.Count);
         List<Guid>? misses = null;
         foreach (var id in userIds)

--- a/tests/Humans.Application.Tests/Services/Users/CachingUserServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Users/CachingUserServiceTests.cs
@@ -269,6 +269,45 @@ public class CachingUserServiceTests
     }
 
     [HumansFact]
+    public async Task GetUserInfosAsync_ColdCache_WarmsBeforeFallback_DoesNotLoadPerKey()
+    {
+        // Issue #743 regression. On cold cache, GetUserInfosAsync(ids) must
+        // trigger the bulk WarmAllAsync exactly once instead of issuing a
+        // per-id LoadRowAsync for each requested userId (which would emit
+        // 7 SELECTs per user via the inner service on each miss).
+        var userA = SampleUser();
+        var userB = SampleUser();
+        var userC = SampleUser();
+        _userRepo.GetAllAsync(Arg.Any<CancellationToken>())
+            .Returns(new List<User> { userA, userB, userC });
+        _userEmailRepo.GetAllAsync(Arg.Any<CancellationToken>())
+            .Returns([]);
+        _userRepo.GetExternalLoginsByUserIdsAsync(
+                Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<Guid, IReadOnlyList<(string Provider, string ProviderKey)>>());
+        _userRepo.GetEventParticipationsByUserIdsAsync(
+                Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<Guid, IReadOnlyList<EventParticipation>>());
+        _profileRepo.GetAllAsync(Arg.Any<CancellationToken>())
+            .Returns([]);
+        _contactFieldRepo.GetAllAsync(Arg.Any<CancellationToken>())
+            .Returns([]);
+
+        var sut = CreateSut();
+
+        // Cold cache — no StartAsync. First call must warm in bulk, not per-id.
+        var result = await sut.GetUserInfosAsync([userA.Id, userB.Id, userC.Id]);
+
+        result.Should().HaveCount(3);
+
+        // Bulk warm path ran exactly once.
+        await _userRepo.Received(1).GetAllAsync(Arg.Any<CancellationToken>());
+        // The inner per-id loader was never called — the bug would have
+        // routed each of the three misses through inner.GetUserInfoAsync.
+        await _inner.DidNotReceive().GetUserInfoAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
     public async Task SingleKeyReads_StillWorkBeforeWarmup()
     {
         var userId = Guid.NewGuid();


### PR DESCRIPTION
Fixes nobodies-collective/Humans#743.

## Problem

`CachingUserService.GetUserInfosAsync` was missing the `EnsureWarmedAsync` gate that its sibling `GetAllUserInfosAsync` already has. On cold cache, every requested userId became a miss routed through per-id `LoadRowAsync` (7 SELECTs per user). On `/Teams/volunteers` (~400 users × 7 tables), this multiplies out to thousands of queries instead of a single bulk `WarmAllAsync` (one SELECT per contributing table).

## Fix

One-line: add `await EnsureWarmedAsync(ct).ConfigureAwait(false)` as the first await of `GetUserInfosAsync`, matching the `GetAllUserInfosAsync` pattern at line ~104.

## Test

`GetUserInfosAsync_ColdCache_WarmsBeforeFallback_DoesNotLoadPerKey` mirrors the shape of `LoadAllReads_TriggerWarmupOnDemand_WhenCold`. Cold cache + `GetUserInfosAsync([a,b,c])` asserts:
- `_userRepo.GetAllAsync` received exactly 1 call (bulk warm path)
- `_inner.GetUserInfoAsync` received zero calls (no per-id fallback)

## Out of scope

The issue also asks to "investigate prod warmup health." That's investigation, not code — left for a separate ticket / manual log inspection.