### PR TITLE
perf(metrics): HumansMetricsService reads UserInfo cache, not profiles table

### DIFF
--- a/src/Humans.Application/UserInfo.cs
+++ b/src/Humans.Application/UserInfo.cs
@@ -337,6 +337,14 @@ public sealed record UserInfo(
         Profile?.State == ProfileState.Suspended;
 
     /// <summary>
+    /// True when the user's profile has been approved by the Consent Coordinator.
+    /// Canonical "is this user approved" predicate — read this instead of chaining
+    /// <c>Profile?.IsApproved ?? false</c> at call sites (see
+    /// <c>memory/architecture/derived-predicates-on-userinfo.md</c>).
+    /// </summary>
+    public bool IsApproved => Profile?.IsApproved ?? false;
+
+    /// <summary>
     /// True when the user has a profile and BurnerName + FirstName + LastName
     /// are all non-blank. Canonical "has a name" predicate — gates Stub→Active
     /// promotion, Consent Coordinator review queue inclusion, and any flow

--- a/src/Humans.Infrastructure/Services/HumansMetricsService.cs
+++ b/src/Humans.Infrastructure/Services/HumansMetricsService.cs
@@ -240,28 +240,31 @@ public sealed class HumansMetricsService : IHumansMetrics, IDisposable
             var now = clock.GetCurrentInstant();
 
             // humans_total by status — read off the cached UserInfo snapshot
-            // instead of issuing two table scans against the users table per
-            // refresh tick.
+            // instead of full-scanning profiles every scrape tick. UserInfo
+            // already projects IsApproved (via Profile) and the canonical
+            // IsSuspended predicate (ProfileState-based, per
+            // memory/code/no-issuspended.md).
             var userInfos = await userService.GetAllUserInfosAsync().ConfigureAwait(false);
             var allUserIds = userInfos.Select(u => u.Id).ToList();
-            var profileData = await db.Profiles
-                .Select(p => new { p.UserId, p.IsApproved, p.IsSuspended })
-                .ToListAsync();
-
-            var profileLookup = profileData.ToDictionary(p => p.UserId);
 
             int activeCount = 0, suspendedCount = 0, pendingCount = 0, inactiveCount = 0;
-            foreach (var userId in allUserIds)
+            foreach (var userInfo in userInfos)
             {
-                if (profileLookup.TryGetValue(userId, out var p))
+                if (userInfo.Profile is null)
                 {
-                    if (p.IsSuspended) suspendedCount++;
-                    else if (!p.IsApproved) pendingCount++;
-                    else activeCount++;
+                    inactiveCount++;
+                }
+                else if (userInfo.IsSuspended)
+                {
+                    suspendedCount++;
+                }
+                else if (!userInfo.Profile.IsApproved)
+                {
+                    pendingCount++;
                 }
                 else
                 {
-                    inactiveCount++;
+                    activeCount++;
                 }
             }
 

--- a/src/Humans.Infrastructure/Services/HumansMetricsService.cs
+++ b/src/Humans.Infrastructure/Services/HumansMetricsService.cs
@@ -258,7 +258,7 @@ public sealed class HumansMetricsService : IHumansMetrics, IDisposable
                 {
                     suspendedCount++;
                 }
-                else if (!userInfo.Profile.IsApproved)
+                else if (!userInfo.IsApproved)
                 {
                     pendingCount++;
                 }


### PR DESCRIPTION
Closes nobodies-collective/Humans#742

## Problem

`HumansMetricsService.RefreshSnapshotAsync` loaded the entire UserInfo cache and then immediately threw it away to issue a full-table scan against `profiles` for the `IsApproved` / `IsSuspended` counters — every scrape tick. With Prometheus default scrape intervals (15s–1m), this materially contributes to `profiles` being the most-hit SELECT in prod.

## Fix

Replace the EF projection with an in-memory project over the already-loaded `userInfos`. Both fields are already on the cached projection:
- `Profile.IsApproved` → `userInfo.Profile?.IsApproved`
- `IsSuspended` → `userInfo.IsSuspended` (canonical `ProfileState`-based predicate, not the legacy `Profile.IsSuspended` bool — per `memory/code/no-issuspended.md`)

`db` remains in scope for the other reads in the method (RoleAssignments, LegalDocuments) which are out of scope for this issue.

## Tests

Direct tier — no new test. The mapping is mechanical:
- `Profile is null` → `inactiveCount`
- `IsSuspended` → `suspendedCount`
- `!IsApproved` → `pendingCount`
- otherwise → `activeCount`

The architecture-test guard asserting nothing outside `ProfileRepository` references `DbContext.Profiles` is sibling work in #741; not added here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)