### PR TITLE
feat(tickets,profiles): EventParticipation.CheckedInAt + /Tickets/Admin/Onsite view + profile onsite chip (nobodies-collective/Humans#736)

### DIFF
--- a/src/Humans.Application/DTOs/TicketSyncDtos.cs
+++ b/src/Humans.Application/DTOs/TicketSyncDtos.cs
@@ -17,8 +17,12 @@ public record UserEmailLookupEntry(string Email, Guid UserId);
 /// An attendee row projected for the event-participation reconciliation pass.
 /// Only includes attendees with a non-null <c>MatchedUserId</c>, scoped to a
 /// single vendor event (matching <see cref="TicketSyncService"/> behavior).
+/// <c>VendorTicketId</c> is included so sync can join the row to the vendor
+/// delta by ticket identity, not by attendee email — necessary because
+/// <c>MatchedUserId</c> can diverge from the email path after account-merge
+/// re-FK or non-email match assignment.
 /// </summary>
-public record MatchedAttendeeRow(Guid MatchedUserId, TicketAttendeeStatus Status);
+public record MatchedAttendeeRow(string VendorTicketId, Guid MatchedUserId, TicketAttendeeStatus Status);
 
 /// <summary>
 /// A discount-code projection row used to build

--- a/src/Humans.Application/DTOs/TicketVendorDtos.cs
+++ b/src/Humans.Application/DTOs/TicketVendorDtos.cs
@@ -19,6 +19,12 @@ public record VendorOrderDto(
     decimal DonationAmount = 0m);
 
 /// <summary>Vendor-agnostic issued ticket data.</summary>
+/// <param name="CheckedInAt">
+/// When the attendee was checked in at the gate, when the vendor exposes it
+/// (TicketTailor: <c>check_in.checked_in_at</c>, epoch seconds). Null when the
+/// vendor did not return a timestamp or the attendee is not checked in. Issue
+/// nobodies-collective/Humans#736.
+/// </param>
 public record VendorTicketDto(
     string VendorTicketId,
     string? VendorOrderId,
@@ -26,7 +32,8 @@ public record VendorTicketDto(
     string? AttendeeEmail,
     string TicketTypeName,
     decimal Price,
-    string Status);
+    string Status,
+    Instant? CheckedInAt = null);
 
 /// <summary>High-level event summary from vendor.</summary>
 public record VendorEventSummaryDto(

--- a/src/Humans.Application/Interfaces/Repositories/IUserRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/IUserRepository.cs
@@ -314,6 +314,13 @@ public interface IUserRepository : IRepository
     /// If no record exists, a new one is created with the provided values and
     /// persisted — returns the new row. The returned entity is detached
     /// (AsNoTracking semantics; the owning context is disposed before return).
+    /// <para>
+    /// <paramref name="checkedInAt"/> is the vendor-reported gate-arrival
+    /// instant carried from <see cref="ParticipationSource.TicketSync"/>. Set
+    /// on row creation, and on the no-existing-row → Attended path. NEVER
+    /// overwritten once non-null — Attended-permanence applies to the
+    /// timestamp as well (issue nobodies-collective/Humans#736).
+    /// </para>
     /// </summary>
     Task<EventParticipation?> UpsertParticipationAsync(
         Guid userId,
@@ -321,6 +328,7 @@ public interface IUserRepository : IRepository
         ParticipationStatus status,
         ParticipationSource source,
         Instant? declaredAt,
+        Instant? checkedInAt,
         CancellationToken ct = default);
 
     /// <summary>

--- a/src/Humans.Application/Interfaces/Tickets/IOnsiteRosterService.cs
+++ b/src/Humans.Application/Interfaces/Tickets/IOnsiteRosterService.cs
@@ -1,0 +1,45 @@
+using Humans.Application.Interfaces;
+using NodaTime;
+
+namespace Humans.Application.Interfaces.Tickets;
+
+/// <summary>
+/// Orchestrates the "Who's onsite" view (#736). Joins the cached set of
+/// Attended+CheckedInAt humans for the active year with their camp / team /
+/// governance-role names and applies the requested filters. Used by the
+/// <c>/Tickets/Admin/Onsite</c> admin view.
+/// </summary>
+public interface IOnsiteRosterService : IApplicationService
+{
+    /// <summary>
+    /// Returns the filtered, enriched onsite roster for <paramref name="year"/>.
+    /// Filter strings match camp / team / governance-role names case-insensitively
+    /// (Ordinal). Rows are returned in unspecified order — caller sorts at the
+    /// presentation layer per <c>memory/architecture/display-sort-in-controllers.md</c>.
+    /// </summary>
+    Task<OnsiteRosterResult> GetRosterAsync(
+        int year,
+        string? campFilter,
+        string? teamFilter,
+        string? roleFilter,
+        CancellationToken ct = default);
+}
+
+/// <summary>
+/// Outcome of <see cref="IOnsiteRosterService.GetRosterAsync"/>: the filtered
+/// rows plus the full set of camp / team / role names known to be onsite
+/// (drives the filter dropdowns in the view).
+/// </summary>
+public sealed record OnsiteRosterResult(
+    IReadOnlyList<OnsiteRosterRow> Rows,
+    IReadOnlyList<string> AvailableCamps,
+    IReadOnlyList<string> AvailableTeams,
+    IReadOnlyList<string> AvailableRoles);
+
+public sealed record OnsiteRosterRow(
+    Guid UserId,
+    string DisplayName,
+    Instant CheckedInAt,
+    IReadOnlyList<string> CampNames,
+    IReadOnlyList<string> TeamNames,
+    IReadOnlyList<string> RoleNames);

--- a/src/Humans.Application/Interfaces/Users/IUserService.cs
+++ b/src/Humans.Application/Interfaces/Users/IUserService.cs
@@ -114,11 +114,34 @@ public interface IUserService : IApplicationService, IUserMerge
 
     /// <summary>
     /// Set participation status from ticket sync. Handles the lifecycle rules:
-    /// - Valid ticket → Ticketed
+    /// - Valid ticket → Ticketed (<paramref name="checkedInAt"/> ignored)
     /// - Checked in → Attended (permanent)
     /// - Ticket purchase overrides NotAttending
+    /// <para>
+    /// <paramref name="checkedInAt"/> is the vendor-reported gate-arrival
+    /// instant. Stored on <see cref="EventParticipation.CheckedInAt"/> when an
+    /// Attended row is being created or upgraded. Never overwritten once
+    /// non-null — matches the "Attended is permanent" invariant (issue
+    /// nobodies-collective/Humans#736).
+    /// </para>
     /// </summary>
-    Task SetParticipationFromTicketSyncAsync(Guid userId, int year, ParticipationStatus status, CancellationToken ct = default);
+    Task SetParticipationFromTicketSyncAsync(
+        Guid userId,
+        int year,
+        ParticipationStatus status,
+        Instant? checkedInAt,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns a flat list of every user currently on-site — that is, whose
+    /// <see cref="EventParticipation"/> for <paramref name="year"/> has
+    /// <see cref="ParticipationStatus.Attended"/> with a non-null
+    /// <see cref="EventParticipation.CheckedInAt"/>. Caller (Web layer) joins in
+    /// camp / team / governance-role names via the owning section services and
+    /// applies filters. Issue nobodies-collective/Humans#736.
+    /// </summary>
+    Task<IReadOnlyList<OnsiteUserRow>> GetOnsiteUsersAsync(
+        int year, CancellationToken ct = default);
 
     /// <summary>
     /// Remove a TicketSync-sourced participation record when a user no longer has valid tickets.
@@ -339,3 +362,14 @@ public record AnonymizedAccountSummary(
     string OriginalDisplayName,
     string PreferredLanguage,
     IReadOnlyList<(Guid SignupId, Guid ShiftId)> CancelledSignupIds);
+
+/// <summary>
+/// Per-user row returned from <see cref="IUserService.GetOnsiteUsersAsync"/>.
+/// Names of camps / teams / governance roles are not stitched in here; the Web
+/// layer joins them via the owning section services before rendering. Issue
+/// nobodies-collective/Humans#736.
+/// </summary>
+public sealed record OnsiteUserRow(
+    Guid UserId,
+    string DisplayName,
+    NodaTime.Instant? CheckedInAt);

--- a/src/Humans.Application/Services/Tickets/AttendeeContactImportService.cs
+++ b/src/Humans.Application/Services/Tickets/AttendeeContactImportService.cs
@@ -232,7 +232,7 @@ public sealed class AttendeeContactImportService : IAttendeeContactImportService
             foreach (var userId in newlyMatchedUserIds)
             {
                 await _users.SetParticipationFromTicketSyncAsync(
-                    userId, active.Year, ParticipationStatus.Ticketed, ct);
+                    userId, active.Year, ParticipationStatus.Ticketed, checkedInAt: null, ct);
             }
         }
 

--- a/src/Humans.Application/Services/Tickets/OnsiteRosterService.cs
+++ b/src/Humans.Application/Services/Tickets/OnsiteRosterService.cs
@@ -1,0 +1,166 @@
+using Humans.Application.Interfaces;
+using Humans.Application.Interfaces.Auth;
+using Humans.Application.Interfaces.Camps;
+using Humans.Application.Interfaces.Shifts;
+using Humans.Application.Interfaces.Teams;
+using Humans.Application.Interfaces.Tickets;
+using Humans.Application.Interfaces.Users;
+using Humans.Domain.Enums;
+
+namespace Humans.Application.Services.Tickets;
+
+/// <summary>
+/// Builds the "Who's onsite" roster (#736): joins
+/// <see cref="IUserService.GetOnsiteUsersAsync"/> output with camp / team /
+/// governance-role names and applies filters. Pure orchestration over existing
+/// section services — no DB access.
+/// </summary>
+public sealed class OnsiteRosterService : IOnsiteRosterService, IApplicationService
+{
+    private readonly IUserService _users;
+    private readonly IShiftManagementService _shifts;
+    private readonly ICampService _camps;
+    private readonly ITeamService _teams;
+    private readonly IRoleAssignmentService _roles;
+
+    public OnsiteRosterService(
+        IUserService users,
+        IShiftManagementService shifts,
+        ICampService camps,
+        ITeamService teams,
+        IRoleAssignmentService roles)
+    {
+        _users = users;
+        _shifts = shifts;
+        _camps = camps;
+        _teams = teams;
+        _roles = roles;
+    }
+
+    public async Task<OnsiteRosterResult> GetRosterAsync(
+        int year,
+        string? campFilter,
+        string? teamFilter,
+        string? roleFilter,
+        CancellationToken ct = default)
+    {
+        if (year <= 0)
+            return new OnsiteRosterResult([], [], [], []);
+
+        var onsite = await _users.GetOnsiteUsersAsync(year, ct);
+        if (onsite.Count == 0)
+            return new OnsiteRosterResult([], [], [], []);
+
+        var onsiteIds = onsite.Select(o => o.UserId).ToHashSet();
+
+        var campNamesByUserId = await BuildCampNamesAsync(year, onsiteIds, ct);
+        var teamNamesByUserId = await BuildTeamNamesAsync(onsiteIds, ct);
+        var roleNamesByUserId = await BuildRoleNamesAsync(onsiteIds, ct);
+
+        IEnumerable<(OnsiteUserRow Row, IReadOnlyList<string> Camps,
+            IReadOnlyList<string> Teams, IReadOnlyList<string> Roles)> joined = onsite
+            .Where(o => o.CheckedInAt is not null)
+            .Select(o => (
+                Row: o,
+                Camps: NamesFor(campNamesByUserId, o.UserId),
+                Teams: NamesFor(teamNamesByUserId, o.UserId),
+                Roles: NamesFor(roleNamesByUserId, o.UserId)));
+
+        if (!string.IsNullOrWhiteSpace(campFilter))
+            joined = joined.Where(x => x.Camps.Contains(campFilter!, StringComparer.OrdinalIgnoreCase));
+        if (!string.IsNullOrWhiteSpace(teamFilter))
+            joined = joined.Where(x => x.Teams.Contains(teamFilter!, StringComparer.OrdinalIgnoreCase));
+        if (!string.IsNullOrWhiteSpace(roleFilter))
+            joined = joined.Where(x => x.Roles.Contains(roleFilter!, StringComparer.OrdinalIgnoreCase));
+
+        var rows = joined
+            .Select(x => new OnsiteRosterRow(
+                x.Row.UserId,
+                x.Row.DisplayName,
+                x.Row.CheckedInAt!.Value,
+                x.Camps,
+                x.Teams,
+                x.Roles))
+            .ToList();
+
+        var availableCamps = DistinctSortedNames(campNamesByUserId);
+        var availableTeams = DistinctSortedNames(teamNamesByUserId);
+        var availableRoles = DistinctSortedNames(roleNamesByUserId);
+
+        return new OnsiteRosterResult(rows, availableCamps, availableTeams, availableRoles);
+    }
+
+    private async Task<Dictionary<Guid, SortedSet<string>>> BuildCampNamesAsync(
+        int year, HashSet<Guid> onsiteIds, CancellationToken ct)
+    {
+        var result = new Dictionary<Guid, SortedSet<string>>();
+        var camps = await _camps.GetCampsForYearAsync(year, ct);
+        foreach (var camp in camps)
+        {
+            foreach (var season in camp.Seasons)
+            {
+                var members = await _camps.GetSeasonMembersAsync(season.Id, ct);
+                foreach (var m in members)
+                {
+                    if (!onsiteIds.Contains(m.UserId)) continue;
+                    if (m.Status != CampMemberStatus.Active) continue;
+                    Add(result, m.UserId, season.Name);
+                }
+            }
+        }
+        return result;
+    }
+
+    private async Task<Dictionary<Guid, SortedSet<string>>> BuildTeamNamesAsync(
+        HashSet<Guid> onsiteIds, CancellationToken ct)
+    {
+        var result = new Dictionary<Guid, SortedSet<string>>();
+        var teamsById = await _teams.GetTeamsAsync(ct);
+        foreach (var (_, team) in teamsById)
+        {
+            if (!team.IsActive) continue;
+            if (team.IsSystemTeam) continue;
+            foreach (var member in team.Members)
+            {
+                if (!onsiteIds.Contains(member.UserId)) continue;
+                Add(result, member.UserId, team.Name);
+            }
+        }
+        return result;
+    }
+
+    private async Task<Dictionary<Guid, SortedSet<string>>> BuildRoleNamesAsync(
+        HashSet<Guid> onsiteIds, CancellationToken ct)
+    {
+        var result = new Dictionary<Guid, SortedSet<string>>();
+        foreach (var userId in onsiteIds)
+        {
+            var assignments = await _roles.GetActiveForUserAsync(userId, ct);
+            if (assignments.Count == 0) continue;
+            foreach (var r in assignments) Add(result, userId, r.RoleName);
+        }
+        return result;
+    }
+
+    private static void Add(Dictionary<Guid, SortedSet<string>> map, Guid userId, string name)
+    {
+        if (!map.TryGetValue(userId, out var set))
+        {
+            set = new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
+            map[userId] = set;
+        }
+        set.Add(name);
+    }
+
+    private static IReadOnlyList<string> NamesFor(
+        Dictionary<Guid, SortedSet<string>> map, Guid userId) =>
+        map.TryGetValue(userId, out var set) ? set.ToList() : [];
+
+    private static IReadOnlyList<string> DistinctSortedNames(
+        Dictionary<Guid, SortedSet<string>> map) =>
+        map.Values
+            .SelectMany(s => s)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(s => s, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+}

--- a/src/Humans.Application/Services/Tickets/TicketSyncService.cs
+++ b/src/Humans.Application/Services/Tickets/TicketSyncService.cs
@@ -155,7 +155,7 @@ public sealed class TicketSyncService : ITicketSyncService, IUserMerge
 
             var codesRedeemed = await MatchDiscountCodesAsync(ct);
 
-            await SyncEventParticipationsAsync(ct);
+            await SyncEventParticipationsAsync(tickets, emailLookup, ct);
 
             syncState.SyncStatus = TicketSyncStatus.Idle;
             syncState.StatusChangedAt = _clock.GetCurrentInstant();
@@ -434,8 +434,21 @@ public sealed class TicketSyncService : ITicketSyncService, IUserMerge
     /// Derive EventParticipation records from current ticket data.
     /// For each matched user: 1+ valid tickets → Ticketed, any checked-in → Attended.
     /// If user had Ticketed from TicketSync but now has 0 valid tickets → remove record.
+    /// <para>
+    /// <paramref name="vendorTicketsThisSync"/> carries the per-attendee
+    /// <see cref="VendorTicketDto.CheckedInAt"/> when the vendor returned one;
+    /// we min across this user's checked-in tickets and pass the result down to
+    /// <see cref="IUserService.SetParticipationFromTicketSyncAsync"/>. Older
+    /// checked-in tickets not in this delta won't have a timestamp here — that
+    /// is the graceful-null fallback (issue nobodies-collective/Humans#736);
+    /// the repo's "never overwrite non-null CheckedInAt" rule preserves prior
+    /// values.
+    /// </para>
     /// </summary>
-    private async Task SyncEventParticipationsAsync(CancellationToken ct)
+    private async Task SyncEventParticipationsAsync(
+        IReadOnlyList<VendorTicketDto> vendorTicketsThisSync,
+        Dictionary<string, Guid> emailLookup,
+        CancellationToken ct)
     {
         var activeEvent = await _shiftManagementService.GetActiveAsync();
         if (activeEvent is null || activeEvent.Year == 0)
@@ -452,6 +465,20 @@ public sealed class TicketSyncService : ITicketSyncService, IUserMerge
                 g => g.Key,
                 g => g.Select(a => a.Status).ToList());
 
+        // Per-user min(CheckedInAt) across the vendor tickets we just pulled.
+        // Vendor delta sync only returns *changed* tickets, so this only
+        // populates timestamps for users whose check-in event was in THIS batch
+        // — which is exactly the moment we want to capture the timestamp.
+        var checkedInAtByUserId = vendorTicketsThisSync
+            .Where(t => t.CheckedInAt is not null
+                && t.AttendeeEmail is not null)
+            .Select(t => (
+                UserId: LookupUserId(emailLookup, t.AttendeeEmail),
+                CheckedInAt: t.CheckedInAt!.Value))
+            .Where(x => x.UserId is not null)
+            .GroupBy(x => x.UserId!.Value)
+            .ToDictionary(g => g.Key, g => g.Min(x => x.CheckedInAt));
+
         foreach (var (userId, statuses) in userTicketStatuses)
         {
             var hasCheckedIn = statuses.Any(s => s == TicketAttendeeStatus.CheckedIn);
@@ -460,13 +487,16 @@ public sealed class TicketSyncService : ITicketSyncService, IUserMerge
 
             if (hasCheckedIn)
             {
+                Instant? checkedInAt = checkedInAtByUserId.TryGetValue(userId, out var ts)
+                    ? ts
+                    : null;
                 await _userService.SetParticipationFromTicketSyncAsync(
-                    userId, year, ParticipationStatus.Attended, ct);
+                    userId, year, ParticipationStatus.Attended, checkedInAt, ct);
             }
             else if (hasValidTicket)
             {
                 await _userService.SetParticipationFromTicketSyncAsync(
-                    userId, year, ParticipationStatus.Ticketed, ct);
+                    userId, year, ParticipationStatus.Ticketed, checkedInAt: null, ct);
             }
         }
 

