### PR TITLE
feat(admin): add Warmed column to /Admin/CacheStats decorator table

### DIFF
--- a/src/Humans.Application/Interfaces/Caching/ICacheStats.cs
+++ b/src/Humans.Application/Interfaces/Caching/ICacheStats.cs
@@ -21,6 +21,10 @@ public interface ICacheStats
     /// re-warm via <c>EnsureWarmed</c> / <c>EnsureWarmedAsync</c>.</summary>
     long BulkInvalidations { get; }
 
+    /// <summary>True once a warm-all pass has completed. For lazy caches
+    /// (<c>warmOnStartup: false</c>) with no warm-all model, stays false.</summary>
+    bool IsWarmedUp { get; }
+
     double HitRatePercent { get; }
     void ResetCounters();
 }

--- a/src/Humans.Application/Interfaces/Caching/TrackedCache.cs
+++ b/src/Humans.Application/Interfaces/Caching/TrackedCache.cs
@@ -44,8 +44,8 @@ public class TrackedCache<TKey, TValue> : IHostedService, ICacheStats where TKey
         ? Math.Round(Hits * 100.0 / (Hits + Misses), 1)
         : 0;
 
-    /// <summary>True once WarmAllAsync has completed; resets on Clear. Readers use EnsureWarmedAsync, not this directly.</summary>
-    protected bool IsWarmedUp => _warmedUp;
+    /// <summary>True once WarmAllAsync has completed; resets on Clear. Readers use EnsureWarmedAsync, not this directly. Surfaced on <c>/Admin/CacheStats</c> as a "Warmed" indicator.</summary>
+    public bool IsWarmedUp => _warmedUp;
 
     /// <summary>Live snapshot of cached values; concurrent-safe iteration, not a copy.</summary>
     public ICollection<TValue> Values => _dict.Values;

--- a/src/Humans.Web/Controllers/AdminController.cs
+++ b/src/Humans.Web/Controllers/AdminController.cs
@@ -381,6 +381,7 @@ public class AdminController : HumansControllerBase
                         KeyRemovals = s.KeyRemovals,
                         BulkInvalidations = s.BulkInvalidations,
                         HitRatePercent = s.HitRatePercent,
+                        IsWarmedUp = s.IsWarmedUp,
                     })
                     .ToList()
             };

--- a/src/Humans.Web/Models/AdminViewModels.cs
+++ b/src/Humans.Web/Models/AdminViewModels.cs
@@ -325,6 +325,7 @@ public class DecoratorCacheStatEntryViewModel
     public long KeyRemovals { get; set; }
     public long BulkInvalidations { get; set; }
     public double HitRatePercent { get; set; }
+    public bool IsWarmedUp { get; set; }
 }
 
 public class DuplicateAccountListViewModel

--- a/src/Humans.Web/Views/Admin/CacheStats.cshtml
+++ b/src/Humans.Web/Views/Admin/CacheStats.cshtml
@@ -125,12 +125,13 @@ else
             <thead>
                 <tr>
                     <th style="cursor:pointer;" data-sort-col="0">Name <i class="fa-solid fa-sort fa-xs"></i></th>
-                    <th style="cursor:pointer;" data-sort-col="1" class="text-end">Entries <i class="fa-solid fa-sort fa-xs"></i></th>
-                    <th style="cursor:pointer;" data-sort-col="2" class="text-end">Hits <i class="fa-solid fa-sort fa-xs"></i></th>
-                    <th style="cursor:pointer;" data-sort-col="3" class="text-end">Misses <i class="fa-solid fa-sort fa-xs"></i></th>
-                    <th style="cursor:pointer;" data-sort-col="4" class="text-end">Hit Rate % <i class="fa-solid fa-sort fa-xs"></i></th>
-                    <th style="cursor:pointer;" data-sort-col="5" class="text-end">Key Rmv <i class="fa-solid fa-sort fa-xs"></i></th>
-                    <th style="cursor:pointer;" data-sort-col="6" class="text-end">Bulk Inval <i class="fa-solid fa-sort fa-xs"></i></th>
+                    <th style="cursor:pointer;" data-sort-col="1" class="text-center">Warmed <i class="fa-solid fa-sort fa-xs"></i></th>
+                    <th style="cursor:pointer;" data-sort-col="2" class="text-end">Entries <i class="fa-solid fa-sort fa-xs"></i></th>
+                    <th style="cursor:pointer;" data-sort-col="3" class="text-end">Hits <i class="fa-solid fa-sort fa-xs"></i></th>
+                    <th style="cursor:pointer;" data-sort-col="4" class="text-end">Misses <i class="fa-solid fa-sort fa-xs"></i></th>
+                    <th style="cursor:pointer;" data-sort-col="5" class="text-end">Hit Rate % <i class="fa-solid fa-sort fa-xs"></i></th>
+                    <th style="cursor:pointer;" data-sort-col="6" class="text-end">Key Rmv <i class="fa-solid fa-sort fa-xs"></i></th>
+                    <th style="cursor:pointer;" data-sort-col="7" class="text-end">Bulk Inval <i class="fa-solid fa-sort fa-xs"></i></th>
                 </tr>
             </thead>
             <tbody>
