### PR TITLE
perf(teams): serve GetMyTeamMembershipsAsync from cache

### DIFF
--- a/src/Humans.Application/Interfaces/Teams/ITeamService.cs
+++ b/src/Humans.Application/Interfaces/Teams/ITeamService.cs
@@ -39,7 +39,8 @@ public record TeamInfo(
     string? PageContent = null,
     IReadOnlyList<CallToAction>? CallsToAction = null,
     Instant? PageContentUpdatedAt = null,
-    Guid? PageContentUpdatedByUserId = null)
+    Guid? PageContentUpdatedByUserId = null,
+    int PendingRequestCount = 0)
 {
     /// <summary>
     /// Full Google Group email address, or null if no prefix is set. Mirrors

--- a/src/Humans.Infrastructure/Services/Teams/CachingTeamService.cs
+++ b/src/Humans.Infrastructure/Services/Teams/CachingTeamService.cs
@@ -364,10 +364,71 @@ public sealed class CachingTeamService : TrackedCache<Guid, TeamInfo>, ITeamServ
         IsPromotedToDirectory = info.IsPromotedToDirectory,
     };
 
-    public Task<IReadOnlyList<MyTeamMembershipSummary>> GetMyTeamMembershipsAsync(
+    public async Task<IReadOnlyList<MyTeamMembershipSummary>> GetMyTeamMembershipsAsync(
         Guid userId,
-        CancellationToken cancellationToken = default) =>
-        WithInner(inner => inner.GetMyTeamMembershipsAsync(userId, cancellationToken));
+        CancellationToken cancellationToken = default)
+    {
+        // Cache-served. Uses the user→teams inverse index from WarmAllAsync to
+        // find the user's memberships, and TeamInfo.PendingRequestCount +
+        // ChildTeamIds to compute manageable counts. The single remaining inner
+        // call is IRoleAssignmentService.IsUserBoardMemberAsync — that data is
+        // owned by Auth (not Teams) and is not on TeamInfo.
+        await EnsureWarmedAsync(cancellationToken);
+        var teamsById = AsReadOnlyDictionary;
+        if (!_teamIdsByUserId.TryGetValue(userId, out var teamIds) || teamIds.Count == 0)
+            return [];
+
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        var roleAssignmentService = scope.ServiceProvider.GetRequiredService<IRoleAssignmentService>();
+        var isBoardMember = await roleAssignmentService.IsUserBoardMemberAsync(userId, cancellationToken);
+
+        var result = new List<MyTeamMembershipSummary>(teamIds.Count);
+        foreach (var teamId in teamIds)
+        {
+            if (!teamsById.TryGetValue(teamId, out var team))
+                continue;
+
+            var membership = team.Members.FirstOrDefault(m => m.UserId == userId);
+            if (membership is null)
+                continue;
+
+            var canManage =
+                (membership.Role == TeamMemberRole.Coordinator || isBoardMember)
+                && !team.IsSystemTeam;
+
+            var pendingCount = 0;
+            if (canManage)
+            {
+                pendingCount += team.PendingRequestCount;
+                if (team.ChildTeamIds is not null)
+                {
+                    foreach (var childId in team.ChildTeamIds)
+                    {
+                        if (!teamsById.TryGetValue(childId, out var child) || !child.IsActive)
+                            continue;
+                        pendingCount += child.PendingRequestCount;
+                    }
+                }
+            }
+
+            var displayName = team.ParentTeamId.HasValue
+                && teamsById.TryGetValue(team.ParentTeamId.Value, out var parent)
+                ? $"{parent.Name} - {team.Name}"
+                : team.Name;
+
+            result.Add(new MyTeamMembershipSummary(
+                team.Id,
+                displayName,
+                team.Slug,
+                team.IsSystemTeam,
+                membership.Role,
+                membership.JoinedAt,
+                CanLeave: !team.IsSystemTeam,
+                PendingRequestCount: pendingCount));
+        }
+
+        return result;
+    }
 
     public async Task<Team> UpdateTeamAsync(
         Guid teamId,
@@ -398,12 +459,18 @@ public sealed class CachingTeamService : TrackedCache<Guid, TeamInfo>, ITeamServ
         InvalidateTeamsCache();
     }
 