--- a/src/Humans.Application/Services/Tickets/TicketSyncService.cs
+++ b/src/Humans.Application/Services/Tickets/TicketSyncService.cs
@@ -155,7 +155,7 @@ public sealed class TicketSyncService : ITicketSyncService, IUserMerge
 
             var codesRedeemed = await MatchDiscountCodesAsync(ct);
 
-            await SyncEventParticipationsAsync(tickets, emailLookup, ct);
+            await SyncEventParticipationsAsync(tickets, ct);
 
             syncState.SyncStatus = TicketSyncStatus.Idle;
             syncState.StatusChangedAt = _clock.GetCurrentInstant();
@@ -447,7 +447,6 @@ public sealed class TicketSyncService : ITicketSyncService, IUserMerge
     /// </summary>
     private async Task SyncEventParticipationsAsync(
         IReadOnlyList<VendorTicketDto> vendorTicketsThisSync,
-        Dictionary<string, Guid> emailLookup,
         CancellationToken ct)
     {
         var activeEvent = await _shiftManagementService.GetActiveAsync();
@@ -465,15 +464,23 @@ public sealed class TicketSyncService : ITicketSyncService, IUserMerge
                 g => g.Key,
                 g => g.Select(a => a.Status).ToList());
 
-        // Per-user min(CheckedInAt) across the vendor tickets we just pulled.
-        // Vendor delta sync only returns *changed* tickets, so this only
-        // populates timestamps for users whose check-in event was in THIS batch
-        // — which is exactly the moment we want to capture the timestamp.
+        // Per-user min(CheckedInAt) across the vendor tickets we just pulled,
+        // joined to matched-attendee rows by VendorTicketId so the user identity
+        // matches what the participation loop below uses (MatchedUserId). Using
+        // an email lookup here would drop users whose attendee was re-FKed via
+        // account-merge or matched through non-email paths.
+        // Vendor delta sync only returns *changed* tickets, so this populates
+        // timestamps for users whose check-in event was in THIS batch — which
+        // is exactly the moment we want to capture the timestamp.
+        var matchedUserByVendorTicketId = matchedAttendees
+            .ToDictionary(a => a.VendorTicketId, a => a.MatchedUserId, StringComparer.Ordinal);
+
         var checkedInAtByUserId = vendorTicketsThisSync
-            .Where(t => t.CheckedInAt is not null
-                && t.AttendeeEmail is not null)
+            .Where(t => t.CheckedInAt is not null)
             .Select(t => (
-                UserId: LookupUserId(emailLookup, t.AttendeeEmail),
+                UserId: matchedUserByVendorTicketId.TryGetValue(t.VendorTicketId, out var uid)
+                    ? (Guid?)uid
+                    : null,
                 CheckedInAt: t.CheckedInAt!.Value))
             .Where(x => x.UserId is not null)
             .GroupBy(x => x.UserId!.Value)

--- a/src/Humans.Application/Services/Users/UserService.cs
+++ b/src/Humans.Application/Services/Users/UserService.cs
@@ -237,7 +237,8 @@ public sealed class UserService : IUserService, IUserDataContributor, IUserMerge
     {
         var now = _clock.GetCurrentInstant();
         var persisted = await _repo.UpsertParticipationAsync(
-            userId, year, ParticipationStatus.NotAttending, ParticipationSource.UserDeclared, now, ct);
+            userId, year, ParticipationStatus.NotAttending, ParticipationSource.UserDeclared,
+            declaredAt: now, checkedInAt: null, ct);
 
         if (persisted is null)
         {
@@ -284,9 +285,18 @@ public sealed class UserService : IUserService, IUserDataContributor, IUserMerge
     }
 
     public Task SetParticipationFromTicketSyncAsync(
-        Guid userId, int year, ParticipationStatus status, CancellationToken ct = default) =>
-        // Attended-is-permanent and source-override semantics live in repo upsert.
-        _repo.UpsertParticipationAsync(userId, year, status, ParticipationSource.TicketSync, declaredAt: null, ct);
+        Guid userId, int year, ParticipationStatus status, Instant? checkedInAt, CancellationToken ct = default) =>
+        // Attended-is-permanent, source-override and CheckedInAt-never-overwrite
+        // semantics live in repo upsert.
+        _repo.UpsertParticipationAsync(
+            userId, year, status, ParticipationSource.TicketSync,
+            declaredAt: null, checkedInAt: checkedInAt, ct);
+
+    public Task<IReadOnlyList<OnsiteUserRow>> GetOnsiteUsersAsync(int year, CancellationToken ct = default) =>
+        throw new NotSupportedException(
+            "GetOnsiteUsersAsync is only meaningful through CachingUserService — it projects " +
+            "Attended+CheckedInAt rows from the cached UserInfo snapshot. Hitting the inner " +
+            "UserService indicates a DI registration mistake.");
 
     public Task RemoveTicketSyncParticipationAsync(Guid userId, int year, CancellationToken ct = default) =>
         _repo.RemoveParticipationAsync(userId, year, ParticipationSource.TicketSync, ct);

--- a/src/Humans.Application/UserInfo.cs
+++ b/src/Humans.Application/UserInfo.cs
@@ -53,7 +53,8 @@ public sealed record EventParticipationInfo(
     int Year,
     ParticipationStatus Status,
     ParticipationSource Source,
-    Instant? DeclaredAt);
+    Instant? DeclaredAt,
+    Instant? CheckedInAt);
 
 /// <summary>Compact projection of an <c>AspNetUserLogins</c> row.</summary>
 public sealed record UserExternalLoginInfo(
@@ -213,6 +214,19 @@ public sealed record UserInfo(
         (p.Status == ParticipationStatus.Ticketed ||
          p.Status == ParticipationStatus.Attended));
 
+    /// <summary>
+    /// On-site for the given <paramref name="year"/> when an Attended row with
+    /// a non-null <see cref="EventParticipationInfo.CheckedInAt"/> exists.
+    /// Returns the gate-arrival instant or null. Drives the profile "Onsite
+    /// since {time}" chip (issue nobodies-collective/Humans#736).
+    /// </summary>
+    public Instant? OnsiteSinceForYear(int year) => EventParticipations
+        .Where(p => p.Year == year
+            && p.Status == ParticipationStatus.Attended
+            && p.CheckedInAt is not null)
+        .Select(p => p.CheckedInAt)
+        .FirstOrDefault();
+
     /// <summary>Stub profile: no profile row, explicit Stub state, or legacy null State. Callers writing consents must block on this.</summary>
     public bool IsStub =>
         Profile is null || Profile.State is null or ProfileState.Stub;
@@ -268,7 +282,7 @@ public sealed record UserInfo(
         var participationInfos = eventParticipations
             .OrderBy(p => p.Year)
             .Select(p => new EventParticipationInfo(
-                p.Id, p.Year, p.Status, p.Source, p.DeclaredAt))
+                p.Id, p.Year, p.Status, p.Source, p.DeclaredAt, p.CheckedInAt))
             .ToList();
 
         var loginInfos = externalLogins

