### PR TITLE
perf(auth): claims transformation reads UserInfo cache, not profiles table

### DIFF
--- a/src/Humans.Application/UserInfo.cs
+++ b/src/Humans.Application/UserInfo.cs
@@ -345,6 +345,13 @@ public sealed record UserInfo(
     public bool IsApproved => Profile?.IsApproved ?? false;
 
     /// <summary>
+    /// True when this user has a <see cref="ProfileInfo"/> row attached. Canonical
+    /// "does this user have a profile yet" predicate — callers should never have
+    /// to navigate <c>userInfo.Profile is not null</c> themselves.
+    /// </summary>
+    public bool HasProfile => Profile is not null;
+
+    /// <summary>
     /// True when the user has a profile and BurnerName + FirstName + LastName
     /// are all non-blank. Canonical "has a name" predicate — gates Stub→Active
     /// promotion, Consent Coordinator review queue inclusion, and any flow

--- a/src/Humans.Web/Authorization/RoleAssignmentClaimsTransformation.cs
+++ b/src/Humans.Web/Authorization/RoleAssignmentClaimsTransformation.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 using NodaTime;
 using Humans.Application;
+using Humans.Application.Interfaces.Users;
 using Humans.Domain.Constants;
 using Humans.Infrastructure.Data;
 
@@ -33,12 +34,18 @@ public class RoleAssignmentClaimsTransformation : IClaimsTransformation
     private static readonly TimeSpan CacheDuration = TimeSpan.FromSeconds(60);
 
     private readonly IServiceProvider _serviceProvider;
+    private readonly IUserService _userService;
     private readonly IClock _clock;
     private readonly IMemoryCache _cache;
 
-    public RoleAssignmentClaimsTransformation(IServiceProvider serviceProvider, IClock clock, IMemoryCache cache)
+    public RoleAssignmentClaimsTransformation(
+        IServiceProvider serviceProvider,
+        IUserService userService,
+        IClock clock,
+        IMemoryCache cache)
     {
         _serviceProvider = serviceProvider;
+        _userService = userService;
         _clock = clock;
         _cache = cache;
     }
@@ -90,11 +97,14 @@ public class RoleAssignmentClaimsTransformation : IClaimsTransformation
         var now = _clock.GetCurrentInstant();
         var claims = new List<Claim>();
 
-        // Check suspension status — suspended users lose ActiveMember claim
-        // but keep role claims (Admin/Board) so they can manage their own unsuspension
-        var isSuspended = await dbContext.Profiles
-            .AsNoTracking()
-            .AnyAsync(p => p.UserId == userId && p.IsSuspended);
+        // Suspension + profile-presence both come from the cached UserInfo
+        // read-model so we don't hit the profiles table on every authenticated
+        // request. Null userInfo (user row not yet loaded / not in cache) is
+        // treated as "no profile, not suspended" — same observable behavior as
+        // the prior dbContext.Profiles.AnyAsync calls returning false.
+        var userInfo = await _userService.GetUserInfoAsync(userId);
+        var isSuspended = userInfo?.IsSuspended ?? false;
+        var hasProfile = userInfo?.Profile is not null;
 
         var activeRoles = await dbContext.RoleAssignments
             .AsNoTracking()
@@ -125,10 +135,6 @@ public class RoleAssignmentClaimsTransformation : IClaimsTransformation
                 claims.Add(new Claim(ActiveMemberClaimType, ActiveClaimValue));
             }
         }
