### PR TITLE
fix(infra): design-time DbContext factory reads connection-string env var

### DIFF
--- a/src/Humans.Web/Infrastructure/HumansDbContextDesignTimeFactory.cs
+++ b/src/Humans.Web/Infrastructure/HumansDbContextDesignTimeFactory.cs
@@ -8,9 +8,18 @@ public sealed class HumansDbContextDesignTimeFactory : IDesignTimeDbContextFacto
 {
     public HumansDbContext CreateDbContext(string[] args)
     {
+        // Prefer the standard ASP.NET Core env var when set (CI's
+        // verify-migrations-apply job in .github/workflows/build.yml sets this
+        // to point at a sibling Postgres container — localhost is unreachable
+        // from the runner container). Fall back to a localhost dev string so
+        // `dotnet ef migrations add` keeps working locally without any setup.
+        var connectionString =
+            Environment.GetEnvironmentVariable("ConnectionStrings__DefaultConnection")
+            ?? "Host=localhost;Database=humans_design_time;Username=humans;Password=humans";
+
         var optionsBuilder = new DbContextOptionsBuilder<HumansDbContext>();
         optionsBuilder.UseNpgsql(
-            "Host=localhost;Database=humans_design_time;Username=humans;Password=humans",
+            connectionString,
             npgsqlOptions =>
             {
                 npgsqlOptions.UseNodaTime();


### PR DESCRIPTION
## Summary

Fixes nobodies-collective/Humans#738.

`HumansDbContextDesignTimeFactory` hardcoded `Host=localhost` for the design-time connection string. CI's `verify-migrations-apply` job in `.github/workflows/build.yml` runs inside a container that reaches Postgres by container name (`humans-mig-pg-...`) — `localhost` is unreachable from the runner container, so every migration-touching PR failed with `Connection refused on 127.0.0.1:5432`.

The factory now prefers `ConnectionStrings__DefaultConnection` when set and falls back to the existing localhost dev string. The workflow already exports that env var on both `dotnet ef database update` and `dotnet ef migrations has-pending-model-changes` steps (build.yml lines 156-157 and 165-166), so no workflow change is needed.

## Changes

- `src/Humans.Web/Infrastructure/HumansDbContextDesignTimeFactory.cs` — read env var first, fall back to existing hardcoded string.

## Acceptance criteria

- [x] Factory reads env var when set, falls back otherwise.
- [x] `verify-migrations-apply` workflow sets that env var (already present at build.yml:156-157 and :165-166 — no change needed).
- [x] Local `dotnet ef migrations add` still works without env vars — fallback string is byte-identical to the previous hardcoded value.

## Test plan

- [ ] `dotnet build Humans.slnx -v quiet` passes locally (verified).
- [ ] Next migration-touching PR's `verify-migrations-apply` job reaches Postgres instead of failing with `Connection refused`.