### PR TITLE
fix(shifts): isolate per-recipient enqueue failures in rota email loop

### DIFF
--- a/src/Humans.Application/Services/Shifts/RotaCoordinatorMessageService.cs
+++ b/src/Humans.Application/Services/Shifts/RotaCoordinatorMessageService.cs
@@ -148,6 +148,13 @@ public sealed class RotaCoordinatorMessageService : IRotaCoordinatorMessageServi
                 + auditSuffix,
             senderUserId);
 
+        // Total-failure path: every enqueue threw. Audit row already records
+        // the failures; surface a Failure result so the controller does not
+        // render a misleading "Queued 0 email(s)" success toast.
+        if (queued == 0 && failed > 0)
+            return RotaMessageDispatchResult.Failure(
+                $"Failed to enqueue any emails ({failed} enqueue error(s)); check server logs.");
+
         return RotaMessageDispatchResult.Success(queued, rota.Name);
     }
 

--- a/src/Humans.Application/Services/Shifts/RotaCoordinatorMessageService.cs
+++ b/src/Humans.Application/Services/Shifts/RotaCoordinatorMessageService.cs
@@ -85,6 +85,7 @@ public sealed class RotaCoordinatorMessageService : IRotaCoordinatorMessageServi
 
         var queued = 0;
         var skipped = 0;
+        var failed = 0;
         foreach (var (userId, userSignups) in byUser)
         {
             if (!recipientInfos.TryGetValue(userId, out var recipient))
@@ -118,15 +119,33 @@ public sealed class RotaCoordinatorMessageService : IRotaCoordinatorMessageServi
                 ShiftLines: shiftLines,
                 Culture: recipient.PreferredLanguage);
 
-            await _emailService.SendCoordinatorRotaMessageAsync(request, ct);
-            queued++;
+            // Per-recipient enqueue is isolated: a transient outbox-write
+            // failure on one recipient must not unwind the loop and leave
+            // the audit row unwritten or earlier enqueues unaccounted for.
+            // Matches the fan-out pattern in AttendeeContactImportService.
+            try
+            {
+                await _emailService.SendCoordinatorRotaMessageAsync(request, ct);
+                queued++;
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                failed++;
+                _logger.LogError(ex,
+                    "Failed to enqueue rota email for recipient {UserId} on rota {RotaId}",
+                    userId, rotaId);
+            }
         }
+
+        var auditSuffix = string.Empty;
+        if (skipped > 0) auditSuffix += $" ({skipped} skipped: no email or missing user)";
+        if (failed > 0) auditSuffix += $" ({failed} failed: enqueue error)";
 
         await _auditLogService.LogAsync(
             AuditAction.CoordinatorRotaMessageSent,
             nameof(Rota), rota.Id,
             $"Sent rota message '{Truncate(messageText, 120)}' to {queued} recipient(s) on '{rota.Name}'"
-                + (skipped > 0 ? $" ({skipped} skipped: no email or missing user)" : string.Empty),
+                + auditSuffix,
             senderUserId);
 
         return RotaMessageDispatchResult.Success(queued, rota.Name);

--- a/tests/Humans.Application.Tests/Services/Shifts/RotaCoordinatorMessageServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Shifts/RotaCoordinatorMessageServiceTests.cs
@@ -275,6 +275,49 @@ public sealed class RotaCoordinatorMessageServiceTests
             Arg.Any<string?>());
     }
 
+    [HumansFact]
+    public async Task SendRotaMessageAsync_ReturnsFailure_WhenAllRecipientEnqueuesThrow()
+    {
+        var rota = MakeRota(out _);
+        _signupRepo.GetRotaWithShiftsAsync(rota.Id, Arg.Any<CancellationToken>()).Returns(rota);
+
+        var userA = Guid.NewGuid();
+        var userB = Guid.NewGuid();
+        var sender = Guid.NewGuid();
+        var shift = MakeShift(rota.Id, dayOffset: 1, startHour: 10);
+
+        _signupRepo.GetActiveByRotaAsync(rota.Id, Arg.Any<CancellationToken>())
+            .Returns(new ShiftSignup[]
+            {
+                MakeSignup(userA, shift),
+                MakeSignup(userB, shift),
+            });
+
+        StubUsers(sender, userA, userB);
+
+        // Every recipient's enqueue throws — no email gets queued.
+        _emailService
+            .When(s => s.SendCoordinatorRotaMessageAsync(
+                Arg.Any<CoordinatorRotaMessageRequest>(), Arg.Any<CancellationToken>()))
+            .Do(_ => throw new InvalidOperationException("simulated outbox outage"));
+
+        var result = await CreateSut().SendRotaMessageAsync(rota.Id, sender, "schedule change");
+
+        result.Succeeded.Should().BeFalse(
+            "queued == 0 && failed > 0 must surface as Failure so the controller does not render a misleading success toast");
+        result.Error.Should().Contain("Failed to enqueue");
+
+        // Audit row still written so the failures are forensically visible.
+        await _auditLog.Received(1).LogAsync(
+            AuditAction.CoordinatorRotaMessageSent,
+            nameof(Rota),
+            rota.Id,
+            Arg.Is<string>(d => d.Contains("2 failed")),
+            sender,
+            Arg.Any<Guid?>(),
+            Arg.Any<string?>());
+    }
+
     private static Rota MakeRota(out EventSettings es)
     {
         es = new EventSettings

--- a/tests/Humans.Application.Tests/Services/Shifts/RotaCoordinatorMessageServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Shifts/RotaCoordinatorMessageServiceTests.cs
@@ -228,6 +228,53 @@ public sealed class RotaCoordinatorMessageServiceTests
             Arg.Any<CoordinatorRotaMessageRequest>(), Arg.Any<CancellationToken>());
     }
 