-
-        var hasProfile = await dbContext.Profiles
-            .AsNoTracking()
-            .AnyAsync(p => p.UserId == userId);
 
         if (hasProfile)
         {

--- a/src/Humans.Web/Authorization/RoleAssignmentClaimsTransformation.cs
+++ b/src/Humans.Web/Authorization/RoleAssignmentClaimsTransformation.cs
@@ -104,7 +104,7 @@ public class RoleAssignmentClaimsTransformation : IClaimsTransformation
         // the prior dbContext.Profiles.AnyAsync calls returning false.
         var userInfo = await _userService.GetUserInfoAsync(userId);
         var isSuspended = userInfo?.IsSuspended ?? false;
-        var hasProfile = userInfo?.Profile is not null;
+        var hasProfile = userInfo?.HasProfile ?? false;
 
         var activeRoles = await dbContext.RoleAssignments
             .AsNoTracking()

--- a/tests/Humans.Web.Tests/Authorization/RoleAssignmentClaimsTransformationTests.cs
+++ b/tests/Humans.Web.Tests/Authorization/RoleAssignmentClaimsTransformationTests.cs
@@ -1,0 +1,214 @@
+using System.Security.Claims;
+using AwesomeAssertions;
+using Humans.Application;
+using Humans.Application.Interfaces.Users;
+using Humans.Domain.Constants;
+using Humans.Domain.Entities;
+using Humans.Domain.Enums;
+using Humans.Infrastructure.Data;
+using Humans.Web.Authorization;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using NodaTime;
+using NSubstitute;
+using Xunit;
+
+namespace Humans.Web.Tests.Authorization;
+
+/// <summary>
+/// Verifies that <see cref="RoleAssignmentClaimsTransformation"/> sources
+/// <c>IsSuspended</c> and <c>HasProfile</c> from the cached
+/// <see cref="UserInfo"/> read-model (issue #741) rather than re-querying
+/// <c>dbContext.Profiles</c> on every authenticated request.
+/// </summary>
+public class RoleAssignmentClaimsTransformationTests : IDisposable
+{
+    private readonly HumansDbContext _dbContext;
+    private readonly IServiceProvider _serviceProvider;
+    private readonly IUserService _userService;
+    private readonly IClock _clock;
+    private readonly IMemoryCache _cache;
+
+    public RoleAssignmentClaimsTransformationTests()
+    {
+        var options = new DbContextOptionsBuilder<HumansDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        _dbContext = new HumansDbContext(options);
+
+        var services = new ServiceCollection();
+        services.AddSingleton(_dbContext);
+        _serviceProvider = services.BuildServiceProvider();
+
+        _userService = Substitute.For<IUserService>();
+        _clock = Substitute.For<IClock>();
+        _clock.GetCurrentInstant().Returns(Instant.FromUtc(2026, 5, 17, 12, 0));
+        _cache = new MemoryCache(new MemoryCacheOptions());
+    }
+
+    public void Dispose()
+    {
+        _dbContext.Dispose();
+        _cache.Dispose();
+        (_serviceProvider as IDisposable)?.Dispose();
+    }
+
+    private RoleAssignmentClaimsTransformation BuildSut() =>
+        new(_serviceProvider, _userService, _clock, _cache);
+
+    private static ClaimsPrincipal BuildPrincipal(Guid userId)
+    {
+        var identity = new ClaimsIdentity(
+            new[] { new Claim(ClaimTypes.NameIdentifier, userId.ToString()) },
+            authenticationType: "test");
+        return new ClaimsPrincipal(identity);
+    }
+
+    private static UserInfo MakeUserInfo(Guid id, bool hasProfile, bool isSuspended)
+    {
+        Profile? profile = hasProfile
+            ? new Profile
+            {
+                Id = Guid.NewGuid(),
+                UserId = id,
+                BurnerName = "Burner",
+                FirstName = "First",
+                LastName = "Last",
+                CreatedAt = Instant.FromUtc(2026, 1, 1, 0, 0),
+                UpdatedAt = Instant.FromUtc(2026, 1, 1, 0, 0),
+                State = isSuspended ? ProfileState.Suspended : ProfileState.Active,
+            }
+            : null;
+
+        return UserInfo.Create(
+            user: new User
+            {
+                Id = id,
+                DisplayName = "Test User",
+                PreferredLanguage = "en",
+                CreatedAt = Instant.FromUtc(2026, 1, 1, 0, 0),
+                GoogleEmailStatus = GoogleEmailStatus.Unknown,
+            },
+            userEmails: [],
+            eventParticipations: [],
+            externalLogins: [],
+            profile: profile,
+            contactFields: [],
+            profileLanguages: [],
+            volunteerHistory: [],
+            communicationPreferences: []);
+    }
+
+    [HumansFact]
+    public async Task Transform_for_authenticated_user_never_reads_profiles_table()
+    {
+        var userId = Guid.NewGuid();
+
+        // Plant a row in dbContext.Profiles whose State contradicts the
+        // cached UserInfo. If the transformation read the profiles table,
+        // the claim output would reflect this row instead of the UserInfo.
+        _dbContext.Profiles.Add(new Profile
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            BurnerName = "Stale",
+            FirstName = "Stale",
+            LastName = "Row",
+            CreatedAt = Instant.FromUtc(2026, 1, 1, 0, 0),
+            UpdatedAt = Instant.FromUtc(2026, 1, 1, 0, 0),
+            State = ProfileState.Suspended, // contradicts UserInfo below
+        });
+        await _dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        // UserInfo says: profile present, NOT suspended.
+        _userService.GetUserInfoAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<UserInfo?>(MakeUserInfo(userId, hasProfile: true, isSuspended: false)));
+
+        var principal = await BuildSut().TransformAsync(BuildPrincipal(userId));
+
+        // HasProfile claim reflects UserInfo (true), not "no profile".
+        principal.HasClaim(
+            RoleAssignmentClaimsTransformation.HasProfileClaimType,
+            RoleAssignmentClaimsTransformation.ActiveClaimValue)
+            .Should().BeTrue("HasProfile must be sourced from UserInfo.Profile");
+
+        // IUserService was actually consulted.
+        await _userService.Received(1).GetUserInfoAsync(userId, Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task Transform_omits_ActiveMember_claim_when_UserInfo_reports_suspended()
+    {
+        var userId = Guid.NewGuid();
+
+        // Put the user in the Volunteers team so the ActiveMember claim
+        // would otherwise be granted.
+        _dbContext.TeamMembers.Add(new TeamMember
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            TeamId = SystemTeamIds.Volunteers,
+            JoinedAt = Instant.FromUtc(2026, 1, 1, 0, 0),
+        });
+        await _dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        _userService.GetUserInfoAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<UserInfo?>(MakeUserInfo(userId, hasProfile: true, isSuspended: true)));
+
+        var principal = await BuildSut().TransformAsync(BuildPrincipal(userId));
+
+        principal.HasClaim(
+            RoleAssignmentClaimsTransformation.ActiveMemberClaimType,
+            RoleAssignmentClaimsTransformation.ActiveClaimValue)
+            .Should().BeFalse("suspended users lose the ActiveMember claim");
+    }
+
+    [HumansFact]
+    public async Task Transform_omits_HasProfile_claim_when_UserInfo_has_no_profile()
+    {
+        var userId = Guid.NewGuid();
+
+        _userService.GetUserInfoAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<UserInfo?>(MakeUserInfo(userId, hasProfile: false, isSuspended: false)));
+
+        var principal = await BuildSut().TransformAsync(BuildPrincipal(userId));
+
+        principal.HasClaim(
+            RoleAssignmentClaimsTransformation.HasProfileClaimType,
+            RoleAssignmentClaimsTransformation.ActiveClaimValue)
+            .Should().BeFalse("profileless UserInfo should not emit HasProfile");
+    }
+
+    [HumansFact]
+    public async Task Transform_treats_null_UserInfo_as_no_profile_and_not_suspended()
+    {
+        var userId = Guid.NewGuid();
+
+        // User is on the Volunteers team — should produce ActiveMember claim
+        // when not suspended (and null UserInfo is treated as not suspended).
+        _dbContext.TeamMembers.Add(new TeamMember
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            TeamId = SystemTeamIds.Volunteers,
+            JoinedAt = Instant.FromUtc(2026, 1, 1, 0, 0),
+        });
+        await _dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        _userService.GetUserInfoAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<UserInfo?>((UserInfo?)null));
+
+        var principal = await BuildSut().TransformAsync(BuildPrincipal(userId));
+
+        principal.HasClaim(
+            RoleAssignmentClaimsTransformation.HasProfileClaimType,
+            RoleAssignmentClaimsTransformation.ActiveClaimValue)
+            .Should().BeFalse("null UserInfo means no profile");
+
+        principal.HasClaim(
+            RoleAssignmentClaimsTransformation.ActiveMemberClaimType,
+            RoleAssignmentClaimsTransformation.ActiveClaimValue)
+            .Should().BeTrue("null UserInfo is not suspended; volunteer team membership still grants ActiveMember");
+    }
+}

