### PR TITLE
perf(teams): user→teams index in CachingTeamService for warm-cache GetUserTeamsAsync

### DIFF
--- a/src/Humans.Infrastructure/Services/Teams/CachingTeamService.cs
+++ b/src/Humans.Infrastructure/Services/Teams/CachingTeamService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using Humans.Application.DTOs;
 using Humans.Application.Interfaces.Auth;
 using Humans.Application.Interfaces.Caching;
@@ -30,6 +31,30 @@ public sealed class CachingTeamService : TrackedCache<Guid, TeamInfo>, ITeamServ
     private readonly ITeamRepository _teamRepository;
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly ILogger<CachingTeamService> _logger;
+
+    /// <summary>
+    /// Secondary user→teams index, populated during <see cref="WarmAllAsync"/>
+    /// alongside the primary <c>teamId → TeamInfo</c> dict. Serves
+    /// <see cref="GetUserTeamsAsync"/> without touching the inner scoped
+    /// <see cref="ITeamService"/> / EF.
+    ///
+    /// <para>Every membership-mutating path on this decorator calls
+    /// <see cref="InvalidateTeamsCache"/>, which clears the primary cache and
+    /// flips the warmed flag back to false. The next reader drives
+    /// <see cref="WarmAllAsync"/> on demand, which empties this index and
+    /// rebuilds it from the freshly loaded teams. No per-mutation diffing
+    /// against the inverse map is needed — the all-or-nothing re-warm pattern
+    /// keeps the two structures consistent by construction.</para>
+    ///
+    /// <para>Writes during warmup are confined to <see cref="WarmAllAsync"/>,
+    /// which the base coalesces under its warm semaphore. Readers go through
+    /// <see cref="GetTeamsByIdAsync"/> first (which calls
+    /// <see cref="TrackedCache{TKey,TValue}.EnsureWarmedAsync"/>), so a
+    /// concurrent reader either sees the post-warmup state or waits for warmup
+    /// to complete. The <see cref="HashSet{T}"/> values are written only during
+    /// warmup; readers iterate the set without locking.</para>
+    /// </summary>
+    private readonly ConcurrentDictionary<Guid, HashSet<Guid>> _teamIdsByUserId = new();
 
     public CachingTeamService(
         ITeamRepository teamRepository,
@@ -245,10 +270,99 @@ public sealed class CachingTeamService : TrackedCache<Guid, TeamInfo>, ITeamServ
             Role: member.Role,
             JoinedAt: member.JoinedAt);
 