-    public Task<TeamJoinRequest> RequestToJoinTeamAsync(
+    public async Task<TeamJoinRequest> RequestToJoinTeamAsync(
         Guid teamId,
         Guid userId,
         string? message,
-        CancellationToken cancellationToken = default) =>
-        WithInner(inner => inner.RequestToJoinTeamAsync(teamId, userId, message, cancellationToken));
+        CancellationToken cancellationToken = default)
+    {
+        var result = await WithInner(inner => inner.RequestToJoinTeamAsync(teamId, userId, message, cancellationToken));
+        // Invalidates so the next read of TeamInfo.PendingRequestCount picks up
+        // the new pending row.
+        InvalidateTeamsCache();
+        return result;
+    }
 
     public async Task<TeamMember> JoinTeamDirectlyAsync(
         Guid teamId,
@@ -425,11 +492,16 @@ public sealed class CachingTeamService : TrackedCache<Guid, TeamInfo>, ITeamServ
         return result;
     }
 
-    public Task WithdrawJoinRequestAsync(
+    public async Task WithdrawJoinRequestAsync(
         Guid requestId,
         Guid userId,
-        CancellationToken cancellationToken = default) =>
-        WithInner(inner => inner.WithdrawJoinRequestAsync(requestId, userId, cancellationToken));
+        CancellationToken cancellationToken = default)
+    {
+        await WithInner(inner => inner.WithdrawJoinRequestAsync(requestId, userId, cancellationToken));
+        // Invalidates so the next read of TeamInfo.PendingRequestCount drops the
+        // withdrawn pending row.
+        InvalidateTeamsCache();
+    }
 
     public async Task<TeamMember> ApproveJoinRequestAsync(
         Guid requestId,
@@ -443,12 +515,17 @@ public sealed class CachingTeamService : TrackedCache<Guid, TeamInfo>, ITeamServ
         return result;
     }
 
