### PR TITLE
feat(camps): roster polish + Google sync 403 auto-provision + admin summary totals

### DIFF
--- a/src/Humans.Application/Interfaces/Camps/ICampRoleService.cs
+++ b/src/Humans.Application/Interfaces/Camps/ICampRoleService.cs
@@ -15,6 +15,12 @@ public interface ICampRoleService : IApplicationService
     Task<CampRoleDefinitionInfo?> GetDefinitionBySlugAsync(string slug, CancellationToken ct = default);
 
     /// <summary>
+    /// Builds the deterministic Google Group key for a (role-definition slug, season year) pair:
+    /// <c>barrios-{year}-{slug}@{domain}</c>. Caller is responsible for guarding empty slugs.
+    /// </summary>
+    string BuildGroupKey(int year, string slug);
+
+    /// <summary>
     /// Builds the cross-camp roster for one role definition in a given year. One row per
     /// camp-season participating in <paramref name="year"/>, with assignees (name + Google email)
     /// or an empty state. Read-only; caller authorizes.

--- a/src/Humans.Application/Interfaces/Camps/ICampService.cs
+++ b/src/Humans.Application/Interfaces/Camps/ICampService.cs
@@ -339,7 +339,8 @@ public sealed record CampSeasonInfo(
     SpaceSize? SpaceRequirement,
     ElectricalGrid? ElectricalGrid,
     int EeSlotCount,
-    int? EeGrantedCount);
+    int? EeGrantedCount,
+    int? JoinedMemberCount);
 
 // CampLookup / CampInfo.Leads is populated only from camp loads that apply the
 // filtered Include `.Include(c => c.Leads.Where(l => l.LeftAt == null))`, so

--- a/src/Humans.Application/Services/Camps/CampService.cs
+++ b/src/Humans.Application/Services/Camps/CampService.cs
@@ -483,6 +483,9 @@ public sealed class CampService : ICampService, IUserDataContributor, IUserMerge
             season.EeSlotCount,
             includeEarlyEntryGrantCount
                 ? season.Members.Count(m => m.Status == CampMemberStatus.Active && m.HasEarlyEntry)
+                : null,
+            includeEarlyEntryGrantCount
+                ? season.Members.Count(m => m.Status == CampMemberStatus.Active)
                 : null);
     }
 

--- a/src/Humans.Application/Services/GoogleIntegration/GoogleGroupSyncService.cs
+++ b/src/Humans.Application/Services/GoogleIntegration/GoogleGroupSyncService.cs
@@ -190,9 +190,11 @@ public sealed class GoogleGroupSyncService : IGoogleGroupSync
         var lookup = await _provisioningClient.LookupGroupIdAsync(claim.GroupKey, ct);
 
         // Provisioning: a claim references a group key that doesn't exist in Google.
-        // Cloud Identity returns HTTP 404 (or sometimes 403) when the group is
-        // not found. Best-effort create-then-retry-lookup; on failure we fall
-        // through to the existing error path.
+        // Cloud Identity returns HTTP 404 — or HTTP 403 with a "permission
+        // denied" body, because Google won't confirm/deny existence to a
+        // caller without access. See IsGroupNotFound. Best-effort
+        // create-then-retry-lookup; on failure we fall through to the existing
+        // error path.
         if (lookup.GroupNumericId is null
             && IsGroupNotFound(lookup.Error)
             && action == SyncAction.Execute)
@@ -682,12 +684,17 @@ public sealed class GoogleGroupSyncService : IGoogleGroupSync
         $"{prefix} (HTTP {error?.StatusCode ?? 0}): {error?.RawMessage}";
 
     /// <summary>
-    /// Cloud Identity returns HTTP 404 when a Group lookup misses. Other
-    /// status codes (403 caller permission, 5xx backend, etc.) are real
-    /// failures and must not trigger auto-provisioning.
+    /// Cloud Identity returns HTTP 404 when a Group lookup misses — and, in
+    /// practice, sometimes HTTP 403 with a "Permission denied" / "caller does
+    /// not have permission" message, because Google declines to confirm or
+    /// deny the existence of a group the caller can't see. Both are treated as
+    /// "group not found" so we attempt auto-provision. If the 403 actually
+    /// reflects a real caller-permission problem, the subsequent CreateGroup
+    /// call will fail the same way and we fall through to the normal error
+    /// path. 5xx and other status codes remain real failures.
     /// </summary>
     private static bool IsGroupNotFound(GoogleClientError? error)
