### PR TITLE
perf(consent): bulk-bucket CachingConsentService cold-cache misses

### DIFF
--- a/src/Humans.Infrastructure/Services/Consent/CachingConsentService.cs
+++ b/src/Humans.Infrastructure/Services/Consent/CachingConsentService.cs
@@ -103,13 +103,46 @@ public sealed class CachingConsentService
         if (userIds.Count == 0)
             return new Dictionary<Guid, IReadOnlySet<Guid>>();
 
+        // Bucket hits from misses up front. Hits come straight from the
+        // dict (no scope, no inner call). Misses are resolved via a SINGLE
+        // bulk inner call — not a per-id loop into LoadRowAsync, which
+        // would open N DI scopes and do N rounds of repo + IUserService
+        // calls. Issue #747.
         var result = new Dictionary<Guid, IReadOnlySet<Guid>>(userIds.Count);
+        List<Guid>? misses = null;
         foreach (var userId in userIds)
         {
             if (result.ContainsKey(userId)) continue;
-            var info = await GetAsync(userId, ct).ConfigureAwait(false);
-            result[userId] = info?.ConsentedVersionIds ?? new HashSet<Guid>();
+            if (TryGet(userId, out var hit))
+            {
+                result[userId] = hit.ConsentedVersionIds;
+            }
+            else
+            {
+                (misses ??= new List<Guid>()).Add(userId);
+            }
         }
+
+        if (misses is { Count: > 0 })
+        {
+            await using var scope = _scopeFactory.CreateAsyncScope();
+            var inner = scope.ServiceProvider.GetRequiredKeyedService<IConsentService>(InnerServiceKey);
+            var bulk = await inner.GetConsentMapForUsersAsync(misses, ct).ConfigureAwait(false);
+
+            foreach (var userId in misses)
+            {
+                // Inner contract: every input id appears in the result
+                // (empty set if no consents). Defensively freeze the set
+                // for cache storage — same invariant LoadRowAsync upholds.
+                var versions = bulk.TryGetValue(userId, out var v)
+                    ? v
+                    : (IReadOnlySet<Guid>)new HashSet<Guid>();
+                var frozen = new HashSet<Guid>(versions);
+                Set(userId, new UserConsentInfo(userId, frozen));
+                result[userId] = frozen;
+            }
+        }
+
         return result;
     }
 

--- a/src/Humans.Infrastructure/Services/Consent/CachingConsentService.cs
+++ b/src/Humans.Infrastructure/Services/Consent/CachingConsentService.cs
@@ -109,7 +109,11 @@ public sealed class CachingConsentService
         // would open N DI scopes and do N rounds of repo + IUserService
         // calls. Issue #747.
         var result = new Dictionary<Guid, IReadOnlySet<Guid>>(userIds.Count);
-        List<Guid>? misses = null;
+        // Dedupe misses: duplicate ids in userIds must not redo merge/source
+        // resolution work in the inner bulk call. Tracked via a HashSet
+        // because `result` is only populated after the bulk call, so the
+        // result.ContainsKey check above can't catch a repeat-miss id.
+        HashSet<Guid>? misses = null;
         foreach (var userId in userIds)
         {
             if (result.ContainsKey(userId)) continue;
@@ -119,7 +123,7 @@ public sealed class CachingConsentService
             }
             else
             {
-                (misses ??= new List<Guid>()).Add(userId);
+                (misses ??= new HashSet<Guid>()).Add(userId);
             }
         }
 
