### PR TITLE
perf(profile): GetCustomPictureInfoByUserIdsAsync reads UserInfo cache

### DIFF
--- a/src/Humans.Application/Interfaces/Repositories/IProfileRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/IProfileRepository.cs
@@ -60,13 +60,6 @@ public interface IProfileRepository : IRepository
         Guid profileId, CancellationToken ct = default);
 
     /// <summary>
-    /// Batch query returning (ProfileId, UserId, UpdatedAtTicks) for users
-    /// that have a custom profile picture. Read-only.
-    /// </summary>
-    Task<IReadOnlyList<(Guid ProfileId, Guid UserId, long UpdatedAtTicks)>>
-        GetCustomPictureInfoByUserIdsAsync(IEnumerable<Guid> userIds, CancellationToken ct = default);
-
-    /// <summary>
     /// Issue nobodies-collective/Humans#702: returns every profile whose
     /// <c>ProfilePictureContentType</c> is non-null — the population the
     /// DB→FS migration verification page operates on. Projects only the

--- a/src/Humans.Application/Services/Profiles/ProfileService.cs
+++ b/src/Humans.Application/Services/Profiles/ProfileService.cs
@@ -369,9 +369,18 @@ public sealed class ProfileService : IProfileService, IUserDataContributor, IUse
         return profile.Id;
     }
 
-    public Task<IReadOnlyList<(Guid ProfileId, Guid UserId, long UpdatedAtTicks)>>
-        GetCustomPictureInfoByUserIdsAsync(IEnumerable<Guid> userIds, CancellationToken ct = default) =>
-        _profileRepository.GetCustomPictureInfoByUserIdsAsync(userIds, ct);
+    public async Task<IReadOnlyList<(Guid ProfileId, Guid UserId, long UpdatedAtTicks)>>
+        GetCustomPictureInfoByUserIdsAsync(IEnumerable<Guid> userIds, CancellationToken ct = default)
+    {
+        var userIdList = userIds.ToList();
+        if (userIdList.Count == 0) return [];
+
+        var infos = await _userService.GetUserInfosAsync(userIdList, ct);
+        return infos.Values
+            .Where(u => u.Profile is not null && u.Profile.HasCustomPicture)
+            .Select(u => (u.Profile!.Id, u.Id, u.Profile.UpdatedAt.ToUnixTimeTicks()))
+            .ToList();
+    }
 
     public async Task<(bool CanAdd, int MinutesUntilResend, Guid? PendingEmailId)>
         GetEmailCooldownInfoAsync(Guid pendingEmailId, CancellationToken ct = default)

--- a/src/Humans.Infrastructure/Repositories/Profiles/ProfileRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Profiles/ProfileRepository.cs
@@ -74,23 +74,6 @@ public sealed class ProfileRepository : IProfileRepository
             .FirstOrDefaultAsync(ct);
     }
 
-    public async Task<IReadOnlyList<(Guid ProfileId, Guid UserId, long UpdatedAtTicks)>>
-        GetCustomPictureInfoByUserIdsAsync(IEnumerable<Guid> userIds, CancellationToken ct = default)
-    {
-        var userIdList = userIds.ToList();
-        if (userIdList.Count == 0)
-            return [];
-
-        await using var ctx = await _factory.CreateDbContextAsync(ct);
-        return await ctx.Profiles
-            .AsNoTracking()
-            .Where(p => userIdList.Contains(p.UserId) && p.ProfilePictureContentType != null)
-            .Select(p => new { p.Id, p.UserId, p.UpdatedAt })
-            .AsAsyncEnumerable()
-            .Select(p => (p.Id, p.UserId, p.UpdatedAt.ToUnixTimeTicks()))
-            .ToListAsync(ct);
-    }
-
     public async Task<IReadOnlyList<(Guid ProfileId, Guid UserId, string BurnerName, string ContentType, Instant UpdatedAt)>>
         GetCustomPictureRowsAsync(CancellationToken ct = default)
     {

--- a/tests/Humans.Application.Tests/Services/ProfileServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/ProfileServiceTests.cs
@@ -422,7 +422,6 @@ public class ProfileServiceTests : IDisposable
         result[0].UserId.Should().Be(u1);
         result[0].UpdatedAtTicks.Should().Be(profileUpdatedAt.ToUnixTimeTicks());
 
-        _ = profileRepo.ReceivedCalls();
         profileRepo.ReceivedCalls().Should().BeEmpty(
             "GetCustomPictureInfoByUserIdsAsync should read from the UserInfo cache, not the profiles table");
     }

--- a/tests/Humans.Application.Tests/Services/ProfileServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/ProfileServiceTests.cs
@@ -350,6 +350,83 @@ public class ProfileServiceTests : IDisposable
         result.Should().BeEmpty();
     }
 
