### PR TITLE
feat(notifications): refresh popup — kill meter-duplicates, slim row, fix popup-doesn't-load

### DIFF
--- a/docs/sections/Notifications.md
+++ b/docs/sections/Notifications.md
@@ -93,6 +93,7 @@ The originating system for a notification, mapped to a `MessageCategory` for pre
 - `Actionable` notifications cannot be dismissed (dismiss requires `Class == Informational` in the repository); they can only be resolved via `Resolve` or click-through into the underlying work item.
 - Notification fan-out should be fire-and-forget from the caller's perspective. (Note: the dispatch methods themselves are not `try/catch`-wrapped today — callers wrap the call when needed; see `design-rules` §7a for the current pattern.)
 - In-app notifications and email notifications are separate surfaces — emitting a notification does not automatically queue an email. Sections that need both send both.
+- Role-fanout `Actionable` notifications (`SendToRoleAsync(…, Actionable, …)`) must **not** duplicate a meter. If a role-gated meter already counts the same work (e.g. "Applications pending your vote" for Board, "Consent reviews pending" for Consent Coordinators), the meter is the surface and a stored per-event row would just be noise. Role-fanout `Actionable` is reserved for sources without a corresponding meter. Per-recipient `Actionable` (via `SendAsync(…, recipientUserIds)` to specific humans) is fine — it's not a fan-out.
 
 ## Negative Access Rules
 

--- a/src/Humans.Application/Interfaces/Notifications/INotificationInboxService.cs
+++ b/src/Humans.Application/Interfaces/Notifications/INotificationInboxService.cs
@@ -101,20 +101,16 @@ public record NotificationRowDto
 {
     public Guid Id { get; init; }
     public string Title { get; init; } = string.Empty;
-    public string? Body { get; init; }
     public string? ActionUrl { get; init; }
     public string? ActionLabel { get; init; }
     public NotificationPriority Priority { get; init; }
     public NotificationSource Source { get; init; }
     public NotificationClass Class { get; init; }
-    public string? TargetGroupName { get; init; }
     public DateTime CreatedAt { get; init; }
     public bool IsRead { get; init; }
     public bool IsResolved { get; init; }
     public DateTime? ResolvedAt { get; init; }
     public string? ResolvedByName { get; init; }
-    public List<string> RecipientInitials { get; init; } = [];
-    public int TotalRecipientCount { get; init; }
 }
 
 /// <summary>

--- a/src/Humans.Application/Services/Governance/ApplicationDecisionService.cs
+++ b/src/Humans.Application/Services/Governance/ApplicationDecisionService.cs
@@ -363,26 +363,6 @@ public sealed class ApplicationDecisionService : IApplicationDecisionService, IU
             "User {UserId} submitted application {ApplicationId}",
             userId, application.Id);
 
-        try
-        {
-            await _notificationService.SendToRoleAsync(
-                NotificationSource.ApplicationSubmitted,
-                NotificationClass.Actionable,
-                NotificationPriority.Normal,
-                $"New {tier} application submitted",
-                RoleNames.Board,
-                body: $"A new {tier} application requires Board review.",
-                actionUrl: "/Governance/BoardVoting",
-                actionLabel: "Review \u2192",
-                cancellationToken: ct);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex,
-                "Failed to dispatch ApplicationSubmitted notification for application {ApplicationId}",
-                application.Id);
-        }
-
         return new ApplicationDecisionResult(true, ApplicationId: application.Id);
     }
 

--- a/src/Humans.Application/Services/Notifications/NotificationInboxService.cs
+++ b/src/Humans.Application/Services/Notifications/NotificationInboxService.cs
@@ -255,7 +255,6 @@ public sealed class NotificationInboxService : INotificationInboxService, IUserD
         IReadOnlyDictionary<Guid, string> displayNames)
     {
         var n = nr.Notification;
-        var allRecipients = n.Recipients?.ToList() ?? [];
 
         string? resolvedByName = null;
         if (n.ResolvedByUserId is { } resolverId &&
@@ -268,34 +267,17 @@ public sealed class NotificationInboxService : INotificationInboxService, IUserD
         {
             Id = n.Id,
             Title = n.Title,
-            Body = n.Body,
             ActionUrl = n.ActionUrl,
             ActionLabel = n.ActionLabel,
             Priority = n.Priority,
             Source = n.Source,
             Class = n.Class,
-            TargetGroupName = n.TargetGroupName,
             CreatedAt = n.CreatedAt.ToDateTimeUtc(),
             IsRead = nr.ReadAt is not null,
             IsResolved = n.ResolvedAt is not null,
             ResolvedAt = n.ResolvedAt?.ToDateTimeUtc(),
             ResolvedByName = resolvedByName,
-            RecipientInitials = allRecipients
-                .Take(3)
-                .Select(r => GetInitials(displayNames.TryGetValue(r.UserId, out var dn) ? dn : null))
-                .ToList(),
-            TotalRecipientCount = allRecipients.Count,
         };
-    }
-
-    private static string GetInitials(string? displayName)
-    {
-        if (string.IsNullOrWhiteSpace(displayName))
-            return "?";
-        var parts = displayName.Split(' ', StringSplitOptions.RemoveEmptyEntries);
-        return parts.Length >= 2
-            ? $"{parts[0][0]}{parts[^1][0]}".ToUpperInvariant()
-            : parts[0][..Math.Min(2, parts[0].Length)].ToUpperInvariant();
     }
 
     private static NotificationActionResult ToActionResult(NotificationMutationOutcome outcome) =>

--- a/src/Humans.Application/Services/Onboarding/OnboardingService.cs
+++ b/src/Humans.Application/Services/Onboarding/OnboardingService.cs
@@ -282,24 +282,6 @@ public sealed class OnboardingService : IOnboardingService
         if (!set)
             return false;
 
-        try
-        {
-            await _notificationService.SendToRoleAsync(
-                NotificationSource.ConsentReviewNeeded,
-                NotificationClass.Actionable,
-                NotificationPriority.High,
-                "New consent review needed",
-                RoleNames.ConsentCoordinator,
-                body: "A human has completed all required consents and needs review.",
-                actionUrl: "/OnboardingReview",
-                actionLabel: "Review →",
-                cancellationToken: ct);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to dispatch ConsentReviewNeeded notification for user {UserId}", userId);
-        }
-
         return true;
     }
 

