### PR TITLE
feat(search): GUID lookup for all sections, drop public-only profile filters

### DIFF
--- a/src/Humans.Application/Services/Camps/CampService.cs
+++ b/src/Humans.Application/Services/Camps/CampService.cs
@@ -370,6 +370,15 @@ public sealed class CampService : ICampService, IUserDataContributor, IUserMerge
     {
         var settings = await GetSettingsAsync(cancellationToken);
         var year = settings.PublicYear;
+
+        if (Guid.TryParse(query, out var id))
+        {
+            var camp = await _repo.GetByIdAsync(id, cancellationToken);
+            if (camp is null) return [];
+            var season = camp.Seasons.FirstOrDefault(s => s.Year == year);
+            return [new CampSearchHit(camp.Slug, season?.Name ?? camp.Slug)];
+        }
+
         var camps = await _repo.SearchForYearAsync(
             query, year, onlyPublicStatus: true, max, cancellationToken);
 

--- a/src/Humans.Application/Services/Search/SearchService.cs
+++ b/src/Humans.Application/Services/Search/SearchService.cs
@@ -81,13 +81,14 @@ public sealed class SearchService : ISearchService
         string query, int limit, CancellationToken ct)
     {
         var hits = await _teamService.SearchAsync(query, limit, ct);
+        var isGuidQuery = Guid.TryParse(query, out _);
         return hits
             .Select(t => new GlobalSearchResult(
                 Type: SearchResultType.Team,
                 Title: t.Name,
                 Subtitle: t.Slug,
                 Url: $"/Teams/{t.Slug}",
-                Score: ScoreNameField(t.Name, query)))
+                Score: isGuidQuery ? ScoreExactName : ScoreNameField(t.Name, query)))
             .Where(r => r.Score > 0)
             .ToList();
     }
@@ -96,13 +97,14 @@ public sealed class SearchService : ISearchService
         string query, int limit, CancellationToken ct)
     {
         var hits = await _campService.SearchAsync(query, limit, ct);
+        var isGuidQuery = Guid.TryParse(query, out _);
         return hits
             .Select(c => new GlobalSearchResult(
                 Type: SearchResultType.Camp,
                 Title: c.Name,
                 Subtitle: c.Slug,
                 Url: $"/Camps/{c.Slug}",
-                Score: ScoreNameField(c.Name, query)))
+                Score: isGuidQuery ? ScoreExactName : ScoreNameField(c.Name, query)))
             .Where(r => r.Score > 0)
             .ToList();
     }
@@ -112,13 +114,14 @@ public sealed class SearchService : ISearchService
     {
         // Hits are Rotas (named shift groupings), not individual Shift rows (which have no title).
         var hits = await _shiftService.SearchAsync(query, limit, ct);
+        var isGuidQuery = Guid.TryParse(query, out _);
         return hits
             .Select(r => new GlobalSearchResult(
                 Type: SearchResultType.Shift,
                 Title: r.Name,
                 Subtitle: r.TeamName,
                 Url: $"/Shifts?departmentId={r.TeamId}",
-                Score: ScoreNameField(r.Name, query)))
+                Score: isGuidQuery ? ScoreExactName : ScoreNameField(r.Name, query)))
             .Where(r => r.Score > 0)
             .ToList();
     }