@@ -146,6 +147,16 @@ else
                         };
                     <tr class="@rateClass">
                         <td>@entry.Name</td>
+                        <td class="text-center" data-sort-value="@(entry.IsWarmedUp ? 1 : 0)">
+                            @if (entry.IsWarmedUp)
+                            {
+                                <i class="fa-solid fa-check text-success" title="Warmed"></i>
+                            }
+                            else
+                            {
+                                <i class="fa-solid fa-xmark text-muted" title="Cold (lazy or awaiting warmup)"></i>
+                            }
+                        </td>
                         <td class="text-end">@entry.Entries.ToString("N0")</td>
                         <td class="text-end">@entry.Hits.ToString("N0")</td>
                         <td class="text-end">@entry.Misses.ToString("N0")</td>
@@ -175,8 +186,10 @@ else
                         const dir = sortDir[colIndex] ? 1 : -1;
 
                         rows.sort((a, b) => {
-                            const aVal = a.cells[colIndex].textContent.trim().replace(/[,%]/g, '');
-                            const bVal = b.cells[colIndex].textContent.trim().replace(/[,%]/g, '');
+                            const aCell = a.cells[colIndex];
+                            const bCell = b.cells[colIndex];
+                            const aVal = (aCell.dataset.sortValue ?? aCell.textContent).trim().replace(/[,%]/g, '');
+                            const bVal = (bCell.dataset.sortValue ?? bCell.textContent).trim().replace(/[,%]/g, '');
                             if (isNumeric) {
                                 return (parseFloat(aVal) - parseFloat(bVal)) * dir;
                             }
@@ -188,7 +201,7 @@ else
                 });
             }
             wireTable('cacheStatsTable', [2, 4, 5, 6]);
-            wireTable('decoratorCacheStatsTable', [1, 2, 3, 4, 5, 6]);
+            wireTable('decoratorCacheStatsTable', [1, 2, 3, 4, 5, 6, 7]);
         })();
     </script>
 }


### PR DESCRIPTION
## Summary
- Surface `TrackedCache.IsWarmedUp` on the `ICacheStats` interface (was previously a `protected` helper on the base class).
- Render a "Warmed" indicator column (check / x) on the Caching Decorators table at `/Admin/CacheStats`, between Name and Entries.
- Sort script falls back on `data-sort-value` so the icon column sorts by underlying bool.

Operators can now see at a glance which `warmOnStartup: true` caches are warmed vs cold after a Clear, and which lazy caches remain unwarmed by design.

## Test plan
- [ ] Visit `/Admin/CacheStats` and confirm the Caching Decorators table shows a Warmed column.
- [ ] After app startup, warm-on-startup caches (User, Team, Camp, Calendar, Auth.RoleAssignmentRow, Legal, Tickets.Orders) show a green check.
- [ ] Lazy caches (Event.ApprovedEventView, Consent.UserConsentInfo, ShiftView.UserView, ShiftView.RotaView) show a muted x.
- [ ] Sort by Warmed column works (groups warmed vs cold).
- [ ] Trigger a Clear on a warmed cache (e.g. via an admin action), confirm column flips to x, then back to check after a load-all read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)