### PR TITLE
Admin: UserInfo derived-emails diagnostic card on /Profile/{id}/Admin/Emails

### DIFF
--- a/src/Humans.Web/Controllers/ProfileController.cs
+++ b/src/Humans.Web/Controllers/ProfileController.cs
@@ -2538,6 +2538,11 @@ public class ProfileController : HumansControllerBase
                 && User.IsInRole(Domain.Constants.RoleNames.Admin)
                 ? user.IdentityEmailColumn
                 : null,
+            UserInfoEmails = isAdminContext
+                && User.IsInRole(Domain.Constants.RoleNames.Admin)
+                && info is not null
+                    ? new UserInfoEmailDiagnostic(info.Email, info.PrimaryEmail, info.GoogleEmail)
+                    : null,
         };
     }
 

--- a/src/Humans.Web/Controllers/ProfileController.cs
+++ b/src/Humans.Web/Controllers/ProfileController.cs
@@ -2538,10 +2538,9 @@ public class ProfileController : HumansControllerBase
                 && User.IsInRole(Domain.Constants.RoleNames.Admin)
                 ? user.IdentityEmailColumn
                 : null,
-            UserInfoEmails = isAdminContext
+            TargetUserInfo = isAdminContext
                 && User.IsInRole(Domain.Constants.RoleNames.Admin)
-                && info is not null
-                    ? new UserInfoEmailDiagnostic(info.Email, info.PrimaryEmail, info.GoogleEmail)
+                    ? info
                     : null,
         };
     }

--- a/src/Humans.Web/Models/EmailsViewModel.cs
+++ b/src/Humans.Web/Models/EmailsViewModel.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using Humans.Application;
 using Humans.Application.Interfaces.Profiles;
 using Humans.Domain.Enums;
 using NodaTime;
@@ -77,14 +78,13 @@ public class EmailsViewModel
     public string? LegacyIdentityEmailColumn { get; set; }
 
     /// <summary>
-    /// Admin-only diagnostic: the derived email fields read from the cached
-    /// <c>UserInfo</c> for this target user. These are what the rest of the
-    /// app actually consumes — what we send mail to, what we resolve as the
-    /// Google identity. Used to spot drift between the cached read-model and
-    /// the underlying <c>UserEmails</c> rows after detached-provider or
-    /// account-merge scenarios. Null in self contexts and for non-Admin actors.
+    /// Admin-only diagnostic: the cached <c>UserInfo</c> for the target user.
+    /// The view reads <c>Email</c>/<c>PrimaryEmail</c>/<c>GoogleEmail</c>
+    /// directly — these are what the rest of the app actually consumes
+    /// (outbound mail, Google identity, the legacy <c>User.Email</c>
+    /// override). Null in self contexts and for non-Admin actors.
     /// </summary>
-    public UserInfoEmailDiagnostic? UserInfoEmails { get; init; }
+    public UserInfo? TargetUserInfo { get; init; }
 
     /// <summary>
     /// When non-null, identifies the email row that is the user's Workspace
@@ -226,14 +226,3 @@ public class EmailRowViewModel
     /// </summary>
     public bool HasOrphanProviderTag { get; init; }
 }
-
-/// <summary>
-/// Admin-only diagnostic snapshot of <c>UserInfo</c>'s derived email fields.
-/// These are what callers across the app see when they ask the cached
-/// read-model for a user's email — used to compare against the raw
-/// <c>UserEmails</c> rows above and the legacy <c>User.Email</c> column.
-/// </summary>
-public sealed record UserInfoEmailDiagnostic(
-    string? EffectiveEmail,
-    string? PrimaryEmail,
-    string? GoogleEmail);

--- a/src/Humans.Web/Models/EmailsViewModel.cs
+++ b/src/Humans.Web/Models/EmailsViewModel.cs
@@ -77,6 +77,16 @@ public class EmailsViewModel
     public string? LegacyIdentityEmailColumn { get; set; }
 
     /// <summary>
+    /// Admin-only diagnostic: the derived email fields read from the cached
+    /// <c>UserInfo</c> for this target user. These are what the rest of the
+    /// app actually consumes — what we send mail to, what we resolve as the
+    /// Google identity. Used to spot drift between the cached read-model and
+    /// the underlying <c>UserEmails</c> rows after detached-provider or
+    /// account-merge scenarios. Null in self contexts and for non-Admin actors.
+    /// </summary>
+    public UserInfoEmailDiagnostic? UserInfoEmails { get; init; }
+
+    /// <summary>
     /// When non-null, identifies the email row that is the user's Workspace
     /// canonical identity (Provider=Google + email on the configured Workspace
     /// domain). While set, the view locks Primary and Google radios across the