@@ -127,9 +131,10 @@ public sealed class CachingConsentService
         {
             await using var scope = _scopeFactory.CreateAsyncScope();
             var inner = scope.ServiceProvider.GetRequiredKeyedService<IConsentService>(InnerServiceKey);
-            var bulk = await inner.GetConsentMapForUsersAsync(misses, ct).ConfigureAwait(false);
+            var missList = misses.ToList();
+            var bulk = await inner.GetConsentMapForUsersAsync(missList, ct).ConfigureAwait(false);
 
-            foreach (var userId in misses)
+            foreach (var userId in missList)
             {
                 // Inner contract: every input id appears in the result
                 // (empty set if no consents). Defensively freeze the set

--- a/tests/Humans.Application.Tests/Services/Consent/CachingConsentServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Consent/CachingConsentServiceTests.cs
@@ -91,6 +91,33 @@ public class CachingConsentServiceTests
     }
 
     [HumansFact]
+    public async Task GetConsentMapForUsersAsync_DuplicateColdIds_DedupedBeforeInnerCall()
+    {
+        // Caller passes the same uncached id multiple times. The inner
+        // bulk call must see each id once, not redo merge/source work
+        // per duplicate.
+        var id = Guid.NewGuid();
+        var userIds = new List<Guid> { id, id, id };
+        var stub = new Dictionary<Guid, IReadOnlySet<Guid>>
+        {
+            [id] = new HashSet<Guid> { Guid.NewGuid() },
+        };
+        _inner.GetConsentMapForUsersAsync(
+                Arg.Any<IReadOnlyList<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(stub);
+
+        var sut = CreateSut();
+        var result = await sut.GetConsentMapForUsersAsync(userIds);
+
+        result.Should().HaveCount(1);
+        result[id].Should().BeEquivalentTo(stub[id]);
+
+        await _inner.Received(1).GetConsentMapForUsersAsync(
+            Arg.Is<IReadOnlyList<Guid>>(ids => ids.Count == 1 && ids[0] == id),
+            Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
     public async Task GetConsentMapForUsersAsync_PartialHits_OnlyMissesGoToInner()
     {
         var hitIds = Enumerable.Range(0, 3).Select(_ => Guid.NewGuid()).ToList();

--- a/tests/Humans.Application.Tests/Services/Consent/CachingConsentServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Consent/CachingConsentServiceTests.cs
@@ -1,0 +1,130 @@
+using AwesomeAssertions;
+using Humans.Application.Interfaces.Consent;
+using Humans.Application.Interfaces.Legal;
+using Humans.Application.Interfaces.Repositories;
+using Humans.Infrastructure.Services.Consent;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using NodaTime;
+using NSubstitute;
+
+namespace Humans.Application.Tests.Services.Consent;
+
+/// <summary>
+/// Issue #747. Pins the bulk-bucket behavior of
+/// <see cref="CachingConsentService.GetConsentMapForUsersAsync"/>: a
+/// cold-cache call must issue a single bulk inner call (not N per-id
+/// loads), and the result must be cached for the next call.
+/// </summary>
+public class CachingConsentServiceTests
+{
+    private readonly IConsentService _inner = Substitute.For<IConsentService>();
+    private readonly IConsentRepository _repo = Substitute.For<IConsentRepository>();
+    private readonly ILegalDocumentSyncService _legalSync = Substitute.For<ILegalDocumentSyncService>();
+    private readonly IClock _clock = Substitute.For<IClock>();
+
+    private CachingConsentService CreateSut()
+    {
+        var services = new ServiceCollection();
+        services.AddKeyedScoped<IConsentService>(
+            CachingConsentService.InnerServiceKey, (_, _) => _inner);
+        var scopeFactory = services.BuildServiceProvider()
+            .GetRequiredService<IServiceScopeFactory>();
+        return new CachingConsentService(
+            _repo, _legalSync, _clock,
+            scopeFactory,
+            NullLogger<CachingConsentService>.Instance);
+    }
+
+    [HumansFact]
+    public async Task GetConsentMapForUsersAsync_ColdCache_50Ids_IssuesSingleBulkInnerCall()
+    {
+        var userIds = Enumerable.Range(0, 50).Select(_ => Guid.NewGuid()).ToList();
+        var stub = userIds.ToDictionary(
+            id => id,
+            id => (IReadOnlySet<Guid>)new HashSet<Guid> { Guid.NewGuid() });
+        _inner.GetConsentMapForUsersAsync(
+                Arg.Any<IReadOnlyList<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(stub);
+
+        var sut = CreateSut();
+
+        var result = await sut.GetConsentMapForUsersAsync(userIds);
+
+        result.Should().HaveCount(50);
+        foreach (var id in userIds)
+            result[id].Should().BeEquivalentTo(stub[id]);
+
+        // The acceptance criterion: a single bulk inner call, not a
+        // per-id loop.
+        await _inner.Received(1).GetConsentMapForUsersAsync(
+            Arg.Is<IReadOnlyList<Guid>>(ids => ids.Count == 50),
+            Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task GetConsentMapForUsersAsync_AllHits_NoInnerCall()
+    {
+        var userIds = Enumerable.Range(0, 10).Select(_ => Guid.NewGuid()).ToList();
+        var firstCallStub = userIds.ToDictionary(
+            id => id,
+            id => (IReadOnlySet<Guid>)new HashSet<Guid> { Guid.NewGuid() });
+        _inner.GetConsentMapForUsersAsync(
+                Arg.Any<IReadOnlyList<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(firstCallStub);
+
+        var sut = CreateSut();
+
+        // Warm the cache.
+        _ = await sut.GetConsentMapForUsersAsync(userIds);
+        _inner.ClearReceivedCalls();
+
+        // All-hit path: no scope, no inner call.
+        var second = await sut.GetConsentMapForUsersAsync(userIds);
+
+        second.Should().HaveCount(10);
+        foreach (var id in userIds)
+            second[id].Should().BeEquivalentTo(firstCallStub[id]);
+
+        await _inner.DidNotReceive().GetConsentMapForUsersAsync(
+            Arg.Any<IReadOnlyList<Guid>>(), Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task GetConsentMapForUsersAsync_PartialHits_OnlyMissesGoToInner()
+    {
+        var hitIds = Enumerable.Range(0, 3).Select(_ => Guid.NewGuid()).ToList();
+        var missIds = Enumerable.Range(0, 4).Select(_ => Guid.NewGuid()).ToList();
+
+        var hitStub = hitIds.ToDictionary(
+            id => id,
+            id => (IReadOnlySet<Guid>)new HashSet<Guid> { Guid.NewGuid() });
+        _inner.GetConsentMapForUsersAsync(
+                Arg.Is<IReadOnlyList<Guid>>(ids => ids.Count == hitIds.Count),
+                Arg.Any<CancellationToken>())
+            .Returns(hitStub);
+
+        var sut = CreateSut();
+        _ = await sut.GetConsentMapForUsersAsync(hitIds); // warm
+
+        var missStub = missIds.ToDictionary(
+            id => id,
+            id => (IReadOnlySet<Guid>)new HashSet<Guid> { Guid.NewGuid() });
+        _inner.GetConsentMapForUsersAsync(
+                Arg.Is<IReadOnlyList<Guid>>(ids => ids.Count == missIds.Count
+                    && ids.All(missIds.Contains)),
+                Arg.Any<CancellationToken>())
+            .Returns(missStub);
+
+        var combined = hitIds.Concat(missIds).ToList();
+        var result = await sut.GetConsentMapForUsersAsync(combined);
+
+        result.Should().HaveCount(7);
+
+        // Inner saw exactly the miss set in the second call — not all 7 ids.
+        await _inner.Received(1).GetConsentMapForUsersAsync(
+            Arg.Is<IReadOnlyList<Guid>>(ids => ids.Count == missIds.Count
+                && ids.All(missIds.Contains)),
+            Arg.Any<CancellationToken>());
+    }
+}


### PR DESCRIPTION
Closes nobodies-collective/Humans#747.

## Summary

`CachingConsentService.GetConsentMapForUsersAsync` previously fell back to a per-id sequential loop on cache miss. Each missed id opened its own DI scope inside `LoadRowAsync` and issued one inner round-trip plus an `IUserService.GetMergedSourceIdsAsync` call — so a cold-cache batch of N ids cost N scopes + N rounds of (user-service + repo) work, defeating the bulk-batch primitive the inner `ConsentService.GetConsentMapForUsersAsync` already exposes.

This change buckets hits vs misses up front:

- **Hits** are served straight from the dict via `TryGet` — no scope, no inner call.
- **Misses** trigger a *single* DI scope and a *single* `inner.GetConsentMapForUsersAsync(misses, ct)` call. Inner already chain-follows merge tombstones and returns a per-target merged set, so the decorator just wraps each result in `UserConsentInfo` (defensively frozen, same invariant `LoadRowAsync` upholds) and writes it back to the cache so the next call serves the same ids as hits.
- **All-hit** path: no scope is created at all.

Cold-cache N ids now costs O(tables) repo round-trips, not O(N x tables).

## Acceptance

- [x] At most one DI scope per call.
- [x] Cold-cache bulk call → single bulk inner call (O(tables) round-trips).
- [x] Hit path unchanged — no scope when all hit.
- [x] Missed ids land in cache for next call (`Set(userId, new UserConsentInfo(...))`).
- [x] Unit test: cold-cache + 50 ids → single inner `GetConsentMapForUsersAsync(50)` call (plus all-hits and partial-hit coverage).

## Test plan

- [x] `dotnet build Humans.slnx -v quiet` clean.
- [x] `dotnet test tests/Humans.Application.Tests/Humans.Application.Tests.csproj --filter FullyQualifiedName~CachingConsentService` — 5 pass / 0 fail.
- [x] `dotnet test ... --filter FullyQualifiedName~ConsentArchitecture` — 10 pass / 0 fail (no architectural drift).