### PR TITLE
fix(tickets): onsite roster review findings — Razor selected + N+1s

### DIFF
--- a/src/Humans.Application/Interfaces/Auth/RoleAssignmentRow.cs
+++ b/src/Humans.Application/Interfaces/Auth/RoleAssignmentRow.cs
@@ -4,12 +4,13 @@ namespace Humans.Application.Interfaces.Auth;
 
 /// <summary>
 /// Compact projection of a single <c>role_assignments</c> row, used as the
-/// cached unit in <c>CachingRoleAssignmentService</c>. Only the fields needed
-/// to derive active-by-role counts are included; broader read methods continue
-/// to pass through to the inner service.
+/// cached unit in <c>CachingRoleAssignmentService</c>. Carries the fields
+/// needed to derive both active-by-role counts and active-for-user lookups
+/// in memory.
 /// </summary>
 public sealed record RoleAssignmentRow(
     Guid Id,
+    Guid UserId,
     string RoleName,
     Instant ValidFrom,
     Instant? ValidTo)

--- a/src/Humans.Application/Interfaces/Camps/ICampService.cs
+++ b/src/Humans.Application/Interfaces/Camps/ICampService.cs
@@ -14,6 +14,7 @@ namespace Humans.Application.Interfaces.Camps;
 /// <remarks>
 /// Surface-budget recent history (newest first):
 /// <list type="bullet">
+///   <item>55→55 — onsite-roster N+1 fix: added <see cref="GetCampMembersByYearAsync"/> (year-scoped bulk member fetch) for <c>OnsiteRosterService</c>; net-zero by dropping obsolete <c>GetCampsWithLeadsForYearAsync</c> (T-06 alias of <see cref="GetCampsForYearAsync"/>, zero external callers).</item>
 ///   <item>2026-05-11 — InterfaceMethodBudgetTests retired; budget migrated to [SurfaceBudget(55)] (issue nobodies-collective/Humans#700).</item>
 ///   <item>52→55 — issue-490 Early Entry (camps consumer): added SetEeStartDateAsync, SetCampSeasonEeSlotCountAsync, SetEarlyEntryAsync. Authorized by Peter 2026-05-10. EE state lives on CampSeason/CampMember/CampSettings — tables ICampService already owns — so the methods belong here per design-rules §6 (no service split).</item>
 ///   <item>51→52 — issue-682 global search: added SearchAsync(query, max). Authorized exception (Peter, 2026-05-09): queries against camps must live in the owning section per design-rules §6.</item>
@@ -73,19 +74,6 @@ public interface ICampService : IApplicationService
     Task<IReadOnlyList<CampPublicSummary>> GetCampPublicSummariesForYearAsync(int year, CancellationToken cancellationToken = default);
     Task<IReadOnlyList<CampPlacementSummary>> GetCampPlacementSummariesForYearAsync(int year, CancellationToken cancellationToken = default);
     Task<CampSettingsInfo> GetSettingsAsync(CancellationToken cancellationToken = default);