-    public Task RejectJoinRequestAsync(
+    public async Task RejectJoinRequestAsync(
         Guid requestId,
         Guid approverUserId,
         string reason,
-        CancellationToken cancellationToken = default) =>
-        WithInner(inner => inner.RejectJoinRequestAsync(requestId, approverUserId, reason, cancellationToken));
+        CancellationToken cancellationToken = default)
+    {
+        await WithInner(inner => inner.RejectJoinRequestAsync(requestId, approverUserId, reason, cancellationToken));
+        // Invalidates so the next read of TeamInfo.PendingRequestCount drops the
+        // rejected pending row.
+        InvalidateTeamsCache();
+    }
 
     public Task<IReadOnlyList<TeamJoinRequestSnapshot>> GetPendingRequestsForTeamAsync(
         Guid teamId,
@@ -919,11 +996,17 @@ public sealed class CachingTeamService : TrackedCache<Guid, TeamInfo>, ITeamServ
             .GroupBy(t => t.ParentTeamId!.Value)
             .ToDictionary(g => g.Key, g => (IReadOnlyList<Guid>)g.Select(t => t.Id).ToList());
 
+        // Bulk pending-request counts so TeamInfo.PendingRequestCount is part of
+        // the cache projection. Teams with zero pending requests are absent from
+        // the dictionary; BuildTeamInfo defaults to 0 in that case.
+        var pendingCounts = await _teamRepository.GetPendingCountsByTeamIdsAsync(
+            teams.Select(t => t.Id).ToList(), ct);
+
         // No defensive Clear() — InvalidateTeamsCache already emptied the cache
         // before flipping the warmed flag to false (or the cache is empty on first
         // startup). Set is upsert, so any rare leftover entry is overwritten.
         foreach (var team in teams)
-            Set(team.Id, BuildTeamInfo(team, users, managementHolders, roleDefinitionsByTeam, childIdsByParent));
+            Set(team.Id, BuildTeamInfo(team, users, managementHolders, roleDefinitionsByTeam, childIdsByParent, pendingCounts));
 
         // Rebuild the inverse user→teams index from scratch. The base coalesces
         // WarmAllAsync under its warm semaphore so this body runs serially;
@@ -970,7 +1053,8 @@ public sealed class CachingTeamService : TrackedCache<Guid, TeamInfo>, ITeamServ
         IReadOnlyDictionary<Guid, Application.UserInfo> users,
         IReadOnlyDictionary<Guid, IReadOnlySet<Guid>> managementHolders,
         IReadOnlyDictionary<Guid, IReadOnlyList<TeamRoleDefinition>> roleDefinitionsByTeam,
-        IReadOnlyDictionary<Guid, IReadOnlyList<Guid>> childIdsByParent) => new(
+        IReadOnlyDictionary<Guid, IReadOnlyList<Guid>> childIdsByParent,
+        IReadOnlyDictionary<Guid, int> pendingCounts) => new(
         Id: team.Id,
         Name: team.Name,
         Description: team.Description,
@@ -1014,7 +1098,8 @@ public sealed class CachingTeamService : TrackedCache<Guid, TeamInfo>, ITeamServ
         PageContent: team.PageContent,
         CallsToAction: team.CallsToAction,
         PageContentUpdatedAt: team.PageContentUpdatedAt,
-        PageContentUpdatedByUserId: team.PageContentUpdatedByUserId);
+        PageContentUpdatedByUserId: team.PageContentUpdatedByUserId,
+        PendingRequestCount: pendingCounts.TryGetValue(team.Id, out var pending) ? pending : 0);
 
     private static TeamRoleDefinitionSnapshot ProjectRoleDefinitionSnapshot(TeamRoleDefinition d, Team team) =>
         new(

--- a/src/Humans.Infrastructure/Services/Teams/CachingTeamService.cs
+++ b/src/Humans.Infrastructure/Services/Teams/CachingTeamService.cs
@@ -392,8 +392,12 @@ public sealed class CachingTeamService : TrackedCache<Guid, TeamInfo>, ITeamServ
             if (membership is null)
                 continue;
 
+            // Inherited coordinator: a user can manage a team if they're a
+            // direct Coordinator, a board member, or coordinate any ancestor
+            // team (matches CanUserApproveRequestsForTeamAsync's recursive
+            // parent walk via IsUserCoordinatorOfActiveTeam).
             var canManage =
-                (membership.Role == TeamMemberRole.Coordinator || isBoardMember)
+                (isBoardMember || IsUserCoordinatorOfActiveTeam(teamsById, team.Id, userId))
                 && !team.IsSystemTeam;
 
             var pendingCount = 0;

--- a/tests/Humans.Application.Tests/Services/CachingTeamServiceGetTeamDetailTests.cs
+++ b/tests/Humans.Application.Tests/Services/CachingTeamServiceGetTeamDetailTests.cs
@@ -47,6 +47,9 @@ public sealed class CachingTeamServiceGetTeamDetailTests : IDisposable
         _teamRepository
             .GetAllRoleDefinitionsByTeamAsync(Arg.Any<CancellationToken>())
             .Returns(new Dictionary<Guid, IReadOnlyList<TeamRoleDefinition>>());
+        _teamRepository
+            .GetPendingCountsByTeamIdsAsync(Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<Guid, int>());
 
         var services = new ServiceCollection();
         services.AddSingleton(userService);

--- a/tests/Humans.Application.Tests/Services/CachingTeamServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/CachingTeamServiceTests.cs
@@ -1,4 +1,5 @@
 using AwesomeAssertions;
+using Humans.Application.Interfaces.Auth;
 using Humans.Application.Interfaces.Repositories;
 using Humans.Application.Interfaces.Teams;
 using Humans.Application.Interfaces.Users;
@@ -23,6 +24,7 @@ public sealed class CachingTeamServiceTests : IDisposable
     private readonly HumansDbContext _dbContext;
     private readonly FakeClock _clock = new(Instant.FromUtc(2026, 3, 1, 12, 0));
     private readonly ServiceProvider _serviceProvider;
+    private readonly IRoleAssignmentService _roleAssignmentService;
     private readonly CachingTeamService _service;
 
     public CachingTeamServiceTests()
@@ -42,8 +44,14 @@ public sealed class CachingTeamServiceTests : IDisposable
             });
         userService.StubGetUserInfosFromDb(_options);
 
+        _roleAssignmentService = Substitute.For<IRoleAssignmentService>();
+        _roleAssignmentService
+            .IsUserBoardMemberAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(false);
+
         var services = new ServiceCollection();
         services.AddSingleton(userService);
+        services.AddSingleton(_roleAssignmentService);
         services.AddKeyedScoped<ITeamService>(
             CachingTeamService.InnerServiceKey,
             (_, _) => Substitute.For<ITeamService>());
@@ -304,6 +312,217 @@ public sealed class CachingTeamServiceTests : IDisposable
         var inner = _serviceProvider.GetRequiredKeyedService<ITeamService>(
             CachingTeamService.InnerServiceKey);
         await inner.DidNotReceive().GetUserTeamsAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+    }