--- a/src/Humans.Domain/Entities/EventParticipation.cs
+++ b/src/Humans.Domain/Entities/EventParticipation.cs
@@ -32,6 +32,18 @@ public class EventParticipation
     public Instant? DeclaredAt { get; set; }
 
     /// <summary>
+    /// When the user was first checked in at the event gate (from the
+    /// TicketTailor <c>check_in.checked_in_at</c> field). Populated only when
+    /// <see cref="Status"/> becomes <see cref="ParticipationStatus.Attended"/>
+    /// via <see cref="ParticipationSource.TicketSync"/>. Once set it is never
+    /// cleared or overwritten — matches the existing invariant that
+    /// <see cref="ParticipationStatus.Attended"/> rows are permanent and not
+    /// removed by sync. May be null if the vendor did not return a timestamp
+    /// when the status flipped (graceful fallback).
+    /// </summary>
+    public Instant? CheckedInAt { get; set; }
+
+    /// <summary>
     /// How the status was set.
     /// </summary>
     public ParticipationSource Source { get; set; }

--- a/src/Humans.Infrastructure/Migrations/20260517234057_Add_EventParticipation_CheckedInAt.Designer.cs
+++ b/src/Humans.Infrastructure/Migrations/20260517234057_Add_EventParticipation_CheckedInAt.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Humans.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Humans.Infrastructure.Migrations
 {
     [DbContext(typeof(HumansDbContext))]
-    partial class HumansDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260517234057_Add_EventParticipation_CheckedInAt")]
+    partial class Add_EventParticipation_CheckedInAt
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Humans.Infrastructure/Migrations/20260517234057_Add_EventParticipation_CheckedInAt.cs
+++ b/src/Humans.Infrastructure/Migrations/20260517234057_Add_EventParticipation_CheckedInAt.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using NodaTime;
+
+#nullable disable
+
+namespace Humans.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class Add_EventParticipation_CheckedInAt : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Instant>(
+                name: "CheckedInAt",
+                table: "event_participations",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CheckedInAt",
+                table: "event_participations");
+        }
+    }
+}

--- a/src/Humans.Infrastructure/Repositories/Tickets/TicketRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Tickets/TicketRepository.cs
@@ -194,7 +194,7 @@ internal sealed class TicketRepository : ITicketRepository
         return await ctx.TicketAttendees
             .AsNoTracking()
             .Where(a => a.MatchedUserId != null && a.VendorEventId == vendorEventId)
-            .Select(a => new MatchedAttendeeRow(a.MatchedUserId!.Value, a.Status))
+            .Select(a => new MatchedAttendeeRow(a.VendorTicketId, a.MatchedUserId!.Value, a.Status))
             .ToListAsync(ct);
     }
 

--- a/src/Humans.Infrastructure/Repositories/Users/UserRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Users/UserRepository.cs
@@ -622,6 +622,7 @@ internal sealed class UserRepository : IUserRepository
         ParticipationStatus status,
         ParticipationSource source,
         Instant? declaredAt,
+        Instant? checkedInAt,
         CancellationToken ct = default)
     {
         await using var ctx = await _factory.CreateDbContextAsync(ct);
@@ -638,6 +639,11 @@ internal sealed class UserRepository : IUserRepository
             existing.Status = status;
             existing.Source = source;
             existing.DeclaredAt = declaredAt;
+            // CheckedInAt is set on the first transition into Attended and is
+            // permanent afterwards. Don't overwrite an already-non-null value
+            // (issue nobodies-collective/Humans#736).
+            if (existing.CheckedInAt is null)
+                existing.CheckedInAt = checkedInAt;
             persisted = existing;
         }
         else
@@ -650,6 +656,7 @@ internal sealed class UserRepository : IUserRepository
                 Status = status,
                 Source = source,
                 DeclaredAt = declaredAt,
+                CheckedInAt = checkedInAt,
             };
             ctx.EventParticipations.Add(persisted);
         }

--- a/src/Humans.Infrastructure/Services/StubTicketVendorService.cs
+++ b/src/Humans.Infrastructure/Services/StubTicketVendorService.cs
@@ -172,6 +172,20 @@ public sealed class StubTicketVendorService : ITicketVendorService
                 // Every 5th ticket is checked in for realistic event summary stats
                 var status = (orderIndex * 10 + t) % 5 == 0 ? "checked_in" : "valid";
 
+                // Stub a gate-arrival time for checked-in tickets so dev /
+                // preview environments can exercise the "Who's onsite" view
+                // (#736). Spreads arrivals across the gate-day window.
+                Instant? checkedInAt = null;
+                if (string.Equals(status, "checked_in", StringComparison.Ordinal))
+                {
+                    var gateDay = new LocalDate(2026, 7, 8);
+                    var hour = 9 + ((orderIndex * 10 + t) % 12); // 09:00–20:00
+                    checkedInAt = gateDay
+                        .At(new LocalTime(hour, (orderIndex * 7 + t * 13) % 60))
+                        .InUtc()
+                        .ToInstant();
+                }
+
                 var ticketDto = new VendorTicketDto(
                     VendorTicketId: vendorTicketId,
                     VendorOrderId: vendorOrderId,
@@ -179,7 +193,8 @@ public sealed class StubTicketVendorService : ITicketVendorService
                     AttendeeEmail: attendee.Email,
                     TicketTypeName: ticket.Type,
                     Price: ticket.Price,
-                    Status: status);
+                    Status: status,
+                    CheckedInAt: checkedInAt);
 
                 vendorTickets.Add(ticketDto);
                 tickets.Add(ticketDto);

--- a/src/Humans.Infrastructure/Services/TicketTailorService.cs
+++ b/src/Humans.Infrastructure/Services/TicketTailorService.cs
@@ -142,7 +142,10 @@ public class TicketTailorService : ITicketVendorService
                     AttendeeEmail: ResolveAttendeeEmail(ticket),
                     TicketTypeName: ticket.Description ?? "Unknown",
                     Price: (ticket.ListedPrice ?? 0) / 100m,
-                    Status: ticket.Status ?? "valid"));
+                    Status: ticket.Status ?? "valid",
+                    CheckedInAt: ticket.CheckIn?.CheckedInAt is long epoch and > 0
+                        ? Instant.FromUnixTimeSeconds(epoch)
+                        : null));
             }
 
             cursor = body.Links?.Next is not null ? body.Data[^1].Id : null;
@@ -352,7 +355,14 @@ public class TicketTailorService : ITicketVendorService
         [property: JsonPropertyName("listed_price")] int? ListedPrice,
         [property: JsonPropertyName("status")] string? Status,
         [property: JsonPropertyName("order_id")] string? OrderId,
-        [property: JsonPropertyName("custom_questions")] List<TtCustomQuestion>? CustomQuestions);
+        [property: JsonPropertyName("custom_questions")] List<TtCustomQuestion>? CustomQuestions,
+        [property: JsonPropertyName("check_in")] TtCheckIn? CheckIn = null);
+
+    // TicketTailor returns `check_in` as a nested object on issued_tickets when
+    // a ticket has been scanned at the gate. `checked_in_at` is epoch seconds.
+    // Absent / null when not checked in. Issue nobodies-collective/Humans#736.
+    internal sealed record TtCheckIn(
+        [property: JsonPropertyName("checked_in_at")] long? CheckedInAt);
 
     internal sealed record TtCustomQuestion(
         [property: JsonPropertyName("question")] string? Question,

--- a/src/Humans.Infrastructure/Services/Users/CachingUserService.cs
+++ b/src/Humans.Infrastructure/Services/Users/CachingUserService.cs
@@ -569,9 +569,24 @@ public sealed class CachingUserService : TrackedCache<Guid, UserInfo>, IUserServ
                     Year = p.Year,
                     Status = p.Status,
                     Source = p.Source,
-                    DeclaredAt = p.DeclaredAt
+                    DeclaredAt = p.DeclaredAt,
+                    CheckedInAt = p.CheckedInAt,
                 });
             }
+        }
+        return result;
+    }
+
+    public async Task<IReadOnlyList<OnsiteUserRow>> GetOnsiteUsersAsync(
+        int year, CancellationToken ct = default)
+    {
+        await EnsureWarmedAsync(ct).ConfigureAwait(false);
+        var result = new List<OnsiteUserRow>();
+        foreach (var u in Values)
+        {
+            var onsiteSince = u.OnsiteSinceForYear(year);
+            if (onsiteSince is null) continue;
+            result.Add(new OnsiteUserRow(u.Id, u.BurnerName, onsiteSince));
         }
         return result;
     }
@@ -683,9 +698,10 @@ public sealed class CachingUserService : TrackedCache<Guid, UserInfo>, IUserServ
     }
 
     public async Task SetParticipationFromTicketSyncAsync(
-        Guid userId, int year, ParticipationStatus status, CancellationToken ct = default)
+        Guid userId, int year, ParticipationStatus status, Instant? checkedInAt, CancellationToken ct = default)
     {
-        await WithInnerAsync(inner => inner.SetParticipationFromTicketSyncAsync(userId, year, status, ct));
+        await WithInnerAsync(inner =>
+            inner.SetParticipationFromTicketSyncAsync(userId, year, status, checkedInAt, ct));
         await RefreshEntryAsync(userId, ct);
     }
 

--- a/src/Humans.Web/Controllers/ProfileController.cs
+++ b/src/Humans.Web/Controllers/ProfileController.cs
@@ -245,6 +245,10 @@ public class ProfileController : HumansControllerBase
             IsOwnProfile = true,
             DisplayName = info.BurnerName,
             CampaignGrants = campaignGrants,
+            // Onsite chip — own profile, always visible. Issue
+            // nobodies-collective/Humans#736.
+            OnsiteSince = await ResolveOnsiteSinceAsync(info, ct),
+            CanViewOnsiteChip = true,
         };
 
         // Tier app status (skip Withdrawn).
@@ -256,6 +260,19 @@ public class ProfileController : HumansControllerBase
         }
 
         return View("Index", viewModel);
+    }
+
+    /// <summary>
+    /// Returns the user's "onsite since" instant for the active event year, or
+    /// null if they are not yet checked in (or there is no active event). Reads
+    /// from the cached <see cref="UserInfo"/> snapshot — no extra DB hit. Issue
+    /// nobodies-collective/Humans#736.
+    /// </summary>
+    private async Task<Instant?> ResolveOnsiteSinceAsync(UserInfo info, CancellationToken ct)
+    {
+        var active = await _shiftMgmt.GetActiveAsync();
+        if (active is null || active.Year == 0) return null;
+        return info.OnsiteSinceForYear(active.Year);
     }
 
     [HttpGet("Me/Edit")]
@@ -1859,6 +1876,14 @@ public class ProfileController : HumansControllerBase
 
         var noShowContext = await BuildNoShowHistoryContextAsync(id, viewer.Id, isOwnProfile, ct);
 
+        // Onsite chip visibility (#736): self always, plus the same admin/board
+        // policy that gates /Tickets/Admin/Onsite. Coordinators below board
+        // tier don't see the chip on other humans — wider visibility is a
+        // follow-up PR if needed.
+        var canViewOnsiteChip = isOwnProfile
+            || (await _authorizationService.AuthorizeAsync(
+                User, PolicyNames.TicketAdminBoardOrAdmin)).Succeeded;
+
         var viewModel = new ProfileViewModel
         {
             Id = profile.Id,
@@ -1868,6 +1893,10 @@ public class ProfileController : HumansControllerBase
             IsApproved = profile.IsApproved,
             NoShowHistory = noShowContext.History,
             CanViewShiftSignups = noShowContext.CanView,
+            OnsiteSince = canViewOnsiteChip
+                ? await ResolveOnsiteSinceAsync(profileInfo, ct)
+                : null,
+            CanViewOnsiteChip = canViewOnsiteChip,
         };
 
         return View("Index", viewModel);

--- a/src/Humans.Web/Controllers/TicketsOnsiteAdminController.cs
+++ b/src/Humans.Web/Controllers/TicketsOnsiteAdminController.cs
@@ -1,9 +1,6 @@
-using Humans.Application.Interfaces.Auth;
-using Humans.Application.Interfaces.Camps;
 using Humans.Application.Interfaces.Shifts;
-using Humans.Application.Interfaces.Teams;
+using Humans.Application.Interfaces.Tickets;
 using Humans.Application.Interfaces.Users;
-using Humans.Domain.Enums;
 using Humans.Web.Authorization;
 using Humans.Web.Models.Tickets;
 using Microsoft.AspNetCore.Authorization;
@@ -12,31 +9,28 @@ using Microsoft.AspNetCore.Mvc;
 namespace Humans.Web.Controllers;
 
 /// <summary>
