### PR TITLE
tech-debt: finish Stream C cross-domain Team FK strip (HUM0010 deadline 2026-06-01)

### DIFF
--- a/src/Humans.Domain/Entities/BudgetLineItem.cs
+++ b/src/Humans.Domain/Entities/BudgetLineItem.cs
@@ -13,16 +13,6 @@ public class BudgetLineItem
     public string Description { get; set; } = string.Empty;
     public decimal Amount { get; set; }
     public Guid? ResponsibleTeamId { get; set; }
-
-    /// <summary>
-    /// Cross-domain navigation to the responsible team. Do not use — callers
-    /// resolve team slices via <c>ITeamService</c>, keyed off
-    /// <see cref="ResponsibleTeamId"/>. Retained only so EF's configured FK
-    /// constraint stays modelled.
-    /// </summary>
-    [Architecture.ExpiresOn("2026-06-01", reason: "Stream C typed-FK conversion — readers must stitch via ITeamService.")]
-    [Obsolete("Cross-domain nav. Use ResponsibleTeamId + ITeamService to resolve the team.")]
-    public Team? ResponsibleTeam { get; set; }
     public string? Notes { get; set; }
 
     /// <summary>

--- a/src/Humans.Domain/Entities/GoogleResource.cs
+++ b/src/Humans.Domain/Entities/GoogleResource.cs
@@ -39,16 +39,6 @@ public class GoogleResource
     public Guid TeamId { get; set; }
 
     /// <summary>
-    /// Cross-domain navigation to the owning team. Do not use — callers resolve
-    /// team slices via <c>ITeamService</c>, keyed off <see cref="TeamId"/>. Retained
-    /// only so EF's configured relationship keeps the FK constraint (see
-    /// <see cref="Humans.Infrastructure"/> GoogleResourceConfiguration / TeamConfiguration).
-    /// </summary>
-    [Architecture.ExpiresOn("2026-06-01", reason: "Stream C typed-FK conversion — readers must stitch via ITeamService.")]
-    [Obsolete("Cross-domain nav. Use TeamId + ITeamService to resolve the team.")]
-    public Team Team { get; set; } = null!;
-
-    /// <summary>
     /// When the resource was provisioned.
     /// </summary>
     public Instant ProvisionedAt { get; init; }

--- a/src/Humans.Domain/Entities/LegalDocument.cs
+++ b/src/Humans.Domain/Entities/LegalDocument.cs
@@ -25,15 +25,6 @@ public class LegalDocument
     public Guid TeamId { get; set; }
 
     /// <summary>
-    /// Cross-domain navigation to the owning <see cref="Team"/>. Kept so EF's
-    /// snapshot remains in sync with the schema; do not read in application
-    /// code — resolve via <c>ITeamService</c>. See design-rules §6c.
-    /// </summary>
-    [Architecture.ExpiresOn("2026-06-01", reason: "peterdrier#719 — Legal section migrated off LegalDocument.Team. Schedule-for-strip in a follow-up PR once prod-verified.")]
-    [Obsolete("Cross-domain nav — resolve via ITeamService instead of navigating LegalDocument.Team. See design-rules §6c.")]
-    public Team Team { get; set; } = null!;
-
-    /// <summary>
     /// Grace period in days before membership becomes inactive due to missing re-consent.
     /// </summary>
     public int GracePeriodDays { get; set; } = 7;

--- a/src/Humans.Domain/Entities/Team.cs
+++ b/src/Humans.Domain/Entities/Team.cs
@@ -155,15 +155,6 @@ public class Team
     public ICollection<TeamJoinRequest> JoinRequests { get; } = new List<TeamJoinRequest>();
 
     /// <summary>
-    /// Reverse navigation kept solely so EF can declare the FK + cascade behavior
-    /// for <c>LegalDocument.Team</c>. Not read by application code — query via
-    /// <c>ILegalDocumentSyncService</c>. Collection-side nav is left unmarked to
-    /// avoid the obsolete-nav scanner false-positive on <c>DbContext.LegalDocuments</c>
-    /// (same identifier).
-    /// </summary>
-    public ICollection<LegalDocument> LegalDocuments { get; } = new List<LegalDocument>();
-
-    /// <summary>
     /// Navigation property to role definitions.
     /// </summary>
     public ICollection<TeamRoleDefinition> RoleDefinitions { get; } = new List<TeamRoleDefinition>();