-        => error is { StatusCode: 404 };
+        => error is { StatusCode: 404 } || error is { StatusCode: 403 };
 
     private sealed record GroupClaim(string GroupKey, int ClaimCount, string[] SourceNames, Guid[] UserIds)
     {

--- a/src/Humans.Infrastructure/Services/Camps/CachingCampService.cs
+++ b/src/Humans.Infrastructure/Services/Camps/CachingCampService.cs
@@ -687,6 +687,9 @@ public sealed class CachingCampService :
         season.EeSlotCount,
         season.Members is { Count: > 0 }
             ? season.Members.Count(m => m.Status == CampMemberStatus.Active && m.HasEarlyEntry)
+            : 0,
+        season.Members is { Count: > 0 }
+            ? season.Members.Count(m => m.Status == CampMemberStatus.Active)
             : 0);
 
     private static CampInfo FilterToYear(CampInfo camp, int year) =>

--- a/src/Humans.Web/Controllers/CampAdminController.cs
+++ b/src/Humans.Web/Controllers/CampAdminController.cs
@@ -327,13 +327,20 @@ public class CampAdminController : HumansControllerBase
     public async Task<IActionResult> Roles(CancellationToken ct)
     {
         var defs = await _campRoleService.ListDefinitionsAsync(includeDeactivated: true, ct);
+        var settings = await _campService.GetSettingsAsync(ct);
+        var year = settings.PublicYear;
+        CampRoleDefinitionListRowViewModel MapRow(CampRoleDefinitionInfo d) =>
+            new(d.Id, d.Name, d.Slug, d.Description, d.SlotCount, d.MinimumRequired, d.SortOrder, d.IsActive,
+                string.IsNullOrWhiteSpace(d.Slug) ? null : _campRoleService.BuildGroupKey(year, d.Slug));
         var active = defs.Where(d => d.IsActive).Select(MapRow).ToList();
         var deactivated = defs.Where(d => !d.IsActive).Select(MapRow).ToList();
-        return View(new CampRoleDefinitionListViewModel { Active = active, Deactivated = deactivated });
+        return View(new CampRoleDefinitionListViewModel
+        {
+            Active = active,
+            Deactivated = deactivated,
+            PublicYear = year,
+        });
     }
-
-    private static CampRoleDefinitionListRowViewModel MapRow(CampRoleDefinitionInfo d) =>
-        new(d.Id, d.Name, d.Slug, d.Description, d.SlotCount, d.MinimumRequired, d.SortOrder, d.IsActive);
 
     [HttpGet("Roles/{slug}")]
     public async Task<IActionResult> RolesDrillDown(string slug, int? year, CancellationToken ct)
@@ -377,8 +384,7 @@ public class CampAdminController : HumansControllerBase
                     r.CampId, r.CampName, r.CampSlug, r.CampSeasonId,
                     r.Assignees
                         .OrderBy(a => a.AssignedAt)
-                        .Select(a => new CampRoleDrillDownAssigneeViewModel(
-                            a.UserId, a.GoogleEmail))
+                        .Select(a => new CampRoleDrillDownAssigneeViewModel(a.UserId))
                         .ToList()))
                 .ToList(),
         };

--- a/src/Humans.Web/Models/CampAdmin/CampAdminPageBuilder.cs
+++ b/src/Humans.Web/Models/CampAdmin/CampAdminPageBuilder.cs
@@ -102,6 +102,7 @@ public sealed class CampAdminPageBuilder
                 YearsParticipating = c.TimesAtNowhere,
                 EeSlotCount = season?.EeSlotCount ?? 0,
                 EeGrantedCount = season?.EeGrantedCount ?? 0,