-/// "Who's onsite" view (#736). Flat list of every user with an Attended +
-/// non-null CheckedInAt EventParticipation for the active event year, joined
-/// with camp / team / governance-role names for filtering. Read-only.
+/// "Who's onsite" view (#736). Read-only flat list of every human with an
+/// Attended + non-null CheckedInAt EventParticipation for the active event
+/// year. Camp / team / governance-role filtering + name stitching are
+/// delegated to <see cref="IOnsiteRosterService"/>; this controller stays a
+/// thin HTTP adapter per
+/// <c>memory/architecture/no-business-logic-in-controllers.md</c>.
 /// </summary>
 [Authorize(Policy = PolicyNames.TicketAdminBoardOrAdmin)]
 [Route("Tickets/Admin/Onsite")]
 public sealed class TicketsOnsiteAdminController : HumansControllerBase
 {
     private readonly IShiftManagementService _shifts;
-    private readonly ICampService _camps;
-    private readonly ITeamService _teams;
-    private readonly IRoleAssignmentService _roles;
+    private readonly IOnsiteRosterService _roster;
 
     public TicketsOnsiteAdminController(
         IUserService userService,
         IShiftManagementService shifts,
-        ICampService camps,
-        ITeamService teams,
-        IRoleAssignmentService roles)
+        IOnsiteRosterService roster)
         : base(userService)
     {
         _shifts = shifts;
-        _camps = camps;
-        _teams = teams;
-        _roles = roles;
+        _roster = roster;
     }
 
     [HttpGet("")]
@@ -47,139 +41,27 @@ public sealed class TicketsOnsiteAdminController : HumansControllerBase
         CancellationToken ct)
     {
         var active = await _shifts.GetActiveAsync();
-        if (active is null || active.Year == 0)
-        {
-            // No active event configured — empty roster.
-            return View("~/Views/Tickets/Admin/Onsite.cshtml",
-                new OnsiteRosterViewModel(
-                    Year: 0,
-                    CampFilter: camp,
-                    TeamFilter: team,
-                    RoleFilter: role,
-                    AvailableCamps: [],
-                    AvailableTeams: [],
-                    AvailableRoles: [],
-                    Rows: []));
-        }
+        var year = active?.Year ?? 0;
 
-        var year = active.Year;
+        var result = await _roster.GetRosterAsync(year, camp, team, role, ct);
 
-        var onsite = await UserService.GetOnsiteUsersAsync(year, ct);
-        var onsiteIds = onsite.Select(o => o.UserId).ToHashSet();
-
-        // ---- Build per-user maps for camp / team / role names ----
-
-        var camps = await _camps.GetCampsForYearAsync(year, ct);
-        var campNamesByUserId = new Dictionary<Guid, SortedSet<string>>();
-        foreach (var campInfo in camps)
-        {
-            // CampInfo.Seasons is filtered to this year by GetCampsForYearAsync.
-            foreach (var season in campInfo.Seasons)
-            {
-                var members = await _camps.GetSeasonMembersAsync(season.Id, ct);
-                foreach (var m in members)
-                {
-                    if (!onsiteIds.Contains(m.UserId)) continue;
-                    if (m.Status != CampMemberStatus.Active) continue;
-                    if (!campNamesByUserId.TryGetValue(m.UserId, out var set))
-                    {
-                        set = new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
-                        campNamesByUserId[m.UserId] = set;
-                    }
-                    set.Add(season.Name);
-                }
-            }
-        }
-
-        var teamsById = await _teams.GetTeamsAsync(ct);
-        var teamNamesByUserId = new Dictionary<Guid, SortedSet<string>>();
-        foreach (var (_, teamInfo) in teamsById)
-        {
-            if (!teamInfo.IsActive) continue;
-            if (teamInfo.IsSystemTeam) continue; // system teams (Volunteers etc) aren't a useful filter here
-            foreach (var member in teamInfo.Members)
-            {
-                if (!onsiteIds.Contains(member.UserId)) continue;
-                if (!teamNamesByUserId.TryGetValue(member.UserId, out var set))
-                {
-                    set = new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
-                    teamNamesByUserId[member.UserId] = set;
-                }
-                set.Add(teamInfo.Name);
-            }
-        }
-
-        var roleNamesByUserId = new Dictionary<Guid, SortedSet<string>>();
-        foreach (var userId in onsiteIds)
-        {
-            var rs = await _roles.GetActiveForUserAsync(userId, ct);
-            if (rs.Count == 0) continue;
-            var set = new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
-            foreach (var r in rs) set.Add(r.RoleName);
-            roleNamesByUserId[userId] = set;
-        }
-
-        // ---- Filter ----
-
-        var filtered = onsite.Select(o =>
-        {
-            var campsForUser = campNamesByUserId.TryGetValue(o.UserId, out var c)
-                ? (IReadOnlyList<string>)c.ToList()
-                : [];
-            var teamsForUser = teamNamesByUserId.TryGetValue(o.UserId, out var t)
-                ? (IReadOnlyList<string>)t.ToList()
-                : [];
-            var rolesForUser = roleNamesByUserId.TryGetValue(o.UserId, out var r)
-                ? (IReadOnlyList<string>)r.ToList()
-                : [];
-            return (Row: o, Camps: campsForUser, Teams: teamsForUser, Roles: rolesForUser);
-        });
-
-        if (!string.IsNullOrWhiteSpace(camp))
-            filtered = filtered.Where(x => x.Camps.Contains(camp!, StringComparer.OrdinalIgnoreCase));
-        if (!string.IsNullOrWhiteSpace(team))
-            filtered = filtered.Where(x => x.Teams.Contains(team!, StringComparer.OrdinalIgnoreCase));
-        if (!string.IsNullOrWhiteSpace(role))
-            filtered = filtered.Where(x => x.Roles.Contains(role!, StringComparer.OrdinalIgnoreCase));
-
-        // Display sort: most-recent check-in first.
-        var rows = filtered
-            .Where(x => x.Row.CheckedInAt is not null)
-            .OrderByDescending(x => x.Row.CheckedInAt)
-            .Select(x => new OnsiteRosterRow(
-                x.Row.UserId,
-                x.Row.DisplayName,
-                x.Row.CheckedInAt!.Value,
-                x.Camps,
-                x.Teams,
-                x.Roles))
+        // Display sort lives at the presentation layer per
+        // memory/architecture/display-sort-in-controllers.md — most-recent
+        // check-in first.
+        var rows = result.Rows
+            .OrderByDescending(r => r.CheckedInAt)
             .ToList();
 
-        var availableCamps = campNamesByUserId.Values
-            .SelectMany(s => s)
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .OrderBy(s => s, StringComparer.OrdinalIgnoreCase)
-            .ToList();
-        var availableTeams = teamNamesByUserId.Values
-            .SelectMany(s => s)
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .OrderBy(s => s, StringComparer.OrdinalIgnoreCase)
-            .ToList();
-        var availableRoles = roleNamesByUserId.Values
-            .SelectMany(s => s)
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .OrderBy(s => s, StringComparer.OrdinalIgnoreCase)
-            .ToList();
+        var vm = new OnsiteRosterViewModel(
+            Year: year,
+            CampFilter: camp,
+            TeamFilter: team,
+            RoleFilter: role,
+            AvailableCamps: result.AvailableCamps,
+            AvailableTeams: result.AvailableTeams,
+            AvailableRoles: result.AvailableRoles,
+            Rows: rows);
 
-        return View("~/Views/Tickets/Admin/Onsite.cshtml",
-            new OnsiteRosterViewModel(
-                Year: year,
-                CampFilter: camp,
-                TeamFilter: team,
-                RoleFilter: role,
-                AvailableCamps: availableCamps,
-                AvailableTeams: availableTeams,
-                AvailableRoles: availableRoles,
-                Rows: rows));
+        return View("~/Views/Tickets/Admin/Onsite.cshtml", vm);
     }
 }