-    public Task<IReadOnlyList<TeamMember>> GetUserTeamsAsync(
+    public async Task<IReadOnlyList<TeamMember>> GetUserTeamsAsync(
         Guid userId,
-        CancellationToken cancellationToken = default) =>
-        WithInner(inner => inner.GetUserTeamsAsync(userId, cancellationToken));
+        CancellationToken cancellationToken = default)
+    {
+        // Ensure the inverse map and primary dict are in lockstep (both rebuilt
+        // by WarmAllAsync). Without warmup the inverse map is empty even when
+        // the user is genuinely a member of a team.
+        await EnsureWarmedAsync(cancellationToken);
+
+        if (!_teamIdsByUserId.TryGetValue(userId, out var teamIds) || teamIds.Count == 0)
+            return [];
+
+        var snapshot = AsReadOnlyDictionary;
+        var result = new List<TeamMember>(teamIds.Count);
+        foreach (var teamId in teamIds)
+        {
+            if (!snapshot.TryGetValue(teamId, out var team))
+                continue;
+
+            var membership = team.Members.FirstOrDefault(m => m.UserId == userId);
+            if (membership is null)
+                continue;
+
+            result.Add(ProjectToTeamMember(team, membership, snapshot));
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Synthesize the <see cref="TeamMember"/> Domain entity shape from the
+    /// cached <see cref="TeamInfo"/> + <see cref="TeamMemberInfo"/> projections
+    /// so consumers of <see cref="GetUserTeamsAsync"/> keep their existing
+    /// field access on the membership row and its nested team entity
+    /// (SystemTeamType / IsHidden / DisplayName / Slug / Role / JoinedAt /
+    /// TeamId / LeftAt) without reaching back to EF. Members are filtered by
+    /// <c>LeftAt is null</c> at warmup time, so all synthesized memberships
+    /// are active and <see cref="TeamMember.LeftAt"/> stays null.
+    ///
+    /// <para>Populates the synthesized team's <c>ParentTeam</c> nav when a
+    /// parent is in cache so the <c>DisplayName</c> "Parent - Name" form
+    /// resolves without an EF round-trip.</para>
+    /// </summary>
+    private static TeamMember ProjectToTeamMember(
+        TeamInfo team,
+        TeamMemberInfo membership,
+        IReadOnlyDictionary<Guid, TeamInfo> teamsById)
+    {
+        Team? parent = null;
+        if (team.ParentTeamId.HasValue && teamsById.TryGetValue(team.ParentTeamId.Value, out var parentInfo))
+        {
+            parent = SynthesizeTeam(parentInfo, parent: null);
+        }
+
+        var teamEntity = SynthesizeTeam(team, parent);
+        return new TeamMember
+        {
+            Id = membership.TeamMemberId,
+            TeamId = team.Id,
+            Team = teamEntity,
+            UserId = membership.UserId,
+            Role = membership.Role,
+            JoinedAt = membership.JoinedAt,
+            LeftAt = null,
+        };
+    }
+
+    private static Team SynthesizeTeam(TeamInfo info, Team? parent) => new()
+    {
+        Id = info.Id,
+        Name = info.Name,
+        Description = info.Description,
+        Slug = info.Slug,
+        IsActive = info.IsActive,
+        SystemTeamType = info.SystemTeamType,
+        RequiresApproval = info.RequiresApproval,
+        GoogleGroupPrefix = info.GoogleGroupPrefix,
+        CreatedAt = info.CreatedAt,
+        UpdatedAt = info.UpdatedAt ?? info.CreatedAt,
+        CustomSlug = info.CustomSlug,
+        IsPublicPage = info.IsPublicPage,
+        ShowCoordinatorsOnPublicPage = info.ShowCoordinatorsOnPublicPage,
+        PageContent = info.PageContent,
+        PageContentUpdatedAt = info.PageContentUpdatedAt,
+        PageContentUpdatedByUserId = info.PageContentUpdatedByUserId,
+        CallsToAction = info.CallsToAction is null ? null : [.. info.CallsToAction],
+        HasBudget = info.HasBudget,
+        IsHidden = info.IsHidden,
+        IsSensitive = info.IsSensitive,
+        ParentTeamId = info.ParentTeamId,
+        ParentTeam = parent,
+        IsPromotedToDirectory = info.IsPromotedToDirectory,
+    };
 
     public Task<IReadOnlyList<MyTeamMembershipSummary>> GetMyTeamMembershipsAsync(
         Guid userId,
@@ -810,6 +924,22 @@ public sealed class CachingTeamService : TrackedCache<Guid, TeamInfo>, ITeamServ
         // startup). Set is upsert, so any rare leftover entry is overwritten.
         foreach (var team in teams)
             Set(team.Id, BuildTeamInfo(team, users, managementHolders, roleDefinitionsByTeam, childIdsByParent));
+
+        // Rebuild the inverse user→teams index from scratch. The base coalesces
+        // WarmAllAsync under its warm semaphore so this body runs serially;
+        // readers wait at EnsureWarmedAsync until both maps are populated.
+        _teamIdsByUserId.Clear();
+        foreach (var team in teams)
+        {
+            foreach (var member in team.Members)
+            {
+                if (member.LeftAt is not null)
+                    continue;
+
+                var set = _teamIdsByUserId.GetOrAdd(member.UserId, static _ => new HashSet<Guid>());
+                set.Add(team.Id);
+            }
+        }
     }
 
     private bool IsUserCoordinatorOfActiveTeam(

--- a/tests/Humans.Application.Tests/Services/CachingTeamServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/CachingTeamServiceTests.cs
@@ -175,6 +175,147 @@ public sealed class CachingTeamServiceTests : IDisposable
         return member;
     }
 
+    [HumansFact]
+    public async Task GetUserTeamsAsync_AfterWarmup_ReturnsAllActiveMemberships()
+    {
+        var user = SeedUser("Alice");
+        var team1 = SeedTeam("Alpha");
+        var team2 = SeedTeam("Beta");
+        SeedTeamMember(team1.Id, user.Id, TeamMemberRole.Member);
+        SeedTeamMember(team2.Id, user.Id, TeamMemberRole.Coordinator);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _service.GetUserTeamsAsync(user.Id);
+
+        result.Should().HaveCount(2);
+        result.Should().Contain(m => m.TeamId == team1.Id && m.Role == TeamMemberRole.Member);
+        result.Should().Contain(m => m.TeamId == team2.Id && m.Role == TeamMemberRole.Coordinator);
+        result.Should().OnlyContain(m => m.LeftAt == null);
+    }
+
+    [HumansFact]
+    public async Task GetUserTeamsAsync_LeftMemberships_ExcludedFromInverseIndex()
+    {
+        var user = SeedUser("Alice");
+        var team = SeedTeam("Alpha");
+        var member = SeedTeamMember(team.Id, user.Id, TeamMemberRole.Member);
+        member.LeftAt = _clock.GetCurrentInstant();
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _service.GetUserTeamsAsync(user.Id);
+
+        result.Should().BeEmpty();
+    }
+
+    [HumansFact]
+    public async Task GetUserTeamsAsync_SynthesizedTeamHasDisplayNameAndSlug()
+    {
+        var user = SeedUser("Alice");
+        var parent = SeedTeam("Comms");
+        var child = SeedTeam("Logo");
+        child.ParentTeamId = parent.Id;
+        SeedTeamMember(child.Id, user.Id, TeamMemberRole.Member);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _service.GetUserTeamsAsync(user.Id);
+
+        var membership = result.Should().ContainSingle().Subject;
+        membership.Team.Should().NotBeNull();
+        membership.Team.Slug.Should().Be("logo");
+        // Team.DisplayName concatenates ParentTeam.Name when ParentTeam is set;
+        // synthesized entity must populate ParentTeam so consumers like
+        // ProfileCardViewComponent render "Parent - Child" without an EF round-trip.
+        membership.Team.DisplayName.Should().Be("Comms - Logo");
+    }
+
+    [HumansFact]
+    public async Task GetUserTeamsAsync_AfterMutationInvalidation_ReflectsNewState()
+    {
+        var user = SeedUser("Alice");
+        var team = SeedTeam("Alpha");
+        SeedTeamMember(team.Id, user.Id, TeamMemberRole.Member);
+        await _dbContext.SaveChangesAsync();
+
+        // Warm the cache + inverse index.
+        var before = await _service.GetUserTeamsAsync(user.Id);
+        before.Should().HaveCount(1);
+
+        // New membership written outside the decorator: clearing simulates the
+        // real path where mutation methods call InvalidateTeamsCache().
+        var team2 = SeedTeam("Beta");
+        SeedTeamMember(team2.Id, user.Id, TeamMemberRole.Coordinator);
+        await _dbContext.SaveChangesAsync();
+        _service.InvalidateActiveTeamsCache();
+
+        var after = await _service.GetUserTeamsAsync(user.Id);
+        after.Should().HaveCount(2);
+    }
+
+    [HumansFact]
+    public async Task GetUserTeamsAsync_ForwardAndInverseIndexAgreeAfterWarmup()
+    {
+        // Seed several users across overlapping teams; verify the inverse map
+        // contains exactly the team IDs derivable from the forward map.
+        var alice = SeedUser("Alice");
+        var bob = SeedUser("Bob");
+        var carol = SeedUser("Carol");
+        var t1 = SeedTeam("Alpha");
+        var t2 = SeedTeam("Beta");
+        var t3 = SeedTeam("Gamma");
+        SeedTeamMember(t1.Id, alice.Id, TeamMemberRole.Member);
+        SeedTeamMember(t1.Id, bob.Id, TeamMemberRole.Member);
+        SeedTeamMember(t2.Id, alice.Id, TeamMemberRole.Coordinator);
+        SeedTeamMember(t3.Id, carol.Id, TeamMemberRole.Member);
+        await _dbContext.SaveChangesAsync();
+
+        var aliceTeams = (await _service.GetUserTeamsAsync(alice.Id))
+            .Select(m => m.TeamId).ToHashSet();
+        var bobTeams = (await _service.GetUserTeamsAsync(bob.Id))
+            .Select(m => m.TeamId).ToHashSet();
+        var carolTeams = (await _service.GetUserTeamsAsync(carol.Id))
+            .Select(m => m.TeamId).ToHashSet();
+
+        aliceTeams.Should().BeEquivalentTo([t1.Id, t2.Id]);
+        bobTeams.Should().BeEquivalentTo([t1.Id]);
+        carolTeams.Should().BeEquivalentTo([t3.Id]);
+    }
+
+    [HumansFact]
+    public async Task GetUserTeamsAsync_WarmCache_DoesNotCallInnerService()
+    {
+        var user = SeedUser("Alice");
+        var team = SeedTeam("Alpha");
+        SeedTeamMember(team.Id, user.Id, TeamMemberRole.Member);
+        await _dbContext.SaveChangesAsync();
+
+        // First call drives warmup (which uses repository, not inner service).
+        await _service.GetUserTeamsAsync(user.Id);
+
+        // The inner ITeamService is an unconfigured NSubstitute mock; if the
+        // warm-cache path served from the index, no method on it is invoked.
+        var inner = _serviceProvider.GetRequiredKeyedService<ITeamService>(
+            CachingTeamService.InnerServiceKey);
+
+        var second = await _service.GetUserTeamsAsync(user.Id);
+        second.Should().HaveCount(1);
+
+        await inner.DidNotReceive().GetUserTeamsAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task GetUserTeamsAsync_UnknownUser_ReturnsEmptyWithoutInnerCall()
+    {
+        var team = SeedTeam("Alpha");
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _service.GetUserTeamsAsync(Guid.NewGuid());
+
+        result.Should().BeEmpty();
+        var inner = _serviceProvider.GetRequiredKeyedService<ITeamService>(
+            CachingTeamService.InnerServiceKey);
+        await inner.DidNotReceive().GetUserTeamsAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+    }
+
     public void Dispose()
     {
         _dbContext.Dispose();


### PR DESCRIPTION
Closes nobodies-collective/Humans#746.

## Summary
- Adds a secondary `userId → set<teamId>` index on `CachingTeamService`, rebuilt during `WarmAllAsync` alongside the primary `teamId → TeamInfo` dict.
- `GetUserTeamsAsync` now serves from the inverse index + cached `TeamInfo`. No call to the inner scoped `ITeamService`, no `team_members` SELECT on the warm-cache path.
- Hot path: `ProfileCardViewComponent.InvokeAsync` calls `GetUserTeamsAsync` on every profile render.

## Implementation notes
- The inverse map is rebuilt entirely during `WarmAllAsync` (the base coalesces this under its warm semaphore). Every membership-mutating decorator method already calls `InvalidateTeamsCache()` → `Clear()`, which flips the warmed flag back to false; the next reader drives a full re-warm. No per-mutation diffing of the inverse map is needed — the all-or-nothing re-warm pattern keeps the two maps consistent by construction.
- `GetUserTeamsAsync` returns the existing `TeamMember` Domain entity shape (path A in the spec) so all consumers (`ProfileCardViewComponent`, `MembershipQuery`, `ContactFieldService`, `DuplicateAccountService`, `TeamResourceService`, `GoogleWorkspaceSyncService`, `GoogleAdminService`, `SuspendNonCompliantMembersJob`, admin merge controllers, internal `TeamService` callers) keep their existing field access without change. `ParentTeam` is wired on the synthesized entity so `Team.DisplayName` resolves "Parent - Name" without an EF round-trip.
- Reader path is lock-free: it consults `EnsureWarmedAsync` first (so the inverse map and primary dict are both populated), then iterates the `HashSet<Guid>` snapshot. Writes to the index are confined to `WarmAllAsync`, which runs serially under the base's warm semaphore.

## Test plan
- [x] `dotnet build Humans.slnx -v quiet` — 0 errors
- [x] All 3038 `Humans.Application.Tests` pass (was 1 failure → fixed via comment rephrasing to avoid `NoObsoleteNavReads` rule false-positive on `.Team` text in doc comments)
- [x] 7 new unit tests on `CachingTeamServiceTests` covering: warmup correctness, left-membership exclusion, parent display name, mutation→re-warm consistency, multi-user forward/inverse agreement, zero inner-service call on warm cache, unknown-user fast path

🤖 Generated with [Claude Code](https://claude.com/claude-code)