-    /// <summary>
-    /// Gets camps with their active leads for a given year. Optionally filters
-    /// to specific season statuses.
-    /// </summary>
-    /// <remarks>
-    /// T-06: deprecated alias of <see cref="GetCampsForYearAsync"/> with an
-    /// extra status filter. <see cref="CampInfo.Leads"/> is always populated
-    /// (non-null) on every code path now. New callers should use
-    /// <see cref="GetCampsForYearAsync"/> and filter on
-    /// <c>CampInfo.Seasons[].Status</c> in-memory.
-    /// </remarks>
-    [Obsolete("T-06: GetCampsForYearAsync now always populates leads; filter by season Status in-memory.")]
-    Task<IReadOnlyList<CampInfo>> GetCampsWithLeadsForYearAsync(int year, IReadOnlyList<CampSeasonStatus>? statusFilter = null, CancellationToken cancellationToken = default);
     Task<IReadOnlyList<CampSeasonInfo>> GetPendingSeasonsAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -204,6 +192,19 @@ public interface ICampService : IApplicationService
     /// <summary>Raw rows (no display-name stitching, no lead union). Privileged — caller must authorize.</summary>
     Task<IReadOnlyList<CampSeasonMemberInfo>> GetSeasonMembersAsync(
         Guid campSeasonId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Year-scoped bulk variant of <see cref="GetSeasonMembersAsync"/>. Returns
+    /// every non-Removed <c>CampMember</c> across every <c>CampSeason</c> of
+    /// <paramref name="year"/>, grouped by <c>CampSeasonId</c>. Seasons with no
+    /// members are absent from the dictionary. Read-only; no display-name
+    /// stitching or lead union. Used by cross-section composers (e.g.
+    /// <c>OnsiteRosterService</c>) that need camp membership for many seasons
+    /// in one query instead of N per-season calls. Privileged — caller must
+    /// authorize.
+    /// </summary>
+    Task<IReadOnlyDictionary<Guid, IReadOnlyList<CampSeasonMemberInfo>>> GetCampMembersByYearAsync(
+        int year, CancellationToken cancellationToken = default);
 
     Task<IReadOnlyList<CampMembershipSummary>> GetCampMembershipsForUserAsync(
         Guid userId, CancellationToken cancellationToken = default);

--- a/src/Humans.Application/Interfaces/Repositories/ICampRepository.cs
+++ b/src/Humans.Application/Interfaces/Repositories/ICampRepository.cs
@@ -423,6 +423,15 @@ public interface ICampRepository : IRepository
         Guid campSeasonId, CancellationToken ct = default);
 
     /// <summary>
+    /// Year-scoped bulk variant of <see cref="GetSeasonMembersAsync"/>. Returns
+    /// every non-Removed <c>CampMember</c> across every <c>CampSeason</c> of
+    /// <paramref name="year"/>, grouped by <c>CampSeasonId</c>. Seasons with no
+    /// members are absent from the dictionary. One SQL round-trip. Read-only.
+    /// </summary>
+    Task<IReadOnlyDictionary<Guid, IReadOnlyList<CampMember>>> GetMembersForYearAsync(
+        int year, CancellationToken ct = default);
+
+    /// <summary>
     /// Returns all active-or-pending memberships for the user, with their
     /// <c>CampSeason</c> and the season's parent <c>Camp</c> loaded so the
     /// caller can build display summaries. Read-only.

--- a/src/Humans.Application/Interfaces/Users/IUserService.cs
+++ b/src/Humans.Application/Interfaces/Users/IUserService.cs
@@ -141,6 +141,14 @@ public interface IUserService : IApplicationService, IUserMerge
     /// camp / team / governance-role names via the owning section services and
     /// applies filters. Issue nobodies-collective/Humans#736.
     /// </summary>
+    /// <remarks>
+    /// Implemented on the caching decorator only — the inner
+    /// <c>UserService</c> derives this from the cached <c>UserInfo</c>
+    /// snapshot and the inner implementation throws
+    /// <see cref="NotSupportedException"/>. Any DI registration that resolves
+    /// the inner service directly (test doubles aside) will hit that throw on
+    /// first call.
+    /// </remarks>
     Task<IReadOnlyList<OnsiteUserRow>> GetOnsiteUsersAsync(
         int year, CancellationToken ct = default);
 

--- a/src/Humans.Application/Services/Camps/CampService.cs
+++ b/src/Humans.Application/Services/Camps/CampService.cs
@@ -335,19 +335,6 @@ public sealed class CampService : ICampService, IUserDataContributor, IUserMerge
             .ToList();
     }
 