--- a/src/Humans.Web/Controllers/TicketsOnsiteAdminController.cs
+++ b/src/Humans.Web/Controllers/TicketsOnsiteAdminController.cs
@@ -1,0 +1,185 @@
+using Humans.Application.Interfaces.Auth;
+using Humans.Application.Interfaces.Camps;
+using Humans.Application.Interfaces.Shifts;
+using Humans.Application.Interfaces.Teams;
+using Humans.Application.Interfaces.Users;
+using Humans.Domain.Enums;
+using Humans.Web.Authorization;
+using Humans.Web.Models.Tickets;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Humans.Web.Controllers;
+
+/// <summary>
+/// "Who's onsite" view (#736). Flat list of every user with an Attended +
+/// non-null CheckedInAt EventParticipation for the active event year, joined
+/// with camp / team / governance-role names for filtering. Read-only.
+/// </summary>
+[Authorize(Policy = PolicyNames.TicketAdminBoardOrAdmin)]
+[Route("Tickets/Admin/Onsite")]
+public sealed class TicketsOnsiteAdminController : HumansControllerBase
+{
+    private readonly IShiftManagementService _shifts;
+    private readonly ICampService _camps;
+    private readonly ITeamService _teams;
+    private readonly IRoleAssignmentService _roles;
+
+    public TicketsOnsiteAdminController(
+        IUserService userService,
+        IShiftManagementService shifts,
+        ICampService camps,
+        ITeamService teams,
+        IRoleAssignmentService roles)
+        : base(userService)
+    {
+        _shifts = shifts;
+        _camps = camps;
+        _teams = teams;
+        _roles = roles;
+    }
+
+    [HttpGet("")]
+    public async Task<IActionResult> Index(
+        [FromQuery] string? camp,
+        [FromQuery] string? team,
+        [FromQuery] string? role,
+        CancellationToken ct)
+    {
+        var active = await _shifts.GetActiveAsync();
+        if (active is null || active.Year == 0)
+        {
+            // No active event configured — empty roster.
+            return View("~/Views/Tickets/Admin/Onsite.cshtml",
+                new OnsiteRosterViewModel(
+                    Year: 0,
+                    CampFilter: camp,
+                    TeamFilter: team,
+                    RoleFilter: role,
+                    AvailableCamps: [],
+                    AvailableTeams: [],
+                    AvailableRoles: [],
+                    Rows: []));
+        }
+
+        var year = active.Year;
+
+        var onsite = await UserService.GetOnsiteUsersAsync(year, ct);
+        var onsiteIds = onsite.Select(o => o.UserId).ToHashSet();
+
+        // ---- Build per-user maps for camp / team / role names ----
+
+        var camps = await _camps.GetCampsForYearAsync(year, ct);
+        var campNamesByUserId = new Dictionary<Guid, SortedSet<string>>();
+        foreach (var campInfo in camps)
+        {
+            // CampInfo.Seasons is filtered to this year by GetCampsForYearAsync.
+            foreach (var season in campInfo.Seasons)
+            {
+                var members = await _camps.GetSeasonMembersAsync(season.Id, ct);
+                foreach (var m in members)
+                {
+                    if (!onsiteIds.Contains(m.UserId)) continue;
+                    if (m.Status != CampMemberStatus.Active) continue;
+                    if (!campNamesByUserId.TryGetValue(m.UserId, out var set))
+                    {
+                        set = new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
+                        campNamesByUserId[m.UserId] = set;
+                    }
+                    set.Add(season.Name);
+                }
+            }
+        }
+
+        var teamsById = await _teams.GetTeamsAsync(ct);
+        var teamNamesByUserId = new Dictionary<Guid, SortedSet<string>>();
+        foreach (var (_, teamInfo) in teamsById)
+        {
+            if (!teamInfo.IsActive) continue;
+            if (teamInfo.IsSystemTeam) continue; // system teams (Volunteers etc) aren't a useful filter here
+            foreach (var member in teamInfo.Members)
+            {
+                if (!onsiteIds.Contains(member.UserId)) continue;
+                if (!teamNamesByUserId.TryGetValue(member.UserId, out var set))
+                {
+                    set = new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
+                    teamNamesByUserId[member.UserId] = set;
+                }
+                set.Add(teamInfo.Name);
+            }
+        }
+
+        var roleNamesByUserId = new Dictionary<Guid, SortedSet<string>>();
+        foreach (var userId in onsiteIds)
+        {
+            var rs = await _roles.GetActiveForUserAsync(userId, ct);
+            if (rs.Count == 0) continue;
+            var set = new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var r in rs) set.Add(r.RoleName);
+            roleNamesByUserId[userId] = set;
+        }
+
+        // ---- Filter ----
+
+        var filtered = onsite.Select(o =>
+        {
+            var campsForUser = campNamesByUserId.TryGetValue(o.UserId, out var c)
+                ? (IReadOnlyList<string>)c.ToList()
+                : [];
+            var teamsForUser = teamNamesByUserId.TryGetValue(o.UserId, out var t)
+                ? (IReadOnlyList<string>)t.ToList()
+                : [];
+            var rolesForUser = roleNamesByUserId.TryGetValue(o.UserId, out var r)
+                ? (IReadOnlyList<string>)r.ToList()
+                : [];
+            return (Row: o, Camps: campsForUser, Teams: teamsForUser, Roles: rolesForUser);
+        });
+
+        if (!string.IsNullOrWhiteSpace(camp))
+            filtered = filtered.Where(x => x.Camps.Contains(camp!, StringComparer.OrdinalIgnoreCase));
+        if (!string.IsNullOrWhiteSpace(team))
+            filtered = filtered.Where(x => x.Teams.Contains(team!, StringComparer.OrdinalIgnoreCase));
+        if (!string.IsNullOrWhiteSpace(role))
+            filtered = filtered.Where(x => x.Roles.Contains(role!, StringComparer.OrdinalIgnoreCase));
+
+        // Display sort: most-recent check-in first.
+        var rows = filtered
+            .Where(x => x.Row.CheckedInAt is not null)
+            .OrderByDescending(x => x.Row.CheckedInAt)
+            .Select(x => new OnsiteRosterRow(
+                x.Row.UserId,
+                x.Row.DisplayName,
+                x.Row.CheckedInAt!.Value,
+                x.Camps,
+                x.Teams,
+                x.Roles))
+            .ToList();
+
+        var availableCamps = campNamesByUserId.Values
+            .SelectMany(s => s)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(s => s, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        var availableTeams = teamNamesByUserId.Values
+            .SelectMany(s => s)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(s => s, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        var availableRoles = roleNamesByUserId.Values
+            .SelectMany(s => s)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(s => s, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        return View("~/Views/Tickets/Admin/Onsite.cshtml",
+            new OnsiteRosterViewModel(
+                Year: year,
+                CampFilter: camp,
+                TeamFilter: team,
+                RoleFilter: role,
+                AvailableCamps: availableCamps,
+                AvailableTeams: availableTeams,
+                AvailableRoles: availableRoles,
+                Rows: rows));
+    }
+}

--- a/src/Humans.Web/Extensions/Sections/TicketsSectionExtensions.cs
+++ b/src/Humans.Web/Extensions/Sections/TicketsSectionExtensions.cs
@@ -45,6 +45,9 @@ internal static class TicketsSectionExtensions
         services.AddScoped<IAttendeeContactImportService, AttendeeContactImportService>();
         services.AddScoped<TicketDashboardPageBuilder>();
 
+        // "Who's onsite" roster orchestrator (#736).
+        services.AddScoped<IOnsiteRosterService, OnsiteRosterService>();
+
         services.AddScoped<IUserParticipationBackfillService, UserParticipationBackfillService>();
 
         services.AddScoped<TicketSyncJob>();

--- a/src/Humans.Web/Models/ProfileViewModel.cs
+++ b/src/Humans.Web/Models/ProfileViewModel.cs
@@ -346,6 +346,22 @@ public class ProfileViewModel
     /// Posted from the Edit form so the same submit saves preferences alongside the profile.
     /// </summary>
     public List<Guid> EditableShiftTagIds { get; set; } = [];
+
+    /// <summary>
+    /// When the human was first checked in at the active event's gate, or null
+    /// if not yet onsite. Drives the "Onsite since {time}" chip per issue
+    /// nobodies-collective/Humans#736. Visibility is policy-gated on
+    /// <see cref="CanViewOnsiteChip"/>.
+    /// </summary>
+    public Instant? OnsiteSince { get; set; }
+
+    /// <summary>
+    /// Whether the viewer is permitted to see the onsite chip. True for the
+    /// human themselves and for users matching the same admin/coordinator
+    /// policy that gates <c>/Tickets/Admin/Onsite</c>
+    /// (<c>PolicyNames.TicketAdminBoardOrAdmin</c>).
+    /// </summary>
+    public bool CanViewOnsiteChip { get; set; }
 }
 
 /// <summary>

--- a/src/Humans.Web/Models/Tickets/OnsiteRosterViewModel.cs
+++ b/src/Humans.Web/Models/Tickets/OnsiteRosterViewModel.cs
@@ -1,0 +1,26 @@
+using NodaTime;
+
+namespace Humans.Web.Models.Tickets;
+
+/// <summary>
+/// View model for <c>/Tickets/Admin/Onsite</c> — flat roster of currently
+/// checked-in humans for the active event year, joined with their camp / team /
+/// governance-role names. Issue nobodies-collective/Humans#736.
+/// </summary>
+public sealed record OnsiteRosterViewModel(
+    int Year,
+    string? CampFilter,
+    string? TeamFilter,
+    string? RoleFilter,
+    IReadOnlyList<string> AvailableCamps,
+    IReadOnlyList<string> AvailableTeams,
+    IReadOnlyList<string> AvailableRoles,
+    IReadOnlyList<OnsiteRosterRow> Rows);
+
+public sealed record OnsiteRosterRow(
+    Guid UserId,
+    string DisplayName,
+    Instant CheckedInAt,
+    IReadOnlyList<string> CampNames,
+    IReadOnlyList<string> TeamNames,
+    IReadOnlyList<string> RoleNames);

--- a/src/Humans.Web/Models/Tickets/OnsiteRosterViewModel.cs
+++ b/src/Humans.Web/Models/Tickets/OnsiteRosterViewModel.cs
@@ -1,11 +1,13 @@
-using NodaTime;
+using Humans.Application.Interfaces.Tickets;
 
 namespace Humans.Web.Models.Tickets;
 
 /// <summary>
 /// View model for <c>/Tickets/Admin/Onsite</c> — flat roster of currently
 /// checked-in humans for the active event year, joined with their camp / team /
-/// governance-role names. Issue nobodies-collective/Humans#736.
+/// governance-role names. Issue nobodies-collective/Humans#736. Rows are the
+/// service-layer <see cref="OnsiteRosterRow"/> records — no Web-layer remapping
+/// needed since the shape is already presentation-ready.
 /// </summary>
 public sealed record OnsiteRosterViewModel(
     int Year,
@@ -16,11 +18,3 @@ public sealed record OnsiteRosterViewModel(
     IReadOnlyList<string> AvailableTeams,
     IReadOnlyList<string> AvailableRoles,
     IReadOnlyList<OnsiteRosterRow> Rows);
-
-public sealed record OnsiteRosterRow(
-    Guid UserId,
-    string DisplayName,
-    Instant CheckedInAt,
-    IReadOnlyList<string> CampNames,
-    IReadOnlyList<string> TeamNames,
-    IReadOnlyList<string> RoleNames);

--- a/src/Humans.Web/Views/Profile/Index.cshtml
+++ b/src/Humans.Web/Views/Profile/Index.cshtml
@@ -1,5 +1,6 @@
 @using Microsoft.AspNetCore.Authorization
 @using Humans.Web.Authorization
+@using Humans.Web.Extensions
 @inject IAuthorizationService AuthService
 @model Humans.Web.Models.ProfileViewModel
 @{
@@ -17,6 +18,14 @@
                 </a>
             </div>
         </div>
+
+        @if (Model.CanViewOnsiteChip && Model.OnsiteSince is not null)
+        {
+            <span class="badge text-bg-success mb-2" title="Checked in at the gate">
+                <i class="fa-solid fa-circle-check"></i>
+                Onsite since @Model.OnsiteSince.Value.ToDisplayDateTime()
+            </span>
+        }
 
         @if (Model.IsOwnProfile)
         {

--- a/src/Humans.Web/Views/Tickets/Admin/Onsite.cshtml
+++ b/src/Humans.Web/Views/Tickets/Admin/Onsite.cshtml
@@ -1,0 +1,89 @@
+@using Humans.Web.Extensions
+@model Humans.Web.Models.Tickets.OnsiteRosterViewModel
+@{
+    ViewData["Title"] = "Who's Onsite";
+}
+
+<h1>Who's Onsite</h1>
+
+@if (Model.Year == 0)
+{
+    <p class="text-muted">No active event configured.</p>
+}
+else
+{
+    <p class="text-muted">
+        @Model.Rows.Count human@(Model.Rows.Count == 1 ? "" : "s") currently checked in for the @Model.Year event.
+        Sorted by most-recent arrival first.
+    </p>
+
+    <form method="get" class="row g-2 mb-3">
+        <div class="col-auto">
+            <label for="camp-filter" class="form-label small mb-0">Camp</label>
+            <select id="camp-filter" name="camp" class="form-select form-select-sm">
+                <option value="">All camps</option>
+                @foreach (var c in Model.AvailableCamps)
+                {
+                    <option value="@c" selected="@(string.Equals(c, Model.CampFilter, StringComparison.OrdinalIgnoreCase))">@c</option>
+                }
+            </select>
+        </div>
+        <div class="col-auto">
+            <label for="team-filter" class="form-label small mb-0">Team</label>
+            <select id="team-filter" name="team" class="form-select form-select-sm">
+                <option value="">All teams</option>
+                @foreach (var t in Model.AvailableTeams)
+                {
+                    <option value="@t" selected="@(string.Equals(t, Model.TeamFilter, StringComparison.OrdinalIgnoreCase))">@t</option>
+                }
+            </select>
+        </div>
+        <div class="col-auto">
+            <label for="role-filter" class="form-label small mb-0">Governance role</label>
+            <select id="role-filter" name="role" class="form-select form-select-sm">
+                <option value="">All roles</option>
+                @foreach (var r in Model.AvailableRoles)
+                {
+                    <option value="@r" selected="@(string.Equals(r, Model.RoleFilter, StringComparison.OrdinalIgnoreCase))">@r</option>
+                }
+            </select>
+        </div>
+        <div class="col-auto align-self-end">
+            <button type="submit" class="btn btn-sm btn-primary">Filter</button>
+            <a class="btn btn-sm btn-outline-secondary" href="@Url.Action("Index")">Reset</a>
+        </div>
+    </form>
+
+    @if (Model.Rows.Count == 0)
+    {
+        <p class="text-muted">No humans currently onsite matching the selected filters.</p>
+    }
+    else
+    {
+        <table class="table table-sm table-hover">
+            <thead>
+                <tr>
+                    <th>Human</th>
+                    <th>Checked in at</th>
+                    <th>Camps</th>
+                    <th>Teams</th>
+                    <th>Governance roles</th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach (var row in Model.Rows)
+                {
+                    <tr>
+                        <td>
+                            <a asp-controller="Profile" asp-action="Index" asp-route-userId="@row.UserId">@row.DisplayName</a>
+                        </td>
+                        <td>@row.CheckedInAt.ToDisplayDateTime()</td>
+                        <td>@(row.CampNames.Count == 0 ? "—" : string.Join(", ", row.CampNames))</td>
+                        <td>@(row.TeamNames.Count == 0 ? "—" : string.Join(", ", row.TeamNames))</td>
+                        <td>@(row.RoleNames.Count == 0 ? "—" : string.Join(", ", row.RoleNames))</td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+    }
+}

--- a/src/Humans.Web/Views/Tickets/Admin/Onsite.cshtml
+++ b/src/Humans.Web/Views/Tickets/Admin/Onsite.cshtml
@@ -75,7 +75,7 @@ else
                 {
                     <tr>
                         <td>
-                            <a asp-controller="Profile" asp-action="Index" asp-route-userId="@row.UserId">@row.DisplayName</a>
+                            <a asp-controller="Profile" asp-action="ViewProfile" asp-route-id="@row.UserId">@row.DisplayName</a>
                         </td>
                         <td>@row.CheckedInAt.ToDisplayDateTime()</td>
                         <td>@(row.CampNames.Count == 0 ? "—" : string.Join(", ", row.CampNames))</td>

--- a/tests/Humans.Application.Tests/Repositories/UserRepositoryTests.cs
+++ b/tests/Humans.Application.Tests/Repositories/UserRepositoryTests.cs
@@ -164,7 +164,8 @@ public sealed class UserRepositoryTests : IDisposable
         var now = _clock.GetCurrentInstant();
 
         var result = await _repo.UpsertParticipationAsync(
-            userId, 2026, ParticipationStatus.NotAttending, ParticipationSource.UserDeclared, now, default);
+            userId, 2026, ParticipationStatus.NotAttending, ParticipationSource.UserDeclared, now,
+            checkedInAt: null, default);
 
         result.Should().NotBeNull();
         result!.Status.Should().Be(ParticipationStatus.NotAttending);
@@ -192,12 +193,94 @@ public sealed class UserRepositoryTests : IDisposable
         await _dbContext.SaveChangesAsync();
 
         var result = await _repo.UpsertParticipationAsync(
-            userId, 2026, ParticipationStatus.Ticketed, ParticipationSource.TicketSync, null, default);
+            userId, 2026, ParticipationStatus.Ticketed, ParticipationSource.TicketSync, null,
+            checkedInAt: null, default);
 
         result.Should().NotBeNull();
         result!.Status.Should().Be(ParticipationStatus.Ticketed);
         result.Source.Should().Be(ParticipationSource.TicketSync);
         result.DeclaredAt.Should().BeNull();
+    }
+
+    // ==========================================================================
+    // CheckedInAt (#736)
+    // ==========================================================================
+
+    [HumansFact]
+    public async Task UpsertParticipationAsync_CreatesAttendedRow_WithCheckedInAt()
+    {
+        var userId = Guid.NewGuid();
+        var arrival = Instant.FromUtc(2026, 7, 8, 14, 30);
+
+        var result = await _repo.UpsertParticipationAsync(
+            userId, 2026, ParticipationStatus.Attended, ParticipationSource.TicketSync,
+            declaredAt: null, checkedInAt: arrival, default);
+
+        result.Should().NotBeNull();
+        result!.Status.Should().Be(ParticipationStatus.Attended);
+        result.CheckedInAt.Should().Be(arrival);
+
+        var persisted = await _dbContext.EventParticipations.AsNoTracking()
+            .FirstAsync(ep => ep.UserId == userId && ep.Year == 2026);
+        persisted.CheckedInAt.Should().Be(arrival);
+    }
+
+    [HumansFact]
+    public async Task UpsertParticipationAsync_NeverOverwritesNonNullCheckedInAt()
+    {
+        // Pre-existing Attended row with CheckedInAt set. Repo's Attended-is-
+        // permanent rule short-circuits the whole call to null. CheckedInAt
+        // therefore cannot be overwritten via this path.
+        var userId = Guid.NewGuid();
+        var originalArrival = Instant.FromUtc(2026, 7, 8, 9, 0);
+        _dbContext.EventParticipations.Add(new EventParticipation
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            Year = 2026,
+            Status = ParticipationStatus.Attended,
+            Source = ParticipationSource.TicketSync,
+            CheckedInAt = originalArrival,
+        });
+        await _dbContext.SaveChangesAsync();
+
+        var laterArrival = Instant.FromUtc(2026, 7, 8, 18, 0);
+        var result = await _repo.UpsertParticipationAsync(
+            userId, 2026, ParticipationStatus.Attended, ParticipationSource.TicketSync,
+            declaredAt: null, checkedInAt: laterArrival, default);
+
+        result.Should().BeNull(); // Attended-is-permanent short-circuit
+        var persisted = await _dbContext.EventParticipations.AsNoTracking()
+            .FirstAsync(ep => ep.UserId == userId && ep.Year == 2026);
+        persisted.CheckedInAt.Should().Be(originalArrival);
+    }
+
+    [HumansFact]
+    public async Task UpsertParticipationAsync_FillsCheckedInAt_OnTicketedToAttendedUpgrade()
+    {
+        // Existing Ticketed row from earlier sync. Now a CheckedIn ticket
+        // arrives — repo upgrades the row to Attended and fills CheckedInAt
+        // (because it was null before).
+        var userId = Guid.NewGuid();
+        _dbContext.EventParticipations.Add(new EventParticipation
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            Year = 2026,
+            Status = ParticipationStatus.Ticketed,
+            Source = ParticipationSource.TicketSync,
+            CheckedInAt = null,
+        });
+        await _dbContext.SaveChangesAsync();
+
+        var arrival = Instant.FromUtc(2026, 7, 8, 12, 0);
+        var result = await _repo.UpsertParticipationAsync(
+            userId, 2026, ParticipationStatus.Attended, ParticipationSource.TicketSync,
+            declaredAt: null, checkedInAt: arrival, default);
+
+        result.Should().NotBeNull();
+        result!.Status.Should().Be(ParticipationStatus.Attended);
+        result.CheckedInAt.Should().Be(arrival);
     }
 
     [HumansFact]
@@ -217,7 +300,8 @@ public sealed class UserRepositoryTests : IDisposable
         await _dbContext.SaveChangesAsync();
 
         var result = await _repo.UpsertParticipationAsync(
-            userId, 2026, ParticipationStatus.NotAttending, ParticipationSource.UserDeclared, _clock.GetCurrentInstant(), default);
+            userId, 2026, ParticipationStatus.NotAttending, ParticipationSource.UserDeclared, _clock.GetCurrentInstant(),
+            checkedInAt: null, default);
 
         result.Should().BeNull();
         var persisted = await _dbContext.EventParticipations.AsNoTracking()