--- a/src/Humans.Infrastructure/Data/Configurations/Budget/BudgetLineItemConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/Budget/BudgetLineItemConfiguration.cs
@@ -21,10 +21,6 @@ public class BudgetLineItemConfiguration : IEntityTypeConfiguration<BudgetLineIt
         builder.Property(l => l.CreatedAt).IsRequired();
         builder.Property(l => l.UpdatedAt).IsRequired();
 
-#pragma warning disable CS0618 // Obsolete cross-domain nav kept so EF FK constraint stays modelled.
-        builder.HasOne(l => l.ResponsibleTeam).WithMany().HasForeignKey(l => l.ResponsibleTeamId).OnDelete(DeleteBehavior.SetNull);
-#pragma warning restore CS0618
-
         builder.HasIndex(l => new { l.BudgetCategoryId, l.SortOrder });
         builder.HasIndex(l => l.ResponsibleTeamId).HasFilter("\"ResponsibleTeamId\" IS NOT NULL");
     }

--- a/src/Humans.Infrastructure/Data/Configurations/Legal/LegalDocumentConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/Legal/LegalDocumentConfiguration.cs
@@ -35,13 +35,6 @@ public class LegalDocumentConfiguration : IEntityTypeConfiguration<LegalDocument
         builder.Property(ld => ld.LastSyncedAt)
             .IsRequired();
 
-#pragma warning disable CS0618 // LegalDocument.Team is an obsolete cross-domain nav (peterdrier#719); EF config still references it so the snapshot stays in sync until a follow-up PR strips both.
-        builder.HasOne(ld => ld.Team)
-            .WithMany(t => t.LegalDocuments)
-            .HasForeignKey(ld => ld.TeamId)
-            .OnDelete(DeleteBehavior.Restrict);
-#pragma warning restore CS0618, HUM0010
-
         builder.HasMany(ld => ld.Versions)
             .WithOne(v => v.LegalDocument)
             .HasForeignKey(v => v.LegalDocumentId)

--- a/src/Humans.Infrastructure/Data/Configurations/Teams/TeamConfiguration.cs
+++ b/src/Humans.Infrastructure/Data/Configurations/Teams/TeamConfiguration.cs
@@ -110,19 +110,6 @@ public class TeamConfiguration : IEntityTypeConfiguration<Team>
             .HasForeignKey(jr => jr.TeamId)
             .OnDelete(DeleteBehavior.Cascade);
 
-        // google_resources is owned by TeamResourceService. The Team → GoogleResource
-        // navigation was removed to enforce ownership — the relationship is now
-        // configured from the GoogleResource side only via its Team nav property.
-        // Restrict (not SetNull): GoogleResource.TeamId is non-nullable, so SetNull
-        // would produce a NOT NULL violation on team delete. Teams should never be
-        // hard-deleted if resources exist — the caller must unlink resources first.
-#pragma warning disable CS0618 // GoogleResource.Team is an obsolete cross-domain nav kept so EF FK constraint stays modelled.
-        builder.HasMany<GoogleResource>()
-            .WithOne(gr => gr.Team)
-            .HasForeignKey(gr => gr.TeamId)
-            .OnDelete(DeleteBehavior.Restrict);
-#pragma warning restore CS0618
-
         builder.HasIndex(t => t.Slug)
             .IsUnique();
 