+    /// <summary>
+    /// Issue nobodies-collective/Humans#745: GetCustomPictureInfoByUserIdsAsync
+    /// must read from the UserInfo cache via IUserService — the profiles table
+    /// must NOT be queried on the happy path.
+    /// </summary>
+    [HumansFact]
+    public async Task GetCustomPictureInfoByUserIdsAsync_ReadsFromUserInfoCache_DoesNotTouchProfileRepository()
+    {
+        // Build an alternate service with a substituted IProfileRepository so we
+        // can assert it's never invoked. IUserService is the only source for the
+        // (ProfileId, UserId, UpdatedAtTicks) tuple.
+        var profileRepo = Substitute.For<IProfileRepository>();
+        var userService = Substitute.For<IUserService>();
+        var service = new ProfileService(
+            profileRepo, userService,
+            Substitute.For<IUserEmailRepository>(),
+            Substitute.For<IContactFieldRepository>(),
+            Substitute.For<ICommunicationPreferenceRepository>(),
+            Substitute.For<IAuditLogService>(),
+            new InMemoryFileStorage(),
+            Substitute.For<IUserInfoInvalidator>(),
+            _clock,
+            NullLogger<ProfileService>.Instance);
+
+        var u1 = Guid.NewGuid();
+        var u2 = Guid.NewGuid();
+        var p1 = Guid.NewGuid();
+        var p2 = Guid.NewGuid();
+        var profileUpdatedAt = Instant.FromUtc(2026, 4, 1, 10, 0);
+
+        var profile1 = new Profile
+        {
+            Id = p1,
+            UserId = u1,
+            BurnerName = "A",
+            FirstName = "A",
+            LastName = "A",
+            ProfilePictureContentType = "image/png",
+            CreatedAt = profileUpdatedAt,
+            UpdatedAt = profileUpdatedAt,
+        };
+        var profile2 = new Profile
+        {
+            Id = p2,
+            UserId = u2,
+            BurnerName = "B",
+            FirstName = "B",
+            LastName = "B",
+            ProfilePictureContentType = null, // no custom picture
+            CreatedAt = profileUpdatedAt,
+            UpdatedAt = profileUpdatedAt,
+        };
+
+        var userInfos = new Dictionary<Guid, UserInfo>
+        {
+            [u1] = new User { Id = u1, DisplayName = "A", PreferredLanguage = "en" }
+                .ToUserInfo(profile: profile1),
+            [u2] = new User { Id = u2, DisplayName = "B", PreferredLanguage = "en" }
+                .ToUserInfo(profile: profile2),
+        };
+
+        userService
+            .GetUserInfosAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<IReadOnlyDictionary<Guid, UserInfo>>(userInfos));
+
+        var result = await service.GetCustomPictureInfoByUserIdsAsync([u1, u2]);
+
+        result.Should().HaveCount(1);
+        result[0].ProfileId.Should().Be(p1);
+        result[0].UserId.Should().Be(u1);
+        result[0].UpdatedAtTicks.Should().Be(profileUpdatedAt.ToUnixTimeTicks());
+
+        _ = profileRepo.ReceivedCalls();
+        profileRepo.ReceivedCalls().Should().BeEmpty(
+            "GetCustomPictureInfoByUserIdsAsync should read from the UserInfo cache, not the profiles table");
+    }
+
     // Birthday/Location snapshot tests removed alongside the FullProfile delete —
     // those widgets now read directly from the UserInfo cache via CachingUserService.
 


### PR DESCRIPTION
## Summary

Cache-route `ProfileService.GetCustomPictureInfoByUserIdsAsync` to read from the `UserInfo` cache via `IUserService.GetUserInfosAsync` instead of querying the `profiles` table through `IProfileRepository`.

The cached `UserInfo.Profile` already carries every field needed:
- `Profile.Id` (= `ProfileId`)
- `Profile.HasCustomPicture` (mirror of `ProfilePictureContentType is not null`)
- `Profile.UpdatedAt` (used for the `?v=` cache-buster ticks)

Eliminates a per-page DB round-trip from the team admin / shifts / profile-picture URL helper call sites.

## Changes

- `ProfileService.GetCustomPictureInfoByUserIdsAsync` rewritten to project from `_userService.GetUserInfosAsync(...)`. Tuple shape and signature unchanged — the 4 callers don't need updates.
- `IProfileRepository.GetCustomPictureInfoByUserIdsAsync` + `ProfileRepository` impl removed: no other production callers remained after the swap.
- Added `GetCustomPictureInfoByUserIdsAsync_ReadsFromUserInfoCache_DoesNotTouchProfileRepository` asserting the repo is never touched on the happy path.

Closes nobodies-collective/Humans#745

## Test plan

- [x] `dotnet build Humans.slnx -v quiet` — 0 errors
- [x] `dotnet test tests/Humans.Application.Tests/...` — 44 ProfileService tests pass (2 pre-existing + 1 new)
- [x] Full `dotnet test Humans.slnx` — only pre-existing unrelated integration failures (Hangfire JobStorage / WebApplicationFactory startup) remain