--- a/tests/Humans.Application.Tests/Services/AccountProvisioningServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/AccountProvisioningServiceTests.cs
@@ -171,7 +171,8 @@ public class AccountProvisioningServiceTests
             throw new NotSupportedException();
         public Task<EventParticipation?> UpsertParticipationAsync(
             Guid userId, int year, ParticipationStatus status,
-            ParticipationSource source, Instant? declaredAt, CancellationToken ct = default) =>
+            ParticipationSource source, Instant? declaredAt, Instant? checkedInAt,
+            CancellationToken ct = default) =>
             throw new NotSupportedException();
         public Task<bool> RemoveParticipationAsync(
             Guid userId, int year, ParticipationSource requiredSource, CancellationToken ct = default) =>

--- a/tests/Humans.Application.Tests/Services/Shifts/ShiftDashboardMetricsTests.cs
+++ b/tests/Humans.Application.Tests/Services/Shifts/ShiftDashboardMetricsTests.cs
@@ -1070,7 +1070,8 @@ public class ShiftDashboardMetricsTests : IDisposable
         public Task<List<EventParticipation>> GetAllParticipationsForYearAsync(int year, CancellationToken ct = default) => throw new NotSupportedException();
         public Task<EventParticipation> DeclareNotAttendingAsync(Guid userId, int year, CancellationToken ct = default) => throw new NotSupportedException();
         public Task<bool> UndoNotAttendingAsync(Guid userId, int year, CancellationToken ct = default) => throw new NotSupportedException();
-        public Task SetParticipationFromTicketSyncAsync(Guid userId, int year, ParticipationStatus status, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task SetParticipationFromTicketSyncAsync(Guid userId, int year, ParticipationStatus status, Instant? checkedInAt, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task<IReadOnlyList<OnsiteUserRow>> GetOnsiteUsersAsync(int year, CancellationToken ct = default) => throw new NotSupportedException();
         public Task RemoveTicketSyncParticipationAsync(Guid userId, int year, CancellationToken ct = default) => throw new NotSupportedException();
         public Task<int> BackfillParticipationsAsync(int year, List<(Guid UserId, ParticipationStatus Status)> entries, CancellationToken ct = default) => throw new NotSupportedException();
         public Task<IReadOnlyList<User>> GetAllUsersAsync(CancellationToken ct = default) => throw new NotSupportedException();

--- a/tests/Humans.Application.Tests/Services/TicketSyncServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/TicketSyncServiceTests.cs
@@ -433,6 +433,129 @@ public class TicketSyncServiceTests : IDisposable
     }
 
     // ==========================================================================
+    // EventParticipation.CheckedInAt threading (#736)
+    // ==========================================================================
+
+    [HumansFact]
+    public async Task SyncEventParticipations_PassesVendorCheckedInAt_ForCheckedInAttendees()
+    {
+        var userId = Guid.NewGuid();
+        SeedUser(userId);
+        SeedUserEmail(userId, "alice@example.com", isOAuth: true);
+        await _dbContext.SaveChangesAsync();
+
+        _shiftManagementService.GetActiveAsync()
+            .Returns(new EventSettings { Year = 2026 });
+
+        var checkInInstant = Instant.FromUtc(2026, 7, 8, 14, 30);
+
+        _vendorService.GetOrdersAsync(Arg.Any<Instant?>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new List<VendorOrderDto> { MakeOrderDto("ord_chk", "Alice", "alice@example.com") });
+        _vendorService.GetIssuedTicketsAsync(Arg.Any<Instant?>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new List<VendorTicketDto>
+            {
+                MakeTicketDto("tkt_chk", "ord_chk", "Alice", "alice@example.com",
+                    status: "checked_in", checkedInAt: checkInInstant)
+            });
+
+        await _service.SyncOrdersAndAttendeesAsync();
+
+        await _userService.Received(1).SetParticipationFromTicketSyncAsync(
+            userId, 2026, ParticipationStatus.Attended,
+            checkInInstant, Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task SyncEventParticipations_TakesMinCheckedInAt_AcrossUsersCheckedInAttendees()
+    {
+        var userId = Guid.NewGuid();
+        SeedUser(userId);
+        SeedUserEmail(userId, "alice@example.com", isOAuth: true);
+        await _dbContext.SaveChangesAsync();
+
+        _shiftManagementService.GetActiveAsync()
+            .Returns(new EventSettings { Year = 2026 });
+
+        var earlier = Instant.FromUtc(2026, 7, 8, 10, 0);
+        var later = Instant.FromUtc(2026, 7, 8, 18, 0);
+
+        _vendorService.GetOrdersAsync(Arg.Any<Instant?>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new List<VendorOrderDto> { MakeOrderDto("ord_two", "Alice", "alice@example.com") });
+        _vendorService.GetIssuedTicketsAsync(Arg.Any<Instant?>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new List<VendorTicketDto>
+            {
+                MakeTicketDto("tkt_a", "ord_two", "Alice", "alice@example.com",
+                    status: "checked_in", checkedInAt: later),
+                MakeTicketDto("tkt_b", "ord_two", "Alice", "alice@example.com",
+                    status: "checked_in", checkedInAt: earlier),
+            });
+
+        await _service.SyncOrdersAndAttendeesAsync();
+
+        await _userService.Received(1).SetParticipationFromTicketSyncAsync(
+            userId, 2026, ParticipationStatus.Attended,
+            earlier, Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task SyncEventParticipations_PassesNullCheckedInAt_WhenVendorDidntReturnTimestamp()
+    {
+        // Graceful fallback: vendor returned status=checked_in but no
+        // check_in.checked_in_at — sync still flips to Attended but with null
+        // timestamp. Repo's "never overwrite non-null" rule preserves a prior
+        // timestamp if one already exists.
+        var userId = Guid.NewGuid();
+        SeedUser(userId);
+        SeedUserEmail(userId, "alice@example.com", isOAuth: true);
+        await _dbContext.SaveChangesAsync();
+
+        _shiftManagementService.GetActiveAsync()
+            .Returns(new EventSettings { Year = 2026 });
+
+        _vendorService.GetOrdersAsync(Arg.Any<Instant?>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new List<VendorOrderDto> { MakeOrderDto("ord_x", "Alice", "alice@example.com") });
+        _vendorService.GetIssuedTicketsAsync(Arg.Any<Instant?>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new List<VendorTicketDto>
+            {
+                MakeTicketDto("tkt_x", "ord_x", "Alice", "alice@example.com",
+                    status: "checked_in", checkedInAt: null)
+            });
+
+        await _service.SyncOrdersAndAttendeesAsync();
+
+        await _userService.Received(1).SetParticipationFromTicketSyncAsync(
+            userId, 2026, ParticipationStatus.Attended,
+            (Instant?)null, Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task SyncEventParticipations_PassesNullCheckedInAt_ForTicketedOnlyAttendees()
+    {
+        var userId = Guid.NewGuid();
+        SeedUser(userId);
+        SeedUserEmail(userId, "alice@example.com", isOAuth: true);
+        await _dbContext.SaveChangesAsync();
+
+        _shiftManagementService.GetActiveAsync()
+            .Returns(new EventSettings { Year = 2026 });
+
+        _vendorService.GetOrdersAsync(Arg.Any<Instant?>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new List<VendorOrderDto> { MakeOrderDto("ord_v", "Alice", "alice@example.com") });
+        _vendorService.GetIssuedTicketsAsync(Arg.Any<Instant?>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new List<VendorTicketDto>
+            {
+                MakeTicketDto("tkt_v", "ord_v", "Alice", "alice@example.com",
+                    status: "valid", checkedInAt: null)
+            });
+
+        await _service.SyncOrdersAndAttendeesAsync();
+
+        await _userService.Received(1).SetParticipationFromTicketSyncAsync(
+            userId, 2026, ParticipationStatus.Ticketed,
+            (Instant?)null, Arg.Any<CancellationToken>());
+    }
+
+    // ==========================================================================
     // Helpers
     // ==========================================================================
 
@@ -498,7 +621,8 @@ public class TicketSyncServiceTests : IDisposable
         string attendeeName,
         string? attendeeEmail,
         decimal price = 50m,
-        string status = "valid")
+        string status = "valid",
+        Instant? checkedInAt = null)
     {
         return new VendorTicketDto(
             VendorTicketId: vendorTicketId,
@@ -507,6 +631,7 @@ public class TicketSyncServiceTests : IDisposable
             AttendeeEmail: attendeeEmail,
             TicketTypeName: "Full Week",
             Price: price,
-            Status: status);
+            Status: status,
+            CheckedInAt: checkedInAt);
     }
 }

--- a/tests/Humans.Application.Tests/Services/Tickets/AttendeeContactImportServiceApplyTests.cs
+++ b/tests/Humans.Application.Tests/Services/Tickets/AttendeeContactImportServiceApplyTests.cs
@@ -60,7 +60,8 @@ public class AttendeeContactImportServiceApplyTests
                 l => l.Count == 1 && l[0].Id == attendeeId), Arg.Any<CancellationToken>());
 
         await harness.Users.Received(1).SetParticipationFromTicketSyncAsync(
-            targetUserId, 2026, ParticipationStatus.Ticketed, Arg.Any<CancellationToken>());
+            targetUserId, 2026, ParticipationStatus.Ticketed,
+            (Instant?)null, Arg.Any<CancellationToken>());
 
         harness.TicketQuery.Received(1).InvalidateAfterContactImport();
 