+                JoinedMemberCount = season?.JoinedMemberCount ?? 0,
                 Leads = c.Leads
                     .Select(l => new CampLeadViewModel
                     {

--- a/src/Humans.Web/Models/CampAdmin/CampRoleDefinitionListViewModel.cs
+++ b/src/Humans.Web/Models/CampAdmin/CampRoleDefinitionListViewModel.cs
@@ -4,8 +4,9 @@ public sealed class CampRoleDefinitionListViewModel
 {
     public required IReadOnlyList<CampRoleDefinitionListRowViewModel> Active { get; init; }
     public required IReadOnlyList<CampRoleDefinitionListRowViewModel> Deactivated { get; init; }
+    public required int PublicYear { get; init; }
 }
 
 public sealed record CampRoleDefinitionListRowViewModel(
     Guid Id, string Name, string Slug, string? Description, int SlotCount, int MinimumRequired,
-    int SortOrder, bool IsActive);
+    int SortOrder, bool IsActive, string? GroupEmail);

--- a/src/Humans.Web/Models/CampAdmin/CampRoleDrillDownViewModel.cs
+++ b/src/Humans.Web/Models/CampAdmin/CampRoleDrillDownViewModel.cs
@@ -27,5 +27,4 @@ public sealed record CampRoleDrillDownCampRowViewModel(
     IReadOnlyList<CampRoleDrillDownAssigneeViewModel> Assignees);
 
 public sealed record CampRoleDrillDownAssigneeViewModel(
-    Guid UserId,
-    string? GoogleEmail);
+    Guid UserId);

--- a/src/Humans.Web/Models/CampViewModels.cs
+++ b/src/Humans.Web/Models/CampViewModels.cs
@@ -231,4 +231,6 @@ public class CampSummaryRowViewModel
     public int EeSlotCount { get; set; }
     /// <summary>Count of Active members with HasEarlyEntry=true for this season.</summary>
     public int EeGrantedCount { get; set; }
+    /// <summary>Count of Active <see cref="Humans.Domain.Entities.CampMember"/> rows for this season (humans who joined in-app).</summary>
+    public int JoinedMemberCount { get; set; }
 }

--- a/src/Humans.Web/Views/CampAdmin/Index.cshtml
+++ b/src/Humans.Web/Views/CampAdmin/Index.cshtml
@@ -307,6 +307,17 @@
             var totalGranted = Model.AllCampSummaries.Sum(c => c.EeGrantedCount);
         }
         <p class="mb-2">
+            EE start date:
+            @if (Model.EeStartDate.HasValue)
+            {
+                <strong>@Model.EeStartDate.Value.ToDisplayDate()</strong>
+            }
+            else
+            {
+                <span class="text-muted">not set</span>
+            }
+        </p>
+        <p class="mb-2">
             <strong>@totalGranted granted</strong> across <strong>@totalSlots configured slots</strong>
             @if (totalGranted > totalSlots)
             {
@@ -315,7 +326,7 @@
         </p>
         <form method="post" asp-controller="CampAdmin" asp-action="SetEeStartDate" class="d-flex align-items-center gap-2">
             @Html.AntiForgeryToken()
-            <label class="form-label mb-0">EE start date:</label>
+            <label class="form-label mb-0">Set EE start date:</label>
             <input type="date" name="eeStartDate" class="form-control form-control-sm" style="max-width:180px;"
                    value="@(Model.EeStartDate?.ToString("yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture))" />
             <button type="submit" class="btn btn-sm btn-primary text-nowrap">Save</button>
@@ -336,7 +347,8 @@
                     <tr>
                         <th>Camp Name</th>
                         <th>Accepting</th>
-                        <th class="text-end">Humans</th>
+                        <th class="text-end" title="Headcount the camp declared on its season">Humans</th>
+                        <th class="text-end" title="Active CampMember rows — humans who joined in-app">Joined</th>
                         <th>Zone</th>
                         <th>Space</th>
                         <th class="text-end">Years</th>
@@ -353,6 +365,7 @@
                             </td>
                             <td>@camp.AcceptingMembers</td>
                             <td class="text-end">@camp.MemberCount</td>
+                            <td class="text-end">@camp.JoinedMemberCount</td>
                             <td>@camp.Zone</td>
                             <td>@camp.SpaceRequirement</td>
                             <td class="text-end">@camp.YearsParticipating</td>
@@ -391,6 +404,25 @@
                         </tr>
                     }
                 </tbody>