+
+    // ==========================================================================
+    // GetMyTeamMembershipsAsync — cache-served (issue nobodies-collective/Humans#748)
+    // ==========================================================================
+
+    [HumansFact]
+    public async Task GetMyTeamMembershipsAsync_Coordinator_GetsPendingCountsForManageableNonSystemTeams()
+    {
+        var user = SeedUser("Coordinator");
+        var managedTeam = SeedTeam("Alpha");
+        var systemTeam = SeedTeam("Volunteers");
+        systemTeam.SystemTeamType = SystemTeamType.Volunteers;
+        SeedTeamMember(managedTeam.Id, user.Id, TeamMemberRole.Coordinator);
+        SeedTeamMember(systemTeam.Id, user.Id, TeamMemberRole.Coordinator);
+        SeedJoinRequest(managedTeam.Id, SeedUser("Requester A").Id);
+        SeedJoinRequest(systemTeam.Id, SeedUser("Requester B").Id);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _service.GetMyTeamMembershipsAsync(user.Id);
+
+        result.Should().HaveCount(2);
+        result.Single(m => m.TeamId == managedTeam.Id).PendingRequestCount.Should().Be(1);
+        result.Single(m => m.TeamId == managedTeam.Id).CanLeave.Should().BeTrue();
+        result.Single(m => m.TeamId == systemTeam.Id).PendingRequestCount.Should().Be(0);
+        result.Single(m => m.TeamId == systemTeam.Id).CanLeave.Should().BeFalse();
+    }
+
+    [HumansFact]
+    public async Task GetMyTeamMembershipsAsync_BoardMember_GetsPendingCountsForRegularMemberships()
+    {
+        var user = SeedUser("Board Human");
+        _roleAssignmentService
+            .IsUserBoardMemberAsync(user.Id, Arg.Any<CancellationToken>())
+            .Returns(true);
+        var team = SeedTeam("Alpha");
+        SeedTeamMember(team.Id, user.Id, TeamMemberRole.Member);
+        SeedJoinRequest(team.Id, SeedUser("Requester").Id);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _service.GetMyTeamMembershipsAsync(user.Id);
+
+        result.Should().ContainSingle();
+        result[0].Role.Should().Be(TeamMemberRole.Member);
+        result[0].PendingRequestCount.Should().Be(1);
+    }
+
+    [HumansFact]
+    public async Task GetMyTeamMembershipsAsync_Coordinator_AggregatesChildTeamPendingCounts()
+    {
+        var user = SeedUser("Department Coordinator");
+        var department = SeedTeam("Department");
+        var child = SeedTeam("Child");
+        child.ParentTeamId = department.Id;
+        SeedTeamMember(department.Id, user.Id, TeamMemberRole.Coordinator);
+        SeedJoinRequest(department.Id, SeedUser("Direct Requester").Id);
+        SeedJoinRequest(child.Id, SeedUser("Child Requester A").Id);
+        SeedJoinRequest(child.Id, SeedUser("Child Requester B").Id);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _service.GetMyTeamMembershipsAsync(user.Id);
+
+        var deptRow = result.Should().ContainSingle(m => m.TeamId == department.Id).Subject;
+        deptRow.PendingRequestCount.Should().Be(3);
+        deptRow.TeamName.Should().Be("Department");
+    }
+
+    [HumansFact]
+    public async Task GetMyTeamMembershipsAsync_NonCoordinatorNonBoard_DoesNotCountPending()
+    {
+        var user = SeedUser("Regular Member");
+        var team = SeedTeam("Alpha");
+        SeedTeamMember(team.Id, user.Id, TeamMemberRole.Member);
+        SeedJoinRequest(team.Id, SeedUser("Requester").Id);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _service.GetMyTeamMembershipsAsync(user.Id);
+
+        result.Should().ContainSingle();
+        result[0].PendingRequestCount.Should().Be(0);
+    }
+
+    [HumansFact]
+    public async Task GetMyTeamMembershipsAsync_ChildTeamMembership_DisplayNameIsParentDashChild()
+    {
+        var user = SeedUser("Alice");
+        var parent = SeedTeam("Comms");
+        var child = SeedTeam("Logo");
+        child.ParentTeamId = parent.Id;
+        SeedTeamMember(child.Id, user.Id, TeamMemberRole.Member);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _service.GetMyTeamMembershipsAsync(user.Id);
+
+        var row = result.Should().ContainSingle().Subject;
+        row.TeamName.Should().Be("Comms - Logo");
+    }
+
+    [HumansFact]
+    public async Task GetMyTeamMembershipsAsync_WarmCache_DoesNotCallInnerService()
+    {
+        var user = SeedUser("Alice");
+        var team = SeedTeam("Alpha");
+        SeedTeamMember(team.Id, user.Id, TeamMemberRole.Coordinator);
+        SeedJoinRequest(team.Id, SeedUser("Requester").Id);
+        await _dbContext.SaveChangesAsync();
+
+        // Drive a first call to warm the cache (which uses the repository, not
+        // the inner service).
+        var first = await _service.GetMyTeamMembershipsAsync(user.Id);
+        first.Should().ContainSingle();
+        first[0].PendingRequestCount.Should().Be(1);
+
+        var inner = _serviceProvider.GetRequiredKeyedService<ITeamService>(
+            CachingTeamService.InnerServiceKey);
+
+        // A warm-cache second call must NOT touch the inner ITeamService — the
+        // T-01 zero-EF-on-warm assertion for GetMyTeamMembershipsAsync.
+        var second = await _service.GetMyTeamMembershipsAsync(user.Id);
+        second.Should().ContainSingle();
+
+        await inner.DidNotReceive()
+            .GetMyTeamMembershipsAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+    }
+
+    // ==========================================================================
+    // Join-lifecycle invalidation — issue nobodies-collective/Humans#748
+    // ==========================================================================
+
+    [HumansFact]
+    public async Task RequestToJoinTeamAsync_InvalidatesCache()
+    {
+        var team = SeedTeam("Alpha");
+        await _dbContext.SaveChangesAsync();
+
+        // Warm the cache so we can observe invalidation by counter.
+        await _service.GetTeamAsync(team.Id);
+        var before = _service.BulkInvalidations;
+
+        await _service.RequestToJoinTeamAsync(team.Id, Guid.NewGuid(), null);
+
+        _service.BulkInvalidations.Should().BeGreaterThan(before);
+    }
+
+    [HumansFact]
+    public async Task WithdrawJoinRequestAsync_InvalidatesCache()
+    {
+        var team = SeedTeam("Alpha");
+        await _dbContext.SaveChangesAsync();
+        await _service.GetTeamAsync(team.Id);
+        var before = _service.BulkInvalidations;
+
+        await _service.WithdrawJoinRequestAsync(Guid.NewGuid(), Guid.NewGuid());
+
+        _service.BulkInvalidations.Should().BeGreaterThan(before);
+    }
+
+    [HumansFact]
+    public async Task RejectJoinRequestAsync_InvalidatesCache()
+    {
+        var team = SeedTeam("Alpha");
+        await _dbContext.SaveChangesAsync();
+        await _service.GetTeamAsync(team.Id);
+        var before = _service.BulkInvalidations;
+
+        await _service.RejectJoinRequestAsync(Guid.NewGuid(), Guid.NewGuid(), "reason");
+
+        _service.BulkInvalidations.Should().BeGreaterThan(before);
+    }
+
+    [HumansFact]
+    public async Task ApproveJoinRequestAsync_InvalidatesCache()
+    {
+        var team = SeedTeam("Alpha");
+        await _dbContext.SaveChangesAsync();
+        await _service.GetTeamAsync(team.Id);
+        var before = _service.BulkInvalidations;
+
+        // Inner is an unconfigured NSubstitute mock; ApproveJoinRequestAsync
+        // returns default (null TeamMember) — that's fine for this assertion.
+        await _service.ApproveJoinRequestAsync(Guid.NewGuid(), Guid.NewGuid(), null);
+
+        _service.BulkInvalidations.Should().BeGreaterThan(before);
+    }
+
+    [HumansFact]
+    public async Task WarmAllAsync_PopulatesTeamInfoPendingRequestCount()
+    {
+        var team = SeedTeam("Alpha");
+        SeedJoinRequest(team.Id, SeedUser("Requester A").Id);
+        SeedJoinRequest(team.Id, SeedUser("Requester B").Id);
+        await _dbContext.SaveChangesAsync();
+
+        var info = await _service.GetTeamAsync(team.Id);
+
+        info.Should().NotBeNull();
+        info!.PendingRequestCount.Should().Be(2);
+    }
+
+    private TeamJoinRequest SeedJoinRequest(Guid teamId, Guid userId)
+    {
+        var request = new TeamJoinRequest
+        {
+            Id = Guid.NewGuid(),
+            TeamId = teamId,
+            UserId = userId,
+            Status = TeamJoinRequestStatus.Pending,
+            RequestedAt = _clock.GetCurrentInstant()
+        };
+        _dbContext.TeamJoinRequests.Add(request);
+        return request;
     }
 
     public void Dispose()