@@ -109,7 +110,8 @@ public class AttendeeContactImportServiceApplyTests
             "fresh@x.com", "Fresh Face", ContactSource.TicketTailor, Arg.Any<CancellationToken>());
 
         await harness.Users.Received(1).SetParticipationFromTicketSyncAsync(
-            newUserId, 2026, ParticipationStatus.Ticketed, Arg.Any<CancellationToken>());
+            newUserId, 2026, ParticipationStatus.Ticketed,
+            (Instant?)null, Arg.Any<CancellationToken>());
     }
 
     [HumansFact]
@@ -311,7 +313,8 @@ public class AttendeeContactImportServiceApplyTests
 
         // Participation flips once for the single user, not twice.
         await harness.Users.Received(1).SetParticipationFromTicketSyncAsync(
-            targetUserId, 2026, ParticipationStatus.Ticketed, Arg.Any<CancellationToken>());
+            targetUserId, 2026, ParticipationStatus.Ticketed,
+            (Instant?)null, Arg.Any<CancellationToken>());
     }
 
     [HumansFact]

--- a/tests/Humans.Application.Tests/Services/Tickets/OnsiteRosterServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Tickets/OnsiteRosterServiceTests.cs
@@ -1,0 +1,139 @@
+using AwesomeAssertions;
+using Humans.Application.Interfaces.Auth;
+using Humans.Application.Interfaces.Camps;
+using Humans.Application.Interfaces.Shifts;
+using Humans.Application.Interfaces.Teams;
+using Humans.Application.Interfaces.Tickets;
+using Humans.Application.Interfaces.Users;
+using Humans.Application.Services.Tickets;
+using Humans.Domain.Enums;
+using NodaTime;
+using NSubstitute;
+
+namespace Humans.Application.Tests.Services.Tickets;
+
+public class OnsiteRosterServiceTests
+{
+    private readonly IUserService _users = Substitute.For<IUserService>();
+    private readonly IShiftManagementService _shifts = Substitute.For<IShiftManagementService>();
+    private readonly ICampService _camps = Substitute.For<ICampService>();
+    private readonly ITeamService _teams = Substitute.For<ITeamService>();
+    private readonly IRoleAssignmentService _roles = Substitute.For<IRoleAssignmentService>();
+
+    private OnsiteRosterService NewService() =>
+        new(_users, _shifts, _camps, _teams, _roles);
+
+    [HumansFact]
+    public async Task GetRosterAsync_YearZero_ReturnsEmpty()
+    {
+        var service = NewService();
+        var result = await service.GetRosterAsync(0, null, null, null, default);
+        result.Rows.Should().BeEmpty();
+        await _users.DidNotReceive().GetOnsiteUsersAsync(Arg.Any<int>(), Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task GetRosterAsync_EmptyOnsite_ReturnsEmpty()
+    {
+        _users.GetOnsiteUsersAsync(2026, Arg.Any<CancellationToken>())
+            .Returns(new List<OnsiteUserRow>());
+
+        var service = NewService();
+        var result = await service.GetRosterAsync(2026, null, null, null, default);
+
+        result.Rows.Should().BeEmpty();
+        await _camps.DidNotReceive().GetCampsForYearAsync(Arg.Any<int>(), Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
+    public async Task GetRosterAsync_NoFilters_ReturnsAllOnsite_WithJoinedNames()
+    {
+        var aliceId = Guid.NewGuid();
+        var bobId = Guid.NewGuid();
+        var ts = Instant.FromUtc(2026, 7, 8, 12, 0);
+
+        _users.GetOnsiteUsersAsync(2026, Arg.Any<CancellationToken>())
+            .Returns(new List<OnsiteUserRow>
+            {
+                new(aliceId, "Alice", ts),
+                new(bobId, "Bob", ts),
+            });
+
+        _camps.GetCampsForYearAsync(2026, Arg.Any<CancellationToken>())
+            .Returns(new List<CampInfo>());
+        _teams.GetTeamsAsync(Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<Guid, TeamInfo>());
+        _roles.GetActiveForUserAsync(aliceId, Arg.Any<CancellationToken>())
+            .Returns(new List<RoleAssignmentSnapshot> { new("Board", ValidTo: null) });
+        _roles.GetActiveForUserAsync(bobId, Arg.Any<CancellationToken>())
+            .Returns(new List<RoleAssignmentSnapshot>());
+
+        var service = NewService();
+        var result = await service.GetRosterAsync(2026, null, null, null, default);
+
+        result.Rows.Should().HaveCount(2);
+        result.Rows.Single(r => r.UserId == aliceId).RoleNames.Should().Contain("Board");
+        result.AvailableRoles.Should().Contain("Board");
+    }
+
+    [HumansFact]
+    public async Task GetRosterAsync_RoleFilter_NarrowsToHolders()
+    {
+        var aliceId = Guid.NewGuid();
+        var bobId = Guid.NewGuid();
+        var ts = Instant.FromUtc(2026, 7, 8, 12, 0);
+
+        _users.GetOnsiteUsersAsync(2026, Arg.Any<CancellationToken>())
+            .Returns(new List<OnsiteUserRow>
+            {
+                new(aliceId, "Alice", ts),
+                new(bobId, "Bob", ts),
+            });
+
+        _camps.GetCampsForYearAsync(2026, Arg.Any<CancellationToken>())
+            .Returns(new List<CampInfo>());
+        _teams.GetTeamsAsync(Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<Guid, TeamInfo>());
+        _roles.GetActiveForUserAsync(aliceId, Arg.Any<CancellationToken>())
+            .Returns(new List<RoleAssignmentSnapshot> { new("Board", ValidTo: null) });
+        _roles.GetActiveForUserAsync(bobId, Arg.Any<CancellationToken>())
+            .Returns(new List<RoleAssignmentSnapshot>());
+
+        var service = NewService();
+        var result = await service.GetRosterAsync(2026, null, null, "Board", default);
+
+        result.Rows.Should().ContainSingle();
+        result.Rows[0].UserId.Should().Be(aliceId);
+    }
+
+    [HumansFact]
+    public async Task GetRosterAsync_SkipsRowsWithNullCheckedInAt()
+    {
+        // OnsiteUserRow.CheckedInAt is null when the snapshot view of the cache
+        // happens to have an Attended row without a stored timestamp (legacy /
+        // pre-#736 rows). The service filters these out — they don't belong in
+        // a "currently onsite" view.
+        var nullId = Guid.NewGuid();
+        var liveId = Guid.NewGuid();
+        var ts = Instant.FromUtc(2026, 7, 8, 12, 0);
+
+        _users.GetOnsiteUsersAsync(2026, Arg.Any<CancellationToken>())
+            .Returns(new List<OnsiteUserRow>
+            {
+                new(nullId, "NoTimestamp", null),
+                new(liveId, "Live", ts),
+            });
+        _camps.GetCampsForYearAsync(2026, Arg.Any<CancellationToken>())
+            .Returns(new List<CampInfo>());
+        _teams.GetTeamsAsync(Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<Guid, TeamInfo>());
+        _roles.GetActiveForUserAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(new List<RoleAssignmentSnapshot>());
+
+        var service = NewService();
+        var result = await service.GetRosterAsync(2026, null, null, null, default);
+
+        result.Rows.Should().ContainSingle();
+        result.Rows[0].UserId.Should().Be(liveId);
+    }
+}

--- a/tests/Humans.Web.Tests/Controllers/TicketsOnsiteAdminControllerTests.cs
+++ b/tests/Humans.Web.Tests/Controllers/TicketsOnsiteAdminControllerTests.cs
@@ -1,0 +1,152 @@
+using AwesomeAssertions;
+using Humans.Application;
+using Humans.Application.Interfaces.Auth;
+using Humans.Application.Interfaces.Camps;
+using Humans.Application.Interfaces.Shifts;
+using Humans.Application.Interfaces.Teams;
+using Humans.Application.Interfaces.Users;
+using Humans.Domain.Entities;
+using Humans.Web.Controllers;
+using Humans.Web.Models.Tickets;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.Extensions.DependencyInjection;
+using NodaTime;
+using NSubstitute;
+
+namespace Humans.Web.Tests.Controllers;
+
+public class TicketsOnsiteAdminControllerTests
+{
+    private static TicketsOnsiteAdminController NewController(
+        IUserService users,
+        IShiftManagementService shifts,
+        ICampService camps,
+        ITeamService teams,
+        IRoleAssignmentService roles)
+    {
+        var ctrl = new TicketsOnsiteAdminController(users, shifts, camps, teams, roles);
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        var http = new DefaultHttpContext { RequestServices = services.BuildServiceProvider() };
+        ctrl.ControllerContext = new ControllerContext
+        {
+            HttpContext = http,
+            ActionDescriptor = new ControllerActionDescriptor { ActionName = "Index" },
+        };
+        ctrl.TempData = new TempDataDictionary(http, Substitute.For<ITempDataProvider>());
+        ctrl.Url = Substitute.For<IUrlHelper>();
+        return ctrl;
+    }
+
+    [HumansFact]
+    public async Task Index_NoActiveEvent_ReturnsEmptyRoster()
+    {
+        var users = Substitute.For<IUserService>();
+        var shifts = Substitute.For<IShiftManagementService>();
+        shifts.GetActiveAsync().Returns((EventSettings?)null);
+
+        var ctrl = NewController(users, shifts,
+            Substitute.For<ICampService>(),
+            Substitute.For<ITeamService>(),
+            Substitute.For<IRoleAssignmentService>());
+
+        var result = await ctrl.Index(camp: null, team: null, role: null, ct: default);
+
+        var vm = result.Should().BeOfType<ViewResult>().Subject
+            .Model.Should().BeOfType<OnsiteRosterViewModel>().Subject;
+        vm.Year.Should().Be(0);
+        vm.Rows.Should().BeEmpty();
+    }
+
+    [HumansFact]
+    public async Task Index_ReturnsOnsiteUsers_SortedMostRecentFirst()
+    {
+        var aliceId = Guid.NewGuid();
+        var bobId = Guid.NewGuid();
+        var earlier = Instant.FromUtc(2026, 7, 8, 10, 0);
+        var later = Instant.FromUtc(2026, 7, 8, 18, 0);
+
+        var users = Substitute.For<IUserService>();
+        users.GetOnsiteUsersAsync(2026, Arg.Any<CancellationToken>())
+            .Returns(new List<OnsiteUserRow>
+            {
+                new(aliceId, "Alice", earlier),
+                new(bobId, "Bob", later),
+            });
+
+        var shifts = Substitute.For<IShiftManagementService>();
+        shifts.GetActiveAsync().Returns(new EventSettings { Year = 2026 });
+
+        var camps = Substitute.For<ICampService>();
+        camps.GetCampsForYearAsync(2026, Arg.Any<CancellationToken>())
+            .Returns(new List<CampInfo>());
+
+        var teams = Substitute.For<ITeamService>();
+        teams.GetTeamsAsync(Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<Guid, TeamInfo>());
+
+        var roles = Substitute.For<IRoleAssignmentService>();
+        roles.GetActiveForUserAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(new List<RoleAssignmentSnapshot>());
+
+        var ctrl = NewController(users, shifts, camps, teams, roles);
+
+        var result = await ctrl.Index(camp: null, team: null, role: null, ct: default);
+
+        var vm = result.Should().BeOfType<ViewResult>().Subject
+            .Model.Should().BeOfType<OnsiteRosterViewModel>().Subject;
+        vm.Year.Should().Be(2026);
+        vm.Rows.Should().HaveCount(2);
+        // Sorted by CheckedInAt descending.
+        vm.Rows[0].UserId.Should().Be(bobId);
+        vm.Rows[1].UserId.Should().Be(aliceId);
+    }
+
+    [HumansFact]
+    public async Task Index_RoleFilter_NarrowsToRoleHolders()
+    {
+        var aliceId = Guid.NewGuid();
+        var bobId = Guid.NewGuid();
+        var ts = Instant.FromUtc(2026, 7, 8, 12, 0);
+
+        var users = Substitute.For<IUserService>();
+        users.GetOnsiteUsersAsync(2026, Arg.Any<CancellationToken>())
+            .Returns(new List<OnsiteUserRow>
+            {
+                new(aliceId, "Alice", ts),
+                new(bobId, "Bob", ts),
+            });
+
+        var shifts = Substitute.For<IShiftManagementService>();
+        shifts.GetActiveAsync().Returns(new EventSettings { Year = 2026 });
+
+        var camps = Substitute.For<ICampService>();
+        camps.GetCampsForYearAsync(2026, Arg.Any<CancellationToken>())
+            .Returns(new List<CampInfo>());
+
+        var teams = Substitute.For<ITeamService>();
+        teams.GetTeamsAsync(Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<Guid, TeamInfo>());
+
+        var roles = Substitute.For<IRoleAssignmentService>();
+        roles.GetActiveForUserAsync(aliceId, Arg.Any<CancellationToken>())
+            .Returns(new List<RoleAssignmentSnapshot> { new("Board", ValidTo: null) });
+        roles.GetActiveForUserAsync(bobId, Arg.Any<CancellationToken>())
+            .Returns(new List<RoleAssignmentSnapshot>()); // none
+
+        var ctrl = NewController(users, shifts, camps, teams, roles);
+
+        var result = await ctrl.Index(camp: null, team: null, role: "Board", ct: default);
+
+        var vm = result.Should().BeOfType<ViewResult>().Subject
+            .Model.Should().BeOfType<OnsiteRosterViewModel>().Subject;
+        vm.Rows.Should().ContainSingle();
+        vm.Rows[0].UserId.Should().Be(aliceId);
+        vm.Rows[0].RoleNames.Should().Contain("Board");
+        vm.AvailableRoles.Should().Contain("Board");
+    }
+}

--- a/tests/Humans.Web.Tests/Controllers/TicketsOnsiteAdminControllerTests.cs
+++ b/tests/Humans.Web.Tests/Controllers/TicketsOnsiteAdminControllerTests.cs
@@ -1,9 +1,6 @@
 using AwesomeAssertions;
-using Humans.Application;
-using Humans.Application.Interfaces.Auth;
-using Humans.Application.Interfaces.Camps;
 using Humans.Application.Interfaces.Shifts;
-using Humans.Application.Interfaces.Teams;
+using Humans.Application.Interfaces.Tickets;
 using Humans.Application.Interfaces.Users;
 using Humans.Domain.Entities;
 using Humans.Web.Controllers;
@@ -23,11 +20,9 @@ public class TicketsOnsiteAdminControllerTests
     private static TicketsOnsiteAdminController NewController(
         IUserService users,
         IShiftManagementService shifts,
-        ICampService camps,
-        ITeamService teams,
-        IRoleAssignmentService roles)
+        IOnsiteRosterService roster)
     {
-        var ctrl = new TicketsOnsiteAdminController(users, shifts, camps, teams, roles);
+        var ctrl = new TicketsOnsiteAdminController(users, shifts, roster);
 
         var services = new ServiceCollection();
         services.AddLogging();
@@ -43,16 +38,17 @@ public class TicketsOnsiteAdminControllerTests
     }
 
     [HumansFact]
-    public async Task Index_NoActiveEvent_ReturnsEmptyRoster()
+    public async Task Index_NoActiveEvent_DispatchesYearZero_AndReturnsEmpty()
     {
         var users = Substitute.For<IUserService>();
         var shifts = Substitute.For<IShiftManagementService>();
         shifts.GetActiveAsync().Returns((EventSettings?)null);
 
-        var ctrl = NewController(users, shifts,
-            Substitute.For<ICampService>(),
-            Substitute.For<ITeamService>(),
-            Substitute.For<IRoleAssignmentService>());
+        var roster = Substitute.For<IOnsiteRosterService>();
+        roster.GetRosterAsync(0, null, null, null, Arg.Any<CancellationToken>())
+            .Returns(new OnsiteRosterResult([], [], [], []));
+
+        var ctrl = NewController(users, shifts, roster);
 
         var result = await ctrl.Index(camp: null, team: null, role: null, ct: default);
 
@@ -60,10 +56,12 @@ public class TicketsOnsiteAdminControllerTests
             .Model.Should().BeOfType<OnsiteRosterViewModel>().Subject;
         vm.Year.Should().Be(0);
         vm.Rows.Should().BeEmpty();
+
+        await roster.Received(1).GetRosterAsync(0, null, null, null, Arg.Any<CancellationToken>());
     }
 
     [HumansFact]
-    public async Task Index_ReturnsOnsiteUsers_SortedMostRecentFirst()
+    public async Task Index_SortsRowsByCheckedInAt_Descending()
     {
         var aliceId = Guid.NewGuid();
         var bobId = Guid.NewGuid();
@@ -71,82 +69,48 @@ public class TicketsOnsiteAdminControllerTests
         var later = Instant.FromUtc(2026, 7, 8, 18, 0);
 
         var users = Substitute.For<IUserService>();
-        users.GetOnsiteUsersAsync(2026, Arg.Any<CancellationToken>())
-            .Returns(new List<OnsiteUserRow>
-            {
-                new(aliceId, "Alice", earlier),
-                new(bobId, "Bob", later),
-            });
-
         var shifts = Substitute.For<IShiftManagementService>();
         shifts.GetActiveAsync().Returns(new EventSettings { Year = 2026 });
 
-        var camps = Substitute.For<ICampService>();
-        camps.GetCampsForYearAsync(2026, Arg.Any<CancellationToken>())
-            .Returns(new List<CampInfo>());
+        var roster = Substitute.For<IOnsiteRosterService>();
+        roster.GetRosterAsync(2026, null, null, null, Arg.Any<CancellationToken>())
+            .Returns(new OnsiteRosterResult(
+                Rows: new List<OnsiteRosterRow>
+                {
+                    new(aliceId, "Alice", earlier, [], [], []),
+                    new(bobId, "Bob", later, [], [], []),
+                },
+                AvailableCamps: [],
+                AvailableTeams: [],
+                AvailableRoles: []));
 
-        var teams = Substitute.For<ITeamService>();
-        teams.GetTeamsAsync(Arg.Any<CancellationToken>())
-            .Returns(new Dictionary<Guid, TeamInfo>());
-
-        var roles = Substitute.For<IRoleAssignmentService>();
-        roles.GetActiveForUserAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
-            .Returns(new List<RoleAssignmentSnapshot>());
-
-        var ctrl = NewController(users, shifts, camps, teams, roles);
+        var ctrl = NewController(users, shifts, roster);
 
         var result = await ctrl.Index(camp: null, team: null, role: null, ct: default);
 
         var vm = result.Should().BeOfType<ViewResult>().Subject
             .Model.Should().BeOfType<OnsiteRosterViewModel>().Subject;
-        vm.Year.Should().Be(2026);
         vm.Rows.Should().HaveCount(2);
-        // Sorted by CheckedInAt descending.
         vm.Rows[0].UserId.Should().Be(bobId);
         vm.Rows[1].UserId.Should().Be(aliceId);
     }
 
     [HumansFact]
-    public async Task Index_RoleFilter_NarrowsToRoleHolders()
+    public async Task Index_ForwardsFilterParamsToService()
     {
-        var aliceId = Guid.NewGuid();
-        var bobId = Guid.NewGuid();
-        var ts = Instant.FromUtc(2026, 7, 8, 12, 0);
-
         var users = Substitute.For<IUserService>();
-        users.GetOnsiteUsersAsync(2026, Arg.Any<CancellationToken>())
-            .Returns(new List<OnsiteUserRow>
-            {
-                new(aliceId, "Alice", ts),
-                new(bobId, "Bob", ts),
-            });
-
         var shifts = Substitute.For<IShiftManagementService>();
         shifts.GetActiveAsync().Returns(new EventSettings { Year = 2026 });
 
-        var camps = Substitute.For<ICampService>();
-        camps.GetCampsForYearAsync(2026, Arg.Any<CancellationToken>())
-            .Returns(new List<CampInfo>());
+        var roster = Substitute.For<IOnsiteRosterService>();
+        roster.GetRosterAsync(2026, "Cosmic Camp", "Gate", "Board", Arg.Any<CancellationToken>())
+            .Returns(new OnsiteRosterResult([], [], [], []));
 
-        var teams = Substitute.For<ITeamService>();
-        teams.GetTeamsAsync(Arg.Any<CancellationToken>())
-            .Returns(new Dictionary<Guid, TeamInfo>());
+        var ctrl = NewController(users, shifts, roster);
 
-        var roles = Substitute.For<IRoleAssignmentService>();
-        roles.GetActiveForUserAsync(aliceId, Arg.Any<CancellationToken>())
-            .Returns(new List<RoleAssignmentSnapshot> { new("Board", ValidTo: null) });
-        roles.GetActiveForUserAsync(bobId, Arg.Any<CancellationToken>())
-            .Returns(new List<RoleAssignmentSnapshot>()); // none
+        await ctrl.Index(camp: "Cosmic Camp", team: "Gate", role: "Board", ct: default);
 
-        var ctrl = NewController(users, shifts, camps, teams, roles);
-
-        var result = await ctrl.Index(camp: null, team: null, role: "Board", ct: default);
-
-        var vm = result.Should().BeOfType<ViewResult>().Subject
-            .Model.Should().BeOfType<OnsiteRosterViewModel>().Subject;
-        vm.Rows.Should().ContainSingle();
-        vm.Rows[0].UserId.Should().Be(aliceId);
-        vm.Rows[0].RoleNames.Should().Contain("Board");
-        vm.AvailableRoles.Should().Contain("Board");
+        await roster.Received(1).GetRosterAsync(
+            2026, "Cosmic Camp", "Gate", "Board", Arg.Any<CancellationToken>());
     }
 }


### PR DESCRIPTION
## Summary

Adds real-time check-in propagation from TicketTailor sync into a queryable surface on the human's record, plus an admin roster view and a profile chip.

- **Domain**: New `EventParticipation.CheckedInAt : Instant?`. Set on first transition into `Attended` via `TicketSync`; never overwritten once non-null (matches the existing "Attended is permanent" invariant). EF migration `Add_EventParticipation_CheckedInAt`, generated, not hand-edited.
- **Vendor**: `TicketTailorService` parses the nested `check_in.checked_in_at` (epoch seconds) into a new `VendorTicketDto.CheckedInAt`. `StubTicketVendorService` populates plausible gate-arrival times for checked-in tickets so dev/preview exercises the view.
- **Sync derivation**: `TicketSyncService.SyncEventParticipationsAsync` builds a per-user `min(CheckedInAt)` from the vendor batch and threads it through `IUserService.SetParticipationFromTicketSyncAsync(userId, year, Attended, checkedInAt, ct)`. When the vendor returns no timestamp, the call passes `null` — repo's "never overwrite non-null" rule preserves earlier values. No new job: piggybacks on the existing 15-min `TicketSyncJob`.
- **Read surface**: New `IUserService.GetOnsiteUsersAsync(year)` projects Attended+CheckedInAt rows from the cached `UserInfo` snapshot. The inner `UserService` throws — cache-only by design. New helper `UserInfo.OnsiteSinceForYear(year)` drives the chip.
- **Admin view `/Tickets/Admin/Onsite`** (policy `TicketAdminBoardOrAdmin`): flat sortable roster, filterable by camp / team / governance-role. Route under `/Tickets/Admin/*` because top-level `/Admin/*` is frozen by `memory/architecture/no-admin-url-section.md`. Camp/team/role name stitching + filter logic lives in a new `OnsiteRosterService` (Tickets section) so the controller stays a thin HTTP adapter.
- **Profile chip** "Onsite since {time}": visible to self always, plus the same `TicketAdminBoardOrAdmin` policy as the admin view. Coordinator-only visibility on other humans is a follow-up if needed.

## Policy choices (called out per spec ask)

- `/Tickets/Admin/Onsite` is gated by `TicketAdminBoardOrAdmin` (broadest existing Tickets-section read policy; matches `/Tickets/GateList` etc.).
- Profile chip uses the same `TicketAdminBoardOrAdmin` gate plus self-always. No new policy invented.

## Acceptance criteria — file:line evidence

- [x] `CheckedInAt` on the human's record, populated from TicketTailor sync — `src/Humans.Domain/Entities/EventParticipation.cs` (CheckedInAt prop), `src/Humans.Infrastructure/Services/TicketTailorService.cs:147-150` (parse epoch), `src/Humans.Application/Services/Tickets/TicketSyncService.cs:466-487` (derive min + write), `src/Humans.Infrastructure/Repositories/Users/UserRepository.cs:642-650` (persist + never-overwrite).
- [x] `/Tickets/Admin/Onsite` lists currently-onsite people with check-in time — `src/Humans.Web/Controllers/TicketsOnsiteAdminController.cs:20` (route), view at `src/Humans.Web/Views/Tickets/Admin/Onsite.cshtml`.
- [x] Filterable by camp, team, role — `src/Humans.Application/Services/Tickets/OnsiteRosterService.cs:70-78` (filter logic), view filter selects.
- [x] Profile page surfaces onsite status — `src/Humans.Web/Views/Profile/Index.cshtml:22-28` (chip), `src/Humans.Web/Controllers/ProfileController.cs` (`Me` + `ViewProfile` VM build).
- [x] Near-real-time — driven by the existing sync cadence (no new job); `TicketSyncService.SyncEventParticipationsAsync` is the writer.

## Test plan

- [x] `TicketSyncServiceTests` — 4 new tests covering single check-in, min-across-multiple, null-fallback when vendor omits timestamp, Ticketed-only path.
- [x] `UserRepositoryTests` — 3 new tests: create with CheckedInAt; never-overwrite-non-null; Ticketed→Attended upgrade fills CheckedInAt.
- [x] `OnsiteRosterServiceTests` — year zero / empty onsite / no filters / role filter / null-CheckedInAt skip.
- [x] `TicketsOnsiteAdminControllerTests` — empty-active-event dispatches year zero, sort order, filter forwarding.
- [x] `dotnet build Humans.slnx -v quiet` — green.
- [x] `dotnet test` on Application + Web + Domain + Analyzers — green (integration test suite has 53 pre-existing Hangfire-init failures on `origin/main`, unrelated).

Closes nobodies-collective/Humans#736.

🤖 Generated with [Claude Code](https://claude.com/claude-code)