--- a/src/Humans.Application/Services/Shifts/ShiftManagementService.cs
+++ b/src/Humans.Application/Services/Shifts/ShiftManagementService.cs
@@ -274,6 +274,15 @@ public sealed class ShiftManagementService : IShiftManagementService, IShiftAuth
         string query, int max,
         CancellationToken cancellationToken = default)
     {
+        if (Guid.TryParse(query, out var id))
+        {
+            var rota = await _repo.GetRotaByIdWithShiftsAsync(id);
+            if (rota is null) return [];
+            var teams = await TeamService.GetTeamsAsync(cancellationToken);
+            var teamName = teams.TryGetValue(rota.TeamId, out var t) ? t.Name : string.Empty;
+            return [new RotaSearchHit(rota.Name, rota.TeamId, teamName)];
+        }
+
         var settings = await _repo.GetActiveEventSettingsAsync(cancellationToken);
         if (settings is null) return [];
 

--- a/src/Humans.Application/Services/Teams/TeamService.cs
+++ b/src/Humans.Application/Services/Teams/TeamService.cs
@@ -186,6 +186,12 @@ public sealed class TeamService : ITeamService, IGoogleGroupMembershipSource, IU
         string query, int max,
         CancellationToken cancellationToken = default)
     {
+        if (Guid.TryParse(query, out var id))
+        {
+            var team = await _repo.GetByIdAsync(id, cancellationToken);
+            return team is null ? [] : [new TeamSearchHit(team.Name, team.Slug)];
+        }
+
         var teams = await _repo.SearchAsync(
             query, includeHidden: false, max, cancellationToken);
         return teams

--- a/src/Humans.Infrastructure/Services/Users/CachingUserService.cs
+++ b/src/Humans.Infrastructure/Services/Users/CachingUserService.cs
@@ -154,12 +154,9 @@ public sealed class CachingUserService :
 
         await EnsureWarmedAsync(ct).ConfigureAwait(false);
 
-        var includeAdmin = (fields & PersonSearchFields.Admin) != PersonSearchFields.None;
-
-        // Admin-only exact-UserId lookup. Lets an admin paste a UserId from
-        // logs / audit trails / URLs and jump straight to that human. Public
-        // callers fall through to text matching so they can't enumerate IDs.
-        if (includeAdmin && Guid.TryParse(query, out var idGuid))
+        // Exact-UserId lookup. Lets anyone paste a UserId from logs / audit
+        // trails / URLs and jump straight to that human.
+        if (Guid.TryParse(query, out var idGuid))
         {
             if (TryGet(idGuid, out var byId) && byId.Profile is not null && byId.Profile.RejectedAt is null)
             {
@@ -180,18 +177,8 @@ public sealed class CachingUserService :
         var results = new List<HumanSearchResult>();
         foreach (var u in Values)
         {
-            // Must have a profile and not be rejected to be searchable.
             if (u.Profile is null) continue;
             if (u.Profile.RejectedAt is not null) continue;
-
-            // Public-only callers never see suspended humans. Admin callers
-            // do, because admin search is the primary tool for finding a
-            // suspended person to lift suspension etc.
-            if (!includeAdmin && u.IsSuspended) continue;
-
-            // Public-only: only approved profiles surface. Admin: pre-approval
-            // / consent-pending profiles are valid search targets.
-            if (!includeAdmin && !u.Profile.IsApproved) continue;
 
             var match = TryMatchBuckets(u, query, fields);
             if (match is null) continue;

--- a/tests/Humans.Application.Tests/Services/Users/CachingUserServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Users/CachingUserServiceTests.cs
@@ -841,25 +841,25 @@ public class CachingUserServiceTests
     }
 
     [HumansFact]
-    public async Task SearchUsersAsync_PublicAll_ExcludesSuspended()
+    public async Task SearchUsersAsync_PublicAll_IncludesSuspended()
     {
         var sut = CreateSut();
         await PrimeAsync(sut, BuildSearchableUserInfo(Guid.NewGuid(), city: "Madrid", isSuspended: true));
 
         var results = await sut.SearchUsersAsync("Madrid", PersonSearchFields.PublicAll);
 
-        results.Should().BeEmpty();
+        results.Should().HaveCount(1);
     }
 
     [HumansFact]
-    public async Task SearchUsersAsync_PublicAll_ExcludesUnapproved()
+    public async Task SearchUsersAsync_PublicAll_IncludesUnapproved()
     {
         var sut = CreateSut();
         await PrimeAsync(sut, BuildSearchableUserInfo(Guid.NewGuid(), city: "Madrid", isApproved: false));
 
         var results = await sut.SearchUsersAsync("Madrid", PersonSearchFields.PublicAll);
 
-        results.Should().BeEmpty();
+        results.Should().HaveCount(1);
     }
 
     [HumansFact]
@@ -921,7 +921,7 @@ public class CachingUserServiceTests
     }
 
     [HumansFact]
-    public async Task SearchUsersAsync_PublicAll_GuidDoesNotShortCircuitById()
+    public async Task SearchUsersAsync_PublicAll_GuidShortCircuitsById()
     {
         var userId = Guid.NewGuid();
         var sut = CreateSut();
@@ -929,7 +929,9 @@ public class CachingUserServiceTests
 
         var results = await sut.SearchUsersAsync(userId.ToString(), PersonSearchFields.PublicAll);
 
-        results.Should().BeEmpty();
+        results.Should().HaveCount(1);
+        results[0].UserId.Should().Be(userId);
+        results[0].MatchField.Should().Be("User ID");
     }
 
     [HumansFact]


### PR DESCRIPTION
## Summary

- `/Search?q=<guid>` now resolves to the matching entity for **all four** sections (Human / Team / Camp / Rota), not just Humans-when-admin. Each section's service-layer `SearchAsync` short-circuits on `Guid.TryParse` via the existing repo get-by-id.
- Dropped the admin gate on the user GUID lookup in `CachingUserService.SearchUsersAsync` — every caller can now resolve a UserId. Everything is already reachable via slug pages, so gating the GUID URL was a non-feature.
- Dropped the two public-only filters in `SearchUsersAsync` (`IsSuspended`, `!IsApproved`) that were hiding humans clearly present in the app — e.g. volunteers whose `IsApproved` bit was missed by a legacy provisioning path. Affects all `SearchUsersAsync` callers: global search, ticket transfer, shift volunteer picker, `/Profile/Search`. `RejectedAt` filter remains.

## Test plan

- [x] `dotnet build Humans.slnx -v quiet` — clean
- [x] `dotnet test Humans.slnx -v quiet` — 3306 / 3307 pass (1 pre-existing skip)
- [ ] On preview: `/Search?q=<my-user-guid>` returns the matching user
- [ ] On preview: `/Search?q=<team-guid>` / `<camp-guid>` / `<rota-guid>` each resolves
- [ ] On preview: search for a known-unapproved volunteer's burner name returns the hit

🤖 Generated with [Claude Code](https://claude.com/claude-code)