@@ -216,3 +226,14 @@ public class EmailRowViewModel
     /// </summary>
     public bool HasOrphanProviderTag { get; init; }
 }
+
+/// <summary>
+/// Admin-only diagnostic snapshot of <c>UserInfo</c>'s derived email fields.
+/// These are what callers across the app see when they ask the cached
+/// read-model for a user's email — used to compare against the raw
+/// <c>UserEmails</c> rows above and the legacy <c>User.Email</c> column.
+/// </summary>
+public sealed record UserInfoEmailDiagnostic(
+    string? EffectiveEmail,
+    string? PrimaryEmail,
+    string? GoogleEmail);

--- a/src/Humans.Web/Views/Profile/Emails.cshtml
+++ b/src/Humans.Web/Views/Profile/Emails.cshtml
@@ -356,6 +356,62 @@
             </div>
         </div>
 
+        @* Admin UserInfo derived-email diagnostic — what callers across the app actually see *@
+        @if (Model.IsAdminContext && Model.UserInfoEmails is not null)
+        {
+            <div class="card mb-4 border-danger" id="userinfo-emails">
+                <div class="card-header bg-danger text-white">
+                    <h5 class="mb-0"><i class="fa-solid fa-user-shield me-1"></i><code>UserInfo</code> derived emails <small class="ms-2 opacity-75">(Admin only)</small></h5>
+                    <small class="text-white-50">What the cached read-model returns when callers ask for this user's email. Drives outbound mail, Google identity resolution, and the legacy <code>User.Email</code> override. Compare against the raw <code>user_emails</code> rows below.</small>
+                </div>
+                <div class="card-body p-0">
+                    <table class="table mb-0">
+                        <tbody>
+                            <tr>
+                                <th style="width: 16rem;"><code>UserInfo.Email</code><div class="small fw-normal text-muted">Effective — mail sender + <code>User.Email</code> override</div></th>
+                                <td>
+                                    @if (!string.IsNullOrEmpty(Model.UserInfoEmails.EffectiveEmail))
+                                    {
+                                        <code>@Model.UserInfoEmails.EffectiveEmail</code>
+                                    }
+                                    else
+                                    {
+                                        <span class="text-muted">(null)</span>
+                                    }
+                                </td>
+                            </tr>
+                            <tr>
+                                <th><code>UserInfo.PrimaryEmail</code><div class="small fw-normal text-muted">First verified row with <code>IsPrimary</code></div></th>
+                                <td>
+                                    @if (!string.IsNullOrEmpty(Model.UserInfoEmails.PrimaryEmail))
+                                    {
+                                        <code>@Model.UserInfoEmails.PrimaryEmail</code>
+                                    }
+                                    else
+                                    {
+                                        <span class="text-muted">(null)</span>
+                                    }
+                                </td>
+                            </tr>
+                            <tr>
+                                <th><code>UserInfo.GoogleEmail</code><div class="small fw-normal text-muted">First verified row with <code>IsGoogle</code> — Workspace identity</div></th>
+                                <td>
+                                    @if (!string.IsNullOrEmpty(Model.UserInfoEmails.GoogleEmail))
+                                    {
+                                        <code>@Model.UserInfoEmails.GoogleEmail</code>
+                                    }
+                                    else
+                                    {
+                                        <span class="text-muted">(null)</span>
+                                    }
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        }
+
         @* see nobodies-collective/Humans#697 — admin AspNetUserLogins snapshot + disagreement flags *@
         @if (Model.IsAdminContext)
         {

--- a/src/Humans.Web/Views/Profile/Emails.cshtml
+++ b/src/Humans.Web/Views/Profile/Emails.cshtml
@@ -357,7 +357,7 @@
         </div>
 
         @* Admin UserInfo derived-email diagnostic — what callers across the app actually see *@
-        @if (Model.IsAdminContext && Model.UserInfoEmails is not null)
+        @if (Model.IsAdminContext && Model.TargetUserInfo is not null)
         {
             <div class="card mb-4 border-danger" id="userinfo-emails">
                 <div class="card-header bg-danger text-white">
@@ -369,9 +369,9 @@
                             <tr>
                                 <th style="width: 16rem;"><code>UserInfo.Email</code></th>
                                 <td>
-                                    @if (!string.IsNullOrEmpty(Model.UserInfoEmails.EffectiveEmail))
+                                    @if (!string.IsNullOrEmpty(Model.TargetUserInfo.Email))
                                     {
-                                        <code>@Model.UserInfoEmails.EffectiveEmail</code>
+                                        <code>@Model.TargetUserInfo.Email</code>
                                     }
                                     else
                                     {
@@ -382,9 +382,9 @@
                             <tr>
                                 <th><code>UserInfo.PrimaryEmail</code></th>
                                 <td>
-                                    @if (!string.IsNullOrEmpty(Model.UserInfoEmails.PrimaryEmail))
+                                    @if (!string.IsNullOrEmpty(Model.TargetUserInfo.PrimaryEmail))
                                     {
-                                        <code>@Model.UserInfoEmails.PrimaryEmail</code>
+                                        <code>@Model.TargetUserInfo.PrimaryEmail</code>
                                     }
                                     else
                                     {
@@ -395,9 +395,9 @@
                             <tr>
                                 <th><code>UserInfo.GoogleEmail</code></th>
                                 <td>
-                                    @if (!string.IsNullOrEmpty(Model.UserInfoEmails.GoogleEmail))
+                                    @if (!string.IsNullOrEmpty(Model.TargetUserInfo.GoogleEmail))
                                     {
-                                        <code>@Model.UserInfoEmails.GoogleEmail</code>
+                                        <code>@Model.TargetUserInfo.GoogleEmail</code>
                                     }
                                     else
                                     {

--- a/src/Humans.Web/Views/Profile/Emails.cshtml
+++ b/src/Humans.Web/Views/Profile/Emails.cshtml
@@ -362,13 +362,12 @@
             <div class="card mb-4 border-danger" id="userinfo-emails">
                 <div class="card-header bg-danger text-white">
                     <h5 class="mb-0"><i class="fa-solid fa-user-shield me-1"></i><code>UserInfo</code> derived emails <small class="ms-2 opacity-75">(Admin only)</small></h5>
-                    <small class="text-white-50">What the cached read-model returns when callers ask for this user's email. Drives outbound mail, Google identity resolution, and the legacy <code>User.Email</code> override. Compare against the raw <code>user_emails</code> rows below.</small>
                 </div>
                 <div class="card-body p-0">
                     <table class="table mb-0">
                         <tbody>
                             <tr>
-                                <th style="width: 16rem;"><code>UserInfo.Email</code><div class="small fw-normal text-muted">Effective — mail sender + <code>User.Email</code> override</div></th>
+                                <th style="width: 16rem;"><code>UserInfo.Email</code></th>
                                 <td>
                                     @if (!string.IsNullOrEmpty(Model.UserInfoEmails.EffectiveEmail))
                                     {
@@ -381,7 +380,7 @@
                                 </td>
                             </tr>
                             <tr>
-                                <th><code>UserInfo.PrimaryEmail</code><div class="small fw-normal text-muted">First verified row with <code>IsPrimary</code></div></th>
+                                <th><code>UserInfo.PrimaryEmail</code></th>
                                 <td>
                                     @if (!string.IsNullOrEmpty(Model.UserInfoEmails.PrimaryEmail))
                                     {
@@ -394,7 +393,7 @@
                                 </td>
                             </tr>
                             <tr>
-                                <th><code>UserInfo.GoogleEmail</code><div class="small fw-normal text-muted">First verified row with <code>IsGoogle</code> — Workspace identity</div></th>
+                                <th><code>UserInfo.GoogleEmail</code></th>
                                 <td>
                                     @if (!string.IsNullOrEmpty(Model.UserInfoEmails.GoogleEmail))
                                     {


### PR DESCRIPTION
## Summary
- Adds an Admin-only red card on the per-user `Emails` admin page showing the three derived email fields that the cached `UserInfo` exposes: `Email` (effective — outbound mail + `User.Email` override), `PrimaryEmail`, and `GoogleEmail`.
- Same gate as the existing `LegacyIdentityEmailColumn` diagnostic: `isAdminContext && User.IsInRole(Admin)`.
- Motivating case: a user who originally signed in with Google then switched to magic-link logins and detached Google. The legacy `User.Email` column still shows the old Google address; this card lets an admin quickly verify what the rest of the app actually sees (mail sender, Google resolution) without cross-referencing the raw `user_emails` table.

## Test plan
- [ ] Visit `/Profile/{id}/Admin/Emails` as an Admin → new red `UserInfo derived emails` card appears above the AspNetUserLogins card with three rows; `(null)` shown when a field is null.
- [ ] Visit as a non-Admin admin-context actor (HumanAdmin/Board reaching the page via `UserEmailOperations.Edit`) → card does NOT appear.
- [ ] Visit own `/Profile/Emails` (self context) → card does NOT appear.
- [ ] Spot-check on the user described above: `UserInfo.Email` and `UserInfo.GoogleEmail` reflect the current magic-link state, not the stale legacy column value (still shown in the gray alert above for comparison).

🤖 Generated with [Claude Code](https://claude.com/claude-code)