--- a/src/Humans.Infrastructure/Jobs/ProcessGoogleSyncOutboxJob.cs
+++ b/src/Humans.Infrastructure/Jobs/ProcessGoogleSyncOutboxJob.cs
@@ -3,7 +3,6 @@ using Microsoft.Extensions.Logging;
 using NodaTime;
 using Humans.Application.Interfaces;
 using Humans.Application.Interfaces.GoogleIntegration;
-using Humans.Application.Interfaces.Notifications;
 using Humans.Application.Interfaces.Repositories;
 using Humans.Application.Interfaces.Teams;
 using Humans.Application.Interfaces.Users;
@@ -44,7 +43,6 @@ public class ProcessGoogleSyncOutboxJob : IRecurringJob
     private readonly IUserService _userService;
     private readonly ITeamService _teamService;
     private readonly IGoogleSyncService _googleSyncService;
-    private readonly INotificationService _notificationService;
     private readonly IHumansMetrics _metrics;
     private readonly IClock _clock;
     private readonly ILogger<ProcessGoogleSyncOutboxJob> _logger;
@@ -55,7 +53,6 @@ public class ProcessGoogleSyncOutboxJob : IRecurringJob
         IUserService userService,
         ITeamService teamService,
         IGoogleSyncService googleSyncService,
-        INotificationService notificationService,
         IHumansMetrics metrics,
         IClock clock,
         ILogger<ProcessGoogleSyncOutboxJob> logger)
@@ -65,7 +62,6 @@ public class ProcessGoogleSyncOutboxJob : IRecurringJob
         _userService = userService;
         _teamService = teamService;
         _googleSyncService = googleSyncService;
-        _notificationService = notificationService;
         _metrics = metrics;
         _clock = clock;
         _logger = logger;
@@ -177,30 +173,6 @@ public class ProcessGoogleSyncOutboxJob : IRecurringJob
                         retryCount,
                         MaxRetryCount);
 
-                    // Notify admins on final failure (exhausted retries)
-                    if (exhausted)
-                    {
-                        var snippet = ex.Message.Length > 200 ? ex.Message[..200] : ex.Message;
-                        try
-                        {
-                            await _notificationService.SendToRoleAsync(
-                                NotificationSource.SyncError,
-                                NotificationClass.Actionable,
-                                NotificationPriority.High,
-                                "Google sync event failed after all retries",
-                                RoleNames.Admin,
-                                body: $"Event {outboxEvent.EventType} for team {outboxEvent.TeamId} failed: {snippet}",
-                                actionUrl: "/Google/SyncOutbox",
-                                actionLabel: "View →",
-                                cancellationToken: cancellationToken);
-                        }
-                        catch (Exception notifEx)
-                        {
-                            _logger.LogError(notifEx,
-                                "Failed to dispatch SyncError notification for outbox event {OutboxId}",
-                                outboxEvent.Id);
-                        }
-                    }
                 }
             }
 