+                @{
+                    var totalHumans = Model.AllCampSummaries.Sum(c => c.MemberCount);
+                    var totalJoined = Model.AllCampSummaries.Sum(c => c.JoinedMemberCount);
+                    var totalEeSlotsRow = Model.AllCampSummaries.Sum(c => c.EeSlotCount);
+                    var totalEeGrantedRow = Model.AllCampSummaries.Sum(c => c.EeGrantedCount);
+                }
+                <tfoot>
+                    <tr class="table-light fw-semibold">
+                        <td>Totals</td>
+                        <td></td>
+                        <td class="text-end">@totalHumans</td>
+                        <td class="text-end">@totalJoined</td>
+                        <td></td>
+                        <td></td>
+                        <td></td>
+                        <td>@totalEeGrantedRow / @totalEeSlotsRow</td>
+                        <td></td>
+                    </tr>
+                </tfoot>
             </table>
         </div>
     </div>

--- a/src/Humans.Web/Views/CampAdmin/RoleDrillDown.cshtml
+++ b/src/Humans.Web/Views/CampAdmin/RoleDrillDown.cshtml
@@ -2,12 +2,6 @@
 @model CampRoleDrillDownViewModel
 @{
     ViewData["Title"] = $"{Model.RoleName} — {Model.Year}";
-    var allAssigneeEmails = Model.Camps
-        .SelectMany(c => c.Assignees)
-        .Where(a => !string.IsNullOrWhiteSpace(a.GoogleEmail))
-        .Select(a => a.GoogleEmail!)
-        .Distinct(StringComparer.OrdinalIgnoreCase)
-        .ToList();
 }
 
 <nav aria-label="breadcrumb">
@@ -64,20 +58,9 @@
                     <span class="small text-muted me-2">Group email:</span>
                     <code>@Model.GroupEmail</code>
                 </div>
-                @if (allAssigneeEmails.Count > 0)
-                {
-                    var mailto = "mailto:" + Model.GroupEmail
-                        + "?bcc=" + string.Join(",", allAssigneeEmails);
-                    <a href="@mailto" class="btn btn-outline-primary btn-sm">
-                        <i class="fa-regular fa-envelope me-1"></i>Email assignees (@allAssigneeEmails.Count)
-                    </a>
-                }
-                else
-                {
-                    <a href="@("mailto:" + Model.GroupEmail)" class="btn btn-outline-secondary btn-sm">
-                        <i class="fa-regular fa-envelope me-1"></i>Email group
-                    </a>
-                }
+                <a href="@("mailto:" + Model.GroupEmail)" class="btn btn-outline-primary btn-sm">
+                    <i class="fa-regular fa-envelope me-1"></i>Email group
+                </a>
             </div>
         }
     </div>
@@ -124,18 +107,12 @@
                                 }
                                 else
                                 {
-                                    <ul class="list-unstyled mb-0">
+                                    <div class="d-flex flex-wrap gap-3 align-items-center">
                                         @foreach (var a in row.Assignees)
                                         {
-                                            <li class="mb-2">
-                                                <vc:human user-id="@a.UserId" layout="AvatarName" size="60" />
-                                                @if (!string.IsNullOrWhiteSpace(a.GoogleEmail))
-                                                {
-                                                    <span class="text-muted small ms-1">&lt;@a.GoogleEmail&gt;</span>
-                                                }
-                                            </li>
+                                            <vc:human user-id="@a.UserId" layout="AvatarName" size="40" />
                                         }
-                                    </ul>
+                                    </div>
                                 }
                             </td>
                         </tr>

--- a/src/Humans.Web/Views/CampAdmin/Roles.cshtml
+++ b/src/Humans.Web/Views/CampAdmin/Roles.cshtml
@@ -54,8 +54,10 @@
                             <td>@row.SortOrder</td>
                             <td>
                                 <a asp-controller="CampAdmin" asp-action="RolesDrillDown" asp-route-slug="@(string.IsNullOrWhiteSpace(row.Slug) ? row.Id.ToString() : row.Slug)"><strong>@row.Name</strong></a>
-                                <br />
-                                <small class="text-muted"><code>@row.Slug</code></small>
+                                @if (!string.IsNullOrWhiteSpace(row.GroupEmail))
+                                {
+                                    <small class="text-muted ms-2"><code>@row.GroupEmail</code></small>
+                                }
                                 @if (!string.IsNullOrWhiteSpace(row.Description))
                                 {
                                     <br />

--- a/tests/Humans.Application.Tests/Infrastructure/GoogleIntegration/GoogleGroupSyncServiceTests.cs
+++ b/tests/Humans.Application.Tests/Infrastructure/GoogleIntegration/GoogleGroupSyncServiceTests.cs
@@ -505,6 +505,42 @@ public sealed class GoogleGroupSyncServiceTests
     }
 
     [HumansFact]