--- a/src/Humans.Infrastructure/Migrations/20260517154100_DropCrossDomainTeamFkConstraints.Designer.cs
+++ b/src/Humans.Infrastructure/Migrations/20260517154100_DropCrossDomainTeamFkConstraints.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Humans.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Humans.Infrastructure.Migrations
 {
     [DbContext(typeof(HumansDbContext))]
-    partial class HumansDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260517154100_DropCrossDomainTeamFkConstraints")]
+    partial class DropCrossDomainTeamFkConstraints
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Humans.Infrastructure/Migrations/20260517154100_DropCrossDomainTeamFkConstraints.cs
+++ b/src/Humans.Infrastructure/Migrations/20260517154100_DropCrossDomainTeamFkConstraints.cs
@@ -1,0 +1,54 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Humans.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class DropCrossDomainTeamFkConstraints : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_budget_line_items_teams_ResponsibleTeamId",
+                table: "budget_line_items");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_google_resources_teams_TeamId",
+                table: "google_resources");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_legal_documents_teams_TeamId",
+                table: "legal_documents");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddForeignKey(
+                name: "FK_budget_line_items_teams_ResponsibleTeamId",
+                table: "budget_line_items",
+                column: "ResponsibleTeamId",
+                principalTable: "teams",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_google_resources_teams_TeamId",
+                table: "google_resources",
+                column: "TeamId",
+                principalTable: "teams",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_legal_documents_teams_TeamId",
+                table: "legal_documents",
+                column: "TeamId",
+                principalTable: "teams",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+    }
+}

--- a/tests/Humans.Application.Tests/Architecture/Baselines/NoCrossSectionEfJoins.baseline.txt
+++ b/tests/Humans.Application.Tests/Architecture/Baselines/NoCrossSectionEfJoins.baseline.txt
@@ -17,7 +17,6 @@ src/Humans.Infrastructure/Data/Configurations/Email/EmailOutboxMessageConfigurat
 src/Humans.Infrastructure/Data/Configurations/Email/EmailOutboxMessageConfiguration.cs:HasOne<User>(Email->Users)#1
 src/Humans.Infrastructure/Data/Configurations/Feedback/FeedbackReportConfiguration.cs:HasOne(=>.User)(Feedback->Users)#1
 src/Humans.Infrastructure/Data/Configurations/Legal/ConsentRecordConfiguration.cs:HasOne(=>.User)(Legal->Users)#1
-src/Humans.Infrastructure/Data/Configurations/Legal/LegalDocumentConfiguration.cs:HasOne(=>.Team)(Legal->Teams)#1
 src/Humans.Infrastructure/Data/Configurations/Notifications/NotificationRecipientConfiguration.cs:HasOne(=>.User)(Notifications->Users)#1
 src/Humans.Infrastructure/Data/Configurations/Profiles/CommunicationPreferenceConfiguration.cs:HasOne<User>(Profiles->Users)#1
 src/Humans.Infrastructure/Data/Configurations/Profiles/ProfileConfiguration.cs:HasOne<User>(Profiles->Users)#1

--- a/tests/Humans.Application.Tests/Architecture/Baselines/NoDestructiveMigrationOps.baseline.txt
+++ b/tests/Humans.Application.Tests/Architecture/Baselines/NoDestructiveMigrationOps.baseline.txt
@@ -28,3 +28,6 @@ src/Humans.Infrastructure/Migrations/20260414215135_RestrictGoogleResourceTeamDe
 src/Humans.Infrastructure/Migrations/20260426185621_DropCampRoleIsRequired.cs:DropColumn(name=IsRequired)#1
 src/Humans.Infrastructure/Migrations/20260514170550_AddContainers.cs:DropColumn(name=ContainerCount)#1
 src/Humans.Infrastructure/Migrations/20260514170550_AddContainers.cs:DropColumn(name=ContainerNotes)#1
+src/Humans.Infrastructure/Migrations/20260517154100_DropCrossDomainTeamFkConstraints.cs:DropForeignKey(name=FK_budget_line_items_teams_ResponsibleTeamId)#1
+src/Humans.Infrastructure/Migrations/20260517154100_DropCrossDomainTeamFkConstraints.cs:DropForeignKey(name=FK_google_resources_teams_TeamId)#1
+src/Humans.Infrastructure/Migrations/20260517154100_DropCrossDomainTeamFkConstraints.cs:DropForeignKey(name=FK_legal_documents_teams_TeamId)#1

--- a/tests/Humans.Application.Tests/Services/ConsentServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/ConsentServiceTests.cs
@@ -74,16 +74,20 @@ public class ConsentServiceTests : IDisposable
                 if (teamIds.Count == 0)
                     return (IReadOnlyList<ActiveRequiredLegalDocumentSnapshot>)[];
 
-#pragma warning disable CS0618 // Test stub uses LegalDocument.Team to populate the snapshot's TeamName; production stitches via ITeamService.
                 var documents = await _dbContext.LegalDocuments
                     .AsNoTracking()
                     .Where(d => d.IsActive && d.IsRequired && teamIds.Contains(d.TeamId))