--- a/src/Humans.Infrastructure/Repositories/Notifications/NotificationRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Notifications/NotificationRepository.cs
@@ -324,6 +324,7 @@ internal sealed class NotificationRepository : INotificationRepository
                 break;
             case NotificationInboxFilter.Approvals:
                 query = query.Where(nr =>
+                    // ConsentReviewNeeded and ApplicationSubmitted retained for pre-PR-642 historical rows only; no new rows emit these sources.
                     nr.Notification.Source == NotificationSource.ConsentReviewNeeded ||
                     nr.Notification.Source == NotificationSource.ApplicationSubmitted ||
                     nr.Notification.Source == NotificationSource.ApplicationApproved ||

--- a/src/Humans.Web/Controllers/NotificationsController.cs
+++ b/src/Humans.Web/Controllers/NotificationsController.cs
@@ -1,12 +1,9 @@
 using Humans.Application.Interfaces.Notifications;
-using Humans.Domain.Entities;
+using Humans.Application.Interfaces.Users;
 using Humans.Web.Models;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Localization;
-
-using Humans.Application.Interfaces.Users;
 
 namespace Humans.Web.Controllers;
 
@@ -34,14 +31,14 @@ public class NotificationsController : HumansControllerBase
     public async Task<IActionResult> Index(
         string? search, string filter = "all", string tab = "unread")
     {
-        var (err, user) = await RequireCurrentUserAsync();
-        if (err is not null) return err;
+        var userId = GetCurrentUserId();
+        if (userId is null) return Unauthorized();
 
         // Resolved filter is incompatible with unread tab
         if (string.Equals(filter, "resolved", StringComparison.OrdinalIgnoreCase))
             tab = "all";
 
-        var result = await _inboxService.GetInboxAsync(user.Id, search, filter, tab);
+        var result = await _inboxService.GetInboxAsync(userId.Value, search, filter, tab);
 
         var defaultActionLabel = _localizer["Notification_DefaultActionLabel"].Value;
 
@@ -63,10 +60,10 @@ public class NotificationsController : HumansControllerBase
     [HttpGet("Popup")]
     public async Task<IActionResult> GetPopup()
     {
-        var (err, user) = await RequireCurrentUserAsync();
-        if (err is not null) return err;
+        var userId = GetCurrentUserId();
+        if (userId is null) return Unauthorized();
 
-        var result = await _inboxService.GetPopupAsync(user.Id);
+        var result = await _inboxService.GetPopupAsync(userId.Value);
 
         var defaultActionLabel = _localizer["Notification_DefaultActionLabel"].Value;
 
@@ -85,10 +82,10 @@ public class NotificationsController : HumansControllerBase
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> Resolve(Guid id)
     {
-        var (err, user) = await RequireCurrentUserAsync();
-        if (err is not null) return err;
+        var userId = GetCurrentUserId();
+        if (userId is null) return Unauthorized();
 
-        var result = await _inboxService.ResolveAsync(id, user.Id);
+        var result = await _inboxService.ResolveAsync(id, userId.Value);
 
         if (result.NotFound) return NotFound();
         if (result.Forbidden) return Forbid();
@@ -103,10 +100,10 @@ public class NotificationsController : HumansControllerBase
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> Dismiss(Guid id)
     {
-        var (err, user) = await RequireCurrentUserAsync();
-        if (err is not null) return err;
+        var userId = GetCurrentUserId();
+        if (userId is null) return Unauthorized();
 
-        var result = await _inboxService.DismissAsync(id, user.Id);
+        var result = await _inboxService.DismissAsync(id, userId.Value);
 
         if (result.NotFound) return NotFound();
         if (result.Forbidden) return StatusCode(403);
@@ -121,10 +118,10 @@ public class NotificationsController : HumansControllerBase
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> MarkRead(Guid id)
     {
-        var (err, user) = await RequireCurrentUserAsync();
-        if (err is not null) return err;
+        var userId = GetCurrentUserId();
+        if (userId is null) return Unauthorized();
 
-        var result = await _inboxService.MarkReadAsync(id, user.Id);
+        var result = await _inboxService.MarkReadAsync(id, userId.Value);
 
         if (result.NotFound) return NotFound();
 
@@ -138,10 +135,10 @@ public class NotificationsController : HumansControllerBase
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> MarkAllRead()
     {
-        var (err, user) = await RequireCurrentUserAsync();
-        if (err is not null) return err;
+        var userId = GetCurrentUserId();
+        if (userId is null) return Unauthorized();
 
-        await _inboxService.MarkAllReadAsync(user.Id);
+        await _inboxService.MarkAllReadAsync(userId.Value);
 
         if (Request.Headers.XRequestedWith == "XMLHttpRequest")
             return Ok();
@@ -153,13 +150,13 @@ public class NotificationsController : HumansControllerBase
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> BulkResolve(List<Guid> selectedIds)
     {
-        var (err, user) = await RequireCurrentUserAsync();
-        if (err is not null) return err;
+        var userId = GetCurrentUserId();
+        if (userId is null) return Unauthorized();
 
         if (selectedIds.Count == 0)
             return RedirectToAction(nameof(Index));
 
-        await _inboxService.BulkResolveAsync(selectedIds, user.Id);
+        await _inboxService.BulkResolveAsync(selectedIds, userId.Value);
 
         if (Request.Headers.XRequestedWith == "XMLHttpRequest")
             return Ok();
@@ -171,13 +168,13 @@ public class NotificationsController : HumansControllerBase
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> BulkDismiss(List<Guid> selectedIds)
     {
-        var (err, user) = await RequireCurrentUserAsync();
-        if (err is not null) return err;
+        var userId = GetCurrentUserId();
+        if (userId is null) return Unauthorized();
 
         if (selectedIds.Count == 0)
             return RedirectToAction(nameof(Index));
 
-        await _inboxService.BulkDismissAsync(selectedIds, user.Id);
+        await _inboxService.BulkDismissAsync(selectedIds, userId.Value);
 
         if (Request.Headers.XRequestedWith == "XMLHttpRequest")
             return Ok();
@@ -188,10 +185,10 @@ public class NotificationsController : HumansControllerBase
     [HttpGet("ClickThrough/{id}")]
     public async Task<IActionResult> ClickThrough(Guid id)
     {
-        var (err, user) = await RequireCurrentUserAsync();
-        if (err is not null) return err;
+        var userId = GetCurrentUserId();
+        if (userId is null) return Unauthorized();
 
-        var url = await _inboxService.ClickThroughAsync(id, user.Id);
+        var url = await _inboxService.ClickThroughAsync(id, userId.Value);
 
         if (!string.IsNullOrEmpty(url) && Url.IsLocalUrl(url))
             return LocalRedirect(url);

--- a/src/Humans.Web/Controllers/NotificationsController.cs
+++ b/src/Humans.Web/Controllers/NotificationsController.cs
@@ -190,7 +190,9 @@ public class NotificationsController : HumansControllerBase
 
         var url = await _inboxService.ClickThroughAsync(id, userId.Value);
 
-        if (!string.IsNullOrEmpty(url) && Url.IsLocalUrl(url))
+        if (url is null) return NotFound();
+
+        if (Url.IsLocalUrl(url))
             return LocalRedirect(url);
 
         return RedirectToAction(nameof(Index));
@@ -202,20 +204,16 @@ public class NotificationsController : HumansControllerBase
         {
             Id = dto.Id,
             Title = dto.Title,
-            Body = dto.Body,
             ActionUrl = dto.ActionUrl,
             ActionLabel = dto.ActionLabel ?? defaultActionLabel,
             Priority = dto.Priority,
             Source = dto.Source,
             Class = dto.Class,
-            TargetGroupName = dto.TargetGroupName,
             CreatedAt = dto.CreatedAt,
             IsRead = dto.IsRead,
             IsResolved = dto.IsResolved,
             ResolvedAt = dto.ResolvedAt,
             ResolvedByName = dto.ResolvedByName,
-            RecipientInitials = dto.RecipientInitials,
-            TotalRecipientCount = dto.TotalRecipientCount,
         };
     }
 }

--- a/src/Humans.Web/Models/NotificationsViewModels.cs
+++ b/src/Humans.Web/Models/NotificationsViewModels.cs
@@ -7,23 +7,17 @@ public class NotificationRowViewModel
 {
     public Guid Id { get; init; }
     public string Title { get; init; } = string.Empty;
-    public string? Body { get; init; }
     public string? ActionUrl { get; init; }
     public string ActionLabel { get; init; } = "View \u2192";
     public NotificationPriority Priority { get; init; }
     public NotificationSource Source { get; init; }
     public NotificationClass Class { get; init; }
-    public string? TargetGroupName { get; init; }
     public DateTime CreatedAt { get; init; }
     public bool IsRead { get; init; }
 
     public bool IsResolved { get; init; }
     public DateTime? ResolvedAt { get; init; }
     public string? ResolvedByName { get; init; }
-
-    // Group avatar cluster data
-    public List<string> RecipientInitials { get; init; } = [];
-    public int TotalRecipientCount { get; init; }
 }
 
 public class NotificationPopupViewModel

--- a/src/Humans.Web/Views/Notifications/Index.cshtml
+++ b/src/Humans.Web/Views/Notifications/Index.cshtml
@@ -152,25 +152,6 @@
 @section Scripts {
 <script>
 (function() {
-    // AJAX dismiss
-    document.querySelectorAll('[data-ajax-dismiss]').forEach(function(btn) {
-        btn.addEventListener('click', function(e) {
-            e.preventDefault();
-            var form = btn.closest('form');
-            fetch(form.action, {
-                method: 'POST',
-                headers: { 'X-Requested-With': 'XMLHttpRequest' },
-                body: new FormData(form)
-            }).then(function(r) {
-                if (r.ok) {
-                    var wrapper = btn.closest('.notification-row-wrapper') || btn.closest('.notification-row');
-                    if (wrapper) wrapper.remove();
-                    updateBulkToolbar();
-                }
-            });
-        });
-    });
-
     // Bulk selection
     var toolbar = document.getElementById('bulkToolbar');
     var countEl = document.getElementById('bulkCount');

--- a/src/Humans.Web/Views/Notifications/_NotificationRow.cshtml
+++ b/src/Humans.Web/Views/Notifications/_NotificationRow.cshtml
@@ -1,5 +1,6 @@
 @model Humans.Web.Models.NotificationRowViewModel
 @inject IStringLocalizer<SharedResource> Localizer
+@inject NodaTime.IClock Clock
 
 @{
     var borderClass = Model switch
@@ -52,9 +53,11 @@
 </div>
 
 @functions {
-    static string TimeAgo(DateTime utcTime, IStringLocalizer localizer)
+    string TimeAgo(DateTime utcTime, IStringLocalizer localizer)
     {
-        var span = DateTime.UtcNow - utcTime;
+        var now = Clock.GetCurrentInstant();
+        var then = NodaTime.Instant.FromDateTimeUtc(DateTime.SpecifyKind(utcTime, DateTimeKind.Utc));
+        var span = (now - then).ToTimeSpan();
         if (span.TotalMinutes < 1) return localizer["Notification_TimeAgo_JustNow"].Value;
         if (span.TotalMinutes < 60) return string.Format(localizer["Notification_TimeAgo_Minutes"].Value, (int)span.TotalMinutes);
         if (span.TotalHours < 24) return string.Format(localizer["Notification_TimeAgo_Hours"].Value, (int)span.TotalHours);

--- a/src/Humans.Web/Views/Notifications/_NotificationRow.cshtml
+++ b/src/Humans.Web/Views/Notifications/_NotificationRow.cshtml
@@ -2,7 +2,6 @@
 @inject IStringLocalizer<SharedResource> Localizer
 
 @{
-    // Left border accent color
     var borderClass = Model switch
     {
         { IsResolved: true } => "notification-border-resolved",
@@ -12,7 +11,6 @@
         _ => "notification-border-muted"
     };
 
-    // Row background
     var bgClass = Model switch
     {
         { IsResolved: true } => "notification-row-resolved",
@@ -20,82 +18,37 @@
         _ => "notification-row-informational"
     };
 
-    // Type tag
-    var (tagText, tagClass) = Model switch
-    {
-        { Priority: NotificationPriority.Critical } => (Localizer["Notification_Tag_Urgent"].Value, "notification-tag-urgent"),
-        { Class: NotificationClass.Actionable } => (Localizer["Notification_Tag_Action"].Value, "notification-tag-action"),
-        _ => (Localizer["Notification_Tag_Info"].Value, "notification-tag-info")
-    };
-
-    // Time ago
     var timeAgo = TimeAgo(Model.CreatedAt, Localizer);
     var resolvedTimeAgo = Model.ResolvedAt.HasValue ? TimeAgo(Model.ResolvedAt.Value, Localizer) : "";
+    var hasActionUrl = !string.IsNullOrEmpty(Model.ActionUrl);
 }
 
 <div class="notification-row @borderClass @bgClass" data-notification-id="@Model.Id">
-    <div class="notification-row-top">
-        <span class="notification-title">@Model.Title</span>
-        <span class="notification-timestamp">@timeAgo</span>
-    </div>
-    @if (!string.IsNullOrEmpty(Model.Body))
+    @if (Model.IsResolved)
     {
-        <div class="notification-body">@Model.Body</div>
+        <div class="notification-row-line">
+            <span class="notification-title notification-title-resolved">@Model.Title</span>
+            <span class="notification-timestamp">@timeAgo</span>
+        </div>
+        <div class="notification-resolved-label">
+            @string.Format(Localizer["Notification_HandledBy"].Value, Model.ResolvedByName ?? "?", resolvedTimeAgo)
+        </div>
     }
-    <div class="notification-row-bottom">
-        <div class="notification-meta">
-            <span class="notification-tag @tagClass">@tagText</span>
-            @if (!string.IsNullOrEmpty(Model.TargetGroupName) && Model.RecipientInitials.Count > 0)
-            {
-                <span class="notification-avatar-cluster">
-                    @foreach (var initials in Model.RecipientInitials)
-                    {
-                        <span class="notification-avatar-circle">@initials</span>
-                    }
-                    @if (Model.TotalRecipientCount > 3)
-                    {
-                        <span class="notification-avatar-overflow">+@(Model.TotalRecipientCount - 3)</span>
-                    }
-                    <span class="notification-group-label">@Model.TargetGroupName</span>
-                </span>
-            }
+    else if (hasActionUrl)
+    {
+        <a href="@Url.Action("ClickThrough", "Notifications", new { id = Model.Id })"
+           class="notification-row-line notification-action-btn">
+            <span class="notification-title">@Model.Title</span>
+            <span class="notification-timestamp">@timeAgo</span>
+        </a>
+    }
+    else
+    {
+        <div class="notification-row-line">
+            <span class="notification-title">@Model.Title</span>
+            <span class="notification-timestamp">@timeAgo</span>
         </div>
-        <div class="notification-actions">
-            @if (Model.IsResolved)
-            {
-                <span class="notification-resolved-label">
-                    @string.Format(Localizer["Notification_HandledBy"].Value, Model.ResolvedByName ?? "?", resolvedTimeAgo)
-                </span>
-            }
-            else if (Model.Class == NotificationClass.Actionable)
-            {
-                @if (!string.IsNullOrEmpty(Model.ActionUrl))
-                {
-                    <a href="@Url.Action("ClickThrough", "Notifications", new { id = Model.Id })"
-                       class="btn btn-sm btn-outline-primary notification-action-btn">
-                        @Model.ActionLabel
-                    </a>
-                }
-            }
-            else
-            {
-                @if (!string.IsNullOrEmpty(Model.ActionUrl))
-                {
-                    <a href="@Url.Action("ClickThrough", "Notifications", new { id = Model.Id })"
-                       class="notification-text-link">@Model.ActionLabel</a>
-                }
-                <form method="post" asp-controller="Notifications" asp-action="Dismiss" asp-route-id="@Model.Id"
-                      class="d-inline">
-                    @Html.AntiForgeryToken()
-                    <button type="submit" class="notification-dismiss-btn" data-ajax-dismiss
-                            aria-label="@Localizer["Notification_Dismiss"]"
-                            title="@Localizer["Notification_Dismiss"]">
-                        <i class="fa-solid fa-xmark"></i>
-                    </button>
-                </form>
-            }
-        </div>
-    </div>
+    }
 </div>
 
 @functions {

--- a/src/Humans.Web/wwwroot/css/site.css
+++ b/src/Humans.Web/wwwroot/css/site.css
@@ -1306,11 +1306,17 @@ tr[data-href] {
 .notification-row-informational { background-color: var(--h-parchment-light); }
 .notification-row-resolved { opacity: 0.6; background-color: var(--h-bg-card); }
 
-.notification-row-top {
+.notification-row-line {
     display: flex;
     justify-content: space-between;
-    align-items: flex-start;
+    align-items: baseline;
     gap: 0.5rem;
+    text-decoration: none;
+    color: inherit;
+}
+
+a.notification-row-line:hover .notification-title {
+    text-decoration: underline;
 }
 
 .notification-title {
@@ -1319,6 +1325,13 @@ tr[data-href] {
     font-weight: 600;
     color: var(--h-aged-ink);
     line-height: 1.3;
+    flex: 1 1 auto;
+    min-width: 0;
+}
+
+.notification-title-resolved {
+    color: var(--h-sepia-light);
+    font-weight: 500;
 }
 
 .notification-timestamp {
@@ -1329,132 +1342,12 @@ tr[data-href] {
     flex-shrink: 0;
 }
 
-.notification-body {
-    font-family: var(--h-font-body);
-    font-size: 0.8rem;
-    color: var(--h-sepia);
-    margin-top: 0.15rem;
-    line-height: 1.4;
-}
-
-.notification-row-bottom {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-top: 0.35rem;
-    gap: 0.5rem;
-}
-
-.notification-meta {
-    display: flex;
-    align-items: center;
-    gap: 0.4rem;
-    flex-wrap: wrap;
-}
-
-.notification-tag {
-    font-size: 0.65rem;
-    font-weight: 700;
-    padding: 0.15em 0.45em;
-    border-radius: 3px;
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
-}
-
-.notification-tag-urgent {
-    background-color: var(--h-rust);
-    color: var(--h-text-on-dark);
-}
-
-.notification-tag-action {
-    background-color: var(--h-amber);
-    color: var(--h-text-on-dark);
-}
-
-.notification-tag-info {
-    background-color: var(--h-sage);
-    color: var(--h-text-on-dark);
-}
-
-/* --- Group Avatar Cluster --- */
-.notification-avatar-cluster {
-    display: inline-flex;
-    align-items: center;
-    gap: 0;
-}
-
-.notification-avatar-circle {
-    width: 14px;
-    height: 14px;
-    border-radius: 50%;
-    background-color: var(--h-gold);
-    color: var(--h-aged-ink);
-    font-size: 0.45rem;
-    font-weight: 700;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    border: 2px solid var(--h-bg-elevated);
-    margin-left: -4px;
-    line-height: 1;
-}
-
-.notification-avatar-circle:first-child {
-    margin-left: 0;
-}
-
-.notification-avatar-overflow {
-    font-size: 0.55rem;
-    font-weight: 600;
-    color: var(--h-sepia);
-    margin-left: 2px;
-}
-
-.notification-group-label {
-    font-size: 0.7rem;
-    color: var(--h-sepia-light);
-    margin-left: 4px;
-}
-
-/* --- Actions --- */
-.notification-actions {
-    display: flex;
-    align-items: center;
-    gap: 0.4rem;
-    flex-shrink: 0;
-}
-
-.notification-action-btn {
-    font-size: 0.75rem;
-    padding: 0.2rem 0.5rem;
-    white-space: nowrap;
-}
-
-.notification-text-link {
-    font-size: 0.75rem;
-    color: var(--h-sepia);
-    text-decoration: underline;
-}
-
-.notification-dismiss-btn {
-    background: none;
-    border: none;
-    color: var(--h-sepia-light);
-    cursor: pointer;
-    padding: 0.15rem 0.3rem;
-    font-size: 0.8rem;
-    transition: color 0.15s;
-}
-
-.notification-dismiss-btn:hover {
-    color: var(--h-rust);
-}
-
 .notification-resolved-label {
     font-family: var(--h-font-body);
-    font-size: 0.75rem;
+    font-size: 0.7rem;
     color: var(--h-sepia-light);
     font-style: italic;
+    margin-top: 0.15rem;
 }
 
 /* --- Inbox Page --- */

--- a/src/Humans.Web/wwwroot/css/site.css
+++ b/src/Humans.Web/wwwroot/css/site.css
@@ -1535,17 +1535,6 @@ a.notification-row-line:hover .notification-title {
     .notification-filter-pill {
         flex-shrink: 0;
     }
-
-    .notification-row-bottom {
-        flex-direction: column;
-        align-items: flex-start;
-    }
-
-    .notification-actions {
-        width: 100%;
-        justify-content: flex-end;
-        margin-top: 0.25rem;
-    }
 }
 
 /* ─── Guest Dashboard ─── */

--- a/src/Humans.Web/wwwroot/js/site.js
+++ b/src/Humans.Web/wwwroot/js/site.js
@@ -78,29 +78,6 @@ document.addEventListener('click', function (e) {
 
     var isOpen = false;
 
-    function updateBellBadge() {
-        // Count remaining rows in the popup by class
-        var actionableRows = popup.querySelectorAll('.notification-row-actionable');
-        var informationalRows = popup.querySelectorAll('.notification-row-informational');
-        var badge = btn.querySelector('.notification-badge');
-        var actionableCount = actionableRows.length;
-        var informationalCount = informationalRows.length;
-
-        // Remove existing badge
-        if (badge) badge.remove();
-
-        if (actionableCount > 0) {
-            var newBadge = document.createElement('span');
-            newBadge.className = 'notification-badge notification-badge-danger';
-            newBadge.textContent = actionableCount > 9 ? '9+' : actionableCount.toString();
-            btn.appendChild(newBadge);
-        } else if (informationalCount > 0) {
-            var dot = document.createElement('span');
-            dot.className = 'notification-badge notification-badge-dot';
-            btn.appendChild(dot);
-        }
-    }
-
     function openPopup() {
         popup.style.display = 'block';
         btn.setAttribute('aria-expanded', 'true');
@@ -115,7 +92,6 @@ document.addEventListener('click', function (e) {
             .then(function (html) {
                 if (content) content.innerHTML = html;
                 bindPopupClose();
-                bindPopupDismiss();
                 bindPopupMarkAllRead();
                 trapFocus();
             })
@@ -136,26 +112,6 @@ document.addEventListener('click', function (e) {
         if (closeBtn) {
             closeBtn.addEventListener('click', closePopup);
         }
-    }
-
-    function bindPopupDismiss() {
-        popup.querySelectorAll('[data-ajax-dismiss]').forEach(function (dismissBtn) {
-            dismissBtn.addEventListener('click', function (e) {
-                e.preventDefault();
-                var form = dismissBtn.closest('form');
-                fetch(form.action, {
-                    method: 'POST',
-                    headers: { 'X-Requested-With': 'XMLHttpRequest' },
-                    body: new FormData(form)
-                }).then(function (r) {
-                    if (r.ok) {
-                        var row = dismissBtn.closest('.notification-row');
-                        if (row) row.remove();
-                        updateBellBadge();
-                    }
-                });
-            });
-        });
     }
 
     function bindPopupMarkAllRead() {

--- a/tests/Humans.Application.Tests/GoogleIntegration/ProcessGoogleSyncOutboxJobTests.cs
+++ b/tests/Humans.Application.Tests/GoogleIntegration/ProcessGoogleSyncOutboxJobTests.cs
@@ -5,7 +5,6 @@ using NodaTime;
 using NodaTime.Testing;
 using NSubstitute;
 using Humans.Application.Interfaces.GoogleIntegration;
-using Humans.Application.Interfaces.Notifications;
 using Humans.Application.Interfaces.Repositories;
 using Humans.Application.Interfaces.Teams;
 using Humans.Application.Interfaces.Users;
@@ -29,7 +28,6 @@ public class ProcessGoogleSyncOutboxJobTests : IDisposable
     private readonly IUserService _userService;
     private readonly ITeamService _teamService;
     private readonly IGoogleSyncService _googleSyncService;
-    private readonly INotificationService _notificationService;
     private readonly FakeClock _clock;
     private readonly HumansMetricsService _metrics;
     private readonly ProcessGoogleSyncOutboxJob _job;
@@ -57,7 +55,6 @@ public class ProcessGoogleSyncOutboxJobTests : IDisposable
             .GetTeamsAsync(Arg.Any<CancellationToken>())
             .Returns((IReadOnlyDictionary<Guid, TeamInfo>)new Dictionary<Guid, TeamInfo>());
         _googleSyncService = Substitute.For<IGoogleSyncService>();
-        _notificationService = Substitute.For<INotificationService>();
         _clock = new FakeClock(Instant.FromUtc(2026, 2, 15, 20, 0));
         _metrics = new HumansMetricsService(
             Substitute.For<IServiceScopeFactory>(),
@@ -70,7 +67,6 @@ public class ProcessGoogleSyncOutboxJobTests : IDisposable
             _userService,
             _teamService,
             _googleSyncService,
-            _notificationService,
             _metrics,
             _clock,
             logger);
@@ -122,7 +118,7 @@ public class ProcessGoogleSyncOutboxJobTests : IDisposable
     }
 
     [HumansFact]
-    public async Task ExecuteAsync_FinalFailure_SendsAdminNotificationToGoogleSyncDashboard()
+    public async Task ExecuteAsync_FinalFailure_RecordsLastErrorAndExhaustsRetries()
     {
         var outboxEvent = await SeedOutboxEventAsync(
             GoogleSyncOutboxEventTypes.RemoveUserFromTeamResources,
@@ -137,16 +133,11 @@ public class ProcessGoogleSyncOutboxJobTests : IDisposable
 
         await _job.ExecuteAsync();
 
-        await _notificationService.Received(1).SendToRoleAsync(
-            NotificationSource.SyncError,
-            NotificationClass.Actionable,
-            NotificationPriority.High,
-            "Google sync event failed after all retries",
-            RoleNames.Admin,
-            Arg.Any<string?>(),
-            "/Google/SyncOutbox",
-            "View →",
-            Arg.Any<CancellationToken>());
+        var updatedEvent = await _dbContext.GoogleSyncOutboxEvents.AsNoTracking().SingleAsync();
+        updatedEvent.RetryCount.Should().Be(10);
+        updatedEvent.LastError.Should().Contain("google timeout");
+        updatedEvent.FailedPermanently.Should().BeTrue();
+        updatedEvent.ProcessedAt.Should().Be(_clock.GetCurrentInstant());
     }
 
     private async Task<GoogleSyncOutboxEvent> SeedOutboxEventAsync(string eventType, int retryCount = 0)


### PR DESCRIPTION
## Summary

- **Frank's bug fix.** `NotificationsController` endpoints required `UserInfo` to be non-null while the bell `ViewComponent` only needed the claim Guid — so an authenticated user whose `UserInfo` failed to load got *bell renders, popup 404s*. All eight endpoints now use claim-only `GetCurrentUserId()` (401 on null), consistent with the bell.
- **Kill meter-duplicating Actionable fan-outs.** Three sites used to emit one stored Actionable row per event to a role that already had a meter counting the same work. Five board members × five Asociado submissions = 25 inbox rows that never auto-resolved, alongside the "Applications pending your vote: 5" meter that already did the right thing. Removed.
  - `ApplicationDecisionService.SubmitAsync` — was `ApplicationSubmitted` → Board (meter: "Applications pending your vote")
  - `OnboardingService.MaybeEnterConsentCheckPendingAsync` — was `ConsentReviewNeeded` → Consent Coordinators (meter: "Consent reviews pending")
  - `ProcessGoogleSyncOutboxJob` — was `SyncError` → Admin (meter: "Failed Google sync events"). `INotificationService` ctor dep dropped.
- **Slim `_NotificationRow`.** One line: title + timestamp, wrapped in the click-through anchor when there's an action URL. Resolved rows show "Handled by X · 2h ago" beneath. Removed: body, Urgent/Action/Info tag chip, group avatar cluster, group label, per-row dismiss button. Bulk-dismiss on the inbox page remains for informational rows; auto-cleanup at 30 days handles the rest.
- **Section invariant** added in `docs/sections/Notifications.md`: role-fanout `Actionable` must not duplicate a meter. Per-recipient `Actionable` (specific humans, not a fan-out) is unaffected.

## What's *not* in this PR

- **`TeamJoinRequestSubmitted`** (TeamService → team coordinators, Actionable) **stays.** Coordinators don't have a "join requests pending" meter today (the existing meter is admin-only). Adding a per-coordinator meter is a natural follow-up that would let the same dedup happen here. Not bundled to keep this PR surgical.
- **Stripping unused source enum values** (`ApplicationSubmitted`, `ConsentReviewNeeded`, `SyncError`) — they remain in `NotificationSource` because the email channel and the inbox filter machinery still reference them, and old already-emitted rows in production still carry them. Removing would require a migration. Out of scope.

## Test plan

- [ ] Smoke `/Notifications/Popup` as a Board member after submitting a tier application → no per-event row, meter shows the count, voting resets the meter.
- [ ] Smoke as a Consent Coordinator when a new consent review enters the queue → no per-event row, meter shows the count.
- [ ] Smoke as an Admin when a Google sync event exhausts retries → no per-event row, meter shows the count.
- [ ] Open the bell as a fresh user / merge-tombstoned user / any user whose `UserInfo` lookup might be null → popup loads (no 404), shows empty/meter content as appropriate.
- [ ] Verify the inbox at `/Notifications` still renders correctly with the slim row format, bulk-select + bulk-dismiss still work, mark-all-read still works.
- [ ] Existing notification rows in the prod DB (with body/group label/etc.) still render — they just render slimmed; no schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)