-    /// <inheritdoc />
-#pragma warning disable CS0618
-    public async Task<IReadOnlyList<CampInfo>> GetCampsWithLeadsForYearAsync(
-        int year,
-        IReadOnlyList<CampSeasonStatus>? statusFilter = null,
-        CancellationToken cancellationToken = default)
-    {
-        var camps = await _repo.GetCampsWithLeadsForYearAsync(
-            year, statusFilter, cancellationToken);
-        return camps.Select(CreateCampInfo).ToList();
-    }
-#pragma warning restore CS0618
-
     public async Task<CampSettingsInfo> GetSettingsAsync(CancellationToken cancellationToken = default)
     {
         var settings = await _repo.GetSettingsReadOnlyAsync(cancellationToken);
@@ -1791,6 +1778,18 @@ public sealed class CampService : ICampService, IUserDataContributor, IUserMerge
     {
         var members = await _repo.GetSeasonMembersAsync(campSeasonId, cancellationToken);
         return members.Select(CreateCampSeasonMemberInfo).ToList();
+    }
+
+    public async Task<IReadOnlyDictionary<Guid, IReadOnlyList<CampSeasonMemberInfo>>> GetCampMembersByYearAsync(
+        int year, CancellationToken cancellationToken = default)
+    {
+        var grouped = await _repo.GetMembersForYearAsync(year, cancellationToken);
+        var result = new Dictionary<Guid, IReadOnlyList<CampSeasonMemberInfo>>(grouped.Count);
+        foreach (var (seasonId, members) in grouped)
+        {
+            result[seasonId] = members.Select(CreateCampSeasonMemberInfo).ToList();
+        }
+        return result;
     }
 
     public Task<int> GetPendingMembershipCountForLeadAsync(

--- a/src/Humans.Application/Services/Tickets/OnsiteRosterService.cs
+++ b/src/Humans.Application/Services/Tickets/OnsiteRosterService.cs
@@ -95,11 +95,12 @@ public sealed class OnsiteRosterService : IOnsiteRosterService, IApplicationServ
     {
         var result = new Dictionary<Guid, SortedSet<string>>();
         var camps = await _camps.GetCampsForYearAsync(year, ct);
+        var membersByCampSeason = await _camps.GetCampMembersByYearAsync(year, ct);
         foreach (var camp in camps)
         {
             foreach (var season in camp.Seasons)
             {
-                var members = await _camps.GetSeasonMembersAsync(season.Id, ct);
+                if (!membersByCampSeason.TryGetValue(season.Id, out var members)) continue;
                 foreach (var m in members)
                 {
                     if (!onsiteIds.Contains(m.UserId)) continue;

--- a/src/Humans.Infrastructure/Repositories/Camps/CampRepository.cs
+++ b/src/Humans.Infrastructure/Repositories/Camps/CampRepository.cs
@@ -817,6 +817,21 @@ internal sealed class CampRepository : ICampRepository
             .ToListAsync(ct);
     }
 
+    public async Task<IReadOnlyDictionary<Guid, IReadOnlyList<CampMember>>> GetMembersForYearAsync(
+        int year, CancellationToken ct = default)
+    {
+        await using var ctx = await _factory.CreateDbContextAsync(ct);
+        var rows = await ctx.CampMembers
+            .AsNoTracking()
+            .Where(m => m.CampSeason.Year == year && m.Status != CampMemberStatus.Removed)
+            .ToListAsync(ct);
+        return rows
+            .GroupBy(m => m.CampSeasonId)
+            .ToDictionary(
+                g => g.Key,
+                g => (IReadOnlyList<CampMember>)g.ToList());
+    }
+
     public async Task<IReadOnlyList<CampMember>> GetUserMembershipsAsync(
         Guid userId, CancellationToken ct = default)
     {

--- a/src/Humans.Infrastructure/Services/Auth/CachingRoleAssignmentService.cs
+++ b/src/Humans.Infrastructure/Services/Auth/CachingRoleAssignmentService.cs
@@ -19,13 +19,13 @@ namespace Humans.Infrastructure.Services.Auth;
 /// <remarks>
 /// Mirrors <c>CachingLegalDocumentSyncService</c>: warmed on startup via the
 /// <see cref="TrackedCache{TKey,TValue}"/> base, wholesale flush on writes,
-/// stats exposed via <c>/Admin/CacheStats</c>. Today only
-/// <see cref="GetActiveCountsByRoleAsync"/> is served from cache; every other
-/// surface method passes through to the inner service via a freshly
-/// resolved scope. Other read methods can be migrated to cached derivations
-/// incrementally as new callers arrive — the cache shape
-/// (<see cref="RoleAssignmentRow"/>) already holds enough to answer
-/// "active-at-now" predicates.
+/// stats exposed via <c>/Admin/CacheStats</c>. Reads served from cache:
+/// <see cref="GetActiveCountsByRoleAsync"/>,
+/// <see cref="GetActiveForUserAsync"/>. Every other surface method passes
+/// through to the inner service via a freshly resolved scope. Other read
+/// methods can be migrated to cached derivations incrementally as new
+/// callers arrive — the cache shape (<see cref="RoleAssignmentRow"/>) holds
+/// the fields needed to answer "active-at-now" predicates by user or role.
 /// </remarks>
 public sealed class CachingRoleAssignmentService
     : TrackedCache<Guid, RoleAssignmentRow>,
@@ -90,7 +90,7 @@ public sealed class CachingRoleAssignmentService
     {
         var entities = await _repository.GetAllRowsForCacheAsync(ct);
         foreach (var ra in entities)
-            Set(ra.Id, new RoleAssignmentRow(ra.Id, ra.RoleName, ra.ValidFrom, ra.ValidTo));
+            Set(ra.Id, new RoleAssignmentRow(ra.Id, ra.UserId, ra.RoleName, ra.ValidFrom, ra.ValidTo));
     }
 
     // ==========================================================================
@@ -147,8 +147,16 @@ public sealed class CachingRoleAssignmentService
     public Task<IReadOnlyList<Guid>> GetActiveUserIdsInRoleAsync(string roleName, CancellationToken ct = default) =>
         WithInner(inner => inner.GetActiveUserIdsInRoleAsync(roleName, ct));
 
-    public Task<IReadOnlyList<RoleAssignmentSnapshot>> GetActiveForUserAsync(Guid userId, CancellationToken ct = default) =>
-        WithInner(inner => inner.GetActiveForUserAsync(userId, ct));
+    public async Task<IReadOnlyList<RoleAssignmentSnapshot>> GetActiveForUserAsync(Guid userId, CancellationToken ct = default)
+    {
+        await EnsureWarmedAsync(ct);
+        var now = _clock.GetCurrentInstant();
+        return AsReadOnlyDictionary.Values
+            .Where(row => row.UserId == userId && row.IsActiveAt(now))
+            .OrderBy(row => row.RoleName, StringComparer.Ordinal)
+            .Select(row => new RoleAssignmentSnapshot(row.RoleName, row.ValidTo))
+            .ToList();
+    }
 
     public void InvalidateClaimsCacheForUser(Guid userId)
     {

--- a/src/Humans.Infrastructure/Services/Camps/CachingCampService.cs
+++ b/src/Humans.Infrastructure/Services/Camps/CachingCampService.cs
@@ -87,31 +87,6 @@ public sealed class CachingCampService :
         return snapshot is not null && snapshot.Contains(year);
     }
 
-#pragma warning disable CS0618
-    public async Task<IReadOnlyList<CampInfo>> GetCampsWithLeadsForYearAsync(
-        int year, IReadOnlyList<CampSeasonStatus>? statusFilter = null,
-        CancellationToken cancellationToken = default)
-    {
-        // Deprecated alias: filter in-memory by season status.
-        await EnsureWarmedAsync(cancellationToken);
-        if (!IsWarmYear(year))
-        {
-            return await WithInner(inner => inner.GetCampsWithLeadsForYearAsync(year, statusFilter, cancellationToken));
-        }
-        var snapshot = Values;
-        var result = new List<CampInfo>(snapshot.Count);
-        foreach (var camp in snapshot)
-        {
-            var seasonsThisYear = camp.Seasons.Where(s => s.Year == year).ToList();
-            if (seasonsThisYear.Count == 0) continue;
-            if (statusFilter is { Count: > 0 } && !seasonsThisYear.Any(s => statusFilter.Contains(s.Status)))
-                continue;
-            result.Add(FilterToYear(camp, year));
-        }
-        return result;
-    }
-#pragma warning restore CS0618
-
     public async Task<CampSettingsInfo> GetSettingsAsync(CancellationToken cancellationToken = default)
     {
         var snapshot = _settings;
@@ -201,6 +176,10 @@ public sealed class CachingCampService :
     public Task<IReadOnlyList<CampSeasonMemberInfo>> GetSeasonMembersAsync(
         Guid campSeasonId, CancellationToken cancellationToken = default) =>
         WithInner(inner => inner.GetSeasonMembersAsync(campSeasonId, cancellationToken));
+
+    public Task<IReadOnlyDictionary<Guid, IReadOnlyList<CampSeasonMemberInfo>>> GetCampMembersByYearAsync(
+        int year, CancellationToken cancellationToken = default) =>
+        WithInner(inner => inner.GetCampMembersByYearAsync(year, cancellationToken));
 
     public Task<IReadOnlyList<CampMembershipSummary>> GetCampMembershipsForUserAsync(
         Guid userId, CancellationToken cancellationToken = default) =>

--- a/src/Humans.Web/Models/CampAdmin/CampAdminPageBuilder.cs
+++ b/src/Humans.Web/Models/CampAdmin/CampAdminPageBuilder.cs
@@ -43,8 +43,7 @@ public sealed class CampAdminPageBuilder
             .ToList();
 
         // T-06: GetCampsForYearAsync always populates leads; filter by season
-        // status in-memory (was previously a repo-side filter via the now-
-        // deprecated GetCampsWithLeadsForYearAsync).
+        // status in-memory.
         var activeStatuses = new HashSet<CampSeasonStatus> { CampSeasonStatus.Active, CampSeasonStatus.Full };
         var campsWithLeads = (await _campService.GetCampsForYearAsync(settings.PublicYear))
             .Where(c => c.Seasons.Any(s => s.Year == settings.PublicYear && activeStatuses.Contains(s.Status)))

--- a/src/Humans.Web/Views/Tickets/Admin/Onsite.cshtml
+++ b/src/Humans.Web/Views/Tickets/Admin/Onsite.cshtml
@@ -24,7 +24,7 @@ else
                 <option value="">All camps</option>
                 @foreach (var c in Model.AvailableCamps)
                 {
-                    <option value="@c" selected="@(string.Equals(c, Model.CampFilter, StringComparison.OrdinalIgnoreCase))">@c</option>
+                    <option value="@c" selected="@(string.Equals(c, Model.CampFilter, StringComparison.OrdinalIgnoreCase) ? "selected" : null)">@c</option>
                 }
             </select>
         </div>
@@ -34,7 +34,7 @@ else
                 <option value="">All teams</option>
                 @foreach (var t in Model.AvailableTeams)
                 {
-                    <option value="@t" selected="@(string.Equals(t, Model.TeamFilter, StringComparison.OrdinalIgnoreCase))">@t</option>
+                    <option value="@t" selected="@(string.Equals(t, Model.TeamFilter, StringComparison.OrdinalIgnoreCase) ? "selected" : null)">@t</option>
                 }
             </select>
         </div>
@@ -44,7 +44,7 @@ else
                 <option value="">All roles</option>
                 @foreach (var r in Model.AvailableRoles)
                 {
-                    <option value="@r" selected="@(string.Equals(r, Model.RoleFilter, StringComparison.OrdinalIgnoreCase))">@r</option>
+                    <option value="@r" selected="@(string.Equals(r, Model.RoleFilter, StringComparison.OrdinalIgnoreCase) ? "selected" : null)">@r</option>
                 }
             </select>
         </div>

--- a/tests/Humans.Application.Tests/Services/Auth/CachingRoleAssignmentServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Auth/CachingRoleAssignmentServiceTests.cs
@@ -11,11 +11,12 @@ using NSubstitute;
 namespace Humans.Application.Tests.Services.Auth;
 
 /// <summary>
-/// Exercises <see cref="CachingRoleAssignmentService"/>'s cache-served path
-/// (<c>GetActiveCountsByRoleAsync</c>) and wholesale invalidation. Pass-
-/// through methods are not tested here — the build verifies they satisfy
-/// <see cref="IRoleAssignmentService"/>; their behavior is the inner
-/// service's behavior, covered by <c>RoleAssignmentServiceTests</c>.
+/// Exercises <see cref="CachingRoleAssignmentService"/>'s cache-served paths
+/// (<c>GetActiveCountsByRoleAsync</c>, <c>GetActiveForUserAsync</c>) and
+/// wholesale invalidation. Pass-through methods are not tested here — the
+/// build verifies they satisfy <see cref="IRoleAssignmentService"/>; their
+/// behavior is the inner service's behavior, covered by
+/// <c>RoleAssignmentServiceTests</c>.
 /// </summary>
 public class CachingRoleAssignmentServiceTests
 {
@@ -139,6 +140,48 @@ public class CachingRoleAssignmentServiceTests
         afterExpiry.Should().NotContainKey("Board");
     }
 
+    [HumansFact]
+    public async Task GetActiveForUserAsync_ReturnsOnlyActiveRolesForUser_OrderedByRoleName()
+    {
+        var now = Instant.FromUtc(2026, 5, 17, 12, 0);
+        var clock = new FakeClock(now);
+        var userA = Guid.NewGuid();
+        var userB = Guid.NewGuid();
+        var repository = Substitute.For<IRoleAssignmentRepository>();
+        repository.GetAllRowsForCacheAsync(Arg.Any<CancellationToken>())
+            .Returns(new List<RoleAssignment>
+            {
+                ActiveFor(userA, "Coordinator", now),
+                ActiveFor(userA, "Board", now),
+                ExpiredFor(userA, "Admin", now),         // past — excluded
+                ActiveFor(userB, "Board", now),          // other user — excluded
+            });
+
+        var service = BuildService(repository, clock);
+
+        var roles = await service.GetActiveForUserAsync(userA);
+
+        roles.Select(r => r.RoleName).Should().Equal("Board", "Coordinator");
+    }
+
+    [HumansFact]
+    public async Task GetActiveForUserAsync_SecondCall_DoesNotReQueryRepository()
+    {
+        var now = Instant.FromUtc(2026, 5, 17, 12, 0);
+        var clock = new FakeClock(now);
+        var userId = Guid.NewGuid();
+        var repository = Substitute.For<IRoleAssignmentRepository>();
+        repository.GetAllRowsForCacheAsync(Arg.Any<CancellationToken>())
+            .Returns(new List<RoleAssignment> { ActiveFor(userId, "Board", now) });
+
+        var service = BuildService(repository, clock);
+
+        await service.GetActiveForUserAsync(userId);
+        await service.GetActiveForUserAsync(userId);
+
+        await repository.Received(1).GetAllRowsForCacheAsync(Arg.Any<CancellationToken>());
+    }
+
     private static CachingRoleAssignmentService BuildService(
         IRoleAssignmentRepository repository,
         IClock clock) =>
@@ -173,5 +216,25 @@ public class CachingRoleAssignmentServiceTests
             RoleName = role,
             ValidFrom = now + Duration.FromDays(1),
             ValidTo = null,
+        };
+
+    private static RoleAssignment ActiveFor(Guid userId, string role, Instant now) =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            RoleName = role,
+            ValidFrom = now - Duration.FromDays(30),
+            ValidTo = now + Duration.FromDays(30),
+        };
+
+    private static RoleAssignment ExpiredFor(Guid userId, string role, Instant now) =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            RoleName = role,
+            ValidFrom = now - Duration.FromDays(60),
+            ValidTo = now - Duration.FromDays(1),
         };
 }

--- a/tests/Humans.Application.Tests/Services/Tickets/OnsiteRosterServiceTests.cs
+++ b/tests/Humans.Application.Tests/Services/Tickets/OnsiteRosterServiceTests.cs
@@ -136,4 +136,56 @@ public class OnsiteRosterServiceTests
         result.Rows.Should().ContainSingle();
         result.Rows[0].UserId.Should().Be(liveId);
     }
+
+    [HumansFact]
+    public async Task GetRosterAsync_JoinsCampNames_FromBulkMembersByYear()
+    {
+        // Verifies the N+1 fix: the service pulls all camp members for the year
+        // in one call (GetCampMembersByYearAsync) rather than per-season.
+        var aliceId = Guid.NewGuid();
+        var ts = Instant.FromUtc(2026, 7, 8, 12, 0);
+        var campId = Guid.NewGuid();
+        var seasonId = Guid.NewGuid();
+
+        _users.GetOnsiteUsersAsync(2026, Arg.Any<CancellationToken>())
+            .Returns(new List<OnsiteUserRow> { new(aliceId, "Alice", ts) });
+
+        _camps.GetCampsForYearAsync(2026, Arg.Any<CancellationToken>())
+            .Returns(new List<CampInfo>
+            {
+                new(campId, "thunderdome", "x@y", "p", false, 0,
+                    new List<CampSeasonInfo>
+                    {
+                        new(seasonId, campId, "thunderdome", 2026, null, "Thunderdome 2026",
+                            "", "", new List<Humans.Domain.Enums.CampVibe>(),
+                            Humans.Domain.Enums.CampSeasonStatus.Active,
+                            Humans.Domain.Enums.YesNoMaybe.Yes, Humans.Domain.Enums.YesNoMaybe.No,
+                            Humans.Domain.Enums.AdultPlayspacePolicy.No,
+                            1, null, null, null, 0, null, null),
+                    },
+                    new List<CampLeadInfo>()),
+            });
+
+        _camps.GetCampMembersByYearAsync(2026, Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<Guid, IReadOnlyList<CampSeasonMemberInfo>>
+            {
+                [seasonId] = new List<CampSeasonMemberInfo>
+                {
+                    new(Guid.NewGuid(), aliceId, CampMemberStatus.Active, ts, ts, false),
+                },
+            });
+        _teams.GetTeamsAsync(Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<Guid, TeamInfo>());
+        _roles.GetActiveForUserAsync(aliceId, Arg.Any<CancellationToken>())
+            .Returns(new List<RoleAssignmentSnapshot>());
+
+        var service = NewService();
+        var result = await service.GetRosterAsync(2026, null, null, null, default);
+
+        result.Rows.Should().ContainSingle();
+        result.Rows[0].CampNames.Should().Equal("Thunderdome 2026");
+        result.AvailableCamps.Should().Equal("Thunderdome 2026");
+        await _camps.Received(1).GetCampMembersByYearAsync(2026, Arg.Any<CancellationToken>());
+        await _camps.DidNotReceive().GetSeasonMembersAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+    }
 }


### PR DESCRIPTION
## Summary

Addresses the four actionable findings from `/pr-review`'s pass on the pending prod-promo delta (`origin/main` vs `upstream/main`).

- **CRITICAL** — `selected="@bool"` in three `Views/Tickets/Admin/Onsite.cshtml` dropdowns. Razor renders the bool verbatim (`selected="False"`), and per HTML spec a present `selected` attribute selects the option regardless of value, so each filter dropdown was showing the last-listed option instead of the actual filter. Switched to `selected="@(... ? "selected" : null)"`. Reject rule: `docs/architecture/code-review-rules.md:19`.
- **IMPORTANT** — `OnsiteRosterService.BuildRoleNamesAsync` was a DB-per-user N+1: `CachingRoleAssignmentService.GetActiveForUserAsync` was a passthrough to the inner service. Added `UserId` to `RoleAssignmentRow` (the row record already underpins the warmed cache) and moved `GetActiveForUserAsync` into the cache-served set. Per-user lookups now resolve in-memory across every caller (also covers `AgentUserSnapshotProvider`).
- **IMPORTANT** — `OnsiteRosterService.BuildCampNamesAsync` was a DB-per-(camp × season) N+1. Added `ICampService.GetCampMembersByYearAsync` (year-scoped, one SQL round-trip) and rewrote the join. **Net-zero surface delta** on `ICampService` (`[SurfaceBudget(55)]`): dropped the obsolete T-06 alias `GetCampsWithLeadsForYearAsync` (zero external callers, already deprecated). Recorded in the interface's history list.
- **MINOR** — Documented on `IUserService.GetOnsiteUsersAsync` that only the caching decorator implements it; the inner `UserService` throws `NotSupportedException`.

**Finding #5 dropped** — the reviewer flagged `CommunicationPreferenceService.GetPreferencesAsync` as not invalidating UserInfo after creating default rows, but `UserInfoSaveChangesInterceptor:158-160` catches `CommunicationPreference` writes via the slice refresher, so the save inside `AddDefaultsOrReloadAsync` already invalidates correctly. False positive.

## Test plan
- [x] `dotnet build Humans.slnx -v quiet` — clean, 0 errors
- [x] `dotnet test Humans.slnx -v quiet` — 3612 passed, 2 skipped (pre-existing), 0 failed
- [x] Architecture ratchet (`No_new_display_sorts_in_repositories`) — green; the new repo method has no `OrderBy`
- [x] Added `CachingRoleAssignmentService.GetActiveForUserAsync` tests (ordering + cache-served invariant)
- [x] Added `OnsiteRosterService` test that verifies the bulk path (`GetCampMembersByYearAsync` called once, `GetSeasonMembersAsync` not called)
- [ ] Smoke-test `/Tickets/Admin/Onsite` filters in preview once the PR env is up

🤖 Generated with [Claude Code](https://claude.com/claude-code)