+    public async Task ReconcileOneAsync_GroupLookup403_AutoProvisionsAndReconciles()
+    {
+        // Cloud Identity sometimes returns HTTP 403 (instead of 404) when the
+        // target group does not exist, because Google won't confirm/deny the
+        // existence of a group the caller can't see. The orchestrator must
+        // treat that as "not found" and attempt auto-provision.
+        var userId = Guid.NewGuid();
+        var service = CreateService(new StaticSource("new-group@nobodies.team", userId));
+        StubUsers((userId, "Alice", "alice@nobodies.team"));
+
+        _provisioningClient.LookupGroupIdAsync("new-group@nobodies.team", Arg.Any<CancellationToken>())
+            .Returns(
+                new GroupLookupIdResult(null, new GoogleClientError(403, "permission denied")),
+                new GroupLookupIdResult("group-new", null));
+        _provisioningClient.CreateGroupAsync(
+                "new-group@nobodies.team",
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new GroupCreateResult("group-new", null));
+        _membershipClient.ListMembershipsAsync("group-new", Arg.Any<CancellationToken>())
+            .Returns(new GroupMembershipListResult([], null));
+        _membershipClient.CreateMembershipAsync("group-new", "alice@nobodies.team", Arg.Any<CancellationToken>())
+            .Returns(new GroupMembershipMutationResult(GroupMembershipMutationOutcome.Added, null));
+
+        var diff = await service.ReconcileOneAsync("new-group@nobodies.team", SyncAction.Execute);
+
+        diff.ErrorMessage.Should().BeNull();
+        await _provisioningClient.Received(1).CreateGroupAsync(
+            "new-group@nobodies.team",
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [HumansFact]
     public async Task ReconcileOneAsync_GroupNotFoundButCreateFails_RecordsErrorAndSchedulesRetry()
     {
         // When auto-provisioning fails (e.g. backend 503), the reconcile path

--- a/tests/Humans.Application.Tests/Infrastructure/GoogleIntegration/GoogleGroupSyncServiceTests.cs
+++ b/tests/Humans.Application.Tests/Infrastructure/GoogleIntegration/GoogleGroupSyncServiceTests.cs
@@ -538,6 +538,10 @@ public sealed class GoogleGroupSyncServiceTests
             Arg.Any<string>(),
             Arg.Any<string>(),
             Arg.Any<CancellationToken>());
+        await _provisioningClient.Received(2).LookupGroupIdAsync(
+            "new-group@nobodies.team", Arg.Any<CancellationToken>());
+        await _membershipClient.Received(1).CreateMembershipAsync(
+            "group-new", "alice@nobodies.team", Arg.Any<CancellationToken>());
     }
 
     [HumansFact]


### PR DESCRIPTION
## Summary

- **/Barrios/Admin/Roles** — show full Google Group email (`barrios-{year}-{slug}@{domain}`) beside each role name; drop pink slug badge.
- **/Barrios/Admin/Roles/{slug}** — drop BCC from "Email assignees" mailto (was leaking addresses), collapse to single "Email group" button. Roster renders horizontally per camp via `<vc:human>`, no email column.
- **Google Group sync** — treat HTTP 403 on group lookup as not-found so auto-provision fires. Cloud Identity returns 403 instead of 404 when the caller can't see a non-existent group; the fall-through CreateGroup will fail the same way if it's a real permission problem, so this is safe.
- **/Barrios/Admin** — surface EE start date prominently (was only in the form input). Add **Joined** column (active `CampMember` count) next to declared **Humans** headcount. Totals row sums humans, joined, EE granted/slots.

## Test plan
- [ ] /Barrios/Admin/Roles — each row shows the full group email; deactivated rows still render
- [ ] /Barrios/Admin/Roles/{slug} — Email-group button has no `bcc=`; roster wraps horizontally with avatars only, no email addresses
- [ ] Add a new role slug, run /Google/Sync — verify the group is auto-created instead of 403 hard-failing
- [ ] /Barrios/Admin — set EE start date, reload, see it shown above the form; verify totals row matches per-camp values

🤖 Generated with [Claude Code](https://claude.com/claude-code)