--- a/tests/Humans.Application.Tests/Services/CachingTeamServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/CachingTeamServiceTests.cs
@@ -380,6 +380,29 @@ public sealed class CachingTeamServiceTests : IDisposable
     }
 
     [HumansFact]
+    public async Task GetMyTeamMembershipsAsync_InheritedCoordinator_GetsPendingCountForChildMembership()
+    {
+        // User coordinates the parent and is a regular Member on the child.
+        // Per CanUserApproveRequestsForTeamAsync's parent-walk semantics, they
+        // can manage the child team, so the child membership row must surface
+        // its pending count.
+        var user = SeedUser("Inherited Coordinator");
+        var parent = SeedTeam("Parent");
+        var child = SeedTeam("Child");
+        child.ParentTeamId = parent.Id;
+        SeedTeamMember(parent.Id, user.Id, TeamMemberRole.Coordinator);
+        SeedTeamMember(child.Id, user.Id, TeamMemberRole.Member);
+        SeedJoinRequest(child.Id, SeedUser("Child Requester").Id);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _service.GetMyTeamMembershipsAsync(user.Id);
+
+        var childRow = result.Should().ContainSingle(m => m.TeamId == child.Id).Subject;
+        childRow.Role.Should().Be(TeamMemberRole.Member);
+        childRow.PendingRequestCount.Should().Be(1);
+    }
+
+    [HumansFact]
     public async Task GetMyTeamMembershipsAsync_NonCoordinatorNonBoard_DoesNotCountPending()
     {
         var user = SeedUser("Regular Member");


### PR DESCRIPTION
## Summary

Issue: nobodies-collective/Humans#748
**Depends on PR #629 (issue #746)** — uses the `_teamIdsByUserId` user→teams index from #746. This branch is currently based on `sprint/2026-05-17/issue-746`; rebase onto `origin/main` once #629 merges.

Bakes `PendingRequestCount` onto the `TeamInfo` cache projection and converts `CachingTeamService.GetMyTeamMembershipsAsync` from a pass-through into a cache-served implementation. On a warm cache, the only remaining cross-section call is `IRoleAssignmentService.IsUserBoardMemberAsync` — Auth-owned data that is not on `TeamInfo`.

## Changes

- **`TeamInfo.PendingRequestCount`** — new optional field, populated in `WarmAllAsync` via the existing bulk `ITeamRepository.GetPendingCountsByTeamIdsAsync`.
- **Lifecycle invalidation** — `RequestToJoinTeamAsync`, `WithdrawJoinRequestAsync`, and `RejectJoinRequestAsync` on the decorator now call `InvalidateTeamsCache()`. `ApproveJoinRequestAsync` already invalidated. Follows the #746 "Clear() → re-warm" pattern.
- **`GetMyTeamMembershipsAsync` cache-served** — projects from `_teamIdsByUserId` (#746) + `TeamInfo`, walks `TeamInfo.ChildTeamIds` for department-coordinator child aggregation, computes `"Parent - Name"` display name in memory. The inner `TeamService.GetMyTeamMembershipsAsync` remains untouched as fallback per the spec.

## Test plan

- [x] `dotnet build Humans.slnx -v quiet` — 0 errors
- [x] `dotnet test Humans.slnx -v quiet --filter "FullyQualifiedName~CachingTeamService"` — 28/28 pass
- [x] Full `Humans.Application.Tests` — 3053/3053 pass
- [x] Integration test failures verified pre-existing on base branch (Hangfire `JobStorage` setup, unrelated to this change)

## New tests

- `RequestToJoinTeamAsync_InvalidatesCache`, `WithdrawJoinRequestAsync_InvalidatesCache`, `RejectJoinRequestAsync_InvalidatesCache`, `ApproveJoinRequestAsync_InvalidatesCache` — lifecycle invalidation per event
- `GetMyTeamMembershipsAsync_WarmCache_DoesNotCallInnerService` — zero-EF-on-warm assertion
- `GetMyTeamMembershipsAsync_Coordinator_GetsPendingCountsForManageableNonSystemTeams`
- `GetMyTeamMembershipsAsync_BoardMember_GetsPendingCountsForRegularMemberships`
- `GetMyTeamMembershipsAsync_Coordinator_AggregatesChildTeamPendingCounts`
- `GetMyTeamMembershipsAsync_NonCoordinatorNonBoard_DoesNotCountPending`
- `GetMyTeamMembershipsAsync_ChildTeamMembership_DisplayNameIsParentDashChild`
- `WarmAllAsync_PopulatesTeamInfoPendingRequestCount`