+    [HumansFact]
+    public async Task SendRotaMessageAsync_IsolatesPerRecipientFailures_AndStillAudits()
+    {
+        var rota = MakeRota(out _);
+        _signupRepo.GetRotaWithShiftsAsync(rota.Id, Arg.Any<CancellationToken>()).Returns(rota);
+
+        var userA = Guid.NewGuid();
+        var userB = Guid.NewGuid();
+        var sender = Guid.NewGuid();
+        var shift = MakeShift(rota.Id, dayOffset: 1, startHour: 10);
+
+        _signupRepo.GetActiveByRotaAsync(rota.Id, Arg.Any<CancellationToken>())
+            .Returns(new ShiftSignup[]
+            {
+                MakeSignup(userA, shift),
+                MakeSignup(userB, shift),
+            });
+
+        StubUsers(sender, userA, userB);
+
+        // First recipient throws (simulating a transient outbox-write failure);
+        // the loop must continue, enqueue the second, and still write the audit row.
+        _emailService
+            .When(s => s.SendCoordinatorRotaMessageAsync(
+                Arg.Is<CoordinatorRotaMessageRequest>(r => r.RecipientEmail == "a@example.com"),
+                Arg.Any<CancellationToken>()))
+            .Do(_ => throw new InvalidOperationException("simulated outbox blip"));
+
+        var result = await CreateSut().SendRotaMessageAsync(rota.Id, sender, "schedule change");
+
+        result.Succeeded.Should().BeTrue("partial dispatch still returns success");
+        result.RecipientCount.Should().Be(1, "only the surviving enqueue counts as queued");
+
+        await _emailService.Received(1).SendCoordinatorRotaMessageAsync(
+            Arg.Is<CoordinatorRotaMessageRequest>(r => r.RecipientEmail == "b@example.com"),
+            Arg.Any<CancellationToken>());
+
+        await _auditLog.Received(1).LogAsync(
+            AuditAction.CoordinatorRotaMessageSent,
+            nameof(Rota),
+            rota.Id,
+            Arg.Is<string>(d => d.Contains("1 failed") && d.Contains("schedule change")),
+            sender,
+            Arg.Any<Guid?>(),
+            Arg.Any<string?>());
+    }
+
     private static Rota MakeRota(out EventSettings es)
     {
         es = new EventSettings


### PR DESCRIPTION
## Summary

- Wrap per-recipient `SendCoordinatorRotaMessageAsync` in try/catch (excluding `OperationCanceledException`) inside `RotaCoordinatorMessageService.SendRotaMessageAsync` so a transient outbox-write blip on one recipient no longer unwinds the loop, swallows earlier enqueues, and skips the audit row.
- Audit description appends `(N failed: enqueue error)` alongside the existing skipped suffix when partial failures occur.
- New test `SendRotaMessageAsync_IsolatesPerRecipientFailures_AndStillAudits` covers the partial-dispatch path.

Surfaced by reviewer on prod PR nobodies-collective/Humans#752. The companion Codex P2 finding on `AttendeeContactImportService` (lead-must-survive grouped apply) is being refuted as a no-op concern — group is keyed by email, the only lead-derived datum is the displayName hint to `FindOrCreateUserByEmailAsync`, and email-row lookup wins over name.

## Test plan
- [x] `dotnet build Humans.slnx -v quiet` — 0 errors
- [x] `dotnet test … --filter RotaCoordinatorMessageServiceTests` — 8/8 pass (7 existing + 1 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)