--- a/tests/Humans.Web.Tests/Humans.Web.Tests.csproj
+++ b/tests/Humans.Web.Tests/Humans.Web.Tests.csproj
@@ -4,4 +4,8 @@
     <ProjectReference Include="..\..\src\Humans.Web\Humans.Web.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Closes nobodies-collective/Humans#741.

## Summary

`RoleAssignmentClaimsTransformation.LoadClaimsFromDbAsync` was hitting `dbContext.Profiles` twice on every authenticated request — once to check suspension, once to check profile presence — even though both signals are already on the cached `UserInfo` read-model.

- Replace both `dbContext.Profiles.AnyAsync(...)` calls with a single `IUserService.GetUserInfoAsync(userId)`.
- `isSuspended = userInfo?.IsSuspended ?? false` (canonical predicate, not the legacy `Profile.IsSuspended` bool).
- `hasProfile = userInfo?.Profile is not null`.
- Null `UserInfo` is treated as "not suspended, no profile" — preserves the prior behavior of `AnyAsync` returning false when no row matches.

`RoleAssignments` and `TeamMembers` reads remain in place (out of scope per the issue).

## Acceptance

- [x] No `dbContext.Profiles` references in `RoleAssignmentClaimsTransformation`.
- [x] `IsSuspended` + `hasProfile` sourced from `IUserService.GetUserInfoAsync`.
- [x] Null-user case preserved.
- [x] Test added at `tests/Humans.Web.Tests/Authorization/RoleAssignmentClaimsTransformationTests.cs` covering: profile + not suspended, profile + suspended (no ActiveMember), no profile, and null `UserInfo`. The "never reads profiles table" assertion plants a contradictory `Profiles` row in the DbContext — if the transformation read that table, the claim output would change; it doesn't.
- [ ] Architecture test / analyzer extension forbidding `DbContext.Profiles` access outside `ProfileRepository`: skipped as a rabbit hole — would need to enumerate every legitimate non-ProfileRepository reader (migrations, EF model config, seed scripts) and is a separate cross-cutting cleanup. The behavioral test above guards the specific regression that motivated #741.

## Test plan

- [x] `dotnet build Humans.slnx -v quiet` — clean.
- [x] `dotnet test tests/Humans.Web.Tests/Humans.Web.Tests.csproj --filter FullyQualifiedName~RoleAssignmentClaimsTransformation` — 4/4 pass.