-                    .Include(d => d.Team)
                     .Include(d => d.Versions)
                     .ToListAsync();
 
-                return documents.Select(ToActiveRequiredDocumentSnapshot).ToList();
-#pragma warning restore CS0618
+                var teamNames = await _dbContext.Teams
+                    .AsNoTracking()
+                    .Where(t => teamIds.Contains(t.Id))
+                    .ToDictionaryAsync(t => t.Id, t => t.Name);
+
+                return documents
+                    .Select(d => ToActiveRequiredDocumentSnapshot(d, teamNames.GetValueOrDefault(d.TeamId, "")))
+                    .ToList();
             });
 
         var factory = new TestDbContextFactory(options);
@@ -271,13 +275,12 @@ public class ConsentServiceTests : IDisposable
         });
     }
 
-#pragma warning disable CS0618 // Test stub mirrors the legacy Include(d => d.Team) read path; prod stitches via ITeamService.
-    private static ActiveRequiredLegalDocumentSnapshot ToActiveRequiredDocumentSnapshot(LegalDocument document) =>
+    private static ActiveRequiredLegalDocumentSnapshot ToActiveRequiredDocumentSnapshot(LegalDocument document, string teamName) =>
         new(
             document.Id,
             document.Name,
             document.TeamId,
-            document.Team.Name,
+            teamName,
             document.LastSyncedAt,
             document.Versions.Select(v => new LegalDocumentVersionSnapshot(
                 v.Id,
@@ -290,7 +293,6 @@ public class ConsentServiceTests : IDisposable
                 v.RequiresReConsent,
                 v.CreatedAt,
                 v.ChangesSummary)).ToList());
-#pragma warning restore CS0618
 
     [HumansFact]
     public async Task SubmitConsentAsync_RecordsMetric()


### PR DESCRIPTION
## Summary

Finishes the Stream C cross-domain Team FK conversion that PR #594 deferred. Three nav properties carried `[ExpiresOn("2026-06-01")]` — that deadline is 15 days away and auto-promotes the warnings to errors at that point.

- Delete `BudgetLineItem.ResponsibleTeam`, `GoogleResource.Team`, `LegalDocument.Team` (and the `Team.LegalDocuments` inverse collection).
- Delete the matching `HasOne`/`HasMany` configs (and their CS0618 pragma wrappers).
- Auto-generated migration `DropCrossDomainTeamFkConstraints`: three `DropForeignKey` ops only. FK columns (`ResponsibleTeamId` / `TeamId`) stay as bare `Guid?` per `memory/architecture/no-cross-section-ef-joins.md`.
- Fix the one test stub in `ConsentServiceTests` that stitched team name via `Include(d => d.Team)` — now stitches from `_dbContext.Teams` in-memory.
- Ratchet baselines updated: drop the now-fixed `LegalDocumentConfiguration` cross-section entry; add the three new `DropForeignKey` ops to the destructive-ops baseline (intentional drops).

## Test plan

- [x] `dotnet build Humans.slnx -v quiet` — 0 errors. HUM0010 warning count: 6 → 0.
- [x] `dotnet test Humans.slnx -v quiet --filter "FullyQualifiedName~Architecture"` — 381 passed.
- [x] Unit tests touching the affected area pass (Domain/Web/Analyzers/Application — 502 in the targeted run).
- [ ] Preview env smoke (PR auto-deploys to `{pr_id}.n.burn.camp`).

## Out of scope (follow-up)

This branch also explored migrating the `HUM_USER_DISPLAYNAME` / `HUM_USERINFO_DISPLAYNAME` render-path leaks (the 277 warnings in the rest of the build). That work was started in parallel subagents but did not survive — one of them ran `git checkout -- .` mid-pass. The remaining DisplayName cleanup needs its own focused PR. The carve-outs that *can never* be migrated (Identity claims, repository tombstones, EF mapping, dev seeders, debug screens, GDPR export, SEPA legal-name fallback, caching plumbing) emit warnings forever by design — see `Directory.Build.props:34-40` and `memory/process/no-analyzer-suppressions.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)